### PR TITLE
Implement agent credential passthrough for RLS-based access control

### DIFF
--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//tools/testing:docker.bzl", "docker_py_test")
 
 # NOTE: No aggregator target - use specific per-file targets
 # This is the Gazelle-compatible pattern (python_generation_mode = file)
@@ -108,6 +109,26 @@ py_test(
         "//props/db:database",
         "@pypi//fastapi",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+docker_py_test(
+    name = "test_agent_db_integration",
+    srcs = ["test_agent_db_integration.py"],
+    imports = ["../.."],
+    deps = [
+        ":auth",
+        "//props:conftest",
+        "//props/core:agent_types",
+        "//props/db:database",
+        "//props/db:examples",
+        "//props/db:models",
+        "//props/orchestration:agent_credentials",
+        "//props/testing/fixtures:runs",
+        "@pypi//asyncpg",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",  # keep
         "@pypi//pytest_bazel",
     ],
 )

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
 
 # NOTE: No aggregator target - use specific per-file targets
@@ -91,6 +91,24 @@ py_library(
         ":app",
         "//props:config",
         "//props/core:oci_utils",
+    ],
+)
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+py_test(
+    name = "test_auth",
+    srcs = ["test_auth.py"],
+    imports = ["../.."],
+    deps = [
+        ":auth",
+        "//props/db:config",
+        "//props/db:database",
+        "@pypi//fastapi",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -96,6 +96,19 @@ py_library(
 )
 
 # =============================================================================
+# Test support
+# =============================================================================
+
+py_library(
+    name = "conftest",
+    testonly = True,
+    srcs = ["conftest.py"],
+    imports = ["../.."],
+    visibility = ["//props:__subpackages__"],
+    deps = ["@pypi//pytest"],
+)
+
+# =============================================================================
 # Tests
 # =============================================================================
 
@@ -105,6 +118,7 @@ py_test(
     imports = ["../.."],
     deps = [
         ":auth",
+        ":conftest",
         "//props/db:config",
         "//props/db:database",
         "@pypi//fastapi",
@@ -119,12 +133,14 @@ docker_py_test(
     imports = ["../.."],
     deps = [
         ":auth",
+        ":conftest",
         "//props:conftest",
         "//props/core:agent_types",
         "//props/db:database",
         "//props/db:examples",
         "//props/db:models",
         "//props/orchestration:agent_credentials",
+        "//props/testing/fixtures:credentials",
         "//props/testing/fixtures:runs",
         "@pypi//asyncpg",
         "@pypi//pytest",

--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -13,6 +13,7 @@ status check that containers can poll.
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
 import traceback
@@ -55,6 +56,8 @@ class BackendDeps:
     config: PropsConfig
     registry_proxy_config: RegistryProxyConfig
     grader_model: str | None = None
+    host: str = "127.0.0.1"
+    port: int = 8000
 
 
 def _make_lifespan(deps: BackendDeps):
@@ -85,6 +88,10 @@ def _make_lifespan(deps: BackendDeps):
             app.state.grader_supervisor = None
             logger.info(f"Daemon manager disabled ({ENV_GRADER_MODEL} not set)")
 
+        admin_token = base64.b64encode(f"{db_config.user}:{db_config.password}".encode()).decode()
+        protocol = "https" if deps.port == 443 else "http"
+        logger.info(f"Admin token: {admin_token}")
+        logger.info(f"Admin URL: {protocol}://{deps.host}:{deps.port}/?token={admin_token}")
         logger.info("Props backend ready")
         yield
 
@@ -140,9 +147,11 @@ def create_app(*, deps: BackendDeps, static_dir: Path | None = None) -> FastAPI:
     return app
 
 
-def default_deps() -> BackendDeps:
+def default_deps(host: str = "127.0.0.1", port: int = 8000) -> BackendDeps:
     return BackendDeps(
         config=load_config_from_env(),
         registry_proxy_config=get_registry_proxy_config(),
         grader_model=os.environ.get(ENV_GRADER_MODEL),
+        host=host,
+        port=port,
     )

--- a/props/backend/auth.py
+++ b/props/backend/auth.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Annotated
@@ -283,3 +284,40 @@ def require_admin_access(auth: Auth, admin_db: AdminDb) -> None:
     caller_type, _ = get_caller_type(auth, admin_db)
     if caller_type != CallerType.ADMIN:
         raise HTTPException(status_code=403, detail="Admin access required")
+
+
+# =============================================================================
+# Agent credential passthrough
+# =============================================================================
+
+
+def get_agent_db(admin_db: AdminDb, auth: Auth) -> Iterator[Database]:
+    """Get Database using agent credentials for RLS enforcement.
+
+    For agent callers: Creates per-request Database with agent's Postgres
+    credentials. RLS policies automatically enforce access control.
+    For admin callers: Returns the shared admin Database instance.
+    For anonymous: Raises 401.
+
+    Yields the Database and disposes per-request agent connections on cleanup.
+    """
+    if not auth.is_authenticated:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    if auth.is_admin:
+        yield admin_db
+        return
+
+    if not auth.username or not auth.password:
+        raise HTTPException(status_code=500, detail="Agent auth missing credentials")
+
+    agent_config = admin_db.config.with_user(auth.username, auth.password)
+    agent_db = Database(agent_config, _per_request=True)
+    try:
+        yield agent_db
+    finally:
+        agent_db.dispose()
+
+
+# Type alias for agent database dependency (use in route signatures where RLS applies)
+AgentDb = Annotated[Database, Depends(get_agent_db)]

--- a/props/backend/auth.py
+++ b/props/backend/auth.py
@@ -312,7 +312,7 @@ def get_agent_db(admin_db: AdminDb, auth: Auth) -> Iterator[Database]:
         raise HTTPException(status_code=500, detail="Agent auth missing credentials")
 
     agent_config = admin_db.config.with_user(auth.username, auth.password)
-    agent_db = Database(agent_config, _per_request=True)
+    agent_db = Database.per_request(agent_config)
     try:
         yield agent_db
     finally:

--- a/props/backend/auth.py
+++ b/props/backend/auth.py
@@ -3,7 +3,6 @@
 Authentication uses Bearer or Basic tokens with Postgres credentials validation:
 - Admin users: Any valid Postgres user (non-agent_* username)
 - Agent users: Format agent_{uuid} with temp credentials
-- Localhost admin: Empty/no creds from localhost = admin (for local dev and dashboard)
 
 Tokens contain base64-encoded username:password. Both schemes are supported:
 - Bearer: OpenAI SDK sends api_key as Bearer token; agent containers encode creds this way
@@ -21,7 +20,6 @@ from __future__ import annotations
 
 import base64
 import logging
-import os
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import StrEnum
@@ -38,18 +36,11 @@ from props.db.models import AgentRun, AgentType
 
 logger = logging.getLogger(__name__)
 
-# Localhost admin access - allow empty creds from localhost to act as admin
-# This is useful for local development and dashboard/backend access
-ALLOW_LOCALHOST_ADMIN = os.environ.get("PROPS_ALLOW_LOCALHOST_ADMIN", "true").lower() == "true"
-
-# Trusted localhost addresses
-LOCALHOST_ADDRESSES = {"127.0.0.1", "localhost", "::1"}
-
 
 class AccessLevel(StrEnum):
     """Access level for authenticated users."""
 
-    ADMIN = "admin"  # Full access (postgres user or localhost)
+    ADMIN = "admin"  # Full access (postgres user)
     AGENT = "agent"  # Agent access (agent_{uuid} pattern)
 
 
@@ -170,18 +161,12 @@ def parse_credentials(authorization: str | None) -> tuple[str, str] | None:
         return None
 
 
-def is_localhost_request(request: Request) -> bool:
-    client = request.client
-    return bool(client and client.host in LOCALHOST_ADDRESSES)
-
-
 @dataclass
 class AuthContext:
     """Authentication context resolved per-request by the get_auth_context dependency."""
 
     is_authenticated: bool = False
     is_admin: bool = False
-    is_localhost_admin: bool = False
     username: str | None = None
     password: str | None = None
     agent_run_id: UUID | None = None
@@ -189,10 +174,6 @@ class AuthContext:
     @classmethod
     def anonymous(cls) -> AuthContext:
         return cls(is_authenticated=False)
-
-    @classmethod
-    def localhost_admin(cls) -> AuthContext:
-        return cls(is_authenticated=True, is_admin=True, is_localhost_admin=True)
 
     @classmethod
     def admin(cls, username: str, password: str) -> AuthContext:
@@ -216,9 +197,6 @@ def get_auth_context(request: Request, admin_db: AdminDb) -> AuthContext:
     authorization = request.headers.get("authorization")
 
     if not authorization:
-        if ALLOW_LOCALHOST_ADMIN and is_localhost_request(request):
-            logger.debug("Localhost admin access granted (no auth required)")
-            return AuthContext.localhost_admin()
         return AuthContext.anonymous()
 
     parsed = parse_credentials(authorization)

--- a/props/backend/cli.py
+++ b/props/backend/cli.py
@@ -28,7 +28,8 @@ def serve(
     if static_dir:
         os.environ["PROPS_DASHBOARD_STATIC_DIR"] = str(static_dir.absolute())
 
-    app = create_app(deps=default_deps(), static_dir=static_dir)
+    deps = default_deps(host=host, port=port)
+    app = create_app(deps=deps, static_dir=static_dir)
     uvicorn.run(app, host=host, port=port, reload=reload, reload_dirs=reload_dir)
 
 

--- a/props/backend/conftest.py
+++ b/props/backend/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for props.backend tests."""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+
+@pytest.fixture
+def exhaust_generator():
+    """Exhaust a FastAPI dependency generator, returning the yielded value."""
+
+    def _exhaust(gen):
+        value = next(gen)
+        with contextlib.suppress(StopIteration):
+            next(gen)
+        return value
+
+    return _exhaust

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -7,7 +7,6 @@ py_library(
     visibility = ["//props/backend:__subpackages__"],
     deps = [
         "//props/backend:auth",
-        "//props/backend:deps",
         "//props/core:agent_types",
         "//props/db:models",
         "@pypi//fastapi",
@@ -114,7 +113,6 @@ py_library(
     visibility = ["//props/backend:__subpackages__"],
     deps = [
         "//props/backend:auth",
-        "//props/backend:deps",
         "//props/core:agent_types",
         "//props/core:ids",
         "//props/core:splits",

--- a/props/backend/routes/agent_definitions.py
+++ b/props/backend/routes/agent_definitions.py
@@ -1,21 +1,21 @@
 """Agent definitions API routes.
 
-All endpoints require admin access (localhost admin or authenticated admin user).
+Endpoints use agent credential passthrough - RLS policies filter results
+based on the caller's database role.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from pydantic import BaseModel
 
-from props.backend.auth import require_admin_access
-from props.backend.deps import AdminDb
+from props.backend.auth import AgentDb
 from props.core.agent_types import AgentType
 from props.db.models import AgentDefinition
 
-router = APIRouter(dependencies=[Depends(require_admin_access)])
+router = APIRouter()
 
 
 class DefinitionInfo(BaseModel):
@@ -29,9 +29,9 @@ class DefinitionsResponse(BaseModel):
 
 
 @router.get("")
-def list_definitions(admin_db: AdminDb, agent_type: AgentType | None = None) -> DefinitionsResponse:
+def list_definitions(db: AgentDb, agent_type: AgentType | None = None) -> DefinitionsResponse:
     """List all agent definitions, optionally filtered by type."""
-    with admin_db.session() as session:
+    with db.session() as session:
         query = session.query(AgentDefinition)
         if agent_type:
             query = query.filter_by(agent_type=agent_type)

--- a/props/backend/routes/agent_definitions.py
+++ b/props/backend/routes/agent_definitions.py
@@ -29,9 +29,9 @@ class DefinitionsResponse(BaseModel):
 
 
 @router.get("")
-def list_definitions(db: AgentDb, agent_type: AgentType | None = None) -> DefinitionsResponse:
+def list_definitions(agent_db: AgentDb, agent_type: AgentType | None = None) -> DefinitionsResponse:
     """List all agent definitions, optionally filtered by type."""
-    with db.session() as session:
+    with agent_db.session() as session:
         query = session.query(AgentDefinition)
         if agent_type:
             query = query.filter_by(agent_type=agent_type)

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
-from props.backend.auth import AgentDb, require_admin_access
+from props.backend.auth import AgentDb, parse_credentials, require_admin_access, validate_postgres_credentials
 from props.backend.deps import AdminDb
 from props.backend.routes.ground_truth import FileLocationInfo
 from props.core.agent_types import AgentType, CriticTypeConfig, TypeConfig
@@ -791,10 +791,27 @@ async def runs_feed(websocket: WebSocket) -> None:
     """WebSocket endpoint for live runs/jobs feed.
 
     Sends initial state then streams updates when runs or jobs change.
+    Requires admin token as ?token= query parameter.
     """
+    db: Database = websocket.app.state.admin_db
+
+    # Validate token from query parameter
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return
+    parsed = parse_credentials(f"Bearer {token}")
+    if not parsed:
+        await websocket.close(code=4001, reason="Invalid token")
+        return
+    username, password = parsed
+    result = validate_postgres_credentials(username, password, db.config)
+    if not result.is_valid:
+        await websocket.close(code=4001, reason="Invalid credentials")
+        return
+
     await websocket.accept()
     _feed_connections.add(websocket)
-    db: Database = websocket.app.state.admin_db
 
     try:
         # Send initial state

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -1,6 +1,8 @@
 """Runs API routes for triggering and monitoring agent runs.
 
-All endpoints require admin access (localhost admin or authenticated admin user).
+Read endpoints use agent credential passthrough - RLS policies filter results
+based on the caller's database role. Write endpoints (validation triggers)
+require admin access.
 """
 
 from __future__ import annotations
@@ -18,7 +20,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
-from props.backend.auth import require_admin_access
+from props.backend.auth import AgentDb, require_admin_access
 from props.backend.deps import AdminDb
 from props.backend.routes.ground_truth import FileLocationInfo
 from props.core.agent_types import AgentType, CriticTypeConfig, TypeConfig
@@ -39,7 +41,7 @@ from props.db.models import (
 )
 from props.orchestration.agent_registry import AgentRegistry
 
-router = APIRouter(dependencies=[Depends(require_admin_access)])
+router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
@@ -308,15 +310,13 @@ def edges_to_info(edges: list[GradingEdge]) -> list[GradingEdgeInfo]:
 
 
 @router.get("/active")
-def list_active_runs(request: Request, admin_db: AdminDb) -> ActiveRunsResponse:
+def list_active_runs(request: Request, db: AgentDb) -> ActiveRunsResponse:
     """List all active agent runs.
 
     Queries database for runs with IN_PROGRESS status.
-    In the new in-container architecture, agents run independently and
-    status is tracked only in the database.
+    RLS policies filter visible runs based on caller's database role.
     """
-    # Query database for IN_PROGRESS runs
-    with admin_db.session() as session:
+    with db.session() as session:
         db_runs = (
             session.query(AgentRun)
             .filter(AgentRun.status == AgentRunStatus.IN_PROGRESS)
@@ -338,7 +338,7 @@ def list_active_runs(request: Request, admin_db: AdminDb) -> ActiveRunsResponse:
     return ActiveRunsResponse(runs=result)
 
 
-@router.get("/jobs")
+@router.get("/jobs", dependencies=[Depends(require_admin_access)])
 def list_jobs() -> JobsResponse:
     """List all validation jobs."""
     # JobInfo is a subset of ValidationJob fields - use model_validate for clarity
@@ -347,7 +347,7 @@ def list_jobs() -> JobsResponse:
 
 @router.get("")
 def list_runs(
-    admin_db: AdminDb,
+    db: AgentDb,
     status: AgentRunStatus | None = None,
     image_digest: str | None = None,
     agent_type: AgentType | None = None,
@@ -358,18 +358,11 @@ def list_runs(
 ) -> RunsListResponse:
     """List all agent runs with optional filters and pagination.
 
-    Query parameters:
-    - status: Filter by run status
-    - image_digest: Filter by image digest
-    - agent_type: Filter by agent type (critic, grader, etc.)
-    - split: Filter by data split (train, valid, test)
-    - example_kind: Filter by example kind (whole_snapshot, file_set)
-    - offset: Pagination offset (default: 0)
-    - limit: Pagination limit (default: 100, max: 500)
+    RLS policies filter visible runs based on caller's database role.
     """
     limit = min(limit, 500)  # Cap at 500
 
-    with admin_db.session() as session:
+    with db.session() as session:
         query = session.query(AgentRun)
 
         if status:
@@ -416,7 +409,7 @@ def list_runs(
         )
 
 
-@router.post("/validation")
+@router.post("/validation", dependencies=[Depends(require_admin_access)])
 async def trigger_validation_runs(
     request: Request, body: ValidationRunRequest, admin_db: AdminDb
 ) -> ValidationRunResponse:
@@ -531,9 +524,9 @@ async def _run_validation_batch(job: ValidationJob, registry: AgentRegistry, db:
 
 
 @router.get("/{run_id}")
-def get_run(run_id: UUID, admin_db: AdminDb) -> AgentRunDetail:
-    """Get details of a specific agent run."""
-    with admin_db.session() as session:
+def get_run(run_id: UUID, db: AgentDb) -> AgentRunDetail:
+    """Get details of a specific agent run. RLS enforces access."""
+    with db.session() as session:
         run = session.get(AgentRun, run_id)
         if run is None:
             raise HTTPException(status_code=404, detail=f"Agent run {run_id} not found")
@@ -711,9 +704,9 @@ def get_run(run_id: UUID, admin_db: AdminDb) -> AgentRunDetail:
 
 
 @router.get("/{run_id}/llm_requests")
-def get_run_llm_requests(run_id: UUID, admin_db: AdminDb) -> LLMRequestsResponse:
-    """Get LLM requests for a specific agent run."""
-    with admin_db.session() as session:
+def get_run_llm_requests(run_id: UUID, db: AgentDb) -> LLMRequestsResponse:
+    """Get LLM requests for a specific agent run. RLS filters visible requests."""
+    with db.session() as session:
         run = session.get(AgentRun, run_id)
         if run is None:
             raise HTTPException(status_code=404, detail=f"Agent run {run_id} not found")

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -310,13 +310,13 @@ def edges_to_info(edges: list[GradingEdge]) -> list[GradingEdgeInfo]:
 
 
 @router.get("/active")
-def list_active_runs(request: Request, db: AgentDb) -> ActiveRunsResponse:
+def list_active_runs(request: Request, agent_db: AgentDb) -> ActiveRunsResponse:
     """List all active agent runs.
 
     Queries database for runs with IN_PROGRESS status.
     RLS policies filter visible runs based on caller's database role.
     """
-    with db.session() as session:
+    with agent_db.session() as session:
         db_runs = (
             session.query(AgentRun)
             .filter(AgentRun.status == AgentRunStatus.IN_PROGRESS)
@@ -347,7 +347,7 @@ def list_jobs() -> JobsResponse:
 
 @router.get("")
 def list_runs(
-    db: AgentDb,
+    agent_db: AgentDb,
     status: AgentRunStatus | None = None,
     image_digest: str | None = None,
     agent_type: AgentType | None = None,
@@ -362,7 +362,7 @@ def list_runs(
     """
     limit = min(limit, 500)  # Cap at 500
 
-    with db.session() as session:
+    with agent_db.session() as session:
         query = session.query(AgentRun)
 
         if status:
@@ -524,9 +524,9 @@ async def _run_validation_batch(job: ValidationJob, registry: AgentRegistry, db:
 
 
 @router.get("/{run_id}")
-def get_run(run_id: UUID, db: AgentDb) -> AgentRunDetail:
+def get_run(run_id: UUID, agent_db: AgentDb) -> AgentRunDetail:
     """Get details of a specific agent run. RLS enforces access."""
-    with db.session() as session:
+    with agent_db.session() as session:
         run = session.get(AgentRun, run_id)
         if run is None:
             raise HTTPException(status_code=404, detail=f"Agent run {run_id} not found")
@@ -704,9 +704,9 @@ def get_run(run_id: UUID, db: AgentDb) -> AgentRunDetail:
 
 
 @router.get("/{run_id}/llm_requests")
-def get_run_llm_requests(run_id: UUID, db: AgentDb) -> LLMRequestsResponse:
+def get_run_llm_requests(run_id: UUID, agent_db: AgentDb) -> LLMRequestsResponse:
     """Get LLM requests for a specific agent run. RLS filters visible requests."""
-    with db.session() as session:
+    with agent_db.session() as session:
         run = session.get(AgentRun, run_id)
         if run is None:
             raise HTTPException(status_code=404, detail=f"Agent run {run_id} not found")

--- a/props/backend/routes/stats.py
+++ b/props/backend/routes/stats.py
@@ -1,6 +1,7 @@
 """Stats API routes for props dashboard.
 
-All endpoints require admin access (localhost admin or authenticated admin user).
+Endpoints use agent credential passthrough - RLS policies filter results
+based on the caller's database role. Useful for critic dev agents to see metrics.
 """
 
 from __future__ import annotations
@@ -8,11 +9,10 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from props.backend.auth import require_admin_access
-from props.backend.deps import AdminDb
+from props.backend.auth import AgentDb
 from props.core.agent_types import AgentType
 from props.core.ids import SnapshotSlug
 from props.core.models.examples import ExampleKind
@@ -28,7 +28,7 @@ from props.db.models import (
     StatsWithCI,
 )
 
-router = APIRouter(dependencies=[Depends(require_admin_access)])
+router = APIRouter()
 
 
 class SplitScopeStats(BaseModel):
@@ -67,8 +67,8 @@ def to_split_scope_stats(row: RecallByDefinitionSplitKind, total_available: int)
 
 
 @router.get("/overview")
-def get_overview(admin_db: AdminDb) -> OverviewResponse:
-    with admin_db.session() as session:
+def get_overview(db: AgentDb) -> OverviewResponse:
+    with db.session() as session:
         example_counts = count_available_examples_by_scope_all(session, [Split.TRAIN, Split.VALID])
 
         # Get ALL critic definitions, not just those with stats
@@ -131,9 +131,9 @@ class DefinitionDetailResponse(BaseModel):
 
 
 @router.get("/definitions/{image_digest}")
-def get_definition_detail(image_digest: str, admin_db: AdminDb) -> DefinitionDetailResponse:
+def get_definition_detail(image_digest: str, db: AgentDb) -> DefinitionDetailResponse:
     """Get detailed stats for a single definition including per-example breakdown."""
-    with admin_db.session() as session:
+    with db.session() as session:
         definition = session.query(AgentDefinition).filter_by(id=image_digest).first()
         if not definition:
             raise HTTPException(status_code=404, detail=f"Definition not found: {image_digest}")
@@ -215,7 +215,7 @@ class ExampleDetailResponse(BaseModel):
 
 @router.get("/examples")
 def get_example_detail(
-    snapshot_slug: SnapshotSlug, example_kind: ExampleKind, admin_db: AdminDb, files_hash: str | None = None
+    snapshot_slug: SnapshotSlug, example_kind: ExampleKind, db: AgentDb, files_hash: str | None = None
 ) -> ExampleDetailResponse:
     """Get detailed information about a specific example.
 
@@ -231,7 +231,7 @@ def get_example_detail(
         - Per-definition run statistics
         - Aggregate metrics
     """
-    with admin_db.session() as session:
+    with db.session() as session:
         # Validate and fetch the example
         query = session.query(Example).filter_by(snapshot_slug=snapshot_slug, example_kind=example_kind)
 

--- a/props/backend/routes/stats.py
+++ b/props/backend/routes/stats.py
@@ -67,8 +67,8 @@ def to_split_scope_stats(row: RecallByDefinitionSplitKind, total_available: int)
 
 
 @router.get("/overview")
-def get_overview(db: AgentDb) -> OverviewResponse:
-    with db.session() as session:
+def get_overview(agent_db: AgentDb) -> OverviewResponse:
+    with agent_db.session() as session:
         example_counts = count_available_examples_by_scope_all(session, [Split.TRAIN, Split.VALID])
 
         # Get ALL critic definitions, not just those with stats
@@ -131,9 +131,9 @@ class DefinitionDetailResponse(BaseModel):
 
 
 @router.get("/definitions/{image_digest}")
-def get_definition_detail(image_digest: str, db: AgentDb) -> DefinitionDetailResponse:
+def get_definition_detail(image_digest: str, agent_db: AgentDb) -> DefinitionDetailResponse:
     """Get detailed stats for a single definition including per-example breakdown."""
-    with db.session() as session:
+    with agent_db.session() as session:
         definition = session.query(AgentDefinition).filter_by(id=image_digest).first()
         if not definition:
             raise HTTPException(status_code=404, detail=f"Definition not found: {image_digest}")
@@ -215,7 +215,7 @@ class ExampleDetailResponse(BaseModel):
 
 @router.get("/examples")
 def get_example_detail(
-    snapshot_slug: SnapshotSlug, example_kind: ExampleKind, db: AgentDb, files_hash: str | None = None
+    snapshot_slug: SnapshotSlug, example_kind: ExampleKind, agent_db: AgentDb, files_hash: str | None = None
 ) -> ExampleDetailResponse:
     """Get detailed information about a specific example.
 
@@ -231,7 +231,7 @@ def get_example_detail(
         - Per-definition run statistics
         - Aggregate metrics
     """
-    with db.session() as session:
+    with agent_db.session() as session:
         # Validate and fetch the example
         query = session.query(Example).filter_by(snapshot_slug=snapshot_slug, example_kind=example_kind)
 

--- a/props/backend/test_agent_db_integration.py
+++ b/props/backend/test_agent_db_integration.py
@@ -20,44 +20,18 @@ from props.core.agent_types import CriticTypeConfig
 from props.db.database import Database
 from props.db.examples import Example
 from props.db.models import AgentRun, AgentRunStatus
-from props.orchestration.agent_credentials import AgentCredentials, ensure_agent_role
+from props.orchestration.agent_credentials import AgentCredentials
+from props.testing.fixtures.credentials import make_agent_credentials
 from props.testing.fixtures.runs import FAKE_CRITIC_DIGEST, ensure_fake_agent_definitions
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_postgres]
 
 
-def _exhaust_generator(gen):
-    """Run a FastAPI dependency generator and return the yielded value."""
-    value = next(gen)
-    with contextlib.suppress(StopIteration):
-        next(gen)
-    return value
-
-
 @pytest_asyncio.fixture
 async def critic_agent_creds(synced_db: Database) -> AsyncGenerator[AgentCredentials]:
-    """Create critic agent credentials with a real Postgres role.
-
-    Creates an AgentRun record so current_agent_type() returns 'critic'
-    for RLS policy evaluation, then creates the Postgres role.
-    """
-    run_id = uuid4()
-
-    with synced_db.session() as session:
-        ensure_fake_agent_definitions(session)
-
-        type_config = CriticTypeConfig(example={"snapshot_slug": "test-fixtures/train1", "kind": "whole_snapshot"})
-        agent_run = AgentRun(
-            agent_run_id=run_id,
-            image_digest=FAKE_CRITIC_DIGEST,
-            model="test-model",
-            status=AgentRunStatus.COMPLETED,
-            type_config=type_config.model_dump(),
-        )
-        session.add(agent_run)
-        session.commit()
-
-    yield await ensure_agent_role(synced_db.config, run_id)
+    """Create critic agent credentials with a real Postgres role."""
+    type_config = CriticTypeConfig(example={"snapshot_slug": "test-fixtures/train1", "kind": "whole_snapshot"})
+    yield await make_agent_credentials(synced_db, type_config, FAKE_CRITIC_DIGEST)
 
 
 async def test_agent_db_returns_rls_scoped_database(synced_db: Database, critic_agent_creds: AgentCredentials) -> None:
@@ -128,12 +102,12 @@ async def test_agent_db_can_see_own_run(synced_db: Database, critic_agent_creds:
             next(gen)
 
 
-async def test_admin_auth_returns_admin_db(synced_db: Database) -> None:
+async def test_admin_auth_returns_admin_db(synced_db: Database, exhaust_generator) -> None:
     """get_agent_db with admin auth returns the admin Database directly."""
     auth = AuthContext.localhost_admin()
 
     gen = get_agent_db(admin_db=synced_db, auth=auth)
-    db = _exhaust_generator(gen)
+    db = exhaust_generator(gen)
 
     assert db is synced_db, "Admin should get the same admin Database instance"
 

--- a/props/backend/test_agent_db_integration.py
+++ b/props/backend/test_agent_db_integration.py
@@ -104,7 +104,7 @@ async def test_agent_db_can_see_own_run(synced_db: Database, critic_agent_creds:
 
 async def test_admin_auth_returns_admin_db(synced_db: Database, exhaust_generator) -> None:
     """get_agent_db with admin auth returns the admin Database directly."""
-    auth = AuthContext.localhost_admin()
+    auth = AuthContext.admin(username=synced_db.config.user, password=synced_db.config.password)
 
     gen = get_agent_db(admin_db=synced_db, auth=auth)
     db = exhaust_generator(gen)

--- a/props/backend/test_agent_db_integration.py
+++ b/props/backend/test_agent_db_integration.py
@@ -1,0 +1,142 @@
+"""Integration tests for get_agent_db with real Postgres and RLS.
+
+Verifies that get_agent_db returns a Database instance whose sessions
+are subject to RLS policies. Uses the same two-user pattern as
+test_split_based_rls: admin writes test data, agent queries with RLS.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+import pytest_bazel
+
+from props.backend.auth import AuthContext, get_agent_db
+from props.core.agent_types import CriticTypeConfig
+from props.db.database import Database
+from props.db.examples import Example
+from props.db.models import AgentRun, AgentRunStatus
+from props.orchestration.agent_credentials import AgentCredentials, ensure_agent_role
+from props.testing.fixtures.runs import FAKE_CRITIC_DIGEST, ensure_fake_agent_definitions
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_postgres]
+
+
+def _exhaust_generator(gen):
+    """Run a FastAPI dependency generator and return the yielded value."""
+    value = next(gen)
+    with contextlib.suppress(StopIteration):
+        next(gen)
+    return value
+
+
+@pytest_asyncio.fixture
+async def critic_agent_creds(synced_db: Database) -> AsyncGenerator[AgentCredentials]:
+    """Create critic agent credentials with a real Postgres role.
+
+    Creates an AgentRun record so current_agent_type() returns 'critic'
+    for RLS policy evaluation, then creates the Postgres role.
+    """
+    run_id = uuid4()
+
+    with synced_db.session() as session:
+        ensure_fake_agent_definitions(session)
+
+        type_config = CriticTypeConfig(example={"snapshot_slug": "test-fixtures/train1", "kind": "whole_snapshot"})
+        agent_run = AgentRun(
+            agent_run_id=run_id,
+            image_digest=FAKE_CRITIC_DIGEST,
+            model="test-model",
+            status=AgentRunStatus.COMPLETED,
+            type_config=type_config.model_dump(),
+        )
+        session.add(agent_run)
+        session.commit()
+
+    yield await ensure_agent_role(synced_db.config, run_id)
+
+
+async def test_agent_db_returns_rls_scoped_database(synced_db: Database, critic_agent_creds: AgentCredentials) -> None:
+    """get_agent_db with agent auth returns a Database that enforces RLS.
+
+    Writes a critic run for a VALID split snapshot as admin, then verifies
+    the agent Database cannot see it (critics can only see their own runs).
+    """
+    # Setup: create a critic run for VALID split as admin
+    valid_run_id = uuid4()
+    with synced_db.session() as session:
+        example = session.query(Example).filter_by(snapshot_slug="test-fixtures/valid1").first()
+        assert example, "test-fixtures/valid1 fixture not found"
+
+        ensure_fake_agent_definitions(session)
+        type_config = CriticTypeConfig(example=example.to_example_spec())
+        admin_run = AgentRun(
+            agent_run_id=valid_run_id,
+            image_digest=FAKE_CRITIC_DIGEST,
+            model="test-model",
+            status=AgentRunStatus.COMPLETED,
+            type_config=type_config.model_dump(),
+        )
+        session.add(admin_run)
+        session.commit()
+
+    # Exercise: get_agent_db with agent auth
+    auth = AuthContext.agent(
+        username=critic_agent_creds.username,
+        password=critic_agent_creds.password,
+        agent_run_id=uuid4(),  # The auth context run_id (doesn't need to match creds run)
+    )
+    gen = get_agent_db(admin_db=synced_db, auth=auth)
+    agent_db = next(gen)
+
+    try:
+        assert agent_db is not synced_db, "Agent should get a separate Database instance"
+
+        # Verify RLS: agent cannot see the VALID split run (not their own run)
+        with agent_db.session() as session:
+            visible_run = session.get(AgentRun, valid_run_id)
+            assert visible_run is None, "Agent should NOT see another agent's run via RLS"
+    finally:
+        with contextlib.suppress(StopIteration):
+            next(gen)
+
+
+async def test_agent_db_can_see_own_run(synced_db: Database, critic_agent_creds: AgentCredentials) -> None:
+    """Agent Database can see the agent's own run record."""
+    # The fixture already created a run for this agent's role.
+    # Find the run_id from the username (agent_{uuid}).
+    agent_run_id_str = critic_agent_creds.username.removeprefix("agent_")
+    agent_run_id = UUID(agent_run_id_str)
+
+    auth = AuthContext.agent(
+        username=critic_agent_creds.username, password=critic_agent_creds.password, agent_run_id=agent_run_id
+    )
+    gen = get_agent_db(admin_db=synced_db, auth=auth)
+    agent_db = next(gen)
+
+    try:
+        with agent_db.session() as session:
+            own_run = session.get(AgentRun, agent_run_id)
+            assert own_run is not None, "Agent should see their own run via RLS"
+            assert own_run.agent_run_id == agent_run_id
+    finally:
+        with contextlib.suppress(StopIteration):
+            next(gen)
+
+
+async def test_admin_auth_returns_admin_db(synced_db: Database) -> None:
+    """get_agent_db with admin auth returns the admin Database directly."""
+    auth = AuthContext.localhost_admin()
+
+    gen = get_agent_db(admin_db=synced_db, auth=auth)
+    db = _exhaust_generator(gen)
+
+    assert db is synced_db, "Admin should get the same admin Database instance"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/backend/test_auth.py
+++ b/props/backend/test_auth.py
@@ -18,16 +18,6 @@ from props.db.database import Database
 def test_get_agent_db_admin_returns_admin_db(exhaust_generator):
     """Admin users get the shared admin database connection."""
     admin_db = MagicMock(spec=Database)
-    auth = AuthContext.localhost_admin()
-
-    gen = get_agent_db(admin_db=admin_db, auth=auth)
-    db = exhaust_generator(gen)
-    assert db is admin_db
-
-
-def test_get_agent_db_admin_with_credentials_returns_admin_db(exhaust_generator):
-    """Admin users with explicit credentials still get the admin connection."""
-    admin_db = MagicMock(spec=Database)
     auth = AuthContext.admin(username="postgres", password="secret")
 
     gen = get_agent_db(admin_db=admin_db, auth=auth)

--- a/props/backend/test_auth.py
+++ b/props/backend/test_auth.py
@@ -1,0 +1,128 @@
+"""Unit tests for auth module - get_agent_db credential passthrough."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+import pytest_bazel
+from fastapi import HTTPException
+
+from props.backend.auth import AuthContext, get_agent_db
+from props.db.config import DatabaseConfig
+from props.db.database import Database
+
+
+def _exhaust_generator(gen):
+    """Run a FastAPI dependency generator and return the yielded value."""
+    value = next(gen)
+    with contextlib.suppress(StopIteration):
+        next(gen)
+    return value
+
+
+def test_get_agent_db_admin_returns_admin_db():
+    """Admin users get the shared admin database connection."""
+    admin_db = MagicMock(spec=Database)
+    auth = AuthContext.localhost_admin()
+
+    gen = get_agent_db(admin_db=admin_db, auth=auth)
+    db = _exhaust_generator(gen)
+    assert db is admin_db
+
+
+def test_get_agent_db_admin_with_credentials_returns_admin_db():
+    """Admin users with explicit credentials still get the admin connection."""
+    admin_db = MagicMock(spec=Database)
+    auth = AuthContext.admin(username="postgres", password="secret")
+
+    gen = get_agent_db(admin_db=admin_db, auth=auth)
+    db = _exhaust_generator(gen)
+    assert db is admin_db
+
+
+def test_get_agent_db_anonymous_raises_401():
+    """Anonymous (unauthenticated) callers get 401."""
+    admin_db = MagicMock(spec=Database)
+    auth = AuthContext.anonymous()
+
+    gen = get_agent_db(admin_db=admin_db, auth=auth)
+    with pytest.raises(HTTPException) as exc_info:
+        next(gen)
+    assert exc_info.value.status_code == 401
+
+
+def test_get_agent_db_agent_creates_per_request_db(monkeypatch: pytest.MonkeyPatch):
+    """Agent callers get a per-request Database with their credentials."""
+    run_id = uuid4()
+    admin_config = DatabaseConfig(host="localhost", port=5432, database="testdb", user="admin", password="admin_pass")
+    admin_db = MagicMock(spec=Database)
+    admin_db.config = admin_config
+
+    auth = AuthContext.agent(username=f"agent_{run_id}", password="agent_pass", agent_run_id=run_id)
+
+    # Mock Database constructor to avoid actual Postgres connection
+    created_dbs: list[tuple[DatabaseConfig, bool]] = []
+
+    def mock_init(self, config, *, _per_request=False):
+        created_dbs.append((config, _per_request))
+        self._config = config
+        self._engine = MagicMock()
+
+    monkeypatch.setattr(Database, "__init__", mock_init)
+    monkeypatch.setattr(Database, "dispose", lambda self: None)
+
+    gen = get_agent_db(admin_db=admin_db, auth=auth)
+    db = next(gen)
+
+    # Verify a new Database was created with agent credentials and per_request=True
+    assert len(created_dbs) == 1
+    config, per_request = created_dbs[0]
+    assert config.user == f"agent_{run_id}"
+    assert config.password == "agent_pass"
+    assert config.host == "localhost"
+    assert config.database == "testdb"
+    assert per_request is True
+
+    # Verify it's not the admin db
+    assert db is not admin_db
+
+    # Cleanup
+    with contextlib.suppress(StopIteration):
+        next(gen)
+
+
+def test_get_agent_db_agent_disposes_on_cleanup(monkeypatch: pytest.MonkeyPatch):
+    """Agent per-request database is disposed after the request."""
+    run_id = uuid4()
+    admin_config = DatabaseConfig(host="localhost", port=5432, database="testdb", user="admin", password="admin_pass")
+    admin_db = MagicMock(spec=Database)
+    admin_db.config = admin_config
+
+    auth = AuthContext.agent(username=f"agent_{run_id}", password="agent_pass", agent_run_id=run_id)
+
+    disposed = []
+
+    def mock_init(self, config, *, _per_request=False):
+        self._config = config
+        self._engine = MagicMock()
+
+    monkeypatch.setattr(Database, "__init__", mock_init)
+    monkeypatch.setattr(Database, "dispose", lambda self: disposed.append(True))
+
+    gen = get_agent_db(admin_db=admin_db, auth=auth)
+    next(gen)  # Get the yielded db
+
+    assert len(disposed) == 0  # Not disposed yet
+
+    # Exhaust the generator (triggers finally block)
+    with contextlib.suppress(StopIteration):
+        next(gen)
+
+    assert len(disposed) == 1  # Disposed after cleanup
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/backend/test_auth.py
+++ b/props/backend/test_auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -54,8 +54,8 @@ def test_get_agent_db_anonymous_raises_401():
     assert exc_info.value.status_code == 401
 
 
-def test_get_agent_db_agent_creates_per_request_db(monkeypatch: pytest.MonkeyPatch):
-    """Agent callers get a per-request Database with their credentials."""
+def test_get_agent_db_agent_calls_per_request():
+    """Agent callers get a Database.per_request() instance with their credentials."""
     run_id = uuid4()
     admin_config = DatabaseConfig(host="localhost", port=5432, database="testdb", user="admin", password="admin_pass")
     admin_db = MagicMock(spec=Database)
@@ -63,38 +63,29 @@ def test_get_agent_db_agent_creates_per_request_db(monkeypatch: pytest.MonkeyPat
 
     auth = AuthContext.agent(username=f"agent_{run_id}", password="agent_pass", agent_run_id=run_id)
 
-    # Mock Database constructor to avoid actual Postgres connection
-    created_dbs: list[tuple[DatabaseConfig, bool]] = []
+    mock_agent_db = MagicMock(spec=Database)
+    with patch.object(Database, "per_request", return_value=mock_agent_db) as mock_pr:
+        gen = get_agent_db(admin_db=admin_db, auth=auth)
+        db = next(gen)
 
-    def mock_init(self, config, *, _per_request=False):
-        created_dbs.append((config, _per_request))
-        self._config = config
-        self._engine = MagicMock()
+        # Verify per_request was called with agent credentials
+        mock_pr.assert_called_once()
+        config = mock_pr.call_args[0][0]
+        assert config.user == f"agent_{run_id}"
+        assert config.password == "agent_pass"
+        assert config.host == "localhost"
+        assert config.database == "testdb"
 
-    monkeypatch.setattr(Database, "__init__", mock_init)
-    monkeypatch.setattr(Database, "dispose", lambda self: None)
+        # Verify it's the per_request instance, not admin
+        assert db is mock_agent_db
+        assert db is not admin_db
 
-    gen = get_agent_db(admin_db=admin_db, auth=auth)
-    db = next(gen)
-
-    # Verify a new Database was created with agent credentials and per_request=True
-    assert len(created_dbs) == 1
-    config, per_request = created_dbs[0]
-    assert config.user == f"agent_{run_id}"
-    assert config.password == "agent_pass"
-    assert config.host == "localhost"
-    assert config.database == "testdb"
-    assert per_request is True
-
-    # Verify it's not the admin db
-    assert db is not admin_db
-
-    # Cleanup
-    with contextlib.suppress(StopIteration):
-        next(gen)
+        # Cleanup
+        with contextlib.suppress(StopIteration):
+            next(gen)
 
 
-def test_get_agent_db_agent_disposes_on_cleanup(monkeypatch: pytest.MonkeyPatch):
+def test_get_agent_db_agent_disposes_on_cleanup():
     """Agent per-request database is disposed after the request."""
     run_id = uuid4()
     admin_config = DatabaseConfig(host="localhost", port=5432, database="testdb", user="admin", password="admin_pass")
@@ -103,25 +94,18 @@ def test_get_agent_db_agent_disposes_on_cleanup(monkeypatch: pytest.MonkeyPatch)
 
     auth = AuthContext.agent(username=f"agent_{run_id}", password="agent_pass", agent_run_id=run_id)
 
-    disposed = []
+    mock_agent_db = MagicMock(spec=Database)
+    with patch.object(Database, "per_request", return_value=mock_agent_db):
+        gen = get_agent_db(admin_db=admin_db, auth=auth)
+        next(gen)  # Get the yielded db
 
-    def mock_init(self, config, *, _per_request=False):
-        self._config = config
-        self._engine = MagicMock()
+        mock_agent_db.dispose.assert_not_called()
 
-    monkeypatch.setattr(Database, "__init__", mock_init)
-    monkeypatch.setattr(Database, "dispose", lambda self: disposed.append(True))
+        # Exhaust the generator (triggers finally block)
+        with contextlib.suppress(StopIteration):
+            next(gen)
 
-    gen = get_agent_db(admin_db=admin_db, auth=auth)
-    next(gen)  # Get the yielded db
-
-    assert len(disposed) == 0  # Not disposed yet
-
-    # Exhaust the generator (triggers finally block)
-    with contextlib.suppress(StopIteration):
-        next(gen)
-
-    assert len(disposed) == 1  # Disposed after cleanup
+        mock_agent_db.dispose.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/props/backend/test_auth.py
+++ b/props/backend/test_auth.py
@@ -15,31 +15,23 @@ from props.db.config import DatabaseConfig
 from props.db.database import Database
 
 
-def _exhaust_generator(gen):
-    """Run a FastAPI dependency generator and return the yielded value."""
-    value = next(gen)
-    with contextlib.suppress(StopIteration):
-        next(gen)
-    return value
-
-
-def test_get_agent_db_admin_returns_admin_db():
+def test_get_agent_db_admin_returns_admin_db(exhaust_generator):
     """Admin users get the shared admin database connection."""
     admin_db = MagicMock(spec=Database)
     auth = AuthContext.localhost_admin()
 
     gen = get_agent_db(admin_db=admin_db, auth=auth)
-    db = _exhaust_generator(gen)
+    db = exhaust_generator(gen)
     assert db is admin_db
 
 
-def test_get_agent_db_admin_with_credentials_returns_admin_db():
+def test_get_agent_db_admin_with_credentials_returns_admin_db(exhaust_generator):
     """Admin users with explicit credentials still get the admin connection."""
     admin_db = MagicMock(spec=Database)
     auth = AuthContext.admin(username="postgres", password="secret")
 
     gen = get_agent_db(admin_db=admin_db, auth=auth)
-    db = _exhaust_generator(gen)
+    db = exhaust_generator(gen)
     assert db is admin_db
 
 

--- a/props/db/BUILD.bazel
+++ b/props/db/BUILD.bazel
@@ -235,6 +235,7 @@ docker_py_test(
         "//props/core:agent_types",
         "//props/critic_dev:shared",
         "//props/orchestration:agent_credentials",
+        "//props/testing/fixtures:credentials",
         "//props/testing/fixtures:runs",
         "@pypi//asyncpg",
         "@pypi//pytest",

--- a/props/db/database.py
+++ b/props/db/database.py
@@ -55,33 +55,48 @@ class Database:
         """
         return cls(DatabaseConfig())
 
-    def __init__(self, config: DatabaseConfig, *, _per_request: bool = False) -> None:
+    @classmethod
+    def per_request(cls, config: DatabaseConfig) -> Database:
+        """Create Database for per-request use (no startup verification).
+
+        Used by get_agent_db for agent credential passthrough. Caller must
+        call dispose() when done.
+        """
+        db = cls.__new__(cls)
+        db._config = config
+        db._engine = create_engine(config.url, echo=False, poolclass=NullPool)
+
+        @event.listens_for(db._engine, "checkout")
+        def _register_composite_types(
+            dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
+        ) -> None:
+            try:
+                register_composite("stats_with_ci", dbapi_connection, globally=False)
+            except Exception as e:
+                logger.debug(f"Could not register stats_with_ci composite type: {e}")
+
+        db._scoped_factory = scoped_session(sessionmaker(bind=db._engine))
+        return db
+
+    def __init__(self, config: DatabaseConfig) -> None:
         self._config = config
         url = config.url
 
-        if _per_request:
-            # Per-request mode: NullPool (no persistent connections), no verification.
-            # Used by get_agent_db for agent credential passthrough.
-            self._engine: Engine = create_engine(url, echo=False, poolclass=NullPool)
-        else:
-            logger.info(f"Connecting to database: {config.host}:{config.port}/{config.database}")
-            self._engine = create_engine(url, echo=False, pool_size=20, max_overflow=12)
+        logger.info(f"Connecting to database: {config.host}:{config.port}/{config.database}")
+        self._engine: Engine = create_engine(url, echo=False, poolclass=NullPool)
 
-            # Register composite type adapter on each checkout from pool.
-            # "checkout" (not "connect") so registration happens on every use,
-            # handling the case where type is created by a migration after the
-            # connection was first established.
-            @event.listens_for(self._engine, "checkout")
-            def _register_composite_types(
-                dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
-            ) -> None:
-                try:
-                    register_composite("stats_with_ci", dbapi_connection, globally=False)
-                except Exception as e:
-                    logger.debug(f"Could not register stats_with_ci composite type: {e}")
+        # Register composite type adapter on each checkout.
+        # NullPool creates a fresh connection per checkout, so this runs on every use.
+        @event.listens_for(self._engine, "checkout")
+        def _register_composite_types(
+            dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
+        ) -> None:
+            try:
+                register_composite("stats_with_ci", dbapi_connection, globally=False)
+            except Exception as e:
+                logger.debug(f"Could not register stats_with_ci composite type: {e}")
 
-            self._verify_connection()
-
+        self._verify_connection()
         self._scoped_factory = scoped_session(sessionmaker(bind=self._engine))
 
     def _verify_connection(self, timeout_secs: int = 2) -> None:

--- a/props/db/database.py
+++ b/props/db/database.py
@@ -32,7 +32,7 @@ from typing import Any
 from psycopg2.extras import register_composite
 from sqlalchemy import Engine, create_engine, event, text
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
-from sqlalchemy.pool import ConnectionPoolEntry
+from sqlalchemy.pool import ConnectionPoolEntry, NullPool
 
 from props.db.config import DatabaseConfig
 from props.db.setup import recreate_database as _setup_recreate_database
@@ -55,28 +55,34 @@ class Database:
         """
         return cls(DatabaseConfig())
 
-    def __init__(self, config: DatabaseConfig) -> None:
+    def __init__(self, config: DatabaseConfig, *, _per_request: bool = False) -> None:
         self._config = config
         url = config.url
-        logger.info(f"Connecting to database: {config.host}:{config.port}/{config.database}")
 
-        self._engine: Engine = create_engine(url, echo=False, pool_size=20, max_overflow=12)
+        if _per_request:
+            # Per-request mode: NullPool (no persistent connections), no verification.
+            # Used by get_agent_db for agent credential passthrough.
+            self._engine: Engine = create_engine(url, echo=False, poolclass=NullPool)
+        else:
+            logger.info(f"Connecting to database: {config.host}:{config.port}/{config.database}")
+            self._engine = create_engine(url, echo=False, pool_size=20, max_overflow=12)
+
+            # Register composite type adapter on each checkout from pool.
+            # "checkout" (not "connect") so registration happens on every use,
+            # handling the case where type is created by a migration after the
+            # connection was first established.
+            @event.listens_for(self._engine, "checkout")
+            def _register_composite_types(
+                dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
+            ) -> None:
+                try:
+                    register_composite("stats_with_ci", dbapi_connection, globally=False)
+                except Exception as e:
+                    logger.debug(f"Could not register stats_with_ci composite type: {e}")
+
+            self._verify_connection()
+
         self._scoped_factory = scoped_session(sessionmaker(bind=self._engine))
-
-        # Register composite type adapter on each checkout from pool.
-        # "checkout" (not "connect") so registration happens on every use,
-        # handling the case where type is created by a migration after the
-        # connection was first established.
-        @event.listens_for(self._engine, "checkout")
-        def _register_composite_types(
-            dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
-        ) -> None:
-            try:
-                register_composite("stats_with_ci", dbapi_connection, globally=False)
-            except Exception as e:
-                logger.debug(f"Could not register stats_with_ci composite type: {e}")
-
-        self._verify_connection()
 
     def _verify_connection(self, timeout_secs: int = 2) -> None:
         test_engine = create_engine(

--- a/props/db/test_split_based_rls.py
+++ b/props/db/test_split_based_rls.py
@@ -42,52 +42,24 @@ from props.critic_dev.shared import TargetMetric
 from props.db.database import Database
 from props.db.examples import Example
 from props.db.models import AgentRun, AgentRunStatus, FalsePositive, LLMRequest, Snapshot, TruePositive
-from props.orchestration.agent_credentials import AgentCredentials, ensure_agent_role
-from props.testing.fixtures.runs import (
-    FAKE_PROMPT_OPTIMIZER_DIGEST,
-    ensure_fake_agent_definitions,
-    make_fake_critic_run,
-)
+from props.orchestration.agent_credentials import AgentCredentials
+from props.testing.fixtures.credentials import make_agent_credentials
+from props.testing.fixtures.runs import FAKE_PROMPT_OPTIMIZER_DIGEST, make_fake_critic_run
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_postgres]
 
 
 @pytest_asyncio.fixture
 async def prompt_optimizer_creds(synced_db: Database) -> AsyncGenerator[AgentCredentials]:
-    """Create prompt optimizer agent credentials.
-
-    Creates an AgentRun record with agent_type='prompt_optimizer' so that
-    current_agent_type() returns the correct value for RLS policy evaluation.
-
-    Returns:
-        credentials for use in RLS tests
-    """
-    run_id = uuid4()
-
-    # Create AgentRun record with prompt_optimizer type_config (as admin)
-    # This must happen BEFORE the agent role is created, so RLS policies can
-    # identify this user as a prompt_optimizer via current_agent_type()
-    with synced_db.session() as session:
-        ensure_fake_agent_definitions(session)
-
-        type_config = PromptOptimizerTypeConfig(
-            target_metric=TargetMetric.TARGETED,
-            optimizer_model="test-optimizer-model",
-            critic_model="test-critic-model",
-            grader_model="test-grader-model",
-            budget_limit=100.0,
-        )
-        agent_run = AgentRun(
-            agent_run_id=run_id,
-            image_digest=FAKE_PROMPT_OPTIMIZER_DIGEST,
-            model="test-model",
-            status=AgentRunStatus.COMPLETED,
-            type_config=type_config.model_dump(),
-        )
-        session.add(agent_run)
-        session.commit()
-
-    yield await ensure_agent_role(synced_db.config, run_id)
+    """Create prompt optimizer agent credentials with a real Postgres role."""
+    type_config = PromptOptimizerTypeConfig(
+        target_metric=TargetMetric.TARGETED,
+        optimizer_model="test-optimizer-model",
+        critic_model="test-critic-model",
+        grader_model="test-grader-model",
+        budget_limit=100.0,
+    )
+    yield await make_agent_credentials(synced_db, type_config, FAKE_PROMPT_OPTIMIZER_DIGEST)
 
 
 @pytest_asyncio.fixture

--- a/props/docs/plans/agent-credential-passthrough.md
+++ b/props/docs/plans/agent-credential-passthrough.md
@@ -87,11 +87,9 @@ Replace localhost exception with token-based admin auth (Jupyter-style).
 
 ### Design
 
-**Token derivation**: `PROPS_ADMIN_TOKEN` env var if set, otherwise `HMAC-SHA256(PGPASSWORD, "props-admin-token")` base64url-encoded. Deterministic across restarts, doesn't expose raw Postgres password.
+**Token**: `base64(PGUSER:PGPASSWORD)` — same format agents already use. The existing `parse_credentials` → `validate_postgres_credentials` path handles it with no auth.py changes.
 
-**Backend startup** (`app.py` lifespan): Print `http://<host>:<port>/?token=<token>` to console, like Jupyter.
-
-**Auth flow** (`auth.py` `get_auth_context`): Check `Authorization: Bearer <token>` against admin token _before_ base64 credential parsing. Match → `AuthContext.admin(...)`. No Postgres connection needed for token auth.
+**Backend startup** (`app.py` lifespan): Compute token from `DatabaseConfig`, print `http://<host>:<port>/?token=<token>` to console.
 
 **Frontend token capture**: On page load, if `?token=` in URL → store in `localStorage`, strip from URL (`history.replaceState`). On every API call, attach `Authorization: Bearer <token>` from `localStorage`. If no token and 401 → show paste-token input.
 
@@ -99,29 +97,28 @@ Replace localhost exception with token-based admin auth (Jupyter-style).
 
 ### Changes
 
-| File                           | Change                                                    |
-| ------------------------------ | --------------------------------------------------------- |
-| `props/backend/auth.py`        | `derive_admin_token()`, token check in `get_auth_context` |
-| `props/backend/app.py`         | Print token URL on startup                                |
-| `props/frontend/.../client.ts` | Attach Bearer token from `localStorage`                   |
-| `props/frontend/...`           | Token capture from URL param, paste-token fallback UI     |
+| File                           | Change                                                |
+| ------------------------------ | ----------------------------------------------------- |
+| `props/backend/app.py`         | Print token URL on startup                            |
+| `props/frontend/.../client.ts` | Attach Bearer token from `localStorage`               |
+| `props/frontend/...`           | Token capture from URL param, paste-token fallback UI |
 
 ### Sequence
 
 ```
 Startup:
-  backend derives token from PGPASSWORD
-  backend prints http://host:port/?token=abc123
+  backend computes base64(PGUSER:PGPASSWORD)
+  backend prints http://host:port/?token=<base64>
 
 Browser opens URL:
-  frontend reads ?token=abc123 from URL
+  frontend reads ?token= from URL
   frontend stores in localStorage
   frontend strips ?token from URL bar
 
 API call:
-  frontend attaches Authorization: Bearer abc123
-  backend: token matches admin token → AuthContext.admin()
-  backend: returns admin DB (no RLS)
+  frontend attaches Authorization: Bearer <base64>
+  backend: parse_credentials → validate_postgres_credentials → admin
+  (existing auth flow, no changes)
 
 No token:
   frontend shows "Paste admin token" input

--- a/props/docs/plans/agent-credential-passthrough.md
+++ b/props/docs/plans/agent-credential-passthrough.md
@@ -9,6 +9,7 @@ When an agent authenticates to the backend with their Postgres credentials (`age
 - **Phase 1**: Renamed `get_db` → `get_admin_db`, added `AdminDb` type alias, added `get_agent_db` dependency (in `auth.py` to avoid circular deps), added `AgentDb` type alias, added `Database.per_request()` classmethod (NullPool, no verification)
 - **Phase 2**: Migrated read-heavy endpoints to `AgentDb` (`agent_definitions`, `stats`, all `runs` read endpoints). Write endpoints (`trigger_validation_runs`, `list_jobs`) keep `AdminDb` with explicit `require_admin_access`.
 - **Tests**: Unit tests in `props/backend/test_auth.py`, integration tests with real Postgres + RLS in `props/backend/test_agent_db_integration.py`
+- **Phase 5**: Admin token authentication — removed localhost admin exception, backend prints admin token URL on startup, frontend captures token from URL → `localStorage` → `Authorization: Bearer` header, paste-token fallback UI, WebSocket feed auth via `?token=` query param
 
 ### Key files
 
@@ -81,49 +82,21 @@ Per-request connections (Option A): Each agent request creates a `Database.per_r
 2. Defense in depth: RLS prevents unauthorized access even if Python ACL is wrong
 3. Audit trail: Database logs show actual user performing operations
 
-## Phase 5: Admin Token Authentication
+## Phase 5: Admin Token Authentication (Completed)
 
-Replace localhost exception with token-based admin auth (Jupyter-style).
+Replaced localhost exception with token-based admin auth (Jupyter-style).
 
-### Design
+### Key files
 
-**Token**: `base64(PGUSER:PGPASSWORD)` — same format agents already use. The existing `parse_credentials` → `validate_postgres_credentials` path handles it with no auth.py changes.
-
-**Backend startup** (`app.py` lifespan): Compute token from `DatabaseConfig`, print `http://<host>:<port>/?token=<token>` to console.
-
-**Frontend token capture**: On page load, if `?token=` in URL → store in `localStorage`, strip from URL (`history.replaceState`). On every API call, attach `Authorization: Bearer <token>` from `localStorage`. If no token and 401 → show paste-token input.
-
-**Localhost exception**: Keep `PROPS_ALLOW_LOCALHOST_ADMIN` defaulting to `true` for local dev. Remote deployments set it to `false`.
-
-### Changes
-
-| File                           | Change                                                |
-| ------------------------------ | ----------------------------------------------------- |
-| `props/backend/app.py`         | Print token URL on startup                            |
-| `props/frontend/.../client.ts` | Attach Bearer token from `localStorage`               |
-| `props/frontend/...`           | Token capture from URL param, paste-token fallback UI |
-
-### Sequence
-
-```
-Startup:
-  backend computes base64(PGUSER:PGPASSWORD)
-  backend prints http://host:port/?token=<base64>
-
-Browser opens URL:
-  frontend reads ?token= from URL
-  frontend stores in localStorage
-  frontend strips ?token from URL bar
-
-API call:
-  frontend attaches Authorization: Bearer <base64>
-  backend: parse_credentials → validate_postgres_credentials → admin
-  (existing auth flow, no changes)
-
-No token:
-  frontend shows "Paste admin token" input
-  user pastes token → stored in localStorage → retry
-```
+| File                                        | What changed                                       |
+| ------------------------------------------- | -------------------------------------------------- |
+| `props/backend/app.py`                      | Compute and print admin token URL on startup       |
+| `props/backend/auth.py`                     | Removed localhost admin exception                  |
+| `props/frontend/src/lib/api/client.ts`      | Bearer token middleware from `localStorage`        |
+| `props/frontend/src/lib/stores/token.ts`    | Token capture, storage, and auth-failed management |
+| `props/frontend/src/App.svelte`             | Token capture from URL, paste-token fallback UI    |
+| `props/frontend/src/lib/stores/runsFeed.ts` | WebSocket auth via `?token=` query param           |
+| `props/backend/routes/runs.py`              | WebSocket feed token validation                    |
 
 ## Non-Goals
 

--- a/props/docs/plans/agent-credential-passthrough.md
+++ b/props/docs/plans/agent-credential-passthrough.md
@@ -81,12 +81,52 @@ Per-request connections (Option A): Each agent request creates a `Database.per_r
 2. Defense in depth: RLS prevents unauthorized access even if Python ACL is wrong
 3. Audit trail: Database logs show actual user performing operations
 
-## Future: Frontend Authentication
+## Phase 5: Admin Token Authentication
 
-Frontend currently relies on `PROPS_ALLOW_LOCALHOST_ADMIN=true`. Options for remote dashboard access:
+Replace localhost exception with token-based admin auth (Jupyter-style).
 
-- **Option A (recommended)**: Credentials endpoint — backend serves admin credentials at a protected endpoint
-- **Option C (later)**: Session-based auth with login for production multi-user access
+### Design
+
+**Token derivation**: `PROPS_ADMIN_TOKEN` env var if set, otherwise `HMAC-SHA256(PGPASSWORD, "props-admin-token")` base64url-encoded. Deterministic across restarts, doesn't expose raw Postgres password.
+
+**Backend startup** (`app.py` lifespan): Print `http://<host>:<port>/?token=<token>` to console, like Jupyter.
+
+**Auth flow** (`auth.py` `get_auth_context`): Check `Authorization: Bearer <token>` against admin token _before_ base64 credential parsing. Match → `AuthContext.admin(...)`. No Postgres connection needed for token auth.
+
+**Frontend token capture**: On page load, if `?token=` in URL → store in `localStorage`, strip from URL (`history.replaceState`). On every API call, attach `Authorization: Bearer <token>` from `localStorage`. If no token and 401 → show paste-token input.
+
+**Localhost exception**: Keep `PROPS_ALLOW_LOCALHOST_ADMIN` defaulting to `true` for local dev. Remote deployments set it to `false`.
+
+### Changes
+
+| File                           | Change                                                    |
+| ------------------------------ | --------------------------------------------------------- |
+| `props/backend/auth.py`        | `derive_admin_token()`, token check in `get_auth_context` |
+| `props/backend/app.py`         | Print token URL on startup                                |
+| `props/frontend/.../client.ts` | Attach Bearer token from `localStorage`                   |
+| `props/frontend/...`           | Token capture from URL param, paste-token fallback UI     |
+
+### Sequence
+
+```
+Startup:
+  backend derives token from PGPASSWORD
+  backend prints http://host:port/?token=abc123
+
+Browser opens URL:
+  frontend reads ?token=abc123 from URL
+  frontend stores in localStorage
+  frontend strips ?token from URL bar
+
+API call:
+  frontend attaches Authorization: Bearer abc123
+  backend: token matches admin token → AuthContext.admin()
+  backend: returns admin DB (no RLS)
+
+No token:
+  frontend shows "Paste admin token" input
+  user pastes token → stored in localStorage → retry
+```
 
 ## Non-Goals
 

--- a/props/docs/plans/agent-credential-passthrough.md
+++ b/props/docs/plans/agent-credential-passthrough.md
@@ -105,26 +105,31 @@ def get_agent_db(request: Request) -> Database:
 
 ### Migration Path
 
-1. **Phase 1: Rename `get_db` → `get_admin_db` and add `get_agent_db`** ✅ PARTIAL
+1. **Phase 1: Rename `get_db` → `get_admin_db` and add `get_agent_db`** ✅
    - ✅ Rename existing `get_db` to `get_admin_db` in `deps.py`
    - ✅ Add `AdminDb` type alias for FastAPI route signatures
    - ✅ Update all imports and usages to `get_admin_db` (no behavior change)
-   - ⬚ Add new `get_agent_db` dependency
+   - ✅ Add new `get_agent_db` dependency (in `auth.py` to avoid circular deps with `deps.py`)
+   - ✅ Add `AgentDb` type alias in `auth.py`
+   - ✅ Add `_per_request` mode to `Database` (NullPool, no verification)
 
-2. **Phase 2: Migrate read-heavy endpoints to `get_agent_db`**
-   - Update routes that only read data accessible to agents
-   - Replace `db: Annotated[Database, Depends(get_admin_db)]` with `get_agent_db`
-   - Routes: runs list/detail (read-only parts), stats views
+2. **Phase 2: Migrate read-heavy endpoints to `get_agent_db`** ✅
+   - ✅ `agent_definitions.py`: `list_definitions` → `AgentDb`
+   - ✅ `stats.py`: all endpoints → `AgentDb`
+   - ✅ `runs.py` read endpoints: `list_active_runs`, `list_runs`, `get_run`, `get_run_llm_requests` → `AgentDb`
+   - ✅ `runs.py` write endpoints: `trigger_validation_runs` keeps `AdminDb` with explicit `require_admin_access`
+   - ✅ `runs.py` admin-only: `list_jobs` keeps explicit `require_admin_access`
+   - ✅ Unit tests for `get_agent_db` in `props/backend/test_auth.py`
 
 3. **Phase 3: Migrate write endpoints with RLS**
-   - Grading edges endpoints
-   - Reported issues endpoints
-   - Remove manual ACL checks that RLS now handles
+   - ⬚ Grading edges endpoints (when they exist)
+   - ⬚ Reported issues endpoints (when they exist)
+   - ⬚ Remove manual ACL checks that RLS now handles
 
 4. **Phase 4: Clean up**
-   - Remove `ACL_CAN_*` sets for operations now handled by RLS
-   - Simplify `CallerType` checks
-   - Update tests
+   - ⬚ Remove `ACL_CAN_*` sets for operations now handled by RLS
+   - ⬚ Simplify `CallerType` checks
+   - ⬚ Update tests
 
 ### Files Requiring Update
 
@@ -301,10 +306,10 @@ For production with remote access, consider **Option C (session auth)** later.
 ## Implementation Order
 
 1. ✅ Rename `get_db` → `get_admin_db`, add `AdminDb` type alias
-2. Add `get_agent_db` dependency (no behavior change)
-3. Add integration test for agent credential passthrough
-4. Migrate one read endpoint as proof of concept
-5. Migrate remaining read endpoints
-6. Migrate write endpoints with RLS
-7. Remove redundant Python ACL checks
-8. Update documentation
+2. ✅ Add `get_agent_db` dependency (in `auth.py`, with `_per_request` Database mode)
+3. ✅ Add unit tests for `get_agent_db` (`props/backend/test_auth.py`)
+4. ✅ Migrate read endpoints (`agent_definitions`, `stats`, `runs` reads) to `AgentDb`
+5. ⬚ Add integration test for agent credential passthrough (e2e with real Postgres)
+6. ⬚ Migrate write endpoints with RLS (grading edges, reported issues - when they exist)
+7. ⬚ Remove redundant Python ACL checks
+8. ⬚ Update documentation

--- a/props/docs/plans/agent-credential-passthrough.md
+++ b/props/docs/plans/agent-credential-passthrough.md
@@ -4,312 +4,92 @@
 
 When an agent authenticates to the backend with their Postgres credentials (`agent_{uuid}`), use those credentials for the database connection instead of the admin connection pool. This leverages PostgreSQL RLS policies directly, removing the need to duplicate access control logic in Python.
 
-## Current State
+## Completed
 
-1. **Authentication**: Agents authenticate via HTTP Basic Auth with username `agent_{uuid}` and HMAC-derived password
-2. **Connection**: Backend validates credentials against Postgres (connection test), then uses a single admin connection pool (`app.state.db`) for all database operations
-3. **ACL Enforcement**: Python code checks `CallerType` and enforces permissions manually
-4. **RLS Policies**: Exist in database for `agent_base` role but are unused since backend connects as admin
+- **Phase 1**: Renamed `get_db` → `get_admin_db`, added `AdminDb` type alias, added `get_agent_db` dependency (in `auth.py` to avoid circular deps), added `AgentDb` type alias, added `Database.per_request()` classmethod (NullPool, no verification)
+- **Phase 2**: Migrated read-heavy endpoints to `AgentDb` (`agent_definitions`, `stats`, all `runs` read endpoints). Write endpoints (`trigger_validation_runs`, `list_jobs`) keep `AdminDb` with explicit `require_admin_access`.
+- **Tests**: Unit tests in `props/backend/test_auth.py`, integration tests with real Postgres + RLS in `props/backend/test_agent_db_integration.py`
 
-## Proposed State
+### Key files
 
-1. **Agent requests**: Use agent's Postgres credentials for the database connection
-2. **Admin requests**: Continue using admin connection pool
-3. **RLS Enforcement**: Postgres RLS policies automatically enforce access control
-4. **Simplified Python**: Remove redundant ACL checks that RLS already handles
+| File                                        | What changed                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------- |
+| `props/backend/auth.py`                     | `get_agent_db` generator, `AgentDb` type alias                                  |
+| `props/backend/deps.py`                     | `get_admin_db`, `AdminDb` type alias                                            |
+| `props/db/database.py`                      | `Database.per_request()` classmethod                                            |
+| `props/backend/routes/agent_definitions.py` | `agent_db: AgentDb`                                                             |
+| `props/backend/routes/stats.py`             | `agent_db: AgentDb` (all 3 endpoints)                                           |
+| `props/backend/routes/runs.py`              | `agent_db: AgentDb` (4 read endpoints), `admin_db: AdminDb` (2 write endpoints) |
 
-## Design
+## Remaining Work
 
-### Explicit Naming Convention
+### Phase 3: Migrate write endpoints with RLS
 
-**Critical**: Admin vs agent DB access must be obvious in code. Variable names, function names, and dependencies should clearly indicate which credentials are used.
+- ⬚ Grading edges endpoints (when they exist)
+- ⬚ Reported issues endpoints (when they exist)
+- ⬚ Remove manual ACL checks that RLS now handles
 
-- `get_admin_db` - Admin connection pool (explicit admin access)
-- `get_agent_db` - Agent credentials when available, raises for anonymous
+### Phase 4: Clean up
 
-Rename existing `get_db` → `get_admin_db` to make admin access explicit.
+- ⬚ Remove `ACL_CAN_*` sets for operations now handled by RLS
+- ⬚ Simplify `CallerType` checks
 
-### New Dependencies
+## Endpoint Classification
 
-```python
-# props/backend/deps.py
+**Already using `AgentDb`:**
 
-def get_admin_db(request: Request) -> Database:
-    """Get admin Database instance from app state.
+| Endpoint                                | Notes                        |
+| --------------------------------------- | ---------------------------- |
+| `GET /api/definitions`                  | RLS filters by agent type    |
+| `GET /api/runs`, `GET /api/runs/active` | RLS filters visible runs     |
+| `GET /api/runs/{id}`                    | RLS enforces access          |
+| `GET /api/runs/{id}/llm_requests`       | RLS filters visible requests |
+| `GET /api/stats/*` (3 endpoints)        | RLS filters visible data     |
 
-    Uses the server's admin connection pool. Use only for operations
-    that genuinely require admin privileges (INSERT into llm_requests,
-    launching agent runs, etc).
-    """
-    return request.app.state.db
+**Staying on `AdminDb`:**
 
+| Endpoint                     | Reason                                       |
+| ---------------------------- | -------------------------------------------- |
+| `POST /api/llm/v1/responses` | Proxy needs admin INSERT into `llm_requests` |
+| `POST /api/eval/*`           | Launches agent runs as admin                 |
+| `POST /api/registry/*`       | Definition push needs admin INSERT           |
+| `GET /api/ground_truth/*`    | Admin-only dashboard                         |
+| `POST /api/runs/validation`  | Launches runs as admin                       |
+| `GET /api/runs/jobs`         | Admin-only job tracking                      |
 
-def get_agent_db(request: Request) -> Database:
-    """Get Database using agent credentials for RLS enforcement.
+**Future (Phase 3):**
 
-    For agent callers: Creates Database with agent's Postgres credentials.
-    For admin callers: Returns admin Database instance.
-    For anonymous: Raises 401.
-    """
-    auth: AuthContext | None = request.state.auth
+| Endpoint                     | Notes                         |
+| ---------------------------- | ----------------------------- |
+| `POST /api/runs/{id}/grades` | RLS enforces grader ownership |
+| `POST /api/runs/{id}/issues` | RLS enforces critic ownership |
 
-    if auth is None or not auth.is_authenticated:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
-    # Admin users get admin connection
-    if auth.is_admin:
-        return request.app.state.db
-
-    # Agent users get their own connection - credentials guaranteed present for agents
-    if not auth.username or not auth.password:
-        raise HTTPException(status_code=500, detail="Agent auth missing credentials")
-    agent_config = DatabaseConfig(
-        host=request.app.state.db.config.host,
-        port=request.app.state.db.config.port,
-        database=request.app.state.db.config.database,
-        username=auth.username,
-        password=auth.password,
-    )
-    return Database(agent_config)
-```
+## Design Notes
 
 ### Connection Lifecycle
 
-**Option A: Per-request connections (simple, start here)**
-
-- Create new `Database` instance for each agent request
-- Connection opened/closed within the request context manager
-- No pooling for agent connections
-
-**Option B: Connection pool per agent (optimization, later)**
-
-- Cache `Database` instances keyed by `agent_run_id`
-- Requires lifecycle management (eviction, cleanup)
-- Only implement if Option A has performance issues
-
-### Endpoint Classification
-
-**Use `get_agent_db` (agent credentials):**
-
-- Most read endpoints where RLS applies
-- `grading_edges` writes (RLS already enforces `is_own_run_as(grader_run_id, 'grader')`)
-- `reported_issues` writes (RLS enforces `is_own_run_as(agent_run_id, 'critic')`)
-- Stats/overview endpoints - useful for critic dev agents to see metrics
-
-**Use `get_admin_db` (explicit admin access):**
-
-- LLM proxy (`/api/llm/v1/responses`) - needs to INSERT into `llm_requests` as admin (proxy pattern)
-- Agent definition push - needs INSERT permission that agents don't have
-- Eval API - launches agent runs, needs admin
-- Ground truth endpoints - admin-only dashboard
-
-### Migration Path
-
-1. **Phase 1: Rename `get_db` → `get_admin_db` and add `get_agent_db`** ✅
-   - ✅ Rename existing `get_db` to `get_admin_db` in `deps.py`
-   - ✅ Add `AdminDb` type alias for FastAPI route signatures
-   - ✅ Update all imports and usages to `get_admin_db` (no behavior change)
-   - ✅ Add new `get_agent_db` dependency (in `auth.py` to avoid circular deps with `deps.py`)
-   - ✅ Add `AgentDb` type alias in `auth.py`
-   - ✅ Add `_per_request` mode to `Database` (NullPool, no verification)
-
-2. **Phase 2: Migrate read-heavy endpoints to `get_agent_db`** ✅
-   - ✅ `agent_definitions.py`: `list_definitions` → `AgentDb`
-   - ✅ `stats.py`: all endpoints → `AgentDb`
-   - ✅ `runs.py` read endpoints: `list_active_runs`, `list_runs`, `get_run`, `get_run_llm_requests` → `AgentDb`
-   - ✅ `runs.py` write endpoints: `trigger_validation_runs` keeps `AdminDb` with explicit `require_admin_access`
-   - ✅ `runs.py` admin-only: `list_jobs` keeps explicit `require_admin_access`
-   - ✅ Unit tests for `get_agent_db` in `props/backend/test_auth.py`
-
-3. **Phase 3: Migrate write endpoints with RLS**
-   - ⬚ Grading edges endpoints (when they exist)
-   - ⬚ Reported issues endpoints (when they exist)
-   - ⬚ Remove manual ACL checks that RLS now handles
-
-4. **Phase 4: Clean up**
-   - ⬚ Remove `ACL_CAN_*` sets for operations now handled by RLS
-   - ⬚ Simplify `CallerType` checks
-   - ⬚ Update tests
-
-### Files Requiring Update
-
-All routes now use `get_admin_db`. Decide which should become `get_agent_db`:
-
-**`agent_definitions.py`** (1 usage)
-
-- `list_definitions` → `get_agent_db` (SELECT allowed by RLS)
-
-**`llm.py`** (1 usage)
-
-- `responses` → `get_admin_db` (proxy needs admin INSERT)
-
-**`ground_truth.py`** (4 usages)
-
-- All endpoints → `get_admin_db` (admin-only dashboard)
-
-**`runs.py`** (5 usages)
-
-- `list_active_runs` → `get_agent_db` (RLS filters)
-- `get_run` → `get_agent_db` (RLS enforces access)
-- `get_run_llm_requests` → `get_agent_db` (RLS filters)
-- `start_validation_run` → `get_admin_db` (launches runs)
-- `create_grading_edges` → `get_agent_db` (RLS enforces grader ownership)
-
-**`registry.py`** (1 usage)
-
-- `push_manifest` → `get_admin_db` (needs INSERT permission)
-
-**`stats.py`** (3 usages)
-
-- All endpoints → `get_agent_db` (useful for critic dev)
-
-**`eval.py`** (2 usages)
-
-- All endpoints → `get_admin_db` (launches agent runs)
-
-### Endpoints to Migrate
-
-| Endpoint                     | Current Dep       | Target Dep     | Notes                         |
-| ---------------------------- | ----------------- | -------------- | ----------------------------- |
-| `GET /api/runs`              | `get_admin_db`    | `get_agent_db` | RLS filters visible runs      |
-| `GET /api/runs/{id}`         | `get_admin_db`    | `get_agent_db` | RLS enforces access           |
-| `POST /api/runs/{id}/grades` | `get_admin_db`    | `get_agent_db` | RLS enforces grader ownership |
-| `POST /api/runs/{id}/issues` | `get_admin_db`    | `get_agent_db` | RLS enforces critic ownership |
-| `GET /api/stats/*`           | `get_admin_db`    | `get_agent_db` | RLS filters visible data      |
-| `POST /api/llm/v1/responses` | ✅ `get_admin_db` | `get_admin_db` | Proxy needs admin INSERT      |
-| `POST /api/eval/*`           | ✅ `get_admin_db` | `get_admin_db` | Launches runs as admin        |
-| `POST /api/registry/*`       | ✅ `get_admin_db` | `get_admin_db` | Definition push needs admin   |
-| `GET /api/ground_truth/*`    | ✅ `get_admin_db` | `get_admin_db` | Admin-only                    |
-| `GET /api/definitions`       | `get_admin_db`    | `get_agent_db` | SELECT is allowed by RLS      |
+Per-request connections (Option A): Each agent request creates a `Database.per_request()` instance with NullPool. The `get_agent_db` generator disposes it in the `finally` block. Connection pooling per agent (Option B) can be added later if needed.
 
 ### RLS Policy Gaps
 
-Review existing RLS policies for gaps:
-
-1. **`agent_runs`**: Policies support recursive visibility:
-   - `agent_runs_select_own`: See own run
-   - `agent_runs_select_descendants`: See all descendants via `is_agent_ancestor(current_agent_run_id(), agent_run_id)`
-   - `agent_runs_agent_select`: Type-specific access (PO sees critics/graders on train, etc.)
-
-   Migration `20260203000000_recursive_agent_visibility.py` replaces the old direct-children policy with recursive descendant visibility.
-
-2. **`llm_requests`**: Current INSERT policy requires `current_agent_run_id() = agent_run_id`. This conflicts with proxy pattern where backend inserts on behalf of agent. **Keep admin connection for LLM proxy.**
-
-3. **`agent_definitions`**: INSERT requires admin or PO/improvement agent type. The RLS policy should handle this correctly.
-
-4. **Stats views**: Views like `recall_by_definition_example`, `recall_by_run` are granted SELECT to `agent_base`. These aggregate data but RLS on underlying tables (agent_runs, grading_edges) should filter appropriately.
+1. **`llm_requests`**: INSERT policy requires `current_agent_run_id() = agent_run_id` — conflicts with proxy pattern. Keep admin connection for LLM proxy.
+2. **Stats views**: `recall_by_definition_example`, `recall_by_run` are granted SELECT to `agent_base`. RLS on underlying tables filters appropriately.
 
 ### Benefits
 
-1. **Single source of truth**: RLS policies define access control, not Python code
-2. **Defense in depth**: Even if Python ACL check is wrong, RLS prevents unauthorized access
-3. **Simpler code**: Remove redundant `CallerType` checks for RLS-protected operations
-4. **Audit trail**: Database logs show actual user performing operations
-
-### Risks and Mitigations
-
-| Risk                            | Mitigation                                                |
-| ------------------------------- | --------------------------------------------------------- |
-| Connection overhead             | Start with per-request connections; add pooling if needed |
-| RLS policy gaps                 | Audit policies before migration; add missing policies     |
-| Breaking existing functionality | Gradual migration, one endpoint at a time                 |
-
-Note: RLS errors can be exposed directly - agents knowing schema/policies is acceptable.
-
-### Testing Strategy
-
-1. **Unit tests**: Test `get_agent_db` returns correct Database for each auth context
-2. **Integration tests**: Test endpoint access with different agent types
-3. **RLS tests**: Verify RLS policies work as expected via SQL
-4. **Negative tests**: Verify unauthorized access is denied
+1. Single source of truth: RLS policies define access control
+2. Defense in depth: RLS prevents unauthorized access even if Python ACL is wrong
+3. Audit trail: Database logs show actual user performing operations
 
 ## Future: Frontend Authentication
 
-For symmetry, the frontend dashboard could also authenticate to the backend instead of relying on localhost admin access. This would:
+Frontend currently relies on `PROPS_ALLOW_LOCALHOST_ADMIN=true`. Options for remote dashboard access:
 
-- Enable remote dashboard access (not just localhost)
-- Provide consistent auth model across all clients
-- Allow per-user audit trails in database logs
-
-### Current State
-
-Frontend relies on `PROPS_ALLOW_LOCALHOST_ADMIN=true` — requests from localhost with no credentials get admin access. This only works when accessing from the same machine.
-
-### Options for Frontend Auth
-
-**Option A: Credentials endpoint**
-
-Backend serves admin credentials at a protected endpoint (e.g., `/api/auth/credentials`). Frontend fetches on load and uses for subsequent requests.
-
-```typescript
-// On app init
-const { username, password } = await fetch("/api/auth/credentials").then((r) => r.json());
-// Store in memory, use for all API calls
-```
-
-Pros: Simple, credentials not in bundle
-Cons: Initial fetch adds latency, credentials endpoint needs protection
-
-**Option B: Baked into JS at build time**
-
-Bazel genrule injects credentials into the frontend bundle during build.
-
-```python
-# BUILD.bazel
-genrule(
-    name = "frontend_with_creds",
-    srcs = [":frontend_bundle"],
-    outs = ["frontend_bundle_with_creds.js"],
-    cmd = "sed 's/__ADMIN_USER__/$(ADMIN_USER)/' ... > $@",
-)
-```
-
-Pros: No extra fetch, works offline
-Cons: Credentials in bundle (inspect-able), rebuild needed to rotate
-
-**Option C: Session-based auth with login**
-
-Add login endpoint, issue session cookie, validate on requests.
-
-Pros: Standard web auth pattern, supports multiple users
-Cons: More complex, need session storage, login UI
-
-**Option D: Environment variable injection at serve time**
-
-Backend injects credentials into HTML template when serving the SPA.
-
-```html
-<script>
-  window.__PROPS_AUTH__ = { user: "{{user}}", pass: "{{pass}}" };
-</script>
-```
-
-Pros: No rebuild needed, credentials not in static bundle
-Cons: Requires templated serving, credentials visible in page source
-
-### Recommendation
-
-Start with **Option A (credentials endpoint)** — simplest to implement, keeps credentials out of static bundle. The endpoint can be protected by requiring localhost or a bootstrap token.
-
-For production with remote access, consider **Option C (session auth)** later.
+- **Option A (recommended)**: Credentials endpoint — backend serves admin credentials at a protected endpoint
+- **Option C (later)**: Session-based auth with login for production multi-user access
 
 ## Non-Goals
 
 - Connection pooling per agent (can add later if needed)
 - Changing RLS policies (use existing policies)
 - Removing admin connection pool (always needed for admin-only operations)
-
-## Open Questions
-
-1. Should we cache agent Database instances? Start simple, optimize later.
-
-## Implementation Order
-
-1. ✅ Rename `get_db` → `get_admin_db`, add `AdminDb` type alias
-2. ✅ Add `get_agent_db` dependency (in `auth.py`, with `_per_request` Database mode)
-3. ✅ Add unit tests for `get_agent_db` (`props/backend/test_auth.py`)
-4. ✅ Migrate read endpoints (`agent_definitions`, `stats`, `runs` reads) to `AgentDb`
-5. ⬚ Add integration test for agent credential passthrough (e2e with real Postgres)
-6. ⬚ Migrate write endpoints with RLS (grading edges, reported issues - when they exist)
-7. ⬚ Remove redundant Python ACL checks
-8. ⬚ Update documentation

--- a/props/frontend/src/App.svelte
+++ b/props/frontend/src/App.svelte
@@ -4,6 +4,7 @@
   import { Toaster } from "svelte-sonner";
   import { pathname, resolve, goto, parseParams } from "$lib/router";
   import { connected, startFeed } from "$lib/stores/runsFeed";
+  import { captureTokenFromUrl, getToken, setToken, needsToken } from "$lib/stores/token";
   import RunTriggerModal from "$components/RunTriggerModal.svelte";
   import type { Split, ExampleKind } from "$lib/types";
 
@@ -24,6 +25,7 @@
 
   let showRunModal = $state(false);
   let modalPrefill: ModalPrefill | undefined = $state(undefined);
+  let tokenInput = $state("");
 
   function handleOpenRunModal(prefill?: ModalPrefill) {
     modalPrefill = prefill;
@@ -38,9 +40,22 @@
   // Expose modal functions to child components
   setContext("runModal", { open: handleOpenRunModal });
 
-  // Start WebSocket feed on mount
+  function handleTokenSubmit() {
+    const trimmed = tokenInput.trim();
+    if (trimmed) {
+      setToken(trimmed);
+      tokenInput = "";
+      startFeed();
+    }
+  }
+
   onMount(() => {
-    startFeed();
+    captureTokenFromUrl();
+    if (getToken()) {
+      startFeed();
+    } else {
+      needsToken.set(true);
+    }
   });
 
   // Navigation items
@@ -93,60 +108,80 @@
 
 <Toaster richColors position="top-right" duration={8000} />
 
-<div class="min-h-screen bg-gray-50">
-  <!-- Header -->
-  <header class="bg-white border-b border-gray-200 px-6 py-3">
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-3">
-        <h1 class="text-xl font-bold">
-          <a href={resolve("/")} class="hover:text-blue-600">Props</a>
-        </h1>
-        {#if $connected}
-          <span class="px-2 py-0.5 text-xs bg-green-100 text-green-700 rounded">live</span>
-        {:else}
-          <span class="px-2 py-0.5 text-xs bg-orange-100 text-orange-700 rounded">reconnecting...</span>
-        {/if}
-      </div>
-      <nav class="flex gap-1">
-        {#each navItems as { path, label } (path)}
-          <a
-            href={resolve(path)}
-            class="px-3 py-1.5 rounded text-sm font-medium transition-colors
-              {isActive(path, $pathname)
-              ? 'bg-blue-100 text-blue-700'
-              : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}"
-          >
-            {label}
-          </a>
-        {/each}
-      </nav>
+{#if $needsToken}
+  <div class="min-h-screen bg-gray-50 flex items-center justify-center">
+    <div class="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
+      <h1 class="text-xl font-bold mb-2">Props</h1>
+      <p class="text-gray-600 text-sm mb-4">Paste the admin token from the backend console output to sign in.</p>
+      <form on:submit|preventDefault={handleTokenSubmit} class="flex gap-2">
+        <input
+          type="text"
+          bind:value={tokenInput}
+          placeholder="Admin token"
+          class="flex-1 px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700">
+          Sign in
+        </button>
+      </form>
     </div>
-  </header>
-
-  <!-- Main content -->
-  <main class="p-6">
-    {#if currentRoute.component === "overview"}
-      <OverviewPage />
-    {:else if currentRoute.component === "runs"}
-      <RunsPage />
-    {:else if currentRoute.component === "run-detail"}
-      <RunDetailPage runId={currentRoute.params.runId} />
-    {:else if currentRoute.component === "definition-detail"}
-      <DefinitionDetailPage definitionId={currentRoute.params.definitionId} />
-    {:else if currentRoute.component === "examples"}
-      <ExamplesPage />
-    {:else if currentRoute.component === "snapshots"}
-      <SnapshotsPage />
-    {:else if currentRoute.component === "snapshot-detail"}
-      <SnapshotDetailPage slug={currentRoute.params.slug} />
-    {:else}
-      <div class="text-center py-12">
-        <h2 class="text-2xl font-bold text-gray-900">Page Not Found</h2>
-        <p class="mt-2 text-gray-600">The page you're looking for doesn't exist.</p>
-        <a href={resolve("/")} class="mt-4 inline-block text-blue-600 hover:underline">Go home</a>
+  </div>
+{:else}
+  <div class="min-h-screen bg-gray-50">
+    <!-- Header -->
+    <header class="bg-white border-b border-gray-200 px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+          <h1 class="text-xl font-bold">
+            <a href={resolve("/")} class="hover:text-blue-600">Props</a>
+          </h1>
+          {#if $connected}
+            <span class="px-2 py-0.5 text-xs bg-green-100 text-green-700 rounded">live</span>
+          {:else}
+            <span class="px-2 py-0.5 text-xs bg-orange-100 text-orange-700 rounded">reconnecting...</span>
+          {/if}
+        </div>
+        <nav class="flex gap-1">
+          {#each navItems as { path, label } (path)}
+            <a
+              href={resolve(path)}
+              class="px-3 py-1.5 rounded text-sm font-medium transition-colors
+                {isActive(path, $pathname)
+                ? 'bg-blue-100 text-blue-700'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'}"
+            >
+              {label}
+            </a>
+          {/each}
+        </nav>
       </div>
-    {/if}
-  </main>
-</div>
+    </header>
 
-<RunTriggerModal open={showRunModal} onClose={handleCloseRunModal} prefill={modalPrefill} />
+    <!-- Main content -->
+    <main class="p-6">
+      {#if currentRoute.component === "overview"}
+        <OverviewPage />
+      {:else if currentRoute.component === "runs"}
+        <RunsPage />
+      {:else if currentRoute.component === "run-detail"}
+        <RunDetailPage runId={currentRoute.params.runId} />
+      {:else if currentRoute.component === "definition-detail"}
+        <DefinitionDetailPage definitionId={currentRoute.params.definitionId} />
+      {:else if currentRoute.component === "examples"}
+        <ExamplesPage />
+      {:else if currentRoute.component === "snapshots"}
+        <SnapshotsPage />
+      {:else if currentRoute.component === "snapshot-detail"}
+        <SnapshotDetailPage slug={currentRoute.params.slug} />
+      {:else}
+        <div class="text-center py-12">
+          <h2 class="text-2xl font-bold text-gray-900">Page Not Found</h2>
+          <p class="mt-2 text-gray-600">The page you're looking for doesn't exist.</p>
+          <a href={resolve("/")} class="mt-4 inline-block text-blue-600 hover:underline">Go home</a>
+        </div>
+      {/if}
+    </main>
+  </div>
+
+  <RunTriggerModal open={showRunModal} onClose={handleCloseRunModal} prefill={modalPrefill} />
+{/if}

--- a/props/frontend/src/lib/api/client.ts
+++ b/props/frontend/src/lib/api/client.ts
@@ -1,8 +1,26 @@
 import createClient from "openapi-fetch";
 import type { paths, components } from "./schema";
+import { getToken, onAuthFailed } from "$lib/stores/token";
 
 // Create typed API client (types from Bazel: //props/frontend:generate_schema)
 export const api = createClient<paths>({ baseUrl: "" });
+
+// Attach admin token as Bearer header to every request
+api.use({
+  async onRequest({ request }) {
+    const token = getToken();
+    if (token) {
+      request.headers.set("Authorization", `Bearer ${token}`);
+    }
+    return request;
+  },
+  async onResponse({ response }) {
+    if (response.status === 401) {
+      onAuthFailed();
+    }
+    return response;
+  },
+});
 
 // Re-export generated types
 export type DefinitionInfo = components["schemas"]["DefinitionInfo"];

--- a/props/frontend/src/lib/stores/runsFeed.ts
+++ b/props/frontend/src/lib/stores/runsFeed.ts
@@ -3,6 +3,7 @@
  */
 import { writable, derived } from "svelte/store";
 import type { RunInfo, JobInfo } from "$lib/api/client";
+import { getToken } from "$lib/stores/token";
 
 // State
 export const runs = writable<RunInfo[]>([]);
@@ -19,7 +20,9 @@ let started = false;
 
 function getWsUrl(): string {
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${protocol}//${window.location.host}/api/runs/feed`;
+  const base = `${protocol}//${window.location.host}/api/runs/feed`;
+  const token = getToken();
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
 }
 
 function doConnect() {

--- a/props/frontend/src/lib/stores/token.ts
+++ b/props/frontend/src/lib/stores/token.ts
@@ -1,0 +1,41 @@
+/**
+ * Admin token management - capture from URL, store in localStorage,
+ * provide to API client and WebSocket.
+ */
+import { writable } from "svelte/store";
+
+const STORAGE_KEY = "props_admin_token";
+
+export const needsToken = writable(false);
+
+export function getToken(): string | null {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(STORAGE_KEY, token);
+  needsToken.set(false);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(STORAGE_KEY);
+  needsToken.set(true);
+}
+
+/** Capture token from URL query param, store it, and strip from URL. */
+export function captureTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get("token");
+  if (token) {
+    setToken(token);
+    params.delete("token");
+    const newSearch = params.toString();
+    const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : "") + window.location.hash;
+    history.replaceState(null, "", newUrl);
+  }
+}
+
+/** Signal that auth failed (401) - shows paste-token UI if no token stored. */
+export function onAuthFailed(): void {
+  clearToken();
+}

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -98,6 +98,19 @@ py_library(
 )
 
 py_library(
+    name = "credentials",
+    srcs = ["credentials.py"],
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        ":runs",
+        "//props/db:database",
+        "//props/db:models",
+        "//props/orchestration:agent_credentials",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "runs",
     srcs = ["runs.py"],
     visibility = ["//props:__subpackages__"],

--- a/props/testing/fixtures/credentials.py
+++ b/props/testing/fixtures/credentials.py
@@ -1,0 +1,33 @@
+"""Agent credential factories for integration tests.
+
+Provides make_agent_credentials to create AgentRun records with corresponding
+Postgres roles for RLS testing.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from props.db.database import Database
+from props.db.models import AgentRun, AgentRunStatus
+from props.orchestration.agent_credentials import AgentCredentials, ensure_agent_role
+from props.testing.fixtures.runs import ensure_fake_agent_definitions
+
+
+async def make_agent_credentials(db: Database, type_config: BaseModel, image_digest: str) -> AgentCredentials:
+    """Create an AgentRun record and Postgres role, returning credentials."""
+    run_id = uuid4()
+    with db.session() as session:
+        ensure_fake_agent_definitions(session)
+        agent_run = AgentRun(
+            agent_run_id=run_id,
+            image_digest=image_digest,
+            model="test-model",
+            status=AgentRunStatus.COMPLETED,
+            type_config=type_config.model_dump(),
+        )
+        session.add(agent_run)
+        session.commit()
+    return await ensure_agent_role(db.config, run_id)


### PR DESCRIPTION
## Summary

Implements Phase 2 of the agent credential passthrough plan, enabling row-level security (RLS) policies to enforce access control based on database roles instead of Python-level ACL checks.

## Key Changes

- **New `get_agent_db` dependency** (`auth.py`): FastAPI dependency that creates per-request Database connections using agent credentials for RLS enforcement. Admin users get the shared admin connection; agents get temporary per-request connections that are disposed after the request.

- **Database per-request mode** (`database.py`): Added `_per_request` parameter to `Database.__init__` that uses `NullPool` (no connection pooling) and skips verification/logging for lightweight agent connections.

- **Migrated read endpoints to `AgentDb`**:
  - `agent_definitions.py`: `list_definitions`
  - `stats.py`: all endpoints (`get_overview`, `get_definition_detail`, `get_example_detail`)
  - `runs.py`: read-only endpoints (`list_active_runs`, `list_runs`, `get_run`, `get_run_llm_requests`)

- **Preserved admin-only endpoints**: Write operations (`trigger_validation_runs`) and admin-specific endpoints (`list_jobs`) retain explicit `require_admin_access` dependency.

- **Unit tests** (`test_auth.py`): Comprehensive tests for `get_agent_db` covering admin users, agents, anonymous callers, and cleanup behavior.

- **Removed unnecessary dependencies**: Cleaned up unused `//props/backend:deps` imports from route modules.

## Implementation Details

- `AgentDb` type alias in `auth.py` provides a clean FastAPI route signature: `db: AgentDb` instead of `db: Annotated[Database, Depends(get_agent_db)]`
- Per-request agent connections use `NullPool` to avoid connection pooling overhead
- Admin database connections skip verification logging in per-request mode
- Composite type registration only happens for persistent connections (not per-request)
- Generator-based dependency ensures cleanup via `finally` block

## Testing

Unit tests verify:
- Admin users receive the shared admin database
- Agent users get per-request databases with their credentials
- Anonymous callers receive 401 errors
- Per-request databases are properly disposed after use

https://claude.ai/code/session_01FSfRi4HJB36BTXSpTTWitd