### PR TITLE
Integrate Prettier formatting into CI workflow generation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,6 +74,20 @@ js_library(
     ],
 )
 
+# Prettier configuration as js_library
+# Makes the config and its plugins available to the prettier binary in tools/ci
+# no-lint: This is a config file, not a target to lint
+js_library(
+    name = "prettierrc",
+    srcs = [".prettierrc.cjs"],
+    tags = ["no-lint"],
+    visibility = ["//tools:__subpackages__"],
+    deps = [
+        ":node_modules/prettier-plugin-svelte",
+        ":node_modules/svelte",
+    ],
+)
+
 # Generate requirements_bazel.txt from pyproject.toml
 # Run: bazel run //:requirements.update
 #

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@npm_ducktape//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//tools/testing:defs.bzl", "py_test")
 
@@ -14,6 +15,11 @@ filegroup(
         "//.github/workflows:gnome-terminal-profile-switcher-release.yml",
         "//.github/workflows:headscale-cleanup-release.yml",
     ],
+)
+
+prettier_bin.prettier_binary(
+    name = "prettier",
+    visibility = ["//visibility:private"],
 )
 
 # === Base modules (no internal deps) ===
@@ -98,12 +104,16 @@ py_library(
 py_library(
     name = "generate_ci",
     srcs = ["generate_ci.py"],
-    data = [":workflows.yaml"],
+    data = [
+        ":prettier",
+        ":workflows.yaml",
+    ],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":github_actions",
         ":models",
+        "//util/bazel:runfiles",
         "//util/bazel:workspace",
         "@pypi//pyyaml",
     ],

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -19,6 +19,11 @@ filegroup(
 
 prettier_bin.prettier_binary(
     name = "prettier",
+    data = ["//:prettierrc"],
+    fixed_args = [
+        "--config",
+        "\"$$JS_BINARY__RUNFILES\"/$(rlocationpath //:prettierrc)",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -9,12 +9,14 @@ Usage:
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import yaml
 
 from tools.ci.github_actions import Job, Step, Workflow
 from tools.ci.models import HarborImageConfig, ReleaseConfig, WorkflowConfig, WorkflowManifest
+from util.bazel.runfiles import get_required_path
 from util.bazel.workspace import get_build_workspace_directory
 
 SCRIPT_DIR = Path(__file__).parent
@@ -328,15 +330,30 @@ def write_workflow(path: Path, workflow: Workflow) -> None:
     print(f"Generated {path}")
 
 
+_PRETTIER_RLOCATION = "_main/tools/ci/prettier_/prettier"
+
+
+def format_with_prettier(paths: list[Path]) -> None:
+    """Run prettier on generated workflow files to match pre-commit formatting."""
+    prettier = get_required_path(_PRETTIER_RLOCATION)
+    subprocess.run([prettier, "--write", "--no-config", "--print-width", "120", "--tab-width", "2", *paths], check=True)
+
+
 def main() -> None:
     """Main entry point."""
     manifest = WorkflowManifest.from_yaml(WORKFLOWS_YAML)
 
     out_dir = get_build_workspace_directory() / ".github" / "workflows"
-    write_workflow(out_dir / "ci.yml", generate_ci_config(manifest))
-    write_workflow(out_dir / "bazel-harbor-images.yml", generate_harbor_images_config(manifest.harbor_images))
+    generated: list[Path] = []
+    generated.append(out_dir / "ci.yml")
+    write_workflow(generated[-1], generate_ci_config(manifest))
+    generated.append(out_dir / "bazel-harbor-images.yml")
+    write_workflow(generated[-1], generate_harbor_images_config(manifest.harbor_images))
     for name, config in manifest.releases.items():
-        write_workflow(out_dir / f"{name}-release.yml", generate_release_config(name, config))
+        generated.append(out_dir / f"{name}-release.yml")
+        write_workflow(generated[-1], generate_release_config(name, config))
+
+    format_with_prettier(generated)
 
 
 if __name__ == "__main__":

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -331,7 +331,7 @@ def write_workflow(path: Path, workflow: Workflow) -> None:
     """Write a workflow file and run prettier to match pre-commit formatting."""
     path.write_text(generate_ci_yml(workflow))
     prettier = get_required_path(_PRETTIER_RLOCATION)
-    subprocess.run([prettier, "--write", "--no-config", "--print-width", "120", "--tab-width", "2", path], check=True)
+    subprocess.run([prettier, "--write", path], check=True)
     print(f"Generated {path}")
 
 

--- a/tools/ci/generate_ci.py
+++ b/tools/ci/generate_ci.py
@@ -324,19 +324,15 @@ def generate_harbor_images_config(images: list[HarborImageConfig]) -> Workflow:
     )
 
 
-def write_workflow(path: Path, workflow: Workflow) -> None:
-    """Write a workflow file."""
-    path.write_text(generate_ci_yml(workflow))
-    print(f"Generated {path}")
-
-
 _PRETTIER_RLOCATION = "_main/tools/ci/prettier_/prettier"
 
 
-def format_with_prettier(paths: list[Path]) -> None:
-    """Run prettier on generated workflow files to match pre-commit formatting."""
+def write_workflow(path: Path, workflow: Workflow) -> None:
+    """Write a workflow file and run prettier to match pre-commit formatting."""
+    path.write_text(generate_ci_yml(workflow))
     prettier = get_required_path(_PRETTIER_RLOCATION)
-    subprocess.run([prettier, "--write", "--no-config", "--print-width", "120", "--tab-width", "2", *paths], check=True)
+    subprocess.run([prettier, "--write", "--no-config", "--print-width", "120", "--tab-width", "2", path], check=True)
+    print(f"Generated {path}")
 
 
 def main() -> None:
@@ -344,16 +340,10 @@ def main() -> None:
     manifest = WorkflowManifest.from_yaml(WORKFLOWS_YAML)
 
     out_dir = get_build_workspace_directory() / ".github" / "workflows"
-    generated: list[Path] = []
-    generated.append(out_dir / "ci.yml")
-    write_workflow(generated[-1], generate_ci_config(manifest))
-    generated.append(out_dir / "bazel-harbor-images.yml")
-    write_workflow(generated[-1], generate_harbor_images_config(manifest.harbor_images))
+    write_workflow(out_dir / "ci.yml", generate_ci_config(manifest))
+    write_workflow(out_dir / "bazel-harbor-images.yml", generate_harbor_images_config(manifest.harbor_images))
     for name, config in manifest.releases.items():
-        generated.append(out_dir / f"{name}-release.yml")
-        write_workflow(generated[-1], generate_release_config(name, config))
-
-    format_with_prettier(generated)
+        write_workflow(out_dir / f"{name}-release.yml", generate_release_config(name, config))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR integrates Prettier code formatting into the CI workflow generation process, ensuring that generated workflow files are automatically formatted to match project standards.

## Key Changes
- **Added Prettier binary target** (`tools/ci/BUILD.bazel`): Created a `prettier_binary` rule that wraps the Prettier formatter with the project's `.prettierrc.cjs` configuration
- **Exposed Prettier configuration** (`BUILD.bazel`): Created a `prettierrc` js_library target that makes the Prettier configuration and its dependencies (prettier-plugin-svelte, svelte) available to the CI tools
- **Automated formatting in workflow generation** (`tools/ci/generate_ci.py`): Modified `write_workflow()` to automatically run Prettier on generated workflow files after writing them, ensuring consistent formatting without manual intervention
- **Updated dependencies**: Added `util.bazel.runfiles` dependency to support locating the Prettier binary at runtime

## Implementation Details
- The Prettier binary is configured with fixed arguments to use the project's `.prettierrc.cjs` configuration file via Bazel's runfiles mechanism
- The `write_workflow()` function now uses `subprocess.run()` to invoke Prettier with the `--write` flag, formatting files in-place
- The Prettier rlocation path (`_main/tools/ci/prettier_/prettier`) is resolved at runtime using the `get_required_path()` utility

https://claude.ai/code/session_019RbHxhayTVtLSMqP8QFHds