### PR TITLE
Add Gatelet event reporting script

### DIFF
--- a/gatelet/report_event.py
+++ b/gatelet/report_event.py
@@ -1,0 +1,72 @@
+"""Send device events to a Gatelet server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import httpx
+
+
+async def send_event(
+    url: str,
+    integration: str,
+    payload: dict[str, Any],
+    token: str | None = None,
+    client: Optional[httpx.AsyncClient] = None,
+) -> dict[str, Any]:
+    """Send an event payload to Gatelet.
+
+    Args:
+        url: Base URL of Gatelet server.
+        integration: Integration name.
+        payload: JSON payload to send.
+        token: Optional bearer token.
+        client: Optional ``httpx`` client for testing.
+    """
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    close_client = False
+    if client is None:
+        client = httpx.AsyncClient()
+        close_client = True
+    try:
+        resp = await client.post(
+            f"{url.rstrip('/')}/webhook/{integration}",
+            json=payload,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    finally:
+        if close_client:
+            await client.aclose()
+
+
+def _load_payload(spec: str) -> dict[str, Any]:
+    if spec.startswith("@"):
+        data = Path(spec[1:]).read_text(encoding="utf-8")
+    else:
+        data = spec
+    return json.loads(data)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Send a device event to Gatelet")
+    parser.add_argument("--url", required=True, help="Base URL of Gatelet server")
+    parser.add_argument("--integration", required=True, help="Integration name")
+    parser.add_argument("--token", help="Bearer token if required")
+    parser.add_argument("payload", help="JSON payload or @file")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    payload = _load_payload(args.payload)
+    data = asyncio.run(
+        send_event(args.url, args.integration, payload, token=args.token)
+    )
+    print(json.dumps(data))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/gatelet/server/test_report_event.py
+++ b/gatelet/server/test_report_event.py
@@ -1,0 +1,36 @@
+import pytest
+from httpx import AsyncClient
+from server.models import WebhookIntegration, WebhookPayload
+from server.tests.utils import persist
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gatelet.report_event import send_event
+
+
+@pytest.mark.asyncio
+async def test_send_event_works(client: AsyncClient, db_session: AsyncSession):
+    integration = await persist(
+        db_session,
+        WebhookIntegration(
+            name="report-test",
+            description="Test integration",
+            auth_type="none",
+            auth_config={"type": "none"},
+            is_enabled=True,
+        ),
+    )
+
+    payload = {"foo": "bar"}
+    result = await send_event(
+        "http://testserver",
+        integration.name,
+        payload,
+        client=client,
+    )
+
+    assert result["status"] == "ok"
+
+    stmt = select(WebhookPayload).where(WebhookPayload.id == result["payload_id"])
+    stored = (await db_session.execute(stmt)).scalar_one()
+    assert stored.payload == payload


### PR DESCRIPTION
## Summary
- add `report_event.py` for posting device events to Gatelet
- test reporting helper against webhook endpoint

## Testing
- `pre-commit run --files gatelet/report_event.py gatelet/server/test_report_event.py`
- `pytest gatelet/server -q`