### PR TITLE
Remove extract_text_from_tool_content function

### DIFF
--- a/mcp_utils/resources.py
+++ b/mcp_utils/resources.py
@@ -2,30 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 from mcp import types as mcp_types
 from more_itertools import one
 from pydantic import TypeAdapter
-
-
-def extract_text_from_tool_content(
-    content: Iterable[
-        mcp_types.TextContent
-        | mcp_types.ImageContent
-        | mcp_types.AudioContent
-        | mcp_types.ResourceLink
-        | mcp_types.EmbeddedResource
-    ],
-) -> str | None:
-    """Extract text from MCP CallToolResult content blocks.
-
-    Returns the first TextContent.text found, or None if no text content exists.
-    """
-    for item in content:
-        if isinstance(item, mcp_types.TextContent):
-            return item.text
-    return None
 
 
 def parse_tool_result_as[T](result: mcp_types.CallToolResult, model: type[T]) -> T:


### PR DESCRIPTION
## Summary
Removed the `extract_text_from_tool_content` utility function from the resources module as it is no longer needed.

## Changes
- Deleted `extract_text_from_tool_content()` function that extracted text from MCP tool result content blocks
- Removed unused `Iterable` import from `collections.abc`
- Kept the `parse_tool_result_as()` function which provides similar functionality with stronger type guarantees

## Details
The removed function iterated through content blocks to find and return the first `TextContent.text` value. The `parse_tool_result_as()` function that remains provides a more robust alternative by using `more_itertools.one()` to ensure exactly one content item exists before parsing, making it a safer approach for extracting and validating tool results.

https://claude.ai/code/session_017gqgKRgTCDgxjzY5Sw3MHJ