### PR TITLE
Fix Bazel test environment caching issue

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -120,7 +120,8 @@ jobs:
             --nocache_test_results \
             --test_env=CLAUDE_HOOKS_USE_WHEEL=1 \
             --test_env=CI=true \
-            --test_env=JAVA_HOME
+            --test_env=JAVA_HOME \
+            --test_env=PATH
 
       - uses: ./.github/actions/bazel-cache-save
         if: always()

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -472,9 +472,7 @@ async def run_web_mode(hook_input: HookInput) -> None:
         return_exceptions=True,
     )
 
-    # Log failures
-    if isinstance(proxy_result, Exception):
-        logger.warning("Failed to setup proxy: %s", proxy_result)
+    # Log non-critical failures (git, cluster tools, bazelisk, nix, podman)
     if isinstance(git_result, Exception):
         logger.warning("Failed to install git pre-commit: %s", git_result)
     if isinstance(cluster_result, Exception):
@@ -498,7 +496,12 @@ async def run_web_mode(hook_input: HookInput) -> None:
     TIMESTAMP_FILE.write_text(f"{hook_timestamp.isoformat()}\n")
     logger.info("Session start hook timestamp: %s", hook_timestamp.isoformat())
 
-    # Collect environment variables
+    # Proxy setup is required - propagate failure with clear error message
+    if isinstance(proxy_result, Exception):
+        logger.error("Proxy setup failed: %s", proxy_result)
+        raise RuntimeError(f"Proxy setup failed: {proxy_result}") from proxy_result
+
+    # Verify combined CA was created (sanity check - should always exist after successful proxy setup)
     combined_ca = proxy_setup._get_bazel_combined_ca()
     if not combined_ca.exists():
         raise RuntimeError("Combined CA bundle not found - proxy setup incomplete")


### PR DESCRIPTION
The e2e tests were failing with confusing "Combined CA bundle not found" errors when the actual issue was a proxy setup failure. This fix:

1. Propagates proxy setup errors with clear messaging instead of logging them as warnings and then failing with a different error
2. Adds --test_env=PATH to the CI workflow to ensure the wheel's bin directory (with claude-auth-proxy) is available in the test environment

The original code path was:
- Proxy setup fails -> logged as warning
- Code continues -> combined CA doesn't exist
- "Combined CA bundle not found" error raised

Now:
- Proxy setup fails -> actual error is raised with context
- Clear error message shows what actually went wrong