### PR TITLE
Refactor BUILD dependencies to use specific modules instead of __init__

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -107,6 +107,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":events",
+        ":handler",
         ":loop_control",
         ":tool_provider",
         "//openai_utils:model",

--- a/props/BUILD.bazel
+++ b/props/BUILD.bazel
@@ -14,7 +14,8 @@ py_library(
     imports = [".."],
     visibility = ["//props:__subpackages__"],
     deps = [
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:fixtures",
+        "//agent_core_testing:responses",
         "//mcp_infra/testing:fixtures",
         "//props/testing",
         "//props/testing/fixtures:__init__",

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -85,7 +85,7 @@ py_binary(
     srcs = ["export_schema.py"],
     main = "export_schema.py",
     visibility = ["//:__subpackages__"],
-    deps = [":__init__"],
+    deps = [":app"],
 )
 
 genrule(

--- a/props/core/BUILD.bazel
+++ b/props/core/BUILD.bazel
@@ -189,6 +189,7 @@ py_test(
     srcs = ["test_rationale.py"],
     imports = ["../.."],
     deps = [
+        "//props:conftest",
         "@pypi//pydantic",
         "@pypi//pyhamcrest",
         "@pypi//pytest",
@@ -264,7 +265,8 @@ py_test(
     deps = [
         ":eval_api_models",
         ":ids",
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
+        "//agent_core_testing:steps",
         "//props/core/models:examples",
         "//props/critic_dev:shared",
         "//props/critic_dev/optimize:main_lib",

--- a/props/critic/BUILD.bazel
+++ b/props/critic/BUILD.bazel
@@ -148,7 +148,8 @@ py_test(
     ],
     deps = [
         ":conftest",
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
+        "//agent_core_testing:steps",
         "//props/db:agent_definition_ids",
         "//props/db:models",
         "//props/db:session",

--- a/props/critic_dev/improve/BUILD.bazel
+++ b/props/critic_dev/improve/BUILD.bazel
@@ -100,7 +100,8 @@ py_test(
         "requires_docker",
     ],
     deps = [
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
+        "//agent_core_testing:steps",
         "//props/db:agent_definition_ids",
         "//props/db:examples",
         "//props/db:models",

--- a/props/critic_dev/optimize/BUILD.bazel
+++ b/props/critic_dev/optimize/BUILD.bazel
@@ -86,7 +86,7 @@ py_library(
     imports = ["../../.."],
     visibility = ["//props:__subpackages__"],
     deps = [
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
         "//openai_utils:model",
         "//props/backend:__init__",
         "//props/db:config",
@@ -117,7 +117,8 @@ py_test(
     deps = [
         ":main_lib",
         ":orchestration_fixtures",
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
+        "//agent_core_testing:steps",
         "//props/core:agent_types",
         "//props/core:eval_api_models",
         "//props/core:ids",

--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -37,6 +37,7 @@ py_library(
     imports = ["../../.."],
     visibility = ["//props/db:__subpackages__"],
     deps = [
+        ":_models",
         "//props/core:ids",
         "@pypi//pyyaml",
     ],

--- a/props/grader/BUILD.bazel
+++ b/props/grader/BUILD.bazel
@@ -223,7 +223,7 @@ py_test(
     ],
     deps = [
         ":conftest",
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
         "//props/db:models",
         "//props/db:session",
         "//props/db:snapshots",

--- a/props/testing/BUILD.bazel
+++ b/props/testing/BUILD.bazel
@@ -10,7 +10,7 @@ py_library(
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:responses",
         "//mcp_infra/exec:models",
         "//openai_utils:model",
         "//props/grader:tools",

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -68,6 +68,13 @@ py_library(
     name = "__init__",
     srcs = ["__init__.py"],
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":db",
+        ":e2e",
+        ":ground_truth",
+        ":runs",
+        ":scopes",
+    ],
 )
 
 py_library(
@@ -91,7 +98,7 @@ py_library(
     srcs = ["e2e.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//agent_core_testing:__init__",
+        "//agent_core_testing:openai_mock",
         "//openai_utils:model",
         "//props/core:ids",
         "//props/critic_dev/improve:main_lib",


### PR DESCRIPTION
Multiple tests were failing due to missing Bazel dependencies:

- agent_core:agent: Add missing :handler dependency (imports from .handler)
- props/backend:export_schema: Depend on :app instead of :__init__ to get create_app import
- props/testing/fixtures:__init__: Add deps on submodules that __init__.py imports (:db, :e2e, :ground_truth, :runs, :scopes)
- props/db/sync:_yaml: Add missing :_models dependency
- Various test targets: Replace //agent_core_testing:__init__ with specific module deps (:responses, :steps, :fixtures, :openai_mock) that tests actually import
- props:conftest: Add specific agent_core_testing module deps
- props/core:test_rationale: Add //props:conftest dep for fixture discovery

These fixes allow more tests to build and run. Remaining test failures are primarily due to missing infrastructure (PostgreSQL, Docker containers) rather than BUILD configuration issues.