### PR TITLE
chore: add [skip ci] to flux image automation commit messages

### DIFF
--- a/cluster/k8s/flux-image-automation/image-update-automation.yaml
+++ b/cluster/k8s/flux-image-automation/image-update-automation.yaml
@@ -17,7 +17,7 @@ spec:
         name: flux-image-automation
         email: flux@allegedly.works
       messageTemplate: |-
-        chore: update props-backend image
+        chore: update props-backend image [skip ci]
         {{ range $resource, $changes := .Changed.Objects -}}
         {{ range $_, $change := $changes -}}
         {{ $change.OldValue }} -> {{ $change.NewValue }}


### PR DESCRIPTION
## Summary

- Adds `[skip ci]` to the Flux `ImageUpdateAutomation` commit message template for `props-backend`

## Problem

Flux commits directly to `devel` on every new image tag. CI is configured to do a **full build** on every `devel` push, which always includes `props-backend-image`. This pushes a new image tag, which Flux then commits again — an indefinite feedback loop (~10 min cycle).

## Fix

GitHub Actions natively skips workflows when `[skip ci]` appears in the commit message. Adding it to the `messageTemplate` breaks the loop with no other changes needed.

## Test plan

- [ ] After merging, verify the next Flux automation commit message contains `[skip ci]`
- [ ] Verify no CI run is triggered for that commit

https://claude.ai/code/session_01CAqsXajj1DH1FhWJK4uoYQ