### PR TITLE
Increase hook daemon idle timeout from 5 to 30 minutes

### DIFF
--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -35,7 +35,7 @@ from devinfra.claude.settings import HookSettings
 
 logger = logging.getLogger(__name__)
 
-IDLE_TIMEOUT_SECONDS = 300  # 5 minutes
+IDLE_TIMEOUT_SECONDS = 1800  # 30 minutes
 IDLE_CHECK_INTERVAL_SECONDS = 30
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
Increased the idle timeout for the hook daemon server to allow longer periods of inactivity before connection termination.

## Changes
- Updated `IDLE_TIMEOUT_SECONDS` from 300 seconds (5 minutes) to 1800 seconds (30 minutes) in the hook daemon server configuration

## Details
This change extends the grace period before idle connections are closed, reducing the likelihood of premature disconnections during periods of low activity while the daemon remains operational.

https://claude.ai/code/session_015HezLRLmiLCQS1Dkb1BDrm