### PR TITLE
Sync model metadata during database recreation

### DIFF
--- a/.claude/skills/test_props/SKILL.md
+++ b/.claude/skills/test_props/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: test_props
-description: Run end-to-end props testing with a real OpenAI API key. Tests critic, grader, improver, and optimizer workflows in a podman + host networking environment.
+description: Manual live props deployment testing — sets up Podman infrastructure (postgres, registry, backend) and runs real agent containers with a real OpenAI API key. NOT for standard Bazel tests (use `bazel test //props/...` for those).
 argument-hint: "[workflow: setup|critic|grader|improver|all]"
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, WebFetch, Task
 ---
 
-# Test Props E2E
+# Test Props Live Deployment
 
-Run end-to-end props testing. Sets up infrastructure, initializes the database,
-runs the backend, pushes agent images, and tests agent workflows.
+Manual live deployment testing. Sets up Podman infrastructure, initializes the database,
+runs the backend, pushes agent images, and tests agent workflows with real OpenAI calls.
+
+**Not for standard tests** — use `bazel test //props/...` for unit, integration, and e2e
+Bazel tests. This skill is for manual live deployment verification only.
 
 **Argument:** `$ARGUMENTS` (default: `all`)
 

--- a/props/cli/BUILD.bazel
+++ b/props/cli/BUILD.bazel
@@ -17,6 +17,7 @@ py_library(
         "//props/db:database",
         "//props/db:setup",
         "//props/db/sync",
+        "//props/db/sync:model_metadata",
         "@pypi//rich",
         "@pypi//typer_slim",
     ],

--- a/props/cli/cmd_db.py
+++ b/props/cli/cmd_db.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from props.db.database import Database
 from props.db.setup import ensure_database_exists
+from props.db.sync.model_metadata import sync_model_metadata_with_session
 from props.db.sync.sync import SpecimenBundle, sync_metadata, sync_specimen
 
 # Database subcommand group
@@ -98,11 +99,17 @@ def cmd_db_recreate(
     db: Database = ctx.obj
     ensure_database_exists(db.config, db.config.database, drop_existing=False)
 
-    # Recreate schema only (no sync)
+    # Recreate schema and sync model metadata
     console = Console()
     console.print("Recreating database schema...")
     db.recreate()
     console.print("✓ Database schema recreated")
+
+    console.print("Syncing model metadata...")
+    with db.session() as session:
+        sync_model_metadata_with_session(session)
+        session.commit()
+    console.print("✓ Model metadata synced")
     console.print("\nTo sync specimens, use: props db sync-specimen --code-tar <tar> --data-yaml <yaml>")
 
 

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -26,6 +26,7 @@ py_library(
         "//props/db:database",
         "//props/db:setup",
         "//props/db/sync",
+        "//props/db/sync:model_metadata",
         "//test_util:image_loader",
         "//third_party/containers:rlocations",
         "@pypi//opentelemetry_api",

--- a/props/testing/fixtures/db.py
+++ b/props/testing/fixtures/db.py
@@ -20,6 +20,7 @@ from bazel_util.runfiles import get_required_path
 from props.db.config import DatabaseConfig
 from props.db.database import Database
 from props.db.setup import ensure_database_exists
+from props.db.sync.model_metadata import sync_model_metadata_with_session
 from props.db.sync.sync import SpecimenBundle, sync_specimen
 from test_util.image_loader import load_image
 from third_party.containers.rlocations import POSTGRES_16_TARBALL, RYUK_TARBALL
@@ -167,6 +168,7 @@ def _sync_test_fixtures(db: Database, monkeypatch: pytest.MonkeyPatch) -> None:
     fixture_slugs = ["test-fixtures/test1", "test-fixtures/train1", "test-fixtures/valid1", "test-fixtures/valid2"]
 
     with db.session() as session:
+        sync_model_metadata_with_session(session)
         for slug in fixture_slugs:
             base_path = f"props/testing/fixtures/testdata/specimens/{slug}"
             code_tar = get_required_path(f"_main/{base_path}/specimen_code.tar")


### PR DESCRIPTION
## Summary
Add automatic model metadata synchronization to the database recreation workflow, ensuring that model metadata is properly initialized when the database schema is recreated.

## Key Changes
- **Database recreation**: Modified `cmd_db_recreate()` to call `sync_model_metadata_with_session()` after schema recreation, ensuring model metadata is synced alongside schema setup
- **Test fixtures**: Updated `_sync_test_fixtures()` to sync model metadata before syncing specimen fixtures, establishing proper metadata state for test data
- **Dependencies**: Added `model_metadata` module imports and build dependencies to both CLI and testing fixture modules
- **Documentation**: Updated skill documentation to clarify that `test_props` is for manual live deployment testing, not standard Bazel tests

## Implementation Details
- Model metadata synchronization is now a required step in the database initialization pipeline
- The sync operation uses the existing `sync_model_metadata_with_session()` utility with proper session management and commit handling
- Changes maintain backward compatibility while ensuring consistent database state across initialization paths

https://claude.ai/code/session_01AXzNpEoayEKLryBes1F21h