### PR TITLE
flux: add spec.ignore to suppress reconciliation waves from non-cluster commits

### DIFF
--- a/cluster/k8s/flux-system/kustomization.yaml
+++ b/cluster/k8s/flux-system/kustomization.yaml
@@ -12,3 +12,8 @@ patches:
         path: /spec/sparseCheckout
         value:
           - cluster/
+      - op: add
+        path: /spec/ignore
+        value: |
+          /*
+          !/cluster/


### PR DESCRIPTION
## Summary

- `sparseCheckout` only limits what Flux *fetches* — the artifact revision is still the Git commit SHA, so every push to `devel` re-publishes the artifact and fans out to all Kustomizations regardless of what changed
- `spec.ignore` is the actual knob: when set, source-controller computes a content digest from non-ignored files and **skips re-publishing** (leaves revision unchanged) when that digest is stable
- Adds `spec.ignore: "/*\n!/cluster/"` to the existing GitRepository patch, mirroring the `sparseCheckout` scope — the two work as a pair (sparse checkout for bandwidth, `spec.ignore` for reconciliation gating)

## Test plan

- [ ] After merging, push a commit that only touches non-`cluster/` files (e.g. a README change)
- [ ] Verify `kubectl get gitrepository flux-system -n flux-system` does not show a new revision
- [ ] Verify no Kustomization objects show a new reconciliation timestamp

https://claude.ai/code/session_01AjSPFbkrNsH83eQiuz9f96