### PR TITLE
Move git rebase to immediately before push in bump action

### DIFF
--- a/.github/actions/bump-nix-release/action.yml
+++ b/.github/actions/bump-nix-release/action.yml
@@ -24,13 +24,6 @@ inputs:
   branch:
     description: "Branch to push to (pass github.ref_name)"
     required: true
-  skip_pull:
-    description: |
-      Skip the git pull --rebase step. Set to 'true' when the caller already
-      synced with remote before making file changes (to avoid rebasing over a
-      dirty working tree).
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -44,22 +37,11 @@ runs:
         PACKAGE_PREFIX: ${{ inputs.package_prefix }}
         EXTRA_FILES: ${{ inputs.extra_files }}
         BRANCH: ${{ inputs.branch }}
-        SKIP_PULL: ${{ inputs.skip_pull }}
       run: |
         set -x
 
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-        if [[ "$SKIP_PULL" != "true" ]]; then
-          if ! git pull --rebase origin "$BRANCH"; then
-            echo "::error::Rebase failed. Git status:"
-            git status
-            echo "Conflicting files:"
-            git diff --name-only --diff-filter=U
-            exit 1
-          fi
-        fi
 
         # Compute SRI hash from artifact
         SHA256=$(sha256sum "$ARTIFACT_FILE" | cut -d' ' -f1)
@@ -84,6 +66,16 @@ runs:
         # shellcheck disable=SC2086
         git add "$NIX_PKG" $EXTRA_FILES
         git commit -m "chore: bump ${PACKAGE_PREFIX} to ${TAG} [skip ci]"
+
+        # Rebase our commit on top of any concurrent pushes immediately before
+        # pushing, to minimise the race window.
+        if ! git pull --rebase origin "$BRANCH"; then
+          echo "::error::Rebase failed. Git status:"
+          git status
+          echo "Conflicting files:"
+          git diff --name-only --diff-filter=U
+          exit 1
+        fi
 
         if ! git push origin "HEAD:${BRANCH}"; then
           echo "::error::Push failed. Diagnostics:"

--- a/.github/actions/bump-nix-release/action.yml
+++ b/.github/actions/bump-nix-release/action.yml
@@ -43,12 +43,24 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+        # Stash any pre-existing working tree changes (e.g. runner-modified files
+        # like .claude/settings.json) so the rebase has a clean slate.
+        STASHED=0
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+          git stash --include-untracked
+          STASHED=1
+        fi
+
         if ! git pull --rebase origin "$BRANCH"; then
           echo "::error::Rebase failed. Git status:"
           git status
           echo "Conflicting files:"
           git diff --name-only --diff-filter=U
           exit 1
+        fi
+
+        if [[ "$STASHED" == "1" ]]; then
+          git stash pop
         fi
 
         # Compute SRI hash from artifact

--- a/.github/actions/bump-nix-release/action.yml
+++ b/.github/actions/bump-nix-release/action.yml
@@ -24,6 +24,13 @@ inputs:
   branch:
     description: "Branch to push to (pass github.ref_name)"
     required: true
+  skip_pull:
+    description: |
+      Skip the git pull --rebase step. Set to 'true' when the caller already
+      synced with remote before making file changes (to avoid rebasing over a
+      dirty working tree).
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -37,30 +44,21 @@ runs:
         PACKAGE_PREFIX: ${{ inputs.package_prefix }}
         EXTRA_FILES: ${{ inputs.extra_files }}
         BRANCH: ${{ inputs.branch }}
+        SKIP_PULL: ${{ inputs.skip_pull }}
       run: |
         set -x
 
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-        # Stash any pre-existing working tree changes (e.g. runner-modified files
-        # like .claude/settings.json) so the rebase has a clean slate.
-        STASHED=0
-        if ! git diff --quiet || ! git diff --cached --quiet; then
-          git stash --include-untracked
-          STASHED=1
-        fi
-
-        if ! git pull --rebase origin "$BRANCH"; then
-          echo "::error::Rebase failed. Git status:"
-          git status
-          echo "Conflicting files:"
-          git diff --name-only --diff-filter=U
-          exit 1
-        fi
-
-        if [[ "$STASHED" == "1" ]]; then
-          git stash pop
+        if [[ "$SKIP_PULL" != "true" ]]; then
+          if ! git pull --rebase origin "$BRANCH"; then
+            echo "::error::Rebase failed. Git status:"
+            git status
+            echo "Conflicting files:"
+            git diff --name-only --diff-filter=U
+            exit 1
+          fi
         fi
 
         # Compute SRI hash from artifact

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -227,12 +227,6 @@ jobs:
             Requires Python 3.13+
           files: dist/*.whl
 
-      - name: Sync with remote before modifying files
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin "${{ github.ref_name }}"
-
       - name: Update Claude settings wheel URL
         run: |
           sed -i "s|releases/download/claude-hooks-[a-f0-9]*/claude_hooks|releases/download/claude-hooks-${{ env.SHORT_SHA }}/claude_hooks|g" .claude/settings.json
@@ -245,4 +239,3 @@ jobs:
           package_prefix: claude-hooks
           extra_files: .claude/settings.json
           branch: ${{ github.ref_name }}
-          skip_pull: "true"

--- a/.github/workflows/claude-hooks-release.yml
+++ b/.github/workflows/claude-hooks-release.yml
@@ -227,6 +227,12 @@ jobs:
             Requires Python 3.13+
           files: dist/*.whl
 
+      - name: Sync with remote before modifying files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin "${{ github.ref_name }}"
+
       - name: Update Claude settings wheel URL
         run: |
           sed -i "s|releases/download/claude-hooks-[a-f0-9]*/claude_hooks|releases/download/claude-hooks-${{ env.SHORT_SHA }}/claude_hooks|g" .claude/settings.json
@@ -239,3 +245,4 @@ jobs:
           package_prefix: claude-hooks
           extra_files: .claude/settings.json
           branch: ${{ github.ref_name }}
+          skip_pull: "true"


### PR DESCRIPTION
## Summary
Reorganized the git rebase operation in the bump-nix-release action to occur immediately before pushing, rather than at the beginning of the workflow. This minimizes the race condition window where concurrent pushes could cause conflicts.

## Key Changes
- Removed the `git pull --rebase` call that occurred early in the workflow (before computing hashes and making commits)
- Moved the rebase operation to execute immediately before `git push`, after all local commits have been prepared
- Added a clarifying comment explaining the rationale for the timing

## Implementation Details
This change reduces the likelihood of merge conflicts by:
1. Performing all local work (hash computation, file modifications, commits) without rebasing
2. Only rebasing against remote changes at the last possible moment before pushing
3. Minimizing the window where concurrent pushes to the same branch could introduce conflicts that would require manual intervention

The error handling for rebase failures remains unchanged.

https://claude.ai/code/session_01UnFQikRqNqPfksyJ1Ut39z