### PR TITLE
Remove AgentResources wrapper, pass dependencies individually

### DIFF
--- a/ember/tests/test_openai_agent.py
+++ b/ember/tests/test_openai_agent.py
@@ -23,7 +23,7 @@ from ember.config import (
 )
 from ember.history import ConversationHistory
 from ember.matrix_client import ConversationStatus
-from ember.openai_agent import AgentResources, OpenAIAgent
+from ember.openai_agent import OpenAIAgent
 from ember.secrets import ProjectedSecret
 import ember.tools.run_shell_command as run_shell_tool
 from ember.tools.run_shell_command import ShellCommandResult
@@ -86,14 +86,14 @@ def agent_factory(
     workspace_path = history.path.parent  # type: ignore[attr-defined]
 
     def factory(client: AsyncOpenAI) -> OpenAIAgent:
-        resources = AgentResources(
+        return OpenAIAgent(
+            settings=settings,
             history=history,
             client=client,
             status_provider=matrix_client,
             workspace_path=workspace_path,
             object_store=None,
         )
-        return OpenAIAgent(settings, resources)
 
     return factory
 


### PR DESCRIPTION
The OpenAIAgent constructor was refactored to take individual dependencies instead of an AgentResources wrapper class. Update the test to match.

- Remove AgentResources import
- Pass settings, history, client, status_provider, workspace_path, and object_store as individual arguments to OpenAIAgent constructor

All ember tests now pass (4/4).