### PR TITLE
Add props/docs data dep to grader and critic container targets

### DIFF
--- a/props/critic/BUILD.bazel
+++ b/props/critic/BUILD.bazel
@@ -26,6 +26,7 @@ load("//tools/testing:docker.bzl", "docker_py_test")
 py_library(
     name = "main",
     srcs = ["main.py"],
+    data = ["//props/docs"],
     imports = ["../.."],
     visibility = ["//props:__subpackages__"],
     deps = [

--- a/props/grader/BUILD.bazel
+++ b/props/grader/BUILD.bazel
@@ -63,6 +63,7 @@ py_library(
 py_library(
     name = "main",
     srcs = ["main.py"],
+    data = ["//props/docs"],
     imports = ["../.."],
     visibility = ["//props:__subpackages__"],
     deps = [


### PR DESCRIPTION
The in-container agent loop renders system prompts from Jinja2 templates in props/docs/. Without declaring these as data deps, the template files are not included in the container's runfiles, causing the grader daemon to crash with a traceback at "Rendering system prompt".

https://claude.ai/code/session_019bEmCTS71oTK94fJm9bejp