### PR TITLE
Add tombstone convention for deferred cleanup and decommission headscale

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -160,6 +160,35 @@ Style and convention rules for this repository. Package-specific elaborations be
   - Use `itertools.batched` (stdlib since 3.12) instead of `for i in range(0, len(x), n): batch = x[i:i+n]`.
   - Choose `one()` vs `first()` based on semantics: if receiving multiple items is a bug, use `one()` to enforce the invariant. If multiple items are valid and you want the first, use `first()`.
 
+## Tombstones
+
+When removing something that cannot be deleted atomically — because downstream consumers
+need a transition period (old clients still reading a serialized field, a service being
+decommissioned still holding an OAuth registration, a deprecated API still called by code
+being migrated) — leave a **tombstone**: a dated marker that records what was removed and
+the condition under which the tombstone itself can be deleted.
+
+**Tag**: `CLEANUP` followed by the ISO date the tombstone was added (today's date when you
+write it — useful for spotting stale tombstones during review). The condition text encodes
+when to remove it:
+
+```python
+# CLEANUP(2026-03-22): Remove field once all clients are on ≥v2.3
+#   (commit abc123 drops the last reader).
+old_field: str | None = None
+```
+
+**Rules:**
+
+- The condition must be specific and verifiable — "once commit X ships to all releases" or
+  "after YYYY-MM-DD", not "when safe".
+- Delete the tombstone (and any code/config it guards) once the condition is met. Tombstones
+  are not permanent fixtures.
+- Tombstones are **not** historical comments. "Used to do X" explains the past and should be
+  deleted; a `CLEANUP` comment is an active work item near the code it refers to.
+- Cross-cutting cleanup that spans many files belongs in `TODO.md`; tombstones are for
+  localized removals where the marker lives right next to the thing being cleaned up.
+
 ## SQLAlchemy
 
 - **Prefer SQLAlchemy ORM over raw SQL**: In projects using SQLAlchemy, prefer the ORM query interface over raw SQL strings. The ORM provides type safety, IDE support, and protection against SQL injection. Use raw SQL only when the ORM would make the query significantly less readable (e.g., complex window functions, CTEs, or database-specific features not well-supported by the ORM).

--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -111,6 +111,14 @@ spec:
 
 `namespaceSelector` + `podSelector` in the same `from` item are ANDed.
 
+**Deleting Authentik providers or applications**: Always add a `state: absent` tombstone
+entry — never just remove the `state: present` block. The worker re-applies blueprints
+every 60 min; the absent entry is what actually removes the stale resource. Follow the
+`CLEANUP` tombstone convention from <../STYLE.md>. Place absent entries in the app's
+existing blueprint, or in a dedicated cleanup blueprint (e.g.,
+`k8s/authentik/blueprints/headscale-cleanup.yaml`) when the app itself is gone. Remove
+the entries after a few reconcile cycles once confirmed clean.
+
 ## Operational Context
 
 - **SSH**: `root@atlas` (Proxmox host, key auth)

--- a/cluster/k8s/authentik/blueprints/airlock-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/airlock-sso.yaml
@@ -8,11 +8,24 @@ metadata:
       "read" scopes for operator access.
 
 entries:
-  # Remove old proxy provider (replaced by native OAuth2 for SPA).
+  # CLEANUP(2026-03-22): Remove once confirmed absent in Authentik (proxy provider replaced
+  #   by native OAuth2 for the airlock SPA).
   - model: authentik_providers_proxy.proxyprovider
     state: absent
     identifiers:
       name: airlock
+
+  # CLEANUP(2026-03-22): Remove once confirmed absent in Authentik (oauth-broker merged
+  #   into airlock).
+  - model: authentik_providers_oauth2.oauth2provider
+    state: absent
+    identifiers:
+      name: oauth-broker
+
+  - model: authentik_core.application
+    state: absent
+    identifiers:
+      slug: oauth-broker
 
   # OAuth2 provider — public client for the operator SPA (Authorization Code + PKCE).
   - model: authentik_providers_oauth2.oauth2provider

--- a/cluster/k8s/authentik/blueprints/headscale-cleanup.yaml
+++ b/cluster/k8s/authentik/blueprints/headscale-cleanup.yaml
@@ -1,0 +1,18 @@
+version: 1
+metadata:
+  name: Cleanup - Headscale
+  labels:
+    blueprints.goauthentik.io/description: >-
+      Remove headscale SSO registration (headscale decommissioned).
+
+entries:
+  # CLEANUP(2026-03-22): Remove once confirmed absent in Authentik (headscale decommissioned).
+  - model: authentik_providers_oauth2.oauth2provider
+    state: absent
+    identifiers:
+      name: headscale
+
+  - model: authentik_core.application
+    state: absent
+    identifiers:
+      slug: headscale

--- a/cluster/k8s/authentik/kustomization.yaml
+++ b/cluster/k8s/authentik/kustomization.yaml
@@ -36,4 +36,5 @@ configMapGenerator:
       - blueprints/openclaw-agent-oauth2.yaml
       - blueprints/airlock-sso.yaml
       - blueprints/claude-code-airlock-oauth2.yaml
+      - blueprints/headscale-cleanup.yaml
     namespace: authentik


### PR DESCRIPTION
## Summary

This PR establishes a formal tombstone convention for managing non-atomic removals (deprecated fields, decommissioned services, migrated APIs) and applies it to decommission the headscale OAuth2 provider from Authentik.

## Changes

- **STYLE.md**: Added "Tombstones" section documenting the `CLEANUP(YYYY-MM-DD)` convention for marking code/config slated for removal, with specific rules for verifiable conditions and lifecycle management.

- **Authentik blueprints**: 
  - Created `headscale-cleanup.yaml` with `state: absent` entries to remove the decommissioned headscale OAuth2 provider and application.
  - Updated `airlock-sso.yaml` to convert existing cleanup comments to formal `CLEANUP` tombstones and add absent entries for the deprecated oauth-broker provider/application.

- **AGENTS.md**: Added operational guidance on deleting Authentik providers/applications, emphasizing the use of `state: absent` tombstone entries and the `CLEANUP` convention.

- **kustomization.yaml**: Registered the new `headscale-cleanup.yaml` blueprint for deployment.

## Implementation Details

The tombstone convention uses ISO dates (YYYY-MM-DD) to enable easy identification of stale markers during code review. Conditions are specific and verifiable (e.g., "once commit X ships" or "after YYYY-MM-DD"), not vague ("when safe"). Tombstones are active work items that live next to the code they guard and must be deleted once conditions are met—they are not permanent historical comments.

For Authentik, the `state: absent` entries are critical because the worker re-applies blueprints every 60 minutes; removing only the `state: present` block would not actually delete the stale resource.

https://claude.ai/code/session_01YNCQQwAGJ2TW9LCFux5vA7