### PR TITLE
Configure Docker network bridge for requirements test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -105,6 +105,7 @@ lock(
 native_test(
     name = "requirements_test",
     src = ":requirements.update",
+    exec_properties = {"dockerNetwork": "bridge"},
     tags = [
         "no-cache",
         "requires-network",


### PR DESCRIPTION
## Summary
Added Docker network configuration to the `requirements_test` target to ensure proper network isolation during test execution.

## Changes
- Added `exec_properties = {"dockerNetwork": "bridge"}` to the `requirements_test` native_test rule in BUILD.bazel

## Details
This change explicitly configures the Docker network mode for the requirements test to use bridge networking. This ensures consistent network behavior when the test is executed in containerized environments, which is particularly important for tests that require network access (as indicated by the existing "requires-network" tag).

https://claude.ai/code/session_01Hfvcxxg9i18tP2NYzqbXpw