### PR TITLE
Add cluster diagnostics reader RBAC role and binding

### DIFF
--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -33,14 +33,36 @@ rules:
     resources:
       - horizontalpodautoscalers
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.k8s.io"]
     resources:
       - ingresses
+      - ingressclasses
       - networkpolicies
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources:
       - storageclasses
+      - volumeattachments
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources:
+      - priorityclasses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
     verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources:

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -64,6 +64,13 @@ rules:
     resources:
       - customresourcedefinitions
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - certificaterequests
+      - issuers
+      - clusterissuers
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources:
       - pods

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -71,6 +71,29 @@ rules:
       - issuers
       - clusterissuers
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - helmrepositories
+      - ocirepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources:
       - pods

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -99,3 +99,7 @@ rules:
       - pods
       - nodes
     verbs: ["get", "list", "watch"]
+# TODO: configmaps — decide scope: cluster-wide (risk: may contain connection strings/secrets)
+#   vs. namespaced Roles for specific namespaces (e.g. kube-system, flux-system) vs. skip.
+# TODO: pods/log — most useful for diagnostics but logs routinely contain printed secrets/tokens.
+#   Decide: cluster-wide, restrict to specific namespaces via namespaced Roles, or skip.

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-diagnostics-reader
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - pods
+      - pods/status
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - persistentvolumes
+      - resourcequotas
+      - limitranges
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - pods
+      - nodes
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/claude-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-diagnostics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-diagnostics-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw

--- a/cluster/k8s/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/claude-rbac/kustomization.yaml
@@ -17,3 +17,5 @@ resources:
   - rolebinding-sandbox-openclaw.yaml
   - rolebinding-props-reader-openclaw.yaml
   - rolebinding-gatus-reader-openclaw.yaml
+  - clusterrole-cluster-diagnostics-reader.yaml
+  - clusterrolebinding-cluster-diagnostics-reader.yaml


### PR DESCRIPTION
## Summary
This PR introduces a new ClusterRole and ClusterRoleBinding to enable read-only access to cluster diagnostics information for Claude and OpenClaw service accounts.

## Key Changes
- **New ClusterRole (`cluster-diagnostics-reader`)**: Grants read-only access (get, list, watch) to a comprehensive set of Kubernetes resources across multiple API groups, including:
  - Core resources (nodes, namespaces, pods, services, volumes, etc.)
  - Workload resources (deployments, statefulsets, jobs, etc.)
  - Networking resources (ingresses, network policies)
  - Storage resources (storage classes, volume attachments)
  - RBAC resources (roles, rolebindings, cluster roles/bindings)
  - Cert-manager resources (certificates, issuers)
  - Flux CD resources (git repositories, helm releases)
  - Metrics resources (pod and node metrics)

- **New ClusterRoleBinding (`cluster-diagnostics-reader`)**: Binds the ClusterRole to:
  - `claude-code-web` ServiceAccount in the `default` namespace
  - `openclaw` ServiceAccount in the `openclaw` namespace

- **Updated kustomization.yaml**: Registers the new RBAC resources for deployment

## Notable Implementation Details
- The role is intentionally read-only (get, list, watch verbs only) to minimize security risk
- Two TODOs are included for future consideration:
  - ConfigMaps access (currently excluded due to potential exposure of sensitive connection strings)
  - Pod logs access (excluded due to risk of exposing secrets/tokens in logs)
- These decisions can be revisited and implemented via namespaced Roles if needed

https://claude.ai/code/session_01H64JfmBXybCqgkGJz1xy5F