### PR TITLE
Fix Podman integration tests in CI

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -86,6 +86,15 @@ jobs:
       - uses: ./.github/actions/bazel-cache
         id: bazel-cache
 
+      - name: Reset podman storage
+        run: |
+          # Clear any pre-existing podman storage to avoid driver mismatch errors.
+          # The hook configures VFS driver for gVisor compatibility, but CI runners
+          # may have existing storage from Docker or previous podman runs with
+          # a different driver. The hook intentionally doesn't auto-delete state.
+          sudo rm -rf /var/lib/containers/storage /run/containers/storage
+          sudo rm -rf /etc/containers
+
       - name: Run Podman integration tests
         run: |
           # Run the e2e tests with podman enabled

--- a/props/core/cli/cmd_grade_validation.py
+++ b/props/core/cli/cmd_grade_validation.py
@@ -30,9 +30,7 @@ logger = logging.getLogger(__name__)
 
 @async_run
 async def cmd_grade_validation(
-    critic_model: str = opt.OPT_CRITIC_MODEL,
-    max_parallel: int = opt.OPT_MAX_PARALLEL,
-    verbose: bool = opt.OPT_VERBOSE,
+    critic_model: str = opt.OPT_CRITIC_MODEL, max_parallel: int = opt.OPT_MAX_PARALLEL, verbose: bool = opt.OPT_VERBOSE
 ) -> None:
     """Grade validation set: ensure complete critic coverage across all definitions.
 
@@ -143,11 +141,7 @@ async def cmd_grade_validation(
         typer.echo(f"\n=== Processing {need_critic} items with {max_parallel} workers ===\n")
 
         async def process_one(
-            example: ExampleSpec,
-            image_digest: str,
-            worker_id: int,
-            item_index: int,
-            total_items: int,
+            example: ExampleSpec, image_digest: str, worker_id: int, item_index: int, total_items: int
         ) -> tuple[str, bool, UUID | None]:
             """Process one work item: run critic.
             Returns (status, success, critic_run_id)."""

--- a/props/core/prompt_optimize/test_e2e.py
+++ b/props/core/prompt_optimize/test_e2e.py
@@ -67,9 +67,7 @@ def make_critic_mock_with_issue() -> PropsMock:
     @PropsMock.mock()
     def mock(m: PropsMock) -> PlayGen:
         yield None  # First request
-        result = yield from m.docker_exec_roundtrip(
-            ["critique", "insert-issue", "test-issue-001", "Test issue"]
-        )
+        result = yield from m.docker_exec_roundtrip(["critique", "insert-issue", "test-issue-001", "Test issue"])
         assert_that(result, exited_successfully())
         result = yield from m.docker_exec_roundtrip(
             ["critique", "insert-occurrence", "test-issue-001", "subtract.py", "-s", "1", "-e", "5"]

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -17,7 +17,7 @@ from importlib.resources.abc import Traversable
 from pathlib import Path
 
 from tools.claude_hooks.errors import SkipError
-from tools.claude_hooks.supervisor_setup import SupervisorClient
+from tools.claude_hooks.supervisor_setup import ProcessState, SupervisorClient
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +119,12 @@ def setup_podman_storage() -> None:
     3. Explicit runroot and graphroot paths
     4. Host user namespace (userns = "host")
     5. Registry configuration for short image names
+
+    Note: If there's pre-existing podman storage created with a different driver,
+    podman will fail with "database graph driver X does not match our graph driver Y".
+    This is intentional - we don't automatically delete existing state. To fix:
+      rm -rf /var/lib/containers/storage /run/containers/storage
+    See tools/claude_hooks/podman_service.py for details.
     """
     podman_config: Traversable = importlib.resources.files("tools.claude_hooks.config.podman")
 
@@ -146,6 +152,7 @@ def setup_podman(supervisor: SupervisorClient) -> PodmanSetup:
     """Set up podman storage and start service.
 
     If podman is not installed, attempts to install it via apt.
+    Idempotent: if podman service is already running, returns immediately.
 
     Args:
         supervisor: Supervisor client for managing services
@@ -161,6 +168,14 @@ def setup_podman(supervisor: SupervisorClient) -> PodmanSetup:
         logger.info("Skipping podman setup (%s set)", SKIP_ENV_VAR)
         raise SkipError("Podman", SKIP_ENV_VAR)
 
+    socket_path = Path("/run/podman/podman.sock")
+    socket_url = f"unix://{socket_path}"
+
+    # Check if podman service is already running (idempotent case)
+    if _is_podman_service_healthy(supervisor, socket_path):
+        logger.info("Podman service already running, skipping setup")
+        return PodmanSetup(socket_url=socket_url, supervisor=supervisor)
+
     if not is_podman_available():
         logger.info("Podman not found, installing...")
         install_podman()
@@ -170,6 +185,19 @@ def setup_podman(supervisor: SupervisorClient) -> PodmanSetup:
     socket_url = start_podman_service(supervisor)
     logger.info(f"Podman service started: DOCKER_HOST={socket_url}")
     return PodmanSetup(socket_url=socket_url, supervisor=supervisor)
+
+
+def _is_podman_service_healthy(supervisor: SupervisorClient, socket_path: Path) -> bool:
+    """Check if podman service is running and socket exists.
+
+    Used for idempotency: skip setup if service is already healthy.
+    """
+    if not socket_path.exists():
+        return False
+    try:
+        return supervisor.is_service_running(PODMAN_SERVICE, wait_for_start=False)
+    except Exception:
+        return False
 
 
 def start_podman_service(supervisor: SupervisorClient) -> str:
@@ -215,11 +243,36 @@ def _wait_for_socket(socket_path: Path, supervisor: SupervisorClient, timeout: i
         timeout: Maximum wait time in seconds
 
     Raises:
-        TimeoutError: If socket doesn't become ready in time
+        TimeoutError: If socket doesn't become ready in time, with diagnostic info
     """
+    last_state = None
     for _i in range(timeout * 10):  # Check every 0.1s
         if socket_path.exists() and supervisor.is_service_running("podman", wait_for_start=False):
             return
+        # Track service state for diagnostics
+        try:
+            info = supervisor.get_process_info("podman")
+            last_state = info.statename if info else "unknown"
+        except Exception:
+            last_state = "error"
         time.sleep(0.1)
 
-    raise TimeoutError(f"Podman socket {socket_path} did not become ready in {timeout}s")
+    # Build diagnostic message
+    socket_exists = socket_path.exists()
+    diag = f"socket_exists={socket_exists}, last_service_state={last_state}"
+
+    # Log full process info at error level for visibility
+    if last_state in (ProcessState.FATAL, ProcessState.BACKOFF, ProcessState.EXITED):
+        try:
+            info = supervisor.get_process_info("podman")
+            logger.error("Podman service failed: %s", info.model_dump())
+        except Exception:
+            pass
+
+    # Common cause: storage driver mismatch from pre-existing state
+    hint = (
+        "Common cause: storage driver mismatch. "
+        "If podman was previously used with a different driver, run: "
+        "rm -rf /var/lib/containers/storage /run/containers/storage"
+    )
+    raise TimeoutError(f"Podman socket {socket_path} did not become ready in {timeout}s ({diag}). {hint}")


### PR DESCRIPTION
The podman e2e tests were failing in CI due to storage driver mismatch. Instead of silently deleting pre-existing storage, the hook now:

1. Checks if podman is already running and healthy (idempotent)
2. Fails with clear error message if storage driver conflicts
3. Logs full ProcessInfo at error level for visibility

CI workflow explicitly resets storage before running podman tests, which is the appropriate place for destructive cleanup.

Changes:
- Add _is_podman_service_healthy() for idempotency check
- Improve _wait_for_socket() diagnostics with hint about driver mismatch
- Log ProcessInfo.model_dump() at error level on service failure
- Add "Reset podman storage" step to CI workflow
- Include unrelated formatting changes (multi-line function signatures)