### PR TITLE
Refactor mock egress proxy image loading to use tarball

### DIFF
--- a/airlock/app.py
+++ b/airlock/app.py
@@ -158,7 +158,7 @@ def create_app(settings: Settings, *, include_static: bool = True) -> FastAPI:
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=100)
         gate.add_sse_listener(queue)
 
-        async def generate():  # type: ignore[no-untyped-def]
+        async def generate():
             try:
                 while True:
                     event = await queue.get()

--- a/devinfra/claude/testing/BUILD.bazel
+++ b/devinfra/claude/testing/BUILD.bazel
@@ -110,6 +110,13 @@ oci_load(
     repo_tags = ["mock-egress-proxy:latest"],
 )
 
+filegroup(
+    name = "mock_egress_proxy_tarball",
+    testonly = True,
+    srcs = [":mock_egress_proxy_load"],
+    output_group = "tarball",
+)
+
 py_library(
     name = "session_start_helpers",
     testonly = True,

--- a/devinfra/claude/testing/container_e2e/BUILD.bazel
+++ b/devinfra/claude/testing/container_e2e/BUILD.bazel
@@ -7,7 +7,7 @@ py_test(
     data = [
         "//:wheel",
         "//devinfra/claude/testdata/test_workspace:workspace_files",
-        "//devinfra/claude/testing:mock_egress_proxy_load",
+        "//devinfra/claude/testing:mock_egress_proxy_tarball",
     ],
     # Inherit proxy env vars so the proxy container can chain through real proxy
     env_inherit = [

--- a/devinfra/claude/testing/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/testing/container_e2e/test_container_e2e.py
@@ -43,7 +43,7 @@ from devinfra.claude.auth_proxy.setup import SSL_CA_ENV_VARS, SYSTEM_CA_BUNDLES
 from devinfra.claude.auth_proxy.vars import PROXY_ENV_VARS
 from devinfra.claude.testing.mock_egress_proxy import ConnectionStats, EgressProxyConfig
 from util.bazel.runfiles import get_required_path
-from util.oci import load_bazel_image
+from util.oci import load_image
 from util.testing.undeclared_outputs import undeclared_outputs_dir
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ _E2E_IMAGE = "ghcr.io/agentydragon/e2e-container:latest"
 
 # OCI image for the mock egress proxy container
 _MOCK_PROXY_IMAGE = "mock-egress-proxy:latest"
-_MOCK_PROXY_LOAD_SCRIPT = "devinfra/claude/testing/mock_egress_proxy_load/load.sh"
+_MOCK_PROXY_TARBALL = "_main/devinfra/claude/testing/mock_egress_proxy_load/tarball.tar"
 
 # Container name prefix
 _CONTAINER_NAME = "ducktape-container-e2e"
@@ -228,7 +228,8 @@ def test_workspace_path() -> Path:
 @pytest.fixture
 def mock_proxy_image() -> str:
     """Load the mock egress proxy OCI image into Docker."""
-    return load_bazel_image(_MOCK_PROXY_LOAD_SCRIPT, _MOCK_PROXY_IMAGE)
+    load_image(_MOCK_PROXY_TARBALL)
+    return _MOCK_PROXY_IMAGE
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Refactored the mock egress proxy image loading mechanism to use a pre-built OCI tarball instead of a load script, simplifying the image loading process and improving build consistency.

## Key Changes
- Added `mock_egress_proxy_tarball` filegroup in BUILD.bazel that extracts the tarball output from the OCI image load target
- Updated `test_container_e2e.py` to load the proxy image from a tarball file instead of executing a load script
  - Changed from `load_bazel_image(_MOCK_PROXY_LOAD_SCRIPT, _MOCK_PROXY_IMAGE)` to `load_image(_MOCK_PROXY_TARBALL)`
  - Updated the mock proxy tarball path to reference the new tarball artifact
- Updated BUILD.bazel dependency in container_e2e tests to use the new `mock_egress_proxy_tarball` target instead of `mock_egress_proxy_load`
- Minor type annotation cleanup in `airlock/app.py` (removed `# type: ignore[no-untyped-def]` comment)

## Implementation Details
The refactoring leverages Bazel's `output_group` feature to extract the tarball output from the OCI image load operation, allowing the test to load the image directly from the tarball artifact rather than executing a shell script. This approach is more deterministic and aligns better with Bazel's build system semantics.

https://claude.ai/code/session_01P9rmTKXLpHbyWkHpb1EF1Q