### PR TITLE
Use anyio for async path operations and fix FileLock string conversion

### DIFF
--- a/devinfra/claude/hook_daemon/client.py
+++ b/devinfra/claude/hook_daemon/client.py
@@ -198,7 +198,7 @@ def _ensure_daemon(paths: SessionPaths) -> None:
     # Create daemon dir before acquiring the lock (FileLock needs the parent to exist).
     daemon_dir.mkdir(parents=True, exist_ok=True)
 
-    with FileLock(daemon_dir / "daemon.lock"):
+    with FileLock(str(daemon_dir / "daemon.lock")):
         # Re-check after acquiring: another client may have won the race and
         # already started a healthy daemon while we were waiting.
         if check_health(sock_path):

--- a/devinfra/claude/hook_daemon/main.py
+++ b/devinfra/claude/hook_daemon/main.py
@@ -28,7 +28,7 @@ def main() -> None:
     # The kernel releases it on process death (flock is fd-based), so clients
     # can probe the lock to determine liveness without PID-reuse ambiguity.
     pidfile = daemon_dir / "daemon.pid"
-    _pidfile_lock = FileLock(pidfile)
+    _pidfile_lock = FileLock(str(pidfile))
     _pidfile_lock.acquire()
     pidfile.write_text(str(os.getpid()))
 

--- a/devinfra/claude/hook_daemon/session_start/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/BUILD.bazel
@@ -137,6 +137,7 @@ py_library(
         "//devinfra/claude/claude_api/hooks:session_start",
         "//devinfra/claude/hook_daemon:tracing",
         "//devinfra/claude/supervisor:setup",
+        "@pypi//anyio",
         "@pypi//httpx",
         "@pypi//mako",
         "@pypi//opentelemetry_api",

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+import anyio
 import httpx
 from mako.template import Template
 from opentelemetry import trace
@@ -225,7 +226,7 @@ async def _setup_web(
 
     async def mount_tmpfs_at(path: Path) -> bool:
         """Mount a tmpfs at the given path. Returns True on success, False on failure."""
-        await run_in_thread(path.mkdir, parents=True, exist_ok=True)
+        await anyio.Path(path).mkdir(parents=True, exist_ok=True)
         try:
             await run_in_thread(tmpfs.ensure_tmpfs_mounted, path)
             return True

--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -6,7 +6,7 @@
 ---
 manifest:
   modules_mapping:
-    7ae574991b77ef47acad__mypyc: mypy
+    4c842c94c09923bae9e4__mypyc: mypy
     7bce59c0a152c0e01f70__mypyc: tomli
     81d243bd2c585b0f4821__mypyc: charset_normalizer
     Crypto: pycryptodome
@@ -296,6 +296,11 @@ manifest:
     langgraph_sdk: langgraph_sdk
     langsmith: langsmith
     lark: lark
+    librt.base64: librt
+    librt.internal: librt
+    librt.strings: librt
+    librt.time: librt
+    librt.vecs: librt
     litellm: litellm
     logfire_api: logfire_api
     lxml: lxml
@@ -325,7 +330,6 @@ manifest:
     mypy_extensions: mypy_extensions
     mypyc: mypy
     nacl: pynacl
-    native_internal: mypy
     nbclient: nbclient
     nbconvert: nbconvert
     nbformat: nbformat
@@ -584,4 +588,4 @@ manifest:
     zstandard: zstandard
   pip_repository:
     name: pypi
-integrity: a329b65f6a3e41cdb1de8a4da17c0162afe99e3cecbde7b67e49049a69844a2e
+integrity: 57ad9a2ed439f89ce35d1d9dd3c309de420813a5cd9543c1f4ee8cb863eaf61c

--- a/mypy.ini
+++ b/mypy.ini
@@ -147,6 +147,10 @@ ignore_errors = True
 [mypy-zmq.*]
 ignore_errors = True
 
+# filelock stubs have unused type: ignore comments
+[mypy-filelock.*]
+ignore_errors = True
+
 # matplotlib bundled stubs have unused type: ignore comments
 [mypy-matplotlib.*]
 ignore_errors = True


### PR DESCRIPTION
## Summary
This PR updates the hook daemon to use `anyio` for async filesystem operations and ensures `FileLock` receives string paths instead of `Path` objects for compatibility.

## Key Changes
- **Async path operations**: Replaced `await run_in_thread(path.mkdir, ...)` with `await anyio.Path(path).mkdir(...)` in `session_start/handler.py` for more idiomatic async filesystem handling
- **FileLock compatibility**: Converted `Path` objects to strings when passing to `FileLock` in both `client.py` and `main.py`, as `FileLock` expects string paths
- **Dependencies**: Added `anyio` as a dependency in the BUILD.bazel file
- **Type checking**: Updated `mypy.ini` to ignore errors in `filelock.*` stubs due to unused type ignore comments

## Implementation Details
The changes improve code clarity by using `anyio`'s async path API instead of wrapping synchronous operations in thread pools, and ensure compatibility with the `FileLock` library's string path requirement.

https://claude.ai/code/session_019kEEBQ9ywoWugA4oUwgRkg