### PR TITLE
PostToolUse hook: check-only lint with diff feedback

### DIFF
--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -341,6 +341,7 @@ py_library(
 
 py_binary(
     name = "hook_dispatch",
+    data = [":bazel_wrapper"],
     imports = ["../.."],
     main_module = "devinfra.claude.hook_dispatch",
     visibility = ["//visibility:public"],

--- a/devinfra/claude/post_tool_use.py
+++ b/devinfra/claude/post_tool_use.py
@@ -1,13 +1,24 @@
-"""PostToolUse hook: auto-format files after Edit/Write tool calls.
+"""PostToolUse hook: lint-check files after Edit/Write tool calls.
 
-Runs pre-commit on files that Claude Code just modified. Delegates all
-formatter dispatch to pre-commit's own configuration (.pre-commit-config.yaml),
-maintaining a single source of truth for file-to-formatter mapping.
+Runs pre-commit on files that Claude Code just modified, reports any
+issues back to the agent (with a short diff of what pre-commit would
+change), then restores the original file content so the agent can
+fix issues itself.
+
+TODO: Import pre-commit as a Python dependency and use its API directly
+instead of subprocess. This would give structured output (per-hook results,
+exit codes) without messy stdout parsing. subprocess.run already accepts
+Path objects for the command, so the transition path is: find pre-commit's
+internal run API, call it with the file list, and get back typed results.
 """
 
+from __future__ import annotations
+
+import difflib
 import logging
 import shutil
 import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +31,18 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
 logger = logging.getLogger(__name__)
 
 FILE_MODIFYING_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
+
+_TIMEOUT_SECONDS = 30
+_MAX_ISSUES_SHOWN = 3
+_MAX_DIFF_LINES = 20
+
+
+@dataclass
+class CheckResult:
+    issue_count: int
+    issues: list[str] = field(default_factory=list)
+    fix_command: str = ""
+    diff: str = ""
 
 
 def _get_file_path(tool_input: dict[str, Any]) -> Path | None:
@@ -38,21 +61,80 @@ def _find_git_root(start: Path) -> Path | None:
     return None
 
 
-def _run_precommit(file_path: Path, project_dir: Path) -> bool:
-    """Run pre-commit on a single file. Returns True if the file was modified."""
+def _make_short_diff(original: bytes, modified: bytes, filename: str) -> str:
+    """Generate a truncated unified diff between original and modified content."""
+    orig_lines = original.decode(errors="replace").splitlines(keepends=True)
+    mod_lines = modified.decode(errors="replace").splitlines(keepends=True)
+    diff_lines = list(difflib.unified_diff(orig_lines, mod_lines, fromfile=f"a/{filename}", tofile=f"b/{filename}"))
+    if not diff_lines:
+        return ""
+    if len(diff_lines) > _MAX_DIFF_LINES:
+        diff_lines = diff_lines[:_MAX_DIFF_LINES]
+        diff_lines.append(f"... (diff truncated, {len(diff_lines)} more lines)\n")
+    return "".join(diff_lines).rstrip()
+
+
+def _run_precommit_check(file_path: Path, project_dir: Path) -> CheckResult | None:
+    """Run pre-commit on a file, capture output and diff, then restore original content."""
     precommit = shutil.which("pre-commit")
     if precommit is None:
-        return False
+        return None
 
     original_content = file_path.read_bytes()
+    try:
+        result = subprocess.run(
+            [precommit, "run", "--files", str(file_path)],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+            cwd=project_dir,
+        )
+        modified_content = file_path.read_bytes()
+    finally:
+        file_path.write_bytes(original_content)
 
-    subprocess.run(
-        [precommit, "run", "--files", str(file_path)], check=False, cwd=project_dir, capture_output=True, timeout=30
+    if result.returncode == 0:
+        return None
+
+    # Parse pre-commit output for failed hooks and their messages
+    lines = (result.stdout or "").splitlines()
+    failed_hooks = 0
+    failure_lines: list[str] = []
+    in_failure = False
+
+    for line in lines:
+        if "Failed" in line:
+            failed_hooks += 1
+            in_failure = True
+            continue
+        if "Passed" in line or "Skipped" in line:
+            in_failure = False
+            continue
+        if in_failure and line.strip() and len(failure_lines) < _MAX_ISSUES_SHOWN:
+            failure_lines.append(line.rstrip())
+
+    diff = _make_short_diff(original_content, modified_content, file_path.name)
+
+    return CheckResult(
+        issue_count=max(failed_hooks, 1),
+        issues=failure_lines,
+        fix_command=f"pre-commit run --files {file_path}",
+        diff=diff,
     )
-    # pre-commit returns non-zero when hooks fail or modify files.
-    # We don't care about the exit code — only whether the file changed.
 
-    return file_path.read_bytes() != original_content
+
+def _format_check_result(result: CheckResult, file_path: Path) -> str:
+    noun = "hook" if result.issue_count == 1 else "hooks"
+    parts = [f"{result.issue_count} {noun} failed on {file_path.name}:"]
+    for issue in result.issues:
+        parts.append(f"  {issue}")
+    if result.diff:
+        parts.append("Changes pre-commit would make:")
+        parts.append(result.diff)
+    if result.fix_command:
+        parts.append(f"Run `{result.fix_command}` to apply fixes.")
+    return "\n".join(parts)
 
 
 def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
@@ -68,16 +150,16 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         return PostToolUseOutput()
 
     try:
-        changed = _run_precommit(file_path, project_dir)
+        check_result = _run_precommit_check(file_path, project_dir)
     except (subprocess.TimeoutExpired, OSError) as e:
-        logger.warning("pre-commit failed on %s: %s", file_path, e)
+        logger.warning("Lint check failed on %s: %s", file_path, e)
         return PostToolUseOutput()
 
-    if not changed:
+    if check_result is None:
         return PostToolUseOutput()
 
     return PostToolUseOutput(
         hook_specific_output=PostToolUseHookSpecificOutput(
-            additional_context=f"Auto-formatted {file_path.name} via pre-commit. File updated in-place."
+            additional_context=_format_check_result(check_result, file_path)
         )
     )

--- a/devinfra/claude/test_post_tool_use.py
+++ b/devinfra/claude/test_post_tool_use.py
@@ -1,6 +1,7 @@
 """Tests for post_tool_use hook."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import pytest_bazel
@@ -10,7 +11,7 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
-from devinfra.claude.post_tool_use import _find_git_root, evaluate
+from devinfra.claude.post_tool_use import CheckResult, _find_git_root, _format_check_result, _make_short_diff, evaluate
 
 _COMMON = {
     "session_id": "test-session",
@@ -21,6 +22,9 @@ _COMMON = {
     "tool_use_id": "toolu_test123",
     "tool_response": "",
 }
+
+
+# === Guard tests ===
 
 
 def test_non_file_tool_returns_default() -> None:
@@ -41,6 +45,9 @@ def test_nonexistent_file_returns_default() -> None:
     assert result.hook_specific_output is None
 
 
+# === Git root tests ===
+
+
 def test_find_git_root(tmp_path: Path) -> None:
     (tmp_path / ".git").mkdir()
     subdir = tmp_path / "a" / "b"
@@ -50,6 +57,9 @@ def test_find_git_root(tmp_path: Path) -> None:
 
 def test_find_git_root_no_git(tmp_path: Path) -> None:
     assert _find_git_root(tmp_path / "file.py") is None
+
+
+# === Serialization tests ===
 
 
 def test_output_serializes_camel_case() -> None:
@@ -69,6 +79,211 @@ def test_stop_reason_with_continue_false() -> None:
     out = PostToolUseOutput(stop_reason="done", continue_=False)
     assert out.stop_reason == "done"
     assert out.continue_ is False
+
+
+# === Diff generation tests ===
+
+
+def test_make_short_diff_no_change() -> None:
+    content = b"hello\nworld\n"
+    assert _make_short_diff(content, content, "test.py") == ""
+
+
+def test_make_short_diff_with_change() -> None:
+    original = b"hello\nworld\n"
+    modified = b"hello\nearth\n"
+    diff = _make_short_diff(original, modified, "test.py")
+    assert "a/test.py" in diff
+    assert "-world" in diff
+    assert "+earth" in diff
+
+
+def test_make_short_diff_truncates() -> None:
+    """Long diffs are truncated to _MAX_DIFF_LINES."""
+    original = "".join(f"line{i}\n" for i in range(50)).encode()
+    modified = "".join(f"changed{i}\n" for i in range(50)).encode()
+    diff = _make_short_diff(original, modified, "big.py")
+    assert "truncated" in diff
+
+
+# === Format output tests ===
+
+
+def test_format_check_result_basic() -> None:
+    result = CheckResult(issue_count=1, issues=["bad indent"], fix_command="pre-commit run --files test.py")
+    output = _format_check_result(result, Path("test.py"))
+    assert "1 hook failed on test.py:" in output
+    assert "bad indent" in output
+    assert "pre-commit run" in output
+
+
+def test_format_check_result_with_diff() -> None:
+    result = CheckResult(issue_count=2, issues=["err1"], diff="--- a/f\n+++ b/f\n-old\n+new")
+    output = _format_check_result(result, Path("f.py"))
+    assert "2 hooks failed" in output
+    assert "Changes pre-commit would make:" in output
+    assert "+new" in output
+
+
+# === Pre-commit integration tests ===
+
+
+def test_precommit_with_diff(tmp_path: Path) -> None:
+    """When pre-commit modifies a file, the diff is included and file is restored."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "test.py"
+    original = b"x=1\n"
+    test_file.write_bytes(original)
+
+    # Simulate pre-commit that reformats the file
+    def fake_run(cmd, **kwargs):
+        test_file.write_bytes(b"x = 1\n")
+
+        class FakeResult:
+            returncode = 1
+            stdout = (
+                "ruff-format..................................................Failed\n"
+                "- hook id: ruff-format\n"
+                "- files were modified by this hook\n"
+            )
+            stderr = ""
+
+        return FakeResult()
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
+        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
+            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+            result = evaluate(inp)
+
+    # File should be restored
+    assert test_file.read_bytes() == original
+    # Output should contain diff
+    assert result.hook_specific_output is not None
+    ctx = result.hook_specific_output.additional_context
+    assert ctx is not None
+    assert "-x=1" in ctx
+    assert "+x = 1" in ctx
+
+
+def test_precommit_no_file_change(tmp_path: Path) -> None:
+    """When pre-commit fails but doesn't modify the file, no diff is shown."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "test.yaml"
+    original = b"key: value\n"
+    test_file.write_bytes(original)
+
+    def fake_run(cmd, **kwargs):
+        # Don't modify the file (e.g. check-yaml just validates)
+        class FakeResult:
+            returncode = 1
+            stdout = (
+                "check-yaml...................................................Failed\n"
+                "- hook id: check-yaml\n"
+                "- exit code: 1\n"
+                "invalid yaml\n"
+            )
+            stderr = ""
+
+        return FakeResult()
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
+        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
+            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+            result = evaluate(inp)
+
+    assert test_file.read_bytes() == original
+    assert result.hook_specific_output is not None
+    ctx = result.hook_specific_output.additional_context
+    assert ctx is not None
+    assert "Changes pre-commit would make:" not in ctx
+
+
+def test_precommit_passes(tmp_path: Path) -> None:
+    """When pre-commit passes, no output is returned."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "clean.py"
+    test_file.write_bytes(b"x = 1\n")
+
+    def fake_run(cmd, **kwargs):
+        class FakeResult:
+            returncode = 0
+            stdout = "All passed"
+            stderr = ""
+
+        return FakeResult()
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
+        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
+            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+            result = evaluate(inp)
+
+    assert result.hook_specific_output is None
+
+
+def test_precommit_restores_on_timeout(tmp_path: Path) -> None:
+    """File is restored even when pre-commit times out."""
+    import subprocess
+
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "slow.py"
+    original = b"x = 1\n"
+    test_file.write_bytes(original)
+
+    def fake_run(cmd, **kwargs):
+        test_file.write_bytes(b"modified\n")
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
+        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
+            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+            result = evaluate(inp)
+
+    assert test_file.read_bytes() == original
+    assert result.hook_specific_output is None
+
+
+def test_precommit_not_found(tmp_path: Path) -> None:
+    """When pre-commit is not installed, no output is returned."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "file.py"
+    test_file.write_bytes(b"x = 1\n")
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value=None):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
+
+    assert result.hook_specific_output is None
+
+
+def test_precommit_multiple_hooks_fail(tmp_path: Path) -> None:
+    """Multiple hooks failing reports correct count."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "test.py"
+    test_file.write_bytes(b"x=1\n")
+
+    def fake_run(cmd, **kwargs):
+        class FakeResult:
+            returncode = 1
+            stdout = (
+                "ruff-format..................................................Failed\n"
+                "- files were modified\n"
+                "ruff-check...................................................Failed\n"
+                "- exit code: 1\n"
+                "E001 bad style\n"
+            )
+            stderr = ""
+
+        return FakeResult()
+
+    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
+        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
+            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+            result = evaluate(inp)
+
+    assert result.hook_specific_output is not None
+    ctx = result.hook_specific_output.additional_context
+    assert ctx is not None
+    assert "2 hooks failed" in ctx
 
 
 if __name__ == "__main__":

--- a/devinfra/claude/testing/session_start_helpers.py
+++ b/devinfra/claude/testing/session_start_helpers.py
@@ -190,7 +190,7 @@ async def run_session_start_hook(
 
     use_wheel = os.environ.get(settings.ENV_USE_WHEEL) == "1"
 
-    cmd: str | Path = "claude-hook" if use_wheel else get_required_path(shell_helpers.SESSION_START)
+    cmd: str | Path = "claude-hook" if use_wheel else get_required_path(shell_helpers.HOOK_DISPATCH)
 
     env = dict(os.environ)
     if use_wheel:

--- a/devinfra/claude/testing/shell_helpers.py
+++ b/devinfra/claude/testing/shell_helpers.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 # Runfiles paths for binaries
-SESSION_START = "_main/devinfra/claude/hook_dispatch"
+HOOK_DISPATCH = "_main/devinfra/claude/hook_dispatch"
 
 
 async def run_with_env_file(


### PR DESCRIPTION
## Summary

- Change PostToolUse hook from auto-formatting files to **check-only**: runs pre-commit, captures output and diff, then **restores** the original file so the agent can fix issues itself
- Report lint failures back to the agent via `additional_context` with truncated pre-commit output and a short unified diff of what pre-commit would change
- Rename `SESSION_START` constant to `HOOK_DISPATCH` in test helpers (it was already pointing at hook_dispatch)
- Add `data = [":bazel_wrapper"]` to hook_dispatch binary target

## Test plan

- [x] `bazel build //devinfra/claude:post_tool_use_lib` — builds with mypy
- [x] `bazel test //devinfra/claude:test_post_tool_use` — 18 tests pass (guard tests, git root, serialization, diff generation, format output, pre-commit integration with mocks for: diff included, no file change, passes, timeout restores, not found, multiple hooks fail)

https://claude.ai/code/session_014QTw213uphnU7tY7APzxBm