### PR TITLE
Auto-install pre-commit via pip if not found on PATH

### DIFF
--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -230,13 +230,29 @@ def emit_session_context(
 def install_git_precommit_hook(project_dir: Path) -> None:
     """Install git pre-commit hook using the pre-commit CLI.
 
-    Expects `pre-commit` to be pre-installed on PATH (it is in Claude Code web).
+    If `pre-commit` is not on PATH, installs it via pip first.
+    pre-commit is not pre-installed in Claude Code on the web's container.
     pre-commit itself handles missing .git, missing config, and idempotent installs.
     """
     precommit = shutil.which("pre-commit")
     if not precommit:
-        logger.warning("pre-commit not found on PATH, skipping git hook install")
-        return
+        logger.info("pre-commit not found on PATH, installing via pip...")
+        try:
+            subprocess.run(
+                ["pip", "install", "pre-commit"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            logger.info("Installed pre-commit via pip")
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning("Failed to install pre-commit via pip: %s", e)
+            return
+        precommit = shutil.which("pre-commit")
+        if not precommit:
+            logger.warning("pre-commit still not found on PATH after pip install")
+            return
 
     try:
         version = subprocess.run([precommit, "--version"], capture_output=True, text=True, check=True, timeout=5)


### PR DESCRIPTION
## Summary
Modified the git pre-commit hook installation to automatically install `pre-commit` via pip if it's not already available on PATH, rather than silently skipping the installation.

## Changes
- Updated `install_git_precommit_hook()` to attempt pip installation when `pre-commit` is not found on PATH
- Added subprocess call to `pip install pre-commit` with a 120-second timeout
- Implemented error handling for installation failures (CalledProcessError, TimeoutExpired, FileNotFoundError)
- Added verification that `pre-commit` is available after pip installation
- Updated docstring to reflect the new behavior and clarify that pre-commit is not pre-installed in Claude Code web's container

## Implementation Details
- Installation is attempted with `capture_output=True` to suppress output and `check=True` to raise on non-zero exit codes
- Gracefully falls back to skipping hook installation if pip install fails or pre-commit remains unavailable
- Uses appropriate logging levels: `info` for successful operations, `warning` for failures
- Maintains backward compatibility by returning early if installation cannot be completed

https://claude.ai/code/session_01KdTWhCtLFp59MDm45YpnvY