### PR TITLE
Fix GEPA optimization result access using correct index

### DIFF
--- a/props/core/gepa/gepa_adapter.py
+++ b/props/core/gepa/gepa_adapter.py
@@ -699,7 +699,7 @@ async def optimize_with_gepa(
         seed=seed if seed is not None else 0,
     )
 
-    optimized_prompt = result.best_candidate["system_prompt"]
+    optimized_prompt = result.candidates[result.best_idx]["system_prompt"]
     best_score = result.val_aggregate_scores[result.best_idx]
     logger.info(f"GEPA optimization complete. Best score: {best_score:.3f}, Metric calls: {result.total_metric_calls}")
 


### PR DESCRIPTION
## Summary
Fixed incorrect access pattern for retrieving the optimized prompt from GEPA optimization results. The code was attempting to access a non-existent `best_candidate` dictionary key instead of using the proper indexed access pattern.

## Key Changes
- Changed `result.best_candidate["system_prompt"]` to `result.candidates[result.best_idx]["system_prompt"]`
- This aligns with the existing pattern used in the next line where `result.best_idx` is already being used to access `result.val_aggregate_scores`

## Implementation Details
The fix ensures consistency in how the result object is accessed. The `result` object provides:
- `result.candidates`: list of candidate solutions
- `result.best_idx`: index of the best candidate
- `result.val_aggregate_scores`: array of scores indexed by candidate position

By using `result.candidates[result.best_idx]`, we correctly retrieve the best candidate dictionary and access its `system_prompt` field, matching the established pattern for accessing other result properties.

https://claude.ai/code/session_013X3dao9c7JADdEha34PdBh