### PR TITLE
Add dbus-daemon to RBE image for D-Bus session tests

### DIFF
--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -16,6 +16,9 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
     && apt-get install -y --no-install-recommends \
         libssl-dev \
         pkg-config \
+        # dbus-daemon: needed by tests that spawn a private D-Bus session
+        # (e.g. experimental/dbus_fast_example)
+        dbus-daemon \
         # Chromium headless shell shared library dependencies
         libasound2t64 \
         libatk-bridge2.0-0t64 \


### PR DESCRIPTION
## Summary
Added `dbus-daemon` package to the RBE (Remote Build Execution) Docker image to support tests that require a private D-Bus session.

## Changes
- Added `dbus-daemon` system package to the apt-get install command in the Dockerfile
- Included explanatory comments indicating this dependency is needed for tests that spawn private D-Bus sessions (e.g., experimental/dbus_fast_example)

## Details
The `dbus-daemon` package is required by certain test suites that need to establish their own D-Bus session bus for testing D-Bus functionality. This ensures the RBE image has all necessary dependencies to run these tests in the remote build environment.

https://claude.ai/code/session_012UcVZvbh2Ad5oF86aikE69