### PR TITLE
Add Web Setup documentation for Claude Code integration

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -390,6 +390,17 @@ Key files: TF module in `cluster/terraform/gitops/alloy-otlp-bearer-token/`,
 Authentik blueprint in `cluster/k8s/authentik/blueprints/alloy-otlp-sso.yaml`.
 Rotation: bump `rotation_version` in the TF module.
 
+## Web Setup
+
+To use this repository with Claude Code on the web, configure the following setup script in the Claude Code web UI:
+
+```bash
+#!/bin/bash
+pip install --break-system-packages --force-reinstall https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl 2>&1 | tee /tmp/setup-script.log
+```
+
+This installs the `claude-hooks` wheel which provides the `claude-hook` binary used by the session start and other hooks in `.claude/settings.json`.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary
Added documentation for setting up this repository to work with Claude Code on the web, including the required setup script and explanation of the `claude-hooks` dependency.

## Changes
- Added new "Web Setup" section to README.md with instructions for configuring Claude Code web UI
- Documented the setup script that installs the `claude-hooks` wheel from the ducktape releases
- Explained the purpose of the `claude-hook` binary and its role in the session start and other hooks defined in `.claude/settings.json`

## Details
The setup script uses `pip install` with `--break-system-packages` and `--force-reinstall` flags to install the `claude-hooks` wheel, which provides the `claude-hook` binary needed for the repository's hook configuration. This documentation helps users get the web-based Claude Code integration working correctly.

https://claude.ai/code/session_01VeviFzbjjuojrbXHvwmbix