### PR TITLE
feat(oauth-broker): split tokens into refresh + access secrets

### DIFF
--- a/cluster/k8s/oauth-broker/config.yaml
+++ b/cluster/k8s/oauth-broker/config.yaml
@@ -14,12 +14,15 @@ providers:
       - session
       - spo2
     redirect_uri: https://oauth-broker.allegedly.works/callback/oura
-    secret_name: oura-tokens
-    secret_annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
+    refresh_secret:
+      name: oura-tokens
+    access_secret:
+      name: oura-access-token
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
     refresh_margin_seconds: 3600
 
   - name: google
@@ -39,12 +42,15 @@ providers:
       # Workspace Enterprise accounts and is not available for personal Gmail
       # accounts. Requesting it causes Error 400: invalid_scope for all users.
     redirect_uri: https://oauth-broker.allegedly.works/callback/google
-    secret_name: google-tokens
-    secret_annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
+    refresh_secret:
+      name: google-tokens
+    access_secret:
+      name: google-access-token
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
     refresh_margin_seconds: 300
     extra_auth_params:
       access_type: offline
@@ -60,9 +66,12 @@ providers:
       - identity
       - investments
     redirect_uri: https://oauth-broker.allegedly.works/callback/plaid
-    secret_name: plaid-tokens
-    secret_annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
+    refresh_secret:
+      name: plaid-tokens
+    access_secret:
+      name: plaid-access-token
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox

--- a/oauth_broker/app.py
+++ b/oauth_broker/app.py
@@ -11,7 +11,7 @@ from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
 from oauth_broker.k8s_client import K8sTokenStore
-from oauth_broker.provider import PlaidProvider, Provider
+from oauth_broker.provider import ACCESS_TOKEN_FIELDS, PlaidProvider, Provider
 from oauth_broker.refresh import token_refresh_loop
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI
     async def index() -> str:
         provider_rows = []
         for name, provider in providers.items():
-            token = await get_store().read_token(provider.config.secret_name, target_namespace)
+            token = await get_store().read_token(provider.config.refresh_secret.name, target_namespace)
             if token is not None:
                 if isinstance(provider, PlaidProvider):
                     status = "Connected"
@@ -129,7 +129,17 @@ def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI
 
         token = await provider.exchange_code(code)
         await get_store().write_token(
-            provider.config.secret_name, target_namespace, token, annotations=provider.config.secret_annotations or None
+            provider.config.refresh_secret.name,
+            target_namespace,
+            token,
+            annotations=provider.config.refresh_secret.annotations or None,
+        )
+        await get_store().write_token(
+            provider.config.access_secret.name,
+            target_namespace,
+            token,
+            annotations=provider.config.access_secret.annotations or None,
+            fields=ACCESS_TOKEN_FIELDS,
         )
         logger.info(f"Stored tokens for {provider_name} (expires {token.expires_at})")
         return RedirectResponse("/")
@@ -144,7 +154,17 @@ def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI
             raise HTTPException(405, f"{provider_name} does not support POST callback")
         token = await provider.exchange_public_token(body.public_token)
         await get_store().write_token(
-            provider.config.secret_name, target_namespace, token, annotations=provider.config.secret_annotations or None
+            provider.config.refresh_secret.name,
+            target_namespace,
+            token,
+            annotations=provider.config.refresh_secret.annotations or None,
+        )
+        await get_store().write_token(
+            provider.config.access_secret.name,
+            target_namespace,
+            token,
+            annotations=provider.config.access_secret.annotations or None,
+            fields=ACCESS_TOKEN_FIELDS,
         )
         logger.info(f"Stored Plaid tokens for {provider_name}")
         return RedirectResponse("/", status_code=303)
@@ -153,7 +173,7 @@ def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI
     async def status() -> dict:
         result = {}
         for name, provider in providers.items():
-            token = await get_store().read_token(provider.config.secret_name, target_namespace)
+            token = await get_store().read_token(provider.config.refresh_secret.name, target_namespace)
             if token is not None:
                 result[name] = {"connected": True, "expires_at": token.expires_at.isoformat(), "scope": token.scope}
             else:

--- a/oauth_broker/k8s_client.py
+++ b/oauth_broker/k8s_client.py
@@ -6,7 +6,7 @@ import logging
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import ApiException
 
-from oauth_broker.provider import TokenData
+from oauth_broker.provider import ALL_TOKEN_FIELDS, TokenData
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +25,11 @@ class K8sTokenStore:
         secret_name: str,
         namespace: str,
         token: TokenData,
+        *,
+        fields: frozenset[str] = ALL_TOKEN_FIELDS,
         annotations: dict[str, str] | None = None,
-        fields: frozenset[str] | None = None,
     ) -> None:
-        data = token.model_dump(mode="json")
-        if fields is not None:
-            data = {k: v for k, v in data.items() if k in fields}
+        data = {k: v for k, v in token.model_dump(mode="json").items() if k in fields}
         secret = client.V1Secret(
             metadata=client.V1ObjectMeta(
                 name=secret_name,

--- a/oauth_broker/k8s_client.py
+++ b/oauth_broker/k8s_client.py
@@ -21,8 +21,16 @@ class K8sTokenStore:
         return cls(client.CoreV1Api())
 
     async def write_token(
-        self, secret_name: str, namespace: str, token: TokenData, annotations: dict[str, str] | None = None
+        self,
+        secret_name: str,
+        namespace: str,
+        token: TokenData,
+        annotations: dict[str, str] | None = None,
+        fields: frozenset[str] | None = None,
     ) -> None:
+        data = token.model_dump(mode="json")
+        if fields is not None:
+            data = {k: v for k, v in data.items() if k in fields}
         secret = client.V1Secret(
             metadata=client.V1ObjectMeta(
                 name=secret_name,
@@ -30,7 +38,7 @@ class K8sTokenStore:
                 labels={"app.kubernetes.io/managed-by": "oauth-broker"},
                 annotations=annotations or None,
             ),
-            string_data=token.model_dump(mode="json"),
+            string_data=data,
             type="Opaque",
         )
 

--- a/oauth_broker/provider.py
+++ b/oauth_broker/provider.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 ACCESS_TOKEN_FIELDS: frozenset[str] = frozenset({"access_token", "token_type", "expires_at", "scope"})
+ALL_TOKEN_FIELDS: frozenset[str] = frozenset({"access_token", "refresh_token", "token_type", "expires_at", "scope"})
 
 
 class TokenSecretConfig(BaseModel):
@@ -26,8 +27,8 @@ class BaseProviderConfig(BaseModel):
     name: str = Field(description="Provider identifier used in URL paths and env var prefixes")
     display_name: str = Field(description="Human-readable provider name for the UI")
     redirect_uri: str = Field(description="Redirect URI registered with the provider")
-    refresh_secret: TokenSecretConfig = Field(description="Secret holding all token fields; never reflected")
-    access_secret: TokenSecretConfig = Field(description="Secret holding access token + metadata; may be reflected")
+    refresh_secret: TokenSecretConfig = Field(description="Secret holding all token fields including refresh_token")
+    access_secret: TokenSecretConfig = Field(description="Secret holding access_token, token_type, expires_at, scope")
 
 
 class OAuth2ProviderConfig(BaseProviderConfig):

--- a/oauth_broker/provider.py
+++ b/oauth_broker/provider.py
@@ -14,14 +14,20 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger(__name__)
 
 
+ACCESS_TOKEN_FIELDS: frozenset[str] = frozenset({"access_token", "token_type", "expires_at", "scope"})
+
+
+class TokenSecretConfig(BaseModel):
+    name: str
+    annotations: dict[str, str] = Field(default_factory=dict)
+
+
 class BaseProviderConfig(BaseModel):
     name: str = Field(description="Provider identifier used in URL paths and env var prefixes")
     display_name: str = Field(description="Human-readable provider name for the UI")
     redirect_uri: str = Field(description="Redirect URI registered with the provider")
-    secret_name: str = Field(description="K8s secret name for storing tokens")
-    secret_annotations: dict[str, str] = Field(
-        default_factory=dict, description="Annotations to add to the token secret"
-    )
+    refresh_secret: TokenSecretConfig = Field(description="Secret holding all token fields; never reflected")
+    access_secret: TokenSecretConfig = Field(description="Secret holding access token + metadata; may be reflected")
 
 
 class OAuth2ProviderConfig(BaseProviderConfig):

--- a/oauth_broker/refresh.py
+++ b/oauth_broker/refresh.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Mapping
 
 from oauth_broker.k8s_client import K8sTokenStore
-from oauth_broker.provider import Provider
+from oauth_broker.provider import ACCESS_TOKEN_FIELDS, Provider
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +17,7 @@ async def token_refresh_loop(
     while True:
         for name, provider in providers.items():
             try:
-                secret_name = provider.config.secret_name
-                token = await k8s_store.read_token(secret_name, target_namespace)
+                token = await k8s_store.read_token(provider.config.refresh_secret.name, target_namespace)
                 if token is None:
                     continue
                 if not provider.needs_refresh(token):
@@ -26,7 +25,17 @@ async def token_refresh_loop(
                 logger.info(f"Refreshing token for {name} (expires {token.expires_at})")
                 new_token = await provider.refresh_tokens(token.refresh_token)
                 await k8s_store.write_token(
-                    secret_name, target_namespace, new_token, annotations=provider.config.secret_annotations or None
+                    provider.config.refresh_secret.name,
+                    target_namespace,
+                    new_token,
+                    annotations=provider.config.refresh_secret.annotations or None,
+                )
+                await k8s_store.write_token(
+                    provider.config.access_secret.name,
+                    target_namespace,
+                    new_token,
+                    annotations=provider.config.access_secret.annotations or None,
+                    fields=ACCESS_TOKEN_FIELDS,
                 )
                 logger.info(f"Refreshed token for {name} (new expiry {new_token.expires_at})")
             except Exception:

--- a/oauth_broker/test_provider.py
+++ b/oauth_broker/test_provider.py
@@ -15,6 +15,7 @@ from oauth_broker.provider import (
     GenericOAuth2Provider,
     OAuth2ProviderConfig,
     TokenData,
+    TokenSecretConfig,
     _parse_token_response,
 )
 
@@ -28,7 +29,8 @@ def provider_config() -> OAuth2ProviderConfig:
         token_url="https://example.com/token",
         scopes=["scope1", "scope2"],
         redirect_uri="http://localhost:8080/callback/test",
-        secret_name="test-tokens",
+        refresh_secret=TokenSecretConfig(name="test-tokens"),
+        access_secret=TokenSecretConfig(name="test-access-token"),
     )
 
 
@@ -59,7 +61,8 @@ def test_build_authorize_url_with_extra_params() -> None:
         token_url="https://oauth2.googleapis.com/token",
         scopes=["email"],
         redirect_uri="http://localhost/callback/google",
-        secret_name="google-tokens",
+        refresh_secret=TokenSecretConfig(name="google-tokens"),
+        access_secret=TokenSecretConfig(name="google-access-token"),
         extra_auth_params={"access_type": "offline", "prompt": "consent"},
     )
     provider = GenericOAuth2Provider(config, "gid", "gsecret")
@@ -178,17 +181,23 @@ def test_broker_config_from_yaml(tmp_path: Path) -> None:
             token_url: https://example.com/token
             scopes: [a]
             redirect_uri: http://localhost/callback/test
-            secret_name: test-tokens
-            secret_annotations:
-              reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+            refresh_secret:
+              name: test-tokens
+            access_secret:
+              name: test-access-token
+              annotations:
+                reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     """)
     )
     config = BrokerConfig.from_file(config_file)
     assert config.target_namespace == "test-ns"
     assert len(config.providers) == 1
     assert config.providers[0].name == "test"
-    assert config.providers[0].secret_name == "test-tokens"
-    assert config.providers[0].secret_annotations == {"reflector.v1.k8s.emberstack.com/reflection-allowed": "true"}
+    assert config.providers[0].refresh_secret.name == "test-tokens"
+    assert config.providers[0].access_secret.name == "test-access-token"
+    assert config.providers[0].access_secret.annotations == {
+        "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+    }
 
 
 def test_broker_config_defaults() -> None:

--- a/oauth_broker/test_refresh.py
+++ b/oauth_broker/test_refresh.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_bazel
 
-from oauth_broker.provider import GenericOAuth2Provider, OAuth2ProviderConfig, TokenData
+from oauth_broker.provider import (
+    ACCESS_TOKEN_FIELDS,
+    GenericOAuth2Provider,
+    OAuth2ProviderConfig,
+    TokenData,
+    TokenSecretConfig,
+)
 from oauth_broker.refresh import token_refresh_loop
 
 
@@ -21,7 +27,8 @@ def provider() -> GenericOAuth2Provider:
             token_url="https://example.com/token",
             scopes=["daily"],
             redirect_uri="https://example.com/callback/test",
-            secret_name="test-tokens",
+            refresh_secret=TokenSecretConfig(name="test-tokens"),
+            access_secret=TokenSecretConfig(name="test-access-token"),
             refresh_margin_seconds=3600,
         ),
         client_id="test-id",
@@ -68,7 +75,10 @@ async def test_refresh_loop_refreshes_expiring_token(provider: GenericOAuth2Prov
         await _run_loop_briefly({"test": provider}, mock_store, "test-ns")
 
     mock_store.read_token.assert_called_with("test-tokens", "test-ns")
-    mock_store.write_token.assert_called_with("test-tokens", "test-ns", refreshed_token, annotations=None)
+    mock_store.write_token.assert_any_call("test-tokens", "test-ns", refreshed_token, annotations=None)
+    mock_store.write_token.assert_any_call(
+        "test-access-token", "test-ns", refreshed_token, annotations=None, fields=ACCESS_TOKEN_FIELDS
+    )
 
 
 async def test_refresh_loop_skips_fresh_token(provider: GenericOAuth2Provider) -> None:


### PR DESCRIPTION
## Summary

- Adds `TokenSecretConfig` model (`name` + `annotations`) and replaces the old `secret_name`/`secret_annotations` fields in `BaseProviderConfig` with `refresh_secret` and `access_secret`
- Introduces `ACCESS_TOKEN_FIELDS` constant (`access_token`, `token_type`, `expires_at`, `scope`) used when writing the access secret
- `K8sTokenStore.write_token` gains an optional `fields: frozenset[str] | None` parameter to write only a subset of `TokenData` fields
- On every token write (OAuth callback + background refresh), two secrets are written per provider: the full-field refresh secret and the access-only secret
- `config.yaml` updated for all three providers (oura, google, plaid); refresh secret keeps existing name (`*-tokens`), access secret is new (`*-access-token`)

**Security impact:** Refresh tokens are no longer reflected to `openclaw-sandbox`/`claude-sandbox`. Consumer namespaces only receive short-lived access tokens.

## Migration note

Consumer workloads currently mounting `{provider}-tokens` from reflected secrets need to update their references to `{provider}-access-token`.

## Test plan

- [x] `bazel test //oauth_broker/...` — both test targets pass
- [x] `bazel build //oauth_broker:image` — image builds successfully
- [ ] After deploy: verify `kubectl get secret -n oauth-broker` shows both `*-tokens` and `*-access-token`
- [ ] Verify `kubectl get secret google-access-token -n claude-sandbox` has no `refresh_token` field

https://claude.ai/code/session_012uuyfE16AuvNSQH5LZowmJ