### PR TITLE
cleanup: execute three CLEANUP tombstones

### DIFF
--- a/ansible/vps.yaml
+++ b/ansible/vps.yaml
@@ -129,6 +129,8 @@
           - "adgn.link"
           - "www.adgn.link"
 
+    # CLEANUP(2026-03-22): Remove this block once headscale has been confirmed absent
+    #   from the VPS across several deployments (headscale moved to Nebula/cluster).
     - name: Uninstall headscale server
       tags: [headscale]
       block:
@@ -211,6 +213,8 @@
           notify:
             - Reload nginx
 
+    # CLEANUP(2026-03-22): Remove once legacy nginx stream directories are confirmed
+    #   absent from VPS across several deployments.
     - name: Remove legacy nginx stream configs (test cluster)
       tags: [nginx]
       block:

--- a/cluster/k8s/authentik/blueprints/gatus-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/gatus-sso.yaml
@@ -5,7 +5,8 @@ metadata:
     blueprints.goauthentik.io/description: "Gatus OAuth2 OIDC provider and application"
 
 entries:
-  # Remove old proxy provider (replaced by native OIDC)
+  # CLEANUP(2026-03-22): Remove once confirmed absent in Authentik (proxy provider replaced
+  #   by native OIDC).
   - model: authentik_providers_proxy.proxyprovider
     state: absent
     identifiers:

--- a/cluster/k8s/authentik/blueprints/headlamp-sso.yaml
+++ b/cluster/k8s/authentik/blueprints/headlamp-sso.yaml
@@ -5,7 +5,8 @@ metadata:
     blueprints.goauthentik.io/description: "Headlamp OAuth2 OIDC provider and application"
 
 entries:
-  # Remove old proxy provider (replaced by oauth2 provider for direct OIDC login)
+  # CLEANUP(2026-03-22): Remove once confirmed absent in Authentik (proxy provider replaced
+  #   by native OAuth2 OIDC for direct login).
   - model: authentik_providers_proxy.proxyprovider
     state: absent
     identifiers:

--- a/mcp_infra/compositor/admin.py
+++ b/mcp_infra/compositor/admin.py
@@ -4,7 +4,7 @@ from fastmcp.mcp_config import MCPServerTypes, RemoteMCPServer, StdioMCPServer
 from pydantic import Field
 
 from mcp_infra.compositor.compositor import Compositor
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.mcp_types import SimpleOk
 from mcp_infra.prefix import MCPMountPrefix

--- a/mcp_infra/compositor/resources_server.py
+++ b/mcp_infra/compositor/resources_server.py
@@ -12,7 +12,7 @@ from mcp.shared.exceptions import McpError
 from pydantic import BaseModel, ConfigDict, Field
 
 from mcp_infra.compositor.server import BaseCompositor
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.mcp_types import SimpleOk
 from mcp_infra.mount_types import MountEvent

--- a/mcp_infra/enhanced/flat_mixin.py
+++ b/mcp_infra/enhanced/flat_mixin.py
@@ -13,9 +13,6 @@ from agent_core.pydantic_utils import format_validation_error
 from mcp_infra.flat_tool import FlatTool, _EmptyModel
 from openai_utils.json_schema import openai_json_schema
 
-# Re-export for backwards compatibility
-__all__ = ["FlatModelMixin", "FlatTool"]
-
 logger = logging.getLogger(__name__)
 
 

--- a/mcp_infra/exec/bwrap.py
+++ b/mcp_infra/exec/bwrap.py
@@ -9,7 +9,7 @@ import mcp.types as mcp_types
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.models import BaseExecResult, ExecArgsBase, ExecOutcome, render_outcome_to_result
 from mcp_infra.exec.read_image import ReadImageInput, validate_and_encode_image

--- a/mcp_infra/exec/direct.py
+++ b/mcp_infra/exec/direct.py
@@ -11,7 +11,7 @@ import mcp.types as mcp_types
 from fastmcp.server.auth import AuthProvider
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.models import BaseExecResult
 from mcp_infra.exec.read_image import ReadImageInput, validate_and_encode_image

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -16,7 +16,7 @@ import mcp.types as mcp_types
 from fastmcp.server.context import Context
 from pydantic import Field, create_model
 
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.docker.container_session import (
     ContainerOptions,

--- a/mcp_infra/exec/seatbelt.py
+++ b/mcp_infra/exec/seatbelt.py
@@ -11,7 +11,7 @@ import mcp.types as mcp_types
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.models import (
     BaseExecResult,

--- a/mcp_infra/stubs/typed_stubs.py
+++ b/mcp_infra/stubs/typed_stubs.py
@@ -8,7 +8,7 @@ from fastmcp.client.client import CallToolResult as FastMCPCallToolResult
 from fastmcp.server import FastMCP
 from pydantic import BaseModel, TypeAdapter
 
-from mcp_infra.enhanced.flat_mixin import FlatTool
+from mcp_infra.flat_tool import FlatTool
 
 
 def _structured_content(result: FastMCPCallToolResult, *, tool_name: str) -> dict[str, Any]:

--- a/props/core/models/true_positive.py
+++ b/props/core/models/true_positive.py
@@ -5,8 +5,6 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
-from props.core.models.types import SnapshotRelativePath
-
 
 class LineRange(BaseModel):
     start_line: int = Field(ge=1, description="1-based start line number")
@@ -70,17 +68,6 @@ class Occurrence(BaseModel):
             "do not repeat issue-level rationale here."
         )
     )
-
-    @classmethod
-    def from_files_dict(
-        cls, files: dict[SnapshotRelativePath, list[LineRange] | None], note: str | None = None
-    ) -> Occurrence:
-        """Create Occurrence from dict-based files (migration helper)."""
-        return cls(files=[FileOccurrence(path=path, ranges=ranges) for path, ranges in files.items()], note=note)
-
-    def files_dict(self) -> dict[Path, list[LineRange] | None]:
-        """Convert files list to dict (for backward compatibility)."""
-        return {fo.path: fo.ranges for fo in self.files}
 
     model_config = ConfigDict(extra="forbid")
 

--- a/props/db/migrations/versions/20251228000000_complete_schema.py
+++ b/props/db/migrations/versions/20251228000000_complete_schema.py
@@ -68,21 +68,14 @@ def upgrade() -> None:
         )
     """)
 
-    # Note: 'clustering' value kept for backward compatibility but is deprecated/unused
     op.execute("""
         CREATE TYPE agent_type_enum AS ENUM (
             'critic',
             'grader',
             'critic_dev_optimize',
-            'clustering',
             'freeform',
             'critic_dev_improve'
         )
-    """)
-
-    op.execute("""
-        COMMENT ON TYPE agent_type_enum IS
-        'Agent types. Note: clustering value is deprecated and unused.'
     """)
 
     op.execute("""
@@ -751,7 +744,6 @@ Requires caller to be a whole-repo mode agent (critic_dev_optimize or critic_dev
                 "critic",
                 "grader",
                 "critic_dev_optimize",
-                "clustering",
                 "freeform",
                 "critic_dev_improve",
                 name="agent_type_enum",

--- a/x/claude_linter_v2/cli.py
+++ b/x/claude_linter_v2/cli.py
@@ -24,7 +24,7 @@ from x.claude_linter_v2.checker import FileChecker
 from x.claude_linter_v2.config.models import AutofixCategory
 from x.claude_linter_v2.hooks.exceptions import HookBugError
 from x.claude_linter_v2.hooks.handler import HOOK_REQUEST_TYPES, HookHandler
-from x.claude_linter_v2.session.manager import RuleAction, SessionInfo, SessionManager
+from x.claude_linter_v2.session.manager import RuleAction, SessionData, SessionManager
 
 __version__ = "2.0.0a1"
 
@@ -296,7 +296,7 @@ def session_list(all: bool) -> None:
     current_dir = Path.cwd()
 
     # Group by directory
-    by_dir: dict[Path, list[SessionInfo]] = {}
+    by_dir: dict[Path, list[SessionData]] = {}
     for session_info in sessions:
         dir_path = session_info.directory
         if dir_path and dir_path not in by_dir:
@@ -320,7 +320,7 @@ def session_list(all: bool) -> None:
                 _display_session(session_info)
 
 
-def _display_session(session_info: SessionInfo) -> None:
+def _display_session(session_info: SessionData) -> None:
     """Display a single session's information."""
     ago = humanize.naturaltime(session_info.last_seen) if session_info.last_seen else "unknown"
     session_id_str = str(session_info.id)

--- a/x/claude_linter_v2/session/manager.py
+++ b/x/claude_linter_v2/session/manager.py
@@ -43,9 +43,6 @@ class SessionData(BaseModel):
     notification_id: int | None = None
 
 
-# Type alias for backwards compatibility
-SessionInfo = SessionData
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
- FlatTool re-export: migrate 7 callers to import from mcp_infra.flat_tool directly; remove __all__ re-export from flat_mixin.py
- SessionInfo alias: update cli.py to import SessionData, delete alias
- clustering agent_type: remove 'clustering' from agent_type_enum in migration (prod DB will be recreated)

https://claude.ai/code/session_01YNCQQwAGJ2TW9LCFux5vA7