### PR TITLE
Fix ollama kustomization: add namespace for configMapGenerator

### DIFF
--- a/cluster/k8s/ollama/kustomization.yaml
+++ b/cluster/k8s/ollama/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: ollama
 resources:
   - pvc.yaml
   - deployment.yaml


### PR DESCRIPTION
## Summary

- Add `namespace: ollama` to `cluster/k8s/ollama/kustomization.yaml`
- The `configMapGenerator` was producing `gpt-oss-modelfiles` and `gpt-oss-scripts` ConfigMaps without a namespace, causing Flux to fail with: `ConfigMap/gpt-oss-scripts namespace not specified: the server could not find the requested resource`
- This blocked the `setup-gpt-oss-v1` job from ever being applied (model downloads never ran)

## Test plan

- [ ] Flux `ollama` kustomization reconciles successfully (currently `False`)
- [ ] `setup-gpt-oss-v1` job appears in `ollama` namespace and completes
- [ ] `gpt-oss:20b`, `gpt-oss:120b`, `gpt-oss-256k`, `gpt-oss-512k` models available in ollama

https://claude.ai/code/session_01EgDwkkLgjMcFMWe8C1p2og