### PR TITLE
Migrate theme scripts to Nix solarized module with writeShellApplication

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -22,9 +22,10 @@ See `docs/shell-configuration.md` for migration status and loading order.
 
 Utility scripts symlinked to `~/.local/bin/`:
 
-- Theme switchers (`set_dark_theme`, `set_light_theme`)
 - Backup utilities (`duplicity`)
 
+
+Theme switchers (`set_dark_theme`, `set_light_theme`) migrated to Nix (`nix/home/modules/solarized.nix`).
 
 ## Commands
 

--- a/dotfiles/local/bin/set_dark_theme
+++ b/dotfiles/local/bin/set_dark_theme
@@ -1,2 +1,0 @@
-#!/bin/bash
-switch_gnome_terminal_profile --profile='Solarized Dark'

--- a/dotfiles/local/bin/set_light_theme
+++ b/dotfiles/local/bin/set_light_theme
@@ -1,2 +1,0 @@
-#!/bin/bash
-switch_gnome_terminal_profile --profile='Solarized Light'

--- a/nix/home/modules/solarized.nix
+++ b/nix/home/modules/solarized.nix
@@ -12,6 +12,21 @@
 let
   solarizedLightScheme = solarizedLight;
   solarizedDarkScheme = solarizedDark;
+
+  # Theme switching scripts - wrappers around switch_gnome_terminal_profile.
+  # Installed to PATH via home.packages; called by Night Theme Switcher
+  # extension on sunrise/sunset and available for manual use.
+  set_light_theme = pkgs.writeShellApplication {
+    name = "set_light_theme";
+    runtimeInputs = [ ]; # switch_gnome_terminal_profile expected on PATH via pip/pipx
+    text = "switch_gnome_terminal_profile --profile='Solarized Light'";
+  };
+
+  set_dark_theme = pkgs.writeShellApplication {
+    name = "set_dark_theme";
+    runtimeInputs = [ ]; # switch_gnome_terminal_profile expected on PATH via pip/pipx
+    text = "switch_gnome_terminal_profile --profile='Solarized Dark'";
+  };
 in
 {
   # Install Night Theme Switcher extension and theme switching utility
@@ -21,6 +36,10 @@ in
       # Required system libraries (always needed for other tools)
       gobject-introspection
       glib
+    ]
+    ++ [
+      set_light_theme
+      set_dark_theme
     ]
     ++ lib.optionals enableGui [
       gnomeExtensions.night-theme-switcher # ID 2236: Night Theme Switcher
@@ -168,8 +187,8 @@ in
     # Night Theme Switcher extension settings
     "org/gnome/shell/extensions/nightthemeswitcher/commands" = {
       enabled = true;
-      sunrise = "switch_gnome_terminal_profile --profile='Solarized Light'";
-      sunset = "switch_gnome_terminal_profile --profile='Solarized Dark'";
+      sunrise = "set_light_theme";
+      sunset = "set_dark_theme";
     };
   };
 }

--- a/nix/home/scripts/default.nix
+++ b/nix/home/scripts/default.nix
@@ -42,19 +42,10 @@ let
     echo
   '';
 
-  # Theme switchers (depend on switch_gnome_terminal_profile - may be obsolete)
-  set_dark_theme = pkgs.writeShellScriptBin "set_dark_theme" ''
-    switch_gnome_terminal_profile --profile='Solarized Dark'
-  '';
-
-  set_light_theme = pkgs.writeShellScriptBin "set_light_theme" ''
-    switch_gnome_terminal_profile --profile='Solarized Light'
-  '';
+  # Theme switchers (set_light_theme, set_dark_theme) are in modules/solarized.nix
 in
 {
   home.packages = [
     duplicity
-    set_dark_theme
-    set_light_theme
   ];
 }


### PR DESCRIPTION
Move set_light_theme and set_dark_theme from dotfiles/local/bin/ and scripts/default.nix into modules/solarized.nix using writeShellApplication (shellcheck at build, set -euo pipefail). Update Night Theme Switcher dconf to call the wrapper scripts instead of switch_gnome_terminal_profile directly.

https://claude.ai/code/session_01ArGFa9CsdRoLjMXgMX1ckX