### PR TITLE
Clean up ansible-lint config for legacy role migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,5 +20,7 @@ tana/testdata/** rules-lint-ignored=true
 
 # Archived/legacy code
 k8s-old/** rules-lint-ignored=true
+# TODO: Delete legacy_* roles once all machines switch to Nix home-manager
+ansible/roles/legacy_*/** rules-lint-ignored=true
 tana/export/references/** rules-lint-ignored=true
 llm/html/llm_html/coding.md rules-lint-ignored=true

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -1,16 +1,12 @@
 ---
 # Ansible-lint configuration for ducktape infrastructure
 
+# TODO: Delete all legacy_* roles once all machines have switched to Nix home-manager.
 # Exclude legacy roles that are being phased out
 # Also exclude non-Ansible YAML files (Helm templates, k8s manifests)
 exclude_paths:
-  - roles/legacy_cli/**         # Legacy role, being migrated to Nix home-manager
-  - roles/legacy_claude_mcp/**  # Legacy role, being migrated to Nix home-manager
-  - roles/legacy_nerd_fonts/** # Legacy role, fonts now managed by Nix home-manager
+  - roles/legacy_cli/**
+  - roles/legacy_claude_mcp/**
+  - roles/legacy_gui/**
+  - roles/legacy_nerd_fonts/**
   - ../k8s/**                   # Kubernetes/Helm files with Go templating and custom YAML tags
-
-# These legacy roles contain:
-# - Variable naming violations (legacy_claude_mcp_* vars in legacy_cli)
-# - Command-instead-of-shell false positives (bash -lc usage)
-# - Package-latest and formatting issues
-# All will be resolved when roles are fully migrated to home.nix


### PR DESCRIPTION
## Summary
Updated ansible-lint configuration and gitattributes to better manage legacy Ansible roles that are being migrated to Nix home-manager. Simplified exclusion rules and added a new legacy_gui role to the exclusion list.

## Changes
- **ansible/.ansible-lint**: 
  - Removed verbose inline comments explaining why each legacy role is excluded
  - Added `roles/legacy_gui/**` to the exclusion list
  - Added a TODO comment at the top noting that all legacy_* roles should be deleted once machines have switched to Nix home-manager
  - Cleaned up the detailed explanation block at the end of the file

- **.gitattributes**:
  - Added exclusion for `ansible/roles/legacy_*/**` with rules-lint-ignored flag
  - Added TODO comment indicating these should be deleted after full migration to Nix home-manager

## Implementation Details
The changes consolidate the legacy role management strategy by:
1. Using a wildcard pattern in gitattributes to cover all current and future legacy_* roles
2. Simplifying the ansible-lint config by removing redundant explanatory comments (the intent is clear from the role naming convention)
3. Ensuring the new legacy_gui role is properly excluded from linting
4. Adding clear TODO markers for future cleanup once the migration is complete

https://claude.ai/code/session_01EGLJue3iEiTTR68HVBNiwb