### PR TITLE
Enable parallel execution for KubeSpan topology tests

### DIFF
--- a/cluster/kubespand/qemu_tests/kubespan/kubespan_test.go
+++ b/cluster/kubespand/qemu_tests/kubespan/kubespan_test.go
@@ -10,14 +10,17 @@ import (
 )
 
 func TestFlat(t *testing.T) {
+	t.Parallel()
 	runTopology(t, "flat")
 }
 
 func TestCrossSubnet(t *testing.T) {
+	t.Parallel()
 	runTopology(t, "cross_subnet")
 }
 
 func TestDiscoveryOnly(t *testing.T) {
+	t.Parallel()
 	runTopology(t, "discovery_only")
 }
 


### PR DESCRIPTION
## Summary
Added `t.Parallel()` calls to all three KubeSpan topology test functions to enable parallel test execution, improving test suite performance.

## Changes
- Added `t.Parallel()` to `TestFlat()`
- Added `t.Parallel()` to `TestCrossSubnet()`
- Added `t.Parallel()` to `TestDiscoveryOnly()`

## Details
These tests can safely run in parallel as they operate on isolated topology configurations. Enabling parallel execution will reduce overall test suite runtime without affecting test correctness or reliability.

https://claude.ai/code/session_01S3m46nn75vZoM6JDCrnHUo