### PR TITLE
Fix RBE image CI build: set context to tools/rbe_image

### DIFF
--- a/.github/workflows/rbe-image.yml
+++ b/.github/workflows/rbe-image.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: tools/rbe_image/Dockerfile
+          context: tools/rbe_image
           push: true
           tags: |
             ${{ env.IMAGE }}:latest


### PR DESCRIPTION
The COPY daemon.json instruction needs the build context to be the directory containing the Dockerfile. Previously context was repo root, so Docker couldn't find daemon.json.

https://claude.ai/code/session_01T1n1WphbWQgHhBYAMQbF8g