### PR TITLE
Simplify Ansible dependencies and remove unused roles

### DIFF
--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -2,7 +2,6 @@ roles:
   - src: geerlingguy.docker
   - src: systemli.letsencrypt
   - src: nbigot.ansible-fail2ban # Fail2Ban
-  - src: diodonfrost.p10k # Powerlevel10k
   - src: rolehippie.syncthing
 
   # My fork - makes GNOME Shell not always restart (since unneeded). TODO: merge upstream

--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -1,19 +1,6 @@
 roles:
-  - src: geerlingguy.docker
-  - src: systemli.letsencrypt
   - src: nbigot.ansible-fail2ban # Fail2Ban
-  - src: rolehippie.syncthing
-
-  # My fork - makes GNOME Shell not always restart (since unneeded). TODO: merge upstream
-  # - src: petermosmans.customize-gnome
-  - name: petermosmans.customize-gnome
-    src: https://github.com/agentydragon/ansible-role-customize-gnome.git
-    scm: git
-    version: agentydragon/updates
 
 collections:
-  - community.docker
-  - community.general # cargo
-  - community.crypto # ACME / TLS certificates
-  - ansible.netcommon
-  - ansible.posix
+  - community.general # dconf module
+  - ansible.posix # mount module


### PR DESCRIPTION
## Summary
This PR streamlines the Ansible configuration by removing unused roles and collections, keeping only the essential dependencies needed for the current playbook.

## Key Changes
- **Removed roles:**
  - `geerlingguy.docker` - Docker role no longer needed
  - `systemli.letsencrypt` - Let's Encrypt role removed
  - `diodonfrost.p10k` - Powerlevel10k shell theme removed
  - `rolehippie.syncthing` - Syncthing role removed
  - `petermosmans.customize-gnome` - Custom GNOME Shell fork removed (including the custom git-based fork)

- **Removed collections:**
  - `community.docker` - Docker collection no longer required
  - `community.general` (partial) - Kept only for `dconf` module
  - `community.crypto` - ACME/TLS certificate collection removed
  - `ansible.netcommon` - Network utilities collection removed

- **Retained dependencies:**
  - `nbigot.ansible-fail2ban` - Fail2Ban role kept
  - `community.general` - For `dconf` module support
  - `ansible.posix` - For `mount` module support

## Notes
This cleanup reduces the dependency footprint and should improve installation time and maintainability. The retained roles and collections are actively used by the playbook.