### PR TITLE
Fix bazel wrapper to require runfiles binary in Bazel mode

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -89,7 +89,10 @@ py_library(
     srcs = ["bazelisk_setup.py"],
     imports = ["../.."],
     visibility = ["//visibility:public"],
-    deps = [":settings"],
+    deps = [
+        ":settings",
+        "@rules_python//python/runfiles",
+    ],
 )
 
 py_library(
@@ -152,6 +155,7 @@ py_binary(
 py_binary(
     name = "session_start",
     srcs = ["session_start.py"],
+    data = [":bazel_wrapper"],
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -15,10 +15,11 @@ import shutil
 import ssl
 import stat
 import subprocess
-import sys
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+from python.runfiles import runfiles
 
 from tools.claude_hooks.settings import HookSettings
 
@@ -133,6 +134,23 @@ def install_bazelisk(settings: HookSettings) -> Path:
     return bazelisk_path
 
 
+def _get_bazel_wrapper_from_runfiles() -> Path:
+    """Get bazel_wrapper binary path from Bazel runfiles.
+
+    Raises RuntimeError if not in Bazel environment or binary not found.
+    """
+    r = runfiles.Create()
+    if r is None:
+        raise RuntimeError("Not running in Bazel environment (runfiles.Create() returned None)")
+    resolved = r.Rlocation("_main/tools/claude_hooks/bazel_wrapper")
+    if not resolved:
+        raise RuntimeError("Could not resolve bazel_wrapper in runfiles")
+    path = Path(resolved)
+    if not path.exists():
+        raise RuntimeError(f"bazel_wrapper not found at {path}")
+    return path
+
+
 def install_wrapper(settings: HookSettings) -> Path:
     """Install wrapper script that sets proxy env vars before calling bazelisk.
 
@@ -148,11 +166,9 @@ def install_wrapper(settings: HookSettings) -> Path:
 
     wrapper_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create a shell wrapper that uses the same Python as the current process
-    # and invokes the bazel_wrapper module. Using -m ensures the package is found
-    # whether installed via wheel or running from source with PYTHONPATH.
+    bazel_wrapper_bin = _get_bazel_wrapper_from_runfiles()
     wrapper_script = f"""#!/bin/sh
-exec "{sys.executable}" -m tools.claude_hooks.bazel_wrapper "$@"
+exec "{bazel_wrapper_bin}" "$@"
 """
     wrapper_path.write_text(wrapper_script)
     wrapper_path.chmod(0o755)

--- a/tools/claude_hooks/test_e2e.py
+++ b/tools/claude_hooks/test_e2e.py
@@ -153,6 +153,7 @@ def hook_env(isolated_dirs: IsolatedDirs, forwarding_proxy: ForwardingTLSProxy) 
         # Bazel test mode: use runfiles binaries
         env[settings.ENV_AUTH_PROXY_CMD] = str(get_required_path(runfiles_util.RUN_AUTH_PROXY))
     # When use_wheel=True, console scripts (claude-session-start, claude-auth-proxy) are in PATH
+    # Note: bazel_wrapper auto-detects runfiles, no env var override needed
 
     return env
 


### PR DESCRIPTION
The bazel wrapper script invokes Python to run bazel_wrapper module, which
requires all dependencies to be available.

Logic:
- use_wheel=True: Use python -m (deps installed via pip for wheel installs)
- Default (Bazel): REQUIRE runfiles binary, hard fail if not found

No silent fallback - if runfiles lookup fails in Bazel mode, that's a
configuration error that should surface immediately.

Changes:
- _get_bazel_wrapper_from_runfiles() now raises RuntimeError instead of
  returning None, making failures explicit
- install_wrapper() checks use_wheel setting to determine which mode
- session_start has bazel_wrapper as data dep for runfiles lookup

This fixes the CI failure where test_bazel_build_after_hook failed with:
  "No module named tools.claude_hooks.bazel_wrapper"