### PR TITLE
Fix failing CI pipeline checks and tests

### DIFF
--- a/.ansible-lint.yaml
+++ b/.ansible-lint.yaml
@@ -15,7 +15,8 @@
 skip_list:
   - args[module]  # Collection modules have incomplete parameter validation, causing false warnings
 exclude_paths:
-  - "ansible/roles/legacy_*/**"        # All legacy roles, being migrated to Nix home-manager
+  - "roles/legacy_*/**"                 # All legacy roles, being migrated to Nix home-manager (relative to ansible/ dir)
+  - ".ansible/**"                       # Exclude ansible-lint generated mock modules (relative to ansible/ dir)
 
 # Custom modules and plugins configuration
 # Note: custom_module_paths and action_plugins are not valid in config file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       - id: ansible-lint
         files: "^ansible/"
         exclude: "k8s/.*"  # Exclude k8s files that cause parsing issues
-        entry: bash -c 'cd "$(git rev-parse --show-toplevel)/ansible" && ANSIBLE_LINT_SKIP_VAULT=1 ANSIBLE_VAULT_IDENTITY_LIST= ansible-lint --config-file ../.ansible-lint.yaml'
+        entry: bash -c 'cd "$(git rev-parse --show-toplevel)/ansible" && ./run-ansible-lint.sh'
         args: []  # Clear default args since we're using custom entry
         additional_dependencies:
           - ansible-core>=2.18.0,<2.19.0  # Avoid fucking breaking module removal in 2.19.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ".*/testdata/.*|.*/fixtures/.*|nonrcm-dotfiles/config/cronomix/.*\\.json$|adgn/src/adgn/props/specimens/.*|.*/examples/.*\\.py$"
+exclude: ".*/testdata/.*|.*/fixtures/.*|nonrcm-dotfiles/config/cronomix/.*\\.json$|adgn/src/adgn/props/specimens/.*|.*/examples/.*\\.py$|^ansible/\\.ansible/.*"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -15,6 +15,7 @@ repos:
 
       # Syntax checks
       - id: check-ast  # valid Python parse
+        language_version: python3.12
       - id: check-yaml
         args: ["--allow-multiple-documents"]
         # Skip Helm (contains Go templating, not valid YAML)
@@ -50,7 +51,7 @@ repos:
       - id: ansible-lint
         files: "^ansible/"
         exclude: "k8s/.*"  # Exclude k8s files that cause parsing issues
-        entry: bash -c 'cd "$(git rev-parse --show-toplevel)/ansible" && ansible-lint --config-file ../.ansible-lint.yaml'
+        entry: bash -c 'cd "$(git rev-parse --show-toplevel)/ansible" && ANSIBLE_LINT_SKIP_VAULT=1 ANSIBLE_VAULT_IDENTITY_LIST= ansible-lint --config-file ../.ansible-lint.yaml'
         args: []  # Clear default args since we're using custom entry
         additional_dependencies:
           - ansible-core>=2.18.0,<2.19.0  # Avoid fucking breaking module removal in 2.19.0

--- a/adgn/tests/agent/server/test_servers_attach_snapshot.py
+++ b/adgn/tests/agent/server/test_servers_attach_snapshot.py
@@ -48,10 +48,8 @@ def test_attach_server_populates_sampling_servers(agent_app_client):
         s = client.get(f"/api/agents/{agent_id}/snapshot")
         assert s.status_code == 200
         snap = TypeAdapter(Snapshot).validate_python(s.json())
-        if not snap.details:
-            pytest.fail("No snapshot details found")
-        if not snap.details.sampling.servers:
-            pytest.fail("No servers found in snapshot")
+        assert snap.details is not None
+        assert snap.details.sampling.servers is not None
 
         # Servers should be a dict[str, ServerEntry] where keys are server names
         assert "echo" in snap.details.sampling.servers

--- a/adgn/tests/agent/server/test_servers_attach_snapshot.py
+++ b/adgn/tests/agent/server/test_servers_attach_snapshot.py
@@ -48,7 +48,9 @@ def test_attach_server_populates_sampling_servers(agent_app_client):
         s = client.get(f"/api/agents/{agent_id}/snapshot")
         assert s.status_code == 200
         snap = TypeAdapter(Snapshot).validate_python(s.json())
-        if not snap.details or not snap.details.sampling.servers:
+        if not snap.details:
+            pytest.fail("No snapshot details found")
+        if not snap.details.sampling.servers:
             pytest.fail("No servers found in snapshot")
 
         # Servers should be a dict[str, ServerEntry] where keys are server names

--- a/ansible/run-ansible-lint.sh
+++ b/ansible/run-ansible-lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# Install collections if not already present
+if [ ! -d "collections/ansible_collections/community" ]; then
+    echo "Installing Ansible collections..." >&2
+    ansible-galaxy collection install -r requirements.yaml -p collections --force
+fi
+
+# Run ansible-lint with collections path
+ANSIBLE_LINT_SKIP_VAULT=1 ANSIBLE_COLLECTIONS_PATH=collections ansible-lint --config-file ../.ansible-lint.yaml "$@"

--- a/ansible/tools/vault_pass.sh
+++ b/ansible/tools/vault_pass.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/env bash
+# In CI/ansible-lint environments, return mock password to allow syntax checks
+# without vault access (Ansible requires non-empty password even for syntax checks)
+if [ -n "$ANSIBLE_LINT_SKIP_VAULT" ]; then
+  echo "mock_password_for_ci_syntax_check"
+  exit 0
+fi
 exec secret-tool lookup service ansible-vault account ducktape

--- a/difftree/src/difftree/__main__.py
+++ b/difftree/src/difftree/__main__.py
@@ -80,13 +80,11 @@ def main(diff_args: tuple[str, ...], sort: str, columns: list[Column], bar_width
             try:
                 # Use os.fstat to check if stdin is a regular file or pipe with data
                 mode = os.fstat(sys.stdin.fileno()).st_mode
-                if stat.S_ISFIFO(mode) or stat.S_ISREG(mode):
-                    # It's a pipe or file, check if it has content
-                    if select.select([sys.stdin], [], [], 0.0)[0]:
-                        # Data is available, but it might just be EOF
-                        # Try to peek at one byte
-                        peek_data = sys.stdin.buffer.peek(1)
-                        has_stdin_data = len(peek_data) > 0
+                if (stat.S_ISFIFO(mode) or stat.S_ISREG(mode)) and select.select([sys.stdin], [], [], 0.0)[0]:
+                    # Data is available, but it might just be EOF
+                    # Try to peek at one byte
+                    peek_data = sys.stdin.buffer.peek(1)
+                    has_stdin_data = len(peek_data) > 0
             except (OSError, AttributeError):
                 pass
 

--- a/difftree/src/difftree/config.py
+++ b/difftree/src/difftree/config.py
@@ -49,6 +49,6 @@ class RenderConfig:
     bar_right_blocks: BlockChars | None = None
 
     @classmethod
-    def default(cls) -> "RenderConfig":
+    def default(cls) -> RenderConfig:
         """Default configuration with all columns."""
         return cls(columns=[Column.TREE, Column.COUNTS, Column.BARS, Column.PERCENTAGES])

--- a/difftree/src/difftree/diff_tree.py
+++ b/difftree/src/difftree/diff_tree.py
@@ -9,8 +9,9 @@ This module handles the VIEW layer - rendering TreeNode data with:
 Takes immutable TreeNode from tree.py and renders it to Rich console output.
 """
 
-from rich.console import Console, ConsoleOptions, Group, RenderResult
-from rich.segment import Segment
+from io import StringIO
+
+from rich.console import Console, ConsoleOptions, RenderResult
 from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
@@ -18,6 +19,7 @@ from rich.tree import Tree
 from .config import Column, RenderConfig
 from .progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS, ProgressBar
 from .tree import TreeNode
+
 
 class DiffTree:
     """Renderable diff tree with progress bars and statistics."""
@@ -37,8 +39,6 @@ class DiffTree:
 
         # Render tree to capture its visual structure
         # Use a temporary console that doesn't output to avoid double printing
-        from io import StringIO
-
         temp_output = StringIO()
         temp_console = Console(
             file=temp_output,
@@ -66,7 +66,7 @@ class DiffTree:
                 table.add_column(justify="left", overflow="ellipsis", no_wrap=True)
             elif column == Column.COUNTS:
                 table.add_column(justify="right")  # Additions (right-aligned)
-                table.add_column(justify="left")   # Deletions (left-aligned)
+                table.add_column(justify="left")  # Deletions (left-aligned)
             elif column == Column.BARS:
                 # Constrain bars to configured width so tree always has space
                 # Use ratio for proportional distribution within bar_width constraint
@@ -76,9 +76,7 @@ class DiffTree:
                     max_width=self.config.bar_width,
                 )
                 table.add_column(
-                    justify="left",
-                    ratio=total_deletions if total_deletions > 0 else 1,
-                    max_width=self.config.bar_width,
+                    justify="left", ratio=total_deletions if total_deletions > 0 else 1, max_width=self.config.bar_width
                 )
             elif column == Column.PERCENTAGES:
                 table.add_column(justify="right")
@@ -149,7 +147,11 @@ class DiffTree:
         label = Text(collapsed_path, style=name_color, overflow="ellipsis")
         tree = Tree(label, guide_style="dim")
 
-        if (self.config.max_depth is None or final_depth < self.config.max_depth) and not final_node.is_file and final_node.children:
+        if (
+            (self.config.max_depth is None or final_depth < self.config.max_depth)
+            and not final_node.is_file
+            and final_node.children
+        ):
             for child in final_node.children.values():
                 child_tree = self._build_tree_structure(child, final_depth + 1)
                 tree.add(child_tree)
@@ -163,7 +165,11 @@ class DiffTree:
 
         result = [final_node]
 
-        if (self.config.max_depth is None or final_depth < self.config.max_depth) and not final_node.is_file and final_node.children:
+        if (
+            (self.config.max_depth is None or final_depth < self.config.max_depth)
+            and not final_node.is_file
+            and final_node.children
+        ):
             for child in final_node.children.values():
                 result.extend(self._flatten_tree(child, final_depth + 1))
 

--- a/difftree/src/difftree/parser.py
+++ b/difftree/src/difftree/parser.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import subprocess
-import sys
 
 from unidiff import PatchSet
 

--- a/difftree/src/difftree/progress_bar.py
+++ b/difftree/src/difftree/progress_bar.py
@@ -1,14 +1,14 @@
 """Progress bar renderables with RTL/LTR alignment support."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.measure import Measurement
 from rich.text import Text
 
-
 DEFAULT_PARTIALS = ("▏", "▎", "▍", "▌", "▋", "▊", "▉")
+
 
 @dataclass(frozen=True)
 class BlockChars:
@@ -42,19 +42,12 @@ class BlockChars:
 # - RTL: empty space on left, filled blocks on right (e.g., "    ███")
 
 # Left-growing blocks (for LTR alignment): filled portion grows from left edge
-DEFAULT_LEFT_BLOCKS = BlockChars(
-    full="█",
-    empty=" ",
-    partials=("▏", "▎", "▍", "▌", "▋", "▊", "▉"),
-)
+DEFAULT_LEFT_BLOCKS = BlockChars(full="█", empty=" ", partials=("▏", "▎", "▍", "▌", "▋", "▊", "▉"))
 
 # Right-growing blocks (for RTL alignment): filled portion grows from right edge
 # Note: Unicode has limited right-block granularity, so we approximate
-DEFAULT_RIGHT_BLOCKS = BlockChars(
-    full="█",
-    empty=" ",
-    partials=("▕", "▕", "▐", "▐", "▐", "▉", "█"),
-)
+DEFAULT_RIGHT_BLOCKS = BlockChars(full="█", empty=" ", partials=("▕", "▕", "▐", "▐", "▐", "▉", "█"))
+
 
 class ProgressBar:
     """Progress bar with RTL or LTR alignment for diff statistics."""

--- a/difftree/src/difftree/tree.py
+++ b/difftree/src/difftree/tree.py
@@ -7,7 +7,6 @@ TreeNode is immutable (frozen dataclass) - all tree transformations return new n
 View-level rendering logic (path collapsing, tree decoration styling) lives in diff_tree.py.
 """
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -42,21 +41,21 @@ def build_tree(changes: list[FileChange]) -> TreeNode:
 
     Uses a mutable builder structure internally, then creates frozen TreeNodes.
     """
-    from dataclasses import dataclass, field as dc_field
 
     @dataclass
     class _MutableNode:
         """Mutable builder for TreeNode."""
+
         name: str
         is_file: bool
         additions: int = 0
         deletions: int = 0
         is_binary: bool = False
-        children: dict[str, "_MutableNode"] = dc_field(default_factory=dict)
+        children: dict[str, "_MutableNode"] = field(default_factory=dict)
         path: str = ""
 
     # Build mutable tree
-    root_name = os.path.basename(os.getcwd()) or "."
+    root_name = Path.cwd().name or "."
     root = _MutableNode(name=root_name, is_file=False, path=".")
 
     for change in changes:

--- a/difftree/tests/conftest.py
+++ b/difftree/tests/conftest.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import subprocess
 import tempfile
 
-from difftree.parser import FileChange
-from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS
 import pytest
 from rich.console import Console
+
+from difftree.parser import FileChange
+from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS
 
 # Test constants
 PNG_HEADER = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"

--- a/difftree/tests/conftest.py
+++ b/difftree/tests/conftest.py
@@ -16,8 +16,8 @@ PNG_HEADER = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
 
 # Block character constants for assertions
 # Import from progress_bar to avoid hardcoding in tests
-LEFT_BLOCK_CHARS = (DEFAULT_LEFT_BLOCKS.full,) + DEFAULT_LEFT_BLOCKS.partials
-RIGHT_BLOCK_CHARS = (DEFAULT_RIGHT_BLOCKS.full,) + DEFAULT_RIGHT_BLOCKS.partials
+LEFT_BLOCK_CHARS = (DEFAULT_LEFT_BLOCKS.full, *DEFAULT_LEFT_BLOCKS.partials)
+RIGHT_BLOCK_CHARS = (DEFAULT_RIGHT_BLOCKS.full, *DEFAULT_RIGHT_BLOCKS.partials)
 
 
 def render_to_string(

--- a/difftree/tests/test_cli.py
+++ b/difftree/tests/test_cli.py
@@ -1,6 +1,5 @@
 """Tests for CLI functionality."""
 
-import os
 from pathlib import Path
 
 from click.testing import CliRunner

--- a/difftree/tests/test_cli.py
+++ b/difftree/tests/test_cli.py
@@ -3,8 +3,9 @@
 from pathlib import Path
 
 from click.testing import CliRunner
-from difftree.__main__ import main
 import pytest
+
+from difftree.__main__ import main
 
 from .conftest import create_file, git_add_commit
 

--- a/difftree/tests/test_config.py
+++ b/difftree/tests/test_config.py
@@ -1,7 +1,8 @@
 """Tests for configuration module."""
 
-from difftree.config import Column, RenderConfig, parse_columns
 import pytest
+
+from difftree.config import Column, RenderConfig, parse_columns
 
 
 @pytest.mark.parametrize(

--- a/difftree/tests/test_diff_tree.py
+++ b/difftree/tests/test_diff_tree.py
@@ -7,11 +7,12 @@ from difftree.diff_tree import DiffTree
 from difftree.parser import FileChange
 from difftree.progress_bar import BlockChars
 from difftree.tree import build_tree
-from .conftest import render_to_string
 import pytest
 from rich.console import Console
 from rich.segment import Segment
 from rich.text import Text
+
+from .conftest import render_to_string
 
 
 def _render_to_text_lines(diff_tree: DiffTree, width: int = 80) -> list[Text]:
@@ -258,7 +259,7 @@ def test_tree_column_never_wraps():
             # Next line should either have tree chars OR be empty/whitespace
             # It should NOT be a continuation of the current line's filename
             if next_line.strip() and not any(char in next_line for char in ["├", "└", "│", "─"]):
-                pytest.fail(f"Line {i} appears to have wrapped:\n  Line {i}: {repr(line)}\n  Line {i+1}: {repr(next_line)}")
+                pytest.fail(f"Line {i} appears to have wrapped:\n  Line {i}: {line!r}\n  Line {i + 1}: {next_line!r}")
 
 
 def test_tree_styling_preserved():
@@ -282,8 +283,9 @@ def test_tree_styling_preserved():
     # Reset: \x1b[0m
 
     # Tree decorations should be dim
-    assert "\x1b[2m├── \x1b[0m" in result or "\x1b[2m└── \x1b[0m" in result, \
+    assert "\x1b[2m├── \x1b[0m" in result or "\x1b[2m└── \x1b[0m" in result, (
         "Tree decorations (├── or └──) should have dim style"
+    )
 
     # Vertical guides should also be dim
     assert "\x1b[2m│" in result, "Tree vertical guides (│) should have dim style"
@@ -306,9 +308,7 @@ def test_tree_styling_preserved():
 
 def test_column_ordering():
     """Test that columns appear in the order specified in config."""
-    changes = [
-        FileChange(path="file.py", additions=10, deletions=5),
-    ]
+    changes = [FileChange(path="file.py", additions=10, deletions=5)]
     root = build_tree(changes)
 
     # Test bars before tree
@@ -323,9 +323,7 @@ def test_column_ordering():
         if "file.py" in line:
             # Find positions of key elements
             bar_pos = line.find("█") if "█" in line else -1
-            tree_char_positions = [
-                line.find(char) for char in [".", "└", "├", "│"] if char in line
-            ]
+            tree_char_positions = [line.find(char) for char in [".", "└", "├", "│"] if char in line]
             tree_pos = min(tree_char_positions) if tree_char_positions else -1
 
             if bar_pos != -1 and tree_pos != -1:
@@ -342,9 +340,7 @@ def test_column_ordering():
     for line in lines:
         if "file.py" in line:
             bar_pos = line.find("█") if "█" in line else -1
-            tree_char_positions = [
-                line.find(char) for char in [".", "└", "├", "│"] if char in line
-            ]
+            tree_char_positions = [line.find(char) for char in [".", "└", "├", "│"] if char in line]
             tree_pos = min(tree_char_positions) if tree_char_positions else -1
 
             if bar_pos != -1 and tree_pos != -1:
@@ -355,9 +351,7 @@ def test_column_ordering():
 
 def test_column_ordering_counts_first():
     """Test counts column can appear first."""
-    changes = [
-        FileChange(path="file.py", additions=10, deletions=5),
-    ]
+    changes = [FileChange(path="file.py", additions=10, deletions=5)]
     root = build_tree(changes)
 
     # Counts first, then tree
@@ -370,14 +364,14 @@ def test_column_ordering_counts_first():
         if "file.py" in line:
             # Find positions of key elements
             plus_pos = line.find("+10") if "+10" in line else -1
-            tree_char_positions = [
-                line.find(char) for char in [".", "└", "├", "│"] if char in line
-            ]
+            tree_char_positions = [line.find(char) for char in [".", "└", "├", "│"] if char in line]
             tree_pos = min(tree_char_positions) if tree_char_positions else -1
 
             if plus_pos != -1 and tree_pos != -1:
                 # Counts should come before tree when COUNTS is listed first
-                assert plus_pos < tree_pos, f"Expected counts before tree, but got counts at {plus_pos}, tree at {tree_pos}"
+                assert plus_pos < tree_pos, (
+                    f"Expected counts before tree, but got counts at {plus_pos}, tree at {tree_pos}"
+                )
                 break
 
 
@@ -385,8 +379,8 @@ def test_bar_proportionality():
     """Test that progress bars render proportionally to actual changes."""
     changes = [
         FileChange(path="file1.py", additions=50, deletions=10),  # 5:1 ratio
-        FileChange(path="file2.py", additions=1, deletions=10),   # 1:10 ratio
-        FileChange(path="file3.py", additions=10, deletions=0),   # Only additions
+        FileChange(path="file2.py", additions=1, deletions=10),  # 1:10 ratio
+        FileChange(path="file3.py", additions=10, deletions=0),  # Only additions
     ]
     root = build_tree(changes)
 
@@ -397,7 +391,7 @@ def test_bar_proportionality():
     config = RenderConfig(
         columns=[Column.TREE, Column.BARS],
         bar_width=10,
-        bar_left_blocks=BlockChars.simple("-"),   # Deletions (LTR)
+        bar_left_blocks=BlockChars.simple("-"),  # Deletions (LTR)
         bar_right_blocks=BlockChars.simple("+"),  # Additions (RTL)
     )
     diff_tree = DiffTree(root, config=config)
@@ -428,14 +422,17 @@ def test_bar_proportionality():
     # File1: +50 -10
     # Expected green bar: 50/61 ≈ 82% of 10 blocks ≈ 8 blocks
     # Expected red bar: 10/20 = 50% of 10 blocks = 5 blocks
-    assert file1_plus >= 7 and file1_plus <= 9, f"file1.py should have ~8 '+', got {file1_plus}"
-    assert file1_minus >= 4 and file1_minus <= 6, f"file1.py should have ~5 '-', got {file1_minus}"
+    assert file1_plus >= 7, f"file1.py should have at least 7 '+', got {file1_plus}"
+    assert file1_plus <= 9, f"file1.py should have at most 9 '+', got {file1_plus}"
+    assert file1_minus >= 4, f"file1.py should have at least 4 '-', got {file1_minus}"
+    assert file1_minus <= 6, f"file1.py should have at most 6 '-', got {file1_minus}"
 
     # File2: +1 -10
     # Expected green bar: 1/61 ≈ 1.6% ≈ minimal sliver (1 char)
     # Expected red bar: 10/20 = 50% = 5 blocks
     assert file2_plus == 1, f"file2.py should have exactly 1 '+' (minimal sliver), got {file2_plus}"
-    assert file2_minus >= 4 and file2_minus <= 6, f"file2.py should have ~5 '-', got {file2_minus}"
+    assert file2_minus >= 4, f"file2.py should have at least 4 '-', got {file2_minus}"
+    assert file2_minus <= 6, f"file2.py should have at most 6 '-', got {file2_minus}"
 
     # File2 and file1 should have same '-' count (both have 10 deletions at same scale)
     assert abs(file2_minus - file1_minus) <= 1, (
@@ -446,16 +443,17 @@ def test_bar_proportionality():
     # File3: +10 -0
     # Expected green bar: 10/61 ≈ 16.4% ≈ 1.6 blocks
     # Expected red bar: 0/20 = 0% = 0 blocks
-    assert file3_plus >= 1 and file3_plus <= 3, f"file3.py should have ~2 '+', got {file3_plus}"
+    assert file3_plus >= 1, f"file3.py should have at least 1 '+', got {file3_plus}"
+    assert file3_plus <= 3, f"file3.py should have at most 3 '+', got {file3_plus}"
     assert file3_minus == 0, f"file3.py should have no '-', got {file3_minus}"
 
 
 def test_deletion_bar_alignment():
     """Test that deletion bars start at the same column position regardless of addition bar width."""
     changes = [
-        FileChange(path="file1.py", additions=100, deletions=1),   # Mostly additions
-        FileChange(path="file2.py", additions=1, deletions=100),   # Mostly deletions
-        FileChange(path="file3.py", additions=50, deletions=50),   # Balanced
+        FileChange(path="file1.py", additions=100, deletions=1),  # Mostly additions
+        FileChange(path="file2.py", additions=1, deletions=100),  # Mostly deletions
+        FileChange(path="file3.py", additions=50, deletions=50),  # Balanced
     ]
     root = build_tree(changes)
 
@@ -463,7 +461,7 @@ def test_deletion_bar_alignment():
     config = RenderConfig(
         columns=[Column.TREE, Column.BARS],
         bar_width=10,
-        bar_left_blocks=BlockChars.simple("X"),   # Deletions (LTR)
+        bar_left_blocks=BlockChars.simple("X"),  # Deletions (LTR)
         bar_right_blocks=BlockChars.simple("+"),  # Additions (RTL)
     )
     diff_tree = DiffTree(root, config=config)
@@ -484,7 +482,7 @@ def test_deletion_bar_alignment():
     # Find position of first 'X' (deletion bar start) in each line
     positions = []
     for i, line in enumerate(file_lines):
-        pos = line.find('X')
+        pos = line.find("X")
         assert pos != -1, f"No deletion bar found in line {i}: {line}"
         positions.append(pos)
 

--- a/difftree/tests/test_diff_tree.py
+++ b/difftree/tests/test_diff_tree.py
@@ -2,15 +2,16 @@
 
 import re
 
+import pytest
+from rich.console import Console
+from rich.segment import Segment
+from rich.text import Text
+
 from difftree.config import Column, RenderConfig
 from difftree.diff_tree import DiffTree
 from difftree.parser import FileChange
 from difftree.progress_bar import BlockChars
 from difftree.tree import build_tree
-import pytest
-from rich.console import Console
-from rich.segment import Segment
-from rich.text import Text
 
 from .conftest import render_to_string
 

--- a/difftree/tests/test_e2e.py
+++ b/difftree/tests/test_e2e.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from difftree.parser import parse_unified_diff
@@ -44,7 +43,7 @@ def test_e2e_complete_workflow(temp_git_repo: Path, run_git):
     root = build_tree(changes)
 
     # Root name is basename of current directory
-    assert root.name in (".", "difftree", os.path.basename(os.getcwd()))
+    assert root.name in (".", "difftree", Path.cwd().name)
     assert "src" in root.children or len(changes) > 0
 
     root = sort_tree(root, sort_by="size")

--- a/difftree/tests/test_progress_bar.py
+++ b/difftree/tests/test_progress_bar.py
@@ -1,8 +1,8 @@
 """Tests for ProgressBar component."""
 
+from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS, ProgressBar
 import pytest
 
-from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS, ProgressBar, BlockChars
 from .conftest import LEFT_BLOCK_CHARS, RIGHT_BLOCK_CHARS, render_to_string
 
 

--- a/difftree/tests/test_progress_bar.py
+++ b/difftree/tests/test_progress_bar.py
@@ -1,7 +1,8 @@
 """Tests for ProgressBar component."""
 
-from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS, ProgressBar
 import pytest
+
+from difftree.progress_bar import DEFAULT_LEFT_BLOCKS, DEFAULT_RIGHT_BLOCKS, ProgressBar
 
 from .conftest import LEFT_BLOCK_CHARS, RIGHT_BLOCK_CHARS, render_to_string
 

--- a/difftree/tests/test_snapshots.py
+++ b/difftree/tests/test_snapshots.py
@@ -4,8 +4,9 @@ from difftree.config import Column, RenderConfig
 from difftree.diff_tree import DiffTree
 from difftree.parser import FileChange
 from difftree.tree import build_tree, sort_tree
-from .conftest import render_to_string as render_renderable
 import pytest
+
+from .conftest import render_to_string as render_renderable
 
 
 @pytest.fixture
@@ -32,7 +33,7 @@ def render_to_string(changes: list[FileChange], sort_by: str = "size", config: R
     diff_tree = DiffTree(root, config=config)
     result = render_renderable(diff_tree, width=120, legacy_windows=False, color_system="standard")
 
-    assert "…" not in result, f"Output contains ellipsis character (…)"
+    assert "…" not in result, "Output contains ellipsis character (…)"
     return result
 
 

--- a/difftree/tests/test_snapshots.py
+++ b/difftree/tests/test_snapshots.py
@@ -1,10 +1,11 @@
 """Snapshot tests for ANSI-rendered output."""
 
+import pytest
+
 from difftree.config import Column, RenderConfig
 from difftree.diff_tree import DiffTree
 from difftree.parser import FileChange
 from difftree.tree import build_tree, sort_tree
-import pytest
 
 from .conftest import render_to_string as render_renderable
 

--- a/difftree/tests/test_tree.py
+++ b/difftree/tests/test_tree.py
@@ -1,6 +1,6 @@
 """Tests for tree structure building."""
 
-import os
+from pathlib import Path
 
 from difftree.parser import FileChange
 from difftree.tree import TreeNode, build_tree, sort_tree
@@ -12,7 +12,7 @@ def test_build_tree_single_file():
     root = build_tree(changes)
 
     # Root name is the basename of current directory
-    assert root.name in (".", "difftree", os.path.basename(os.getcwd()))
+    assert root.name in (".", "difftree", Path.cwd().name)
     assert not root.is_file
     assert root.additions == 10
     assert root.deletions == 5

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,6 +6,17 @@ line-length = 120
 # Target Python 3.12+ consistently
 target-version = "py312"
 
+# Exclude specimens, testdata, fixtures, third-party and examples from all ruff operations
+exclude = [
+    "adgn/src/adgn/props/specimens",
+    "adgn/src/adgn/third_party",
+    "adgn/tests/*/testdata",
+    "adgn/tests/*/fixtures",
+    "**/testdata",
+    "**/fixtures",
+    "**/examples",
+]
+
 [format]
 # Ignore trailing commas when deciding whether to collapse to one line
 # (Google-style formatting: pack code densely when it fits)


### PR DESCRIPTION
Pre-commit fixes:
- Set Python 3.12 for check-ast hook to support type statement syntax
- Fix ansible-lint vault password issue by setting ANSIBLE_LINT_SKIP_VAULT and ANSIBLE_VAULT_IDENTITY_LIST in pre-commit hook
- Exclude ansible/.ansible/ directory from pre-commit checks (generated files)
- Update vault_pass.sh to skip vault lookup when ANSIBLE_LINT_SKIP_VAULT is set

Ruff linting fixes in difftree:
- Combine nested if statements (SIM102)
- Replace os.path.basename/os.getcwd with Path.cwd().name (PTH119, PTH109)
- Use iterable unpacking for tuple concatenation (RUF005)
- Break down compound assertions into multiple parts (PT018)
- Move imports to top level (PLC0415)
- Remove unused os import (F401)

Mypy fixes in adgn:
- Fix union-attr error by splitting None check to properly narrow type in test_servers_attach_snapshot.py

These changes ensure all pre-commit hooks pass with Python 3.12 and prepare the codebase for green CI pipelines.