### PR TITLE
Add meta_icon URLs to Authentik SSO application blueprints

### DIFF
--- a/cluster/k8s/authentik/sso-blueprints.yaml
+++ b/cluster/k8s/authentik/sso-blueprints.yaml
@@ -121,6 +121,7 @@ data:
           protocol_provider: !KeyOf gitea-provider
           meta_description: "Gitea Git Repository Management"
           meta_publisher: "Gitea"
+          meta_icon: "https://cdn.simpleicons.org/gitea"
           open_in_new_tab: true
 
   # --- Grafana OAuth2 SSO ---
@@ -163,6 +164,7 @@ data:
           protocol_provider: !KeyOf grafana-provider
           meta_description: "Grafana Monitoring and Observability"
           meta_publisher: "Grafana Labs"
+          meta_icon: "https://cdn.simpleicons.org/grafana"
           open_in_new_tab: true
 
   # --- Harbor OAuth2 SSO ---
@@ -205,6 +207,7 @@ data:
           protocol_provider: !KeyOf harbor-provider
           meta_description: "Harbor Container Registry"
           meta_publisher: "Harbor"
+          meta_icon: "https://cdn.simpleicons.org/harbor"
           open_in_new_tab: true
 
   # --- Matrix OAuth2 SSO ---
@@ -247,6 +250,7 @@ data:
           protocol_provider: !KeyOf matrix-provider
           meta_description: "Matrix Chat (Element Web)"
           meta_launch_url: "https://chat.allegedly.works"
+          meta_icon: "https://cdn.simpleicons.org/element"
           open_in_new_tab: true
 
   # --- Vault OAuth2/OIDC SSO ---
@@ -291,6 +295,7 @@ data:
           protocol_provider: !KeyOf vault-provider
           meta_description: "HashiCorp Vault Secrets Management"
           meta_publisher: "HashiCorp"
+          meta_icon: "https://cdn.simpleicons.org/vault"
           open_in_new_tab: true
 
   # --- Loki Proxy SSO ---
@@ -387,6 +392,7 @@ data:
           protocol_provider: !KeyOf hubble-provider
           meta_description: "Cilium Hubble Network Observability"
           meta_launch_url: "https://hubble.allegedly.works"
+          meta_icon: "https://cdn.simpleicons.org/cilium"
           open_in_new_tab: true
 
       - model: authentik_policies.policybinding


### PR DESCRIPTION
## Summary
This change adds icon URLs to the Authentik SSO application blueprints, improving the visual presentation of applications in the Authentik user interface by displaying branded icons from Simple Icons CDN.

## Key Changes
- Added `meta_icon` field to 6 SSO application configurations:
  - Gitea: `https://cdn.simpleicons.org/gitea`
  - Grafana: `https://cdn.simpleicons.org/grafana`
  - Harbor: `https://cdn.simpleicons.org/harbor`
  - Matrix (Element): `https://cdn.simpleicons.org/element`
  - Vault: `https://cdn.simpleicons.org/vault`
  - Cilium Hubble: `https://cdn.simpleicons.org/cilium`

## Implementation Details
- Icons are sourced from the Simple Icons CDN, providing consistent and recognizable branding for each application
- The `meta_icon` field is placed alongside other metadata fields (`meta_description`, `meta_publisher`, `meta_launch_url`)
- This enhancement improves user experience by providing visual cues in the Authentik portal for quick application identification

https://claude.ai/code/session_01D5MVergeB7fhrqo6Mwctwb