### PR TITLE
Remove unnecessary check-yaml exclusion for config.example.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: check-yaml
         args: ["--allow-multiple-documents"]
         # Skip Helm templates (Go templating, not valid YAML), ansible vault files, cluster charts, Flux-generated manifests
-        exclude: "ansible/host_vars/.*\\.yml$|claude/claude_optimizer/config\\.example\\.yaml$|cluster/k8s/|cluster/charts/"
+        exclude: "ansible/host_vars/.*\\.yml$|cluster/k8s/|cluster/charts/"
       - id: check-toml
 
       # TODO: disabled - should NOT fix within dotfiles e.g. OrcaSlicer


### PR DESCRIPTION
The file is valid YAML and parses fine — the exclusion was a historical leftover from when the file was being prototyped.

https://claude.ai/code/session_01KKKSKGfZM16AD2D9xWKF6d