### PR TITLE
Fix E2E tests with local spawn strategy

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -135,9 +135,11 @@ jobs:
         run: |
           # E2E tests run against the installed wheel (CLAUDE_HOOKS_USE_WHEEL=1).
           # PATH is passed through so podman (pre-installed on GitHub runners) is available.
+          # --spawn_strategy=local is required for podman to create Unix sockets.
           bazel test //tools/claude_hooks:test_e2e \
             --test_output=all \
             --nocache_test_results \
+            --spawn_strategy=local \
             --test_env=CLAUDE_HOOKS_USE_WHEEL=1 \
             --test_env=CI=true \
             --test_env=JAVA_HOME \


### PR DESCRIPTION
The wheel test step was missing --spawn_strategy=local which is required for podman to create Unix sockets. This caused the podman integration tests to fail with "Podman socket not created" errors.

https://claude.ai/code/session_01USUxq6zTedKZf9zScAccTN