### PR TITLE
Use session_dir instead of cache_dir for kubeconfig setup

### DIFF
--- a/tools/claude_hooks/kubeconfig_setup.py
+++ b/tools/claude_hooks/kubeconfig_setup.py
@@ -31,7 +31,7 @@ class KubeconfigSecret(BaseModel):
 
 
 def setup_kubeconfig(
-    cache_dir: Path, secret: KubeconfigSecret, env_vars: dict[str, str], proxy_ca_pem: str | None = None
+    session_dir: Path, secret: KubeconfigSecret, env_vars: dict[str, str], proxy_ca_pem: str | None = None
 ) -> Path:
     """Build and write a kubeconfig from typed secret fields.
 
@@ -60,7 +60,7 @@ def setup_kubeconfig(
         "users": [{"name": "claude-code-web", "user": {"token": secret.token}}],
     }
 
-    kubeconfig_path = cache_dir / "kubeconfig"
+    kubeconfig_path = session_dir / "kubeconfig"
     kubeconfig_path.write_text(yaml.dump(kubeconfig, default_flow_style=False))
     kubeconfig_path.chmod(0o600)
 

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -638,10 +638,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
             proxy_ca_file = settings.get_auth_proxy_ca_file()
             proxy_ca_pem = proxy_ca_file.read_text() if proxy_ca_file.exists() else None
             kubeconfig_setup.setup_kubeconfig(
-                cache_dir=settings.get_cache_dir(),
-                secret=secrets.kubeconfig,
-                env_vars=secrets.env_vars,
-                proxy_ca_pem=proxy_ca_pem,
+                session_dir=session_dir, secret=secrets.kubeconfig, env_vars=secrets.env_vars, proxy_ca_pem=proxy_ca_pem
             )
 
     # Render session bazelrc (unified for web mode with proxy configuration)


### PR DESCRIPTION
## Summary
Updated the kubeconfig setup to use `session_dir` instead of `cache_dir` for storing the kubeconfig file, providing better separation between session-specific and cached data.

## Changes
- Modified `setup_kubeconfig()` function signature to accept `session_dir: Path` parameter instead of `cache_dir: Path`
- Updated kubeconfig file path from `cache_dir / "kubeconfig"` to `session_dir / "kubeconfig"`
- Updated the call site in `session_start.py` to pass `session_dir` instead of `settings.get_cache_dir()`

## Details
This change improves the organization of kubeconfig files by storing them in session-specific directories rather than a shared cache directory. This ensures each session has its own isolated kubeconfig configuration, which is more appropriate for session-scoped credentials and configuration.

https://claude.ai/code/session_017sbQejXRgtFH5XykaF5Eym