### PR TITLE
Add proxy URL support to kubeconfig generation

### DIFF
--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -656,6 +656,7 @@ py_test(
         ":k8s_secrets_setup",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
     ],
 )
 

--- a/devinfra/claude/k8s_secrets_setup.py
+++ b/devinfra/claude/k8s_secrets_setup.py
@@ -45,12 +45,16 @@ def _read_secret_ref(api: CoreV1Api, ref: K8sSecretRef, namespace: str) -> str |
     return None
 
 
-def _build_kubeconfig(token: str, server: str, service_account: str, namespace: str, ca_path: Path | None) -> dict:
+def _build_kubeconfig(
+    token: str, server: str, service_account: str, namespace: str, ca_path: Path | None, proxy_url: str | None = None
+) -> dict:
     """Build kubeconfig dict for kubectl CLI use."""
     cluster_config: dict[str, str] = {"server": server}
     if ca_path and ca_path.exists():
         ca_pem = ca_path.read_text()
         cluster_config["certificate-authority-data"] = base64.b64encode(ca_pem.encode()).decode()
+    if proxy_url:
+        cluster_config["proxy-url"] = proxy_url
 
     return {
         "apiVersion": "v1",
@@ -124,8 +128,10 @@ def setup_k8s_secrets(
     if secrets_cfg.otel_bearer_token:
         result.otel_bearer_token = _read_secret_ref(api, secrets_cfg.otel_bearer_token, secrets_cfg.namespace)
 
-    # Write kubeconfig
-    kubeconfig = _build_kubeconfig(token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path)
+    # Write kubeconfig (pass proxy_url so kubectl routes through the same proxy as the Python client)
+    kubeconfig = _build_kubeconfig(
+        token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path, proxy_url=proxy
+    )
     kubeconfig_path = session_dir / "kubeconfig"
     kubeconfig_path.write_text(yaml.dump(kubeconfig, default_flow_style=False))
     kubeconfig_path.chmod(0o600)

--- a/devinfra/claude/test_k8s_secrets_setup.py
+++ b/devinfra/claude/test_k8s_secrets_setup.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytest_bazel
+import yaml
 
 from devinfra.claude.hook_config import HookConfig, K8sConfig, K8sSecretMapping, K8sSecretsConfig
 from devinfra.claude.k8s_secrets_setup import setup_k8s_secrets
@@ -77,6 +78,32 @@ def test_unique_env_vars_succeeds(tmp_path: Path, mock_k8s_api: MagicMock) -> No
 
     assert result.env_vars["VAR_A"] == "value_a"
     assert result.env_vars["VAR_B"] == "value_b"
+
+
+def test_kubeconfig_proxy_url(tmp_path: Path, mock_k8s_api: MagicMock) -> None:
+    """When proxy is set, kubeconfig should include proxy-url in the cluster config."""
+    config = _make_config([])
+    mock_k8s_api.read_namespaced_secret.side_effect = []
+
+    result = setup_k8s_secrets(
+        token="tok", session_dir=tmp_path, combined_ca_path=None, config=config, proxy="http://localhost:18081"
+    )
+
+    assert result.kubeconfig_path is not None
+    kubeconfig = yaml.safe_load(result.kubeconfig_path.read_text())
+    assert kubeconfig["clusters"][0]["cluster"]["proxy-url"] == "http://localhost:18081"
+
+
+def test_kubeconfig_no_proxy_url_when_unset(tmp_path: Path, mock_k8s_api: MagicMock) -> None:
+    """When proxy is not set, kubeconfig should not include proxy-url."""
+    config = _make_config([])
+    mock_k8s_api.read_namespaced_secret.side_effect = []
+
+    result = setup_k8s_secrets(token="tok", session_dir=tmp_path, combined_ca_path=None, config=config)
+
+    assert result.kubeconfig_path is not None
+    kubeconfig = yaml.safe_load(result.kubeconfig_path.read_text())
+    assert "proxy-url" not in kubeconfig["clusters"][0]["cluster"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This change adds support for configuring a proxy URL in the generated kubeconfig file, ensuring that kubectl commands route through the same proxy as the Python Kubernetes client.

## Key Changes
- Modified `_build_kubeconfig()` to accept an optional `proxy_url` parameter and include it in the cluster configuration when provided
- Updated `setup_k8s_secrets()` to pass the `proxy` parameter to `_build_kubeconfig()` so the proxy URL is written to the kubeconfig file
- Added two new test cases:
  - `test_kubeconfig_proxy_url()`: Verifies that when a proxy is set, the kubeconfig includes the `proxy-url` field
  - `test_kubeconfig_no_proxy_url_when_unset()`: Verifies that when no proxy is set, the `proxy-url` field is not included
- Added `yaml` import to test file for kubeconfig validation

## Implementation Details
- The proxy URL is conditionally added to the cluster configuration only when provided, maintaining backward compatibility
- The kubeconfig file is validated in tests by parsing it with `yaml.safe_load()` to ensure proper YAML structure
- The change ensures consistent proxy configuration across both the Python client and kubectl CLI usage

https://claude.ai/code/session_0144zsgsh757nkJhJV9N5HBD