### PR TITLE
Replace subprocess git calls with pygit2 API in filename conventions check

### DIFF
--- a/tools/precommit/check_filename_conventions.py
+++ b/tools/precommit/check_filename_conventions.py
@@ -2,37 +2,21 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import PurePosixPath
 
 import pygit2
 
+_IGNORE_ATTRIBUTES = ("filename-conventions-ignored", "rules-lint-ignored")
 
-def _lint_excluded_paths(filepaths: list[str]) -> set[str]:
+
+def _lint_excluded_paths(repo: pygit2.Repository, filepaths: list[str]) -> set[str]:
     """Return filepaths excluded from filename convention checks.
 
     Checks for either:
     - filename-conventions-ignored=true (specific to this check)
     - rules-lint-ignored=true (general lint exclusion)
     """
-    if not filepaths:
-        return set()
-
-    excluded: set[str] = set()
-    for attr in ["filename-conventions-ignored", "rules-lint-ignored"]:
-        result = subprocess.run(
-            ["git", "check-attr", attr, "--stdin"],
-            check=False,
-            input="\n".join(filepaths),
-            capture_output=True,
-            text=True,
-        )
-        for line in result.stdout.splitlines():
-            # Format: "path: attr-name: true"
-            if ": true" in line:
-                path = line.split(f": {attr}:")[0]
-                excluded.add(path)
-    return excluded
+    return {f for f in filepaths if any(repo.get_attr(f, attr) in (True, "true") for attr in _IGNORE_ATTRIBUTES)}
 
 
 def check_filename_conventions(repo: pygit2.Repository) -> list[str]:
@@ -60,7 +44,7 @@ def check_filename_conventions(repo: pygit2.Repository) -> list[str]:
     if not new_files:
         return []
 
-    excluded = _lint_excluded_paths(new_files)
+    excluded = _lint_excluded_paths(repo, new_files)
 
     violations: list[str] = []
     checked_dirs: set[str] = set()

--- a/tools/precommit/test_check_filename_conventions.py
+++ b/tools/precommit/test_check_filename_conventions.py
@@ -109,6 +109,26 @@ def test_no_staged_changes(repo: pygit2.Repository) -> None:
     assert check_filename_conventions(repo) == []
 
 
+def test_filename_conventions_ignored_attr(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / ".gitattributes").write_text("bad-name.py filename-conventions-ignored=true\n")
+    repo.index.add(".gitattributes")
+    (tmp_path / "bad-name.py").write_text("# test")
+    repo.index.add("bad-name.py")
+    repo.index.write()
+    assert check_filename_conventions(repo) == []
+
+
+def test_rules_lint_ignored_attr(repo: pygit2.Repository, tmp_path: Path) -> None:
+    (tmp_path / ".gitattributes").write_text("ignored-dir/** rules-lint-ignored=true\n")
+    repo.index.add(".gitattributes")
+    ignored_dir = tmp_path / "ignored-dir"
+    ignored_dir.mkdir()
+    (ignored_dir / "bad-name.py").write_text("# test")
+    repo.index.add("ignored-dir/bad-name.py")
+    repo.index.write()
+    assert check_filename_conventions(repo) == []
+
+
 def test_both_filename_and_directory_violations(repo: pygit2.Repository, tmp_path: Path) -> None:
     new_dir = tmp_path / "bad-dir"
     new_dir.mkdir()


### PR DESCRIPTION
## Summary
Refactored the filename conventions linting tool to use the pygit2 library's native attribute checking API instead of spawning subprocess calls to `git check-attr`. This improves performance and reduces external process overhead.

## Key Changes
- Replaced `subprocess.run()` calls to `git check-attr` with `pygit2.Repository.get_attr()` method
- Simplified `_lint_excluded_paths()` function from 20+ lines to a single-line set comprehension
- Updated function signature to accept `pygit2.Repository` parameter for direct attribute access
- Consolidated attribute names into a module-level constant `_IGNORE_ATTRIBUTES`
- Added comprehensive test coverage for both `filename-conventions-ignored` and `rules-lint-ignored` attributes

## Implementation Details
- The new implementation uses a set comprehension that checks if any of the ignore attributes return `True` or the string `"true"` (to handle both boolean and string attribute values)
- Removed the need to parse git command output, eliminating string manipulation and potential parsing edge cases
- Tests verify that files with either ignore attribute are properly excluded from filename convention checks

https://claude.ai/code/session_01Br3otdewvZVAaGDybH4TTT