### PR TITLE
Remove git-purge-file utility script

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -24,7 +24,7 @@ Utility scripts symlinked to `~/.local/bin/`:
 
 - Theme switchers (`set_dark_theme`, `set_light_theme`)
 - Backup utilities (`duplicity`)
-- Git utilities (`git-purge-file`)
+
 
 ## Commands
 

--- a/dotfiles/local/bin/git-purge-file
+++ b/dotfiles/local/bin/git-purge-file
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# TODO: usage; spaces in name!
-
-COMMAND="git rm --cached --ignore-unmatch '$1'"
-git filter-branch -f --index-filter "$COMMAND" --prune-empty --tag-name-filter cat -- --all

--- a/nix/home/scripts/default.nix
+++ b/nix/home/scripts/default.nix
@@ -42,13 +42,6 @@ let
     echo
   '';
 
-  # Purge a file from git history (uses filter-branch)
-  git-purge-file = pkgs.writeShellScriptBin "git-purge-file" ''
-    # TODO: usage; spaces in name!
-    COMMAND="git rm --cached --ignore-unmatch '$1'"
-    git filter-branch -f --index-filter "$COMMAND" --prune-empty --tag-name-filter cat -- --all
-  '';
-
   # Theme switchers (depend on switch_gnome_terminal_profile - may be obsolete)
   set_dark_theme = pkgs.writeShellScriptBin "set_dark_theme" ''
     switch_gnome_terminal_profile --profile='Solarized Dark'
@@ -61,7 +54,6 @@ in
 {
   home.packages = [
     duplicity
-    git-purge-file
     set_dark_theme
     set_light_theme
   ];


### PR DESCRIPTION
## Summary
Remove the `git-purge-file` utility script from the dotfiles and Nix configuration. This script was used to purge files from git history using `git filter-branch`, but is being deprecated.

## Changes
- Removed `dotfiles/local/bin/git-purge-file` shell script
- Removed `git-purge-file` package definition from `nix/home/scripts/default.nix`
- Removed `git-purge-file` from the home packages list in `nix/home/scripts/default.nix`
- Updated `dotfiles/README.md` to remove reference to `git-purge-file` from the utility scripts list

## Notes
The script had a TODO comment indicating incomplete implementation (no usage documentation and issues with spaces in filenames), which may have contributed to the decision to remove it.

https://claude.ai/code/session_01C7FVYgP1FqxXxuNcygLLmm