### PR TITLE
Improve flake input update resilience in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,24 +451,34 @@ jobs:
       - uses: cachix/install-nix-action@v30
       - name: Update references and push
         run: |-
+          FAILED_INPUTS=()
+          update_flake_input() {
+            local input_name="$1"
+            if nix flake update "$input_name"; then
+              echo "Updated flake input: $input_name"
+            else
+              echo "::warning::Failed to update flake input: $input_name"
+              FAILED_INPUTS+=("$input_name")
+            fi
+          }
           if [ "${{ needs.release-kubespand.outputs.released }}" = "true" ]; then
             sed -i 's|releases/download/kubespand-[^/]*/kubespand|releases/download/${{ needs.release-kubespand.outputs.tag }}/kubespand|' flake.nix
             sed -i 's|releases/download/kubespand-[^/]*/apid|releases/download/${{ needs.release-kubespand.outputs.tag }}/apid|' flake.nix
-            nix flake lock --update-input kubespand-bin .
-            nix flake lock --update-input apid-bin .
+            update_flake_input kubespand-bin
+            update_flake_input apid-bin
           fi
           if [ "${{ needs.release-ducktape.outputs.released }}" = "true" ]; then
             sed -i 's|releases/download/ducktape-[^/]*/ducktape|releases/download/${{ needs.release-ducktape.outputs.tag }}/ducktape|' flake.nix
             sed -i "s|releases/download/ducktape-[a-f0-9]*/ducktape|releases/download/${{ needs.release-ducktape.outputs.tag }}/ducktape|g" .claude/settings.json
-            nix flake lock --update-input ducktape-wheel .
+            update_flake_input ducktape-wheel
           fi
           if [ "${{ needs.release-headscale_cleanup.outputs.released }}" = "true" ]; then
             sed -i 's|releases/download/headscale-cleanup-[^/]*/headscale_cleanup|releases/download/${{ needs.release-headscale_cleanup.outputs.tag }}/headscale_cleanup|' flake.nix
-            nix flake lock --update-input headscale-cleanup-wheel .
+            update_flake_input headscale-cleanup-wheel
           fi
           if [ "${{ needs.release-gterm_theme.outputs.released }}" = "true" ]; then
             sed -i 's|releases/download/gterm-theme-[^/]*/gterm_theme|releases/download/${{ needs.release-gterm_theme.outputs.tag }}/gterm_theme|' flake.nix
-            nix flake lock --update-input gterm-theme-wheel .
+            update_flake_input gterm-theme-wheel
           fi
 
           git config user.name "github-actions[bot]"
@@ -478,6 +488,10 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No downstream changes"
+            if [ ${#FAILED_INPUTS[@]} -gt 0 ]; then
+              echo "::error::Failed to update flake inputs: ${FAILED_INPUTS[*]}"
+              exit 1
+            fi
             exit 0
           fi
 
@@ -486,3 +500,8 @@ jobs:
           BRANCH="${{ github.ref_name }}"
           git pull --rebase origin "$BRANCH"
           git push origin "HEAD:${BRANCH}"
+
+          if [ ${#FAILED_INPUTS[@]} -gt 0 ]; then
+            echo "::error::Partial update committed, but failed to update: ${FAILED_INPUTS[*]}"
+            exit 1
+          fi

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,7 @@
 - [ ] Migrate all Python packages to Bazel monorepo style (colocated tests, flat structure like `git_commit_ai/`)
 - [ ] Re-enable `bazel coverage` in CI once compatible with remote execution (RBE). Currently disabled because the Java-based `remote_coverage_tools` can't locate its runfiles on BuildBuddy workers, causing all tests to be marked as failed. See `bazel-test.yml`.
 - [ ] Set up BuildBuddy [remote runner features](https://www.buildbuddy.io/docs/remote-runner-features) for artifacts / extra test outputs
+- [ ] Upgrade protobuf once UPB uninitialized variable warnings are fixed upstream. Currently on `protobuf 34.0.bcr.1` (latest in BCR as of March 2026). GCC emits `-Wmaybe-uninitialized` warnings from `external/protobuf+/upb/wire/decode.c` (lines 281, 732, 1089: `upb_StringView sv` used uninitialized). These are false positives from GCC's static analysis failing to prove the variable is always set before use. Upstream issues: [#17052](https://github.com/protocolbuffers/protobuf/issues/17052), [PR #18805](https://github.com/protocolbuffers/protobuf/pull/18805). Also `src/google/protobuf/compiler/rust/message.cc` triggers `-Wdeprecated-declarations` for `FieldOptions::weak()`. Monitor protobuf releases >34.0 for fixes.
 
 ## Repository
 

--- a/devinfra/ci/generate_ci.py
+++ b/devinfra/ci/generate_ci.py
@@ -459,7 +459,7 @@ def generate_consolidated_release(releases: dict[str, ReleaseConfig]) -> Workflo
                     f"  sed -i 's|releases/download/{name}-[^/]*/{file_pattern}|"
                     f"releases/download/${{{{ needs.{job_name}.outputs.tag }}}}/{file_pattern}|' flake.nix\n"
                 )
-                lock_lines += f"  nix flake lock --update-input {target.flake_input} .\n"
+                lock_lines += f"  update_flake_input {target.flake_input}\n"
         if config.update_claude_settings:
             # Update settings.json BEFORE nix flake lock so it succeeds even if nix fails
             settings_file_pattern = name.replace("-", "_")
@@ -472,7 +472,21 @@ def generate_consolidated_release(releases: dict[str, ReleaseConfig]) -> Workflo
             f'if [ "${{{{ needs.{job_name}.outputs.released }}}}" = "true" ]; then\n{sed_lines}{lock_lines}fi'
         )
 
-    downstream_run = "\n".join(flake_updates)
+    # Preamble: helper function for resilient flake input updates
+    preamble = (
+        "FAILED_INPUTS=()\n"
+        "update_flake_input() {\n"
+        '  local input_name="$1"\n'
+        '  if nix flake update "$input_name"; then\n'
+        '    echo "Updated flake input: $input_name"\n'
+        "  else\n"
+        '    echo "::warning::Failed to update flake input: $input_name"\n'
+        '    FAILED_INPUTS+=("$input_name")\n'
+        "  fi\n"
+        "}\n"
+    )
+
+    downstream_run = preamble + "\n".join(flake_updates)
 
     downstream_run += (
         '\n\ngit config user.name "github-actions[bot]"\n'
@@ -482,6 +496,10 @@ def generate_consolidated_release(releases: dict[str, ReleaseConfig]) -> Workflo
         "\n"
         "if git diff --cached --quiet; then\n"
         '  echo "No downstream changes"\n'
+        "  if [ ${#FAILED_INPUTS[@]} -gt 0 ]; then\n"
+        '    echo "::error::Failed to update flake inputs: ${FAILED_INPUTS[*]}"\n'
+        "    exit 1\n"
+        "  fi\n"
         "  exit 0\n"
         "fi\n"
         "\n"
@@ -489,7 +507,12 @@ def generate_consolidated_release(releases: dict[str, ReleaseConfig]) -> Workflo
         "\n"
         'BRANCH="${{ github.ref_name }}"\n'
         'git pull --rebase origin "$BRANCH"\n'
-        'git push origin "HEAD:${BRANCH}"'
+        'git push origin "HEAD:${BRANCH}"\n'
+        "\n"
+        "if [ ${#FAILED_INPUTS[@]} -gt 0 ]; then\n"
+        '  echo "::error::Partial update committed, but failed to update: ${FAILED_INPUTS[*]}"\n'
+        "  exit 1\n"
+        "fi"
     )
 
     jobs["update-downstream"] = Job(

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
     };
 
     # SideroLabs docs — source of truth for Talos/Omni AI agent skill
-    # Update: nix flake lock --update-input siderolabs-docs
+    # Update: nix flake update siderolabs-docs
     siderolabs-docs = {
       url = "github:siderolabs/docs";
       flake = false;


### PR DESCRIPTION
## Summary
This PR improves the robustness of the release workflow's flake input update process by introducing error handling and tracking for failed updates, while also updating the documentation to reflect the new approach.

## Key Changes

- **Added resilient flake input update function**: Introduced a `update_flake_input()` helper function in the release workflow that wraps `nix flake update` calls with error handling. Failed updates are tracked in a `FAILED_INPUTS` array and reported as warnings rather than immediately failing.

- **Enhanced error reporting**: The workflow now:
  - Reports failed flake input updates as warnings during the update phase
  - Fails the job if any inputs failed to update when there are no downstream changes
  - Fails the job after committing if partial updates occurred with failures, providing clear error messages about which inputs failed

- **Updated code generation**: Modified `devinfra/ci/generate_ci.py` to generate the new resilient update pattern, including the preamble function and error checking logic at both the pre-commit and post-commit stages.

- **Updated documentation**: Changed the flake.nix comment to reference `nix flake update` instead of the deprecated `nix flake lock --update-input` command syntax.

- **Added TODO item**: Documented a pending protobuf upgrade task once upstream UPB warnings are resolved.

## Implementation Details

The solution allows the workflow to continue attempting all flake input updates even if some fail, then report which ones failed. This provides better visibility into partial failures and prevents silent failures while still allowing the workflow to complete its other tasks.

https://claude.ai/code/session_01RMw6ghHm1aEpJDqse2qJfa