### PR TITLE
fix: render cached_input and max_output_tokens in props chart

### DIFF
--- a/.claude_hooks/secrets/ollama.age
+++ b/.claude_hooks/secrets/ollama.age
@@ -1,8 +1,0 @@
-age-encryption.org/v1
--> X25519 4inLiOrKjHPdTTI2zqq6+M8AIaXgihMcTuGOmiDc5i4
-rxKGQkflLWZ00tDj8EuQ0fOdDgWZcFb9x9Ui+PewYt0
--> 4-grease ([> "'t]3al
-ZcbY5Cp8wVp4Dajrzy1/waZnQIXf1sM7hYGSKOcOE8C1JGFZp4fdxoPRpdekRbG3
-l05l2U1ZdoXF
---- UJtnax1kSJ/MMa9D2DCG22rp4oG512EAesK8Q7ZDBz0
-`ÈNS5\|÷Ì]vBe~Ò˜ãÐíÑÅ)ã0eFw¤U]ð4©“}th‚6{Å×?Tü¯¾?Øêªed+Gñ¯ábãuC4MI&dH)»h«þ/Â%fàl*T¢@wÞ>ù\WÎš¶5×ÑÍiq¢‹¢Œ8èžÈ6í…ù22"O¡o‡×åBýyve!'UúÞñû(ëGŒoyuv

--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -10,10 +10,9 @@
   Option B (fork): `git remote add fork https://github.com/agentydragon-agent/ducktape.git` (if not already configured),
     `git push fork <branch>`, then `gh pr create --repo agentydragon/ducktape --head agentydragon-agent:<branch-name> --base devel`.
 % endif
-% if "OLLAMA_API_KEY" in secrets.env_vars:
-Ollama: `OLLAMA_BASE_URL` and `OLLAMA_API_KEY` set. OpenAI-compatible LLM inference (2x RTX 5090).
-  Usage: `OpenAI(base_url=os.environ["OLLAMA_BASE_URL"], api_key=os.environ["OLLAMA_API_KEY"])`
-% endif
+Ollama: OpenAI-compatible LLM inference at `https://ollama.allegedly.works/v1` (2x RTX 5090).
+  API key in k8s secret `ollama-api-key`, key `api-key`, namespace `claude-sandbox`.
+  Retrieve: `kubectl get secret ollama-api-key -n claude-sandbox -o jsonpath='{.data.api-key}' | base64 -d`
 % if "BUILDBUDDY_API_KEY" in secrets.env_vars:
 `BUILDBUDDY_API_KEY`: BuildBuddy remote cache/execution key (also configured in ~/.config/bazel/buildbuddy.bazelrc).
 % endif

--- a/bazel_util/BUILD.bazel
+++ b/bazel_util/BUILD.bazel
@@ -27,6 +27,7 @@ py_test(
     srcs = ["test_subprocess.py"],
     deps = [
         ":subprocess",
+        "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
 )

--- a/bazel_util/subprocess.py
+++ b/bazel_util/subprocess.py
@@ -62,32 +62,41 @@ async def async_run_python_module(
     return await asyncio.create_subprocess_exec(*cmd, env=python_env(inherit=inherit_env), **kwargs)
 
 
-def generate_shell_wrapper(module: str, *, extra_lines: str = "") -> str:
+def _format_exports(env: dict[str, str]) -> str:
+    """Format a dict of env vars as shell export lines."""
+    return "\n".join(f'export {k}="{v}"' for k, v in env.items())
+
+
+def generate_shell_wrapper(module: str, *, baked_env: dict[str, str] | None = None, extra_lines: str = "") -> str:
     """Generate a ``#!/bin/sh`` script that invokes ``sys.executable -m <module>``.
 
-    The wrapper bakes the current PYTHONPATH into the script so the subprocess
-    can find packages without leaking PYTHONPATH into every child process via
-    a shared env file.
+    Bakes PYTHONPATH (and any additional ``baked_env`` entries) into the script so
+    subprocesses can find packages without leaking state via a shared env file.
 
     Args:
         module: Python module path (e.g. ``"tools.claude_hooks.bazel_wrapper"``).
-        extra_lines: Additional shell lines inserted before the ``exec``.
+        baked_env: Extra env vars to export before the exec (merged after PYTHONPATH).
+        extra_lines: Raw shell lines inserted after exports and before the ``exec``
+                     (use for dynamic expressions like ``$(...)``).
     """
     pythonpath = os.environ.get("PYTHONPATH") or os.pathsep.join(sys.path)
-    parts = ["#!/bin/sh", f'export PYTHONPATH="{pythonpath}"']
+    env = {"PYTHONPATH": pythonpath}
+    if baked_env:
+        env.update(baked_env)
+    parts = ["#!/bin/sh", _format_exports(env)]
     if extra_lines:
         parts.append(extra_lines)
     parts.append(f'exec "{sys.executable}" -m {module} "$@"')
     return "\n".join(parts) + "\n"
 
 
-def write_shell_wrapper(path: Path, module: str, *, extra_lines: str = "") -> Path:
+def write_shell_wrapper(path: Path, module: str, *, baked_env: dict[str, str] | None = None, extra_lines: str = "") -> Path:
     """Write a shell wrapper script and make it executable.
 
     See :func:`generate_shell_wrapper` for argument docs.
     Returns *path* for chaining.
     """
-    content = generate_shell_wrapper(module, extra_lines=extra_lines)
+    content = generate_shell_wrapper(module, baked_env=baked_env, extra_lines=extra_lines)
     path.write_text(content)
     path.chmod(0o755)
     return path

--- a/bazel_util/subprocess.py
+++ b/bazel_util/subprocess.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -62,9 +64,13 @@ async def async_run_python_module(
     return await asyncio.create_subprocess_exec(*cmd, env=python_env(inherit=inherit_env), **kwargs)
 
 
-def _format_exports(env: dict[str, str]) -> str:
-    """Format a dict of env vars as shell export lines."""
-    return "\n".join(f'export {k}="{v}"' for k, v in env.items())
+def exports_from_dict(env: Mapping[str, str | Path]) -> list[str]:
+    """Generate shell export lines from an env var mapping.
+
+    Values are shell-escaped with shlex.quote() to handle special characters.
+    Accepts both str and Path values.
+    """
+    return [f"export {name}={shlex.quote(str(value))}" for name, value in env.items()]
 
 
 def generate_shell_wrapper(module: str, *, baked_env: dict[str, str] | None = None, extra_lines: str = "") -> str:
@@ -83,14 +89,16 @@ def generate_shell_wrapper(module: str, *, baked_env: dict[str, str] | None = No
     env = {"PYTHONPATH": pythonpath}
     if baked_env:
         env.update(baked_env)
-    parts = ["#!/bin/sh", _format_exports(env)]
+    parts = ["#!/bin/sh", *exports_from_dict(env)]
     if extra_lines:
         parts.append(extra_lines)
     parts.append(f'exec "{sys.executable}" -m {module} "$@"')
     return "\n".join(parts) + "\n"
 
 
-def write_shell_wrapper(path: Path, module: str, *, baked_env: dict[str, str] | None = None, extra_lines: str = "") -> Path:
+def write_shell_wrapper(
+    path: Path, module: str, *, baked_env: dict[str, str] | None = None, extra_lines: str = ""
+) -> Path:
     """Write a shell wrapper script and make it executable.
 
     See :func:`generate_shell_wrapper` for argument docs.

--- a/bazel_util/test_subprocess.py
+++ b/bazel_util/test_subprocess.py
@@ -5,9 +5,16 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import pytest_bazel
 
-from bazel_util.subprocess import generate_shell_wrapper, python_env, run_python_module, write_shell_wrapper
+from bazel_util.subprocess import (
+    exports_from_dict,
+    generate_shell_wrapper,
+    python_env,
+    run_python_module,
+    write_shell_wrapper,
+)
 
 
 def test_python_env_inherit_includes_pythonpath():
@@ -59,7 +66,7 @@ def test_run_python_module_with_pathlike_args(tmp_path: Path):
 def test_generate_shell_wrapper():
     wrapper = generate_shell_wrapper("my.module")
     assert wrapper.startswith("#!/bin/sh\n")
-    assert 'export PYTHONPATH="' in wrapper
+    assert "export PYTHONPATH=" in wrapper
     assert f'exec "{sys.executable}" -m my.module "$@"' in wrapper
 
 
@@ -70,8 +77,23 @@ def test_generate_shell_wrapper_extra_lines():
 
 def test_generate_shell_wrapper_baked_env():
     wrapper = generate_shell_wrapper("my.module", baked_env={"MY_VAR": "/some/path"})
-    assert 'export MY_VAR="/some/path"' in wrapper
-    assert 'export PYTHONPATH="' in wrapper
+    assert "export MY_VAR=/some/path" in wrapper
+    assert "export PYTHONPATH=" in wrapper
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({"FOO": "bar"}, ["export FOO=bar"]),
+        ({"BAZ": "/some/path"}, ["export BAZ=/some/path"]),
+        ({"P": "/a:/b"}, ["export P=/a:/b"]),  # colon-separated paths (PYTHONPATH-style)
+        ({"DIR": Path("/some/path")}, ["export DIR=/some/path"]),  # Path values
+        ({"MSG": "hello world"}, ["export MSG='hello world'"]),  # space requires quoting
+        ({"EXPR": "a$b"}, ["export EXPR='a$b'"]),  # $ requires quoting
+    ],
+)
+def test_exports_from_dict(env: dict, expected: list[str]):
+    assert exports_from_dict(env) == expected
 
 
 def test_write_shell_wrapper(tmp_path: Path):

--- a/bazel_util/test_subprocess.py
+++ b/bazel_util/test_subprocess.py
@@ -68,6 +68,12 @@ def test_generate_shell_wrapper_extra_lines():
     assert 'export FOO="bar"' in wrapper
 
 
+def test_generate_shell_wrapper_baked_env():
+    wrapper = generate_shell_wrapper("my.module", baked_env={"MY_VAR": "/some/path"})
+    assert 'export MY_VAR="/some/path"' in wrapper
+    assert 'export PYTHONPATH="' in wrapper
+
+
 def test_write_shell_wrapper(tmp_path: Path):
     path = tmp_path / "wrapper.sh"
     result = write_shell_wrapper(path, "my.module")

--- a/cluster/k8s/claude-sandbox-secrets/externalsecret.yaml
+++ b/cluster/k8s/claude-sandbox-secrets/externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ollama-api-key
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ollama-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: kv/ollama/api-key
+        property: api_key

--- a/cluster/k8s/claude-sandbox-secrets/flux-kustomization.yaml
+++ b/cluster/k8s/claude-sandbox-secrets/flux-kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: claude-sandbox-secrets
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/claude-sandbox-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  dependsOn:
+    - name: claude-rbac
+    - name: external-secrets-config
+    - name: ollama-secrets

--- a/cluster/k8s/claude-sandbox-secrets/kustomization.yaml
+++ b/cluster/k8s/claude-sandbox-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - tofu-controller/flux-kustomization.yaml
   - reloader/flux-kustomization.yaml
   - claude-rbac/flux-kustomization.yaml
+  - claude-sandbox-secrets/flux-kustomization.yaml
   - kube-api-proxy/flux-kustomization.yaml
   - coredns-custom/flux-kustomization.yaml
   - kyverno-policies/flux-kustomization.yaml

--- a/props/helm/templates/configmap.yaml
+++ b/props/helm/templates/configmap.yaml
@@ -6,33 +6,4 @@ metadata:
     {{- include "props.labels" . | nindent 4 }}
 data:
   config.toml: |
-    backend_url = {{ .Values.config.backend_url | quote }}
-    {{- if .Values.config.grader_model }}
-    grader_model = {{ .Values.config.grader_model | quote }}
-    {{- end }}
-
-    [agent_env]
-    {{- range $key, $value := .Values.config.agent_env }}
-    {{ $key }} = {{ $value | quote }}
-    {{- end }}
-
-    [executor]
-    {{- range $key, $value := .Values.config.executor }}
-    {{ $key }} = {{ $value | quote }}
-    {{- end }}
-    {{- range $name, $upstream := .Values.config.upstreams }}
-
-    [upstreams.{{ $name }}]
-    url = {{ $upstream.url | quote }}
-    api_key_env = {{ $upstream.api_key_env | quote }}
-    {{- end }}
-    {{- range .Values.config.models }}
-
-    [[models]]
-    name = {{ .name | quote }}
-    upstream = {{ .upstream | quote }}
-    upstream_model = {{ .upstream_model | quote }}
-    input_usd_per_1m_tokens = {{ .input_usd_per_1m_tokens }}
-    output_usd_per_1m_tokens = {{ .output_usd_per_1m_tokens }}
-    context_window_tokens = {{ .context_window_tokens }}
-    {{- end }}
+    {{- .Values.config | toToml | nindent 4 }}

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -91,6 +91,7 @@ py_library(
         ":proxy_setup",
         ":proxy_vars",
         ":settings",
+        "//bazel_util:subprocess",
     ],
 )
 

--- a/tools/claude_hooks/bazelisk_setup.py
+++ b/tools/claude_hooks/bazelisk_setup.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from bazel_util.subprocess import write_shell_wrapper
 from tools.claude_hooks.platform_utils import get_platform
-from tools.claude_hooks.settings import HookSettings
+from tools.claude_hooks.settings import ENV_SESSION_DIR, HookSettings
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def install_bazelisk(settings: HookSettings) -> Path:
     return bazelisk_path
 
 
-_WRAPPER_EXTRA_LINES = (
+_WRAPPER_RUNTIME_LINES = (
     'export _BAZEL_WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"\nexport _BAZEL_WRAPPER_NAME="$(basename "$0")"'
 )
 
@@ -116,10 +116,8 @@ def install_wrapper(settings: HookSettings, *, wrapper_dir: Path | None = None) 
     The wrapper is in ~/.cache/claude-hooks/auth-proxy/bin/bazel (web mode) or a
     session-specific bin directory (CLI mode). Also creates a bazelisk symlink.
 
-    The wrapper reads configuration from environment variables (set via get_env_script).
-    It exports _BAZEL_WRAPPER_NAME and _BAZEL_WRAPPER_DIR so the Python module
-    can route to the correct binary (bazel vs bazelisk) and skip its own directory
-    when searching PATH.
+    Bakes DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR into the script so subprocesses
+    (pre-commit, CI) that don't source the env file still have the session dir set.
 
     Args:
         settings: Hook settings
@@ -131,7 +129,12 @@ def install_wrapper(settings: HookSettings, *, wrapper_dir: Path | None = None) 
 
     wrapper_dir.mkdir(parents=True, exist_ok=True)
 
-    write_shell_wrapper(wrapper_path, "tools.claude_hooks.bazel_wrapper", extra_lines=_WRAPPER_EXTRA_LINES)
+    write_shell_wrapper(
+        wrapper_path,
+        "tools.claude_hooks.bazel_wrapper",
+        baked_env={ENV_SESSION_DIR: str(settings.session_dir)},
+        extra_lines=_WRAPPER_RUNTIME_LINES,
+    )
     logger.info("Installed bazel wrapper at %s", wrapper_path)
 
     # Create bazelisk symlink for pre-commit hooks

--- a/tools/claude_hooks/env_file.py
+++ b/tools/claude_hooks/env_file.py
@@ -6,13 +6,12 @@ Centralizes all environment variable exports into a single file write.
 from __future__ import annotations
 
 import os
-import shlex
 import shutil
-from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from bazel_util.subprocess import exports_from_dict
 from tools.claude_hooks.managed_files import write_config
 from tools.claude_hooks.proxy_setup import SSL_CA_ENV_VARS
 from tools.claude_hooks.settings import ENV_SESSION_DIR, ENV_SUPERVISOR_PORT
@@ -48,15 +47,6 @@ def _strip_no_proxy_google() -> dict[str, str] | None:
 
     cleaned = ",".join(filtered)
     return {"NO_PROXY": cleaned, "no_proxy": cleaned}
-
-
-def _exports_from_dict(env_vars: Mapping[str, str | Path]) -> list[str]:
-    """Generate export lines from a dict of env var name -> value.
-
-    Properly shell-escapes values to handle special characters.
-    Accepts both str and Path values.
-    """
-    return [f"export {name}={shlex.quote(str(value))}" for name, value in env_vars.items()]
 
 
 @dataclass
@@ -134,7 +124,7 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     }
     ca_config: dict[str, str | Path] = dict.fromkeys(SSL_CA_ENV_VARS, vars.combined_ca)
     exports.extend(["", "# Auth proxy configuration"])
-    exports.extend(_exports_from_dict(auth_proxy_config | ca_config))
+    exports.extend(exports_from_dict(auth_proxy_config | ca_config))
 
     # NOTE: We intentionally do NOT export HTTPS_PROXY/HTTP_PROXY here.
     # Anthropic sets these in the container with fresh JWT credentials.
@@ -150,26 +140,26 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     no_proxy_override = _strip_no_proxy_google()
     if no_proxy_override is not None:
         exports.extend(["", "# NO_PROXY fix: strip *.googleapis.com/*.google.com (breaks Go module downloads)"])
-        exports.extend(_exports_from_dict(no_proxy_override))
+        exports.extend(exports_from_dict(no_proxy_override))
 
     # Docker/Podman configuration
     if vars.docker_env:
         exports.extend(["", "# Docker/Podman configuration"])
-        exports.extend(_exports_from_dict(vars.docker_env))
+        exports.extend(exports_from_dict(vars.docker_env))
 
     # mkcert localhost TLS certificate
     if vars.mkcert_cert and vars.mkcert_key:
         exports.extend(["", "# Localhost TLS certificate (mkcert)"])
-        exports.extend(_exports_from_dict({"MKCERT_CERT": vars.mkcert_cert, "MKCERT_KEY": vars.mkcert_key}))
+        exports.extend(exports_from_dict({"MKCERT_CERT": vars.mkcert_cert, "MKCERT_KEY": vars.mkcert_key}))
 
     # Session metadata
     exports.extend(["", "# Session metadata"])
-    exports.extend(_exports_from_dict({"DUCKTAPE_SESSION_START_HOOK_TS": vars.hook_timestamp.isoformat()}))
+    exports.extend(exports_from_dict({"DUCKTAPE_SESSION_START_HOOK_TS": vars.hook_timestamp.isoformat()}))
 
     # Age-decrypted secrets
     if vars.secrets_env_vars:
         exports.extend(["", "# Decrypted secrets (from *.age component files)"])
-        exports.extend(_exports_from_dict(vars.secrets_env_vars))
+        exports.extend(exports_from_dict(vars.secrets_env_vars))
 
     content = "\n".join(exports) + "\n"
     write_config(env_file, content, "session environment")
@@ -178,7 +168,7 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
 def write_cli_env_file(env_file_path: Path, *, wrapper_dir: Path, session_bazelrc: Path) -> None:
     """Write CLI-mode environment: wrapper PATH + bazel config + direnv eval."""
     lines = [f'export PATH="{wrapper_dir}:$PATH"']
-    lines.extend(_exports_from_dict({ENV_SESSION_BAZELRC: session_bazelrc}))
+    lines.extend(exports_from_dict({ENV_SESSION_BAZELRC: session_bazelrc}))
     if shutil.which("direnv"):
         lines.append('eval "$(direnv export bash 2>/dev/null)"')
     content = "\n".join(lines) + "\n"

--- a/tools/claude_hooks/settings.py
+++ b/tools/claude_hooks/settings.py
@@ -92,6 +92,8 @@ class HookSettings(BaseSettings):
 
     # Per-session output directory. Exported as DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR so
     # subprocesses (e.g. bazel_wrapper) pick it up automatically via pydantic-settings.
+    # Baked into the bazel/bazelisk shell wrapper at install time so it survives
+    # into pre-commit and other subprocess invocations that don't source the env file.
     # All session-scoped outputs (auth-proxy CAs, supervisor, bin wrappers, etc.) go here.
     session_dir: Path = Field(description="Per-session output directory")
 
@@ -182,14 +184,6 @@ class HookSettings(BaseSettings):
     def get_log_file(self) -> Path:
         """Get path to session-start log file."""
         return self.session_dir / "session-start.log"
-
-    def get_session_dir(self, env_file_path: Path) -> Path:
-        """Get session directory from CLAUDE_ENV_FILE path.
-
-        Both web and CLI modes use the parent directory of CLAUDE_ENV_FILE as the session directory.
-        Session-specific files (bazelrc, bin wrappers) are stored here.
-        """
-        return env_file_path.parent
 
     def get_docker_dir(self) -> Path:
         """Get Docker configuration directory."""


### PR DESCRIPTION
The Helm chart template was missing these two model fields, so
the ConfigMap rendered without them even though the HelmRelease
values included them. Pydantic requires both fields.