### PR TITLE
Replace Python dockerd wrapper with shell for Firecracker raw table fix

### DIFF
--- a/tools/rbe_image/Dockerfile
+++ b/tools/rbe_image/Dockerfile
@@ -51,13 +51,15 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
 # Firecracker VMs are single-tenant and ephemeral).
 #
 # Problem: BuildBuddy's init-dockerd (goinit) unconditionally overwrites
-# /etc/docker/daemon.json via MMDS metadata before starting dockerd. There's
-# no exec property to pass custom flags or preserve image settings.
+# /etc/docker/daemon.json via MMDS metadata before starting dockerd, and
+# there's no exec property to pass custom dockerd flags.
 #
-# Workaround: Rename the real dockerd and install a wrapper script that merges
-# allow-direct-routing into daemon.json before exec'ing the real binary.
+# Workaround: Rename the real dockerd and install a shell wrapper that passes
+# --allow-direct-routing as a CLI flag before exec'ing the real binary.
 # goinit calls `dockerd` by name via exec.LookPath, so the wrapper intercepts.
-COPY tools/rbe_image/dockerd-wrapper.py /usr/bin/dockerd-wrapper.py
+# Shell (not Python) because goinit's 30s Docker init timeout is too tight
+# for Python interpreter startup inside Firecracker VMs.
+COPY tools/rbe_image/dockerd-wrapper.sh /usr/bin/dockerd-wrapper.sh
 RUN mv /usr/bin/dockerd /usr/bin/dockerd.real \
-    && mv /usr/bin/dockerd-wrapper.py /usr/bin/dockerd \
+    && mv /usr/bin/dockerd-wrapper.sh /usr/bin/dockerd \
     && chmod +x /usr/bin/dockerd

--- a/tools/rbe_image/dockerd-wrapper.sh
+++ b/tools/rbe_image/dockerd-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Wrapper around dockerd for Firecracker VMs lacking CONFIG_IP_NF_RAW.
+#
+# Docker 28+ adds iptables "raw" table rules for direct access filtering
+# when publishing ports. Firecracker's guest kernel lacks CONFIG_IP_NF_RAW,
+# so any container with published ports (-p) fails.
+#
+# Two complementary workarounds:
+#   DOCKER_INSECURE_NO_IPTABLES_RAW=1  (env var, Docker 28.0.2+)
+#     Skips ALL raw table operations (create and delete). This is the more
+#     complete fix — --allow-direct-routing alone doesn't prevent raw table
+#     deletion attempts which also fail without the kernel module.
+#   --allow-direct-routing  (CLI flag)
+#     Tells dockerd to skip direct access filtering DROP rules. Belt and
+#     suspenders with the env var.
+#
+# BuildBuddy's goinit has no exec property to pass custom dockerd flags or
+# env vars. This wrapper intercepts the dockerd call to add them.
+#
+# Shell (not Python) because goinit's 30s Docker init timeout is too tight
+# for Python interpreter startup inside Firecracker VMs.
+
+export DOCKER_INSECURE_NO_IPTABLES_RAW=1
+exec /usr/bin/dockerd.real --allow-direct-routing "$@"


### PR DESCRIPTION
The Python wrapper (dockerd-wrapper.py) caused Docker init timeouts inside Firecracker VMs — Python interpreter startup exceeded goinit's 30s timeout.

The shell wrapper does the same thing with negligible startup overhead:
- Sets DOCKER_INSECURE_NO_IPTABLES_RAW=1 (skips all raw table ops)
- Passes --allow-direct-routing to dockerd (belt and suspenders)

Docker 28's direct access filtering creates iptables raw table rules when publishing ports. Firecracker's kernel lacks CONFIG_IP_NF_RAW, so docker run -p fails without these workarounds.

https://claude.ai/code/session_013m2x52WJTyQzbGqx87bJsS