### PR TITLE
Refactor Bazel caching: repository-only cache + RBE image selection

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -46,21 +46,16 @@ jobs:
           pre-commit install
           pre-commit install --hook-type commit-msg
 
-      - name: Install cluster tools (optional)
-        run: |
-          # Install opentofu
-          TOFU_VERSION="1.9.0"
-          curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_amd64.zip" -o /tmp/tofu.zip
-          unzip -q /tmp/tofu.zip -d /tmp
-          sudo mv /tmp/tofu /usr/local/bin/tofu
-          sudo chmod +x /usr/local/bin/tofu
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.9.0
+        continue-on-error: true
 
-          # Install tflint
-          TFLINT_VERSION="0.53.0"
-          curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip
-          unzip -q /tmp/tflint.zip -d /tmp
-          sudo mv /tmp/tflint /usr/local/bin/tflint
-          sudo chmod +x /usr/local/bin/tflint
+      - name: Install TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.60.0
         continue-on-error: true
 
       - name: Verify environment

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,8 +32,20 @@ jobs:
         with:
           tofu_version: 1.9.0
 
-      # NOTE: tflint is hermetic via @multitool//tools/tflint in bazel precommit
-      # Plugin init is handled by precommit.py (run_tflint runs --init)
+      # TFLint for antonbabenko/pre-commit-terraform hook
+      - name: Install TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.60.0
+
+      # Cache tflint plugins (~/.tflint.d/plugins) to avoid re-downloading from GitHub
+      - name: Restore TFLint plugin cache
+        id: cache-tflint-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.tflint.d
+          key: tflint-plugins-${{ runner.os }}-${{ hashFiles('cluster/.tflint.hcl') }}
+          restore-keys: tflint-plugins-${{ runner.os }}-
 
       # kubeconform for kubeconform-precommit-hook (not hermetic via Bazel)
       # Other tools (kustomize, flux, helm, kubeseal) are hermetic via @multitool
@@ -144,3 +156,10 @@ jobs:
         with:
           path: ~/.ansible/roles
           key: ${{ steps.cache-ansible-roles-restore.outputs.cache-primary-key }}
+
+      - name: Save TFLint plugin cache
+        if: always() && steps.cache-tflint-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.tflint.d
+          key: ${{ steps.cache-tflint-restore.outputs.cache-primary-key }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,8 +135,18 @@ repos:
         args: ["--framework", "terraform", "--skip-check", "CKV_TF_1", "-f"]
         files: "^cluster/terraform/.*\\.tf$"
 
-  # NOTE: The following hooks are now combined into bazel-precommit:
+  # TFLint - Terraform linter (uses antonbabenko wrapper which handles tflint --init)
+  # Config: cluster/.tflint.hcl; plugins cached in ~/.tflint.d/plugins
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_ROOT__/cluster/.tflint.hcl
+        files: "^cluster/terraform/.*\\.tf$"
+
+  # NOTE: The following hooks are combined into bazel-precommit:
   # - bazel-format (prettier, ruff, shfmt, buildifier)
   # - bazel-validate (buildifier-lint, pytest-main check, cluster validations)
-  # - terraform checks (tflint, tofu validate, terraform-version-centralization)
+  # - terraform checks (tofu validate, terraform-version-centralization)
   # This avoids Bazel client lock contention and runs terraform checks in parallel.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,8 @@ repos:
 
   # TFLint - Terraform linter (uses antonbabenko wrapper which handles tflint --init)
   # Config: cluster/.tflint.hcl; plugins cached in ~/.tflint.d/plugins
+  # Wrapper groups changed files by directory and runs tflint --chdir=<dir> per directory
+  # (tflint always lints the whole module, not individual files)
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:

--- a/tools/claude_hooks/TODO.md
+++ b/tools/claude_hooks/TODO.md
@@ -4,12 +4,18 @@
 
 **Problem**: Installing nix on Claude Code web times out because downloading nixpkgs takes >2 minutes (session start hook timeout).
 
-**Current Workaround**: The `claude_hooks` package is installed via `uv tool install` from a pre-built wheel (published to GitHub releases), avoiding Python dependency installation during session start. Terraform tools (opentofu, tflint) are Bazel-managed via `@multitool//tools/*`. Nix is installed separately for `nix eval`, flake operations, and `nix run nixpkgs#nixfmt` (used by pre-commit hook).
+**Current Workaround**: The `claude_hooks` package is installed via `uv tool install` from a pre-built wheel (published to GitHub releases), avoiding Python dependency installation during session start. Terraform tools (opentofu) are Bazel-managed via `@multitool//tools/*`; tflint is installed by `antonbabenko/pre-commit-terraform` hook (requires tflint on PATH). Nix is installed separately for `nix eval`, flake operations, and `nix run nixpkgs#nixfmt` (used by pre-commit hook).
 
 **Potential Solutions:** See <docs/nix-speed-options.md> for detailed analysis. Summary:
 
 - **Pre-built nix store tarball** (recommended) - CI builds closure, publishes tarball, session hook unpacks
 - **Pre-computed store paths** - CI records paths, session hook does `nix copy`
+
+## Auto-install tflint in Session Start Hook
+
+**Problem**: The `terraform_tflint` pre-commit hook (via `antonbabenko/pre-commit-terraform`) requires tflint on PATH. On Claude Code web (gVisor sandbox), tflint may not be available.
+
+**Solution**: Consider auto-installing tflint in the session start hook (similar to how opentofu is handled), so `pre-commit run` works out of the box for terraform changes.
 
 ## gVisor Dockerfile Build as Claude Code Skill
 

--- a/tools/precommit/BUILD.bazel
+++ b/tools/precommit/BUILD.bazel
@@ -41,7 +41,6 @@ py_binary(
         "//cluster/scripts:validate_kustomizations",
         "//cluster/scripts:validate_sealed_secrets",
         # Terraform tools
-        "@multitool//tools/tflint",
         "@multitool//tools/tofu",
     ],
     env = {
@@ -49,7 +48,6 @@ py_binary(
         "PRETTIER_BIN": "$(rlocationpath //tools/lint:prettier)",
         "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",
-        "TFLINT_BIN": "$(rlocationpath @multitool//tools/tflint)",
         "TOFU_BIN": "$(rlocationpath @multitool//tools/tofu)",
     },
     visibility = ["//visibility:public"],
@@ -58,7 +56,6 @@ py_binary(
         "//tools:check_pytest_main",
         "//tools:env_utils",
         "@pypi//pygit2",
-        "@pypi//tenacity",
         "@rules_python//python/runfiles",
     ],
 )
@@ -80,7 +77,6 @@ py_binary(
         "//cluster/scripts:validate_kustomizations",
         "//cluster/scripts:validate_sealed_secrets",
         # Terraform tools
-        "@multitool//tools/tflint",
         "@multitool//tools/tofu",
     ],
     env = {
@@ -89,7 +85,6 @@ py_binary(
         "PRETTIER_BIN": "$(rlocationpath //tools/lint:prettier)",
         "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",
-        "TFLINT_BIN": "$(rlocationpath @multitool//tools/tflint)",
         "TOFU_BIN": "$(rlocationpath @multitool//tools/tofu)",
     },
     main = "precommit.py",
@@ -99,7 +94,6 @@ py_binary(
         "//tools:check_pytest_main",
         "//tools:env_utils",
         "@pypi//pygit2",
-        "@pypi//tenacity",
         "@rules_python//python/runfiles",
     ],
 )

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pygit2
-import tenacity
 from python.runfiles import runfiles
 
 from tools.check_pytest_main import check_files_async
@@ -318,70 +317,6 @@ async def run_terraform_centralization_check(files: list[Path]) -> ValidationRes
     return ValidationResult(name, elapsed, not violations, output)
 
 
-@tenacity.retry(
-    stop=tenacity.stop_after_attempt(3),
-    wait=tenacity.wait_exponential(multiplier=1, min=1, max=4),
-    retry=tenacity.retry_if_result(lambda output: output != ""),
-)
-async def _tflint_init(tflint_bin: str, config_path: Path) -> str:
-    """Run tflint --init, returning empty string on success or error output on failure."""
-    proc = await asyncio.create_subprocess_exec(
-        tflint_bin, "--init", f"--config={config_path}", stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-    )
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
-        return (stdout + stderr).decode().strip()
-    return ""
-
-
-async def run_tflint(files: list[Path], repo_root: Path) -> ValidationResult:
-    """Run tflint on terraform files."""
-    name = "tflint"
-    tf_files = [f for f in files if is_terraform_file(f)]
-    if not tf_files:
-        return ValidationResult(name, 0.0, True, skipped=True)
-
-    start = time.perf_counter()
-    tflint_bin = resolve_formatter_bin("tflint")
-    tf_dirs = {f.parent for f in tf_files}
-    config_path = repo_root / "cluster" / ".tflint.hcl"
-
-    # Initialize plugins (downloads terraform ruleset if not cached).
-    # Retry on failure since this downloads from GitHub and can fail
-    # transiently (rate limiting, connectivity).
-    try:
-        await _tflint_init(tflint_bin, config_path)
-    except tenacity.RetryError as e:
-        elapsed = time.perf_counter() - start
-        return ValidationResult(name, elapsed, False, f"tflint --init failed after retries:\n{e.last_attempt.result()}")
-
-    # Run tflint on each directory
-    tasks = []
-    for tf_dir in tf_dirs:
-        tasks.append(
-            asyncio.create_subprocess_exec(
-                tflint_bin,
-                f"--chdir={tf_dir}",
-                f"--config={config_path}",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-        )
-
-    procs = await asyncio.gather(*tasks)
-    results = await asyncio.gather(*[p.communicate() for p in procs])
-    elapsed = time.perf_counter() - start
-
-    failed_outputs = []
-    for proc, (stdout, stderr) in zip(procs, results, strict=True):
-        if proc.returncode != 0:
-            output = (stdout + stderr).decode().strip()
-            if output:
-                failed_outputs.append(output)
-
-    return ValidationResult(name, elapsed, not failed_outputs, "\n".join(failed_outputs))
-
-
 async def run_tofu_validate(files: list[Path]) -> list[ValidationResult]:
     """Run tofu validate on terraform directories."""
     tf_files = [f for f in files if is_terraform_file(f)]
@@ -435,7 +370,6 @@ async def run_validate(files: list[Path], repo_root: Path) -> list[ValidationRes
             run_buildifier_lint(files),
             run_pytest_main_check(files, repo_root),
             run_terraform_centralization_check(files),
-            run_tflint(files, repo_root),
             run_subprocess_validation(
                 "kustomize-validate", "_main/cluster/scripts/validate_kustomizations", files, is_cluster_k8s
             ),


### PR DESCRIPTION
## Summary

This PR refactors CI caching to focus on Bazel's repository cache (compressed external dependencies) rather than the full local cache, which exceeds GitHub Actions' 10GB per-repo limit. It also introduces dynamic RBE container image selection via workflow parameters.

## Key Changes

### Caching Architecture
- **Removed** `bazel-cache` and `bazel-cache-save` actions (cached full `~/.cache/bazel`, too large)
- **Added** `bazel-repo-cache` and `bazel-repo-cache-save` actions that cache only:
  - `~/.cache/bazelisk` (Bazel binary)
  - `~/.cache/bazel/_bazel_runner/cache/repos/v1` (compressed external deps, ~2GB)
- **Added** `.github/docs/bazel-caching.md` documenting the design rationale and cache strategy
- **Updated** `setup-bazel` action to use the new repo-cache actions and removed BuildBuddy skip logic

### CI Workflow Updates
- **Removed** `enable_profiling` input from all Bazel workflow files (bazel-build, bazel-test, bazel-lint, bazel-typecheck, bazel-rust-lint)
- **Removed** `--config=ci-profile` profiling support and artifact uploads
- **Removed** `bazel-cache-save` calls from all workflows (no longer needed with repo-cache-only approach)
- **Added** `rbe_image` input parameter to allow dynamic RBE container image selection
- **Added** `compute-targets` job to prewarm repository cache with `bazel fetch //...`
- **Added** `rbe-image` workflow that builds and pushes custom RBE container images
- **Updated** all downstream jobs to depend on `rbe-image` and pass the image reference to BuildBuddy

### Configuration Changes
- **Removed** `ci-profile` Bazel config from `.bazelrc` (profiling no longer supported)
- **Updated** `.bazelrc` test config: removed `test --test_env=DOCKER_HOST` with explanatory comment (RBE Firecracker workers use default socket)
- **Updated** `.gitattributes` and `.prettierignore` to reflect directory structure changes

### Workflow Improvements
- **Simplified** `setup-buildbuddy` to accept optional `rbe_image` override
- **Updated** `rbe-image.yml` to support `workflow_call` trigger with image reference output
- **Updated** `copilot-setup-steps.yml` to use official GitHub Actions for OpenTofu and TFLint
- **Updated** `pre-commit.yml` to cache TFLint plugins and use standalone TFLint action
- **Removed** profiling-related code from all Bazel workflows

## Implementation Details

- Repository cache key: `bazel-repo-cache-<hash of MODULE.bazel + MODULE.bazel.lock>`
- Shared across all CI jobs (no per-job slug) since repository contents are identical
- `compute-targets` job runs first and seeds the cache; downstream jobs restore and skip downloads
- RBE image selection allows testing with custom container images without workflow changes
- Extraction of LLVM toolchain (~1-2 minutes) is unavoidable on cache miss but acceptable vs. full re-download

## Benefits

- **Fits within GHA limits**: ~2GB repository cache vs. ~12GB full cache
- **Faster analysis phase**: Pre-warmed downloads avoid network fetches
- **Simpler caching logic**: Single cache entry, no per-job complexity
- **Dynamic RBE images**: Support for custom container images in CI
- **Cleaner workflows**: Removed profiling overhead and cache-save boilerplate

https://claude.ai/code/session_01K34dHVZjWK6MKDy6253isJ