### PR TITLE
perf: switch Talos disk image from raw.zst to native qcow2

### DIFF
--- a/cluster/kubespand/qemu_tests/helpers.go
+++ b/cluster/kubespand/qemu_tests/helpers.go
@@ -27,7 +27,7 @@ const (
 	DoublenatInitramfs = "cluster/kubespand/qemu_tests/vms/doublenat/initramfs.cpio.gz"
 	NftInitramfs       = "cluster/kubespand/qemu_tests/nft/initramfs.cpio.gz"
 	// Talos nocloud image built by genrule — under _main/ prefix.
-	TalosNocloudImagePath = "cluster/kubespand/qemu_tests/talos/nocloud-amd64.raw.zst"
+	TalosNocloudImagePath = "cluster/kubespand/qemu_tests/talos/nocloud-amd64.qcow2"
 
 	// Pre-generated Talos configs (committed as testdata).
 	TalosVPSConfig  = "cluster/kubespand/qemu_tests/talos/testdata/vps-controlplane.yaml"

--- a/cluster/kubespand/qemu_tests/talos/BUILD.bazel
+++ b/cluster/kubespand/qemu_tests/talos/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_load")
 
 # ─ Talos nocloud disk image (built from pinned imager container) ─────────────
-# Produces a reproducible Talos nocloud raw disk image via the official imager.
+# Produces a reproducible Talos nocloud qcow2 disk image via the official imager.
 # The imager container is pinned by OCI digest in MODULE.bazel, and
 # SOURCE_DATE_EPOCH + DETERMINISTIC_SEED ensure identical output across builds.
 
@@ -20,27 +20,30 @@ filegroup(
 
 genrule(
     name = "talos_nocloud_image",
-    srcs = [":talos_imager_tarball"],
-    outs = ["nocloud-amd64.raw.zst"],
+    srcs = [
+        ":talos_imager_tarball",
+        "imager-profile.yaml",
+    ],
+    outs = ["nocloud-amd64.qcow2"],
     cmd = " && ".join([
         # Load the pinned imager image into Docker.
         "docker load -i $(location :talos_imager_tarball) >&2",
-        # Build a reproducible nocloud disk image.
+        # Build a reproducible Talos nocloud disk image in qcow2 format.
         # SOURCE_DATE_EPOCH + DETERMINISTIC_SEED ensure byte-identical output.
-        # Output goes to /tmp (scratch disk) to avoid filling the workspace disk
-        # — the imager creates a 4.5 GB intermediate raw image before compressing.
-        "mkdir -p /tmp/talos_out",
+        # qcow2 stores only non-zero blocks: ~200 MB vs 4.2 GB raw, eliminating
+        # the ~47s zstd decompression step the test previously needed.
+        "TALOS_OUT=$$(mktemp -d)",
         " ".join([
             "docker run --rm",
             "-e SOURCE_DATE_EPOCH=1700000000",
             "-e DETERMINISTIC_SEED=1",
-            "-v /tmp/talos_out:/out",
-            "siderolabs/imager:build",
-            "nocloud --arch amd64",
+            "-v $$TALOS_OUT:/out",
+            "-i siderolabs/imager:build",
+            "- < $(location imager-profile.yaml)",
             ">&2",
         ]),
-        "mv /tmp/talos_out/nocloud-amd64.raw.zst $@",
-        "rm -rf /tmp/talos_out",
+        "mv $$TALOS_OUT/nocloud-amd64.qcow2 $@",
+        "rm -rf $$TALOS_OUT",
     ]),
     tags = ["requires-docker"],
 )
@@ -59,7 +62,6 @@ go_test(
     deps = [
         "//cluster/kubespand/qemu_tests",
         "@com_github_cosi_project_runtime//pkg/safe",
-        "@com_github_klauspost_compress//zstd",
         "@com_github_siderolabs_talos_pkg_machinery//client",
         "@com_github_siderolabs_talos_pkg_machinery//client/config",
         "@com_github_siderolabs_talos_pkg_machinery//resources/kubespan",

--- a/cluster/kubespand/qemu_tests/talos/imager-profile.yaml
+++ b/cluster/kubespand/qemu_tests/talos/imager-profile.yaml
@@ -1,0 +1,8 @@
+baseProfileName: nocloud
+arch: amd64
+output:
+  kind: image
+  outFormat: raw
+  imageOptions:
+    diskFormat: qcow2
+    diskFormatOptions: "compat=1.1"

--- a/cluster/kubespand/qemu_tests/talos/talos_test.go
+++ b/cluster/kubespand/qemu_tests/talos/talos_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
-	"github.com/klauspost/compress/zstd"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/kubespan"
@@ -23,7 +21,7 @@ import (
 func TestTalosKubeSpanDoubleNAT(t *testing.T) {
 	sw := h.NewStopwatch(t)
 
-	talosImageZst := h.RunfilePath(t, h.TalosNocloudImagePath)
+	talosBaseImage := h.RunfilePath(t, h.TalosNocloudImagePath)
 	alpineVmlinuz := h.RunfilePath(t, h.VmlinuzPath)
 	alpineInitramfsDisc := h.RunfilePath(t, h.DiscoveryInitramfs)
 	alpineInitramfsRouter := h.RunfilePath(t, h.RouterInitramfs)
@@ -31,10 +29,6 @@ func TestTalosKubeSpanDoubleNAT(t *testing.T) {
 
 	out := h.OutputDir(t)
 	tmpDir := t.TempDir()
-
-	talosBaseImage := filepath.Join(tmpDir, "nocloud-amd64.raw")
-	decompressZstd(t, talosImageZst, talosBaseImage)
-	sw.Lap("decompress talos image")
 
 	vpsConfig := readRunfile(t, h.TalosVPSConfig)
 	nat1Config := readRunfile(t, h.TalosNAT1Config)
@@ -145,14 +139,14 @@ func createCIDATA(t *testing.T, tmpDir, name string, machineConfig []byte) strin
 	return imgPath
 }
 
-// bootTalosVM starts a Talos QEMU VM from a raw disk image with CIDATA config.
-// Uses snapshot=on so QEMU creates a temporary overlay per VM, avoiding full
-// copies of the ~4.5 GB base image.
+// bootTalosVM starts a Talos QEMU VM from a qcow2 disk image with CIDATA config.
+// Uses snapshot=on so QEMU creates a temporary overlay per VM, keeping the
+// base image read-only and allowing multiple VMs to share it.
 func bootTalosVM(t *testing.T, name, baseImage, cidataPath string, mgmtPort int, netArgs []string) *h.VM {
 	t.Helper()
 
 	args := []string{
-		"-drive", fmt.Sprintf("file=%s,if=virtio,format=raw,snapshot=on", baseImage),
+		"-drive", fmt.Sprintf("file=%s,if=virtio,format=qcow2,snapshot=on", baseImage),
 		"-drive", fmt.Sprintf("file=%s,if=virtio,format=raw,readonly=on", cidataPath),
 		"-nographic",
 		"-m", "1536",
@@ -267,29 +261,4 @@ func pollKubeSpanStatus(t *testing.T, c *client.Client, nodeIP string, timeout t
 	}
 
 	return nil, fmt.Errorf("timeout after %v, last error: %s", timeout, lastErr)
-}
-
-func decompressZstd(t *testing.T, src, dst string) {
-	t.Helper()
-	in, err := os.Open(src)
-	if err != nil {
-		t.Fatalf("open zstd source: %v", err)
-	}
-	defer in.Close()
-
-	dec, err := zstd.NewReader(in)
-	if err != nil {
-		t.Fatalf("create zstd decoder: %v", err)
-	}
-	defer dec.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		t.Fatalf("create output file: %v", err)
-	}
-	defer out.Close()
-
-	if _, err := io.Copy(out, dec); err != nil {
-		t.Fatalf("decompress zstd: %v", err)
-	}
 }


### PR DESCRIPTION
## Summary

- Switch Talos imager to produce qcow2 natively via an `imager-profile.yaml` file, eliminating the ~47s zstd decompression step
- qcow2 stores only non-zero blocks (~200 MB vs 4.2 GB raw), with QEMU `snapshot=on` creating temporary overlays per VM
- Remove `decompressZstd` function and zstd dependency from the test

## Test plan

- [x] `bazel build //cluster/kubespand/qemu_tests/talos:talos_test` compiles successfully
- [ ] `bazel test //cluster/kubespand/qemu_tests/talos:talos_test` passes (requires QEMU)

https://claude.ai/code/session_01S3m46nn75vZoM6JDCrnHUo