### PR TITLE
Simplify wheel build targets and exclude gnome_terminal_profile_switcher

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -65,10 +65,10 @@ actions:
     bazel_commands:
       # Build all wheel targets for potential release
       # These are built but not published (GitHub Actions handles publishing)
+      # Note: gnome_terminal_profile_switcher:wheel excluded (requires system deps: libdbus-1-dev, libgirepository1.0-dev)
       - >
         build --config=rbe
-        //gnome_terminal_profile_switcher:wheel
-        //ducktape:wheel
+        //:wheel
         //headscale_cleanup:wheel
         //tools/claude_hooks:wheel
 


### PR DESCRIPTION
## Summary
Updated the wheel build configuration in buildbuddy.yaml to simplify the build targets and exclude the gnome_terminal_profile_switcher wheel due to system dependency requirements.

## Key Changes
- Replaced individual wheel build targets (`//gnome_terminal_profile_switcher:wheel` and `//ducktape:wheel`) with a single root-level target (`//:wheel`)
- Added a comment documenting why gnome_terminal_profile_switcher is excluded: it requires system dependencies (libdbus-1-dev, libgirepository1.0-dev) that may not be available in the build environment
- Maintained the existing headscale_cleanup and tools/claude_hooks wheel targets

## Implementation Details
This change consolidates the wheel build configuration, likely leveraging a root-level build rule that handles multiple wheel targets more efficiently. The exclusion of gnome_terminal_profile_switcher prevents build failures due to missing system-level dependencies while still allowing other wheels to be built successfully.

https://claude.ai/code/session_012ekEponCRjTJKqnSZGceeB