### PR TITLE
chore(ollama): bump LiteLLM to 1.82.0-stable, pin Ollama to 0.18.0

### DIFF
--- a/cluster/k8s/ollama/deployment.yaml
+++ b/cluster/k8s/ollama/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           effect: PreferNoSchedule
       containers:
         - name: ollama
-          image: ollama/ollama:latest
+          image: ollama/ollama:0.18.0
           ports:
             - name: ollama
               containerPort: 11434

--- a/cluster/k8s/ollama/litellm.yaml
+++ b/cluster/k8s/ollama/litellm.yaml
@@ -21,14 +21,14 @@ spec:
   chart:
     spec:
       chart: litellm-helm
-      version: "1.81.13"
+      version: "1.82.0-stable.patch5"
       sourceRef:
         kind: HelmRepository
         name: litellm
         namespace: ollama
   values:
-    # Chart 1.81.13 defaults to image tag main-v1.81.13 which doesn't exist
-    # on ghcr.io (upstream issue BerriAI/litellm#15288). Pin to main-stable.
+    # Upstream issue BerriAI/litellm#15288: chart-derived image tags may not
+    # exist on ghcr.io. Pin to main-stable (rolling stable tag).
     image:
       tag: "main-stable"
     proxy_config:


### PR DESCRIPTION
## Summary
- Bump LiteLLM Helm chart from 1.81.13 to 1.82.0-stable.patch5 — fixes Ollama tool calling (BerriAI/litellm#11104, PR #11171)
- Pin Ollama image from `:latest` to `0.18.0` — includes tool call parsing fixes (v0.17.8+)

## Test plan
- [ ] Verify Flux reconciles successfully: `kubectl get helmrelease litellm -n ollama`
- [ ] Verify pods restart with new versions: `kubectl get pods -n ollama`
- [ ] Test tool calling through LiteLLM proxy with gpt-oss

https://claude.ai/code/session_0149kq7FqRFtY6FrKxonCSYh