### PR TITLE
cluster/props: limit gpt-oss-20b-128k to 3 parallel agents

### DIFF
--- a/cluster/k8s/props/config.toml
+++ b/cluster/k8s/props/config.toml
@@ -25,3 +25,4 @@ cached_input_usd_per_1m_tokens = 0
 output_usd_per_1m_tokens = 0
 context_window_tokens = 131072
 max_output_tokens = 131072
+max_parallel_agents = 3

--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -115,6 +115,9 @@ def _make_lifespan(deps: BackendDeps):
 
         executor = await create_executor(deps.config.executor, db_config, deps.registry_proxy_config)
         logger.info("Using %s executor", deps.config.executor.type)
+        model_parallelism_limits = {
+            m.name: m.max_parallel_agents for m in deps.config.models if m.max_parallel_agents is not None
+        }
         app.state.registry = AgentRegistry(
             executor=executor,
             db=db,
@@ -122,6 +125,7 @@ def _make_lifespan(deps: BackendDeps):
             backend_url=deps.backend_url,
             agent_base_env=deps.config.agent_env,
             registry_config=deps.registry_proxy_config,
+            model_parallelism_limits=model_parallelism_limits,
         )
 
         if deps.grader_model:

--- a/props/config.py
+++ b/props/config.py
@@ -73,6 +73,7 @@ class CustomModelConfig(BaseModelMetadata):
     name: str
     upstream: str
     upstream_model: str
+    max_parallel_agents: int | None = None
 
 
 class DockerExecutorConfig(BaseModel):

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -39,6 +39,7 @@ import asyncio
 import contextlib
 import logging
 import tempfile
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -177,6 +178,7 @@ class AgentRegistry:
         backend_url: str,
         agent_base_env: dict[str, str],
         registry_config: RegistryProxyConfig,
+        model_parallelism_limits: dict[str, int] | None = None,
     ) -> None:
         self._executor = executor
         self._db = db
@@ -186,6 +188,9 @@ class AgentRegistry:
         self._registry_config = registry_config
         # Track running background critic tasks by agent_run_id to prevent GC and allow lookup
         self._running_critics: dict[UUID, asyncio.Task[None]] = {}
+        self._model_semaphores: dict[str, asyncio.Semaphore] = {
+            model: asyncio.Semaphore(limit) for model, limit in (model_parallelism_limits or {}).items()
+        }
 
     async def close(self) -> None:
         await self._executor.close()
@@ -197,6 +202,24 @@ class AgentRegistry:
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         await self.close()
+
+    # --- Model Parallelism ---
+
+    @contextlib.asynccontextmanager
+    async def _model_slot(self, model: str) -> AsyncIterator[None]:
+        """Acquire a parallelism slot for the given model, if a limit is configured.
+
+        Blocks until a slot is available. No-op when no limit is configured for the model.
+        Held for the entire duration of the agent container run to bound concurrent usage.
+        """
+        sem = self._model_semaphores.get(model)
+        if sem is None:
+            yield
+        else:
+            if sem.locked():
+                logger.info("Model %s at capacity, queuing agent", model)
+            async with sem:
+                yield
 
     # --- Image Resolution ---
 
@@ -436,18 +459,19 @@ class AgentRegistry:
         agent_run_id = uuid4()
         slug_seg = _slug_to_container_segment(example.snapshot_slug)
         container_name = f"critic-{slug_seg}-{str(agent_run_id)[:8]}"
-        handle = await self._create_and_start(
-            agent_run_id,
-            image=image,
-            model=model,
-            type_config=CriticTypeConfig(example=example),
-            budget_usd=budget_usd,
-            parent_run_id=parent_run_id,
-            verify_snapshot=example.snapshot_slug,
-            container_name=container_name,
-            timeout_seconds=timeout_seconds,
-        )
-        await handle
+        async with self._model_slot(model):
+            handle = await self._create_and_start(
+                agent_run_id,
+                image=image,
+                model=model,
+                type_config=CriticTypeConfig(example=example),
+                budget_usd=budget_usd,
+                parent_run_id=parent_run_id,
+                verify_snapshot=example.snapshot_slug,
+                container_name=container_name,
+                timeout_seconds=timeout_seconds,
+            )
+            await handle
         return agent_run_id
 
     async def start_critic(
@@ -484,10 +508,11 @@ class AgentRegistry:
 
         async def _run() -> None:
             try:
-                handle = await self._start_agent(
-                    agent_run_id, image=image.oci_ref, timeout_seconds=timeout_seconds, name=container_name
-                )
-                await handle
+                async with self._model_slot(model):
+                    handle = await self._start_agent(
+                        agent_run_id, image=image.oci_ref, timeout_seconds=timeout_seconds, name=container_name
+                    )
+                    await handle
             except Exception:
                 logger.exception("Unhandled error in background critic run %s", agent_run_id)
 
@@ -509,18 +534,19 @@ class AgentRegistry:
         """Run a critic-dev optimizer agent. Returns agent run ID (query DB for status)."""
         agent_run_id = uuid4()
         container_name = f"critic-dev-opt-{str(agent_run_id)[:8]}"
-        handle = await self._create_and_start(
-            agent_run_id,
-            image=image,
-            model=optimizer_model,
-            type_config=CriticDevOptimizeTypeConfig(
-                target_metric=target_metric, optimizer_model=optimizer_model, critic_model=critic_model
-            ),
-            budget_usd=budget,
-            container_name=container_name,
-            timeout_seconds=timeout_seconds,
-        )
-        await handle
+        async with self._model_slot(optimizer_model):
+            handle = await self._create_and_start(
+                agent_run_id,
+                image=image,
+                model=optimizer_model,
+                type_config=CriticDevOptimizeTypeConfig(
+                    target_metric=target_metric, optimizer_model=optimizer_model, critic_model=critic_model
+                ),
+                budget_usd=budget,
+                container_name=container_name,
+                timeout_seconds=timeout_seconds,
+            )
+            await handle
         return agent_run_id
 
     async def run_critic_dev_improve(
@@ -552,21 +578,22 @@ class AgentRegistry:
 
         agent_run_id = uuid4()
         container_name = f"critic-dev-imp-{str(agent_run_id)[:8]}"
-        handle = await self._create_and_start(
-            agent_run_id,
-            image=image,
-            model=improvement_model,
-            type_config=CriticDevImproveTypeConfig(
-                baseline_image_digests=resolved_baselines,
-                allowed_examples=examples,
-                improvement_model=improvement_model,
-                critic_model=critic_model,
-            ),
-            budget_usd=budget_usd,
-            container_name=container_name,
-            timeout_seconds=timeout_seconds,
-        )
-        await handle
+        async with self._model_slot(improvement_model):
+            handle = await self._create_and_start(
+                agent_run_id,
+                image=image,
+                model=improvement_model,
+                type_config=CriticDevImproveTypeConfig(
+                    baseline_image_digests=resolved_baselines,
+                    allowed_examples=examples,
+                    improvement_model=improvement_model,
+                    critic_model=critic_model,
+                ),
+                budget_usd=budget_usd,
+                container_name=container_name,
+                timeout_seconds=timeout_seconds,
+            )
+            await handle
         return agent_run_id
 
     # --- State Tracking ---


### PR DESCRIPTION
## Summary
- Adds `max_parallel_agents = 3` to the `gpt-oss-20b-128k` model in `cluster/k8s/props/config.toml`
- Caps concurrent agent containers using the local Ollama model to avoid GPU overload on the 2x RTX 5090s

## Test plan
- [ ] Verify props backend picks up new config after Flux reconciles
- [ ] Confirm no more than 3 agent containers run simultaneously against the ollama upstream

https://claude.ai/code/session_012rWcyqLZLZUb5R53ntBMu1