### PR TITLE
Add CI test failure diagnosis and Docker-on-RBE probe tests

### DIFF
--- a/CI_TEST_FAILURES.md
+++ b/CI_TEST_FAILURES.md
@@ -1,0 +1,130 @@
+# CI `bazel-test` Failure Diagnosis
+
+Analyzed 5 most recent failed runs on `devel` (2026-01-31). The most recent run
+has 18 real test failures plus ~46 tests that never executed (RBE infra flakiness).
+
+## Fix 1 (HIGH): Missing `pre-commit` on RBE — 7 targets
+
+**Targets:**
+
+- `//claude/claude_hooks:test_autofixer`
+- `//claude/claude_hooks:test_integration`
+- `//claude/claude_hooks:test_precommit_integration`
+- `//llm/claude_linter:test_claude_post_hook`
+- `//llm/claude_linter:test_hooks`
+- `//llm/claude_linter_v2:test_integration`
+- `//llm/claude_linter_v2:test_stop_hook_gitignore`
+
+**Error:** `FileNotFoundError: [Errno 2] No such file or directory: 'pre-commit'`
+
+**Root cause:** Tests spawn `pre-commit` as a subprocess. The RBE worker image
+doesn't have it.
+
+**Fix:** Tag these tests `no-remote` to force local execution.
+
+## Fix 2 (HIGH): Missing `python` binary in mcp_starter — 1 target (5 cases)
+
+**Target:** `//mcp_starter:test_server`
+
+**Error:** `FileNotFoundError: [Errno 2] No such file or directory: 'python'`
+
+**Root cause:** `mcp_starter/conftest.py:15` hardcodes `command="python"` but
+the RBE image only has `python3`.
+
+**Fix:** Use `sys.executable` instead of `"python"`.
+
+## Fix 3 (HIGH): Missing `anyio` in subprocess on RBE — 2 targets
+
+**Targets:**
+
+- `//agent_server/mcp:test_notifications_envelope`
+- `//mcp_infra/compositor:test_admin`
+
+**Error:** `ModuleNotFoundError: No module named 'anyio'` in subprocess,
+causing `McpError: Connection closed`.
+
+**Root cause:** `mcp_infra/testing/stdio_notifier.py` imports `anyio`. The
+BUILD deps are correct, but when the `stdio_notifier` `py_binary` is launched
+as a subprocess, its runfiles may not ship correctly to RBE.
+
+**Fix:** Investigate runfiles propagation for `py_binary` on RBE. May need
+`data` dep on tests or `exec_properties` adjustments.
+
+## Fix 4 (MEDIUM): pytest-asyncio fixture incompatibility — 4 targets (15 cases)
+
+**Targets:**
+
+- `//homeassistant/iaqi/custom_components/indoor_aqi:test_config_flow`
+- `//homeassistant/iaqi/custom_components/indoor_aqi:test_init`
+- `//homeassistant/iaqi/custom_components/indoor_aqi:test_sensor`
+- `//homeassistant/iaqi/custom_components/indoor_aqi:test_sensor_simple`
+
+**Error:** `'test_import_flow' requested an async fixture 'hass', with no
+plugin or hook that supports it`
+
+**Root cause:** The `hass` fixture from `pytest_homeassistant_custom_component`
+is async. The conftest.py has no `pytest_configure` hook to set
+`asyncio_mode = "auto"`, unlike other packages in this repo.
+
+**Fix:** Add `pytest_configure` hook to set asyncio auto mode in
+`homeassistant/iaqi/custom_components/indoor_aqi/conftest.py`.
+
+## Fix 5 (MEDIUM): Ruff not available on RBE — 1 target (2 cases)
+
+**Target:** `//llm/claude_linter_v2:test_cl2_check`
+
+**Error:** `assert 'x=1\ny=2\n' == 'x = 1\ny = 2\n'` — ruff auto-fix didn't
+run.
+
+**Fix:** Add `ruff` as a `data` dep on the test target, or tag `no-remote`.
+
+## Fix 6 (LOW): Test assertion mismatch — 1 target
+
+**Target:** `//llm/claude_linter_v2:test_stop_hook_fresh_scan`
+
+**Error:** Test expects `"Do not use bare \`except\`"`in reason but gets`"Use of hasattr"` instead.
+
+**Root cause:** The test file has both `except:` and `hasattr()` violations.
+The detector returns the `hasattr` violation first.
+
+**Fix:** Fix detector ordering or relax the assertion to accept either
+violation.
+
+## Fix 7 (LOW): Jinja2 template syntax — 1 target
+
+**Target:** `//llm/html/llm_html:test_html_rendering`
+
+**Error:** `expected token 'end of statement block', got '='`
+
+**Fix:** Escape `{{ ... }}` Jinja2-like syntax in markdown content.
+
+## Fix 8 (LOW): Missing `dbus-daemon` — 1 target
+
+**Target:** `//experimental/dbus_fast_example:test_example`
+
+**Fix:** Tag `no-remote`.
+
+## Infrastructure: Firecracker VM crashes — ~46 tests per run
+
+**Error:** `Unavailable: failed to sync workspace: Firecracker VM crashed: rpc error: code = DeadlineExceeded desc = docker init timed out after 30s`
+
+**Root cause:** The custom RBE image (`ghcr.io/agentydragon/rbe-worker`) was based on bare `ubuntu:24.04` with `docker.io` from Ubuntu's repos. Ubuntu 24.04 defaults iptables to the nftables backend, but Firecracker's guest kernel lacks nf_tables support. When BuildBuddy's `init-dockerd` starts dockerd inside the Firecracker VM, Docker networking setup hangs on nftables calls, exceeding the hardcoded 30-second timeout in BuildBuddy's vmexec server.
+
+**Evidence:** BuildBuddy's own `rbe-ubuntu24-04` image passed the probe test in 5.2s; our custom image crashed every time. BuildBuddy's Dockerfile explicitly switches to `iptables-legacy` with a comment about this exact issue.
+
+**Fix:** Rebase the RBE image on `gcr.io/flame-public/rbe-ubuntu24-04:latest` (which includes Docker CE and the iptables-legacy workaround). See `tools/rbe_image/Dockerfile`.
+
+## Summary
+
+| #   | Fix                                                     | Targets fixed | Effort   |
+| --- | ------------------------------------------------------- | ------------- | -------- |
+| 1   | Tag 7 pre-commit tests `no-remote`                      | 7             | Trivial  |
+| 2   | `"python"` -> `sys.executable` in mcp_starter           | 1 (5 cases)   | One-line |
+| 3   | Investigate anyio subprocess runfiles on RBE            | 2             | Medium   |
+| 4   | Add `pytest_configure` asyncio auto-mode to HA conftest | 4 (15 cases)  | 3-line   |
+| 5   | Add ruff data dep or tag `no-remote`                    | 1 (2 cases)   | Small    |
+| 6   | Fix assertion in `test_stop_hook_fresh_scan`            | 1             | Small    |
+| 7   | Fix Jinja2 template escaping                            | 1             | Small    |
+| 8   | Tag dbus test `no-remote`                               | 1             | Trivial  |
+
+Fixes 1-4 resolve 13 of 18 failing targets with minimal effort.

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -1,2 +1,98 @@
 # Bazel macros for testing infrastructure.
 # NOTE: No aggregator target - use specific .bzl files like :docker.bzl
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# === Docker-on-RBE probe tests ===
+# Minimal tests to determine which exec_properties combination gives us a
+# working Docker daemon on BuildBuddy RBE workers.
+#
+# Run all probes:  bazel test //tools/testing:docker_probe_*
+# Run one probe:   bazel test //tools/testing:docker_probe_firecracker
+
+# Variant 1: Firecracker + init-dockerd (current config that crashes)
+sh_test(
+    name = "docker_probe_firecracker",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "false",
+        "test.EstimatedComputeUnits": "3",
+    },
+    tags = ["requires_docker"],
+)
+
+# Variant 2: Firecracker + init-dockerd + recycle-runner + more resources
+sh_test(
+    name = "docker_probe_firecracker_warm",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        "test.EstimatedComputeUnits": "6",
+    },
+    tags = ["requires_docker"],
+)
+
+# Variant 3: No Firecracker, just init-dockerd (does BuildBuddy support this?)
+sh_test(
+    name = "docker_probe_no_firecracker",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.init-dockerd": "true",
+        "test.EstimatedComputeUnits": "3",
+    },
+    tags = ["requires_docker"],
+)
+
+# Variant 4: Plain execution, no special properties (baseline - should fail)
+sh_test(
+    name = "docker_probe_plain",
+    srcs = ["docker_probe_test.sh"],
+    tags = ["requires_docker"],
+)
+
+# Variant 5: Firecracker + massive resources (10 compute units = 10 CPUs + 25GB RAM)
+sh_test(
+    name = "docker_probe_firecracker_large",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "false",
+        "test.EstimatedComputeUnits": "10",
+    },
+    tags = ["requires_docker"],
+)
+
+# Variant 6: Firecracker + dockerd on TCP (in case Unix socket is the problem)
+sh_test(
+    name = "docker_probe_firecracker_tcp",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.enable-dockerd-tcp": "true",
+        "test.recycle-runner": "false",
+        "test.EstimatedComputeUnits": "3",
+    },
+    tags = ["requires_docker"],
+)
+
+# Variant 7: Firecracker + init-dockerd using BuildBuddy's default image
+# (gcr.io/flame-public/executor-docker-default) instead of our custom image.
+# This bisects whether the crash is our custom image or Firecracker itself.
+sh_test(
+    name = "docker_probe_default_bb_image",
+    srcs = ["docker_probe_test.sh"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "false",
+        "test.EstimatedComputeUnits": "3",
+        "test.container-image": "docker://gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0",
+    },
+    tags = ["requires_docker"],
+)

--- a/tools/testing/docker_probe_test.sh
+++ b/tools/testing/docker_probe_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Minimal probe: can we talk to a Docker daemon on this RBE worker?
+set -euo pipefail
+
+echo "=== Environment ==="
+echo "Hostname: $(hostname)"
+echo "Kernel: $(uname -r)"
+echo "User: $(whoami)"
+echo "Docker socket: $(ls -la /var/run/docker.sock 2>&1 || echo 'not found')"
+echo "Memory: $(free -h 2>/dev/null | head -2 || echo 'free not available')"
+echo "CPUs: $(nproc 2>/dev/null || echo 'nproc not available')"
+echo "Disk: $(df -h / 2>/dev/null | tail -1 || echo 'df not available')"
+
+echo ""
+echo "=== Processes ==="
+ps aux 2>/dev/null || echo "ps not available"
+
+echo ""
+echo "=== Docker info ==="
+docker info 2>&1 || echo "docker info failed: $?"
+
+echo ""
+echo "=== Docker run ==="
+docker run --rm alpine:3.20 echo "DOCKER_WORKS" 2>&1


### PR DESCRIPTION
## Summary

- `CI_TEST_FAILURES.md` documenting all 8 failure categories with root causes and fixes
- Docker-on-RBE probe `sh_test` targets (`//tools/testing:docker_probe_*`) used to bisect the Firecracker VM crash issue
- `TODO.md` entry for BuildBuddy remote runner features
- `bazel_subprocess` module for pre-commit/ruff Python `-m` invocation

The actual Firecracker fix (rebasing the RBE image on BuildBuddy's `rbe-ubuntu24-04`) was merged directly to devel in fbfc65ecd.

## Test plan

- [ ] `bazel build --config=check //...` passes
- [ ] `bazel test //tools/testing:docker_probe_firecracker` passes on RBE (pending new image build)