### PR TITLE
Split Rust lint into separate CI workflow

### DIFF
--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -1,0 +1,92 @@
+# Bazel Rust lint reusable workflow
+#
+# Runs Rust linting via Bazel aspects:
+# - Rust: clippy
+name: Bazel Rust Lint
+
+on:
+  workflow_call:
+    inputs:
+      targets:
+        description: "Bazel targets to lint (default: //finance/...)"
+        required: false
+        type: string
+        default: "//finance/..."
+      enable_profiling:
+        description: "Enable Bazel profiling (generates downloadable artifacts)"
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: "Bazel targets to lint (default: //finance/...)"
+        required: false
+        type: string
+        default: "//finance/..."
+      enable_profiling:
+        description: "Enable Bazel profiling (generates downloadable artifacts)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  rust-lint:
+    name: Rust Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Restore Bazel cache
+        id: cache-bazel-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: bazel-${{ runner.os }}-rust-lint-${{ hashFiles('MODULE.bazel', 'Cargo.toml', 'Cargo.lock') }}
+          restore-keys: bazel-${{ runner.os }}-
+
+      - name: Rust lint
+        run: |
+          PROFILE_FLAG=""
+          if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
+            PROFILE_FLAG="--config=ci-profile"
+          fi
+          bazel build --keep_going --config=rust-check $PROFILE_FLAG ${{ inputs.targets }}
+
+      - name: Upload Bazel profile
+        if: inputs.enable_profiling && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-profile-rust-lint-${{ github.run_id }}
+          path: |
+            bazel-profile.gz
+            execution-log.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Save Bazel cache
+        if: always() && steps.cache-bazel-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: ${{ steps.cache-bazel-restore.outputs.cache-primary-key }}

--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -1,6 +1,6 @@
 # Bazel test reusable workflow
 #
-# Runs all Bazel tests and Rust clippy
+# Runs all Bazel tests
 name: Bazel Test
 
 on:
@@ -203,10 +203,6 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo ":package: Logs available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
           fi
-
-      # Rust lint (separate because finance/ is optional)
-      - name: Rust lint
-        run: bazel build --keep_going --config=rust-check //finance/... || true
 
       - name: Save Bazel cache
         if: always() && steps.cache-bazel-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@
 # - bazel-build: Build all targets
 # - bazel-lint: Linting (Python ruff, JS/TS eslint)
 # - bazel-typecheck: Type checking (Python mypy)
+# - bazel-rust-lint: Rust linting (clippy)
 # - bazel-test: Run all tests (excludes e2e tests requiring Docker infra)
 # - props-e2e-test: Props e2e tests (requires Docker registry, proxy, postgres)
 # - editor-e2e-test: Editor agent e2e tests (requires Docker)
@@ -132,6 +133,15 @@ jobs:
     uses: ./.github/workflows/bazel-typecheck.yml
     with:
       targets: ${{ needs.compute-targets.outputs.bazel_targets }}
+      enable_profiling: ${{ inputs.enable_profiling || false }}
+
+  bazel-rust-lint:
+    needs: compute-targets
+    if: |
+      needs.compute-targets.outputs.has_bazel_changes == 'true' &&
+      contains(needs.compute-targets.outputs.bazel_targets, '//finance/')
+    uses: ./.github/workflows/bazel-rust-lint.yml
+    with:
       enable_profiling: ${{ inputs.enable_profiling || false }}
 
   bazel-test:


### PR DESCRIPTION
Extract Rust clippy linting from bazel-test.yml into a dedicated bazel-rust-lint.yml workflow. Runs conditionally only when finance/ targets are affected.