### PR TITLE
Remove unused runtime_image.py and simplify OCI image entrypoint

### DIFF
--- a/agent_server/BUILD.bazel
+++ b/agent_server/BUILD.bazel
@@ -97,16 +97,9 @@ py_binary(
 
 # --- OCI Runtime Image ---
 
-py_binary(
-    name = "runtime_image",
-    srcs = ["runtime_image.py"],
-    visibility = ["//:__subpackages__"],
-)
-
 pkg_tar(
     name = "runtime_image_tar",
     srcs = [
-        ":runtime_image",
         "//agent_server/policy_eval:shim",
     ],
     include_runfiles = True,
@@ -117,7 +110,7 @@ pkg_tar(
 oci_image(
     name = "image",
     base = "@python_slim_linux_amd64",
-    entrypoint = ["/opt/adgn/runtime_image"],
+    entrypoint = ["/opt/adgn/policy_eval/shim"],
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",
         "PYTHONUNBUFFERED": "1",

--- a/agent_server/runtime_image.py
+++ b/agent_server/runtime_image.py
@@ -1,4 +1,0 @@
-"""Runtime image entry point - deps pulled in via py_binary."""
-
-if __name__ == "__main__":
-    pass  # Entry point used only to pull deps into container image


### PR DESCRIPTION
## Summary
This PR removes the unused `runtime_image.py` file and updates the OCI image configuration to use the policy evaluation shim as the direct entrypoint, eliminating an unnecessary intermediate entry point.

## Changes
- **Removed** `agent_server/runtime_image.py` - This file was only used as a placeholder to pull dependencies into the container image and is no longer needed
- **Removed** `py_binary` target for `runtime_image` from BUILD.bazel
- **Updated** `runtime_image_tar` pkg_tar target to remove the now-deleted `runtime_image` binary from sources
- **Updated** OCI image entrypoint from `/opt/adgn/runtime_image` to `/opt/adgn/policy_eval/shim`, making the policy evaluation shim the direct entry point

## Implementation Details
The policy evaluation shim now serves as the primary entry point for the container image, removing the indirection through the runtime_image wrapper. This simplifies the container structure while maintaining all necessary dependencies through the existing `//agent_server/policy_eval:shim` target.

https://claude.ai/code/session_01QSiXC7Cu9RVs9sbD9ro3JX