### PR TITLE
Add localsend for local file sharing across devices

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -508,6 +508,7 @@ in
       # System utilities
       scrcpy # Android screen mirroring
       virt-viewer # SPICE/VNC viewer for virtual machines (Proxmox viewer)
+      localsend # Local file sharing across devices (LAN)
 
       # Learning
       anki


### PR DESCRIPTION
## Summary
Added localsend package to the home configuration for local file sharing capabilities across devices on a LAN.

## Changes
- Added `localsend` to the system utilities section in `home.nix`
  - Positioned alongside other system utilities like `scrcpy` and `virt-viewer`
  - Enables local file sharing across devices without requiring internet connectivity

## Details
This addition provides a convenient tool for transferring files between devices on the same local network, complementing the existing system utilities in the configuration.

https://claude.ai/code/session_01GEqts3xtbJBhTpahhzgerc