### PR TITLE
oauth-broker: remove keep.readonly scope (Workspace Enterprise only)

### DIFF
--- a/cluster/k8s/oauth-broker/config.yaml
+++ b/cluster/k8s/oauth-broker/config.yaml
@@ -33,7 +33,9 @@ providers:
       - https://www.googleapis.com/auth/documents.readonly
       - https://www.googleapis.com/auth/spreadsheets.readonly
       - https://www.googleapis.com/auth/youtube.readonly
-      - https://www.googleapis.com/auth/keep.readonly
+      # keep.readonly is omitted: the Google Keep API is restricted to Google
+      # Workspace Enterprise accounts and is not available for personal Gmail
+      # accounts. Requesting it causes Error 400: invalid_scope for all users.
     redirect_uri: https://oauth-broker.allegedly.works/callback/google
     secret_name: google-tokens
     secret_annotations:


### PR DESCRIPTION
## Summary

- Removes `https://www.googleapis.com/auth/keep.readonly` from the Google OAuth provider scopes in `cluster/k8s/oauth-broker/config.yaml`
- This scope is restricted to Google Workspace Enterprise accounts; requesting it for a personal Gmail account causes `Error 400: invalid_scope`, blocking the entire OAuth flow
- Added a comment explaining the restriction for future reference

## Test plan

- [ ] Navigate to `https://oauth-broker.allegedly.works` and authenticate with Google — consent screen should load without the `invalid_scope` error

https://claude.ai/code/session_01RDbkgod3vPjcM4T21XBkuS