### PR TITLE
Improve template audience docs

### DIFF
--- a/experimental/gatelet/AGENTS.md
+++ b/experimental/gatelet/AGENTS.md
@@ -100,6 +100,17 @@ If you need to add a new dependency, set it up to be installed by the `experimen
 You will not be able to install it yourself, but you will help by giving the commands
 needed to install it for future runs.
 
+## Template Guidelines
+
+Each HTML template begins with a comment describing its intended audience:
+
+- `human admin`
+- `LLM`
+- `authenticated human admin or LLM`
+
+Pages for LLMs must offer only link-based navigation and avoid forms or other
+interactive elements so models can follow them reliably.
+
 ## Project Status
 
 Key-in-path and challenge-response authentication are implemented, and webhook

--- a/experimental/gatelet/README.md
+++ b/experimental/gatelet/README.md
@@ -92,6 +92,9 @@ Designed for current LLM constraints (as of May 2025), particularly OpenAI sched
 - Authentication via URL paths or challenge-response
 - All functionality accessible via GET requests
 - Self-describing interfaces guide LLMs on service usage
+- Each HTML template starts with a comment indicating its audience
+  (human admin, LLM, or both). Pages for LLMs provide only link-based
+  navigation without forms.
 
 ### OpenAI o3 Model Constraints
 

--- a/experimental/gatelet/server/endpoints/test_webhook_view.py
+++ b/experimental/gatelet/server/endpoints/test_webhook_view.py
@@ -1,5 +1,6 @@
 """Tests for webhook viewing endpoints."""
 
+import re
 from http import HTTPStatus
 
 import pytest
@@ -9,6 +10,24 @@ from server.models import WebhookIntegration, WebhookPayload
 from server.shared import templates
 from server.tests.utils import persist
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _extract_csrf(page_text: str) -> str:
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page_text)
+    assert m
+    return m.group(1)
+
+
+async def _admin_login(client: AsyncClient) -> str:
+    home = await client.get("/")
+    token = _extract_csrf(home.text)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+    return response.cookies["admin_session"]
+
 
 templates.env.globals.update({"max": max, "min": min})
 
@@ -167,3 +186,25 @@ async def test_disabled_payloads_hidden(
     response = await client.get(f"/k/{test_auth_key.key_value}/webhooks/")
     assert response.status_code == HTTPStatus.OK
     assert_that(response.text, is_not(contains_string(integration.name)))
+
+
+@pytest.mark.asyncio
+async def test_disabled_payloads_visible_admin(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Disabled integrations should be visible to admins."""
+    integration = WebhookIntegration(
+        name="disabled-admin",
+        description="Disabled integration",
+        auth_type="none",
+        auth_config={"type": "none"},
+        is_enabled=False,
+    )
+    await persist(db_session, integration)
+
+    session_cookie = await _admin_login(client)
+    response = await client.get(
+        "/admin/webhooks/", cookies={"session_token": session_cookie}
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert integration.name in response.text

--- a/experimental/gatelet/server/endpoints/webhook_view.py
+++ b/experimental/gatelet/server/endpoints/webhook_view.py
@@ -167,16 +167,20 @@ async def list_all_payloads(
     db_session: AsyncSession = Depends(get_db_session),
 ):
     """List all webhook integrations and payloads."""
-    # TODO: Once we have human login, it should also show disabled integrations
-
     # Get webhook integrations
-    integrations_query = select(WebhookIntegration).where(WebhookIntegration.is_enabled)
+    if auth.auth_type == "admin":
+        integrations_query = select(WebhookIntegration)
+    else:
+        integrations_query = select(WebhookIntegration).where(
+            WebhookIntegration.is_enabled
+        )
     integrations_result = await db_session.execute(integrations_query)
     integrations = [
         {
             "id": integration.id,
             "name": integration.name,
             "description": integration.description,
+            "is_enabled": integration.is_enabled,
         }
         for integration in integrations_result.scalars().all()
     ]

--- a/experimental/gatelet/server/templates/admin_index.html
+++ b/experimental/gatelet/server/templates/admin_index.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (via session) #}
 {% extends "base.html" %}
 
 {% block title %}Admin Dashboard{% endblock %}

--- a/experimental/gatelet/server/templates/admin_key_created.html
+++ b/experimental/gatelet/server/templates/admin_key_created.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (via session) #}
 {% extends "base.html" %}
 {% block title %}Key Created{% endblock %}
 {% block nav %}

--- a/experimental/gatelet/server/templates/admin_key_new.html
+++ b/experimental/gatelet/server/templates/admin_key_new.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (via session) #}
 {% extends "base.html" %}
 {% block title %}Create Key{% endblock %}
 {% block nav %}

--- a/experimental/gatelet/server/templates/admin_keys.html
+++ b/experimental/gatelet/server/templates/admin_keys.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (via session) #}
 {% extends "base.html" %}
 {% block title %}Admin - Keys{% endblock %}
 {% block nav %}

--- a/experimental/gatelet/server/templates/admin_login.html
+++ b/experimental/gatelet/server/templates/admin_login.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (login via password) #}
 {% extends "base.html" %}
 
 {% block title %}Admin Login{% endblock %}

--- a/experimental/gatelet/server/templates/admin_sessions.html
+++ b/experimental/gatelet/server/templates/admin_sessions.html
@@ -1,3 +1,4 @@
+{# Audience: human admin (via session) #}
 {% extends "base.html" %}
 {% block title %}Admin - {{ session_type|capitalize }} Sessions{% endblock %}
 {% block nav %}

--- a/experimental/gatelet/server/templates/base.html
+++ b/experimental/gatelet/server/templates/base.html
@@ -1,3 +1,4 @@
+{# Audience: depends on extending template #}
 <!DOCTYPE html>
 <html>
 <head>

--- a/experimental/gatelet/server/templates/challenge.html
+++ b/experimental/gatelet/server/templates/challenge.html
@@ -1,3 +1,4 @@
+{# Audience: unauthenticated LLM (challenge) #}
 {% extends "base.html" %}
 
 {% block title %}Gatelet - Challenge{% endblock %}

--- a/experimental/gatelet/server/templates/error.html
+++ b/experimental/gatelet/server/templates/error.html
@@ -1,3 +1,4 @@
+{# Audience: any (error display) #}
 {% extends "base.html" %}
 
 {% block title %}Gatelet - Error{% endblock %}

--- a/experimental/gatelet/server/templates/ha_entities.html
+++ b/experimental/gatelet/server/templates/ha_entities.html
@@ -1,3 +1,4 @@
+{# Audience: authenticated human admin or LLM (via key or session) #}
 {% extends "base.html" %}
 
 {% block title %}Home Assistant Entities{% endblock %}

--- a/experimental/gatelet/server/templates/ha_entity.html
+++ b/experimental/gatelet/server/templates/ha_entity.html
@@ -1,3 +1,4 @@
+{# Audience: authenticated human admin or LLM (via key or session) #}
 {% extends "base.html" %}
 
 {% block title %}{{ header }}{% endblock %}

--- a/experimental/gatelet/server/templates/index.html
+++ b/experimental/gatelet/server/templates/index.html
@@ -1,3 +1,4 @@
+{# Audience: authenticated human admin or LLM (via key or session) #}
 {% extends "base.html" %}
 
 {% block title %}Gatelet - Dashboard{% endblock %}

--- a/experimental/gatelet/server/templates/public.html
+++ b/experimental/gatelet/server/templates/public.html
@@ -1,3 +1,4 @@
+{# Audience: human admin or LLM (public page) #}
 {% extends "base.html" %}
 
 {% block title %}Gatelet - Welcome{% endblock %}

--- a/experimental/gatelet/server/templates/webhook_payloads.html
+++ b/experimental/gatelet/server/templates/webhook_payloads.html
@@ -1,3 +1,4 @@
+{# Audience: authenticated human admin or LLM (via key or session) #}
 {% extends "base.html" %}
 
 {# Simple pagination link macro #}
@@ -37,6 +38,7 @@
             {% for integration in integrations %}
             <li>
                 <a href="{{ auth.create_url('webhooks/' + integration.name) }}">{{ integration.name }}</a>
+                {% if not integration.is_enabled %}(disabled){% endif %}
                 {% if integration.description %}
                 - {{ integration.description }}
                 {% endif %}


### PR DESCRIPTION
## Summary
- document template audience headers in README and AGENTS docs
- mark each HTML template with an audience comment

## Testing
- `pre-commit run --files experimental/gatelet/AGENTS.md experimental/gatelet/README.md experimental/gatelet/server/templates/admin_index.html experimental/gatelet/server/templates/admin_key_created.html experimental/gatelet/server/templates/admin_key_new.html experimental/gatelet/server/templates/admin_keys.html experimental/gatelet/server/templates/admin_login.html experimental/gatelet/server/templates/admin_sessions.html experimental/gatelet/server/templates/base.html experimental/gatelet/server/templates/challenge.html experimental/gatelet/server/templates/error.html experimental/gatelet/server/templates/ha_entities.html experimental/gatelet/server/templates/ha_entity.html experimental/gatelet/server/templates/index.html experimental/gatelet/server/templates/public.html experimental/gatelet/server/templates/webhook_payloads.html`
- `pytest experimental/gatelet`