### PR TITLE
Use pre-commit Python API via interface library

### DIFF
--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -260,11 +260,22 @@ py_library(
 )
 
 py_library(
+    name = "precommit_runner",
+    srcs = ["precommit_runner.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//pre_commit",
+    ],
+)
+
+py_library(
     name = "post_tool_use_lib",
     srcs = ["post_tool_use.py"],
     imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [
+        ":precommit_runner",
         "//devinfra/claude/claude_api/hooks:post_tool_use",
     ],
 )
@@ -387,6 +398,7 @@ py_test(
     deps = [
         ":conftest",
         ":post_tool_use_lib",
+        ":precommit_runner",
         "//devinfra/claude/claude_api/hooks:post_tool_use",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/devinfra/claude/post_tool_use.py
+++ b/devinfra/claude/post_tool_use.py
@@ -87,11 +87,7 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
     if project_dir is None:
         return PostToolUseOutput()
 
-    try:
-        run_result = run_on_file(file_path, project_dir)
-    except Exception as e:
-        logger.warning("Lint check failed on %s: %s", file_path, e)
-        return PostToolUseOutput()
+    run_result = run_on_file(file_path, project_dir)
 
     if run_result.all_passed:
         return PostToolUseOutput()

--- a/devinfra/claude/post_tool_use.py
+++ b/devinfra/claude/post_tool_use.py
@@ -93,7 +93,7 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         logger.warning("Lint check failed on %s: %s", file_path, e)
         return PostToolUseOutput()
 
-    if run_result is None:
+    if run_result.all_passed:
         return PostToolUseOutput()
 
     return PostToolUseOutput(

--- a/devinfra/claude/post_tool_use.py
+++ b/devinfra/claude/post_tool_use.py
@@ -4,21 +4,12 @@ Runs pre-commit on files that Claude Code just modified, reports any
 issues back to the agent (with a short diff of what pre-commit would
 change), then restores the original file content so the agent can
 fix issues itself.
-
-TODO: Import pre-commit as a Python dependency and use its API directly
-instead of subprocess. This would give structured output (per-hook results,
-exit codes) without messy stdout parsing. subprocess.run already accepts
-Path objects for the command, so the transition path is: find pre-commit's
-internal run API, call it with the file list, and get back typed results.
 """
 
 from __future__ import annotations
 
 import difflib
 import logging
-import shutil
-import subprocess
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -27,22 +18,14 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
+from devinfra.claude.precommit_runner import RunResult, run_on_file
 
 logger = logging.getLogger(__name__)
 
 FILE_MODIFYING_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
 
-_TIMEOUT_SECONDS = 30
 _MAX_ISSUES_SHOWN = 3
 _MAX_DIFF_LINES = 20
-
-
-@dataclass
-class CheckResult:
-    issue_count: int
-    issues: list[str] = field(default_factory=list)
-    fix_command: str = ""
-    diff: str = ""
 
 
 def _get_file_path(tool_input: dict[str, Any]) -> Path | None:
@@ -74,66 +57,21 @@ def _make_short_diff(original: bytes, modified: bytes, filename: str) -> str:
     return "".join(diff_lines).rstrip()
 
 
-def _run_precommit_check(file_path: Path, project_dir: Path) -> CheckResult | None:
-    """Run pre-commit on a file, capture output and diff, then restore original content."""
-    precommit = shutil.which("pre-commit")
-    if precommit is None:
-        return None
-
-    original_content = file_path.read_bytes()
-    try:
-        result = subprocess.run(
-            [precommit, "run", "--files", str(file_path)],
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT_SECONDS,
-            check=False,
-            cwd=project_dir,
-        )
-        modified_content = file_path.read_bytes()
-    finally:
-        file_path.write_bytes(original_content)
-
-    if result.returncode == 0:
-        return None
-
-    # Parse pre-commit output for failed hooks and their messages
-    lines = (result.stdout or "").splitlines()
-    failed_hooks = 0
-    failure_lines: list[str] = []
-    in_failure = False
-
-    for line in lines:
-        if "Failed" in line:
-            failed_hooks += 1
-            in_failure = True
-            continue
-        if "Passed" in line or "Skipped" in line:
-            in_failure = False
-            continue
-        if in_failure and line.strip() and len(failure_lines) < _MAX_ISSUES_SHOWN:
-            failure_lines.append(line.rstrip())
-
-    diff = _make_short_diff(original_content, modified_content, file_path.name)
-
-    return CheckResult(
-        issue_count=max(failed_hooks, 1),
-        issues=failure_lines,
-        fix_command=f"pre-commit run --files {file_path}",
-        diff=diff,
-    )
-
-
-def _format_check_result(result: CheckResult, file_path: Path) -> str:
-    noun = "hook" if result.issue_count == 1 else "hooks"
-    parts = [f"{result.issue_count} {noun} failed on {file_path.name}:"]
-    for issue in result.issues:
-        parts.append(f"  {issue}")
-    if result.diff:
+def _format_check_result(result: RunResult, file_path: Path) -> str:
+    failed = result.failed_hooks
+    noun = "hook" if len(failed) == 1 else "hooks"
+    parts = [f"{len(failed)} {noun} failed on {file_path.name}:"]
+    for hr in failed:
+        status = "modified file" if hr.files_modified else "non-zero exit"
+        parts.append(f"  {hr.hook_name} ({status})")
+        if hr.output:
+            for line in hr.output.splitlines()[:_MAX_ISSUES_SHOWN]:
+                parts.append(f"    {line}")
+    diff = _make_short_diff(result.original_content, result.modified_content, file_path.name)
+    if diff:
         parts.append("Changes pre-commit would make:")
-        parts.append(result.diff)
-    if result.fix_command:
-        parts.append(f"Run `{result.fix_command}` to apply fixes.")
+        parts.append(diff)
+    parts.append(f"Run `pre-commit run --files {file_path}` to apply fixes.")
     return "\n".join(parts)
 
 
@@ -150,16 +88,16 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         return PostToolUseOutput()
 
     try:
-        check_result = _run_precommit_check(file_path, project_dir)
-    except (subprocess.TimeoutExpired, OSError) as e:
+        run_result = run_on_file(file_path, project_dir)
+    except Exception as e:
         logger.warning("Lint check failed on %s: %s", file_path, e)
         return PostToolUseOutput()
 
-    if check_result is None:
+    if run_result is None:
         return PostToolUseOutput()
 
     return PostToolUseOutput(
         hook_specific_output=PostToolUseHookSpecificOutput(
-            additional_context=_format_check_result(check_result, file_path)
+            additional_context=_format_check_result(run_result, file_path)
         )
     )

--- a/devinfra/claude/precommit_runner.py
+++ b/devinfra/claude/precommit_runner.py
@@ -71,63 +71,69 @@ class RunResult:
         return all(h.passed for h in self.hooks)
 
 
+def _run_hooks(file_path: Path, project_dir: Path) -> list[HookResult]:
+    """Run all applicable pre-commit hooks on a single file.
+
+    Caller must ensure cwd is project_dir.
+    """
+    config_path = project_dir / CONFIG_FILE
+    original_content = file_path.read_bytes()
+
+    store = Store()
+    config = load_config(str(config_path))
+    hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
+    if not hooks:
+        return []
+
+    install_hook_envs(hooks, store)
+
+    rel_path = str(file_path.relative_to(project_dir))
+    classifier = Classifier([rel_path])
+    results: list[HookResult] = []
+
+    for hook in hooks:
+        filenames = tuple(classifier.filenames_for_hook(hook))
+        if not filenames and not hook.always_run:
+            continue
+
+        language = languages[hook.language]
+        with language.in_env(hook.prefix, hook.language_version):
+            retcode, out = language.run_hook(
+                hook.prefix,
+                hook.entry,
+                hook.args,
+                filenames if hook.pass_filenames else (),
+                is_local=hook.src == "local",
+                require_serial=hook.require_serial,
+                color=False,
+            )
+
+        modified = file_path.read_bytes() != original_content
+        results.append(
+            HookResult(
+                hook_id=hook.id,
+                hook_name=hook.name,
+                passed=retcode == 0 and not modified,
+                output=out.decode(errors="replace").strip()[:_MAX_OUTPUT_CHARS],
+                files_modified=modified,
+            )
+        )
+
+    return results
+
+
 def run_on_file(file_path: Path, project_dir: Path) -> RunResult:
     """Run pre-commit hooks on a single file using the Python API.
 
     Always restores the original file content after running.
-    Returns a RunResult with an empty hooks list if no config exists
-    or no hooks apply to the file.
     """
-    config_path = project_dir / CONFIG_FILE
-    if not config_path.exists():
-        return RunResult()
-
     original_content = file_path.read_bytes()
 
     # pre-commit's internals assume cwd is the project root:
     # Classifier uses relative paths and hooks inherit process cwd
     # via subprocess.Popen (no cwd= parameter).
     with _chdir(project_dir), _restore_file(file_path):
-        store = Store()
-        config = load_config(str(config_path))
-        hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
-        if not hooks:
-            return RunResult()
-
-        install_hook_envs(hooks, store)
-
-        rel_path = str(file_path.relative_to(project_dir))
-        classifier = Classifier([rel_path])
-        hook_results: list[HookResult] = []
-
-        for hook in hooks:
-            filenames = tuple(classifier.filenames_for_hook(hook))
-            if not filenames and not hook.always_run:
-                continue
-
-            language = languages[hook.language]
-            with language.in_env(hook.prefix, hook.language_version):
-                retcode, out = language.run_hook(
-                    hook.prefix,
-                    hook.entry,
-                    hook.args,
-                    filenames if hook.pass_filenames else (),
-                    is_local=hook.src == "local",
-                    require_serial=hook.require_serial,
-                    color=False,
-                )
-
-            modified = file_path.read_bytes() != original_content
-            hook_results.append(
-                HookResult(
-                    hook_id=hook.id,
-                    hook_name=hook.name,
-                    passed=retcode == 0 and not modified,
-                    output=out.decode(errors="replace").strip()[:_MAX_OUTPUT_CHARS],
-                    files_modified=modified,
-                )
-            )
-
+        hook_results = _run_hooks(file_path, project_dir)
         modified_content = file_path.read_bytes()
 
     return RunResult(hooks=hook_results, modified_content=modified_content, original_content=original_content)

--- a/devinfra/claude/precommit_runner.py
+++ b/devinfra/claude/precommit_runner.py
@@ -1,0 +1,109 @@
+"""Interface library for running pre-commit hooks programmatically.
+
+Wraps pre-commit's Python internals to provide structured per-hook results
+without subprocess calls or stdout parsing. All pre-commit imports are
+confined to this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pre_commit.all_languages import languages
+from pre_commit.clientlib import load_config
+from pre_commit.commands.run import Classifier
+from pre_commit.constants import CONFIG_FILE
+from pre_commit.repository import all_hooks, install_hook_envs
+from pre_commit.store import Store
+
+logger = logging.getLogger(__name__)
+
+_MAX_OUTPUT_CHARS = 500
+
+
+@dataclass
+class HookResult:
+    hook_id: str
+    hook_name: str
+    passed: bool
+    output: str
+    files_modified: bool
+
+
+@dataclass
+class RunResult:
+    failed_hooks: list[HookResult] = field(default_factory=list)
+    modified_content: bytes = b""
+    original_content: bytes = b""
+
+
+def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
+    """Run pre-commit hooks on a single file using the Python API.
+
+    Returns None if no config exists, no hooks apply, or all hooks pass.
+    Always restores the original file content after running.
+    """
+    config_path = project_dir / CONFIG_FILE
+    if not config_path.exists():
+        return None
+
+    original_content = file_path.read_bytes()
+    saved_cwd = Path.cwd()
+    try:
+        # pre-commit's internals assume cwd is the project root:
+        # Classifier uses relative paths and hooks inherit process cwd
+        # via subprocess.Popen (no cwd= parameter).
+        os.chdir(project_dir)
+        store = Store()
+        config = load_config(str(config_path))
+        hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
+        if not hooks:
+            return None
+
+        install_hook_envs(hooks, store)
+
+        rel_path = str(file_path.relative_to(project_dir))
+        classifier = Classifier([rel_path])
+        hook_results: list[HookResult] = []
+
+        for hook in hooks:
+            filenames = tuple(classifier.filenames_for_hook(hook))
+            if not filenames and not hook.always_run:
+                continue
+
+            language = languages[hook.language]
+            with language.in_env(hook.prefix, hook.language_version):
+                retcode, out = language.run_hook(
+                    hook.prefix,
+                    hook.entry,
+                    hook.args,
+                    filenames if hook.pass_filenames else (),
+                    is_local=hook.src == "local",
+                    require_serial=hook.require_serial,
+                    color=False,
+                )
+
+            modified = file_path.read_bytes() != original_content
+            hook_results.append(
+                HookResult(
+                    hook_id=hook.id,
+                    hook_name=hook.name,
+                    passed=retcode == 0 and not modified,
+                    output=out.decode(errors="replace").strip()[:_MAX_OUTPUT_CHARS],
+                    files_modified=modified,
+                )
+            )
+
+        modified_content = file_path.read_bytes()
+    finally:
+        os.chdir(saved_cwd)
+        file_path.write_bytes(original_content)
+
+    failed = [r for r in hook_results if not r.passed]
+    if not failed:
+        return None
+
+    return RunResult(failed_hooks=failed, modified_content=modified_content, original_content=original_content)

--- a/devinfra/claude/precommit_runner.py
+++ b/devinfra/claude/precommit_runner.py
@@ -7,8 +7,10 @@ confined to this module.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+from collections.abc import Generator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -22,6 +24,27 @@ from pre_commit.store import Store
 logger = logging.getLogger(__name__)
 
 _MAX_OUTPUT_CHARS = 500
+
+
+@contextlib.contextmanager
+def _chdir(path: Path) -> Generator[None]:
+    """Temporarily change working directory, restoring on exit."""
+    saved = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(saved)
+
+
+@contextlib.contextmanager
+def _restore_file(path: Path) -> Generator[None]:
+    """Restore file content on exit, even if hooks modified it."""
+    original = path.read_bytes()
+    try:
+        yield
+    finally:
+        path.write_bytes(original)
 
 
 @dataclass
@@ -51,12 +74,11 @@ def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
         return None
 
     original_content = file_path.read_bytes()
-    saved_cwd = Path.cwd()
-    try:
-        # pre-commit's internals assume cwd is the project root:
-        # Classifier uses relative paths and hooks inherit process cwd
-        # via subprocess.Popen (no cwd= parameter).
-        os.chdir(project_dir)
+
+    # pre-commit's internals assume cwd is the project root:
+    # Classifier uses relative paths and hooks inherit process cwd
+    # via subprocess.Popen (no cwd= parameter).
+    with _chdir(project_dir), _restore_file(file_path):
         store = Store()
         config = load_config(str(config_path))
         hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
@@ -98,9 +120,6 @@ def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
             )
 
         modified_content = file_path.read_bytes()
-    finally:
-        os.chdir(saved_cwd)
-        file_path.write_bytes(original_content)
 
     failed = [r for r in hook_results if not r.passed]
     if not failed:

--- a/devinfra/claude/precommit_runner.py
+++ b/devinfra/claude/precommit_runner.py
@@ -58,20 +58,29 @@ class HookResult:
 
 @dataclass
 class RunResult:
-    failed_hooks: list[HookResult] = field(default_factory=list)
+    hooks: list[HookResult] = field(default_factory=list)
     modified_content: bytes = b""
     original_content: bytes = b""
 
+    @property
+    def failed_hooks(self) -> list[HookResult]:
+        return [h for h in self.hooks if not h.passed]
 
-def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
+    @property
+    def all_passed(self) -> bool:
+        return all(h.passed for h in self.hooks)
+
+
+def run_on_file(file_path: Path, project_dir: Path) -> RunResult:
     """Run pre-commit hooks on a single file using the Python API.
 
-    Returns None if no config exists, no hooks apply, or all hooks pass.
     Always restores the original file content after running.
+    Returns a RunResult with an empty hooks list if no config exists
+    or no hooks apply to the file.
     """
     config_path = project_dir / CONFIG_FILE
     if not config_path.exists():
-        return None
+        return RunResult()
 
     original_content = file_path.read_bytes()
 
@@ -83,7 +92,7 @@ def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
         config = load_config(str(config_path))
         hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
         if not hooks:
-            return None
+            return RunResult()
 
         install_hook_envs(hooks, store)
 
@@ -121,8 +130,4 @@ def run_on_file(file_path: Path, project_dir: Path) -> RunResult | None:
 
         modified_content = file_path.read_bytes()
 
-    failed = [r for r in hook_results if not r.passed]
-    if not failed:
-        return None
-
-    return RunResult(failed_hooks=failed, modified_content=modified_content, original_content=original_content)
+    return RunResult(hooks=hook_results, modified_content=modified_content, original_content=original_content)

--- a/devinfra/claude/test_post_tool_use.py
+++ b/devinfra/claude/test_post_tool_use.py
@@ -25,6 +25,15 @@ _COMMON = {
 }
 
 
+@pytest.fixture
+def git_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a tmp git project with a test file, return (project_dir, test_file)."""
+    (tmp_path / ".git").mkdir()
+    test_file = tmp_path / "test.py"
+    test_file.write_bytes(b"x=1\n")
+    return tmp_path, test_file
+
+
 # === Guard tests ===
 
 
@@ -154,11 +163,9 @@ def test_format_check_result_non_zero_exit() -> None:
 # === Pre-commit integration tests ===
 
 
-def test_precommit_with_diff(tmp_path: Path) -> None:
+def test_precommit_with_diff(git_project: tuple[Path, Path]) -> None:
     """When pre-commit modifies a file, the diff is included."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "test.py"
-    test_file.write_bytes(b"x=1\n")
+    _, test_file = git_project
 
     fake_result = RunResult(
         hooks=[
@@ -185,11 +192,9 @@ def test_precommit_with_diff(tmp_path: Path) -> None:
     assert "+x = 1" in ctx
 
 
-def test_precommit_no_file_change(tmp_path: Path) -> None:
+def test_precommit_no_file_change(git_project: tuple[Path, Path]) -> None:
     """When pre-commit fails but doesn't modify the file, no diff is shown."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "test.yaml"
-    test_file.write_bytes(b"key: value\n")
+    _, test_file = git_project
 
     fake_result = RunResult(
         hooks=[
@@ -197,8 +202,8 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
                 hook_id="check-yaml", hook_name="check-yaml", passed=False, output="invalid yaml", files_modified=False
             )
         ],
-        original_content=b"key: value\n",
-        modified_content=b"key: value\n",
+        original_content=b"x=1\n",
+        modified_content=b"x=1\n",
     )
 
     with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
@@ -211,18 +216,16 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
     assert "Changes pre-commit would make:" not in ctx
 
 
-def test_precommit_passes(tmp_path: Path) -> None:
+def test_precommit_passes(git_project: tuple[Path, Path]) -> None:
     """When all hooks pass, no output is returned."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "clean.py"
-    test_file.write_bytes(b"x = 1\n")
+    _, test_file = git_project
 
     fake_result = RunResult(
         hooks=[
             HookResult(hook_id="ruff-format", hook_name="ruff-format", passed=True, output="", files_modified=False)
         ],
-        original_content=b"x = 1\n",
-        modified_content=b"x = 1\n",
+        original_content=b"x=1\n",
+        modified_content=b"x=1\n",
     )
 
     with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
@@ -232,24 +235,9 @@ def test_precommit_passes(tmp_path: Path) -> None:
     assert result.hook_specific_output is None
 
 
-def test_precommit_error_returns_default(tmp_path: Path) -> None:
-    """When run_on_file raises an exception, no output is returned."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "slow.py"
-    test_file.write_bytes(b"x = 1\n")
-
-    with patch("devinfra.claude.post_tool_use.run_on_file", side_effect=OSError("something broke")):
-        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-        result = evaluate(inp)
-
-    assert result.hook_specific_output is None
-
-
-def test_no_config_file(tmp_path: Path) -> None:
-    """When no config exists (empty RunResult), no output is returned."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "file.py"
-    test_file.write_bytes(b"x = 1\n")
+def test_no_hooks_applied(git_project: tuple[Path, Path]) -> None:
+    """When no hooks apply (empty RunResult), no output is returned."""
+    _, test_file = git_project
 
     with patch("devinfra.claude.post_tool_use.run_on_file", return_value=RunResult()):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
@@ -258,11 +246,9 @@ def test_no_config_file(tmp_path: Path) -> None:
     assert result.hook_specific_output is None
 
 
-def test_precommit_multiple_hooks_fail(tmp_path: Path) -> None:
+def test_precommit_multiple_hooks_fail(git_project: tuple[Path, Path]) -> None:
     """Multiple hooks failing reports correct count."""
-    (tmp_path / ".git").mkdir()
-    test_file = tmp_path / "test.py"
-    test_file.write_bytes(b"x=1\n")
+    _, test_file = git_project
 
     fake_result = RunResult(
         hooks=[

--- a/devinfra/claude/test_post_tool_use.py
+++ b/devinfra/claude/test_post_tool_use.py
@@ -112,7 +112,7 @@ def test_make_short_diff_truncates() -> None:
 
 def test_format_check_result_basic() -> None:
     result = RunResult(
-        failed_hooks=[
+        hooks=[
             HookResult(hook_id="ruff", hook_name="ruff-format", passed=False, output="bad indent", files_modified=True)
         ],
         original_content=b"x=1\n",
@@ -127,7 +127,7 @@ def test_format_check_result_basic() -> None:
 
 def test_format_check_result_with_diff() -> None:
     result = RunResult(
-        failed_hooks=[
+        hooks=[
             HookResult(hook_id="ruff", hook_name="ruff-format", passed=False, output="err1", files_modified=True),
             HookResult(hook_id="mypy", hook_name="mypy", passed=False, output="err2", files_modified=False),
         ],
@@ -142,9 +142,7 @@ def test_format_check_result_with_diff() -> None:
 
 def test_format_check_result_non_zero_exit() -> None:
     result = RunResult(
-        failed_hooks=[
-            HookResult(hook_id="mypy", hook_name="mypy", passed=False, output="type error", files_modified=False)
-        ],
+        hooks=[HookResult(hook_id="mypy", hook_name="mypy", passed=False, output="type error", files_modified=False)],
         original_content=b"x = 1\n",
         modified_content=b"x = 1\n",
     )
@@ -163,7 +161,7 @@ def test_precommit_with_diff(tmp_path: Path) -> None:
     test_file.write_bytes(b"x=1\n")
 
     fake_result = RunResult(
-        failed_hooks=[
+        hooks=[
             HookResult(
                 hook_id="ruff-format",
                 hook_name="ruff-format",
@@ -194,7 +192,7 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
     test_file.write_bytes(b"key: value\n")
 
     fake_result = RunResult(
-        failed_hooks=[
+        hooks=[
             HookResult(
                 hook_id="check-yaml", hook_name="check-yaml", passed=False, output="invalid yaml", files_modified=False
             )
@@ -214,12 +212,20 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
 
 
 def test_precommit_passes(tmp_path: Path) -> None:
-    """When pre-commit passes (run_on_file returns None), no output is returned."""
+    """When all hooks pass, no output is returned."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "clean.py"
     test_file.write_bytes(b"x = 1\n")
 
-    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=None):
+    fake_result = RunResult(
+        hooks=[
+            HookResult(hook_id="ruff-format", hook_name="ruff-format", passed=True, output="", files_modified=False)
+        ],
+        original_content=b"x = 1\n",
+        modified_content=b"x = 1\n",
+    )
+
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
         result = evaluate(inp)
 
@@ -240,12 +246,12 @@ def test_precommit_error_returns_default(tmp_path: Path) -> None:
 
 
 def test_no_config_file(tmp_path: Path) -> None:
-    """When run_on_file returns None (no config), no output is returned."""
+    """When no config exists (empty RunResult), no output is returned."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "file.py"
     test_file.write_bytes(b"x = 1\n")
 
-    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=None):
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=RunResult()):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
         result = evaluate(inp)
 
@@ -259,7 +265,7 @@ def test_precommit_multiple_hooks_fail(tmp_path: Path) -> None:
     test_file.write_bytes(b"x=1\n")
 
     fake_result = RunResult(
-        failed_hooks=[
+        hooks=[
             HookResult(
                 hook_id="ruff-format",
                 hook_name="ruff-format",

--- a/devinfra/claude/test_post_tool_use.py
+++ b/devinfra/claude/test_post_tool_use.py
@@ -11,7 +11,8 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
-from devinfra.claude.post_tool_use import CheckResult, _find_git_root, _format_check_result, _make_short_diff, evaluate
+from devinfra.claude.post_tool_use import _find_git_root, _format_check_result, _make_short_diff, evaluate
+from devinfra.claude.precommit_runner import HookResult, RunResult
 
 _COMMON = {
     "session_id": "test-session",
@@ -110,54 +111,75 @@ def test_make_short_diff_truncates() -> None:
 
 
 def test_format_check_result_basic() -> None:
-    result = CheckResult(issue_count=1, issues=["bad indent"], fix_command="pre-commit run --files test.py")
+    result = RunResult(
+        failed_hooks=[
+            HookResult(hook_id="ruff", hook_name="ruff-format", passed=False, output="bad indent", files_modified=True)
+        ],
+        original_content=b"x=1\n",
+        modified_content=b"x = 1\n",
+    )
     output = _format_check_result(result, Path("test.py"))
     assert "1 hook failed on test.py:" in output
+    assert "ruff-format (modified file)" in output
     assert "bad indent" in output
     assert "pre-commit run" in output
 
 
 def test_format_check_result_with_diff() -> None:
-    result = CheckResult(issue_count=2, issues=["err1"], diff="--- a/f\n+++ b/f\n-old\n+new")
+    result = RunResult(
+        failed_hooks=[
+            HookResult(hook_id="ruff", hook_name="ruff-format", passed=False, output="err1", files_modified=True),
+            HookResult(hook_id="mypy", hook_name="mypy", passed=False, output="err2", files_modified=False),
+        ],
+        original_content=b"old\n",
+        modified_content=b"new\n",
+    )
     output = _format_check_result(result, Path("f.py"))
     assert "2 hooks failed" in output
     assert "Changes pre-commit would make:" in output
     assert "+new" in output
 
 
+def test_format_check_result_non_zero_exit() -> None:
+    result = RunResult(
+        failed_hooks=[
+            HookResult(hook_id="mypy", hook_name="mypy", passed=False, output="type error", files_modified=False)
+        ],
+        original_content=b"x = 1\n",
+        modified_content=b"x = 1\n",
+    )
+    output = _format_check_result(result, Path("test.py"))
+    assert "mypy (non-zero exit)" in output
+    assert "Changes pre-commit would make:" not in output
+
+
 # === Pre-commit integration tests ===
 
 
 def test_precommit_with_diff(tmp_path: Path) -> None:
-    """When pre-commit modifies a file, the diff is included and file is restored."""
+    """When pre-commit modifies a file, the diff is included."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "test.py"
-    original = b"x=1\n"
-    test_file.write_bytes(original)
+    test_file.write_bytes(b"x=1\n")
 
-    # Simulate pre-commit that reformats the file
-    def fake_run(cmd, **kwargs):
-        test_file.write_bytes(b"x = 1\n")
-
-        class FakeResult:
-            returncode = 1
-            stdout = (
-                "ruff-format..................................................Failed\n"
-                "- hook id: ruff-format\n"
-                "- files were modified by this hook\n"
+    fake_result = RunResult(
+        failed_hooks=[
+            HookResult(
+                hook_id="ruff-format",
+                hook_name="ruff-format",
+                passed=False,
+                output="- files were modified by this hook",
+                files_modified=True,
             )
-            stderr = ""
+        ],
+        original_content=b"x=1\n",
+        modified_content=b"x = 1\n",
+    )
 
-        return FakeResult()
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
 
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
-        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
-            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-            result = evaluate(inp)
-
-    # File should be restored
-    assert test_file.read_bytes() == original
-    # Output should contain diff
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context
     assert ctx is not None
@@ -169,29 +191,22 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
     """When pre-commit fails but doesn't modify the file, no diff is shown."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "test.yaml"
-    original = b"key: value\n"
-    test_file.write_bytes(original)
+    test_file.write_bytes(b"key: value\n")
 
-    def fake_run(cmd, **kwargs):
-        # Don't modify the file (e.g. check-yaml just validates)
-        class FakeResult:
-            returncode = 1
-            stdout = (
-                "check-yaml...................................................Failed\n"
-                "- hook id: check-yaml\n"
-                "- exit code: 1\n"
-                "invalid yaml\n"
+    fake_result = RunResult(
+        failed_hooks=[
+            HookResult(
+                hook_id="check-yaml", hook_name="check-yaml", passed=False, output="invalid yaml", files_modified=False
             )
-            stderr = ""
+        ],
+        original_content=b"key: value\n",
+        modified_content=b"key: value\n",
+    )
 
-        return FakeResult()
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
 
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
-        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
-            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-            result = evaluate(inp)
-
-    assert test_file.read_bytes() == original
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context
     assert ctx is not None
@@ -199,56 +214,38 @@ def test_precommit_no_file_change(tmp_path: Path) -> None:
 
 
 def test_precommit_passes(tmp_path: Path) -> None:
-    """When pre-commit passes, no output is returned."""
+    """When pre-commit passes (run_on_file returns None), no output is returned."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "clean.py"
     test_file.write_bytes(b"x = 1\n")
 
-    def fake_run(cmd, **kwargs):
-        class FakeResult:
-            returncode = 0
-            stdout = "All passed"
-            stderr = ""
-
-        return FakeResult()
-
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
-        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
-            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-            result = evaluate(inp)
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=None):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
 
     assert result.hook_specific_output is None
 
 
-def test_precommit_restores_on_timeout(tmp_path: Path) -> None:
-    """File is restored even when pre-commit times out."""
-    import subprocess
-
+def test_precommit_error_returns_default(tmp_path: Path) -> None:
+    """When run_on_file raises an exception, no output is returned."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "slow.py"
-    original = b"x = 1\n"
-    test_file.write_bytes(original)
+    test_file.write_bytes(b"x = 1\n")
 
-    def fake_run(cmd, **kwargs):
-        test_file.write_bytes(b"modified\n")
-        raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+    with patch("devinfra.claude.post_tool_use.run_on_file", side_effect=OSError("something broke")):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
 
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
-        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
-            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-            result = evaluate(inp)
-
-    assert test_file.read_bytes() == original
     assert result.hook_specific_output is None
 
 
-def test_precommit_not_found(tmp_path: Path) -> None:
-    """When pre-commit is not installed, no output is returned."""
+def test_no_config_file(tmp_path: Path) -> None:
+    """When run_on_file returns None (no config), no output is returned."""
     (tmp_path / ".git").mkdir()
     test_file = tmp_path / "file.py"
     test_file.write_bytes(b"x = 1\n")
 
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value=None):
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=None):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
         result = evaluate(inp)
 
@@ -261,24 +258,30 @@ def test_precommit_multiple_hooks_fail(tmp_path: Path) -> None:
     test_file = tmp_path / "test.py"
     test_file.write_bytes(b"x=1\n")
 
-    def fake_run(cmd, **kwargs):
-        class FakeResult:
-            returncode = 1
-            stdout = (
-                "ruff-format..................................................Failed\n"
-                "- files were modified\n"
-                "ruff-check...................................................Failed\n"
-                "- exit code: 1\n"
-                "E001 bad style\n"
-            )
-            stderr = ""
+    fake_result = RunResult(
+        failed_hooks=[
+            HookResult(
+                hook_id="ruff-format",
+                hook_name="ruff-format",
+                passed=False,
+                output="- files were modified",
+                files_modified=True,
+            ),
+            HookResult(
+                hook_id="ruff-check",
+                hook_name="ruff-check",
+                passed=False,
+                output="E001 bad style",
+                files_modified=False,
+            ),
+        ],
+        original_content=b"x=1\n",
+        modified_content=b"x=1\n",
+    )
 
-        return FakeResult()
-
-    with patch("devinfra.claude.post_tool_use.shutil.which", return_value="/usr/bin/pre-commit"):
-        with patch("devinfra.claude.post_tool_use.subprocess.run", side_effect=fake_run):
-            inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
-            result = evaluate(inp)
+    with patch("devinfra.claude.post_tool_use.run_on_file", return_value=fake_result):
+        inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
+        result = evaluate(inp)
 
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context


### PR DESCRIPTION
## Summary
- Extract pre-commit wiring into `precommit_runner.py` interface library that wraps pre-commit's internal Python API (`load_config`, `all_hooks`, `run_hook`) for structured per-hook results
- Simplify `post_tool_use.py` to a thin formatting layer — no subprocess calls, no stdout parsing state machine
- Use `pre_commit.constants.CONFIG_FILE` instead of hardcoding `.pre-commit-config.yaml`

## Test plan
- [x] `bazel build //devinfra/claude:precommit_runner` passes
- [x] `bazel build //devinfra/claude:post_tool_use_lib` passes
- [x] `bazel test //devinfra/claude:test_post_tool_use` passes (18 tests)
- [ ] Verify pre-commit hooks run correctly in a Claude Code web session

https://claude.ai/code/session_014QTw213uphnU7tY7APzxBm