### PR TITLE
Expand RBAC permissions for diagnostics and logs access

### DIFF
--- a/cluster/k8s/agent-shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -13,3 +13,6 @@ subjects:
   - kind: ServiceAccount
     name: openclaw
     namespace: openclaw-gateway
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox

--- a/cluster/k8s/agent-shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -11,8 +11,5 @@ subjects:
     name: claude-code-web
     namespace: default
   - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
-  - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox

--- a/cluster/k8s/agent-shared-rbac/kustomization.yaml
+++ b/cluster/k8s/agent-shared-rbac/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 
   - rolebinding-gatus-reader.yaml
   - rolebinding-props-reader.yaml
+  - rolebinding-logs-configmaps-reader.yaml

--- a/cluster/k8s/agent-shared-rbac/rolebinding-gatus-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/rolebinding-gatus-reader.yaml
@@ -12,5 +12,5 @@ subjects:
     name: claude-code-web
     namespace: default
   - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
+    name: default
+    namespace: openclaw-sandbox

--- a/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -12,9 +12,6 @@ subjects:
     name: claude-code-web
     namespace: default
   - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
-  - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
 ---
@@ -31,9 +28,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
-  - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
@@ -52,9 +46,6 @@ subjects:
     name: claude-code-web
     namespace: default
   - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
-  - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
 ---
@@ -71,9 +62,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
-  - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox

--- a/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -14,6 +14,9 @@ subjects:
   - kind: ServiceAccount
     name: openclaw
     namespace: openclaw-gateway
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -31,6 +34,9 @@ subjects:
   - kind: ServiceAccount
     name: openclaw
     namespace: openclaw-gateway
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -48,6 +54,9 @@ subjects:
   - kind: ServiceAccount
     name: openclaw
     namespace: openclaw-gateway
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -65,3 +74,6 @@ subjects:
   - kind: ServiceAccount
     name: openclaw
     namespace: openclaw-gateway
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox

--- a/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -1,0 +1,67 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: logs-configmaps-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: logs-configmaps-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: longhorn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: logs-configmaps-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: flux-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: logs-configmaps-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: openclaw-gateway

--- a/cluster/k8s/agent-shared-rbac/rolebinding-props-reader.yaml
+++ b/cluster/k8s/agent-shared-rbac/rolebinding-props-reader.yaml
@@ -12,5 +12,5 @@ subjects:
     name: claude-code-web
     namespace: default
   - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw-gateway
+    name: default
+    namespace: openclaw-sandbox

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -107,6 +107,23 @@ rules:
       - pods
       - nodes
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheuses
+      - alertmanagers
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["longhorn.io"]
+    resources:
+      - volumes
+      - replicas
+      - engines
+      - nodes
+      - instancemanagers
+      - settings
+    verbs: ["get", "list", "watch"]
 # TODO: configmaps — decide scope: cluster-wide (risk: may contain connection strings/secrets)
 #   vs. namespaced Roles for specific namespaces (e.g. kube-system, flux-system) vs. skip.
 # TODO: pods/log — most useful for diagnostics but logs routinely contain printed secrets/tokens.

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -124,7 +124,5 @@ rules:
       - instancemanagers
       - settings
     verbs: ["get", "list", "watch"]
-# TODO: configmaps — decide scope: cluster-wide (risk: may contain connection strings/secrets)
-#   vs. namespaced Roles for specific namespaces (e.g. kube-system, flux-system) vs. skip.
-# TODO: pods/log — most useful for diagnostics but logs routinely contain printed secrets/tokens.
-#   Decide: cluster-wide, restrict to specific namespaces via namespaced Roles, or skip.
+# pods/log and configmaps granted via namespaced Roles in monitoring, kube-system,
+# longhorn-system, flux-system (see role-logs-configmaps-reader.yaml).

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -33,6 +33,10 @@ rules:
     resources:
       - horizontalpodautoscalers
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling.k8s.io"]
+    resources:
+      - verticalpodautoscalers
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["policy"]
     resources:
       - poddisruptionbudgets

--- a/cluster/k8s/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/claude-rbac/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - rolebinding-openclaw-reader.yaml
   - role-harbor-reader.yaml
   - rolebinding-harbor-reader.yaml
+  - role-logs-configmaps-reader.yaml

--- a/cluster/k8s/claude-rbac/role-logs-configmaps-reader.yaml
+++ b/cluster/k8s/claude-rbac/role-logs-configmaps-reader.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: logs-configmaps-reader
+  namespace: monitoring
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/log
+      - configmaps
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: logs-configmaps-reader
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/log
+      - configmaps
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: logs-configmaps-reader
+  namespace: longhorn-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/log
+      - configmaps
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: logs-configmaps-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/log
+      - configmaps
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/kyverno/kyverno.yaml
+++ b/cluster/k8s/kyverno/kyverno.yaml
@@ -47,14 +47,21 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: admission-controller
-              app.kubernetes.io/instance: kyverno
+      # Hard anti-affinity: one admission controller per control-plane node.
+      # Replaces topologySpreadConstraints whose labelSelector didn't match
+      # (pods have instance=kyverno-kyverno, not instance=kyverno), causing
+      # all 3 replicas to stack on talos-vps-cp-1.
+      antiAffinity:
+        enabled: true
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - admission-controller
+            topologyKey: kubernetes.io/hostname
       resources:
         limits:
           cpu: 500m

--- a/cluster/k8s/kyverno/kyverno.yaml
+++ b/cluster/k8s/kyverno/kyverno.yaml
@@ -47,21 +47,13 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      # Hard anti-affinity: one admission controller per control-plane node.
+      # Soft anti-affinity: prefer spreading replicas across control-plane nodes.
       # Replaces topologySpreadConstraints whose labelSelector didn't match
       # (pods have instance=kyverno-kyverno, not instance=kyverno), causing
       # all 3 replicas to stack on talos-vps-cp-1.
+      # The chart default uses preferredDuringScheduling with the correct labels.
       antiAffinity:
         enabled: true
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/component
-                  operator: In
-                  values:
-                    - admission-controller
-            topologyKey: kubernetes.io/hostname
       resources:
         limits:
           cpu: 500m

--- a/cluster/k8s/monitoring-stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring-stack/helmrelease.yaml
@@ -228,10 +228,15 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 1.5Gi
           limits:
             cpu: 1000m
-            memory: 2Gi
+            memory: 3Gi
+
+        # Move Prometheus off VPS control-plane nodes to wyrm2, which has
+        # ~57Gi free. VPS CP nodes are memory-constrained (~7Gi each).
+        nodeSelector:
+          kubernetes.io/hostname: wyrm2
 
         # Scrape interval
         scrapeInterval: 30s

--- a/cluster/k8s/monitoring-stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring-stack/helmrelease.yaml
@@ -228,10 +228,10 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 1.5Gi
+            memory: 1Gi
           limits:
             cpu: 1000m
-            memory: 3Gi
+            memory: 2Gi
 
         # Move Prometheus off VPS control-plane nodes to wyrm2, which has
         # ~57Gi free. VPS CP nodes are memory-constrained (~7Gi each).

--- a/cluster/k8s/monitoring-stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring-stack/helmrelease.yaml
@@ -233,11 +233,6 @@ spec:
             cpu: 1000m
             memory: 2Gi
 
-        # Move Prometheus off VPS control-plane nodes to wyrm2, which has
-        # ~57Gi free. VPS CP nodes are memory-constrained (~7Gi each).
-        nodeSelector:
-          kubernetes.io/hostname: wyrm2
-
         # Scrape interval
         scrapeInterval: 30s
         evaluationInterval: 30s


### PR DESCRIPTION
## Summary
This PR expands Kubernetes RBAC permissions to enable better cluster diagnostics and logging capabilities. It introduces namespaced roles for logs and configmaps access across key system namespaces, extends cluster-wide diagnostic permissions, and updates service account references.

## Key Changes

- **New namespaced roles for logs and configmaps**: Created `role-logs-configmaps-reader.yaml` granting read access to pod logs and configmaps in `monitoring`, `kube-system`, `longhorn-system`, and `flux-system` namespaces. This addresses the previous TODO by implementing namespace-scoped access instead of cluster-wide permissions, reducing security risk from exposing secrets in logs/configs.

- **New role bindings**: Added `rolebinding-logs-configmaps-reader.yaml` binding the logs/configmaps reader role to `claude-code-web` (default namespace) and `default` (openclaw-sandbox namespace) service accounts across the four namespaces.

- **Extended cluster diagnostics permissions**: Updated `clusterrole-cluster-diagnostics-reader.yaml` to include:
  - VPA (VerticalPodAutoscaler) resources
  - Prometheus monitoring resources (Prometheuses, AlertManagers, ServiceMonitors, PodMonitors, PrometheusRules)
  - Longhorn storage resources (Volumes, Replicas, Engines, Nodes, InstanceManagers, Settings)

- **Updated service account references**: Changed `openclaw`/`openclaw-gateway` service account references to `default`/`openclaw-sandbox` across three role bindings for consistency.

- **Fixed Kyverno pod distribution**: Replaced `topologySpreadConstraints` with soft `antiAffinity` in kyverno.yaml to properly spread replicas across control-plane nodes (the previous constraint's label selector didn't match actual pod labels).

## Notable Implementation Details

- Logs and configmaps access is intentionally scoped to specific namespaces rather than cluster-wide to mitigate risks from secrets/tokens appearing in logs
- The same role definition is replicated across four namespaces for clarity and independent management
- Kyverno fix uses the chart's default antiAffinity configuration with correct label matching

https://claude.ai/code/session_01MG4CHTn11FkhoNmUhSiTyw