### PR TITLE
fix: reorder pull --rebase before sed in claude-hooks release

### DIFF
--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -276,22 +276,23 @@ jobs:
       - name: Bump settings.json to new release tag
         run: |
           set -x  # Print commands for debugging
-          TAG="claude-hooks-${{ env.SHORT_SHA }}"
-          sed -i "s|claude-hooks-[a-f0-9]\{8\}|${TAG}|g" .claude/settings.json
-          if git diff --quiet .claude/settings.json; then
-            echo "No change needed"
-            exit 0
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Pull with rebase, show error details if it fails
+          # Pull with rebase before making changes (rebase fails with dirty working tree)
           if ! git pull --rebase origin ${{ github.ref_name }}; then
             echo "::error::Rebase failed. Git status:"
             git status
             echo "Conflicting files:"
             git diff --name-only --diff-filter=U
             exit 1
+          fi
+
+          TAG="claude-hooks-${{ env.SHORT_SHA }}"
+          sed -i "s|claude-hooks-[a-f0-9]\{8\}|${TAG}|g" .claude/settings.json
+          if git diff --quiet .claude/settings.json; then
+            echo "No change needed"
+            exit 0
           fi
 
           git add .claude/settings.json


### PR DESCRIPTION
## Summary
- Moved `git pull --rebase` before the `sed` modification to `.claude/settings.json` in the claude-hooks release workflow
- The previous order caused `git pull --rebase` to fail because `sed` had already modified the file, leaving unstaged changes in the working tree

## Test plan
- [ ] Trigger a claude-hooks release and verify the "Bump settings.json to new release tag" step succeeds

https://claude.ai/code/session_01LAh8AmXxs63gVQGYuFQmiV