### PR TITLE
fix: Kyverno CEL null-safety + LiteLLM config reload

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -139,8 +139,17 @@ kubernetes.io/hostname: wyrm2` as a temporary fix for the 2026-03-17 OOM cascade
       (gateway-system instead of outpost), remove from `shared-proxy-outpost.yaml`.
 - [ ] **Ollama: per-user auth** — Options: Authentik JWTs, LiteLLM proxy.
       Currently the LiteLLM openai-chat models use a dummy `api_key: "ollama"`
-      because Ollama accepts any key. Once per-user auth is deployed, replace
-      the dummy key with a real credential (stored in Vault, injected via ESO).
+      because Ollama accepts any key. Ollama 0.18 does NOT support native API
+      key auth for self-hosted instances (`OLLAMA_API_KEY` is only for
+      ollama.com cloud). Once per-user auth is deployed, replace the dummy key
+      with a real credential (stored in Vault, injected via ESO).
+- [ ] **LiteLLM: ollama-native tool_calls not forwarded** — The `ollama/`
+      provider in LiteLLM drops `tool_calls` from Ollama responses (returns
+      empty content + `finish_reason: "stop"`). Tool calling works correctly
+      via Ollama's native `/api/chat` endpoint and via the `openai/` provider
+      (Ollama's `/v1` OpenAI-compatible endpoint). Prefer `openai-chat` model
+      variants for tool-using agents. Investigate whether this is a LiteLLM
+      bug or a missing config option.
 - [ ] **Harbor terraform: switch to robot accounts** for least-privilege
 - [ ] **Harbor CI robot: scope per-namespace pull secrets to read-only on specific projects** —
       `activitywatch`, `inventree`, `openclaw`, `props` namespaces all use the same system-level

--- a/cluster/k8s/kyverno-policies/restrict-agent-kustomization-patch.yaml
+++ b/cluster/k8s/kyverno-policies/restrict-agent-kustomization-patch.yaml
@@ -45,14 +45,18 @@ spec:
             - expression: "object.spec == oldObject.spec"
               message: "Changes to spec are not permitted."
             - expression: >
-                object.metadata.annotations.all(k,
-                  k == 'reconcile.fluxcd.io/requestedAt' ||
-                  (k in oldObject.metadata.annotations &&
-                   object.metadata.annotations[k] == oldObject.metadata.annotations[k]))
+                (!has(object.metadata.annotations) ||
+                 object.metadata.annotations.all(k,
+                   k == 'reconcile.fluxcd.io/requestedAt' ||
+                   (has(oldObject.metadata.annotations) &&
+                    k in oldObject.metadata.annotations &&
+                    object.metadata.annotations[k] == oldObject.metadata.annotations[k])))
                 &&
-                oldObject.metadata.annotations.all(k,
-                  k == 'reconcile.fluxcd.io/requestedAt' ||
-                  (k in object.metadata.annotations &&
-                   oldObject.metadata.annotations[k] == object.metadata.annotations[k]))
+                (!has(oldObject.metadata.annotations) ||
+                 oldObject.metadata.annotations.all(k,
+                   k == 'reconcile.fluxcd.io/requestedAt' ||
+                   (has(object.metadata.annotations) &&
+                    k in object.metadata.annotations &&
+                    oldObject.metadata.annotations[k] == object.metadata.annotations[k])))
               message: "Only the reconcile.fluxcd.io/requestedAt annotation may be changed."
   validationFailureAction: Enforce

--- a/cluster/k8s/litellm/deployment.yaml
+++ b/cluster/k8s/litellm/deployment.yaml
@@ -9,7 +9,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: litellm
-  namespace: ollama
+  namespace: litellm
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/cluster/k8s/ollama/nginx-auth-proxy.conf.template
+++ b/cluster/k8s/ollama/nginx-auth-proxy.conf.template
@@ -2,7 +2,7 @@ server {
     listen 11435;
 
     location / {
-        set $expected "Bearer $${OLLAMA_DIRECT_TOKEN}";
+        set $expected "Bearer ${OLLAMA_DIRECT_TOKEN}";
         if ($http_authorization != $expected) {
             return 401 '{"error": "unauthorized"}';
         }

--- a/cluster/k8s/ollama/nginx-auth-proxy.conf.template
+++ b/cluster/k8s/ollama/nginx-auth-proxy.conf.template
@@ -2,7 +2,7 @@ server {
     listen 11435;
 
     location / {
-        set $expected "Bearer ${OLLAMA_DIRECT_TOKEN}";
+        set $expected "Bearer $${OLLAMA_DIRECT_TOKEN}";
         if ($http_authorization != $expected) {
             return 401 '{"error": "unauthorized"}';
         }


### PR DESCRIPTION
## Summary
- **Kyverno restrict-agent-kustomization-patch**: Add has() guards for metadata.annotations in CEL expressions. The policy crashed with 'no such key: annotations' when annotating Kustomizations that had no prior annotations.
- **LiteLLM deployment**: Add Stakater Reloader annotation so ConfigMap changes trigger automatic pod rollouts.
- **LiteLLM deployment**: Fix namespace from ollama to litellm.

## Test plan
- [x] bazel test //cluster/k8s/litellm:test_generate_litellm passes
- [x] kubeconform passes on Kyverno policy
- [x] Verified tool calling works via Ollama native API (gpt-oss:20b correctly returns tool_calls)
- [ ] After merge: verify Kyverno policy allows reconcile annotation
- [ ] After merge: verify LiteLLM pod restarts when ConfigMap changes

https://claude.ai/code/session_01GNaryKTDqzWjy8WLzutpHd