### PR TITLE
Split lint and typecheck GitHub workflows

### DIFF
--- a/.github/workflows/bazel-typecheck.yml
+++ b/.github/workflows/bazel-typecheck.yml
@@ -1,15 +1,14 @@
-# Bazel lint reusable workflow
+# Bazel typecheck reusable workflow
 #
-# Runs linting via Bazel aspects:
-# - Python: ruff
-# - JS/TS: ESLint
-name: Bazel Lint
+# Runs type checking via Bazel aspects:
+# - Python: mypy
+name: Bazel Typecheck
 
 on:
   workflow_call:
     inputs:
       targets:
-        description: "Bazel targets to lint (default: //...)"
+        description: "Bazel targets to typecheck (default: //...)"
         required: false
         type: string
         default: "//..."
@@ -21,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       targets:
-        description: "Bazel targets to lint (default: //...)"
+        description: "Bazel targets to typecheck (default: //...)"
         required: false
         type: string
         default: "//..."
@@ -32,8 +31,8 @@ on:
         default: false
 
 jobs:
-  lint:
-    name: Lint
+  typecheck:
+    name: Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -61,22 +60,25 @@ jobs:
           path: |
             ~/.cache/bazel
             ~/.cache/bazelisk
-          key: bazel-${{ runner.os }}-lint-${{ hashFiles('MODULE.bazel', 'requirements_bazel.txt') }}
+          key: bazel-${{ runner.os }}-typecheck-${{ hashFiles('MODULE.bazel', 'requirements_bazel.txt') }}
           restore-keys: bazel-${{ runner.os }}-
 
-      - name: Lint
+      - name: Typecheck
         run: |
           PROFILE_FLAG=""
           if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
             PROFILE_FLAG="--config=ci-profile"
           fi
-          bazel build --keep_going --config=lint $PROFILE_FLAG ${{ inputs.targets }}
+          # Use local strategy for mypy to avoid sandbox copying (saves ~50% disk)
+          # mypy_runner.py copies upstream caches via shutil.copy(), not symlinks
+          # With sandbox, this happens twice: once by Bazel, once by mypy_runner
+          bazel build --keep_going --config=typecheck --strategy=mypy=local $PROFILE_FLAG ${{ inputs.targets }}
 
       - name: Upload Bazel profile
         if: inputs.enable_profiling && always()
         uses: actions/upload-artifact@v4
         with:
-          name: bazel-profile-lint-${{ github.run_id }}
+          name: bazel-profile-typecheck-${{ github.run_id }}
           path: |
             bazel-profile.gz
             execution-log.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@
 # Jobs (defined in separate files):
 # - pre-commit: Safety checks + Bazel aspects (lint, typecheck, format)
 # - bazel-build: Build all targets
-# - bazel-lint: Comprehensive linting (Python ruff + mypy, JS/TS eslint)
+# - bazel-lint: Linting (Python ruff, JS/TS eslint)
+# - bazel-typecheck: Type checking (Python mypy)
 # - bazel-test: Run all tests (excludes e2e tests requiring Docker infra)
 # - props-e2e-test: Props e2e tests (requires Docker registry, proxy, postgres)
 # - editor-e2e-test: Editor agent e2e tests (requires Docker)
@@ -12,7 +13,7 @@
 # - ansible-lint-full: Ansible validation
 # - nix-flake-check: Verify NixOS and home-manager configurations evaluate
 #
-# Linting via Bazel aspects (run in both pre-commit and bazel-lint):
+# Linting via Bazel aspects (run in pre-commit, bazel-lint, and bazel-typecheck):
 # - Python: ruff (lint), mypy (types), ruff format (formatting)
 # - JS/TS: ESLint (lint), prettier (formatting)
 # - Rust: clippy (lint), rustfmt (formatting)
@@ -121,6 +122,14 @@ jobs:
     needs: compute-targets
     if: needs.compute-targets.outputs.has_bazel_changes == 'true'
     uses: ./.github/workflows/bazel-lint.yml
+    with:
+      targets: ${{ needs.compute-targets.outputs.bazel_targets }}
+      enable_profiling: ${{ inputs.enable_profiling || false }}
+
+  bazel-typecheck:
+    needs: compute-targets
+    if: needs.compute-targets.outputs.has_bazel_changes == 'true'
+    uses: ./.github/workflows/bazel-typecheck.yml
     with:
       targets: ${{ needs.compute-targets.outputs.bazel_targets }}
       enable_profiling: ${{ inputs.enable_profiling || false }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@
 # - ansible-lint-full: Ansible validation
 # - nix-flake-check: Verify NixOS and home-manager configurations evaluate
 #
-# Linting via Bazel aspects (run in pre-commit, bazel-lint, and bazel-typecheck):
-# - Python: ruff (lint), mypy (types), ruff format (formatting)
+# Static analysis via Bazel aspects:
+# - Python: ruff (lint and formatting), mypy (types)
 # - JS/TS: ESLint (lint), prettier (formatting)
 # - Rust: clippy (lint), rustfmt (formatting)
 # - Shell: shfmt (formatting)


### PR DESCRIPTION
Separates the bazel-lint workflow into two focused workflows:
- bazel-lint.yml: runs ruff (Python) and ESLint (JS/TS)
- bazel-typecheck.yml: runs mypy (Python type checking)

This allows lint and typecheck jobs to run in parallel in CI, providing faster feedback and clearer failure attribution.