### PR TITLE
claude_hooks: speed up session init, add OTel sub-spans

### DIFF
--- a/props/db/setup.py
+++ b/props/db/setup.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
+@tracer.start_as_current_span("ensure_database_exists")
 def ensure_database_exists(base_config: DatabaseConfig, database_name: str, *, drop_existing: bool = False) -> None:
     """Ensure a PostgreSQL database exists.
 
@@ -38,80 +39,79 @@ def ensure_database_exists(base_config: DatabaseConfig, database_name: str, *, d
     Note: Does not terminate connections. Tests use unique database names so no
           conflicts in setup. Connection termination remains in test teardown only.
     """
-    with tracer.start_as_current_span("ensure_database_exists"):
-        postgres_config = base_config.with_database("postgres")
-        engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
+    postgres_config = base_config.with_database("postgres")
+    engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
 
-        with engine.connect() as conn:
-            if drop_existing:
-                # Fail fast if other sessions are connected to the target DB to surface
-                # cross-test interference instead of a vague DROP failure.
-                active_sessions = conn.execute(
-                    text(
-                        """
-                        select pid, usename, application_name, client_addr
-                        from pg_stat_activity
-                        where datname = :dbname and pid <> pg_backend_pid()
-                        """
-                    ),
-                    {"dbname": database_name},
-                ).fetchall()
+    with engine.connect() as conn:
+        if drop_existing:
+            # Fail fast if other sessions are connected to the target DB to surface
+            # cross-test interference instead of a vague DROP failure.
+            active_sessions = conn.execute(
+                text(
+                    """
+                    select pid, usename, application_name, client_addr
+                    from pg_stat_activity
+                    where datname = :dbname and pid <> pg_backend_pid()
+                    """
+                ),
+                {"dbname": database_name},
+            ).fetchall()
 
-                if active_sessions:
-                    details = ", ".join(
-                        f"pid={pid} user={user} app={app or '-'} addr={addr or '-'}"
-                        for pid, user, app, addr in active_sessions
-                    )
-                    raise RuntimeError(
-                        "Test database in use by other sessions; aborting drop. "
-                        f"database={database_name}; sessions=[{details}]"
-                    )
+            if active_sessions:
+                details = ", ".join(
+                    f"pid={pid} user={user} app={app or '-'} addr={addr or '-'}"
+                    for pid, user, app, addr in active_sessions
+                )
+                raise RuntimeError(
+                    "Test database in use by other sessions; aborting drop. "
+                    f"database={database_name}; sessions=[{details}]"
+                )
 
-                # Idempotent drop (for test setup)
-                conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+            # Idempotent drop (for test setup)
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
 
-            # Check if database exists
-            result = conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :dbname"), {"dbname": database_name})
+        # Check if database exists
+        result = conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :dbname"), {"dbname": database_name})
 
-            if not result.fetchone():
-                # Create using safe identifier quoting
-                raw_conn = conn.connection
-                cursor = raw_conn.cursor()
-                cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
-                cursor.close()
+        if not result.fetchone():
+            # Create using safe identifier quoting
+            raw_conn = conn.connection
+            cursor = raw_conn.cursor()
+            cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
+            cursor.close()
 
-        engine.dispose()
+    engine.dispose()
 
 
+@tracer.start_as_current_span("upgrade_database")
 def upgrade_database(engine: Engine) -> None:
     """Run Alembic migrations to HEAD (idempotent, non-destructive).
 
     Safe to call on every startup — Alembic checks the alembic_version table
     and only applies pending migrations.
     """
-    with tracer.start_as_current_span("upgrade_database"):
-        logger.info("Running Alembic migrations...")
-        config = Config()
-        config.set_main_option("script_location", str(Path(__file__).parent / "migrations"))
+    logger.info("Running Alembic migrations...")
+    config = Config()
+    config.set_main_option("script_location", str(Path(__file__).parent / "migrations"))
 
-        with engine.begin() as conn:
-            config.attributes["connection"] = conn
-            command.upgrade(config, "head")
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "head")
 
-        logger.info("Alembic migrations complete")
+    logger.info("Alembic migrations complete")
 
 
+@tracer.start_as_current_span("recreate_database")
 def recreate_database(engine: Engine) -> None:
     """Recreate database from scratch (drop all + migrate).
 
     This is destructive: drops all existing tables, views, and policies,
     then runs all migrations from scratch. For tests only.
     """
-    with tracer.start_as_current_span("recreate_database"):
-        logger.info("Recreating database from scratch...")
-        _drop_all(engine)
-        upgrade_database(engine)
-        logger.info("Database recreation complete")
+    logger.info("Recreating database from scratch...")
+    _drop_all(engine)
+    upgrade_database(engine)
+    logger.info("Database recreation complete")
 
 
 def _drop_all(engine: Engine) -> None:

--- a/props/testing/fixtures/e2e_infra.py
+++ b/props/testing/fixtures/e2e_infra.py
@@ -72,41 +72,41 @@ def _e2e_registry_container() -> Generator[DockerContainer]:
         registry.stop()
 
 
+@tracer.start_as_current_span("delete registry manifests")
 def _delete_all_manifests(registry_url: str) -> None:
     """Delete all agent manifests from registry to ensure clean state for next test."""
-    with tracer.start_as_current_span("delete registry manifests"):
-        for agent_type in AgentType:
-            repo = agent_type.value
-            # List tags for this repo
+    for agent_type in AgentType:
+        repo = agent_type.value
+        # List tags for this repo
+        try:
+            resp = httpx.get(f"{registry_url}/v2/{repo}/tags/list", timeout=5.0)
+            if resp.status_code == 404:
+                continue  # Repo doesn't exist yet
+            resp.raise_for_status()
+            tags = resp.json().get("tags") or []
+        except httpx.HTTPError:
+            continue
+
+        # Delete each tag's manifest
+        for tag in tags:
             try:
-                resp = httpx.get(f"{registry_url}/v2/{repo}/tags/list", timeout=5.0)
-                if resp.status_code == 404:
-                    continue  # Repo doesn't exist yet
-                resp.raise_for_status()
-                tags = resp.json().get("tags") or []
-            except httpx.HTTPError:
-                continue
+                # Get manifest digest
+                head_resp = httpx.head(
+                    f"{registry_url}/v2/{repo}/manifests/{tag}",
+                    headers={"Accept": "application/vnd.oci.image.manifest.v1+json"},
+                    timeout=5.0,
+                )
+                if head_resp.status_code != 200:
+                    continue
+                digest = head_resp.headers.get("Docker-Content-Digest")
+                if not digest:
+                    continue
 
-            # Delete each tag's manifest
-            for tag in tags:
-                try:
-                    # Get manifest digest
-                    head_resp = httpx.head(
-                        f"{registry_url}/v2/{repo}/manifests/{tag}",
-                        headers={"Accept": "application/vnd.oci.image.manifest.v1+json"},
-                        timeout=5.0,
-                    )
-                    if head_resp.status_code != 200:
-                        continue
-                    digest = head_resp.headers.get("Docker-Content-Digest")
-                    if not digest:
-                        continue
-
-                    # Delete by digest
-                    httpx.delete(f"{registry_url}/v2/{repo}/manifests/{digest}", timeout=5.0)
-                    logger.debug(f"Deleted {repo}:{tag} ({digest})")
-                except httpx.HTTPError as e:
-                    logger.warning(f"Failed to delete {repo}:{tag}: {e}")
+                # Delete by digest
+                httpx.delete(f"{registry_url}/v2/{repo}/manifests/{digest}", timeout=5.0)
+                logger.debug(f"Deleted {repo}:{tag} ({digest})")
+            except httpx.HTTPError as e:
+                logger.warning(f"Failed to delete {repo}:{tag}: {e}")
 
 
 @pytest.fixture

--- a/props/testing/fixtures/e2e_infra.py
+++ b/props/testing/fixtures/e2e_infra.py
@@ -78,35 +78,29 @@ def _delete_all_manifests(registry_url: str) -> None:
     for agent_type in AgentType:
         repo = agent_type.value
         # List tags for this repo
-        try:
-            resp = httpx.get(f"{registry_url}/v2/{repo}/tags/list", timeout=5.0)
-            if resp.status_code == 404:
-                continue  # Repo doesn't exist yet
-            resp.raise_for_status()
-            tags = resp.json().get("tags") or []
-        except httpx.HTTPError:
-            continue
+        resp = httpx.get(f"{registry_url}/v2/{repo}/tags/list", timeout=5.0)
+        if resp.status_code == 404:
+            continue  # Repo doesn't exist yet
+        resp.raise_for_status()
+        tags = resp.json().get("tags") or []
 
         # Delete each tag's manifest
         for tag in tags:
-            try:
-                # Get manifest digest
-                head_resp = httpx.head(
-                    f"{registry_url}/v2/{repo}/manifests/{tag}",
-                    headers={"Accept": "application/vnd.oci.image.manifest.v1+json"},
-                    timeout=5.0,
-                )
-                if head_resp.status_code != 200:
-                    continue
-                digest = head_resp.headers.get("Docker-Content-Digest")
-                if not digest:
-                    continue
+            # Get manifest digest
+            head_resp = httpx.head(
+                f"{registry_url}/v2/{repo}/manifests/{tag}",
+                headers={"Accept": "application/vnd.oci.image.manifest.v1+json"},
+                timeout=5.0,
+            )
+            if head_resp.status_code != 200:
+                continue
+            digest = head_resp.headers.get("Docker-Content-Digest")
+            if not digest:
+                continue
 
-                # Delete by digest
-                httpx.delete(f"{registry_url}/v2/{repo}/manifests/{digest}", timeout=5.0)
-                logger.debug(f"Deleted {repo}:{tag} ({digest})")
-            except httpx.HTTPError as e:
-                logger.warning(f"Failed to delete {repo}:{tag}: {e}")
+            # Delete by digest
+            httpx.delete(f"{registry_url}/v2/{repo}/manifests/{digest}", timeout=5.0).raise_for_status()
+            logger.debug(f"Deleted {repo}:{tag} ({digest})")
 
 
 @pytest.fixture

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -213,6 +213,7 @@ py_library(
         ":settings",
         "//tools/claude_hooks/supervisor:client",
         "//tools/claude_hooks/supervisor:service_utils",
+        "@pypi//httpx",
     ],
 )
 

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -148,6 +148,7 @@ py_library(
     deps = [
         ":platform_utils",
         ":settings",
+        "@pypi//opentelemetry_api",
     ],
 )
 
@@ -187,6 +188,7 @@ py_library(
         "//tools/claude_hooks/supervisor:client",
         "@pypi//cryptography",
         "@pypi//mako",
+        "@pypi//opentelemetry_api",
     ],
 )
 

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -148,6 +148,7 @@ py_library(
     deps = [
         ":platform_utils",
         ":settings",
+        "@pypi//httpx",
         "@pypi//opentelemetry_api",
     ],
 )

--- a/tools/claude_hooks/container_runtime.py
+++ b/tools/claude_hooks/container_runtime.py
@@ -35,6 +35,8 @@ from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Literal
 
+import httpx
+
 from tools.claude_hooks.errors import SkipError
 from tools.claude_hooks.managed_files import write_config
 from tools.claude_hooks.proxy_setup import SSL_CA_ENV_VARS
@@ -106,6 +108,23 @@ async def _is_service_healthy(supervisor: SupervisorClient, service_name: str, s
     try:
         return await supervisor.is_service_running(service_name)
     except Exception:
+        return False
+
+
+async def _is_docker_socket_responsive(socket_path: Path) -> bool:
+    """Return True if a dockerd is already listening on the socket.
+
+    Handles the case where the environment injects a pre-existing dockerd
+    (e.g. the Claude Code web sandbox starts with one) that is not managed
+    by this session's supervisor instance.
+    """
+    if not socket_path.exists():
+        return False
+    try:
+        async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=str(socket_path)), timeout=1.0) as client:
+            response = await client.get("http://localhost/_ping")
+            return response.status_code == 200
+    except (OSError, httpx.HTTPError, httpx.TransportError):
         return False
 
 
@@ -339,6 +358,18 @@ async def setup_container_runtime(
             runtime=runtime,
             socket_url=socket_url,
             status=status,
+            storage_driver=spec.storage_driver,
+            env_vars=spec.client_env_vars,
+        )
+
+    # Check for a pre-existing daemon not managed by this supervisor (e.g. the
+    # Claude Code web sandbox injects a dockerd before the hook runs).
+    if runtime == "docker" and await _is_docker_socket_responsive(spec.socket_path):
+        logger.info("Pre-existing dockerd responsive on %s, using it", spec.socket_path)
+        return ContainerRuntimeSetup(
+            runtime=runtime,
+            socket_url=socket_url,
+            status="pre-existing",
             storage_driver=spec.storage_driver,
             env_vars=spec.client_env_vars,
         )

--- a/tools/claude_hooks/mkcert_setup.py
+++ b/tools/claude_hooks/mkcert_setup.py
@@ -11,10 +11,10 @@ import asyncio
 import logging
 import os
 import stat
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
 from opentelemetry import trace
 
 from tools.claude_hooks.platform_utils import get_platform
@@ -53,12 +53,6 @@ def _get_download_url() -> str:
     )
 
 
-def _fetch_url_bytes(url: str) -> bytes:
-    with urllib.request.urlopen(url, timeout=60) as response:
-        data: bytes = response.read()
-    return data
-
-
 async def _download_mkcert(settings: HookSettings) -> Path:
     """Download mkcert binary if not already present."""
     mkcert_dir = _get_mkcert_dir(settings)
@@ -73,7 +67,11 @@ async def _download_mkcert(settings: HookSettings) -> Path:
     url = _get_download_url()
     logger.info("Downloading mkcert from %s", url)
 
-    data = await asyncio.to_thread(_fetch_url_bytes, url)
+    async with httpx.AsyncClient(follow_redirects=True, timeout=60) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        data = response.content
+
     mkcert_path.write_bytes(data)
     mkcert_path.chmod(mkcert_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     logger.info("Installed mkcert to %s", mkcert_path)

--- a/tools/claude_hooks/mkcert_setup.py
+++ b/tools/claude_hooks/mkcert_setup.py
@@ -128,11 +128,11 @@ async def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> Mkce
         logger.info("Generating localhost certificate...")
         with tracer.start_as_current_span("mkcert_generate_cert"):
             proc = await asyncio.create_subprocess_exec(
-                str(mkcert_bin),
+                mkcert_bin,
                 "-cert-file",
-                str(cert_path),
+                cert_path,
                 "-key-file",
-                str(key_path),
+                key_path,
                 "localhost",
                 "127.0.0.1",
                 "::1",

--- a/tools/claude_hooks/mkcert_setup.py
+++ b/tools/claude_hooks/mkcert_setup.py
@@ -1,24 +1,27 @@
 """Install mkcert and generate a trusted localhost TLS certificate.
 
-mkcert creates a local Certificate Authority and installs it into system
-trust stores, then generates certificates signed by that CA. This gives
-localhost a valid TLS certificate trusted by curl, Python, Node, etc.
+mkcert creates a local Certificate Authority and generates certificates
+signed by that CA. This gives localhost a valid TLS certificate trusted
+by curl, Python, Node, etc. via the combined CA bundle (SSL_CERT_FILE).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import stat
-import subprocess
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+from opentelemetry import trace
 
 from tools.claude_hooks.platform_utils import get_platform
 from tools.claude_hooks.settings import HookSettings
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 MKCERT_VERSION = "1.4.4"
 
@@ -50,7 +53,13 @@ def _get_download_url() -> str:
     )
 
 
-def _download_mkcert(settings: HookSettings) -> Path:
+def _fetch_url_bytes(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=60) as response:
+        data: bytes = response.read()
+    return data
+
+
+async def _download_mkcert(settings: HookSettings) -> Path:
     """Download mkcert binary if not already present."""
     mkcert_dir = _get_mkcert_dir(settings)
     mkcert_path = _get_mkcert_binary(settings)
@@ -64,20 +73,23 @@ def _download_mkcert(settings: HookSettings) -> Path:
     url = _get_download_url()
     logger.info("Downloading mkcert from %s", url)
 
-    with urllib.request.urlopen(url, timeout=60) as response:
-        mkcert_path.write_bytes(response.read())
-
+    data = await asyncio.to_thread(_fetch_url_bytes, url)
+    mkcert_path.write_bytes(data)
     mkcert_path.chmod(mkcert_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     logger.info("Installed mkcert to %s", mkcert_path)
     return mkcert_path
 
 
-def _append_ca_to_bundle(root_ca: Path, combined_ca: Path) -> None:
+def append_mkcert_ca_to_bundle(ca_root: Path, combined_ca: Path) -> None:
     """Append mkcert root CA to the combined CA bundle.
 
     The combined CA bundle is recreated from scratch on each hook run
     (system CAs + proxy CA), so we always need to re-append.
     """
+    root_ca = ca_root / "rootCA.pem"
+    if not root_ca.exists():
+        logger.warning("mkcert root CA not found at %s, skipping bundle append", root_ca)
+        return
     ca_content = root_ca.read_text()
     with combined_ca.open("a") as f:
         f.write("\n# mkcert local CA\n")
@@ -85,12 +97,18 @@ def _append_ca_to_bundle(root_ca: Path, combined_ca: Path) -> None:
     logger.info("Appended mkcert root CA to %s", combined_ca)
 
 
-def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> MkcertSetup:
-    """Install mkcert, generate trusted localhost certificate.
+async def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> MkcertSetup:
+    """Generate a trusted localhost TLS certificate via mkcert.
 
-    Downloads mkcert, installs a local CA into system trust stores,
-    generates a certificate for localhost/127.0.0.1/::1, and appends
-    the root CA to the combined CA bundle so Python/curl/Node trust it.
+    Downloads the mkcert binary if needed, generates a certificate for
+    localhost/127.0.0.1/::1, and optionally appends the root CA to the
+    combined CA bundle so Python/curl/Node trust it via SSL_CERT_FILE.
+
+    Note: `mkcert -install` (system trust store installation) is intentionally
+    skipped. We rely on the combined CA bundle (SSL_CERT_FILE) for tool trust,
+    which doesn't require browser or OS trust store integration. mkcert
+    automatically creates rootCA.pem in CAROOT when generating the first cert,
+    so -install is not needed to produce the CA file.
     """
     mkcert_dir = _get_mkcert_dir(settings)
     mkcert_dir.mkdir(parents=True, exist_ok=True)
@@ -104,22 +122,12 @@ def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> MkcertSetu
     env = {**os.environ, "CAROOT": str(ca_root)}
 
     if not cert_path.exists() or not key_path.exists():
-        mkcert_bin = _download_mkcert(settings)
+        with tracer.start_as_current_span("mkcert_download_binary"):
+            mkcert_bin = await _download_mkcert(settings)
 
-        # Install local CA into system trust stores
-        logger.info("Installing mkcert local CA (CAROOT=%s)...", ca_root)
-        result = subprocess.run([str(mkcert_bin), "-install"], env=env, capture_output=True, text=True, check=False)
-        if result.returncode != 0:
-            # -install can fail if certutil (libnss3-tools) is missing;
-            # the CA still works for non-browser tools via the combined bundle
-            logger.warning("mkcert -install returned %d: %s", result.returncode, result.stderr.strip())
-        else:
-            logger.info("mkcert CA installed into system trust stores")
-
-        # Generate localhost certificate
         logger.info("Generating localhost certificate...")
-        subprocess.run(
-            [
+        with tracer.start_as_current_span("mkcert_generate_cert"):
+            proc = await asyncio.create_subprocess_exec(
                 str(mkcert_bin),
                 "-cert-file",
                 str(cert_path),
@@ -128,17 +136,17 @@ def setup_mkcert(settings: HookSettings, combined_ca: Path | None) -> MkcertSetu
                 "localhost",
                 "127.0.0.1",
                 "::1",
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError(f"mkcert certificate generation failed: {stderr.decode().strip()}")
         logger.info("Generated localhost cert: %s", cert_path)
 
-    # Append mkcert root CA to combined CA bundle so Python/curl/Node trust localhost
-    root_ca = ca_root / "rootCA.pem"
-    if combined_ca and combined_ca.exists() and root_ca.exists():
-        _append_ca_to_bundle(root_ca, combined_ca)
+    with tracer.start_as_current_span("mkcert_append_bundle"):
+        if combined_ca and combined_ca.exists():
+            append_mkcert_ca_to_bundle(ca_root, combined_ca)
 
     return MkcertSetup(cert_path=cert_path, key_path=key_path, ca_root=ca_root, status=f"installed ({cert_path})")

--- a/tools/claude_hooks/proxy_setup.py
+++ b/tools/claude_hooks/proxy_setup.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from cryptography import x509
+from opentelemetry import trace
 
 from bazel_util.subprocess import python_env
 from net_util.net import async_wait_for_port, is_port_in_use
@@ -27,6 +28,7 @@ from tools.claude_hooks.settings import HookSettings
 from tools.claude_hooks.supervisor.client import SupervisorClient
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # Env vars set by Bazel BUILD targets (rlocation keys for hermetic JDK files)
 _KEYTOOL_RLOCATION_ENV = "KEYTOOL_RLOCATION"
@@ -325,7 +327,8 @@ async def ensure_proxy_running(settings: HookSettings, supervisor: SupervisorCli
             name=AUTH_PROXY_SERVICE, command=command, directory=proxy_dir, environment=python_env(inherit=False)
         )
 
-    await _wait_for_proxy_running(settings, supervisor)
+    with tracer.start_as_current_span("proxy_wait_socket"):
+        await _wait_for_proxy_running(settings, supervisor)
     logger.info("Auth proxy running successfully")
 
 
@@ -396,16 +399,20 @@ async def setup_auth_proxy(
     settings.get_auth_proxy_dir().mkdir(parents=True, exist_ok=True)
 
     # Step 1: Start auth proxy first (needed for CA extraction)
-    await ensure_proxy_running(settings, supervisor)
+    with tracer.start_as_current_span("proxy_start_service"):
+        await ensure_proxy_running(settings, supervisor)
 
     # Step 2: Load the TLS inspection CA from filesystem
-    _extract_proxy_ca(settings)
+    with tracer.start_as_current_span("proxy_extract_ca"):
+        _extract_proxy_ca(settings)
 
     # Step 3: Create Java truststore with the CA
-    await _create_java_truststore(settings)
+    with tracer.start_as_current_span("proxy_create_truststore"):
+        await _create_java_truststore(settings)
 
     # Step 4: Create combined CA bundle (for tools like uv that use SSL_CERT_FILE)
-    _create_combined_ca_bundle(settings)
+    with tracer.start_as_current_span("proxy_create_bundle"):
+        _create_combined_ca_bundle(settings)
 
     status = await _snapshot_proxy_status(settings, supervisor, port)
     ca_status = "custom CA" if combined_ca.exists() else "system"

--- a/tools/claude_hooks/proxy_setup.py
+++ b/tools/claude_hooks/proxy_setup.py
@@ -149,6 +149,7 @@ def _is_anthropic_tls_inspection_ca(cert: x509.Certificate) -> bool:
     return org == ANTHROPIC_CA_ORG and ANTHROPIC_CA_CN_SUBSTRING in cn
 
 
+@tracer.start_as_current_span("proxy_extract_ca")
 def _extract_proxy_ca(settings: HookSettings) -> None:
     """Load the TLS inspection CA certificate from the filesystem.
 
@@ -332,6 +333,7 @@ async def ensure_proxy_running(settings: HookSettings, supervisor: SupervisorCli
     logger.info("Auth proxy running successfully")
 
 
+@tracer.start_as_current_span("proxy_create_bundle")
 def _create_combined_ca_bundle(settings: HookSettings) -> None:
     """Create a combined CA bundle with system CAs plus the proxy CA.
 
@@ -403,16 +405,14 @@ async def setup_auth_proxy(
         await ensure_proxy_running(settings, supervisor)
 
     # Step 2: Load the TLS inspection CA from filesystem
-    with tracer.start_as_current_span("proxy_extract_ca"):
-        _extract_proxy_ca(settings)
+    _extract_proxy_ca(settings)
 
     # Step 3: Create Java truststore with the CA
     with tracer.start_as_current_span("proxy_create_truststore"):
         await _create_java_truststore(settings)
 
     # Step 4: Create combined CA bundle (for tools like uv that use SSL_CERT_FILE)
-    with tracer.start_as_current_span("proxy_create_bundle"):
-        _create_combined_ca_bundle(settings)
+    _create_combined_ca_bundle(settings)
 
     status = await _snapshot_proxy_status(settings, supervisor, port)
     ca_status = "custom CA" if combined_ca.exists() else "system"

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -459,25 +459,25 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_p
             await mount_tmpfs_at(bazel_cache_dir)
             return tmpfs_setup.setup_bazel_cache(bazel_cache_dir)
 
+    @tracer.start_as_current_span("install_bazelisk", context=root_ctx)
     def install_bazelisk_wrapper() -> bazelisk_setup.BazeliskSetup:
         """Install bazelisk and wrapper as separate tasks.
 
         Always installs the wrapper. Optionally downloads bazelisk unless
         DUCKTAPE_CLAUDE_HOOKS_INSTALL_BAZELISK is False.
         """
-        with tracer.start_as_current_span("install_bazelisk", context=root_ctx):
-            wrapper_path = bazelisk_setup.install_wrapper(settings)
-            skipped = not settings.install_bazelisk
-            if not skipped:
-                bazelisk_setup.install_bazelisk(settings)
-            else:
-                logger.info("Skipping bazelisk download (install_bazelisk=False)")
-            return bazelisk_setup.BazeliskSetup(
-                bazelisk_path=settings.get_bazelisk_path(),
-                wrapper_path=wrapper_path,
-                settings=settings,
-                bazelisk_skipped=skipped,
-            )
+        wrapper_path = bazelisk_setup.install_wrapper(settings)
+        skipped = not settings.install_bazelisk
+        if not skipped:
+            bazelisk_setup.install_bazelisk(settings)
+        else:
+            logger.info("Skipping bazelisk download (install_bazelisk=False)")
+        return bazelisk_setup.BazeliskSetup(
+            bazelisk_path=settings.get_bazelisk_path(),
+            wrapper_path=wrapper_path,
+            settings=settings,
+            bazelisk_skipped=skipped,
+        )
 
     # Decrypt age-encrypted secrets from .claude_hooks/secrets/ in the repo checkout.
     with tracer.start_as_current_span("setup_secrets", context=root_ctx):

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -506,14 +506,26 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_p
     # Create proxy task with BuildBuddy configuration state
     proxy_task = asyncio.create_task(setup_proxy_with_supervisor(buildbuddy_configured=buildbuddy_configured))
 
-    async def setup_mkcert_with_proxy() -> mkcert_setup.MkcertSetup:
-        """Set up mkcert (depends on proxy for the combined CA bundle)."""
+    async def mkcert_generate_certs() -> mkcert_setup.MkcertSetup:
+        """Generate mkcert certs (no proxy dependency — runs immediately in parallel)."""
         with tracer.start_as_current_span("setup_mkcert", context=root_ctx):
             if not settings.install_mkcert:
                 raise SkipError("mkcert disabled (install_mkcert=False)")
+            # Pass combined_ca=None: bundle append happens in mkcert_append_bundle
+            return await mkcert_setup.setup_mkcert(settings, combined_ca=None)
+
+    # Start cert generation immediately, without waiting for the proxy.
+    mkcert_task = asyncio.create_task(mkcert_generate_certs())
+
+    async def mkcert_append_bundle() -> mkcert_setup.MkcertSetup:
+        """Append mkcert CA to the combined CA bundle (depends on proxy + cert gen)."""
+        with tracer.start_as_current_span("mkcert_append_bundle", context=root_ctx):
+            mkcert_result = await mkcert_task
             await proxy_task
             combined_ca = settings.get_auth_proxy_combined_ca()
-            return mkcert_setup.setup_mkcert(settings, combined_ca if combined_ca.exists() else None)
+            if combined_ca.exists():
+                mkcert_setup.append_mkcert_ca_to_bundle(mkcert_result.ca_root, combined_ca)
+            return mkcert_result
 
     async def traced_precommit():
         with tracer.start_as_current_span("install_precommit", context=root_ctx):
@@ -534,7 +546,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_p
         traced_nix(),
         run_in_thread(install_bazelisk_wrapper),
         setup_bazel_on_tmpfs(),
-        setup_mkcert_with_proxy(),
+        mkcert_append_bundle(),
         traced_cli_tools(),
         return_exceptions=True,
     )


### PR DESCRIPTION
mkcert_setup.py:
- Skip `mkcert -install` (was ~12s: certutil on NSS databases, not needed since we use SSL_CERT_FILE / combined CA bundle for tool trust)
- Make setup_mkcert async with asyncio.create_subprocess_exec
- Make _download_mkcert async with asyncio.to_thread
- Add OTel sub-spans: mkcert_download_binary, mkcert_generate_cert, mkcert_append_bundle
- Expose append_mkcert_ca_to_bundle() as public function for phase-split

session_start.py:
- Decouple mkcert cert generation from proxy: split into two phases
  - mkcert_generate_certs task: runs immediately in parallel with proxy
  - mkcert_append_bundle coroutine: awaits both cert gen + proxy, then appends
- Previously mkcert awaited proxy_task before any cert work, serializing ~4.8s of proxy startup onto the critical path unnecessarily

proxy_setup.py:
- Add OTel sub-spans: proxy_start_service, proxy_wait_socket, proxy_extract_ca, proxy_create_truststore, proxy_create_bundle

BUILD.bazel:
- Add @pypi//opentelemetry_api to mkcert_setup and proxy_setup deps

Expected: cold session init ~5s vs ~17s; critical path now supervisor → proxy (socket wait) → mkcert bundle append → tail.

https://claude.ai/code/session_01HjPYuVXbdeuXDF5zVhkiwU