### PR TITLE
Add RBE image override support for CI workflows

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Additional hash to append to cache key (use hashFiles() at call site)"
     required: false
     default: ""
+  rbe_image:
+    description: "Override RBE container image (optional - uses platform default if empty)"
+    required: false
+    default: ""
 
 outputs:
   buildbuddy-enabled:
@@ -49,6 +53,7 @@ runs:
       uses: ./.github/actions/setup-buildbuddy
       with:
         api_key: ${{ inputs.buildbuddy_api_key }}
+        rbe_image: ${{ inputs.rbe_image }}
 
     - name: Setup Bazel cache
       id: cache

--- a/.github/actions/setup-buildbuddy/action.yml
+++ b/.github/actions/setup-buildbuddy/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "BuildBuddy API key (optional - no-op if not provided)"
     required: false
     default: ""
+  rbe_image:
+    description: "Override RBE container image (optional - uses platform default if empty)"
+    required: false
+    default: ""
 
 outputs:
   enabled:
@@ -34,6 +38,7 @@ runs:
       shell: bash
       env:
         BUILDBUDDY_API_KEY: ${{ inputs.api_key }}
+        RBE_IMAGE: ${{ inputs.rbe_image }}
       run: |
         if [[ -z "$BUILDBUDDY_API_KEY" ]]; then
           echo "enabled=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         default: "//..."
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -46,6 +51,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
 
       - name: Build
         run: |

--- a/.github/workflows/bazel-lint.yml
+++ b/.github/workflows/bazel-lint.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -65,6 +70,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
 
       - name: Lint
         run: |

--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -58,6 +63,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
           extra_hash: ${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
 
       - name: Rust lint

--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -78,6 +83,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
 
       - name: Run tests
         id: tests

--- a/.github/workflows/bazel-typecheck.yml
+++ b/.github/workflows/bazel-typecheck.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -64,6 +69,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
 
       - name: Typecheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # AUTO-GENERATED from tools/ci/workflows.yaml - DO NOT EDIT DIRECTLY
 # Regenerate with: uv run tools/ci/generate_ci.py
 name: CI
-"on":
+'on':
   push:
     branches:
-      - main
-      - master
-      - devel
+    - main
+    - master
+    - devel
   pull_request: null
   workflow_dispatch:
     inputs:
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
+  packages: write
 jobs:
   compute-targets:
     name: Compute affected targets
@@ -30,103 +31,126 @@ jobs:
       workflows: ${{ steps.decide.outputs.workflows }}
       infra_changed: ${{ steps.decide.outputs.infra_changed }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@v4
-      - uses: bazelbuild/setup-bazelisk@v3
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      - name: Cache bazel-diff JAR
-        id: cache-bazel-diff
-        uses: actions/cache@v4
-        with:
-          path: bazel-diff.jar
-          key: bazel-diff-12.1.1
-      - name: Download bazel-diff
-        run: |-
-          curl -fsSL -o bazel-diff.jar \
-            "https://github.com/Tinder/bazel-diff/releases/download/12.1.1/bazel-diff_deploy.jar"
-        if: steps.cache-bazel-diff.outputs.cache-hit != 'true'
-      - name: Cache bazel-diff hashes
-        uses: actions/cache@v4
-        with:
-          path: .bazel-diff-cache
-          key: bazel-diff-hashes-${{ github.sha }}
-          restore-keys: bazel-diff-hashes-
-      - name: Set CI env
-        run: |-
-          echo "BAZEL_DIFF_JAR=$PWD/bazel-diff.jar" >> $GITHUB_ENV
-          echo "BAZEL_DIFF_CACHE_DIR=$PWD/.bazel-diff-cache" >> $GITHUB_ENV
-          echo "BAZEL_QUERY_LOG_DIR=$PWD/bazel-query-logs" >> $GITHUB_ENV
-          echo "CI_WORKFLOWS_MANIFEST=$PWD/tools/ci/workflows.yaml" >> $GITHUB_ENV
-          # Full build on main/devel pushes; incremental on PRs and feature branches
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ ^(main|master|devel)$ ]]; then
-            echo "CI_PUSH_STRATEGY=full" >> $GITHUB_ENV
-          else
-            echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV
-          fi
-      - name: Compute CI decision
-        id: decide
-        run: uv run tools/ci/ci_decide.py
-      - name: Upload targets file
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: targets
-          path: targets.txt
-          if-no-files-found: ignore
-      - name: Upload query logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: bazel-query-logs-${{ github.run_id }}
-          path: bazel-query-logs
-          if-no-files-found: ignore
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: astral-sh/setup-uv@v4
+    - uses: bazelbuild/setup-bazelisk@v3
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+    - name: Cache bazel-diff JAR
+      id: cache-bazel-diff
+      uses: actions/cache@v4
+      with:
+        path: bazel-diff.jar
+        key: bazel-diff-12.1.1
+    - name: Download bazel-diff
+      run: |-
+        curl -fsSL -o bazel-diff.jar \
+          "https://github.com/Tinder/bazel-diff/releases/download/12.1.1/bazel-diff_deploy.jar"
+      if: steps.cache-bazel-diff.outputs.cache-hit != 'true'
+    - name: Cache bazel-diff hashes
+      uses: actions/cache@v4
+      with:
+        path: .bazel-diff-cache
+        key: bazel-diff-hashes-${{ github.sha }}
+        restore-keys: bazel-diff-hashes-
+    - name: Set CI env
+      run: |-
+        echo "BAZEL_DIFF_JAR=$PWD/bazel-diff.jar" >> $GITHUB_ENV
+        echo "BAZEL_DIFF_CACHE_DIR=$PWD/.bazel-diff-cache" >> $GITHUB_ENV
+        echo "BAZEL_QUERY_LOG_DIR=$PWD/bazel-query-logs" >> $GITHUB_ENV
+        echo "CI_WORKFLOWS_MANIFEST=$PWD/tools/ci/workflows.yaml" >> $GITHUB_ENV
+        # Full build on main/devel pushes; incremental on PRs and feature branches
+        if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" =~ ^(main|master|devel)$ ]]; then
+          echo "CI_PUSH_STRATEGY=full" >> $GITHUB_ENV
+        else
+          echo "CI_PUSH_STRATEGY=incremental" >> $GITHUB_ENV
+        fi
+    - name: Compute CI decision
+      id: decide
+      run: uv run tools/ci/ci_decide.py
+    - name: Upload targets file
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: targets
+        path: targets.txt
+        if-no-files-found: ignore
+    - name: Upload query logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: bazel-query-logs-${{ github.run_id }}
+        path: bazel-query-logs
+        if-no-files-found: ignore
   bazel-build:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-build')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-build')
     uses: ./.github/workflows/bazel-build.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-test:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-test')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-test')
     uses: ./.github/workflows/bazel-test.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-lint:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-lint')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-lint')
     uses: ./.github/workflows/bazel-lint.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
       enable_profiling: ${{ inputs.enable_profiling || false }}
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-typecheck:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-typecheck')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-typecheck')
     uses: ./.github/workflows/bazel-typecheck.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
       enable_profiling: ${{ inputs.enable_profiling || false }}
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   bazel-rust-lint:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-rust-lint')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-rust-lint')
     uses: ./.github/workflows/bazel-rust-lint.yml
     with:
       enable_profiling: ${{ inputs.enable_profiling || false }}
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
   visual-regression:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'visual-regression')
+    needs:
+    - compute-targets
+    - rbe-image-ci
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'visual-regression')
     uses: ./.github/workflows/visual-regression.yml
+    with:
+      rbe_image: ${{ needs.rbe-image-ci.outputs.rbe_image }}
     secrets: inherit
+  rbe-image-ci:
+    needs: compute-targets
+    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'rbe-image-ci')
+    uses: ./.github/workflows/rbe-image-ci.yml
   nix-flake-check:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows), 'nix-flake-check')

--- a/.github/workflows/ducktape-release.yml
+++ b/.github/workflows/ducktape-release.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED from tools/ci/workflows.yaml - DO NOT EDIT DIRECTLY
 # Regenerate with: uv run tools/ci/generate_ci.py
 name: ducktape Release
-"on":
+'on':
   push:
     branches:
-      - devel
-      - main
+    - devel
+    - main
   workflow_dispatch:
     inputs:
       force_release:
@@ -25,27 +25,27 @@ jobs:
     outputs:
       release_needed: ${{ steps.check.outputs.release_needed }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: bazel
-        uses: ./.github/actions/setup-bazel
-        with:
-          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      - name: Check if release needed
-        id: check
-        uses: ./.github/actions/check-release-needed
-        with:
-          package_prefix: ducktape
-          bazel_target: //:wheel
-          latest_release_tag: ducktape-latest
-      - uses: ./.github/actions/bazel-cache-save
-        if: always()
-        with:
-          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - id: bazel
+      uses: ./.github/actions/setup-bazel
+      with:
+        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+    - name: Check if release needed
+      id: check
+      uses: ./.github/actions/check-release-needed
+      with:
+        package_prefix: ducktape
+        bazel_target: //:wheel
+        latest_release_tag: ducktape-latest
+    - uses: ./.github/actions/bazel-cache-save
+      if: always()
+      with:
+        cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+        cache-key: ${{ steps.bazel.outputs.cache-key }}
+        skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/gnome-terminal-profile-switcher-release.yml
+++ b/.github/workflows/gnome-terminal-profile-switcher-release.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED from tools/ci/workflows.yaml - DO NOT EDIT DIRECTLY
 # Regenerate with: uv run tools/ci/generate_ci.py
 name: gnome-terminal-profile-switcher Release
-"on":
+'on':
   push:
     branches:
-      - devel
-      - main
+    - devel
+    - main
   workflow_dispatch:
     inputs:
       force_release:
@@ -25,27 +25,27 @@ jobs:
     outputs:
       release_needed: ${{ steps.check.outputs.release_needed }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: bazel
-        uses: ./.github/actions/setup-bazel
-        with:
-          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      - name: Check if release needed
-        id: check
-        uses: ./.github/actions/check-release-needed
-        with:
-          package_prefix: gnome-terminal-profile-switcher
-          bazel_target: //gnome_terminal_profile_switcher:wheel
-          latest_release_tag: gnome-terminal-profile-switcher-latest
-      - uses: ./.github/actions/bazel-cache-save
-        if: always()
-        with:
-          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - id: bazel
+      uses: ./.github/actions/setup-bazel
+      with:
+        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+    - name: Check if release needed
+      id: check
+      uses: ./.github/actions/check-release-needed
+      with:
+        package_prefix: gnome-terminal-profile-switcher
+        bazel_target: //gnome_terminal_profile_switcher:wheel
+        latest_release_tag: gnome-terminal-profile-switcher-latest
+    - uses: ./.github/actions/bazel-cache-save
+      if: always()
+      with:
+        cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+        cache-key: ${{ steps.bazel.outputs.cache-key }}
+        skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/headscale-cleanup-release.yml
+++ b/.github/workflows/headscale-cleanup-release.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED from tools/ci/workflows.yaml - DO NOT EDIT DIRECTLY
 # Regenerate with: uv run tools/ci/generate_ci.py
 name: headscale-cleanup Release
-"on":
+'on':
   push:
     branches:
-      - devel
-      - main
+    - devel
+    - main
   workflow_dispatch:
     inputs:
       force_release:
@@ -25,27 +25,27 @@ jobs:
     outputs:
       release_needed: ${{ steps.check.outputs.release_needed }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: bazel
-        uses: ./.github/actions/setup-bazel
-        with:
-          buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      - name: Check if release needed
-        id: check
-        uses: ./.github/actions/check-release-needed
-        with:
-          package_prefix: headscale-cleanup
-          bazel_target: //headscale_cleanup:wheel
-          latest_release_tag: headscale-cleanup-latest
-      - uses: ./.github/actions/bazel-cache-save
-        if: always()
-        with:
-          cache-hit: ${{ steps.bazel.outputs.cache-hit }}
-          cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - id: bazel
+      uses: ./.github/actions/setup-bazel
+      with:
+        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+    - name: Check if release needed
+      id: check
+      uses: ./.github/actions/check-release-needed
+      with:
+        package_prefix: headscale-cleanup
+        bazel_target: //headscale_cleanup:wheel
+        latest_release_tag: headscale-cleanup-latest
+    - uses: ./.github/actions/bazel-cache-save
+      if: always()
+      with:
+        cache-hit: ${{ steps.bazel.outputs.cache-hit }}
+        cache-key: ${{ steps.bazel.outputs.cache-key }}
+        skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/rbe-image-ci.yml
+++ b/.github/workflows/rbe-image-ci.yml
@@ -1,0 +1,52 @@
+# Build the RBE worker image for CI validation.
+#
+# Called from ci.yml when tools/rbe_image/** changes on a PR. Pushes a
+# commit-tagged image so downstream Bazel jobs can test with the updated image
+# before it becomes :latest on merge.
+name: RBE Image CI Build
+
+on:
+  workflow_call:
+    outputs:
+      rbe_image:
+        description: "Full image reference (e.g. ghcr.io/.../rbe-worker:ci-<sha>), empty if skipped"
+        value: ${{ jobs.build.outputs.rbe_image }}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/rbe-worker
+
+jobs:
+  build:
+    name: Build RBE Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      rbe_image: ${{ steps.meta.outputs.rbe_image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: meta
+        run: |
+          TAG="ci-${{ github.sha }}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "rbe_image=${{ env.IMAGE }}:$TAG" >> $GITHUB_OUTPUT
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tools/rbe_image/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -5,6 +5,12 @@ name: Visual regression tests
 
 on:
   workflow_call:
+    inputs:
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
     secrets:
       BUILDBUDDY_API_KEY:
         description: "BuildBuddy API key for remote cache (optional)"
@@ -35,6 +41,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
           extra_hash: ${{ hashFiles('props/frontend/pnpm-lock.yaml') }}
 
       - name: Run visual regression tests

--- a/tools/ci/generate_ci_lib.py
+++ b/tools/ci/generate_ci_lib.py
@@ -105,7 +105,15 @@ COMPUTE_TARGETS_JOB = Job(
 )
 
 
-def build_workflow_job(name: str, config: WorkflowConfig) -> Job:
+RBE_IMAGE_CI_JOB = "rbe-image-ci"
+
+
+def _uses_rbe(name: str, config: WorkflowConfig) -> bool:
+    """Whether this workflow uses BuildBuddy RBE and should receive rbe_image."""
+    return name != RBE_IMAGE_CI_JOB and "BUILDBUDDY_API_KEY" in config.secrets
+
+
+def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: bool) -> Job:
     """Build a job definition from workflow config."""
     with_args: dict[str, str] = {}
     if config.targets:
@@ -113,9 +121,23 @@ def build_workflow_job(name: str, config: WorkflowConfig) -> Job:
     if config.inputs:
         with_args.update(config.inputs)
 
+    needs: str | list[str] = "compute-targets"
+    if_cond = f"contains(fromJson(needs.compute-targets.outputs.workflows), '{name}')"
+
+    # Bazel workflows that use RBE should wait for the rbe-image-ci job (when
+    # it exists) and forward the built image reference. The job may be skipped
+    # when no RBE image files changed, so we allow skipped results.
+    if has_rbe_image_job and _uses_rbe(name, config):
+        needs = ["compute-targets", RBE_IMAGE_CI_JOB]
+        if_cond = (
+            f"always() && !cancelled() && !failure() "
+            f"&& contains(fromJson(needs.compute-targets.outputs.workflows), '{name}')"
+        )
+        with_args["rbe_image"] = f"${{{{ needs.{RBE_IMAGE_CI_JOB}.outputs.rbe_image }}}}"
+
     return Job(
-        needs="compute-targets",
-        if_cond=f"contains(fromJson(needs.compute-targets.outputs.workflows), '{name}')",
+        needs=needs,
+        if_cond=if_cond,
         uses=f"./.github/workflows/{name}.yml",
         with_args=with_args if with_args else None,
         secrets="inherit" if config.secrets else None,
@@ -124,9 +146,16 @@ def build_workflow_job(name: str, config: WorkflowConfig) -> Job:
 
 def generate_ci_config(manifest: WorkflowManifest) -> Workflow:
     """Generate the complete ci.yml config."""
+    has_rbe_image_job = RBE_IMAGE_CI_JOB in manifest.workflows
+
     jobs: dict[str, Job] = {"compute-targets": COMPUTE_TARGETS_JOB}
     for name, config in manifest.workflows.items():
-        jobs[name] = build_workflow_job(name, config)
+        jobs[name] = build_workflow_job(name, config, has_rbe_image_job=has_rbe_image_job)
+
+    # The rbe-image-ci job pushes container images, so we need packages:write.
+    permissions: dict[str, str] = {"contents": "read"}
+    if has_rbe_image_job:
+        permissions["packages"] = "write"
 
     return Workflow(
         name="CI",
@@ -145,7 +174,7 @@ def generate_ci_config(manifest: WorkflowManifest) -> Workflow:
             },
         },
         concurrency={"group": "${{ github.workflow }}-${{ github.ref }}", "cancel-in-progress": True},
-        permissions={"contents": "read"},
+        permissions=permissions,
         jobs=jobs,
     )
 

--- a/tools/ci/github_actions.py
+++ b/tools/ci/github_actions.py
@@ -90,7 +90,7 @@ class Job(BaseModel):
     name: str | None = None
     runs_on: str | None = Field(None, alias="runs-on", serialization_alias="runs-on")
     timeout_minutes: int | None = Field(None, alias="timeout-minutes", serialization_alias="timeout-minutes")
-    needs: str | None = None
+    needs: str | list[str] | None = None
     if_cond: str | None = Field(None, alias="if", serialization_alias="if")
     uses: str | None = None
     with_args: dict[str, str] | None = Field(None, alias="with", serialization_alias="with")

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -53,6 +53,10 @@ workflows:
     trigger: { kind: bazel_query, query: "$targets intersect //props/frontend/..." }
     secrets: [BUILDBUDDY_API_KEY]
 
+  # RBE image build (tested on PRs, output consumed by Bazel workflows)
+  rbe-image-ci:
+    trigger: { kind: path, pattern: "^tools/rbe_image/" }
+
   # Path-based workflows (non-Bazel)
   nix-flake-check:
     trigger: { kind: path, pattern: "^nix/" }

--- a/tools/setup-buildbuddy.sh
+++ b/tools/setup-buildbuddy.sh
@@ -39,6 +39,14 @@ build --spawn_strategy=remote,local
 build --jobs=50
 EOF
 
+# Override the RBE container image if RBE_IMAGE is set (used by CI when
+# testing an updated RBE image before it becomes :latest).
+# remote_header platform overrides take precedence over platform exec_properties.
+if [[ -n "${RBE_IMAGE:-}" ]]; then
+  echo "build --remote_header=x-buildbuddy-platform.container-image=docker://${RBE_IMAGE}" >>"$BUILDBUDDY_BAZELRC"
+  echo "RBE image override: $RBE_IMAGE"
+fi
+
 # Ensure ~/.bazelrc has the try-import (for CI environments without home-manager)
 USER_BAZELRC="$HOME/.bazelrc"
 if [[ ! -f "$USER_BAZELRC" ]] || ! grep -q "try-import.*buildbuddy.bazelrc" "$USER_BAZELRC" 2>/dev/null; then


### PR DESCRIPTION
## Summary
This PR adds support for overriding the RBE (Remote Build Execution) container image used during CI builds, enabling testing of updated RBE images before they become the default `:latest` tag.

## Key Changes

- **New RBE Image CI workflow** (`rbe-image-ci.yml`): Builds and pushes RBE worker container images tagged with commit SHA when `tools/rbe_image/` changes, allowing downstream jobs to test the updated image
- **RBE image parameter propagation**: Added `rbe_image` input parameter to all Bazel-based workflows (bazel-build, bazel-test, bazel-lint, bazel-typecheck, bazel-rust-lint, visual-regression) and their underlying setup actions
- **CI orchestration**: Updated `ci.yml` to:
  - Depend on the new `rbe-image-ci` job when it exists
  - Forward the built image reference to all RBE-using workflows
  - Add `packages: write` permission for pushing container images to GHCR
- **BuildBuddy integration**: Modified `setup-buildbuddy` action to accept and apply the RBE image override via `--remote_header` flag
- **Code generation**: Updated CI generation library to automatically handle RBE image job dependencies and parameter forwarding

## Implementation Details

- The `rbe-image-ci` job is conditionally included in the CI workflow only when `tools/rbe_image/` files change
- Workflows that depend on `rbe-image-ci` use relaxed failure conditions (`always() && !cancelled() && !failure()`) to allow the job to be skipped without blocking downstream jobs
- The RBE image override is applied via BuildBuddy's `x-buildbuddy-platform.container-image` header, which takes precedence over platform exec_properties
- YAML formatting was normalized (quote style consistency) in auto-generated workflow files

https://claude.ai/code/session_01ChKQUtBxfGmtS4CxnakqSA