### PR TITLE
web_setup: revert Nix pin to 2.28.3 (2.34.4 stuck in proxy cache)

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -57,9 +57,9 @@ echo "Installing Nix..."
 # Anthropic's egress proxy caches responses; using a pinned version-specific URL
 # avoids serving a stale tarball whose hash no longer matches the installer's expectation.
 # Installer script hash verified before execution.
-NIX_VERSION="2.34.4"
+NIX_VERSION="2.28.3"
 NIX_INSTALLER_URL="https://releases.nixos.org/nix/nix-${NIX_VERSION}/install"
-NIX_INSTALLER_SHA256="e0c3ae05ded52aa8f05e2e2e41d25ca1320fcce1fe2e3829b77acef2e94376e3"
+NIX_INSTALLER_SHA256="46b8d7165dceb471f4346366b3a93f1009407b99729b843b8664918f4cc800a0"
 # Ensure $USER is set — the installer's nix.sh (sourced below) is a no-op
 # when $USER is empty, which means PATH never gets ~/.nix-profile/bin.
 # The container runs as root but may not have $USER in the environment.


### PR DESCRIPTION
## Summary

- Revert Nix installer pin from 2.34.4 back to 2.28.3

## Why

Two consecutive sessions returned the identical hash mismatch for the 2.34.4 tarball — expected `f5096772...`, got `595669eb...`. This is a persistent proxy cache issue, not transient. Anthropic's egress proxy has cached a wrong/stale tarball at the 2.34.4 URL.

2.28.3 is not in the proxy's cache, so it gets a fresh uncached download with the correct hash.

Will revisit bumping to 2.34.x once the proxy cache expires.

https://claude.ai/code/session_014iYPduvy8qaLPg1prqArUo