### PR TITLE
Use dedicated exec-capable tmpfs for Bazel cache instead of /dev/shm

### DIFF
--- a/tools/claude_hooks/bazel_wrapper.py
+++ b/tools/claude_hooks/bazel_wrapper.py
@@ -7,11 +7,8 @@ Provides auto-recovery: restarts supervisor and proxy if not running.
 import asyncio
 import logging
 import os
-import subprocess
 import sys
-import tempfile
 from datetime import UTC, datetime
-from pathlib import Path
 
 from tools.claude_hooks import proxy_setup
 from tools.claude_hooks.debug import log_entrypoint_debug
@@ -77,47 +74,6 @@ def _setup_logging(settings: HookSettings) -> None:
     logger.info("bazel_wrapper started")
 
 
-def _is_noexec(path: Path) -> bool:
-    """Check if a path resides on a noexec-mounted filesystem."""
-    probe_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(dir=path, suffix=".probe", delete=False) as probe:
-            probe_path = Path(probe.name)
-            probe.write(b"#!/bin/sh\necho ok\n")
-        probe_path.chmod(0o755)
-        result = subprocess.run([str(probe_path)], check=False, capture_output=True, timeout=5)
-        return result.returncode != 0
-    except (OSError, subprocess.TimeoutExpired):
-        return True
-    finally:
-        if probe_path is not None:
-            probe_path.unlink(missing_ok=True)
-
-
-_INSTALL_BASE_FALLBACK = Path("/tmp/bazel-install")
-
-
-_BAZEL_USER_CACHE = Path.home() / ".cache" / "bazel"
-
-
-def _executable_install_base(settings: HookSettings) -> Path | None:
-    """Return an alternative --install_base path if the default is on a noexec fs.
-
-    Bazel unpacks its embedded JDK into the install base directory under
-    ``~/.cache/bazel/``.  When that path lives on /dev/shm (mounted noexec in
-    gVisor), those binaries can't execute.  Detect this and redirect to the
-    root (9p) filesystem.
-    """
-    bazel_cache = _BAZEL_USER_CACHE.resolve()
-    if not bazel_cache.exists() or not _is_noexec(bazel_cache):
-        return None
-
-    logger.info(
-        "Bazel cache %s is on a noexec fs, redirecting install/output base to %s", bazel_cache, _INSTALL_BASE_FALLBACK
-    )
-    return _INSTALL_BASE_FALLBACK
-
-
 def main() -> None:
     """Main entry point."""
     settings = HookSettings()
@@ -145,18 +101,7 @@ def main() -> None:
     bazelrc_path = get_required_env(ENV_AUTH_PROXY_BAZELRC)
     bazelisk_path = str(get_required_existing_path(ENV_BAZELISK_PATH))
 
-    args = [bazelisk_path, f"--bazelrc={bazelrc_path}"]
-
-    # /dev/shm is mounted noexec in gVisor sandboxes.  When the Bazel cache
-    # dir is symlinked there, the embedded JDK can't execute.  Detect this
-    # and redirect --install_base to the (executable) root filesystem.
-    exec_base = _executable_install_base(settings)
-    if exec_base is not None:
-        args.append(f"--install_base={exec_base / 'install'}")
-        args.append(f"--output_base={exec_base / 'output'}")
-
-    args.extend(sys.argv[1:])
-    os.execvp(bazelisk_path, args)
+    os.execvp(bazelisk_path, [bazelisk_path, f"--bazelrc={bazelrc_path}", *sys.argv[1:]])
 
 
 if __name__ == "__main__":

--- a/tools/claude_hooks/bazel_wrapper.py
+++ b/tools/claude_hooks/bazel_wrapper.py
@@ -7,8 +7,11 @@ Provides auto-recovery: restarts supervisor and proxy if not running.
 import asyncio
 import logging
 import os
+import subprocess
 import sys
+import tempfile
 from datetime import UTC, datetime
+from pathlib import Path
 
 from tools.claude_hooks import proxy_setup
 from tools.claude_hooks.debug import log_entrypoint_debug
@@ -74,6 +77,47 @@ def _setup_logging(settings: HookSettings) -> None:
     logger.info("bazel_wrapper started")
 
 
+def _is_noexec(path: Path) -> bool:
+    """Check if a path resides on a noexec-mounted filesystem."""
+    probe_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path, suffix=".probe", delete=False) as probe:
+            probe_path = Path(probe.name)
+            probe.write(b"#!/bin/sh\necho ok\n")
+        probe_path.chmod(0o755)
+        result = subprocess.run([str(probe_path)], check=False, capture_output=True, timeout=5)
+        return result.returncode != 0
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    finally:
+        if probe_path is not None:
+            probe_path.unlink(missing_ok=True)
+
+
+_INSTALL_BASE_FALLBACK = Path("/tmp/bazel-install")
+
+
+_BAZEL_USER_CACHE = Path.home() / ".cache" / "bazel"
+
+
+def _executable_install_base(settings: HookSettings) -> Path | None:
+    """Return an alternative --install_base path if the default is on a noexec fs.
+
+    Bazel unpacks its embedded JDK into the install base directory under
+    ``~/.cache/bazel/``.  When that path lives on /dev/shm (mounted noexec in
+    gVisor), those binaries can't execute.  Detect this and redirect to the
+    root (9p) filesystem.
+    """
+    bazel_cache = _BAZEL_USER_CACHE.resolve()
+    if not bazel_cache.exists() or not _is_noexec(bazel_cache):
+        return None
+
+    logger.info(
+        "Bazel cache %s is on a noexec fs, redirecting install/output base to %s", bazel_cache, _INSTALL_BASE_FALLBACK
+    )
+    return _INSTALL_BASE_FALLBACK
+
+
 def main() -> None:
     """Main entry point."""
     settings = HookSettings()
@@ -101,7 +145,18 @@ def main() -> None:
     bazelrc_path = get_required_env(ENV_AUTH_PROXY_BAZELRC)
     bazelisk_path = str(get_required_existing_path(ENV_BAZELISK_PATH))
 
-    os.execvp(bazelisk_path, [bazelisk_path, f"--bazelrc={bazelrc_path}", *sys.argv[1:]])
+    args = [bazelisk_path, f"--bazelrc={bazelrc_path}"]
+
+    # /dev/shm is mounted noexec in gVisor sandboxes.  When the Bazel cache
+    # dir is symlinked there, the embedded JDK can't execute.  Detect this
+    # and redirect --install_base to the (executable) root filesystem.
+    exec_base = _executable_install_base(settings)
+    if exec_base is not None:
+        args.append(f"--install_base={exec_base / 'install'}")
+        args.append(f"--output_base={exec_base / 'output'}")
+
+    args.extend(sys.argv[1:])
+    os.execvp(bazelisk_path, args)
 
 
 if __name__ == "__main__":

--- a/tools/claude_hooks/tmpfs_setup.py
+++ b/tools/claude_hooks/tmpfs_setup.py
@@ -1,19 +1,25 @@
 """Set up tmpfs-backed directories for better performance.
 
-gVisor's 9p root filesystem is slow (~30GB). /dev/shm is a 315GB tmpfs.
-This module symlinks cache directories to tmpfs for faster I/O.
+gVisor's 9p root filesystem is slow (~30GB).  This module mounts a dedicated
+tmpfs and symlinks the Bazel cache there for faster I/O.
+
+We do NOT use /dev/shm because gVisor mounts it ``noexec``, which prevents
+Bazel's embedded JDK and external toolchain binaries from executing.  Instead
+we ``mount -t tmpfs`` our own volume (inherits no ``noexec`` restriction).
 """
 
 from __future__ import annotations
 
 import logging
 import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-TMPFS_ROOT = Path("/dev/shm")
+TMPFS_MOUNT = Path("/mnt/bazel-tmpfs")
+TMPFS_SIZE = "300G"
 BAZEL_CACHE_NAME = "bazel-cache"
 
 
@@ -24,16 +30,39 @@ class TmpfsSetup:
     bazel_cache: Path | None
 
 
-def setup_bazel_tmpfs() -> Path:
-    """Set up Bazel cache on tmpfs for faster builds.
+def _ensure_tmpfs_mounted() -> Path:
+    """Mount a dedicated exec-capable tmpfs at ``TMPFS_MOUNT``.
 
-    Creates /dev/shm/bazel-cache and symlinks ~/.cache/bazel to it.
+    Returns the tmpfs root path.  Idempotent — skips if already mounted.
+    """
+    TMPFS_MOUNT.mkdir(parents=True, exist_ok=True)
+
+    # Check if already mounted
+    with Path("/proc/mounts").open() as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2 and parts[1] == str(TMPFS_MOUNT):
+                logger.info("tmpfs already mounted at %s", TMPFS_MOUNT)
+                return TMPFS_MOUNT
+
+    subprocess.run(
+        ["mount", "-t", "tmpfs", "-o", f"size={TMPFS_SIZE}", "tmpfs", str(TMPFS_MOUNT)], check=True, capture_output=True
+    )
+    logger.info("Mounted tmpfs (%s) at %s", TMPFS_SIZE, TMPFS_MOUNT)
+    return TMPFS_MOUNT
+
+
+def setup_bazel_tmpfs() -> Path:
+    """Set up Bazel cache on a dedicated exec-capable tmpfs.
+
+    Mounts a tmpfs at /mnt/bazel-tmpfs and symlinks ~/.cache/bazel to it.
     If ~/.cache/bazel already exists and is not a symlink, moves its
     contents to tmpfs first.
 
     Returns the tmpfs cache path.
     """
-    tmpfs_cache = TMPFS_ROOT / BAZEL_CACHE_NAME
+    tmpfs_root = _ensure_tmpfs_mounted()
+    tmpfs_cache = tmpfs_root / BAZEL_CACHE_NAME
     local_cache = Path.home() / ".cache" / "bazel"
 
     # Create tmpfs directory
@@ -74,7 +103,7 @@ def setup_tmpfs() -> TmpfsSetup:
     """Set up all tmpfs-backed directories.
 
     Currently sets up:
-    - Bazel cache (~/.cache/bazel -> /dev/shm/bazel-cache)
+    - Bazel cache (~/.cache/bazel -> /mnt/bazel-tmpfs/bazel-cache)
     """
     bazel_cache: Path | None = None
 


### PR DESCRIPTION
## Summary
Replace the use of `/dev/shm` for Bazel caching with a dedicated tmpfs mount at `/mnt/bazel-tmpfs`. This resolves issues where gVisor's `noexec` restriction on `/dev/shm` prevents Bazel's embedded JDK and external toolchain binaries from executing.

## Key Changes
- **New tmpfs mount strategy**: Added `_ensure_tmpfs_mounted()` function that creates and mounts a dedicated tmpfs volume at `/mnt/bazel-tmpfs` with 300GB size
- **Idempotent mounting**: The mount operation checks `/proc/mounts` to skip remounting if already present
- **Updated cache path**: Changed Bazel cache symlink target from `/dev/shm/bazel-cache` to `/mnt/bazel-tmpfs/bazel-cache`
- **Added subprocess import**: Required for executing the `mount` command
- **Updated documentation**: Clarified why `/dev/shm` cannot be used and how the new approach solves the problem

## Implementation Details
- The `_ensure_tmpfs_mounted()` function is idempotent and safe to call multiple times
- The dedicated tmpfs inherits normal exec permissions (no `noexec` restriction), allowing Bazel toolchain binaries to run
- Existing cache migration logic is preserved—if `~/.cache/bazel` exists as a regular directory, its contents are moved to the new tmpfs location
- All existing symlink creation and validation logic remains unchanged

https://claude.ai/code/session_01P8uGnX6zSGQprKwzcWKUWP