### PR TITLE
fix: PostToolUse hook output misleads Claude about report-only hooks

### DIFF
--- a/devinfra/claude/bazel_wrapper.py
+++ b/devinfra/claude/bazel_wrapper.py
@@ -129,7 +129,8 @@ def _refresh_proxy_creds(paths: SessionPaths) -> str:
         return update_proxy_creds(https_proxy, paths)
     except OSError as e:
         raise AuthProxyError(
-            f"Auth proxy RPC failed: {e}. The hook daemon may not be running. Try restarting your Claude Code session."
+            f"Auth proxy RPC failed: {e}. The hook daemon may not be running. "
+            f"See AGENTS.md 'Recovering from a Broken Session Start Hook' for recovery steps."
         ) from e
 
 

--- a/devinfra/claude/hook_config.py
+++ b/devinfra/claude/hook_config.py
@@ -84,6 +84,9 @@ class PreCommitConfig(BaseModel):
     show_report_diffs: bool = Field(
         default=False, description="Show unified diffs from report-only hooks in the PostToolUse output."
     )
+    show_hook_output: bool = Field(
+        default=False, description="Show stdout/stderr from failing hooks in the PostToolUse output."
+    )
 
 
 class HookConfig(BaseModel):

--- a/devinfra/claude/hook_config.py
+++ b/devinfra/claude/hook_config.py
@@ -81,6 +81,9 @@ class PreCommitConfig(BaseModel):
         description="Hook IDs whose file modifications are kept (not reverted). "
         "All other hooks' modifications are reverted and reported as diffs."
     )
+    show_report_diffs: bool = Field(
+        default=False, description="Show unified diffs from report-only hooks in the PostToolUse output."
+    )
 
 
 class HookConfig(BaseModel):

--- a/devinfra/claude/hook_config.py
+++ b/devinfra/claude/hook_config.py
@@ -74,12 +74,13 @@ class K8sConfig(BaseModel):
     namespace: str = Field(description="Default namespace for kubectl operations")
 
 
-class PreCommitConfig(BaseModel):
+class PreCommitConfig(BaseModel, frozen=True):
     """Pre-commit hook behavior configuration."""
 
-    auto_apply_hooks: set[str] = Field(
+    auto_apply_hooks: frozenset[str] = Field(
+        default_factory=frozenset,
         description="Hook IDs whose file modifications are kept (not reverted). "
-        "All other hooks' modifications are reverted and reported as diffs."
+        "All other hooks' modifications are reverted and reported as diffs.",
     )
     show_report_diffs: bool = Field(
         default=False, description="Show unified diffs from report-only hooks in the PostToolUse output."

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -167,6 +167,7 @@ py_library(
     imports = ["../../.."],
     deps = [
         "//devinfra/claude:session_paths",
+        "@pypi//pygit2",
         "@pypi//pytest",
     ],
 )
@@ -225,6 +226,7 @@ py_test(
         ":post_tool_use_lib",
         ":precommit_runner",
         "//devinfra/claude:conftest",
+        "//devinfra/claude:hook_config",
         "//devinfra/claude/claude_api/hooks:post_tool_use",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
@@ -238,10 +240,11 @@ py_test(
     data = ["__snapshots__/test_precommit_e2e.ambr"],
     imports = ["../../.."],
     deps = [
+        ":hook_daemon_conftest",
         ":post_tool_use_lib",
         ":precommit_runner",
         "//devinfra/claude:conftest",
-        "@pypi//pygit2",
+        "//devinfra/claude:hook_config",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
@@ -252,15 +255,18 @@ py_test(
 py_test(
     name = "test_post_tool_use_ruff_e2e",
     srcs = ["test_post_tool_use_ruff_e2e.py"],
-    data = ["@multitool//tools/ruff"],
+    data = [
+        "testdata/ruff_repo/.claude_hooks/config.yaml",
+        "testdata/ruff_repo/ruff.toml",
+        "@multitool//tools/ruff",
+    ],
     imports = ["../../.."],
     deps = [
+        ":hook_daemon_conftest",
         ":post_tool_use_lib",
         ":precommit_runner",
         "//devinfra/claude:conftest",
-        "//devinfra/claude:hook_config",
         "//devinfra/claude/claude_api/hooks:post_tool_use",
-        "@pypi//pygit2",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -170,6 +170,7 @@ py_library(
         "//devinfra/claude:session_paths",
         "@pypi//pygit2",
         "@pypi//pytest",
+        "@pypi//pyyaml",
     ],
 )
 

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -249,6 +249,7 @@ py_test(
         ":precommit_runner",
         "//devinfra/claude:conftest",
         "//devinfra/claude:hook_config",
+        "@pypi//more_itertools",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -248,3 +248,21 @@ py_test(
         "@pypi//syrupy",
     ],
 )
+
+py_test(
+    name = "test_post_tool_use_ruff_e2e",
+    srcs = ["test_post_tool_use_ruff_e2e.py"],
+    data = ["@multitool//tools/ruff"],
+    imports = ["../../.."],
+    deps = [
+        ":post_tool_use_lib",
+        ":precommit_runner",
+        "//devinfra/claude:conftest",
+        "//devinfra/claude:hook_config",
+        "//devinfra/claude/claude_api/hooks:post_tool_use",
+        "@pypi//pygit2",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
+    ],
+)

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -249,7 +249,6 @@ py_test(
         ":precommit_runner",
         "//devinfra/claude:conftest",
         "//devinfra/claude:hook_config",
-        "@pypi//more_itertools",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -56,6 +56,7 @@ py_library(
         "//devinfra/claude:hook_config",
         "//devinfra/claude/claude_api/hooks:post_tool_use",
         "@pypi//mako",
+        "@pypi//pygit2",
     ],
 )
 
@@ -223,6 +224,7 @@ py_test(
     data = ["__snapshots__/test_post_tool_use.ambr"],
     imports = ["../../.."],
     deps = [
+        ":hook_daemon_conftest",
         ":post_tool_use_lib",
         ":precommit_runner",
         "//devinfra/claude:conftest",
@@ -230,6 +232,7 @@ py_test(
         "//devinfra/claude/claude_api/hooks:post_tool_use",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
         "@pypi//syrupy",
     ],
 )

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -20,22 +20,8 @@
   '''
 # ---
 # name: test_format_report_only_failure
-  '''
-  1 hook failed on test.py:
-    ruff-format (modified file)
-      bad indent
-  Run `pre-commit run --files test.py` to apply fixes.
-  '''
+  'Would also edit test.py: ruff-format'
 # ---
 # name: test_format_with_diff
-  '''
-  1 hook failed on test.py:
-    fixer (modified file)
-      fixed
-  Changes pre-commit would make:
-  @@ -1 +1 @@
-  -x=1
-  +x = 1
-  Run `pre-commit run --files test.py` to apply fixes.
-  '''
+  'Would also edit test.py: fixer'
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -27,7 +27,7 @@
 # name: test_format_report_only_failure
   '''
   test.py:
-    Not auto-applied (would also edit): ruff-format
+    Not auto-applied (would also edit): ruff
   '''
 # ---
 # name: test_format_with_diff

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -10,7 +10,6 @@
   test.py:
     Auto-applied: ruff-format
     ruff-check (exit 1)
-      F401 unused import
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
@@ -18,7 +17,6 @@
   '''
   test.py:
     mypy (exit 1)
-      type error
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -1,11 +1,14 @@
 # serializer version: 1
 # name: test_format_auto_applied_only
-  'Auto-applied: ruff-format'
+  '''
+  test.py:
+    Auto-applied: ruff-format
+  '''
 # ---
 # name: test_format_mixed_auto_apply_and_report
   '''
-  Auto-applied: ruff-format
-  1 hook failed on test.py:
+  test.py:
+    Auto-applied: ruff-format
     ruff-check (exit 1)
       F401 unused import
   Run `pre-commit run --files test.py` to apply fixes.
@@ -13,15 +16,25 @@
 # ---
 # name: test_format_non_zero_exit
   '''
-  1 hook failed on test.py:
+  test.py:
     mypy (exit 1)
       type error
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
 # name: test_format_report_only_failure
-  'Would also edit test.py: ruff-format'
+  '''
+  test.py:
+    Not auto-applied (would also edit): ruff-format
+  '''
 # ---
 # name: test_format_with_diff
-  'Would also edit test.py: fixer'
+  '''
+  test.py:
+    Not auto-applied (would also edit): fixer
+  Changes pre-commit would make:
+  @@ -1 +1 @@
+  -x=1
+  +x = 1
+  '''
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -3,22 +3,24 @@
   '''
   test.py:
     Auto-applied:
-      ruff-format (exit 0)
+      ruff-format (now clean)
   '''
 # ---
 # name: test_format_mixed_auto_apply_and_report
   '''
   test.py:
     Auto-applied:
-      ruff-format (exit 0)
-    ruff-check (exit 1)
+      ruff-format (now clean)
+    Failed (not applied):
+      ruff-check (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
 # name: test_format_non_zero_exit
   '''
   test.py:
-    mypy (exit 1)
+    Failed (not applied):
+      mypy (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_post_tool_use.ambr
@@ -2,13 +2,15 @@
 # name: test_format_auto_applied_only
   '''
   test.py:
-    Auto-applied: ruff-format
+    Auto-applied:
+      ruff-format (exit 0)
   '''
 # ---
 # name: test_format_mixed_auto_apply_and_report
   '''
   test.py:
-    Auto-applied: ruff-format
+    Auto-applied:
+      ruff-format (exit 0)
     ruff-check (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -3,14 +3,16 @@
   '''
   test.py:
     Not auto-applied (would also edit): fixer (foo->bar)
-    checker (no BANNED) (exit 1)
+    Failed (not applied):
+      checker (no BANNED) (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
 # name: test_only_checker_fails
   '''
   test.py:
-    checker (no BANNED) (exit 1)
+    Failed (not applied):
+      checker (no BANNED) (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -1,10 +1,16 @@
 # serializer version: 1
+# name: test_binary_file_no_diff
+  '''
+  test.bin:
+    Not auto-applied (would also edit): binfixer
+  '''
+# ---
 # name: test_fixer_modifies_checker_fails
   '''
   test.py:
-    Not auto-applied (would also edit): fixer (foo->bar)
+    Not auto-applied (would also edit): fixer
     Failed (not applied):
-      checker (no BANNED) (exit 1)
+      checker (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
@@ -12,13 +18,7 @@
   '''
   test.py:
     Failed (not applied):
-      checker (no BANNED) (exit 1)
+      checker (exit 1)
   Run `pre-commit run --files test.py` to apply fixes.
-  '''
-# ---
-# name: test_binary_file_no_diff
-  '''
-  test.bin:
-    Not auto-applied (would also edit): binfixer
   '''
 # ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -16,3 +16,9 @@
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
+# name: test_binary_file_no_diff
+  '''
+  test.bin:
+    Not auto-applied (would also edit): binfixer
+  '''
+# ---

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
 # name: test_fixer_modifies_checker_fails
   '''
-  2 hooks failed on test.py:
-    fixer (foo->bar) (modified file)
+  Would also edit test.py: fixer (foo->bar)
+  1 hook failed on test.py:
     checker (no BANNED) (exit 1)
       test.py: contains BANNED keyword
   Changes pre-commit would make:

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -1,22 +1,16 @@
 # serializer version: 1
 # name: test_fixer_modifies_checker_fails
   '''
-  Would also edit test.py: fixer (foo->bar)
-  1 hook failed on test.py:
+  test.py:
+    Not auto-applied (would also edit): fixer (foo->bar)
     checker (no BANNED) (exit 1)
       test.py: contains BANNED keyword
-  Changes pre-commit would make:
-  --- 
-  +++ 
-  @@ -1 +1 @@
-  -foo = 1  # BANNED
-  +bar = 1  # BANNED
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
 # name: test_only_checker_fails
   '''
-  1 hook failed on test.py:
+  test.py:
     checker (no BANNED) (exit 1)
       test.py: contains BANNED keyword
   Run `pre-commit run --files test.py` to apply fixes.

--- a/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
+++ b/devinfra/claude/hook_daemon/__snapshots__/test_precommit_e2e.ambr
@@ -4,7 +4,6 @@
   test.py:
     Not auto-applied (would also edit): fixer (foo->bar)
     checker (no BANNED) (exit 1)
-      test.py: contains BANNED keyword
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---
@@ -12,7 +11,6 @@
   '''
   test.py:
     checker (no BANNED) (exit 1)
-      test.py: contains BANNED keyword
   Run `pre-commit run --files test.py` to apply fixes.
   '''
 # ---

--- a/devinfra/claude/hook_daemon/conftest.py
+++ b/devinfra/claude/hook_daemon/conftest.py
@@ -2,11 +2,13 @@
 
 import tempfile
 import uuid
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from pathlib import Path
+from typing import Any
 
 import pygit2
 import pytest
+import yaml
 
 from devinfra.claude.session_paths import SessionPaths
 
@@ -21,6 +23,12 @@ def init_git_repo(repo_path: Path) -> None:
     tree = repo.index.write_tree()
     sig = pygit2.Signature("Test", "test@test.com")
     repo.create_commit("HEAD", sig, sig, "init", tree, [])
+
+
+def write_precommit_config(repo_path: Path, hooks: Sequence[dict[str, Any]]) -> None:
+    """Write a .pre-commit-config.yaml with local system hooks."""
+    config = {"repos": [{"repo": "local", "hooks": list(hooks)}]}
+    (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(config))
 
 
 @pytest.fixture

--- a/devinfra/claude/hook_daemon/conftest.py
+++ b/devinfra/claude/hook_daemon/conftest.py
@@ -5,9 +5,22 @@ import uuid
 from collections.abc import Generator
 from pathlib import Path
 
+import pygit2
 import pytest
 
 from devinfra.claude.session_paths import SessionPaths
+
+
+def init_git_repo(repo_path: Path) -> None:
+    """Initialize a git repo at repo_path with all files committed."""
+    repo = pygit2.init_repository(str(repo_path))
+    repo.config["user.name"] = "Test"
+    repo.config["user.email"] = "test@test.com"
+    repo.index.add_all()
+    repo.index.write()
+    tree = repo.index.write_tree()
+    sig = pygit2.Signature("Test", "test@test.com")
+    repo.create_commit("HEAD", sig, sig, "init", tree, [])
 
 
 @pytest.fixture

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -44,12 +44,15 @@ def _find_git_root(start: Path) -> Path | None:
     return None
 
 
-def _format_check_result(result: RunResult, file_path: Path, *, show_report_diffs: bool = False) -> str:
+def _format_check_result(
+    result: RunResult, file_path: Path, *, show_report_diffs: bool = False, show_hook_output: bool = False
+) -> str:
     template = Template((_TEMPLATES_DIR / "post_tool_use.mako").read_text())
     output: str = template.render(
         auto_applied=result.auto_applied_results,
         failed=result.failed_hooks,
         diff_lines=result.report_only_diff if show_report_diffs else [],
+        show_hook_output=show_hook_output,
         file_name=file_path.name,
         file_path=file_path,
     )
@@ -72,6 +75,7 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
     pre_commit = config.pre_commit if config else None
     auto_apply_hooks = frozenset(pre_commit.auto_apply_hooks) if pre_commit else frozenset()
     show_report_diffs = pre_commit.show_report_diffs if pre_commit else False
+    show_hook_output = pre_commit.show_hook_output if pre_commit else False
 
     run_result = run_on_file(file_path, project_dir, auto_apply_hooks=auto_apply_hooks)
 
@@ -95,6 +99,8 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
 
     return PostToolUseOutput(
         hook_specific_output=PostToolUseHookSpecificOutput(
-            additional_context=_format_check_result(run_result, file_path, show_report_diffs=show_report_diffs)
+            additional_context=_format_check_result(
+                run_result, file_path, show_report_diffs=show_report_diffs, show_hook_output=show_hook_output
+            )
         )
     )

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -69,13 +69,13 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
     pre_commit = config.pre_commit
     run_result = run_on_file(file_path, project_dir, auto_apply_hooks=pre_commit.auto_apply_hooks)
 
-    for hr in run_result.hooks:
+    for hook_id, hr in run_result.hooks.items():
         if isinstance(hr, HookAutoApplied):
-            logger.info("hook %s auto-applied on %s (rerun exit %d)", hr.hook_name, file_path.name, hr.rerun_exit_code)
+            logger.info("hook %s auto-applied on %s (rerun exit %d)", hook_id, file_path.name, hr.rerun_exit_code)
         elif isinstance(hr, (HookWouldEdit, HookFailedNotApplied)):
             logger.info(
                 "hook %s on %s (exit_code=%d):\n%s",
-                hr.hook_name,
+                hook_id,
                 file_path.name,
                 hr.exit_code,
                 hr.output.decode(errors="replace"),

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -44,12 +44,12 @@ def _find_git_root(start: Path) -> Path | None:
     return None
 
 
-def _format_check_result(result: RunResult, file_path: Path) -> str:
+def _format_check_result(result: RunResult, file_path: Path, *, show_report_diffs: bool = False) -> str:
     template = Template((_TEMPLATES_DIR / "post_tool_use.mako").read_text())
     output: str = template.render(
         auto_applied=result.auto_applied_results,
         failed=result.failed_hooks,
-        diff_lines=result.report_only_diff,
+        diff_lines=result.report_only_diff if show_report_diffs else [],
         file_name=file_path.name,
         file_path=file_path,
     )
@@ -69,7 +69,9 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         return PostToolUseOutput()
 
     config = HookConfig.load_from_repo(project_dir)
-    auto_apply_hooks = frozenset(config.pre_commit.auto_apply_hooks) if config and config.pre_commit else frozenset()
+    pre_commit = config.pre_commit if config else None
+    auto_apply_hooks = frozenset(pre_commit.auto_apply_hooks) if pre_commit else frozenset()
+    show_report_diffs = pre_commit.show_report_diffs if pre_commit else False
 
     run_result = run_on_file(file_path, project_dir, auto_apply_hooks=auto_apply_hooks)
 
@@ -93,6 +95,6 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
 
     return PostToolUseOutput(
         hook_specific_output=PostToolUseHookSpecificOutput(
-            additional_context=_format_check_result(run_result, file_path)
+            additional_context=_format_check_result(run_result, file_path, show_report_diffs=show_report_diffs)
         )
     )

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -20,7 +20,13 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseOutput,
 )
 from devinfra.claude.hook_config import HookConfig, PreCommitConfig
-from devinfra.claude.hook_daemon.precommit_runner import RunResult, run_on_file
+from devinfra.claude.hook_daemon.precommit_runner import (
+    HookAutoApplied,
+    HookFailedNotApplied,
+    HookWouldEdit,
+    RunResult,
+    run_on_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,21 +70,18 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
     run_result = run_on_file(file_path, project_dir, auto_apply_hooks=pre_commit.auto_apply_hooks)
 
     for hr in run_result.hooks:
-        if hr.auto_applied:
-            logger.info("hook %s auto-applied on %s", hr.hook_name, file_path.name)
-        elif hr.passed:
-            logger.debug("hook %s passed on %s", hr.hook_name, file_path.name)
-        else:
+        if isinstance(hr, HookAutoApplied):
+            logger.info("hook %s auto-applied on %s (rerun exit %d)", hr.hook_name, file_path.name, hr.rerun_exit_code)
+        elif isinstance(hr, (HookWouldEdit, HookFailedNotApplied)):
             logger.info(
-                "hook %s failed on %s (exit_code=%d, files_modified=%s):\n%s",
+                "hook %s on %s (exit_code=%d):\n%s",
                 hr.hook_name,
                 file_path.name,
                 hr.exit_code,
-                hr.files_modified,
                 hr.output.decode(errors="replace"),
             )
 
-    if run_result.all_passed and not run_result.auto_applied_results:
+    if not run_result.has_issues:
         return PostToolUseOutput()
 
     return PostToolUseOutput(

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -18,7 +18,7 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
-from devinfra.claude.hook_config import HookConfig
+from devinfra.claude.hook_config import HookConfig, PreCommitConfig
 from devinfra.claude.hook_daemon.precommit_runner import RunResult, run_on_file
 
 logger = logging.getLogger(__name__)
@@ -44,18 +44,9 @@ def _find_git_root(start: Path) -> Path | None:
     return None
 
 
-def _format_check_result(
-    result: RunResult, file_path: Path, *, show_report_diffs: bool = False, show_hook_output: bool = False
-) -> str:
+def _format_check_result(result: RunResult, file_path: Path, pre_commit: PreCommitConfig) -> str:
     template = Template((_TEMPLATES_DIR / "post_tool_use.mako").read_text())
-    output: str = template.render(
-        auto_applied=result.auto_applied_results,
-        failed=result.failed_hooks,
-        diff_lines=result.report_only_diff if show_report_diffs else [],
-        show_hook_output=show_hook_output,
-        file_name=file_path.name,
-        file_path=file_path,
-    )
+    output: str = template.render(result=result, file_path=file_path, pre_commit=pre_commit)
     return output.strip()
 
 
@@ -72,12 +63,11 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         return PostToolUseOutput()
 
     config = HookConfig.load_from_repo(project_dir)
-    pre_commit = config.pre_commit if config else None
-    auto_apply_hooks = frozenset(pre_commit.auto_apply_hooks) if pre_commit else frozenset()
-    show_report_diffs = pre_commit.show_report_diffs if pre_commit else False
-    show_hook_output = pre_commit.show_hook_output if pre_commit else False
+    if not config or not config.pre_commit:
+        return PostToolUseOutput()
 
-    run_result = run_on_file(file_path, project_dir, auto_apply_hooks=auto_apply_hooks)
+    pre_commit = config.pre_commit
+    run_result = run_on_file(file_path, project_dir, auto_apply_hooks=frozenset(pre_commit.auto_apply_hooks))
 
     for hr in run_result.hooks:
         if hr.auto_applied:
@@ -99,8 +89,6 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
 
     return PostToolUseOutput(
         hook_specific_output=PostToolUseHookSpecificOutput(
-            additional_context=_format_check_result(
-                run_result, file_path, show_report_diffs=show_report_diffs, show_hook_output=show_hook_output
-            )
+            additional_context=_format_check_result(run_result, file_path, pre_commit)
         )
     )

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -61,7 +61,7 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
         return PostToolUseOutput()
 
     pre_commit = config.pre_commit
-    run_result = run_on_file(file_path, project_dir, auto_apply_hooks=frozenset(pre_commit.auto_apply_hooks))
+    run_result = run_on_file(file_path, project_dir, auto_apply_hooks=pre_commit.auto_apply_hooks)
 
     for hr in run_result.hooks:
         if hr.auto_applied:

--- a/devinfra/claude/hook_daemon/post_tool_use.py
+++ b/devinfra/claude/hook_daemon/post_tool_use.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import pygit2
 from mako.template import Template
 
 from devinfra.claude.claude_api.hooks.post_tool_use import (
@@ -35,15 +36,6 @@ def _get_file_path(tool_input: dict[str, Any]) -> Path | None:
     return Path(file_path)
 
 
-def _find_git_root(start: Path) -> Path | None:
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if (current / ".git").exists():
-            return current
-        current = current.parent
-    return None
-
-
 def _format_check_result(result: RunResult, file_path: Path, pre_commit: PreCommitConfig) -> str:
     template = Template((_TEMPLATES_DIR / "post_tool_use.mako").read_text())
     output: str = template.render(result=result, file_path=file_path, pre_commit=pre_commit)
@@ -58,9 +50,11 @@ def evaluate(hook_input: PostToolUseInput) -> PostToolUseOutput:
     if file_path is None or not file_path.exists():
         return PostToolUseOutput()
 
-    project_dir = _find_git_root(file_path)
-    if project_dir is None:
+    search_dir = str(file_path.parent if file_path.is_file() else file_path)
+    git_path = pygit2.discover_repository(search_dir)
+    if git_path is None:
         return PostToolUseOutput()
+    project_dir = Path(pygit2.Repository(git_path).workdir).resolve()
 
     config = HookConfig.load_from_repo(project_dir)
     if not config or not config.pre_commit:

--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -44,6 +44,7 @@ class HookResult:
     files_modified: bool
     exit_code: int
     auto_applied: bool = False
+    rerun_exit_code: int | None = None
 
     @property
     def passed(self) -> bool:
@@ -110,22 +111,32 @@ def _run_hooks(
 
     results: list[HookResult] = []
 
-    # Phase 1: auto-apply hooks — keep their changes.
+    # Phase 1: auto-apply hooks — keep their changes, re-run to verify satisfaction.
     for hook, filenames in auto_hooks:
         content_before = file_path.read_bytes()
         language = languages[hook.language]
+        run_kwargs = {
+            "prefix": hook.prefix,
+            "entry": hook.entry,
+            "args": hook.args,
+            "file_args": filenames if hook.pass_filenames else (),
+            "is_local": hook.src == "local",
+            "require_serial": hook.require_serial,
+            "color": False,
+        }
         with language.in_env(hook.prefix, hook.language_version):
-            retcode, out = language.run_hook(
-                hook.prefix,
-                hook.entry,
-                hook.args,
-                filenames if hook.pass_filenames else (),
-                is_local=hook.src == "local",
-                require_serial=hook.require_serial,
-                color=False,
-            )
+            retcode, out = language.run_hook(**run_kwargs)
         current = file_path.read_bytes()
         modified = current != content_before
+
+        # Re-run to check if the hook is now satisfied after auto-apply.
+        rerun_retcode = None
+        if modified:
+            with language.in_env(hook.prefix, hook.language_version):
+                rerun_retcode, _ = language.run_hook(**run_kwargs)
+            rerun_content = file_path.read_bytes()
+            if rerun_content != current:
+                file_path.write_bytes(current)
         results.append(
             HookResult(
                 hook_id=hook.id,
@@ -134,6 +145,7 @@ def _run_hooks(
                 files_modified=modified,
                 exit_code=retcode,
                 auto_applied=modified,
+                rerun_exit_code=rerun_retcode if modified else None,
             )
         )
 

--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -11,7 +11,7 @@ import contextlib
 import difflib
 import logging
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -71,7 +71,7 @@ class RunResult:
 
 
 def _run_hooks(
-    file_path: Path, project_dir: Path, auto_apply_hooks: frozenset[str] = frozenset()
+    file_path: Path, project_dir: Path, auto_apply_hooks: Iterable[str] = ()
 ) -> tuple[list[HookResult], list[str]]:
     """Run all applicable pre-commit hooks on a single file.
 
@@ -82,6 +82,7 @@ def _run_hooks(
 
     Returns (hook_results, report_only_diff_lines).
     """
+    auto_apply = set(auto_apply_hooks)
     config_path = project_dir / CONFIG_FILE
 
     store = Store()
@@ -102,7 +103,7 @@ def _run_hooks(
         filenames = tuple(classifier.filenames_for_hook(hook))
         if not filenames and not hook.always_run:
             continue
-        if hook.id in auto_apply_hooks:
+        if hook.id in auto_apply:
             auto_hooks.append((hook, filenames))
         else:
             report_hooks.append((hook, filenames))
@@ -169,7 +170,7 @@ def _run_hooks(
     return results, diff_lines
 
 
-def run_on_file(file_path: Path, project_dir: Path, auto_apply_hooks: frozenset[str] = frozenset()) -> RunResult:
+def run_on_file(file_path: Path, project_dir: Path, auto_apply_hooks: Iterable[str] = ()) -> RunResult:
     """Run pre-commit hooks on a single file using the Python API.
 
     Auto-apply hooks keep their modifications on disk. All other hooks'

--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -139,51 +139,11 @@ def _run_hooks(
         else:
             report_hooks.append((hook, filenames))
 
-    results: list[HookOutcome] = []
-
-    # Phase 1: auto-apply hooks — keep their changes, re-run to verify satisfaction.
-    for hook, filenames in auto_hooks:
-        content_before = file_path.read_bytes()
-        language = languages[hook.language]
-        run_kwargs = {
-            "prefix": hook.prefix,
-            "entry": hook.entry,
-            "args": hook.args,
-            "file_args": filenames if hook.pass_filenames else (),
-            "is_local": hook.src == "local",
-            "require_serial": hook.require_serial,
-            "color": False,
-        }
-        with language.in_env(hook.prefix, hook.language_version):
-            retcode, out = language.run_hook(**run_kwargs)
-        current = file_path.read_bytes()
-        modified = current != content_before
-
-        if modified:
-            # Re-run to check if the hook is now satisfied after auto-apply.
-            with language.in_env(hook.prefix, hook.language_version):
-                rerun_retcode, _ = language.run_hook(**run_kwargs)
-            rerun_content = file_path.read_bytes()
-            if rerun_content != current:
-                file_path.write_bytes(current)
-            results.append(
-                HookAutoApplied(
-                    hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out, rerun_exit_code=rerun_retcode
-                )
-            )
-        elif retcode == 0:
-            results.append(HookPassed(hook_id=hook.id, hook_name=hook.name))
-        else:
-            # Auto-apply hook failed without modifying — treat as failed-not-applied.
-            results.append(HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
-
-    # Phase 2: report-only hooks — capture diff, then revert.
-    baseline = file_path.read_bytes()
-    for hook, filenames in report_hooks:
-        content_before = file_path.read_bytes()
+    def run_hook(hook, filenames) -> tuple[int, bytes]:
+        """Run a single pre-commit hook, returning (exit_code, output)."""
         language = languages[hook.language]
         with language.in_env(hook.prefix, hook.language_version):
-            retcode, out = language.run_hook(
+            return language.run_hook(
                 hook.prefix,
                 hook.entry,
                 hook.args,
@@ -192,23 +152,57 @@ def _run_hooks(
                 require_serial=hook.require_serial,
                 color=False,
             )
+
+    def classify_report_only(hook, retcode: int, out: bytes, modified: bool) -> HookOutcome:
+        if modified:
+            return HookWouldEdit(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out)
+        if retcode == 0:
+            return HookPassed(hook_id=hook.id, hook_name=hook.name)
+        return HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out)
+
+    results: list[HookOutcome] = []
+
+    # Phase 1: auto-apply hooks — keep their changes, re-run to verify satisfaction.
+    for hook, filenames in auto_hooks:
+        content_before = file_path.read_bytes()
+        retcode, out = run_hook(hook, filenames)
         current = file_path.read_bytes()
         modified = current != content_before
 
         if modified:
-            results.append(HookWouldEdit(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
-        elif retcode == 0:
-            results.append(HookPassed(hook_id=hook.id, hook_name=hook.name))
+            rerun_retcode, _ = run_hook(hook, filenames)
+            rerun_content = file_path.read_bytes()
+            if rerun_content != current:
+                file_path.write_bytes(current)
+            results.append(
+                HookAutoApplied(
+                    hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out, rerun_exit_code=rerun_retcode
+                )
+            )
         else:
-            results.append(HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
+            results.append(classify_report_only(hook, retcode, out, modified=False))
+
+    # Phase 2: report-only hooks — capture diff, then revert.
+    baseline = file_path.read_bytes()
+    for hook, filenames in report_hooks:
+        content_before = file_path.read_bytes()
+        retcode, out = run_hook(hook, filenames)
+        current = file_path.read_bytes()
+        results.append(classify_report_only(hook, retcode, out, modified=current != content_before))
 
     # Compute diff of what report-only hooks would change, then revert.
     after_all = file_path.read_bytes()
     diff_lines: list[str] = []
     if after_all != baseline:
-        baseline_lines = baseline.decode(errors="replace").splitlines(keepends=True)
-        after_lines = after_all.decode(errors="replace").splitlines(keepends=True)
-        diff_lines = list(difflib.unified_diff(baseline_lines, after_lines))
+        # Skip diff for binary files (non-UTF-8).
+        try:
+            baseline_text = baseline.decode()
+            after_text = after_all.decode()
+            diff_lines = list(
+                difflib.unified_diff(baseline_text.splitlines(keepends=True), after_text.splitlines(keepends=True))
+            )
+        except UnicodeDecodeError:
+            pass
         file_path.write_bytes(baseline)
 
     return results, diff_lines

--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -40,16 +40,11 @@ def _chdir(path: Path) -> Generator[None]:
 class HookPassed:
     """Hook ran clean — exit 0, no file modifications."""
 
-    hook_id: str
-    hook_name: str
-
 
 @dataclass(frozen=True)
 class HookAutoApplied:
     """Hook modified the file; changes kept on disk. Re-run verified satisfaction."""
 
-    hook_id: str
-    hook_name: str
     exit_code: int
     output: bytes
     rerun_exit_code: int
@@ -59,8 +54,6 @@ class HookAutoApplied:
 class HookWouldEdit:
     """Report-only hook that would modify the file (changes reverted)."""
 
-    hook_id: str
-    hook_name: str
     exit_code: int
     output: bytes
 
@@ -69,8 +62,6 @@ class HookWouldEdit:
 class HookFailedNotApplied:
     """Report-only hook that exited non-zero without modifying the file."""
 
-    hook_id: str
-    hook_name: str
     exit_code: int
     output: bytes
 
@@ -80,20 +71,20 @@ HookOutcome = HookPassed | HookAutoApplied | HookWouldEdit | HookFailedNotApplie
 
 @dataclass
 class RunResult:
-    hooks: list[HookOutcome] = field(default_factory=list)
+    hooks: dict[str, HookOutcome] = field(default_factory=dict)
     report_only_diff: list[str] = field(default_factory=list)
 
     @property
-    def auto_applied(self) -> list[HookAutoApplied]:
-        return [h for h in self.hooks if isinstance(h, HookAutoApplied)]
+    def auto_applied(self) -> dict[str, HookAutoApplied]:
+        return {k: h for k, h in self.hooks.items() if isinstance(h, HookAutoApplied)}
 
     @property
-    def would_edit(self) -> list[HookWouldEdit]:
-        return [h for h in self.hooks if isinstance(h, HookWouldEdit)]
+    def would_edit(self) -> dict[str, HookWouldEdit]:
+        return {k: h for k, h in self.hooks.items() if isinstance(h, HookWouldEdit)}
 
     @property
-    def failed_not_applied(self) -> list[HookFailedNotApplied]:
-        return [h for h in self.hooks if isinstance(h, HookFailedNotApplied)]
+    def failed_not_applied(self) -> dict[str, HookFailedNotApplied]:
+        return {k: h for k, h in self.hooks.items() if isinstance(h, HookFailedNotApplied)}
 
     @property
     def has_issues(self) -> bool:
@@ -153,14 +144,14 @@ def _run_hooks(
                 color=False,
             )
 
-    def classify_report_only(hook, retcode: int, out: bytes, modified: bool) -> HookOutcome:
+    def classify_report_only(retcode: int, out: bytes, *, modified: bool) -> HookOutcome:
         if modified:
-            return HookWouldEdit(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out)
+            return HookWouldEdit(exit_code=retcode, output=out)
         if retcode == 0:
-            return HookPassed(hook_id=hook.id, hook_name=hook.name)
-        return HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out)
+            return HookPassed()
+        return HookFailedNotApplied(exit_code=retcode, output=out)
 
-    results: list[HookOutcome] = []
+    results: dict[str, HookOutcome] = {}
 
     # Phase 1: auto-apply hooks — keep their changes, re-run to verify satisfaction.
     for hook, filenames in auto_hooks:
@@ -169,26 +160,24 @@ def _run_hooks(
         current = file_path.read_bytes()
         modified = current != content_before
 
+        assert hook.id not in results, f"Duplicate hook ID: {hook.id}"
         if modified:
             rerun_retcode, _ = run_hook(hook, filenames)
             rerun_content = file_path.read_bytes()
             if rerun_content != current:
                 file_path.write_bytes(current)
-            results.append(
-                HookAutoApplied(
-                    hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out, rerun_exit_code=rerun_retcode
-                )
-            )
+            results[hook.id] = HookAutoApplied(exit_code=retcode, output=out, rerun_exit_code=rerun_retcode)
         else:
-            results.append(classify_report_only(hook, retcode, out, modified=False))
+            results[hook.id] = classify_report_only(retcode, out, modified=False)
 
     # Phase 2: report-only hooks — capture diff, then revert.
     baseline = file_path.read_bytes()
     for hook, filenames in report_hooks:
+        assert hook.id not in results, f"Duplicate hook ID: {hook.id}"
         content_before = file_path.read_bytes()
         retcode, out = run_hook(hook, filenames)
         current = file_path.read_bytes()
-        results.append(classify_report_only(hook, retcode, out, modified=current != content_before))
+        results[hook.id] = classify_report_only(retcode, out, modified=current != content_before)
 
     # Compute diff of what report-only hooks would change, then revert.
     after_all = file_path.read_bytes()

--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -36,44 +36,74 @@ def _chdir(path: Path) -> Generator[None]:
         os.chdir(saved)
 
 
-@dataclass
-class HookResult:
+@dataclass(frozen=True)
+class HookPassed:
+    """Hook ran clean — exit 0, no file modifications."""
+
     hook_id: str
     hook_name: str
-    output: bytes
-    files_modified: bool
-    exit_code: int
-    auto_applied: bool = False
-    rerun_exit_code: int | None = None
 
-    @property
-    def passed(self) -> bool:
-        return self.exit_code == 0 and not self.files_modified
+
+@dataclass(frozen=True)
+class HookAutoApplied:
+    """Hook modified the file; changes kept on disk. Re-run verified satisfaction."""
+
+    hook_id: str
+    hook_name: str
+    exit_code: int
+    output: bytes
+    rerun_exit_code: int
+
+
+@dataclass(frozen=True)
+class HookWouldEdit:
+    """Report-only hook that would modify the file (changes reverted)."""
+
+    hook_id: str
+    hook_name: str
+    exit_code: int
+    output: bytes
+
+
+@dataclass(frozen=True)
+class HookFailedNotApplied:
+    """Report-only hook that exited non-zero without modifying the file."""
+
+    hook_id: str
+    hook_name: str
+    exit_code: int
+    output: bytes
+
+
+HookOutcome = HookPassed | HookAutoApplied | HookWouldEdit | HookFailedNotApplied
 
 
 @dataclass
 class RunResult:
-    hooks: list[HookResult] = field(default_factory=list)
+    hooks: list[HookOutcome] = field(default_factory=list)
     report_only_diff: list[str] = field(default_factory=list)
 
     @property
-    def failed_hooks(self) -> list[HookResult]:
-        """Hooks that failed and were NOT auto-applied."""
-        return [h for h in self.hooks if not h.passed and not h.auto_applied]
+    def auto_applied(self) -> list[HookAutoApplied]:
+        return [h for h in self.hooks if isinstance(h, HookAutoApplied)]
 
     @property
-    def auto_applied_results(self) -> list[HookResult]:
-        return [h for h in self.hooks if h.auto_applied]
+    def would_edit(self) -> list[HookWouldEdit]:
+        return [h for h in self.hooks if isinstance(h, HookWouldEdit)]
 
     @property
-    def all_passed(self) -> bool:
-        """True when all hooks either passed or were auto-applied."""
-        return all(h.passed or h.auto_applied for h in self.hooks)
+    def failed_not_applied(self) -> list[HookFailedNotApplied]:
+        return [h for h in self.hooks if isinstance(h, HookFailedNotApplied)]
+
+    @property
+    def has_issues(self) -> bool:
+        """True when any hook has something to report (auto-applied, would-edit, or failed)."""
+        return bool(self.auto_applied or self.would_edit or self.failed_not_applied)
 
 
 def _run_hooks(
     file_path: Path, project_dir: Path, auto_apply_hooks: Iterable[str] = ()
-) -> tuple[list[HookResult], list[str]]:
+) -> tuple[list[HookOutcome], list[str]]:
     """Run all applicable pre-commit hooks on a single file.
 
     Two-phase execution:
@@ -109,7 +139,7 @@ def _run_hooks(
         else:
             report_hooks.append((hook, filenames))
 
-    results: list[HookResult] = []
+    results: list[HookOutcome] = []
 
     # Phase 1: auto-apply hooks — keep their changes, re-run to verify satisfaction.
     for hook, filenames in auto_hooks:
@@ -129,25 +159,23 @@ def _run_hooks(
         current = file_path.read_bytes()
         modified = current != content_before
 
-        # Re-run to check if the hook is now satisfied after auto-apply.
-        rerun_retcode = None
         if modified:
+            # Re-run to check if the hook is now satisfied after auto-apply.
             with language.in_env(hook.prefix, hook.language_version):
                 rerun_retcode, _ = language.run_hook(**run_kwargs)
             rerun_content = file_path.read_bytes()
             if rerun_content != current:
                 file_path.write_bytes(current)
-        results.append(
-            HookResult(
-                hook_id=hook.id,
-                hook_name=hook.name,
-                output=out,
-                files_modified=modified,
-                exit_code=retcode,
-                auto_applied=modified,
-                rerun_exit_code=rerun_retcode if modified else None,
+            results.append(
+                HookAutoApplied(
+                    hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out, rerun_exit_code=rerun_retcode
+                )
             )
-        )
+        elif retcode == 0:
+            results.append(HookPassed(hook_id=hook.id, hook_name=hook.name))
+        else:
+            # Auto-apply hook failed without modifying — treat as failed-not-applied.
+            results.append(HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
 
     # Phase 2: report-only hooks — capture diff, then revert.
     baseline = file_path.read_bytes()
@@ -166,9 +194,13 @@ def _run_hooks(
             )
         current = file_path.read_bytes()
         modified = current != content_before
-        results.append(
-            HookResult(hook_id=hook.id, hook_name=hook.name, output=out, files_modified=modified, exit_code=retcode)
-        )
+
+        if modified:
+            results.append(HookWouldEdit(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
+        elif retcode == 0:
+            results.append(HookPassed(hook_id=hook.id, hook_name=hook.name))
+        else:
+            results.append(HookFailedNotApplied(hook_id=hook.id, hook_name=hook.name, exit_code=retcode, output=out))
 
     # Compute diff of what report-only hooks would change, then revert.
     after_all = file_path.read_bytes()

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 import pytest_bazel
+import yaml
 from syrupy.assertion import SnapshotAssertion
 
 from devinfra.claude.claude_api.hooks.post_tool_use import (
@@ -12,8 +13,9 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
-from devinfra.claude.hook_config import PreCommitConfig
-from devinfra.claude.hook_daemon.post_tool_use import _find_git_root, _format_check_result, evaluate
+from devinfra.claude.hook_config import HookConfig, PreCommitConfig
+from devinfra.claude.hook_daemon.conftest import init_git_repo
+from devinfra.claude.hook_daemon.post_tool_use import _format_check_result, evaluate
 from devinfra.claude.hook_daemon.precommit_runner import HookResult, RunResult
 
 _COMMON = {
@@ -32,13 +34,16 @@ _DEFAULT_PRE_COMMIT = PreCommitConfig(auto_apply_hooks=set())
 @pytest.fixture
 def git_project(tmp_path: Path) -> tuple[Path, Path]:
     """Create a tmp git project with .claude_hooks config and a test file."""
-    (tmp_path / ".git").mkdir()
-    hooks_dir = tmp_path / ".claude_hooks"
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    config = HookConfig(pre_commit=PreCommitConfig(auto_apply_hooks=set()))
+    hooks_dir = repo_path / ".claude_hooks"
     hooks_dir.mkdir()
-    (hooks_dir / "config.yaml").write_text("pre_commit:\n  auto_apply_hooks: []\n")
-    test_file = tmp_path / "test.py"
+    (hooks_dir / "config.yaml").write_text(yaml.dump(config.model_dump(exclude_none=True)))
+    test_file = repo_path / "test.py"
     test_file.write_bytes(b"x=1\n")
-    return tmp_path, test_file
+    init_git_repo(repo_path)
+    return repo_path, test_file
 
 
 # === Guard tests ===
@@ -60,20 +65,6 @@ def test_nonexistent_file_returns_default() -> None:
     inp = PostToolUseInput(**_COMMON, tool_name="Edit", tool_input={"file_path": "/nonexistent/file.py"})
     result = evaluate(inp)
     assert result.hook_specific_output is None
-
-
-# === Git root tests ===
-
-
-def test_find_git_root(tmp_path: Path) -> None:
-    (tmp_path / ".git").mkdir()
-    subdir = tmp_path / "a" / "b"
-    subdir.mkdir(parents=True)
-    assert _find_git_root(subdir / "file.py") == tmp_path
-
-
-def test_find_git_root_no_git(tmp_path: Path) -> None:
-    assert _find_git_root(tmp_path / "file.py") is None
 
 
 # === Serialization tests ===

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -28,18 +28,16 @@ _COMMON = {
     "tool_response": "",
 }
 
-_DEFAULT_PRE_COMMIT = PreCommitConfig(auto_apply_hooks=set())
-
 
 @pytest.fixture
 def git_project(tmp_path: Path) -> tuple[Path, Path]:
     """Create a tmp git project with .claude_hooks config and a test file."""
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
-    config = HookConfig(pre_commit=PreCommitConfig(auto_apply_hooks=set()))
+    config = HookConfig(pre_commit=PreCommitConfig())
     hooks_dir = repo_path / ".claude_hooks"
     hooks_dir.mkdir()
-    (hooks_dir / "config.yaml").write_text(yaml.dump(config.model_dump(exclude_none=True)))
+    (hooks_dir / "config.yaml").write_text(yaml.dump(config.model_dump(mode="json", exclude_none=True)))
     test_file = repo_path / "test.py"
     test_file.write_bytes(b"x=1\n")
     init_git_repo(repo_path)
@@ -98,14 +96,14 @@ def test_format_report_only_failure(snapshot: SnapshotAssertion) -> None:
             HookResult(hook_id="ruff", hook_name="ruff-format", output=b"bad indent", files_modified=True, exit_code=1)
         ]
     )
-    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
+    assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_non_zero_exit(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
         hooks=[HookResult(hook_id="mypy", hook_name="mypy", output=b"type error", files_modified=False, exit_code=1)]
     )
-    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
+    assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
@@ -121,7 +119,7 @@ def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
             )
         ]
     )
-    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
+    assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None:
@@ -144,7 +142,7 @@ def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None
             ),
         ]
     )
-    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
+    assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_with_diff(snapshot: SnapshotAssertion) -> None:

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -221,7 +221,8 @@ def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context
     assert ctx is not None
-    assert "ruff-format (modified file)" in ctx
+    assert "Would also edit" in ctx
+    assert "ruff-format" in ctx
 
 
 def test_precommit_passes(git_project: tuple[Path, Path]) -> None:

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -155,7 +155,7 @@ def test_format_with_diff(snapshot: SnapshotAssertion) -> None:
         hooks=[HookResult(hook_id="fixer", hook_name="fixer", output=b"fixed", files_modified=True, exit_code=1)],
         report_only_diff=["@@ -1 +1 @@\n", "-x=1\n", "+x = 1\n"],
     )
-    assert _format_check_result(result, Path("test.py")) == snapshot
+    assert _format_check_result(result, Path("test.py"), show_report_diffs=True) == snapshot
 
 
 # === RunResult property tests ===
@@ -221,7 +221,7 @@ def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context
     assert ctx is not None
-    assert "Would also edit" in ctx
+    assert "Not auto-applied" in ctx
     assert "ruff-format" in ctx
 
 

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -12,6 +12,7 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
     PostToolUseInput,
     PostToolUseOutput,
 )
+from devinfra.claude.hook_config import PreCommitConfig
 from devinfra.claude.hook_daemon.post_tool_use import _find_git_root, _format_check_result, evaluate
 from devinfra.claude.hook_daemon.precommit_runner import HookResult, RunResult
 
@@ -25,11 +26,16 @@ _COMMON = {
     "tool_response": "",
 }
 
+_DEFAULT_PRE_COMMIT = PreCommitConfig(auto_apply_hooks=set())
+
 
 @pytest.fixture
 def git_project(tmp_path: Path) -> tuple[Path, Path]:
-    """Create a tmp git project with a test file, return (project_dir, test_file)."""
+    """Create a tmp git project with .claude_hooks config and a test file."""
     (tmp_path / ".git").mkdir()
+    hooks_dir = tmp_path / ".claude_hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "config.yaml").write_text("pre_commit:\n  auto_apply_hooks: []\n")
     test_file = tmp_path / "test.py"
     test_file.write_bytes(b"x=1\n")
     return tmp_path, test_file
@@ -101,14 +107,14 @@ def test_format_report_only_failure(snapshot: SnapshotAssertion) -> None:
             HookResult(hook_id="ruff", hook_name="ruff-format", output=b"bad indent", files_modified=True, exit_code=1)
         ]
     )
-    assert _format_check_result(result, Path("test.py")) == snapshot
+    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
 
 
 def test_format_non_zero_exit(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
         hooks=[HookResult(hook_id="mypy", hook_name="mypy", output=b"type error", files_modified=False, exit_code=1)]
     )
-    assert _format_check_result(result, Path("test.py")) == snapshot
+    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
 
 
 def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
@@ -124,7 +130,7 @@ def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
             )
         ]
     )
-    assert _format_check_result(result, Path("test.py")) == snapshot
+    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
 
 
 def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None:
@@ -147,7 +153,7 @@ def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None
             ),
         ]
     )
-    assert _format_check_result(result, Path("test.py")) == snapshot
+    assert _format_check_result(result, Path("test.py"), _DEFAULT_PRE_COMMIT) == snapshot
 
 
 def test_format_with_diff(snapshot: SnapshotAssertion) -> None:
@@ -155,7 +161,8 @@ def test_format_with_diff(snapshot: SnapshotAssertion) -> None:
         hooks=[HookResult(hook_id="fixer", hook_name="fixer", output=b"fixed", files_modified=True, exit_code=1)],
         report_only_diff=["@@ -1 +1 @@\n", "-x=1\n", "+x = 1\n"],
     )
-    assert _format_check_result(result, Path("test.py"), show_report_diffs=True) == snapshot
+    pre_commit = PreCommitConfig(auto_apply_hooks=set(), show_report_diffs=True)
+    assert _format_check_result(result, Path("test.py"), pre_commit) == snapshot
 
 
 # === RunResult property tests ===

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -91,83 +91,62 @@ def test_stop_reason_with_continue_false() -> None:
 
 
 def test_format_report_only_failure(snapshot: SnapshotAssertion) -> None:
-    result = RunResult(
-        hooks=[HookWouldEdit(hook_id="ruff", hook_name="ruff-format", output=b"bad indent", exit_code=1)]
-    )
+    result = RunResult(hooks={"ruff": HookWouldEdit(output=b"bad indent", exit_code=1)})
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_non_zero_exit(snapshot: SnapshotAssertion) -> None:
-    result = RunResult(
-        hooks=[HookFailedNotApplied(hook_id="mypy", hook_name="mypy", output=b"type error", exit_code=1)]
-    )
+    result = RunResult(hooks={"mypy": HookFailedNotApplied(output=b"type error", exit_code=1)})
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[
-            HookAutoApplied(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"1 file reformatted",
-                exit_code=0,
-                rerun_exit_code=0,
-            )
-        ]
+        hooks={"ruff-format": HookAutoApplied(output=b"1 file reformatted", exit_code=0, rerun_exit_code=0)}
     )
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[
-            HookAutoApplied(
-                hook_id="ruff-format", hook_name="ruff-format", output=b"reformatted", exit_code=0, rerun_exit_code=0
-            ),
-            HookFailedNotApplied(
-                hook_id="ruff-check", hook_name="ruff-check", output=b"F401 unused import", exit_code=1
-            ),
-        ]
+        hooks={
+            "ruff-format": HookAutoApplied(output=b"reformatted", exit_code=0, rerun_exit_code=0),
+            "ruff-check": HookFailedNotApplied(output=b"F401 unused import", exit_code=1),
+        }
     )
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_with_diff(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[HookWouldEdit(hook_id="fixer", hook_name="fixer", output=b"fixed", exit_code=1)],
+        hooks={"fixer": HookWouldEdit(output=b"fixed", exit_code=1)},
         report_only_diff=["@@ -1 +1 @@\n", "-x=1\n", "+x = 1\n"],
     )
-    pre_commit = PreCommitConfig(show_report_diffs=True)
-    assert _format_check_result(result, Path("test.py"), pre_commit) == snapshot
+    assert _format_check_result(result, Path("test.py"), PreCommitConfig(show_report_diffs=True)) == snapshot
 
 
 # === RunResult property tests ===
 
 
 def test_run_result_has_issues_false_when_all_passed() -> None:
-    result = RunResult(hooks=[])
+    result = RunResult(hooks={})
     assert not result.has_issues
 
 
 def test_run_result_has_issues_with_auto_applied() -> None:
-    result = RunResult(
-        hooks=[
-            HookAutoApplied(hook_id="ruff-format", hook_name="ruff-format", output=b"", exit_code=0, rerun_exit_code=0)
-        ]
-    )
+    result = RunResult(hooks={"ruff-format": HookAutoApplied(output=b"", exit_code=0, rerun_exit_code=0)})
     assert result.has_issues
 
 
 def test_run_result_failed_not_applied_excludes_auto_applied() -> None:
     result = RunResult(
-        hooks=[
-            HookAutoApplied(hook_id="ruff-format", hook_name="ruff-format", output=b"", exit_code=0, rerun_exit_code=0),
-            HookFailedNotApplied(hook_id="ruff-check", hook_name="ruff-check", output=b"err", exit_code=1),
-        ]
+        hooks={
+            "ruff-format": HookAutoApplied(output=b"", exit_code=0, rerun_exit_code=0),
+            "ruff-check": HookFailedNotApplied(output=b"err", exit_code=1),
+        }
     )
     assert len(result.failed_not_applied) == 1
-    assert result.failed_not_applied[0].hook_id == "ruff-check"
+    assert "ruff-check" in result.failed_not_applied
 
 
 # === Integration tests (mocked run_on_file) ===
@@ -176,9 +155,7 @@ def test_run_result_failed_not_applied_excludes_auto_applied() -> None:
 def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
     _, test_file = git_project
 
-    fake_result = RunResult(
-        hooks=[HookWouldEdit(hook_id="ruff-format", hook_name="ruff-format", output=b"modified", exit_code=0)]
-    )
+    fake_result = RunResult(hooks={"ruff-format": HookWouldEdit(output=b"modified", exit_code=0)})
 
     with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=fake_result):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
@@ -194,9 +171,7 @@ def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
 def test_precommit_passes(git_project: tuple[Path, Path]) -> None:
     _, test_file = git_project
 
-    fake_result = RunResult(hooks=[])
-
-    with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=fake_result):
+    with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=RunResult()):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
         result = evaluate(inp)
 
@@ -217,15 +192,7 @@ def test_auto_applied_only_returns_context(git_project: tuple[Path, Path]) -> No
     _, test_file = git_project
 
     fake_result = RunResult(
-        hooks=[
-            HookAutoApplied(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"1 file reformatted",
-                exit_code=0,
-                rerun_exit_code=0,
-            )
-        ]
+        hooks={"ruff-format": HookAutoApplied(output=b"1 file reformatted", exit_code=0, rerun_exit_code=0)}
     )
 
     with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=fake_result):

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -16,7 +16,7 @@ from devinfra.claude.claude_api.hooks.post_tool_use import (
 from devinfra.claude.hook_config import HookConfig, PreCommitConfig
 from devinfra.claude.hook_daemon.conftest import init_git_repo
 from devinfra.claude.hook_daemon.post_tool_use import _format_check_result, evaluate
-from devinfra.claude.hook_daemon.precommit_runner import HookResult, RunResult
+from devinfra.claude.hook_daemon.precommit_runner import HookAutoApplied, HookFailedNotApplied, HookWouldEdit, RunResult
 
 _COMMON = {
     "session_id": "test-session",
@@ -92,16 +92,14 @@ def test_stop_reason_with_continue_false() -> None:
 
 def test_format_report_only_failure(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[
-            HookResult(hook_id="ruff", hook_name="ruff-format", output=b"bad indent", files_modified=True, exit_code=1)
-        ]
+        hooks=[HookWouldEdit(hook_id="ruff", hook_name="ruff-format", output=b"bad indent", exit_code=1)]
     )
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
 
 def test_format_non_zero_exit(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[HookResult(hook_id="mypy", hook_name="mypy", output=b"type error", files_modified=False, exit_code=1)]
+        hooks=[HookFailedNotApplied(hook_id="mypy", hook_name="mypy", output=b"type error", exit_code=1)]
     )
     assert _format_check_result(result, Path("test.py"), PreCommitConfig()) == snapshot
 
@@ -109,13 +107,12 @@ def test_format_non_zero_exit(snapshot: SnapshotAssertion) -> None:
 def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
         hooks=[
-            HookResult(
+            HookAutoApplied(
                 hook_id="ruff-format",
                 hook_name="ruff-format",
                 output=b"1 file reformatted",
-                files_modified=True,
                 exit_code=0,
-                auto_applied=True,
+                rerun_exit_code=0,
             )
         ]
     )
@@ -125,20 +122,11 @@ def test_format_auto_applied_only(snapshot: SnapshotAssertion) -> None:
 def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
         hooks=[
-            HookResult(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"reformatted",
-                files_modified=True,
-                exit_code=0,
-                auto_applied=True,
+            HookAutoApplied(
+                hook_id="ruff-format", hook_name="ruff-format", output=b"reformatted", exit_code=0, rerun_exit_code=0
             ),
-            HookResult(
-                hook_id="ruff-check",
-                hook_name="ruff-check",
-                output=b"F401 unused import",
-                files_modified=False,
-                exit_code=1,
+            HookFailedNotApplied(
+                hook_id="ruff-check", hook_name="ruff-check", output=b"F401 unused import", exit_code=1
             ),
         ]
     )
@@ -147,49 +135,39 @@ def test_format_mixed_auto_apply_and_report(snapshot: SnapshotAssertion) -> None
 
 def test_format_with_diff(snapshot: SnapshotAssertion) -> None:
     result = RunResult(
-        hooks=[HookResult(hook_id="fixer", hook_name="fixer", output=b"fixed", files_modified=True, exit_code=1)],
+        hooks=[HookWouldEdit(hook_id="fixer", hook_name="fixer", output=b"fixed", exit_code=1)],
         report_only_diff=["@@ -1 +1 @@\n", "-x=1\n", "+x = 1\n"],
     )
-    pre_commit = PreCommitConfig(auto_apply_hooks=set(), show_report_diffs=True)
+    pre_commit = PreCommitConfig(show_report_diffs=True)
     assert _format_check_result(result, Path("test.py"), pre_commit) == snapshot
 
 
 # === RunResult property tests ===
 
 
-def test_run_result_all_passed_with_auto_applied() -> None:
-    result = RunResult(
-        hooks=[
-            HookResult(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"",
-                files_modified=True,
-                exit_code=0,
-                auto_applied=True,
-            ),
-            HookResult(hook_id="check-ast", hook_name="check-ast", output=b"", files_modified=False, exit_code=0),
-        ]
-    )
-    assert result.all_passed
+def test_run_result_has_issues_false_when_all_passed() -> None:
+    result = RunResult(hooks=[])
+    assert not result.has_issues
 
 
-def test_run_result_failed_hooks_excludes_auto_applied() -> None:
+def test_run_result_has_issues_with_auto_applied() -> None:
     result = RunResult(
         hooks=[
-            HookResult(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"",
-                files_modified=True,
-                exit_code=0,
-                auto_applied=True,
-            ),
-            HookResult(hook_id="ruff-check", hook_name="ruff-check", output=b"err", files_modified=False, exit_code=1),
+            HookAutoApplied(hook_id="ruff-format", hook_name="ruff-format", output=b"", exit_code=0, rerun_exit_code=0)
         ]
     )
-    assert len(result.failed_hooks) == 1
-    assert result.failed_hooks[0].hook_id == "ruff-check"
+    assert result.has_issues
+
+
+def test_run_result_failed_not_applied_excludes_auto_applied() -> None:
+    result = RunResult(
+        hooks=[
+            HookAutoApplied(hook_id="ruff-format", hook_name="ruff-format", output=b"", exit_code=0, rerun_exit_code=0),
+            HookFailedNotApplied(hook_id="ruff-check", hook_name="ruff-check", output=b"err", exit_code=1),
+        ]
+    )
+    assert len(result.failed_not_applied) == 1
+    assert result.failed_not_applied[0].hook_id == "ruff-check"
 
 
 # === Integration tests (mocked run_on_file) ===
@@ -199,15 +177,7 @@ def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
     _, test_file = git_project
 
     fake_result = RunResult(
-        hooks=[
-            HookResult(
-                hook_id="ruff-format",
-                hook_name="ruff-format",
-                output=b"- files were modified by this hook",
-                files_modified=True,
-                exit_code=0,
-            )
-        ]
+        hooks=[HookWouldEdit(hook_id="ruff-format", hook_name="ruff-format", output=b"modified", exit_code=0)]
     )
 
     with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=fake_result):
@@ -224,11 +194,7 @@ def test_precommit_report_only_failure(git_project: tuple[Path, Path]) -> None:
 def test_precommit_passes(git_project: tuple[Path, Path]) -> None:
     _, test_file = git_project
 
-    fake_result = RunResult(
-        hooks=[
-            HookResult(hook_id="ruff-format", hook_name="ruff-format", output=b"", files_modified=False, exit_code=0)
-        ]
-    )
+    fake_result = RunResult(hooks=[])
 
     with patch("devinfra.claude.hook_daemon.post_tool_use.run_on_file", return_value=fake_result):
         inp = PostToolUseInput(**_COMMON, tool_name="Write", tool_input={"file_path": str(test_file)})
@@ -252,13 +218,12 @@ def test_auto_applied_only_returns_context(git_project: tuple[Path, Path]) -> No
 
     fake_result = RunResult(
         hooks=[
-            HookResult(
+            HookAutoApplied(
                 hook_id="ruff-format",
                 hook_name="ruff-format",
                 output=b"1 file reformatted",
-                files_modified=True,
                 exit_code=0,
-                auto_applied=True,
+                rerun_exit_code=0,
             )
         ]
     )

--- a/devinfra/claude/hook_daemon/test_post_tool_use.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use.py
@@ -270,7 +270,8 @@ def test_auto_applied_only_returns_context(git_project: tuple[Path, Path]) -> No
     assert result.hook_specific_output is not None
     ctx = result.hook_specific_output.additional_context
     assert ctx is not None
-    assert "Auto-applied: ruff-format" in ctx
+    assert "Auto-applied:" in ctx
+    assert "ruff-format" in ctx
 
 
 if __name__ == "__main__":

--- a/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
@@ -1,0 +1,136 @@
+"""E2E test: PostToolUse hook with real ruff preserves unused imports.
+
+Verifies that when ruff-check is a report-only hook (not in auto_apply_hooks),
+it does NOT persist import removal to disk, and the hook output correctly
+characterizes the situation.
+"""
+
+import shutil
+from pathlib import Path
+from textwrap import dedent
+
+import pygit2
+import pytest
+import pytest_bazel
+import yaml
+
+from devinfra.claude.claude_api.hooks.post_tool_use import PostToolUseInput
+from devinfra.claude.hook_daemon.post_tool_use import evaluate
+
+_COMMON_INPUT = {
+    "session_id": "test-session",
+    "transcript_path": "/tmp/transcript.jsonl",
+    "cwd": "/tmp",
+    "permission_mode": "default",
+    "hook_event_name": "PostToolUse",
+    "tool_use_id": "toolu_test_ruff",
+    "tool_response": "",
+}
+
+
+@pytest.fixture
+def ruff_repo(tmp_path: Path) -> Path:
+    """Git repo with real ruff hooks and .claude_hooks config."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+
+    ruff_path = shutil.which("ruff")
+    if ruff_path is None:
+        pytest.skip("ruff not found on PATH")
+
+    # Minimal ruff config enabling F401 (unused imports)
+    (repo_path / "ruff.toml").write_text(
+        dedent("""\
+        [lint]
+        select = ["F401"]
+    """)
+    )
+
+    # Pre-commit config with ruff-check (--fix) and ruff-format
+    precommit_config = {
+        "repos": [
+            {
+                "repo": "local",
+                "hooks": [
+                    {
+                        "id": "ruff-check",
+                        "name": "ruff-check",
+                        "entry": f"{ruff_path} check --fix --config ruff.toml",
+                        "language": "system",
+                        "files": r"\.py$",
+                    },
+                    {
+                        "id": "ruff-format",
+                        "name": "ruff-format",
+                        "entry": f"{ruff_path} format --config ruff.toml",
+                        "language": "system",
+                        "files": r"\.py$",
+                    },
+                ],
+            }
+        ]
+    }
+    (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(precommit_config))
+
+    # Hook config: ruff-format is auto-applied, ruff-check is report-only
+    hooks_dir = repo_path / ".claude_hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "config.yaml").write_text(
+        dedent("""\
+        pre_commit:
+          auto_apply_hooks:
+            - ruff-format
+    """)
+    )
+
+    repo = pygit2.init_repository(str(repo_path))
+    repo.config["user.name"] = "Test"
+    repo.config["user.email"] = "test@test.com"
+    repo.index.add_all()
+    repo.index.write()
+    tree = repo.index.write_tree()
+    sig = pygit2.Signature("Test", "test@test.com")
+    repo.create_commit("HEAD", sig, sig, "init", tree, [])
+
+    return repo_path
+
+
+def test_unused_import_preserved_after_hook(ruff_repo: Path) -> None:
+    """Report-only ruff-check must not remove unused imports from disk.
+
+    After PostToolUse hook runs, the file should still contain the unused
+    import. The hook should warn about the violation but not report it as
+    "modified file" (since the modification was reverted).
+    """
+    test_file = ruff_repo / "test.py"
+    original_content = dedent("""\
+        import os
+
+        x = 1
+    """)
+    test_file.write_text(original_content)
+
+    inp = PostToolUseInput(**_COMMON_INPUT, tool_name="Edit", tool_input={"file_path": str(test_file)})
+    result = evaluate(inp)
+
+    # File content must be preserved — ruff-check is report-only, changes reverted
+    assert "import os" in test_file.read_text(), (
+        "ruff-check (report-only) removed the unused import from disk — Phase 2 revert failed"
+    )
+
+    # Hook should have produced output (ruff-check detected F401)
+    assert result.hook_specific_output is not None, "Hook should report ruff-check findings"
+    ctx = result.hook_specific_output.additional_context
+    assert ctx is not None
+
+    # The output must NOT say "modified file" for a report-only hook whose
+    # changes were reverted — that misleads Claude into removing the import.
+    assert "modified file" not in ctx, (
+        f"Hook output says 'modified file' for a reverted report-only hook.\n"
+        f"This misleads Claude into removing the import itself.\n"
+        f"Output:\n{ctx}"
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
@@ -11,10 +11,9 @@ from textwrap import dedent
 
 import pytest
 import pytest_bazel
-import yaml
 
 from devinfra.claude.claude_api.hooks.post_tool_use import PostToolUseInput
-from devinfra.claude.hook_daemon.conftest import init_git_repo
+from devinfra.claude.hook_daemon.conftest import init_git_repo, write_precommit_config
 from devinfra.claude.hook_daemon.post_tool_use import evaluate
 
 _COMMON_INPUT = {
@@ -34,43 +33,32 @@ _TESTDATA = Path(__file__).resolve().parent / "testdata" / "ruff_repo"
 def ruff_repo(tmp_path: Path) -> Path:
     """Git repo with real ruff hooks and .claude_hooks config from testdata."""
     repo_path = tmp_path / "repo"
-    repo_path.mkdir()
+    shutil.copytree(_TESTDATA, repo_path)
 
     ruff_path = shutil.which("ruff")
     assert ruff_path is not None, "ruff binary not found on PATH (expected via @multitool//tools/ruff data dep)"
 
-    # Copy static config files from testdata
-    shutil.copytree(_TESTDATA / ".claude_hooks", repo_path / ".claude_hooks")
-    shutil.copy2(_TESTDATA / "ruff.toml", repo_path / "ruff.toml")
-
-    # Pre-commit config needs dynamic ruff path
-    precommit_config = {
-        "repos": [
+    write_precommit_config(
+        repo_path,
+        [
             {
-                "repo": "local",
-                "hooks": [
-                    {
-                        "id": "ruff-check",
-                        "name": "ruff-check",
-                        "entry": f"{ruff_path} check --fix --config ruff.toml",
-                        "language": "system",
-                        "files": r"\.py$",
-                    },
-                    {
-                        "id": "ruff-format",
-                        "name": "ruff-format",
-                        "entry": f"{ruff_path} format --config ruff.toml",
-                        "language": "system",
-                        "files": r"\.py$",
-                    },
-                ],
-            }
-        ]
-    }
-    (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(precommit_config))
+                "id": "ruff-check",
+                "name": "ruff-check",
+                "entry": f"{ruff_path} check --fix --config ruff.toml",
+                "language": "system",
+                "files": r"\.py$",
+            },
+            {
+                "id": "ruff-format",
+                "name": "ruff-format",
+                "entry": f"{ruff_path} format --config ruff.toml",
+                "language": "system",
+                "files": r"\.py$",
+            },
+        ],
+    )
 
     init_git_repo(repo_path)
-
     return repo_path
 
 

--- a/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
@@ -9,12 +9,12 @@ import shutil
 from pathlib import Path
 from textwrap import dedent
 
-import pygit2
 import pytest
 import pytest_bazel
 import yaml
 
 from devinfra.claude.claude_api.hooks.post_tool_use import PostToolUseInput
+from devinfra.claude.hook_daemon.conftest import init_git_repo
 from devinfra.claude.hook_daemon.post_tool_use import evaluate
 
 _COMMON_INPUT = {
@@ -27,26 +27,23 @@ _COMMON_INPUT = {
     "tool_response": "",
 }
 
+_TESTDATA = Path(__file__).resolve().parent / "testdata" / "ruff_repo"
+
 
 @pytest.fixture
 def ruff_repo(tmp_path: Path) -> Path:
-    """Git repo with real ruff hooks and .claude_hooks config."""
+    """Git repo with real ruff hooks and .claude_hooks config from testdata."""
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
 
     ruff_path = shutil.which("ruff")
-    if ruff_path is None:
-        pytest.skip("ruff not found on PATH")
+    assert ruff_path is not None, "ruff binary not found on PATH (expected via @multitool//tools/ruff data dep)"
 
-    # Minimal ruff config enabling F401 (unused imports)
-    (repo_path / "ruff.toml").write_text(
-        dedent("""\
-        [lint]
-        select = ["F401"]
-    """)
-    )
+    # Copy static config files from testdata
+    shutil.copytree(_TESTDATA / ".claude_hooks", repo_path / ".claude_hooks")
+    shutil.copy2(_TESTDATA / "ruff.toml", repo_path / "ruff.toml")
 
-    # Pre-commit config with ruff-check (--fix) and ruff-format
+    # Pre-commit config needs dynamic ruff path
     precommit_config = {
         "repos": [
             {
@@ -72,25 +69,7 @@ def ruff_repo(tmp_path: Path) -> Path:
     }
     (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(precommit_config))
 
-    # Hook config: ruff-format is auto-applied, ruff-check is report-only
-    hooks_dir = repo_path / ".claude_hooks"
-    hooks_dir.mkdir()
-    (hooks_dir / "config.yaml").write_text(
-        dedent("""\
-        pre_commit:
-          auto_apply_hooks:
-            - ruff-format
-    """)
-    )
-
-    repo = pygit2.init_repository(str(repo_path))
-    repo.config["user.name"] = "Test"
-    repo.config["user.email"] = "test@test.com"
-    repo.index.add_all()
-    repo.index.write()
-    tree = repo.index.write_tree()
-    sig = pygit2.Signature("Test", "test@test.com")
-    repo.create_commit("HEAD", sig, sig, "init", tree, [])
+    init_git_repo(repo_path)
 
     return repo_path
 
@@ -103,12 +82,13 @@ def test_unused_import_preserved_after_hook(ruff_repo: Path) -> None:
     "modified file" (since the modification was reverted).
     """
     test_file = ruff_repo / "test.py"
-    original_content = dedent("""\
+    test_file.write_text(
+        dedent("""\
         import os
 
         x = 1
     """)
-    test_file.write_text(original_content)
+    )
 
     inp = PostToolUseInput(**_COMMON_INPUT, tool_name="Edit", tool_input={"file_path": str(test_file)})
     result = evaluate(inp)

--- a/devinfra/claude/hook_daemon/test_precommit_e2e.py
+++ b/devinfra/claude/hook_daemon/test_precommit_e2e.py
@@ -12,20 +12,12 @@ from textwrap import dedent
 
 import pytest
 import pytest_bazel
-from more_itertools import one
 from syrupy.assertion import SnapshotAssertion
 
 from devinfra.claude.hook_config import PreCommitConfig
 from devinfra.claude.hook_daemon.conftest import init_git_repo, write_precommit_config
 from devinfra.claude.hook_daemon.post_tool_use import _format_check_result
-from devinfra.claude.hook_daemon.precommit_runner import (
-    HookFailedNotApplied,
-    HookOutcome,
-    HookPassed,
-    HookWouldEdit,
-    RunResult,
-    run_on_file,
-)
+from devinfra.claude.hook_daemon.precommit_runner import HookFailedNotApplied, HookPassed, HookWouldEdit, run_on_file
 
 # Relative path used in _format_check_result to keep snapshots stable
 # (avoids embedding tmp dir absolute paths).
@@ -123,11 +115,6 @@ def precommit_repo(tmp_path: Path) -> Path:
     return repo_path
 
 
-def _hook_by_id(result: RunResult, hook_id: str) -> HookOutcome:
-    """Find a hook outcome by ID."""
-    return one(h for h in result.hooks if h.hook_id == hook_id)
-
-
 def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -> None:
     """Fixer modifies file, checker fails without modifying — correct labels."""
     test_file = precommit_repo / "test.py"
@@ -135,9 +122,9 @@ def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAs
 
     result = run_on_file(test_file, precommit_repo)
 
-    assert isinstance(_hook_by_id(result, "fixer"), HookWouldEdit)
-    assert isinstance(_hook_by_id(result, "checker"), HookFailedNotApplied)
-    assert isinstance(_hook_by_id(result, "passthrough"), HookPassed)
+    assert isinstance(result.hooks["fixer"], HookWouldEdit)
+    assert isinstance(result.hooks["checker"], HookFailedNotApplied)
+    assert isinstance(result.hooks["passthrough"], HookPassed)
 
     output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
@@ -150,9 +137,9 @@ def test_only_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -
 
     result = run_on_file(test_file, precommit_repo)
 
-    assert isinstance(_hook_by_id(result, "fixer"), HookPassed)
-    assert isinstance(_hook_by_id(result, "checker"), HookFailedNotApplied)
-    assert isinstance(_hook_by_id(result, "passthrough"), HookPassed)
+    assert isinstance(result.hooks["fixer"], HookPassed)
+    assert isinstance(result.hooks["checker"], HookFailedNotApplied)
+    assert isinstance(result.hooks["passthrough"], HookPassed)
 
     output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
@@ -211,7 +198,7 @@ def test_binary_file_no_diff(tmp_path: Path, snapshot: SnapshotAssertion) -> Non
 
     result = run_on_file(test_file, repo_path)
 
-    assert isinstance(_hook_by_id(result, "binfixer"), HookWouldEdit)
+    assert isinstance(result.hooks["binfixer"], HookWouldEdit)
     assert result.report_only_diff == []
     # File should be restored to original
     assert test_file.read_bytes() == b"\x00\xaa\xff\xfe"

--- a/devinfra/claude/hook_daemon/test_precommit_e2e.py
+++ b/devinfra/claude/hook_daemon/test_precommit_e2e.py
@@ -167,6 +167,59 @@ def test_all_pass(precommit_repo: Path) -> None:
     assert not result.has_issues
 
 
+def test_binary_file_no_diff(tmp_path: Path, snapshot: SnapshotAssertion) -> None:
+    """Binary files that hooks modify should not produce a diff."""
+    repo_path = tmp_path / "binrepo"
+    repo_path.mkdir()
+
+    # Binary-safe fixer: replaces 0xAA with 0xBB using raw bytes
+    _make_script(
+        repo_path,
+        "binfixer.py",
+        """\
+        import sys
+        from pathlib import Path
+
+        changed = False
+        for f in sys.argv[1:]:
+            p = Path(f)
+            content = p.read_bytes()
+            new = content.replace(b"\\xaa", b"\\xbb")
+            if new != content:
+                p.write_bytes(new)
+                changed = True
+        sys.exit(1 if changed else 0)
+        """,
+    )
+
+    write_precommit_config(
+        repo_path,
+        [
+            {
+                "id": "binfixer",
+                "name": "binfixer",
+                "entry": f"{sys.executable} {repo_path / 'binfixer.py'}",
+                "language": "system",
+                "pass_filenames": True,
+            }
+        ],
+    )
+    init_git_repo(repo_path)
+
+    test_file = repo_path / "test.bin"
+    test_file.write_bytes(b"\x00\xaa\xff\xfe")
+
+    result = run_on_file(test_file, repo_path)
+
+    assert isinstance(_hook_by_id(result, "binfixer"), HookWouldEdit)
+    assert result.report_only_diff == []
+    # File should be restored to original
+    assert test_file.read_bytes() == b"\x00\xaa\xff\xfe"
+
+    output = _format_check_result(result, Path("test.bin"), PreCommitConfig())
+    assert output == snapshot
+
+
 def test_file_restored_after_run(precommit_repo: Path) -> None:
     """Original file content is restored after run_on_file returns."""
     test_file = precommit_repo / "test.py"

--- a/devinfra/claude/hook_daemon/test_precommit_e2e.py
+++ b/devinfra/claude/hook_daemon/test_precommit_e2e.py
@@ -10,18 +10,20 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
-import pygit2
 import pytest
 import pytest_bazel
 import yaml
 from syrupy.assertion import SnapshotAssertion
 
+from devinfra.claude.hook_config import PreCommitConfig
+from devinfra.claude.hook_daemon.conftest import init_git_repo
 from devinfra.claude.hook_daemon.post_tool_use import _format_check_result
 from devinfra.claude.hook_daemon.precommit_runner import run_on_file
 
 # Relative path used in _format_check_result to keep snapshots stable
 # (avoids embedding tmp dir absolute paths).
 _TEST_FILE = Path("test.py")
+_DEFAULT_PRE_COMMIT = PreCommitConfig(auto_apply_hooks=set())
 
 
 def _make_script(repo: Path, name: str, body: str) -> Path:
@@ -36,10 +38,6 @@ def precommit_repo(tmp_path: Path) -> Path:
     """Git repo with three local hooks: fixer, checker, passthrough."""
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
-
-    repo = pygit2.init_repository(str(repo_path))
-    repo.config["user.name"] = "Test"
-    repo.config["user.email"] = "test@test.com"
 
     # Hook 1: replaces 'foo' with 'bar', exits 1 on change
     _make_script(
@@ -120,11 +118,7 @@ def precommit_repo(tmp_path: Path) -> Path:
 
     (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(config))
 
-    repo.index.add_all()
-    repo.index.write()
-    tree = repo.index.write_tree()
-    sig = pygit2.Signature("Test", "test@test.com")
-    repo.create_commit("HEAD", sig, sig, "init", tree, [])
+    init_git_repo(repo_path)
 
     return repo_path
 
@@ -143,7 +137,7 @@ def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAs
     assert hooks["checker"].passed is False
     assert hooks["passthrough"].passed is True
 
-    output = _format_check_result(result, _TEST_FILE)
+    output = _format_check_result(result, _TEST_FILE, _DEFAULT_PRE_COMMIT)
     assert output == snapshot
 
 
@@ -160,7 +154,7 @@ def test_only_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -
     assert hooks["checker"].passed is False
     assert hooks["passthrough"].passed is True
 
-    output = _format_check_result(result, _TEST_FILE)
+    output = _format_check_result(result, _TEST_FILE, _DEFAULT_PRE_COMMIT)
     assert output == snapshot
 
 

--- a/devinfra/claude/hook_daemon/test_precommit_e2e.py
+++ b/devinfra/claude/hook_daemon/test_precommit_e2e.py
@@ -12,12 +12,20 @@ from textwrap import dedent
 
 import pytest
 import pytest_bazel
+from more_itertools import one
 from syrupy.assertion import SnapshotAssertion
 
 from devinfra.claude.hook_config import PreCommitConfig
 from devinfra.claude.hook_daemon.conftest import init_git_repo, write_precommit_config
 from devinfra.claude.hook_daemon.post_tool_use import _format_check_result
-from devinfra.claude.hook_daemon.precommit_runner import run_on_file
+from devinfra.claude.hook_daemon.precommit_runner import (
+    HookFailedNotApplied,
+    HookOutcome,
+    HookPassed,
+    HookWouldEdit,
+    RunResult,
+    run_on_file,
+)
 
 # Relative path used in _format_check_result to keep snapshots stable
 # (avoids embedding tmp dir absolute paths).
@@ -115,6 +123,11 @@ def precommit_repo(tmp_path: Path) -> Path:
     return repo_path
 
 
+def _hook_by_id(result: RunResult, hook_id: str) -> HookOutcome:
+    """Find a hook outcome by ID."""
+    return one(h for h in result.hooks if h.hook_id == hook_id)
+
+
 def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -> None:
     """Fixer modifies file, checker fails without modifying — correct labels."""
     test_file = precommit_repo / "test.py"
@@ -122,12 +135,9 @@ def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAs
 
     result = run_on_file(test_file, precommit_repo)
 
-    hooks = {h.hook_id: h for h in result.hooks}
-    assert hooks["fixer"].files_modified is True
-    assert hooks["fixer"].passed is False
-    assert hooks["checker"].files_modified is False
-    assert hooks["checker"].passed is False
-    assert hooks["passthrough"].passed is True
+    assert isinstance(_hook_by_id(result, "fixer"), HookWouldEdit)
+    assert isinstance(_hook_by_id(result, "checker"), HookFailedNotApplied)
+    assert isinstance(_hook_by_id(result, "passthrough"), HookPassed)
 
     output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
@@ -140,11 +150,9 @@ def test_only_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -
 
     result = run_on_file(test_file, precommit_repo)
 
-    hooks = {h.hook_id: h for h in result.hooks}
-    assert hooks["fixer"].passed is True
-    assert hooks["checker"].files_modified is False
-    assert hooks["checker"].passed is False
-    assert hooks["passthrough"].passed is True
+    assert isinstance(_hook_by_id(result, "fixer"), HookPassed)
+    assert isinstance(_hook_by_id(result, "checker"), HookFailedNotApplied)
+    assert isinstance(_hook_by_id(result, "passthrough"), HookPassed)
 
     output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
@@ -156,7 +164,7 @@ def test_all_pass(precommit_repo: Path) -> None:
     test_file.write_text("clean = 1\n")
 
     result = run_on_file(test_file, precommit_repo)
-    assert result.all_passed
+    assert not result.has_issues
 
 
 def test_file_restored_after_run(precommit_repo: Path) -> None:
@@ -168,7 +176,7 @@ def test_file_restored_after_run(precommit_repo: Path) -> None:
     result = run_on_file(test_file, precommit_repo)
 
     # Fixer should have changed foo->bar, but file is restored
-    assert not result.all_passed
+    assert result.has_issues
     assert test_file.read_text() == original
 
 

--- a/devinfra/claude/hook_daemon/test_precommit_e2e.py
+++ b/devinfra/claude/hook_daemon/test_precommit_e2e.py
@@ -12,18 +12,16 @@ from textwrap import dedent
 
 import pytest
 import pytest_bazel
-import yaml
 from syrupy.assertion import SnapshotAssertion
 
 from devinfra.claude.hook_config import PreCommitConfig
-from devinfra.claude.hook_daemon.conftest import init_git_repo
+from devinfra.claude.hook_daemon.conftest import init_git_repo, write_precommit_config
 from devinfra.claude.hook_daemon.post_tool_use import _format_check_result
 from devinfra.claude.hook_daemon.precommit_runner import run_on_file
 
 # Relative path used in _format_check_result to keep snapshots stable
 # (avoids embedding tmp dir absolute paths).
 _TEST_FILE = Path("test.py")
-_DEFAULT_PRE_COMMIT = PreCommitConfig(auto_apply_hooks=set())
 
 
 def _make_script(repo: Path, name: str, body: str) -> Path:
@@ -85,38 +83,32 @@ def precommit_repo(tmp_path: Path) -> Path:
         """,
     )
 
-    config = {
-        "repos": [
+    write_precommit_config(
+        repo_path,
+        [
             {
-                "repo": "local",
-                "hooks": [
-                    {
-                        "id": "fixer",
-                        "name": "fixer (foo->bar)",
-                        "entry": f"{sys.executable} {repo_path / 'fixer.py'}",
-                        "language": "system",
-                        "pass_filenames": True,
-                    },
-                    {
-                        "id": "checker",
-                        "name": "checker (no BANNED)",
-                        "entry": f"{sys.executable} {repo_path / 'checker.py'}",
-                        "language": "system",
-                        "pass_filenames": True,
-                    },
-                    {
-                        "id": "passthrough",
-                        "name": "passthrough",
-                        "entry": f"{sys.executable} {repo_path / 'passthrough.py'}",
-                        "language": "system",
-                        "pass_filenames": True,
-                    },
-                ],
-            }
-        ]
-    }
-
-    (repo_path / ".pre-commit-config.yaml").write_text(yaml.dump(config))
+                "id": "fixer",
+                "name": "fixer (foo->bar)",
+                "entry": f"{sys.executable} {repo_path / 'fixer.py'}",
+                "language": "system",
+                "pass_filenames": True,
+            },
+            {
+                "id": "checker",
+                "name": "checker (no BANNED)",
+                "entry": f"{sys.executable} {repo_path / 'checker.py'}",
+                "language": "system",
+                "pass_filenames": True,
+            },
+            {
+                "id": "passthrough",
+                "name": "passthrough",
+                "entry": f"{sys.executable} {repo_path / 'passthrough.py'}",
+                "language": "system",
+                "pass_filenames": True,
+            },
+        ],
+    )
 
     init_git_repo(repo_path)
 
@@ -137,7 +129,7 @@ def test_fixer_modifies_checker_fails(precommit_repo: Path, snapshot: SnapshotAs
     assert hooks["checker"].passed is False
     assert hooks["passthrough"].passed is True
 
-    output = _format_check_result(result, _TEST_FILE, _DEFAULT_PRE_COMMIT)
+    output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
 
 
@@ -154,7 +146,7 @@ def test_only_checker_fails(precommit_repo: Path, snapshot: SnapshotAssertion) -
     assert hooks["checker"].passed is False
     assert hooks["passthrough"].passed is True
 
-    output = _format_check_result(result, _TEST_FILE, _DEFAULT_PRE_COMMIT)
+    output = _format_check_result(result, _TEST_FILE, PreCommitConfig())
     assert output == snapshot
 
 

--- a/devinfra/claude/hook_daemon/testdata/ruff_repo/.claude_hooks/config.yaml
+++ b/devinfra/claude/hook_daemon/testdata/ruff_repo/.claude_hooks/config.yaml
@@ -1,0 +1,3 @@
+pre_commit:
+  auto_apply_hooks:
+    - ruff-format

--- a/devinfra/claude/hook_daemon/testdata/ruff_repo/ruff.toml
+++ b/devinfra/claude/hook_daemon/testdata/ruff_repo/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+select = ["F401"]

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -2,19 +2,16 @@
 MAX_DIFF_LINES = 20
 MAX_ISSUES_SHOWN = 3
 MAX_OUTPUT_CHARS = 500
-# Report-only hooks that modified the file (changes reverted, e.g. ruff-check --fix)
 would_fix = [h for h in failed if h.files_modified]
-# Hooks that exited non-zero without modifying (genuine errors, e.g. mypy)
 errors = [h for h in failed if not h.files_modified]
 %>\
+${file_name}:
 % if auto_applied:
-Auto-applied: ${", ".join(h.hook_name for h in auto_applied)}
+  Auto-applied: ${", ".join(h.hook_name for h in auto_applied)}
 % endif
 % if would_fix:
-Would also edit ${file_name}: ${", ".join(h.hook_name for h in would_fix)}
+  Not auto-applied (would also edit): ${", ".join(h.hook_name for h in would_fix)}
 % endif
-% if errors:
-${len(errors)} ${"hook" if len(errors) == 1 else "hooks"} failed on ${file_name}:
 % for hr in errors:
 <%
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]
@@ -33,5 +30,6 @@ ${line}\
 ... (diff truncated, ${len(diff_lines) - MAX_DIFF_LINES} more lines)
 % endif
 % endif
+% if errors:
 Run `pre-commit run --files ${file_path}` to apply fixes.
 % endif

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -7,7 +7,19 @@ errors = [h for h in result.failed_hooks if not h.files_modified]
 %>\
 ${file_path.name}:
 % if result.auto_applied_results:
-  Auto-applied: ${", ".join(h.hook_name for h in result.auto_applied_results)}
+  Auto-applied:\
+% for hr in result.auto_applied_results:
+<%
+    if hr.rerun_exit_code is not None and hr.rerun_exit_code == 0:
+        status = "now clean"
+    elif hr.rerun_exit_code is not None:
+        status = f"not fully fixed, still exit {hr.rerun_exit_code}"
+    else:
+        status = f"exit {hr.exit_code}"
+%>
+    ${hr.hook_name} (${status})\
+% endfor
+
 % endif
 % if would_fix:
   Not auto-applied (would also edit): ${", ".join(h.hook_name for h in would_fix)}

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -13,13 +13,15 @@ ${file_name}:
   Not auto-applied (would also edit): ${", ".join(h.hook_name for h in would_fix)}
 % endif
 % for hr in errors:
+  ${hr.hook_name} (exit ${hr.exit_code})
+% if show_hook_output:
 <%
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]
 %>\
-  ${hr.hook_name} (exit ${hr.exit_code})
 % for line in output_text.splitlines()[:MAX_ISSUES_SHOWN]:
     ${line}
 % endfor
+% endif
 % endfor
 % if diff_lines:
 Changes pre-commit would make:

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -2,18 +2,24 @@
 MAX_DIFF_LINES = 20
 MAX_ISSUES_SHOWN = 3
 MAX_OUTPUT_CHARS = 500
+# Report-only hooks that modified the file (changes reverted, e.g. ruff-check --fix)
+would_fix = [h for h in failed if h.files_modified]
+# Hooks that exited non-zero without modifying (genuine errors, e.g. mypy)
+errors = [h for h in failed if not h.files_modified]
 %>\
 % if auto_applied:
 Auto-applied: ${", ".join(h.hook_name for h in auto_applied)}
 % endif
-% if failed:
-${len(failed)} ${"hook" if len(failed) == 1 else "hooks"} failed on ${file_name}:
-% for hr in failed:
+% if would_fix:
+Would also edit ${file_name}: ${", ".join(h.hook_name for h in would_fix)}
+% endif
+% if errors:
+${len(errors)} ${"hook" if len(errors) == 1 else "hooks"} failed on ${file_name}:
+% for hr in errors:
 <%
-    status = "modified file" if hr.files_modified else f"exit {hr.exit_code}"
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]
 %>\
-  ${hr.hook_name} (${status})
+  ${hr.hook_name} (exit ${hr.exit_code})
 % for line in output_text.splitlines()[:MAX_ISSUES_SHOWN]:
     ${line}
 % endfor

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -2,19 +2,19 @@
 MAX_DIFF_LINES = 20
 MAX_ISSUES_SHOWN = 3
 MAX_OUTPUT_CHARS = 500
-would_fix = [h for h in failed if h.files_modified]
-errors = [h for h in failed if not h.files_modified]
+would_fix = [h for h in result.failed_hooks if h.files_modified]
+errors = [h for h in result.failed_hooks if not h.files_modified]
 %>\
-${file_name}:
-% if auto_applied:
-  Auto-applied: ${", ".join(h.hook_name for h in auto_applied)}
+${file_path.name}:
+% if result.auto_applied_results:
+  Auto-applied: ${", ".join(h.hook_name for h in result.auto_applied_results)}
 % endif
 % if would_fix:
   Not auto-applied (would also edit): ${", ".join(h.hook_name for h in would_fix)}
 % endif
 % for hr in errors:
   ${hr.hook_name} (exit ${hr.exit_code})
-% if show_hook_output:
+% if pre_commit.show_hook_output:
 <%
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]
 %>\
@@ -23,13 +23,13 @@ ${file_name}:
 % endfor
 % endif
 % endfor
-% if diff_lines:
+% if pre_commit.show_report_diffs and result.report_only_diff:
 Changes pre-commit would make:
-% for line in diff_lines[:MAX_DIFF_LINES]:
+% for line in result.report_only_diff[:MAX_DIFF_LINES]:
 ${line}\
 % endfor
-% if len(diff_lines) > MAX_DIFF_LINES:
-... (diff truncated, ${len(diff_lines) - MAX_DIFF_LINES} more lines)
+% if len(result.report_only_diff) > MAX_DIFF_LINES:
+... (diff truncated, ${len(result.report_only_diff) - MAX_DIFF_LINES} more lines)
 % endif
 % endif
 % if errors:

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -6,22 +6,22 @@ MAX_OUTPUT_CHARS = 500
 ${file_path.name}:
 % if result.auto_applied:
   Auto-applied:\
-% for hr in result.auto_applied:
+% for hook_id, hr in result.auto_applied.items():
 <%
     status = "now clean" if hr.rerun_exit_code == 0 else f"not fully fixed, still exit {hr.rerun_exit_code}"
 %>
-    ${hr.hook_name} (${status})\
+    ${hook_id} (${status})\
 % endfor
 
 % endif
 % if result.would_edit:
-  Not auto-applied (would also edit): ${", ".join(h.hook_name for h in result.would_edit)}
+  Not auto-applied (would also edit): ${", ".join(result.would_edit)}
 % endif
 % if result.failed_not_applied:
   Failed (not applied):\
-% for hr in result.failed_not_applied:
+% for hook_id, hr in result.failed_not_applied.items():
 
-    ${hr.hook_name} (exit ${hr.exit_code})\
+    ${hook_id} (exit ${hr.exit_code})\
 % if pre_commit.show_hook_output:
 <%
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]

--- a/devinfra/claude/templates/post_tool_use.mako
+++ b/devinfra/claude/templates/post_tool_use.mako
@@ -2,39 +2,38 @@
 MAX_DIFF_LINES = 20
 MAX_ISSUES_SHOWN = 3
 MAX_OUTPUT_CHARS = 500
-would_fix = [h for h in result.failed_hooks if h.files_modified]
-errors = [h for h in result.failed_hooks if not h.files_modified]
 %>\
 ${file_path.name}:
-% if result.auto_applied_results:
+% if result.auto_applied:
   Auto-applied:\
-% for hr in result.auto_applied_results:
+% for hr in result.auto_applied:
 <%
-    if hr.rerun_exit_code is not None and hr.rerun_exit_code == 0:
-        status = "now clean"
-    elif hr.rerun_exit_code is not None:
-        status = f"not fully fixed, still exit {hr.rerun_exit_code}"
-    else:
-        status = f"exit {hr.exit_code}"
+    status = "now clean" if hr.rerun_exit_code == 0 else f"not fully fixed, still exit {hr.rerun_exit_code}"
 %>
     ${hr.hook_name} (${status})\
 % endfor
 
 % endif
-% if would_fix:
-  Not auto-applied (would also edit): ${", ".join(h.hook_name for h in would_fix)}
+% if result.would_edit:
+  Not auto-applied (would also edit): ${", ".join(h.hook_name for h in result.would_edit)}
 % endif
-% for hr in errors:
-  ${hr.hook_name} (exit ${hr.exit_code})
+% if result.failed_not_applied:
+  Failed (not applied):\
+% for hr in result.failed_not_applied:
+
+    ${hr.hook_name} (exit ${hr.exit_code})\
 % if pre_commit.show_hook_output:
 <%
     output_text = hr.output.decode(errors="replace").strip()[:MAX_OUTPUT_CHARS]
 %>\
 % for line in output_text.splitlines()[:MAX_ISSUES_SHOWN]:
-    ${line}
+
+      ${line}\
 % endfor
 % endif
 % endfor
+
+% endif
 % if pre_commit.show_report_diffs and result.report_only_diff:
 Changes pre-commit would make:
 % for line in result.report_only_diff[:MAX_DIFF_LINES]:
@@ -44,6 +43,6 @@ ${line}\
 ... (diff truncated, ${len(result.report_only_diff) - MAX_DIFF_LINES} more lines)
 % endif
 % endif
-% if errors:
+% if result.failed_not_applied:
 Run `pre-commit run --files ${file_path}` to apply fixes.
 % endif


### PR DESCRIPTION
## Summary

- **E2E test with real ruff**: Proves that report-only hooks (like `ruff-check`) correctly preserve file content (revert works), but the hook output previously said `ruff-check (modified file)` with a diff showing import removal — misleading Claude into removing the import itself.

- **Fix output format**: Report-only file-modifying hooks now shown as `Not auto-applied (would also edit): ruff-check` instead of `ruff-check (modified file)`. Single filename header, no repetition.

- **Flag-guard report diffs**: `PreCommitConfig.show_report_diffs` (default `false`) gates diff output from report-only hooks. Diffs were showing Claude exactly what to remove, causing it to act on reverted changes.

- **Bazel wrapper error message**: Points to AGENTS.md recovery docs instead of "Try restarting your Claude Code session".

Example output before:
```
Auto-applied: ruff-format
1 hook failed on test.py:
  ruff-check (modified file)
    Found 1 error (1 fixed, 0 remaining).
Changes pre-commit would make:
-import os
Run `pre-commit run --files test.py` to apply fixes.
```

After:
```
test.py:
  Auto-applied: ruff-format
  Not auto-applied (would also edit): ruff-check
```

## Test plan

- [x] `bazel test //devinfra/claude/hook_daemon:test_post_tool_use_ruff_e2e` — E2E with real ruff
- [x] `bazel test //devinfra/claude/hook_daemon:test_post_tool_use` — unit + snapshot tests
- [x] `bazel test //devinfra/claude/hook_daemon:test_precommit_e2e` — precommit runner E2E

https://claude.ai/code/session_01Vp5WLzmu4kQXZo5v4L2FJj