### PR TITLE
Verify Claude session hook and dev environments

### DIFF
--- a/.claude/claude-code-web/nix.conf
+++ b/.claude/claude-code-web/nix.conf
@@ -3,3 +3,8 @@ experimental-features = nix-command flakes
 sandbox = false
 # Disable local builds - gVisor PTY bug breaks Nix build sandbox (see session-start-direnv.sh)
 max-jobs = 0
+# Override system features to match what binary caches expect (empty set)
+system-features =
+# Add devenv cachix for prebuilt binaries (required since we can't build locally)
+substituters = https://cache.nixos.org https://devenv.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=

--- a/.claude/session-start-direnv.sh
+++ b/.claude/session-start-direnv.sh
@@ -72,9 +72,15 @@ NIX_BIN=$(ls -d /nix/store/*-nix-[0-9]*/bin 2>/dev/null | head -1)
 [ -d "$NIX_BIN" ] && export PATH="$NIX_BIN:$PATH"
 [ -d ~/.nix-profile/bin ] && export PATH="$HOME/.nix-profile/bin:$PATH"
 
-# Install direnv via nix
+# Install direnv, devenv, and uv via nix (using nixpkgs for better cache coverage)
 if ! command -v direnv &> /dev/null; then
     nix profile install nixpkgs#direnv 2>&1 | tail -3 >&2 || true
+fi
+if ! command -v devenv &> /dev/null; then
+    nix profile install nixpkgs#devenv 2>&1 | tail -3 >&2 || true
+fi
+if ! command -v uv &> /dev/null; then
+    nix profile install nixpkgs#uv 2>&1 | tail -3 >&2 || true
 fi
 
 # Allow .envrc files
@@ -83,15 +89,24 @@ find . -name ".envrc" -type f 2>/dev/null | while read f; do
     direnv allow "$(dirname "$f")" 2>/dev/null || true
 done
 
-# Output hooks for bash (NIX_BIN was set earlier)
-cat << EOF
-# Nix
+# Persist environment variables for subsequent Claude Bash tool calls
+# CLAUDE_ENV_FILE is sourced before each bash command
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+    cat >> "$CLAUDE_ENV_FILE" << EOF
+# Nix environment (added by session-start-direnv.sh)
 export NIX_USER_CONF_FILES="$NIX_CONF"
 [ -d "$NIX_BIN" ] && export PATH="$NIX_BIN:\$PATH"
 [ -d ~/.nix-profile/bin ] && export PATH="\$HOME/.nix-profile/bin:\$PATH"
-
-# direnv
-command -v direnv &>/dev/null && eval "\$(direnv hook bash)"
 EOF
+    echo "Wrote environment to CLAUDE_ENV_FILE" >&2
+fi
 
-echo "Setup complete: nix=$(nix --version 2>/dev/null || echo 'N/A'), direnv=$(direnv version 2>/dev/null || echo 'N/A')" >&2
+# Output context for Claude (informational - not executed)
+echo "Session environment initialized:"
+echo "  nix: $(nix --version 2>/dev/null || echo 'N/A')"
+echo "  direnv: $(direnv version 2>/dev/null || echo 'N/A')"
+echo "  devenv: $(devenv version 2>/dev/null || echo 'N/A')"
+echo "  uv: $(uv --version 2>/dev/null || echo 'N/A')"
+echo "PATH includes: ~/.nix-profile/bin, $NIX_BIN"
+
+echo "Setup complete" >&2


### PR DESCRIPTION
- Add devenv.cachix.org substituter and system-features override to nix.conf to allow fetching prebuilt binaries
- Install devenv and uv in addition to direnv
- Use nixpkgs#devenv instead of github:cachix/devenv/latest for better binary cache coverage
- Write environment variables to CLAUDE_ENV_FILE for persistence across bash commands (stdout is context-only, not executed)
- Output structured version info for Claude context