### PR TITLE
Address remaining PR #889 review comments

### DIFF
--- a/cluster/kubespand/agentconfig/agentconfig.go
+++ b/cluster/kubespand/agentconfig/agentconfig.go
@@ -43,7 +43,7 @@ type AgentConfig struct {
 // Routes use Talos's v1alpha1.Route type directly, fed through the standard
 // Talos route pipeline (RouteConfigController → RouteMergeController → RouteSpecController).
 type NetworkConfig struct {
-	// Interface is the network interface for static routes. Default: "eth0".
+	// Interface is the network interface for static routes. Required when routes are configured.
 	Interface string `yaml:"interface,omitempty"`
 	// Routes are static routes to apply on the host interface.
 	// Uses the same type as Talos machine config routes.

--- a/cluster/kubespand/kubespand.example.yaml
+++ b/cluster/kubespand/kubespand.example.yaml
@@ -99,8 +99,7 @@ cluster:
 #   port: 7445
 
 # network:
-#   # Host network interface name. Used for static route management.
-#   # Default: "eth0".
+#   # Host network interface name. Required when routes are configured.
 #   interface: "eth0"
 #
 #   # Static routes managed by kubespand via the Talos route pipeline

--- a/cluster/kubespand/main.go
+++ b/cluster/kubespand/main.go
@@ -110,12 +110,11 @@ func run(configPath string, logger *zap.Logger) error {
 	// Build the network device shim for RouteConfigController if routes are configured.
 	var networkDevice config.Device
 	if len(cfg.Network.Routes) > 0 {
-		iface := cfg.Network.Interface
-		if iface == "" {
-			iface = "eth0"
+		if cfg.Network.Interface == "" {
+			return fmt.Errorf("network.interface is required when network.routes are configured")
 		}
 		networkDevice = &v1alpha1.Device{
-			DeviceInterface: iface,
+			DeviceInterface: cfg.Network.Interface,
 			DeviceRoutes:    cfg.Network.Routes,
 		}
 	}

--- a/cluster/kubespand/qemu_tests/mesh_node.go
+++ b/cluster/kubespand/qemu_tests/mesh_node.go
@@ -281,11 +281,7 @@ func (w *MeshNode) DumpNetstat(t *testing.T) {
 
 	for _, msg := range resp.Messages {
 		for _, rec := range msg.Connectrecord {
-			w.Logf("%s %s:%d -> %s:%d state=%s",
-				rec.L4Proto,
-				rec.Localip, rec.Localport,
-				rec.Remoteip, rec.Remoteport,
-				rec.State)
+			w.Logf("netstat: %+v", rec)
 		}
 	}
 }

--- a/cluster/kubespand/qemu_tests/mesh_test_runner.go
+++ b/cluster/kubespand/qemu_tests/mesh_test_runner.go
@@ -77,7 +77,7 @@ func (s *MeshState) Summary() string {
 // cosiEvent wraps a COSI state.Event with source node name and resource type.
 type cosiEvent struct {
 	NodeName     string
-	ResourceType string
+	ResourceType resource.Type
 	Event        state.Event
 }
 
@@ -104,15 +104,14 @@ type nodeReady struct {
 type watchSpec struct {
 	Namespace    string
 	ResourceType resource.Type
-	Label        string
 }
 
 var defaultWatches = []watchSpec{
-	{kubespan.NamespaceName, kubespan.IdentityType, "Identity"},
-	{kubespan.NamespaceName, kubespan.PeerSpecType, "PeerSpec"},
-	{kubespan.NamespaceName, kubespan.PeerStatusType, "PeerStatus"},
-	{kubespan.NamespaceName, kubespan.EndpointType, "Endpoint"},
-	{cluster.NamespaceName, cluster.AffiliateType, "Affiliate"},
+	{kubespan.NamespaceName, kubespan.IdentityType},
+	{kubespan.NamespaceName, kubespan.PeerSpecType},
+	{kubespan.NamespaceName, kubespan.PeerStatusType},
+	{kubespan.NamespaceName, kubespan.EndpointType},
+	{cluster.NamespaceName, cluster.AffiliateType},
 }
 
 // Run blocks until SuccessFunc returns true or ctx is cancelled.
@@ -181,11 +180,7 @@ func (r *MeshTestRunner) Run(ctx context.Context) {
 		case pr := <-probeCh:
 			ns := meshState.Nodes[pr.NodeName]
 			ns.ProbeResults[pr.Key] = pr.OK
-			if pr.OK {
-				r.T.Logf("[%s] probe %s: ok", pr.NodeName, pr.Key)
-			} else {
-				r.T.Logf("[%s] probe %s: FAIL", pr.NodeName, pr.Key)
-			}
+			r.T.Logf("[%s] probe: %+v", pr.NodeName, pr)
 			if r.SuccessFunc(meshState) {
 				r.Stopwatch.Lap("success")
 				return
@@ -232,7 +227,7 @@ func (r *MeshTestRunner) watchNode(ctx context.Context, node *MeshNode, eventCh 
 		ch := make(chan state.Event, 16)
 		kind := resource.NewMetadata(ws.Namespace, ws.ResourceType, "", resource.VersionUndefined)
 		if err := st.WatchKind(nctx, kind, ch, state.WithBootstrapContents(true)); err != nil {
-			r.T.Logf("[%s] WatchKind %s: %v", name, ws.Label, err)
+			r.T.Logf("[%s] WatchKind %s: %v", name, ws.ResourceType, err)
 			continue
 		}
 		go func() {
@@ -243,7 +238,7 @@ func (r *MeshTestRunner) watchNode(ctx context.Context, node *MeshNode, eventCh 
 				case ev := <-ch:
 					eventCh <- cosiEvent{
 						NodeName:     name,
-						ResourceType: ws.Label,
+						ResourceType: ws.ResourceType,
 						Event:        ev,
 					}
 				}
@@ -305,7 +300,7 @@ func (r *MeshTestRunner) handleCOSIEvent(ctx context.Context, meshState *MeshSta
 		id := res.Metadata().ID()
 
 		switch ev.ResourceType {
-		case "PeerStatus":
+		case kubespan.PeerStatusType:
 			ps, ok := res.(*kubespan.PeerStatus)
 			if !ok {
 				return
@@ -313,16 +308,15 @@ func (r *MeshTestRunner) handleCOSIEvent(ctx context.Context, meshState *MeshSta
 			spec := *ps.TypedSpec()
 			if ev.Event.Type == state.Updated {
 				if old, exists := ns.PeerStatuses[id]; exists && old.State != spec.State {
-					r.T.Logf("[%s] PeerStatus %s: %s -> %s ep=%s",
-						ev.NodeName, spec.Label, old.State, spec.State, spec.Endpoint)
+					r.T.Logf("[%s] PeerStatus %s -> %s: %+v",
+						ev.NodeName, old.State, spec.State, spec)
 				}
 			} else {
-				r.T.Logf("[%s] PeerStatus created: %s state=%s ep=%s",
-					ev.NodeName, spec.Label, spec.State, spec.Endpoint)
+				r.T.Logf("[%s] PeerStatus created: %+v", ev.NodeName, spec)
 			}
 			ns.PeerStatuses[id] = spec
 
-		case "PeerSpec":
+		case kubespan.PeerSpecType:
 			ps, ok := res.(*kubespan.PeerSpec)
 			if !ok {
 				return
@@ -331,21 +325,20 @@ func (r *MeshTestRunner) handleCOSIEvent(ctx context.Context, meshState *MeshSta
 			r.T.Logf("[%s] PeerSpec %s: %s %+v", ev.NodeName, ev.Event.Type, id, spec)
 			ns.PeerSpecs[id] = spec
 
-		case "Affiliate":
+		case cluster.AffiliateType:
 			aff, ok := res.(*cluster.Affiliate)
 			if !ok {
 				return
 			}
 			spec := *aff.TypedSpec()
-			r.T.Logf("[%s] Affiliate %s: %s hostname=%s nodeID=%s",
-				ev.NodeName, ev.Event.Type, id, spec.Hostname, spec.NodeID)
+			r.T.Logf("[%s] Affiliate %s: %+v", ev.NodeName, ev.Event.Type, spec)
 			ns.Affiliates[id] = spec
 
-		case "Identity":
+		case kubespan.IdentityType:
 			r.T.Logf("[%s] Identity %s: %s %+v", ev.NodeName, ev.Event.Type, id, res)
 			ns.HasIdentity = true
 
-		case "Endpoint":
+		case kubespan.EndpointType:
 			r.T.Logf("[%s] Endpoint %s: %s %+v", ev.NodeName, ev.Event.Type, id, res)
 		}
 
@@ -361,13 +354,13 @@ func (r *MeshTestRunner) handleCOSIEvent(ctx context.Context, meshState *MeshSta
 		r.T.Logf("[%s] %s destroyed: %s", ev.NodeName, ev.ResourceType, id)
 
 		switch ev.ResourceType {
-		case "PeerStatus":
+		case kubespan.PeerStatusType:
 			delete(ns.PeerStatuses, id)
-		case "PeerSpec":
+		case kubespan.PeerSpecType:
 			delete(ns.PeerSpecs, id)
-		case "Affiliate":
+		case cluster.AffiliateType:
 			delete(ns.Affiliates, id)
-		case "Identity":
+		case kubespan.IdentityType:
 			ns.HasIdentity = false
 		}
 


### PR DESCRIPTION
## Summary

Addresses the remaining unresolved review comments from PR #889:

- **`mesh_node.go` DumpNetstat**: Use `%+v` instead of manual field formatting for netstat records
- **`mesh_test_runner.go` watchSpec/handleCOSIEvent**: Remove redundant string `Label` field from `watchSpec`, use `resource.Type` directly. Switch on COSI type constants (`kubespan.PeerStatusType`, `cluster.AffiliateType`, etc.) instead of string literals
- **`mesh_test_runner.go` probe logging**: Replace if/else OK/FAIL branch with `%+v` on the `probeResult` struct
- **`mesh_test_runner.go` PeerStatus/Affiliate logging**: Use `%+v` on specs instead of manually formatting individual fields
- **`main.go` network interface**: Require `network.interface` when `network.routes` are configured instead of silently defaulting to `"eth0"`

## Test plan

- [x] `bazel build //cluster/kubespand/... --config=nolint` passes
- [ ] `bazel test //cluster/kubespand/...` (QEMU tests require KVM)

https://claude.ai/code/session_01DL8DMg7uChNiAd5vbbTgs3