### PR TITLE
Refactor Gatelet tests to reuse DB override

### DIFF
--- a/experimental/gatelet/server/conftest.py
+++ b/experimental/gatelet/server/conftest.py
@@ -8,10 +8,10 @@ import shutil
 import subprocess
 import tempfile
 import time
+from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
-from collections.abc import AsyncGenerator
 
 import pytest
 import pytest_asyncio
@@ -30,8 +30,9 @@ os.environ.setdefault(
 # pylint: disable=wrong-import-position
 
 from server.app import app  # type: ignore[import]
+from server.config import settings  # type: ignore[import]
 from server.database import get_db_session  # type: ignore[import]
-from server.models import Base, AuthCRSession, AuthKey  # type: ignore[import]
+from server.models import AuthCRSession, AuthKey, Base  # type: ignore[import]
 from server.tests.utils import persist  # type: ignore[import]
 
 logging.basicConfig(
@@ -53,10 +54,12 @@ def _postgres():
     bin_dir = Path(shutil.which("initdb")).parent
     initdb = bin_dir / "initdb"
     pg_ctl = bin_dir / "pg_ctl"
+    createdb = bin_dir / "createdb"
+    port = "55432"
     subprocess.check_call(
         ["sudo", "-u", "postgres", str(initdb), "-D", datadir, "-A", "trust"]
     )
-    proc = subprocess.Popen(
+    subprocess.check_call(
         [
             "sudo",
             "-u",
@@ -65,10 +68,18 @@ def _postgres():
             "-D",
             datadir,
             "-w",
+            "-o",
+            f"-p {port}",
             "start",
         ]
     )
-    os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres@localhost/postgres"
+    subprocess.check_call(
+        ["sudo", "-u", "postgres", str(createdb), "-p", port, "gatelet"]
+    )
+    os.environ["DATABASE_URL"] = (
+        f"postgresql+asyncpg://postgres@localhost:{port}/gatelet"
+    )
+    settings.database.dsn = os.environ["DATABASE_URL"]
     os.environ.setdefault(
         "GATELET_CONFIG",
         str(Path(__file__).resolve().parent.parent / "gatelet.toml"),
@@ -127,6 +138,19 @@ async def db_session(db_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, Non
         finally:
             if trans.is_active:
                 await trans.rollback()
+
+
+@pytest.fixture(autouse=True)
+def _patch_get_db_session(monkeypatch, db_session: AsyncSession) -> None:
+    """Override ``get_db_session`` globally for tests."""
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _override() -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    monkeypatch.setattr("server.database.get_db_session", _override)
 
 
 @pytest_asyncio.fixture

--- a/experimental/gatelet/server/endpoints/test_challenge.py
+++ b/experimental/gatelet/server/endpoints/test_challenge.py
@@ -1,7 +1,6 @@
 """Tests for challenge-response authentication endpoints."""
 
 import html
-from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from http import HTTPStatus
 
@@ -12,15 +11,6 @@ from server.endpoints.challenge import COMPUTE_OPTION_SOURCE, compute_correct_op
 from server.models import AuthCRSession, AuthKey, AuthNonce  # type: ignore[import]
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-
-
-@pytest.fixture(autouse=True)
-def _override_get_db(monkeypatch, db_session: AsyncSession):
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-
-    monkeypatch.setattr("server.database.get_db_session", _override)
 
 
 @pytest.mark.asyncio

--- a/experimental/gatelet/server/endpoints/test_webhook_view.py
+++ b/experimental/gatelet/server/endpoints/test_webhook_view.py
@@ -6,22 +6,11 @@ import pytest
 from hamcrest import all_of, assert_that, contains_string
 from httpx import AsyncClient
 from server.models import WebhookIntegration, WebhookPayload
+from server.shared import templates
 from server.tests.utils import persist
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-@pytest.fixture(autouse=True)
-def _override_get_db(monkeypatch, db_session: AsyncSession):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-
-    monkeypatch.setattr("server.database.get_db_session", _override)
-    from server.shared import templates
-
-    templates.env.globals.update({"max": max, "min": min})
+templates.env.globals.update({"max": max, "min": min})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure temporary Postgres uses its own port
- patch settings to use the temporary database
- provide autouse fixture to override `get_db_session`
- drop redundant overrides in challenge and webhook view tests

## Testing
- `pre-commit run --files experimental/gatelet/server/conftest.py experimental/gatelet/server/endpoints/test_challenge.py experimental/gatelet/server/endpoints/test_webhook_view.py`
- `pytest experimental/gatelet/server/auth/test_key_auth.py experimental/gatelet/server/auth/test_handlers.py experimental/gatelet/server/auth/test_key_path_auth.py experimental/gatelet/server/auth/test_webhook_auth.py experimental/gatelet/server/endpoints/test_challenge.py experimental/gatelet/server/endpoints/test_compute_correct_option.py experimental/gatelet/server/endpoints/test_webhook_receive.py experimental/gatelet/server/endpoints/test_webhook_view.py`