### PR TITLE
Fix test target path in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         run: uv tool install bazel-bin/ducktape-*.whl
       - name: Test installed wheel
         run: |
-          bazel test //devinfra/claude:test_session_start \
+          bazel test //devinfra/claude/hook_daemon:test_session_start \
             --test_output=all \
             --nocache_test_results \
             --spawn_strategy=local \

--- a/devinfra/ci/workflows.yaml
+++ b/devinfra/ci/workflows.yaml
@@ -154,7 +154,7 @@ releases:
             run: uv tool install bazel-bin/ducktape-*.whl
           - name: Test installed wheel
             run: |
-              bazel test //devinfra/claude:test_session_start \
+              bazel test //devinfra/claude/hook_daemon:test_session_start \
                 --test_output=all \
                 --nocache_test_results \
                 --spawn_strategy=local \


### PR DESCRIPTION
## Summary
Updated the bazel test target path in release workflows to reflect the correct location of the test_session_start test.

## Changes
- Updated test target path from `//devinfra/claude:test_session_start` to `//devinfra/claude/hook_daemon:test_session_start` in both:
  - `.github/workflows/release.yml`
  - `devinfra/ci/workflows.yaml`

## Details
The test target has been moved to a subdirectory (`hook_daemon`) within the `devinfra/claude` package. This change ensures the release workflows correctly reference the test in its new location when validating the installed wheel.

https://claude.ai/code/session_015uBCPZ4JSbtwCWUwAGb2y2