### PR TITLE
Fix mypy error: pass skip kwarg via lambda in run_in_thread call

### DIFF
--- a/devinfra/claude/hook_daemon/session_start.py
+++ b/devinfra/claude/hook_daemon/session_start.py
@@ -341,7 +341,7 @@ async def _setup_web(
             ]
             if not enabled
         }
-        return await run_in_thread(cli_tools_setup.install_cli_tools, paths.wrapper_dir, http, skip=skip_tools)
+        return await run_in_thread(lambda: cli_tools_setup.install_cli_tools(paths.wrapper_dir, http, skip=skip_tools))
 
     results = await asyncio.gather(
         proxy_task,


### PR DESCRIPTION
run_in_thread only accepts positional args; use a lambda to pass the skip keyword argument to install_cli_tools.

https://claude.ai/code/session_01RBabyaPo3iMbcYxTeGPP5F