### PR TITLE
Add libssl-dev and pkg-config to RBE worker for Rust openssl-sys

### DIFF
--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -16,6 +16,8 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
         file \
         fuse-overlayfs \
         git \
+        libssl-dev \
+        pkg-config \
         podman \
         python3 \
         uidmap \


### PR DESCRIPTION
The openssl-sys crate (used by finance/worthy) needs pkg-config to locate OpenSSL headers when compiling remotely on BuildBuddy workers.

https://claude.ai/code/session_013cHPcRuVnwbETrMbtsaDnL