### PR TITLE
Upgrade rules_python 1.4.1→1.8.3 and gazelle 0.34.0→0.47.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,9 +4,9 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "rules_python", version = "1.4.1")
-bazel_dep(name = "rules_python_gazelle_plugin", version = "1.4.1")
-bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_python", version = "1.8.3")
+bazel_dep(name = "rules_python_gazelle_plugin", version = "1.8.3")
+bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2")
 bazel_dep(name = "aspect_rules_lint", version = "2.0.0")


### PR DESCRIPTION
Bump rules_python, rules_python_gazelle_plugin, and gazelle to latest compatible versions. These upgrades are prerequisites for Bazel 9 (which requires Starlark Python rules) but also work on the current Bazel version.

https://claude.ai/code/session_01Vxe4pia4G7PZ2ZhD7oxEBS