### PR TITLE
test(qemu): remove manual tags from QEMU integration tests

### DIFF
--- a/cluster/kubespan_agent/qemu/BUILD.bazel
+++ b/cluster/kubespan_agent/qemu/BUILD.bazel
@@ -114,7 +114,6 @@ sh_test(
         ":vmlinuz",
     ],
     tags = [
-        "manual",
         "requires_qemu",
     ],
 )
@@ -140,7 +139,6 @@ sh_test(
         "//third_party/siderolabs:discovery_service_tarball",
     ],
     tags = [
-        "manual",
         "requires_docker",
         "requires_qemu",
     ],


### PR DESCRIPTION
## Summary

- Removes `"manual"` tag from `nft_smoke_qemu` and `kubespan_qemu` in `cluster/kubespan_agent/qemu/BUILD.bazel`
- These tests are now included in the default `bazel test //...` run

## Why these are safe to un-tag

- `qemu-system-x86` is **explicitly installed** in the RBE worker image (`tools/rbe_image/Dockerfile`) with a comment specifically referencing these tests
- All kernel modules (nftables, WireGuard) are **bundled inside the QEMU initramfs** — no host kernel module dependencies
- Tests use `-machine accel=tcg` (software emulation) — **no KVM hardware acceleration needed**
- Docker is available on RBE workers for the `kubespan_qemu` discovery service
- No special `exec_properties` needed; default executor is sufficient

## Tags retained

- `requires_qemu` — informational, not filtered in CI
- `requires_docker` (on `kubespan_qemu`) — informational, not filtered in CI
- `timeout = "long"` / `timeout = "eternal"` — kept as-is for correct timeout behavior

## Test plan
- [ ] Verify `bazel test //cluster/kubespan_agent/qemu:nft_smoke_qemu` passes on RBE
- [ ] Verify `bazel test //cluster/kubespan_agent/qemu:kubespan_qemu` passes on RBE

https://claude.ai/code/session_01CRtVsTvHubtBFTmZu8kZLo