### PR TITLE
Remove unused ConfigConflictError import from podman_service

### DIFF
--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -19,7 +19,7 @@ from importlib.resources.abc import Traversable
 from pathlib import Path
 
 from tools.claude_hooks.errors import SkipError
-from tools.claude_hooks.managed_files import ConfigConflictError, write_config
+from tools.claude_hooks.managed_files import write_config
 from tools.claude_hooks.proxy_setup import SSL_CA_ENV_VARS
 from tools.claude_hooks.proxy_vars import PROXY_ENV_VARS
 from tools.claude_hooks.settings import HookSettings
@@ -126,7 +126,7 @@ def setup_podman_storage(settings: HookSettings) -> dict[str, str]:
         Dict of environment variables to export (CONTAINERS_CONF, etc.)
 
     Raises:
-        ConfigConflictError: If existing config file has conflicting content.
+        managed_files.ConfigConflictError: If existing config file has conflicting content.
     """
     podman_dir = settings.get_podman_dir()
     podman_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
Cleaned up unused import and updated documentation reference in the podman_service module.

## Changes
- Removed unused `ConfigConflictError` from the direct import statement in `podman_service.py`
- Updated the docstring reference to `ConfigConflictError` to use the fully qualified name `managed_files.ConfigConflictError` for clarity

## Details
The `ConfigConflictError` exception was being imported but never used directly in the `podman_service.py` module. By removing it from the import and updating the docstring to reference it via its module path, we reduce unnecessary imports while maintaining clear documentation of which exceptions can be raised by the `setup_podman_storage()` function.

https://claude.ai/code/session_01Xfo1F5pfjx3A7VS1S3zCEE