### PR TITLE
Fix Gazelle pypi config and e2e test runfiles

### DIFF
--- a/llm/ducktape_llm_common/ducktape_llm_common/claude_linter/test_claude_pre_hook.py
+++ b/llm/ducktape_llm_common/ducktape_llm_common/claude_linter/test_claude_pre_hook.py
@@ -4,6 +4,7 @@
 import json
 from pathlib import Path
 
+import pytest_bazel
 from click.testing import CliRunner
 
 from ducktape_llm_common.claude_linter.cli import cli
@@ -151,3 +152,7 @@ class TestPreHook:
         result = run_pre_hook("not valid json")
         assert result.exit_code == 1
         assert "Invalid JSON input" in result.output
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/compositor/test_admin_client.py
+++ b/mcp_infra/compositor/test_admin_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import pytest_bazel
 from fastmcp.exceptions import ToolError
 
 from mcp_infra.compositor.admin import DetachServerArgs
@@ -40,3 +41,7 @@ async def test_admin_cannot_detach_pinned_server(compositor, compositor_admin_to
     # Verify meta server still present after failed detach
     states_after = await compositor.server_entries()
     assert COMPOSITOR_META_MOUNT_PREFIX in states_after
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/compositor/test_meta_basic.py
+++ b/mcp_infra/compositor/test_meta_basic.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest_bazel
+
 from mcp_infra.resource_utils import read_text_json_typed
 from mcp_infra.snapshots import RunningServerEntry, ServerEntry
 
@@ -18,3 +20,7 @@ async def test_compositor_meta_resources_available(make_compositor, make_simple_
         )
         entry: ServerEntry = await read_text_json_typed(client, state_uri, ServerEntry)
         assert isinstance(entry, RunningServerEntry)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/compositor/test_meta_inproc_proxies.py
+++ b/mcp_infra/compositor/test_meta_inproc_proxies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest_bazel
+
 from mcp_infra.resource_utils import read_text_json_typed
 from mcp_infra.snapshots import RunningServerEntry, ServerEntry
 
@@ -35,3 +37,7 @@ async def test_meta_presents_inproc_mounts(make_compositor, make_simple_mcp):
         assert isinstance(entry, RunningServerEntry)
         assert entry.initialize is not None
         assert isinstance(entry.tools, list)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/compositor/test_pinned_unmount.py
+++ b/mcp_infra/compositor/test_pinned_unmount.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import pytest_bazel
 
 from mcp_infra.prefix import MCPMountPrefix
 
@@ -17,3 +18,7 @@ async def test_unmount_pinned_server_errors_and_kept(compositor, make_simple_mcp
     # Verify server is still mounted by checking server entries
     entries = await compositor.server_entries()
     assert backend_prefix in entries, "pinned server should remain mounted after failed unmount"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/enhanced/test_flat_helper.py
+++ b/mcp_infra/enhanced/test_flat_helper.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Literal
 
 import pytest
+import pytest_bazel
 from fastmcp.client import Client
 from fastmcp.server import FastMCP
 from pydantic import Field
@@ -94,3 +95,7 @@ async def test_tool_flat_explicit_models(list_tools_via_client):
     tool = next(t for t in tools if t.name == "echo")
     props = (tool.inputSchema or {}).get("properties", {})
     assert set(props) >= {"msg", "upper"}
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/enhanced/test_oob_broadcast.py
+++ b/mcp_infra/enhanced/test_oob_broadcast.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import anyio
+import pytest_bazel
 from fastmcp.client import Client
 from fastmcp.client.messages import MessageHandler
 from mcp import types
@@ -77,3 +78,7 @@ async def test_notifying_fastmcp_multisession_broadcast() -> None:
     assert "resource://multi/test" in rec2.updated
     assert rec1.list_changed >= 1
     assert rec2.list_changed >= 1
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -4,16 +4,6 @@ load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
-    name = "auth_proxy",
-    srcs = [
-        "proxy/auth_forwarding_proxy.py",
-        "proxy/run_auth_proxy.py",
-    ],
-    imports = ["../.."],
-    visibility = ["//visibility:public"],
-)
-
-py_library(
     name = "claude_hooks",
     srcs = [
         "bazel_wrapper.py",
@@ -43,7 +33,6 @@ py_library(
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [
-        ":auth_proxy",
         "//tools:build_info",
         "//tools:env_utils",
         "@pypi//cryptography",
@@ -130,6 +119,8 @@ py_test(
     name = "test_e2e",
     srcs = ["test_e2e.py"],
     data = [
+        ":session_start",
+        "//tools/claude_hooks/proxy:run_auth_proxy",
         "//tools/claude_hooks/testdata/test_workspace:workspace_files",
     ],
     # Inherit proxy env vars so ForwardingTLSProxy can chain through hook's bazel proxy
@@ -154,6 +145,7 @@ py_test(
         "//tools/claude_hooks/testing:shell_helpers",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@rules_python//python/runfiles",
     ],
 )
 

--- a/tools/claude_hooks/proxy/BUILD.bazel
+++ b/tools/claude_hooks/proxy/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+py_library(
+    name = "auth_proxy",
+    srcs = [
+        "auth_forwarding_proxy.py",
+        "run_auth_proxy.py",
+    ],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "run_auth_proxy",
+    srcs = ["run_auth_proxy.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [":auth_proxy"],
+)

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -15,7 +15,6 @@ import shutil
 import signal
 import socket
 import subprocess
-import sys
 import time
 import urllib.parse
 from collections.abc import Generator
@@ -24,9 +23,33 @@ from pathlib import Path
 
 import pytest
 import pytest_bazel
+from python.runfiles import runfiles
 
 from tools.claude_hooks.testing import shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
+
+# Runfiles for locating binaries in Bazel test mode
+_RUNFILES = runfiles.Create()
+
+
+def _get_runfiles_binary(rlocation: str) -> str:
+    """Get path to a binary from runfiles.
+
+    Args:
+        rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")
+
+    Returns:
+        Absolute path to the binary.
+    """
+    path = _RUNFILES.Rlocation(rlocation)
+    if not path:
+        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
+    return path
+
+
+# Runfiles paths for binaries
+_SESSION_START = "_main/tools/claude_hooks/session_start"
+_RUN_AUTH_PROXY = "_main/tools/claude_hooks/proxy/run_auth_proxy"
 
 
 @dataclass
@@ -159,9 +182,8 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
         env["JAVA_HOME"] = java_home
 
     if not use_wheel:
-        # Bazel test mode: need PYTHONPATH and custom proxy command
-        env["PYTHONPATH"] = os.pathsep.join(sys.path)
-        env["CLAUDE_AUTH_PROXY_CMD"] = f"{sys.executable} -m tools.claude_hooks.proxy.run_auth_proxy"
+        # Bazel test mode: use runfiles binaries
+        env["CLAUDE_AUTH_PROXY_CMD"] = _get_runfiles_binary(_RUN_AUTH_PROXY)
     # When use_wheel=True, console scripts (claude-session-start, claude-auth-proxy) are in PATH
 
     return env
@@ -222,14 +244,12 @@ def run_session_start_hook(
 
     if os.environ.get("CLAUDE_HOOKS_USE_WHEEL") == "1":
         # Run installed console script (tests wheel packaging)
-        cmd = ["claude-session-start"]
-        # Don't pass PYTHONPATH - use wheel's installed packages
-        env = {k: v for k, v in env.items() if k != "PYTHONPATH"}
+        cmd = "claude-session-start"
     else:
-        # Run via python -m (Bazel test mode)
-        cmd = [sys.executable, "-m", "tools.claude_hooks.session_start"]
+        # Run via runfiles binary (Bazel test mode)
+        cmd = _get_runfiles_binary(_SESSION_START)
 
-    result = subprocess.run(cmd, check=False, input=hook_input, capture_output=True, text=True, env=env, timeout=300)
+    result = subprocess.run([cmd], check=False, input=hook_input, capture_output=True, text=True, env=env, timeout=300)
 
     # Print hook output for debugging (pytest captures and shows on failure)
     print(f"\n=== Hook stdout ===\n{result.stdout}")
@@ -416,9 +436,8 @@ class TestPodmanIntegration:
             env["JAVA_HOME"] = java_home
 
         if not use_wheel:
-            # Bazel test mode: need PYTHONPATH and custom proxy command
-            env["PYTHONPATH"] = os.pathsep.join(sys.path)
-            env["CLAUDE_AUTH_PROXY_CMD"] = f"{sys.executable} -m tools.claude_hooks.proxy.run_auth_proxy"
+            # Bazel test mode: use runfiles binaries
+            env["CLAUDE_AUTH_PROXY_CMD"] = _get_runfiles_binary(_RUN_AUTH_PROXY)
 
         return env
 

--- a/tools/claude_hooks/testing/forwarding_tls_proxy.py
+++ b/tools/claude_hooks/testing/forwarding_tls_proxy.py
@@ -379,6 +379,12 @@ class ForwardingTLSProxy:
         server_ctx = ssl.create_default_context()
         if upstream.ca_bundle and Path(upstream.ca_bundle).exists():
             server_ctx.load_verify_locations(upstream.ca_bundle)
+        else:
+            # No CA bundle available - disable verification for test proxy
+            # This happens in CI when HTTPS_PROXY is set but SSL_CERT_FILE is not
+            logger.debug("No CA bundle for upstream proxy, disabling certificate verification")
+            server_ctx.check_hostname = False
+            server_ctx.verify_mode = ssl.CERT_NONE
         return server_ctx.wrap_socket(proxy_sock, server_hostname=target_host)
 
     def _handle_client(self, client_sock: socket.socket) -> None:


### PR DESCRIPTION
- Add pytest_bazel.main() to 7 test files missing entry points
- Fix test_e2e.py to use Bazel runfiles instead of python -m
- Move run_auth_proxy py_binary to proxy/BUILD.bazel
- Add SSL verification bypass for upstream proxy connections without CA bundle (graceful degradation)

This fixes the CI failure where tests couldn't import tools.claude_hooks.session_start in Bazel's sandboxed environment.