### PR TITLE
Refactor auth handlers and improve security with argon2

### DIFF
--- a/experimental/gatelet/server/BUILD.bazel
+++ b/experimental/gatelet/server/BUILD.bazel
@@ -114,7 +114,10 @@ py_library(
     srcs = ["security.py"],
     imports = ["../../.."],
     visibility = ["//experimental/gatelet:__subpackages__"],
-    deps = ["@pypi//passlib"],
+    deps = [
+        "@pypi//argon2_cffi",
+        "@pypi//passlib",
+    ],
 )
 
 py_library(
@@ -136,6 +139,7 @@ py_library(
         ":config",
         ":database",
         ":models",
+        ":security",
         "//experimental/gatelet/server/endpoints:webhook_view",
         "//experimental/gatelet/server/tests:utils",
         "@pypi//asgi_lifespan",

--- a/experimental/gatelet/server/auth/BUILD.bazel
+++ b/experimental/gatelet/server/auth/BUILD.bazel
@@ -10,6 +10,7 @@ py_library(
     visibility = ["//experimental/gatelet:__subpackages__"],
     deps = [
         ":handlers",
+        "//experimental/gatelet/server:config",
         "//experimental/gatelet/server:database",
         "@pypi//fastapi",
     ],
@@ -23,9 +24,7 @@ py_library(
     deps = [
         ":key_auth",
         "//experimental/gatelet/server:config",
-        "//experimental/gatelet/server:database",
         "//experimental/gatelet/server:models",
-        "@pypi//fastapi",
         "@pypi//sqlalchemy",
     ],
 )

--- a/experimental/gatelet/server/auth/dependencies.py
+++ b/experimental/gatelet/server/auth/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Cookie, Depends
 
 from experimental.gatelet.server import database
 from experimental.gatelet.server.auth.handlers import AuthContext, admin_auth, key_path_auth, session_auth
+from experimental.gatelet.server.config import Settings, get_settings
 
 
 class AuthDependency:
@@ -27,16 +28,16 @@ auth_dependency = AuthDependency()
 Auth = Annotated[AuthContext, Depends(auth_dependency)]
 
 
-async def get_key_path_auth_with_context(key: str) -> AuthContext:
+async def get_key_path_auth_with_context(key: str, settings: Settings = Depends(get_settings)) -> AuthContext:
     async with database.get_db_session() as session:
-        auth_context = await key_path_auth(key, session)
+        auth_context = await key_path_auth(key, session, settings)
         auth_dependency.set_context(auth_context)
         return auth_context
 
 
-async def get_session_auth_with_context(session_token: str) -> AuthContext:
+async def get_session_auth_with_context(session_token: str, settings: Settings = Depends(get_settings)) -> AuthContext:
     async with database.get_db_session() as session:
-        auth_context = await session_auth(session_token, session)
+        auth_context = await session_auth(session_token, session, settings)
         auth_dependency.set_context(auth_context)
         return auth_context
 

--- a/experimental/gatelet/server/auth/handlers.py
+++ b/experimental/gatelet/server/auth/handlers.py
@@ -7,13 +7,11 @@ from enum import StrEnum
 from typing import Protocol
 from urllib.parse import urlencode
 
-from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from experimental.gatelet.server.auth.key_auth import KeyAuthError, validate_key
-from experimental.gatelet.server.config import Settings, get_settings
-from experimental.gatelet.server.database import get_db_session
+from experimental.gatelet.server.config import Settings
 from experimental.gatelet.server.models import AdminSession, AuthCRSession, AuthKey
 
 logger = logging.getLogger(__name__)
@@ -144,9 +142,7 @@ class AdminAuthContext:
         return f"{base_url}?{urlencode(query_params)}"
 
 
-async def key_path_auth(
-    key: str, db_session: AsyncSession = Depends(get_db_session), settings: Settings = Depends(get_settings)
-) -> KeyPathAuthContext:
+async def key_path_auth(key: str, db_session: AsyncSession, settings: Settings) -> KeyPathAuthContext:
     """Authenticate using key in path."""
     logger.debug("key_path_auth called with key: %s...", key[:4])
 
@@ -160,9 +156,7 @@ async def key_path_auth(
         raise AuthHandlerError
 
 
-async def session_auth(
-    session_token: str, db_session: AsyncSession = Depends(get_db_session), settings: Settings = Depends(get_settings)
-) -> SessionAuthContext:
+async def session_auth(session_token: str, db_session: AsyncSession, settings: Settings) -> SessionAuthContext:
     """Authenticate using challenge-response session token."""
     # Find session
     query = select(AuthCRSession).where(AuthCRSession.session_token == session_token)
@@ -188,7 +182,7 @@ async def session_auth(
     return SessionAuthContext(session)
 
 
-async def admin_auth(session_token: str, db_session: AsyncSession = Depends(get_db_session)) -> AdminAuthContext:
+async def admin_auth(session_token: str, db_session: AsyncSession) -> AdminAuthContext:
     """Authenticate using admin session token."""
     query = select(AdminSession).where(AdminSession.session_token == session_token)
     admin_session = (await db_session.execute(query)).scalar_one_or_none()

--- a/experimental/gatelet/server/conftest.py
+++ b/experimental/gatelet/server/conftest.py
@@ -34,6 +34,7 @@ from experimental.gatelet.server.config import (
     ServerSettings,
     Settings,
     WebhookSettings,
+    get_settings,
 )
 from experimental.gatelet.server.database import get_db_session
 from experimental.gatelet.server.endpoints.webhook_view import PayloadSummary
@@ -169,13 +170,14 @@ def _patch_get_settings(monkeypatch, test_settings: Settings) -> None:
 
 
 @pytest_asyncio.fixture
-async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
+async def client(db_session: AsyncSession, test_settings: Settings) -> AsyncGenerator[AsyncClient]:
     """Get a test client connected to the test database with test settings."""
 
     async def override_db() -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     app.dependency_overrides[get_db_session] = override_db
+    app.dependency_overrides[get_settings] = lambda: test_settings
 
     # Use LifespanManager to properly trigger app startup (which registers auth routes)
     async with (
@@ -185,6 +187,7 @@ async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
         yield client
 
     app.dependency_overrides.pop(get_db_session, None)
+    app.dependency_overrides.pop(get_settings, None)
 
 
 @pytest_asyncio.fixture

--- a/experimental/gatelet/server/conftest.py
+++ b/experimental/gatelet/server/conftest.py
@@ -39,9 +39,12 @@ from experimental.gatelet.server.config import (
 from experimental.gatelet.server.database import get_db_session
 from experimental.gatelet.server.endpoints.webhook_view import PayloadSummary
 from experimental.gatelet.server.models import AuthCRSession, AuthKey, Base
+from experimental.gatelet.server.security import hash_password
 from experimental.gatelet.server.tests.utils import persist
 
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+TEST_ADMIN_PASSWORD = "gatelet"
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -128,11 +131,12 @@ def _patch_get_db_session(monkeypatch, db_session: AsyncSession) -> None:
     """Override ``get_db_session`` globally for tests."""
 
     @asynccontextmanager
-    async def _override() -> AsyncGenerator[AsyncSession]:
+    async def _override(*_args, **_kwargs) -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     monkeypatch.setattr("experimental.gatelet.server.database.get_db_session", _override)
     monkeypatch.setattr("experimental.gatelet.server.app.get_db_session", _override)
+    monkeypatch.setattr("experimental.gatelet.server.lifespan.get_db_session", _override)
 
 
 @pytest.fixture
@@ -151,9 +155,7 @@ def test_settings(tmp_path: Path, postgres_config: PostgresConfig) -> Settings:
         ),
         home_assistant=HomeAssistantSettings(api_url="http://test:8123", api_token="test-token"),
         webhook=WebhookSettings(),
-        admin=AdminSettings(
-            password_hash="$argon2id$v=19$m=65536,t=3,p=4$RCjF2HuPkbI2htBaK8X4/w$ZaY5qRPTqw/wMjAVnxaK9cneVhAsRBQ0Ru1oZW09Mx8"  # argon2 hash for "gatelet"
-        ),
+        admin=AdminSettings(password_hash=hash_password(TEST_ADMIN_PASSWORD)),
         security=SecuritySettings(csrf_secret="test-csrf-secret"),
     )
 

--- a/experimental/gatelet/server/endpoints/test_homeassistant.py
+++ b/experimental/gatelet/server/endpoints/test_homeassistant.py
@@ -34,7 +34,7 @@ async def test_entities_page_admin_links(client: AsyncClient, db_session: AsyncS
     session_cookie = resp.cookies["admin_session"]
     resp = await client.get("/admin/ha/", cookies={"session_token": session_cookie})
     assert resp.status_code == HTTPStatus.OK
-    assert "homeassistant.local:8123" in resp.text
+    assert "test:8123" in resp.text
 
 
 if __name__ == "__main__":

--- a/experimental/gatelet/server/endpoints/webhook_view.py
+++ b/experimental/gatelet/server/endpoints/webhook_view.py
@@ -90,7 +90,10 @@ async def get_webhook_payloads(
     join_condition = WebhookPayload.integration_id == WebhookIntegration.id
     count_query = select(func.count()).select_from(WebhookPayload).join(WebhookIntegration, join_condition)
     payloads_query = (
-        select(WebhookPayload).join(WebhookIntegration, join_condition).order_by(WebhookPayload.received_at.desc())
+        select(WebhookPayload)
+        .join(WebhookIntegration, join_condition)
+        .options(selectinload(WebhookPayload.integration_config))
+        .order_by(WebhookPayload.received_at.desc())
     )
 
     # Apply filter if integration name provided
@@ -116,7 +119,7 @@ async def get_webhook_payloads(
     formatted_payloads = [
         {
             "id": payload.id,
-            "integration_name": payload.integration_name,
+            "integration_name": payload.integration_config.name,
             "received_at": payload.received_at,
             "payload_json": json_formatter.serialize(payload.payload),
         }

--- a/experimental/gatelet/server/lifespan.py
+++ b/experimental/gatelet/server/lifespan.py
@@ -6,10 +6,11 @@ Handles startup and shutdown of application-scoped resources (database engine, t
 import logging
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from pathlib import Path
 from typing import Literal
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from fastapi_csrf_protect import CsrfProtect
@@ -31,6 +32,12 @@ from experimental.gatelet.server.endpoints.webhook_view import get_latest_payloa
 logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).parent
+
+
+def _format_minutes(td: timedelta) -> str:
+    """Jinja2 filter: format a timedelta as minutes."""
+    total_seconds = td.total_seconds() if isinstance(td, timedelta) else float(td)
+    return f"{total_seconds / 60:.1f}m"
 
 
 class _CsrfSettings(BaseModel):
@@ -94,8 +101,10 @@ def _register_auth_routes(app: FastAPI, settings: Settings) -> None:
                 dependencies=[Depends(get_admin_auth_with_context)],
             )
 
-    # Handler for authenticated root
-    async def authenticated_root_handler(request, auth: Auth, settings: Settings = Depends(get_settings)):
+    # Handler for authenticated root — uses settings from the enclosing
+    # _register_auth_routes scope rather than Depends(get_settings), which
+    # would capture the wrong function reference when monkeypatched in tests.
+    async def authenticated_root_handler(request: Request, auth: Auth):
         """Shared handler for authenticated root endpoint."""
         async with get_db_session(request) as db_session:
             recent = await get_latest_payloads(db_session, limit=5)
@@ -163,6 +172,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.templates = Jinja2Templates(directory=BASE_DIR / "templates")
     # Add Python builtins needed by templates
     app.state.templates.env.globals.update({"max": max, "min": min})
+    # Add custom filters
+    app.state.templates.env.filters["minutes"] = _format_minutes
     logger.info("Templates initialized")
 
     yield


### PR DESCRIPTION
## Summary
This PR refactors the authentication system to improve separation of concerns and adds argon2-cffi for password hashing. The main changes involve moving dependency injection from handler functions to the dependency layer, and updating the test infrastructure to properly support the new architecture.

## Key Changes

- **Security improvements**: Added `argon2-cffi` dependency for password hashing and updated test fixtures to use `hash_password()` instead of hardcoded hashes
- **Auth handler refactoring**: Removed `Depends()` decorators from `key_path_auth()`, `session_auth()`, and `admin_auth()` functions, making them pure business logic functions that accept parameters directly
- **Dependency injection consolidation**: Moved dependency resolution to `dependencies.py` where `get_key_path_auth_with_context()` and `get_session_auth_with_context()` now handle FastAPI dependency injection and pass resolved values to handlers
- **Build configuration updates**: Updated `BUILD.bazel` files to reflect new dependencies and module relationships
- **Test infrastructure improvements**: 
  - Enhanced `conftest.py` to properly patch `get_db_session` and `get_settings` across all modules
  - Fixed test client fixture to override both database and settings dependencies
  - Updated test assertions to use test configuration values
- **Template enhancements**: Added `_format_minutes()` Jinja2 filter for formatting timedeltas
- **Query optimization**: Added `selectinload()` to webhook payload queries to prevent N+1 queries and fixed integration name access to use the relationship

## Implementation Details

The auth handler refactoring improves testability by separating concerns: handlers are now pure functions that don't depend on FastAPI's dependency injection system, while the dependency layer (`dependencies.py`) handles all FastAPI-specific concerns. This makes handlers easier to test and reuse.

The settings dependency is now properly threaded through the authentication flow, allowing tests to override settings globally via `app.dependency_overrides`.

https://claude.ai/code/session_01FUvCW6ykhW1y6MrEZfCDEv