### PR TITLE
fix: narrow mypy type: ignore to [method-assign]

### DIFF
--- a/mcp_infra/enhanced/server.py
+++ b/mcp_infra/enhanced/server.py
@@ -79,4 +79,4 @@ class EnhancedFastMCP(OpenAIStrictModeMixin, FlatModelMixin, NotificationsMixin,
                 caps.resources.subscribe = True
             return caps
 
-        mcp_server.get_capabilities = _patched_get_capabilities  # type: ignore[assignment]
+        mcp_server.get_capabilities = _patched_get_capabilities  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
- Fixed mypy `[unused-ignore]` error in `mcp_infra/enhanced/server.py:82` that was causing the CI build to fail
- Narrowed `# type: ignore[assignment]` to `# type: ignore[method-assign]`, which is the specific code mypy now requires for monkey-patching bound methods on instances

## Context
BuildBuddy invocation [d470a16b](https://app.buildbuddy.io/invocation/d470a16b-847d-433d-958e-540b028a38f6) failed with:
```
mcp_infra/enhanced/server.py:82: error: Unused "type: ignore" comment, use narrower [method-assign] instead of [assignment] code  [unused-ignore]
```

The monkey-patch is necessary because FastMCP v3's `on_initialize` middleware sees the `InitializeResult` only *after* it's already been sent to the client (via `responder.respond()` directly to the write stream), so modifying capabilities in middleware wouldn't propagate.

## Test plan
- [x] `bazel build //mcp_infra/enhanced:server` passes with mypy lint

https://claude.ai/code/session_01LPUTBHFkWdxPF9sf8KtH5K