### PR TITLE
Fix Python closure variable error in make_logging_callback

### DIFF
--- a/cli_util/logging.py
+++ b/cli_util/logging.py
@@ -106,16 +106,11 @@ def make_logging_callback(default_level: LogLevel = LogLevel.INFO):
             typer.Option(
                 "--log-output",
                 envvar="ADGN_LOG_OUTPUT",
-                help="Where to send logs: 'stderr' (default), 'stdout', 'none', or a file path",
+                help="Where to send logs: 'stderr', 'stdout', 'none', or a file path",
             ),
         ] = "stderr",
         log_level: Annotated[
-            str,
-            typer.Option(
-                "--log-level",
-                envvar="ADGN_LOG_LEVEL",
-                help=f"Log level: {', '.join(LogLevel)} (default: {default_level})",
-            ),
+            str, typer.Option("--log-level", envvar="ADGN_LOG_LEVEL", help="Log level")
         ] = default_level,
     ) -> None:
         """Configure logging for all subcommands."""


### PR DESCRIPTION
Remove closure variable references from annotation help text. With PEP 563
(`from __future__ import annotations`), annotations are stored as strings and
evaluated later via eval() in the module's global namespace, where closure
variables don't exist. Default argument values are still evaluated at function
definition time (inside the closure), so using `default_level` there is fine.

https://claude.ai/code/session_018Yb7uaA9TW5dBfSMudoNrc