### PR TITLE
Refactor CI secrets handling to use inherit pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,13 @@ jobs:
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'rbe-image')
     uses: ./.github/workflows/rbe-image.yml
   props-backend-image:
-    needs: compute-targets
-    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'props-backend-image')
+    needs:
+      - compute-targets
+      - rbe-image
+    if: always() && !cancelled() && !failure() && contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'props-backend-image')
     uses: ./.github/workflows/props-backend-image.yml
+    with:
+      rbe_image: ${{ needs.rbe-image.outputs.rbe_image }}
     secrets: inherit
   props-agents-image:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'props-backend-image')
     uses: ./.github/workflows/props-backend-image.yml
+    secrets: inherit
   props-agents-image:
     needs:
       - compute-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'props-backend-image')
     uses: ./.github/workflows/props-backend-image.yml
-    secrets: inherit
   props-agents-image:
     needs:
       - compute-targets

--- a/.github/workflows/props-backend-image.yml
+++ b/.github/workflows/props-backend-image.yml
@@ -14,6 +14,19 @@ name: Props Backend Image
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      rbe_image:
+        description: "Override RBE container image (optional)"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      BUILDBUDDY_API_KEY:
+        required: false
+      HARBOR_ROBOT_USERNAME:
+        required: true
+      HARBOR_ROBOT_TOKEN:
+        required: true
 
 concurrency:
   # Use hardcoded name to avoid deadlock when called via workflow_call
@@ -39,6 +52,7 @@ jobs:
         id: bazel
         with:
           buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          rbe_image: ${{ inputs.rbe_image }}
 
       - name: Build and load image
         run: bazel run //props/backend:load

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -111,7 +111,7 @@ RBE_IMAGE_JOB = "rbe-image"
 
 def _uses_rbe(name: str, config: WorkflowConfig) -> bool:
     """Whether this workflow uses BuildBuddy RBE and should receive rbe_image."""
-    return name != RBE_IMAGE_JOB and "BUILDBUDDY_API_KEY" in config.secrets
+    return name != RBE_IMAGE_JOB and config.secrets == "inherit"
 
 
 def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: bool) -> Job:
@@ -141,7 +141,7 @@ def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: 
         if_cond=if_cond,
         uses=f"./.github/workflows/{name}.yml",
         with_args=with_args if with_args else None,
-        secrets="inherit" if config.secrets else None,
+        secrets=config.secrets,
     )
 
 

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -111,11 +111,7 @@ RBE_IMAGE_JOB = "rbe-image"
 
 def _uses_rbe(name: str, config: WorkflowConfig) -> bool:
     """Whether this workflow uses BuildBuddy RBE and should receive rbe_image."""
-    if name == RBE_IMAGE_JOB:
-        return False
-    if config.rbe is not None:
-        return config.rbe
-    return "BUILDBUDDY_API_KEY" in config.secrets
+    return name != RBE_IMAGE_JOB and "BUILDBUDDY_API_KEY" in config.secrets
 
 
 def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: bool) -> Job:

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -111,7 +111,11 @@ RBE_IMAGE_JOB = "rbe-image"
 
 def _uses_rbe(name: str, config: WorkflowConfig) -> bool:
     """Whether this workflow uses BuildBuddy RBE and should receive rbe_image."""
-    return name != RBE_IMAGE_JOB and "BUILDBUDDY_API_KEY" in config.secrets
+    if name == RBE_IMAGE_JOB:
+        return False
+    if config.rbe is not None:
+        return config.rbe
+    return "BUILDBUDDY_API_KEY" in config.secrets
 
 
 def build_workflow_job(name: str, config: WorkflowConfig, *, has_rbe_image_job: bool) -> Job:

--- a/tools/ci/models.py
+++ b/tools/ci/models.py
@@ -59,7 +59,7 @@ class WorkflowConfig(BaseModel):
     trigger: WorkflowTrigger
     targets: bool = False
     inputs: dict[str, str] = Field(default_factory=dict)
-    secrets: list[str] = Field(default_factory=list)
+    secrets: Literal["inherit"] | None = None
 
 
 class ReleaseConfig(BaseModel):

--- a/tools/ci/models.py
+++ b/tools/ci/models.py
@@ -60,11 +60,6 @@ class WorkflowConfig(BaseModel):
     targets: bool = False
     inputs: dict[str, str] = Field(default_factory=dict)
     secrets: list[str] = Field(default_factory=list)
-    # Whether this workflow uses BuildBuddy RBE and should receive rbe_image as
-    # an input and depend on the rbe-image job. Defaults to True when
-    # BUILDBUDDY_API_KEY is in secrets, but can be set False for workflows that
-    # use BuildBuddy only for remote caching (not RBE image execution).
-    rbe: bool | None = None
 
 
 class ReleaseConfig(BaseModel):

--- a/tools/ci/models.py
+++ b/tools/ci/models.py
@@ -60,6 +60,11 @@ class WorkflowConfig(BaseModel):
     targets: bool = False
     inputs: dict[str, str] = Field(default_factory=dict)
     secrets: list[str] = Field(default_factory=list)
+    # Whether this workflow uses BuildBuddy RBE and should receive rbe_image as
+    # an input and depend on the rbe-image job. Defaults to True when
+    # BUILDBUDDY_API_KEY is in secrets, but can be set False for workflows that
+    # use BuildBuddy only for remote caching (not RBE image execution).
+    rbe: bool | None = None
 
 
 class ReleaseConfig(BaseModel):

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -10,7 +10,7 @@
 #
 # Job options:
 #   targets: Pass affected targets to the workflow (default: false)
-#   secrets: List of secrets to pass (default: [BUILDBUDDY_API_KEY])
+#   secrets: inherit - pass all caller secrets to the workflow (also implies RBE wiring)
 #   inputs: Additional inputs to pass to the workflow
 #
 # Workflow file changes automatically trigger their workflow.
@@ -21,7 +21,7 @@ workflows:
   bazel-check:
     trigger: { kind: bazel_query, query: "$targets" }
     targets: true
-    secrets: [BUILDBUDDY_API_KEY]
+    secrets: inherit
 
   bazel-test:
     # Java (keytool) is provided hermetically via //third_party/jdk.
@@ -30,7 +30,7 @@ workflows:
     # Bazel's default wildcard exclusion of manual targets.
     trigger: { kind: bazel_query, query: 'kind(".*_test rule", $targets) except attr(tags, "manual", $targets)' }
     targets: true
-    secrets: [BUILDBUDDY_API_KEY]
+    secrets: inherit
 
   # Image builds
   rbe-image:
@@ -38,7 +38,7 @@ workflows:
 
   props-backend-image:
     trigger: { kind: bazel_query, query: "$targets intersect set(//props/backend:image)" }
-    secrets: [BUILDBUDDY_API_KEY]
+    secrets: inherit
 
   props-agents-image:
     trigger:
@@ -55,7 +55,7 @@ workflows:
           //props/agents/critic/variants:high_recall
           //props/agents/critic/variants:verbose_docs
         )
-    secrets: [BUILDBUDDY_API_KEY]
+    secrets: inherit
 
   # Path-based workflows (non-Bazel)
   nix-flake-check:

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -39,7 +39,6 @@ workflows:
   props-backend-image:
     trigger: { kind: bazel_query, query: "$targets intersect set(//props/backend:image)" }
     secrets: [BUILDBUDDY_API_KEY]
-    rbe: false
 
   props-agents-image:
     trigger:

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -38,6 +38,8 @@ workflows:
 
   props-backend-image:
     trigger: { kind: bazel_query, query: "$targets intersect set(//props/backend:image)" }
+    secrets: [BUILDBUDDY_API_KEY]
+    rbe: false
 
   props-agents-image:
     trigger:


### PR DESCRIPTION
## Summary
This PR refactors the CI workflow secrets handling to use a simpler "inherit" pattern instead of explicitly listing individual secrets. It also adds support for passing the RBE image output from the `rbe-image` job to dependent workflows.

## Key Changes

- **Secrets model change**: Updated `WorkflowConfig.secrets` from `list[str]` to `Literal["inherit"] | None` to support the inherit pattern
- **Workflow configuration updates**: Changed all workflows that use BuildBuddy RBE (`bazel-check`, `bazel-test`, `props-agents-image`) to use `secrets: inherit` instead of explicitly listing `BUILDBUDDY_API_KEY`
- **Props backend image workflow**: 
  - Added explicit `secrets: inherit` configuration
  - Added input parameter `rbe_image` to accept the RBE container image override
  - Updated the bazel setup step to pass the `rbe_image` input
- **CI job orchestration**: Modified `props-backend-image` job to depend on both `compute-targets` and `rbe-image` jobs, with conditional logic to handle job dependencies properly
- **RBE image propagation**: Added logic to pass the `rbe_image` output from the `rbe-image` job to the `props-backend-image` job via workflow inputs
- **Generator logic**: Updated `_uses_rbe()` function to check for `config.secrets == "inherit"` instead of checking for `BUILDBUDDY_API_KEY` in the secrets list

## Implementation Details

The refactoring simplifies secret management by using GitHub Actions' `secrets: inherit` feature, which automatically passes all secrets from the caller workflow to the called workflow. This eliminates the need to maintain explicit lists of required secrets in the configuration.

The RBE image output is now properly threaded through the workflow dependency chain, allowing the `props-backend-image` workflow to use a custom RBE image if one was built by the `rbe-image` job.

https://claude.ai/code/session_015jf4WMEBz8p4DiMCyT4sRq