### PR TITLE
Configure npmrc for ActivityWatch npm package resolution

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -290,6 +290,7 @@ npm_activitywatch.npm_translate_lock(
     # resolve in the http_archive where npm_link_all_packages() creates them,
     # not in the main workspace where the lockfile lives.
     link_workspace = "aw_webui",
+    npmrc = "@@//:.npmrc",
     # vue-demi's postinstall switches lib/index.mjs to the correct Vue version
     # variant, but lifecycle hooks are disabled in sandboxed builds.  Patch the
     # default (Vue 3) stub to add the missing hasInjectionContext export that


### PR DESCRIPTION
## Summary
Added npmrc configuration to the ActivityWatch npm package translation setup in MODULE.bazel to enable custom npm registry and authentication settings during package installation.

## Changes
- Added `npmrc = "@@//:.npmrc"` to the `npm_activitywatch.npm_translate_lock()` configuration, pointing to the root-level `.npmrc` file for npm package resolution

## Details
This change allows the npm package manager to use custom registry configurations and credentials defined in the `.npmrc` file when resolving and installing dependencies for the ActivityWatch web UI. This is particularly important for accessing private registries or applying organization-specific npm settings during the build process.

https://claude.ai/code/session_01D8tg35fP7FrfT6jfFdKmtd