### PR TITLE
Update BuildBuddy CI container image to Ubuntu 24.04

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -15,6 +15,9 @@ actions:
           - devel
       pull_request: {}
 
+    # Use Ubuntu 24.04 for glibc 2.39 (Node.js 22.11.0 requires glibc 2.28+)
+    container_image: "ubuntu-24.04"
+
     # Bazel commands run sequentially. Each uses RBE via setup-buildbuddy.sh config.
     bazel_commands:
       # 1. Run all tests (excluding live OpenAI API tests)
@@ -49,6 +52,8 @@ actions:
           - devel
       workflow_dispatch: {}
 
+    container_image: "ubuntu-24.04"
+
     bazel_commands:
       # Build all wheel targets for potential release
       # These are built but not published (GitHub Actions handles publishing)
@@ -65,6 +70,8 @@ actions:
           - main
           - devel
       workflow_dispatch: {}
+
+    container_image: "ubuntu-24.04"
 
     bazel_commands:
       # Build OCI images for potential release


### PR DESCRIPTION
## Summary
Updated the BuildBuddy CI configuration to use Ubuntu 24.04 container images across all workflow actions to ensure compatibility with Node.js 22.11.0, which requires glibc 2.28+.

## Changes
- Added `container_image: "ubuntu-24.04"` to the test workflow action
- Added `container_image: "ubuntu-24.04"` to the wheel build workflow action
- Added `container_image: "ubuntu-24.04"` to the OCI image build workflow action

## Details
Ubuntu 24.04 provides glibc 2.39, which satisfies the minimum glibc 2.28+ requirement for Node.js 22.11.0. This ensures all CI workflows run on a consistent, modern base image with the necessary system libraries for the project's dependencies.

https://claude.ai/code/session_01WtTXvRPh3ZJ85zmsbjuYRs