### PR TITLE
Fix gatelet admin login CSRF validation

### DIFF
--- a/experimental/gatelet/server/endpoints/admin.py
+++ b/experimental/gatelet/server/endpoints/admin.py
@@ -31,6 +31,8 @@ router = APIRouter(tags=["admin"])
 
 class _CsrfSettings(BaseModel):
     secret_key: str = settings.security.csrf_secret
+    token_location: str = "body"
+    token_key: str = "csrf_token"
 
 
 @CsrfProtect.load_config

--- a/experimental/gatelet/server/endpoints/test_admin_keys.py
+++ b/experimental/gatelet/server/endpoints/test_admin_keys.py
@@ -31,7 +31,6 @@ async def _login(client: AsyncClient) -> str:
     response = await client.post(
         "/admin/login",
         data={"password": "gatelet", "csrf_token": token},
-        headers={"X-CSRF-Token": token},
     )
     assert response.status_code == HTTPStatus.FOUND
     return response.cookies["admin_session"]
@@ -59,7 +58,6 @@ async def test_create_key(client: AsyncClient, db_session: AsyncSession):
     response = await client.post(
         "/admin/keys/new",
         data={"description": "test key", "csrf_token": token},
-        headers={"X-CSRF-Token": token},
         cookies={"admin_session": session},
     )
     assert response.status_code == HTTPStatus.OK
@@ -79,7 +77,6 @@ async def test_revoke_key(
     response = await client.post(
         f"/admin/keys/{test_auth_key.id}/revoke",
         data={"csrf_token": token},
-        headers={"X-CSRF-Token": token},
         cookies={"admin_session": session},
     )
     assert response.status_code == HTTPStatus.FOUND

--- a/experimental/gatelet/server/endpoints/test_admin_login.py
+++ b/experimental/gatelet/server/endpoints/test_admin_login.py
@@ -1,9 +1,8 @@
 """Tests for admin password authentication."""
 
-from http import HTTPStatus
+import re
 
 import pytest
-import re
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,7 +29,6 @@ async def test_admin_login_success(client: AsyncClient, db_session: AsyncSession
     response = await client.post(
         "/admin/login",
         data={"password": "gatelet", "csrf_token": token},
-        headers={"X-CSRF-Token": token},
     )
     assert response.status_code == 302  # noqa: PLR2004
     assert response.headers["location"] == "/admin/"
@@ -46,6 +44,5 @@ async def test_admin_login_invalid(client: AsyncClient, db_session: AsyncSession
     response = await client.post(
         "/admin/login",
         data={"password": "wrong", "csrf_token": token},
-        headers={"X-CSRF-Token": token},
     )
     assert response.status_code == 401  # noqa: PLR2004

--- a/experimental/gatelet/server/endpoints/test_challenge.py
+++ b/experimental/gatelet/server/endpoints/test_challenge.py
@@ -13,6 +13,35 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
+@pytest.fixture(autouse=True)
+async def _stub_data(monkeypatch):
+    async def _states():
+        import datetime
+
+        return [
+            {
+                "entity_id": "sensor.test",
+                "state": "on",
+                "last_changed": datetime.datetime(2020, 1, 1),
+            }
+        ]
+
+    async def _payloads(*_args, **_kwargs):
+        return [
+            {
+                "id": 1,
+                "integration_name": "test",
+                "received_at": __import__("datetime").datetime(2020, 1, 1),
+            }
+        ]
+
+    monkeypatch.setattr("server.endpoints.homeassistant.fetch_states", _states)
+    monkeypatch.setattr("server.endpoints.webhook_view.get_latest_payloads", _payloads)
+    monkeypatch.setattr("server.app.fetch_states", _states)
+    monkeypatch.setattr("server.app.get_latest_payloads", _payloads)
+    yield
+
+
 @pytest.mark.asyncio
 async def test_start_challenge_creates_nonce(
     client: AsyncClient, db_session: AsyncSession, test_auth_key: AuthKey


### PR DESCRIPTION
## Summary
- configure CsrfProtect to look for tokens in form bodies
- update admin tests to send CSRF token only in form data
- patch challenge tests to stub network access

## Testing
- `pre-commit run --files experimental/gatelet/server/endpoints/admin.py experimental/gatelet/server/endpoints/test_admin_login.py experimental/gatelet/server/endpoints/test_admin_keys.py experimental/gatelet/server/endpoints/test_challenge.py`
- `pytest experimental/gatelet/server`