### PR TITLE
fix: release.yml dispatch + manual repin to 6009197

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,20 @@ name: Release
 # Updates npins with new artifact hashes and commits. Attic push happens automatically
 # via nix-attic-push workflow on the resulting commit.
 #
-# Dispatched with --ref <full-sha> so github.sha is the exact triggering commit —
-# no SHA inputs needed.
+# Dispatched with --ref devel (GitHub workflow_dispatch requires a branch/tag name,
+# not a bare SHA). The exact triggering commit is passed as inputs.sha so we check
+# out the right code regardless of how far devel has advanced since the BB run.
 "on":
   workflow_dispatch:
     inputs:
+      sha:
+        description: Full commit SHA to check out (exact triggering commit)
+        required: true
       changed:
         description: Space-separated packages with new releases (e.g. "claude-hooks bbapi")
         required: true
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.sha }}
   cancel-in-progress: false
 permissions:
   contents: write
@@ -25,12 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post pending status on triggering commit
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+          gh api "repos/${{ github.repository }}/statuses/${{ inputs.sha }}" \
             -f state=pending \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -f description="Updating npins" \
@@ -64,7 +68,7 @@ jobs:
       - name: Post success status
         if: success()
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+          gh api "repos/${{ github.repository }}/statuses/${{ inputs.sha }}" \
             -f state=success \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -f description="Release complete" \
@@ -75,7 +79,7 @@ jobs:
       - name: Post failure status
         if: failure()
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+          gh api "repos/${{ github.repository }}/statuses/${{ inputs.sha }}" \
             -f state=failure \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -f description="Release failed" \

--- a/devinfra/ci/bb_release.sh
+++ b/devinfra/ci/bb_release.sh
@@ -89,6 +89,9 @@ if [ ${#changed[@]} -eq 0 ]; then
   exit 0
 fi
 
+# --ref must be a branch name (GitHub rejects bare SHAs for workflow_dispatch).
+# Pass the exact commit SHA as an input so release.yml checks out the right commit.
 gh workflow run release.yml \
-  --ref "$FULL_SHA" \
+  --ref devel \
+  --field "sha=$FULL_SHA" \
   --field "changed=${changed[*]}"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,13 +7,13 @@
     },
     "claude-hooks": {
       "fetch": "file",
-      "url": "https://github.com/agentydragon/ducktape/releases/download/claude-hooks-5f12ef1/claude_hooks-0.1.0-py3-none-any.whl",
-      "hash": "sha256-oQSXNSxXD/Uj4V4I4Yyxu4JmmNHZ5W5vvy2py5eF5Rg="
+      "url": "https://github.com/agentydragon/ducktape/releases/download/claude-hooks-6009197/claude_hooks-0.1.0-py3-none-any.whl",
+      "hash": "sha256-s9rR3WjpToS5kXOcrUuS7zX1YXVncze/KVNxegNXhnE="
     },
     "ducktape": {
       "fetch": "file",
-      "url": "https://github.com/agentydragon/ducktape/releases/download/ducktape-4476fe7/ducktape-0.1.0-py3-none-any.whl",
-      "hash": "sha256-htheP5FTHLQyR+UZsM85TF4yBAr9DNANq9YnCOmtxeU="
+      "url": "https://github.com/agentydragon/ducktape/releases/download/ducktape-6009197/ducktape-0.1.0-py3-none-any.whl",
+      "hash": "sha256-gKMHGJdMihFG88JUP8XbiCeybnmcJU1YeKY52SiQc2I="
     },
     "gterm-theme": {
       "fetch": "file",
@@ -22,8 +22,8 @@
     },
     "skills": {
       "fetch": "unpack",
-      "url": "https://github.com/agentydragon/ducktape/releases/download/skills-be90bd0/skills.tar",
-      "hash": "sha256-0hiWv3UQV079muE2ROB3AnqfIteVJZplHo+Mbz0OqCk="
+      "url": "https://github.com/agentydragon/ducktape/releases/download/skills-6009197/skills.tar",
+      "hash": "sha256-kF00dg0lifxaQ59vnVUf4P4OCvN8D7c6HJhHGO7lpDQ="
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fix `gh workflow run release.yml --ref <SHA>` failure — GitHub workflow_dispatch requires a branch/tag name, not a bare commit SHA
- Manual repin of `npins/sources.json` to `claude-hooks-6009197` (the release `bb_release.sh` successfully created)

## Root cause

PR #1006 changed the dispatch from `--ref "$BRANCH"` to `--ref "$FULL_SHA"` to avoid race conditions with a moving devel branch. But `workflow_dispatch` only accepts branch/tag names as refs — bare SHAs return HTTP 422 "No ref found". This has been silently breaking every release since #1006.

## Fix

- `bb_release.sh`: `--ref devel` + `--field "sha=$FULL_SHA"`
- `release.yml`: New `inputs.sha` field, used for checkout and commit status. Concurrency group keyed on `inputs.sha`.
- `npins/sources.json`: Manual repin to `6009197` releases (claude-hooks, ducktape, skills). This promotes the flock-based daemon (#1010), UDS proxy (#1018), and all fixes from #1017–#1025 into the nix flake.

https://claude.ai/code/session_019kEEBQ9ywoWugA4oUwgRkg