### PR TITLE
Add visual regression test artifacts to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,19 +224,56 @@ jobs:
             bazel-${{ runner.os }}-
 
       - name: Run visual regression tests
+        id: visual_test
+        continue-on-error: true
         run: |
           # Chromium is provided hermetically by rules_playwright
           bazel test //props/frontend:visual_test --test_output=errors
+
+      - name: Extract visual regression artifacts
+        if: always()
+        run: |
+          # Bazel stores undeclared test outputs in a zip file
+          OUTPUT_ZIP="bazel-testlogs/props/frontend/visual_test/test.outputs/outputs.zip"
+          ARTIFACT_DIR="visual-regression-artifacts"
+
+          mkdir -p "$ARTIFACT_DIR"
+
+          if [ -f "$OUTPUT_ZIP" ]; then
+            echo "Extracting test outputs from $OUTPUT_ZIP"
+            unzip -o "$OUTPUT_ZIP" -d "$ARTIFACT_DIR"
+            echo "Extracted files:"
+            ls -la "$ARTIFACT_DIR"
+          else
+            echo "No test outputs found at $OUTPUT_ZIP"
+            # Check if there are any outputs in the test directory
+            find bazel-testlogs -name "*.png" -o -name "outputs.zip" 2>/dev/null || true
+          fi
+
+      - name: Upload visual regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-screenshots
+          path: visual-regression-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Generate test summary
         if: always()
         run: |
           echo "### Visual Regression Results" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ job.status }}" = "success" ]; then
+          if [ "${{ steps.visual_test.outcome }}" = "success" ]; then
             echo "✅ All visual tests passed" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Visual regression tests failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "📦 Screenshots and diffs are available in the workflow artifacts" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Fail if visual tests failed
+        if: steps.visual_test.outcome == 'failure'
+        run: exit 1
 
   bazel-build:
     name: Bazel build and test

--- a/props/frontend/tests/visual-regression.spec.js
+++ b/props/frontend/tests/visual-regression.spec.js
@@ -13,6 +13,11 @@ const __dirname = dirname(__filename);
 // Update mode: set UPDATE_BASELINES=1 to overwrite existing baselines
 const UPDATE_BASELINES = process.env.UPDATE_BASELINES === '1';
 
+// Output directory for test artifacts (diffs, actual screenshots)
+// Use TEST_UNDECLARED_OUTPUTS_DIR for Bazel tests (preserved after test completion)
+// Fall back to local diffs/ directory for manual runs
+const OUTPUT_DIR = process.env.TEST_UNDECLARED_OUTPUTS_DIR || join(__dirname, 'diffs');
+
 // Component scenarios to test (mirrors harness.ts)
 const scenarios = [
   { component: 'BackButton', scenario: 'Default' },
@@ -77,10 +82,9 @@ function compareBaseline(name, screenshot) {
   // Use same naming convention as Playwright for compatibility with existing baselines
   const baselineDir = join(__dirname, 'visual-regression.spec.ts-snapshots');
   const baselinePath = join(baselineDir, `${name}-chromium-linux.png`);
-  const diffDir = join(__dirname, 'diffs');
 
-  if (!existsSync(diffDir)) {
-    mkdirSync(diffDir, { recursive: true });
+  if (!existsSync(OUTPUT_DIR)) {
+    mkdirSync(OUTPUT_DIR, { recursive: true });
   }
 
   // Update mode: always overwrite baselines
@@ -109,7 +113,7 @@ function compareBaseline(name, screenshot) {
     console.error(
       `  ✗ Dimensions differ: baseline=${baseline.width}x${baseline.height}, actual=${actual.width}x${actual.height}`
     );
-    writeFileSync(join(diffDir, `${name}-actual.png`), screenshot);
+    writeFileSync(join(OUTPUT_DIR, `${name}-actual.png`), screenshot);
     return { passed: false, reason: 'dimensions' };
   }
 
@@ -119,8 +123,8 @@ function compareBaseline(name, screenshot) {
   });
 
   if (numDiffPixels > 0) {
-    writeFileSync(join(diffDir, `${name}-actual.png`), screenshot);
-    writeFileSync(join(diffDir, `${name}-diff.png`), PNG.sync.write(diff));
+    writeFileSync(join(OUTPUT_DIR, `${name}-actual.png`), screenshot);
+    writeFileSync(join(OUTPUT_DIR, `${name}-diff.png`), PNG.sync.write(diff));
     console.error(`  ✗ ${numDiffPixels} pixels differ`);
     return { passed: false, reason: 'pixels', diffCount: numDiffPixels };
   }


### PR DESCRIPTION
When visual regression tests fail, the actual screenshots and diff images are now uploaded as GitHub Actions artifacts, making it easier to debug visual differences.

Changes:
- Use TEST_UNDECLARED_OUTPUTS_DIR in test script so Bazel preserves output files
- Extract and upload test outputs as artifacts on test completion
- Keep workflow failure status while still uploading artifacts