### PR TITLE
Fix Gatelet config and testing setup

### DIFF
--- a/experimental/gatelet/server/config.py
+++ b/experimental/gatelet/server/config.py
@@ -11,8 +11,11 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Literal, Union, Type, TypeVar, cast
 
-import toml
-from pydantic import BaseModel, Field, PostgresDsn, validator
+try:
+    import tomllib as toml
+except ModuleNotFoundError:  # pragma: no cover - fallback for older Python
+    import toml  # type: ignore
+from pydantic import BaseModel, Field, validator
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +43,8 @@ WebhookAuthConfig = Union[NoAuth, BearerAuth]
 
 
 class DatabaseSettings(BaseModel):
-    dsn: PostgresDsn = Field(
+    # Use a simple string so we can support both Postgres and SQLite for tests
+    dsn: str = Field(
         default="postgresql://postgres:postgres@localhost:5432/gatelet"
     )
 
@@ -138,7 +142,8 @@ class Settings(BaseModel):
     def from_file(cls, path: Path):
         """Load settings from file at path."""
         logger.info(f"Loading settings from {path.absolute()}")
-        with open(path, "r") as f:
+        # tomllib expects binary mode for file objects
+        with open(path, "rb") as f:
             config_dict = toml.load(f)
         return cls.parse_obj(config_dict)
 

--- a/experimental/gatelet/server/conftest.py
+++ b/experimental/gatelet/server/conftest.py
@@ -4,9 +4,13 @@ import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
-from importlib import reload
+from importlib import import_module, reload
 from pathlib import Path
 from typing import AsyncGenerator
+
+# Ensure the test configuration is loaded before importing the server modules
+TEST_CONFIG_PATH = Path(__file__).parent / "tests" / "gatelet_test.toml"
+os.environ.setdefault("GATELET_CONFIG", str(TEST_CONFIG_PATH))
 
 import pytest
 import pytest_asyncio
@@ -14,7 +18,6 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.pool import NullPool
 
-import server.config
 from server.database import get_db_session
 from server.models import Base, WebhookIntegration, WebhookPayload, AuthKey, AuthCRSession, AuthNonce
 
@@ -32,11 +35,13 @@ def setup_test_config():
     test_config_path = str(Path(__file__).parent / "tests" / "gatelet_test.toml")
     os.environ["GATELET_CONFIG"] = test_config_path
     
-    # Re-import config to ensure we're using the test config
-    reload(server.config)
-    
+    # Import config after setting the environment variable so it uses
+    # the test configuration file. Reload in case it was imported earlier.
+    server_config = import_module("server.config")
+    reload(server_config)
+
     # Return the reloaded settings
-    return server.config.settings
+    return server_config.settings
 
 
 @pytest.fixture(scope="session")

--- a/experimental/gatelet/server/tests/gatelet_test.toml
+++ b/experimental/gatelet/server/tests/gatelet_test.toml
@@ -1,7 +1,8 @@
 # Test configuration for Gatelet
 
 [database]
-dsn = "postgresql+asyncpg://postgres:postgres@db/gatelet_test"
+# Use in-memory SQLite for tests to avoid needing a running Postgres server
+dsn = "sqlite+aiosqlite:///:memory:"
 
 [server]
 host = "0.0.0.0"

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,7 @@ run pip install -e llm/mcp/habitify
 
 # PostgreSQL drivers (sync & async)
 run pip install "psycopg[binary,pool]" asyncpg sqlalchemy
+run pip install aiosqlite
 
 # LLM / NLP helpers
 # run pip install sentence-transformers openai tiktoken


### PR DESCRIPTION
## Summary
- adjust config loader to use `tomllib`
- allow database DSN strings for sqlite
- ensure tests pick up config path in `conftest`
- switch test configuration to in-memory sqlite
- install `aiosqlite` in setup script

## Testing
- `pytest experimental/gatelet/server -q` *(fails: ModuleNotFoundError for aiosqlite)*