### PR TITLE
migrate props OCI images to py_image_layer (aspect_rules_py)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,6 +44,9 @@ use_repo(tf, "tf_toolchains")
 
 register_toolchains("@tf_toolchains//:all")
 
+# Python OCI image layering (aspect_rules_py)
+bazel_dep(name = "aspect_rules_py", version = "1.8.4")
+
 # Container images (rules_oci)
 bazel_dep(name = "rules_oci", version = "2.2.7")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
@@ -60,6 +63,18 @@ oci.pull(
     image = "gcr.io/distroless/cc-debian12",
     platforms = ["linux/amd64"],
     tag = "latest",
+)
+
+# Production base image for py_image_layer containers.
+# aspect_rules_py's py_binary generates a bash launcher, so the base needs a
+# shell. Debian slim provides bash + glibc + libstdc++ at ~30 MB compressed.
+# The hermetic Python toolchain is bundled in the interpreter layer.
+oci.pull(
+    name = "debian_slim",
+    digest = "sha256:6458e6ce2b6448e31bfdced4be7d8aa88d389e6694ab09f5a718a694abe147f4",
+    image = "docker.io/library/debian",
+    platforms = ["linux/amd64"],
+    tag = "bookworm-slim",
 )
 
 # Test-only: Python image for container exec tests (needs shell + Python)
@@ -97,7 +112,7 @@ oci.pull(
     platforms = ["linux/amd64"],
     tag = "0.8.1",
 )
-use_repo(oci, "distroless_cc", "distroless_cc_linux_amd64", "oci_crane_linux_amd64", "postgres_16_linux_amd64", "python_slim", "python_slim_linux_amd64", "registry_2_linux_amd64", "ryuk_linux_amd64")
+use_repo(oci, "debian_slim_linux_amd64", "distroless_cc", "distroless_cc_linux_amd64", "oci_crane_linux_amd64", "postgres_16_linux_amd64", "python_slim", "python_slim_linux_amd64", "registry_2_linux_amd64", "ryuk_linux_amd64")
 
 # Re-export crane binary with public visibility for py_test data deps
 crane = use_extension("//tools:crane_export.bzl", "crane_export")

--- a/props/agents/critic/BUILD.bazel
+++ b/props/agents/critic/BUILD.bazel
@@ -13,10 +13,10 @@ The container runs an agent loop that:
 6. Exits 0 on successful submit
 """
 
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//tools/testing:docker.bzl", "docker_py_test")
 
 exports_files(
@@ -74,12 +74,20 @@ py_binary(
     ],
 )
 
-pkg_tar(
-    name = "main_tar",
-    srcs = [":critic"],
-    include_runfiles = True,
-    package_dir = "/app",
-    strip_prefix = ".",
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
+    name = "critic_bin",
+    imports = ["../../.."],
+    main = "main.py",
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        ":main",
+    ],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":critic_bin",
     visibility = ["//props:__subpackages__"],
 )
 
@@ -171,10 +179,10 @@ docker_py_test(
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
-    cmd = py_binary_distroless_cmd("critic"),
-    env = py_binary_distroless_env("critic"),
-    tars = [":main_tar"],
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("critic_bin"),
+    env = py_image_env(),
+    tars = [":layers"],
     visibility = ["//visibility:public"],
     workdir = "/workspace",
 )

--- a/props/agents/critic/variants/critic.bzl
+++ b/props/agents/critic/variants/critic.bzl
@@ -4,18 +4,18 @@ Each critic variant differs only in its system prompt markdown file.
 All variants share the same agent loop code (main.py) and tools.
 
 Architecture:
-- All variants use //props/agents/critic:main_tar (shared agent loop + variant prompts)
+- All variants use //props/agents/critic:layers (shared agent loop + variant prompts)
 - PROMPT_TEMPLATE_PATH env var selects which variant prompt to use at runtime
 """
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
 def critic_variant(name, prompt_md):
     """Build a critic variant using the in-container model.
 
     All variants share:
-    - //props/agents/critic:main_tar (agent loop, tool definitions, all variant prompts)
+    - //props/agents/critic:layers (agent loop, tool definitions, all variant prompts)
     - Same container base, env, workdir
 
     Each variant differs only in:
@@ -32,18 +32,18 @@ def critic_variant(name, prompt_md):
     """
 
     # Runfiles path for the variant prompt inside the container
-    prompt_runfiles_path = "/app/critic.runfiles/_main/props/agents/critic/variants/" + prompt_md
+    prompt_runfiles_path = "/props/agents/critic/critic_bin.runfiles/_main/props/agents/critic/variants/" + prompt_md
 
-    # Build OCI image: shared main_tar (includes variant prompts via data)
+    # Build OCI image: shared layers (includes variant prompts via data)
     oci_image(
         name = name,
-        base = "@distroless_cc_linux_amd64",
-        cmd = py_binary_distroless_cmd("critic", binary_package = "props/agents/critic"),
-        env = py_binary_distroless_env("critic", extra_env = {
+        base = "@debian_slim_linux_amd64",
+        entrypoint = py_image_entrypoint("critic_bin", binary_package = "props/agents/critic"),
+        env = py_image_env(extra_env = {
             "PROMPT_TEMPLATE_PATH": prompt_runfiles_path,
         }),
         tars = [
-            "//props/agents/critic:main_tar",
+            "//props/agents/critic:layers",
         ],
         workdir = "/workspace",
     )

--- a/props/agents/critic_dev/BUILD.bazel
+++ b/props/agents/critic_dev/BUILD.bazel
@@ -14,6 +14,13 @@ exports_files([
     "rollouts.md.mako",
 ])
 
+# Exported for aspect_py_binary in improve/ and optimize/ (py_image_layer needs
+# a file label for `main`, unlike rules_python's `main_module`).
+exports_files(
+    ["main.py"],
+    visibility = ["//props/agents/critic_dev:__subpackages__"],
+)
+
 py_library(
     name = "eval_client",
     srcs = ["eval_client.py"],

--- a/props/agents/critic_dev/improve/BUILD.bazel
+++ b/props/agents/critic_dev/improve/BUILD.bazel
@@ -5,25 +5,22 @@ Build targets:
     bazel run //props/agents/critic_dev/improve:push  -- Push to local registry (localhost:8000)
 """
 
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@rules_python//python:defs.bzl", "py_binary")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//tools/testing:docker.bzl", "docker_py_test")
 
-py_binary(
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
     name = "improve",
-    main_module = "props.agents.critic_dev.main",
+    main = "//props/agents/critic_dev:main.py",
     visibility = ["//visibility:public"],
     deps = ["//props/agents/critic_dev:main"],
 )
 
-pkg_tar(
-    name = "main_tar",
-    srcs = [":improve"],
-    include_runfiles = True,
-    package_dir = "/app",
-    strip_prefix = ".",
+py_image_layer(
+    name = "layers",
+    binary = ":improve",
     visibility = ["//props:__subpackages__"],
 )
 
@@ -55,11 +52,11 @@ docker_py_test(
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
-    cmd = py_binary_distroless_cmd("improve"),
-    env = py_binary_distroless_env("improve"),
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("improve"),
+    env = py_image_env(),
     tars = [
-        ":main_tar",
+        ":layers",
         "//props:crane_tar",
     ],
     visibility = ["//visibility:public"],

--- a/props/agents/critic_dev/optimize/BUILD.bazel
+++ b/props/agents/critic_dev/optimize/BUILD.bazel
@@ -5,25 +5,22 @@ Build targets:
     bazel run //props/agents/critic_dev/optimize:push  -- Push to local registry (localhost:8000)
 """
 
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@rules_python//python:defs.bzl", "py_binary")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//tools/testing:docker.bzl", "docker_py_test")
 
-py_binary(
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
     name = "optimize",
-    main_module = "props.agents.critic_dev.main",
+    main = "//props/agents/critic_dev:main.py",
     visibility = ["//visibility:public"],
     deps = ["//props/agents/critic_dev:main"],
 )
 
-pkg_tar(
-    name = "main_tar",
-    srcs = [":optimize"],
-    include_runfiles = True,
-    package_dir = "/app",
-    strip_prefix = ".",
+py_image_layer(
+    name = "layers",
+    binary = ":optimize",
     visibility = ["//props:__subpackages__"],
 )
 
@@ -65,11 +62,11 @@ docker_py_test(
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
-    cmd = py_binary_distroless_cmd("optimize"),
-    env = py_binary_distroless_env("optimize"),
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("optimize"),
+    env = py_image_env(),
     tars = [
-        ":main_tar",
+        ":layers",
         "//props:crane_tar",
     ],
     visibility = ["//visibility:public"],

--- a/props/agents/grader/BUILD.bazel
+++ b/props/agents/grader/BUILD.bazel
@@ -12,10 +12,10 @@ The container runs a daemon agent loop that:
 5. Sleeps on pg_notify, wakes to grade new critiques
 """
 
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//tools/testing:docker.bzl", "docker_py_test")
 
 exports_files(
@@ -87,12 +87,20 @@ py_binary(
     ],
 )
 
-pkg_tar(
-    name = "main_tar",
-    srcs = [":grader"],
-    include_runfiles = True,
-    package_dir = "/app",
-    strip_prefix = ".",
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
+    name = "grader_bin",
+    imports = ["../../.."],
+    main = "main.py",
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        ":main",
+    ],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":grader_bin",
     visibility = ["//props:__subpackages__"],
 )
 
@@ -246,10 +254,10 @@ docker_py_test(
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
-    cmd = py_binary_distroless_cmd("grader"),
-    env = py_binary_distroless_env("grader"),
-    tars = [":main_tar"],
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("grader_bin"),
+    env = py_image_env(),
+    tars = [":layers"],
     visibility = ["//visibility:public"],
     workdir = "/workspace",
 )

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -1,9 +1,9 @@
 """Props backend - FastAPI unified server (dashboard, proxies, eval APIs)."""
 
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//props:oci.bzl", "py_binary_distroless_cmd", "py_binary_distroless_env")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//tools/testing:docker.bzl", "docker_py_test")
 
 # NOTE: No aggregator target - use specific per-file targets
@@ -186,20 +186,28 @@ genrule(
 # OCI Image
 # =============================================================================
 
-pkg_tar(
-    name = "app_tar",
-    srcs = [":backend_cli"],
-    include_runfiles = True,
-    package_dir = "/app",
-    strip_prefix = ".",
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
+    name = "backend_bin",
+    imports = ["../.."],
+    main = "cli.py",
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        ":cli",
+    ],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":backend_bin",
 )
 
 oci_image(
     name = "image",
-    base = "@distroless_cc_linux_amd64",
-    entrypoint = py_binary_distroless_cmd("backend_cli") + ["serve"],
-    env = py_binary_distroless_env("backend_cli"),
-    tars = [":app_tar"],
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("backend_bin") + ["serve"],
+    env = py_image_env(),
+    tars = [":layers"],
 )
 
 oci_load(

--- a/props/oci.bzl
+++ b/props/oci.bzl
@@ -1,58 +1,38 @@
-"""OCI image helpers for Bazel py_binary targets on distroless base images.
+"""OCI image helpers for py_image_layer containers.
 
-rules_python's py_binary generates a bash bootstrap script that locates the
-hermetic Python interpreter in runfiles and exec's it. distroless images have
-no shell, so the bash wrapper fails with "no such file or directory".
-
-These helpers compute the CMD and env that bypass the bash wrapper by directly
-invoking the hermetic Python interpreter and stage2 bootstrap from runfiles.
-
-TODO: This is a workaround — we're hand-computing internal rules_python paths
-(venv layout, stage2 bootstrap) that could break on rules_python upgrades.
-Investigate whether rules_python or rules_oci have a first-class solution for
-distroless py_binary containers, or whether switching to a non-distroless base
-with a shell (e.g. cc-debian) would be simpler.
+Uses aspect_rules_py's py_image_layer for multi-layer OCI images
+(interpreter, site-packages, app code) on a debian-slim base with bash.
+The aspect py_binary launcher is a bash script that sets up a venv and
+exec's the Python interpreter, so the base image must provide /bin/bash.
 """
 
-def py_binary_distroless_cmd(binary_name, binary_package = None):
-    """Compute CMD for a distroless container running a Bazel py_binary.
+_PY_IMAGE_ENV = {
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUNBUFFERED": "1",
+}
+
+def py_image_entrypoint(binary_name, binary_package = None):
+    """Compute entrypoint for an OCI image running an aspect py_binary.
 
     Args:
-        binary_name: Name of the py_binary target (e.g., "critic").
-        binary_package: Bazel package of the py_binary (e.g., "props/critic").
-            Defaults to the calling BUILD file's package.
+        binary_name: Name of the aspect_py_binary target (e.g., "critic_bin").
+        binary_package: Bazel package path. Defaults to calling BUILD's package.
 
     Returns:
-        CMD list for oci_image.
+        Entrypoint list for oci_image.
     """
     pkg = binary_package or native.package_name()
-    runfiles = "/app/{}.runfiles".format(binary_name)
-    return [
-        "{}/_main/{}/_{}.venv/bin/python3".format(runfiles, pkg, binary_name),
-        "{}/_main/{}/_{}_stage2_bootstrap.py".format(runfiles, pkg, binary_name),
-    ]
+    return ["/{}/{}".format(pkg, binary_name)]
 
-def py_binary_distroless_env(binary_name, binary_package = None, extra_env = {}):
-    """Compute env for a distroless container running a Bazel py_binary.
+def py_image_env(extra_env = {}):
+    """Standard env dict for py_image_layer containers.
 
     Args:
-        binary_name: Name of the py_binary target (e.g., "critic").
-        binary_package: Bazel package of the py_binary (e.g., "props/critic").
-            Defaults to the calling BUILD file's package.
         extra_env: Additional env vars to merge.
 
     Returns:
         Env dict for oci_image.
     """
-    pkg = binary_package or native.package_name()
-    runfiles = "/app/{}.runfiles".format(binary_name)
-    venv_bin = "{}/_main/{}/_{}.venv/bin".format(runfiles, pkg, binary_name)
-    env = {
-        "PATH": venv_bin,
-        "PYTHONDONTWRITEBYTECODE": "1",
-        "PYTHONUNBUFFERED": "1",
-        "PYTHONSAFEPATH": "1",
-        "RUNFILES_DIR": runfiles,
-    }
+    env = dict(_PY_IMAGE_ENV)
     env.update(extra_env)
     return env


### PR DESCRIPTION
Replace the manual pkg_tar + distroless workaround with aspect_rules_py's py_image_layer, which automatically splits py_binary outputs into three optimized OCI layers: interpreter, site-packages, and application code. This improves layer caching (app-only changes don't rebuild dep layers) and removes the fragile oci.bzl helper that hand-computed internal rules_python paths.

Key changes:
- Add aspect_rules_py v1.8.4 and debian:bookworm-slim base image
- Switch from distroless (no shell) to Debian slim (has bash) since aspect_rules_py's py_binary generates a bash launcher script
- Replace pkg_tar(include_runfiles=True) with py_image_layer in all 5 props container images: critic, grader, improve, optimize, backend
- Rewrite oci.bzl helpers for the new py_image_layer pattern
- Update critic variant macro to use new layer structure

All 5 images build successfully. 31/33 props tests pass (2 pre-existing flaky failures unrelated to this change).

https://claude.ai/code/session_01GFNpsMP5AqHeC2hTNBGCVF