### PR TITLE
Add ActivityWatch event aggregation

### DIFF
--- a/gatelet/gatelet.example.toml
+++ b/gatelet/gatelet.example.toml
@@ -32,6 +32,10 @@ entities = [
     "climate.living_room"
 ]
 
+[activitywatch]
+enabled = false
+server_url = "http://127.0.0.1:5600"
+
 [webhook.integrations.home-assistant]
 enabled = true
 

--- a/gatelet/gatelet.toml
+++ b/gatelet/gatelet.toml
@@ -23,6 +23,10 @@ api_url = "http://homeassistant.local:8123"
 api_token = "replace_with_your_actual_token"
 entities = ["binary_sensor.front_door", "binary_sensor.motion_sensor_living_room", "sensor.temperature_bedroom", "sensor.humidity_bedroom", "climate.living_room"]
 
+[activitywatch]
+enabled = false
+server_url = "http://127.0.0.1:5600"
+
 [webhook.integrations.home-assistant]
 enabled = true
 

--- a/gatelet/gatelet/aw_summary.py
+++ b/gatelet/gatelet/aw_summary.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""ActivityWatch quick-look reporter.
+
+This small utility fetches recent events directly from ActivityWatch
+buckets and prints a short summary. It mirrors the implementation used
+by Gatelet for its dashboard view.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Dict, List, Tuple
+
+from aw_client import ActivityWatchClient
+
+
+def pick_buckets(client: ActivityWatchClient) -> Tuple[List[str], List[str], List[str]]:
+    """Return lists of window, web, and afk bucket IDs."""
+    buckets = client.get_buckets()
+    window_bk = [b for b in buckets if b.startswith("aw-watcher-window")]
+    web_bk = [b for b in buckets if b.startswith("aw-watcher-web")]
+    afk_bk = [b for b in buckets if b.startswith("aw-watcher-afk")]
+    return window_bk, web_bk, afk_bk
+
+
+def iter_events(
+    client: ActivityWatchClient, bucket_ids: List[str], start: datetime, end: datetime
+):
+    """Yield events from all buckets in [start, end)."""
+    for bid in bucket_ids:
+        for ev in client.get_events(bid, start=start, end=end):
+            yield ev
+
+
+def summarize(minutes: int | None = 30, *, day: date | None = None) -> None:  # noqa: PLR0912 - clarity over brevity
+    now = datetime.now(timezone.utc)
+
+    if day:
+        start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+        label = day.isoformat()
+    else:
+        start = now - timedelta(minutes=minutes or 15)
+        end = now
+        label = f"last {round((end - start).total_seconds() / 60)} min"
+
+    client = ActivityWatchClient("aw-summary")
+    client.connect()
+
+    window_bk, web_bk, afk_bk = pick_buckets(client)
+
+    app_secs: Dict[str, float] = defaultdict(float)
+    url_secs: Dict[str, float] = defaultdict(float)
+    afk_secs = 0.0
+    active_secs = 0.0
+
+    for ev in iter_events(client, window_bk, start, end):
+        dur = ev.get("duration", 0)
+        if isinstance(dur, timedelta):
+            dur = dur.total_seconds()
+        app = ev["data"].get("app", "unknown-app")
+        app_secs[app] += dur
+
+    for ev in iter_events(client, web_bk, start, end):
+        dur = ev.get("duration", 0)
+        if isinstance(dur, timedelta):
+            dur = dur.total_seconds()
+        url = ev["data"].get("url")
+        if url:
+            url_secs[url] += dur
+
+    for ev in iter_events(client, afk_bk, start, end):
+        dur = ev.get("duration", 0)
+        if isinstance(dur, timedelta):
+            dur = dur.total_seconds()
+        status = ev["data"].get("status", "unknown")
+        if status == "afk":
+            afk_secs += dur
+        else:
+            active_secs += dur
+
+    print(
+        f"\nActivityWatch summary for {label} ({start.isoformat()} → {end.isoformat()})\n"
+    )
+
+    tot_secs = active_secs + afk_secs
+
+    def pct(x: float) -> str:
+        return f"{100 * x / tot_secs:5.1f}%" if tot_secs else "n/a"
+
+    print("AFK vs Active")
+    print(f"  Active : {active_secs / 60:6.1f} min  ({pct(active_secs)})")
+    print(f"  AFK    : {afk_secs / 60:6.1f} min  ({pct(afk_secs)})\n")
+
+    print("Top applications")
+    for app, secs in sorted(app_secs.items(), key=lambda kv: kv[1], reverse=True)[:10]:
+        print(f"  {secs / 60:6.1f} min  {app}")
+
+    print("\nTop URLs")
+    for url, secs in sorted(url_secs.items(), key=lambda kv: kv[1], reverse=True)[:10]:
+        print(f"  {secs / 60:6.1f} min  {url}")
+
+    # TODO: test with actual web watcher events when available
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="ActivityWatch quick summary")
+    ap.add_argument(
+        "--day", metavar="YYYY-MM-DD", help="daily summary for given date (UTC)"
+    )
+    ap.add_argument(
+        "--mins",
+        type=int,
+        default=15,
+        help="rolling window length in minutes (ignored if --day)",
+    )
+    args = ap.parse_args()
+
+    chosen_day = date.fromisoformat(args.day) if args.day else None
+    summarize(None if chosen_day else args.mins, day=chosen_day)

--- a/gatelet/gatelet/server/app.py
+++ b/gatelet/gatelet/server/app.py
@@ -21,6 +21,7 @@ from .auth.webhook_auth import AuthError
 from .config import settings
 from .database import get_db_session
 from .endpoints import (
+    activitywatch,
     admin,
     challenge,
     homeassistant,
@@ -152,6 +153,7 @@ async def authenticated_root_handler(request: Request, auth: Auth):
     async with get_db_session() as db_session:
         recent = await get_latest_payloads(db_session, limit=5)
     ha_states = await fetch_states()
+    aw_summary = await activitywatch.fetch_recent_activity()
     return templates.TemplateResponse(
         "index.html",
         {
@@ -160,6 +162,7 @@ async def authenticated_root_handler(request: Request, auth: Auth):
             "auth": auth,
             "recent_payloads": recent,
             "ha_states": ha_states,
+            "aw_activity": aw_summary,
         },
     )
 

--- a/gatelet/gatelet/server/config.py
+++ b/gatelet/gatelet/server/config.py
@@ -100,6 +100,13 @@ class HomeAssistantSettings(BaseModel):
     entities: List[str] = Field(default_factory=list)
 
 
+class ActivityWatchSettings(BaseModel):
+    """Configuration for ActivityWatch integration."""
+
+    enabled: bool = Field(default=False)
+    server_url: str = Field(default="http://127.0.0.1:5600")
+
+
 class WebhookIntegrationSettings(BaseModel):
     auth_config: WebhookAuthConfig = Field()
     enabled: bool = Field(default=False)
@@ -151,6 +158,7 @@ class Settings(BaseModel):
     server: ServerSettings
     auth: AuthSettings
     home_assistant: HomeAssistantSettings
+    activitywatch: ActivityWatchSettings = Field(default=ActivityWatchSettings())
     webhook: WebhookSettings
     admin: AdminSettings
     security: SecuritySettings

--- a/gatelet/gatelet/server/endpoints/activitywatch.py
+++ b/gatelet/gatelet/server/endpoints/activitywatch.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from aw_client import ActivityWatchClient
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_recent_activity(minutes: int = 15) -> dict[str, Any] | None:
+    """Fetch ActivityWatch activity summary for the given window."""
+    if not settings.activitywatch.enabled:
+        return None
+
+    parsed = urlparse(settings.activitywatch.server_url)
+
+    def _duration_seconds(ev: Any) -> float:
+        dur = ev.get("duration", 0)
+        if isinstance(dur, timedelta):
+            return dur.total_seconds()
+        return float(dur)
+
+    def _query() -> dict[str, Any] | None:
+        try:
+            awc = ActivityWatchClient(
+                "gatelet",
+                host=parsed.hostname,
+                port=parsed.port,
+                protocol=parsed.scheme,
+            )
+            awc.connect()
+
+            buckets = awc.get_buckets()
+            window_bk = [b for b in buckets if b.startswith("aw-watcher-window")]
+            web_bk = [b for b in buckets if b.startswith("aw-watcher-web")]
+            afk_bk = [b for b in buckets if b.startswith("aw-watcher-afk")]
+
+            now = datetime.now(timezone.utc)
+            start = now - timedelta(minutes=minutes)
+
+            app_secs: dict[str, float] = defaultdict(float)
+            url_secs: dict[str, float] = defaultdict(float)
+            afk_secs = 0.0
+            active_secs = 0.0
+
+            for bid in window_bk:
+                for ev in awc.get_events(bid, start=start, end=now):
+                    app = ev.get("data", {}).get("app", "unknown-app")
+                    app_secs[app] += _duration_seconds(ev)
+
+            for bid in web_bk:
+                for ev in awc.get_events(bid, start=start, end=now):
+                    url = ev.get("data", {}).get("url")
+                    if url:
+                        url_secs[url] += _duration_seconds(ev)
+
+            for bid in afk_bk:
+                for ev in awc.get_events(bid, start=start, end=now):
+                    status = ev.get("data", {}).get("status", "unknown")
+                    if status == "afk":
+                        afk_secs += _duration_seconds(ev)
+                    else:
+                        active_secs += _duration_seconds(ev)
+
+            return {
+                "active_minutes": active_secs / 60,
+                "afk_minutes": afk_secs / 60,
+                "app_seconds": sorted(
+                    app_secs.items(), key=lambda kv: kv[1], reverse=True
+                ),
+                "url_seconds": sorted(
+                    url_secs.items(), key=lambda kv: kv[1], reverse=True
+                ),
+            }
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to fetch ActivityWatch data: %s", exc)
+            return None
+
+    return await asyncio.to_thread(_query)

--- a/gatelet/gatelet/server/endpoints/admin.py
+++ b/gatelet/gatelet/server/endpoints/admin.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..auth.dependencies import Auth, get_admin_auth_with_context
 from ..config import settings
 from ..database import get_db_session
+from ..endpoints import activitywatch
 from ..endpoints.homeassistant import fetch_states
 from ..endpoints.webhook_view import get_latest_payloads
 from ..models import AdminSession, AuthCRSession, AuthKey
@@ -106,6 +107,7 @@ async def admin_root(request: Request, auth: Auth) -> HTMLResponse:
     async with get_db_session() as db_session:
         recent = await get_latest_payloads(db_session, limit=5)
     ha_states = await fetch_states()
+    aw_summary = await activitywatch.fetch_recent_activity()
     return templates.TemplateResponse(
         "index.html",
         {
@@ -113,6 +115,7 @@ async def admin_root(request: Request, auth: Auth) -> HTMLResponse:
             "auth": auth,
             "recent_payloads": recent,
             "ha_states": ha_states,
+            "aw_activity": aw_summary,
         },
     )
 

--- a/gatelet/gatelet/server/endpoints/test_activitywatch.py
+++ b/gatelet/gatelet/server/endpoints/test_activitywatch.py
@@ -1,0 +1,44 @@
+import pytest
+
+from gatelet.server.endpoints import activitywatch
+from gatelet.server.tests import activitywatch_sample as sample
+
+EPS = 0.01
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_activity_disabled(monkeypatch):
+    monkeypatch.setattr(activitywatch.settings.activitywatch, "enabled", False)
+    result = await activitywatch.fetch_recent_activity()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_activity(monkeypatch):
+    class StubClient:
+        def connect(self):
+            pass
+
+        def get_buckets(self):
+            return sample.SAMPLE_BUCKETS
+
+        def get_events(self, bucket_id, start=None, end=None):
+            if bucket_id.startswith("aw-watcher-window"):
+                return sample.SAMPLE_WINDOW_EVENTS
+            if bucket_id.startswith("aw-watcher-web"):
+                return sample.SAMPLE_WEB_EVENTS
+            if bucket_id.startswith("aw-watcher-afk"):
+                return sample.SAMPLE_AFK_EVENTS
+            return []
+
+    monkeypatch.setattr(activitywatch.settings.activitywatch, "enabled", True)
+    monkeypatch.setattr(
+        activitywatch, "ActivityWatchClient", lambda *a, **k: StubClient()
+    )
+
+    result = await activitywatch.fetch_recent_activity(minutes=10)
+    assert result is not None
+    assert abs(result["active_minutes"] - 3.0) < EPS
+    assert abs(result["afk_minutes"] - 0.5) < EPS
+    assert result["app_seconds"][0][0] == "ExampleBrowser"
+    assert result["url_seconds"][0][0] == "https://example.com"

--- a/gatelet/gatelet/server/templates/index.html
+++ b/gatelet/gatelet/server/templates/index.html
@@ -61,4 +61,32 @@
     <p>Home Assistant data unavailable.</p>
     {% endif %}
 </section>
+
+<section>
+    <h3>ActivityWatch (last 15 minutes)</h3>
+    {% if aw_activity %}
+    <p>
+        Active {{ aw_activity.active_minutes | round(1) }} min /
+        AFK {{ aw_activity.afk_minutes | round(1) }} min
+    </p>
+    {% if aw_activity.app_seconds %}
+    <h4>Top applications</h4>
+    <ul>
+        {% for app, secs in aw_activity.app_seconds[:5] %}
+        <li>{{ app }} - {{ (secs/60)|round(1) }} min</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% if aw_activity.url_seconds %}
+    <h4>Top URLs</h4>
+    <ul>
+        {% for url, secs in aw_activity.url_seconds[:5] %}
+        <li>{{ url }} - {{ (secs/60)|round(1) }} min</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% else %}
+    <p>No ActivityWatch data.</p>
+    {% endif %}
+</section>
 {% endblock %}

--- a/gatelet/gatelet/server/tests/activitywatch_sample.py
+++ b/gatelet/gatelet/server/tests/activitywatch_sample.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+# Sample buckets used for ActivityWatch tests. Titles were redacted.
+SAMPLE_BUCKETS: dict[str, dict[str, object]] = {
+    "aw-watcher-afk_test": {
+        "id": "aw-watcher-afk_test",
+        "created": "2025-05-22T00:30:13.592843+00:00",
+        "name": None,
+        "type": "afkstatus",
+        "client": "aw-watcher-afk",
+        "hostname": "test",
+        "data": {},
+        "last_updated": "2025-05-22T09:53:48.805000+00:00",
+    },
+    "aw-watcher-window_test": {
+        "id": "aw-watcher-window_test",
+        "created": "2025-05-22T00:30:15.292850+00:00",
+        "name": None,
+        "type": "currentwindow",
+        "client": "aw-watcher-window",
+        "hostname": "test",
+        "data": {},
+        "last_updated": "2025-05-22T09:53:54.741000+00:00",
+    },
+    "aw-watcher-web_test": {
+        "id": "aw-watcher-web_test",
+        "created": "2025-05-22T00:30:15.292850+00:00",
+        "name": None,
+        "type": "web.tab.current",
+        "client": "aw-watcher-web",
+        "hostname": "test",
+        "data": {},
+        "last_updated": "2025-05-22T09:53:54.741000+00:00",
+    },
+}
+
+SAMPLE_WINDOW_EVENTS = [
+    {
+        "id": 1,
+        "timestamp": datetime(2025, 5, 22, 9, 50, 0, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=120),
+        "data": {"app": "ExampleBrowser", "title": "Example Domain"},
+    },
+    {
+        "id": 2,
+        "timestamp": datetime(2025, 5, 22, 9, 52, 0, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=60),
+        "data": {"app": "Editor", "title": "README.md"},
+    },
+]
+
+SAMPLE_WEB_EVENTS = [
+    {
+        "id": 10,
+        "timestamp": datetime(2025, 5, 22, 9, 50, 0, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=90),
+        "data": {"url": "https://example.com", "title": "Example"},
+    },
+    {
+        "id": 11,
+        "timestamp": datetime(2025, 5, 22, 9, 51, 30, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=30),
+        "data": {"url": "https://wikipedia.org", "title": "Wikipedia"},
+    },
+]
+
+SAMPLE_AFK_EVENTS = [
+    {
+        "id": 20,
+        "timestamp": datetime(2025, 5, 22, 9, 50, 0, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=180),
+        "data": {"status": "not-afk"},
+    },
+    {
+        "id": 21,
+        "timestamp": datetime(2025, 5, 22, 9, 53, 0, tzinfo=timezone.utc),
+        "duration": timedelta(seconds=30),
+        "data": {"status": "afk"},
+    },
+]


### PR DESCRIPTION
## Summary
- compute ActivityWatch summaries by reading buckets directly
- expose the aggregated data on the dashboard
- add a CLI tool for quick ActivityWatch summaries
- provide redacted sample data for ActivityWatch tests
- test ActivityWatch endpoint with stub client

## Testing
- `pre-commit run --files gatelet/gatelet/server/endpoints/activitywatch.py gatelet/gatelet/server/endpoints/test_activitywatch.py gatelet/gatelet/server/templates/index.html gatelet/gatelet/aw_summary.py gatelet/gatelet/server/tests/activitywatch_sample.py`
- `pytest gatelet/gatelet/server/endpoints/test_activitywatch.py -q`