### PR TITLE
Refactor stdio_app and stdio_notifier into reusable libraries

### DIFF
--- a/mcp_infra/testing/BUILD.bazel
+++ b/mcp_infra/testing/BUILD.bazel
@@ -37,6 +37,8 @@ py_library(
     deps = [
         ":notifications",
         ":simple_servers",
+        ":stdio_app_lib",
+        ":stdio_notifier_lib",
         "//:bazel_subprocess",
         "//mcp_infra:prefix",
         "//mcp_infra/compositor",
@@ -78,8 +80,8 @@ py_library(
     ],
 )
 
-py_binary(
-    name = "stdio_app",
+py_library(
+    name = "stdio_app_lib",
     srcs = ["stdio_app.py"],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
@@ -87,6 +89,14 @@ py_binary(
         ":simple_servers",
         "@pypi//anyio",
     ],
+)
+
+py_binary(
+    name = "stdio_app",
+    imports = ["../.."],
+    main_module = "mcp_infra.testing.stdio_app",
+    visibility = ["//:__subpackages__"],
+    deps = [":stdio_app_lib"],
 )
 
 py_library(


### PR DESCRIPTION
## Summary
This change refactors the `stdio_app` and `stdio_notifier` targets to separate library code from binary entry points, enabling these modules to be reused as dependencies in other targets.

## Key Changes
- Converted `stdio_app` from a `py_binary` to a `py_library` named `stdio_app_lib`
- Created a new `py_binary` target `stdio_app` that depends on `stdio_app_lib` and specifies the main module
- Added `stdio_app_lib` and `stdio_notifier_lib` as dependencies to the `simple_servers` library
- This allows other targets to import and use the functionality from these modules without creating circular dependencies or binary conflicts

## Implementation Details
- The library targets (`stdio_app_lib` and `stdio_notifier_lib`) contain the actual implementation code
- The binary target (`stdio_app`) serves as the entry point, depending on the library and specifying `main_module` to indicate the entry point
- This pattern follows Bazel best practices for separating reusable code from executable targets

https://claude.ai/code/session_01VPZ41dSs2CLwJhR65CygEh