### PR TITLE
Fix takethetime package name mapping in Gazelle Python manifest

### DIFF
--- a/tools/gazelle_python.yaml
+++ b/tools/gazelle_python.yaml
@@ -462,7 +462,7 @@ manifest:
     supervisor: supervisor
     syrupy: syrupy
     tabulate: tabulate
-    takethetime: TakeTheTime
+    takethetime: takethetime
     tenacity: tenacity
     termcolor: termcolor
     terminado: terminado
@@ -562,4 +562,4 @@ manifest:
     zmq: pyzmq
   pip_repository:
     name: pypi
-integrity: 707cbce97956f39b12dae8529ad61a9ec34eb234e529162d6c7e1bd77f8f90c5
+integrity: da2cb3f2073d678556b9d78a2105decfd61f632168f15bbf7a1ddad7800141b8


### PR DESCRIPTION
## Summary
Corrected the package name mapping for the `takethetime` dependency in the Gazelle Python manifest configuration.

## Changes
- Fixed the import name mapping for `takethetime` from `TakeTheTime` to `takethetime` to match the actual package name used in imports

## Details
The `takethetime` package uses lowercase naming in its import statements, not the mixed-case `TakeTheTime` variant. This correction ensures that Gazelle Python can properly resolve and manage this dependency when processing Python build targets.

https://claude.ai/code/session_011YWfrbsbSPMbWUzUPaCZzc