### PR TITLE
Unify Gatelet test DB overrides

### DIFF
--- a/gatelet/gatelet/server/endpoints/test_admin_cr_sessions.py
+++ b/gatelet/gatelet/server/endpoints/test_admin_cr_sessions.py
@@ -3,20 +3,10 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from gatelet.server.models import AuthCRSession
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-@pytest.fixture(autouse=True)
-async def _override_db(monkeypatch, db_session: AsyncSession):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-
-    monkeypatch.setattr("gatelet.server.database.get_db_session", _override)
+from gatelet.server.models import AuthCRSession
 
 
 def _extract_csrf(page_text: str) -> str:

--- a/gatelet/gatelet/server/endpoints/test_admin_keys.py
+++ b/gatelet/gatelet/server/endpoints/test_admin_keys.py
@@ -3,20 +3,10 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from gatelet.server.models import AuthKey
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-@pytest.fixture(autouse=True)
-async def _override_db(monkeypatch, db_session: AsyncSession):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-
-    monkeypatch.setattr("gatelet.server.database.get_db_session", _override)
+from gatelet.server.models import AuthKey
 
 
 def _extract_csrf(page_text: str) -> str:

--- a/gatelet/gatelet/server/endpoints/test_admin_login.py
+++ b/gatelet/gatelet/server/endpoints/test_admin_login.py
@@ -7,19 +7,6 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-@pytest.fixture(autouse=True)
-async def _override_db(monkeypatch, db_session: AsyncSession):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-        await db_session.execute("DELETE FROM admin_sessions")
-        await db_session.commit()
-
-    monkeypatch.setattr("gatelet.server.database.get_db_session", _override)
-
-
 @pytest.mark.asyncio
 async def test_admin_login_success(client: AsyncClient, db_session: AsyncSession):
     home = await client.get("/")

--- a/gatelet/gatelet/server/endpoints/test_admin_sessions.py
+++ b/gatelet/gatelet/server/endpoints/test_admin_sessions.py
@@ -3,20 +3,10 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
-from gatelet.server.models import AdminSession
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-@pytest.fixture(autouse=True)
-async def _override_db(monkeypatch, db_session: AsyncSession):
-    from contextlib import asynccontextmanager
-
-    @asynccontextmanager
-    async def _override():
-        yield db_session
-
-    monkeypatch.setattr("gatelet.server.database.get_db_session", _override)
+from gatelet.server.models import AdminSession
 
 
 def _extract_csrf(page_text: str) -> str:


### PR DESCRIPTION
## Summary
- drop per-file `_override_db` fixtures
- rely on `conftest.py::_patch_get_db_session` for DB override

## Testing
- `pre-commit run --files gatelet/gatelet/server/endpoints/test_admin_cr_sessions.py gatelet/gatelet/server/endpoints/test_admin_keys.py gatelet/gatelet/server/endpoints/test_admin_login.py gatelet/gatelet/server/endpoints/test_admin_sessions.py`
- `IS_CODEX_ENV=1 pytest gatelet/gatelet/server/endpoints/test_admin_login.py::test_admin_login_success -vv`
- `IS_CODEX_ENV=1 pytest gatelet/gatelet/server` *(fails: RuntimeError: Cannot run the event loop while another loop is running)*