### PR TITLE
Update GitHub token environment variable name

### DIFF
--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -220,12 +220,12 @@ def emit_session_context(collector: LogCollector, log_file: Path) -> None:
         lines.append("Warnings:")
         lines.extend(f"  - {msg}" for msg in collector.warnings)
 
-    # Check for GitHub CI token
-    if os.environ.get("DUCKTAPE_CI_READ_GITHUB_TOKEN"):
+    # Check for GitHub token
+    if os.environ.get("GITHUB_TOKEN"):
         lines.append("GitHub CI Access:")
-        lines.append("  DUCKTAPE_CI_READ_GITHUB_TOKEN is set - GitHub PAT with read access to ducktape repo.")
+        lines.append("  GITHUB_TOKEN is set - GitHub PAT with read access to ducktape repo.")
         lines.append(
-            "  Use via: curl -H 'Authorization: token $DUCKTAPE_CI_READ_GITHUB_TOKEN' https://api.github.com/..."
+            "  Use via: curl -H 'Authorization: token $GITHUB_TOKEN' https://api.github.com/..."
         )
         lines.append("  Capabilities: read repo, read CI logs, list workflow runs, view PR status.")
 


### PR DESCRIPTION
## Summary
Updated the session context logging to use the standard `GITHUB_TOKEN` environment variable instead of the custom `DUCKTAPE_CI_READ_GITHUB_TOKEN` variable.

## Changes
- Changed environment variable check from `DUCKTAPE_CI_READ_GITHUB_TOKEN` to `GITHUB_TOKEN`
- Updated all references in log messages and usage examples to use the standard variable name
- Updated comments to reflect the change from "GitHub CI token" to "GitHub token"

## Details
This change aligns with GitHub's standard environment variable naming convention, making the codebase more consistent with GitHub Actions and other GitHub integrations. The `GITHUB_TOKEN` is the conventional name used across GitHub's ecosystem for authentication tokens.