### PR TITLE
Add workflow to promote props-backend image to :latest on CI success

### DIFF
--- a/.github/workflows/props-backend-image.yml
+++ b/.github/workflows/props-backend-image.yml
@@ -7,8 +7,7 @@
 #   - workflow_call (from ci.yml): tags :<sha>
 #   - workflow_dispatch: tags :latest + :<sha>
 #
-# TODO: auto-trigger :latest push on green props tests on devel
-#   (e.g., on: workflow_run targeting the CI workflow with props test success)
+# :latest promotion on green CI is handled by props-backend-promote.yml.
 name: Props Backend Image
 
 on:

--- a/.github/workflows/props-backend-promote.yml
+++ b/.github/workflows/props-backend-promote.yml
@@ -1,0 +1,43 @@
+# Promote the props-backend container image to :latest after successful CI.
+#
+# When CI completes successfully on devel/main/master, the props-backend-image
+# job has already built and pushed a :<sha> image. This workflow re-tags that
+# image as :latest.
+#
+# On devel/main/master CI uses the "full" strategy (all targets), so
+# props-backend-image always runs and tests always cover //props/....
+# A green CI conclusion therefore implies both passing tests and a built image.
+name: Promote Props Backend to Latest
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [devel, main, master]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/props-backend
+
+jobs:
+  promote:
+    name: Promote to latest
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote SHA image to :latest
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          docker pull "${{ env.IMAGE }}:$SHA"
+          docker tag "${{ env.IMAGE }}:$SHA" "${{ env.IMAGE }}:latest"
+          docker push "${{ env.IMAGE }}:latest"


### PR DESCRIPTION
## Summary
This PR implements automatic promotion of the props-backend container image to the `:latest` tag when CI completes successfully on the main branches (devel, main, master).

## Key Changes
- **New workflow**: Added `.github/workflows/props-backend-promote.yml` that automatically re-tags the SHA-specific image as `:latest` after successful CI completion
- **Updated documentation**: Modified `.github/workflows/props-backend-image.yml` to reference the new promotion workflow instead of the TODO comment

## Implementation Details
The new promotion workflow:
- Triggers on successful completion of the CI workflow on devel/main/master branches
- Pulls the already-built image tagged with the commit SHA (built by props-backend-image.yml during CI)
- Re-tags it as `:latest` and pushes it to GHCR
- Requires `packages: write` permission to push images
- Only runs when CI conclusion is `success`, ensuring only validated images are promoted

This approach leverages the existing CI infrastructure where props-backend-image is already built and pushed with a SHA tag, avoiding redundant builds while ensuring only green CI results promote to latest.

https://claude.ai/code/session_01SdmHnP8q15xQQ83BkGFAoe