### PR TITLE
Mark generated lockfiles as linguist-generated in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,8 +22,6 @@ flake.lock linguist-generated=true
 pnpm-lock.yaml linguist-generated=true
 package-lock.json linguist-generated=true
 requirements_bazel.txt linguist-generated=true
-tools/multitool/lockfile.json linguist-generated=true
-MODULE.bazel.lock linguist-generated=true
 
 # Artifacts captured from live Claude Code containers — not our source code
 claude_web_env/rootfs/** rules-lint-ignored=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,13 @@ tana/testdata/** rules-lint-ignored=true
 
 # Generated lockfiles - large, not useful to diff
 Cargo.Bazel.lock linguist-generated=true
+Cargo.lock linguist-generated=true
+flake.lock linguist-generated=true
+pnpm-lock.yaml linguist-generated=true
+package-lock.json linguist-generated=true
+requirements_bazel.txt linguist-generated=true
+tools/multitool/lockfile.json linguist-generated=true
+MODULE.bazel.lock linguist-generated=true
 
 # Artifacts captured from live Claude Code containers — not our source code
 claude_web_env/rootfs/** rules-lint-ignored=true


### PR DESCRIPTION
## Summary
Updated `.gitattributes` to mark additional generated lockfiles as `linguist-generated=true`, ensuring they are properly excluded from language statistics and diffs on GitHub.

## Changes
- Added `Cargo.lock` to generated files list
- Added `flake.lock` (Nix flake lockfile) to generated files list
- Added `pnpm-lock.yaml` (pnpm package manager lockfile) to generated files list
- Added `package-lock.json` (npm package manager lockfile) to generated files list
- Added `requirements_bazel.txt` (Bazel-generated requirements file) to generated files list

## Details
These files are automatically generated by their respective package managers and build systems, so they should not be counted toward repository language statistics or highlighted in pull request diffs. This change follows the existing pattern already established for `Cargo.Bazel.lock`.

https://claude.ai/code/session_011PiXdFJTKQgSAEJ5WDkrEb