### PR TITLE
Add pre-commit hook to block amending already-pushed commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,6 +123,17 @@ repos:
   # ============================================================================
   # LOCAL HOOKS
   # ============================================================================
+
+  # Block amending already-pushed commits (prepare-commit-msg stage)
+  - repo: local
+    hooks:
+      - id: block-amend-pushed
+        name: Block amending pushed commits
+        entry: devinfra/precommit/block_amend_pushed.sh
+        language: system
+        stages: [prepare-commit-msg]
+        always_run: true
+
   - repo: local
     hooks:
       # Ansible syntax check: Fast validation for pre-commit

--- a/devinfra/precommit/block_amend_pushed.sh
+++ b/devinfra/precommit/block_amend_pushed.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-commit hook (prepare-commit-msg stage): block amending already-pushed commits.
+#
+# Git invokes prepare-commit-msg with:
+#   $1 = commit message file
+#   $2 = source: "commit" (amend), "message" (-m), "merge", "squash", or empty
+#   $3 = SHA (only for amend)
+#
+# When $2 = "commit", this is a --amend. We check if HEAD has been pushed to
+# any remote tracking branch. If so, we abort to prevent history rewriting.
+set -euo pipefail
+
+# Only act on amend commits
+if [[ "${2:-}" != "commit" ]]; then
+  exit 0
+fi
+
+# Check if HEAD exists on any remote branch
+if git branch -r --contains HEAD 2>/dev/null | grep -q .; then
+  echo "ERROR: Refusing to amend a commit that has already been pushed." >&2
+  echo "Create a new commit instead. See AGENTS.md: \"NEVER amend a commit that has already been pushed.\"" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
This change adds a new pre-commit hook that prevents developers from amending commits that have already been pushed to remote branches, helping protect repository history integrity.

## Key Changes
- **New hook script** (`devinfra/precommit/block_amend_pushed.sh`): Implements a `prepare-commit-msg` stage hook that:
  - Detects when a commit amendment (`git commit --amend`) is being performed
  - Checks if the current HEAD exists on any remote tracking branch
  - Aborts the amendment with a clear error message if the commit has been pushed
  - References AGENTS.md documentation for guidance on proper workflow

- **Updated pre-commit configuration** (`.pre-commit-config.yaml`): Registers the new hook with:
  - `prepare-commit-msg` stage execution
  - `always_run: true` to ensure it runs on every amend attempt
  - Clear naming and entry point configuration

## Implementation Details
The hook leverages Git's `branch -r --contains` command to efficiently check if HEAD exists on any remote branch, providing a lightweight safeguard against accidental history rewrites that could cause issues for collaborators.

https://claude.ai/code/session_01WYH2feTNqRExP9S96CuAZW