### PR TITLE
Fix ansible-lint violations

### DIFF
--- a/.ansible-lint.yaml
+++ b/.ansible-lint.yaml
@@ -15,6 +15,7 @@
 skip_list: []
 exclude_paths:
   - "roles/legacy_*/**"                 # All legacy roles, being migrated to Nix home-manager (relative to ansible/ dir)
+  - ".ansible/**"                       # Galaxy-installed roles and collections (not our code)
 
 # Custom modules and plugins configuration
 # Note: custom_module_paths and action_plugins are not valid in config file

--- a/ansible/roles/cli/tasks/main.yml
+++ b/ansible/roles/cli/tasks/main.yml
@@ -97,7 +97,7 @@
     - Public
     - Templates
     - Videos
-  register: dir_contents
+  register: cli_dir_contents
   become: true
   become_user: "{{ cli_user | default(ansible_user_id) }}"
   failed_when: false  # Don't fail if directory doesn't exist
@@ -107,7 +107,7 @@
     path: "/home/{{ cli_user | default(ansible_user_id) }}/{{ item.item }}"
     state: absent
   when: item.matched == 0  # Directory exists but is empty
-  loop: "{{ dir_contents.results }}"
+  loop: "{{ cli_dir_contents.results }}"
   become: true
   become_user: "{{ cli_user | default(ansible_user_id) }}"
   failed_when:

--- a/ansible/roles/grocy/tasks/enabled.yml
+++ b/ansible/roles/grocy/tasks/enabled.yml
@@ -58,7 +58,7 @@
 
 - name: Start Grocy Docker container
   community.docker.docker_container:
-    container_default_behavior: false_defaults
+    container_default_behavior: no_defaults
     detach: true
     init: false
     interactive: false


### PR DESCRIPTION
Fixed two ansible-lint violations in our roles:
- var-naming[no-role-prefix]: Renamed 'dir_contents' to 'cli_dir_contents' in roles/cli/tasks/main.yml to follow role variable naming convention
- args[module]: Changed 'container_default_behavior' from invalid 'false_defaults' to 'no_defaults' in roles/grocy/tasks/enabled.yml

Also excluded .ansible/ directory from ansible-lint to avoid linting third-party Galaxy-installed roles and collections.

ansible-lint now passes with 0 failures, 0 warnings.