### PR TITLE
Add ansible-lint noqa comments and fix comment formatting

### DIFF
--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -8,7 +8,7 @@ all:
       ansible_connection: local_cached_sudo
     wyrm:
       # ansible_connection: local_cached_sudo
-      ansible_connection: local #_cached_sudo
+      ansible_connection: local # _cached_sudo
       ansible_become_pass_ask: true
       # ansible_host: 10.0.167.15
       # ansible_user: agentydragon

--- a/ansible/wyrm.yaml
+++ b/ansible/wyrm.yaml
@@ -158,7 +158,7 @@
       become: true
       tags: [podman, gpu]
 
-    - name: Install podman from Kubic repo
+    - name: Install podman from Kubic repo # noqa: package-latest
       ansible.builtin.apt:
         name: podman
         state: latest
@@ -193,7 +193,7 @@
       become: true
       tags: [nvidia, podman, gpu]
 
-    - name: Upgrade nvidia-container-toolkit from NVIDIA repo
+    - name: Upgrade nvidia-container-toolkit from NVIDIA repo # noqa: package-latest
       ansible.builtin.apt:
         name: nvidia-container-toolkit
         state: latest


### PR DESCRIPTION
## Summary
This PR addresses ansible-lint warnings by adding `noqa` comments to tasks that intentionally use `state: latest`, and fixes a minor comment formatting issue in the inventory configuration.

## Changes
- **ansible/inventory.yaml**: Fixed comment formatting on the `wyrm` host's `ansible_connection` setting (added space before underscore in comment)
- **ansible/wyrm.yaml**: Added `# noqa: package-latest` comments to two apt tasks:
  - "Install podman from Kubic repo" task
  - "Upgrade nvidia-container-toolkit from NVIDIA repo" task

These noqa comments suppress the ansible-lint `package-latest` rule, which warns against using `state: latest` in package management tasks. The comments indicate these tasks intentionally use `state: latest` for these specific packages.

## Implementation Details
The `package-latest` rule is suppressed for these two tasks because they are explicitly intended to install/upgrade to the latest available versions from their respective repositories (Kubic and NVIDIA), making the use of `state: latest` appropriate in these cases.

https://claude.ai/code/session_01MPQ1Y5REup4HNMTswK9hBi