### PR TITLE
Add NetworkPolicies for Authentik and Prometheus APIs

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -268,10 +268,10 @@ observe traffic flows first, then generate baseline allow-rules.
       Any pod can currently reach `instance.vault:8200` and attempt auth method exploitation.
 - [x] **PowerDNS API** — restrict `powerdns-api.dns-system:8081` to cert-manager webhook,
       powerdns-operator, and external-dns. Unauthenticated zone modification = DNS poisoning.
-- [ ] **Authentik API** — restrict `authentik-server.authentik:80` to system namespaces
+- [x] **Authentik API** — restrict `authentik-server.authentik:80` to system namespaces
       and tofu-controller. Unauthenticated `/api/v3/` enables user enumeration, provider
       tampering, backdoor user creation.
-- [ ] **Prometheus** — restrict `prometheus.monitoring:9090` to Grafana, Alertmanager.
+- [x] **Prometheus** — restrict `prometheus.monitoring:9090` to Grafana, Alertmanager.
       No auth; exposes full cluster topology, node IPs, resource usage, secret cardinality.
 - [ ] **Sealed Secrets webhook** — restrict to flux-system namespace only.
 

--- a/cluster/k8s/authentik/kustomization.yaml
+++ b/cluster/k8s/authentik/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - authentik-host-configmap.yaml
   - token-secret.yaml
   - httproute.yaml
+  - networkpolicy.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/cluster/k8s/authentik/networkpolicy.yaml
+++ b/cluster/k8s/authentik/networkpolicy.yaml
@@ -1,0 +1,40 @@
+# Restrict Authentik API (port 80) to authorized cluster consumers.
+# Unauthenticated /api/v3/ enables user enumeration, provider tampering,
+# and backdoor user creation — restrict to prevent abuse from any cluster pod.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: authentik-server-ingress
+  namespace: authentik
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: authentik
+  policyTypes:
+    - Ingress
+  ingress:
+    # authentik namespace: outposts call server API for config sync
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: authentik
+      ports:
+        - port: 80
+          protocol: TCP
+    # flux-system: tofu-controller tf-runner calls Authentik API via Terraform
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: flux-system
+      ports:
+        - port: 80
+          protocol: TCP
+    # kube-system: cilium-envoy proxies external HTTPS traffic to server (Gateway API)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 80
+          protocol: TCP

--- a/cluster/k8s/monitoring-stack/kustomization.yaml
+++ b/cluster/k8s/monitoring-stack/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrelease.yaml
   - dashboards/harbor-dashboard.yaml
   - grafana-httproute.yaml
+  - networkpolicy.yaml

--- a/cluster/k8s/monitoring-stack/networkpolicy.yaml
+++ b/cluster/k8s/monitoring-stack/networkpolicy.yaml
@@ -1,0 +1,37 @@
+# Restrict Prometheus API (port 9090) to authorized consumers.
+# Prometheus has no authentication; unrestricted access exposes full cluster
+# topology, node IPs, resource usage, and secret cardinality to any pod.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    # Grafana: datasource queries for dashboards
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - port: 9090
+          protocol: TCP
+    # Alertmanager: Prometheus pushes alerts to Alertmanager; allow return traffic
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+      ports:
+        - port: 9090
+          protocol: TCP


### PR DESCRIPTION
## Summary
Implement Kubernetes NetworkPolicies to restrict unauthenticated access to Authentik and Prometheus APIs, reducing the attack surface for sensitive cluster services.

## Key Changes
- **Authentik API NetworkPolicy** (`cluster/k8s/authentik/networkpolicy.yaml`): Restricts port 80 access to authorized consumers only:
  - authentik namespace (outposts calling server API for config sync)
  - flux-system namespace (tofu-controller calling Authentik API via Terraform)
  - kube-system namespace (cilium-envoy proxying external HTTPS traffic via Gateway API)

- **Prometheus API NetworkPolicy** (`cluster/k8s/monitoring-stack/networkpolicy.yaml`): Restricts port 9090 access to:
  - Grafana (datasource queries for dashboards)
  - Alertmanager (alert push and return traffic)

- **Kustomization updates**: Added networkpolicy.yaml resources to both authentik and monitoring-stack kustomization files

- **Documentation**: Updated cluster/docs/plan.md to mark both Authentik API and Prometheus restrictions as completed

## Implementation Details
Both NetworkPolicies follow the principle of least privilege by:
- Targeting specific pods via label selectors (app.kubernetes.io/name and app.kubernetes.io/component)
- Restricting to specific namespaces via namespace selectors
- Limiting to specific ports and TCP protocol
- Including detailed comments explaining the security rationale for each rule

The policies address critical security concerns:
- **Authentik**: Prevents user enumeration, provider tampering, and backdoor user creation via unauthenticated `/api/v3/` endpoints
- **Prometheus**: Prevents exposure of cluster topology, node IPs, resource usage, and secret cardinality to unauthorized pods

https://claude.ai/code/session_01QV9fQk2mBHwR1TmBY1AJHs