### PR TITLE
feat(props): skip agent image pushes when content unchanged

### DIFF
--- a/.github/workflows/props-agents-image.yml
+++ b/.github/workflows/props-agents-image.yml
@@ -15,6 +15,11 @@
 #   critic_dev_improve:latest, critic_dev_improve:{sha}
 #   critic_dev_optimize:latest, critic_dev_optimize:{sha}
 #
+# Skip logic: agent images are stamp-free (no //tools:build_info dep), so the
+# Docker image ID (sha256 of the image config) is a stable content fingerprint.
+# push_if_changed compares the local image ID against the remote config digest
+# and skips the push when they match.
+#
 # Triggers:
 #   - workflow_call (from ci.yml): when agent image targets are affected
 #   - workflow_dispatch: manual push of all agents
@@ -86,25 +91,34 @@ jobs:
           REGISTRY: ${{ secrets.PROPS_REGISTRY_URL }}
           SHA: ${{ github.sha }}
         run: |
-          push() {
-            local local_tag="$1" remote_repo="$2" remote_tag="$3"
-            docker tag "$local_tag" "$REGISTRY/$remote_repo:$remote_tag"
-            docker push --quiet "$REGISTRY/$remote_repo:$remote_tag"
+          # Agent images are stamp-free: same sources → same image ID across commits.
+          # Skip pushing when the local image ID matches the remote config digest.
+          push_if_changed() {
+            local local_tag="$1" remote_repo="$2"
+            shift 2
+            local remote_tags=("$@")
+
+            local local_id remote_digest
+            local_id=$(docker inspect --format='{{.Id}}' "$local_tag")
+            remote_digest=$(docker manifest inspect "$REGISTRY/$remote_repo:latest" 2>/dev/null \
+              | jq -r '.config.digest // empty' 2>/dev/null || true)
+
+            if [[ -n "$remote_digest" && "$local_id" == "$remote_digest" ]]; then
+              echo "$remote_repo: unchanged, skipping push"
+              return
+            fi
+
+            for tag in "${remote_tags[@]}"; do
+              docker tag "$local_tag" "$REGISTRY/$remote_repo:$tag"
+              docker push --quiet "$REGISTRY/$remote_repo:$tag"
+            done
           }
 
-          push critic:latest critic latest
-          push critic:latest critic "$SHA"
-
-          push grader:latest grader latest
-          push grader:latest grader "$SHA"
-
-          push critic_dev_improve:latest critic_dev_improve latest
-          push critic_dev_improve:latest critic_dev_improve "$SHA"
-
-          push critic_dev_optimize:latest critic_dev_optimize latest
-          push critic_dev_optimize:latest critic_dev_optimize "$SHA"
+          push_if_changed critic:latest critic latest "$SHA"
+          push_if_changed grader:latest grader latest "$SHA"
+          push_if_changed critic_dev_improve:latest critic_dev_improve latest "$SHA"
+          push_if_changed critic_dev_optimize:latest critic_dev_optimize latest "$SHA"
 
           for variant in contract_truthfulness dead_code flag_propagation high_recall verbose_docs; do
-            push "critic:$variant" critic "$variant"
-            push "critic:$variant" critic "${variant}-${SHA}"
+            push_if_changed "critic:$variant" critic "$variant" "${variant}-${SHA}"
           done


### PR DESCRIPTION
## Summary

- Adds `push_if_changed()` to the agent images workflow
- Compares the local image ID (`sha256` of the image config) against the remote `:latest` config digest
- Skips that image's push if they match; pushes all tags when content differs

Agent images are stamp-free (no `//tools:build_info` dependency), so the Docker image ID is a stable content fingerprint: same source files → same ID, even across different commits. This avoids redundant pushes when CI runs for commits that don't touch agent sources.

## Test plan

- [ ] Trigger the agents workflow on a commit that doesn't change agent sources — expect all images skipped
- [ ] Trigger on a commit that changes an agent — expect that agent pushed, others skipped
- [ ] First run (no `:latest` in registry yet) — expect all images pushed normally

https://claude.ai/code/session_01SH8f79hwKNa6wwVS56bXER