### PR TITLE
Configure Docker daemon for Firecracker compatibility

### DIFF
--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -42,3 +42,13 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
         http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
     && dpkg -i /tmp/libtinfo5.deb \
     && rm /tmp/libtinfo5.deb
+
+# Docker 28+ adds "direct access filtering" DROP rules to the iptables raw
+# table, but Firecracker's guest kernel lacks CONFIG_IP_NF_RAW. Setting
+# allow-direct-routing tells dockerd to skip these raw table rules entirely.
+# Containers still get isolated bridge networking; the only difference is that
+# direct-IP access to container ports is not blocked (acceptable since
+# Firecracker VMs are single-tenant and ephemeral).
+# TODO: Ideally, build a custom Firecracker kernel with CONFIG_IP_NF_RAW=y
+# to get full Docker networking security. This is a workaround.
+COPY daemon.json /etc/docker/daemon.json

--- a/tools/rbe_image/daemon.json
+++ b/tools/rbe_image/daemon.json
@@ -1,0 +1,3 @@
+{
+  "allow-direct-routing": true
+}


### PR DESCRIPTION
## Summary
This change configures the Docker daemon to work properly with Firecracker VMs by enabling the `allow-direct-routing` option, which bypasses Docker 28+ iptables raw table rules that are incompatible with Firecracker's guest kernel.

## Changes
- Added `daemon.json` configuration file with `allow-direct-routing: true` setting
- Updated Dockerfile to copy the daemon configuration into the RBE image at `/etc/docker/daemon.json`
- Added explanatory comments documenting the rationale for this workaround

## Details
Docker 28 and later versions add "direct access filtering" DROP rules to the iptables raw table for enhanced networking security. However, Firecracker's guest kernel lacks `CONFIG_IP_NF_RAW` support, causing these rules to fail.

The `allow-direct-routing` option tells dockerd to skip raw table rules entirely. While this means direct-IP access to container ports is not blocked, this is acceptable for Firecracker VMs since they are single-tenant and ephemeral.

A long-term solution would be to build a custom Firecracker kernel with `CONFIG_IP_NF_RAW=y` enabled, but this workaround allows the RBE image to function with current Docker versions.

https://claude.ai/code/session_01B7xqYG49MC3kkbzW5kdngJ