### PR TITLE
Update Claude hooks to latest version

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v claude-session-start >/dev/null 2>&1 || uv tool install 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-c0d48345/claude_hooks-0.1.0-py3-none-any.whl'; claude-session-start"
+            "command": "command -v claude-session-start >/dev/null 2>&1 || uv tool install 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest-devel/claude_hooks-0.1.0-py3-none-any.whl'; claude-session-start"
           }
         ]
       }


### PR DESCRIPTION
Switch from pinned commit-based release (c0d48345) to the rolling claude-hooks-latest-devel release tag that auto-updates when CI passes on devel branch.