### PR TITLE
fix: patch rules_tf to check provider mirror download exit code

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,19 @@ git_override(
 # Terraform/OpenTofu validation (cluster/)
 bazel_dep(name = "rules_tf", version = "0.0.10")
 
+# Patch: check exit code of `tofu/terraform providers mirror` in the repo rule.
+# Upstream silently ignores failures (stdout >/dev/null, return code unchecked),
+# so a transient registry outage produces an incomplete mirror that Bazel caches,
+# causing validate tests to fail with "provider not found in mirror".
+single_version_override(
+    module_name = "rules_tf",
+    patch_strip = 1,
+    patches = [
+        "//patches:rules_tf_check_tofu_mirror.patch",
+        "//patches:rules_tf_check_terraform_mirror.patch",
+    ],
+)
+
 tf = use_extension("@rules_tf//tf:extensions.bzl", "tf_repositories")
 tf.download(
     # Pre-fetch provider plugins at Bazel fetch time so that tf_module validate

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(
+    [
+        "rules_tf_check_terraform_mirror.patch",
+        "rules_tf_check_tofu_mirror.patch",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/patches/rules_tf_check_terraform_mirror.patch
+++ b/patches/rules_tf_check_terraform_mirror.patch
@@ -1,0 +1,20 @@
+--- a/tf/toolchains/terraform/toolchain.bzl
++++ b/tf/toolchains/terraform/toolchain.bzl
+@@ -72,12 +72,15 @@
+
+     ctx.file("versions.tf.json", content = json.encode(versions_tf))
+
+-    ctx.execute([
++    result = ctx.execute([
+         "bash",
+         "-c",
+-        "mkdir -p mirror; terraform/terraform providers mirror ./mirror > /dev/null",
++        "mkdir -p mirror; terraform/terraform providers mirror ./mirror",
+         ])
+
++    if result.return_code != 0:
++        fail("terraform providers mirror failed (exit {}):\n{}\n{}".format(result.return_code, result.stdout, result.stderr))
++
+     return
+
+ terraform_download = repository_rule(

--- a/patches/rules_tf_check_tofu_mirror.patch
+++ b/patches/rules_tf_check_tofu_mirror.patch
@@ -1,0 +1,20 @@
+--- a/tf/toolchains/tofu/toolchain.bzl
++++ b/tf/toolchains/tofu/toolchain.bzl
+@@ -72,12 +72,15 @@
+
+     ctx.file("versions.tf.json", content = json.encode(versions_tf))
+
+-    ctx.execute([
++    result = ctx.execute([
+         "bash",
+         "-c",
+-        "mkdir -p mirror; tofu/tofu providers mirror ./mirror > /dev/null",
++        "mkdir -p mirror; tofu/tofu providers mirror ./mirror",
+         ])
+
++    if result.return_code != 0:
++        fail("tofu providers mirror failed (exit {}):\n{}\n{}".format(result.return_code, result.stdout, result.stderr))
++
+     return
+
+ tofu_download = repository_rule(


### PR DESCRIPTION
## Summary

- Patch `rules_tf` 0.0.10 via `single_version_override` to fix a silent failure bug in the provider mirror download step
- The upstream `tofu/toolchain.bzl` and `terraform/toolchain.bzl` repo rules run `tofu providers mirror ./mirror > /dev/null` but **never check the exit code** — if the OpenTofu registry is transiently unreachable, the mirror is incomplete and Bazel caches the broken result
- This caused the `//cluster/terraform/gitops/headscale-config:validate` failure in [BuildBuddy invocation dedc4cf0](https://app.buildbuddy.io/invocation/dedc4cf0-2966-4524-ad32-bde26521e952): the `awlsring/headscale` provider was missing from the cached mirror

## What changed

Two patches applied to `rules_tf` (via `patches/`):
1. Remove `> /dev/null` stdout suppression from the `tofu/terraform providers mirror` command
2. Check `ctx.execute()` return code and `fail()` with stdout/stderr on error

This converts a silent, cached, hard-to-debug failure into an immediate, loud failure during repository rule execution.

## Test plan

- [x] `bazel test //cluster/terraform/gitops/headscale-config:validate` passes
- [x] `bazel test //cluster/terraform/...` — all 75 tests pass
- [x] Verified patched source has correct `result = ctx.execute(...)` + `if result.return_code != 0: fail(...)` in both tofu and terraform toolchain files

https://claude.ai/code/session_01JSgua5um7265m5SoB828L5