### PR TITLE
Add native exec injection mode as alternative to sidecar

### DIFF
--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -22,8 +22,9 @@
  * event queue and would not work from a node process.
  *
  * Notification delivery uses `enqueueSystemEvent` (OpenClaw's in-memory
- * per-session event queue). Events are drained and prepended to the agent's
- * next prompt automatically by the heartbeat mechanism.
+ * per-session event queue) followed by `requestHeartbeatNow` to immediately
+ * flush the event to the agent rather than waiting for the next scheduled
+ * heartbeat.
  */
 
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk";
@@ -108,7 +109,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     return;
   }
 
-  const { enqueueSystemEvent } = api.runtime.system;
+  const { enqueueSystemEvent, requestHeartbeatNow } = api.runtime.system;
 
   // ── Exec sidecar MCP connection ───────────────────────────────────────────
   const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", execLog);
@@ -219,6 +220,7 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
 
       const message = formatNotificationMessage(keyStr, entry.detail);
       enqueueSystemEvent(message, { sessionKey });
+      requestHeartbeatNow({ reason: "approval-gate:notification", sessionKey });
       log.info(`enqueued system event for action ${keyStr}`);
     }
 

--- a/openclaw/approval-gate/index.ts
+++ b/openclaw/approval-gate/index.ts
@@ -3,10 +3,15 @@
  *
  * Two responsibilities:
  *
- *   1. **Exec tool**: Registers an `exec` tool that calls the DirectExecServer
- *      sidecar (pod-local, unauthenticated). Injects `OPENCLAW_SESSION_ID` as
- *      an env var so the agent knows its session identity when calling external
- *      services (e.g. the approval gate via mcporter).
+ *   1. **Exec tool** (optional): Two mutually exclusive modes:
+ *      - **Sidecar** (`execServer.url` configured): Registers an `exec` tool
+ *        that proxies calls to the DirectExecServer sidecar (pod-local,
+ *        unauthenticated). Injects `OPENCLAW_SESSION_ID` and `APPROVAL_GATE_URL`
+ *        as env vars.
+ *      - **Native injection** (`nativeExecInjection: true`): Intercepts the
+ *        built-in `exec` tool via `before_tool_call` and injects
+ *        `OPENCLAW_SESSION_ID` and `APPROVAL_GATE_URL` into the env. No sidecar
+ *        required. Use this when the agent uses the built-in exec tool directly.
  *
  *   2. **Approval gate notifications**: Connects to the approval gate MCP server,
  *      subscribes to session log HWM resources, and delivers terminal action
@@ -96,13 +101,15 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
     | {
         approvalGate?: { url?: string; token?: string };
         execServer?: { url?: string };
+        nativeExecInjection?: boolean;
         registerTools?: boolean;
       }
     | undefined;
 
   const approvalGateUrl = cfg?.approvalGate?.url?.trim();
   const approvalGateToken = cfg?.approvalGate?.token?.trim();
-  const execServerUrl = cfg?.execServer?.url?.trim() ?? DEFAULT_EXEC_SERVER_URL;
+  const execServerUrl = cfg?.execServer?.url?.trim();
+  const nativeExecInjection = cfg?.nativeExecInjection ?? false;
 
   if (!approvalGateUrl || !approvalGateToken) {
     log.warn("approvalGate.url and approvalGate.token are required in plugin config; plugin disabled");
@@ -111,68 +118,92 @@ export default async function register(api: OpenClawPluginApi): Promise<void> {
 
   const { enqueueSystemEvent, requestHeartbeatNow } = api.runtime.system;
 
-  // ── Exec sidecar MCP connection ───────────────────────────────────────────
-  const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", execLog);
-  try {
-    await execConnection.connect();
-  } catch (err) {
-    log.error(`exec server initial connection failed: ${String(err)} — will retry in background`);
+  // ── Exec sidecar MCP connection (optional) ────────────────────────────────
+  if (execServerUrl) {
+    const execConnection = new ReconnectingMcpClient(execServerUrl, "openclaw-exec", execLog);
+    try {
+      await execConnection.connect();
+    } catch (err) {
+      log.error(`exec server initial connection failed: ${String(err)} — will retry in background`);
+    }
+
+    // Discover the exec tool schema from the sidecar MCP server, strip env/inherit_env
+    // (we inject OPENCLAW_SESSION_ID ourselves), and re-register with OpenClaw.
+    if (!execConnection.connected) {
+      log.error("exec server not connected on startup; exec tool not registered");
+    } else {
+      let execToolList: Awaited<ReturnType<Client["listTools"]>>;
+      try {
+        execToolList = await execConnection.listTools();
+      } catch (err) {
+        log.error(`failed to list exec server tools: ${String(err)}`);
+        execToolList = { tools: [] };
+      }
+
+      const execTools = execToolList.tools.filter((t) => t.name === "exec");
+      if (execTools.length !== 1) {
+        log.error(`expected exactly 1 exec tool from sidecar, got ${execTools.length}`);
+      } else {
+        const execTool = execTools[0];
+        const execSchema = stripSchemaKeys((execTool.inputSchema ?? {}) as Record<string, unknown>, [
+          "env",
+          "inherit_env",
+        ]);
+
+        api.registerTool((ctx: OpenClawPluginToolContext) => ({
+          name: "exec",
+          label: "exec",
+          description:
+            "Execute a command in the exec container. " +
+            "The workspace directory is shared with the gateway (same path). " +
+            "OPENCLAW_SESSION_ID is automatically set in the environment.",
+          parameters: execSchema,
+          async execute(_id: string, params: Record<string, unknown>) {
+            const env = [`OPENCLAW_SESSION_ID=${ctx.sessionKey ?? ""}`, `APPROVAL_GATE_URL=${approvalGateUrl}`];
+            const cwd = (params.cwd as string | undefined) ?? ctx.workspaceDir;
+            const callArgs = { ...params, env, ...(cwd ? { cwd } : {}) };
+
+            try {
+              return await execConnection.callTool("exec", callArgs);
+            } catch (err) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Exec server is currently unavailable. Please retry shortly. (${String(err)})`,
+                  },
+                ],
+              };
+            }
+          },
+        }));
+        log.info("registered exec tool (schema discovered from sidecar)");
+      }
+    }
+  } else {
+    execLog.info("execServer.url not configured; exec sidecar disabled");
   }
 
-  // ── Register exec tool ────────────────────────────────────────────────────
-  // Discover the exec tool schema from the sidecar MCP server, strip env/inherit_env
-  // (we inject OPENCLAW_SESSION_ID ourselves), and re-register with OpenClaw.
-  // TODO: Consider allowing env merging with session ID later.
-  if (!execConnection.connected) {
-    log.error("exec server not connected on startup; exec tool not registered");
-  } else {
-    let execToolList: Awaited<ReturnType<Client["listTools"]>>;
-    try {
-      execToolList = await execConnection.listTools();
-    } catch (err) {
-      log.error(`failed to list exec server tools: ${String(err)}`);
-      execToolList = { tools: [] };
-    }
-
-    const execTools = execToolList.tools.filter((t) => t.name === "exec");
-    if (execTools.length !== 1) {
-      log.error(`expected exactly 1 exec tool from sidecar, got ${execTools.length}`);
-    } else {
-      const execTool = execTools[0];
-      const execSchema = stripSchemaKeys((execTool.inputSchema ?? {}) as Record<string, unknown>, [
-        "env",
-        "inherit_env",
-      ]);
-
-      api.registerTool((ctx: OpenClawPluginToolContext) => ({
-        name: "exec",
-        label: "exec",
-        description:
-          "Execute a command in the exec container. " +
-          "The workspace directory is shared with the gateway (same path). " +
-          "OPENCLAW_SESSION_ID is automatically set in the environment.",
-        parameters: execSchema,
-        async execute(_id: string, params: Record<string, unknown>) {
-          const env = [`OPENCLAW_SESSION_ID=${ctx.sessionKey ?? ""}`, `APPROVAL_GATE_URL=${approvalGateUrl}`];
-          const cwd = (params.cwd as string | undefined) ?? ctx.workspaceDir;
-          const callArgs = { ...params, env, ...(cwd ? { cwd } : {}) };
-
-          try {
-            return await execConnection.callTool("exec", callArgs);
-          } catch (err) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Exec server is currently unavailable. Please retry shortly. (${String(err)})`,
-                },
-              ],
-            };
-          }
+  // ── Native exec injection via before_tool_call (optional) ─────────────────
+  // Intercepts the built-in `exec` tool and injects OPENCLAW_SESSION_ID and
+  // APPROVAL_GATE_URL into the env Record, so the agent knows its session
+  // identity without a sidecar. Mutually exclusive with the sidecar approach.
+  if (nativeExecInjection) {
+    api.on("before_tool_call", (event, ctx) => {
+      if (event.toolName !== "exec") return;
+      const existing = (event.params.env as Record<string, string> | undefined) ?? {};
+      return {
+        params: {
+          ...event.params,
+          env: {
+            ...existing,
+            OPENCLAW_SESSION_ID: ctx.sessionKey ?? "",
+            APPROVAL_GATE_URL: approvalGateUrl,
+          },
         },
-      }));
-      log.info("registered exec tool (schema discovered from sidecar)");
-    }
+      };
+    });
+    log.info("native exec injection enabled (before_tool_call hook registered for exec)");
   }
 
   // ── Resilient MCP connection to approval gate server ──────────────────────

--- a/openclaw/approval-gate/openclaw.plugin.json
+++ b/openclaw/approval-gate/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "approval-gate",
   "name": "Approval Gate",
-  "description": "Provides exec tool (via DirectExecServer sidecar) with session context injection, and bridges the approval gate MCP proxy for privileged action notifications.",
+  "description": "Bridges the approval gate MCP proxy for privileged action notifications. Optionally injects session context into exec tool calls (via sidecar or built-in exec hook).",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -28,10 +28,14 @@
         "properties": {
           "url": {
             "type": "string",
-            "default": "http://127.0.0.1:8766/mcp",
-            "description": "URL of the DirectExecServer sidecar MCP endpoint (pod-local, unauthenticated)"
+            "description": "URL of the DirectExecServer sidecar MCP endpoint (pod-local, unauthenticated). When set, the plugin connects to the sidecar and registers an exec tool that injects OPENCLAW_SESSION_ID and APPROVAL_GATE_URL. Omit to disable sidecar wiring entirely."
           }
         }
+      },
+      "nativeExecInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, intercepts the built-in exec tool via before_tool_call and injects OPENCLAW_SESSION_ID and APPROVAL_GATE_URL into the env. Use this instead of execServer when the agent uses the built-in exec tool directly (no sidecar required)."
       },
       "registerTools": {
         "type": "boolean",


### PR DESCRIPTION
## Summary
This PR refactors the approval-gate plugin to support two mutually exclusive modes for injecting session context into exec tool calls: the existing sidecar approach and a new native injection mode that intercepts the built-in exec tool via `before_tool_call`.

## Key Changes

- **Made exec sidecar optional**: Changed `execServer.url` from having a default value to being truly optional. The sidecar connection and tool registration now only occur when `execServer.url` is explicitly configured.

- **Added native exec injection mode**: Introduced a new `nativeExecInjection` boolean config option that, when enabled, registers a `before_tool_call` hook to intercept the built-in `exec` tool and inject `OPENCLAW_SESSION_ID` and `APPROVAL_GATE_URL` environment variables directly into the tool's env parameter.

- **Improved notification delivery**: Changed from relying on the heartbeat mechanism to immediately flush approval gate notifications to the agent by calling `requestHeartbeatNow()` after enqueueing system events.

- **Updated documentation**: 
  - Clarified in code comments that the exec tool registration is now optional with two mutually exclusive modes
  - Updated plugin description to emphasize the approval gate bridging as primary responsibility
  - Enhanced config schema descriptions to explain when to use each mode

## Implementation Details

- The sidecar connection logic is now wrapped in a conditional block that only executes when `execServerUrl` is defined
- Native injection uses the `before_tool_call` event hook to merge environment variables while preserving any existing env configuration
- Both modes inject the same environment variables (`OPENCLAW_SESSION_ID` and `APPROVAL_GATE_URL`) to maintain consistency
- The native injection mode requires no sidecar infrastructure, making it suitable for agents that use the built-in exec tool directly

https://claude.ai/code/session_01J9EAj1cGybfubfSBa423R3