### PR TITLE
Fix session hook URL: claude-hooks-latest-devel → claude-hooks-latest

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest-devel/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
+            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
           }
         ]
       }


### PR DESCRIPTION
The CI workflow (claude-hooks-release.yml) publishes to the
`claude-hooks-latest` tag, but settings.json was still referencing the
stale `claude-hooks-latest-devel` tag (last updated 2 days ago).

https://claude.ai/code/session_018khxHPqguArmrts2XJh9mb