### PR TITLE
Allow host CC toolchain detection in CI environments

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,8 @@
 common --enable_bzlmod
 
-# Use hermetic LLVM CC toolchain instead of auto-detected host toolchain.
-# Prevents Nix store paths from leaking into RBE actions.
+# Disable host CC auto-detection to prevent Nix store paths leaking into builds.
+# CI overrides this to 0 (in .github/actions/bazel-repo-cache) to use the GHA
+# runner's system GCC. The BuildBuddy GCC toolchain handles RBE independently.
 build --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 # Disable MODULE.bazel.lock to avoid churn between environments.

--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -23,6 +23,16 @@ runs:
     - name: Setup Bazelisk
       uses: bazelbuild/setup-bazelisk@v3
 
+    - name: Enable host CC toolchain detection
+      shell: bash
+      run: |
+        # The workspace .bazelrc sets BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 to
+        # prevent Nix store paths leaking into builds. GHA runners use standard
+        # Ubuntu with system GCC (13/14), so we override to allow detection.
+        echo "" >> ~/.bazelrc
+        echo "# CI: allow Bazel to detect system GCC on GHA runners" >> ~/.bazelrc
+        echo "build --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0" >> ~/.bazelrc
+
     - name: Derive cache key
       id: cache-key
       shell: bash

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -211,8 +211,9 @@ use_repo(buildbuddy, "buildbuddy_toolchain")
 # BuildBuddy CC toolchain — uses GCC pre-installed in the RBE container, avoiding the
 # ~500 MB LLVM toolchain download. The toolchain's exec_compatible_with includes
 # @bazel_tools//tools/cpp:gcc, which only //:rbe_linux_x64 satisfies (via parent
-# inheritance), so all CC actions are routed to RBE — including Cargo build scripts.
-# BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 in .bazelrc prevents host CC auto-detection.
+# inheritance), so CC actions targeting RBE use this toolchain.
+# .bazelrc sets BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 to block host auto-detection on
+# Nix; CI overrides this to 0 in bazel-repo-cache to use the GHA runner's system GCC.
 register_toolchains("@buildbuddy_toolchain//:ubuntu_cc_toolchain")
 
 # Rust rules


### PR DESCRIPTION
## Summary
This PR updates the Bazel configuration to allow host C++ toolchain detection in CI environments while maintaining the existing Nix store path isolation for local development.

## Changes
- **`.bazelrc`**: Updated comments to clarify that `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1` is the default to prevent Nix store paths from leaking into builds, and that CI overrides this setting.
- **`.github/actions/bazel-repo-cache/action.yml`**: Added a new step that overrides the toolchain detection setting to `0` in CI, allowing GitHub Actions runners to use their system GCC (versions 13/14) instead of relying solely on the BuildBuddy RBE container's toolchain.
- **`MODULE.bazel`**: Clarified comments explaining the BuildBuddy CC toolchain behavior and the relationship between the workspace `.bazelrc` setting and CI overrides.

## Implementation Details
The BuildBuddy GCC toolchain handles RBE independently through its `exec_compatible_with` constraints, so enabling host CC detection in CI doesn't interfere with RBE routing. This approach:
- Maintains Nix store path isolation in local development environments
- Leverages standard Ubuntu system GCC on GitHub Actions runners
- Reduces reliance on the ~500 MB LLVM toolchain download
- Keeps the BuildBuddy toolchain as the primary mechanism for RBE CC actions

https://claude.ai/code/session_01VKu1Hjo5ZeLzC7pPUU6T5Q