### PR TITLE
Fix Docker build context for RBE image workflow

### DIFF
--- a/.github/workflows/rbe-image.yml
+++ b/.github/workflows/rbe-image.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: tools/rbe_image
+          context: .
+          file: tools/rbe_image/Dockerfile
           push: true
           tags: |
             ${{ env.IMAGE }}:latest

--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -51,4 +51,4 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
 # Firecracker VMs are single-tenant and ephemeral).
 # TODO: Ideally, build a custom Firecracker kernel with CONFIG_IP_NF_RAW=y
 # to get full Docker networking security. This is a workaround.
-COPY daemon.json /etc/docker/daemon.json
+COPY tools/rbe_image/daemon.json /etc/docker/daemon.json


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow for building the RBE Docker image to use the correct build context and file path, ensuring the build works properly regardless of the working directory.

## Key Changes
- Changed Docker build context from `tools/rbe_image` to `.` (repository root)
- Added explicit `file` parameter pointing to `tools/rbe_image/Dockerfile`
- Updated the `COPY` instruction in the Dockerfile to use the full path `tools/rbe_image/daemon.json` instead of relative path `daemon.json`

## Details
These changes ensure that:
1. The Docker build context is the entire repository, which is the standard practice for multi-file builds
2. The Dockerfile path is explicitly specified, making the build configuration clearer
3. The `COPY` instruction uses a path relative to the build context root, which is the correct way to reference files when the context is the repository root

This prevents potential build failures that could occur when the build context is too narrow or when relative paths don't resolve correctly.

https://claude.ai/code/session_01U9pxEey44XoXjkFJbSuBXZ