### PR TITLE
Switch from LLVM to BuildBuddy GCC toolchain for RBE

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,16 +158,13 @@ platform(
 
 platform(
     name = "rbe_linux_x64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
     exec_properties = {
-        "OSFamily": "linux",
-        # Custom image with git, ca-certificates, and podman for e2e tests.
-        # Built by .github/workflows/rbe-image.yml → ghcr.io/agentydragon/rbe-worker
+        # Custom image layered on BuildBuddy's rbe-ubuntu24-04 with git,
+        # ca-certificates, and podman for e2e tests.
+        # Built by .github/workflows/rbe-image.yml
         "container-image": "docker://ghcr.io/agentydragon/rbe-worker:latest",
     },
+    parents = ["@buildbuddy_toolchain//:platform_linux_x86_64"],
 )
 
 # Ducktape wheel - bundles CLI tools for distribution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -199,12 +199,19 @@ use_repo(types, "pip_types")
 uv = use_extension("@rules_python//python/uv:uv.bzl", "uv")
 uv.configure(version = "0.6.2")
 
-# Hermetic CC toolchain (LLVM/Clang) — prevents Nix store paths from leaking into RBE actions.
-# toolchains_buildbuddy was evaluated but doesn't work here for two reasons:
-# 1. Its CC toolchain requires @bazel_tools//tools/cpp:gcc in exec_compatible_with,
-#    which neither the host platform nor //:rbe_linux_x64 declares.
-# 2. Even if the RBE platform added that constraint, Cargo build scripts and other
-#    exec-config tools resolve CC against the host platform, which still wouldn't match.
+# BuildBuddy platform definitions — our //:rbe_linux_x64 inherits from these
+# since our RBE worker image is based on BuildBuddy's rbe-ubuntu24-04.
+bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4")
+
+buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
+buildbuddy.platform(buildbuddy_container_image = "UBUNTU24_04_IMAGE")
+buildbuddy.gcc_toolchain(gcc_major_version = "13")
+use_repo(buildbuddy, "buildbuddy_toolchain")
+
+# Hermetic CC toolchain (LLVM/Clang) — prevents Nix store paths from leaking into
+# actions. toolchains_buildbuddy's GCC toolchain requires @bazel_tools//tools/cpp:gcc
+# in exec_compatible_with, which the host platform doesn't declare — so exec-config
+# tools (Cargo build scripts, etc.) can't resolve CC. LLVM works everywhere.
 bazel_dep(name = "toolchains_llvm", version = "1.6.0")
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -199,7 +199,12 @@ use_repo(types, "pip_types")
 uv = use_extension("@rules_python//python/uv:uv.bzl", "uv")
 uv.configure(version = "0.6.2")
 
-# Hermetic CC toolchain (LLVM/Clang) — prevents Nix store paths from leaking into RBE actions
+# Hermetic CC toolchain (LLVM/Clang) — prevents Nix store paths from leaking into RBE actions.
+# toolchains_buildbuddy was evaluated but doesn't work here for two reasons:
+# 1. Its CC toolchain requires @bazel_tools//tools/cpp:gcc in exec_compatible_with,
+#    which neither the host platform nor //:rbe_linux_x64 declares.
+# 2. Even if the RBE platform added that constraint, Cargo build scripts and other
+#    exec-config tools resolve CC against the host platform, which still wouldn't match.
 bazel_dep(name = "toolchains_llvm", version = "1.6.0")
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -208,20 +208,12 @@ buildbuddy.platform(buildbuddy_container_image = "UBUNTU24_04_IMAGE")
 buildbuddy.gcc_toolchain(gcc_major_version = "13")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
-# Hermetic CC toolchain (LLVM/Clang) — prevents Nix store paths from leaking into
-# actions. toolchains_buildbuddy's GCC toolchain requires @bazel_tools//tools/cpp:gcc
-# in exec_compatible_with, which the host platform doesn't declare — so exec-config
-# tools (Cargo build scripts, etc.) can't resolve CC. LLVM works everywhere.
-bazel_dep(name = "toolchains_llvm", version = "1.6.0")
-
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
-llvm.toolchain(
-    name = "llvm_toolchain",
-    llvm_version = "19.1.4",
-)
-use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
-
-register_toolchains("@llvm_toolchain//:all")
+# BuildBuddy CC toolchain — uses GCC pre-installed in the RBE container, avoiding the
+# ~500 MB LLVM toolchain download. The toolchain's exec_compatible_with includes
+# @bazel_tools//tools/cpp:gcc, which only //:rbe_linux_x64 satisfies (via parent
+# inheritance), so all CC actions are routed to RBE — including Cargo build scripts.
+# BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 in .bazelrc prevents host CC auto-detection.
+register_toolchains("@buildbuddy_toolchain//:ubuntu_cc_toolchain")
 
 # Rust rules
 bazel_dep(name = "rules_rust", version = "0.68.1")  # upgraded from 0.61.0 to fix bzlmod ctve repo naming

--- a/tools/setup-buildbuddy.sh
+++ b/tools/setup-buildbuddy.sh
@@ -37,6 +37,7 @@ build --remote_executor=grpcs://remote.buildbuddy.io
 build --extra_execution_platforms=//:rbe_linux_x64
 build --spawn_strategy=remote,local
 build --jobs=50
+build --remote_download_minimal
 EOF
 
 # Override the RBE container image if RBE_IMAGE is set (used by CI when


### PR DESCRIPTION
## Summary
This PR replaces the hermetic LLVM/Clang toolchain with BuildBuddy's GCC toolchain to reduce build overhead and simplify RBE configuration. The custom RBE platform now inherits from BuildBuddy's base platform definitions, leveraging the GCC compiler pre-installed in the RBE container.

## Key Changes

- **MODULE.bazel**: Replaced `toolchains_llvm` dependency with `toolchains_buildbuddy` (v0.0.4)
  - Removed LLVM 19.1.4 toolchain configuration
  - Added BuildBuddy platform and GCC 13 toolchain setup
  - Registered BuildBuddy's `ubuntu_cc_toolchain` instead of LLVM toolchain

- **BUILD.bazel**: Refactored `//:rbe_linux_x64` platform
  - Removed explicit `constraint_values` (now inherited via `parents`)
  - Added `parents = ["@buildbuddy_toolchain//:platform_linux_x86_64"]` to inherit base platform
  - Updated `exec_properties` comment to clarify the image is layered on BuildBuddy's rbe-ubuntu24-04

- **tools/setup-buildbuddy.sh**: Added `--remote_download_minimal` flag to reduce bandwidth usage during remote builds

## Implementation Details

The BuildBuddy GCC toolchain is configured with `exec_compatible_with` constraints that only match `//:rbe_linux_x64` (via parent inheritance), ensuring all C++ actions—including Cargo build scripts—are routed to RBE. The `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1` setting in `.bazelrc` prevents host toolchain auto-detection.

This approach eliminates the ~500 MB LLVM toolchain download while maintaining hermetic builds by using the pre-installed GCC in the RBE container.

https://claude.ai/code/session_01CVd7iTjEm9CmvytYQui1tT