### PR TITLE
Implement secure admin config for gatelet

### DIFF
--- a/experimental/gatelet/gatelet.example.toml
+++ b/experimental/gatelet/gatelet.example.toml
@@ -43,3 +43,9 @@ enabled = true
 
 [webhook.integrations.activity-watch.auth_config]
 type = "none"
+
+[admin]
+password_hash = "$argon2id$v=19$m=65536,t=3,p=4$QGhN6d1bi1EKQUhJqfUe4w$lRUJ6+taip7yBS6Q652QLcP14eqE3ehX95tBTTkypiU"
+
+[security]
+csrf_secret = "change_me"

--- a/experimental/gatelet/gatelet.toml
+++ b/experimental/gatelet/gatelet.toml
@@ -43,3 +43,9 @@ enabled = true
 
 [webhook.integrations.activity-watch.auth_config]
 type = "none"
+
+[admin]
+password_hash = "$argon2id$v=19$m=65536,t=3,p=4$QGhN6d1bi1EKQUhJqfUe4w$lRUJ6+taip7yBS6Q652QLcP14eqE3ehX95tBTTkypiU"
+
+[security]
+csrf_secret = "change_me"

--- a/experimental/gatelet/manage.py
+++ b/experimental/gatelet/manage.py
@@ -1,15 +1,22 @@
-from __future__ import annotations
-
 """Command line utilities for Gatelet management."""
 
+from __future__ import annotations
 import argparse
 import getpass
 from typing import Iterable
+import tomllib
+from tomlkit import dumps
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select
 
-from server.config import settings
-from server.models import AdminUser, Base, get_engine, get_session_maker
+from server.config import settings, CONFIG_PATH
+from server.models import (
+    Base,
+    get_engine,
+    get_session_maker,
+    WebhookIntegration,
+    WebhookPayload,
+)
 from server.security import hash_password
 
 
@@ -29,7 +36,7 @@ def _entity_counts(session) -> Iterable[tuple[str, int]]:
 
 
 def reset_db() -> None:
-    """Drop and recreate tables, set default admin password."""
+    """Drop and recreate tables and populate with sample data."""
     engine = get_engine(str(settings.database.dsn))
     Session = get_session_maker(engine)
     with Session() as session:
@@ -43,26 +50,43 @@ def reset_db() -> None:
                 return
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
-    with Session() as session:
-        admin = AdminUser(password_hash=hash_password("gatelet"))
-        session.add(admin)
-        session.commit()
-    print("Database initialized with default admin password 'gatelet'.")
+    with Session.begin() as session:  # pylint: disable=no-member
+        # Sample integration and payloads for UI demos
+        integ = WebhookIntegration(
+            name="sample",
+            description="Sample integration",
+            auth_type="none",
+            auth_config={"type": "none"},
+            is_enabled=True,
+        )
+        session.add(integ)
+        session.flush()
+        for i in range(3):
+            session.add(
+                WebhookPayload(
+                    integration_name=integ.name,
+                    integration_id=integ.id,
+                    payload={"sample": i},
+                )
+            )
+    print("Database initialized with sample webhook payloads.")
 
 
 def change_password(password: str | None) -> None:
-    """Change admin password."""
-    engine = get_engine(str(settings.database.dsn))
-    Session = get_session_maker(engine)
+    """Change admin password stored in the config file."""
+
     pwd = password or getpass.getpass("New admin password: ")
-    with Session.begin() as session:  # pylint: disable=no-member
-        admin = session.execute(select(AdminUser)).scalar_one_or_none()
-        hashed = hash_password(pwd)
-        if admin:
-            session.execute(update(AdminUser).values(password_hash=hashed))
-        else:
-            session.add(AdminUser(password_hash=hashed))
-    print("Admin password updated.")
+    hashed = hash_password(pwd)
+
+    with open(CONFIG_PATH, "rb") as f:
+        data = tomllib.load(f)
+
+    data.setdefault("admin", {})["password_hash"] = hashed
+
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        f.write(dumps(data))
+
+    print("Admin password updated in config.")
 
 
 def main() -> None:

--- a/experimental/gatelet/server/app.py
+++ b/experimental/gatelet/server/app.py
@@ -20,6 +20,9 @@ from .auth.webhook_auth import AuthError
 from .config import settings
 from .endpoints import admin, challenge, webhook_receive, webhook_view
 from .shared import BASE_DIR, templates
+from .database import get_db_session
+from .models import AdminSession
+from fastapi_csrf_protect import CsrfProtect
 
 logger = logging.getLogger(__name__)
 
@@ -64,14 +67,12 @@ async def webhook_auth_error(request: Request, exc: AuthError):
     )
 
 
-from .database import get_db_session
-
-# Root endpoint - public information and login form
-from .models import AdminSession
-
-
 @app.get("/", response_class=HTMLResponse)
-async def root(request: Request, session: Optional[str] = Cookie(None)):
+async def root(
+    request: Request,
+    session: Optional[str] = Cookie(None),
+    csrf_protect: CsrfProtect = Depends(),
+):
     """Root endpoint with service information and authentication options."""
     # Check if already authenticated via cookie
     if session:
@@ -81,15 +82,19 @@ async def root(request: Request, session: Optional[str] = Cookie(None)):
             if admin_session and admin_session.expires_at > datetime.now():
                 return RedirectResponse("/admin/", status_code=302)
 
-    return templates.TemplateResponse(
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
         "public.html",
         {
             "request": request,
             "header": "Gatelet",
             "show_admin_login": True,
             "llm_instructions": "To access this service as an LLM, follow the instructions provided by your user.",
+            "csrf_token": token,
         },
     )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
 
 
 def register_with_all_auth_methods(

--- a/experimental/gatelet/server/config.py
+++ b/experimental/gatelet/server/config.py
@@ -129,12 +129,26 @@ class WebhookSettings(BaseModel):
         return v
 
 
+class AdminSettings(BaseModel):
+    """Configuration for the human admin account."""
+
+    password_hash: str = Field(...)
+
+
+class SecuritySettings(BaseModel):
+    """Misc security configuration."""
+
+    csrf_secret: str = Field(...)
+
+
 class Settings(BaseModel):
     database: DatabaseSettings
     server: ServerSettings
     auth: AuthSettings
     home_assistant: HomeAssistantSettings
     webhook: WebhookSettings
+    admin: AdminSettings
+    security: SecuritySettings
 
     @classmethod
     def from_file(cls, path: Path):
@@ -149,10 +163,13 @@ class Settings(BaseModel):
         except ModuleNotFoundError:  # pragma: no cover - fallback for older Python
             import toml  # type: ignore
 
-            with open(path, "r") as f:
+            with open(path, "rb") as f:
                 config_dict = toml.load(f)
         return cls.parse_obj(config_dict)
 
 
+# Path to the active configuration file
+CONFIG_PATH = Path(os.getenv("GATELET_CONFIG", "gatelet.toml"))
+
 # Load settings
-settings = Settings.from_file(Path(os.getenv("GATELET_CONFIG", "gatelet.toml")))
+settings = Settings.from_file(CONFIG_PATH)

--- a/experimental/gatelet/server/endpoints/admin.py
+++ b/experimental/gatelet/server/endpoints/admin.py
@@ -18,23 +18,27 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..config import settings
+from fastapi_csrf_protect import CsrfProtect
+from pydantic import BaseModel
 from ..database import get_db_session
-from ..models import AdminSession, AdminUser
-from ..security import hash_password, verify_password
+from ..models import AdminSession
+from ..security import verify_password
 from ..shared import templates
 
 router = APIRouter(tags=["admin"])
 
+
+class _CsrfSettings(BaseModel):
+    secret_key: str = settings.security.csrf_secret
+
+
+@CsrfProtect.load_config
+def _get_csrf_config():
+    return _CsrfSettings()
+
+
 SESSION_DURATION = timedelta(hours=1)
-
-
-async def _get_admin(db_session: AsyncSession) -> AdminUser:
-    admin = (await db_session.execute(select(AdminUser))).scalar_one_or_none()
-    if not admin:
-        admin = AdminUser(password_hash=hash_password("gatelet"))
-        db_session.add(admin)
-        await db_session.flush()
-    return admin
 
 
 async def _get_admin_session(
@@ -57,9 +61,10 @@ async def login(
     request: Request,
     password: str = Form(...),
     db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
 ) -> Response:
-    admin = await _get_admin(db_session)
-    if not verify_password(password, admin.password_hash):
+    await csrf_protect.validate_csrf(request)
+    if not verify_password(password, settings.admin.password_hash):
         return templates.TemplateResponse(
             "public.html",
             {
@@ -81,6 +86,8 @@ async def login(
     await db_session.flush()
     response = RedirectResponse("/admin/", status_code=302)
     response.set_cookie("admin_session", session.session_token, httponly=True)
+    token, signed = csrf_protect.generate_csrf_tokens()
+    csrf_protect.set_csrf_cookie(signed, response)
     return response
 
 

--- a/experimental/gatelet/server/endpoints/test_admin_login.py
+++ b/experimental/gatelet/server/endpoints/test_admin_login.py
@@ -1,10 +1,9 @@
 """Tests for admin password authentication."""
 
 import pytest
+import re
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from server.models import AdminUser
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +13,7 @@ async def _override_db(monkeypatch, db_session: AsyncSession):
     @asynccontextmanager
     async def _override():
         yield db_session
-        await db_session.execute(AdminUser.__table__.delete())
+        await db_session.execute("DELETE FROM admin_sessions")
         await db_session.commit()
 
     monkeypatch.setattr("server.database.get_db_session", _override)
@@ -22,14 +21,30 @@ async def _override_db(monkeypatch, db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_admin_login_success(client: AsyncClient, db_session: AsyncSession):
-    response = await client.post("/admin/login", data={"password": "gatelet"})
-    assert response.status_code == 302
+    home = await client.get("/")
+    m = re.search(r'name="csrf_token" value="([^"]+)"', home.text)
+    assert m
+    token = m.group(1)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+        headers={"X-CSRF-Token": token},
+    )
+    assert response.status_code == 302  # noqa: PLR2004
     assert response.headers["location"] == "/admin/"
     assert "admin_session" in response.cookies
 
 
 @pytest.mark.asyncio
 async def test_admin_login_invalid(client: AsyncClient, db_session: AsyncSession):
-    response = await client.post("/admin/login", data={"password": "wrong"})
-    assert response.status_code == 401
+    home = await client.get("/")
+    m = re.search(r'name="csrf_token" value="([^"]+)"', home.text)
+    assert m
+    token = m.group(1)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "wrong", "csrf_token": token},
+        headers={"X-CSRF-Token": token},
+    )
+    assert response.status_code == 401  # noqa: PLR2004
     assert "Invalid password" in response.text

--- a/experimental/gatelet/server/models.py
+++ b/experimental/gatelet/server/models.py
@@ -149,15 +149,6 @@ class AuthNonce(Base):
         return self.used_at is not None
 
 
-class AdminUser(Base):
-    """Model for administrator password."""
-
-    __tablename__ = "admin_users"
-
-    id = Column(Integer, primary_key=True)
-    password_hash = Column(String, nullable=False)
-
-
 class AdminSession(Base):
     """Admin session model."""
 

--- a/experimental/gatelet/server/security.py
+++ b/experimental/gatelet/server/security.py
@@ -1,23 +1,18 @@
-"""Password hashing helpers."""
+"""Password hashing helpers using Argon2."""
 
-import binascii
-import hashlib
-import os
+from passlib.hash import argon2
 
 
-def hash_password(password: str, salt: str | None = None) -> str:
-    """Return PBKDF2-HMAC-SHA256 hash of the password with a hex salt."""
-    salt_bytes = os.urandom(16) if salt is None else bytes.fromhex(salt)
-    pwd_hash = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, 100000)
-    return f"{salt_bytes.hex()}${binascii.hexlify(pwd_hash).decode()}"
+def hash_password(password: str) -> str:
+    """Return Argon2 hash of ``password``."""
+
+    return argon2.hash(password)
 
 
 def verify_password(password: str, hashed: str) -> bool:
-    """Verify password against stored hash."""
+    """Verify ``password`` against ``hashed`` Argon2 digest."""
+
     try:
-        salt_hex, hash_hex = hashed.split("$")
-    except ValueError:
+        return argon2.verify(password, hashed)
+    except Exception:  # pragma: no cover - passlib raises various errors
         return False
-    salt_bytes = bytes.fromhex(salt_hex)
-    expected = hashlib.pbkdf2_hmac("sha256", password.encode(), salt_bytes, 100000)
-    return binascii.hexlify(expected).decode() == hash_hex

--- a/experimental/gatelet/server/templates/public.html
+++ b/experimental/gatelet/server/templates/public.html
@@ -13,6 +13,7 @@
     <h2>Administrator Login</h2>
     {% if login_error %}<p>{{ login_error }}</p>{% endif %}
     <form method="post" action="/admin/login">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <label>Password: <input type="password" name="password"></label>
         <button type="submit">Login</button>
     </form>


### PR DESCRIPTION
## Summary
- keep admin password outside database using a config file
- hash passwords with passlib argon2
- add CSRF protection for admin login
- include sample webhook payloads in reset-db
- update tests for new CSRF workflow

## Testing
- `ruff check experimental/gatelet/server/security.py experimental/gatelet/server/config.py experimental/gatelet/server/endpoints/admin.py experimental/gatelet/server/app.py experimental/gatelet/server/models.py experimental/gatelet/manage.py experimental/gatelet/server/endpoints/test_admin_login.py`
- `pytest experimental/gatelet/server/endpoints/test_admin_login.py -q`
- `pre-commit run ruff-check --files experimental/gatelet/manage.py` *(fails: E902 No such file or directory)*