### PR TITLE
Add UDS remote proxy for Bazel gRPC traffic

### DIFF
--- a/devinfra/claude/auth_proxy/proxy.py
+++ b/devinfra/claude/auth_proxy/proxy.py
@@ -64,6 +64,9 @@ def parse_upstream_url(url: str) -> UpstreamConfig:
     return UpstreamConfig(host=host, port=port, auth_header=auth_header)
 
 
+# CLEANUP(2026-03-26): Remove AuthForwardingProxy once UDS proxy mode is confirmed
+# stable. In UDS mode, BCR uses native JAVA_TOOL_OPTIONS proxy and gRPC goes through
+# UdsRemoteProxy. The TCP proxy is only needed if proxy_mode="tcp" (legacy fallback).
 class AuthForwardingProxy:
     """HTTP CONNECT proxy that adds authentication when forwarding to upstream.
 
@@ -237,7 +240,7 @@ class AuthForwardingProxy:
             upstream_sock.settimeout(None)
 
             # Now tunnel data bidirectionally (no inspection)
-            self._tunnel_bidirectional(client_sock, upstream_sock)
+            _tunnel_bidirectional(client_sock, upstream_sock)
             logger.info("[conn %d] Tunnel completed for %s", conn_id, target)
 
         except (OSError, ValueError) as e:
@@ -252,10 +255,6 @@ class AuthForwardingProxy:
             # Remove from connections list to allow garbage collection
             with contextlib.suppress(ValueError):
                 self._connections.remove(client_sock)
-
-    @staticmethod
-    def _tunnel_bidirectional(client_sock: socket.socket, upstream_sock: socket.socket) -> None:
-        _tunnel_bidirectional(client_sock, upstream_sock)
 
 
 def _tunnel_bidirectional(sock_a: socket.socket, sock_b: socket.socket) -> None:

--- a/devinfra/claude/auth_proxy/proxy.py
+++ b/devinfra/claude/auth_proxy/proxy.py
@@ -13,6 +13,11 @@ timing: gRPC connects to an unauthenticated localhost proxy immediately, and the
 proxy injects credentials when forwarding to the egress proxy. BCR fetches (Java
 HTTP layer) also benefit since they go through the same proxy.
 
+Also provides UdsRemoteProxy: a Unix domain socket proxy for Bazel's
+--remote_proxy flag. Bazel sends raw gRPC (HTTP/2) through the UDS; the proxy
+establishes a CONNECT tunnel through the egress proxy to a fixed remote endpoint
+(e.g. remote.buildbuddy.io:443), then shuttles bytes bidirectionally.
+
 Reads upstream proxy URL from a file on each connection, enabling credential
 hot-reload without restarting the proxy.
 """
@@ -25,6 +30,7 @@ import socket
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -247,28 +253,180 @@ class AuthForwardingProxy:
             with contextlib.suppress(ValueError):
                 self._connections.remove(client_sock)
 
-    def _tunnel_bidirectional(self, client_sock: socket.socket, upstream_sock: socket.socket) -> None:
-        """Tunnel data bidirectionally between client and upstream."""
-        sockets = [client_sock, upstream_sock]
+    @staticmethod
+    def _tunnel_bidirectional(client_sock: socket.socket, upstream_sock: socket.socket) -> None:
+        _tunnel_bidirectional(client_sock, upstream_sock)
+
+
+def _tunnel_bidirectional(sock_a: socket.socket, sock_b: socket.socket) -> None:
+    """Tunnel data bidirectionally between two sockets."""
+    sockets = [sock_a, sock_b]
+
+    try:
+        while True:
+            readable, _, errored = select.select(sockets, [], sockets, 1.0)
+
+            if errored:
+                break
+
+            for sock in readable:
+                try:
+                    data = sock.recv(8192)
+                    if not data:
+                        return  # Connection closed
+
+                    # Forward to the other socket
+                    other = sock_b if sock is sock_a else sock_a
+                    other.sendall(data)
+                except OSError:
+                    return
+
+    except OSError:
+        pass
+
+
+class UdsRemoteProxy:
+    """Unix domain socket proxy for Bazel's --remote_proxy flag.
+
+    Bazel sends raw gRPC (HTTP/2) through the UDS. For each connection, this
+    proxy establishes a CONNECT tunnel through the egress proxy to a fixed
+    remote endpoint, then shuttles bytes bidirectionally.
+
+    This bypasses gRPC-Java's ProxyDetectorImpl entirely — Bazel's
+    --remote_proxy routes gRPC traffic through the UDS natively, so there's
+    no Authenticator timing issue.
+    """
+
+    def __init__(self, sock_path: Path, remote_target: str, max_workers: int = 100):
+        """
+        Args:
+            sock_path: Path for the Unix domain socket.
+            remote_target: host:port to CONNECT to through the egress proxy
+                (e.g. "remote.buildbuddy.io:443").
+        """
+        self.sock_path = sock_path
+        self.remote_target = remote_target
+        self.max_workers = max_workers
+        self._upstream_url: str | None = None
+        self._creds_lock = threading.Lock()
+        self.server_socket: socket.socket | None = None
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._executor: ThreadPoolExecutor | None = None
+        self._connections: list[socket.socket] = []
+        self._conn_counter = 0
+        self._conn_lock = threading.Lock()
+
+    def set_creds(self, upstream_url: str) -> None:
+        """Update upstream proxy credentials (thread-safe)."""
+        with self._creds_lock:
+            self._upstream_url = upstream_url
+
+    def _get_upstream_config(self) -> UpstreamConfig:
+        with self._creds_lock:
+            url = self._upstream_url
+        if url is None:
+            raise ValueError("Proxy credentials not set")
+        return parse_upstream_url(url)
+
+    def start(self) -> None:
+        """Start the UDS proxy server."""
+        # Remove stale socket file
+        self.sock_path.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            self.sock_path.unlink()
+
+        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server_socket.bind(str(self.sock_path))
+        self.server_socket.listen(50)
+        self.server_socket.settimeout(0.5)
+
+        self._executor = ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix="uds-proxy")
+        self._running = True
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+        logger.info("UDS remote proxy started on %s → %s", self.sock_path, self.remote_target)
+
+    def stop(self) -> None:
+        """Stop the UDS proxy server."""
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+        if self._executor:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+        for conn in self._connections:
+            with contextlib.suppress(OSError):
+                conn.close()
+        if self.server_socket:
+            self.server_socket.close()
+        with contextlib.suppress(FileNotFoundError):
+            self.sock_path.unlink()
+        logger.info("UDS remote proxy stopped")
+
+    def _serve(self) -> None:
+        """Main server loop."""
+        while self._running:
+            try:
+                client_sock, _ = self.server_socket.accept()  # type: ignore[union-attr]
+                self._connections.append(client_sock)
+                self._executor.submit(self._handle_client, client_sock)  # type: ignore[union-attr]
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+
+    def _handle_client(self, client_sock: socket.socket) -> None:
+        """Handle a single UDS connection: establish CONNECT tunnel, then shuttle bytes."""
+        with self._conn_lock:
+            self._conn_counter += 1
+            conn_id = self._conn_counter
+
+        upstream_sock: socket.socket | None = None
 
         try:
-            while True:
-                readable, _, errored = select.select(sockets, [], sockets, 1.0)
+            config = self._get_upstream_config()
 
-                if errored:
-                    break
+            # Connect to egress proxy
+            logger.debug("[uds %d] Connecting to upstream %s:%d", conn_id, config.host, config.port)
+            upstream_sock = socket.create_connection((config.host, config.port), timeout=30)
+            upstream_sock.settimeout(None)
 
-                for sock in readable:
-                    try:
-                        data = sock.recv(8192)
-                        if not data:
-                            return  # Connection closed
+            # Send CONNECT request to establish tunnel to remote_target
+            connect_request = f"CONNECT {self.remote_target} HTTP/1.1\r\nHost: {self.remote_target}\r\n"
+            connect_request += config.auth_header
+            connect_request += "\r\n"
+            upstream_sock.sendall(connect_request.encode())
 
-                        # Forward to the other socket
-                        other = upstream_sock if sock is client_sock else client_sock
-                        other.sendall(data)
-                    except OSError:
-                        return
+            # Read CONNECT response
+            response = b""
+            while b"\r\n\r\n" not in response:
+                chunk = upstream_sock.recv(4096)
+                if not chunk:
+                    logger.error("[uds %d] Upstream closed before CONNECT response", conn_id)
+                    return
+                response += chunk
 
-        except OSError:
-            pass
+            response_str = response.decode("utf-8", errors="replace")
+            status_line = response_str.split("\r\n")[0]
+
+            if not status_line.startswith("HTTP/1.1 200"):
+                logger.error("[uds %d] CONNECT to %s rejected: %s", conn_id, self.remote_target, status_line)
+                return
+
+            logger.debug("[uds %d] Tunnel established to %s", conn_id, self.remote_target)
+
+            # Tunnel: raw gRPC from Bazel ↔ egress proxy ↔ remote endpoint
+            client_sock.settimeout(None)
+            _tunnel_bidirectional(client_sock, upstream_sock)
+            logger.debug("[uds %d] Tunnel completed", conn_id)
+
+        except (OSError, ValueError) as e:
+            logger.error("[uds %d] Error: %s", conn_id, e)
+        finally:
+            for sock in [client_sock, upstream_sock]:
+                if sock:
+                    with contextlib.suppress(OSError):
+                        sock.close()
+            with contextlib.suppress(ValueError):
+                self._connections.remove(client_sock)

--- a/devinfra/claude/bazel_wrapper.py
+++ b/devinfra/claude/bazel_wrapper.py
@@ -137,8 +137,14 @@ def _run(paths: SessionPaths) -> None:
     if is_web_mode():
         local_proxy = _refresh_proxy_creds(paths)
         warn_if_credentials_expiring()
-        for var in PROXY_ENV_VARS:
-            os.environ[var] = local_proxy
+        # CLEANUP(2026-03-26): Remove TCP proxy branch once UDS mode is confirmed stable.
+        # In TCP mode, override HTTPS_PROXY to point at the local auth proxy so
+        # all JVM HTTP traffic goes through it. In UDS mode, gRPC goes through
+        # --remote_proxy UDS and BCR uses the native JAVA_TOOL_OPTIONS proxy,
+        # so no env var override is needed.
+        if local_proxy != "uds-only":
+            for var in PROXY_ENV_VARS:
+                os.environ[var] = local_proxy
 
     real_binary = _resolve_real_binary()
 

--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -15,11 +15,12 @@ startup --host_jvm_args=-Dhttps.proxyPort=${proxy_port}
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}
 % if remote_proxy_sock:
-# Route gRPC remote execution/cache through a UDS proxy that establishes
-# a CONNECT tunnel through the egress proxy. This uses Bazel's native
-# --remote_proxy mechanism instead of relying on JVM proxy system properties,
-# bypassing the gRPC-Java Authenticator timing issue entirely.
+# Route gRPC remote execution/cache and BES through a UDS proxy that
+# establishes a CONNECT tunnel through the egress proxy. This uses Bazel's
+# native --remote_proxy/--bes_proxy mechanism instead of relying on JVM proxy
+# system properties, bypassing the gRPC-Java Authenticator timing issue.
 build --remote_proxy=unix:${remote_proxy_sock}
+build --bes_proxy=unix:${remote_proxy_sock}
 % endif
 
 # Pass proxy + TLS CA to repository rules (for Go modules in gazelle, etc.)

--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -3,22 +3,28 @@
 startup --output_user_root=${bazel_cache_dir | sh}
 % endif
 % if web_proxy:
-# Route Bazel's JVM through the local auth proxy (localhost:${proxy_port}).
-# The auth proxy adds Proxy-Authorization credentials when forwarding to the
-# egress proxy. This is needed because gRPC-Java's ProxyDetectorImpl reads
-# proxy settings from ProxySelector (via these system properties) but cannot
-# reliably authenticate — Bazel's ProxyHelper installs the Authenticator only
-# when a repository rule triggers a download, which may be after the gRPC
-# remote execution channel is already established.
-startup --host_jvm_args=-Dhttps.proxyHost=127.0.0.1
-startup --host_jvm_args=-Dhttps.proxyPort=${proxy_port}
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}
+% if use_tcp_proxy:
+## CLEANUP(2026-03-26): Remove TCP proxy block once UDS mode is confirmed stable.
+# Legacy TCP mode: route all Bazel JVM traffic through the local auth proxy.
+# The auth proxy adds Proxy-Authorization credentials when forwarding to the
+# egress proxy. Needed because gRPC-Java's ProxyDetectorImpl cannot reliably
+# authenticate — Bazel's ProxyHelper installs the Authenticator only when a
+# repository rule triggers a download, which may be after the gRPC channel
+# is already established.
+startup --host_jvm_args=-Dhttps.proxyHost=127.0.0.1
+startup --host_jvm_args=-Dhttps.proxyPort=${proxy_port}
+% else:
+# UDS mode: BCR fetches use the native JVM proxy settings from Anthropic's
+# JAVA_TOOL_OPTIONS (proxyHost/proxyPort/proxyUser/proxyPassword). Only gRPC
+# traffic (remote execution, cache, BES) needs the UDS proxy.
+startup --host_jvm_args=-Djdk.http.auth.tunneling.disabledSchemes=
+% endif
 % if remote_proxy_sock:
 # Route gRPC remote execution/cache and BES through a UDS proxy that
-# establishes a CONNECT tunnel through the egress proxy. This uses Bazel's
-# native --remote_proxy/--bes_proxy mechanism instead of relying on JVM proxy
-# system properties, bypassing the gRPC-Java Authenticator timing issue.
+# establishes a CONNECT tunnel through the egress proxy. Uses Bazel's native
+# --remote_proxy/--bes_proxy, bypassing the gRPC-Java Authenticator timing issue.
 build --remote_proxy=unix:${remote_proxy_sock}
 build --bes_proxy=unix:${remote_proxy_sock}
 % endif

--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -14,6 +14,13 @@ startup --host_jvm_args=-Dhttps.proxyHost=127.0.0.1
 startup --host_jvm_args=-Dhttps.proxyPort=${proxy_port}
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}
+% if remote_proxy_sock:
+# Route gRPC remote execution/cache through a UDS proxy that establishes
+# a CONNECT tunnel through the egress proxy. This uses Bazel's native
+# --remote_proxy mechanism instead of relying on JVM proxy system properties,
+# bypassing the gRPC-Java Authenticator timing issue entirely.
+build --remote_proxy=unix:${remote_proxy_sock}
+% endif
 
 # Pass proxy + TLS CA to repository rules (for Go modules in gazelle, etc.)
 # GONOPROXY=* forces all Go module downloads through HTTP proxy.

--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -20,7 +20,7 @@ from fastapi import FastAPI, HTTPException
 from opentelemetry import trace
 from pydantic import BaseModel
 
-from devinfra.claude.auth_proxy.proxy import AuthForwardingProxy
+from devinfra.claude.auth_proxy.proxy import AuthForwardingProxy, UdsRemoteProxy
 from devinfra.claude.auth_proxy.vars import get_upstream_proxy_url
 from devinfra.claude.claude_api.hooks.dispatch_output import AnyHookOutput
 from devinfra.claude.claude_api.hooks.post_tool_use import PostToolUseInput
@@ -50,12 +50,13 @@ def configure(daemon_dir: Path, otlp_exporter: DeferredOtlpExporter) -> None:
     app.state.otlp_exporter = otlp_exporter
     app.state.last_request_time = time.monotonic()
     app.state.proxy = None
+    app.state.uds_proxy = None
     app.state.background_tasks = set[asyncio.Task[object]]()
-    # Proxy is started lazily on the first SessionStart hook, not here.
+    # Proxies are started lazily on the first SessionStart hook, not here.
 
 
-async def _start_session_proxy() -> None:
-    """Start the auth proxy for the current session.
+async def _start_session_proxy(session_id: str) -> None:
+    """Start the auth proxy and UDS remote proxy for the current session.
 
     Called at the start of SessionStart handling — not at daemon startup. Using
     listen_port=0 lets the OS assign a free port, so concurrent sessions (each
@@ -71,6 +72,15 @@ async def _start_session_proxy() -> None:
     proxy.start()  # OS assigns a free port; proxy.listen_port is updated after bind
     app.state.proxy = proxy
     logger.info("Auth proxy started in-process on port %d (dynamic)", proxy.listen_port)
+
+    # Start UDS proxy for --remote_proxy (Bazel gRPC remote execution/cache).
+    paths = SessionPaths(session_id=session_id, home=Path.home(), xdg_cache_home=Path.home())
+    uds_proxy = UdsRemoteProxy(sock_path=paths.remote_proxy_sock, remote_target=app.state.settings.remote_proxy_target)
+    upstream_url = get_upstream_proxy_url()
+    if upstream_url:
+        uds_proxy.set_creds(upstream_url)
+    uds_proxy.start()
+    app.state.uds_proxy = uds_proxy
 
 
 def _save_session_env(env: dict[str, str]) -> None:
@@ -103,7 +113,7 @@ async def handle_hook(req: HookRequest) -> HookResponse:
         output: AnyHookOutput | None = None
         match req.hook:
             case SessionStartHookInput():
-                await _start_session_proxy()
+                await _start_session_proxy(req.hook.session_id)
                 paths = SessionPaths.from_env(req.hook.session_id, req.env)
                 with build_http_client(req.env) as http:
                     output = await handle_session_start(
@@ -143,6 +153,9 @@ async def update_proxy_creds(req: _UpdateProxyCredsRequest) -> UpdateProxyCredsR
     if proxy is None:
         raise HTTPException(status_code=503, detail="Auth proxy not running")
     proxy.set_creds(req.https_proxy)
+    uds_proxy: UdsRemoteProxy | None = app.state.uds_proxy
+    if uds_proxy is not None:
+        uds_proxy.set_creds(req.https_proxy)
     logger.debug("Updated proxy credentials via RPC")
     return UpdateProxyCredsResponse(proxy_url=f"http://localhost:{proxy.listen_port}")
 
@@ -176,8 +189,12 @@ async def _start_idle_watchdog() -> None:
 
 @app.on_event("shutdown")
 async def _stop_proxy() -> None:
-    """Stop the in-process auth proxy on daemon shutdown."""
+    """Stop the in-process proxies on daemon shutdown."""
     proxy: AuthForwardingProxy | None = getattr(app.state, "proxy", None)
     if proxy is not None:
         logger.info("Stopping in-process auth proxy...")
         proxy.stop()
+    uds_proxy: UdsRemoteProxy | None = getattr(app.state, "uds_proxy", None)
+    if uds_proxy is not None:
+        logger.info("Stopping UDS remote proxy...")
+        uds_proxy.stop()

--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -33,7 +33,7 @@ from devinfra.claude.hook_daemon.session_start.handler import handle as handle_s
 from devinfra.claude.hook_daemon.session_start.http_client import build_http_client
 from devinfra.claude.hook_daemon.tracing import DeferredOtlpExporter
 from devinfra.claude.session_paths import SessionPaths
-from devinfra.claude.settings import HookSettings, is_web_mode
+from devinfra.claude.settings import HookSettings, ProxyMode, is_web_mode
 
 logger = logging.getLogger(__name__)
 
@@ -56,27 +56,38 @@ def configure(daemon_dir: Path, otlp_exporter: DeferredOtlpExporter) -> None:
 
 
 async def _start_session_proxy(session_id: str) -> None:
-    """Start the auth proxy and UDS remote proxy for the current session.
+    """Start proxy infrastructure for the current session.
 
-    Called at the start of SessionStart handling — not at daemon startup. Using
-    listen_port=0 lets the OS assign a free port, so concurrent sessions (each
-    with their own daemon) never collide. Idempotent: no-op if the proxy is
-    already running or no upstream proxy is configured.
+    In UDS mode (default): only the UDS proxy is started. Bazel uses
+    --remote_proxy/--bes_proxy for gRPC, and JAVA_TOOL_OPTIONS (set by
+    Anthropic) for BCR fetches.
+
+    In TCP mode (legacy): both the TCP HTTP CONNECT proxy and UDS proxy
+    are started. The TCP proxy handles all Bazel traffic via JVM system
+    properties.
+
+    Called at the start of SessionStart handling — not at daemon startup.
+    Idempotent: no-op if proxies are already running or no upstream proxy
+    is configured.
     """
-    if app.state.proxy is not None:
+    if app.state.uds_proxy is not None:
         return
     if not get_upstream_proxy_url():
         return
 
-    proxy = AuthForwardingProxy(listen_port=0)
-    proxy.start()  # OS assigns a free port; proxy.listen_port is updated after bind
-    app.state.proxy = proxy
-    logger.info("Auth proxy started in-process on port %d (dynamic)", proxy.listen_port)
-
-    # Start UDS proxy for --remote_proxy (Bazel gRPC remote execution/cache).
-    paths = SessionPaths(session_id=session_id, home=Path.home(), xdg_cache_home=Path.home())
-    uds_proxy = UdsRemoteProxy(sock_path=paths.remote_proxy_sock, remote_target=app.state.settings.remote_proxy_target)
+    settings: HookSettings = app.state.settings
     upstream_url = get_upstream_proxy_url()
+
+    # CLEANUP(2026-03-26): Remove TCP proxy once UDS mode is confirmed stable.
+    if settings.proxy_mode == ProxyMode.TCP:
+        proxy = AuthForwardingProxy(listen_port=0)
+        proxy.start()
+        app.state.proxy = proxy
+        logger.info("Auth proxy started in-process on port %d (tcp mode)", proxy.listen_port)
+
+    # UDS proxy for --remote_proxy/--bes_proxy (both modes).
+    paths = SessionPaths(session_id=session_id, home=Path.home(), xdg_cache_home=Path.home())
+    uds_proxy = UdsRemoteProxy(sock_path=paths.remote_proxy_sock, remote_target=settings.remote_proxy_target)
     if upstream_url:
         uds_proxy.set_creds(upstream_url)
     uds_proxy.start()
@@ -148,16 +159,19 @@ class _UpdateProxyCredsRequest(BaseModel):
 
 @app.post("/update-proxy-creds")
 async def update_proxy_creds(req: _UpdateProxyCredsRequest) -> UpdateProxyCredsResponse:
-    """Update in-process auth proxy credentials. Called by bazel_wrapper on each invocation."""
-    proxy: AuthForwardingProxy | None = app.state.proxy
-    if proxy is None:
-        raise HTTPException(status_code=503, detail="Auth proxy not running")
-    proxy.set_creds(req.https_proxy)
+    """Update in-process proxy credentials. Called by bazel_wrapper on each invocation."""
     uds_proxy: UdsRemoteProxy | None = app.state.uds_proxy
-    if uds_proxy is not None:
-        uds_proxy.set_creds(req.https_proxy)
+    if uds_proxy is None:
+        raise HTTPException(status_code=503, detail="No proxy running")
+    uds_proxy.set_creds(req.https_proxy)
+    # CLEANUP(2026-03-26): Remove TCP proxy branch once UDS mode is confirmed stable.
+    proxy: AuthForwardingProxy | None = app.state.proxy
+    if proxy is not None:
+        proxy.set_creds(req.https_proxy)
     logger.debug("Updated proxy credentials via RPC")
-    return UpdateProxyCredsResponse(proxy_url=f"http://localhost:{proxy.listen_port}")
+    # Return TCP proxy URL if available (legacy mode), otherwise a placeholder.
+    proxy_url = f"http://localhost:{proxy.listen_port}" if proxy else "uds-only"
+    return UpdateProxyCredsResponse(proxy_url=proxy_url)
 
 
 @app.get("/health")

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -50,7 +50,7 @@ from devinfra.claude.hook_daemon.session_start import tmpfs
 from devinfra.claude.hook_daemon.tracing import DeferredOtlpExporter
 from devinfra.claude.managed_files import write_config
 from devinfra.claude.session_paths import SessionPaths
-from devinfra.claude.settings import CONFIG_FILES, HookSettings
+from devinfra.claude.settings import CONFIG_FILES, HookSettings, ProxyMode
 from devinfra.claude.supervisor import setup as supervisor_setup
 
 logger = logging.getLogger(__name__)
@@ -518,6 +518,7 @@ async def run_session(
         )
         bazelrc_content: str = bazelrc_template.render(
             web_proxy=ctx.web_mode,
+            use_tcp_proxy=settings.proxy_mode == ProxyMode.TCP,
             proxy_port=setup.proxy_port,
             remote_proxy_sock=setup.remote_proxy_sock,
             truststore_path=setup.truststore_path,

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -104,6 +104,7 @@ class PlatformSetup:
 
     # Bazelrc rendering params
     proxy_port: int | None = None
+    remote_proxy_sock: Path | None = None
     truststore_path: Path | None = None
     truststore_password: str | None = None
     combined_ca_path: Path | None = None
@@ -416,6 +417,7 @@ async def _setup_web(
     return PlatformSetup(
         # Bazelrc rendering
         proxy_port=auth_proxy_result.port,
+        remote_proxy_sock=paths.remote_proxy_sock,
         truststore_path=paths.auth_proxy_truststore,
         truststore_password=proxy_setup.TRUSTSTORE_PASSWORD,
         combined_ca_path=combined_ca,
@@ -517,6 +519,7 @@ async def run_session(
         bazelrc_content: str = bazelrc_template.render(
             web_proxy=ctx.web_mode,
             proxy_port=setup.proxy_port,
+            remote_proxy_sock=setup.remote_proxy_sock,
             truststore_path=setup.truststore_path,
             truststore_password=setup.truststore_password,
             combined_ca_path=setup.combined_ca_path,

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -86,9 +86,14 @@ class SessionPaths:
         return self.auth_proxy_dir / "cacerts.jks"
 
     @property
+    def _short_dir(self) -> Path:
+        """Short session-scoped dir under /tmp for Unix sockets (108-byte AF_UNIX limit)."""
+        return _short_session_dir(self.session_id)
+
+    @property
     def remote_proxy_sock(self) -> Path:
         """UDS path for --remote_proxy (Bazel gRPC remote execution/cache)."""
-        return _short_session_dir(self.session_id) / "remote-proxy.sock"
+        return self._short_dir / "remote-proxy.sock"
 
     @property
     def wrapper_dir(self) -> Path:
@@ -146,10 +151,9 @@ class SessionPaths:
     def hook_daemon_sock(self) -> Path:
         """UDS path for the hook daemon.
 
-        Uses a short path under /tmp to stay within the 108-byte AF_UNIX limit.
         The parent directory is created by ensure_dirs(), not on every access.
         """
-        return hook_daemon_sock(self.session_id)
+        return self._short_dir / "d.sock"
 
     def ensure_dirs(self) -> None:
         """Create all directories that must exist before use (socket dir, session dir, etc.)."""

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -81,6 +81,14 @@ class SessionPaths:
         return self.auth_proxy_dir / "cacerts.jks"
 
     @property
+    def remote_proxy_sock(self) -> Path:
+        """UDS path for --remote_proxy (Bazel gRPC remote execution/cache).
+
+        Uses a short path under /tmp to stay within the 108-byte AF_UNIX limit.
+        """
+        return Path("/tmp/claude-hd") / self.session_id / "remote-proxy.sock"
+
+    @property
     def wrapper_dir(self) -> Path:
         """Wrapper directory (added to PATH)."""
         return self.session_dir / "bin"

--- a/devinfra/claude/session_paths.py
+++ b/devinfra/claude/session_paths.py
@@ -15,9 +15,14 @@ def default_cache_dir() -> Path:
     return Path(user_cache_dir(appname="claude-hooks"))
 
 
+def _short_session_dir(session_id: str) -> Path:
+    """Short session-scoped dir under /tmp for Unix sockets (108-byte AF_UNIX limit)."""
+    return Path("/tmp/claude-hd") / session_id
+
+
 def hook_daemon_sock(session_id: str) -> Path:
     """UDS path for the hook daemon, derived from session_id alone."""
-    return Path("/tmp/claude-hd") / session_id / "d.sock"
+    return _short_session_dir(session_id) / "d.sock"
 
 
 @dataclass(frozen=True)
@@ -82,11 +87,8 @@ class SessionPaths:
 
     @property
     def remote_proxy_sock(self) -> Path:
-        """UDS path for --remote_proxy (Bazel gRPC remote execution/cache).
-
-        Uses a short path under /tmp to stay within the 108-byte AF_UNIX limit.
-        """
-        return Path("/tmp/claude-hd") / self.session_id / "remote-proxy.sock"
+        """UDS path for --remote_proxy (Bazel gRPC remote execution/cache)."""
+        return _short_session_dir(self.session_id) / "remote-proxy.sock"
 
     @property
     def wrapper_dir(self) -> Path:

--- a/devinfra/claude/settings.py
+++ b/devinfra/claude/settings.py
@@ -11,6 +11,7 @@ Environment Variables (in priority order):
 
 import importlib.resources
 import os
+from enum import StrEnum
 from importlib.resources.abc import Traversable
 from typing import Literal
 
@@ -42,6 +43,13 @@ def is_web_mode() -> bool:
     return os.environ.get("CLAUDE_CODE_REMOTE") == "true"
 
 
+class ProxyMode(StrEnum):
+    """Bazel proxy routing mode."""
+
+    UDS = "uds"
+    TCP = "tcp"
+
+
 class HookSettings(BaseSettings):
     """Configuration for claude via environment variables.
 
@@ -66,6 +74,14 @@ class HookSettings(BaseSettings):
 
     warmup_bazel_server: bool = Field(default=True, description="Start Bazel server in background after session setup")
 
+    proxy_mode: ProxyMode = Field(
+        default=ProxyMode.UDS,
+        description=(
+            "Bazel proxy mode. 'uds': route gRPC via --remote_proxy/--bes_proxy UDS, "
+            "BCR uses native JAVA_TOOL_OPTIONS proxy. 'tcp': route all Bazel traffic "
+            "through localhost TCP HTTP CONNECT proxy (legacy)."
+        ),
+    )
     remote_proxy_target: str = Field(
         default="remote.buildbuddy.io:443",
         description="host:port for UDS remote proxy CONNECT tunnel (Bazel --remote_proxy destination)",

--- a/devinfra/claude/settings.py
+++ b/devinfra/claude/settings.py
@@ -66,6 +66,11 @@ class HookSettings(BaseSettings):
 
     warmup_bazel_server: bool = Field(default=True, description="Start Bazel server in background after session setup")
 
+    remote_proxy_target: str = Field(
+        default="remote.buildbuddy.io:443",
+        description="host:port for UDS remote proxy CONNECT tunnel (Bazel --remote_proxy destination)",
+    )
+
     # Per-session output directory. Exported as DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR so
     # subprocesses (e.g. bazel_wrapper) pick it up automatically via pydantic-settings.
     # Baked into the bazel/bazelisk shell wrapper at install time so it survives


### PR DESCRIPTION
## Summary
Introduces a new Unix domain socket (UDS) proxy mode for routing Bazel's gRPC traffic (remote execution, caching, BES) through an egress proxy via HTTP CONNECT tunnels. This bypasses gRPC-Java's Authenticator timing issues by using Bazel's native `--remote_proxy` and `--bes_proxy` flags instead of relying on JVM system properties.

## Key Changes

- **New `UdsRemoteProxy` class** (`auth_proxy/proxy.py`):
  - Listens on a Unix domain socket for Bazel's gRPC connections
  - Establishes HTTP CONNECT tunnels through the egress proxy to a configurable remote endpoint
  - Shuttles bytes bidirectionally between client and remote via the egress proxy
  - Supports credential hot-reload via `set_creds()`

- **Refactored `_tunnel_bidirectional`** as a module-level function:
  - Extracted from `AuthForwardingProxy` to be reused by both proxy implementations
  - Handles bidirectional socket tunneling with select-based multiplexing

- **New `ProxyMode` enum** (`settings.py`):
  - `UDS` (default): Routes gRPC via UDS proxy, BCR uses native JAVA_TOOL_OPTIONS
  - `TCP` (legacy): Routes all Bazel traffic through TCP HTTP CONNECT proxy

- **Updated hook daemon** (`hook_daemon/server.py`):
  - `_start_session_proxy()` now starts both TCP (if enabled) and UDS proxies
  - UDS proxy is always started in web mode; TCP proxy only if `proxy_mode=tcp`
  - Credential updates propagate to both proxy types

- **Updated bazelrc template** (`config/bazelrc.mako`):
  - Adds `--remote_proxy=unix:${remote_proxy_sock}` and `--bes_proxy` flags for UDS mode
  - Conditional TCP proxy configuration based on `proxy_mode`
  - Includes JVM truststore settings for both modes

- **Session paths** (`session_paths.py`):
  - Added `remote_proxy_sock` property for UDS socket path
  - Uses short `/tmp/claude-hd` paths to stay within 108-byte AF_UNIX limit

- **Bazel wrapper** (`bazel_wrapper.py`):
  - Skips HTTPS_PROXY env var override in UDS mode (returns "uds-only" placeholder)
  - TCP mode still sets proxy env vars for backward compatibility

## Implementation Details

- UDS proxy establishes CONNECT tunnels with proper HTTP/1.1 formatting and authentication headers
- Validates CONNECT responses (expects HTTP/1.1 200) before tunneling
- Thread-safe credential management with locks
- Graceful shutdown with socket cleanup and file removal
- Includes cleanup comments marking TCP proxy for removal once UDS mode is confirmed stable

https://claude.ai/code/session_01RKWfXpNGd9fG8FWxcW9tyr