### PR TITLE
Revert async/retry/timeout changes from dirty branch

### DIFF
--- a/ansible/atlas.yaml
+++ b/ansible/atlas.yaml
@@ -9,9 +9,6 @@
     docker_state: absent  # Proxmox host doesn't need Docker
     skip_ubuntu_ppas: true  # Debian-based Proxmox can't use Ubuntu PPAs
     include_heavy_dev_packages: false
-    apt_async_timeout: 600
-    apt_async_poll_interval: 5
-    git_async_timeout: 300
   remote_user: root
 
   tasks:
@@ -34,20 +31,7 @@
 
     - name: Update apt cache after repository changes
       ansible.builtin.apt:
-        update_cache: yes
-      async: "{{ apt_async_timeout }}"
-      poll: 0
-      register: apt_cache_job
-      tags: [repositories]
-
-    - name: Wait for apt cache update
-      ansible.builtin.async_status:
-        jid: "{{ apt_cache_job.ansible_job_id }}"
-      register: apt_cache_status
-      until: apt_cache_status.finished
-      retries: "{{ (apt_async_timeout // apt_async_poll_interval) | int }}"
-      delay: "{{ apt_async_poll_interval }}"
-      failed_when: apt_cache_status.failed | default(false)
+        update_cache: true
       tags: [repositories]
 
     - name: Ensure ducktape directory parent exists
@@ -66,39 +50,13 @@
         accept_hostkey: true
       become: true
       become_user: "{{ my_user }}"
-      async: "{{ git_async_timeout }}"
-      poll: 0
-      register: ducktape_git_job
       tags: [dotfiles]
       failed_when: false  # In case SSH keys aren't set up yet
-
-    - name: Wait for ducktape repository clone
-      ansible.builtin.async_status:
-        jid: "{{ ducktape_git_job.ansible_job_id }}"
-      register: ducktape_git_status
-      until: ducktape_git_status.finished
-      retries: "{{ (git_async_timeout // apt_async_poll_interval) | int }}"
-      delay: "{{ apt_async_poll_interval }}"
-      failed_when: ducktape_git_status.rc is defined and ducktape_git_status.rc != 0
-      tags: [dotfiles]
 
     - name: Install Firefox
       ansible.builtin.package:
         name: firefox-esr
         state: present
-      async: "{{ apt_async_timeout }}"
-      poll: 0
-      register: install_firefox_job
-      tags: [packages]
-
-    - name: Wait for Firefox installation
-      ansible.builtin.async_status:
-        jid: "{{ install_firefox_job.ansible_job_id }}"
-      register: install_firefox_status
-      until: install_firefox_status.finished
-      retries: "{{ (apt_async_timeout // apt_async_poll_interval) | int }}"
-      delay: "{{ apt_async_poll_interval }}"
-      failed_when: install_firefox_status.failed | default(false)
       tags: [packages]
 
     - name: Install desktop and virtualization packages
@@ -113,19 +71,6 @@
           - spice-client-gtk  # For SPICE console connections
         state: present
         install_recommends: false
-      async: "{{ apt_async_timeout }}"
-      poll: 0
-      register: desktop_pkg_job
-      tags: [packages, desktop, virtualization]
-
-    - name: Wait for desktop package installation
-      ansible.builtin.async_status:
-        jid: "{{ desktop_pkg_job.ansible_job_id }}"
-      register: desktop_pkg_status
-      until: desktop_pkg_status.finished
-      retries: "{{ (apt_async_timeout // apt_async_poll_interval) | int }}"
-      delay: "{{ apt_async_poll_interval }}"
-      failed_when: desktop_pkg_status.failed | default(false)
       tags: [packages, desktop, virtualization]
 
     - name: Ensure libvirt service is started
@@ -170,11 +115,8 @@
       ansible.builtin.import_role:
         name: cli
       tags: [cli]
-<<<<<<< HEAD
-    # legacy_without_home_manager/cli excluded - atlas uses Nix/home-manager for these tools
-=======
+
     # cli_nix_migrated excluded - atlas now uses Nix/home-manager for migrated packages
->>>>>>> 4a66ade6 (dirty state)
 
     - name: Apply Nix role
       ansible.builtin.import_role:

--- a/ansible/roles/k3s/tasks/create_vms_proper.yml
+++ b/ansible/roles/k3s/tasks/create_vms_proper.yml
@@ -185,8 +185,6 @@
     status_code: 200
   register: k3s_health
   until: k3s_health.status == 200
-  retries: 60
-  delay: 10
   tags: [k3s, vm-start]
 
 - name: Fetch kubeconfig from master


### PR DESCRIPTION
Remove async task execution, retry logic, and timeout configurations that were added in the dirty branch. Keep all other changes intact.

Changes:
- Remove apt_async_timeout, apt_async_poll_interval, git_async_timeout vars
- Remove async/poll/register patterns from apt and git tasks
- Remove "Wait for..." async_status tasks
- Remove retries/delay from k3s health check
- Fix merge conflict markers in atlas.yaml

This restores simpler synchronous task execution while preserving all other improvements from the dirty branch.