### PR TITLE
Move grading wait logic from MCP to database polling inside container

### DIFF
--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -4,7 +4,11 @@ This is the unified props backend that includes:
 - Dashboard API: /api/stats, /api/runs, /api/gt
 - LLM Proxy: /v1/responses
 - Registry Proxy: /v2/*
-- Eval API: /api/eval/run_critic, /api/eval/wait_until_graded
+- Eval API: /api/eval/run_critic, /api/eval/grading_status/{critic_run_id}
+
+Note: wait_until_graded is implemented inside containers by polling the grading_pending
+view directly, not as a REST endpoint. The grading_status endpoint provides a non-blocking
+status check that containers can poll.
 """
 
 from __future__ import annotations

--- a/props/compose.yaml
+++ b/props/compose.yaml
@@ -51,7 +51,8 @@ services:
   # Dashboard API: /api/stats, /api/runs, /api/gt
   # LLM Proxy: POST /v1/responses
   # Registry Proxy: /v2/* (OCI Distribution API)
-  # Eval API: /api/eval/run_critic, /api/eval/wait_until_graded
+  # Eval API: /api/eval/run_critic, /api/eval/grading_status/{run_id}
+  # Note: wait_until_graded is implemented by agents polling the database directly
   backend:
     image: props-backend:latest
     container_name: props-backend

--- a/props/core/BUILD.bazel
+++ b/props/core/BUILD.bazel
@@ -113,17 +113,6 @@ py_library(
 )
 
 py_library(
-    name = "mcp_http_server",
-    srcs = ["mcp_http_server.py"],
-    imports = ["../.."],
-    visibility = ["//props:__subpackages__"],
-    deps = [
-        "//net_util",
-        "@pypi//fastmcp",
-    ],
-)
-
-py_library(
     name = "eval_api_models",
     srcs = ["eval_api_models.py"],
     imports = ["../.."],
@@ -345,7 +334,6 @@ ruff_test(
         ":exceptions",
         ":ids",
         ":loop_agent_env",
-        ":mcp_http_server",
         ":oci_utils",
         ":runs_context",
         ":splits",

--- a/props/core/agent_helpers.py
+++ b/props/core/agent_helpers.py
@@ -25,12 +25,14 @@ Usage:
     with get_session() as session:
         snapshots = session.query(Snapshot).filter_by(split='train').all()
 
-    # Eval API client (REST-based, replaces MCP)
-    from props.core.eval_client import EvalClient
+    # Eval API client for running critics (REST-based)
+    from props.core.eval_client import EvalClient, wait_until_graded
 
     async with EvalClient.from_env() as client:
         result = await client.run_critic(definition_id="critic", example=example)
-        status = await client.wait_until_graded(result.critic_run_id)
+
+    # Wait for grading by polling database directly (not via API)
+    status = await wait_until_graded(result.critic_run_id)
 """
 
 from __future__ import annotations

--- a/props/core/docs/backend_api.md
+++ b/props/core/docs/backend_api.md
@@ -16,23 +16,28 @@ auth = (os.environ["PGUSER"], os.environ["PGPASSWORD"])
 
 ## Using EvalClient (Recommended)
 
-For running critic evaluations, use the `EvalClient` class which handles authentication and polling:
+For running critic evaluations, use the `EvalClient` class for the REST API calls and the `wait_until_graded()` function for polling grading status directly from the database:
 
 ```python
-from props.core.eval_client import EvalClient
+from props.core.eval_client import EvalClient, wait_until_graded
 from props.core.models.examples import WholeSnapshotExample
 
 async with EvalClient.from_env() as client:
-    # Run critic
+    # Run critic (calls REST API)
     result = await client.run_critic(
         definition_id="critic",
         example=WholeSnapshotExample(snapshot_slug="ducktape/2025-01-01"),
     )
 
-    # Wait for grading completion (polls automatically)
-    status = await client.wait_until_graded(result.critic_run_id)
-    print(f"Recall: {status.total_credit}/{status.max_credit}")
+# Wait for grading completion (polls database directly, not via API)
+status = await wait_until_graded(result.critic_run_id)
+print(f"Recall: {status.total_credit}/{status.max_credit}")
 ```
+
+**Note:** `wait_until_graded()` validates that:
+
+- The critic run is finished (COMPLETED, FAILED, or MAX_TURNS_EXCEEDED)
+- The critic run was started by the current agent
 
 ## OpenAPI Schema
 

--- a/props/core/docs/database_access.md
+++ b/props/core/docs/database_access.md
@@ -107,3 +107,22 @@ Run `\d+ table_name` before writing queries to understand the schema.
 | `recall_by_definition_split_kind`  | All splits (view)     | -        | -        |
 
 [^1]: VALID/TEST access restricted to prevent overfitting. See `db/evaluation_flow.md.j2` for details.
+
+## Monitoring Grading Status
+
+PO/PI agents can monitor grading status by querying the `grading_pending` view directly:
+
+```bash
+# Check pending grading edges for a critic run
+psql -c "SELECT COUNT(*) FROM grading_pending WHERE critique_run_id = 'YOUR-RUN-ID'"
+
+# See details of pending edges
+psql -c "SELECT critique_issue_id, tp_id, fp_id FROM grading_pending WHERE critique_run_id = 'YOUR-RUN-ID'"
+
+# Check if grading is complete (returns 0 when done)
+psql -c "SELECT COUNT(*) AS pending_count FROM grading_pending WHERE critique_run_id = 'YOUR-RUN-ID'"
+```
+
+**Grading drift:** The `grading_pending` view shows all `(critique_issue, ground_truth_occurrence)` pairs that need grading edges. Grading is complete when the view returns no rows for a given critique run.
+
+For programmatic waiting, use `wait_until_graded()` from `props.core.eval_client` which polls this view automatically.

--- a/props/core/eval_api_models.py
+++ b/props/core/eval_api_models.py
@@ -33,14 +33,6 @@ class RunCriticRequest(BaseModel):
     critic_model: str = Field(default="gpt-5.1-codex-mini", description="Model for the critic agent")
 
 
-class WaitUntilGradedRequest(BaseModel):
-    """Request to wait for grading completion."""
-
-    critic_run_id: UUID = Field(description="agent_run_id of the critic run to wait for grading")
-    timeout_seconds: int = Field(default=300, ge=10, le=3600, description="Max time to wait (default 300s)")
-    poll_interval_seconds: int = Field(default=5, ge=1, le=60, description="Polling interval (default 5s)")
-
-
 # =============================================================================
 # Response models
 # =============================================================================

--- a/props/core/eval_client.py
+++ b/props/core/eval_client.py
@@ -1,7 +1,12 @@
 """REST API client for evaluation endpoints.
 
-Provides a client for PO/PI agent containers to call the backend's eval API.
-Replaces the MCP-based PromptEvalServer with direct HTTP calls.
+Provides:
+- EvalClient: REST client for PO/PI agents to call backend's /api/eval/run_critic
+- wait_until_graded(): Polls grading_pending view until grading is complete
+
+Architecture:
+- run_critic: REST API call to backend, which spawns critic container
+- wait_until_graded: Direct database polling inside container (no REST call)
 
 Usage (inside container):
     from props.core.eval_client import EvalClient, wait_until_graded
@@ -12,7 +17,7 @@ Usage (inside container):
             example={"kind": "whole_snapshot", "snapshot_slug": "repo/2025-01-01"},
         )
 
-    # Wait for grading by polling the database directly
+    # Wait for grading by polling the database directly (not via REST API)
     grading_result = await wait_until_graded(result.critic_run_id)
 """
 
@@ -29,11 +34,12 @@ from uuid import UUID
 import httpx
 from sqlalchemy import func
 
+from props.core.agent_helpers import get_current_agent_run_id
 from props.core.eval_api_models import GradingStatusResponse, RunCriticRequest, RunCriticResponse
 from props.core.ids import DefinitionId
 from props.core.models.examples import ExampleSpec
 from props.db.examples import Example
-from props.db.models import AgentRun, GradingEdge, GradingPending, Snapshot
+from props.db.models import AgentRun, AgentRunStatus, GradingEdge, GradingPending, Snapshot
 from props.db.session import get_session
 
 logger = logging.getLogger(__name__)
@@ -131,6 +137,10 @@ async def wait_until_graded(
     Polls the grading_pending view directly using the container's database
     credentials until there's no more drift (all edges graded) or timeout.
 
+    Validates that:
+    - The critic run exists and is not IN_PROGRESS (must be in a terminal state)
+    - The critic run was started by the current agent (parent_agent_run_id check)
+
     Args:
         critic_run_id: agent_run_id of the critic run
         timeout_seconds: Max seconds to wait (default: 300)
@@ -140,8 +150,30 @@ async def wait_until_graded(
         GradingStatusResponse with completion status and metrics
 
     Raises:
+        ValueError: If critic run doesn't exist, isn't finished, or wasn't started by this agent
         TimeoutError: If grading doesn't complete within timeout
     """
+    # Validate the critic run before waiting
+    with get_session() as session:
+        critic_run = session.get(AgentRun, critic_run_id)
+        if critic_run is None:
+            raise ValueError(f"Critic run {critic_run_id} not found")
+
+        # Check that critic run is in a terminal state (not IN_PROGRESS)
+        if critic_run.status == AgentRunStatus.IN_PROGRESS:
+            raise ValueError(
+                f"Critic run {critic_run_id} is still in progress (status: {critic_run.status}). "
+                f"wait_until_graded only works on finished runs."
+            )
+
+        # Verify this critic run was started by the current agent
+        current_agent_id = get_current_agent_run_id(session)
+        if critic_run.parent_agent_run_id != current_agent_id:
+            raise ValueError(
+                f"Critic run {critic_run_id} was not started by this agent. "
+                f"Expected parent {current_agent_id}, got {critic_run.parent_agent_run_id}."
+            )
+
     start_time = time.monotonic()
     deadline = start_time + timeout_seconds
     last_pending_count: int | None = None

--- a/props/core/test_agent_pkg_e2e.py
+++ b/props/core/test_agent_pkg_e2e.py
@@ -26,21 +26,16 @@ from hamcrest import assert_that
 
 from agent_core_testing.responses import PlayGen, tool_roundtrip
 from agent_core_testing.steps import exited_successfully
-from mcp_infra.naming import MCPMountPrefix
+from props.core.eval_api_models import GradingStatusResponse, RunCriticResponse
 from props.core.ids import SnapshotSlug
 from props.core.models.examples import ExampleKind, WholeSnapshotExample
+from props.critic_dev.optimize.main import RunCriticToolArgs, WaitUntilGradedToolArgs
 from props.critic_dev.optimize.test_e2e import (
     ORCHESTRATION_CRITIC_MODEL,
     ORCHESTRATION_GRADER_MODEL,
     ORCHESTRATION_OPTIMIZER_MODEL,
     make_orchestration_grader_mock,
     multi_model_e2e_stack,
-)
-from props.critic_dev.prompt_eval_server import (
-    RunCriticInput,
-    RunCriticOutput,
-    WaitUntilGradedInput,
-    WaitUntilGradedOutput,
 )
 from props.critic_dev.shared import TargetMetric
 from props.db.agent_definition_ids import CRITIC_IMAGE_REF
@@ -60,8 +55,8 @@ def make_po_orchestration_mock(snapshot_slug: SnapshotSlug) -> PropsMock:
     """Create PO mock that orchestrates critic runs.
 
     The mock:
-    1. Calls run_critic MCP tool
-    2. Waits for grading
+    1. Calls run_critic tool (DirectToolProvider, calls REST API)
+    2. Waits for grading via wait_until_graded_tool (polls database)
     3. Reports success
     """
 
@@ -69,22 +64,22 @@ def make_po_orchestration_mock(snapshot_slug: SnapshotSlug) -> PropsMock:
     def mock(m: PropsMock) -> PlayGen:
         yield None  # First request
 
-        # Call run_critic MCP tool
+        # Call run_critic tool (DirectToolProvider)
         example = WholeSnapshotExample(kind=ExampleKind.WHOLE_SNAPSHOT, snapshot_slug=snapshot_slug)
-        run_critic_input = RunCriticInput(
+        run_critic_args = RunCriticToolArgs(
             definition_id="builtin", example=example, timeout_seconds=120, budget_usd=None
         )
 
-        call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "run_critic", run_critic_input)
-        run_critic_output: RunCriticOutput = yield from tool_roundtrip(call, RunCriticOutput)
+        call = m.tool_call("run_critic", run_critic_args)
+        run_critic_output: RunCriticResponse = yield from tool_roundtrip(call, RunCriticResponse)
 
         critic_run_id = run_critic_output.critic_run_id
         logger.info(f"PO got critic_run_id: {critic_run_id}")
 
-        # Wait for grading
-        wait_input = WaitUntilGradedInput(critic_run_id=critic_run_id, timeout_seconds=60)
-        wait_call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "wait_until_graded", wait_input)
-        wait_output: WaitUntilGradedOutput = yield from tool_roundtrip(wait_call, WaitUntilGradedOutput)
+        # Wait for grading (polls database directly inside container)
+        wait_args = WaitUntilGradedToolArgs(critic_run_id=str(critic_run_id), timeout_seconds=60)
+        wait_call = m.tool_call("wait_until_graded_tool", wait_args)
+        wait_output: GradingStatusResponse = yield from tool_roundtrip(wait_call, GradingStatusResponse)
         logger.info(f"PO got grading: total_credit={wait_output.total_credit}")
 
         # Report success
@@ -100,7 +95,7 @@ def make_po_custom_image_mock(snapshot_slug: SnapshotSlug, random_token: str) ->
     1. Creates /workspace/custom_critic/ directory with agent.md containing the token
     2. Calls 'props agent-pkg create' CLI to build and push the image
     3. Extracts the new digest and calls run_critic with it
-    4. Waits for grading
+    4. Waits for grading via wait_until_graded_tool (polls database)
     5. Reports success
 
     NOTE: Requires registry proxy to be available for agent-pkg create to succeed.
@@ -148,25 +143,25 @@ AGENT_EOF
         new_digest = stdout.strip()
         logger.info(f"Created custom critic with digest: {new_digest}")
 
-        # Call run_critic with the CUSTOM critic image
+        # Call run_critic with the CUSTOM critic image (DirectToolProvider)
         example = WholeSnapshotExample(kind=ExampleKind.WHOLE_SNAPSHOT, snapshot_slug=snapshot_slug)
-        run_critic_input = RunCriticInput(
+        run_critic_args = RunCriticToolArgs(
             definition_id=new_digest,  # Use the custom image!
             example=example,
             timeout_seconds=120,
             budget_usd=None,
         )
 
-        call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "run_critic", run_critic_input)
-        run_critic_output: RunCriticOutput = yield from tool_roundtrip(call, RunCriticOutput)
+        call = m.tool_call("run_critic", run_critic_args)
+        run_critic_output: RunCriticResponse = yield from tool_roundtrip(call, RunCriticResponse)
 
         critic_run_id = run_critic_output.critic_run_id
         logger.info(f"PO got critic_run_id: {critic_run_id}")
 
-        # Wait for grading
-        wait_input = WaitUntilGradedInput(critic_run_id=critic_run_id, timeout_seconds=60)
-        wait_call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "wait_until_graded", wait_input)
-        wait_output: WaitUntilGradedOutput = yield from tool_roundtrip(wait_call, WaitUntilGradedOutput)
+        # Wait for grading (polls database directly inside container)
+        wait_args = WaitUntilGradedToolArgs(critic_run_id=str(critic_run_id), timeout_seconds=60)
+        wait_call = m.tool_call("wait_until_graded_tool", wait_args)
+        wait_output: GradingStatusResponse = yield from tool_roundtrip(wait_call, GradingStatusResponse)
         logger.info(f"PO got grading: total_credit={wait_output.total_credit}")
 
         # Report success

--- a/props/critic_dev/cli.py
+++ b/props/critic_dev/cli.py
@@ -21,6 +21,7 @@ from props.core.agent_helpers import get_current_agent_run, get_current_agent_ru
 from props.core.agent_types import AgentType
 from props.core.display import ColumnDef, build_table_from_schema
 from props.core.eval_client import EvalClient
+from props.core.ids import DefinitionId
 from props.core.models.examples import ExampleSpec, SingleFileSetExample, WholeSnapshotExample
 from props.core.splits import Split
 from props.critic_dev.cli_helpers import show_execution_traces, show_grading_summary, show_run_status
@@ -81,7 +82,10 @@ async def run_critic_cmd(
 
     async with EvalClient.from_env() as client:
         response = await client.run_critic(
-            definition_id=image_ref, example=example, timeout_seconds=timeout_seconds, budget_usd=budget_usd
+            definition_id=DefinitionId(image_ref),
+            example=example,
+            timeout_seconds=timeout_seconds,
+            budget_usd=budget_usd,
         )
         typer.echo(f"Critic run ID: {response.critic_run_id}")
         typer.echo(f"Status: {response.status}")

--- a/props/critic_dev/optimize/test_e2e.py
+++ b/props/critic_dev/optimize/test_e2e.py
@@ -35,20 +35,15 @@ from hamcrest import all_of, assert_that
 
 from agent_core_testing.responses import PlayGen, tool_roundtrip
 from agent_core_testing.steps import exited_successfully, stdout_contains
-from mcp_infra.naming import MCPMountPrefix
 from openai_utils.model import OpenAIModelProto
 from props.backend.app import app as backend_app
 from props.core.agent_registry import AgentRegistry
 from props.core.agent_types import AgentType
-from props.core.eval_api_models import (
-    GradingStatusResponse,
-    RunCriticRequest,
-    RunCriticResponse,
-    WaitUntilGradedRequest,
-)
+from props.core.eval_api_models import GradingStatusResponse, RunCriticResponse
 from props.core.ids import SnapshotSlug
 from props.core.models.examples import ExampleKind, WholeSnapshotExample
 from props.core.splits import Split
+from props.critic_dev.optimize.main import RunCriticToolArgs, WaitUntilGradedToolArgs
 from props.critic_dev.shared import TargetMetric
 from props.db.agent_definition_ids import CRITIC_IMAGE_REF
 from props.db.config import DatabaseConfig
@@ -244,30 +239,35 @@ HOST_GATEWAY = {E2E_HOST_HOSTNAME: "host-gateway"} if E2E_HOST_HOSTNAME == "host
 
 
 def make_orchestration_optimizer_mock(snapshot_slug: SnapshotSlug) -> PropsMock:
-    """Create optimizer mock that calls run_critic MCP tool and waits for grading."""
+    """Create optimizer mock that calls run_critic tool and waits for grading.
+
+    Uses DirectToolProvider tools (not MCP):
+    - run_critic: calls backend REST API
+    - wait_until_graded_tool: polls database directly
+    """
 
     @PropsMock.mock()
     def mock(m: PropsMock) -> PlayGen:
         yield None  # First request (system message)
 
-        # Call run_critic tool (now via REST API in container)
+        # Call run_critic tool (DirectToolProvider tool that calls REST API)
         example = WholeSnapshotExample(kind=ExampleKind.WHOLE_SNAPSHOT, snapshot_slug=snapshot_slug)
-        run_critic_request = RunCriticRequest(
+        run_critic_args = RunCriticToolArgs(
             definition_id="builtin",  # Use builtin critic
             example=example,
             timeout_seconds=120,
             budget_usd=None,
         )
 
-        call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "run_critic", run_critic_request)
+        call = m.tool_call("run_critic", run_critic_args)
         run_critic_response: RunCriticResponse = yield from tool_roundtrip(call, RunCriticResponse)
 
         critic_run_id = run_critic_response.critic_run_id
         logger.info(f"Orchestration optimizer got critic_run_id: {critic_run_id}")
 
-        # Call wait_until_graded tool (now via REST API in container)
-        wait_request = WaitUntilGradedRequest(critic_run_id=critic_run_id, timeout_seconds=60)
-        wait_call = m.mcp_tool_call(MCPMountPrefix("prompt_eval"), "wait_until_graded", wait_request)
+        # Call wait_until_graded_tool (DirectToolProvider tool that polls database)
+        wait_args = WaitUntilGradedToolArgs(critic_run_id=str(critic_run_id), timeout_seconds=60)
+        wait_call = m.tool_call("wait_until_graded_tool", wait_args)
         grading_response: GradingStatusResponse = yield from tool_roundtrip(wait_call, GradingStatusResponse)
 
         total_credit = grading_response.total_credit or 0.0
@@ -431,18 +431,16 @@ async def multi_model_e2e_stack(
 @pytest.mark.timeout(180)
 @pytest.mark.requires_docker
 @pytest.mark.slow
-async def test_optimizer_orchestrates_critic_via_mcp(
-    synced_test_db: DatabaseConfig, async_docker_client: aiodocker.Docker
-):
-    """Test optimizer can orchestrate critic runs via MCP tools with simulated grading.
+async def test_optimizer_orchestrates_critic(synced_test_db: DatabaseConfig, async_docker_client: aiodocker.Docker):
+    """Test optimizer can orchestrate critic runs with simulated grading.
 
     This e2e test verifies the full orchestration flow:
-    1. Optimizer container starts and connects to MCP server (PromptEvalServer)
-    2. Optimizer calls run_critic MCP tool
+    1. Optimizer container starts with DirectToolProvider tools
+    2. Optimizer calls run_critic tool (REST API to backend)
     3. Registry spawns critic container with different model
     4. Critic runs, submits issues, completes
-    5. Background task injects grader run (simulating grading daemon)
-    6. Optimizer's wait_until_graded returns with grading results
+    5. Background grader daemon processes edges
+    6. Optimizer's wait_until_graded_tool returns (polls database directly)
     7. Optimizer reports success
 
     Uses MultiModelFakeOpenAI to route optimizer and critic to different mocks.

--- a/props/docs/agent-loop-inside-container.md
+++ b/props/docs/agent-loop-inside-container.md
@@ -169,38 +169,41 @@ The `llm_run_costs` view joins `llm_requests` with `model_metadata` pricing tabl
 
 ### Subagent Spawning
 
-| Aspect          | Decision                                                               |
-| --------------- | ---------------------------------------------------------------------- |
-| Spawn           | MCP-over-HTTP via `PromptEvalServer` (host serves, container connects) |
-| Status query    | Direct Postgres query (no external call needed)                        |
-| Results/logs    | Direct Postgres query                                                  |
-| Cost accounting | Counts against parent's budget                                         |
-| Limits          | No explicit concurrency/spawn limits; cost + timeout sufficient        |
-| Wait helpers    | MCP tools: `wait_until_graded(critic_run_id)` polls DB internally      |
+| Aspect          | Decision                                                                        |
+| --------------- | ------------------------------------------------------------------------------- |
+| Spawn           | REST API call to backend (`/api/eval/run_critic`)                               |
+| Status query    | Direct Postgres query (no external call needed)                                 |
+| Results/logs    | Direct Postgres query                                                           |
+| Cost accounting | Counts against parent's budget                                                  |
+| Limits          | No explicit concurrency/spawn limits; cost + timeout sufficient                 |
+| Wait helpers    | `wait_until_graded_tool` polls `grading_pending` view directly inside container |
 
 **Architecture:**
 
-Host scaffold starts `PromptEvalServer` (FastMCP) and serves it via HTTP. Container connects as MCP client using `MCPToolProvider`. This reuses the existing MCP infrastructure rather than adding new REST endpoints.
+PO/PI agents have DirectToolProvider tools that call the backend REST API for spawning and poll the database directly for grading status. No MCP required.
 
 ```
-Host Scaffold                           Container (PO/PI)
-─────────────                           ─────────────────
-PromptEvalServer (FastMCP)              MCPToolProvider
-├─ run_critic tool      ◄───────────────  client.call_tool("run_critic", ...)
-├─ run_grader tool      ◄───────────────  client.call_tool("run_grader", ...)
-└─ wait_until_graded    ◄───────────────  client.call_tool("wait_until_graded", ...)
+Backend                                 Container (PO/PI)
+───────                                 ─────────────────
+/api/eval/run_critic (REST)             DirectToolProvider
+├─ Spawns critic container   ◄──────────  run_critic tool (HTTP POST)
+└─ Returns critic_run_id
+
+PostgreSQL                              DirectToolProvider
+──────────                              ──────────────────
+grading_pending view         ◄──────────  wait_until_graded_tool (polls DB)
+└─ Returns when drift = 0
 ```
 
-**Tools provided by PromptEvalServer:**
+**Tools provided by DirectToolProvider:**
 
-- `run_critic(image, example, model)` → `agent_run_id` (non-blocking)
-- `run_grader(critic_run_id, model)` → `agent_run_id` (non-blocking, deprecated - prefer daemon)
-- `wait_until_graded(critic_run_id)` → grading results (blocks until daemon grades)
+- `run_critic(definition_id, example, ...)` → critic_run_id (calls REST API)
+- `wait_until_graded_tool(critic_run_id)` → grading results (polls database directly)
 
 **Typical PO workflow:**
 
-1. `run_critic(...)` → critic_run_id (returns immediately)
-2. `wait_until_graded(critic_run_id)` (blocks until daemon grader grades it)
+1. `run_critic(...)` → critic_run_id (returns when critic completes)
+2. `wait_until_graded_tool(critic_run_id)` (polls `grading_pending` until empty)
 3. Query metrics from DB
 
 ### Observability
@@ -441,17 +444,17 @@ Note: Model pricing already exists in `model_metadata` table; `llm_request_costs
 
 ### To Keep (unchanged or minor changes)
 
-| Component                 | Notes                                                         |
-| ------------------------- | ------------------------------------------------------------- |
-| `props critic-agent` CLI  | Already exists, used by agent via subprocess                  |
-| `props grader-agent` CLI  | Already exists, used by agent via subprocess                  |
-| `props snapshot fetch`    | Already exists, used by agent to fetch snapshot               |
-| `grader/daemon.py`        | Keep, but agent loop moves inside container                   |
-| `grader/drift_handler.py` | Keep, runs inside container now                               |
-| `noop_classifier/`        | Keep as-is (specialized utility)                              |
-| Database models, RLS      | Keep as-is                                                    |
-| Registry proxy            | Keep as-is                                                    |
-| **PromptEvalServer**      | Keep for PO/PI - host serves MCP, container connects via HTTP |
+| Component                 | Notes                                                        |
+| ------------------------- | ------------------------------------------------------------ |
+| `props critic-agent` CLI  | Already exists, used by agent via subprocess                 |
+| `props grader-agent` CLI  | Already exists, used by agent via subprocess                 |
+| `props snapshot fetch`    | Already exists, used by agent to fetch snapshot              |
+| `grader/daemon.py`        | Keep, but agent loop moves inside container                  |
+| `grader/drift_handler.py` | Keep, runs inside container now                              |
+| `noop_classifier/`        | Keep as-is (specialized utility)                             |
+| Database models, RLS      | Keep as-is                                                   |
+| Registry proxy            | Keep as-is                                                   |
+| **Backend eval API**      | PO/PI call REST API for spawning, poll DB for grading status |
 
 ## Migration Path
 
@@ -517,11 +520,14 @@ Features:
 
 **Daemon loop:** `DriftHandler.on_before_sample()` checks `grading_pending` view. Returns `Abort()` when empty → agent loop exits → outer loop sleeps on pg_notify → wakes and creates fresh agent context.
 
-### Phase 4: Prompt Optimizer
+### Phase 4: Prompt Optimizer ✓
 
-1. Update PO/PI to run agent loop inside container (keep `PromptEvalServer` MCP-over-HTTP for spawning)
-2. PO/PI containers connect to host `PromptEvalServer` via `MCPToolProvider`
-3. Give PO/PI access to container logs via DB queries
+**Status: Complete**
+
+1. PO/PI run agent loop inside container with DirectToolProvider tools
+2. `run_critic` tool calls backend REST API (`/api/eval/run_critic`)
+3. `wait_until_graded_tool` polls `grading_pending` view directly from container
+4. PO/PI access container logs via DB queries
 
 ### Phase 5: Cleanup
 
@@ -533,12 +539,12 @@ Features:
 
 ### HTTP MCP Servers
 
-| Server                 | Location                              | Tools                                           | Fate                                                  |
-| ---------------------- | ------------------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
-| **CriticSubmitServer** | `critic/submit_server.py`             | `submit`, `report_failure`                      | **Kill** - replaced by in-container tools + exit 0    |
-| **GraderSubmitServer** | `grader/submit_server.py`             | `grader_submit`, `report_failure`               | **Kill** - replaced by in-container tools + exit 0    |
-| **PromptEvalServer**   | `prompt_optimize/prompt_optimizer.py` | `run_critic`, `run_grader`, `wait_until_graded` | **Keep** - PO/PI containers connect via MCP-over-HTTP |
-| **ClassifierServer**   | `noop_classifier/classifier.py`       | `submit_classifications`                        | **Keep** - specialized utility, not core agent flow   |
+| Server                 | Location                        | Tools                      | Fate                                                 |
+| ---------------------- | ------------------------------- | -------------------------- | ---------------------------------------------------- |
+| **CriticSubmitServer** | `critic/submit_server.py`       | `submit`, `report_failure` | **Killed** - replaced by in-container tools + exit 0 |
+| **GraderSubmitServer** | `grader/submit_server.py`       | `grader_submit`, ...       | **Killed** - replaced by in-container tools + exit 0 |
+| **PromptEvalServer**   | (deleted)                       | (migrated)                 | **Killed** - replaced by REST API + DB polling       |
+| **ClassifierServer**   | `noop_classifier/classifier.py` | `submit_classifications`   | **Keep** - specialized utility, not core agent flow  |
 
 ### Snapshot Fetching
 


### PR DESCRIPTION
- Remove WaitUntilGradedRequest from eval_api_models (no REST endpoint)
- Update wait_until_graded() to poll grading_pending view directly
- Add validation: only accept finished critic runs started by this agent
- Update test mocks to use DirectToolProvider tools instead of MCP
- Remove mcp_http_server BUILD target (module was deleted)
- Update documentation to reflect REST API + DB polling architecture
- Fix compose.yaml comments to show correct endpoints
- Add psql monitoring instructions to database_access.md