### PR TITLE
Add pytest-bazel main entry points and fix markdown formatting

### DIFF
--- a/docs/precommit-performance-analysis.md
+++ b/docs/precommit-performance-analysis.md
@@ -4,17 +4,18 @@ Analysis of pre-commit hook execution times and implemented optimizations.
 
 ## Current State (After Optimization)
 
-| Hook               | Time  | Notes                                              |
-| ------------------ | ----- | -------------------------------------------------- |
-| bazel-precommit    | ~42s  | 22s build + 14s parallel batches (16 batches)      |
-| checkov            | ~13s  | Terraform security scanner                         |
-| terraform_validate | ~11s  | Terraform validation                               |
-| terraform_tflint   | ~4s   | Terraform linting                                  |
-| markdownlint-cli2  | ~3s   | Markdown linting                                   |
-| other hooks        | ~5s   | YAML/AST/TOML checks, ruff, etc.                   |
-| **Total**          | ~78s  | Down from ~160s (parallel execution via script-path) |
+| Hook               | Time | Notes                                                |
+| ------------------ | ---- | ---------------------------------------------------- |
+| bazel-precommit    | ~42s | 22s build + 14s parallel batches (16 batches)        |
+| checkov            | ~13s | Terraform security scanner                           |
+| terraform_validate | ~11s | Terraform validation                                 |
+| terraform_tflint   | ~4s  | Terraform linting                                    |
+| markdownlint-cli2  | ~3s  | Markdown linting                                     |
+| other hooks        | ~5s  | YAML/AST/TOML checks, ruff, etc.                     |
+| **Total**          | ~78s | Down from ~160s (parallel execution via script-path) |
 
 Per-batch breakdown (runs in parallel):
+
 - prettier: ~6s (100+ files)
 - ruff: ~1s (60+ files)
 - buildifier: ~0.2s

--- a/llm/ducktape_llm_common/ducktape_llm_common/claude_linter/test_claude_post_hook.py
+++ b/llm/ducktape_llm_common/ducktape_llm_common/claude_linter/test_claude_post_hook.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import pytest_bazel
 import yaml
 from click.testing import CliRunner
 
@@ -174,3 +175,7 @@ def foo(x):
         # Should have fixed "fix-me" to "fixed"
         assert "fixed" in formatted_content
         assert "fix-me" not in formatted_content
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/enhanced/test_oob_session_capturing.py
+++ b/mcp_infra/enhanced/test_oob_session_capturing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest_bazel
 from fastmcp.client import Client
 
 from mcp_infra.enhanced.server import EnhancedFastMCP
@@ -47,3 +48,7 @@ async def test_broadcast_continues_after_session_failure(make_buffered_client):
         assert target_uri in batch.resources["notifier"].updated, (
             "expected resources_updated for the active session despite one failing client"
         )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/mcp_infra/enhanced/test_openai_strict_validation.py
+++ b/mcp_infra/enhanced/test_openai_strict_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+import pytest_bazel
 from pydantic import BaseModel, ConfigDict, Field
 
 from mcp_infra.enhanced.server import EnhancedFastMCP
@@ -127,3 +128,7 @@ def test_strict_mode_rejects_nested_set_in_defs(mcp: EnhancedFastMCP):
         def nested_set_tool(input: InputWithNestedSet) -> str:
             """Tool with nested model containing set."""
             return str(input.inner.ids)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
This PR adds pytest-bazel main entry points to test files and fixes markdown table formatting in the pre-commit performance analysis documentation.

## Key Changes
- **Test Files**: Added `if __name__ == "__main__": pytest_bazel.main()` entry points to three test files:
  - `llm/ducktape_llm_common/ducktape_llm_common/claude_linter/test_claude_post_hook.py`
  - `mcp_infra/enhanced/test_oob_session_capturing.py`
  - `mcp_infra/enhanced/test_openai_strict_validation.py`
  - Added corresponding `import pytest_bazel` statements where needed

- **Documentation**: Fixed markdown table formatting in `docs/precommit-performance-analysis.md`:
  - Adjusted column alignment and spacing for better readability
  - Added blank line after table header for improved markdown rendering
  - No content changes to the performance data itself

## Implementation Details
The pytest-bazel entry points enable these test files to be run directly as scripts while maintaining compatibility with Bazel's test runner. This is a common pattern for Python test files in Bazel-based projects.