### PR TITLE
Add skip knobs for CLI tools and apt in E2E test

### DIFF
--- a/devinfra/claude/cli_tools_setup.py
+++ b/devinfra/claude/cli_tools_setup.py
@@ -105,14 +105,18 @@ def _install_tool(tool: CliTool, bin_dir: Path, http: httpx.Client) -> None:
     logger.info("Installed %s to %s", tool.name, dest)
 
 
-def install_cli_tools(bin_dir: Path, http: httpx.Client) -> list[str]:
+def install_cli_tools(bin_dir: Path, http: httpx.Client, *, skip: set[str] | None = None) -> list[str]:
     """Install all CLI tools into bin_dir. Returns list of successfully installed tool names.
 
     Non-fatal — logs warnings for individual failures and continues.
+    skip: tool names to skip (e.g. {"gh", "kubectl", "flux"}).
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
     installed: list[str] = []
     for tool in _tools():
+        if skip and tool.name in skip:
+            logger.info("Skipping %s install (disabled by settings)", tool.name)
+            continue
         try:
             _install_tool(tool, bin_dir, http)
             installed.append(tool.name)

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -332,16 +332,15 @@ async def _setup_web(
 
     @tracer.start_as_current_span("install_cli_tools", context=root_ctx)
     async def traced_cli_tools():
-        skip_tools: set[str] = set()
-        if not settings.install_cli_tools:
-            skip_tools = {"gh", "kubectl", "flux"}
-        else:
-            if not settings.install_gh:
-                skip_tools.add("gh")
-            if not settings.install_kubectl:
-                skip_tools.add("kubectl")
-            if not settings.install_flux:
-                skip_tools.add("flux")
+        skip_tools = {
+            name
+            for name, enabled in [
+                ("gh", settings.install_gh),
+                ("kubectl", settings.install_kubectl),
+                ("flux", settings.install_flux),
+            ]
+            if not enabled
+        }
         return await run_in_thread(cli_tools_setup.install_cli_tools, paths.wrapper_dir, http, skip=skip_tools)
 
     results = await asyncio.gather(

--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -284,8 +284,12 @@ async def _setup_web(
     #   setup_bazel_on_tmpfs mounts its own tmpfs independently
     logger.info("Starting parallel installations...")
 
-    # Consolidated apt install: native dev headers (always) + podman (if needed).
-    apt_packages = list(apt_setup.NATIVE_DEV_PACKAGES)
+    # Consolidated apt install: native dev headers (if enabled) + podman (if needed).
+    apt_packages: list[str] = []
+    if settings.install_apt_packages:
+        apt_packages.extend(apt_setup.NATIVE_DEV_PACKAGES)
+    else:
+        logger.info("Skipping native apt packages (install_apt_packages=False)")
     if settings.container_runtime == "podman" and shutil.which("podman") is None:
         apt_packages.extend(apt_setup.PODMAN_PACKAGES)
 
@@ -328,7 +332,17 @@ async def _setup_web(
 
     @tracer.start_as_current_span("install_cli_tools", context=root_ctx)
     async def traced_cli_tools():
-        return await run_in_thread(cli_tools_setup.install_cli_tools, paths.wrapper_dir, http)
+        skip_tools: set[str] = set()
+        if not settings.install_cli_tools:
+            skip_tools = {"gh", "kubectl", "flux"}
+        else:
+            if not settings.install_gh:
+                skip_tools.add("gh")
+            if not settings.install_kubectl:
+                skip_tools.add("kubectl")
+            if not settings.install_flux:
+                skip_tools.add("flux")
+        return await run_in_thread(cli_tools_setup.install_cli_tools, paths.wrapper_dir, http, skip=skip_tools)
 
     results = await asyncio.gather(
         proxy_task,

--- a/devinfra/claude/settings.py
+++ b/devinfra/claude/settings.py
@@ -60,11 +60,10 @@ class HookSettings(BaseSettings):
     # Feature flags (enable/disable installations)
     install_bazelisk: bool = Field(default=True, description="Download and install bazelisk")
     install_mkcert: bool = Field(default=True, description="Install mkcert and generate localhost TLS cert")
-    install_cli_tools: bool = Field(default=True, description="Download CLI tools (gh, kubectl, flux)")
-    install_gh: bool = Field(default=True, description="Download gh CLI")
-    install_kubectl: bool = Field(default=True, description="Download kubectl")
-    install_flux: bool = Field(default=True, description="Download flux CLI")
-    install_apt_packages: bool = Field(default=True, description="Install native dev apt packages")
+    install_gh: bool = True
+    install_kubectl: bool = True
+    install_flux: bool = True
+    install_apt_packages: bool = True
     container_runtime: Literal["podman", "docker", "none"] = Field(
         default="docker", description="Container runtime to set up (podman, docker, or none)"
     )

--- a/devinfra/claude/settings.py
+++ b/devinfra/claude/settings.py
@@ -60,6 +60,11 @@ class HookSettings(BaseSettings):
     # Feature flags (enable/disable installations)
     install_bazelisk: bool = Field(default=True, description="Download and install bazelisk")
     install_mkcert: bool = Field(default=True, description="Install mkcert and generate localhost TLS cert")
+    install_cli_tools: bool = Field(default=True, description="Download CLI tools (gh, kubectl, flux)")
+    install_gh: bool = Field(default=True, description="Download gh CLI")
+    install_kubectl: bool = Field(default=True, description="Download kubectl")
+    install_flux: bool = Field(default=True, description="Download flux CLI")
+    install_apt_packages: bool = Field(default=True, description="Install native dev apt packages")
     container_runtime: Literal["podman", "docker", "none"] = Field(
         default="docker", description="Container runtime to set up (podman, docker, or none)"
     )

--- a/devinfra/claude/testing/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/testing/container_e2e/test_container_e2e.py
@@ -21,14 +21,13 @@ Architecture:
           auth proxy, supervisor, bazel wrapper, CA bundles, env file
         - Runs bazel build through the full proxy chain
 
-Network traffic profile (~327 MB total, measured 2026-03-20):
-    releases.bazel.build:443       130 MB  40%  Bazel binary (2 conns)
-    files.pythonhosted.org:443      81 MB  25%  pip wheel deps (protobuf, cryptography, etc.)
-    dl.k8s.io:443                   57 MB  17%  kubectl binary
-    deb.debian.org:80               49 MB  15%  apt packages (libdbus, etc.)
-    pypi.org:443                    10 MB   3%  pip index metadata
+Network traffic profile (~221 MB with cli tools + apt skipped, measured 2026-03-20):
+    releases.bazel.build:443       130 MB  59%  Bazel binary (2 conns)
+    files.pythonhosted.org:443      81 MB  37%  pip wheel deps (protobuf, cryptography, etc.)
+    pypi.org:443                    10 MB   4%  pip index metadata
     bcr.bazel.build:443            0.3 MB  <1%  Bazel Central Registry metadata
-    Top 4 hosts account for 97% of traffic. See proxy.log in undeclared outputs.
+    Skipped by settings: kubectl (57 MB), apt packages (49 MB), gh, flux.
+    See proxy.log in undeclared outputs.
 """
 
 import asyncio
@@ -433,6 +432,10 @@ async def test_container_e2e(
         "CLAUDE_ENV_FILE": _ENV_FILE,
         "DUCKTAPE_CLAUDE_HOOKS_INSTALL_BAZELISK": "true",
         "DUCKTAPE_CLAUDE_HOOKS_INSTALL_MKCERT": "false",
+        "DUCKTAPE_CLAUDE_HOOKS_INSTALL_GH": "false",
+        "DUCKTAPE_CLAUDE_HOOKS_INSTALL_KUBECTL": "false",
+        "DUCKTAPE_CLAUDE_HOOKS_INSTALL_FLUX": "false",
+        "DUCKTAPE_CLAUDE_HOOKS_INSTALL_APT_PACKAGES": "false",
         "DUCKTAPE_CLAUDE_HOOKS_CONTAINER_RUNTIME": "none",
         "ANTHROPIC_CA_PATH": "/certs/mock_ca.pem",
         "WHEEL_PATH": f"/wheel/{_WHEEL_FILENAME}",


### PR DESCRIPTION
## Summary
- Add per-tool install settings (`install_gh`, `install_kubectl`, `install_flux`, `install_apt_packages`) to `HookSettings`
- Wire them through `session_start.py` → `cli_tools_setup.py` (new `skip` param) and apt setup
- Container E2E test now skips gh, kubectl, flux, and apt packages — saves ~106 MB of downloads not exercised by the test

## Test plan
- [ ] `bazel build //devinfra/claude/...` passes
- [ ] Container E2E test still passes with reduced downloads
- [ ] Production (no env overrides) still installs all tools by default

https://claude.ai/code/session_018KyDG1oJafRnECZ3Rjwziu