### PR TITLE
Fix helm_import_repository canonical dict to avoid spurious DEBUG messages

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,6 +74,16 @@ bazel_dep(name = "rules_pkg", version = "1.2.0")
 # Helm chart packaging (rules_helm)
 bazel_dep(name = "rules_helm", version = "0.21.0")
 
+# Fix: helm_import_repository returns chart_name/version derived from url in
+# its canonical dict, causing spurious DEBUG messages. The rule forbids setting
+# those attrs alongside url, so the suggestion is unfollowable.
+single_version_override(
+    module_name = "rules_helm",
+    patch_strip = 1,
+    patches = ["//third_party/rules_helm:canonical-return.patch"],
+    version = "0.21.0",
+)
+
 helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
 helm.toolchain(
     name = "helm_toolchains",

--- a/third_party/rules_helm/BUILD.bazel
+++ b/third_party/rules_helm/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["canonical-return.patch"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rules_helm/canonical-return.patch
+++ b/third_party/rules_helm/canonical-return.patch
@@ -1,0 +1,25 @@
+--- a/helm/private/import.bzl
++++ b/helm/private/import.bzl
+@@ -191,14 +191,17 @@
+         repository_name = repository_ctx.name,
+     ))
+
+-    return {
+-        "chart_name": chart_name,
++    canonical = {
+         "name": repository_ctx.name,
+-        "repository": repository_ctx.attr.repository,
+         "sha256": result.sha256,
+-        "url": chart_url,
+-        "version": chart_version,
+     }
++    if repository_ctx.attr.url:
++        canonical["url"] = repository_ctx.attr.url
++    else:
++        canonical["chart_name"] = chart_name
++        canonical["repository"] = repository_ctx.attr.repository
++        canonical["version"] = chart_version
++    return canonical
+
+ helm_import_repository = repository_rule(
+     implementation = _helm_import_repository_impl,


### PR DESCRIPTION
## Summary
Apply a patch to `rules_helm` that fixes the `helm_import_repository` rule to return a canonical dict with only the relevant fields based on how the repository was configured, eliminating spurious DEBUG messages about unfollowable suggestions.

## Key Changes
- Added `third_party/rules_helm/canonical-return.patch` that modifies the return value of `_helm_import_repository_impl` in `helm/private/import.bzl`
- The patch restructures the canonical dict to conditionally include fields:
  - Always includes: `name` and `sha256`
  - If `url` is provided: includes `url` only
  - If `url` is not provided: includes `chart_name`, `repository`, and `version`
- Added `third_party/rules_helm/BUILD.bazel` to export the patch file
- Updated `MODULE.bazel` to apply the patch to `rules_helm` version 0.21.0 via `single_version_override`

## Implementation Details
The fix addresses a bug where the rule was returning all fields in the canonical dict regardless of configuration, causing Bazel to suggest setting `chart_name` and `version` attributes even when the repository was configured with a direct `url`. Since the rule forbids setting these attributes alongside `url`, the suggestions were impossible to follow. The patch makes the canonical dict reflect only the fields that are actually relevant to the repository's configuration.

https://claude.ai/code/session_01SEXMX7ncHpY2swVzggsYkd