### PR TITLE
Add TODO comment for rules_tf patch removal

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,7 @@ bazel_dep(name = "rules_tf", version = "0.0.10")
 # Upstream silently ignores failures (stdout >/dev/null, return code unchecked),
 # so a transient registry outage produces an incomplete mirror that Bazel caches,
 # causing validate tests to fail with "provider not found in mirror".
+# TODO: remove patches once https://github.com/yanndegat/rules_tf/pull/28 is merged
 single_version_override(
     module_name = "rules_tf",
     patch_strip = 1,


### PR DESCRIPTION
This change adds a TODO comment to document a pending patch removal for the `rules_tf` dependency.

**Summary:**
Added a TODO comment referencing the upstream pull request that, once merged, will allow the removal of the current patches applied to the `rules_tf` module.

**Key changes:**
- Added TODO comment linking to https://github.com/yanndegat/rules_tf/pull/28 to track when patches can be removed

**Details:**
The comment clarifies that the patches are a temporary workaround for an issue in the upstream `rules_tf` repository where transient registry outages can produce incomplete mirrors that Bazel caches, causing validation test failures. Once the referenced upstream PR is merged, these patches should no longer be necessary.

https://claude.ai/code/session_014ZBAiyeychPb2xrP1kJPZ4