### PR TITLE
Remove image_ref parameter from run_prompt_optimizer

### DIFF
--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -266,7 +266,6 @@ class AgentRegistry:
         critic_model: str,
         target_metric: TargetMetric,
         timeout_seconds: int,
-        image_ref: str = BUILTIN_TAG,
     ) -> UUID:
         """Run a prompt optimizer agent. Returns agent run ID (query DB for status)."""
         # Get train snapshots from database
@@ -280,10 +279,10 @@ class AgentRegistry:
         agent_run_id = uuid4()
         logger.info(f"Prompt optimizer agent_run_id: {agent_run_id}")
 
-        # Resolve image reference to digest and construct full OCI reference
-        image_digest = self._resolve_image_ref(AgentType.PROMPT_OPTIMIZER, image_ref)
+        # Resolve builtin prompt-optimizer image to digest
+        image_digest = self._resolve_image_ref(AgentType.PROMPT_OPTIMIZER, BUILTIN_TAG)
         image = self._registry_config.build_oci_reference(AgentType.PROMPT_OPTIMIZER, image_digest)
-        logger.info(f"Resolved prompt-optimizer image {image_ref} → {image}")
+        logger.info(f"Resolved prompt-optimizer image {BUILTIN_TAG} → {image}")
 
         # Phase 1: Write initial AgentRun to DB (BEFORE agent runs - FK constraint!)
         with get_session() as session:


### PR DESCRIPTION
## Summary
Removed the `image_ref` parameter from the `run_prompt_optimizer` method and hardcoded the use of `BUILTIN_TAG` instead. This simplifies the API by removing unnecessary flexibility for this specific agent type.

## Changes
- Removed `image_ref: str = BUILTIN_TAG` parameter from `run_prompt_optimizer()` method signature
- Updated image resolution logic to directly use `BUILTIN_TAG` instead of the parameter
- Updated corresponding log message to reference `BUILTIN_TAG` directly
- Updated code comment to clarify that the builtin prompt-optimizer image is being resolved

## Rationale
The prompt optimizer agent should always use the builtin image tag. Removing the parameter simplifies the API surface and prevents callers from accidentally specifying a custom image reference for this agent type, ensuring consistent behavior.

https://claude.ai/code/session_014aXdYkabgRZz8dyHYSZmiu