### PR TITLE
Refactor imports to use x. namespace prefix across codebase

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,10 @@
 # gazelle:python_generation_mode file
 # gazelle:python_default_visibility NONE
 # gazelle:python_manifest_file_name devinfra/gazelle_python.yaml
+# Map py_binary -> py_library globally: the codebase pattern is one py_library per .py file,
+# with py_binary targets named differently (using main_module). Prevents name conflicts when a
+# .py file with __main__ already has a py_library target of the same name.
+# gazelle:map_kind py_binary py_library @rules_python//python:defs.bzl
 #
 # Bazel-provided libraries (not from PyPI)
 # gazelle:resolve py rules_python.python.runfiles @rules_python//python/runfiles

--- a/agent_cli/BUILD.bazel
+++ b/agent_cli/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
+# gazelle:map_kind py_binary py_library cli.py
+
 py_library(
     name = "cli",
     srcs = ["cli.py"],

--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -2,6 +2,8 @@ load("@rules_python//python:defs.bzl", "py_library")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 
+# gazelle:exclude test_ollama_reasoning.py
+
 py_library(
     name = "pydantic_utils",
     srcs = ["pydantic_utils.py"],

--- a/devinfra/lint/BUILD.bazel
+++ b/devinfra/lint/BUILD.bazel
@@ -68,8 +68,7 @@ buildifier(
 
 # Go static analysis via rules_go nogo.
 # Runs go vet analyzers on every go_library/go_binary compile action.
-# TODO: Add third-party analyzers (staticcheck, errcheck) and a nogo_config.json
-# to exclude vendored code (devinfra/claude/web_env/re/).
+# TODO: Add third-party analyzers (staticcheck, errcheck).
 nogo(
     name = "nogo",
     vet = True,

--- a/laser/material_test/BUILD.bazel
+++ b/laser/material_test/BUILD.bazel
@@ -1,5 +1,8 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
+# gazelle:exclude material_test.py
+# gazelle:exclude test_material_test.py
+
 py_library(
     name = "material_test_lib",
     srcs = ["material_test.py"],

--- a/llm/ducktape_llm_common/scripts/BUILD.bazel
+++ b/llm/ducktape_llm_common/scripts/BUILD.bazel
@@ -1,0 +1,2 @@
+# gazelle:ignore
+# Manual test scripts not intended as Bazel targets.

--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -6,6 +6,8 @@ load("//devinfra/testing:defs.bzl", "py_test")
 load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
+# gazelle:exclude test_exec_roundtrip.py
+
 # Core models - no MCP dependencies, usable outside fastmcp
 py_library(
     name = "models",

--- a/openai_utils/BUILD.bazel
+++ b/openai_utils/BUILD.bazel
@@ -2,6 +2,9 @@ load("@rules_python//python:defs.bzl", "py_library")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 
+# gazelle:exclude test_live_api.py
+# gazelle:exclude test_pydantic_strict_mode.py
+
 py_library(
     name = "types",
     srcs = ["types.py"],

--- a/props/BUILD.bazel
+++ b/props/BUILD.bazel
@@ -1,4 +1,5 @@
 # Props workspace - top-level package
+# gazelle:exclude specimens
 
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_library")

--- a/props/specimens/BUILD.bazel
+++ b/props/specimens/BUILD.bazel
@@ -1,4 +1,4 @@
-# gazelle:python_generation_mode off
+# gazelle:ignore
 
 load("@rules_python//python:defs.bzl", "py_binary")
 

--- a/x/claude_linter/BUILD.bazel
+++ b/x/claude_linter/BUILD.bazel
@@ -4,7 +4,6 @@ load("//devinfra/testing:defs.bzl", "py_test")
 py_library(
     name = "cli",
     srcs = ["cli.py"],
-    imports = [".."],
     visibility = ["//visibility:public"],
     deps = [
         ":config",
@@ -20,7 +19,6 @@ py_library(
 py_library(
     name = "config",
     srcs = ["config.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//platformdirs",
@@ -31,7 +29,6 @@ py_library(
 py_library(
     name = "models",
     srcs = ["models.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -42,7 +39,6 @@ py_library(
 py_library(
     name = "precommit_runner",
     srcs = ["precommit_runner.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//util/bazel:subprocess",
@@ -55,7 +51,6 @@ py_library(
 py_binary(
     name = "claude_linter",
     srcs = ["cli.py"],
-    imports = [".."],
     main = "cli.py",
     deps = [
         ":cli",
@@ -73,7 +68,6 @@ py_library(
     name = "conftest",
     testonly = True,
     srcs = ["conftest.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//pygit2",
@@ -85,7 +79,6 @@ py_library(
 py_test(
     name = "test_claude_linter",
     srcs = ["test_claude_linter.py"],
-    imports = [".."],
     main = "test_claude_linter.py",
     deps = [
         ":cli",
@@ -98,7 +91,6 @@ py_test(
 py_test(
     name = "test_claude_post_hook",
     srcs = ["test_claude_post_hook.py"],
-    imports = [".."],
     deps = [
         ":cli",
         ":conftest",
@@ -112,7 +104,6 @@ py_test(
 py_test(
     name = "test_claude_pre_hook",
     srcs = ["test_claude_pre_hook.py"],
-    imports = [".."],
     deps = [
         ":cli",
         ":conftest",
@@ -125,7 +116,6 @@ py_test(
 py_test(
     name = "test_hooks",
     srcs = ["test_hooks.py"],
-    imports = [".."],
     deps = [
         ":cli",
         ":conftest",

--- a/x/claude_linter/BUILD.bazel
+++ b/x/claude_linter/BUILD.bazel
@@ -4,6 +4,7 @@ load("//devinfra/testing:defs.bzl", "py_test")
 py_library(
     name = "cli",
     srcs = ["cli.py"],
+    imports = ["../.."],
     visibility = ["//visibility:public"],
     deps = [
         ":config",
@@ -19,6 +20,7 @@ py_library(
 py_library(
     name = "config",
     srcs = ["config.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//platformdirs",
@@ -29,6 +31,7 @@ py_library(
 py_library(
     name = "models",
     srcs = ["models.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -39,6 +42,7 @@ py_library(
 py_library(
     name = "precommit_runner",
     srcs = ["precommit_runner.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//util/bazel:subprocess",
@@ -51,6 +55,7 @@ py_library(
 py_binary(
     name = "claude_linter",
     srcs = ["cli.py"],
+    imports = ["../.."],
     main = "cli.py",
     deps = [
         ":cli",
@@ -68,6 +73,7 @@ py_library(
     name = "conftest",
     testonly = True,
     srcs = ["conftest.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "@pypi//pygit2",
@@ -79,6 +85,7 @@ py_library(
 py_test(
     name = "test_claude_linter",
     srcs = ["test_claude_linter.py"],
+    imports = ["../.."],
     main = "test_claude_linter.py",
     deps = [
         ":cli",
@@ -91,6 +98,7 @@ py_test(
 py_test(
     name = "test_claude_post_hook",
     srcs = ["test_claude_post_hook.py"],
+    imports = ["../.."],
     deps = [
         ":cli",
         ":conftest",
@@ -104,6 +112,7 @@ py_test(
 py_test(
     name = "test_claude_pre_hook",
     srcs = ["test_claude_pre_hook.py"],
+    imports = ["../.."],
     deps = [
         ":cli",
         ":conftest",
@@ -116,6 +125,7 @@ py_test(
 py_test(
     name = "test_hooks",
     srcs = ["test_hooks.py"],
+    imports = ["../.."],
     deps = [
         ":cli",
         ":conftest",

--- a/x/claude_linter/cli.py
+++ b/x/claude_linter/cli.py
@@ -8,10 +8,10 @@ import click
 import platformdirs
 from pydantic import ValidationError
 
-from claude_linter.config import get_merged_config
-from claude_linter.models import HookRequest, LinterHookResponse
-from claude_linter.precommit_runner import PreCommitRunner
 from llm.claude_code_api import EditToolCall, MultiEditToolCall, WriteToolCall
+from x.claude_linter.config import get_merged_config
+from x.claude_linter.models import HookRequest, LinterHookResponse
+from x.claude_linter.precommit_runner import PreCommitRunner
 
 
 def get_cache_dir() -> Path:

--- a/x/claude_linter/test_claude_linter.py
+++ b/x/claude_linter/test_claude_linter.py
@@ -3,7 +3,7 @@
 import pytest_bazel
 from click.testing import CliRunner
 
-from claude_linter.cli import cli
+from x.claude_linter.cli import cli
 
 
 def run_claude_linter(args: list[str], input_text: str | None = None):

--- a/x/claude_linter/test_claude_post_hook.py
+++ b/x/claude_linter/test_claude_post_hook.py
@@ -10,7 +10,7 @@ import pytest_bazel
 import yaml
 from click.testing import CliRunner
 
-from claude_linter.cli import cli
+from x.claude_linter.cli import cli
 
 
 def run_post_hook(test_input: dict[str, Any]):

--- a/x/claude_linter/test_claude_pre_hook.py
+++ b/x/claude_linter/test_claude_pre_hook.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest_bazel
 from click.testing import CliRunner
 
-from claude_linter.cli import cli
-from claude_linter.precommit_runner import PreCommitRunner
+from x.claude_linter.cli import cli
+from x.claude_linter.precommit_runner import PreCommitRunner
 
 
 def run_pre_hook(test_input: str):

--- a/x/claude_linter/test_hooks.py
+++ b/x/claude_linter/test_hooks.py
@@ -7,7 +7,7 @@ import pytest_bazel
 import yaml
 from click.testing import CliRunner
 
-from claude_linter.cli import cli
+from x.claude_linter.cli import cli
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/BUILD.bazel
+++ b/x/claude_linter_v2/BUILD.bazel
@@ -4,7 +4,6 @@ load("//devinfra/testing:defs.bzl", "py_test")
 py_library(
     name = "check_python",
     srcs = ["check_python.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":pattern_matcher",
@@ -18,7 +17,6 @@ py_library(
 py_library(
     name = "checker",
     srcs = ["checker.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/config:loader",
@@ -32,7 +30,6 @@ py_library(
 py_library(
     name = "checkers_v2",
     srcs = ["checkers_v2.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":rule_registry",
@@ -44,7 +41,6 @@ py_library(
 py_library(
     name = "cli",
     srcs = ["cli.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":checker",
@@ -62,7 +58,6 @@ py_library(
 py_library(
     name = "conftest",
     srcs = ["conftest.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":types",
@@ -74,7 +69,6 @@ py_library(
 py_library(
     name = "llm_analyzer",
     srcs = ["llm_analyzer.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -85,14 +79,12 @@ py_library(
 py_library(
     name = "notifications",
     srcs = ["notifications.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "pattern_matcher",
     srcs = ["pattern_matcher.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -100,7 +92,6 @@ py_library(
 py_library(
     name = "rule_registry",
     srcs = ["rule_registry.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -108,7 +99,6 @@ py_library(
 py_library(
     name = "types",
     srcs = ["types.py"],
-    imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = ["//llm:claude_code_api"],
 )
@@ -116,7 +106,6 @@ py_library(
 py_binary(
     name = "claude_linter_v2",
     srcs = ["cli.py"],
-    imports = [".."],
     main = "cli.py",
     deps = [
         ":checker",
@@ -136,7 +125,6 @@ py_test(
     srcs = ["test_cl2_check.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":cli",
         ":conftest",
@@ -150,7 +138,6 @@ py_test(
 py_test(
     name = "test_diff_intelligence",
     srcs = ["test_diff_intelligence.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -165,7 +152,6 @@ py_test(
 py_test(
     name = "test_diff_intelligence_edge_cases",
     srcs = ["test_diff_intelligence_edge_cases.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -182,7 +168,6 @@ py_test(
     srcs = ["test_integration.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":cli",
         ":conftest",
@@ -196,7 +181,6 @@ py_test(
 py_test(
     name = "test_mcp_tools",
     srcs = ["test_mcp_tools.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         ":types",
@@ -213,7 +197,6 @@ py_test(
 py_test(
     name = "test_modular_config",
     srcs = ["test_modular_config.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         ":rule_registry",
@@ -226,7 +209,6 @@ py_test(
 py_test(
     name = "test_multiline_predicates",
     srcs = ["test_multiline_predicates.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         ":types",
@@ -240,7 +222,6 @@ py_test(
 py_test(
     name = "test_python_ast",
     srcs = ["test_python_ast.py"],
-    imports = [".."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/linters:python_ast",
@@ -253,7 +234,6 @@ py_test(
     srcs = ["test_python_formatter.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/config:models",
@@ -268,7 +248,6 @@ py_test(
     srcs = ["test_python_ruff.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/linters:python_ruff",
@@ -282,7 +261,6 @@ py_test(
     srcs = ["test_stop_hook_fresh_scan.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -300,7 +278,6 @@ py_test(
     srcs = ["test_stop_hook_gitignore.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -316,7 +293,6 @@ py_test(
     srcs = ["test_stop_hook_quality_gate.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    imports = [".."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/BUILD.bazel
+++ b/x/claude_linter_v2/BUILD.bazel
@@ -4,6 +4,7 @@ load("//devinfra/testing:defs.bzl", "py_test")
 py_library(
     name = "check_python",
     srcs = ["check_python.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":pattern_matcher",
@@ -17,6 +18,7 @@ py_library(
 py_library(
     name = "checker",
     srcs = ["checker.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/config:loader",
@@ -30,6 +32,7 @@ py_library(
 py_library(
     name = "checkers_v2",
     srcs = ["checkers_v2.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":rule_registry",
@@ -41,6 +44,7 @@ py_library(
 py_library(
     name = "cli",
     srcs = ["cli.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":checker",
@@ -58,6 +62,7 @@ py_library(
 py_library(
     name = "conftest",
     srcs = ["conftest.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":types",
@@ -69,6 +74,7 @@ py_library(
 py_library(
     name = "llm_analyzer",
     srcs = ["llm_analyzer.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -79,12 +85,14 @@ py_library(
 py_library(
     name = "notifications",
     srcs = ["notifications.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "pattern_matcher",
     srcs = ["pattern_matcher.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -92,6 +100,7 @@ py_library(
 py_library(
     name = "rule_registry",
     srcs = ["rule_registry.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -99,6 +108,7 @@ py_library(
 py_library(
     name = "types",
     srcs = ["types.py"],
+    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//llm:claude_code_api"],
 )
@@ -106,6 +116,7 @@ py_library(
 py_binary(
     name = "claude_linter_v2",
     srcs = ["cli.py"],
+    imports = ["../.."],
     main = "cli.py",
     deps = [
         ":checker",
@@ -125,6 +136,7 @@ py_test(
     srcs = ["test_cl2_check.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":cli",
         ":conftest",
@@ -138,6 +150,7 @@ py_test(
 py_test(
     name = "test_diff_intelligence",
     srcs = ["test_diff_intelligence.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -152,6 +165,7 @@ py_test(
 py_test(
     name = "test_diff_intelligence_edge_cases",
     srcs = ["test_diff_intelligence_edge_cases.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -168,6 +182,7 @@ py_test(
     srcs = ["test_integration.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":cli",
         ":conftest",
@@ -181,6 +196,7 @@ py_test(
 py_test(
     name = "test_mcp_tools",
     srcs = ["test_mcp_tools.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         ":types",
@@ -197,6 +213,7 @@ py_test(
 py_test(
     name = "test_modular_config",
     srcs = ["test_modular_config.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         ":rule_registry",
@@ -209,6 +226,7 @@ py_test(
 py_test(
     name = "test_multiline_predicates",
     srcs = ["test_multiline_predicates.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         ":types",
@@ -222,6 +240,7 @@ py_test(
 py_test(
     name = "test_python_ast",
     srcs = ["test_python_ast.py"],
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/linters:python_ast",
@@ -234,6 +253,7 @@ py_test(
     srcs = ["test_python_formatter.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/config:models",
@@ -248,6 +268,7 @@ py_test(
     srcs = ["test_python_ruff.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//x/claude_linter_v2/linters:python_ruff",
@@ -261,6 +282,7 @@ py_test(
     srcs = ["test_stop_hook_fresh_scan.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -278,6 +300,7 @@ py_test(
     srcs = ["test_stop_hook_gitignore.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",
@@ -293,6 +316,7 @@ py_test(
     srcs = ["test_stop_hook_quality_gate.py"],
     data = ["@multitool//tools/ruff"],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
+    imports = ["../.."],
     deps = [
         ":conftest",
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/access/BUILD.bazel
+++ b/x/claude_linter_v2/access/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "context",
     srcs = ["context.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2:types"],
 )
@@ -10,6 +11,7 @@ py_library(
 py_library(
     name = "evaluator",
     srcs = ["evaluator.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/access:context",
@@ -20,6 +22,7 @@ py_library(
 py_library(
     name = "rule_engine",
     srcs = ["rule_engine.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",

--- a/x/claude_linter_v2/access/BUILD.bazel
+++ b/x/claude_linter_v2/access/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "context",
     srcs = ["context.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2:types"],
 )
@@ -11,7 +10,6 @@ py_library(
 py_library(
     name = "evaluator",
     srcs = ["evaluator.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/access:context",
@@ -22,7 +20,6 @@ py_library(
 py_library(
     name = "rule_engine",
     srcs = ["rule_engine.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",

--- a/x/claude_linter_v2/access/context.py
+++ b/x/claude_linter_v2/access/context.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
-from claude_linter_v2.types import SessionID
+from x.claude_linter_v2.types import SessionID
 
 
 @dataclass

--- a/x/claude_linter_v2/access/evaluator.py
+++ b/x/claude_linter_v2/access/evaluator.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 
 from more_itertools import one
 
-from claude_linter_v2.access.context import PredicateContext
+from x.claude_linter_v2.access.context import PredicateContext
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/access/rule_engine.py
+++ b/x/claude_linter_v2/access/rule_engine.py
@@ -4,12 +4,12 @@ import logging
 from dataclasses import dataclass
 from enum import IntEnum
 
-from claude_linter_v2.access.context import PredicateContext
-from claude_linter_v2.access.evaluator import PredicateEvaluator
-from claude_linter_v2.config.clean_models import ModularConfig
-from claude_linter_v2.config.models import AccessControlRule, RuleAction
-from claude_linter_v2.session.manager import SessionManager
-from claude_linter_v2.types import SessionID
+from x.claude_linter_v2.access.context import PredicateContext
+from x.claude_linter_v2.access.evaluator import PredicateEvaluator
+from x.claude_linter_v2.config.clean_models import ModularConfig
+from x.claude_linter_v2.config.models import AccessControlRule, RuleAction
+from x.claude_linter_v2.session.manager import SessionManager
+from x.claude_linter_v2.types import SessionID
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/check_python.py
+++ b/x/claude_linter_v2/check_python.py
@@ -2,11 +2,11 @@
 
 from pathlib import Path
 
-from claude_linter_v2.config.clean_models import ModularConfig
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.linters.python_ast import PythonASTAnalyzer
-from claude_linter_v2.linters.python_ruff import PythonRuffLinter
-from claude_linter_v2.pattern_matcher import PatternMatcher
+from x.claude_linter_v2.config.clean_models import ModularConfig
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.linters.python_ast import PythonASTAnalyzer
+from x.claude_linter_v2.linters.python_ruff import PythonRuffLinter
+from x.claude_linter_v2.pattern_matcher import PatternMatcher
 
 
 def check_python_file(

--- a/x/claude_linter_v2/checker.py
+++ b/x/claude_linter_v2/checker.py
@@ -3,11 +3,11 @@
 import logging
 from pathlib import Path
 
-from claude_linter_v2.config.loader import ConfigLoader
-from claude_linter_v2.config.models import AutofixCategory, Violation
-from claude_linter_v2.linters.python_ast import PythonASTAnalyzer
-from claude_linter_v2.linters.python_formatter import PythonFormatter
-from claude_linter_v2.linters.python_ruff import PythonRuffLinter
+from x.claude_linter_v2.config.loader import ConfigLoader
+from x.claude_linter_v2.config.models import AutofixCategory, Violation
+from x.claude_linter_v2.linters.python_ast import PythonASTAnalyzer
+from x.claude_linter_v2.linters.python_formatter import PythonFormatter
+from x.claude_linter_v2.linters.python_ruff import PythonRuffLinter
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/checkers_v2.py
+++ b/x/claude_linter_v2/checkers_v2.py
@@ -2,9 +2,9 @@
 
 from typing import Literal
 
-from claude_linter_v2.config.clean_models import ModularConfig
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.rule_registry import RuleRegistry, map_violation_to_rule_key
+from x.claude_linter_v2.config.clean_models import ModularConfig
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.rule_registry import RuleRegistry, map_violation_to_rule_key
 
 
 def filter_violations(

--- a/x/claude_linter_v2/cli.py
+++ b/x/claude_linter_v2/cli.py
@@ -19,12 +19,12 @@ import click
 import humanize
 from pytimeparse import parse as parse_duration
 
-from claude_linter_v2.checker import FileChecker
-from claude_linter_v2.config.models import AutofixCategory
-from claude_linter_v2.hooks.exceptions import HookBugError
-from claude_linter_v2.hooks.handler import HOOK_REQUEST_TYPES, HookHandler
-from claude_linter_v2.session.manager import RuleAction, SessionInfo, SessionManager
 from llm.claude_code_api import SessionID
+from x.claude_linter_v2.checker import FileChecker
+from x.claude_linter_v2.config.models import AutofixCategory
+from x.claude_linter_v2.hooks.exceptions import HookBugError
+from x.claude_linter_v2.hooks.handler import HOOK_REQUEST_TYPES, HookHandler
+from x.claude_linter_v2.session.manager import RuleAction, SessionInfo, SessionManager
 
 __version__ = "2.0.0a1"
 

--- a/x/claude_linter_v2/config/BUILD.bazel
+++ b/x/claude_linter_v2/config/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "clean_models",
     srcs = ["clean_models.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:rule_registry",
@@ -16,6 +17,7 @@ py_library(
 py_library(
     name = "loader",
     srcs = ["loader.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:clean_models"],
 )
@@ -23,6 +25,7 @@ py_library(
 py_library(
     name = "models",
     srcs = ["models.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = ["@pypi//pydantic"],
 )

--- a/x/claude_linter_v2/config/BUILD.bazel
+++ b/x/claude_linter_v2/config/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "clean_models",
     srcs = ["clean_models.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:rule_registry",
@@ -17,7 +16,6 @@ py_library(
 py_library(
     name = "loader",
     srcs = ["loader.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:clean_models"],
 )
@@ -25,7 +23,6 @@ py_library(
 py_library(
     name = "models",
     srcs = ["models.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["@pypi//pydantic"],
 )

--- a/x/claude_linter_v2/config/clean_models.py
+++ b/x/claude_linter_v2/config/clean_models.py
@@ -10,7 +10,7 @@ import tomli
 import tomli_w
 from pydantic import BaseModel, Field
 
-from claude_linter_v2.config.models import (
+from x.claude_linter_v2.config.models import (
     AccessControlRule,
     AutofixCategory,
     LLMAnalysisConfig,
@@ -23,7 +23,7 @@ from claude_linter_v2.config.models import (
     SubagentStopHookConfig,
     TaskProfile,
 )
-from claude_linter_v2.rule_registry import RuleRegistry
+from x.claude_linter_v2.rule_registry import RuleRegistry
 
 
 class LogLevel(StrEnum):

--- a/x/claude_linter_v2/config/loader.py
+++ b/x/claude_linter_v2/config/loader.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import ClassVar
 
-from claude_linter_v2.config.clean_models import LogLevel, ModularConfig
+from x.claude_linter_v2.config.clean_models import LogLevel, ModularConfig
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/conftest.py
+++ b/x/claude_linter_v2/conftest.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pytest
 
-from claude_linter_v2.types import SessionID, parse_session_id
 from llm.claude_code_api import PostToolUseRequest, PreToolUseRequest
+from x.claude_linter_v2.types import SessionID, parse_session_id
 
 # Synthetic file path for tests that need a path but don't create real files
 TEST_FILE = Path("/test/file.py")

--- a/x/claude_linter_v2/diff/BUILD.bazel
+++ b/x/claude_linter_v2/diff/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "categorizer",
     srcs = ["categorizer.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/config:models",
@@ -13,6 +14,7 @@ py_library(
 py_library(
     name = "intelligence",
     srcs = ["intelligence.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -25,6 +27,7 @@ py_library(
 py_library(
     name = "parser",
     srcs = ["parser.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/diff/BUILD.bazel
+++ b/x/claude_linter_v2/diff/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "categorizer",
     srcs = ["categorizer.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2/config:models",
@@ -14,7 +13,6 @@ py_library(
 py_library(
     name = "intelligence",
     srcs = ["intelligence.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -27,7 +25,6 @@ py_library(
 py_library(
     name = "parser",
     srcs = ["parser.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/diff/categorizer.py
+++ b/x/claude_linter_v2/diff/categorizer.py
@@ -4,8 +4,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import StrEnum
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.diff.parser import ParsedDiff
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.diff.parser import ParsedDiff
 
 
 class ViolationCategory(StrEnum):

--- a/x/claude_linter_v2/diff/intelligence.py
+++ b/x/claude_linter_v2/diff/intelligence.py
@@ -3,10 +3,10 @@
 from collections import defaultdict
 from typing import Any
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategorizer, ViolationCategory
-from claude_linter_v2.diff.parser import parse_tool_response
 from llm.claude_code_api import EditToolCall, MultiEditToolCall
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategorizer, ViolationCategory
+from x.claude_linter_v2.diff.parser import parse_tool_response
 
 
 class DiffIntelligence:

--- a/x/claude_linter_v2/hooks/BUILD.bazel
+++ b/x/claude_linter_v2/hooks/BUILD.bazel
@@ -3,14 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "exceptions",
     srcs = ["exceptions.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "formatting",
     srcs = ["formatting.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -21,7 +19,6 @@ py_library(
 py_library(
     name = "handler",
     srcs = ["handler.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -53,7 +50,6 @@ py_library(
 py_library(
     name = "validation",
     srcs = ["validation.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/hooks/BUILD.bazel
+++ b/x/claude_linter_v2/hooks/BUILD.bazel
@@ -3,12 +3,14 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "exceptions",
     srcs = ["exceptions.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
 )
 
 py_library(
     name = "formatting",
     srcs = ["formatting.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -19,6 +21,7 @@ py_library(
 py_library(
     name = "handler",
     srcs = ["handler.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",
@@ -50,6 +53,7 @@ py_library(
 py_library(
     name = "validation",
     srcs = ["validation.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//llm:claude_code_api",

--- a/x/claude_linter_v2/hooks/formatting.py
+++ b/x/claude_linter_v2/hooks/formatting.py
@@ -2,8 +2,8 @@
 
 from string import Template
 
-from claude_linter_v2.config.models import Violation
 from llm.claude_code_api import SessionID
+from x.claude_linter_v2.config.models import Violation
 
 # Templates for different message types
 ACCESS_DENIAL_TEMPLATE = Template("""$message

--- a/x/claude_linter_v2/hooks/handler.py
+++ b/x/claude_linter_v2/hooks/handler.py
@@ -9,33 +9,6 @@ from typing import Any
 
 import platformdirs
 
-from claude_linter_v2.access.context import PredicateContext
-from claude_linter_v2.access.rule_engine import RuleEngine
-from claude_linter_v2.check_python import check_python_file
-from claude_linter_v2.checkers_v2 import filter_violations
-from claude_linter_v2.config.clean_models import ModularConfig
-from claude_linter_v2.config.loader import ConfigLoader
-from claude_linter_v2.config.models import (
-    AutofixCategory,
-    NotificationHookConfig,
-    PostToolHookConfig,
-    RuleAction,
-    StopHookConfig,
-    Violation,
-)
-from claude_linter_v2.diff.categorizer import ViolationCategory
-from claude_linter_v2.diff.intelligence import DiffIntelligence
-from claude_linter_v2.hooks.exceptions import HookBugError
-from claude_linter_v2.hooks.formatting import format_access_denial, format_llm_message
-from claude_linter_v2.hooks.validation import validate_hook_outcome
-from claude_linter_v2.linters.python_formatter import PythonFormatter
-from claude_linter_v2.llm_analyzer import LLMAnalyzer
-from claude_linter_v2.notifications import close_desktop_notification, send_desktop_notification
-from claude_linter_v2.pattern_matcher import PatternMatcher
-from claude_linter_v2.session.manager import SessionManager
-from claude_linter_v2.session.violations import ViolationTracker
-from claude_linter_v2.types import SessionID
-from claude_linter_v2.utils.gitignore import get_git_tracked_files
 from llm.claude_code_api import (
     BaseHookRequest,
     BaseResponse,
@@ -62,6 +35,33 @@ from llm.claude_outcomes import (
     StopPrevent,
     SubagentStopAllow,
 )
+from x.claude_linter_v2.access.context import PredicateContext
+from x.claude_linter_v2.access.rule_engine import RuleEngine
+from x.claude_linter_v2.check_python import check_python_file
+from x.claude_linter_v2.checkers_v2 import filter_violations
+from x.claude_linter_v2.config.clean_models import ModularConfig
+from x.claude_linter_v2.config.loader import ConfigLoader
+from x.claude_linter_v2.config.models import (
+    AutofixCategory,
+    NotificationHookConfig,
+    PostToolHookConfig,
+    RuleAction,
+    StopHookConfig,
+    Violation,
+)
+from x.claude_linter_v2.diff.categorizer import ViolationCategory
+from x.claude_linter_v2.diff.intelligence import DiffIntelligence
+from x.claude_linter_v2.hooks.exceptions import HookBugError
+from x.claude_linter_v2.hooks.formatting import format_access_denial, format_llm_message
+from x.claude_linter_v2.hooks.validation import validate_hook_outcome
+from x.claude_linter_v2.linters.python_formatter import PythonFormatter
+from x.claude_linter_v2.llm_analyzer import LLMAnalyzer
+from x.claude_linter_v2.notifications import close_desktop_notification, send_desktop_notification
+from x.claude_linter_v2.pattern_matcher import PatternMatcher
+from x.claude_linter_v2.session.manager import SessionManager
+from x.claude_linter_v2.session.violations import ViolationTracker
+from x.claude_linter_v2.types import SessionID
+from x.claude_linter_v2.utils.gitignore import get_git_tracked_files
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/hooks/validation.py
+++ b/x/claude_linter_v2/hooks/validation.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any
 
-from claude_linter_v2.hooks.exceptions import HookBugError
 from llm.claude_code_api import HookEventName
 from llm.claude_outcomes import (
     HookError,
@@ -19,6 +18,7 @@ from llm.claude_outcomes import (
     StopPrevent,
     SubagentStopAllow,
 )
+from x.claude_linter_v2.hooks.exceptions import HookBugError
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/linters/BUILD.bazel
+++ b/x/claude_linter_v2/linters/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "python_ast",
     srcs = ["python_ast.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -11,7 +10,6 @@ py_library(
 py_library(
     name = "python_formatter",
     srcs = ["python_formatter.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":ruff_binary",
@@ -22,7 +20,6 @@ py_library(
 py_library(
     name = "python_ruff",
     srcs = ["python_ruff.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":ruff_binary",
@@ -33,6 +30,5 @@ py_library(
 py_library(
     name = "ruff_binary",
     srcs = ["ruff_binary.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/x/claude_linter_v2/linters/BUILD.bazel
+++ b/x/claude_linter_v2/linters/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "python_ast",
     srcs = ["python_ast.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = ["//x/claude_linter_v2/config:models"],
 )
@@ -10,6 +11,7 @@ py_library(
 py_library(
     name = "python_formatter",
     srcs = ["python_formatter.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":ruff_binary",
@@ -20,6 +22,7 @@ py_library(
 py_library(
     name = "python_ruff",
     srcs = ["python_ruff.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         ":ruff_binary",
@@ -30,5 +33,6 @@ py_library(
 py_library(
     name = "ruff_binary",
     srcs = ["ruff_binary.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/x/claude_linter_v2/linters/python_ast.py
+++ b/x/claude_linter_v2/linters/python_ast.py
@@ -4,7 +4,7 @@ import ast
 import logging
 from pathlib import Path
 
-from claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.config.models import Violation
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/linters/python_formatter.py
+++ b/x/claude_linter_v2/linters/python_formatter.py
@@ -4,8 +4,8 @@ import logging
 import subprocess
 from pathlib import Path
 
-from claude_linter_v2.config.models import AutofixCategory
-from claude_linter_v2.linters.ruff_binary import find_ruff_binary
+from x.claude_linter_v2.config.models import AutofixCategory
+from x.claude_linter_v2.linters.ruff_binary import find_ruff_binary
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/linters/python_ruff.py
+++ b/x/claude_linter_v2/linters/python_ruff.py
@@ -6,8 +6,8 @@ import subprocess
 from pathlib import Path
 from typing import ClassVar
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.linters.ruff_binary import find_ruff_binary
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.linters.ruff_binary import find_ruff_binary
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/llm_analyzer.py
+++ b/x/claude_linter_v2/llm_analyzer.py
@@ -4,8 +4,8 @@ import json
 import logging
 from typing import Any
 
-from claude_linter_v2.config.models import LLMAnalysisConfig, Violation
 from llm.claude_code_api import EditToolCall, MultiEditToolCall, ToolCall, WriteToolCall
+from x.claude_linter_v2.config.models import LLMAnalysisConfig, Violation
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/pattern_matcher.py
+++ b/x/claude_linter_v2/pattern_matcher.py
@@ -3,7 +3,7 @@
 import fnmatch
 from pathlib import Path
 
-from claude_linter_v2.config.models import PatternBasedRule
+from x.claude_linter_v2.config.models import PatternBasedRule
 
 
 class PatternMatcher:

--- a/x/claude_linter_v2/rule_registry.py
+++ b/x/claude_linter_v2/rule_registry.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
-    from claude_linter_v2.config.models import Violation
+    from x.claude_linter_v2.config.models import Violation
 
 
 @dataclass(frozen=True)

--- a/x/claude_linter_v2/session/BUILD.bazel
+++ b/x/claude_linter_v2/session/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "manager",
     srcs = ["manager.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",
@@ -15,7 +14,6 @@ py_library(
 py_library(
     name = "state",
     srcs = ["state.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",
@@ -27,7 +25,6 @@ py_library(
 py_library(
     name = "violations",
     srcs = ["violations.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",

--- a/x/claude_linter_v2/session/BUILD.bazel
+++ b/x/claude_linter_v2/session/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "manager",
     srcs = ["manager.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",
@@ -14,6 +15,7 @@ py_library(
 py_library(
     name = "state",
     srcs = ["state.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",
@@ -25,6 +27,7 @@ py_library(
 py_library(
     name = "violations",
     srcs = ["violations.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
     deps = [
         "//x/claude_linter_v2:types",

--- a/x/claude_linter_v2/session/manager.py
+++ b/x/claude_linter_v2/session/manager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from platformdirs import user_data_dir
 from pydantic import BaseModel, ConfigDict, Field
 
-from claude_linter_v2.types import SessionID, parse_session_id
+from x.claude_linter_v2.types import SessionID, parse_session_id
 
 
 class RuleAction(StrEnum):

--- a/x/claude_linter_v2/session/state.py
+++ b/x/claude_linter_v2/session/state.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.types import SessionID
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.types import SessionID
 
 
 class Rule(BaseModel):

--- a/x/claude_linter_v2/session/violations.py
+++ b/x/claude_linter_v2/session/violations.py
@@ -7,11 +7,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.types import SessionID
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.types import SessionID
 
 if TYPE_CHECKING:
-    from claude_linter_v2.session.manager import SessionManager
+    from x.claude_linter_v2.session.manager import SessionManager
 
 logger = logging.getLogger(__name__)
 

--- a/x/claude_linter_v2/test_cl2_check.py
+++ b/x/claude_linter_v2/test_cl2_check.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_bazel
 from click.testing import CliRunner
 
-from claude_linter_v2.cli import cli
+from x.claude_linter_v2.cli import cli
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/test_diff_intelligence.py
+++ b/x/claude_linter_v2/test_diff_intelligence.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import pytest_bazel
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategorizer, ViolationCategory
-from claude_linter_v2.diff.intelligence import DiffIntelligence
-from claude_linter_v2.diff.parser import ParsedDiff, parse_tool_response
 from llm.claude_code_api import EditOperation, EditToolCall, MultiEditToolCall
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategorizer, ViolationCategory
+from x.claude_linter_v2.diff.intelligence import DiffIntelligence
+from x.claude_linter_v2.diff.parser import ParsedDiff, parse_tool_response
 
 TEST_FILE = Path("/test.py")
 

--- a/x/claude_linter_v2/test_diff_intelligence_edge_cases.py
+++ b/x/claude_linter_v2/test_diff_intelligence_edge_cases.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import pytest_bazel
 
-from claude_linter_v2.config.models import Violation
-from claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategory
-from claude_linter_v2.diff.intelligence import DiffIntelligence
-from claude_linter_v2.diff.parser import parse_tool_response
 from llm.claude_code_api import EditOperation, EditToolCall, MultiEditToolCall
+from x.claude_linter_v2.config.models import Violation
+from x.claude_linter_v2.diff.categorizer import CategorizedViolation, ViolationCategory
+from x.claude_linter_v2.diff.intelligence import DiffIntelligence
+from x.claude_linter_v2.diff.parser import parse_tool_response
 
 TEST_FILE = Path("/test.py")
 

--- a/x/claude_linter_v2/test_integration.py
+++ b/x/claude_linter_v2/test_integration.py
@@ -20,7 +20,7 @@ def _has_ruff() -> bool:
 
 def _run_cli(*args: str, **kwargs) -> subprocess.CompletedProcess:
     """Run the claude-linter-v2 CLI via run_python_module."""
-    return run_python_module("claude_linter_v2.cli", *args, capture_output=True, text=True, check=False, **kwargs)
+    return run_python_module("x.claude_linter_v2.cli", *args, capture_output=True, text=True, check=False, **kwargs)
 
 
 class TestCLIIntegration:
@@ -214,7 +214,7 @@ class TestSessionCommands:
     def test_session_list(self, tmp_path):
         """Test listing sessions."""
         result = run_python_module(
-            "claude_linter_v2.cli", "session", "list", capture_output=True, text=True, cwd=tmp_path, check=False
+            "x.claude_linter_v2.cli", "session", "list", capture_output=True, text=True, cwd=tmp_path, check=False
         )
 
         assert result.returncode == 0
@@ -224,7 +224,7 @@ class TestSessionCommands:
     def test_session_allow(self, tmp_path):
         """Test adding an allow rule."""
         result = run_python_module(
-            "claude_linter_v2.cli",
+            "x.claude_linter_v2.cli",
             "session",
             "allow",
             "Edit('**/*.py')",

--- a/x/claude_linter_v2/test_mcp_tools.py
+++ b/x/claude_linter_v2/test_mcp_tools.py
@@ -9,12 +9,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_bazel
 
-from claude_linter_v2.config.clean_models import ModularConfig
-from claude_linter_v2.config.models import AutofixCategory, PostToolHookConfig
-from claude_linter_v2.hooks.handler import HookHandler
-from claude_linter_v2.types import SessionID
 from llm.claude_code_api import PostToolUseRequest, PreToolUseRequest
 from llm.claude_outcomes import PostToolSuccess, PreToolApprove
+from x.claude_linter_v2.config.clean_models import ModularConfig
+from x.claude_linter_v2.config.models import AutofixCategory, PostToolHookConfig
+from x.claude_linter_v2.hooks.handler import HookHandler
+from x.claude_linter_v2.types import SessionID
 
 
 def make_pre_tool_request(session_id: SessionID, tool_name: str, tool_input: dict[str, Any]) -> PreToolUseRequest:

--- a/x/claude_linter_v2/test_modular_config.py
+++ b/x/claude_linter_v2/test_modular_config.py
@@ -2,9 +2,9 @@
 
 import pytest_bazel
 
-from claude_linter_v2.config.clean_models import ModularConfig, RuleConfig
-from claude_linter_v2.config.loader import ConfigLoader
-from claude_linter_v2.rule_registry import RuleRegistry
+from x.claude_linter_v2.config.clean_models import ModularConfig, RuleConfig
+from x.claude_linter_v2.config.loader import ConfigLoader
+from x.claude_linter_v2.rule_registry import RuleRegistry
 
 
 def test_modular_config_creation():

--- a/x/claude_linter_v2/test_multiline_predicates.py
+++ b/x/claude_linter_v2/test_multiline_predicates.py
@@ -6,9 +6,9 @@ from uuid import UUID
 import pytest
 import pytest_bazel
 
-from claude_linter_v2.access.context import PredicateContext
-from claude_linter_v2.access.evaluator import PredicateEvaluator
-from claude_linter_v2.types import SessionID
+from x.claude_linter_v2.access.context import PredicateContext
+from x.claude_linter_v2.access.evaluator import PredicateEvaluator
+from x.claude_linter_v2.types import SessionID
 
 # Test session ID using valid UUID format
 TEST_SESSION_ID = SessionID(UUID("00000000-0000-0000-0000-000000000001"))

--- a/x/claude_linter_v2/test_python_ast.py
+++ b/x/claude_linter_v2/test_python_ast.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest_bazel
 
-from claude_linter_v2.linters.python_ast import PythonASTAnalyzer
+from x.claude_linter_v2.linters.python_ast import PythonASTAnalyzer
 
 TEST_FILE = Path("/tmp/test.py")
 

--- a/x/claude_linter_v2/test_python_formatter.py
+++ b/x/claude_linter_v2/test_python_formatter.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_bazel
 
-from claude_linter_v2.config.models import AutofixCategory
-from claude_linter_v2.linters.python_formatter import PythonFormatter
+from x.claude_linter_v2.config.models import AutofixCategory
+from x.claude_linter_v2.linters.python_formatter import PythonFormatter
 
 TEST_FILE = Path("/tmp/test.py")
 
-_MOCK_FIND = "claude_linter_v2.linters.python_formatter.find_ruff_binary"
+_MOCK_FIND = "x.claude_linter_v2.linters.python_formatter.find_ruff_binary"
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/test_python_ruff.py
+++ b/x/claude_linter_v2/test_python_ruff.py
@@ -6,11 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_bazel
 
-from claude_linter_v2.linters.python_ruff import PythonRuffLinter
+from x.claude_linter_v2.linters.python_ruff import PythonRuffLinter
 
 TEST_FILE = Path("/tmp/test.py")
 
-_MOCK_FIND = "claude_linter_v2.linters.python_ruff.find_ruff_binary"
+_MOCK_FIND = "x.claude_linter_v2.linters.python_ruff.find_ruff_binary"
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/test_stop_hook_fresh_scan.py
+++ b/x/claude_linter_v2/test_stop_hook_fresh_scan.py
@@ -6,9 +6,9 @@ import pytest
 import pytest_bazel
 from hamcrest import all_of, assert_that, contains_string, has_entries
 
-from claude_linter_v2.config.models import StopHookConfig
-from claude_linter_v2.hooks.handler import HookHandler
 from llm.claude_code_api import StopRequest
+from x.claude_linter_v2.config.models import StopHookConfig
+from x.claude_linter_v2.hooks.handler import HookHandler
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/test_stop_hook_gitignore.py
+++ b/x/claude_linter_v2/test_stop_hook_gitignore.py
@@ -4,9 +4,9 @@ import subprocess
 
 import pytest_bazel
 
-from claude_linter_v2.config.models import StopHookConfig
-from claude_linter_v2.hooks.handler import HookHandler
 from llm.claude_code_api import StopRequest
+from x.claude_linter_v2.config.models import StopHookConfig
+from x.claude_linter_v2.hooks.handler import HookHandler
 
 
 def _enable_quality_gate(handler: HookHandler) -> None:

--- a/x/claude_linter_v2/test_stop_hook_quality_gate.py
+++ b/x/claude_linter_v2/test_stop_hook_quality_gate.py
@@ -5,9 +5,9 @@ import subprocess
 import pytest
 import pytest_bazel
 
-from claude_linter_v2.config.models import StopHookConfig
-from claude_linter_v2.hooks.handler import HookHandler
 from llm.claude_code_api import StopRequest
+from x.claude_linter_v2.config.models import StopHookConfig
+from x.claude_linter_v2.hooks.handler import HookHandler
 
 
 @pytest.fixture

--- a/x/claude_linter_v2/utils/BUILD.bazel
+++ b/x/claude_linter_v2/utils/BUILD.bazel
@@ -3,6 +3,5 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "gitignore",
     srcs = ["gitignore.py"],
-    imports = ["../.."],
     visibility = ["//:__subpackages__"],
 )

--- a/x/claude_linter_v2/utils/BUILD.bazel
+++ b/x/claude_linter_v2/utils/BUILD.bazel
@@ -3,5 +3,6 @@ load("@rules_python//python:defs.bzl", "py_library")
 py_library(
     name = "gitignore",
     srcs = ["gitignore.py"],
+    imports = ["../../.."],
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
## Summary
This PR refactors all internal imports throughout the codebase to use the `x.` namespace prefix, moving from relative imports to absolute imports with the `x.` prefix. This includes updates to Python source files, Bazel BUILD files, and test files.

## Key Changes

### Python Source Files
- Updated all internal imports in `claude_linter_v2/` and `claude_linter/` modules to use `x.` prefix (e.g., `from claude_linter_v2.config import X` → `from x.claude_linter_v2.config import X`)
- Reorganized import statements to group external dependencies (like `llm.claude_code_api`) before internal `x.` imports
- Updated imports in test files to match the new namespace convention

### Bazel BUILD Files
- Updated `imports` attribute in all `py_library`, `py_binary`, and `py_test` targets from `[".."]` to `["../.."]` or `["../../.."]` to account for the new namespace structure
- Applied changes across:
  - `x/claude_linter_v2/BUILD.bazel`
  - `x/claude_linter/BUILD.bazel`
  - `x/claude_linter_v2/hooks/BUILD.bazel`
  - `x/claude_linter_v2/linters/BUILD.bazel`
  - `x/claude_linter_v2/access/BUILD.bazel`
  - `x/claude_linter_v2/config/BUILD.bazel`
  - `x/claude_linter_v2/diff/BUILD.bazel`
  - `x/claude_linter_v2/session/BUILD.bazel`
  - `x/claude_linter_v2/utils/BUILD.bazel`

### Gazelle Configuration
- Added global `gazelle:map_kind py_binary py_lib` directive to root BUILD.bazel to prevent name conflicts
- Added `gazelle:exclude` directives to various BUILD.bazel files for test scripts and generated code
- Changed `gazelle:python_generation_mode off` to `gazelle:ignore` in `props/specimens/BUILD.bazel`

### Minor Code Improvements
- Fixed type annotation in `claude_web_env/tools/fetch_debs.py` by explicitly typing the `data` variable
- Added explicit type parameters to `std::mem::transmute` calls in `firecracker_init.rs` for better type safety

## Implementation Details
- All internal module references now use the `x.` namespace consistently
- External dependencies (like `llm.claude_code_api`) remain unchanged and are imported before internal modules
- The refactoring maintains backward compatibility through the namespace structure
- Bazel import paths adjusted to reflect the new directory depth with the `x.` namespace prefix

https://claude.ai/code/session_015BaYYYVEVLYVMm5Zmc1gPx