### PR TITLE
Document MCP OAuth spec compliance and DCR implementation roadmap

### DIFF
--- a/airlock/TODO.md
+++ b/airlock/TODO.md
@@ -1,5 +1,47 @@
 # Airlock TODOs
 
+## MCP OAuth spec compliance + Dynamic Client Registration
+
+Make Airlock a compliant MCP resource server per the MCP authorization spec and RFC 9728.
+
+### Why deferred
+
+Authentik does not support RFC 7591 Dynamic Client Registration — no `registration_endpoint`
+is advertised in its OIDC discovery document. Without DCR, interactive MCP clients like
+Claude Code on the web cannot self-register and must use pre-provisioned `client_id` values.
+
+### What full implementation would require
+
+1. **`/.well-known/oauth-protected-resource`** (RFC 9728): add a new `Route` in `app.py`
+   returning JSON with `resource`, `authorization_servers` (pointing at the Authentik
+   provider's issuer URL), `bearer_methods_supported`, and `scopes_supported`.
+
+2. **`WWW-Authenticate` on 401**: add a Starlette middleware that adds
+   `WWW-Authenticate: Bearer realm="airlock", resource_metadata="<base_url>/.well-known/oauth-protected-resource"`
+   to all 401 responses, enabling clients to auto-discover the auth server.
+
+3. **DCR proxy endpoint** (the hard part): implement `POST /oauth/register` in Airlock
+   that calls the Authentik admin API (`/api/v3/providers/oauth2/` + `/api/v3/core/applications/`)
+   to dynamically create an OAuth2 provider+application, then returns a standard RFC 7591
+   registration response (`client_id`, `redirect_uris`, etc.). Requires Airlock to hold an
+   Authentik API token (Vault → ESO → env var). Optionally implement cleanup of
+   stale registrations via background task or TTL-based GC.
+
+4. **`authorization_servers` update**: once the DCR proxy is live, the
+   `authorization_servers` field in the resource metadata should list Airlock's own
+   DCR endpoint (or a dedicated sub-issuer), not just Authentik directly.
+
+5. **JWTVerifier multi-issuer support**: if the DCR proxy creates providers under
+   different Authentik issuers, `JWTVerifier` may need to accept tokens from multiple
+   issuers (or rely on JWKS key matching alone).
+
+### Pre-provisioned fallback (simpler, no DCR)
+
+If DCR is not needed (e.g. Claude Code is always configured with a fixed `client_id`),
+items 1 and 2 above alone provide MCP spec compliance for discovery. Add an Authentik
+OAuth2 provider (`airlock-human`, public, PKCE, `propose read` or `propose read decide`
+scopes) via a new blueprint in `cluster/k8s/authentik/blueprints/`.
+
 ## Capability token grant system
 
 Allow agents to request temporary or permanent capability grants, which are approved


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation of the work required to make Airlock a fully compliant MCP resource server per RFC 9728 and implement Dynamic Client Registration (DCR) support. It also outlines a simpler pre-provisioned fallback approach for cases where DCR is not immediately needed.

## Changes

- **Added MCP OAuth spec compliance section** to TODO.md documenting the deferred work for full RFC 9728 compliance
- **Documented DCR implementation roadmap** with 5 key components:
  - `/.well-known/oauth-protected-resource` endpoint for resource metadata discovery
  - `WWW-Authenticate` header middleware for auto-discovery
  - DCR proxy endpoint (`POST /oauth/register`) to dynamically create OAuth2 providers in Authentik
  - Authorization server metadata updates
  - Multi-issuer JWT verification support
- **Explained the blocker**: Authentik's lack of RFC 7591 DCR support, which prevents interactive MCP clients from self-registering
- **Provided a simpler alternative**: Pre-provisioned OAuth2 provider approach that achieves basic MCP spec compliance without DCR

## Implementation Notes

The documentation clarifies that full DCR implementation would require:
- Airlock to hold an Authentik API token for dynamic provider/application creation
- Background cleanup tasks for stale registrations
- Potential multi-issuer JWT verification if DCR creates providers under different issuers

The pre-provisioned fallback offers a pragmatic path forward when DCR is not required, needing only items 1-2 of the full implementation plus a new Authentik blueprint.

https://claude.ai/code/session_01BC1wFnnMSkafZbarxkoCFw