### PR TITLE
Simplify SSL handling and deduplicate URL logic in bazelisk_setup

### DIFF
--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 import platform
 import shutil
-import ssl
 import stat
 import subprocess
 import sys
@@ -79,13 +78,10 @@ def get_bazelisk_url() -> str:
     else:
         raise RuntimeError(f"Unsupported architecture: {machine}")
 
-    if system == "linux":
-        binary = f"bazelisk-linux-{arch}"
-    elif system == "darwin":
-        binary = f"bazelisk-darwin-{arch}"
-    else:
+    if system not in ("linux", "darwin"):
         raise RuntimeError(f"Unsupported OS: {system}")
 
+    binary = f"bazelisk-{system}-{arch}"
     return f"https://github.com/bazelbuild/bazelisk/releases/download/v{BAZELISK_VERSION}/{binary}"
 
 
@@ -109,21 +105,9 @@ def install_bazelisk(settings: HookSettings) -> Path:
     url = get_bazelisk_url()
     logger.info("Downloading Bazelisk from %s", url)
 
-    # Create SSL context with combined CA bundle (includes proxy's TLS inspection CA)
-    # Use only our combined bundle to avoid issues with missing system CAs in sandboxes
-    combined_ca = settings.get_bazel_combined_ca()
-    ssl_context: ssl.SSLContext | None = None
-    if combined_ca.exists():
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ssl_context.check_hostname = True
-        ssl_context.verify_mode = ssl.CERT_REQUIRED
-        ssl_context.load_verify_locations(combined_ca)
-        logger.info("Using combined CA bundle for bazelisk download: %s", combined_ca)
-    else:
-        logger.warning("Combined CA bundle not found at %s, using default SSL context", combined_ca)
-
-    # Download with proxy support (urllib respects https_proxy env var)
-    with urllib.request.urlopen(url, timeout=60, context=ssl_context) as response:
+    # urllib respects HTTPS_PROXY env var and uses system CA bundle (SSL_CERT_FILE).
+    # In CC web, system CAs already include the Anthropic TLS inspection CA.
+    with urllib.request.urlopen(url, timeout=60) as response:
         bazelisk_path.write_bytes(response.read())
 
     # Make executable


### PR DESCRIPTION
Remove custom SSL context creation for bazelisk downloads - urllib already respects SSL_CERT_FILE and HTTPS_PROXY env vars, and the system CA bundle in CC web already includes the Anthropic TLS inspection CA. Also simplify get_bazelisk_url() by deduplicating the platform-specific binary name construction.

https://claude.ai/code/session_013wKowNsXPBD5tdtVpbq8k2