### PR TITLE
Add Google Workspace MCP server deployment with Authentik SSO

### DIFF
--- a/airlock/TODO.md
+++ b/airlock/TODO.md
@@ -1,0 +1,53 @@
+# Airlock TODOs
+
+## Capability token grant system
+
+Allow agents to request temporary or permanent capability grants, which are approved
+by the human operator and encoded as tokens the agent can present on subsequent calls.
+
+### Flow
+
+1. Agent calls a special airlock tool (e.g. `airlock_request_grant`) with a description
+   of the capability it wants (e.g. "run commands matching `kubectl get *`").
+2. Airlock queues the grant request for operator approval (same UI as normal actions).
+3. Operator approves → airlock issues a signed token encoding the granted capability.
+4. Agent receives the token and presents it in future tool calls (e.g. via a
+   `grant_token` parameter or a dedicated header/field).
+5. Predicate/policy layer checks the token and returns `Approved` without requiring
+   another human decision.
+
+### Token design options
+
+- **Signed JWT claims**: Token is a JWT signed with an airlock server secret.
+  Claims encode the capability scope (namespace, tool pattern, argument constraints),
+  issuing time, and optional expiry. Stateless — airlock just verifies signature + claims.
+- **Stateful grant records**: Airlock stores grant records in the DB (like actions).
+  Token is an opaque ID referencing the record. Supports explicit revocation.
+- **Hybrid**: JWT with a JTI claim; DB stores revoked JTIs for revocation support.
+
+### Capability scope representation
+
+Grants should be able to express:
+
+- Which backend namespace(s) and tool(s) the grant applies to.
+- Optional argument-level constraints (e.g. read-only commands, specific paths).
+- Temporal constraints: expiry time, or "one-shot" (consumed on first use).
+- Optional human-readable label shown in the approval UI.
+
+### Predicate integration
+
+The predicate function (or a new pre-predicate hook) receives the presented grant
+token alongside `(server_namespace, tool_name, arguments)` and can return `Approved`
+if the token matches and is valid. The existing `NeedsHumanDecision` / `Denied` paths
+are unchanged for calls without a valid token.
+
+### Implementation sketch
+
+- New DB table `grants` (id, created_at, expires_at, scope_json, revoked).
+- New MCP tool `airlock_request_grant(description, scope)` exposed to agents.
+- `proxy_server.py`: extract optional `grant_token` from tool call arguments before
+  forwarding; validate token against DB / JWT signature; short-circuit to `Approved`
+  if valid.
+- Frontend: grant requests appear in the action queue; approval issues the token and
+  returns it to the waiting agent call.
+- Config: `grant_signing_secret` (for JWT mode) or toggle between stateful/JWT modes.

--- a/cluster/k8s/airlock/config.yaml
+++ b/cluster/k8s/airlock/config.yaml
@@ -1,6 +1,8 @@
 backends:
   kubeapi_admin:
     url: http://kubeapi-admin-exec-mcp.airlock.svc.cluster.local:8766/mcp
+  google_workspace_mcp:
+    url: http://google-workspace-mcp.google-workspace-mcp.svc.cluster.local:8000/mcp
 
 public_base_url: "https://airlock.allegedly.works"
 oidc_issuer: "https://auth.allegedly.works/application/o/airlock/"

--- a/cluster/k8s/authentik-proxy-routes/google-workspace-mcp-httproute.yaml
+++ b/cluster/k8s/authentik-proxy-routes/google-workspace-mcp-httproute.yaml
@@ -1,0 +1,18 @@
+# HTTPRoute for Google Workspace MCP via shared Authentik proxy outpost.
+# Traffic flows: Gateway → outpost (auth) → google-workspace-mcp backend.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: google-workspace-mcp
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "google-workspace-mcp.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/authentik-proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik-proxy-routes/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - filebrowser-httproute.yaml
   - openclaw-mitmproxy-httproute.yaml
   - proxmox-httproute.yaml
+  - google-workspace-mcp-httproute.yaml

--- a/cluster/k8s/authentik/blueprints/google-workspace-mcp-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/google-workspace-mcp-sso.yaml
@@ -1,0 +1,36 @@
+version: 1
+metadata:
+  name: SSO - Google Workspace MCP
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    id: google-workspace-mcp-provider
+    state: present
+    identifiers:
+      name: google-workspace-mcp
+    attrs:
+      external_host: "https://google-workspace-mcp.allegedly.works"
+      internal_host: "http://google-workspace-mcp.google-workspace-mcp.svc.cluster.local:8000"
+      mode: proxy
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: "hours=24"
+
+  - model: authentik_core.application
+    id: google-workspace-mcp-app
+    state: present
+    identifiers:
+      slug: google-workspace-mcp
+    attrs:
+      name: Google Workspace MCP
+      provider: !KeyOf google-workspace-mcp-provider
+      meta_description: "Google Workspace MCP server (Gmail, Calendar, Drive)"
+      meta_launch_url: "https://google-workspace-mcp.allegedly.works"
+      open_in_new_tab: true
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !KeyOf google-workspace-mcp-app
+      group: !Find [authentik_core.group, [name, authentik Admins]]
+      order: 0

--- a/cluster/k8s/authentik/blueprints/shared-proxy-outpost.yaml
+++ b/cluster/k8s/authentik/blueprints/shared-proxy-outpost.yaml
@@ -24,6 +24,7 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, openclaw-mitmproxy]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, proxmox]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, scanner-filebrowser]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, google-workspace-mcp]]
 
   # Remove the standalone k8s outpost deployment (superseded by embedded outpost).
   - model: authentik_outposts.outpost

--- a/cluster/k8s/google-workspace-mcp/ciliumnetworkpolicy.yaml
+++ b/cluster/k8s/google-workspace-mcp/ciliumnetworkpolicy.yaml
@@ -1,0 +1,42 @@
+# CiliumNetworkPolicy for google-workspace-mcp.
+#
+# google-workspace-mcp (port 8000) accepts traffic from two sources:
+#   - Authentik embedded outpost (browser-based OAuth setup UI, SSO protected)
+#   - Airlock server (agent MCP calls, JWT-gated with human approval)
+# Kubelet health probes from the node host are also allowed.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: google-workspace-mcp-ingress
+  namespace: google-workspace-mcp
+spec:
+  endpointSelector:
+    matchLabels:
+      app: google-workspace-mcp
+  ingress:
+    # Kubelet liveness/readiness probes.
+    - fromEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Authentik embedded outpost — SSO-protected browser access for OAuth setup.
+    - fromEndpoints:
+        - matchLabels:
+            goauthentik.io/outpost-name: shared-proxy-outpost
+            k8s:io.kubernetes.pod.namespace: authentik
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Airlock server — proxies agent MCP calls after JWT validation + approval.
+    - fromEndpoints:
+        - matchLabels:
+            app: airlock
+            component: server
+            k8s:io.kubernetes.pod.namespace: airlock
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/cluster/k8s/google-workspace-mcp/deployment.yaml
+++ b/cluster/k8s/google-workspace-mcp/deployment.yaml
@@ -1,0 +1,107 @@
+# google_workspace_mcp — Google Workspace MCP server (Gmail, Calendar, Drive, Docs, etc.)
+# Tokens stored in PVC; Google OAuth credentials shared from oauth-broker via Reflector.
+# Access: Authentik proxy outpost (browser OAuth setup) + Airlock (agent MCP calls).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: google-workspace-mcp
+  namespace: google-workspace-mcp
+  labels:
+    app: google-workspace-mcp
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: google-workspace-mcp
+  template:
+    metadata:
+      labels:
+        app: google-workspace-mcp
+    spec:
+      initContainers:
+        # google_workspace_mcp expects a client_secret.json file in addition to env vars.
+        # Generate it from the env vars so we avoid storing the JSON as a separate secret.
+        - name: gen-client-secret
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              printf '{"web":{"client_id":"%s","client_secret":"%s","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","redirect_uris":["https://google-workspace-mcp.allegedly.works/oauth2callback"]}}\n' \
+                "$GOOGLE_OAUTH_CLIENT_ID" "$GOOGLE_OAUTH_CLIENT_SECRET" \
+                > /client-secret/client_secret.json
+          env:
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: google-client-credentials
+                  key: client_id
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: google-client-credentials
+                  key: client_secret
+          volumeMounts:
+            - name: client-secret
+              mountPath: /client-secret
+      containers:
+        - name: google-workspace-mcp
+          image: ghcr.io/taylorwilsdon/google_workspace_mcp:1.14.2
+          args:
+            - --transport
+            - streamable-http
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: google-client-credentials
+                  key: client_id
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: google-client-credentials
+                  key: client_secret
+            - name: WORKSPACE_MCP_BASE_URI
+              value: "https://google-workspace-mcp.allegedly.works"
+            - name: WORKSPACE_MCP_PORT
+              value: "8000"
+            - name: GOOGLE_MCP_CREDENTIALS_DIR
+              value: /app/store_creds
+          volumeMounts:
+            - name: store-creds
+              mountPath: /app/store_creds
+            - name: client-secret
+              mountPath: /app/client_secret.json
+              subPath: client_secret.json
+              readOnly: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: store-creds
+          persistentVolumeClaim:
+            claimName: google-workspace-mcp-creds
+        - name: client-secret
+          emptyDir: {}

--- a/cluster/k8s/google-workspace-mcp/flux-kustomization.yaml
+++ b/cluster/k8s/google-workspace-mcp/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: google-workspace-mcp
+  namespace: flux-system
+spec:
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/google-workspace-mcp
+  prune: true
+  wait: true
+  dependsOn:
+    - name: oauth-broker-secrets # google-client-credentials SealedSecret (Reflector mirrors it here)
+    - name: proxmox-csi
+    - name: reflector

--- a/cluster/k8s/google-workspace-mcp/kustomization.yaml
+++ b/cluster/k8s/google-workspace-mcp/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ciliumnetworkpolicy.yaml

--- a/cluster/k8s/google-workspace-mcp/namespace.yaml
+++ b/cluster/k8s/google-workspace-mcp/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: google-workspace-mcp
+  labels:
+    name: google-workspace-mcp

--- a/cluster/k8s/google-workspace-mcp/pvc.yaml
+++ b/cluster/k8s/google-workspace-mcp/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: google-workspace-mcp-creds
+  namespace: google-workspace-mcp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: proxmox-csi-retain
+  resources:
+    requests:
+      storage: 1Gi

--- a/cluster/k8s/google-workspace-mcp/service.yaml
+++ b/cluster/k8s/google-workspace-mcp/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: google-workspace-mcp
+  namespace: google-workspace-mcp
+spec:
+  selector:
+    app: google-workspace-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/cluster/k8s/oauth-broker-secrets/google-client-credentials-sealed.yaml
+++ b/cluster/k8s/oauth-broker-secrets/google-client-credentials-sealed.yaml
@@ -12,3 +12,8 @@ spec:
     metadata:
       name: google-client-credentials
       namespace: oauth-broker
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "google-workspace-mcp"
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "google-workspace-mcp"


### PR DESCRIPTION
## Summary
This PR adds a complete deployment for the Google Workspace MCP server, enabling AI agents to access Gmail, Calendar, Drive, and other Google Workspace services through a secure, authenticated interface. The server is integrated with Authentik for browser-based OAuth setup and Airlock for agent MCP calls.

## Key Changes

- **Google Workspace MCP Deployment**: New Kubernetes deployment with:
  - Init container to generate OAuth client secret JSON from environment variables
  - Persistent volume for storing user credentials
  - Health checks (liveness/readiness probes)
  - Resource limits (256Mi-512Mi memory, 100m-500m CPU)

- **Network Security**: 
  - CiliumNetworkPolicy restricting ingress to Authentik outpost (SSO) and Airlock server (agent calls)
  - Kubelet health probe access from host

- **Authentik Integration**:
  - SSO blueprint defining proxy provider, application, and admin group policy
  - HTTPRoute for `google-workspace-mcp.allegedly.works` via shared Authentik proxy outpost

- **Airlock Integration**:
  - Added `google_workspace_mcp` backend to Airlock config pointing to the MCP server
  - Updated shared proxy outpost to include the new provider

- **Secret Management**:
  - Modified `google-client-credentials` SealedSecret to enable Reflector auto-mirroring to `google-workspace-mcp` namespace
  - Flux Kustomization with dependencies on oauth-broker-secrets, proxmox-csi, and reflector

- **Infrastructure**:
  - PersistentVolumeClaim for credential storage (1Gi, proxmox-csi-retain)
  - Service exposing port 8000
  - Namespace and Kustomization manifests

## Notable Implementation Details

- OAuth credentials are injected as environment variables and dynamically converted to the required `client_secret.json` format via init container, avoiding separate secret storage
- Credentials directory is mounted at `/app/store_creds` for persistent token storage across pod restarts
- Base URI and port are configurable via environment variables for flexibility
- The deployment follows the existing pattern of using Authentik for browser access and Airlock for programmatic agent access

https://claude.ai/code/session_01C3LQKLbfDbnxXBp2FrHHyw