### PR TITLE
build: make lint default, add --config=nolint to opt out

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,13 +34,17 @@ build:typecheck --@rules_python//python/config_settings:python_version=3.13
 build:typecheck --aspects=//tools/lint:linters.bzl%mypy_aspect
 build:typecheck --output_groups=+mypy
 
-# Combined lint + typecheck
-# Run with: bazel build --config=check //...
-# Combines lint (ruff, ESLint), typecheck (mypy), and Rust checks (clippy, rustfmt)
-# Use Python 3.13 for mypy to parse Python 3.13 syntax (e.g., homeassistant)
-build:check --@rules_python//python/config_settings:python_version=3.13
-build:check --aspects=//tools/lint:linters.bzl%ruff,//tools/lint:linters.bzl%mypy_aspect,//tools/lint:linters.bzl%eslint,@rules_rust//rust:defs.bzl%rust_clippy_aspect,@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:check --output_groups=+rules_lint_report,+mypy,+clippy_checks,+rustfmt_checks
+# Lint + typecheck enabled by default on all builds.
+# Combines lint (ruff, ESLint), typecheck (mypy), and Rust checks (clippy, rustfmt).
+# Use Python 3.13 for mypy to parse Python 3.13 syntax (e.g., homeassistant).
+# To skip lint (e.g. for fast iterative builds): bazel build --config=nolint //...
+build --@rules_python//python/config_settings:python_version=3.13
+build --aspects=//tools/lint:linters.bzl%ruff,//tools/lint:linters.bzl%mypy_aspect,//tools/lint:linters.bzl%eslint,@rules_rust//rust:defs.bzl%rust_clippy_aspect,@rules_rust//rust:defs.bzl%rustfmt_aspect
+build --output_groups=+rules_lint_report,+mypy,+clippy_checks,+rustfmt_checks
+
+# Skip lint/typecheck. Bazel evaluates aspects lazily, so removing their
+# output groups prevents the aspect actions from running.
+build:nolint --output_groups=-rules_lint_report,-mypy,-clippy_checks,-rustfmt_checks
 
 # Rust linting (clippy)
 # Run with: bazel build --config=clippy //finance/worthy:all

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,9 +19,8 @@ For detailed repository guidance, see: [AGENTS.md](../AGENTS.md) and [STYLE.md](
 **Bazel** is the unified build system. Always use Bazel, never direct `pytest` or `python`:
 
 ```bash
-bazel build //...                    # Build all
+bazel build //...                    # Build all (lint runs by default)
 bazel test //...                     # Run all tests
-bazel build --config=check //...     # Lint (ruff + mypy + eslint)
 bazel run //tools/format             # Format code
 bazel run //tools:gazelle            # Update BUILD files
 ```
@@ -33,11 +32,11 @@ Python 3.12+. Dependencies in `requirements_bazel.txt`.
 Before handing in any work:
 
 ```bash
-bazel build --config=check //...   # Lint (ruff + mypy)
-bazel test //...                   # Run all tests
+bazel build //...   # Build + lint (runs by default)
+bazel test //...    # Run all tests
 ```
 
-For Rust code: `bazel build --config=rust-check //finance/...`
+For Rust code: `bazel build //finance/...`
 
 If you modified `ansible/`, follow the checklist in [ansible/AGENTS.md](../ansible/AGENTS.md).
 

--- a/.github/workflows/bazel-check.yml
+++ b/.github/workflows/bazel-check.yml
@@ -1,6 +1,6 @@
 # Bazel check reusable workflow
 #
-# Build + all quality checks in a single pass via --config=check:
+# Build + all quality checks in a single pass (lint runs by default):
 # - Python: ruff (lint), mypy (typecheck)
 # - JS/TS: ESLint
 # - Rust: clippy, rustfmt
@@ -79,7 +79,7 @@ jobs:
             TARGET_ARG="${{ inputs.targets }}"
             echo "Using targets from input: $TARGET_ARG"
           fi
-          # --config=check runs: ruff, ESLint, mypy, clippy, rustfmt
-          bazel build --keep_going --config=check \
+          # Lint runs by default: ruff, ESLint, mypy, clippy, rustfmt.
+          bazel build --keep_going \
             --build_metadata=ROLE=ci --build_metadata=TAGS=check \
             $TARGET_ARG

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
         args: [--config, ruff.toml]
         files: "\\.py$"
 
-  # TODO: Check if Bazel mypy (bazelisk build --config=check //...) can replace
+  # TODO: Check if Bazel mypy (runs by default via bazel build //...) can replace
   # pre-commit mypy hooks. The Bazel mypy setup handles workspace dependencies
   # correctly and uses a single mypy.ini config.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,13 @@ If a component is macOS-only, document it explicitly. Do not silently assume mac
 ## Before Hand-off
 
 ```bash
-bazel build --config=check //...
+bazel build //...
 bazel test //...
 ```
 
-This runs ruff + mypy lint checks and all tests. For Rust code, also run `bazel build --config=rust-check //finance/...`.
+This runs ruff + mypy lint checks and all tests (lint runs by default).
+Use `--config=nolint` to skip lint for faster iterative builds.
+For Rust code, lint is also included by default; `--config=rust-check` still works as a standalone Rust-only subset.
 
 If you touched `ansible/`, also follow the checklist in `ansible/AGENTS.md`.
 
@@ -138,7 +140,7 @@ live_openai_py_test(
 
 ### JavaScript / TypeScript (Bazel with rules_js)
 
-Frontend sub-projects use `@aspect_rules_js` with `js_library` targets. ESLint linting is handled by the workspace lint aspect (`--config=check`). Declare precise deps — each `js_library` lists only the files it directly imports; transitive deps propagate automatically via `JsInfo`.
+Frontend sub-projects use `@aspect_rules_js` with `js_library` targets. ESLint linting is handled by the workspace lint aspect (runs by default). Declare precise deps — each `js_library` lists only the files it directly imports; transitive deps propagate automatically via `JsInfo`.
 
 See <props/frontend/AGENTS.md> for frontend-specific conventions.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This repository uses **Bazel** as the unified build system for all Python packag
 
 - `requirements_bazel.txt` - Single source of truth for Python dependencies
 - All Python packages have `BUILD.bazel` files defining targets
-- Linting via Bazel aspects (`--config=check` runs ruff + mypy + eslint)
+- Linting via Bazel aspects (runs by default; use `--config=nolint` to skip)
 - Python 3.12+ is the target runtime version
 
 **Adding dependencies:**
@@ -217,7 +217,7 @@ This repository uses **Bazel** as the primary build system. Install the git pre-
 pre-commit install
 ```
 
-This installs the pre-commit framework which runs ruff, buildifier, rustfmt, prettier and other linters on staged files, checks for conflict markers, validates syntax, and more (see `.pre-commit-config.yaml`). For ESLint and mypy, run `bazel build --config=check //...`.
+This installs the pre-commit framework which runs ruff, buildifier, rustfmt, prettier and other linters on staged files, checks for conflict markers, validates syntax, and more (see `.pre-commit-config.yaml`). ESLint and mypy run automatically on every `bazel build` (use `--config=nolint` to skip).
 
 ### Lint/Format Exclusions
 
@@ -242,7 +242,7 @@ To exclude a file/directory:
 BuildBuddy Workflows provides fast, Bazel-native CI with remote execution. The `buildbuddy.yaml` configuration runs:
 
 - `bazel test //...` - Run all tests (excluding `live_openai_api`)
-- `bazel build --config=check //...` - Unified quality checks (ruff, ESLint, mypy, clippy, rustfmt)
+- `bazel build //...` - Unified quality checks (ruff, ESLint, mypy, clippy, rustfmt; runs by default)
 
 **Setup**:
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -20,6 +20,7 @@ Style and convention rules for this repository. Package-specific elaborations be
   - First line: `@README.md` (if README exists)
   - Then: Agent-specific instructions (idioms, "always do X", "never do Y", conventions)
   - Package-specific elaborations of STYLE.md rules go here
+  - **Nesting/inheritance**: Agents read AGENTS.md files from the repo root down to the current package. A sub-folder AGENTS.md must not repeat instructions already covered by a parent AGENTS.md. If `foo/AGENTS.md` says X, `foo/bar/AGENTS.md` should not repeat X. Only document what is new or different at this level.
 - **CLAUDE.md**: Always exactly one line: `@AGENTS.md`
 - **STYLE.md**: Repository-wide rules. If a rule applies across packages, it belongs here, not in a package's AGENTS.md.
 

--- a/bazelization/STATUS.md
+++ b/bazelization/STATUS.md
@@ -53,7 +53,7 @@ Shell script categories: CI/Ansible (`.github/scripts/`, `ansible/scripts/`), Do
 ### Commands
 
 ```bash
-bazel build --config=check //...        # Lint + typecheck
+bazel build //...                       # Build + lint (runs by default)
 bazel build --config=typecheck //...    # Mypy only
 bazel run //:requirements.update        # Update Python requirements lock
 bazel run //tools/orphans:find_orphans  # Find un-Bazelized files

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -38,13 +38,12 @@ actions:
         //...
 
       # 2. Build + lint + typecheck + rust-check (all quality checks in one pass)
-      # Use local strategy for mypy to avoid sandbox copying overhead
-      # --config=check runs: ruff, ESLint, mypy, clippy, rustfmt
+      # Lint runs by default: ruff, ESLint, mypy, clippy, rustfmt.
+      # Use local strategy for mypy to avoid sandbox copying overhead.
       - >
         build
         --keep_going
         --config=rbe
-        --config=check
         --strategy=mypy=local
         --build_metadata=ROLE=ci
         --build_metadata=TAGS=check

--- a/homeassistant/iaqi/README.md
+++ b/homeassistant/iaqi/README.md
@@ -87,14 +87,6 @@ The sensor exposes the following attributes:
 
 ## Development & Testing
 
-See the repository root AGENTS.md for the standard Bazel workflow.
-
-```bash
-bazel build //homeassistant/iaqi/...
-bazel test //homeassistant/iaqi/...
-bazel build --config=check //homeassistant/iaqi/...  # lint + typecheck
-```
-
 ### Test Setup with pytest_homeassistant_custom_component
 
 The tests use `pytest_homeassistant_custom_component` for Home Assistant fixtures (`hass`, `enable_custom_integrations`, etc.). Running these tests under Bazel requires two workarounds in `conftest.py`:

--- a/props/README.md
+++ b/props/README.md
@@ -79,10 +79,9 @@ bazelisk run //props/agents/critic_dev/optimize:push
 ## Development
 
 ```bash
-docker compose up -d                       # Start infrastructure
-docker compose down                        # Stop infrastructure
-docker compose logs -f postgres            # View logs
-bazelisk build --config=check //props/...  # Lint + typecheck
+docker compose up -d            # Start infrastructure
+docker compose down             # Stop infrastructure
+docker compose logs -f postgres # View logs
 ```
 
 For frontend hot-reload during development, use `frontend:dev` instead of the

--- a/props/frontend/AGENTS.md
+++ b/props/frontend/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Bazel Build
 
-Sub-packages use `js_library` directly (from `@aspect_rules_js`). ESLint linting is handled by the workspace lint aspect (`--config=check`); type checking by `svelte_check_test`.
+Sub-packages use `js_library` directly (from `@aspect_rules_js`). ESLint linting is handled by the workspace lint aspect (runs by default); type checking by `svelte_check_test`.
 
 **Dependency philosophy**: Declare precise deps. No grab-bag filegroups, no globs, no `_ALL_SRCS` constants. Each `js_library` target lists only the files it directly imports. Transitive deps propagate automatically via `JsInfo`.
 

--- a/tana/README.md
+++ b/tana/README.md
@@ -8,12 +8,7 @@ parsers/renderers under the `tana.export` namespace.
 
 See the repository root AGENTS.md for the standard Bazel workflow.
 
-```bash
-bazel build //tana/...
-bazel test //tana/...
-bazel build --config=check //tana/...  # lint + typecheck
-bazel run //tana:tana-export-convert -- --help
-```
+`bazel run //tana:tana-export-convert -- --help`
 
 Key layout (`tana/`):
 

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -17,7 +17,7 @@
 
 workflows:
   # Core Bazel workflows
-  # Build + all quality checks (ruff, ESLint, mypy, clippy, rustfmt) via --config=check
+  # Build + all quality checks (ruff, ESLint, mypy, clippy, rustfmt; run by default)
   bazel-check:
     trigger: { kind: bazel_query, query: "$targets" }
     targets: true

--- a/tools/docs/ci_unification_plan.md
+++ b/tools/docs/ci_unification_plan.md
@@ -494,8 +494,7 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v3
       - run: sudo apt-get install -y libdbus-1-dev libgirepository-2.0-dev libcairo2-dev
       - run: |
-          bazel build //...
-          bazel build --config=check //...
+          bazel build //...  # lint runs by default
           bazel test //...
 ```
 

--- a/tools/docs/linting.md
+++ b/tools/docs/linting.md
@@ -4,21 +4,21 @@ This document describes the linting and formatting setup across pre-commit, Baze
 
 ## Quick Reference
 
-| Tool                             | Pre-commit             | Bazel Aspect          | GitHub CI           |
-| -------------------------------- | ---------------------- | --------------------- | ------------------- |
-| **Python (ruff check)**          | `ruff-check` hook      | `--config=lint`       | Both                |
-| **Python (ruff format)**         | `ruff-format` hook     | N/A                   | Pre-commit          |
-| **Python (mypy)**                | -                      | `--config=typecheck`  | bazel-check         |
-| **JS/TS (eslint)**               | -                      | `--config=lint`       | bazel-check         |
-| **JS/TS (prettier)**             | `prettier` hook        | N/A                   | Pre-commit          |
-| **Starlark (buildifier)**        | `buildifier-lint` hook | -                     | Pre-commit          |
-| **Starlark (buildifier format)** | `buildifier` hook      | N/A                   | Pre-commit          |
-| **Rust (clippy)**                | -                      | `--config=rust-check` | bazel-check         |
-| **Rust (rustfmt)**               | `rustfmt` hook         | `--config=rust-check` | Both                |
-| **Shell (shfmt)**                | `bazel-precommit` hook | N/A                   | Pre-commit          |
-| **Nix (nixfmt)**                 | `nixfmt` hook          | N/A                   | Pre-commit          |
-| **Ansible**                      | syntax-check (fast)    | -                     | ansible-lint (full) |
-| **Terraform**                    | fmt/validate/tflint    | -                     | Pre-commit          |
+| Tool                             | Pre-commit             | Bazel Aspect | GitHub CI           |
+| -------------------------------- | ---------------------- | ------------ | ------------------- |
+| **Python (ruff check)**          | `ruff-check` hook      | default      | Both                |
+| **Python (ruff format)**         | `ruff-format` hook     | N/A          | Pre-commit          |
+| **Python (mypy)**                | -                      | default      | bazel-check         |
+| **JS/TS (eslint)**               | -                      | default      | bazel-check         |
+| **JS/TS (prettier)**             | `prettier` hook        | N/A          | Pre-commit          |
+| **Starlark (buildifier)**        | `buildifier-lint` hook | -            | Pre-commit          |
+| **Starlark (buildifier format)** | `buildifier` hook      | N/A          | Pre-commit          |
+| **Rust (clippy)**                | -                      | default      | bazel-check         |
+| **Rust (rustfmt)**               | `rustfmt` hook         | default      | Both                |
+| **Shell (shfmt)**                | `bazel-precommit` hook | N/A          | Pre-commit          |
+| **Nix (nixfmt)**                 | `nixfmt` hook          | N/A          | Pre-commit          |
+| **Ansible**                      | syntax-check (fast)    | -            | ansible-lint (full) |
+| **Terraform**                    | fmt/validate/tflint    | -            | Pre-commit          |
 
 ## Configuration Files
 
@@ -56,23 +56,20 @@ Common exclusion patterns (should match across files):
 
 ## Bazel Aspect Configs
 
-Defined in `.bazelrc`:
+Defined in `.bazelrc`. Lint runs by default on every `bazel build`.
 
 ```bash
-# Lint: ruff + eslint
-bazel build --config=lint //...
+# Lint runs by default (ruff + eslint + mypy + clippy + rustfmt):
+bazel build //...
 
-# Type check: mypy
-bazel build --config=typecheck //...
+# Skip lint for faster iterative builds:
+bazel build --config=nolint //...
 
-# Combined: ruff + eslint + mypy + clippy + rustfmt
-bazel build --config=check //...
-
-# Rust: clippy + rustfmt
-bazel build --config=rust-check //finance/...
-
-# ESLint only
-bazel build --config=eslint //props/frontend:all
+# Subset configs (still valid when you only want a specific tool):
+bazel build --config=lint //...        # ruff + eslint only
+bazel build --config=typecheck //...   # mypy only
+bazel build --config=rust-check //finance/...  # clippy + rustfmt only
+bazel build --config=eslint //props/frontend:all  # ESLint only
 ```
 
 Aspect definitions in `tools/lint/linters.bzl`:
@@ -86,7 +83,7 @@ Aspect definitions in `tools/lint/linters.bzl`:
 | Workflow           | What Runs                                       |
 | ------------------ | ----------------------------------------------- |
 | `pre-commit.yml`   | `pre-commit run --all-files`                    |
-| `bazel-check.yml`  | `bazel build --config=check //...`              |
+| `bazel-check.yml`  | `bazel build //...` (lint runs by default)      |
 | `ansible-lint.yml` | Full ansible-lint (thorough mode)               |
 | `bazel-test.yml`   | `bazel test //...` (includes visual regression) |
 

--- a/wt/AGENTS.md
+++ b/wt/AGENTS.md
@@ -4,8 +4,6 @@
 
 ## Environment and Tooling
 
-See @../AGENTS.md for standard Bazel workflow (`bazel build --config=check //...`, `bazel test //...`).
-
 Requirements: Bazel (via bazelisk), Python **3.13**+.
 
 ### Extra dependencies / binaries
@@ -16,10 +14,6 @@ Requirements: Bazel (via bazelisk), Python **3.13**+.
 ## Development Commands
 
 - Run the CLI entry point: `bazel run //wt:wt_cli -- --help`
-- Tests: `bazel test //wt/...`
-- Linting: `bazel build --config=lint //wt/...`
-- Type checking: `bazel build --config=typecheck //wt/...`
-- Format: `bazel run //tools/format`
 
 Integration tests marked `integration` or `shell` spawn git repos and daemons; they may need
 relaxed sandboxing to allow UNIX sockets and filesystem operations.

--- a/wt/README.md
+++ b/wt/README.md
@@ -20,11 +20,7 @@ Makes switching between git worktrees feel like `git switch` while adding copy-o
 
 See the repository root AGENTS.md for the standard Bazel workflow.
 
-```bash
-bazel run //wt:wt_cli -- --help
-bazel test //wt/...
-bazel build --config=check //wt/...  # lint + typecheck
-```
+`bazel run //wt:wt_cli -- --help`
 
 ## Installation
 


### PR DESCRIPTION
Lint (ruff, mypy, ESLint, clippy, rustfmt) now runs on every `bazel build` without needing --config=check. Use --config=nolint for faster iterative builds that skip lint. Update all docs and CI configs accordingly.

https://claude.ai/code/session_01JBaE6RzWF6MZbmYiXc7QTP