### PR TITLE
Add explicit platforms dependency to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@ module(
     version = "0.1.0",
 )
 
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "1.8.3")


### PR DESCRIPTION
Bazel 9 requires platforms as an explicit bazel_dep (no longer implicit). Adding it now on Bazel 7 is a no-op that prepares for the upgrade.

https://claude.ai/code/session_01Vxe4pia4G7PZ2ZhD7oxEBS