### PR TITLE
Add CwdPolicy tagged union for exec tool cwd configuration

### DIFF
--- a/editor_agent/host/runner.py
+++ b/editor_agent/host/runner.py
@@ -9,13 +9,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import aiodocker
+import anyio
 from fastmcp.server.auth import StaticTokenVerifier
 
 from editor_agent.host.submit_server import EditorSubmitServer
 from mcp_infra.compositor.compositor import Compositor
 from mcp_infra.compositor.resources_server import ResourcesServer
 from mcp_infra.constants import WORKING_DIR
-from mcp_infra.exec.docker.container_session import ContainerOptions
+from mcp_infra.exec.docker.container_session import ContainerOptions, DefaultValue
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.mounted import Mounted
 from util.docker import get_docker_network_gateway_async
@@ -62,7 +63,7 @@ async def editor_docker_session(
     - Starts submit MCP server reachable from the container via streamable HTTP.
     - Container runs the editor agent image (with /init baked in).
     """
-    original_content = file_path.read_text(encoding="utf-8")
+    original_content = await anyio.Path(file_path).read_text(encoding="utf-8")
     filename = file_path.name
 
     # Create submit server with bearer token auth
@@ -90,7 +91,7 @@ async def editor_docker_session(
     await compositor.__aenter__()
     resources_mount = compositor.resources
 
-    container_server = ContainerExecServer(docker_client, opts)
+    container_server = ContainerExecServer(docker_client, opts, cwd_policy=DefaultValue(value=WORKING_DIR))
     runtime_mount = await compositor.mount_inproc(
         ContainerExecServer.DOCKER_MOUNT_PREFIX, container_server, pinned=True
     )

--- a/inop/runners/openai_runner.py
+++ b/inop/runners/openai_runner.py
@@ -37,7 +37,7 @@ from mcp_infra.constants import WORKING_DIR
 from mcp_infra.display.event_renderer import DisplayEventsHandler
 from mcp_infra.exec.bwrap import BwrapExecServer
 from mcp_infra.exec.direct import DirectExecServer
-from mcp_infra.exec.docker.container_session import BindMount, ContainerOptions
+from mcp_infra.exec.docker.container_session import BindMount, ContainerOptions, DefaultValue
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import NetworkMode
 from mcp_infra.prefix import MCPMountPrefix
@@ -131,6 +131,7 @@ class OpenAIRunner(AgentRunner):
                         environment=setup.docker.env or {},
                         labels={"adgn.project": "inop", "adgn.role": "container"},
                     ),
+                    cwd_policy=DefaultValue(value=WORKING_DIR),
                 )
 
             return {"container": _factory}

--- a/mcp_infra/exec/docker/container_session.py
+++ b/mcp_infra/exec/docker/container_session.py
@@ -140,6 +140,31 @@ class ContainerOptions:
         }
 
 
+# -- CwdPolicy: controls how the `cwd` field is exposed in the exec tool schema --
+
+
+@dataclass(frozen=True)
+class ModelChooses:
+    """Model picks the cwd via a required tool input field."""
+
+
+@dataclass(frozen=True)
+class DefaultValue:
+    """cwd is optional in schema; falls back to this value when omitted."""
+
+    value: Path
+
+
+@dataclass(frozen=True)
+class AlwaysSetTo:
+    """cwd is hidden from model; always uses this value."""
+
+    value: Path
+
+
+CwdPolicy = ModelChooses | DefaultValue | AlwaysSetTo
+
+
 def session_state_from_ctx(ctx: Any) -> ContainerSessionState:
     return cast(ContainerSessionState, ctx.request_context.lifespan_context)
 

--- a/mcp_infra/exec/docker/launcher.py
+++ b/mcp_infra/exec/docker/launcher.py
@@ -12,7 +12,7 @@ import aiodocker
 import typer
 from typer_di import TyperDI
 
-from mcp_infra.exec.docker.container_session import BindMount, ContainerOptions
+from mcp_infra.exec.docker.container_session import BindMount, ContainerOptions, DefaultValue
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import NetworkMode
 from util.typer import async_run
@@ -65,7 +65,7 @@ async def main(
             labels=labels_dict,
         )
 
-        server = ContainerExecServer(docker_client, opts)
+        server = ContainerExecServer(docker_client, opts, cwd_policy=DefaultValue(value=Path(working_dir)))
         await server.run_stdio_async()
     finally:
         await docker_client.close()

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -226,11 +226,13 @@ class ContainerExecServer(EnhancedFastMCP):
             '- DO: {"cmd": ["sh", "-c", "cat > file.txt"], "stdin_text": "content"}',
         ]
 
+        if isinstance(cwd_policy, AlwaysSetTo):
+            _exec_doc_lines.append(f"\nCommands always run in {cwd_policy.value}.")
+        _exec_description = "\n".join(_exec_doc_lines)
+
         async def exec(input, context: Context) -> BaseExecResult:
-            """Placeholder docstring — replaced below."""
             async with async_timer() as get_duration_ms:
                 s = session_state_from_ctx(context)
-                # Build a full ExecInput for run_session_container; disabled fields become None.
                 effective = ExecInput(
                     cmd=input.cmd,
                     cwd=resolve_cwd(cwd_policy, input),
@@ -245,10 +247,7 @@ class ContainerExecServer(EnhancedFastMCP):
                 return render_container_result(stdout_buf, stderr_buf, exit_code, timed_out, duration_ms)
 
         exec.__annotations__["input"] = exec_input_type
-        if isinstance(cwd_policy, AlwaysSetTo):
-            _exec_doc_lines.append(f"\nCommands always run in {cwd_policy.value}.")
-        exec.__doc__ = "\n".join(_exec_doc_lines)
-        self.exec_tool = self.flat_model()(exec)
+        self.exec_tool = self.flat_model(description=_exec_description)(exec)
 
         # Register file:// resource template for reading files from container
         async def read_container_file(path: str, ctx: Context) -> str:

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -40,14 +40,21 @@ from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 FILE_RESOURCE_URI_TEMPLATE = "file://{path*}"
 
 
-def resolve_cwd(policy: CwdPolicy, model_input_cwd: str | None) -> str | None:
-    """Resolve the effective cwd from the policy and optional model input."""
-    if isinstance(policy, AlwaysSetTo):
-        return str(policy.value)
-    if isinstance(policy, DefaultValue):
-        return model_input_cwd if model_input_cwd is not None else str(policy.value)
-    # ModelChooses
-    return model_input_cwd
+def resolve_cwd(policy: CwdPolicy, tool_input: Any) -> str | None:
+    """Resolve the effective cwd from the policy and the tool input model.
+
+    The tool input model may or may not have a ``cwd`` field depending on the policy.
+    """
+    match policy:
+        case AlwaysSetTo(value=v):
+            return str(v)
+        case DefaultValue(value=v):
+            model_cwd: str | None = tool_input.cwd
+            return model_cwd if model_cwd is not None else str(v)
+        case ModelChooses():
+            return tool_input.cwd
+        case _:
+            raise TypeError(f"Unknown CwdPolicy: {policy!r}")
 
 
 def _make_exec_input_model(*, allow_user: bool, allow_env: bool, cwd_policy: CwdPolicy) -> type:
@@ -220,7 +227,7 @@ class ContainerExecServer(EnhancedFastMCP):
                 # Build a full ExecInput for run_session_container; disabled fields become None.
                 effective = ExecInput(
                     cmd=input.cmd,
-                    cwd=resolve_cwd(cwd_policy, getattr(input, "cwd", None)),
+                    cwd=resolve_cwd(cwd_policy, input),
                     timeout_ms=input.timeout_ms,
                     env=input.env if allow_env_field else None,
                     user=input.user if allow_user_field else None,

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -205,23 +205,29 @@ class ContainerExecServer(EnhancedFastMCP):
             allow_user=allow_user_field, allow_env=allow_env_field, cwd_policy=cwd_policy
         )
 
+        _exec_doc_lines = [
+            "Run a command inside the per-session Docker container.",
+            "",
+            "The cmd array is passed directly to Docker exec (execve-style, no shell).",
+            "No shell interpretation - arguments are passed as-is to the executable.",
+            "",
+            "Usage patterns:",
+            '- Simple command: {"cmd": ["python", "--version"]}',
+            '- With arguments: {"cmd": ["nl", "-ba", "/workspace/file.py"]}',
+            '- Shell features (pipes, redirection): {"cmd": ["sh", "-c", "grep pattern | head"]}',
+        ]
+        if not isinstance(cwd_policy, AlwaysSetTo):
+            _exec_doc_lines.append('- Working directory: {"cmd": ["ls"], "cwd": "/snapshots"}')
+        _exec_doc_lines += [
+            "",
+            "Common mistakes:",
+            """- DON'T: {"cmd": ["python '- << 'PY'"]} (shell syntax without sh -c)""",
+            """- DON'T: {"cmd": ["grep", "'pattern'"]} (quotes in string)""",
+            '- DO: {"cmd": ["sh", "-c", "cat > file.txt"], "stdin_text": "content"}',
+        ]
+
         async def exec(input, context: Context) -> BaseExecResult:
-            """Run a command inside the per-session Docker container.
-
-            The cmd array is passed directly to Docker exec (execve-style, no shell).
-            No shell interpretation - arguments are passed as-is to the executable.
-
-            Usage patterns:
-            - Simple command: {"cmd": ["python", "--version"]}
-            - With arguments: {"cmd": ["nl", "-ba", "/workspace/file.py"]}
-            - Shell features (pipes, redirection): {"cmd": ["sh", "-c", "grep pattern | head"]}
-            - Working directory: {"cmd": ["ls"], "cwd": "/snapshots"}
-
-            Common mistakes:
-            - DON'T: {"cmd": ["python '- << 'PY'"]} (shell syntax without sh -c)
-            - DON'T: {"cmd": ["grep", "'pattern'"]} (quotes in string)
-            - DO: {"cmd": ["sh", "-c", "cat > file.txt"], "stdin_text": "content"}
-            """
+            """Placeholder docstring — replaced below."""
             async with async_timer() as get_duration_ms:
                 s = session_state_from_ctx(context)
                 # Build a full ExecInput for run_session_container; disabled fields become None.
@@ -239,9 +245,9 @@ class ContainerExecServer(EnhancedFastMCP):
                 return render_container_result(stdout_buf, stderr_buf, exit_code, timed_out, duration_ms)
 
         exec.__annotations__["input"] = exec_input_type
-        # Surface the fixed cwd in the tool description so the model knows where commands run.
         if isinstance(cwd_policy, AlwaysSetTo):
-            exec.__doc__ = (exec.__doc__ or "") + f"\n\nCommands always run in {cwd_policy.value}."
+            _exec_doc_lines.append(f"\nCommands always run in {cwd_policy.value}.")
+        exec.__doc__ = "\n".join(_exec_doc_lines)
         self.exec_tool = self.flat_model()(exec)
 
         # Register file:// resource template for reading files from container

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -18,7 +18,11 @@ from pydantic import Field, create_model
 
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.docker.container_session import (
+    AlwaysSetTo,
     ContainerOptions,
+    CwdPolicy,
+    DefaultValue,
+    ModelChooses,
     make_container_lifespan,
     render_container_result,
     run_session_container,
@@ -36,11 +40,22 @@ from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 FILE_RESOURCE_URI_TEMPLATE = "file://{path*}"
 
 
-def _make_exec_input_model(*, allow_user: bool, allow_env: bool) -> type:
+def resolve_cwd(policy: CwdPolicy, model_input_cwd: str | None) -> str | None:
+    """Resolve the effective cwd from the policy and optional model input."""
+    if isinstance(policy, AlwaysSetTo):
+        return str(policy.value)
+    if isinstance(policy, DefaultValue):
+        return model_input_cwd if model_input_cwd is not None else str(policy.value)
+    # ModelChooses
+    return model_input_cwd
+
+
+def _make_exec_input_model(*, allow_user: bool, allow_env: bool, cwd_policy: CwdPolicy) -> type:
     """Dynamically create an ExecInput-compatible Pydantic model for the exec tool.
 
     When allow_user=False or allow_env=False, the corresponding field is omitted from
     the schema so the LLM cannot set it (the handler substitutes None for disabled fields).
+    cwd_policy controls how the cwd field appears in the schema.
     """
     fields: dict[str, Any] = {
         "cmd": (
@@ -55,12 +70,18 @@ def _make_exec_input_model(*, allow_user: bool, allow_env: bool) -> type:
                 )
             ),
         ),
-        "cwd": (str | None, Field(description="Working directory inside container (None = container default)")),
         "timeout_ms": (
             TimeoutMs,
             Field(description="Timeout in milliseconds; sends TERM (exit status becomes TimedOut)"),
         ),
     }
+    if isinstance(cwd_policy, ModelChooses):
+        fields["cwd"] = (str, Field(description="Working directory inside container"))
+    elif isinstance(cwd_policy, DefaultValue):
+        fields["cwd"] = (
+            str | None,
+            Field(default=None, description=f"Working directory inside container (None = {cwd_policy.value!s})"),
+        )
     if allow_env:
         fields["env"] = (
             list[EnvVar] | None,
@@ -104,6 +125,7 @@ class ContainerExecServer(EnhancedFastMCP):
         *,
         allow_user_field: bool = True,
         allow_env_field: bool = True,
+        cwd_policy: CwdPolicy,
     ):
         """Create a generic per-session container exec FastMCP server.
 
@@ -114,6 +136,7 @@ class ContainerExecServer(EnhancedFastMCP):
                 prevent the LLM from switching Unix users inside the container.
             allow_env_field: Expose ``env`` in the exec tool schema. Set False to
                 prevent the LLM from injecting arbitrary environment variables.
+            cwd_policy: Controls how the ``cwd`` field appears in the exec tool schema.
 
         Note:
             The caller must create and manage the docker_client lifecycle. The server
@@ -169,9 +192,11 @@ class ContainerExecServer(EnhancedFastMCP):
         )(container_info_json)
 
         # Register exec tool - name derived from function name.
-        # Input model is created dynamically based on allow_user_field / allow_env_field;
+        # Input model is created dynamically based on allow_user_field / allow_env_field / cwd_policy;
         # annotation is set after definition so FastMCP sees the correct schema.
-        exec_input_type = _make_exec_input_model(allow_user=allow_user_field, allow_env=allow_env_field)
+        exec_input_type = _make_exec_input_model(
+            allow_user=allow_user_field, allow_env=allow_env_field, cwd_policy=cwd_policy
+        )
 
         async def exec(input, context: Context) -> BaseExecResult:
             """Run a command inside the per-session Docker container.
@@ -195,7 +220,7 @@ class ContainerExecServer(EnhancedFastMCP):
                 # Build a full ExecInput for run_session_container; disabled fields become None.
                 effective = ExecInput(
                     cmd=input.cmd,
-                    cwd=input.cwd,
+                    cwd=resolve_cwd(cwd_policy, getattr(input, "cwd", None)),
                     timeout_ms=input.timeout_ms,
                     env=input.env if allow_env_field else None,
                     user=input.user if allow_user_field else None,
@@ -207,6 +232,9 @@ class ContainerExecServer(EnhancedFastMCP):
                 return render_container_result(stdout_buf, stderr_buf, exit_code, timed_out, duration_ms)
 
         exec.__annotations__["input"] = exec_input_type
+        # Surface the fixed cwd in the tool description so the model knows where commands run.
+        if isinstance(cwd_policy, AlwaysSetTo):
+            exec.__doc__ = (exec.__doc__ or "") + f"\n\nCommands always run in {cwd_policy.value}."
         self.exec_tool = self.flat_model()(exec)
 
         # Register file:// resource template for reading files from container

--- a/mcp_infra/exec/test_docker.py
+++ b/mcp_infra/exec/test_docker.py
@@ -95,7 +95,7 @@ async def test_cwd_always_set_to(make_cwd_server) -> None:
     async with Client(server) as c:
         tools = await c.list_tools()
         exec_tool = next(t for t in tools if t.name == "exec")
-        assert "cwd" not in exec_tool.inputSchema.get("properties", {})
+        assert "cwd" not in exec_tool.inputSchema["properties"]
 
         result = await c.call_tool("exec", {"cmd": ["pwd"], "timeout_ms": 10000})
         text = result.content[0].text if result.content else ""
@@ -108,8 +108,8 @@ async def test_cwd_model_chooses(make_cwd_server) -> None:
     async with Client(server) as c:
         tools = await c.list_tools()
         exec_tool = next(t for t in tools if t.name == "exec")
-        assert "cwd" in exec_tool.inputSchema.get("properties", {})
-        assert "cwd" in exec_tool.inputSchema.get("required", [])
+        assert "cwd" in exec_tool.inputSchema["properties"]
+        assert "cwd" in exec_tool.inputSchema["required"]
 
         result = await c.call_tool("exec", {"cmd": ["pwd"], "cwd": "/tmp", "timeout_ms": 10000})
         text = result.content[0].text if result.content else ""

--- a/mcp_infra/exec/test_docker.py
+++ b/mcp_infra/exec/test_docker.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import pytest_bazel
+from fastmcp.client import Client
 
+from mcp_infra.constants import WORKING_DIR
+from mcp_infra.exec.docker.container_session import AlwaysSetTo, DefaultValue, ModelChooses
+from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.models import Exited, TimedOut, make_exec_input
+from mcp_infra.testing.fixtures import make_container_opts
 
 
 @pytest.fixture
@@ -46,6 +53,76 @@ async def test_timeout_flag(typed_docker_client) -> None:
     client, _session = typed_docker_client
     res = await client.exec(make_exec_input(["sh", "-lc", "sleep 5"], timeout_ms=500))
     assert isinstance(res.exit, TimedOut)
+
+
+# -- CwdPolicy tests: verify each mode runs commands in the expected directory --
+
+
+@pytest.fixture
+def make_cwd_server(async_docker_client, debian_slim_image):
+    """Factory for ContainerExecServer with a specific cwd_policy."""
+
+    def _factory(cwd_policy):
+        opts = make_container_opts(debian_slim_image)
+        return ContainerExecServer(
+            async_docker_client, opts, cwd_policy=cwd_policy, allow_user_field=False, allow_env_field=False
+        )
+
+    return _factory
+
+
+async def test_cwd_default_value(make_cwd_server) -> None:
+    """DefaultValue: command runs in the default cwd when cwd is omitted."""
+    server = make_cwd_server(DefaultValue(value=WORKING_DIR))
+    async with Client(server) as c:
+        result = await c.call_tool("exec", {"cmd": ["pwd"], "timeout_ms": 10000})
+        text = result.content[0].text if result.content else ""
+        assert str(WORKING_DIR) in text
+
+
+async def test_cwd_default_value_override(make_cwd_server) -> None:
+    """DefaultValue: model can override cwd."""
+    server = make_cwd_server(DefaultValue(value=WORKING_DIR))
+    async with Client(server) as c:
+        result = await c.call_tool("exec", {"cmd": ["pwd"], "cwd": "/tmp", "timeout_ms": 10000})
+        text = result.content[0].text if result.content else ""
+        assert "/tmp" in text
+
+
+async def test_cwd_always_set_to(make_cwd_server) -> None:
+    """AlwaysSetTo: command always runs in the fixed cwd, field hidden from schema."""
+    server = make_cwd_server(AlwaysSetTo(value=Path("/tmp")))
+    async with Client(server) as c:
+        tools = await c.list_tools()
+        exec_tool = next(t for t in tools if t.name == "exec")
+        assert "cwd" not in exec_tool.inputSchema.get("properties", {})
+
+        result = await c.call_tool("exec", {"cmd": ["pwd"], "timeout_ms": 10000})
+        text = result.content[0].text if result.content else ""
+        assert "/tmp" in text
+
+
+async def test_cwd_model_chooses(make_cwd_server) -> None:
+    """ModelChooses: cwd is required in the schema, model must provide it."""
+    server = make_cwd_server(ModelChooses())
+    async with Client(server) as c:
+        tools = await c.list_tools()
+        exec_tool = next(t for t in tools if t.name == "exec")
+        assert "cwd" in exec_tool.inputSchema.get("properties", {})
+        assert "cwd" in exec_tool.inputSchema.get("required", [])
+
+        result = await c.call_tool("exec", {"cmd": ["pwd"], "cwd": "/tmp", "timeout_ms": 10000})
+        text = result.content[0].text if result.content else ""
+        assert "/tmp" in text
+
+
+async def test_cwd_always_set_to_description(make_cwd_server) -> None:
+    """AlwaysSetTo: tool description mentions the fixed cwd."""
+    server = make_cwd_server(AlwaysSetTo(value=Path("/var")))
+    async with Client(server) as c:
+        tools = await c.list_tools()
+        exec_tool = next(t for t in tools if t.name == "exec")
+        assert "/var" in (exec_tool.description or "")
 
 
 if __name__ == "__main__":

--- a/mcp_infra/exec/test_docker_unit.py
+++ b/mcp_infra/exec/test_docker_unit.py
@@ -4,6 +4,8 @@ import pytest
 import pytest_bazel
 from fastmcp.resources.template import match_uri_template
 
+from mcp_infra.constants import WORKING_DIR
+from mcp_infra.exec.docker.container_session import DefaultValue
 from mcp_infra.exec.docker.server import FILE_RESOURCE_URI_TEMPLATE, ContainerExecServer
 from mcp_infra.exec.models import Exited, TimedOut, make_exec_input
 from mcp_infra.testing.fixtures import make_container_opts
@@ -12,7 +14,9 @@ from mcp_infra.testing.fixtures import make_container_opts
 @pytest.fixture
 def exec_server(async_docker_client, debian_slim_image):
     """Container exec server for docker exec tests."""
-    return ContainerExecServer(async_docker_client, make_container_opts(debian_slim_image))
+    return ContainerExecServer(
+        async_docker_client, make_container_opts(debian_slim_image), cwd_policy=DefaultValue(value=WORKING_DIR)
+    )
 
 
 @pytest.fixture

--- a/mcp_infra/testing/docker_fixtures.py
+++ b/mcp_infra/testing/docker_fixtures.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import pytest
 
+from mcp_infra.constants import WORKING_DIR
+from mcp_infra.exec.docker.container_session import DefaultValue
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.testing.fixtures import make_container_opts
 
@@ -16,4 +18,4 @@ from mcp_infra.testing.fixtures import make_container_opts
 async def docker_exec_server(async_docker_client, debian_slim_image):
     """Canonical Docker exec server using debian-slim image."""
     opts = make_container_opts(debian_slim_image)
-    return ContainerExecServer(async_docker_client, opts)
+    return ContainerExecServer(async_docker_client, opts, cwd_policy=DefaultValue(value=WORKING_DIR))

--- a/skills/info_gathering/evals/docker_scratch.py
+++ b/skills/info_gathering/evals/docker_scratch.py
@@ -7,12 +7,13 @@ The server registers an `exec` tool and manages container lifecycle via its life
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import aiodocker
 from fastmcp.client import Client
 
 from agent_core.mcp_provider import MCPToolProvider
-from mcp_infra.exec.docker.container_session import ContainerOptions
+from mcp_infra.exec.docker.container_session import AlwaysSetTo, ContainerOptions
 from mcp_infra.exec.docker.server import ContainerExecServer
 from third_party.debian_slim.rlocations import IMAGE_TAG, TARBALL
 from util.oci import load_image
@@ -29,7 +30,13 @@ async def scratch_container(image: str) -> AsyncGenerator[MCPToolProvider]:
     """
     opts = ContainerOptions(image=image)  # network_mode defaults to "none"
     async with aiodocker.Docker() as docker_client:
-        server = ContainerExecServer(docker_client, opts, allow_user_field=False, allow_env_field=False)
+        server = ContainerExecServer(
+            docker_client,
+            opts,
+            allow_user_field=False,
+            allow_env_field=False,
+            cwd_policy=AlwaysSetTo(value=Path("/tmp")),
+        )
         async with Client(server) as mcp_client:
             logger.info("Scratch container started (image=%s)", image)
             yield MCPToolProvider(mcp_client)

--- a/skills/info_gathering/evals/docker_scratch.py
+++ b/skills/info_gathering/evals/docker_scratch.py
@@ -7,14 +7,11 @@ The server registers an `exec` tool and manages container lifecycle via its life
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from pathlib import Path
 
-import aiodocker
 from fastmcp.client import Client
 
 from agent_core.mcp_provider import MCPToolProvider
-from mcp_infra.exec.docker.container_session import AlwaysSetTo, ContainerOptions
-from mcp_infra.exec.docker.server import ContainerExecServer
+from skills.info_gathering.evals.twenty_questions.x.shared.docker_exec import scratch_exec_server
 from third_party.debian_slim.rlocations import IMAGE_TAG, TARBALL
 from util.oci import load_image
 
@@ -28,19 +25,10 @@ async def scratch_container(image: str) -> AsyncGenerator[MCPToolProvider]:
     Container is created by ContainerExecServer's lifespan on Client entry and
     destroyed on exit. Network mode defaults to "none" (isolated).
     """
-    opts = ContainerOptions(image=image)  # network_mode defaults to "none"
-    async with aiodocker.Docker() as docker_client:
-        server = ContainerExecServer(
-            docker_client,
-            opts,
-            allow_user_field=False,
-            allow_env_field=False,
-            cwd_policy=AlwaysSetTo(value=Path("/tmp")),
-        )
-        async with Client(server) as mcp_client:
-            logger.info("Scratch container started (image=%s)", image)
-            yield MCPToolProvider(mcp_client)
-        logger.info("Scratch container stopped")
+    async with scratch_exec_server(image) as server, Client(server) as mcp_client:
+        logger.info("Scratch container started (image=%s)", image)
+        yield MCPToolProvider(mcp_client)
+    logger.info("Scratch container stopped")
 
 
 def load_scratch_image() -> str:

--- a/skills/info_gathering/evals/twenty_questions/x/shared/docker_exec.py
+++ b/skills/info_gathering/evals/twenty_questions/x/shared/docker_exec.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 async def scratch_exec_server(image: str = "alpine:latest") -> AsyncGenerator[ContainerExecServer]:
     """Create a scratch container with an MCP exec tool server.
 
-    The server exposes an `exec` tool with schema: cmd (list[str]), cwd (str|None),
-    timeout_ms (int). User and env fields are disabled for safety.
+    The server exposes an `exec` tool with cmd (list[str]) and timeout_ms (int).
+    cwd is fixed to /tmp (hidden from the model). User and env fields are disabled.
     """
     opts = ContainerOptions(image=image)
     async with aiodocker.Docker() as docker_client:

--- a/skills/info_gathering/evals/twenty_questions/x/shared/docker_exec.py
+++ b/skills/info_gathering/evals/twenty_questions/x/shared/docker_exec.py
@@ -9,10 +9,11 @@ or via fastmcp.Client for others).
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import aiodocker
 
-from mcp_infra.exec.docker.container_session import ContainerOptions
+from mcp_infra.exec.docker.container_session import AlwaysSetTo, ContainerOptions
 from mcp_infra.exec.docker.server import ContainerExecServer
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,12 @@ async def scratch_exec_server(image: str = "alpine:latest") -> AsyncGenerator[Co
     """
     opts = ContainerOptions(image=image)
     async with aiodocker.Docker() as docker_client:
-        server = ContainerExecServer(docker_client, opts, allow_user_field=False, allow_env_field=False)
+        server = ContainerExecServer(
+            docker_client,
+            opts,
+            allow_user_field=False,
+            allow_env_field=False,
+            cwd_policy=AlwaysSetTo(value=Path("/tmp")),
+        )
         logger.info("Scratch exec server created (image=%s)", image)
         yield server

--- a/x/agent_server/matrix_bot.py
+++ b/x/agent_server/matrix_bot.py
@@ -17,9 +17,10 @@ from agent_core.mcp_provider import MCPToolProvider
 from mcp_infra.compositor.compositor import Compositor
 from mcp_infra.compositor.notifications_buffer import NotificationsBuffer
 from mcp_infra.config_loader import build_mcp_config
+from mcp_infra.constants import WORKING_DIR
 from mcp_infra.display.event_renderer import DisplayEventsHandler
 from mcp_infra.enhanced.server import EnhancedFastMCP
-from mcp_infra.exec.docker.container_session import ContainerOptions
+from mcp_infra.exec.docker.container_session import ContainerOptions, DefaultValue
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import NetworkMode
 from mcp_infra.exec.models import BaseExecResult, make_exec_input
@@ -67,6 +68,7 @@ class MatrixBotCompositor(Compositor):
                     environment=self._environment,
                     labels={"adgn.project": "matrix-bot", "adgn.role": "runtime"},
                 ),
+                cwd_policy=DefaultValue(value=WORKING_DIR),
             ),
             pinned=True,
         )


### PR DESCRIPTION
## Summary

- Introduces `CwdPolicy = ModelChooses | DefaultValue | AlwaysSetTo` tagged union to control how the `cwd` field appears in the Docker exec tool schema
- `ModelChooses`: cwd is required in schema, model must provide it
- `DefaultValue(path)`: cwd is optional, falls back to the given path (preserves current behavior)
- `AlwaysSetTo(path)`: cwd is hidden from schema entirely, always uses the given path. Tool description updated to tell the model where commands run.
- All existing `ContainerExecServer` callers updated to explicitly pass `cwd_policy`
- Fixes pre-existing ASYNC240 lint error in `editor_agent/host/runner.py` (sync `Path.read_text` in async function → `anyio.Path`)

## Test plan

- [x] `bazel test //mcp_infra/exec:test_docker` — e2e tests for all three CwdPolicy modes against real Docker containers on RBE
- [x] `bazel test //mcp_infra/exec:test_docker_unit` — existing unit tests pass
- [ ] `bazel build //...` — full repo builds with all callers updated

https://claude.ai/code/session_01Ez2vG2NbTdDhGKCaQ2Udj6