### PR TITLE
Fix wheel: include bazel_subprocess in claude_hooks package

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -203,6 +203,7 @@ py_binary(
 py_package(
     name = "claude_hooks_pkg",
     packages = [
+        "bazel_subprocess",
         "fmt_util",
         "net_util",
         "tools",
@@ -223,6 +224,7 @@ py_package(
         ":session_start_lib",
         ":settings",
         ":streaming",
+        "//:bazel_subprocess",
         "//net_util:net",
         "//tools/claude_hooks/auth_proxy:main",
         "//tools/claude_hooks/auth_proxy:proxy",


### PR DESCRIPTION
The Wheel Mode Test CI job failed because bazel_subprocess was not
included in the py_package for the claude-hooks wheel. session_start.py
imports from bazel_subprocess, so it must be bundled.

https://claude.ai/code/session_01N5rtCMopXr9F4rK5hwWMsU