### PR TITLE
Refactor build configuration and improve test setup

### DIFF
--- a/mcp_starter/BUILD.bazel
+++ b/mcp_starter/BUILD.bazel
@@ -15,13 +15,20 @@ py_library(
     ],
 )
 
-py_binary(
-    name = "mcp_starter_bin",
+py_library(
+    name = "__main__",
     srcs = ["__main__.py"],
     imports = [".."],
-    main = "__main__.py",
     visibility = ["//:__subpackages__"],
     deps = [":server"],
+)
+
+py_binary(
+    name = "mcp_starter_bin",
+    imports = [".."],
+    main_module = "mcp_starter.__main__",
+    visibility = ["//:__subpackages__"],
+    deps = [":__main__"],
 )
 
 py_library(
@@ -30,7 +37,9 @@ py_library(
     srcs = ["conftest.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//:bazel_subprocess",
         "@pypi//fastmcp",
+        "@pypi//pytest",
         "@pypi//pytest_asyncio",
     ],
 )
@@ -39,6 +48,7 @@ py_test(
     name = "test_server",
     srcs = ["test_server.py"],
     deps = [
+        ":__main__",
         ":conftest",
         ":server",
         "@pypi//fastmcp",
@@ -53,6 +63,7 @@ py_test(
     # Requires running MCP server
     tags = ["manual"],
     deps = [
+        ":__main__",
         ":conftest",
         "@pypi//fastmcp",
         "@pypi//mcp",

--- a/mcp_starter/conftest.py
+++ b/mcp_starter/conftest.py
@@ -1,8 +1,17 @@
+import sys
 from collections.abc import AsyncIterator
 
+import pytest
 import pytest_asyncio
 from fastmcp import Client
 from fastmcp.mcp_config import MCPConfig, StdioMCPServer
+
+from bazel_subprocess import python_env
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure pytest-asyncio auto mode."""
+    config.option.asyncio_mode = "auto"
 
 
 @pytest_asyncio.fixture
@@ -12,6 +21,12 @@ async def mcp_client() -> AsyncIterator[Client]:
     Yields a connected Client so tests can call methods without context managers.
     """
     async with Client(
-        MCPConfig(mcpServers={"starter": StdioMCPServer(command="python", args=["-m", "mcp_starter", "--debug"])})
+        MCPConfig(
+            mcpServers={
+                "starter": StdioMCPServer(
+                    command=sys.executable, args=["-m", "mcp_starter", "--debug"], env=python_env(inherit=False)
+                )
+            }
+        )
     ) as client:
         yield client


### PR DESCRIPTION
## Summary
This PR refactors the Bazel build configuration to separate the `__main__` module from the binary target, and improves the test infrastructure by configuring pytest-asyncio and using proper Python environment handling.

## Key Changes

- **Build Configuration Refactoring**
  - Converted `__main__.py` from a `py_binary` target to a `py_library` target
  - Created a new `py_binary` target that depends on the `__main__` library and uses `main_module` attribute
  - This separation allows the `__main__` module to be reused as a dependency in tests

- **Test Infrastructure Improvements**
  - Added `pytest_configure` hook to enable pytest-asyncio auto mode
  - Updated `conftest.py` to import and use `bazel_subprocess.python_env()` for proper Python environment handling
  - Changed MCP server command from hardcoded `"python"` to `sys.executable` for better cross-platform compatibility
  - Added missing dependencies to `conftest` target: `bazel_subprocess`, `pytest`

- **Test Dependencies**
  - Updated `test_server` and `test_integration` targets to depend on the new `__main__` library
  - Ensured all test fixtures have access to the main module

## Implementation Details
The refactoring follows Bazel best practices by separating executable binaries from library code, making the `__main__` module testable and reusable. The pytest-asyncio configuration ensures consistent async test behavior across the test suite.

https://claude.ai/code/session_018MwJMZ8YGjRsRY4pFQkFx1