### PR TITLE
Add concurrency controls to release workflow files

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -18,6 +18,11 @@ on:
       - ".github/workflows/claude-hooks-release.yml"
   workflow_dispatch:
 
+# Cancel outdated workflow runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/ducktape-release.yml
+++ b/.github/workflows/ducktape-release.yml
@@ -15,6 +15,11 @@ on:
       - "mcp_utils/**"
   workflow_dispatch:
 
+# Cancel outdated workflow runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/gnome-terminal-profile-switcher-release.yml
+++ b/.github/workflows/gnome-terminal-profile-switcher-release.yml
@@ -8,6 +8,11 @@ on:
       - "gnome_terminal_profile_switcher/**"
   workflow_dispatch:
 
+# Cancel outdated workflow runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/headscale-cleanup-release.yml
+++ b/.github/workflows/headscale-cleanup-release.yml
@@ -8,6 +8,11 @@ on:
       - "headscale_cleanup/**"
   workflow_dispatch:
 
+# Cancel outdated workflow runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/props-cli-image.yml
+++ b/.github/workflows/props-cli-image.yml
@@ -16,6 +16,11 @@ on:
       - ".github/workflows/props-cli-image.yml"
   workflow_dispatch:
 
+# Cancel outdated workflow runs when new commits are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
## Summary
Added concurrency configuration to all release and image build workflow files to cancel outdated workflow runs when new commits are pushed to the same branch.

## Changes
- Added `concurrency` configuration block to 5 workflow files:
  - `.github/workflows/claude-hooks-release.yml`
  - `.github/workflows/ducktape-release.yml`
  - `.github/workflows/gnome-terminal-profile-switcher-release.yml`
  - `.github/workflows/headscale-cleanup-release.yml`
  - `.github/workflows/props-cli-image.yml`

## Implementation Details
Each workflow now includes:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

This configuration ensures that:
- Only one workflow run executes per branch at a time
- Previous runs are automatically cancelled when new commits trigger the workflow
- Prevents duplicate/redundant release builds and reduces resource consumption
- Improves CI/CD efficiency by avoiding unnecessary concurrent executions