### PR TITLE
fix(claude_hooks): parse credentials with Pydantic to fix mypy no-any-return

### DIFF
--- a/tools/claude_hooks/usage_api.py
+++ b/tools/claude_hooks/usage_api.py
@@ -7,7 +7,6 @@ fast on repeated invocations.
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from datetime import datetime
@@ -15,6 +14,7 @@ from pathlib import Path
 
 import httpx
 from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,18 @@ CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
 CACHE_PATH = Path.home() / ".cache" / "claude-hooks" / "usage_cache.json"
 CACHE_TTL_SECONDS = 120
 API_TIMEOUT_SECONDS = 2.0
+
+
+class _OAuthCredentials(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
+
+    access_token: str | None = None
+
+
+class _Credentials(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
+
+    claude_ai_oauth: _OAuthCredentials | None = None
 
 
 class UsageBucket(BaseModel):
@@ -49,9 +61,9 @@ class _CachedUsage(BaseModel):
 def _read_access_token() -> str | None:
     """Read OAuth access token from Claude credentials file."""
     try:
-        data = json.loads(CREDENTIALS_PATH.read_text())
-        return data["claudeAiOauth"]["accessToken"]
-    except (OSError, KeyError, json.JSONDecodeError):
+        creds = _Credentials.model_validate_json(CREDENTIALS_PATH.read_text())
+        return creds.claude_ai_oauth.access_token if creds.claude_ai_oauth else None
+    except (OSError, ValueError):
         logger.debug("Could not read Claude OAuth token from %s", CREDENTIALS_PATH)
         return None
 


### PR DESCRIPTION
## Summary

- `_read_access_token()` in `tools/claude_hooks/usage_api.py` was returning `Any` from a function declared `str | None`, causing a mypy `no-any-return` error
- Replaces raw `json.loads` + dict indexing with typed Pydantic models (`_Credentials`, `_OAuthCredentials`) using `alias_generator=to_camel` to handle the camelCase JSON keys automatically

## Test plan

- [x] `bazel build //tools/claude_hooks:usage_api` passes mypy clean

https://claude.ai/code/session_01BRBYswT7HeNtG3ZXkF3ZzT