### PR TITLE
Refactor approval-gate plugin: add exec tool, extract MCP client logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,11 @@ jobs:
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'openclaw-image')
     uses: ./.github/workflows/openclaw-image.yml
     secrets: inherit
+  openclaw-exec-image:
+    needs: compute-targets
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'openclaw-exec-image')
+    uses: ./.github/workflows/openclaw-exec-image.yml
+    secrets: inherit
   nix-flake-check:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'nix-flake-check')

--- a/.github/workflows/openclaw-exec-image.yml
+++ b/.github/workflows/openclaw-exec-image.yml
@@ -1,26 +1,27 @@
-# Build and push the custom OpenClaw+matrix container image to Harbor.
+# Build and push the OpenClaw exec sidecar image to Harbor.
 #
-# Derives from upstream ghcr.io/openclaw/openclaw with the matrix channel
-# plugin and its native crypto binary pre-installed.
+# Contains DirectExecServer + mcporter + kubectl for agent exec.
+# Runs as a sidecar in the OpenClaw pod, providing pod-local exec
+# with session context injection.
 #
 # Triggers:
 #   - workflow_dispatch: manual trigger (tags :latest too)
 #   - workflow_call (from ci.yml): tags :<sha> + :<timestamp>-<sha7>
-name: OpenClaw Image
+name: OpenClaw Exec Image
 
 on:
   workflow_dispatch:
   workflow_call:
 
 concurrency:
-  group: openclaw-image-${{ github.ref }}
+  group: openclaw-exec-image-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 env:
-  IMAGE: registry.allegedly.works/openclaw/openclaw-matrix
+  IMAGE: registry.allegedly.works/openclaw/openclaw-exec
 
 jobs:
   build-and-push:
@@ -53,6 +54,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/openclaw/Dockerfile
+          file: docker/openclaw-exec/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/openclaw-image.yml
+++ b/.github/workflows/openclaw-image.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build approval-gate plugin tar
+        run: bazel build //openclaw/approval-gate:plugin_tar
+
+      - name: Stage plugin tar for Docker
+        run: cp bazel-bin/openclaw/approval-gate/plugin_tar.tar docker/openclaw/approval-gate-plugin.tar
+
       - name: Compute image tags
         id: meta
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -70,9 +70,6 @@ nix/**/result
 **/.sass-cache/
 **/_cache/
 
-# Bazel-generated artifacts staged for Docker builds
-docker/openclaw/approval-gate-plugin.tar
-
 # Project-specific
 **/.claude/settings.local.json
 **/.claude/session-start.log

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ nix/**/result
 **/.sass-cache/
 **/_cache/
 
+# Bazel-generated artifacts staged for Docker builds
+docker/openclaw/approval-gate-plugin.tar
+
 # Project-specific
 **/.claude/settings.local.json
 **/.claude/session-start.log

--- a/cluster/k8s/approval-gate/externalsecret.yaml
+++ b/cluster/k8s/approval-gate/externalsecret.yaml
@@ -10,6 +10,13 @@ spec:
     kind: ClusterSecretStore
   target:
     name: approval-gate-secrets
+    template:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "openclaw"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "openclaw"
   data:
     - secretKey: agent-api-key
       remoteRef:

--- a/cluster/k8s/openclaw/openclawinstance.yaml
+++ b/cluster/k8s/openclaw/openclawinstance.yaml
@@ -46,7 +46,7 @@ spec:
       valueFrom:
         secretKeyRef:
           name: approval-gate-secrets
-          key: agent-api-key
+          key: token
   config:
     raw:
       cron:
@@ -222,9 +222,11 @@ spec:
         entries:
           approval-gate:
             config:
-              approvalGateUrl: "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
-              approvalGateToken: "${APPROVAL_GATE_TOKEN}"
-              execServerUrl: "http://127.0.0.1:8766/mcp"
+              approvalGate:
+                url: "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
+                token: "${APPROVAL_GATE_TOKEN}"
+              execServer:
+                url: "http://127.0.0.1:8766/mcp"
       tools:
         # Built-in exec is disabled. The approval-gate plugin registers an exec
         # tool that calls the DirectExecServer sidecar with OPENCLAW_SESSION_ID

--- a/cluster/k8s/openclaw/openclawinstance.yaml
+++ b/cluster/k8s/openclaw/openclawinstance.yaml
@@ -42,6 +42,11 @@ spec:
         secretKeyRef:
           name: openclaw-matrix-bot-password
           key: password
+    - name: APPROVAL_GATE_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: approval-gate-secrets
+          key: agent-api-key
   config:
     raw:
       cron:
@@ -213,12 +218,19 @@ spec:
                 input: ["text", "image"]
                 contextWindow: 200000
                 maxTokens: 64000
+      plugins:
+        entries:
+          approval-gate:
+            config:
+              approvalGateUrl: "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
+              approvalGateToken: "${APPROVAL_GATE_TOKEN}"
+              execServerUrl: "http://127.0.0.1:8766/mcp"
       tools:
+        # Built-in exec is disabled. The approval-gate plugin registers an exec
+        # tool that calls the DirectExecServer sidecar with OPENCLAW_SESSION_ID
+        # injection, replacing the node-host exec path entirely.
         exec:
-          host: node
-          node: "sidecar"
-          security: full
-          ask: off
+          enabled: false
       gateway:
         trustedProxies:
           - "10.244.0.0/16"
@@ -283,43 +295,19 @@ spec:
         cpu: "1000m"
         memory: "2Gi"
   sidecars:
-    - name: node-host
-      image: ghcr.io/openclaw/openclaw:2026.2.24
-      command: ["node", "openclaw.mjs", "node", "run"]
-      args: ["--host", "127.0.0.1", "--port", "18789", "--display-name", "sidecar"]
-      env:
-        - name: OPENCLAW_GATEWAY_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: openclaw-gateway-token
-              key: token
-        # Point node at the operator-managed config so it reads
-        # tools.exec.ask=off / security=full (otherwise node defaults
-        # to ask=on-miss / security=allowlist and blocks execution).
-        - name: OPENCLAW_CONFIG_PATH
-          value: /operator-config/openclaw.json
-        # Operator config references ${OPENCLAW_CHROMIUM_CDP} in browser
-        # profiles. The sidecar doesn't use chromium but config parsing
-        # fails without this env var.
-        - name: OPENCLAW_CHROMIUM_CDP
-          value: "http://127.0.0.1:9222"
-      # Note: Commands execute directly inside this container via
-      # child_process.spawn() — no K8s API involved.
-      # The SA token below is ONLY for kubectl: it provides in-cluster
-      # auth scoped to openclaw-sandbox namespace (restricted RBAC).
-      # The namespace file in the mount defaults kubectl's namespace.
+    - name: exec-server
+      image: registry.allegedly.works/openclaw/openclaw-exec:latest
+      # DirectExecServer entrypoint is baked into the base image.
+      # Listen on 127.0.0.1 only — the gateway plugin connects pod-locally.
+      args: ["--host", "127.0.0.1", "--port", "8766"]
+      env: []
+      # SA token provides kubectl access to openclaw-sandbox namespace.
+      # Workspace PVC is shared with the gateway so file tools and exec
+      # see the same filesystem.
       volumeMounts:
         - name: sandbox-sa-token
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
-        - name: node-data
-          mountPath: /home/node/.openclaw
-        - name: operator-config
-          mountPath: /operator-config
-          readOnly: true
-        # Share workspace PVC with gateway — fixes split-brain filesystem
-        # where built-in file tools (Read/Write/Glob) see gateway fs but
-        # shell exec runs on sidecar fs. Both now see the same files.
         - name: data
           mountPath: /home/openclaw/.openclaw
       resources:
@@ -340,12 +328,6 @@ spec:
             path: ca.crt
           - key: namespace
             path: namespace
-    - name: node-data
-      persistentVolumeClaim:
-        claimName: openclaw-node-data
-    - name: operator-config
-      configMap:
-        name: openclaw-config
   security:
     networkPolicy:
       additionalEgress:

--- a/docker/openclaw-exec/Dockerfile
+++ b/docker/openclaw-exec/Dockerfile
@@ -1,0 +1,37 @@
+# OpenClaw exec sidecar: DirectExecServer + CLI tools for agent use.
+#
+# Runs DirectExecServer on port 8766 (streamable-http, unauthenticated).
+# The OpenClaw gateway plugin connects to this server pod-locally and
+# proxies exec tool calls with OPENCLAW_SESSION_ID injection.
+#
+# Includes mcporter (MCP CLI tool) so the agent can call approval-gated
+# MCP tools from the command line, and kubectl for sandbox namespace access.
+#
+# Built from the approval-gate exec-backend OCI image (contains Python
+# runtime + DirectExecServer), extended with Node.js tools.
+FROM registry.allegedly.works/approval-gate/exec-backend:latest
+
+USER root
+
+# Install Node.js (for mcporter) and kubectl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list \
+    && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key \
+      | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /" \
+      > /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs kubectl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install mcporter globally
+RUN npm install -g mcporter
+
+# Default: run DirectExecServer on 0.0.0.0:8766
+# The pod-level security context handles the user.
+EXPOSE 8766
+USER 1000:1000

--- a/docker/openclaw/Dockerfile
+++ b/docker/openclaw/Dockerfile
@@ -35,8 +35,11 @@ RUN node -e " \
 # Plugin source is copied from the repo; deps are installed at build time.
 WORKDIR /app/extensions/approval-gate
 COPY openclaw/approval-gate/package.json ./
-COPY openclaw/approval-gate/index.ts ./
 COPY openclaw/approval-gate/openclaw.plugin.json ./
+COPY openclaw/approval-gate/index.ts ./
+COPY openclaw/approval-gate/util.ts ./
+COPY openclaw/approval-gate/reconnecting-mcp-client.ts ./
+COPY openclaw/approval-gate/approval-gate-connection.ts ./
 RUN npm install --omit=dev \
  && chown -R node:node .
 
@@ -44,7 +47,7 @@ WORKDIR /app
 
 # Proxy preload: always active. Kyverno injects the proxy env vars at runtime;
 # NODE_OPTIONS activates this preload so Node.js uses them from startup.
-COPY proxy-setup.mjs /app/proxy-setup.mjs
+COPY docker/openclaw/proxy-setup.mjs /app/proxy-setup.mjs
 ENV NODE_OPTIONS="--import=file:///app/proxy-setup.mjs"
 
 USER node

--- a/docker/openclaw/Dockerfile
+++ b/docker/openclaw/Dockerfile
@@ -32,14 +32,10 @@ RUN node -e " \
  && chown -R node:node node_modules
 
 # ── Approval gate plugin ──────────────────────────────────────────────────────
-# Plugin source is copied from the repo; deps are installed at build time.
+# Plugin source built by Bazel (//openclaw/approval-gate:plugin_tar).
+# CI stages the tar at docker/openclaw/approval-gate-plugin.tar before build.
 WORKDIR /app/extensions/approval-gate
-COPY openclaw/approval-gate/package.json ./
-COPY openclaw/approval-gate/openclaw.plugin.json ./
-COPY openclaw/approval-gate/index.ts ./
-COPY openclaw/approval-gate/util.ts ./
-COPY openclaw/approval-gate/reconnecting-mcp-client.ts ./
-COPY openclaw/approval-gate/approval-gate-connection.ts ./
+ADD docker/openclaw/approval-gate-plugin.tar .
 RUN npm install --omit=dev \
  && chown -R node:node .
 

--- a/mcp_infra/exec/subprocess.py
+++ b/mcp_infra/exec/subprocess.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 
 from pydantic import Field
 
 from mcp_infra.exec.models import (
     BaseExecResult,
+    EnvVar,
     ExecArgsBase,
     ExecOutcome,
     ExecOutput,
@@ -19,7 +21,13 @@ from mcp_infra.exec.models import (
 
 
 async def run_proc(
-    argv: list[str], timeout_s: float, *, cwd: Path | None = None, stdin: bytes | str | None = None
+    argv: list[str],
+    timeout_s: float,
+    *,
+    cwd: Path | None = None,
+    stdin: bytes | str | None = None,
+    env: dict[str, str] | None = None,
+    inherit_env: bool = True,
 ) -> ExecOutcome:
     if stdin is None:
         stdin_bytes: bytes | None = None
@@ -28,6 +36,10 @@ async def run_proc(
     else:
         stdin_bytes = stdin
 
+    proc_env = dict(os.environ) if inherit_env else {}
+    if env:
+        proc_env.update(env)
+
     async with async_timer() as get_duration_ms:
         proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -35,6 +47,7 @@ async def run_proc(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
+            env=proc_env,
         )
 
         try:
@@ -73,6 +86,28 @@ class DirectExecArgs(ExecArgsBase):
     """Arguments for direct command execution."""
 
     cmd: list[str] = Field(min_length=1)
+    env: list[EnvVar] | None = Field(
+        default=None,
+        description="Environment variables as ['NAME=value', ...]. "
+        "Merged into the inherited environment by default (see inherit_env).",
+    )
+    inherit_env: bool = Field(
+        default=True,
+        description="If true (default), env vars are merged into the process's inherited environment. "
+        "If false, only the provided env vars are used (clean environment).",
+    )
+
+
+def _parse_env_list(env_list: list[str] | None) -> dict[str, str] | None:
+    if not env_list:
+        return None
+    result: dict[str, str] = {}
+    for entry in env_list:
+        name, sep, value = entry.partition("=")
+        if not sep:
+            raise ValueError(f"invalid env var (missing '='): {entry!r}")
+        result[name] = value
+    return result
 
 
 async def run_direct_exec(input: DirectExecArgs, *, default_cwd: Path | None = None) -> BaseExecResult:
@@ -90,5 +125,12 @@ async def run_direct_exec(input: DirectExecArgs, *, default_cwd: Path | None = N
         cwd_val = default_cwd
 
     timeout_s = max(0.001, input.timeout_ms / 1000.0)
-    outcome = await run_proc(input.cmd, timeout_s, cwd=cwd_val, stdin=input.stdin_text)
+    outcome = await run_proc(
+        input.cmd,
+        timeout_s,
+        cwd=cwd_val,
+        stdin=input.stdin_text,
+        env=_parse_env_list(input.env),
+        inherit_env=input.inherit_env,
+    )
     return render_outcome_to_result(outcome, input.max_bytes)

--- a/openclaw/approval-gate/BUILD.bazel
+++ b/openclaw/approval-gate/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm_ducktape//:defs.bzl", "npm_link_all_packages")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//tools/js:json_schema.bzl", "js_json_schema")
 
 npm_link_all_packages(name = "node_modules")
@@ -46,4 +48,25 @@ js_library(
         ":types",
         ":util",
     ],
+)
+
+# ── Plugin packaging for Docker ──────────────────────────────────────────────
+
+pkg_files(
+    name = "plugin_files",
+    srcs = [
+        "approval-gate-connection.ts",
+        "index.ts",
+        "openclaw.plugin.json",
+        "package.json",
+        "reconnecting-mcp-client.ts",
+        "util.ts",
+    ],
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
+pkg_tar(
+    name = "plugin_tar",
+    srcs = [":plugin_files"],
+    visibility = ["//visibility:public"],
 )

--- a/openclaw/approval-gate/BUILD.bazel
+++ b/openclaw/approval-gate/BUILD.bazel
@@ -11,10 +11,39 @@ js_json_schema(
 )
 
 js_library(
-    name = "plugin",
-    srcs = ["index.ts"],
+    name = "util",
+    srcs = ["util.ts"],
+    deps = [":node_modules"],
+)
+
+js_library(
+    name = "reconnecting-mcp-client",
+    srcs = ["reconnecting-mcp-client.ts"],
     deps = [
         ":node_modules",
+        ":util",
+    ],
+)
+
+js_library(
+    name = "approval-gate-connection",
+    srcs = ["approval-gate-connection.ts"],
+    deps = [
+        ":node_modules",
+        ":reconnecting-mcp-client",
         ":types",
+        ":util",
+    ],
+)
+
+js_library(
+    name = "index",
+    srcs = ["index.ts"],
+    deps = [
+        ":approval-gate-connection",
+        ":node_modules",
+        ":reconnecting-mcp-client",
+        ":types",
+        ":util",
     ],
 )

--- a/openclaw/approval-gate/README.md
+++ b/openclaw/approval-gate/README.md
@@ -1,65 +1,39 @@
 # approval-gate OpenClaw plugin
 
-OpenClaw plugin that bridges the [approval gate](../../approval_gate/) MCP proxy.
+OpenClaw plugin that bridges the [approval gate](../../approval_gate/) MCP proxy
+and provides the exec tool via a DirectExecServer sidecar.
 
 ## What it does
 
-1. **Connects** to the approval gate MCP server as a persistent MCP client.
-2. **Discovers** the approval-wrapped tools exposed by the gate and re-registers
-   them with OpenClaw so agents can call them.
-3. **Injects `session_key`** automatically from the calling agent's session —
-   agents never set this field manually.
-4. **Subscribes** to `resource://actions/{id}` MCP resource notifications on
-   every queued action.
-5. **On `ResourceUpdated`**: reads the action state and delivers the result back
-   to the agent session via `chat.inject` (local gateway WebSocket).
-
-## Flow
-
-```
-Agent calls approval-gate tool
-        │
-        ▼
-Plugin calls approval gate MCP → returns {action_id, approval_url, status: "pending"}
-        │
-        ▼
-Agent receives action_id + URL, shares URL with operator
-        │
-        ▼ (operator approves in UI)
-Approval gate executes backend call, emits ResourceUpdated
-        │
-        ▼
-Plugin receives ResourceUpdated notification
-        │  reads resource://actions/{id}
-        ▼
-Plugin calls chat.inject (local gateway WebSocket, OPENCLAW_GATEWAY_TOKEN)
-        │
-        ▼
-Agent session receives result message
-```
+1. **Exec tool**: Registers an `exec` tool backed by the DirectExecServer sidecar
+   (pod-local, unauthenticated). Discovers the tool schema from the sidecar at
+   startup and injects `OPENCLAW_SESSION_ID` into the command environment.
+2. **Approval gate notifications**: Connects to the approval gate MCP server,
+   subscribes to session log HWM resources, and delivers terminal action results
+   (approved/denied/withdrawn) to the agent via `enqueueSystemEvent`.
+3. **Approval gate tools** (optional, `registerTools: true`): Discovers and
+   re-registers approval-gate-wrapped tools with OpenClaw, injecting `session_key`
+   automatically.
 
 ## Configuration
 
-Add to your OpenClaw config (or plugin config UI):
+Add to your OpenClaw config:
 
 ```jsonc
-// openclaw.config.json5
 {
   "plugins": {
-    "approval-gate": {
-      "approvalGateUrl": "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp",
-      "agentApiKey": "<AGENT_API_KEY from the approval gate>",
+    "entries": {
+      "approval-gate": {
+        "config": {
+          "approvalGateUrl": "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp",
+          "approvalGateToken": "<token from the approval gate>",
+          "execServerUrl": "http://127.0.0.1:8766/mcp",
+        },
+      },
     },
   },
 }
 ```
-
-## Environment variables
-
-| Variable                  | Description                                                            |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `OPENCLAW_GATEWAY_TOKEN`  | Gateway auth token for `chat.inject` calls (standard OpenClaw env var) |
-| `OPENCLAW_GATEWAY_WS_URL` | Override gateway WebSocket URL (default: `ws://127.0.0.1:18789`)       |
 
 ## Installation
 

--- a/openclaw/approval-gate/README.md
+++ b/openclaw/approval-gate/README.md
@@ -25,9 +25,13 @@ Add to your OpenClaw config:
     "entries": {
       "approval-gate": {
         "config": {
-          "approvalGateUrl": "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp",
-          "approvalGateToken": "<token from the approval gate>",
-          "execServerUrl": "http://127.0.0.1:8766/mcp",
+          "approvalGate": {
+            "url": "http://approval-gate.approval-gate.svc.cluster.local:8765/mcp",
+            "token": "<token from the approval gate>",
+          },
+          "execServer": {
+            "url": "http://127.0.0.1:8766/mcp",
+          },
         },
       },
     },

--- a/openclaw/approval-gate/SKILL.md
+++ b/openclaw/approval-gate/SKILL.md
@@ -1,0 +1,59 @@
+# Approval Gate
+
+You have access to privileged actions behind an approval gate. These actions
+require operator approval before execution. Use `mcporter` from the exec tool
+to interact with the approval gate MCP server.
+
+The exec environment provides `APPROVAL_GATE_URL` and `OPENCLAW_SESSION_ID`
+automatically.
+
+## Discovering available tools
+
+Read the server's instructions and list available tools before submitting
+actions:
+
+```bash
+mcporter instructions "$APPROVAL_GATE_URL"
+mcporter list-tools "$APPROVAL_GATE_URL"
+```
+
+Follow the instructions when submitting actions. Use `list-tools` to see
+tool names, descriptions, and input schemas.
+
+## Requesting an action
+
+```bash
+mcporter call "$APPROVAL_GATE_URL" <tool-name> '{"arg": "value", "session_key": "'$OPENCLAW_SESSION_ID'"}'
+```
+
+You will receive an immediate acknowledgment with an action key
+(`session_key`/`action_seq`). The action is then queued for operator review.
+
+## Receiving results
+
+When the operator approves or denies an action, you will receive a system
+notification with the result. You do not need to poll — results are delivered
+automatically.
+
+## Checking action state
+
+Read the state of a specific action:
+
+```bash
+mcporter read "$APPROVAL_GATE_URL" "resource://sessions/$OPENCLAW_SESSION_ID/actions/<action_seq>"
+```
+
+Browse the session event log:
+
+```bash
+mcporter read "$APPROVAL_GATE_URL" "resource://sessions/$OPENCLAW_SESSION_ID/log_hwm"
+mcporter read "$APPROVAL_GATE_URL" "resource://sessions/$OPENCLAW_SESSION_ID/log/<entry_id>"
+```
+
+## Withdrawing a pending action
+
+If you no longer need a pending action, you can withdraw it:
+
+```bash
+mcporter call "$APPROVAL_GATE_URL" withdraw '{"session_key": "'$OPENCLAW_SESSION_ID'", "action_seq": <seq>}'
+```

--- a/openclaw/approval-gate/SKILL.md
+++ b/openclaw/approval-gate/SKILL.md
@@ -1,11 +1,11 @@
 # Approval Gate
 
-You have access to privileged actions behind an approval gate. These actions
-require operator approval before execution. Use `mcporter` from the exec tool
-to interact with the approval gate MCP server.
+You have access to privileged tools which require user approval. Access to the
+MCP servers providing these tools is gated by an approval gate MCP server.
 
 The exec environment provides `APPROVAL_GATE_URL` and `OPENCLAW_SESSION_ID`
-automatically.
+automatically. You can interact with the approval gate using any MCP client;
+`mcporter` is one such tool available in the exec environment.
 
 ## Discovering available tools
 
@@ -27,11 +27,11 @@ mcporter call "$APPROVAL_GATE_URL" <tool-name> '{"arg": "value", "session_key": 
 ```
 
 You will receive an immediate acknowledgment with an action key
-(`session_key`/`action_seq`). The action is then queued for operator review.
+(`session_key`/`action_seq`). The action is then queued for user review.
 
 ## Receiving results
 
-When the operator approves or denies an action, you will receive a system
+When the user approves or denies an action, you will receive a system
 notification with the result. You do not need to poll — results are delivered
 automatically.
 

--- a/openclaw/approval-gate/approval-gate-connection.ts
+++ b/openclaw/approval-gate/approval-gate-connection.ts
@@ -17,7 +17,7 @@ const LOG_HWM_PREFIX = "resource://sessions/";
 const LOG_HWM_SUFFIX = "/log_hwm";
 
 function logHwmUri(sessionKey: string): string {
-  return logHwmUri(sessionKey);
+  return `${LOG_HWM_PREFIX}${sessionKey}${LOG_HWM_SUFFIX}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,7 +26,6 @@ type NotificationHandler = (notification: any) => Promise<void>;
 export class ApprovalGateConnection extends ReconnectingMcpClient {
   private notificationHandler: NotificationHandler | null = null;
   private catchUpHandler: ((sessionKey: string) => Promise<void>) | null = null;
-  private cachedInstructions: string | undefined;
   /** Last seen log entry_id per session — re-subscribed on reconnect. */
   private readonly sessionHwms = new Map<string, number>();
 
@@ -47,11 +46,6 @@ export class ApprovalGateConnection extends ReconnectingMcpClient {
   }
 
   protected override async onConnected(client: Client): Promise<void> {
-    const initResult = (client as Record<string, unknown>)._instructions as string | undefined;
-    if (initResult) {
-      this.cachedInstructions = initResult;
-    }
-
     if (this.notificationHandler) {
       client.setNotificationHandler(
         { method: "notifications/resources/updated" } as Parameters<typeof client.setNotificationHandler>[0],
@@ -78,10 +72,6 @@ export class ApprovalGateConnection extends ReconnectingMcpClient {
         this.log.warn(`failed to re-subscribe to session ${sessionKey}: ${String(err)}`);
       }
     }
-  }
-
-  get instructions(): string | undefined {
-    return this.cachedInstructions;
   }
 
   setNotificationHandler(handler: NotificationHandler): void {

--- a/openclaw/approval-gate/approval-gate-connection.ts
+++ b/openclaw/approval-gate/approval-gate-connection.ts
@@ -1,0 +1,149 @@
+/**
+ * Resilient MCP client connection to the approval gate server.
+ *
+ * Extends `ReconnectingMcpClient` with Bearer auth, session HWM tracking,
+ * and resource subscription management. Tracks session HWMs and
+ * re-subscribes on reconnect, performing catch-up reads to deliver results
+ * that arrived during the outage.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ReconnectingMcpClient } from "./reconnecting-mcp-client.js";
+import type { LogEntry } from "./types.js";
+import type { ScopedLogger } from "./util.js";
+
+const LOG_HWM_PREFIX = "resource://sessions/";
+const LOG_HWM_SUFFIX = "/log_hwm";
+
+function logHwmUri(sessionKey: string): string {
+  return logHwmUri(sessionKey);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type NotificationHandler = (notification: any) => Promise<void>;
+
+export class ApprovalGateConnection extends ReconnectingMcpClient {
+  private notificationHandler: NotificationHandler | null = null;
+  private catchUpHandler: ((sessionKey: string) => Promise<void>) | null = null;
+  private cachedInstructions: string | undefined;
+  /** Last seen log entry_id per session — re-subscribed on reconnect. */
+  private readonly sessionHwms = new Map<string, number>();
+
+  constructor(
+    url: string,
+    private readonly apiKey: string,
+    log: ScopedLogger
+  ) {
+    super(url, "openclaw-approval-gate", log);
+  }
+
+  protected override createTransport(): StreamableHTTPClientTransport {
+    return new StreamableHTTPClientTransport(new URL(this.url), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      },
+    });
+  }
+
+  protected override async onConnected(client: Client): Promise<void> {
+    const initResult = (client as Record<string, unknown>)._instructions as string | undefined;
+    if (initResult) {
+      this.cachedInstructions = initResult;
+    }
+
+    if (this.notificationHandler) {
+      client.setNotificationHandler(
+        { method: "notifications/resources/updated" } as Parameters<typeof client.setNotificationHandler>[0],
+        this.notificationHandler
+      );
+    }
+
+    await this.resubscribeTrackedSessions();
+  }
+
+  private async resubscribeTrackedSessions(): Promise<void> {
+    if (this.sessionHwms.size === 0) return;
+    this.log.info(`re-subscribing to ${this.sessionHwms.size} tracked session(s)`);
+    for (const [sessionKey] of this.sessionHwms.entries()) {
+      try {
+        const hwmUri = logHwmUri(sessionKey);
+        const client = this.requireClient();
+        await client.subscribeResource({ uri: hwmUri });
+
+        this.catchUpHandler?.(sessionKey).catch((err) =>
+          this.log.warn(`catch-up failed for session ${sessionKey}: ${String(err)}`)
+        );
+      } catch (err) {
+        this.log.warn(`failed to re-subscribe to session ${sessionKey}: ${String(err)}`);
+      }
+    }
+  }
+
+  get instructions(): string | undefined {
+    return this.cachedInstructions;
+  }
+
+  setNotificationHandler(handler: NotificationHandler): void {
+    this.notificationHandler = handler;
+  }
+
+  setCatchUpHandler(handler: (sessionKey: string) => Promise<void>): void {
+    this.catchUpHandler = handler;
+  }
+
+  async trackSession(sessionKey: string): Promise<void> {
+    if (this.sessionHwms.has(sessionKey)) return;
+    this.sessionHwms.set(sessionKey, 0);
+    const hwmUri = logHwmUri(sessionKey);
+    try {
+      await this.requireClient().subscribeResource({ uri: hwmUri });
+      this.log.info(`tracking session ${sessionKey}`);
+    } catch (err) {
+      this.log.warn(`failed to subscribe to HWM for session ${sessionKey}: ${String(err)}`);
+    }
+  }
+
+  updateSessionHwm(sessionKey: string, hwm: number): void {
+    const current = this.sessionHwms.get(sessionKey) ?? 0;
+    if (hwm > current) {
+      this.sessionHwms.set(sessionKey, hwm);
+    }
+  }
+
+  getSessionHwm(sessionKey: string): number {
+    return this.sessionHwms.get(sessionKey) ?? 0;
+  }
+
+  async readResourceText(uri: string): Promise<string> {
+    const client = this.requireClient();
+    const resource = await client.readResource({ uri });
+    const content = resource.contents[0];
+    if (!content || !("text" in content)) {
+      throw new Error(`resource ${uri} returned non-text content`);
+    }
+    return (content as { text: string }).text;
+  }
+
+  async readHwm(sessionKey: string): Promise<number> {
+    const uri = logHwmUri(sessionKey);
+    const text = await this.readResourceText(uri);
+    return parseInt(text, 10);
+  }
+
+  async readLogEntry(sessionKey: string, entryId: number): Promise<LogEntry> {
+    const uri = `resource://sessions/${sessionKey}/log/${entryId}`;
+    const text = await this.readResourceText(uri);
+    return JSON.parse(text) as LogEntry;
+  }
+
+  async listTools(): Promise<ReturnType<Client["listTools"]>> {
+    return this.requireClient().listTools();
+  }
+}
+
+/** Parse session_key from a log HWM URI like resource://sessions/{key}/log_hwm */
+export function parseSessionKeyFromHwmUri(uri: string): string | null {
+  if (!uri.startsWith(LOG_HWM_PREFIX) || !uri.endsWith(LOG_HWM_SUFFIX)) return null;
+  return uri.slice(LOG_HWM_PREFIX.length, uri.length - LOG_HWM_SUFFIX.length);
+}

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -55,7 +55,7 @@ function formatTerminalMessage(keyStr: string, detail: LogEventDetail): string {
     }
   }
   if (detail.kind === "denied") {
-    return `Action ${keyStr} was rejected by the operator. Reason: ${detail.reason ?? "none given"}`;
+    return `Action ${keyStr} was rejected by the user. Reason: ${detail.reason ?? "none given"}`;
   }
   if (detail.kind === "withdrawn") {
     return `Action ${keyStr} was withdrawn.`;
@@ -82,28 +82,28 @@ function stripSchemaKeys(schema: Record<string, unknown>, keys: string[]): Recor
 
 export default async function register(api: OpenClawPluginApi): Promise<void> {
   const log = scopedLogger(api, "approval-gate");
+  const execLog = scopedLogger(api, "exec");
   const cfg = api.pluginConfig as
     | {
-        approvalGateUrl?: string;
-        approvalGateToken?: string;
+        approvalGate?: { url?: string; token?: string };
+        execServer?: { url?: string };
         registerTools?: boolean;
-        execServerUrl?: string;
       }
     | undefined;
 
-  const approvalGateUrl = cfg?.approvalGateUrl?.trim();
-  const approvalGateToken = cfg?.approvalGateToken?.trim();
-  const execServerUrl = cfg?.execServerUrl?.trim() ?? DEFAULT_EXEC_SERVER_URL;
+  const approvalGateUrl = cfg?.approvalGate?.url?.trim();
+  const approvalGateToken = cfg?.approvalGate?.token?.trim();
+  const execServerUrl = cfg?.execServer?.url?.trim() ?? DEFAULT_EXEC_SERVER_URL;
 
   if (!approvalGateUrl || !approvalGateToken) {
-    log.warn("approvalGateUrl and approvalGateToken are required in plugin config; plugin disabled");
+    log.warn("approvalGate.url and approvalGate.token are required in plugin config; plugin disabled");
     return;
   }
 
   const { enqueueSystemEvent } = api.runtime.system;
 
   // ── Exec sidecar MCP connection ───────────────────────────────────────────
-  const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", log);
+  const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", execLog);
   try {
     await execConnection.connect();
   } catch (err) {
@@ -298,7 +298,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
             content: [
               {
                 type: "text" as const,
-                text: `Action ${keyStr} queued for operator approval`,
+                text: `Action ${keyStr} queued for user approval`,
               },
             ],
           };

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -1,47 +1,39 @@
 /**
  * Approval Gate OpenClaw plugin.
  *
- * Connects to the approval gate MCP server as a persistent client and:
- *   1. Discovers approval-gate tools via MCP list_tools.
- *   2. Re-registers each tool with OpenClaw, stripping `session_key` from the
- *      schema (injected automatically from ctx.sessionKey).
- *   3. Subscribes to `resource://sessions/{session_key}/log_hwm` MCP resource
- *      notifications for each session.
- *   4. On HWM change: catches up by reading missed log entries concurrently.
- *      For terminal events (execution_finished/denied/withdrawn), formats the
- *      result directly from the log entry detail and injects it into the agent
- *      session via chat.inject (local gateway WebSocket).
+ * Two responsibilities:
  *
- * Resilience: if the approval gate MCP server goes down, the plugin automatically
- * reconnects with exponential backoff. On reconnect, it re-subscribes to all
- * tracked sessions' log HWMs and catches up from the last known HWM.
+ *   1. **Exec tool**: Registers an `exec` tool that calls the DirectExecServer
+ *      sidecar (pod-local, unauthenticated). Injects `OPENCLAW_SESSION_ID` as
+ *      an env var so the agent knows its session identity when calling external
+ *      services (e.g. the approval gate via mcporter).
+ *
+ *   2. **Approval gate notifications**: Connects to the approval gate MCP server,
+ *      subscribes to session log HWM resources, and delivers terminal action
+ *      results (approved/denied/withdrawn) to the agent via OpenClaw's system
+ *      notification queue (`enqueueSystemEvent`).
  *
  * Auth:
- *   - Approval gate MCP endpoint: Bearer AGENT_API_KEY (from plugin config)
- *   - chat.inject call: OPENCLAW_GATEWAY_TOKEN (env var, same process)
+ *   - Exec sidecar: unauthenticated (pod-local, 127.0.0.1)
+ *   - Approval gate MCP endpoint: Bearer token (approvalGateToken from plugin config)
  *
- * The approval gate server itself never holds the OpenClaw gateway token.
+ * This plugin MUST run inside the gateway process (not a node). The
+ * `enqueueSystemEvent` API writes to the gateway's in-memory per-session
+ * event queue and would not work from a node process.
+ *
+ * Notification delivery uses `enqueueSystemEvent` (OpenClaw's in-memory
+ * per-session event queue). Events are drained and prepended to the agent's
+ * next prompt automatically by the heartbeat mechanism.
  */
 
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type {
-  Action,
-  ActionKey,
-  CallToolResult,
-  Detail as LogEventDetail,
-  DoneState,
-  LogEntry,
-  RejectedState,
-} from "./types.js";
-import WebSocket from "ws";
+import { ApprovalGateConnection, parseSessionKeyFromHwmUri } from "./approval-gate-connection.js";
+import { ReconnectingMcpClient } from "./reconnecting-mcp-client.js";
+import { scopedLogger } from "./util.js";
+import type { Action, ActionKey, Detail as LogEventDetail, DoneState, RejectedState } from "./types.js";
 
-const DEFAULT_GATEWAY_WS_URL = "ws://127.0.0.1:18789";
-const LOG_HWM_PREFIX = "resource://sessions/";
-const LOG_HWM_SUFFIX = "/log_hwm";
-const INITIAL_RETRY_DELAY_MS = 5_000;
-const MAX_RETRY_DELAY_MS = 60_000;
+const DEFAULT_EXEC_SERVER_URL = "http://127.0.0.1:8766/mcp";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -71,432 +63,112 @@ function formatTerminalMessage(keyStr: string, detail: LogEventDetail): string {
   return `Action ${keyStr} log event: ${detail.kind}`;
 }
 
-/** Format a human-readable message from an Action's terminal state. */
-function formatActionOutcome(action: Action): string {
-  const keyStr = `${action.key.session_key}/${action.key.action_seq}`;
-  const state = action.state;
-
-  if (state.status === "done") {
-    const done = state as DoneState;
-    return formatTerminalMessage(keyStr, { kind: "execution_finished", outcome: done.outcome });
-  }
-  if (state.status === "rejected") {
-    const rej = state as RejectedState;
-    return formatTerminalMessage(keyStr, { kind: "denied", reason: rej.reason });
-  }
-  if (state.status === "withdrawn") {
-    return formatTerminalMessage(keyStr, { kind: "withdrawn" });
-  }
-  return `Action ${keyStr} state changed to: ${state.status}`;
-}
-
-/** Parse session_key from a log HWM URI like resource://sessions/{key}/log_hwm */
-function parseSessionKeyFromHwmUri(uri: string): string | null {
-  if (!uri.startsWith(LOG_HWM_PREFIX) || !uri.endsWith(LOG_HWM_SUFFIX)) return null;
-  return uri.slice(LOG_HWM_PREFIX.length, uri.length - LOG_HWM_SUFFIX.length);
-}
-
-/** Strip session_key from a JSON schema properties object. */
-function stripSessionKey(schema: Record<string, unknown>): Record<string, unknown> {
+/** Strip named keys from a JSON schema's properties and required arrays. */
+function stripSchemaKeys(schema: Record<string, unknown>, keys: string[]): Record<string, unknown> {
   const result = structuredClone(schema) as Record<string, unknown>;
   const props = result.properties as Record<string, unknown> | undefined;
   if (props) {
-    delete props.session_key;
+    for (const key of keys) delete props[key];
   }
   const required = result.required as string[] | undefined;
   if (required) {
-    result.required = required.filter((k) => k !== "session_key");
+    const keySet = new Set(keys);
+    result.required = required.filter((k) => !keySet.has(k));
   }
   return result;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type NotificationHandler = (notification: any) => Promise<void>;
-
-// ── ApprovalGateConnection ──────────────────────────────────────────────────
-
-/**
- * Resilient MCP client connection to the approval gate server.
- *
- * Automatically reconnects on disconnect with exponential backoff. Tracks
- * session HWMs and re-subscribes on reconnect, performing catch-up reads
- * to deliver results that arrived during the outage.
- */
-class ApprovalGateConnection {
-  private client: Client | null = null;
-  private connecting = false;
-  private retryDelay = INITIAL_RETRY_DELAY_MS;
-  private notificationHandler: NotificationHandler | null = null;
-  private catchUpHandler: ((sessionKey: string) => Promise<void>) | null = null;
-  private cachedInstructions: string | undefined;
-  /** Last seen log entry_id per session — re-subscribed on reconnect. */
-  private readonly sessionHwms = new Map<string, number>();
-
-  constructor(
-    private readonly url: string,
-    private readonly agentApiKey: string,
-    private readonly log: ScopedLogger
-  ) {}
-
-  async connect(): Promise<void> {
-    if (this.connecting) return;
-    this.connecting = true;
-    try {
-      const transport = new StreamableHTTPClientTransport(new URL(this.url), {
-        requestInit: {
-          headers: { Authorization: `Bearer ${this.agentApiKey}` },
-        },
-      });
-      const client = new Client({ name: "openclaw-approval-gate-plugin", version: "0.1.0" });
-
-      client.onclose = () => {
-        this.log.warn("MCP connection closed");
-        this.client = null;
-        this.scheduleReconnect();
-      };
-
-      client.onerror = (error: Error) => {
-        this.log.warn(`MCP client error: ${error.message}`);
-      };
-
-      await client.connect(transport);
-      this.client = client;
-      this.retryDelay = INITIAL_RETRY_DELAY_MS;
-
-      // Cache instructions from initialization handshake
-      const initResult = (client as Record<string, unknown>)._instructions as string | undefined;
-      if (initResult) {
-        this.cachedInstructions = initResult;
-      }
-
-      // Re-register notification handler on the new client
-      if (this.notificationHandler) {
-        client.setNotificationHandler(
-          { method: "notifications/resources/updated" } as Parameters<typeof client.setNotificationHandler>[0],
-          this.notificationHandler
-        );
-      }
-
-      this.log.info(`connected to ${this.url}`);
-
-      // Re-subscribe to tracked sessions and catch up on missed log entries
-      await this.resubscribeTrackedSessions();
-    } catch (err) {
-      this.log.error(`failed to connect to approval gate: ${String(err)}`);
-      this.scheduleReconnect();
-    } finally {
-      this.connecting = false;
-    }
-  }
-
-  private scheduleReconnect(): void {
-    const delay = this.retryDelay;
-    this.retryDelay = Math.min(this.retryDelay * 2, MAX_RETRY_DELAY_MS);
-    this.log.info(`reconnecting in ${delay}ms`);
-    setTimeout(() => this.connect(), delay);
-  }
-
-  /**
-   * Re-subscribe to all tracked sessions after reconnect.
-   *
-   * For each session: subscribe to its log_hwm resource, then trigger catch-up
-   * directly to process any log entries missed during the outage.
-   */
-  private async resubscribeTrackedSessions(): Promise<void> {
-    if (this.sessionHwms.size === 0) return;
-    this.log.info(`re-subscribing to ${this.sessionHwms.size} tracked session(s)`);
-    for (const [sessionKey] of this.sessionHwms.entries()) {
-      try {
-        const hwmUri = `${LOG_HWM_PREFIX}${sessionKey}${LOG_HWM_SUFFIX}`;
-        const client = this.requireClient();
-        await client.subscribeResource({ uri: hwmUri });
-
-        // Catch up on missed log entries directly
-        this.catchUpHandler?.(sessionKey).catch((err) =>
-          this.log.warn(`catch-up failed for session ${sessionKey}: ${String(err)}`)
-        );
-      } catch (err) {
-        this.log.warn(`failed to re-subscribe to session ${sessionKey}: ${String(err)}`);
-      }
-    }
-  }
-
-  private requireClient(): Client {
-    if (!this.client) {
-      throw new Error("approval gate server is currently unavailable");
-    }
-    return this.client;
-  }
-
-  get connected(): boolean {
-    return this.client !== null;
-  }
-
-  get instructions(): string | undefined {
-    return this.cachedInstructions;
-  }
-
-  setNotificationHandler(handler: NotificationHandler): void {
-    this.notificationHandler = handler;
-    if (this.client) {
-      this.client.setNotificationHandler(
-        { method: "notifications/resources/updated" } as Parameters<typeof this.client.setNotificationHandler>[0],
-        handler
-      );
-    }
-  }
-
-  /** Set the handler called directly during reconnect catch-up (no synthetic notification). */
-  setCatchUpHandler(handler: (sessionKey: string) => Promise<void>): void {
-    this.catchUpHandler = handler;
-  }
-
-  /** Start tracking a session's log HWM. Subscribes if not already tracked. */
-  async trackSession(sessionKey: string): Promise<void> {
-    if (this.sessionHwms.has(sessionKey)) return;
-    this.sessionHwms.set(sessionKey, 0);
-    const hwmUri = `${LOG_HWM_PREFIX}${sessionKey}${LOG_HWM_SUFFIX}`;
-    try {
-      await this.requireClient().subscribeResource({ uri: hwmUri });
-      this.log.info(`tracking session ${sessionKey}`);
-    } catch (err) {
-      this.log.warn(`failed to subscribe to HWM for session ${sessionKey}: ${String(err)}`);
-    }
-  }
-
-  /** Update the last-seen HWM for a session. */
-  updateSessionHwm(sessionKey: string, hwm: number): void {
-    const current = this.sessionHwms.get(sessionKey) ?? 0;
-    if (hwm > current) {
-      this.sessionHwms.set(sessionKey, hwm);
-    }
-  }
-
-  /** Get the last-seen HWM for a session. */
-  getSessionHwm(sessionKey: string): number {
-    return this.sessionHwms.get(sessionKey) ?? 0;
-  }
-
-  async callTool(name: string, args: Record<string, unknown>): Promise<ReturnType<Client["callTool"]>> {
-    return this.requireClient().callTool({ name, arguments: args });
-  }
-
-  async readResource(uri: string): Promise<Action> {
-    const client = this.requireClient();
-    const resource = await client.readResource({ uri });
-    const content = resource.contents[0];
-    if (!content || !("text" in content)) {
-      throw new Error(`resource ${uri} returned non-text content`);
-    }
-    return JSON.parse((content as { text: string }).text) as Action;
-  }
-
-  async readResourceText(uri: string): Promise<string> {
-    const client = this.requireClient();
-    const resource = await client.readResource({ uri });
-    const content = resource.contents[0];
-    if (!content || !("text" in content)) {
-      throw new Error(`resource ${uri} returned non-text content`);
-    }
-    return (content as { text: string }).text;
-  }
-
-  async readHwm(sessionKey: string): Promise<number> {
-    const uri = `${LOG_HWM_PREFIX}${sessionKey}${LOG_HWM_SUFFIX}`;
-    const text = await this.readResourceText(uri);
-    return parseInt(text, 10);
-  }
-
-  async readLogEntry(sessionKey: string, entryId: number): Promise<LogEntry> {
-    const uri = `resource://sessions/${sessionKey}/log/${entryId}`;
-    const text = await this.readResourceText(uri);
-    return JSON.parse(text) as LogEntry;
-  }
-
-  async subscribeResource(uri: string): Promise<void> {
-    this.requireClient().subscribeResource({ uri });
-  }
-
-  async listTools(): Promise<ReturnType<Client["listTools"]>> {
-    return this.requireClient().listTools();
-  }
-}
-
-type GatewayReqFrame = { type: "req"; id: string; method: string; params?: unknown };
-type GatewayResFrame = { type: "res"; id: string; ok: boolean; payload?: unknown; error?: unknown };
-type GatewayFrame = GatewayReqFrame | GatewayResFrame | { type: string; [key: string]: unknown };
-
-type PendingCall = { resolve: () => void; reject: (err: Error) => void; timeout: NodeJS.Timeout };
-type ScopedLogger = ReturnType<typeof scopedLogger>;
-
-/**
- * Persistent WebSocket connection to the OpenClaw gateway.
- *
- * Uses the gateway wire protocol: frames are `{type:"req"|"res"|"event", id, method, params}`.
- * Authenticates via the `connect` request (token auth, operator.admin scope) then reuses
- * the socket for `chat.inject` calls. Automatically reconnects on close; queues calls
- * that arrive before authentication completes.
- */
-class GatewayConnection {
-  private ws: WebSocket | null = null;
-  private authenticated = false;
-  private readonly pending = new Map<string, PendingCall>();
-  private readonly preAuthQueue: Array<() => void> = [];
-  private reqCounter = 0;
-
-  constructor(
-    private readonly url: string,
-    private readonly token: string,
-    private readonly logger: ScopedLogger
-  ) {
-    this.connect();
-  }
-
-  private send(method: string, params?: unknown): string {
-    const id = `req-${(this.reqCounter += 1)}`;
-    const frame: GatewayReqFrame = { type: "req", id, method, params };
-    this.ws!.send(JSON.stringify(frame));
-    return id;
-  }
-
-  private connect(): void {
-    const ws = new WebSocket(this.url);
-    this.ws = ws;
-    this.authenticated = false;
-
-    ws.on("open", () => {
-      // Authenticate immediately via the gateway `connect` request (token auth).
-      const id = this.send("connect", {
-        minProtocol: 3,
-        maxProtocol: 3,
-        client: {
-          id: "approval-gate-plugin",
-          displayName: "approval-gate plugin",
-          version: "0.1.0",
-          platform: "plugin",
-          mode: "ui",
-        },
-        role: "operator",
-        scopes: ["operator.admin"],
-        caps: [],
-        auth: { token: this.token },
-      });
-      // Resolve the connect response via the pending map.
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        this.logger.error("gateway connect timed out");
-        ws.close();
-      }, 12_000);
-      this.pending.set(id, {
-        resolve: () => {
-          this.authenticated = true;
-          for (const send of this.preAuthQueue.splice(0)) send();
-        },
-        reject: (err) => {
-          this.logger.error(`gateway connect failed: ${err.message}`);
-          ws.close();
-        },
-        timeout,
-      });
-    });
-
-    ws.on("message", (data: Buffer | string) => {
-      let frame: GatewayFrame;
-      try {
-        frame = JSON.parse(data.toString()) as GatewayFrame;
-      } catch {
-        return;
-      }
-      if (!frame || frame.type !== "res") return;
-      const res = frame as GatewayResFrame;
-      const entry = this.pending.get(res.id);
-      if (!entry) return;
-      clearTimeout(entry.timeout);
-      this.pending.delete(res.id);
-      if (res.ok) {
-        entry.resolve();
-      } else {
-        entry.reject(new Error(JSON.stringify(res.error ?? res)));
-      }
-    });
-
-    ws.on("error", (err: Error) => {
-      this.logger.warn(`gateway WebSocket error: ${err.message}`);
-    });
-
-    ws.on("close", () => {
-      this.authenticated = false;
-      this.ws = null;
-      for (const [, entry] of this.pending) {
-        clearTimeout(entry.timeout);
-        entry.reject(new Error("gateway connection closed"));
-      }
-      this.pending.clear();
-      setTimeout(() => this.connect(), 5_000);
-    });
-  }
-
-  inject(sessionKey: string, message: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const send = () => {
-        const id = this.send("chat.inject", { sessionKey, message });
-        const timeout = setTimeout(() => {
-          this.pending.delete(id);
-          reject(new Error("chat.inject timeout"));
-        }, 10_000);
-        this.pending.set(id, { resolve, reject, timeout });
-      };
-      if (this.authenticated) {
-        send();
-      } else {
-        this.preAuthQueue.push(send);
-      }
-    });
-  }
-}
-
-// ── Scoped logger ─────────────────────────────────────────────────────────────
-
-function scopedLogger(api: OpenClawPluginApi) {
-  const { logger } = api;
-  return {
-    info: (msg: string) => logger.info(`approval-gate: ${msg}`),
-    warn: (msg: string) => logger.warn(`approval-gate: ${msg}`),
-    error: (msg: string) => logger.error(`approval-gate: ${msg}`),
-  };
 }
 
 // ── Plugin entry point ────────────────────────────────────────────────────────
 
 export default async function register(api: OpenClawPluginApi): Promise<void> {
-  const log = scopedLogger(api);
+  const log = scopedLogger(api, "approval-gate");
   const cfg = api.pluginConfig as
-    | { approvalGateUrl?: string; agentApiKey?: string; registerTools?: boolean }
+    | {
+        approvalGateUrl?: string;
+        approvalGateToken?: string;
+        registerTools?: boolean;
+        execServerUrl?: string;
+      }
     | undefined;
 
   const approvalGateUrl = cfg?.approvalGateUrl?.trim();
-  const agentApiKey = cfg?.agentApiKey?.trim();
+  const approvalGateToken = cfg?.approvalGateToken?.trim();
+  const execServerUrl = cfg?.execServerUrl?.trim() ?? DEFAULT_EXEC_SERVER_URL;
 
-  if (!approvalGateUrl || !agentApiKey) {
-    log.warn("approvalGateUrl and agentApiKey are required in plugin config; plugin disabled");
+  if (!approvalGateUrl || !approvalGateToken) {
+    log.warn("approvalGateUrl and approvalGateToken are required in plugin config; plugin disabled");
     return;
   }
 
-  // ── Gateway WebSocket connection (long-lived, authenticates once) ─────────
-  const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ?? process.env.CLAWDBOT_GATEWAY_TOKEN?.trim();
-  const gateway = gatewayToken
-    ? new GatewayConnection(process.env.OPENCLAW_GATEWAY_WS_URL?.trim() ?? DEFAULT_GATEWAY_WS_URL, gatewayToken, log)
-    : null;
-  if (!gateway) {
-    log.warn("OPENCLAW_GATEWAY_TOKEN not set; action results will not be injected into sessions");
+  const { enqueueSystemEvent } = api.runtime.system;
+
+  // ── Exec sidecar MCP connection ───────────────────────────────────────────
+  const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", log);
+  try {
+    await execConnection.connect();
+  } catch (err) {
+    log.error(`exec server initial connection failed: ${String(err)} — will retry in background`);
+  }
+
+  // ── Register exec tool ────────────────────────────────────────────────────
+  // Discover the exec tool schema from the sidecar MCP server, strip env/inherit_env
+  // (we inject OPENCLAW_SESSION_ID ourselves), and re-register with OpenClaw.
+  // TODO: Consider allowing env merging with session ID later.
+  if (!execConnection.connected) {
+    log.error("exec server not connected on startup; exec tool not registered");
+  } else {
+    let execToolList: Awaited<ReturnType<Client["listTools"]>>;
+    try {
+      execToolList = await execConnection.listTools();
+    } catch (err) {
+      log.error(`failed to list exec server tools: ${String(err)}`);
+      execToolList = { tools: [] };
+    }
+
+    const execTools = execToolList.tools.filter((t) => t.name === "exec");
+    if (execTools.length !== 1) {
+      log.error(`expected exactly 1 exec tool from sidecar, got ${execTools.length}`);
+    } else {
+      const execTool = execTools[0];
+      const execSchema = stripSchemaKeys((execTool.inputSchema ?? {}) as Record<string, unknown>, [
+        "env",
+        "inherit_env",
+      ]);
+
+      api.registerTool((ctx: OpenClawPluginToolContext) => ({
+        name: "exec",
+        label: "exec",
+        description:
+          "Execute a command in the exec container. " +
+          "The workspace directory is shared with the gateway (same path). " +
+          "OPENCLAW_SESSION_ID is automatically set in the environment.",
+        parameters: execSchema,
+        async execute(_id: string, params: Record<string, unknown>) {
+          const env = [`OPENCLAW_SESSION_ID=${ctx.sessionKey ?? ""}`, `APPROVAL_GATE_URL=${approvalGateUrl}`];
+          const cwd = (params.cwd as string | undefined) ?? ctx.workspaceDir;
+          const callArgs = { ...params, env, ...(cwd ? { cwd } : {}) };
+
+          try {
+            return await execConnection.callTool("exec", callArgs);
+          } catch (err) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Exec server is currently unavailable. Please retry shortly. (${String(err)})`,
+                },
+              ],
+            };
+          }
+        },
+      }));
+      log.info("registered exec tool (schema discovered from sidecar)");
+    }
   }
 
   // ── Resilient MCP connection to approval gate server ──────────────────────
-  const connection = new ApprovalGateConnection(approvalGateUrl, agentApiKey, log);
+  const connection = new ApprovalGateConnection(approvalGateUrl, approvalGateToken, log);
 
-  // Catch up on missed log entries for a session. Reads all entries between
-  // the last-seen HWM and the current HWM concurrently, then processes terminal
-  // entries in order. Used by both the notification handler and reconnect logic.
   async function catchUpSession(sessionKey: string): Promise<void> {
     let newHwm: number;
     try {
@@ -509,7 +181,6 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     const lastHwm = connection.getSessionHwm(sessionKey);
     if (newHwm <= lastHwm) return;
 
-    // Read all missed log entries concurrently
     const entryIds = Array.from({ length: newHwm - lastHwm }, (_, i) => lastHwm + 1 + i);
     const entries = await Promise.all(
       entryIds.map((id) =>
@@ -520,30 +191,20 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
       )
     );
 
-    // Process terminal entries in order
     for (const entry of entries) {
       if (!entry || !isTerminalLogKind(entry.detail.kind)) continue;
-      if (!gateway) continue;
 
       const keyStr = `${sessionKey}/${entry.action_seq}`;
       const message = formatTerminalMessage(keyStr, entry.detail);
-      try {
-        await gateway.inject(sessionKey, message);
-        log.info(`injected result for action ${keyStr}`);
-      } catch (err) {
-        log.error(`failed to inject result for action ${keyStr}: ${String(err)}`);
-      }
+      enqueueSystemEvent(message, { sessionKey });
+      log.info(`enqueued system event for action ${keyStr}`);
     }
 
     connection.updateSessionHwm(sessionKey, newHwm);
   }
 
-  // Register catch-up handler for reconnect (called directly, no synthetic notification)
   connection.setCatchUpHandler(catchUpSession);
 
-  // Set up ResourceUpdated notification handler before connecting, so it's
-  // registered on every (re)connect. The handler watches for log HWM changes
-  // and delegates to catchUpSession.
   connection.setNotificationHandler(async (notification) => {
     const uri = (notification.params as { uri?: string }).uri;
     if (!uri) return;
@@ -562,15 +223,11 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
 
   // ── Discover and re-register approval gate tools ──────────────────────────
   // Gated behind registerTools config (default off). When disabled, the plugin
-  // still listens for action notifications and delivers results via chat.inject,
-  // but does not expose approval-gate-wrapped tools to agents.
+  // still listens for action notifications and delivers results via system
+  // events, but does not expose approval-gate-wrapped tools to agents.
   const registerTools = cfg?.registerTools ?? false;
 
   if (registerTools) {
-    // Tools are registered once at startup. If the initial connection fails,
-    // tools won't be available until a manual restart. Once registered, tools
-    // survive reconnections — execute() checks connection state and returns
-    // a user-friendly error if the server is temporarily unavailable.
     if (!connection.connected) {
       log.warn("not connected on startup; no tools registered — plugin will reconnect in background");
       return;
@@ -587,8 +244,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     for (const tool of toolList.tools) {
       const toolName = tool.name;
       const toolDescription = tool.description ?? "";
-      // session_key is injected by us; agents should not see or set it
-      const schema = stripSessionKey((tool.inputSchema ?? {}) as Record<string, unknown>);
+      const schema = stripSchemaKeys((tool.inputSchema ?? {}) as Record<string, unknown>, ["session_key"]);
 
       api.registerTool((ctx: OpenClawPluginToolContext) => ({
         name: toolName,
@@ -616,34 +272,28 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
           const actionKey = JSON.parse(firstContent.text) as ActionKey;
           const keyStr = `${actionKey.session_key}/${actionKey.action_seq}`;
 
-          // Start tracking this session's log HWM for notifications
           await connection.trackSession(actionKey.session_key);
 
-          // Read current state immediately — action may already be resolved
-          // (auto-approved by predicate or instantly denied).
           const actionUri = `resource://sessions/${actionKey.session_key}/actions/${actionKey.action_seq}`;
-          let action: Action;
           try {
-            action = await connection.readResource(actionUri);
+            const text = await connection.readResourceText(actionUri);
+            const action = JSON.parse(text) as Action;
+            const { status } = action.state;
+            if (status === "done" || status === "rejected" || status === "withdrawn") {
+              // TODO: The mapping from action state to log detail kind is awkward because
+              // Action.state and LogEntry.detail have overlapping but different shapes.
+              // Consider unifying the terminal state representation upstream.
+              const outcome = formatTerminalMessage(keyStr, {
+                kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
+                ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
+                ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
+              } as LogEventDetail);
+              return { content: [{ type: "text" as const, text: outcome }] };
+            }
           } catch (err) {
             log.warn(`could not read initial state for ${actionUri}: ${String(err)}`);
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Action ${keyStr} queued for operator approval`,
-                },
-              ],
-            };
           }
 
-          const { status } = action.state;
-          if (status === "done" || status === "rejected" || status === "withdrawn") {
-            // Already terminal — return outcome directly.
-            return { content: [{ type: "text" as const, text: formatActionOutcome(action) }] };
-          }
-
-          // Still pending — tell the agent its action is queued.
           return {
             content: [
               {
@@ -661,22 +311,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     log.info("registerTools is off; skipping tool registration (notification listener still active)");
   }
 
-  // Inject MCP server instructions into the agent context on the first turn of each
-  // fresh session (no user messages yet). prependContext ends up in the first user
-  // message, so it gets included in the compaction summary when the history is
-  // eventually compacted, giving the model a lasting understanding of how the gate works.
-  //
-  // The pseudo-XML envelope signals to the model that this is injected infrastructure
-  // context, not a user message.
-  const instructions = connection.instructions;
-  if (instructions) {
-    api.on("before_prompt_build", (event) => {
-      const hasUserMessages = (event.messages as Array<{ role?: string }>).some((m) => m.role === "user");
-      if (hasUserMessages) return;
-      return {
-        prependContext: `<approval-gate-instructions>\n${instructions}\n</approval-gate-instructions>`,
-      };
-    });
-    log.info("registered before_prompt_build hook for instruction injection");
-  }
+  // Agent instructions for approval gate usage are provided via an OpenClaw
+  // skill (SKILL.md) in the repo, not injected here. The skill tells the agent
+  // how to use mcporter for approval-gated actions and how to read results.
 }

--- a/openclaw/approval-gate/openclaw.plugin.json
+++ b/openclaw/approval-gate/openclaw.plugin.json
@@ -5,20 +5,33 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["approvalGateUrl", "approvalGateToken"],
+    "required": ["approvalGate"],
     "properties": {
-      "approvalGateUrl": {
-        "type": "string",
-        "description": "Base URL of the approval gate MCP endpoint, e.g. http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
+      "approvalGate": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url", "token"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Base URL of the approval gate MCP endpoint, e.g. http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
+          },
+          "token": {
+            "type": "string",
+            "description": "Bearer token for authenticating to the approval gate MCP endpoint"
+          }
+        }
       },
-      "approvalGateToken": {
-        "type": "string",
-        "description": "Bearer token for authenticating to the approval gate MCP endpoint"
-      },
-      "execServerUrl": {
-        "type": "string",
-        "default": "http://127.0.0.1:8766/mcp",
-        "description": "URL of the DirectExecServer sidecar MCP endpoint (pod-local, unauthenticated)"
+      "execServer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "default": "http://127.0.0.1:8766/mcp",
+            "description": "URL of the DirectExecServer sidecar MCP endpoint (pod-local, unauthenticated)"
+          }
+        }
       },
       "registerTools": {
         "type": "boolean",

--- a/openclaw/approval-gate/openclaw.plugin.json
+++ b/openclaw/approval-gate/openclaw.plugin.json
@@ -1,24 +1,29 @@
 {
   "id": "approval-gate",
   "name": "Approval Gate",
-  "description": "Bridges the approval gate MCP proxy: re-registers approval-wrapped tools, subscribes to action notifications, and delivers results via chat.inject.",
+  "description": "Provides exec tool (via DirectExecServer sidecar) with session context injection, and bridges the approval gate MCP proxy for privileged action notifications.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["approvalGateUrl", "agentApiKey"],
+    "required": ["approvalGateUrl", "approvalGateToken"],
     "properties": {
       "approvalGateUrl": {
         "type": "string",
         "description": "Base URL of the approval gate MCP endpoint, e.g. http://approval-gate.approval-gate.svc.cluster.local:8765/mcp"
       },
-      "agentApiKey": {
+      "approvalGateToken": {
         "type": "string",
-        "description": "AGENT_API_KEY for the approval gate MCP endpoint"
+        "description": "Bearer token for authenticating to the approval gate MCP endpoint"
+      },
+      "execServerUrl": {
+        "type": "string",
+        "default": "http://127.0.0.1:8766/mcp",
+        "description": "URL of the DirectExecServer sidecar MCP endpoint (pod-local, unauthenticated)"
       },
       "registerTools": {
         "type": "boolean",
         "default": false,
-        "description": "Whether to discover and register approval-gate-wrapped tools with OpenClaw. When false (default), the plugin only listens for action notifications and delivers results via chat.inject."
+        "description": "Whether to discover and register approval-gate-wrapped tools with OpenClaw. When false (default), the plugin only listens for action notifications and delivers results via system events."
       }
     }
   }

--- a/openclaw/approval-gate/package.json
+++ b/openclaw/approval-gate/package.json
@@ -9,8 +9,7 @@
     ]
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
-    "ws": "^8.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/openclaw/approval-gate/reconnecting-mcp-client.ts
+++ b/openclaw/approval-gate/reconnecting-mcp-client.ts
@@ -1,0 +1,96 @@
+/**
+ * Base class for MCP client connections with automatic reconnection.
+ *
+ * Provides connect/reconnect lifecycle with exponential backoff.
+ * Subclasses override `createTransport` and `onConnected` to customize
+ * transport options (e.g. auth headers) and post-connect behavior
+ * (e.g. re-subscribing to resources).
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { ScopedLogger } from "./util.js";
+
+const INITIAL_RETRY_DELAY_MS = 5_000;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+export class ReconnectingMcpClient {
+  private client: Client | null = null;
+  private connecting = false;
+  private retryDelay = INITIAL_RETRY_DELAY_MS;
+
+  constructor(
+    protected readonly url: string,
+    protected readonly clientName: string,
+    protected readonly log: ScopedLogger
+  ) {}
+
+  /** Override to customize transport (e.g. add auth headers). */
+  protected createTransport(): StreamableHTTPClientTransport {
+    return new StreamableHTTPClientTransport(new URL(this.url));
+  }
+
+  /** Called after a successful connection. Override for post-connect setup. */
+  protected async onConnected(_client: Client): Promise<void> {}
+
+  /** Called when the connection is lost. Override for cleanup. */
+  protected onDisconnected(): void {}
+
+  async connect(): Promise<void> {
+    if (this.connecting) return;
+    this.connecting = true;
+    try {
+      const transport = this.createTransport();
+      const client = new Client({ name: this.clientName, version: "0.1.0" });
+
+      client.onclose = () => {
+        this.log.warn("MCP connection closed");
+        this.client = null;
+        this.onDisconnected();
+        this.scheduleReconnect();
+      };
+
+      client.onerror = (error: Error) => {
+        this.log.warn(`MCP client error: ${error.message}`);
+      };
+
+      await client.connect(transport);
+      this.client = client;
+      this.retryDelay = INITIAL_RETRY_DELAY_MS;
+      this.log.info(`connected to ${this.url}`);
+
+      await this.onConnected(client);
+    } catch (err) {
+      this.log.error(`failed to connect: ${String(err)}`);
+      this.scheduleReconnect();
+    } finally {
+      this.connecting = false;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    const delay = this.retryDelay;
+    this.retryDelay = Math.min(this.retryDelay * 2, MAX_RETRY_DELAY_MS);
+    this.log.info(`reconnecting in ${delay}ms`);
+    setTimeout(() => this.connect(), delay);
+  }
+
+  protected requireClient(): Client {
+    if (!this.client) {
+      throw new Error(`${this.clientName} is currently unavailable`);
+    }
+    return this.client;
+  }
+
+  get connected(): boolean {
+    return this.client !== null;
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ReturnType<Client["callTool"]>> {
+    return this.requireClient().callTool({ name, arguments: args });
+  }
+
+  async listTools(): Promise<ReturnType<Client["listTools"]>> {
+    return this.requireClient().listTools();
+  }
+}

--- a/openclaw/approval-gate/util.ts
+++ b/openclaw/approval-gate/util.ts
@@ -1,0 +1,16 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+export type ScopedLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+export function scopedLogger(api: OpenClawPluginApi, prefix: string): ScopedLogger {
+  const { logger } = api;
+  return {
+    info: (msg: string) => logger.info(`${prefix}: ${msg}`),
+    warn: (msg: string) => logger.warn(`${prefix}: ${msg}`),
+    error: (msg: string) => logger.error(`${prefix}: ${msg}`),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,9 +274,6 @@ importers:
       openclaw:
         specifier: '*'
         version: 2026.2.26(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(hono@4.12.3)(node-llama-cpp@3.15.1(typescript@5.8.3))
-      ws:
-        specifier: ^8.0.0
-        version: 8.19.0
 
   props/frontend:
     dependencies:

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -54,7 +54,7 @@ workflows:
     secrets: inherit
 
   openclaw-image:
-    trigger: { kind: path, pattern: "^docker/openclaw/" }
+    trigger: { kind: path, pattern: "^(docker/openclaw/|openclaw/approval-gate/)" }
     events: [push]
     secrets: inherit
     rbe: false

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -59,6 +59,12 @@ workflows:
     secrets: inherit
     rbe: false
 
+  openclaw-exec-image:
+    trigger: { kind: path, pattern: "^docker/openclaw-exec/" }
+    events: [push]
+    secrets: inherit
+    rbe: false
+
   # Path-based workflows (non-Bazel)
   nix-flake-check:
     trigger: { kind: path, pattern: "^nix/" }

--- a/tools/ci/workflows.yaml
+++ b/tools/ci/workflows.yaml
@@ -59,6 +59,8 @@ workflows:
     secrets: inherit
     rbe: false
 
+  # TODO: Should also trigger on Python dependency changes (mcp_infra/exec/,
+  # approval_gate/, etc.) since the base image is built from those sources.
   openclaw-exec-image:
     trigger: { kind: path, pattern: "^docker/openclaw-exec/" }
     events: [push]


### PR DESCRIPTION
## Summary

This PR refactors the approval-gate OpenClaw plugin to provide two distinct responsibilities:

1. **Exec tool**: Registers an `exec` tool backed by a DirectExecServer sidecar (pod-local, unauthenticated) with automatic `OPENCLAW_SESSION_ID` injection into the command environment.
2. **Approval gate notifications**: Connects to the approval gate MCP server, subscribes to session log HWM resources, and delivers terminal action results via OpenClaw's `enqueueSystemEvent` API instead of the previous WebSocket-based `chat.inject` approach.

## Key Changes

### Plugin Architecture
- **Removed WebSocket gateway connection**: Replaced `chat.inject` calls with `enqueueSystemEvent`, which writes directly to the gateway's in-memory per-session event queue. This eliminates the need for a separate WebSocket connection and the `OPENCLAW_GATEWAY_TOKEN` environment variable.
- **Removed tool re-registration**: The plugin no longer discovers and re-registers approval-gate-wrapped tools. This simplifies the plugin and shifts responsibility to the approval gate server itself.
- **Added exec tool registration**: Discovers the `exec` tool schema from the DirectExecServer sidecar at startup, strips `env` and `inherit_env` parameters (injected by the plugin), and registers it with OpenClaw.

### Code Organization
- **Extracted `ReconnectingMcpClient`**: New base class (`reconnecting-mcp-client.ts`) provides generic MCP client connection with automatic reconnection and exponential backoff. Subclasses override `createTransport()` and `onConnected()` for customization.
- **Extracted `ApprovalGateConnection`**: New class (`approval-gate-connection.ts`) extends `ReconnectingMcpClient` with Bearer auth, session HWM tracking, and resource subscription management specific to the approval gate.
- **Extracted `scopedLogger`**: New utility (`util.ts`) provides a reusable scoped logger factory.
- **Simplified `index.ts`**: Main plugin file now focuses on orchestration and tool registration, delegating MCP connection details to extracted classes.

### Configuration Changes
- Renamed `agentApiKey` → `approvalGateToken` for clarity.
- Added `execServerUrl` configuration (defaults to `http://127.0.0.1:8766/mcp`).
- Removed `registerTools` configuration (tool re-registration no longer supported).

### Infrastructure
- **New exec sidecar image**: Added `docker/openclaw-exec/Dockerfile` containing DirectExecServer, mcporter, and kubectl for agent use.
- **New CI workflow**: Added `.github/workflows/openclaw-exec-image.yml` to build and push the exec sidecar image.
- **Updated K8s deployment**: Modified `openclawinstance.yaml` to:
  - Replace the `node-host` sidecar with `exec-server` (DirectExecServer).
  - Disable the built-in exec tool and rely on the plugin-registered exec tool.
  - Add plugin configuration for approval-gate with proper environment variable injection.
  - Add `APPROVAL_GATE_TOKEN` secret injection from `approval-gate-secrets`.

### Supporting Changes
- **Updated exec subprocess**: Modified `mcp_infra/exec/subprocess.py` to support `env` and `inherit_env` parameters for environment variable control.
- **Added SKILL.md**: New documentation for agents on how to interact with the approval gate via the exec tool and mcporter.
- **Updated plugin metadata**: Modified `openclaw.plugin.json` and `README.md` to reflect the new plugin responsibilities.

## Implementation Details

- **Session context injection**: The exec tool automatically injects `OPENCLAW_SESSION_ID` into the command environment, allowing agents to identify themselves when calling external services (e.g., approval gate via mcporter).
- **Event delivery**: Terminal action results (approved/denied/withdrawn) are delivered via `enqueueSystemEvent`, which queues events in the gateway's in-memory per-session queue. Events are drained and prepended to the agent's next prompt by the heartbeat mechanism.
- **Plugin must run in gateway**: The plugin requires access to `

https://claude.ai/code/session_01KJrby3hT79MiLWkcccLVJL