### PR TITLE
Remove dead exports_files directives

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,8 +23,6 @@ npm_link_all_packages(name = "node_modules")
 
 # Export workspace files for npm_translate_lock data tracking
 exports_files([
-    ".clippy.toml",
-    ".yamllint.yaml",
     "mypy.ini",
     "package.json",
     "pnpm-workspace.yaml",

--- a/agent_core_testing/BUILD.bazel
+++ b/agent_core_testing/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "agent_core_testing",
     srcs = glob(

--- a/claude/claude_hooks/BUILD.bazel
+++ b/claude/claude_hooks/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "claude_hooks",
     srcs = [

--- a/claude/claude_optimizer/BUILD.bazel
+++ b/claude/claude_optimizer/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "claude_optimizer",
     srcs = [

--- a/ember/BUILD.bazel
+++ b/ember/BUILD.bazel
@@ -5,8 +5,6 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["devenv.nix"])
-
 py_library(
     name = "ember",
     srcs = [

--- a/experimental/claude-history/BUILD.bazel
+++ b/experimental/claude-history/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 
-exports_files(["pyproject.toml"])
-
 # Claude Code history reader - standalone script
 py_binary(
     name = "claude_history_reader",

--- a/experimental/cotrl/BUILD.bazel
+++ b/experimental/cotrl/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 # Experimental LLM RL scripts - not a proper package, just standalone scripts
 py_library(
     name = "cotrl",

--- a/experimental/dbus_fast_example/BUILD.bazel
+++ b/experimental/dbus_fast_example/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "dbus_fast_example",
     srcs = [

--- a/finance/BUILD.bazel
+++ b/finance/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_python//python:python.bzl", "py_library")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "gnucash_util",
     srcs = ["gnucash_util.py"],

--- a/gatelet/BUILD.bazel
+++ b/gatelet/BUILD.bazel
@@ -3,10 +3,7 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files([
-    "gatelet.toml",
-    "pyproject.toml",
-])
+exports_files(["gatelet.toml"])
 
 # Reporter is a standalone CLI tool - doesn't depend on server
 py_library(

--- a/git_commit_ai/BUILD.bazel
+++ b/git_commit_ai/BUILD.bazel
@@ -4,8 +4,6 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "git_commit_ai_lib",
     srcs = [

--- a/inop/BUILD.bazel
+++ b/inop/BUILD.bazel
@@ -3,8 +3,6 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 # no-mypy: statsmodels (transitive dep of plotnine) has broken __init__.py structure
 # that causes mypy to error with "Source file found twice under different module names".
 # rules_mypy adds all transitive deps to MYPYPATH, and mypy's exclude pattern doesn't

--- a/inventree_utils/BUILD.bazel
+++ b/inventree_utils/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 # Core utilities (no external deps)
 py_library(
     name = "iter_util",

--- a/llm/ducktape_llm_common/BUILD.bazel
+++ b/llm/ducktape_llm_common/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "core",
     srcs = [

--- a/llm/html/BUILD.bazel
+++ b/llm/html/BUILD.bazel
@@ -3,8 +3,6 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "llm_html",
     srcs = [

--- a/llm/mcp/habitify/BUILD.bazel
+++ b/llm/mcp/habitify/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "habitify",
     srcs = [

--- a/mcp_starter/BUILD.bazel
+++ b/mcp_starter/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "adgn_mcp_starter",
     srcs = glob(["adgn_mcp_starter/**/*.py"]),

--- a/props/BUILD.bazel
+++ b/props/BUILD.bazel
@@ -2,10 +2,7 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-exports_files([
-    "conftest.py",
-    "devenv.nix",
-])
+exports_files(["conftest.py"])
 
 # Shared pytest configuration for all props tests
 py_library(

--- a/sandboxed_jupyter/BUILD.bazel
+++ b/sandboxed_jupyter/BUILD.bazel
@@ -3,8 +3,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files(["pyproject.toml"])
-
 py_library(
     name = "sandboxed_jupyter",
     srcs = [

--- a/terraform/nixos-dev-env/BUILD.bazel
+++ b/terraform/nixos-dev-env/BUILD.bazel
@@ -1,3 +1,1 @@
 # Terraform NixOS dev environment
-
-exports_files(["cloud-image.nix"])

--- a/tools/yamllint/BUILD.bazel
+++ b/tools/yamllint/BUILD.bazel
@@ -2,10 +2,6 @@ load("@rules_python//python:defs.bzl", "py_binary")
 
 # Yamllint tool for YAML linting in Bazel
 
-exports_files([
-    "pyproject.toml",
-])
-
 # Yamllint binary via py_binary entry point
 py_binary(
     name = "yamllint",

--- a/wt/BUILD.bazel
+++ b/wt/BUILD.bazel
@@ -1,10 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/lint:linters.bzl", "ruff_test")
 
-exports_files([
-    "devenv.nix",
-])
-
 py_library(
     name = "cli",
     srcs = [


### PR DESCRIPTION
Remove unused exports_files from BUILD.bazel files:
- pyproject.toml exports (no longer used after consolidating deps to root)
- devenv.nix exports (not referenced by any Bazel targets)
- .clippy.toml and .yamllint.yaml exports (not referenced by any rules)
- cloud-image.nix export (not referenced)