### PR TITLE
Fix difftree GitHub CI step

### DIFF
--- a/difftree/tests/test_tree.py
+++ b/difftree/tests/test_tree.py
@@ -29,7 +29,7 @@ def test_build_tree_single_file():
     assert "test.py" in root.children
 
     test_file = root.children["test.py"]
-    assert test_file == TreeNode(name="test.py", is_file=True, additions=10, deletions=5)
+    assert test_file == TreeNode(name="test.py", is_file=True, additions=10, deletions=5, path="test.py")
 
 
 def test_build_tree_nested_files(sample_changes: list[FileChange]):


### PR DESCRIPTION
The TreeNode dataclass has a path attribute that gets populated during tree building. Update the test to include the expected path value in the comparison.