### PR TITLE
Enable in-cluster auth for Headlamp and document OIDC migration plan

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -119,6 +119,12 @@ are not found"`. Added `kubectl wait --for=condition=Established` before Cilium 
       and enter it once in the UI settings. Investigate options: operator exposing token
       in bootstrap config, gateway-side token injection into served HTML, or upstream
       PR to accept `"trusted-proxy"` in `sharedAuthOk` (message-handler.ts:385-387).
+- [ ] **Headlamp: per-user OIDC auth** — Currently uses a shared `cluster-admin` ServiceAccount
+      (`inCluster: true`). Switch to OIDC so Kubernetes API calls are made under the
+      authenticated user's identity with per-user RBAC: 1. Configure k3s `--oidc-issuer-url` (Authentik OIDC endpoint) and `--oidc-client-id` 2. Update Headlamp HelmRelease to use OIDC flow (pointing at Authentik) 3. Create `ClusterRoleBinding`s mapping Authentik groups → Kubernetes roles
+      (e.g. `authentik Admins` → `cluster-admin`)
+      Benefit: audit logs show real usernames; compromised Authentik session can't
+      exceed RBAC permissions; no single shared all-powerful SA token.
 - [ ] **Ollama: per-user auth** — OpenClaw currently talks directly to Ollama (no auth,
       dummy `OLLAMA_API_KEY` env var). Wire up proper auth: either re-introduce LiteLLM
       proxy with API key (once OpenClaw's OpenAI streaming handler supports
@@ -201,6 +207,7 @@ No separate ansible-managed VPS. Everything currently on the VPS must move into 
 | OpenClaw       | AI coding agent        | ✅  |
 | Gatus          | Health monitoring      | ✅  |
 | Grocy          | Household/grocery mgmt | ✅  |
+| Headlamp       | Kubernetes cluster UI  | ✅  |
 
 ## Applications (disabled - need flux-kustomization.yaml)
 

--- a/cluster/k8s/headlamp/helmrelease.yaml
+++ b/cluster/k8s/headlamp/helmrelease.yaml
@@ -32,6 +32,9 @@ spec:
     # Use in-cluster ServiceAccount for Kubernetes API access.
     # The chart creates a ClusterRoleBinding to cluster-admin by default,
     # so no token needs to be pasted in the UI.
+    # TODO: Consider switching to OIDC auth so Kubernetes API calls are made
+    # under the authenticated user's identity (requires configuring k3s
+    # --oidc-issuer-url to trust Authentik and Headlamp to use OIDC flow).
     inCluster: true
 
     ingress:

--- a/cluster/k8s/headlamp/helmrelease.yaml
+++ b/cluster/k8s/headlamp/helmrelease.yaml
@@ -29,6 +29,11 @@ spec:
   values:
     replicaCount: 1
 
+    # Use in-cluster ServiceAccount for Kubernetes API access.
+    # The chart creates a ClusterRoleBinding to cluster-admin by default,
+    # so no token needs to be pasted in the UI.
+    inCluster: true
+
     ingress:
       enabled: false
 


### PR DESCRIPTION
## Summary
Enables Headlamp to use in-cluster Kubernetes API access via ServiceAccount authentication, and documents the future migration path to per-user OIDC authentication.

## Changes
- **HelmRelease configuration**: Set `inCluster: true` in Headlamp values to use the in-cluster ServiceAccount for Kubernetes API access. The chart automatically creates a ClusterRoleBinding to cluster-admin, eliminating the need to manually paste tokens in the UI.
- **Documentation**: 
  - Added a TODO comment explaining the rationale for in-cluster auth and the planned migration to OIDC
  - Added a new task in the plan documenting the OIDC migration strategy, including:
    - Configuration steps for k3s OIDC integration with Authentik
    - Per-user RBAC via ClusterRoleBindings mapping Authentik groups to Kubernetes roles
    - Benefits: audit trail with real usernames, RBAC-bounded compromised sessions, elimination of shared all-powerful tokens
  - Updated the applications table to mark Headlamp as deployed (✅)

## Implementation Details
The current implementation uses a shared cluster-admin ServiceAccount for simplicity. The documented OIDC migration path provides a clear roadmap for future enhancement to support per-user authentication and fine-grained access control.

https://claude.ai/code/session_016EUsVr3mFrqJ6FQxYf2cFw