### PR TITLE
Support proxy configuration from environment variables

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
+++ b/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
@@ -12,6 +12,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 from kubernetes import client as k8s_client
@@ -99,7 +100,16 @@ def setup_k8s_secrets(
         client_config.verify_ssl = True
     effective_proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
     if effective_proxy:
-        client_config.proxy = effective_proxy
+        # urllib3 v2 ProxyManager does not auto-send Proxy-Authorization for HTTPS CONNECT
+        # tunnels when credentials are embedded in the proxy URL. Extract them explicitly.
+        parsed = urlparse(effective_proxy)
+        if parsed.username:
+            creds = f"{parsed.username}:{parsed.password}"
+            auth = base64.b64encode(creds.encode()).decode()
+            client_config.proxy_headers = {"Proxy-Authorization": f"Basic {auth}"}
+            client_config.proxy = parsed._replace(netloc=f"{parsed.hostname}:{parsed.port}").geturl()
+        else:
+            client_config.proxy = effective_proxy
 
     api = CoreV1Api(k8s_client.ApiClient(client_config))
 

--- a/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
+++ b/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
@@ -9,6 +9,7 @@ Config mapping (secret name, data keys, env vars) is defined in
 
 import base64
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -80,8 +81,7 @@ def setup_k8s_secrets(
     from the configured namespace, maps data keys to env var names, and
     writes a kubeconfig file for kubectl CLI use.
 
-    In web mode, pass proxy="http://localhost:<port>" to route through the
-    auth proxy, which adds Proxy-Authorization for the upstream egress proxy.
+    Proxy priority: explicit `proxy` arg > HTTPS_PROXY > HTTP_PROXY env vars.
     """
     result = K8sSecretsResult()
     if not config.k8s or not config.k8s_secrets:
@@ -97,8 +97,9 @@ def setup_k8s_secrets(
         client_config.ssl_ca_cert = str(combined_ca_path)
     else:
         client_config.verify_ssl = True
-    if proxy:
-        client_config.proxy = proxy
+    effective_proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+    if effective_proxy:
+        client_config.proxy = effective_proxy
 
     api = CoreV1Api(k8s_client.ApiClient(client_config))
 
@@ -132,7 +133,7 @@ def setup_k8s_secrets(
 
     # Write kubeconfig (pass proxy_url so kubectl routes through the same proxy as the Python client)
     kubeconfig = _build_kubeconfig(
-        token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path, proxy_url=proxy
+        token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path, proxy_url=effective_proxy
     )
     kubeconfig_path = session_dir / "kubeconfig"
     kubeconfig_path.write_text(yaml.dump(kubeconfig, default_flow_style=False))

--- a/devinfra/claude/hook_daemon/session_start/test_k8s_secrets.py
+++ b/devinfra/claude/hook_daemon/session_start/test_k8s_secrets.py
@@ -94,16 +94,36 @@ def test_kubeconfig_proxy_url(tmp_path: Path, mock_k8s_api: MagicMock) -> None:
     assert kubeconfig["clusters"][0]["cluster"]["proxy-url"] == "http://localhost:18081"
 
 
-def test_kubeconfig_no_proxy_url_when_unset(tmp_path: Path, mock_k8s_api: MagicMock) -> None:
-    """When proxy is not set, kubeconfig should not include proxy-url."""
+def test_kubeconfig_no_proxy_url_when_unset(
+    tmp_path: Path, mock_k8s_api: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When proxy is not set and no proxy env vars are present, kubeconfig should not include proxy-url."""
     config = _make_config([])
     mock_k8s_api.read_namespaced_secret.side_effect = []
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
 
     result = setup_k8s_secrets(token="tok", session_dir=tmp_path, combined_ca_path=None, config=config)
 
     assert result.kubeconfig_path is not None
     kubeconfig = yaml.safe_load(result.kubeconfig_path.read_text())
     assert "proxy-url" not in kubeconfig["clusters"][0]["cluster"]
+
+
+def test_kubeconfig_proxy_url_from_env(
+    tmp_path: Path, mock_k8s_api: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no explicit proxy is given but HTTPS_PROXY is set, kubeconfig should use it."""
+    config = _make_config([])
+    mock_k8s_api.read_namespaced_secret.side_effect = []
+    monkeypatch.setenv("HTTPS_PROXY", "http://egress-proxy:15004")
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+
+    result = setup_k8s_secrets(token="tok", session_dir=tmp_path, combined_ca_path=None, config=config)
+
+    assert result.kubeconfig_path is not None
+    kubeconfig = yaml.safe_load(result.kubeconfig_path.read_text())
+    assert kubeconfig["clusters"][0]["cluster"]["proxy-url"] == "http://egress-proxy:15004"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Enhanced the Kubernetes secrets setup to support proxy configuration from environment variables (`HTTPS_PROXY` and `HTTP_PROXY`) in addition to explicit proxy arguments, with proper priority handling and credential extraction for proxy authentication.

## Key Changes
- **Proxy priority hierarchy**: Explicit `proxy` argument takes precedence over `HTTPS_PROXY`, which takes precedence over `HTTP_PROXY` environment variables
- **Proxy credential handling**: Added extraction and Base64 encoding of embedded credentials in proxy URLs, with explicit `Proxy-Authorization` header injection to work around urllib3 v2 limitations with HTTPS CONNECT tunnels
- **Consistent proxy usage**: Both the Kubernetes Python client and generated kubeconfig now use the same effective proxy URL
- **Test coverage**: Added test for environment variable-based proxy configuration and updated existing test to explicitly clear proxy environment variables for isolation

## Implementation Details
- Uses `os.environ.get()` to check for proxy environment variables with fallback chain
- Parses proxy URLs with `urllib.parse.urlparse()` to extract credentials
- Reconstructs proxy URL without credentials for the actual proxy connection while setting `Proxy-Authorization` header separately
- Updated docstring to document the proxy priority behavior

https://claude.ai/code/session_01Vp5WLzmu4kQXZo5v4L2FJj