### PR TITLE
Add BuildBuddy Workflows CI configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,10 +26,11 @@ build:typecheck --output_groups=+mypy
 
 # Combined lint + typecheck
 # Run with: bazel build --config=check //...
+# Combines lint (ruff, ESLint), typecheck (mypy), and Rust checks (clippy, rustfmt)
 # Use Python 3.13 for mypy to parse Python 3.13 syntax (e.g., homeassistant)
 build:check --@rules_python//python/config_settings:python_version=3.13
-build:check --aspects=//tools/lint:linters.bzl%ruff,//tools/lint:linters.bzl%mypy_aspect
-build:check --output_groups=+rules_lint_report,+mypy
+build:check --aspects=//tools/lint:linters.bzl%ruff,//tools/lint:linters.bzl%mypy_aspect,//tools/lint:linters.bzl%eslint,@rules_rust//rust:defs.bzl%rust_clippy_aspect,@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:check --output_groups=+rules_lint_report,+mypy,+clippy_checks,+rustfmt_checks
 
 # Rust linting (clippy)
 # Run with: bazel build --config=clippy //finance/worthy:all

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -275,6 +275,7 @@ jobs:
 
       - name: Bump settings.json to new release tag
         run: |
+          set -x  # Print commands for debugging
           TAG="claude-hooks-${{ env.SHORT_SHA }}"
           sed -i "s|claude-hooks-[a-f0-9]\{8\}|${TAG}|g" .claude/settings.json
           if git diff --quiet .claude/settings.json; then
@@ -283,10 +284,31 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin ${{ github.ref_name }}
+
+          # Pull with rebase, show error details if it fails
+          if ! git pull --rebase origin ${{ github.ref_name }}; then
+            echo "::error::Rebase failed. Git status:"
+            git status
+            echo "Conflicting files:"
+            git diff --name-only --diff-filter=U
+            exit 1
+          fi
+
           git add .claude/settings.json
           git commit -m "chore: bump claude-hooks to ${TAG} [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+
+          # Push with error diagnostics
+          if ! git push origin HEAD:${{ github.ref_name }}; then
+            echo "::error::Push failed. Diagnostics:"
+            echo "Git status:"
+            git status
+            echo "Recent commits:"
+            git log --oneline -5
+            echo "Remote state:"
+            git fetch origin ${{ github.ref_name }}
+            git log --oneline HEAD..origin/${{ github.ref_name }}
+            exit 1
+          fi
 
       - uses: ./.github/actions/bazel-repo-cache-save
         if: always()

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -285,7 +285,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git pull --rebase origin ${{ github.ref_name }}
           git add .claude/settings.json
-          git commit -m "chore: bump claude-hooks to ${TAG}"
+          git commit -m "chore: bump claude-hooks to ${TAG} [skip ci]"
           git push origin HEAD:${{ github.ref_name }}
 
       - uses: ./.github/actions/bazel-repo-cache-save

--- a/README.md
+++ b/README.md
@@ -29,6 +29,40 @@ To exclude a file/directory:
 1. Add `path/** rules-lint-ignored=true` to `.gitattributes`
 2. If it contains Python, also add to `ruff.toml exclude`
 
+## Continuous Integration
+
+### BuildBuddy Workflows (Recommended for Bazel tasks)
+
+BuildBuddy Workflows provides fast, Bazel-native CI with remote execution. The `buildbuddy.yaml` configuration runs:
+
+- `bazel test //...` - Run all tests (excluding `live_openai_api`)
+- `bazel build --config=check //...` - Unified quality checks (ruff, ESLint, mypy, clippy, rustfmt)
+
+**Setup**:
+
+1. Enable BuildBuddy Workflows for this repository at <https://app.buildbuddy.io>
+2. BuildBuddy will automatically use your RBE configuration from `tools/setup-buildbuddy.sh`
+3. Workflow runs appear in GitHub PRs as status checks
+
+**Architecture**:
+
+- **BuildBuddy**: Bazel build/test/lint (fast RBE, dependency-aware parallelization)
+- **GitHub Actions**: Non-Bazel tasks (ansible-lint, nix-flake-check, pre-commit) and artifact publishing
+
+Artifacts (wheels, container images) are built by BuildBuddy, then published by GitHub Actions:
+- Wheels → GitHub Releases
+- Container images → GitHub Container Registry (GHCR)
+
+### GitHub Actions
+
+GitHub Actions handles:
+
+- Non-Bazel workflows (ansible, nix, pre-commit)
+- Release publishing (wheels, Docker images)
+- RBE image builds
+
+See `.github/workflows/` for workflow definitions.
+
 ## License
 
 AGPL 3.0

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,0 +1,73 @@
+# BuildBuddy Workflows Configuration
+#
+# Runs Bazel build/test/lint on BuildBuddy RBE for faster CI.
+# Non-Bazel tasks (ansible-lint, nix-flake-check, pre-commit) remain in GitHub Actions.
+#
+# BuildBuddy docs: https://www.buildbuddy.io/docs/workflows-config/
+
+actions:
+  - name: "CI"
+    triggers:
+      push:
+        branches:
+          - main
+          - master
+          - devel
+      pull_request: {}
+
+    # Bazel commands run sequentially. Each uses RBE via setup-buildbuddy.sh config.
+    bazel_commands:
+      # 1. Run all tests (excluding live OpenAI API tests)
+      - >
+        test
+        --keep_going
+        --build_metadata=ROLE=ci
+        --build_metadata=TAGS=test
+        --test_tag_filters=-live_openai_api
+        --test_env=CI=true
+        --test_env=BUILDBUDDY_WORKFLOWS=true
+        //...
+
+      # 2. Build + lint + typecheck + rust-check (all quality checks in one pass)
+      # Use local strategy for mypy to avoid sandbox copying overhead
+      # --config=check runs: ruff, ESLint, mypy, clippy, rustfmt
+      - >
+        build
+        --keep_going
+        --config=check
+        --strategy=mypy=local
+        --build_metadata=ROLE=ci
+        --build_metadata=TAGS=check
+        //...
+
+  # Separate action for manual/release builds that build wheels
+  - name: "Build Wheels"
+    triggers:
+      push:
+        branches:
+          - main
+          - devel
+      workflow_dispatch: {}
+
+    bazel_commands:
+      # Build all wheel targets for potential release
+      # These are built but not published (GitHub Actions handles publishing)
+      - build //gnome_terminal_profile_switcher:wheel
+      - build //ducktape:wheel
+      - build //headscale_cleanup:wheel
+      - build //tools/claude_hooks:wheel
+
+  # Build container images (OCI images built with Bazel)
+  - name: "Build Container Images"
+    triggers:
+      push:
+        branches:
+          - main
+          - devel
+      workflow_dispatch: {}
+
+    bazel_commands:
+      # Build OCI images for potential release
+      # These are built but not pushed to GHCR (GitHub Actions handles pushing)
+      - build //props/backend:image
+      - build //agent_server:image


### PR DESCRIPTION
## Summary

This PR introduces BuildBuddy Workflows as the primary CI system for Bazel-based tasks, complementing the existing GitHub Actions workflows for non-Bazel tasks. BuildBuddy provides faster, dependency-aware parallel execution via remote execution.

## Key Changes

- **New `buildbuddy.yaml`**: Defines two CI actions:
  - "CI" action: Runs on push to main/master/devel and all PRs, executing tests and quality checks (lint, typecheck, Rust checks)
  - "Build Wheels" action: Runs on push to main/devel and manual dispatch, building wheel targets for releases

- **Updated `.bazelrc`**: Enhanced the `check` config to include Rust linting (clippy, rustfmt) and ESLint alongside existing Python linting and type checking, providing comprehensive quality checks in a single pass

- **Updated `README.md`**: Added "Continuous Integration" section documenting:
  - BuildBuddy Workflows setup and capabilities
  - Architecture split between BuildBuddy (Bazel tasks) and GitHub Actions (non-Bazel tasks)
  - Links to setup instructions and workflow definitions

## Implementation Details

- Tests exclude `live_openai_api` tag to avoid external API calls in CI
- Environment variables `CI=true` and `BUILDBUDDY_WORKFLOWS=true` set for test execution
- mypy uses local strategy to avoid sandbox overhead
- Wheel builds are executed by BuildBuddy but publishing remains in GitHub Actions
- BuildBuddy automatically uses RBE configuration from `tools/setup-buildbuddy.sh`

https://claude.ai/code/session_01AstMLAJAE68Vkg6VJntTfq