### PR TITLE
Automate claude-hooks wheel URL updates in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "claude-session-start"
+            "command": "uvx --from https://github.com/agentydragon/ducktape/releases/download/claude-hooks-13edf694/claude_hooks-0.1.0-py3-none-any.whl claude-session-start"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "claude-pre-tool-use"
+            "command": "uvx --from https://github.com/agentydragon/ducktape/releases/download/claude-hooks-13edf694/claude_hooks-0.1.0-py3-none-any.whl claude-pre-tool-use"
           }
         ]
       }

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -278,13 +278,17 @@ jobs:
           sed -i "s|shortSha = \".*\"|shortSha = \"${{ env.SHORT_SHA }}\"|" "$NIX_PKG"
           sed -i "s|hash = \"sha256-.*\"|hash = \"${SRI_HASH}\"|" "$NIX_PKG"
 
-          if git diff --quiet "$NIX_PKG"; then
+          # Bump wheel URL in Claude Code settings (both SessionStart and PreToolUse hooks)
+          CLAUDE_SETTINGS=".claude/settings.json"
+          sed -i "s|releases/download/claude-hooks-[a-f0-9]*/claude_hooks|releases/download/claude-hooks-${{ env.SHORT_SHA }}/claude_hooks|g" "$CLAUDE_SETTINGS"
+
+          if git diff --quiet "$NIX_PKG" "$CLAUDE_SETTINGS"; then
             echo "No change needed"
             exit 0
           fi
 
           TAG="claude-hooks-${{ env.SHORT_SHA }}"
-          git add "$NIX_PKG"
+          git add "$NIX_PKG" "$CLAUDE_SETTINGS"
           git commit -m "chore: bump claude-hooks to ${TAG} [skip ci]"
 
           # Push with error diagnostics


### PR DESCRIPTION
## Summary
This PR automates the process of updating the claude-hooks wheel URL in Claude Code settings whenever a new release is published. Previously, the wheel URL had to be manually updated in `.claude/settings.json`.

## Key Changes
- **Workflow automation**: Extended the `claude-hooks-release.yml` workflow to automatically update wheel URLs in `.claude/settings.json` during the release process
- **Settings file updates**: Added sed command to replace the wheel download URL with the new release version in both SessionStart and PreToolUse hook configurations
- **Git tracking**: Updated the workflow to stage and commit both the Nix package file and the settings file together
- **Settings.json**: Updated both hook commands to use the full `uvx --from` URL pointing to the claude-hooks wheel release

## Implementation Details
- The workflow now updates `.claude/settings.json` using a sed pattern that matches any previous release hash and replaces it with the current `SHORT_SHA`
- Both the SessionStart and PreToolUse hooks in the settings file are updated in a single sed command using the global flag
- The git diff check now validates both files to ensure changes are detected before committing
- This ensures the Claude Code extension always uses the latest released version of claude-hooks without manual intervention

https://claude.ai/code/session_015R63QP2zPcwhCEyyEZFsu6