### PR TITLE
Remove error handling from ansible-galaxy install commands

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -73,10 +73,8 @@ jobs:
         run: |
           pip install "ansible-core>=2.18"
           cd ansible
-          # Use --ignore-errors and || true to continue even when Ansible Galaxy API is down
-          # CI should not fail due to transient Galaxy API issues (HTTP 503)
-          ansible-galaxy role install -r requirements.yaml --ignore-errors || true
-          ansible-galaxy collection install -r requirements.yaml --ignore-errors || true
+          ansible-galaxy role install -r requirements.yaml
+          ansible-galaxy collection install -r requirements.yaml
 
       - name: Restore pre-commit cache
         id: cache-precommit-restore


### PR DESCRIPTION
## Summary
Removed the `--ignore-errors` flag and error suppression (`|| true`) from the ansible-galaxy role and collection installation commands in the pre-commit CI workflow.

## Changes
- Removed `--ignore-errors` flag from `ansible-galaxy role install` command
- Removed `--ignore-errors` flag from `ansible-galaxy collection install` command
- Removed `|| true` error suppression from both commands
- Deleted associated comments about Galaxy API transient failures

## Details
Previously, the workflow was configured to continue even when the Ansible Galaxy API was unavailable (HTTP 503 errors). This change makes the workflow fail if either ansible-galaxy command fails, ensuring that dependency installation issues are caught and addressed rather than silently ignored.

This is a stricter approach that prioritizes build reliability over tolerance for transient Galaxy API issues.