### PR TITLE
Fix session hooks: bazelisk version check, bazelrc location, precommit envs

### DIFF
--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -58,7 +58,10 @@ def get_bazelisk_version(settings: HookSettings) -> str | None:
     bazelisk_path = settings.get_bazelisk_path()
     if not bazelisk_path.exists():
         return None
-    result = subprocess.run([bazelisk_path, "version"], capture_output=True, text=True, check=False)
+    # Use --version (a bazelisk flag) instead of "version" (a bazel subcommand).
+    # "bazel version" starts a Bazel server, which is expensive and may start
+    # without JVM proxy args if called outside the wrapper.
+    result = subprocess.run([bazelisk_path, "--version"], capture_output=True, text=True, check=False)
     if result.returncode != 0:
         return None
     # Return first line (e.g. "Bazelisk version: v1.25.0")

--- a/tools/claude_hooks/precommit_setup.py
+++ b/tools/claude_hooks/precommit_setup.py
@@ -19,12 +19,6 @@ class PrecommitNotInstalled(BaseModel):
     kind: Literal["not_installed"] = "not_installed"
 
 
-class PrecommitReady(BaseModel):
-    """pre-commit hook was already installed; environments assumed ready."""
-
-    kind: Literal["ready"] = "ready"
-
-
 class PrecommitInstallingHooks(BaseModel):
     """pre-commit hook freshly installed and background `install-hooks` is running."""
 
@@ -32,20 +26,7 @@ class PrecommitInstallingHooks(BaseModel):
     pid: int
 
 
-PrecommitSetup = PrecommitNotInstalled | PrecommitReady | PrecommitInstallingHooks
-
-
-def _hook_already_installed(project_dir: Path) -> bool:
-    """Check whether a pre-commit hook is already present in the git repo."""
-    hook = project_dir / ".git" / "hooks" / "pre-commit"
-    if not hook.exists():
-        return False
-    try:
-        content = hook.read_text(errors="replace")
-    except OSError:
-        return False
-    # pre-commit's generated hook contains this marker
-    return "pre-commit" in content
+PrecommitSetup = PrecommitNotInstalled | PrecommitInstallingHooks
 
 
 def install_precommit(project_dir: Path) -> PrecommitSetup:
@@ -55,11 +36,10 @@ def install_precommit(project_dir: Path) -> PrecommitSetup:
     pre-commit is not pre-installed in Claude Code on the web's container.
     pre-commit itself handles missing .git, missing config, and idempotent installs.
 
-    If the hook was already installed, skips the background `install-hooks` step
-    (environments are assumed to already be in place).
+    Always runs `install-hooks` in the background, even if the hook file already
+    exists. The hook file persists across sessions but ~/.cache/pre-commit/
+    environments may not, so we always ensure environments are populated.
     """
-    already_installed = _hook_already_installed(project_dir)
-
     precommit = shutil.which("pre-commit")
     if not precommit:
         logger.info("pre-commit not found on PATH, installing via pip...")
@@ -95,10 +75,6 @@ def install_precommit(project_dir: Path) -> PrecommitSetup:
 
     if not hook_installed:
         return PrecommitNotInstalled()
-
-    if already_installed:
-        logger.info("pre-commit hook was already installed, skipping background install-hooks")
-        return PrecommitReady()
 
     # Launch install-hooks in the background to eagerly pre-install hook
     # environments (especially the ansible language:python venv). Without this,

--- a/tools/claude_hooks/proxy_setup.py
+++ b/tools/claude_hooks/proxy_setup.py
@@ -305,7 +305,13 @@ def _get_local_registry_path() -> Path | None:
 
 
 def _write_bazel_config(settings: HookSettings) -> None:
-    """Write Bazel config to separate file for auth proxy integration."""
+    """Write Bazel config for auth proxy integration.
+
+    Writes to two locations:
+    1. The auth-proxy bazelrc (always written, used by --bazelrc= in wrapper)
+    2. ~/.bazelrc (only if it doesn't already exist, so non-wrapper bazel
+       invocations also pick up proxy config)
+    """
     truststore = settings.get_auth_proxy_truststore()
     combined_ca = settings.get_auth_proxy_combined_ca()
     proxy_rc = settings.get_auth_proxy_rc()
@@ -337,6 +343,17 @@ def _write_bazel_config(settings: HookSettings) -> None:
         local_registry_path=local_registry,
     )
     write_config(proxy_rc, result, "proxy bazelrc")
+
+    # Also write to ~/.bazelrc so that bazel invocations outside the wrapper
+    # (e.g. raw bazelisk calls) pick up proxy config. Skip if ~/.bazelrc
+    # already exists to avoid clobbering user configuration.
+    user_bazelrc = Path.home() / ".bazelrc"
+    if not user_bazelrc.exists():
+        header = "# Written by tools/claude_hooks session_start hook.\n# Delete this file to force regeneration.\n"
+        user_bazelrc.write_text(header + result)
+        logger.info("Wrote proxy bazelrc to %s", user_bazelrc)
+    else:
+        logger.debug("Skipping ~/.bazelrc (already exists)")
 
 
 def _create_combined_ca_bundle(settings: HookSettings) -> None:


### PR DESCRIPTION
…t envs

Three fixes to tools/claude_hooks:

1. bazelisk_setup: Use --version instead of "version" to check bazelisk. "bazel version" starts a Bazel server (expensive, and starts without JVM proxy args when called outside the wrapper).

2. proxy_setup: Also write bazelrc to ~/.bazelrc (skip if it already exists) so non-wrapper bazel invocations pick up proxy config.

3. precommit_setup: Always run install-hooks in background, even when the hook file already exists. The hook file persists across sessions but ~/.cache/pre-commit/ environments may not.

https://claude.ai/code/session_01RxtthvvtsHZWbKXPYG3Gf5