### PR TITLE
Update verify-docs skill; fix wt/README github_repo

### DIFF
--- a/skills/verify_docs/SKILL.md
+++ b/skills/verify_docs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: verify-docs
-description: Verify documentation claims against actual code, finding and fixing stale or incorrect docs. Audit AGENTS.md/README.md/STYLE.md for token efficiency — cut what strong LLMs already know, keep local specifics and gotchas. Use when asked to review docs, trim docs, or check docs are accurate.
-allowed-tools: Bash Read Grep Glob Edit Write Agent
+description: Verify documentation claims against actual code, finding and fixing stale or incorrect docs. Audit docs for token efficiency — cut what strong LLMs already know, keep local specifics and gotchas. Use when asked to review docs, trim docs, or check docs are accurate.
 ---
 
 # Verify and Optimize Documentation
@@ -10,7 +9,7 @@ Audit repo documentation for correctness and token efficiency.
 
 ## Principles
 
-Docs are primarily consumed by LLM agents. Strong LLMs already know Python, k8s, general SE practices, well-known APIs. Only document:
+Docs are primarily consumed by LLM agents. Strong LLMs already know standard languages, frameworks, well-known APIs, and general SE practices. Only document:
 
 - **Local specifics**: bespoke APIs, repo-specific patterns, non-obvious config
 - **Gotchas**: things that previously broke, counterintuitive behavior
@@ -18,54 +17,51 @@ Docs are primarily consumed by LLM agents. Strong LLMs already know Python, k8s,
 
 Cut everything a strong LLM could derive from reading the code or from general knowledge.
 
-## File hierarchy
+## Standards
 
-| File        | Role                                     |
-| ----------- | ---------------------------------------- |
-| `CLAUDE.md` | Always just `@AGENTS.md`                 |
-| `AGENTS.md` | Transcludes README + agent prescriptions |
-| `README.md` | What it is, how to run (humans + agents) |
-| `STYLE.md`  | Repo-wide style rules (root only)        |
-
-`AGENTS.md` should transitively transclude (`@file`) things agents always need. For rarely-needed docs, reference them (link/path) so agents read on demand.
-
-Sub-package `AGENTS.md` must not repeat parent-level instructions.
+- **AGENTS.md**: open standard for AI coding agent instructions. Spec: <https://agents.md/>, repo: <https://github.com/agentsmd/agents.md>. Agents read the nearest AGENTS.md in the directory tree; monorepos use per-package files.
+- **CLAUDE.md**: Claude Code's equivalent. Claude reads CLAUDE.md files hierarchically — all parents from repo root to current directory are loaded into context. Docs: <https://code.claude.com/docs/en/memory>
+- **`@`-transclusion**: Claude Code feature where `@path/to/file` on its own line imports that file's content. Paths resolve relative to the importing file. Max depth: 5 hops.
 
 ## Audit procedure
 
-1. **Inventory**: Glob for `**/AGENTS.md`, `**/README.md`, `**/CLAUDE.md`, `**/STYLE.md`
-2. **Structural check**: Verify each `CLAUDE.md` is just `@AGENTS.md`. Verify `AGENTS.md` files start with `@README.md` where a README exists.
-3. **Staleness check**: For each claim in docs (file paths, function signatures, env vars, CLI flags, Bazel targets), grep the codebase to verify it still exists and is accurate. Flag stale references.
-4. **Token audit**: For each doc, flag:
-   - General SE knowledge LLMs already have (e.g., "pytest uses fixtures for shared setup")
+1. **Discover conventions**: read root AGENTS.md, STYLE.md, README.md to learn this repo's doc structure, file hierarchy, and naming conventions. Don't assume — each repo may differ.
+2. **Inventory**: find all documentation files (markdown, plaintext, in-code docs).
+3. **Structural check**: verify the repo's own doc conventions are followed consistently.
+4. **Staleness check**: for each claim in docs (file paths, function signatures, env vars, CLI flags, build targets), grep the codebase to verify it still exists and is accurate. Flag stale references.
+5. **Token audit**: for each doc, flag:
+   - General knowledge LLMs already have
    - Restated type signatures or parameter lists
    - Explanatory prose that doesn't add info beyond what the code shows
    - Redundant examples (one is enough per pattern)
-   - Content duplicated between parent and child AGENTS.md
-5. **Classify kept content**: Confirm remaining content falls into: local specifics, gotchas, deviations, bespoke API details, or recovery procedures for past failures.
-6. **Propose changes**: Present a concrete diff or list of cuts with rationale. Group by file.
+   - Content duplicated between parent and child docs
+   - Repo conventions restated in sub-docs that inherit from parent
+6. **Classify kept content**: confirm remaining content falls into: local specifics, gotchas, deviations, bespoke API details, or recovery procedures for past failures.
+7. **Propose changes**: present a concrete diff or list of cuts with rationale. Group by file.
 
 ## What to cut (examples)
 
-- "Framework: pytest with pytest-asyncio" — LLMs know pytest
-- "Fixtures for shared setup" — obvious
-- Explaining what `pathlib.Path` is or why to prefer it
-- Lengthy examples of standard Python patterns (comprehensions, async/await)
-- Docstring style rules that restate PEP 257
+- General framework knowledge ("pytest uses fixtures for shared setup")
+- Standard library explanations (what `pathlib.Path` is)
+- Obvious build/test commands (`bazel test //path:target`)
+- Lengthy examples of standard patterns
+- Style rules that restate language conventions (PEP 257, etc.)
 
 ## What to keep (examples)
 
-- `pytest_bazel.main()` requirement — non-obvious, caused silent test passes
-- Session start hook recovery — bespoke, multi-step, previously caused outages
-- BuildBuddy RBE setup — bespoke API, not widely known
-- `dangerouslyDisableSandbox` for network commands — local gotcha
-- `live_openai_py_test` macro — repo-specific Bazel macro
-- Never amend pushed commits — repo policy (could be either way)
+- Non-obvious gotchas that caused real failures
+- Bespoke API details not widely known
+- Recovery procedures for past outages
+- Repo-specific macros, entry points, or tooling
+- Policy decisions that could go either way
 
 ## Prefer references over inline context
 
-When docs need to convey knowledge available elsewhere, reference the source rather than restating it. Prescribe agents to fetch context on demand (WebFetch a URL, invoke a skill, read a file) instead of embedding the full content.
+Reference external sources rather than restating them. Prescribe agents to fetch context on demand (WebFetch a URL, invoke a skill, read a file) instead of embedding the full content. This keeps docs small and avoids staleness.
 
-Good references: GitHub issue/PR URLs, upstream doc URLs, file paths with `@`-transclusion or `<path>` links, skill invocations (`/skill-name`).
+## Structural improvements
 
-This keeps docs small and avoids staleness from duplicated content. The agent can always fetch the authoritative source when it needs the detail.
+- **Historical/stale docs should be clearly marked** — by convention, filename, banner, or directory placement (e.g., `archive/`). The mechanism doesn't matter; what matters is that agents can tell current docs from historical ones.
+- **Verify link targets**: check all internal links actually resolve. Common issues: hyphens vs underscores, missing subdirectories, renamed files.
+- **Cohesive flow over cumulative patches**: docs that grew by accretion should be restructured into logical sections. Group related content; don't just append. Choose an internal structure appropriate to the doc type — e.g., investigation notes: summary → timeline → diagnostics → root cause → fix. Decision docs: problem statement → requirements → options considered → decision. Don't force a single template; pick what fits.
+- **Structural reshuffling**: when a doc is too large (>200 lines), consider splitting into focused sub-docs. When multiple small docs overlap, merge them. Rename/move files to better locations when the current placement is confusing. Extract reusable sub-docs that multiple parents can reference. The goal is docs that are cohesive, focused, and easy to navigate — not accumulated patches.

--- a/wt/README.md
+++ b/wt/README.md
@@ -48,7 +48,7 @@ main_repo: /path/to/repo # Required
 worktrees_dir: /path/to/worktrees # Required
 branch_prefix: feature/ # Required
 upstream_branch: main # Required
-github_repo: owner/repo # Required
+github_repo: owner/repo # Required when github_enabled=true
 ```
 
 Optional: `log_operations`, `cow_method` (auto|reflink|copy|rsync), `hydrate_worktrees`, `github_enabled`, `gitstatusd_path`, `post_creation_script`, `post_creation_timeout`.


### PR DESCRIPTION
## Summary

Split from #959.

- **2 files changed, +33/-37**
- verify-docs SKILL.md: repo-agnostic rewrite with AGENTS.md/CLAUDE.md standard refs, transclusion docs, removed `allowed-tools`
- wt/README.md: `github_repo` marked as required only when `github_enabled=true`

## Test plan

- [x] Pre-commit hooks pass
- [x] Docs only