### PR TITLE
Add display_name field to agent definitions from OCI labels

### DIFF
--- a/props/agents/critic/BUILD.bazel
+++ b/props/agents/critic/BUILD.bazel
@@ -188,6 +188,7 @@ oci_image(
     base = "@debian_slim_linux_amd64",
     entrypoint = py_image_entrypoint("critic_bin"),
     env = py_image_env(binary_name = "critic_bin"),
+    labels = {"org.opencontainers.image.title": "critic"},
     tars = [
         ":layers",
         ":python3_symlink",

--- a/props/agents/critic/variants/critic.bzl
+++ b/props/agents/critic/variants/critic.bzl
@@ -42,6 +42,7 @@ def critic_variant(name, prompt_md):
         env = py_image_env(extra_env = {
             "PROMPT_TEMPLATE_PATH": prompt_runfiles_path,
         }),
+        labels = {"org.opencontainers.image.title": "critic-" + name},
         tars = [
             "//props/agents/critic:layers",
         ],

--- a/props/agents/critic_dev/authoring_agents.md.mako
+++ b/props/agents/critic_dev/authoring_agents.md.mako
@@ -106,8 +106,12 @@ cp /workspace/my_custom_main.py /tmp/layer/$MAIN_PY
 tar -cf /tmp/layer.tar -C /tmp/layer .
 
 # Append layer to the base image (no entrypoint change needed)
+# Set org.opencontainers.image.title to a short, human-readable name for your variant.
+# This becomes the display name shown in the UI — use something descriptive like
+# "chain-of-thought-critic" or "ast-analysis-v2" (keep it under 40 chars).
 crane mutate $REGISTRY/critic:latest \
   --append /tmp/layer.tar \
+  --label org.opencontainers.image.title="my-variant-name" \
   -o /tmp/image.tar \
   --insecure
 
@@ -126,7 +130,7 @@ ${include_doc("props/agents/critic_dev/built_in_critic.md.mako")}
 After pushing a custom image, run and evaluate it:
 
 ```
-1. Build image:  crane mutate ... --append ... -o /tmp/image.tar --insecure
+1. Build image:  crane mutate ... --append ... --label org.opencontainers.image.title="my-name" -o /tmp/image.tar --insecure
 2. Get digest:   DIGEST=$(crane digest --tarball /tmp/image.tar)
 3. Push:         crane push /tmp/image.tar $REGISTRY/critic@$DIGEST --insecure
 4. Run:          run_critic(definition_id=$DIGEST, example=..., timeout_seconds=120, budget_usd=0.5)

--- a/props/agents/critic_dev/improve/BUILD.bazel
+++ b/props/agents/critic_dev/improve/BUILD.bazel
@@ -61,6 +61,7 @@ oci_image(
     base = "@debian_slim_linux_amd64",
     entrypoint = py_image_entrypoint("improve"),
     env = py_image_env(binary_name = "improve"),
+    labels = {"org.opencontainers.image.title": "critic-dev-improve"},
     tars = [
         ":layers",
         ":python3_symlink",

--- a/props/agents/critic_dev/optimize/BUILD.bazel
+++ b/props/agents/critic_dev/optimize/BUILD.bazel
@@ -73,6 +73,7 @@ oci_image(
     base = "@debian_slim_linux_amd64",
     entrypoint = py_image_entrypoint("optimize"),
     env = py_image_env(binary_name = "optimize"),
+    labels = {"org.opencontainers.image.title": "critic-dev-optimize"},
     tars = [
         ":layers",
         ":python3_symlink",

--- a/props/agents/grader/BUILD.bazel
+++ b/props/agents/grader/BUILD.bazel
@@ -326,6 +326,7 @@ oci_image(
     base = "@debian_slim_linux_amd64",
     entrypoint = py_image_entrypoint("grader_bin"),
     env = py_image_env(binary_name = "grader_bin"),
+    labels = {"org.opencontainers.image.title": "grader"},
     tars = [
         ":layers",
         ":python3_symlink",

--- a/props/backend/routes/agent_definitions.py
+++ b/props/backend/routes/agent_definitions.py
@@ -20,6 +20,7 @@ router = APIRouter()
 
 class DefinitionInfo(BaseModel):
     image_digest: str
+    display_name: str | None
     agent_type: AgentType
     created_at: datetime
 
@@ -38,7 +39,12 @@ def list_definitions(caller_db: CallerDb, agent_type: AgentType | None = None) -
         definitions = query.order_by(AgentDefinition.created_at.desc()).all()
         return DefinitionsResponse(
             definitions=[
-                DefinitionInfo(image_digest=d.digest, agent_type=AgentType(d.agent_type), created_at=d.created_at)
+                DefinitionInfo(
+                    image_digest=d.digest,
+                    display_name=d.display_name,
+                    agent_type=AgentType(d.agent_type),
+                    created_at=d.created_at,
+                )
                 for d in definitions
             ]
         )

--- a/props/backend/routes/registry.py
+++ b/props/backend/routes/registry.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import logging
 import os
+from dataclasses import dataclass
 from uuid import UUID
 
 import httpx
@@ -77,40 +78,49 @@ async def _proxy_to_upstream(request: Request) -> Response:
         )
 
 
-async def _extract_base_digest(manifest_body: bytes, repository: str) -> str | None:
-    """Extract base image digest from OCI manifest."""
+@dataclass
+class _ImageMetadata:
+    base_digest: str | None
+    display_name: str | None
+
+
+async def _extract_image_metadata(manifest_body: bytes, repository: str) -> _ImageMetadata:
+    """Extract base digest and display name from OCI manifest config labels."""
     try:
         manifest = json.loads(manifest_body)
         config_descriptor = manifest.get("config")
         if not config_descriptor:
-            return None
+            return _ImageMetadata(base_digest=None, display_name=None)
 
         config_digest = config_descriptor.get("digest")
         if not config_digest:
-            return None
+            return _ImageMetadata(base_digest=None, display_name=None)
 
         config_url = f"{_upstream_registry_url()}/v2/{repository}/blobs/{config_digest}"
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(config_url, timeout=5.0)
                 if response.status_code != 200:
-                    return None
+                    return _ImageMetadata(base_digest=None, display_name=None)
 
                 config = response.json()
-                config_annotations = config.get("config", {}).get("Labels", {})
-                base_digest: str | None = config_annotations.get("org.opencontainers.image.base.digest")
+                labels = config.get("config", {}).get("Labels", {})
+                base_digest: str | None = labels.get("org.opencontainers.image.base.digest")
+                display_name: str | None = labels.get("org.opencontainers.image.title")
 
                 if base_digest:
                     logger.info(f"Extracted base_digest from annotation: {base_digest}")
-                return base_digest
+                if display_name:
+                    logger.info(f"Extracted display_name from annotation: {display_name}")
+                return _ImageMetadata(base_digest=base_digest, display_name=display_name)
 
             except (httpx.RequestError, json.JSONDecodeError) as e:
                 logger.warning(f"Error fetching/parsing config blob: {e}")
-                return None
+                return _ImageMetadata(base_digest=None, display_name=None)
 
     except (json.JSONDecodeError, KeyError) as e:
-        logger.warning(f"Error parsing manifest for base_digest extraction: {e}")
-        return None
+        logger.warning(f"Error parsing manifest for image metadata extraction: {e}")
+        return _ImageMetadata(base_digest=None, display_name=None)
 
 
 async def _record_manifest_push(
@@ -131,16 +141,21 @@ async def _record_manifest_push(
             logger.info(f"Agent definition {digest} already exists, skipping")
             return
 
-        base_digest = await _extract_base_digest(manifest_body, repository)
+        metadata = await _extract_image_metadata(manifest_body, repository)
         definition = AgentDefinition(
-            digest=digest, agent_type=agent_type, created_by_agent_run_id=agent_run_id, base_digest=base_digest
+            digest=digest,
+            agent_type=agent_type,
+            created_by_agent_run_id=agent_run_id,
+            base_digest=metadata.base_digest,
+            display_name=metadata.display_name,
         )
         session.add(definition)
         session.commit()
 
         logger.info(
             f"Recorded agent definition: {repository}@{digest} "
-            f"(type={agent_type}, created_by={agent_run_id}, base={base_digest or 'none'})"
+            f"(type={agent_type}, created_by={agent_run_id}, "
+            f"base={metadata.base_digest or 'none'}, display_name={metadata.display_name or 'none'})"
         )
 
 

--- a/props/backend/routes/stats.py
+++ b/props/backend/routes/stats.py
@@ -49,6 +49,7 @@ SplitStats = dict[Split, dict[ExampleKind, SplitScopeStats]]
 
 class DefinitionRow(BaseModel):
     image_digest: str
+    display_name: str | None
     created_at: datetime
     stats: SplitStats
 
@@ -100,7 +101,9 @@ def get_overview(caller_db: CallerDb) -> OverviewResponse:
             return dict(result)
 
         rows = [
-            DefinitionRow(image_digest=d.digest, created_at=d.created_at, stats=build_stats(d.digest))
+            DefinitionRow(
+                image_digest=d.digest, display_name=d.display_name, created_at=d.created_at, stats=build_stats(d.digest)
+            )
             for d in all_definitions
         ]
 
@@ -126,6 +129,7 @@ class ExampleStats(BaseModel):
 
 class DefinitionDetailResponse(BaseModel):
     image_digest: str
+    display_name: str | None
     agent_type: AgentType
     created_at: datetime
     stats: SplitStats
@@ -184,6 +188,7 @@ def get_definition_detail(image_digest: str, caller_db: CallerDb) -> DefinitionD
 
         return DefinitionDetailResponse(
             image_digest=definition.digest,
+            display_name=definition.display_name,
             agent_type=AgentType(definition.agent_type),
             created_at=definition.created_at,
             stats=dict(stats),

--- a/props/db/migrations/versions/20260228000000_add_display_name.py
+++ b/props/db/migrations/versions/20260228000000_add_display_name.py
@@ -1,0 +1,37 @@
+"""Add display_name column to agent_definitions.
+
+Stores the human-readable display name extracted from the OCI image label
+org.opencontainers.image.title at manifest push time.
+
+Revision ID: 20260228000000
+Revises: 20260227000000
+Create Date: 2026-02-28
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260228000000"
+down_revision: str | None = "20260227000000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_definitions",
+        sa.Column(
+            "display_name",
+            sa.Text(),
+            nullable=True,
+            comment="Human-readable name from OCI label org.opencontainers.image.title",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_definitions", "display_name")

--- a/props/db/models.py
+++ b/props/db/models.py
@@ -1398,6 +1398,9 @@ class AgentDefinition(Base):
     base_digest: Mapped[str | None] = mapped_column(
         String, nullable=True, comment="Parent image digest if this is a layered image"
     )
+    display_name: Mapped[str | None] = mapped_column(
+        String, nullable=True, comment="Human-readable name from OCI label org.opencontainers.image.title"
+    )
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()

--- a/props/frontend/src/components/DefinitionDetail.svelte
+++ b/props/frontend/src/components/DefinitionDetail.svelte
@@ -45,12 +45,20 @@
       </div>
     </div>
     <Breadcrumb
-      items={[{ label: "Home", href: "/" }, { label: "Definitions", href: "/" }, { label: data.image_digest }]}
+      items={[
+        { label: "Home", href: "/" },
+        { label: "Definitions", href: "/" },
+        { label: data.display_name ?? data.image_digest },
+      ]}
     />
 
     <div class="space-y-3 mt-3">
       <!-- Definition ID and metadata -->
       <div class="flex items-center gap-4 text-sm">
+        {#if data.display_name}
+          <span class="font-semibold text-gray-800 dark:text-gray-200">{data.display_name}</span>
+          <span class="text-gray-400 dark:text-gray-500">|</span>
+        {/if}
         <span class="font-mono text-blue-600 dark:text-blue-400">{data.image_digest}</span>
         <span class="text-gray-400 dark:text-gray-500">|</span>
         <span class="text-gray-600 dark:text-gray-400">{data.agent_type}</span>

--- a/props/frontend/src/components/stats/DefinitionsTable.svelte
+++ b/props/frontend/src/components/stats/DefinitionsTable.svelte
@@ -139,7 +139,7 @@
       {#each table.rows as def (def.image_digest)}
         <tr class="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800">
           <td class="px-3 py-2 font-mono text-xs">
-            <DefinitionIdLink id={def.image_digest} />
+            <DefinitionIdLink id={def.image_digest} display_name={def.display_name} />
           </td>
           <td class="px-3 py-2 text-right text-gray-600 dark:text-gray-400">
             {formatTableAge(def.created_at)}

--- a/props/frontend/src/lib/DefinitionIdLink.svelte
+++ b/props/frontend/src/lib/DefinitionIdLink.svelte
@@ -4,9 +4,10 @@
 
   interface Props {
     id: string;
+    display_name?: string | null;
   }
 
-  let { id }: Props = $props();
+  let { id, display_name }: Props = $props();
 </script>
 
 <a
@@ -14,5 +15,5 @@
   class="text-blue-600 dark:text-blue-400 underline hover:text-blue-800 dark:hover:text-blue-300"
   title={id}
 >
-  {formatDigest(id)}
+  {display_name ?? formatDigest(id)}
 </a>


### PR DESCRIPTION
## Summary
This PR adds support for extracting and displaying human-readable names for agent definitions from OCI image labels. The `org.opencontainers.image.title` label is now extracted during manifest push and stored in the database, then displayed throughout the UI instead of just showing digest hashes.

## Key Changes

- **Backend metadata extraction**: Refactored `_extract_base_digest()` into `_extract_image_metadata()` that returns a dataclass containing both `base_digest` and `display_name` extracted from OCI config labels
- **Database schema**: Added `display_name` column to `AgentDefinition` model with migration `20260228000000`
- **API responses**: Updated `DefinitionInfo`, `DefinitionRow`, and `DefinitionDetailResponse` models to include `display_name` field
- **Frontend display**: 
  - Updated breadcrumb navigation to show display name when available
  - Modified `DefinitionDetail` component to display display name prominently
  - Updated `DefinitionIdLink` component to show display name instead of truncated digest
  - Updated definitions table to pass display name to link component
- **Build configuration**: Added `org.opencontainers.image.title` labels to all agent OCI image builds (critic, critic variants, critic-dev improve/optimize, grader)
- **Documentation**: Updated authoring guide to explain how to set the display name label when building custom agent variants

## Implementation Details

- The `_ImageMetadata` dataclass encapsulates both metadata fields, making the return type explicit and extensible
- Display name extraction gracefully handles missing labels (returns `None`)
- All API endpoints and UI components handle `None` display names by falling back to digest display
- The label follows OCI Image Spec standard (`org.opencontainers.image.title`)

https://claude.ai/code/session_0111MB91NBf5btcTghoBkVim