### PR TITLE
Fix tar creation with symlinked sandbox inputs in Bazel RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,12 @@ build:rbe --extra_execution_platforms=//:rbe_linux_x64
 # tools (e.g. Rust linking needs CC) succeeds even though
 # BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 disables local auto-detection.
 build:rbe --host_platform=//:rbe_linux_x64
+# TODO: Investigate why GH Actions CI runs many actions locally (processwrapper-sandbox)
+# instead of via RBE. The PR #734 CI run showed 3096 processwrapper-sandbox vs 196 local
+# out of 7556 total processes. The local fallback caused specimen tar creation to use
+# symlinked sandbox inputs, producing broken tars (fixed in compile.py). CI should be
+# running most actions remotely. Check if --remote_download_minimal or missing platform
+# constraints are causing unnecessary local fallback.
 build:rbe --spawn_strategy=remote,local
 test:rbe --spawn_strategy=remote,local
 build:rbe --jobs=50

--- a/props/specimens/compile.py
+++ b/props/specimens/compile.py
@@ -28,7 +28,12 @@ def _compile_code_tar(args: argparse.Namespace) -> None:
     with tarfile.open(args.output, "w") as tar:
         for arcname in sorted(files_to_add.keys(), key=str):
             src_path = files_to_add[arcname]
-            tarinfo = tar.gettarinfo(str(src_path), arcname=str(arcname))
+            # Use os.stat (not lstat) so symlinks resolve to regular files.
+            # Bazel sandboxes inputs as symlinks; gettarinfo uses lstat,
+            # which would create SYMTYPE entries that fail isfile() on read.
+            stat = src_path.stat()
+            tarinfo = tarfile.TarInfo(name=str(arcname))
+            tarinfo.size = stat.st_size
             tarinfo.mtime = 0
             tarinfo.uid = 0
             tarinfo.gid = 0


### PR DESCRIPTION
## Summary
Fixes an issue where tar files created during Bazel RBE builds contained broken symlink entries instead of regular files, causing `isfile()` checks to fail on read.

## Key Changes
- **compile.py**: Modified `_compile_code_tar()` to manually construct `TarInfo` objects using `os.stat()` instead of `tar.gettarinfo()`. This ensures symlinked sandbox inputs (created by Bazel) are resolved to regular files rather than being stored as SYMTYPE entries in the tar archive.
- **.bazelrc**: Added a TODO comment documenting an investigation into why GH Actions CI runs many actions locally via processwrapper-sandbox instead of via RBE, which exposed this symlink issue.

## Implementation Details
The fix replaces the automatic tar info generation with explicit stat-based construction:
- Uses `src_path.stat()` (not `lstat()`) to resolve symlinks to their target files
- Manually creates `TarInfo` objects with the resolved file size
- Preserves existing metadata handling (mtime=0, uid=0, gid=0, mode=0o644)

This ensures that when Bazel sandboxes inputs as symlinks in RBE environments, the resulting tar archive contains proper file entries that work correctly when extracted and read.

https://claude.ai/code/session_01JSgua5um7265m5SoB828L5