### PR TITLE
Fix self-referential deps in gatelet BUILD targets

### DIFF
--- a/gatelet/BUILD.bazel
+++ b/gatelet/BUILD.bazel
@@ -25,7 +25,6 @@ py_binary(
     main = "reporter_main.py",
     visibility = ["//:__subpackages__"],
     deps = [
-        ":reporter",
         ":reporter_lib",
     ],
 )
@@ -52,7 +51,6 @@ py_binary(
     main = "manage_main.py",
     visibility = ["//:__subpackages__"],
     deps = [
-        ":manage",
         ":manage_lib",
     ],
 )


### PR DESCRIPTION
The reporter and manage py_binary targets listed themselves in their own deps, creating dependency cycles that prevented analysis.

https://claude.ai/code/session_01REjD3Ya8k5vPLGsN7SXBRn