### PR TITLE
Move Docker daemon config from .bazelrc to platform exec_properties

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,8 +75,6 @@ build:rbe --spawn_strategy=remote,local
 test:rbe --spawn_strategy=remote,local
 build:rbe --jobs=50
 build:rbe --remote_download_minimal
-# Docker daemon for all RBE tests (lightweight - Firecracker isolation already enabled in platform)
-test:rbe --remote_default_exec_properties=test.init-dockerd=true
 # BuildBuddy Build Event Service (BES) and remote cache configuration
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --bes_backend=grpcs://remote.buildbuddy.io

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -132,6 +132,11 @@ platform(
         # BuildBuddy Firecracker isolation for all RBE actions (better isolation + runner recycling)
         "workload-isolation-type": "firecracker",
         "recycle-runner": "true",
+        # Start Docker daemon for tests (lightweight with Firecracker).
+        # Defined here (not via --remote_default_exec_properties in .bazelrc)
+        # to avoid duplicate-key crash when --config=rbe is expanded twice
+        # (e.g., both buildbuddy.bazelrc and auth-proxy/bazelrc enable it).
+        "test.init-dockerd": "true",
     },
     parents = ["@buildbuddy_toolchain//:platform_linux_x86_64"],
 )

--- a/editor_agent/host/BUILD.bazel
+++ b/editor_agent/host/BUILD.bazel
@@ -1,6 +1,7 @@
 """Editor agent host package."""
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 py_library(
     name = "cli",

--- a/experimental/gatelet/server/endpoints/BUILD.bazel
+++ b/experimental/gatelet/server/endpoints/BUILD.bazel
@@ -1,6 +1,7 @@
 """Gatelet server endpoints."""
 
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 py_library(
     name = "activitywatch",

--- a/inop/BUILD.bazel
+++ b/inop/BUILD.bazel
@@ -3,7 +3,8 @@
 # gazelle:resolve py inop.engine.optimizer //inop/engine:optimizer
 # gazelle:resolve py inop.engine //inop/engine:optimizer
 
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 # no-mypy: statsmodels (transitive dep of plotnine) has broken __init__.py structure
 # that causes mypy to error with "Source file found twice under different module names".

--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -1,6 +1,7 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
 load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 load("//tools/deps:check.bzl", "assert_no_deps")
+load("//tools/testing:defs.bzl", "py_test")
 
 # Core models - no MCP dependencies, usable outside fastmcp
 py_library(

--- a/props/agents/grader/BUILD.bazel
+++ b/props/agents/grader/BUILD.bazel
@@ -14,8 +14,9 @@ The container runs a persistent agent loop that:
 
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env", "py_python3_symlink")
+load("//tools/testing:defs.bzl", "py_test")
 
 exports_files(
     ["prompt.md.mako"],

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 py_library(
     name = "agent_definitions",

--- a/props/core/gepa/BUILD.bazel
+++ b/props/core/gepa/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 # =============================================================================
 # Library targets

--- a/props/db/BUILD.bazel
+++ b/props/db/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library")
 load("//tools/deps:check.bzl", "assert_no_deps")
+load("//tools/testing:defs.bzl", "py_test")
 
 # =============================================================================
 # Leaf modules (no db/ deps)

--- a/tools/testing/defs.bzl
+++ b/tools/testing/defs.bzl
@@ -10,7 +10,7 @@ def py_test(name, size = "small", requires_docker = False, tags = None, **kwargs
     - Optional Docker tag via requires_docker parameter
 
     Note: Docker exec properties (Firecracker, init-dockerd, recycle-runner)
-    are now configured globally in //:rbe_linux_x64 platform and .bazelrc.
+    are configured globally in //:rbe_linux_x64 platform exec_properties.
 
     Args:
         name: Target name.


### PR DESCRIPTION
## Summary
Consolidate Docker daemon initialization configuration for RBE tests by moving it from `.bazelrc` to the platform's `exec_properties` in `BUILD.bazel`. This prevents duplicate-key crashes when the `--config=rbe` flag is expanded multiple times across different bazelrc files.

## Key Changes
- **BUILD.bazel**: Added `"test.init-dockerd": "true"` to the `rbe_linux_x64` platform's `exec_properties` with explanatory comments about why it's defined here instead of in `.bazelrc`
- **.bazelrc**: Removed the `test:rbe --remote_default_exec_properties=test.init-dockerd=true` line that was causing duplicate-key conflicts
- **tools/testing/defs.bzl**: Updated documentation comment to reflect that Docker exec properties are now configured in the platform's `exec_properties` rather than `.bazelrc`
- **Multiple BUILD.bazel files**: Standardized `py_test` imports across the codebase by:
  - Removing `py_test` from `@rules_python//python:defs.bzl` imports
  - Adding `py_test` from `//tools/testing:defs.bzl` imports
  - Affected files: `editor_agent/host/`, `experimental/gatelet/server/endpoints/`, `inop/`, `mcp_infra/exec/`, `props/agents/grader/`, `props/backend/routes/`, `props/core/gepa/`, `props/db/`

## Implementation Details
The change addresses a specific issue where including `--config=rbe` multiple times (e.g., from both `buildbuddy.bazelrc` and `auth-proxy/bazelrc`) would cause a crash due to duplicate keys in `remote_default_exec_properties`. By moving the Docker daemon configuration to the platform definition, it's applied consistently without requiring command-line flags that can conflict when expanded multiple times.

https://claude.ai/code/session_016BzV4dbdMyf8NNBEwtCZcH