### PR TITLE
refactor: rename dashed Bazel target names to underscores

### DIFF
--- a/agent_server/BUILD.bazel
+++ b/agent_server/BUILD.bazel
@@ -56,7 +56,7 @@ py_library(
 # Each binary depends only on what it actually uses
 
 py_binary(
-    name = "adgn-agent-serve",
+    name = "adgn_agent_serve",
     srcs = ["cli.py"],
     main = "cli.py",
     visibility = ["//:__subpackages__"],
@@ -74,13 +74,13 @@ py_binary(
 )
 
 py_binary(
-    name = "agent-server-matrix-bot",
+    name = "agent_server_matrix_bot",
     main_module = "agent_server.matrix_bot",
     deps = [":matrix_bot"],
 )
 
 py_binary(
-    name = "agent-server-generate-frontend-code",
+    name = "agent_server_generate_frontend_code",
     srcs = ["scripts/generate_frontend_code.py"],
     main = "scripts/generate_frontend_code.py",
     deps = [

--- a/claude/claude_hooks/BUILD.bazel
+++ b/claude/claude_hooks/BUILD.bazel
@@ -79,7 +79,7 @@ py_library(
 )
 
 py_binary(
-    name = "claude-autofixer",
+    name = "claude_autofixer",
     srcs = ["precommit_autofix.py"],
     imports = [".."],
     main = "precommit_autofix.py",

--- a/editor_agent/host/BUILD.bazel
+++ b/editor_agent/host/BUILD.bazel
@@ -26,7 +26,7 @@ py_library(
 )
 
 py_binary(
-    name = "adgn-editor-docker",
+    name = "adgn_editor_docker",
     imports = ["../.."],
     main_module = "editor_agent.host.cli",
     visibility = ["//:__subpackages__"],

--- a/editor_agent/host/cli.py
+++ b/editor_agent/host/cli.py
@@ -55,7 +55,7 @@ async def edit(
 ) -> None:
     """Edit a file using an LLM agent in an isolated Docker container.
 
-    Usage: adgn-editor-docker FILE "PROMPT"
+    Usage: adgn_editor_docker FILE "PROMPT"
 
     The agent reads the file content via MCP resource, makes edits using
     docker exec, and submits the final content. On success, the file is

--- a/ember/BUILD.bazel
+++ b/ember/BUILD.bazel
@@ -27,16 +27,16 @@ py_binary(
     deps = ["@pypi//uvicorn"],
 )
 
-# TODO: ember-eval target disabled - src/ember/evals/runner.py does not exist
+# TODO: ember_eval target disabled - src/ember/evals/runner.py does not exist
 # py_binary(
-#     name = "ember-eval",
+#     name = "ember_eval",
 #     srcs = ["src/ember/evals/runner.py"],
 #     main = "src/ember/evals/runner.py",
 #     deps = [":ember"],
 # )
 
 py_binary(
-    name = "ember-python",
+    name = "ember_python",
     main_module = "ember.python_session",
     deps = [":python_session"],
 )

--- a/ember/python_session.py
+++ b/ember/python_session.py
@@ -129,7 +129,7 @@ def cli_main(argv: list[str] | None = None) -> int:
     try:
         output = run_code(code)
     except Exception as exc:  # pragma: no cover - CLI convenience
-        print(f"ember-python: {exc}", file=sys.stderr)
+        print(f"ember_python: {exc}", file=sys.stderr)
         return 1
 
     if not args.quiet and output:

--- a/ember/resources/examples/python-session/demo.sh
+++ b/ember/resources/examples/python-session/demo.sh
@@ -2,22 +2,22 @@
 set -euo pipefail
 
 echo "::demo::status-before"
-ember-python --status || true
+ember_python --status || true
 
 echo "::demo::persist-state"
-ember-python -c "x = 41"
-ember-python -c "x += 1"
-PERSISTED=$(ember-python -c "print(x)")
+ember_python -c "x = 41"
+ember_python -c "x += 1"
+PERSISTED=$(ember_python -c "print(x)")
 printf 'persisted_value=%s\n' "$PERSISTED"
 
 echo "::demo::restart"
-ember-python --restart
-POST_RESTART=$(ember-python -c "print(globals().get('x'))")
+ember_python --restart
+POST_RESTART=$(ember_python -c "print(globals().get('x'))")
 printf 'post_restart=%s\n' "$POST_RESTART"
 
 echo "::demo::heredoc"
 HEREDOC_OUTPUT=$(
-  ember-python <<'PY'
+  ember_python <<'PY'
 print("strings with 'quotes' and $variables stay literal")
 PY
 )
@@ -34,7 +34,7 @@ def changeable() -> str:
     return "first"
 PY
 
-MODULE_VALUE=$(ember-python -c "import helper; print(helper.hello()); print(helper.changeable())")
+MODULE_VALUE=$(ember_python -c "import helper; print(helper.hello()); print(helper.changeable())")
 printf 'module_value=%s\n' "$MODULE_VALUE"
 
 cat <<'PY' >"$WORKSPACE/helper.py"
@@ -45,10 +45,10 @@ def changeable() -> str:
     return "second"
 PY
 
-RELOADED=$(ember-python -c "import importlib, helper; importlib.reload(helper); print(helper.changeable())")
+RELOADED=$(ember_python -c "import importlib, helper; importlib.reload(helper); print(helper.changeable())")
 printf 'module_reloaded=%s\n' "$RELOADED"
 
 echo "::demo::status-after"
-ember-python --status || true
+ember_python --status || true
 
-ember-python --stop || true
+ember_python --stop || true

--- a/ember/system_prompt.md.mako
+++ b/ember/system_prompt.md.mako
@@ -28,7 +28,7 @@ They may be subject to rotation, so re-read them accordingly.
 At container startup a persistent IPython kernel is launched for you. Its connection file lives at
 `/var/run/ember/python/kernel.json`. Connect interactively with `jupyter console --existing
 /var/run/ember/python/kernel.json`. To run a one-off command against the persistent session without staying
-attached, run e.g. `ember-python -c "print('hello from ember')"` or pipe a script.
+attached, run e.g. `ember_python -c "print('hello from ember')"` or pipe a script.
 
 The container ships with a self-checking demo under `/var/emberd/examples/python-session/`. The main script shows the
 workflow:

--- a/ember/test_documentation_snippets.py
+++ b/ember/test_documentation_snippets.py
@@ -39,8 +39,8 @@ def test_python_session_demo_scripts_are_embedded_and_work(
     env["EMBER_WORKSPACE_DIR"] = str(tmp_path / "workspace")
     env["EMBER_PYTHON_SESSION_DIR"] = str(tmp_path / "session")
     env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env['PATH']}"
-    if not shutil.which("ember-python", path=env["PATH"]):
-        pytest.skip("ember-python CLI not available on PATH")
+    if not shutil.which("ember_python", path=env["PATH"]):
+        pytest.skip("ember_python CLI not available on PATH")
 
     test_script = resources.files(ember).joinpath(f"resources/{test_relative}")
     subprocess.run(["bash", str(test_script)], check=True, env=env, text=True)

--- a/experimental/sandboxed_jupyter/BUILD.bazel
+++ b/experimental/sandboxed_jupyter/BUILD.bazel
@@ -36,7 +36,7 @@ py_library(
 )
 
 py_binary(
-    name = "sandbox-jupyter",
+    name = "sandbox_jupyter",
     srcs = ["wrapper.py"],
     main = "wrapper.py",
     deps = [
@@ -49,7 +49,7 @@ py_binary(
 )
 
 py_binary(
-    name = "sandboxed-jupyter",
+    name = "sandboxer",
     srcs = ["sandboxer.py"],
     main = "sandboxer.py",
     deps = [

--- a/headscale_cleanup/BUILD.bazel
+++ b/headscale_cleanup/BUILD.bazel
@@ -21,7 +21,7 @@ py_library(
 )
 
 py_binary(
-    name = "headscale-cleanup",
+    name = "headscale_cleanup",
     srcs = ["__main__.py"],
     main = "__main__.py",
     visibility = ["//:__subpackages__"],

--- a/llm/claude_linter/BUILD.bazel
+++ b/llm/claude_linter/BUILD.bazel
@@ -54,7 +54,7 @@ py_library(
 )
 
 py_binary(
-    name = "claude-linter",
+    name = "claude_linter",
     srcs = ["cli.py"],
     main = "cli.py",
     deps = [

--- a/llm/claude_linter_v2/BUILD.bazel
+++ b/llm/claude_linter_v2/BUILD.bazel
@@ -106,7 +106,7 @@ py_library(
 )
 
 py_binary(
-    name = "claude-linter-v2",
+    name = "claude_linter_v2",
     srcs = ["cli.py"],
     main = "cli.py",
     deps = [

--- a/wt/AGENTS.md
+++ b/wt/AGENTS.md
@@ -15,7 +15,7 @@ Requirements: Bazel (via bazelisk), Python **3.13**+.
 
 ## Development Commands
 
-- Run the CLI entry point: `bazel run //wt:wt-cli -- --help`
+- Run the CLI entry point: `bazel run //wt:wt_cli -- --help`
 - Tests: `bazel test //wt/...`
 - Linting: `bazel build --config=lint //wt/...`
 - Type checking: `bazel build --config=typecheck //wt/...`

--- a/wt/BUILD.bazel
+++ b/wt/BUILD.bazel
@@ -21,7 +21,7 @@ py_library(
 )
 
 py_binary(
-    name = "wt-cli",
+    name = "wt_cli",
     srcs = ["__main__.py"],
     main = "__main__.py",
     visibility = ["//visibility:public"],

--- a/wt/README.md
+++ b/wt/README.md
@@ -21,7 +21,7 @@ Makes switching between git worktrees feel like `git switch` while adding copy-o
 See the repository root AGENTS.md for the standard Bazel workflow.
 
 ```bash
-bazel run //wt:wt-cli -- --help
+bazel run //wt:wt_cli -- --help
 bazel test //wt/...
 bazel build --config=check //wt/...  # lint + typecheck
 ```

--- a/wt/e2e/BUILD.bazel
+++ b/wt/e2e/BUILD.bazel
@@ -17,7 +17,7 @@ py_test(
     srcs = ["test_copy_dirty_state.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -31,7 +31,7 @@ py_test(
     srcs = ["test_github_pr_display_real.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -48,7 +48,7 @@ py_test(
     srcs = ["test_github_pr_display_variants.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -64,7 +64,7 @@ py_test(
     srcs = ["test_manual_delete_then_create.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -78,7 +78,7 @@ py_test(
     srcs = ["test_path_watcher_integration.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -95,7 +95,7 @@ py_test(
     srcs = ["test_post_creation_python_script.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -110,7 +110,7 @@ py_test(
     srcs = ["test_post_creation_script.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -125,7 +125,7 @@ py_test(
     srcs = ["test_post_creation_script_failure_streaming.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -139,7 +139,7 @@ py_test(
     srcs = ["test_real_integration.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -156,7 +156,7 @@ py_test(
     srcs = ["test_real_workflow.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -173,7 +173,7 @@ py_test(
     srcs = ["test_status_dynamic_index.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -189,7 +189,7 @@ py_test(
     srcs = ["test_status_output.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",
@@ -205,7 +205,7 @@ py_test(
     srcs = ["test_worktree_branches.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",

--- a/wt/integration/BUILD.bazel
+++ b/wt/integration/BUILD.bazel
@@ -45,7 +45,7 @@ py_test(
     srcs = ["test_integration_shell.py"],
     data = [
         "//third_party/gitstatusd",
-        "//wt:wt-cli",
+        "//wt:wt_cli",
     ],
     deps = [
         ":conftest",

--- a/wt/shell/BUILD.bazel
+++ b/wt/shell/BUILD.bazel
@@ -14,7 +14,7 @@ py_library(
 )
 
 py_binary(
-    name = "wt-install",
+    name = "wt_install",
     srcs = ["install.py"],
     data = [":shell_scripts"],
     main = "install.py",

--- a/wt/testing/conftest.py
+++ b/wt/testing/conftest.py
@@ -543,15 +543,15 @@ def _apply_isolated_git_env(tmp_path: Path, monkeypatch):
 
 
 def _find_wt_cli_binary() -> str | None:
-    """Find the Bazel-built wt-cli binary if running under Bazel."""
+    """Find the Bazel-built wt_cli binary if running under Bazel."""
     # Check for Bazel runfiles environment
     runfiles_dir = os.environ.get("RUNFILES_DIR") or os.environ.get("TEST_SRCDIR")
     if not runfiles_dir:
         return None
 
-    # Try to find wt-cli in runfiles (it's in the same repo)
-    # The path structure is: runfiles/_main/wt/wt-cli
-    candidate = Path(runfiles_dir) / "_main" / "wt" / "wt-cli"
+    # Try to find wt_cli in runfiles (it's in the same repo)
+    # The path structure is: runfiles/_main/wt/wt_cli
+    candidate = Path(runfiles_dir) / "_main" / "wt" / "wt_cli"
     if candidate.exists():
         return str(candidate)
 
@@ -582,11 +582,11 @@ def shell_runner(tmp_path: Path):
             # Ensure env is a copy
             env = os.environ.copy() if env is None else env.copy()
 
-            # Find the Bazel-built wt-cli binary - tests require it for proper environment setup
+            # Find the Bazel-built wt_cli binary - tests require it for proper environment setup
             wt_cli_path = _find_wt_cli_binary()
             if not wt_cli_path:
                 raise RuntimeError(
-                    "wt-cli binary not found in runfiles. Ensure //wt:wt-cli is in the test's data dependencies."
+                    "wt_cli binary not found in runfiles. Ensure //wt:wt_cli is in the test's data dependencies."
                 )
             wt_fn = _generate_wt_function_for_binary(wt_cli_path)
 

--- a/wt/testing/utils.py
+++ b/wt/testing/utils.py
@@ -12,12 +12,12 @@ _RUNFILES = runfiles.Create()
 
 
 def _get_wt_cli_path() -> str:
-    """Get path to wt-cli binary via Bazel runfiles."""
+    """Get path to wt_cli binary via Bazel runfiles."""
     if _RUNFILES is None:
         raise RuntimeError("Runfiles not available - must run under Bazel")
-    path = _RUNFILES.Rlocation("_main/wt/wt-cli")
+    path = _RUNFILES.Rlocation("_main/wt/wt_cli")
     if path is None:
-        raise RuntimeError("wt-cli binary not found in runfiles")
+        raise RuntimeError("wt_cli binary not found in runfiles")
     return path
 
 


### PR DESCRIPTION
Rename 15 py_binary targets from dash-separated to underscore-separated
names for consistency with Python naming conventions:

- wt-cli → wt_cli (+ all runfiles paths, test refs, docs)
- wt-install → wt_install
- adgn-agent-serve → adgn_agent_serve
- agent-server-matrix-bot → agent_server_matrix_bot
- agent-server-generate-frontend-code → agent_server_generate_frontend_code
- claude-autofixer → claude_autofixer
- claude-linter-v2 → claude_linter_v2
- claude-linter → claude_linter
- headscale-cleanup → headscale_cleanup
- sandbox-jupyter → sandbox_jupyter
- sandboxed-jupyter → sandboxer (resolved naming conflict with py_library)
- ember-python → ember_python (+ demo scripts, system prompt, tests)
- ember-eval → ember_eval (commented-out target)
- adgn-editor-docker → adgn_editor_docker

Skipped svelte-check — it wraps the npm package of the same name.
User-facing CLI names in console_scripts entries are left unchanged.

https://claude.ai/code/session_01MbFVBgtpukmCPsistwxWKs