### PR TITLE
Add libxfixes3 to RBE worker image for Chromium headless shell

### DIFF
--- a/tools/claude_hooks/AGENTS.md
+++ b/tools/claude_hooks/AGENTS.md
@@ -9,42 +9,7 @@
 
 ## Building Dockerfiles in gVisor
 
-`podman build` does not work in gVisor due to two independent issues:
-
-- **OCI isolation**: crun calls `deny_setgroups()` which opens `/proc/<pid>/setgroups` — this file doesn't exist in gVisor.
-- **Chroot isolation**: `/dev/null` is read-only, breaking apt-get/gpg.
-
-**Workaround**: simulate Dockerfile steps using `podman run` + `podman commit`:
-
-```bash
-# FROM
-podman pull docker.io/library/ubuntu:24.04
-IMAGE=docker.io/library/ubuntu:24.04
-
-# RUN
-podman run --rm=false --name build-step --network=host "$IMAGE" \
-  /bin/sh -c 'apt-get update && apt-get install -y curl'
-IMAGE=$(podman commit build-step | tail -1)
-podman rm -f build-step
-
-# COPY (mount source, cp inside container, commit)
-podman run --rm=false --name build-step --network=host \
-  -v /path/to/local/file.conf:/mnt/file.conf:ro \
-  "$IMAGE" /bin/sh -c 'cp /mnt/file.conf /etc/file.conf'
-IMAGE=$(podman commit build-step | tail -1)
-podman rm -f build-step
-
-# Tag final image
-podman tag "$IMAGE" my-image:latest
-```
-
-To verify shared library completeness of an image (e.g., for Chromium):
-
-```bash
-podman run --rm --network=host \
-  -v /path/to/binary:/tmp/binary:ro \
-  my-image:latest ldd /tmp/binary | grep "not found"
-```
+@docs/gvisor-dockerfile-build.md
 
 ## Debugging Commands
 

--- a/tools/claude_hooks/AGENTS.md
+++ b/tools/claude_hooks/AGENTS.md
@@ -7,6 +7,45 @@
 - **gVisor environment**: Claude Code web runs on gVisor, not real Linux. Some syscalls behave differently.
 - **9p filesystem limitation**: Root `/` is 9p. Supervisor uses TCP socket (`127.0.0.1:19001`) instead of Unix socket to avoid 9p hard link issues (EOPNOTSUPP).
 
+## Building Dockerfiles in gVisor
+
+`podman build` does not work in gVisor due to two independent issues:
+
+- **OCI isolation**: crun calls `deny_setgroups()` which opens `/proc/<pid>/setgroups` — this file doesn't exist in gVisor.
+- **Chroot isolation**: `/dev/null` is read-only, breaking apt-get/gpg.
+
+**Workaround**: simulate Dockerfile steps using `podman run` + `podman commit`:
+
+```bash
+# FROM
+podman pull docker.io/library/ubuntu:24.04
+IMAGE=docker.io/library/ubuntu:24.04
+
+# RUN
+podman run --rm=false --name build-step --network=host "$IMAGE" \
+  /bin/sh -c 'apt-get update && apt-get install -y curl'
+IMAGE=$(podman commit build-step | tail -1)
+podman rm -f build-step
+
+# COPY (mount source, cp inside container, commit)
+podman run --rm=false --name build-step --network=host \
+  -v /path/to/local/file.conf:/mnt/file.conf:ro \
+  "$IMAGE" /bin/sh -c 'cp /mnt/file.conf /etc/file.conf'
+IMAGE=$(podman commit build-step | tail -1)
+podman rm -f build-step
+
+# Tag final image
+podman tag "$IMAGE" my-image:latest
+```
+
+To verify shared library completeness of an image (e.g., for Chromium):
+
+```bash
+podman run --rm --network=host \
+  -v /path/to/binary:/tmp/binary:ro \
+  my-image:latest ldd /tmp/binary | grep "not found"
+```
+
 ## Debugging Commands
 
 ```bash

--- a/tools/claude_hooks/TODO.md
+++ b/tools/claude_hooks/TODO.md
@@ -11,6 +11,10 @@
 - **Pre-built nix store tarball** (recommended) - CI builds closure, publishes tarball, session hook unpacks
 - **Pre-computed store paths** - CI records paths, session hook does `nix copy`
 
+## gVisor Dockerfile Build as Claude Code Skill
+
+Consider turning <docs/gvisor-dockerfile-build.md> into a Claude Code skill (`.claude/skills/`) so Claude can automatically apply the `podman run`+`podman commit` workaround when asked to build a Dockerfile, rather than requiring the agent to read the docs first.
+
 ## Supervisor Health Check Eventlistener
 
 **Problem**: No proactive health monitoring for auth proxy - if it crashes, supervisor restarts it but we only notice on next bazel invocation.

--- a/tools/claude_hooks/docs/gvisor-dockerfile-build.md
+++ b/tools/claude_hooks/docs/gvisor-dockerfile-build.md
@@ -1,0 +1,50 @@
+# Building Dockerfiles in gVisor
+
+`podman build` does not work in gVisor due to two independent issues:
+
+- **OCI isolation**: crun calls `deny_setgroups()` which opens `/proc/<pid>/setgroups` — this file doesn't exist in gVisor.
+- **Chroot isolation**: `/dev/null` is read-only, breaking apt-get/gpg.
+
+## Workaround: podman run + commit
+
+Simulate Dockerfile steps using `podman run` + `podman commit`:
+
+```bash
+# FROM
+podman pull docker.io/library/ubuntu:24.04
+IMAGE=docker.io/library/ubuntu:24.04
+
+# RUN
+podman run --rm=false --name build-step --network=host "$IMAGE" \
+  /bin/sh -c 'apt-get update && apt-get install -y curl'
+IMAGE=$(podman commit build-step | tail -1)
+podman rm -f build-step
+
+# COPY (mount source, cp inside container, commit)
+podman run --rm=false --name build-step --network=host \
+  -v /path/to/local/file.conf:/mnt/file.conf:ro \
+  "$IMAGE" /bin/sh -c 'cp /mnt/file.conf /etc/file.conf'
+IMAGE=$(podman commit build-step | tail -1)
+podman rm -f build-step
+
+# Tag final image
+podman tag "$IMAGE" my-image:latest
+```
+
+## Verifying shared library completeness
+
+To check that an image has all shared libraries needed by a binary (e.g., Chromium headless shell):
+
+```bash
+podman run --rm --network=host \
+  -v /path/to/binary:/tmp/binary:ro \
+  my-image:latest ldd /tmp/binary | grep "not found"
+```
+
+No output means all libraries resolve.
+
+## Root cause details
+
+**OCI isolation path**: `podman run --network=host` works because `containers.conf` sets `userns=host`, which skips user namespace creation entirely. `podman build` creates intermediate containers for each `RUN` step that don't inherit this setting, so crun tries to set up a user namespace and fails when writing to `/proc/<pid>/setgroups`.
+
+**Chroot isolation path**: buildah's chroot mode creates a minimal `/dev` on a devtmpfs that gVisor mounts read-only. Volume mounts (`--volume /dev/null:/dev/null:rw`) don't override this because the devtmpfs layer takes precedence.

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -3,10 +3,8 @@ Environment: gVisor sandbox, TLS-inspecting proxy, no overlay fs (vfs), 9p fs
 Bazel: wrapper adds auth proxy (port ${proxy.port}, ${proxy.ca_status})
 % if podman:
 Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified image names (docker.io/library/...)
-  `podman run` works (with --network=host). `podman build` does NOT work in gVisor:
-    OCI isolation fails (/proc/self/setgroups missing — crun's deny_setgroups), chroot isolation fails (/dev/null read-only).
-  Workaround: use `podman run --network=host <image> <cmd>` then `podman commit <container>` for each Dockerfile step.
-  For COPY: mount source with -v and cp inside the container, then commit.
+  `podman run` works (with --network=host). `podman build` does NOT work in gVisor.
+  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for workaround (podman run+commit).
 % endif
 % for record in log_entries:
 % if record.levelno >= WARNING:

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -3,6 +3,10 @@ Environment: gVisor sandbox, TLS-inspecting proxy, no overlay fs (vfs), 9p fs
 Bazel: wrapper adds auth proxy (port ${proxy.port}, ${proxy.ca_status})
 % if podman:
 Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified image names (docker.io/library/...)
+  `podman run` works (with --network=host). `podman build` does NOT work in gVisor:
+    OCI isolation fails (/proc/self/setgroups missing — crun's deny_setgroups), chroot isolation fails (/dev/null read-only).
+  Workaround: use `podman run --network=host <image> <cmd>` then `podman commit <container>` for each Dockerfile step.
+  For COPY: mount source with -v and cp inside the container, then commit.
 % endif
 % for record in log_entries:
 % if record.levelno >= WARNING:

--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -37,6 +37,7 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
         libxdamage1 \
         libxkbcommon0 \
         libxrandr2 \
+        libxfixes3 \
         libxshmfence1 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The visual regression test fails on RBE because chromium_headless_shell requires libXfixes.so.3 which was missing from the worker image.

https://claude.ai/code/session_01QDMs2nXptUaVxrrH1yUceR