### PR TITLE
docs: update kubespand README, remove HAProxy references

### DIFF
--- a/cluster/docs/plans/roaming-laptop-worker.md
+++ b/cluster/docs/plans/roaming-laptop-worker.md
@@ -9,8 +9,7 @@ Join a regular Linux desktop/laptop to the Talos cluster as a worker without VMs
 │  Linux Desktop (NixOS)       │
 │  ├── desktop environment     │
 │  ├── containerd + kubelet    │
-│  ├── kubespand (KubeSpan)    │
-│  ├── HAProxy (localhost:7445)│
+│  ├── kubespand (KubeSpan+KubePrism) │
 │  └── Cilium agent (DaemonSet)│
 └──────────────────────────────┘
          │ KubeSpan mesh (UDP 51820)
@@ -111,7 +110,7 @@ Components (both fabrics):
 
 - **containerd** with systemd cgroup driver
 - **kubelet** as a custom systemd service (TLS bootstrap, not auto-started)
-- **HAProxy** at `localhost:7445` → `api.allegedly.works` (replaces Talos KubePrism)
+- **KubePrism** (via kubespand) at `localhost:7445` → discovered control plane endpoints
 - **Kernel prereqs**: `overlay`, `br_netfilter`, IP forwarding
 - **Firewall**: VXLAN (UDP 8472), kubelet (TCP 10250)
 
@@ -191,7 +190,7 @@ Verify:
 # Extract bootstrap kubeconfig + CA
 talosctl -n <cp-ip> cat /etc/kubernetes/bootstrap-kubeconfig > bootstrap-kubelet.conf
 talosctl -n <cp-ip> cat /etc/kubernetes/pki/ca.crt > ca.crt
-# Keep server as https://127.0.0.1:7445 — HAProxy handles routing to control plane
+# Keep server as https://127.0.0.1:7445 — KubePrism (via kubespand) routes to control plane
 
 # Copy to VM
 scp bootstrap-kubelet.conf ca.crt user@<vm-ip>:/tmp/
@@ -290,7 +289,7 @@ Mitigations:
 ## Known Gotchas
 
 - **KubePrism**: Cilium is configured with `k8sServiceHost: localhost`,
-  `k8sServicePort: 7445`. Non-Talos nodes don't have KubePrism — HAProxy fills this role.
+  `k8sServicePort: 7445`. Non-Talos nodes get KubePrism via kubespand (`kubeprism.enabled: true`).
 - **Cilium `SYS_MODULE`**: Talos drops this capability from Cilium pods. On a regular
   Linux box, Cilium may need to load kernel modules. Pre-load `sch_ingress` etc. or
   adjust via `CiliumNodeConfig`.
@@ -315,20 +314,12 @@ Mitigations:
 - **CSR auto-approval**: Consider deploying a CSR approver controller to avoid manual
   `kubectl certificate approve` on every node join.
 
-### HAProxy Control Plane Endpoint Management
+### Control Plane Endpoint (KubePrism)
 
-**Resolved**: HAProxy now resolves `api.allegedly.works` via DNS at runtime using
-`server-template` with a `resolvers` section. The DNS record (managed by Terraform in
-`cluster/terraform/gitops/dns-records/main.tf`) round-robins across VPS public IPs.
-
-**Why HAProxy exists**: Cilium is configured cluster-wide with `k8sServiceHost: localhost`,
+Cilium is configured cluster-wide with `k8sServiceHost: localhost`,
 `k8sServicePort: 7445`. On Talos nodes, KubePrism (built into `machined`) provides this.
-On non-Talos nodes, nothing listens there without a local proxy. KubePrism is not a
-standalone binary.
-
-The Proxmox CP (`10.2.1.1`) is excluded — it has no public IP, and if both VPS nodes are
-down, the NixOS worker would be effectively offline regardless. 2/3 CPs is sufficient for
-API access.
+On non-Talos nodes, kubespand provides KubePrism (`kubeprism.enabled: true`) — it discovers
+control plane endpoints from the KubeSpan mesh and load-balances across them.
 
 ## Appendix: KubeSpan Internals
 

--- a/cluster/docs/wyrm2-gpu-worker.md
+++ b/cluster/docs/wyrm2-gpu-worker.md
@@ -1,7 +1,7 @@
-# NixOS GPU Desktop + K8s Worker (Unified VM)
+# wyrm2 — NixOS GPU Desktop + K8s Worker
 
-Replace the separate Talos GPU worker VM and wyrm desktop VM with a single NixOS VM
-that serves both roles: a K8s worker with GPU access and a daily-driver Linux desktop.
+wyrm2 is a single NixOS VM on Proxmox that serves as both a K8s worker with GPU access
+and a daily-driver Linux desktop.
 
 ## Motivation
 
@@ -12,10 +12,6 @@ the desktop starves during heavy use, or vice versa.
 
 A single VM eliminates the split entirely — one VM gets ~28GB (leaving ~4GB for
 Proxmox host + lightweight Talos CP VM).
-
-## Current State ✅ (Completed)
-
-wyrm2 is live as a NixOS GPU desktop + K8s worker with 2x RTX 5090.
 
 | VM    | Role                     | RAM   | GPUs    | OS    |
 | ----- | ------------------------ | ----- | ------- | ----- |
@@ -41,8 +37,8 @@ The Talos control plane VM on Proxmox stays unchanged (lightweight, ~4GB).
 │  └──────────────────────────────────────────┘   │
 │                                                 │
 │  ┌─── Networking ───────────────────────────┐   │
-│  │  Tailscale → Headscale (mesh)            │   │
-│  │  HAProxy localhost:7445 → control plane  │   │
+│  │  KubeSpan mesh (kubespand)               │   │
+│  │  KubePrism localhost:7445 → CP endpoints │   │
 │  └──────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────┘
 ```
@@ -93,7 +89,7 @@ kubectl uncordon gpu-node
 
 A desktop script/shortcut can automate either workflow.
 
-## NixOS Configuration (Implemented)
+## NixOS Configuration
 
 Built on the `k8s-worker` NixOS module (`nix/nixos/modules/k8s-worker.nix`) with
 `enableNvidiaRuntime = true`:
@@ -109,44 +105,11 @@ Built on the `k8s-worker` NixOS module (`nix/nixos/modules/k8s-worker.nix`) with
   NixOS FHS path incompatibility in `tryResolveLibrary`)
 - **Workload pods**: Must specify `runtimeClassName: nvidia` to get GPU access
 
-## Migration Steps
-
-1. **Prepare NixOS config**: Extend `k8s-worker-test` host config with GPU + desktop
-2. **Create new VM**: Proxmox VM with both GPUs passed through, q35 machine type,
-   PCIe passthrough (same hardware config as current `talos-pve-gpu-worker-0`)
-3. **Join cluster**: Bootstrap kubeconfig + Headscale registration + CSR approval
-   (same procedure as roaming laptop worker)
-4. **Verify GPU workloads**: Ollama schedules on the NixOS node, `nvidia-smi` works
-   inside pods
-5. **Migrate wyrm data**: Copy home directory, dev environments, etc.
-6. **Decommission old VMs**: Remove `talos-pve-gpu-worker-0` and `wyrm` from Proxmox
-
-## Differences from Talos GPU Worker
-
-| Aspect             | Talos GPU Worker (current)  | NixOS GPU Desktop (target)     |
-| ------------------ | --------------------------- | ------------------------------ |
-| OS management      | Talos API (`talosctl`)      | NixOS (`nixos-rebuild`, SSH)   |
-| Immutability       | Fully immutable filesystem  | Declarative but mutable        |
-| Desktop            | None                        | Full desktop environment       |
-| GPU mode switching | Not possible (Talos only)   | Taint toggle or drain+stop     |
-| Container runtime  | Talos-managed containerd    | NixOS-managed containerd       |
-| NVIDIA drivers     | Talos extension             | `hardware.nvidia` NixOS module |
-| Debugging          | `talosctl` only             | SSH + standard Linux tools     |
-| Node join          | Automatic (Talos bootstrap) | Manual (bootstrap kubeconfig)  |
-
 ## Open Questions
 
 - **Partial GPU detach**: Could expose only 1 GPU to k8s (via device plugin config
   file `NVIDIA_VISIBLE_DEVICES` filter) and keep 1 for desktop. Adds complexity;
   probably not worth it vs the clean taint-toggle approach.
-- **NVIDIA driver version alignment**: NixOS and Talos extension may ship different
-  driver versions. Shouldn't matter (each node runs its own drivers), but container
-  images built for one driver version might behave differently on another.
-- **NFD on NixOS**: Node Feature Discovery CrashLoopBackOff was observed on the
-  `k8s-worker-test` VM (non-critical, but labels like `pci-10de.present` may need
-  to be set manually until resolved).
-- **Proxmox CSI**: Current GPU worker uses `proxmox-csi-retain` for some PVCs.
-  NixOS node would need the same CSI driver or those PVCs migrate to `local-path`.
 
 ## Related
 

--- a/cluster/kubespand/README.md
+++ b/cluster/kubespand/README.md
@@ -44,7 +44,8 @@ automatically when their inputs change.
    Enabled when `kubeprism.enabled: true`.
 8. **KubePrismController** (optional, embedded from Talos): watches `k8s.KubePrismConfig`
    → manages a TCP load balancer on `localhost:7445` that proxies to kube-apiserver
-   endpoints. Replaces HAProxy as the local API server proxy.
+   endpoints. Provides the same local API server proxy that Talos nodes get natively
+   via KubePrism built into `machined`.
 
 ## Prerequisites
 

--- a/cluster/kubespand/kubespand.example.yaml
+++ b/cluster/kubespand/kubespand.example.yaml
@@ -85,7 +85,7 @@ cluster:
 #     - "10.96.0.0/12"
 
 # kubeprism:
-#   # Enable KubePrism local API server load balancer. Replaces HAProxy as the
+#   # Enable KubePrism local API server load balancer. Binds
 #   # localhost:7445 → kube-apiserver proxy. Discovers control plane endpoints
 #   # from the KubeSpan mesh and load-balances across them.
 #   # Requires cluster.endpoint to be set.


### PR DESCRIPTION
## Summary

- Remove "Replaces HAProxy" mentions from kubespand README and example config — KubePrism is now the established local API server proxy
- Update `roaming-laptop-worker.md` to reference KubePrism (via kubespand) instead of HAProxy throughout
- Move `nixos-gpu-desktop-worker.md` out of `plans/` to `docs/wyrm2-gpu-worker.md` since wyrm2 is live — cleaned up planning language, removed completed migration steps, updated networking diagram from Tailscale/HAProxy to KubeSpan/KubePrism

## Test plan

- [ ] Documentation-only change, no code modified
- [ ] Verify no remaining stale HAProxy references in kubespand docs (debug log left as historical)

https://claude.ai/code/session_012tEJEkYsYycgoBirGrw3oJ