### PR TITLE
Revert frozen manifests

### DIFF
--- a/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/test1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/test1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: test
+bundle: null

--- a/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/train1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/train1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: train
+bundle: null

--- a/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: valid
+bundle: null

--- a/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid2/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-17-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid2/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: valid
+bundle: null

--- a/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/test1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/test1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: test
+bundle: null

--- a/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/train1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/train1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: train
+bundle: null

--- a/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: valid
+bundle: null

--- a/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid2/manifest.yaml
+++ b/props/specimens/ducktape/2026-01-29-00/code/props/testing/fixtures/testdata/specimens/test-fixtures/valid2/manifest.yaml
@@ -1,7 +1,5 @@
-# Deprecated fields (removed, kept for reference):
-#   bundle: None
-
 source:
   vcs: local
   root: code
 split: valid
+bundle: null


### PR DESCRIPTION
## Summary
Updated all test fixture manifest files to replace deprecated field comments with an explicit `bundle: null` field declaration.

## Key Changes
- Removed deprecated field reference comments from 8 manifest files across two specimen versions (2026-01-17-00 and 2026-01-29-00)
- Added explicit `bundle: null` field to each manifest file to replace the commented-out reference
- Applied consistently across all test fixture splits: test1, train1, valid1, and valid2

## Implementation Details
This change modernizes the manifest file format by:
- Eliminating ambiguous comment-based deprecation notices
- Making the `bundle` field explicit in the YAML structure with a null value
- Maintaining the same semantic meaning while improving clarity and consistency
- Affecting 8 manifest files in total across different specimen versions and test fixture directories

https://claude.ai/code/session_01WXDfVFKnsZDUPJHzjwbjdJ