### PR TITLE
Fix broken exclusion paths in .gitattributes and .pre-commit-config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,7 @@
 **/third_party/** rules-lint-ignored=true
 
 # Test data files - inputs to tests, not source code
-claude/claude_hooks/claude_hooks/testdata/** rules-lint-ignored=true
+claude/claude_hooks/testdata/** rules-lint-ignored=true
 props/testing/fixtures/testdata/** rules-lint-ignored=true
 experimental/sandboxed_jupyter/testdata/** rules-lint-ignored=true
 sysrw/testdata/** rules-lint-ignored=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: check-yaml
         args: ["--allow-multiple-documents"]
         # Skip Helm templates (Go templating, not valid YAML), ansible vault files, cluster charts, Flux-generated manifests
-        exclude: "ansible/host_vars/.*\\.yml$|claude/claude_optimizer/config\\.example\\.yaml$|cluster/k8s/|cluster/charts/|cluster/flux-system/"
+        exclude: "ansible/host_vars/.*\\.yml$|claude/claude_optimizer/config\\.example\\.yaml$|cluster/k8s/|cluster/charts/"
       - id: check-toml
 
       # TODO: disabled - should NOT fix within dotfiles e.g. OrcaSlicer


### PR DESCRIPTION
- .gitattributes: Remove doubled claude_hooks segment (claude/claude_hooks/claude_hooks/testdata → claude/claude_hooks/testdata) so rules-lint-ignored actually applies to the real testdata files
- check-yaml: Remove dead cluster/flux-system/ pattern (directory doesn't exist; cluster/k8s/ already covers cluster/k8s/flux-system/)

https://claude.ai/code/session_01KKKSKGfZM16AD2D9xWKF6d