### PR TITLE
Use modulesPath instead of pkgs.path for NixOS module imports

### DIFF
--- a/nix/nixos/hosts/bazel-test/default.nix
+++ b/nix/nixos/hosts/bazel-test/default.nix
@@ -5,10 +5,10 @@
 # system.build.tarball — a complete NixOS filesystem tarball for docker import.
 # On container start, /init (systemd) runs NixOS activation: /etc, nix-ld,
 # home-manager (bazelrc, direnv), etc. No manual wiring needed.
-{ pkgs, ... }:
+{ modulesPath, pkgs, ... }:
 {
   imports = [
-    "${pkgs.path}/nixos/modules/virtualisation/docker-image.nix"
+    (modulesPath + "/virtualisation/docker-image.nix")
     ../../modules/bazel-dev.nix
   ];
 


### PR DESCRIPTION
## Summary
Refactored the bazel-test NixOS configuration to use the `modulesPath` parameter instead of `pkgs.path` for importing NixOS modules. This is a more idiomatic and maintainable approach in NixOS configurations.

## Changes
- Added `modulesPath` to the function parameters
- Replaced `"${pkgs.path}/nixos/modules/virtualisation/docker-image.nix"` with `(modulesPath + "/virtualisation/docker-image.nix")`

## Details
The `modulesPath` parameter is the recommended way to reference NixOS modules in configuration files. It provides a cleaner, more direct path to the modules directory compared to dereferencing through `pkgs.path`, making the configuration more maintainable and less dependent on the structure of the pkgs derivation.

https://claude.ai/code/session_01DByJtar28pAy9hsTgiezdh