### PR TITLE
Remove Gazelle directives from BUILD files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,9 +17,6 @@
 #
 # Non-standard import paths (import name doesn't match directory structure)
 # gazelle:resolve py samplebooks_parts_data //inventree_utils:samplebooks_parts_data
-#
-# Root-level targets with non-standard import paths
-# gazelle:resolve py fmt_util.fmt_util //fmt_util:fmt_util
 
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//rules:native_binary.bzl", "native_test")

--- a/difftree/BUILD.bazel
+++ b/difftree/BUILD.bazel
@@ -1,6 +1,3 @@
-# gazelle:python_library_naming_convention $package_name$_lib
-# gazelle:resolve py difftree.cli //difftree:cli
-# gazelle:resolve py difftree.cli.main //difftree:cli
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/testing:defs.bzl", "py_test")
 

--- a/finance/reconcile/BUILD.bazel
+++ b/finance/reconcile/BUILD.bazel
@@ -1,5 +1,4 @@
 # gazelle:ignore
-# gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 py_library(

--- a/git_commit_ai/BUILD.bazel
+++ b/git_commit_ai/BUILD.bazel
@@ -1,6 +1,5 @@
 """Git commit AI package."""
 
-# gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
 load("//tools/testing:defs.bzl", "py_test")

--- a/gmail_archiver/BUILD.bazel
+++ b/gmail_archiver/BUILD.bazel
@@ -1,4 +1,3 @@
-# gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/testing:defs.bzl", "py_test")
 

--- a/inop/BUILD.bazel
+++ b/inop/BUILD.bazel
@@ -1,8 +1,5 @@
 """Instruction optimizer package."""
 
-# gazelle:resolve py inop.engine.optimizer //inop/engine:optimizer
-# gazelle:resolve py inop.engine //inop/engine:optimizer
-
 load("@rules_python//python:defs.bzl", "py_library")
 load("//tools/testing:defs.bzl", "py_test")
 

--- a/llm/claude_linter/BUILD.bazel
+++ b/llm/claude_linter/BUILD.bazel
@@ -1,6 +1,3 @@
-# gazelle:resolve py llm.claude_linter.cli //llm/claude_linter:cli
-# gazelle:resolve py llm.claude_linter.cli.cli //llm/claude_linter:cli
-
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/testing:defs.bzl", "py_test")
 

--- a/props/BUILD.bazel
+++ b/props/BUILD.bazel
@@ -1,5 +1,3 @@
-# gazelle:python_generation_mode file
-# gazelle:python_library_naming_convention $package_name$_lib
 # Props workspace - top-level package
 
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")

--- a/props/cli/BUILD.bazel
+++ b/props/cli/BUILD.bazel
@@ -1,6 +1,5 @@
 # Props has complex inter-package dependencies that are manually configured
 
-# gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 # =============================================================================

--- a/tools/yamllint/BUILD.bazel
+++ b/tools/yamllint/BUILD.bazel
@@ -1,4 +1,3 @@
-# gazelle:python_library_naming_convention $package_name$_lib
 load("@rules_python//python:defs.bzl", "py_binary")
 
 # Yamllint tool for YAML linting in Bazel


### PR DESCRIPTION
## Summary
This PR removes Gazelle configuration directives from multiple BUILD files across the repository. These directives were used to configure Gazelle's Python code generation behavior, including custom import path resolution and library naming conventions.

## Key Changes
- Removed `gazelle:resolve py` directives that manually specified import path mappings for:
  - `fmt_util.fmt_util` in root BUILD.bazel
  - `difftree.cli` and `difftree.cli.main` in difftree/BUILD.bazel
  - `inop.engine` and `inop.engine.optimizer` in inop/BUILD.bazel
  - `llm.claude_linter.cli` and `llm.claude_linter.cli.cli` in llm/claude_linter/BUILD.bazel

- Removed `gazelle:python_library_naming_convention $package_name$_lib` directives from:
  - difftree/BUILD.bazel
  - props/BUILD.bazel
  - finance/reconcile/BUILD.bazel
  - git_commit_ai/BUILD.bazel
  - gmail_archiver/BUILD.bazel
  - props/cli/BUILD.bazel
  - tools/yamllint/BUILD.bazel

- Removed `gazelle:python_generation_mode file` directive from props/BUILD.bazel

## Rationale
These directives appear to be no longer necessary, likely due to:
- Changes in Gazelle's default behavior or configuration
- Refactoring of package structures to align with standard conventions
- Centralized Gazelle configuration that supersedes these local directives

The removal simplifies BUILD files by eliminating redundant or obsolete configuration.

https://claude.ai/code/session_015ngPzqM18iwmFiYJdKCDoA