### PR TITLE
fix: correct NewPollHook call and add missing apiURL in RE'd environment-manager

### DIFF
--- a/devinfra/claude/web_env/re/environment_manager/a6f96673/src/cmd/cmd_orchestrator.go
+++ b/devinfra/claude/web_env/re/environment_manager/a6f96673/src/cmd/cmd_orchestrator.go
@@ -164,7 +164,7 @@ to validate them against the token's identity.`,
 			var poller orchestrator.PollerInterface
 			if pollHook != "" {
 				// Create PollHook when poll hook command is specified
-				poller = orchestrator.NewPollHook(nil, pollHook, pollHookTimeout, nil, sandboxBackend, nil, log)
+				poller = orchestrator.NewPollHook(nil, pollHook, pollHookTimeout, nil, sandboxBackend != "" && sandboxBackend != "none", sandboxBackend, nil, log)
 			} else {
 				// Create regular Poller when no hook command
 				poller = orchestrator.NewPollerWithWorkerID(apiURL, environmentID, secret, serviceKeyFile, clientID, log)

--- a/devinfra/claude/web_env/re/environment_manager/a6f96673/src/cmd/cmd_task_run.go
+++ b/devinfra/claude/web_env/re/environment_manager/a6f96673/src/cmd/cmd_task_run.go
@@ -226,6 +226,12 @@ Provide a JSON object via stdin with the following structure:
 			stdinParseDuration := time.Since(stdinStartTime)
 			o11y.RecordDuration("env_manager.stdin_parse.duration_ms", nil, nil, float64(stdinParseDuration.Milliseconds()))
 
+			// Derive apiURL from parsed context's startup context.
+			var apiURL string
+			if parsedCtx != nil && parsedCtx.StartupContext != nil {
+				apiURL = parsedCtx.StartupContext.APIBaseURL
+			}
+
 			// 0xb79583: Create HTTP client for session ingress and activity recorder
 			var activityRecorder session.ActivityRecorder
 			if parsedCtx != nil && parsedCtx.AuthContext != nil {


### PR DESCRIPTION
## Summary

- `cmd_orchestrator.go`: `NewPollHook` call was missing the `sandboxEnabled bool` argument between `hookArgs` and `sandboxBackend`; fixed by passing `sandboxBackend != "" && sandboxBackend != "none"`
- `cmd_task_run.go`: `apiURL` variable was used but never declared; added declaration deriving it from `parsedCtx.StartupContext.APIBaseURL`, matching the `// from parsed context` comment pattern already in the file

## Test plan

- [ ] `bazel build //devinfra/claude/web_env/re/environment_manager/...` passes

https://claude.ai/code/session_01M7baVYBebhv7KZpWpHbii8