### PR TITLE
Update web setup script branch reference from main to devel

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -324,7 +324,7 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/main/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/devel/devinfra/claude/web_setup.sh | bash
 ```
 
 This runs <web_setup.sh> which installs:


### PR DESCRIPTION
## Summary
Updated the branch reference in the web setup installation command from `main` to `devel` to point users to the development branch.

## Changes
- Updated the curl command in the Claude Code web setup instructions to reference the `devel` branch instead of `main` when fetching `web_setup.sh`

## Details
This change ensures that users following the web setup instructions will pull the script from the development branch, which likely contains the latest updates and improvements to the setup process.

https://claude.ai/code/session_01FwFvpsgPCZqVDLRLhqHRJY