### PR TITLE
Fix baseline resolution for visual tests in subdirectories

### DIFF
--- a/approval_gate/frontend/defs.bzl
+++ b/approval_gate/frontend/defs.bzl
@@ -32,11 +32,13 @@ def visual_test(name, srcs, deps = [], baseline = None, size = "small"):
     env = dict(_VISUAL_ENV)
     env["BASELINE_WORKSPACE_PATH"] = native.package_name() + "/baselines"
 
+    baseline_data = [baseline] if baseline else native.glob(["baselines/*.png"])
+
     js_test(
         name = name,
         size = size,
         entry_point = srcs[0],
-        data = _VISUAL_BASE_DATA + deps + ([baseline] if baseline else []),
+        data = _VISUAL_BASE_DATA + deps + baseline_data,
         env = env,
         no_copy_to_bin = _VISUAL_BASE_DATA,
     )

--- a/approval_gate/frontend/package.json
+++ b/approval_gate/frontend/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.23.0",
     "openapi-fetch": "^0.15.0",
-    "svelte": "^5.38.1",
-    "tailwindcss": "^4.1.18"
+    "svelte": "^5.38.1"
   },
   "devDependencies": {
     "esbuild": "^0.25.1",
@@ -17,6 +16,7 @@
     "pngjs": "^7.0.0",
     "puppeteer": "^23.11.1",
     "svelte-check": "^4.3.1",
+    "tailwindcss": "^4.1.18",
     "typescript": "^5.7.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,6 @@ importers:
       svelte:
         specifier: ^5.38.1
         version: 5.53.5
-      tailwindcss:
-        specifier: ^4.1.18
-        version: 4.2.1
     devDependencies:
       esbuild:
         specifier: '>=0.21.0'
@@ -266,6 +263,9 @@ importers:
       svelte-check:
         specifier: ^4.3.1
         version: 4.4.4(picomatch@4.0.3)(svelte@5.53.5)(typescript@5.8.3)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.2.1
       typescript:
         specifier: ^5.7.0
         version: 5.8.3

--- a/props/frontend/defs.bzl
+++ b/props/frontend/defs.bzl
@@ -33,11 +33,13 @@ def visual_test(name, srcs, deps = [], baseline = None, size = "small"):
     env = dict(_VISUAL_ENV)
     env["BASELINE_WORKSPACE_PATH"] = native.package_name() + "/baselines"
 
+    baseline_data = [baseline] if baseline else native.glob(["baselines/*.png"])
+
     js_test(
         name = name,
         size = size,
         entry_point = srcs[0],
-        data = _VISUAL_BASE_DATA + deps + ([baseline] if baseline else []),
+        data = _VISUAL_BASE_DATA + deps + baseline_data,
         env = env,
         no_copy_to_bin = _VISUAL_BASE_DATA,
     )

--- a/util/frontend_visual_test/visual-test-lib.mjs
+++ b/util/frontend_visual_test/visual-test-lib.mjs
@@ -118,9 +118,25 @@ function compareBaseline(name, screenshot, outputDir, baselineDir, updateWriteDi
  */
 export async function main(scenarioName, callerUrl = null, options = {}) {
   const baselineName = options.baselineName || scenarioName;
-  const baselineDir = callerUrl
-    ? join(dirname(fileURLToPath(callerUrl)), "baselines")
-    : DEFAULT_BASELINE_DIR;
+
+  // Resolve baseline directory. Prefer BASELINE_WORKSPACE_PATH (set by the
+  // visual_test() Bazel macro) so baselines resolve correctly even when the
+  // test file lives in a subdirectory (e.g., tests/) separate from baselines/.
+  let baselineDir;
+  const baselineWsPath = process.env.BASELINE_WORKSPACE_PATH;
+  if (baselineWsPath && callerUrl) {
+    const callerDir = dirname(fileURLToPath(callerUrl));
+    const pkgPath = dirname(baselineWsPath);
+    const idx = callerDir.lastIndexOf(pkgPath);
+    if (idx >= 0 && (idx === 0 || callerDir[idx - 1] === "/")) {
+      baselineDir = join(callerDir.substring(0, idx), baselineWsPath);
+    }
+  }
+  if (!baselineDir) {
+    baselineDir = callerUrl
+      ? join(dirname(fileURLToPath(callerUrl)), "baselines")
+      : DEFAULT_BASELINE_DIR;
+  }
   const harnessPath = process.env.HARNESS_PATH || join(__dirname, "harness/dist/harness.js");
   const distDir = dirname(harnessPath);
   const harnessDir = distDir.endsWith("/dist") ? dirname(distDir) : distDir;


### PR DESCRIPTION
## Summary
This PR fixes baseline image resolution for visual tests when test files are located in subdirectories (e.g., `tests/`) separate from baseline directories. It also moves `tailwindcss` to devDependencies where it belongs.

## Key Changes

- **Visual test baseline resolution**: Enhanced the `main()` function in `visual-test-lib.mjs` to use the `BASELINE_WORKSPACE_PATH` environment variable (set by the Bazel `visual_test()` macro) to correctly resolve baseline directories regardless of test file location. Falls back to the original logic if the environment variable is not set.

- **Bazel configuration**: Updated both `approval_gate/frontend/defs.bzl` and `props/frontend/defs.bzl` to:
  - Set `BASELINE_WORKSPACE_PATH` environment variable in visual tests
  - Use `native.glob(["baselines/*.png"])` to automatically discover baseline images instead of requiring explicit specification
  - Simplify the data dependency logic with a `baseline_data` variable

- **Dependency organization**: Moved `tailwindcss` from `dependencies` to `devDependencies` in `package.json` since it's only needed for development/build time, not runtime.

## Implementation Details

The baseline resolution now follows this priority:
1. If `BASELINE_WORKSPACE_PATH` is set and `callerUrl` is provided, compute the baseline directory by finding the package path within the caller directory
2. Otherwise, fall back to the original behavior: resolve relative to the caller's directory or use the default baseline directory

This ensures baselines are found correctly even when test files are organized in subdirectories within a Bazel package.

https://claude.ai/code/session_01H6a7n9MA3AeoC765VW9MVk