### PR TITLE
fix: add goldilocks.fairwinds.com/enabled=true labels to all namespaces

### DIFF
--- a/cluster/k8s/activitywatch-namespace/namespace.yaml
+++ b/cluster/k8s/activitywatch-namespace/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: activitywatch
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/cluster/k8s/applications/nix-cache/namespace.yaml
+++ b/cluster/k8s/applications/nix-cache/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: nix-cache
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/atuin-namespace/namespace.yaml
+++ b/cluster/k8s/atuin-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: atuin
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/authentik-namespace/namespace.yaml
+++ b/cluster/k8s/authentik-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: authentik
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"

--- a/cluster/k8s/cnpg/namespace.yaml
+++ b/cluster/k8s/cnpg/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: cnpg-system
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"

--- a/cluster/k8s/dns-system-namespace/namespace.yaml
+++ b/cluster/k8s/dns-system-namespace/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: dns-system
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"
     name: dns-system
     # Allow unsafe sysctls (net.ipv4.tcp_mtu_probing) for PMTUD blackhole mitigation

--- a/cluster/k8s/gatus-namespace/namespace.yaml
+++ b/cluster/k8s/gatus-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: gatus
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/gitea-namespace/namespace.yaml
+++ b/cluster/k8s/gitea-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: gitea
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/goldilocks/namespace.yaml
+++ b/cluster/k8s/goldilocks/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: goldilocks
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/google-workspace-mcp/namespace.yaml
+++ b/cluster/k8s/google-workspace-mcp/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: google-workspace-mcp
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     name: google-workspace-mcp

--- a/cluster/k8s/grocy-namespace/namespace.yaml
+++ b/cluster/k8s/grocy-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: grocy
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/harbor-namespace/namespace.yaml
+++ b/cluster/k8s/harbor-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: harbor
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/headlamp-namespace/namespace.yaml
+++ b/cluster/k8s/headlamp-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: headlamp
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/homeassistant-proxy-namespace/namespace.yaml
+++ b/cluster/k8s/homeassistant-proxy-namespace/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: homeassistant-proxy
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     pod-security.kubernetes.io/enforce: restricted

--- a/cluster/k8s/inventree-namespace/namespace.yaml
+++ b/cluster/k8s/inventree-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: inventree
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/langfuse-namespace/namespace.yaml
+++ b/cluster/k8s/langfuse-namespace/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: langfuse
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
   annotations:
     goldilocks.fairwinds.com/cpu-min: "500m"

--- a/cluster/k8s/loki/namespace.yaml
+++ b/cluster/k8s/loki/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: loki
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/cluster/k8s/matrix-namespace/namespace.yaml
+++ b/cluster/k8s/matrix-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: matrix
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/monitoring-namespace/namespace.yaml
+++ b/cluster/k8s/monitoring-namespace/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: monitoring
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/cluster/k8s/ollama-namespace/namespace.yaml
+++ b/cluster/k8s/ollama-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: ollama
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/openclaw-gateway-namespace/namespace.yaml
+++ b/cluster/k8s/openclaw-gateway-namespace/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: openclaw-gateway
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     name: openclaw-gateway

--- a/cluster/k8s/openclaw-mitmproxy-namespace/namespace.yaml
+++ b/cluster/k8s/openclaw-mitmproxy-namespace/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: openclaw-mitmproxy
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     name: openclaw-mitmproxy

--- a/cluster/k8s/props-namespace/namespace.yaml
+++ b/cluster/k8s/props-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: props
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/proxmox-proxy-namespace/namespace.yaml
+++ b/cluster/k8s/proxmox-proxy-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: proxmox-proxy
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/scanner-namespace/namespace.yaml
+++ b/cluster/k8s/scanner-namespace/namespace.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: scanner
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"
     pod-security.kubernetes.io/enforce: privileged

--- a/cluster/k8s/tana-mcp-namespace/namespace.yaml
+++ b/cluster/k8s/tana-mcp-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: tana-mcp
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/tofu-state-namespace/namespace.yaml
+++ b/cluster/k8s/tofu-state-namespace/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: tofu-state
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/vault-operator/operator.yaml
+++ b/cluster/k8s/vault-operator/operator.yaml
@@ -4,6 +4,7 @@ kind: Namespace
 metadata:
   name: vault
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     goldilocks.fairwinds.com/vpa-update-mode: "initial"
     # Pod Security Standards - Allow privileged containers for Vault's IPC_LOCK capability
     # TODO: IPC_LOCK should not require particularly wide privileges

--- a/cluster/scripts/validate_cluster/checks.py
+++ b/cluster/scripts/validate_cluster/checks.py
@@ -74,6 +74,22 @@ def check_controller_resource_health_checks(cluster: ParsedCluster, k8s_dir: Pat
     return check_controller_health_checks(cluster, k8s_dir, repo_root)
 
 
+def check_goldilocks_namespace_labels(cluster: ParsedCluster) -> list[str]:
+    """Check that namespaces with a goldilocks vpa-update-mode label also have goldilocks enabled."""
+    errors = []
+    for file_path, resources in cluster.source_resources.items():
+        for resource in resources:
+            if resource.kind != "Namespace":
+                continue
+            labels = resource.metadata.labels
+            if "goldilocks.fairwinds.com/vpa-update-mode" in labels and labels.get("goldilocks.fairwinds.com/enabled") != "true":
+                errors.append(
+                    f"{file_path}: namespace '{resource.name}' has goldilocks.fairwinds.com/vpa-update-mode "
+                    f"but is missing goldilocks.fairwinds.com/enabled=\"true\""
+                )
+    return errors
+
+
 def check_blueprint_completeness(k8s_dir: Path) -> list[str]:
     """Check that all blueprint YAML files are listed in the authentik configMapGenerator."""
     authentik_kust = k8s_dir / "authentik" / "kustomization.yaml"

--- a/cluster/scripts/validate_cluster/main.py
+++ b/cluster/scripts/validate_cluster/main.py
@@ -32,6 +32,7 @@ from cluster.scripts.validate_cluster.checks import (
     check_controller_resource_health_checks,
     check_crd_layering,
     check_duplicate_external_secrets,
+    check_goldilocks_namespace_labels,
     find_orphaned_files,
 )
 from cluster.scripts.validate_cluster.flux import validate_flux_build
@@ -104,6 +105,9 @@ async def main() -> int:
 
     # Check authentik blueprint completeness
     global_errors.extend(check_blueprint_completeness(root))
+
+    # Check goldilocks namespace labels
+    global_errors.extend(check_goldilocks_namespace_labels(cluster))
 
     # Validate dependencies
     if not args.skip_dependencies:

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -205,6 +205,7 @@ py_test(
         ":cluster",
         ":dependencies",
         ":health_checks",
+        "//cluster/scripts/validate_cluster:checks",
         "//util/bazel:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/cluster/validation/k8s.py
+++ b/cluster/validation/k8s.py
@@ -16,6 +16,7 @@ class K8sMetadata(BaseModel):
 
     name: str = ""
     namespace: str = ""
+    labels: dict[str, str] = Field(default_factory=dict)
 
 
 class HelmChartSpec(BaseModel):

--- a/cluster/validation/test_cluster_integration.py
+++ b/cluster/validation/test_cluster_integration.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_bazel
 import yaml
 
+from cluster.scripts.validate_cluster.checks import check_goldilocks_namespace_labels
 from cluster.validation.cluster import ParsedCluster, parse_cluster
 from cluster.validation.dependencies import validate_dependencies
 from cluster.validation.health_checks import check_controller_health_checks, check_retry_policy
@@ -86,6 +87,12 @@ def test_no_unwired_flux_kustomizations(cluster: ParsedCluster, k8s_dir: Path) -
     assert not unwired, "flux-kustomization.yaml files not listed in root kustomization.yaml:\n" + "\n".join(
         f"  {f}" for f in unwired
     )
+
+
+def test_goldilocks_namespace_labels(cluster: ParsedCluster) -> None:
+    """Namespaces with goldilocks vpa-update-mode must also have goldilocks enabled."""
+    errors = check_goldilocks_namespace_labels(cluster)
+    assert not errors, "\n".join(errors)
 
 
 def test_blueprint_completeness(k8s_dir: Path) -> None:


### PR DESCRIPTION
Goldilocks dashboard requires the `goldilocks.fairwinds.com/enabled=true` label
to discover namespaces. All 28 namespaces were only labeled with
`goldilocks.fairwinds.com/vpa-update-mode` (auto or initial), which controls
VPA update behavior but does NOT enable dashboard discovery.

This explains why https://goldilocks.allegedly.works/namespaces showed "No
namespaces are labelled for use by Goldilocks."

https://claude.ai/code/session_01XHhCUZ7e9t9fD8KD2iJRrE