### PR TITLE
Add ToolOutputData type alias for structured tool output

### DIFF
--- a/agent_core/agent.py
+++ b/agent_core/agent.py
@@ -42,7 +42,7 @@ from agent_core.loop_control import (
     RequireSpecific,
     ToolPolicy,
 )
-from agent_core.tool_provider import ImageContent, ResultContent, TextContent, ToolProvider, ToolResult
+from agent_core.tool_provider import ImageContent, ResultContent, TextContent, ToolOutputData, ToolProvider, ToolResult
 from openai_utils.model import (
     AssistantMessage,
     AssistantMessageOut,
@@ -235,7 +235,7 @@ def _check_size(result: str) -> None:
         raise RuntimeError(f"Tool output too large: {len(result)} > {MAX_TOOL_RESULT_BYTES}")
 
 
-def _content_is_redundant(content: list[ResultContent], sc: dict[str, Any]) -> bool:
+def _content_is_redundant(content: list[ResultContent], sc: ToolOutputData) -> bool:
     """Check if content is just JSON serialization of structuredContent."""
     if len(content) != 1:
         return False
@@ -289,7 +289,7 @@ def _tool_result_to_openai(result: ToolResult) -> FunctionCallOutputType:
 def _openai_to_tool_result(output: FunctionCallOutputType) -> ToolResult:
     """Convert OpenAI FunctionCallOutputItem.output format to ToolResult."""
     content: list[ResultContent] = []
-    structured_content: dict[str, Any] | None = None
+    structured_content: ToolOutputData | None = None
 
     if isinstance(output, str):
         # Try to parse as JSON for structured_content

--- a/agent_core/tool_provider.py
+++ b/agent_core/tool_provider.py
@@ -30,6 +30,10 @@ class ImageContent(BaseModel):
 
 ResultContent = Annotated[TextContent | ImageContent, Field(discriminator="type")]
 
+# Structured tool output data. Wider than MCP's structuredContent (dict[str, Any] | None)
+# because DirectToolProvider bypasses MCP and can return lists directly. OpenAI's tool
+# output is ultimately a JSON string, so any JSON-serializable value works.
+ToolOutputData = dict[str, Any] | list[Any]
 
 # --- Tool result ---
 
@@ -38,7 +42,7 @@ class ToolResult(BaseModel):
     """Result from a tool invocation."""
 
     content: list[ResultContent] = Field(default_factory=list)
-    structured_content: dict[str, Any] | None = None
+    structured_content: ToolOutputData | None = None
     is_error: bool = False
 
     @classmethod
@@ -52,8 +56,8 @@ class ToolResult(BaseModel):
         return cls(content=[TextContent(text=message)], is_error=True)
 
     @classmethod
-    def structured(cls, data: dict[str, Any], *, is_error: bool = False) -> ToolResult:
-        """Create a structured result with JSON data."""
+    def structured(cls, data: ToolOutputData, *, is_error: bool = False) -> ToolResult:
+        """Create a structured result with JSON data (dict or list)."""
         return cls(structured_content=data, is_error=is_error)
 
     def extract_structured[T](self, output_type: type[T]) -> T:

--- a/mcp_infra/display/result_utils.py
+++ b/mcp_infra/display/result_utils.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from agent_core.tool_provider import TextContent, ToolResult
+from agent_core.tool_provider import TextContent, ToolOutputData, ToolResult
 
 
-def extract_display_data(result: ToolResult) -> dict[str, Any] | str | None:
+def extract_display_data(result: ToolResult) -> ToolOutputData | str | None:
     """Extract display-friendly data from ToolResult.
 
     Prefers structured_content if present, otherwise extracts text from content blocks.


### PR DESCRIPTION
Introduces ToolOutputData = dict[str, Any] | list[Any] as a named type for structured tool output. This is wider than MCP's structuredContent (dict[str, Any] | None) because DirectToolProvider bypasses MCP and can return lists directly — OpenAI's tool output is ultimately a JSON string, so any JSON-serializable value works.

https://claude.ai/code/session_019bEmCTS71oTK94fJm9bejp