### PR TITLE
Add wait_mode support for tool call resolution control

### DIFF
--- a/approval_gate/AGENTS.md
+++ b/approval_gate/AGENTS.md
@@ -8,5 +8,6 @@
 - `session_key` is injected by the OpenClaw plugin; agents must not set it manually.
 - `justification` is required; operators see it when deciding whether to approve.
 - The `resource://actions/{id}` MCP resource is the source of truth for action state.
-- Tool call results always contain `action_id`; the plugin reads state via the resource.
-  The server never embeds the tool execution result in the immediate tool response.
+- Tool call results return a full `Action` object with `state.status` indicating whether
+  the action resolved (`done`, `rejected`) or is still in flight (`pending`, `executing`).
+  With `approval_timeout_seconds`, resolved actions include the result directly.

--- a/approval_gate/AGENTS.md
+++ b/approval_gate/AGENTS.md
@@ -1,13 +1,1 @@
 @README.md
-
-# approval_gate — Agent Instructions
-
-## Conventions
-
-- State transitions are append-only: once an action leaves `pending`, it cannot go back.
-- `session_key` is injected by the OpenClaw plugin; agents must not set it manually.
-- `justification` is required; operators see it when deciding whether to approve.
-- The `resource://actions/{id}` MCP resource is the source of truth for action state.
-- Tool call results return a full `Action` object with `state.status` indicating whether
-  the action resolved (`done`, `rejected`) or is still in flight (`pending`, `executing`).
-  With `default_approval_timeout_seconds`, resolved actions include the result directly.

--- a/approval_gate/AGENTS.md
+++ b/approval_gate/AGENTS.md
@@ -10,4 +10,4 @@
 - The `resource://actions/{id}` MCP resource is the source of truth for action state.
 - Tool call results return a full `Action` object with `state.status` indicating whether
   the action resolved (`done`, `rejected`) or is still in flight (`pending`, `executing`).
-  With `approval_timeout_seconds`, resolved actions include the result directly.
+  With `default_approval_timeout_seconds`, resolved actions include the result directly.

--- a/approval_gate/BUILD.bazel
+++ b/approval_gate/BUILD.bazel
@@ -63,6 +63,7 @@ py_library(
     imports = [".."],
     visibility = ["//visibility:public"],
     deps = [
+        ":models",
         "//mcp_infra:prefix",
         "@pypi//fastmcp",
         "@pypi//pydantic",

--- a/approval_gate/README.md
+++ b/approval_gate/README.md
@@ -85,6 +85,19 @@ backends:
 Each backend entry supports the full `MCPServerTypes` config (URL + headers for
 streamable-http, command + args + env for stdio).
 
+### Approval timeout
+
+The `approval_timeout_seconds` config field controls how long tool calls wait for
+action resolution before returning. When set, actions that resolve within the timeout
+(via auto-approval predicate or fast operator decision) return the result directly
+in the tool call response. When `null` or omitted, tool calls return immediately with
+the current action state (typically `pending`). Callers can also override the server
+default on a per-call basis via the `approval_timeout_seconds` tool parameter.
+
+```yaml
+approval_timeout_seconds: 30 # wait up to 30s for resolution
+```
+
 ### Environment variables
 
 | Variable      | Required | Description                                                         |

--- a/approval_gate/README.md
+++ b/approval_gate/README.md
@@ -87,15 +87,15 @@ streamable-http, command + args + env for stdio).
 
 ### Approval timeout
 
-The `approval_timeout_seconds` config field controls how long tool calls wait for
-action resolution before returning. When set, actions that resolve within the timeout
-(via auto-approval predicate or fast operator decision) return the result directly
-in the tool call response. When `null` or omitted, tool calls return immediately with
-the current action state (typically `pending`). Callers can also override the server
-default on a per-call basis via the `approval_timeout_seconds` tool parameter.
+The `default_approval_timeout_seconds` config field controls how long tool calls wait
+for action resolution before returning. When set, actions that resolve within the
+timeout (via auto-approval predicate or fast operator decision) return the result
+directly in the tool call response. When `null` or omitted, tool calls return
+immediately with the current action state (typically `pending`). Callers can also
+override the server default on a per-call basis via the `wait_mode` tool parameter.
 
 ```yaml
-approval_timeout_seconds: 30 # wait up to 30s for resolution
+default_approval_timeout_seconds: 30 # wait up to 30s for resolution
 ```
 
 ### Environment variables

--- a/approval_gate/README.md
+++ b/approval_gate/README.md
@@ -85,17 +85,22 @@ backends:
 Each backend entry supports the full `MCPServerTypes` config (URL + headers for
 streamable-http, command + args + env for stdio).
 
-### Approval timeout
+### Default wait mode
 
-The `default_approval_timeout_seconds` config field controls how long tool calls wait
-for action resolution before returning. When set, actions that resolve within the
-timeout (via auto-approval predicate or fast operator decision) return the result
-directly in the tool call response. When `null` or omitted, tool calls return
-immediately with the current action state (typically `pending`). Callers can also
-override the server default on a per-call basis via the `wait_mode` tool parameter.
+The `default_wait_mode` config field sets the server-wide default for how long tool
+calls wait for action resolution before returning. Agents can override per-call via
+the `wait_mode` tool parameter. When omitted, tool calls return immediately with
+the current action state (typically `pending`).
 
 ```yaml
-default_approval_timeout_seconds: 30 # wait up to 30s for resolution
+# Wait up to 30s for resolution
+default_wait_mode:
+  mode: yield_after_ms
+  timeout_ms: 30000
+
+# Or wait indefinitely
+default_wait_mode:
+  mode: blocking
 ```
 
 ### Environment variables

--- a/approval_gate/app.py
+++ b/approval_gate/app.py
@@ -51,6 +51,7 @@ def create_app(settings: Settings, *, include_static: bool = True) -> Starlette:
         db_path=settings.db_path,
         predicate=predicate,
         public_base_url=settings.public_base_url,
+        approval_timeout_seconds=settings.approval_timeout_seconds,
         auth=JWTVerifier(jwks_uri=discovery["jwks_uri"]),
     )
     mcp_app = gate.http_app(path="/")

--- a/approval_gate/app.py
+++ b/approval_gate/app.py
@@ -51,7 +51,7 @@ def create_app(settings: Settings, *, include_static: bool = True) -> Starlette:
         db_path=settings.db_path,
         predicate=predicate,
         public_base_url=settings.public_base_url,
-        approval_timeout_seconds=settings.approval_timeout_seconds,
+        default_approval_timeout_seconds=settings.default_approval_timeout_seconds,
         auth=JWTVerifier(jwks_uri=discovery["jwks_uri"]),
     )
     mcp_app = gate.http_app(path="/")

--- a/approval_gate/app.py
+++ b/approval_gate/app.py
@@ -51,7 +51,7 @@ def create_app(settings: Settings, *, include_static: bool = True) -> Starlette:
         db_path=settings.db_path,
         predicate=predicate,
         public_base_url=settings.public_base_url,
-        default_approval_timeout_seconds=settings.default_approval_timeout_seconds,
+        default_wait_mode=settings.default_wait_mode,
         auth=JWTVerifier(jwks_uri=discovery["jwks_uri"]),
     )
     mcp_app = gate.http_app(path="/")

--- a/approval_gate/config.py
+++ b/approval_gate/config.py
@@ -47,6 +47,12 @@ class Settings(BaseModel):
     )
     oidc_issuer: str
     oidc_client_id: str
+    approval_timeout_seconds: float | None = Field(
+        default=None,
+        description=(
+            "Default seconds to wait for action resolution before returning. None = return immediately without waiting."
+        ),
+    )
     host: str = "0.0.0.0"
     port: int = 8765
 

--- a/approval_gate/config.py
+++ b/approval_gate/config.py
@@ -29,7 +29,7 @@ import yaml
 from fastmcp.mcp_config import MCPServerTypes, RemoteMCPServer
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from approval_gate.models import WaitMode
+from approval_gate.models import WaitMode, YieldAfterMs
 from mcp_infra.prefix import MCPMountPrefix
 
 
@@ -47,9 +47,9 @@ class Settings(BaseModel):
     )
     oidc_issuer: str
     oidc_client_id: str
-    default_wait_mode: WaitMode | None = None
+    default_wait_mode: WaitMode = YieldAfterMs(timeout_ms=0)
     host: str = "0.0.0.0"
-    port: int = 8765
+    port: int
 
     @field_validator("public_base_url", mode="after")
     @classmethod

--- a/approval_gate/config.py
+++ b/approval_gate/config.py
@@ -29,6 +29,7 @@ import yaml
 from fastmcp.mcp_config import MCPServerTypes, RemoteMCPServer
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from approval_gate.models import WaitMode
 from mcp_infra.prefix import MCPMountPrefix
 
 
@@ -46,12 +47,7 @@ class Settings(BaseModel):
     )
     oidc_issuer: str
     oidc_client_id: str
-    default_approval_timeout_seconds: float | None = Field(
-        default=None,
-        description=(
-            "Default seconds to wait for action resolution before returning. None = return immediately without waiting."
-        ),
-    )
+    default_wait_mode: WaitMode | None = None
     host: str = "0.0.0.0"
     port: int = 8765
 

--- a/approval_gate/config.py
+++ b/approval_gate/config.py
@@ -38,12 +38,11 @@ class Settings(BaseModel):
     backends: dict[MCPMountPrefix, MCPServerTypes]
     public_base_url: str
     db_path: Path = Path("/data/approval_gate.db")
-    predicate_path: Path | None = Field(
-        default=None,
+    predicate_path: Path = Field(
         description=(
             "Path to a Python module exporting "
             "decide(server_namespace, tool_name, arguments) → Approved|Denied|NeedsHumanDecision."
-        ),
+        )
     )
     oidc_issuer: str
     oidc_client_id: str

--- a/approval_gate/config.py
+++ b/approval_gate/config.py
@@ -46,7 +46,7 @@ class Settings(BaseModel):
     )
     oidc_issuer: str
     oidc_client_id: str
-    approval_timeout_seconds: float | None = Field(
+    default_approval_timeout_seconds: float | None = Field(
         default=None,
         description=(
             "Default seconds to wait for action resolution before returning. None = return immediately without waiting."

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -94,12 +94,26 @@ class GateClient(Client, MessageHandler):
 
     async def call_gate_tool(self, tool_name: str, args: dict[str, object]) -> ActionKey:
         """Call a gate-wrapped tool and parse the ActionKey from the result."""
-        return parse_tool_result_as(await self.call_tool_mcp(tool_name, args), ActionKey)
+        action = parse_tool_result_as(await self.call_tool_mcp(tool_name, args), Action)
+        return action.key
+
+    async def call_gate_tool_full(self, tool_name: str, args: dict[str, object]) -> Action:
+        """Call a gate-wrapped tool and return the full Action."""
+        return parse_tool_result_as(await self.call_tool_mcp(tool_name, args), Action)
 
     async def call_echo(self, text: str, *, justification: str = "test", session_key: str) -> ActionKey:
         return await self.call_gate_tool(
             "test_echo", {"input": {"text": text}, "justification": justification, "session_key": session_key}
         )
+
+    async def call_echo_full(
+        self, text: str, *, justification: str = "test", session_key: str, approval_timeout_seconds: float | None = None
+    ) -> Action:
+        """Call test_echo and return the full Action (with state)."""
+        args: dict[str, object] = {"input": {"text": text}, "justification": justification, "session_key": session_key}
+        if approval_timeout_seconds is not None:
+            args["approval_timeout_seconds"] = approval_timeout_seconds
+        return await self.call_gate_tool_full("test_echo", args)
 
     async def approve(self, key: ActionKey) -> Action:
         return parse_tool_result_as(await self.call_tool_mcp("approve_action", {"key": key.model_dump()}), Action)
@@ -181,13 +195,17 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
     """
 
     def _factory(
-        backends: Mapping[MCPMountPrefix, MCPServerTypes | FastMCP], *, predicate: PredicateFn | None = None
+        backends: Mapping[MCPMountPrefix, MCPServerTypes | FastMCP],
+        *,
+        predicate: PredicateFn | None = None,
+        approval_timeout_seconds: float | None = None,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),
             db_path=tmp_path / "gate.db",
             predicate=predicate or (lambda ns, tool, args: NeedsHumanDecision()),
             public_base_url="http://test",
+            approval_timeout_seconds=approval_timeout_seconds,
             auth=JWTVerifier(public_key=rsa_key_pair.public_key),
         )
 

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -22,7 +22,7 @@ from pydantic import AnyUrl
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
-from approval_gate.models import Action, ActionKey, ActionStatus
+from approval_gate.models import Action, ActionKey, ActionStatus, WaitMode
 from approval_gate.predicates import NeedsHumanDecision, PredicateFn
 from approval_gate.proxy_server import DECIDE_SCOPE, PROPOSE_SCOPE, READ_SCOPE, ApprovalGateServer
 from approval_gate.storage import ActionStorage
@@ -92,25 +92,18 @@ class GateClient(Client, MessageHandler):
         if evt is not None:
             evt.set()
 
-    async def call_gate_tool_full(self, tool_name: str, args: dict[str, object]) -> Action:
-        """Call a gate-wrapped tool and return the full Action."""
+    async def call_gate_tool(self, tool_name: str, args: dict[str, object]) -> Action:
+        """Call a gate-wrapped tool and return the Action."""
         return parse_tool_result_as(await self.call_tool_mcp(tool_name, args), Action)
 
-    async def call_gate_tool(self, tool_name: str, args: dict[str, object]) -> ActionKey:
-        """Call a gate-wrapped tool and parse the ActionKey from the result."""
-        return (await self.call_gate_tool_full(tool_name, args)).key
-
-    async def call_echo_full(
+    async def call_echo(
         self, text: str, *, justification: str = "test", session_key: str, wait_mode: dict[str, object] | None = None
     ) -> Action:
-        """Call test_echo and return the full Action (with state)."""
+        """Call test_echo and return the Action."""
         args: dict[str, object] = {"input": {"text": text}, "justification": justification, "session_key": session_key}
         if wait_mode is not None:
             args["wait_mode"] = wait_mode
-        return await self.call_gate_tool_full("test_echo", args)
-
-    async def call_echo(self, text: str, *, justification: str = "test", session_key: str) -> ActionKey:
-        return (await self.call_echo_full(text, justification=justification, session_key=session_key)).key
+        return await self.call_gate_tool("test_echo", args)
 
     async def approve(self, key: ActionKey) -> Action:
         return parse_tool_result_as(await self.call_tool_mcp("approve_action", {"key": key.model_dump()}), Action)
@@ -157,6 +150,21 @@ def free_port() -> int:
 
 
 @pytest.fixture
+def base_url(free_port: int) -> str:
+    return f"http://127.0.0.1:{free_port}"
+
+
+@pytest.fixture
+def agent_client_transport(base_url: str, agent_jwt: str):
+    return agent_transport(base_url, agent_jwt)
+
+
+@pytest.fixture
+def operator_client_transport(base_url: str, operator_jwt: str):
+    return operator_transport(base_url, operator_jwt)
+
+
+@pytest.fixture
 def rsa_key_pair():
     return RSAKeyPair.generate()
 
@@ -181,6 +189,24 @@ async def storage(tmp_path: Path) -> AsyncGenerator[ActionStorage]:
         await store.close()
 
 
+class EchoBackend:
+    """A simple echo backend for testing, tracking calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.server = FastMCP()
+
+        @self.server.tool()
+        async def echo(text: str) -> str:
+            self.calls.append(text)
+            return f"echoed: {text}"
+
+
+@pytest.fixture
+def echo_backend() -> EchoBackend:
+    return EchoBackend()
+
+
 GateServerFactory = Callable[..., ApprovalGateServer]
 
 
@@ -195,14 +221,14 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
         backends: Mapping[MCPMountPrefix, MCPServerTypes | FastMCP],
         *,
         predicate: PredicateFn | None = None,
-        default_approval_timeout_seconds: float | None = None,
+        default_wait_mode: WaitMode | None = None,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),
             db_path=tmp_path / "gate.db",
             predicate=predicate or (lambda ns, tool, args: NeedsHumanDecision()),
             public_base_url="http://test",
-            default_approval_timeout_seconds=default_approval_timeout_seconds,
+            default_wait_mode=default_wait_mode,
             auth=JWTVerifier(public_key=rsa_key_pair.public_key),
         )
 
@@ -226,3 +252,14 @@ def make_gate_app(make_gate_server: GateServerFactory) -> GateAppFactory:
         return gate_http_app(make_gate_server(backends, **kwargs))
 
     return _factory
+
+
+@pytest.fixture
+def echo_gate_app(make_gate_app: GateAppFactory, echo_backend: EchoBackend) -> Starlette:
+    """Gate app with a single echo backend under TEST_NS."""
+    return make_gate_app({TEST_NS: echo_backend.server})
+
+
+@pytest.fixture
+def session_key() -> str:
+    return "test-session"

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -210,7 +210,6 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
         *,
         predicate: PredicateFn | None = None,
         approval_timeout_seconds: float | None = None,
-        execution_running_notice_seconds: float = 10.0,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),
@@ -218,7 +217,6 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
             predicate=predicate or (lambda ns, tool, args: NeedsHumanDecision()),
             public_base_url="http://test",
             approval_timeout_seconds=approval_timeout_seconds,
-            execution_running_notice_seconds=execution_running_notice_seconds,
             auth=JWTVerifier(public_key=rsa_key_pair.public_key),
         )
 

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -92,19 +92,13 @@ class GateClient(Client, MessageHandler):
         if evt is not None:
             evt.set()
 
-    async def call_gate_tool(self, tool_name: str, args: dict[str, object]) -> ActionKey:
-        """Call a gate-wrapped tool and parse the ActionKey from the result."""
-        action = parse_tool_result_as(await self.call_tool_mcp(tool_name, args), Action)
-        return action.key
-
     async def call_gate_tool_full(self, tool_name: str, args: dict[str, object]) -> Action:
         """Call a gate-wrapped tool and return the full Action."""
         return parse_tool_result_as(await self.call_tool_mcp(tool_name, args), Action)
 
-    async def call_echo(self, text: str, *, justification: str = "test", session_key: str) -> ActionKey:
-        return await self.call_gate_tool(
-            "test_echo", {"input": {"text": text}, "justification": justification, "session_key": session_key}
-        )
+    async def call_gate_tool(self, tool_name: str, args: dict[str, object]) -> ActionKey:
+        """Call a gate-wrapped tool and parse the ActionKey from the result."""
+        return (await self.call_gate_tool_full(tool_name, args)).key
 
     async def call_echo_full(
         self, text: str, *, justification: str = "test", session_key: str, wait_mode: dict[str, object] | None = None
@@ -114,6 +108,9 @@ class GateClient(Client, MessageHandler):
         if wait_mode is not None:
             args["wait_mode"] = wait_mode
         return await self.call_gate_tool_full("test_echo", args)
+
+    async def call_echo(self, text: str, *, justification: str = "test", session_key: str) -> ActionKey:
+        return (await self.call_echo_full(text, justification=justification, session_key=session_key)).key
 
     async def approve(self, key: ActionKey) -> Action:
         return parse_tool_result_as(await self.call_tool_mcp("approve_action", {"key": key.model_dump()}), Action)
@@ -198,14 +195,14 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
         backends: Mapping[MCPMountPrefix, MCPServerTypes | FastMCP],
         *,
         predicate: PredicateFn | None = None,
-        approval_timeout_seconds: float | None = None,
+        default_approval_timeout_seconds: float | None = None,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),
             db_path=tmp_path / "gate.db",
             predicate=predicate or (lambda ns, tool, args: NeedsHumanDecision()),
             public_base_url="http://test",
-            approval_timeout_seconds=approval_timeout_seconds,
+            default_approval_timeout_seconds=default_approval_timeout_seconds,
             auth=JWTVerifier(public_key=rsa_key_pair.public_key),
         )
 

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -107,12 +107,23 @@ class GateClient(Client, MessageHandler):
         )
 
     async def call_echo_full(
-        self, text: str, *, justification: str = "test", session_key: str, approval_timeout_seconds: float | None = None
+        self,
+        text: str,
+        *,
+        justification: str = "test",
+        session_key: str,
+        approval_timeout_seconds: float | None = None,
+        background: bool | None = None,
+        yield_ms: float | None = None,
     ) -> Action:
         """Call test_echo and return the full Action (with state)."""
         args: dict[str, object] = {"input": {"text": text}, "justification": justification, "session_key": session_key}
         if approval_timeout_seconds is not None:
             args["approval_timeout_seconds"] = approval_timeout_seconds
+        if background is not None:
+            args["background"] = background
+        if yield_ms is not None:
+            args["yield_ms"] = yield_ms
         return await self.call_gate_tool_full("test_echo", args)
 
     async def approve(self, key: ActionKey) -> Action:
@@ -199,6 +210,7 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
         *,
         predicate: PredicateFn | None = None,
         approval_timeout_seconds: float | None = None,
+        execution_running_notice_seconds: float = 10.0,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),
@@ -206,6 +218,7 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
             predicate=predicate or (lambda ns, tool, args: NeedsHumanDecision()),
             public_base_url="http://test",
             approval_timeout_seconds=approval_timeout_seconds,
+            execution_running_notice_seconds=execution_running_notice_seconds,
             auth=JWTVerifier(public_key=rsa_key_pair.public_key),
         )
 

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -107,23 +107,12 @@ class GateClient(Client, MessageHandler):
         )
 
     async def call_echo_full(
-        self,
-        text: str,
-        *,
-        justification: str = "test",
-        session_key: str,
-        approval_timeout_seconds: float | None = None,
-        background: bool | None = None,
-        yield_ms: float | None = None,
+        self, text: str, *, justification: str = "test", session_key: str, wait_mode: dict[str, object] | None = None
     ) -> Action:
         """Call test_echo and return the full Action (with state)."""
         args: dict[str, object] = {"input": {"text": text}, "justification": justification, "session_key": session_key}
-        if approval_timeout_seconds is not None:
-            args["approval_timeout_seconds"] = approval_timeout_seconds
-        if background is not None:
-            args["background"] = background
-        if yield_ms is not None:
-            args["yield_ms"] = yield_ms
+        if wait_mode is not None:
+            args["wait_mode"] = wait_mode
         return await self.call_gate_tool_full("test_echo", args)
 
     async def approve(self, key: ActionKey) -> Action:

--- a/approval_gate/conftest.py
+++ b/approval_gate/conftest.py
@@ -24,7 +24,7 @@ from starlette.routing import Mount
 
 from approval_gate.models import Action, ActionKey, ActionStatus, WaitMode
 from approval_gate.predicates import NeedsHumanDecision, PredicateFn
-from approval_gate.proxy_server import DECIDE_SCOPE, PROPOSE_SCOPE, READ_SCOPE, ApprovalGateServer
+from approval_gate.proxy_server import _DEFAULT_WAIT_MODE, DECIDE_SCOPE, PROPOSE_SCOPE, READ_SCOPE, ApprovalGateServer
 from approval_gate.storage import ActionStorage
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.resource_utils import read_text_json_typed
@@ -221,7 +221,7 @@ def make_gate_server(rsa_key_pair: RSAKeyPair, tmp_path: Path) -> GateServerFact
         backends: Mapping[MCPMountPrefix, MCPServerTypes | FastMCP],
         *,
         predicate: PredicateFn | None = None,
-        default_wait_mode: WaitMode | None = None,
+        default_wait_mode: WaitMode = _DEFAULT_WAIT_MODE,
     ) -> ApprovalGateServer:
         return ApprovalGateServer(
             backends=dict(backends),

--- a/approval_gate/instructions.mako
+++ b/approval_gate/instructions.mako
@@ -13,15 +13,21 @@ exposes a tool called `run_command`, it appears here as `exec_run_command`.
 
 ## How it works
 
-When you call any tool here, the call is **queued for operator approval** and returns
-immediately with an `ActionKey` (`session_key` + `action_seq`). Your call is **not executed yet**.
+When you call any tool here, the call is **queued for operator approval**. The tool returns
+a full `Action` JSON object whose `state.status` tells you what happened:
 
-Share the approval URL `${public_base_url}/sessions/<session_key>/actions/<action_seq>`
-with the user so they can approve or reject the action.
+- `done` — action was approved and executed; result in `state.outcome`
+- `rejected` — action was denied; reason in `state.reason`
+- `pending` — still waiting for operator approval
+- `executing` — approved, backend call in flight
 
-Once the operator approves it, the call is forwarded to the correct backend server and the
-result is recorded. If the OpenClaw plugin is active, the outcome will be **injected
-into your session** automatically; otherwise, poll or subscribe to the session log HWM.
+If the action is already terminal (`done` or `rejected`), you have the result immediately.
+If it is `pending` or `executing`, the outcome will be **delivered later** via system
+notification (if the OpenClaw plugin is active) or you can poll the action resource.
+
+For `pending` actions, share the approval URL
+`${public_base_url}/sessions/<session_key>/actions/<action_seq>` with the user so they
+can approve or reject it.
 
 ## Tool schema additions
 
@@ -33,16 +39,27 @@ Every wrapped tool accepts:
   This is shown to the operator to help them decide. Be specific.
 - `session_key` (required `string`): Your session key for result notifications.
   This is injected automatically by the OpenClaw plugin — do not set it manually.
+- `approval_timeout_seconds` (optional `number`): Seconds to wait for the action to
+  resolve before returning. If the action completes within this time (via auto-approval
+  policy or fast operator decision), you get the result immediately. Omit to use the
+  server default (which may be no wait).
 
-Example call shape: `{ "input": { ...backend args... }, "justification": "...", "session_key": "..." }`
+Example call shape: `{ "input": { ...backend args... }, "justification": "...", "session_key": "...", "approval_timeout_seconds": 30 }`
 
 ## Response format
 
-Every tool call returns immediately with an `ActionKey` JSON object:
-`{ "session_key": "...", "action_seq": 1 }`
+Every tool call returns a full `Action` JSON object:
+`{ "key": { "session_key": "...", "action_seq": 1 }, "state": { "status": "..." }, ... }`
 
-Actions may be auto-decided by a server-side policy. If auto-denied, the action will
-appear as `rejected` when you read its resource — there is no separate error path.
+Check `state.status` to determine the outcome:
+- `done`: `state.outcome.content` holds the backend result; `state.outcome.isError`
+  indicates whether the backend reported an error.
+- `rejected`: `state.reason` contains the denial reason (if provided).
+- `pending`: Awaiting operator decision. The outcome will arrive via notification.
+- `executing`: Approved; backend call in flight. The outcome will arrive via notification.
+
+Actions may be auto-decided by a server-side policy. With `approval_timeout_seconds`,
+auto-decided actions resolve within the tool call itself.
 
 ## Withdrawing an action
 
@@ -52,13 +69,8 @@ operator decides it. Only works on actions in `pending` state.
 ## Checking action status
 
 Read the action resource `resource://sessions/{session_key}/actions/{action_seq}` to
-get the current state.
-
-The resource returns the full `Action` JSON including `state.status` which is one of:
-`pending`, `executing`, `done`, `rejected`, `withdrawn`.
-
-For `done` actions, `state.outcome.content` holds the backend result and
-`state.outcome.isError` indicates whether the backend reported an error.
+get the current state. This is useful for `pending` or `executing` actions where the
+tool call returned before resolution.
 
 ## Session event log
 

--- a/approval_gate/instructions.mako
+++ b/approval_gate/instructions.mako
@@ -39,12 +39,14 @@ Every wrapped tool accepts:
   This is shown to the operator to help them decide. Be specific.
 - `session_key` (required `string`): Your session key for result notifications.
   This is injected automatically by the OpenClaw plugin — do not set it manually.
-- `approval_timeout_seconds` (optional `number`): Seconds to wait for the action to
-  resolve before returning. If the action completes within this time (via auto-approval
-  policy or fast operator decision), you get the result immediately. Omit to use the
-  server default (which may be no wait).
+- `wait_mode` (optional `object`): How long to wait for action resolution before
+  returning. Two variants:
+  - `{ "mode": "blocking" }` — wait indefinitely until terminal resolution.
+  - `{ "mode": "yield_after_ms", "timeout_ms": 5000 }` — wait up to N ms then return
+    current state.
+  Omit to use the server default (which may be no wait).
 
-Example call shape: `{ "input": { ...backend args... }, "justification": "...", "session_key": "...", "approval_timeout_seconds": 30 }`
+Example call shape: `{ "input": { ...backend args... }, "justification": "...", "session_key": "...", "wait_mode": { "mode": "yield_after_ms", "timeout_ms": 5000 } }`
 
 ## Response format
 
@@ -58,8 +60,8 @@ Check `state.status` to determine the outcome:
 - `pending`: Awaiting operator decision. The outcome will arrive via notification.
 - `executing`: Approved; backend call in flight. The outcome will arrive via notification.
 
-Actions may be auto-decided by a server-side policy. With `approval_timeout_seconds`,
-auto-decided actions resolve within the tool call itself.
+Actions may be auto-decided by a server-side policy. With `wait_mode`, auto-decided
+actions resolve within the tool call itself.
 
 ## Withdrawing an action
 

--- a/approval_gate/instructions.mako
+++ b/approval_gate/instructions.mako
@@ -13,77 +13,15 @@ exposes a tool called `run_command`, it appears here as `exec_run_command`.
 
 ## How it works
 
-When you call any tool here, the call is **queued for operator approval**. The tool returns
-a full `Action` JSON object whose `state.status` tells you what happened:
+When you call any tool here, the call is **queued for operator approval**. The tool
+returns an `Action` JSON object — check `state.status` for the outcome.
 
-- `done` — action was approved and executed; result in `state.outcome`
-- `rejected` — action was denied; reason in `state.reason`
-- `pending` — still waiting for operator approval
-- `executing` — approved, backend call in flight
-
-If the action is already terminal (`done` or `rejected`), you have the result immediately.
-If it is `pending` or `executing`, the outcome will be **delivered later** via system
-notification (if the OpenClaw plugin is active) or you can poll the action resource.
+If the action is terminal (`done` or `rejected`), you have the result immediately.
+If `pending` or `executing`, the outcome will arrive via system notification (if the
+OpenClaw plugin is active) or you can poll the action resource.
 
 For `pending` actions, share the approval URL
-`${public_base_url}/sessions/<session_key>/actions/<action_seq>` with the user so they
-can approve or reject it.
-
-## Tool schema additions
-
-Every wrapped tool accepts:
-
-- `input` (required `object`): The backend tool's original arguments, nested as-is
-  under this key to avoid collisions with the approval fields.
-- `justification` (required `string`): Explain **why** you want to run this action.
-  This is shown to the operator to help them decide. Be specific.
-- `session_key` (required `string`): Your session key for result notifications.
-  This is injected automatically by the OpenClaw plugin — do not set it manually.
-- `wait_mode` (optional `object`): How long to wait for action resolution before
-  returning. Two variants:
-  - `{ "mode": "blocking" }` — wait indefinitely until terminal resolution.
-  - `{ "mode": "yield_after_ms", "timeout_ms": 5000 }` — wait up to N ms then return
-    current state.
-  Omit to use the server default (which may be no wait).
-
-Example call shape: `{ "input": { ...backend args... }, "justification": "...", "session_key": "...", "wait_mode": { "mode": "yield_after_ms", "timeout_ms": 5000 } }`
-
-## Response format
-
-Every tool call returns a full `Action` JSON object:
-`{ "key": { "session_key": "...", "action_seq": 1 }, "state": { "status": "..." }, ... }`
-
-Check `state.status` to determine the outcome:
-- `done`: `state.outcome.content` holds the backend result; `state.outcome.isError`
-  indicates whether the backend reported an error.
-- `rejected`: `state.reason` contains the denial reason (if provided).
-- `pending`: Awaiting operator decision. The outcome will arrive via notification.
-- `executing`: Approved; backend call in flight. The outcome will arrive via notification.
-
-Actions may be auto-decided by a server-side policy. With `wait_mode`, auto-decided
-actions resolve within the tool call itself.
-
-## Withdrawing an action
-
-Call `withdraw_action(session_key, action_seq)` to cancel a pending action before an
-operator decides it. Only works on actions in `pending` state.
-
-## Checking action status
-
-Read the action resource `resource://sessions/{session_key}/actions/{action_seq}` to
-get the current state. This is useful for `pending` or `executing` actions where the
-tool call returned before resolution.
-
-## Session event log
-
-Each session has an append-only event log. Subscribe to the log high-water mark (HWM)
-resource for a session to be notified of any state changes:
-
-- `resource://sessions/{session_key}/log_hwm` — returns the entry_id of the last log entry
-- `resource://sessions/{session_key}/log/{entry_id}` — returns a specific log entry
-
-Log event kinds: `action_received`, `approved`, `denied`, `withdrawn`,
-`execution_started`, `execution_finished`.
+`${public_base_url}/sessions/<session_key>/actions/<action_seq>` with the user.
 % if backend_instructions:
 
 ---

--- a/approval_gate/models.py
+++ b/approval_gate/models.py
@@ -126,6 +126,7 @@ class LogEventKind(StrEnum):
     DENIED = "denied"
     WITHDRAWN = "withdrawn"
     EXECUTION_STARTED = "execution_started"
+    EXECUTION_RUNNING = "execution_running"
     EXECUTION_FINISHED = "execution_finished"
 
 
@@ -150,6 +151,14 @@ class ExecutionStartedDetail(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ExecutionRunningDetail(BaseModel):
+    """Emitted when a backend call has been running longer than the configured notice threshold."""
+
+    kind: Literal[LogEventKind.EXECUTION_RUNNING] = LogEventKind.EXECUTION_RUNNING
+    elapsed_seconds: float
+    model_config = ConfigDict(extra="forbid")
+
+
 class ExecutionFinishedDetail(BaseModel):
     kind: Literal[LogEventKind.EXECUTION_FINISHED] = LogEventKind.EXECUTION_FINISHED
     outcome: mcp_types.CallToolResult
@@ -157,7 +166,12 @@ class ExecutionFinishedDetail(BaseModel):
 
 
 LogEventDetail = Annotated[
-    ActionReceivedDetail | DeniedDetail | WithdrawnDetail | ExecutionStartedDetail | ExecutionFinishedDetail,
+    ActionReceivedDetail
+    | DeniedDetail
+    | WithdrawnDetail
+    | ExecutionStartedDetail
+    | ExecutionRunningDetail
+    | ExecutionFinishedDetail,
     Field(discriminator="kind"),
 ]
 

--- a/approval_gate/models.py
+++ b/approval_gate/models.py
@@ -155,7 +155,7 @@ class ExecutionRunningDetail(BaseModel):
     """Emitted when a backend call has been running longer than the configured notice threshold."""
 
     kind: Literal[LogEventKind.EXECUTION_RUNNING] = LogEventKind.EXECUTION_RUNNING
-    elapsed_seconds: float
+    started_at: datetime
     model_config = ConfigDict(extra="forbid")
 
 

--- a/approval_gate/models.py
+++ b/approval_gate/models.py
@@ -196,3 +196,26 @@ class DenyDecision(BaseModel):
 
 
 OperatorDecision = Annotated[ApproveDecision | DenyDecision, Field(discriminator="kind")]
+
+
+# ── Wait mode for tool calls ──────────────────────────────────────────────
+
+
+class BlockingWait(BaseModel):
+    """Wait indefinitely until terminal resolution."""
+
+    mode: Literal["blocking"] = "blocking"
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class YieldAfterMs(BaseModel):
+    """Wait up to timeout_ms then return current state."""
+
+    mode: Literal["yield_after_ms"] = "yield_after_ms"
+    timeout_ms: float
+
+    model_config = ConfigDict(extra="forbid")
+
+
+WaitMode = Annotated[BlockingWait | YieldAfterMs, Field(discriminator="mode")]

--- a/approval_gate/models.py
+++ b/approval_gate/models.py
@@ -126,7 +126,6 @@ class LogEventKind(StrEnum):
     DENIED = "denied"
     WITHDRAWN = "withdrawn"
     EXECUTION_STARTED = "execution_started"
-    EXECUTION_RUNNING = "execution_running"
     EXECUTION_FINISHED = "execution_finished"
 
 
@@ -148,13 +147,6 @@ class WithdrawnDetail(BaseModel):
 
 class ExecutionStartedDetail(BaseModel):
     kind: Literal[LogEventKind.EXECUTION_STARTED] = LogEventKind.EXECUTION_STARTED
-    model_config = ConfigDict(extra="forbid")
-
-
-class ExecutionRunningDetail(BaseModel):
-    """Emitted when a backend call has been running longer than the configured notice threshold."""
-
-    kind: Literal[LogEventKind.EXECUTION_RUNNING] = LogEventKind.EXECUTION_RUNNING
     started_at: datetime
     model_config = ConfigDict(extra="forbid")
 
@@ -166,12 +158,7 @@ class ExecutionFinishedDetail(BaseModel):
 
 
 LogEventDetail = Annotated[
-    ActionReceivedDetail
-    | DeniedDetail
-    | WithdrawnDetail
-    | ExecutionStartedDetail
-    | ExecutionRunningDetail
-    | ExecutionFinishedDetail,
+    ActionReceivedDetail | DeniedDetail | WithdrawnDetail | ExecutionStartedDetail | ExecutionFinishedDetail,
     Field(discriminator="kind"),
 ]
 

--- a/approval_gate/predicates.py
+++ b/approval_gate/predicates.py
@@ -61,26 +61,19 @@ def _always_needs_human(server_namespace: str, tool_name: str, arguments: dict) 
     return NeedsHumanDecision()
 
 
-def load_predicate(path: Path | None) -> PredicateFn:
+def load_predicate(path: Path) -> PredicateFn:
     """Load a predicate function from a Python file.
 
-    Returns the fail-safe (always NeedsHumanDecision) if path is None or loading fails.
+    The file must export a `decide` function matching PredicateFn.
     """
-    if path is None:
-        return _always_needs_human
-
-    try:
-        spec = importlib.util.spec_from_file_location("_approval_predicate", path)
-        if spec is None or spec.loader is None:
-            raise ImportError(f"cannot load spec from {path}")
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        fn: PredicateFn = module.decide
-        logger.info("loaded predicate from %s", path)
-        return fn
-    except Exception:
-        logger.exception("failed to load predicate from %s; defaulting to NeedsHumanDecision", path)
-        return _always_needs_human
+    spec = importlib.util.spec_from_file_location("_approval_predicate", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load module spec from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    fn: PredicateFn = module.decide
+    logger.info("loaded predicate from %s", path)
+    return fn
 
 
 def call_predicate(fn: PredicateFn, server_namespace: str, tool_name: str, arguments: dict) -> PredicateDecision:

--- a/approval_gate/predicates.py
+++ b/approval_gate/predicates.py
@@ -57,10 +57,6 @@ class PredicateFn(Protocol):
 # ── Loader ────────────────────────────────────────────────────────────────────
 
 
-def _always_needs_human(server_namespace: str, tool_name: str, arguments: dict) -> PredicateDecision:
-    return NeedsHumanDecision()
-
-
 def load_predicate(path: Path) -> PredicateFn:
     """Load a predicate function from a Python file.
 

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -94,6 +94,13 @@ def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
                 "type": "string",
                 "description": "Session key for result notifications. Injected by plugin.",
             },
+            "approval_timeout_seconds": {
+                "type": "number",
+                "description": (
+                    "Seconds to wait for action resolution before returning. "
+                    "Overrides server default. Omit to use server default."
+                ),
+            },
         },
         "required": ["input", "justification", "session_key"],
     }
@@ -109,6 +116,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         db_path: Path,
         predicate: PredicateFn,
         public_base_url: str,
+        approval_timeout_seconds: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -119,9 +127,11 @@ class ApprovalGateServer(EnhancedFastMCP):
         self._storage: ActionStorage | None = None
         self._predicate = predicate
         self._public_base_url = public_base_url
+        self._approval_timeout_seconds = approval_timeout_seconds
         self._backend_clients: dict[MCPMountPrefix, Client] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._subscriptions: defaultdict[ServerSession, set[str]] = defaultdict(set)
+        self._action_resolved_events: dict[ActionKey, asyncio.Event] = {}
 
     # ── Lifespan ──────────────────────────────────────────────────────────────
 
@@ -251,7 +261,8 @@ class ApprovalGateServer(EnhancedFastMCP):
             justification: str,
             session_key: str,
             input: dict[str, object] = {},  # noqa: B006
-        ) -> ActionKey:
+            approval_timeout_seconds: float | None = None,
+        ) -> Action:
             call = ToolCall(server_namespace=namespace, tool_name=tool_name, arguments=input)
             action = await self._req_storage.create_action(
                 session_key=session_key, call=call, justification=justification
@@ -259,8 +270,36 @@ class ApprovalGateServer(EnhancedFastMCP):
             key = action.key
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
+
+            effective_timeout = (
+                approval_timeout_seconds if approval_timeout_seconds is not None else self._approval_timeout_seconds
+            )
+
+            if effective_timeout is not None and effective_timeout > 0:
+                event = asyncio.Event()
+                self._action_resolved_events[key] = event
+            else:
+                event = None
+
             self._spawn(self._apply_predicate(key, namespace, tool_name, input))
-            return key
+
+            if event is not None:
+                with anyio.move_on_after(effective_timeout):
+                    while True:
+                        await event.wait()
+                        current = await self._req_storage.get_action(key)
+                        if current is not None and isinstance(
+                            current.state, (DoneState, RejectedState, WithdrawnState)
+                        ):
+                            break
+                        # Intermediate transition (e.g. PENDING → EXECUTING); reset and wait again
+                        event = asyncio.Event()
+                        self._action_resolved_events[key] = event
+                self._action_resolved_events.pop(key, None)
+
+            result = await self._req_storage.get_action(key)
+            assert result is not None
+            return result
 
         tool = FunctionTool(
             fn=_tool_handler,
@@ -360,4 +399,9 @@ class ApprovalGateServer(EnhancedFastMCP):
         action, _ = await self._req_storage.update_state_and_log(key, new_state, detail)
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/actions/{key.action_seq}")
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/log_hwm")
+        # Signal any waiter for this action on non-pending transitions
+        if not isinstance(new_state, PendingState):
+            event = self._action_resolved_events.get(key)
+            if event is not None:
+                event.set()
         return action

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -48,6 +48,7 @@ from approval_gate.models import (
     DoneState,
     ExecutingState,
     ExecutionFinishedDetail,
+    ExecutionRunningDetail,
     ExecutionStartedDetail,
     LogEventDetail,
     OperatorDecision,
@@ -101,9 +102,43 @@ def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
                     "Overrides server default. Omit to use server default."
                 ),
             },
+            "background": {
+                "type": "boolean",
+                "description": (
+                    "If true, return immediately without waiting for resolution "
+                    "(equivalent to approval_timeout_seconds=0)."
+                ),
+            },
+            "yield_ms": {
+                "type": "number",
+                "description": (
+                    "Milliseconds to wait for resolution before returning. "
+                    "Converted to seconds internally. Overrides approval_timeout_seconds."
+                ),
+            },
         },
         "required": ["input", "justification", "session_key"],
     }
+
+
+def _resolve_effective_timeout(
+    *, background: bool, yield_ms: float | None, approval_timeout_seconds: float | None, server_default: float | None
+) -> float | None:
+    """Resolve the effective wait timeout from the priority chain.
+
+    Priority (highest first):
+      1. background=True → 0 (return immediately)
+      2. yield_ms → converted to seconds
+      3. approval_timeout_seconds (per-call override)
+      4. server_default
+    """
+    if background:
+        return 0
+    if yield_ms is not None:
+        return max(0, yield_ms / 1000)
+    if approval_timeout_seconds is not None:
+        return approval_timeout_seconds
+    return server_default
 
 
 class ApprovalGateServer(EnhancedFastMCP):
@@ -117,6 +152,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         predicate: PredicateFn,
         public_base_url: str,
         approval_timeout_seconds: float | None = None,
+        execution_running_notice_seconds: float = 10.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -128,6 +164,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         self._predicate = predicate
         self._public_base_url = public_base_url
         self._approval_timeout_seconds = approval_timeout_seconds
+        self._execution_running_notice_seconds = execution_running_notice_seconds
         self._backend_clients: dict[MCPMountPrefix, Client] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._subscriptions: defaultdict[ServerSession, set[str]] = defaultdict(set)
@@ -262,6 +299,8 @@ class ApprovalGateServer(EnhancedFastMCP):
             session_key: str,
             input: dict[str, object] = {},  # noqa: B006
             approval_timeout_seconds: float | None = None,
+            background: bool = False,
+            yield_ms: float | None = None,
         ) -> Action:
             call = ToolCall(server_namespace=namespace, tool_name=tool_name, arguments=input)
             action = await self._req_storage.create_action(
@@ -271,8 +310,11 @@ class ApprovalGateServer(EnhancedFastMCP):
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
 
-            effective_timeout = (
-                approval_timeout_seconds if approval_timeout_seconds is not None else self._approval_timeout_seconds
+            effective_timeout = _resolve_effective_timeout(
+                background=background,
+                yield_ms=yield_ms,
+                approval_timeout_seconds=approval_timeout_seconds,
+                server_default=self._approval_timeout_seconds,
             )
 
             if effective_timeout is not None and effective_timeout > 0:
@@ -380,12 +422,40 @@ class ApprovalGateServer(EnhancedFastMCP):
         return await self._update_and_notify(key, WithdrawnState(), WithdrawnDetail())
 
     async def _execute_and_finish(self, key: ActionKey, action: Action) -> None:
-        """Execute the backend call and update state to done."""
+        """Execute the backend call and update state to done.
+
+        If the call takes longer than ``_execution_running_notice_seconds``,
+        emits an ``execution_running`` log event so subscribers know the action
+        is still in flight.
+        """
         namespace = MCPMountPrefix(action.call.server_namespace)
         client = self._backend_clients.get(namespace)
         if client is None:
             raise RuntimeError(f"backend client not connected for namespace: {namespace!r}")
-        outcome = await client.call_tool_mcp(action.call.tool_name, action.call.arguments)
+
+        notice_delay = self._execution_running_notice_seconds
+        finished = False
+        start_time = asyncio.get_event_loop().time()
+
+        async def _running_notice() -> None:
+            await asyncio.sleep(notice_delay)
+            if finished:
+                return
+            elapsed = asyncio.get_event_loop().time() - start_time
+            await self._append_log_and_notify(key, ExecutionRunningDetail(elapsed_seconds=round(elapsed, 1)))
+            logger.info("action %s/%d still executing after %.1fs", key.session_key, key.action_seq, elapsed)
+
+        notice_task: asyncio.Task[None] | None = None
+        if notice_delay > 0:
+            notice_task = asyncio.create_task(_running_notice())
+
+        try:
+            outcome = await client.call_tool_mcp(action.call.tool_name, action.call.arguments)
+        finally:
+            finished = True
+            if notice_task is not None:
+                notice_task.cancel()
+
         await self._update_and_notify(key, DoneState(outcome=outcome), ExecutionFinishedDetail(outcome=outcome))
 
     def _spawn(self, coro: Coroutine[Any, Any, Any]) -> None:

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -79,6 +79,7 @@ _INSTRUCTIONS_TEMPLATE = Path(__file__).parent / "instructions.mako"
 
 
 _WAIT_MODE_SCHEMA: dict[str, Any] = TypeAdapter(WaitMode).json_schema()
+_DEFAULT_WAIT_MODE = YieldAfterMs(timeout_ms=0)
 
 
 def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
@@ -108,18 +109,11 @@ def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _resolve_effective_wait(wait_mode: WaitMode | None, server_default: WaitMode | None) -> WaitMode | None:
-    """Resolve effective wait mode from per-call override or server default."""
-    return wait_mode if wait_mode is not None else server_default
-
-
-def _wait_mode_to_timeout(wait_mode: WaitMode | None) -> float | None:
+def _wait_mode_to_timeout(wait_mode: WaitMode) -> float:
     """Convert a WaitMode to a timeout in seconds.
 
-    Returns None = no wait, float('inf') = wait forever, N = bounded.
+    Returns float('inf') = wait forever, N = bounded (0 = immediate).
     """
-    if wait_mode is None:
-        return None
     match wait_mode:
         case BlockingWait():
             return float("inf")
@@ -137,7 +131,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         db_path: Path,
         predicate: PredicateFn,
         public_base_url: str,
-        default_wait_mode: WaitMode | None = None,
+        default_wait_mode: WaitMode = _DEFAULT_WAIT_MODE,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -292,9 +286,10 @@ class ApprovalGateServer(EnhancedFastMCP):
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
 
-            effective_timeout = _wait_mode_to_timeout(_resolve_effective_wait(wait_mode, self._default_wait_mode))
+            effective = wait_mode if wait_mode is not None else self._default_wait_mode
+            effective_timeout = _wait_mode_to_timeout(effective)
 
-            if effective_timeout is not None and effective_timeout > 0:
+            if effective_timeout > 0:
                 event = asyncio.Event()
                 self._action_resolved_events[key] = event
             else:

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -121,13 +121,13 @@ def _resolve_effective_timeout(wait_mode: WaitMode | None, server_default: float
 
     Returns seconds to wait: None = no wait, float('inf') = wait forever, N = bounded.
     """
-    if wait_mode is not None:
-        match wait_mode:
-            case BlockingWait():
-                return float("inf")
-            case YieldAfterMs(timeout_ms=ms):
-                return max(0, ms / 1000)
-    return server_default
+    if wait_mode is None:
+        return server_default
+    match wait_mode:
+        case BlockingWait():
+            return float("inf")
+        case YieldAfterMs(timeout_ms=ms):
+            return max(0, ms / 1000)
 
 
 class ApprovalGateServer(EnhancedFastMCP):
@@ -140,7 +140,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         db_path: Path,
         predicate: PredicateFn,
         public_base_url: str,
-        approval_timeout_seconds: float | None = None,
+        default_approval_timeout_seconds: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -151,7 +151,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         self._storage: ActionStorage | None = None
         self._predicate = predicate
         self._public_base_url = public_base_url
-        self._approval_timeout_seconds = approval_timeout_seconds
+        self._default_approval_timeout_seconds = default_approval_timeout_seconds
         self._backend_clients: dict[MCPMountPrefix, Client] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._subscriptions: defaultdict[ServerSession, set[str]] = defaultdict(set)
@@ -295,7 +295,7 @@ class ApprovalGateServer(EnhancedFastMCP):
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
 
-            effective_timeout = _resolve_effective_timeout(wait_mode, self._approval_timeout_seconds)
+            effective_timeout = _resolve_effective_timeout(wait_mode, self._default_approval_timeout_seconds)
 
             if effective_timeout is not None and effective_timeout > 0:
                 event = asyncio.Event()

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -35,6 +35,7 @@ from fastmcp.tools.tool import FunctionTool
 from mako.template import Template
 from mcp import types as mcp_types
 from mcp.server.session import ServerSession
+from pydantic import TypeAdapter
 from pydantic.networks import AnyUrl
 
 from approval_gate.models import (
@@ -44,6 +45,7 @@ from approval_gate.models import (
     ActionState,
     ActionStatus,
     ApproveDecision,
+    BlockingWait,
     DeniedDetail,
     DenyDecision,
     DoneState,
@@ -55,8 +57,10 @@ from approval_gate.models import (
     PendingState,
     RejectedState,
     ToolCall,
+    WaitMode,
     WithdrawnDetail,
     WithdrawnState,
+    YieldAfterMs,
 )
 from approval_gate.predicates import Approved, Denied, NeedsHumanDecision, PredicateFn, call_predicate
 from approval_gate.storage import ActionStorage
@@ -74,11 +78,22 @@ READ_SCOPE = "read"
 _INSTRUCTIONS_TEMPLATE = Path(__file__).parent / "instructions.mako"
 
 
+_WAIT_MODE_SCHEMA: dict[str, Any] = {
+    "description": (
+        "How long to wait for action resolution before returning. "
+        "Omit to use server default. "
+        "blocking: wait indefinitely. "
+        "yield_after_ms: wait up to timeout_ms then return current state."
+    ),
+    **TypeAdapter(WaitMode).json_schema(),
+}
+
+
 def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
     """Wrap a backend tool's input schema in an approval envelope.
 
     Produces:
-      { input: <original_schema>, justification: str, session_key: str }
+      { input: <original_schema>, justification: str, session_key: str, wait_mode?: WaitMode }
 
     The nested `input` property holds the backend's original schema unchanged,
     avoiding any risk of name collisions with the approval fields.
@@ -95,49 +110,23 @@ def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
                 "type": "string",
                 "description": "Session key for result notifications. Injected by plugin.",
             },
-            "approval_timeout_seconds": {
-                "type": "number",
-                "description": (
-                    "Seconds to wait for action resolution before returning. "
-                    "Overrides server default. Omit to use server default."
-                ),
-            },
-            "background": {
-                "type": "boolean",
-                "description": (
-                    "If true, return immediately without waiting for resolution "
-                    "(equivalent to approval_timeout_seconds=0)."
-                ),
-            },
-            "yield_ms": {
-                "type": "number",
-                "description": (
-                    "Milliseconds to wait for resolution before returning. "
-                    "Converted to seconds internally. Overrides approval_timeout_seconds."
-                ),
-            },
+            "wait_mode": _WAIT_MODE_SCHEMA,
         },
         "required": ["input", "justification", "session_key"],
     }
 
 
-def _resolve_effective_timeout(
-    *, background: bool, yield_ms: float | None, approval_timeout_seconds: float | None, server_default: float | None
-) -> float | None:
-    """Resolve the effective wait timeout from the priority chain.
+def _resolve_effective_timeout(wait_mode: WaitMode | None, server_default: float | None) -> float | None:
+    """Resolve effective wait timeout from per-call wait_mode or server default.
 
-    Priority (highest first):
-      1. background=True → 0 (return immediately)
-      2. yield_ms → converted to seconds
-      3. approval_timeout_seconds (per-call override)
-      4. server_default
+    Returns seconds to wait: None = no wait, float('inf') = wait forever, N = bounded.
     """
-    if background:
-        return 0
-    if yield_ms is not None:
-        return max(0, yield_ms / 1000)
-    if approval_timeout_seconds is not None:
-        return approval_timeout_seconds
+    if wait_mode is not None:
+        match wait_mode:
+            case BlockingWait():
+                return float("inf")
+            case YieldAfterMs(timeout_ms=ms):
+                return max(0, ms / 1000)
     return server_default
 
 
@@ -296,9 +285,7 @@ class ApprovalGateServer(EnhancedFastMCP):
             justification: str,
             session_key: str,
             input: dict[str, object] = {},  # noqa: B006
-            approval_timeout_seconds: float | None = None,
-            background: bool = False,
-            yield_ms: float | None = None,
+            wait_mode: WaitMode | None = None,
         ) -> Action:
             call = ToolCall(server_namespace=namespace, tool_name=tool_name, arguments=input)
             action = await self._req_storage.create_action(
@@ -308,12 +295,7 @@ class ApprovalGateServer(EnhancedFastMCP):
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
 
-            effective_timeout = _resolve_effective_timeout(
-                background=background,
-                yield_ms=yield_ms,
-                approval_timeout_seconds=approval_timeout_seconds,
-                server_default=self._approval_timeout_seconds,
-            )
+            effective_timeout = _resolve_effective_timeout(wait_mode, self._approval_timeout_seconds)
 
             if effective_timeout is not None and effective_timeout > 0:
                 event = asyncio.Event()

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -22,6 +22,7 @@ import logging
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -435,14 +436,14 @@ class ApprovalGateServer(EnhancedFastMCP):
 
         notice_delay = self._execution_running_notice_seconds
         finished = False
-        start_time = asyncio.get_event_loop().time()
+        started_at = datetime.now(tz=UTC)
 
         async def _running_notice() -> None:
             await asyncio.sleep(notice_delay)
             if finished:
                 return
-            elapsed = asyncio.get_event_loop().time() - start_time
-            await self._append_log_and_notify(key, ExecutionRunningDetail(elapsed_seconds=round(elapsed, 1)))
+            await self._append_log_and_notify(key, ExecutionRunningDetail(started_at=started_at))
+            elapsed = (datetime.now(tz=UTC) - started_at).total_seconds()
             logger.info("action %s/%d still executing after %.1fs", key.session_key, key.action_seq, elapsed)
 
         notice_task: asyncio.Task[None] | None = None

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -49,7 +49,6 @@ from approval_gate.models import (
     DoneState,
     ExecutingState,
     ExecutionFinishedDetail,
-    ExecutionRunningDetail,
     ExecutionStartedDetail,
     LogEventDetail,
     OperatorDecision,
@@ -153,7 +152,6 @@ class ApprovalGateServer(EnhancedFastMCP):
         predicate: PredicateFn,
         public_base_url: str,
         approval_timeout_seconds: float | None = None,
-        execution_running_notice_seconds: float = 10.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -165,7 +163,6 @@ class ApprovalGateServer(EnhancedFastMCP):
         self._predicate = predicate
         self._public_base_url = public_base_url
         self._approval_timeout_seconds = approval_timeout_seconds
-        self._execution_running_notice_seconds = execution_running_notice_seconds
         self._backend_clients: dict[MCPMountPrefix, Client] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._subscriptions: defaultdict[ServerSession, set[str]] = defaultdict(set)
@@ -404,7 +401,10 @@ class ApprovalGateServer(EnhancedFastMCP):
             raise ValueError(f"Action {key.session_key}/{key.action_seq} is not pending ({action.state.status=})")
         match decision:
             case ApproveDecision():
-                action = await self._update_and_notify(key, ExecutingState(), ExecutionStartedDetail())
+                started_at = datetime.now(tz=UTC)
+                action = await self._update_and_notify(
+                    key, ExecutingState(), ExecutionStartedDetail(started_at=started_at)
+                )
                 self._spawn(self._execute_and_finish(key, action))
                 return action
             case DenyDecision(reason=reason):
@@ -423,40 +423,13 @@ class ApprovalGateServer(EnhancedFastMCP):
         return await self._update_and_notify(key, WithdrawnState(), WithdrawnDetail())
 
     async def _execute_and_finish(self, key: ActionKey, action: Action) -> None:
-        """Execute the backend call and update state to done.
-
-        If the call takes longer than ``_execution_running_notice_seconds``,
-        emits an ``execution_running`` log event so subscribers know the action
-        is still in flight.
-        """
+        """Execute the backend call and update state to done."""
         namespace = MCPMountPrefix(action.call.server_namespace)
         client = self._backend_clients.get(namespace)
         if client is None:
             raise RuntimeError(f"backend client not connected for namespace: {namespace!r}")
 
-        notice_delay = self._execution_running_notice_seconds
-        finished = False
-        started_at = datetime.now(tz=UTC)
-
-        async def _running_notice() -> None:
-            await asyncio.sleep(notice_delay)
-            if finished:
-                return
-            await self._append_log_and_notify(key, ExecutionRunningDetail(started_at=started_at))
-            elapsed = (datetime.now(tz=UTC) - started_at).total_seconds()
-            logger.info("action %s/%d still executing after %.1fs", key.session_key, key.action_seq, elapsed)
-
-        notice_task: asyncio.Task[None] | None = None
-        if notice_delay > 0:
-            notice_task = asyncio.create_task(_running_notice())
-
-        try:
-            outcome = await client.call_tool_mcp(action.call.tool_name, action.call.arguments)
-        finally:
-            finished = True
-            if notice_task is not None:
-                notice_task.cancel()
-
+        outcome = await client.call_tool_mcp(action.call.tool_name, action.call.arguments)
         await self._update_and_notify(key, DoneState(outcome=outcome), ExecutionFinishedDetail(outcome=outcome))
 
     def _spawn(self, coro: Coroutine[Any, Any, Any]) -> None:

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -78,15 +78,7 @@ READ_SCOPE = "read"
 _INSTRUCTIONS_TEMPLATE = Path(__file__).parent / "instructions.mako"
 
 
-_WAIT_MODE_SCHEMA: dict[str, Any] = {
-    "description": (
-        "How long to wait for action resolution before returning. "
-        "Omit to use server default. "
-        "blocking: wait indefinitely. "
-        "yield_after_ms: wait up to timeout_ms then return current state."
-    ),
-    **TypeAdapter(WaitMode).json_schema(),
-}
+_WAIT_MODE_SCHEMA: dict[str, Any] = TypeAdapter(WaitMode).json_schema()
 
 
 def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
@@ -116,13 +108,18 @@ def _wrap_tool_schema(original_schema: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _resolve_effective_timeout(wait_mode: WaitMode | None, server_default: float | None) -> float | None:
-    """Resolve effective wait timeout from per-call wait_mode or server default.
+def _resolve_effective_wait(wait_mode: WaitMode | None, server_default: WaitMode | None) -> WaitMode | None:
+    """Resolve effective wait mode from per-call override or server default."""
+    return wait_mode if wait_mode is not None else server_default
 
-    Returns seconds to wait: None = no wait, float('inf') = wait forever, N = bounded.
+
+def _wait_mode_to_timeout(wait_mode: WaitMode | None) -> float | None:
+    """Convert a WaitMode to a timeout in seconds.
+
+    Returns None = no wait, float('inf') = wait forever, N = bounded.
     """
     if wait_mode is None:
-        return server_default
+        return None
     match wait_mode:
         case BlockingWait():
             return float("inf")
@@ -140,7 +137,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         db_path: Path,
         predicate: PredicateFn,
         public_base_url: str,
-        default_approval_timeout_seconds: float | None = None,
+        default_wait_mode: WaitMode | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -151,7 +148,7 @@ class ApprovalGateServer(EnhancedFastMCP):
         self._storage: ActionStorage | None = None
         self._predicate = predicate
         self._public_base_url = public_base_url
-        self._default_approval_timeout_seconds = default_approval_timeout_seconds
+        self._default_wait_mode = default_wait_mode
         self._backend_clients: dict[MCPMountPrefix, Client] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._subscriptions: defaultdict[ServerSession, set[str]] = defaultdict(set)
@@ -295,7 +292,7 @@ class ApprovalGateServer(EnhancedFastMCP):
             await self._append_log_and_notify(key, ActionReceivedDetail())
             await self.broadcast_resource_list_changed()
 
-            effective_timeout = _resolve_effective_timeout(wait_mode, self._default_approval_timeout_seconds)
+            effective_timeout = _wait_mode_to_timeout(_resolve_effective_wait(wait_mode, self._default_wait_mode))
 
             if effective_timeout is not None and effective_timeout > 0:
                 event = asyncio.Event()

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -11,9 +11,18 @@ import anyio
 import pytest_bazel
 from fastmcp import FastMCP
 
-from approval_gate.conftest import TEST_NS, GateAppFactory, GateClient, agent_transport, operator_transport, serve_app
-from approval_gate.models import ActionStatus
-from approval_gate.predicates import Approved
+from approval_gate.conftest import (
+    TEST_NS,
+    GateAppFactory,
+    GateClient,
+    GateServerFactory,
+    agent_transport,
+    gate_http_app,
+    operator_transport,
+    serve_app,
+)
+from approval_gate.models import ActionStatus, DoneState, RejectedState
+from approval_gate.predicates import Approved, Denied
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.resource_utils import read_text
 
@@ -193,6 +202,86 @@ async def test_log_hwm_increments_on_state_changes(
 
         hwm_after_done = int(await read_text(agent, f"resource://sessions/{_SESSION}/log_hwm"))
         assert hwm_after_done > hwm_after_create
+
+
+async def test_auto_approve_with_timeout_returns_done(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """With approval_timeout_seconds and auto-approve predicate, tool call returns done Action."""
+    backend, calls = _make_backend()
+    gate = make_gate_server(
+        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=5.0
+    )
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("hello", session_key=_SESSION)
+
+    assert action.state.status == ActionStatus.DONE
+    assert isinstance(action.state, DoneState)
+    assert calls == ["hello"]
+
+
+async def test_auto_deny_with_timeout_returns_rejected(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """With approval_timeout_seconds and auto-deny predicate, tool call returns rejected Action."""
+    backend, calls = _make_backend()
+    gate = make_gate_server(
+        {TEST_NS: backend}, predicate=lambda ns, tool, args: Denied(reason="nope"), approval_timeout_seconds=5.0
+    )
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("deny-me", session_key=_SESSION)
+
+    assert action.state.status == ActionStatus.REJECTED
+    assert isinstance(action.state, RejectedState)
+    assert action.state.reason == "nope"
+    assert calls == []
+
+
+async def test_no_timeout_returns_pending(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
+    """Without approval_timeout_seconds (default None), tool call returns pending Action."""
+    backend, _ = _make_backend()
+    app = make_gate_app({TEST_NS: backend})
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("pending", session_key=_SESSION)
+
+    assert action.state.status == ActionStatus.PENDING
+
+
+async def test_per_call_timeout_overrides_server_default(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """Per-call approval_timeout_seconds overrides server default (None)."""
+    backend, calls = _make_backend()
+    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("override", session_key=_SESSION, approval_timeout_seconds=5.0)
+
+    assert action.state.status == ActionStatus.DONE
+    assert calls == ["override"]
+
+
+async def test_timeout_expires_returns_pending(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """When timeout expires before resolution, tool call returns pending/executing Action."""
+    backend, _ = _make_backend()
+    gate = make_gate_server({TEST_NS: backend}, approval_timeout_seconds=0.1)
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("slow", session_key=_SESSION)
+
+    assert action.state.status == ActionStatus.PENDING
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -213,7 +213,7 @@ def _auto_approve(ns: str, tool: str, args: dict) -> Approved:
     ("server_kwargs", "call_kwargs", "expected_status"),
     [
         pytest.param(
-            {"predicate": _auto_approve, "approval_timeout_seconds": 5.0},
+            {"predicate": _auto_approve, "default_approval_timeout_seconds": 5.0},
             {},
             ActionStatus.DONE,
             id="server-default-timeout-done",
@@ -263,7 +263,7 @@ async def test_auto_deny_with_timeout_returns_rejected(
     """Auto-deny predicate + server timeout → rejected with reason."""
     backend, calls = _make_backend()
     gate = make_gate_server(
-        {TEST_NS: backend}, predicate=lambda ns, tool, args: Denied(reason="nope"), approval_timeout_seconds=5.0
+        {TEST_NS: backend}, predicate=lambda ns, tool, args: Denied(reason="nope"), default_approval_timeout_seconds=5.0
     )
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
@@ -285,7 +285,7 @@ async def test_yield_zero_overrides_large_server_default(
 ):
     """yield_after_ms=0 returns immediately despite a 30s server default."""
     backend, _ = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, approval_timeout_seconds=30.0)
+    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, default_approval_timeout_seconds=30.0)
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
@@ -304,7 +304,7 @@ async def test_blocking_overrides_tiny_server_default(
 ):
     """blocking wait_mode overrides a 10ms server default — waits for completion."""
     backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, approval_timeout_seconds=0.01)
+    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, default_approval_timeout_seconds=0.01)
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -11,44 +11,26 @@ import anyio
 import pytest
 import pytest_bazel
 from fastmcp import FastMCP
+from starlette.applications import Starlette
 
 from approval_gate.conftest import (
     TEST_NS,
+    EchoBackend,
     GateAppFactory,
     GateClient,
     GateServerFactory,
-    agent_transport,
     gate_http_app,
-    operator_transport,
     serve_app,
 )
-from approval_gate.models import Action, ActionKey, ActionStatus, RejectedState
+from approval_gate.models import Action, ActionKey, ActionStatus, RejectedState, YieldAfterMs
 from approval_gate.predicates import Approved, Denied
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.resource_utils import read_text
 
-_SESSION = "e2e-session"
 
-
-def _make_backend():
-    calls: list[str] = []
-    srv = FastMCP()
-
-    @srv.tool()
-    async def echo(text: str) -> str:
-        calls.append(text)
-        return f"echoed: {text}"
-
-    return srv, calls
-
-
-async def test_tool_list_wraps_backend_tools(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
+async def test_tool_list_wraps_backend_tools(echo_gate_app: Starlette, free_port: int, agent_client_transport: object):
     """MCP tool list exposes backend tools wrapped with the approval-gate schema envelope."""
-    backend, _ = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as client:
+    async with serve_app(echo_gate_app, port=free_port), GateClient(agent_client_transport) as client:
         tools = await client.list_tools()
 
     names = [t.name for t in tools]
@@ -63,62 +45,70 @@ async def test_tool_list_wraps_backend_tools(make_gate_app: GateAppFactory, free
 
 
 async def test_approve_executes_backend_tool(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    echo_gate_app: Starlette,
+    free_port: int,
+    agent_client_transport: object,
+    operator_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """Happy path: tool call queued -> operator approves -> backend runs -> action done."""
-    backend, calls = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
-
     async with (
-        serve_app(app, port=free_port),
-        GateClient(agent_transport(base_url, agent_jwt)) as agent,
-        GateClient(operator_transport(base_url, operator_jwt)) as operator,
+        serve_app(echo_gate_app, port=free_port),
+        GateClient(agent_client_transport) as agent,
+        GateClient(operator_client_transport) as operator,
     ):
-        key = await agent.call_echo("hello", session_key=_SESSION)
-        await operator.approve(key)
+        action = await agent.call_echo("hello", session_key=session_key)
+        await operator.approve(action.key)
         with anyio.fail_after(5.0):
-            await agent.wait_for(key, ActionStatus.DONE)
+            await agent.wait_for(action.key, ActionStatus.DONE)
 
-    assert calls == ["hello"]
+    assert echo_backend.calls == ["hello"]
 
 
 async def test_reject_leaves_action_rejected_and_skips_backend(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    echo_gate_app: Starlette,
+    free_port: int,
+    agent_client_transport: object,
+    operator_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """Reject path: tool call queued -> operator rejects -> rejected state, backend not called."""
-    backend, calls = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
-
     async with (
-        serve_app(app, port=free_port),
-        GateClient(agent_transport(base_url, agent_jwt)) as agent,
-        GateClient(operator_transport(base_url, operator_jwt)) as operator,
+        serve_app(echo_gate_app, port=free_port),
+        GateClient(agent_client_transport) as agent,
+        GateClient(operator_client_transport) as operator,
     ):
-        key = await agent.call_echo("no-run", session_key=_SESSION)
-        await operator.reject(key, reason="test rejection")
+        action = await agent.call_echo("no-run", session_key=session_key)
+        await operator.reject(action.key, reason="test rejection")
         with anyio.fail_after(5.0):
-            await agent.wait_for(key, ActionStatus.REJECTED)
+            await agent.wait_for(action.key, ActionStatus.REJECTED)
 
-    assert calls == []
+    assert echo_backend.calls == []
 
 
-async def test_auto_approve_predicate_skips_queue(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
+async def test_auto_approve_predicate_skips_queue(
+    make_gate_app: GateAppFactory,
+    free_port: int,
+    agent_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
+):
     """Auto-approve predicate: tool call immediately executes without any operator action."""
-    backend, calls = _make_backend()
-    app = make_gate_app({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
-    base_url = f"http://127.0.0.1:{free_port}"
+    app = make_gate_app({TEST_NS: echo_backend.server}, predicate=lambda ns, tool, args: Approved())
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        key = await agent.call_echo("auto", justification="auto", session_key=_SESSION)
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as agent:
+        action = await agent.call_echo("auto", justification="auto", session_key=session_key)
         with anyio.fail_after(5.0):
-            await agent.wait_for(key, ActionStatus.DONE)
+            await agent.wait_for(action.key, ActionStatus.DONE)
 
-    assert calls == ["auto"]
+    assert echo_backend.calls == ["auto"]
 
 
-async def test_multi_backend_namespace_isolation(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
+async def test_multi_backend_namespace_isolation(
+    make_gate_app: GateAppFactory, free_port: int, agent_client_transport: object, session_key: str
+):
     """Multiple backends each get namespaced tools that route to the correct backend."""
     calls_a: list[str] = []
     calls_b: list[str] = []
@@ -140,68 +130,65 @@ async def test_multi_backend_namespace_isolation(make_gate_app: GateAppFactory, 
     ns_a = MCPMountPrefix("alpha")
     ns_b = MCPMountPrefix("beta")
     app = make_gate_app({ns_a: srv_a, ns_b: srv_b}, predicate=lambda ns, tool, args: Approved())
-    base_url = f"http://127.0.0.1:{free_port}"
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as client:
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as client:
         tools = await client.list_tools()
         tool_names = {t.name for t in tools}
         assert {"alpha_echo", "beta_echo"} <= tool_names
 
-        key_a = await client.call_gate_tool(
-            "alpha_echo", {"input": {"text": "from-a"}, "justification": "test", "session_key": _SESSION}
+        action_a = await client.call_gate_tool(
+            "alpha_echo", {"input": {"text": "from-a"}, "justification": "test", "session_key": session_key}
         )
         with anyio.fail_after(5.0):
-            await client.wait_for(key_a, ActionStatus.DONE)
+            await client.wait_for(action_a.key, ActionStatus.DONE)
 
-        key_b = await client.call_gate_tool(
-            "beta_echo", {"input": {"text": "from-b"}, "justification": "test", "session_key": _SESSION}
+        action_b = await client.call_gate_tool(
+            "beta_echo", {"input": {"text": "from-b"}, "justification": "test", "session_key": session_key}
         )
         with anyio.fail_after(5.0):
-            await client.wait_for(key_b, ActionStatus.DONE)
+            await client.wait_for(action_b.key, ActionStatus.DONE)
 
     assert calls_a == ["from-a"]
     assert calls_b == ["from-b"]
 
 
-async def test_action_seq_increments_within_session(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
+async def test_action_seq_increments_within_session(
+    echo_gate_app: Starlette, free_port: int, agent_client_transport: object, session_key: str
+):
     """Action sequences increment monotonically within a session."""
-    backend, _ = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
+    async with serve_app(echo_gate_app, port=free_port), GateClient(agent_client_transport) as client:
+        a1 = await client.call_echo("a", justification="t", session_key=session_key)
+        a2 = await client.call_echo("b", justification="t", session_key=session_key)
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as client:
-        k1 = await client.call_echo("a", justification="t", session_key=_SESSION)
-        k2 = await client.call_echo("b", justification="t", session_key=_SESSION)
-
-    assert k1.session_key == _SESSION
-    assert k2.session_key == _SESSION
-    assert k1.action_seq == 1
-    assert k2.action_seq == 2
+    assert a1.key.session_key == session_key
+    assert a2.key.session_key == session_key
+    assert a1.key.action_seq == 1
+    assert a2.key.action_seq == 2
 
 
 async def test_log_hwm_increments_on_state_changes(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    echo_gate_app: Starlette,
+    free_port: int,
+    agent_client_transport: object,
+    operator_client_transport: object,
+    session_key: str,
 ):
     """The session log HWM increases as actions are received and decided."""
-    backend, _ = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
-
     async with (
-        serve_app(app, port=free_port),
-        GateClient(agent_transport(base_url, agent_jwt)) as agent,
-        GateClient(operator_transport(base_url, operator_jwt)) as operator,
+        serve_app(echo_gate_app, port=free_port),
+        GateClient(agent_client_transport) as agent,
+        GateClient(operator_client_transport) as operator,
     ):
-        key = await agent.call_echo("log-test", justification="t", session_key=_SESSION)
+        action = await agent.call_echo("log-test", justification="t", session_key=session_key)
 
-        hwm_after_create = int(await read_text(agent, f"resource://sessions/{_SESSION}/log_hwm"))
+        hwm_after_create = int(await read_text(agent, f"resource://sessions/{session_key}/log_hwm"))
         assert hwm_after_create >= 1
 
-        await operator.approve(key)
+        await operator.approve(action.key)
         with anyio.fail_after(5.0):
-            await agent.wait_for(key, ActionStatus.DONE)
+            await agent.wait_for(action.key, ActionStatus.DONE)
 
-        hwm_after_done = int(await read_text(agent, f"resource://sessions/{_SESSION}/log_hwm"))
+        hwm_after_done = int(await read_text(agent, f"resource://sessions/{session_key}/log_hwm"))
         assert hwm_after_done > hwm_after_create
 
 
@@ -213,10 +200,10 @@ def _auto_approve(ns: str, tool: str, args: dict) -> Approved:
     ("server_kwargs", "call_kwargs", "expected_status"),
     [
         pytest.param(
-            {"predicate": _auto_approve, "default_approval_timeout_seconds": 5.0},
+            {"predicate": _auto_approve, "default_wait_mode": YieldAfterMs(timeout_ms=5000)},
             {},
             ActionStatus.DONE,
-            id="server-default-timeout-done",
+            id="server-default-yield-done",
         ),
         pytest.param(
             {"predicate": _auto_approve},
@@ -239,60 +226,68 @@ def _auto_approve(ns: str, tool: str, args: dict) -> Approved:
 async def test_wait_mode_resolution(
     make_gate_server: GateServerFactory,
     free_port: int,
-    agent_jwt: str,
+    agent_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
     server_kwargs: dict,
     call_kwargs: dict,
     expected_status: ActionStatus,
 ):
     """Various wait_mode / server-default combinations resolve to expected status."""
-    backend, _ = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, **server_kwargs)
+    gate = make_gate_server({TEST_NS: echo_backend.server}, **server_kwargs)
     app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as agent:
         with anyio.fail_after(10.0):
-            action = await agent.call_echo_full("test", session_key=_SESSION, **call_kwargs)
+            action = await agent.call_echo("test", session_key=session_key, **call_kwargs)
 
     assert action.state.status == expected_status
 
 
 async def test_auto_deny_with_timeout_returns_rejected(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+    make_gate_server: GateServerFactory,
+    free_port: int,
+    agent_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
-    """Auto-deny predicate + server timeout → rejected with reason."""
-    backend, calls = _make_backend()
+    """Auto-deny predicate + server timeout -> rejected with reason."""
     gate = make_gate_server(
-        {TEST_NS: backend}, predicate=lambda ns, tool, args: Denied(reason="nope"), default_approval_timeout_seconds=5.0
+        {TEST_NS: echo_backend.server},
+        predicate=lambda ns, tool, args: Denied(reason="nope"),
+        default_wait_mode=YieldAfterMs(timeout_ms=5000),
     )
     app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("deny-me", session_key=_SESSION)
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as agent:
+        action = await agent.call_echo("deny-me", session_key=session_key)
 
     assert action.state.status == ActionStatus.REJECTED
     assert isinstance(action.state, RejectedState)
     assert action.state.reason == "nope"
-    assert calls == []
+    assert echo_backend.calls == []
 
 
 # ── per-call wait_mode overrides server default ──────────────────────────
 
 
 async def test_yield_zero_overrides_large_server_default(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+    make_gate_server: GateServerFactory,
+    free_port: int,
+    agent_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """yield_after_ms=0 returns immediately despite a 30s server default."""
-    backend, _ = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, default_approval_timeout_seconds=30.0)
+    gate = make_gate_server(
+        {TEST_NS: echo_backend.server}, predicate=_auto_approve, default_wait_mode=YieldAfterMs(timeout_ms=30000)
+    )
     app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as agent:
         with anyio.fail_after(5.0):
-            action = await agent.call_echo_full(
-                "bg", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 0}
+            action = await agent.call_echo(
+                "bg", session_key=session_key, wait_mode={"mode": "yield_after_ms", "timeout_ms": 0}
             )
 
     # Returns before auto-approve completes — any status is valid
@@ -300,55 +295,62 @@ async def test_yield_zero_overrides_large_server_default(
 
 
 async def test_blocking_overrides_tiny_server_default(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+    make_gate_server: GateServerFactory,
+    free_port: int,
+    agent_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """blocking wait_mode overrides a 10ms server default — waits for completion."""
-    backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, default_approval_timeout_seconds=0.01)
+    gate = make_gate_server(
+        {TEST_NS: echo_backend.server}, predicate=_auto_approve, default_wait_mode=YieldAfterMs(timeout_ms=10)
+    )
     app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
 
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+    async with serve_app(app, port=free_port), GateClient(agent_client_transport) as agent:
         with anyio.fail_after(10.0):
-            action = await agent.call_echo_full("override", session_key=_SESSION, wait_mode={"mode": "blocking"})
+            action = await agent.call_echo("override", session_key=session_key, wait_mode={"mode": "blocking"})
 
     assert action.state.status == ActionStatus.DONE
-    assert calls == ["override"]
+    assert echo_backend.calls == ["override"]
 
 
 # ── blocking with operator ───────────────────────────────────────────────
 
 
 async def test_blocking_waits_for_operator_approval(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    make_gate_server: GateServerFactory,
+    free_port: int,
+    agent_client_transport: object,
+    operator_client_transport: object,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """blocking wait_mode with NeedsHumanDecision blocks until operator approves."""
-    backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend})
+    gate = make_gate_server({TEST_NS: echo_backend.server})
     app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
 
     async with (
         serve_app(app, port=free_port),
-        GateClient(agent_transport(base_url, agent_jwt)) as agent,
-        GateClient(operator_transport(base_url, operator_jwt)) as operator,
+        GateClient(agent_client_transport) as agent,
+        GateClient(operator_client_transport) as operator,
     ):
         async with anyio.create_task_group() as tg:
             action_holder: list[Action] = []
 
             async def blocking_call():
-                action = await agent.call_echo_full("block-human", session_key=_SESSION, wait_mode={"mode": "blocking"})
+                action = await agent.call_echo("block-human", session_key=session_key, wait_mode={"mode": "blocking"})
                 action_holder.append(action)
 
             tg.start_soon(blocking_call)
 
             await anyio.sleep(0.5)
-            key = ActionKey(session_key=_SESSION, action_seq=1)
+            key = ActionKey(session_key=session_key, action_seq=1)
             await operator.approve(key)
 
         assert len(action_holder) == 1
         assert action_holder[0].state.status == ActionStatus.DONE
-        assert calls == ["block-human"]
+        assert echo_backend.calls == ["block-human"]
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -8,6 +8,7 @@ and transport stack end-to-end.
 from __future__ import annotations
 
 import anyio
+import pytest
 import pytest_bazel
 from fastmcp import FastMCP
 
@@ -21,7 +22,7 @@ from approval_gate.conftest import (
     operator_transport,
     serve_app,
 )
-from approval_gate.models import Action, ActionKey, ActionStatus, DoneState, RejectedState
+from approval_gate.models import Action, ActionKey, ActionStatus, RejectedState
 from approval_gate.predicates import Approved, Denied
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.resource_utils import read_text
@@ -204,29 +205,62 @@ async def test_log_hwm_increments_on_state_changes(
         assert hwm_after_done > hwm_after_create
 
 
-async def test_auto_approve_with_timeout_returns_done(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+def _auto_approve(ns: str, tool: str, args: dict) -> Approved:
+    return Approved()
+
+
+@pytest.mark.parametrize(
+    ("server_kwargs", "call_kwargs", "expected_status"),
+    [
+        pytest.param(
+            {"predicate": _auto_approve, "approval_timeout_seconds": 5.0},
+            {},
+            ActionStatus.DONE,
+            id="server-default-timeout-done",
+        ),
+        pytest.param(
+            {"predicate": _auto_approve},
+            {"wait_mode": {"mode": "yield_after_ms", "timeout_ms": 5000}},
+            ActionStatus.DONE,
+            id="per-call-yield-done",
+        ),
+        pytest.param(
+            {"predicate": _auto_approve}, {"wait_mode": {"mode": "blocking"}}, ActionStatus.DONE, id="blocking-done"
+        ),
+        pytest.param({}, {}, ActionStatus.PENDING, id="no-wait-pending"),
+        pytest.param(
+            {},
+            {"wait_mode": {"mode": "yield_after_ms", "timeout_ms": 100}},
+            ActionStatus.PENDING,
+            id="short-yield-pending",
+        ),
+    ],
+)
+async def test_wait_mode_resolution(
+    make_gate_server: GateServerFactory,
+    free_port: int,
+    agent_jwt: str,
+    server_kwargs: dict,
+    call_kwargs: dict,
+    expected_status: ActionStatus,
 ):
-    """With approval_timeout_seconds and auto-approve predicate, tool call returns done Action."""
-    backend, calls = _make_backend()
-    gate = make_gate_server(
-        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=5.0
-    )
+    """Various wait_mode / server-default combinations resolve to expected status."""
+    backend, _ = _make_backend()
+    gate = make_gate_server({TEST_NS: backend}, **server_kwargs)
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("hello", session_key=_SESSION)
+        with anyio.fail_after(10.0):
+            action = await agent.call_echo_full("test", session_key=_SESSION, **call_kwargs)
 
-    assert action.state.status == ActionStatus.DONE
-    assert isinstance(action.state, DoneState)
-    assert calls == ["hello"]
+    assert action.state.status == expected_status
 
 
 async def test_auto_deny_with_timeout_returns_rejected(
     make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
 ):
-    """With approval_timeout_seconds and auto-deny predicate, tool call returns rejected Action."""
+    """Auto-deny predicate + server timeout → rejected with reason."""
     backend, calls = _make_backend()
     gate = make_gate_server(
         {TEST_NS: backend}, predicate=lambda ns, tool, args: Denied(reason="nope"), approval_timeout_seconds=5.0
@@ -243,62 +277,15 @@ async def test_auto_deny_with_timeout_returns_rejected(
     assert calls == []
 
 
-async def test_no_timeout_returns_pending(make_gate_app: GateAppFactory, free_port: int, agent_jwt: str):
-    """Without approval_timeout_seconds (default None), tool call returns pending Action."""
-    backend, _ = _make_backend()
-    app = make_gate_app({TEST_NS: backend})
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("pending", session_key=_SESSION)
-
-    assert action.state.status == ActionStatus.PENDING
+# ── per-call wait_mode overrides server default ──────────────────────────
 
 
-async def test_per_call_yield_overrides_server_default(
+async def test_yield_zero_overrides_large_server_default(
     make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
 ):
-    """Per-call yield_after_ms overrides server default (None)."""
-    backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
-    app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full(
-            "override", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 5000}
-        )
-
-    assert action.state.status == ActionStatus.DONE
-    assert calls == ["override"]
-
-
-async def test_yield_timeout_expires_returns_pending(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
-):
-    """When yield timeout expires before resolution, tool call returns pending Action."""
+    """yield_after_ms=0 returns immediately despite a 30s server default."""
     backend, _ = _make_backend()
-    gate = make_gate_server({TEST_NS: backend})
-    app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full(
-            "slow", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 100}
-        )
-
-    assert action.state.status == ActionStatus.PENDING
-
-
-# ── yield_after_ms tests ──────────────────────────────────────────────────
-
-
-async def test_yield_zero_returns_immediately(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """yield_after_ms with timeout_ms=0 returns without blocking even with a large server default."""
-    backend, _ = _make_backend()
-    gate = make_gate_server(
-        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=30.0
-    )
+    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, approval_timeout_seconds=30.0)
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
@@ -308,44 +295,28 @@ async def test_yield_zero_returns_immediately(make_gate_server: GateServerFactor
                 "bg", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 0}
             )
 
+    # Returns before auto-approve completes — any status is valid
     assert action.state.status in (ActionStatus.PENDING, ActionStatus.EXECUTING, ActionStatus.DONE)
 
 
-async def test_yield_waits_for_auto_approve(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """yield_after_ms with enough time for auto-approve to resolve."""
-    backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
-    app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full(
-            "yield", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 5000}
-        )
-
-    assert action.state.status == ActionStatus.DONE
-    assert calls == ["yield"]
-
-
-# ── blocking mode tests ─────────────────────────────────────────────────
-
-
-async def test_blocking_with_auto_approve_returns_done(
+async def test_blocking_overrides_tiny_server_default(
     make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
 ):
-    """blocking wait_mode with auto-approve predicate waits and returns done Action."""
+    """blocking wait_mode overrides a 10ms server default — waits for completion."""
     backend, calls = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
+    gate = make_gate_server({TEST_NS: backend}, predicate=_auto_approve, approval_timeout_seconds=0.01)
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
         with anyio.fail_after(10.0):
-            action = await agent.call_echo_full("block-auto", session_key=_SESSION, wait_mode={"mode": "blocking"})
+            action = await agent.call_echo_full("override", session_key=_SESSION, wait_mode={"mode": "blocking"})
 
     assert action.state.status == ActionStatus.DONE
-    assert isinstance(action.state, DoneState)
-    assert calls == ["block-auto"]
+    assert calls == ["override"]
+
+
+# ── blocking with operator ───────────────────────────────────────────────
 
 
 async def test_blocking_waits_for_operator_approval(
@@ -378,25 +349,6 @@ async def test_blocking_waits_for_operator_approval(
         assert len(action_holder) == 1
         assert action_holder[0].state.status == ActionStatus.DONE
         assert calls == ["block-human"]
-
-
-async def test_blocking_overrides_server_default_timeout(
-    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
-):
-    """blocking wait_mode overrides a short server default timeout."""
-    backend, calls = _make_backend()
-    gate = make_gate_server(
-        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=0.01
-    )
-    app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        with anyio.fail_after(10.0):
-            action = await agent.call_echo_full("block-override", session_key=_SESSION, wait_mode={"mode": "blocking"})
-
-    assert action.state.status == ActionStatus.DONE
-    assert calls == ["block-override"]
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -363,7 +363,7 @@ async def test_execution_running_notice_emitted(make_gate_server: GateServerFact
             entry = json.loads(entry_json)
             if entry["detail"]["kind"] == "execution_running":
                 found_running = True
-                assert "elapsed_seconds" in entry["detail"]
+                assert "started_at" in entry["detail"]
                 break
 
         assert found_running, f"expected execution_running in {hwm} log entries"

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -7,6 +7,9 @@ and transport stack end-to-end.
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 import anyio
 import pytest_bazel
 from fastmcp import FastMCP
@@ -282,6 +285,93 @@ async def test_timeout_expires_returns_pending(make_gate_server: GateServerFacto
         action = await agent.call_echo_full("slow", session_key=_SESSION)
 
     assert action.state.status == ActionStatus.PENDING
+
+
+# ── background / yield_ms tests ────────────────────────────────────────────
+
+
+async def test_background_returns_immediately(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """background=True returns without blocking even with a large server default timeout."""
+    backend, _ = _make_backend()
+    gate = make_gate_server(
+        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=30.0
+    )
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        # Should return near-instantly despite 30s server default
+        with anyio.fail_after(5.0):
+            action = await agent.call_echo_full("bg", session_key=_SESSION, background=True)
+
+    # With auto-approve + instant backend, may already be done
+    assert action.state.status in (ActionStatus.PENDING, ActionStatus.EXECUTING, ActionStatus.DONE)
+
+
+async def test_yield_ms_waits_then_returns(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """yield_ms provides enough time for auto-approve to resolve."""
+    backend, calls = _make_backend()
+    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        action = await agent.call_echo_full("yield", session_key=_SESSION, yield_ms=5000)
+
+    assert action.state.status == ActionStatus.DONE
+    assert calls == ["yield"]
+
+
+# ── execution_running notice tests ──────────────────────────────────────────
+
+
+async def test_execution_running_notice_emitted(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """Backend execution exceeding the notice threshold emits an execution_running log entry."""
+    slow_release = asyncio.Event()
+
+    srv = FastMCP()
+
+    @srv.tool()
+    async def echo(text: str) -> str:
+        # Block until released by the test
+        for _ in range(100):
+            if slow_release.is_set():
+                break
+            await asyncio.sleep(0.05)
+        return f"slow: {text}"
+
+    gate = make_gate_server(
+        {TEST_NS: srv},
+        predicate=lambda ns, tool, args: Approved(),
+        approval_timeout_seconds=10.0,
+        execution_running_notice_seconds=0.1,
+    )
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        # Submit with background=True so we can inspect logs while it runs
+        action = await agent.call_echo_full("slow", session_key=_SESSION, background=True)
+
+        # Wait for the running notice (delay is 0.1s, give it 0.5s)
+        await asyncio.sleep(0.5)
+
+        hwm = int(await read_text(agent, f"resource://sessions/{_SESSION}/log_hwm"))
+        found_running = False
+        for eid in range(1, hwm + 1):
+            entry_json = await read_text(agent, f"resource://sessions/{_SESSION}/log/{eid}")
+            entry = json.loads(entry_json)
+            if entry["detail"]["kind"] == "execution_running":
+                found_running = True
+                assert "elapsed_seconds" in entry["detail"]
+                break
+
+        assert found_running, f"expected execution_running in {hwm} log entries"
+
+        # Release the slow backend and wait for completion
+        slow_release.set()
+        with anyio.fail_after(5.0):
+            await agent.wait_for(action.key, ActionStatus.DONE)
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -7,9 +7,6 @@ and transport stack end-to-end.
 
 from __future__ import annotations
 
-import asyncio
-import json
-
 import anyio
 import pytest_bazel
 from fastmcp import FastMCP
@@ -320,58 +317,6 @@ async def test_yield_ms_waits_then_returns(make_gate_server: GateServerFactory, 
 
     assert action.state.status == ActionStatus.DONE
     assert calls == ["yield"]
-
-
-# ── execution_running notice tests ──────────────────────────────────────────
-
-
-async def test_execution_running_notice_emitted(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """Backend execution exceeding the notice threshold emits an execution_running log entry."""
-    slow_release = asyncio.Event()
-
-    srv = FastMCP()
-
-    @srv.tool()
-    async def echo(text: str) -> str:
-        # Block until released by the test
-        for _ in range(100):
-            if slow_release.is_set():
-                break
-            await asyncio.sleep(0.05)
-        return f"slow: {text}"
-
-    gate = make_gate_server(
-        {TEST_NS: srv},
-        predicate=lambda ns, tool, args: Approved(),
-        approval_timeout_seconds=10.0,
-        execution_running_notice_seconds=0.1,
-    )
-    app = gate_http_app(gate)
-    base_url = f"http://127.0.0.1:{free_port}"
-
-    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        # Submit with background=True so we can inspect logs while it runs
-        action = await agent.call_echo_full("slow", session_key=_SESSION, background=True)
-
-        # Wait for the running notice (delay is 0.1s, give it 0.5s)
-        await asyncio.sleep(0.5)
-
-        hwm = int(await read_text(agent, f"resource://sessions/{_SESSION}/log_hwm"))
-        found_running = False
-        for eid in range(1, hwm + 1):
-            entry_json = await read_text(agent, f"resource://sessions/{_SESSION}/log/{eid}")
-            entry = json.loads(entry_json)
-            if entry["detail"]["kind"] == "execution_running":
-                found_running = True
-                assert "started_at" in entry["detail"]
-                break
-
-        assert found_running, f"expected execution_running in {hwm} log entries"
-
-        # Release the slow backend and wait for completion
-        slow_release.set()
-        with anyio.fail_after(5.0):
-            await agent.wait_for(action.key, ActionStatus.DONE)
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_e2e.py
+++ b/approval_gate/test_e2e.py
@@ -21,7 +21,7 @@ from approval_gate.conftest import (
     operator_transport,
     serve_app,
 )
-from approval_gate.models import ActionStatus, DoneState, RejectedState
+from approval_gate.models import Action, ActionKey, ActionStatus, DoneState, RejectedState
 from approval_gate.predicates import Approved, Denied
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.resource_utils import read_text
@@ -255,40 +255,46 @@ async def test_no_timeout_returns_pending(make_gate_app: GateAppFactory, free_po
     assert action.state.status == ActionStatus.PENDING
 
 
-async def test_per_call_timeout_overrides_server_default(
+async def test_per_call_yield_overrides_server_default(
     make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
 ):
-    """Per-call approval_timeout_seconds overrides server default (None)."""
+    """Per-call yield_after_ms overrides server default (None)."""
     backend, calls = _make_backend()
     gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("override", session_key=_SESSION, approval_timeout_seconds=5.0)
+        action = await agent.call_echo_full(
+            "override", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 5000}
+        )
 
     assert action.state.status == ActionStatus.DONE
     assert calls == ["override"]
 
 
-async def test_timeout_expires_returns_pending(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """When timeout expires before resolution, tool call returns pending/executing Action."""
+async def test_yield_timeout_expires_returns_pending(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """When yield timeout expires before resolution, tool call returns pending Action."""
     backend, _ = _make_backend()
-    gate = make_gate_server({TEST_NS: backend}, approval_timeout_seconds=0.1)
+    gate = make_gate_server({TEST_NS: backend})
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("slow", session_key=_SESSION)
+        action = await agent.call_echo_full(
+            "slow", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 100}
+        )
 
     assert action.state.status == ActionStatus.PENDING
 
 
-# ── background / yield_ms tests ────────────────────────────────────────────
+# ── yield_after_ms tests ──────────────────────────────────────────────────
 
 
-async def test_background_returns_immediately(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """background=True returns without blocking even with a large server default timeout."""
+async def test_yield_zero_returns_immediately(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """yield_after_ms with timeout_ms=0 returns without blocking even with a large server default."""
     backend, _ = _make_backend()
     gate = make_gate_server(
         {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=30.0
@@ -297,26 +303,100 @@ async def test_background_returns_immediately(make_gate_server: GateServerFactor
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        # Should return near-instantly despite 30s server default
         with anyio.fail_after(5.0):
-            action = await agent.call_echo_full("bg", session_key=_SESSION, background=True)
+            action = await agent.call_echo_full(
+                "bg", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 0}
+            )
 
-    # With auto-approve + instant backend, may already be done
     assert action.state.status in (ActionStatus.PENDING, ActionStatus.EXECUTING, ActionStatus.DONE)
 
 
-async def test_yield_ms_waits_then_returns(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
-    """yield_ms provides enough time for auto-approve to resolve."""
+async def test_yield_waits_for_auto_approve(make_gate_server: GateServerFactory, free_port: int, agent_jwt: str):
+    """yield_after_ms with enough time for auto-approve to resolve."""
     backend, calls = _make_backend()
     gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
     app = gate_http_app(gate)
     base_url = f"http://127.0.0.1:{free_port}"
 
     async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        action = await agent.call_echo_full("yield", session_key=_SESSION, yield_ms=5000)
+        action = await agent.call_echo_full(
+            "yield", session_key=_SESSION, wait_mode={"mode": "yield_after_ms", "timeout_ms": 5000}
+        )
 
     assert action.state.status == ActionStatus.DONE
     assert calls == ["yield"]
+
+
+# ── blocking mode tests ─────────────────────────────────────────────────
+
+
+async def test_blocking_with_auto_approve_returns_done(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """blocking wait_mode with auto-approve predicate waits and returns done Action."""
+    backend, calls = _make_backend()
+    gate = make_gate_server({TEST_NS: backend}, predicate=lambda ns, tool, args: Approved())
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        with anyio.fail_after(10.0):
+            action = await agent.call_echo_full("block-auto", session_key=_SESSION, wait_mode={"mode": "blocking"})
+
+    assert action.state.status == ActionStatus.DONE
+    assert isinstance(action.state, DoneState)
+    assert calls == ["block-auto"]
+
+
+async def test_blocking_waits_for_operator_approval(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str, operator_jwt: str
+):
+    """blocking wait_mode with NeedsHumanDecision blocks until operator approves."""
+    backend, calls = _make_backend()
+    gate = make_gate_server({TEST_NS: backend})
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with (
+        serve_app(app, port=free_port),
+        GateClient(agent_transport(base_url, agent_jwt)) as agent,
+        GateClient(operator_transport(base_url, operator_jwt)) as operator,
+    ):
+        async with anyio.create_task_group() as tg:
+            action_holder: list[Action] = []
+
+            async def blocking_call():
+                action = await agent.call_echo_full("block-human", session_key=_SESSION, wait_mode={"mode": "blocking"})
+                action_holder.append(action)
+
+            tg.start_soon(blocking_call)
+
+            await anyio.sleep(0.5)
+            key = ActionKey(session_key=_SESSION, action_seq=1)
+            await operator.approve(key)
+
+        assert len(action_holder) == 1
+        assert action_holder[0].state.status == ActionStatus.DONE
+        assert calls == ["block-human"]
+
+
+async def test_blocking_overrides_server_default_timeout(
+    make_gate_server: GateServerFactory, free_port: int, agent_jwt: str
+):
+    """blocking wait_mode overrides a short server default timeout."""
+    backend, calls = _make_backend()
+    gate = make_gate_server(
+        {TEST_NS: backend}, predicate=lambda ns, tool, args: Approved(), approval_timeout_seconds=0.01
+    )
+    app = gate_http_app(gate)
+    base_url = f"http://127.0.0.1:{free_port}"
+
+    async with serve_app(app, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
+        with anyio.fail_after(10.0):
+            action = await agent.call_echo_full("block-override", session_key=_SESSION, wait_mode={"mode": "blocking"})
+
+    assert action.state.status == ActionStatus.DONE
+    assert calls == ["block-override"]
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_models.py
+++ b/approval_gate/test_models.py
@@ -131,7 +131,7 @@ def test_log_entry_roundtrip():
         entry_id=3,
         session_key="sess-1",
         action_seq=2,
-        detail=ExecutionStartedDetail(),
+        detail=ExecutionStartedDetail(started_at=datetime(2026, 1, 1, tzinfo=UTC)),
         timestamp=datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC),
     )
     parsed = LogEntry.model_validate_json(entry.model_dump_json())
@@ -177,7 +177,7 @@ def test_log_entry_with_execution_finished_detail():
         ActionReceivedDetail(),
         DeniedDetail(reason="x"),
         WithdrawnDetail(),
-        ExecutionStartedDetail(),
+        ExecutionStartedDetail(started_at=datetime(2026, 1, 1, tzinfo=UTC)),
         ExecutionFinishedDetail(outcome=CallToolResult(content=[])),
     ],
 )

--- a/approval_gate/test_predicates.py
+++ b/approval_gate/test_predicates.py
@@ -4,21 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import pytest_bazel
 
 from approval_gate.predicates import Approved, Denied, NeedsHumanDecision, call_predicate, load_predicate
 
 
-def test_load_predicate_none_returns_failsafe():
-    fn = load_predicate(None)
-    result = fn("test", "any_tool", {})
-    assert isinstance(result, NeedsHumanDecision)
-
-
-def test_load_predicate_missing_file_returns_failsafe(tmp_path: Path):
-    fn = load_predicate(tmp_path / "nonexistent.py")
-    result = fn("test", "any_tool", {})
-    assert isinstance(result, NeedsHumanDecision)
+def test_load_predicate_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        load_predicate(tmp_path / "nonexistent.py")
 
 
 def test_load_predicate_approved(tmp_path: Path):
@@ -57,13 +51,11 @@ def test_load_predicate_conditional(tmp_path: Path):
     assert isinstance(fn("dangerous", "any_tool", {}), NeedsHumanDecision)
 
 
-def test_load_predicate_syntax_error_returns_failsafe(tmp_path: Path):
+def test_load_predicate_syntax_error_raises(tmp_path: Path):
     predicate_file = tmp_path / "predicate.py"
     predicate_file.write_text("this is not valid python !!!")
-    fn = load_predicate(predicate_file)
-    # Should fall back to NeedsHumanDecision, not raise
-    result = fn("test", "any", {})
-    assert isinstance(result, NeedsHumanDecision)
+    with pytest.raises(SyntaxError):
+        load_predicate(predicate_file)
 
 
 def test_call_predicate_catches_runtime_exception():

--- a/approval_gate/test_proxy_server.py
+++ b/approval_gate/test_proxy_server.py
@@ -1,7 +1,8 @@
+import pytest
 import pytest_bazel
 
 from approval_gate.models import BlockingWait, YieldAfterMs
-from approval_gate.proxy_server import _resolve_effective_timeout, _wrap_tool_schema
+from approval_gate.proxy_server import _resolve_effective_wait, _wait_mode_to_timeout, _wrap_tool_schema
 
 
 def test_wraps_original_schema_under_input():
@@ -36,39 +37,39 @@ def test_schema_includes_wait_mode():
     assert "wait_mode" not in result["required"]
 
 
-# ── _resolve_effective_timeout ──────────────────────────────────────────────
+# ── _resolve_effective_wait ─────────────────────────────────────────────────
 
 
-def test_blocking_returns_inf():
-    assert _resolve_effective_timeout(BlockingWait(), server_default=30.0) == float("inf")
+@pytest.mark.parametrize(
+    ("per_call", "server_default", "expected"),
+    [
+        pytest.param(BlockingWait(), YieldAfterMs(timeout_ms=5000), BlockingWait(), id="per-call-overrides-default"),
+        pytest.param(None, BlockingWait(), BlockingWait(), id="falls-back-to-default"),
+        pytest.param(None, None, None, id="none-with-none"),
+        pytest.param(
+            YieldAfterMs(timeout_ms=0), BlockingWait(), YieldAfterMs(timeout_ms=0), id="yield-overrides-blocking"
+        ),
+    ],
+)
+def test_resolve_effective_wait(per_call, server_default, expected):
+    assert _resolve_effective_wait(per_call, server_default) == expected
 
 
-def test_blocking_overrides_server_default():
-    assert _resolve_effective_timeout(BlockingWait(), server_default=0.01) == float("inf")
+# ── _wait_mode_to_timeout ──────────────────────────────────────────────────
 
 
-def test_yield_after_ms_converts_to_seconds():
-    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=5000), server_default=None) == 5.0
-
-
-def test_yield_after_ms_overrides_server_default():
-    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=2000), server_default=30.0) == 2.0
-
-
-def test_yield_after_ms_clamps_negative_to_zero():
-    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=-100), server_default=None) == 0
-
-
-def test_yield_after_ms_zero_returns_zero():
-    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=0), server_default=30.0) == 0
-
-
-def test_none_falls_back_to_server_default():
-    assert _resolve_effective_timeout(None, server_default=30.0) == 30.0
-
-
-def test_none_with_none_default_returns_none():
-    assert _resolve_effective_timeout(None, server_default=None) is None
+@pytest.mark.parametrize(
+    ("wait_mode", "expected"),
+    [
+        pytest.param(BlockingWait(), float("inf"), id="blocking-inf"),
+        pytest.param(YieldAfterMs(timeout_ms=5000), 5.0, id="yield-converts-to-seconds"),
+        pytest.param(YieldAfterMs(timeout_ms=0), 0, id="yield-zero"),
+        pytest.param(YieldAfterMs(timeout_ms=-100), 0, id="yield-negative-clamps-to-zero"),
+        pytest.param(None, None, id="none-returns-none"),
+    ],
+)
+def test_wait_mode_to_timeout(wait_mode, expected):
+    assert _wait_mode_to_timeout(wait_mode) == expected
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_proxy_server.py
+++ b/approval_gate/test_proxy_server.py
@@ -1,5 +1,6 @@
 import pytest_bazel
 
+from approval_gate.models import BlockingWait, YieldAfterMs
 from approval_gate.proxy_server import _resolve_effective_timeout, _wrap_tool_schema
 
 
@@ -29,71 +30,45 @@ def test_does_not_mutate_original_schema():
     assert original["required"] == ["x"]
 
 
-def test_schema_includes_background_and_yield_ms():
+def test_schema_includes_wait_mode():
     result = _wrap_tool_schema({})
-    assert "background" in result["properties"]
-    assert "yield_ms" in result["properties"]
-    assert "background" not in result["required"]
-    assert "yield_ms" not in result["required"]
+    assert "wait_mode" in result["properties"]
+    assert "wait_mode" not in result["required"]
 
 
 # ── _resolve_effective_timeout ──────────────────────────────────────────────
 
 
-def test_background_returns_zero():
-    assert (
-        _resolve_effective_timeout(background=True, yield_ms=None, approval_timeout_seconds=None, server_default=30.0)
-        == 0
-    )
+def test_blocking_returns_inf():
+    assert _resolve_effective_timeout(BlockingWait(), server_default=30.0) == float("inf")
 
 
-def test_background_overrides_yield_ms_and_approval_timeout():
-    assert (
-        _resolve_effective_timeout(background=True, yield_ms=5000, approval_timeout_seconds=10.0, server_default=30.0)
-        == 0
-    )
+def test_blocking_overrides_server_default():
+    assert _resolve_effective_timeout(BlockingWait(), server_default=0.01) == float("inf")
 
 
-def test_yield_ms_converts_to_seconds():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=5000, approval_timeout_seconds=None, server_default=None)
-        == 5.0
-    )
+def test_yield_after_ms_converts_to_seconds():
+    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=5000), server_default=None) == 5.0
 
 
-def test_yield_ms_overrides_approval_timeout():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=2000, approval_timeout_seconds=10.0, server_default=30.0)
-        == 2.0
-    )
+def test_yield_after_ms_overrides_server_default():
+    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=2000), server_default=30.0) == 2.0
 
 
-def test_yield_ms_clamps_negative_to_zero():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=-100, approval_timeout_seconds=None, server_default=None)
-        == 0
-    )
+def test_yield_after_ms_clamps_negative_to_zero():
+    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=-100), server_default=None) == 0
 
 
-def test_approval_timeout_overrides_server_default():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=5.0, server_default=30.0)
-        == 5.0
-    )
+def test_yield_after_ms_zero_returns_zero():
+    assert _resolve_effective_timeout(YieldAfterMs(timeout_ms=0), server_default=30.0) == 0
 
 
-def test_falls_back_to_server_default():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=None, server_default=30.0)
-        == 30.0
-    )
+def test_none_falls_back_to_server_default():
+    assert _resolve_effective_timeout(None, server_default=30.0) == 30.0
 
 
-def test_all_none_returns_none():
-    assert (
-        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=None, server_default=None)
-        is None
-    )
+def test_none_with_none_default_returns_none():
+    assert _resolve_effective_timeout(None, server_default=None) is None
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_proxy_server.py
+++ b/approval_gate/test_proxy_server.py
@@ -2,7 +2,7 @@ import pytest
 import pytest_bazel
 
 from approval_gate.models import BlockingWait, YieldAfterMs
-from approval_gate.proxy_server import _resolve_effective_wait, _wait_mode_to_timeout, _wrap_tool_schema
+from approval_gate.proxy_server import _wait_mode_to_timeout, _wrap_tool_schema
 
 
 def test_wraps_original_schema_under_input():
@@ -37,24 +37,6 @@ def test_schema_includes_wait_mode():
     assert "wait_mode" not in result["required"]
 
 
-# ── _resolve_effective_wait ─────────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    ("per_call", "server_default", "expected"),
-    [
-        pytest.param(BlockingWait(), YieldAfterMs(timeout_ms=5000), BlockingWait(), id="per-call-overrides-default"),
-        pytest.param(None, BlockingWait(), BlockingWait(), id="falls-back-to-default"),
-        pytest.param(None, None, None, id="none-with-none"),
-        pytest.param(
-            YieldAfterMs(timeout_ms=0), BlockingWait(), YieldAfterMs(timeout_ms=0), id="yield-overrides-blocking"
-        ),
-    ],
-)
-def test_resolve_effective_wait(per_call, server_default, expected):
-    assert _resolve_effective_wait(per_call, server_default) == expected
-
-
 # ── _wait_mode_to_timeout ──────────────────────────────────────────────────
 
 
@@ -65,7 +47,6 @@ def test_resolve_effective_wait(per_call, server_default, expected):
         pytest.param(YieldAfterMs(timeout_ms=5000), 5.0, id="yield-converts-to-seconds"),
         pytest.param(YieldAfterMs(timeout_ms=0), 0, id="yield-zero"),
         pytest.param(YieldAfterMs(timeout_ms=-100), 0, id="yield-negative-clamps-to-zero"),
-        pytest.param(None, None, id="none-returns-none"),
     ],
 )
 def test_wait_mode_to_timeout(wait_mode, expected):

--- a/approval_gate/test_proxy_server.py
+++ b/approval_gate/test_proxy_server.py
@@ -1,6 +1,6 @@
 import pytest_bazel
 
-from approval_gate.proxy_server import _wrap_tool_schema
+from approval_gate.proxy_server import _resolve_effective_timeout, _wrap_tool_schema
 
 
 def test_wraps_original_schema_under_input():
@@ -27,6 +27,73 @@ def test_does_not_mutate_original_schema():
     _wrap_tool_schema(original)
     assert list(original["properties"].keys()) == ["x"]
     assert original["required"] == ["x"]
+
+
+def test_schema_includes_background_and_yield_ms():
+    result = _wrap_tool_schema({})
+    assert "background" in result["properties"]
+    assert "yield_ms" in result["properties"]
+    assert "background" not in result["required"]
+    assert "yield_ms" not in result["required"]
+
+
+# ── _resolve_effective_timeout ──────────────────────────────────────────────
+
+
+def test_background_returns_zero():
+    assert (
+        _resolve_effective_timeout(background=True, yield_ms=None, approval_timeout_seconds=None, server_default=30.0)
+        == 0
+    )
+
+
+def test_background_overrides_yield_ms_and_approval_timeout():
+    assert (
+        _resolve_effective_timeout(background=True, yield_ms=5000, approval_timeout_seconds=10.0, server_default=30.0)
+        == 0
+    )
+
+
+def test_yield_ms_converts_to_seconds():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=5000, approval_timeout_seconds=None, server_default=None)
+        == 5.0
+    )
+
+
+def test_yield_ms_overrides_approval_timeout():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=2000, approval_timeout_seconds=10.0, server_default=30.0)
+        == 2.0
+    )
+
+
+def test_yield_ms_clamps_negative_to_zero():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=-100, approval_timeout_seconds=None, server_default=None)
+        == 0
+    )
+
+
+def test_approval_timeout_overrides_server_default():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=5.0, server_default=30.0)
+        == 5.0
+    )
+
+
+def test_falls_back_to_server_default():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=None, server_default=30.0)
+        == 30.0
+    )
+
+
+def test_all_none_returns_none():
+    assert (
+        _resolve_effective_timeout(background=False, yield_ms=None, approval_timeout_seconds=None, server_default=None)
+        is None
+    )
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_reconnect.py
+++ b/approval_gate/test_reconnect.py
@@ -16,47 +16,44 @@ from __future__ import annotations
 
 import anyio
 import pytest_bazel
-from fastmcp import FastMCP
 
-from approval_gate.conftest import TEST_NS, GateAppFactory, GateClient, agent_transport, operator_transport, serve_app
+from approval_gate.conftest import (
+    TEST_NS,
+    EchoBackend,
+    GateAppFactory,
+    GateClient,
+    agent_transport,
+    operator_transport,
+    serve_app,
+)
 from approval_gate.models import Action, ActionStatus
 from mcp_infra.resource_utils import read_text_json_typed
 
-_SESSION = "reconnect-session"
-
-
-def _make_backend():
-    calls: list[str] = []
-    backend = FastMCP()
-
-    @backend.tool()
-    async def echo(text: str) -> str:
-        calls.append(text)
-        return f"echoed: {text}"
-
-    return backend, calls
-
 
 async def test_client_reconnects_after_server_restart(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    make_gate_app: GateAppFactory,
+    free_port: int,
+    base_url: str,
+    agent_jwt: str,
+    operator_jwt: str,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """New client connects after server restart and can call tools successfully."""
-    backend, calls = _make_backend()
-    base_url = f"http://127.0.0.1:{free_port}"
 
     # ── Phase 1: start server, call tool ─────────────────────────────────
-    app1 = make_gate_app({TEST_NS: backend})
+    app1 = make_gate_app({TEST_NS: echo_backend.server})
     async with serve_app(app1, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
         tools = await agent.list_tools()
         assert any(t.name == "test_echo" for t in tools)
 
-        key_1 = await agent.call_echo("before-restart", session_key=_SESSION)
-        assert key_1.session_key == _SESSION
+        a1 = await agent.call_echo("before-restart", session_key=session_key)
+        assert a1.key.session_key == session_key
 
     # Server is now down — old client is disconnected
 
     # ── Phase 2: restart server on same port, same db ────────────────────
-    app2 = make_gate_app({TEST_NS: backend})
+    app2 = make_gate_app({TEST_NS: echo_backend.server})
     async with serve_app(app2, port=free_port):
         # New client connects successfully
         async with GateClient(agent_transport(base_url, agent_jwt)) as agent:
@@ -64,74 +61,82 @@ async def test_client_reconnects_after_server_restart(
             assert any(t.name == "test_echo" for t in tools)
 
             # Call tool again — new action
-            key_2 = await agent.call_echo("after-restart", session_key=_SESSION)
-            assert key_2.action_seq > key_1.action_seq
+            a2 = await agent.call_echo("after-restart", session_key=session_key)
+            assert a2.key.action_seq > a1.key.action_seq
 
         # Approve via operator and verify execution
         async with GateClient(operator_transport(base_url, operator_jwt)) as operator:
-            await operator.approve(key_2)
+            await operator.approve(a2.key)
 
-        assert "after-restart" in calls
+        assert "after-restart" in echo_backend.calls
 
 
 async def test_pending_action_survives_server_restart(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    make_gate_app: GateAppFactory,
+    free_port: int,
+    base_url: str,
+    agent_jwt: str,
+    operator_jwt: str,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """Action created before restart is readable and resolvable after restart."""
-    backend, calls = _make_backend()
-    base_url = f"http://127.0.0.1:{free_port}"
 
     # ── Phase 1: create action ───────────────────────────────────────────
-    app1 = make_gate_app({TEST_NS: backend})
+    app1 = make_gate_app({TEST_NS: echo_backend.server})
     async with serve_app(app1, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        key = await agent.call_echo("survive", session_key=_SESSION)
+        created = await agent.call_echo("survive", session_key=session_key)
 
     # Server down — action is persisted in SQLite
 
     # ── Phase 2: restart, approve, verify catch-up ───────────────────────
-    app2 = make_gate_app({TEST_NS: backend})
+    app2 = make_gate_app({TEST_NS: echo_backend.server})
     async with (
         serve_app(app2, port=free_port),
         GateClient(operator_transport(base_url, operator_jwt)) as operator,
         GateClient(agent_transport(base_url, agent_jwt)) as agent,
     ):
-        await operator.approve(key)
-        action_uri = f"resource://sessions/{key.session_key}/actions/{key.action_seq}"
+        await operator.approve(created.key)
+        action_uri = f"resource://sessions/{created.key.session_key}/actions/{created.key.action_seq}"
         action: Action = await read_text_json_typed(agent, action_uri, Action)
         assert action.state.status == ActionStatus.DONE
 
-    assert "survive" in calls
+    assert "survive" in echo_backend.calls
 
 
 async def test_resubscribe_receives_notifications_after_restart(
-    make_gate_app: GateAppFactory, free_port: int, agent_jwt: str, operator_jwt: str
+    make_gate_app: GateAppFactory,
+    free_port: int,
+    base_url: str,
+    agent_jwt: str,
+    operator_jwt: str,
+    echo_backend: EchoBackend,
+    session_key: str,
 ):
     """Re-subscribing to a session's log HWM on a new connection receives notifications."""
-    backend, calls = _make_backend()
-    base_url = f"http://127.0.0.1:{free_port}"
 
     # ── Phase 1: create action ───────────────────────────────────────────
-    app1 = make_gate_app({TEST_NS: backend})
+    app1 = make_gate_app({TEST_NS: echo_backend.server})
     async with serve_app(app1, port=free_port), GateClient(agent_transport(base_url, agent_jwt)) as agent:
-        key = await agent.call_echo("resub", session_key=_SESSION)
+        created = await agent.call_echo("resub", session_key=session_key)
 
     # Server down
 
     # ── Phase 2: restart, re-subscribe, approve, wait for notification ───
-    app2 = make_gate_app({TEST_NS: backend})
+    app2 = make_gate_app({TEST_NS: echo_backend.server})
     async with serve_app(app2, port=free_port):
         async with GateClient(agent_transport(base_url, agent_jwt)) as agent:
             # Approve via operator
             async with GateClient(operator_transport(base_url, operator_jwt)) as operator:
-                await operator.approve(key)
+                await operator.approve(created.key)
 
             # Wait for the ResourceUpdated notification on the new connection
             with anyio.fail_after(10.0):
-                action = await agent.wait_for(key, ActionStatus.DONE)
+                action = await agent.wait_for(created.key, ActionStatus.DONE)
 
             assert action.state.status == ActionStatus.DONE
 
-        assert "resub" in calls
+        assert "resub" in echo_backend.calls
 
 
 if __name__ == "__main__":

--- a/approval_gate/test_storage.py
+++ b/approval_gate/test_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest_bazel
 from mcp.types import CallToolResult, TextContent
 
@@ -15,6 +17,8 @@ from approval_gate.models import (
     ToolCall,
 )
 from approval_gate.storage import ActionStorage
+
+_NOW = datetime.now(tz=UTC)
 
 
 async def test_create_and_get(storage: ActionStorage):
@@ -113,13 +117,15 @@ async def test_get_log_hwm(storage: ActionStorage):
     await storage.append_log_entry(session_key="hwm-sess", action_seq=1, detail=ActionReceivedDetail())
     assert await storage.get_log_hwm("hwm-sess") == 1
 
-    await storage.append_log_entry(session_key="hwm-sess", action_seq=1, detail=ExecutionStartedDetail())
+    await storage.append_log_entry(session_key="hwm-sess", action_seq=1, detail=ExecutionStartedDetail(started_at=_NOW))
     assert await storage.get_log_hwm("hwm-sess") == 2
 
 
 async def test_get_log_entry(storage: ActionStorage):
     await storage.append_log_entry(session_key="entry-sess", action_seq=1, detail=ActionReceivedDetail())
-    await storage.append_log_entry(session_key="entry-sess", action_seq=1, detail=ExecutionStartedDetail())
+    await storage.append_log_entry(
+        session_key="entry-sess", action_seq=1, detail=ExecutionStartedDetail(started_at=_NOW)
+    )
 
     entry = await storage.get_log_entry("entry-sess", 2)
     assert entry is not None

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -169,6 +169,9 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
   // ── Resilient MCP connection to approval gate server ──────────────────────
   const connection = new ApprovalGateConnection(approvalGateUrl, approvalGateToken, log);
 
+  // Actions resolved inline (within approval_timeout_seconds) — skip notifications for these
+  const inlineResolvedActions = new Set<string>();
+
   async function catchUpSession(sessionKey: string): Promise<void> {
     let newHwm: number;
     try {
@@ -195,6 +198,10 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
       if (!entry || !isTerminalLogKind(entry.detail.kind)) continue;
 
       const keyStr = `${sessionKey}/${entry.action_seq}`;
+
+      // Skip notification for actions that were resolved inline within the tool call
+      if (inlineResolvedActions.delete(keyStr)) continue;
+
       const message = formatTerminalMessage(keyStr, entry.detail);
       enqueueSystemEvent(message, { sessionKey });
       log.info(`enqueued system event for action ${keyStr}`);
@@ -269,7 +276,35 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
           }
 
           const firstContent = result.content?.[0] as { text: string };
-          const actionKey = JSON.parse(firstContent.text) as ActionKey;
+          const parsed = JSON.parse(firstContent.text) as Action | ActionKey;
+
+          // New server returns full Action; old server returns bare ActionKey
+          if ("state" in parsed) {
+            const action = parsed as Action;
+            const keyStr = `${action.key.session_key}/${action.key.action_seq}`;
+            const { status } = action.state;
+
+            if (status === "done" || status === "rejected" || status === "withdrawn") {
+              // Resolved inline — return result directly, suppress duplicate notification
+              inlineResolvedActions.add(keyStr);
+              await connection.trackSession(action.key.session_key);
+              const outcome = formatTerminalMessage(keyStr, {
+                kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
+                ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
+                ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
+              } as LogEventDetail);
+              return { content: [{ type: "text" as const, text: outcome }] };
+            }
+
+            // Still pending or executing — set up notifications for later delivery
+            await connection.trackSession(action.key.session_key);
+            return {
+              content: [{ type: "text" as const, text: `Action ${keyStr} is ${status}` }],
+            };
+          }
+
+          // Old server format: bare ActionKey — existing behavior
+          const actionKey = parsed as ActionKey;
           const keyStr = `${actionKey.session_key}/${actionKey.action_seq}`;
 
           await connection.trackSession(actionKey.session_key);
@@ -280,9 +315,6 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
             const action = JSON.parse(text) as Action;
             const { status } = action.state;
             if (status === "done" || status === "rejected" || status === "withdrawn") {
-              // TODO: The mapping from action state to log detail kind is awkward because
-              // Action.state and LogEntry.detail have overlapping but different shapes.
-              // Consider unifying the terminal state representation upstream.
               const outcome = formatTerminalMessage(keyStr, {
                 kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
                 ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -56,8 +56,8 @@ function formatNotificationMessage(keyStr: string, detail: LogEventDetail): stri
     }
   }
   if (detail.kind === "execution_running") {
-    const elapsed = (detail as { elapsed_seconds?: number }).elapsed_seconds;
-    const suffix = typeof elapsed === "number" ? ` (${elapsed}s elapsed)` : "";
+    const startedAt = (detail as { started_at?: string }).started_at;
+    const suffix = startedAt ? ` (started at ${startedAt})` : "";
     return `Action ${keyStr} is still executing${suffix}`;
   }
   if (detail.kind === "denied") {

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -31,13 +31,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ApprovalGateConnection, parseSessionKeyFromHwmUri } from "./approval-gate-connection.js";
 import { ReconnectingMcpClient } from "./reconnecting-mcp-client.js";
 import { scopedLogger } from "./util.js";
-import type { Action, Detail as LogEventDetail, DoneState, RejectedState } from "./types.js";
+import type { Action, Detail as LogEventDetail, DoneState, ExecutionStartedDetail, RejectedState } from "./types.js";
 
 const DEFAULT_EXEC_SERVER_URL = "http://127.0.0.1:8766/mcp";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TERMINAL_LOG_KINDS = new Set(["execution_finished", "denied", "withdrawn"]);
+const TERMINAL_STATUSES = new Set(["done", "rejected", "withdrawn"]);
 const NOTIFY_LOG_KINDS = new Set([...TERMINAL_LOG_KINDS, "execution_started"]);
 
 function shouldNotifyLogKind(kind: string): boolean {
@@ -56,8 +57,9 @@ function formatNotificationMessage(keyStr: string, detail: LogEventDetail): stri
     }
   }
   if (detail.kind === "execution_started") {
-    const startedAt = (detail as { started_at?: string }).started_at;
-    const suffix = startedAt ? ` (started at ${startedAt})` : "";
+    const suffix = (detail as ExecutionStartedDetail).started_at
+      ? ` (started at ${(detail as ExecutionStartedDetail).started_at})`
+      : "";
     return `Action ${keyStr} execution started${suffix}`;
   }
   if (detail.kind === "denied") {
@@ -94,8 +96,6 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         approvalGate?: { url?: string; token?: string };
         execServer?: { url?: string };
         registerTools?: boolean;
-        approvalMode?: "immediate" | "bounded" | "blocking";
-        approvalTimeoutSeconds?: number;
       }
     | undefined;
 
@@ -266,7 +266,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     for (const tool of toolList.tools) {
       const toolName = tool.name;
       const toolDescription = tool.description ?? "";
-      const schema = stripSchemaKeys((tool.inputSchema ?? {}) as Record<string, unknown>, ["session_key", "wait_mode"]);
+      const schema = stripSchemaKeys((tool.inputSchema ?? {}) as Record<string, unknown>, ["session_key"]);
 
       api.registerTool((ctx: OpenClawPluginToolContext) => ({
         name: toolName,
@@ -274,23 +274,9 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         description: toolDescription,
         parameters: schema,
         async execute(_id: string, params: Record<string, unknown>) {
-          // Derive wait_mode from plugin config when not explicitly provided per-call.
-          // 3 modes: immediate (yield 0ms), bounded (yield Nms), blocking (wait forever).
-          let waitMode: Record<string, unknown> | undefined;
-          if (!("wait_mode" in params)) {
-            const mode = cfg?.approvalMode ?? "bounded";
-            if (mode === "immediate") {
-              waitMode = { mode: "yield_after_ms", timeout_ms: 0 };
-            } else if (mode === "blocking") {
-              waitMode = { mode: "blocking" };
-            } else {
-              waitMode = { mode: "yield_after_ms", timeout_ms: (cfg?.approvalTimeoutSeconds ?? 30) * 1000 };
-            }
-          }
           const callArgs = {
             ...params,
             session_key: ctx.sessionKey,
-            ...(waitMode ? { wait_mode: waitMode } : {}),
           };
 
           let result: Awaited<ReturnType<Client["callTool"]>>;
@@ -312,7 +298,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
           const keyStr = `${action.key.session_key}/${action.key.action_seq}`;
           const { status } = action.state;
 
-          if (status === "done" || status === "rejected" || status === "withdrawn") {
+          if (TERMINAL_STATUSES.has(status)) {
             // Resolved inline — return result directly, suppress duplicate notification
             inlineResolvedActions.add(keyStr);
             await connection.trackSession(action.key.session_key);

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -38,7 +38,7 @@ const DEFAULT_EXEC_SERVER_URL = "http://127.0.0.1:8766/mcp";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TERMINAL_LOG_KINDS = new Set(["execution_finished", "denied", "withdrawn"]);
-const NOTIFY_LOG_KINDS = new Set([...TERMINAL_LOG_KINDS, "execution_running"]);
+const NOTIFY_LOG_KINDS = new Set([...TERMINAL_LOG_KINDS, "execution_started"]);
 
 function shouldNotifyLogKind(kind: string): boolean {
   return NOTIFY_LOG_KINDS.has(kind);
@@ -55,10 +55,10 @@ function formatNotificationMessage(keyStr: string, detail: LogEventDetail): stri
       return `Action ${keyStr} was approved but execution returned an error:\n\n${body}`;
     }
   }
-  if (detail.kind === "execution_running") {
+  if (detail.kind === "execution_started") {
     const startedAt = (detail as { started_at?: string }).started_at;
     const suffix = startedAt ? ` (started at ${startedAt})` : "";
-    return `Action ${keyStr} is still executing${suffix}`;
+    return `Action ${keyStr} execution started${suffix}`;
   }
   if (detail.kind === "denied") {
     return `Action ${keyStr} was rejected by the user. Reason: ${detail.reason ?? "none given"}`;
@@ -206,8 +206,8 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
       const keyStr = `${sessionKey}/${entry.action_seq}`;
 
       // Skip notification for actions that were resolved inline within the tool call.
-      // Only consume the suppression on terminal events — running notices should not
-      // eat the suppression token meant for the subsequent terminal event.
+      // Only consume the suppression on terminal events — non-terminal events
+      // (execution_started) should not eat the suppression token.
       if (inlineResolvedActions.has(keyStr)) {
         if (TERMINAL_LOG_KINDS.has(entry.detail.kind)) {
           inlineResolvedActions.delete(keyStr);

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -38,13 +38,14 @@ const DEFAULT_EXEC_SERVER_URL = "http://127.0.0.1:8766/mcp";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TERMINAL_LOG_KINDS = new Set(["execution_finished", "denied", "withdrawn"]);
+const NOTIFY_LOG_KINDS = new Set([...TERMINAL_LOG_KINDS, "execution_running"]);
 
-function isTerminalLogKind(kind: string): boolean {
-  return TERMINAL_LOG_KINDS.has(kind);
+function shouldNotifyLogKind(kind: string): boolean {
+  return NOTIFY_LOG_KINDS.has(kind);
 }
 
-/** Format a human-readable message from a terminal log entry detail. */
-function formatTerminalMessage(keyStr: string, detail: LogEventDetail): string {
+/** Format a human-readable message from a notifiable log entry detail. */
+function formatNotificationMessage(keyStr: string, detail: LogEventDetail): string {
   if (detail.kind === "execution_finished") {
     const parts = detail.outcome.content.filter((c) => c.type === "text" && c.text).map((c) => c.text as string);
     const body = parts.join("\n") || JSON.stringify(detail.outcome.content, null, 2);
@@ -53,6 +54,11 @@ function formatTerminalMessage(keyStr: string, detail: LogEventDetail): string {
     } else {
       return `Action ${keyStr} was approved but execution returned an error:\n\n${body}`;
     }
+  }
+  if (detail.kind === "execution_running") {
+    const elapsed = (detail as { elapsed_seconds?: number }).elapsed_seconds;
+    const suffix = typeof elapsed === "number" ? ` (${elapsed}s elapsed)` : "";
+    return `Action ${keyStr} is still executing${suffix}`;
   }
   if (detail.kind === "denied") {
     return `Action ${keyStr} was rejected by the user. Reason: ${detail.reason ?? "none given"}`;
@@ -195,14 +201,21 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     );
 
     for (const entry of entries) {
-      if (!entry || !isTerminalLogKind(entry.detail.kind)) continue;
+      if (!entry || !shouldNotifyLogKind(entry.detail.kind)) continue;
 
       const keyStr = `${sessionKey}/${entry.action_seq}`;
 
-      // Skip notification for actions that were resolved inline within the tool call
-      if (inlineResolvedActions.delete(keyStr)) continue;
+      // Skip notification for actions that were resolved inline within the tool call.
+      // Only consume the suppression on terminal events — running notices should not
+      // eat the suppression token meant for the subsequent terminal event.
+      if (inlineResolvedActions.has(keyStr)) {
+        if (TERMINAL_LOG_KINDS.has(entry.detail.kind)) {
+          inlineResolvedActions.delete(keyStr);
+        }
+        continue;
+      }
 
-      const message = formatTerminalMessage(keyStr, entry.detail);
+      const message = formatNotificationMessage(keyStr, entry.detail);
       enqueueSystemEvent(message, { sessionKey });
       log.info(`enqueued system event for action ${keyStr}`);
     }
@@ -288,7 +301,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
               // Resolved inline — return result directly, suppress duplicate notification
               inlineResolvedActions.add(keyStr);
               await connection.trackSession(action.key.session_key);
-              const outcome = formatTerminalMessage(keyStr, {
+              const outcome = formatNotificationMessage(keyStr, {
                 kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
                 ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
                 ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
@@ -315,7 +328,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
             const action = JSON.parse(text) as Action;
             const { status } = action.state;
             if (status === "done" || status === "rejected" || status === "withdrawn") {
-              const outcome = formatTerminalMessage(keyStr, {
+              const outcome = formatNotificationMessage(keyStr, {
                 kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
                 ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
                 ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -31,7 +31,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ApprovalGateConnection, parseSessionKeyFromHwmUri } from "./approval-gate-connection.js";
 import { ReconnectingMcpClient } from "./reconnecting-mcp-client.js";
 import { scopedLogger } from "./util.js";
-import type { Action, ActionKey, Detail as LogEventDetail, DoneState, RejectedState } from "./types.js";
+import type { Action, Detail as LogEventDetail, DoneState, RejectedState } from "./types.js";
 
 const DEFAULT_EXEC_SERVER_URL = "http://127.0.0.1:8766/mcp";
 
@@ -94,6 +94,8 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         approvalGate?: { url?: string; token?: string };
         execServer?: { url?: string };
         registerTools?: boolean;
+        approvalMode?: "immediate" | "bounded" | "blocking";
+        approvalTimeoutSeconds?: number;
       }
     | undefined;
 
@@ -264,7 +266,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     for (const tool of toolList.tools) {
       const toolName = tool.name;
       const toolDescription = tool.description ?? "";
-      const schema = stripSchemaKeys((tool.inputSchema ?? {}) as Record<string, unknown>, ["session_key"]);
+      const schema = stripSchemaKeys((tool.inputSchema ?? {}) as Record<string, unknown>, ["session_key", "wait_mode"]);
 
       api.registerTool((ctx: OpenClawPluginToolContext) => ({
         name: toolName,
@@ -272,7 +274,24 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         description: toolDescription,
         parameters: schema,
         async execute(_id: string, params: Record<string, unknown>) {
-          const callArgs = { ...params, session_key: ctx.sessionKey };
+          // Derive wait_mode from plugin config when not explicitly provided per-call.
+          // 3 modes: immediate (yield 0ms), bounded (yield Nms), blocking (wait forever).
+          let waitMode: Record<string, unknown> | undefined;
+          if (!("wait_mode" in params)) {
+            const mode = cfg?.approvalMode ?? "bounded";
+            if (mode === "immediate") {
+              waitMode = { mode: "yield_after_ms", timeout_ms: 0 };
+            } else if (mode === "blocking") {
+              waitMode = { mode: "blocking" };
+            } else {
+              waitMode = { mode: "yield_after_ms", timeout_ms: (cfg?.approvalTimeoutSeconds ?? 30) * 1000 };
+            }
+          }
+          const callArgs = {
+            ...params,
+            session_key: ctx.sessionKey,
+            ...(waitMode ? { wait_mode: waitMode } : {}),
+          };
 
           let result: Awaited<ReturnType<Client["callTool"]>>;
           try {
@@ -289,63 +308,26 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
           }
 
           const firstContent = result.content?.[0] as { text: string };
-          const parsed = JSON.parse(firstContent.text) as Action | ActionKey;
+          const action = JSON.parse(firstContent.text) as Action;
+          const keyStr = `${action.key.session_key}/${action.key.action_seq}`;
+          const { status } = action.state;
 
-          // New server returns full Action; old server returns bare ActionKey
-          if ("state" in parsed) {
-            const action = parsed as Action;
-            const keyStr = `${action.key.session_key}/${action.key.action_seq}`;
-            const { status } = action.state;
-
-            if (status === "done" || status === "rejected" || status === "withdrawn") {
-              // Resolved inline — return result directly, suppress duplicate notification
-              inlineResolvedActions.add(keyStr);
-              await connection.trackSession(action.key.session_key);
-              const outcome = formatNotificationMessage(keyStr, {
-                kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
-                ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
-                ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
-              } as LogEventDetail);
-              return { content: [{ type: "text" as const, text: outcome }] };
-            }
-
-            // Still pending or executing — set up notifications for later delivery
+          if (status === "done" || status === "rejected" || status === "withdrawn") {
+            // Resolved inline — return result directly, suppress duplicate notification
+            inlineResolvedActions.add(keyStr);
             await connection.trackSession(action.key.session_key);
-            return {
-              content: [{ type: "text" as const, text: `Action ${keyStr} is ${status}` }],
-            };
+            const outcome = formatNotificationMessage(keyStr, {
+              kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
+              ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
+              ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
+            } as LogEventDetail);
+            return { content: [{ type: "text" as const, text: outcome }] };
           }
 
-          // Old server format: bare ActionKey — existing behavior
-          const actionKey = parsed as ActionKey;
-          const keyStr = `${actionKey.session_key}/${actionKey.action_seq}`;
-
-          await connection.trackSession(actionKey.session_key);
-
-          const actionUri = `resource://sessions/${actionKey.session_key}/actions/${actionKey.action_seq}`;
-          try {
-            const text = await connection.readResourceText(actionUri);
-            const action = JSON.parse(text) as Action;
-            const { status } = action.state;
-            if (status === "done" || status === "rejected" || status === "withdrawn") {
-              const outcome = formatNotificationMessage(keyStr, {
-                kind: status === "done" ? "execution_finished" : status === "rejected" ? "denied" : "withdrawn",
-                ...(status === "done" ? { outcome: (action.state as DoneState).outcome } : {}),
-                ...(status === "rejected" ? { reason: (action.state as RejectedState).reason } : {}),
-              } as LogEventDetail);
-              return { content: [{ type: "text" as const, text: outcome }] };
-            }
-          } catch (err) {
-            log.warn(`could not read initial state for ${actionUri}: ${String(err)}`);
-          }
-
+          // Still pending or executing — set up notifications for later delivery
+          await connection.trackSession(action.key.session_key);
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Action ${keyStr} queued for user approval`,
-              },
-            ],
+            content: [{ type: "text" as const, text: `Action ${keyStr} is ${status}` }],
           };
         },
       }));

--- a/openclaw/approval-gate/openclaw.plugin.json
+++ b/openclaw/approval-gate/openclaw.plugin.json
@@ -37,6 +37,17 @@
         "type": "boolean",
         "default": false,
         "description": "Whether to discover and register approval-gate-wrapped tools with OpenClaw. When false (default), the plugin only listens for action notifications and delivers results via system events."
+      },
+      "approvalMode": {
+        "type": "string",
+        "enum": ["immediate", "bounded", "blocking"],
+        "default": "bounded",
+        "description": "Default resolution mode for tool calls. 'immediate': return thunk without waiting. 'bounded': wait up to approvalTimeoutSeconds then return thunk. 'blocking': wait indefinitely for terminal resolution."
+      },
+      "approvalTimeoutSeconds": {
+        "type": "number",
+        "default": 30,
+        "description": "Seconds to wait in 'bounded' mode before returning a thunk. Ignored in 'immediate' and 'blocking' modes."
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR adds configurable wait modes to the approval-gate system, allowing agents to control how long tool calls wait for action resolution before returning. Servers can set a default wait mode, and agents can override it per-call.

## Key Changes

- **Wait mode models**: Added `BlockingWait` and `YieldAfterMs` discriminated union types to `models.py` for specifying resolution behavior
  - `BlockingWait`: Wait indefinitely until terminal state
  - `YieldAfterMs`: Wait up to N milliseconds then return current state

- **Tool schema updates**: Modified `_wrap_tool_schema()` to include optional `wait_mode` parameter in wrapped tool signatures

- **Server-side wait implementation**: 
  - Added `default_wait_mode` config field and server parameter
  - Implemented `_wait_mode_to_timeout()` helper to convert wait modes to timeout values
  - Tool handler now waits for action resolution based on resolved wait mode (server default + per-call override)
  - Added `_action_resolved_events` tracking to signal when actions reach terminal state

- **Client API updates**:
  - `GateClient.call_gate_tool()` now returns full `Action` object instead of just `ActionKey`
  - `GateClient.call_echo()` accepts optional `wait_mode` parameter
  - Test fixtures refactored: `echo_backend`, `agent_client_transport`, `operator_client_transport`, `base_url`, `session_key` for cleaner test setup

- **Test coverage**: Added comprehensive parametrized tests for wait mode resolution scenarios:
  - Server default + per-call override combinations
  - Auto-deny with timeout returning rejected state
  - Blocking wait with operator approval
  - Yield-after-ms with various timeouts

- **Predicate loading**: Removed fail-safe fallback behavior; `load_predicate()` now raises on missing/invalid files instead of silently defaulting to `NeedsHumanDecision`

- **Notification filtering**: Updated OpenClaw plugin to skip duplicate notifications for actions resolved inline within tool calls, tracking via `inlineResolvedActions` set

- **Documentation**: Updated instructions and README to reflect new wait mode behavior and immediate vs. deferred resolution patterns

## Implementation Details

- Wait mode resolution follows: per-call override > server default > immediate return (0ms)
- Actions reaching terminal state signal via `asyncio.Event` to unblock waiting callers
- `ExecutionStartedDetail` now includes `started_at` timestamp for better observability
- Test fixtures consolidated to reduce boilerplate and improve maintainability

https://claude.ai/code/session_01EyT241Yd4cjsCXcUjBNSPL