### PR TITLE
Add Terraform resource read permissions to cluster diagnostics role

### DIFF
--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -132,5 +132,9 @@ rules:
     resources:
       - clusters
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["infra.contrib.fluxcd.io"]
+    resources:
+      - terraforms
+    verbs: ["get", "list", "watch"]
 # pods/log and configmaps granted via namespaced Roles in monitoring, kube-system,
 # longhorn-system, flux-system (see role-logs-configmaps-reader.yaml).


### PR DESCRIPTION
## Summary
Extended the cluster diagnostics reader RBAC role to include read permissions for Terraform resources from the Flux CD infrastructure API group.

## Key Changes
- Added new rule to `clusterrole-cluster-diagnostics-reader.yaml` granting read access (`get`, `list`, `watch`) to `terraforms` resources in the `infra.contrib.fluxcd.io` API group

## Details
This change allows the cluster diagnostics reader role to inspect Terraform resources managed by Flux CD, enabling better observability and diagnostics of infrastructure-as-code deployments within the cluster.

https://claude.ai/code/session_01MwTLGN5t77qpejApmZvBba