### PR TITLE
Use runfiles to locate auth proxy binary in integration tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,6 +76,14 @@ py_library(
     visibility = ["//:__subpackages__"],
 )
 
+# Runfiles utilities for locating binaries and data files
+py_library(
+    name = "runfiles",
+    srcs = ["runfiles.py"],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
 # ESLint configuration as js_library
 # This makes the config and its npm dependencies available to the ESLint aspect
 # no-lint: This is a config file, not a target to lint (avoids aspect self-application)

--- a/runfiles.py
+++ b/runfiles.py
@@ -15,24 +15,6 @@ if _RUNFILES_OPT is None:
 RUNFILES: runfiles.Runfiles = _RUNFILES_OPT
 
 
-def get_binary(rlocation: str) -> str:
-    """Get path to a binary from runfiles.
-
-    Args:
-        rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")
-
-    Returns:
-        Absolute path to the binary as a string.
-
-    Raises:
-        RuntimeError: If the binary cannot be located in runfiles.
-    """
-    path = RUNFILES.Rlocation(rlocation)
-    if not path:
-        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
-    return path
-
-
 def get_path(rlocation: str) -> Path:
     """Get path to a file or directory from runfiles.
 

--- a/runfiles.py
+++ b/runfiles.py
@@ -5,14 +5,19 @@ Provides helpers to locate binaries and data files in Bazel runfiles.
 
 from __future__ import annotations
 
+from functools import cache
 from pathlib import Path
 
 from python.runfiles import runfiles
 
-_RUNFILES_OPT = runfiles.Create()
-if _RUNFILES_OPT is None:
-    raise RuntimeError("Could not create runfiles - are you running via Bazel?")
-RUNFILES: runfiles.Runfiles = _RUNFILES_OPT
+
+@cache
+def _get_runfiles() -> runfiles.Runfiles:
+    """Get runfiles instance (lazily initialized, cached)."""
+    r = runfiles.Create()
+    if r is None:
+        raise RuntimeError("Could not create runfiles - are you running via Bazel?")
+    return r
 
 
 def get_required_path(rlocation: str) -> Path:
@@ -27,7 +32,7 @@ def get_required_path(rlocation: str) -> Path:
     Raises:
         RuntimeError: If the path cannot be located or doesn't exist.
     """
-    resolved = RUNFILES.Rlocation(rlocation)
+    resolved = _get_runfiles().Rlocation(rlocation)
     if not resolved:
         raise RuntimeError(f"Could not resolve runfiles path: {rlocation}")
     path = Path(resolved)

--- a/runfiles.py
+++ b/runfiles.py
@@ -15,8 +15,8 @@ if _RUNFILES_OPT is None:
 RUNFILES: runfiles.Runfiles = _RUNFILES_OPT
 
 
-def get_path(rlocation: str) -> Path:
-    """Get path to a file or directory from runfiles.
+def get_required_path(rlocation: str) -> Path:
+    """Get path to a file or directory from runfiles, checking it exists.
 
     Args:
         rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")

--- a/test_util/BUILD.bazel
+++ b/test_util/BUILD.bazel
@@ -1,25 +1,16 @@
-"""Shared utilities: runfiles (general) and test helpers (testonly)."""
+"""Test utilities for shared testing infrastructure."""
 
 load("@rules_python//python:defs.bzl", "py_library")
 
-py_library(
-    name = "runfiles",
-    srcs = ["runfiles.py"],
-    imports = [".."],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@rules_python//python/runfiles",
-    ],
-)
+package(default_testonly = True)
 
 py_library(
     name = "test_util",
-    testonly = True,
     srcs = ["docker.py"],
     imports = [".."],
     visibility = ["//visibility:public"],
     deps = [
-        ":runfiles",
+        "//:runfiles",
         "@pypi//docker",
         "@pypi//pytest",
     ],

--- a/test_util/BUILD.bazel
+++ b/test_util/BUILD.bazel
@@ -1,15 +1,26 @@
-"""Test utilities for shared testing infrastructure."""
+"""Shared utilities: runfiles (general) and test helpers (testonly)."""
 
 load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
+    name = "runfiles",
+    srcs = ["runfiles.py"],
+    imports = [".."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rules_python//python/runfiles",
+    ],
+)
+
+py_library(
     name = "test_util",
+    testonly = True,
     srcs = ["docker.py"],
     imports = [".."],
     visibility = ["//visibility:public"],
     deps = [
+        ":runfiles",
         "@pypi//docker",
         "@pypi//pytest",
-        "@rules_python//python/runfiles",
     ],
 )

--- a/test_util/docker.py
+++ b/test_util/docker.py
@@ -29,7 +29,7 @@ def load_bazel_image(load_script_path: str, image_tag: str) -> str:
     Raises:
         RuntimeError: If loading the image fails.
     """
-    load_script = runfiles.get_path(f"_main/{load_script_path}")
+    load_script = runfiles.get_required_path(f"_main/{load_script_path}")
 
     result = subprocess.run(
         [load_script],

--- a/test_util/docker.py
+++ b/test_util/docker.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 import docker
 import pytest
-from rules_python.python.runfiles import runfiles
+
+from test_util import runfiles as runfiles_util
 
 
 def get_runfiles_path(relative_path: str) -> Path:
@@ -23,22 +24,9 @@ def get_runfiles_path(relative_path: str) -> Path:
         relative_path: Path relative to repository root (e.g., "mcp_infra/testing/python_slim_load.sh")
 
     Returns:
-        Absolute path to the file, either from runfiles or bazel-bin fallback.
+        Absolute path to the file from runfiles.
     """
-    r = runfiles.Create()
-    path = r.Rlocation(f"_main/{relative_path}")
-    if path:
-        return Path(path)
-
-    # Fallback: check bazel-bin for local dev (walk up to find repo root)
-    current = Path(__file__).parent
-    while current != current.parent:
-        if (current / "MODULE.bazel").exists():
-            return current / "bazel-bin" / relative_path
-        current = current.parent
-
-    # Last resort: assume 1 level up from this file
-    return Path(__file__).parent.parent / "bazel-bin" / relative_path
+    return runfiles_util.get_path(f"_main/{relative_path}")
 
 
 def load_bazel_image(load_script_path: str, image_tag: str) -> str:

--- a/test_util/docker.py
+++ b/test_util/docker.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import docker
 import pytest
 
-from test_util import runfiles as runfiles_util
+import runfiles
 
 
 def get_runfiles_path(relative_path: str) -> Path:
@@ -26,7 +26,7 @@ def get_runfiles_path(relative_path: str) -> Path:
     Returns:
         Absolute path to the file from runfiles.
     """
-    return runfiles_util.get_path(f"_main/{relative_path}")
+    return runfiles.get_path(f"_main/{relative_path}")
 
 
 def load_bazel_image(load_script_path: str, image_tag: str) -> str:

--- a/test_util/docker.py
+++ b/test_util/docker.py
@@ -9,24 +9,11 @@ from __future__ import annotations
 import os
 import subprocess
 from contextlib import suppress
-from pathlib import Path
 
 import docker
 import pytest
 
 import runfiles
-
-
-def get_runfiles_path(relative_path: str) -> Path:
-    """Get path to a file in Bazel runfiles.
-
-    Args:
-        relative_path: Path relative to repository root (e.g., "mcp_infra/testing/python_slim_load.sh")
-
-    Returns:
-        Absolute path to the file from runfiles.
-    """
-    return runfiles.get_path(f"_main/{relative_path}")
 
 
 def load_bazel_image(load_script_path: str, image_tag: str) -> str:
@@ -42,7 +29,7 @@ def load_bazel_image(load_script_path: str, image_tag: str) -> str:
     Raises:
         RuntimeError: If loading the image fails.
     """
-    load_script = get_runfiles_path(load_script_path)
+    load_script = runfiles.get_path(f"_main/{load_script_path}")
 
     result = subprocess.run(
         [load_script],

--- a/test_util/runfiles.py
+++ b/test_util/runfiles.py
@@ -1,0 +1,54 @@
+"""Shared runfiles utilities for Bazel tests and scripts.
+
+Provides helpers to locate binaries and data files in Bazel runfiles.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from python.runfiles import runfiles
+
+_RUNFILES_OPT = runfiles.Create()
+if _RUNFILES_OPT is None:
+    raise RuntimeError("Could not create runfiles - are you running via Bazel?")
+RUNFILES: runfiles.Runfiles = _RUNFILES_OPT
+
+
+def get_binary(rlocation: str) -> str:
+    """Get path to a binary from runfiles.
+
+    Args:
+        rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")
+
+    Returns:
+        Absolute path to the binary as a string.
+
+    Raises:
+        RuntimeError: If the binary cannot be located in runfiles.
+    """
+    path = RUNFILES.Rlocation(rlocation)
+    if not path:
+        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
+    return path
+
+
+def get_path(rlocation: str) -> Path:
+    """Get path to a file or directory from runfiles.
+
+    Args:
+        rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")
+
+    Returns:
+        Absolute Path to the file or directory.
+
+    Raises:
+        RuntimeError: If the path cannot be located or doesn't exist.
+    """
+    resolved = RUNFILES.Rlocation(rlocation)
+    if not resolved:
+        raise RuntimeError(f"Could not resolve runfiles path: {rlocation}")
+    path = Path(resolved)
+    if not path.exists():
+        raise RuntimeError(f"Resolved path does not exist: {path}")
+    return path

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -113,10 +113,11 @@ py_test(
     deps = [
         ":claude_hooks",
         "//net_util",
+        "//test_util:runfiles",
+        "//tools/claude_hooks/testing:runfiles_util",
         "@pypi//cryptography",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
-        "@rules_python//python/runfiles",
     ],
 )
 
@@ -146,11 +147,12 @@ py_test(
     ],
     deps = [
         ":claude_hooks",
+        "//test_util:runfiles",
         "//tools/claude_hooks/testing:forwarding_tls_proxy",
+        "//tools/claude_hooks/testing:runfiles_util",
         "//tools/claude_hooks/testing:shell_helpers",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
-        "@rules_python//python/runfiles",
     ],
 )
 

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -116,6 +116,7 @@ py_test(
         "@pypi//cryptography",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@rules_python//python/runfiles",
     ],
 )
 

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -16,6 +16,7 @@ py_library(
         "podman_service.py",
         "proxy_credentials.py",
         "proxy_setup.py",
+        "proxy_vars.py",
         "resources.py",
         "session_start.py",
         "streaming.py",

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -104,6 +104,10 @@ py_test(
 py_test(
     name = "test_integration",
     srcs = ["test_integration.py"],
+    data = [
+        # The proxy binary is spawned as a subprocess by supervisor
+        "//tools/claude_hooks/proxy:run_auth_proxy",
+    ],
     imports = ["../.."],
     tags = ["integration"],
     deps = [

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -112,8 +112,8 @@ py_test(
     tags = ["integration"],
     deps = [
         ":claude_hooks",
+        "//:runfiles",
         "//net_util",
-        "//test_util:runfiles",
         "//tools/claude_hooks/testing:runfiles_util",
         "@pypi//cryptography",
         "@pypi//pytest",
@@ -147,7 +147,7 @@ py_test(
     ],
     deps = [
         ":claude_hooks",
-        "//test_util:runfiles",
+        "//:runfiles",
         "//tools/claude_hooks/testing:forwarding_tls_proxy",
         "//tools/claude_hooks/testing:runfiles_util",
         "//tools/claude_hooks/testing:shell_helpers",

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -148,6 +148,7 @@ py_test(
     deps = [
         ":claude_hooks",
         "//:runfiles",
+        "//net_util",
         "//tools/claude_hooks/testing:forwarding_tls_proxy",
         "//tools/claude_hooks/testing:runfiles_util",
         "//tools/claude_hooks/testing:shell_helpers",

--- a/tools/claude_hooks/bazel_wrapper.py
+++ b/tools/claude_hooks/bazel_wrapper.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from tools.claude_hooks import proxy_setup, supervisor_setup
 from tools.claude_hooks.errors import BazelProxyError, MissingEnvVarError
 from tools.claude_hooks.proxy_credentials import check_credential_expiry
+from tools.claude_hooks.proxy_vars import PROXY_ENV_VARS
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ def main() -> None:
         log_recovery_instructions(require_env("DUCKTAPE_REPO_ROOT"))
         raise SystemExit(1) from e
 
-    for var in ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]:
+    for var in PROXY_ENV_VARS:
         os.environ[var] = require_env("BAZEL_LOCAL_PROXY")
 
     bazelisk_path = require_env("BAZELISK_PATH")

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from tools.claude_hooks.proxy_vars import PROXY_ENV_VARS
+
 
 def _exports_from_dict(env_vars: dict[str, str]) -> list[str]:
     """Generate export lines from a dict of env var name -> value.
@@ -91,18 +93,8 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
 
     # Proxy env vars for subprocesses (point to local auth-forwarding proxy)
     # These override Anthropic's original proxy vars so subprocesses use our local proxy
-    proxy_var_names = [
-        "HTTPS_PROXY",
-        "https_proxy",
-        "HTTP_PROXY",
-        "http_proxy",
-        "GLOBAL_AGENT_HTTPS_PROXY",
-        "GLOBAL_AGENT_HTTP_PROXY",
-        "YARN_HTTPS_PROXY",
-        "YARN_HTTP_PROXY",
-    ]
     exports.extend(["", "# Proxy env vars for subprocesses (point to local auth-forwarding proxy)"])
-    exports.extend(_exports_from_dict(dict.fromkeys(proxy_var_names, local_proxy)))
+    exports.extend(_exports_from_dict(dict.fromkeys(PROXY_ENV_VARS, local_proxy)))
 
     # Upstream proxy (original before hook rewrites HTTPS_PROXY)
     # Exported so tests can chain through the real upstream when testing the hook

--- a/tools/claude_hooks/proxy_vars.py
+++ b/tools/claude_hooks/proxy_vars.py
@@ -1,0 +1,17 @@
+"""Proxy environment variable names used by claude_hooks.
+
+These constants define the standard proxy environment variables that various
+tools and runtimes recognize. Use these instead of hardcoding the strings.
+"""
+
+# All proxy variables recognized by various tools (curl, yarn, global-agent, etc.)
+PROXY_ENV_VARS = [
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "GLOBAL_AGENT_HTTPS_PROXY",
+    "GLOBAL_AGENT_HTTP_PROXY",
+    "YARN_HTTPS_PROXY",
+    "YARN_HTTP_PROXY",
+]

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -23,33 +23,10 @@ from pathlib import Path
 
 import pytest
 import pytest_bazel
-from python.runfiles import runfiles
 
-from tools.claude_hooks.testing import shell_helpers
+from test_util.runfiles import get_binary
+from tools.claude_hooks.testing import runfiles_util, shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
-
-# Runfiles for locating binaries in Bazel test mode
-_RUNFILES = runfiles.Create()
-
-
-def _get_runfiles_binary(rlocation: str) -> str:
-    """Get path to a binary from runfiles.
-
-    Args:
-        rlocation: Runfiles path (e.g., "_main/tools/claude_hooks/session_start")
-
-    Returns:
-        Absolute path to the binary.
-    """
-    path = _RUNFILES.Rlocation(rlocation)
-    if not path:
-        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
-    return path
-
-
-# Runfiles paths for binaries
-_SESSION_START = "_main/tools/claude_hooks/session_start"
-_RUN_AUTH_PROXY = "_main/tools/claude_hooks/proxy/run_auth_proxy"
 
 
 @dataclass
@@ -183,7 +160,7 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
 
     if not use_wheel:
         # Bazel test mode: use runfiles binaries
-        env["CLAUDE_AUTH_PROXY_CMD"] = _get_runfiles_binary(_RUN_AUTH_PROXY)
+        env["CLAUDE_AUTH_PROXY_CMD"] = get_binary(runfiles_util.RUN_AUTH_PROXY)
     # When use_wheel=True, console scripts (claude-session-start, claude-auth-proxy) are in PATH
 
     return env
@@ -247,7 +224,7 @@ def run_session_start_hook(
         cmd = "claude-session-start"
     else:
         # Run via runfiles binary (Bazel test mode)
-        cmd = _get_runfiles_binary(_SESSION_START)
+        cmd = get_binary(runfiles_util.SESSION_START)
 
     result = subprocess.run([cmd], check=False, input=hook_input, capture_output=True, text=True, env=env, timeout=300)
 
@@ -437,7 +414,7 @@ class TestPodmanIntegration:
 
         if not use_wheel:
             # Bazel test mode: use runfiles binaries
-            env["CLAUDE_AUTH_PROXY_CMD"] = _get_runfiles_binary(_RUN_AUTH_PROXY)
+            env["CLAUDE_AUTH_PROXY_CMD"] = get_binary(runfiles_util.RUN_AUTH_PROXY)
 
         return env
 

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
+from net_util.net import pick_free_port
 from runfiles import get_required_path
 from tools.claude_hooks.testing import runfiles_util, shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
@@ -106,23 +107,14 @@ def isolated_dirs(tmp_path: Path) -> IsolatedDirs:
     return dirs
 
 
-def _pick_free_port() -> int:
-    """Pick an available ephemeral port."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port: int = sock.getsockname()[1]
-    sock.close()
-    return port
-
-
 @pytest.fixture
 def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) -> dict[str, str]:
     """Set up environment for running the session start hook."""
     proxy_url = f"http://proxy_user:test_jwt_token@127.0.0.1:{forwarding_proxy.port}"
 
     # Pick isolated ports for supervisor and bazel proxy
-    supervisor_port = _pick_free_port()
-    bazel_proxy_port = _pick_free_port()
+    supervisor_port = pick_free_port()
+    bazel_proxy_port = pick_free_port()
 
     use_wheel = os.environ.get("CLAUDE_HOOKS_USE_WHEEL") == "1"
 
@@ -377,8 +369,8 @@ class TestPodmanIntegration:
         proxy_url = f"http://proxy_user:test_jwt_token@127.0.0.1:{forwarding_proxy.port}"
 
         # Pick isolated ports for supervisor and bazel proxy
-        supervisor_port = _pick_free_port()
-        bazel_proxy_port = _pick_free_port()
+        supervisor_port = pick_free_port()
+        bazel_proxy_port = pick_free_port()
 
         use_wheel = os.environ.get("CLAUDE_HOOKS_USE_WHEEL") == "1"
 

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from test_util.runfiles import get_binary
+from runfiles import get_path
 from tools.claude_hooks.testing import runfiles_util, shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
 
@@ -160,7 +160,7 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
 
     if not use_wheel:
         # Bazel test mode: use runfiles binaries
-        env["CLAUDE_AUTH_PROXY_CMD"] = get_binary(runfiles_util.RUN_AUTH_PROXY)
+        env["CLAUDE_AUTH_PROXY_CMD"] = str(get_path(runfiles_util.RUN_AUTH_PROXY))
     # When use_wheel=True, console scripts (claude-session-start, claude-auth-proxy) are in PATH
 
     return env
@@ -224,7 +224,7 @@ def run_session_start_hook(
         cmd = "claude-session-start"
     else:
         # Run via runfiles binary (Bazel test mode)
-        cmd = get_binary(runfiles_util.SESSION_START)
+        cmd = get_path(runfiles_util.SESSION_START)
 
     result = subprocess.run([cmd], check=False, input=hook_input, capture_output=True, text=True, env=env, timeout=300)
 
@@ -414,7 +414,7 @@ class TestPodmanIntegration:
 
         if not use_wheel:
             # Bazel test mode: use runfiles binaries
-            env["CLAUDE_AUTH_PROXY_CMD"] = get_binary(runfiles_util.RUN_AUTH_PROXY)
+            env["CLAUDE_AUTH_PROXY_CMD"] = str(get_path(runfiles_util.RUN_AUTH_PROXY))
 
         return env
 

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from runfiles import get_path
+from runfiles import get_required_path
 from tools.claude_hooks.testing import runfiles_util, shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
 
@@ -160,7 +160,7 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
 
     if not use_wheel:
         # Bazel test mode: use runfiles binaries
-        env["CLAUDE_AUTH_PROXY_CMD"] = str(get_path(runfiles_util.RUN_AUTH_PROXY))
+        env["CLAUDE_AUTH_PROXY_CMD"] = str(get_required_path(runfiles_util.RUN_AUTH_PROXY))
     # When use_wheel=True, console scripts (claude-session-start, claude-auth-proxy) are in PATH
 
     return env
@@ -224,7 +224,7 @@ def run_session_start_hook(
         cmd = "claude-session-start"
     else:
         # Run via runfiles binary (Bazel test mode)
-        cmd = get_path(runfiles_util.SESSION_START)
+        cmd = get_required_path(runfiles_util.SESSION_START)
 
     result = subprocess.run([cmd], check=False, input=hook_input, capture_output=True, text=True, env=env, timeout=300)
 
@@ -414,7 +414,7 @@ class TestPodmanIntegration:
 
         if not use_wheel:
             # Bazel test mode: use runfiles binaries
-            env["CLAUDE_AUTH_PROXY_CMD"] = str(get_path(runfiles_util.RUN_AUTH_PROXY))
+            env["CLAUDE_AUTH_PROXY_CMD"] = str(get_required_path(runfiles_util.RUN_AUTH_PROXY))
 
         return env
 

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -26,6 +26,7 @@ import pytest_bazel
 
 from net_util.net import pick_free_port
 from runfiles import get_required_path
+from tools.claude_hooks.proxy_vars import PROXY_ENV_VARS
 from tools.claude_hooks.testing import runfiles_util, shell_helpers
 from tools.claude_hooks.testing.forwarding_tls_proxy import ForwardingTLSProxy, UpstreamProxyConfig
 
@@ -125,11 +126,6 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
             "CLAUDE_CODE_REMOTE": "true",
             "CLAUDE_PROJECT_DIR": str(isolated_dirs.project),
             "CLAUDE_ENV_FILE": str(isolated_dirs.env_file),
-            # Proxy configuration (simulating Claude Code web)
-            "https_proxy": proxy_url,
-            "HTTPS_PROXY": proxy_url,
-            "http_proxy": proxy_url,
-            "HTTP_PROXY": proxy_url,
             # Isolated directories
             "HOME": str(isolated_dirs.home),
             "XDG_CACHE_HOME": str(isolated_dirs.cache),
@@ -143,6 +139,8 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
             "CLAUDE_HOOKS_SKIP_PODMAN": "1",
             # Skip bazelisk download (tests use system bazel)
             "CLAUDE_HOOKS_SKIP_BAZELISK": "1",
+            # Proxy configuration (simulating Claude Code web)
+            **dict.fromkeys(PROXY_ENV_VARS, proxy_url),
         }
     )
 

--- a/tools/claude_hooks/test_integration.py
+++ b/tools/claude_hooks/test_integration.py
@@ -26,23 +26,11 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from python.runfiles import runfiles
 
 from net_util.net import pick_free_port
+from test_util.runfiles import get_binary
 from tools.claude_hooks import proxy_setup, supervisor_setup
-
-# Runfiles for locating binaries in Bazel test mode
-_RUNFILES = runfiles.Create()
-_RUN_AUTH_PROXY = "_main/tools/claude_hooks/proxy/run_auth_proxy"
-
-
-def _get_runfiles_binary(rlocation: str) -> str:
-    """Get path to a binary from runfiles."""
-    path = _RUNFILES.Rlocation(rlocation)
-    if not path:
-        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
-    return path
-
+from tools.claude_hooks.testing import runfiles_util
 
 # =============================================================================
 # Test Fixtures: Mock TLS-Inspecting Proxy
@@ -253,7 +241,7 @@ def isolated_env(tmp_path: Path, mock_tls_proxy: MockTLSProxy, monkeypatch: pyte
     monkeypatch.setenv("CLAUDE_HOOKS_BAZEL_PROXY_PORT", str(test_proxy_port))
 
     # Set CLAUDE_AUTH_PROXY_CMD to use the runfiles binary (same approach as test_e2e)
-    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", _get_runfiles_binary(_RUN_AUTH_PROXY))
+    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", get_binary(runfiles_util.RUN_AUTH_PROXY))
 
     # Set https_proxy env var pointing to mock proxy
     proxy_url = f"http://testuser:testpass@127.0.0.1:{mock_tls_proxy.port}"

--- a/tools/claude_hooks/test_integration.py
+++ b/tools/claude_hooks/test_integration.py
@@ -13,7 +13,6 @@ import os
 import signal
 import socket
 import ssl
-import sys
 import threading
 import time
 from collections.abc import Generator
@@ -27,9 +26,23 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from python.runfiles import runfiles
 
 from net_util.net import pick_free_port
 from tools.claude_hooks import proxy_setup, supervisor_setup
+
+# Runfiles for locating binaries in Bazel test mode
+_RUNFILES = runfiles.Create()
+_RUN_AUTH_PROXY = "_main/tools/claude_hooks/proxy/run_auth_proxy"
+
+
+def _get_runfiles_binary(rlocation: str) -> str:
+    """Get path to a binary from runfiles."""
+    path = _RUNFILES.Rlocation(rlocation)
+    if not path:
+        raise RuntimeError(f"Could not locate {rlocation} in runfiles")
+    return path
+
 
 # =============================================================================
 # Test Fixtures: Mock TLS-Inspecting Proxy
@@ -239,12 +252,8 @@ def isolated_env(tmp_path: Path, mock_tls_proxy: MockTLSProxy, monkeypatch: pyte
     monkeypatch.setenv("CLAUDE_HOOKS_BAZEL_PROXY_DIR", str(bazel_proxy_dir))
     monkeypatch.setenv("CLAUDE_HOOKS_BAZEL_PROXY_PORT", str(test_proxy_port))
 
-    # Set CLAUDE_AUTH_PROXY_CMD so proxy_setup can run the proxy in Bazel sandbox
-    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", f"{sys.executable} -m tools.claude_hooks.proxy.run_auth_proxy")
-
-    # Set PYTHONPATH so the subprocess can find the module (Bazel sets up sys.path but not PYTHONPATH)
-    pythonpath = os.pathsep.join(sys.path)
-    monkeypatch.setenv("PYTHONPATH", pythonpath)
+    # Set CLAUDE_AUTH_PROXY_CMD to use the runfiles binary (same approach as test_e2e)
+    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", _get_runfiles_binary(_RUN_AUTH_PROXY))
 
     # Set https_proxy env var pointing to mock proxy
     proxy_url = f"http://testuser:testpass@127.0.0.1:{mock_tls_proxy.port}"

--- a/tools/claude_hooks/test_integration.py
+++ b/tools/claude_hooks/test_integration.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from net_util.net import pick_free_port
-from test_util.runfiles import get_binary
+from runfiles import get_path
 from tools.claude_hooks import proxy_setup, supervisor_setup
 from tools.claude_hooks.testing import runfiles_util
 
@@ -241,7 +241,7 @@ def isolated_env(tmp_path: Path, mock_tls_proxy: MockTLSProxy, monkeypatch: pyte
     monkeypatch.setenv("CLAUDE_HOOKS_BAZEL_PROXY_PORT", str(test_proxy_port))
 
     # Set CLAUDE_AUTH_PROXY_CMD to use the runfiles binary (same approach as test_e2e)
-    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", get_binary(runfiles_util.RUN_AUTH_PROXY))
+    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", str(get_path(runfiles_util.RUN_AUTH_PROXY)))
 
     # Set https_proxy env var pointing to mock proxy
     proxy_url = f"http://testuser:testpass@127.0.0.1:{mock_tls_proxy.port}"

--- a/tools/claude_hooks/test_integration.py
+++ b/tools/claude_hooks/test_integration.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from net_util.net import pick_free_port
-from runfiles import get_path
+from runfiles import get_required_path
 from tools.claude_hooks import proxy_setup, supervisor_setup
 from tools.claude_hooks.testing import runfiles_util
 
@@ -241,7 +241,7 @@ def isolated_env(tmp_path: Path, mock_tls_proxy: MockTLSProxy, monkeypatch: pyte
     monkeypatch.setenv("CLAUDE_HOOKS_BAZEL_PROXY_PORT", str(test_proxy_port))
 
     # Set CLAUDE_AUTH_PROXY_CMD to use the runfiles binary (same approach as test_e2e)
-    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", str(get_path(runfiles_util.RUN_AUTH_PROXY)))
+    monkeypatch.setenv("CLAUDE_AUTH_PROXY_CMD", str(get_required_path(runfiles_util.RUN_AUTH_PROXY)))
 
     # Set https_proxy env var pointing to mock proxy
     proxy_url = f"http://testuser:testpass@127.0.0.1:{mock_tls_proxy.port}"

--- a/tools/claude_hooks/testing/BUILD.bazel
+++ b/tools/claude_hooks/testing/BUILD.bazel
@@ -12,6 +12,14 @@ py_library(
 )
 
 py_library(
+    name = "runfiles_util",
+    testonly = True,
+    srcs = ["runfiles_util.py"],
+    imports = ["../../.."],
+    visibility = ["//tools/claude_hooks:__subpackages__"],
+)
+
+py_library(
     name = "shell_helpers",
     testonly = True,
     srcs = ["shell_helpers.py"],

--- a/tools/claude_hooks/testing/runfiles_util.py
+++ b/tools/claude_hooks/testing/runfiles_util.py
@@ -1,0 +1,5 @@
+"""Runfiles paths for claude_hooks binaries."""
+
+# Runfiles paths for binaries
+SESSION_START = "_main/tools/claude_hooks/session_start"
+RUN_AUTH_PROXY = "_main/tools/claude_hooks/proxy/run_auth_proxy"


### PR DESCRIPTION
## Summary
Updated the integration test to use Bazel's runfiles mechanism for locating the auth proxy binary, instead of relying on `sys.path` and `PYTHONPATH` environment variables. This makes the test more robust and consistent with how Bazel tests should locate their dependencies.

## Key Changes
- Added `runfiles` dependency from `@rules_python//python/runfiles` to the test target
- Declared the proxy binary as a data dependency in the BUILD file so it's available during test execution
- Replaced the manual `PYTHONPATH` setup with a `_get_runfiles_binary()` helper function that uses the runfiles API to locate the proxy binary
- Removed the `sys` import which is no longer needed

## Implementation Details
- The runfiles mechanism is initialized once at module load time via `runfiles.Create()`
- The proxy binary location is resolved using the rlocation path `_main/tools/claude_hooks/proxy/run_auth_proxy`
- This approach is more reliable in sandboxed Bazel test environments where `sys.path` may not be properly configured for subprocess execution
- The change aligns with Bazel best practices for test dependencies and binary location