### PR TITLE
Remove Docker availability checks from test infrastructure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,7 +53,6 @@ py_library(
     srcs = ["conftest.py"],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@pypi//docker",
         "@pypi//pytest",
     ],
 )

--- a/agent_server/conftest.py
+++ b/agent_server/conftest.py
@@ -25,7 +25,7 @@ from mcp_infra.compositor.compositor import Compositor
 from mcp_infra.mcp_types import McpServerSpecs
 from mcp_infra.naming import build_mcp_function
 from mcp_infra.prefix import MCPMountPrefix
-from test_util.docker import load_bazel_image, pytest_runtest_setup, python_slim_image
+from test_util.docker import load_bazel_image, python_slim_image
 
 # Image tags and load scripts for Bazel-loaded images
 RUNTIME_IMAGE_TAG = "adgn-runtime:latest"

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import platform
-from contextlib import suppress
 
 import pytest
 
@@ -48,18 +47,6 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     # sandbox-exec requires macOS
     if item.get_closest_marker("requires_sandbox_exec") is not None and platform.system() != "Darwin":
         pytest.skip("sandbox-exec requires macOS")
-
-    # Docker availability check
-    if item.get_closest_marker("requires_docker") is not None:
-        try:
-            import docker  # noqa: PLC0415 - optional dependency, lazy import
-
-            client = docker.from_env()
-            client.ping()
-            with suppress(Exception):
-                client.close()
-        except Exception as exc:
-            pytest.skip(f"Docker not available: {exc}")
 
     # PostgreSQL availability check
     if item.get_closest_marker("requires_postgres") is not None:

--- a/editor_agent/host/conftest.py
+++ b/editor_agent/host/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 # Import fixtures from testing modules (replaces deprecated pytest_plugins)
 from mcp_infra.testing.fixtures import *  # noqa: F403
-from test_util.docker import load_bazel_image, skip_if_docker_unavailable
+from test_util.docker import load_bazel_image
 
 EDITOR_IMAGE_TAG = "adgn-editor:latest"
 EDITOR_LOAD_SCRIPT = "editor_agent/runtime/load.sh"
@@ -13,11 +13,6 @@ EDITOR_LOAD_SCRIPT = "editor_agent/runtime/load.sh"
 def pytest_configure(config: pytest.Config) -> None:
     """Configure pytest-asyncio auto mode."""
     config.option.asyncio_mode = "auto"
-
-
-def pytest_runtest_setup(item: pytest.Item) -> None:
-    """Skip Docker tests when Docker daemon is not available."""
-    skip_if_docker_unavailable(item)
 
 
 @pytest.fixture(scope="session")

--- a/mcp_infra/exec/conftest.py
+++ b/mcp_infra/exec/conftest.py
@@ -5,7 +5,7 @@ import pytest
 # Import fixtures from source modules
 from mcp_infra.testing.docker_fixtures import docker_exec_server_py312slim
 from mcp_infra.testing.fixtures import *  # noqa: F403
-from test_util.docker import pytest_runtest_setup, python_slim_image
+from test_util.docker import python_slim_image
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/test_util/BUILD.bazel
+++ b/test_util/BUILD.bazel
@@ -11,7 +11,6 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:runfiles",
-        "@pypi//docker",
         "@pypi//pytest",
     ],
 )

--- a/test_util/docker.py
+++ b/test_util/docker.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from contextlib import suppress
 
-import docker
 import pytest
 
 import runfiles
@@ -42,35 +40,6 @@ def load_bazel_image(load_script_path: str, image_tag: str) -> str:
         raise RuntimeError(f"Failed to load image {image_tag}: {result.stderr}")
 
     return image_tag
-
-
-def skip_if_docker_unavailable(item: pytest.Item) -> None:
-    """Skip test if Docker daemon is not available.
-
-    Used by pytest_runtest_setup for tests marked with @pytest.mark.requires_docker.
-    """
-    if item.get_closest_marker("requires_docker") is None:
-        return
-
-    client = None
-    try:
-        client = docker.from_env()
-        client.ping()
-    except docker.errors.DockerException as exc:
-        pytest.skip(f"Docker not available: {exc}")
-    finally:
-        if client is not None:
-            with suppress(Exception):
-                client.close()
-
-
-def pytest_runtest_setup(item: pytest.Item) -> None:
-    """Pytest hook to skip Docker tests when Docker daemon is not available.
-
-    Import this function in conftest.py to enable automatic Docker test skipping:
-        from test_util.docker import pytest_runtest_setup  # noqa: F401
-    """
-    skip_if_docker_unavailable(item)
 
 
 # Image tags and load scripts for shared test images

--- a/tools/ci/E2E_TESTING.md
+++ b/tools/ci/E2E_TESTING.md
@@ -25,15 +25,13 @@ Docker test utilities are consolidated in `//test_util`:
 from test_util.docker import (
     load_bazel_image,       # Load OCI image from Bazel oci_load target
     python_slim_image,       # Session fixture for python-slim image
-    pytest_runtest_setup,    # Hook for skipping unavailable Docker tests
 )
 ```
 
 **Pattern for Docker tests:**
 
 1. Add `tags = ["requires_docker"]` to the Bazel test target
-2. Import `pytest_runtest_setup` in conftest.py (auto-skips if Docker unavailable)
-3. Use fixtures from `test_util.docker` or `mcp_infra/testing/docker_fixtures.py`
+2. Use fixtures from `test_util.docker` or `mcp_infra/testing/docker_fixtures.py`
 
 ### Props E2E Tests (Testcontainers)
 


### PR DESCRIPTION
## Summary
This PR removes the Docker daemon availability checking infrastructure from the test utilities. The `skip_if_docker_unavailable()` function and `pytest_runtest_setup()` hook that automatically skipped tests when Docker was unavailable have been removed, along with their associated imports and dependencies.

## Key Changes
- Removed `docker` dependency from `BUILD.bazel` files in `//` and `//test_util`
- Deleted Docker availability check functions from `test_util/docker.py`:
  - `skip_if_docker_unavailable()`
  - `pytest_runtest_setup()` hook
- Removed Docker availability checks from `conftest.py` (root level)
- Removed Docker check imports and hook registrations from:
  - `agent_server/conftest.py`
  - `editor_agent/host/conftest.py`
  - `mcp_infra/exec/conftest.py`
- Updated `tools/ci/E2E_TESTING.md` documentation to reflect the removal

## Implementation Details
- Tests marked with `@pytest.mark.requires_docker` will no longer be automatically skipped if Docker is unavailable
- The `load_bazel_image()` and `python_slim_image` utilities remain available for tests that need Docker
- Removed unused imports: `contextlib.suppress`, `docker` module
- This simplifies the test infrastructure by removing the automatic skip mechanism, allowing tests to fail explicitly if Docker is required but unavailable

https://claude.ai/code/session_01KVi5G2hGue79hbdQamf7tZ