### PR TITLE
Add null checks for hook_specific_output in pre-tool-use tests

### DIFF
--- a/devinfra/claude/test_pre_tool_use.py
+++ b/devinfra/claude/test_pre_tool_use.py
@@ -21,6 +21,7 @@ class TestEvaluate:
     def test_allowed_bash_command_returns_allow(self, command: str) -> None:
         hook_input = PreToolUseInput(**_COMMON, tool_name="Bash", tool_input={"command": command})
         result = evaluate(hook_input)
+        assert result.hook_specific_output is not None
         assert result.hook_specific_output.permission_decision == PermissionDecision.ALLOW
 
     def test_output_serializes_to_camel_case(self) -> None:
@@ -39,6 +40,7 @@ class TestEvaluate:
     def test_returns_allow_for_unmatched(self, tool_name: str, tool_input: dict) -> None:
         hook_input = PreToolUseInput(**_COMMON, tool_name=tool_name, tool_input=tool_input)
         result = evaluate(hook_input)
+        assert result.hook_specific_output is not None
         assert result.hook_specific_output.permission_decision == PermissionDecision.ALLOW
 
 


### PR DESCRIPTION
## Summary
Added explicit null assertions for `hook_specific_output` in the pre-tool-use evaluation tests to ensure the output is not None before accessing its properties.

## Key Changes
- Added `assert result.hook_specific_output is not None` check in `test_allowed_bash_command_returns_allow()` before accessing `permission_decision`
- Added `assert result.hook_specific_output is not None` check in `test_returns_allow_for_unmatched()` before accessing `permission_decision`

## Details
These assertions serve as defensive checks to catch cases where `hook_specific_output` might unexpectedly be None, preventing AttributeError exceptions and making test failures more explicit. This improves test robustness and helps catch potential issues in the `evaluate()` function's return value structure.

https://claude.ai/code/session_01KEG8vCQarRqvE1hUhbuDFm