### PR TITLE
Refactor twenty questions eval logging and game loop

### DIFF
--- a/skills/info_gathering/evals/BUILD.bazel
+++ b/skills/info_gathering/evals/BUILD.bazel
@@ -17,6 +17,7 @@ py_library(
     imports = ["../../.."],
     visibility = ["//skills/info_gathering/evals:__subpackages__"],
     deps = [
+        "//agent_core:events",
         "//openai_utils:model",
         "//openai_utils:retry",
         "//util/bazel:runfiles",

--- a/skills/info_gathering/evals/harness.py
+++ b/skills/info_gathering/evals/harness.py
@@ -17,6 +17,7 @@ from typing import Literal
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 
+from agent_core.events import ToolCall
 from openai_utils.model import BoundOpenAIModel, OpenAIModelProto
 from openai_utils.retry import RetryingOpenAIModel
 from util.bazel.runfiles import get_required_path
@@ -34,7 +35,7 @@ class LogEntry(BaseModel):
     turn: int
     model: str
     content: str
-    tool_calls: list[dict] = []
+    tool_calls: list[ToolCall] = []
     stop_reason: str
 
 
@@ -48,18 +49,19 @@ class RunSummary(BaseModel):
 # === Logging/saving helpers ===================================================
 
 
-def save_results(*, name: str, log_entries: list[LogEntry], summary: RunSummary, output_dir: Path) -> None:
+def run_output_paths(name: str, output_dir: Path) -> tuple[Path, Path]:
+    """Create output_dir and return (calls_jsonl_path, summary_json_path)."""
     output_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     prefix = output_dir / f"{name}_{ts}"
-
     calls_path = prefix.with_name(prefix.name + "_calls.jsonl")
-    calls_path.write_text("".join(entry.model_dump_json() + "\n" for entry in log_entries))
-
     summary_path = prefix.with_name(prefix.name + "_summary.json")
-    summary_path.write_text(summary.model_dump_json(indent=2))
+    return calls_path, summary_path
 
-    logger.info("Saved: %s_*", prefix)
+
+def save_summary(*, summary: RunSummary, summary_path: Path) -> None:
+    summary_path.write_text(summary.model_dump_json(indent=2))
+    logger.info("Saved results to %s", summary_path.parent)
 
 
 # === CLI helpers ==============================================================

--- a/skills/info_gathering/evals/twenty_questions/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/twenty_questions.py
@@ -33,7 +33,8 @@ from skills.info_gathering.evals.harness import (
     load_skill,
     model_from_args,
     output_dir_from_args,
-    save_results,
+    run_output_paths,
+    save_summary,
 )
 from util.bazel.runfiles import get_required_path
 
@@ -63,12 +64,16 @@ class AnswerInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-@dataclass
-class SimAction:
-    """Records the sim's game action from a tool call."""
+class SimAnswer(BaseModel):
+    kind: Literal["answer"] = "answer"
+    response: Literal["yes", "no", "sort_of"]
 
-    tool_name: str
-    answer: str | None = None
+
+class SimCorrectAnswer(BaseModel):
+    kind: Literal["correct_answer"] = "correct_answer"
+
+
+SimAction = SimAnswer | SimCorrectAnswer
 
 
 @dataclass
@@ -116,24 +121,24 @@ class _TurnLogHandler(BaseHandler):
         *,
         eval_name: str,
         player: Literal["agent", "simulator"],
-        log_entries: list[LogEntry],
+        write_entry: Callable[[LogEntry], None],
         turn_getter: Callable[[], int],
     ) -> None:
         self._eval_name = eval_name
         self._player = player
-        self._log_entries = log_entries
+        self._write_entry = write_entry
         self._turn_getter = turn_getter
         self._text = ""
-        self._tool_calls: list[dict] = []
+        self._tool_calls: list[ToolCall] = []
 
     def on_assistant_text_event(self, evt: AssistantText) -> None:
         self._text += evt.text
 
     def on_tool_call_event(self, evt: ToolCall) -> None:
-        self._tool_calls.append({"id": evt.call_id, "name": evt.name, "arguments": evt.args_json})
+        self._tool_calls.append(evt)
 
     def on_response(self, evt: Response) -> None:
-        self._log_entries.append(
+        self._write_entry(
             LogEntry(
                 timestamp=datetime.now(UTC).isoformat(),
                 eval_name=self._eval_name,
@@ -163,104 +168,117 @@ class _TwentyQuestionsRunner:
     ) -> None:
         self.name = name
         self.model = model
-        self.log_entries: list[LogEntry] = []
-        self._current_turn = 0
+        self._agent_system = agent_system
+        self._sim_system = sim_system
+        self._agent_tool_provider = agent_tool_provider
+
+    async def run(self, *, first_user_message: str, turn_limit: int, output_dir: Path) -> RunSummary:
+        """Run the full game loop and return summary."""
+        calls_path, summary_path = run_output_paths(self.name, output_dir)
+
+        with calls_path.open("w") as calls_file:
+
+            def write_entry(entry: LogEntry) -> None:
+                calls_file.write(entry.model_dump_json() + "\n")
+                calls_file.flush()
+
+            summary = await self._run_game(
+                first_user_message=first_user_message, turn_limit=turn_limit, write_entry=write_entry
+            )
+
+        save_summary(summary=summary, summary_path=summary_path)
+        return summary
+
+    async def _run_game(
+        self, *, first_user_message: str, turn_limit: int, write_entry: Callable[[LogEntry], None]
+    ) -> RunSummary:
+        current_turn = 0
 
         # Sim tool provider: closures capture sim_action
-        self.sim_action: SimAction | None = None
+        sim_action: SimAction | None = None
         sim_provider = DirectToolProvider()
 
         @sim_provider.tool
         def answer(args: AnswerInput) -> str:
             """Answer the player's yes/no question."""
-            self.sim_action = SimAction(tool_name="answer", answer=args.response)
+            nonlocal sim_action
+            sim_action = SimAnswer(response=args.response)
             return args.response
 
         @sim_provider.tool
         def correct_answer() -> None:
             """The player correctly guessed the secret."""
-            self.sim_action = SimAction(tool_name="correct_answer")
+            nonlocal sim_action
+            sim_action = SimCorrectAnswer()
 
         agent_log = _TurnLogHandler(
-            eval_name=name, player="agent", log_entries=self.log_entries, turn_getter=lambda: self._current_turn
+            eval_name=self.name, player="agent", write_entry=write_entry, turn_getter=lambda: current_turn
         )
         sim_log = _TurnLogHandler(
-            eval_name=name, player="simulator", log_entries=self.log_entries, turn_getter=lambda: self._current_turn
+            eval_name=self.name, player="simulator", write_entry=write_entry, turn_getter=lambda: current_turn
         )
-        self._text_capture = _TextCaptureHandler()
+        text_capture = _TextCaptureHandler()
 
-        self._agent = Agent(
-            tool_provider=agent_tool_provider,
-            client=model,
+        agent = Agent(
+            tool_provider=self._agent_tool_provider,
+            client=self.model,
             parallel_tool_calls=False,
-            handlers=[agent_log, self._text_capture],
+            handlers=[agent_log, text_capture],
             tool_policy=AllowAnyToolOrTextMessage(),
         )
-        self._agent.process_message(SystemMessage.text(agent_system))
+        agent.process_message(SystemMessage.text(self._agent_system))
 
-        self._sim = Agent(
+        sim = Agent(
             tool_provider=sim_provider,
-            client=model,
+            client=self.model,
             parallel_tool_calls=False,
             handlers=[sim_log],
             tool_policy=RequireAnyTool(),
         )
-        self._sim.process_message(SystemMessage.text(sim_system))
+        sim.process_message(SystemMessage.text(self._sim_system))
 
-    async def _agent_turn(self) -> str | None:
-        """Step the agent until it produces text. Returns the text or None if stuck."""
-        for _ in range(_MAX_SCRATCH_STEPS):
-            await self._agent.step()
-            text = self._text_capture.take()
-            if text:
-                return text
-        logger.warning("Agent hit scratch step limit without producing text")
-        return None
+        async def agent_turn() -> str | None:
+            for _ in range(_MAX_SCRATCH_STEPS):
+                await agent.step()
+                text = text_capture.take()
+                if text:
+                    return text
+            logger.warning("Agent hit scratch step limit without producing text")
+            return None
 
-    async def _sim_turn(self, question: str) -> SimAction | None:
-        """Feed question to sim and step once. Returns the sim's action or None on failure."""
-        self.sim_action = None
-        self._sim.process_message(UserMessage.text(question))
-        await self._sim.step()
-        if self.sim_action is None:
-            logger.warning("Sim step produced no action (tool_choice=required was ignored)")
-        return self.sim_action
+        async def sim_turn(question: str) -> SimAction | None:
+            nonlocal sim_action
+            sim_action = None
+            sim.process_message(UserMessage.text(question))
+            await sim.step()
+            if sim_action is None:
+                logger.warning("Sim step produced no action (tool_choice=required was ignored)")
+            return sim_action
 
-    async def run(self, *, first_user_message: str, turn_limit: int, output_dir: Path) -> RunSummary:
-        """Run the full game loop and return summary."""
-        self._agent.process_message(UserMessage.text(first_user_message))
+        agent.process_message(UserMessage.text(first_user_message))
 
-        result: Correct | Timeout | None = None
-        turn = 0
+        result: Correct | Timeout = Timeout(limit=turn_limit)
+        last_turn = 0
         for turn in range(1, turn_limit + 1):
-            self._current_turn = turn
+            last_turn = turn
+            current_turn = turn
             logger.info("Turn %d...", turn)
 
-            agent_text = await self._agent_turn()
+            agent_text = await agent_turn()
             if not agent_text:
-                result = Timeout(limit=turn_limit)
                 break
 
-            action = await self._sim_turn(agent_text)
+            action = await sim_turn(agent_text)
             if action is None:
-                result = Timeout(limit=turn_limit)
                 break
 
-            if action.tool_name == "correct_answer":
+            if isinstance(action, SimCorrectAnswer):
                 result = Correct(turns=turn)
                 break
 
-            assert action.answer is not None
-            self._agent.process_message(UserMessage.text(action.answer))
-        else:
-            result = Timeout(limit=turn_limit)
+            agent.process_message(UserMessage.text(action.response))
 
-        if result is None:
-            result = Timeout(limit=turn_limit)
-
-        summary = RunSummary(eval_name=self.name, model=self.model.model, turns=turn, result=result)
-        save_results(name=self.name, log_entries=self.log_entries, summary=summary, output_dir=output_dir)
-        return summary
+        return RunSummary(eval_name=self.name, model=self.model.model, turns=last_turn, result=result)
 
 
 async def run_twenty_questions(


### PR DESCRIPTION
## Summary
Refactored the twenty questions evaluation to improve code organization and logging architecture. The main changes involve separating concerns between game loop logic and result persistence, converting the `SimAction` dataclass to a union type, and making the logging system more flexible through callback-based entry writing.

## Key Changes

- **Logging Architecture**: Replaced direct list mutation (`log_entries`) with a callback-based approach (`write_entry` callable) in `_TurnLogHandler`, enabling streaming writes to disk during game execution rather than batch writes at the end.

- **SimAction Type System**: Converted `SimAction` from a simple dataclass to a union type (`SimAnswer | SimCorrectAnswer`) using Pydantic `BaseModel`, providing better type safety and clearer semantics for different action types.

- **Game Loop Refactoring**: 
  - Extracted game logic into a separate `_run_game()` method that accepts a `write_entry` callback
  - Moved `run()` method to handle file I/O and call `_run_game()` with a file-writing callback
  - Converted instance methods (`_agent_turn`, `_sim_turn`) to local async functions within `_run_game()` using closures

- **Result Handling**: Simplified result tracking by initializing `result` to `Timeout` and only updating it on success, eliminating the need for `None` checks.

- **Output Path Handling**: Split `save_results()` into two functions:
  - `run_output_paths()`: Creates output directory and returns paths for calls and summary files
  - `save_summary()`: Writes only the summary JSON file

- **Tool Call Tracking**: Changed `tool_calls` field in `LogEntry` from `list[dict]` to `list[ToolCall]` for type safety, storing the actual `ToolCall` event objects instead of manually constructed dictionaries.

## Notable Implementation Details

- The `write_entry` callback is passed through the logging handler chain, allowing entries to be written to disk immediately as they're generated rather than accumulated in memory.
- Local variables (`current_turn`, `sim_action`, `agent`, `sim`, `text_capture`) are now scoped to `_run_game()` instead of being instance attributes, reducing state management complexity.
- The game loop now uses `last_turn` to track the final turn number for the summary, simplifying the result initialization logic.

https://claude.ai/code/session_01GsmWrhp1GRf2XixQMmc7Fa