### PR TITLE
feat(openclaw): allow HTTP egress for internet access

### DIFF
--- a/cluster/k8s/openclaw/openclawinstance.yaml
+++ b/cluster/k8s/openclaw/openclawinstance.yaml
@@ -360,8 +360,10 @@ spec:
           ports:
             - port: 8008
               protocol: TCP
-        # Allow egress to Telegram API (api.telegram.org, HTTPS).
+        # Allow HTTP/HTTPS egress to the internet (Telegram, browsing, APIs).
         - ports:
+            - port: 80
+              protocol: TCP
             - port: 443
               protocol: TCP
         # TODO: Add egress rules for InvenTree and Grocy when deployed.


### PR DESCRIPTION
Port 443 (HTTPS) was already allowed to any destination, but port 80 (HTTP) was missing. Many URLs the agent fetches use HTTP or redirect from 80→443, so both are needed for general internet access.

https://claude.ai/code/session_012zYNyp61hLPL61aGNN7gXR