### PR TITLE
Fix type ignore comment for method assignment

### DIFF
--- a/mcp_infra/enhanced/server.py
+++ b/mcp_infra/enhanced/server.py
@@ -79,4 +79,4 @@ class EnhancedFastMCP(OpenAIStrictModeMixin, FlatModelMixin, NotificationsMixin,
                 caps.resources.subscribe = True
             return caps
 
-        mcp_server.get_capabilities = _patched_get_capabilities  # type: ignore[assignment]
+        mcp_server.get_capabilities = _patched_get_capabilities  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
Updated the type ignore comment to use the correct directive for method assignment operations.

## Changes
- Changed `type: ignore[assignment]` to `type: ignore[method-assign]` on the `get_capabilities` method assignment in the MCP server patching code

## Details
The type checker directive was updated to use the more specific `method-assign` error code instead of the generic `assignment` code. This provides more precise type checking suppression for this particular operation where a function is being assigned to a method attribute.

https://claude.ai/code/session_01LPUTBHFkWdxPF9sf8KtH5K