### PR TITLE
Fix Docker-dependent approval_policy tests for RBE

### DIFF
--- a/agent_server/conftest.py
+++ b/agent_server/conftest.py
@@ -103,7 +103,7 @@ async def _mount_servers(comp: Compositor, servers: McpServerSpecs) -> None:
 
 
 @pytest.fixture
-async def approval_policy_server(sqlite_persistence, async_docker_client) -> PolicyEngine:
+async def approval_policy_server(sqlite_persistence, async_docker_client, runtime_image) -> PolicyEngine:
     """PolicyEngine fixture that owns .reader, .proposer and .approver sub-servers."""
     return PolicyEngine(
         agent_id="tests",
@@ -115,7 +115,7 @@ async def approval_policy_server(sqlite_persistence, async_docker_client) -> Pol
 
 @pytest.fixture
 async def make_approval_policy_server(
-    sqlite_persistence, test_agent_id, async_docker_client
+    sqlite_persistence, test_agent_id, async_docker_client, runtime_image
 ) -> Callable[[str], Awaitable[PolicyEngine]]:
     """Factory producing PolicyEngine instances with per-test defaults."""
 
@@ -189,7 +189,7 @@ async def _create_test_policy_engine(sqlite_persistence, async_docker_client) ->
 
 
 @pytest.fixture
-async def _setup_policy_gateway_compositor(sqlite_persistence, async_docker_client, test_agent_id):
+async def _setup_policy_gateway_compositor(sqlite_persistence, async_docker_client, test_agent_id, runtime_image):
     """Fixture factory for AgentContainerCompositor with policy gateway middleware."""
 
     @asynccontextmanager

--- a/agent_server/mcp/approval_policy/BUILD.bazel
+++ b/agent_server/mcp/approval_policy/BUILD.bazel
@@ -65,6 +65,8 @@ docker_py_test(
     imports = ["../../.."],
     deps = [
         ":engine",
+        "//agent_server:conftest",
+        "//agent_server/mcp:conftest",
         "//agent_server/policies:policy_types",
         "//mcp_infra:naming",
         "//mcp_infra:prefix",

--- a/agent_server/mcp/approval_policy/test_engine.py
+++ b/agent_server/mcp/approval_policy/test_engine.py
@@ -16,7 +16,7 @@ from mcp_utils.resources import extract_single_text_content
 
 
 @pytest.fixture
-async def policy_engine(sqlite_persistence, async_docker_client) -> PolicyEngine:
+async def policy_engine(sqlite_persistence, async_docker_client, runtime_image) -> PolicyEngine:
     """PolicyEngine instance for validation tests."""
     return PolicyEngine(
         agent_id="testagent",

--- a/agent_server/policy_eval/BUILD.bazel
+++ b/agent_server/policy_eval/BUILD.bazel
@@ -7,7 +7,14 @@ py_binary(
     srcs = ["shim.py"],
     main = "shim.py",
     visibility = ["//visibility:public"],
-    deps = [":constants"],
+    deps = [
+        ":constants",
+        "//agent_server/policies:default_policy",
+        "//agent_server/policies:policy_types",
+        "//agent_server/policies:scaffold",
+        "//mcp_infra:constants",
+        "//mcp_infra:naming",
+    ],
 )
 
 py_library(

--- a/agent_server/policy_eval/runner.py
+++ b/agent_server/policy_eval/runner.py
@@ -57,7 +57,7 @@ async def run_policy_source(
     # Use dedicated policy_shim binary which has proper PYTHONPATH setup
     config: JSONObject = {
         "Image": img,
-        "Entrypoint": ["/opt/adgn/policy_shim"],
+        "Entrypoint": ["/opt/adgn/policy_eval/shim"],
         "Cmd": [],
         "AttachStdout": True,
         "AttachStderr": True,


### PR DESCRIPTION
Three issues prevented these tests from passing on BuildBuddy RBE:

1. Runtime image not loaded: test fixtures that create PolicyEngine
   instances didn't depend on the `runtime_image` session fixture,
   so the adgn-runtime:latest image was never loaded into Docker.

2. Wrong shim path: runner.py referenced /opt/adgn/policy_shim but
   pkg_tar places the binary at /opt/adgn/policy_eval/shim.

3. Missing shim deps: the policy_eval shim binary only depended on
   :constants, but exec'd policy programs import policy_types,
   scaffold, mcp_infra.constants, and mcp_infra.naming. Added these
   so they're included in the container image's runfiles.

4. Missing conftest dep: test_gateway_middleware was missing
   //agent_server:conftest and //agent_server/mcp:conftest deps,
   so fixtures like policy_gateway_client weren't discovered.

https://claude.ai/code/session_01EPaipgx8PZpfwn1AgKeiqz