### PR TITLE
Generalize Bazel trigger from pattern matching to query expressions

### DIFF
--- a/tools/ci/bazel_query.py
+++ b/tools/ci/bazel_query.py
@@ -58,12 +58,16 @@ def run_query(query: str) -> list[str]:
     return _run_bazel_query_cmd(["bazelisk", "query"], query)
 
 
-def query_intersection(targets: list[str], pattern: str) -> list[str]:
-    """Query targets that intersect with a pattern. Returns matching targets."""
+def query_with_targets(query_template: str, targets: list[str]) -> list[str]:
+    """Run a Bazel query template with ``$targets`` replaced by the target set.
+
+    Returns matching targets, or an empty list if targets is empty.
+    """
     if not targets:
         return []
 
-    query = f"set({' '.join(targets)}) intersect {pattern}"
+    target_set = f"set({' '.join(targets)})"
+    query = query_template.replace("$targets", target_set)
     return run_query(query)
 
 

--- a/tools/ci/ci_decide_lib.py
+++ b/tools/ci/ci_decide_lib.py
@@ -18,10 +18,10 @@ import pygit2
 from pydantic import BaseModel, Field
 
 from fmt_util.fmt_util import format_limited_list
-from tools.ci.bazel_query import filter_for_ci, query_intersection
+from tools.ci.bazel_query import filter_for_ci, query_with_targets
 from tools.ci.diff_utils import get_changed_files, get_ci_base_commit, has_infra_changes, run_bazel_diff
 from tools.ci.github_actions import CIEnvironment, PushStrategy
-from tools.ci.models import AlwaysTrigger, BazelPatternTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
+from tools.ci.models import AlwaysTrigger, BazelQueryTrigger, PathPatternTrigger, WorkflowConfig, WorkflowManifest
 from tools.env_utils import get_optional_env_path, get_required_existing_path
 
 logger = logging.getLogger(__name__)
@@ -65,8 +65,8 @@ def should_trigger(name: str, config: WorkflowConfig, targets: list[str], change
             if any(regex.match(f) for f in changed_files):
                 logger.info("Path pattern '%s' matched -> triggers %s", pattern, name)
                 return True
-        case BazelPatternTrigger(pattern=pattern):
-            if targets and query_intersection(targets, pattern):
+        case BazelQueryTrigger(query=query):
+            if targets and query_with_targets(query, targets):
                 return True
 
     return False

--- a/tools/ci/models.py
+++ b/tools/ci/models.py
@@ -21,11 +21,19 @@ class AlwaysTrigger(BaseModel):
     kind: Literal["always"] = "always"
 
 
-class BazelPatternTrigger(BaseModel):
-    """Workflow triggered by Bazel target pattern."""
+class BazelQueryTrigger(BaseModel):
+    """Workflow triggered by a Bazel query over affected targets.
 
-    kind: Literal["bazel"] = "bazel"
-    pattern: str
+    The query field is a Bazel query expression where ``$targets`` is replaced
+    with ``set(...)`` of the affected targets.  The workflow triggers when the
+    query returns at least one result.
+
+    Example: ``kind(".*_test rule", $targets)`` triggers only when the affected
+    set contains test targets.
+    """
+
+    kind: Literal["bazel_query"] = "bazel_query"
+    query: str
 
 
 class PathPatternTrigger(BaseModel):
@@ -37,7 +45,7 @@ class PathPatternTrigger(BaseModel):
 
 WorkflowTrigger = Annotated[
     Annotated[AlwaysTrigger, Tag("always")]
-    | Annotated[BazelPatternTrigger, Tag("bazel")]
+    | Annotated[BazelQueryTrigger, Tag("bazel_query")]
     | Annotated[PathPatternTrigger, Tag("path")],
     Discriminator("kind"),
 ]

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -5,7 +5,7 @@
 #
 # Trigger types (discriminated by trigger.kind):
 #   always: Always run this workflow
-#   bazel: Bazel target pattern (uses bazel query intersection)
+#   bazel_query: Bazel query expression over affected targets ($targets placeholder)
 #   path: Regex pattern for changed files
 #
 # Job options:
@@ -18,24 +18,24 @@
 workflows:
   # Core Bazel workflows
   bazel-build:
-    trigger: { kind: bazel, pattern: "//..." }
+    trigger: { kind: bazel_query, query: "$targets" }
     targets: true
     secrets: [BUILDBUDDY_API_KEY]
 
   bazel-test:
-    trigger: { kind: bazel, pattern: "//..." }
+    trigger: { kind: bazel_query, query: 'kind(".*_test rule", $targets)' }
     targets: true
     secrets: [BUILDBUDDY_API_KEY]
 
   bazel-lint:
-    trigger: { kind: bazel, pattern: "//..." }
+    trigger: { kind: bazel_query, query: "$targets" }
     targets: true
     inputs:
       enable_profiling: ${{ inputs.enable_profiling || false }}
     secrets: [BUILDBUDDY_API_KEY]
 
   bazel-typecheck:
-    trigger: { kind: bazel, pattern: "//..." }
+    trigger: { kind: bazel_query, query: "$targets" }
     targets: true
     inputs:
       enable_profiling: ${{ inputs.enable_profiling || false }}
@@ -43,14 +43,14 @@ workflows:
 
   # Rust-specific (only finance/ has Rust code)
   bazel-rust-lint:
-    trigger: { kind: bazel, pattern: "//finance/..." }
+    trigger: { kind: bazel_query, query: "$targets intersect //finance/..." }
     inputs:
       enable_profiling: ${{ inputs.enable_profiling || false }}
     secrets: [BUILDBUDDY_API_KEY]
 
   # Frontend visual regression
   visual-regression:
-    trigger: { kind: bazel, pattern: "//props/frontend/..." }
+    trigger: { kind: bazel_query, query: "$targets intersect //props/frontend/..." }
     secrets: [BUILDBUDDY_API_KEY]
 
   # Path-based workflows (non-Bazel)


### PR DESCRIPTION
## Summary
Refactored the Bazel workflow trigger system to support arbitrary Bazel query expressions instead of simple pattern matching. This provides more flexibility for defining when workflows should run based on affected targets.

## Key Changes

- **Renamed `BazelPatternTrigger` to `BazelQueryTrigger`** in `models.py`:
  - Changed `kind` discriminator from `"bazel"` to `"bazel_query"`
  - Replaced `pattern: str` field with `query: str` field
  - Updated documentation to explain the `$targets` placeholder mechanism

- **Generalized `query_intersection()` to `query_with_targets()`** in `bazel_query.py`:
  - Now accepts a `query_template` parameter instead of a hardcoded intersection pattern
  - Replaces `$targets` placeholder with the actual target set
  - Maintains backward compatibility by returning empty list when targets list is empty

- **Updated all workflow triggers** in `workflows.yaml`:
  - Simple triggers now use `query: "$targets"` (equivalent to previous `pattern: "//..."`)
  - Scoped triggers now use intersection syntax: `query: "$targets intersect //finance/..."` (equivalent to previous `pattern: "//finance/..."`)
  - Test-specific trigger uses Bazel's `kind()` function: `query: 'kind(".*_test rule", $targets)'`

- **Updated imports** in `ci_decide_lib.py` to reflect the renamed function and model

## Implementation Details

The `$targets` placeholder is replaced with `set(target1 target2 ...)` containing all affected targets, allowing any valid Bazel query expression to be used. This enables more sophisticated filtering logic while maintaining the same performance characteristics.

https://claude.ai/code/session_014nxvPnMCk8RJBPSsrrBNAc