### PR TITLE
Fix workflow_dispatch support for claude-hooks release

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -204,8 +204,10 @@ jobs:
       always() &&
       needs.test.result == 'success' &&
       needs.wheel-test.result == 'success' &&
-      github.event_name == 'push' &&
-      (needs.check-release.outputs.release_needed == 'true' || inputs.force_release == true)
+      (
+        (github.event_name == 'push' && needs.check-release.outputs.release_needed == 'true') ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_release == true)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/tools/ci/bazel_diff.py
+++ b/tools/ci/bazel_diff.py
@@ -42,6 +42,7 @@ if str(_REPO_ROOT) not in sys.path:
 import os
 import re
 import subprocess
+import tempfile
 import urllib.request
 from dataclasses import dataclass
 


### PR DESCRIPTION
The release job required `github.event_name == 'push'` which prevented
manual triggers (workflow_dispatch) from ever running the release job,
even with `force_release: true`.

Update the condition to allow:
- Push events when release_needed is true
- workflow_dispatch events when force_release is true

https://claude.ai/code/session_01M4BnazaMsTy7SuK8zA84aN