### PR TITLE
Fix 6 broken props e2e tests

### DIFF
--- a/props/agents/critic/test_e2e.py
+++ b/props/agents/critic/test_e2e.py
@@ -35,7 +35,7 @@ TEST_TIMEOUT_SECONDS = 120
 def make_critic_mock_zero_issues() -> DecoratorMock:
     """Create mock for critic that finds zero issues."""
 
-    @DecoratorMock.mock(check_consumed=False)
+    @DecoratorMock.mock()
     def mock(m: DecoratorMock) -> PlayGen:
         yield None  # First request
         yield m.tool_call("submit", SubmitArgs(issues_count=0, summary="Reviewed code, no issues found"))
@@ -73,7 +73,7 @@ async def test_critic_zero_issues(e2e_stack, test_snapshot, all_files_scope, cri
 def make_critic_mock_with_issues() -> DecoratorMock:
     """Create mock for critic that finds and submits issues."""
 
-    @DecoratorMock.mock(check_consumed=False)
+    @DecoratorMock.mock()
     def mock(m: DecoratorMock) -> PlayGen:
         yield None  # First request
         yield m.tool_call(
@@ -137,7 +137,7 @@ async def test_python3_can_import_and_inspect_props(
     to read bundled source code at runtime (the "show over retell" principle).
     """
 
-    @CriticMock.mock(check_consumed=False)
+    @CriticMock.mock()
     def mock(m: CriticMock) -> PlayGen:
         yield None  # First request
 

--- a/props/agents/grader/test_e2e.py
+++ b/props/agents/grader/test_e2e.py
@@ -44,8 +44,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 async def test_grader_picks_up_drift(e2e_stack, test_snapshot, all_files_scope, grader_image, db: Database):
     """Test that snapshot grader detects, grades, and clusters new critique issues.
 
-    Train1 fixture for subtract.py produces 5 edges:
-    - 4 TP edges: tp-001/occ-1, tp-003/occ-1, tp-004/occ-1, tp-005/occ-1
+    Train1 fixture for subtract.py produces 6 edges:
+    - 5 TP edges: tp-001/occ-1, tp-003/occ-1, tp-004/occ-1, tp-005/occ-1, tp-006/occ-subtract
     - 1 FP edge: fp-001/fp-occ-1
 
     All graded with credit=0, so issue appears in clustering_pending.
@@ -61,8 +61,8 @@ async def test_grader_picks_up_drift(e2e_stack, test_snapshot, all_files_scope, 
         drift = yield from m.get_drift_roundtrip()
         run_id = drift.grading[0].critique_run_id
 
-        # Fill all 5 edges with credit=0
-        yield from m.fill_remaining_roundtrip(run_id, "test-issue-1", 5, "No matching ground truth")
+        # Fill all 6 edges with credit=0
+        yield from m.fill_remaining_roundtrip(run_id, "test-issue-1", 6, "No matching ground truth")
 
         # Issue has credit=0, so it appears in clustering_pending
         drift = yield from m.get_drift_roundtrip()

--- a/props/agents/grader/test_e2e_sleep_wake.py
+++ b/props/agents/grader/test_e2e_sleep_wake.py
@@ -43,8 +43,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 async def test_grader_sleep_wake_cycle(e2e_stack, test_snapshot, all_files_scope, grader_image, db: Database):
     """Test that snapshot grader sleeps after grading, wakes on new drift, grades again.
 
-    Train1 fixture for subtract.py produces 5 edges per issue:
-    - 4 TP edges: tp-001/occ-1, tp-003/occ-1, tp-004/occ-1, tp-005/occ-1
+    Train1 fixture for subtract.py produces 6 edges per issue:
+    - 5 TP edges: tp-001/occ-1, tp-003/occ-1, tp-004/occ-1, tp-005/occ-1, tp-006/occ-subtract
     - 1 FP edge: fp-001/fp-occ-1
 
     Since we give TP edges credit > 0, issues won't appear in clustering_pending.
@@ -70,6 +70,7 @@ async def test_grader_sleep_wake_cycle(e2e_stack, test_snapshot, all_files_scope
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-003", occurrence_id="occ-1"), credit=0.1),
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-004", occurrence_id="occ-1"), credit=0.1),
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-005", occurrence_id="occ-1"), credit=0.1),
+                EdgeSpec(gt_ref=TPRef(tp_id="tp-006", occurrence_id="occ-subtract"), credit=0.1),
                 EdgeSpec(gt_ref=FPRef(fp_id="fp-001", occurrence_id="fp-occ-1"), credit=0.0),
             ],
             "All edges for issue-1",
@@ -94,6 +95,7 @@ async def test_grader_sleep_wake_cycle(e2e_stack, test_snapshot, all_files_scope
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-003", occurrence_id="occ-1"), credit=0.2),
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-004", occurrence_id="occ-1"), credit=0.2),
                 EdgeSpec(gt_ref=TPRef(tp_id="tp-005", occurrence_id="occ-1"), credit=0.2),
+                EdgeSpec(gt_ref=TPRef(tp_id="tp-006", occurrence_id="occ-subtract"), credit=0.2),
                 EdgeSpec(gt_ref=FPRef(fp_id="fp-001", occurrence_id="fp-occ-1"), credit=0.0),
             ],
             "All edges for issue-2",

--- a/props/testing/fixtures/e2e_container.py
+++ b/props/testing/fixtures/e2e_container.py
@@ -189,7 +189,7 @@ async def _make_stack(
 
     try:
         _set_backend_env(monkeypatch, db.config, e2e_registry_url)
-        monkeypatch.setenv("OPENAI_BASE_URL", fake_openai.url)
+        monkeypatch.setenv("OPENAI_BASE_URL", f"{fake_openai.url}/v1")
 
         backend_port = pick_free_port()
         registry_proxy_config = RegistryProxyConfig(host="localhost", port=backend_port)


### PR DESCRIPTION
Three root causes:

1. OPENAI_BASE_URL missing /v1 suffix in e2e fixture — backend constructs
   upstream URL as {base}/responses, but FakeOpenAI route is at /v1/responses.
   All 6 e2e tests got 404s.

2. tp-006.yaml (added in c26dc2c) introduced a 6th matchable edge for
   subtract.py (tp-006/occ-subtract), breaking grader tests that hardcoded
   expected_count=5.

3. Critic test mocks used check_consumed=False, allowing false passes when
   agents crashed — zero reported issues matched the crash outcome.

https://claude.ai/code/session_01TvjJ2uKsmz2e7PjmW3K9JJ