### PR TITLE
Fix e2e test: chmod container outputs before collection

### DIFF
--- a/devinfra/claude/testing/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/testing/container_e2e/test_container_e2e.py
@@ -496,7 +496,20 @@ async def test_container_e2e(
         stderr = "".join(await container.log(stdout=False, stderr=True))
         _save_output("container-stdout.log", stdout)
         _save_output("container-stderr.log", stderr)
+
+        # Fix permissions on bind-mounted session logs before container deletion.
+        # The container runs as root, so files it creates (bazel cache, hook logs)
+        # are owned by root. The CI runner can't read them, causing Bazel to fail
+        # when collecting undeclared test outputs.
+        await _exec(container, ["chmod", "-R", "a+rX", f"/root/.claude/session-env/{_SESSION_ID}"], check=False)
+
         await container.delete(force=True)
+
+        # Remove container's bazel cache — not useful diagnostics and contains
+        # symlinks into execroot that break Bazel's output collection.
+        bazel_cache = session_logs_dir / "bazel-cache"
+        if bazel_cache.exists():
+            shutil.rmtree(bazel_cache, ignore_errors=True)
 
         _cleanup_dangling_symlinks(session_logs_dir)
 


### PR DESCRIPTION
## Summary

- Fix `FileAccessException` / `EACCES` in the container e2e test caused by root-owned files in bind-mounted session logs directory
- `chmod -R a+rX` inside the container before deletion so the CI runner can read outputs
- Remove the `bazel-cache/` subtree from undeclared outputs (not useful diagnostics, contains symlinks that break Bazel output collection)

**Root cause**: Container runs as root, creates files in bind-mounted `session_logs_dir`. CI runner (`runner` user) can't read root-owned files when Bazel collects undeclared test outputs.

## Test plan

- [ ] CI `test-ducktape-e2e` job passes (no more `Permission denied` errors)
- [ ] Release workflow unblocked after merge

https://claude.ai/code/session_01LKkSj4NqVScSgSyduphUgL