### PR TITLE
Add dbus-fast example

### DIFF
--- a/experimental/dbus_fast_example/README.md
+++ b/experimental/dbus_fast_example/README.md
@@ -1,0 +1,12 @@
+# DBus-fast example
+
+This folder contains a minimal example showing how to use
+[dbus-fast](https://github.com/agoode/dbus-fast) to:
+
+- run a small service that exposes a method and a signal
+- listen to that signal from a client
+- unsubscribe from the signal
+- gracefully handle the service going away and a replacement appearing
+
+Tests spin up a private `dbus-daemon`, launch the service in a separate
+process and drive it via a helper `ServiceManager`.

--- a/experimental/dbus_fast_example/client.py
+++ b/experimental/dbus_fast_example/client.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from dbus_fast.aio import MessageBus
+
+
+class ExampleClient:
+    """Client that subscribes to Notify signals."""
+
+    def __init__(self, bus_address: str) -> None:
+        self.bus_address = bus_address
+        self.bus: MessageBus | None = None
+        self.interface: Any = None
+
+    async def connect(self) -> None:
+        self.bus = await MessageBus(bus_address=self.bus_address).connect()
+        introspection = await self.bus.introspect(
+            "org.example.TestService",
+            "/org/example/TestObject",
+        )
+        obj = self.bus.get_proxy_object(
+            "org.example.TestService",
+            "/org/example/TestObject",
+            introspection,
+        )
+        self.interface = obj.get_interface("org.example.TestInterface")
+
+    async def disconnect(self) -> None:
+        if self.bus:
+            self.bus.disconnect()
+            self.bus = None
+
+    def on_notify(self, cb: Callable[[str], None]) -> None:
+        assert self.interface
+        self.interface.on_notify(cb)
+
+    def off_notify(self, cb: Callable[[str], None]) -> None:
+        assert self.interface
+        self.interface.off_notify(cb)

--- a/experimental/dbus_fast_example/dbus_service.py
+++ b/experimental/dbus_fast_example/dbus_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dbus_fast.aio import MessageBus
+from dbus_fast.service import ServiceInterface, method, signal
+
+
+class ExampleService(ServiceInterface):
+    """A minimal service exposing a method and signal."""
+
+    def __init__(self) -> None:
+        super().__init__("org.example.TestInterface")
+        self.stop_event = asyncio.Event()
+
+    @method()
+    def Ping(self) -> str:  # noqa: N802 - DBus method name
+        return "pong"
+
+    @method()
+    def EmitSignal(self, msg: str) -> None:  # noqa: N802 - DBus method name
+        self.Notify(msg)
+
+    @method()
+    def Quit(self) -> None:  # noqa: N802 - DBus method name
+        self.stop_event.set()
+
+    @signal()
+    def Notify(self, msg: str) -> str:  # noqa: N802 - DBus signal name
+        return msg
+
+
+async def main(bus_address: str) -> None:
+    bus = await MessageBus(bus_address=bus_address).connect()
+    service = ExampleService()
+    bus.export("/org/example/TestObject", service)
+    await bus.request_name("org.example.TestService")
+    await service.stop_event.wait()
+    bus.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1]))

--- a/experimental/dbus_fast_example/pyproject.toml
+++ b/experimental/dbus_fast_example/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "dbus_fast_example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "dbus-fast",
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.pytest.ini_options]
+addopts = "-vv"
+asyncio_mode = "auto"

--- a/experimental/dbus_fast_example/service_manager.py
+++ b/experimental/dbus_fast_example/service_manager.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+from dbus_fast.aio import MessageBus
+from dbus_fast.message import Message
+
+
+class ServiceManager:
+    """Launch and control the example service in a subprocess."""
+
+    def __init__(self, bus_address: str) -> None:
+        self.bus_address = bus_address
+        self.proc: subprocess.Popen[bytes] | None = None
+
+    async def start(self) -> None:
+        if self.proc:
+            raise RuntimeError("service already running")
+        script = Path(__file__).with_name("dbus_service.py")
+        self.proc = subprocess.Popen(  # noqa: ASYNC220 - short blocking call
+            [sys.executable, str(script), self.bus_address],
+        )
+        await self._wait_until_running()
+
+    async def _wait_until_running(self) -> None:
+        bus = await MessageBus(bus_address=self.bus_address).connect()
+        while True:
+            try:
+                msg = Message(
+                    destination="org.freedesktop.DBus",
+                    path="/org/freedesktop/DBus",
+                    interface="org.freedesktop.DBus",
+                    member="NameHasOwner",
+                    signature="s",
+                    body=["org.example.TestService"],
+                )
+                reply = await bus.call(msg)
+                if reply and reply.body[0]:
+                    break
+            except Exception:
+                await asyncio.sleep(0.05)
+            else:
+                await asyncio.sleep(0.05)
+        bus.disconnect()
+
+    async def emit(self, msg: str) -> None:
+        bus = await MessageBus(bus_address=self.bus_address).connect()
+        introspection = await bus.introspect(
+            "org.example.TestService",
+            "/org/example/TestObject",
+        )
+        obj = bus.get_proxy_object(
+            "org.example.TestService",
+            "/org/example/TestObject",
+            introspection,
+        )
+        interface = obj.get_interface("org.example.TestInterface")  # type: ignore[attr-defined]
+        await interface.call_emit_signal(msg)  # type: ignore[attr-defined]
+        bus.disconnect()
+
+    async def stop(self) -> None:
+        if not self.proc:
+            return
+        bus = await MessageBus(bus_address=self.bus_address).connect()
+        introspection = await bus.introspect(
+            "org.example.TestService",
+            "/org/example/TestObject",
+        )
+        obj = bus.get_proxy_object(
+            "org.example.TestService",
+            "/org/example/TestObject",
+            introspection,
+        )
+        interface = obj.get_interface("org.example.TestInterface")  # type: ignore[attr-defined]
+        await interface.call_quit()  # type: ignore[attr-defined]
+        bus.disconnect()
+        self.proc.wait(timeout=2)
+        self.proc = None

--- a/experimental/dbus_fast_example/test_example.py
+++ b/experimental/dbus_fast_example/test_example.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from collections.abc import Iterator
+
+import pytest
+
+from .client import ExampleClient
+from .service_manager import ServiceManager
+
+
+@pytest.fixture(scope="session")
+def bus_address() -> Iterator[str]:
+    proc = subprocess.Popen(
+        ["dbus-daemon", "--session", "--nofork", "--print-address=1"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout
+    address = proc.stdout.readline().strip()
+    yield address
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+async def test_signal_flow(bus_address: str) -> None:
+    manager = ServiceManager(bus_address)
+    await manager.start()
+
+    client = ExampleClient(bus_address)
+    await client.connect()
+
+    received: list[str] = []
+
+    def handler(msg: str) -> None:
+        received.append(msg)
+
+    client.on_notify(handler)
+
+    await manager.emit("hello")
+    await asyncio.sleep(0.1)
+
+    assert received == ["hello"]
+
+    client.off_notify(handler)
+    await manager.emit("bye")
+    await asyncio.sleep(0.1)
+
+    assert received == ["hello"]
+
+    assert client.bus
+    first_unique = client.bus._name_owners["org.example.TestService"]
+    await manager.stop()
+    await manager.start()
+    assert client.bus
+    second_unique = client.bus._name_owners["org.example.TestService"]
+    assert first_unique != second_unique
+
+    client.on_notify(handler)
+    await manager.emit("again")
+    await asyncio.sleep(0.1)
+
+    assert received[-1] == "again"
+
+    await client.disconnect()
+    await manager.stop()


### PR DESCRIPTION
## Summary
- add a small example using dbus-fast
- include a service, client and helper manager
- provide pytest-based integration test

## Testing
- `pre-commit run --files experimental/dbus_fast_example/dbus_service.py experimental/dbus_fast_example/service_manager.py experimental/dbus_fast_example/client.py experimental/dbus_fast_example/test_example.py experimental/dbus_fast_example/__init__.py experimental/dbus_fast_example/README.md experimental/dbus_fast_example/pyproject.toml`
- `mypy experimental/dbus_fast_example/service_manager.py experimental/dbus_fast_example/dbus_service.py experimental/dbus_fast_example/client.py experimental/dbus_fast_example/test_example.py`
- `pytest experimental/dbus_fast_example/test_example.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6841b88c5ac88331bbc78c945f253a06