### PR TITLE
Fix database initialization order in e2e tests

### DIFF
--- a/.github/workflows/props-e2e-test.yml
+++ b/.github/workflows/props-e2e-test.yml
@@ -65,15 +65,31 @@ jobs:
           docker pull postgres:16
           docker pull registry:2
 
-      # Start services using existing compose.yaml
-      - name: Start infrastructure
+      # Start postgres and registry first (backend needs schema to exist)
+      - name: Start postgres and registry
         working-directory: props
         run: |
-          docker compose up -d
+          docker compose up -d postgres registry
           echo "Waiting for PostgreSQL..."
           until pg_isready -h 127.0.0.1 -p 5433 -U postgres; do sleep 1; done
           echo "Waiting for registry..."
           until curl -sf http://127.0.0.1:5000/v2/; do sleep 1; done
+
+      # Initialize database schema and sync test data (before backend starts)
+      - name: Setup database
+        env:
+          PGHOST: 127.0.0.1
+          PGPORT: 5433
+          PGUSER: postgres
+          PGDATABASE: eval_results
+          ADGN_PROPS_SPECIMENS_ROOT: ${{ github.workspace }}/props/testing/fixtures/testdata/specimens
+        run: bazel run //props/cli:cli -- db recreate -y
+
+      # Now start backend (schema exists)
+      - name: Start backend
+        working-directory: props
+        run: |
+          docker compose up -d backend
           echo "Waiting for backend..."
           for i in {1..60}; do
             HTTP=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/health || echo "000")
@@ -86,16 +102,6 @@ jobs:
             sleep 1
           done
           echo "Infrastructure ready"
-
-      # Initialize database schema and sync test data
-      - name: Setup database
-        env:
-          PGHOST: 127.0.0.1
-          PGPORT: 5433
-          PGUSER: postgres
-          PGDATABASE: eval_results
-          ADGN_PROPS_SPECIMENS_ROOT: ${{ github.workspace }}/props/testing/fixtures/testdata/specimens
-        run: bazel run //props/cli:cli -- db recreate -y
 
       # Build and push agent images to local registry
       - name: Push agent images

--- a/props/cli/cmd_grader_agent.py
+++ b/props/cli/cmd_grader_agent.py
@@ -25,10 +25,8 @@ from rich.table import Table
 
 from agent_pkg.runtime.output import render_agent_prompt
 from props.core.agent_helpers import get_current_agent_run
-from props.core.agent_types import GraderTypeConfig
 from props.core.display import short_uuid
 from props.db.models import (
-    AgentRun,
     FalsePositive,
     FalsePositiveOccurrenceORM,
     GradingPending,

--- a/props/core/agent_types.py
+++ b/props/core/agent_types.py
@@ -120,11 +120,7 @@ class ImprovementTypeConfig(BaseModel):
 
 # Discriminated union for type-specific config
 TypeConfig = Annotated[
-    CriticTypeConfig
-    | GraderTypeConfig
-    | FreeformTypeConfig
-    | PromptOptimizerTypeConfig
-    | ImprovementTypeConfig,
+    CriticTypeConfig | GraderTypeConfig | FreeformTypeConfig | PromptOptimizerTypeConfig | ImprovementTypeConfig,
     Field(discriminator="agent_type"),
 ]
 


### PR DESCRIPTION
## Summary
Reorders the e2e test workflow to initialize the database schema before starting the backend service, ensuring the database is ready when the backend attempts to connect.

## Key Changes
- **Workflow reordering**: Split the infrastructure startup into three sequential steps:
  1. Start postgres and registry services
  2. Initialize database schema via `bazel run //props/cli:cli -- db recreate`
  3. Start backend service (which now has a ready database)
- **Removed unused imports**: Cleaned up unused imports in `props/cli/cmd_grader_agent.py` (`GraderTypeConfig`, `AgentRun`)
- **Code formatting**: Reformatted the `TypeConfig` union in `props/core/agent_types.py` to a single line for consistency

## Implementation Details
The key insight is that the backend service requires the database schema to exist before it starts. By explicitly running the database initialization step before starting the backend, we eliminate a race condition where the backend might fail to connect or initialize properly. The postgres and registry services are started first with explicit health checks to ensure they're ready before proceeding.