### PR TITLE
Fix CI fromJson error on empty compute-targets output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-build')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'bazel-build')
     uses: ./.github/workflows/bazel-build.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
@@ -103,7 +103,7 @@ jobs:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-test')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'bazel-test')
     uses: ./.github/workflows/bazel-test.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
@@ -113,7 +113,7 @@ jobs:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-lint')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'bazel-lint')
     uses: ./.github/workflows/bazel-lint.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
@@ -123,7 +123,7 @@ jobs:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-typecheck')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'bazel-typecheck')
     uses: ./.github/workflows/bazel-typecheck.yml
     with:
       targets: ${{ needs.compute-targets.outputs.targets }}
@@ -133,33 +133,33 @@ jobs:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'bazel-rust-lint')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'bazel-rust-lint')
     uses: ./.github/workflows/bazel-rust-lint.yml
     with:
       rbe_image: ${{ needs.rbe-image.outputs.rbe_image }}
     secrets: inherit
   rbe-image:
     needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'rbe-image')
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'rbe-image')
     uses: ./.github/workflows/rbe-image.yml
   props-cli-image:
     needs:
       - compute-targets
       - rbe-image
-    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows), 'props-cli-image')
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'props-cli-image')
     uses: ./.github/workflows/props-cli-image.yml
     with:
       rbe_image: ${{ needs.rbe-image.outputs.rbe_image }}
     secrets: inherit
   nix-flake-check:
     needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'nix-flake-check')
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'nix-flake-check')
     uses: ./.github/workflows/nix-flake-check.yml
   ansible-lint:
     needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'ansible-lint')
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'ansible-lint')
     uses: ./.github/workflows/ansible-lint.yml
   pre-commit:
     needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows), 'pre-commit')
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'pre-commit')
     uses: ./.github/workflows/pre-commit.yml

--- a/tools/ci/generate_ci_lib.py
+++ b/tools/ci/generate_ci_lib.py
@@ -136,7 +136,7 @@ def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: 
         with_args.update(config.inputs)
 
     needs: str | list[str] = "compute-targets"
-    if_cond = f"contains(fromJson(needs.compute-targets.outputs.workflows), '{name}')"
+    if_cond = f"contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), '{name}')"
 
     # Bazel workflows that use RBE should wait for the rbe-image job (when
     # it exists) and forward the built image reference. The job may be skipped
@@ -145,7 +145,7 @@ def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: 
         needs = ["compute-targets", RBE_IMAGE_JOB]
         if_cond = (
             f"always() && !cancelled() && !failure() "
-            f"&& contains(fromJson(needs.compute-targets.outputs.workflows), '{name}')"
+            f"&& contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), '{name}')"
         )
         with_args["rbe_image"] = f"${{{{ needs.{RBE_IMAGE_JOB}.outputs.rbe_image }}}}"
 


### PR DESCRIPTION
When compute-targets job fails before writing outputs, downstream jobs
with `always()` conditions still evaluate `fromJson("")` which errors
with "empty input". Add `|| '[]'` fallback so an empty/unset output
defaults to an empty JSON array.

https://claude.ai/code/session_015hUhipZPym858EbntzaqTb