### PR TITLE
fix: daemon crash detection via proc.poll() instead of os.kill(pid, 0)

### DIFF
--- a/devinfra/claude/hook_daemon/client.py
+++ b/devinfra/claude/hook_daemon/client.py
@@ -24,8 +24,6 @@ from util.bazel.subprocess import python_env
 logger = logging.getLogger(__name__)
 
 # How long to wait for the daemon socket to appear after starting the daemon.
-# Must be generous: on cold CI runners, importing uvicorn/FastAPI/opentelemetry
-# can take several seconds.
 _DAEMON_STARTUP_TIMEOUT_SECS = 5
 
 
@@ -61,9 +59,9 @@ def call_daemon(hook_input: AnyHookInput, env: dict[str, str], paths: SessionPat
         logger.info("Daemon unreachable on existing socket %s, will restart", sock_path)
 
     # Daemon unreachable or socket missing — start it
-    daemon_pid = _start_daemon(paths)
-    if daemon_pid is not None:
-        _wait_for_sock(sock_path, daemon_pid=daemon_pid, daemon_dir=paths.hook_daemon_dir)
+    proc = _start_daemon(paths)
+    if proc is not None:
+        _wait_for_sock(sock_path, proc=proc, daemon_dir=paths.hook_daemon_dir)
         return _post_to_daemon(request, sock_path)
 
     return None
@@ -96,8 +94,12 @@ def _is_pid_alive(pid: int) -> bool:
         return False
 
 
-def _start_daemon(paths: SessionPaths) -> int | None:
-    """Fork daemon as a detached background process. Returns PID if started, None on failure."""
+def _start_daemon(paths: SessionPaths) -> subprocess.Popen[bytes] | None:
+    """Fork daemon as a detached background process.
+
+    Returns the Popen object so callers can use proc.poll() for crash detection
+    (os.kill(pid, 0) cannot distinguish zombies from live processes).
+    """
     daemon_dir = paths.hook_daemon_dir
     sock_path = paths.hook_daemon_sock
     pidfile = paths.hook_daemon_pidfile
@@ -117,7 +119,7 @@ def _start_daemon(paths: SessionPaths) -> int | None:
                     logger.info("Killed stale daemon pid=%d", pid)
                 else:
                     logger.debug("Daemon already running (pid=%d, socket=%s)", pid, sock_path)
-                    return pid
+                    return None
             else:
                 logger.info("Stale pidfile (pid=%d is dead), cleaning up", pid)
         except (ValueError, OSError) as e:
@@ -151,7 +153,7 @@ def _start_daemon(paths: SessionPaths) -> int | None:
     # Write pidfile
     pidfile.write_text(str(proc.pid))
     logger.info("Started daemon (pid=%d, sock=%s)", proc.pid, sock_path)
-    return proc.pid
+    return proc
 
 
 def _read_daemon_error_log(daemon_dir: Path) -> str:
@@ -167,14 +169,18 @@ def _read_daemon_error_log(daemon_dir: Path) -> str:
 
 
 def _wait_for_sock(
-    sock_path: Path, *, daemon_pid: int, daemon_dir: Path, timeout_secs: float = _DAEMON_STARTUP_TIMEOUT_SECS
+    sock_path: Path,
+    *,
+    proc: subprocess.Popen[bytes],
+    daemon_dir: Path,
+    timeout_secs: float = _DAEMON_STARTUP_TIMEOUT_SECS,
 ) -> bool:
     """Poll until socket file exists and accepts connections.
 
-    Checks daemon process health during the wait. If the daemon dies before
-    the socket appears, fails fast and logs the daemon's error output.
+    Uses proc.poll() for crash detection — this correctly reaps zombies via
+    waitpid(WNOHANG), unlike os.kill(pid, 0) which succeeds on zombies.
     """
-    logger.debug("Waiting for daemon socket %s (pid=%d, timeout=%.1fs)", sock_path, daemon_pid, timeout_secs)
+    logger.debug("Waiting for daemon socket %s (pid=%d, timeout=%.1fs)", sock_path, proc.pid, timeout_secs)
     deadline = time.monotonic() + timeout_secs
     while time.monotonic() < deadline:
         if sock_path.exists():
@@ -187,10 +193,13 @@ def _wait_for_sock(
             except (ConnectionRefusedError, OSError):
                 pass
 
-        # Check if daemon process is still alive — fail fast if it crashed
-        if not _is_pid_alive(daemon_pid):
+        # proc.poll() calls waitpid(WNOHANG) — reaps zombies and returns exit code
+        exit_code = proc.poll()
+        if exit_code is not None:
             logs = _read_daemon_error_log(daemon_dir)
-            raise DaemonStartError(f"Daemon process (pid={daemon_pid}) died before socket appeared.\n{logs}")
+            raise DaemonStartError(
+                f"Daemon process (pid={proc.pid}) exited with code {exit_code} before socket appeared.\n{logs}"
+            )
 
         time.sleep(0.1)
     logger.warning("Daemon socket did not appear within %.1fs at %s", timeout_secs, sock_path)


### PR DESCRIPTION
## Summary

- `_start_daemon` returns the `Popen` object instead of just the PID
- `_wait_for_sock` uses `proc.poll()` instead of `os.kill(pid, 0)` for crash detection
- `os.kill(pid, 0)` succeeds on zombie processes (parent never reaps due to `start_new_session=True`), so the daemon could crash instantly and the client would wait the full 5s timeout silently
- `proc.poll()` calls `waitpid(WNOHANG)` which correctly reaps zombies and returns the exit code

This should fix the `test-ducktape-wheel` CI failure — if the daemon crashes on import in the wheel venv, we now get an immediate `DaemonStartError` with the daemon's stderr.

## Test plan

- [x] `bazel test //devinfra/claude/hook_daemon/...` — all 5 tests pass
- [x] `bazel build //devinfra/claude/hook_daemon/...` — lint clean
- [ ] CI `test-ducktape-wheel` — will reveal actual wheel issue if daemon crashes

https://claude.ai/code/session_0126x1qwwubMMcRC7tW6o6Pz