### PR TITLE
Add platform targeting guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to LLM agents for working with this repository.
 
+## Target Platform
+
+Unless stated otherwise, this repository targets **Linux**. When writing code, scripts, or configuration, default to Linux assumptions (paths, syscalls, packaging, etc.).
+
+Some components are macOS-specific and only relevant on macOS:
+
+- **Seatbelt** (`sandbox-exec`) — macOS kernel sandbox. Do not apply to Linux code.
+- **Sandboxer** — macOS-specific sandboxing tooling. Linux equivalents use different mechanisms (seccomp, namespaces, etc.).
+
+If a component is macOS-only, document it explicitly. Do not silently assume macOS conventions.
+
 @STYLE.md
 
 ## Before Hand-off


### PR DESCRIPTION
## Summary
Added explicit documentation to guide LLM agents on platform assumptions and conventions when working with this repository.

## Key Changes
- Established **Linux as the default target platform** for code, scripts, and configuration
- Documented macOS-specific components that should not be applied to Linux code:
  - Seatbelt (`sandbox-exec`) — macOS kernel sandbox
  - Sandboxer — macOS-specific sandboxing tooling
- Noted that Linux uses different sandboxing mechanisms (seccomp, namespaces, etc.)
- Added requirement to explicitly document macOS-only components rather than silently assuming macOS conventions

## Details
This guidance helps prevent platform-specific code from being incorrectly applied across different operating systems and ensures clear documentation of platform-specific features.

https://claude.ai/code/session_01JBaE6RzWF6MZbmYiXc7QTP