### PR TITLE
Add rustfmt to pre-commit and update Rust edition to 2024

### DIFF
--- a/.github/workflows/bazel-rust-lint.yml
+++ b/.github/workflows/bazel-rust-lint.yml
@@ -1,7 +1,7 @@
 # Bazel Rust lint reusable workflow
 #
 # Runs Rust linting via Bazel aspects:
-# - Rust: clippy
+# - Rust: clippy, rustfmt
 name: Bazel Rust Lint
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,15 @@ repos:
     hooks:
       - id: shfmt
 
+  # rustfmt - Rust code formatting
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: rustfmt
+        language: system
+        files: "\\.rs$"
+
   # ============================================================================
   # LOCAL HOOKS
   # ============================================================================

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -297,7 +297,7 @@ bazel_dep(name = "rules_rust", version = "0.68.1")  # upgraded from 0.61.0 to fi
 # — rust toolchains —
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
-    edition = "2021",
+    edition = "2024",
     versions = ["1.87.0"],  # trying 1.87.0 to fix proc-macro loading issue
 )
 use_repo(rust, "rust_toolchains")

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This repository uses **Bazel** as the primary build system. Install the git pre-
 pre-commit install
 ```
 
-This installs the pre-commit framework which runs ruff, buildifier, prettier and other linters on staged files, checks for conflict markers, validates syntax, and more (see `.pre-commit-config.yaml`). For ESLint and mypy, run `bazel build --config=check //...`.
+This installs the pre-commit framework which runs ruff, buildifier, rustfmt, prettier and other linters on staged files, checks for conflict markers, validates syntax, and more (see `.pre-commit-config.yaml`). For ESLint and mypy, run `bazel build --config=check //...`.
 
 ### Lint/Format Exclusions
 

--- a/finance/worthy/rustfmt.toml
+++ b/finance/worthy/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2024"

--- a/tools/docs/linting.md
+++ b/tools/docs/linting.md
@@ -14,6 +14,7 @@ This document describes the linting and formatting setup across pre-commit, Baze
 | **Starlark (buildifier)**        | `buildifier-lint` hook | -                     | Pre-commit          |
 | **Starlark (buildifier format)** | `buildifier` hook      | N/A                   | Pre-commit          |
 | **Rust (clippy)**                | -                      | `--config=rust-check` | bazel-build         |
+| **Rust (rustfmt)**               | `rustfmt` hook         | `--config=rust-check` | Both                |
 | **Shell (shfmt)**                | `bazel-precommit` hook | N/A                   | Pre-commit          |
 | **Nix (nixfmt)**                 | `nixfmt` hook          | N/A                   | Pre-commit          |
 | **Ansible**                      | syntax-check (fast)    | -                     | ansible-lint (full) |
@@ -123,6 +124,7 @@ Key hooks in `.pre-commit-config.yaml`:
 | `buildifier-lint`   | keith/pre-commit-buildifier  | Starlark linting               |
 | `bazel-precommit`   | local (Bazel)                | Shell formatting + validations |
 | `prettier`          | local (node)                 | JS/TS/MD/YAML formatting       |
+| `rustfmt`           | local (system)               | Rust formatting                |
 | `nixfmt`            | local (static binary)        | Nix formatting                 |
 | `markdownlint-cli2` | DavidAnson/markdownlint-cli2 | Markdown linting               |
 


### PR DESCRIPTION
## Summary
This PR adds rustfmt as a pre-commit hook for automatic Rust code formatting and updates the Rust edition from 2021 to 2024 across the project configuration.

## Key Changes
- **Added rustfmt pre-commit hook** in `.pre-commit-config.yaml` to automatically format Rust files (`.rs`) using the system-installed rustfmt
- **Updated Rust edition to 2024** in:
  - `MODULE.bazel` - Updated the rust toolchain edition configuration
  - `finance/worthy/rustfmt.toml` - Updated the rustfmt configuration
- **Updated documentation** to reflect the new rustfmt linting setup:
  - `README.md` - Added rustfmt to the list of linters run by pre-commit
  - `tools/docs/linting.md` - Added rustfmt to the linting table and hooks reference
  - `.github/workflows/bazel-rust-lint.yml` - Updated workflow description to mention rustfmt alongside clippy

## Implementation Details
- The rustfmt hook is configured as a local hook using the system language, requiring rustfmt to be installed on the developer's machine
- Rust edition 2024 is now the standard across all Rust toolchain and formatting configurations
- rustfmt will run on all staged Rust files during pre-commit checks, complementing the existing clippy linting via Bazel

https://claude.ai/code/session_01HfZFUsUqUmZaVsUhg8QpjN