### PR TITLE
Update claude-hooks release reference to specific commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
+            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-eb9833cb/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Updated the claude-hooks tool installation reference to point to a specific commit hash instead of the generic "latest" release tag.

## Changes
- Updated the `claude-hooks` installation URL in `.claude/settings.json` to reference a specific release build (`claude-hooks-eb9833cb`) instead of the `claude-hooks-latest` tag
- This ensures a consistent, reproducible version of the claude-hooks tool is used across environments

## Details
The change pins the claude-hooks dependency to a specific build artifact identified by commit hash `eb9833cb`, which improves reproducibility and prevents unexpected behavior changes from automatic "latest" release updates.

https://claude.ai/code/session_016pbkUp9cHECYiesvP2TRXD