### PR TITLE
Refactor dependency validation to use networkx graph library

### DIFF
--- a/cluster/k8s/alloy/helmrelease.yaml
+++ b/cluster/k8s/alloy/helmrelease.yaml
@@ -38,6 +38,9 @@ spec:
           containerPort: 4318
           protocol: TCP
 
+    serviceMonitor:
+      enabled: true
+
     resources:
       requests:
         cpu: 50m

--- a/cluster/k8s/applications/gitea-servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/applications/gitea-servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gitea-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/applications/gitea-servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: gitea
+    - name: monitoring-stack

--- a/cluster/k8s/applications/gitea-servicemonitor/kustomization.yaml
+++ b/cluster/k8s/applications/gitea-servicemonitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml

--- a/cluster/k8s/applications/gitea-servicemonitor/servicemonitor.yaml
+++ b/cluster/k8s/applications/gitea-servicemonitor/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gitea
+  namespace: gitea
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gitea
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      # TODO: Set metrics.TOKEN in Gitea config and add bearerTokenSecret here once
+      # a Vault secret + ESO pattern is in place (follow LiteLLM token pattern).

--- a/cluster/k8s/applications/gitea/helmrelease.yaml
+++ b/cluster/k8s/applications/gitea/helmrelease.yaml
@@ -77,6 +77,12 @@ spec:
         queue:
           TYPE: level
 
+        metrics:
+          ENABLED: true
+          TOKEN: ""
+          # TODO: Set a metrics token and add bearerTokenSecret to the ServiceMonitor once
+          # a Vault secret + ESO pattern is in place (follow LiteLLM token pattern).
+
         security:
           INSTALL_LOCK: true
           SECRET_KEY: "change-this-secret-key-in-production"

--- a/cluster/k8s/authentik-db/postgres-cluster.yaml
+++ b/cluster/k8s/authentik-db/postgres-cluster.yaml
@@ -27,6 +27,9 @@ spec:
     storageClass: local-path
     size: 8Gi
 
+  monitoring:
+    enablePodMonitor: true
+
   bootstrap:
     initdb:
       database: authentik

--- a/cluster/k8s/authentik-servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/authentik-servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: authentik-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/authentik-servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: authentik
+    - name: monitoring-stack

--- a/cluster/k8s/authentik-servicemonitor/kustomization.yaml
+++ b/cluster/k8s/authentik-servicemonitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - podmonitor.yaml

--- a/cluster/k8s/authentik-servicemonitor/podmonitor.yaml
+++ b/cluster/k8s/authentik-servicemonitor/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: authentik-server
+  namespace: authentik
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: authentik
+      app.kubernetes.io/component: server
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      # TODO: Consider adding bearer token auth if Authentik metrics require authentication.

--- a/cluster/k8s/cert-manager/flux-kustomization.yaml
+++ b/cluster/k8s/cert-manager/flux-kustomization.yaml
@@ -32,3 +32,4 @@ spec:
         name: cert-manager-issuer-config
   dependsOn:
     - name: cert-manager-issuer-config
+    - name: monitoring-stack

--- a/cluster/k8s/cert-manager/helmrelease.yaml
+++ b/cluster/k8s/cert-manager/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
     prometheus:
       enabled: true
       servicemonitor:
-        enabled: false # Enable later when we have Prometheus
+        enabled: true
 
     # Resource configuration
     resources:

--- a/cluster/k8s/headscale-db/postgres-cluster.yaml
+++ b/cluster/k8s/headscale-db/postgres-cluster.yaml
@@ -27,6 +27,9 @@ spec:
     storageClass: local-path
     size: 1Gi
 
+  monitoring:
+    enablePodMonitor: true
+
   bootstrap:
     initdb:
       database: headscale

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -57,6 +57,7 @@ resources:
   - authentik-namespace/flux-kustomization.yaml
   - authentik-db/flux-kustomization.yaml
   - authentik/flux-kustomization.yaml
+  - authentik-servicemonitor/flux-kustomization.yaml
   - authentik-secrets/flux-kustomization.yaml
   - authentik-token/flux-kustomization.yaml
   - harbor-namespace/flux-kustomization.yaml
@@ -68,6 +69,7 @@ resources:
   - harbor-webhook/flux-kustomization.yaml
   - gitea-namespace/flux-kustomization.yaml
   - applications/gitea/flux-kustomization.yaml
+  - applications/gitea-servicemonitor/flux-kustomization.yaml
   - applications/gitea-admin-token/flux-kustomization.yaml
   - applications/gitea-secrets/flux-kustomization.yaml
   - matrix-namespace/flux-kustomization.yaml

--- a/cluster/k8s/powerdns-db/postgres-cluster.yaml
+++ b/cluster/k8s/powerdns-db/postgres-cluster.yaml
@@ -27,6 +27,9 @@ spec:
     storageClass: local-path
     size: 1Gi
 
+  monitoring:
+    enablePodMonitor: true
+
   bootstrap:
     initdb:
       database: pdns

--- a/cluster/k8s/props-db/postgres-cluster.yaml
+++ b/cluster/k8s/props-db/postgres-cluster.yaml
@@ -17,6 +17,9 @@ spec:
     storageClass: longhorn
     size: 10Gi
 
+  monitoring:
+    enablePodMonitor: true
+
   bootstrap:
     initdb:
       database: eval_results

--- a/cluster/k8s/vault/flux-kustomization.yaml
+++ b/cluster/k8s/vault/flux-kustomization.yaml
@@ -15,6 +15,7 @@ spec:
   dependsOn:
     - name: vault-operator # Vault instance needs operator and CRDs
     - name: local-path-provisioner # Vault uses local-path storage
+    - name: monitoring-stack # ServiceMonitor CRD must exist before vault deploys servicemonitor.yaml
   # Verify Bank-Vaults operator, Vault StatefulSet, and unseal keys are ready.
   # The instance-unseal-keys secret is created by Bank-Vaults after Vault
   # initialization — downstream consumers (vault-token, external-secrets-config)

--- a/cluster/k8s/vault/instance.yaml
+++ b/cluster/k8s/vault/instance.yaml
@@ -61,6 +61,11 @@ spec:
     api_addr: "http://instance.vault.svc.cluster.local:8200"
     cluster_addr: "http://${.Env.POD_NAME}.vault.svc.cluster.local:8201"
     ui: true
+    telemetry:
+      unauthenticated_metrics_access: true
+      prometheus_retention_time: "30s"
+      # TODO: Consider restricting /v1/sys/metrics to monitoring namespace only
+      # via CiliumNetworkPolicy once baseline metrics are confirmed working.
 
   # Automatic unsealing using Kubernetes secrets
   unsealConfig:

--- a/cluster/k8s/vault/kustomization.yaml
+++ b/cluster/k8s/vault/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - rbac.yaml
   - internal-tls-certificate.yaml
   - instance.yaml
+  - servicemonitor.yaml
 # Note: Vault uses cluster-internal-ca (from cluster-ca kustomization) instead of vault-specific CA
 # Note: ingress.yaml and certificate.yaml in separate vault-ingress kustomization

--- a/cluster/k8s/vault/servicemonitor.yaml
+++ b/cluster/k8s/vault/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+  endpoints:
+    - port: api-port
+      path: /v1/sys/metrics
+      params:
+        format: ["prometheus"]
+      interval: 30s

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -47,7 +47,9 @@ py_library(
         ":flux",
         ":k8s",
         ":kustomize",
-        "@pypi//pydantic",
+        "@pypi//networkx",
+        "@pypi//numpy",
+        "@pypi//types_networkx",
     ],
 )
 
@@ -57,7 +59,11 @@ py_library(
     imports = ["../.."],
     deps = [
         ":cluster",
+        ":crd_layering",
         ":flux",
+        "@pypi//networkx",
+        "@pypi//numpy",
+        "@pypi//types_networkx",
     ],
 )
 
@@ -136,6 +142,7 @@ py_test(
     data = glob(["testdata/**"]),
     imports = ["../.."],
     deps = [
+        ":cluster",
         ":dependencies",
         ":flux",
         "//util/bazel:runfiles",
@@ -149,8 +156,10 @@ py_test(
     srcs = ["test_dependencies.py"],
     imports = ["../.."],
     deps = [
+        ":cluster",
         ":dependencies",
         ":flux",
+        ":k8s",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/cluster/validation/cluster.py
+++ b/cluster/validation/cluster.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 
-from pydantic import BaseModel
+import networkx as nx
 
 from cluster.validation.flux import FluxKustomization, parse_flux_kustomization
 from cluster.validation.k8s import K8sResource, parse_k8s_resource_file
@@ -15,19 +16,36 @@ from cluster.validation.kustomize import KustomizeBuildResult, KustomizeFile, pa
 _K8S_SUBPATH = Path("cluster/k8s")
 
 
-class ParsedCluster(BaseModel):
+@dataclass
+class ParsedCluster:
     """All parsed data from the cluster directory - parsed once, used everywhere."""
 
-    kustomize_files: dict[Path, KustomizeFile] = {}
-    flux_kustomizations: dict[str, FluxKustomization] = {}  # keyed by name
-    all_yaml_files: set[Path] = set()
-    source_resources: dict[Path, list[K8sResource]] = {}
-    build_results: list[KustomizeBuildResult] = []
+    kustomize_files: dict[Path, KustomizeFile] = field(default_factory=dict)
+    flux_kustomizations: dict[str, FluxKustomization] = field(default_factory=dict)  # keyed by name
+    all_yaml_files: set[Path] = field(default_factory=set)
+    source_resources: dict[Path, list[K8sResource]] = field(default_factory=dict)
+    build_results: list[KustomizeBuildResult] = field(default_factory=list)
+
+    # Directed graph of Flux kustomization dependencies.
+    # Edge A->B means kustomization A depends on B (A must start after B is ready).
+    # Computed from flux_kustomizations in __post_init__; do not set manually.
+    graph: nx.DiGraph = field(init=False)
+
+    def __post_init__(self) -> None:
+        g: nx.DiGraph = nx.DiGraph()
+        g.add_nodes_from(self.flux_kustomizations)
+        for name, kust in self.flux_kustomizations.items():
+            for dep in kust.spec.depends_on:
+                g.add_edge(name, dep.name)
+        self.graph = g
 
 
 def parse_cluster(k8s_dir: Path) -> ParsedCluster:
     """Parse all files in the cluster directory once."""
-    cluster = ParsedCluster()
+    kustomize_files: dict[Path, KustomizeFile] = {}
+    flux_kustomizations: dict[str, FluxKustomization] = {}
+    all_yaml_files: set[Path] = set()
+    source_resources: dict[Path, list[K8sResource]] = {}
 
     for yaml_file in k8s_dir.rglob("*.yaml"):
         # Skip flux-system (auto-generated)
@@ -38,20 +56,25 @@ def parse_cluster(k8s_dir: Path) -> ParsedCluster:
         if "charts" in yaml_file.parts:
             continue
 
-        cluster.all_yaml_files.add(yaml_file.resolve())
+        all_yaml_files.add(yaml_file.resolve())
 
         if yaml_file.name == "kustomization.yaml":
             kust = parse_kustomize_file(yaml_file)
             if kust:
-                cluster.kustomize_files[yaml_file] = kust
+                kustomize_files[yaml_file] = kust
 
         elif yaml_file.name == "flux-kustomization.yaml":
             for flux_kust in parse_flux_kustomization(yaml_file):
-                cluster.flux_kustomizations[flux_kust.name] = flux_kust
+                flux_kustomizations[flux_kust.name] = flux_kust
 
         else:
             resources = parse_k8s_resource_file(yaml_file)
             if resources:
-                cluster.source_resources[yaml_file] = resources
+                source_resources[yaml_file] = resources
 
-    return cluster
+    return ParsedCluster(
+        kustomize_files=kustomize_files,
+        flux_kustomizations=flux_kustomizations,
+        all_yaml_files=all_yaml_files,
+        source_resources=source_resources,
+    )

--- a/cluster/validation/crd_layering.py
+++ b/cluster/validation/crd_layering.py
@@ -27,8 +27,25 @@ OPERATOR_CRDS: dict[str, set[str]] = {
     "vault-operator": {"Vault"},
     "vault": set(),
     "tofu-controller": {"Terraform"},
-    "powerdns-operator": {"ClusterZone", "ClusterRRset"},
-    "sealed-secrets": set(),
+    "powerdns-operator": {"ClusterZone", "ClusterRRset", "Zone", "RRset"},
+    "sealed-secrets": {"SealedSecret"},
+    "monitoring-stack": {"ServiceMonitor", "PodMonitor"},
+    "cnpg": {
+        "Cluster",
+        "Backup",
+        "ScheduledBackup",
+        "Pooler",
+        "ClusterImageCatalog",
+        "ImageCatalog",
+        "Database",
+        "Publication",
+        "Subscription",
+    },
+    "longhorn": set(),  # Longhorn CRDs (Volume, Engine, etc.) are internal to the operator
+    "vpa": {"VerticalPodAutoscaler", "VerticalPodAutoscalerCheckpoint"},
+    "node-feature-discovery": {"NodeFeatureRule", "NodeFeature", "NodeFeatureGroup"},
+    "openclaw-operator": {"OpenClawInstance", "OpenClawSelfConfig"},
+    "flux-image-automation": {"ImageRepository", "ImagePolicy", "ImageUpdateAutomation"},
 }
 
 # Derived: CRD kind -> operator name (for error messages)

--- a/cluster/validation/dependencies.py
+++ b/cluster/validation/dependencies.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
+import networkx as nx
+
 from cluster.validation.cluster import ParsedCluster
-from cluster.validation.flux import FluxKustomization
+from cluster.validation.crd_layering import CRD_TO_OPERATOR
 
 
 @dataclass
@@ -18,8 +19,9 @@ class _DependencyRule:
 
 
 _DEPENDENCY_RULES: list[_DependencyRule] = [
-    # external-secrets-config ordering is enforced dynamically by validate_external_secrets_dependencies().
-    # vault → external-secrets ordering is enforced by CRD layering checks in test_kustomize.py.
+    # CRD-based operator ordering (ExternalSecret->external-secrets-config, ServiceMonitor->monitoring-stack, etc.)
+    # is enforced dynamically by validate_operator_dependencies() using CRD_TO_OPERATOR from crd_layering.py.
+    # vault -> external-secrets ordering is enforced by CRD layering checks in test_kustomize.py.
     _DependencyRule(
         prerequisite="cert-manager",
         must_come_before=["gateway", "authentik", "gitea", "harbor"],
@@ -33,120 +35,85 @@ _DEPENDENCY_RULES: list[_DependencyRule] = [
 ]
 
 
-def build_dependency_graph(flux_kustomizations: dict[str, FluxKustomization]) -> dict[str, list[str]]:
-    """Build dependency graph from flux kustomizations."""
-    graph: dict[str, list[str]] = defaultdict(list)
-    for name, kust in flux_kustomizations.items():
-        for dep in kust.spec.depends_on:
-            graph[dep.name].append(name)
-    return dict(graph)
+class CyclicDependencyError(Exception):
+    """Raised when a circular dependency is detected in the Flux kustomization graph."""
 
 
-def find_cycles(graph: dict[str, list[str]], all_nodes: set[str]) -> list[list[str]]:
-    """Find cycles in dependency graph using DFS."""
-    unvisited, in_progress, done = 0, 1, 2
-    color = dict.fromkeys(all_nodes, unvisited)
-    cycles = []
-
-    def dfs(node: str, path: list[str]) -> None:
-        if color[node] == in_progress:
-            cycle_start = path.index(node)
-            cycles.append([*path[cycle_start:], node])
-            return
-        if color[node] == done:
-            return
-
-        color[node] = in_progress
-        path.append(node)
-        for neighbor in graph.get(node, []):
-            dfs(neighbor, path)
-        path.pop()
-        color[node] = done
-
-    for node in all_nodes:
-        if color[node] == unvisited:
-            dfs(node, [])
-
-    return cycles
+def assert_no_cycles(g: nx.DiGraph) -> None:
+    """Raise CyclicDependencyError if the graph contains any cycle."""
+    cycle = next(nx.simple_cycles(g), None)
+    if cycle is not None:
+        raise CyclicDependencyError(f"Circular dependency: {' -> '.join([*cycle, cycle[0]])}")
 
 
-def check_required_dependencies(flux_kustomizations: dict[str, FluxKustomization]) -> list[str]:
+def check_required_dependencies(cluster: ParsedCluster) -> list[str]:
     """Check that critical dependencies are correctly set up."""
     errors = []
-
-    # Build dependency lookup
-    depends_on_map: dict[str, list[str]] = {}
-    for name, kust in flux_kustomizations.items():
-        depends_on_map[name] = [dep.name for dep in kust.spec.depends_on]
-
-    def has_dependency_path(from_kust: str, to_kust: str, visited: set[str] | None = None) -> bool:
-        if visited is None:
-            visited = set()
-        if to_kust in visited:
-            return False
-        if from_kust == to_kust:
-            return True
-        visited.add(to_kust)
-        return any(has_dependency_path(from_kust, dep, visited) for dep in depends_on_map.get(to_kust, []))
+    g = cluster.graph
 
     for rule in _DEPENDENCY_RULES:
-        if rule.prerequisite not in flux_kustomizations:
+        if rule.prerequisite not in cluster.flux_kustomizations:
             raise ValueError(f"Dependency rule references unknown kustomization: {rule.prerequisite}")
         for dependent in rule.must_come_before:
-            if dependent not in flux_kustomizations:
+            if dependent not in cluster.flux_kustomizations:
                 continue
-            if rule.prerequisite not in depends_on_map.get(dependent, []):
-                has_transitive = any(
-                    has_dependency_path(rule.prerequisite, dep) for dep in depends_on_map.get(dependent, [])
-                )
-                if not has_transitive:
-                    errors.append(f"{dependent} should depend on {rule.prerequisite} ({rule.reason})")
+            if not nx.has_path(g, dependent, rule.prerequisite):
+                errors.append(f"{dependent} should depend on {rule.prerequisite} ({rule.reason})")
 
     return errors
 
 
-def validate_external_secrets_dependencies(cluster: ParsedCluster, k8s_dir: Path) -> list[str]:
-    """Validate external-secrets specific dependency patterns."""
+def _kust_name_for_file(file_path: Path, k8s_dir: Path) -> str | None:
+    """Return the top-level kustomization directory name for a source file."""
+    relative = file_path.relative_to(k8s_dir)
+    return relative.parts[0] if relative.parts else None
+
+
+def validate_operator_dependencies(
+    cluster: ParsedCluster, k8s_dir: Path, crd_to_operator: dict[str, str] | None = None
+) -> list[str]:
+    """Validate that kustomizations using CRD instances transitively depend on the managing operator.
+
+    Uses CRD_TO_OPERATOR from crd_layering.py as the source of truth for which CRD kinds
+    require which operator prerequisite.
+    """
+    if crd_to_operator is None:
+        crd_to_operator = CRD_TO_OPERATOR
+
     errors = []
-    services_with_external_secrets: set[str] = set()
+    g = cluster.graph
+    # Track (kust, operator) pairs already reported to avoid duplicate errors per file.
+    reported: set[tuple[str, str]] = set()
 
     for file_path, resources in cluster.source_resources.items():
         for resource in resources:
-            if resource.kind == "ExternalSecret" and resource.api_version.startswith("external-secrets.io"):
-                relative = file_path.relative_to(k8s_dir)
-                service_name = relative.parts[0] if relative.parts else None
-                if service_name:
-                    services_with_external_secrets.add(service_name)
-
-    for service in services_with_external_secrets:
-        if service in cluster.flux_kustomizations:
-            deps = [dep.name for dep in cluster.flux_kustomizations[service].spec.depends_on]
-            if "external-secrets-config" not in deps:
-                errors.append(f"{service} uses ExternalSecret resources but doesn't depend on external-secrets-config")
+            operator = crd_to_operator.get(resource.kind)
+            if operator is None:
+                continue
+            service = _kust_name_for_file(file_path, k8s_dir)
+            if not service or service not in cluster.flux_kustomizations:
+                continue
+            key = (service, operator)
+            if key in reported:
+                continue
+            if operator not in g or not nx.has_path(g, service, operator):
+                errors.append(f"{service} uses {resource.kind} resources but doesn't transitively depend on {operator}")
+                reported.add(key)
 
     return errors
 
 
 def validate_dependencies(cluster: ParsedCluster, k8s_dir: Path) -> list[str]:
-    """Validate GitOps dependency graph."""
-    errors = []
+    """Validate GitOps dependency graph.
 
+    Raises CyclicDependencyError if any circular dependency is detected.
+    """
     if not cluster.flux_kustomizations:
-        errors.append("No Flux kustomizations found")
-        return errors
+        return ["No Flux kustomizations found"]
 
-    graph = build_dependency_graph(cluster.flux_kustomizations)
-    all_nodes = (
-        set(cluster.flux_kustomizations.keys()) | set().union(*graph.values())
-        if graph
-        else set(cluster.flux_kustomizations.keys())
-    )
+    assert_no_cycles(cluster.graph)
 
-    cycles = find_cycles(graph, all_nodes)
-    for cycle in cycles:
-        errors.append(f"Circular dependency: {' → '.join(cycle)}")
-
-    errors.extend(check_required_dependencies(cluster.flux_kustomizations))
-    errors.extend(validate_external_secrets_dependencies(cluster, k8s_dir))
-
+    errors = []
+    errors.extend(check_required_dependencies(cluster))
+    errors.extend(validate_operator_dependencies(cluster, k8s_dir))
     return errors

--- a/cluster/validation/test_dependencies.py
+++ b/cluster/validation/test_dependencies.py
@@ -7,49 +7,86 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from cluster.validation.dependencies import build_dependency_graph, check_required_dependencies, find_cycles
+from cluster.validation.cluster import ParsedCluster
+from cluster.validation.dependencies import (
+    CyclicDependencyError,
+    assert_no_cycles,
+    check_required_dependencies,
+    validate_operator_dependencies,
+)
 from cluster.validation.flux import DependsOn, FluxKustomization, FluxKustomizationSpec
+from cluster.validation.k8s import K8sResource
+
+
+def _cluster(
+    flux_kustomizations: dict[str, FluxKustomization], source_resources: dict[Path, list[tuple[str, str]]] | None = None
+) -> ParsedCluster:
+    return ParsedCluster(
+        flux_kustomizations=flux_kustomizations,
+        source_resources={
+            p: [K8sResource(kind=kind, apiVersion=api) for kind, api in rs]
+            for p, rs in (source_resources or {}).items()
+        },
+    )
 
 
 class TestDependencyGraph:
     """Tests for dependency graph building and cycle detection."""
 
     def test_builds_graph_from_kustomizations(self) -> None:
-        """Builds correct dependency graph."""
-        kustomizations = {
-            "app-a": FluxKustomization(
-                name="app-a",
-                file_path=Path("./k8s/app-a"),
-                spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core")]),
-            ),
-            "app-b": FluxKustomization(
-                name="app-b",
-                file_path=Path("./k8s/app-b"),
-                spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core"), DependsOn(name="app-a")]),
-            ),
-            "core": FluxKustomization(name="core", file_path=Path("./k8s/core")),
-        }
-        graph = build_dependency_graph(kustomizations)
+        """Builds correct directed graph: edges run from dependent -> prerequisite."""
+        cluster = _cluster(
+            {
+                "app-a": FluxKustomization(
+                    name="app-a",
+                    file_path=Path("./k8s/app-a"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core")]),
+                ),
+                "app-b": FluxKustomization(
+                    name="app-b",
+                    file_path=Path("./k8s/app-b"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core"), DependsOn(name="app-a")]),
+                ),
+                "core": FluxKustomization(name="core", file_path=Path("./k8s/core")),
+            }
+        )
 
-        assert set(graph["core"]) == {"app-a", "app-b"}
-        assert graph["app-a"] == ["app-b"]
+        assert set(cluster.graph.predecessors("core")) == {"app-a", "app-b"}
+        assert set(cluster.graph.predecessors("app-a")) == {"app-b"}
 
     def test_detects_cycle(self) -> None:
         """Detects circular dependencies."""
-        graph = {"a": ["b"], "b": ["a"]}
-        all_nodes = {"a", "b"}
-        cycles = find_cycles(graph, all_nodes)
-        assert len(cycles) > 0
-        cycle_nodes = set(cycles[0])
-        assert "a" in cycle_nodes
-        assert "b" in cycle_nodes
+        cluster = _cluster(
+            {
+                "a": FluxKustomization(
+                    name="a", file_path=Path("./k8s/a"), spec=FluxKustomizationSpec(depends_on=[DependsOn(name="b")])
+                ),
+                "b": FluxKustomization(
+                    name="b", file_path=Path("./k8s/b"), spec=FluxKustomizationSpec(depends_on=[DependsOn(name="a")])
+                ),
+            }
+        )
+        with pytest.raises(CyclicDependencyError, match="a"):
+            assert_no_cycles(cluster.graph)
 
     def test_no_cycle_in_dag(self) -> None:
         """No false positives for valid DAGs."""
-        graph = {"core": ["app-a", "app-b"], "app-a": ["app-b"]}
-        all_nodes = {"core", "app-a", "app-b"}
-        cycles = find_cycles(graph, all_nodes)
-        assert cycles == []
+        cluster = _cluster(
+            {
+                "core": FluxKustomization(name="core", file_path=Path("./k8s/core")),
+                "app-a": FluxKustomization(
+                    name="app-a",
+                    file_path=Path("./k8s/app-a"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core")]),
+                ),
+                "app-b": FluxKustomization(
+                    name="app-b",
+                    file_path=Path("./k8s/app-b"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="core"), DependsOn(name="app-a")]),
+                ),
+            }
+        )
+        assert_no_cycles(cluster.graph)  # should not raise
 
 
 class TestRequiredDependencies:
@@ -57,43 +94,105 @@ class TestRequiredDependencies:
 
     def test_detects_missing_dependency(self) -> None:
         """Detects when authentik is missing cert-manager dependency."""
-        kustomizations = {
-            "authentik": FluxKustomization(name="authentik", file_path=Path("./k8s/authentik")),
-            "cert-manager": FluxKustomization(name="cert-manager", file_path=Path("./k8s/cert-manager")),
-            "gateway": FluxKustomization(
-                name="gateway",
-                file_path=Path("./k8s/gateway"),
-                spec=FluxKustomizationSpec(depends_on=[DependsOn(name="cert-manager")]),
-            ),
-        }
-        errors = check_required_dependencies(kustomizations)
-        matching = [e for e in errors if "authentik" in e and "cert-manager" in e]
-        assert len(matching) > 0
+        cluster = _cluster(
+            {
+                "authentik": FluxKustomization(name="authentik", file_path=Path("./k8s/authentik")),
+                "cert-manager": FluxKustomization(name="cert-manager", file_path=Path("./k8s/cert-manager")),
+                "gateway": FluxKustomization(
+                    name="gateway",
+                    file_path=Path("./k8s/gateway"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="cert-manager")]),
+                ),
+            }
+        )
+        errors = check_required_dependencies(cluster)
+        assert any("authentik" in e and "cert-manager" in e for e in errors)
 
     def test_accepts_valid_dependencies(self) -> None:
         """No errors when required dependencies are present."""
-        kustomizations = {
-            "authentik": FluxKustomization(
-                name="authentik",
-                file_path=Path("./k8s/authentik"),
-                spec=FluxKustomizationSpec(depends_on=[DependsOn(name="gateway"), DependsOn(name="cert-manager")]),
-            ),
-            "gateway": FluxKustomization(
-                name="gateway",
-                file_path=Path("./k8s/gateway"),
-                spec=FluxKustomizationSpec(depends_on=[DependsOn(name="cert-manager")]),
-            ),
-            "cert-manager": FluxKustomization(name="cert-manager", file_path=Path("./k8s/cert-manager")),
-        }
-        errors = check_required_dependencies(kustomizations)
-        authentik_errors = [e for e in errors if "authentik" in e]
-        assert len(authentik_errors) == 0
+        cluster = _cluster(
+            {
+                "authentik": FluxKustomization(
+                    name="authentik",
+                    file_path=Path("./k8s/authentik"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="gateway"), DependsOn(name="cert-manager")]),
+                ),
+                "gateway": FluxKustomization(
+                    name="gateway",
+                    file_path=Path("./k8s/gateway"),
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="cert-manager")]),
+                ),
+                "cert-manager": FluxKustomization(name="cert-manager", file_path=Path("./k8s/cert-manager")),
+            }
+        )
+        errors = check_required_dependencies(cluster)
+        assert not any("authentik" in e for e in errors)
 
     def test_raises_on_unknown_prerequisite(self) -> None:
         """Raises ValueError when a rule references a kustomization not in the cluster."""
-        kustomizations = {"authentik": FluxKustomization(name="authentik", file_path=Path("./k8s/authentik"))}
+        cluster = _cluster({"authentik": FluxKustomization(name="authentik", file_path=Path("./k8s/authentik"))})
         with pytest.raises(ValueError, match="unknown kustomization: cert-manager"):
-            check_required_dependencies(kustomizations)
+            check_required_dependencies(cluster)
+
+
+class TestValidateOperatorDependencies:
+    """Tests for validate_operator_dependencies."""
+
+    def test_direct_dep_passes(self, tmp_path: Path) -> None:
+        """Kustomization with direct dep on operator passes."""
+        k8s_dir = tmp_path / "k8s"
+        cluster = _cluster(
+            {
+                "my-app": FluxKustomization(
+                    name="my-app",
+                    file_path=k8s_dir / "my-app",
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="some-operator")]),
+                ),
+                "some-operator": FluxKustomization(name="some-operator", file_path=k8s_dir / "some-operator"),
+            },
+            {k8s_dir / "my-app" / "resource.yaml": [("MyCRD", "example.com/v1")]},
+        )
+        assert validate_operator_dependencies(cluster, k8s_dir, {"MyCRD": "some-operator"}) == []
+
+    def test_transitive_dep_passes(self, tmp_path: Path) -> None:
+        """Transitive dependency (app -> middle -> operator) is accepted."""
+        k8s_dir = tmp_path / "k8s"
+        cluster = _cluster(
+            {
+                "my-app": FluxKustomization(
+                    name="my-app",
+                    file_path=k8s_dir / "my-app",
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="middle")]),
+                ),
+                "middle": FluxKustomization(
+                    name="middle",
+                    file_path=k8s_dir / "middle",
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="some-operator")]),
+                ),
+                "some-operator": FluxKustomization(name="some-operator", file_path=k8s_dir / "some-operator"),
+            },
+            {k8s_dir / "my-app" / "resource.yaml": [("MyCRD", "example.com/v1")]},
+        )
+        errors = validate_operator_dependencies(cluster, k8s_dir, {"MyCRD": "some-operator"})
+        assert errors == [], f"Unexpected errors for transitive dep: {errors}"
+
+    def test_missing_dep_fails(self, tmp_path: Path) -> None:
+        """Kustomization with no path to operator is flagged."""
+        k8s_dir = tmp_path / "k8s"
+        cluster = _cluster(
+            {
+                "my-app": FluxKustomization(
+                    name="my-app",
+                    file_path=k8s_dir / "my-app",
+                    spec=FluxKustomizationSpec(depends_on=[DependsOn(name="unrelated")]),
+                ),
+                "some-operator": FluxKustomization(name="some-operator", file_path=k8s_dir / "some-operator"),
+                "unrelated": FluxKustomization(name="unrelated", file_path=k8s_dir / "unrelated"),
+            },
+            {k8s_dir / "my-app" / "resource.yaml": [("MyCRD", "example.com/v1")]},
+        )
+        errors = validate_operator_dependencies(cluster, k8s_dir, {"MyCRD": "some-operator"})
+        assert any("my-app" in e and "some-operator" in e for e in errors)
 
 
 if __name__ == "__main__":

--- a/cluster/validation/test_flux.py
+++ b/cluster/validation/test_flux.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from textwrap import dedent
-
+import pytest
 import pytest_bazel
 
-from cluster.validation.dependencies import build_dependency_graph, find_cycles
+from cluster.validation.cluster import ParsedCluster
+from cluster.validation.dependencies import CyclicDependencyError, assert_no_cycles
 from cluster.validation.flux import parse_flux_kustomization
 from util.bazel.runfiles import get_required_path
 
@@ -15,43 +14,26 @@ from util.bazel.runfiles import get_required_path
 class TestParseFluxKustomization:
     """Tests for parsing flux-kustomization.yaml files."""
 
-    def test_parses_valid_kustomization(self, tmp_path: Path) -> None:
-        """Parses flux-kustomization.yaml correctly."""
-        kust_file = tmp_path / "flux-kustomization.yaml"
-        kust_file.write_text(
-            dedent("""
-            apiVersion: kustomize.toolkit.fluxcd.io/v1
-            kind: Kustomization
-            metadata:
-              name: test-app
-              namespace: flux-system
-            spec:
-              interval: 10m
-              path: ./k8s/test-app
-              dependsOn:
-                - name: core
-        """)
-        )
+    def test_parses_valid_kustomization(self) -> None:
+        """Parses a real flux-kustomization.yaml manifest correctly."""
+        kust_file = get_required_path("_main/cluster/validation/testdata/valid/flux-kustomization.yaml")
         kustomizations = parse_flux_kustomization(kust_file)
         assert len(kustomizations) == 1
         assert kustomizations[0].name == "test-app"
         assert len(kustomizations[0].spec.depends_on) == 1
-        assert kustomizations[0].spec.depends_on[0].name == "core"
+        assert kustomizations[0].spec.depends_on[0].name == "external-secrets-config"
 
-    def test_loads_cycle_testdata(self) -> None:
-        """Loads cycle testdata and detects the cycle."""
+    def test_cycle_manifests_raise(self) -> None:
+        """Cycle testdata manifests are detected as a circular dependency."""
         testdata_dir = get_required_path("_main/cluster/validation/testdata/cycle")
-
         kustomizations = {}
         for flux_file in testdata_dir.rglob("flux-kustomization.yaml"):
             for kust in parse_flux_kustomization(flux_file):
                 kustomizations[kust.name] = kust
 
-        graph = build_dependency_graph(kustomizations)
-        all_nodes = set(kustomizations.keys()) | set().union(*graph.values()) if graph else set(kustomizations.keys())
-        cycles = find_cycles(graph, all_nodes)
-
-        assert len(cycles) > 0, "Should detect cycle between cycle-a and cycle-b"
+        cluster = ParsedCluster(flux_kustomizations=kustomizations)
+        with pytest.raises(CyclicDependencyError):
+            assert_no_cycles(cluster.graph)
 
 
 if __name__ == "__main__":

--- a/mypy.ini
+++ b/mypy.ini
@@ -90,8 +90,16 @@ ignore_errors = True
 [mypy-absl.*]
 ignore_errors = True
 
-# numpy bundled stubs have internal override/overload conflicts
+# numpy bundled stubs have internal override/overload conflicts.
+# ignore_missing_imports is needed because types-networkx stubs import numpy
+# in the rules_mypy stubs virtualenv where numpy may not be resolved.
 [mypy-numpy.*]
+ignore_errors = True
+ignore_missing_imports = True
+
+# types-networkx stubs have stale # type: ignore[misc] comments that should use
+# [overload-overlap] — upstream bug in the stubs package.
+[mypy-networkx.*]
 ignore_errors = True
 
 # aiodocker has no type stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ dependencies = [
     # Visualization
     "plotnine>=0.13.0",
     "matplotlib",
+    "networkx>=3.0",
+    "types-networkx",
 
 
     # Jupyter

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -2731,6 +2731,10 @@ nest-asyncio==1.6.0 \
     # via
     #   ducktape (pyproject.toml)
     #   ipykernel
+networkx==3.6.1 \
+    --hash=sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509 \
+    --hash=sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762
+    # via ducktape (pyproject.toml)
 nodeenv==1.10.0 \
     --hash=sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827 \
     --hash=sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb
@@ -2820,6 +2824,7 @@ numpy==2.4.2 \
     #   plotnine
     #   scipy
     #   statsmodels
+    #   types-networkx
 oauthlib==3.3.1 \
     --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
     --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
@@ -5206,6 +5211,10 @@ types-jsonschema==4.26.0.20260202 \
 types-markdown==3.10.2.20260211 \
     --hash=sha256:2d94d08587e3738203b3c4479c449845112b171abe8b5cadc9b0c12fcf3e99da \
     --hash=sha256:66164310f88c11a58c6c706094c6f8c537c418e3525d33b76276a5fbd66b01ce
+    # via ducktape (pyproject.toml)
+types-networkx==3.6.1.20260303 \
+    --hash=sha256:754c7c7bcaab3c317b0b86441240c0a5bd0d2f419aba80a88e9718248a5c89af \
+    --hash=sha256:8248aa6fcadc08bd7992af6e412bfc5cfa043bda5ce7ab407fa591c808ce8557
     # via ducktape (pyproject.toml)
 types-paramiko==4.0.0.20250822 \
     --hash=sha256:1b56b0cbd3eec3d2fd123c9eb2704e612b777e15a17705a804279ea6525e0c53 \


### PR DESCRIPTION
## Summary
Refactored the dependency validation system to use NetworkX for graph operations instead of custom implementations. This improves code maintainability and enables more sophisticated dependency analysis, particularly for validating CRD-based operator dependencies.

## Key Changes

### Core Refactoring
- **Replaced custom graph implementation with NetworkX**: Migrated from manual dictionary-based graph representation to `nx.DiGraph` for cleaner, more robust graph operations
- **Converted ParsedCluster to dataclass**: Changed from Pydantic `BaseModel` to Python `@dataclass` with automatic graph construction in `__post_init__`
- **Simplified cycle detection**: Replaced custom DFS-based cycle finding with `nx.simple_cycles()`, raising new `CyclicDependencyError` exception
- **Improved path checking**: Used `nx.has_path()` for transitive dependency validation instead of manual recursive traversal

### New Operator Dependency Validation
- **Added `validate_operator_dependencies()` function**: Validates that kustomizations using CRD instances (e.g., ServiceMonitor, PodMonitor, SealedSecret) transitively depend on the managing operator
- **Integrated CRD-to-operator mapping**: Uses `CRD_TO_OPERATOR` from `crd_layering.py` as source of truth for operator prerequisites
- **Replaced `validate_external_secrets_dependencies()`**: Generalized the external-secrets-specific logic into a flexible CRD-based system

### Enhanced CRD Layering
- **Expanded CRD_TO_OPERATOR mapping** with new operators and CRD kinds:
  - `sealed-secrets`: SealedSecret
  - `monitoring-stack`: ServiceMonitor, PodMonitor
  - `cnpg`: Cluster, Backup, ScheduledBackup, Pooler, etc.
  - `vpa`: VerticalPodAutoscaler, VerticalPodAutoscalerCheckpoint
  - `node-feature-discovery`: NodeFeatureRule, NodeFeature, NodeFeatureGroup
  - `openclaw-operator`: OpenClawInstance, OpenClawSelfConfig
  - `flux-image-automation`: ImageRepository, ImagePolicy, ImageUpdateAutomation
  - Added missing CRDs for `powerdns-operator` (Zone, RRset)

### Cluster Configuration Updates
- **Added monitoring ServiceMonitors/PodMonitors**:
  - `gitea-servicemonitor`: Monitors Gitea metrics
  - `authentik-servicemonitor`: Monitors Authentik via PodMonitor
  - `vault/servicemonitor`: Monitors Vault metrics
- **Enabled monitoring in applications**:
  - Cert-manager: Enabled ServiceMonitor
  - Alloy: Enabled ServiceMonitor
  - PostgreSQL clusters: Enabled PodMonitor for authentik-db, headscale-db, powerdns-db, props-db
  - Gitea: Added metrics configuration
  - Vault: Enabled unauthenticated metrics access with Prometheus retention

## Implementation Details
- Graph edges run from dependent → prerequisite (A→B means A depends on B)
- Transitive dependencies are now properly validated using graph path algorithms
- Error messages are consistent and informative
- Tests updated to use new API and validate both direct and transitive dependencies
- Type hints improved with NetworkX type stubs (`types-networkx`)

https://claude.ai/code/session_01GobWqsKPjMLo5s6SWKY6iA