### PR TITLE
Configure Ruff for Google-style one-line formatting

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,14 @@
 # TODO(mpokorny): Once nested pyprojects are gone, move this Ruff config into
 # the single pyproject.toml at repo root and delete ruff.toml.
 
+# Prefer one-line formatting when code fits
+line-length = 120
+
+[format]
+# Ignore trailing commas when deciding whether to collapse to one line
+# (Google-style formatting: pack code densely when it fits)
+skip-magic-trailing-comma = true
+
 [lint]
 select = [
     # Base
@@ -52,6 +60,8 @@ extend-ignore = ["COM812"]
 known-first-party = ["adgn", "tana", "wt", "ducktape", "claude_hooks", "homeassistant", "llm"]
 force-sort-within-sections = true
 combine-as-imports = true
+# Compatible with format.skip-magic-trailing-comma
+split-on-trailing-comma = false
 
 [lint.per-file-ignores]
 "experimental/webhook_inbox/webhook_inbox.py" = ["RUF003"]  # Ambiguous unicode characters in comments


### PR DESCRIPTION
Add configuration to enable automatic one-line collapsing:

ruff.toml changes:
- Set line-length = 120
- Added [format] section with skip-magic-trailing-comma = true
- Added isort.split-on-trailing-comma = false for compatibility

With this config, Ruff will automatically:
- Collapse multi-line constructs to one line when they fit
- Ignore trailing commas as "keep multi-line" signals
- Remove trailing commas from collapsed lines

Example transformation (automatic on format):
  @click.option( "--flag", is_flag=True, help="Description", ) → @click.option("--flag", is_flag=True, help="Description")

No pre-commit hooks or custom scripts needed - just built-in Ruff.