### PR TITLE
fix: resolve devel branch CI BUILD_FAILURE issues

### DIFF
--- a/claude_web_env/re/environment_manager/6b49f1ca/src/internal/envtype/anthropic/BUILD.bazel
+++ b/claude_web_env/re/environment_manager/6b49f1ca/src/internal/envtype/anthropic/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/anthropics/anthropic/api-go/environment-manager/internal/envtype/anthropic",
     visibility = ["//claude_web_env/re/environment_manager/6b49f1ca/src:__subpackages__"],
     deps = [
+        "//claude_web_env/re/environment_manager/6b49f1ca/src/internal/auth",
         "//claude_web_env/re/environment_manager/6b49f1ca/src/internal/config",
         "//claude_web_env/re/environment_manager/6b49f1ca/src/internal/envtype",
         "//claude_web_env/re/environment_manager/6b49f1ca/src/internal/envtype/anthropic/install_scripts",

--- a/props/agents/BUILD.bazel
+++ b/props/agents/BUILD.bazel
@@ -63,6 +63,7 @@ py_test(
     deps = [
         ":runtime",
         "//props:conftest",
+        "//props/core:agent_types",
         "//props/db:database",
         "//test_util:undeclared_outputs",
         "@pypi//mako",

--- a/props/agents/test_system_prompts.py
+++ b/props/agents/test_system_prompts.py
@@ -15,6 +15,8 @@ import importlib.resources
 import pytest_bazel
 
 from props.agents.runtime import render_template_string
+from props.core.agent_types import CriticDevImproveTypeConfig, CriticDevOptimizeTypeConfig, TargetMetric
+from props.core.models.examples import WholeSnapshotExample
 from props.db.database import Database
 from test_util.undeclared_outputs import undeclared_outputs_dir
 
@@ -62,14 +64,35 @@ def test_grader_prompt(db: Database):
 
 
 def test_critic_dev_optimize_prompt(db: Database):
-    rendered = _render(db, "props/agents/critic_dev/prompt.md.mako", helpers={"mode": "optimize"})
+    rendered = _render(
+        db,
+        "props/agents/critic_dev/prompt.md.mako",
+        helpers={
+            "type_config": CriticDevOptimizeTypeConfig(
+                target_metric=TargetMetric.WHOLE_REPO,
+                optimizer_model="claude-opus-4-5",
+                critic_model="claude-sonnet-4-5",
+            )
+        },
+    )
     _write_output("critic_dev_optimize.md", rendered)
     assert "engineer" in rendered.lower()
     assert "recall" in rendered.lower()
 
 
 def test_critic_dev_improve_prompt(db: Database):
-    rendered = _render(db, "props/agents/critic_dev/prompt.md.mako", helpers={"mode": "improve"})
+    rendered = _render(
+        db,
+        "props/agents/critic_dev/prompt.md.mako",
+        helpers={
+            "type_config": CriticDevImproveTypeConfig(
+                baseline_image_digests=["sha256:abc123"],
+                allowed_examples=[WholeSnapshotExample(snapshot_slug="test/s")],
+                improvement_model="claude-opus-4-5",
+                critic_model="claude-sonnet-4-5",
+            )
+        },
+    )
     _write_output("critic_dev_improve.md", rendered)
     assert "allowed_examples" in rendered
 

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -465,7 +465,12 @@ class AgentRegistry:
         if parent_run_id is not None:
             self._validate_spawn_budget(parent_run_id, budget_usd)
 
-        agent_run_id = self._create_run(
+        agent_run_id = uuid4()
+        slug_seg = _slug_to_container_segment(example.snapshot_slug)
+        container_name = f"critic-{slug_seg}-{str(agent_run_id)[:8]}"
+
+        self._create_run(
+            agent_run_id,
             image=image,
             model=model,
             type_config=CriticTypeConfig(example=example),
@@ -476,7 +481,10 @@ class AgentRegistry:
 
         async def _run() -> None:
             try:
-                await self._run_agent(agent_run_id, image=image.oci_ref, timeout_seconds=timeout_seconds)
+                handle = await self._start_agent(
+                    agent_run_id, image=image.oci_ref, timeout_seconds=timeout_seconds, name=container_name
+                )
+                await handle
             except Exception:
                 logger.exception("Unhandled error in background critic run %s", agent_run_id)
 


### PR DESCRIPTION
Three fixes:

1. props/orchestration/agent_registry.py: Fix start_critic method which had 4 mypy errors from the non-blocking critic implementation. The method incorrectly treated _create_run as returning a UUID (it returns None and takes agent_run_id as first positional arg), and called non-existent _run_agent (should be _start_agent).

2. claude_web_env/.../envtype/anthropic/BUILD.bazel: Add missing auth dep to Go BUILD.bazel. anthropic.go imports the internal/auth package (used in writeSupabaseEnvFiles) but it was absent from deps, causing a strict dependency compilepkg failure.

3. props/agents/test_system_prompts.py + BUILD.bazel: Fix test_critic_dev_{optimize,improve}_prompt tests which still passed helpers={"mode": "..."} but the template was refactored to use isinstance(type_config, CriticDevOptimizeTypeConfig). Updated tests to pass proper type_config objects and added //props/core:agent_types to test deps.

https://claude.ai/code/session_01UXUfVLHqD35KR7EeTrjqFL