### PR TITLE
Simplify database setup by removing drop_existing parameter

### DIFF
--- a/props/cli/cmd_db.py
+++ b/props/cli/cmd_db.py
@@ -79,7 +79,7 @@ def cmd_db_recreate(
     # Ensure databases exist before trying to connect
     typer.echo("Ensuring databases exist...")
     db: Database = ctx.obj
-    ensure_database_exists(db.config, db.config.database, drop_existing=False)
+    ensure_database_exists(db.config, db.config.database)
 
     # Recreate schema and sync model metadata
     console = Console()

--- a/props/db/setup.py
+++ b/props/db/setup.py
@@ -27,54 +27,15 @@ tracer = trace.get_tracer(__name__)
 
 
 @tracer.start_as_current_span("ensure_database_exists")
-def ensure_database_exists(base_config: DatabaseConfig, database_name: str, *, drop_existing: bool = False) -> None:
-    """Ensure a PostgreSQL database exists.
-
-    Args:
-        base_config: Config with connection params (database name will be replaced)
-        database_name: Name of database to create
-        drop_existing: If True, drop and recreate (for test setup).
-                      If False, create only if missing (for production).
-
-    Note: Does not terminate connections. Tests use unique database names so no
-          conflicts in setup. Connection termination remains in test teardown only.
-    """
+def ensure_database_exists(base_config: DatabaseConfig, database_name: str) -> None:
+    """Ensure a PostgreSQL database exists, creating it if absent."""
     postgres_config = base_config.with_database("postgres")
     engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
 
     with engine.connect() as conn:
-        if drop_existing:
-            # Fail fast if other sessions are connected to the target DB to surface
-            # cross-test interference instead of a vague DROP failure.
-            active_sessions = conn.execute(
-                text(
-                    """
-                    select pid, usename, application_name, client_addr
-                    from pg_stat_activity
-                    where datname = :dbname and pid <> pg_backend_pid()
-                    """
-                ),
-                {"dbname": database_name},
-            ).fetchall()
-
-            if active_sessions:
-                details = ", ".join(
-                    f"pid={pid} user={user} app={app or '-'} addr={addr or '-'}"
-                    for pid, user, app, addr in active_sessions
-                )
-                raise RuntimeError(
-                    "Test database in use by other sessions; aborting drop. "
-                    f"database={database_name}; sessions=[{details}]"
-                )
-
-            # Idempotent drop (for test setup)
-            conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
-
-        # Check if database exists
         result = conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :dbname"), {"dbname": database_name})
 
         if not result.fetchone():
-            # Create using safe identifier quoting
             raw_conn = conn.connection
             cursor = raw_conn.cursor()
             cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))

--- a/props/testing/fixtures/db.py
+++ b/props/testing/fixtures/db.py
@@ -103,6 +103,17 @@ def _terminate_and_drop_db(postgres_engine, db_name: str) -> None:
         conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
 
 
+def _setup_test_database(postgres_base_config: DatabaseConfig, db_name: str) -> tuple[Database, Engine]:
+    """Drop (if exists), create, and migrate a test database. Returns (database, postgres_engine)."""
+    postgres_config = postgres_base_config.with_database("postgres")
+    postgres_engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
+    _terminate_and_drop_db(postgres_engine, db_name)
+    ensure_database_exists(postgres_base_config, db_name)
+    database = Database(postgres_base_config.with_database(db_name))
+    database.recreate()
+    return database, postgres_engine
+
+
 def _sanitize_test_id(test_id: str, max_length: int = 63) -> str:
     """Sanitize pytest node ID for use in PostgreSQL database name."""
     # Keep only alphanumeric and underscore; replace other chars with underscore
@@ -133,15 +144,7 @@ def db(request: pytest.FixtureRequest, postgres_base_config: DatabaseConfig) -> 
     sanitized_id = _sanitize_test_id(test_node_id)
     db_name = f"props_test_{sanitized_id}"
 
-    ensure_database_exists(postgres_base_config, db_name, drop_existing=True)
-
-    test_config = postgres_base_config.with_database(db_name)
-
-    postgres_config = postgres_base_config.with_database("postgres")
-    postgres_engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
-
-    database = Database(test_config)
-    database.recreate()
+    database, postgres_engine = _setup_test_database(postgres_base_config, db_name)
 
     try:
         yield database
@@ -149,6 +152,7 @@ def db(request: pytest.FixtureRequest, postgres_base_config: DatabaseConfig) -> 
         database.dispose()
         keep_db = request.config.getoption("--keep-db") or os.environ.get("KEEP_TEST_DB") == "1"
         if keep_db:
+            test_config = postgres_base_config.with_database(db_name)
             print(f"\n\n=== KEEPING TEST DATABASE: {db_name} ===")
             print(f"Database config: {test_config}")
             print(f"Connect with: psql {test_config.url}")
@@ -196,14 +200,8 @@ async def _session_synced_db(
     Uses the session-scoped postgres container.
     """
     db_name = "props_test_session_shared"
-    ensure_database_exists(postgres_base_config, db_name, drop_existing=True)
-    test_config = postgres_base_config.with_database(db_name)
 
-    postgres_config = postgres_base_config.with_database("postgres")
-    postgres_engine = create_engine(postgres_config.url, isolation_level="AUTOCOMMIT")
-
-    database = Database(test_config)
-    database.recreate()
+    database, postgres_engine = _setup_test_database(postgres_base_config, db_name)
     _sync_test_fixtures(database, session_monkeypatch)
 
     try:


### PR DESCRIPTION
## Summary
Refactored database setup logic to simplify the `ensure_database_exists()` function by removing the `drop_existing` parameter and its associated complexity. Database dropping is now handled explicitly in test fixtures through a dedicated helper function.

## Key Changes
- **Simplified `ensure_database_exists()`**: Removed the `drop_existing` parameter and all conditional logic for dropping databases. The function now only creates a database if it doesn't exist.
- **Extracted test database setup**: Created `_setup_test_database()` helper function in `props/testing/fixtures/db.py` that explicitly handles the drop → create → migrate workflow for test databases.
- **Updated test fixtures**: Modified `db()` and `_session_synced_db()` fixtures to use the new `_setup_test_database()` helper, making the test setup flow more explicit and readable.
- **Removed drop_existing calls**: Updated `props/cli/cmd_db.py` to call `ensure_database_exists()` without the `drop_existing` parameter.

## Implementation Details
- The `_setup_test_database()` helper encapsulates the full test database lifecycle: terminating existing connections, dropping the database if it exists, creating it fresh, and running migrations.
- This change separates concerns: production code (`ensure_database_exists`) handles simple creation, while test code explicitly manages the more complex drop/recreate workflow.
- The refactoring improves code clarity by making test database setup intentions explicit rather than hidden behind a boolean flag.

https://claude.ai/code/session_01E4RQD5Zu5H99Sj9nhKdFX5