### PR TITLE
Remove Bazel profiling feature from CI workflows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,12 +53,6 @@ build:eslint --output_groups=+rules_lint_report
 # Formatting: use bazel run //tools/format (fix) or //tools/format.check (check)
 # Supports: prettier (JS/TS/CSS/HTML/MD), ruff (Python), shfmt (Shell), buildifier (Bazel), rustfmt (Rust)
 
-# CI profiling - captures performance data for every build
-# Run with: bazel build --config=ci-profile //...
-# Produces: bazel-profile.gz (Chrome tracing format), execution-log.json (action-level timing)
-build:ci-profile --profile=bazel-profile.gz
-build:ci-profile --execution_log_json_file=execution-log.json
-
 # Stamping - embeds build metadata (commit hash, etc.) into build artifacts
 # Only targets that depend on ctx.info_file (like build_info_gen) are invalidated on commit change
 build --stamp --workspace_status_command=tools/stamp.sh

--- a/.github/workflows/bazel-lint.yml
+++ b/.github/workflows/bazel-lint.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: string
         default: "//..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
       rbe_image:
         description: "Override RBE container image (optional)"
         required: false
@@ -34,11 +29,6 @@ on:
         required: false
         type: string
         default: "//..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   lint:
@@ -88,24 +78,9 @@ jobs:
             TARGET_ARG="${{ inputs.targets }}"
             echo "Using targets from input: $TARGET_ARG"
           fi
-          PROFILE_FLAG=""
-          if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
-            PROFILE_FLAG="--config=ci-profile"
-          fi
           bazel build --keep_going --config=lint \
             --build_metadata=ROLE=ci --build_metadata=TAGS=lint \
-            $PROFILE_FLAG $TARGET_ARG
-
-      - name: Upload Bazel profile
-        if: inputs.enable_profiling && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-profile-lint-${{ github.run_id }}
-          path: |
-            bazel-profile.gz
-            execution-log.json
-          retention-days: 14
-          if-no-files-found: warn
+            $TARGET_ARG
 
       - uses: ./.github/actions/bazel-cache-save
         if: always()

--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: "//finance/..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
       rbe_image:
         description: "Override RBE container image (optional)"
         required: false
@@ -33,11 +28,6 @@ on:
         required: false
         type: string
         default: "//finance/..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   rust-lint:
@@ -68,24 +58,9 @@ jobs:
 
       - name: Rust lint
         run: |
-          PROFILE_FLAG=""
-          if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
-            PROFILE_FLAG="--config=ci-profile"
-          fi
           bazel build --keep_going --config=rust-check \
             --build_metadata=ROLE=ci --build_metadata=TAGS=rust-lint \
-            $PROFILE_FLAG ${{ inputs.targets }}
-
-      - name: Upload Bazel profile
-        if: inputs.enable_profiling && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-profile-rust-lint-${{ github.run_id }}
-          path: |
-            bazel-profile.gz
-            execution-log.json
-          retention-days: 14
-          if-no-files-found: warn
+            ${{ inputs.targets }}
 
       - uses: ./.github/actions/bazel-cache-save
         if: always()

--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: "//... - //tools/claude_hooks/..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
       rbe_image:
         description: "Override RBE container image (optional)"
         required: false
@@ -33,12 +28,6 @@ on:
         required: false
         type: string
         default: "//... - //tools/claude_hooks/..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
-
 jobs:
   test:
     name: Test
@@ -117,10 +106,6 @@ jobs:
             echo "Using targets from input: $TARGET_ARG"
           fi
 
-          PROFILE_FLAG=""
-          if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
-            PROFILE_FLAG="--config=ci-profile"
-          fi
           bazel test --keep_going \
             --build_metadata=ROLE=ci --build_metadata=TAGS=test \
             --test_tag_filters=-visual,-e2e,-live_openai_api \
@@ -129,24 +114,12 @@ jobs:
             --test_env=PGUSER=postgres --test_env=PGPASSWORD=postgres \
             --test_env=PGDATABASE=postgres \
             --test_env=PROPS_E2E_HOST_HOSTNAME=host.docker.internal \
-            $PROFILE_FLAG \
             $TARGET_ARG
 
       - uses: ./.github/actions/collect-test-logs
         if: always()
         with:
           artifact-name: test-logs
-
-      - name: Upload Bazel profile
-        if: inputs.enable_profiling && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-profile-test-${{ github.run_id }}
-          path: |
-            bazel-profile.gz
-            execution-log.json
-          retention-days: 14
-          if-no-files-found: warn
 
       # Skip when all tests were remote-cached (no local XML outputs).
       - name: Test Report

--- a/.github/workflows/bazel-typecheck.yml
+++ b/.github/workflows/bazel-typecheck.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: "//..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
       rbe_image:
         description: "Override RBE container image (optional)"
         required: false
@@ -33,11 +28,6 @@ on:
         required: false
         type: string
         default: "//..."
-      enable_profiling:
-        description: "Enable Bazel profiling (generates downloadable artifacts)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   typecheck:
@@ -87,27 +77,12 @@ jobs:
             TARGET_ARG="${{ inputs.targets }}"
             echo "Using targets from input: $TARGET_ARG"
           fi
-          PROFILE_FLAG=""
-          if [[ "${{ inputs.enable_profiling }}" == "true" ]]; then
-            PROFILE_FLAG="--config=ci-profile"
-          fi
           # Use local strategy for mypy to avoid sandbox copying (saves ~50% disk)
           # mypy_runner.py copies upstream caches via shutil.copy(), not symlinks
           # With sandbox, this happens twice: once by Bazel, once by mypy_runner
           bazel build --keep_going --config=typecheck --strategy=mypy=local \
             --build_metadata=ROLE=ci --build_metadata=TAGS=typecheck \
-            $PROFILE_FLAG $TARGET_ARG
-
-      - name: Upload Bazel profile
-        if: inputs.enable_profiling && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bazel-profile-typecheck-${{ github.run_id }}
-          path: |
-            bazel-profile.gz
-            execution-log.json
-          retention-days: 14
-          if-no-files-found: warn
+            $TARGET_ARG
 
       - uses: ./.github/actions/bazel-cache-save
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,7 @@ name: CI
     - master
     - devel
   pull_request: null
-  workflow_dispatch:
-    inputs:
-      enable_profiling:
-        description: Enable Bazel profiling (generates downloadable artifacts)
-        required: false
-        type: boolean
-        default: false
+  workflow_dispatch: null
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -114,7 +108,6 @@ jobs:
     uses: ./.github/workflows/bazel-lint.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
-      enable_profiling: ${{ inputs.enable_profiling || false }}
       rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-typecheck:
@@ -125,7 +118,6 @@ jobs:
     uses: ./.github/workflows/bazel-typecheck.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
-      enable_profiling: ${{ inputs.enable_profiling || false }}
       rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-rust-lint:
@@ -135,7 +127,6 @@ jobs:
     if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-rust-lint')
     uses: ./.github/workflows/bazel-rust-lint.yml
     with:
-      enable_profiling: ${{ inputs.enable_profiling || false }}
       rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   visual-regression:

--- a/tools/ci/generate_ci_lib.py
+++ b/tools/ci/generate_ci_lib.py
@@ -162,16 +162,7 @@ def generate_ci_config(manifest: WorkflowManifest) -> Workflow:
         on={
             "push": {"branches": ["main", "master", "devel"]},
             "pull_request": None,
-            "workflow_dispatch": {
-                "inputs": {
-                    "enable_profiling": {
-                        "description": "Enable Bazel profiling (generates downloadable artifacts)",
-                        "required": False,
-                        "type": "boolean",
-                        "default": False,
-                    }
-                }
-            },
+            "workflow_dispatch": None,
         },
         concurrency={"group": "${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress": True},
         permissions=permissions,

--- a/tools/ci/generate_ci_lib.py
+++ b/tools/ci/generate_ci_lib.py
@@ -159,11 +159,7 @@ def generate_ci_config(manifest: WorkflowManifest) -> Workflow:
 
     return Workflow(
         name="CI",
-        on={
-            "push": {"branches": ["main", "master", "devel"]},
-            "pull_request": None,
-            "workflow_dispatch": None,
-        },
+        on={"push": {"branches": ["main", "master", "devel"]}, "pull_request": None, "workflow_dispatch": None},
         concurrency={"group": "${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress": True},
         permissions=permissions,
         jobs=jobs,

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -30,22 +30,16 @@ workflows:
   bazel-lint:
     trigger: { kind: bazel_query, query: "$targets" }
     targets: true
-    inputs:
-      enable_profiling: ${{ inputs.enable_profiling || false }}
     secrets: [BUILDBUDDY_API_KEY]
 
   bazel-typecheck:
     trigger: { kind: bazel_query, query: "$targets" }
     targets: true
-    inputs:
-      enable_profiling: ${{ inputs.enable_profiling || false }}
     secrets: [BUILDBUDDY_API_KEY]
 
   # Rust-specific (only finance/ has Rust code)
   bazel-rust-lint:
     trigger: { kind: bazel_query, query: "$targets intersect //finance/..." }
-    inputs:
-      enable_profiling: ${{ inputs.enable_profiling || false }}
     secrets: [BUILDBUDDY_API_KEY]
 
   # Frontend visual regression


### PR DESCRIPTION
## Summary
Removes the optional Bazel profiling feature that was previously available in CI workflows. This includes removing the `enable_profiling` input parameter, the `ci-profile` Bazel configuration, and all associated artifact upload steps across multiple workflow files.

## Changes Made
- **`.bazelrc`**: Removed the `ci-profile` build configuration that captured performance data (profile.gz and execution-log.json)
- **Workflow files**: Removed `enable_profiling` input parameter from:
  - `bazel-lint.yml`
  - `bazel-typecheck.yml`
  - `bazel-rust-lint.yml`
  - `bazel-test.yml`
  - `ci.yml`
- **Workflow logic**: Removed conditional profiling flag logic and artifact upload steps from all affected workflows
- **CI generation**: Updated `generate_ci_lib.py` to remove profiling input from the generated CI workflow configuration
- **Workflow manifest**: Updated `tools/ci/workflows.yaml` to remove profiling input declarations
- **Formatting**: Fixed YAML indentation in generated workflow files (quote style consistency)

## Rationale
This simplifies the CI infrastructure by removing an optional feature that was not being actively used. The removal reduces complexity in workflow definitions and eliminates unnecessary conditional logic and artifact uploads.

https://claude.ai/code/session_01L6tZBRokR3GW8YqFC3jtXn