### PR TITLE
Add filename convention checker for new Python and Markdown files

### DIFF
--- a/tools/precommit/BUILD.bazel
+++ b/tools/precommit/BUILD.bazel
@@ -9,7 +9,27 @@
 #   bazel run //tools/precommit -- [files...]
 #   bazel run //tools/precommit  # format and validate all tracked files
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+
+py_library(
+    name = "check_filename_conventions",
+    srcs = ["check_filename_conventions.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+    deps = ["@pypi//pygit2"],
+)
+
+py_test(
+    name = "test_check_filename_conventions",
+    srcs = ["test_check_filename_conventions.py"],
+    imports = ["../.."],
+    deps = [
+        ":check_filename_conventions",
+        "@pypi//pygit2",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
 
 py_library(
     name = "check_terraform_centralization",
@@ -47,6 +67,7 @@ py_binary(
     },
     visibility = ["//visibility:public"],
     deps = [
+        ":check_filename_conventions",
         ":check_terraform_centralization",
         "//tools:check_pytest_main",
         "//tools:env_utils",
@@ -80,6 +101,7 @@ py_binary(
     main = "precommit.py",
     visibility = ["//visibility:public"],
     deps = [
+        ":check_filename_conventions",
         ":check_terraform_centralization",
         "//tools:check_pytest_main",
         "//tools:env_utils",

--- a/tools/precommit/check_filename_conventions.py
+++ b/tools/precommit/check_filename_conventions.py
@@ -1,0 +1,53 @@
+"""Check that new .py/.md files and directories use underscores, not dashes."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+import pygit2
+
+
+def check_filename_conventions(repo: pygit2.Repository) -> list[str]:
+    """Check newly staged files for filename convention violations.
+
+    Only flags files with GIT_STATUS_INDEX_NEW (newly added to the index),
+    so existing files with dashes are grandfathered in.
+    """
+    new_files = [path for path, flags in repo.status().items() if flags & pygit2.GIT_STATUS_INDEX_NEW]
+    if not new_files:
+        return []
+
+    try:
+        head_tree = repo.head.peel(pygit2.Tree)
+    except pygit2.GitError:
+        head_tree = None  # No HEAD yet (initial commit)
+
+    violations: list[str] = []
+    checked_dirs: set[str] = set()
+
+    for filepath in sorted(new_files):
+        path = PurePosixPath(filepath)
+
+        if path.suffix in (".py", ".md") and "-" in path.stem:
+            violations.append(f"{filepath}: filename '{path.name}' contains dash, use underscore")
+
+        for parent in path.parents:
+            dir_str = str(parent)
+            if dir_str == "." or dir_str in checked_dirs:
+                continue
+            checked_dirs.add(dir_str)
+
+            if "-" not in parent.name:
+                continue
+
+            # Only flag directories that don't exist in HEAD
+            if head_tree is not None:
+                try:
+                    head_tree[dir_str]
+                    continue
+                except KeyError:
+                    pass
+
+            violations.append(f"{filepath}: new directory '{parent.name}' contains dash, use underscore")
+
+    return violations

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -30,6 +30,7 @@ from python.runfiles import runfiles
 
 from tools.check_pytest_main import check_files_async
 from tools.env_utils import get_workspace_dir
+from tools.precommit.check_filename_conventions import check_filename_conventions
 from tools.precommit.check_terraform_centralization import find_violations
 
 _RUNFILES_OPT = runfiles.Create()
@@ -305,13 +306,24 @@ async def run_terraform_centralization_check(files: list[Path]) -> ValidationRes
 # (bridgecrewio/checkov, antonbabenko/pre-commit-terraform terraform_validate)
 
 
-async def run_validate(files: list[Path], repo_root: Path) -> list[ValidationResult]:
+async def run_filename_convention_check(repo: pygit2.Repository) -> ValidationResult:
+    """Check that new .py/.md files and directories use underscores, not dashes."""
+    name = "filename-conventions"
+    start = time.perf_counter()
+    violations = check_filename_conventions(repo)
+    elapsed = time.perf_counter() - start
+    output = "\n".join(violations) if violations else ""
+    return ValidationResult(name, elapsed, not violations, output)
+
+
+async def run_validate(files: list[Path], repo_root: Path, repo: pygit2.Repository) -> list[ValidationResult]:
     """Run all validations on files."""
     return list(
         await asyncio.gather(
             run_buildifier_lint(files),
             run_pytest_main_check(files, repo_root),
             run_terraform_centralization_check(files),
+            run_filename_convention_check(repo),
             run_subprocess_validation(
                 "kustomize-validate", "_main/cluster/scripts/validate_kustomizations", files, is_cluster_k8s
             ),
@@ -373,7 +385,7 @@ async def main_async() -> int:
 
     # Run validate
     print(f"\nValidating {len(files)} files...")
-    validate_results = await run_validate(files, repo_root)
+    validate_results = await run_validate(files, repo_root, repo)
 
     validate_failed = []
     for vresult in validate_results:

--- a/tools/precommit/test_check_filename_conventions.py
+++ b/tools/precommit/test_check_filename_conventions.py
@@ -1,0 +1,128 @@
+"""Tests for check_filename_conventions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pygit2
+import pytest
+import pytest_bazel
+
+from tools.precommit.check_filename_conventions import check_filename_conventions
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> pygit2.Repository:
+    repo = pygit2.init_repository(str(tmp_path))
+    repo.config["user.name"] = "Test"
+    repo.config["user.email"] = "test@test.com"
+    return repo
+
+
+def _commit(repo: pygit2.Repository) -> None:
+    sig = pygit2.Signature("Test", "test@test.com")
+    tree = repo.index.write_tree()
+    parents = [repo.head.target] if not repo.head_is_unborn else []
+    repo.create_commit("HEAD", sig, sig, "commit", tree, parents)
+
+
+def test_no_violations_with_underscores(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "foo_bar.py").write_text("# test")
+    repo.index.add("foo_bar.py")
+    repo.index.write()
+    assert check_filename_conventions(repo) == []
+
+
+def test_py_file_with_dash(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "foo-bar.py").write_text("# test")
+    repo.index.add("foo-bar.py")
+    repo.index.write()
+    violations = check_filename_conventions(repo)
+    assert len(violations) == 1
+    assert "foo-bar.py" in violations[0]
+    assert "underscore" in violations[0]
+
+
+def test_md_file_with_dash(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "foo-bar.md").write_text("# test")
+    repo.index.add("foo-bar.md")
+    repo.index.write()
+    violations = check_filename_conventions(repo)
+    assert len(violations) == 1
+    assert "foo-bar.md" in violations[0]
+
+
+def test_existing_file_modification_not_flagged(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "foo-bar.py").write_text("# test")
+    repo.index.add("foo-bar.py")
+    repo.index.write()
+    _commit(repo)
+
+    (tmp_path / "foo-bar.py").write_text("# modified")
+    repo.index.add("foo-bar.py")
+    repo.index.write()
+
+    assert check_filename_conventions(repo) == []
+
+
+def test_new_directory_with_dash(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "existing.py").write_text("# test")
+    repo.index.add("existing.py")
+    repo.index.write()
+    _commit(repo)
+
+    new_dir = tmp_path / "my-dir"
+    new_dir.mkdir()
+    (new_dir / "foo.py").write_text("# test")
+    repo.index.add("my-dir/foo.py")
+    repo.index.write()
+
+    violations = check_filename_conventions(repo)
+    assert len(violations) == 1
+    assert "my-dir" in violations[0]
+    assert "directory" in violations[0]
+
+
+def test_existing_directory_with_dash_not_flagged(repo: pygit2.Repository, tmp_path: Path) -> None:
+    dash_dir = tmp_path / "my-dir"
+    dash_dir.mkdir()
+    (dash_dir / "existing.py").write_text("# test")
+    repo.index.add("my-dir/existing.py")
+    repo.index.write()
+    _commit(repo)
+
+    (dash_dir / "new_file.py").write_text("# test")
+    repo.index.add("my-dir/new_file.py")
+    repo.index.write()
+
+    assert check_filename_conventions(repo) == []
+
+
+def test_other_extensions_not_checked(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / "foo-bar.txt").write_text("test")
+    repo.index.add("foo-bar.txt")
+    repo.index.write()
+    assert check_filename_conventions(repo) == []
+
+
+def test_no_staged_changes(repo: pygit2.Repository) -> None:
+    assert check_filename_conventions(repo) == []
+
+
+def test_both_filename_and_directory_violations(repo: pygit2.Repository, tmp_path: Path) -> None:
+    new_dir = tmp_path / "bad-dir"
+    new_dir.mkdir()
+    (new_dir / "bad-name.py").write_text("# test")
+    repo.index.add("bad-dir/bad-name.py")
+    repo.index.write()
+
+    violations = check_filename_conventions(repo)
+    assert len(violations) == 2
+    filenames = [v for v in violations if "filename" in v]
+    dirs = [v for v in violations if "directory" in v]
+    assert len(filenames) == 1
+    assert len(dirs) == 1
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
This PR adds a new validation check to the precommit pipeline that enforces filename conventions for newly added files and directories. The checker ensures that new `.py` and `.md` files, as well as new directories, use underscores instead of dashes in their names.

## Key Changes
- **New module `check_filename_conventions.py`**: Implements the core validation logic that:
  - Scans newly staged files (using git index status)
  - Flags `.py` and `.md` files containing dashes in their names
  - Flags newly created directories containing dashes (existing directories are grandfathered in)
  - Uses pygit2 to interact with git repository state
  
- **Comprehensive test suite `test_check_filename_conventions.py`**: Covers:
  - Valid filenames with underscores
  - Violations for `.py` and `.md` files with dashes
  - Grandfathering of existing files (modifications don't trigger violations)
  - Directory naming violations for new directories only
  - Edge cases like files with other extensions and empty staged changes

- **Integration into precommit pipeline**:
  - Added `run_filename_convention_check()` async function
  - Integrated into `run_validate()` to run alongside other checks
  - Updated `main_async()` to pass repository object to validation runner

- **BUILD.bazel updates**: Added library and test targets with appropriate dependencies

## Implementation Details
- The checker only flags files with `GIT_STATUS_INDEX_NEW` status, ensuring existing files with dashes are not flagged
- Directory violations are only reported for directories that don't exist in the git HEAD tree, allowing existing dash-containing directories to remain
- The implementation gracefully handles repositories with no HEAD (initial commit scenario)
- Results are formatted as human-readable violation messages integrated into the existing validation output

https://claude.ai/code/session_01RxtthvvtsHZWbKXPYG3Gf5