### PR TITLE
web_setup: symlink all nix bins to /usr/local/bin, fix hook PATH

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -328,9 +328,9 @@ To use this repository with Claude Code on the web, configure the following setu
 curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/154ce3ea6dfb5075cafbcbb3c89f86c707782b35/devinfra/claude/web_setup.sh | bash
 ```
 
-**Note**: Use a pinned commit SHA, not the `devel` branch ref — GitHub CDN caches
-branch-ref `raw.githubusercontent.com` URLs aggressively. SHA-addressed URLs are
-served from the immutable object store and are always fresh. Update the SHA when
+**Note**: Use a pinned commit SHA, not the `devel` branch ref — Anthropic caches
+the setup script at configuration time (when saved in the web UI). Changing the
+URL triggers a re-fetch; updating `devel` alone does not. Update the SHA when
 `web_setup.sh` changes (see <docs/web-setup-debug.md> for history).
 
 This runs <web_setup.sh> which installs:

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -325,7 +325,7 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/e9f4a33faab99c094930a6abf0b67e87202292a0/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/9b1f373c818b8077a9ab655191a85ba502e82f1a/devinfra/claude/web_setup.sh | bash
 ```
 
 **Note**: Use a pinned commit SHA, not the `devel` branch ref — GitHub CDN caches

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -325,8 +325,13 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/devel/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/e9f4a33faab99c094930a6abf0b67e87202292a0/devinfra/claude/web_setup.sh | bash
 ```
+
+**Note**: Use a pinned commit SHA, not the `devel` branch ref — GitHub CDN caches
+branch-ref `raw.githubusercontent.com` URLs aggressively. SHA-addressed URLs are
+served from the immutable object store and are always fresh. Update the SHA when
+`web_setup.sh` changes (see <docs/web-setup-debug.md> for history).
 
 This runs <web_setup.sh> which installs:
 

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -325,7 +325,7 @@ To use this repository with Claude Code on the web, configure the following setu
 
 ```bash
 #!/bin/bash
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/9b1f373c818b8077a9ab655191a85ba502e82f1a/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/154ce3ea6dfb5075cafbcbb3c89f86c707782b35/devinfra/claude/web_setup.sh | bash
 ```
 
 **Note**: Use a pinned commit SHA, not the `devel` branch ref — GitHub CDN caches

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -16,14 +16,16 @@ Investigation into `web_setup.sh` failures in Claude Code web sessions.
    attic cache miss. Fixed by removing `devinfra.build_info` from the wheel's
    dependency tree (`52e7c39`).
 
-3. **GitHub CDN caches branch-ref `raw.githubusercontent.com` URLs
-   aggressively.** After merging `max-jobs=auto` fixes (#994, #995), sessions
-   continued failing because `curl https://raw.githubusercontent.com/.../devel/...`
-   was still serving the pre-fix script. Fixed by pinning the setup script URL
-   to a specific commit SHA (`e9f4a33`) — SHA-addressed URLs are served from
-   the immutable object store, not the CDN branch cache. Also added
-   `--max-jobs auto` to the `nix profile install` command line (`e9f4a33`) so
-   even stale CDN content cannot re-introduce `max-jobs=0`.
+3. **Anthropic caches the setup script URL at configuration time.** After
+   merging `max-jobs=auto` fixes (#994, #995), sessions continued failing
+   because Anthropic had fetched and cached the script when the branch-ref URL
+   was first configured in the web UI — new sessions received the cached
+   pre-fix script, not the updated one from GitHub. Fixed by pinning to a
+   specific commit SHA (`e9f4a33`) and reconfiguring the web UI with the new
+   URL — Anthropic re-fetches on URL change, so SHA-pinned URLs guarantee a
+   fresh fetch. Also added `--max-jobs auto` to the `nix profile install`
+   command line (`e9f4a33`) so even a stale cached script cannot re-introduce
+   `max-jobs=0`.
 
 With all three fixes applied, `nix profile install` works reliably on gVisor.
 The setup script URL in the Claude Code web UI should use the pinned SHA form.
@@ -186,13 +188,14 @@ curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/154ce3ea6dfb5
    if CI pushes a pin-bump commit before the web session starts, changing
    the derivation hash. Fixed by making wheel hash deterministic.
 
-9. **GitHub CDN caches `raw.githubusercontent.com` branch refs aggressively.**
-   After merging fixes to `devel`, sessions continued to receive the stale script
-   for many more sessions. SHA-addressed URLs (`/blob/<sha>/...`) are served from
-   the immutable object store and are not subject to this caching. For setup
-   scripts that must be fresh, pin to a specific commit SHA rather than a branch
-   name. Belt-and-suspenders: also pass critical flags (like `--max-jobs`) on the
-   command line so stale script content can't reintroduce broken defaults.
+9. **Anthropic caches the setup script at configuration time, not per-session.**
+   After merging fixes to `devel`, sessions continued to receive the stale script.
+   The cache is on Anthropic's side — they fetch the URL when it's saved in the
+   web UI and serve that cached copy to new sessions. Changing the URL (e.g. to a
+   new SHA) triggers a fresh fetch. For setup scripts that must be fresh: pin to a
+   specific commit SHA and update the URL in the web UI when the script changes.
+   Belt-and-suspenders: also pass critical flags (like `--max-jobs`) on the
+   command line so a stale cached script can't reintroduce broken defaults.
 
 ## Container Environment (from RE docs)
 

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -4,7 +4,7 @@ Investigation into `web_setup.sh` failures in Claude Code web sessions.
 
 ## Current Status — RESOLVED
 
-**Root cause identified and fixed.** Two independent problems combined:
+**Root cause identified and fixed.** Three independent problems combined:
 
 1. **`max-jobs=0` in nix config** blocked all local builds, including trivial
    `symlinkJoin` derivations. Changing to `max-jobs=auto` fixes this — gVisor
@@ -16,7 +16,17 @@ Investigation into `web_setup.sh` failures in Claude Code web sessions.
    attic cache miss. Fixed by removing `devinfra.build_info` from the wheel's
    dependency tree (`52e7c39`).
 
-With both fixes, `nix profile install` works reliably on gVisor.
+3. **GitHub CDN caches branch-ref `raw.githubusercontent.com` URLs
+   aggressively.** After merging `max-jobs=auto` fixes (#994, #995), sessions
+   continued failing because `curl https://raw.githubusercontent.com/.../devel/...`
+   was still serving the pre-fix script. Fixed by pinning the setup script URL
+   to a specific commit SHA (`e9f4a33`) — SHA-addressed URLs are served from
+   the immutable object store, not the CDN branch cache. Also added
+   `--max-jobs auto` to the `nix profile install` command line (`e9f4a33`) so
+   even stale CDN content cannot re-introduce `max-jobs=0`.
+
+With all three fixes applied, `nix profile install` works reliably on gVisor.
+The setup script URL in the Claude Code web UI should use the pinned SHA form.
 
 ### Correction: gVisor CAN run nix builds
 
@@ -119,6 +129,8 @@ during early debugging.
 | `8e1eea6e7` | `max-jobs=auto` (allow local builds)                  | Still crashed — **misdiagnosed as gVisor issue** (see below) |
 | `8688fc17f` | `nix build` + manual symlinks, `max-jobs=0`           | Failed — `max-jobs=0` blocked `claude-web-session.drv`       |
 | `52e7c39`   | Remove `build_info` stamping from wheel               | Fixes spurious pin bumps (wheel hash now stable)             |
+| `842b26c`   | `max-jobs=auto`, revert to `nix profile install`      | Merged to devel; CDN still served old script for many sessions |
+| `e9f4a33`   | Add `--max-jobs auto` CLI flag, nix.conf debug dump   | Pin setup URL to this SHA → bypasses CDN → setup succeeds ✓  |
 
 **Re `8e1eea6e7`**: This commit used `nix profile install` with `max-jobs=auto`.
 It still failed and was diagnosed as "gVisor can't run build operations". Later
@@ -127,14 +139,19 @@ install` works fine on gVisor with `max-jobs=auto` and `sandbox=false`. The
 `8e1eea6e7` failure was likely a different issue (Nix crash, network, or the
 fact that `sandbox=false` wasn't set at that point).
 
-## Remaining Fix
+## Fix Summary
 
-Change `max-jobs = 0` to `max-jobs = auto` in `web_setup.sh`. Combined with
-the build_info removal (`52e7c39`), this should make web setup work reliably:
+All fixes are in place as of `e9f4a33`:
 
-- `max-jobs=auto` allows nix to build `symlinkJoin` / `buildEnv` locally
-- Stable wheel hash eliminates spurious pin bumps and cache invalidation
-- Even if a cache miss occurs, the local build succeeds
+- `max-jobs=auto` in nix.conf allows nix to build `symlinkJoin` / `buildEnv` locally
+- `--max-jobs auto` on the `nix profile install` command line overrides any stale nix.conf
+- Stable wheel hash (build_info removed) eliminates spurious pin bumps and cache invalidation
+- Setup URL pinned to `e9f4a33` SHA bypasses GitHub CDN branch-ref caching
+
+**Setup URL** (use this in the Claude Code web UI):
+```
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/e9f4a33faab99c094930a6abf0b67e87202292a0/devinfra/claude/web_setup.sh | bash
+```
 
 ## Key Lessons
 
@@ -165,6 +182,14 @@ the build_info removal (`52e7c39`), this should make web setup work reliably:
 8. **CI pin-bump race**: pushing to attic from a local machine doesn't help
    if CI pushes a pin-bump commit before the web session starts, changing
    the derivation hash. Fixed by making wheel hash deterministic.
+
+9. **GitHub CDN caches `raw.githubusercontent.com` branch refs aggressively.**
+   After merging fixes to `devel`, sessions continued to receive the stale script
+   for many more sessions. SHA-addressed URLs (`/blob/<sha>/...`) are served from
+   the immutable object store and are not subject to this caching. For setup
+   scripts that must be fresh, pin to a specific commit SHA rather than a branch
+   name. Belt-and-suspenders: also pass critical flags (like `--max-jobs`) on the
+   command line so stale script content can't reintroduce broken defaults.
 
 ## Container Environment (from RE docs)
 

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -131,7 +131,7 @@ during early debugging.
 | `52e7c39`   | Remove `build_info` stamping from wheel               | Fixes spurious pin bumps (wheel hash now stable)             |
 | `842b26c`   | `max-jobs=auto`, revert to `nix profile install`      | Merged to devel; CDN still served old script for many sessions |
 | `e9f4a33`   | Add `--max-jobs auto` CLI flag, nix.conf debug dump   | Pin setup URL to this SHA → bypasses CDN → setup succeeds ✓  |
-| `9b1f373`   | Symlink all `~/.nix-profile/bin/*` into `/usr/local/bin` | Fixes `claude-hook: not found`; also makes `bb`, `gh`, etc. available |
+| `154ce3e`   | Symlink all `~/.nix-profile/bin/*` into `/usr/local/bin` | Fixes `claude-hook: not found`; also makes `bb`, `gh`, etc. available |
 
 **Re `8e1eea6e7`**: This commit used `nix profile install` with `max-jobs=auto`.
 It still failed and was diagnosed as "gVisor can't run build operations". Later
@@ -142,7 +142,7 @@ fact that `sandbox=false` wasn't set at that point).
 
 ## Fix Summary
 
-All fixes are in place as of `9b1f373`:
+All fixes are in place as of `154ce3e`:
 
 - `max-jobs=auto` in nix.conf allows nix to build `symlinkJoin` / `buildEnv` locally
 - `--max-jobs auto` on the `nix profile install` command line overrides any stale nix.conf
@@ -153,7 +153,7 @@ All fixes are in place as of `9b1f373`:
 
 **Setup URL** (use this in the Claude Code web UI):
 ```
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/9b1f373c818b8077a9ab655191a85ba502e82f1a/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/154ce3ea6dfb5075cafbcbb3c89f86c707782b35/devinfra/claude/web_setup.sh | bash
 ```
 
 ## Key Lessons

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -131,6 +131,7 @@ during early debugging.
 | `52e7c39`   | Remove `build_info` stamping from wheel               | Fixes spurious pin bumps (wheel hash now stable)             |
 | `842b26c`   | `max-jobs=auto`, revert to `nix profile install`      | Merged to devel; CDN still served old script for many sessions |
 | `e9f4a33`   | Add `--max-jobs auto` CLI flag, nix.conf debug dump   | Pin setup URL to this SHA → bypasses CDN → setup succeeds ✓  |
+| `9b1f373`   | Symlink all `~/.nix-profile/bin/*` into `/usr/local/bin` | Fixes `claude-hook: not found`; also makes `bb`, `gh`, etc. available |
 
 **Re `8e1eea6e7`**: This commit used `nix profile install` with `max-jobs=auto`.
 It still failed and was diagnosed as "gVisor can't run build operations". Later
@@ -141,16 +142,18 @@ fact that `sandbox=false` wasn't set at that point).
 
 ## Fix Summary
 
-All fixes are in place as of `e9f4a33`:
+All fixes are in place as of `9b1f373`:
 
 - `max-jobs=auto` in nix.conf allows nix to build `symlinkJoin` / `buildEnv` locally
 - `--max-jobs auto` on the `nix profile install` command line overrides any stale nix.conf
 - Stable wheel hash (build_info removed) eliminates spurious pin bumps and cache invalidation
-- Setup URL pinned to `e9f4a33` SHA bypasses GitHub CDN branch-ref caching
+- Setup URL pinned to SHA bypasses Anthropic-side caching of setup script URL
+- All `~/.nix-profile/bin/*` symlinked into `/usr/local/bin` — fixes `claude-hook: not found`
+  and makes all Nix-installed tools (`bb`, `gh`, etc.) available to hooks and BashTool
 
 **Setup URL** (use this in the Claude Code web UI):
 ```
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/e9f4a33faab99c094930a6abf0b67e87202292a0/devinfra/claude/web_setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/9b1f373c818b8077a9ab655191a85ba502e82f1a/devinfra/claude/web_setup.sh | bash
 ```
 
 ## Key Lessons

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -100,6 +100,13 @@ echo "Installing web session tools..."
 # Pass --max-jobs explicitly to override any nix.conf misconfiguration.
 nix profile install --max-jobs auto "${FLAKE}#web-session"
 
+# Symlink all Nix-installed binaries into /usr/local/bin so they're on PATH.
+# Claude Code is launched directly (not via login shell), so ~/.nix-profile/bin
+# is not in PATH when hooks run. /usr/local/bin is always in PATH.
+for bin in ~/.nix-profile/bin/*; do
+  ln -sfn "$bin" /usr/local/bin/"$(basename "$bin")"
+done
+
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.


### PR DESCRIPTION
## Summary

- `web_setup.sh`: symlink all `~/.nix-profile/bin/*` into `/usr/local/bin` — fixes `claude-hook: not found` and makes every Nix-installed tool (`bb`, `gh`, etc.) available to hooks and BashTool without a login shell
- `web_setup.sh`: pass `--max-jobs auto` on CLI and dump nix.conf/show-config before install
- `.claude/settings.json`: remove inline shell hook that wrote nix PATH to `CLAUDE_ENV_FILE` — the `/usr/local/bin` symlinks make it unnecessary
- `docs/web-setup-debug.md` + `README.md`: document Anthropic-side caching as root cause, add timeline entries, update pinned SHA

## Root cause of `claude-hook: not found`

Claude Code is launched directly by `environment-manager` (no `-l` flag, no login shell), so `~/.nix-profile/bin` is never in PATH. `/usr/local/bin` is always on the hardcoded PATH in the container Dockerfile. Symlinking all of `~/.nix-profile/bin/*` there is the correct fix — same pattern used for Node and Python in the container.

## Test plan

- [ ] Update setup URL in Claude Code web UI to `9b1f373c818b8077a9ab655191a85ba502e82f1a` (branch HEAD; update again after merge to devel commit SHA)
- [ ] Start a new web session and verify setup log shows all skills deployed and no `claude-hook: not found`
- [ ] Verify `bb`, `gh`, and other Nix tools work from BashTool

https://claude.ai/code/session_014iYPduvy8qaLPg1prqArUo