### PR TITLE
Mark slow tests as medium size in Bazel configuration

### DIFF
--- a/props/agents/grader/BUILD.bazel
+++ b/props/agents/grader/BUILD.bazel
@@ -163,6 +163,7 @@ py_test(
 
 py_test(
     name = "test_grading_edges_constraints",
+    size = "medium",
     srcs = ["test_grading_edges_constraints.py"],
     imports = ["../../.."],
     requires_docker = True,

--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -114,6 +114,7 @@ py_test(
 
 py_test(
     name = "test_sync_occurrence_update",
+    size = "medium",
     srcs = ["test_sync_occurrence_update.py"],
     imports = ["../../.."],
     requires_docker = True,


### PR DESCRIPTION
## Summary
Updated Bazel test configurations to mark two slow-running tests with the `size = "medium"` attribute, allowing the test runner to allocate appropriate resources and timeouts for these tests.

## Key Changes
- Added `size = "medium"` to `test_grading_edges_constraints` in `props/agents/grader/BUILD.bazel`
- Added `size = "medium"` to `test_sync_occurrence_update` in `props/db/sync/BUILD.bazel`

## Details
These tests require Docker and have longer execution times than typical unit tests. Marking them as medium-sized tests ensures Bazel applies appropriate resource constraints and timeout values during test execution, improving test reliability and CI/CD pipeline efficiency.

https://claude.ai/code/session_01WGyjduXFwBoW3ArTRkzcrQ