### PR TITLE
Remove empty glob patterns and fix props/core docs data path

### DIFF
--- a/agent_server/web/BUILD.bazel
+++ b/agent_server/web/BUILD.bazel
@@ -18,8 +18,6 @@ _SRCS = glob([
     "src/**/*.ts",
     "src/**/*.svelte",
     "src/**/*.css",
-    "src/**/*.html",
-    "static/**",
 ]) + [
     "svelte.config.js",
     "vite.config.ts",

--- a/gatelet/server/BUILD.bazel
+++ b/gatelet/server/BUILD.bazel
@@ -31,7 +31,6 @@ py_library(
     data = glob([
         "**/*.css",
         "**/*.html",
-        "**/*.jinja2",
     ]),
     imports = ["../.."],
     visibility = ["//gatelet:__subpackages__"],

--- a/props/core/BUILD.bazel
+++ b/props/core/BUILD.bazel
@@ -135,10 +135,7 @@ py_library(
 py_library(
     name = "agent_helpers",
     srcs = ["agent_helpers.py"],
-    data = glob([
-        "docs/**/*.md",
-        "docs/**/*.j2",
-    ]),
+    data = ["//props/docs"],
     imports = ["../.."],
     visibility = ["//props:__subpackages__"],
     deps = [

--- a/props/docs/BUILD.bazel
+++ b/props/docs/BUILD.bazel
@@ -1,0 +1,8 @@
+filegroup(
+    name = "docs",
+    srcs = glob([
+        "**/*.md",
+        "**/*.j2",
+    ]),
+    visibility = ["//props:__subpackages__"],
+)

--- a/props/frontend/BUILD.bazel
+++ b/props/frontend/BUILD.bazel
@@ -16,7 +16,6 @@ _SRCS = glob([
     "src/**/*.ts",
     "src/**/*.svelte",
     "src/**/*.css",
-    "src/**/*.html",
 ]) + [
     "index.html",
     "svelte.config.js",


### PR DESCRIPTION
- agent_server/web: remove src/**/*.html and static/** (no matching files)
- props/frontend: remove src/**/*.html (no matching files)
- props/core: fix docs glob pointing at nonexistent local docs/ dir — create //props/docs filegroup and reference it as data dep
- gatelet/server: remove **/*.jinja2 (templates use .html)

These patterns silently matched nothing. Bazel 9 enforces --incompatible_disallow_empty_glob by default, surfacing the issue.

https://claude.ai/code/session_01Vxe4pia4G7PZ2ZhD7oxEBS