### PR TITLE
Fix session setup

### DIFF
--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -110,7 +110,7 @@ def install_bazelisk() -> Path:
     The wrapper script in ~/.cache/bazel-proxy/bin/bazel will call this.
     Skips download if already installed.
     """
-    bazel_proxy_dir = proxy_setup._get_bazel_proxy_dir()
+    bazel_proxy_dir = paths.get_bazel_proxy_dir()
     bazelisk_path = _get_bazelisk_path()
 
     bazel_proxy_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The install_bazelisk() function was calling proxy_setup._get_bazel_proxy_dir() which doesn't exist. The function is in the paths module as get_bazel_proxy_dir(). This bug prevented bazelisk installation in session start hooks.