### PR TITLE
Fix handler name capitalization and formatting in Tailscale role

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ BuildBuddy Workflows provides fast, Bazel-native CI with remote execution. The `
 - **GitHub Actions**: Non-Bazel tasks (ansible-lint, nix-flake-check, pre-commit) and artifact publishing
 
 Artifacts (wheels, container images) are built by BuildBuddy, then published by GitHub Actions:
+
 - Wheels → GitHub Releases
 - Container images → GitHub Container Registry (GHCR)
 

--- a/ansible/roles/tailscale_client/handlers/main.yml
+++ b/ansible/roles/tailscale_client/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart NetworkManager
+- name: Restart NetworkManager
   ansible.builtin.systemd:
     name: NetworkManager
     state: restarted

--- a/ansible/roles/tailscale_client/tasks/main.yml
+++ b/ansible/roles/tailscale_client/tasks/main.yml
@@ -46,7 +46,7 @@
     mode: "0644"
   become: true
   when: ansible_os_family == "Debian"
-  notify: restart NetworkManager
+  notify: Restart NetworkManager
   tags: [tailscale, install]
 
 - name: Start and enable tailscaled service


### PR DESCRIPTION
## Summary
This PR fixes inconsistent naming conventions and formatting in the Tailscale client Ansible role and documentation.

## Key Changes
- **Handler naming**: Capitalized the handler name from "restart NetworkManager" to "Restart NetworkManager" for consistency with Ansible naming conventions
- **Notification reference**: Updated the task notification to match the corrected handler name
- **Documentation formatting**: Added blank line in README.md for improved readability in the artifacts section

## Details
The changes ensure that Ansible handler names follow proper capitalization conventions (title case), making the codebase more consistent and easier to maintain. The handler definition and its reference in the task notification are now aligned.

https://claude.ai/code/session_01Defg4DougTWkcpzq8zPxdW