### PR TITLE
Reorganize .pre-commit-config.yaml: consolidate local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,20 +52,6 @@ repos:
   # This gives fast local feedback (1-3 seconds) while ensuring thorough validation in CI.
   # Syntax check catches: YAML errors, undefined variables, invalid module usage, etc.
   # Full ansible-lint in CI catches: Style issues, best practices, deprecated modules, etc.
-  - repo: local
-    hooks:
-      - id: ansible-syntax-check
-        name: ansible-playbook --syntax-check
-        entry: ansible/scripts/run-syntax-check.sh
-        language: python
-        additional_dependencies: [ansible]
-        # Only root-level ansible/*.yaml (playbooks), not roles/vars/etc subdirs.
-        files: "^ansible/[^/]+\\.yaml$"
-        # TODO: Re-enable gpd.yaml once all machines use Nix home-manager
-        # and legacy_* roles are deleted. Currently gpd.yaml → legacy_gui →
-        # petermosmans.customize-gnome (missing galaxy role) breaks syntax-check.
-        exclude: "^ansible/(gpd|requirements|inventory)\\.yaml$"
-        pass_filenames: true
 
   # Ruff linter (formatting handled by bazel-format below)
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -86,35 +72,6 @@ repos:
     hooks:
       - id: nixfmt-nix
 
-  # Prettier formatter - uses .prettierrc.cjs config and .prettierignore
-  # The .prettierrc.cjs uses require() for the svelte plugin, which resolves via
-  # NODE_PATH set by pre-commit's language:node environment
-  - repo: local
-    hooks:
-      - id: prettier
-        name: prettier
-        entry: prettier --write --ignore-unknown
-        language: node
-        additional_dependencies:
-          - prettier@3.7.4
-          - prettier-plugin-svelte@3.4.1
-          - svelte@5.38.1
-        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html)$"
-        exclude: "\\.pnpm/"
-
-  - repo: local
-    hooks:
-      # Unified pre-commit: format + validate
-      # Uses --script_path runner to avoid Bazel lock (allows parallel batch execution)
-      # Runners stored in .git/precommit-runners/, one per pre-commit invocation
-      - id: bazel-precommit
-        name: bazel precommit (format + validate)
-        entry: tools/precommit/run-precommit.sh
-        language: system
-        pass_filenames: true
-        # Triggers on: formattable files, Bazel files, test files, cluster files
-        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html|py|sh|bash|tf)$|BUILD(\\.bazel)?$|WORKSPACE(\\.bazel)?$|\\.bzl$|MODULE\\.bazel$|^cluster/"
-
   # Markdown linting (scoped to match .markdownlint-cli2.jsonc globs)
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.17.2
@@ -129,12 +86,49 @@ repos:
   #                 bazel test //agent_server/src/agent_server/web:svelte_check_test
 
   # ============================================================================
-  # CLUSTER-SPECIFIC HOOKS (scoped to cluster/ directory)
+  # LOCAL HOOKS
   # ============================================================================
-
-  # Kubernetes manifest validation (auto-installed via go install)
   - repo: local
     hooks:
+      - id: ansible-syntax-check
+        name: ansible-playbook --syntax-check
+        entry: ansible/scripts/run-syntax-check.sh
+        language: python
+        additional_dependencies: [ansible]
+        # Only root-level ansible/*.yaml (playbooks), not roles/vars/etc subdirs.
+        files: "^ansible/[^/]+\\.yaml$"
+        # TODO: Re-enable gpd.yaml once all machines use Nix home-manager
+        # and legacy_* roles are deleted. Currently gpd.yaml → legacy_gui →
+        # petermosmans.customize-gnome (missing galaxy role) breaks syntax-check.
+        exclude: "^ansible/(gpd|requirements|inventory)\\.yaml$"
+        pass_filenames: true
+
+      # Prettier formatter - uses .prettierrc.cjs config and .prettierignore
+      # The .prettierrc.cjs uses require() for the svelte plugin, which resolves via
+      # NODE_PATH set by pre-commit's language:node environment
+      - id: prettier
+        name: prettier
+        entry: prettier --write --ignore-unknown
+        language: node
+        additional_dependencies:
+          - prettier@3.7.4
+          - prettier-plugin-svelte@3.4.1
+          - svelte@5.38.1
+        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html)$"
+        exclude: "\\.pnpm/"
+
+      # Unified pre-commit: format + validate
+      # Uses --script_path runner to avoid Bazel lock (allows parallel batch execution)
+      # Runners stored in .git/precommit-runners/, one per pre-commit invocation
+      - id: bazel-precommit
+        name: bazel precommit (format + validate)
+        entry: tools/precommit/run-precommit.sh
+        language: system
+        pass_filenames: true
+        # Triggers on: formattable files, Bazel files, test files, cluster files
+        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html|py|sh|bash|tf)$|BUILD(\\.bazel)?$|WORKSPACE(\\.bazel)?$|\\.bzl$|MODULE\\.bazel$|^cluster/"
+
+      # Kubernetes manifest validation (auto-installed via go install)
       - id: kubeconform
         name: kubeconform (cluster)
         language: golang
@@ -143,6 +137,10 @@ repos:
         entry: kubeconform
         files: ^cluster/k8s/.*\.(yaml|yml)$
         types: [yaml]
+
+  # ============================================================================
+  # CLUSTER-SPECIFIC HOOKS (external repos, scoped to cluster/ directory)
+  # ============================================================================
 
   # Checkov security scanner for Terraform (standalone, avoids 10s import in bazel-precommit)
   - repo: https://github.com/bridgecrewio/checkov


### PR DESCRIPTION
## Summary
Reorganized `.pre-commit-config.yaml` to improve maintainability by consolidating all local hooks into a single section and adding clear section headers for better navigation.

## Key Changes
- **Consolidated local hooks**: Merged three separate `repo: local` sections into one unified section with clear subsections
- **Added section headers**: Introduced markdown headers to visually separate:
  - Local hooks (ansible-syntax-check, prettier, bazel-precommit, kubeconform)
  - Cluster-specific hooks (external repos)
- **Reordered hooks**: Moved markdownlint-cli2 and ESLint/svelte-check notes earlier in the file for better logical flow
- **Improved comments**: Updated section descriptions to clarify scope and purpose

## Implementation Details
- No functional changes to hook behavior or configuration
- All hook definitions remain identical; only their organization changed
- The consolidation makes it easier to:
  - Find and modify local hooks (all in one place)
  - Understand the overall pre-commit structure at a glance
  - Add new local hooks in the future
- Cluster-specific hooks section now clearly separated from general local hooks

https://claude.ai/code/session_01XbEB3XXTgknJixhYC32PDV