### PR TITLE
Add fmt_util module and adopt in gmail_archiver

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@
 #
 # Root-level targets
 # gazelle:resolve py bazel_util //:bazel_util
+# gazelle:resolve py fmt_util //:fmt_util
 
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
@@ -81,6 +82,13 @@ py_library(
     srcs = ["runfiles.py"],
     visibility = ["//visibility:public"],
     deps = ["@rules_python//python/runfiles"],
+)
+
+# Formatting utilities for truncated collections
+py_library(
+    name = "fmt_util",
+    srcs = ["fmt_util.py"],
+    visibility = ["//visibility:public"],
 )
 
 # ESLint configuration as js_library

--- a/fmt_util.py
+++ b/fmt_util.py
@@ -1,0 +1,64 @@
+"""Formatting utilities for displaying truncated collections.
+
+Provides generic functions for formatting collections with overflow indicators,
+used across multiple packages (props, tools/ci, gmail_archiver, etc.).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def format_limited_list(
+    items: Sequence[str], limit: int, *, separator: str = ", ", overflow_format: str = " (+{remaining} more)"
+) -> str:
+    """Join items with separator, adding overflow indicator if truncated.
+
+    Args:
+        items: Items to join
+        limit: Maximum number of items to show
+        separator: String between items
+        overflow_format: Format string with {remaining} placeholder
+
+    Returns:
+        Joined string like "a, b, c (+5 more)" or just "a, b, c" if not truncated
+
+    Examples:
+        >>> format_limited_list(["a", "b", "c", "d", "e"], 3)
+        'a, b, c (+2 more)'
+        >>> format_limited_list(["a", "b"], 3)
+        'a, b'
+        >>> format_limited_list(["x", "y", "z"], 2, overflow_format=" ... and {remaining} more")
+        'x, y ... and 1 more'
+    """
+    if len(items) <= limit:
+        return separator.join(items)
+    shown = items[:limit]
+    remaining = len(items) - limit
+    return separator.join(shown) + overflow_format.format(remaining=remaining)
+
+
+def format_truncation_suffix(total: int, shown: int, item_name: str = "") -> str:
+    """Return '... and N more {item_name}' or empty string if all shown.
+
+    Use this when displaying items one-by-one with a footer for overflow.
+
+    Args:
+        total: Total number of items
+        shown: Number of items shown
+        item_name: Optional name for items (e.g., "files", "errors")
+
+    Examples:
+        >>> format_truncation_suffix(10, 5, "files")
+        '... and 5 more files'
+        >>> format_truncation_suffix(10, 5)
+        '... and 5 more'
+        >>> format_truncation_suffix(3, 5)
+        ''
+    """
+    if total <= shown:
+        return ""
+    remaining = total - shown
+    if item_name:
+        return f"... and {remaining} more {item_name}"
+    return f"... and {remaining} more"

--- a/gmail_archiver/BUILD.bazel
+++ b/gmail_archiver/BUILD.bazel
@@ -17,6 +17,7 @@ py_binary(
         ":models",
         ":plan",
         ":plan_display",
+        "//:fmt_util",
         "//gmail_archiver/cli:common",
         "//gmail_archiver/cli:filters",
         "//gmail_archiver/cli:labels",
@@ -98,6 +99,8 @@ py_library(
     srcs = ["gmail_client.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        ":gmail_api_models",
+        "//:fmt_util",
         "@pypi//google_api_python_client",
         "@pypi//google_auth",
     ],

--- a/gmail_archiver/__main__.py
+++ b/gmail_archiver/__main__.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 from rich.table import Table
 
+from fmt_util import format_truncation_suffix
 from gmail_archiver.cli.common import DryRunDefaultTrueOption, TokenFileOption, get_client
 from gmail_archiver.cli.filters import filters_app
 from gmail_archiver.cli.labels import labels_app
@@ -189,8 +190,8 @@ def download_matching(
             orphaned_list = sorted(orphaned_ids)[:10]
             for msg_id in orphaned_list:
                 console.print(f"  - {msg_id}.eml")
-            if len(orphaned_ids) > 10:
-                console.print(f"  ... and {len(orphaned_ids) - 10} more")
+            if suffix := format_truncation_suffix(len(orphaned_ids), 10):
+                console.print(suffix)
 
             console.print()
             delete_confirm = typer.confirm("Delete these orphaned files?", default=False)
@@ -218,8 +219,8 @@ def download_matching(
         sample_table.add_row(str(idx), msg.sender[:30], msg.subject[:50], (msg.date_header or "")[:20])
 
     console.print(sample_table)
-    if len(all_message_ids) > sample_size:
-        console.print(f"... and {len(all_message_ids) - sample_size} more emails\n")
+    if suffix := format_truncation_suffix(len(all_message_ids), sample_size, "emails"):
+        console.print(suffix + "\n")
 
     existing_preview = {f.stem for f in output_dir.glob("*.eml")} if output_dir.exists() else set()
     to_download_count = len([msg_id for msg_id in all_message_ids if msg_id not in existing_preview])
@@ -283,8 +284,8 @@ def download_matching(
         console.print(f"\n[bold red]✗[/bold red] Failed to download {len(all_failed)} emails:")
         for msg_id, error in all_failed[:10]:  # Show first 10
             console.print(f"  - {msg_id}: {error[:80]}")
-        if len(all_failed) > 10:
-            console.print(f"  ... and {len(all_failed) - 10} more failures")
+        if suffix := format_truncation_suffix(len(all_failed), 10, "failures"):
+            console.print(suffix)
 
 
 def parse_gmail_link(url: str) -> str | None:

--- a/gmail_archiver/gmail_client.py
+++ b/gmail_archiver/gmail_client.py
@@ -14,6 +14,8 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from fmt_util import format_truncation_suffix
+
 from .gmail_api_models import (
     CreateFilterRequest,
     GmailFilter,
@@ -425,8 +427,8 @@ class GmailClient:
             print(f"Warning: Failed to fetch {len(all_errors)} messages:", file=sys.stderr)
             for req_id, error in all_errors[:5]:  # Show first 5
                 print(f"  - Request {req_id}: {error}", file=sys.stderr)
-            if len(all_errors) > 5:
-                print(f"  ... and {len(all_errors) - 5} more errors", file=sys.stderr)
+            if suffix := format_truncation_suffix(len(all_errors), 5, "errors"):
+                print(suffix, file=sys.stderr)
 
         return emails
 

--- a/gmail_archiver/planners/BUILD.bazel
+++ b/gmail_archiver/planners/BUILD.bazel
@@ -75,6 +75,7 @@ py_library(
     srcs = ["doordash.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//:fmt_util",
         "//gmail_archiver:gmail_api_models",
         "//gmail_archiver:inbox",
         "//gmail_archiver:models",

--- a/gmail_archiver/planners/doordash.py
+++ b/gmail_archiver/planners/doordash.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 
+from fmt_util import format_truncation_suffix
 from gmail_archiver.gmail_api_models import SystemLabel
 from gmail_archiver.inbox import GmailInbox
 from gmail_archiver.models import Email
@@ -116,8 +117,8 @@ class DoorDashPlanner:
             plan.add_message(f"Skipping {len(unparseable)} emails with unrecognized format:")
             for msg in unparseable[:5]:
                 plan.add_message(f"  - {msg.subject[:60]}...")
-            if len(unparseable) > 5:
-                plan.add_message(f"  ... and {len(unparseable) - 5} more")
+            if suffix := format_truncation_suffix(len(unparseable), 5):
+                plan.add_message(suffix)
 
         for order_emails in by_order.values():
             # Sort by email type priority (highest priority = most final)


### PR DESCRIPTION
Extract shared truncation formatting into fmt_util.py (format_limited_list, format_truncation_suffix) and replace inline overflow logic in gmail_archiver (__main__.py, gmail_client.py, planners/doordash.py).

https://claude.ai/code/session_013wKowNsXPBD5tdtVpbq8k2