### PR TITLE
Grant Claude and openclaw-sandbox read access to openclaw namespace logs

### DIFF
--- a/cluster/k8s/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/claude-rbac/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - clusterrole-cluster-diagnostics-reader.yaml
   - clusterrolebinding-cluster-diagnostics-reader.yaml
   - rolebinding-ollama-reader.yaml
+  - rolebinding-openclaw-reader.yaml

--- a/cluster/k8s/claude-rbac/rolebinding-openclaw-reader.yaml
+++ b/cluster/k8s/claude-rbac/rolebinding-openclaw-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: claude-openclaw-reader
+  namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default

--- a/cluster/k8s/openclaw-sandbox/kustomization.yaml
+++ b/cluster/k8s/openclaw-sandbox/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - rolebinding-openclaw-sa.yaml
   - sa-token-secret.yaml
   - rolebinding-ollama-reader.yaml
+  - rolebinding-openclaw-reader.yaml

--- a/cluster/k8s/openclaw-sandbox/rolebinding-openclaw-reader.yaml
+++ b/cluster/k8s/openclaw-sandbox/rolebinding-openclaw-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-sandbox-openclaw-reader
+  namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox

--- a/cluster/k8s/openclaw/kustomization.yaml
+++ b/cluster/k8s/openclaw/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - networkpolicy-node-ingress.yaml
   - cnp-kube-api-egress.yaml
   - rolebinding-gatus-reader.yaml
+  - role-openclaw-reader.yaml

--- a/cluster/k8s/openclaw/role-openclaw-reader.yaml
+++ b/cluster/k8s/openclaw/role-openclaw-reader.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-reader
+  namespace: openclaw
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - persistentvolumeclaims
+      - events
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

- Add `openclaw-reader` Role in `openclaw` namespace (get/list/watch on pods, pods/log, services, configmaps, PVCs, events, deployments, replicasets)
- Bind `claude-code-web` SA (default namespace) to the role via `claude-rbac/rolebinding-openclaw-reader.yaml`
- Bind `default` SA (openclaw-sandbox namespace) to the role via `openclaw-sandbox/rolebinding-openclaw-reader.yaml`
- Update all three `kustomization.yaml` files to include the new resources

## Test plan

- [ ] Flux reconciles `openclaw`, `claude-rbac`, and `openclaw-sandbox` kustomizations without errors
- [ ] `kubectl logs -n openclaw <pod>` works from the claude-sandbox context
- [ ] `kubectl logs -n openclaw <pod>` works from an openclaw-sandbox tool pod

https://claude.ai/code/session_01S1BiiQNFMMhk2nb2TB4zaj