### PR TITLE
Add pytest_asyncio dependency to Claude tests

### DIFF
--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -552,6 +552,7 @@ py_test(
         ":errors",
         ":settings",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )


### PR DESCRIPTION
## Summary
Added `pytest_asyncio` as a test dependency to the Claude test target in the Bazel build configuration.

## Changes
- Added `@pypi//pytest_asyncio` to the `deps` list of the Claude `py_test` target in `devinfra/claude/BUILD.bazel`

## Details
This dependency is required to support asynchronous test execution in the Claude test suite, enabling the use of `pytest-asyncio` fixtures and markers for testing async code.

https://claude.ai/code/session_01JaajDHJTTtzPfwwSDbh2t6