### PR TITLE
Add stub RBE platform target to test workspace

### DIFF
--- a/tools/claude_hooks/testdata/test_workspace/BUILD.bazel
+++ b/tools/claude_hooks/testdata/test_workspace/BUILD.bazel
@@ -1,5 +1,16 @@
 """Simple test targets for e2e testing."""
 
+# The generated bazelrc (bazelrc.mako) sets --host_platform=//:rbe_linux_x64.
+# The real workspace defines this via @buildbuddy_toolchain; here we provide a
+# minimal stub so the flag doesn't cause "no such target" errors.
+platform(
+    name = "rbe_linux_x64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 genrule(
     name = "hello",
     outs = ["hello.txt"],


### PR DESCRIPTION
## Summary
Added a minimal `rbe_linux_x64` platform target to the test workspace BUILD file to prevent "no such target" errors when the generated bazelrc applies the `--host_platform` flag.

## Changes
- Added a stub `platform` target named `rbe_linux_x64` with Linux x86_64 constraint values
- Included explanatory comment documenting why this target is needed (the generated bazelrc.mako sets `--host_platform=//:rbe_linux_x64`)
- This allows the test workspace to work with the bazelrc configuration without requiring the full `@buildbuddy_toolchain` setup

## Details
The real workspace defines the `rbe_linux_x64` platform through `@buildbuddy_toolchain`, but the test workspace needs a minimal stub implementation to satisfy the platform flag reference without introducing external dependencies.

https://claude.ai/code/session_01A3PAnWt6CCXDk83hvhc6um