### PR TITLE
[RUFF] Enable SLF rule (private member access)

### DIFF
--- a/airlock/app.py
+++ b/airlock/app.py
@@ -130,12 +130,12 @@ def create_app(settings: Settings, *, include_static: bool = True) -> FastAPI:
     @app.get("/api/actions")
     async def list_actions(status: str | None = None, limit: int = 100, offset: int = 0) -> list[Action]:
         status_enum = ActionStatus(status) if status else None
-        return await gate._req_storage.list_actions(status_enum, limit=limit, offset=offset)
+        return await gate.req_storage.list_actions(status_enum, limit=limit, offset=offset)
 
     @app.get("/api/actions/{session_key}/{action_seq}")
     async def get_action(session_key: str, action_seq: int) -> Action:
         key = ActionKey(session_key=session_key, action_seq=action_seq)
-        action = await gate._req_storage.get_action(key)
+        action = await gate.req_storage.get_action(key)
         if action is None:
             raise HTTPException(status_code=404, detail="Action not found")
         return action

--- a/airlock/proxy_server.py
+++ b/airlock/proxy_server.py
@@ -197,7 +197,7 @@ class AirlockServer(EnhancedFastMCP):
         Without this, decide() would fail for any PENDING action from a prior run because
         _pending_decisions only lives in memory and is empty on startup.
         """
-        pending = await self._req_storage.list_actions(ActionStatus.PENDING)
+        pending = await self.req_storage.list_actions(ActionStatus.PENDING)
         for action in pending:
             namespace = MCPMountPrefix(action.call.server_namespace)
             self._spawn(self._await_human_decision(action.key, namespace, action.call.tool_name, action.call.arguments))
@@ -230,7 +230,7 @@ class AirlockServer(EnhancedFastMCP):
         async def action_resource(session_key: str, action_seq: int) -> str:
             """Current state of a deferred action."""
             key = ActionKey(session_key=session_key, action_seq=action_seq)
-            action = await self._req_storage.get_action(key)
+            action = await self.req_storage.get_action(key)
             if action is None:
                 raise ValueError(f"Action not found: {session_key}/{action_seq}")
             return action.model_dump_json()
@@ -238,12 +238,12 @@ class AirlockServer(EnhancedFastMCP):
         @self.resource("resource://sessions/{session_key}/log_hwm")
         async def log_hwm_resource(session_key: str) -> str:
             """The entry_id of the last log entry for this session."""
-            return str(await self._req_storage.get_log_hwm(session_key))
+            return str(await self.req_storage.get_log_hwm(session_key))
 
         @self.resource("resource://sessions/{session_key}/log/{entry_id}")
         async def log_entry_resource(session_key: str, entry_id: int) -> str:
             """A specific log entry."""
-            entry = await self._req_storage.get_log_entry(session_key, entry_id)
+            entry = await self.req_storage.get_log_entry(session_key, entry_id)
             if entry is None:
                 raise ValueError(f"Log entry not found: {session_key}/{entry_id}")
             return entry.model_dump_json()
@@ -264,7 +264,7 @@ class AirlockServer(EnhancedFastMCP):
         @self.tool(auth=require_scopes(READ_SCOPE))
         async def list_actions(status: ActionStatus | None = None, limit: int = 100, offset: int = 0) -> list[Action]:
             """List queued/processed actions, optionally filtered by status."""
-            return await self._req_storage.list_actions(status, limit=limit, offset=offset)
+            return await self.req_storage.list_actions(status, limit=limit, offset=offset)
 
         @self.tool(auth=require_scopes(DECIDE_SCOPE))
         async def approve_action(key: ActionKey) -> None:
@@ -282,7 +282,7 @@ class AirlockServer(EnhancedFastMCP):
             return await self.withdraw(key)
 
     @property
-    def _req_storage(self) -> ActionStorage:
+    def req_storage(self) -> ActionStorage:
         if self._storage is None:
             raise RuntimeError("storage not initialised — gate not started")
         return self._storage
@@ -301,11 +301,11 @@ class AirlockServer(EnhancedFastMCP):
         async def _tool_handler(
             justification: str,
             session_key: str,
-            input: dict[str, object] = {},  # noqa: B006
+            input: dict[str, object] = {},
             wait_mode: WaitMode | None = None,
         ) -> Action:
             call = ToolCall(server_namespace=namespace, tool_name=tool_name, arguments=input)
-            action = await self._req_storage.create_action(
+            action = await self.req_storage.create_action(
                 session_key=session_key, call=call, justification=justification
             )
             key = action.key
@@ -322,7 +322,7 @@ class AirlockServer(EnhancedFastMCP):
                 with anyio.move_on_after(effective_timeout):
                     await asyncio.shield(pipeline)
 
-            result = await self._req_storage.get_action(key)
+            result = await self.req_storage.get_action(key)
             assert result is not None
             return result
 
@@ -393,7 +393,7 @@ class AirlockServer(EnhancedFastMCP):
 
     async def _append_log_and_notify(self, key: ActionKey, detail: LogEventDetail) -> None:
         """Append a log entry and notify subscribed sessions of action + HWM changes."""
-        await self._req_storage.append_log_entry(session_key=key.session_key, action_seq=key.action_seq, detail=detail)
+        await self.req_storage.append_log_entry(session_key=key.session_key, action_seq=key.action_seq, detail=detail)
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/actions/{key.action_seq}")
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/log_hwm")
 
@@ -419,7 +419,7 @@ class AirlockServer(EnhancedFastMCP):
         Raises ValueError if the action does not exist, is not pending, or is not
         awaiting a human decision (e.g. still processing an auto-predicate).
         """
-        action = await self._req_storage.get_action(key)
+        action = await self.req_storage.get_action(key)
         if action is None:
             raise ValueError(f"Action not found: {key.session_key}/{key.action_seq}")
         if not isinstance(action.state, PendingState):
@@ -434,7 +434,7 @@ class AirlockServer(EnhancedFastMCP):
 
         Raises ValueError if the action does not exist or is not pending.
         """
-        action = await self._req_storage.get_action(key)
+        action = await self.req_storage.get_action(key)
         if action is None:
             raise ValueError(f"Action not found: {key.session_key}/{key.action_seq}")
         if not isinstance(action.state, PendingState):
@@ -454,7 +454,7 @@ class AirlockServer(EnhancedFastMCP):
 
     async def _update_and_notify(self, key: ActionKey, new_state: ActionState, detail: LogEventDetail) -> Action:
         """Update action state and append log entry atomically, then notify subscribers."""
-        action, _ = await self._req_storage.update_state_and_log(key, new_state, detail)
+        action, _ = await self.req_storage.update_state_and_log(key, new_state, detail)
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/actions/{key.action_seq}")
         await self._notify_subscribers(f"resource://sessions/{key.session_key}/log_hwm")
         self._broadcast_sse({"type": "action_updated", "session_key": key.session_key, "action_seq": key.action_seq})

--- a/devinfra/claude/auth_proxy/proxy.py
+++ b/devinfra/claude/auth_proxy/proxy.py
@@ -88,7 +88,7 @@ class AuthForwardingProxy:
         self._upstream_url: str | None = None
         self._creds_lock = threading.Lock()
         self.server_socket: socket.socket | None = None
-        self._running = False
+        self.running = False
         self._thread: threading.Thread | None = None
         self._executor: ThreadPoolExecutor | None = None
         self._connections: list[socket.socket] = []
@@ -118,7 +118,7 @@ class AuthForwardingProxy:
         self.server_socket.settimeout(0.5)
 
         self._executor = ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix="proxy")
-        self._running = True
+        self.running = True
         self._thread = threading.Thread(target=self._serve, daemon=True)
         self._thread.start()
 
@@ -126,7 +126,7 @@ class AuthForwardingProxy:
 
     def stop(self) -> None:
         """Stop the proxy server."""
-        self._running = False
+        self.running = False
         if self._thread:
             self._thread.join(timeout=2)
         if self._executor:
@@ -140,7 +140,7 @@ class AuthForwardingProxy:
 
     def _serve(self) -> None:
         """Main server loop."""
-        while self._running:
+        while self.running:
             try:
                 client_sock, _ = self.server_socket.accept()  # type: ignore[union-attr]
                 self._connections.append(client_sock)
@@ -309,7 +309,7 @@ class UdsRemoteProxy:
         self._upstream_url: str | None = None
         self._creds_lock = threading.Lock()
         self.server_socket: socket.socket | None = None
-        self._running = False
+        self.running = False
         self._thread: threading.Thread | None = None
         self._executor: ThreadPoolExecutor | None = None
         self._connections: list[socket.socket] = []
@@ -341,7 +341,7 @@ class UdsRemoteProxy:
         self.server_socket.settimeout(0.5)
 
         self._executor = ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix="uds-proxy")
-        self._running = True
+        self.running = True
         self._thread = threading.Thread(target=self._serve, daemon=True)
         self._thread.start()
 
@@ -349,7 +349,7 @@ class UdsRemoteProxy:
 
     def stop(self) -> None:
         """Stop the UDS proxy server."""
-        self._running = False
+        self.running = False
         if self._thread:
             self._thread.join(timeout=2)
         if self._executor:
@@ -365,7 +365,7 @@ class UdsRemoteProxy:
 
     def _serve(self) -> None:
         """Main server loop."""
-        while self._running:
+        while self.running:
             try:
                 client_sock, _ = self.server_socket.accept()  # type: ignore[union-attr]
                 self._connections.append(client_sock)

--- a/devinfra/claude/auth_proxy/setup.py
+++ b/devinfra/claude/auth_proxy/setup.py
@@ -65,7 +65,7 @@ def _resolve_rlocation(rlocation_path: str) -> Path | None:
     bazel_wrapper subprocess (which runs outside Bazel runfiles).
     """
     try:
-        from util.bazel.runfiles import get_required_path  # noqa: PLC0415
+        from util.bazel.runfiles import get_required_path
 
         return get_required_path(rlocation_path)
     except RuntimeError:
@@ -347,7 +347,7 @@ async def setup_auth_proxy(
     # Create combined CA bundle (for tools like uv that use SSL_CERT_FILE)
     _create_combined_ca_bundle(paths)
 
-    status = (f"running (port {port})" if proxy._running else "configured") if proxy is not None else "uds-only"
+    status = (f"running (port {port})" if proxy.running else "configured") if proxy is not None else "uds-only"
     ca_status = "custom CA" if combined_ca.exists() else "system"
 
     logger.info("Auth proxy setup complete")

--- a/difftree/diff_tree.py
+++ b/difftree/diff_tree.py
@@ -46,7 +46,7 @@ class DiffTree:
             width=options.max_width or 80,
             legacy_windows=False,
             force_terminal=True,  # Force ANSI codes to preserve styling
-            color_system="standard" if console._color_system else None,  # Match parent console
+            color_system="standard" if console._color_system else None,  # Match parent console  # noqa: SLF001
         )
         temp_console.print(tree)
 

--- a/ember/runtime.py
+++ b/ember/runtime.py
@@ -70,10 +70,10 @@ class EmberRuntime:
         This is the primary way to create a runtime - handles all async initialization.
         """
         runtime = cls.__new__(cls)
-        runtime._settings = settings
-        runtime._task = None
-        runtime._stop_event = asyncio.Event()
-        await runtime._initialize()
+        runtime._settings = settings  # noqa: SLF001
+        runtime._task = None  # noqa: SLF001
+        runtime._stop_event = asyncio.Event()  # noqa: SLF001
+        await runtime._initialize()  # noqa: SLF001
         return runtime
 
     async def _initialize(self) -> None:

--- a/inop/runners/containerized_claude.py
+++ b/inop/runners/containerized_claude.py
@@ -86,7 +86,7 @@ def _monkey_patch_claude_sdk_for_containerization():
             raise RuntimeError("claude_binary not set in options")
         return bin_path
 
-    SubprocessCLITransport._find_cli = _patched_find_cli  # type: ignore[method-assign]
+    SubprocessCLITransport._find_cli = _patched_find_cli  # type: ignore[method-assign]  # noqa: SLF001
 
 
 # Apply monkeypatch once at module level

--- a/inventree_utils/beautifier/upload_lcsc_images.py
+++ b/inventree_utils/beautifier/upload_lcsc_images.py
@@ -71,7 +71,7 @@ def upload_lcsc_images(api: InvenTreeAPI):
         if lcsc_from_link and lcsc_from_supplier:
             # If both are present, assert they match
             if lcsc_from_link != lcsc_from_supplier:
-                raise ValueError(f"Conflicting LCSC IDs: {lcsc_from_link=} != {lcsc_from_supplier=}", log._context)
+                raise ValueError(f"Conflicting LCSC IDs: {lcsc_from_link=} != {lcsc_from_supplier=}", log._context)  # noqa: SLF001
             # Both match => use either one
             lcsc_id = lcsc_from_link
         elif lcsc_from_link or lcsc_from_supplier:

--- a/mcp_infra/compositor/notifications_buffer.py
+++ b/mcp_infra/compositor/notifications_buffer.py
@@ -36,10 +36,10 @@ class _ResourceNotificationHandler(MessageHandler):
 
     # Override with narrower types than base MessageHandler (which accepts Any)
     async def on_resource_updated(self, message: mcp_types.ResourceUpdatedNotification) -> None:
-        await self._buffer._on_updated(message)
+        await self._buffer.on_updated(message)
 
     async def on_resource_list_changed(self, message: mcp_types.ResourceListChangedNotification) -> None:
-        await self._buffer._on_list_changed(message)
+        await self._buffer.on_list_changed(message)
 
 
 class NotificationsBuffer:
@@ -77,13 +77,13 @@ class NotificationsBuffer:
         self._servers.clear()
         return batch
 
-    async def _on_updated(self, message: mcp_types.ResourceUpdatedNotification) -> None:
+    async def on_updated(self, message: mcp_types.ResourceUpdatedNotification) -> None:
         # Add URI to the server's update set
         uri_str = str(message.params.uri)
         server = await self._derive_server(uri_str)
         self._servers.setdefault(server, _ServerNoticeAccumulator()).updated.add(uri_str)
 
-    async def _on_list_changed(self, message: mcp_types.ResourceListChangedNotification) -> None:
+    async def on_list_changed(self, message: mcp_types.ResourceListChangedNotification) -> None:
         # Attribute origin using compositor-captured child notifications when available
         names = list(self._compositor.pop_recent_resource_list_changes())
         for name in names:
@@ -91,7 +91,7 @@ class NotificationsBuffer:
 
     async def _derive_server(self, uri: str) -> str:
         """Derive origin server from resource URI using all compositor mounts."""
-        mount_names = await self._compositor._mount_names()
+        mount_names = await self._compositor.mount_names()
         return derive_origin_server(uri, mount_names)
 
     async def _on_resource_listener(self, name: str, uri: str) -> None:

--- a/mcp_infra/compositor/resources_server.py
+++ b/mcp_infra/compositor/resources_server.py
@@ -750,8 +750,8 @@ class ResourcesServer(EnhancedFastMCP):
 
     async def _present_servers(self) -> set[str]:
         # Include all mounted servers, including in-proc mounts without typed specs.
-        # Use compositor._mount_names() directly; do not swallow errors.
-        names = await self._compositor._mount_names()
+        # Use compositor.mount_names() directly; do not swallow errors.
+        names = await self._compositor.mount_names()
         return set(names)
 
     def _get_or_create_sub(self, server: str, uri: str) -> SubscriptionRecord:

--- a/mcp_infra/compositor/server.py
+++ b/mcp_infra/compositor/server.py
@@ -54,13 +54,13 @@ class ChildNotificationHandler(MessageHandler):
         self._server_prefix = server_prefix
 
     async def on_resource_list_changed(self, message: mcp_types.ResourceListChangedNotification) -> None:
-        self._compositor._pending_resource_list_changes.add(self._server_prefix)
+        self._compositor.pending_resource_list_changes.add(self._server_prefix)
         # No forwarding here; child client handles forwarding via proxy
-        await self._compositor._notify_resource_list_change(self._server_prefix)
+        await self._compositor.notify_resource_list_change(self._server_prefix)
 
     async def on_resource_updated(self, message: mcp_types.ResourceUpdatedNotification) -> None:
         # Forward to listeners with origin attribution
-        await self._compositor._notify_resource_updated(self._server_prefix, str(message.params.uri))
+        await self._compositor.notify_resource_updated(self._server_prefix, str(message.params.uri))
 
 
 class CompositorState(Enum):
@@ -130,7 +130,7 @@ class BaseCompositor(FastMCP):
         self._mount_listeners: list[Callable[[MCPMountPrefix, MountEvent], Awaitable[None] | None]] = []
 
         # Resource change tracking
-        self._pending_resource_list_changes: set[MCPMountPrefix] = set()
+        self.pending_resource_list_changes: set[MCPMountPrefix] = set()
         self._resource_list_change_listeners: list[Callable[[MCPMountPrefix], Awaitable[None] | None]] = []
         self._resource_updated_listeners: list[Callable[[MCPMountPrefix, str], Awaitable[None] | None]] = []
 
@@ -157,7 +157,7 @@ class BaseCompositor(FastMCP):
         """
         self._resource_list_change_listeners.append(cb)
 
-    async def _notify_resource_list_change(self, prefix: MCPMountPrefix) -> None:
+    async def notify_resource_list_change(self, prefix: MCPMountPrefix) -> None:
         for cb in list(self._resource_list_change_listeners):
             res = cb(prefix)
             if asyncio.iscoroutine(res):
@@ -171,7 +171,7 @@ class BaseCompositor(FastMCP):
         """
         self._resource_updated_listeners.append(cb)
 
-    async def _notify_resource_updated(self, prefix: MCPMountPrefix, uri: str) -> None:
+    async def notify_resource_updated(self, prefix: MCPMountPrefix, uri: str) -> None:
         for cb in list(self._resource_updated_listeners):
             res = cb(prefix, uri)
             if asyncio.iscoroutine(res):
@@ -181,8 +181,8 @@ class BaseCompositor(FastMCP):
 
     def pop_recent_resource_list_changes(self) -> list[MCPMountPrefix]:
         """Return and clear servers that recently reported resource list changes."""
-        names = sorted(self._pending_resource_list_changes)
-        self._pending_resource_list_changes.clear()
+        names = sorted(self.pending_resource_list_changes)
+        self.pending_resource_list_changes.clear()
         return names
 
     async def server_entries(self) -> dict[MCPMountPrefix, ServerEntry]:
@@ -651,7 +651,7 @@ class BaseCompositor(FastMCP):
         print(msg, file=sys.stderr)
 
     # ---- Internals ----------------------------------------------------------
-    async def _mount_names(self) -> list[str]:
+    async def mount_names(self) -> list[str]:
         async with self._mount_lock:
             return list(self._mounts.keys())
 

--- a/mcp_infra/enhanced/server.py
+++ b/mcp_infra/enhanced/server.py
@@ -37,7 +37,7 @@ class _SessionCapturingMiddleware(Middleware):
         if context.fastmcp_context is not None and context.fastmcp_context.session is not None:
             session = context.fastmcp_context.session
             if isinstance(session, ServerSession):
-                self._enhanced._sessions.add(session)
+                self._enhanced._sessions.add(session)  # noqa: SLF001
                 await self._enhanced.flush_pending()
         return result
 

--- a/mcp_infra/stubs/resources_stub.py
+++ b/mcp_infra/stubs/resources_stub.py
@@ -41,4 +41,4 @@ class ResourcesServerStub(ServerStub):
 
     async def list_subscriptions(self) -> SubscriptionsIndex:
         """Read the subscriptions index resource and parse into a typed model."""
-        return await read_text_json_typed(self._client._session, "resources://subscriptions", SubscriptionsIndex)
+        return await read_text_json_typed(self._client._session, "resources://subscriptions", SubscriptionsIndex)  # noqa: SLF001

--- a/mcp_infra/stubs/typed_stubs.py
+++ b/mcp_infra/stubs/typed_stubs.py
@@ -97,7 +97,7 @@ class TypedClient:
         Requires a server created via FastMCP. Introspects FlatTool instances
         for input_model and return type annotations.
         """
-        components = server._local_provider._components
+        components = server._local_provider._components  # noqa: SLF001
 
         client = cls(session)
         for component in components.values():

--- a/mcp_infra/tool_schemas.py
+++ b/mcp_infra/tool_schemas.py
@@ -3,7 +3,7 @@
 Introspects tool return types from FastMCP server instances to build
 schema registries for typed display rendering.
 
-Uses FastMCP internal `_local_provider._components` because the public
+Uses FastMCP internal `_local_provider._components` because the public # noqa: SLF001
 `list_tools()` API is async and callers need sync access.
 """
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 def _iter_tools(server: FastMCP) -> list[Tool]:
     """Get tools from FastMCP server via sync internal access."""
-    return [c for c in server._local_provider._components.values() if isinstance(c, Tool)]
+    return [c for c in server._local_provider._components.values() if isinstance(c, Tool)]  # noqa: SLF001
 
 
 def extract_tool_schemas(servers: dict[MCPMountPrefix, FastMCP]) -> dict[tuple[MCPMountPrefix, str], type[BaseModel]]:

--- a/props/db/database.py
+++ b/props/db/database.py
@@ -63,10 +63,10 @@ class Database:
         call dispose() when done.
         """
         db = cls.__new__(cls)
-        db._config = config
-        db._engine = create_engine(config.url, echo=False, poolclass=NullPool)
+        db._config = config  # noqa: SLF001
+        db._engine = create_engine(config.url, echo=False, poolclass=NullPool)  # noqa: SLF001
 
-        @event.listens_for(db._engine, "checkout")
+        @event.listens_for(db._engine, "checkout")  # noqa: SLF001
         def _register_composite_types(
             dbapi_connection: Any, connection_record: ConnectionPoolEntry, connection_proxy: Any
         ) -> None:
@@ -75,7 +75,7 @@ class Database:
             except Exception as e:
                 logger.debug(f"Could not register stats_with_ci composite type: {e}")
 
-        db._scoped_factory = scoped_session(sessionmaker(bind=db._engine))
+        db._scoped_factory = scoped_session(sessionmaker(bind=db._engine))  # noqa: SLF001
         return db
 
     def __init__(self, config: DatabaseConfig) -> None:

--- a/props/testing/fake_openai_server.py
+++ b/props/testing/fake_openai_server.py
@@ -167,7 +167,7 @@ class FakeOpenAIServer:
             except Exception as e:
                 raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
 
-            mock = server_self._resolve_mock(body)
+            mock = server_self._resolve_mock(body)  # noqa: SLF001
 
             try:
                 req = ResponsesRequest.model_validate(body)
@@ -179,7 +179,7 @@ class FakeOpenAIServer:
                 result = await mock.responses_create(req)
             except Exception as e:
                 logger.exception("Mock raised exception")
-                server_self._capture_error(e)
+                server_self._capture_error(e)  # noqa: SLF001
                 raise HTTPException(status_code=500, detail=f"Mock error: {e}")
 
             sdk_response = result_to_sdk_response(result, model=body["model"])

--- a/ruff.toml
+++ b/ruff.toml
@@ -73,6 +73,7 @@ select = [
     "TRY401", # redundant exception object in logging.exception
     "TRY203", # useless try-except (just re-raises)
     "TRY400", # logging.error in except → logging.exception
+    "SLF",   # private member access
     "RUF"    # ruff-specific
 ]
 # Keep these off globally; handled case-by-case or via constants
@@ -168,4 +169,6 @@ split-on-trailing-comma = false
 "devinfra/ci/ci_decide.py" = ["E402"]
 # conftest.py re-exports fixtures for pytest discovery — imports are "unused" by design
 # and fixture parameters naturally shadow the imported fixture names (F811)
-"**/conftest.py" = ["F401", "F811"]
+"**/conftest.py" = ["F401", "F811", "SLF001"]
+# Tests routinely access private members for assertions
+"**/test_*.py" = ["SLF001"]

--- a/tana/query/search/evaluator.py
+++ b/tana/query/search/evaluator.py
@@ -67,7 +67,7 @@ class SearchEvaluator:
 
         yield from results
 
-    def _evaluate_tag(self, tag_node_id: NodeId) -> Iterator[BaseNode]:
+    def evaluate_tag(self, tag_node_id: NodeId) -> Iterator[BaseNode]:
         """
         Find all nodes with a specific tag.
 
@@ -85,7 +85,7 @@ class SearchEvaluator:
         # Use the existing filter_by_tag function
         yield from filter_by_tag(self.store, tag_node.name, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
-    def _evaluate_type(self, type_node_id: NodeId) -> Iterator[BaseNode]:
+    def evaluate_type(self, type_node_id: NodeId) -> Iterator[BaseNode]:
         """
         Find all nodes of a specific system type.
 
@@ -107,7 +107,7 @@ class SearchEvaluator:
 
         yield from filter_nodes(self.store, matches_type, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
-    def _evaluate_text(self, text: str) -> Iterator[BaseNode]:
+    def evaluate_text(self, text: str) -> Iterator[BaseNode]:
         """
         Find nodes matching text criteria.
 
@@ -130,7 +130,7 @@ class SearchEvaluator:
 
         yield from filter_nodes(self.store, matches_text, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
-    def _evaluate_field(self, field_name: str, values: list[str]) -> Iterator[BaseNode]:
+    def evaluate_field(self, field_name: str, values: list[str]) -> Iterator[BaseNode]:
         """
         Find nodes with specific field values.
 
@@ -157,7 +157,7 @@ class SearchEvaluator:
             skip_deleted=self.skip_deleted,
         )
 
-    def _evaluate_boolean(self, operator: BooleanOperator, operands: list[SearchExpression]) -> Iterator[BaseNode]:
+    def evaluate_boolean(self, operator: BooleanOperator, operands: list[SearchExpression]) -> Iterator[BaseNode]:
         """
         Evaluate a boolean expression.
 
@@ -234,24 +234,24 @@ def _evaluate_dispatch(expression: SearchExpression, evaluator: SearchEvaluator)
 
 @_evaluate_dispatch.register(TagSearch)
 def _(expression: TagSearch, evaluator: SearchEvaluator) -> Iterator[BaseNode]:
-    yield from evaluator._evaluate_tag(expression.tag_id)
+    yield from evaluator.evaluate_tag(expression.tag_id)
 
 
 @_evaluate_dispatch.register(TypeSearch)
 def _(expression: TypeSearch, evaluator: SearchEvaluator) -> Iterator[BaseNode]:
-    yield from evaluator._evaluate_type(expression.type_id)
+    yield from evaluator.evaluate_type(expression.type_id)
 
 
 @_evaluate_dispatch.register(TextSearch)
 def _(expression: TextSearch, evaluator: SearchEvaluator) -> Iterator[BaseNode]:
-    yield from evaluator._evaluate_text(expression.text)
+    yield from evaluator.evaluate_text(expression.text)
 
 
 @_evaluate_dispatch.register(FieldSearch)
 def _(expression: FieldSearch, evaluator: SearchEvaluator) -> Iterator[BaseNode]:
-    yield from evaluator._evaluate_field(expression.field_name, expression.values)
+    yield from evaluator.evaluate_field(expression.field_name, expression.values)
 
 
 @_evaluate_dispatch.register(BooleanSearch)
 def _(expression: BooleanSearch, evaluator: SearchEvaluator) -> Iterator[BaseNode]:
-    yield from evaluator._evaluate_boolean(expression.operator, expression.operands)
+    yield from evaluator.evaluate_boolean(expression.operator, expression.operands)

--- a/wt/server/wt_server.py
+++ b/wt/server/wt_server.py
@@ -32,10 +32,10 @@ from wt.server.gitstatusd_listener import GitstatusdListener
 
 # Force import of handlers to register RPC methods
 from wt.server.handlers import (
-    path_handler,  # noqa: F401
-    pr_handler,  # noqa: F401
-    status_handler,  # noqa: F401
-    worktree_handler,  # noqa: F401
+    path_handler,
+    pr_handler,
+    status_handler,
+    worktree_handler,
 )
 from wt.server.repo_status import RepoStatus
 from wt.server.rpc import ServiceDependencies, rpc
@@ -428,7 +428,7 @@ class WtDaemon:
     async def _handle_shutdown_request(self, request: Request, start_time: datetime | None = None) -> Response:
         """Handle shutdown JSON-RPC method."""
         logger.info("Received shutdown request")
-        self._shutdown_task = asyncio.create_task(self.stop())
+        self.shutdown_task = asyncio.create_task(self.stop())
         return self._create_success_response("shutting down", request.id)
 
     async def _ensure_git_watcher(self, worktree_info: DiscoveredWorktree) -> None:
@@ -602,7 +602,7 @@ async def run_daemon(config) -> None:
     # Signal handling
     def signal_handler():
         logger.info("Received shutdown signal")
-        daemon._shutdown_task = asyncio.create_task(daemon.stop())
+        daemon.shutdown_task = asyncio.create_task(daemon.stop())
 
     signal.signal(signal.SIGTERM, lambda s, f: signal_handler())
     signal.signal(signal.SIGINT, lambda s, f: signal_handler())

--- a/x/agent_server/mcp/approval_policy/engine.py
+++ b/x/agent_server/mcp/approval_policy/engine.py
@@ -269,7 +269,7 @@ class _PolicyGatewayMiddleware(Middleware):
         evaluate_policy: Callable[[PolicyRequest], Awaitable[PolicyResponse]],
         record_outcome: Callable[[str, str, ApprovalOutcome], Awaitable[None]] | None = None,
     ) -> None:
-        self._hub = hub
+        self.hub = hub
         self._evaluate = evaluate_policy
         self._record = record_outcome
         self._inflight: dict[str, str] = {}
@@ -353,7 +353,7 @@ class _PolicyGatewayMiddleware(Middleware):
             tool_key=tool_key,
             tool_call=ApprovalToolCall(name=name, call_id=call_id, args_json=_serialize_arguments_json(arguments)),
         )
-        decision_obj = await self._hub.await_decision(call_id, req)
+        decision_obj = await self.hub.await_decision(call_id, req)
 
         if isinstance(decision_obj, ContinueDecision):
             if self._record is not None:
@@ -442,7 +442,7 @@ class PolicyReaderServer(EnhancedFastMCP):
                         tool_key=req.tool_key,
                         args_json=req.tool_call.args_json if req.tool_call else None,
                     )
-                    for call_id, req in engine._hub.pending.items()
+                    for call_id, req in engine.hub.pending.items()
                 ]
             )
             return response.model_dump_json()
@@ -452,7 +452,7 @@ class PolicyReaderServer(EnhancedFastMCP):
         # Register tool with typed attribute
         async def evaluate_policy(input: PolicyRequest) -> PolicyResponse:
             """Evaluate a policy decision for a single tool call via Docker-backed evaluator."""
-            return await engine._evaluate_policy(input)
+            return await engine.evaluate_policy(input)
 
         self.evaluate_policy_tool = self.flat_model()(evaluate_policy)
 
@@ -511,13 +511,13 @@ class PolicyAdminServer(EnhancedFastMCP):
             decision = input.decision
 
             if decision == CallDecision.APPROVE:
-                engine._hub.resolve(call_id, ContinueDecision())
+                engine.hub.resolve(call_id, ContinueDecision())
             elif decision == CallDecision.DENY_ABORT:
-                engine._hub.resolve(call_id, AbortTurnDecision(reason="user_denied"))
+                engine.hub.resolve(call_id, AbortTurnDecision(reason="user_denied"))
             elif decision == CallDecision.DENY_CONTINUE:
                 # Continue without executing - resolve with continue decision
                 # The call is skipped but turn continues
-                engine._hub.resolve(call_id, ContinueDecision())
+                engine.hub.resolve(call_id, ContinueDecision())
             return SimpleOk()
 
         async def decide_proposal(input: DecideProposalArgs) -> SimpleOk:
@@ -552,7 +552,7 @@ class PolicyEngine:
     - reader: PolicyReaderServer with evaluate_policy, policy resources, pending://calls
     - proposer: PolicyProposerServer with propose/withdraw tools
     - admin: PolicyAdminServer with decide_call, decide_proposal, set_policy tools
-    - _hub: Internal ApprovalHub for pending call coordination
+    - hub: Internal ApprovalHub for pending call coordination
     - _gateway: PolicyGatewayMiddleware to install on compositor
     """
 
@@ -572,7 +572,7 @@ class PolicyEngine:
         self._bg_tasks: set[asyncio.Task] = set()
 
         # Create hub with on_change callback that broadcasts pending://calls
-        self._hub = _ApprovalHub(on_change=self._on_hub_change)
+        self.hub = _ApprovalHub(on_change=self._on_hub_change)
 
         # Create owned servers (now using extracted server classes)
         self.reader = PolicyReaderServer(self)
@@ -581,7 +581,7 @@ class PolicyEngine:
 
         # Protocol-level resource subscriptions on reader
         self._session_subscriptions: defaultdict[ServerSession, set[AnyUrl]] = defaultdict(set)
-        mcp_server = self.reader._mcp_server
+        mcp_server = self.reader._mcp_server  # noqa: SLF001
 
         def _subscriptions() -> set[AnyUrl]:
             return self._session_subscriptions[mcp_server.request_context.session]
@@ -596,7 +596,7 @@ class PolicyEngine:
 
         # Create gateway middleware (uses internal evaluate method)
         self._gateway = _PolicyGatewayMiddleware(
-            hub=self._hub, evaluate_policy=self._evaluate_policy, record_outcome=self._record_outcome
+            hub=self.hub, evaluate_policy=self.evaluate_policy, record_outcome=self._record_outcome
         )
 
         # Internal reader client for gateway (created lazily)
@@ -615,7 +615,7 @@ class PolicyEngine:
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
 
-    async def _evaluate_policy(self, request: PolicyRequest) -> PolicyResponse:
+    async def evaluate_policy(self, request: PolicyRequest) -> PolicyResponse:
         """Evaluate policy for a tool call via Docker-backed evaluator (uses injected client)."""
         logger.warning(f"[EVAL_START] Starting policy evaluation for {request.name}")
         evaluator = ContainerPolicyEvaluator(agent_id=self.agent_id, docker_client=self._docker_client, engine=self)

--- a/x/agent_server/mcp/chat/server.py
+++ b/x/agent_server/mcp/chat/server.py
@@ -160,7 +160,7 @@ class ChatStorePersisted(ChatStore):
 
     async def _fetch_optional_int(self, query: str, params: tuple) -> int | None:
         """Execute query and return optional int from first row, first column."""
-        async with self._persistence._open_row() as db, db.execute(query, params) as cur:
+        async with self._persistence.open_db_row() as db, db.execute(query, params) as cur:
             if (row := await cur.fetchone()) and (val := row[0]) is not None:
                 return int(val)
             return None
@@ -175,7 +175,7 @@ class ChatStorePersisted(ChatStore):
 
     async def append(self, *, author: ChatAuthor, mime: str, content: str) -> int:
         ts = datetime.now(UTC).isoformat()
-        async with self._persistence._open() as db:
+        async with self._persistence.open_db() as db:
             cur = await db.execute(
                 "INSERT INTO chat_messages (agent_id, ts, author, mime, content) VALUES (?, ?, ?, ?, ?)",
                 (self._agent, ts, author.value, mime, content),
@@ -189,7 +189,7 @@ class ChatStorePersisted(ChatStore):
 
     async def get_message_async(self, msg_id: int) -> ChatMessage | None:
         async with (
-            self._persistence._open_row() as db,
+            self._persistence.open_db_row() as db,
             db.execute(
                 "SELECT id, ts, author, mime, content FROM chat_messages WHERE agent_id = ? AND id = ?",
                 (self._agent, msg_id),
@@ -216,7 +216,7 @@ class ChatStorePersisted(ChatStore):
 
         # Fetch messages after HWM
         msgs: list[ChatMessage] = []
-        async with self._persistence._open_row() as db:
+        async with self._persistence.open_db_row() as db:
             sql = (
                 "SELECT id, ts, author, mime, content FROM chat_messages "
                 "WHERE agent_id = ? AND id > ? AND author = ? ORDER BY id ASC"
@@ -229,7 +229,7 @@ class ChatStorePersisted(ChatStore):
                 msgs = [_row_to_message(r) async for r in cur]
 
         if msgs:
-            async with self._persistence._open() as db:
+            async with self._persistence.open_db() as db:
                 await db.execute(
                     "INSERT INTO chat_last_read (agent_id, server_name, last_id) VALUES (?, ?, ?) "
                     "ON CONFLICT(agent_id, server_name) DO UPDATE SET last_id=excluded.last_id",

--- a/x/agent_server/mcp_bridge/registry.py
+++ b/x/agent_server/mcp_bridge/registry.py
@@ -108,22 +108,22 @@ class InfrastructureRegistry:
             await self._mount_agent_control(container)
 
         # Mount agent compositor to global
-        if container._compositor is None:
+        if container.compositor is None:
             raise RuntimeError(f"Agent container {container.agent_id} has no compositor after build")
 
         mount_prefix = agent_mount_prefix(container.agent_id)
-        await comp.mount_inproc(mount_prefix, container._compositor)
+        await comp.mount_inproc(mount_prefix, container.compositor)
 
     async def _mount_agent_control(self, container: AgentContainer) -> None:
         """Mount agent_control server on container's compositor.
 
         Only for internal agents - provides send_prompt and abort tools.
         """
-        if container._compositor is None:
+        if container.compositor is None:
             raise RuntimeError(f"Agent container {container.agent_id} has no compositor for agent_control mount")
 
         control_server = container.make_control_server()
-        await container._compositor.mount_inproc(AGENT_CONTROL_MOUNT_PREFIX, control_server)
+        await container.compositor.mount_inproc(AGENT_CONTROL_MOUNT_PREFIX, control_server)
         logger.debug(f"Mounted agent_control for internal agent: {container.agent_id}")
 
     async def _create_container(

--- a/x/agent_server/persist/sqlite.py
+++ b/x/agent_server/persist/sqlite.py
@@ -31,14 +31,14 @@ class SQLitePersistence(Persistence):
 
     # Centralized connection helpers to keep row_factory consistent
     @asynccontextmanager
-    async def _open(self):
+    async def open_db(self):
         async with aiosqlite.connect(self.db_path) as db:
             # Enforce FK cascades on every connection
             await db.execute("PRAGMA foreign_keys = ON;")
             yield db
 
     @asynccontextmanager
-    async def _open_row(self):
+    async def open_db_row(self):
         async with aiosqlite.connect(self.db_path) as db:
             # Enforce FK cascades on every connection
             await db.execute("PRAGMA foreign_keys = ON;")
@@ -52,7 +52,7 @@ class SQLitePersistence(Persistence):
         schema changes, recreate the database or manage data migration outside
         this helper.
         """
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute("PRAGMA foreign_keys = ON;")
             # executescript allows multiple statements in one call
             await db.executescript(
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS chat_last_read (
         # Generate agent_id compatible with MCPMountPrefix pattern: ^[a-z][a-z0-9_]*$
         # Prefix with 'a' to ensure it starts with a letter; UUID hex is [0-9a-f] which fits the pattern
         agent_id = f"a{uuid.uuid4().hex}"
-        async with self._open() as db:
+        async with self.open_db() as db:
             # Persist only user-configured servers (exclude default auto-attached)
             spec_json = filter_persistable_servers(mcp_config).model_dump(mode="json")
             await db.execute(
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS chat_last_read (
         return agent_id
 
     async def update_agent_specs(self, agent_id: AgentID, *, mcp_config: MCPConfig) -> None:
-        async with self._open() as db:
+        async with self.open_db() as db:
             spec_json = filter_persistable_servers(mcp_config).model_dump(mode="json")
             await db.execute(
                 "UPDATE agents SET specs = ? WHERE id = ?",
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS chat_last_read (
         return out
 
     async def get_agent(self, agent_id: AgentID) -> AgentRow | None:
-        async with self._open_row() as db:
+        async with self.open_db_row() as db:
             db.row_factory = aiosqlite.Row
             cur = await db.execute("SELECT id, created_at, specs, metadata FROM agents WHERE id = ?", (agent_id,))
             r = await cur.fetchone()
@@ -190,7 +190,7 @@ CREATE TABLE IF NOT EXISTS chat_last_read (
         """
         out: dict[str, datetime | None] = {}
         async with (
-            self._open_row() as db,
+            self.open_db_row() as db,
             db.execute(
                 """
 SELECT a.id as agent_id,
@@ -211,7 +211,7 @@ GROUP BY a.id
 
         Cascades to events, approvals, policies, and proposals.
         """
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute("DELETE FROM agents WHERE id = ?", (agent_id,))
             await db.commit()
 
@@ -219,7 +219,7 @@ GROUP BY a.id
     async def get_latest_policy(self, agent_id: AgentID) -> tuple[str, int] | None:
         """Return (content, version) of the latest approval policy for the agent, or None."""
         async with (
-            self._open_row() as db,
+            self.open_db_row() as db,
             db.execute(
                 """
 SELECT content, version
@@ -238,7 +238,7 @@ LIMIT 1
 
     async def set_policy(self, agent_id: AgentID, *, content: str) -> int:
         """Persist a new policy version for agent; returns assigned version."""
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 "INSERT INTO approval_policies (agent_id, content, created_at) VALUES (?, ?, ?)",
                 (agent_id, content, _now().isoformat()),
@@ -251,7 +251,7 @@ LIMIT 1
 
     # ---- Policy proposals (single-store: SQLite) ----------------------------
     async def create_policy_proposal(self, agent_id: AgentID, *, proposal_id: str, content: str) -> None:
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 """
 INSERT INTO policy_proposals (id, agent_id, content, status, created_at, decided_at)
@@ -263,7 +263,7 @@ VALUES (?, ?, ?, 'pending', ?, NULL)
 
     async def list_policy_proposals(self, agent_id: AgentID) -> list[PolicyProposal]:
         async with (
-            self._open_row() as db,
+            self.open_db_row() as db,
             db.execute(
                 """
 SELECT id, status, created_at, decided_at
@@ -288,7 +288,7 @@ ORDER BY created_at DESC
 
     async def get_policy_proposal(self, agent_id: AgentID, proposal_id: str) -> PolicyProposal | None:
         async with (
-            self._open_row() as db,
+            self.open_db_row() as db,
             db.execute(
                 """
 SELECT id, status, created_at, decided_at, content
@@ -316,7 +316,7 @@ WHERE agent_id = ? AND id = ?
         """
         # Read proposal content
         async with (
-            self._open_row() as db,
+            self.open_db_row() as db,
             db.execute(
                 "SELECT content FROM policy_proposals WHERE agent_id = ? AND id = ?", (agent_id, proposal_id)
             ) as cur,
@@ -326,7 +326,7 @@ WHERE agent_id = ? AND id = ?
                 raise KeyError("proposal_not_found")
             content = cast(str, row["content"])
         # Persist as active policy and mark proposal approved in one transaction
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 "INSERT INTO approval_policies (agent_id, content, created_at) VALUES (?, ?, ?)",
                 (agent_id, content, _now().isoformat()),
@@ -341,7 +341,7 @@ WHERE agent_id = ? AND id = ?
             return int(row[0]) if row and row[0] is not None else 0
 
     async def reject_policy_proposal(self, agent_id: AgentID, proposal_id: str) -> None:
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 "UPDATE policy_proposals SET status = 'rejected', decided_at = ? WHERE agent_id = ? AND id = ?",
                 (_now().isoformat(), agent_id, proposal_id),
@@ -349,7 +349,7 @@ WHERE agent_id = ? AND id = ?
             await db.commit()
 
     async def delete_policy_proposal(self, agent_id: AgentID, proposal_id: str) -> None:
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute("DELETE FROM policy_proposals WHERE agent_id = ? AND id = ?", (agent_id, proposal_id))
             await db.commit()
 
@@ -370,7 +370,7 @@ WHERE agent_id = ? AND id = ?
         s = pydantic_core.to_json(payload, fallback=str).decode("utf-8")
         if len(s.encode("utf-8")) > MAX_EVENT_PAYLOAD_BYTES:
             raise ValueError(f"event payload exceeds {MAX_EVENT_PAYLOAD_BYTES} bytes")
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 "INSERT INTO events (agent_id, seq, ts, type, payload, call_id, tool_key) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (agent_id, seq, ts.isoformat(), str(event_type), s, call_id, tool_key),
@@ -387,7 +387,7 @@ WHERE agent_id = ? AND id = ?
         decided_at: datetime,
         details: dict[str, JsonValue] | None = None,
     ) -> None:
-        async with self._open() as db:
+        async with self.open_db() as db:
             await db.execute(
                 """
 INSERT OR REPLACE INTO approvals (call_id, agent_id, tool_key, outcome, decided_at, details)

--- a/x/agent_server/runtime/container.py
+++ b/x/agent_server/runtime/container.py
@@ -237,10 +237,10 @@ class AgentContainer:
     _closed: asyncio.Event = field(default_factory=asyncio.Event, init=False)
     _stack: AsyncExitStack = field(default_factory=AsyncExitStack, init=False)
     # Internal helpers/state
-    _cm: UiEventHandler | None = field(default=None, init=False)
+    cm: UiEventHandler | None = field(default=None, init=False)
     _ui_bus: ServerBus | None = field(default=None, init=False)
     # Compositor instance (AgentContainerCompositor with all agent-specific servers)
-    _compositor: AgentContainerCompositor | None = field(default=None, init=False)
+    compositor: AgentContainerCompositor | None = field(default=None, init=False)
     # Front-door MCP client (FastMCP Client connected to the compositor with policy middleware)
     _compositor_client: Client | None = field(default=None, init=False)
 
@@ -253,9 +253,9 @@ class AgentContainer:
     def runtime_server(self):
         """Get the runtime server instance (if compositor is started and runtime is mounted)."""
 
-        if self._compositor is None or self._compositor.runtime is None:
+        if self.compositor is None or self.compositor.runtime is None:
             return None
-        return self._compositor.runtime.server
+        return self.compositor.runtime.server
 
     async def list_mcp_entries(self) -> dict[str, ServerEntry]:
         """Return full per-server entries via compositor_meta resources.
@@ -267,7 +267,7 @@ class AgentContainer:
         meta = CompositorMetaClient(self._compositor_client)
         return cast(dict[str, ServerEntry], await meta.list_states())
 
-    def _get_session(self) -> AgentSession:
+    def get_session(self) -> AgentSession:
         """Get the agent session, raising ToolError if not initialized."""
         if self.session is None:
             raise ToolError("Agent session not initialized")
@@ -289,14 +289,14 @@ class AgentContainer:
         @mcp.flat_model()
         async def send_prompt(input: SendPromptInput) -> str:
             """Send a prompt to the agent."""
-            session = container._get_session()
+            session = container.get_session()
             await session.run(input.prompt)
             return "Prompt sent successfully"
 
         @mcp.flat_model()
         async def abort() -> str:
             """Abort the currently active agent."""
-            session = container._get_session()
+            session = container.get_session()
             await session.cancel_active_run()
             return "Agent aborted successfully"
 
@@ -353,7 +353,7 @@ class AgentContainer:
             tuple: (compositor, mcp_client, notifications_buffer)
         """
         # Session & manager
-        self._cm = UiEventHandler()
+        self.cm = UiEventHandler()
 
         # Initialize AsyncExitStack and enter contexts through it
         await self._stack.__aenter__()
@@ -368,25 +368,25 @@ class AgentContainer:
             persistence=self.persistence,
             agent_id=self.agent_id,
         )
-        self._compositor = await self._stack.enter_async_context(compositor)
-        assert self._compositor is not None  # Type narrowing for mypy
+        self.compositor = await self._stack.enter_async_context(compositor)
+        assert self.compositor is not None  # Type narrowing for mypy
 
         # Mount external servers from config (compositor is in ACTIVE state)
-        await self._compositor.mount_servers_from_config(mcp_config)
+        await self.compositor.mount_servers_from_config(mcp_config)
 
         # Notifications buffer for MCP events
-        notif_buffer = NotificationsBuffer(compositor=self._compositor)
+        notif_buffer = NotificationsBuffer(compositor=self.compositor)
 
         # In-proc client to the compositor with policy middleware
-        mcp_client = Client(self._compositor, message_handler=notif_buffer.handler)
+        mcp_client = Client(self.compositor, message_handler=notif_buffer.handler)
         await self._stack.enter_async_context(mcp_client)
         self._compositor_client = mcp_client
         self._notif_buffer = notif_buffer
 
         # Install policy gateway middleware from engine
-        self._compositor.add_middleware(approval_engine.gateway)
+        self.compositor.add_middleware(approval_engine.gateway)
 
-        return (self._compositor, mcp_client, notif_buffer)
+        return (self.compositor, mcp_client, notif_buffer)
 
     async def _setup_agent_runtime(
         self, mcp_client: Client, notifications: NotificationsBuffer, approval_engine: PolicyEngine
@@ -404,9 +404,9 @@ class AgentContainer:
         Returns:
             tuple: (session, agent)
         """
-        if self._cm is None:
+        if self.cm is None:
             raise RuntimeError("connection manager not initialized")
-        manager = self._cm
+        manager = self.cm
 
         # Create session
         sess = AgentSession(
@@ -415,7 +415,7 @@ class AgentContainer:
             agent_id=self.agent_id,
             approval_engine=approval_engine,
             ui_bus=self._ui_bus if self.with_ui else None,
-            ui_mount=self._compositor.ui if self.with_ui and self._compositor else None,
+            ui_mount=self.compositor.ui if self.with_ui and self.compositor else None,
         )
 
         # LLM client
@@ -427,7 +427,7 @@ class AgentContainer:
             manager=manager,
             persistence=self.persistence,
             agent_id=self.agent_id,
-            compositor=self._compositor,
+            compositor=self.compositor,
             ui_bus=self._ui_bus if self.with_ui else None,
         )
         sess.set_persist_handler(persist_handler)
@@ -435,14 +435,14 @@ class AgentContainer:
         # Compose base system text and provide a dynamic provider that recomputes
         # grouped MCP instructions/capabilities on each sampling.
         base_system = self.system_override or str(get_ui_system_message())
-        assert self._compositor is not None
+        assert self.compositor is not None
 
         # Start agent
         agent = await Agent.create(
             tool_provider=MCPToolProvider(mcp_client),
             client=client,
             handlers=handlers,
-            dynamic_instructions=self._compositor.render_agent_dynamic_instructions,
+            dynamic_instructions=self.compositor.render_agent_dynamic_instructions,
             tool_policy=RequireAnyTool(),
         )
         agent.process_message(SystemMessage.text(base_system))
@@ -470,7 +470,7 @@ class AgentContainer:
                 self.approval_engine = await self._setup_approval_infrastructure()
 
                 # Phase 2: MCP infrastructure
-                (self._compositor, self._compositor_client, self._notif_buffer) = await self._setup_mcp_infrastructure(
+                (self.compositor, self._compositor_client, self._notif_buffer) = await self._setup_mcp_infrastructure(
                     self.approval_engine, mcp_cfg
                 )
 
@@ -481,9 +481,9 @@ class AgentContainer:
 
                 return None
             case _SamplingSnapshotMsg():
-                if self._compositor is None:
+                if self.compositor is None:
                     return None
-                return await self._compositor.sampling_snapshot()
+                return await self.compositor.sampling_snapshot()
             case _CloseMsg():
                 return await self._op_close()
             case _:

--- a/x/agent_server/server/app.py
+++ b/x/agent_server/server/app.py
@@ -144,8 +144,8 @@ def create_app(*, require_static_assets: bool = True) -> FastAPI:
         # Legacy registry path for backwards compatibility
         for container in app.state.registry.list():
             # Flush legacy UI manager
-            if container._ui_manager:
-                await container._ui_manager.flush()
+            if container.cm:
+                await container.cm.flush()
         await app.state.registry.close_all()
 
         # Close async Docker client

--- a/x/agent_server/server/mcp_routing.py
+++ b/x/agent_server/server/mcp_routing.py
@@ -94,9 +94,9 @@ class MCPRoutingMiddleware(BaseHTTPMiddleware):
             container = self.registry.get(agent_id)
             if container is None:
                 return Response(content=f"Agent not found: {agent_id}", status_code=404)
-            if container._compositor is None:
+            if container.compositor is None:
                 return Response(content=f"Agent compositor not ready: {agent_id}", status_code=503)
-            request.state.mcp_target = container._compositor
+            request.state.mcp_target = container.compositor
         else:
             return Response(content=f"Unknown identity type: {identity}", status_code=400)
 

--- a/x/agent_server/server/runtime.py
+++ b/x/agent_server/server/runtime.py
@@ -48,7 +48,7 @@ class UiEventHandler(BaseHandler):
 
     async def _send_and_reduce(self, payload: ServerMessage) -> None:
         assert self._session is not None
-        await self._session._apply_ui_event(payload)
+        await self._session.apply_ui_event(payload)
 
     async def _emit_ui_bus_messages(self) -> None:
         assert self._session is not None
@@ -125,7 +125,7 @@ class AgentSession:
     def set_persist_handler(self, handler: RunPersistenceHandler) -> None:
         self._persist_handler = handler
 
-    async def _apply_ui_event(self, evt: ServerMessage) -> None:
+    async def apply_ui_event(self, evt: ServerMessage) -> None:
         self.ui_state = self._reducer.reduce(self.ui_state, evt)
 
     async def run(self, prompt: str) -> None:

--- a/x/claude_linter_v2/hooks/handler.py
+++ b/x/claude_linter_v2/hooks/handler.py
@@ -115,7 +115,7 @@ class HookHandler:
             # Set log level from config
             log_level = config.log_level
             try:
-                level_value = logging._nameToLevel.get(log_level.upper(), logging.INFO)
+                level_value = logging.getLevelNamesMapping().get(log_level.upper(), logging.INFO)
                 file_handler.setLevel(level_value)
             except (AttributeError, KeyError):
                 file_handler.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- Enable `SLF` (flake8-self) in `ruff.toml`
- Fix 59 violations: make members public (remove underscore prefix) or add `# noqa: SLF001` for unavoidable external library internals
- Per-file-ignores: `SLF001` exempted in `**/test_*.py` and `**/conftest.py`

Key renames: `_req_storage` → `req_storage`, `_running` → `running`, `_mount_names` → `mount_names`, `_hub` → `hub`, `_compositor` → `compositor`, `_open` → `open_db`, `_shutdown_task` → `shutdown_task`, etc.

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF