### PR TITLE
Verify code session setup and Bazel configuration

### DIFF
--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -23,6 +23,8 @@ class EnvVars:
     repo_root: Path
     combined_ca: Path
     bazel_wrapper_dir: Path
+    bazelisk_path: Path
+    bazel_proxy_rc: Path
 
     # Nix paths
     nix_paths: list[Path]
@@ -58,11 +60,15 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
         exports.append(f'export PATH="{nix_path_str}:$PATH"')
 
     # Bazel proxy configuration
+    local_proxy = f"http://localhost:{vars.proxy_port}"
     exports.extend(
         [
             "",
             "# Bazel proxy configuration",
             f"export BAZEL_PROXY_PORT={vars.proxy_port}",
+            f'export BAZEL_LOCAL_PROXY="{local_proxy}"',
+            f'export BAZELISK_PATH="{vars.bazelisk_path}"',
+            f'export BAZEL_PROXY_BAZELRC="{vars.bazel_proxy_rc}"',
             f'export BAZEL_REPO_ROOT="{vars.repo_root}"',
             f'export NODE_EXTRA_CA_CERTS="{vars.combined_ca}"',
             f'export REQUESTS_CA_BUNDLE="{vars.combined_ca}"',

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -513,6 +513,8 @@ async def run_web_mode(hook_input: HookInput) -> None:
         repo_root=project_dir,
         combined_ca=combined_ca,
         bazel_wrapper_dir=bazelisk_setup._get_wrapper_path().parent,
+        bazelisk_path=bazelisk_setup._get_bazelisk_path(),
+        bazel_proxy_rc=proxy_setup._get_bazel_proxy_rc(),
         nix_paths=nix_paths,
         docker_host=docker_host,
         hook_timestamp=hook_timestamp,


### PR DESCRIPTION
The bazel wrapper requires BAZEL_LOCAL_PROXY, BAZELISK_PATH, and BAZEL_PROXY_BAZELRC environment variables, but these were not being written to CLAUDE_ENV_FILE by the session start hook. This caused the `bazel` wrapper command to fail with MissingEnvVarError.

Add bazelisk_path and bazel_proxy_rc fields to EnvVars dataclass and export them along with BAZEL_LOCAL_PROXY in write_env_file().