### PR TITLE
Add Headscale OIDC SSO integration with Authentik

### DIFF
--- a/cluster/k8s/applications/headscale/flux-kustomization.yaml
+++ b/cluster/k8s/applications/headscale/flux-kustomization.yaml
@@ -27,3 +27,4 @@ spec:
     - name: gateway
     - name: cert-manager-environment
     - name: local-path-provisioner
+    - name: authentik-blueprint-headscale-secret # OIDC client secret must exist before deploy

--- a/cluster/k8s/applications/headscale/helmrelease.yaml
+++ b/cluster/k8s/applications/headscale/helmrelease.yaml
@@ -19,6 +19,12 @@ spec:
   install:
     remediation:
       retries: 3
+  valuesFrom:
+    # Injects headscale.config.oidc.client_secret from Vault (via ExternalSecret).
+    # client_secret is kept out of ConfigMaps by merging it here at deploy time.
+    - kind: Secret
+      name: headscale-oidc-client-secret
+      valuesKey: values.yaml
   chart:
     spec:
       chart: headscale
@@ -48,6 +54,18 @@ spec:
         log:
           format: text
           level: info
+        # OIDC authentication via Authentik — client_secret injected via valuesFrom
+        oidc:
+          only_start_if_oidc_is_available: true
+          issuer: "https://auth.allegedly.works/application/o/headscale/"
+          client_id: "headscale"
+          scope: ["openid", "profile", "email"]
+          strip_email_domain: true
+          expiry: "180d"
+          use_expiry_from_token: false
+          pkce:
+            enabled: true
+            method: S256
 
     persistence:
       enabled: true

--- a/cluster/k8s/authentik-blueprint/headscale-secret/client-secret-eso.yaml
+++ b/cluster/k8s/authentik-blueprint/headscale-secret/client-secret-eso.yaml
@@ -1,0 +1,30 @@
+---
+# ExternalSecret for Headscale OIDC client secret from Vault.
+# Generates a values.yaml fragment consumed by the HelmRelease via valuesFrom,
+# injecting client_secret into headscale.config.oidc without storing it in a ConfigMap.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headscale-oidc-client-secret
+  namespace: headscale
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: headscale-oidc-client-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        values.yaml: |
+          headscale:
+            config:
+              oidc:
+                client_secret: "{{ .client_secret }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/headscale
+        property: client_secret

--- a/cluster/k8s/authentik-blueprint/headscale-secret/flux-kustomization.yaml
+++ b/cluster/k8s/authentik-blueprint/headscale-secret/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: authentik-blueprint-headscale-secret
+  namespace: flux-system
+spec:
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./cluster/k8s/authentik-blueprint/headscale-secret"
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: headscale-oidc-client-secret
+      namespace: headscale
+  dependsOn:
+    - name: headscale-namespace # headscale namespace exists
+    - name: external-secrets-config # ClusterSecretStore exists
+    - name: authentik-blueprint-sso-secrets # Vault data exists

--- a/cluster/k8s/authentik-blueprint/headscale-secret/kustomization.yaml
+++ b/cluster/k8s/authentik-blueprint/headscale-secret/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-kustomization.yaml
+  - client-secret-eso.yaml

--- a/cluster/k8s/authentik-sso-secrets/sso-client-secrets-eso.yaml
+++ b/cluster/k8s/authentik-sso-secrets/sso-client-secrets-eso.yaml
@@ -39,6 +39,10 @@ spec:
       remoteRef:
         key: sso/inventree
         property: client_secret
+    - secretKey: HEADSCALE_CLIENT_SECRET
+      remoteRef:
+        key: sso/headscale
+        property: client_secret
     - secretKey: USER_PASSWORD
       remoteRef:
         key: kv/users/agentydragon

--- a/cluster/k8s/authentik/blueprints/headscale-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/headscale-sso.yaml
@@ -1,0 +1,40 @@
+version: 1
+metadata:
+  name: SSO - Headscale
+  labels:
+    blueprints.goauthentik.io/description: "Headscale OIDC provider and application"
+
+entries:
+  - model: authentik_providers_oauth2.oauth2provider
+    id: headscale-provider
+    state: present
+    identifiers:
+      name: headscale-oauth2
+    attrs:
+      client_id: headscale
+      client_secret: !Env HEADSCALE_CLIENT_SECRET
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      client_type: confidential
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      redirect_uris:
+        - url: "https://headscale.allegedly.works/oidc/callback"
+          matching_mode: strict
+
+  - model: authentik_core.application
+    state: present
+    identifiers:
+      slug: headscale
+    attrs:
+      name: Headscale
+      provider: !KeyOf headscale-provider
+      meta_description: "Headscale VPN Coordination Server"
+      meta_publisher: "Headscale"
+      meta_icon: "https://cdn.simpleicons.org/tailscale"
+      open_in_new_tab: true

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -103,6 +103,7 @@ resources:
   - authentik-blueprint/matrix-secret/flux-kustomization.yaml
   - authentik-blueprint/vault-secret/flux-kustomization.yaml
   - authentik-blueprint/inventree-secret/flux-kustomization.yaml
+  - authentik-blueprint/headscale-secret/flux-kustomization.yaml
   - inventree-namespace/flux-kustomization.yaml
   - applications/inventree-secrets/flux-kustomization.yaml
   - applications/inventree/flux-kustomization.yaml

--- a/cluster/terraform/gitops/sso-secrets/main.tf
+++ b/cluster/terraform/gitops/sso-secrets/main.tf
@@ -87,6 +87,16 @@ resource "random_password" "inventree_client_secret" {
   }
 }
 
+resource "random_password" "headscale_client_secret" {
+  length  = 32
+  special = false
+  keepers = { rotation_version = var.rotation_version }
+
+  lifecycle {
+    ignore_changes = [length, special]
+  }
+}
+
 # --- Vault Storage: Basic Credentials ---
 
 resource "vault_kv_secret_v2" "gitea_oidc" {
@@ -146,6 +156,16 @@ resource "vault_kv_secret_v2" "inventree_oidc" {
   data_json = jsonencode({
     client_id     = "inventree"
     client_secret = random_password.inventree_client_secret.result
+  })
+}
+
+resource "vault_kv_secret_v2" "headscale_oidc" {
+  mount = "kv"
+  name  = "sso/headscale"
+
+  data_json = jsonencode({
+    client_id     = "headscale"
+    client_secret = random_password.headscale_client_secret.result
   })
 }
 


### PR DESCRIPTION
## Summary
This PR adds complete OIDC single sign-on (SSO) integration between Headscale and Authentik, enabling users to authenticate to the Headscale VPN coordination server using their Authentik credentials.

## Key Changes

- **Authentik Blueprint**: Created `headscale-sso.yaml` defining the OAuth2 provider and application configuration for Headscale with OIDC scopes (openid, email, profile) and strict redirect URI matching
- **Secret Management**: 
  - Added Terraform resources to generate and store Headscale OIDC client credentials in Vault (`sso/headscale`)
  - Created ExternalSecret to inject the client secret into Headscale's Helm values at deploy time, keeping sensitive data out of ConfigMaps
  - Updated the main SSO secrets ExternalSecret to include the Headscale client secret for Authentik blueprint consumption
- **Headscale Configuration**: 
  - Updated HelmRelease to include OIDC configuration with Authentik as the issuer
  - Configured PKCE (S256 method) for enhanced security
  - Set token expiry to 180 days with email domain stripping enabled
  - Added `valuesFrom` to merge the client secret from the ExternalSecret at deploy time
- **Deployment Dependencies**: Added proper Flux Kustomization dependencies to ensure secrets are created before Headscale deployment

## Implementation Details

- Client secret is generated as a 32-character random string without special characters
- OIDC issuer URL: `https://auth.allegedly.works/application/o/headscale/`
- Redirect URI: `https://headscale.allegedly.works/oidc/callback` (strict matching)
- Uses Authentik's default provider authorization and invalidation flows
- Secrets are refreshed every 24 hours via ExternalSecret

https://claude.ai/code/session_01PKuVyxKJmiXFbdjRmape1w