### PR TITLE
Install Ansible Galaxy roles in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -66,9 +66,25 @@ jobs:
       # - No official status page (github.com/ansible/galaxy/issues/3508)
       # All required collections (community.docker, community.general, community.crypto,
       # ansible.netcommon, ansible.posix) are included in the ansible package.
-      # Roles from requirements.yaml are NOT needed for syntax checking.
       - name: Install Ansible
         run: pip install "ansible>=10"
+
+      # Cache Ansible Galaxy roles (required for syntax check - meta/main.yml dependencies)
+      - name: Restore Ansible Galaxy roles cache
+        id: cache-ansible-roles-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.ansible/roles
+          key: ansible-roles-${{ runner.os }}-${{ hashFiles('ansible/requirements.yaml') }}
+          restore-keys: ansible-roles-${{ runner.os }}-
+
+      # Roles ARE needed for syntax checking - ansible-playbook --syntax-check resolves
+      # role dependencies from meta/main.yml files (e.g., legacy_gui depends on
+      # petermosmans.customize-gnome)
+      - name: Install Ansible Galaxy roles
+        run: |
+          cd ansible
+          ansible-galaxy role install -r requirements.yaml
 
       - name: Restore pre-commit cache
         id: cache-precommit-restore
@@ -116,3 +132,10 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: ${{ steps.cache-precommit-restore.outputs.cache-primary-key }}
+
+      - name: Save Ansible Galaxy roles cache
+        if: always() && steps.cache-ansible-roles-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.ansible/roles
+          key: ${{ steps.cache-ansible-roles-restore.outputs.cache-primary-key }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           tflint_version: v0.53.0
 
+      - name: Initialize TFLint plugins
+        run: tflint --init --config=cluster/.tflint.hcl
+
       # kubeconform for kubeconform-precommit-hook (not hermetic via Bazel)
       # Other tools (kustomize, flux, helm, kubeseal) are hermetic via @multitool
       - name: Install kubeconform

--- a/agent_server/e2e/BUILD.bazel
+++ b/agent_server/e2e/BUILD.bazel
@@ -1,19 +1,6 @@
-"""Agent server E2E tests (manual, require Playwright)."""
+# Agent server E2E tests (manual, require Playwright).
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-
-# Common E2E test dependencies (only what's actually needed)
-_E2E_COMMON_DEPS = [
-    "//agent_core_testing",
-    "@pypi//pytest",
-    "@pypi//pytest_bazel",
-    "@pypi//pytest_asyncio",  # keep
-    "@pypi//playwright",
-]
-
-_E2E_TEST_SUPPORT = [
-    "conftest.py",
-]
 
 py_test(
     name = "test_abort",

--- a/agent_server/policies/BUILD.bazel
+++ b/agent_server/policies/BUILD.bazel
@@ -1,6 +1,6 @@
 load("presets.py", "py_library")
 
-"""Policies package - policy types, presets, and standalone policy programs."""
+# Policies package - policy types, presets, and standalone policy programs.
 
 # gazelle:map_kind py_binary py_library approve_all.py
 # gazelle:map_kind py_binary py_library default_policy.py

--- a/third_party/openai_cookbook/BUILD.bazel
+++ b/third_party/openai_cookbook/BUILD.bazel
@@ -1,6 +1,6 @@
 load("apply_patch.py", "py_library")
 
-"""Vendored OpenAI Cookbook utilities."""
+# Vendored OpenAI Cookbook utilities.
 
 # gazelle:map_kind py_binary py_library apply_patch.py
 


### PR DESCRIPTION
The ansible-playbook --syntax-check hook requires external roles because
it resolves role dependencies from meta/main.yml files. The legacy_gui
role depends on petermosmans.customize-gnome, which is installed from
ansible/requirements.yaml.

Added role installation with caching (same pattern as ansible-lint.yml).