### PR TITLE
web_setup: add nix.conf debug dump, pass --max-jobs auto explicitly

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -90,8 +90,15 @@ echo "---"
 echo "Connectivity check (cache.allegedly.works)..."
 curl -fsSL --max-time 10 https://cache.allegedly.works/main/nix-cache-info
 
+echo "--- nix.conf ---"
+cat ~/.config/nix/nix.conf
+echo "--- nix show-config ---"
+nix show-config 2>/dev/null | grep -E "max-jobs|sandbox|build-users" || true
+echo "---"
+
 echo "Installing web session tools..."
-nix profile install "${FLAKE}#web-session"
+# Pass --max-jobs explicitly to override any nix.conf misconfiguration.
+nix profile install --max-jobs auto "${FLAKE}#web-session"
 
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's


### PR DESCRIPTION
Sessions are still seeing `max-jobs = 0` despite the nix.conf fix in #995. Something is preventing the new `web_setup.sh` from taking effect (GitHub CDN caching, `/etc/nix/nix.conf`, `NIX_CONFIG` env var, or something else).

Two changes:

1. **Diagnostic dump** before `nix profile install`: prints `~/.config/nix/nix.conf` and `nix show-config` output filtered to `max-jobs`/`sandbox`/`build-users`. The next session log will show exactly what Nix sees.

2. **`--max-jobs auto` flag** on `nix profile install`: command-line flags override all config sources, so the install succeeds regardless of whatever is wrong with the config.

https://claude.ai/code/session_014iYPduvy8qaLPg1prqArUo