### PR TITLE
Test session start hook setup for Bazel and Podman

### DIFF
--- a/tools/claude_hooks/config/podman/containers.conf
+++ b/tools/claude_hooks/config/podman/containers.conf
@@ -2,5 +2,10 @@
 # Host user namespace for gVisor compatibility
 userns = "host"
 
+# gVisor compatibility: bypass /proc/self/setgroups which is unavailable
+# Without this, containers fail with:
+#   "crun: error opening file `/proc/self/setgroups`: No such file or directory"
+annotations = ["run.oci.keep_original_groups=1"]
+
 [engine]
 network_backend = "cni"

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -73,6 +73,7 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
             f'export NODE_EXTRA_CA_CERTS="{vars.combined_ca}"',
             f'export REQUESTS_CA_BUNDLE="{vars.combined_ca}"',
             f'export CURL_CA_BUNDLE="{vars.combined_ca}"',
+            f'export SSL_CERT_FILE="{vars.combined_ca}"',
         ]
     )
 

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -53,19 +53,13 @@ class PodmanSetup:
             Podman is configured with gVisor-specific workarounds.
             Running under supervisor (status: {self.status}). DOCKER_HOST={self.socket_url}
 
-            Required Container Flags
-            ------------------------
-            All containers MUST use `--annotation run.oci.keep_original_groups=1`.
-            This bypasses /proc/self/setgroups which is unavailable in gVisor.
-            Otherwise they will fail with:
-              "crun: error opening file `/proc/self/setgroups`: No such file or directory"
-
             Use fully qualified image names (docker.io/library/...)
 
             Configuration Applied:
             ----------------------
             - VFS storage (/etc/containers/storage.conf)
             - userns = "host"
+            - run.oci.keep_original_groups=1 annotation (auto-applied)
             - --network=host
             """
         )

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -294,11 +294,29 @@ class TestFullSessionStartHook:
         assert result.returncode == 0, f"Hook failed on resume:\nstderr: {result.stderr}"
 
 
+def _is_root() -> bool:
+    """Check if running as root user."""
+    return os.geteuid() == 0
+
+
+def _can_install_podman() -> bool:
+    """Check if podman can be installed or is already available.
+
+    Returns True if:
+    - podman is already installed, OR
+    - apt-get is available (hook will auto-install)
+    """
+    if shutil.which("podman"):
+        return True
+    return bool(shutil.which("apt-get"))
+
+
 class TestPodmanIntegration:
     """E2E tests for podman integration with session start hook.
 
     These tests verify that podman is properly configured and can run containers
-    after the session start hook runs. They require podman to be installed.
+    after the session start hook runs. They require podman to be installed and
+    root access (for writing to /run/podman and /etc/containers).
     """
 
     @pytest.fixture
@@ -346,6 +364,8 @@ class TestPodmanIntegration:
         return env
 
     @pytest.mark.skipif(not shutil.which("keytool"), reason="keytool required")
+    @pytest.mark.skipif(not _is_root(), reason="requires root for /run/podman and /etc/containers")
+    @pytest.mark.skipif(not _can_install_podman(), reason="requires podman or apt-get")
     def test_podman_service_starts(self, isolated_dirs: IsolatedDirs, podman_hook_env: dict[str, str]) -> None:
         """Verify podman service starts after session start hook.
 
@@ -366,6 +386,8 @@ class TestPodmanIntegration:
         assert "unix:///run/podman/podman.sock" in env_content, "DOCKER_HOST not pointing to podman socket"
 
     @pytest.mark.skipif(not shutil.which("keytool"), reason="keytool required")
+    @pytest.mark.skipif(not _is_root(), reason="requires root for /run/podman and /etc/containers")
+    @pytest.mark.skipif(not _can_install_podman(), reason="requires podman or apt-get")
     def test_podman_can_run_container(self, isolated_dirs: IsolatedDirs, podman_hook_env: dict[str, str]) -> None:
         """Verify podman can run a container after session start hook.
 
@@ -377,19 +399,13 @@ class TestPodmanIntegration:
         assert result.returncode == 0, f"Hook failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
 
         # Verify we can run podman hello-world
-        # Use --annotation for gVisor compatibility (documented in hook guidance)
-        podman_result = subprocess.run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "--annotation",
-                "run.oci.keep_original_groups=1",
-                "docker.io/library/hello-world",
-            ],
+        # The gVisor annotation is auto-applied via containers.conf
+        # Run through env file to pick up SSL_CERT_FILE for TLS proxy CA
+        podman_result = shell_helpers.run_with_env_file(
+            command="podman run --rm docker.io/library/hello-world",
+            env_file=isolated_dirs.env_file,
+            cwd=isolated_dirs.project,
             check=False,
-            capture_output=True,
-            text=True,
             timeout=120,
             env=podman_hook_env,
         )


### PR DESCRIPTION
Changes:
- Add skipif decorators for root and podman availability checks to properly skip tests in non-root CI environment
- Export SSL_CERT_FILE in env_file.py for Go-based tools (podman) that need the CA bundle for TLS-inspecting proxy support
- Auto-apply gVisor annotation (run.oci.keep_original_groups=1) in containers.conf instead of requiring manual flag
- Update test to source env file before running podman to pick up the SSL_CERT_FILE configuration
- Remove obsolete manual annotation requirement from guidance

The podman tests were failing in CI because:
1. The 'test' job runs without root, causing PermissionError
2. The TLS proxy CA wasn't being passed to podman