### PR TITLE
Fix failing CI/CD pipeline tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,3 +58,7 @@ build:eslint --output_groups=+rules_lint_report
 # Produces: bazel-profile.gz (Chrome tracing format), execution-log.json (action-level timing)
 build:ci-profile --profile=bazel-profile.gz
 build:ci-profile --execution_log_json_file=execution-log.json
+
+# Stamping - embeds build metadata (commit hash, etc.) into build artifacts
+# Only targets that depend on ctx.info_file (like build_info_gen) are invalidated on commit change
+build --stamp --workspace_status_command=tools/stamp.sh

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -43,14 +43,29 @@ jobs:
       - uses: ./.github/actions/bazel-cache
         id: bazel-cache
 
-      - name: Run all Claude hooks tests
+      - name: Run unit tests (sandboxed)
         run: |
           bazel test --keep_going \
             --test_output=all \
             --nocache_test_results \
+            --test_tag_filters=-e2e \
             --test_env=CI=true \
             --test_env=GITHUB_ACTIONS=true \
             --test_env=JAVA_HOME \
+            //tools/claude_hooks:all
+
+      - name: Run e2e tests (no sandbox for podman)
+        run: |
+          # E2E tests need --spawn_strategy=local so podman can create Unix sockets
+          bazel test \
+            --test_output=all \
+            --nocache_test_results \
+            --test_tag_filters=e2e \
+            --spawn_strategy=local \
+            --test_env=CI=true \
+            --test_env=GITHUB_ACTIONS=true \
+            --test_env=JAVA_HOME \
+            --test_env=PATH \
             //tools/claude_hooks:all
 
       - uses: ./.github/actions/collect-test-logs
@@ -73,58 +88,13 @@ jobs:
           cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
           cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
 
-  # Podman integration tests - GitHub Actions runners have podman pre-installed
-  podman-test:
-    name: Podman Integration Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup Java (for keytool)
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "21"
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-
-      - name: Run Podman integration tests
-        run: |
-          # Run the e2e tests with podman enabled
-          # Config and socket use isolated paths (~/.cache/claude-hooks/podman/)
-          # so no conflict with system podman and no root required
-          bazel test //tools/claude_hooks:test_e2e \
-            --test_output=all \
-            --nocache_test_results \
-            --test_env=CI=true \
-            --test_env=GITHUB_ACTIONS=true \
-            --test_env=JAVA_HOME \
-            --test_filter='TestPodmanIntegration'
-
-      - name: Verify podman is available
-        run: |
-          # Verify podman exists (either pre-installed or installed by hook)
-          which podman && podman --version
-          echo "Podman available"
-
-      - uses: ./.github/actions/collect-test-logs
-        if: failure()
-        with:
-          artifact-name: podman-test-logs
-
-      - uses: ./.github/actions/bazel-cache-save
-        if: always()
-        with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-
   # Build wheel, test it, and release (on push to devel/main)
+  # Note: Podman integration tests run here via the e2e tests with PATH passed through.
+  # A separate podman-test job using Bazel sandbox doesn't work because Bazel's sandbox
+  # doesn't expose podman even when it's installed on the runner.
   wheel-build-test-release:
     name: Wheel Build, Test & Release
-    needs: [test, podman-test]
+    needs: [test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -161,8 +131,10 @@ jobs:
       - name: Install wheel
         run: uv tool install bazel-bin/tools/claude_hooks/claude_hooks-*.whl
 
-      - name: Test installed wheel
+      - name: Test installed wheel (including podman integration)
         run: |
+          # E2E tests run against the installed wheel (CLAUDE_HOOKS_USE_WHEEL=1).
+          # PATH is passed through so podman (pre-installed on GitHub runners) is available.
           bazel test //tools/claude_hooks:test_e2e \
             --test_output=all \
             --nocache_test_results \

--- a/ruff.toml
+++ b/ruff.toml
@@ -94,6 +94,7 @@ known-third-party = ["docker"]
 # First-party = our workspace packages (ruff uses heuristics otherwise)
 # TODO: Auto-generate this list from Bazel once bazelized
 known-first-party = [
+    "tools",
     "adgn",
     "adgn_mcp_starter",
     "agent_core",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,19 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load(":build_info.bzl", "build_info")
+
+# Copy workspace status file for Python to parse at runtime
+# Stamping is enabled globally in .bazelrc
+build_info(
+    name = "build_info_gen",
+)
+
+# Build information parsed from Bazel workspace status
+py_library(
+    name = "build_info",
+    srcs = ["build_info.py"],
+    data = [":build_info_gen"],
+    visibility = ["//visibility:public"],
+)
 
 # Shared utilities for environment variable handling
 py_library(

--- a/tools/build_info.bzl
+++ b/tools/build_info.bzl
@@ -1,0 +1,22 @@
+"""Rule to copy workspace status file for Python to parse at runtime."""
+
+def _build_info_impl(ctx):
+    """Copy workspace status file to a data file Python can read."""
+    output = ctx.actions.declare_file("_build_status.txt")
+
+    # Just copy the stable status file - Python will parse it
+    ctx.actions.run_shell(
+        outputs = [output],
+        inputs = [ctx.info_file],
+        command = "cp '{info_file}' '{output}'".format(
+            info_file = ctx.info_file.path,
+            output = output.path,
+        ),
+    )
+
+    return [DefaultInfo(files = depset([output]))]
+
+build_info = rule(
+    implementation = _build_info_impl,
+    attrs = {},
+)

--- a/tools/build_info.py
+++ b/tools/build_info.py
@@ -1,0 +1,27 @@
+"""Build information parsed from Bazel workspace status at runtime."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+
+def get_build_commit() -> str:
+    """Read build commit from workspace status file.
+
+    Returns the STABLE_BUILD_COMMIT value from the status file,
+    or "dev" if not available (e.g., running outside Bazel).
+    """
+    try:
+        # Read the status file from package data
+        status_text = resources.files(__package__).joinpath("_build_status.txt").read_text()
+        for line in status_text.splitlines():
+            if line.startswith("STABLE_BUILD_COMMIT "):
+                return line.split(" ", 1)[1]
+    except FileNotFoundError:
+        # Expected when running outside Bazel (e.g., development)
+        pass
+    return "dev"
+
+
+# For backwards compatibility and simple imports
+BUILD_COMMIT = get_build_commit()

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -43,6 +43,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":auth_proxy",
+        "//tools:build_info",
         "//tools:env_utils",
         "@pypi//cryptography",
         "@pypi//mako",

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -21,6 +21,7 @@ from typing import Literal
 from pydantic import BaseModel
 
 from tools import env_utils
+from tools.build_info import BUILD_COMMIT
 from tools.claude_hooks import (
     bazelisk_setup,
     binary_tools,
@@ -212,7 +213,7 @@ def emit_session_context(collector: LogCollector) -> None:
     has_warnings = len(collector.warnings) > 0
 
     lines = [
-        "Claude Code on the web (gVisor sandbox)",
+        f"Claude Code on the web (gVisor sandbox) [build: {BUILD_COMMIT}]",
         "Status: " + ("ERRORS" if has_errors else "OK with warnings" if has_warnings else "OK"),
         "Constraints:",
         "  - TLS-inspecting proxy (custom CA configured)",
@@ -233,9 +234,10 @@ def emit_session_context(collector: LogCollector) -> None:
     if os.environ.get("DUCKTAPE_CI_READ_GITHUB_TOKEN"):
         lines.append("GitHub CI Access:")
         lines.append("  DUCKTAPE_CI_READ_GITHUB_TOKEN is set - GitHub PAT with read access to ducktape repo.")
-        lines.append("  Use with `gh` CLI: GH_TOKEN=$DUCKTAPE_CI_READ_GITHUB_TOKEN gh ...")
+        lines.append(
+            "  Use via: curl -H 'Authorization: token $DUCKTAPE_CI_READ_GITHUB_TOKEN' https://api.github.com/..."
+        )
         lines.append("  Capabilities: read repo, read CI logs, list workflow runs, view PR status.")
-        lines.append("  Workflow: push to branch, ask user to create PR, then poll CI status via gh.")
 
     lines.append(f"Full log: {LOG_FILE}")
 

--- a/tools/stamp.sh
+++ b/tools/stamp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Workspace status script for Bazel stamping.
+# Outputs key-value pairs used by --stamp builds.
+# See: https://bazel.build/docs/user-manual#workspace-status
+
+# Volatile: changes every build (timestamp, etc.) - not cached
+# Stable: only changes when repo changes - cached
+
+# Get git commit (short hash)
+if command -v git &>/dev/null && git rev-parse --git-dir &>/dev/null; then
+  COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  # Check for dirty working tree
+  if ! git diff --quiet HEAD 2>/dev/null; then
+    COMMIT="${COMMIT}-dirty"
+  fi
+else
+  COMMIT="unknown"
+fi
+
+# Stable status - only changes when commit changes
+echo "STABLE_BUILD_COMMIT ${COMMIT}"


### PR DESCRIPTION
- Remove separate podman-test job (tests run in wheel job via PATH)
- Add Bazel workspace stamping to embed commit hash in builds
- Remove gh CLI advice (not available in Claude Code web)
- Show build commit in session hook output: [build: <commit>]
- Enable stamping globally (only stamp-dependent targets rebuild on commit change)

CI was failing with exit code 3 because podman tests were skipped in the Bazel sandbox (podman not in PATH). Now podman tests run in the wheel test job which passes PATH through, making podman available.