### PR TITLE
Remove bundled Ansible collections and fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 # Caches and temporary files
 **/.ansible/
+ansible/collections/
 **/.cache/
 **/.tmp/
 **/.uv-cache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,8 @@ ansible_lint:
     - job: build_ci_image
   interruptible: true
   script:
-    - ansible-galaxy install -r ansible/requirements.yaml
+    - ansible-galaxy role install -r ansible/requirements.yaml
+    - ansible-galaxy collection install -r ansible/requirements.yaml
     - ansible-lint --progressive ansible | tee ansible-lint-output.txt
   image:
     name: $CI_REGISTRY_IMAGE/cirunner:$CI_COMMIT_SHA


### PR DESCRIPTION
Changes:
- Add ansible/collections/ to .gitignore to prevent bundled collections
- Update CI to explicitly fetch both roles and collections separately
- Collections were already being fetched externally, this makes it explicit

The repository no longer bundles Ansible collections - they are always fetched from ansible-galaxy during CI runs and local development.