### PR TITLE
Consolidate Bazel cache setup into composite action

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -1,0 +1,58 @@
+# Composite action for Bazel environment setup
+#
+# Combines BuildBuddy remote cache setup and GitHub Actions cache fallback.
+# Use this as the single entry point for Bazel caching in workflows.
+#
+# Usage:
+#   - uses: ./.github/actions/setup-bazel
+#     id: bazel
+#     with:
+#       buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+#
+#   # ... your build steps ...
+#
+#   - uses: ./.github/actions/bazel-cache-save
+#     if: always()
+#     with:
+#       cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+#       cache-key: ${{ steps.bazel.outputs.cache-key }}
+#       skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
+name: Setup Bazel
+description: Setup Bazel with BuildBuddy remote cache or GitHub Actions cache fallback
+
+inputs:
+  buildbuddy_api_key:
+    description: "BuildBuddy API key for remote cache (optional - falls back to GHA cache)"
+    required: false
+    default: ""
+  extra_hash:
+    description: "Additional hash to append to cache key (use hashFiles() at call site)"
+    required: false
+    default: ""
+
+outputs:
+  buildbuddy-enabled:
+    description: "Whether BuildBuddy remote cache is configured ('true' or 'false')"
+    value: ${{ steps.buildbuddy.outputs.enabled }}
+  cache-hit:
+    description: "Whether GitHub Actions cache was restored"
+    value: ${{ steps.cache.outputs.cache-hit }}
+  cache-key:
+    description: "Cache key (for bazel-cache-save)"
+    value: ${{ steps.cache.outputs.cache-key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup BuildBuddy
+      id: buildbuddy
+      uses: ./.github/actions/setup-buildbuddy
+      with:
+        api_key: ${{ inputs.buildbuddy_api_key }}
+
+    - name: Setup Bazel cache
+      id: cache
+      uses: ./.github/actions/bazel-cache
+      with:
+        extra_hash: ${{ inputs.extra_hash }}
+        skip_cache: ${{ steps.buildbuddy.outputs.enabled }}

--- a/.github/workflows/agent-server-e2e-test.yml
+++ b/.github/workflows/agent-server-e2e-test.yml
@@ -31,15 +31,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Pull required Docker images
         run: docker pull python:3.12-slim
@@ -71,6 +66,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -36,15 +36,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build
         run: bazel build --keep_going ${{ inputs.targets }}
@@ -52,6 +47,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-lint.yml
+++ b/.github/workflows/bazel-lint.yml
@@ -55,15 +55,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Lint
         run: |
@@ -87,6 +82,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -54,16 +54,11 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
           extra_hash: ${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
 
       - name: Rust lint
         run: |
@@ -87,6 +82,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -67,15 +67,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       # Pull Docker image needed by agent_server tests (removed by free-disk-space)
       - name: Pull test Docker image
@@ -142,6 +137,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-typecheck.yml
+++ b/.github/workflows/bazel-typecheck.yml
@@ -54,15 +54,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Typecheck
         run: |
@@ -89,6 +84,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
     needs: compute-targets
     if: needs.compute-targets.outputs.has_props_frontend == 'true'
     uses: ./.github/workflows/visual-regression.yml
+    secrets:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   # Conditional - only when Bazel targets changed
   bazel-build:

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -47,8 +47,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
+        with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Check if release needed
         id: check
@@ -65,8 +67,9 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 
   # All tests run on all pushes and PRs
   test:
@@ -86,8 +89,10 @@ jobs:
       - name: Verify keytool available
         run: keytool -help >/dev/null
 
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
+        with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Run unit tests (sandboxed)
         run: |
@@ -131,8 +136,9 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 
   # Build wheel, test it, and release (only on push to devel/main when release is needed)
   wheel-build-test-release:
@@ -174,8 +180,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
+        with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build wheel
         run: bazel build //tools/claude_hooks:claude_hooks_wheel
@@ -277,5 +285,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,29 +31,10 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install Bazelisk
-        run: |
-          # Bazelisk is usually pre-installed on GitHub Actions runners
-          # but we'll ensure it's available and up to date
-          if ! command -v bazelisk &> /dev/null; then
-            echo "Installing Bazelisk..."
-            BAZELISK_VERSION="v1.24.0"
-            BAZELISK_ARCH="linux-amd64"
-            curl -fsSL "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${BAZELISK_ARCH}" -o /usr/local/bin/bazelisk
-            chmod +x /usr/local/bin/bazelisk
-            ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
-          fi
-          bazelisk version
-
-      - name: Cache Bazel artifacts
-        uses: actions/cache@v4
+      - name: Setup Bazel
+        uses: ./.github/actions/setup-bazel
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazelisk
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'requirements_bazel.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/editor-e2e-test.yml
+++ b/.github/workflows/editor-e2e-test.yml
@@ -31,15 +31,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build and load editor runtime image
         run: bazel run //editor_agent/runtime:load
@@ -68,6 +63,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/props-e2e-test.yml
+++ b/.github/workflows/props-e2e-test.yml
@@ -43,15 +43,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/setup-buildbuddy
-        id: buildbuddy
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
-          api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
-        with:
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       # Generate PGPASSWORD (compose.yaml expects it from environment)
       - name: Setup environment
@@ -149,6 +144,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-          skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -5,6 +5,10 @@ name: Visual regression tests
 
 on:
   workflow_call:
+    secrets:
+      BUILDBUDDY_API_KEY:
+        description: "BuildBuddy API key for remote cache (optional)"
+        required: false
   workflow_dispatch:
 
 jobs:
@@ -27,9 +31,10 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: ./.github/actions/bazel-cache
-        id: bazel-cache
+      - uses: ./.github/actions/setup-bazel
+        id: bazel
         with:
+          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
           extra_hash: ${{ hashFiles('props/frontend/pnpm-lock.yaml') }}
 
       - name: Run visual regression tests
@@ -67,5 +72,6 @@ jobs:
       - uses: ./.github/actions/bazel-cache-save
         if: always()
         with:
-          cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
+          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+          cache-key: ${{ steps.bazel.outputs.cache-key }}
+          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}


### PR DESCRIPTION
## Summary
Introduces a new composite GitHub Action (`setup-bazel`) that consolidates Bazel environment setup by combining BuildBuddy remote cache configuration and GitHub Actions cache fallback into a single reusable action. This simplifies workflow configuration and reduces duplication across multiple CI workflows.

## Key Changes
- **New composite action**: Created `.github/actions/setup-bazel` that wraps both `setup-buildbuddy` and `bazel-cache` actions
  - Accepts `buildbuddy_api_key` and optional `extra_hash` inputs
  - Outputs `buildbuddy-enabled`, `cache-hit`, and `cache-key` for downstream steps
  
- **Workflow updates**: Replaced two-step setup pattern across all workflows:
  - `setup-buildbuddy` + `bazel-cache` → single `setup-bazel` call
  - Updated 10+ workflows: `bazel-build.yml`, `bazel-test.yml`, `bazel-lint.yml`, `bazel-typecheck.yml`, `bazel-rust-lint.yml`, `agent-server-e2e-test.yml`, `editor-e2e-test.yml`, `props-e2e-test.yml`, `claude-hooks-release.yml`, `ci.yml`, `copilot-setup-steps.yml`, and `visual-regression.yml`

- **Output consistency**: Standardized output references across all workflows to use `steps.bazel.outputs.*` instead of separate `steps.buildbuddy.outputs.*` and `steps.bazel-cache.outputs.*`

- **Workflow improvements**:
  - Added `BUILDBUDDY_API_KEY` secret to `visual-regression.yml` workflow_call definition
  - Added secret pass-through in `ci.yml` for the visual-regression workflow
  - Simplified `copilot-setup-steps.yml` by removing manual Bazelisk installation and cache setup

## Implementation Details
- The composite action maintains backward compatibility by properly delegating to existing actions
- All workflows now have a consistent single entry point for Bazel setup
- The `extra_hash` parameter is properly passed through for workflows that need it (e.g., Rust lint with Cargo.lock)
- Cache save steps now consistently reference the unified output names