### PR TITLE
fix: pass canary=False when writing Docker daemon.json

### DIFF
--- a/tools/claude_hooks/docker_service.py
+++ b/tools/claude_hooks/docker_service.py
@@ -87,7 +87,7 @@ def setup_docker_config(settings: HookSettings, tmpfs_root: Path | None) -> tupl
     }
 
     config_path = docker_dir / "daemon.json"
-    write_config(config_path, json.dumps(daemon_config, indent=2), "daemon.json")
+    write_config(config_path, json.dumps(daemon_config, indent=2), "daemon.json", canary=False)
 
     return config_path, driver
 


### PR DESCRIPTION
## Summary

- `write_config()` prepends a `# CANARY:SESSION_START_HOOK` header by default
- Docker's `daemon.json` is JSON, which doesn't support `#` comments
- Docker failed to start with: `invalid character '#' looking for beginning of value`

Fix: pass `canary=False` to `write_config()` for `daemon.json` (as documented in `managed_files.py`: "use canary=False for formats like JSON that don't support comments").

## Test plan

- [ ] Session start no longer produces the Docker daemon.json parse error
- [ ] Docker service starts successfully when `container_runtime=docker`

https://claude.ai/code/session_01PGc6hiDzuoscrMcRzV3eR9