### PR TITLE
Refactor process cleanup and fix Java truststore handling

### DIFF
--- a/cluster/validation/flux.py
+++ b/cluster/validation/flux.py
@@ -36,7 +36,6 @@ class FluxKustomizationSpec(BaseModel):
     path: str = ""
     depends_on: list[DependsOn] = []
     health_checks: list[HealthCheck] = []
-    retries: int | None = None
     retry_interval: str | None = None
     wait: bool = False
 

--- a/cluster/validation/health_checks.py
+++ b/cluster/validation/health_checks.py
@@ -52,27 +52,19 @@ def check_controller_health_checks(cluster: ParsedCluster, k8s_dir: Path, worksp
 
 
 def check_retry_policy(cluster: ParsedCluster, k8s_dir: Path) -> None:
-    """Enforce semantically correct retry policies on Flux Kustomizations.
+    """Enforce retryInterval on async Flux Kustomizations.
 
-    Async kustomizations (those with async health check kinds or wait: true)
-    require retries > 0 AND retryInterval. Retries without retryInterval is
-    nearly useless — retries default to the interval cadence (10m).
+    spec.retries does not exist in the Flux Kustomization CRD (v2.7.5+).
+    Only spec.retryInterval is valid — require it on kustomizations with async
+    health checks or wait: true.
     """
     errors: list[str] = []
     for name, flux_kust in cluster.flux_kustomizations.items():
         needs_retry = _has_async_health_checks(cluster, name) or flux_kust.spec.wait
-        retries = flux_kust.spec.retries
-        retry_interval = flux_kust.spec.retry_interval
-
         if not needs_retry:
             continue
-
-        rel_path = flux_kust.file_path.relative_to(k8s_dir)
-        if retries is None or retries <= 0:
-            errors.append(
-                f"{name}: has async health checks or wait: true but retries={retries}. Set retries > 0 in {rel_path}."
-            )
-        if not retry_interval:
+        if not flux_kust.spec.retry_interval:
+            rel_path = flux_kust.file_path.relative_to(k8s_dir)
             errors.append(
                 f"{name}: has async health checks or wait: true but no retryInterval. "
                 f"Set retryInterval (e.g. 1m) in {rel_path}."

--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -374,6 +374,14 @@ py_test(
 py_test(
     name = "test_integration",
     srcs = ["test_integration.py"],
+    data = [
+        "//third_party/jdk:cacerts",
+        "//third_party/jdk:keytool",
+    ],
+    env = {
+        "JAVA_CACERTS_RLOCATION": "$(rlocationpath //third_party/jdk:cacerts)",
+        "KEYTOOL_RLOCATION": "$(rlocationpath //third_party/jdk:keytool)",
+    },
     env_inherit = [
         "HTTPS_PROXY",
         "https_proxy",
@@ -381,6 +389,8 @@ py_test(
         "REQUESTS_CA_BUNDLE",
     ],
     imports = ["../.."],
+    # local: keytool (Adoptium JDK) needs libjli.so which isn't on the RBE worker image
+    local = True,
     tags = ["e2e"],
     deps = [
         ":conftest",

--- a/devinfra/claude/auth_proxy/setup.py
+++ b/devinfra/claude/auth_proxy/setup.py
@@ -194,9 +194,8 @@ async def _create_java_truststore(paths: SessionPaths) -> None:
 
     try:
         system_cacerts = _find_system_file(_get_java_cacerts_candidates(), "system Java cacerts")
-    except FileNotFoundError:
-        logger.warning("No Java cacerts found; skipping Java truststore creation")
-        return
+    except FileNotFoundError as e:
+        raise TruststoreError(str(e)) from e
 
     logger.info("Creating custom Java truststore from %s", system_cacerts)
 

--- a/devinfra/claude/auth_proxy/setup.py
+++ b/devinfra/claude/auth_proxy/setup.py
@@ -161,6 +161,7 @@ def _extract_proxy_ca(paths: SessionPaths) -> None:
         raise CaExtractionError(f"CA at {ca_file} is not an Anthropic TLS Inspection CA")
 
     logger.info("Loaded Anthropic CA from filesystem: %s", ca_file)
+    paths.auth_proxy_dir.mkdir(parents=True, exist_ok=True)
     paths.auth_proxy_ca_file.write_text(ca_pem)
 
 
@@ -193,8 +194,9 @@ async def _create_java_truststore(paths: SessionPaths) -> None:
 
     try:
         system_cacerts = _find_system_file(_get_java_cacerts_candidates(), "system Java cacerts")
-    except FileNotFoundError as e:
-        raise TruststoreError(str(e)) from e
+    except FileNotFoundError:
+        logger.warning("No Java cacerts found; skipping Java truststore creation")
+        return
 
     logger.info("Creating custom Java truststore from %s", system_cacerts)
 

--- a/devinfra/claude/conftest.py
+++ b/devinfra/claude/conftest.py
@@ -1,6 +1,5 @@
 """Pytest configuration for claude tests."""
 
-import os
 import uuid
 from pathlib import Path
 from unittest.mock import patch
@@ -17,9 +16,17 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @pytest.fixture
-def session_paths() -> SessionPaths:
+def session_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SessionPaths:
     """Minimal SessionPaths for tests that don't need supervisor/proxy infrastructure."""
-    return SessionPaths.from_env(f"test-session-{uuid.uuid4().hex[:8]}", dict(os.environ))
+    home = tmp_path / "session-home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    session_id = f"test-session-{uuid.uuid4().hex[:8]}"
+    paths = SessionPaths.from_env(session_id, {"HOME": str(home)})
+    # Pre-create subdirs that production code expects to exist
+    paths.session_dir.mkdir(parents=True, exist_ok=True)
+    paths.auth_proxy_dir.mkdir(parents=True, exist_ok=True)
+    return paths
 
 
 @pytest.fixture

--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -46,7 +46,7 @@ def configure(daemon_dir: Path, otlp_exporter: DeferredOtlpExporter) -> None:
     app.state.settings = HookSettings()
     app.state.otlp_exporter = otlp_exporter
     app.state.last_request_time = time.monotonic()
-    app.state.proxy: AuthForwardingProxy | None = None
+    app.state.proxy = None
 
     # Start auth proxy in-process if upstream proxy is configured.
     # The proxy binds the port immediately; credentials are written later

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -485,6 +485,7 @@ async def run_session(
 
     # Platform-specific setup
     if ctx.web_mode:
+        assert proxy is not None, "proxy must be running in web mode"
         setup = await _setup_web(paths, settings, project_dir, tracer, root_ctx, hook_config, http=http, proxy=proxy)
     else:
         # CLI mode: read k8s secrets (no proxy needed, combined_ca_path=None).

--- a/devinfra/claude/mkcert_setup.py
+++ b/devinfra/claude/mkcert_setup.py
@@ -58,6 +58,7 @@ def _download_mkcert(paths: SessionPaths, http: httpx.Client) -> Path:
     mkcert_path = _get_mkcert_binary(paths)
 
     mkcert_dir.mkdir(parents=True, exist_ok=True)
+    mkcert_path.parent.mkdir(parents=True, exist_ok=True)
 
     if mkcert_path.exists():
         logger.info("mkcert already downloaded: %s", mkcert_path)

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -76,9 +76,18 @@ class SessionPaths:
         return self.auth_proxy_dir / "cacerts.jks"
 
     @property
+    def cached_bin_dir(self) -> Path:
+        """Cached binary directory for downloaded tools (bazelisk, mkcert, etc.).
+
+        Unlike wrapper_dir, this is not session-scoped — binaries are shared
+        across sessions and only downloaded once.
+        """
+        return self.cache_dir / "bin"
+
+    @property
     def bazelisk_path(self) -> Path:
         """Bazelisk binary path (global cache, not session-scoped)."""
-        return self.cache_dir / "bin" / "bazelisk"
+        return self.cached_bin_dir / "bazelisk"
 
     @property
     def wrapper_dir(self) -> Path:
@@ -98,7 +107,7 @@ class SessionPaths:
     @property
     def mkcert_binary(self) -> Path:
         """mkcert binary path (global cache, not session-scoped)."""
-        return self.cache_dir / "mkcert"
+        return self.cached_bin_dir / "mkcert"
 
     @property
     def podman_dir(self) -> Path:

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -78,7 +78,7 @@ class SessionPaths:
     @property
     def bazelisk_path(self) -> Path:
         """Bazelisk binary path (global cache, not session-scoped)."""
-        return self.cache_dir / "bazelisk"
+        return self.cache_dir / "bin" / "bazelisk"
 
     @property
     def wrapper_dir(self) -> Path:

--- a/devinfra/claude/testing/session_start_helpers.py
+++ b/devinfra/claude/testing/session_start_helpers.py
@@ -139,30 +139,45 @@ def make_hook_input(project_dir: Path, source: HookSource = HookSource.STARTUP) 
     ).model_dump_json()
 
 
+def _kill_by_pidfile(pidfile: Path) -> None:
+    """Kill a process using its pidfile. Ignores errors."""
+    if not pidfile.exists():
+        return
+    try:
+        pid = int(pidfile.read_text().strip())
+        os.kill(pid, signal.SIGTERM)
+        for _ in range(20):
+            time.sleep(0.1)
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+        else:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+    except (ValueError, ProcessLookupError, OSError):
+        pass
+    with contextlib.suppress(OSError):
+        pidfile.unlink()
+
+
 def cleanup_supervisor(config_dir: Path) -> None:
     """Kill any lingering supervisor processes."""
-    pidfile = config_dir / "supervisor" / "supervisord.pid"
-    if pidfile.exists():
-        try:
-            pid = int(pidfile.read_text().strip())
-            # Send SIGTERM first
-            os.kill(pid, signal.SIGTERM)
-            # Wait for process to die (up to 2 seconds)
-            for _ in range(20):
-                time.sleep(0.1)
-                try:
-                    os.kill(pid, 0)  # Check if process exists
-                except ProcessLookupError:
-                    break  # Process is gone
-            else:
-                # Force kill if still running
-                with contextlib.suppress(ProcessLookupError):
-                    os.kill(pid, signal.SIGKILL)
-        except (ValueError, ProcessLookupError, OSError):
-            pass
-        # Clean up pidfile
-        with contextlib.suppress(OSError):
-            pidfile.unlink()
+    _kill_by_pidfile(config_dir / "supervisor" / "supervisord.pid")
+
+
+def cleanup_hook_daemon(session_dir: Path) -> None:
+    """Kill any lingering hook daemon process and remove its socket.
+
+    The daemon shares a socket path based on session_id, so killing it between
+    tests ensures each test gets a fresh daemon with its own isolated port config.
+    """
+    _kill_by_pidfile(session_dir / "hook-daemon" / "daemon.pid")
+    # Remove the shared socket so the next test's daemon can bind to it
+    # Socket path: /tmp/claude-hd/<session_id>/d.sock (see SessionPaths.hook_daemon_sock)
+    sock_path = Path("/tmp/claude-hd") / session_dir.name / "d.sock"
+    with contextlib.suppress(OSError):
+        sock_path.unlink()
 
 
 def write_output_log(name: str, content: str) -> Path:
@@ -223,7 +238,8 @@ async def run_session_start_hook(
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test(isolated_dirs: IsolatedDirs) -> Generator[None]:
-    """Cleanup supervisor and tmpfs mounts after each test."""
+    """Cleanup supervisor, hook daemon, and tmpfs mounts after each test."""
     yield
     unmount_tmpfs_under(isolated_dirs.session_dir)
     cleanup_supervisor(isolated_dirs.session_dir)
+    cleanup_hook_daemon(isolated_dirs.session_dir)

--- a/devinfra/claude/testing/session_start_helpers.py
+++ b/devinfra/claude/testing/session_start_helpers.py
@@ -21,6 +21,7 @@ from devinfra.claude.auth_proxy.setup import SSL_CA_ENV_VARS, SYSTEM_CA_BUNDLES
 from devinfra.claude.auth_proxy.vars import PROXY_ENV_VARS
 from devinfra.claude.claude_api.hooks.common import PermissionMode
 from devinfra.claude.claude_api.hooks.session_start import HookSource, SessionStartHookInput
+from devinfra.claude.session_paths import SessionPaths
 from devinfra.claude.testing import shell_helpers
 from devinfra.claude.testing.mock_egress_proxy import MockEgressProxy
 from devinfra.claude.tmpfs_setup import unmount_tmpfs_under
@@ -172,12 +173,11 @@ def cleanup_hook_daemon(session_dir: Path) -> None:
     The daemon shares a socket path based on session_id, so killing it between
     tests ensures each test gets a fresh daemon with its own isolated port config.
     """
-    _kill_by_pidfile(session_dir / "hook-daemon" / "daemon.pid")
-    # Remove the shared socket so the next test's daemon can bind to it
-    # Socket path: /tmp/claude-hd/<session_id>/d.sock (see SessionPaths.hook_daemon_sock)
-    sock_path = Path("/tmp/claude-hd") / session_dir.name / "d.sock"
+    home = session_dir.parent.parent.parent  # session_dir = home/.claude/session-env/<id>
+    paths = SessionPaths.from_env(session_dir.name, {"HOME": str(home)})
+    _kill_by_pidfile(paths.hook_daemon_pidfile)
     with contextlib.suppress(OSError):
-        sock_path.unlink()
+        paths.hook_daemon_sock.unlink()
 
 
 def write_output_log(name: str, content: str) -> Path:


### PR DESCRIPTION
## Summary
This PR refactors process cleanup logic, improves error handling for Java truststore creation, and fixes several configuration issues across the codebase.

## Key Changes

- **Process cleanup refactoring**: Extracted common pidfile-based process killing logic into a reusable `_kill_by_pidfile()` helper function to reduce code duplication
- **Hook daemon cleanup**: Added new `cleanup_hook_daemon()` function to properly terminate hook daemon processes and clean up their Unix sockets between tests, ensuring test isolation
- **Java truststore handling**: Changed Java truststore creation to gracefully skip when system cacerts are not found (with a warning) instead of raising an error
- **Flux validation simplification**: Removed validation for non-existent `spec.retries` field from Flux Kustomization CRD and updated docstring to clarify that only `spec.retryInterval` is valid
- **Directory creation**: Added explicit directory creation before writing auth proxy CA file to ensure parent directories exist
- **Bazelisk path fix**: Updated bazelisk cache path from `cache_dir/bazelisk` to `cache_dir/bin/bazelisk` for proper binary organization
- **Type annotation cleanup**: Simplified type annotation in hook daemon server state initialization
- **Web mode assertion**: Added assertion to ensure proxy is running when in web mode

## Notable Implementation Details

- The `_kill_by_pidfile()` helper implements a graceful shutdown pattern: sends SIGTERM, waits up to 2 seconds for process termination, then sends SIGKILL if needed
- Hook daemon socket cleanup uses the session directory name to construct the socket path (`/tmp/claude-hd/<session_id>/d.sock`)
- Test cleanup fixture now calls both supervisor and hook daemon cleanup functions

https://claude.ai/code/session_01A8HsAKVWnFY7qS6UsADKWY