### PR TITLE
Add timedelta formatting for Gatelet ActivityWatch data

### DIFF
--- a/gatelet/gatelet/server/endpoints/activitywatch.py
+++ b/gatelet/gatelet/server/endpoints/activitywatch.py
@@ -70,14 +70,20 @@ async def fetch_recent_activity(minutes: int = 15) -> dict[str, Any] | None:
                         active_secs += _duration_seconds(ev)
 
             return {
-                "active_minutes": active_secs / 60,
-                "afk_minutes": afk_secs / 60,
-                "app_seconds": sorted(
-                    app_secs.items(), key=lambda kv: kv[1], reverse=True
-                ),
-                "url_seconds": sorted(
-                    url_secs.items(), key=lambda kv: kv[1], reverse=True
-                ),
+                "active": timedelta(seconds=active_secs),
+                "afk": timedelta(seconds=afk_secs),
+                "app": [
+                    (app, timedelta(seconds=secs))
+                    for app, secs in sorted(
+                        app_secs.items(), key=lambda kv: kv[1], reverse=True
+                    )
+                ],
+                "url": [
+                    (url, timedelta(seconds=secs))
+                    for url, secs in sorted(
+                        url_secs.items(), key=lambda kv: kv[1], reverse=True
+                    )
+                ],
             }
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("Failed to fetch ActivityWatch data: %s", exc)

--- a/gatelet/gatelet/server/endpoints/test_activitywatch.py
+++ b/gatelet/gatelet/server/endpoints/test_activitywatch.py
@@ -38,7 +38,7 @@ async def test_fetch_recent_activity(monkeypatch):
 
     result = await activitywatch.fetch_recent_activity(minutes=10)
     assert result is not None
-    assert abs(result["active_minutes"] - 3.0) < EPS
-    assert abs(result["afk_minutes"] - 0.5) < EPS
-    assert result["app_seconds"][0][0] == "ExampleBrowser"
-    assert result["url_seconds"][0][0] == "https://example.com"
+    assert abs(result["active"].total_seconds() / 60 - 3.0) < EPS
+    assert abs(result["afk"].total_seconds() / 60 - 0.5) < EPS
+    assert result["app"][0][0] == "ExampleBrowser"
+    assert result["url"][0][0] == "https://example.com"

--- a/gatelet/gatelet/server/shared.py
+++ b/gatelet/gatelet/server/shared.py
@@ -1,8 +1,19 @@
 """Shared resources for the Gatelet server."""
 
+from datetime import timedelta
 from pathlib import Path
 
 from fastapi.templating import Jinja2Templates
 
 BASE_DIR = Path(__file__).parent
 templates = Jinja2Templates(directory=BASE_DIR / "templates")
+
+
+def format_minutes(td: timedelta) -> str:
+    """Return a human readable minutes string for ``td``."""
+
+    minutes = td.total_seconds() / 60
+    return f"{round(minutes)} min"
+
+
+templates.env.filters["minutes"] = format_minutes

--- a/gatelet/gatelet/server/templates/index.html
+++ b/gatelet/gatelet/server/templates/index.html
@@ -66,22 +66,22 @@
     <h3>ActivityWatch (last 15 minutes)</h3>
     {% if aw_activity %}
     <p>
-        Active {{ aw_activity.active_minutes | round(1) }} min /
-        AFK {{ aw_activity.afk_minutes | round(1) }} min
+        Active {{ aw_activity.active | minutes }} /
+        AFK {{ aw_activity.afk | minutes }}
     </p>
-    {% if aw_activity.app_seconds %}
+    {% if aw_activity.app %}
     <h4>Top applications</h4>
     <ul>
-        {% for app, secs in aw_activity.app_seconds[:5] %}
-        <li>{{ app }} - {{ (secs/60)|round(1) }} min</li>
+        {% for app, td in aw_activity.app[:5] %}
+        <li>{{ app }} - {{ td | minutes }}</li>
         {% endfor %}
     </ul>
     {% endif %}
-    {% if aw_activity.url_seconds %}
+    {% if aw_activity.url %}
     <h4>Top URLs</h4>
     <ul>
-        {% for url, secs in aw_activity.url_seconds[:5] %}
-        <li>{{ url }} - {{ (secs/60)|round(1) }} min</li>
+        {% for url, td in aw_activity.url[:5] %}
+        <li>{{ url }} - {{ td | minutes }}</li>
         {% endfor %}
     </ul>
     {% endif %}


### PR DESCRIPTION
## Summary
- keep ActivityWatch times as `timedelta`
- add `format_minutes` Jinja filter
- use the new filter in dashboard template
- update tests for new structure

## Testing
- `pre-commit run --files gatelet/gatelet/server/endpoints/activitywatch.py gatelet/gatelet/server/endpoints/test_activitywatch.py gatelet/gatelet/server/templates/index.html gatelet/gatelet/server/shared.py`
- `pytest gatelet -q` *(fails: RuntimeError: Cannot run the event loop while another loop is running)*