### PR TITLE
Remove deprecated save-always from actions/cache@v4

### DIFF
--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -2,9 +2,10 @@
 # See .github/docs/bazel_caching.md for design rationale.
 #
 # Uses the unified actions/cache@v4 which restores at step time and saves as a
-# post step. The save only fires when the exact key was NOT found during restore,
-# avoiding the duplicate-key problem that broke the previous actions/cache/save@v4
-# approach (see bazel_caching.md § Duplicate-key problem).
+# post step (on job success). The save only fires when the exact key was NOT
+# found during restore, avoiding the duplicate-key problem that broke the
+# previous actions/cache/save@v4 approach (see bazel_caching.md §
+# Duplicate-key problem).
 name: Bazel Repo Cache
 description: Setup Bazelisk and restore/save Bazel repository cache
 
@@ -63,4 +64,3 @@ runs:
           ~/.cache/bazel/_bazel_runner/cache/repos/v1
         key: ${{ steps.cache-key.outputs.key }}
         restore-keys: bazel-repo-cache-
-        save-always: true

--- a/.github/docs/bazel_caching.md
+++ b/.github/docs/bazel_caching.md
@@ -45,7 +45,7 @@ compute-targets job
         post step: save skipped (exact-key hit from compute-targets)
 ```
 
-The `bazel-repo-cache` action uses the unified `actions/cache@v4` with `save-always: true`. This saves the cache as a post step even if the job fails, since external repos are fetched during the analysis phase regardless of build outcome. The unified action only saves when the exact key was NOT found during restore, avoiding duplicate entries.
+The `bazel-repo-cache` action uses the unified `actions/cache@v4`, which saves the cache as a post step on job success. The unified action only saves when the exact key was NOT found during restore, avoiding duplicate entries.
 
 There is **no prewarm step**. The `compute-targets` job runs `bazel query` via `bazel-diff`, which fetches all external repos during analysis. Downstream jobs benefit from the cache saved by `compute-targets`.
 


### PR DESCRIPTION
## Summary
- Remove deprecated `save-always: true` input from `actions/cache@v4` in the `bazel-repo-cache` composite action
- The flag was deprecated because it [does not work as intended](https://github.com/actions/cache/tree/main/save#always-save-cache) and will be removed in a future release
- The unified `actions/cache@v4` post step still saves the cache on job success without this flag, which matches the actual behavior (since `save-always` was broken)
- Update `bazel_caching.md` docs to reflect the change

## Test plan
- [ ] CI passes without the `save-always` deprecation warning

https://claude.ai/code/session_01XA3jEu9cK8aFMp8qbxWjKP