### PR TITLE
Address Copilot review comments from PR #775

### DIFF
--- a/approval_gate/models.py
+++ b/approval_gate/models.py
@@ -147,7 +147,7 @@ class WithdrawnDetail(BaseModel):
 
 class ExecutionStartedDetail(BaseModel):
     kind: Literal[LogEventKind.EXECUTION_STARTED] = LogEventKind.EXECUTION_STARTED
-    started_at: datetime
+    started_at: datetime | None = None
     model_config = ConfigDict(extra="forbid")
 
 

--- a/approval_gate/proxy_server.py
+++ b/approval_gate/proxy_server.py
@@ -306,9 +306,17 @@ class ApprovalGateServer(EnhancedFastMCP):
                             current.state, (DoneState, RejectedState, WithdrawnState)
                         ):
                             break
-                        # Intermediate transition (e.g. PENDING → EXECUTING); reset and wait again
+                        # Intermediate transition (e.g. PENDING → EXECUTING); reset and wait again.
+                        # Re-check state immediately after installing the new event to avoid a race
+                        # where the terminal transition fires between the get_action call above and
+                        # the new event being registered (which would leave the new event never set).
                         event = asyncio.Event()
                         self._action_resolved_events[key] = event
+                        current = await self._req_storage.get_action(key)
+                        if current is not None and isinstance(
+                            current.state, (DoneState, RejectedState, WithdrawnState)
+                        ):
+                            break
                 self._action_resolved_events.pop(key, None)
 
             result = await self._req_storage.get_action(key)

--- a/cluster/k8s/approval-gate/config.yaml
+++ b/cluster/k8s/approval-gate/config.yaml
@@ -6,3 +6,8 @@ public_base_url: "https://approval-gate.allegedly.works"
 oidc_issuer: "https://auth.allegedly.works/application/o/approval-gate/"
 oidc_client_id: "approval-gate-operator"
 db_path: "/data/approval_gate.db"
+predicate_path: "/etc/approval-gate/predicate.py"
+port: 8765
+default_wait_mode:
+  mode: yield_after_ms
+  timeout_ms: 30000

--- a/cluster/k8s/approval-gate/kustomization.yaml
+++ b/cluster/k8s/approval-gate/kustomization.yaml
@@ -18,3 +18,4 @@ configMapGenerator:
     namespace: approval-gate
     files:
       - config.yaml
+      - predicate.py

--- a/cluster/k8s/approval-gate/predicate.py
+++ b/cluster/k8s/approval-gate/predicate.py
@@ -1,0 +1,5 @@
+from approval_gate.predicates import NeedsHumanDecision
+
+
+def decide(server_namespace: str, tool_name: str, arguments: dict) -> NeedsHumanDecision:
+    return NeedsHumanDecision()

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -96,12 +96,23 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         approvalGate?: { url?: string; token?: string };
         execServer?: { url?: string };
         registerTools?: boolean;
+        approvalMode?: "immediate" | "bounded" | "blocking";
+        approvalTimeoutSeconds?: number;
       }
     | undefined;
 
   const approvalGateUrl = cfg?.approvalGate?.url?.trim();
   const approvalGateToken = cfg?.approvalGate?.token?.trim();
   const execServerUrl = cfg?.execServer?.url?.trim() ?? DEFAULT_EXEC_SERVER_URL;
+
+  const approvalMode = cfg?.approvalMode ?? "bounded";
+  const approvalTimeoutSeconds = cfg?.approvalTimeoutSeconds ?? 30;
+  const defaultWaitMode =
+    approvalMode === "blocking"
+      ? { mode: "blocking" }
+      : approvalMode === "immediate"
+        ? { mode: "yield_after_ms", timeout_ms: 0 }
+        : { mode: "yield_after_ms", timeout_ms: approvalTimeoutSeconds * 1000 };
 
   if (!approvalGateUrl || !approvalGateToken) {
     log.warn("approvalGate.url and approvalGate.token are required in plugin config; plugin disabled");
@@ -275,6 +286,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
         parameters: schema,
         async execute(_id: string, params: Record<string, unknown>) {
           const callArgs = {
+            wait_mode: defaultWaitMode,
             ...params,
             session_key: ctx.sessionKey,
           };

--- a/openclaw/approval-gate/openclaw.plugin.json
+++ b/openclaw/approval-gate/openclaw.plugin.json
@@ -42,12 +42,12 @@
         "type": "string",
         "enum": ["immediate", "bounded", "blocking"],
         "default": "bounded",
-        "description": "Default resolution mode for tool calls. 'immediate': return thunk without waiting. 'bounded': wait up to approvalTimeoutSeconds then return thunk. 'blocking': wait indefinitely for terminal resolution."
+        "description": "Default wait_mode for tool calls. 'immediate': return current action state without waiting. 'bounded': wait up to approvalTimeoutSeconds for terminal resolution. 'blocking': wait indefinitely for terminal resolution."
       },
       "approvalTimeoutSeconds": {
         "type": "number",
         "default": 30,
-        "description": "Seconds to wait in 'bounded' mode before returning a thunk. Ignored in 'immediate' and 'blocking' modes."
+        "description": "Seconds to wait in 'bounded' mode before returning. Ignored in 'immediate' and 'blocking' modes."
       }
     }
   }


### PR DESCRIPTION
Addresses all four Copilot review comments on PR #775.

## Changes

### `approval_gate/models.py` — backward-compat optional field
`ExecutionStartedDetail.started_at` changed from `datetime` (required) to `datetime | None = None` so existing persisted log entries (which don't have this field) can still be parsed.

### `approval_gate/proxy_server.py` — fix event race condition
After an intermediate state transition (PENDING → EXECUTING), the wait loop replaced the event and set it in `_action_resolved_events`. But if the terminal transition arrived between the previous `get_action()` call and the new event being installed, it would signal the old event and the new one would never fire.

Fix: re-check state immediately after installing the new event — if already terminal, break before waiting.

### `cluster/k8s/approval-gate/` — update deployed config
PR #775 made `predicate_path` and `port` required (removing their defaults). The deployed config was missing both. Added:
- `port: 8765`
- `predicate_path: /etc/approval-gate/predicate.py`
- `default_wait_mode: {mode: yield_after_ms, timeout_ms: 30000}` (30s bounded)
- `cluster/k8s/approval-gate/predicate.py`: default predicate (always `NeedsHumanDecision`) added to ConfigMap

### `openclaw/approval-gate/index.ts` + `openclaw.plugin.json` — implement approvalMode/approvalTimeoutSeconds
The plugin JSON schema exposed `approvalMode` and `approvalTimeoutSeconds` but the plugin ignored them. Now:
- Plugin reads `cfg.approvalMode` (`"immediate"` | `"bounded"` | `"blocking"`, default `"bounded"`)
- Plugin reads `cfg.approvalTimeoutSeconds` (default `30`)
- Maps to a `wait_mode` object injected as the default into every tool call
- Updated descriptions to remove stale "thunk" language

https://claude.ai/code/session_01GCN1sCDQ2mTrYGW2eyoGhE