### PR TITLE
Exclude puppeteer from npm lifecycle hooks in Bazel builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,10 +119,19 @@ npm.npm_translate_lock(
         "//:pnpm-workspace.yaml",
         "//:props/frontend/package.json",
     ],
-    # Disable postinstall for unrs-resolver - it tries to download native bindings from npm registry
-    # which fails in Bazel's sandboxed build (network blocked). Safe to skip since @storybook/test-runner
-    # (the only consumer via jest-resolve) isn't executed during bazel build - only used for manual testing.
-    lifecycle_hooks_exclude = ["unrs-resolver"],
+    # Disable postinstall for packages that download binaries during lifecycle hooks.
+    # These fail in Bazel's sandboxed builds (network blocked, gVisor, RBE).
+    lifecycle_hooks_exclude = [
+        # Tries to download native bindings from npm registry. Safe to skip since
+        # @storybook/test-runner (the only consumer via jest-resolve) isn't executed
+        # during bazel build - only used for manual testing.
+        "unrs-resolver",
+        # Postinstall downloads Chromium (~280MB) which fails in sandboxed builds.
+        # .puppeteerrc.cjs (skipDownload: true) isn't visible inside the lifecycle
+        # hook sandbox. Browsers are provided hermetically via rules_playwright
+        # (@playwright_browsers//:chromium-headless-shell) and PUPPETEER_EXECUTABLE_PATH.
+        "puppeteer",
+    ],
     npmrc = "@@//:.npmrc",
     # Root pnpm-lock.yaml with workspace packages
     pnpm_lock = "//:pnpm-lock.yaml",


### PR DESCRIPTION
## Summary
Extended the `lifecycle_hooks_exclude` configuration in MODULE.bazel to prevent puppeteer from executing its postinstall script during Bazel builds, which was failing due to network restrictions in sandboxed environments.

## Changes
- Added `puppeteer` to the `lifecycle_hooks_exclude` list alongside the existing `unrs-resolver` entry
- Improved documentation by converting the single-line comment into a multi-line explanation that covers both excluded packages
- Added detailed rationale for excluding puppeteer: its postinstall script attempts to download Chromium (~280MB), which fails in sandboxed builds since `.puppeteerrc.cjs` configuration is not visible within the lifecycle hook sandbox
- Documented that browsers are provided hermetically via `rules_playwright` and the `PUPPETEER_EXECUTABLE_PATH` environment variable

## Implementation Details
The puppeteer exclusion is safe because:
- Chromium binaries are provided through the hermetic `@playwright_browsers//:chromium-headless-shell` target
- The `PUPPETEER_EXECUTABLE_PATH` environment variable directs puppeteer to use the pre-built browser
- The package's postinstall script is not needed during the Bazel build process

https://claude.ai/code/session_01YQbcMXVyaDCuRTbHdhdRFi