### PR TITLE
Remove completed Gatus direct HTTPRoute task from plan

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -101,9 +101,6 @@ are not found"`. Added `kubectl wait --for=condition=Established` before Cilium 
 - [ ] **Gatus: LiteLLM inference health probe** — Add a Gatus endpoint that sends a
       lightweight chat completion request to `ollama.allegedly.works` and verifies a
       valid response. Proves the full LiteLLM→Ollama inference pipeline is working.
-- [ ] **Gatus: remove direct HTTPRoute** — Once Authentik proxy outpost is confirmed working,
-      remove the direct HTTPRoute from `k8s/gatus/` (proxy route in `authentik-proxy-routes/`
-      takes over)
 - [ ] **Nix cache: initialize Attic cache** — Attic server is running but has no caches
       created (empty `cache` table). `cache.allegedly.works/nix-cache-info` returns 404
       because Attic serves that endpoint per-cache at `/<name>/nix-cache-info`. Fix: run


### PR DESCRIPTION
## Summary
Removed a completed task from the cluster documentation plan that tracked the removal of the direct HTTPRoute from Gatus once the Authentik proxy outpost was confirmed working.

## Changes
- Removed the "Gatus: remove direct HTTPRoute" task from `cluster/docs/plan.md`
  - This task has been completed as the Authentik proxy outpost is now confirmed working
  - The direct HTTPRoute in `k8s/gatus/` has been replaced by the proxy route in `authentik-proxy-routes/`

## Notes
This is a documentation-only change reflecting the completion of a previously tracked infrastructure task.

https://claude.ai/code/session_01NwCmfsKM1zL34e75FtH1Pi