### PR TITLE
Use OpenAIStrictModeBaseModel for all tool argument models

### DIFF
--- a/props/critic/BUILD.bazel
+++ b/props/critic/BUILD.bazel
@@ -37,6 +37,7 @@ py_library(
         "//mcp_infra/exec:models",
         "//mcp_infra/exec:subprocess",
         "//openai_utils:model",
+        "//openai_utils:pydantic_strict_mode",
         "//props/core:agent_helpers",
         "//props/core:loop_utils",
         "//props/core/models:examples",

--- a/props/critic/main.py
+++ b/props/critic/main.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from openai import AsyncOpenAI
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from agent_core.agent import Agent
 from agent_core.direct_provider import DirectToolProvider
@@ -27,6 +27,7 @@ from agent_core.loop_control import AllowAnyToolOrTextMessage
 from mcp_infra.exec.models import BaseExecResult
 from mcp_infra.exec.subprocess import DirectExecArgs, run_direct_exec
 from openai_utils.model import BoundOpenAIModel, SystemMessage
+from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 from props.core.agent_helpers import fetch_snapshot, get_current_agent_run, get_current_agent_run_id
 from props.core.loop_utils import render_template_string
 from props.core.models.examples import WholeSnapshotExample
@@ -37,46 +38,39 @@ from props.db.snapshots import DBLocationAnchor
 # --- Tool argument models ---
 
 
-class InsertIssueArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class InsertIssueArgs(OpenAIStrictModeBaseModel):
     issue_id: str = Field(..., description="Unique identifier for this issue (kebab-case slug)")
     rationale: str = Field(..., description="Explanation of why this is an issue")
 
 
-class InsertOccurrenceArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class InsertOccurrenceArgs(OpenAIStrictModeBaseModel):
     issue_id: str = Field(..., description="ID of the issue this occurrence belongs to")
     file: str = Field(..., description="File path relative to workspace root")
     start_line: int | None = Field(None, description="Starting line number")
     end_line: int | None = Field(None, description="Ending line number")
 
 
-class LocationSpec(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class LocationSpec(OpenAIStrictModeBaseModel):
     file: str
     start_line: int | None = None
     end_line: int | None = None
 
 
-class InsertOccurrenceMultiArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class InsertOccurrenceMultiArgs(OpenAIStrictModeBaseModel):
     issue_id: str = Field(..., description="ID of the issue this occurrence belongs to")
     locations: list[LocationSpec] = Field(..., description="List of locations for this occurrence")
 
 
-class DeleteIssueArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class DeleteIssueArgs(OpenAIStrictModeBaseModel):
     issue_id: str = Field(..., description="ID of the issue to delete")
 
 
-class SubmitArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class SubmitArgs(OpenAIStrictModeBaseModel):
     issues_count: int = Field(..., description="Total number of issues reported")
     summary: str = Field(..., description="Brief summary of the code review findings")
 
 
-class ReportFailureArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class ReportFailureArgs(OpenAIStrictModeBaseModel):
     message: str = Field(..., description="Description of why the critique could not be completed")
 
 

--- a/props/critic_dev/BUILD.bazel
+++ b/props/critic_dev/BUILD.bazel
@@ -22,6 +22,7 @@ py_library(
         "//agent_core:handler",
         "//mcp_infra/exec:models",
         "//mcp_infra/exec:subprocess",
+        "//openai_utils:pydantic_strict_mode",
         "//props/core:eval_client",
         "//props/core:ids",
         "//props/core/models:examples",

--- a/props/critic_dev/loop.py
+++ b/props/critic_dev/loop.py
@@ -12,12 +12,13 @@ from enum import StrEnum, auto
 from pathlib import Path
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from agent_core.direct_provider import DirectToolProvider
 from agent_core.handler import BaseHandler
 from mcp_infra.exec.models import BaseExecResult
 from mcp_infra.exec.subprocess import DirectExecArgs, run_direct_exec
+from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 from props.core.eval_client import EvalClient, wait_until_graded
 from props.core.ids import DefinitionId
 from props.core.models.examples import ExampleSpec
@@ -40,13 +41,13 @@ WORKSPACE = Path("/workspace")
 # =============================================================================
 
 
-class ReportFailureArgs(BaseModel):
+class ReportFailureArgs(OpenAIStrictModeBaseModel):
     """Arguments for report_failure tool."""
 
     message: str = Field(..., description="Description of why optimization could not be completed")
 
 
-class RunCriticToolArgs(BaseModel):
+class RunCriticToolArgs(OpenAIStrictModeBaseModel):
     """Arguments for run_critic tool (subset of RunCriticRequest for agent use)."""
 
     definition_id: DefinitionId = Field(
@@ -57,7 +58,7 @@ class RunCriticToolArgs(BaseModel):
     budget_usd: float | None = Field(default=None, description="Max USD cost for this agent")
 
 
-class WaitUntilGradedToolArgs(BaseModel):
+class WaitUntilGradedToolArgs(OpenAIStrictModeBaseModel):
     """Arguments for wait_until_graded tool."""
 
     critic_run_id: str = Field(description="agent_run_id of the critic run to wait for grading")

--- a/props/grader/BUILD.bazel
+++ b/props/grader/BUILD.bazel
@@ -28,6 +28,7 @@ py_library(
     imports = ["../.."],
     visibility = ["//props:__subpackages__"],
     deps = [
+        "//openai_utils:pydantic_strict_mode",
         "@pypi//pydantic",
     ],
 )

--- a/props/grader/tools.py
+++ b/props/grader/tools.py
@@ -7,10 +7,12 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
+
 # --- Ground truth reference types (discriminated union) ---
 
 
-class TPRef(BaseModel):
+class TPRef(OpenAIStrictModeBaseModel):
     """Reference to a true positive occurrence."""
 
     type: Literal["tp"] = "tp"
@@ -18,7 +20,7 @@ class TPRef(BaseModel):
     occurrence_id: str = Field(..., description="Occurrence ID")
 
 
-class FPRef(BaseModel):
+class FPRef(OpenAIStrictModeBaseModel):
     """Reference to a false positive occurrence."""
 
     type: Literal["fp"] = "fp"
@@ -32,58 +34,58 @@ GTRef = Annotated[TPRef | FPRef, Field(discriminator="type")]
 # --- Tool argument models ---
 
 
-class ListPendingArgs(BaseModel):
+class ListPendingArgs(OpenAIStrictModeBaseModel):
     issue: str | None = Field(None, description="Filter to specific critique issue ID")
     gt: GTRef | None = Field(None, description="Filter to specific GT occurrence")
     run: UUID | None = Field(None, description="Filter to specific critic run ID")
 
 
-class ShowIssueArgs(BaseModel):
+class ShowIssueArgs(OpenAIStrictModeBaseModel):
     run: UUID = Field(..., description="Critic run ID")
     issue_id: str = Field(..., description="Critique issue ID to show")
 
 
-class ShowTPArgs(BaseModel):
+class ShowTPArgs(OpenAIStrictModeBaseModel):
     tp_id: str = Field(..., description="True positive ID")
     occurrence_id: str = Field(..., description="Occurrence ID")
 
 
-class ShowFPArgs(BaseModel):
+class ShowFPArgs(OpenAIStrictModeBaseModel):
     fp_id: str = Field(..., description="False positive ID")
     occurrence_id: str = Field(..., description="Occurrence ID")
 
 
-class EdgeSpec(BaseModel):
+class EdgeSpec(OpenAIStrictModeBaseModel):
     """A single edge specification for insert_edges."""
 
     gt_ref: GTRef = Field(..., description="GT reference")
     credit: float = Field(..., ge=0.0, le=1.0, description="Credit value 0.0-1.0")
 
 
-class InsertEdgesArgs(BaseModel):
+class InsertEdgesArgs(OpenAIStrictModeBaseModel):
     run: UUID = Field(..., description="Critic run ID")
     issue_id: str = Field(..., description="Critique issue ID")
     rationale: str = Field(..., description="Explanation for the matches")
     edges: list[EdgeSpec] = Field(..., description="List of edges to create")
 
 
-class FillRemainingArgs(BaseModel):
+class FillRemainingArgs(OpenAIStrictModeBaseModel):
     run: UUID = Field(..., description="Critic run ID")
     issue_id: str = Field(..., description="Critique issue ID")
     expected_count: int = Field(..., description="Expected number of edges to fill (safety check)")
     rationale: str = Field(..., description="Explanation for why these don't match")
 
 
-class DeleteEdgesArgs(BaseModel):
+class DeleteEdgesArgs(OpenAIStrictModeBaseModel):
     run: UUID = Field(..., description="Critic run ID")
     issue_id: str = Field(..., description="Critique issue ID")
 
 
-class SubmitArgs(BaseModel):
+class SubmitArgs(OpenAIStrictModeBaseModel):
     summary: str = Field(..., description="Brief summary of grading results")
 
 
-class ReportFailureArgs(BaseModel):
+class ReportFailureArgs(OpenAIStrictModeBaseModel):
     message: str = Field(..., description="Description of why grading could not be completed")
 
 


### PR DESCRIPTION
Replace repeated ConfigDict(extra="forbid") on tool argument models with OpenAIStrictModeBaseModel base class, which provides both extra="forbid" and import-time strict mode schema validation.

Affected modules:
- props/grader/tools.py: All tool arg models + TPRef/FPRef
- props/critic/main.py: All tool arg models + LocationSpec
- props/critic_dev/loop.py: ReportFailureArgs, RunCriticToolArgs, WaitUntilGradedToolArgs

https://claude.ai/code/session_019bEmCTS71oTK94fJm9bejp