### PR TITLE
Debug failing git commit AI test

### DIFF
--- a/git_commit_ai/BUILD.bazel
+++ b/git_commit_ai/BUILD.bazel
@@ -62,14 +62,17 @@ py_test(
         "testing/__init__.py",
         "testing/git_repo_utils.py",
     ],
+    data = ["__snapshots__/test_editor.ambr"],
     main = "test_amend.py",
     deps = [
         ":git_commit_ai_lib",
         "//mcp_infra/testing",
+        "@pypi//fastmcp",
         "@pypi//pygit2",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
+        "@pypi//syrupy",
     ],
 )
 

--- a/git_commit_ai/__snapshots__/test_editor.ambr
+++ b/git_commit_ai/__snapshots__/test_editor.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: test_staged_files_not_duplicated_in_unstaged_section
+  '''
+  test
+  
+  # ai-draft: 0.00s
+  # 
+  # Please enter the commit message for your changes. Lines starting
+  # with '#' will be ignored, and an empty message aborts the commit.
+  # 
+  # On branch main
+  # 
+  # Changes to be committed:
+  # 	modified:    tracked.txt
+  # 
+  # ------------------------ >8 ------------------------
+  # Do not modify or remove the line above.
+  # Everything below it will be ignored.
+  '''
+# ---

--- a/git_commit_ai/git_ro/conftest.py
+++ b/git_commit_ai/git_ro/conftest.py
@@ -39,7 +39,7 @@ def repo_git_ro(tmp_path: Path) -> pygit2.Repository:
     """
     repo_path = tmp_path / "repo_git_ro"
     repo_path.mkdir(parents=True, exist_ok=True)
-    repo = pygit2.init_repository(str(repo_path), bare=False)
+    repo = pygit2.init_repository(str(repo_path), bare=False, initial_head="main")
     _ensure_identity(repo)
 
     (repo_path / "README.md").write_text("hello\n", encoding="utf-8")
@@ -85,7 +85,7 @@ def repo_with_conflict(tmp_path: Path) -> pygit2.Repository:
     """
     repo_path = tmp_path / "repo_conflict"
     repo_path.mkdir(parents=True, exist_ok=True)
-    repo = pygit2.init_repository(str(repo_path), bare=False)
+    repo = pygit2.init_repository(str(repo_path), bare=False, initial_head="main")
     _ensure_identity(repo)
 
     # Create initial commit with base content
@@ -131,7 +131,7 @@ def repo_with_new_file(tmp_path: Path) -> pygit2.Repository:
     """
     repo_path = tmp_path / "repo_new_file"
     repo_path.mkdir(parents=True, exist_ok=True)
-    repo = pygit2.init_repository(str(repo_path), bare=False)
+    repo = pygit2.init_repository(str(repo_path), bare=False, initial_head="main")
     _ensure_identity(repo)
 
     # Create initial commit

--- a/git_commit_ai/git_ro/server.py
+++ b/git_commit_ai/git_ro/server.py
@@ -322,19 +322,22 @@ class GitRoServer(SimpleFastMCP):
                 state.index.read()
 
                 entry: pygit2.IndexEntry | None = None
+                conflicts = state.index.conflicts
                 if stage == 0:
                     # Stage 0: regular index entries (non-conflict)
-                    for e in state.index:
-                        if e.path == path:
-                            entry = e
-                            break
-                else:
-                    # Stages 1-3: conflict entries (ancestor=1, ours=2, theirs=3)
-                    conflicts = state.index.conflicts
+                    # If file is in conflicts, stage 0 doesn't exist
                     if conflicts and path in conflicts:
-                        ancestor, ours, theirs = conflicts[path]
-                        conflict_entries = {1: ancestor, 2: ours, 3: theirs}
-                        entry = conflict_entries.get(stage)
+                        entry = None
+                    else:
+                        for e in state.index:
+                            if e.path == path:
+                                entry = e
+                                break
+                # Stages 1-3: conflict entries (ancestor=1, ours=2, theirs=3)
+                elif conflicts and path in conflicts:
+                    ancestor, ours, theirs = conflicts[path]
+                    conflict_entries = {1: ancestor, 2: ours, 3: theirs}
+                    entry = conflict_entries.get(stage)
 
                 if entry is None:
                     raise FileNotFoundError(f"Index entry not found: {objspec}")

--- a/git_commit_ai/git_ro/test_cat_file.py
+++ b/git_commit_ai/git_ro/test_cat_file.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 import pytest_bazel
+from fastmcp.exceptions import ToolError
 
 from git_commit_ai.git_ro.formatting import TextSlice
 from git_commit_ai.git_ro.server import CatFileInput, TextPage
@@ -54,16 +55,16 @@ async def test_cat_file_tree_object(typed_git_ro) -> None:
 
 
 async def test_cat_file_not_found(typed_git_ro) -> None:
-    """FileNotFoundError for missing path."""
-    with pytest.raises(FileNotFoundError, match="Path not found"):
+    """ToolError wrapping FileNotFoundError for missing path."""
+    with pytest.raises(ToolError, match="not found"):
         await typed_git_ro.cat_file(
             CatFileInput(object="HEAD:nonexistent.txt", slice=TextSlice(offset_chars=0, max_chars=100))
         )
 
 
 async def test_cat_file_index_not_found(typed_git_ro) -> None:
-    """FileNotFoundError for missing index entry."""
-    with pytest.raises(FileNotFoundError, match="Index entry not found"):
+    """ToolError wrapping FileNotFoundError for missing index entry."""
+    with pytest.raises(ToolError, match="Index entry not found"):
         await typed_git_ro.cat_file(
             CatFileInput(object=":nonexistent.txt", slice=TextSlice(offset_chars=0, max_chars=100))
         )
@@ -98,7 +99,7 @@ async def test_conflict_stage3_theirs(typed_git_ro_conflict) -> None:
 
 async def test_conflict_stage0_not_found(typed_git_ro_conflict) -> None:
     """Stage 0 doesn't exist for conflicted files."""
-    with pytest.raises(FileNotFoundError, match="Index entry not found"):
+    with pytest.raises(ToolError, match="Index entry not found"):
         await typed_git_ro_conflict.cat_file(
             CatFileInput(object=":0:conflict.txt", slice=TextSlice(offset_chars=0, max_chars=100))
         )
@@ -116,7 +117,7 @@ async def test_new_file_read_from_index(typed_git_ro_new_file) -> None:
 
 async def test_new_file_not_in_commit_tree(typed_git_ro_new_file) -> None:
     """HEAD:path fails for newly added file not yet committed."""
-    with pytest.raises(FileNotFoundError, match="not found at repository root"):
+    with pytest.raises(ToolError, match="not found at repository root"):
         await typed_git_ro_new_file.cat_file(
             CatFileInput(object="HEAD:src/newfile.py", slice=TextSlice(offset_chars=0, max_chars=100))
         )
@@ -124,7 +125,7 @@ async def test_new_file_not_in_commit_tree(typed_git_ro_new_file) -> None:
 
 async def test_path_error_shows_available_entries(typed_git_ro_new_file) -> None:
     """Error message shows available entries when path component not found."""
-    with pytest.raises(FileNotFoundError, match=r"Entries at repository root:.*README.md"):
+    with pytest.raises(ToolError, match=r"Entries at repository root:.*README.md"):
         await typed_git_ro_new_file.cat_file(
             CatFileInput(object="HEAD:nonexistent/file.py", slice=TextSlice(offset_chars=0, max_chars=100))
         )
@@ -132,7 +133,7 @@ async def test_path_error_shows_available_entries(typed_git_ro_new_file) -> None
 
 async def test_bare_filename_error_message(typed_git_ro) -> None:
     """Helpful error when using bare filename instead of full path."""
-    with pytest.raises(FileNotFoundError, match="Path must be relative to repository root"):
+    with pytest.raises(ToolError, match="Path must be relative to repository root"):
         await typed_git_ro.cat_file(CatFileInput(object="HEAD:README", slice=TextSlice(offset_chars=0, max_chars=100)))
 
 


### PR DESCRIPTION
- Fix exception type mismatch: Tests now catch ToolError (FastMCP wrapper) instead of FileNotFoundError when testing error cases through MCP client
- Add syrupy snapshot testing: Added @pypi//syrupy dep and created snapshot file for test_staged_files_not_duplicated_in_unstaged_section
- Set predictable branch names: All pygit2.init_repository calls now use initial_head="main" to avoid reliance on git config defaults
- Fix stage 0 conflict handling: cat_file now correctly returns error when requesting stage 0 for a file that's in merge conflict state