### PR TITLE
Implement integration filtering in Gatelet payload view

### DIFF
--- a/experimental/gatelet/TODO.md
+++ b/experimental/gatelet/TODO.md
@@ -15,5 +15,4 @@ plan in `ha-api-task.txt`.
 - Expand the Home Assistant integration with history and trend views for
   configured entities
 - Provide reporter scripts to send device events to Gatelet
-- Resolve remaining TODO comments in the code (e.g. redirect after login,
-  integration filtering)
+- Resolve remaining TODO comments in the code (e.g. redirect after login)

--- a/experimental/gatelet/server/endpoints/test_webhook_view.py
+++ b/experimental/gatelet/server/endpoints/test_webhook_view.py
@@ -3,7 +3,7 @@
 from http import HTTPStatus
 
 import pytest
-from hamcrest import all_of, assert_that, contains_string
+from hamcrest import all_of, assert_that, contains_string, is_not
 from httpx import AsyncClient
 from server.models import WebhookIntegration, WebhookPayload
 from server.shared import templates
@@ -141,3 +141,29 @@ async def test_session_auth_webhooks(
             contains_string("session"),
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_disabled_payloads_hidden(
+    client: AsyncClient, db_session: AsyncSession, test_auth_key
+):
+    """Ensure payloads from disabled integrations are not shown."""
+    integration = WebhookIntegration(
+        name="disabled-int",
+        description="Disabled integration",
+        auth_type="none",
+        auth_config={"type": "none"},
+        is_enabled=False,
+    )
+    integration = await persist(db_session, integration)
+
+    payload = WebhookPayload(
+        integration_name=integration.name,
+        integration_id=integration.id,
+        payload={"hidden": True},
+    )
+    await persist(db_session, payload)
+
+    response = await client.get(f"/k/{test_auth_key.key_value}/webhooks/")
+    assert response.status_code == HTTPStatus.OK
+    assert_that(response.text, is_not(contains_string(integration.name)))

--- a/experimental/gatelet/server/endpoints/webhook_view.py
+++ b/experimental/gatelet/server/endpoints/webhook_view.py
@@ -81,17 +81,26 @@ async def get_webhook_payloads(
         Dict with template context variables
     """
     # Build base query
-    count_query = select(func.count()).select_from(WebhookPayload)
-    payloads_query = select(WebhookPayload).order_by(WebhookPayload.received_at.desc())
+    join_condition = WebhookPayload.integration_id == WebhookIntegration.id
+    count_query = (
+        select(func.count())
+        .select_from(WebhookPayload)
+        .join(WebhookIntegration, join_condition)
+    )
+    payloads_query = (
+        select(WebhookPayload)
+        .join(WebhookIntegration, join_condition)
+        .order_by(WebhookPayload.received_at.desc())
+    )
 
     # Apply filter if integration name provided
     if integration_name:
-        count_query = count_query.where(
-            WebhookPayload.integration_name == integration_name
-        )
-        payloads_query = payloads_query.where(
-            WebhookPayload.integration_name == integration_name
-        )
+        condition = WebhookIntegration.name == integration_name
+    else:
+        condition = WebhookIntegration.is_enabled
+
+    count_query = count_query.where(condition)
+    payloads_query = payloads_query.where(condition)
 
     # Get total count
     total_count = await db_session.scalar(count_query)
@@ -131,7 +140,13 @@ async def get_latest_payloads(
 ) -> list[dict[str, Any]]:
     """Get latest webhook payloads across all integrations."""
     query = (
-        select(WebhookPayload).order_by(WebhookPayload.received_at.desc()).limit(limit)
+        select(WebhookPayload)
+        .join(
+            WebhookIntegration, WebhookPayload.integration_id == WebhookIntegration.id
+        )
+        .where(WebhookIntegration.is_enabled)
+        .order_by(WebhookPayload.received_at.desc())
+        .limit(limit)
     )
     result = await db_session.execute(query)
     return [
@@ -152,10 +167,7 @@ async def list_all_payloads(
     db_session: AsyncSession = Depends(get_db_session),
 ):
     """List all webhook integrations and payloads."""
-    # TODO: This lists all webhook payloads even from disabled integrations.
-    # It's fine for now, but we should consider filtering by enabled integrations in the future.
-
-    # TODO: Once we have human login, with human having logged in, it should also show disabled integrations
+    # TODO: Once we have human login, it should also show disabled integrations
 
     # Get webhook integrations
     integrations_query = select(WebhookIntegration).where(WebhookIntegration.is_enabled)


### PR DESCRIPTION
## Summary
- filter disabled integrations when listing payloads
- ensure latest payloads skip disabled integrations
- test that payloads from disabled integrations are hidden
- update TODO to drop resolved note

## Testing
- `pre-commit run --files experimental/gatelet/server/endpoints/webhook_view.py experimental/gatelet/server/endpoints/test_webhook_view.py experimental/gatelet/TODO.md`
- `pytest experimental/gatelet/server/endpoints/test_webhook_view.py`
