### PR TITLE
Review metrics defined in adgn directory

### DIFF
--- a/adgn/src/adgn/props/cli_app/main.py
+++ b/adgn/src/adgn/props/cli_app/main.py
@@ -430,7 +430,7 @@ async def prompt_optimize(
             sum_unk = sum(int(x.get("unknown", 0) or 0) for x in data)
             recs = []
             for x in data:
-                val = x.get("fuzzy_recall") if x.get("fuzzy_recall") is not None else x.get("recall")
+                val = x.get("recall")
                 if isinstance(val, int | float):
                     recs.append(float(val))
             mean_recall = (sum(recs) / len(recs)) if recs else 0.0

--- a/adgn/src/adgn/props/grade_runner.py
+++ b/adgn/src/adgn/props/grade_runner.py
@@ -28,8 +28,6 @@ def _metrics_row(grade: GradeSubmitPayload, *, specimen: str | None = None) -> d
     row: dict[str, Any] = m.model_dump()
     if specimen is not None:
         row["specimen"] = specimen
-    row["fuzzy_precision"] = m.precision
-    row["fuzzy_recall"] = m.recall
     return row
 
 

--- a/adgn/src/adgn/props/prompt_eval/server.py
+++ b/adgn/src/adgn/props/prompt_eval/server.py
@@ -62,8 +62,6 @@ class MetricsRow(BaseModel):
     false_negatives: int
     precision: float
     recall: float
-    fuzzy_precision: float
-    fuzzy_recall: float
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
These fields were duplicates of precision/recall added for backwards compatibility with old results.json files. Since they're no longer needed:

- Removed fuzzy_precision and fuzzy_recall from MetricsRow in prompt_eval/server.py
- Removed the lines in grade_runner._metrics_row() that added them
- Simplified cli_app/main.py to read recall directly instead of falling back from fuzzy_recall