### PR TITLE
Move test_notifications_handler to runtime package and remove manual tags

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -347,10 +347,7 @@ py_test(
 live_openai_py_test(
     name = "test_ollama_reasoning",
     srcs = ["test_ollama_reasoning.py"],
-    tags = [
-        "manual",
-        "ollama",
-    ],
+    tags = ["ollama"],
     deps = [
         ":agent",
         ":conftest",

--- a/agent_core/test_ollama_reasoning.py
+++ b/agent_core/test_ollama_reasoning.py
@@ -1,7 +1,7 @@
 """Ollama-specific test: verify reasoning items are parsed from thinking models.
 
-Run manually against a local Ollama instance with a thinking model (e.g., gpt-oss).
-Tagged 'manual' + 'ollama' so it never runs in CI.
+Tagged 'ollama'. The mock target runs in CI; the live target requires an Ollama
+instance with a thinking model and OPENAI_API_KEY pointing at it.
 
 Ollama returns reasoning via the OpenAI-compatible Responses API in `summary` and
 leaves `content` empty:

--- a/agent_server/e2e/BUILD.bazel
+++ b/agent_server/e2e/BUILD.bazel
@@ -34,25 +34,6 @@ py_test(
 )
 
 py_test(
-    name = "test_notifications_handler",
-    srcs = ["test_notifications_handler.py"],
-    imports = ["../.."],
-    tags = ["manual"],
-    deps = [
-        ":conftest",
-        "//agent_core/testing/mcp:responses",
-        "//agent_server/mcp/approval_policy:engine",
-        "//agent_server/runtime:container",
-        "//mcp_infra:constants",
-        "//openai_utils:model",
-        "@pypi//fastmcp",
-        "@pypi//pyhamcrest",
-        "@pypi//pytest",
-        "@pypi//pytest_bazel",
-    ],
-)
-
-py_test(
     name = "test_proposals_reject",
     srcs = ["test_proposals_reject.py"],
     imports = ["../.."],

--- a/agent_server/runtime/BUILD.bazel
+++ b/agent_server/runtime/BUILD.bazel
@@ -1,6 +1,7 @@
 """Runtime package - container lifecycle and agent registry."""
 
 load("@rules_python//python:defs.bzl", "py_library")
+load("//tools/testing:defs.bzl", "py_test")
 
 # Utility modules with minimal dependencies - can be imported by persist
 py_library(
@@ -87,5 +88,29 @@ py_library(
         "//openai_utils:model",
         "@pypi//aiodocker",
         "@pypi//fastmcp",
+    ],
+)
+
+py_test(
+    name = "test_notifications_handler",
+    size = "medium",
+    srcs = ["test_notifications_handler.py"],
+    data = [
+        "//agent_server:load",
+        "//third_party/debian_slim:load",
+    ],
+    imports = ["../.."],
+    requires_docker = True,
+    deps = [
+        "//agent_core/testing/mcp:responses",
+        "//agent_server:conftest",
+        "//agent_server/mcp/approval_policy:engine",
+        "//agent_server/runtime:container",
+        "//mcp_infra:constants",
+        "//openai_utils:model",
+        "@pypi//fastmcp",
+        "@pypi//pyhamcrest",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )

--- a/agent_server/runtime/test_notifications_handler.py
+++ b/agent_server/runtime/test_notifications_handler.py
@@ -37,7 +37,7 @@ class IsSystemNotification(BaseMatcher):
 
 @pytest.mark.timeout(35)
 async def test_notifications_handler_in_container_inserts_system_message(
-    async_docker_client, sqlite_persistence, policy_allow_all: str
+    async_docker_client, sqlite_persistence, policy_allow_all: str, runtime_image
 ) -> None:
     @MCPDecoratorMock.mock()
     def mock(m: MCPDecoratorMock):

--- a/cluster/kubespan_agent/qemu/BUILD.bazel
+++ b/cluster/kubespan_agent/qemu/BUILD.bazel
@@ -114,7 +114,6 @@ sh_test(
         ":vmlinuz",
     ],
     tags = [
-        "manual",
         "requires_qemu",
     ],
 )
@@ -140,7 +139,6 @@ sh_test(
         "//third_party/siderolabs:discovery_service_tarball",
     ],
     tags = [
-        "manual",
         "requires_docker",
         "requires_qemu",
     ],

--- a/mcp_starter/BUILD.bazel
+++ b/mcp_starter/BUILD.bazel
@@ -58,8 +58,6 @@ py_test(
 py_test(
     name = "integration_test",
     srcs = ["integration_test.py"],
-    # Requires running MCP server
-    tags = ["manual"],
     deps = [
         ":conftest",
         ":main",


### PR DESCRIPTION
## Summary
This PR reorganizes test structure and updates test tagging strategy across the codebase. The main change moves `test_notifications_handler` from the e2e package to the runtime package where it logically belongs, and removes `manual` tags from several tests to enable them to run in CI with appropriate infrastructure requirements.

## Key Changes

- **Moved test_notifications_handler**: Relocated from `agent_server/e2e/` to `agent_server/runtime/` with updated BUILD configuration including Docker requirements and proper dependencies
- **Removed manual tags**: Eliminated `manual` tags from:
  - `test_ollama_reasoning` in agent_core (now relies on `ollama` tag for filtering)
  - QEMU tests in cluster/kubespan_agent (now rely on `requires_qemu` and `requires_docker` tags)
  - `integration_test` in mcp_starter
- **Updated test documentation**: Modified comments in `test_ollama_reasoning.py` to clarify that the mock target runs in CI while the live target requires external Ollama instance
- **Added runtime_image fixture**: Updated `test_notifications_handler` signature to include `runtime_image` parameter for proper test setup

## Implementation Details

The test relocation includes:
- New py_test target in `agent_server/runtime/BUILD.bazel` with `requires_docker = True`
- Proper dependency declarations including testing utilities and MCP infrastructure
- Data dependencies for container images (`//agent_server:load`, `//third_party/debian_slim:load`)
- Removal of the old test target from `agent_server/e2e/BUILD.bazel`

The removal of `manual` tags reflects a shift toward using more specific infrastructure requirement tags (`requires_docker`, `requires_qemu`, `ollama`) that allow CI systems to selectively run tests based on available resources rather than blanket exclusion.

https://claude.ai/code/session_01CRtVsTvHubtBFTmZu8kZLo