### PR TITLE
Fix CI: filter platform-incompatible targets when infra changes

### DIFF
--- a/tools/ci/bazel_query.py
+++ b/tools/ci/bazel_query.py
@@ -62,15 +62,28 @@ def filter_for_ci(targets: list[str]) -> list[str]:
     - except attr(target_compatible_with, macos) — exclude platform-incompatible
     - except attr(tags, 'manual') — exclude targets needing special setup
       (e.g. system libraries). Release workflows build these explicitly.
+
+    Handles the ``["//..."]`` sentinel (all targets) by using ``//...`` as a
+    direct query expression, avoiding a huge ``set(...)`` enumeration.
     """
     if not targets:
         return targets
 
-    target_set = f"set({' '.join(targets)})"
-    query = (
-        f"let targets = {target_set} in "
-        f"kind('rule', $targets) "
-        f"except attr(target_compatible_with, '@platforms//os:macos', $targets) "
-        f"except attr(tags, 'manual', $targets)"
-    )
+    if targets == ["//..."]:
+        # Use //... directly — set(//...) works but the result would be a
+        # concrete list of thousands of labels, so handle it up front.
+        universe = "//..."
+        query = (
+            f"kind('rule', {universe}) "
+            f"except attr(target_compatible_with, '@platforms//os:macos', {universe}) "
+            f"except attr(tags, 'manual', {universe})"
+        )
+    else:
+        target_set = f"set({' '.join(targets)})"
+        query = (
+            f"let targets = {target_set} in "
+            f"kind('rule', $targets) "
+            f"except attr(target_compatible_with, '@platforms//os:macos', $targets) "
+            f"except attr(tags, 'manual', $targets)"
+        )
     return run_query(query)

--- a/tools/ci/ci_decide.py
+++ b/tools/ci/ci_decide.py
@@ -118,14 +118,17 @@ def _compute_affected_targets(
 ) -> tuple[list[str], bool]:
     """Compute affected Bazel targets and whether infrastructure changed.
 
-    Returns (targets, infra_changed). Short-circuits to ["//..."] when
-    infrastructure files changed, avoiding a bazel-diff run that would fail
-    if the parent commit's BUILD graph is incompatible with the current one.
+    Returns (targets, infra_changed). When infrastructure files changed,
+    skips bazel-diff (which would fail if the parent BUILD graph is
+    incompatible) and queries all CI-compatible targets directly.
+    All returned targets are filtered for CI (no macOS-only, no manual).
     """
     infra_changed = has_infra_changes(changed_files)
     if infra_changed:
         logger.info("Infrastructure change detected, building all targets")
-        return ["//..."], True
+        targets = filter_for_ci(["//..."])
+        logger.info("Filtered to %d CI-compatible targets", len(targets))
+        return targets, True
 
     jar_path = get_required_existing_path("BAZEL_DIFF_JAR")
     cache_dir = get_optional_env_path("BAZEL_DIFF_CACHE_DIR") or (env.workspace / ".bazel-diff-cache")


### PR DESCRIPTION
## Summary

- When infrastructure files change (e.g. `MODULE.bazel`), `ci_decide.py` short-circuits to `targets=["//..."]` without applying `filter_for_ci`. Per-workflow queries then expand `//...` to all targets including macOS-only ones, which get written to `targets-bazel-test.txt` as explicit targets. Bazel errors with "incompatible but explicitly requested" on Linux runners.
- Fix: call `filter_for_ci(["//..."])` in the infra-changed path so per-workflow queries receive an already-filtered list. Handle the `["//..."]` sentinel in `filter_for_ci` by using `//...` as a direct query expression (avoiding a huge `set(...)` enumeration that would choke the Bazel query parser).

## Test plan

- [x] `bazel build //tools/ci:ci_decide //tools/ci:bazel_query` passes (including mypy)
- [x] `bazel test //tools/ci:test_generate_ci` passes
- [ ] CI run on this PR should succeed (the infra-change path triggers since this branch diverges from devel)

https://claude.ai/code/session_01Bje6U33XfUL9w4cyE9WR3i