### PR TITLE
Handle optional token details from non-OpenAI upstreams

### DIFF
--- a/openai_utils/model.py
+++ b/openai_utils/model.py
@@ -40,25 +40,35 @@ class OutputTokensDetails(BaseModel):
 
 
 class ResponseUsage(BaseModel):
-    """Response usage information (wrapped from OpenAI SDK)."""
+    """Response usage information (wrapped from OpenAI SDK).
+
+    input_tokens_details and output_tokens_details are optional because
+    non-OpenAI upstreams (e.g. llama-server) may omit them.
+    """
 
     input_tokens: int
     output_tokens: int
     total_tokens: int
-    input_tokens_details: InputTokensDetails
-    output_tokens_details: OutputTokensDetails
+    input_tokens_details: InputTokensDetails = Field(default_factory=lambda: InputTokensDetails(cached_tokens=0))
+    output_tokens_details: OutputTokensDetails = Field(default_factory=lambda: OutputTokensDetails(reasoning_tokens=0))
     model_config = ConfigDict(extra="allow")
 
     @classmethod
     def from_sdk(cls, sdk_usage: sdk_usage_types.ResponseUsage) -> Self:
-        """Convert OpenAI SDK ResponseUsage to our wrapped type."""
+        """Convert OpenAI SDK ResponseUsage to our wrapped type.
+
+        input_tokens_details and output_tokens_details may be None when using
+        non-OpenAI upstreams (e.g. llama-server).
+        """
+        input_details = sdk_usage.input_tokens_details
+        output_details = sdk_usage.output_tokens_details
         return cls(
             input_tokens=sdk_usage.input_tokens,
             output_tokens=sdk_usage.output_tokens,
             total_tokens=sdk_usage.total_tokens,
-            input_tokens_details=InputTokensDetails(cached_tokens=sdk_usage.input_tokens_details.cached_tokens),
+            input_tokens_details=InputTokensDetails(cached_tokens=input_details.cached_tokens if input_details else 0),
             output_tokens_details=OutputTokensDetails(
-                reasoning_tokens=sdk_usage.output_tokens_details.reasoning_tokens
+                reasoning_tokens=output_details.reasoning_tokens if output_details else 0
             ),
         )
 


### PR DESCRIPTION
## Summary
Updated the `ResponseUsage` model to gracefully handle cases where `input_tokens_details` and `output_tokens_details` are `None`, which can occur when using non-OpenAI upstream services like llama-server.

## Key Changes
- Made `input_tokens_details` and `output_tokens_details` optional fields with sensible defaults (0 for cached_tokens and reasoning_tokens respectively)
- Updated `from_sdk()` method to safely handle `None` values from upstream responses by checking if details exist before accessing their attributes
- Enhanced docstrings to document the optional nature of these fields and the reason (non-OpenAI upstreams may omit them)

## Implementation Details
- Used `Field(default_factory=...)` to provide default `InputTokensDetails` and `OutputTokensDetails` objects when not provided
- Added null-coalescing logic in `from_sdk()` to extract values only when details objects are present, falling back to 0 otherwise
- This maintains backward compatibility with OpenAI SDK responses while supporting alternative upstream implementations

https://claude.ai/code/session_01LPA4vSqbCC4SGmTQdsJoWa