### PR TITLE
Simplify Bazel caching: always use GHA cache alongside BuildBuddy

### DIFF
--- a/.github/actions/bazel-cache-save/action.yml
+++ b/.github/actions/bazel-cache-save/action.yml
@@ -1,7 +1,10 @@
-# Composite action for saving Bazel cache
+# Composite action for saving Bazel local cache
 #
 # Use after bazel-cache action to save the cache on completion.
-# Only saves if the cache wasn't restored (cache miss) and skip_cache is false.
+# Only saves if the cache wasn't restored (cache miss).
+#
+# This runs regardless of whether BuildBuddy is enabled — the GHA local cache
+# and BuildBuddy remote cache are complementary (see bazel-cache/action.yml).
 #
 # Usage:
 #   - uses: ./.github/actions/bazel-cache-save
@@ -9,9 +12,8 @@
 #     with:
 #       cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
 #       cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
-#       skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
 name: Bazel Cache Save
-description: Save Bazel cache (use after bazel-cache action)
+description: Save Bazel local cache (use after bazel-cache action)
 
 inputs:
   cache-hit:
@@ -20,16 +22,12 @@ inputs:
   cache-key:
     description: "Cache key to save under (from bazel-cache output)"
     required: true
-  skip_cache:
-    description: "Skip saving cache (e.g., when using BuildBuddy remote cache)"
-    required: false
-    default: "false"
 
 runs:
   using: composite
   steps:
     - name: Save Bazel cache
-      if: inputs.cache-hit != 'true' && inputs.skip_cache != 'true'
+      if: inputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -1,16 +1,20 @@
-# Composite action for Bazel cache setup and save
+# Composite action for Bazel local cache setup
 #
 # Handles:
 # - Setting up Bazelisk
 # - Deriving cache key from workflow/job name + file hashes
-# - Restoring and saving Bazel cache (skipped if using BuildBuddy remote cache)
+# - Restoring Bazel local cache (output_base/external/, repository_cache, etc.)
+#
+# This cache is complementary to BuildBuddy remote cache: BuildBuddy caches
+# remote action results, while this caches client-side state — particularly
+# extracted external repositories (e.g., LLVM toolchain) that are fetched
+# during analysis and never handled by remote execution.
 #
 # Usage:
 #   - uses: ./.github/actions/bazel-cache
 #     id: bazel-cache
 #     with:
 #       extra_hash: ${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
-#       skip_cache: ${{ steps.buildbuddy.outputs.enabled }}
 #
 #   # ... your build steps ...
 #
@@ -19,17 +23,13 @@
 #       cache-hit: ${{ steps.bazel-cache.outputs.cache-hit }}
 #       cache-key: ${{ steps.bazel-cache.outputs.cache-key }}
 name: Bazel Cache Setup
-description: Setup Bazelisk and restore Bazel cache with auto-derived keys
+description: Setup Bazelisk and restore Bazel local cache with auto-derived keys
 
 inputs:
   extra_hash:
     description: "Additional hash to append to cache key (use hashFiles() at call site)"
     required: false
     default: ""
-  skip_cache:
-    description: "Skip GitHub Actions cache (e.g., when using BuildBuddy remote cache)"
-    required: false
-    default: "false"
 
 outputs:
   cache-hit:
@@ -70,7 +70,6 @@ runs:
 
     - name: Restore Bazel cache
       id: cache-restore
-      if: inputs.skip_cache != 'true'
       uses: actions/cache/restore@v4
       with:
         path: |

--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -1,7 +1,9 @@
 # Composite action for Bazel environment setup
 #
-# Combines BuildBuddy remote cache setup and GitHub Actions cache fallback.
-# Use this as the single entry point for Bazel caching in workflows.
+# Combines BuildBuddy remote cache/execution with GitHub Actions local cache.
+# These are complementary: BuildBuddy handles remote action cache and execution,
+# while GHA cache persists output_base/external/ (extracted repos like the LLVM
+# toolchain) to avoid costly re-fetches during analysis on the GHA runner.
 #
 # Usage:
 #   - uses: ./.github/actions/setup-bazel
@@ -16,9 +18,8 @@
 #     with:
 #       cache-hit: ${{ steps.bazel.outputs.cache-hit }}
 #       cache-key: ${{ steps.bazel.outputs.cache-key }}
-#       skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 name: Setup Bazel
-description: Setup Bazel with BuildBuddy remote cache or GitHub Actions cache fallback
+description: Setup Bazel with BuildBuddy remote cache and GitHub Actions local cache
 
 inputs:
   buildbuddy_api_key:
@@ -35,9 +36,6 @@ inputs:
     default: ""
 
 outputs:
-  buildbuddy-enabled:
-    description: "Whether BuildBuddy remote cache is configured ('true' or 'false')"
-    value: ${{ steps.buildbuddy.outputs.enabled }}
   cache-hit:
     description: "Whether GitHub Actions cache was restored"
     value: ${{ steps.cache.outputs.cache-hit }}
@@ -60,4 +58,3 @@ runs:
       uses: ./.github/actions/bazel-cache
       with:
         extra_hash: ${{ inputs.extra_hash }}
-        skip_cache: ${{ steps.buildbuddy.outputs.enabled }}

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -78,4 +78,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-lint.yml
+++ b/.github/workflows/bazel-lint.yml
@@ -87,4 +87,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -67,4 +67,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-test.yml
+++ b/.github/workflows/bazel-test.yml
@@ -136,4 +136,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/bazel-typecheck.yml
+++ b/.github/workflows/bazel-typecheck.yml
@@ -89,4 +89,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 
   # Unit and E2E tests run on all pushes and PRs
   test:
@@ -134,7 +133,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 
   # Wheel mode tests - build wheel, install it, and run tests against installed package
   # Runs on all triggers (PRs and pushes) to catch wheel packaging issues early
@@ -190,7 +188,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
 
   # Release job - only runs on push to devel/main when release is needed
   release:
@@ -292,4 +289,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/ducktape-release.yml
+++ b/.github/workflows/ducktape-release.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/gnome-terminal-profile-switcher-release.yml
+++ b/.github/workflows/gnome-terminal-profile-switcher-release.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/headscale-cleanup-release.yml
+++ b/.github/workflows/headscale-cleanup-release.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}
   release:
     needs: check
     if: needs.check.outputs.release_needed == 'true' || inputs.force_release == true

--- a/.github/workflows/python-wheel-release.yml
+++ b/.github/workflows/python-wheel-release.yml
@@ -141,4 +141,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -84,4 +84,3 @@ jobs:
         with:
           cache-hit: ${{ steps.bazel.outputs.cache-hit }}
           cache-key: ${{ steps.bazel.outputs.cache-key }}
-          skip_cache: ${{ steps.bazel.outputs.buildbuddy-enabled }}


### PR DESCRIPTION
## Summary
Removes the `skip_cache` parameter from Bazel caching actions and workflows. The GitHub Actions local cache and BuildBuddy remote cache are now always used together as complementary systems, rather than treating them as mutually exclusive fallbacks.

## Key Changes
- **Removed `skip_cache` input parameter** from:
  - `bazel-cache` action
  - `bazel-cache-save` action
  - `setup-bazel` action
  
- **Removed `buildbuddy-enabled` output** from `setup-bazel` action

- **Updated all workflow files** to remove `skip_cache` parameter passing:
  - `bazel-build.yml`
  - `bazel-lint.yml`
  - `bazel-rust-lint.yml`
  - `bazel-test.yml`
  - `bazel-typecheck.yml`
  - `claude-hooks-release.yml`
  - `ducktape-release.yml`
  - `gnome-terminal-profile-switcher-release.yml`
  - `headscale-cleanup-release.yml`
  - `python-wheel-release.yml`
  - `visual-regression.yml`

- **Updated documentation** in action comments to clarify that:
  - GHA local cache persists client-side state (extracted external repositories, output_base/external/, repository_cache)
  - BuildBuddy remote cache handles remote action results
  - These caches are complementary, not alternatives

## Implementation Details
The GHA local cache now always runs regardless of BuildBuddy configuration. This is beneficial because:
- BuildBuddy caches remote action execution results
- GHA local cache caches expensive client-side operations like extracting external repositories (e.g., LLVM toolchain) that occur during analysis
- Both can coexist without conflict, improving overall build performance

https://claude.ai/code/session_01VZQ3ctVDoJNnu7RJ5tTPnm