### PR TITLE
Add mkcert setup for trusted localhost TLS certificates

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -95,8 +95,27 @@ py_library(
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [
+        ":platform_utils",
         ":settings",
         "//bazel_util:subprocess",
+    ],
+)
+
+py_library(
+    name = "platform_utils",
+    srcs = ["platform_utils.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "mkcert_setup",
+    srcs = ["mkcert_setup.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":platform_utils",
+        ":settings",
     ],
 )
 
@@ -207,6 +226,7 @@ py_library(
         ":debug",
         ":env_file",
         ":errors",
+        ":mkcert_setup",
         ":nix_setup",
         ":podman_service",
         ":precommit_setup",
@@ -263,7 +283,9 @@ py_package(
         ":env_file",
         ":errors",
         ":managed_files",
+        ":mkcert_setup",
         ":nix_setup",
+        ":platform_utils",
         ":podman_service",
         ":precommit_setup",
         ":proxy_credentials",

--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -10,7 +10,6 @@ TODO: Eventually unify tool installation via direnv/devenv instead of
 from __future__ import annotations
 
 import logging
-import platform
 import shutil
 import stat
 import subprocess
@@ -19,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from bazel_util.subprocess import write_shell_wrapper
+from tools.claude_hooks.platform_utils import get_platform
 from tools.claude_hooks.settings import HookSettings
 
 logger = logging.getLogger(__name__)
@@ -70,21 +70,8 @@ def get_bazelisk_version(settings: HookSettings) -> str | None:
 
 def get_bazelisk_url() -> str:
     """Get the appropriate Bazelisk download URL for this platform."""
-    system = platform.system().lower()
-    machine = platform.machine().lower()
-
-    # Normalize architecture names
-    if machine in ("x86_64", "amd64"):
-        arch = "amd64"
-    elif machine in ("aarch64", "arm64"):
-        arch = "arm64"
-    else:
-        raise RuntimeError(f"Unsupported architecture: {machine}")
-
-    if system not in ("linux", "darwin"):
-        raise RuntimeError(f"Unsupported OS: {system}")
-
-    binary = f"bazelisk-{system}-{arch}"
+    p = get_platform()
+    binary = f"bazelisk-{p.system}-{p.arch}"
     return f"https://github.com/bazelbuild/bazelisk/releases/download/v{BAZELISK_VERSION}/{binary}"
 
 

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -85,6 +85,10 @@ class EnvVars:
     # Session metadata
     hook_timestamp: datetime
 
+    # mkcert localhost TLS certificate
+    mkcert_cert: Path | None
+    mkcert_key: Path | None
+
     # Age-decrypted secrets (raw shell export lines, appended verbatim)
     secrets_exports: str | None
 
@@ -151,6 +155,11 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
             exports.extend(_exports_from_dict({"DOCKER_HOST": vars.docker_host}))
         if vars.podman_env:
             exports.extend(_exports_from_dict(vars.podman_env))
+
+    # mkcert localhost TLS certificate
+    if vars.mkcert_cert and vars.mkcert_key:
+        exports.extend(["", "# Localhost TLS certificate (mkcert)"])
+        exports.extend(_exports_from_dict({"MKCERT_CERT": vars.mkcert_cert, "MKCERT_KEY": vars.mkcert_key}))
 
     # Session metadata
     exports.extend(["", "# Session metadata"])

--- a/tools/claude_hooks/mkcert_setup.py
+++ b/tools/claude_hooks/mkcert_setup.py
@@ -1,0 +1,144 @@
+"""Install mkcert and generate a trusted localhost TLS certificate.
+
+mkcert creates a local Certificate Authority and installs it into system
+trust stores, then generates certificates signed by that CA. This gives
+localhost a valid TLS certificate trusted by curl, Python, Node, etc.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.claude_hooks.platform_utils import get_platform
+from tools.claude_hooks.settings import HookSettings
+
+logger = logging.getLogger(__name__)
+
+MKCERT_VERSION = "1.4.4"
+
+
+@dataclass
+class MkcertSetup:
+    """Result of mkcert installation and certificate generation."""
+
+    cert_path: Path
+    key_path: Path
+    ca_root: Path
+    status: str
+
+
+def _get_mkcert_dir(settings: HookSettings) -> Path:
+    return settings.get_cache_dir() / "mkcert"
+
+
+def _get_mkcert_binary(settings: HookSettings) -> Path:
+    return _get_mkcert_dir(settings) / "mkcert"
+
+
+def _get_download_url() -> str:
+    """Get the appropriate mkcert download URL for this platform."""
+    p = get_platform()
+    return (
+        f"https://github.com/FiloSottile/mkcert/releases/download/"
+        f"v{MKCERT_VERSION}/mkcert-v{MKCERT_VERSION}-{p.system}-{p.arch}"
+    )
+
+
+def _download_mkcert(settings: HookSettings) -> Path:
+    """Download mkcert binary if not already present."""
+    mkcert_dir = _get_mkcert_dir(settings)
+    mkcert_path = _get_mkcert_binary(settings)
+
+    mkcert_dir.mkdir(parents=True, exist_ok=True)
+
+    if mkcert_path.exists():
+        logger.info("mkcert already downloaded: %s", mkcert_path)
+        return mkcert_path
+
+    url = _get_download_url()
+    logger.info("Downloading mkcert from %s", url)
+
+    with urllib.request.urlopen(url, timeout=60) as response:
+        mkcert_path.write_bytes(response.read())
+
+    mkcert_path.chmod(mkcert_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    logger.info("Installed mkcert to %s", mkcert_path)
+    return mkcert_path
+
+
+def _append_ca_to_bundle(root_ca: Path, combined_ca: Path) -> None:
+    """Append mkcert root CA to the combined CA bundle.
+
+    The combined CA bundle is recreated from scratch on each hook run
+    (system CAs + proxy CA), so we always need to re-append.
+    """
+    ca_content = root_ca.read_text()
+    with combined_ca.open("a") as f:
+        f.write("\n# mkcert local CA\n")
+        f.write(ca_content)
+    logger.info("Appended mkcert root CA to %s", combined_ca)
+
+
+def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> MkcertSetup:
+    """Install mkcert, generate trusted localhost certificate.
+
+    Downloads mkcert, installs a local CA into system trust stores,
+    generates a certificate for localhost/127.0.0.1/::1, and appends
+    the root CA to the combined CA bundle so Python/curl/Node trust it.
+    """
+    mkcert_dir = _get_mkcert_dir(settings)
+    mkcert_dir.mkdir(parents=True, exist_ok=True)
+
+    ca_root = mkcert_dir / "ca"
+    ca_root.mkdir(parents=True, exist_ok=True)
+
+    cert_path = mkcert_dir / "localhost.pem"
+    key_path = mkcert_dir / "localhost-key.pem"
+
+    env = {**os.environ, "CAROOT": str(ca_root)}
+
+    if not cert_path.exists() or not key_path.exists():
+        mkcert_bin = _download_mkcert(settings)
+
+        # Install local CA into system trust stores
+        logger.info("Installing mkcert local CA (CAROOT=%s)...", ca_root)
+        result = subprocess.run([str(mkcert_bin), "-install"], env=env, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            # -install can fail if certutil (libnss3-tools) is missing;
+            # the CA still works for non-browser tools via the combined bundle
+            logger.warning("mkcert -install returned %d: %s", result.returncode, result.stderr.strip())
+        else:
+            logger.info("mkcert CA installed into system trust stores")
+
+        # Generate localhost certificate
+        logger.info("Generating localhost certificate...")
+        subprocess.run(
+            [
+                str(mkcert_bin),
+                "-cert-file",
+                str(cert_path),
+                "-key-file",
+                str(key_path),
+                "localhost",
+                "127.0.0.1",
+                "::1",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Generated localhost cert: %s", cert_path)
+
+    # Append mkcert root CA to combined CA bundle so Python/curl/Node trust localhost
+    root_ca = ca_root / "rootCA.pem"
+    if combined_ca and combined_ca.exists() and root_ca.exists():
+        _append_ca_to_bundle(root_ca, combined_ca)
+
+    return MkcertSetup(cert_path=cert_path, key_path=key_path, ca_root=ca_root, status=f"installed ({cert_path})")

--- a/tools/claude_hooks/platform_utils.py
+++ b/tools/claude_hooks/platform_utils.py
@@ -1,0 +1,35 @@
+"""Platform detection utilities for tool downloads."""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+
+
+@dataclass
+class PlatformInfo:
+    """Normalized platform identifiers for binary downloads."""
+
+    system: str  # "linux" or "darwin"
+    arch: str  # "amd64" or "arm64"
+
+
+def get_platform() -> PlatformInfo:
+    """Detect current platform, normalized for GitHub release binary names.
+
+    Raises RuntimeError for unsupported OS or architecture.
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if machine in ("x86_64", "amd64"):
+        arch = "amd64"
+    elif machine in ("aarch64", "arm64"):
+        arch = "arm64"
+    else:
+        raise RuntimeError(f"Unsupported architecture: {machine}")
+
+    if system not in ("linux", "darwin"):
+        raise RuntimeError(f"Unsupported OS: {system}")
+
+    return PlatformInfo(system=system, arch=arch)

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -27,6 +27,7 @@ from tools.claude_hooks import (
     bazelisk_setup,
     buildbuddy_setup,
     env_file,
+    mkcert_setup,
     nix_setup,
     podman_service,
     precommit_setup,
@@ -176,6 +177,7 @@ def emit_session_context(
     podman: podman_service.PodmanSetup | None,
     precommit: precommit_setup.PrecommitSetup | None,
     secrets: secrets_setup.SecretsSetup | None,
+    mkcert: mkcert_setup.MkcertSetup | None = None,
 ) -> None:
     """Emit compact context summary for Claude Code transcript.
 
@@ -193,6 +195,7 @@ def emit_session_context(
         podman=podman,
         precommit=precommit,
         PrecommitInstallingHooks=precommit_setup.PrecommitInstallingHooks,
+        mkcert=mkcert,
         log_entries=collector.buffer,
         has_github_token=bool(os.environ.get("DUCKTAPE_CI_READ_GITHUB_TOKEN")),
         secrets=secrets,
@@ -345,23 +348,35 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
             bazelisk_skipped=skipped,
         )
 
+    # Create a shared proxy task so both mkcert and other code can depend on it
+    proxy_task = asyncio.create_task(setup_proxy_with_supervisor())
+
+    async def setup_mkcert_with_proxy() -> mkcert_setup.MkcertSetup:
+        """Set up mkcert (depends on proxy for the combined CA bundle)."""
+        if not settings.install_mkcert:
+            raise SkipError("mkcert disabled (install_mkcert=False)")
+        await proxy_task
+        combined_ca = settings.get_auth_proxy_combined_ca()
+        return mkcert_setup.setup_mkcert(settings, combined_ca if combined_ca.exists() else None)
+
     # Decrypt age-encrypted secrets (fast, local file I/O only)
     secrets = secrets_setup.setup_secrets(age_key=settings.secrets_age_key, secrets_dir=settings.secrets_dir)
 
     # PARALLEL: All setup tasks (with explicit dependencies via task awaits)
     # Dependency graph:
-    #   supervisor_task ──┬── setup_proxy_with_supervisor
+    #   supervisor_task ──┬── proxy_task ──── setup_mkcert_with_proxy
     #                     └── setup_podman_with_deps ←── tmpfs_mount_task
     #   tmpfs_mount_task ──── setup_bazel_on_tmpfs
     logger.info("Starting parallel installations...")
     results = await asyncio.gather(
-        setup_proxy_with_supervisor(),
+        proxy_task,
         setup_podman_with_deps(),
         run_in_thread(precommit_setup.install_precommit, project_dir),
         run_in_thread(nix_setup.install_nix, settings),
         run_in_thread(install_bazelisk_wrapper),
         run_in_thread(buildbuddy_setup.setup_buildbuddy, project_dir),
         setup_bazel_on_tmpfs(),
+        setup_mkcert_with_proxy(),
         return_exceptions=True,
     )
     # Unpack with explicit type annotations for mypy
@@ -372,6 +387,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
     bazelisk: bazelisk_setup.BazeliskSetup | BaseException = results[4]
     buildbuddy: buildbuddy_setup.BuildbuddySetup | BaseException = results[5]
     tmpfs: tmpfs_setup.TmpfsSetup | BaseException = results[6]
+    mkcert: mkcert_setup.MkcertSetup | BaseException = results[7]
 
     # Log non-critical failures
     if isinstance(precommit, BaseException):
@@ -382,6 +398,10 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
         logger.warning("Failed to configure BuildBuddy: %s", buildbuddy)
     if isinstance(tmpfs, BaseException):
         logger.warning("Failed to set up tmpfs caches: %s", tmpfs)
+    if isinstance(mkcert, SkipError):
+        logger.info("mkcert setup skipped: %s", mkcert)
+    elif isinstance(mkcert, BaseException):
+        logger.warning("Failed to set up mkcert: %s", mkcert)
 
     # Handle nix result
     if isinstance(nix, SkipError):
@@ -431,6 +451,12 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
     else:
         bazelisk_path = settings.get_bazelisk_path()
 
+    mkcert_cert: Path | None = None
+    mkcert_key: Path | None = None
+    if isinstance(mkcert, mkcert_setup.MkcertSetup):
+        mkcert_cert = mkcert.cert_path
+        mkcert_key = mkcert.key_path
+
     env_vars = env_file.EnvVars(
         proxy_port=settings.get_auth_proxy_port(),
         supervisor_port=settings.get_supervisor_port(),
@@ -444,6 +470,8 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
         podman_env=podman_env,
         hook_timestamp=hook_timestamp,
         secrets_exports=secrets.env_exports if secrets else None,
+        mkcert_cert=mkcert_cert,
+        mkcert_key=mkcert_key,
     )
 
     # Write environment file ONCE
@@ -470,6 +498,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
         podman=None if isinstance(podman, BaseException) else podman,
         precommit=None if isinstance(precommit, BaseException) else precommit,
         secrets=secrets,
+        mkcert=None if isinstance(mkcert, BaseException) else mkcert,
     )
 
 

--- a/tools/claude_hooks/settings.py
+++ b/tools/claude_hooks/settings.py
@@ -72,6 +72,7 @@ class HookSettings(BaseSettings):
     # Feature flags (enable/disable installations)
     install_bazelisk: bool = Field(default=True, description="Download and install bazelisk")
     install_nix: bool = Field(default=False, description="Install nix package manager")
+    install_mkcert: bool = Field(default=True, description="Install mkcert and generate localhost TLS cert")
     install_podman: bool = Field(default=True, description="Set up podman container runtime")
     system_bazel: Path | None = Field(
         default=None, description="Path to system bazel (used when install_bazelisk=False)"

--- a/tools/claude_hooks/templates/session_context.mako
+++ b/tools/claude_hooks/templates/session_context.mako
@@ -11,6 +11,9 @@ Podman: ${podman.status}, DOCKER_HOST=${podman.socket_url}. Use fully qualified 
   Storage: VFS on 9p (no layer caching). Use `--layers=false` for large builds.
 % endif
 % endif
+% if mkcert:
+Localhost TLS: $MKCERT_CERT / $MKCERT_KEY (auto-trusted). Use for HTTPS dev servers.
+% endif
 % if isinstance(precommit, PrecommitInstallingHooks):
 pre-commit: hook environments installing in background (pid ${precommit.pid}). First `git commit` may block briefly on pre-commit's flock until done. Log: ~/.cache/claude-hooks/pre-commit-install-hooks.log
 % endif

--- a/tools/claude_hooks/test_session_start.py
+++ b/tools/claude_hooks/test_session_start.py
@@ -7,6 +7,7 @@ Includes:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
@@ -256,10 +257,10 @@ def _write_output_log(name: str, content: str) -> Path:
     return log_path
 
 
-def run_session_start_hook(
+async def run_session_start_hook(
     project_dir: Path, source: HookSource = HookSource.STARTUP
 ) -> subprocess.CompletedProcess[str]:
-    """Run the session start hook (inherits environment from os.environ via monkeypatch).
+    """Run the session start hook as an async subprocess.
 
     By default, runs via `python -m tools.claude_hooks.session_start` for Bazel tests.
     Set DUCKTAPE_CLAUDE_HOOKS_USE_WHEEL=1 to run via the installed `claude-session-start` console
@@ -271,7 +272,7 @@ def run_session_start_hook(
 
     use_wheel = os.environ.get(settings.ENV_USE_WHEEL) == "1"
 
-    cmd = "claude-session-start" if use_wheel else str(get_required_path(shell_helpers.SESSION_START))
+    cmd: str | Path = "claude-session-start" if use_wheel else get_required_path(shell_helpers.SESSION_START)
 
     env = dict(os.environ)
     if use_wheel:
@@ -281,7 +282,21 @@ def run_session_start_hook(
         # requires list. Clear it so only the wheel venv's packages are visible.
         env.pop("PYTHONPATH", None)
 
-    result = subprocess.run([cmd], check=False, input=hook_input, capture_output=True, text=True, timeout=300, env=env)
+    proc = await asyncio.create_subprocess_exec(
+        cmd, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, env=env
+    )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(input=hook_input.encode()), timeout=300)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise subprocess.TimeoutExpired(cmd=[cmd], timeout=300)
+    result = subprocess.CompletedProcess(
+        args=[cmd],
+        returncode=proc.returncode or 0,
+        stdout=stdout_bytes.decode() if stdout_bytes else "",
+        stderr=stderr_bytes.decode() if stderr_bytes else "",
+    )
 
     # Write hook output to log files for debugging (collected as CI artifacts)
     stdout_log = _write_output_log("hook-stdout.log", result.stdout)
@@ -302,9 +317,9 @@ def cleanup_after_test(isolated_dirs: IsolatedDirs) -> Generator[None]:
 class TestFullSessionStartHook:
     """E2E tests running the complete session start hook."""
 
-    def test_session_start_succeeds(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
+    async def test_session_start_succeeds(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
         """Run full session start hook and verify it succeeds."""
-        result = run_session_start_hook(isolated_dirs.project)
+        result = await run_session_start_hook(isolated_dirs.project)
 
         assert result.returncode == 0, f"Hook failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
 
@@ -320,11 +335,11 @@ class TestFullSessionStartHook:
         assert (supervisor_dir / "supervisord.pid").exists(), "supervisor not started"
 
     @pytest.mark.skipif(not shutil.which("bazel") and not shutil.which("bazelisk"), reason="bazel/bazelisk required")
-    def test_bazel_build_after_hook(
+    async def test_bazel_build_after_hook(
         self, isolated_dirs: IsolatedDirs, hook_env: None, mock_egress_proxy: MockEgressProxyFixture
     ) -> None:
         """Run hook, then verify bazel can build through the proxy."""
-        result = run_session_start_hook(isolated_dirs.project)
+        result = await run_session_start_hook(isolated_dirs.project)
         assert result.returncode == 0, f"Hook failed: {result.stderr}"
 
         # Copy testdata workspace to test location
@@ -346,18 +361,18 @@ class TestFullSessionStartHook:
         # --output_base isolates this Bazel from the test-running Bazel.
         supervisor_dir = isolated_dirs.config / "claude-hooks" / "supervisor"
         try:
-            shell_helpers.run_with_env_file(
-                command=f"bazel --output_base={output_base} build //:hello",
-                env_file=isolated_dirs.env_file,
-                cwd=workspace,
-                check=True,
-                timeout=60,
-            )
+            async with asyncio.timeout(60):
+                await shell_helpers.run_with_env_file(
+                    command=f"bazel --output_base={output_base} build //:hello",
+                    env_file=isolated_dirs.env_file,
+                    cwd=workspace,
+                    check=True,
+                )
         finally:
             # Always collect logs - critical for debugging CI failures
             collect_supervisor_logs(supervisor_dir)
 
-    def test_stale_socket_recovery(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
+    async def test_stale_socket_recovery(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
         """Verify hook recovers from stale supervisor socket."""
         # Create stale socket/pidfile
         # platformdirs respects XDG_CONFIG_HOME
@@ -366,17 +381,17 @@ class TestFullSessionStartHook:
         (supervisor_dir / "supervisor.sock").touch()
         (supervisor_dir / "supervisord.pid").write_text("99999")  # Non-existent PID
 
-        result = run_session_start_hook(isolated_dirs.project)
+        result = await run_session_start_hook(isolated_dirs.project)
 
         assert result.returncode == 0, f"Hook failed with stale socket:\nstderr: {result.stderr}"
 
-    def test_resume_event(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
+    async def test_resume_event(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
         """Test that resume events also work correctly."""
-        result = run_session_start_hook(isolated_dirs.project, source=HookSource.RESUME)
+        result = await run_session_start_hook(isolated_dirs.project, source=HookSource.RESUME)
 
         assert result.returncode == 0, f"Hook failed on resume:\nstderr: {result.stderr}"
 
-    def test_secrets_decrypted_into_env_file(
+    async def test_secrets_decrypted_into_env_file(
         self, monkeypatch: pytest.MonkeyPatch, isolated_dirs: IsolatedDirs, hook_env: None
     ) -> None:
         """Run hook with age key set, verify decrypted secret is visible in env file."""
@@ -387,11 +402,11 @@ class TestFullSessionStartHook:
         monkeypatch.setenv(settings.ENV_PREFIX + "SECRETS_AGE_KEY", test_age_key)
         monkeypatch.setenv(settings.ENV_PREFIX + "SECRETS_DIR", str(test_secrets_dir))
 
-        result = run_session_start_hook(isolated_dirs.project)
+        result = await run_session_start_hook(isolated_dirs.project)
         assert result.returncode == 0, f"Hook failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
 
         # Verify the secret is visible when sourcing the env file
-        shell_result = shell_helpers.run_with_env_file(
+        shell_result = await shell_helpers.run_with_env_file(
             command="echo $TEST_SECRET_TOKEN", env_file=isolated_dirs.env_file, check=True
         )
         assert shell_result.stdout.strip() == "test-value-12345"
@@ -443,25 +458,15 @@ class TestPodmanIntegration:
         _setup_hook_env(monkeypatch, isolated_dirs, mock_egress_proxy.proxy, system_bazel, install_podman=True)
 
     @pytest.mark.skipif(not _can_use_podman(), reason="podman not installed")
-    def test_podman_service_starts(self, isolated_dirs: IsolatedDirs, podman_hook_env: None) -> None:
-        """Verify podman service starts after session start hook."""
-        result = run_session_start_hook(isolated_dirs.project)
-
-        assert result.returncode == 0, "Hook failed with non-zero exit code"
-
-        socket_path = _extract_docker_host_socket(isolated_dirs.env_file)
-        assert socket_path.exists(), f"Podman socket not created at {socket_path}"
-
-    @pytest.mark.skipif(not _can_use_podman(), reason="podman not installed")
-    def test_podman_can_run_container(
+    async def test_podman_can_run_container(
         self, isolated_dirs: IsolatedDirs, podman_hook_env: None, mock_egress_proxy: MockEgressProxyFixture
     ) -> None:
-        """Verify podman can run a container after session start hook.
+        """Verify podman service starts and can run a container after session start hook.
 
         Runs podman through the MockEgressProxy to verify the full proxy chain works,
         including CA certificate configuration for container registry pulls.
         """
-        result = run_session_start_hook(isolated_dirs.project)
+        result = await run_session_start_hook(isolated_dirs.project)
 
         assert result.returncode == 0, "Hook failed with non-zero exit code"
 
@@ -475,13 +480,13 @@ class TestPodmanIntegration:
         # Verify we can run podman hello-world through the proxy
         # The gVisor annotation is auto-applied via containers.conf
         # Run through env file to pick up SSL_CERT_FILE for TLS proxy CA
-        podman_result = shell_helpers.run_with_env_file(
-            command="podman run --rm docker.io/library/hello-world",
-            env_file=isolated_dirs.env_file,
-            cwd=isolated_dirs.project,
-            check=False,
-            timeout=120,
-        )
+        async with asyncio.timeout(120):
+            podman_result = await shell_helpers.run_with_env_file(
+                command="podman run --rm docker.io/library/hello-world",
+                env_file=isolated_dirs.env_file,
+                cwd=isolated_dirs.project,
+                check=False,
+            )
 
         # Include proxy stats in failure message for debugging
         proxy = mock_egress_proxy.proxy

--- a/tools/claude_hooks/testing/BUILD.bazel
+++ b/tools/claude_hooks/testing/BUILD.bazel
@@ -13,14 +13,26 @@ py_library(
     ],
 )
 
+py_library(
+    name = "conftest",
+    testonly = True,
+    srcs = ["conftest.py"],
+    imports = ["../../.."],
+    visibility = ["//tools/claude_hooks:__subpackages__"],
+    deps = ["@pypi//pytest"],
+)
+
 py_test(
     name = "test_mock_egress_proxy",
     srcs = ["test_mock_egress_proxy.py"],
+    args = ["--asyncio-mode=auto"],
     imports = ["../../.."],
     deps = [
+        ":conftest",
         ":fixtures",
         ":mock_egress_proxy",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )

--- a/tools/claude_hooks/testing/conftest.py
+++ b/tools/claude_hooks/testing/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for claude_hooks/testing tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure pytest-asyncio auto mode."""
+    config.option.asyncio_mode = "auto"

--- a/tools/claude_hooks/testing/fixtures.py
+++ b/tools/claude_hooks/testing/fixtures.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import signal
 import time
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,8 +73,8 @@ def hook_settings(isolated_dirs: IsolatedSupervisorDirs) -> HookSettings:
     return HookSettings()
 
 
-@pytest.fixture(scope="module")
-def mock_egress_proxy() -> Generator[MockEgressProxyFixture]:
+@pytest.fixture
+async def mock_egress_proxy() -> AsyncGenerator[MockEgressProxyFixture]:
     """Mock of Anthropic's TLS-inspecting egress proxy that chains through upstream if available.
 
     Works in gVisor environments by detecting HTTPS_PROXY and chaining through it.
@@ -93,7 +93,7 @@ def mock_egress_proxy() -> Generator[MockEgressProxyFixture]:
     proxy_logger.addHandler(handler)
 
     try:
-        with MockEgressProxy(
+        async with MockEgressProxy(
             listen_port=0, username="proxy_user", password="test_jwt_token", upstream_proxy=EgressProxyConfig.from_env()
         ) as proxy:
             yield MockEgressProxyFixture(proxy=proxy, log_file=log_file)

--- a/tools/claude_hooks/testing/mock_egress_proxy.py
+++ b/tools/claude_hooks/testing/mock_egress_proxy.py
@@ -10,16 +10,15 @@ Used for e2e testing of the session_start hook and auth proxy infrastructure.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import contextlib
 import logging
 import os
-import socket
 import ssl
 import tempfile
-import threading
 import urllib.parse
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -220,24 +219,19 @@ class ConnectionStats:
     failed_connections: int = 0
     bytes_forwarded: int = 0
     errors: list[str] = field(default_factory=list)
-    lock: threading.Lock = field(default_factory=threading.Lock)
 
     def record_success(self, bytes_count: int = 0) -> None:
-        with self.lock:
-            self.successful_connections += 1
-            self.bytes_forwarded += bytes_count
+        self.successful_connections += 1
+        self.bytes_forwarded += bytes_count
 
     def record_failure(self, error: str) -> None:
-        with self.lock:
-            self.failed_connections += 1
-            self.errors.append(error)
-            # Keep only last 100 errors
-            if len(self.errors) > 100:
-                self.errors = self.errors[-100:]
+        self.failed_connections += 1
+        self.errors.append(error)
+        if len(self.errors) > 100:
+            self.errors = self.errors[-100:]
 
     def record_connection(self) -> None:
-        with self.lock:
-            self.total_connections += 1
+        self.total_connections += 1
 
 
 class MockEgressProxy:
@@ -257,100 +251,63 @@ class MockEgressProxy:
         listen_port: int = 0,
         username: str = "testuser",
         password: str = "testpass",
-        temp_dir: Path | None = None,
-        max_workers: int = 100,
+        max_concurrent_outbound: int = 20,
         verify_target_certs: bool = True,
     ):
         self.listen_port = listen_port
         self.username = username
         self.password = password
-        self.temp_dir = temp_dir
-        self.max_workers = max_workers
         self.upstream_proxy = upstream_proxy
         self.verify_target_certs = verify_target_certs
 
-        self.server_socket: socket.socket | None = None
+        self._server: asyncio.Server | None = None
         self.port: int = 0
-        self._running = False
-        self._thread: threading.Thread | None = None
-        self._executor: ThreadPoolExecutor | None = None
-        self._connections: list[socket.socket] = []
+        self._tasks: set[asyncio.Task[None]] = set()
 
-        # CA cert/key for TLS interception
-        self._ca_cert_pem: bytes = b""
-        self._ca_key_pem: bytes = b""
+        self._ca_cert_pem, self._ca_key_pem = generate_mock_ca()
 
         # Cache for generated server certs (hostname -> (cert_pem, key_pem))
         self._server_certs: dict[str, tuple[bytes, bytes]] = {}
-        self._cert_lock = threading.Lock()
 
-        # Connection statistics for debugging
         self.stats = ConnectionStats()
-
-        # Semaphore to limit concurrent outbound connections
-        # This prevents overwhelming target servers when many parallel connections come in
-        self._outbound_semaphore = threading.Semaphore(20)
+        self._outbound_semaphore = asyncio.Semaphore(max_concurrent_outbound)
 
     @property
     def ca_cert_pem(self) -> bytes:
-        """Get the CA certificate PEM."""
         return self._ca_cert_pem
 
     @property
     def url(self) -> str:
-        """Get the proxy URL with credentials."""
         return f"http://{self.username}:{self.password}@127.0.0.1:{self.port}"
 
-    def __enter__(self) -> MockEgressProxy:
-        """Start proxy and return self for context manager use."""
-        self.start()
-        return self
+    async def __aenter__(self) -> MockEgressProxy:
+        self._server = await asyncio.start_server(self._on_connection, "127.0.0.1", self.listen_port)
+        addrs = self._server.sockets
+        assert addrs, "Server has no sockets"
+        self.port = addrs[0].getsockname()[1]
 
-    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
-        """Stop proxy on context exit."""
-        self.stop()
-
-    def start(self) -> None:
-        """Start the proxy server."""
-        # Generate CA cert
-        self._ca_cert_pem, self._ca_key_pem = generate_mock_ca()
-
-        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind(("127.0.0.1", self.listen_port))
-        self.port = self.server_socket.getsockname()[1]
-        self.server_socket.listen(50)  # Increased backlog for concurrent connections
-        self.server_socket.settimeout(0.5)
-
-        self._executor = ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix="mock-proxy")
-        self._running = True
-        self._thread = threading.Thread(target=self._serve, daemon=True)
-        self._thread.start()
         if self.upstream_proxy:
             logger.info(
-                "MockEgressProxy started on port %d (chaining through upstream %s:%d, max_workers=%d)",
+                "MockEgressProxy started on port %d (chaining through upstream %s:%d)",
                 self.port,
                 self.upstream_proxy.host,
                 self.upstream_proxy.port,
-                self.max_workers,
             )
         else:
-            logger.info(
-                "MockEgressProxy started on port %d (direct connections, max_workers=%d)", self.port, self.max_workers
-            )
+            logger.info("MockEgressProxy started on port %d (direct connections)", self.port)
+        return self
 
-    def stop(self) -> None:
-        """Stop the proxy server."""
-        self._running = False
-        if self._thread:
-            self._thread.join(timeout=2)
-        if self._executor:
-            self._executor.shutdown(wait=False, cancel_futures=True)
-        for conn in self._connections:
-            with contextlib.suppress(OSError):
-                conn.close()
-        if self.server_socket:
-            self.server_socket.close()
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object
+    ) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
         logger.info(
             "MockEgressProxy stopped. Stats: %d total, %d success, %d failed, %d bytes",
             self.stats.total_connections,
@@ -361,47 +318,46 @@ class MockEgressProxy:
         if self.stats.errors:
             logger.info("Recent errors: %s", self.stats.errors[-5:])
 
-    def _serve(self) -> None:
-        """Main server loop."""
-        while self._running:
-            try:
-                client_sock, _addr = self.server_socket.accept()  # type: ignore[union-attr]
-                self._connections.append(client_sock)
-                self.stats.record_connection()
-                # Use thread pool instead of spawning unlimited threads
-                self._executor.submit(self._handle_client, client_sock)  # type: ignore[union-attr]
-            except TimeoutError:
-                continue
-            except OSError:
-                break
+    async def _on_connection(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        """Callback for asyncio.start_server — wraps _handle_client in a tracked task."""
+        self.stats.record_connection()
+        task = asyncio.current_task()
+        assert task is not None
+        self._tasks.add(task)
+        try:
+            await self._handle_client(reader, writer)
+        finally:
+            self._tasks.discard(task)
 
     def _get_server_cert(self, hostname: str) -> tuple[bytes, bytes]:
-        """Get or generate a server certificate for the hostname."""
-        with self._cert_lock:
-            if hostname not in self._server_certs:
-                self._server_certs[hostname] = generate_server_cert(self._ca_cert_pem, self._ca_key_pem, hostname)
-            return self._server_certs[hostname]
+        if hostname not in self._server_certs:
+            self._server_certs[hostname] = generate_server_cert(self._ca_cert_pem, self._ca_key_pem, hostname)
+        return self._server_certs[hostname]
 
-    def _connect_to_target(self, target_host: str, target_port: int) -> ssl.SSLSocket:
-        """Connect to target server, optionally through upstream proxy.
+    async def _send_error(self, writer: asyncio.StreamWriter, response: bytes, error: str) -> None:
+        writer.write(response)
+        await writer.drain()
+        self.stats.record_failure(error)
 
-        Returns an SSL-wrapped socket connected to the target.
-        """
+    async def _connect_to_target(
+        self, target_host: str, target_port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         if self.upstream_proxy:
-            return self._connect_via_upstream(target_host, target_port)
-        return self._connect_direct(target_host, target_port)
+            return await self._connect_via_upstream(target_host, target_port)
+        return await self._connect_direct(target_host, target_port)
 
-    def _connect_direct(self, target_host: str, target_port: int) -> ssl.SSLSocket:
-        """Connect directly to target server."""
-        server_sock = socket.create_connection((target_host, target_port), timeout=60)
-        server_sock.settimeout(60)
+    async def _connect_direct(
+        self, target_host: str, target_port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         server_ctx = ssl.create_default_context()
         if not self.verify_target_certs:
             server_ctx.check_hostname = False
             server_ctx.verify_mode = ssl.CERT_NONE
-        return server_ctx.wrap_socket(server_sock, server_hostname=target_host)
+        return await asyncio.open_connection(target_host, target_port, ssl=server_ctx)
 
-    def _connect_via_upstream(self, target_host: str, target_port: int) -> ssl.SSLSocket:
+    async def _connect_via_upstream(
+        self, target_host: str, target_port: int
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         """Connect to target through upstream proxy.
 
         The upstream proxy (e.g., Anthropic's TLS-inspecting proxy) will:
@@ -424,229 +380,200 @@ class MockEgressProxy:
             upstream.ca_bundle,
         )
 
-        # Connect to upstream proxy
-        proxy_sock = socket.create_connection((upstream.host, upstream.port), timeout=60)
-        proxy_sock.settimeout(60)
+        proxy_reader, proxy_writer = await asyncio.open_connection(upstream.host, upstream.port)
+        try:
+            # Build and send CONNECT request
+            connect_req = f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
+            connect_req += f"Host: {target_host}:{target_port}\r\n"
+            if upstream.username and upstream.password:
+                creds = f"{upstream.username}:{upstream.password}"
+                encoded = base64.b64encode(creds.encode()).decode()
+                connect_req += f"Proxy-Authorization: Basic {encoded}\r\n"
+            connect_req += "\r\n"
+            proxy_writer.write(connect_req.encode())
+            await proxy_writer.drain()
 
-        # Build CONNECT request
-        connect_req = f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
-        connect_req += f"Host: {target_host}:{target_port}\r\n"
+            # Read response headers
+            try:
+                response = await proxy_reader.readuntil(b"\r\n\r\n")
+            except asyncio.IncompleteReadError as e:
+                raise ConnectionError("Upstream proxy closed connection") from e
 
-        # Add auth if configured
-        if upstream.username and upstream.password:
-            creds = f"{upstream.username}:{upstream.password}"
-            encoded = base64.b64encode(creds.encode()).decode()
-            connect_req += f"Proxy-Authorization: Basic {encoded}\r\n"
+            status_line = response.split(b"\r\n")[0].decode()
+            if " 200 " not in status_line and " 2" not in status_line.split()[1]:
+                raise ConnectionError(f"Upstream proxy rejected CONNECT: {status_line}")
 
-        connect_req += "\r\n"
-        proxy_sock.sendall(connect_req.encode())
+            logger.debug("Upstream proxy tunnel established to %s:%d", target_host, target_port)
 
-        # Read response
-        response = b""
-        while b"\r\n\r\n" not in response:
-            chunk = proxy_sock.recv(4096)
-            if not chunk:
-                raise ConnectionError("Upstream proxy closed connection")
-            response += chunk
+            # Upgrade to TLS (client side — we're connecting to the target through the tunnel)
+            server_ctx = ssl.create_default_context()
+            if upstream.ca_bundle and Path(upstream.ca_bundle).exists():
+                server_ctx.load_verify_locations(upstream.ca_bundle)
+            else:
+                logger.debug("No CA bundle for upstream proxy, disabling certificate verification")
+                server_ctx.check_hostname = False
+                server_ctx.verify_mode = ssl.CERT_NONE
 
-        # Check for success (2xx status)
-        status_line = response.split(b"\r\n")[0].decode()
-        if " 200 " not in status_line and " 2" not in status_line.split()[1]:
-            raise ConnectionError(f"Upstream proxy rejected CONNECT: {status_line}")
+            await proxy_writer.start_tls(server_ctx, server_hostname=target_host)
+            return proxy_reader, proxy_writer
+        except BaseException:
+            proxy_writer.close()
+            raise
 
-        logger.debug("Upstream proxy tunnel established to %s:%d", target_host, target_port)
-
-        # Wrap with TLS to target (upstream proxy does MITM, we trust its CA)
-        server_ctx = ssl.create_default_context()
-        if upstream.ca_bundle and Path(upstream.ca_bundle).exists():
-            server_ctx.load_verify_locations(upstream.ca_bundle)
-        else:
-            # No CA bundle available - disable verification for test proxy
-            # This happens in CI when HTTPS_PROXY is set but SSL_CERT_FILE is not
-            logger.debug("No CA bundle for upstream proxy, disabling certificate verification")
-            server_ctx.check_hostname = False
-            server_ctx.verify_mode = ssl.CERT_NONE
-        return server_ctx.wrap_socket(proxy_sock, server_hostname=target_host)
-
-    def _handle_client(self, client_sock: socket.socket) -> None:
-        """Handle a single client connection."""
-        client_ssl: ssl.SSLSocket | None = None
-        server_ssl: ssl.SSLSocket | None = None
-        target_host: str = "<unknown>"
-        target_port: int = 0
-        bytes_forwarded: int = 0
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        target_host = "<unknown>"
+        target_port = 0
 
         try:
-            # Set socket timeout for initial handshake
-            client_sock.settimeout(60)
-
-            # Read CONNECT request
-            request = b""
-            while b"\r\n\r\n" not in request:
-                chunk = client_sock.recv(4096)
-                if not chunk:
-                    return
-                request += chunk
-
-            request_line = request.split(b"\r\n", 1)[0].decode()
-            if not request_line.startswith("CONNECT "):
-                client_sock.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-                self.stats.record_failure(f"Non-CONNECT request: {request_line[:50]}")
-                return
-
-            # Parse target host:port
-            parts = request_line.split()
-            if len(parts) < 2:
-                client_sock.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-                self.stats.record_failure("Malformed CONNECT request")
-                return
-
-            target = parts[1]
-            if ":" in target:
-                target_host, port_str = target.rsplit(":", 1)
-                target_port = int(port_str)
-            else:
-                target_host = target
-                target_port = 443
-
-            conn_id = self.stats.total_connections
-            logger.info("[conn %d] CONNECT request for %s:%d", conn_id, target_host, target_port)
-
-            # Check auth header (always required, matching real egress proxy)
-            auth_ok = False
-            for line in request.split(b"\r\n"):
-                if line.lower().startswith(b"proxy-authorization: basic "):
-                    encoded = line.split(b" ", 2)[2]
-                    decoded = base64.b64decode(encoded).decode()
-                    if ":" in decoded:
-                        user, passwd = decoded.split(":", 1)
-                        if user == self.username and passwd == self.password:
-                            auth_ok = True
-                    break
-
-            if not auth_ok:
-                client_sock.sendall(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
-                self.stats.record_failure(f"Auth failed for {target_host}:{target_port}")
-                return
-
-            # Connect to real target BEFORE sending 200 (so we can return error if connection fails)
-            # Use semaphore to limit concurrent outbound connections and prevent overwhelming targets
-            logger.info("[conn %d] Waiting for outbound slot for %s:%d", conn_id, target_host, target_port)
-            with self._outbound_semaphore:
-                logger.info("[conn %d] Connecting to target %s:%d", conn_id, target_host, target_port)
+            async with _close_writer(writer):
+                # Read CONNECT request
                 try:
-                    server_ssl = self._connect_to_target(target_host, target_port)
-                    logger.info("[conn %d] Connected to target %s:%d", conn_id, target_host, target_port)
-                except Exception as e:
-                    error_msg = f"Failed to connect to {target_host}:{target_port}: {e}"
-                    logger.warning("[conn %d] %s", conn_id, error_msg)
-                    self.stats.record_failure(error_msg)
-                    client_sock.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                    request = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=60)
+                except (TimeoutError, asyncio.IncompleteReadError):
                     return
 
-            # Send 200 Connection Established (only after successful connection to target)
-            logger.info("[conn %d] Sending 200 to client for %s:%d", conn_id, target_host, target_port)
-            client_sock.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                request_line = request.split(b"\r\n", 1)[0].decode()
+                if not request_line.startswith("CONNECT "):
+                    await self._send_error(
+                        writer, b"HTTP/1.1 400 Bad Request\r\n\r\n", f"Non-CONNECT request: {request_line[:50]}"
+                    )
+                    return
 
-            # Generate server cert for this hostname and wrap client connection
-            # Include CA cert in chain so clients can extract it via get_unverified_chain()
-            server_cert_pem, server_key_pem = self._get_server_cert(target_host)
+                # Parse target host:port
+                parts = request_line.split()
+                if len(parts) < 2:
+                    await self._send_error(writer, b"HTTP/1.1 400 Bad Request\r\n\r\n", "Malformed CONNECT request")
+                    return
 
-            client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            _load_cert_chain_from_bytes(client_ctx, server_cert_pem, server_key_pem, self._ca_cert_pem)
-            client_ssl = client_ctx.wrap_socket(client_sock, server_side=True)
+                target = parts[1]
+                if ":" in target:
+                    target_host, port_str = target.rsplit(":", 1)
+                    target_port = int(port_str)
+                else:
+                    target_host = target
+                    target_port = 443
 
-            # Bidirectional forward
-            bytes_forwarded = self._forward_bidirectional(client_ssl, server_ssl, target_host)
-            self.stats.record_success(bytes_forwarded)
-            logger.info(
-                "[conn %d] Completed %s:%d, %d bytes forwarded", conn_id, target_host, target_port, bytes_forwarded
-            )
+                conn_id = self.stats.total_connections
+                logger.info("[conn %d] CONNECT request for %s:%d", conn_id, target_host, target_port)
 
-        except TimeoutError as e:
-            error_msg = f"Timeout connecting to {target_host}:{target_port}: {e}"
-            logger.warning(error_msg)
-            self.stats.record_failure(error_msg)
-        except ssl.SSLError as e:
-            error_msg = f"SSL error for {target_host}:{target_port}: {e}"
-            logger.warning(error_msg)
-            self.stats.record_failure(error_msg)
-        except OSError as e:
-            error_msg = f"OS error for {target_host}:{target_port}: {e}"
-            logger.warning(error_msg)
-            self.stats.record_failure(error_msg)
-        except ValueError as e:
-            error_msg = f"Value error for {target_host}:{target_port}: {e}"
-            logger.warning(error_msg)
-            self.stats.record_failure(error_msg)
-        finally:
-            # Close SSL sockets first (they close underlying sockets too)
-            if server_ssl:
-                with contextlib.suppress(OSError):
-                    server_ssl.close()
-            if client_ssl:
-                with contextlib.suppress(OSError):
-                    client_ssl.close()
-            elif client_sock:
-                # Only close raw socket if SSL wrapping didn't happen
-                with contextlib.suppress(OSError):
-                    client_sock.close()
-            # Remove from connections list to allow garbage collection
-            with contextlib.suppress(ValueError):
-                self._connections.remove(client_sock)
+                # Check auth header (always required, matching real egress proxy)
+                auth_ok = False
+                for line in request.split(b"\r\n"):
+                    if line.lower().startswith(b"proxy-authorization: basic "):
+                        encoded = line.split(b" ", 2)[2]
+                        decoded = base64.b64decode(encoded).decode()
+                        if ":" in decoded:
+                            user, passwd = decoded.split(":", 1)
+                            if user == self.username and passwd == self.password:
+                                auth_ok = True
+                        break
 
-    def _forward_bidirectional(self, client_ssl: ssl.SSLSocket, server_ssl: ssl.SSLSocket, target_host: str) -> int:
+                if not auth_ok:
+                    await self._send_error(
+                        writer,
+                        b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n",
+                        f"Auth failed for {target_host}:{target_port}",
+                    )
+                    return
+
+                # Connect to target (with concurrency limit)
+                async with self._outbound_semaphore:
+                    logger.info("[conn %d] Connecting to target %s:%d", conn_id, target_host, target_port)
+                    try:
+                        server_reader, server_writer = await asyncio.wait_for(
+                            self._connect_to_target(target_host, target_port), timeout=60
+                        )
+                        logger.info("[conn %d] Connected to target %s:%d", conn_id, target_host, target_port)
+                    except Exception as e:
+                        error_msg = f"Failed to connect to {target_host}:{target_port}: {e}"
+                        logger.warning("[conn %d] %s", conn_id, error_msg)
+                        await self._send_error(writer, b"HTTP/1.1 502 Bad Gateway\r\n\r\n", error_msg)
+                        return
+
+                async with _close_writer(server_writer):
+                    # Send 200 Connection Established (only after successful target connection)
+                    logger.info("[conn %d] Sending 200 to client for %s:%d", conn_id, target_host, target_port)
+                    writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                    await writer.drain()
+
+                    # Generate server cert and upgrade client connection to TLS (server-side)
+                    server_cert_pem, server_key_pem = self._get_server_cert(target_host)
+                    client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                    _load_cert_chain_from_bytes(client_ctx, server_cert_pem, server_key_pem, self._ca_cert_pem)
+                    # server_side is auto-detected from the protocol (client_connected_cb is set
+                    # for connections from asyncio.start_server), so no need to pass it explicitly.
+                    await writer.start_tls(client_ctx)
+
+                    bytes_forwarded = await self._forward_bidirectional(
+                        reader, writer, server_reader, server_writer, target_host
+                    )
+                    self.stats.record_success(bytes_forwarded)
+                    logger.info(
+                        "[conn %d] Completed %s:%d, %d bytes forwarded",
+                        conn_id,
+                        target_host,
+                        target_port,
+                        bytes_forwarded,
+                    )
+
+        except asyncio.CancelledError:
+            raise
+        except (TimeoutError, ssl.SSLError, OSError, ValueError) as e:
+            self.stats.record_failure(f"{target_host}:{target_port}: {e}")
+
+    async def _forward_bidirectional(
+        self,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+        server_reader: asyncio.StreamReader,
+        server_writer: asyncio.StreamWriter,
+        target_host: str,
+    ) -> int:
         """Forward data bidirectionally between client and server.
 
-        Uses a thread per direction with blocking sockets. A previous
-        non-blocking select() implementation silently dropped data when
-        sendall() raised SSLWantWriteError, corrupting the TLS record
-        stream and causing BAD_LENGTH errors on large transfers.
-
-        Returns total bytes forwarded.
+        Uses two asyncio tasks, one per direction. When either direction
+        completes (EOF or error), the other is cancelled.
         """
         bytes_forwarded = 0
-        lock = threading.Lock()
 
-        def forward(src: ssl.SSLSocket, dst: ssl.SSLSocket, direction: str) -> None:
-            nonlocal bytes_forwarded
-            clean_eof = False
+        async def forward(src: asyncio.StreamReader, dst: asyncio.StreamWriter, direction: str) -> int:
+            count = 0
             try:
                 while True:
-                    data = src.recv(65536)
+                    data = await src.read(65536)
                     if not data:
-                        clean_eof = True
                         break
-                    dst.sendall(data)
-                    with lock:
-                        bytes_forwarded += len(data)
-            except (OSError, ssl.SSLError) as e:
+                    dst.write(data)
+                    await dst.drain()
+                    count += len(data)
+            except (OSError, ssl.SSLError, ConnectionError) as e:
                 logger.debug("Forward %s finished for %s: %s", direction, target_host, e)
-            finally:
-                # Only half-close on clean EOF (source sent all data and closed
-                # gracefully). On TLS errors, shutdown(SHUT_WR) must NOT be
-                # called: it operates at the raw TCP level, sending a FIN that
-                # corrupts the TLS session state for the *other* forwarding
-                # thread still reading from the same SSL socket pair. This
-                # caused intermittent TLSV1_ALERT_DECODE_ERROR failures where
-                # the s2c thread couldn't deliver echo responses because c2s's
-                # cleanup destroyed the underlying transport.
-                if clean_eof:
-                    with contextlib.suppress(OSError):
-                        dst.shutdown(socket.SHUT_WR)
+            return count
 
-        # Both sockets stay in blocking mode (default)
-        client_ssl.settimeout(30.0)
-        server_ssl.settimeout(30.0)
+        c2s = asyncio.create_task(forward(client_reader, server_writer, "c2s"))
+        s2c = asyncio.create_task(forward(server_reader, client_writer, "s2c"))
 
-        t_c2s = threading.Thread(target=forward, args=(client_ssl, server_ssl, "c2s"), daemon=True)
-        t_s2c = threading.Thread(target=forward, args=(server_ssl, client_ssl, "s2c"), daemon=True)
-        t_c2s.start()
-        t_s2c.start()
-        t_c2s.join(timeout=120)
-        t_s2c.join(timeout=120)
+        done, pending = await asyncio.wait([c2s, s2c], return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        for task in done:
+            if not task.cancelled() and task.exception() is None:
+                bytes_forwarded += task.result()
 
         return bytes_forwarded
+
+
+@contextlib.asynccontextmanager
+async def _close_writer(writer: asyncio.StreamWriter) -> AsyncGenerator[None]:
+    try:
+        yield
+    finally:
+        writer.close()
+        with contextlib.suppress(OSError, ssl.SSLError):
+            await writer.wait_closed()
 
 
 def _load_cert_chain_from_bytes(

--- a/tools/claude_hooks/testing/shell_helpers.py
+++ b/tools/claude_hooks/testing/shell_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from pathlib import Path
 
@@ -9,26 +10,26 @@ from pathlib import Path
 SESSION_START = "_main/tools/claude_hooks/session_start"
 
 
-def run_with_env_file(
-    command: str,
-    env_file: Path,
-    cwd: Path | None = None,
-    check: bool = False,
-    capture_output: bool = True,
-    text: bool = True,
-    timeout: float | None = None,
-    env: dict[str, str] | None = None,
+async def run_with_env_file(
+    command: str, env_file: Path, cwd: Path | None = None, check: bool = False, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
-    """Run command in bash with env_file sourced (mimics Claude Code behavior)."""
-    # Source the env file, then run the command
+    """Run command in bash with env_file sourced (mimics Claude Code behavior).
+
+    Callers should wrap with ``async with asyncio.timeout(...)`` if needed.
+    """
     bash_command = f"source {env_file} && {command}"
 
-    return subprocess.run(
-        ["bash", "-c", bash_command],
-        cwd=cwd,
-        check=check,
-        capture_output=capture_output,
-        text=text,
-        timeout=timeout,
-        env=env,
+    proc = await asyncio.create_subprocess_exec(
+        "bash", "-c", bash_command, cwd=cwd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, env=env
     )
+    stdout_bytes, stderr_bytes = await proc.communicate()
+
+    result = subprocess.CompletedProcess(
+        args=["bash", "-c", bash_command],
+        returncode=proc.returncode or 0,
+        stdout=stdout_bytes.decode() if stdout_bytes else "",
+        stderr=stderr_bytes.decode() if stderr_bytes else "",
+    )
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
+    return result

--- a/tools/claude_hooks/testing/test_mock_egress_proxy.py
+++ b/tools/claude_hooks/testing/test_mock_egress_proxy.py
@@ -9,14 +9,15 @@ Tests cover:
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import contextlib
 import hashlib
 import os
-import socket
 import ssl
 import tempfile
-import threading
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -30,213 +31,129 @@ pytest_plugins = ["tools.claude_hooks.testing.fixtures"]
 
 
 # ---------------------------------------------------------------------------
-# Helpers: local TLS echo/send server driven entirely by the test
+# Helpers: local TLS test servers using asyncio
 # ---------------------------------------------------------------------------
 
+_Handler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]]
 
-class _TLSEchoServer:
-    """Minimal TLS server that echoes data back to the client.
 
-    Runs in a background thread so tests can drive both sides.
-    """
+@dataclass
+class _TLSServer:
+    """A running TLS test server."""
 
-    def __init__(self, host: str = "127.0.0.1") -> None:
-        self.host = host
-        self.port: int = 0
-        self._server_socket: socket.socket | None = None
-        self._ctx: ssl.SSLContext | None = None
-        self._thread: threading.Thread | None = None
-        self._running = False
-        self.ca_cert_pem: bytes = b""
+    host: str
+    port: int
+    ca_cert_pem: bytes
+    _server: asyncio.Server
 
-    def start(self) -> None:
-        ca_cert_pem, ca_key_pem = generate_mock_ca()
-        self.ca_cert_pem = ca_cert_pem
-        cert_pem, key_pem = generate_server_cert(ca_cert_pem, ca_key_pem, self.host)
 
-        self._tmpdir = tempfile.mkdtemp()
-        cert_path = Path(self._tmpdir) / "cert.pem"
-        key_path = Path(self._tmpdir) / "key.pem"
+@contextlib.asynccontextmanager
+async def _tls_server(handler: _Handler, host: str = "127.0.0.1") -> AsyncGenerator[_TLSServer]:
+    """Start a TLS server with a self-signed cert, yield it, then shut down."""
+    ca_cert_pem, ca_key_pem = generate_mock_ca()
+    cert_pem, key_pem = generate_server_cert(ca_cert_pem, ca_key_pem, host)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cert_path = Path(tmpdir) / "cert.pem"
+        key_path = Path(tmpdir) / "key.pem"
         cert_path.write_bytes(cert_pem)
         key_path.write_bytes(key_pem)
 
-        self._ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self._ctx.load_cert_chain(str(cert_path), str(key_path))
+        ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_ctx.load_cert_chain(str(cert_path), str(key_path))
 
-        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._server_socket.bind((self.host, 0))
-        self.port = self._server_socket.getsockname()[1]
-        self._server_socket.listen(10)
-        self._server_socket.settimeout(1.0)
-
-        self._running = True
-        self._thread = threading.Thread(target=self._serve, daemon=True)
-        self._thread.start()
-
-    def stop(self) -> None:
-        self._running = False
-        if self._thread:
-            self._thread.join(timeout=5)
-        if self._server_socket:
-            self._server_socket.close()
-
-    def __enter__(self) -> _TLSEchoServer:
-        self.start()
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        self.stop()
-
-    def _serve(self) -> None:
-        while self._running:
-            try:
-                raw_sock, _ = self._server_socket.accept()  # type: ignore[union-attr]
-            except TimeoutError:
-                continue
-            except OSError:
-                break
-            threading.Thread(target=self._handle, args=(raw_sock,), daemon=True).start()
-
-    def _handle(self, raw_sock: socket.socket) -> None:
+        server = await asyncio.start_server(handler, host, 0, ssl=ssl_ctx)
+        addrs = server.sockets
+        assert addrs
+        port = addrs[0].getsockname()[1]
         try:
-            conn = self._ctx.wrap_socket(raw_sock, server_side=True)  # type: ignore[union-attr]
-            conn.settimeout(10)
-            while True:
-                data = conn.recv(65536)
-                if not data:
-                    break
-                conn.sendall(data)
-        except (OSError, ssl.SSLError):
-            pass
+            yield _TLSServer(host=host, port=port, ca_cert_pem=ca_cert_pem, _server=server)
         finally:
-            raw_sock.close()
+            server.close()
+            await server.wait_closed()
 
 
-class _TLSSendServer:
-    """TLS server that sends a fixed payload then closes (no reading).
+async def _echo_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """Echo data back to the client."""
+    try:
+        while data := await reader.read(65536):
+            writer.write(data)
+            await writer.drain()
+    except (OSError, ssl.SSLError):
+        pass
+    finally:
+        writer.close()
 
-    Simulates a download endpoint like releases.bazel.build.
-    """
 
-    def __init__(self, payload: bytes, host: str = "127.0.0.1") -> None:
-        self.host = host
-        self.port: int = 0
-        self.payload = payload
-        self._server_socket: socket.socket | None = None
-        self._ctx: ssl.SSLContext | None = None
-        self._thread: threading.Thread | None = None
-        self._running = False
-        self.ca_cert_pem: bytes = b""
+def _send_handler(payload: bytes) -> _Handler:
+    """Return a handler that sends a fixed payload then closes."""
 
-    def start(self) -> None:
-        ca_cert_pem, ca_key_pem = generate_mock_ca()
-        self.ca_cert_pem = ca_cert_pem
-        cert_pem, key_pem = generate_server_cert(ca_cert_pem, ca_key_pem, self.host)
-
-        self._tmpdir = tempfile.mkdtemp()
-        cert_path = Path(self._tmpdir) / "cert.pem"
-        key_path = Path(self._tmpdir) / "key.pem"
-        cert_path.write_bytes(cert_pem)
-        key_path.write_bytes(key_pem)
-
-        self._ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self._ctx.load_cert_chain(str(cert_path), str(key_path))
-
-        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._server_socket.bind((self.host, 0))
-        self.port = self._server_socket.getsockname()[1]
-        self._server_socket.listen(10)
-        self._server_socket.settimeout(1.0)
-
-        self._running = True
-        self._thread = threading.Thread(target=self._serve, daemon=True)
-        self._thread.start()
-
-    def stop(self) -> None:
-        self._running = False
-        if self._thread:
-            self._thread.join(timeout=5)
-        if self._server_socket:
-            self._server_socket.close()
-
-    def __enter__(self) -> _TLSSendServer:
-        self.start()
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        self.stop()
-
-    def _serve(self) -> None:
-        while self._running:
-            try:
-                raw_sock, _ = self._server_socket.accept()  # type: ignore[union-attr]
-            except TimeoutError:
-                continue
-            except OSError:
-                break
-            threading.Thread(target=self._handle, args=(raw_sock,), daemon=True).start()
-
-    def _handle(self, raw_sock: socket.socket) -> None:
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
-            conn = self._ctx.wrap_socket(raw_sock, server_side=True)  # type: ignore[union-attr]
-            conn.settimeout(10)
-            conn.sendall(self.payload)
-            conn.shutdown(socket.SHUT_WR)
-            # Drain any client data before closing
-            while conn.recv(4096):
+            writer.write(payload)
+            await writer.drain()
+            if writer.can_write_eof():
+                writer.write_eof()
+            else:
+                return  # can't write EOF; finally closes the writer
+            while await reader.read(4096):
                 pass
         except (OSError, ssl.SSLError):
             pass
         finally:
-            raw_sock.close()
+            writer.close()
+
+    return handler
 
 
-def _recv_exact(sock: ssl.SSLSocket, length: int) -> bytes:
-    """Read exactly `length` bytes from an SSL socket."""
+async def _recv_exact(reader: asyncio.StreamReader, length: int) -> bytes:
+    """Read exactly `length` bytes from an asyncio stream."""
     received = b""
     while len(received) < length:
-        chunk = sock.recv(min(65536, length - len(received)))
+        chunk = await reader.read(min(65536, length - len(received)))
         if not chunk:
             break
         received += chunk
     return received
 
 
-def _connect_through_proxy(proxy: MockEgressProxy, target_host: str, target_port: int) -> ssl.SSLSocket:
+@contextlib.asynccontextmanager
+async def _connect_through_proxy(
+    proxy: MockEgressProxy, target_host: str, target_port: int
+) -> AsyncGenerator[tuple[asyncio.StreamReader, asyncio.StreamWriter]]:
     """Open a TLS connection to target_host:target_port through the proxy.
 
-    Performs CONNECT handshake with auth, then wraps in TLS.
+    Performs CONNECT handshake with auth, upgrades to TLS, and closes the
+    writer on exit.
     """
-    sock = socket.create_connection(("127.0.0.1", proxy.port), timeout=10)
-    sock.settimeout(10)
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+    try:
+        creds = base64.b64encode(f"{proxy.username}:{proxy.password}".encode()).decode()
+        connect = (
+            f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
+            f"Host: {target_host}:{target_port}\r\n"
+            f"Proxy-Authorization: Basic {creds}\r\n"
+            f"\r\n"
+        )
+        writer.write(connect.encode())
+        await writer.drain()
 
-    creds = base64.b64encode(f"{proxy.username}:{proxy.password}".encode()).decode()
-    connect = (
-        f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
-        f"Host: {target_host}:{target_port}\r\n"
-        f"Proxy-Authorization: Basic {creds}\r\n"
-        f"\r\n"
-    )
-    sock.sendall(connect.encode())
+        try:
+            response = await reader.readuntil(b"\r\n\r\n")
+        except asyncio.IncompleteReadError as e:
+            raise ConnectionError("Proxy closed during CONNECT") from e
 
-    # Read 200
-    response = b""
-    while b"\r\n\r\n" not in response:
-        chunk = sock.recv(4096)
-        if not chunk:
-            raise ConnectionError("Proxy closed during CONNECT")
-        response += chunk
+        if b"200" not in response.split(b"\r\n")[0]:
+            raise ConnectionError(f"CONNECT failed: {response!r}")
 
-    if b"200" not in response.split(b"\r\n")[0]:
-        raise ConnectionError(f"CONNECT failed: {response!r}")
-
-    # Wrap in TLS trusting the proxy CA (MITM cert)
-    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    return ctx.wrap_socket(sock, server_hostname=target_host)
+        # Upgrade to TLS trusting the proxy CA (MITM cert)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        await writer.start_tls(ctx, server_hostname=target_host)
+        yield reader, writer
+    finally:
+        writer.close()
 
 
 # ---------------------------------------------------------------------------
@@ -245,22 +162,24 @@ def _connect_through_proxy(proxy: MockEgressProxy, target_host: str, target_port
 
 
 @pytest.fixture
-def proxy_socket(mock_egress_proxy: MockEgressProxyFixture) -> Generator[socket.socket]:
-    """Socket connected to the mock proxy."""
-    sock = socket.create_connection(("127.0.0.1", mock_egress_proxy.proxy.port), timeout=5)
+async def proxy_connection(
+    mock_egress_proxy: MockEgressProxyFixture,
+) -> AsyncGenerator[tuple[asyncio.StreamReader, asyncio.StreamWriter]]:
+    """Reader/writer connected to the mock proxy (plain TCP, no TLS upgrade)."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", mock_egress_proxy.proxy.port)
     try:
-        yield sock
+        yield reader, writer
     finally:
-        sock.close()
+        writer.close()
 
 
 @pytest.fixture
-def forwarding_proxy() -> Generator[MockEgressProxy]:
+async def forwarding_proxy() -> AsyncGenerator[MockEgressProxy]:
     """Standalone proxy for forwarding tests (no upstream).
 
     Disables target cert verification since test TLS servers use self-signed certs.
     """
-    with MockEgressProxy(upstream_proxy=None, listen_port=0, verify_target_certs=False) as proxy:
+    async with MockEgressProxy(upstream_proxy=None, listen_port=0, verify_target_certs=False) as proxy:
         yield proxy
 
 
@@ -269,30 +188,34 @@ def forwarding_proxy() -> Generator[MockEgressProxy]:
 # ---------------------------------------------------------------------------
 
 
-def test_proxy_starts_and_stops() -> None:
-    """Test basic proxy lifecycle via context manager."""
-    with MockEgressProxy(upstream_proxy=None, listen_port=0) as proxy:
+async def test_proxy_starts_and_stops() -> None:
+    """Test basic proxy lifecycle via async context manager."""
+    async with MockEgressProxy(upstream_proxy=None, listen_port=0) as proxy:
         assert proxy.port > 0
         assert proxy.ca_cert_pem
 
 
-def test_proxy_requires_auth(proxy_socket: socket.socket) -> None:
+async def test_proxy_requires_auth(proxy_connection: tuple[asyncio.StreamReader, asyncio.StreamWriter]) -> None:
     """Test that proxy rejects unauthenticated requests."""
-    proxy_socket.sendall(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
-    response = proxy_socket.recv(1024)
+    reader, writer = proxy_connection
+    writer.write(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+    await writer.drain()
+    response = await reader.read(1024)
     assert b"407" in response, f"Expected 407, got: {response!r}"
 
 
-def test_proxy_accepts_auth(proxy_socket: socket.socket) -> None:
+async def test_proxy_accepts_auth(proxy_connection: tuple[asyncio.StreamReader, asyncio.StreamWriter]) -> None:
     """Test that proxy does not reject valid credentials (407).
 
     The proxy may return 502 if it can't reach the target (e.g., in a sandbox).
     The key assertion: it does NOT return 407 (auth rejected).
     """
+    _reader, writer = proxy_connection
     creds = base64.b64encode(b"proxy_user:test_jwt_token").decode()
     request = f"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Basic {creds}\r\n\r\n"
-    proxy_socket.sendall(request.encode())
-    response = proxy_socket.recv(1024)
+    writer.write(request.encode())
+    await writer.drain()
+    response = await _reader.read(1024)
     assert b"407" not in response, f"Auth should have been accepted, got: {response!r}"
 
 
@@ -308,36 +231,34 @@ class TestBidirectionalForwarding:
     auth, and verifies data integrity on both sides.
     """
 
-    def test_small_echo(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_small_echo(self, forwarding_proxy: MockEgressProxy) -> None:
         """Small payload round-trips correctly."""
-        with _TLSEchoServer() as echo:
-            conn = _connect_through_proxy(forwarding_proxy, echo.host, echo.port)
-            try:
-                msg = b"hello proxy world"
-                conn.sendall(msg)
-                # Read exactly the expected number of bytes (SSL lacks TCP-style half-close,
-                # so shutdown(SHUT_WR) would trigger close_notify and break the session)
-                received = _recv_exact(conn, len(msg))
-                assert received == msg
-            finally:
-                conn.close()
+        async with (
+            _tls_server(_echo_handler) as echo,
+            _connect_through_proxy(forwarding_proxy, echo.host, echo.port) as (reader, writer),
+        ):
+            msg = b"hello proxy world"
+            writer.write(msg)
+            await writer.drain()
+            received = await _recv_exact(reader, len(msg))
+            assert received == msg
 
-    def test_large_echo(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_large_echo(self, forwarding_proxy: MockEgressProxy) -> None:
         """1 MB payload round-trips without data loss or corruption."""
         payload = os.urandom(1024 * 1024)
         expected_hash = hashlib.sha256(payload).hexdigest()
 
-        with _TLSEchoServer() as echo:
-            conn = _connect_through_proxy(forwarding_proxy, echo.host, echo.port)
-            try:
-                conn.sendall(payload)
-                received = _recv_exact(conn, len(payload))
-                assert len(received) == len(payload)
-                assert hashlib.sha256(received).hexdigest() == expected_hash
-            finally:
-                conn.close()
+        async with (
+            _tls_server(_echo_handler) as echo,
+            _connect_through_proxy(forwarding_proxy, echo.host, echo.port) as (reader, writer),
+        ):
+            writer.write(payload)
+            await writer.drain()
+            received = await _recv_exact(reader, len(payload))
+            assert len(received) == len(payload)
+            assert hashlib.sha256(received).hexdigest() == expected_hash
 
-    def test_large_download(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_large_download(self, forwarding_proxy: MockEgressProxy) -> None:
         """~8 MB server-initiated send (simulates bazelisk download).
 
         The original bug dropped data during large one-directional TLS
@@ -347,68 +268,62 @@ class TestBidirectionalForwarding:
         payload = os.urandom(size)
         expected_hash = hashlib.sha256(payload).hexdigest()
 
-        with _TLSSendServer(payload) as server:
-            conn = _connect_through_proxy(forwarding_proxy, server.host, server.port)
-            try:
-                received = b""
-                while chunk := conn.recv(65536):
-                    received += chunk
-                assert len(received) == size, f"Expected {size} bytes, got {len(received)}"
-                assert hashlib.sha256(received).hexdigest() == expected_hash
-            finally:
-                conn.close()
+        async with (
+            _tls_server(_send_handler(payload)) as server,
+            _connect_through_proxy(forwarding_proxy, server.host, server.port) as (reader, _writer),
+        ):
+            received = b""
+            while chunk := await reader.read(65536):
+                received += chunk
+            assert len(received) == size, f"Expected {size} bytes, got {len(received)}"
+            assert hashlib.sha256(received).hexdigest() == expected_hash
 
-    def test_multiple_messages(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_multiple_messages(self, forwarding_proxy: MockEgressProxy) -> None:
         """Multiple send/recv cycles on the same connection."""
-        with _TLSEchoServer() as echo:
-            conn = _connect_through_proxy(forwarding_proxy, echo.host, echo.port)
-            try:
-                for i in range(10):
-                    msg = f"message {i} ".encode() * 100
-                    conn.sendall(msg)
-                    received = _recv_exact(conn, len(msg))
-                    assert received == msg, f"Mismatch on message {i}"
-            finally:
-                conn.close()
+        async with (
+            _tls_server(_echo_handler) as echo,
+            _connect_through_proxy(forwarding_proxy, echo.host, echo.port) as (reader, writer),
+        ):
+            for i in range(10):
+                msg = f"message {i} ".encode() * 100
+                writer.write(msg)
+                await writer.drain()
+                received = await _recv_exact(reader, len(msg))
+                assert received == msg, f"Mismatch on message {i}"
 
-    def test_concurrent_connections(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_concurrent_connections(self, forwarding_proxy: MockEgressProxy) -> None:
         """Multiple simultaneous connections each transfer data correctly."""
         results: dict[int, bool] = {}
         errors: list[str] = []
 
-        def worker(worker_id: int) -> None:
+        async def worker(worker_id: int) -> None:
             try:
-                with _TLSEchoServer() as echo:
-                    conn = _connect_through_proxy(forwarding_proxy, echo.host, echo.port)
-                    try:
-                        payload = os.urandom(64 * 1024)
-                        conn.sendall(payload)
-                        received = _recv_exact(conn, len(payload))
-                        results[worker_id] = received == payload
-                    finally:
-                        conn.close()
+                async with (
+                    _tls_server(_echo_handler) as echo,
+                    _connect_through_proxy(forwarding_proxy, echo.host, echo.port) as (reader, writer),
+                ):
+                    payload = os.urandom(64 * 1024)
+                    writer.write(payload)
+                    await writer.drain()
+                    received = await _recv_exact(reader, len(payload))
+                    results[worker_id] = received == payload
             except Exception as e:
                 errors.append(f"worker {worker_id}: {e}")
                 results[worker_id] = False
 
-        threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=30)
+        await asyncio.gather(*(worker(i) for i in range(5)))
 
         assert not errors, f"Worker errors: {errors}"
         assert all(results.values()), f"Failed workers: {[k for k, v in results.items() if not v]}"
 
-    def test_server_closes_immediately(self, forwarding_proxy: MockEgressProxy) -> None:
+    async def test_server_closes_immediately(self, forwarding_proxy: MockEgressProxy) -> None:
         """Proxy handles server closing right after TLS handshake."""
-        with _TLSSendServer(b"") as server:
-            conn = _connect_through_proxy(forwarding_proxy, server.host, server.port)
-            try:
-                received = conn.recv(4096)
-                assert received == b""
-            finally:
-                conn.close()
+        async with (
+            _tls_server(_send_handler(b"")) as server,
+            _connect_through_proxy(forwarding_proxy, server.host, server.port) as (reader, _writer),
+        ):
+            received = await reader.read(4096)
+            assert received == b""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add support for installing mkcert and generating trusted localhost TLS certificates. This allows development servers to use HTTPS with certificates automatically trusted by curl, Python, Node, and system browsers.

## Key Changes
- **New `mkcert_setup.py` module**: Handles downloading mkcert binary, installing a local Certificate Authority into system trust stores, and generating certificates for localhost/127.0.0.1/::1
  - Downloads mkcert v1.4.4 for Linux and macOS (x86_64 and ARM64)
  - Manages mkcert binary and CA files in the hook cache directory
  - Appends the mkcert root CA to the combined CA bundle for Python/curl/Node trust
  - Gracefully handles missing system dependencies (certutil) while still providing CA trust via the bundle

- **Integration into session startup**: 
  - Added `setup_mkcert_with_proxy()` async task that depends on the proxy setup (to access the combined CA bundle)
  - Exports `MKCERT_CERT` and `MKCERT_KEY` environment variables for use by development servers
  - Added `install_mkcert` feature flag (default: True) to enable/disable the setup

- **Environment and context updates**:
  - Updated `env_file.py` to export mkcert certificate paths
  - Updated session context template to display mkcert status and usage instructions
  - Added `mkcert` parameter to `emit_session_context()` for logging

- **Build configuration**: Added `mkcert_setup` library target to BUILD.bazel with proper dependencies

## Implementation Details
- Mkcert setup is optional and skipped if `install_mkcert=False`
- The `-install` step (system trust store integration) can fail gracefully if certutil is missing; the CA still works for non-browser tools via the combined bundle
- Certificates are cached and only regenerated if missing
- Proper async task dependency management ensures proxy setup completes before mkcert attempts to append to the combined CA bundle

https://claude.ai/code/session_01JYRNTxHmvoG86UYPgyWZVy