### PR TITLE
Document unused oom_killed_tx field and suppress dead code warning

### DIFF
--- a/claude_web_env/re/process_api/b0e4b2f4/src/proc_handle.rs
+++ b/claude_web_env/re/process_api/b0e4b2f4/src/proc_handle.rs
@@ -133,12 +133,15 @@ pub struct CgroupConfig {
 }
 
 /// Wraps CgroupConfig, OOM channel, and ProcessInfo for a managed process.
-/// Serde visitor at 0x21c870..0x21c96b (251 bytes).
+/// Debug impl at 0x21c870..0x21c96b (251 bytes).
 /// Fields from disassembly: cgroup, oom_killed_tx, process_info
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProcController {
     pub cgroup: Option<CgroupConfig>,
+    /// Present in the original binary's struct layout (confirmed by Debug impl
+    /// at 0x21c870) but never read outside of Debug formatting — always None.
     #[serde(skip)]
+    #[allow(dead_code)]
     pub oom_killed_tx: Option<oneshot::Sender<()>>,
     pub process_info: ProcessInfo,
 }


### PR DESCRIPTION
## Summary
Updated documentation and compiler directives for the `oom_killed_tx` field in `ProcController` to clarify its purpose and suppress the dead code warning.

## Key Changes
- Updated the struct-level comment to reference "Debug impl" instead of "Serde visitor" for accuracy
- Added detailed documentation explaining that `oom_killed_tx` is present in the binary's struct layout but never read outside of Debug formatting
- Added `#[allow(dead_code)]` attribute to suppress compiler warnings about the unused field
- Clarified that the field is always `None` in practice

## Implementation Details
The `oom_killed_tx` field is intentionally kept in the struct for binary compatibility and debugging purposes, even though it's not actively used in the codebase. The changes make this intent explicit through documentation and suppress the resulting compiler warning.

https://claude.ai/code/session_018jgbdHa3usGAmvPnBoy9gM