### PR TITLE
Add match_file_restriction to 9 gmail-archiver TP occurrences

### DIFF
--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/ad-hoc-action-signature-tuple.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/ad-hoc-action-signature-tuple.yaml
@@ -28,3 +28,5 @@ occurrences:
         - [370, 376]
     critic_scopes_expected_to_recall:
       - [gmail_archiver/cli/filters.py]
+    match_file_restriction:
+      - gmail_archiver/cli/filters.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/broad-except-retry-after.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/broad-except-retry-after.yaml
@@ -15,3 +15,5 @@ occurrences:
         - [66, 79] # try/except Exception around timestamp parsing
     critic_scopes_expected_to_recall:
       - [gmail_archiver/gmail_client.py]
+    match_file_restriction:
+      - gmail_archiver/gmail_client.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/datetime-utc-attribute-error.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/datetime-utc-attribute-error.yaml
@@ -17,3 +17,5 @@ occurrences:
         - [74, 74] # datetime.now(datetime.UTC) — AttributeError at runtime
     critic_scopes_expected_to_recall:
       - [gmail_archiver/gmail_client.py]
+    match_file_restriction:
+      - gmail_archiver/gmail_client.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/dict-any-bypasses-validation.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/dict-any-bypasses-validation.yaml
@@ -22,3 +22,5 @@ occurrences:
           - 65
     critic_scopes_expected_to_recall:
       - - gmail_archiver/gmail_yaml_filters_models.py
+    match_file_restriction:
+      - gmail_archiver/gmail_yaml_filters_models.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/dup-inbox-fetch-methods.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/dup-inbox-fetch-methods.yaml
@@ -21,3 +21,5 @@ occurrences:
         - [78, 103]
     critic_scopes_expected_to_recall:
       - [gmail_archiver/inbox.py]
+    match_file_restriction:
+      - gmail_archiver/inbox.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/duplicated-pagination-logic.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/duplicated-pagination-logic.yaml
@@ -11,3 +11,6 @@ occurrences:
     note: manual pagination loop duplicates GmailClient.list_messages_by_query()
     critic_scopes_expected_to_recall:
       - - gmail_archiver/__main__.py
+    match_file_restriction:
+      - gmail_archiver/__main__.py
+      - gmail_archiver/gmail_client.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/falsy-zero-amount.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/falsy-zero-amount.yaml
@@ -12,3 +12,5 @@ occurrences:
         - [112, 112]
     critic_scopes_expected_to_recall:
       - [gmail_archiver/planners/square.py]
+    match_file_restriction:
+      - gmail_archiver/planners/square.py

--- a/props/specimens/gmail-archiver/2025-12-17-00/issues/unfaithful-gmail-message.yaml
+++ b/props/specimens/gmail-archiver/2025-12-17-00/issues/unfaithful-gmail-message.yaml
@@ -13,6 +13,9 @@ occurrences:
     note: GmailMessage.body is single str field, loses MIME structure
     critic_scopes_expected_to_recall:
       - - gmail_archiver/models.py
+    match_file_restriction:
+      - gmail_archiver/gmail_client.py
+      - gmail_archiver/models.py
   - occurrence_id: occ-1
     files:
       gmail_archiver/gmail_client.py:
@@ -20,6 +23,9 @@ occurrences:
     note: get_messages_batch() plaintext extraction (no HTML fallback)
     critic_scopes_expected_to_recall:
       - - gmail_archiver/gmail_client.py
+    match_file_restriction:
+      - gmail_archiver/gmail_client.py
+      - gmail_archiver/models.py
   - occurrence_id: occ-2
     files:
       gmail_archiver/gmail_client.py:
@@ -27,3 +33,6 @@ occurrences:
     note: get_message() plaintext extraction (no HTML fallback)
     critic_scopes_expected_to_recall:
       - - gmail_archiver/gmail_client.py
+    match_file_restriction:
+      - gmail_archiver/gmail_client.py
+      - gmail_archiver/models.py


### PR DESCRIPTION
Narrow grading match scope for 12 occurrences across 9 issues in gmail-archiver/2025-12-17-00:

- ad-hoc-action-signature-tuple: cli/filters.py
- broad-except-retry-after: gmail_client.py
- datetime-utc-attribute-error: gmail_client.py
- dict-any-bypasses-validation: gmail_yaml_filters_models.py
- dup-inbox-fetch-methods: inbox.py
- duplicated-pagination-logic: __main__.py + gmail_client.py
- falsy-zero-amount: planners/square.py
- unfaithful-gmail-message (3 occs): gmail_client.py + models.py

https://claude.ai/code/session_01MG3vUQaT77jW7vypeorNCQ