### PR TITLE
Fix misleading comment about harbor_push.sh digest comparison

### DIFF
--- a/devinfra/ci/workflows.yaml
+++ b/devinfra/ci/workflows.yaml
@@ -40,10 +40,11 @@ workflows:
     trigger: { kind: path, pattern: "^devinfra/claude/testing/container_e2e/Dockerfile" }
 
   # Bazel image workflows always trigger. Bazel builds are hermetic, so same
-  # inputs → same image digest. The workflow compares the local digest against
-  # the registry and skips the push when unchanged. This avoids the stale-image
-  # bug where bazel-diff (HEAD vs HEAD~1) misses changes from earlier commits
-  # whose push step failed.
+  # inputs → same image digest. Docker push deduplicates at the blob level
+  # (existing layers aren't re-uploaded), so unchanged images have minimal
+  # network cost. Always-trigger also avoids the stale-image bug where
+  # bazel-diff (HEAD vs HEAD~1) misses changes from earlier commits whose
+  # push step failed.
   props-images:
     trigger: { kind: always }
     events: [push]


### PR DESCRIPTION
## Summary
- The comment in `workflows.yaml` claimed `harbor_push.sh` compares local digests against the registry and skips pushes when unchanged
- In reality, the script always pushes — Docker's registry protocol handles blob-level dedup (existing layers aren't re-uploaded), but the push + tagging always runs
- Updated comment to accurately describe the caching behavior

## Test plan
- [ ] Comment-only change, no functional impact

https://claude.ai/code/session_01R1J8fZFCEofWusoQ2FHsd2