### PR TITLE
Move all session-scoped outputs into per-session directory

### DIFF
--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -82,10 +82,8 @@ def install_bazelisk(settings: HookSettings) -> Path:
     The wrapper script in ~/.cache/claude-hooks/auth-proxy/bin/bazel will call this.
     Skips download if already installed.
     """
-    auth_proxy_dir = settings.get_auth_proxy_dir()
     bazelisk_path = settings.get_bazelisk_path()
-
-    auth_proxy_dir.mkdir(parents=True, exist_ok=True)
+    bazelisk_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Check if already installed
     if get_bazelisk_version(settings):

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from tools.claude_hooks.managed_files import write_config
 from tools.claude_hooks.proxy_setup import SSL_CA_ENV_VARS
-from tools.claude_hooks.settings import ENV_SUPERVISOR_PORT
+from tools.claude_hooks.settings import ENV_SESSION_DIR, ENV_SUPERVISOR_PORT
 
 # Runtime env var names (written by session hook, read by bazel_wrapper)
 ENV_AUTH_PROXY_PORT = "AUTH_PROXY_PORT"
@@ -66,6 +66,9 @@ class EnvVars:
     All environment variables that need to be exported are collected
     throughout the session hook setup and written once at the end.
     """
+
+    # Per-session directory (exported so subprocesses like bazel_wrapper inherit it)
+    session_dir: Path
 
     # Auth proxy and Bazel configuration
     proxy_port: int
@@ -120,6 +123,7 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     local_proxy = f"http://localhost:{vars.proxy_port}"
 
     auth_proxy_config: dict[str, str | Path] = {
+        ENV_SESSION_DIR: vars.session_dir,
         ENV_AUTH_PROXY_PORT: str(vars.proxy_port),
         ENV_AUTH_PROXY_URL: local_proxy,
         ENV_BAZELISK_PATH: vars.bazelisk_path,

--- a/tools/claude_hooks/mkcert_setup.py
+++ b/tools/claude_hooks/mkcert_setup.py
@@ -34,11 +34,11 @@ class MkcertSetup:
 
 
 def _get_mkcert_dir(settings: HookSettings) -> Path:
-    return settings.get_cache_dir() / "mkcert"
+    return settings.get_mkcert_dir()
 
 
 def _get_mkcert_binary(settings: HookSettings) -> Path:
-    return _get_mkcert_dir(settings) / "mkcert"
+    return settings.get_mkcert_binary()
 
 
 def _get_download_url() -> str:

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -136,19 +136,12 @@ def _render_session_bazelrc(
     return bazelrc_path
 
 
-def _get_session_bin_dir(session_dir: Path) -> Path:
-    """Create and return the session-scoped bin directory for tools and wrappers."""
-    bin_dir = session_dir / "bin"
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    return bin_dir
-
-
 # ============================================================================
 # CLI mode: per-session bazel wrapper with direnv integration
 # ============================================================================
 
 
-async def run_cli_mode(hook_input: HookInput, settings: HookSettings) -> None:
+async def run_cli_mode(hook_input: HookInput, settings: HookSettings, env_file_path: Path) -> None:
     """CLI mode: set up per-session bazel wrapper and direnv eval.
 
     Renders a per-session bazelrc (with --config=ai_agent for quiet output),
@@ -156,7 +149,7 @@ async def run_cli_mode(hook_input: HookInput, settings: HookSettings) -> None:
     wrapper on PATH and direnv eval for .envrc propagation.
     """
     _collector, log_file = setup_logging(settings, print_banner=False)
-    tracer, trace_file = init_tracing(hook_input.session_id, settings.get_cache_dir())
+    tracer, trace_file = init_tracing(hook_input.session_id, settings.session_dir)
 
     with tracer.start_as_current_span(
         "session_start_cli", attributes={"session.id": hook_input.session_id, "hook.source": hook_input.source}
@@ -165,17 +158,9 @@ async def run_cli_mode(hook_input: HookInput, settings: HookSettings) -> None:
         logger.info("Hook input: %s", hook_input.model_dump_json())
         log_entrypoint_debug("session_start")
 
-        env_file_path = os.environ.get("CLAUDE_ENV_FILE")
-        if not env_file_path:
-            logger.warning("CLAUDE_ENV_FILE not available")
-            shutdown_tracing()
-            return
-
-        session_dir = settings.get_session_dir(Path(env_file_path))
-
         with tracer.start_as_current_span("render_bazelrc"):
             session_bazelrc = _render_session_bazelrc(
-                session_dir,
+                settings.session_dir,
                 web_proxy=False,
                 proxy_port=None,
                 truststore_path=None,
@@ -187,13 +172,14 @@ async def run_cli_mode(hook_input: HookInput, settings: HookSettings) -> None:
             )
 
         with tracer.start_as_current_span("install_bazel_wrappers"):
-            bin_dir = _get_session_bin_dir(session_dir)
-            bazelisk_setup.install_wrapper(settings, wrapper_dir=bin_dir)
+            bazelisk_setup.install_wrapper(settings)
 
         with tracer.start_as_current_span("write_env_file"):
-            env_file.write_cli_env_file(Path(env_file_path), wrapper_dir=bin_dir, session_bazelrc=session_bazelrc)
+            env_file.write_cli_env_file(
+                env_file_path, wrapper_dir=settings.get_wrapper_dir(), session_bazelrc=session_bazelrc
+            )
 
-        logger.info("CLI session configured: %s", session_dir)
+        logger.info("CLI session configured: %s", settings.session_dir)
         print(f"Claude Code CLI session configured (log: {log_file})")
 
     shutdown_tracing()
@@ -350,7 +336,7 @@ def setup_logging(settings: HookSettings, *, print_banner: bool = True) -> tuple
 
     Returns (LogCollector, log_file_path) tuple.
     """
-    log_file = settings.get_cache_dir() / "session-start.log"
+    log_file = settings.get_log_file()
 
     formatter = logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
     collector = LogCollector()
@@ -390,7 +376,7 @@ async def run_in_thread(func, *args):
 # ============================================================================
 
 
-async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
+async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_path: Path) -> None:
     """Web mode with parallelized operations.
 
     Uses asyncio to parallelize independent installations (git hook, cluster
@@ -400,7 +386,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
     variables.
     """
     collector, log_file = setup_logging(settings)
-    tracer, trace_file = init_tracing(hook_input.session_id, settings.get_cache_dir())
+    tracer, trace_file = init_tracing(hook_input.session_id, settings.session_dir)
     root_span = tracer.start_span(
         "session_start_web", attributes={"session.id": hook_input.session_id, "hook.source": hook_input.source}
     )
@@ -414,16 +400,10 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
     logger.info("Setting up dev environment...")
     logger.info(format_environment_summary())
 
-    # Get required environment variables (fail early if missing)
-    env_file_path = env_utils.get_required_env_path("CLAUDE_ENV_FILE")
-
     # Get required project directory
     project_dir = env_utils.get_required_env_path("CLAUDE_PROJECT_DIR")
     logger.info("CLAUDE_PROJECT_DIR: %s", project_dir)
-
-    # Session directory (unified for both web and CLI modes)
-    session_dir = settings.get_session_dir(env_file_path)
-    logger.info("Session directory: %s", session_dir)
+    logger.info("Session directory: %s", settings.session_dir)
 
     # --- Traced async helpers ---
     # Each helper creates its own child span under root_ctx so the parallel
@@ -618,7 +598,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
 
     # Generate timestamp
     hook_timestamp = datetime.now()
-    timestamp_file = settings.get_cache_dir() / "session-hook-last-run"
+    timestamp_file = settings.session_dir / "session-hook-last-run"
     timestamp_file.write_text(f"{hook_timestamp.isoformat()}\n")
     logger.info("Session start hook timestamp: %s", hook_timestamp.isoformat())
 
@@ -638,7 +618,10 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
             proxy_ca_file = settings.get_auth_proxy_ca_file()
             proxy_ca_pem = proxy_ca_file.read_text() if proxy_ca_file.exists() else None
             kubeconfig_setup.setup_kubeconfig(
-                session_dir=session_dir, secret=secrets.kubeconfig, env_vars=secrets.env_vars, proxy_ca_pem=proxy_ca_pem
+                session_dir=settings.session_dir,
+                secret=secrets.kubeconfig,
+                env_vars=secrets.env_vars,
+                proxy_ca_pem=proxy_ca_pem,
             )
 
     # Render session bazelrc (unified for web mode with proxy configuration)
@@ -651,7 +634,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
             logger.info("Found local registry at %s (patched ape for native ELF)", local_registry)
 
         session_bazelrc = _render_session_bazelrc(
-            session_dir,
+            settings.session_dir,
             web_proxy=True,
             proxy_port=proxy_port,
             truststore_path=truststore,
@@ -684,6 +667,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings) -> None:
         mkcert_key = mkcert.key_path
 
     env_vars = env_file.EnvVars(
+        session_dir=settings.session_dir,
         proxy_port=settings.get_auth_proxy_port(),
         supervisor_port=settings.get_supervisor_port(),
         repo_root=project_dir,
@@ -755,12 +739,13 @@ async def async_main() -> None:
         print(f"Raw input JSON:\n{raw_input}", file=sys.stderr)
         raise
 
-    settings = HookSettings()
+    env_file_path = env_utils.get_required_env_path("CLAUDE_ENV_FILE")
+    settings = HookSettings(session_dir=env_file_path.parent)
 
     if os.environ.get("CLAUDE_CODE_REMOTE") == "true":
-        await run_web_mode(hook_input, settings)
+        await run_web_mode(hook_input, settings, env_file_path)
     else:
-        await run_cli_mode(hook_input, settings)
+        await run_cli_mode(hook_input, settings, env_file_path)
 
 
 def main() -> None:

--- a/tools/claude_hooks/settings.py
+++ b/tools/claude_hooks/settings.py
@@ -46,6 +46,7 @@ ENV_INSTALL_NIX = _env_name("install_nix")
 ENV_CONTAINER_RUNTIME = _env_name("container_runtime")
 ENV_SYSTEM_BAZEL = _env_name("system_bazel")
 ENV_USE_WHEEL = _env_name("use_wheel")
+ENV_SESSION_DIR = _env_name("session_dir")
 
 
 class HookSettings(BaseSettings):
@@ -89,6 +90,11 @@ class HookSettings(BaseSettings):
     # Test configuration
     use_wheel: bool = Field(default=False, description="Use installed wheel instead of source")
 
+    # Per-session output directory. Exported as DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR so
+    # subprocesses (e.g. bazel_wrapper) pick it up automatically via pydantic-settings.
+    # All session-scoped outputs (auth-proxy CAs, supervisor, bin wrappers, etc.) go here.
+    session_dir: Path = Field(description="Per-session output directory")
+
     def get_cache_dir(self) -> Path:
         """Get base cache directory for claude-hooks (auto-created)."""
         return Path(user_cache_dir(appname="claude-hooks", ensure_exists=True))
@@ -101,7 +107,7 @@ class HookSettings(BaseSettings):
         """Get supervisor configuration directory."""
         if self.supervisor_dir is not None:
             return self.supervisor_dir
-        return self.get_config_dir() / "supervisor"
+        return self.session_dir / "supervisor"
 
     def get_supervisor_pidfile(self) -> Path:
         """Get supervisor pidfile path."""
@@ -115,7 +121,7 @@ class HookSettings(BaseSettings):
         """Get auth proxy cache directory."""
         if self.auth_proxy_dir is not None:
             return self.auth_proxy_dir
-        return self.get_cache_dir() / "auth-proxy"
+        return self.session_dir / "auth-proxy"
 
     def get_auth_proxy_port(self) -> int:
         """Get auth proxy port with default."""
@@ -125,7 +131,7 @@ class HookSettings(BaseSettings):
         """Get podman configuration and storage directory."""
         if self.podman_dir is not None:
             return self.podman_dir
-        return self.get_cache_dir() / "podman"
+        return self.session_dir / "podman"
 
     def get_containers_config_dir(self) -> Path:
         """Get user-level containers config directory (~/.config/containers).
@@ -141,10 +147,6 @@ class HookSettings(BaseSettings):
         """Get path to combined CA bundle (system CAs + proxy CA)."""
         return self.get_auth_proxy_dir() / "combined_ca.pem"
 
-    def get_auth_proxy_rc(self) -> Path:
-        """Get path to auth proxy bazelrc file."""
-        return self.get_auth_proxy_dir() / "bazelrc"
-
     def get_auth_proxy_creds_file(self) -> Path:
         """Get path to upstream proxy credentials file."""
         return self.get_auth_proxy_dir() / "upstream_proxy"
@@ -158,16 +160,28 @@ class HookSettings(BaseSettings):
         return self.get_auth_proxy_dir() / "cacerts.jks"
 
     def get_bazelisk_path(self) -> Path:
-        """Get the bazelisk binary path."""
-        return self.get_auth_proxy_dir() / "bazelisk"
+        """Get the bazelisk binary path (global cache, not session-scoped)."""
+        return self.get_cache_dir() / "bazelisk"
 
     def get_wrapper_dir(self) -> Path:
         """Get the wrapper directory (added to PATH)."""
-        return self.get_auth_proxy_dir() / "bin"
+        return self.session_dir / "bin"
 
     def get_wrapper_path(self) -> Path:
         """Get the wrapper script path."""
         return self.get_wrapper_dir() / "bazel"
+
+    def get_mkcert_dir(self) -> Path:
+        """Get mkcert directory for certs and CA (session-scoped)."""
+        return self.session_dir / "mkcert"
+
+    def get_mkcert_binary(self) -> Path:
+        """Get mkcert binary path (global cache, not session-scoped)."""
+        return self.get_cache_dir() / "mkcert"
+
+    def get_log_file(self) -> Path:
+        """Get path to session-start log file."""
+        return self.session_dir / "session-start.log"
 
     def get_session_dir(self, env_file_path: Path) -> Path:
         """Get session directory from CLAUDE_ENV_FILE path.
@@ -181,4 +195,4 @@ class HookSettings(BaseSettings):
         """Get Docker configuration directory."""
         if self.docker_dir is not None:
             return self.docker_dir
-        return self.get_cache_dir() / "docker"
+        return self.session_dir / "docker"

--- a/tools/claude_hooks/test_session_start.py
+++ b/tools/claude_hooks/test_session_start.py
@@ -301,8 +301,7 @@ async def run_session_start_hook(
 def cleanup_after_test(isolated_dirs: IsolatedDirs) -> Generator[None]:
     """Cleanup supervisor after each test."""
     yield
-    # platformdirs respects XDG_CONFIG_HOME
-    _cleanup_supervisor(isolated_dirs.config / "claude-hooks")
+    _cleanup_supervisor(isolated_dirs.env_file.parent)
 
 
 class TestFullSessionStartHook:
@@ -319,13 +318,12 @@ class TestFullSessionStartHook:
         session_dir = isolated_dirs.env_file.parent
         assert (session_dir / "bazelrc").exists(), "bazelrc not created in session directory"
 
-        # Auth proxy artifacts in cache directory
-        auth_proxy_dir = isolated_dirs.cache / "claude-hooks" / "auth-proxy"
+        # Auth proxy artifacts in session directory
+        auth_proxy_dir = isolated_dirs.env_file.parent / "auth-proxy"
         assert (auth_proxy_dir / "anthropic_ca.pem").exists(), "CA not extracted"
 
         # Verify supervisor started
-        # platformdirs respects XDG_CONFIG_HOME
-        supervisor_dir = isolated_dirs.config / "claude-hooks" / "supervisor"
+        supervisor_dir = isolated_dirs.env_file.parent / "supervisor"
         assert (supervisor_dir / "supervisord.pid").exists(), "supervisor not started"
 
     async def test_bazel_build_after_hook(
@@ -352,7 +350,7 @@ class TestFullSessionStartHook:
         # and exports truststore configuration. The wrapper injects --bazelrc and falls
         # back to system bazel if bazelisk isn't installed.
         # --output_base isolates this Bazel from the test-running Bazel.
-        supervisor_dir = isolated_dirs.config / "claude-hooks" / "supervisor"
+        supervisor_dir = isolated_dirs.env_file.parent / "supervisor"
         bazel_result: subprocess.CompletedProcess[str] | None = None
         try:
             async with asyncio.timeout(60):
@@ -375,8 +373,7 @@ class TestFullSessionStartHook:
     async def test_stale_socket_recovery(self, isolated_dirs: IsolatedDirs, hook_env: None) -> None:
         """Verify hook recovers from stale supervisor socket."""
         # Create stale socket/pidfile
-        # platformdirs respects XDG_CONFIG_HOME
-        supervisor_dir = isolated_dirs.config / "claude-hooks" / "supervisor"
+        supervisor_dir = isolated_dirs.env_file.parent / "supervisor"
         supervisor_dir.mkdir(parents=True, exist_ok=True)
         (supervisor_dir / "supervisor.sock").touch()
         (supervisor_dir / "supervisord.pid").write_text("99999")  # Non-existent PID
@@ -470,7 +467,7 @@ class TestPodmanIntegration:
         assert socket_path.exists(), f"Podman socket not created at {socket_path}"
 
         # Collect supervisor logs (including podman daemon) for CI debugging
-        supervisor_dir = isolated_dirs.config / "claude-hooks" / "supervisor"
+        supervisor_dir = isolated_dirs.env_file.parent / "supervisor"
         collect_supervisor_logs(supervisor_dir)
 
         # Verify we can run podman hello-world through the proxy

--- a/tools/claude_hooks/testing/fixtures.py
+++ b/tools/claude_hooks/testing/fixtures.py
@@ -39,29 +39,35 @@ class MockEgressProxyFixture:
 class IsolatedSupervisorDirs:
     """Isolated directories for supervisor/proxy testing."""
 
+    session_dir: Path
     supervisor_dir: Path
     auth_proxy_dir: Path
 
 
 @pytest.fixture
 def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[IsolatedSupervisorDirs]:
-    """Create isolated supervisor + auth proxy dirs with free ports.
+    """Create isolated session/supervisor/auth-proxy dirs with free ports.
 
     Sets environment variables so HookSettings() picks them up.
     Cleans up any supervisor processes on teardown.
     """
-    supervisor_dir = tmp_path / "supervisor"
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    supervisor_dir = session_dir / "supervisor"
     supervisor_dir.mkdir()
-    auth_proxy_dir = tmp_path / "auth-proxy"
+    auth_proxy_dir = session_dir / "auth-proxy"
     auth_proxy_dir.mkdir()
 
+    monkeypatch.setenv(settings.ENV_SESSION_DIR, str(session_dir))
     monkeypatch.setenv(settings.ENV_SUPERVISOR_DIR, str(supervisor_dir))
     monkeypatch.setenv(settings.ENV_SUPERVISOR_PORT, str(pick_free_port()))
     monkeypatch.setenv(settings.ENV_AUTH_PROXY_DIR, str(auth_proxy_dir))
     monkeypatch.setenv(settings.ENV_AUTH_PROXY_PORT, str(pick_free_port()))
 
     with supervisor_cleanup(supervisor_dir / "supervisord.pid"):
-        yield IsolatedSupervisorDirs(supervisor_dir=supervisor_dir, auth_proxy_dir=auth_proxy_dir)
+        yield IsolatedSupervisorDirs(
+            session_dir=session_dir, supervisor_dir=supervisor_dir, auth_proxy_dir=auth_proxy_dir
+        )
 
     # Collect supervisor logs into test outputs for CI debugging
     collect_supervisor_logs(supervisor_dir)
@@ -70,7 +76,7 @@ def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[
 @pytest.fixture
 def hook_settings(isolated_dirs: IsolatedSupervisorDirs) -> HookSettings:
     """HookSettings wired to isolated dirs."""
-    return HookSettings()
+    return HookSettings(session_dir=isolated_dirs.session_dir)
 
 
 @pytest.fixture

--- a/tools/claude_hooks/tracing.py
+++ b/tools/claude_hooks/tracing.py
@@ -23,14 +23,12 @@ def _format_span(span: ReadableSpan) -> str:
     return json_str + "\n"
 
 
-def init_tracing(session_id: str, cache_dir: Path) -> tuple[trace.Tracer, Path]:
+def init_tracing(session_id: str, session_dir: Path) -> tuple[trace.Tracer, Path]:
     """Initialize OTel tracing with a per-session file exporter.
 
     Returns (tracer, trace_file_path).
     """
-    traces_dir = cache_dir / "traces"
-    trace_file = traces_dir / f"{session_id}.jsonl"
-    traces_dir.mkdir(parents=True, exist_ok=True)
+    trace_file = session_dir / "traces.jsonl"
 
     resource = Resource.create({"service.name": "claude-hooks", "session.id": session_id})
     provider = TracerProvider(resource=resource)


### PR DESCRIPTION
All session-scoped directories and files now live under `<session_dir>` (parent of `CLAUDE_ENV_FILE`), which is a required field on `HookSettings` and exported as
`DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR` so subprocesses inherit it.

Session-scoped (moved):
- `supervisor/` — supervisord config, conf.d, logs
- `auth-proxy/` — proxy CAs and TLS artifacts
- `podman/` — podman config and storage
- `docker/` — docker config
- `mkcert/` — localhost cert/key (binary stays global)
- `bin/` — bazel/bazelisk wrapper trampolines
- `traces.jsonl` — OTel trace spans (flat file, no subdir)
- `session-start.log` — hook log

Global (unchanged):
- `~/.cache/claude-hooks/bazelisk` — bazelisk binary
- `~/.cache/claude-hooks/mkcert` — mkcert binary

`session_dir` is now a required field (no default); the hook always runs within a Claude Code session where `CLAUDE_ENV_FILE` is set. Tests set `session_dir` explicitly via `HookSettings(session_dir=...)`.

https://claude.ai/code/session_017sbQejXRgtFH5XykaF5Eym