### PR TITLE
fix: TLS trust chain and env var fixes for session hooks

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -368,11 +368,12 @@ py_test(
     },
     # Inherit proxy env vars so MockEgressProxy can chain through real proxy
     env_inherit = [
+        "CURL_CA_BUNDLE",
         "HTTPS_PROXY",
         "https_proxy",
-        "SSL_CERT_FILE",
-        "REQUESTS_CA_BUNDLE",
         "NODE_EXTRA_CA_CERTS",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
     ],
     imports = ["../.."],
     # local: podman needs user namespaces (newuidmap), blocked by linux-sandbox

--- a/tools/claude_hooks/podman_service.py
+++ b/tools/claude_hooks/podman_service.py
@@ -248,27 +248,21 @@ async def setup_podman(settings: HookSettings, supervisor: SupervisorClient, tmp
 
 
 def _get_podman_env_vars(settings: HookSettings) -> dict[str, str]:
-    """Get podman env vars for already-configured setup.
+    """Get podman config env vars for already-configured setup.
 
-    Includes container config paths and any proxy/SSL env vars from the
-    current environment. The podman daemon runs under supervisor which
-    doesn't inherit env vars implicitly — they must be passed explicitly.
-    Without proxy vars, the daemon can't pull images through a TLS proxy.
+    Returns only podman-specific config paths (CONTAINERS_*, BUILDAH_*).
+    Proxy/SSL env vars are NOT included here — they're merged separately
+    in start_podman_service() for the daemon, and the session env file's
+    auth proxy section sets SSL CA vars to the correct combined CA bundle.
     """
     podman_dir = settings.get_podman_dir()
-    env_vars: dict[str, str] = {
+    return {
         "CONTAINERS_STORAGE_CONF": str(podman_dir / "storage.conf"),
         "CONTAINERS_CONF": str(podman_dir / "containers.conf"),
         "CONTAINERS_REGISTRIES_CONF": str(podman_dir / "registries.conf"),
         # OCI isolation avoids read-only /dev/null from chroot mode's devtmpfs
         "BUILDAH_ISOLATION": "oci",
     }
-    # Pass proxy and SSL CA env vars so the daemon can pull images through
-    # the TLS-inspecting proxy (e.g., Anthropic's egress proxy)
-    for var in PROXY_ENV_VARS + SSL_CA_ENV_VARS:
-        if value := os.environ.get(var):
-            env_vars[var] = value
-    return env_vars
 
 
 async def _is_podman_service_healthy(supervisor: SupervisorClient, socket_path: Path) -> bool:
@@ -304,13 +298,24 @@ async def start_podman_service(
     socket_url = f"unix://{socket_path}"
     socket_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # The podman daemon runs under supervisor which doesn't inherit the
+    # container's env vars. Merge proxy/SSL vars from the current environment
+    # so the daemon can pull images through the TLS-inspecting egress proxy.
+    # These are NOT included in _get_podman_env_vars() because that dict is
+    # also exported to the session env file, where the auth proxy section
+    # already sets SSL CA vars to the correct combined CA bundle.
+    daemon_env = dict(env_vars)
+    for var in PROXY_ENV_VARS + SSL_CA_ENV_VARS:
+        if value := os.environ.get(var):
+            daemon_env[var] = value
+
     # Start podman system service (--time=0 means never timeout, keep running)
     # Pass config env vars so podman uses our isolated paths
     await supervisor.add_service(
         name=PODMAN_SERVICE,
         command=f"podman system service --time=0 {socket_url}",
         directory=Path.home(),
-        environment=env_vars,
+        environment=daemon_env,
     )
 
     # Wait for socket to be ready

--- a/tools/claude_hooks/proxy_setup.py
+++ b/tools/claude_hooks/proxy_setup.py
@@ -405,8 +405,10 @@ def _create_combined_ca_bundle(settings: HookSettings) -> None:
     combined_ca = settings.get_auth_proxy_combined_ca()
     ca_file_path = settings.get_auth_proxy_ca_file()
 
-    # Prefer pre-installed Anthropic CA, fall back to extracted one
-    ca_file = ANTHROPIC_CA_PREINSTALLED if ANTHROPIC_CA_PREINSTALLED.exists() else ca_file_path
+    # Prefer extracted CA (written by _extract_proxy_ca) — it's always the validated,
+    # correct CA for this session. In tests, ANTHROPIC_CA_PATH overrides the CA;
+    # using the pre-installed file would bypass that override.
+    ca_file = ca_file_path if ca_file_path.exists() else ANTHROPIC_CA_PREINSTALLED
     if not ca_file.exists():
         raise CaBundleError("No CA file to add to bundle")
 

--- a/tools/claude_hooks/test_session_start.py
+++ b/tools/claude_hooks/test_session_start.py
@@ -124,7 +124,15 @@ def isolated_dirs(tmp_path: Path) -> IsolatedDirs:
 
 @pytest.fixture
 def system_bazel() -> str:
-    """Get system bazel/bazelisk path, failing if not found."""
+    """Get the real bazelisk binary path.
+
+    Prefers the actual binary at auth-proxy/bazelisk over bin/bazelisk,
+    which is a symlink to the wrapper script and would cause an infinite
+    loop when used as BAZELISK_PATH.
+    """
+    real = settings.HookSettings().get_bazelisk_path()
+    if real.exists():
+        return str(real)
     path = shutil.which("bazelisk") or shutil.which("bazel")
     if not path:
         pytest.fail("Neither bazelisk nor bazel found on PATH")

--- a/tools/claude_hooks/testing/mock_egress_proxy.py
+++ b/tools/claude_hooks/testing/mock_egress_proxy.py
@@ -62,7 +62,7 @@ class EgressProxyConfig:
         if not parsed.hostname:
             return None
 
-        # Get CA bundle for verifying upstream proxy's TLS
+        # Get CA bundle for verifying upstream proxy's TLS interception cert.
         ca_bundle = next((v for var in SSL_CA_ENV_VARS if (v := os.environ.get(var))), None)
 
         return cls(


### PR DESCRIPTION
- Filter debug env dump to key prefixes only (9p performance: ~58s → fast)
- Resolve BAZELISK_PATH to actual binary, not wrapper symlink (infinite loop)
- Make mock egress proxy CA trusted by bazelisk in tests: prefer extracted CA over pre-installed, add CURL_CA_BUNDLE to env_inherit
- Stop podman env section from overriding SSL CA vars in session env file: move proxy/SSL collection to start_podman_service() supervisor call site

https://claude.ai/code/session_01JYRNTxHmvoG86UYPgyWZVy