### PR TITLE
Clarify session types and add LLM session admin

### DIFF
--- a/experimental/gatelet/README.md
+++ b/experimental/gatelet/README.md
@@ -117,8 +117,8 @@ Gatelet supports multiple authentication methods:
    - Success grants session with time-limited links
 
 3. **Human Admin Authentication** - Standard username/password for human administrators
-   - Uses cookies for session management
-   - Provides access to logs, session management, and key administration
+   - Uses cookies for **admin session** management
+   - Provides access to logs, session management for both **admin** and **LLM** sessions, and key administration
 
 ## Authentication and Session Terms
 
@@ -147,9 +147,10 @@ Gatelet supports multiple authentication methods:
 - Trend data for continuous sensors (temperature, humidity, etc.)
 
 ### Session Management
-- Challenge-based authentication for LLMs
+- Challenge-based authentication for LLMs (LLM sessions)
 - Time-limited tokens with automatic extension
-- Human admin interface for viewing sessions, managing keys, and monitoring logs
+- Human admin interface for viewing **admin sessions**
+  and **LLM sessions**, managing keys, and monitoring logs
 
 ## Implementation Plan
 

--- a/experimental/gatelet/TODO.md
+++ b/experimental/gatelet/TODO.md
@@ -10,7 +10,8 @@ is available. The tasks below track what is still needed to fully implement the
 plan in `ha-api-task.txt`.
 
 - Finish the human admin interface:
-  - List and invalidate active sessions
+  - ~~List and invalidate active admin sessions~~ (done)
+  - ~~List and invalidate active LLM sessions~~ (done)
   - Expose log inspection pages
 - Expand the Home Assistant integration with history and trend views for
   configured entities

--- a/experimental/gatelet/server/endpoints/admin.py
+++ b/experimental/gatelet/server/endpoints/admin.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import settings
 from ..database import get_db_session
-from ..models import AdminSession, AuthKey
+from ..models import AdminSession, AuthCRSession, AuthKey
 from ..security import verify_password
 from ..shared import templates
 
@@ -173,4 +173,108 @@ async def revoke_key(
         key.revoked_at = datetime.now()
         await db_session.flush()
     response = RedirectResponse("/admin/keys/", status_code=302)
+    return response
+
+
+@router.get("/admin/admin-sessions/", response_class=HTMLResponse)
+async def list_admin_sessions(
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> HTMLResponse:
+    sessions = (
+        (
+            await db_session.execute(
+                select(AdminSession).order_by(AdminSession.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
+        "admin_sessions.html",
+        {
+            "request": request,
+            "sessions": sessions,
+            "csrf_token": token,
+            "session_type": "admin",
+        },
+    )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.post(
+    "/admin/admin-sessions/{session_id}/invalidate", response_class=RedirectResponse
+)
+async def invalidate_admin_session(
+    session_id: int,
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> Response:
+    await csrf_protect.validate_csrf(request)
+    stmt = select(AdminSession).where(AdminSession.id == session_id)
+    sess = (await db_session.execute(stmt)).scalar_one_or_none()
+    if sess:
+        await db_session.delete(sess)
+        await db_session.flush()
+
+    response = RedirectResponse("/admin/admin-sessions/", status_code=302)
+    if sess and sess.session_token == request.cookies.get("admin_session"):
+        response.delete_cookie("admin_session")
+    return response
+
+
+@router.get("/admin/llm-sessions/", response_class=HTMLResponse)
+async def list_llm_sessions(
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> HTMLResponse:
+    sessions = (
+        (
+            await db_session.execute(
+                select(AuthCRSession).order_by(AuthCRSession.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = templates.TemplateResponse(
+        "admin_sessions.html",
+        {
+            "request": request,
+            "sessions": sessions,
+            "csrf_token": token,
+            "session_type": "llm",
+        },
+    )
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.post(
+    "/admin/llm-sessions/{session_id}/invalidate", response_class=RedirectResponse
+)
+async def invalidate_llm_session(
+    session_id: int,
+    request: Request,
+    admin_session: AdminSession = Depends(_get_admin_session),
+    db_session: AsyncSession = Depends(get_db_session),
+    csrf_protect: CsrfProtect = Depends(),
+) -> Response:
+    await csrf_protect.validate_csrf(request)
+    stmt = select(AuthCRSession).where(AuthCRSession.id == session_id)
+    sess = (await db_session.execute(stmt)).scalar_one_or_none()
+    if sess:
+        await db_session.delete(sess)
+        await db_session.flush()
+
+    response = RedirectResponse("/admin/llm-sessions/", status_code=302)
     return response

--- a/experimental/gatelet/server/endpoints/test_admin_cr_sessions.py
+++ b/experimental/gatelet/server/endpoints/test_admin_cr_sessions.py
@@ -1,0 +1,73 @@
+import re
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from server.models import AuthCRSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _override_db(monkeypatch, db_session: AsyncSession):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _override():
+        yield db_session
+
+    monkeypatch.setattr("server.database.get_db_session", _override)
+
+
+def _extract_csrf(page_text: str) -> str:
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page_text)
+    assert m
+    return m.group(1)
+
+
+async def _login(client: AsyncClient) -> str:
+    home = await client.get("/")
+    token = _extract_csrf(home.text)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+    return response.cookies["admin_session"]
+
+
+@pytest.mark.asyncio
+async def test_list_llm_sessions(
+    client: AsyncClient, db_session: AsyncSession, test_auth_session: AuthCRSession
+):
+    session_cookie = await _login(client)
+    response = await client.get(
+        "/admin/llm-sessions/", cookies={"admin_session": session_cookie}
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert test_auth_session.session_token in response.text
+
+
+@pytest.mark.asyncio
+async def test_invalidate_llm_session(
+    client: AsyncClient, db_session: AsyncSession, test_auth_session: AuthCRSession
+):
+    session_cookie = await _login(client)
+    response = await client.get(
+        "/admin/llm-sessions/", cookies={"admin_session": session_cookie}
+    )
+    token = _extract_csrf(response.text)
+
+    response = await client.post(
+        f"/admin/llm-sessions/{test_auth_session.id}/invalidate",
+        data={"csrf_token": token},
+        cookies={"admin_session": session_cookie},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+
+    result = (
+        await db_session.execute(
+            select(AuthCRSession).where(AuthCRSession.id == test_auth_session.id)
+        )
+    ).scalar_one_or_none()
+    assert result is None

--- a/experimental/gatelet/server/endpoints/test_admin_sessions.py
+++ b/experimental/gatelet/server/endpoints/test_admin_sessions.py
@@ -1,0 +1,75 @@
+import re
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from server.models import AdminSession
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture(autouse=True)
+async def _override_db(monkeypatch, db_session: AsyncSession):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _override():
+        yield db_session
+
+    monkeypatch.setattr("server.database.get_db_session", _override)
+
+
+def _extract_csrf(page_text: str) -> str:
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page_text)
+    assert m
+    return m.group(1)
+
+
+async def _login(client: AsyncClient) -> str:
+    home = await client.get("/")
+    token = _extract_csrf(home.text)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+    return response.cookies["admin_session"]
+
+
+@pytest.mark.asyncio
+async def test_list_admin_sessions(client: AsyncClient, db_session: AsyncSession):
+    session_cookie = await _login(client)
+    response = await client.get(
+        "/admin/admin-sessions/", cookies={"admin_session": session_cookie}
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert session_cookie in response.text
+
+
+@pytest.mark.asyncio
+async def test_invalidate_admin_session(client: AsyncClient, db_session: AsyncSession):
+    session_cookie = await _login(client)
+    response = await client.get(
+        "/admin/admin-sessions/", cookies={"admin_session": session_cookie}
+    )
+    token = _extract_csrf(response.text)
+
+    session_obj = (
+        await db_session.execute(
+            select(AdminSession).where(AdminSession.session_token == session_cookie)
+        )
+    ).scalar_one()
+
+    response = await client.post(
+        f"/admin/admin-sessions/{session_obj.id}/invalidate",
+        data={"csrf_token": token},
+        cookies={"admin_session": session_cookie},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+
+    result = (
+        await db_session.execute(
+            select(AdminSession).where(AdminSession.id == session_obj.id)
+        )
+    ).scalar_one_or_none()
+    assert result is None

--- a/experimental/gatelet/server/templates/admin_index.html
+++ b/experimental/gatelet/server/templates/admin_index.html
@@ -6,6 +6,8 @@
 <h2>Admin Dashboard</h2>
 <ul>
   <li><a href="/admin/webhooks/">Webhook Payloads</a></li>
+  <li><a href="/admin/admin-sessions/">Active Admin Sessions</a></li>
+  <li><a href="/admin/llm-sessions/">Active LLM Sessions</a></li>
   <li><a href="/admin/keys/">Manage Keys</a></li>
   <li><a href="/">Public Index</a></li>
 </ul>

--- a/experimental/gatelet/server/templates/admin_sessions.html
+++ b/experimental/gatelet/server/templates/admin_sessions.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Admin - {{ session_type|capitalize }} Sessions{% endblock %}
+{% block nav %}
+<nav>
+    <a href="/admin/">Admin Home</a>
+</nav>
+{% endblock %}
+{% block content %}
+<section>
+    <h2>Active {{ session_type|capitalize }} Sessions</h2>
+    {% if sessions %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th><th>Token</th><th>Created</th><th>Expires</th><th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for s in sessions %}
+            <tr>
+                <td>{{ s.id }}</td>
+                <td>{{ s.session_token }}</td>
+                <td>{{ s.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>{{ s.expires_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>
+                    <form method="post" action="/admin/{{ session_type }}-sessions/{{ s.id }}/invalidate">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        <button type="submit">Invalidate</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No active sessions.</p>
+    {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- distinguish admin and LLM sessions in routes and templates
- add admin pages to list and invalidate LLM sessions
- update admin session paths
- clarify documentation and TODO entries
- test admin and LLM session management

## Testing
- `pre-commit run --files experimental/gatelet/README.md experimental/gatelet/TODO.md experimental/gatelet/server/endpoints/admin.py experimental/gatelet/server/endpoints/test_admin_sessions.py experimental/gatelet/server/endpoints/test_admin_cr_sessions.py experimental/gatelet/server/templates/admin_index.html experimental/gatelet/server/templates/admin_sessions.html`
- `pytest experimental/gatelet/server/endpoints/test_admin_sessions.py -q`
- `pytest experimental/gatelet/server/endpoints/test_admin_cr_sessions.py -q`
- `pytest experimental/gatelet/server/endpoints -q`
