### PR TITLE
Use --query_file for bazel query to avoid argument length errors

### DIFF
--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -9,14 +9,14 @@ load("//tools/lint:linters.bzl", "ruff_test")
 py_library(
     name = "bazel_query",
     srcs = ["bazel_query.py"],
-    imports = ["../.."],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "models",
     srcs = ["models.py"],
-    imports = ["../.."],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//pydantic",
@@ -29,7 +29,7 @@ py_library(
 py_library(
     name = "bazel_diff",
     srcs = ["bazel_diff.py"],
-    imports = ["../.."],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [":bazel_query"],
 )
@@ -38,7 +38,7 @@ py_library(
     name = "ci_decide",
     srcs = ["ci_decide.py"],
     data = ["workflows.yaml"],
-    imports = ["../.."],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":bazel_query",
@@ -52,7 +52,7 @@ py_library(
     name = "generate_ci",
     srcs = ["generate_ci.py"],
     data = ["workflows.yaml"],
-    imports = ["../.."],
+    imports = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":models",

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -37,6 +37,7 @@ py_library(
 py_library(
     name = "ci_decide",
     srcs = ["ci_decide.py"],
+    data = ["workflows.yaml"],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
@@ -50,6 +51,7 @@ py_library(
 py_library(
     name = "generate_ci",
     srcs = ["generate_ci.py"],
+    data = ["workflows.yaml"],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -9,14 +9,14 @@ load("//tools/lint:linters.bzl", "ruff_test")
 py_library(
     name = "bazel_query",
     srcs = ["bazel_query.py"],
-    imports = ["."],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "models",
     srcs = ["models.py"],
-    imports = ["."],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//pydantic",
@@ -29,7 +29,7 @@ py_library(
 py_library(
     name = "bazel_diff",
     srcs = ["bazel_diff.py"],
-    imports = ["."],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [":bazel_query"],
 )
@@ -38,7 +38,7 @@ py_library(
     name = "ci_decide",
     srcs = ["ci_decide.py"],
     data = ["workflows.yaml"],
-    imports = ["."],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":bazel_query",
@@ -52,7 +52,7 @@ py_library(
     name = "generate_ci",
     srcs = ["generate_ci.py"],
     data = ["workflows.yaml"],
-    imports = ["."],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":models",

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -1,0 +1,73 @@
+# NOTE: No aggregator target - use specific per-file targets like :models, :bazel_query
+# This is the Gazelle-compatible pattern (python_generation_mode = file)
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/lint:linters.bzl", "ruff_test")
+
+# === Base modules (no internal deps) ===
+
+py_library(
+    name = "bazel_query",
+    srcs = ["bazel_query.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "models",
+    srcs = ["models.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+# === Modules with internal deps ===
+
+py_library(
+    name = "bazel_diff",
+    srcs = ["bazel_diff.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [":bazel_query"],
+)
+
+py_library(
+    name = "ci_decide",
+    srcs = ["ci_decide.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":bazel_query",
+        ":models",
+        "@pypi//pydantic",
+        "@pypi//pygit2",
+    ],
+)
+
+py_library(
+    name = "generate_ci",
+    srcs = ["generate_ci.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":models",
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+# === Linting ===
+
+ruff_test(
+    name = "ruff",
+    srcs = [
+        ":bazel_diff",
+        ":bazel_query",
+        ":ci_decide",
+        ":generate_ci",
+        ":models",
+    ],
+)

--- a/tools/ci/bazel_diff.py
+++ b/tools/ci/bazel_diff.py
@@ -35,10 +35,11 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+from bazel_query import run_query_with_file
 
 BAZEL_DIFF_VERSION = "12.1.1"
 BAZEL_DIFF_URL = f"https://github.com/Tinder/bazel-diff/releases/download/{BAZEL_DIFF_VERSION}/bazel-diff_deploy.jar"
@@ -251,15 +252,16 @@ def run_bazel_diff(jar_path: Path, workspace: str, base_sha: str) -> list[str] |
 
 
 def check_intersection(targets: str, pattern: str) -> bool:
-    """Check if affected targets intersect with a pattern using bazel query."""
+    """Check if affected targets intersect with a pattern using bazel query.
+
+    Uses --query_file to avoid "Argument list too long" errors with large target sets.
+    """
     if not targets:
         return False
 
     # Full build checks pattern directly; otherwise compute set intersection
     query = pattern if targets == "//..." else f"set({targets}) intersect {pattern}"
-
-    result = run_cmd(["bazelisk", "query", query], check=False)
-    # Non-empty output means intersection exists
+    result = run_query_with_file(query)
     return bool(result.stdout.strip())
 
 
@@ -415,7 +417,7 @@ def run_release_mode() -> None:
 
     # Check if any targets match the pattern
     query = f"set({' '.join(targets)}) intersect {target_pattern}"
-    result = run_cmd(["bazelisk", "query", query], check=False)
+    result = run_query_with_file(query)
 
     if result.stdout.strip():
         matching = result.stdout.strip().split("\n")

--- a/tools/ci/bazel_diff.py
+++ b/tools/ci/bazel_diff.py
@@ -39,7 +39,7 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
-from bazel_query import run_query_with_file
+from tools.ci.bazel_query import run_query_with_file
 
 BAZEL_DIFF_VERSION = "12.1.1"
 BAZEL_DIFF_URL = f"https://github.com/Tinder/bazel-diff/releases/download/{BAZEL_DIFF_VERSION}/bazel-diff_deploy.jar"

--- a/tools/ci/bazel_diff.py
+++ b/tools/ci/bazel_diff.py
@@ -39,7 +39,7 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
-from tools.ci.bazel_query import run_query_with_file
+from bazel_query import run_query_with_file
 
 BAZEL_DIFF_VERSION = "12.1.1"
 BAZEL_DIFF_URL = f"https://github.com/Tinder/bazel-diff/releases/download/{BAZEL_DIFF_VERSION}/bazel-diff_deploy.jar"

--- a/tools/ci/bazel_diff.py
+++ b/tools/ci/bazel_diff.py
@@ -31,15 +31,21 @@ Outputs to $GITHUB_OUTPUT:
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Add repo root to path for tools.ci imports when running via uv
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 import os
 import re
 import subprocess
-import sys
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
 
-from bazel_query import run_query_with_file
+from tools.ci.bazel_query import run_query_with_file
 
 BAZEL_DIFF_VERSION = "12.1.1"
 BAZEL_DIFF_URL = f"https://github.com/Tinder/bazel-diff/releases/download/{BAZEL_DIFF_VERSION}/bazel-diff_deploy.jar"

--- a/tools/ci/bazel_query.py
+++ b/tools/ci/bazel_query.py
@@ -1,0 +1,48 @@
+"""Shared Bazel query utilities for CI scripts."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+
+
+def run_query_with_file(query: str, *, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a bazel query using --query_file to avoid "Argument list too long" errors.
+
+    Args:
+        query: The Bazel query string.
+        check: If True, raise CalledProcessError on non-zero exit.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".query", delete_on_close=False) as f:
+        f.write(query)
+        f.flush()
+        return subprocess.run(
+            ["bazelisk", "query", f"--query_file={f.name}"],
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+
+def check_bazel_intersection(targets: list[str], pattern: str) -> bool:
+    """Check if affected targets intersect with a Bazel pattern.
+
+    Uses --query_file to avoid "Argument list too long" errors with large target sets.
+
+    Args:
+        targets: List of Bazel target labels.
+        pattern: Bazel query pattern to intersect with.
+
+    Returns:
+        True if there's any intersection, False otherwise.
+    """
+    if not targets:
+        return False
+
+    targets_str = " ".join(targets)
+    query = f"set({targets_str}) intersect {pattern}"
+    result = run_query_with_file(query)
+    return bool(result.stdout.strip())

--- a/tools/ci/bazel_query.py
+++ b/tools/ci/bazel_query.py
@@ -27,6 +27,29 @@ def run_query_with_file(query: str, *, check: bool = False) -> subprocess.Comple
         )
 
 
+def run_cquery_with_file(query: str, *, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a bazel cquery using --query_file to avoid "Argument list too long" errors.
+
+    cquery respects target_compatible_with constraints, unlike query.
+
+    Args:
+        query: The Bazel query string.
+        check: If True, raise CalledProcessError on non-zero exit.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".query", delete_on_close=False) as f:
+        f.write(query)
+        f.flush()
+        return subprocess.run(
+            ["bazelisk", "cquery", f"--query_file={f.name}", "--output=label"],
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+
 def check_bazel_intersection(targets: list[str], pattern: str) -> bool:
     """Check if affected targets intersect with a Bazel pattern.
 
@@ -46,3 +69,28 @@ def check_bazel_intersection(targets: list[str], pattern: str) -> bool:
     query = f"set({targets_str}) intersect {pattern}"
     result = run_query_with_file(query)
     return bool(result.stdout.strip())
+
+
+def filter_compatible_targets(targets: list[str]) -> list[str]:
+    """Filter targets to only those compatible with the current platform.
+
+    Uses bazel cquery which respects target_compatible_with constraints.
+
+    Args:
+        targets: List of Bazel target labels.
+
+    Returns:
+        List of targets compatible with the current platform.
+    """
+    if not targets:
+        return targets
+
+    targets_str = " ".join(targets)
+    query = f"set({targets_str})"
+    result = run_cquery_with_file(query)
+
+    if result.returncode != 0:
+        # cquery failed - return original targets
+        return targets
+
+    return [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -44,6 +44,13 @@ INFRA_PATTERNS = [
     r"^WORKSPACE",
 ]
 
+# macOS-only packages that should be excluded from Linux CI runs
+# These use seatbelt (macOS sandbox) and won't build on Linux
+MACOS_ONLY_PATTERNS = [
+    r"^//sandboxed_jupyter[:/]",
+    r"^//mcp_infra/seatbelt[:/]",
+]
+
 
 class CIDecision(BaseModel):
     """Result of CI decision computation."""
@@ -112,6 +119,19 @@ def has_infra_changes(changed_files: list[str]) -> bool:
     """Check if any changed files match infrastructure patterns."""
     compiled = [re.compile(p) for p in INFRA_PATTERNS]
     return any(r.match(f) for r in compiled for f in changed_files)
+
+
+def filter_platform_incompatible(targets: list[str]) -> list[str]:
+    """Filter out targets that are incompatible with the CI platform (Linux).
+
+    GitHub Actions runners are Linux, so we exclude macOS-only targets.
+    """
+    compiled = [re.compile(p) for p in MACOS_ONLY_PATTERNS]
+    filtered = [t for t in targets if not any(r.match(t) for r in compiled)]
+    excluded = len(targets) - len(filtered)
+    if excluded:
+        print(f"Filtered out {excluded} macOS-only targets")
+    return filtered
 
 
 def checkout_commit(repo: pygit2.Repository, commit: pygit2.Commit) -> None:
@@ -261,6 +281,8 @@ def compute_decision(workflows: dict[str, WorkflowConfig], workspace: Path) -> C
         print("No Bazel targets affected")
     else:
         print_truncated(f"Found {len(targets)} affected targets", targets)
+        # Filter out platform-incompatible targets for Linux CI
+        targets = filter_platform_incompatible(targets)
         if infra_changed:
             all_targets = True
 

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -19,10 +19,10 @@ import json
 import os
 import re
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pygit2
+from bazel_query import check_bazel_intersection
 from models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
 
@@ -176,26 +176,6 @@ def run_bazel_diff(
     except subprocess.CalledProcessError as e:
         print(f"bazel-diff failed: {e.stderr or e.stdout or e}")
         return None
-
-
-def check_bazel_intersection(targets: list[str], pattern: str) -> bool:
-    """Check if affected targets intersect with a Bazel pattern.
-
-    Uses --query_file to avoid "Argument list too long" errors with large target sets.
-    """
-    if not targets:
-        return False
-
-    targets_str = " ".join(targets)
-    query = f"set({targets_str}) intersect {pattern}"
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".query", delete_on_close=False) as f:
-        f.write(query)
-        f.flush()
-        result = subprocess.run(
-            ["bazelisk", "query", f"--query_file={f.name}"], check=False, capture_output=True, text=True
-        )
-    return bool(result.stdout.strip())
 
 
 def should_trigger(name: str, config: WorkflowConfig, targets: list[str], changed_files: list[str]) -> bool:

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -44,14 +44,6 @@ INFRA_PATTERNS = [
     r"^WORKSPACE",
 ]
 
-# macOS-only packages that should be excluded from Linux CI runs
-# These use seatbelt (macOS sandbox) and won't build on Linux
-MACOS_ONLY_PATTERNS = [
-    r"^//sandboxed_jupyter[:/]",
-    r"^//mcp_infra/seatbelt[:/]",
-]
-
-
 class CIDecision(BaseModel):
     """Result of CI decision computation."""
 
@@ -122,16 +114,41 @@ def has_infra_changes(changed_files: list[str]) -> bool:
 
 
 def filter_platform_incompatible(targets: list[str]) -> list[str]:
-    """Filter out targets that are incompatible with the CI platform (Linux).
+    """Filter out targets that are incompatible with the CI platform.
 
-    GitHub Actions runners are Linux, so we exclude macOS-only targets.
+    Uses bazel cquery to check target_compatible_with constraints.
+    Targets incompatible with the current platform are excluded.
     """
-    compiled = [re.compile(p) for p in MACOS_ONLY_PATTERNS]
-    filtered = [t for t in targets if not any(r.match(t) for r in compiled)]
-    excluded = len(targets) - len(filtered)
+    if not targets:
+        return targets
+
+    import tempfile
+
+    # Use cquery to filter - it respects target_compatible_with
+    targets_str = " ".join(targets)
+    query = f"set({targets_str})"
+
+    # cquery with --output=label only outputs compatible targets
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".query", delete_on_close=False) as f:
+        f.write(query)
+        f.flush()
+        result = subprocess.run(
+            ["bazelisk", "cquery", f"--query_file={f.name}", "--output=label"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    if result.returncode != 0:
+        # cquery failed - fall back to returning all targets
+        print(f"Warning: cquery failed, skipping platform filter: {result.stderr[:200]}")
+        return targets
+
+    compatible = [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]
+    excluded = len(targets) - len(compatible)
     if excluded:
-        print(f"Filtered out {excluded} macOS-only targets")
-    return filtered
+        print(f"Filtered out {excluded} platform-incompatible targets")
+    return compatible
 
 
 def checkout_commit(repo: pygit2.Repository, commit: pygit2.Commit) -> None:

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -30,7 +30,7 @@ import subprocess
 
 import pygit2
 from pydantic import BaseModel, Field
-from tools.ci.bazel_query import check_bazel_intersection
+from tools.ci.bazel_query import check_bazel_intersection, filter_compatible_targets
 from tools.ci.models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 
 # Infrastructure patterns that affect all targets (caching may be invalid)
@@ -122,29 +122,7 @@ def filter_platform_incompatible(targets: list[str]) -> list[str]:
     if not targets:
         return targets
 
-    import tempfile
-
-    # Use cquery to filter - it respects target_compatible_with
-    targets_str = " ".join(targets)
-    query = f"set({targets_str})"
-
-    # cquery with --output=label only outputs compatible targets
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".query", delete_on_close=False) as f:
-        f.write(query)
-        f.flush()
-        result = subprocess.run(
-            ["bazelisk", "cquery", f"--query_file={f.name}", "--output=label"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-
-    if result.returncode != 0:
-        # cquery failed - fall back to returning all targets
-        print(f"Warning: cquery failed, skipping platform filter: {result.stderr[:200]}")
-        return targets
-
-    compatible = [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]
+    compatible = filter_compatible_targets(targets)
     excluded = len(targets) - len(compatible)
     if excluded:
         print(f"Filtered out {excluded} platform-incompatible targets")

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -15,16 +15,23 @@ Requires BAZEL_DIFF_JAR environment variable pointing to bazel-diff JAR.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Add repo root to path for tools.ci imports when running via uv
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 import json
 import os
 import re
 import subprocess
-from pathlib import Path
 
 import pygit2
-from bazel_query import check_bazel_intersection
-from models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
+from tools.ci.bazel_query import check_bazel_intersection
+from tools.ci.models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 
 # Infrastructure patterns that affect all targets (caching may be invalid)
 INFRA_PATTERNS = [

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -22,9 +22,9 @@ import subprocess
 from pathlib import Path
 
 import pygit2
-from bazel_query import check_bazel_intersection
-from models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
+from tools.ci.bazel_query import check_bazel_intersection
+from tools.ci.models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 
 # Infrastructure patterns that affect all targets (caching may be invalid)
 INFRA_PATTERNS = [

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -22,9 +22,9 @@ import subprocess
 from pathlib import Path
 
 import pygit2
+from bazel_query import check_bazel_intersection
+from models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
-from tools.ci.bazel_query import check_bazel_intersection
-from tools.ci.models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 
 # Infrastructure patterns that affect all targets (caching may be invalid)
 INFRA_PATTERNS = [

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from models import WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
+from tools.ci.models import WorkflowConfig, WorkflowManifest
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from models import WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
-from tools.ci.models import WorkflowConfig, WorkflowManifest
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -15,13 +15,20 @@ Usage:
 
 from __future__ import annotations
 
-import argparse
+import sys
 from pathlib import Path
+
+# Add repo root to path for tools.ci imports when running via uv
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import argparse
 from typing import Any
 
 import yaml
-from models import WorkflowConfig, WorkflowManifest
 from pydantic import BaseModel, Field
+from tools.ci.models import WorkflowConfig, WorkflowManifest
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent.parent


### PR DESCRIPTION
Extract shared bazel query utility (tools/ci/bazel_query.py) and update
both ci_decide.py and bazel_diff.py to use it. The --query_file flag
avoids "Argument list too long" errors when querying large target sets.