### PR TITLE
Fix GitHub integration issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
           # UV version synced with flake.nix / .envrc
           pip install uv==0.5.11
           uv pip install --system -e ".[dev]" || uv pip install --system -e .
+
+          # Install Playwright browsers if playwright is installed (for gatelet e2e tests)
+          if uv pip show playwright >/dev/null 2>&1; then
+            playwright install --with-deps chromium
+          fi
+
           if uv pip show pytest >/dev/null 2>&1; then
             pytest -v
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,6 @@ jobs:
             ${{ runner.os }}-pip-uv-${{ matrix.project }}-
             ${{ runner.os }}-pip-uv-
 
-      - name: Install system dependencies for projects with dbus-python
-        if: matrix.project == 'gnome-terminal-profile-switcher' || matrix.project == 'llm/ducktape_llm_common'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev libgirepository1.0-dev
-
       - name: Install gitstatusd for wt tests
         if: matrix.project == 'wt'
         run: |
@@ -121,13 +115,22 @@ jobs:
         run: |
           # UV version synced with flake.nix / .envrc
           pip install uv==0.5.11
+
+          # Check if project needs dbus-python system dependencies
+          if grep -q "dbus-python" pyproject.toml 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y libdbus-1-dev libgirepository1.0-dev
+          fi
+
+          # Install project dependencies
           uv pip install --system -e ".[dev]" || uv pip install --system -e .
 
-          # Install Playwright browsers if playwright is installed (for gatelet e2e tests)
+          # Install Playwright browsers if playwright is installed
           if uv pip show playwright >/dev/null 2>&1; then
             playwright install --with-deps chromium
           fi
 
+          # Run tests if pytest is available
           if uv pip show pytest >/dev/null 2>&1; then
             pytest -v
           else


### PR DESCRIPTION
The gatelet tests include an end-to-end test (test_admin_webhook_e2e.py) that uses Playwright to test the admin UI. While the CI workflow installs the playwright package, it wasn't installing the actual browser binaries needed to run the tests.

This commit adds automatic Playwright browser installation for any project that has playwright as a dependency. The installation happens after the project dependencies are installed, and only if playwright is detected.

This fix:
- Checks if playwright is installed in the project dependencies
- Installs Chromium browser with system dependencies if playwright is found
- Works automatically for any future projects that use Playwright