### PR TITLE
Remove token tracking from evaluation harness

### DIFF
--- a/skills/info_gathering/evals/README.md
+++ b/skills/info_gathering/evals/README.md
@@ -15,7 +15,7 @@ Each eval tests a different aspect of the info-gathering skill. See each eval's
 
 - `LLMClient` — LiteLLM wrapper (call, resolve_tool_calls)
 - CLI utilities (`add_common_args`, `client_from_args`, etc.)
-- Result models (`RunSummary`, `LogEntry`, `TokenTracker`)
+- Result models (`RunSummary`, `LogEntry`)
 
 `litellm_tool_provider.py` handles LiteLLM ↔ `ToolProvider` wiring
 (`tool_params_from_provider`, `tool_result_content`).

--- a/skills/info_gathering/evals/harness.py
+++ b/skills/info_gathering/evals/harness.py
@@ -49,38 +49,11 @@ class LogEntry(BaseModel):
     usage: dict[str, Any]
 
 
-class TokenTracker(BaseModel):
-    model: str
-    api_calls: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-
-    PRICING: dict[str, dict[str, float]] = {
-        "anthropic/claude-haiku-4-5-20251001": {"input": 1.0, "output": 5.0},
-        "anthropic/claude-sonnet-4-6-20250514": {"input": 3.0, "output": 15.0},
-        "anthropic/claude-opus-4-6-20250514": {"input": 15.0, "output": 75.0},
-    }
-
-    def add(self, usage: Usage) -> None:
-        self.input_tokens += usage.prompt_tokens or 0
-        self.output_tokens += usage.completion_tokens or 0
-        self.api_calls += 1
-
-    @property
-    def cost_usd(self) -> float:
-        p = self.PRICING.get(self.model, {"input": 1.0, "output": 5.0})
-        return (self.input_tokens * p["input"] + self.output_tokens * p["output"]) / 1_000_000
-
-
 class RunSummary(BaseModel):
     eval_name: str
     model: str
     turns: int
     result: BaseModel
-    api_calls: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    api_cost_usd: float = 0
 
 
 # === Tool helpers ==============================================================

--- a/skills/info_gathering/evals/twenty_questions/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/twenty_questions.py
@@ -21,7 +21,6 @@ from skills.info_gathering.evals.harness import (
     LLMClient,
     LogEntry,
     RunSummary,
-    TokenTracker,
     _serialize_message,
     add_common_args,
     build_agent_system,
@@ -114,7 +113,6 @@ class _TwentyQuestionsRunner:
         self.agent_system = agent_system
         self.sim_system = sim_system
         self.agent_tool_provider = agent_tool_provider
-        self.tracker = TokenTracker(model=client.model)
         self.log_entries: list[LogEntry] = []
         self.agent_messages: list[dict[str, Any]] = []
         self.sim_messages: list[dict[str, Any]] = []
@@ -126,21 +124,18 @@ class _TwentyQuestionsRunner:
         agent_resp = await self.client.call(
             messages=self.agent_messages, system=self.agent_system, tools=agent_tool_params or None
         )
-        self.tracker.add(agent_resp.usage)
         log_response(
             self.log_entries, name=self.name, player="agent", turn=turn, model=self.client.model, response=agent_resp
         )
 
         # Resolve any scratch tool calls — does not count as a new turn
         if extract_tool_calls(agent_resp):
-            agent_resp, self.agent_messages, usages = await self.client.resolve_tool_calls(
+            agent_resp, self.agent_messages, _ = await self.client.resolve_tool_calls(
                 response=agent_resp,
                 messages=self.agent_messages,
                 system=self.agent_system,
                 provider=self.agent_tool_provider,
             )
-            for u in usages:
-                self.tracker.add(u)
             log_response(
                 self.log_entries,
                 name=self.name,
@@ -167,7 +162,6 @@ class _TwentyQuestionsRunner:
         sim_resp = await self.client.call(
             messages=self.sim_messages, system=self.sim_system, tools=SIM_TOOLS, tool_choice="required"
         )
-        self.tracker.add(sim_resp.usage)
         log_response(
             self.log_entries, name=self.name, player="simulator", turn=turn, model=self.client.model, response=sim_resp
         )
@@ -225,10 +219,6 @@ class _TwentyQuestionsRunner:
             model=self.client.model,
             turns=turn,
             result=result,
-            api_calls=self.tracker.api_calls,
-            input_tokens=self.tracker.input_tokens,
-            output_tokens=self.tracker.output_tokens,
-            api_cost_usd=round(self.tracker.cost_usd, 4),
         )
         save_results(name=self.name, log_entries=self.log_entries, summary=summary, output_dir=output_dir)
         return summary


### PR DESCRIPTION
## Summary
Removes token and cost tracking functionality from the evaluation harness. The `TokenTracker` class and related token/cost fields have been removed from the codebase, simplifying the result models and evaluation runner.

## Key Changes
- **Removed `TokenTracker` class** from `harness.py` including pricing data and cost calculation logic
- **Simplified `RunSummary` model** by removing `api_calls`, `input_tokens`, `output_tokens`, and `api_cost_usd` fields
- **Updated `TwentyQuestions` evaluator** to remove token tracking:
  - Removed `TokenTracker` initialization
  - Removed calls to `tracker.add()` for API responses
  - Removed token tracking from tool call resolution
  - Removed token/cost fields from final summary output
- **Updated documentation** to reflect removal of `TokenTracker` from result models

## Implementation Details
The changes maintain all logging functionality through `LogEntry` objects, which continue to capture usage data. Token tracking is no longer aggregated at the runner level, allowing for simpler result summaries while preserving detailed per-request usage information in logs.

https://claude.ai/code/session_01XzqgtiwWvv5yB2sDUa3gDB