### PR TITLE
Update claude-hooks release reference in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-eb9833cb/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
+            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-6d2709a6/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Updates the claude-hooks tool reference to point to a newer release version.

## Changes
- Updated the claude-hooks release URL from `claude-hooks-eb9833cb` to `claude-hooks-6d2709a6` in the Claude session start hook configuration

## Details
This change updates the `.claude/settings.json` configuration to use a different release build of the claude-hooks tool. The wheel file version remains the same (0.1.0), but the release identifier has been updated, likely to incorporate bug fixes or improvements in the hook implementation.

https://claude.ai/code/session_016R65Cy8MB5ZEut4kZDrW2D