### PR TITLE
refactor: switch to keith/pre-commit-buildifier for Bazel files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,15 @@ repos:
   # - svelte-check: bazel test //props/frontend:svelte_check_test
   #                 bazel test //agent_server/src/agent_server/web:svelte_check_test
 
+  # Buildifier - Bazel/Starlark formatting and linting
+  # TODO: Sync buildifier version with Bazel (currently keith=8.2.1.1, Bazel=8.2.1.2 in MODULE.bazel)
+  # Consider: extract version from MODULE.bazel, or pin both to same source
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 8.2.1.1
+    hooks:
+      - id: buildifier
+      - id: buildifier-lint
+
   # ============================================================================
   # LOCAL HOOKS
   # ============================================================================
@@ -129,13 +138,14 @@ repos:
       # Unified pre-commit: format + validate
       # Uses --script_path runner to avoid Bazel lock (allows parallel batch execution)
       # Runners stored in .git/precommit-runners/, one per pre-commit invocation
+      # NOTE: buildifier moved to keith/pre-commit-buildifier (see above)
       - id: bazel-precommit
         name: bazel precommit (format + validate)
         entry: tools/precommit/run-precommit.sh
         language: system
         pass_filenames: true
-        # Triggers on: formattable files, Bazel files, test files, cluster files
-        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html|py|sh|bash|tf)$|BUILD(\\.bazel)?$|WORKSPACE(\\.bazel)?$|\\.bzl$|MODULE\\.bazel$|^cluster/"
+        # Triggers on: formattable files (not Bazel - handled by buildifier hook), test files, cluster files
+        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html|py|sh|bash|tf)$|^cluster/"
 
       # Specimens: block changes to committed snapshot code/ directories
       - id: block-specimen-code-changes
@@ -217,7 +227,8 @@ repos:
   # See MODULE.bazel tf.download(mirror={...}) for provider configuration.
 
   # NOTE: The following hooks are combined into bazel-precommit:
-  # - bazel-format (ruff, shfmt, buildifier)
-  # - bazel-validate (buildifier-lint, pytest-main check, cluster validations)
+  # - bazel-format (ruff, shfmt)
+  # - bazel-validate (pytest-main check, cluster validations)
   # - terraform checks (terraform-version-centralization)
   # This avoids Bazel client lock contention and runs validations in parallel.
+  # buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.

--- a/tools/docs/linting.md
+++ b/tools/docs/linting.md
@@ -7,14 +7,14 @@ This document describes the linting and formatting setup across pre-commit, Baze
 | Tool                             | Pre-commit             | Bazel Aspect          | GitHub CI           |
 | -------------------------------- | ---------------------- | --------------------- | ------------------- |
 | **Python (ruff check)**          | `ruff-check` hook      | `--config=lint`       | Both                |
-| **Python (ruff format)**         | `bazel-format` hook    | N/A                   | Pre-commit          |
+| **Python (ruff format)**         | `bazel-precommit` hook | N/A                   | Pre-commit          |
 | **Python (mypy)**                | -                      | `--config=typecheck`  | bazel-build         |
 | **JS/TS (eslint)**               | -                      | `--config=lint`       | bazel-build         |
-| **JS/TS (prettier)**             | `bazel-format` hook    | N/A                   | Pre-commit          |
+| **JS/TS (prettier)**             | `prettier` hook        | N/A                   | Pre-commit          |
 | **Starlark (buildifier)**        | `buildifier-lint` hook | -                     | Pre-commit          |
-| **Starlark (buildifier format)** | `bazel-format` hook    | N/A                   | Pre-commit          |
+| **Starlark (buildifier format)** | `buildifier` hook      | N/A                   | Pre-commit          |
 | **Rust (clippy)**                | -                      | `--config=rust-check` | bazel-build         |
-| **Shell (shfmt)**                | `bazel-format` hook    | N/A                   | Pre-commit          |
+| **Shell (shfmt)**                | `bazel-precommit` hook | N/A                   | Pre-commit          |
 | **Nix (nixfmt)**                 | `nixfmt` hook          | N/A                   | Pre-commit          |
 | **Ansible**                      | syntax-check (fast)    | -                     | ansible-lint (full) |
 | **Terraform**                    | fmt/validate/tflint    | -                     | Pre-commit          |
@@ -106,21 +106,24 @@ Formatters included:
 - **prettier** - JS/TS, CSS, HTML, Markdown, YAML, JSON
 - **ruff format** - Python
 - **shfmt** - Shell scripts
-- **buildifier** - Starlark/BUILD files
 
 The formatter respects `.gitattributes` exclusions (`rules-lint-ignored=true`).
+
+Note: **buildifier** is managed separately via `keith/pre-commit-buildifier` hooks.
 
 ## Pre-commit Hooks
 
 Key hooks in `.pre-commit-config.yaml`:
 
-| Hook                | Source                       | Purpose            |
-| ------------------- | ---------------------------- | ------------------ |
-| `ruff-check`        | astral-sh/ruff-pre-commit    | Python linting     |
-| `buildifier-lint`   | keith/pre-commit-buildifier  | Starlark linting   |
-| `bazel-format`      | local (Bazel)                | Unified formatting |
-| `nixfmt`            | local (static binary)        | Nix formatting     |
-| `markdownlint-cli2` | DavidAnson/markdownlint-cli2 | Markdown linting   |
+| Hook                | Source                       | Purpose                       |
+| ------------------- | ---------------------------- | ----------------------------- |
+| `ruff-check`        | astral-sh/ruff-pre-commit    | Python linting                |
+| `buildifier`        | keith/pre-commit-buildifier  | Starlark formatting           |
+| `buildifier-lint`   | keith/pre-commit-buildifier  | Starlark linting              |
+| `bazel-precommit`   | local (Bazel)                | Unified formatting + validate |
+| `prettier`          | local (node)                 | JS/TS/MD/YAML formatting      |
+| `nixfmt`            | local (static binary)        | Nix formatting                |
+| `markdownlint-cli2` | DavidAnson/markdownlint-cli2 | Markdown linting              |
 
 Cluster-specific hooks run only on `cluster/` files:
 
@@ -133,20 +136,20 @@ Cluster-specific hooks run only on `cluster/` files:
 Pre-commit uses external tool versions for some hooks:
 
 - `ruff-check`: from `astral-sh/ruff-pre-commit`
-- `buildifier-lint`: from `keith/pre-commit-buildifier`
+- `buildifier`/`buildifier-lint`: from `keith/pre-commit-buildifier`
 
 Bazel uses managed versions:
 
 - ruff: `@multitool//tools/ruff`
-- buildifier: `@buildifier_prebuilt//buildifier`
+- buildifier: `@buildifier_prebuilt//buildifier` (used by `//tools/format`, `//tools/lint`)
 
-The formatting hook (`bazel-format`) uses Bazel-managed versions, ensuring consistency.
+The `bazel-precommit` hook uses Bazel-managed ruff and shfmt versions, ensuring consistency.
 
 ### Known Gaps
 
 See `TODO.md` for tracked items. Current gaps:
 
-1. **Version drift risk**: Pre-commit uses external ruff/buildifier versions that may differ from Bazel-managed versions. A unified linter script (like `//tools/format`) would eliminate this.
+1. **Version drift risk**: Pre-commit uses external ruff/buildifier versions that may differ from Bazel-managed versions. TODO in `.pre-commit-config.yaml` tracks the buildifier version sync issue.
 
 2. **ESLint not in pre-commit**: JS/TS linting only runs in CI via Bazel aspects, not locally during commit.
 

--- a/tools/precommit/BUILD.bazel
+++ b/tools/precommit/BUILD.bazel
@@ -5,6 +5,8 @@
 # the Bazel client lock (~55s each). This single binary runs both sequentially
 # within one invocation (~20s total).
 #
+# Note: buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.
+#
 # Usage:
 #   bazel run //tools/precommit -- [files...]
 #   bazel run //tools/precommit  # format and validate all tracked files
@@ -52,14 +54,12 @@ py_binary(
         # Formatters
         "@aspect_rules_lint//format:ruff",
         "@aspect_rules_lint//format:shfmt",
-        "@buildifier_prebuilt//buildifier",
         # Validators (validate_kustomizations is unified: kustomize + CRD layering + deps + flux)
         "//cluster/scripts:validate_helm_templates",
         "//cluster/scripts:validate_kustomizations",
         "//cluster/scripts:validate_sealed_secrets",
     ],
     env = {
-        "BUILDIFIER_BIN": "$(rlocationpath @buildifier_prebuilt//buildifier:buildifier)",
         "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",
     },
@@ -82,14 +82,12 @@ py_binary(
         # Formatters
         "@aspect_rules_lint//format:ruff",
         "@aspect_rules_lint//format:shfmt",
-        "@buildifier_prebuilt//buildifier",
         # Validators (validate_kustomizations is unified: kustomize + CRD layering + deps + flux)
         "//cluster/scripts:validate_helm_templates",
         "//cluster/scripts:validate_kustomizations",
         "//cluster/scripts:validate_sealed_secrets",
     ],
     env = {
-        "BUILDIFIER_BIN": "$(rlocationpath @buildifier_prebuilt//buildifier:buildifier)",
         "FMT_CHECK": "1",
         "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -5,8 +5,10 @@ When pre-commit runs multiple Bazel hooks concurrently, they serialize on
 the Bazel client lock, causing ~55s per hook even though actual work is <20s.
 
 This single binary runs both in sequence within one Bazel invocation:
-1. Format: prettier, ruff, shfmt, buildifier
-2. Validate: buildifier-lint, pytest-main check, cluster validations
+1. Format: ruff, shfmt
+2. Validate: pytest-main check, cluster validations
+
+Note: buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.
 
 Usage:
     bazel run //tools/precommit -- [files...]
@@ -47,20 +49,9 @@ def resolve_bin(rlocation: str) -> str:
     return path
 
 
-EXTENSION_MAP: dict[str, str] = {
-    ".py": "ruff",
-    ".sh": "shfmt",
-    ".bash": "shfmt",
-    ".bzl": "buildifier",
-    ".bazel": "buildifier",
-}
+EXTENSION_MAP: dict[str, str] = {".py": "ruff", ".sh": "shfmt", ".bash": "shfmt"}
 
-FILENAME_MAP: dict[str, str] = {
-    "BUILD": "buildifier",
-    "BUILD.bazel": "buildifier",
-    "WORKSPACE": "buildifier",
-    "WORKSPACE.bazel": "buildifier",
-}
+FILENAME_MAP: dict[str, str] = {}
 
 SHELL_SHEBANG_RE = re.compile(rb"^#![ \t]*/(usr/)?bin/(env[ \t]+)?(sh|bash|mksh|bats|zsh)")
 IGNORE_ATTRIBUTES = ("linguist-generated", "gitlab-generated", "rules-lint-ignored")
@@ -141,7 +132,6 @@ def resolve_formatter_bin(formatter: str) -> str:
 FORMATTER_COMMANDS: dict[str, Callable[[str, bool], list[str]]] = {
     "ruff": lambda bin_path, check: [bin_path, "format", *(["--check"] if check else [])],
     "shfmt": lambda bin_path, check: [bin_path, "-d" if check else "-w"],
-    "buildifier": lambda bin_path, _: [bin_path],
 }
 
 
@@ -203,10 +193,6 @@ class ValidationResult:
     skipped: bool = False
 
 
-def is_bazel_file(p: Path) -> bool:
-    return p.name in ("BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel") or p.suffix in (".bzl", ".bazel")
-
-
 def is_test_file(p: Path) -> bool:
     return p.suffix == ".py" and "test_" in p.name
 
@@ -227,30 +213,6 @@ def is_sealed_secret(p: Path) -> bool:
 
 def is_terraform_module(p: Path) -> bool:
     return p.suffix == ".tf" and p.is_relative_to("cluster/terraform/modules")
-
-
-async def run_buildifier_lint(files: list[Path]) -> ValidationResult:
-    """Run buildifier lint on Bazel files."""
-    name = "buildifier-lint"
-    bazel_files = [str(f) for f in files if is_bazel_file(f)]
-    if not bazel_files:
-        return ValidationResult(name, 0.0, True, skipped=True)
-
-    start = time.perf_counter()
-    buildifier = resolve_bin("buildifier_prebuilt/buildifier/buildifier")
-    proc = await asyncio.create_subprocess_exec(
-        buildifier,
-        "--mode=check",
-        "--lint=warn",
-        *bazel_files,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate()
-    elapsed = time.perf_counter() - start
-
-    output = (stdout + stderr).decode()
-    return ValidationResult(name, elapsed, proc.returncode == 0, output)
 
 
 async def run_pytest_main_check(files: list[Path], repo_root: Path) -> ValidationResult:
@@ -323,7 +285,6 @@ async def run_validate(files: list[Path], repo_root: Path, repo: pygit2.Reposito
     """Run all validations on files."""
     return list(
         await asyncio.gather(
-            run_buildifier_lint(files),
             run_pytest_main_check(files, repo_root),
             run_terraform_centralization_check(files),
             run_filename_convention_check(repo),


### PR DESCRIPTION
Migrate buildifier formatting and linting from custom Bazel-integrated precommit tool to the standard keith/pre-commit-buildifier hooks.

Changes:
- Add keith/pre-commit-buildifier (8.2.1.1) with buildifier + buildifier-lint hooks
- Remove buildifier handling from tools/precommit (format/validate)
- Update bazel-precommit hook to exclude Bazel files from triggers
- Update documentation to reflect new hook architecture
- Add TODO to sync buildifier versions between pre-commit and Bazel

Benefits:
- Follows standard pre-commit patterns for buildifier
- Separates concerns: Bazel precommit handles Python/Shell, buildifier handles Bazel files
- Easier to update buildifier version via pre-commit autoupdate

https://claude.ai/code/session_01R2eBkyTruexFuj39oaBBiw