### PR TITLE
Remove conditional image push logic from CI workflows

### DIFF
--- a/.github/scripts/harbor_push.sh
+++ b/.github/scripts/harbor_push.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# harbor_push_if_changed.sh <bazel_load_target> <local_tag> <remote_repo>
+# harbor_push.sh <bazel_load_target> <local_tag> <remote_repo>
 #
 # Runs `bazel run <bazel_load_target>` to build the OCI image and load it
-# into the local Docker daemon, then compares its digest against the remote
-# :latest. If changed, pushes with tags: GITHUB_SHA, BRANCH-YYYYMMDDHHMMSS-sha7,
-# and :latest (only when GITHUB_EVENT_NAME != workflow_call).
+# into the local Docker daemon, then pushes with tags: GITHUB_SHA,
+# BRANCH-YYYYMMDDHHMMSS-sha7, and :latest (only when GITHUB_EVENT_NAME !=
+# workflow_call).
 # Skips entirely on pull_request builds.
 #
 # Environment variables (set automatically by GitHub Actions):
@@ -24,16 +24,7 @@ fi
 
 bazel run "$bazel_target"
 
-local_id=$(docker inspect --format='{{.Id}}' "$local_tag")
-remote_digest=$(docker manifest inspect "$remote_repo:latest" 2>/dev/null \
-  | jq -r '.config.digest // empty' 2>/dev/null || true)
-
-if [[ -n "$remote_digest" && "$local_id" == "$remote_digest" ]]; then
-  echo "$remote_repo: unchanged (local=$local_id, remote=$remote_digest), skipping push"
-  exit 0
-fi
-
-echo "$remote_repo: changed (local=$local_id, remote=${remote_digest:-<none>}), pushing"
+echo "$remote_repo: pushing"
 
 BRANCH="${GITHUB_REF_NAME//\//-}"
 TS="$(date -u +%Y%m%d%H%M%S)"

--- a/.github/workflows/inventree-token-provisioner-image.yml
+++ b/.github/workflows/inventree-token-provisioner-image.yml
@@ -1,10 +1,7 @@
 # Build and push the InvenTree token provisioner OCI image to Harbor.
 #
-# Bazel-built OCI image — same inputs → same image digest.
-# Compares local digest against remote and skips push when unchanged.
-#
 # Triggers:
-#   - workflow_call (from ci.yml): digest comparison handles skip
+#   - workflow_call (from ci.yml)
 #   - workflow_dispatch: manual push
 name: InvenTree Token Provisioner Image
 
@@ -52,9 +49,9 @@ jobs:
           username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
           password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
 
-      - name: Build and push if changed
+      - name: Build and push
         run: |
-          .github/scripts/harbor_push_if_changed.sh \
+          .github/scripts/harbor_push.sh \
             //cluster/k8s/applications/inventree-token-provisioner:load \
             inventree-token-provisioner:latest \
             registry.allegedly.works/inventree/token-provisioner

--- a/.github/workflows/oauth-broker-image.yml
+++ b/.github/workflows/oauth-broker-image.yml
@@ -1,10 +1,7 @@
 # Build and push the OAuth broker container image to Harbor.
 #
-# Bazel-built OCI image — same inputs → same image digest.
-# Compares local digest against remote and skips push when unchanged.
-#
 # Triggers:
-#   - workflow_call (from ci.yml): digest comparison handles skip
+#   - workflow_call (from ci.yml)
 #   - workflow_dispatch: manual push
 name: OAuth Broker Image
 
@@ -52,9 +49,9 @@ jobs:
           username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
           password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
 
-      - name: Build and push if changed
+      - name: Build and push
         run: |
-          .github/scripts/harbor_push_if_changed.sh \
+          .github/scripts/harbor_push.sh \
             //oauth_broker:load \
             oauth-broker:latest \
             registry.allegedly.works/oauth-broker/oauth-broker

--- a/.github/workflows/props-images.yml
+++ b/.github/workflows/props-images.yml
@@ -3,15 +3,11 @@
 # Combines backend and agent image builds into a single workflow to share
 # Bazel setup, RBE warm cache, and checkout overhead.
 #
-# All images are stamp-free: same sources → same image ID across commits.
-# harbor_push_if_changed.sh compares the local image ID against the remote
-# config digest and skips the push when unchanged.
-#
 # Backend image → registry.allegedly.works (Harbor)
 # Agent images  → props registry (PROPS_REGISTRY_URL)
 #
 # Triggers:
-#   - workflow_call (from ci.yml): always (digest comparison handles skip)
+#   - workflow_call (from ci.yml)
 #   - workflow_dispatch: manual push of all images
 name: Props Images
 
@@ -70,9 +66,9 @@ jobs:
           username: ${{ secrets.PROPS_REGISTRY_USERNAME }}
           password: ${{ secrets.PROPS_REGISTRY_PASSWORD }}
 
-      - name: Push backend image (if changed)
+      - name: Push backend image
         run: |
-          .github/scripts/harbor_push_if_changed.sh \
+          .github/scripts/harbor_push.sh \
             //props/backend:load \
             props-backend:latest \
             registry.allegedly.works/props/props-backend
@@ -89,7 +85,7 @@ jobs:
           bazel run //props/agents/critic/variants:high_recall_load
           bazel run //props/agents/critic/variants:verbose_docs_load
 
-      - name: Push agent images (if changed)
+      - name: Push agent images
         env:
           REGISTRY: ${{ vars.PROPS_REGISTRY_URL }}
           SHA: ${{ github.sha }}
@@ -99,32 +95,21 @@ jobs:
             exit 0
           fi
 
-          push_if_changed() {
+          push_image() {
             local local_tag="$1" remote_repo="$2"
             shift 2
             local remote_tags=("$@")
-
-            local local_id remote_digest
-            local_id=$(docker inspect --format='{{.Id}}' "$local_tag")
-            remote_digest=$(docker manifest inspect "$REGISTRY/$remote_repo:latest" 2>/dev/null \
-              | jq -r '.config.digest // empty' 2>/dev/null || true)
-
-            if [[ -n "$remote_digest" && "$local_id" == "$remote_digest" ]]; then
-              echo "$remote_repo: unchanged, skipping push"
-              return
-            fi
-
             for tag in "${remote_tags[@]}"; do
               docker tag "$local_tag" "$REGISTRY/$remote_repo:$tag"
               docker push --quiet "$REGISTRY/$remote_repo:$tag"
             done
           }
 
-          push_if_changed critic:latest critic latest "$SHA"
-          push_if_changed grader:latest grader latest "$SHA"
-          push_if_changed critic_dev_improve:latest critic_dev_improve latest "$SHA"
-          push_if_changed critic_dev_optimize:latest critic_dev_optimize latest "$SHA"
+          push_image critic:latest critic latest "$SHA"
+          push_image grader:latest grader latest "$SHA"
+          push_image critic_dev_improve:latest critic_dev_improve latest "$SHA"
+          push_image critic_dev_optimize:latest critic_dev_optimize latest "$SHA"
 
           for variant in contract_truthfulness dead_code flag_propagation high_recall verbose_docs; do
-            push_if_changed "critic:$variant" critic "$variant" "${variant}-${SHA}"
+            push_image "critic:$variant" critic "$variant" "${variant}-${SHA}"
           done


### PR DESCRIPTION
## Summary
This PR removes the conditional push logic that skipped pushing container images when their digest hadn't changed. All images are now pushed unconditionally on each workflow run.

## Key Changes
- **Renamed script**: `harbor_push_if_changed.sh` → `harbor_push.sh` to reflect the removal of conditional logic
- **Removed digest comparison**: Eliminated the logic that compared local image IDs against remote config digests to determine whether to skip pushes
- **Simplified push logic**: 
  - Removed `push_if_changed()` function in props-images workflow and replaced with simpler `push_image()` function
  - Removed digest inspection and comparison code from `harbor_push.sh`
- **Updated workflow documentation**: Removed comments explaining the digest comparison behavior from three workflows:
  - `props-images.yml`
  - `inventree-token-provisioner-image.yml`
  - `oauth-broker-image.yml`
- **Updated step names**: Changed "Build and push if changed" → "Build and push" to reflect unconditional behavior

## Implementation Details
The digest comparison logic that previously allowed skipping unchanged images has been completely removed. This simplifies the CI/CD pipeline by always pushing images, relying on registry deduplication or other mechanisms to handle redundant pushes rather than client-side logic.

https://claude.ai/code/session_015imjcXw3ZvJywQyuLaAi1t