### PR TITLE
fix(buildbuddy): exclude gnome_terminal_profile_switcher:wheel from CI

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -60,7 +60,9 @@ actions:
     bazel_commands:
       # Build all wheel targets for potential release
       # These are built but not published (GitHub Actions handles publishing)
-      - build //gnome_terminal_profile_switcher:wheel
+      # Note: gnome_terminal_profile_switcher:wheel excluded - requires C++ toolchain
+      # and system libraries (libgirepository1.0-dev, libdbus-1-dev) not available
+      # in stock Ubuntu image. Tagged 'manual' in BUILD file.
       - build //ducktape:wheel
       - build //headscale_cleanup:wheel
       - build //tools/claude_hooks:wheel


### PR DESCRIPTION
The wheel build requires a C++ toolchain and system libraries (libgirepository1.0-dev, libdbus-1-dev) for native Python packages (dbus-python, pycairo, pygobject). These aren't available in the stock Ubuntu 24.04 image used by BuildBuddy Workflows.

The target is already tagged 'manual' in the BUILD file, indicating it shouldn't be built in CI.

Fixes build failure: https://app.buildbuddy.io/invocation/e22a3f2d-a7c8-4b94-b1cf-acb1d67877ec

https://claude.ai/code/session_01A3ZTRLhcwjQC9qhMciRx1q