### PR TITLE
Remove polling logic from RunDetail component

### DIFF
--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import BackButton from "./BackButton.svelte";
@@ -43,7 +43,6 @@
   // State
   let run: AgentRunDetail | null = $state(initialRun ?? null);
   let loading = $state(!initialRun);
-  let pollInterval: ReturnType<typeof setInterval> | null = null;
 
   // Critique viewer state
   let snapshotDetail: SnapshotDetailResponse | null = $state(initialSnapshotDetail ?? null);
@@ -214,8 +213,6 @@
     }
   }
 
-  let polling = false;
-
   onMount(() => {
     // Skip fetching when initial data is provided (visual tests)
     if (initialRun) return;
@@ -226,29 +223,6 @@
         loadLLMRequests();
       }
     });
-    // Poll while in progress, guarding against overlapping calls
-    pollInterval = setInterval(() => {
-      if (!run || run.status !== "in_progress") {
-        if (pollInterval) {
-          clearInterval(pollInterval);
-          pollInterval = null;
-        }
-        return;
-      }
-      if (!polling) {
-        polling = true;
-        loadData(true).finally(() => {
-          polling = false;
-        });
-        if (llmRequestsFetched) {
-          loadLLMRequests();
-        }
-      }
-    }, 1000);
-  });
-
-  onDestroy(() => {
-    if (pollInterval) clearInterval(pollInterval);
   });
 </script>
 


### PR DESCRIPTION
## Summary
Removed the automatic polling mechanism from the RunDetail component that was continuously fetching run status updates while a run was in progress.

## Key Changes
- Removed `onDestroy` lifecycle hook and its cleanup logic for the poll interval
- Removed the `setInterval`-based polling loop that checked run status every 1000ms
- Removed the `pollInterval` state variable that tracked the interval ID
- Removed the `polling` flag that guarded against overlapping fetch calls
- Removed the `onDestroy` import from Svelte since it's no longer needed
- Simplified `onMount` to only handle initial data fetching and subscription setup

## Implementation Details
The polling mechanism was checking if a run had `status === "in_progress"` and would continuously call `loadData(true)` and `loadLLMRequests()` while the run was active. This logic has been completely removed, likely in favor of a different approach to handling run status updates (such as server-sent events, WebSockets, or manual refresh triggers).

https://claude.ai/code/session_01PwGgA1TdCXrP8mwndxFdjc