### PR TITLE
feat(props): restart deployment on ConfigMap changes via Reloader

### DIFF
--- a/cluster/k8s/props/deployment.yaml
+++ b/cluster/k8s/props/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: props
   namespace: props
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary

- Adds `reloader.stakater.com/auto: "true"` annotation to the `props` deployment
- Stakater Reloader (already running in `kube-system`) will automatically restart the pod whenever `props-config` ConfigMap changes
- Without this, config changes (e.g. switching Ollama upstream URL) require a manual pod restart to take effect

## Test plan

- [ ] Verify `reloader-reloader` pod in `kube-system` picks up the annotation and restarts props pod on next ConfigMap change

https://claude.ai/code/session_01QgdUF9cC6AEQ7fjbPYMszm