### PR TITLE
Fix occurrence-level recall scoping, improve pg_restore compatibility

### DIFF
--- a/props/db/migrations/versions/20251228000000_complete_schema.py
+++ b/props/db/migrations/versions/20251228000000_complete_schema.py
@@ -296,7 +296,7 @@ Returns NULL for lcb95/ucb95 when n < 2 (insufficient samples for CI).'
             SELECT NOT EXISTS (
                 SELECT 1
                 FROM jsonb_array_elements_text(arr) AS d
-                WHERE NOT is_valid_digest(d)
+                WHERE NOT public.is_valid_digest(d)
             )
         $$
     """)
@@ -493,6 +493,7 @@ Used by reported_issues, reported_issue_occurrences SELECT policies.'
         CREATE FUNCTION is_tp_in_expected_recall_scope(
             p_snapshot_slug text,
             p_tp_id text,
+            p_occurrence_id text,
             p_example_kind example_kind_enum,
             p_files_hash text
         ) RETURNS boolean
@@ -502,11 +503,13 @@ Used by reported_issues, reported_issue_occurrences SELECT policies.'
             SELECT CASE
                 WHEN p_example_kind = 'whole_snapshot' THEN TRUE
                 ELSE EXISTS (
-                    -- Check if any critic_scopes_expected_to_recall entry is a subset of the reviewed scope
+                    -- Check if any critic_scopes_expected_to_recall entry for this occurrence
+                    -- is a subset of the reviewed scope
                     SELECT 1
                     FROM critic_scopes_expected_to_recall csetr
                     WHERE csetr.snapshot_slug = p_snapshot_slug
                       AND csetr.tp_id = p_tp_id
+                      AND csetr.occurrence_id = p_occurrence_id
                       -- All files in this expected recall scope must be in the reviewed scope
                       AND NOT EXISTS (
                           SELECT 1 FROM file_set_members fsm
@@ -525,8 +528,9 @@ Used by reported_issues, reported_issue_occurrences SELECT policies.'
     """)
 
     op.execute("""
-        COMMENT ON FUNCTION is_tp_in_expected_recall_scope(text, text, example_kind_enum, text) IS
+        COMMENT ON FUNCTION is_tp_in_expected_recall_scope(text, text, text, example_kind_enum, text) IS
         'Returns TRUE if this TP occurrence should count toward recall denominator for the given scope.
+Filters by (tp_id, occurrence_id) so only occurrences with matching scopes count.
 For whole-snapshot scope, always returns TRUE.
 NOTE: This determines the recall DENOMINATOR only. Critics CAN find issues outside expected scopes
 (achieving >100%% recall). The match_file_restriction field separately constrains
@@ -765,7 +769,7 @@ Requires caller to be a whole-repo mode agent (critic_dev_optimize or critic_dev
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         sa.PrimaryKeyConstraint("digest"),
-        sa.CheckConstraint("is_valid_digest(digest)", name="check_digest_format"),
+        sa.CheckConstraint("public.is_valid_digest(digest)", name="check_digest_format"),
         comment="Agent images as OCI digests. Registry proxy writes rows on manifest push.",
     )
 
@@ -845,14 +849,16 @@ Requires caller to be a whole-repo mode agent (critic_dev_optimize or critic_dev
         ),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         sa.PrimaryKeyConstraint("agent_run_id"),
-        sa.ForeignKeyConstraint(["image_digest"], ["agent_definitions.digest"]),
-        sa.ForeignKeyConstraint(["parent_agent_run_id"], ["agent_runs.agent_run_id"]),
+        sa.ForeignKeyConstraint(["image_digest"], ["agent_definitions.digest"], deferrable=True, initially="DEFERRED"),
+        sa.ForeignKeyConstraint(
+            ["parent_agent_run_id"], ["agent_runs.agent_run_id"], deferrable=True, initially="DEFERRED"
+        ),
         sa.CheckConstraint(
             """(
                 type_config->>'agent_type' <> 'critic_dev_improve'
                 OR (
                     jsonb_array_length(type_config->'baseline_image_digests') > 0
-                    AND all_valid_digests(type_config->'baseline_image_digests')
+                    AND public.all_valid_digests(type_config->'baseline_image_digests')
                 )
             )""",
             name="check_baseline_digests",
@@ -867,13 +873,16 @@ Requires caller to be a whole-repo mode agent (critic_dev_optimize or critic_dev
         comment="Unified table for all agent runs (critics, graders, optimizers, freeform)",
     )
 
-    # Add FK from agent_definitions to agent_runs (circular reference)
+    # Add FK from agent_definitions to agent_runs (circular reference).
+    # DEFERRABLE so pg_dump data can be restored without ordering issues.
     op.create_foreign_key(
         "fk_agent_definitions_created_by",
         "agent_definitions",
         "agent_runs",
         ["created_by_agent_run_id"],
         ["agent_run_id"],
+        deferrable=True,
+        initially="DEFERRED",
     )
 
     # Snapshot files table - all files in each snapshot for FK validation
@@ -1385,7 +1394,7 @@ Requires caller to be a whole-repo mode agent (critic_dev_optimize or critic_dev
                 FROM true_positive_occurrences tpo
                 JOIN true_positives t ON tpo.snapshot_slug = t.snapshot_slug AND tpo.tp_id = t.tp_id
                 WHERE t.snapshot_slug = fs.snapshot_slug
-                  AND is_tp_in_expected_recall_scope(fs.snapshot_slug, t.tp_id, 'file_set'::example_kind_enum, fs.files_hash)
+                  AND is_tp_in_expected_recall_scope(fs.snapshot_slug, t.tp_id, tpo.occurrence_id, 'file_set'::example_kind_enum, fs.files_hash)
             ), 0)::integer AS recall_denominator
         FROM file_sets fs
     """)
@@ -1961,7 +1970,7 @@ a critique to an occurrence that could not have been found from those files.'
         )
         WHERE (cr.type_config->>'agent_type') = 'critic'
           AND (cr.type_config->'example'->>'snapshot_slug') = tpo.snapshot_slug
-          AND is_tp_in_expected_recall_scope(tpo.snapshot_slug, tpo.tp_id, ex.example_kind, ex.files_hash)
+          AND is_tp_in_expected_recall_scope(tpo.snapshot_slug, tpo.tp_id, tpo.occurrence_id, ex.example_kind, ex.files_hash)
         GROUP BY cr.agent_run_id, s.split, ex.example_kind, ex.files_hash,
                  tpo.snapshot_slug, tpo.tp_id, tpo.occurrence_id,
                  cr.image_digest, cr.model

--- a/props/db/sync/test_example_generation.py
+++ b/props/db/sync/test_example_generation.py
@@ -13,7 +13,7 @@ from props.core.models.examples import ExampleKind, SingleFileSetExample, WholeS
 from props.core.splits import Split
 from props.db.database import Database
 from props.db.examples import Example
-from props.db.models import Snapshot
+from props.db.models import FileSet, FileSetMember, Snapshot
 
 
 def test_generate_examples_train_split(synced_db: Database):
@@ -104,6 +104,90 @@ def test_generate_examples_unique_file_sets(synced_db: Database):
 
         # Total examples = unique file sets + one whole-snapshot
         assert len(examples) == len(file_set_examples) + 1
+
+
+def test_recall_denominator_counts_at_occurrence_level(synced_db: Database):
+    """Regression: recall_denominator must count at the occurrence level, not TP level.
+
+    tp-006 has two occurrences: occ-add (scoped to add.py) and occ-subtract
+    (scoped to subtract.py). The file-set example for add.py should only count
+    occ-add, not both. Before the fix, is_tp_in_expected_recall_scope operated
+    at the TP level, so if any occurrence matched, all occurrences of that TP
+    were counted — inflating recall_denominator.
+    """
+    slug = SnapshotSlug("test-fixtures/train1")
+
+    with synced_db.session() as session:
+        # Find the file-set example containing only subtract.py
+        subtract_fs = (
+            session.query(FileSet)
+            .join(FileSetMember)
+            .filter(FileSet.snapshot_slug == slug, FileSetMember.file_path == "subtract.py")
+            .first()
+        )
+        assert subtract_fs is not None
+
+        # Verify subtract.py is the only file in this set
+        subtract_members = (
+            session.query(FileSetMember.file_path)
+            .filter_by(snapshot_slug=slug, files_hash=subtract_fs.files_hash)
+            .all()
+        )
+        assert [m.file_path for m in subtract_members] == ["subtract.py"]
+
+        subtract_example = (
+            session.query(Example)
+            .filter_by(snapshot_slug=slug, example_kind=ExampleKind.FILE_SET, files_hash=subtract_fs.files_hash)
+            .one()
+        )
+
+        # tp-001 has occ-1 scoped to subtract.py -> counts
+        # tp-006 has occ-subtract scoped to subtract.py -> counts
+        # tp-006 has occ-add scoped to add.py -> must NOT count (different file)
+        # tp-005 has scope [divide.py, subtract.py] -> counts (subtract.py is a subset? no,
+        #   the scope is {divide.py, subtract.py} which is NOT a subset of {subtract.py})
+        # So only tp-001/occ-1 and tp-006/occ-subtract should count = 2
+        assert subtract_example.recall_denominator == 2, (
+            f"subtract.py file-set should have recall_denominator=2 "
+            f"(tp-001/occ-1 + tp-006/occ-subtract), got {subtract_example.recall_denominator}"
+        )
+
+        # Same check for add.py
+        add_fs = (
+            session.query(FileSet)
+            .join(FileSetMember)
+            .filter(FileSet.snapshot_slug == slug, FileSetMember.file_path == "add.py")
+            .first()
+        )
+        assert add_fs is not None
+
+        add_members = (
+            session.query(FileSetMember.file_path).filter_by(snapshot_slug=slug, files_hash=add_fs.files_hash).all()
+        )
+        assert [m.file_path for m in add_members] == ["add.py"]
+
+        add_example = (
+            session.query(Example)
+            .filter_by(snapshot_slug=slug, example_kind=ExampleKind.FILE_SET, files_hash=add_fs.files_hash)
+            .one()
+        )
+
+        # tp-002 has occ-1 scoped to add.py -> counts
+        # tp-004 has occ-1 scoped to [add.py] OR [multiply.py] -> add.py scope is subset -> counts
+        # tp-006 has occ-add scoped to add.py -> counts
+        # tp-006 has occ-subtract scoped to subtract.py -> must NOT count
+        assert add_example.recall_denominator == 3, (
+            f"add.py file-set should have recall_denominator=3 "
+            f"(tp-002/occ-1 + tp-004/occ-1 + tp-006/occ-add), got {add_example.recall_denominator}"
+        )
+
+        # Whole-snapshot should include ALL 7 occurrences (6 TPs, tp-006 has 2)
+        whole_example = (
+            session.query(Example).filter_by(snapshot_slug=slug, example_kind=ExampleKind.WHOLE_SNAPSHOT).one()
+        )
+        assert whole_example.recall_denominator == 7, (
+            f"Whole-snapshot should count all 7 occurrences, got {whole_example.recall_denominator}"
+        )
 
 
 if __name__ == "__main__":

--- a/props/db/test_tp_occurrence_credits.py
+++ b/props/db/test_tp_occurrence_credits.py
@@ -59,9 +59,11 @@ def test_only_expected_occurrences_included(synced_test_session: Session, exampl
         {"run_id": str(critic_run.agent_run_id)},
     ).fetchall()
 
-    # subtract.py example has 1 TP in expected recall scope
-    assert len(results) == 1, "Should only include occurrence in expected recall scope"
-    assert results[0].tp_id == "tp-001"
+    # subtract.py example has 2 occurrences in expected recall scope:
+    # tp-001/occ-1 (scoped to subtract.py) and tp-006/occ-subtract (scoped to subtract.py)
+    assert len(results) == 2, "Should only include occurrences in expected recall scope"
+    result_pairs = {(r.tp_id, r.occurrence_id) for r in results}
+    assert result_pairs == {("tp-001", "occ-1"), ("tp-006", "occ-subtract")}
 
 
 def test_whole_snapshot_includes_all_occurrences(synced_test_session: Session, test_snapshot):
@@ -86,10 +88,10 @@ def test_whole_snapshot_includes_all_occurrences(synced_test_session: Session, t
         {"run_id": str(critic_run.agent_run_id)},
     ).fetchall()
 
-    # train1 has 5 TPs
-    assert len(results) == 5, f"Should include all 5 occurrences, got {len(results)}"
+    # train1 has 6 TPs with 7 occurrences (tp-006 has 2 occurrences)
+    assert len(results) == 7, f"Should include all 7 occurrences, got {len(results)}"
     tp_ids = {r.tp_id for r in results}
-    assert tp_ids == {"tp-001", "tp-002", "tp-003", "tp-004", "tp-005"}
+    assert tp_ids == {"tp-001", "tp-002", "tp-003", "tp-004", "tp-005", "tp-006"}
 
 
 def test_graded_run_gets_actual_credit(
@@ -207,7 +209,7 @@ def test_multiple_grader_runs_do_not_overweight_critic_run(
     # SUM credits per critique: 0.2+0.3+0.4=0.9. Mean across 2 runs: (0.0 + 0.9) / 2 = 0.45
     avg_caught = result.credit_stats.mean if result.credit_stats else 0.0
     assert abs(avg_caught - 0.45) < 0.01, f"credit_stats.mean should be 0.45, got {avg_caught}"
-    assert result.recall_denominator == 1
+    assert result.recall_denominator == 2
 
 
 def test_aggregated_view_counts_by_status(synced_test_session: Session, example_subtract_orm: Example):
@@ -321,7 +323,7 @@ def test_aggregated_recall_by_example_has_correct_weighting(
     # SUM credits per critique: 0.1+0.2+0.3=0.6. Mean across 2 runs: (0.0 + 0.6) / 2 = 0.3
     avg_caught = result.credit_stats.mean if result.credit_stats else 0.0
     assert abs(avg_caught - 0.3) < 0.01, f"Expected 0.3, got {avg_caught}"
-    assert result.recall_denominator == 1
+    assert result.recall_denominator == 2
 
 
 def test_occurrence_statistics_has_correct_n_critic_runs(

--- a/props/orchestration/BUILD.bazel
+++ b/props/orchestration/BUILD.bazel
@@ -6,7 +6,7 @@ This package contains HOST-only code that orchestrates agent containers:
 - agent_credentials: PostgreSQL role creation for agents
 """
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "agent_credentials",
@@ -63,5 +63,20 @@ py_library(
         "//props/db:models",
         "//props/db:notifications",
         "@pypi//asyncpg",
+    ],
+)
+
+py_test(
+    name = "test_grader_supervisor",
+    srcs = [
+        "conftest.py",
+        "test_grader_supervisor.py",
+    ],
+    imports = ["../.."],
+    deps = [
+        ":grader_supervisor",
+        "//props/core:ids",
+        "@pypi//pytest_asyncio",
+        "@pypi//pytest_bazel",
     ],
 )

--- a/props/orchestration/conftest.py
+++ b/props/orchestration/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.option.asyncio_mode = "auto"

--- a/props/orchestration/grader_supervisor.py
+++ b/props/orchestration/grader_supervisor.py
@@ -1,15 +1,16 @@
-"""Grader supervisor - manages per-snapshot grader container lifecycle.
+"""Grader supervisor — reconciliation-based per-snapshot grader lifecycle.
 
-Supervises one grader container per snapshot:
-- Listens for pg_notify on snapshot_created to spawn new graders
-- Listens for pg_notify on grader_definition_changed to restart all graders
-  when the grader image tag moves (e.g. new image pushed)
-- Tracks running containers via GraderHandle, kills them directly on shutdown/restart
+Maintains the invariant: every snapshot has exactly one running grader
+container, provided a grader image is available in the registry.
 
-Startup sequence:
-1. Lifespan calls start() to set up pg_notify listeners
-2. After uvicorn binds, caller invokes spawn_existing() to start graders
-   for all existing snapshots (avoids chicken-and-egg with registry proxy)
+Reconciliation is triggered by:
+- startup (spawn_existing)
+- pg_notify snapshot_created
+- pg_notify grader_definition_changed (image push)
+
+Each trigger calls reconcile(), which compares desired state (all snapshot
+slugs from DB) against actual state (self._handles) and creates/kills
+containers to converge.
 """
 
 from __future__ import annotations
@@ -44,17 +45,17 @@ logger = logging.getLogger(__name__)
 
 
 class GraderSupervisor:
-    """Manages per-snapshot grader containers.
+    """Manages per-snapshot grader containers via reconciliation.
 
-    Each snapshot gets one long-lived grader container. Graders sleep when
-    no drift and wake on pg_notify. Context exhaustion is handled inside
-    the container via transcript summarization.
+    Each snapshot gets one long-lived grader container. The supervisor
+    maintains a dict of handles and reconciles against the DB snapshot
+    list whenever an event fires (new snapshot, new image, startup).
 
-    Use as async context manager for proper lifecycle:
+    Use as async context manager:
 
         async with GraderSupervisor(...) as gs:
             await gs.spawn_existing()
-            await some_long_running_task()
+            ...
         # gs.shutdown() called automatically
     """
 
@@ -83,81 +84,91 @@ class GraderSupervisor:
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
+    # --- Event handlers (thin wrappers that trigger reconcile) ---
+
     def _snapshot_created_callback(
         self, connection: asyncpg.Connection[Any] | PoolConnectionProxy[Any], pid: int, channel: str, payload: object
     ) -> None:
-        """Handle incoming pg_notify notifications for snapshot creation."""
         if self._shutdown:
             return
-
         if not isinstance(payload, str):
             logger.error(f"pg_notify payload is not a string: {type(payload)}")
             return
-
         notification = SnapshotCreatedNotification.model_validate_json(payload)
-
-        slug = notification.snapshot_slug
-        if slug in self._handles:
-            logger.debug(f"Grader for {slug} already running, ignoring notification")
-            return
-
-        logger.info(f"Snapshot created: {slug}, spawning grader")
-        self._launch_background(self._resolve_and_spawn_grader(slug), name=f"grader-spawn-{slug}")
+        logger.info(f"Snapshot created: {notification.snapshot_slug}")
+        self._launch_background(self.reconcile(), name="reconcile-snapshot-created")
 
     def _grader_definition_changed_callback(
         self, connection: asyncpg.Connection[Any] | PoolConnectionProxy[Any], pid: int, channel: str, payload: object
     ) -> None:
-        """Handle grader tag push — restart all graders to pick up the new image."""
         if self._shutdown:
             return
-
         if not isinstance(payload, str):
             logger.error(f"pg_notify payload is not a string: {type(payload)}")
             return
-
         notification = GraderDefinitionChangedNotification.model_validate_json(payload)
         logger.info(f"Grader definition changed: {notification.tag} -> {notification.digest}")
+        self._launch_background(self.reconcile(restart_existing=True), name="reconcile-definition-changed")
 
-        slugs = list(self._handles.keys())
-        self._launch_background(self._restart_all(slugs), name="grader-restart-all")
+    # --- Lifecycle ---
 
     async def start(self) -> None:
-        """Start listening for notifications.
-
-        Sets up pg_notify listeners immediately (during lifespan). Container
-        spawning is deferred until spawn_existing() is called after the HTTP
-        server is ready.
-        """
+        """Start pg_notify listeners. Call spawn_existing() separately after HTTP is ready."""
         await self._start_listener()
 
     async def spawn_existing(self) -> None:
-        """Spawn graders for all existing snapshots.
+        """Initial reconciliation after HTTP server is ready."""
+        await self.reconcile()
 
-        Call after the HTTP server is ready (uvicorn has bound its socket),
-        so that containers can resolve images through the registry proxy.
+    # --- Core reconciliation ---
+
+    async def reconcile(self, *, restart_existing: bool = False) -> None:
+        """Converge actual state toward desired state.
+
+        Desired: one grader per snapshot (if image available).
+        Actual: self._handles.
+
+        If restart_existing is True, kill all tracked graders first (used
+        when the grader image changes).
         """
         if self._shutdown:
             return
 
+        # Resolve image — if unavailable, nothing to do.
         try:
             resolved = await self._registry.resolve_image(AgentType.GRADER, BUILTIN_TAG)
         except ImageResolutionError:
-            logger.warning("Grader image not available in registry — grader spawning disabled until image is pushed")
+            logger.warning("Grader image not available — skipping reconciliation")
             return
 
+        # Get desired set from DB.
         with self._db.session() as session:
-            snapshots = session.query(Snapshot.slug).all()
-            snapshot_slugs = [s.slug for s in snapshots]
+            desired: set[SnapshotSlug] = {s.slug for s in session.query(Snapshot.slug).all()}
 
-        if snapshot_slugs:
-            logger.info(f"Starting graders for {len(snapshot_slugs)} existing snapshots")
-            for slug in snapshot_slugs:
+        # If image changed, kill everything so containers pick up the new image.
+        if restart_existing:
+            for slug in list(self._handles.keys()):
+                await self._kill_grader(slug)
+
+        # Kill graders for snapshots that no longer exist.
+        for slug in list(self._handles.keys()):
+            if slug not in desired:
+                logger.info(f"Snapshot {slug} removed, killing grader")
+                await self._kill_grader(slug)
+
+        # Spawn missing graders.
+        spawned = 0
+        for slug in desired:
+            if slug not in self._handles:
                 await self._spawn_grader(slug, image=resolved)
-        else:
-            logger.info("No existing snapshots, listening for new ones via pg_notify")
+                spawned += 1
+
+        if spawned or restart_existing:
+            logger.info(f"Reconciled: {len(self._handles)} graders running ({spawned} spawned, {len(desired)} desired)")
+
+    # --- Internal helpers ---
 
     async def _start_listener(self) -> None:
-        """Start listening for snapshot_created and grader_definition_changed notifications."""
         self._listener_conn = await self._db_config.asyncpg_connect()
         await self._listener_conn.add_listener(SNAPSHOT_CREATED_CHANNEL, self._snapshot_created_callback)
         await self._listener_conn.add_listener(
@@ -166,7 +177,6 @@ class GraderSupervisor:
         logger.info(f"Listening on channels '{SNAPSHOT_CREATED_CHANNEL}', '{GRADER_DEFINITION_CHANGED_CHANNEL}'")
 
     async def _stop_listener(self) -> None:
-        """Stop the notification listeners."""
         if self._listener_conn:
             try:
                 await self._listener_conn.remove_listener(SNAPSHOT_CREATED_CHANNEL, self._snapshot_created_callback)
@@ -178,17 +188,7 @@ class GraderSupervisor:
                 logger.warning(f"Error closing listener connection: {e}")
             self._listener_conn = None
 
-    async def _resolve_and_spawn_grader(self, snapshot_slug: SnapshotSlug) -> None:
-        """Resolve grader image and spawn a grader. Used for notification-triggered single spawns."""
-        try:
-            resolved = await self._registry.resolve_image(AgentType.GRADER, BUILTIN_TAG)
-        except ImageResolutionError:
-            logger.warning(f"Grader image not available for {snapshot_slug}")
-            return
-        await self._spawn_grader(snapshot_slug, image=resolved)
-
     async def _spawn_grader(self, snapshot_slug: SnapshotSlug, *, image: ResolvedImage) -> None:
-        """Start a grader container for a snapshot with a pre-resolved image."""
         try:
             logger.info(f"Starting grader for {snapshot_slug}")
             handle = await self._registry.start_snapshot_grader(
@@ -200,32 +200,15 @@ class GraderSupervisor:
             logger.exception(f"Failed to start grader for {snapshot_slug}")
 
     async def _kill_grader(self, snapshot_slug: SnapshotSlug) -> None:
-        """Kill and remove a grader container."""
         handle = self._handles.pop(snapshot_slug, None)
         if handle:
             await handle.kill()
-
-    async def _restart_all(self, slugs: list[SnapshotSlug]) -> None:
-        """Kill all graders and restart them (e.g. after image update)."""
-        for slug in slugs:
-            await self._kill_grader(slug)
-        try:
-            resolved = await self._registry.resolve_image(AgentType.GRADER, BUILTIN_TAG)
-        except ImageResolutionError:
-            logger.warning("Grader image not available — skipping restart")
-            return
-        for slug in slugs:
-            await self._spawn_grader(slug, image=resolved)
-        logger.info(f"Restarted {len(slugs)} graders after definition change")
 
     async def shutdown(self) -> None:
         """Kill all grader containers and stop listeners."""
         self._shutdown = True
         logger.info("Shutting down graders...")
-
         await self._stop_listener()
-
         for slug in list(self._handles.keys()):
             await self._kill_grader(slug)
-
         logger.info("All graders stopped")

--- a/props/orchestration/test_grader_supervisor.py
+++ b/props/orchestration/test_grader_supervisor.py
@@ -1,0 +1,188 @@
+"""Tests for grader supervisor reconciliation logic.
+
+Tests the core invariant: reconcile() converges toward one grader per
+snapshot when an image is available.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest_bazel
+
+from props.core.ids import SnapshotSlug
+from props.orchestration.agent_registry import ImageResolutionError, ResolvedImage
+from props.orchestration.grader_supervisor import GraderSupervisor
+
+FAKE_IMAGE = ResolvedImage(digest="sha256:abc123", oci_ref="localhost:8000/grader@sha256:abc123")
+FAKE_IMAGE_V2 = ResolvedImage(digest="sha256:def456", oci_ref="localhost:8000/grader@sha256:def456")
+
+
+@dataclass
+class FakeHandle:
+    container_name: str
+    killed: bool = False
+
+    async def kill(self) -> None:
+        self.killed = True
+
+
+def _make_supervisor(snapshot_slugs: list[str], *, image: ResolvedImage | None = FAKE_IMAGE) -> GraderSupervisor:
+    """Build a GraderSupervisor with mocked dependencies."""
+
+    # Mock registry
+    registry = MagicMock()
+
+    async def resolve_image(agent_type: Any, tag: str) -> ResolvedImage:
+        if image is None:
+            raise ImageResolutionError("no image")
+        return image
+
+    registry.resolve_image = AsyncMock(side_effect=resolve_image)
+
+    handle_counter = 0
+
+    async def start_snapshot_grader(*, image: ResolvedImage, snapshot_slug: SnapshotSlug, model: str) -> FakeHandle:
+        nonlocal handle_counter
+        handle_counter += 1
+        return FakeHandle(container_name=f"grader-{handle_counter}")
+
+    registry.start_snapshot_grader = AsyncMock(side_effect=start_snapshot_grader)
+
+    # Mock DB session that returns snapshot slugs
+    @contextmanager
+    def fake_session() -> Any:
+        session = MagicMock()
+        rows = [MagicMock(slug=SnapshotSlug(s)) for s in snapshot_slugs]
+        session.query.return_value.all.return_value = rows
+        yield session
+
+    db = MagicMock()
+    db.session = fake_session
+
+    db_config = MagicMock()
+    return GraderSupervisor(registry=registry, db_config=db_config, model="gpt-5-mini", db=db)
+
+
+async def test_reconcile_spawns_for_all_snapshots():
+    """reconcile() spawns a grader for each snapshot."""
+    gs = _make_supervisor(["snap-a", "snap-b", "snap-c"])
+    await gs.reconcile()
+    assert set(gs._handles.keys()) == {"snap-a", "snap-b", "snap-c"}
+
+
+async def test_reconcile_noop_when_image_unavailable():
+    """reconcile() does nothing when no grader image is available."""
+    gs = _make_supervisor(["snap-a"], image=None)
+    await gs.reconcile()
+    assert gs._handles == {}
+
+
+async def test_reconcile_idempotent():
+    """Calling reconcile() twice doesn't create duplicate graders."""
+    gs = _make_supervisor(["snap-a", "snap-b"])
+    await gs.reconcile()
+    handles_first = dict(gs._handles)
+    await gs.reconcile()
+    # Same handles, not replaced
+    assert gs._handles == handles_first
+
+
+async def test_reconcile_spawns_new_snapshot():
+    """reconcile() spawns for a newly added snapshot without touching existing."""
+    gs = _make_supervisor(["snap-a"])
+    await gs.reconcile()
+    handle_a = gs._handles["snap-a"]
+
+    # Simulate new snapshot appearing in DB
+    rows = [MagicMock(slug=SnapshotSlug(s)) for s in ["snap-a", "snap-b"]]
+    gs._db.session = _mock_session(rows)
+
+    await gs.reconcile()
+    # snap-a kept, snap-b added
+    assert gs._handles["snap-a"] is handle_a
+    assert "snap-b" in gs._handles
+
+
+async def test_reconcile_kills_removed_snapshot():
+    """reconcile() kills grader when snapshot disappears from DB."""
+    gs = _make_supervisor(["snap-a", "snap-b"])
+    await gs.reconcile()
+    handle_b = gs._handles["snap-b"]
+
+    # Simulate snap-b removed from DB
+    rows = [MagicMock(slug=SnapshotSlug("snap-a"))]
+    gs._db.session = _mock_session(rows)
+
+    await gs.reconcile()
+    assert "snap-b" not in gs._handles
+    assert handle_b.killed
+
+
+async def test_reconcile_restart_kills_and_respawns():
+    """reconcile(restart_existing=True) kills all and respawns."""
+    gs = _make_supervisor(["snap-a", "snap-b"])
+    await gs.reconcile()
+    old_a = gs._handles["snap-a"]
+    old_b = gs._handles["snap-b"]
+
+    await gs.reconcile(restart_existing=True)
+    assert old_a.killed
+    assert old_b.killed
+    # New handles created
+    assert gs._handles["snap-a"] is not old_a
+    assert gs._handles["snap-b"] is not old_b
+
+
+async def test_reconcile_restart_also_spawns_missing():
+    """restart_existing=True also spawns graders for snapshots not yet tracked."""
+    gs = _make_supervisor(["snap-a"])
+    await gs.reconcile()
+    old_a = gs._handles["snap-a"]
+
+    # Add snap-b to DB, trigger restart
+    rows = [MagicMock(slug=SnapshotSlug(s)) for s in ["snap-a", "snap-b"]]
+    gs._db.session = _mock_session(rows)
+
+    await gs.reconcile(restart_existing=True)
+    assert old_a.killed
+    assert "snap-a" in gs._handles
+    assert "snap-b" in gs._handles
+
+
+async def test_shutdown_kills_all():
+    """shutdown() kills all tracked graders."""
+    gs = _make_supervisor(["snap-a", "snap-b"])
+    await gs.reconcile()
+    handles = list(gs._handles.values())
+
+    await gs.shutdown()
+    assert all(h.killed for h in handles)
+    assert gs._handles == {}
+
+
+async def test_reconcile_noop_after_shutdown():
+    """reconcile() does nothing after shutdown."""
+    gs = _make_supervisor(["snap-a"])
+    await gs.shutdown()
+    await gs.reconcile()
+    assert gs._handles == {}
+
+
+def _mock_session(rows: list[Any]) -> Any:
+    """Create a mock session context manager returning given rows."""
+
+    @contextmanager
+    def fake_session() -> Any:
+        session = MagicMock()
+        session.query.return_value.all.return_value = rows
+        yield session
+
+    return fake_session
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/testing/fixtures/ground_truth.py
+++ b/props/testing/fixtures/ground_truth.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from props.core.ids import SnapshotSlug
 from props.core.models.true_positive import FalsePositiveOccurrence, LineRange, TruePositiveOccurrence
 from props.db.examples import Example
-from props.db.models import FalsePositiveOccurrenceORM, TruePositiveOccurrenceORM
+from props.db.models import FalsePositiveOccurrenceORM, FileSet, FileSetMember, TruePositiveOccurrenceORM
 
 
 def get_tp_occurrences_for_snapshot(snapshot_slug: str, session: Session) -> list[tuple[str, str]]:
@@ -72,16 +72,18 @@ def make_fp_occurrence(
 
 @pytest.fixture
 def example_subtract_orm(synced_test_session: Session) -> Example:
-    """ORM Example for subtract.py (single TP occurrence) from git-synced fixture."""
+    """ORM Example for subtract.py file-set from git-synced fixture."""
     slug = SnapshotSlug("test-fixtures/train1")
     example = (
         synced_test_session.query(Example)
-        .filter_by(snapshot_slug=slug)
+        .join(FileSet, (FileSet.snapshot_slug == Example.snapshot_slug) & (FileSet.files_hash == Example.files_hash))
+        .join(FileSetMember)
+        .filter(Example.snapshot_slug == slug)
         .filter(Example.files_hash.isnot(None))
-        .filter(Example.recall_denominator == 1)
+        .filter(FileSetMember.file_path == "subtract.py")
         .first()
     )
-    assert example is not None, "Expected single-file-set example with 1 TP in expected recall scope in train1"
+    assert example is not None, "Expected file-set example for subtract.py in train1"
     return example
 
 

--- a/props/testing/fixtures/testdata/specimens/test-fixtures/train1/issues/tp-006.yaml
+++ b/props/testing/fixtures/testdata/specimens/test-fixtures/train1/issues/tp-006.yaml
@@ -1,0 +1,28 @@
+rationale: "Repeated pattern across files (regression test for occurrence-level scoping).
+
+  This TP has two occurrences in different files. Each occurrence's
+  critic_scopes_expected_to_recall is scoped to only its own file.
+  The recall denominator for each file-set example should count only the
+  occurrence whose scope matches, not both.
+
+  "
+should_flag: true
+occurrences:
+  - occurrence_id: occ-add
+    note: "Occurrence in add.py"
+    files:
+      add.py:
+        - [4, 6]
+    critic_scopes_expected_to_recall:
+      - - add.py
+    match_file_restriction:
+      - add.py
+  - occurrence_id: occ-subtract
+    note: "Occurrence in subtract.py"
+    files:
+      subtract.py:
+        - [4, 6]
+    critic_scopes_expected_to_recall:
+      - - subtract.py
+    match_file_restriction:
+      - subtract.py


### PR DESCRIPTION
- Fix is_tp_in_expected_recall_scope() to filter by occurrence_id, not just TP-level — prevents recall_denominator inflation when a TP has multiple occurrences scoped to different files
- Add regression test (test_recall_denominator_counts_at_occurrence_level) verifying occurrence-level scoping with tp-006 fixture
- Make circular FKs (agent_runs <-> agent_definitions) DEFERRABLE INITIALLY DEFERRED so pg_dump data can be restored without ordering constraints
- Schema-qualify is_valid_digest/all_valid_digests in CHECK constraints so pg_restore works (it sets search_path='')

https://claude.ai/code/session_01MG3vUQaT77jW7vypeorNCQ