### PR TITLE
Refactor specimen sync to use bundle artifacts (code tar + data YAML)

### DIFF
--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -22,17 +22,6 @@ py_library(
 )
 
 py_library(
-    name = "loader",
-    srcs = ["loader.py"],
-    imports = ["../../.."],
-    visibility = ["//props:__subpackages__"],
-    deps = [
-        "//props/core/models:snapshot",
-        "@pypi//pyyaml",
-    ],
-)
-
-py_library(
     name = "export",
     srcs = ["export.py"],
     imports = ["../../.."],
@@ -72,18 +61,20 @@ py_library(
     imports = ["../../.."],
     visibility = ["//props:__subpackages__"],
     deps = [
-        ":loader",
         ":model_metadata",
         ":stats",
         ":yaml_loader",
         "//props:config",
         "//props/core:ids",
         "//props/core:runs_context",
+        "//props/core:splits",
         "//props/core/models:snapshot",
         "//props/core/models:true_positive",
         "//props/db:models",
         "@pypi//opentelemetry_api",
+        "@pypi//pydantic",
         "@pypi//pygit2",
+        "@pypi//pyyaml",
         "@pypi//sqlalchemy",
     ],
 )
@@ -92,7 +83,7 @@ py_library(
 # Boundary enforcement
 # =============================================================================
 
-# yaml_loader and loader are pure parsing layers — they must not depend on
+# yaml_loader is a pure parsing layer — it must not depend on
 # the DB/ORM layer (sqlalchemy, props/db:models).
 assert_no_deps(
     name = "test_yaml_loader_no_db_deps",
@@ -101,15 +92,6 @@ assert_no_deps(
         "//props/db:models",
     ],
     targets = ["//props/db/sync:yaml_loader"],
-)
-
-assert_no_deps(
-    name = "test_loader_no_db_deps",
-    forbidden = [
-        "@pypi//sqlalchemy",
-        "//props/db:models",
-    ],
-    targets = ["//props/db/sync:loader"],
 )
 
 # =============================================================================
@@ -166,22 +148,5 @@ py_test(
         "//props/db:models",
         "@pypi//pytest_bazel",
         "@pypi//sqlalchemy",
-    ],
-)
-
-py_test(
-    name = "test_manifest_loading",
-    srcs = ["test_manifest_loading.py"],
-    imports = ["../../.."],
-    requires_docker = True,
-    deps = [
-        ":loader",
-        "//props:conftest",
-        "//props/core:ids",
-        "//props/db:conftest",
-        "@pypi//pydantic",
-        "@pypi//pytest",
-        "@pypi//pytest_bazel",
-        "@pypi//pyyaml",
     ],
 )

--- a/props/specimens/defs.bzl
+++ b/props/specimens/defs.bzl
@@ -1,6 +1,6 @@
 """Bazel rules for specimen tar generation and testing."""
 
-load("//tools/testing:docker.bzl", "docker_py_test")
+load("//tools/testing:defs.bzl", "py_test")
 
 def _create_code_tar_impl(ctx):
     """Implementation for create_code_tar rule."""
@@ -75,7 +75,7 @@ def specimen_targets(name, slug, split):
     Generates:
         - {name}_code_tar: Deterministic uncompressed tar of code/ with BUILD.bazel restored
         - {name}_data_blob: YAML with {split, issues} structure
-        - test_{name}: docker_py_test validating this specimen
+        - test_{name}: py_test validating this specimen
     """
     code_tar_target = name + "_code_tar"
     data_blob_target = name + "_data_blob"
@@ -96,7 +96,7 @@ def specimen_targets(name, slug, split):
     )
 
     # Per-specimen test
-    docker_py_test(
+    py_test(
         name = "test_" + name,
         srcs = ["//props/specimens:test_specimen.py"],
         data = [
@@ -109,6 +109,7 @@ def specimen_targets(name, slug, split):
             "SPECIMEN_DATA_YAML": "$(location :" + data_blob_target + ")",
         },
         imports = ["../.."],
+        requires_docker = True,
         tags = ["integration", "specimen"],
         deps = [
             "//bazel_util:runfiles",

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -1,2 +1,2 @@
 # Bazel macros for testing infrastructure.
-# NOTE: No aggregator target - use specific .bzl files like :docker.bzl
+# NOTE: No aggregator target - use :defs.bzl for py_test wrapper


### PR DESCRIPTION
## Summary

This PR refactors the specimen synchronization infrastructure to use pre-built bundle artifacts (code tar + data YAML) instead of reading directly from the source tree. This enables better separation of concerns, supports external repositories, and provides a clearer path for production deployment.

## Key Changes

- **New bundle format**: Specimens are now packaged as:
  - `code.tar`: Uncompressed tar with code/ directory (BUILD.bazel files renamed to BUILD.bazel.specimen)
  - `data.yaml`: Merged YAML with `{split, issues}` structure
  
- **Bazel rules for artifact generation** (`props/specimens/defs.bzl`):
  - `create_code_tar`: Generates code tar with BUILD file renaming
  - `create_data_blob`: Merges issue YAMLs and wraps with split field
  - `specimen_targets`: Generates per-specimen test targets

- **New CLI tool** (`props/cli/sync_specimen.py`):
  - Syncs a single specimen from bundle artifacts
  - Replaces direct source tree reading for production use

- **Refactored sync logic** (`props/db/sync/sync.py`):
  - Added `SpecimenData` and `SpecimenBundle` models for bundle structure
  - New `sync_specimen_from_bundle()` function for bundle-based sync
  - Renamed `_add_ranges_to_occurrence()` to `_add_ranges_to_tp_occurrence()` for clarity
  - Removed `loader.py` (manifest discovery) - now handled by bundle generation

- **Removed legacy test infrastructure**:
  - Deleted `props/core/test_production_specimens.py` (replaced by per-specimen Bazel tests)
  - Deleted `props/db/sync/test_manifest_loading.py` (manifest loading now in bundle generation)
  - Deleted `props/db/sync/loader.py` (manifest discovery logic)

- **Specimen BUILD files**: Added per-specimen BUILD.bazel files that call `specimen_targets()` macro to generate test targets

- **File renaming**: 287 BUILD.bazel files in specimen code/ directories renamed to BUILD.bazel.specimen to avoid Bazel package conflicts

## Implementation Details

- Bundle artifacts are generated at build time via Bazel rules, ensuring reproducibility
- The `SpecimenData` model validates bundle structure (split + issues) using Pydantic
- Per-specimen tests are generated by the `specimen_targets()` macro, enabling parallel execution and RBE compatibility
- The refactoring maintains backward compatibility with existing sync logic while enabling new deployment patterns

https://claude.ai/code/session_012Ajd3gaEAezhkF2jW5cUYM