### PR TITLE
Configure BuildBuddy remote cache compression and profiling

### DIFF
--- a/tools/setup-buildbuddy.sh
+++ b/tools/setup-buildbuddy.sh
@@ -27,6 +27,11 @@ common --remote_cache=grpcs://remote.buildbuddy.io
 common --remote_timeout=10m
 common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
 common --experimental_remote_cache_compression
+common --experimental_remote_cache_compression_threshold=100
+build --noslim_profile
+build --experimental_profile_include_target_label
+build --experimental_profile_include_primary_output
+build --nolegacy_important_outputs
 EOF
 
 # Ensure ~/.bazelrc has the try-import (for CI environments without home-manager)


### PR DESCRIPTION
## Summary
Enhanced the BuildBuddy setup configuration to improve remote cache efficiency and enable detailed build profiling capabilities.

## Key Changes
- **Remote cache compression threshold**: Set `experimental_remote_cache_compression_threshold=100` to compress cache artifacts larger than 100 bytes, reducing network bandwidth usage
- **Build profiling**: Enabled three experimental profiling flags:
  - `experimental_profile_include_target_label`: Include target labels in build profiles for better traceability
  - `experimental_profile_include_primary_output`: Include primary output information in profiles
  - `noslim_profile`: Disable slim profile mode to capture more detailed profiling data
- **Output handling**: Disabled `legacy_important_outputs` to use the newer output handling mechanism

## Details
These changes optimize the remote caching behavior by compressing smaller artifacts and provide more comprehensive build profiling data for performance analysis and debugging. The profiling enhancements will help identify bottlenecks and understand build performance characteristics more effectively.