### PR TITLE
Add bazel_subprocess module for Bazel-compatible subprocess execution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@
 # gazelle:resolve py samplebooks_parts_data //inventree_utils:samplebooks_parts_data
 #
 # Root-level targets
+# gazelle:resolve py bazel_subprocess //:bazel_subprocess
 # gazelle:resolve py bazel_util //:bazel_util
 # gazelle:resolve py fmt_util.fmt_util //fmt_util:fmt_util
 
@@ -26,7 +27,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 load("@npm_ducktape//:defs.bzl", "npm_link_all_packages")
 load("@proxy_config//:proxy_env.bzl", "PROXY_ENV")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 load("@rules_python//python/uv:lock.bzl", "lock")
 
@@ -62,6 +63,22 @@ py_library(
     name = "bazel_util",
     srcs = ["bazel_util.py"],
     visibility = ["//:__subpackages__"],
+)
+
+# Subprocess helpers for launching Python modules under rules_python
+py_library(
+    name = "bazel_subprocess",
+    srcs = ["bazel_subprocess.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "test_bazel_subprocess",
+    srcs = ["test_bazel_subprocess.py"],
+    deps = [
+        ":bazel_subprocess",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 # Runfiles utilities for locating binaries and data files

--- a/bazel_subprocess.py
+++ b/bazel_subprocess.py
@@ -1,0 +1,93 @@
+"""Run Python modules as subprocesses under Bazel's rules_python.
+
+rules_python's venv-based bootstrap sets up sys.path via a virtual environment,
+but that doesn't carry over to subprocesses spawned via sys.executable. This
+module provides subprocess.run / asyncio.create_subprocess_exec wrappers and a
+shell-wrapper generator that propagate PYTHONPATH automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def python_env(*, inherit: bool = True) -> dict[str, str]:
+    """Environment dict with PYTHONPATH propagated for Bazel subprocesses.
+
+    Args:
+        inherit: If True, start from os.environ. If False, return a minimal
+                 dict with only PYTHONPATH.
+    """
+    env = os.environ.copy() if inherit else {}
+    env["PYTHONPATH"] = os.environ.get("PYTHONPATH") or os.pathsep.join(sys.path)
+    return env
+
+
+def run_python_module(
+    module: str, *args: str | os.PathLike[str], inherit_env: bool = True, **kwargs: Any
+) -> subprocess.CompletedProcess[Any]:
+    """Run ``sys.executable -m <module> <args>`` with PYTHONPATH propagated.
+
+    Thin wrapper around :func:`subprocess.run`.  All *kwargs* are forwarded
+    directly (``cwd``, ``timeout``, ``capture_output``, …).
+
+    Args:
+        module: Python module to run (e.g. ``"pre_commit"``, ``"ruff"``).
+        *args: Command-line arguments passed after the module name.
+               Accepts :class:`str` and :class:`os.PathLike`.
+        inherit_env: If True, start from ``os.environ``. If False, minimal env
+                     with only ``PYTHONPATH``.
+    """
+    cmd: list[str | os.PathLike[str]] = [sys.executable, "-m", module, *args]
+    return subprocess.run(cmd, env=python_env(inherit=inherit_env), **kwargs)  # noqa: PLW1510  check forwarded via kwargs
+
+
+async def async_run_python_module(
+    module: str, *args: str | os.PathLike[str], inherit_env: bool = True, **kwargs: Any
+) -> asyncio.subprocess.Process:
+    """Async variant of :func:`run_python_module`.
+
+    Returns an :class:`asyncio.subprocess.Process` (not awaited to completion).
+    Caller is responsible for awaiting ``process.wait()`` or
+    ``process.communicate()``.
+
+    All *kwargs* are forwarded to :func:`asyncio.create_subprocess_exec`.
+    """
+    cmd: list[str] = [sys.executable, "-m", module, *(str(a) for a in args)]
+    return await asyncio.create_subprocess_exec(*cmd, env=python_env(inherit=inherit_env), **kwargs)
+
+
+def generate_shell_wrapper(module: str, *, extra_lines: str = "") -> str:
+    """Generate a ``#!/bin/sh`` script that invokes ``sys.executable -m <module>``.
+
+    The wrapper bakes the current PYTHONPATH into the script so the subprocess
+    can find packages without leaking PYTHONPATH into every child process via
+    a shared env file.
+
+    Args:
+        module: Python module path (e.g. ``"tools.claude_hooks.bazel_wrapper"``).
+        extra_lines: Additional shell lines inserted before the ``exec``.
+    """
+    pythonpath = os.environ.get("PYTHONPATH") or os.pathsep.join(sys.path)
+    parts = ["#!/bin/sh", f'export PYTHONPATH="{pythonpath}"']
+    if extra_lines:
+        parts.append(extra_lines)
+    parts.append(f'exec "{sys.executable}" -m {module} "$@"')
+    return "\n".join(parts) + "\n"
+
+
+def write_shell_wrapper(path: Path, module: str, *, extra_lines: str = "") -> Path:
+    """Write a shell wrapper script and make it executable.
+
+    See :func:`generate_shell_wrapper` for argument docs.
+    Returns *path* for chaining.
+    """
+    content = generate_shell_wrapper(module, extra_lines=extra_lines)
+    path.write_text(content)
+    path.chmod(0o755)
+    return path

--- a/claude/claude_hooks/BUILD.bazel
+++ b/claude/claude_hooks/BUILD.bazel
@@ -71,7 +71,9 @@ py_library(
         ":inputs",
         ":logging_context",
         ":tool_models",
+        "//:bazel_subprocess",
         "@pypi//platformdirs",
+        "@pypi//pre_commit",
         "@pypi//pygit2",
     ],
 )
@@ -176,6 +178,8 @@ py_test(
         ":actions",
         ":conftest",
         ":precommit_autofix",
+        "//:bazel_subprocess",
+        "@pypi//pre_commit",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/claude/claude_hooks/precommit_autofix.py
+++ b/claude/claude_hooks/precommit_autofix.py
@@ -1,7 +1,6 @@
 """Pre-commit autofix hook implementation."""
 
 import ast
-import subprocess
 import textwrap
 import traceback
 from dataclasses import dataclass
@@ -10,6 +9,7 @@ from pathlib import Path
 import pygit2
 from platformdirs import user_state_dir
 
+from bazel_subprocess import run_python_module
 from claude_hooks.actions import PostToolAction, PostToolContinue, PostToolFeedbackToClaude
 from claude_hooks.base import PostToolUseHook
 from claude_hooks.config import AutofixerConfig
@@ -218,16 +218,20 @@ class PreCommitAutoFixerHook(PostToolUseHook):
             config_root = self._get_precommit_root(file_path)
 
             config_file = config_root / PRECOMMIT_CONFIG_FILE
-            cmd = ["pre-commit", "run", "--config", str(config_file), "--files", str(file_path)]
-            self.logger.info(f"Running command: {cmd}")
+            self.logger.info(f"Running pre-commit on {file_path} with config {config_file}")
 
-            result = subprocess.run(
-                cmd,
+            result = run_python_module(
+                "pre_commit",
+                "run",
+                "--config",
+                str(config_file),
+                "--files",
+                str(file_path),
                 cwd=config_root,
                 capture_output=True,
                 text=True,
                 timeout=self.autofixer_config.timeout_seconds,
-                check=False,  # Don't raise on non-zero exit
+                check=False,
             )
 
             # Log subprocess result for debugging

--- a/claude/claude_hooks/test_integration.py
+++ b/claude/claude_hooks/test_integration.py
@@ -1,11 +1,11 @@
 """Integration tests for hooks in isolated Claude Code environments."""
 
 import json
-import subprocess
 
 import pytest
 import pytest_bazel
 
+from bazel_subprocess import run_python_module
 from claude_hooks.actions import PostToolContinue, PostToolFeedbackToClaude
 from claude_hooks.precommit_autofix import PreCommitAutoFixerHook
 
@@ -116,7 +116,7 @@ def test_precommit_actually_works(integration_env, monkeypatch):
     monkeypatch.chdir(integration_env.project_dir)
 
     # Run pre-commit directly on the file
-    subprocess.run(["pre-commit", "run", "--files", "test.py"], cwd=integration_env.project_dir, check=False)
+    run_python_module("pre_commit", "run", "--files", "test.py", cwd=integration_env.project_dir, check=False)
 
     final_content = integration_env.read_file("test.py")
     compile(final_content, "test.py", "exec")

--- a/llm/claude_linter/BUILD.bazel
+++ b/llm/claude_linter/BUILD.bazel
@@ -46,7 +46,9 @@ py_library(
     srcs = ["precommit_runner.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//:bazel_subprocess",
         "@pypi//platformdirs",
+        "@pypi//pre_commit",
         "@pypi//pyyaml",
     ],
 )

--- a/llm/claude_linter/precommit_runner.py
+++ b/llm/claude_linter/precommit_runner.py
@@ -9,6 +9,8 @@ from typing import Any
 import platformdirs
 import yaml
 
+from bazel_subprocess import run_python_module
+
 
 class PreCommitRunner:
     """Runner for pre-commit hooks based on provided config.
@@ -114,23 +116,23 @@ class PreCommitRunner:
             # Stage files
             subprocess.run(["git", "add", *temp_paths], cwd=tmpdir, capture_output=True, check=False)
 
-            # Build command
-            cmd = [
-                "pre-commit",
+            # Run pre-commit via python -m for Bazel sandbox compatibility
+            result = run_python_module(
+                "pre_commit",
                 "run",
                 "--all-files",  # Safe since we're in a temp dir with only our files
                 "--verbose",
-                # Use default stage (pre-commit)
-            ]
-
-            # Run as subprocess
-            result = subprocess.run(cmd, cwd=tmpdir, capture_output=True, text=True, check=False)
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
 
             # Append results to log if enabled
             if log_file:
                 with log_file.open("a") as f:
                     f.write("\n--- Pre-commit command ---\n")
-                    f.write(f"Command: {' '.join(cmd)}\n")
+                    f.write(f"Command: {result.args}\n")
                     f.write(f"Return code: {result.returncode}\n")
                     f.write(f"\n--- Stdout ---\n{result.stdout}\n")
                     f.write(f"\n--- Stderr ---\n{result.stderr}\n")

--- a/llm/claude_linter_v2/linters/BUILD.bazel
+++ b/llm/claude_linter_v2/linters/BUILD.bazel
@@ -18,5 +18,9 @@ py_library(
     name = "python_ruff",
     srcs = ["python_ruff.py"],
     visibility = ["//:__subpackages__"],
-    deps = ["//llm/claude_linter_v2/config:models"],
+    deps = [
+        "//:bazel_subprocess",
+        "//llm/claude_linter_v2/config:models",
+        "@pypi//ruff",
+    ],
 )

--- a/llm/claude_linter_v2/linters/python_ruff.py
+++ b/llm/claude_linter_v2/linters/python_ruff.py
@@ -3,10 +3,10 @@
 import json
 import logging
 import subprocess
-import sys
 from pathlib import Path
 from typing import ClassVar
 
+from bazel_subprocess import run_python_module
 from llm.claude_linter_v2.config.models import Violation
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,7 @@ class PythonRuffLinter:
     def _check_ruff_available(self) -> bool:
         """Check if ruff is available."""
         try:
-            result = subprocess.run(
-                [sys.executable, "-m", "ruff", "--version"], capture_output=True, text=True, timeout=5, check=False
-            )
+            result = run_python_module("ruff", "--version", capture_output=True, text=True, timeout=5, check=False)
             if result.returncode == 0:
                 logger.debug(f"Found ruff: {result.stdout.strip()}")
                 return True
@@ -76,21 +74,23 @@ class PythonRuffLinter:
 
         violations = []
 
-        # Build ruff command (use python -m ruff to work in Bazel sandbox)
-        cmd = [sys.executable, "-m", "ruff", "check", "--output-format", "json", "--stdin-filename", str(file_path)]
+        # Build ruff args
+        args: list[str] = ["check", "--output-format", "json", "--stdin-filename", str(file_path)]
 
         # Add force-select rules if provided
         if self.force_select:
-            cmd.extend(["--select", ",".join(self.force_select)])
+            args.extend(["--select", ",".join(self.force_select)])
         elif critical_only:
             # Only check critical rules in pre-hook
-            cmd.extend(["--select", ",".join(self.CRITICAL_RULES)])
+            args.extend(["--select", ",".join(self.CRITICAL_RULES)])
 
         # Add stdin marker
-        cmd.append("-")
+        args.append("-")
 
         try:
-            result = subprocess.run(cmd, input=code, capture_output=True, text=True, timeout=30, check=False)
+            result = run_python_module(
+                "ruff", *args, input=code, capture_output=True, text=True, timeout=30, check=False
+            )
 
             # Ruff returns 1 if violations found, 0 if clean
             if result.returncode in (0, 1):

--- a/mcp_infra/testing/BUILD.bazel
+++ b/mcp_infra/testing/BUILD.bazel
@@ -37,6 +37,7 @@ py_library(
     deps = [
         ":notifications",
         ":simple_servers",
+        "//:bazel_subprocess",
         "//mcp_infra:prefix",
         "//mcp_infra/compositor",
         "//mcp_infra/compositor:notifications_buffer",

--- a/mcp_infra/testing/fixtures.py
+++ b/mcp_infra/testing/fixtures.py
@@ -6,7 +6,6 @@ Register in downstream packages via:
 
 from __future__ import annotations
 
-import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -17,6 +16,7 @@ from fastmcp.client import Client
 from fastmcp.mcp_config import StdioMCPServer
 from fastmcp.server import FastMCP
 
+from bazel_subprocess import python_env
 from mcp_infra.compositor.compositor import Compositor
 from mcp_infra.compositor.notifications_buffer import NotificationsBuffer
 from mcp_infra.compositor.resources_server import ResourcesServer
@@ -27,14 +27,6 @@ from mcp_infra.stubs.resources_stub import ResourcesServerStub
 from mcp_infra.stubs.typed_stubs import TypedClient
 from mcp_infra.testing.notifications import SubscriptionRecorder, enable_resources_caps, install_subscription_recorder
 from mcp_infra.testing.simple_servers import make_simple_mcp as _make_simple_mcp  # avoid fixture collision
-
-
-def _stdio_env() -> dict[str, str]:
-    """Environment for stdio subprocess with Python path forwarded."""
-    env: dict[str, str] = {}
-    if "PYTHONPATH" in os.environ:
-        env["PYTHONPATH"] = os.environ["PYTHONPATH"]
-    return env
 
 
 def make_container_opts(image: str, *, working_dir: Path = Path("/workspace")) -> ContainerOptions:
@@ -116,13 +108,17 @@ async def typed_resources_client(resources_server, resources_client):
 @pytest.fixture
 def stdio_echo_spec() -> StdioMCPServer:
     """Launch packaged echo server module via -m as a stdio spec."""
-    return StdioMCPServer(command=sys.executable, args=["-m", "mcp_infra.testing.stdio_app"], env=_stdio_env())
+    return StdioMCPServer(
+        command=sys.executable, args=["-m", "mcp_infra.testing.stdio_app"], env=python_env(inherit=False)
+    )
 
 
 @pytest.fixture
 def stdio_notifier_spec() -> StdioMCPServer:
     """Launch notification-emitting server via -m as stdio spec."""
-    return StdioMCPServer(command=sys.executable, args=["-m", "mcp_infra.testing.stdio_notifier"], env=_stdio_env())
+    return StdioMCPServer(
+        command=sys.executable, args=["-m", "mcp_infra.testing.stdio_notifier"], env=python_env(inherit=False)
+    )
 
 
 @pytest.fixture

--- a/test_bazel_subprocess.py
+++ b/test_bazel_subprocess.py
@@ -1,0 +1,83 @@
+"""Tests for bazel_subprocess module."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest_bazel
+
+from bazel_subprocess import generate_shell_wrapper, python_env, run_python_module, write_shell_wrapper
+
+
+def test_python_env_inherit_includes_pythonpath():
+    env = python_env(inherit=True)
+    assert "PYTHONPATH" in env
+    # Should also contain other env vars
+    assert "PATH" in env
+
+
+def test_python_env_no_inherit_minimal():
+    env = python_env(inherit=False)
+    assert "PYTHONPATH" in env
+    assert "PATH" not in env
+
+
+def test_python_env_uses_existing_pythonpath():
+    with patch.dict(os.environ, {"PYTHONPATH": "/custom/path"}):
+        env = python_env(inherit=False)
+        assert env["PYTHONPATH"] == "/custom/path"
+
+
+def test_python_env_falls_back_to_sys_path():
+    with patch.dict(os.environ, {}, clear=True):
+        env = python_env(inherit=False)
+        assert env["PYTHONPATH"] == os.pathsep.join(sys.path)
+
+
+def test_run_python_module_basic():
+    result = run_python_module("sys", capture_output=True, text=True, check=False)
+    # python -m sys doesn't exist as runnable, but the command should execute
+    # without FileNotFoundError (sys.executable is found)
+    assert isinstance(result.returncode, int)
+
+
+def test_run_python_module_version():
+    result = run_python_module("platform", capture_output=True, text=True, check=False)
+    # python -m platform prints platform info
+    assert result.returncode == 0
+    assert result.stdout.strip()  # Should have output
+
+
+def test_run_python_module_with_pathlike_args(tmp_path: Path):
+    """Args accept PathLike objects."""
+    result = run_python_module("json.tool", tmp_path / "nonexistent.json", capture_output=True, text=True, check=False)
+    # Will fail because file doesn't exist, but shouldn't raise TypeError
+    assert result.returncode != 0
+
+
+def test_generate_shell_wrapper():
+    wrapper = generate_shell_wrapper("my.module")
+    assert wrapper.startswith("#!/bin/sh\n")
+    assert 'export PYTHONPATH="' in wrapper
+    assert f'exec "{sys.executable}" -m my.module "$@"' in wrapper
+
+
+def test_generate_shell_wrapper_extra_lines():
+    wrapper = generate_shell_wrapper("my.module", extra_lines='export FOO="bar"')
+    assert 'export FOO="bar"' in wrapper
+
+
+def test_write_shell_wrapper(tmp_path: Path):
+    path = tmp_path / "wrapper.sh"
+    result = write_shell_wrapper(path, "my.module")
+    assert result == path
+    assert path.exists()
+    assert path.stat().st_mode & 0o755
+    content = path.read_text()
+    assert content.startswith("#!/bin/sh\n")
+    assert "my.module" in content
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -84,6 +84,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":settings",
+        "//:bazel_subprocess",
     ],
 )
 
@@ -108,6 +109,7 @@ py_library(
         ":errors",
         ":proxy_vars",
         ":settings",
+        "//:bazel_subprocess",
         "//net_util:net",
         "//tools/claude_hooks/supervisor:client",
         "@pypi//cryptography",
@@ -166,11 +168,13 @@ py_library(
         ":proxy_credentials",
         ":proxy_setup",
         ":settings",
+        "//:bazel_subprocess",
         "//fmt_util",
         "//tools:build_info",
         "//tools:env_utils",
         "//tools/claude_hooks/supervisor:setup",
         "@pypi//mako",
+        "@pypi//pre_commit",
         "@pypi//pydantic",
     ],
 )

--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -10,16 +10,15 @@ TODO: Eventually unify tool installation via direnv/devenv instead of
 from __future__ import annotations
 
 import logging
-import os
 import platform
 import shutil
 import stat
 import subprocess
-import sys
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
+from bazel_subprocess import write_shell_wrapper
 from tools.claude_hooks.settings import HookSettings
 
 logger = logging.getLogger(__name__)
@@ -136,21 +135,8 @@ def install_wrapper(settings: HookSettings) -> Path:
 
     wrapper_dir.mkdir(parents=True, exist_ok=True)
 
-    # Use sys.executable -m for both Bazel and wheel mode.
-    # Bake PYTHONPATH into the script so the wrapper can find dependencies (e.g. PyJWT)
-    # without leaking it into every agent subprocess via the env file.
-    # In wheel mode PYTHONPATH is unset, so no export line is emitted.
-    # rules_python's venv-based bootstrap (1.8.3+) sets up sys.path via a virtual
-    # environment that doesn't set PYTHONPATH, so fall back to sys.path.
-    pythonpath = os.environ.get("PYTHONPATH") or os.pathsep.join(sys.path)
-    pythonpath_line = f'\nexport PYTHONPATH="{pythonpath}"'
-    wrapper_script = f"""#!/bin/sh{pythonpath_line}
-exec "{sys.executable}" -m tools.claude_hooks.bazel_wrapper "$@"
-"""
-    logger.info("Installed bazel wrapper at %s (using %s)", wrapper_path, sys.executable)
-
-    wrapper_path.write_text(wrapper_script)
-    wrapper_path.chmod(0o755)
+    write_shell_wrapper(wrapper_path, "tools.claude_hooks.bazel_wrapper")
+    logger.info("Installed bazel wrapper at %s", wrapper_path)
 
     # Create bazelisk symlink for pre-commit hooks
     bazelisk_symlink = wrapper_dir / "bazelisk"

--- a/tools/claude_hooks/proxy_setup.py
+++ b/tools/claude_hooks/proxy_setup.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from cryptography import x509
 from mako.template import Template
 
+from bazel_subprocess import python_env
 from net_util.net import async_wait_for_port, is_port_in_use
 from tools.claude_hooks.errors import CaBundleError, CaExtractionError, ProxyServiceError, TruststoreError
 from tools.claude_hooks.proxy_vars import get_upstream_proxy_url
@@ -202,24 +203,11 @@ async def _create_java_truststore(settings: HookSettings) -> None:
         raise TruststoreError(f"Failed to create truststore: {e}") from e
 
 
-def _get_proxy_service_env() -> dict[str, str]:
-    """Get environment variables to pass to the proxy service.
-
-    Propagates sys.path as PYTHONPATH so the supervisor-managed subprocess can
-    find third-party packages. rules_python's venv-based bootstrap sets up
-    sys.path via a virtual environment that doesn't carry over to subprocesses.
-    """
-    env: dict[str, str] = {}
-    pythonpath = os.environ.get("PYTHONPATH") or os.pathsep.join(sys.path)
-    env["PYTHONPATH"] = pythonpath
-    return env
-
-
 def _build_auth_proxy_command(settings: HookSettings) -> str:
     """Build command to run auth proxy.
 
     Uses sys.executable -m to run the module. This works in both:
-    - Bazel mode: PYTHONPATH is set and forwarded via _get_proxy_service_env()
+    - Bazel mode: PYTHONPATH is set and forwarded via python_env()
     - Wheel mode: the package is installed, so the module is importable
     """
     proxy_port = settings.get_auth_proxy_port()
@@ -291,13 +279,13 @@ async def ensure_proxy_running(settings: HookSettings, supervisor: SupervisorCli
     if await supervisor.service_exists(AUTH_PROXY_SERVICE):
         logger.info("Restarting proxy service on port %d", proxy_port)
         await supervisor.update_service(
-            name=AUTH_PROXY_SERVICE, command=command, directory=proxy_dir, environment=_get_proxy_service_env()
+            name=AUTH_PROXY_SERVICE, command=command, directory=proxy_dir, environment=python_env(inherit=False)
         )
     else:
         # Start proxy service for the first time
         logger.info("Starting auth proxy on port %d via supervisor", proxy_port)
         await supervisor.add_service(
-            name=AUTH_PROXY_SERVICE, command=command, directory=proxy_dir, environment=_get_proxy_service_env()
+            name=AUTH_PROXY_SERVICE, command=command, directory=proxy_dir, environment=python_env(inherit=False)
         )
 
     await _wait_for_proxy_running(settings, supervisor)

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -24,6 +24,7 @@ from typing import Literal
 from mako.template import Template
 from pydantic import BaseModel
 
+from bazel_subprocess import run_python_module
 from fmt_util.fmt_util import format_limited_list
 from tools import env_utils
 from tools.build_info import BUILD_COMMIT
@@ -252,7 +253,7 @@ def install_git_precommit_hook(project_dir: Path) -> None:
     # Ensure pre-commit is installed.
     # Ansible is installed by pre-commit itself (language: python + additional_dependencies).
     try:
-        subprocess.run(["pre-commit", "--version"], capture_output=True, check=True, timeout=5)
+        run_python_module("pre_commit", "--version", capture_output=True, check=True, timeout=5)
         logger.info("pre-commit already available")
     except (FileNotFoundError, subprocess.CalledProcessError):
         logger.info("Installing pre-commit==4.0.1 via pip")
@@ -274,8 +275,8 @@ def install_git_precommit_hook(project_dir: Path) -> None:
 
     # Install the git hook
     try:
-        result = subprocess.run(
-            ["pre-commit", "install"], check=False, cwd=project_dir, capture_output=True, text=True, timeout=30
+        result = run_python_module(
+            "pre_commit", "install", check=False, cwd=project_dir, capture_output=True, text=True, timeout=30
         )
         if result.returncode == 0:
             logger.info("Installed git pre-commit hook via pre-commit install")

--- a/tools/claude_hooks/supervisor/BUILD.bazel
+++ b/tools/claude_hooks/supervisor/BUILD.bazel
@@ -22,6 +22,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":client",
+        "//:bazel_subprocess",
         "//net_util:net",
         "//tools/claude_hooks:errors",
         "//tools/claude_hooks:settings",

--- a/tools/claude_hooks/supervisor/setup.py
+++ b/tools/claude_hooks/supervisor/setup.py
@@ -12,9 +12,9 @@ import asyncio
 import configparser
 import logging
 import os
-import sys
 from dataclasses import dataclass
 
+from bazel_subprocess import async_run_python_module
 from net_util.net import is_port_in_use
 from tools.claude_hooks.errors import SupervisorError
 from tools.claude_hooks.settings import HookSettings
@@ -161,31 +161,24 @@ async def start(settings: HookSettings) -> SupervisorSetup:
     supervisor_port = settings.get_supervisor_port()
 
     # Log what we're about to execute
-    cmd = [sys.executable, "-m", "supervisor.supervisord", "-c", str(supervisor_conf)]
-    logger.info("Starting supervisor with command: %s", " ".join(cmd))
+    logger.info("Starting supervisor.supervisord -c %s", supervisor_conf)
     logger.info("  config: %s", supervisor_conf)
     logger.info("  log: %s", supervisor_log)
     logger.info("  port: %d", supervisor_port)
     logger.info("  dir: %s", supervisor_dir)
 
-    # Propagate sys.path as PYTHONPATH so the subprocess can find third-party
-    # packages (e.g. supervisor). rules_python's venv-based bootstrap sets up
-    # sys.path via a virtual environment, but that doesn't carry over to
-    # subprocesses spawned via sys.executable.
-    env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(sys.path)
-
     try:
         stderr_path = supervisor_dir / "supervisord_stderr.log"
         stderr_file = stderr_path.open("w")
-        process = await asyncio.create_subprocess_exec(
-            *cmd,
+        process = await async_run_python_module(
+            "supervisor.supervisord",
+            "-c",
+            str(supervisor_conf),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=stderr_file,
             stdin=asyncio.subprocess.DEVNULL,
             start_new_session=True,
             cwd=supervisor_dir,
-            env=env,
         )
         # Give it a tiny bit to check if it crashes immediately
         await asyncio.sleep(0.1)
@@ -197,7 +190,7 @@ async def start(settings: HookSettings) -> SupervisorSetup:
             stderr_content = stderr_path.read_text().strip() if stderr_path.exists() else ""
             error_parts = [
                 f"supervisord exited immediately with code {process.returncode}",
-                f"Command: {' '.join(cmd)}",
+                f"Module: supervisor.supervisord -c {supervisor_conf}",
                 f"Log: {log_content[-1000:]}",
             ]
             if stderr_content:


### PR DESCRIPTION
## Summary
Introduces a new `bazel_subprocess` module that provides subprocess wrappers for executing Python modules under Bazel's rules_python. This solves the issue where rules_python's venv-based bootstrap sets up `sys.path` via a virtual environment that doesn't carry over to subprocesses spawned via `sys.executable`.

## Key Changes

- **New `bazel_subprocess` module** (`bazel_subprocess.py`):
  - `python_env()`: Returns environment dict with PYTHONPATH propagated for Bazel subprocesses
  - `run_python_module()`: Wrapper around `subprocess.run` for executing Python modules with PYTHONPATH
  - `async_run_python_module()`: Async variant using `asyncio.create_subprocess_exec`
  - `generate_shell_wrapper()` / `write_shell_wrapper()`: Generate shell scripts that invoke Python modules with baked-in PYTHONPATH

- **Comprehensive test coverage** (`test_bazel_subprocess.py`):
  - Tests for environment variable handling, inheritance modes, and shell wrapper generation
  - Validates that PathLike arguments are properly handled

- **Refactored subprocess calls across codebase** to use the new module:
  - `claude/claude_hooks/precommit_autofix.py`: Replaced direct `subprocess.run` calls for pre-commit
  - `claude/claude_hooks/test_integration.py`: Updated integration tests
  - `llm/claude_linter/precommit_runner.py`: Migrated pre-commit execution
  - `llm/claude_linter_v2/linters/python_ruff.py`: Updated ruff invocation
  - `mcp_infra/testing/fixtures.py`: Replaced custom `_stdio_env()` with `python_env()`
  - `tools/claude_hooks/bazelisk_setup.py`: Simplified wrapper script generation
  - `tools/claude_hooks/proxy_setup.py`: Replaced custom env handling with `python_env()`
  - `tools/claude_hooks/session_start.py`: Updated pre-commit calls
  - `tools/claude_hooks/supervisor/setup.py`: Migrated to `async_run_python_module()`

- **Updated BUILD.bazel files** to add dependencies on the new module and required packages (`pre_commit`, `ruff`)

## Implementation Details

The module handles the core issue where PYTHONPATH set by rules_python's venv bootstrap doesn't propagate to child processes. By explicitly passing PYTHONPATH through the environment dict, subprocesses can locate packages installed in the virtual environment. The implementation provides both synchronous and asynchronous variants, plus utilities for generating shell wrappers that bake PYTHONPATH into scripts for use in pre-commit hooks and other contexts.

https://claude.ai/code/session_01Grv2Sz6jrgbBZQ6asF2XkZ