### PR TITLE
fix: k8s proxy fallback + anyio.Path migration (ASYNC240)

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/BUILD.bazel
@@ -75,6 +75,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//devinfra/claude:hook_config",
+        "//devinfra/claude/auth_proxy:vars",
         "@pypi//kubernetes",
         "@pypi//pyyaml",
     ],
@@ -167,6 +168,8 @@ py_test(
         ":k8s_secrets",
         "//devinfra/claude:conftest",
         "//devinfra/claude:hook_config",
+        "//devinfra/claude/auth_proxy:vars",
+        "@pypi//kubernetes",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",

--- a/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
+++ b/devinfra/claude/hook_daemon/session_start/k8s_secrets.py
@@ -9,7 +9,6 @@ Config mapping (secret name, data keys, env vars) is defined in
 
 import base64
 import logging
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
@@ -18,6 +17,7 @@ import yaml
 from kubernetes import client as k8s_client
 from kubernetes.client import Configuration, CoreV1Api
 
+from devinfra.claude.auth_proxy.vars import get_upstream_proxy_url
 from devinfra.claude.hook_config import HookConfig, K8sSecretRef
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ def setup_k8s_secrets(
     from the configured namespace, maps data keys to env var names, and
     writes a kubeconfig file for kubectl CLI use.
 
-    Proxy priority: explicit `proxy` arg > HTTPS_PROXY > HTTP_PROXY env vars.
+    Proxy priority: explicit `proxy` arg > get_upstream_proxy_url() env vars.
     """
     result = K8sSecretsResult()
     if not config.k8s or not config.k8s_secrets:
@@ -98,16 +98,20 @@ def setup_k8s_secrets(
         client_config.ssl_ca_cert = str(combined_ca_path)
     else:
         client_config.verify_ssl = True
-    effective_proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+    effective_proxy = proxy or get_upstream_proxy_url()
     if effective_proxy:
         # urllib3 v2 ProxyManager does not auto-send Proxy-Authorization for HTTPS CONNECT
         # tunnels when credentials are embedded in the proxy URL. Extract them explicitly.
         parsed = urlparse(effective_proxy)
+        if not parsed.hostname:
+            raise ValueError(f"Invalid proxy URL (missing hostname): {effective_proxy!r}")
         if parsed.username:
-            creds = f"{parsed.username}:{parsed.password}"
+            password = parsed.password or ""
+            creds = f"{parsed.username}:{password}"
             auth = base64.b64encode(creds.encode()).decode()
             client_config.proxy_headers = {"Proxy-Authorization": f"Basic {auth}"}
-            client_config.proxy = parsed._replace(netloc=f"{parsed.hostname}:{parsed.port}").geturl()
+            netloc = parsed.hostname if parsed.port is None else f"{parsed.hostname}:{parsed.port}"
+            client_config.proxy = parsed._replace(netloc=netloc).geturl()
         else:
             client_config.proxy = effective_proxy
 
@@ -142,6 +146,9 @@ def setup_k8s_secrets(
         result.otel_bearer_token = _read_secret_ref(api, secrets_cfg.otel_bearer_token, secrets_cfg.namespace)
 
     # Write kubeconfig (pass proxy_url so kubectl routes through the same proxy as the Python client)
+    # CLEANUP(2026-03-27): effective_proxy may contain embedded credentials that get written
+    # verbatim into kubeconfig proxy-url, persisting them to disk. Pass the sanitized
+    # client_config.proxy once we verify kubectl still works without credentials in proxy-url.
     kubeconfig = _build_kubeconfig(
         token, k8s_cfg.server, k8s_cfg.service_account, k8s_cfg.namespace, combined_ca_path, proxy_url=effective_proxy
     )

--- a/devinfra/claude/hook_daemon/session_start/mkcert.py
+++ b/devinfra/claude/hook_daemon/session_start/mkcert.py
@@ -98,7 +98,7 @@ async def setup_mkcert(paths: SessionPaths, combined_ca: Path | None) -> MkcertS
         logger.info("Generated localhost cert: %s", cert_path)
 
     with tracer.start_as_current_span("mkcert_append_bundle"):
-        if combined_ca and await asyncio.to_thread(combined_ca.exists):
+        if combined_ca and await asyncio.to_thread(os.path.exists, combined_ca):
             append_mkcert_ca_to_bundle(ca_root, combined_ca)
 
     return MkcertSetup(cert_path=cert_path, key_path=key_path, ca_root=ca_root, status=f"installed ({cert_path})")

--- a/devinfra/claude/hook_daemon/session_start/mkcert.py
+++ b/devinfra/claude/hook_daemon/session_start/mkcert.py
@@ -14,6 +14,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+import anyio
 from opentelemetry import trace
 
 from devinfra.claude.session_paths import SessionPaths
@@ -61,18 +62,18 @@ async def setup_mkcert(paths: SessionPaths, combined_ca: Path | None) -> MkcertS
     appends the root CA to the combined CA bundle so Python/curl/Node trust
     it via SSL_CERT_FILE.
     """
-    mkcert_dir = _get_mkcert_dir(paths)
-    mkcert_dir.mkdir(parents=True, exist_ok=True)
+    mkcert_dir = anyio.Path(_get_mkcert_dir(paths))
+    await mkcert_dir.mkdir(parents=True, exist_ok=True)
 
     ca_root = mkcert_dir / "ca"
-    ca_root.mkdir(parents=True, exist_ok=True)
+    await ca_root.mkdir(parents=True, exist_ok=True)
 
     cert_path = mkcert_dir / "localhost.pem"
     key_path = mkcert_dir / "localhost-key.pem"
 
     env = {**os.environ, "CAROOT": str(ca_root)}
 
-    if not cert_path.exists() or not key_path.exists():
+    if not await cert_path.exists() or not await key_path.exists():
         mkcert_bin = shutil.which("mkcert")
         if not mkcert_bin:
             raise RuntimeError("mkcert not found on PATH (expected from Nix web-session package)")
@@ -82,9 +83,9 @@ async def setup_mkcert(paths: SessionPaths, combined_ca: Path | None) -> MkcertS
             proc = await asyncio.create_subprocess_exec(
                 mkcert_bin,
                 "-cert-file",
-                cert_path,
+                str(cert_path),
                 "-key-file",
-                key_path,
+                str(key_path),
                 "localhost",
                 "127.0.0.1",
                 "::1",
@@ -98,7 +99,9 @@ async def setup_mkcert(paths: SessionPaths, combined_ca: Path | None) -> MkcertS
         logger.info("Generated localhost cert: %s", cert_path)
 
     with tracer.start_as_current_span("mkcert_append_bundle"):
-        if combined_ca and await asyncio.to_thread(os.path.exists, combined_ca):
-            append_mkcert_ca_to_bundle(ca_root, combined_ca)
+        if combined_ca and await anyio.Path(combined_ca).exists():
+            append_mkcert_ca_to_bundle(Path(ca_root), combined_ca)
 
-    return MkcertSetup(cert_path=cert_path, key_path=key_path, ca_root=ca_root, status=f"installed ({cert_path})")
+    return MkcertSetup(
+        cert_path=Path(cert_path), key_path=Path(key_path), ca_root=Path(ca_root), status=f"installed ({cert_path})"
+    )

--- a/devinfra/claude/hook_daemon/session_start/test_k8s_secrets.py
+++ b/devinfra/claude/hook_daemon/session_start/test_k8s_secrets.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytest_bazel
 import yaml
+from kubernetes.client import Configuration
 
+from devinfra.claude.auth_proxy.vars import PROXY_ENV_VARS
 from devinfra.claude.hook_config import HookConfig, K8sConfig, K8sSecretMapping, K8sSecretsConfig
 from devinfra.claude.hook_daemon.session_start.k8s_secrets import setup_k8s_secrets
 
@@ -100,8 +102,8 @@ def test_kubeconfig_no_proxy_url_when_unset(
     """When proxy is not set and no proxy env vars are present, kubeconfig should not include proxy-url."""
     config = _make_config([])
     mock_k8s_api.read_namespaced_secret.side_effect = []
-    monkeypatch.delenv("HTTPS_PROXY", raising=False)
-    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    for var in PROXY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
 
     result = setup_k8s_secrets(token="tok", session_dir=tmp_path, combined_ca_path=None, config=config)
 
@@ -116,14 +118,50 @@ def test_kubeconfig_proxy_url_from_env(
     """When no explicit proxy is given but HTTPS_PROXY is set, kubeconfig should use it."""
     config = _make_config([])
     mock_k8s_api.read_namespaced_secret.side_effect = []
+    for var in PROXY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("HTTPS_PROXY", "http://egress-proxy:15004")
-    monkeypatch.delenv("HTTP_PROXY", raising=False)
 
     result = setup_k8s_secrets(token="tok", session_dir=tmp_path, combined_ca_path=None, config=config)
 
     assert result.kubeconfig_path is not None
     kubeconfig = yaml.safe_load(result.kubeconfig_path.read_text())
     assert kubeconfig["clusters"][0]["cluster"]["proxy-url"] == "http://egress-proxy:15004"
+
+
+def test_proxy_credentials_extracted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Proxy URL with embedded credentials sets Proxy-Authorization and sanitizes client proxy URL."""
+    config = _make_config([])
+    for var in PROXY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    captured_configs: list[Configuration] = []
+
+    class CapturingConfiguration(Configuration):
+        def __init__(self) -> None:
+            super().__init__()
+            captured_configs.append(self)
+
+    with (
+        patch("devinfra.claude.hook_daemon.session_start.k8s_secrets.k8s_client"),
+        patch("devinfra.claude.hook_daemon.session_start.k8s_secrets.CoreV1Api"),
+        patch("devinfra.claude.hook_daemon.session_start.k8s_secrets.Configuration", CapturingConfiguration),
+    ):
+        setup_k8s_secrets(
+            token="tok",
+            session_dir=tmp_path,
+            combined_ca_path=None,
+            config=config,
+            proxy="http://user:secret@proxy.example.com:8080",
+        )
+
+    assert len(captured_configs) == 1
+    cfg = captured_configs[0]
+    # Credentials must be stripped from the proxy URL used by the k8s client
+    assert cfg.proxy == "http://proxy.example.com:8080"
+    # Credentials must be sent via explicit Proxy-Authorization header
+    expected_auth = "Basic " + base64.b64encode(b"user:secret").decode()
+    assert cfg.proxy_headers == {"Proxy-Authorization": expected_auth}
 
 
 if __name__ == "__main__":

--- a/editor_agent/host/cli.py
+++ b/editor_agent/host/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Annotated
 
 import aiodocker
+import anyio
 import typer
 
 from editor_agent.host.agent_runner import run_editor_docker_agent
@@ -68,7 +69,7 @@ async def edit(
     if prompt is None:
         raise typer.BadParameter("PROMPT argument is required")
     file = file.resolve()
-    if not file.is_file():
+    if not await anyio.Path(file).is_file():
         raise typer.BadParameter(f"Not a file: {file}")
 
     model_client = build_client(model, enable_debug_logging=True)

--- a/editor_agent/host/cli.py
+++ b/editor_agent/host/cli.py
@@ -68,7 +68,7 @@ async def edit(
         raise typer.BadParameter("FILE argument is required")
     if prompt is None:
         raise typer.BadParameter("PROMPT argument is required")
-    file = file.resolve()
+    file = Path(await anyio.Path(file).resolve())
     if not await anyio.Path(file).is_file():
         raise typer.BadParameter(f"Not a file: {file}")
 

--- a/editor_agent/runtime/cli.py
+++ b/editor_agent/runtime/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from typing import Annotated
 
+import anyio
 import typer
 
 from agent_pkg.mcp import mcp_client_from_env, read_text_resource
@@ -57,8 +58,8 @@ async def materialize(
     async with mcp_client_from_env() as (client, _init_result):
         filename = await _get_filename()
         content = await read_text_resource(client, EDIT_RESOURCE_URI)
-    target_path = directory / filename
-    target_path.write_text(content, encoding="utf-8")
+    target_path = anyio.Path(directory) / filename
+    await target_path.write_text(content, encoding="utf-8")
     print(target_path)
 
 
@@ -69,7 +70,7 @@ async def submit_success(
     file: Annotated[Path, typer.Option("--file", "-f", help="Path to file with edited content")],
 ) -> None:
     """Submit successful edit with the file content."""
-    content = file.read_text(encoding="utf-8")
+    content = await anyio.Path(file).read_text(encoding="utf-8")
     async with mcp_client_from_env() as (client, _init_result):
         await client.call_tool("submit_success", {"message": message, "content": content})
 


### PR DESCRIPTION
## Summary

- **k8s secrets proxy fallback**: When the auth proxy runs in UDS mode (`proxy_url=None`), the k8s client was attempting direct DNS resolution for `api.allegedly.works` instead of routing through Anthropic's egress proxy. Now falls back to `HTTPS_PROXY`/`HTTP_PROXY` env vars automatically.
- **urllib3 v2 `Proxy-Authorization` fix**: urllib3 v2's `ProxyManager` does not auto-send `Proxy-Authorization` headers for HTTPS CONNECT tunnels from URL-embedded credentials. Explicitly extracts username/password from the proxy URL and sets `client_config.proxy_headers`.
- **`anyio.Path` migration (ASYNC240)**: Replaced all blocking `pathlib.Path` method calls in async functions with `anyio.Path` equivalents across `mkcert.py`, `editor_agent/host/cli.py`, and `editor_agent/runtime/cli.py`. This also fixes a pre-existing mypy error in `mkcert.py` that was failing the BB Release workflow.

## Test plan

- [ ] `bazel test //devinfra/claude/hook_daemon/session_start:test_k8s_secrets` — covers proxy fallback, credential extraction, kubeconfig proxy-url field
- [ ] `bazel build //editor_agent/...` — verifies anyio.Path changes compile cleanly
- [ ] Session start hook in a new Claude Code web session should successfully fetch k8s secrets (GITHUB_TOKEN, BUILDBUDDY_API_KEY)

https://claude.ai/code/session_01Vp5WLzmu4kQXZo5v4L2FJj