### PR TITLE
Remove mypy sandbox strategy override from bazel-check workflow

### DIFF
--- a/.github/workflows/bazel-check.yml
+++ b/.github/workflows/bazel-check.yml
@@ -80,7 +80,6 @@ jobs:
             echo "Using targets from input: $TARGET_ARG"
           fi
           # --config=check runs: ruff, ESLint, mypy, clippy, rustfmt
-          # --strategy=mypy=local avoids sandbox copying overhead for mypy
-          bazel build --keep_going --config=check --strategy=mypy=local \
+          bazel build --keep_going --config=check \
             --build_metadata=ROLE=ci --build_metadata=TAGS=check \
             $TARGET_ARG


### PR DESCRIPTION
## Summary
Removed the `--strategy=mypy=local` flag from the Bazel check workflow, allowing mypy to use the default sandbox strategy instead of bypassing it.

## Changes
- Removed `--strategy=mypy=local` flag from the `bazel build` command in the check job
- Removed the associated comment explaining the sandbox copying overhead optimization

## Details
The `--strategy=mypy=local` flag was previously used to avoid sandbox copying overhead for mypy runs during CI checks. This change removes that optimization, allowing mypy to execute with Bazel's default sandboxing strategy. This may result in slightly longer check times but simplifies the configuration and ensures consistency with standard Bazel execution practices.

https://claude.ai/code/session_011Kh6gRtTE1oUpyNQMWax99