### PR TITLE
Add background Bazel server warmup to session start hook

### DIFF
--- a/devinfra/claude/BUILD.bazel
+++ b/devinfra/claude/BUILD.bazel
@@ -131,6 +131,13 @@ py_library(
 )
 
 py_library(
+    name = "bazel_server_warmup",
+    srcs = ["bazel_server_warmup.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "bazelisk_setup",
     srcs = ["bazelisk_setup.py"],
     imports = ["../.."],
@@ -343,6 +350,19 @@ py_test(
         "//devinfra/claude/auth_proxy:credentials",
         "@pypi//pyjwt",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_bazel_server_warmup",
+    srcs = ["test_bazel_server_warmup.py"],
+    imports = ["../.."],
+    deps = [
+        ":bazel_server_warmup",
+        ":conftest",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )

--- a/devinfra/claude/bazel_server_warmup.py
+++ b/devinfra/claude/bazel_server_warmup.py
@@ -1,0 +1,66 @@
+"""Background Bazel server warmup for Claude Code sessions.
+
+Starts the Bazel server by running `bazel info` so the first real command
+doesn't pay the JVM startup cost.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WARMUP_TIMEOUT_SECS = 120
+
+
+@dataclass(frozen=True)
+class BazelServerWarmup:
+    """Result of a Bazel server warmup attempt."""
+
+    server_pid: int | None = None
+    output_base: Path | None = None
+
+
+def _parse_info_output(stdout: str) -> BazelServerWarmup:
+    """Parse `bazel info server_pid output_base` key-value output."""
+    fields: dict[str, str] = {}
+    for line in stdout.strip().splitlines():
+        if ": " in line:
+            key, _, value = line.partition(": ")
+            fields[key.strip()] = value.strip()
+
+    pid_str = fields.get("server_pid", "")
+    return BazelServerWarmup(
+        server_pid=int(pid_str) if pid_str.isdigit() else None,
+        output_base=Path(fields["output_base"]) if "output_base" in fields else None,
+    )
+
+
+async def warmup_bazel_server(wrapper_path: Path, project_dir: Path, env: dict[str, str]) -> BazelServerWarmup:
+    """Start the Bazel server by running `bazel info server_pid output_base`.
+
+    Uses the bazel wrapper so --bazelrc, proxy credentials, and session env
+    vars are applied. Runs as an async subprocess with a timeout.
+    """
+    logger.info("Warming up Bazel server (wrapper=%s, project=%s)", wrapper_path, project_dir)
+
+    proc = await asyncio.create_subprocess_exec(
+        str(wrapper_path),
+        "info",
+        "server_pid",
+        "output_base",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(project_dir),
+        env=env,
+    )
+    stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=_WARMUP_TIMEOUT_SECS)
+
+    if proc.returncode != 0:
+        logger.warning("Bazel server warmup failed (exit=%d): %s", proc.returncode, stderr_bytes.decode().strip())
+        return BazelServerWarmup()
+
+    result = _parse_info_output(stdout_bytes.decode())
+    logger.info("Bazel server warm (pid=%s, output_base=%s)", result.server_pid, result.output_base)
+    return result

--- a/devinfra/claude/env_file.py
+++ b/devinfra/claude/env_file.py
@@ -162,3 +162,21 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
 
     content = "\n".join(exports) + "\n"
     write_config(env_file, content, "session environment")
+
+
+def build_subprocess_env(vars: EnvVars) -> dict[str, str]:
+    """Build an environment dict for running the bazel wrapper as a subprocess.
+
+    Merges the current process env with session-specific overrides that would
+    normally be sourced from the env file.
+    """
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join(filter(None, [str(vars.bazel_wrapper_dir), env.get("PATH")]))
+    env[ENV_SESSION_BAZELRC] = str(vars.session_bazelrc)
+    if vars.session_dir is not None:
+        env[ENV_SESSION_DIR] = str(vars.session_dir)
+    if vars.bazelisk_path is not None:
+        env[ENV_BAZELISK_PATH] = str(vars.bazelisk_path)
+    if vars.proxy_port is not None:
+        env[ENV_AUTH_PROXY_URL] = f"http://localhost:{vars.proxy_port}"
+    return env

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -67,6 +67,7 @@ py_library(
         ":tracing",
         "//devinfra:build_info",
         "//devinfra/claude:apt_setup",
+        "//devinfra/claude:bazel_server_warmup",
         "//devinfra/claude:bazel_wrapper_lib",
         "//devinfra/claude:bazelisk_setup",
         "//devinfra/claude:buildbuddy_setup",

--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -47,6 +47,7 @@ def configure(daemon_dir: Path, otlp_exporter: DeferredOtlpExporter) -> None:
     app.state.otlp_exporter = otlp_exporter
     app.state.last_request_time = time.monotonic()
     app.state.proxy = None
+    app.state.background_tasks = set[asyncio.Task[object]]()
 
     # Start auth proxy in-process if upstream proxy is configured.
     # The proxy binds the port immediately; credentials are written later
@@ -100,6 +101,7 @@ async def handle_hook(req: HookRequest) -> HookResponse:
                         http=http,
                         otlp_exporter=app.state.otlp_exporter,
                         proxy=app.state.proxy,
+                        background_tasks=app.state.background_tasks,
                     )
             case PreToolUseInput():
                 output = evaluate_pre(req.hook)

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -22,6 +22,7 @@ from opentelemetry import trace
 from devinfra.build_info import get_build_info
 from devinfra.claude import (
     apt_setup,
+    bazel_server_warmup,
     bazelisk_setup,
     buildbuddy_setup,
     cli_tools_setup,
@@ -52,6 +53,9 @@ from devinfra.claude.supervisor import setup as supervisor_setup
 logger = logging.getLogger(__name__)
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+
+# Strong references to fire-and-forget background tasks (prevents GC).
+_background_tasks: set[asyncio.Task] = set()
 
 
 @dataclass(frozen=True)
@@ -465,6 +469,21 @@ async def _setup_web(
 # ============================================================================
 
 
+async def _run_bazel_warmup(
+    paths: SessionPaths, project_dir: Path, env: dict[str, str], tracer: trace.Tracer, root_ctx: trace.Context
+) -> None:
+    """Fire-and-forget Bazel server warmup. Logs errors, never raises."""
+    try:
+        with tracer.start_as_current_span("bazel_server_warmup", context=root_ctx):
+            await bazel_server_warmup.warmup_bazel_server(
+                wrapper_path=paths.wrapper_path, project_dir=project_dir, env=env
+            )
+    except TimeoutError:
+        logger.warning("Bazel server warmup timed out")
+    except Exception as e:
+        logger.warning("Bazel server warmup failed: %s", e)
+
+
 async def run_session(
     hook_input: SessionStartHookInput,
     paths: SessionPaths,
@@ -577,6 +596,14 @@ async def run_session(
         )
         env_file.write_env_file(ctx.env_file_path, env_vars)
     logger.info("Wrote environment to %s", ctx.env_file_path)
+
+    # Fire-and-forget Bazel server warmup (both web and CLI modes).
+    # Store task reference to prevent GC before completion.
+    if settings.warmup_bazel_server:
+        warmup_env = env_file.build_subprocess_env(env_vars)
+        task = asyncio.create_task(_run_bazel_warmup(paths, ctx.project_dir, warmup_env, tracer, root_ctx))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     # Build structured session context for Claude Code transcript
     with tracer.start_as_current_span("emit_session_context", context=root_ctx):

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -54,9 +54,6 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 
-# Strong references to fire-and-forget background tasks (prevents GC).
-_background_tasks: set[asyncio.Task] = set()
-
 
 @dataclass(frozen=True)
 class CallerContext:
@@ -492,6 +489,7 @@ async def run_session(
     http: httpx.Client,
     otlp_exporter: DeferredOtlpExporter,
     proxy: AuthForwardingProxy | None,
+    background_tasks: set[asyncio.Task[object]] | None = None,
 ) -> SessionStartOutput:
     """Unified session setup for both web and CLI modes.
 
@@ -598,12 +596,12 @@ async def run_session(
     logger.info("Wrote environment to %s", ctx.env_file_path)
 
     # Fire-and-forget Bazel server warmup (both web and CLI modes).
-    # Store task reference to prevent GC before completion.
-    if settings.warmup_bazel_server:
+    # Store task reference in background_tasks to prevent GC before completion.
+    if settings.warmup_bazel_server and background_tasks is not None:
         warmup_env = env_file.build_subprocess_env(env_vars)
         task = asyncio.create_task(_run_bazel_warmup(paths, ctx.project_dir, warmup_env, tracer, root_ctx))
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
+        background_tasks.add(task)
+        task.add_done_callback(background_tasks.discard)
 
     # Build structured session context for Claude Code transcript
     with tracer.start_as_current_span("emit_session_context", context=root_ctx):
@@ -641,8 +639,11 @@ async def handle(
     http: httpx.Client,
     otlp_exporter: DeferredOtlpExporter,
     proxy: AuthForwardingProxy | None,
+    background_tasks: set[asyncio.Task[object]] | None = None,
 ) -> SessionStartOutput:
     """Entry point called from the hook daemon with the client's env."""
     logger.info("Caller environment: %s", caller_env)
     ctx = CallerContext.from_env(caller_env)
-    return await run_session(hook_input, paths, settings, ctx, http, otlp_exporter, proxy=proxy)
+    return await run_session(
+        hook_input, paths, settings, ctx, http, otlp_exporter, proxy=proxy, background_tasks=background_tasks
+    )

--- a/devinfra/claude/settings.py
+++ b/devinfra/claude/settings.py
@@ -70,6 +70,8 @@ class HookSettings(BaseSettings):
 
     k8s_token: str | None = Field(default=None, description="K8s SA token for reading secrets from cluster")
 
+    warmup_bazel_server: bool = Field(default=True, description="Start Bazel server in background after session setup")
+
     # Test configuration
     use_wheel: bool = Field(default=False, description="Use installed wheel instead of source")
 

--- a/devinfra/claude/test_bazel_server_warmup.py
+++ b/devinfra/claude/test_bazel_server_warmup.py
@@ -1,0 +1,74 @@
+"""Tests for bazel_server_warmup module."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_bazel
+
+from devinfra.claude.bazel_server_warmup import BazelServerWarmup, _parse_info_output, warmup_bazel_server
+
+
+def test_parse_info_output_success():
+    output = "server_pid: 12345\noutput_base: /home/user/.cache/bazel/_bazel_root/abc123\n"
+    result = _parse_info_output(output)
+    assert result.server_pid == 12345
+    assert result.output_base == Path("/home/user/.cache/bazel/_bazel_root/abc123")
+
+
+def test_parse_info_output_empty():
+    result = _parse_info_output("")
+    assert result.server_pid is None
+    assert result.output_base is None
+
+
+def test_parse_info_output_partial():
+    result = _parse_info_output("server_pid: 99\n")
+    assert result.server_pid == 99
+    assert result.output_base is None
+
+
+async def test_warmup_success():
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"server_pid: 12345\noutput_base: /tmp/bazel\n", b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = await warmup_bazel_server(
+            wrapper_path=Path("/fake/bin/bazel"), project_dir=Path("/fake/project"), env={}
+        )
+    assert result == BazelServerWarmup(server_pid=12345, output_base=Path("/tmp/bazel"))
+
+
+async def test_warmup_failure():
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"ERROR: something\n"))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = await warmup_bazel_server(
+            wrapper_path=Path("/fake/bin/bazel"), project_dir=Path("/fake/project"), env={}
+        )
+    assert result == BazelServerWarmup()
+
+
+async def test_warmup_timeout():
+    mock_proc = AsyncMock()
+
+    async def hang_forever():
+        await asyncio.sleep(999)
+        return (b"", b"")
+
+    mock_proc.communicate = hang_forever
+
+    with (
+        patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch("devinfra.claude.bazel_server_warmup._WARMUP_TIMEOUT_SECS", 0.01),
+        pytest.raises(TimeoutError),
+    ):
+        await warmup_bazel_server(wrapper_path=Path("/fake/bin/bazel"), project_dir=Path("/fake/project"), env={})
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

- Adds a background Bazel server warmup step (`bazel info server_pid output_base`) that runs after session setup completes, so the first real `bazel build`/`test` command doesn't pay the JVM startup cost (~5-10s)
- Warmup is fire-and-forget with a 120s timeout; failures are logged but never block the session
- Controlled by a new `warmup_bazel_server` setting (default: `True`)
- Adds `build_subprocess_env()` helper in `env_file.py` to construct the subprocess environment matching what the env file would source

## Test plan

- [x] Unit tests for `_parse_info_output` (success, empty, partial output)
- [x] Async tests for `warmup_bazel_server` (success, failure, timeout)
- [x] `bazel test //devinfra/claude:test_bazel_server_warmup` passes
- [ ] Verify warmup runs in a live web session (check daemon log for "Bazel server warm" message)

https://claude.ai/code/session_01Aq9LgjeBVwbjRthDwsdA8e