### PR TITLE
Add Talos readonly client configuration with os:reader RBAC role

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -36,6 +36,10 @@ See <changelog.md> for detailed change history.
 - [ ] **Plaid integration: fix onboarding** — `link/token/create` returns 400.
       Plaid's production onboarding process is involved (redirect URI registration,
       per-product approval, environment-specific keys). Revisit when needed.
+- [ ] **Deploy readonly Talos credentials into cluster** — Store the `os:reader`
+      talosconfig (generated in `talos-reader-config.tf`) into Vault, then create
+      ExternalSecrets in `claude-sandbox-secrets/` and `openclaw-sandbox-secrets/` so
+      both sandbox namespaces can read Talos cluster state.
 - [ ] **Grocy: provision API token for agent access**
 - [x] **Harbor: co-locate core and Redis on same node** — Harbor core crashes on startup
       when Redis is on a different node and Cilium hasn't fully programmed the cross-node

--- a/cluster/terraform/bootstrap/infrastructure/outputs.tf
+++ b/cluster/terraform/bootstrap/infrastructure/outputs.tf
@@ -32,6 +32,12 @@ output "talos_config" {
   sensitive   = true
 }
 
+output "talos_reader_config" {
+  description = "Talos readonly client configuration (os:reader role)"
+  value       = local.talos_reader_config
+  sensitive   = true
+}
+
 # ============================================================================
 # CLUSTER INFORMATION
 # ============================================================================

--- a/cluster/terraform/bootstrap/infrastructure/talos-reader-config.tf
+++ b/cluster/terraform/bootstrap/infrastructure/talos-reader-config.tf
@@ -1,0 +1,51 @@
+# Talos readonly client configuration (os:reader role)
+#
+# The talos_client_configuration data source always generates os:admin certs.
+# To produce an os:reader cert we sign our own client certificate with the
+# Talos OS CA, setting Organization = "os:reader" (how Talos encodes RBAC roles
+# in X.509 — see https://docs.siderolabs.com/talos/v1.9/security/rbac).
+
+resource "tls_private_key" "talos_reader" {
+  algorithm = "ED25519"
+}
+
+resource "tls_cert_request" "talos_reader" {
+  private_key_pem = tls_private_key.talos_reader.private_key_pem
+
+  subject {
+    organization = "os:reader"
+  }
+}
+
+resource "tls_locally_signed_cert" "talos_reader" {
+  cert_request_pem   = tls_cert_request.talos_reader.cert_request_pem
+  ca_private_key_pem = base64decode(talos_machine_secrets.cluster.machine_secrets.certs.os.key)
+  ca_cert_pem        = base64decode(talos_machine_secrets.cluster.machine_secrets.certs.os.cert)
+
+  validity_period_hours = 8760 # 1 year
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "client_auth",
+  ]
+}
+
+locals {
+  talos_reader_config = yamlencode({
+    context = var.cluster_name
+    contexts = {
+      (var.cluster_name) = {
+        endpoints = local.all_controlplane_ips
+        ca        = talos_machine_secrets.cluster.machine_secrets.certs.os.cert
+        crt       = base64encode(tls_locally_signed_cert.talos_reader.cert_pem)
+        key       = base64encode(tls_private_key.talos_reader.private_key_pem)
+      }
+    }
+  })
+}
+
+resource "local_file" "talosconfig_reader" {
+  content  = local.talos_reader_config
+  filename = "${path.module}/talosconfig-reader.yml"
+}

--- a/cluster/terraform/bootstrap/infrastructure/talos-reader-config.tf
+++ b/cluster/terraform/bootstrap/infrastructure/talos-reader-config.tf
@@ -49,3 +49,9 @@ resource "local_file" "talosconfig_reader" {
   content  = local.talos_reader_config
   filename = "${path.module}/talosconfig-reader.yml"
 }
+
+# TODO: Deploy the readonly Talos credentials into the cluster as a K8s Secret,
+# readable by openclaw-sandbox and claude-sandbox namespaces. Pattern: store the
+# reader config in Vault (via Terraform output → Vault KV), then use ExternalSecrets
+# in claude-sandbox-secrets/ and openclaw-sandbox-secrets/ to read it into each
+# namespace (following the existing Vault → ESO pattern used for other shared secrets).


### PR DESCRIPTION
## Summary
This PR adds support for generating and managing Talos readonly client credentials with the `os:reader` RBAC role, enabling read-only access to cluster state without admin privileges.

## Key Changes
- **New Terraform module** (`talos-reader-config.tf`): Generates a readonly Talos client certificate signed by the cluster's OS CA with `Organization = "os:reader"` to enforce RBAC restrictions
  - Creates ED25519 private key and certificate signing request
  - Signs certificate using existing Talos OS CA credentials
  - Generates YAML configuration file (`talosconfig-reader.yml`) with readonly credentials
- **New Terraform output** (`outputs.tf`): Exports the readonly talosconfig for downstream consumption
- **Updated plan** (`plan.md`): Documents the next step of deploying these credentials into the cluster via Vault and ExternalSecrets

## Implementation Details
The solution leverages Talos's X.509-based RBAC system where roles are encoded in certificate Organization fields. Rather than using the `talos_client_configuration` data source (which only generates admin certs), we manually sign a certificate with `Organization = "os:reader"` using the cluster's existing CA. The generated config is written to a local file and exposed as a Terraform output for integration with the cluster's secret management pipeline (Vault + ExternalSecrets).

A TODO comment outlines the planned deployment pattern: store credentials in Vault, then use ExternalSecrets to distribute them to sandbox namespaces that need read-only cluster access.

https://claude.ai/code/session_01MJ51Z1UcaUxKbwBCDD2MTZ