### PR TITLE
Add networkx to Python dependencies manifest

### DIFF
--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -278,6 +278,7 @@ manifest:
     nbconvert: nbconvert
     nbformat: nbformat
     nest_asyncio: nest_asyncio
+    networkx: networkx
     nio: matrix_nio
     nodeenv: nodeenv
     numpy: numpy
@@ -508,4 +509,4 @@ manifest:
     zmq: pyzmq
   pip_repository:
     name: pypi
-integrity: a7e17ac3c3434be8311d772bfbf1752f8d5cd5ff2139d2b41c03367624c95634
+integrity: cc5b081634595d1db3b534715d8ed77fcd057a596804a34783a41be5c20ed65a


### PR DESCRIPTION
## Summary
Added networkx as a new Python dependency to the Gazelle Python manifest configuration.

## Changes
- Added `networkx: networkx` mapping to the pip dependencies manifest in `devinfra/gazelle_python.yaml`
- Updated the pip repository integrity hash to reflect the new dependency resolution

## Details
This change registers networkx as an available Python package in the Gazelle build system's dependency manifest, allowing it to be used as a dependency in Python targets within the build configuration.

https://claude.ai/code/session_01DDzKN23v6CY5XwTuZgYhRV