### PR TITLE
Use pre-commit's dependency management for ansible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,8 @@ repos:
       - id: ansible-syntax-check
         name: ansible-playbook --syntax-check
         entry: ansible/scripts/run-syntax-check.sh
-        language: system
+        language: python
+        additional_dependencies: [ansible]
         files: "^ansible/.*\\.ya?ml$"
         exclude: "^ansible/k8s/.*" # Exclude k8s files
         pass_filenames: true

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -286,6 +286,10 @@ def install_git_precommit_hook(project_dir: Path) -> None:
     except subprocess.TimeoutExpired:
         logger.warning("pre-commit install timed out")
 
+    # TODO: Run `pre-commit install-hooks` in the background to eagerly pre-install
+    # hook environments (especially the ansible language:python venv). Without this,
+    # the first commit pays the cost of creating the venv and downloading ansible.
+
 
 class LogCollector(logging.handlers.MemoryHandler):
     """Handler that collects log records for later inspection.

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -249,17 +249,16 @@ def install_git_precommit_hook(project_dir: Path) -> None:
         logger.info("Git pre-commit hook already installed")
         return
 
-    # Ensure pre-commit and its dependencies are installed
-    # ansible-lint hook requires ansible package
-    # TODO: Deduplicate this setup with CI setup steps (see .github/workflows/*.yml)
+    # Ensure pre-commit is installed.
+    # Ansible is installed by pre-commit itself (language: python + additional_dependencies).
     try:
         subprocess.run(["pre-commit", "--version"], capture_output=True, check=True, timeout=5)
         logger.info("pre-commit already available")
     except (FileNotFoundError, subprocess.CalledProcessError):
-        logger.info("Installing pre-commit==4.0.1 and ansible via pip")
+        logger.info("Installing pre-commit==4.0.1 via pip")
         try:
             result = subprocess.run(
-                ["pip", "install", "--user", "pre-commit==4.0.1", "ansible"],
+                ["pip", "install", "--user", "pre-commit==4.0.1"],
                 check=False,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## Summary
Refactor the ansible dependency management to leverage pre-commit's built-in dependency handling instead of requiring manual installation. This simplifies the setup process and reduces duplication between the pre-commit configuration and installation scripts.

## Key Changes
- Updated `.pre-commit-config.yaml` to specify `language: python` and `additional_dependencies: [ansible]` for the ansible-syntax-check hook, allowing pre-commit to manage the ansible installation automatically
- Removed manual ansible installation from `tools/claude_hooks/session_start.py` since pre-commit now handles it
- Updated installation logging and comments to reflect that ansible is no longer installed separately

## Implementation Details
- The ansible-syntax-check hook now uses pre-commit's dependency management system instead of relying on system-level installation
- This approach ensures the correct version of ansible is available in the pre-commit environment without requiring users to install it globally
- Reduces the setup burden on developers and eliminates the TODO comment about deduplicating CI setup steps

https://claude.ai/code/session_019LgrZbhWvHNxcUNve3ijxy