### PR TITLE
fix(git_commit_ai): fix mypy str | None assignment error

### DIFF
--- a/git_commit_ai/cli.py
+++ b/git_commit_ai/cli.py
@@ -184,9 +184,10 @@ async def commit(
             user_context=message,
             previous_message=prev_msg,
         )
-        ai_msg = await run_editor(repo, content)
-        if ai_msg is None:
+        edited = await run_editor(repo, content)
+        if edited is None:
             raise SystemExit(1)
+        ai_msg = edited
 
     cmd = ["git", "commit", "-m", ai_msg, "--no-verify"]
     if amend:


### PR DESCRIPTION
## Summary

- `run_editor` returns `str | None`; reassigning its result to `ai_msg` (inferred as `str`) caused a mypy error
- Use a separate `edited` variable, guard against `None`, then assign to `ai_msg` so mypy can narrow the type correctly

## Test plan

- [x] `bazel build //git_commit_ai:git_commit_ai` passes (mypy clean)

https://claude.ai/code/session_01RxihVtwWdfa5WoBaooo5C3