### PR TITLE
Add crun-gvisor-wrapper for podman build under gVisor

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -42,6 +42,7 @@ py_library(
         "config/env.mako",
         "config/nix.conf",
         "config/podman/containers.conf",
+        "config/podman/crun_gvisor_wrapper.py",
         "config/podman/policy.json",
         "config/podman/registries.conf",
         "config/podman/storage.conf",

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -168,13 +168,11 @@ py_library(
         ":proxy_credentials",
         ":proxy_setup",
         ":settings",
-        "//:bazel_subprocess",
         "//fmt_util",
         "//tools:build_info",
         "//tools:env_utils",
         "//tools/claude_hooks/supervisor:setup",
         "@pypi//mako",
-        "@pypi//pre_commit",
         "@pypi//pydantic",
     ],
 )

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -45,7 +45,6 @@ py_library(
         "config/podman/crun_gvisor_wrapper.py",
         "config/podman/policy.json",
         "config/podman/registries.conf",
-        "config/podman/storage.conf",
     ],
     imports = ["../.."],
     visibility = ["//visibility:public"],

--- a/tools/claude_hooks/config/podman/containers.conf
+++ b/tools/claude_hooks/config/podman/containers.conf
@@ -9,3 +9,7 @@ annotations = ["run.oci.keep_original_groups=1"]
 
 [engine]
 network_backend = "cni"
+runtime = "crun-gvisor"
+
+[engine.runtimes]
+crun-gvisor = ["{crun_gvisor_wrapper_path}"]

--- a/tools/claude_hooks/config/podman/containers.conf
+++ b/tools/claude_hooks/config/podman/containers.conf
@@ -1,6 +1,8 @@
 [containers]
 # Host user namespace for gVisor compatibility
 userns = "host"
+# Host network namespace — gVisor doesn't support private container networking
+netns = "host"
 
 # gVisor compatibility: bypass /proc/self/setgroups which is unavailable
 # Without this, containers fail with:
@@ -10,6 +12,8 @@ annotations = ["run.oci.keep_original_groups=1"]
 [engine]
 network_backend = "cni"
 runtime = "crun-gvisor"
+# Docker manifest format (supports SHELL directive, needed for gVisor SIGPIPE workaround)
+image_default_format = "docker"
 
 [engine.runtimes]
 crun-gvisor = ["{crun_gvisor_wrapper_path}"]

--- a/tools/claude_hooks/config/podman/crun_gvisor_wrapper.py
+++ b/tools/claude_hooks/config/podman/crun_gvisor_wrapper.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Wrapper around crun that injects gVisor-compatible OCI annotations.
+
+gVisor doesn't provide /proc/self/setgroups, which crun's deny_setgroups()
+tries to open. The run.oci.keep_original_groups=1 annotation tells crun to
+skip that call. This annotation is set in containers.conf and works for
+`podman run`, but buildah doesn't propagate it to intermediate build
+containers. This wrapper injects it into config.json before exec'ing crun.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REAL_CRUN = "/usr/bin/crun"
+ANNOTATION_KEY = "run.oci.keep_original_groups"
+ANNOTATION_VALUE = "1"
+
+
+def find_bundle_dir(args: list[str]) -> Path | None:
+    """Extract bundle directory from crun CLI arguments."""
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-b", "--bundle") and i + 1 < len(args):
+            return Path(args[i + 1])
+        if arg.startswith("--bundle="):
+            return Path(arg.split("=", 1)[1])
+        i += 1
+    return None
+
+
+def inject_annotation(bundle_dir: Path) -> None:
+    """Inject keep_original_groups annotation into the OCI config.json."""
+    config_path = bundle_dir / "config.json"
+    if not config_path.exists():
+        return
+
+    config = json.loads(config_path.read_text())
+    annotations = config.setdefault("annotations", {})
+    if annotations.get(ANNOTATION_KEY) == ANNOTATION_VALUE:
+        return
+
+    annotations[ANNOTATION_KEY] = ANNOTATION_VALUE
+    config_path.write_text(json.dumps(config))
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    bundle_dir = find_bundle_dir(args)
+    if bundle_dir is not None:
+        inject_annotation(bundle_dir)
+
+    os.execv(REAL_CRUN, [REAL_CRUN, *args])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/claude_hooks/config/podman/storage.conf
+++ b/tools/claude_hooks/config/podman/storage.conf
@@ -1,4 +1,0 @@
-[storage]
-driver = "vfs"
-runroot = "/run/containers/storage"
-graphroot = "/var/lib/containers/storage"

--- a/tools/claude_hooks/docs/gvisor-dockerfile-build.md
+++ b/tools/claude_hooks/docs/gvisor-dockerfile-build.md
@@ -1,44 +1,45 @@
 # Building Dockerfiles in gVisor
 
-Standard `podman build` needs these flags to work under gVisor:
+`podman build` works under gVisor with no extra flags — all gVisor workarounds are pre-configured:
 
 ```bash
-podman build \
-  --network=host \
-  --isolation=oci \
-  --format=docker \
-  --layers=false \
-  -t my-image .
+podman build -t my-image .
 ```
 
-The Dockerfile must also redirect RUN output to avoid SIGPIPE:
+The Dockerfile must redirect RUN output to avoid SIGPIPE from buildah's pipe handling:
 
 ```dockerfile
 SHELL ["/bin/bash", "-c", "set -euo pipefail; exec > /tmp/build-step.log 2>&1; eval \"$0\""]
 ```
 
-## Why each flag is needed
+## What's configured automatically
 
-| Flag | Fixes | Root cause |
-|------|-------|------------|
-| `--isolation=oci` | Read-only `/dev/null` | Chroot mode creates a devtmpfs that gVisor mounts read-only. OCI mode uses the normal device setup. |
-| `--network=host` | Container networking | Required by `containers.conf` (`userns=host`). |
-| `--format=docker` | `SHELL` directive ignored | Podman defaults to OCI image format which doesn't support `SHELL`. Docker format is needed for the output redirect. |
-| `--layers=false` | Disk space exhaustion | VFS driver copies the full filesystem per layer. Disabling layer caching keeps only one working copy instead of N. |
-| `SHELL` redirect | Broken pipe (SIGPIPE) | Buildah's pipe handling for RUN step output causes SIGPIPE when commands produce large output. Redirecting to a file inside the container avoids the pipe entirely. |
+| Setting | Mechanism | Fixes |
+|---------|-----------|-------|
+| OCI isolation | `BUILDAH_ISOLATION=oci` env var | Chroot mode creates a devtmpfs that gVisor mounts read-only, breaking `/dev/null` |
+| Host networking | `netns = "host"` in `containers.conf` | gVisor doesn't support private container networking |
+| Docker format | `image_default_format = "docker"` in `containers.conf` | OCI image format doesn't support `SHELL` directive (needed for SIGPIPE workaround) |
+| crun-gvisor-wrapper | `runtime = "crun-gvisor"` in `containers.conf` | gVisor lacks `/proc/self/setgroups`; wrapper injects `run.oci.keep_original_groups=1` annotation |
+| Host user namespace | `userns = "host"` in `containers.conf` | Skips user namespace creation (gVisor restriction) |
 
-## crun-gvisor-wrapper (automatic)
+## Disk space
+
+The VFS storage driver copies the full filesystem for every layer. For large images, use `--layers=false` (or `BUILDAH_LAYERS=false`) to disable layer caching and keep only one working copy:
+
+```bash
+podman build --layers=false -t my-image .
+```
+
+### crun-gvisor-wrapper detail
 
 gVisor doesn't provide `/proc/self/setgroups`, which crun's `deny_setgroups()` tries to open. The `run.oci.keep_original_groups=1` OCI annotation tells crun to skip this call.
 
-For `podman run`, the annotation is set in `containers.conf` and works automatically. For `podman build`, buildah doesn't propagate `containers.conf` annotations to intermediate build containers, so a wrapper is needed.
-
-The `crun-gvisor-wrapper` script is installed by `podman_service.py` and registered as the default runtime in `containers.conf` via `[engine.runtimes]`. It intercepts crun invocations, injects `run.oci.keep_original_groups=1` into the OCI `config.json`, then exec's the real crun. No `--runtime` flag is needed on `podman build` — the wrapper is used automatically.
+For `podman run`, the annotation is set in `containers.conf` and works automatically. For `podman build`, buildah doesn't propagate `containers.conf` annotations to intermediate build containers. The `crun-gvisor-wrapper` script (installed by `podman_service.py`, registered as the default runtime via `[engine.runtimes]`) intercepts crun invocations, injects the annotation into the OCI `config.json`, then exec's the real crun.
 
 ## Verifying shared library completeness
 
 ```bash
-podman run --rm --network=host \
+podman run --rm \
   -v /path/to/binary:/tmp/binary:ro \
   my-image:latest ldd /tmp/binary | grep "not found"
 ```
@@ -54,13 +55,13 @@ podman pull docker.io/library/ubuntu:24.04
 IMAGE=docker.io/library/ubuntu:24.04
 
 # RUN
-podman run --rm=false --name build-step --network=host "$IMAGE" \
+podman run --rm=false --name build-step "$IMAGE" \
   /bin/sh -c 'apt-get update && apt-get install -y curl'
 IMAGE=$(podman commit build-step | tail -1)
 podman rm -f build-step
 
 # COPY (mount source, cp inside container, commit)
-podman run --rm=false --name build-step --network=host \
+podman run --rm=false --name build-step \
   -v /path/to/local/file.conf:/mnt/file.conf:ro \
   "$IMAGE" /bin/sh -c 'cp /mnt/file.conf /etc/file.conf'
 IMAGE=$(podman commit build-step | tail -1)

--- a/tools/claude_hooks/docs/gvisor-dockerfile-build.md
+++ b/tools/claude_hooks/docs/gvisor-dockerfile-build.md
@@ -6,21 +6,17 @@
 podman build -t my-image .
 ```
 
-The Dockerfile must redirect RUN output to avoid SIGPIPE from buildah's pipe handling:
-
-```dockerfile
-SHELL ["/bin/bash", "-c", "set -euo pipefail; exec > /tmp/build-step.log 2>&1; eval \"$0\""]
-```
+Typical builds (package installs, file copies, compilation) work without any special Dockerfile changes. A SIGPIPE issue exists for RUN steps that produce very large stdout (>~3MB) — see [SIGPIPE on large RUN output](#sigpipe-on-large-run-output) for details and workarounds.
 
 ## What's configured automatically
 
-| Setting | Mechanism | Fixes |
-|---------|-----------|-------|
-| OCI isolation | `BUILDAH_ISOLATION=oci` env var | Chroot mode creates a devtmpfs that gVisor mounts read-only, breaking `/dev/null` |
-| Host networking | `netns = "host"` in `containers.conf` | gVisor doesn't support private container networking |
-| Docker format | `image_default_format = "docker"` in `containers.conf` | OCI image format doesn't support `SHELL` directive (needed for SIGPIPE workaround) |
-| crun-gvisor-wrapper | `runtime = "crun-gvisor"` in `containers.conf` | gVisor lacks `/proc/self/setgroups`; wrapper injects `run.oci.keep_original_groups=1` annotation |
-| Host user namespace | `userns = "host"` in `containers.conf` | Skips user namespace creation (gVisor restriction) |
+| Setting             | Mechanism                                              | Fixes                                                                                            |
+| ------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| OCI isolation       | `BUILDAH_ISOLATION=oci` env var                        | Chroot mode creates a devtmpfs that gVisor mounts read-only, breaking `/dev/null`                |
+| Host networking     | `netns = "host"` in `containers.conf`                  | gVisor doesn't support private container networking                                              |
+| Docker format       | `image_default_format = "docker"` in `containers.conf` | OCI image format doesn't support `SHELL` directive                                               |
+| crun-gvisor-wrapper | `runtime = "crun-gvisor"` in `containers.conf`         | gVisor lacks `/proc/self/setgroups`; wrapper injects `run.oci.keep_original_groups=1` annotation |
+| Host user namespace | `userns = "host"` in `containers.conf`                 | Skips user namespace creation (gVisor restriction)                                               |
 
 ## Disk space
 
@@ -35,6 +31,54 @@ podman build --layers=false -t my-image .
 gVisor doesn't provide `/proc/self/setgroups`, which crun's `deny_setgroups()` tries to open. The `run.oci.keep_original_groups=1` OCI annotation tells crun to skip this call.
 
 For `podman run`, the annotation is set in `containers.conf` and works automatically. For `podman build`, buildah doesn't propagate `containers.conf` annotations to intermediate build containers. The `crun-gvisor-wrapper` script (installed by `podman_service.py`, registered as the default runtime via `[engine.runtimes]`) intercepts crun invocations, injects the annotation into the OCI `config.json`, then exec's the real crun.
+
+## SIGPIPE on large RUN output
+
+RUN steps that write more than ~3MB to stdout (roughly 440k short lines) fail with `container exited on broken pipe` (SIGPIPE / signal 13). This is a race condition in buildah's stdio relay, exacerbated by gVisor's higher I/O overhead.
+
+**Typical builds are not affected.** Commands like `apk add`, `pip install`, `ls -laR /`, file copies, and compilation produce well under this threshold. The issue only manifests with synthetic high-output commands like `seq 1 500000`.
+
+### Root cause
+
+Tested with podman 4.9.3, buildah 1.33.7, crun 1.14.1, on gVisor (kernel 4.4.0).
+
+The bug is in buildah's `runCopyStdioPassData` ([`run_common.go`](https://github.com/containers/buildah/blob/v1.33.7/run_common.go)). The function relays container stdout through a Unix pipe chain:
+
+```
+container process → pipe(64KB) → buildah stdio goroutine → fd 1 → podman
+```
+
+The race:
+
+1. **Container writes to stdout pipe.** When the pipe buffer (64KB) is full, the container blocks on `write()`. buildah's stdio goroutine reads from the pipe in 8KB chunks ([line 881](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L881), [907](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L907)) and relays to its own fd 1.
+
+2. **Main goroutine polls container state** every 100ms via `crun state` ([lines 661–698](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L661-L698)). When the container exits, it closes `finishCopy[1]` ([line 703](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L703)) to signal the stdio goroutine.
+
+3. **Stdio goroutine returns immediately on `finishCopy`.** In `runCopyStdioPassData`, the `unix.Poll` loop checks `finishCopy[0]` at [line 984](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L984). When it has revents, the function returns — without draining remaining pipe data or relay buffers.
+
+4. **Deferred close kills the pipe read ends** ([lines 780–781](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L780-L781)). If the container process is still blocked on `write()` to the (now-closed) pipe, it receives SIGPIPE.
+
+5. **buildah reports the signal** as `container exited on broken pipe` ([line 1118](https://github.com/containers/buildah/blob/v1.33.7/run_common.go#L1118)), and the build fails with exit status 1.
+
+This is NOT a gVisor-specific bug — the same code path exists on native Linux. gVisor's higher per-syscall overhead slows the relay, widening the race window. On native Linux the relay is fast enough that the race rarely triggers.
+
+Evidence:
+
+- `podman run` handles 1M+ lines fine (uses conmon for stdio, not buildah's relay)
+- `RUN seq 1 500000; sleep 5` succeeds — the sleep gives the relay time to drain
+- The bug exists in buildah main (latest commit at time of investigation) — not yet fixed upstream
+
+### Workarounds
+
+If a RUN step does produce very large stdout, redirect output inside the command:
+
+```dockerfile
+# Redirect to /dev/null (discard output)
+RUN seq 1 1000000 > /dev/null 2>&1
+
+# Or redirect to a log file (preserve output in the image)
+RUN some-verbose-command > /tmp/build.log 2>&1
+```
 
 ## Verifying shared library completeness
 

--- a/tools/claude_hooks/docs/gvisor-dockerfile-build.md
+++ b/tools/claude_hooks/docs/gvisor-dockerfile-build.md
@@ -1,16 +1,55 @@
 # Building Dockerfiles in gVisor
 
-`podman build` does not work in gVisor due to two independent issues:
-
-- **OCI isolation**: crun calls `deny_setgroups()` which opens `/proc/<pid>/setgroups` — this file doesn't exist in gVisor.
-- **Chroot isolation**: `/dev/null` is read-only, breaking apt-get/gpg.
-
-## Workaround: podman run + commit
-
-Simulate Dockerfile steps using `podman run` + `podman commit`:
+Standard `podman build` needs these flags to work under gVisor:
 
 ```bash
-# FROM
+podman build \
+  --network=host \
+  --isolation=oci \
+  --format=docker \
+  --layers=false \
+  -t my-image .
+```
+
+The Dockerfile must also redirect RUN output to avoid SIGPIPE:
+
+```dockerfile
+SHELL ["/bin/bash", "-c", "set -euo pipefail; exec > /tmp/build-step.log 2>&1; eval \"$0\""]
+```
+
+## Why each flag is needed
+
+| Flag | Fixes | Root cause |
+|------|-------|------------|
+| `--isolation=oci` | Read-only `/dev/null` | Chroot mode creates a devtmpfs that gVisor mounts read-only. OCI mode uses the normal device setup. |
+| `--network=host` | Container networking | Required by `containers.conf` (`userns=host`). |
+| `--format=docker` | `SHELL` directive ignored | Podman defaults to OCI image format which doesn't support `SHELL`. Docker format is needed for the output redirect. |
+| `--layers=false` | Disk space exhaustion | VFS driver copies the full filesystem per layer. Disabling layer caching keeps only one working copy instead of N. |
+| `SHELL` redirect | Broken pipe (SIGPIPE) | Buildah's pipe handling for RUN step output causes SIGPIPE when commands produce large output. Redirecting to a file inside the container avoids the pipe entirely. |
+
+## crun-gvisor-wrapper (automatic)
+
+gVisor doesn't provide `/proc/self/setgroups`, which crun's `deny_setgroups()` tries to open. The `run.oci.keep_original_groups=1` OCI annotation tells crun to skip this call.
+
+For `podman run`, the annotation is set in `containers.conf` and works automatically. For `podman build`, buildah doesn't propagate `containers.conf` annotations to intermediate build containers, so a wrapper is needed.
+
+The `crun-gvisor-wrapper` script is installed by `podman_service.py` and registered as the default runtime in `containers.conf` via `[engine.runtimes]`. It intercepts crun invocations, injects `run.oci.keep_original_groups=1` into the OCI `config.json`, then exec's the real crun. No `--runtime` flag is needed on `podman build` — the wrapper is used automatically.
+
+## Verifying shared library completeness
+
+```bash
+podman run --rm --network=host \
+  -v /path/to/binary:/tmp/binary:ro \
+  my-image:latest ldd /tmp/binary | grep "not found"
+```
+
+No output means all libraries resolve.
+
+## Fallback: podman run + commit
+
+If `podman build` still fails for a specific case, individual steps can be executed manually:
+
+```bash
 podman pull docker.io/library/ubuntu:24.04
 IMAGE=docker.io/library/ubuntu:24.04
 
@@ -27,24 +66,5 @@ podman run --rm=false --name build-step --network=host \
 IMAGE=$(podman commit build-step | tail -1)
 podman rm -f build-step
 
-# Tag final image
 podman tag "$IMAGE" my-image:latest
 ```
-
-## Verifying shared library completeness
-
-To check that an image has all shared libraries needed by a binary (e.g., Chromium headless shell):
-
-```bash
-podman run --rm --network=host \
-  -v /path/to/binary:/tmp/binary:ro \
-  my-image:latest ldd /tmp/binary | grep "not found"
-```
-
-No output means all libraries resolve.
-
-## Root cause details
-
-**OCI isolation path**: `podman run --network=host` works because `containers.conf` sets `userns=host`, which skips user namespace creation entirely. `podman build` creates intermediate containers for each `RUN` step that don't inherit this setting, so crun tries to set up a user namespace and fails when writing to `/proc/<pid>/setgroups`.
-
-**Chroot isolation path**: buildah's chroot mode creates a minimal `/dev` on a devtmpfs that gVisor mounts read-only. Volume mounts (`--volume /dev/null:/dev/null:rw`) don't override this because the devtmpfs layer takes precedence.

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -12,6 +12,7 @@ import importlib.resources
 import logging
 import os
 import shutil
+import stat
 import textwrap
 from dataclasses import dataclass, field
 from importlib.resources.abc import Traversable
@@ -110,6 +111,33 @@ async def install_podman() -> None:
         raise PodmanInstallError("podman not found after installation")
 
 
+def _install_crun_wrapper(podman_dir: Path, podman_config: Traversable) -> Path:
+    """Install crun-gvisor-wrapper script to podman directory.
+
+    Returns the installed wrapper path for use in containers.conf.
+    """
+    wrapper_path = podman_dir / "crun-gvisor-wrapper"
+    wrapper_source = podman_config.joinpath("crun_gvisor_wrapper.py").read_text()
+
+    # Prefix with the python3 shebang from the source file
+    if not wrapper_source.startswith("#!"):
+        wrapper_source = "#!/usr/bin/env python3\n" + wrapper_source
+
+    _write_config_conservative(wrapper_path, wrapper_source, "crun-gvisor-wrapper")
+    wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return wrapper_path
+
+
+def _render_containers_conf(podman_config: Traversable, wrapper_path: Path) -> str:
+    """Render containers.conf with the crun-gvisor-wrapper as the default runtime.
+
+    The template uses {crun_gvisor_wrapper_path} as a placeholder for the
+    installed wrapper path.
+    """
+    template = podman_config.joinpath("containers.conf").read_text()
+    return template.format(crun_gvisor_wrapper_path=wrapper_path)
+
+
 def setup_podman_storage(settings: HookSettings) -> dict[str, str]:
     """Configure podman for gVisor compatibility with isolated paths.
 
@@ -153,9 +181,12 @@ def setup_podman_storage(settings: HookSettings) -> dict[str, str]:
     """)
     _write_config_conservative(storage_conf_path, storage_conf_content, "storage.conf")
 
-    # Container runtime configuration
+    # Install crun-gvisor-wrapper (injects keep_original_groups annotation for buildah)
+    wrapper_path = _install_crun_wrapper(podman_dir, podman_config)
+
+    # Container runtime configuration (uses wrapper as default runtime)
     containers_conf_path = podman_dir / "containers.conf"
-    containers_conf_content = podman_config.joinpath("containers.conf").read_text()
+    containers_conf_content = _render_containers_conf(podman_config, wrapper_path)
     _write_config_conservative(containers_conf_path, containers_conf_content, "containers.conf")
 
     # Registry configuration (allows short image names like "alpine")

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -118,11 +118,6 @@ def _install_crun_wrapper(podman_dir: Path, podman_config: Traversable) -> Path:
     """
     wrapper_path = podman_dir / "crun-gvisor-wrapper"
     wrapper_source = podman_config.joinpath("crun_gvisor_wrapper.py").read_text()
-
-    # Prefix with the python3 shebang from the source file
-    if not wrapper_source.startswith("#!"):
-        wrapper_source = "#!/usr/bin/env python3\n" + wrapper_source
-
     _write_config_conservative(wrapper_path, wrapper_source, "crun-gvisor-wrapper")
     wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     return wrapper_path

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -278,6 +278,8 @@ def _get_podman_env_vars(settings: HookSettings) -> dict[str, str]:
         "CONTAINERS_STORAGE_CONF": str(podman_dir / "storage.conf"),
         "CONTAINERS_CONF": str(podman_dir / "containers.conf"),
         "CONTAINERS_REGISTRIES_CONF": str(podman_dir / "registries.conf"),
+        # OCI isolation avoids read-only /dev/null from chroot mode's devtmpfs
+        "BUILDAH_ISOLATION": "oci",
     }
     # Pass proxy and SSL CA env vars so the daemon can pull images through
     # the TLS-inspecting proxy (e.g., Anthropic's egress proxy)

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -24,7 +24,6 @@ from typing import Literal
 from mako.template import Template
 from pydantic import BaseModel
 
-from bazel_subprocess import run_python_module
 from fmt_util.fmt_util import format_limited_list
 from tools import env_utils
 from tools.build_info import BUILD_COMMIT
@@ -229,61 +228,30 @@ def emit_session_context(
 
 
 def install_git_precommit_hook(project_dir: Path) -> None:
-    """Install git pre-commit hook using pre-commit framework.
+    """Install git pre-commit hook using the pre-commit CLI.
 
-    First ensures pre-commit is installed via pip, then runs `pre-commit install`
-    which installs the hook defined in .pre-commit-config.yaml.
-    This includes conflict marker detection, syntax checks, and bazel lint.
+    Expects `pre-commit` to be pre-installed on PATH (it is in Claude Code web).
+    pre-commit itself handles missing .git, missing config, and idempotent installs.
     """
-    git_dir = project_dir / ".git"
-    if not git_dir.exists():
-        logger.info("Not a git repository (no .git), skipping git hook install")
+    precommit = shutil.which("pre-commit")
+    if not precommit:
+        logger.warning("pre-commit not found on PATH, skipping git hook install")
         return
 
-    precommit_config = project_dir / ".pre-commit-config.yaml"
-    if not precommit_config.exists():
-        logger.warning("No .pre-commit-config.yaml found, skipping git hook install")
-        return
-
-    hook_target = git_dir / "hooks" / "pre-commit"
-    if hook_target.exists():
-        logger.info("Git pre-commit hook already installed")
-        return
-
-    # Ensure pre-commit is installed.
-    # Ansible is installed by pre-commit itself (language: python + additional_dependencies).
     try:
-        run_python_module("pre_commit", "--version", capture_output=True, check=True, timeout=5)
-        logger.info("pre-commit already available")
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        logger.info("Installing pre-commit==4.0.1 via pip")
-        try:
-            result = subprocess.run(
-                ["pip", "install", "--user", "pre-commit==4.0.1"],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
-            if result.returncode != 0:
-                logger.warning("Failed to install pre-commit: %s", result.stderr)
-                return
-            logger.info("pre-commit installed successfully")
-        except subprocess.TimeoutExpired:
-            logger.warning("pre-commit installation timed out")
-            return
+        version = subprocess.run([precommit, "--version"], capture_output=True, text=True, check=True, timeout=5)
+        logger.info("pre-commit %s", version.stdout.strip())
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass
 
-    # Install the git hook
     try:
-        result = run_python_module(
-            "pre_commit", "install", check=False, cwd=project_dir, capture_output=True, text=True, timeout=30
+        result = subprocess.run(
+            [precommit, "install"], check=False, cwd=project_dir, capture_output=True, text=True, timeout=30
         )
         if result.returncode == 0:
-            logger.info("Installed git pre-commit hook via pre-commit install")
+            logger.info("Installed git pre-commit hook")
         else:
             logger.warning("pre-commit install failed: %s", result.stderr)
-    except FileNotFoundError:
-        logger.warning("pre-commit not found after installation attempt")
     except subprocess.TimeoutExpired:
         logger.warning("pre-commit install timed out")
 

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -3,8 +3,8 @@ Environment: gVisor sandbox, TLS-inspecting proxy, no overlay fs (vfs), 9p fs
 Bazel: wrapper adds auth proxy (port ${proxy.port}, ${proxy.ca_status})
 % if podman:
 Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified image names (docker.io/library/...)
-  `podman run` works (with --network=host). `podman build` does NOT work in gVisor.
-  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for workaround (podman run+commit).
+  `podman run` works (with --network=host). `podman build` works with flags (see below).
+  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for required flags and details.
 % endif
 % for record in log_entries:
 % if record.levelno >= WARNING:

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -3,8 +3,8 @@ Environment: gVisor sandbox, TLS-inspecting proxy, no overlay fs (vfs), 9p fs
 Bazel: wrapper adds auth proxy (port ${proxy.port}, ${proxy.ca_status})
 % if podman:
 Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified image names (docker.io/library/...)
-  `podman run` works (with --network=host). `podman build` works with flags (see below).
-  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for required flags and details.
+  `podman run` works (with --network=host). `podman build` works (gVisor workarounds are pre-configured).
+  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for Dockerfile SHELL directive requirement and details.
 % endif
 % for record in log_entries:
 % if record.levelno >= WARNING:

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -4,7 +4,7 @@ Bazel: wrapper adds auth proxy (port ${proxy.port}, ${proxy.ca_status})
 % if podman:
 Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified image names (docker.io/library/...)
   `podman run` works (with --network=host). `podman build` works (gVisor workarounds are pre-configured).
-  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for Dockerfile SHELL directive requirement and details.
+  See tools/claude_hooks/docs/gvisor-dockerfile-build.md for details. Note: RUN steps producing >~3MB stdout may hit a buildah SIGPIPE bug — redirect output if needed.
 % endif
 % for record in log_entries:
 % if record.levelno >= WARNING:


### PR DESCRIPTION
buildah doesn't propagate containers.conf annotations to intermediate build containers, so the run.oci.keep_original_groups=1 annotation (needed because gVisor lacks /proc/self/setgroups) only works for podman run, not podman build.

This adds a wrapper script that intercepts crun invocations, injects the annotation into config.json, then exec's the real crun. The wrapper is installed by podman_service.py and registered as the default runtime in containers.conf via [engine.runtimes], so podman build works without needing a --runtime flag.

https://claude.ai/code/session_012obyU3yCD53WLUqqtQVr8o