### PR TITLE
Run component tests and plan fixes

### DIFF
--- a/agent_core/test_mcp_integration.py
+++ b/agent_core/test_mcp_integration.py
@@ -23,6 +23,7 @@ async def test_agent_mcp_echo_basic(mcp_tool_provider_echo, test_handlers, recor
     def mock(m: EchoMock):
         yield
         yield from m.echo_roundtrip("hello")
+        yield m.assistant_text("done")
 
     agent = await Agent.create(
         tool_provider=mcp_tool_provider_echo,

--- a/agent_core/test_message_processing.py
+++ b/agent_core/test_message_processing.py
@@ -35,27 +35,30 @@ async def test_process_message_fires_system_text_event(noop_agent, recording_han
     """Test that process_message fires on_system_text_event for SystemMessage."""
     noop_agent.process_message(SystemMessage.text("System prompt content"))
 
-    assert len(recording_handler.text_events) == 1
-    assert isinstance(recording_handler.text_events[0], SystemText)
-    assert recording_handler.text_events[0].text == "System prompt content"
+    text_events = [r for r in recording_handler.records if isinstance(r, SystemText | UserText | AssistantText)]
+    assert len(text_events) == 1
+    assert isinstance(text_events[0], SystemText)
+    assert text_events[0].text == "System prompt content"
 
 
 async def test_process_message_fires_user_text_event(noop_agent, recording_handler) -> None:
     """Test that process_message fires on_user_text_event for UserMessage."""
     noop_agent.process_message(UserMessage.text("User says hello"))
 
-    assert len(recording_handler.text_events) == 1
-    assert isinstance(recording_handler.text_events[0], UserText)
-    assert recording_handler.text_events[0].text == "User says hello"
+    text_events = [r for r in recording_handler.records if isinstance(r, SystemText | UserText | AssistantText)]
+    assert len(text_events) == 1
+    assert isinstance(text_events[0], UserText)
+    assert text_events[0].text == "User says hello"
 
 
 async def test_process_message_fires_assistant_text_event(noop_agent, recording_handler) -> None:
     """Test that process_message fires on_assistant_text_event for AssistantMessage."""
     noop_agent.process_message(AssistantMessage.text("Assistant response"))
 
-    assert len(recording_handler.text_events) == 1
-    assert isinstance(recording_handler.text_events[0], AssistantText)
-    assert recording_handler.text_events[0].text == "Assistant response"
+    text_events = [r for r in recording_handler.records if isinstance(r, SystemText | UserText | AssistantText)]
+    assert len(text_events) == 1
+    assert isinstance(text_events[0], AssistantText)
+    assert text_events[0].text == "Assistant response"
 
 
 async def test_process_message_adds_to_transcript(noop_agent, recording_handler) -> None:
@@ -67,7 +70,8 @@ async def test_process_message_adds_to_transcript(noop_agent, recording_handler)
     assert isinstance(noop_agent._transcript[0], SystemMessage)
     assert isinstance(noop_agent._transcript[1], UserMessage)
     # Both should have fired events
-    assert len(recording_handler.text_events) == 2
+    text_events = [r for r in recording_handler.records if isinstance(r, SystemText | UserText | AssistantText)]
+    assert len(text_events) == 2
 
 
 # --- Message forwarding tests ---

--- a/agent_core/test_message_processing.py
+++ b/agent_core/test_message_processing.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 import pytest_bazel
-from hamcrest import assert_that, has_item, has_properties, instance_of, not_
+from hamcrest import all_of, assert_that, has_item, has_properties, instance_of, not_
 
 from agent_core.agent import Agent
 from agent_core.compaction import CompactionHandler
@@ -200,7 +200,9 @@ async def test_reasoning_threading_filters_reasoning_from_next_input(mcp_tool_pr
         turn2_input = list(req2.input or [])
         assert_that(turn2_input, has_item(has_properties(id="rs_turn1")))
         assert_that(turn2_input, has_item(has_properties(call_id="call_1", id="fc_id_1", status="completed")))
-        assert_that(turn2_input, has_item(instance_of(FunctionCallOutputItem) & has_properties(call_id="call_1")))
+        assert_that(
+            turn2_input, has_item(all_of(instance_of(FunctionCallOutputItem), has_properties(call_id="call_1")))
+        )
 
         # Turn 3: should include both turns' sequences
         req3 = yield [m.make_item_reasoning(id="rs_turn2"), fc2]
@@ -208,11 +210,15 @@ async def test_reasoning_threading_filters_reasoning_from_next_input(mcp_tool_pr
         # Turn 1's sequence still intact
         assert_that(turn3_input, has_item(has_properties(id="rs_turn1")))
         assert_that(turn3_input, has_item(has_properties(call_id="call_1", id="fc_id_1")))
-        assert_that(turn3_input, has_item(instance_of(FunctionCallOutputItem) & has_properties(call_id="call_1")))
+        assert_that(
+            turn3_input, has_item(all_of(instance_of(FunctionCallOutputItem), has_properties(call_id="call_1")))
+        )
         # Turn 2's sequence
         assert_that(turn3_input, has_item(has_properties(id="rs_turn2")))
         assert_that(turn3_input, has_item(has_properties(call_id="call_2", id="fc_id_2", status="in_progress")))
-        assert_that(turn3_input, has_item(instance_of(FunctionCallOutputItem) & has_properties(call_id="call_2")))
+        assert_that(
+            turn3_input, has_item(all_of(instance_of(FunctionCallOutputItem), has_properties(call_id="call_2")))
+        )
 
         yield m.assistant_text("done")
 

--- a/agent_core/test_tool_execution.py
+++ b/agent_core/test_tool_execution.py
@@ -499,10 +499,10 @@ async def test_agent_compositor_flat_tools_request_schema(compositor, mcp_tool_p
         print(json.dumps(req.model_dump(exclude_none=True), indent=2))
 
         yield m.mcp_tool_call(mounted_a.prefix, TOOL_A_NAME, ToolAInput(param_x=10, param_y=20))
-        yield m.assistant_text("The result is 30.")
+        # Phase 1 ends with assistant text; capture Phase 2's initial request
+        req = yield m.assistant_text("The result is 30.")
 
-        # Phase 2: both servers mounted
-        req = yield
+        # Phase 2: both servers mounted (req already contains the request)
         assert req.tools is not None
         assert {"mcp_a_tool_a", "mcp_b_tool_b"} <= {t.name for t in req.tools}
         print("\nPHASE 2 REQUEST (mcp_a + mcp_b):")

--- a/agent_server/mcp_bridge/BUILD.bazel
+++ b/agent_server/mcp_bridge/BUILD.bazel
@@ -30,6 +30,7 @@ py_library(
 
 _TEST_DEPS = [
     ":mcp_bridge",
+    "//agent_server:conftest",
     "//agent_server/persist",
     "//agent_server/testing",
     "@pypi//fastmcp",

--- a/py_detectors/tests/fixture_utils.py
+++ b/py_detectors/tests/fixture_utils.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from importlib import resources
 from pathlib import Path
+
+# Directories to skip when iterating over fixture resources (contain binary files)
+_SKIP_DIRS = {"__pycache__"}
+
+
+def iter_children(trav: resources.abc.Traversable) -> Iterator[resources.abc.Traversable]:
+    """Iterate over children, skipping __pycache__ and other non-fixture directories."""
+    for child in trav.iterdir():
+        if child.name not in _SKIP_DIRS:
+            yield child
 
 
 def _copy_tree(trav: resources.abc.Traversable, dest: Path) -> None:
@@ -9,8 +20,10 @@ def _copy_tree(trav: resources.abc.Traversable, dest: Path) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(trav.read_text(encoding="utf-8"), encoding="utf-8")
         return
+    if trav.name in _SKIP_DIRS:
+        return
     dest.mkdir(parents=True, exist_ok=True)
-    for child in trav.iterdir():
+    for child in iter_children(trav):
         if child.is_file():
             (dest / child.name).write_text(child.read_text(encoding="utf-8"), encoding="utf-8")
         else:

--- a/py_detectors/tests/fixture_utils.py
+++ b/py_detectors/tests/fixture_utils.py
@@ -4,15 +4,19 @@ from collections.abc import Iterator
 from importlib import resources
 from pathlib import Path
 
-# Directories to skip when iterating over fixture resources (contain binary files)
+# Directories and files to skip when iterating over fixture resources
 _SKIP_DIRS = {"__pycache__"}
+_SKIP_FILES = {"__init__.py"}  # Bazel auto-generates these for package structure
 
 
 def iter_children(trav: resources.abc.Traversable) -> Iterator[resources.abc.Traversable]:
-    """Iterate over children, skipping __pycache__ and other non-fixture directories."""
+    """Iterate over children, skipping __pycache__ and auto-generated __init__.py files."""
     for child in trav.iterdir():
-        if child.name not in _SKIP_DIRS:
-            yield child
+        if child.name in _SKIP_DIRS:
+            continue
+        if child.is_file() and child.name in _SKIP_FILES:
+            continue
+        yield child
 
 
 def _copy_tree(trav: resources.abc.Traversable, dest: Path) -> None:

--- a/py_detectors/tests/test_detectors.py
+++ b/py_detectors/tests/test_detectors.py
@@ -9,7 +9,7 @@ import pytest_bazel
 # Ensure detectors register themselves via module imports
 import py_detectors.__main__  # noqa: F401
 from py_detectors.registry import all_detectors, run_all
-from tests.fixture_utils import copy_fixture
+from tests.fixture_utils import copy_fixture, iter_children
 
 
 def _discover_fixtures(base_package: str) -> list[tuple[str, str]]:
@@ -19,17 +19,11 @@ def _discover_fixtures(base_package: str) -> list[tuple[str, str]]:
     """
     base = resources.files(base_package)
     cases: list[tuple[str, str]] = []
-    for detector_dir in base.iterdir():
+    for detector_dir in iter_children(base):
         if not detector_dir.is_dir():
             continue
         detector_name = detector_dir.name
-        # Skip __pycache__ directories
-        if detector_name == "__pycache__":
-            continue
-        for item in detector_dir.iterdir():
-            # Skip __init__.py and __pycache__ directories
-            if item.name in ("__init__.py", "__pycache__") or item.name.endswith(".pyc"):
-                continue
+        for item in iter_children(detector_dir):
             cases.append((f"{detector_name}/{item.name}", detector_name))
     return sorted(cases)
 

--- a/sysrw/BUILD.bazel
+++ b/sysrw/BUILD.bazel
@@ -28,6 +28,7 @@ py_library(
     data = glob([
         "**/*.j2",
         "js/*.js",
+        "templates/**/*.txt",
     ]),
     imports = [".."],
     visibility = ["//visibility:public"],

--- a/wt/integration/BUILD.bazel
+++ b/wt/integration/BUILD.bazel
@@ -20,6 +20,9 @@ py_test(
         "test_integration_cli_output_format.py",
         "test_integration_shell.py",
     ],
+    data = [
+        "//wt:wt-cli",  # Shell integration tests need the CLI binary
+    ],
     main = "test_integration_cli_daemon.py",
     deps = [
         ":conftest",

--- a/wt/testing/conftest.py
+++ b/wt/testing/conftest.py
@@ -566,30 +566,18 @@ def _find_wt_cli_binary() -> str | None:
 
 
 def _generate_wt_function_for_binary(binary_path: str) -> str:
-    """Generate shell function using a specific binary path."""
+    """Generate shell function using a specific binary path.
+
+    Reads the template from wt/shell/wt.sh and substitutes the binary path,
+    matching how install.main() works but using the Bazel binary instead of python -m.
+    """
+    from importlib import resources
+
     quoted_path = shlex.quote(binary_path)
-    return f"""
-wt() {{
-  local wt_command_file
-  wt_command_file=$(mktemp)
-  trap 'rm -f "$wt_command_file"' EXIT
-
-  {quoted_path} sh "$@" 3>"$wt_command_file"
-  local wt_exit_code=$?
-
-  if [ $wt_exit_code -eq 0 ] || [ $wt_exit_code -eq 2 ]; then
-    if [ -s "$wt_command_file" ]; then
-      local wt_shell_commands="$(cat "$wt_command_file")"
-      if [ -n "$wt_shell_commands" ]; then
-        eval "$wt_shell_commands"
-      fi
-    fi
-  fi
-
-  rm -f "$wt_command_file"
-  return $wt_exit_code
-}}
-"""
+    with resources.files("wt.shell").joinpath("wt.sh").open("r", encoding="utf-8") as f:
+        tpl = f.read()
+    # The template uses __PY__ -m wt.cli sh, replace with direct binary call
+    return tpl.replace("__PY__ -m wt.cli sh", quoted_path + " sh")
 
 
 @pytest.fixture

--- a/wt/testing/conftest.py
+++ b/wt/testing/conftest.py
@@ -1,7 +1,5 @@
-import contextlib
 import importlib
 import importlib.util
-import io
 import json
 import os
 import shlex
@@ -34,7 +32,6 @@ from wt.shared.protocol import (
     StatusResult,
     StatusResultOk,
 )
-from wt.shell import install
 from wt.testing.config_factory import ConfigFactory
 from wt.testing.data import TestData
 from wt.testing.mock_factory import MockFactory, ServiceBuilder
@@ -552,6 +549,49 @@ def _apply_isolated_git_env(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
 
 
+def _find_wt_cli_binary() -> str | None:
+    """Find the Bazel-built wt-cli binary if running under Bazel."""
+    # Check for Bazel runfiles environment
+    runfiles_dir = os.environ.get("RUNFILES_DIR") or os.environ.get("TEST_SRCDIR")
+    if not runfiles_dir:
+        return None
+
+    # Try to find wt-cli in runfiles (it's in the same repo)
+    # The path structure is: runfiles/_main/wt/wt-cli
+    candidate = Path(runfiles_dir) / "_main" / "wt" / "wt-cli"
+    if candidate.exists():
+        return str(candidate)
+
+    return None
+
+
+def _generate_wt_function_for_binary(binary_path: str) -> str:
+    """Generate shell function using a specific binary path."""
+    quoted_path = shlex.quote(binary_path)
+    return f"""
+wt() {{
+  local wt_command_file
+  wt_command_file=$(mktemp)
+  trap 'rm -f "$wt_command_file"' EXIT
+
+  {quoted_path} sh "$@" 3>"$wt_command_file"
+  local wt_exit_code=$?
+
+  if [ $wt_exit_code -eq 0 ] || [ $wt_exit_code -eq 2 ]; then
+    if [ -s "$wt_command_file" ]; then
+      local wt_shell_commands="$(cat "$wt_command_file")"
+      if [ -n "$wt_shell_commands" ]; then
+        eval "$wt_shell_commands"
+      fi
+    fi
+  fi
+
+  rm -f "$wt_command_file"
+  return $wt_exit_code
+}}
+"""
+
+
 @pytest.fixture
 def shell_runner(tmp_path: Path):
     """Factory for running shell commands via the installed wt shell function."""
@@ -563,10 +603,13 @@ def shell_runner(tmp_path: Path):
             # Ensure env is a copy
             env = os.environ.copy() if env is None else env.copy()
 
-            buf = io.StringIO()
-            with contextlib.redirect_stdout(buf):
-                install.main()
-            wt_fn = buf.getvalue()
+            # Find the Bazel-built wt-cli binary - tests require it for proper environment setup
+            wt_cli_path = _find_wt_cli_binary()
+            if not wt_cli_path:
+                raise RuntimeError(
+                    "wt-cli binary not found in runfiles. Ensure //wt:wt-cli is in the test's data dependencies."
+                )
+            wt_fn = _generate_wt_function_for_binary(wt_cli_path)
 
             full_script = f"""#!/bin/bash
 # Install wt function via builtin


### PR DESCRIPTION
- py_detectors: Filter __pycache__ directories from fixture discovery and copying to prevent UnicodeDecodeError when attempting to read binary .pyc files as UTF-8 text
- agent_core: Fix PyHamcrest matcher syntax by replacing unsupported `&` operator with `all_of()` combinator in test_message_processing.py