### PR TITLE
Upgrade protobuf dependency from 29.3 to 32.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "1.8.3")
 bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "protobuf", version = "29.3")
+bazel_dep(name = "protobuf", version = "32.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2")
 bazel_dep(name = "aspect_rules_lint", version = "2.0.0")


### PR DESCRIPTION
## Summary
This PR updates the protobuf Bazel dependency to a newer version.

## Changes
- Updated `protobuf` dependency version from `29.3` to `32.1` in MODULE.bazel

## Details
This is a minor version bump that brings in the latest protobuf improvements and bug fixes. The upgrade spans 3 minor versions (29.3 → 32.1), which may include new features and enhancements to the protobuf tooling and libraries used in the build system.

https://claude.ai/code/session_01PDPcCahBtxvvsjsxTZgENt