### PR TITLE
Increase disk resource allocation for BuildBuddy workflow actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -23,6 +23,8 @@ actions:
     # BuildBuddy Workflows only supports predefined Ubuntu images, not custom images
     # like ghcr.io/agentydragon/rbe-worker. RBE workers still use the custom image.
     container_image: "ubuntu-24.04"
+    resource_requests:
+      disk: "50GB"
 
     bazel_commands:
       # 1. Run all tests (excluding live OpenAI API tests)
@@ -60,6 +62,8 @@ actions:
 
     # Same as CI action - BuildBuddy Workflows doesn't support custom images
     container_image: "ubuntu-24.04"
+    resource_requests:
+      disk: "50GB"
 
     bazel_commands:
       # Build all wheel targets for potential release
@@ -82,6 +86,8 @@ actions:
 
     # Same as CI action - BuildBuddy Workflows doesn't support custom images
     container_image: "ubuntu-24.04"
+    resource_requests:
+      disk: "50GB"
 
     bazel_commands:
       # Build OCI images for potential release


### PR DESCRIPTION
## Summary
This change increases the disk resource allocation for all three BuildBuddy workflow actions (CI, release wheels, and release OCI images) from the default to 50GB to accommodate larger build artifacts and dependencies.

## Changes
- Added `resource_requests.disk: "50GB"` to the CI action workflow configuration
- Added `resource_requests.disk: "50GB"` to the release wheels action workflow configuration
- Added `resource_requests.disk: "50GB"` to the release OCI images action workflow configuration

## Details
All three actions now explicitly request 50GB of disk space. This ensures sufficient storage capacity during build and test execution, preventing potential disk space exhaustion issues that could cause workflow failures.

https://claude.ai/code/session_011RryRFCwfGpWuViLWVriWM