### PR TITLE
Remove all ruff_test targets from BUILD.bazel files

### DIFF
--- a/adgn/BUILD.bazel
+++ b/adgn/BUILD.bazel
@@ -1,7 +1,5 @@
 """ADGN - Agent framework and LLM tooling."""
 
-load("//tools/lint:linters.bzl", "ruff_test")
-
 # NOTE: No aggregator target - use specific per-file targets in subdirectories
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
 #
@@ -11,14 +9,3 @@ load("//tools/lint:linters.bzl", "ruff_test")
 #   //adgn/gitea_pr_gate:policy_server_fastapi - Gitea PR gate server
 #   //adgn/testing:bootstrap - Testing bootstrap utilities
 #   //adgn/tools:trivial_patterns - Trivial patterns linter
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        "//adgn/agent:cli",
-        "//adgn/gitea_pr_gate:policy_common",
-        "//adgn/gitea_pr_gate:policy_server_fastapi",
-        "//adgn/testing:bootstrap",
-        "//adgn/tools:trivial_patterns",
-    ],
-)

--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "tool_provider",
@@ -159,25 +158,6 @@ py_library(
         "//mcp_infra/testing:fixtures",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":agent",
-        ":compaction",
-        ":conftest",
-        ":direct_provider",
-        ":events",
-        ":handler",
-        ":logging_utils",
-        ":loop_control",
-        ":mcp_provider",
-        ":progress",
-        ":tool_provider",
-        ":transcript_handler",
-        ":turn_limit",
     ],
 )
 

--- a/agent_core_testing/BUILD.bazel
+++ b/agent_core_testing/BUILD.bazel
@@ -1,21 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # NOTE: No aggregator target - use specific per-file targets like :fixtures, :responses, :steps
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":assertions",
-        ":echo_server",
-        ":fixtures",
-        ":matchers",
-        ":openai_mock",
-        ":responses",
-        ":steps",
-    ],
-)
 
 py_library(
     name = "assertions",

--- a/agent_pkg/host/BUILD.bazel
+++ b/agent_pkg/host/BUILD.bazel
@@ -1,16 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle will create per-file py_library targets
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":bootstrap_handler",
-        ":builder",
-        ":init_runner",
-    ],
-)
 
 py_library(
     name = "bootstrap_handler",

--- a/agent_pkg/runtime/BUILD.bazel
+++ b/agent_pkg/runtime/BUILD.bazel
@@ -1,15 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle will create per-file py_library targets
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":mcp",
-        ":output",
-    ],
-)
 
 py_library(
     name = "mcp",

--- a/agent_server/BUILD.bazel
+++ b/agent_server/BUILD.bazel
@@ -3,7 +3,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 exports_files(["conftest.py"])
 
@@ -358,17 +357,6 @@ py_test(
 # E2E tests moved to agent_server/e2e/BUILD.bazel
 
 # --- Linting ---
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":agent_types",
-        ":approvals",
-        ":logging_config",
-        ":presets",
-        ":ui_asserts",
-    ],
-)
 
 # --- OCI Runtime Image ---
 

--- a/agent_server/testing/BUILD.bazel
+++ b/agent_server/testing/BUILD.bazel
@@ -1,21 +1,8 @@
 """Testing utilities package for agent_server."""
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 package(default_testonly = True)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":approval_policy_testdata",
-        ":chat_stubs",
-        ":fixtures",
-        ":helpers",
-        ":steps",
-        ":typed_asserts",
-    ],
-)
 
 py_library(
     name = "approval_policy_testdata",

--- a/bazelization/STATUS.md
+++ b/bazelization/STATUS.md
@@ -84,7 +84,7 @@ Unified Bazel build system for all Python packages:
 | TypeScript | 36    | -        | 36          | -      | -        |
 | JavaScript | 14    | -        | 14          | -      | -        |
 
-**Bazel Targets:** 183 py_library, 115 py_test, 46 ruff_test
+**Bazel Targets:** 183 py_library, 115 py_test
 
 Run `bazel run //tools/orphans:find_orphans` to list orphaned files.
 
@@ -385,9 +385,7 @@ MODULE.bazel
 
 tools/lint/linters.bzl
   → lint_ruff_aspect(binary = "@multitool//tools/ruff")
-
-BUILD.bazel files
-  → ruff_test(name = "ruff", srcs = [":my_lib"])
+  NOTE: ruff_test targets removed - ruff is now enforced via pre-commit hook
 ```
 
 ### Ruff Configuration
@@ -734,9 +732,8 @@ The pre-commit framework manages all git hooks. Install with `pre-commit install
 ### Ongoing Maintenance
 
 1. **Check for orphans periodically**: `bazel run //tools/orphans:find_orphans`
-2. **Add ruff_test to new packages**: Every BUILD.bazel with py_library should have ruff_test
-3. **Keep requirements_bazel.txt updated**: Run `bazel run //:requirements.update` after adding deps
-4. **Test with `bazel test //...`**: Ensure all non-manual tests pass before commits
+2. **Keep requirements_bazel.txt updated**: Run `bazel run //:requirements.update` after adding deps
+3. **Test with `bazel test //...`**: Ensure all non-manual tests pass before commits
 
 ### Git Pre-commit Hook (Recommended)
 

--- a/claude/claude_hooks/BUILD.bazel
+++ b/claude/claude_hooks/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:ignore
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # NOTE: No aggregator target - use specific per-file targets like :actions, :base, etc.
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
@@ -240,16 +239,3 @@ py_test(
 # =============================================================================
 # Lint
 # =============================================================================
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":actions",
-        ":base",
-        ":config",
-        ":inputs",
-        ":logging_context",
-        ":precommit_autofix",
-        ":tool_models",
-    ],
-)

--- a/claude/claude_optimizer/BUILD.bazel
+++ b/claude/claude_optimizer/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "claude_optimizer",
@@ -13,11 +12,6 @@ py_library(
         "@pypi//openai",
         "@pypi//pydantic",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":claude_optimizer"],
 )
 
 py_library(

--- a/cli_util/BUILD.bazel
+++ b/cli_util/BUILD.bazel
@@ -1,15 +1,6 @@
 """CLI utilities package."""
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":decorators",
-        ":logging",
-    ],
-)
 
 py_library(
     name = "decorators",

--- a/difftree/BUILD.bazel
+++ b/difftree/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # NOTE: No aggregator target - use specific per-file targets like :config, :parser, etc.
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
@@ -215,15 +214,3 @@ py_test(
 # =============================================================================
 # Lint
 # =============================================================================
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":__main__",
-        ":config",
-        ":diff_tree",
-        ":parser",
-        ":progress_bar",
-        ":tree",
-    ],
-)

--- a/editor_agent/host/BUILD.bazel
+++ b/editor_agent/host/BUILD.bazel
@@ -1,7 +1,6 @@
 """Editor agent host package."""
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Init script for the container image (called as /init)
 filegroup(
@@ -100,11 +99,6 @@ py_test(
         "@pypi//pytest_asyncio",  # keep
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":editor_agent_host"],
 )
 
 py_library(

--- a/editor_agent/runtime/BUILD.bazel
+++ b/editor_agent/runtime/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "editor_agent_runtime",
@@ -35,11 +34,6 @@ py_binary(
         "//cli_util:logging",
         "@pypi//typer_slim",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":editor_agent_runtime"],
 )
 
 # --- OCI Image ---

--- a/ember/BUILD.bazel
+++ b/ember/BUILD.bazel
@@ -3,7 +3,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 filegroup(
     name = "data_files",
@@ -75,21 +74,6 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_asyncio",  # keep
         "@pypi//pytest_bazel",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":app",
-        ":config",
-        ":handlers",
-        ":matrix_client",
-        ":mcp_tools",
-        ":python_session",
-        ":runtime",
-        ":secrets",
-        ":system_prompt",
     ],
 )
 

--- a/experimental/cotrl/BUILD.bazel
+++ b/experimental/cotrl/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:ignore
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Experimental LLM RL scripts - not a proper package, just standalone scripts
 py_library(
@@ -43,9 +42,4 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":cotrl"],
 )

--- a/experimental/dbus_fast_example/BUILD.bazel
+++ b/experimental/dbus_fast_example/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:ignore
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "dbus_fast_example",
@@ -28,9 +27,4 @@ py_test(
         "@pypi//pytest_asyncio",  # keep
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":dbus_fast_example"],
 )

--- a/experimental/flake8-early-bailout/BUILD.bazel
+++ b/experimental/flake8-early-bailout/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:ignore
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "flake8_early_bailout",
@@ -17,9 +16,4 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":flake8_early_bailout"],
 )

--- a/experimental/webhook_inbox/BUILD.bazel
+++ b/experimental/webhook_inbox/BUILD.bazel
@@ -2,7 +2,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "webhook_inbox",
@@ -37,11 +36,6 @@ py_test(
         "@pypi//pytest_bazel",
         "@pypi//starlette",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":webhook_inbox"],
 )
 
 # --- OCI Image ---

--- a/gatelet/BUILD.bazel
+++ b/gatelet/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 exports_files(["gatelet.toml"])
 
@@ -50,14 +49,6 @@ py_binary(
     main = "manage_main.py",
     visibility = ["//:__subpackages__"],
     deps = [":manage_lib"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":manage_lib",
-        ":reporter_lib",
-    ],
 )
 
 # --- OCI Image ---

--- a/gatelet/server/BUILD.bazel
+++ b/gatelet/server/BUILD.bazel
@@ -4,7 +4,6 @@
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_binary(
     name = "server",
@@ -154,20 +153,6 @@ py_library(
     imports = ["../.."],
     visibility = ["//gatelet:__subpackages__"],
     deps = ["@pypi//pytest_bazel"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":app",
-        ":config",
-        ":database",
-        ":lifespan",
-        ":models",
-        ":prompts",
-        ":security",
-        ":shared",
-    ],
 )
 
 py_test(

--- a/git_commit_ai/BUILD.bazel
+++ b/git_commit_ai/BUILD.bazel
@@ -3,7 +3,6 @@
 # gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle manages git_ro/ and testing/ subpackages
 
@@ -44,17 +43,6 @@ py_binary(
         "//cli_util:decorators",
         "@pypi//pygit2",
         "@pypi//typer",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":agent_backend",
-        ":config",
-        ":conftest",
-        ":editor",
-        ":git_commit_ai",
     ],
 )
 

--- a/gmail_archiver/BUILD.bazel
+++ b/gmail_archiver/BUILD.bazel
@@ -1,6 +1,5 @@
 # gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle will create per-file py_library targets
 # Subdirectories (cli/, planners/) will get their own BUILD files
@@ -36,26 +35,6 @@ py_binary(
         "@pypi//typer_slim",
     ],
     # deps will be filled by Gazelle
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":date_patterns",
-        ":dirs",
-        ":event_classifier",
-        ":filter_planner",
-        ":filter_sync",
-        ":gmail_api_models",
-        ":gmail_archiver",
-        ":gmail_client",
-        ":gmail_yaml_filters_models",
-        ":html_utils",
-        ":inbox",
-        ":models",
-        ":plan",
-        ":plan_display",
-    ],
 )
 
 py_library(

--- a/gnome_terminal_profile_switcher/BUILD.bazel
+++ b/gnome_terminal_profile_switcher/BUILD.bazel
@@ -1,7 +1,6 @@
 # gazelle:ignore
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "main",
@@ -25,12 +24,6 @@ py_binary(
     main = "main.py",
     tags = ["manual"],
     deps = [":main"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":main"],
-    tags = ["manual"],
 )
 
 py_package(

--- a/headscale_cleanup/BUILD.bazel
+++ b/headscale_cleanup/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "__main__",
@@ -53,12 +52,4 @@ py_wheel(
     ],
     version = "0.1.0",
     deps = [":headscale_cleanup_pkg"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":__main__",
-        ":cli",
-    ],
 )

--- a/homeassistant/iaqi/custom_components/indoor_aqi/BUILD.bazel
+++ b/homeassistant/iaqi/custom_components/indoor_aqi/BUILD.bazel
@@ -2,7 +2,6 @@
 # Uses @pypi_homeassistant hub, not the main @pypi
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "indoor_aqi",
@@ -79,9 +78,4 @@ py_test(
     imports = ["../.."],
     main = "test_sensor_simple.py",
     deps = _TEST_DEPS,
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":indoor_aqi"],
 )

--- a/inop/BUILD.bazel
+++ b/inop/BUILD.bazel
@@ -1,7 +1,6 @@
 """Instruction optimizer package."""
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # no-mypy: statsmodels (transitive dep of plotnine) has broken __init__.py structure
 # that causes mypy to error with "Source file found twice under different module names".
@@ -50,11 +49,6 @@ py_test(
         "@pypi//pytest_asyncio",  # keep
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":inop"],
 )
 
 py_library(

--- a/inventree_utils/BUILD.bazel
+++ b/inventree_utils/BUILD.bazel
@@ -2,7 +2,6 @@
 # rai_plugin uses InvenTree's plugin framework (not in @pypi)
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle manages beautifier/ subpackage
 
@@ -23,14 +22,6 @@ py_binary(
         "@pypi//inventree",
         "@pypi//pint",
         "@pypi//tqdm",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":make_prompt",
-        ":tasks",
     ],
 )
 

--- a/llm/mcp/habitify/BUILD.bazel
+++ b/llm/mcp/habitify/BUILD.bazel
@@ -4,7 +4,6 @@
 # Per-file py_library targets (Gazelle-compatible pattern)
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # --- Base types (no internal deps) ---
 
@@ -230,22 +229,3 @@ py_test(
 )
 
 # --- Lint ---
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":__main__",
-        ":cli",
-        ":cli_utils",
-        ":config",
-        ":constants",
-        ":context",
-        ":date_utils",
-        ":habit_resolver",
-        ":habitify_client",
-        ":server",
-        ":testing_models",
-        ":tools",
-        ":types",
-    ],
-)

--- a/llm/ultra-long-cot/BUILD.bazel
+++ b/llm/ultra-long-cot/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "ultra_long_cot_lib",
@@ -34,9 +33,4 @@ py_binary(
         "@pypi//pydantic",
         "@pypi//tiktoken",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":ultra_long_cot_lib"],
 )

--- a/mcp_infra/BUILD.bazel
+++ b/mcp_infra/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Shared test utilities (non-Docker)
 py_library(
@@ -29,28 +28,6 @@ py_test(
         "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":_markers",
-        ":calltool",
-        ":client_helpers",
-        ":config_loader",
-        ":conftest",
-        ":constants",
-        ":flat_tool",
-        ":mcp_types",
-        ":mount_types",
-        ":mounted",
-        ":naming",
-        ":prefix",
-        ":resource_utils",
-        ":snapshots",
-        ":tool_schemas",
-        ":urls",
     ],
 )
 

--- a/mcp_starter/BUILD.bazel
+++ b/mcp_starter/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle manages adgn_mcp_starter/ subpackage
 
@@ -48,15 +47,5 @@ py_binary(
     deps = [
         "@pypi//claude_code_sdk",
         "@pypi//rich",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":conftest",
-        ":integration_test",
-        ":manual_test_sdk",
-        ":test_server",
     ],
 )

--- a/mcp_utils/BUILD.bazel
+++ b/mcp_utils/BUILD.bazel
@@ -1,7 +1,6 @@
 """MCP utilities package."""
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "mcp_utils",
@@ -11,9 +10,4 @@ py_library(
     deps = [
         "@pypi//mcp",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":mcp_utils"],
 )

--- a/net_util/BUILD.bazel
+++ b/net_util/BUILD.bazel
@@ -1,7 +1,6 @@
 """Network utilities package."""
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "net_util",
@@ -15,11 +14,6 @@ py_library(
         "@pypi//aiodocker",
         "@pypi//tenacity",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":net_util"],
 )
 
 py_library(

--- a/openai_utils/BUILD.bazel
+++ b/openai_utils/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "types",
@@ -125,24 +124,6 @@ py_library(
     deps = [
         "@pypi//openai",
         "@pypi//pytest",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":builders",
-        ":client_factory",
-        ":conftest",
-        ":errors",
-        ":http_logging",
-        ":json_schema",
-        ":model",
-        ":model_metadata",
-        ":pydantic_strict_mode",
-        ":retry",
-        ":text_extraction",
-        ":types",
     ],
 )
 

--- a/prompts/scans/BUILD.bazel
+++ b/prompts/scans/BUILD.bazel
@@ -1,7 +1,6 @@
 """Standalone codebase scanning scripts (stdlib only)."""
 
 load("@rules_python//python:defs.bzl", "py_binary")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_binary(
     name = "scan_comments",
@@ -37,16 +36,4 @@ py_binary(
     name = "scan_string_literals",
     srcs = ["scan_string_literals.py"],
     visibility = ["//:__subpackages__"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":scan_comments",
-        ":scan_dataclass_candidates",
-        ":scan_error_handling",
-        ":scan_manual_serde",
-        ":scan_single_line_functions",
-        ":scan_string_literals",
-    ],
 )

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -3,7 +3,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # NOTE: No aggregator target - use specific per-file targets
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
@@ -108,22 +107,6 @@ genrule(
 # =============================================================================
 # Linting
 # =============================================================================
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":app",
-        ":auth",
-        ":cli",
-        ":export_schema",
-        "//props/backend/routes:eval",
-        "//props/backend/routes:ground_truth",
-        "//props/backend/routes:llm",
-        "//props/backend/routes:registry",
-        "//props/backend/routes:runs",
-        "//props/backend/routes:stats",
-    ],
-)
 
 # =============================================================================
 # OCI Image

--- a/props/core/BUILD.bazel
+++ b/props/core/BUILD.bazel
@@ -8,7 +8,6 @@ TODO: This package is being phased out. Remaining modules should move to:
 """
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # =============================================================================
 # Leaf modules (no props.core deps)
@@ -283,19 +282,3 @@ py_test(
 )
 
 # Collect all library targets for ruff
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":agent_helpers",
-        ":agent_pkg_utils",
-        ":agent_types",
-        ":agent_workspace",
-        ":display",
-        ":docker_env",
-        ":exceptions",
-        ":ids",
-        ":oci_utils",
-        ":runs_context",
-        ":splits",
-    ],
-)

--- a/py_detectors/BUILD.bazel
+++ b/py_detectors/BUILD.bazel
@@ -4,7 +4,6 @@
 """Python detectors package."""
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "py_detectors",
@@ -66,11 +65,6 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":py_detectors"],
 )
 
 py_library(

--- a/rspcache/BUILD.bazel
+++ b/rspcache/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # NOTE: No aggregator target - use specific per-file targets like :app, :cli, :models
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
@@ -14,19 +13,6 @@ py_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         ":cli",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":admin_app",
-        ":app",
-        ":cli",
-        ":codegen",
-        ":events",
-        ":models",
-        ":responses_db",
     ],
 )
 

--- a/sandboxed_jupyter/BUILD.bazel
+++ b/sandboxed_jupyter/BUILD.bazel
@@ -4,7 +4,6 @@
 """Sandboxed Jupyter execution package."""
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "sandboxed_jupyter",
@@ -79,9 +78,4 @@ py_test(
         "@pypi//pyyaml",
         "@pypi//types_pyyaml",
     ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [":sandboxed_jupyter"],
 )

--- a/sysrw/BUILD.bazel
+++ b/sysrw/BUILD.bazel
@@ -1,7 +1,6 @@
 """System rewriter package."""
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # Gazelle will create per-file py_library targets
 # Subdirectories (anthropic/, templates/, tools/) have their own BUILD files
@@ -39,27 +38,6 @@ py_test(
     deps = [
         ":conftest",
         "@pypi//pytest_bazel",
-    ],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":cli",
-        ":compare_eval_vs_ccr",
-        ":conftest",
-        ":constants",
-        ":extract_common",
-        ":extract_dataset",
-        ":extract_dataset_ccr",
-        ":extract_dataset_crush",
-        ":leaderboard",
-        ":openai_typing",
-        ":prompts",
-        ":run_eval",
-        ":schemas",
-        ":translation",
-        ":validation",
     ],
 )
 

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -2,7 +2,6 @@
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # === Base modules (no internal deps) ===
 
@@ -62,14 +61,3 @@ py_library(
 )
 
 # === Linting ===
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":bazel_diff",
-        ":bazel_query",
-        ":ci_decide",
-        ":generate_ci",
-        ":models",
-    ],
-)

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -3,7 +3,6 @@
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 # === Base modules (no internal deps) ===
 
@@ -311,23 +310,3 @@ py_test(
 )
 
 # === Linting ===
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":bazel_wrapper",
-        ":bazelisk_setup",
-        ":binary_tools",
-        ":env_file",
-        ":errors",
-        ":nix_setup",
-        ":podman_service",
-        ":proxy_credentials",
-        ":proxy_setup",
-        ":proxy_vars",
-        ":resources",
-        ":session_start",
-        ":settings",
-        ":streaming",
-    ],
-)

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -49,10 +49,9 @@ eslint = lint_eslint_aspect(
 # NOTE: Prettier is a formatter, not a linter - handled via //tools/format:format
 # Run formatting with: bazel run //tools/format
 
-# Test rule factories - use these in BUILD.bazel files:
-#   load("//tools/lint:linters.bzl", "ruff_test")
-#   ruff_test(name = "ruff", srcs = [":my_library"])
-ruff_test = lint_test(aspect = ruff)
+#   load("//tools/lint:linters.bzl", "eslint_test")
+#   eslint_test(name = "eslint", srcs = [":my_library"])
+# NOTE: ruff_test removed - ruff is enforced via pre-commit hook
 eslint_test = lint_test(aspect = eslint)
 
 # NOTE: mypy_aspect is used via --config=typecheck, not via lint_test

--- a/wt/BUILD.bazel
+++ b/wt/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//tools/lint:linters.bzl", "ruff_test")
 
 py_library(
     name = "cli",
@@ -28,15 +27,6 @@ py_binary(
     main = "__main__.py",
     visibility = ["//visibility:public"],
     deps = [":cli"],
-)
-
-ruff_test(
-    name = "ruff",
-    srcs = [
-        ":cli",
-        ":demo_plugin",
-        ":plugins",
-    ],
 )
 
 py_library(


### PR DESCRIPTION
Ruff linting is now enforced via the pre-commit hook, making the per-package ruff_test Bazel targets redundant. Remove all ruff_test rule invocations, their load statements, and the ruff_test macro definition from linters.bzl. Update STATUS.md accordingly.

https://claude.ai/code/session_013wKowNsXPBD5tdtVpbq8k2