### PR TITLE
Configure rules_mypy types extension for automatic stub handling

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -148,6 +148,31 @@ pip.parse(
 )
 use_repo(pip, "pypi", "pypi_homeassistant")
 
+# Type stubs for mypy - extracts types-* and *-stubs packages from requirements
+# and provides them to the mypy aspect for per-target stub inclusion.
+types = use_extension("@rules_mypy//mypy:types.bzl", "types")
+types.requirements(
+    name = "pip_types",
+    # Exclusions:
+    # - sqlalchemy-stubs, types-sqlalchemy: SQLAlchemy 2.0+ has inline types via
+    #   the [mypy] extra, so external stubs conflict and cause duplicate keys.
+    # - types-paramiko: transitive dep but paramiko isn't in pypi hub
+    # - types-psycopg2: we use psycopg2-binary, not psycopg2
+    # - types-toml: we use tomli, not toml
+    # - types-jinja2: jinja2 has py.typed; stubs have broken markupsafe dep
+    exclude_requirements = [
+        "sqlalchemy-stubs",
+        "types-jinja2",
+        "types-paramiko",
+        "types-psycopg2",
+        "types-sqlalchemy",
+        "types-toml",
+    ],
+    pip_requirements = "@pypi//:requirements.bzl",
+    requirements_txt = "//:requirements_bazel.txt",
+)
+use_repo(types, "pip_types")
+
 # uv toolchain for requirements locking
 uv = use_extension("@rules_python//python/uv:uv.bzl", "uv")
 uv.configure(version = "0.6.2")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -10,8 +10,6 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
-    "https://bcr.bazel.build/modules/ape/1.0.1/MODULE.bazel": "37411cfd13bfc28cd264674d660a3ecb3b5b35b9dbe4c0b2be098683641b3fee",
-    "https://bcr.bazel.build/modules/ape/1.0.1/source.json": "96bc5909d1e3ccc4203272815ef874dbfd99651e240c05049f12193d16c1110b",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/source.json": "cf725267cbacc5f028ef13bb77e7f2c2e0066923a4dab1025e4a0511b1ed258a",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
@@ -2194,6 +2192,40 @@
             "rules_kotlin~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_mypy~//mypy:types.bzl%types": {
+      "general": {
+        "bzlTransitiveDigest": "NRCQLKlh6DMNV8O7wtrrgFwoxCrepDJ64vJWgl4xKIo=",
+        "usagesDigest": "hno7vBHbl3mQo2rOAv8715vx2/irXtCEdy5yXyBoB+A=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pip_types": {
+            "bzlFile": "@@rules_mypy~//mypy/private:types.bzl",
+            "ruleClassName": "generate",
+            "attributes": {
+              "pip_requirements": "@@rules_python~~pip~pypi//:requirements.bzl",
+              "requirements_txt": "@@//:requirements_bazel.txt",
+              "exclude_requirements": [
+                "sqlalchemy-stubs",
+                "types-jinja2",
+                "types-paramiko",
+                "types-psycopg2",
+                "types-sqlalchemy",
+                "types-toml"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "pypi",
+            "rules_python~~pip~pypi"
           ]
         ]
       }

--- a/mcp_infra/BUILD.bazel
+++ b/mcp_infra/BUILD.bazel
@@ -58,8 +58,11 @@ py_library(
 py_test(
     name = "test_types",
     srcs = ["test_types.py"],
-    main = "test_types.py",
-    deps = [":test_support"],
+    deps = [
+        ":test_support",
+        "@pypi//pydantic",  # imports TypeAdapter, ValidationError
+        "@pypi//pytest",  # imports pytest
+    ],
 )
 
 ruff_test(

--- a/mcp_infra/display/BUILD.bazel
+++ b/mcp_infra/display/BUILD.bazel
@@ -17,6 +17,7 @@ py_library(
         "//mcp_infra/exec",
         "//openai_utils",
         "@pypi//compact_json",
+        "@pypi//fastmcp",  # event_renderer.py, rich_display.py
         "@pypi//mcp",
         "@pypi//pydantic",
         "@pypi//rich",

--- a/mcp_infra/resources/BUILD.bazel
+++ b/mcp_infra/resources/BUILD.bazel
@@ -10,6 +10,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//mcp_infra",
+        "@pypi//mcp",  # types.py imports mcp.types
         "@pypi//pydantic",
     ],
 )

--- a/mcp_infra/seatbelt/BUILD.bazel
+++ b/mcp_infra/seatbelt/BUILD.bazel
@@ -35,5 +35,6 @@ py_test(
     deps = [
         ":seatbelt",
         "//mcp_infra:test_support",
+        "@pypi//pytest",  # test files import pytest directly
     ],
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -11,9 +11,13 @@ package(default_visibility = ["//visibility:public"])
 # This reduces disk usage from O(n²) to O(n) for the mypy cache merge step.
 # See mypy_runner.py for details on the patch.
 #
-# deps includes mypy plugins:
+# deps includes mypy and its plugins:
 #   - pydantic: understands Field aliases, model validation
 #   - sqlalchemy: ORM type inference for mapped columns
+#
+# Type stubs and packages with py.typed are provided by:
+# 1. The types extension (@pip_types) for types-*/stubs packages
+# 2. The target's deps for packages with py.typed (via MYPYPATH from aspect)
 py_binary(
     name = "mypy_cli",
     srcs = ["mypy_runner.py"],
@@ -21,40 +25,8 @@ py_binary(
     python_version = "3.13",
     deps = [
         "@pypi//mypy",
-        # Mypy plugins
         "@pypi//pydantic",  # pydantic.mypy plugin
         "@pypi//sqlalchemy",  # sqlalchemy.ext.mypy.plugin
-        # Packages with inline stubs (py.typed)
-        "@pypi//click",
-        "@pypi//pytest",
-        "@pypi//httpx",
-        "@pypi//humanize",
-        "@pypi//platformdirs",
-        "@pypi//pyyaml",
-        "@pypi//tomli",
-        "@pypi//tomli_w",
-        "@pypi//openai",
-        "@pypi//anthropic",
-        "@pypi//anyio",
-        "@pypi//rich",
-        "@pypi//typer",
-        "@pypi//structlog",
-        "@pypi//requests",
-        "@pypi//fastapi",
-        "@pypi//uvicorn",
-        "@pypi//tenacity",
-        "@pypi//jinja2",
-        "@pypi//markdown",
-        "@pypi//markdownify",
-        "@pypi//mcp",
-        "@pypi//fastmcp",
-        "@pypi//ruff",
-        "@pypi//pygit2",
-        "@pypi//pytimeparse",
-        # Type stubs for packages without inline types
-        "@pypi//types_colorama",
-        "@pypi//types_markdown",
-        "@pypi//types_pyyaml",
     ],
 )
 

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -3,6 +3,7 @@
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
+load("@pip_types//:types.bzl", "types")
 load("@rules_mypy//mypy:mypy.bzl", "mypy")
 
 # Ruff aspect for --config=lint builds
@@ -27,6 +28,7 @@ ruff = lint_ruff_aspect(
 mypy_aspect = mypy(
     mypy_cli = Label("//tools/lint:mypy_cli"),
     mypy_ini = Label("//:mypy.ini"),
+    types = types,
 )
 
 # ESLint aspect for JS/TS linting


### PR DESCRIPTION
Add types.requirements() extension to MODULE.bazel which extracts types-* and *-stubs packages from requirements and provides them to the mypy aspect automatically. This removes the need to manually list type stub packages in mypy_cli deps.

Exclusions for packages that conflict or don't have matching base packages in the pip hub:
- sqlalchemy-stubs, types-sqlalchemy: SQLAlchemy 2.0+ has inline types
- types-paramiko: paramiko not in pip hub
- types-psycopg2: we use psycopg2-binary
- types-toml: we use tomli
- types-jinja2: jinja2 has py.typed

Also fixes several BUILD files where targets depended on packages transitively instead of directly listing imports:
- mcp_infra/resources: add @pypi//mcp
- mcp_infra/display: add @pypi//fastmcp
- mcp_infra/BUILD.bazel: add pytest, pydantic to test_types
- mcp_infra/seatbelt: add @pypi//pytest to test