### PR TITLE
Fix critic image build to use runfiles path and push by digest

### DIFF
--- a/props/agents/critic_dev/recipes/build_critic.sh
+++ b/props/agents/critic_dev/recipes/build_critic.sh
@@ -55,7 +55,10 @@ fi
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-MAIN_PY_PATH="props/agents/critic/main.py"
+# The critic image uses aspect_py_binary "critic_bin", so main.py lives under
+# the runfiles tree at this path.  Appending a layer with the same path shadows
+# the original file.
+MAIN_PY_PATH="props/agents/critic/critic_bin.runfiles/_main/props/agents/critic/main.py"
 echo "Overlaying ${CUSTOM_MAIN} at ${MAIN_PY_PATH}" >&2
 
 # 1. Create a tarball with the custom main.py at the correct runfiles path
@@ -77,7 +80,7 @@ crane mutate "${BASE_REF}" \
 # 3. Compute the digest from the local tarball
 DIGEST="$(crane digest --tarball "${WORK_DIR}/image.tar")"
 
-# 4. Push and print digest
-crane push "${WORK_DIR}/image.tar" "${REGISTRY}/critic:${VARIANT}" --insecure
+# 4. Push by digest (agents are not allowed to push by tag)
+crane push "${WORK_DIR}/image.tar" "${REGISTRY}/critic@${DIGEST}" --insecure
 
 echo "${DIGEST}"


### PR DESCRIPTION
## Summary
Updated the critic image build script to correctly reference the main.py file in the runfiles tree and push the image by digest instead of by tag, aligning with agent deployment constraints.

## Key Changes
- Updated `MAIN_PY_PATH` to point to the correct location in the runfiles tree: `props/agents/critic/critic_bin.runfiles/_main/props/agents/critic/main.py`
  - Added explanatory comment clarifying that the critic image uses `aspect_py_binary "critic_bin"` and that appending a layer with the same path shadows the original file
- Changed image push strategy from tag-based to digest-based push
  - Modified push command from `${REGISTRY}/critic:${VARIANT}` to `${REGISTRY}/critic@${DIGEST}`
  - Updated comment to reflect that agents are not allowed to push by tag

## Implementation Details
These changes ensure that:
1. The custom main.py overlay is placed at the correct path within the container's runfiles structure
2. The built image is pushed using its content digest rather than a mutable tag, providing better reproducibility and compliance with agent deployment policies

https://claude.ai/code/session_01PGraiMrPu7w4u92oj9ZrAA