### PR TITLE
Simplify Claude Code web setup script to use local path

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -312,18 +312,7 @@ Rotation: bump `rotation_version` in the TF module.
 To use this repository with Claude Code on the web, configure the following setup script in the Claude Code web UI:
 
 ```bash
-{
-  echo "=== web setup diagnostics ==="
-  echo "pwd: $(pwd)"
-  echo "whoami: $(whoami)"
-  echo "HOME: $HOME"
-  echo "flake.nix exists: $(test -f /home/user/ducktape/flake.nix && echo yes || echo no)"
-  echo "web_setup.sh exists: $(test -f /home/user/ducktape/devinfra/claude/web_setup.sh && echo yes || echo no)"
-  echo "ls /home/user/ducktape:"
-  ls /home/user/ducktape 2>&1 || echo "(not found)"
-  echo "==="
-} | tee /tmp/web-setup-pre.log
-bash /home/user/ducktape/devinfra/claude/web_setup.sh
+bash ducktape/devinfra/claude/web_setup.sh
 ```
 
 This runs <web_setup.sh> which installs:

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -312,6 +312,17 @@ Rotation: bump `rotation_version` in the TF module.
 To use this repository with Claude Code on the web, configure the following setup script in the Claude Code web UI:
 
 ```bash
+{
+  echo "=== web setup diagnostics ==="
+  echo "pwd: $(pwd)"
+  echo "whoami: $(whoami)"
+  echo "HOME: $HOME"
+  echo "flake.nix exists: $(test -f /home/user/ducktape/flake.nix && echo yes || echo no)"
+  echo "web_setup.sh exists: $(test -f /home/user/ducktape/devinfra/claude/web_setup.sh && echo yes || echo no)"
+  echo "ls /home/user/ducktape:"
+  ls /home/user/ducktape 2>&1 || echo "(not found)"
+  echo "==="
+} | tee /tmp/web-setup-pre.log
 bash /home/user/ducktape/devinfra/claude/web_setup.sh
 ```
 

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -312,14 +312,8 @@ Rotation: bump `rotation_version` in the TF module.
 To use this repository with Claude Code on the web, configure the following setup script in the Claude Code web UI:
 
 ```bash
-#!/bin/bash
-curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/680d78946bf72e5e3601cdb69299546b495cab1b/devinfra/claude/web_setup.sh | bash
+bash /home/user/ducktape/devinfra/claude/web_setup.sh
 ```
-
-**Note**: Use a pinned commit SHA, not the `devel` branch ref — Anthropic caches
-the setup script at configuration time (when saved in the web UI). Changing the
-URL triggers a re-fetch; updating `devel` alone does not. Update the SHA when
-`web_setup.sh` changes (see <docs/web-setup-debug.md> for history).
 
 This runs <web_setup.sh> which installs:
 

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -121,6 +121,9 @@ nix show-config 2>/dev/null | grep -E "max-jobs|sandbox|build-users" || true
 echo "---"
 
 echo "[$(date -Iseconds)] Installing web session tools..."
+echo "  FLAKE=${FLAKE}"
+echo "  pwd=$(pwd)"
+echo "  flake.nix exists: $(test -f flake.nix && echo yes || echo no)"
 # Pass --max-jobs explicitly to override any nix.conf misconfiguration.
 nix profile install --max-jobs auto "${FLAKE}#web-session"
 echo "[$(date -Iseconds)] Web session tools installed."

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -124,6 +124,8 @@ echo "[$(date -Iseconds)] Installing web session tools..."
 echo "  FLAKE=${FLAKE}"
 echo "  pwd=$(pwd)"
 echo "  flake.nix exists: $(test -f flake.nix && echo yes || echo no)"
+echo "  ls pwd:"
+ls -la
 # Pass --max-jobs explicitly to override any nix.conf misconfiguration.
 nix profile install --max-jobs auto "${FLAKE}#web-session"
 echo "[$(date -Iseconds)] Web session tools installed."

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -10,7 +10,7 @@
 # fails. Failures are logged to /tmp/web-setup.log and uploaded to ix.io.
 #
 # Usage (Claude Code web UI setup command):
-#   bash /home/user/ducktape/devinfra/claude/web_setup.sh
+#   bash ducktape/devinfra/claude/web_setup.sh
 
 LOG_FILE="/tmp/web-setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -10,7 +10,7 @@
 # fails. Failures are logged to /tmp/web-setup.log and uploaded to ix.io.
 #
 # Usage (Claude Code web UI setup command):
-#   curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/devel/devinfra/claude/web_setup.sh | bash
+#   bash /home/user/ducktape/devinfra/claude/web_setup.sh
 
 LOG_FILE="/tmp/web-setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
@@ -36,7 +36,7 @@ trap on_exit EXIT
 
 set -euo pipefail
 
-FLAKE="path:$(pwd)"
+FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # --- Step 1: Install Nix ---
 # Write nix.conf BEFORE the installer runs. The installer internally runs


### PR DESCRIPTION
## Summary
This PR simplifies the Claude Code web setup process by changing from a remote curl-based installation to a local script execution, and improves the flake path resolution to work correctly regardless of where the script is invoked from.

## Key Changes
- **Updated setup command**: Changed from `curl -fsSL https://raw.githubusercontent.com/.../web_setup.sh | bash` to `bash ducktape/devinfra/claude/web_setup.sh`, simplifying the setup instructions and removing the need to maintain pinned commit SHAs
- **Fixed flake path resolution**: Modified `FLAKE` variable to resolve relative to the script's location (`$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)`) instead of the current working directory, ensuring the flake is found correctly regardless of where the script is executed from
- **Added debugging output**: Added diagnostic logging before installing web session tools to help troubleshoot setup issues (FLAKE path, current directory, flake.nix existence, and directory listing)
- **Updated documentation**: Simplified the README instructions and removed the note about maintaining pinned commit SHAs, as the script is now executed locally

## Implementation Details
The key improvement is making the script location-independent by using `${BASH_SOURCE[0]}` to determine the script's directory and then navigating to the repository root. This allows the setup script to work correctly when invoked from any working directory, which is important for the Claude Code web UI integration.

https://claude.ai/code/session_01CBacADyEV9T5AuRRXkPoGz