### PR TITLE
Add Home Assistant panel to Gatelet dashboard

### DIFF
--- a/experimental/gatelet/server/app.py
+++ b/experimental/gatelet/server/app.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 from fastapi import Cookie, Depends, FastAPI, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi_csrf_protect import CsrfProtect
 from sqlalchemy import select
 
 from .auth.dependencies import (
@@ -18,11 +19,18 @@ from .auth.dependencies import (
 from .auth.handlers import AuthHandlerError
 from .auth.webhook_auth import AuthError
 from .config import settings
-from .endpoints import admin, challenge, webhook_receive, webhook_view
-from .shared import BASE_DIR, templates
 from .database import get_db_session
+from .endpoints import (
+    admin,
+    challenge,
+    homeassistant,
+    webhook_receive,
+    webhook_view,
+)
+from .endpoints.homeassistant import fetch_states
+from .endpoints.webhook_view import get_latest_payloads
 from .models import AdminSession
-from fastapi_csrf_protect import CsrfProtect
+from .shared import BASE_DIR, templates
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +48,7 @@ app.include_router(webhook_receive.router)
 app.include_router(webhook_view.router)
 app.include_router(challenge.router)
 app.include_router(admin.router)
+app.include_router(homeassistant.router)
 
 
 # Error handlers
@@ -140,8 +149,18 @@ def register_with_all_auth_methods(
 # Create auth-method-agnostic route handlers for each endpoint type
 async def authenticated_root_handler(request: Request, auth: Auth):
     """Shared handler for authenticated root endpoint."""
+    async with get_db_session() as db_session:
+        recent = await get_latest_payloads(db_session, limit=5)
+    ha_states = await fetch_states()
     return templates.TemplateResponse(
-        "index.html", {"request": request, "header": "Gatelet", "auth": auth}
+        "index.html",
+        {
+            "request": request,
+            "header": "Gatelet",
+            "auth": auth,
+            "recent_payloads": recent,
+            "ha_states": ha_states,
+        },
     )
 
 
@@ -153,3 +172,7 @@ register_with_all_auth_methods("/webhooks/", webhook_view.list_all_payloads)
 register_with_all_auth_methods(
     "/webhooks/{integration_name}", webhook_view.list_integration_payloads
 )
+
+# Register Home Assistant routes with all auth methods
+register_with_all_auth_methods("/ha/", homeassistant.list_entities)
+register_with_all_auth_methods("/ha/{entity_id}", homeassistant.entity_details)

--- a/experimental/gatelet/server/config.py
+++ b/experimental/gatelet/server/config.py
@@ -9,7 +9,7 @@ import os
 import re
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, List, Literal, Union
+from typing import BinaryIO, Dict, List, Literal, TextIO, Union, cast
 
 from pydantic import BaseModel, Field, validator
 
@@ -159,13 +159,13 @@ class Settings(BaseModel):
 
             # tomllib expects binary mode for file objects
             with open(path, "rb") as f:
-                config_dict = toml.load(f)
+                config_dict = toml.load(cast(BinaryIO, f))
         except ModuleNotFoundError:  # pragma: no cover - fallback for older Python
             import toml  # type: ignore
 
             # toml library (not Python builtin - used in case of Python < 3.11) reads strings
             with open(path, "r") as f:
-                config_dict = toml.load(f)
+                config_dict = toml.load(cast(TextIO, f))  # type: ignore[arg-type]
         return cls.parse_obj(config_dict)
 
 

--- a/experimental/gatelet/server/conftest.py
+++ b/experimental/gatelet/server/conftest.py
@@ -151,6 +151,7 @@ def _patch_get_db_session(monkeypatch, db_session: AsyncSession) -> None:
         yield db_session
 
     monkeypatch.setattr("server.database.get_db_session", _override)
+    monkeypatch.setattr("server.app.get_db_session", _override)
 
 
 @pytest_asyncio.fixture

--- a/experimental/gatelet/server/endpoints/homeassistant.py
+++ b/experimental/gatelet/server/endpoints/homeassistant.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import homeassistant_api
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from ..auth.dependencies import Auth
+from ..config import settings
+from ..shared import templates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["homeassistant"])
+
+
+async def fetch_states() -> list[dict[str, Any]]:
+    """Fetch states for configured entities."""
+    entities: list[dict[str, Any]] = []
+    async with homeassistant_api.Client(
+        settings.home_assistant.api_url,
+        settings.home_assistant.api_token,
+        use_async=True,
+        verify_ssl=False,
+    ) as client:
+        for entity_id in settings.home_assistant.entities:
+            try:
+                state = await client.async_get_state(entity_id=entity_id)
+                entities.append(
+                    {
+                        "entity_id": entity_id,
+                        "state": state.state,
+                        "last_changed": state.last_changed,
+                    }
+                )
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.error("Failed fetching %s: %s", entity_id, exc)
+    return entities
+
+
+@router.get("/ha/", response_class=HTMLResponse)
+async def list_entities(request: Request, auth: Auth) -> HTMLResponse:
+    """List configured Home Assistant entity states."""
+    states = await fetch_states()
+    return templates.TemplateResponse(
+        "ha_entities.html",
+        {"request": request, "auth": auth, "states": states, "header": "Entities"},
+    )
+
+
+@router.get("/ha/{entity_id}", response_class=HTMLResponse)
+async def entity_details(request: Request, entity_id: str, auth: Auth) -> HTMLResponse:
+    """Display details for a single entity."""
+    states = await fetch_states()
+    entity = next((s for s in states if s["entity_id"] == entity_id), None)
+    return templates.TemplateResponse(
+        "ha_entity.html",
+        {
+            "request": request,
+            "auth": auth,
+            "state": entity,
+            "header": f"{entity_id} Details",
+        },
+    )

--- a/experimental/gatelet/server/endpoints/test_homeassistant.py
+++ b/experimental/gatelet/server/endpoints/test_homeassistant.py
@@ -1,0 +1,55 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.fixture(autouse=True)
+async def _stub_data(monkeypatch):
+    async def _states():
+        import datetime
+
+        return [
+            {
+                "entity_id": "sensor.test",
+                "state": "on",
+                "last_changed": datetime.datetime(2020, 1, 1),
+            },
+        ]
+
+    async def _payloads(*args, **kwargs):
+        return [
+            {
+                "id": 1,
+                "integration_name": "test",
+                "received_at": __import__("datetime").datetime(2020, 1, 1),
+            }
+        ]
+
+    monkeypatch.setattr("server.endpoints.homeassistant.fetch_states", _states)
+    monkeypatch.setattr("server.endpoints.webhook_view.get_latest_payloads", _payloads)
+    monkeypatch.setattr("server.app.fetch_states", _states)
+    monkeypatch.setattr("server.app.get_latest_payloads", _payloads)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_home_page(client: AsyncClient, test_auth_key):
+    resp = await client.get(f"/k/{test_auth_key.key_value}/")
+    assert resp.status_code == HTTPStatus.OK
+    assert "sensor.test" in resp.text
+    assert "test" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_entities_page(client: AsyncClient, test_auth_key):
+    resp = await client.get(f"/k/{test_auth_key.key_value}/ha/")
+    assert resp.status_code == HTTPStatus.OK
+    assert "sensor.test" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_entity_detail(client: AsyncClient, test_auth_key):
+    resp = await client.get(f"/k/{test_auth_key.key_value}/ha/sensor.test")
+    assert resp.status_code == HTTPStatus.OK
+    assert "sensor.test" in resp.text

--- a/experimental/gatelet/server/endpoints/webhook_view.py
+++ b/experimental/gatelet/server/endpoints/webhook_view.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Dict, Optional
 
 from compact_json import Formatter
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.dependencies import Auth
@@ -126,6 +126,24 @@ async def get_webhook_payloads(
     }
 
 
+async def get_latest_payloads(
+    db_session: AsyncSession, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Get latest webhook payloads across all integrations."""
+    query = (
+        select(WebhookPayload).order_by(WebhookPayload.received_at.desc()).limit(limit)
+    )
+    result = await db_session.execute(query)
+    return [
+        {
+            "id": payload.id,
+            "integration_name": payload.integration_name,
+            "received_at": payload.received_at,
+        }
+        for payload in result.scalars().all()
+    ]
+
+
 async def list_all_payloads(
     request: Request,
     auth: Auth,
@@ -140,9 +158,7 @@ async def list_all_payloads(
     # TODO: Once we have human login, with human having logged in, it should also show disabled integrations
 
     # Get webhook integrations
-    integrations_query = select(WebhookIntegration).where(
-        WebhookIntegration.is_enabled == True
-    )
+    integrations_query = select(WebhookIntegration).where(WebhookIntegration.is_enabled)
     integrations_result = await db_session.execute(integrations_query)
     integrations = [
         {
@@ -170,7 +186,7 @@ async def list_all_payloads(
     )
 
 
-async def list_integration_payloads(
+async def list_integration_payloads(  # noqa: PLR0913
     request: Request,
     integration_name: str,
     auth: Auth,

--- a/experimental/gatelet/server/templates/ha_entities.html
+++ b/experimental/gatelet/server/templates/ha_entities.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Home Assistant Entities{% endblock %}
+
+{% block nav %}
+<nav>
+    <a href="{{ auth.create_url('') }}">Home</a>
+    <a href="{{ auth.create_url('webhooks') }}">Webhooks</a>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Home Assistant Entities</h2>
+{% if states %}
+<ul>
+    {% for s in states %}
+    <li><a href="{{ auth.create_url('ha/' + s.entity_id) }}">{{ s.entity_id }}</a>: {{ s.state }}</li>
+    {% endfor %}
+</ul>
+{% else %}
+<p>No data available.</p>
+{% endif %}
+{% endblock %}

--- a/experimental/gatelet/server/templates/ha_entity.html
+++ b/experimental/gatelet/server/templates/ha_entity.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}{{ header }}{% endblock %}
+
+{% block nav %}
+<nav>
+    <a href="{{ auth.create_url('') }}">Home</a>
+    <a href="{{ auth.create_url('ha') }}">Entities</a>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>{{ header }}</h2>
+{% if state %}
+<p>State: {{ state.state }}</p>
+<p>Last changed: {{ state.last_changed.strftime('%Y-%m-%d %H:%M:%S') }}</p>
+{% else %}
+<p>No data found.</p>
+{% endif %}
+{% endblock %}

--- a/experimental/gatelet/server/templates/index.html
+++ b/experimental/gatelet/server/templates/index.html
@@ -19,6 +19,39 @@
     <h3>Available Services</h3>
     <ul>
         <li><a href="{{ auth.create_url('webhooks') }}">Webhooks</a> - View and filter webhook payloads</li>
+        <li><a href="{{ auth.create_url('ha') }}">Home Assistant Entities</a></li>
     </ul>
+</section>
+
+<section>
+    <h3>Latest Webhook Events</h3>
+    {% if recent_payloads %}
+    <ul>
+        {% for p in recent_payloads %}
+        <li>
+            {{ p.received_at.strftime('%Y-%m-%d %H:%M:%S') }} -
+            <a href="{{ auth.create_url('webhooks/' + p.integration_name) }}">{{ p.integration_name }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>No events recorded.</p>
+    {% endif %}
+</section>
+
+<section>
+    <h3>Home Assistant Status</h3>
+    {% if ha_states %}
+    <ul>
+        {% for s in ha_states %}
+        <li>
+            <a href="{{ auth.create_url('ha/' + s.entity_id) }}">{{ s.entity_id }}</a>:
+            {{ s.state }}
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>Home Assistant data unavailable.</p>
+    {% endif %}
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show Home Assistant entities and recent webhook events on dashboard
- add new `/ha/` endpoints to display entity status
- include templates for entity list and details
- register HA routes and fetch latest events on index page
- add basic tests for the new functionality

## Testing
- `pre-commit run --files experimental/gatelet/server/endpoints/homeassistant.py experimental/gatelet/server/endpoints/webhook_view.py experimental/gatelet/server/app.py experimental/gatelet/server/templates/index.html experimental/gatelet/server/templates/ha_entities.html experimental/gatelet/server/templates/ha_entity.html experimental/gatelet/server/endpoints/test_homeassistant.py experimental/gatelet/server/config.py experimental/gatelet/server/conftest.py`
- `pytest experimental/gatelet/server/endpoints/test_homeassistant.py -q`