### PR TITLE
Upgrade protobuf dependency to version 34.0.bcr.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "1.8.3")
 bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "protobuf", version = "33.4")
+bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2")
 bazel_dep(name = "aspect_rules_lint", version = "2.0.0")


### PR DESCRIPTION
## Summary
Updates the protobuf dependency to a newer version in the Bazel module configuration.

## Changes
- Upgraded `protobuf` from version `33.4` to `34.0.bcr.1` in MODULE.bazel

## Details
This change updates the protobuf Bazel dependency to leverage improvements and fixes available in the newer release. The version `34.0.bcr.1` is a BCR (Bazel Central Registry) compatible release.

https://claude.ai/code/session_015jr76u3qfcXEPV3SrAmBtJ