### PR TITLE
Mark Docker-dependent test as manual in BUILD configuration

### DIFF
--- a/x/agent_server/runtime/BUILD.bazel
+++ b/x/agent_server/runtime/BUILD.bazel
@@ -112,6 +112,7 @@ py_test(
     ],
     imports = ["../../.."],
     requires_docker = True,
+    tags = ["manual"],
     deps = [
         ":conftest",
         "//agent_core/testing/mcp:responses",


### PR DESCRIPTION
## Summary
Added the `manual` tag to a Docker-dependent test in the BUILD configuration to prevent it from running in standard test suites.

## Key Changes
- Added `tags = ["manual"]` to the `py_test` target in `x/agent_server/runtime/BUILD.bazel`
- This tag is applied to a test that already has `requires_docker = True`, indicating it should only run when explicitly requested

## Implementation Details
The test will now be excluded from automatic test runs and will only execute when explicitly targeted (e.g., `bazel test //path/to/test:target`). This is a common pattern for tests with external dependencies like Docker that may not be available in all CI/CD environments.

https://claude.ai/code/session_01V2YrAWNaqWeCW9GKeFTfyG