### PR TITLE
Stop piping BUILDBUDDY_API_KEY as env var in claude_hooks

### DIFF
--- a/.claude_hooks/config.yaml
+++ b/.claude_hooks/config.yaml
@@ -11,6 +11,6 @@ k8s_secrets:
     - name: github-token
       data:
         token: GITHUB_TOKEN
-    - name: buildbuddy-api-key
-      data:
-        api-key: BUILDBUDDY_API_KEY
+  buildbuddy_api_key:
+    secret_name: buildbuddy-api-key
+    data_key: api-key

--- a/.claude_hooks/templates/context.mako
+++ b/.claude_hooks/templates/context.mako
@@ -32,8 +32,8 @@ Ollama: OpenAI-compatible LLM inference at `https://ollama.allegedly.works/v1` (
   Available model: `gpt-oss-20b-128k` (OpenAI gpt-oss 20B, 128K context, Apache 2.0).
   API key in k8s secret `ollama-api-key`, key `api-key`, namespace `claude-sandbox`.
   Retrieve: `kubectl get secret ollama-api-key -n claude-sandbox -o jsonpath='{.data.api-key}' | base64 -d`
-% if "BUILDBUDDY_API_KEY" in secrets.env_vars:
-`BUILDBUDDY_API_KEY`: BuildBuddy remote cache/execution key (also configured in ~/.config/bazel/buildbuddy.bazelrc).
+% if secrets.buildbuddy_api_key:
+API key in `~/.config/bazel/buildbuddy.bazelrc`. See <docs/buildbuddy_api.md> for undocumented endpoints (profile download, invocation search, cache scorecard).
 % endif
 % if "KUBECONFIG" in secrets.env_vars:
 `KUBECONFIG`: Points to decoded kubeconfig for the `cluster/` Talos k8s cluster. ServiceAccount `claude-code-web` with access to the `claude-sandbox` namespace (pods, services, secrets, exec). Resource limits: 4 CPU, 8Gi memory, 10 pods. Use `kubectl` for `cluster/` operations (deploy, inspect, debug).

--- a/devinfra/claude_hooks/buildbuddy_setup.py
+++ b/devinfra/claude_hooks/buildbuddy_setup.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,39 +23,25 @@ class BuildbuddySetup:
     configured: bool
 
 
-def setup_buildbuddy(project_dir: Path, *, api_key: str | None = None) -> BuildbuddySetup:
+def setup_buildbuddy(*, api_key: str | None = None) -> BuildbuddySetup:
     """Configure BuildBuddy remote cache.
 
-    Writes config to ~/.config/bazel/buildbuddy.bazelrc and ensures
-    ~/.bazelrc has the try-import line.
-
-    TODO: Make this session-local. Instead of writing to the user-global
-    ~/.config/bazel/buildbuddy.bazelrc and modifying ~/.bazelrc, generate the
-    BuildBuddy bazelrc content directly and write it to session_dir/buildbuddy.bazelrc,
-    then include it via an extra ``--bazelrc=`` flag injected by the wrapper (or by
-    appending a ``try-import`` line to the session bazelrc template). That would keep
-    BuildBuddy config fully within the session directory and avoid touching global Bazel
-    config files.
+    Writes config to ~/.config/bazel/buildbuddy.bazelrc. The session bazelrc
+    template includes a try-import for this file.
     """
     if not api_key:
         logger.info("BuildBuddy API key not provided, skipping setup")
         return BuildbuddySetup(configured=False)
 
-    script_path = project_dir / "devinfra" / "setup_buildbuddy.sh"
-    if not script_path.exists():
-        logger.warning("BuildBuddy setup script not found: %s", script_path)
-        return BuildbuddySetup(configured=False)
-
-    result = subprocess.run(
-        [script_path],
-        env={**os.environ, "BUILDBUDDY_API_KEY": api_key},
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
+    BUILDBUDDY_BAZELRC.parent.mkdir(parents=True, exist_ok=True)
+    BUILDBUDDY_BAZELRC.write_text(
+        "# BuildBuddy authentication (auto-generated)\n"
+        "# Static configuration is in .bazelrc under build:rbe\n"
+        f"common --remote_header=x-buildbuddy-api-key={api_key}\n"
+        "\n"
+        "# Enable RBE (platforms, exec properties in .bazelrc + BUILD.bazel platform)\n"
+        "build --config=rbe\n"
     )
-    if result.returncode == 0:
-        logger.info("BuildBuddy remote cache configured")
-        return BuildbuddySetup(configured=True)
-    logger.warning("BuildBuddy setup failed: %s", result.stderr)
-    return BuildbuddySetup(configured=False)
+
+    logger.info("BuildBuddy remote cache configured at %s", BUILDBUDDY_BAZELRC)
+    return BuildbuddySetup(configured=True)

--- a/devinfra/claude_hooks/config/bazelrc.mako
+++ b/devinfra/claude_hooks/config/bazelrc.mako
@@ -35,6 +35,9 @@ build --build_metadata=ROLE=claude-code
 test --test_tag_filters=-live_openai_api
 % endif
 
+# BuildBuddy remote cache (API key in separate bazelrc, no-op if absent)
+try-import ${buildbuddy_bazelrc}
+
 # AI agent quiet mode (suppress verbose progress for agent transcript)
 # Bazel 7.6+ reads workspace and user RC files in addition to --bazelrc=,
 # so the config definition in the workspace .bazelrc is available here.

--- a/devinfra/claude_hooks/k8s_secrets_setup.py
+++ b/devinfra/claude_hooks/k8s_secrets_setup.py
@@ -33,11 +33,19 @@ class K8sSecretMapping(BaseModel):
     data: dict[str, str]  # secret data key -> env var name
 
 
+class K8sSecretRef(BaseModel):
+    """Reference to a single key in a k8s Secret."""
+
+    secret_name: str
+    data_key: str
+
+
 class K8sSecretsConfig(BaseModel):
     """Config for reading secrets from k8s."""
 
     namespace: str
     secrets: list[K8sSecretMapping]
+    buildbuddy_api_key: K8sSecretRef | None = None
 
 
 class K8sConfig(BaseModel):
@@ -62,6 +70,7 @@ class K8sSecretsResult:
 
     env_vars: dict[str, str] = field(default_factory=dict)
     kubeconfig_path: Path | None = None
+    buildbuddy_api_key: str | None = None
 
 
 def load_config(config_path: Path) -> HookConfig:
@@ -99,11 +108,7 @@ def _build_kubeconfig(token: str, server: str, service_account: str, namespace: 
 
 
 def setup_k8s_secrets(
-    token: str,
-    session_dir: Path,
-    combined_ca_path: Path | None,
-    config: HookConfig,
-    proxy: str | None = None,
+    token: str, session_dir: Path, combined_ca_path: Path | None, config: HookConfig, proxy: str | None = None
 ) -> K8sSecretsResult:
     """Read secrets from k8s and write kubeconfig.
 
@@ -152,6 +157,19 @@ def setup_k8s_secrets(
             value = base64.b64decode(secret.data[data_key]).decode()
             result.env_vars[env_var] = value
             logger.info("Mapped %s/%s[%s] -> %s", secrets_cfg.namespace, entry.name, data_key, env_var)
+
+    # Fetch BuildBuddy API key (internal use only, not exported as env var)
+    if secrets_cfg.buildbuddy_api_key:
+        ref = secrets_cfg.buildbuddy_api_key
+        try:
+            bb_secret = api.read_namespaced_secret(ref.secret_name, secrets_cfg.namespace)
+            if bb_secret.data and ref.data_key in bb_secret.data:
+                result.buildbuddy_api_key = base64.b64decode(bb_secret.data[ref.data_key]).decode()
+                logger.info(
+                    "BuildBuddy API key read from %s/%s[%s]", secrets_cfg.namespace, ref.secret_name, ref.data_key
+                )
+        except k8s_client.ApiException as e:
+            logger.warning("Failed to read BuildBuddy API key: %s", e.reason)
 
     # Write kubeconfig
     kubeconfig = _build_kubeconfig(token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path)

--- a/devinfra/claude_hooks/session_start.py
+++ b/devinfra/claude_hooks/session_start.py
@@ -383,11 +383,9 @@ async def _setup_web(
             )
 
     # Configure BuildBuddy now that k8s secrets (with API key) are available.
-    buildbuddy_api_key = secrets.env_vars.get("BUILDBUDDY_API_KEY") if secrets else None
+    buildbuddy_api_key = secrets.buildbuddy_api_key if secrets else None
     with tracer.start_as_current_span("setup_buildbuddy", context=root_ctx):
-        buildbuddy_result = await run_in_thread(
-            lambda: buildbuddy_setup.setup_buildbuddy(project_dir, api_key=buildbuddy_api_key)
-        )
+        buildbuddy_result = await run_in_thread(lambda: buildbuddy_setup.setup_buildbuddy(api_key=buildbuddy_api_key))
     buildbuddy_configured = (
         isinstance(buildbuddy_result, buildbuddy_setup.BuildbuddySetup) and buildbuddy_result.configured
     )
@@ -515,6 +513,7 @@ async def run_session(hook_input: HookInput, settings: HookSettings, env_file_pa
             local_proxy=setup.local_proxy,
             combined_ca_path=setup.combined_ca_path,
             buildbuddy_configured=setup.buildbuddy_configured,
+            buildbuddy_bazelrc=buildbuddy_setup.BUILDBUDDY_BAZELRC,
             bazel_cache_dir=setup.bazel_cache_dir,
         )
         session_bazelrc = settings.session_dir / "bazelrc"


### PR DESCRIPTION
## Summary

- Fetch BuildBuddy API key into a dedicated `K8sSecretsResult.buildbuddy_api_key` field instead of the generic `env_vars` dict, so it's no longer exported to `CLAUDE_ENV_FILE`
- Rewrite `buildbuddy_setup.py` to write the bazelrc directly in Python instead of shelling out to `setup_buildbuddy.sh` via subprocess
- Add unconditional `try-import` for buildbuddy.bazelrc in the session bazelrc template

## Test plan

- [x] `bazel build //devinfra/claude_hooks/...` passes (with lint)
- [x] `bazel test //devinfra/claude_hooks/...` — all 12 tests pass

https://claude.ai/code/session_019r5vr7XgyveGai5dub4iJY