### PR TITLE
CLI mode: write dynamic direnv eval instead of static exports

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -216,7 +216,6 @@ py_library(
         ":settings",
         ":tmpfs_setup",
         "//env_utils",
-        "//fmt_util",
         "//tools:build_info",
         "//tools/claude_hooks/supervisor:setup",
         "@pypi//mako",
@@ -315,6 +314,18 @@ py_library(
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = ["@pypi//pytest"],
+)
+
+py_test(
+    name = "test_envrc_propagation",
+    srcs = ["test_envrc_propagation.py"],
+    imports = ["../.."],
+    deps = [
+        ":conftest",
+        ":env_file",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 py_test(

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -165,12 +165,11 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     write_config(env_file, content, "session environment")
 
 
-def write_direnv_env_file(env_file_path: Path, env_vars: dict[str, str]) -> None:
-    """Write direnv-exported environment variables to CLAUDE_ENV_FILE.
+def write_direnv_env_file(env_file_path: Path) -> None:
+    """Write dynamic direnv eval to CLAUDE_ENV_FILE.
 
-    This is the CLI-mode counterpart to write_env_file. Both routes go
-    through write_config so the env file is always canary-protected.
+    Instead of static exports, writes an eval that re-runs direnv on each
+    Bash tool call, so .envrc changes mid-session are picked up.
     """
-    lines = [f"export {key}={shlex.quote(value)}" for key, value in sorted(env_vars.items())]
-    content = "\n".join(lines) + "\n"
+    content = 'eval "$(direnv export bash 2>/dev/null)"\n'
     write_config(env_file_path, content, "direnv environment")

--- a/tools/claude_hooks/errors.py
+++ b/tools/claude_hooks/errors.py
@@ -41,9 +41,5 @@ class SkipError(Exception):
         self.component = component
 
 
-class DirenvError(Exception):
-    """Error running direnv."""
-
-
 class ProjectNotFoundError(Exception):
     """Could not detect project root directory."""

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -7,7 +7,6 @@ CLI mode: Loads direnv environment.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import logging.handlers
 import os
@@ -23,7 +22,6 @@ from mako.template import Template
 from pydantic import BaseModel
 
 from env_utils import env_utils
-from fmt_util.fmt_util import format_limited_list
 from tools.build_info import BUILD_COMMIT
 from tools.claude_hooks import (
     bazelisk_setup,
@@ -37,7 +35,7 @@ from tools.claude_hooks import (
     tmpfs_setup,
 )
 from tools.claude_hooks.debug import log_entrypoint_debug
-from tools.claude_hooks.errors import DirenvError, SkipError
+from tools.claude_hooks.errors import SkipError
 from tools.claude_hooks.settings import HookSettings
 from tools.claude_hooks.supervisor import setup as supervisor_setup
 
@@ -76,61 +74,24 @@ class HookInput(BaseModel):
 # ============================================================================
 
 
-def find_envrc(start_dir: Path) -> Path | None:
-    """Walk up from start_dir to find .envrc file."""
-    current = start_dir.resolve()
-    while current != current.parent:
-        envrc = current / ".envrc"
-        if envrc.exists():
-            return envrc
-        current = current.parent
-    return None
-
-
 async def run_cli_mode(hook_input: HookInput) -> None:
-    """CLI mode: load direnv environment."""
-    # Find .envrc (walk up from cwd)
-    envrc = find_envrc(hook_input.cwd)
-    if not envrc:
-        # Fallback to ducktape root
-        ducktape_envrc = Path.home() / "code" / "ducktape" / ".envrc"
-        if ducktape_envrc.exists():
-            envrc = ducktape_envrc
-        else:
-            return  # No .envrc to load
+    """CLI mode: write direnv eval into CLAUDE_ENV_FILE.
 
-    # Print direnv-style loading banner
-    print(f"direnv: loading {envrc}")
-
-    # Use direnv to export the environment as JSON
-    try:
-        result = await asyncio.create_subprocess_exec(
-            "direnv", "export", "json", cwd=envrc.parent, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
-        stdout, stderr = await asyncio.wait_for(result.communicate(), timeout=30)
-    except FileNotFoundError:
+    Writes a dynamic `eval "$(direnv export bash)"` snippet so that
+    every Bash tool call re-evaluates direnv. This means .envrc changes
+    mid-session are picked up automatically.
+    """
+    if not shutil.which("direnv"):
         print("direnv: not installed, skipping", file=sys.stderr)
         return
-    except TimeoutError as e:
-        raise DirenvError("direnv export timed out") from e
-
-    if result.returncode != 0:
-        raise DirenvError(f"direnv export failed: {stderr.decode()}")
-
-    stdout_str = stdout.decode()
 
     env_file_path = os.environ.get("CLAUDE_ENV_FILE")
     if not env_file_path:
         print("direnv: CLAUDE_ENV_FILE not available", file=sys.stderr)
         return
 
-    if stdout_str.strip():
-        env_vars: dict[str, str] = json.loads(stdout_str)
-        env_file.write_direnv_env_file(Path(env_file_path), env_vars)
-        # Print direnv-style export banner (summarize changes)
-        exports = [f"+{key}" for key in sorted(env_vars)]
-        if exports:
-            print(f"direnv: export {format_limited_list(exports, 5, separator=' ')}")
+    env_file.write_direnv_env_file(Path(env_file_path))
+    print("direnv: configured (eval on each Bash call)")
 
 
 # ============================================================================

--- a/tools/claude_hooks/test_envrc_propagation.py
+++ b/tools/claude_hooks/test_envrc_propagation.py
@@ -1,0 +1,39 @@
+"""Tests for CLI-mode direnv integration.
+
+Verifies that write_direnv_env_file writes a dynamic eval snippet
+(not static exports), so .envrc changes mid-session propagate into
+subsequent Bash tool calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest_bazel
+
+from tools.claude_hooks.env_file import write_direnv_env_file
+
+
+def test_write_direnv_env_file_writes_eval_snippet(tmp_path: Path) -> None:
+    """Env file contains a dynamic direnv eval, not static exports."""
+    env_file = tmp_path / "env.sh"
+    write_direnv_env_file(env_file)
+
+    content = env_file.read_text()
+    assert 'eval "$(direnv export bash 2>/dev/null)"' in content
+
+
+def test_write_direnv_env_file_no_static_exports(tmp_path: Path) -> None:
+    """Env file should NOT contain static export lines (only the eval)."""
+    env_file = tmp_path / "env.sh"
+    write_direnv_env_file(env_file)
+
+    content = env_file.read_text()
+    # The only "export" should be inside the eval, not standalone export KEY=VALUE lines
+    for line in content.splitlines():
+        if line.startswith("export "):
+            pytest_bazel.fail(f"Found static export line: {line!r}")
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
CLAUDE_ENV_FILE is sourced before every Bash tool call. Previously, the CLI-mode session hook ran `direnv export json` once and wrote static export lines — so .envrc changes mid-session were invisible.

Now writes `eval "$(direnv export bash 2>/dev/null)"` which re-evaluates direnv on each Bash call, picking up .envrc changes automatically.

https://claude.ai/code/session_014LfE4kGLYoiF9LRLn3yegd