### PR TITLE
Add retry policy validation for async Flux Kustomizations

### DIFF
--- a/cluster/validation/health_checks.py
+++ b/cluster/validation/health_checks.py
@@ -10,6 +10,23 @@ from cluster.validation.kustomize import KustomizeFile
 
 HEALTH_CHECK_REQUIRED_KINDS = ["HelmRelease", "Terraform"]
 
+_ASYNC_HEALTH_CHECK_KINDS = {
+    "HelmRelease",
+    "Terraform",
+    "Deployment",
+    "StatefulSet",
+    "DaemonSet",
+    "ExternalSecret",
+    "ClusterZone",
+    "Certificate",
+}
+
+
+def _has_async_health_checks(cluster: ParsedCluster, name: str) -> bool:
+    """Check if a kustomization has health checks for async resource kinds."""
+    flux_kust = cluster.flux_kustomizations[name]
+    return any(hc.kind in _ASYNC_HEALTH_CHECK_KINDS for hc in flux_kust.spec.health_checks)
+
 
 def kust_deploys_kind(kind: str, kust: KustomizeFile, source_resources: dict[Path, list[K8sResource]]) -> bool:
     return any(
@@ -32,3 +49,33 @@ def check_controller_health_checks(cluster: ParsedCluster, k8s_dir: Path, worksp
         if kust_deploys_kind(kind, kust, cluster.source_resources)
         if not any(hc.kind == kind for hc in flux_kust.spec.health_checks)
     ]
+
+
+def check_retry_policy(cluster: ParsedCluster, k8s_dir: Path) -> None:
+    """Enforce semantically correct retry policies on Flux Kustomizations.
+
+    Async kustomizations (those with async health check kinds or wait: true)
+    require retries > 0 AND retryInterval. Retries without retryInterval is
+    nearly useless — retries default to the interval cadence (10m).
+    """
+    errors: list[str] = []
+    for name, flux_kust in cluster.flux_kustomizations.items():
+        needs_retry = _has_async_health_checks(cluster, name) or flux_kust.spec.wait
+        retries = flux_kust.spec.retries
+        retry_interval = flux_kust.spec.retry_interval
+
+        if not needs_retry:
+            continue
+
+        rel_path = flux_kust.file_path.relative_to(k8s_dir)
+        if retries is None or retries <= 0:
+            errors.append(
+                f"{name}: has async health checks or wait: true but retries={retries}. Set retries > 0 in {rel_path}."
+            )
+        if not retry_interval:
+            errors.append(
+                f"{name}: has async health checks or wait: true but no retryInterval. "
+                f"Set retryInterval (e.g. 1m) in {rel_path}."
+            )
+
+    assert not errors, "Retry policy violations:\n" + "\n".join(f"  {e}" for e in errors)

--- a/cluster/validation/test_health_checks.py
+++ b/cluster/validation/test_health_checks.py
@@ -129,7 +129,7 @@ class TestRetryPolicy:
         check_retry_policy(cluster, k8s_dir)
 
     def test_async_health_check_without_retry_fails(self, k8s_dir: Path) -> None:
-        cluster = self._make_cluster_with_retry(k8s_dir, retries=0)
+        cluster = self._make_cluster_with_retry(k8s_dir, retries=0, retry_interval="1m")
         with pytest.raises(AssertionError, match="retries=0"):
             check_retry_policy(cluster, k8s_dir)
 
@@ -139,7 +139,9 @@ class TestRetryPolicy:
             check_retry_policy(cluster, k8s_dir)
 
     def test_wait_true_requires_retry(self, k8s_dir: Path) -> None:
-        cluster = self._make_cluster_with_retry(k8s_dir, health_check_kind="Namespace", wait=True, retries=0)
+        cluster = self._make_cluster_with_retry(
+            k8s_dir, health_check_kind="Namespace", wait=True, retries=0, retry_interval="1m"
+        )
         with pytest.raises(AssertionError, match="retries=0"):
             check_retry_policy(cluster, k8s_dir)
 

--- a/cluster/validation/test_health_checks.py
+++ b/cluster/validation/test_health_checks.py
@@ -9,7 +9,7 @@ import pytest_bazel
 
 from cluster.validation.cluster import ParsedCluster
 from cluster.validation.flux import FluxKustomization, FluxKustomizationSpec, HealthCheck
-from cluster.validation.health_checks import check_controller_health_checks
+from cluster.validation.health_checks import check_controller_health_checks, check_retry_policy
 from cluster.validation.k8s import K8sResource
 from cluster.validation.kustomize import KustomizeFile
 
@@ -87,6 +87,72 @@ class TestControllerResourceHealthChecks:
     def test_no_error_for_plain_resources(self, k8s_dir: Path, repo_root: Path) -> None:
         cluster = _make_cluster(k8s_dir, resource_kind="ConfigMap", resource_api_version="v1")
         assert check_controller_health_checks(cluster, k8s_dir, repo_root) == []
+
+
+class TestRetryPolicy:
+    @pytest.fixture
+    def k8s_dir(self, tmp_path: Path) -> Path:
+        k8s = tmp_path / "cluster" / "k8s"
+        k8s.mkdir(parents=True)
+        return k8s
+
+    def _make_cluster_with_retry(
+        self,
+        k8s_dir: Path,
+        *,
+        health_check_kind: str = "HelmRelease",
+        retries: int | None = None,
+        retry_interval: str | None = None,
+        wait: bool = False,
+    ) -> ParsedCluster:
+        flux_file = k8s_dir / "test-app" / "flux-kustomization.yaml"
+        return ParsedCluster(
+            kustomize_files={},
+            flux_kustomizations={
+                "test-app": FluxKustomization(
+                    name="test-app",
+                    file_path=flux_file,
+                    spec=FluxKustomizationSpec(
+                        path="./cluster/k8s/test-app",
+                        health_checks=[HealthCheck(kind=health_check_kind, name="test-app", namespace="test-app")],
+                        retries=retries,
+                        retry_interval=retry_interval,
+                        wait=wait,
+                    ),
+                )
+            },
+            source_resources={},
+        )
+
+    def test_async_health_check_with_retry_passes(self, k8s_dir: Path) -> None:
+        cluster = self._make_cluster_with_retry(k8s_dir, retries=5, retry_interval="1m")
+        check_retry_policy(cluster, k8s_dir)
+
+    def test_async_health_check_without_retry_fails(self, k8s_dir: Path) -> None:
+        cluster = self._make_cluster_with_retry(k8s_dir, retries=0)
+        with pytest.raises(AssertionError, match="retries=0"):
+            check_retry_policy(cluster, k8s_dir)
+
+    def test_async_health_check_without_retry_interval_fails(self, k8s_dir: Path) -> None:
+        cluster = self._make_cluster_with_retry(k8s_dir, retries=5)
+        with pytest.raises(AssertionError, match="no retryInterval"):
+            check_retry_policy(cluster, k8s_dir)
+
+    def test_wait_true_requires_retry(self, k8s_dir: Path) -> None:
+        cluster = self._make_cluster_with_retry(k8s_dir, health_check_kind="Namespace", wait=True, retries=0)
+        with pytest.raises(AssertionError, match="retries=0"):
+            check_retry_policy(cluster, k8s_dir)
+
+    def test_wait_true_with_retry_passes(self, k8s_dir: Path) -> None:
+        cluster = self._make_cluster_with_retry(
+            k8s_dir, health_check_kind="Namespace", wait=True, retries=5, retry_interval="1m"
+        )
+        check_retry_policy(cluster, k8s_dir)
+
+    def test_sync_only_no_wait_no_retry_passes(self, k8s_dir: Path) -> None:
+        """Sync-only health checks (Namespace) without wait don't need retries."""
+        cluster = self._make_cluster_with_retry(k8s_dir, health_check_kind="Namespace", retries=0)
+        check_retry_policy(cluster, k8s_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR adds validation to enforce semantically correct retry policies on Flux Kustomizations that have asynchronous health checks or `wait: true` settings.

## Key Changes
- **New validation function `check_retry_policy()`**: Enforces that Flux Kustomizations with async health checks or `wait: true` must have both `retries > 0` AND `retryInterval` configured
- **Async health check detection**: Introduced `_ASYNC_HEALTH_CHECK_KINDS` set containing resource kinds that require retry configuration (HelmRelease, Terraform, Deployment, StatefulSet, DaemonSet, ExternalSecret, ClusterZone, Certificate)
- **Helper function `_has_async_health_checks()`**: Determines if a kustomization has health checks for async resource kinds
- **Comprehensive test coverage**: Added `TestRetryPolicy` class with 6 test cases covering:
  - Async health checks with proper retry configuration (pass)
  - Async health checks without retries (fail)
  - Async health checks without retryInterval (fail)
  - `wait: true` requiring retry configuration
  - Sync-only health checks (Namespace) that don't require retries

## Implementation Details
- The validation prevents a common misconfiguration where retries are set without retryInterval, which is nearly useless since retries default to the interval cadence (10m)
- Sync-only health checks (like Namespace) without `wait: true` are allowed to have no retry configuration
- Error messages include the relative path to the kustomization file for easy remediation

https://claude.ai/code/session_01X9WyqomJY4DA6vkS3ERtdf