### PR TITLE
fix: correct test target path in test-ducktape-wheel CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         run: uv tool install bazel-bin/ducktape-*.whl
       - name: Test installed wheel
         run: |
-          bazel test //devinfra/claude:test_session_start \
+          bazel test //devinfra/claude/hook_daemon:test_session_start \
             --test_output=all \
             --nocache_test_results \
             --spawn_strategy=local \


### PR DESCRIPTION
## Summary

- The `test-ducktape-wheel` CI job was referencing `//devinfra/claude:test_session_start`, which doesn't exist
- The target lives at `//devinfra/claude/hook_daemon:test_session_start`

## Test plan

- [ ] Re-run the `test-ducktape-wheel` job and confirm it proceeds past target resolution to actually run tests

https://claude.ai/code/session_01BSTiKYohFEN8kz9bCfmD3k