### PR TITLE
Add event logging to hook dispatch for debugging and monitoring

### DIFF
--- a/devinfra/claude/hook_daemon/hook_dispatch.py
+++ b/devinfra/claude/hook_daemon/hook_dispatch.py
@@ -5,9 +5,12 @@ handles dispatch, OTEL, and session start setup. If the daemon is unreachable,
 the client starts a new one automatically.
 """
 
+import json
 import os
 import sys
+import time
 import traceback
+from pathlib import Path
 
 from pydantic import TypeAdapter
 
@@ -17,27 +20,57 @@ from devinfra.claude.session_paths import SessionPaths
 
 _adapter: TypeAdapter[AnyHookInput] = TypeAdapter(AnyHookInput)
 
+_HOOK_EVENT_LOG = Path("/tmp/claude-hook-events.jsonl")
+
+
+def _log_event(direction: str, raw_json: str | None, *, hook_name: str = "", session_id: str = "") -> None:
+    """Append a hook event entry to the machine-wide event log."""
+    entry = {
+        "ts": time.time(),
+        "pid": os.getpid(),
+        "dir": direction,
+        "hook": hook_name,
+        "session_id": session_id,
+        "data": raw_json,
+    }
+    with _HOOK_EVENT_LOG.open("a") as f:
+        f.write(json.dumps(entry, default=str) + "\n")
+
 
 def main() -> None:
     raw = sys.stdin.buffer.read()
-    parsed = _adapter.validate_json(raw)
+    raw_str = raw.decode("utf-8", errors="replace")
+
+    try:
+        parsed = _adapter.validate_json(raw)
+    except Exception:
+        _log_event("input_parse_error", raw_str)
+        raise
+
+    _log_event("input", raw_str, hook_name=parsed.hook_event_name, session_id=parsed.session_id)
 
     paths = SessionPaths.from_env(parsed.session_id, dict(os.environ))
 
     result = call_daemon(parsed, dict(os.environ), paths)
     if result is not None and result.output is not None:
+        output_json = result.output.model_dump_json(by_alias=True, exclude_none=True)
+        _log_event("output", output_json, hook_name=parsed.hook_event_name, session_id=parsed.session_id)
         # exclude_none: Zod .optional() accepts undefined (absent) but NOT null.
         # Pydantic emits None as null by default; exclude_none omits those fields.
-        sys.stdout.write(result.output.model_dump_json(by_alias=True, exclude_none=True))
+        sys.stdout.write(output_json)
     elif result is None:
+        _log_event("error", "daemon_unavailable", hook_name=parsed.hook_event_name, session_id=parsed.session_id)
         print("ERROR: hook daemon unavailable", file=sys.stderr)
         sys.exit(1)
+    else:
+        _log_event("output", None, hook_name=parsed.hook_event_name, session_id=parsed.session_id)
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
+        _log_event("crash", traceback.format_exc())
         print(f"Hook dispatch failed: {e}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
This change adds comprehensive event logging to the hook dispatch system, enabling better visibility into hook execution flow and debugging of issues in production environments.

## Key Changes
- **New logging infrastructure**: Added `_log_event()` function that writes structured JSON events to a machine-wide event log at `/tmp/claude-hook-events.jsonl`
- **Event tracking**: Logs are now recorded for:
  - Input parsing (successful and failed)
  - Hook execution output
  - Error conditions (daemon unavailable, crashes)
- **Event metadata**: Each log entry includes timestamp, process ID, direction (input/output/error), hook name, session ID, and relevant data
- **Error handling**: Input parsing errors are now logged before being re-raised, ensuring visibility into malformed inputs
- **Output optimization**: The output JSON is now computed once and reused, avoiding redundant serialization

## Implementation Details
- Uses `pathlib.Path` for cleaner file handling
- Logs raw input as UTF-8 decoded string (with error replacement for robustness)
- Logs output as the serialized JSON string for consistency
- Crash events include full traceback via `traceback.format_exc()`
- All log entries use `default=str` in JSON serialization to handle any non-serializable objects gracefully

https://claude.ai/code/session_01V819795WqeMvLmHsHVKXH5