### PR TITLE
Document why BuildBuddy Workflows uses stock Ubuntu image

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -16,6 +16,8 @@ actions:
       pull_request: {}
 
     # Use Ubuntu 24.04 for glibc 2.39 (Node.js 22.11.0 requires glibc 2.28+)
+    # BuildBuddy Workflows only supports predefined Ubuntu images, not custom images
+    # like ghcr.io/agentydragon/rbe-worker. RBE workers still use the custom image.
     container_image: "ubuntu-24.04"
 
     # Bazel commands run sequentially. Each uses RBE via setup-buildbuddy.sh config.
@@ -52,6 +54,7 @@ actions:
           - devel
       workflow_dispatch: {}
 
+    # Same as CI action - BuildBuddy Workflows doesn't support custom images
     container_image: "ubuntu-24.04"
 
     bazel_commands:
@@ -71,6 +74,7 @@ actions:
           - devel
       workflow_dispatch: {}
 
+    # Same as CI action - BuildBuddy Workflows doesn't support custom images
     container_image: "ubuntu-24.04"
 
     bazel_commands:


### PR DESCRIPTION
Add comments explaining that BuildBuddy Workflows only supports predefined Ubuntu images (18.04, 20.04, 22.04, 24.04), not custom Docker images like ghcr.io/agentydragon/rbe-worker. The custom RBE image is still used for remote execution via the //:rbe_linux_x64 platform.

https://claude.ai/code/session_01WtTXvRPh3ZJ85zmsbjuYRs