### PR TITLE
Add code quality scan prompts and antipattern documentation

### DIFF
--- a/prompts/scans/api-model-design.md
+++ b/prompts/scans/api-model-design.md
@@ -1,0 +1,185 @@
+# Scan: API Model Design Antipatterns
+
+## Context
+@../shared-context.md
+
+## Pattern 1: Denormalized/Computed Fields in Models
+
+### Seen in: adgn/rspcache/admin_app.py
+
+```python
+# BAD: Storing denormalized relationship data as flat fields
+class ResponseRecordModel(BaseModel):
+    api_key_id: UUID | None
+    api_key_name: str | None  # Denormalized from api_key.name!
+
+# GOOD: Nested models matching relationships
+class ResponseRecordModel(BaseModel):
+    api_key: APIKeyModel | None  # Properly nested
+
+    # Backward compat if needed
+    @property
+    def api_key_id(self) -> UUID | None:
+        """Deprecated: use api_key.id instead."""
+        return self.api_key.id if self.api_key else None
+```
+
+Issues:
+- **Data duplication** - Same info in two places (api_key.name and api_key_name)
+- **No type safety** - Flat UUID doesn't tell you what it references
+- **Harder to evolve** - Adding new api_key fields requires flattening each one
+- **Inconsistent** - Some relationships nested, others flattened
+
+## Pattern 2: Duplicated Data Across Tables
+
+### Seen in: adgn/rspcache (Response.token_usage vs ResponseSnapshot.token_usage)
+
+```python
+# BAD: Same data stored in two tables with different types
+class Response(Base):
+    token_usage: Mapped[dict[str, Any] | None]  # Untyped
+
+class ResponseSnapshot(Base):
+    token_usage: Mapped[dict[str, Any] | None]  # Also untyped, duplicated
+
+# GOOD: Single source of truth with proper types
+class Response(Base):
+    # No token_usage here
+
+class ResponseSnapshot(Base):
+    token_usage: Mapped[dict[str, Any] | None]  # Only here
+
+# Pydantic model properly typed
+class FinalResponseSnapshot(BaseModel):
+    token_usage: ResponseUsage | None  # Properly typed!
+```
+
+Issues:
+- **Synchronization burden** - Must keep both copies in sync
+- **Wasted storage** - Same data stored twice
+- **Type confusion** - One is `dict[str, Any]`, other should be `ResponseUsage`
+
+## Pattern 3: `_json` Suffix on DB Columns
+
+### Seen in: adgn/rspcache (request_body_json, token_usage_json)
+
+```python
+# BAD: Leaking DB implementation details into naming
+class Response(Base):
+    request_body_json: Mapped[dict[str, Any]]  # "_json" is redundant
+
+class ResponseRecordModel(BaseModel):
+    request_body_json: dict[str, Any]  # API exposes DB detail
+
+# GOOD: Clean names, type system already tells you it's JSON
+class Response(Base):
+    request_body: Mapped[dict[str, Any]]  # Type + JSONB column = obviously JSON
+
+class ResponseRecordModel(BaseModel):
+    request_body: dict[str, Any]  # Clean API field name
+```
+
+Issues:
+- **Redundant** - `Mapped[dict[str, Any]]` + JSONB already tells you it's JSON
+- **Leaky abstraction** - API shouldn't know about DB storage format
+- **Breaking changes** - If you change DB storage (e.g., to BSON), API breaks
+
+## Pattern 4: Flattened API Models vs Nested DB Relationships
+
+### Seen in: adgn/rspcache/admin_app.py (before refactor)
+
+```python
+# BAD: Flattening nested data with renamed fields
+class ResponseRecordModel(BaseModel):
+    final_response: dict[str, Any] | None  # snapshot.response renamed
+    response_error: dict[str, Any] | None  # snapshot.error renamed
+    token_usage: dict[str, Any] | None     # snapshot.token_usage duplicated
+
+# GOOD: Match DB structure with nested models
+class ResponseRecordModel(BaseModel):
+    snapshot: FinalResponseSnapshot | None
+
+class FinalResponseSnapshot(BaseModel):
+    response: OpenAIResponse | None  # Properly typed
+    error: ErrorPayload | None       # Properly typed
+    token_usage: ResponseUsage | None  # Properly typed
+```
+
+Issues:
+- **Lost structure** - Relationship between response/error/token_usage is obscured
+- **Type loss** - `dict[str, Any]` instead of properly typed models
+- **Confusing names** - `final_response` vs `response`, `response_error` vs `error`
+- **Harder to evolve** - Adding new snapshot fields requires flattening
+
+## Pattern 5: Untyped Dicts Instead of Pydantic Models
+
+### Seen in: Throughout rspcache
+
+```python
+# BAD: Using dict[str, Any] when proper types exist
+class Response(Base):
+    request_body: Mapped[dict[str, Any]]  # OpenAI request exists!
+
+class ResponseRecordModel(BaseModel):
+    token_usage: dict[str, Any] | None  # ResponseUsage exists!
+
+# GOOD: Use proper Pydantic types
+class FinalResponseSnapshot(BaseModel):
+    response: OpenAIResponse | None     # ✓ Typed
+    error: ErrorPayload | None          # ✓ Typed
+    token_usage: ResponseUsage | None   # ✓ Typed
+
+# Still TODO: type request_body properly
+```
+
+Issues:
+- **No validation** - `dict[str, Any]` accepts anything, even malformed data
+- **No autocomplete** - Can't navigate fields in IDE
+- **Runtime errors** - Typos caught at runtime, not compile time
+- **Lost documentation** - Type tells you nothing about structure
+
+## Detection
+
+```bash
+# Find denormalized fields (ID + name pairs)
+rg --type py "_id.*=.*UUID" -A3 | rg "_name.*="
+
+# Find _json suffixes
+rg --type py "_json.*Mapped\[dict"
+
+# Find dict[str, Any] that should be typed
+rg --type py "dict\[str, Any\]" --type py | grep -v "# OK"
+```
+
+## Fix Strategy
+
+1. **For denormalized fields**:
+   - Replace flat fields with nested models
+   - Add `@property` getters for backward compat
+   - Mark old fields as deprecated in docstrings
+
+2. **For duplicated data**:
+   - Identify single source of truth
+   - Remove duplicates from other tables
+   - Update queries to use relationships
+
+3. **For `_json` suffixes**:
+   - Rename DB columns (breaking change, needs migration)
+   - Update all queries
+   - Type system already indicates JSON storage
+
+4. **For flattened structures**:
+   - Group related fields into nested models
+   - Match API structure to DB relationships
+   - Use proper Pydantic models, not dicts
+
+5. **For untyped dicts**:
+   - Find or create proper Pydantic models
+   - Use TypeAdapter for existing SDK types
+   - Add validation at boundaries
+
+## References
+
+- [Pydantic Models](https://docs.pydantic.dev/latest/concepts/models/)
+- [Database Normalization](https://en.wikipedia.org/wiki/Database_normalization)
+- [API Design Best Practices](https://stackoverflow.blog/2020/03/02/best-practices-for-rest-api-design/)

--- a/prompts/scans/library-type-misuse.md
+++ b/prompts/scans/library-type-misuse.md
@@ -1,0 +1,247 @@
+# Scan: Library Type Misuse
+
+## Context
+@../shared-context.md
+
+## Pattern Description
+
+Using casts, hasattr, getattr, or other dynamic patterns when the library actually provides proper static types. Often caused by not reading the actual library source code.
+
+## The Core Problem
+
+**Assumption**: "The library probably doesn't have good types, so I'll cast/check at runtime"
+**Reality**: Modern Python libraries (OpenAI SDK, Pydantic, etc.) have excellent type annotations
+
+## Examples of Misuse
+
+### OpenAI SDK - Unnecessarily Defensive
+
+```python
+# BAD: Assumes poor typing
+from openai.types.responses import Response
+
+def get_response_data(response: Any) -> dict:
+    if hasattr(response, 'model_dump'):
+        return response.model_dump(mode="json")
+    elif isinstance(response, dict):
+        return response
+    else:
+        return {"error": "unknown type"}
+
+# GOOD: Trust the SDK types
+def get_response_data(response: Response) -> dict[str, Any]:
+    return response.model_dump(mode="json")
+```
+
+### Pydantic - Casting model_dump
+
+```python
+# BAD: Unnecessary cast
+from pydantic import BaseModel
+
+class MyModel(BaseModel):
+    name: str
+
+def serialize(model: MyModel) -> dict[str, Any]:
+    # model_dump already returns dict[str, Any]!
+    return cast(dict[str, Any], model.model_dump(mode="json"))
+
+# GOOD: Read the source
+def serialize(model: MyModel) -> dict[str, Any]:
+    return model.model_dump(mode="json")
+```
+
+### SQLAlchemy - Poor ORM Type Usage
+
+```python
+# BAD: Runtime checks on typed relationships
+class User(Base):
+    posts: Mapped[list[Post]] = relationship()
+
+def get_post_titles(user: User) -> list[str]:
+    if hasattr(user, 'posts'):
+        if isinstance(user.posts, list):
+            return [p.title for p in user.posts]
+    return []
+
+# GOOD: Trust the relationship typing
+def get_post_titles(user: User) -> list[str]:
+    return [p.title for p in user.posts]
+```
+
+## How to Fix: Read The Source
+
+### Step 1: Find the Library Source
+
+```python
+import openai
+import pydantic
+print(openai.__file__)   # /path/to/site-packages/openai/__init__.py
+print(pydantic.__file__)  # /path/to/site-packages/pydantic/__init__.py
+```
+
+### Step 2: Find Type Definitions
+
+```bash
+# Look for .pyi stub files (type hints)
+find /path/to/site-packages/openai -name "*.pyi"
+
+# Or look at actual source
+cat /path/to/site-packages/openai/types/responses.py
+```
+
+### Step 3: Read the Actual Type
+
+```python
+# From openai/types/responses.py
+class Response(BaseModel):
+    """OpenAI Response object."""
+
+    def model_dump(
+        self,
+        *,
+        mode: Literal["json", "python"] = "python",
+        # ...
+    ) -> dict[str, Any]:  # <-- Returns dict[str, Any]
+        ...
+```
+
+**Conclusion**: `model_dump(mode="json")` already returns `dict[str, Any]`, no cast needed!
+
+## Common Libraries with Good Types
+
+### Excellent Typing (use confidently)
+- **OpenAI SDK** (`openai`): Response, Message types
+- **Pydantic** (v2): BaseModel, TypeAdapter, validators
+- **httpx**: Client, Response, Request
+- **FastAPI**: Depends, Request, Response
+
+### Good Typing with Caveats
+- **SQLAlchemy**: ORM relationships may need type stubs improvement
+- **asyncpg**: Connection, Record types are well-typed
+- **Click**: Decorators work well with type hints
+
+### Known Typing Issues
+- **pygit2**: Minimal type annotations (consider type stubs)
+- **Some older SQLAlchemy patterns**: May need casts for legacy code
+
+## Detection Strategy
+
+### Find Suspicious Patterns
+
+```bash
+# Cast on common well-typed libraries
+rg --type py "cast.*\b(model_dump|Response|httpx|pydantic)\b"
+
+# hasattr on typed objects
+rg --type py "hasattr\(.*,\s*['\"]model_dump|hasattr\(.*,\s*['\"]response"
+
+# isinstance checks on already-typed variables
+rg --type py "isinstance\(response,.*Response\)"
+```
+
+### Verification Process
+
+For each suspicious cast/check:
+1. Find the library source
+2. Read the actual type definition
+3. Check if cast/runtime check is needed
+4. If types are good, remove defensive code
+
+## Example Investigation
+
+```python
+# Found this code:
+result = cast(dict[str, Any], snapshot.response.model_dump(mode="json"))
+
+# Investigation:
+# 1. Find source
+import openai
+print(openai.types.responses.__file__)
+
+# 2. Read Response class
+# openai/types/responses.py shows:
+#   def model_dump(self, *, mode: ...) -> dict[str, Any]
+
+# 3. Conclusion: Cast unnecessary
+result = snapshot.response.model_dump(mode="json")
+```
+
+## Improving Type Stubs
+
+If you find a library with genuinely poor types:
+
+### Option 1: Inline Type Stubs
+
+```python
+# my_project/stubs/pygit2.pyi
+class Repository:
+    def lookup_branch(self, name: str) -> Branch | None: ...
+
+class Branch:
+    name: str
+```
+
+Configure mypy:
+```ini
+# mypy.ini
+[mypy]
+mypy_path = $MYPY_CONFIG_FILE_DIR/stubs
+```
+
+### Option 2: Check for Community Stubs
+
+```bash
+# Search for type stubs
+pip search types-pygit2
+pip install types-sqlalchemy  # Official stubs often exist
+```
+
+### Option 3: Contribute to typeshed
+
+- Fork https://github.com/python/typeshed
+- Add stubs for the library
+- Submit PR to help everyone
+
+## Validation
+
+```bash
+# Check if cast removal breaks mypy
+mypy --strict path/to/file.py
+
+# Use reveal_type to verify inference
+# Add this temporarily:
+reveal_type(response.model_dump(mode="json"))
+# mypy will show: Revealed type is "dict[str, Any]"
+```
+
+## When Casts/Checks Are Acceptable
+
+```python
+# OK: Library genuinely has poor types
+import pygit2  # No proper type stubs
+repo: Any = pygit2.Repository(path)
+branches = cast(list[str], repo.listall_branches())
+
+# OK: Protocol matching complex structural types
+def process_dumpable(obj: SupportsDump) -> dict:
+    # cast may be needed for protocol compliance
+    return cast(dict[str, Any], obj.model_dump())
+
+# OK: Gradual migration, with TODO
+# TODO(typing): Remove cast once SQLAlchemy stubs improve
+users = cast(list[User], session.query(User).all())
+```
+
+Always document WHY:
+```python
+# Cast needed: pygit2 lacks type stubs (as of 2024)
+branches = cast(list[str], repo.listall_branches())
+```
+
+## Reference Links
+
+- OpenAI Python SDK: https://github.com/openai/openai-python
+- Pydantic types: https://docs.pydantic.dev/latest/concepts/types/
+- typeshed (Python type stubs): https://github.com/python/typeshed
+- mypy reveal_type: https://mypy.readthedocs.io/en/stable/common_issues.html#reveal-type

--- a/prompts/scans/manual-serde-needs-pydantic.md
+++ b/prompts/scans/manual-serde-needs-pydantic.md
@@ -1,0 +1,340 @@
+# Scan: Manual Serialization Patterns That Should Use Pydantic
+
+## Context
+@../shared-context.md
+
+## Pattern Description
+
+Code using manual JSON serialization/deserialization, dict construction, and validation instead of leveraging Pydantic's built-in capabilities.
+
+## Examples of Antipatterns
+
+### 1. Manual json.loads with dict validation
+
+```python
+# BAD: Manual JSON parsing and dict access
+def load_config(data: str) -> dict:
+    config = json.loads(data)
+    if "name" not in config:
+        raise ValueError("Missing name")
+    if not isinstance(config["name"], str):
+        raise TypeError("Invalid name type")
+    return config
+
+# GOOD: Pydantic handles validation
+class Config(BaseModel):
+    name: str
+
+def load_config(data: str) -> Config:
+    return Config.model_validate_json(data)
+```
+
+### 2. Dataclass + manual dict assembly
+
+```python
+# BAD: Dataclass with manual serialization
+@dataclass
+class UserData:
+    id: str
+    email: str
+    created: datetime
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "created": self.created.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> UserData:
+        return cls(
+            id=data["id"],
+            email=data["email"],
+            created=datetime.fromisoformat(data["created"]),
+        )
+
+# GOOD: Pydantic handles it
+class UserData(BaseModel):
+    id: str
+    email: str
+    created: datetime
+
+# Now just:
+user.model_dump(mode="json")  # Auto-handles datetime
+UserData.model_validate(data)  # Auto-parses datetime
+```
+
+### 3. Manual field extraction from JSON
+
+```python
+# BAD: Manual extraction pattern
+data = json.loads(response_text)
+mcp_config = MCPConfig.model_validate(json.loads(data["specs"])) if data["specs"] else MCPConfig()
+metadata = json.loads(data["metadata"]) if data.get("metadata") else {}
+
+# BETTER: Nested Pydantic models
+class ResponseData(BaseModel):
+    specs: MCPConfig | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+data = ResponseData.model_validate_json(response_text)
+# Access: data.specs, data.metadata
+```
+
+### 4. Dict wrangling for nested structures
+
+```python
+# BAD: Manual dict construction
+def build_request(user_id: str, items: list[str]) -> dict:
+    return {
+        "user": {
+            "id": user_id,
+            "preferences": {"lang": "en"}
+        },
+        "items": [{"name": item, "qty": 1} for item in items],
+        "timestamp": datetime.now().isoformat()
+    }
+
+# GOOD: Nested Pydantic models
+class UserPreferences(BaseModel):
+    lang: str = "en"
+
+class User(BaseModel):
+    id: str
+    preferences: UserPreferences = Field(default_factory=UserPreferences)
+
+class Item(BaseModel):
+    name: str
+    qty: int = 1
+
+class Request(BaseModel):
+    user: User
+    items: list[Item]
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+def build_request(user_id: str, items: list[str]) -> Request:
+    return Request(
+        user=User(id=user_id),
+        items=[Item(name=item) for item in items]
+    )
+
+# Serialize: request.model_dump(mode="json")
+```
+
+### 5. TypedDict for structure that should be BaseModel
+
+```python
+# BAD: TypedDict with manual validation
+class EventPayload(TypedDict):
+    event_type: str
+    timestamp: str
+    data: dict
+
+def parse_event(raw: str) -> EventPayload:
+    data = json.loads(raw)
+    # Manual validation...
+    if "event_type" not in data:
+        raise ValueError("Missing event_type")
+    return data  # No runtime validation!
+
+# GOOD: Pydantic BaseModel
+class EventPayload(BaseModel):
+    event_type: str
+    timestamp: datetime  # Auto-parsed!
+    data: dict[str, Any]
+
+def parse_event(raw: str) -> EventPayload:
+    return EventPayload.model_validate_json(raw)
+```
+
+## When Pydantic Adds Value
+
+Use Pydantic when you have:
+- **Validation needs**: Type checking, constraints, custom validators
+- **Nested structures**: Complex object hierarchies
+- **Serialization**: Need JSON/dict conversion with proper type handling
+- **Type coercion**: Auto-parsing (datetime, enums, etc.)
+- **Schema generation**: OpenAPI, JSON Schema
+- **Settings/config**: Environment variable loading, .env files
+
+## Detection Strategy
+
+### Grep Patterns
+
+```bash
+# Manual JSON with validation
+rg --type py "json\.loads.*\n.*if.*not in"
+
+# Dataclass with to_dict/from_dict
+rg --type py -A5 "@dataclass" | grep -A3 "def (to_dict|from_dict|asdict)"
+
+# Manual datetime.isoformat() in dict construction
+rg --type py "\.isoformat\(\)" | rg "\{|\["
+
+# TypedDict (often should be BaseModel)
+rg --type py "class \w+\(TypedDict\)"
+
+# Manual field extraction patterns
+rg --type py "json\.loads.*\[.*\].*if.*else"
+```
+
+### AST Analysis
+
+```python
+import ast
+
+class ManualSerdeDetector(ast.NodeVisitor):
+    def visit_ClassDef(self, node):
+        # Check if dataclass with manual serialization methods
+        has_dataclass = any(
+            isinstance(d, ast.Name) and d.id == 'dataclass'
+            for d in node.decorator_list
+        )
+        if has_dataclass:
+            methods = {n.name for n in node.body if isinstance(n, ast.FunctionDef)}
+            if 'to_dict' in methods or 'from_dict' in methods:
+                print(f"Dataclass with manual serde: {node.name}")
+```
+
+## Examples from This Codebase
+
+### adgn/src/adgn/agent/persist/sqlite.py
+
+```python
+# Current pattern:
+mcp_config=MCPConfig.model_validate(json.loads(r["specs"]))
+    if r["specs"]
+    else MCPConfig(),
+metadata=meta_val,
+
+# Could be improved with nested Pydantic:
+class AgentRowDB(BaseModel):
+    id: str
+    created_at: datetime
+    specs: MCPConfig = Field(default_factory=MCPConfig)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+# Then just:
+row = AgentRowDB.model_validate(db_row_dict)
+```
+
+## Fix Strategy
+
+### Step 1: Identify the data structure
+- What fields exist?
+- What types are they?
+- Any validation rules?
+- Any nested structures?
+
+### Step 2: Create Pydantic model(s)
+
+```python
+class MyModel(BaseModel):
+    field1: str
+    field2: int
+    nested: NestedModel | None = None
+
+    model_config = ConfigDict(
+        # Add config as needed
+        str_strip_whitespace=True,
+        validate_default=True,
+    )
+```
+
+### Step 3: Replace manual code
+
+```python
+# Replace:
+data = json.loads(text)
+obj = SomeClass(data["field1"], data["field2"])
+
+# With:
+obj = MyModel.model_validate_json(text)
+```
+
+### Step 4: Update serialization
+
+```python
+# Replace:
+output = json.dumps({"field1": obj.field1, "field2": obj.field2})
+
+# With:
+output = obj.model_dump_json()
+```
+
+## When NOT to Use Pydantic
+
+- **Performance-critical tight loops**: Validation overhead may matter
+- **Simple passthrough**: Just forwarding a dict unchanged
+- **Dynamic schemas**: Structure changes at runtime
+- **Legacy compatibility**: Need exact dict behavior for external API
+
+In these cases, consider:
+- TypedDict for static typing without validation
+- Plain dicts with explicit type hints
+- Custom __init__ with targeted validation
+
+## Validation
+
+```bash
+# Verify model works
+pytest tests/test_models.py
+
+# Check serialization round-trip
+python -c "
+from mymodel import MyModel
+m = MyModel(field1='test', field2=42)
+json_str = m.model_dump_json()
+m2 = MyModel.model_validate_json(json_str)
+assert m == m2
+"
+
+# Verify mypy still passes
+mypy path/to/file.py
+```
+
+## Pydantic Features Reference
+
+### Model Validation
+```python
+Model.model_validate(dict)           # From dict
+Model.model_validate_json(str)       # From JSON string
+Model.model_validate_strings(dict)   # Coerce strings to types
+```
+
+### Serialization
+```python
+model.model_dump()                   # To dict (Python objects)
+model.model_dump(mode="json")        # To JSON-compatible dict
+model.model_dump_json()              # To JSON string
+model.model_dump(exclude={"field"})  # Exclude fields
+model.model_dump(by_alias=True)      # Use aliases
+```
+
+### Field Configuration
+```python
+Field(default=...)                   # Default value
+Field(default_factory=...)           # Default factory
+Field(alias="external_name")         # For input
+Field(serialization_alias="...")     # For output
+Field(validation_alias="...")        # For validation
+Field(gt=0, le=100)                  # Constraints
+```
+
+### Validators
+```python
+@field_validator('email')
+@classmethod
+def validate_email(cls, v: str) -> str:
+    if '@' not in v:
+        raise ValueError('Invalid email')
+    return v.lower()
+```
+
+## References
+
+- [Pydantic V2 Docs](https://docs.pydantic.dev/latest/)
+- [Migration Guide](https://docs.pydantic.dev/latest/migration/)
+- [JSON Schema](https://docs.pydantic.dev/latest/concepts/json_schema/)
+- [Performance Tips](https://docs.pydantic.dev/latest/concepts/performance/)

--- a/prompts/scans/mypy-appeasing-code.md
+++ b/prompts/scans/mypy-appeasing-code.md
@@ -1,0 +1,249 @@
+# Scan: Mypy-Appeasing Code Antipatterns
+
+## Context
+@../shared-context.md
+
+## Pattern Description
+
+Code written solely to satisfy mypy without adding semantic value. Often indicates misunderstanding of library types or unnecessary type manipulation.
+
+## Examples of Antipatterns
+
+### 1. Unnecessary casts
+
+```python
+# BAD: cast when return type is already correct
+def list_states(self) -> dict[str, ServerEntry]:
+    entries = await meta.list_states()  # Already returns dict[str, ServerEntry]
+    return cast(dict[str, ServerEntry], entries)
+
+# BAD: cast on model_dump which always returns dict
+return cast(dict[str, Any], model.model_dump(mode="json"))
+```
+
+### 2. Assign-to-typed-variable (just for type annotation)
+
+```python
+# BAD: Variable exists only to annotate type
+presets: dict[str, AgentPreset] = discover_presets(...)
+return presets
+
+# GOOD: Just return directly
+return discover_presets(...)
+```
+
+### 3. Redundant isinstance assertions
+
+```python
+# BAD: Type is already known from prior check
+if isinstance(item, AssistantMessageOut):
+    msg: AssistantMessageOut = item
+    text = msg.text
+    assert isinstance(text, str)  # text is already str | None
+    if text: return text
+
+# GOOD: Use type directly
+if isinstance(item, AssistantMessageOut):
+    text = item.text
+    if text: return text
+```
+
+### 4. Unnecessary TypeAdapter intermediate variables
+
+```python
+# BAD: TypeAdapter stored just to call once
+adapter = TypeAdapter(dict[str, Any])
+return adapter.validate_json(s)
+
+# GOOD: Call directly
+return TypeAdapter(dict[str, Any]).validate_json(s)
+```
+
+## Root Causes
+
+Often these patterns appear because:
+- **Not reading library source**: Assuming types are worse than they are
+- **Cargo-culting**: Copying patterns without understanding
+- **Outdated**: Code written for older library versions with worse typing
+- **Missing type stubs**: Library has types but stubs aren't installed
+- **Old library version**: Newer versions have better typing
+
+## Before Assuming Types Are Bad: Research Library Improvements
+
+When you find mypy-appeasing code, **always research if there's a better solution** before accepting the cast/workaround:
+
+### 1. Check for Type Stubs Packages
+
+```bash
+# Search PyPI for type stubs
+pip index versions types-{library}
+
+# Common stub packages:
+types-sqlalchemy      # SQLAlchemy ORM types
+types-pygit2          # pygit2 Git library types
+types-requests        # requests HTTP library
+types-redis           # Redis client types
+```
+
+**Action**: If stubs exist, add to requirements and test if casts can be removed.
+
+### 2. Check Library Version
+
+```bash
+# Find current version
+pip show library-name
+
+# Check latest version
+pip index versions library-name
+
+# Read changelog for typing improvements
+# Often in CHANGELOG.md or release notes on GitHub
+```
+
+**Action**: If newer version has better types, update pinned version.
+
+### 3. Check for Better Patterns/Helpers
+
+Read library documentation for:
+- Type-safe helper functions
+- Generic/overload improvements in newer versions
+- Recommended patterns in migration guides
+
+**Example**: SQLAlchemy 2.0 added much better typing with `Mapped[]` annotations:
+
+```python
+# Old pattern (required casts)
+users = cast(list[User], session.query(User).all())
+
+# New pattern (no cast needed with SQLAlchemy 2.0)
+users = session.scalars(select(User)).all()  # Properly typed!
+```
+
+### 4. Research Process for Each Cast
+
+```python
+# Found this cast:
+result = cast(pygit2.Oid, repo.index.write_tree())
+
+# Research steps:
+# 1. Check current version
+pip show pygit2  # Shows: 1.14.0
+
+# 2. Check for type stubs
+pip index versions types-pygit2  # Shows: 1.15.0.20250319 available!
+
+# 3. Install and test
+pip install types-pygit2
+mypy file.py  # Does cast still needed?
+
+# 4. If cast no longer needed, remove it
+result = repo.index.write_tree()  # Now properly typed
+```
+
+### 5. Document Remaining Casts
+
+If after research the cast is still needed:
+
+```python
+# Cast needed: pygit2.index.write_tree() returns Any in v1.14
+# TODO: Recheck after updating to pygit2 1.16+
+result = cast(pygit2.Oid, repo.index.write_tree())
+```
+
+## Detection Strategy
+
+### AST Analysis for Casts
+
+```python
+import ast
+
+class UnnecessaryCastDetector(ast.NodeVisitor):
+    def visit_Call(self, node):
+        if (isinstance(node.func, ast.Name) and node.func.id == 'cast'):
+            # Check if cast target matches actual type
+            # Requires type inference - use mypy's AST
+            pass
+```
+
+### Grep Patterns
+
+```bash
+# Find casts
+rg --type py "cast\("
+
+# Find typed variable assignments that immediately return
+rg --type py -U "^\s+\w+:\s+\w+.*=.*\n\s+return \w+$"
+
+# Find TypeAdapter intermediate variables
+rg --type py -A1 "adapter.*=.*TypeAdapter"
+```
+
+### Mypy Analysis
+
+```bash
+# Check if removing cast changes mypy output
+# If mypy still passes without cast, it was unnecessary
+```
+
+## Fix Strategy
+
+### Before Removing Casts
+1. **Read the actual source**: Check library .pyi or source for real return type
+2. **Use mypy reveal_type**: Add `reveal_type(expr)` to see actual inferred type
+3. **Test removal**: Remove cast and run mypy
+
+### For Library Types
+```python
+# STEP 1: Find the library source
+import openai
+print(openai.__file__)  # Find installation location
+
+# STEP 2: Read the actual type definition
+# openai/types/responses.py or .pyi file
+class Response(BaseModel):
+    def model_dump(self, *, mode: Literal["json", "python"] = "python") -> dict[str, Any]:
+        ...  # Returns dict[str, Any] - no cast needed!
+```
+
+## Example Fixes
+
+### Cast Removal
+```python
+# Before:
+return cast(dict[str, Any], model.model_dump(mode="json"))
+
+# After (reading source shows model_dump returns dict[str, Any]):
+return model.model_dump(mode="json")
+```
+
+### Variable Removal
+```python
+# Before:
+entries: dict[str, ServerEntry] = await meta.list_states()
+return entries
+
+# After:
+return await meta.list_states()
+```
+
+## Validation
+
+```bash
+# All fixes MUST pass mypy
+mypy --strict path/to/file.py
+
+# Check for remaining instances
+rg --type py "cast\(|: \w+.*= .*\n.*return"
+```
+
+## When Casts Are Actually Needed
+
+- **Third-party library with poor/missing types**: Consider contributing stubs
+- **Complex protocol matching**: Where structural typing needs hint
+- **Gradual typing migration**: Temporary during migration, document with TODO
+
+Always add a comment explaining WHY the cast is needed:
+```python
+# cast needed: sqlalchemy relationship typing limitation
+return cast(list[Model], query.all())
+```

--- a/prompts/scans/pydantic-antipatterns.md
+++ b/prompts/scans/pydantic-antipatterns.md
@@ -1,0 +1,85 @@
+# Scan: Pydantic Antipatterns
+
+## Context
+@../shared-context.md
+
+## Pattern 1: Manual Field-by-Field model_dump
+
+### Seen in: adgn/rspcache/models.py
+
+```python
+# BAD: Repetitive manual dumping per field
+def to_db_payload(self) -> dict[str, Any]:
+    return {
+        "status": self.status.value,
+        "response_json": self.response.model_dump(mode="json") if self.response else None,
+        "error_json": self.error.model_dump(mode="json") if self.error else None,
+        "token_usage_json": self.token_usage.model_dump(mode="json") if self.token_usage else None,
+    }
+
+# GOOD: Let Pydantic handle it
+def to_db_payload(self) -> dict[str, Any]:
+    return self.model_dump(mode="json")
+```
+
+Issues:
+- Repetitive `model_dump(mode="json") if ... else None`
+- Fragile: adding fields needs manual updates
+- Not using Pydantic's nested serialization
+
+## Pattern 2: Manual Field-by-Field model_validate
+
+### Seen in: adgn/rspcache/models.py
+
+```python
+# BAD: Manual validation replicating what Pydantic does
+@classmethod
+def from_db(cls, *, status: str, response: Any, error: Any, token_usage: Any) -> FinalResponseSnapshot:
+    return cls(
+        status=ResponseStatus(status),
+        response=parse_response(response) if response is not None else None,
+        error=parse_error(error) if error is not None else None,
+        token_usage=parse_usage(token_usage) if token_usage is not None else None,
+    )
+
+# GOOD: Use model_validate directly
+def to_model(self) -> FinalResponseSnapshot:
+    return FinalResponseSnapshot.model_validate({
+        "status": self.status,
+        "response": self.response,
+        "error": self.error,
+        "token_usage": self.token_usage,
+    })
+```
+
+Issues:
+- Manual field-by-field validation/parsing
+- Doesn't leverage Pydantic's built-in validation
+- Extra boilerplate code
+
+## Detection
+
+```bash
+# Find manual field-by-field model_dump patterns
+rg --type py -A5 "def (to_db|to_dict|serialize)" | rg "model_dump.*if.*else"
+
+# Find manual field-by-field validation classmethods
+rg --type py -A10 "@classmethod" | rg -B3 "return cls\("
+```
+
+## Fix Strategy
+
+1. **For serialization (model_dump)**:
+   - If field names match: Just use `model_dump(mode="json")`
+   - If enum needs `.value`: Use `@field_serializer`
+   - If fields need different names: Rename DB columns or use separate DB model class
+
+2. **For deserialization (model_validate)**:
+   - Replace manual `from_db()`-style methods with `model_validate(dict)`
+   - Let Pydantic handle type conversion and validation
+   - Only keep custom logic if truly needed (custom parsing, migration, etc.)
+
+## References
+
+- [Pydantic Serialization](https://docs.pydantic.dev/latest/concepts/serialization/)
+- [Pydantic Validation](https://docs.pydantic.dev/latest/concepts/validators/)

--- a/prompts/scans/pygit2-patterns.md
+++ b/prompts/scans/pygit2-patterns.md
@@ -1,0 +1,45 @@
+# Scan: pygit2 Type Narrowing Patterns
+
+## Context
+@../shared-context.md
+
+## Pattern: Proper Type Narrowing Without Casts
+
+### Seen in: adgn/mcp/git_ro/server.py
+
+```python
+# Pattern: Handle Tag vs Commit narrowing
+obj_any = repo.revparse_single(objspec)
+if isinstance(obj_any, pygit2.Tag):
+    obj = obj_any.peel(pygit2.Commit)  # Tag -> Commit
+elif isinstance(obj_any, pygit2.Commit):
+    obj = obj_any  # Already a Commit, no peel needed
+else:
+    raise TypeError(f"Unexpected type: {type(obj_any)}")
+
+# obj is now properly typed as pygit2.Commit
+```
+
+**Important**: `commit.peel(pygit2.Commit)` is identity (noop) - if you already have a Commit, just use it directly.
+
+## Detection
+
+```bash
+# Find isinstance checks that could be simplified
+rg --type py "isinstance.*pygit2\.(Tag|Commit)" -A3
+
+# Find potentially unnecessary peels
+rg --type py "peel\(pygit2\.Commit\)" -B2
+```
+
+## With types-pygit2 Installed
+
+Type stubs (`types-pygit2>=1.15.0`) provide proper return types:
+- `repo.index.write_tree()` returns `Oid` (not `Any`)
+- `obj.peel(T)` returns `T`
+- No casts needed with isinstance narrowing
+
+## References
+
+- [pygit2 Documentation](https://www.pygit2.org/)
+- Install: `pip install types-pygit2`

--- a/prompts/scans/pytest-tmp-paths.md
+++ b/prompts/scans/pytest-tmp-paths.md
@@ -1,0 +1,171 @@
+# Scan: Pytest Temporary Path Antipatterns
+
+## Context
+@../shared-context.md
+
+## Overview
+
+Use pytest's built-in `tmp_path` and `tmp_path_factory` fixtures instead of manual temporary directory/file creation.
+
+Only use manual `tempfile` when pytest fixtures aren't possible (e.g., weird environment constraints, non-pytest code).
+
+## Pattern: Manual tempfile Instead of Pytest Fixtures
+
+### BAD: Manual tempfile usage
+
+```python
+import tempfile
+import os
+
+def test_file_operation():
+    # BAD: Manual temp directory
+    tmpdir = tempfile.mkdtemp()
+    try:
+        filepath = os.path.join(tmpdir, "test.txt")
+        with open(filepath, "w") as f:
+            f.write("test")
+        # ... test logic ...
+    finally:
+        # Manual cleanup needed!
+        import shutil
+        shutil.rmtree(tmpdir)
+
+def test_another():
+    # BAD: Manual temp file
+    fd, path = tempfile.mkstemp()
+    try:
+        os.write(fd, b"data")
+        os.close(fd)
+        # ... test logic ...
+    finally:
+        os.unlink(path)
+```
+
+### GOOD: Use pytest fixtures
+
+```python
+from pathlib import Path
+
+def test_file_operation(tmp_path: Path):
+    # ✓ GOOD: pytest provides tmp_path, auto-cleanup
+    filepath = tmp_path / "test.txt"
+    filepath.write_text("test")
+    # ... test logic ...
+    # No cleanup needed - pytest handles it!
+
+def test_multiple_files(tmp_path: Path):
+    # ✓ GOOD: Can create subdirectories
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "file.txt").write_text("data")
+
+# For session/module scope
+@pytest.fixture(scope="session")
+def shared_data_dir(tmp_path_factory):
+    # ✓ GOOD: tmp_path_factory for shared temp dirs
+    return tmp_path_factory.mktemp("shared")
+```
+
+## Detection
+
+```bash
+# Find tempfile imports in test files
+rg --type py "import tempfile" --glob "test_*.py" --glob "*_test.py"
+
+# Find mkdtemp/mkstemp usage
+rg --type py "(mkdtemp|mkstemp|TemporaryDirectory|NamedTemporaryFile)" --glob "test_*.py"
+
+# Find manual cleanup in tests
+rg --type py "shutil\.rmtree.*tmpdir|os\.unlink.*temp" --glob "test_*.py"
+```
+
+## Fix Strategy
+
+### Replace mkdtemp → tmp_path
+
+```python
+# Before
+import tempfile
+tmpdir = tempfile.mkdtemp()
+
+# After
+def test_foo(tmp_path: Path):
+    # tmp_path is already a directory
+```
+
+### Replace mkstemp → tmp_path
+
+```python
+# Before
+fd, path = tempfile.mkstemp()
+os.write(fd, b"data")
+os.close(fd)
+
+# After
+def test_foo(tmp_path: Path):
+    path = tmp_path / "tempfile"
+    path.write_bytes(b"data")
+```
+
+### Replace TemporaryDirectory → tmp_path
+
+```python
+# Before
+with tempfile.TemporaryDirectory() as tmpdir:
+    # ...
+
+# After
+def test_foo(tmp_path: Path):
+    # tmp_path is the directory
+```
+
+### Session-scoped temp directories
+
+```python
+# Before
+_session_tmpdir = None
+
+def setup_module():
+    global _session_tmpdir
+    _session_tmpdir = tempfile.mkdtemp()
+
+def teardown_module():
+    shutil.rmtree(_session_tmpdir)
+
+# After
+@pytest.fixture(scope="session")
+def session_tmpdir(tmp_path_factory):
+    return tmp_path_factory.mktemp("session")
+```
+
+## When Manual tempfile IS Okay
+
+Manual `tempfile` is acceptable when:
+
+1. **Non-pytest code** - Production code that needs temp files
+2. **Weird environment** - Special constraints (permissions, cross-process, etc.)
+3. **Requires specific location** - Must be in `/tmp` or specific mount point
+4. **Cross-test persistence** - Needs to survive pytest session (rare)
+
+Example of valid manual usage:
+```python
+# Production code (not a test)
+def export_report():
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.pdf', delete=False) as f:
+        generate_pdf(f)
+        return f.name  # Caller responsible for cleanup
+```
+
+## Benefits of pytest fixtures
+
+✅ **Automatic cleanup** - No finally blocks, no forgotten cleanup
+✅ **Unique per test** - Each test gets fresh directory, no conflicts
+✅ **Pathlib by default** - `tmp_path` is `Path`, not string
+✅ **Configurable retention** - `pytest --basetemp` to inspect failed test artifacts
+✅ **Better errors** - pytest shows temp dir location on failure
+✅ **Scoping support** - function/class/module/session scopes
+
+## References
+
+- [pytest tmp_path docs](https://docs.pytest.org/en/stable/how-to/tmp_path.html)
+- [pytest fixtures](https://docs.pytest.org/en/stable/reference/fixtures.html#tmp-path)

--- a/prompts/scans/stringly-typed.md
+++ b/prompts/scans/stringly-typed.md
@@ -1,0 +1,205 @@
+# Scan: Stringly-Typed Code
+
+## Context
+@../shared-context.md
+
+## Overview
+
+**"Strings are evil"** - Prefer `StrEnum` (or library-provided enums) over raw strings for categorical values.
+
+Many libraries (OpenAI SDK, etc.) follow this pattern - USE THEIR ENUMS instead of strings.
+
+## Pattern: String Literals Instead of Enums
+
+### Generic Example
+
+```python
+# BAD: Stringly-typed
+class Request(BaseModel):
+    status: str  # What are valid values? Runtime errors on typos!
+
+def process(request: Request):
+    if request.status == "complet":  # Typo! Runtime error
+        ...
+
+# GOOD: Use StrEnum
+class RequestStatus(StrEnum):
+    QUEUED = "queued"
+    COMPLETE = "complete"
+    ERROR = "error"
+
+class Request(BaseModel):
+    status: RequestStatus  # Type-safe, autocomplete works
+
+def process(request: Request):
+    if request.status == RequestStatus.COMPLETE:  # ✓ Type-checked
+        ...
+```
+
+### Using Library Enums
+
+```python
+# BAD: Re-implementing what library provides
+class ModelType(StrEnum):
+    GPT_4 = "gpt-4"
+    GPT_4_TURBO = "gpt-4-turbo"
+
+# GOOD: Use library's enum (if it exists)
+from openai.types import ChatModel  # Example - check if this exists
+
+# BAD: Using strings for well-known values
+status_code: str = "success"  # What are valid values?
+error_type: str = "validation_error"  # Easy to typo
+
+# GOOD: Use enums from library
+from http import HTTPStatus
+status_code: HTTPStatus = HTTPStatus.OK
+
+from openai import OpenAIError
+# SDK often has error type enums - use them!
+```
+
+## Detection
+
+```bash
+# Find string fields that should be enums (common patterns)
+rg --type py ": str.*#.*(status|type|kind|mode|state)"
+
+# Find string literals in comparisons (might indicate enum candidates)
+rg --type py '== "(queued|pending|complete|error|success|failed)"'
+
+# Find Literal types with multiple options (convert to StrEnum)
+rg --type py 'Literal\[.*,.*\]'
+```
+
+## Fix Strategy
+
+1. **Check library first**:
+   - Does OpenAI SDK / library already have the enum?
+   - Use `from openai.types import X` instead of reinventing
+   - READ THE ACTUAL SOURCE CODE of the library types
+
+2. **Create StrEnum for internal values**:
+   ```python
+   from enum import StrEnum
+
+   class MyStatus(StrEnum):
+       QUEUED = "queued"
+       COMPLETE = "complete"
+   ```
+
+3. **Replace string fields**:
+   ```python
+   # Before
+   status: str
+
+   # After
+   status: MyStatus
+   ```
+
+4. **Update comparisons**:
+   ```python
+   # Before
+   if status == "complete":
+
+   # After
+   if status == MyStatus.COMPLETE:
+   ```
+
+5. **Serialization handled automatically**:
+   - Pydantic serializes `StrEnum` to string in JSON
+   - Deserializes string back to `StrEnum`
+   - Use `@field_serializer` if you need `.value`
+
+## Benefits
+
+✅ **Type safety** - Typos caught at type-check time, not runtime
+✅ **Autocomplete** - IDE shows all valid values
+✅ **Documentation** - Enum definition documents all possible values
+✅ **Refactoring** - Rename enum value, all usages update
+✅ **Exhaustiveness** - Type checker ensures you handle all cases
+
+## Examples from rspcache
+
+```python
+# ✓ GOOD: Using StrEnum for internal status
+class ResponseStatus(StrEnum):
+    COMPLETE = "complete"
+    ERROR = "error"
+
+# ✓ GOOD: Using library types
+from openai.types.responses import (
+    Response as OpenAIResponse,
+    ResponseUsage,
+    ResponseError,
+)
+
+# TODO: Check if OpenAI SDK has status enums we should use
+```
+
+## Pattern: Unstructured Error Messages
+
+Error reason/message fields storing free-form strings should use structured types:
+
+```python
+# BAD: Free-form error strings
+class Response(BaseModel):
+    status_reason: str | None = None  # Could be anything!
+
+# Usage scattered across codebase:
+status_reason = "Streaming proxy failure"
+status_reason = str(exc)  # Exception message
+status_reason = f"Upstream status {resp.status_code}"
+status_reason = "Upstream returned non-JSON response"
+
+# GOOD: Structured error with StrEnum
+class ProxyErrorType(StrEnum):
+    UPSTREAM_HTTP = "upstream_http"
+    STREAMING_FAILURE = "streaming_failure"
+    REQUEST_EXCEPTION = "request_exception"
+    INVALID_RESPONSE = "invalid_response"
+
+class ProxyError(BaseModel):
+    type: ProxyErrorType
+    message: str
+    detail: dict[str, Any] | None = None
+
+class Response(BaseModel):
+    error: ProxyError | None = None
+
+# BETTER: Tagged union for type-specific fields
+class UpstreamHttpError(BaseModel):
+    type: Literal["upstream_http"]
+    status_code: int
+    response_body: str | None = None
+
+class StreamingFailure(BaseModel):
+    type: Literal["streaming_failure"]
+    exception_message: str
+
+ProxyError = UpstreamHttpError | StreamingFailure | ...
+```
+
+**Why structured errors?**
+- Categorize errors for metrics/alerting
+- Type-safe error handling
+- Extract structured info (status codes, etc.)
+- Query/filter errors in DB by type
+
+## Common Enum-Worthy Patterns
+
+These string patterns often indicate enum candidates:
+
+- **Status/State**: `"pending"`, `"active"`, `"completed"`, `"failed"`
+- **Type/Kind**: `"user"`, `"admin"`, `"system"`
+- **Mode**: `"readonly"`, `"readwrite"`, `"admin"`
+- **Level**: `"debug"`, `"info"`, `"warning"`, `"error"`
+- **Direction**: `"inbound"`, `"outbound"`
+- **Format**: `"json"`, `"xml"`, `"csv"`
+- **Error reasons**: Multiple different error messages → categorize with enum
+
+## References
+
+- [Python StrEnum docs](https://docs.python.org/3/library/enum.html#enum.StrEnum)
+- [Stringly-typed (Martin Fowler)](https://martinfowler.com/bliki/StringlyTyped.html)
+- [Pydantic Enums](https://docs.pydantic.dev/latest/concepts/types/#enums)

--- a/prompts/scans/test-assertions.md
+++ b/prompts/scans/test-assertions.md
@@ -1,0 +1,103 @@
+# Scan: Test Assertion Antipatterns
+
+## Context
+@../shared-context.md
+
+## Pattern: Field-by-Field Assertions Instead of Object Comparison
+
+### BAD: Manual field-by-field assertions
+
+```python
+def test_parse_numstat_output():
+    numstat = "10\t5\tsrc/main.py\n3\t0\tREADME.md\n-\t-\timage.png"
+    changes = parse_numstat_output(numstat)
+
+    # BAD: Verbose, repetitive, fragile
+    assert len(changes) == 3
+    assert changes[0].path == "src/main.py"
+    assert changes[0].additions == 10
+    assert changes[0].deletions == 5
+    assert changes[0].is_binary is False
+
+    assert changes[1].path == "README.md"
+    assert changes[1].additions == 3
+    assert changes[1].deletions == 0
+
+    assert changes[2].path == "image.png"
+    assert changes[2].is_binary is True
+    assert changes[2].additions == 0
+    assert changes[2].deletions == 0
+```
+
+### GOOD: Compare whole objects
+
+```python
+def test_parse_numstat_output():
+    numstat = "10\t5\tsrc/main.py\n3\t0\tREADME.md\n-\t-\timage.png"
+
+    assert parse_numstat_output(numstat) == [
+        FileChange("src/main.py", additions=10, deletions=5, is_binary=False),
+        FileChange("README.md", additions=3, deletions=0, is_binary=False),
+        FileChange("image.png", additions=0, deletions=0, is_binary=True),
+    ]
+```
+
+**Intent is clear**: Parse produces these exact changes. Concise, complete.
+
+### Even Better: Parametrize multiple scenarios
+
+```python
+@pytest.mark.parametrize("numstat,expected", [
+    ("10\t5\tfile.py", [FileChange("file.py", additions=10, deletions=5, is_binary=False)]),
+    ("-\t-\timage.png", [FileChange("image.png", additions=0, deletions=0, is_binary=True)]),
+    ("", []),
+])
+def test_parse_numstat_output(numstat, expected):
+    assert parse_numstat_output(numstat) == expected
+```
+
+## Issues with Field-by-Field
+
+- **Verbose** - 20 lines → 5 lines
+- **Fragile** - Add a field? Update every test
+- **Incomplete** - Easy to forget fields
+- **Unclear intent** - What's the expected object?
+- **Harder to read** - Scattered assertions vs clear data structure
+
+## Detection
+
+```bash
+# Find tests with many assertions on same object
+rg --type py -A20 "def test_" | rg "assert.*\[0\].*==" | head -20
+
+# Find patterns like: assert obj.field1 == x; assert obj.field2 == y
+rg --type py "assert \w+\.\w+ ==" --glob "test_*.py" -A1 | grep "assert"
+```
+
+## Fix Strategy
+
+1. **Use `==` on whole objects** (if dataclass/Pydantic with `__eq__`)
+2. **Use pytest.approx for floats** when needed
+3. **Use structured comparison** (dict, list, tuple)
+4. **Parametrize** for multiple test cases
+
+## When Field-by-Field Is Okay
+
+- **Object has 50+ fields** and you only care about 3
+- **Testing specific field transformations** in isolation
+- **Partial matching** with complex nested structures
+
+But even then, consider extracting relevant fields into a test helper:
+
+```python
+def test_api_response_includes_user():
+    resp = get_user_details(123)
+    # Extract what matters
+    user = (resp.user.id, resp.user.name, resp.user.email)
+    assert user == (123, "Alice", "alice@example.com")
+```
+
+## References
+
+- [Effective Python Testing](https://realpython.com/pytest-python-testing/)
+- [Test Clarity](https://www.satisfice.com/blog/archives/856)

--- a/prompts/scans/timestamp-naming.md
+++ b/prompts/scans/timestamp-naming.md
@@ -1,0 +1,155 @@
+# Scan: Timestamp Field Naming
+
+## Context
+@../shared-context.md
+
+## Overview
+
+Timestamp fields should use `_at` suffix (not `_ts`), and should prefer `updated_at` over `last_update_ts`.
+
+## Pattern: `_ts` Suffix
+
+### Bad Examples
+
+```python
+class Response(BaseModel):
+    created_ts: datetime  # Inconsistent with common conventions
+    last_update_ts: datetime  # Verbose, non-standard
+    modified_ts: datetime
+```
+
+### Good Examples
+
+```python
+class Response(BaseModel):
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None = None  # Soft deletes
+```
+
+## Rationale
+
+**Industry standard**: `_at` is the dominant convention:
+- Rails ActiveRecord: `created_at`, `updated_at`
+- Django: `created_at`, `updated_at` (in newer code)
+- SQLAlchemy examples: `created_at`, `updated_at`
+- Stripe API: `created`, but in docs referred to as "created at"
+- GitHub API: `created_at`, `updated_at`
+
+**Consistency**: Most codebases use `_at`, not `_ts`:
+- PostgreSQL guides prefer `_at`
+- Database migration tools default to `_at`
+
+**Clarity**:
+- `created_at` reads naturally ("created at [timestamp]")
+- `created_ts` requires parsing ("created timestamp")
+
+**Brevity**:
+- `updated_at` vs `last_update_ts` (11 chars vs 14 chars)
+- `deleted_at` vs `deletion_ts` (10 chars vs 12 chars)
+
+## Common Timestamp Fields
+
+| Purpose | Recommended | Avoid |
+|---------|------------|-------|
+| Creation time | `created_at` | `created_ts`, `creation_time`, `create_date` |
+| Last update | `updated_at` | `last_update_ts`, `modified_ts`, `last_modified` |
+| Soft delete | `deleted_at` | `deleted_ts`, `deletion_time` |
+| Published | `published_at` | `publish_ts`, `publication_date` |
+| Scheduled | `scheduled_at` | `scheduled_ts`, `schedule_time` |
+
+## Detection
+
+```bash
+# Find _ts suffix timestamp fields
+rg --type py '^\s+\w+_ts:\s*Mapped\[datetime\]'
+rg --type py '^\s+\w+_ts:\s*datetime'
+
+# Find verbose timestamp names
+rg --type py 'last_update|last_modified|creation_time'
+```
+
+## Fix Strategy
+
+1. **Rename database columns** (requires migration):
+   ```python
+   # Before
+   created_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+   # After
+   created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+   ```
+
+2. **Update all references**:
+   ```python
+   # API models
+   created_at: datetime  # was created_ts
+
+   # Queries
+   .order_by(Response.created_at.desc())  # was created_ts
+
+   # Assignments
+   record.updated_at = datetime.now(UTC)  # was last_update_ts
+   ```
+
+3. **Add backward compatibility if needed**:
+   ```python
+   class ResponseRecordModel(BaseModel):
+       created_at: datetime
+
+       @property
+       def created_ts(self) -> datetime:
+           """Deprecated: use created_at"""
+           return self.created_at
+   ```
+
+## Special Cases
+
+**OK to use `_ts` when**:
+- External API requires it (match their naming)
+- Legacy system integration (consistency with existing)
+- Abbreviation is industry-standard for that domain
+
+**Timestamp vs Date**:
+- `*_at` for timestamps (includes time): `datetime`
+- `*_date` for dates only (no time): `date`
+- `*_time` for time only (no date): `time`
+
+```python
+# GOOD: Clear type from name
+birth_date: date  # Date only
+created_at: datetime  # Full timestamp
+daily_start_time: time  # Time only
+
+# BAD: Ambiguous
+birth: datetime  # Date or datetime?
+created: date  # Why date not datetime?
+```
+
+## Benefits
+
+✅ **Consistency** - Matches 90% of modern codebases
+✅ **Readability** - "created at" reads naturally
+✅ **Brevity** - Shorter than verbose alternatives
+✅ **IDE support** - Autocomplete recognizes common pattern
+✅ **Onboarding** - New developers expect `_at` convention
+
+## Examples from rspcache
+
+```python
+# ✗ BAD: Non-standard _ts suffix
+class Response(Base):
+    created_ts: Mapped[datetime]
+    last_update_ts: Mapped[datetime]
+
+# ✓ GOOD: Standard _at suffix
+class Response(Base):
+    created_at: Mapped[datetime]
+    updated_at: Mapped[datetime]
+```
+
+## References
+
+- [Rails ActiveRecord Timestamps](https://guides.rubyonrails.org/active_record_basics.html#timestamps)
+- [PostgreSQL Naming Conventions](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_timestamp_with_time_zone_columns_for_metadata)
+- [Database Design Best Practices](https://www.vertabelo.com/blog/naming-conventions-in-database-modeling/)

--- a/prompts/scans/trivial-forwarder-methods.md
+++ b/prompts/scans/trivial-forwarder-methods.md
@@ -1,0 +1,48 @@
+# Scan: Trivial Forwarder Methods
+
+## Context
+@../shared-context.md
+
+## Pattern: Single-Call Methods That Add No Value
+
+### Seen in: adgn/rspcache/models.py
+
+```python
+# BAD: Method that just calls model_dump
+def to_db_payload(self) -> dict[str, Any]:
+    return self.model_dump(mode="json")
+
+# GOOD: Call model_dump directly at use site
+snapshot.model_dump(mode="json")
+```
+
+This includes:
+- Methods that forward to a single Pydantic/library method
+- Getters that just access an attribute
+- Methods with no additional logic, validation, or transformation
+
+## Detection
+
+```bash
+# Find single-line return methods
+rg --type py -A1 "def \w+\(self.*\):" | rg -B1 "^\s+return self\.\w+\("
+
+# Find methods that just call model_dump
+rg --type py "def.*:$" -A1 | rg -B1 "return.*model_dump"
+```
+
+## When Trivial Methods Are OK
+
+- **Interface compliance**: Implementing a Protocol/ABC
+- **Future extensibility**: Clear plan to add logic
+- **Semantic clarity**: Method name adds domain meaning
+
+## Fix Strategy
+
+1. Remove the method
+2. Update callers to use direct access/method call
+3. If semantics matter, consider a property or use direct access
+
+## References
+
+- [Python properties](https://docs.python.org/3/library/functions.html#property)

--- a/prompts/scans/trivial-forwarders.md
+++ b/prompts/scans/trivial-forwarders.md
@@ -1,0 +1,81 @@
+# Scan: Trivial Forwarder Functions
+
+## Context
+@../shared-context.md
+
+## Pattern Description
+
+Functions that do nothing but forward to another function with identical or trivially transformed arguments.
+
+## Examples of Antipattern
+
+```python
+# BAD: Trivial wrapper around model_dump
+def dump_response(value: OpenAIResponse | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return value.model_dump(mode="json")
+
+# BAD: Just forwarding to another module
+def extract_text_from_openai_response(response: ResponsesResult) -> str:
+    return first_assistant_text(response)
+```
+
+## Detection Strategy
+
+### AST Analysis
+```python
+import ast
+
+class TrivialForwarderDetector(ast.NodeVisitor):
+    def visit_FunctionDef(self, node):
+        # Check if function body is:
+        # 1. Single return statement
+        # 2. That calls another function
+        # 3. With same/trivially mapped arguments
+        if len(node.body) == 1 and isinstance(node.body[0], ast.Return):
+            ret = node.body[0]
+            if isinstance(ret.value, ast.Call):
+                # Analyze if it's just forwarding
+                pass
+```
+
+### Grep Pattern
+```bash
+# Find functions with single return statement
+rg --type py -U "def \w+\([^)]*\):[^\n]*\n\s+return \w+\("
+```
+
+## Fix Strategy
+
+1. **Remove the wrapper**: Migrate all callers to use the underlying function directly
+2. **Update imports**: Change import statements at call sites
+3. **Verify**: Run mypy to ensure types still work
+
+## Common False Positives
+
+- Functions that add validation before forwarding
+- Functions that transform error types
+- Functions that add logging/metrics
+- Functions that provide backward compatibility during migration (temporary)
+
+## Example Fix
+
+```python
+# Before:
+from module import dump_response
+result = dump_response(snapshot.response)
+
+# After:
+result = snapshot.response.model_dump(mode="json") if snapshot.response else None
+```
+
+## Validation
+
+```bash
+# Check no references remain to removed function
+rg "dump_response|extract_text_from_openai_response"
+
+# Run type checker
+mypy path/to/modified/files.py
+```

--- a/prompts/scans/useless-documentation.md
+++ b/prompts/scans/useless-documentation.md
@@ -1,0 +1,219 @@
+# Scan: Useless Documentation
+
+## Context
+@../shared-context.md
+
+## Pattern Description
+
+Documentation that merely repeats what is already obvious from function names, parameter names, and type annotations. Good documentation adds information that isn't immediately obvious from reading the code.
+
+## Examples of Useless Documentation
+
+### Javadoc-Style Redundancy
+
+```python
+# BAD: Everything is obvious from signature
+def truncate_text(text: str, max_length: int, suffix: str = "...") -> str:
+    """Truncate text to max_length with optional suffix.
+
+    Args:
+        text: The text to truncate
+        max_length: Maximum length of the text
+        suffix: The suffix to add (default: "...")
+
+    Returns:
+        The truncated text string
+    """
+    ...
+
+# GOOD: Only document non-obvious behavior
+def truncate_text(text: str, max_length: int, suffix: str = "...") -> str:
+    """Suffix length counts against max_length."""
+    ...
+```
+
+### Obvious Getters/Setters
+
+```python
+# BAD: Function name says it all
+def get_response_id(response: Response) -> str:
+    """Get the response ID from a Response object.
+
+    Args:
+        response: The Response object
+
+    Returns:
+        The response ID as a string
+    """
+    return response.id
+
+# GOOD: No docstring needed, or minimal
+def get_response_id(response: Response) -> str:
+    return response.id
+```
+
+### Repeating Type Annotations
+
+```python
+# BAD: Types already say everything
+def parse_response(data: dict[str, Any]) -> Response:
+    """Parse response data into a Response object.
+
+    Args:
+        data: Dictionary containing response data
+
+    Returns:
+        Response: A Response object parsed from the data
+    """
+    return Response.model_validate(data)
+
+# GOOD: Only document exception behavior
+def parse_response(data: dict[str, Any]) -> Response:
+    """Raises ValidationError if data doesn't match Response schema."""
+    return Response.model_validate(data)
+```
+
+## What Makes Documentation Useful
+
+Good documentation tells you:
+- **Non-obvious behavior**: Side effects, mutation, caching
+- **Error conditions**: When exceptions are raised, edge cases
+- **Performance implications**: O(n²) behavior, blocking I/O
+- **Business logic**: Why something is done, not what is done
+- **Assumptions**: Preconditions, invariants
+- **Examples**: Complex usage patterns
+
+```python
+# GOOD: Explains non-obvious behavior
+def truncate_files_by_tokens(files: list[FileInfo], max_tokens: int) -> list[FileInfo]:
+    """Greedy truncation: includes whole files first (largest to smallest),
+    then binary-search truncates remainder. Stops early if budget < 1000 tokens."""
+    ...
+
+# GOOD: Documents exception
+def first_assistant_text(response: ResponsesResult) -> str:
+    """Raises ValueError if no assistant text found."""
+    ...
+
+# GOOD: Explains "why"
+def skip_global_compinit() -> None:
+    """Skip system compinit to avoid slowdown from oh-my-zsh plugin loading."""
+    ...
+```
+
+## Detection Strategy
+
+### Grep Patterns
+
+```bash
+# Find Args: sections (often indicates javadoc style)
+rg --type py '""".*\n.*Args:'
+
+# Find Returns: sections that just repeat return type
+rg --type py -A2 'Returns:\s*$'
+
+# Find parameter docs that just repeat param name
+rg --type py '    \w+: The \w+'
+```
+
+### AST + Docstring Analysis
+
+```python
+import ast
+import re
+
+class UselessDocstringDetector(ast.NodeVisitor):
+    def visit_FunctionDef(self, node):
+        docstring = ast.get_docstring(node)
+        if not docstring:
+            return
+
+        # Check for javadoc markers
+        if re.search(r'\b(Args|Arguments|Parameters|Returns|Return):', docstring):
+            # Analyze if parameters just repeat names
+            params = {arg.arg for arg in node.args.args}
+            for param in params:
+                # Check for "param: The param" pattern
+                if re.search(rf'{param}:.*\bThe {param}\b', docstring, re.IGNORECASE):
+                    print(f"Useless param doc in {node.name}: {param}")
+```
+
+### Heuristics
+
+- **Long Args section**: If every parameter has a doc that's just "The <param>"
+- **Returns mirrors type**: If "Returns: str" when return type is `-> str`
+- **Function name repetition**: Docstring first sentence just rephrases function name
+- **No exception info**: Doc doesn't mention raises/errors but function can raise
+
+## Fix Strategy
+
+1. **Delete obvious docs**: Remove Args/Returns that add no information
+2. **Keep useful info**: Preserve exception documentation, non-obvious behavior
+3. **Refactor to single line**: If only one useful sentence, make it a single-line docstring
+4. **Module-level docs**: Move general explanations to module docstrings
+
+### Before/After Examples
+
+```python
+# Before:
+def all_assistant_text(response: ResponsesResult) -> list[str]:
+    """Extract all assistant message texts from response.output.
+
+    Args:
+        response: ResponsesResult from API call
+
+    Returns:
+        List of all assistant texts (may be empty)
+    """
+    ...
+
+# After:
+def all_assistant_text(response: ResponsesResult) -> list[str]:
+    ...  # No docstring needed - name and types say it all
+```
+
+```python
+# Before:
+def concatenate_assistant_text(response: ResponsesResult, separator: str = "\n\n") -> str:
+    """Extract and concatenate all assistant texts with separator.
+
+    Args:
+        response: ResponsesResult from API call
+        separator: String to join multiple texts (default: double newline)
+
+    Returns:
+        Concatenated assistant text (empty string if none found)
+    """
+    ...
+
+# After:
+def concatenate_assistant_text(response: ResponsesResult, separator: str = "\n\n") -> str:
+    ...  # Or minimal: """Returns empty string if no assistant text found."""
+```
+
+## False Positives (Keep These)
+
+- **Public API documentation**: If it's a library, users need docs
+- **Complex algorithms**: Non-obvious implementation approach
+- **Domain-specific logic**: Business rules that aren't obvious from code
+- **Type variance**: When generic types need explanation
+- **Module-level context**: Overview of what module provides
+
+## Validation
+
+```bash
+# Count reduction in documentation
+git diff --stat
+
+# Ensure no actual information was lost
+git diff | grep -A5 -B5 '"""'
+
+# Verify code still makes sense
+git show HEAD | rg -A10 "^-.*def "
+```
+
+## References
+
+- Python PEP 257 (Docstring Conventions)
+- Google Python Style Guide (focus on "what's not obvious")
+- When to document: https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/

--- a/prompts/scans/vague-field-names.md
+++ b/prompts/scans/vague-field-names.md
@@ -1,0 +1,131 @@
+# Scan: Vague Field Names
+
+## Context
+@../shared-context.md
+
+## Overview
+
+Field names should be **explicit and self-documenting**. Vague names like `key`, `id`, `name` require context to understand.
+
+## Pattern: Ambiguous Field Names
+
+### Generic Example
+
+```python
+# BAD: What kind of key? What does it identify?
+class Response(BaseModel):
+    key: str  # Hash? Database key? API key? Cache key?
+    id: str   # ID of what? Request? Response? User?
+    name: str # Name of what?
+
+# GOOD: Explicit names
+class Response(BaseModel):
+    cache_key: str      # SHA256 hash for cache lookups
+    response_id: str    # OpenAI's response ID
+    model_name: str     # Model being used
+```
+
+### Real Example from rspcache
+
+```python
+# BAD: 'key' is ambiguous
+class ResponseRecordModel(BaseModel):
+    key: str  # ??? What kind of key?
+
+# GOOD: Explicit purpose
+class ResponseRecordModel(BaseModel):
+    cache_key: str  # SHA256 hash of request body (used for cache lookups)
+```
+
+## Common Vague Names
+
+| Vague | Better Alternatives |
+|-------|-------------------|
+| `key` | `cache_key`, `api_key`, `lookup_key`, `hash_key` |
+| `id` | `user_id`, `request_id`, `session_id`, `transaction_id` |
+| `name` | `user_name`, `file_name`, `model_name`, `project_name` |
+| `data` | `request_data`, `response_data`, `user_data` |
+| `value` | `config_value`, `setting_value`, `threshold_value` |
+| `type` | `content_type`, `error_type`, `request_type` |
+| `status` | Fine if obvious from context, otherwise `job_status`, `request_status` |
+
+## Detection
+
+```bash
+# Find single-word field names that might be vague
+rg --type py '^\s+key:\s'
+rg --type py '^\s+id:\s'
+rg --type py '^\s+name:\s'
+rg --type py '^\s+data:\s'
+rg --type py '^\s+value:\s'
+```
+
+## Fix Strategy
+
+1. **Add prefix/suffix clarifying purpose**:
+   ```python
+   key → cache_key, api_key, encryption_key
+   id → user_id, request_id, session_id
+   ```
+
+2. **Add docstring if renaming breaks compatibility**:
+   ```python
+   class Response(BaseModel):
+       """Response record.
+
+       Attributes:
+           key: SHA256 hash of request body (used for cache lookups)
+       """
+       key: str  # Still vague, but at least documented
+   ```
+
+3. **Best: Rename and update all usages**:
+   ```python
+   # Find all usages
+   rg "\.key\b"
+
+   # Rename in model
+   key → cache_key
+
+   # Update all call sites
+   response.key → response.cache_key
+   ```
+
+## When Vague Names Are OK
+
+- **Within small, focused scope** where context is obvious:
+  ```python
+  def get_user_by_id(id: int) -> User:  # OK: function name provides context
+      ...
+  ```
+
+- **Standard conventions** (e.g., `id` in Django/SQLAlchemy models)
+- **Temporary variables** with short lifetime:
+  ```python
+  for key, value in items:  # OK: loop variable, short scope
+      ...
+  ```
+
+## Benefits
+
+✅ **Self-documenting** - No need to read docs/comments
+✅ **Searchable** - `cache_key` is easier to grep than `key`
+✅ **Less ambiguity** - Clear what the field represents
+✅ **Better autocomplete** - More specific names group logically
+
+## Examples from rspcache
+
+```python
+# ✗ BAD: Renamed from vague name
+key: str  # What kind of key?
+
+# ✓ GOOD: Explicit
+cache_key: str  # SHA256 hash of request body
+api_key: APIKeyModel | None  # Client API key for authentication
+response_id: str | None  # OpenAI's response ID (e.g., 'resp_abc123')
+```
+
+## References
+
+- [Google Python Style Guide - Naming](https://google.github.io/styleguide/pyguide.html#s3.16-naming)
+- [PEP 8 - Descriptive Naming Styles](https://peps.python.org/pep-0008/#descriptive-naming-styles)

--- a/prompts/shared-context.md
+++ b/prompts/shared-context.md
@@ -1,0 +1,43 @@
+# Shared Context for Code Quality Scans
+
+## Philosophy
+
+- **Type safety without ugliness**: Python's type system should enhance code clarity, not obscure it
+- **Trust library types**: Well-typed libraries (OpenAI SDK, Pydantic, etc.) provide excellent types - use them as intended
+- **Read the source**: When uncertain about types, read the actual library source code to understand intended usage patterns
+- **Fail fast**: Prefer methods that raise exceptions over getters that hide errors
+- **No redundancy**: Every line of code should add value; remove trivial wrappers and obvious documentation
+
+## Tools Available
+
+- **mypy**: Type checker - use to verify type safety
+- **ruff**: Fast linter - catches many code quality issues
+- **vulture**: Dead code detector
+- **AST analysis**: Python's `ast` module for structural analysis
+- **grep/ripgrep**: Pattern matching in codebases
+
+## Analysis Workflow
+
+1. **Identify**: Use tools and patterns to find antipatterns
+2. **Verify**: Check if the pattern is actually problematic (read library source if needed)
+3. **Propose fix**: Suggest proper, type-safe alternative
+4. **Validate**: Ensure fix passes mypy and maintains correctness
+
+## Common Library Type Patterns
+
+### OpenAI SDK
+- Generally very well-typed
+- Use `Response`, `ResponseOutputMessage`, etc. directly
+- TypeAdapter for validation, not casts
+- Read `openai/types/` for actual type definitions
+
+### Pydantic
+- `model_dump(mode="json")` for serialization
+- `model_validate()` for parsing
+- TypeAdapter for non-model types
+- Avoid manual field-by-field serialization
+
+### SQLAlchemy
+- Use proper relationship typing
+- Consider better-stubs if ORM types are problematic
+- Avoid runtime hasattr/getattr when types are known


### PR DESCRIPTION
Comprehensive documentation for code quality scanning and refactoring:

Scan Prompts (prompts/scans/):
- test-assertions.md: Field-by-field assertion antipatterns
- pytest-tmp-paths.md: Pytest tmp_path usage patterns
- pydantic-antipatterns.md: Pydantic model antipatterns (from_db, manual serde)
- manual-serde-needs-pydantic.md: Manual serialization that should use Pydantic
- trivial-forwarder-methods.md: Unnecessary wrapper functions
- useless-documentation.md: Javadoc-style and redundant comments
- library-type-misuse.md: Type stubs for library misuse
- mypy-appeasing-code.md: Type annotations that appease mypy without value
- pygit2-patterns.md: pygit2 library usage patterns
- vague-field-names.md: Unclear field naming (key/status_reason)
- stringly-typed.md: Unstructured error messages needing typed models
- api-model-design.md: API model design patterns (OpenAI status literals, timestamps)
- timestamp-naming.md: Timestamp field naming conventions

Supporting Files:
- prompts/shared-context.md: Common context for all scans

These prompts support systematic codebase improvement through targeted scanning and refactoring patterns.