### PR TITLE
Add uv installation to GitHub precommit setup

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Python Environment"
-description: "Set up Python 3.13"
+description: "Set up Python 3.13 with uv"
 
 runs:
   using: composite
@@ -8,3 +8,6 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
Install uv via astral-sh/setup-uv in the setup-python-env composite action, making it available for pre-commit and other CI jobs.