### PR TITLE
Delete best-effort error scraping; fix disjunctive test assertions

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -249,6 +249,7 @@ py_test(
         "//openai_utils:pydantic_strict_mode",
         "//openai_utils/testing:openai_mock",
         "@pypi//fastmcp",
+        "@pypi//more_itertools",
         "@pypi//pydantic",
         "@pypi//pyhamcrest",
         "@pypi//pytest",

--- a/agent_core/mcp_provider.py
+++ b/agent_core/mcp_provider.py
@@ -31,22 +31,6 @@ class MCPToolProvider:
         return fastmcp_result_to_tool_result(fastmcp_result)
 
 
-def tool_result_to_mcp(result: ToolResult) -> mcp_types.CallToolResult:
-    """Convert our ToolResult to mcp.types.CallToolResult."""
-    mcp_content: list[mcp_types.TextContent | mcp_types.ImageContent] = []
-    for block in result.content:
-        if isinstance(block, TextContent):
-            mcp_content.append(mcp_types.TextContent(type="text", text=block.text))
-        elif isinstance(block, ImageContent):
-            mcp_content.append(mcp_types.ImageContent(type="image", mimeType=block.mime_type, data=block.data))
-        else:
-            raise TypeError(f"Unhandled content block type: {type(block)}")
-
-    return mcp_types.CallToolResult(
-        content=mcp_content, structuredContent=result.structured_content, isError=result.is_error
-    )
-
-
 def fastmcp_result_to_tool_result(fastmcp_result: FastMCPCallToolResult) -> ToolResult:
     """Convert fastmcp.client.CallToolResult to our ToolResult.
 

--- a/agent_core/test_tool_execution.py
+++ b/agent_core/test_tool_execution.py
@@ -249,7 +249,7 @@ async def test_malformed_json_in_tool_arguments(mcp_tool_provider_echo, recordin
     text, events = await _run_malformed_json_test(mcp_tool_provider_echo, recording_handler, make_turn)
 
     # Agent should complete successfully despite malformed JSON
-    assert "error" in text.lower()
+    assert text == "I received an error"
 
     # Check that error was emitted as a tool result
     tool_outputs = [evt for evt in events if isinstance(evt, ToolCallOutput)]

--- a/agent_core/test_tool_execution.py
+++ b/agent_core/test_tool_execution.py
@@ -139,8 +139,7 @@ async def test_tool_error_continues_turn(compositor, mcp_tool_provider, validati
     error_block = one(first_output.result.content)
     assert isinstance(error_block, TextContent)
     error_content = error_block.text
-    assert_that(error_content.lower(), contains_string("error"))
-    assert "text/markdown" in error_content or "literal" in error_content.lower()
+    assert_that(error_content, contains_string("text/markdown"))
 
     # Second call should succeed
     second_output = outputs[1]
@@ -250,7 +249,7 @@ async def test_malformed_json_in_tool_arguments(mcp_tool_provider_echo, recordin
     text, events = await _run_malformed_json_test(mcp_tool_provider_echo, recording_handler, make_turn)
 
     # Agent should complete successfully despite malformed JSON
-    assert "error" in text.lower() or "invalid" in text.lower()
+    assert "error" in text.lower()
 
     # Check that error was emitted as a tool result
     tool_outputs = [evt for evt in events if isinstance(evt, ToolCallOutput)]

--- a/agent_core/test_tool_execution.py
+++ b/agent_core/test_tool_execution.py
@@ -12,6 +12,7 @@ import pytest
 import pytest_bazel
 from fastmcp.exceptions import ToolError
 from hamcrest import all_of, assert_that, contains_string, greater_than_or_equal_to, has_entries, has_length
+from more_itertools import one
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_core.agent import Agent, _sanitize_tool_result
@@ -135,7 +136,9 @@ async def test_tool_error_continues_turn(compositor, mcp_tool_provider, validati
     # First call should fail with validation error
     first_output = outputs[0]
     assert first_output.result.is_error is True
-    error_content = first_output.result.content[0].text
+    error_block = one(first_output.result.content)
+    assert isinstance(error_block, TextContent)
+    error_content = error_block.text
     assert_that(error_content.lower(), contains_string("error"))
     assert "text/markdown" in error_content or "literal" in error_content.lower()
 

--- a/agent_core/testing/matchers.py
+++ b/agent_core/testing/matchers.py
@@ -54,12 +54,12 @@ class HasErrorText(BaseMatcher):
         self.text_matcher = text_matcher
 
     def _matches(self, result):
-        """Match ToolResult with is_error=True and TextContent."""
+        """Match ToolResult with is_error=True and a single TextContent."""
         if not isinstance(result, ToolResult):
             return False
         if not result.is_error:
             return False
-        if not result.content:
+        if len(result.content) != 1:
             return False
         content_item = result.content[0]
         if not isinstance(content_item, TextContent):
@@ -67,7 +67,7 @@ class HasErrorText(BaseMatcher):
         return self.text_matcher.matches(content_item.text)
 
     def describe_to(self, description: Description):
-        description.append_text("error ToolResult with text content matching ")
+        description.append_text("error ToolResult with single text content matching ")
         self.text_matcher.describe_to(description)
 
     def describe_mismatch(self, result, mismatch_description: Description):
@@ -77,12 +77,12 @@ class HasErrorText(BaseMatcher):
         if not result.is_error:
             mismatch_description.append_text("was not an error (is_error=False)")
             return
-        if not result.content:
-            mismatch_description.append_text("had empty content")
+        if len(result.content) != 1:
+            mismatch_description.append_text(f"expected 1 content item, got {len(result.content)}")
             return
         content_item = result.content[0]
         if not isinstance(content_item, TextContent):
-            mismatch_description.append_text(f"first content was {type(content_item).__name__}, not TextContent")
+            mismatch_description.append_text(f"content was {type(content_item).__name__}, not TextContent")
             return
         mismatch_description.append_text("error text ")
         self.text_matcher.describe_mismatch(content_item.text, mismatch_description)

--- a/agent_server/mcp/approval_policy/test_engine.py
+++ b/agent_server/mcp/approval_policy/test_engine.py
@@ -116,7 +116,7 @@ class TestPresetPolicyLoading:
         async with Client(engine.reader) as sess:
             result = await sess.read_resource(PolicyReaderServer.ACTIVE_POLICY_URI)
             policy_text = extract_single_text_content(result)
-            assert "approve_all" in policy_text.lower() or "allow" in policy_text.lower()
+            assert "ApprovalDecision.ALLOW" in policy_text
 
     async def test_policy_engine_returns_custom_policy(self, make_approval_policy_server):
         """PolicyEngine correctly returns custom policy source."""
@@ -127,7 +127,7 @@ class TestPresetPolicyLoading:
         async with Client(engine.reader) as sess:
             result = await sess.read_resource(PolicyReaderServer.ACTIVE_POLICY_URI)
             policy_text = extract_single_text_content(result)
-            assert "const" in policy_text.lower() or "PolicyResponse" in policy_text
+            assert "CONST_X" in policy_text
 
     async def test_get_policy_returns_source(self, make_approval_policy_server, policy_allow_all):
         """PolicyEngine.get_policy returns policy source."""

--- a/approval_gate/BUILD.bazel
+++ b/approval_gate/BUILD.bazel
@@ -194,6 +194,7 @@ py_test(
     deps = [
         ":models",
         "@pypi//mcp",
+        "@pypi//more_itertools",
         "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/approval_gate/test_models.py
+++ b/approval_gate/test_models.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 import pytest_bazel
 from mcp.types import CallToolResult, TextContent
+from more_itertools import one
 from pydantic import TypeAdapter, ValidationError
 
 from approval_gate.models import (
@@ -166,7 +167,7 @@ def test_log_entry_with_execution_finished_detail():
     )
     parsed = LogEntry.model_validate_json(entry.model_dump_json())
     assert isinstance(parsed.detail, ExecutionFinishedDetail)
-    content_item = parsed.detail.outcome.content[0]
+    content_item = one(parsed.detail.outcome.content)
     assert isinstance(content_item, TextContent)
     assert content_item.text == "done"
 

--- a/difftree/test_cli.py
+++ b/difftree/test_cli.py
@@ -46,7 +46,7 @@ def test_cli_columns_actually_shows_content(runner, git_repo_with_changes, monke
     assert result_tree_only.exit_code == 0
     assert "main.py" in result_tree_only.output
     # Should not have +/- counts when counts column is disabled
-    assert "+2" not in result_tree_only.output or "counts" not in result_tree_only.output.lower()
+    assert "+2" not in result_tree_only.output
 
     # Test with tree and counts - should have counts
     result_with_counts = runner.invoke(main, ["--columns", "tree,counts"], obj={}, catch_exceptions=False)

--- a/difftree/test_diff_tree.py
+++ b/difftree/test_diff_tree.py
@@ -167,7 +167,7 @@ def test_console_width_handling(width):
     # At very narrow widths (40), tree column takes all space and stats may not be visible
     # At standard widths (80+), stats should be visible
     if width >= 80:
-        assert "+100" in result or "+10" in result
+        assert "+100" in result
 
     # Filename visibility depends on width
     if width >= 200:
@@ -290,10 +290,9 @@ def test_tree_styling_preserved():
     # Bold blue: \x1b[1;34m (used for directories)
     # Reset: \x1b[0m
 
-    # Tree decorations should be dim
-    assert "\x1b[2m├── \x1b[0m" in result or "\x1b[2m└── \x1b[0m" in result, (
-        "Tree decorations (├── or └──) should have dim style"
-    )
+    # Tree decorations should be dim (both connectors present with 3 files across 2 dirs)
+    assert "\x1b[2m├── \x1b[0m" in result, "Tree branch connector (├──) should have dim style"
+    assert "\x1b[2m└── \x1b[0m" in result, "Tree terminal connector (└──) should have dim style"
 
     # Vertical guides should also be dim
     assert "\x1b[2m│" in result, "Tree vertical guides (│) should have dim style"

--- a/difftree/test_e2e.py
+++ b/difftree/test_e2e.py
@@ -44,9 +44,8 @@ def test_e2e_complete_workflow(temp_git_repo: Path, run_git):
     changes = parse_unified_diff(result.stdout)
     root = build_tree(changes)
 
-    # Root name is basename of current directory
-    assert root.name in (".", "difftree", Path.cwd().name)
-    assert "src" in root.children or len(changes) > 0
+    assert len(changes) > 0
+    assert "src" in root.children
 
     root = sort_tree(root, sort_by=SortMode.SIZE)
     assert root is not None

--- a/difftree/test_progress_bar.py
+++ b/difftree/test_progress_bar.py
@@ -53,7 +53,7 @@ def test_progress_bar_right_aligned():
     rendered = render_bar(bar, 10)
     plain = rendered
     # Should be right-aligned (ends with filled blocks, padding on left)
-    assert plain.endswith(RIGHT_BLOCK_CHARS) or plain.strip() == ""
+    assert plain.endswith(RIGHT_BLOCK_CHARS)
     assert len(plain) == 10
 
 
@@ -64,7 +64,7 @@ def test_progress_bar_left_aligned():
     plain = rendered
     # Should be left-aligned (starts with filled blocks, padding on right)
     assert len(plain) == 10
-    assert plain.startswith(LEFT_BLOCK_CHARS) or plain.strip() == ""
+    assert plain.startswith(LEFT_BLOCK_CHARS)
 
 
 @pytest.mark.parametrize(

--- a/difftree/test_tree.py
+++ b/difftree/test_tree.py
@@ -1,7 +1,5 @@
 """Tests for tree structure building."""
 
-from pathlib import Path
-
 import pytest_bazel
 from hamcrest import assert_that, has_properties
 
@@ -22,8 +20,6 @@ def test_build_tree_single_file():
     changes = [FileChange(path="test.py", additions=10, deletions=5)]
     root = build_tree(changes)
 
-    # Root name is the basename of current directory
-    assert root.name in (".", "difftree", Path.cwd().name)
     assert not root.is_file
     assert root.additions == 10
     assert root.deletions == 5

--- a/hack/claude_linter_v2/test_python_ruff.py
+++ b/hack/claude_linter_v2/test_python_ruff.py
@@ -41,7 +41,7 @@ except:
     e722 = [v for v in violations if v.rule == "ruff:E722"]
     assert len(e722) == 1
     assert e722[0].line == 3
-    assert "bare" in e722[0].message.lower() or "except" in e722[0].message.lower()
+    assert "bare" in e722[0].message.lower()
     assert e722[0].fixable is False
 
 

--- a/mcp_infra/BUILD.bazel
+++ b/mcp_infra/BUILD.bazel
@@ -46,8 +46,6 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//fastmcp",
-        "@pypi//mcp",
-        "@pypi//pydantic_core",
     ],
 )
 

--- a/mcp_infra/client_helpers.py
+++ b/mcp_infra/client_helpers.py
@@ -63,7 +63,4 @@ async def call_simple_ok(client: Client, *, name: str, arguments: dict) -> None:
     except Exception as exc:
         raise RuntimeError(f"{name} failed: {exc}") from exc
     if bool(res.is_error):
-        detail = extract_error_detail_from_fastmcp(res)
-        if detail:
-            raise RuntimeError(f"{name} failed: {detail}")
-        raise RuntimeError(f"{name} failed")
+        raise RuntimeError(f"{name} failed (is_error=True)")

--- a/mcp_infra/client_helpers.py
+++ b/mcp_infra/client_helpers.py
@@ -1,50 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Any
-
-import pydantic_core
 from fastmcp.client import Client
-from fastmcp.client.client import CallToolResult as FastMCPCallToolResult
 from fastmcp.exceptions import ToolError
-from mcp import types as mcp_types
-
-
-def extract_text_blocks(contents: Iterable[mcp_types.ContentBlock]) -> list[str]:
-    return [
-        block.text
-        for block in contents
-        if isinstance(block, mcp_types.TextContent) and isinstance(block.text, str) and block.text
-    ]
-
-
-def extract_error_detail_from_fastmcp(res: FastMCPCallToolResult) -> str | None:
-    """Best-effort string representation of a FastMCP tool error result.
-
-    TODO: This pattern is bad - it guesses at error structure by probing for common field
-    names. Replace with either: (a) typed error models that tools actually return, validated
-    at the boundary, or (b) just use the raw structured_content/content without speculation.
-    See also: reducer.py, rich_display.py.
-    """
-    detail: str | None = None
-    try:
-        sc: Any = res.structured_content
-        if isinstance(sc, dict) and sc:
-            for key in ("message", "reason", "error", "detail"):
-                val = sc.get(key)
-                if isinstance(val, str) and val:
-                    detail = val
-                    break
-            if detail is None:
-                detail = pydantic_core.to_json(sc, fallback=str).decode("utf-8")[:200]
-        if not detail:
-            texts = extract_text_blocks(res.content or [])
-            if texts:
-                detail = " | ".join(texts)[:200]
-    except (KeyError, TypeError, AttributeError, ValueError):
-        # Best-effort extraction; suppress malformed responses
-        detail = None
-    return detail
 
 
 async def call_simple_ok(client: Client, *, name: str, arguments: dict) -> None:

--- a/mcp_infra/display/test_compact_display.py
+++ b/mcp_infra/display/test_compact_display.py
@@ -207,10 +207,7 @@ def test_compact_display_handler_with_read_resource_result():
     handler.on_tool_result_event(output)
     output_text = output_buffer.getvalue()
     assert len(output_text) > 0, "Handler should have produced output"
-    # Should contain the resource URI or content
-    assert "resource://" in output_text or "test content" in output_text, (
-        f"Output missing expected content: {output_text}"
-    )
+    assert "resource://" in output_text, f"Output missing resource URI: {output_text}"
 
 
 if __name__ == "__main__":

--- a/mcp_infra/enhanced/BUILD.bazel
+++ b/mcp_infra/enhanced/BUILD.bazel
@@ -76,6 +76,8 @@ py_test(
         "//mcp_infra/stubs:typed_stubs",
         "//openai_utils:pydantic_strict_mode",
         "@pypi//fastmcp",
+        "@pypi//mcp",
+        "@pypi//more_itertools",
         "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/mcp_infra/enhanced/test_flat_decorator.py
+++ b/mcp_infra/enhanced/test_flat_decorator.py
@@ -8,6 +8,8 @@ import pytest
 import pytest_bazel
 from fastmcp.client import Client
 from fastmcp.server.context import Context
+from mcp import types as mcp_types
+from more_itertools import one
 from pydantic import Field, field_validator
 
 from mcp_infra.enhanced.server import EnhancedFastMCP
@@ -194,7 +196,9 @@ async def test_flat_model_validation_error_formatting():
         assert result.is_error
 
         # Parse the error message as JSON
-        error_json = json.loads(result.content[0].text)
+        error_block = one(result.content)
+        assert isinstance(error_block, mcp_types.TextContent)
+        error_json = json.loads(error_block.text)
         assert isinstance(error_json, list)
         assert len(error_json) == 1
 

--- a/mcp_infra/exec/test_seatbelt.py
+++ b/mcp_infra/exec/test_seatbelt.py
@@ -83,7 +83,7 @@ async def test_sandbox_exec_echo_roundtrip(seatbelt_session) -> None:
     assert res.stdout == "HELLO_MINIMAL\n"
     # stderr should be empty or None
     assert isinstance(res.stderr, str)  # Short error should not be truncated
-    assert res.stderr in ("", None)
+    assert res.stderr == ""
     # duration exists and is a non-negative int
     assert isinstance(res.duration_ms, int)
     assert res.duration_ms >= 0

--- a/mcp_infra/stubs/BUILD.bazel
+++ b/mcp_infra/stubs/BUILD.bazel
@@ -31,10 +31,8 @@ py_library(
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//mcp_infra:client_helpers",
         "//mcp_infra/enhanced:flat_mixin",
         "@pypi//fastmcp",
-        "@pypi//mcp",
         "@pypi//pydantic",
     ],
 )

--- a/mcp_infra/stubs/typed_stubs.py
+++ b/mcp_infra/stubs/typed_stubs.py
@@ -6,10 +6,8 @@ from typing import Any, cast, get_origin, get_type_hints
 from fastmcp.client import Client
 from fastmcp.client.client import CallToolResult as FastMCPCallToolResult
 from fastmcp.server import FastMCP
-from mcp import types as mcp_types
 from pydantic import BaseModel, TypeAdapter
 
-from mcp_infra.client_helpers import extract_error_detail_from_fastmcp
 from mcp_infra.enhanced.flat_mixin import FlatTool
 
 
@@ -64,18 +62,6 @@ class ToolModels:
     # Internal wiring details for FastMCP registry
     _arg_model: type[BaseModel] | None = None
     # No output wrapping; servers should return structured content matching Output
-
-
-def _extract_error_message(resp: FastMCPCallToolResult) -> str:
-    detail = extract_error_detail_from_fastmcp(resp)
-    if detail:
-        return cast(str, detail)
-    nontext: list[str] = [
-        type(block).__name__ for block in resp.content or [] if not isinstance(block, mcp_types.TextContent)
-    ]
-    if nontext:
-        raise NotImplementedError(f"Unsupported tool error content types: {', '.join(nontext)}")
-    return "tool error"
 
 
 class TypedClient:
@@ -134,6 +120,11 @@ class TypedClient:
         return client
 
     def error(self, name: str) -> Callable[[BaseModel], Awaitable[str]]:
+        """Return an async callable that invokes the tool expecting failure.
+
+        FastMCP's default raise_on_error=True means tool errors surface as
+        exceptions. The returned string is str(exc) from that exception.
+        """
         models = self._models.get(name)
         if not models:
             raise AttributeError(name)
@@ -143,14 +134,13 @@ class TypedClient:
             if models.Input is not None and not isinstance(payload, models.Input):
                 raise TypeError(f"{name} expects {models.Input.__name__}, got {type(payload).__name__}")
             args_dict = payload.model_dump(exclude_none=False)
-            # Call; FastMCP raises on tool error by default. Capture and return message.
             try:
                 result = await session.call_tool(name=name, arguments=args_dict)
             except Exception as exc:
                 return str(exc)
             if not result.is_error:
                 raise AssertionError("expected tool error")
-            return _extract_error_message(result)
+            raise AssertionError(f"expected exception from {name}, got is_error=True result instead")
 
         return _err
 


### PR DESCRIPTION
## Summary
- Delete `extract_error_detail_from_fastmcp`, `extract_text_blocks`, and `_extract_error_message` — best-effort error field guessing that the code's own TODO warned against. `TypedClient.error()` now just uses `str(exc)`.
- Replace 14 disjunctive test assertions (`assert A or B`) with deterministic ones across 10 test files: remove cwd-dependent tautologies, substring-of-substring bugs, pointless fallbacks, and vague keyword checks. Assert exact known values instead.

## Test plan
- [x] `bazel test //difftree:test_tree //difftree:test_e2e //difftree:test_diff_tree //difftree:test_cli //difftree:test_progress_bar`
- [x] `bazel test //agent_core:test_tool_execution`
- [x] `bazel test //hack/claude_linter_v2:test_python_ruff //mcp_infra/display:test_compact_display`
- [x] `bazel test //agent_server/mcp/approval_policy:test_engine`
- [x] `bazel test //mcp_infra/exec:test_seatbelt`
- [x] `bazel test //hack/gitea/mcp_mirror:test_server //mcp_infra/enhanced:test_flat_decorator`

https://claude.ai/code/session_017gqgKRgTCDgxjzY5Sw3MHJ