### PR TITLE
Fix Docker PID cleanup and Python venv path resolution

### DIFF
--- a/props/oci.bzl
+++ b/props/oci.bzl
@@ -44,7 +44,12 @@ def py_image_env(binary_name = None, binary_package = None, extra_env = {}):
     env = dict(_PY_IMAGE_ENV)
     if binary_name:
         pkg = binary_package or native.package_name()
-        venv_bin = "/{}/_{}.venv/bin".format(pkg, binary_name)
+
+        # The aspect py_binary launcher creates the venv at runtime inside the
+        # runfiles directory as ".{binary_name}.venv".  Use that path so that
+        # subprocess exec calls inherit the correct python3 after the entrypoint
+        # has initialised the venv.
+        venv_bin = "/{}/{}.runfiles/.{}.venv/bin".format(pkg, binary_name, binary_name)
         runfiles_main = "/{}/{}.runfiles/_main".format(pkg, binary_name)
         env["PATH"] = "{}:/usr/local/bin:/usr/bin:/bin".format(venv_bin)
         env["PYTHONPATH"] = runfiles_main
@@ -57,13 +62,17 @@ def py_python3_symlink(name, binary_name, binary_package = None):
     This makes `exec(["python3", ...])` work in agent containers without
     knowing the container-specific venv path.
 
+    The aspect py_binary launcher creates the venv lazily at runtime inside the
+    runfiles directory as ".{binary_name}.venv".  The symlink therefore becomes
+    valid after the container entrypoint has run for the first time.
+
     Args:
         name: Target name for the pkg_tar.
         binary_name: Name of the aspect_py_binary target.
         binary_package: Bazel package path. Defaults to calling BUILD's package.
     """
     pkg = binary_package or native.package_name()
-    venv_python = "/{}/_{}.venv/bin/python3".format(pkg, binary_name)
+    venv_python = "/{}/{}.runfiles/.{}.venv/bin/python3".format(pkg, binary_name, binary_name)
     pkg_tar(
         name = name,
         symlinks = {"/usr/local/bin/python3": venv_python},

--- a/tools/claude_hooks/container_runtime.py
+++ b/tools/claude_hooks/container_runtime.py
@@ -326,17 +326,18 @@ def get_storage_dir(settings: HookSettings) -> Path | None:
     return settings.get_container_storage_dir()
 
 
-def _log_docker_conflict_info() -> None:
-    """Log diagnostic info about a conflicting dockerd process.
+def _cleanup_stale_docker_pid() -> None:
+    """Remove /var/run/docker.pid if it refers to a non-dockerd process.
 
-    Called when the Docker socket is not responsive but we're about to try
-    starting a new dockerd.  Helps diagnose cases where a pre-existing daemon
-    owns /var/run/docker.pid but its socket is missing or unresponsive.
+    Handles the case where a previous session's PID file persists and its PID
+    has since been reused by an unrelated process (e.g. supervisord).  Without
+    this cleanup dockerd refuses to start, mistaking that PID for a live daemon.
     """
+    pid_file = Path("/var/run/docker.pid")
     sock_file = DEFAULT_DOCKER_SOCKET
+
     logger.info("docker socket check: exists=%s", sock_file.exists())
 
-    pid_file = Path("/var/run/docker.pid")
     if not pid_file.exists():
         logger.info("No /var/run/docker.pid found")
         return
@@ -348,6 +349,17 @@ def _log_docker_conflict_info() -> None:
         return
 
     logger.info("Found /var/run/docker.pid with pid=%d", pid)
+
+    comm_path = Path(f"/proc/{pid}/comm")
+    if comm_path.exists():
+        try:
+            comm = comm_path.read_text().strip()
+            logger.info("PID %d comm: %s", pid, comm)
+        except OSError as e:
+            logger.warning("Failed to read comm for PID %d: %s", pid, e)
+            comm = ""
+    else:
+        comm = ""
 
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     if cmdline_path.exists():
@@ -365,6 +377,17 @@ def _log_docker_conflict_info() -> None:
                     logger.info("PID %d status: %s", pid, line)
         except OSError as e:
             logger.warning("Failed to read status for PID %d: %s", pid, e)
+
+    # If the PID exists but isn't dockerd, the pid file is stale — remove it so
+    # dockerd can start.  If the process no longer exists at all, also remove it.
+    is_dockerd = comm == "dockerd"
+    pid_exists = Path(f"/proc/{pid}").exists()
+    if not pid_exists or not is_dockerd:
+        logger.info("Removing stale /var/run/docker.pid (pid=%d, pid_exists=%s, comm=%r)", pid, pid_exists, comm)
+        try:
+            pid_file.unlink()
+        except OSError as e:
+            logger.warning("Failed to remove /var/run/docker.pid: %s", e)
 
 
 async def setup_container_runtime(
@@ -415,10 +438,11 @@ async def setup_container_runtime(
             env_vars=spec.client_env_vars,
         )
 
-    # Log diagnostics before attempting start — helps identify pre-existing
-    # daemons that own /var/run/docker.pid but whose socket is missing/unresponsive.
+    # Clean up stale /var/run/docker.pid before attempting start.  A leftover
+    # pid file whose PID has been reused by a non-dockerd process (e.g.
+    # supervisord) causes dockerd to abort with "process still running".
     if runtime == "docker":
-        _log_docker_conflict_info()
+        _cleanup_stale_docker_pid()
 
     logger.info("Configuring %s...", spec.service_name)
 

--- a/tools/claude_hooks/container_runtime.py
+++ b/tools/claude_hooks/container_runtime.py
@@ -326,6 +326,47 @@ def get_storage_dir(settings: HookSettings) -> Path | None:
     return settings.get_container_storage_dir()
 
 
+def _log_docker_conflict_info() -> None:
+    """Log diagnostic info about a conflicting dockerd process.
+
+    Called when the Docker socket is not responsive but we're about to try
+    starting a new dockerd.  Helps diagnose cases where a pre-existing daemon
+    owns /var/run/docker.pid but its socket is missing or unresponsive.
+    """
+    sock_file = DEFAULT_DOCKER_SOCKET
+    logger.info("docker socket check: exists=%s", sock_file.exists())
+
+    pid_file = Path("/var/run/docker.pid")
+    if not pid_file.exists():
+        logger.info("No /var/run/docker.pid found")
+        return
+
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (ValueError, OSError) as e:
+        logger.warning("Failed to read /var/run/docker.pid: %s", e)
+        return
+
+    logger.info("Found /var/run/docker.pid with pid=%d", pid)
+
+    cmdline_path = Path(f"/proc/{pid}/cmdline")
+    if cmdline_path.exists():
+        try:
+            cmdline = cmdline_path.read_bytes().replace(b"\x00", b" ").decode(errors="replace").strip()
+            logger.info("PID %d cmdline: %s", pid, cmdline)
+        except OSError as e:
+            logger.warning("Failed to read cmdline for PID %d: %s", pid, e)
+
+    status_path = Path(f"/proc/{pid}/status")
+    if status_path.exists():
+        try:
+            for line in status_path.read_text().splitlines():
+                if line.startswith(("Name:", "PPid:", "State:")):
+                    logger.info("PID %d status: %s", pid, line)
+        except OSError as e:
+            logger.warning("Failed to read status for PID %d: %s", pid, e)
+
+
 async def setup_container_runtime(
     settings: HookSettings, supervisor: SupervisorClient, tmpfs_mounted: bool
 ) -> ContainerRuntimeSetup:
@@ -373,6 +414,11 @@ async def setup_container_runtime(
             storage_driver=spec.storage_driver,
             env_vars=spec.client_env_vars,
         )
+
+    # Log diagnostics before attempting start — helps identify pre-existing
+    # daemons that own /var/run/docker.pid but whose socket is missing/unresponsive.
+    if runtime == "docker":
+        _log_docker_conflict_info()
 
     logger.info("Configuring %s...", spec.service_name)
 


### PR DESCRIPTION
## Summary
This PR addresses two issues: stale Docker PID files preventing daemon startup, and incorrect Python virtual environment path resolution in container images.

## Key Changes

### Docker PID Cleanup (`container_runtime.py`)
- Added `_cleanup_stale_docker_pid()` function to detect and remove stale `/var/run/docker.pid` files
- The function checks if the PID in the file corresponds to a `dockerd` process by examining `/proc/{pid}/comm`
- If the PID doesn't exist or belongs to a different process (e.g., `supervisord`), the stale PID file is removed
- Comprehensive logging of process information (comm, cmdline, status) for debugging
- Called before Docker daemon startup to prevent "process still running" errors when PIDs have been reused

### Python Venv Path Resolution (`oci.bzl`)
- Updated `py_image_env()` to use the correct runtime venv path: `/{pkg}/{binary_name}.runfiles/.{binary_name}.venv/bin`
- Updated `py_python3_symlink()` to point to the same venv location
- The aspect py_binary launcher creates the venv lazily at runtime inside the runfiles directory with a leading dot prefix
- This ensures subprocess `exec()` calls inherit the correct Python3 after the container entrypoint initializes the venv
- Added clarifying comments explaining the runtime venv creation behavior

## Implementation Details
- The Docker PID cleanup is defensive: it logs detailed process information before removal and gracefully handles read errors
- The venv path changes align with how the aspect py_binary launcher actually structures the runfiles directory at runtime
- Both changes are backward compatible and improve reliability in containerized environments

https://claude.ai/code/session_01McgRnBS5c31Lp9Y7oU3JHB