### PR TITLE
ci: fix image push race via OCI digest comparison (Option A)

### DIFF
--- a/.github/actions/harbor-build-push/action.yml
+++ b/.github/actions/harbor-build-push/action.yml
@@ -37,10 +37,8 @@ runs:
         SHA="${{ github.sha }}"
         TS="$(date -u +%Y%m%d%H%M%S)"
         SEMVER_TAG="${TS}-${SHA:0:7}"
+        # Never push :latest directly — crane handles it after digest comparison.
         TAGS="${{ inputs.image }}:$SHA,${{ inputs.image }}:$SEMVER_TAG"
-        if [[ "${{ github.event_name }}" != "workflow_call" ]]; then
-          TAGS="$TAGS,${{ inputs.image }}:latest"
-        fi
         echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
         echo "semver_tag=$SEMVER_TAG" >> "$GITHUB_OUTPUT"
 
@@ -58,3 +56,20 @@ runs:
         file: ${{ inputs.file }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
+
+    - name: Install crane
+      uses: imjasonh/setup-crane@v0.4
+
+    - name: Update :latest if changed
+      shell: bash
+      run: |
+        IMAGE="${{ inputs.image }}"
+        SHA="${{ github.sha }}"
+        SHA_DIGEST=$(crane digest "$IMAGE:$SHA")
+        LATEST_DIGEST=$(crane digest "$IMAGE:latest" 2>/dev/null || echo "")
+        if [[ "$SHA_DIGEST" == "$LATEST_DIGEST" ]]; then
+          echo "$IMAGE: :latest unchanged (same digest), skipping tag update"
+        else
+          echo "$IMAGE: content changed, updating :latest"
+          crane tag "$IMAGE:$SHA" latest
+        fi

--- a/.github/scripts/harbor_push.sh
+++ b/.github/scripts/harbor_push.sh
@@ -2,9 +2,10 @@
 # harbor_push.sh <bazel_load_target> <local_tag> <remote_repo>
 #
 # Runs `bazel run <bazel_load_target>` to build the OCI image and load it
-# into the local Docker daemon, then pushes with tags: GITHUB_SHA,
-# BRANCH-YYYYMMDDHHMMSS-sha7, and :latest (only when GITHUB_EVENT_NAME !=
-# workflow_call).
+# into the local Docker daemon, then pushes with tags: GITHUB_SHA and
+# BRANCH-YYYYMMDDHHMMSS-sha7. Updates :latest only if the image digest
+# changed (detected via crane), avoiding spurious tag updates when inputs
+# are unchanged.
 # Skips entirely on pull_request builds.
 #
 # Environment variables (set automatically by GitHub Actions):
@@ -29,13 +30,18 @@ echo "$remote_repo: pushing"
 BRANCH="${GITHUB_REF_NAME//\//-}"
 TS="$(date -u +%Y%m%d%H%M%S)"
 TAG="${BRANCH}-${TS}-${GITHUB_SHA:0:7}"
-TAGS="$remote_repo:$GITHUB_SHA,$remote_repo:$TAG"
-if [[ "${GITHUB_EVENT_NAME:-}" != "workflow_call" ]]; then
-  TAGS="$TAGS,$remote_repo:latest"
-fi
 
-IFS=',' read -ra TAG_LIST <<<"$TAGS"
-for tag in "${TAG_LIST[@]}"; do
+for tag in "$remote_repo:$GITHUB_SHA" "$remote_repo:$TAG"; do
   docker tag "$local_tag" "$tag"
   docker push --quiet "$tag"
 done
+
+# Update :latest only if image content changed (OCI digest comparison).
+SHA_DIGEST=$(crane digest "$remote_repo:$GITHUB_SHA")
+LATEST_DIGEST=$(crane digest "$remote_repo:latest" 2>/dev/null || echo "")
+if [[ "$SHA_DIGEST" == "$LATEST_DIGEST" ]]; then
+  echo "$remote_repo: :latest unchanged (same digest), skipping tag update"
+else
+  echo "$remote_repo: content changed, updating :latest"
+  crane tag "$remote_repo:$GITHUB_SHA" latest
+fi

--- a/.github/workflows/activitywatch-image.yml
+++ b/.github/workflows/activitywatch-image.yml
@@ -1,15 +1,11 @@
 # Build and push the ActivityWatch server (aw-server-rust) image to Harbor.
 #
 # Triggers:
-#   - push to devel changing docker/activitywatch/** (tags :latest too)
-#   - workflow_dispatch: manual trigger (tags :latest too)
-#   - workflow_call (from ci.yml): tags :<sha> + :<timestamp>-<sha7>
+#   - workflow_call (from ci.yml, always on push): updates :latest only if digest changed
+#   - workflow_dispatch: manual trigger
 name: ActivityWatch Image
 
 on:
-  push:
-    branches: [devel]
-    paths: ["docker/activitywatch/**"]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/bazel-harbor-images.yml
+++ b/.github/workflows/bazel-harbor-images.yml
@@ -39,6 +39,7 @@ jobs:
           registry: registry.allegedly.works
           username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
           password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+      - uses: imjasonh/setup-crane@v0.4
       - name: Build and push oauth-broker
         run: |-
           .github/scripts/harbor_push.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,16 @@ jobs:
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'openclaw-exec-image')
     uses: ./.github/workflows/openclaw-exec-image.yml
     secrets: inherit
+  tana-mcp-image:
+    needs: compute-targets
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'tana-mcp-image')
+    uses: ./.github/workflows/tana-mcp-image.yml
+    secrets: inherit
+  activitywatch-image:
+    needs: compute-targets
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'activitywatch-image')
+    uses: ./.github/workflows/activitywatch-image.yml
+    secrets: inherit
   nix-flake-check:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'nix-flake-check')

--- a/.github/workflows/props-images.yml
+++ b/.github/workflows/props-images.yml
@@ -3,7 +3,7 @@
 # The props backend image is now pushed via bazel-harbor-images.yml.
 #
 # Triggers:
-#   - workflow_call (from ci.yml)
+#   - workflow_call (from ci.yml, always on push)
 #   - workflow_dispatch: manual push of all images
 name: Props Images
 
@@ -51,6 +51,9 @@ jobs:
           username: ${{ secrets.PROPS_REGISTRY_USERNAME }}
           password: ${{ secrets.PROPS_REGISTRY_PASSWORD }}
 
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
       - name: Build and load agent images
         run: |
           bazel run //props/agents/critic:load
@@ -73,14 +76,19 @@ jobs:
             exit 0
           fi
 
+          # Push SHA-pinned tag, then update floating tag only if digest changed.
           push_image() {
-            local local_tag="$1" remote_repo="$2"
-            shift 2
-            local remote_tags=("$@")
-            for tag in "${remote_tags[@]}"; do
-              docker tag "$local_tag" "$REGISTRY/$remote_repo:$tag"
-              docker push --quiet "$REGISTRY/$remote_repo:$tag"
-            done
+            local local_tag="$1" remote_repo="$2" floating_tag="$3" sha_tag="$4"
+            docker tag "$local_tag" "$REGISTRY/$remote_repo:$sha_tag"
+            docker push --quiet "$REGISTRY/$remote_repo:$sha_tag"
+            SHA_DIGEST=$(crane digest "$REGISTRY/$remote_repo:$sha_tag")
+            FLOATING_DIGEST=$(crane digest "$REGISTRY/$remote_repo:$floating_tag" 2>/dev/null || echo "")
+            if [[ "$SHA_DIGEST" == "$FLOATING_DIGEST" ]]; then
+              echo "$remote_repo:$floating_tag unchanged (same digest), skipping"
+            else
+              echo "$remote_repo: updating :$floating_tag"
+              crane tag "$REGISTRY/$remote_repo:$sha_tag" "$floating_tag"
+            fi
           }
 
           push_image critic:latest critic latest "$SHA"

--- a/.github/workflows/rbe-image.yml
+++ b/.github/workflows/rbe-image.yml
@@ -4,17 +4,13 @@
 # and Chromium headless shell. See devinfra/rbe_image/Dockerfile.
 #
 # Triggers:
-#   - push to main/devel (when devinfra/rbe_image/** changes): tags :latest + :<sha>
+#   - push to main/devel (always): builds with GHA layer cache; only updates
+#     :latest when the image digest changed.
 #   - workflow_dispatch: tags :latest + :<sha>
-#   - workflow_call (from ci.yml): tags :<sha>, outputs image ref
+#   - workflow_call (from ci.yml): outputs image ref
 name: RBE Worker Image
 
 on:
-  push:
-    branches: [main, devel]
-    paths:
-      - "devinfra/rbe_image/**"
-      - ".github/workflows/rbe-image.yml"
   workflow_dispatch:
   workflow_call:
     outputs:
@@ -41,20 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      rbe_image: ${{ steps.meta.outputs.rbe_image }}
+      rbe_image: ${{ steps.update-latest.outputs.rbe_image }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Compute image tags
-        id: meta
-        run: |
-          TAG="${{ github.sha }}"
-          TAGS="${{ env.IMAGE }}:$TAG"
-          if [[ "${{ github.event_name }}" != "workflow_call" ]]; then
-            TAGS="$TAGS,${{ env.IMAGE }}:latest"
-          fi
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          echo "rbe_image=${{ env.IMAGE }}:$TAG" >> $GITHUB_OUTPUT
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -63,10 +48,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push :<sha>
         uses: docker/build-push-action@v6
         with:
           context: .
           file: devinfra/rbe_image/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=rbe-image
+          cache-to: type=gha,mode=max,scope=rbe-image
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Update :latest if changed
+        id: update-latest
+        run: |
+          SHA_DIGEST=$(crane digest "$IMAGE:${{ github.sha }}")
+          LATEST_DIGEST=$(crane digest "$IMAGE:latest" 2>/dev/null || echo "")
+          if [[ "$SHA_DIGEST" == "$LATEST_DIGEST" ]]; then
+            echo "rbe-worker: :latest unchanged (same digest), skipping tag update"
+            echo "rbe_image=$IMAGE:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "rbe-worker: content changed, updating :latest"
+            crane tag "$IMAGE:${{ github.sha }}" latest
+            echo "rbe_image=$IMAGE:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/tana-mcp-image.yml
+++ b/.github/workflows/tana-mcp-image.yml
@@ -1,15 +1,11 @@
 # Build and push the Tana MCP Desktop image to Harbor.
 #
 # Triggers:
-#   - push to devel changing tana/mcp_server/** (tags :latest too)
-#   - workflow_dispatch: manual trigger (tags :latest too)
-#   - workflow_call (from ci.yml): tags :<sha> + :<timestamp>-<sha7>
+#   - workflow_call (from ci.yml, always on push): updates :latest only if digest changed
+#   - workflow_dispatch: manual trigger
 name: Tana MCP Image
 
 on:
-  push:
-    branches: [devel]
-    paths: ["tana/mcp_server/**"]
   workflow_dispatch:
   workflow_call:
 

--- a/devinfra/ci/generate_ci.py
+++ b/devinfra/ci/generate_ci.py
@@ -280,6 +280,7 @@ def generate_harbor_images_config(images: list[HarborImageConfig]) -> Workflow:
                 "password": "${{ secrets.HARBOR_ROBOT_TOKEN }}",
             },
         ),
+        Step(uses="imjasonh/setup-crane@v0.4"),
     ]
     for img in images:
         image_name = img.local_tag.split(":")[0]

--- a/devinfra/ci/workflows.yaml
+++ b/devinfra/ci/workflows.yaml
@@ -33,14 +33,15 @@ workflows:
     secrets: inherit
 
   # Image builds
+  # All image workflows always trigger on push. Each workflow compares the
+  # locally-built image digest against the registry :latest and skips the tag
+  # update when the content is unchanged. This avoids the stale-image bug
+  # where cancel-in-progress can drop a push when a second commit arrives
+  # that doesn't match the old path filter.
   rbe-image:
-    trigger: { kind: path, pattern: "^devinfra/rbe_image/" }
+    trigger: { kind: always }
+    events: [push]
 
-  # Bazel image workflows always trigger. Bazel builds are hermetic, so same
-  # inputs → same image digest. The workflow compares the local digest against
-  # the registry and skips the push when unchanged. This avoids the stale-image
-  # bug where bazel-diff (HEAD vs HEAD~1) misses changes from earlier commits
-  # whose push step failed.
   props-images:
     trigger: { kind: always }
     events: [push]
@@ -54,15 +55,25 @@ workflows:
     secrets: inherit
 
   openclaw-image:
-    trigger: { kind: path, pattern: "^(docker/openclaw/|airlock/openclaw/)" }
+    trigger: { kind: always }
     events: [push]
     secrets: inherit
     rbe: false
 
-  # TODO: Should also trigger on Python dependency changes (mcp_infra/exec/,
-  # airlock/, etc.) since the base image is built from those sources.
   openclaw-exec-image:
-    trigger: { kind: path, pattern: "^docker/openclaw-exec/" }
+    trigger: { kind: always }
+    events: [push]
+    secrets: inherit
+    rbe: false
+
+  tana-mcp-image:
+    trigger: { kind: always }
+    events: [push]
+    secrets: inherit
+    rbe: false
+
+  activitywatch-image:
+    trigger: { kind: always }
     events: [push]
     secrets: inherit
     rbe: false


### PR DESCRIPTION
Image workflows with cancel-in-progress:true could get cancelled by a second commit that didn't match the old path filters, leaving registries stale. Fix by making all image workflows always trigger and using crane to compare the newly-built image digest against :latest, only updating the floating tag when content actually changed.

Changes:
- harbor_push.sh: push :sha + semver tags only; use crane digest comparison to update :latest conditionally
- harbor-build-push action: same pattern for Docker-build images
- generate_ci.py: add imjasonh/setup-crane step to bazel-harbor-images
- props-images.yml: add crane install; push_image now does digest comparison before updating each floating tag
- rbe-image.yml: remove on.push.paths (now always triggered from ci.yml); add GHA Docker layer cache; crane digest comparison for :latest; output rbe_image:latest when unchanged, :sha when updated
- tana-mcp-image.yml, activitywatch-image.yml: remove on.push.paths triggers (dispatched from ci.yml always instead)
- workflows.yaml: change rbe-image, openclaw-image, openclaw-exec-image, tana-mcp-image, activitywatch-image to kind:always events:[push]
- Regenerate ci.yml and bazel-harbor-images.yml

https://claude.ai/code/session_01BYtvEcirwVYLJNBmHqKBDb