### PR TITLE
Fix missing props.backend dependency in test fixtures

### DIFF
--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -46,6 +46,8 @@ py_library(
         "//props/critic_dev/improve:main_lib",
         # props.testing for fake_openai_server
         "//props/testing:fake_openai_server",
+        # props.backend for e2e_container (AuthMiddleware, llm routes)
+        "//props/backend:backend",
         "@pypi//aiodocker",
         "@pypi//fastapi",
         "@pypi//pydantic",


### PR DESCRIPTION
The props/testing/fixtures:fixtures target includes e2e_container.py which imports from props.backend.auth and props.backend.routes.llm, but the target was missing //props/backend:backend in its deps. This caused all props tests to fail with:

    ModuleNotFoundError: No module named 'props.backend'

The error occurred because props/conftest.py imports e2e_container at module level, triggering the import chain for every test that loads the conftest.

https://claude.ai/code/session_019WXQi3y1o6M4kqT7p39oEX