### PR TITLE
Derive bazelrc path from SessionPaths instead of environment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv tool install https://github.com/agentydragon/ducktape/releases/download/ducktape-ab388584/ducktape-0.1.0-py3-none-any.whl --force >&2"
+            "command": "uv tool install https://github.com/agentydragon/ducktape/releases/download/ducktape-ab388584/ducktape-0.1.0-py3-none-any.whl --force >&2; ~/.local/bin/claude-hook"
           }
         ]
       }

--- a/devinfra/claude/bazel_wrapper.py
+++ b/devinfra/claude/bazel_wrapper.py
@@ -3,7 +3,7 @@
 Mode-aware: in web mode (CLAUDE_CODE_REMOTE=true), writes fresh proxy
 credentials and verifies the in-process auth proxy is running. In CLI mode,
 passes through directly.
-Both modes inject --bazelrc=<per-session-bazelrc> via SESSION_BAZELRC.
+Both modes inject --bazelrc=<per-session-bazelrc> derived from the session dir.
 
 Routes to the correct binary based on invocation name: if invoked as "bazelisk",
 execs bazelisk; if invoked as "bazel", execs bazel. The shell wrapper sets
@@ -22,7 +22,7 @@ from pathlib import Path
 from devinfra.claude.auth_proxy.credentials import check_credential_expiry
 from devinfra.claude.auth_proxy.vars import PROXY_ENV_VARS, get_upstream_proxy_url
 from devinfra.claude.debug import log_entrypoint_debug
-from devinfra.claude.env_file import ENV_AUTH_PROXY_URL, ENV_BAZELISK_PATH, ENV_SESSION_BAZELRC
+from devinfra.claude.env_file import ENV_AUTH_PROXY_URL, ENV_BAZELISK_PATH
 from devinfra.claude.errors import AuthProxyError
 from devinfra.claude.session_paths import SessionPaths
 from devinfra.claude.settings import ENV_SESSION_DIR, HookSettings, is_web_mode
@@ -155,11 +155,10 @@ async def _async_main(paths: SessionPaths, settings: HookSettings) -> None:
         for var in PROXY_ENV_VARS:
             os.environ[var] = local_proxy
 
-    bazelrc_path = get_required_env(ENV_SESSION_BAZELRC)
     real_binary = _resolve_real_binary()
 
     logger.info("Execing %s (invoked as %s)", real_binary, _invocation_name())
-    os.execvp(real_binary, [real_binary, f"--bazelrc={bazelrc_path}", *sys.argv[1:]])
+    os.execvp(real_binary, [real_binary, f"--bazelrc={paths.bazelrc}", *sys.argv[1:]])
 
 
 def main() -> None:

--- a/devinfra/claude/env_file.py
+++ b/devinfra/claude/env_file.py
@@ -19,7 +19,6 @@ ENV_AUTH_PROXY_PORT = "AUTH_PROXY_PORT"
 ENV_AUTH_PROXY_URL = "AUTH_PROXY_URL"
 ENV_SESSION_BAZELRC = "SESSION_BAZELRC"
 ENV_BAZELISK_PATH = "BAZELISK_PATH"
-ENV_BAZEL_REPO_ROOT = "BAZEL_REPO_ROOT"
 
 
 # NO_PROXY entries that break Go module downloads in the gVisor sandbox.
@@ -65,7 +64,6 @@ class EnvVars:
     # Web mode: auth proxy and Bazel configuration
     proxy_port: int | None = None
     supervisor_port: int | None = None
-    repo_root: Path | None = None
     combined_ca: Path | None = None
     bazelisk_path: Path | None = None
 
@@ -104,7 +102,6 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     if vars.proxy_port is not None:
         assert vars.session_dir is not None
         assert vars.supervisor_port is not None
-        assert vars.repo_root is not None
         assert vars.combined_ca is not None
         assert vars.bazelisk_path is not None
         local_proxy = f"http://localhost:{vars.proxy_port}"
@@ -113,7 +110,6 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
             ENV_AUTH_PROXY_PORT: str(vars.proxy_port),
             ENV_AUTH_PROXY_URL: local_proxy,
             ENV_BAZELISK_PATH: vars.bazelisk_path,
-            ENV_BAZEL_REPO_ROOT: vars.repo_root,
             # Supervisor port needed by bazel_wrapper to connect to supervisor
             ENV_SUPERVISOR_PORT: str(vars.supervisor_port),
         }

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -108,7 +108,6 @@ class PlatformSetup:
     # EnvVars params
     session_dir: Path | None = None
     supervisor_port: int | None = None
-    repo_root: Path | None = None
     bazelisk_path: Path | None = None
     docker_env: dict[str, str] | None = None
     mkcert_cert: Path | None = None
@@ -425,7 +424,6 @@ async def _setup_web(
         # EnvVars
         session_dir=paths.session_dir,
         supervisor_port=settings.supervisor_port,
-        repo_root=project_dir,
         bazelisk_path=bazelisk_path,
         docker_env=docker_env,
         mkcert_cert=mkcert_result.cert_path if isinstance(mkcert_result, mkcert_setup.MkcertSetup) else None,
@@ -547,7 +545,6 @@ async def run_session(
             session_dir=setup.session_dir,
             proxy_port=setup.proxy_port,
             supervisor_port=setup.supervisor_port,
-            repo_root=setup.repo_root,
             combined_ca=setup.combined_ca_path,
             bazelisk_path=setup.bazelisk_path,
             docker_env=setup.docker_env,

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -123,6 +123,11 @@ class SessionPaths:
         return Path("/tmp/claude") / self.session_id
 
     @property
+    def bazelrc(self) -> Path:
+        """Per-session bazelrc file (rendered by session start hook)."""
+        return self.session_dir / "bazelrc"
+
+    @property
     def bazel_cache_dir(self) -> Path:
         """Bazel cache directory (tmpfs-backed, via startup --output_user_root)."""
         return self.session_dir / "bazel-cache"


### PR DESCRIPTION
## Summary
Refactored bazelrc path handling to derive it directly from `SessionPaths` rather than passing it through environment variables. This simplifies the configuration flow and reduces unnecessary environment variable coupling.

## Key Changes
- Added `bazelrc` property to `SessionPaths` that returns `session_dir / "bazelrc"`
- Updated `bazel_wrapper.py` to use `paths.bazelrc` instead of reading `ENV_SESSION_BAZELRC` from environment
- Removed `ENV_SESSION_BAZELRC` import from `bazel_wrapper.py`
- Removed `ENV_BAZEL_REPO_ROOT` environment variable and related code:
  - Removed from `env_file.py` constants and `EnvVars` class
  - Removed from `session_start.py` setup flow
  - Removed assertions and writes in `write_env_file()`
- Updated documentation comment in `bazel_wrapper.py` to clarify bazelrc is derived from session dir
- Updated `.claude/settings.json` hook command to include `claude-hook` invocation

## Implementation Details
The bazelrc path is now computed directly from the `SessionPaths` object that's already available in `_async_main()`, eliminating the need to pass it through environment variables. This makes the code more maintainable and reduces the surface area of environment-based configuration.

https://claude.ai/code/session_018oCMKKin4oFoehKRUJxzr6