### PR TITLE
feat: add interactive Flux Kustomization DAG visualization

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -209,6 +209,7 @@ use_repo(oci, "debian_slim", "debian_slim_linux_amd64", "distroless_cc_debian12"
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
 bazel_dep(name = "aspect_rules_js", version = "2.9.2")
+bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.3")
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
@@ -226,6 +227,16 @@ use_repo(playwright, "playwright_browsers")
 # Node.js toolchain
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(node_version = "22.11.0")  # LTS 'Jod'
+
+# esbuild toolchain (for esbuild_bundle rule)
+esbuild = use_extension("@aspect_rules_esbuild//esbuild:extensions.bzl", "esbuild")
+esbuild.toolchain(
+    name = "esbuild",
+    esbuild_version = "0.25.11",
+)
+use_repo(esbuild, "esbuild_toolchains")
+
+register_toolchains("@esbuild_toolchains//:all")
 
 # Pin pnpm v9 to match the lockfile format (rules_js 2.9.2 defaults to pnpm v8
 # which cannot read lockfileVersion 9 and triggers a non-hermetic regeneration).
@@ -256,6 +267,7 @@ npm.npm_translate_lock(
     data = [
         "//:airlock/frontend/package.json",
         "//:airlock/openclaw/package.json",
+        "//:cluster/scripts/visualize_dag/package.json",
         "//:package.json",
         "//:pnpm-workspace.yaml",
         "//:props/frontend/package.json",

--- a/cluster/scripts/visualize_dag/BUILD.bazel
+++ b/cluster/scripts/visualize_dag/BUILD.bazel
@@ -1,0 +1,48 @@
+# gazelle:ignore
+
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm_ducktape//:defs.bzl", "npm_link_all_packages")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+npm_link_all_packages(name = "node_modules")
+
+js_library(
+    name = "dag_js",
+    srcs = ["dag.mjs"],
+    deps = [":node_modules"],
+)
+
+esbuild(
+    name = "dag_bundle",
+    entry_point = "dag.mjs",
+    format = "iife",
+    minify = True,
+    output = "dag.bundle.js",
+    platform = "browser",
+    deps = [":dag_js"],
+)
+
+py_library(
+    name = "main",
+    srcs = ["main.py"],
+    imports = ["../../.."],
+    deps = [
+        "//cluster/validation:cluster",
+        "//util/bazel:runfiles",
+        "//util/bazel:workspace",
+        "@pypi//networkx",
+        "@pypi//types_networkx",
+    ],
+)
+
+py_binary(
+    name = "visualize_dag",
+    data = [
+        "template.html",
+        ":dag_bundle",
+    ],
+    imports = ["../../.."],
+    main_module = "cluster.scripts.visualize_dag.main",
+    deps = [":main"],
+)

--- a/cluster/scripts/visualize_dag/dag.mjs
+++ b/cluster/scripts/visualize_dag/dag.mjs
@@ -1,0 +1,209 @@
+import * as d3 from "d3";
+import { graphStratify, sugiyama, shapeEllipse, tweakShape } from "d3-dag";
+
+const DATA = window.GRAPH_DATA;
+const NODE_R = 7;
+
+// Convert edge list to d3-dag parentIds format.
+// Edge convention: source depends on target → target is parent.
+const parentMap = new Map();
+DATA.nodes.forEach((n) => parentMap.set(n.id, []));
+DATA.links.forEach((l) => {
+  if (parentMap.has(l.source)) parentMap.get(l.source).push(l.target);
+});
+const dagData = DATA.nodes.map((n) => ({
+  id: n.id,
+  parentIds: parentMap.get(n.id) || [],
+}));
+
+// Build DAG and run Sugiyama layout
+const dag = graphStratify()(dagData);
+const nodeW = 180;
+const nodeH = 28;
+const layout = sugiyama()
+  .nodeSize([nodeW, nodeH])
+  .gap([12, 8])
+  .tweaks([tweakShape([nodeW, nodeH], shapeEllipse)]);
+const { width, height } = layout(dag);
+
+// Build adjacency maps for interactive highlight
+const depsOf = new Map();
+const rdepsOf = new Map();
+DATA.nodes.forEach((n) => {
+  depsOf.set(n.id, new Set());
+  rdepsOf.set(n.id, new Set());
+});
+DATA.links.forEach((l) => {
+  depsOf.get(l.source).add(l.target);
+  rdepsOf.get(l.target).add(l.source);
+});
+
+function transitive(startId, adjMap) {
+  const visited = new Set();
+  const stack = [startId];
+  while (stack.length) {
+    const cur = stack.pop();
+    if (visited.has(cur)) continue;
+    visited.add(cur);
+    for (const nb of adjMap.get(cur) || []) stack.push(nb);
+  }
+  return visited;
+}
+
+// SVG setup
+const W = window.innerWidth;
+const H = window.innerHeight;
+const svg = d3.select("#dag").attr("width", W).attr("height", H);
+const root = svg.append("g");
+
+// Fit the DAG into the viewport
+const pad = 40;
+const scale = Math.min((W - 2 * pad) / width, (H - 2 * pad) / height);
+const tx = (W - width * scale) / 2;
+const ty = (H - height * scale) / 2;
+const zoomBehavior = d3
+  .zoom()
+  .scaleExtent([0.05, 4])
+  .on("zoom", (e) => root.attr("transform", e.transform));
+svg.call(zoomBehavior);
+svg.call(
+  zoomBehavior.transform,
+  d3.zoomIdentity.translate(tx, ty).scale(scale),
+);
+
+// Arrow markers
+const defs = root.append("defs");
+function makeArrow(id, color) {
+  defs
+    .append("marker")
+    .attr("id", id)
+    .attr("viewBox", "0 -4 8 8")
+    .attr("refX", 8)
+    .attr("refY", 0)
+    .attr("markerWidth", 5)
+    .attr("markerHeight", 5)
+    .attr("orient", "auto")
+    .append("path")
+    .attr("fill", color)
+    .attr("d", "M0,-4L8,0L0,4Z");
+}
+makeArrow("arrow", "#555");
+makeArrow("arrow-hl", "#ff6b6b");
+
+// Render edges as curved paths
+const line = d3.line().curve(d3.curveCatmullRom);
+const linkG = root.append("g");
+const links = dag.links();
+const linkSel = linkG
+  .selectAll("path")
+  .data(links)
+  .join("path")
+  .attr("class", "link")
+  .attr("marker-end", "url(#arrow)")
+  .attr("d", (d) => line(d.points));
+
+// Render nodes
+const nodeG = root.append("g");
+const nodes = [...dag.nodes()];
+const nodeSel = nodeG
+  .selectAll("g")
+  .data(nodes)
+  .join("g")
+  .attr("class", "node")
+  .attr("transform", (d) => `translate(${d.x},${d.y})`);
+nodeSel.append("circle").attr("r", NODE_R);
+nodeSel
+  .append("text")
+  .text((d) => d.data.id)
+  .attr("dx", NODE_R + 4)
+  .attr("dy", 3);
+
+// Tooltip
+const tooltip = d3.select("#tooltip");
+nodeSel
+  .on("mouseover", (_event, d) => {
+    const id = d.data.id;
+    const deps = [...(depsOf.get(id) || [])].sort();
+    const rdeps = [...(rdepsOf.get(id) || [])].sort();
+    let html = "<h3>" + id + "</h3>";
+    if (deps.length) {
+      html +=
+        '<span class="label">Depends on (' + deps.length + "):</span><ul>";
+      deps.forEach((x) => (html += "<li>" + x + "</li>"));
+      html += "</ul>";
+    }
+    if (rdeps.length) {
+      html +=
+        '<span class="label">Depended on by (' +
+        rdeps.length +
+        "):</span><ul>";
+      rdeps.forEach((x) => (html += "<li>" + x + "</li>"));
+      html += "</ul>";
+    }
+    tooltip.html(html).style("display", "block");
+  })
+  .on("mousemove", (event) => {
+    tooltip
+      .style("left", event.clientX + 16 + "px")
+      .style("top", event.clientY - 10 + "px");
+  })
+  .on("mouseout", () => tooltip.style("display", "none"));
+
+// Click to highlight transitive dependency chain
+let selectedId = null;
+
+function linkId(l) {
+  const s = l.source.data ? l.source.data.id : l.source;
+  const t = l.target.data ? l.target.data.id : l.target;
+  return [s, t];
+}
+
+function clearHighlight() {
+  selectedId = null;
+  nodeSel.select("circle").attr("class", "");
+  nodeSel.select("text").attr("class", "");
+  linkSel.attr("class", "link").attr("marker-end", "url(#arrow)");
+}
+
+nodeSel.on("click", (event, d) => {
+  event.stopPropagation();
+  const id = d.data.id;
+  if (selectedId === id) {
+    clearHighlight();
+    return;
+  }
+  selectedId = id;
+  const ancestors = transitive(id, depsOf);
+  const descendants = transitive(id, rdepsOf);
+  const related = new Set([...ancestors, ...descendants]);
+
+  nodeSel.select("circle").attr("class", (n) => {
+    const nid = n.data.id;
+    if (nid === id) return "selected";
+    return related.has(nid) ? "highlighted" : "dimmed";
+  });
+  nodeSel
+    .select("text")
+    .attr("class", (n) => (related.has(n.data.id) ? "" : "dimmed"));
+  linkSel
+    .attr("class", (l) => {
+      const [s, t] = linkId(l);
+      if (ancestors.has(s) && ancestors.has(t)) return "link highlighted";
+      if (descendants.has(s) && descendants.has(t)) return "link highlighted";
+      return "link dimmed";
+    })
+    .attr("marker-end", (l) => {
+      const [s, t] = linkId(l);
+      if (
+        (ancestors.has(s) && ancestors.has(t)) ||
+        (descendants.has(s) && descendants.has(t))
+      )
+        return "url(#arrow-hl)";
+      return "url(#arrow)";
+    });
+});
+
+svg.on("click", clearHighlight);
+
+// Remove loading indicator
+document.getElementById("loading").remove();

--- a/cluster/scripts/visualize_dag/main.py
+++ b/cluster/scripts/visualize_dag/main.py
@@ -1,0 +1,61 @@
+"""Visualize the Flux Kustomization dependency DAG as an interactive D3.js HTML page.
+
+Usage: bazel run //cluster/scripts/visualize_dag [-- --output /path/to/dag.html]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import networkx as nx
+
+from cluster.validation.cluster import _K8S_SUBPATH, parse_cluster
+from util.bazel.runfiles import get_required_path
+from util.bazel.workspace import get_build_working_directory, get_build_workspace_directory
+
+_DATA_PLACEHOLDER = "/*GRAPH_DATA*/null"
+_BUNDLE_PLACEHOLDER = "/*BUNDLE*/"
+
+
+def _build_graph_json(g: nx.DiGraph) -> str:
+    """Serialize the dependency graph as JSON for the D3 template."""
+    nodes = [{"id": name} for name in g.nodes]
+    links = [{"source": u, "target": v} for u, v in g.edges]
+    return json.dumps({"nodes": nodes, "links": links})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Flux Kustomization DAG → interactive HTML")
+    parser.add_argument("--output", "-o", type=Path, default=Path("flux-dag.html"))
+    parser.add_argument("--include-suspended", action="store_true", help="Include suspended kustomizations")
+    args = parser.parse_args()
+
+    k8s_dir = get_build_workspace_directory() / _K8S_SUBPATH
+    print(f"Parsing {k8s_dir}...", file=sys.stderr)
+    cluster = parse_cluster(k8s_dir)
+    g = cluster.graph
+    if not args.include_suspended:
+        suspended = {name for name, ks in cluster.flux_kustomizations.items() if ks.spec.suspend}
+        if suspended:
+            g = g.copy()
+            g.remove_nodes_from(suspended)
+            print(f"Excluded {len(suspended)} suspended kustomizations", file=sys.stderr)
+    print(f"{g.number_of_nodes()} nodes, {g.number_of_edges()} edges", file=sys.stderr)
+
+    graph_json = _build_graph_json(g)
+    template = get_required_path("_main/cluster/scripts/visualize_dag/template.html").read_text()
+    bundle = get_required_path("_main/cluster/scripts/visualize_dag/dag.bundle.js").read_text()
+
+    html = template.replace(_DATA_PLACEHOLDER, graph_json).replace(_BUNDLE_PLACEHOLDER, bundle)
+
+    out = args.output if args.output.is_absolute() else get_build_working_directory() / args.output
+    out.write_text(html)
+    print(f"Written to {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cluster/scripts/visualize_dag/package.json
+++ b/cluster/scripts/visualize_dag/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "visualize-dag",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "d3": "^7.9.0",
+    "d3-dag": "^1.1.0"
+  }
+}

--- a/cluster/scripts/visualize_dag/template.html
+++ b/cluster/scripts/visualize_dag/template.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Flux Kustomization DAG</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+      }
+      body {
+        background: #1a1a2e;
+        overflow: hidden;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      }
+      svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      .link {
+        stroke: #555;
+        stroke-width: 1.2;
+        fill: none;
+      }
+      .link.highlighted {
+        stroke: #ff6b6b;
+        stroke-width: 2.5;
+      }
+      .link.dimmed {
+        stroke: #222;
+        stroke-width: 0.5;
+      }
+      .node circle {
+        fill: #4a90d9;
+        stroke: #6ab0ff;
+        stroke-width: 1.5;
+        cursor: pointer;
+        transition: fill 0.15s;
+      }
+      .node circle:hover {
+        fill: #6ab0ff;
+      }
+      .node circle.dimmed {
+        fill: #333;
+        stroke: #444;
+      }
+      .node circle.highlighted {
+        fill: #4a90d9;
+        stroke: #ff6b6b;
+        stroke-width: 2.5;
+      }
+      .node circle.selected {
+        fill: #ff6b6b;
+        stroke: #fff;
+        stroke-width: 3;
+      }
+      .node text {
+        fill: #ccc;
+        font-size: 10px;
+        pointer-events: none;
+      }
+      .node text.dimmed {
+        fill: #444;
+      }
+      #tooltip {
+        position: fixed;
+        display: none;
+        background: #16213e;
+        color: #e0e0e0;
+        border: 1px solid #4a90d9;
+        border-radius: 6px;
+        padding: 10px 14px;
+        font-size: 12px;
+        max-width: 350px;
+        pointer-events: none;
+        z-index: 100;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+      #tooltip h3 {
+        color: #6ab0ff;
+        margin-bottom: 6px;
+        font-size: 13px;
+      }
+      #tooltip .label {
+        color: #888;
+      }
+      #tooltip ul {
+        margin: 4px 0 0 16px;
+      }
+      #tooltip li {
+        margin: 1px 0;
+      }
+      #controls {
+        position: fixed;
+        top: 12px;
+        right: 12px;
+        color: #888;
+        font-size: 11px;
+        background: rgba(22, 33, 62, 0.9);
+        padding: 8px 12px;
+        border-radius: 6px;
+        border: 1px solid #333;
+      }
+      #loading {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: #6ab0ff;
+        font-size: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="loading">Computing layout...</div>
+    <div id="tooltip"></div>
+    <div id="controls">
+      Scroll to zoom &middot; Drag to pan &middot; Click node to highlight deps &middot; Click background to reset
+    </div>
+    <svg id="dag"></svg>
+    <script>
+      window.GRAPH_DATA = /*GRAPH_DATA*/ null;
+    </script>
+    <script>
+      /*BUNDLE*/
+    </script>
+  </body>
+</html>

--- a/cluster/validation/flux.py
+++ b/cluster/validation/flux.py
@@ -38,6 +38,7 @@ class FluxKustomizationSpec(BaseModel):
     health_checks: list[HealthCheck] = []
     retry_interval: str | None = None
     wait: bool = False
+    suspend: bool = False
 
 
 class FluxKustomization(BaseModel):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,15 @@ importers:
         specifier: '*'
         version: 2026.2.26(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(hono@4.12.3)(node-llama-cpp@3.15.1(typescript@5.8.3))
 
+  cluster/scripts/visualize_dag:
+    dependencies:
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
+      d3-dag:
+        specifier: ^1.1.0
+        version: 1.1.0
+
   props/frontend:
     dependencies:
       '@careswitch/svelte-data-table':
@@ -3216,6 +3225,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -3293,6 +3306,136 @@ packages:
 
   curve25519-js@0.0.4:
     resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-dag@1.1.0:
+    resolution: {integrity: sha512-N8IxsIHcUaIxLrV3cElTC47kVJGFiY3blqSuJubQhyhYBJs0syfFPTnRSj2Cq0LBxxi4mzJmcqCvHIv9sPdILQ==}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3382,6 +3525,9 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  delaunator@5.0.1:
+    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3998,6 +4144,10 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -4225,6 +4375,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
@@ -4333,6 +4487,10 @@ packages:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -4345,6 +4503,10 @@ packages:
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -4413,6 +4575,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  javascript-lp-solver@0.4.24:
+    resolution: {integrity: sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -5457,6 +5622,10 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  quadprog@1.6.1:
+    resolution: {integrity: sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==}
+    engines: {node: '>=8.x'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -5616,6 +5785,9 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  robust-predicates@3.0.2:
+    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
   rolldown@1.0.0-beta.57:
     resolution: {integrity: sha512-lMMxcNN71GMsSko8RyeTaFoATHkCh4IWU7pYF73ziMYjhHZWfVesC6GQ+iaJCvZmVjvgSks9Ks1aaqEkBd8udg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5635,6 +5807,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -5917,6 +6092,10 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-object@5.0.0:
+    resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
+    engines: {node: '>=14.16'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -9997,6 +10176,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@7.2.0: {}
+
   concat-map@0.0.1: {}
 
   console-control-strings@1.1.0: {}
@@ -10059,6 +10240,165 @@ snapshots:
   csstype@3.2.3: {}
 
   curve25519-js@0.0.4: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-dag@1.1.0:
+    dependencies:
+      d3-array: 3.2.4
+      javascript-lp-solver: 0.4.24
+      quadprog: 1.6.1
+      stringify-object: 5.0.0
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.0.1
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -10132,6 +10472,10 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+
+  delaunator@5.0.1:
+    dependencies:
+      robust-predicates: 3.0.2
 
   delayed-stream@1.0.0: {}
 
@@ -10966,6 +11310,8 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  get-own-enumerable-keys@1.0.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -11228,6 +11574,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  internmap@2.0.3: {}
+
   ip-address@10.0.1: {}
 
   ip-address@10.1.0: {}
@@ -11346,6 +11694,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-obj@3.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
@@ -11360,6 +11710,8 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  is-regexp@3.1.0: {}
 
   is-set@2.0.3: {}
 
@@ -11425,6 +11777,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  javascript-lp-solver@0.4.24: {}
 
   jiti@2.6.1: {}
 
@@ -12601,6 +12955,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quadprog@1.6.1: {}
+
   quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
@@ -12770,6 +13126,8 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  robust-predicates@3.0.2: {}
+
   rolldown@1.0.0-beta.57:
     dependencies:
       '@oxc-project/types': 0.103.0
@@ -12833,6 +13191,8 @@ snapshots:
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
+
+  rw@1.3.3: {}
 
   sade@1.8.1:
     dependencies:
@@ -13208,6 +13568,12 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  stringify-object@5.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
 
   strip-ansi@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "x/agent_server/web"
   - "airlock/frontend"
   - "airlock/openclaw"
+  - "cluster/scripts/visualize_dag"
   - "third_party/mcporter"
   - "x/rspcache/admin_ui"
   - "props/frontend"


### PR DESCRIPTION
Adds `bazel run //cluster/scripts/visualize_dag` which generates a self-contained HTML file with an interactive d3-dag Sugiyama layout of all Flux Kustomization dependencies (159 nodes, 370 edges).

Features: zoom/pan, hover tooltips, click-to-highlight transitive dependency chains. Suspended kustomizations are excluded by default (use `--include-suspended` to show them).

JS dependencies (d3, d3-dag) are bundled via aspect_rules_esbuild and inlined into the HTML so the output works from file://.