### PR TITLE
feat(ollama): expose direct Ollama endpoint with bearer auth

### DIFF
--- a/cluster/k8s/claude-sandbox-secrets/kustomization.yaml
+++ b/cluster/k8s/claude-sandbox-secrets/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - alloy-otlp-bearer-token-externalsecret.yaml
   - externalsecret.yaml
+  - ollama-direct-token-externalsecret.yaml
   - github-token-sealed.yaml

--- a/cluster/k8s/claude-sandbox-secrets/ollama-direct-token-externalsecret.yaml
+++ b/cluster/k8s/claude-sandbox-secrets/ollama-direct-token-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ollama-direct-token
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ollama-direct-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: kv/ollama/direct-api-token
+        property: token

--- a/cluster/k8s/ollama-secrets/flux-kustomization.yaml
+++ b/cluster/k8s/ollama-secrets/flux-kustomization.yaml
@@ -15,6 +15,10 @@ spec:
       kind: Terraform
       name: ollama-api-key
       namespace: flux-system
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: ollama-direct-token
+      namespace: flux-system
   timeout: 10m
   dependsOn:
     - name: ollama-namespace

--- a/cluster/k8s/ollama-secrets/kustomization.yaml
+++ b/cluster/k8s/ollama-secrets/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ollama-api-key-tf.yaml
+  - ollama-direct-token-tf.yaml
   - externalsecret.yaml
+  - ollama-direct-token-externalsecret.yaml
   - langfuse-api-keys.yaml

--- a/cluster/k8s/ollama-secrets/ollama-direct-token-externalsecret.yaml
+++ b/cluster/k8s/ollama-secrets/ollama-direct-token-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ollama-direct-token
+  namespace: ollama
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ollama-direct-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: kv/ollama/direct-api-token
+        property: token

--- a/cluster/k8s/ollama-secrets/ollama-direct-token-tf.yaml
+++ b/cluster/k8s/ollama-secrets/ollama-direct-token-tf.yaml
@@ -1,0 +1,29 @@
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: ollama-direct-token
+  namespace: flux-system
+spec:
+  interval: 15m
+  approvePlan: "auto"
+  path: ./cluster/terraform/gitops/ollama-direct-token
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  serviceAccountName: tf-runner
+  backendConfig:
+    customConfiguration: |
+      backend "kubernetes" {
+        secret_suffix    = "ollama-direct-token"
+        namespace        = "flux-system"
+      }
+  vars:
+    - name: vault_address
+      value: "http://instance.vault.svc.cluster.local:8200"
+  varsFrom:
+    - kind: Secret
+      name: vault-token
+      varsKeys:
+        - vault_token
+      optional: false

--- a/cluster/k8s/ollama/deployment.yaml
+++ b/cluster/k8s/ollama/deployment.yaml
@@ -69,7 +69,36 @@ spec:
               port: ollama
             initialDelaySeconds: 10
             periodSeconds: 10
+        - name: auth-proxy
+          image: nginx:1.27-alpine
+          ports:
+            - name: auth-proxy
+              containerPort: 11435
+              protocol: TCP
+          env:
+            - name: OLLAMA_DIRECT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ollama-direct-token
+                  key: token
+          volumeMounts:
+            - name: nginx-templates
+              mountPath: /etc/nginx/templates
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          livenessProbe:
+            tcpSocket:
+              port: auth-proxy
+            initialDelaySeconds: 5
+            periodSeconds: 30
       volumes:
         - name: models
           persistentVolumeClaim:
             claimName: llm-models
+        - name: nginx-templates
+          configMap:
+            name: ollama-auth-proxy

--- a/cluster/k8s/ollama/httproute-direct.yaml
+++ b/cluster/k8s/ollama/httproute-direct.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ollama-direct
+  namespace: ollama
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "ollama-api.allegedly.works"
+  rules:
+    - timeouts:
+        request: "600s"
+        backendRequest: "600s"
+      backendRefs:
+        - name: ollama
+          port: 11435

--- a/cluster/k8s/ollama/kustomization.yaml
+++ b/cluster/k8s/ollama/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - httproute-direct.yaml
   - clusterrole-ollama-consumer.yaml
   - job-setup-gpt-oss-v1.yaml
   - litellm.yaml
@@ -17,3 +18,8 @@ configMapGenerator:
       disableNameSuffixHash: true
     files:
       - setup-gpt-oss-v1.sh
+  - name: ollama-auth-proxy
+    options:
+      disableNameSuffixHash: true
+    files:
+      - default.conf.template=nginx-auth-proxy.conf.template

--- a/cluster/k8s/ollama/nginx-auth-proxy.conf.template
+++ b/cluster/k8s/ollama/nginx-auth-proxy.conf.template
@@ -1,0 +1,18 @@
+server {
+    listen 11435;
+
+    location / {
+        set $expected "Bearer ${OLLAMA_DIRECT_TOKEN}";
+        if ($http_authorization != $expected) {
+            return 401 '{"error": "unauthorized"}';
+        }
+
+        proxy_pass http://127.0.0.1:11434;
+        proxy_buffering off;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+}

--- a/cluster/k8s/ollama/service.yaml
+++ b/cluster/k8s/ollama/service.yaml
@@ -14,3 +14,7 @@ spec:
       port: 11434
       targetPort: ollama
       protocol: TCP
+    - name: auth-proxy
+      port: 11435
+      targetPort: auth-proxy
+      protocol: TCP

--- a/cluster/k8s/openclaw-sandbox-secrets/kustomization.yaml
+++ b/cluster/k8s/openclaw-sandbox-secrets/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
+  - ollama-direct-token-externalsecret.yaml
   - ibkr-flex-query-credentials-sealed.yaml
   - coinbase-api-credentials-sealed.yaml

--- a/cluster/k8s/openclaw-sandbox-secrets/ollama-direct-token-externalsecret.yaml
+++ b/cluster/k8s/openclaw-sandbox-secrets/ollama-direct-token-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ollama-direct-token
+  namespace: openclaw-sandbox
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ollama-direct-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: kv/ollama/direct-api-token
+        property: token

--- a/cluster/terraform/gitops/ollama-direct-token/BUILD.bazel
+++ b/cluster/terraform/gitops/ollama-direct-token/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
+
+tf_providers_versions(
+    name = "providers",
+    providers = {
+        "vault": "hashicorp/vault:~>5.7.0",
+        "random": "hashicorp/random:~>3.7.0",
+    },
+    tf_version = "1.9.8",
+)
+
+tf_module(
+    name = "ollama-direct-token",
+    providers = [
+        "vault",
+        "random",
+    ],
+    providers_versions = ":providers",
+)

--- a/cluster/terraform/gitops/ollama-direct-token/main.tf
+++ b/cluster/terraform/gitops/ollama-direct-token/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 5.7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.0"
+    }
+  }
+
+  backend "kubernetes" {
+    secret_suffix = "ollama-direct-token"
+    namespace     = "flux-system"
+  }
+}
+
+provider "vault" {
+  address = var.vault_address
+  token   = var.vault_token
+}
+
+resource "random_password" "direct_token" {
+  length  = 48
+  special = false
+  keepers = { rotation_version = var.rotation_version }
+
+  lifecycle {
+    ignore_changes = [length, special]
+  }
+}
+
+resource "vault_kv_secret_v2" "ollama_direct_token" {
+  mount = "kv"
+  name  = "ollama/direct-api-token"
+
+  data_json = jsonencode({
+    token = random_password.direct_token.result
+  })
+}

--- a/cluster/terraform/gitops/ollama-direct-token/variables.tf
+++ b/cluster/terraform/gitops/ollama-direct-token/variables.tf
@@ -1,0 +1,16 @@
+variable "vault_address" {
+  description = "Vault server address"
+  type        = string
+}
+
+variable "vault_token" {
+  description = "Vault authentication token"
+  type        = string
+  sensitive   = true
+}
+
+variable "rotation_version" {
+  description = "Bump to trigger secret rotation"
+  type        = string
+  default     = "1"
+}


### PR DESCRIPTION
## Summary
- Add direct Ollama API endpoint at `ollama-api.allegedly.works` bypassing the LiteLLM proxy
- nginx sidecar validates `Authorization: Bearer $TOKEN` header, proxies to Ollama on localhost:11434
- Token provisioned declaratively: Terraform → Vault (`kv/ollama/direct-api-token`) → ESO → K8s Secret
- Token exposed to `claude-sandbox` and `openclaw-sandbox` namespaces via ExternalSecrets
- nginx config kept as standalone `.conf.template` file via `configMapGenerator` (not embedded in YAML)

## Why
The LiteLLM proxy (v1.81.x) strips tool calls and reasoning from Ollama responses. Direct access to Ollama preserves native tool calling and reasoning content. This endpoint is complementary to the existing LiteLLM proxy route.

## Test plan
- [ ] Verify tofu-controller applies `ollama-direct-token` Terraform: `kubectl get terraform ollama-direct-token -n flux-system`
- [ ] Verify ESO syncs token to ollama namespace: `kubectl get secret ollama-direct-token -n ollama`
- [ ] Verify ESO syncs to sandbox namespaces: `kubectl get secret ollama-direct-token -n claude-sandbox`
- [ ] Verify nginx sidecar starts: `kubectl get pods -n ollama -o wide`
- [ ] Test bearer auth: `curl -H "Authorization: Bearer $TOKEN" https://ollama-api.allegedly.works/v1/chat/completions -d '...'`
- [ ] Test tool calling works through direct endpoint

https://claude.ai/code/session_0149kq7FqRFtY6FrKxonCSYh