### PR TITLE
cluster: expand agent diagnostics ClusterRole with additional CRDs

### DIFF
--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -126,7 +126,10 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources:
+      - gateways
       - httproutes
+      - tlsroutes
+      - grpcroutes
     verbs: ["get", "list", "watch"]
   - apiGroups: ["postgresql.cnpg.io"]
     resources:
@@ -135,6 +138,43 @@ rules:
   - apiGroups: ["infra.contrib.fluxcd.io"]
     resources:
       - terraforms
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources:
+      - imagepolicies
+      - imagerepositories
+      - imageupdateautomations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources:
+      - receivers
+      - alerts
+      - providers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumclusterwidenetworkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kyverno.io"]
+    resources:
+      - clusterpolicies
+      - policies
+      - policyreports
+      - clusterpolicyreports
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dns.cav.enablers.ob"]
+    resources:
+      - clusterzones
+      - clusterrrsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["vault.banzaicloud.com"]
+    resources:
+      - vaults
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["trust.cert-manager.io"]
+    resources:
+      - bundles
     verbs: ["get", "list", "watch"]
 # pods/log and configmaps granted via namespaced Roles in monitoring, kube-system,
 # longhorn-system, flux-system (see role-logs-configmaps-reader.yaml).

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -176,5 +176,13 @@ rules:
     resources:
       - bundles
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["bitnami.com"]
+    resources:
+      - sealedsecrets
+    verbs: ["get", "list", "watch"]
 # pods/log and configmaps granted via namespaced Roles in monitoring, kube-system,
 # longhorn-system, flux-system (see role-logs-configmaps-reader.yaml).


### PR DESCRIPTION
## Summary

- Add read access (get/list/watch) for additional CRDs to the `cluster-diagnostics-reader` ClusterRole, used by both `claude-sandbox` and `openclaw-sandbox`
- **Flux image automation**: `ImagePolicy`, `ImageRepository`, `ImageUpdateAutomation`
- **Flux notifications**: `Receiver`, `Alert`, `Provider`
- **Cilium**: `CiliumNetworkPolicy`, `CiliumClusterwideNetworkPolicy`
- **Kyverno**: `ClusterPolicy`, `Policy`, `PolicyReport`, `ClusterPolicyReport`
- **Gateway API**: `Gateway`, `TLSRoute`, `GRPCRoute` (alongside existing `HTTPRoute`)
- **PowerDNS operator**: `ClusterZone`, `ClusterRRset`
- **Bank-Vaults**: `Vault`
- **cert-manager trust**: `Bundle`
- **ESO**: `ExternalSecret` (metadata only — Vault paths and key names, no secret values)
- **SealedSecrets**: `SealedSecret` (encrypted ciphertext only, no plaintext)

## Test plan

- [x] `kubeconform` pre-commit validation passes
- [ ] Verify agents can read the new resource types after Flux reconciles

https://claude.ai/code/session_01MwTLGN5t77qpejApmZvBba