### PR TITLE
Upgrade Bazel dependencies to latest compatible versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,15 +3,15 @@ module(
     version = "0.1.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "1.4.1")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "1.4.1")
 bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt
-bazel_dep(name = "buildifier_prebuilt", version = "8.0.3")
-bazel_dep(name = "aspect_rules_lint", version = "2.0.0-rc0")
-bazel_dep(name = "rules_multirun", version = "0.9.0")  # Required by format_multirun
-bazel_dep(name = "rules_multitool", version = "1.3.0")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2")
+bazel_dep(name = "aspect_rules_lint", version = "2.0.0")
+bazel_dep(name = "rules_multirun", version = "0.13.0")  # Required by format_multirun
+bazel_dep(name = "rules_multitool", version = "1.11.1")
 bazel_dep(name = "rules_mypy", version = "0.40.0")
 
 # Fork with two fixes for CI disk exhaustion during mypy type-checking:
@@ -44,8 +44,8 @@ use_repo(tf, "tf_toolchains")
 register_toolchains("@tf_toolchains//:all")
 
 # Container images (rules_oci)
-bazel_dep(name = "rules_oci", version = "2.2.6")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_oci", version = "2.2.7")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
@@ -58,9 +58,9 @@ oci.pull(
 use_repo(oci, "python_slim", "python_slim_linux_amd64")
 
 # JavaScript/TypeScript (Node.js frontends)
-bazel_dep(name = "aspect_rules_js", version = "2.4.0")
-bazel_dep(name = "aspect_rules_ts", version = "3.8.0")
-bazel_dep(name = "rules_nodejs", version = "6.5.2")
+bazel_dep(name = "aspect_rules_js", version = "2.9.2")
+bazel_dep(name = "aspect_rules_ts", version = "3.8.3")
+bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Browser testing (provides hermetic Chromium for Puppeteer/Playwright tests)
 bazel_dep(name = "rules_playwright", version = "0.5.3")


### PR DESCRIPTION
Upgrade dependencies that are safe to bump independently of the Bazel 7→9 version upgrade:

- bazel_skylib 1.8.2 → 1.9.0
- buildifier_prebuilt 8.0.3 → 8.2.1.2
- aspect_rules_lint 2.0.0-rc0 → 2.0.0 (RC → stable)
- rules_multirun 0.9.0 → 0.13.0
- rules_multitool 1.3.0 → 1.11.1
- rules_oci 2.2.6 → 2.2.7
- rules_pkg 1.0.1 → 1.2.0
- aspect_rules_js 2.4.0 → 2.9.2
- aspect_rules_ts 3.8.0 → 3.8.3
- rules_nodejs 6.5.2 → 6.7.3

https://claude.ai/code/session_01Vxe4pia4G7PZ2ZhD7oxEBS