### PR TITLE
fix(props): handle error response bodies; fix model metadata sync

### DIFF
--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -13,11 +13,11 @@ import random
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import case, func
 
 from openai_utils.model import ResponsesRequest, ResponsesResult
@@ -298,7 +298,9 @@ class RunsListResponse(BaseModel):
 class LLMRequestInfo(BaseModel):
     """LLM request information for API response.
 
-    Directly mirrors LLMRequest ORM model fields.
+    Directly mirrors LLMRequest ORM model fields. When the upstream returned
+    an error (4xx/5xx), the raw error JSON is in response_error_body instead
+    of response_body so it doesn't fail ResponsesResult validation.
     """
 
     model_config = {"from_attributes": True}
@@ -307,9 +309,36 @@ class LLMRequestInfo(BaseModel):
     model: str
     request_body: ResponsesRequest
     response_body: ResponsesResult | None
+    response_error_body: dict[str, Any] | None = None
     error: str | None
     latency_ms: int | None
     created_at: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def _split_error_response_body(cls, data: Any) -> Any:
+        """Move error response bodies to response_error_body to avoid ResponsesResult validation failure."""
+        if hasattr(data, "response_body"):
+            # ORM object path (from_attributes)
+            response_body = getattr(data, "response_body", None)
+            if isinstance(response_body, dict) and "id" not in response_body:
+                return {
+                    "id": data.id,
+                    "model": data.model,
+                    "request_body": data.request_body,
+                    "response_body": None,
+                    "response_error_body": response_body,
+                    "error": data.error,
+                    "latency_ms": data.latency_ms,
+                    "created_at": data.created_at,
+                }
+        elif isinstance(data, dict):
+            response_body = data.get("response_body")
+            if isinstance(response_body, dict) and "id" not in response_body:
+                data = dict(data)
+                data["response_error_body"] = data["response_body"]
+                data["response_body"] = None
+        return data
 
 
 class LLMRequestsResponse(BaseModel):

--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -133,6 +133,23 @@ py_test(
 )
 
 py_test(
+    name = "test_model_metadata_sync",
+    srcs = ["test_model_metadata_sync.py"],
+    imports = ["../../.."],
+    requires_docker = True,
+    deps = [
+        ":model_metadata",
+        "//props:config",
+        "//props:conftest",
+        "//props/db:conftest",
+        "//props/db:database",
+        "//props/db:models",
+        "@pypi//pytest_bazel",
+        "@pypi//sqlalchemy",
+    ],
+)
+
+py_test(
     name = "test_sync_snapshot_files",
     srcs = ["test_sync_snapshot_files.py"],
     imports = ["../../.."],

--- a/props/db/sync/model_metadata.py
+++ b/props/db/sync/model_metadata.py
@@ -54,14 +54,8 @@ def sync_model_metadata_with_session(session: Session, config: PropsConfig | Non
                 upstream_model=custom.upstream_model,
             )
 
-    # Fast path: if count matches, assume synced
-    existing_count = session.query(ModelMetadata).count()
-    if existing_count == len(source_models):
-        logger.debug(f"Model metadata already synced ({existing_count} models)")
-        return SyncStats(added=0, updated=0, deleted=0, total=existing_count)
-
     # Full sync: make DB exactly match source
-    logger.info(f"Syncing model_metadata table (source: {len(source_models)} models, DB: {existing_count})...")
+    logger.info(f"Syncing model_metadata table (source: {len(source_models)} models)...")
 
     db_models = {m.model_id: m for m in session.query(ModelMetadata).all()}
     source_model_ids = set(source_models.keys())

--- a/props/db/sync/test_model_metadata_sync.py
+++ b/props/db/sync/test_model_metadata_sync.py
@@ -1,0 +1,76 @@
+"""Tests for sync_model_metadata_with_session.
+
+Verifies that the sync correctly propagates content changes (not just additions/
+deletions) to existing rows. The previous count-based fast path skipped updates
+when the model count hadn't changed, causing stale upstream_model values in the DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+import pytest_bazel
+from sqlalchemy.orm import Session
+
+from props.config import CustomModelConfig, PropsConfig, UpstreamConfig
+from props.db.database import Database
+from props.db.models import ModelMetadata
+from props.db.sync.model_metadata import sync_model_metadata_with_session
+
+
+def _make_config(upstream_model: str) -> PropsConfig:
+    return PropsConfig(
+        backend_url="http://props:8000",
+        agent_env={},
+        upstreams={"ollama": UpstreamConfig(url="http://ollama:11434/v1", api_key_env="OLLAMA_API_KEY")},
+        models=[
+            CustomModelConfig(
+                name="gpt-oss-20b-128k",
+                upstream="ollama",
+                upstream_model=upstream_model,
+                input_usd_per_1m_tokens=0,
+                cached_input_usd_per_1m_tokens=0,
+                output_usd_per_1m_tokens=0,
+                context_window_tokens=131072,
+                max_output_tokens=131072,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def session(db: Database) -> Generator[Session]:
+    with db.session() as s:
+        yield s
+        s.rollback()
+
+
+def test_sync_updates_upstream_model_when_changed(session: Session) -> None:
+    """Sync must update upstream_model even when the model count hasn't changed.
+
+    Regression test: the old count-based fast path would skip updates when count
+    matched, leaving stale upstream_model in DB after a config change.
+    """
+    # Populate DB with the model using the old upstream_model name
+    sync_model_metadata_with_session(session, _make_config("gpt-oss:20b-old"))
+    session.flush()
+
+    old_row = session.get(ModelMetadata, "gpt-oss-20b-128k")
+    assert old_row is not None
+    assert old_row.upstream_model == "gpt-oss:20b-old"
+
+    # Re-sync with the corrected upstream_model — count is the same
+    sync_model_metadata_with_session(session, _make_config("gpt-oss:20b"))
+    session.flush()
+
+    session.expire(old_row)
+    updated_row = session.get(ModelMetadata, "gpt-oss-20b-128k")
+    assert updated_row is not None
+    assert updated_row.upstream_model == "gpt-oss:20b", (
+        "Sync must update upstream_model even when model count hasn't changed"
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/frontend/src/components/LLMRequestViewer.svelte
+++ b/props/frontend/src/components/LLMRequestViewer.svelte
@@ -41,6 +41,19 @@
           {#if req.response_body}
             <LLMResponseSection responseBody={req.response_body as Record<string, unknown>} />
           {/if}
+          {#if req.response_error_body}
+            <div class="p-4">
+              <h4 class="text-xs font-semibold uppercase tracking-wide text-red-600 dark:text-red-400 mb-2">
+                Error Response
+              </h4>
+              <pre
+                class="bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300 p-3 rounded text-xs overflow-auto">{JSON.stringify(
+                  req.response_error_body,
+                  null,
+                  2
+                )}</pre>
+            </div>
+          {/if}
           {#if req.error}
             <div class="p-4">
               <h4 class="text-xs font-semibold uppercase tracking-wide text-red-600 dark:text-red-400 mb-2">Error</h4>


### PR DESCRIPTION
## Summary

Three fixes for `props` LLM request logging and model routing:

**1. Fix crash in LLM requests viewer (`runs.py`)**

`GET /api/runs/<id>/llm-requests` crashed with Pydantic `ValidationError` when any
request had an error response body (e.g. `{"error": {"message": "model not found"}}`).
`ResponsesResult` requires `id`; error responses don't have it.

Fix: `model_validator(mode="before")` in `LLMRequestInfo` detects error bodies (dicts
without `id`) and moves them to a new `response_error_body` field.

**2. Display error response bodies in frontend**

`LLMRequestViewer.svelte` previously only showed `req.error` (the HTTP status string).
Now also renders `response_error_body` as formatted JSON so the actual upstream error
message is visible.

**3. Fix model metadata sync missing content changes (`model_metadata.py`)**

`sync_model_metadata_with_session` had a count-based fast path: if DB model count ==
source count, skip the full sync. Changing `upstream_model` on an existing model
(without adding/removing models) was silently ignored.

For `gpt-oss-20b-128k`, the DB had `upstream_model=NULL`, so the LLM proxy sent the
alias name directly to Ollama instead of `gpt-oss:20b`, causing "model not found" errors.

Fix: remove the fast path; always do the full merge sync on startup.
Test: `test_model_metadata_sync.py` is a regression test for the fast-path bug.

## Test plan

- [x] `bazel test //props/db/sync:test_model_metadata_sync` passes
- [ ] After pod restart, `gpt-oss-20b-128k` routes to Ollama as `gpt-oss:20b`
- [ ] LLM requests viewer no longer crashes on runs with error responses
- [ ] Error response bodies shown in the viewer

https://claude.ai/code/session_01QgdUF9cC6AEQ7fjbPYMszm