### PR TITLE
Fix sync losing match_file_restriction on occurrences

### DIFF
--- a/props/db/models.py
+++ b/props/db/models.py
@@ -449,6 +449,7 @@ class TruePositiveOccurrenceORM(Base):
     true_positive: Mapped[TruePositive] = relationship(back_populates="occurrences")
     critic_scopes_expected_to_recall: Mapped[list[CriticScopeExpectedToRecall]] = relationship(
         back_populates="occurrence",
+        cascade="all, delete-orphan",
         primaryjoin="and_(TruePositiveOccurrenceORM.snapshot_slug == foreign(CriticScopeExpectedToRecall.snapshot_slug), "
         "TruePositiveOccurrenceORM.tp_id == foreign(CriticScopeExpectedToRecall.tp_id), "
         "TruePositiveOccurrenceORM.occurrence_id == foreign(CriticScopeExpectedToRecall.occurrence_id))",

--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -149,6 +149,24 @@ py_test(
 )
 
 docker_py_test(
+    name = "test_sync_occurrence_update",
+    srcs = ["test_sync_occurrence_update.py"],
+    imports = ["../../.."],
+    deps = [
+        ":sync",
+        ":yaml_loader",
+        "//props:conftest",
+        "//props/core:ids",
+        "//props/core/models:true_positive",
+        "//props/db:conftest",
+        "//props/db:database",
+        "//props/db:models",
+        "@pypi//pytest_bazel",
+        "@pypi//sqlalchemy",
+    ],
+)
+
+docker_py_test(
     name = "test_manifest_loading",
     srcs = ["test_manifest_loading.py"],
     imports = ["../../.."],

--- a/props/db/sync/sync.py
+++ b/props/db/sync/sync.py
@@ -44,7 +44,7 @@ from props.db.sync.yaml_loader import SyncValidationError, load_yaml_issues
 
 if TYPE_CHECKING:
     from props.config import PropsConfig
-    from props.core.models.true_positive import LineRange
+    from props.core.models.true_positive import FalsePositiveOccurrence, LineRange, TruePositiveOccurrence
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -368,8 +368,10 @@ def sync_issues_to_db(
                         logger.debug(f"Updating issue rationale: {key}")
                         needs_update = True
 
-                    # For now, always update occurrences if any change detected
-                    # TODO: Implement proper occurrence comparison
+                    if _tp_occurrences_changed(list(existing.occurrences), issue.occurrences):
+                        logger.debug(f"Updating issue occurrences: {key}")
+                        needs_update = True
+
                     if needs_update:
                         existing.rationale = issue.rationale
                         # Delete existing occurrences and re-add (cascade handles this)
@@ -433,8 +435,10 @@ def sync_issues_to_db(
                         logger.debug(f"Updating FP rationale: {fp_key}")
                         fp_needs_update = True
 
-                    # For now, always update occurrences if any change detected
-                    # TODO: Implement proper occurrence comparison
+                    if _fp_occurrences_changed(list(existing_fp.occurrences), fp.occurrences):
+                        logger.debug(f"Updating FP occurrences: {fp_key}")
+                        fp_needs_update = True
+
                     if fp_needs_update:
                         existing_fp.rationale = fp.rationale
                         # Delete existing occurrences and re-add (cascade handles this)
@@ -569,6 +573,51 @@ def sync_snapshot_files_to_db(session: Session, slugs: list[SnapshotSlug]) -> Sy
     return SyncStats(total=total, added=added, updated=updated, deleted=deleted)
 
 
+def _compute_restriction_hash(match_file_restriction: set[Path] | None) -> str | None:
+    """Compute the expected DB hash for a match_file_restriction from YAML."""
+    if match_file_restriction is None:
+        return None
+    return compute_files_hash([str(p) for p in match_file_restriction])
+
+
+def _tp_occurrences_changed(
+    existing_occs: list[TruePositiveOccurrenceORM], yaml_occs: list[TruePositiveOccurrence]
+) -> bool:
+    """Check if TP occurrence data differs between DB and YAML."""
+    existing_map = {o.occurrence_id: o for o in existing_occs}
+    yaml_map = {o.occurrence_id: o for o in yaml_occs}
+
+    if set(existing_map.keys()) != set(yaml_map.keys()):
+        return True
+
+    for occ_id, yaml_occ in yaml_map.items():
+        db_occ = existing_map[occ_id]
+        if db_occ.note != yaml_occ.note:
+            return True
+        if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
+            return True
+    return False
+
+
+def _fp_occurrences_changed(
+    existing_occs: list[FalsePositiveOccurrenceORM], yaml_occs: list[FalsePositiveOccurrence]
+) -> bool:
+    """Check if FP occurrence data differs between DB and YAML."""
+    existing_map = {o.occurrence_id: o for o in existing_occs}
+    yaml_map = {o.occurrence_id: o for o in yaml_occs}
+
+    if set(existing_map.keys()) != set(yaml_map.keys()):
+        return True
+
+    for occ_id, yaml_occ in yaml_map.items():
+        db_occ = existing_map[occ_id]
+        if db_occ.note != yaml_occ.note:
+            return True
+        if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
+            return True
+    return False
+
+
 def compute_files_hash(file_paths: list[str]) -> str:
     """Compute content-addressable hash for a file set.
 
@@ -627,7 +676,7 @@ def sync_file_sets_to_db(session: Session, slugs: list[SnapshotSlug], specimens_
     # Load canonical TPs from YAML to get critic_scopes_expected_to_recall
 
     for slug in slugs:
-        true_positives, _ = load_yaml_issues(slug, specimens_dir)
+        true_positives, false_positives = load_yaml_issues(slug, specimens_dir)
 
         for tp in true_positives:
             for occurrence in tp.occurrences:
@@ -639,6 +688,19 @@ def sync_file_sets_to_db(session: Session, slugs: list[SnapshotSlug], specimens_
                     key = (slug, files_hash)
                     desired_file_sets.setdefault(key, file_paths)
                     desired_triggers.add((slug, tp.tp_id, occurrence.occurrence_id, files_hash))
+
+                # Also preserve file sets used by match_file_restriction
+                if occurrence.match_file_restriction is not None:
+                    restriction_paths = [str(f) for f in occurrence.match_file_restriction]
+                    restriction_hash = compute_files_hash(restriction_paths)
+                    desired_file_sets.setdefault((slug, restriction_hash), restriction_paths)
+
+        for fp in false_positives:
+            for fp_occ in fp.occurrences:
+                if fp_occ.match_file_restriction is not None:
+                    restriction_paths = [str(f) for f in fp_occ.match_file_restriction]
+                    restriction_hash = compute_files_hash(restriction_paths)
+                    desired_file_sets.setdefault((slug, restriction_hash), restriction_paths)
 
     # Current state from DB
     existing_file_sets: set[tuple[SnapshotSlug, str]] = {

--- a/props/db/sync/sync.py
+++ b/props/db/sync/sync.py
@@ -8,9 +8,10 @@ import logging
 import shutil
 import tarfile
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlunparse
 from urllib.request import urlopen
@@ -480,8 +481,14 @@ def sync_snapshot_files_to_db(session: Session, slugs: list[SnapshotSlug]) -> Sy
     return SyncStats(total=total, added=added, updated=updated, deleted=deleted)
 
 
-def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrence:
-    """Reconstruct a YAML-equivalent Pydantic model from an ORM occurrence."""
+_OccORM = TypeVar("_OccORM", TruePositiveOccurrenceORM, FalsePositiveOccurrenceORM)
+_OccPydantic = TypeVar("_OccPydantic", TruePositiveOccurrence, FalsePositiveOccurrence)
+
+
+def _reconstruct_occ_common(
+    db_occ: TruePositiveOccurrenceORM | FalsePositiveOccurrenceORM,
+) -> tuple[dict[Path, list[LineRange]], set[Path] | None]:
+    """Reconstruct files dict and match_file_restriction from an ORM occurrence."""
     files: dict[Path, list[LineRange]] = {}
     for r in sorted(db_occ.ranges, key=lambda r: (str(r.file_path), r.range_id)):
         files.setdefault(Path(str(r.file_path)), []).append(
@@ -490,7 +497,6 @@ def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrenc
 
     restriction: set[Path] | None = None
     if db_occ.match_file_restriction is not None:
-        # Resolve hash → paths via file_set_members query on the same session
         session = Session.object_session(db_occ)
         assert session is not None
         members = (
@@ -500,6 +506,12 @@ def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrenc
         )
         restriction = {Path(m.file_path) for m in members}
 
+    return files, restriction
+
+
+def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrence:
+    """Reconstruct a YAML-equivalent Pydantic model from an ORM TP occurrence."""
+    files, restriction = _reconstruct_occ_common(db_occ)
     return TruePositiveOccurrence(
         occurrence_id=db_occ.occurrence_id,
         files=files,
@@ -511,23 +523,7 @@ def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrenc
 
 def _fp_occ_from_orm(db_occ: FalsePositiveOccurrenceORM) -> FalsePositiveOccurrence:
     """Reconstruct a YAML-equivalent Pydantic model from an ORM FP occurrence."""
-    files: dict[Path, list[LineRange]] = {}
-    for r in sorted(db_occ.ranges, key=lambda r: (str(r.file_path), r.range_id)):
-        files.setdefault(Path(str(r.file_path)), []).append(
-            LineRange(start_line=r.start_line, end_line=r.end_line, note=r.note)
-        )
-
-    restriction: set[Path] | None = None
-    if db_occ.match_file_restriction is not None:
-        session = Session.object_session(db_occ)
-        assert session is not None
-        members = (
-            session.query(FileSetMember.file_path)
-            .filter_by(snapshot_slug=db_occ.snapshot_slug, files_hash=db_occ.match_file_restriction)
-            .all()
-        )
-        restriction = {Path(m.file_path) for m in members}
-
+    files, restriction = _reconstruct_occ_common(db_occ)
     return FalsePositiveOccurrence(
         occurrence_id=db_occ.occurrence_id,
         files=files,
@@ -537,64 +533,56 @@ def _fp_occ_from_orm(db_occ: FalsePositiveOccurrenceORM) -> FalsePositiveOccurre
     )
 
 
-def _sync_tp_issue(session: Session, existing: TruePositive, yaml_issue: TruePositive_yaml) -> bool:
-    """Sync a TP issue, returning True if anything changed."""
+def _sync_occurrences(
+    session: Session,
+    db_occs: list[_OccORM],
+    yaml_occs: list[_OccPydantic],
+    from_orm: Callable[[_OccORM], _OccPydantic],
+    add_occ: Callable[[_OccPydantic], None],
+) -> bool:
+    """Diff occurrences by id; delete+re-add only changed ones. Returns True if anything changed."""
     changed = False
-    if existing.rationale != yaml_issue.rationale:
-        existing.rationale = yaml_issue.rationale
-        changed = True
+    db_map = {o.occurrence_id: o for o in db_occs}
+    yaml_map = {o.occurrence_id: o for o in yaml_occs}
 
-    db_map = {o.occurrence_id: o for o in existing.occurrences}
-    yaml_map = {o.occurrence_id: o for o in yaml_issue.occurrences}
-
-    # Removed occurrences
     for occ_id in set(db_map) - set(yaml_map):
         session.delete(db_map[occ_id])
         changed = True
 
     for occ_id, yaml_occ in yaml_map.items():
         if occ_id not in db_map:
-            # New occurrence
-            _add_tp_occurrence(session, yaml_issue.snapshot_slug, yaml_issue.tp_id, yaml_occ)
+            add_occ(yaml_occ)
             changed = True
-        else:
-            # Compare via Pydantic reconstruction
-            db_pydantic = _tp_occ_from_orm(db_map[occ_id])
-            if db_pydantic != yaml_occ:
-                session.delete(db_map[occ_id])
-                _add_tp_occurrence(session, yaml_issue.snapshot_slug, yaml_issue.tp_id, yaml_occ)
-                changed = True
+        elif from_orm(db_map[occ_id]) != yaml_occ:
+            session.delete(db_map[occ_id])
+            add_occ(yaml_occ)
+            changed = True
 
     return changed
+
+
+def _sync_tp_issue(session: Session, existing: TruePositive, yaml_issue: TruePositive_yaml) -> bool:
+    """Sync a TP issue, returning True if anything changed."""
+    changed = existing.rationale != yaml_issue.rationale
+    if changed:
+        existing.rationale = yaml_issue.rationale
+
+    def add(occ: TruePositiveOccurrence) -> None:
+        _add_tp_occurrence(session, yaml_issue.snapshot_slug, yaml_issue.tp_id, occ)
+
+    return _sync_occurrences(session, existing.occurrences, yaml_issue.occurrences, _tp_occ_from_orm, add) or changed
 
 
 def _sync_fp_issue(session: Session, existing: FalsePositive, yaml_fp: FalsePositive_yaml) -> bool:
     """Sync an FP issue, returning True if anything changed."""
-    changed = False
-    if existing.rationale != yaml_fp.rationale:
+    changed = existing.rationale != yaml_fp.rationale
+    if changed:
         existing.rationale = yaml_fp.rationale
-        changed = True
 
-    db_map = {o.occurrence_id: o for o in existing.occurrences}
-    yaml_map = {o.occurrence_id: o for o in yaml_fp.occurrences}
+    def add(occ: FalsePositiveOccurrence) -> None:
+        _add_fp_occurrence(session, yaml_fp.snapshot_slug, yaml_fp.fp_id, occ)
 
-    # Removed occurrences
-    for occ_id in set(db_map) - set(yaml_map):
-        session.delete(db_map[occ_id])
-        changed = True
-
-    for occ_id, yaml_occ in yaml_map.items():
-        if occ_id not in db_map:
-            _add_fp_occurrence(session, yaml_fp.snapshot_slug, yaml_fp.fp_id, yaml_occ)
-            changed = True
-        else:
-            db_pydantic = _fp_occ_from_orm(db_map[occ_id])
-            if db_pydantic != yaml_occ:
-                session.delete(db_map[occ_id])
-                _add_fp_occurrence(session, yaml_fp.snapshot_slug, yaml_fp.fp_id, yaml_occ)
-                changed = True
-
-    return changed
+    return _sync_occurrences(session, existing.occurrences, yaml_fp.occurrences, _fp_occ_from_orm, add) or changed
 
 
 def _add_tp_occurrence(session: Session, snapshot_slug: SnapshotSlug, tp_id: str, occ: TruePositiveOccurrence) -> None:
@@ -612,17 +600,17 @@ def _add_tp_occurrence(session: Session, snapshot_slug: SnapshotSlug, tp_id: str
 
 def _add_fp_occurrence(session: Session, snapshot_slug: SnapshotSlug, fp_id: str, occ: FalsePositiveOccurrence) -> None:
     """Create an FP occurrence ORM row with all dependent rows."""
-    fp_orm_occ = FalsePositiveOccurrenceORM(
+    orm_occ = FalsePositiveOccurrenceORM(
         snapshot_slug=snapshot_slug,
         fp_id=fp_id,
         occurrence_id=occ.occurrence_id,
         note=occ.note,
         match_file_restriction=ensure_file_set(session, snapshot_slug, occ.match_file_restriction),
     )
-    session.add(fp_orm_occ)
-    _add_ranges_to_occurrence(fp_orm_occ, occ.files)
+    session.add(orm_occ)
+    _add_ranges_to_occurrence(orm_occ, occ.files)
     for relevant_file in occ.relevant_files:
-        fp_orm_occ.relevant_file_orms.append(
+        orm_occ.relevant_file_orms.append(
             FalsePositiveRelevantFileORM(
                 snapshot_slug=snapshot_slug, occurrence_id=occ.occurrence_id, file_path=relevant_file
             )

--- a/props/db/sync/sync.py
+++ b/props/db/sync/sync.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 
 from props.core.ids import SnapshotSlug
 from props.core.models.snapshot import BundleFilter, GitHubSource, GitSource, LocalSource, SnapshotDoc
-from props.core.models.true_positive import LineRange
+from props.core.models.true_positive import FalsePositiveOccurrence, LineRange, TruePositiveOccurrence
 from props.core.runs_context import specimens_definitions_root
 from props.db.models import (
     CriticScopeExpectedToRecall,
@@ -41,11 +41,15 @@ from props.db.models import (
 from props.db.sync.loader import discover_snapshots
 from props.db.sync.model_metadata import sync_model_metadata_with_session
 from props.db.sync.stats import SyncStats
-from props.db.sync.yaml_loader import SyncValidationError, load_yaml_issues
+from props.db.sync.yaml_loader import (
+    FalsePositive as FalsePositive_yaml,
+    SyncValidationError,
+    TruePositive as TruePositive_yaml,
+    load_yaml_issues,
+)
 
 if TYPE_CHECKING:
     from props.config import PropsConfig
-    from props.core.models.true_positive import FalsePositiveOccurrence, TruePositiveOccurrence
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -338,62 +342,20 @@ def sync_issues_to_db(
                 seen_issue_keys.add(key)
 
                 if key not in existing_issues:
-                    # New issue - create ORM instance and occurrences
                     logger.debug(f"Adding issue: {issue.snapshot_slug}/{issue.tp_id}")
                     orm_issue = TruePositive(
                         snapshot_slug=issue.snapshot_slug, tp_id=issue.tp_id, rationale=issue.rationale
                     )
                     session.add(orm_issue)
-                    # Note: critic_scopes_expected_to_recall is stored in M:N table, not as column
-                    # Note: files/line ranges are stored in tp_occurrence_ranges table, not as column
                     for occ in issue.occurrences:
-                        orm_occ = TruePositiveOccurrenceORM(
-                            snapshot_slug=issue.snapshot_slug,
-                            tp_id=issue.tp_id,
-                            occurrence_id=occ.occurrence_id,
-                            note=occ.note,
-                            match_file_restriction=ensure_file_set(
-                                session, issue.snapshot_slug, occ.match_file_restriction
-                            ),
-                        )
-                        session.add(orm_occ)
-                        _add_ranges_to_occurrence(orm_occ, occ.files)
+                        _add_tp_occurrence(session, issue.snapshot_slug, issue.tp_id, occ)
                     added += 1
                     total += 1
                 else:
-                    # Existing issue - check if update needed
                     existing = existing_issues[key]
-                    needs_update = False
-
-                    if existing.rationale != issue.rationale:
-                        logger.debug(f"Updating issue rationale: {key}")
-                        needs_update = True
-
-                    if _tp_occurrences_changed(list(existing.occurrences), issue.occurrences):
-                        logger.debug(f"Updating issue occurrences: {key}")
-                        needs_update = True
-
-                    if needs_update:
-                        existing.rationale = issue.rationale
-                        # Delete existing occurrences and re-add (cascade handles this)
-                        for occ_orm in list(existing.occurrences):
-                            session.delete(occ_orm)
-                        for occ in issue.occurrences:
-                            orm_occ = TruePositiveOccurrenceORM(
-                                snapshot_slug=issue.snapshot_slug,
-                                tp_id=issue.tp_id,
-                                occurrence_id=occ.occurrence_id,
-                                note=occ.note,
-                                match_file_restriction=ensure_file_set(
-                                    session, issue.snapshot_slug, occ.match_file_restriction
-                                ),
-                            )
-                            session.add(orm_occ)
-                            _add_ranges_to_occurrence(orm_occ, occ.files)
+                    if _sync_tp_issue(session, existing, issue):
                         updated += 1
-                        total += 1
-                    else:
-                        total += 1
+                    total += 1
 
             # Sync false positives
             for fp in false_positives:
@@ -401,74 +363,18 @@ def sync_issues_to_db(
                 seen_fp_keys.add(fp_key)
 
                 if fp_key not in existing_fps:
-                    # New FP - create ORM instance and occurrences
                     logger.debug(f"Adding false positive: {fp.snapshot_slug}/{fp.fp_id}")
                     orm_fp = FalsePositive(snapshot_slug=fp.snapshot_slug, fp_id=fp.fp_id, rationale=fp.rationale)
                     session.add(orm_fp)
                     for fp_occ in fp.occurrences:
-                        fp_orm_occ = FalsePositiveOccurrenceORM(
-                            snapshot_slug=fp.snapshot_slug,
-                            fp_id=fp.fp_id,
-                            occurrence_id=fp_occ.occurrence_id,
-                            note=fp_occ.note,
-                            match_file_restriction=ensure_file_set(
-                                session, fp.snapshot_slug, fp_occ.match_file_restriction
-                            ),
-                        )
-                        session.add(fp_orm_occ)
-                        _add_ranges_to_occurrence(fp_orm_occ, fp_occ.files)
-                        for relevant_file in fp_occ.relevant_files:
-                            fp_orm_occ.relevant_file_orms.append(
-                                FalsePositiveRelevantFileORM(
-                                    snapshot_slug=fp.snapshot_slug,
-                                    occurrence_id=fp_occ.occurrence_id,
-                                    file_path=relevant_file,
-                                )
-                            )
+                        _add_fp_occurrence(session, fp.snapshot_slug, fp.fp_id, fp_occ)
                     added += 1
                     total += 1
                 else:
-                    # Existing FP - check if update needed
                     existing_fp = existing_fps[fp_key]
-                    fp_needs_update = False
-
-                    if existing_fp.rationale != fp.rationale:
-                        logger.debug(f"Updating FP rationale: {fp_key}")
-                        fp_needs_update = True
-
-                    if _fp_occurrences_changed(list(existing_fp.occurrences), fp.occurrences):
-                        logger.debug(f"Updating FP occurrences: {fp_key}")
-                        fp_needs_update = True
-
-                    if fp_needs_update:
-                        existing_fp.rationale = fp.rationale
-                        # Delete existing occurrences and re-add (cascade handles this)
-                        for fp_occ_orm in list(existing_fp.occurrences):
-                            session.delete(fp_occ_orm)
-                        for fp_occ in fp.occurrences:
-                            fp_orm_occ = FalsePositiveOccurrenceORM(
-                                snapshot_slug=fp.snapshot_slug,
-                                fp_id=fp.fp_id,
-                                occurrence_id=fp_occ.occurrence_id,
-                                note=fp_occ.note,
-                                match_file_restriction=ensure_file_set(
-                                    session, fp.snapshot_slug, fp_occ.match_file_restriction
-                                ),
-                            )
-                            session.add(fp_orm_occ)
-                            _add_ranges_to_occurrence(fp_orm_occ, fp_occ.files)
-                            for relevant_file in fp_occ.relevant_files:
-                                fp_orm_occ.relevant_file_orms.append(
-                                    FalsePositiveRelevantFileORM(
-                                        snapshot_slug=fp.snapshot_slug,
-                                        occurrence_id=fp_occ.occurrence_id,
-                                        file_path=relevant_file,
-                                    )
-                                )
+                    if _sync_fp_issue(session, existing_fp, fp):
                         updated += 1
-                        total += 1
-                    else:
-                        total += 1
+                    total += 1
 
             session.flush()
         except Exception as e:
@@ -574,82 +480,153 @@ def sync_snapshot_files_to_db(session: Session, slugs: list[SnapshotSlug]) -> Sy
     return SyncStats(total=total, added=added, updated=updated, deleted=deleted)
 
 
-def _compute_restriction_hash(match_file_restriction: set[Path] | None) -> str | None:
-    """Compute the expected DB hash for a match_file_restriction from YAML."""
-    if match_file_restriction is None:
-        return None
-    return compute_files_hash([str(p) for p in match_file_restriction])
-
-
-def _db_ranges_to_files(ranges: list[OccurrenceRangeORM]) -> dict[Path, list[LineRange]]:
-    """Reconstruct files dict from DB occurrence ranges."""
+def _tp_occ_from_orm(db_occ: TruePositiveOccurrenceORM) -> TruePositiveOccurrence:
+    """Reconstruct a YAML-equivalent Pydantic model from an ORM occurrence."""
     files: dict[Path, list[LineRange]] = {}
-    for r in sorted(ranges, key=lambda r: (str(r.file_path), r.range_id)):
-        path = Path(str(r.file_path))
-        files.setdefault(path, []).append(LineRange(start_line=r.start_line, end_line=r.end_line, note=r.note))
-    return files
+    for r in sorted(db_occ.ranges, key=lambda r: (str(r.file_path), r.range_id)):
+        files.setdefault(Path(str(r.file_path)), []).append(
+            LineRange(start_line=r.start_line, end_line=r.end_line, note=r.note)
+        )
+
+    restriction: set[Path] | None = None
+    if db_occ.match_file_restriction is not None:
+        # Resolve hash → paths via file_set_members query on the same session
+        session = Session.object_session(db_occ)
+        assert session is not None
+        members = (
+            session.query(FileSetMember.file_path)
+            .filter_by(snapshot_slug=db_occ.snapshot_slug, files_hash=db_occ.match_file_restriction)
+            .all()
+        )
+        restriction = {Path(m.file_path) for m in members}
+
+    return TruePositiveOccurrence(
+        occurrence_id=db_occ.occurrence_id,
+        files=files,
+        note=db_occ.note,
+        critic_scopes_expected_to_recall=db_occ.critic_scopes_expected_to_recall_set,
+        match_file_restriction=restriction,
+    )
 
 
-def _yaml_files_to_comparable(files: dict[Path, list[LineRange] | None]) -> dict[Path, list[LineRange]]:
-    """Normalize YAML files dict for comparison (None ranges -> empty list)."""
-    return {p: (ranges if ranges is not None else []) for p, ranges in files.items()}
+def _fp_occ_from_orm(db_occ: FalsePositiveOccurrenceORM) -> FalsePositiveOccurrence:
+    """Reconstruct a YAML-equivalent Pydantic model from an ORM FP occurrence."""
+    files: dict[Path, list[LineRange]] = {}
+    for r in sorted(db_occ.ranges, key=lambda r: (str(r.file_path), r.range_id)):
+        files.setdefault(Path(str(r.file_path)), []).append(
+            LineRange(start_line=r.start_line, end_line=r.end_line, note=r.note)
+        )
+
+    restriction: set[Path] | None = None
+    if db_occ.match_file_restriction is not None:
+        session = Session.object_session(db_occ)
+        assert session is not None
+        members = (
+            session.query(FileSetMember.file_path)
+            .filter_by(snapshot_slug=db_occ.snapshot_slug, files_hash=db_occ.match_file_restriction)
+            .all()
+        )
+        restriction = {Path(m.file_path) for m in members}
+
+    return FalsePositiveOccurrence(
+        occurrence_id=db_occ.occurrence_id,
+        files=files,
+        note=db_occ.note,
+        relevant_files={Path(str(rf.file_path)) for rf in db_occ.relevant_file_orms},
+        match_file_restriction=restriction,
+    )
 
 
-def _db_critic_scopes_hashes(db_occ: TruePositiveOccurrenceORM) -> set[str]:
-    """Get set of files_hash values from DB critic_scopes_expected_to_recall."""
-    return {scope.files_hash for scope in db_occ.critic_scopes_expected_to_recall}
+def _sync_tp_issue(session: Session, existing: TruePositive, yaml_issue: TruePositive_yaml) -> bool:
+    """Sync a TP issue, returning True if anything changed."""
+    changed = False
+    if existing.rationale != yaml_issue.rationale:
+        existing.rationale = yaml_issue.rationale
+        changed = True
 
+    db_map = {o.occurrence_id: o for o in existing.occurrences}
+    yaml_map = {o.occurrence_id: o for o in yaml_issue.occurrences}
 
-def _yaml_critic_scopes_hashes(yaml_occ: TruePositiveOccurrence) -> set[str]:
-    """Compute files_hash values for YAML critic_scopes_expected_to_recall."""
-    return {compute_files_hash([str(p) for p in scope]) for scope in yaml_occ.critic_scopes_expected_to_recall}
-
-
-def _tp_occurrences_changed(
-    existing_occs: list[TruePositiveOccurrenceORM], yaml_occs: list[TruePositiveOccurrence]
-) -> bool:
-    """Check if TP occurrence data differs between DB and YAML."""
-    existing_map = {o.occurrence_id: o for o in existing_occs}
-    yaml_map = {o.occurrence_id: o for o in yaml_occs}
-
-    if set(existing_map.keys()) != set(yaml_map.keys()):
-        return True
+    # Removed occurrences
+    for occ_id in set(db_map) - set(yaml_map):
+        session.delete(db_map[occ_id])
+        changed = True
 
     for occ_id, yaml_occ in yaml_map.items():
-        db_occ = existing_map[occ_id]
-        if db_occ.note != yaml_occ.note:
-            return True
-        if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
-            return True
-        if _db_ranges_to_files(list(db_occ.ranges)) != _yaml_files_to_comparable(yaml_occ.files):
-            return True
-        if _db_critic_scopes_hashes(db_occ) != _yaml_critic_scopes_hashes(yaml_occ):
-            return True
-    return False
+        if occ_id not in db_map:
+            # New occurrence
+            _add_tp_occurrence(session, yaml_issue.snapshot_slug, yaml_issue.tp_id, yaml_occ)
+            changed = True
+        else:
+            # Compare via Pydantic reconstruction
+            db_pydantic = _tp_occ_from_orm(db_map[occ_id])
+            if db_pydantic != yaml_occ:
+                session.delete(db_map[occ_id])
+                _add_tp_occurrence(session, yaml_issue.snapshot_slug, yaml_issue.tp_id, yaml_occ)
+                changed = True
+
+    return changed
 
 
-def _fp_occurrences_changed(
-    existing_occs: list[FalsePositiveOccurrenceORM], yaml_occs: list[FalsePositiveOccurrence]
-) -> bool:
-    """Check if FP occurrence data differs between DB and YAML."""
-    existing_map = {o.occurrence_id: o for o in existing_occs}
-    yaml_map = {o.occurrence_id: o for o in yaml_occs}
+def _sync_fp_issue(session: Session, existing: FalsePositive, yaml_fp: FalsePositive_yaml) -> bool:
+    """Sync an FP issue, returning True if anything changed."""
+    changed = False
+    if existing.rationale != yaml_fp.rationale:
+        existing.rationale = yaml_fp.rationale
+        changed = True
 
-    if set(existing_map.keys()) != set(yaml_map.keys()):
-        return True
+    db_map = {o.occurrence_id: o for o in existing.occurrences}
+    yaml_map = {o.occurrence_id: o for o in yaml_fp.occurrences}
+
+    # Removed occurrences
+    for occ_id in set(db_map) - set(yaml_map):
+        session.delete(db_map[occ_id])
+        changed = True
 
     for occ_id, yaml_occ in yaml_map.items():
-        db_occ = existing_map[occ_id]
-        if db_occ.note != yaml_occ.note:
-            return True
-        if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
-            return True
-        if _db_ranges_to_files(list(db_occ.ranges)) != _yaml_files_to_comparable(yaml_occ.files):
-            return True
-        db_relevant = {Path(str(rf.file_path)) for rf in db_occ.relevant_file_orms}
-        if db_relevant != yaml_occ.relevant_files:
-            return True
-    return False
+        if occ_id not in db_map:
+            _add_fp_occurrence(session, yaml_fp.snapshot_slug, yaml_fp.fp_id, yaml_occ)
+            changed = True
+        else:
+            db_pydantic = _fp_occ_from_orm(db_map[occ_id])
+            if db_pydantic != yaml_occ:
+                session.delete(db_map[occ_id])
+                _add_fp_occurrence(session, yaml_fp.snapshot_slug, yaml_fp.fp_id, yaml_occ)
+                changed = True
+
+    return changed
+
+
+def _add_tp_occurrence(session: Session, snapshot_slug: SnapshotSlug, tp_id: str, occ: TruePositiveOccurrence) -> None:
+    """Create a TP occurrence ORM row with all dependent rows."""
+    orm_occ = TruePositiveOccurrenceORM(
+        snapshot_slug=snapshot_slug,
+        tp_id=tp_id,
+        occurrence_id=occ.occurrence_id,
+        note=occ.note,
+        match_file_restriction=ensure_file_set(session, snapshot_slug, occ.match_file_restriction),
+    )
+    session.add(orm_occ)
+    _add_ranges_to_occurrence(orm_occ, occ.files)
+
+
+def _add_fp_occurrence(session: Session, snapshot_slug: SnapshotSlug, fp_id: str, occ: FalsePositiveOccurrence) -> None:
+    """Create an FP occurrence ORM row with all dependent rows."""
+    fp_orm_occ = FalsePositiveOccurrenceORM(
+        snapshot_slug=snapshot_slug,
+        fp_id=fp_id,
+        occurrence_id=occ.occurrence_id,
+        note=occ.note,
+        match_file_restriction=ensure_file_set(session, snapshot_slug, occ.match_file_restriction),
+    )
+    session.add(fp_orm_occ)
+    _add_ranges_to_occurrence(fp_orm_occ, occ.files)
+    for relevant_file in occ.relevant_files:
+        fp_orm_occ.relevant_file_orms.append(
+            FalsePositiveRelevantFileORM(
+                snapshot_slug=snapshot_slug, occurrence_id=occ.occurrence_id, file_path=relevant_file
+            )
+        )
 
 
 def compute_files_hash(file_paths: list[str]) -> str:

--- a/props/db/sync/sync.py
+++ b/props/db/sync/sync.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from props.core.ids import SnapshotSlug
 from props.core.models.snapshot import BundleFilter, GitHubSource, GitSource, LocalSource, SnapshotDoc
+from props.core.models.true_positive import LineRange
 from props.core.runs_context import specimens_definitions_root
 from props.db.models import (
     CriticScopeExpectedToRecall,
@@ -44,7 +45,7 @@ from props.db.sync.yaml_loader import SyncValidationError, load_yaml_issues
 
 if TYPE_CHECKING:
     from props.config import PropsConfig
-    from props.core.models.true_positive import FalsePositiveOccurrence, LineRange, TruePositiveOccurrence
+    from props.core.models.true_positive import FalsePositiveOccurrence, TruePositiveOccurrence
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -580,6 +581,30 @@ def _compute_restriction_hash(match_file_restriction: set[Path] | None) -> str |
     return compute_files_hash([str(p) for p in match_file_restriction])
 
 
+def _db_ranges_to_files(ranges: list[OccurrenceRangeORM]) -> dict[Path, list[LineRange]]:
+    """Reconstruct files dict from DB occurrence ranges."""
+    files: dict[Path, list[LineRange]] = {}
+    for r in sorted(ranges, key=lambda r: (str(r.file_path), r.range_id)):
+        path = Path(str(r.file_path))
+        files.setdefault(path, []).append(LineRange(start_line=r.start_line, end_line=r.end_line, note=r.note))
+    return files
+
+
+def _yaml_files_to_comparable(files: dict[Path, list[LineRange] | None]) -> dict[Path, list[LineRange]]:
+    """Normalize YAML files dict for comparison (None ranges -> empty list)."""
+    return {p: (ranges if ranges is not None else []) for p, ranges in files.items()}
+
+
+def _db_critic_scopes_hashes(db_occ: TruePositiveOccurrenceORM) -> set[str]:
+    """Get set of files_hash values from DB critic_scopes_expected_to_recall."""
+    return {scope.files_hash for scope in db_occ.critic_scopes_expected_to_recall}
+
+
+def _yaml_critic_scopes_hashes(yaml_occ: TruePositiveOccurrence) -> set[str]:
+    """Compute files_hash values for YAML critic_scopes_expected_to_recall."""
+    return {compute_files_hash([str(p) for p in scope]) for scope in yaml_occ.critic_scopes_expected_to_recall}
+
+
 def _tp_occurrences_changed(
     existing_occs: list[TruePositiveOccurrenceORM], yaml_occs: list[TruePositiveOccurrence]
 ) -> bool:
@@ -595,6 +620,10 @@ def _tp_occurrences_changed(
         if db_occ.note != yaml_occ.note:
             return True
         if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
+            return True
+        if _db_ranges_to_files(list(db_occ.ranges)) != _yaml_files_to_comparable(yaml_occ.files):
+            return True
+        if _db_critic_scopes_hashes(db_occ) != _yaml_critic_scopes_hashes(yaml_occ):
             return True
     return False
 
@@ -614,6 +643,11 @@ def _fp_occurrences_changed(
         if db_occ.note != yaml_occ.note:
             return True
         if db_occ.match_file_restriction != _compute_restriction_hash(yaml_occ.match_file_restriction):
+            return True
+        if _db_ranges_to_files(list(db_occ.ranges)) != _yaml_files_to_comparable(yaml_occ.files):
+            return True
+        db_relevant = {Path(str(rf.file_path)) for rf in db_occ.relevant_file_orms}
+        if db_relevant != yaml_occ.relevant_files:
             return True
     return False
 

--- a/props/db/sync/test_sync_occurrence_update.py
+++ b/props/db/sync/test_sync_occurrence_update.py
@@ -1,0 +1,322 @@
+"""Tests for occurrence-level sync diffing (update path).
+
+Verifies that _tp_occ_from_orm/_fp_occ_from_orm round-trip correctly and that
+_sync_tp_issue/_sync_fp_issue detect field-level changes, add/remove occurrences,
+and preserve unchanged rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest_bazel
+from sqlalchemy.orm import Session
+
+from props.core.ids import SnapshotSlug
+from props.core.models.true_positive import FalsePositiveOccurrence, LineRange, TruePositiveOccurrence
+from props.db.database import Database
+from props.db.models import FalsePositive, FalsePositiveOccurrenceORM, TruePositive, TruePositiveOccurrenceORM
+from props.db.sync.sync import _fp_occ_from_orm, _sync_fp_issue, _sync_tp_issue, _tp_occ_from_orm
+from props.db.sync.yaml_loader import FalsePositive as FalsePositive_yaml, TruePositive as TruePositive_yaml
+
+SLUG = SnapshotSlug("test-fixtures/train1")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: ORM → Pydantic reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_tp_occ_round_trip(synced_db: Database):
+    """_tp_occ_from_orm produces a Pydantic model matching the original YAML data."""
+    with synced_db.session() as session:
+        # tp-006 has two occurrences with distinct scopes and match_file_restriction
+        db_occ = (
+            session.query(TruePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, tp_id="tp-006", occurrence_id="occ-add")
+            .one()
+        )
+        pydantic_occ = _tp_occ_from_orm(db_occ)
+
+        assert pydantic_occ.occurrence_id == "occ-add"
+        assert pydantic_occ.note == "Occurrence in add.py"
+        assert pydantic_occ.files == {Path("add.py"): [LineRange(start_line=4, end_line=6, note=None)]}
+        assert pydantic_occ.critic_scopes_expected_to_recall == {frozenset({Path("add.py")})}
+        assert pydantic_occ.match_file_restriction == {Path("add.py")}
+
+
+def test_fp_occ_round_trip(synced_db: Database):
+    """_fp_occ_from_orm produces a Pydantic model matching the original YAML data."""
+    with synced_db.session() as session:
+        db_occ = (
+            session.query(FalsePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, fp_id="fp-001", occurrence_id="fp-occ-1")
+            .one()
+        )
+        pydantic_occ = _fp_occ_from_orm(db_occ)
+
+        assert pydantic_occ.occurrence_id == "fp-occ-1"
+        assert pydantic_occ.files == {Path("subtract.py"): [LineRange(start_line=5, end_line=5, note=None)]}
+        assert pydantic_occ.relevant_files == {Path("subtract.py")}
+
+
+# ---------------------------------------------------------------------------
+# No-change re-sync preserves rows (created_at unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_unchanged_occurrence_preserved(synced_db: Database):
+    """Re-syncing identical data preserves existing ORM rows (no delete+re-add)."""
+    with synced_db.session() as session:
+        db_occ = (
+            session.query(TruePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, tp_id="tp-006", occurrence_id="occ-add")
+            .one()
+        )
+        original_created_at = db_occ.created_at
+
+        # Re-sync with identical data
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-006").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert not changed
+
+        session.refresh(db_occ)
+        assert db_occ.created_at == original_created_at
+
+
+# ---------------------------------------------------------------------------
+# Field-level change detection
+# ---------------------------------------------------------------------------
+
+
+def test_note_change_detected(synced_db: Database):
+    """Changing an occurrence's note triggers re-sync."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-006").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        # Mutate the note on one occurrence
+        occ = _find_occ(yaml_issue.occurrences, "occ-add")
+        yaml_issue.occurrences = [
+            TruePositiveOccurrence(
+                occurrence_id=occ.occurrence_id,
+                files=occ.files,
+                note="Changed note",
+                critic_scopes_expected_to_recall=occ.critic_scopes_expected_to_recall,
+                match_file_restriction=occ.match_file_restriction,
+            )
+            if o.occurrence_id == "occ-add"
+            else o
+            for o in yaml_issue.occurrences
+        ]
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert changed
+        refreshed = (
+            session.query(TruePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, tp_id="tp-006", occurrence_id="occ-add")
+            .one()
+        )
+        assert refreshed.note == "Changed note"
+
+
+def test_files_change_detected(synced_db: Database):
+    """Changing an occurrence's file ranges triggers re-sync."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-001").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        # Change line range
+        yaml_issue.occurrences = [
+            TruePositiveOccurrence(
+                occurrence_id="occ-1",
+                files={Path("subtract.py"): [LineRange(start_line=10, end_line=20, note=None)]},
+                note=yaml_issue.occurrences[0].note,
+                critic_scopes_expected_to_recall=yaml_issue.occurrences[0].critic_scopes_expected_to_recall,
+                match_file_restriction=yaml_issue.occurrences[0].match_file_restriction,
+            )
+        ]
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert changed
+        # Verify ranges via ORM directly (critic_scopes are synced in a separate phase,
+        # so _tp_occ_from_orm would fail validation on the freshly re-added occurrence)
+        db_occ = (
+            session.query(TruePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, tp_id="tp-001", occurrence_id="occ-1")
+            .one()
+        )
+        assert len(db_occ.ranges) == 1
+        r = db_occ.ranges[0]
+        assert str(r.file_path) == "subtract.py"
+        assert r.start_line == 10
+        assert r.end_line == 20
+
+
+def test_rationale_change_detected(synced_db: Database):
+    """Changing the issue-level rationale triggers update."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-001").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        yaml_issue.rationale = "Updated rationale."
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert changed
+        session.refresh(existing)
+        assert existing.rationale == "Updated rationale."
+
+
+def test_critic_scopes_change_detected(synced_db: Database):
+    """Changing critic_scopes_expected_to_recall triggers re-sync (detected as changed)."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-001").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        original_created_at = existing.occurrences[0].created_at
+        occ = yaml_issue.occurrences[0]
+        yaml_issue.occurrences = [
+            TruePositiveOccurrence(
+                occurrence_id=occ.occurrence_id,
+                files=occ.files,
+                note=occ.note,
+                # Add a second scope alternative
+                critic_scopes_expected_to_recall=occ.critic_scopes_expected_to_recall | {frozenset({Path("add.py")})},
+                match_file_restriction=occ.match_file_restriction,
+            )
+        ]
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        # The change should be detected; the occurrence is deleted+re-added
+        # (critic_scopes_expected_to_recall rows are populated later by sync_file_sets_to_db)
+        assert changed
+        db_occ = (
+            session.query(TruePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, tp_id="tp-001", occurrence_id="occ-1")
+            .one()
+        )
+        assert db_occ.created_at != original_created_at
+
+
+# ---------------------------------------------------------------------------
+# Occurrence add / remove
+# ---------------------------------------------------------------------------
+
+
+def test_occurrence_added(synced_db: Database):
+    """Adding an occurrence to an existing issue is detected."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-001").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        yaml_issue.occurrences.append(
+            TruePositiveOccurrence(
+                occurrence_id="occ-new",
+                files={Path("add.py"): [LineRange(start_line=1, end_line=3, note=None)]},
+                note="New occurrence",
+                critic_scopes_expected_to_recall={frozenset({Path("add.py")})},
+                match_file_restriction=None,
+            )
+        )
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert changed
+        occ_ids = {
+            o.occurrence_id
+            for o in session.query(TruePositiveOccurrenceORM).filter_by(snapshot_slug=SLUG, tp_id="tp-001").all()
+        }
+        assert occ_ids == {"occ-1", "occ-new"}
+
+
+def test_occurrence_removed(synced_db: Database):
+    """Removing an occurrence from an existing issue is detected."""
+    with synced_db.session() as session:
+        existing = session.query(TruePositive).filter_by(snapshot_slug=SLUG, tp_id="tp-006").one()
+        yaml_issue = _tp_issue_from_orm(session, existing)
+        # Keep only the first occurrence
+        yaml_issue.occurrences = [yaml_issue.occurrences[0]]
+
+        changed = _sync_tp_issue(session, existing, yaml_issue)
+        session.flush()
+
+        assert changed
+        occ_ids = {
+            o.occurrence_id
+            for o in session.query(TruePositiveOccurrenceORM).filter_by(snapshot_slug=SLUG, tp_id="tp-006").all()
+        }
+        assert len(occ_ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# FP-specific: relevant_files change
+# ---------------------------------------------------------------------------
+
+
+def test_fp_relevant_files_change_detected(synced_db: Database):
+    """Changing relevant_files on an FP occurrence triggers re-sync."""
+    with synced_db.session() as session:
+        existing = session.query(FalsePositive).filter_by(snapshot_slug=SLUG, fp_id="fp-001").one()
+        yaml_fp = _fp_issue_from_orm(session, existing)
+        occ = yaml_fp.occurrences[0]
+        yaml_fp.occurrences = [
+            FalsePositiveOccurrence(
+                occurrence_id=occ.occurrence_id,
+                files=occ.files,
+                note=occ.note,
+                relevant_files=occ.relevant_files | {Path("add.py")},
+                match_file_restriction=occ.match_file_restriction,
+            )
+        ]
+
+        changed = _sync_fp_issue(session, existing, yaml_fp)
+        session.flush()
+
+        assert changed
+        db_occ = (
+            session.query(FalsePositiveOccurrenceORM)
+            .filter_by(snapshot_slug=SLUG, fp_id="fp-001", occurrence_id="fp-occ-1")
+            .one()
+        )
+        reconstructed = _fp_occ_from_orm(db_occ)
+        assert Path("add.py") in reconstructed.relevant_files
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build yaml bridge objects from current DB state
+# ---------------------------------------------------------------------------
+
+
+def _find_occ(occs: list[TruePositiveOccurrence], occ_id: str) -> TruePositiveOccurrence:
+    return next(o for o in occs if o.occurrence_id == occ_id)
+
+
+def _tp_issue_from_orm(session: Session, tp: TruePositive) -> TruePositive_yaml:
+    """Build a TruePositive_yaml from current DB state (for mutation tests)."""
+    return TruePositive_yaml(
+        tp_id=tp.tp_id,
+        snapshot_slug=tp.snapshot_slug,
+        rationale=tp.rationale,
+        occurrences=[_tp_occ_from_orm(o) for o in tp.occurrences],
+    )
+
+
+def _fp_issue_from_orm(session: Session, fp: FalsePositive) -> FalsePositive_yaml:
+    """Build a FalsePositive_yaml from current DB state (for mutation tests)."""
+    return FalsePositive_yaml(
+        fp_id=fp.fp_id,
+        snapshot_slug=fp.snapshot_slug,
+        rationale=fp.rationale,
+        occurrences=[_fp_occ_from_orm(o) for o in fp.occurrences],
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
Three bugs caused match_file_restriction values to be silently lost:

1. sync_issues: occurrence-level changes (note, match_file_restriction) were ignored unless the issue rationale also changed. Added _tp_occurrences_changed / _fp_occurrences_changed helpers that compare occurrence IDs, notes, and restriction hashes.

2. sync_file_sets: desired file set computation only included critic_scopes_expected_to_recall hashes, not match_file_restriction hashes. File sets created by ensure_file_set() during issue sync were immediately deleted as orphaned by the file sets pass, which also cleared the restriction back to NULL. Now includes match_file_restriction file sets (TP and FP) in the desired set.

3. Missing cascade on TruePositiveOccurrenceORM's critic_scopes_expected_to_recall relationship caused occurrence deletion to fail with an AssertionError (trying to null PK columns). Added cascade="all, delete-orphan".

https://claude.ai/code/session_01MG3vUQaT77jW7vypeorNCQ