### PR TITLE
Remove local environment configuration file

### DIFF
--- a/dotfiles/config/environment.d/99-local.conf
+++ b/dotfiles/config/environment.d/99-local.conf
@@ -1,4 +1,0 @@
-# After editing, run:
-#   systemctl --user daemon-reload
-EDITOR=/usr/bin/vim
-VISUAL=/usr/bin/vim


### PR DESCRIPTION
## Summary
Remove the local environment configuration file that was used to set editor preferences for the user systemd environment.

## Changes
- Deleted `dotfiles/config/environment.d/99-local.conf` which contained hardcoded EDITOR and VISUAL environment variable settings

## Details
This configuration file was setting `EDITOR` and `VISUAL` to `/usr/bin/vim` for the user's systemd environment. Removing this file likely means:
- These settings are now managed elsewhere (system-wide defaults, shell configuration, or user preferences)
- The manual `systemctl --user daemon-reload` step is no longer needed after editing environment variables
- Simplifying the dotfiles configuration by removing redundant or obsolete settings

https://claude.ai/code/session_014Y3ffGb1qB8sPLVjasqZZH