### PR TITLE
session_context: truncate long warning/error messages to 200 chars

### DIFF
--- a/devinfra/claude/templates/session_context.mako
+++ b/devinfra/claude/templates/session_context.mako
@@ -66,7 +66,11 @@ Use BuildBuddy API (key in `~/.config/bazel/buildbuddy.bazelrc`) to download und
 ## Warnings
 % for record in log_entries:
 % if record.levelno >= WARNING:
-- ${record.levelname}: ${record.getMessage()}
+<%
+    msg = record.getMessage()
+    display_msg = msg[:200] + " [truncated — see log]" if len(msg) > 200 else msg
+%>\
+- ${record.levelname}: ${display_msg}
 % endif
 % endfor
 % endif


### PR DESCRIPTION
## Summary

Truncate warning/error log entries in the session context to 200 characters, appending `[truncated — see log]` when cut.

## Why

The OTEL `BatchSpanProcessor` logs the full HTTP response body on export failure — e.g. a 401 from Authentik embeds an entire HTML page into the session context. Full body is still available in the daemon log.

https://claude.ai/code/session_014iYPduvy8qaLPg1prqArUo