### PR TITLE
Add kubeconfig_setup library to build configuration

### DIFF
--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -109,6 +109,13 @@ py_library(
 )
 
 py_library(
+    name = "kubeconfig_setup",
+    srcs = ["kubeconfig_setup.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "mkcert_setup",
     srcs = ["mkcert_setup.py"],
     imports = ["../.."],
@@ -222,6 +229,7 @@ py_library(
         ":debug",
         ":env_file",
         ":errors",
+        ":kubeconfig_setup",
         ":mkcert_setup",
         ":nix_setup",
         ":podman_service",
@@ -278,6 +286,7 @@ py_package(
         ":buildbuddy_setup",
         ":env_file",
         ":errors",
+        ":kubeconfig_setup",
         ":managed_files",
         ":mkcert_setup",
         ":nix_setup",


### PR DESCRIPTION
## Summary
This change adds a new `kubeconfig_setup` Python library to the Bazel build configuration and integrates it into the existing build targets.

## Key Changes
- Added new `py_library` target for `kubeconfig_setup` module with public visibility
- Integrated `kubeconfig_setup` as a dependency in the main `claude_hooks` library target
- Integrated `kubeconfig_setup` as a dependency in the `py_package` target

## Details
The new `kubeconfig_setup` library follows the same pattern as other setup modules in the codebase (e.g., `mkcert_setup`, `nix_setup`). It is now available as a public dependency and has been added to both the core library and package distribution targets, making it available for use throughout the claude_hooks module.

https://claude.ai/code/session_01Ldh3SC4rEtVzKhXAcbN9EU