### PR TITLE
Switch Gatus SSO from proxy outpost to native OIDC

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -73,6 +73,11 @@ See <changelog.md> for detailed change history.
       `atlas.allegedly.works` which handles network-level access). Needs: Authentik
       blueprint for OIDC provider, Vault secret for client credentials, PVE realm config
       (manual or via API).
+- [ ] **File Browser (scanner): switch to native OAuth2** — File Browser supports native
+      OAuth2/OIDC. Currently behind proxy outpost at `scanbox.allegedly.works`. Migration
+      follows the Gatus pattern: OAuth2 provider blueprint, `sso/scanner-filebrowser`
+      Vault secret, ESO into scanner namespace, direct HTTPRoute, updated networkpolicy
+      (gateway-system instead of outpost), remove from `shared-proxy-outpost.yaml`.
 - [ ] **Ollama: per-user auth** — Options: Authentik JWTs, LiteLLM proxy.
 - [ ] **Harbor terraform: switch to robot accounts** for least-privilege
 - [ ] **Harbor CI robot: scope per-namespace pull secrets to read-only on specific projects** —

--- a/cluster/k8s/authentik-proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik-proxy-routes/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - hubble-httproute.yaml
   - openclaw-httproute.yaml
   - alloy-otlp-httproute.yaml
-  - gatus-httproute.yaml
   - grocy-httproute.yaml
   - oauth-broker-httproute.yaml
   - filebrowser-httproute.yaml

--- a/cluster/k8s/authentik-sso-secrets/sso-client-secrets-eso.yaml
+++ b/cluster/k8s/authentik-sso-secrets/sso-client-secrets-eso.yaml
@@ -47,6 +47,10 @@ spec:
       remoteRef:
         key: sso/headlamp
         property: client_secret
+    - secretKey: GATUS_CLIENT_SECRET
+      remoteRef:
+        key: sso/gatus
+        property: client_secret
     - secretKey: USER_PASSWORD
       remoteRef:
         key: kv/users/agentydragon

--- a/cluster/k8s/authentik/blueprints/gatus-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/gatus-sso.yaml
@@ -2,22 +2,36 @@ version: 1
 metadata:
   name: SSO - Gatus
   labels:
-    blueprints.goauthentik.io/description: "Gatus proxy provider, application, and outpost"
+    blueprints.goauthentik.io/description: "Gatus OAuth2 OIDC provider and application"
 
 entries:
+  # Remove old proxy provider (replaced by native OIDC)
   - model: authentik_providers_proxy.proxyprovider
+    state: absent
+    identifiers:
+      name: gatus
+
+  - model: authentik_providers_oauth2.oauth2provider
     id: gatus-provider
     state: present
     identifiers:
       name: gatus
     attrs:
-      external_host: "https://status.allegedly.works"
-      internal_host: "http://gatus.gatus.svc.cluster.local:80"
-      mode: proxy
-      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      client_id: gatus
+      client_secret: !Env GATUS_CLIENT_SECRET
       authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-      access_token_validity: "hours=1"
+      client_type: confidential
+      issuer_mode: per_provider
+      include_claims_in_id_token: true
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+      redirect_uris:
+        - url: "https://status.allegedly.works/authorization-code/callback"
+          matching_mode: strict
 
   - model: authentik_core.application
     id: gatus-app

--- a/cluster/k8s/authentik/blueprints/shared-proxy-outpost.yaml
+++ b/cluster/k8s/authentik/blueprints/shared-proxy-outpost.yaml
@@ -13,7 +13,6 @@ entries:
       type: proxy
       providers:
         - !Find [authentik_providers_proxy.proxyprovider, [name, alloy-otlp]]
-        - !Find [authentik_providers_proxy.proxyprovider, [name, gatus]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, grocy]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, hubble]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, loki]]

--- a/cluster/k8s/gatus-secrets/flux-kustomization.yaml
+++ b/cluster/k8s/gatus-secrets/flux-kustomization.yaml
@@ -16,3 +16,4 @@ spec:
     - name: gatus-namespace
     - name: external-secrets-operator
     - name: external-secrets-config
+    - name: authentik-blueprint-sso-secrets # gatus OIDC secret written to Vault by sso-secrets terraform

--- a/cluster/k8s/gatus-secrets/gatus-oidc-eso.yaml
+++ b/cluster/k8s/gatus-secrets/gatus-oidc-eso.yaml
@@ -1,0 +1,23 @@
+---
+# ExternalSecret for Gatus OIDC client credentials from Vault.
+# Creates a K8s Secret with GATUS_CLIENT_SECRET env var for the Gatus pod.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gatus-oidc-secret
+  namespace: gatus
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: gatus-oidc-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        GATUS_CLIENT_SECRET: "{{ .client_secret }}"
+  dataFrom:
+    - extract:
+        key: sso/gatus

--- a/cluster/k8s/gatus-secrets/kustomization.yaml
+++ b/cluster/k8s/gatus-secrets/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
+  - gatus-oidc-eso.yaml

--- a/cluster/k8s/gatus/config.yaml
+++ b/cluster/k8s/gatus/config.yaml
@@ -1,5 +1,13 @@
 # TODO: Consider consolidating the many per-app PostgreSQL instances
 # in the cluster into a shared instance, and using postgres backend.
+security:
+  oidc:
+    issuer-url: https://auth.allegedly.works/application/o/gatus/
+    redirect-url: https://status.allegedly.works/authorization-code/callback
+    client-id: gatus
+    client-secret: ${GATUS_CLIENT_SECRET}
+    scopes: [openid]
+
 storage:
   type: sqlite
   path: /data/gatus.db

--- a/cluster/k8s/gatus/helmrelease.yaml
+++ b/cluster/k8s/gatus/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
     envFrom:
       - secretRef:
           name: gatus-ollama-api-key
+      - secretRef:
+          name: gatus-oidc-secret
 
     ingress:
       enabled: false

--- a/cluster/k8s/gatus/httproute.yaml
+++ b/cluster/k8s/gatus/httproute.yaml
@@ -1,11 +1,10 @@
-# HTTPRoute for Gatus via shared Authentik proxy outpost.
-# Traffic flows: Gateway → outpost (auth) → gatus backend.
----
+# HTTPRoute for Gatus. Traffic flows directly: Gateway → Gatus backend.
+# Auth is handled by Gatus's native OIDC integration (no proxy outpost needed).
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: gatus
-  namespace: authentik
+  namespace: gatus
 spec:
   parentRefs:
     - name: cluster-gateway
@@ -14,5 +13,5 @@ spec:
     - "status.allegedly.works"
   rules:
     - backendRefs:
-        - name: ak-outpost-shared-proxy-outpost
-          port: 9000
+        - name: gatus
+          port: 80

--- a/cluster/k8s/gatus/kustomization.yaml
+++ b/cluster/k8s/gatus/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - helmrelease.yaml
   - env-configmap.yaml
   - networkpolicy.yaml
-  # HTTPRoute is in authentik-proxy-routes/gatus-httproute.yaml (SSO-protected via Authentik outpost).
+  - httproute.yaml
 
 configMapGenerator:
   - name: gatus-config

--- a/cluster/k8s/gatus/networkpolicy.yaml
+++ b/cluster/k8s/gatus/networkpolicy.yaml
@@ -1,6 +1,5 @@
-# Restrict Gatus ingress to Authentik proxy outpost and Prometheus scraping.
-# Gatus trusts X-authentik-username for user identity — any pod that
-# can reach port 8080 can impersonate any user.
+# Restrict Gatus ingress to the Cilium gateway and Prometheus scraping.
+# With native OIDC, auth is handled by Gatus itself — gateway passes traffic directly.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -13,14 +12,11 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # Authentik proxy outpost → Gatus (SSO-protected external access)
+    # Cilium gateway → Gatus (external access via HTTPRoute)
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: authentik
-          podSelector:
-            matchLabels:
-              goauthentik.io/outpost-name: shared-proxy-outpost
+              kubernetes.io/metadata.name: gateway-system
       ports:
         - port: 8080
           protocol: TCP

--- a/cluster/terraform/gitops/sso-secrets/main.tf
+++ b/cluster/terraform/gitops/sso-secrets/main.tf
@@ -107,6 +107,16 @@ resource "random_password" "headlamp_client_secret" {
   }
 }
 
+resource "random_password" "gatus_client_secret" {
+  length  = 32
+  special = false
+  keepers = { rotation_version = var.rotation_version }
+
+  lifecycle {
+    ignore_changes = [length, special]
+  }
+}
+
 # --- Vault Storage: Basic Credentials ---
 
 resource "vault_kv_secret_v2" "gitea_oidc" {
@@ -186,6 +196,16 @@ resource "vault_kv_secret_v2" "headlamp_oidc" {
   data_json = jsonencode({
     client_id     = "headlamp"
     client_secret = random_password.headlamp_client_secret.result
+  })
+}
+
+resource "vault_kv_secret_v2" "gatus_oidc" {
+  mount = "kv"
+  name  = "sso/gatus"
+
+  data_json = jsonencode({
+    client_id     = "gatus"
+    client_secret = random_password.gatus_client_secret.result
   })
 }
 


### PR DESCRIPTION
## Summary

- Replace Gatus's Authentik proxy outpost with Gatus's built-in OIDC support — Gatus authenticates directly via Authentik OAuth2 provider
- Add `sso/gatus` client secret to Vault via the sso-secrets Terraform module; inject into both the Authentik worker (for the blueprint `!Env` tag) and the Gatus pod
- Move the HTTPRoute from `authentik-proxy-routes/` into the `gatus/` kustomization; update the network policy to allow `gateway-system` instead of the outpost pod
- Add a todo for File Browser native OAuth2 migration (same pattern)

## Files changed

| Area | Change |
|---|---|
| `gatus-sso.yaml` | Replace `proxyprovider` with `oauth2provider`; cleanup old proxy provider |
| `shared-proxy-outpost.yaml` | Remove `gatus` from providers list |
| `sso-secrets/main.tf` | Add `gatus` client secret (Vault SSOT) |
| `authentik-sso-secrets` ESO | Add `GATUS_CLIENT_SECRET` for Authentik worker |
| `gatus/config.yaml` | Add `security.oidc` block |
| `gatus/helmrelease.yaml` | Mount `gatus-oidc-secret` via envFrom |
| `gatus/httproute.yaml` | New direct HTTPRoute (gateway → gatus) |
| `gatus/networkpolicy.yaml` | Allow `gateway-system` instead of outpost |
| `gatus-secrets/` | New ESO + `authentik-blueprint-sso-secrets` dep |
| `authentik-proxy-routes/` | Remove `gatus-httproute.yaml` |
| `plan.md` | Add File Browser native OAuth2 todo |

## Test plan

- [ ] Run sso-secrets terraform to write `sso/gatus` to Vault
- [ ] Confirm Authentik worker picks up `GATUS_CLIENT_SECRET` (check blueprint applies without error)
- [ ] Confirm `gatus-oidc-secret` ESO syncs in gatus namespace
- [ ] Browse `https://status.allegedly.works` — should redirect to Authentik login
- [ ] Log in as an `authentik Admins` member — should land on Gatus dashboard
- [ ] Confirm non-admin user is denied at the Authentik authorization step

https://claude.ai/code/session_017KD9ik93yBgW6fQUYv28c7