### PR TITLE
fix: resolve pre-commit ruff-format, ruff-check, and nixfmt violations

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -225,7 +225,7 @@ async def _setup_web(
 
     async def mount_tmpfs_at(path: Path) -> bool:
         """Mount a tmpfs at the given path. Returns True on success, False on failure."""
-        path.mkdir(parents=True, exist_ok=True)
+        await run_in_thread(path.mkdir, parents=True, exist_ok=True)
         try:
             await run_in_thread(tmpfs.ensure_tmpfs_mounted, path)
             return True
@@ -346,7 +346,9 @@ async def _setup_web(
     if isinstance(precommit_result, BaseException):
         logger.warning("Failed to install git pre-commit: %s", precommit_result)
     if isinstance(bazelisk_result, BaseException):
-        raise RuntimeError("Bazel wrapper setup failed (is bazelisk on PATH from Nix web-session?)") from bazelisk_result
+        raise RuntimeError(
+            "Bazel wrapper setup failed (is bazelisk on PATH from Nix web-session?)"
+        ) from bazelisk_result
     if isinstance(tmpfs_result, BaseException):
         logger.warning("Failed to set up tmpfs caches: %s", tmpfs_result)
     if isinstance(mkcert_result, SkipError):

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,6 @@
         in
         builtins.mapAttrs fetch data.pins;
 
-
       mkHome =
         {
           hostname,


### PR DESCRIPTION
## Summary
- **handler.py**: Wrap long `RuntimeError` line for ruff-format compliance
- **handler.py**: Use `run_in_thread` for `Path.mkdir` to fix ASYNC240 (sync pathlib in async fn)
- **flake.nix**: Remove extra blank line flagged by nixfmt

## Test plan
- [ ] CI pre-commit checks pass (ruff-format, ruff-check, nixfmt)
- [ ] No functional change — formatting and async correctness only

https://claude.ai/code/session_01E7TZuS37R9jbRhPYWMP137