### PR TITLE
Add log viewer to Gatelet admin interface

### DIFF
--- a/gatelet/README.md
+++ b/gatelet/README.md
@@ -175,12 +175,13 @@ The project is implemented in phases:
 4. **Phase 4** – Human Admin Interface *(in progress)*
    - Password‑based admin login implemented
    - Key management pages available
-   - Session management and log views pending
+  - Session management implemented
+  - Log inspection page available
 
 ## Current Status
 
 Gatelet runs with both key‑in‑path and challenge‑response authentication.
 Webhooks can be received and browsed. The admin login and key management pages
 are operational, and Home Assistant entity states can be listed. Session
-management views, log inspection and historical Home Assistant data are still
-pending. See `gatelet/TODO.md` for the remaining tasks.
+management views and historical Home Assistant data are still pending.
+See `gatelet/TODO.md` for the remaining tasks.

--- a/gatelet/TODO.md
+++ b/gatelet/TODO.md
@@ -12,7 +12,7 @@ plan in `ha-api-task.txt`.
 - Finish the human admin interface:
   - ~~List and invalidate active admin sessions~~ (done)
   - ~~List and invalidate active LLM sessions~~ (done)
-  - Expose log inspection pages
+  - ~~Expose log inspection pages~~ (done)
 - Expand the Home Assistant integration with history and trend views for
   configured entities
 - Provide reporter scripts to send device events to Gatelet

--- a/gatelet/gatelet.example.toml
+++ b/gatelet/gatelet.example.toml
@@ -8,6 +8,7 @@ dsn = "postgresql+asyncpg://postgres:postgres@localhost:5432/gatelet"
 host = "0.0.0.0"
 port = 8000
 log_level = "INFO"
+log_file = "gatelet.log"
 
 [auth.key_in_url]
 enabled = true

--- a/gatelet/gatelet.toml
+++ b/gatelet/gatelet.toml
@@ -5,6 +5,7 @@ dsn = "postgresql+asyncpg://postgres:postgres@localhost:5432/gatelet"
 host = "0.0.0.0"
 port = 8000
 log_level = "INFO"
+log_file = "gatelet.log"
 
 [auth.key_in_url]
 enabled = true

--- a/gatelet/server/config.py
+++ b/gatelet/server/config.py
@@ -51,6 +51,7 @@ class ServerSettings(BaseModel):
     host: str = Field(default="0.0.0.0")
     port: int = Field(default=8000)
     log_level: str = Field(default="INFO")
+    log_file: str = Field(default="gatelet.log")
 
 
 class KeyInUrlAuthSettings(BaseModel):

--- a/gatelet/server/endpoints/admin.py
+++ b/gatelet/server/endpoints/admin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Optional
 
 from fastapi import (
@@ -278,3 +279,26 @@ async def invalidate_llm_session(
 
     response = RedirectResponse("/admin/llm-sessions/", status_code=302)
     return response
+
+
+@router.get("/admin/logs/", response_class=HTMLResponse)
+async def view_logs(
+    request: Request,
+    lines: int = 200,
+    admin_session: AdminSession = Depends(_get_admin_session),
+) -> HTMLResponse:
+    """Display the last ``lines`` lines of the server log file."""
+    log_path = Path(settings.server.log_file)
+    if log_path.exists():
+        try:
+            log_text = "\n".join(
+                log_path.read_text(encoding="utf-8").splitlines()[-lines:]
+            )
+        except Exception:  # pragma: no cover - unexpected read error
+            log_text = "<unable to read log file>"
+    else:
+        log_text = "<log file not found>"
+    return templates.TemplateResponse(
+        "admin_logs.html",
+        {"request": request, "log_text": log_text, "lines": lines},
+    )

--- a/gatelet/server/endpoints/test_admin_logs.py
+++ b/gatelet/server/endpoints/test_admin_logs.py
@@ -1,0 +1,37 @@
+import re
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from server.config import settings
+
+
+def _extract_csrf(page_text: str) -> str:
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page_text)
+    assert m
+    return m.group(1)
+
+
+async def _login(client: AsyncClient) -> str:
+    home = await client.get("/")
+    token = _extract_csrf(home.text)
+    response = await client.post(
+        "/admin/login",
+        data={"password": "gatelet", "csrf_token": token},
+    )
+    assert response.status_code == HTTPStatus.FOUND
+    return response.cookies["admin_session"]
+
+
+@pytest.mark.asyncio
+async def test_view_logs(client: AsyncClient, tmp_path: Path, monkeypatch):
+    log_file = tmp_path / "gatelet.log"
+    log_file.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    monkeypatch.setattr(settings.server, "log_file", str(log_file))
+
+    session = await _login(client)
+    response = await client.get("/admin/logs/", cookies={"admin_session": session})
+    assert response.status_code == HTTPStatus.OK
+    assert "line3" in response.text
+    assert "line1" in response.text

--- a/gatelet/server/templates/admin_logs.html
+++ b/gatelet/server/templates/admin_logs.html
@@ -1,0 +1,14 @@
+{# Audience: human admin (via session) #}
+{% extends "base.html" %}
+{% block title %}Admin - Logs{% endblock %}
+{% block nav %}
+<nav>
+    <a href="/admin/">Admin Home</a>
+</nav>
+{% endblock %}
+{% block content %}
+<section>
+    <h2>Server Logs (last {{ lines }} lines)</h2>
+    <pre>{{ log_text }}</pre>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow configuring log_file
- display log file through a new `/admin/logs/` endpoint
- provide template for logs
- mark TODO item complete and update docs
- test admin log viewer

## Testing
- `pre-commit run --files gatelet/server/endpoints/admin.py gatelet/server/templates/admin_logs.html gatelet/server/config.py gatelet/server/endpoints/test_admin_logs.py gatelet/gatelet.example.toml gatelet/gatelet.toml gatelet/README.md gatelet/TODO.md`
- `pytest gatelet -q`