### PR TITLE
Document KUBECONFIG in session context template

### DIFF
--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -12,6 +12,9 @@ Ollama: `OLLAMA_BASE_URL` and `OLLAMA_API_KEY` set. OpenAI-compatible LLM infere
 % if "BUILDBUDDY_API_KEY" in secrets.env_vars:
 `BUILDBUDDY_API_KEY`: BuildBuddy remote cache/execution key (also configured in ~/.config/bazel/buildbuddy.bazelrc).
 % endif
+% if "KUBECONFIG_B64" in secrets.env_vars:
+`KUBECONFIG`: Points to decoded kubeconfig for the `cluster/` Talos k8s cluster. ServiceAccount `claude-code-web` with access to the `claude-sandbox` namespace (pods, services, secrets, exec). Resource limits: 4 CPU, 8Gi memory, 10 pods. Use `kubectl` for `cluster/` operations (deploy, inspect, debug).
+% endif
 % endif
 % if os.environ.get("DUCKTAPE_CI_READ_GITHUB_TOKEN"):
 `DUCKTAPE_CI_READ_GITHUB_TOKEN`: Fine-grained PAT for agentydragon/ducktape (read-only CI token, separate from `GITHUB_TOKEN`).


### PR DESCRIPTION
The decoded kubeconfig for the cluster/ Talos k8s cluster was not
documented in the Mako context template, so agents didn't know it
was available. Gate on KUBECONFIG_B64 in secrets (matching the
decryption flow in kubeconfig_setup.py).

https://claude.ai/code/session_01Pzgvyc238guqmm5DEqDSmJ