### PR TITLE
Fix claude_hooks wheel missing net_util dependency

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -179,12 +179,14 @@ py_binary(
 py_package(
     name = "claude_hooks_pkg",
     packages = [
+        "net_util",
         "tools",
         "tools.claude_hooks",
         "tools.claude_hooks.proxy",
         "tools.claude_hooks.supervisor",
     ],
     deps = [
+        "//net_util:net",
         ":bazel_wrapper",
         ":bazelisk_setup",
         ":binary_tools",


### PR DESCRIPTION
The supervisor/client.py imports from net_util.net but the wheel's
py_package didn't include the net_util package. This caused
"ModuleNotFoundError: No module named 'net_util'" when running
claude-session-start from the installed wheel.

Add net_util to both the packages list and deps in py_package.