### PR TITLE
Fix mypy no-redef error in tana/export/download_images.py

### DIFF
--- a/tana/export/download_images.py
+++ b/tana/export/download_images.py
@@ -65,8 +65,8 @@ def main() -> None:
 
     if args.dry_run:
         for node, url in media_nodes:
-            mime = get_mime_type(node, store) or "unknown"
-            logger.info("  %s  %s  %s", node.id, mime, url)
+            mime_label = get_mime_type(node, store) or "unknown"
+            logger.info("  %s  %s  %s", node.id, mime_label, url)
         return
 
     output_dir: Path = args.output


### PR DESCRIPTION
## Summary

- Rename `mime` in the dry-run loop to `mime_label` to avoid a mypy `no-redef` / `assignment` error
- The same variable `mime` was assigned with type `str` (via `or "unknown"`) in the dry-run block and `str | None` (directly from `get_mime_type`) in the download block; mypy complained about the incompatible reassignment
- Fixes the CI failure in BuildBuddy invocation `ebf3bbb5-ac39-4457-8fa3-cf81d080d124`

## Test plan

- [ ] `bazel build //tana/export:download_images` passes (verified locally)

https://claude.ai/code/session_01UXnLmzt25jBx3dYPyfxvbo