### PR TITLE
Refactor MCP tool handling and tunnel request types

### DIFF
--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/BUILD.bazel
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/anthropics/anthropic/api-go/environment-manager/internal/mcp",
     visibility = ["//claude_web_env/re/environment_manager/6b49f1ca/src:__subpackages__"],
     deps = [
+        "@com_github_mark3labs_mcp_go//mcp",
         "@com_github_mark3labs_mcp_go//server",
     ],
 )

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/registry.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/registry.go
@@ -27,7 +27,20 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 )
+
+// ToolConfig holds a tool definition and its handler function.
+// This is the mcp package's own tool type used by the MCPServer interface.
+//
+// DWARF type: github.com/anthropics/anthropic/api-go/environment-manager/internal/mcp.ToolConfig
+//   field: Tool -> mcp.Tool (github.com/mark3labs/mcp-go/mcp)
+//   field: Handler -> func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+type ToolConfig struct {
+	Tool    mcplib.Tool
+	Handler func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error)
+}
 
 // MCPServer is the interface that all MCP servers must implement.
 // Implementations include BaseServer (embedded default) and concrete servers
@@ -37,10 +50,10 @@ import (
 //   go:itab.*codesign.CodeSignMCPServer,mcp.MCPServer (0xf68220)
 type MCPServer interface {
 	// GetName returns the server's display name.
-	GetName() (string, int)
+	GetName() string
 
 	// GetTools returns the server tool definitions for the MCP protocol.
-	GetTools() (interface{}, int, int)
+	GetTools() []ToolConfig
 
 	// Start starts the MCP server, binding to a port and serving requests.
 	// It returns the listening port and any error.

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/server.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/server.go
@@ -74,8 +74,8 @@ type BaseServer struct {
 //   MOVQ 0x10(AX), BX   ; name.len
 //   MOVQ CX, AX
 //   RET
-func (s *BaseServer) GetName() (string, int) {
-	return s.name, len(s.name)
+func (s *BaseServer) GetName() string {
+	return s.name
 }
 
 // GetTools returns an empty tool list. Concrete implementations override this.
@@ -88,8 +88,8 @@ func (s *BaseServer) GetName() (string, int) {
 //   XOR BX, BX
 //   MOV BX, CX
 //   RET
-func (s *BaseServer) GetTools() ([]mcpserver.ServerTool, int, int) {
-	return nil, 0, 0
+func (s *BaseServer) GetTools() []ToolConfig {
+	return nil
 }
 
 // ShouldRegisterWithClaude returns true by default. Concrete implementations
@@ -139,9 +139,16 @@ func (s *BaseServer) Start(logger *slog.Logger, name string) (int, error) {
 	mcpSrv := mcpserver.NewMCPServer(s.name, s.version)
 
 	// Register tools with the MCP server
-	tools, _, _ := s.GetTools()
-	if len(tools) > 0 {
-		mcpSrv.AddTools(tools...)
+	toolConfigs := s.GetTools()
+	if len(toolConfigs) > 0 {
+		serverTools := make([]mcpserver.ServerTool, len(toolConfigs))
+		for i, tc := range toolConfigs {
+			serverTools[i] = mcpserver.ServerTool{
+				Tool:    tc.Tool,
+				Handler: tc.Handler,
+			}
+		}
+		mcpSrv.AddTools(serverTools...)
 	}
 
 	// Create streamable HTTP server with options

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/servers/codesign/server.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/mcp/servers/codesign/server.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
-	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/anthropics/anthropic/api-go/environment-manager/internal/config"
 	"github.com/anthropics/anthropic/api-go/environment-manager/internal/mcp"
@@ -66,8 +65,8 @@ type signingConfig struct {
 //   MOVQ 0x8(CX), AX  ; load name.ptr
 //   MOVQ 0x10(CX), BX ; load name.len
 //   RET
-func (s *CodeSignMCPServer) GetName() (string, int) {
-	return s.name, len(s.name)
+func (s *CodeSignMCPServer) GetName() string {
+	return s.name
 }
 
 // ShouldRegisterWithClaude returns false for the codesign server.
@@ -160,7 +159,7 @@ func (s *CodeSignMCPServer) Stop() bool {
 //       "content"            - type: string, description: "content to sign..."
 //
 //   The "required" array at offset 0xb0d3ed (len 7) is likely ["file_path"].
-func (s *CodeSignMCPServer) GetTools() ([]mcpserver.ServerTool, int, int) {
+func (s *CodeSignMCPServer) GetTools() []mcp.ToolConfig {
 	// Build input schema properties for sign_file tool
 	properties := map[string]interface{}{
 		"file_path": map[string]interface{}{
@@ -181,7 +180,7 @@ func (s *CodeSignMCPServer) GetTools() ([]mcpserver.ServerTool, int, int) {
 		},
 	}
 
-	tool := mcpserver.ServerTool{
+	tool := mcp.ToolConfig{
 		Tool: mcplib.Tool{
 			Name:        "sign_file",
 			Description: "Sign a file with the codesigning service",
@@ -194,8 +193,7 @@ func (s *CodeSignMCPServer) GetTools() ([]mcpserver.ServerTool, int, int) {
 		Handler: s.handleSignFile,
 	}
 
-	tools := []mcpserver.ServerTool{tool}
-	return tools, len(tools), len(tools)
+	return []mcp.ToolConfig{tool}
 }
 
 // handleSignFile handles the "sign_file" MCP tool call. It extracts the

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/client.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/client.go
@@ -341,12 +341,10 @@ func (c *Client) handleHTTPRequest(ctx context.Context, httpReq *tunnelpb.Tunnel
 		path := req.GetPath()
 		if len(path) >= 11 && path[:11] == "/__actions/" {
 			// Dispatch to action registry
-			// Convert headers from map[string][]string to map[string]string
+			// Convert repeated Header messages to map[string]string
 			headers := make(map[string]string)
-			for k, v := range req.GetHeaders() {
-				if len(v) > 0 {
-					headers[k] = v[0]
-				}
+			for _, h := range req.GetHeaders() {
+				headers[h.GetName()] = h.GetValue()
 			}
 			c.registry.Execute(
 				ctx,

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/handler.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/handler.go
@@ -39,13 +39,13 @@ type Handler struct {
 // Binary address: 0xb65be0
 func (h *Handler) HandleRequest(
 	ctx context.Context,
-	req *tunnelpb.TunnelRequest,
+	req *tunnelpb.HTTPTunnelRequest,
 	sender ResponseSender,
 ) error {
 	startTime := time.Now()
 
 	// Extract request metadata
-	var path, method, url, contentType string
+	var path, method, url string
 	var port int32
 	var headerCount int
 	var body []byte
@@ -55,7 +55,6 @@ func (h *Handler) HandleRequest(
 		port = req.GetPort()
 		method = req.GetMethod()
 		url = req.GetUrl()
-		contentType = req.GetContentType()
 		body = req.GetBody()
 		headerCount = len(req.GetHeaders())
 	}
@@ -65,7 +64,6 @@ func (h *Handler) HandleRequest(
 		"port", port,
 		"method", method,
 		"url", url,
-		"content_type", contentType,
 		"header_count", headerCount,
 	)
 
@@ -89,12 +87,10 @@ func (h *Handler) HandleRequest(
 		return fmt.Errorf("failed to create upstream HTTP request: %w", err)
 	}
 
-	// Copy headers from tunnel request
+	// Copy headers from tunnel request (repeated Header messages)
 	if req != nil {
-		for key, values := range req.GetHeaders() {
-			for _, v := range values {
-				httpReq.Header.Add(key, v)
-			}
+		for _, h := range req.GetHeaders() {
+			httpReq.Header.Add(h.GetName(), h.GetValue())
 		}
 	}
 
@@ -117,12 +113,12 @@ func (h *Handler) HandleRequest(
 	defer resp.Body.Close()
 
 	// Send headers back through tunnel
-	headers := &tunnelpb.HttpHeaders{
+	respHeaders := &tunnelpb.HttpHeaders{
 		StatusCode: int32(resp.StatusCode),
 	}
 	headersResp := &tunnelpb.TunnelResponse{
 		Payload: &tunnelpb.TunnelResponse_HttpHeaders{
-			HttpHeaders: headers,
+			HttpHeaders: respHeaders,
 		},
 	}
 	if err := sender.SendHeaders(headersResp); err != nil {
@@ -160,8 +156,7 @@ func (h *Handler) HandleRequest(
 		"status", resp.StatusCode,
 		"duration", elapsed,
 		"url", url,
-		"content_type", contentType,
-		"tunnel_id", req.GetTunnelId(),
+		"request_id", req.GetRequestId(),
 	)
 
 	return nil

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/tunnelpb/helpers.go
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/tunnelpb/helpers.go
@@ -146,7 +146,7 @@ func convertHeadersToMap(headers []*Header) map[string][]string {
 	result := make(map[string][]string)
 	for _, h := range headers {
 		if h != nil {
-			result[h.Key] = append(result[h.Key], h.Value)
+			result[h.Name] = append(result[h.Name], h.Value)
 		}
 	}
 	return result

--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/tunnelpb/tunnel.proto
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/tunnel/tunnelpb/tunnel.proto
@@ -9,9 +9,10 @@ package tunnelpb;
 
 option go_package = "github.com/anthropics/anthropic/api-go/environment-manager/internal/tunnel/tunnelpb";
 
-// Header represents a single HTTP header key-value pair.
+// Header represents a single HTTP header name-value pair.
+// DWARF fields: Name (string), Value (string)
 message Header {
-  string key = 1;
+  string name = 1;
   string value = 2;
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the MCP server tool handling interface and updates tunnel request/response types to use a more idiomatic protobuf message structure for HTTP headers.

## Key Changes

### MCP Server Interface Simplification
- **GetName()**: Changed return type from `(string, int)` to `string`, removing redundant length return
- **GetTools()**: Changed return type from `(interface{}, int, int)` to `[]ToolConfig`, eliminating multiple return values and introducing a new `ToolConfig` struct
- Introduced `ToolConfig` type in `registry.go` to encapsulate tool definition and handler function, providing better type safety and clarity
- Updated `BaseServer` and `CodeSignMCPServer` implementations to match new interface signatures
- Modified tool registration in `BaseServer.Start()` to convert `ToolConfig` objects to `mcpserver.ServerTool` for MCP server consumption

### Tunnel Request/Response Type Updates
- Changed `HandleRequest()` parameter from `*tunnelpb.TunnelRequest` to `*tunnelpb.HTTPTunnelRequest` for better semantic clarity
- Refactored HTTP header handling from `map[string][]string` to repeated `Header` protobuf messages with `name` and `value` fields
- Updated header field name from `key` to `name` in protobuf definition for consistency with HTTP terminology
- Removed `contentType` field extraction from tunnel requests (now handled via headers)
- Updated logging to use `request_id` instead of `tunnel_id`
- Simplified header processing in both `handler.go` and `client.go` to iterate over repeated messages instead of map entries

### Build Configuration
- Added explicit dependency on `@com_github_mark3labs_mcp_go//mcp` in BUILD.bazel

## Implementation Details
- The new `ToolConfig` struct provides a cleaner abstraction for tool definitions while maintaining compatibility with the underlying MCP library types
- Header handling now uses protobuf's repeated message pattern, which is more idiomatic for variable-length collections in protobuf
- All changes maintain backward compatibility at the MCP protocol level through appropriate conversions in the server implementation

https://claude.ai/code/session_0121NyzYXu34MCJg2x1wpQ2t