### PR TITLE
Migrate BuildBuddy API docs to skills directory

### DIFF
--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -61,38 +61,28 @@ bb_get "$BB/file/download?invocation_id=<UUID>&artifact=execution_profile&execut
 Tests running on RBE write undeclared outputs (`TEST_UNDECLARED_OUTPUTS_DIR`) to the
 remote worker. These are uploaded as BES artifacts and downloadable via `/file/download`.
 
-```python
-# Download a test output from a BuildBuddy RBE invocation.
-# Set INVOCATION and NAME_FILTER, then run the whole snippet.
-import json, re, urllib.request, urllib.parse
+**Step 1 — fetch the BES event stream:**
 
-INVOCATION = "<UUID>"       # from "Streaming build results to: .../invocation/<UUID>"
-NAME_FILTER = "proxy.log"   # substring match; leave empty to list all outputs
+```bash
+INVOCATION="<UUID>"
+KEY="$(grep -oP 'x-buildbuddy-api-key=\K.*' ~/.config/bazel/buildbuddy.bazelrc)"
+curl -s -H "x-buildbuddy-api-key: $KEY" \
+  "https://app.buildbuddy.io/file/download?invocation_id=$INVOCATION&artifact=raw_json" \
+  > bes.json
+```
 
-BB = "https://app.buildbuddy.io"
-KEY = re.search(r"x-buildbuddy-api-key=(\S+)",
-    open("/root/.config/bazel/buildbuddy.bazelrc").read()).group(1)
+**Step 2 — list all test output files:**
 
-def fetch(url):
-    return urllib.request.urlopen(
-        urllib.request.Request(url, headers={"x-buildbuddy-api-key": KEY})).read()
+```bash
+jq -r '.[].testResult.testActionOutput[]?.name' bes.json | sort
+```
 
-# Parse BES event stream for test output bytestream URIs
-bes = json.loads(fetch(f"{BB}/file/download?invocation_id={INVOCATION}&artifact=raw_json"))
-outputs = {f["name"]: f["uri"]
-           for event in bes
-           for f in event.get("testResult", {}).get("testActionOutput", [])}
+**Step 3 — download one file by name:**
 
-matches = {n: u for n, u in outputs.items() if NAME_FILTER in n} if NAME_FILTER else outputs
-for name in sorted(matches):
-    print(name)
-
-# Download the first match to stdout (pipe to a file if needed)
-if len(matches) == 1:
-    uri = next(iter(matches.values()))
-    import sys
-    sys.stdout.buffer.write(fetch(
-        f"{BB}/file/download?bytestream_url={urllib.parse.quote(uri, safe='')}"))
+```bash
+URI=$(jq -r '.[].testResult.testActionOutput[]? | select(.name | contains("proxy.log")) | .uri' bes.json | head -1)
+curl -s -H "x-buildbuddy-api-key: $KEY" \
+  "https://app.buildbuddy.io/file/download?bytestream_url=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$URI")"
 ```
 
 ## Other Endpoints

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -61,25 +61,19 @@ bb_get "$BB/file/download?invocation_id=<UUID>&artifact=execution_profile&execut
 Tests running on RBE write undeclared outputs (`TEST_UNDECLARED_OUTPUTS_DIR`) to the
 remote worker. These are uploaded as BES artifacts and downloadable via `/file/download`.
 
-**Step 1 — fetch the BES event stream:**
-
 ```bash
 INVOCATION="<UUID>"
 KEY="$(grep -oP 'x-buildbuddy-api-key=\K.*' ~/.config/bazel/buildbuddy.bazelrc)"
+
+# 1. Fetch the BES event stream
 curl -s -H "x-buildbuddy-api-key: $KEY" \
   "https://app.buildbuddy.io/file/download?invocation_id=$INVOCATION&artifact=raw_json" \
   > bes.json
-```
 
-**Step 2 — list all test output files:**
-
-```bash
+# 2. List all test output files
 jq -r '.[].testResult.testActionOutput[]?.name' bes.json | sort
-```
 
-**Step 3 — download one file by name:**
-
-```bash
+# 3. Download one file by name
 URI=$(jq -r '.[].testResult.testActionOutput[]? | select(.name | contains("proxy.log")) | .uri' bes.json | head -1)
 curl -s -H "x-buildbuddy-api-key: $KEY" \
   "https://app.buildbuddy.io/file/download?bytestream_url=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$URI")"

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -1,77 +1,65 @@
+---
+name: buildbuddy_api
+description: >
+  Reference for querying the BuildBuddy API. Use when investigating failed or slow
+  CI builds, inspecting invocations by commit or branch, reading build or test logs,
+  checking remote execution (RBE) details (exit codes, stderr, worker logs), analyzing
+  cache hit/miss rates, or downloading undeclared test outputs from RBE workers.
+  Trigger when the user asks "why did this build fail", "show me the build log",
+  "check RBE execution", "get test output from RBE", "what happened in this CI run",
+  "check cache performance", or any task that requires fetching data from BuildBuddy.
+allowed-tools: Bash
+---
+
 # BuildBuddy API Reference
 
-The BuildBuddy backend is open-source: <https://github.com/buildbuddy-io/buildbuddy>.
-Proto definitions live in `proto/` (service: `proto/buildbuddy_service.proto`,
-public API: `proto/api/v1/service.proto`).
+BuildBuddy's backend is open-source (<https://github.com/buildbuddy-io/buildbuddy>).
+Proto definitions: `proto/buildbuddy_service.proto` (internal, ~70 RPCs) and
+`proto/api/v1/service.proto` (public, 9 endpoints).
 
-[Official docs](https://www.buildbuddy.io/docs/enterprise-api/) cover 9 public
-endpoints. The backend also exposes ~70 internal RPCs via
-`/rpc/BuildBuddyService/` that work with a standard API key.
+## Session Setup
 
-## Authentication
-
-API key is in `~/.config/bazel/buildbuddy.bazelrc`. All endpoints accept
-`x-buildbuddy-api-key: $KEY` as an HTTP header.
-
-## Key Capabilities
-
-- **Search invocations** by repo, branch, commit, user, command
-- **Get invocation details** (status, duration, targets, actions)
-- **Read build logs** (chunked)
-- **Get cache scorecard** (per-action hit/miss, durations, sizes)
-- **Get execution details** (remote actions, exit codes, stderr)
-- **Download artifacts** (BES event stream, build logs, profiles)
-
-## Common Recipes
+Run once before any API calls:
 
 ```bash
 KEY="$(grep -oP 'x-buildbuddy-api-key=\K.*' ~/.config/bazel/buildbuddy.bazelrc)"
 BB="https://app.buildbuddy.io"
+bb()     { curl -s -X POST -H "Content-Type: application/json" -H "x-buildbuddy-api-key: $KEY" "$@"; }
+bb_get() { curl -s -H "x-buildbuddy-api-key: $KEY" "$@"; }
+```
 
+## Common Recipes
+
+```bash
 # List recent invocations for this repo
-curl -s -X POST -H "Content-Type: application/json" \
-  -H "x-buildbuddy-api-key: $KEY" \
-  -d '{"query":{"repo_url":"https://github.com/agentydragon/ducktape"},"count":10}' \
+bb -d '{"query":{"repo_url":"https://github.com/agentydragon/ducktape"},"count":10}' \
   "$BB/rpc/BuildBuddyService/SearchInvocation"
 
 # Get invocation by ID (public API)
-curl -s -X POST -H "Content-Type: application/json" \
-  -H "x-buildbuddy-api-key: $KEY" \
-  -d '{"selector":{"invocation_id":"<UUID>"}}' \
-  "$BB/api/v1/GetInvocation"
+bb -d '{"selector":{"invocation_id":"<UUID>"}}' "$BB/api/v1/GetInvocation"
 
-# Get build log
-curl -s -X POST -H "Content-Type: application/json" \
-  -H "x-buildbuddy-api-key: $KEY" \
-  -d '{"invocation_id":"<UUID>","min_lines":500}' \
+# Get build log (chunked; increase min_lines for larger logs)
+bb -d '{"invocation_id":"<UUID>","min_lines":500}' \
   "$BB/rpc/BuildBuddyService/GetEventLogChunk"
 
 # Get remote executions for an invocation
-curl -s -X POST -H "Content-Type: application/json" \
-  -H "x-buildbuddy-api-key: $KEY" \
-  -d '{"execution_lookup":{"invocation_id":"<UUID>"},"inline_execute_response":true}' \
+bb -d '{"execution_lookup":{"invocation_id":"<UUID>"},"inline_execute_response":true}' \
   "$BB/rpc/BuildBuddyService/GetExecution"
 
-# Get cache scorecard
-curl -s -X POST -H "Content-Type: application/json" \
-  -H "x-buildbuddy-api-key: $KEY" \
-  -d '{"invocation_id":"<UUID>"}' \
-  "$BB/rpc/BuildBuddyService/GetCacheScoreCard"
+# Get cache scorecard (per-action hit/miss, durations, sizes)
+bb -d '{"invocation_id":"<UUID>"}' "$BB/rpc/BuildBuddyService/GetCacheScoreCard"
 
-# Download BES event stream (JSON)
-curl -s -H "x-buildbuddy-api-key: $KEY" \
-  "$BB/file/download?invocation_id=<UUID>&artifact=raw_json"
+# Download BES event stream (JSON) — contains all build events
+bb_get "$BB/file/download?invocation_id=<UUID>&artifact=raw_json"
 
-# Download build profile (for chrome://tracing or ui.perfetto.dev)
-curl -s -H "x-buildbuddy-api-key: $KEY" \
-  "$BB/file/download?invocation_id=<UUID>&artifact=execution_profile&execution_id=<EXEC_ID>"
+# Download build profile (open in chrome://tracing or ui.perfetto.dev)
+bb_get "$BB/file/download?invocation_id=<UUID>&artifact=execution_profile&execution_id=<EXEC_ID>"
 ```
 
 ## Downloading Undeclared Test Outputs from RBE
 
-Tests running on RBE write undeclared outputs (`TEST_UNDECLARED_OUTPUTS_DIR`) to
-the remote worker. These are uploaded to BuildBuddy as BES artifacts and can be
-downloaded via the `/file/download` endpoint.
+Tests running on RBE write undeclared outputs (`TEST_UNDECLARED_OUTPUTS_DIR`) to the
+remote worker. These are uploaded as BES artifacts and downloadable via `/file/download`.
 
 ```python
 # Download a test output from a BuildBuddy RBE invocation.
@@ -107,6 +95,8 @@ if len(matches) == 1:
         f"{BB}/file/download?bytestream_url={urllib.parse.quote(uri, safe='')}"))
 ```
 
+## Endpoint Reference
+
 | Path                                       | Method | Notes                                                |
 | ------------------------------------------ | ------ | ---------------------------------------------------- |
 | `/api/v1/GetInvocation`                    | POST   | By invocation ID or commit SHA                       |
@@ -119,5 +109,5 @@ if len(matches) == 1:
 | `/rpc/BuildBuddyService/GetEventLogChunk`  | POST   | Build log chunks                                     |
 | `/file/download`                           | GET    | Artifact download (`artifact=` or `bytestream_url=`) |
 
-For the full list of ~70 internal RPCs, see `proto/buildbuddy_service.proto` in
-the [BuildBuddy repo](https://github.com/buildbuddy-io/buildbuddy).
+For the full ~70 internal RPCs, see `proto/buildbuddy_service.proto` in the
+[BuildBuddy repo](https://github.com/buildbuddy-io/buildbuddy).

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -63,20 +63,16 @@ remote worker. These are uploaded as BES artifacts and downloadable via `/file/d
 
 ```bash
 INVOCATION="<UUID>"
-KEY="$(grep -oP 'x-buildbuddy-api-key=\K.*' ~/.config/bazel/buildbuddy.bazelrc)"
 
 # 1. Fetch the BES event stream
-curl -s -H "x-buildbuddy-api-key: $KEY" \
-  "https://app.buildbuddy.io/file/download?invocation_id=$INVOCATION&artifact=raw_json" \
-  > bes.json
+bb_get "$BB/file/download?invocation_id=$INVOCATION&artifact=raw_json" > bes.json
 
 # 2. List all test output files
 jq -r '.[].testResult.testActionOutput[]?.name' bes.json | sort
 
 # 3. Download one file by name
 URI=$(jq -r '.[].testResult.testActionOutput[]? | select(.name | contains("proxy.log")) | .uri' bes.json | head -1)
-curl -s -H "x-buildbuddy-api-key: $KEY" \
-  "https://app.buildbuddy.io/file/download?bytestream_url=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$URI")"
+bb_get "$BB/file/download?bytestream_url=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=''))" "$URI")"
 ```
 
 ## Other Endpoints

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -95,19 +95,13 @@ if len(matches) == 1:
         f"{BB}/file/download?bytestream_url={urllib.parse.quote(uri, safe='')}"))
 ```
 
-## Endpoint Reference
+## Other Endpoints
 
-| Path                                       | Method | Notes                                                |
-| ------------------------------------------ | ------ | ---------------------------------------------------- |
-| `/api/v1/GetInvocation`                    | POST   | By invocation ID or commit SHA                       |
-| `/api/v1/GetTarget`                        | POST   | Targets with label, status, rule type                |
-| `/api/v1/GetLog`                           | POST   | Build stderr                                         |
-| `/api/v1/GetFile`                          | POST   | Download blob by bytestream URI                      |
-| `/rpc/BuildBuddyService/SearchInvocation`  | POST   | List/filter invocations (not in public API)          |
-| `/rpc/BuildBuddyService/GetExecution`      | POST   | Remote execution details                             |
-| `/rpc/BuildBuddyService/GetCacheScoreCard` | POST   | Per-action cache hit/miss                            |
-| `/rpc/BuildBuddyService/GetEventLogChunk`  | POST   | Build log chunks                                     |
-| `/file/download`                           | GET    | Artifact download (`artifact=` or `bytestream_url=`) |
+| Path                | Method | Notes                             |
+| ------------------- | ------ | --------------------------------- |
+| `/api/v1/GetTarget` | POST   | Targets with label, status, rule type |
+| `/api/v1/GetLog`    | POST   | Build stderr                      |
+| `/api/v1/GetFile`   | POST   | Download blob by bytestream URI   |
 
 For the full ~70 internal RPCs, see `proto/buildbuddy_service.proto` in the
 [BuildBuddy repo](https://github.com/buildbuddy-io/buildbuddy).

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -24,8 +24,8 @@ Run once before any API calls:
 ```bash
 KEY="$(grep -oP 'x-buildbuddy-api-key=\K.*' ~/.config/bazel/buildbuddy.bazelrc)"
 BB="https://app.buildbuddy.io"
-bb()     { curl -s -X POST -H "Content-Type: application/json" -H "x-buildbuddy-api-key: $KEY" "$@"; }
 bb_get() { curl -s -H "x-buildbuddy-api-key: $KEY" "$@"; }
+bb()     { bb_get -X POST -H "Content-Type: application/json" "$@"; }
 ```
 
 ## Common Recipes


### PR DESCRIPTION
## Summary
Migrated the BuildBuddy API reference documentation from `docs/buildbuddy_api.md` to a new skill format at `skills/buildbuddy_api/SKILL.md`. This reorganizes the documentation to fit the skills-based architecture while improving usability and clarity.

## Key Changes
- **Removed** `docs/buildbuddy_api.md` (123 lines)
- **Added** `skills/buildbuddy_api/SKILL.md` with skill metadata and reorganized content
- **Added skill metadata** including:
  - Skill name and description with use case triggers
  - `allowed-tools: Bash` declaration
  - Clear guidance on when to invoke this skill
- **Improved documentation structure**:
  - Added "Session Setup" section with reusable bash helper functions (`bb_get`, `bb`)
  - Simplified curl commands using the new helper functions
  - Refactored undeclared test outputs section to use bash + jq instead of Python
  - Condensed endpoint reference table (removed redundant entries)
  - Clarified which endpoints are public vs. internal
- **Enhanced clarity**:
  - Better formatting and inline comments
  - More concise descriptions of capabilities
  - Practical examples with clear variable placeholders

## Notable Details
The migration maintains all technical content while making it more accessible as a callable skill. The bash helper functions reduce boilerplate in examples, and the jq-based approach for parsing test outputs is more portable than the previous Python snippet.

https://claude.ai/code/session_018xr51mim8Kt8PY4jeCjxWf