### PR TITLE
Exclude OCI registry routes from OpenAPI schema generation

### DIFF
--- a/props/backend/routes/registry.py
+++ b/props/backend/routes/registry.py
@@ -131,16 +131,20 @@ async def _record_manifest_push(
 
 
 # Routes — order matters: specific routes must precede the catch-all proxy.
+# All registry routes are excluded from OpenAPI schema (include_in_schema=False)
+# because they're OCI distribution spec endpoints proxied to an upstream registry,
+# not part of our API. The catch-all api_route also causes duplicate operationId
+# collisions in the generated schema since one function serves multiple methods.
 
 
-@router.get("/v2/")
-@router.head("/v2/")
+@router.get("/v2/", include_in_schema=False)
+@router.head("/v2/", include_in_schema=False)
 async def v2_check() -> Response:
     """API version check - allows anonymous access per OCI spec."""
     return Response(content=b"{}", status_code=200, headers={"Docker-Distribution-API-Version": "registry/2.0"})
 
 
-@router.put("/v2/{repo}/manifests/{ref}")
+@router.put("/v2/{repo}/manifests/{ref}", include_in_schema=False)
 async def put_manifest(request: Request, repo: str, ref: str, admin_db: AdminDb, auth: Auth) -> Response:
     """Push a manifest — records agent definition on success."""
     caller_type, agent_run_id = get_caller_type(auth, admin_db)
@@ -159,7 +163,7 @@ async def put_manifest(request: Request, repo: str, ref: str, admin_db: AdminDb,
     return response
 
 
-@router.api_route("/v2/{path:path}", methods=["GET", "HEAD", "POST", "PATCH", "PUT"])
+@router.api_route("/v2/{path:path}", methods=["GET", "HEAD", "POST", "PATCH", "PUT"], include_in_schema=False)
 async def registry_proxy(request: Request, path: str, auth: Auth, admin_db: AdminDb) -> Response:
     """Proxy OCI registry requests with method-based ACL (read for GET/HEAD, write for mutations)."""
     caller_type, _ = get_caller_type(auth, admin_db)


### PR DESCRIPTION
## Summary
Excludes all OCI distribution spec registry routes from the generated OpenAPI schema by adding `include_in_schema=False` to their route decorators. These endpoints are proxied to an upstream registry and are not part of our public API.

## Changes
- Added `include_in_schema=False` to the `/v2/` GET and HEAD endpoints
- Added `include_in_schema=False` to the `/v2/{repo}/manifests/{ref}` PUT endpoint
- Added `include_in_schema=False` to the catch-all `/v2/{path:path}` proxy route
- Added explanatory comment documenting why registry routes are excluded from the schema

## Details
The registry routes implement the OCI Image Spec distribution endpoints and proxy requests to an upstream registry. They should not appear in our API documentation since they're infrastructure endpoints, not part of our application's public API contract. Additionally, the catch-all `api_route` was causing duplicate `operationId` collisions in the generated OpenAPI schema since a single function handles multiple HTTP methods.

https://claude.ai/code/session_019B8Gbc274ncpN3if3CRfuN