### PR TITLE
cluster: allow claude to trigger kustomization reconciliation via annotation

### DIFF
--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -101,7 +101,7 @@ rules:
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources:
       - kustomizations
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["metrics.k8s.io"]
     resources:
       - pods

--- a/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -98,6 +98,10 @@ rules:
     resources:
       - helmreleases
     verbs: ["get", "list", "watch"]
+  # patch is required to set reconcile.fluxcd.io/requestedAt for manual reconciliation
+  # triggers. RBAC cannot restrict which fields are patched — the annotation-only
+  # constraint is enforced by the restrict-agent-kustomization-patch Kyverno ClusterPolicy
+  # in cluster/k8s/kyverno-policies/.
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources:
       - kustomizations

--- a/cluster/k8s/kyverno-policies/kustomization.yaml
+++ b/cluster/k8s/kyverno-policies/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - require-gitops.yaml
   - inject-mitmproxy-proxy.yaml
+  - restrict-claude-kustomization-patch.yaml

--- a/cluster/k8s/kyverno-policies/kustomization.yaml
+++ b/cluster/k8s/kyverno-policies/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - require-gitops.yaml
   - inject-mitmproxy-proxy.yaml
-  - restrict-claude-kustomization-patch.yaml
+  - restrict-agent-kustomization-patch.yaml

--- a/cluster/k8s/kyverno-policies/restrict-agent-kustomization-patch.yaml
+++ b/cluster/k8s/kyverno-policies/restrict-agent-kustomization-patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: restrict-claude-kustomization-patch
+  name: restrict-agent-kustomization-patch
   annotations:
     policies.kyverno.io/title: Restrict Agent Kustomization Patches
     policies.kyverno.io/category: Access Control

--- a/cluster/k8s/kyverno-policies/restrict-claude-kustomization-patch.yaml
+++ b/cluster/k8s/kyverno-policies/restrict-claude-kustomization-patch.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: restrict-claude-kustomization-patch
   annotations:
-    policies.kyverno.io/title: Restrict Claude Kustomization Patches
+    policies.kyverno.io/title: Restrict Agent Kustomization Patches
     policies.kyverno.io/category: Access Control
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Kustomization
     policies.kyverno.io/description: >
-      Restricts the claude-code-web ServiceAccount to only patching the
-      reconcile.fluxcd.io/requestedAt annotation on Flux Kustomization resources.
-      Any change to spec is blocked, ensuring only reconciliation triggers are allowed.
+      Restricts agent service accounts (claude-code-web, openclaw-sandbox/default) to
+      only patching the reconcile.fluxcd.io/requestedAt annotation on Flux Kustomization
+      resources. Changes to spec or any other annotation are blocked.
 spec:
   admission: true
   background: false
@@ -27,14 +27,32 @@ spec:
               - kind: ServiceAccount
                 name: claude-code-web
                 namespace: default
+          - resources:
+              kinds:
+                - kustomize.toolkit.fluxcd.io/v1/Kustomization
+              operations:
+                - UPDATE
+            subjects:
+              - kind: ServiceAccount
+                name: default
+                namespace: openclaw-sandbox
       validate:
         message: >
-          claude-code-web may only patch the reconcile.fluxcd.io/requestedAt
-          annotation. Changes to spec are not permitted.
-        deny:
-          conditions:
-            any:
-              - key: "{{ request.object.spec }}"
-                operator: NotEquals
-                value: "{{ request.oldObject.spec }}"
+          Agent service accounts may only patch the reconcile.fluxcd.io/requestedAt
+          annotation. Changes to spec or other annotations are not permitted.
+        cel:
+          expressions:
+            - expression: "object.spec == oldObject.spec"
+              message: "Changes to spec are not permitted."
+            - expression: >
+                object.metadata.annotations.all(k,
+                  k == 'reconcile.fluxcd.io/requestedAt' ||
+                  (k in oldObject.metadata.annotations &&
+                   object.metadata.annotations[k] == oldObject.metadata.annotations[k]))
+                &&
+                oldObject.metadata.annotations.all(k,
+                  k == 'reconcile.fluxcd.io/requestedAt' ||
+                  (k in object.metadata.annotations &&
+                   oldObject.metadata.annotations[k] == object.metadata.annotations[k]))
+              message: "Only the reconcile.fluxcd.io/requestedAt annotation may be changed."
   validationFailureAction: Enforce

--- a/cluster/k8s/kyverno-policies/restrict-claude-kustomization-patch.yaml
+++ b/cluster/k8s/kyverno-policies/restrict-claude-kustomization-patch.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-claude-kustomization-patch
+  annotations:
+    policies.kyverno.io/title: Restrict Claude Kustomization Patches
+    policies.kyverno.io/category: Access Control
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Kustomization
+    policies.kyverno.io/description: >
+      Restricts the claude-code-web ServiceAccount to only patching the
+      reconcile.fluxcd.io/requestedAt annotation on Flux Kustomization resources.
+      Any change to spec is blocked, ensuring only reconciliation triggers are allowed.
+spec:
+  admission: true
+  background: false
+  rules:
+    - name: only-reconcile-annotation
+      match:
+        any:
+          - resources:
+              kinds:
+                - kustomize.toolkit.fluxcd.io/v1/Kustomization
+              operations:
+                - UPDATE
+            subjects:
+              - kind: ServiceAccount
+                name: claude-code-web
+                namespace: default
+      validate:
+        message: >
+          claude-code-web may only patch the reconcile.fluxcd.io/requestedAt
+          annotation. Changes to spec are not permitted.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec }}"
+                operator: NotEquals
+                value: "{{ request.oldObject.spec }}"
+  validationFailureAction: Enforce


### PR DESCRIPTION
## Summary

- Grants `patch` on `kustomize.toolkit.fluxcd.io/kustomizations` to `claude-code-web` and `openclaw-sandbox/default` SAs via `cluster-diagnostics-reader` ClusterRole
- Adds a Kyverno `ClusterPolicy` (`restrict-agent-kustomization-patch`) in Enforce mode that limits patches to setting only `reconcile.fluxcd.io/requestedAt` — blocking any spec changes or other annotation modifications
- Adds a comment on the RBAC rule explaining that field-level restriction lives in the Kyverno policy (since RBAC cannot restrict which fields are patched)

## Test plan

- [ ] Verify `kubectl patch kustomization <name> -n flux-system --type=merge -p '{"metadata":{"annotations":{"reconcile.fluxcd.io/requestedAt":"<timestamp>"}}}'` succeeds as the claude-code-web SA
- [ ] Verify any spec change or non-reconcile annotation patch is blocked by the Kyverno policy

https://claude.ai/code/session_01VdGRvn75bYw9LCgW8LP7DS