### PR TITLE
Fix Terraform Bazel test failures: providers, stale args, data deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,7 @@ npm_link_all_packages(name = "node_modules")
 # Export workspace files for npm_translate_lock data tracking
 exports_files([
     "mypy.ini",
+    "nebula-mesh.json",
     "package.json",
     "pnpm-workspace.yaml",
     "requirements_bazel.txt",

--- a/cluster/terraform/bootstrap/infrastructure/BUILD.bazel
+++ b/cluster/terraform/bootstrap/infrastructure/BUILD.bazel
@@ -11,7 +11,6 @@ tf_providers_versions(
     name = "providers",
     providers = {
         "hcloud": "hetznercloud/hcloud:~>1.45",
-        "helm": "hashicorp/helm:~>3.1.0",
         "kubernetes": "hashicorp/kubernetes:~>2.38.0",
         "local": "hashicorp/local:~>2.5.0",
         "null": "hashicorp/null:~>3.2.0",
@@ -27,9 +26,9 @@ tf_providers_versions(
 # Providers are served from the Bazel-cached mirror (see MODULE.bazel tf.download).
 tf_module(
     name = "infrastructure",
+    data = ["//:nebula-mesh.json"],
     providers = [
         "hcloud",
-        "helm",
         "kubernetes",
         "local",
         "null",

--- a/cluster/terraform/bootstrap/k8s-worker-proxmox/BUILD.bazel
+++ b/cluster/terraform/bootstrap/k8s-worker-proxmox/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
+        "external": "hashicorp/external:~>2.3.0",
+        "null": "hashicorp/null:~>3.2.0",
         "proxmox": "bpg/proxmox:~>0.91.0",
     },
     tf_version = "1.9.8",
@@ -11,6 +13,8 @@ tf_providers_versions(
 tf_module(
     name = "k8s-worker-proxmox",
     providers = [
+        "external",
+        "null",
         "proxmox",
     ],
     providers_versions = ":providers",

--- a/cluster/terraform/bootstrap/k8s-worker-proxmox/main.tf
+++ b/cluster/terraform/bootstrap/k8s-worker-proxmox/main.tf
@@ -41,8 +41,7 @@ locals {
   )
 
   # NixOS image build inputs
-  nix_dir_hash = sha1(join("", [for f in sort(fileset("${path.module}/../../../../nix", "**/*.nix")) : filesha1("${path.module}/../../../../nix/${f}")]))
-  repo_root    = "${path.module}/../../../.."
+  repo_root = "${path.module}/../../../.."
 
 }
 
@@ -87,7 +86,6 @@ module "k8s_worker_test_image" {
   flake_target = "k8s-worker-test"
   proxmox_host = var.proxmox_host
   repo_root    = local.repo_root
-  nix_dir_hash = local.nix_dir_hash
 }
 
 # =============================================================================

--- a/cluster/terraform/bootstrap/k8s-worker-proxmox/terraform.tf
+++ b/cluster/terraform/bootstrap/k8s-worker-proxmox/terraform.tf
@@ -8,6 +8,14 @@ terraform {
   }
 
   required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2.0"
+    }
     proxmox = {
       source  = "bpg/proxmox"
       version = "~> 0.91.0"

--- a/terraform/modules/nixos-image/BUILD.bazel
+++ b/terraform/modules/nixos-image/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
+        "external": "hashicorp/external:~>2.3.0",
         "null": "hashicorp/null:~>3.2.0",
     },
     tf_version = "1.9.8",
@@ -11,6 +12,7 @@ tf_providers_versions(
 tf_module(
     name = "nixos-image",
     providers = [
+        "external",
         "null",
     ],
     providers_versions = ":providers",

--- a/terraform/nixos-dev-env/terraform.tf
+++ b/terraform/nixos-dev-env/terraform.tf
@@ -5,13 +5,17 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    proxmox = {
-      source  = "bpg/proxmox"
-      version = "~> 0.91.0"
-    }
     external = {
       source  = "hashicorp/external"
       version = "~> 2.3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2.0"
+    }
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "~> 0.91.0"
     }
   }
 }


### PR DESCRIPTION
- nixos-image: add missing `external` provider to BUILD.bazel (used by
  `data "external" "ssh_check"` in main.tf)
- nixos-dev-env: add missing `null` provider to terraform.tf (used by
  `null_resource.wyrm2_nixos_rebuild`), alphabetize providers
- infrastructure: remove unused `helm` provider from BUILD.bazel (Helm
  is used via CLI, not the TF provider), add nebula-mesh.json as data
  dep for validate test (nebula.tf reads it via file())
- k8s-worker-proxmox: remove stale `nix_dir_hash` variable/argument
  (removed from nixos-image module in 90c814f), add `external` and
  `null` providers needed by nixos-image child module

https://claude.ai/code/session_01YJJwb6YjTWRLv42y4gTxNg