### PR TITLE
Make model field optional in SessionStartHookInput

### DIFF
--- a/devinfra/claude/claude_api/hooks/session_start.py
+++ b/devinfra/claude/claude_api/hooks/session_start.py
@@ -23,7 +23,7 @@ class HookSource(StrEnum):
 class SessionStartHookInput(HookInputBase):
     """Input for Claude Code SessionStart hooks (parsed from stdin JSON)."""
 
-    model: str
+    model: str | None = Field(default=None, description="Not always sent by Claude Code")
     hook_event_name: Literal["SessionStart"] = "SessionStart"
     source: HookSource
     agent_type: str | None = Field(default=None, description="Present only when started with --agent")

--- a/devinfra/claude/test_session_start_input.py
+++ b/devinfra/claude/test_session_start_input.py
@@ -55,5 +55,19 @@ def test_all_permission_modes(permission_mode: PermissionMode) -> None:
     assert result.permission_mode == permission_mode
 
 
+def test_missing_model_defaults_to_none() -> None:
+    """Claude Code doesn't always send the model field in SessionStart events."""
+    result = SessionStartHookInput.model_validate(
+        {
+            "session_id": "s",
+            "cwd": "/tmp",
+            "transcript_path": "/tmp/t.json",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        }
+    )
+    assert result.model is None
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
## Summary
Updated the `SessionStartHookInput` class to make the `model` field optional, reflecting the actual behavior of Claude Code which does not always send this field.

## Changes
- Changed `model: str` to `model: str | None = Field(default=None, description="Not always sent by Claude Code")`
- This allows the hook input parser to gracefully handle cases where Claude Code does not provide a model value
- Added a descriptive note indicating that this field is not always sent by Claude Code

## Details
The `model` field in `SessionStartHookInput` is now properly typed as optional with a sensible default value of `None`. This change aligns the type definition with the actual runtime behavior and prevents parsing errors when the field is absent from the incoming JSON.

https://claude.ai/code/session_01L4gF4U1KBhgT4xcUkEHQQE