### PR TITLE
Fix syntax error in generate_claude_kubeconfig.py import

### DIFF
--- a/cluster/scripts/generate_claude_kubeconfig.py
+++ b/cluster/scripts/generate_claude_kubeconfig.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from kubernetes import client, config
 
 from devinfra.claude_hooks.k8s_secrets_setup import load_repo_config
-`from util.bazel.workspace import get_build_workspace_directory
+from util.bazel.workspace import get_build_workspace_directory
 
 logging.basicConfig(format="[%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
Fixed a syntax error in the import statement for `get_build_workspace_directory` in the kubeconfig generation script.

## Changes
- Removed erroneous backtick character (`` ` ``) from the beginning of the import statement on line 18
- The import now correctly reads: `from util.bazel.workspace import get_build_workspace_directory`

## Details
The backtick was preventing the module from being imported correctly and would have caused a syntax error at runtime. This was a simple typo that has been corrected.

https://claude.ai/code/session_013ozoMHPMrEBovX11HyuSxN