### PR TITLE
fix: remove unused type: ignore in openai_agents test

### DIFF
--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/test_twenty_questions.py
@@ -50,12 +50,12 @@ class ScriptedModel(Model):
             "arguments": json.dumps(args),
         }
         return ModelResponse(
-            output=cast(list[TResponseOutputItem], [tool_call_item]),  # type: ignore[arg-type]
+            output=cast(list[TResponseOutputItem], [tool_call_item]),
             usage=MagicMock(input_tokens=0, output_tokens=0, total_tokens=0),
             response_id="fake",
         )
 
-    def stream_response(  # type: ignore[override]
+    def stream_response(
         self,
         system_instructions: str | None,
         input: str | list[TResponseInputItem],


### PR DESCRIPTION
## Summary

Remove two unused `# type: ignore` comments that were accidentally included in the squash merge of #1024. The agent's proper fix (correct `stream_response` signature + `cast`) made the ignore comments redundant, causing `unused-ignore` mypy errors that block the BB Release pipeline.

https://claude.ai/code/session_019kEEBQ9ywoWugA4oUwgRkg