### PR TITLE
Remove explicit containerd socket endpoint from kubelet config

### DIFF
--- a/nix/nixos/modules/k8s-worker.nix
+++ b/nix/nixos/modules/k8s-worker.nix
@@ -235,7 +235,6 @@ in
             --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
             --kubeconfig=/var/lib/kubelet/kubelet.conf \
             --config=/etc/kubernetes/kubelet-config.yaml \
-            --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
             --node-ip="$NODE_IP" \
             ${
               lib.optionalString (cfg.nodeLabels != { })


### PR DESCRIPTION
## Summary
Removed the explicit `--container-runtime-endpoint` flag from the kubelet configuration in the Kubernetes worker node module. This allows kubelet to use its default container runtime endpoint detection instead of being hardcoded to the containerd socket path.

## Changes
- Removed `--container-runtime-endpoint=unix:///run/containerd/containerd.sock` from kubelet startup arguments in the k8s-worker NixOS module

## Details
By removing this explicit flag, kubelet will fall back to its default behavior for discovering the container runtime endpoint. This provides better flexibility for different container runtime configurations and aligns with kubelet's built-in defaults, reducing the need for explicit socket path configuration.

https://claude.ai/code/session_015XLcZUkSjJTJW4qGH4L11L