### PR TITLE
fix(testing): don't half-close SSL sockets on TLS errors

### DIFF
--- a/tools/claude_hooks/testing/mock_egress_proxy.py
+++ b/tools/claude_hooks/testing/mock_egress_proxy.py
@@ -610,10 +610,12 @@ class MockEgressProxy:
 
         def forward(src: ssl.SSLSocket, dst: ssl.SSLSocket, direction: str) -> None:
             nonlocal bytes_forwarded
+            clean_eof = False
             try:
                 while True:
                     data = src.recv(65536)
                     if not data:
+                        clean_eof = True
                         break
                     dst.sendall(data)
                     with lock:
@@ -621,9 +623,17 @@ class MockEgressProxy:
             except (OSError, ssl.SSLError) as e:
                 logger.debug("Forward %s finished for %s: %s", direction, target_host, e)
             finally:
-                # Shut down write side so the other direction's recv() returns empty
-                with contextlib.suppress(OSError):
-                    dst.shutdown(socket.SHUT_WR)
+                # Only half-close on clean EOF (source sent all data and closed
+                # gracefully). On TLS errors, shutdown(SHUT_WR) must NOT be
+                # called: it operates at the raw TCP level, sending a FIN that
+                # corrupts the TLS session state for the *other* forwarding
+                # thread still reading from the same SSL socket pair. This
+                # caused intermittent TLSV1_ALERT_DECODE_ERROR failures where
+                # the s2c thread couldn't deliver echo responses because c2s's
+                # cleanup destroyed the underlying transport.
+                if clean_eof:
+                    with contextlib.suppress(OSError):
+                        dst.shutdown(socket.SHUT_WR)
 
         # Both sockets stay in blocking mode (default)
         client_ssl.settimeout(30.0)


### PR DESCRIPTION
The bidirectional forwarding threads called shutdown(SHUT_WR) on the destination SSL socket unconditionally—even after TLS errors. Since shutdown(SHUT_WR) operates at the raw TCP level (sending a FIN), it corrupted the TLS session for the other direction's thread, which was still reading from the same SSL socket pair.

This caused intermittent TLSV1_ALERT_DECODE_ERROR failures in test_small_echo: the c2s thread's cleanup destroyed the transport before the s2c thread could deliver the echo response.

Now only half-close on clean EOF (source closed gracefully). On TLS errors the thread just exits; the socket timeout and eventual close in the parent handler handle cleanup.

https://claude.ai/code/session_01EqqnmKizLieYmj8jaJELZg