### PR TITLE
Add Dockerfile + CI workflow for container E2E test image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,10 @@ jobs:
     needs: compute-targets
     if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'rbe-image')
     uses: ./.github/workflows/rbe-image.yml
+  e2e-container-image:
+    needs: compute-targets
+    if: contains(fromJson(needs.compute-targets.outputs.workflows || '[]'), 'e2e-container-image')
+    uses: ./.github/workflows/e2e-container-image.yml
   props-images:
     needs:
       - compute-targets

--- a/.github/workflows/e2e-container-image.yml
+++ b/.github/workflows/e2e-container-image.yml
@@ -6,6 +6,7 @@
 # Triggers:
 #   - push to main/devel when Dockerfile changes
 #   - workflow_dispatch for manual rebuilds
+#   - workflow_call (from ci.yml)
 #
 # After push, update the oci.pull digest in MODULE.bazel:
 #   docker manifest inspect ghcr.io/agentydragon/e2e-container:latest \
@@ -19,6 +20,7 @@ on:
       - "devinfra/claude/testing/container_e2e/Dockerfile"
       - ".github/workflows/e2e-container-image.yml"
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: e2e-container-image-${{ github.ref }}

--- a/.github/workflows/e2e-container-image.yml
+++ b/.github/workflows/e2e-container-image.yml
@@ -1,0 +1,57 @@
+# Build and push the container E2E test image to GHCR.
+#
+# Pre-bakes python:3.13-slim + git + JDK (keytool) so the container E2E test
+# doesn't spend time on apt-get at test runtime.
+#
+# Triggers:
+#   - push to main/devel when Dockerfile changes
+#   - workflow_dispatch for manual rebuilds
+#
+# After push, update the oci.pull digest in MODULE.bazel:
+#   docker manifest inspect ghcr.io/agentydragon/e2e-container:latest \
+#     --format '{{.Descriptor.Digest}}'
+name: E2E Container Image
+
+on:
+  push:
+    branches: [main, devel]
+    paths:
+      - "devinfra/claude/testing/container_e2e/Dockerfile"
+      - ".github/workflows/e2e-container-image.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-container-image-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/e2e-container
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: devinfra/claude/testing/container_e2e
+          file: devinfra/claude/testing/container_e2e/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}

--- a/devinfra/ci/generate_ci.py
+++ b/devinfra/ci/generate_ci.py
@@ -154,7 +154,7 @@ def generate_ci_config(manifest: WorkflowManifest) -> Workflow:
         jobs[name] = build_workflow_job(name, config, has_rbe_image_job=has_rbe_image_job)
 
     # Jobs that push to GHCR need packages:write.
-    ghcr_jobs = {"rbe-image"}
+    ghcr_jobs = {"rbe-image", "e2e-container-image"}
     permissions: dict[str, str] = {"contents": "read"}
     if ghcr_jobs & manifest.workflows.keys():
         permissions["packages"] = "write"

--- a/devinfra/ci/workflows.yaml
+++ b/devinfra/ci/workflows.yaml
@@ -36,6 +36,9 @@ workflows:
   rbe-image:
     trigger: { kind: path, pattern: "^devinfra/rbe_image/" }
 
+  e2e-container-image:
+    trigger: { kind: path, pattern: "^devinfra/claude/testing/container_e2e/Dockerfile" }
+
   # Bazel image workflows always trigger. Bazel builds are hermetic, so same
   # inputs → same image digest. The workflow compares the local digest against
   # the registry and skips the push when unchanged. This avoids the stale-image

--- a/devinfra/claude/testing/container_e2e/Dockerfile
+++ b/devinfra/claude/testing/container_e2e/Dockerfile
@@ -3,6 +3,10 @@
 # Pre-bakes dependencies that would be slow to install at test time.
 # Built and pushed to GHCR by .github/workflows/e2e-container-image.yml.
 # Pinned in MODULE.bazel via oci.pull and used by test_container_e2e.py.
+#
+# TODO: Unify this with the Claude Code web container RE (reverse-engineered
+# container snapshot). This should eventually match the actual Claude Code web
+# container image so the E2E test exercises a realistic environment.
 FROM python:3.13-slim
 
 RUN apt-get update -qq \

--- a/devinfra/claude/testing/container_e2e/Dockerfile
+++ b/devinfra/claude/testing/container_e2e/Dockerfile
@@ -1,0 +1,12 @@
+# Container E2E test image: python:3.13-slim + git + JDK (keytool).
+#
+# Pre-bakes dependencies that would be slow to install at test time.
+# Built and pushed to GHCR by .github/workflows/e2e-container-image.yml.
+# Pinned in MODULE.bazel via oci.pull and used by test_container_e2e.py.
+FROM python:3.13-slim
+
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends \
+        default-jdk-headless \
+        git \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Adds `devinfra/claude/testing/container_e2e/Dockerfile` — pre-bakes python:3.13-slim + git + JDK (keytool) into a test container image
- Adds `.github/workflows/e2e-container-image.yml` — builds and pushes to `ghcr.io/agentydragon/e2e-container` on Dockerfile changes

## Context
This is Stage 1 of the container E2E test infrastructure. Once this merges and CI pushes the image, Stage 2 will pin the image digest in MODULE.bazel and use it in the test.

## Test plan
- [ ] Merge to devel triggers CI workflow
- [ ] CI builds and pushes `ghcr.io/agentydragon/e2e-container:latest`
- [ ] Image contains python3.13, git, and keytool (JDK)

https://claude.ai/code/session_0126x1qwwubMMcRC7tW6o6Pz