### PR TITLE
Improve logging configuration for better debugging and cleaner output

### DIFF
--- a/tools/claude_hooks/bazel_wrapper.py
+++ b/tools/claude_hooks/bazel_wrapper.py
@@ -50,7 +50,7 @@ def _setup_logging(settings: HookSettings) -> None:
     File logging persists even if the subprocess is killed (e.g., by test timeout),
     making it available for artifact collection.
     """
-    formatter = logging.Formatter("[auth-proxy] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
+    formatter = logging.Formatter("[bazel-wrapper] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
 
     # Always log to stderr
     stderr_handler = logging.StreamHandler(sys.stderr)

--- a/tools/claude_hooks/bazel_wrapper.py
+++ b/tools/claude_hooks/bazel_wrapper.py
@@ -52,22 +52,26 @@ def _setup_logging(settings: HookSettings) -> None:
     """
     formatter = logging.Formatter("[bazel-wrapper] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
 
-    # Always log to stderr
+    # Stderr: only warnings and errors (keep output quiet on happy path)
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setFormatter(formatter)
+    stderr_handler.setLevel(logging.WARNING)
 
-    # Also log to file in supervisor directory (persists on timeout)
+    # File: verbose (DEBUG+) for post-mortem debugging
     log_file = settings.get_supervisor_dir() / "bazel-wrapper.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
     file_handler = logging.FileHandler(log_file, mode="a")
     file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.DEBUG)
 
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(logging.DEBUG)
     root_logger.addHandler(stderr_handler)
     root_logger.addHandler(file_handler)
 
-    logger.info("bazel_wrapper started, log file: %s", log_file)
+    # Show log file path on stderr so users know where to look
+    print(f"[bazel-wrapper] log: {log_file}", file=sys.stderr)
+    logger.info("bazel_wrapper started")
 
 
 def main() -> None:

--- a/tools/claude_hooks/debug.py
+++ b/tools/claude_hooks/debug.py
@@ -16,8 +16,8 @@ def log_entrypoint_debug(name: str) -> None:
     Logs sys.executable, sys.path, and full environment as JSON.
     Call early in each entrypoint (session_start, bazel_wrapper, auth_proxy).
     """
-    logger.info("=== %s debug info ===", name)
-    logger.info("sys.executable: %s", sys.executable)
-    logger.info("sys.path: %s", sys.path)
-    logger.info("Full environment:\n%s", json.dumps(dict(os.environ), sort_keys=True, indent=2))
-    logger.info("=== end %s debug info ===", name)
+    logger.debug("=== %s debug info ===", name)
+    logger.debug("sys.executable: %s", sys.executable)
+    logger.debug("sys.path: %s", sys.path)
+    logger.debug("Full environment:\n%s", json.dumps(dict(os.environ), sort_keys=True, indent=2))
+    logger.debug("=== end %s debug info ===", name)

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -348,9 +348,10 @@ def setup_logging(settings: HookSettings) -> LogCollector:
     # Configure root logger so all child loggers (proxy_setup, bazelisk_setup, etc.) inherit.
     # Logs go to file only — stdout is reserved for structured agent context.
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(logging.DEBUG)
 
     file_handler = logging.FileHandler(log_file, mode="a")
+    file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)
 


### PR DESCRIPTION
## Summary
Refactored logging configuration across hook entrypoints to provide better separation of concerns: verbose logging to files for post-mortem debugging, and minimal output to stderr to keep the happy path quiet.

## Key Changes

- **bazel_wrapper.py**: 
  - Updated log prefix from `[auth-proxy]` to `[bazel-wrapper]` for clarity
  - Set stderr handler to WARNING level only (suppresses INFO/DEBUG on happy path)
  - Set file handler to DEBUG level for comprehensive post-mortem debugging
  - Changed root logger to DEBUG level to capture all messages
  - Replaced logged message with direct stderr print to ensure log file path is always visible to users

- **debug.py**:
  - Downgraded `log_entrypoint_debug()` calls from INFO to DEBUG level
  - Rationale: debug info is verbose and should only appear in log files, not on stderr

- **session_start.py**:
  - Upgraded root logger from INFO to DEBUG level
  - Added explicit DEBUG level to file handler for consistency

## Implementation Details

The logging strategy now follows a two-tier approach:
- **Stderr (WARNING+)**: Only critical issues visible to users during normal operation
- **File (DEBUG+)**: Complete diagnostic information for troubleshooting when things go wrong

This keeps the user-facing output clean while ensuring comprehensive logs are available for artifact collection and debugging, especially important when subprocesses are killed by timeouts.

https://claude.ai/code/session_014cnyioiYKVCNVerXV2jKbc