### PR TITLE
Fix CI: update test_session_start target path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         run: uv tool install bazel-bin/ducktape-*.whl
       - name: Test installed wheel
         run: |
-          bazel test //devinfra/claude:test_session_start \
+          bazel test //devinfra/claude/hook_daemon:test_session_start \
             --test_output=all \
             --nocache_test_results \
             --spawn_strategy=local \

--- a/devinfra/ci/workflows.yaml
+++ b/devinfra/ci/workflows.yaml
@@ -154,7 +154,7 @@ releases:
             run: uv tool install bazel-bin/ducktape-*.whl
           - name: Test installed wheel
             run: |
-              bazel test //devinfra/claude:test_session_start \
+              bazel test //devinfra/claude/hook_daemon:test_session_start \
                 --test_output=all \
                 --nocache_test_results \
                 --spawn_strategy=local \


### PR DESCRIPTION
## Summary

- Update `//devinfra/claude:test_session_start` → `//devinfra/claude/hook_daemon:test_session_start` in `workflows.yaml` and regenerated `release.yml`
- The test was moved in #891 but the CI workflow reference was not updated, breaking the `test-ducktape-wheel` job

## Test plan

- [ ] `test-ducktape-wheel` CI job passes (previously failing with `no such target '//devinfra/claude:test_session_start'`)

https://claude.ai/code/session_015uBCPZ4JSbtwCWUwAGb2y2