### PR TITLE
Auto-configure fork remote with GitHub token authentication

### DIFF
--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -7,7 +7,7 @@
   **PR workflow** (bot is NOT a collaborator on `agentydragon/ducktape`, so use the fork):
   ```bash
   # 1. Add fork remote with GITHUB_TOKEN auth (one-time)
-  git remote add fork "https://agentydragon-agent:${GITHUB_TOKEN}@github.com/agentydragon-agent/ducktape.git"
+  git remote add fork "https://agentydragon-agent:${'$'}{GITHUB_TOKEN}@github.com/agentydragon-agent/ducktape.git"
 
   # 2. Push branch to fork
   git push -u fork <branch-name>

--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -4,18 +4,24 @@
 % if secrets:
 % if "GITHUB_TOKEN" in secrets.env_vars:
 `GITHUB_TOKEN`: GitHub PAT for the `agentydragon-agent` bot account. Used by `gh` CLI automatically.
-  **PR workflow** (bot is NOT a collaborator on `agentydragon/ducktape`, so use the fork):
+  **PR workflow** (`origin` pushes to `agentydragon/ducktape` via proxy, but bot is NOT a collaborator so PRs must come from a fork):
+% if fork_result and fork_result.fork_exists:
+  `fork` remote pre-configured → `https://github.com/${fork_result.username}/${fork_result.repo_name}.git`
   ```bash
-  # 1. Add fork remote with GITHUB_TOKEN auth (one-time)
-  git remote add fork "https://agentydragon-agent:${'$'}{GITHUB_TOKEN}@github.com/agentydragon-agent/ducktape.git"
-
-  # 2. Push branch to fork
   git push -u fork <branch-name>
-
-  # 3. Create PR from fork to main repo
+  gh pr create --repo agentydragon/ducktape --head ${fork_result.username}:<branch-name> --base devel
+  ```
+% elif fork_result and not fork_result.fork_exists:
+  **Fork `https://github.com/${fork_result.username}/${fork_result.repo_name}` not found** — create it first, then re-run session start.
+  Once the fork exists the `fork` remote will be auto-configured on the next session.
+% else:
+  Fork remote setup unavailable this session. Manually:
+  ```bash
+  git remote add fork "https://agentydragon-agent:${'$'}{GITHUB_TOKEN}@github.com/agentydragon-agent/ducktape.git"
+  git push -u fork <branch-name>
   gh pr create --repo agentydragon/ducktape --head agentydragon-agent:<branch-name> --base devel
   ```
-  The `origin` remote pushes to `agentydragon/ducktape` through the Claude Code integration proxy, but you can't create PRs directly (bot isn't a collaborator). Fork + GITHUB_TOKEN is the working workflow.
+% endif
 % endif
 Ollama: OpenAI-compatible LLM inference at `https://ollama.allegedly.works/v1` (2x RTX 5090). Served via LiteLLM proxy.
   Available model: `gpt-oss-20b-128k` (OpenAI gpt-oss 20B, 128K context, Apache 2.0).

--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -12,8 +12,13 @@
   gh pr create --repo agentydragon/ducktape --head ${fork_result.username}:<branch-name> --base devel
   ```
 % elif fork_result and not fork_result.fork_exists:
-  **Fork `https://github.com/${fork_result.username}/${fork_result.repo_name}` not found** — create it first, then re-run session start.
-  Once the fork exists the `fork` remote will be auto-configured on the next session.
+  **Fork `https://github.com/${fork_result.username}/${fork_result.repo_name}` not found.** Create it and add the remote:
+  ```bash
+  gh repo fork agentydragon/ducktape --org ${fork_result.username} --clone=false
+  git remote add fork "https://${fork_result.username}:${'$'}{GITHUB_TOKEN}@github.com/${fork_result.username}/${fork_result.repo_name}.git"
+  git push -u fork <branch-name>
+  gh pr create --repo agentydragon/ducktape --head ${fork_result.username}:<branch-name> --base devel
+  ```
 % else:
   Fork remote setup unavailable this session. Manually:
   ```bash

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -247,6 +247,7 @@ py_library(
     srcs = ["fork_remote_setup.py"],
     imports = ["../.."],
     visibility = ["//visibility:public"],
+    deps = ["@pypi//pygit2"],
 )
 
 # === Libraries for binary sources ===
@@ -407,6 +408,7 @@ py_wheel(
         "pydantic-settings",
         "pyjwt",
         "pyrage",
+        "pygit2",
         "pyyaml",
         "supervisor",
         "tenacity",

--- a/tools/claude_hooks/BUILD.bazel
+++ b/tools/claude_hooks/BUILD.bazel
@@ -242,6 +242,13 @@ py_library(
     ],
 )
 
+py_library(
+    name = "fork_remote_setup",
+    srcs = ["fork_remote_setup.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+)
+
 # === Libraries for binary sources ===
 # py_library targets for source files that are also py_binary entry points.
 # py_package depends on these (not the py_binary targets) to avoid pulling in
@@ -284,6 +291,7 @@ py_library(
         ":debug",
         ":env_file",
         ":errors",
+        ":fork_remote_setup",
         ":kubeconfig_setup",
         ":mkcert_setup",
         ":nix_setup",
@@ -353,6 +361,7 @@ py_package(
         ":container_runtime",
         ":env_file",
         ":errors",
+        ":fork_remote_setup",
         ":kubeconfig_setup",
         ":managed_files",
         ":mkcert_setup",

--- a/tools/claude_hooks/fork_remote_setup.py
+++ b/tools/claude_hooks/fork_remote_setup.py
@@ -1,0 +1,112 @@
+"""Set up 'fork' git remote for GitHub token-based push access.
+
+When a GITHUB_TOKEN is available, introspects the authenticated GitHub user,
+checks whether their fork of the current repo exists, and if so ensures the
+'fork' remote points at it with token-based HTTPS authentication embedded in
+the URL.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ForkRemoteSetup:
+    """Result of fork remote setup."""
+
+    username: str
+    repo_name: str
+    fork_exists: bool
+    # action is set only when fork_exists is True
+    action: str  # "added", "updated", "already_correct", "fork_not_found"
+
+
+def _github_api_get(path: str, github_token: str) -> dict[str, Any]:
+    """Make an authenticated GET request to the GitHub API."""
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"token {github_token}",
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "ducktape-session-hook/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        return cast(dict[str, Any], json.loads(response.read()))
+
+
+def _introspect_github_user(github_token: str) -> str:
+    """Introspect GitHub username from token via the API."""
+    return cast(str, _github_api_get("/user", github_token)["login"])
+
+
+def _check_fork_exists(username: str, repo_name: str, github_token: str) -> bool:
+    """Return True if the repo exists under the given username."""
+    try:
+        _github_api_get(f"/repos/{username}/{repo_name}", github_token)
+        return True
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return False
+        raise
+
+
+def _get_repo_name_from_origin(project_dir: Path) -> str | None:
+    """Extract repo name from git origin remote URL."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"], check=False, capture_output=True, text=True, cwd=project_dir
+    )
+    if result.returncode != 0:
+        return None
+    origin_url = result.stdout.strip()
+    # Matches both HTTPS (owner/repo.git) and SSH (owner:repo.git) URL forms.
+    match = re.search(r"[/:]([^/:]+?)(?:\.git)?$", origin_url)
+    return match.group(1) if match else None
+
+
+def ensure_fork_remote(github_token: str, project_dir: Path) -> ForkRemoteSetup:
+    """Ensure the 'fork' remote points at the authenticated user's fork with token auth.
+
+    If the fork does not yet exist on GitHub, returns a result with
+    fork_exists=False and does not modify git config.
+
+    The embedded token allows password-less git push without a credential helper.
+    """
+    username = _introspect_github_user(github_token)
+    repo_name = _get_repo_name_from_origin(project_dir)
+    if repo_name is None:
+        raise RuntimeError("Could not determine repo name from git origin remote")
+
+    if not _check_fork_exists(username, repo_name, github_token):
+        logger.warning("Fork not found at https://github.com/%s/%s — create it there first", username, repo_name)
+        return ForkRemoteSetup(username=username, repo_name=repo_name, fork_exists=False, action="fork_not_found")
+
+    fork_url = f"https://{username}:{github_token}@github.com/{username}/{repo_name}.git"
+
+    current = subprocess.run(
+        ["git", "remote", "get-url", "fork"], check=False, capture_output=True, text=True, cwd=project_dir
+    )
+    current_url = current.stdout.strip() if current.returncode == 0 else None
+
+    if current_url is None:
+        subprocess.run(["git", "remote", "add", "fork", fork_url], check=True, cwd=project_dir)
+        action = "added"
+    elif current_url == fork_url:
+        action = "already_correct"
+    else:
+        subprocess.run(["git", "remote", "set-url", "fork", fork_url], check=True, cwd=project_dir)
+        action = "updated"
+
+    logger.info("Fork remote %s: https://github.com/%s/%s.git", action, username, repo_name)
+    return ForkRemoteSetup(username=username, repo_name=repo_name, fork_exists=True, action=action)

--- a/tools/claude_hooks/fork_remote_setup.py
+++ b/tools/claude_hooks/fork_remote_setup.py
@@ -10,15 +10,23 @@ from __future__ import annotations
 
 import json
 import logging
-import re
-import subprocess
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, cast
 
+import pygit2
+
 logger = logging.getLogger(__name__)
+
+
+class ForkRemoteAction(StrEnum):
+    ADDED = "added"
+    UPDATED = "updated"
+    ALREADY_CORRECT = "already_correct"
+    FORK_NOT_FOUND = "fork_not_found"
 
 
 @dataclass
@@ -28,8 +36,7 @@ class ForkRemoteSetup:
     username: str
     repo_name: str
     fork_exists: bool
-    # action is set only when fork_exists is True
-    action: str  # "added", "updated", "already_correct", "fork_not_found"
+    action: ForkRemoteAction
 
 
 def _github_api_get(path: str, github_token: str) -> dict[str, Any]:
@@ -63,16 +70,17 @@ def _check_fork_exists(username: str, repo_name: str, github_token: str) -> bool
 
 
 def _get_repo_name_from_origin(project_dir: Path) -> str | None:
-    """Extract repo name from git origin remote URL."""
-    result = subprocess.run(
-        ["git", "remote", "get-url", "origin"], check=False, capture_output=True, text=True, cwd=project_dir
-    )
-    if result.returncode != 0:
+    """Extract repo name from the git origin remote URL."""
+    try:
+        repo = pygit2.Repository(str(project_dir))
+    except pygit2.GitError:
         return None
-    origin_url = result.stdout.strip()
-    # Matches both HTTPS (owner/repo.git) and SSH (owner:repo.git) URL forms.
-    match = re.search(r"[/:]([^/:]+?)(?:\.git)?$", origin_url)
-    return match.group(1) if match else None
+    origin = next((r for r in repo.remotes if r.name == "origin"), None)
+    if origin is None or origin.url is None:
+        return None
+    url = origin.url.rstrip("/")
+    url = url.removesuffix(".git")
+    return url.split("/")[-1]
 
 
 def ensure_fork_remote(github_token: str, project_dir: Path) -> ForkRemoteSetup:
@@ -90,23 +98,23 @@ def ensure_fork_remote(github_token: str, project_dir: Path) -> ForkRemoteSetup:
 
     if not _check_fork_exists(username, repo_name, github_token):
         logger.warning("Fork not found at https://github.com/%s/%s — create it there first", username, repo_name)
-        return ForkRemoteSetup(username=username, repo_name=repo_name, fork_exists=False, action="fork_not_found")
+        return ForkRemoteSetup(
+            username=username, repo_name=repo_name, fork_exists=False, action=ForkRemoteAction.FORK_NOT_FOUND
+        )
 
     fork_url = f"https://{username}:{github_token}@github.com/{username}/{repo_name}.git"
 
-    current = subprocess.run(
-        ["git", "remote", "get-url", "fork"], check=False, capture_output=True, text=True, cwd=project_dir
-    )
-    current_url = current.stdout.strip() if current.returncode == 0 else None
+    repo = pygit2.Repository(str(project_dir))
+    fork_remote = next((r for r in repo.remotes if r.name == "fork"), None)
 
-    if current_url is None:
-        subprocess.run(["git", "remote", "add", "fork", fork_url], check=True, cwd=project_dir)
-        action = "added"
-    elif current_url == fork_url:
-        action = "already_correct"
+    if fork_remote is None:
+        repo.remotes.create("fork", fork_url)
+        action = ForkRemoteAction.ADDED
+    elif fork_remote.url == fork_url:
+        action = ForkRemoteAction.ALREADY_CORRECT
     else:
-        subprocess.run(["git", "remote", "set-url", "fork", fork_url], check=True, cwd=project_dir)
-        action = "updated"
+        repo.remotes.set_url("fork", fork_url)
+        action = ForkRemoteAction.UPDATED
 
     logger.info("Fork remote %s: https://github.com/%s/%s.git", action, username, repo_name)
     return ForkRemoteSetup(username=username, repo_name=repo_name, fork_exists=True, action=action)

--- a/tools/claude_hooks/session_start.py
+++ b/tools/claude_hooks/session_start.py
@@ -33,6 +33,7 @@ from tools.claude_hooks import (
     cli_tools_setup,
     container_runtime,
     env_file,
+    fork_remote_setup,
     kubeconfig_setup,
     mkcert_setup,
     nix_setup,
@@ -266,13 +267,17 @@ def format_environment_summary() -> str:
     return "\n".join(lines)
 
 
-def _render_extra_context(project_dir: Path, secrets: secrets_setup.SecretsSetup | None) -> str:
+def _render_extra_context(
+    project_dir: Path,
+    secrets: secrets_setup.SecretsSetup | None,
+    fork_result: fork_remote_setup.ForkRemoteSetup | None = None,
+) -> str:
     """Render repo-specific context from .claude_hooks/templates/context.mako if it exists."""
     extra_template_path = project_dir / _HOOKS_DOTDIR / "templates" / "context.mako"
     if not extra_template_path.exists():
         return ""
     template = Template(extra_template_path.read_text())
-    result: str = template.render(secrets=secrets)
+    result: str = template.render(secrets=secrets, fork_result=fork_result)
     return result.rstrip("\n")
 
 
@@ -285,6 +290,7 @@ def emit_session_context(
     precommit: precommit_setup.PrecommitSetup | None,
     secrets: secrets_setup.SecretsSetup | None,
     mkcert: mkcert_setup.MkcertSetup | None = None,
+    fork_result: fork_remote_setup.ForkRemoteSetup | None = None,
 ) -> None:
     """Emit compact context summary for Claude Code transcript.
 
@@ -294,7 +300,7 @@ def emit_session_context(
     """
     status = "ERRORS" if collector.has_errors else "OK with warnings" if collector.has_warnings else "OK"
 
-    extra_context = _render_extra_context(project_dir, secrets)
+    extra_context = _render_extra_context(project_dir, secrets, fork_result)
 
     template = Template((_TEMPLATES_DIR / "session_context.mako").read_text())
     result: str = template.render(
@@ -625,6 +631,15 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_p
                 proxy_ca_pem=proxy_ca_pem,
             )
 
+    # Ensure 'fork' git remote when GITHUB_TOKEN is available.
+    fork_result: fork_remote_setup.ForkRemoteSetup | None = None
+    if secrets and "GITHUB_TOKEN" in secrets.env_vars:
+        try:
+            with tracer.start_as_current_span("setup_fork_remote", context=root_ctx):
+                fork_result = fork_remote_setup.ensure_fork_remote(secrets.env_vars["GITHUB_TOKEN"], project_dir)
+        except Exception as e:
+            logger.warning("Fork remote setup failed: %s", e)
+
     # Render session bazelrc (unified for web mode with proxy configuration)
     with tracer.start_as_current_span("render_bazelrc", context=root_ctx):
         truststore = settings.get_auth_proxy_truststore()
@@ -712,6 +727,7 @@ async def run_web_mode(hook_input: HookInput, settings: HookSettings, env_file_p
             precommit=None if isinstance(precommit, BaseException) else precommit,
             secrets=secrets,
             mkcert=None if isinstance(mkcert, BaseException) else mkcert,
+            fork_result=fork_result,
         )
 
     root_span.end()


### PR DESCRIPTION
## Summary
Add automatic setup of a `fork` git remote that uses GitHub token-based authentication, enabling seamless push access to the user's fork without requiring manual configuration or credential helpers.

## Key Changes
- **New module `fork_remote_setup.py`**: Implements fork remote configuration logic
  - Introspects authenticated GitHub user from `GITHUB_TOKEN`
  - Checks if user's fork of the current repo exists on GitHub
  - Creates or updates the `fork` remote with token-embedded HTTPS URL for password-less pushes
  - Returns detailed setup result with action taken (added/updated/already correct/not found)

- **Updated `session_start.py`**: Integrates fork remote setup into session initialization
  - Calls `ensure_fork_remote()` when `GITHUB_TOKEN` is available
  - Passes fork setup result to context rendering
  - Gracefully handles setup failures with warning logging

- **Enhanced `context.mako` template**: Provides dynamic PR workflow instructions
  - Shows pre-configured fork remote when setup succeeds
  - Provides fork creation instructions when fork doesn't exist
  - Includes ready-to-use `git push` and `gh pr create` commands
  - Falls back to manual instructions if setup unavailable

- **Build configuration**: Added `fork_remote_setup` library target with `pygit2` dependency

## Implementation Details
- Uses GitHub API v3 for user introspection and fork existence checks
- Embeds token directly in remote URL (`https://username:token@github.com/...`) for authentication
- Leverages `pygit2` for git repository operations
- Handles edge cases: missing origin remote, fork not found, remote already configured
- Logs all actions for debugging and user awareness

https://claude.ai/code/session_01EapSC7P5Lr4WRRF71NPn7z