### PR TITLE
Replace antonbabenko tflint wrapper with local golang hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,20 +169,35 @@ repos:
         args: ["--framework", "terraform", "--skip-check", "CKV_TF_1", "-f"]
         files: "^cluster/terraform/.*\\.tf$"
 
-  # TFLint - Terraform linter (uses antonbabenko wrapper which handles tflint --init)
+  # TFLint - Terraform linter (auto-installed via go install)
   # Config: cluster/.tflint.hcl; plugins cached in ~/.tflint.d/plugins
   # Wrapper groups changed files by directory and runs tflint --chdir=<dir> per directory
   # (tflint always lints the whole module, not individual files)
+  #
+  # Version pin: v0.56.0 is the latest tflint compatible with Go 1.24 (shipped in
+  # Claude Code web containers). v0.60.0+ requires Go >= 1.25.4. Bump when the
+  # container Go version is upgraded.
+  #
+  # Claude Code web: `go install` needs NO_PROXY to NOT include *.googleapis.com,
+  # because proxy.golang.org redirects zip downloads to storage.googleapis.com.
+  # If NO_PROXY bypasses the egress proxy for that domain, DNS fails (no direct
+  # internet in gVisor sandbox). The session-start hook should strip *.googleapis.com
+  # from NO_PROXY — see tools/claude_hooks/ proxy documentation.
+  - repo: local
+    hooks:
+      - id: tflint
+        name: tflint (cluster)
+        language: golang
+        additional_dependencies:
+          - github.com/terraform-linters/tflint@v0.56.0
+        entry: tools/precommit/run_tflint.sh
+        files: "^cluster/terraform/.*\\.tf$"
+
+  # tofu validate - runs tofu init -backend=false + tofu validate per directory
+  # Wrapper handles init with retry logic; discovers tofu via PCT_TFPATH or PATH
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:
-      - id: terraform_tflint
-        args:
-          - --args=--config=__GIT_WORKING_DIR__/cluster/.tflint.hcl
-        files: "^cluster/terraform/.*\\.tf$"
-
-      # tofu validate - runs tofu init -backend=false + tofu validate per directory
-      # Wrapper handles init with retry logic; discovers tofu via PCT_TFPATH or PATH
       - id: terraform_validate
         files: "^cluster/terraform/.*\\.tf$"
 

--- a/tools/claude_hooks/config/bazelrc.mako
+++ b/tools/claude_hooks/config/bazelrc.mako
@@ -7,7 +7,8 @@ startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password
 
 # Pass proxy + TLS CA to repository rules (for Go modules in gazelle, etc.)
 # GONOPROXY=* forces all Go module downloads through HTTP proxy.
-# Explicitly NOT passing NO_PROXY since it excludes *.googleapis.com.
+# Explicitly NOT passing NO_PROXY since it excludes *.googleapis.com
+# (see also _strip_no_proxy_google in env_file.py which fixes this globally).
 common --repo_env=HTTP_PROXY
 common --repo_env=HTTPS_PROXY
 common --repo_env=http_proxy

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -5,6 +5,7 @@ Centralizes all environment variable exports into a single file write.
 
 from __future__ import annotations
 
+import os
 import shlex
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -21,6 +22,31 @@ ENV_AUTH_PROXY_URL = "AUTH_PROXY_URL"
 ENV_AUTH_PROXY_BAZELRC = "AUTH_PROXY_BAZELRC"
 ENV_BAZELISK_PATH = "BAZELISK_PATH"
 ENV_BAZEL_REPO_ROOT = "BAZEL_REPO_ROOT"
+
+
+# NO_PROXY entries that break Go module downloads in the gVisor sandbox.
+# proxy.golang.org redirects zip downloads to storage.googleapis.com;
+# if that's in NO_PROXY, Go bypasses the egress proxy and DNS fails.
+_NO_PROXY_STRIP_PATTERNS = {"*.googleapis.com", "*.google.com"}
+
+
+def _strip_no_proxy_google() -> dict[str, str] | None:
+    """Strip *.googleapis.com and *.google.com from NO_PROXY/no_proxy.
+
+    Returns dict of env var overrides, or None if no change needed.
+    """
+    original = os.environ.get("NO_PROXY", "")
+    if not original:
+        return None
+
+    entries = [e.strip() for e in original.split(",")]
+    filtered = [e for e in entries if e not in _NO_PROXY_STRIP_PATTERNS]
+
+    if len(filtered) == len(entries):
+        return None  # Nothing to strip
+
+    cleaned = ",".join(filtered)
+    return {"NO_PROXY": cleaned, "no_proxy": cleaned}
 
 
 def _exports_from_dict(env_vars: Mapping[str, str | Path]) -> list[str]:
@@ -103,6 +129,17 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     # Anthropic sets these in the container with fresh JWT credentials.
     # Only the bazel wrapper overrides them for its subprocess.
     # See README.md "Our Design Principle" section.
+
+    # Fix NO_PROXY: Anthropic's container sets NO_PROXY with *.googleapis.com
+    # and *.google.com, which breaks Go module downloads. The Go module proxy
+    # (proxy.golang.org) redirects zip downloads to storage.googleapis.com;
+    # Go's net/http honors NO_PROXY, bypasses the egress proxy for that domain,
+    # and DNS fails (no direct internet in gVisor sandbox). Strip these entries
+    # so all external traffic goes through the proxy.
+    no_proxy_override = _strip_no_proxy_google()
+    if no_proxy_override is not None:
+        exports.extend(["", "# NO_PROXY fix: strip *.googleapis.com/*.google.com (breaks Go module downloads)"])
+        exports.extend(_exports_from_dict(no_proxy_override))
 
     # Docker/Podman configuration
     if vars.docker_host or vars.podman_env:

--- a/tools/precommit/run_tflint.sh
+++ b/tools/precommit/run_tflint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Pre-commit hook for tflint: initializes plugins then lints each changed
+# Terraform module directory.
+# tflint binary is installed by pre-commit via language: golang.
+set -euo pipefail
+
+REPO_ROOT="$(pwd)"
+CONFIG="${REPO_ROOT}/cluster/.tflint.hcl"
+
+# Initialize plugins (downloads to ~/.tflint.d/plugins/)
+tflint --init --config="$CONFIG" >&2
+
+# Group file args by directory and lint each unique directory
+declare -A dirs
+for f in "$@"; do
+  dirs["$(dirname "$f")"]=1
+done
+
+exit_code=0
+for dir in "${!dirs[@]}"; do
+  if ! tflint --chdir="$dir" --config="$CONFIG"; then
+    exit_code=1
+  fi
+done
+
+exit "$exit_code"


### PR DESCRIPTION
The antonbabenko/pre-commit-terraform wrapper uses language: script, which requires tflint to be pre-installed on the system. Replace with a local hook using language: golang that auto-installs tflint via go install, similar to the kubeconform hook.

The wrapper script handles tflint --init (plugin download) and per-directory linting. terraform_validate remains on the antonbabenko wrapper since it needs terraform/tofu which isn't a Go binary.

Pinned to v0.56.0 (last version supporting Go 1.24, which is what Claude Code web containers ship). v0.60.0+ requires Go >= 1.25.4. Bump when the container Go version is upgraded.

Also fix NO_PROXY for Go module downloads: Anthropic's container sets NO_PROXY with *.googleapis.com, but proxy.golang.org redirects zip downloads to storage.googleapis.com. Go's net/http honors NO_PROXY, bypasses the egress proxy, and DNS fails (no direct internet in gVisor sandbox). The session-start hook now strips these entries from NO_PROXY.

https://claude.ai/code/session_018kGWQJfbGDZcPpxvZYwJ2Y