### PR TITLE
Switch kubeconform to local hook with go install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,15 +132,17 @@ repos:
   # CLUSTER-SPECIFIC HOOKS (scoped to cluster/ directory)
   # ============================================================================
 
-  # Kubernetes manifest validation
-  - repo: https://github.com/zrootorg/kubeconform-precommit-hook
-    rev: 7f0288e2809173c0c9eeff05c5ff7bcceabb90d4 # 2023-07-11 latest
+  # Kubernetes manifest validation (auto-installed via go install)
+  - repo: local
     hooks:
       - id: kubeconform
         name: kubeconform (cluster)
-        args: [-p, cluster/k8s/]
-        files: ^cluster/k8s/.*\.yaml$
-        exclude: cluster/charts/
+        language: golang
+        additional_dependencies:
+          - github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0
+        entry: kubeconform
+        files: ^cluster/k8s/.*\.(yaml|yml)$
+        types: [yaml]
 
   # Checkov security scanner for Terraform (standalone, avoids 10s import in bazel-precommit)
   - repo: https://github.com/bridgecrewio/checkov


### PR DESCRIPTION
## Summary
Migrated the kubeconform pre-commit hook from a remote repository to a local hook that uses `go install` for dependency management. This simplifies the hook configuration and improves maintainability.

## Key Changes
- Changed kubeconform hook from remote repository (`zrootorg/kubeconform-precommit-hook`) to `local` hook type
- Updated hook language to `golang` with explicit dependency specification (`github.com/yannh/kubeconform/cmd/kubeconform@v0.7.0`)
- Simplified hook entry point to directly use `kubeconform` command
- Enhanced file matching to include both `.yaml` and `.yml` extensions
- Added `types: [yaml]` for better file type filtering
- Removed `exclude` pattern for `cluster/charts/` (now handled by file pattern specificity)

## Implementation Details
- The hook now relies on Go's dependency management system rather than a third-party pre-commit wrapper
- This approach ensures the kubeconform binary is installed via `go install` when the hook runs
- File pattern updated from `^cluster/k8s/.*\.yaml$` to `^cluster/k8s/.*\.(yaml|yml)$` for broader YAML file support
- The `types: [yaml]` addition provides an additional layer of file filtering

https://claude.ai/code/session_014obEWS37ZzDSByzVSkmWLH