### PR TITLE
Add Flux Kustomization reader RBAC permissions for Claude

### DIFF
--- a/cluster/k8s/claude-rbac/clusterrole-flux-kustomization-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-flux-kustomization-reader.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: claude-flux-kustomization-reader
+rules:
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/claude-rbac/clusterrolebinding-flux-kustomization-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrolebinding-flux-kustomization-reader.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: claude-flux-kustomization-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: claude-flux-kustomization-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default

--- a/cluster/k8s/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/claude-rbac/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - rolebinding-sandbox.yaml
   - role-props-reader.yaml
   - rolebinding-props-reader.yaml
+  - clusterrole-flux-kustomization-reader.yaml
+  - clusterrolebinding-flux-kustomization-reader.yaml


### PR DESCRIPTION
## Summary
This PR adds Kubernetes RBAC permissions to allow the `claude-code-web` service account to read Flux Kustomization resources from the cluster.

## Key Changes
- **New ClusterRole**: `claude-flux-kustomization-reader` - grants read-only access (get, list, watch) to Kustomization resources in the `kustomize.toolkit.fluxcd.io` API group
- **New ClusterRoleBinding**: `claude-flux-kustomization-reader` - binds the ClusterRole to the `claude-code-web` service account in the default namespace
- **Updated kustomization.yaml**: Added references to both new RBAC resources for inclusion in the cluster configuration

## Implementation Details
The permissions are scoped to read-only operations (get, list, watch) on Kustomization resources, allowing the Claude service account to inspect Flux Kustomization objects without the ability to modify them.

https://claude.ai/code/session_01R5FnEtg1tYkQ6qzZyTfxpv