### PR TITLE
fix: resolve mypy errors blocking BB Release pipeline

### DIFF
--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -255,7 +255,9 @@ py_test(
     requires_docker = True,
     deps = [
         ":conftest",
+        ":docker",
         ":models",
+        "@pypi//fastmcp",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/test_twenty_questions.py
@@ -6,13 +6,13 @@ Only the LLM is mocked — all real game logic runs unmodified.
 """
 
 import json
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest_bazel
 from agents import ToolCallOutputItem, set_tracing_disabled
-from agents.items import ModelResponse, TResponseInputItem
+from agents.items import ModelResponse, TResponseInputItem, TResponseOutputItem, TResponseStreamEvent
 from agents.models.interface import Model, ModelTracing
 from agents.tool import Tool
 
@@ -50,12 +50,25 @@ class ScriptedModel(Model):
             "arguments": json.dumps(args),
         }
         return ModelResponse(
-            output=[tool_call_item],
+            output=cast(list[TResponseOutputItem], [tool_call_item]),  # type: ignore[arg-type]
             usage=MagicMock(input_tokens=0, output_tokens=0, total_tokens=0),
             response_id="fake",
         )
 
-    async def stream_response(self, *args: Any, **kwargs: Any) -> Any:
+    def stream_response(  # type: ignore[override]
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: Any,
+        tools: list[Tool],
+        output_schema: Any,
+        handoffs: Any,
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        prompt: Any = None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
         raise NotImplementedError
 
 

--- a/x/agent_server/runtime/container.py
+++ b/x/agent_server/runtime/container.py
@@ -22,7 +22,8 @@ from mcp_infra.compositor.clients import CompositorMetaClient
 from mcp_infra.compositor.compositor import Compositor
 from mcp_infra.compositor.notifications_buffer import NotificationsBuffer
 from mcp_infra.enhanced.server import EnhancedFastMCP
-from mcp_infra.exec.docker.container_session import ContainerOptions
+from mcp_infra.constants import WORKING_DIR
+from mcp_infra.exec.docker.container_session import ContainerOptions, DefaultValue
 from mcp_infra.prefix import MCPMountPrefix
 from mcp_infra.snapshots import SamplingSnapshot, ServerEntry
 from openai_utils.client_factory import build_client
@@ -127,7 +128,9 @@ class AgentContainerCompositor(Compositor):
                 },
             )
             self.runtime = await self.mount_inproc(
-                MCPMountPrefix("runtime"), RuntimeServer(self._async_docker_client, opts), pinned=True
+                MCPMountPrefix("runtime"),
+                RuntimeServer(self._async_docker_client, opts, cwd_policy=DefaultValue(value=WORKING_DIR)),
+                pinned=True,
             )
 
             # Attach persisted chat servers


### PR DESCRIPTION
## Summary

Fix mypy lint errors that cause `bazel test //...` to exit non-zero even though all tests pass. This blocks `bb_release.sh` from running in the BB Release pipeline.

**All 422 tests pass** on devel tip, but 3 mypy errors during build cause exit code 1:

## Changes

**1. `mcp_infra/exec/BUILD.bazel`** — Add `fastmcp` + `docker` deps for `test_docker` target. mypy couldn't find `fastmcp.client` module stubs.

**2. `x/agent_server/runtime/container.py`** — Pass `cwd_policy=DefaultValue(value=WORKING_DIR)` to `RuntimeServer`. The `cwd_policy` parameter became required in #1015 (CwdPolicy) but this caller wasn't updated.

**3. `openai_agents/test_twenty_questions.py`** — (pending) Mock model typing issues with `stream_response` override signature and response output list types.

## Context

The BB Release log shows:
```
All tests passed but there were other errors during the build.
Command failed: exit status 1
```

These mypy-only errors prevent the release step from executing. Once fixed, `bb_release.sh` will finally run, create `claude-hooks-<sha>` GitHub Release, and the flock-based daemon (#1010) will be promoted into the nix flake.

## Test plan

- [x] Tests all pass (verified from BB log: 422 pass, 1 skipped)
- [ ] Full `bazel build //... && bazel test //...` clean on BB CI

https://claude.ai/code/session_019kEEBQ9ywoWugA4oUwgRkg