### PR TITLE
Replace pip with uv tool for claude-hooks installation

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -362,7 +362,7 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-python3.13 -m pip install --break-system-packages --force-reinstall https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl 2>&1 | tee /tmp/setup-script.log
+uv tool install --force https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl 2>&1 | tee /tmp/setup-script.log
 ```
 
 This installs the `claude-hooks` wheel which provides the `claude-hook` binary used by the session start and other hooks in `.claude/settings.json`.

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -362,7 +362,7 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-pip install --break-system-packages --force-reinstall https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl 2>&1 | tee /tmp/setup-script.log
+python3.13 -m pip install --break-system-packages --force-reinstall https://github.com/agentydragon/ducktape/releases/download/claude-hooks-latest/claude_hooks-0.1.0-py3-none-any.whl 2>&1 | tee /tmp/setup-script.log
 ```
 
 This installs the `claude-hooks` wheel which provides the `claude-hook` binary used by the session start and other hooks in `.claude/settings.json`.


### PR DESCRIPTION
## Summary
Updated the setup script in the README to use `uv tool install` instead of `pip install` for installing the claude-hooks wheel.

## Changes
- Replaced `pip install --break-system-packages --force-reinstall` with `uv tool install --force` for installing the claude_hooks wheel
- This modernizes the installation approach to use the faster and more reliable `uv` package manager
- Removes the need for the `--break-system-packages` flag, which is a safer installation method

## Details
The change simplifies the installation command while maintaining the same functionality. The `uv tool install` command with the `--force` flag provides equivalent behavior to the previous pip command, but with better dependency resolution and performance characteristics.

https://claude.ai/code/session_013SqhkvabhgXoXm3FhEefht