### PR TITLE
fix(nix): use lib.mkDefault for nix.package to avoid NixOS HM conflict

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -141,7 +141,7 @@ in
   # TODO: Re-enable when google-drive-service module is re-enabled (see imports above)
   # services.google-drive.enable = lib.mkDefault false;
 
-  nix.package = pkgs.nix;
+  nix.package = lib.mkDefault pkgs.nix;
 
   nix.gc = {
     automatic = true;


### PR DESCRIPTION
## Summary

- Fixes `nix-flake-check` CI failure caused by `home-manager.users.user.nix.package` being defined twice
- `home-manager`'s `nixos/common.nix` sets `nix.package` from the system config at normal priority (100)
- Our `nix/home/home.nix` also set `nix.package = pkgs.nix` at normal priority (100), causing a conflict in NixOS configurations using inline home-manager (e.g. `wyrm2` with `username = "user"`)
- Fix: wrap with `lib.mkDefault` (priority 1000) so the NixOS integration's definition wins

## Test plan

- [ ] `nix-flake-check` CI job passes
- [ ] `nix flake check ./nix` evaluates successfully (especially `nixosConfigurations.wyrm2`)

https://claude.ai/code/session_01PKcRGfBN2SLsUNdPQ67z45