### PR TITLE
Use @rules_python//python:defs.bzl instead of deprecated python.bzl

### DIFF
--- a/finance/BUILD.bazel
+++ b/finance/BUILD.bazel
@@ -1,5 +1,5 @@
 # gazelle:ignore
-load("@rules_python//python:python.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library")
 
 py_library(
     name = "gnucash_util",

--- a/finance/reconcile/BUILD.bazel
+++ b/finance/reconcile/BUILD.bazel
@@ -1,7 +1,6 @@
 # gazelle:ignore
 # gazelle:python_library_naming_convention $package_name$_lib
-load("@rules_python//python:defs.bzl", "py_library")
-load("@rules_python//python:python.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 py_library(
     name = "external_system",

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -29,8 +29,8 @@ py_library(
     srcs = ["e2e.py"],
     visibility = ["//props:__subpackages__"],
     deps = [
-        "//openai_utils/testing:openai_mock",
         "//openai_utils:model",
+        "//openai_utils/testing:openai_mock",
         "//props/core:ids",
         "//props/critic_dev/improve:main",
         "@pypi//pytest",


### PR DESCRIPTION
The python.bzl load path wraps native.py_library/py_binary which will be removed in Bazel 9. Switch to defs.bzl which uses the Starlark implementation and works on both Bazel 7 and 9.

https://claude.ai/code/session_01Vxe4pia4G7PZ2ZhD7oxEBS