### PR TITLE
Fix build_critic.sh: overlay path and push by digest

### DIFF
--- a/props/agents/critic_dev/recipes/build_critic.sh
+++ b/props/agents/critic_dev/recipes/build_critic.sh
@@ -55,7 +55,10 @@ fi
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-MAIN_PY_PATH="props/agents/critic/main.py"
+# The critic image uses aspect_py_binary "critic_bin", so main.py lives under
+# the runfiles tree at this path.  Appending a layer with the same path shadows
+# the original file.
+MAIN_PY_PATH="props/agents/critic/critic_bin.runfiles/_main/props/agents/critic/main.py"
 echo "Overlaying ${CUSTOM_MAIN} at ${MAIN_PY_PATH}" >&2
 
 # 1. Create a tarball with the custom main.py at the correct runfiles path
@@ -77,7 +80,7 @@ crane mutate "${BASE_REF}" \
 # 3. Compute the digest from the local tarball
 DIGEST="$(crane digest --tarball "${WORK_DIR}/image.tar")"
 
-# 4. Push and print digest
-crane push "${WORK_DIR}/image.tar" "${REGISTRY}/critic:${VARIANT}" --insecure
+# 4. Push by digest (agents are not allowed to push by tag)
+crane push "${WORK_DIR}/image.tar" "${REGISTRY}/critic@${DIGEST}" --insecure
 
 echo "${DIGEST}"


### PR DESCRIPTION
## Summary

Fixes two bugs in `build_critic.sh` introduced in #741 that caused `test_build_critic_e2e` to fail in CI:

- **Wrong runfiles overlay path**: Used `props/agents/critic/main.py` but the critic image uses `aspect_py_binary "critic_bin"`, so the actual path is `props/agents/critic/critic_bin.runfiles/_main/props/agents/critic/main.py`. The old path silently failed to shadow the original file, so the custom critic never ran (the original LLM-calling `main.py` ran instead, hitting a model not found error).
- **Push by tag rejected**: `crane push ... critic:variant` returned 403 because the registry auth policy only allows `critic_dev` agents to push **by digest**, not by tag. Changed to `crane push ... critic@$DIGEST` (matching the pattern already used in `test_e2e.py` and documented in `authoring_agents.md.mako`).

## Test plan

- [x] `//props/agents/critic_dev/recipes:test_build_critic_e2e` — PASSED (was timing out / failing)
- [x] `//props/agents/critic_dev:test_e2e` — PASSED (no regression)
- [x] `//props/agents/critic_dev/recipes:test_recipes` — PASSED

https://claude.ai/code/session_01PGraiMrPu7w4u92oj9ZrAA