### PR TITLE
Add --remote_download_toplevel flag to Bazel build commands

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -159,7 +159,7 @@ jobs:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build wheel
-        run: bazel build //tools/claude_hooks:wheel
+        run: bazel build --remote_download_toplevel //tools/claude_hooks:wheel
 
       - name: Install wheel
         run: uv tool install bazel-bin/tools/claude_hooks/claude_hooks-*.whl
@@ -213,7 +213,7 @@ jobs:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build wheel
-        run: bazel build //tools/claude_hooks:wheel
+        run: bazel build --remote_download_toplevel //tools/claude_hooks:wheel
 
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV

--- a/.github/workflows/python-wheel-release.yml
+++ b/.github/workflows/python-wheel-release.yml
@@ -77,7 +77,7 @@ jobs:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
 
       - name: Build wheel
-        run: bazel build ${{ inputs.bazel_target }}
+        run: bazel build --remote_download_toplevel ${{ inputs.bazel_target }}
 
       - name: Prepare wheel
         run: |


### PR DESCRIPTION
## Summary
This PR adds the `--remote_download_toplevel` flag to Bazel build commands in the release workflows to optimize remote build caching and reduce unnecessary downloads.

## Changes
- Added `--remote_download_toplevel` flag to the `bazel build` command in `claude-hooks-release.yml` (2 occurrences)
- Added `--remote_download_toplevel` flag to the `bazel build` command in `python-wheel-release.yml`

## Details
The `--remote_download_toplevel` flag instructs Bazel to only download the top-level build outputs from remote caches rather than downloading all intermediate artifacts. This optimization:
- Reduces bandwidth usage during CI/CD builds
- Speeds up the build process by avoiding unnecessary downloads
- Maintains the same final output while improving efficiency

This change applies to both the Claude hooks release workflow and the Python wheel release workflow.

https://claude.ai/code/session_01H9W66ToovNaER3EseMTXim