### PR TITLE
Fix mypy type checking issues and add kubernetes-asyncio stub workaround

### DIFF
--- a/inventree_utils/rai_plugin/templatetags/custom_tags.py
+++ b/inventree_utils/rai_plugin/templatetags/custom_tags.py
@@ -105,7 +105,10 @@ class ParametersProcessor:
                 out = fn(self, *(self.get(x) for x in attrs), *args, **kwargs)
                 return SafeString(out) if out is not None else None
 
-            frame = inspect.currentframe().f_back  # Get the caller frame (class body)
+            current = inspect.currentframe()
+            assert current is not None
+            frame = current.f_back  # Get the caller frame (class body)
+            assert frame is not None
             frame.f_locals["_displayers"].append((attrs, wrapped))  # Get class-local variables
             return property(wrapped)
 

--- a/inventree_utils/rai_plugin/templatetags/test_custom_tags.py
+++ b/inventree_utils/rai_plugin/templatetags/test_custom_tags.py
@@ -28,7 +28,7 @@ def test_shorten():
 
 
 def test_input_voltage_range():
-    parameters = {}
+    parameters: dict[str, str] = {}
     pp = ParametersProcessor(part=None, parameters=parameters)
     assert pp.input_voltage_range is None
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -183,3 +183,9 @@ ignore_missing_imports = True
 # hack/cotrl uses many untyped deps (gymnasium, scipy, etc.) — pre-existing
 [mypy-x.cotrl.*]
 ignore_errors = True
+
+# kubernetes-asyncio v35 introduced broken stubs referencing
+# IoK8sApimachineryPkgApisMetaV1GroupVersionKind which doesn't exist in
+# kubernetes_asyncio.client.models (upstream bug)
+[mypy-kubernetes_asyncio.*]
+ignore_errors = True


### PR DESCRIPTION
This PR addresses several type checking issues identified by mypy and adds a workaround for a known upstream bug in kubernetes-asyncio stubs.

## Summary
Updates mypy configuration to handle a broken stub in kubernetes-asyncio v35, and fixes type checking errors in the codebase by adding proper assertions and type annotations.

## Key Changes
- **mypy.ini**: Added configuration to ignore errors from `kubernetes_asyncio.*` due to upstream bug where broken stubs reference non-existent `IoK8sApimachineryPkgApisMetaV1GroupVersionKind` class
- **custom_tags.py**: Fixed potential `None` type errors by:
  - Splitting `inspect.currentframe()` call into separate variable assignment
  - Adding assertions to verify `currentframe()` and `f_back` are not `None` before use
- **test_custom_tags.py**: Added explicit type annotation `dict[str, str]` to `parameters` variable for better type safety

## Implementation Details
The changes in `custom_tags.py` improve type safety by explicitly handling the case where `inspect.currentframe()` could return `None`, which mypy was flagging as a potential issue. The assertions document the expected non-None state at that point in the code execution.

https://claude.ai/code/session_017hwAneGaj8jrfMa5ooiUkh