### PR TITLE
Make nix.package configuration overridable with mkDefault

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -141,7 +141,7 @@ in
   # TODO: Re-enable when google-drive-service module is re-enabled (see imports above)
   # services.google-drive.enable = lib.mkDefault false;
 
-  nix.package = pkgs.nix;
+  nix.package = lib.mkDefault pkgs.nix;
 
   nix.gc = {
     automatic = true;


### PR DESCRIPTION
## Summary
Changed the `nix.package` configuration to use `lib.mkDefault` wrapper, allowing it to be overridden by other NixOS modules with higher priority.

## Key Changes
- Wrapped `nix.package = pkgs.nix;` with `lib.mkDefault` to reduce its priority in the module system
- This allows other modules or configurations to override the nix package selection without conflicts

## Implementation Details
By using `lib.mkDefault`, this configuration now has the lowest priority level in NixOS's module system. This is useful when multiple modules might want to set the nix package, as it allows more specific configurations to take precedence while still providing a sensible default.

https://claude.ai/code/session_01PKcRGfBN2SLsUNdPQ67z45