### PR TITLE
fix: exclude .zsh files from shfmt + regenerate requirements lockfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,8 @@ repos:
         files: "(BUILD|WORKSPACE|\\.bzl|\\.bazel)$"
 
   # shfmt - Shell script formatting — shfmt provided by devShell / web-session via Nix
+  # Exclude .zsh: pre-commit's identify tags zsh as shell, but shfmt can't parse
+  # advanced zsh-specific syntax (e.g. p10k.zsh, zsh-init.zsh).
   - repo: local
     hooks:
       - id: shfmt
@@ -113,6 +115,7 @@ repos:
         entry: shfmt -w
         language: system
         types: [shell]
+        exclude: "\\.zsh$"
 
   # rustfmt - Rust code formatting
   - repo: https://github.com/doublify/pre-commit-rust

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -1354,6 +1354,7 @@ filelock==3.25.0 \
     --hash=sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047 \
     --hash=sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3
     # via
+    #   ducktape (pyproject.toml)
     #   huggingface-hub
     #   python-discovery
     #   virtualenv


### PR DESCRIPTION
## Summary

- Exclude `.zsh` files from `shfmt` pre-commit hook (shfmt doesn't support zsh syntax; was causing false failures on zsh scripts)
- Regenerate `requirements_bazel.txt` after `filelock>=3.0` was added explicitly to `pyproject.toml` in #1005 — fixes the consistently failing `//:requirements_test` CI check that was blocking all releases

## Test plan

- [ ] `//:requirements_test` should now pass (lockfile matches pyproject.toml)
- [ ] Pre-commit shfmt hook should no longer fail on `.zsh` files

https://claude.ai/code/session_01GPcjCYQQUXojVH6GqLuvhE