### PR TITLE
Add Headlamp cluster UI behind Authentik

### DIFF
--- a/cluster/k8s/authentik-proxy-routes/headlamp-httproute.yaml
+++ b/cluster/k8s/authentik-proxy-routes/headlamp-httproute.yaml
@@ -1,0 +1,20 @@
+# HTTPRoute for Headlamp via Authentik proxy outpost.
+# Traffic flows: Gateway → outpost (auth) → Headlamp backend.
+# The outpost service (ak-outpost-headlamp-outpost) is auto-created by Authentik
+# when the blueprint deploys the outpost.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "headlamp.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: ak-outpost-headlamp-outpost
+          port: 9000

--- a/cluster/k8s/authentik-proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik-proxy-routes/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - openclaw-httproute.yaml
   - gatus-httproute.yaml
   - grocy-httproute.yaml
+  - headlamp-httproute.yaml

--- a/cluster/k8s/authentik/sso-blueprints.yaml
+++ b/cluster/k8s/authentik/sso-blueprints.yaml
@@ -639,6 +639,68 @@ data:
             authentik_host: "http://authentik-server.authentik:80"
             authentik_host_browser: "https://auth.allegedly.works"
 
+  # --- Headlamp Proxy SSO ---
+  headlamp-sso.yaml: |
+    version: 1
+    metadata:
+      name: SSO - Headlamp
+      labels:
+        blueprints.goauthentik.io/description: "Headlamp proxy provider, application, and outpost"
+
+    entries:
+      - model: authentik_providers_proxy.proxyprovider
+        id: headlamp-provider
+        state: present
+        identifiers:
+          name: headlamp
+        attrs:
+          external_host: "https://headlamp.allegedly.works"
+          internal_host: "http://headlamp.headlamp.svc.cluster.local:4466"
+          mode: proxy
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          access_token_validity: "hours=8"
+
+      - model: authentik_core.application
+        id: headlamp-app
+        state: present
+        identifiers:
+          slug: headlamp
+        attrs:
+          name: Headlamp
+          protocol_provider: !KeyOf headlamp-provider
+          meta_description: "Kubernetes cluster UI"
+          meta_launch_url: "https://headlamp.allegedly.works"
+          meta_icon: "https://headlamp.dev/img/headlamp_logo.svg"
+          open_in_new_tab: true
+
+      - model: authentik_policies.policybinding
+        state: present
+        identifiers:
+          target: !KeyOf headlamp-app
+          group: !Find [authentik_core.group, [name, authentik Admins]]
+          order: 0
+
+      - model: authentik_outposts.outpost
+        state: present
+        identifiers:
+          name: headlamp-outpost
+        attrs:
+          type: proxy
+          protocol_providers:
+            - !KeyOf headlamp-provider
+          service_connection: !Find [authentik_outposts.kubernetesserviceconnection, [name, Local Kubernetes Cluster]]
+          config:
+            authentik_host: "http://authentik-server.authentik:80"
+            authentik_host_browser: "https://auth.allegedly.works"
+            kubernetes_json_patches:
+              deployment:
+                - op: add
+                  path: /spec/template/spec/nodeSelector
+                  value:
+                    topology.kubernetes.io/region: hetzner
+
   # --- Grocy Proxy SSO ---
   grocy-sso.yaml: |
     version: 1

--- a/cluster/k8s/headlamp-namespace/flux-kustomization.yaml
+++ b/cluster/k8s/headlamp-namespace/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headlamp-namespace
+  namespace: flux-system
+spec:
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./cluster/k8s/headlamp-namespace"
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: v1
+      kind: Namespace
+      name: headlamp

--- a/cluster/k8s/headlamp-namespace/kustomization.yaml
+++ b/cluster/k8s/headlamp-namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml

--- a/cluster/k8s/headlamp-namespace/namespace.yaml
+++ b/cluster/k8s/headlamp-namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlamp

--- a/cluster/k8s/headlamp/flux-kustomization.yaml
+++ b/cluster/k8s/headlamp/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: headlamp
+  namespace: flux-system
+spec:
+  interval: 10m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./cluster/k8s/headlamp"
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: headlamp
+      namespace: headlamp
+  dependsOn:
+    - name: headlamp-namespace
+    - name: gateway
+    - name: authentik

--- a/cluster/k8s/headlamp/helmrelease.yaml
+++ b/cluster/k8s/headlamp/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  interval: 24h
+  url: https://headlamp-k8s.github.io/headlamp/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  interval: 15m
+  install:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: headlamp
+      version: "0.26.0"
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp
+        namespace: headlamp
+  values:
+    replicaCount: 1
+
+    ingress:
+      enabled: false
+
+    nodeSelector:
+      topology.kubernetes.io/region: hetzner
+    tolerations:
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+
+    # Flux plugin installed via initContainer.
+    # The initContainer copies plugin files to a shared emptyDir mounted at pluginsDir.
+    initContainers:
+      - name: headlamp-plugin-flux
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:latest
+        command: ["/bin/sh", "-c", "cp -r /plugins/. /headlamp/plugins/"]
+        volumeMounts:
+          - name: headlamp-plugins
+            mountPath: /headlamp/plugins
+
+    volumes:
+      - name: headlamp-plugins
+        emptyDir: {}
+
+    volumeMounts:
+      - name: headlamp-plugins
+        mountPath: /headlamp/plugins

--- a/cluster/k8s/headlamp/kustomization.yaml
+++ b/cluster/k8s/headlamp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helmrelease.yaml
+  # HTTPRoute is in authentik-proxy-routes/headlamp-httproute.yaml (SSO-protected via Authentik outpost).

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -75,6 +75,8 @@ resources:
   - gatus-namespace/flux-kustomization.yaml
   - gatus-secrets/flux-kustomization.yaml
   - gatus/flux-kustomization.yaml
+  - headlamp-namespace/flux-kustomization.yaml
+  - headlamp/flux-kustomization.yaml
   - ollama-namespace/flux-kustomization.yaml
   - ollama-secrets/flux-kustomization.yaml
   - ollama/flux-kustomization.yaml


### PR DESCRIPTION
## Summary

- Deploys Headlamp at `https://headlamp.allegedly.works`, protected by Authentik proxy outpost (same pattern as Hubble, Loki, OpenClaw)
- Includes the `headlamp-plugin-flux` initContainer so Flux Kustomizations, HelmReleases, and GitRepositories are visible alongside pods/logs/events
- Authentik blueprint creates a proxy provider + outpost pinned to hetzner (always-on)

## Files

- `cluster/k8s/headlamp-namespace/` — Namespace
- `cluster/k8s/headlamp/helmrelease.yaml` — HelmRelease (`headlamp` chart 0.26.0) with Flux plugin initContainer
- `authentik/sso-blueprints.yaml` — `headlamp-sso` proxy provider + outpost
- `authentik-proxy-routes/headlamp-httproute.yaml` — HTTPRoute → `ak-outpost-headlamp-outpost:9000`

## Test plan

- [ ] Flux reconciles `headlamp-namespace` and `headlamp` Kustomizations
- [ ] Headlamp pod starts; Flux plugin initContainer copies files without error
- [ ] Authentik blueprint applies `headlamp-sso` and creates `ak-outpost-headlamp-outpost` service in `authentik` namespace
- [ ] `https://headlamp.allegedly.works` redirects to Authentik login, then proxies through to Headlamp
- [ ] Flux tab visible in Headlamp sidebar showing Kustomizations/HelmReleases

## Notes

- Chart version `0.26.0` and plugin image tag `latest` may need adjusting if unavailable; easy to update
- No secrets required — Headlamp uses its auto-created `cluster-admin` ClusterRoleBinding (Helm chart default)

https://claude.ai/code/session_01BS7iGdE2an6oiNyFBrva3c