### PR TITLE
Claude Code Session Setup

### DIFF
--- a/claude_web_hooks/session_start.py
+++ b/claude_web_hooks/session_start.py
@@ -276,7 +276,6 @@ def main() -> int:
 
     if os.environ.get("CLAUDE_CODE_REMOTE") != "true":
         log.info("Not remote environment, skipping setup")
-        emit_session_context(had_warnings=False, had_errors=False)
         return 0
 
     # Full environment dump goes to file only (too verbose for stdout)


### PR DESCRIPTION
The session start hook was printing "Claude Code on the web (gVisor sandbox)" and web environment constraints even when CLAUDE_CODE_REMOTE != "true". This was confusing when running Claude Code locally.