### PR TITLE
Add somepath and allrdeps query strategies to benchmark

### DIFF
--- a/x/enforce_bazel_tests/README.md
+++ b/x/enforce_bazel_tests/README.md
@@ -47,18 +47,24 @@ tests from a cold start. Also benchmarks simpler query strategies
 Measured on Claude Code web (gVisor container, Bazel 8.5.0, cold start
 each measurement — `bazel shutdown` before every query):
 
-| Query                                     |    Time | Targets |
-| ----------------------------------------- | ------: | ------: |
-| `find_affected_tests` (scoped rdeps)      | ~237s\* |   n/a\* |
-| `kind("py_test", //...)`                  |    ~35s |     302 |
-| `kind("go_test", //...)`                  |    ~34s |       8 |
-| `kind(".*_test", //...)`                  |    ~33s |     447 |
-| `//...` (enumerate all targets)           |    ~34s |   8,388 |
-| `rdeps(//..., //util/bazel:workspace.py)` |  ~56s\* |   n/a\* |
+| Query                                       |    Time | Targets |
+| ------------------------------------------- | ------: | ------: |
+| `find_affected_tests` (scoped rdeps)        | ~237s\* |   n/a\* |
+| `kind("py_test", //...)`                    |    ~35s |     302 |
+| `kind("go_test", //...)`                    |    ~34s |       8 |
+| `kind(".*_test", //...)`                    |    ~33s |     447 |
+| `//...` (enumerate all targets)             |    ~34s |   8,388 |
+| `rdeps(//..., <label>)`                     |  ~56s\* |   n/a\* |
+| `somepath(kind(".*_test", //...), <label>)` |     TBD |     TBD |
+| `kind(".*_test", allrdeps(<label>))`        |     TBD |     TBD |
 
 \* `find_affected_tests` and unscoped `rdeps` fail (exit 7) due to broken
 external deps in `//...` universe — the scoped universe excludes these, but
 still times out on cold start. With a warm server, scoped rdeps takes ~3s.
+
+`somepath` and `allrdeps` are alternative strategies being evaluated — they
+find tests first and then check for transitive dependency paths, rather than
+computing rdeps over the full universe.
 
 **Key takeaway**: Cold-start query time is ~33–35s regardless of query
 complexity (dominated by Bazel server startup + BCR resolution). The

--- a/x/enforce_bazel_tests/bench.py
+++ b/x/enforce_bazel_tests/bench.py
@@ -5,6 +5,7 @@ Benchmarks from a cold Bazel server (shut down before each section):
 
 1. Affected-target discovery via find_affected_tests (validate + rdeps)
 2. Simple kind queries: all py_test, all go_test, all *_test targets
+3. Alternative strategies: somepath, allrdeps
 
 Usage:
     bazel run //x/enforce_bazel_tests:bench
@@ -110,10 +111,17 @@ def main() -> int:
     _bench_query(workspace, 'kind("go_test", //...)')
     _bench_query(workspace, 'kind(".*_test", //...)')
 
-    # --- Section 3: universe enumeration and rdeps ---
-    print("\n=== universe and rdeps (each from cold start) ===")
+    # --- Section 3: alternative strategies (each from cold start) ---
+    print("\n=== alternative strategies (each from cold start) ===")
     _bench_query(workspace, "//...")
     _bench_query(workspace, f"rdeps(//..., {label})")
+
+    # somepath: find all tests, then filter to those with a path to the changed label.
+    # This is the "find tests first, then check deps" approach.
+    _bench_query(workspace, f'somepath(kind(".*_test", //...), {label})')
+
+    # allrdeps with kind filter: equivalent to rdeps but may use different evaluation order.
+    _bench_query(workspace, f'kind(".*_test", allrdeps({label}))')
 
     return 0
 


### PR DESCRIPTION
## Summary
- Add `somepath(kind(".*_test", //...), <label>)` and `kind(".*_test", allrdeps(<label>))` to the benchmark
- Update README with new query rows (TBD values — run locally to fill in)

These are the alternative strategies discussed: find all test targets first, then filter by transitive dependency path to the changed file.

## Test plan
- [ ] Run `bazel run //x/enforce_bazel_tests:bench` locally to get timing numbers
- [ ] Update TBD values in README with actual results

https://claude.ai/code/session_015s3E3KrhxaSZ87BUsdFTqb