### PR TITLE
Use get_cache_dir() method instead of direct cache_dir attribute

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-6d2709a6/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
+            "command": "uv tool run --from 'claude_hooks @ https://github.com/agentydragon/ducktape/releases/download/claude-hooks-eb9833cb/claude_hooks-0.1.0-py3-none-any.whl' claude-session-start"
           }
         ]
       }

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -384,7 +384,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
 
     # Setup kubeconfig if KUBECONFIG_B64 is in decrypted secrets
     if secrets and "KUBECONFIG_B64" in secrets.env_vars:
-        kubeconfig_setup.setup_kubeconfig(cache_dir=settings.cache_dir, env_vars=secrets.env_vars)
+        kubeconfig_setup.setup_kubeconfig(cache_dir=settings.get_cache_dir(), env_vars=secrets.env_vars)
 
     # PARALLEL: All setup tasks (with explicit dependencies via task awaits)
     # Dependency graph:


### PR DESCRIPTION
## Summary
Updated the kubeconfig setup call to use the `get_cache_dir()` method instead of directly accessing the `cache_dir` attribute on the settings object.

## Key Changes
- Changed `settings.cache_dir` to `settings.get_cache_dir()` in the kubeconfig setup initialization
- This ensures the cache directory is retrieved through the proper accessor method rather than direct attribute access

## Implementation Details
This change promotes better encapsulation by using the settings object's getter method. This allows for any future logic or validation in the `get_cache_dir()` method to be properly applied when the cache directory is needed for kubeconfig setup.

https://claude.ai/code/session_019Arwc1SWWpiQRD6XKXkwhk