### PR TITLE
Add Gatelet admin key management

### DIFF
--- a/experimental/gatelet/server/config.py
+++ b/experimental/gatelet/server/config.py
@@ -165,7 +165,7 @@ class Settings(BaseModel):
 
             # toml library (not Python builtin - used in case of Python < 3.11) reads strings
             with open(path, "r") as f:
-                config_dict = toml.load(f)
+                config_dict = toml.load(f)  # type: ignore[arg-type]
         return cls.parse_obj(config_dict)
 
 

--- a/experimental/gatelet/server/endpoints/admin.py
+++ b/experimental/gatelet/server/endpoints/admin.py
@@ -15,14 +15,14 @@ from fastapi import (
     status,
 )
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi_csrf_protect import CsrfProtect
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
-from fastapi_csrf_protect import CsrfProtect
-from pydantic import BaseModel
 from ..database import get_db_session
-from ..models import AdminSession
+from ..models import AdminSession, AuthKey
 from ..security import verify_password
 from ..shared import templates
 
@@ -42,7 +42,7 @@ SESSION_DURATION = timedelta(hours=1)
 
 
 async def _get_admin_session(
-    session_token: Optional[str] = Cookie(None),
+    session_token: Optional[str] = Cookie(None, alias="admin_session"),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> AdminSession:
     if not session_token:
@@ -96,3 +96,79 @@ async def admin_root(
     request: Request, admin_session: AdminSession = Depends(_get_admin_session)
 ) -> HTMLResponse:
     return templates.TemplateResponse("admin_index.html", {"request": request})
+
+
+@router.get("/admin/keys/", response_class=HTMLResponse)
+async def list_keys(
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> HTMLResponse:
+    keys = (
+        (await db_session.execute(select(AuthKey).order_by(AuthKey.id))).scalars().all()
+    )
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
+        "admin_keys.html",
+        {"request": request, "keys": keys, "csrf_token": token},
+    )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.get("/admin/keys/new", response_class=HTMLResponse)
+async def new_key_form(
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> HTMLResponse:
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
+        "admin_key_new.html", {"request": request, "csrf_token": token}
+    )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.post("/admin/keys/new", response_class=HTMLResponse)
+async def create_key(
+    request: Request,
+    description: str = Form(""),
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> HTMLResponse:
+    await csrf_protect.validate_csrf(request)
+    key = AuthKey(
+        key_value=uuid.uuid4().hex,
+        description=description or None,
+        created_at=datetime.now(),
+    )
+    db_session.add(key)
+    await db_session.flush()
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
+        "admin_key_created.html",
+        {"request": request, "key": key, "csrf_token": token},
+    )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.post("/admin/keys/{key_id}/revoke", response_class=RedirectResponse)
+async def revoke_key(
+    key_id: int,
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> Response:
+    await csrf_protect.validate_csrf(request)
+    stmt = select(AuthKey).where(AuthKey.id == key_id)
+    key = (await db_session.execute(stmt)).scalar_one_or_none()
+    if key and not key.revoked_at:
+        key.revoked_at = datetime.now()
+        await db_session.flush()
+    response = RedirectResponse("/admin/keys/", status_code=302)
+    return response

--- a/experimental/gatelet/server/endpoints/test_admin_keys.py
+++ b/experimental/gatelet/server/endpoints/test_admin_keys.py
@@ -1,0 +1,88 @@
+import re
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from server.models import AuthKey
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _override_db(monkeypatch, db_session: AsyncSession):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _override():
+        yield db_session
+
+    monkeypatch.setattr("server.database.get_db_session", _override)
+
+
+def _extract_csrf(page_text: str) -> str:
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page_text)
+    assert m
+    return m.group(1)
+
+
+async def _login(client: AsyncClient) -> str:
+    home = await client.get("/")
+    token = _extract_csrf(home.text)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+        headers={"X-CSRF-Token": token},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+    return response.cookies["admin_session"]
+
+
+@pytest.mark.asyncio
+async def test_list_keys(
+    client: AsyncClient, db_session: AsyncSession, test_auth_key: AuthKey
+):
+    session = await _login(client)
+    response = await client.get("/admin/keys/", cookies={"admin_session": session})
+    assert response.status_code == HTTPStatus.OK
+    assert str(test_auth_key.id) in response.text
+    assert test_auth_key.key_value in response.text
+
+
+@pytest.mark.asyncio
+async def test_create_key(client: AsyncClient, db_session: AsyncSession):
+    session = await _login(client)
+    response = await client.get("/admin/keys/new", cookies={"admin_session": session})
+    token = _extract_csrf(response.text)
+
+    count_before = await db_session.scalar(select(func.count()).select_from(AuthKey))
+
+    response = await client.post(
+        "/admin/keys/new",
+        data={"description": "test key", "csrf_token": token},
+        headers={"X-CSRF-Token": token},
+        cookies={"admin_session": session},
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    count_after = await db_session.scalar(select(func.count()).select_from(AuthKey))
+    assert count_after == count_before + 1
+
+
+@pytest.mark.asyncio
+async def test_revoke_key(
+    client: AsyncClient, db_session: AsyncSession, test_auth_key: AuthKey
+):
+    session = await _login(client)
+    response = await client.get("/admin/keys/", cookies={"admin_session": session})
+    token = _extract_csrf(response.text)
+
+    response = await client.post(
+        f"/admin/keys/{test_auth_key.id}/revoke",
+        data={"csrf_token": token},
+        headers={"X-CSRF-Token": token},
+        cookies={"admin_session": session},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+
+    await db_session.refresh(test_auth_key)
+    assert test_auth_key.revoked_at is not None

--- a/experimental/gatelet/server/templates/admin_index.html
+++ b/experimental/gatelet/server/templates/admin_index.html
@@ -6,6 +6,7 @@
 <h2>Admin Dashboard</h2>
 <ul>
   <li><a href="/admin/webhooks/">Webhook Payloads</a></li>
+  <li><a href="/admin/keys/">Manage Keys</a></li>
   <li><a href="/">Public Index</a></li>
 </ul>
 {% endblock %}

--- a/experimental/gatelet/server/templates/admin_key_created.html
+++ b/experimental/gatelet/server/templates/admin_key_created.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Key Created{% endblock %}
+{% block nav %}
+<nav>
+    <a href="/admin/">Admin Home</a>
+    <a href="/admin/keys/">Keys</a>
+</nav>
+{% endblock %}
+{% block content %}
+<section>
+    <h2>New Key Created</h2>
+    <p>Key ID: {{ key.id }}</p>
+    <p>Key Value: {{ key.key_value }}</p>
+    <p>Use for key-in-url: <code>/k/{{ key.key_value }}/</code></p>
+    <p>Use for challenge-response: <code>/cr/{{ key.id }}</code></p>
+    <p><a href="/admin/keys/">Back to Keys</a></p>
+</section>
+{% endblock %}

--- a/experimental/gatelet/server/templates/admin_key_new.html
+++ b/experimental/gatelet/server/templates/admin_key_new.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block title %}Create Key{% endblock %}
+{% block nav %}
+<nav>
+    <a href="/admin/">Admin Home</a>
+    <a href="/admin/keys/">Keys</a>
+</nav>
+{% endblock %}
+{% block content %}
+<h2>Create New Key</h2>
+<form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+    <label>Description: <input type="text" name="description"></label>
+    <button type="submit">Create</button>
+</form>
+{% endblock %}

--- a/experimental/gatelet/server/templates/admin_keys.html
+++ b/experimental/gatelet/server/templates/admin_keys.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}Admin - Keys{% endblock %}
+{% block nav %}
+<nav>
+    <a href="/admin/">Admin Home</a>
+</nav>
+{% endblock %}
+{% block content %}
+<section>
+    <h2>Authentication Keys</h2>
+    <p><a href="/admin/keys/new">Create New Key</a></p>
+    {% if keys %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th><th>Key</th><th>Description</th><th>Created</th><th>Status</th><th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for key in keys %}
+            <tr>
+                <td>{{ key.id }}</td>
+                <td>{{ key.key_value }}</td>
+                <td>{{ key.description or '' }}</td>
+                <td>{{ key.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>{% if key.revoked_at %}Revoked{% else %}Active{% endif %}</td>
+                <td>
+                    {% if not key.revoked_at %}
+                    <form method="post" action="/admin/keys/{{ key.id }}/revoke">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        <button type="submit">Revoke</button>
+                    </form>
+                    {% else %}-{% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No keys defined.</p>
+    {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin interface for listing, creating and revoking LLM keys
- expose new pages in admin dashboard
- tests for the new endpoints

## Testing
- `pre-commit run --files experimental/gatelet/server/endpoints/admin.py experimental/gatelet/server/templates/admin_index.html experimental/gatelet/server/templates/admin_keys.html experimental/gatelet/server/templates/admin_key_new.html experimental/gatelet/server/templates/admin_key_created.html experimental/gatelet/server/endpoints/test_admin_keys.py experimental/gatelet/server/config.py`
- `pytest experimental/gatelet/server/endpoints/test_admin_keys.py`
