### PR TITLE
Switch base image to Python and increase test timeout

### DIFF
--- a/agent_server/BUILD.bazel
+++ b/agent_server/BUILD.bazel
@@ -109,7 +109,7 @@ pkg_tar(
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
+    base = "@python_slim_linux_amd64",
     entrypoint = ["/opt/adgn/policy_eval/shim"],
     env = {
         "PYTHONDONTWRITEBYTECODE": "1",

--- a/agent_server/mcp/approval_policy/test_integration.py
+++ b/agent_server/mcp/approval_policy/test_integration.py
@@ -57,13 +57,13 @@ async def test_approval_system_wired_and_blocks_on_ask(
         # Read pending://calls resource from reader server via MCP
         async with Client(comp._approval_engine.reader) as reader_client:
             pending_data: PendingCallsResponse
-            for _ in range(20):  # up to ~1s
+            for _ in range(30):  # up to ~3s
                 pending_data = await read_text_json_typed(
                     reader_client, comp._approval_engine.reader.pending_calls_resource.uri, PendingCallsResponse
                 )
                 if len(pending_data.pending) >= 1:
                     break
-                await asyncio.sleep(0.05)
+                await asyncio.sleep(0.1)
 
             assert len(pending_data.pending) == 1, f"Expected 1 pending approval, got {len(pending_data.pending)}"
 

--- a/agent_server/policy_eval/BUILD.bazel
+++ b/agent_server/policy_eval/BUILD.bazel
@@ -9,6 +9,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":constants",
+        "//agent_server:approvals",
         "//agent_server/policies:default_policy",
         "//agent_server/policies:policy_types",
         "//agent_server/policies:scaffold",


### PR DESCRIPTION
## Summary
This PR updates the container base image and adjusts test timing to improve reliability and support Python-based operations.

## Key Changes
- **Container Base Image**: Changed from `distroless_cc_linux_amd64` to `python_slim_linux_amd64` to include Python runtime in the container image
- **Test Timeout**: Increased the approval policy integration test retry loop from 20 iterations (1s) to 30 iterations (3s) with longer sleep intervals (0.05s → 0.1s) to reduce flakiness
- **Build Dependency**: Added `//agent_server:approvals` as a dependency to the `policy_eval` binary

## Implementation Details
The base image change enables Python execution within the container, which is necessary for the policy evaluation shim to function properly. The test timing adjustments provide more time for the approval engine to process pending calls, reducing intermittent test failures in CI environments.

https://claude.ai/code/session_013WBvwcYtHh9w1kpqJ1Woxq