### PR TITLE
Add orphaned secret cleanup and configurable managed-by label

### DIFF
--- a/cluster/k8s/oauth-broker/rbac.yaml
+++ b/cluster/k8s/oauth-broker/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "update", "patch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/oauth_broker/app.py
+++ b/oauth_broker/app.py
@@ -23,7 +23,7 @@ class _PlaidCallbackBody(BaseModel):
     public_token: str
 
 
-def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI:
+def create_app(providers: dict[str, Provider], target_namespace: str, managed_by: str = "oauth-broker") -> FastAPI:
     app = FastAPI(title="OAuth Broker", docs_url=None, redoc_url=None)
     jinja_env = Environment(loader=FileSystemLoader(Path(__file__).parent), autoescape=True)
     index_template = jinja_env.get_template("index.html.j2")
@@ -34,7 +34,7 @@ def create_app(providers: dict[str, Provider], target_namespace: str) -> FastAPI
     @app.on_event("startup")
     async def startup() -> None:
         nonlocal k8s_store
-        k8s_store = await K8sTokenStore.from_incluster()
+        k8s_store = await K8sTokenStore.from_incluster(managed_by=managed_by)
         task = asyncio.create_task(token_refresh_loop(providers, k8s_store, target_namespace))
         background_tasks.add(task)
         task.add_done_callback(background_tasks.discard)

--- a/oauth_broker/cli.py
+++ b/oauth_broker/cli.py
@@ -38,7 +38,7 @@ def main() -> None:
         else:
             providers[p.name] = GenericOAuth2Provider(p, client_id, client_secret)
 
-    app = create_app(providers, target_namespace)
+    app = create_app(providers, target_namespace, managed_by=config.managed_by)
     uvicorn.run(app, host="0.0.0.0", port=8080)
 
 

--- a/oauth_broker/k8s_client.py
+++ b/oauth_broker/k8s_client.py
@@ -10,15 +10,22 @@ from oauth_broker.provider import ALL_TOKEN_FIELDS, TokenData
 
 logger = logging.getLogger(__name__)
 
+# TODO: A more civilized cleanup strategy would be to set ownerReferences on each
+# managed secret pointing to a stable anchor object (e.g. the oauth-broker ConfigMap).
+# That way, secrets are garbage-collected automatically by K8s even if the oauth-broker
+# deployment is deleted entirely, without needing the broker to be running. The current
+# label-based sweep requires the broker to be alive to clean up after itself.
+
 
 class K8sTokenStore:
-    def __init__(self, api: client.CoreV1Api) -> None:
+    def __init__(self, api: client.CoreV1Api, managed_by: str = "oauth-broker") -> None:
         self._api = api
+        self._managed_by = managed_by
 
     @classmethod
-    async def from_incluster(cls) -> "K8sTokenStore":
+    async def from_incluster(cls, managed_by: str = "oauth-broker") -> "K8sTokenStore":
         config.load_incluster_config()
-        return cls(client.CoreV1Api())
+        return cls(client.CoreV1Api(), managed_by)
 
     async def write_token(
         self,
@@ -34,7 +41,7 @@ class K8sTokenStore:
             metadata=client.V1ObjectMeta(
                 name=secret_name,
                 namespace=namespace,
-                labels={"app.kubernetes.io/managed-by": "oauth-broker"},
+                labels={"app.kubernetes.io/managed-by": self._managed_by},
                 annotations=annotations or None,
             ),
             string_data=data,
@@ -51,6 +58,16 @@ class K8sTokenStore:
                 logger.info(f"Created secret {namespace}/{secret_name}")
             else:
                 raise
+
+    async def delete_orphaned_secrets(self, namespace: str, known_names: frozenset[str]) -> None:
+        """Delete managed secrets whose names are not in known_names."""
+        label_selector = f"app.kubernetes.io/managed-by={self._managed_by}"
+        secrets = await self._api.list_namespaced_secret(namespace, label_selector=label_selector)
+        for secret in secrets.items:
+            name = secret.metadata.name
+            if name not in known_names:
+                await self._api.delete_namespaced_secret(name, namespace)
+                logger.info(f"Deleted orphaned secret {namespace}/{name}")
 
     async def read_token(self, secret_name: str, namespace: str) -> TokenData | None:
         try:

--- a/oauth_broker/k8s_client.py
+++ b/oauth_broker/k8s_client.py
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class K8sTokenStore:
-    def __init__(self, api: client.CoreV1Api, managed_by: str = "oauth-broker") -> None:
+    def __init__(self, api: client.CoreV1Api, managed_by: str) -> None:
         self._api = api
         self._managed_by = managed_by
 
     @classmethod
-    async def from_incluster(cls, managed_by: str = "oauth-broker") -> "K8sTokenStore":
+    async def from_incluster(cls, managed_by: str) -> "K8sTokenStore":
         config.load_incluster_config()
         return cls(client.CoreV1Api(), managed_by)
 

--- a/oauth_broker/k8s_client.py
+++ b/oauth_broker/k8s_client.py
@@ -2,6 +2,7 @@
 
 import base64
 import logging
+from typing import Self
 
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import ApiException
@@ -23,7 +24,7 @@ class K8sTokenStore:
         self._managed_by = managed_by
 
     @classmethod
-    async def from_incluster(cls, managed_by: str) -> "K8sTokenStore":
+    async def from_incluster(cls, managed_by: str) -> Self:
         config.load_incluster_config()
         return cls(client.CoreV1Api(), managed_by)
 

--- a/oauth_broker/provider.py
+++ b/oauth_broker/provider.py
@@ -61,6 +61,9 @@ class BrokerConfig(BaseModel):
     target_namespace: str | None = Field(
         default=None, description="K8s namespace to write token secrets to (auto-detected from pod if omitted)"
     )
+    managed_by: str = Field(
+        default="oauth-broker", description="Value for app.kubernetes.io/managed-by label on managed secrets"
+    )
     providers: list[ProviderConfig] = Field(description="Provider configurations")
 
     @classmethod

--- a/oauth_broker/refresh.py
+++ b/oauth_broker/refresh.py
@@ -13,7 +13,12 @@ logger = logging.getLogger(__name__)
 async def token_refresh_loop(
     providers: Mapping[str, Provider], k8s_store: K8sTokenStore, target_namespace: str, check_interval: float = 300
 ) -> None:
-    """Check all provider tokens periodically, refresh if near expiry."""
+    """Check all provider tokens periodically, refresh if near expiry, and clean up orphaned secrets."""
+    known_secret_names = frozenset(
+        name
+        for provider in providers.values()
+        for name in (provider.config.refresh_secret.name, provider.config.access_secret.name)
+    )
     while True:
         for name, provider in providers.items():
             try:
@@ -40,4 +45,8 @@ async def token_refresh_loop(
                 logger.info(f"Refreshed token for {name} (new expiry {new_token.expires_at})")
             except Exception:
                 logger.exception(f"Failed to refresh token for {name}")
+        try:
+            await k8s_store.delete_orphaned_secrets(target_namespace, known_secret_names)
+        except Exception:
+            logger.exception("Failed to clean up orphaned secrets")
         await asyncio.sleep(check_interval)

--- a/oauth_broker/test_refresh.py
+++ b/oauth_broker/test_refresh.py
@@ -124,5 +124,15 @@ async def test_refresh_loop_continues_on_error(provider: GenericOAuth2Provider) 
     mock_store.write_token.assert_not_called()
 
 
+async def test_refresh_loop_deletes_orphaned_secrets(provider: GenericOAuth2Provider) -> None:
+    # delete_orphaned_secrets should be called with the set of names declared in config.
+    mock_store = AsyncMock()
+    mock_store.read_token.return_value = None
+
+    await _run_loop_briefly({"test": provider}, mock_store, "test-ns")
+
+    mock_store.delete_orphaned_secrets.assert_called_with("test-ns", frozenset({"test-tokens", "test-access-token"}))
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
## Summary
This PR adds automatic cleanup of orphaned Kubernetes secrets and makes the `app.kubernetes.io/managed-by` label configurable. The oauth-broker now periodically deletes secrets it manages that are no longer referenced by any provider configuration.

## Key Changes
- **Orphaned secret cleanup**: Added `delete_orphaned_secrets()` method to `K8sTokenStore` that removes managed secrets whose names don't match any active provider configuration. This is called periodically in the token refresh loop.
- **Configurable managed-by label**: The `managed_by` parameter is now configurable via `BrokerConfig` (defaults to "oauth-broker"), allowing multiple oauth-broker instances to manage different sets of secrets in the same namespace.
- **RBAC updates**: Added `list` and `delete` verbs to the oauth-broker ClusterRole to support the new cleanup functionality.
- **Constructor changes**: Updated `K8sTokenStore.__init__()` and `from_incluster()` to accept and propagate the `managed_by` parameter through the application stack.

## Implementation Details
- The cleanup strategy uses label selectors to identify managed secrets (`app.kubernetes.io/managed-by={managed_by}`) and compares against a frozenset of known secret names derived from provider configurations.
- A TODO comment documents a future improvement: using Kubernetes `ownerReferences` for automatic garbage collection instead of the current label-based sweep approach.
- Error handling is in place to prevent cleanup failures from disrupting the token refresh loop.
- Added test coverage for the orphaned secret cleanup functionality.

https://claude.ai/code/session_01DFcz755JqvRtxQc3JVbf4z