### PR TITLE
refactor: switch ruff formatting to astral-sh/ruff-pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,12 +60,15 @@ repos:
   # Syntax check catches: YAML errors, undefined variables, invalid module usage, etc.
   # Full ansible-lint in CI catches: Style issues, best practices, deprecated modules, etc.
 
-  # Ruff linter (formatting handled by bazel-format below)
+  # Ruff linter and formatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.6
     hooks:
       - id: ruff-check
         args: [--fix, --config, ruff.toml]
+        files: "\\.py$"
+      - id: ruff-format
+        args: [--config, ruff.toml]
         files: "\\.py$"
 
   # TODO: Check if Bazel mypy (bazelisk build --config=check //...) can replace
@@ -138,14 +141,14 @@ repos:
       # Unified pre-commit: format + validate
       # Uses --script_path runner to avoid Bazel lock (allows parallel batch execution)
       # Runners stored in .git/precommit-runners/, one per pre-commit invocation
-      # NOTE: buildifier moved to keith/pre-commit-buildifier (see above)
+      # NOTE: buildifier moved to keith/pre-commit-buildifier, ruff to astral-sh/ruff-pre-commit (see above)
       - id: bazel-precommit
         name: bazel precommit (format + validate)
         entry: tools/precommit/run-precommit.sh
         language: system
         pass_filenames: true
-        # Triggers on: formattable files (not Bazel - handled by buildifier hook), test files, cluster files
-        files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html|py|sh|bash|tf)$|^cluster/"
+        # Triggers on: shell scripts (shfmt), test files (pytest-main), cluster files (validations), terraform (centralization)
+        files: "\\.(sh|bash|py|tf)$|^cluster/"
 
       # Specimens: block changes to committed snapshot code/ directories
       - id: block-specimen-code-changes
@@ -227,8 +230,9 @@ repos:
   # See MODULE.bazel tf.download(mirror={...}) for provider configuration.
 
   # NOTE: The following hooks are combined into bazel-precommit:
-  # - bazel-format (ruff, shfmt)
+  # - bazel-format (shfmt only)
   # - bazel-validate (pytest-main check, cluster validations)
   # - terraform checks (terraform-version-centralization)
   # This avoids Bazel client lock contention and runs validations in parallel.
-  # buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.
+  # buildifier (format + lint) → keith/pre-commit-buildifier
+  # ruff (format + lint) → astral-sh/ruff-pre-commit

--- a/tools/docs/linting.md
+++ b/tools/docs/linting.md
@@ -7,7 +7,7 @@ This document describes the linting and formatting setup across pre-commit, Baze
 | Tool                             | Pre-commit             | Bazel Aspect          | GitHub CI           |
 | -------------------------------- | ---------------------- | --------------------- | ------------------- |
 | **Python (ruff check)**          | `ruff-check` hook      | `--config=lint`       | Both                |
-| **Python (ruff format)**         | `bazel-precommit` hook | N/A                   | Pre-commit          |
+| **Python (ruff format)**         | `ruff-format` hook     | N/A                   | Pre-commit          |
 | **Python (mypy)**                | -                      | `--config=typecheck`  | bazel-build         |
 | **JS/TS (eslint)**               | -                      | `--config=lint`       | bazel-build         |
 | **JS/TS (prettier)**             | `prettier` hook        | N/A                   | Pre-commit          |
@@ -115,15 +115,16 @@ Note: **buildifier** is managed separately via `keith/pre-commit-buildifier` hoo
 
 Key hooks in `.pre-commit-config.yaml`:
 
-| Hook                | Source                       | Purpose                       |
-| ------------------- | ---------------------------- | ----------------------------- |
-| `ruff-check`        | astral-sh/ruff-pre-commit    | Python linting                |
-| `buildifier`        | keith/pre-commit-buildifier  | Starlark formatting           |
-| `buildifier-lint`   | keith/pre-commit-buildifier  | Starlark linting              |
-| `bazel-precommit`   | local (Bazel)                | Unified formatting + validate |
-| `prettier`          | local (node)                 | JS/TS/MD/YAML formatting      |
-| `nixfmt`            | local (static binary)        | Nix formatting                |
-| `markdownlint-cli2` | DavidAnson/markdownlint-cli2 | Markdown linting              |
+| Hook                | Source                       | Purpose                        |
+| ------------------- | ---------------------------- | ------------------------------ |
+| `ruff-check`        | astral-sh/ruff-pre-commit    | Python linting                 |
+| `ruff-format`       | astral-sh/ruff-pre-commit    | Python formatting              |
+| `buildifier`        | keith/pre-commit-buildifier  | Starlark formatting            |
+| `buildifier-lint`   | keith/pre-commit-buildifier  | Starlark linting               |
+| `bazel-precommit`   | local (Bazel)                | Shell formatting + validations |
+| `prettier`          | local (node)                 | JS/TS/MD/YAML formatting       |
+| `nixfmt`            | local (static binary)        | Nix formatting                 |
+| `markdownlint-cli2` | DavidAnson/markdownlint-cli2 | Markdown linting               |
 
 Cluster-specific hooks run only on `cluster/` files:
 
@@ -135,15 +136,16 @@ Cluster-specific hooks run only on `cluster/` files:
 
 Pre-commit uses external tool versions for some hooks:
 
-- `ruff-check`: from `astral-sh/ruff-pre-commit`
+- `ruff-check`/`ruff-format`: from `astral-sh/ruff-pre-commit`
 - `buildifier`/`buildifier-lint`: from `keith/pre-commit-buildifier`
 
 Bazel uses managed versions:
 
-- ruff: `@multitool//tools/ruff`
+- ruff: `@multitool//tools/ruff` (used by `//tools/format`)
 - buildifier: `@buildifier_prebuilt//buildifier` (used by `//tools/format`, `//tools/lint`)
+- shfmt: `@aspect_rules_lint//format:shfmt` (used by `//tools/precommit`, `//tools/format`)
 
-The `bazel-precommit` hook uses Bazel-managed ruff and shfmt versions, ensuring consistency.
+The `bazel-precommit` hook uses Bazel-managed shfmt version for shell formatting.
 
 ### Known Gaps
 

--- a/tools/precommit/BUILD.bazel
+++ b/tools/precommit/BUILD.bazel
@@ -5,7 +5,7 @@
 # the Bazel client lock (~55s each). This single binary runs both sequentially
 # within one invocation (~20s total).
 #
-# Note: buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.
+# Note: buildifier → keith/pre-commit-buildifier, ruff → astral-sh/ruff-pre-commit
 #
 # Usage:
 #   bazel run //tools/precommit -- [files...]
@@ -52,7 +52,6 @@ py_binary(
     srcs = ["precommit.py"],
     data = [
         # Formatters
-        "@aspect_rules_lint//format:ruff",
         "@aspect_rules_lint//format:shfmt",
         # Validators (validate_kustomizations is unified: kustomize + CRD layering + deps + flux)
         "//cluster/scripts:validate_helm_templates",
@@ -60,7 +59,6 @@ py_binary(
         "//cluster/scripts:validate_sealed_secrets",
     ],
     env = {
-        "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",
     },
     visibility = ["//visibility:public"],
@@ -80,7 +78,6 @@ py_binary(
     srcs = ["precommit.py"],
     data = [
         # Formatters
-        "@aspect_rules_lint//format:ruff",
         "@aspect_rules_lint//format:shfmt",
         # Validators (validate_kustomizations is unified: kustomize + CRD layering + deps + flux)
         "//cluster/scripts:validate_helm_templates",
@@ -89,7 +86,6 @@ py_binary(
     ],
     env = {
         "FMT_CHECK": "1",
-        "RUFF_BIN": "$(rlocationpath @aspect_rules_lint//format:ruff)",
         "SHFMT_BIN": "$(rlocationpath @aspect_rules_lint//format:shfmt)",
     },
     main = "precommit.py",

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -5,10 +5,10 @@ When pre-commit runs multiple Bazel hooks concurrently, they serialize on
 the Bazel client lock, causing ~55s per hook even though actual work is <20s.
 
 This single binary runs both in sequence within one Bazel invocation:
-1. Format: ruff, shfmt
-2. Validate: pytest-main check, cluster validations
+1. Format: shfmt
+2. Validate: pytest-main check, cluster validations, terraform centralization
 
-Note: buildifier (format + lint) is handled separately by keith/pre-commit-buildifier.
+Note: buildifier → keith/pre-commit-buildifier, ruff → astral-sh/ruff-pre-commit
 
 Usage:
     bazel run //tools/precommit -- [files...]
@@ -49,7 +49,7 @@ def resolve_bin(rlocation: str) -> str:
     return path
 
 
-EXTENSION_MAP: dict[str, str] = {".py": "ruff", ".sh": "shfmt", ".bash": "shfmt"}
+EXTENSION_MAP: dict[str, str] = {".sh": "shfmt", ".bash": "shfmt"}
 
 FILENAME_MAP: dict[str, str] = {}
 
@@ -130,8 +130,7 @@ def resolve_formatter_bin(formatter: str) -> str:
 
 
 FORMATTER_COMMANDS: dict[str, Callable[[str, bool], list[str]]] = {
-    "ruff": lambda bin_path, check: [bin_path, "format", *(["--check"] if check else [])],
-    "shfmt": lambda bin_path, check: [bin_path, "-d" if check else "-w"],
+    "shfmt": lambda bin_path, check: [bin_path, "-d" if check else "-w"]
 }
 
 


### PR DESCRIPTION
Migrate ruff formatting from Bazel-integrated precommit tool to the standard ruff-format hook from astral-sh/ruff-pre-commit.

Changes:
- Add ruff-format hook to astral-sh/ruff-pre-commit (alongside ruff-check)
- Remove ruff formatting from tools/precommit (Python tool and BUILD targets)
- Update bazel-precommit hook file triggers (still processes .py for validation)
- Update documentation in tools/docs/linting.md

Benefits:
- Follows standard pre-commit patterns for ruff
- Simplifies bazel-precommit to focus on custom validations
- Easier to update ruff version via pre-commit autoupdate
- Reduces Bazel dependencies and build complexity

After this change, bazel-precommit only handles:
- Formatting: shfmt (shell scripts)
- Validation: pytest-main check, terraform centralization, filename conventions, cluster validations

https://claude.ai/code/session_01R2eBkyTruexFuj39oaBBiw