### PR TITLE
Use full build strategy for main/master/devel branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,13 @@ jobs:
           echo "BAZEL_DIFF_JAR=$PWD/bazel-diff.jar" >> $GITHUB_ENV
           echo "BAZEL_DIFF_CACHE_DIR=$PWD/.bazel-diff-cache" >> $GITHUB_ENV
           echo "BAZEL_QUERY_LOG_DIR=$PWD/bazel-query-logs" >> $GITHUB_ENV
-          echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV
           echo "CI_WORKFLOWS_MANIFEST=$PWD/tools/ci/workflows.yaml" >> $GITHUB_ENV
+          # Full build on main/devel pushes; incremental on PRs and feature branches
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ ^(main|master|devel)$ ]]; then
+            echo "CI_PUSH_STRATEGY=full" >> $GITHUB_ENV
+          else
+            echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV
+          fi
       - name: Compute CI decision
         id: decide
         run: uv run tools/ci/ci_decide.py

--- a/tools/ci/generate_ci_lib.py
+++ b/tools/ci/generate_ci_lib.py
@@ -76,8 +76,13 @@ COMPUTE_TARGETS_JOB = Job(
             run='echo "BAZEL_DIFF_JAR=$PWD/bazel-diff.jar" >> $GITHUB_ENV\n'
             'echo "BAZEL_DIFF_CACHE_DIR=$PWD/.bazel-diff-cache" >> $GITHUB_ENV\n'
             'echo "BAZEL_QUERY_LOG_DIR=$PWD/bazel-query-logs" >> $GITHUB_ENV\n'
-            'echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV\n'
-            'echo "CI_WORKFLOWS_MANIFEST=$PWD/tools/ci/workflows.yaml" >> $GITHUB_ENV',
+            'echo "CI_WORKFLOWS_MANIFEST=$PWD/tools/ci/workflows.yaml" >> $GITHUB_ENV\n'
+            "# Full build on main/devel pushes; incremental on PRs and feature branches\n"
+            'if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ ^(main|master|devel)$ ]]; then\n'
+            '  echo "CI_PUSH_STRATEGY=full" >> $GITHUB_ENV\n'
+            "else\n"
+            '  echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV\n'
+            "fi",
         ),
         Step(name="Compute CI decision", id="decide", run="uv run tools/ci/ci_decide.py"),
         Step(


### PR DESCRIPTION
## Summary
This change modifies the CI build strategy to use full builds when pushing to main/master/devel branches, while maintaining incremental builds for PRs and feature branches.

## Key Changes
- Updated `.github/workflows/ci.yml` to conditionally set `CI_PUSH_STRATEGY` based on the branch and event type
- Updated `tools/ci/generate_ci_lib.py` to reflect the same conditional logic in the CI configuration generator
- Full builds are now triggered for pushes to `main`, `master`, or `devel` branches
- Incremental builds continue to be used for pull requests and feature branch pushes

## Implementation Details
The strategy selection uses a bash conditional that checks:
1. `GITHUB_EVENT_NAME == "push"` - ensures this only applies to push events, not pull requests
2. `GITHUB_REF_NAME` matches the pattern `^(main|master|devel)$` - targets the primary development branches

This approach ensures comprehensive testing on main development branches while optimizing CI time for feature branches and pull requests through incremental builds.

https://claude.ai/code/session_019VbyjhhnRHezSmiMwS88Rb