### PR TITLE
feat(lightburn): simplify cut param model in material test generator

### DIFF
--- a/experimental/lightburn_material_test/BUILD.bazel
+++ b/experimental/lightburn_material_test/BUILD.bazel
@@ -26,10 +26,12 @@ py_binary(
 py_test(
     name = "test_material_test",
     srcs = ["test_material_test.py"],
+    data = ["example_config.toml"],
     imports = ["../.."],
     deps = [
         ":lbrn2_writer",
         ":material_test_lib",
+        "//bazel_util:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/experimental/lightburn_material_test/BUILD.bazel
+++ b/experimental/lightburn_material_test/BUILD.bazel
@@ -26,12 +26,10 @@ py_binary(
 py_test(
     name = "test_material_test",
     srcs = ["test_material_test.py"],
-    data = ["example_config.toml"],
     imports = ["../.."],
     deps = [
         ":lbrn2_writer",
         ":material_test_lib",
-        "//bazel_util:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/experimental/lightburn_material_test/example_config.toml
+++ b/experimental/lightburn_material_test/example_config.toml
@@ -49,28 +49,13 @@ show_cell_text = true   # print x and y parameter values inside each cell
 [border]
 enabled = true
 padding = 3      # mm outside the grid cells
-
-[border.cut]     # full cut parameter set (same fields as [cut])
-power = 10       # % shorthand: sets both power_min and power_max
-# power_min = 10
-# power_max = 10
+power = 10       # %
 speed = 200      # mm/s
-# kerf = 0.0
-# z_offset = 0.0
-# z_per_pass = 0.0
-# num_passes = 1
 
 # ── Text/annotation layer ─────────────────────────────────────────────────────
-# Full cut parameter set (same fields as [cut]).
 [text_layer]
-power = 15       # % shorthand: sets both power_min and power_max — low power just for marking
-# power_min = 15
-# power_max = 15
+power = 15       # % — low power just for marking
 speed = 200      # mm/s
-# kerf = 0.0
-# z_offset = 0.0
-# z_per_pass = 0.0
-# num_passes = 1
 
 # ── Font and text sizes ───────────────────────────────────────────────────────
 [font]

--- a/experimental/lightburn_material_test/material_test.py
+++ b/experimental/lightburn_material_test/material_test.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 
 from experimental.lightburn_material_test.lbrn2_writer import (
     AnyShape,
+    CutMode,
     CutSetting,
     HAlign,
     LightBurnProject,
@@ -69,10 +70,23 @@ def fmt_val(v: float) -> str:
 # ── Pydantic config models ─────────────────────────────────────────────────────
 
 
-class CutParams(BaseModel):
-    """Full set of laser cut parameters for a single fixed layer.
+class AxisConfig(BaseModel):
+    """Configuration for one grid axis (X or Y)."""
 
-    Use `power` as shorthand to set both power_min and power_max simultaneously.
+    model_config = ConfigDict(extra="forbid")
+
+    param: CutParam
+    values: list[float]
+    label: str | None = None  # None = auto-generate from param name + unit; "" = no label
+    show_annotations: bool = True
+
+
+class CutConfig(BaseModel):
+    """Laser cut parameters held constant across the entire grid.
+
+    The x/y axis parameters override their respective entries here for each cell.
+
+    Use 'power' to set both min and max simultaneously.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -87,7 +101,7 @@ class CutParams(BaseModel):
     num_passes: int = 1
 
     @model_validator(mode="after")
-    def apply_power_shorthand(self) -> CutParams:
+    def apply_power_shorthand(self) -> CutConfig:
         if self.power is not None:
             self.power_min = self.power
             self.power_max = self.power
@@ -105,24 +119,6 @@ class CutParams(BaseModel):
             z_per_pass=self.z_per_pass,
             num_passes=self.num_passes,
         )
-
-
-class AxisConfig(BaseModel):
-    """Configuration for one grid axis (X or Y)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    param: CutParam
-    values: list[float]
-    label: str | None = None  # None = auto-generate from param name + unit; "" = no label
-    show_annotations: bool = True
-
-
-class CutConfig(CutParams):
-    """Laser cut parameters held constant across the entire grid.
-
-    The x/y axis parameters override their respective entries here for each cell.
-    """
 
 
 class GeometryConfig(BaseModel):
@@ -149,7 +145,17 @@ class BorderConfig(BaseModel):
 
     enabled: bool = False
     padding: float = 3.0  # mm outside the grid cells
-    cut: CutParams = CutParams(power_min=10.0, power_max=10.0, speed=200.0)
+    power: float = 10.0  # %
+    speed: float = 200.0  # mm/s
+
+
+class TextLayerConfig(BaseModel):
+    """Cut settings for the annotation text layer (layer 0)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    power: float = 15.0  # %
+    speed: float = 200.0  # mm/s
 
 
 class FontConfig(BaseModel):
@@ -183,8 +189,7 @@ class GridConfig(BaseModel):
     geometry: GeometryConfig = GeometryConfig()
     annotations: AnnotationConfig = AnnotationConfig()
     border: BorderConfig = BorderConfig()
-    # text_layer: cut settings for layer 0 (annotation text); x/y axis params do not apply here
-    text_layer: CutParams = CutParams(power_min=15.0, power_max=15.0, speed=200.0)
+    text_layer: TextLayerConfig = TextLayerConfig()
     font: FontConfig = FontConfig()
 
     @model_validator(mode="after")
@@ -309,7 +314,16 @@ def generate(config: GridConfig) -> LightBurnProject:
     shapes: list[AnyShape] = []
 
     # Layer 0: annotation text
-    cut_settings.append(config.text_layer.to_cut_setting(_TEXT_LAYER, "Text"))
+    cut_settings.append(
+        CutSetting(
+            index=_TEXT_LAYER,
+            name="Text",
+            mode=CutMode.CUT,
+            min_power=config.text_layer.power,
+            max_power=config.text_layer.power,
+            speed=config.text_layer.speed,
+        )
+    )
 
     # Layers 1..N*M: one per grid cell
     cell_cut_index: dict[tuple[int, int], int] = {}
@@ -326,7 +340,16 @@ def generate(config: GridConfig) -> LightBurnProject:
     # Optional border layer
     border_layer_index: int | None = None
     if config.border.enabled:
-        cut_settings.append(config.border.cut.to_cut_setting(next_index, "Border"))
+        cut_settings.append(
+            CutSetting(
+                index=next_index,
+                name="Border",
+                mode=CutMode.CUT,
+                min_power=config.border.power,
+                max_power=config.border.power,
+                speed=config.border.speed,
+            )
+        )
         border_layer_index = next_index
         next_index += 1
 

--- a/experimental/lightburn_material_test/test_material_test.py
+++ b/experimental/lightburn_material_test/test_material_test.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree as ET
 import pytest
 import pytest_bazel
 
+from bazel_util import runfiles
 from experimental.lightburn_material_test.lbrn2_writer import (
     CutSetting,
     HAlign,
@@ -335,6 +336,18 @@ def test_generate_auto_subtitle_omits_varied_params():
     assert "Power" not in sub
     assert "Speed" not in sub
     assert "Z=" in sub or "kerf" in sub.lower() or "Kerf" in sub
+
+
+def test_example_config_parses():
+    """example_config.toml must parse without error and produce a valid GridConfig."""
+    path = runfiles.get_required_path("_main/experimental/lightburn_material_test/example_config.toml")
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    cfg = GridConfig.model_validate(data)
+    assert cfg.x.param == CutParam.POWER_MAX
+    assert cfg.y.param == CutParam.Z_PER_PASS
+    assert cfg.border.enabled is True
+    assert cfg.border.power == 10.0
 
 
 if __name__ == "__main__":

--- a/experimental/lightburn_material_test/test_material_test.py
+++ b/experimental/lightburn_material_test/test_material_test.py
@@ -10,7 +10,6 @@ from xml.etree import ElementTree as ET
 import pytest
 import pytest_bazel
 
-from bazel_util import runfiles
 from experimental.lightburn_material_test.lbrn2_writer import (
     CutSetting,
     HAlign,
@@ -26,7 +25,6 @@ from experimental.lightburn_material_test.material_test import (
     BorderConfig,
     CutConfig,
     CutParam,
-    CutParams,
     GridConfig,
     _full_subtitle,
     fmt_val,
@@ -211,81 +209,6 @@ def test_cut_config_power_shorthand_does_not_override_explicit():
     assert cc.power_max == 60
 
 
-# ── CutParams / BorderConfig ───────────────────────────────────────────────────
-
-
-def test_cut_params_power_shorthand():
-    p = CutParams(power=42.0)
-    assert p.power_min == 42.0
-    assert p.power_max == 42.0
-
-
-def test_cut_params_to_cut_setting_full():
-    """to_cut_setting propagates all cut fields."""
-    p = CutParams(power_min=5.0, power_max=95.0, speed=50.0, kerf=0.1, z_offset=-0.5, z_per_pass=-0.2, num_passes=4)
-    cs = p.to_cut_setting(index=3, name="TestLayer")
-    assert cs.index == 3
-    assert cs.name == "TestLayer"
-    assert cs.min_power == 5.0
-    assert cs.max_power == 95.0
-    assert cs.speed == 50.0
-    assert cs.kerf == 0.1
-    assert cs.z_offset == -0.5
-    assert cs.z_per_pass == -0.2
-    assert cs.num_passes == 4
-
-
-def test_border_config_defaults():
-    bc = BorderConfig()
-    assert bc.cut.power_min == 10.0
-    assert bc.cut.power_max == 10.0
-    assert bc.cut.speed == 200.0
-    assert bc.enabled is False
-    assert bc.padding == 3.0
-
-
-def test_border_config_full_params():
-    """BorderConfig.cut accepts the full cut parameter set."""
-    bc = BorderConfig(
-        enabled=True, padding=5.0, cut=CutParams(power_min=8.0, power_max=12.0, speed=100.0, kerf=0.1, num_passes=2)
-    )
-    cs = bc.cut.to_cut_setting(7, "Border")
-    assert cs.min_power == 8.0
-    assert cs.max_power == 12.0
-    assert cs.kerf == 0.1
-    assert cs.num_passes == 2
-
-
-def test_generate_text_layer_full_params_applied():
-    """Full cut params specified on text_layer are reflected in generated layer 0."""
-    cfg = GridConfig(
-        x=AxisConfig(param=CutParam.POWER_MAX, values=[10.0]),
-        y=AxisConfig(param=CutParam.SPEED, values=[50.0]),
-        text_layer=CutParams(power_min=3.0, power_max=7.0, speed=150.0, kerf=0.02),
-    )
-    project = generate(cfg)
-    text_cs = project.cut_settings[0]
-    assert text_cs.min_power == 3.0
-    assert text_cs.max_power == 7.0
-    assert text_cs.speed == 150.0
-    assert text_cs.kerf == 0.02
-
-
-def test_generate_border_full_params_applied():
-    """Full cut params specified on border.cut are reflected in the border layer."""
-    cfg = GridConfig(
-        x=AxisConfig(param=CutParam.POWER_MAX, values=[10.0]),
-        y=AxisConfig(param=CutParam.SPEED, values=[50.0]),
-        border=BorderConfig(enabled=True, cut=CutParams(power_min=2.0, power_max=8.0, speed=120.0, z_offset=-0.3)),
-    )
-    project = generate(cfg)
-    border_cs = next(cs for cs in project.cut_settings if cs.name == "Border")
-    assert border_cs.min_power == 2.0
-    assert border_cs.max_power == 8.0
-    assert border_cs.speed == 120.0
-    assert border_cs.z_offset == -0.3
-
-
 def test_grid_config_from_toml():
     toml_str = textwrap.dedent("""\
         title = "Test"
@@ -342,7 +265,7 @@ def test_generate_rect_count():
 
 
 def test_generate_border_adds_layer_and_rect():
-    project = _make_project(border=BorderConfig(enabled=True, cut=CutParams(power=5, speed=100)))
+    project = _make_project(border=BorderConfig(enabled=True, power=5, speed=100))
     # border layer added
     assert any(cs.name == "Border" for cs in project.cut_settings)
     # border rect added (one extra rect)
@@ -412,18 +335,6 @@ def test_generate_auto_subtitle_omits_varied_params():
     assert "Power" not in sub
     assert "Speed" not in sub
     assert "Z=" in sub or "kerf" in sub.lower() or "Kerf" in sub
-
-
-def test_example_config_parses():
-    """example_config.toml must parse without error and produce a valid GridConfig."""
-    path = runfiles.get_required_path("_main/experimental/lightburn_material_test/example_config.toml")
-    with path.open("rb") as f:
-        data = tomllib.load(f)
-    cfg = GridConfig.model_validate(data)
-    assert cfg.x.param == CutParam.POWER_MAX
-    assert cfg.y.param == CutParam.Z_PER_PASS
-    assert cfg.border.enabled is True
-    assert cfg.border.cut.power_min == 10.0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Simplifies the cut parameter model in the LightBurn material test generator by removing unused/redundant fields
- Restores `test_example_config_parses` test with updated `BorderConfig` API to match the simplified model
- Reduces `example_config.toml` to reflect the leaner parameter schema

## Test plan

- [x] `bazel test //experimental/lightburn_material_test:test_material_test` passes

https://claude.ai/code/session_01HyuUFBDAhpgCexvaMZiLTQ