### PR TITLE
Refactor tests to use fixture and fix nix flake lock command

### DIFF
--- a/devinfra/ci/generate_ci.py
+++ b/devinfra/ci/generate_ci.py
@@ -460,7 +460,7 @@ def generate_consolidated_release(releases: dict[str, ReleaseConfig]) -> Workflo
                 f"releases/download/${{{{ needs.{job_name}.outputs.tag }}}}/{file_pattern}|' flake.nix\n"
             )
             if target.flake_input:
-                lock_lines += f"  nix flake lock --update-input {target.flake_input}\n"
+                lock_lines += f"  nix flake lock --update-input {target.flake_input} .\n"
         flake_updates.append(
             f'if [ "${{{{ needs.{job_name}.outputs.released }}}}" = "true" ]; then\n{sed_lines}{lock_lines}fi'
         )

--- a/devinfra/claude/test_bazel_wrapper.py
+++ b/devinfra/claude/test_bazel_wrapper.py
@@ -10,10 +10,8 @@ from devinfra.claude.errors import SupervisorError
 from devinfra.claude.settings import HookSettings
 
 
-async def test_supervisor_reachable_skips_restart() -> None:
+async def test_supervisor_reachable_skips_restart(hook_settings: HookSettings) -> None:
     """When supervisor is reachable, proxy setup runs without restart."""
-    settings = HookSettings()
-
     with (
         patch(
             "devinfra.claude.bazel_wrapper.try_connect", new_callable=AsyncMock, return_value=AsyncMock()
@@ -21,17 +19,15 @@ async def test_supervisor_reachable_skips_restart() -> None:
         patch("devinfra.claude.bazel_wrapper.proxy_setup.ensure_proxy_running", new_callable=AsyncMock) as mock_ensure,
         patch("devinfra.claude.bazel_wrapper.supervisor_start", new_callable=AsyncMock) as mock_start,
     ):
-        await _ensure_proxy_with_supervisor_restart(settings)
+        await _ensure_proxy_with_supervisor_restart(hook_settings)
 
-        mock_try_connect.assert_awaited_once_with(settings)
+        mock_try_connect.assert_awaited_once_with(hook_settings)
         mock_ensure.assert_awaited_once()
         mock_start.assert_not_awaited()
 
 
-async def test_supervisor_dead_triggers_restart() -> None:
+async def test_supervisor_dead_triggers_restart(hook_settings: HookSettings) -> None:
     """When supervisor is unreachable, it gets restarted before proxy setup."""
-    settings = HookSettings()
-
     with (
         patch(
             "devinfra.claude.bazel_wrapper.try_connect", new_callable=AsyncMock, return_value=None
@@ -39,17 +35,15 @@ async def test_supervisor_dead_triggers_restart() -> None:
         patch("devinfra.claude.bazel_wrapper.proxy_setup.ensure_proxy_running", new_callable=AsyncMock) as mock_ensure,
         patch("devinfra.claude.bazel_wrapper.supervisor_start", new_callable=AsyncMock) as mock_start,
     ):
-        await _ensure_proxy_with_supervisor_restart(settings)
+        await _ensure_proxy_with_supervisor_restart(hook_settings)
 
-        mock_try_connect.assert_awaited_once_with(settings)
-        mock_start.assert_awaited_once_with(settings)
+        mock_try_connect.assert_awaited_once_with(hook_settings)
+        mock_start.assert_awaited_once_with(hook_settings)
         mock_ensure.assert_awaited_once()
 
 
-async def test_supervisor_restart_failure_propagates() -> None:
+async def test_supervisor_restart_failure_propagates(hook_settings: HookSettings) -> None:
     """When supervisor restart fails, the error propagates as SupervisorError."""
-    settings = HookSettings()
-
     with (
         patch("devinfra.claude.bazel_wrapper.try_connect", new_callable=AsyncMock, return_value=None),
         patch(
@@ -59,7 +53,7 @@ async def test_supervisor_restart_failure_propagates() -> None:
         ),
         pytest.raises(SupervisorError, match="did not start in time"),
     ):
-        await _ensure_proxy_with_supervisor_restart(settings)
+        await _ensure_proxy_with_supervisor_restart(hook_settings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR makes two improvements: refactoring test functions to use pytest fixtures for dependency injection, and fixing a nix flake lock command to include the target directory.

## Key Changes

- **Test refactoring in `test_bazel_wrapper.py`**: 
  - Updated three test functions to accept `hook_settings` as a pytest fixture parameter instead of creating `HookSettings()` instances locally
  - Removed redundant local variable assignments and improved test clarity
  - All three affected tests now follow the same pattern: `test_supervisor_reachable_skips_restart`, `test_supervisor_dead_triggers_restart`, and `test_supervisor_restart_failure_propagates`

- **Nix command fix in `generate_ci.py`**:
  - Added missing `.` (current directory) argument to `nix flake lock --update-input` command
  - This ensures the nix flake lock operation targets the correct directory context

## Implementation Details
The fixture-based approach improves test maintainability by centralizing `HookSettings` creation and allowing for easier test configuration changes in the future. The nix command fix aligns with nix flake best practices by explicitly specifying the target directory.

https://claude.ai/code/session_01GwJbvNYPEBYqvxUayPNCKR