### PR TITLE
Grant Claude and openclaw-sandbox read access to harbor logs

### DIFF
--- a/cluster/k8s/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/claude-rbac/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
   - clusterrolebinding-cluster-diagnostics-reader.yaml
   - rolebinding-ollama-reader.yaml
   - rolebinding-openclaw-reader.yaml
+  - role-harbor-reader.yaml
+  - rolebinding-harbor-reader.yaml

--- a/cluster/k8s/claude-rbac/role-harbor-reader.yaml
+++ b/cluster/k8s/claude-rbac/role-harbor-reader.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: harbor-reader
+  namespace: harbor
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - persistentvolumeclaims
+      - events
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/claude-rbac/rolebinding-harbor-reader.yaml
+++ b/cluster/k8s/claude-rbac/rolebinding-harbor-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: claude-harbor-reader
+  namespace: harbor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: harbor-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default

--- a/cluster/k8s/openclaw-sandbox/kustomization.yaml
+++ b/cluster/k8s/openclaw-sandbox/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - sa-token-secret.yaml
   - rolebinding-ollama-reader.yaml
   - rolebinding-openclaw-reader.yaml
+  - rolebinding-harbor-reader.yaml

--- a/cluster/k8s/openclaw-sandbox/rolebinding-harbor-reader.yaml
+++ b/cluster/k8s/openclaw-sandbox/rolebinding-harbor-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-sandbox-harbor-reader
+  namespace: harbor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: harbor-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox


### PR DESCRIPTION
## Summary
- Add `harbor-reader` Role in the `harbor` namespace granting read access to pods, pods/log, services, configmaps, PVCs, events, deployments, replicasets, and statefulsets
- Add RoleBinding for `claude-code-web` SA (Claude sandbox) to the harbor-reader role
- Add RoleBinding for `default` SA in `openclaw-sandbox` namespace to the harbor-reader role
- Follows the established pattern used for `gatus-reader` and `openclaw-reader`

## Test plan
- [x] `kubectl kustomize` validates both `claude-rbac/` and `openclaw-sandbox/` directories
- [x] `kubeconform` pre-commit hook passes
- [ ] After Flux reconciliation, verify with `kubectl auth can-i get pods/log -n harbor --as=system:serviceaccount:default:claude-code-web`

https://claude.ai/code/session_01S9YrjUC7t9fWFEhQDdXqEf