### PR TITLE
Allow zero USD budget for local/free models

### DIFF
--- a/props/backend/routes/llm.py
+++ b/props/backend/routes/llm.py
@@ -99,10 +99,13 @@ def _check_budget(session: Session, agent_run_id: UUID, budget_usd: float) -> No
     """Check if agent has exceeded its budget. Raises HTTPException(429) if over budget.
 
     Uses the agent_run_budget_status view which recursively sums descendant costs.
+    Zero-cost calls (e.g. local models with $0 pricing) are always allowed.
     """
     status = session.get(AgentRunBudgetStatus, agent_run_id)
     if status is None:
         raise HTTPException(status_code=500, detail=f"Agent run {agent_run_id} not found in budget view")
+    if status.tree_spent_usd == 0 and budget_usd == 0:
+        return
     if status.tree_spent_usd >= budget_usd:
         raise HTTPException(
             status_code=429, detail=f"Budget exceeded: spent ${status.tree_spent_usd:.4f} of ${budget_usd:.2f} budget"

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -88,7 +88,7 @@ class ValidationRunRequest(BaseModel):
     split: Split = Split.VALID
     n_samples: int = Field(ge=1, le=50, default=5)
     critic_model: str
-    budget_usd: float = Field(gt=0, description="Max USD cost per critic agent")
+    budget_usd: float = Field(ge=0, description="Max USD cost per critic agent")
 
 
 class ValidationRunResponse(BaseModel):
@@ -556,7 +556,7 @@ async def _run_validation_batch(job: ValidationJob, registry: AgentRegistry, db:
 
 class OptimizeRunRequest(BaseModel):
     target_metric: TargetMetric = Field(description="Validation metric mode: whole-repo or targeted")
-    budget_usd: float = Field(gt=0, description="Dollar budget for optimization")
+    budget_usd: float = Field(ge=0, description="Dollar budget for optimization")
     optimizer_model: str = Field(description="Model for the optimizer agent")
     critic_model: str = Field(description="Model for critic evaluations")
     timeout_seconds: int = Field(ge=60, le=86400, description="Container timeout in seconds")
@@ -582,7 +582,7 @@ async def trigger_optimize_run(request: Request, body: OptimizeRunRequest) -> Op
 
 class ImproveRunRequest(BaseModel):
     n_examples: int = Field(default=10, ge=1, le=100, description="Number of Pareto-optimal training examples")
-    budget_usd: float = Field(gt=0, description="Dollar budget for improvement")
+    budget_usd: float = Field(ge=0, description="Dollar budget for improvement")
     improvement_model: str = Field(description="Model for the improvement agent")
     critic_model: str = Field(description="Model for critic evaluations")
     timeout_seconds: int = Field(ge=60, le=86400, description="Container timeout in seconds")

--- a/props/backend/routes/test_llm_budget.py
+++ b/props/backend/routes/test_llm_budget.py
@@ -140,5 +140,27 @@ def test_budget_includes_child_run_costs(synced_db: Database) -> None:
         assert exc_info.value.status_code == 429
 
 
+def test_budget_allows_zero_cost_with_zero_budget(synced_db: Database) -> None:
+    """Zero-cost calls (e.g. local models) should be allowed even with budget_usd=0."""
+    run_id = uuid4()
+    with synced_db.session() as session:
+        ensure_fake_agent_definitions(session)
+        session.add(
+            AgentRun(
+                agent_run_id=run_id,
+                image_digest=FAKE_CRITIC_DIGEST,
+                model=BUDGET_TEST_MODEL,
+                type_config=CriticTypeConfig(example=TRAIN_EXAMPLE),
+                status=AgentRunStatus.IN_PROGRESS,
+                budget_usd=0.0,
+            )
+        )
+        session.commit()
+
+    # No costs incurred — zero spent against zero budget should pass
+    with synced_db.session() as session:
+        _check_budget(session, run_id, budget_usd=0.0)
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/props/core/eval_api_models.py
+++ b/props/core/eval_api_models.py
@@ -29,7 +29,7 @@ class RunCriticRequest(BaseModel):
     definition_id: DefinitionId = Field(description="Image ref: OCI digest (sha256:...) or tag (e.g., 'latest')")
     example: ExampleSpec = Field(description="Example to evaluate")
     timeout_seconds: int = Field(gt=0, description="Max seconds before container is killed")
-    budget_usd: float = Field(gt=0, description="Max USD cost for this agent")
+    budget_usd: float = Field(ge=0, description="Max USD cost for this agent")
     critic_model: str = Field(description="Model for the critic agent")
 
 


### PR DESCRIPTION
## Summary
This PR enables support for zero-cost models (such as local models with $0 pricing) by allowing `budget_usd=0` in budget-related API requests and budget validation logic.

## Key Changes
- **Budget validation logic** (`llm.py`): Added special case in `_check_budget()` to allow zero-cost calls when both `tree_spent_usd` and `budget_usd` are 0, with updated docstring explaining the behavior
- **API request models** (`runs.py`, `eval_api_models.py`): Changed budget field validation from `gt=0` (greater than) to `ge=0` (greater than or equal) across:
  - `ValidationRunRequest.budget_usd`
  - `OptimizeRunRequest.budget_usd`
  - `ImproveRunRequest.budget_usd`
  - `RunCriticRequest.budget_usd`
- **Test coverage** (`test_llm_budget.py`): Added `test_budget_allows_zero_cost_with_zero_budget()` to verify that zero-cost calls are allowed even with a zero budget

## Implementation Details
The budget check now explicitly allows the case where no costs have been incurred (`tree_spent_usd == 0`) against a zero budget (`budget_usd == 0`), while still enforcing budget limits for all other scenarios. This enables users to run free/local models without being forced to set an arbitrary positive budget value.

https://claude.ai/code/session_0144uFdX5ihEdRtrGX5yHWy7