### PR TITLE
Add Coinbase API credentials sealed secret for agent sandboxes

### DIFF
--- a/cluster/k8s/openclaw-sandbox-secrets/coinbase-api-credentials-sealed.yaml
+++ b/cluster/k8s/openclaw-sandbox-secrets/coinbase-api-credentials-sealed.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: coinbase-api-credentials
+  namespace: openclaw-sandbox
+spec:
+  encryptedData:
+    api_key: AgBkcYhciSGc1VTffT6E2TebX/I8CH4kvUNfrW9dYduDs1nrDNMgjW6IS6uw8sc6r54hHlQC4sFQ8JMs9jI2PwO2CpEjUYBT+A2dHBCckvqmM2m338PmL3bIR6tSqZfrXONN8o6MZrod5exRsKdQ7dev01HdRojCyhnLoSR6veRkTGJ2+iMRrghJCNI/txvIsmRJfxinw+cmsHuMEJRqCEOy4+mnrCp6ptM/+AB+MKYyvBEHHrLUtp6nz4vtMuu/4NEq22kFJJAG8Xcdune40McfwHYALILp4+4huJlJfpiD+FUOWCJODqHsD/HqKTzearZUbsk4IIK6Nsj3ESO9mS06+036rY854x1Xf4UbVQUwTxC3VWzDKEIfFVRMRfPvIbtvwLdywOCq1mGOatRFTdKYP9nHoWUwm54tLSU+Xk9F9kUkPWRpQaIRPgBNARB1ZmtTHfAdlR+4fLLmx3WfhvxFt6HHVTSCLPso0FhAcPKEGMBVAff0A279RXt2UVD3OPgIqmrBeLJbWUAeBrdjjokycfYvCf9BkjUMgi7fe0ascu1R6Q1o7wwMc1ZRQpXt8NJaxO8MJMa1c3be1T6QQ5M8d2SAFhoc3ROJUcxBU6VaLAZ1nIWSHDKsJKRFcVfMd/kN/I+uMB2JjdsFRsxWkHkq/0o9oEYl/12xzuKZf0yNp0nFcR+8/iNkectI1RQOW5H+l7YYXTnImfANVyPR0MKUTuryNS8gZagB/ORk4hwB4YG5ZOo=
+    api_secret: AgBAEDFqcbnZ0ujR4aJ+Rdomzw8/M+5xMTqH5F3KVu+rgFIK63uhsAEaU3WOx+KJhXF6vHrp3EzxARG4LJOKro2qkxkG6Bil0L1x4EcYx6JsbQZyQtaKwGE7KonATzyewkz8mraAtWu74v6C/bZ2IM4C9Itl5Z5Q544xFgV5V7C3hrIsJlLE6wQX/cTYm3K3k50wlDFYqc9blIw/8qn3keIpIoJZ3IP0J+FoBox6YxjSHRQcGhsCAIh1w5OankrhvoSyFtVTPulTf6mYtCX7asXqv5A8HSAxNd5L98BKRPK7dBLlJd+EzS0LnEDS4nKsKUk48XvJCJrHU48z4OXsyHdv7d+Jbd43qf6T6vUNMQhYLYy+CeV2ZY9MecQq9ovJy+l7gEjVKQL5NNf+d2/VnWRZFUAgEm5nr1ApchoLEL6IxdvQuZi196lX8kClYkjre7tQZAEpqamwI5JudosOzb5N+shhKLanyCXlEJ+A4reJslh0szJa+dOamcEDzc20zunM3opiJN/oyadHWhXj81p79DjqH5LSfkiNG6URviDBlsueUZLMlVdeF2z8enXWC6wDnwvy2mySrx13dcexPJo+n+4k1Z8PGt5GZu3bKfWlMUgdDHQmSYEOx/lWQSupPu21cv+9eZZNalB9tH+Ll4BXcHsjGusxxSHRNj0o+OCNosGaB5H58AAsoZ9kr/iE2kvj57BW/q8H0auTEXShUFhPnHwSotowXkgO6afW8BhWgC6og5PWfDhi7rbtQeu1zzoJ5W/L1vEMLQD0YowfsVGJ8JpY9tr1qbWyrzzrWFooUw4+JAxm83mF
+  template:
+    metadata:
+      name: coinbase-api-credentials
+      namespace: openclaw-sandbox
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "claude-sandbox"
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "claude-sandbox"

--- a/cluster/k8s/openclaw-sandbox-secrets/kustomization.yaml
+++ b/cluster/k8s/openclaw-sandbox-secrets/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - ibkr-flex-query-credentials-sealed.yaml
+  - coinbase-api-credentials-sealed.yaml


### PR DESCRIPTION
## Summary

- Adds `coinbase-api-credentials` SealedSecret to `openclaw-sandbox` with Coinbase Advanced Trade API key and secret
- Reflector annotations auto-mirror the secret into `claude-sandbox`
- Follows the same pattern as `ibkr-flex-query-credentials-sealed.yaml`

## Test plan

- [ ] After Flux applies: `kubectl get secret coinbase-api-credentials -n openclaw-sandbox` exists
- [ ] `kubectl get secret coinbase-api-credentials -n claude-sandbox` exists (reflected by Reflector)
- [ ] `kubectl get secret coinbase-api-credentials -n claude-sandbox -o jsonpath='{.data.api_key}' | base64 -d` returns the UUID-format key

https://claude.ai/code/session_01PDVZuYFHhEG1MvtUP7ki76