### PR TITLE
Replace python/runfiles with bazel_util/runfiles utility

### DIFF
--- a/tools/precommit/BUILD.bazel
+++ b/tools/precommit/BUILD.bazel
@@ -60,9 +60,9 @@ py_binary(
     deps = [
         ":check_filename_conventions",
         ":check_terraform_centralization",
+        "//bazel_util:runfiles",
         "//bazel_util:workspace",
         "//tools:check_pytest_main",
         "@pypi//pygit2",
-        "@rules_python//python/runfiles",
     ],
 )

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -28,28 +28,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pygit2
-from python.runfiles import runfiles
 
+from bazel_util.runfiles import get_required_path
 from bazel_util.workspace import get_build_workspace_directory
 from tools.check_pytest_main import check_files_async
 from tools.precommit.check_filename_conventions import check_filename_conventions
 from tools.precommit.check_terraform_centralization import find_violations
 
-_RUNFILES_OPT = runfiles.Create()
-if _RUNFILES_OPT is None:
-    raise RuntimeError("Could not create runfiles")
-_RUNFILES: runfiles.Runfiles = _RUNFILES_OPT
-
 # Attributes that mark a file as ignored — matches rules_lint behavior and tools/format/formatter.py.
 _LINT_IGNORED_ATTRS = ("linguist-generated", "gitlab-generated", "rules-lint-ignored")
-
-
-def resolve_bin(rlocation: str) -> str:
-    """Resolve a runfiles path to an absolute path."""
-    path = _RUNFILES.Rlocation(rlocation)
-    if not path or not Path(path).exists():
-        raise RuntimeError(f"Could not resolve {rlocation}")
-    return path
 
 
 def _is_lint_ignored(repo: pygit2.Repository, path: Path) -> bool:
@@ -131,7 +118,7 @@ async def run_subprocess_validation(
         return ValidationResult(name, Skipped())
 
     start = time.perf_counter()
-    validate_bin = resolve_bin(bin_rlocation)
+    validate_bin = get_required_path(bin_rlocation)
     cmd = [validate_bin] + (extra_args or [])
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=repo_root


### PR DESCRIPTION
This PR refactors the runfiles resolution logic in the precommit tool to use a centralized utility function instead of directly using the Python runfiles library.

**Key changes:**
- Removed direct dependency on `@rules_python//python/runfiles` and replaced with `//bazel_util:runfiles`
- Removed the `resolve_bin()` function from `precommit.py` and replaced its usage with `get_required_path()` from `bazel_util.runfiles`
- Eliminated manual runfiles initialization code (`_RUNFILES_OPT` and `_RUNFILES` variables)
- Updated BUILD.bazel dependencies to reflect the new import

**Implementation details:**
The `get_required_path()` utility function provides the same functionality as the removed `resolve_bin()` function - it resolves a runfiles path to an absolute path and raises a RuntimeError if the path cannot be resolved or doesn't exist. This change centralizes runfiles handling logic and reduces duplication across the codebase.

https://claude.ai/code/session_01AnXTS2itaLzUYBNqutofQp