### PR TITLE
Add target log download and improve artifact/invocation CLI

### DIFF
--- a/agent_core/testing/assertions.py
+++ b/agent_core/testing/assertions.py
@@ -35,7 +35,7 @@ def get_last_function_output[T: BaseModel](req: ResponsesRequest, output_type: t
         ValueError: If structured content is missing or result is an error
     """
     if isinstance(req.input, str):
-        raise TypeError("Cannot extract from string input")
+        raise RuntimeError("Cannot extract from string input")
 
     # Find last FunctionCallOutputItem with output
     for item in reversed(req.input):

--- a/airlock/proxy_server.py
+++ b/airlock/proxy_server.py
@@ -423,7 +423,7 @@ class AirlockServer(EnhancedFastMCP):
         if action is None:
             raise ValueError(f"Action not found: {key.session_key}/{key.action_seq}")
         if not isinstance(action.state, PendingState):
-            raise TypeError(f"Action {key.session_key}/{key.action_seq} is not pending ({action.state.status=})")
+            raise ValueError(f"Action {key.session_key}/{key.action_seq} is not pending ({action.state.status=})")
         fut = self._pending_decisions.get(key)
         if fut is None or fut.done():
             raise ValueError(f"Action {key.session_key}/{key.action_seq} is not awaiting a human decision")
@@ -438,7 +438,7 @@ class AirlockServer(EnhancedFastMCP):
         if action is None:
             raise ValueError(f"Action not found: {key.session_key}/{key.action_seq}")
         if not isinstance(action.state, PendingState):
-            raise TypeError(f"Action {key.session_key}/{key.action_seq} is not pending ({action.state.status=})")
+            raise ValueError(f"Action {key.session_key}/{key.action_seq} is not pending ({action.state.status=})")
         result = await self._update_and_notify(key, WithdrawnState(), WithdrawnDetail())
         fut = self._pending_decisions.pop(key, None)
         if fut is not None and not fut.done():

--- a/devinfra/buildbuddy_cli/cmd_artifact.go
+++ b/devinfra/buildbuddy_cli/cmd_artifact.go
@@ -28,7 +28,7 @@ func artifactCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			artifacts, err := listArtifacts(c, args[0])
+			artifacts, err := listArtifactsResolved(c, args[0])
 			if err != nil {
 				return err
 			}
@@ -67,6 +67,34 @@ func downloadArtifact(c *client, artifacts []artifact, substr string) error {
 		}
 	}
 	if len(matches) == 0 {
+		// Show a few available artifacts as hints
+		seen := map[string]bool{}
+		count := 0
+		fmt.Fprintf(os.Stderr, "No artifacts matching %q\n", substr)
+		if len(artifacts) > 0 {
+			fmt.Fprintf(os.Stderr, "\nAvailable labels (first 5):\n")
+			for _, a := range artifacts {
+				if !seen[a.Label] {
+					seen[a.Label] = true
+					fmt.Fprintf(os.Stderr, "  %s\n", a.Label)
+					count++
+					if count >= 5 {
+						remaining := 0
+						for _, a2 := range artifacts {
+							if !seen[a2.Label] {
+								seen[a2.Label] = true
+								remaining++
+							}
+						}
+						if remaining > 0 {
+							fmt.Fprintf(os.Stderr, "  ... (%d more labels)\n", remaining)
+						}
+						break
+					}
+				}
+			}
+			fmt.Fprintf(os.Stderr, "\nHint: match is against \"label/name\" (e.g., \"test_handlers/test.log\")\n")
+		}
 		return fmt.Errorf("no artifacts matching %q", substr)
 	}
 	if len(matches) > 1 {
@@ -84,6 +112,23 @@ func downloadArtifact(c *client, artifacts []artifact, substr string) error {
 	}
 	_, err = os.Stdout.Write(data)
 	return err
+}
+
+// listArtifactsResolved lists artifacts, auto-resolving workflow invocations to children.
+func listArtifactsResolved(c *client, invocationID string) ([]artifact, error) {
+	ids, err := resolveInvocationIDs(c, invocationID)
+	if err != nil {
+		return nil, err
+	}
+	var all []artifact
+	for _, id := range ids {
+		arts, err := listArtifacts(c, id)
+		if err != nil {
+			return nil, fmt.Errorf("list artifacts for %s: %w", id, err)
+		}
+		all = append(all, arts...)
+	}
+	return all, nil
 }
 
 func listArtifacts(c *client, invocationID string) ([]artifact, error) {

--- a/devinfra/buildbuddy_cli/cmd_invocation.go
+++ b/devinfra/buildbuddy_cli/cmd_invocation.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-
 	eventlogpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 	invocationpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	"github.com/spf13/cobra"
 )
 
 func invocationCmd() *cobra.Command {
@@ -57,6 +56,18 @@ func invocationCmd() *cobra.Command {
 					fmt.Printf("CAS Hits:    %d\n", cs.GetCasCacheHits())
 					fmt.Printf("DL bytes:    %d\n", cs.GetTotalDownloadSizeBytes())
 					fmt.Printf("UL bytes:    %d\n", cs.GetTotalUploadSizeBytes())
+				}
+				// Show child invocation IDs (for workflow invocations)
+				for _, ev := range inv.GetEvent() {
+					be := ev.GetBuildEvent()
+					if be == nil {
+						continue
+					}
+					for _, child := range be.GetChildren() {
+						if cid := child.GetChildInvocationCompleted(); cid != nil && cid.GetInvocationId() != "" {
+							fmt.Printf("Child:       %s\n", cid.GetInvocationId())
+						}
+					}
 				}
 			}
 			return nil
@@ -148,4 +159,46 @@ func invocationLogCmd() *cobra.Command {
 	}
 	cmd.Flags().Int32Var(&minLines, "lines", 500, "Minimum lines to fetch")
 	return cmd
+}
+
+// getChildInvocationIDs returns child invocation IDs for a workflow invocation.
+// Returns nil if the invocation has no children (i.e., is not a workflow wrapper).
+func getChildInvocationIDs(c *client, invocationID string) ([]string, error) {
+	req := &invocationpb.GetInvocationRequest{
+		Lookup: &invocationpb.InvocationLookup{InvocationId: invocationID},
+	}
+	resp := &invocationpb.GetInvocationResponse{}
+	if err := c.call("GetInvocation", req, resp); err != nil {
+		return nil, err
+	}
+	var children []string
+	for _, inv := range resp.GetInvocation() {
+		for _, ev := range inv.GetEvent() {
+			be := ev.GetBuildEvent()
+			if be == nil {
+				continue
+			}
+			for _, child := range be.GetChildren() {
+				if cid := child.GetChildInvocationCompleted(); cid != nil && cid.GetInvocationId() != "" {
+					children = append(children, cid.GetInvocationId())
+				}
+			}
+		}
+	}
+	return children, nil
+}
+
+// resolveInvocationIDs returns the invocation ID(s) to query for artifacts/targets.
+// For workflow invocations (which have children), returns child IDs.
+// For regular invocations, returns the original ID.
+func resolveInvocationIDs(c *client, invocationID string) ([]string, error) {
+	children, err := getChildInvocationIDs(c, invocationID)
+	if err != nil {
+		return nil, err
+	}
+	if len(children) > 0 {
+		fmt.Fprintf(os.Stderr, "Workflow invocation, using child: %s\n", strings.Join(children, ", "))
+		return children, nil
+	}
+	return []string{invocationID}, nil
 }

--- a/devinfra/buildbuddy_cli/cmd_target.go
+++ b/devinfra/buildbuddy_cli/cmd_target.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -52,6 +54,7 @@ func targetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&label, "label", "", "Filter to specific target label")
 	cmd.Flags().StringVar(&filter, "filter", "", "Substring filter on target labels")
 	cmd.AddCommand(targetHistorySubCmd())
+	cmd.AddCommand(targetLogSubCmd())
 	return cmd
 }
 
@@ -104,5 +107,84 @@ func targetHistorySubCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "Repository URL (default: auto-detect from git)")
 	cmd.Flags().StringVar(&label, "label", "", "Filter to specific target label")
+	return cmd
+}
+
+func targetLogSubCmd() *cobra.Command {
+	var artifactName string
+	cmd := &cobra.Command{
+		Use:   "log <invocation-id> <target-label-or-substring>",
+		Short: "Print test.log for a target (downloads from BES artifacts)",
+		Long: `Download and print the test log for a specific target.
+
+Uses the BES (Build Event Stream) artifacts to find and download the test.log
+for the given target. The second argument is matched as a substring against
+"label/name" (e.g., "test_handlers" matches "//x/gatelet/server/auth:test_handlers/test.log").
+
+Examples:
+  bbapi target log <invocation-id> test_handlers
+  bbapi target log <invocation-id> //x/gatelet/server/auth:test_handlers
+  bbapi target log <invocation-id> test_handlers --artifact test.xml`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			artifacts, err := listArtifactsResolved(c, args[0])
+			if err != nil {
+				return err
+			}
+			// Filter to matching target and artifact name
+			var matches []artifact
+			for _, a := range artifacts {
+				combined := a.Label + "/" + a.Name
+				if strings.Contains(combined, args[1]) && strings.Contains(a.Name, artifactName) {
+					matches = append(matches, a)
+				}
+			}
+			if len(matches) == 0 {
+				// Provide helpful suggestions
+				fmt.Fprintf(os.Stderr, "No artifacts matching target %q with artifact %q\n\n", args[1], artifactName)
+				var targetMatches []artifact
+				for _, a := range artifacts {
+					if strings.Contains(a.Label+"/"+a.Name, args[1]) {
+						targetMatches = append(targetMatches, a)
+					}
+				}
+				if len(targetMatches) > 0 {
+					fmt.Fprintf(os.Stderr, "Artifacts for matching targets:\n")
+					for _, a := range targetMatches {
+						fmt.Fprintf(os.Stderr, "  %s  %s\n", a.Label, a.Name)
+					}
+				} else {
+					// Show a few available targets as hints
+					seen := map[string]bool{}
+					count := 0
+					fmt.Fprintf(os.Stderr, "No targets match %q. Available targets (first 5):\n", args[1])
+					for _, a := range artifacts {
+						if !seen[a.Label] {
+							seen[a.Label] = true
+							fmt.Fprintf(os.Stderr, "  %s\n", a.Label)
+							count++
+							if count >= 5 {
+								fmt.Fprintf(os.Stderr, "  ... (%d more)\n", len(artifacts)-count)
+								break
+							}
+						}
+					}
+				}
+				return fmt.Errorf("no matching artifacts found")
+			}
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr, "Multiple matches, using first:\n")
+				for _, a := range matches {
+					fmt.Fprintf(os.Stderr, "  %s  %s\n", a.Label, a.Name)
+				}
+			}
+			return downloadArtifact(c, matches[:1], matches[0].Label+"/"+matches[0].Name)
+		},
+	}
+	cmd.Flags().StringVar(&artifactName, "artifact", "test.log", "Artifact name to download (default: test.log)")
 	return cmd
 }

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -264,6 +264,7 @@ py_test(
         "testdata/ruff_repo/ruff.toml",
         "@multitool//tools/ruff",
     ],
+    env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
     imports = ["../../.."],
     deps = [
         ":hook_daemon_conftest",
@@ -274,5 +275,6 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
+        "@rules_python//python/runfiles",
     ],
 )

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -341,7 +341,9 @@ async def _setup_web(
     if isinstance(precommit_result, BaseException):
         logger.warning("Failed to install git pre-commit: %s", precommit_result)
     if isinstance(bazelisk_result, BaseException):
-        raise TypeError("Bazel wrapper setup failed (is bazelisk on PATH from Nix web-session?)") from bazelisk_result
+        raise RuntimeError(
+            "Bazel wrapper setup failed (is bazelisk on PATH from Nix web-session?)"
+        ) from bazelisk_result
     if isinstance(tmpfs_result, BaseException):
         logger.warning("Failed to set up tmpfs caches: %s", tmpfs_result)
     if isinstance(mkcert_result, SkipError):
@@ -363,7 +365,7 @@ async def _setup_web(
     # Proxy setup is required - propagate failure with clear error message
     if isinstance(auth_proxy_result, BaseException):
         logger.error("Proxy setup failed: %s", auth_proxy_result)
-        raise TypeError(f"Proxy setup failed: {auth_proxy_result}") from auth_proxy_result
+        raise RuntimeError(f"Proxy setup failed: {auth_proxy_result}") from auth_proxy_result
 
     combined_ca = paths.auth_proxy_combined_ca
 

--- a/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
+++ b/devinfra/claude/hook_daemon/test_post_tool_use_ruff_e2e.py
@@ -5,16 +5,32 @@ it does NOT persist import removal to disk, and the hook output correctly
 characterizes the situation.
 """
 
+import os
 import shutil
 from pathlib import Path
 from textwrap import dedent
 
 import pytest
 import pytest_bazel
+from python.runfiles import Runfiles
 
 from devinfra.claude.claude_api.hooks.post_tool_use import PostToolUseInput
 from devinfra.claude.hook_daemon.conftest import init_git_repo, write_precommit_config
 from devinfra.claude.hook_daemon.post_tool_use import evaluate
+
+
+def _find_ruff() -> str:
+    """Resolve ruff binary via RUFF_BIN env var (rlocation) or PATH fallback."""
+    if env_val := os.environ.get("RUFF_BIN"):
+        r = Runfiles.Create()
+        if r and (resolved := r.Rlocation(env_val)):
+            return resolved
+        if Path(env_val).exists():
+            return env_val
+    if which_path := shutil.which("ruff"):
+        return which_path
+    raise FileNotFoundError("ruff binary not found (set RUFF_BIN or add to PATH)")
+
 
 _COMMON_INPUT = {
     "session_id": "test-session",
@@ -35,8 +51,7 @@ def ruff_repo(tmp_path: Path) -> Path:
     repo_path = tmp_path / "repo"
     shutil.copytree(_TESTDATA, repo_path)
 
-    ruff_path = shutil.which("ruff")
-    assert ruff_path is not None, "ruff binary not found on PATH (expected via @multitool//tools/ruff data dep)"
+    ruff_path = _find_ruff()
 
     write_precommit_config(
         repo_path,

--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -588,4 +588,4 @@ manifest:
     zstandard: zstandard
   pip_repository:
     name: pypi
-integrity: 57ad9a2ed439f89ce35d1d9dd3c309de420813a5cd9543c1f4ee8cb863eaf61c
+integrity: d35ec6207796ddab1cdc1f0d4f2561dd65ac1d21fd241b71bb3e2d895b1a0c5d

--- a/ember/matrix_client.py
+++ b/ember/matrix_client.py
@@ -373,7 +373,7 @@ class MatrixClient:
         alias = RoomAlias(identifier)
         response = await self._client.room_resolve_alias(str(alias))
         if isinstance(response, RoomResolveAliasError):
-            raise TypeError(f"Failed to resolve Matrix alias {alias}: {response.message}")
+            raise RuntimeError(f"Failed to resolve Matrix alias {alias}: {response.message}")
         if not isinstance(response, RoomResolveAliasResponse) or not response.room_id:
             raise RuntimeError(f"Matrix alias {alias} returned no room_id")
         return RoomID(response.room_id)
@@ -396,7 +396,7 @@ class MatrixClient:
 
         whoami = await client.whoami()
         if isinstance(whoami, WhoamiError):
-            raise TypeError(f"Matrix whoami failed: {whoami.message}")
+            raise RuntimeError(f"Matrix whoami failed: {whoami.message}")
         if not isinstance(whoami, WhoamiResponse) or not whoami.user_id:
             raise RuntimeError("Matrix whoami response missing user_id")
 

--- a/inop/runners/containerized_claude.py
+++ b/inop/runners/containerized_claude.py
@@ -80,7 +80,7 @@ def _monkey_patch_claude_sdk_for_containerization():
 
     def _patched_find_cli(self) -> str:
         if not isinstance(self._options, ContainerizedClaudeCodeOptions):
-            raise TypeError("No claude_binary in options")
+            raise RuntimeError("No claude_binary in options")
         bin_path = self._options.claude_binary
         if not bin_path:
             raise RuntimeError("claude_binary not set in options")

--- a/mcp_infra/compositor/clients.py
+++ b/mcp_infra/compositor/clients.py
@@ -27,7 +27,7 @@ class CompositorMetaClient:
             isinstance(transport := self._client.transport, FastMCPTransport)
             and isinstance(comp := transport.server, Compositor)
         ):
-            raise TypeError("CompositorMetaClient requires an in-process Compositor transport")
+            raise RuntimeError("CompositorMetaClient requires an in-process Compositor transport")
         return cast(dict[str, ServerEntry], await comp.server_entries())
 
 

--- a/mcp_infra/compositor/mount.py
+++ b/mcp_infra/compositor/mount.py
@@ -141,14 +141,14 @@ class Mount:
     def proxy(self) -> FastMCPProxy:
         """Get proxy. Raises if mount not active."""
         if not isinstance(self._state_data, _MountActive):
-            raise TypeError(f"Mount '{self._prefix}' not active (state: {self._state_data.kind.name})")
+            raise RuntimeError(f"Mount '{self._prefix}' not active (state: {self._state_data.kind.name})")
         return self._state_data.proxy
 
     @property
     def child_client(self) -> Client:
         """Get child client. Raises if mount not active."""
         if not isinstance(self._state_data, _MountActive):
-            raise TypeError(f"Mount '{self._prefix}' not active (state: {self._state_data.kind.name})")
+            raise RuntimeError(f"Mount '{self._prefix}' not active (state: {self._state_data.kind.name})")
         return self._state_data.child_client
 
     # Setup methods
@@ -170,7 +170,7 @@ class Mount:
             Exception: If setup fails (after cleanup)
         """
         if not isinstance(self._state_data, _MountPending):
-            raise TypeError(f"Mount '{self._prefix}' already setup")
+            raise RuntimeError(f"Mount '{self._prefix}' already setup")
 
         stack = AsyncExitStack()
         try:
@@ -227,7 +227,7 @@ class Mount:
             Exception: If setup fails (after cleanup)
         """
         if not isinstance(self._state_data, _MountPending):
-            raise TypeError(f"Mount '{self._prefix}' already setup")
+            raise RuntimeError(f"Mount '{self._prefix}' already setup")
 
         stack = AsyncExitStack()
         try:

--- a/props/testing/fixtures/testdata/specimens/test-fixtures/train1/code/divide.py
+++ b/props/testing/fixtures/testdata/specimens/test-fixtures/train1/code/divide.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Division operations for test fixture."""
 
 

--- a/props/testing/fixtures/testdata/specimens/test-fixtures/train1/code/subtract.py
+++ b/props/testing/fixtures/testdata/specimens/test-fixtures/train1/code/subtract.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """A trivial script that subtracts two numbers."""
 
 

--- a/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/code/sample_subtract.py
+++ b/props/testing/fixtures/testdata/specimens/test-fixtures/valid1/code/sample_subtract.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """A trivial script that subtracts two numbers."""
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -63,7 +63,10 @@ select = [
     "N",     # naming
     "PERF",  # perflint
     "FAST",  # FastAPI best practices
-    "TRY004", # prefer TypeError for type checks
+    # TRY004 disabled: isinstance() checks are used for state validation (e.g.,
+    # "mount not active", "app resources not initialized"), not just type narrowing.
+    # TRY004 blindly converts these to TypeError, which is semantically wrong —
+    # a mount being in the wrong lifecycle state is a RuntimeError, not a type error.
     "EXE",   # shebang/executable consistency
     "RUF"    # ruff-specific
 ]

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -75,7 +75,7 @@ bbapi invocation log <invocation-id>
 # 3. Download the test.log for a specific failed target
 #    Works with both workflow and child invocation IDs (auto-resolves)
 bbapi target log <invocation-id> <target-substring>
-#    Example: bbapi target log 870a5be1 test_handlers
+#    Example: bbapi target log 870a5be1-c296-4792-8c8a-77def20b2dcc test_handlers
 ```
 
 ### Workflow vs Child Invocations

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -22,14 +22,26 @@ All commands require `BUILDBUDDY_API_KEY` to be set (session hook exports it aut
 If `bbapi` is in PATH, prefer it over raw API calls:
 
 ```bash
-# Show invocation details
+# Show invocation details (shows child invocation IDs for workflows)
 bbapi invocation <invocation-id>
 
 # List recent invocations (auto-detects repo from git remote)
 bbapi invocation list [--repo URL] [--count N]
 
-# Print build log
+# Print build log (shows test pass/fail summary with test.log paths)
 bbapi invocation log <invocation-id>
+
+# Download test.log for a specific target (most common for debugging failures)
+bbapi target log <invocation-id> <target-label-or-substring>
+
+# List targets in an invocation
+bbapi target <invocation-id> [--filter SUBSTR] [--label LABEL]
+
+# Show pass/fail/flake history for targets
+bbapi target history <target-label>
+
+# List artifacts, or download one by name match
+bbapi artifact <invocation-id> [name-substring]
 
 # List remote executions for an invocation
 bbapi execution <invocation-id>
@@ -41,22 +53,52 @@ bbapi execution search <query>
 bbapi cache <invocation-id>
 
 # Get metadata for a cached artifact by digest
-bbapi cache metadata <digest>
-
-# List artifacts, or download one by name match
-bbapi artifact <invocation-id> [name-substring]
-
-# List targets in an invocation
-bbapi target <invocation-id> [--filter SUBSTR] [--label LABEL]
-
-# Show pass/fail/flake history for targets
-bbapi target history <target-label>
+bbapi cache metadata <digest> <size-bytes>
 
 # Show build performance trends
 bbapi trend [--days N] [--repo URL]
 ```
 
 All commands support `--json` for raw JSON output.
+
+## Investigating Failed CI Builds
+
+Typical workflow for debugging a failed CI build:
+
+```bash
+# 1. Get invocation details — note the Child: line for workflow invocations
+bbapi invocation <invocation-id>
+
+# 2. Get the build log to see which tests failed
+bbapi invocation log <invocation-id>
+
+# 3. Download the test.log for a specific failed target
+#    Works with both workflow and child invocation IDs (auto-resolves)
+bbapi target log <invocation-id> <target-substring>
+#    Example: bbapi target log 870a5be1 test_handlers
+```
+
+### Workflow vs Child Invocations
+
+BuildBuddy CI runs use **workflow invocations** that spawn **child invocations**.
+The workflow invocation (command: `workflow run`) is a wrapper; the child
+invocation contains the actual `bazel test` results, targets, and artifacts.
+
+- `bbapi invocation` shows `Child: <child-id>` for workflow invocations
+- `bbapi artifact` and `bbapi target log` auto-resolve workflow invocations
+  to their children — you can pass either the workflow or child ID
+- `bbapi target` does NOT auto-resolve (uses the BuildBuddy `GetTarget` RPC
+  which requires the exact invocation ID)
+
+### Artifact Name Matching
+
+`bbapi artifact` and `bbapi target log` match against `"label/name"`:
+
+- `"test_handlers"` matches `//x/gatelet/server/auth:test_handlers/test.log`
+- `"test_handlers/test.xml"` matches the XML output specifically
+- `"compositor/test_lifecycle"` matches `//mcp_infra/compositor:test_lifecycle/test.log`
+
+When no match is found, the CLI prints available labels as hints.
 
 ## Raw API Fallback
 

--- a/skills/info_gathering/evals/twenty_questions/x/autogen/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/autogen/twenty_questions.py
@@ -118,7 +118,7 @@ async def _run_simulator(
     result = await model_client.create(sim_history, tools=sim_tool_schemas, tool_choice="required")
 
     if isinstance(result.content, str):
-        raise TypeError(f"Simulator returned text instead of tool call: {result.content!r}")
+        raise RuntimeError(f"Simulator returned text instead of tool call: {result.content!r}")
 
     function_calls = result.content
     sim_history.append(AssistantMessage(content=function_calls, source="simulator"))

--- a/x/gatelet/server/app.py
+++ b/x/gatelet/server/app.py
@@ -66,7 +66,7 @@ app = create_app()
 
 
 @app.get("/", response_class=HTMLResponse)
-async def root(request: Request, session: str | None = Cookie(None), csrf_protect: CsrfProtect = Depends()):
+async def root(request: Request, session: str | None = Cookie(default=None), csrf_protect: CsrfProtect = Depends()):
     """Root endpoint with service information and authentication options."""
     # Check if already authenticated via cookie
     if session:

--- a/x/gatelet/server/auth/dependencies.py
+++ b/x/gatelet/server/auth/dependencies.py
@@ -48,7 +48,7 @@ async def get_session_auth_with_context(
 
 
 async def get_admin_auth_with_context(
-    session_token: str | None = Cookie(None, alias=ADMIN_SESSION_COOKIE), db_session: AsyncSession = DB_SESSION
+    session_token: str | None = Cookie(alias=ADMIN_SESSION_COOKIE, default=None), db_session: AsyncSession = DB_SESSION
 ) -> AuthContext:
     if session_token is None:
         raise RuntimeError("No admin session")

--- a/x/gatelet/server/endpoints/admin.py
+++ b/x/gatelet/server/endpoints/admin.py
@@ -29,7 +29,7 @@ Csrf = Annotated[CsrfProtect, Depends()]
 
 
 async def _get_admin_session(
-    session_token: Annotated[str | None, Cookie(None, alias=ADMIN_SESSION_COOKIE)], db_session: DbSession
+    db_session: DbSession, session_token: Annotated[str | None, Cookie(alias=ADMIN_SESSION_COOKIE)] = None
 ) -> AdminSession:
     if not session_token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
@@ -125,10 +125,10 @@ async def new_key_form(request: Request, admin_session: AdminSessionDep, csrf_pr
 @router.post("/admin/keys/new", response_class=HTMLResponse)
 async def create_key(
     request: Request,
-    description: Annotated[str, Form("")],
     admin_session: AdminSessionDep,
     db_session: DbSession,
     csrf_protect: Csrf,
+    description: Annotated[str, Form()] = "",
 ) -> HTMLResponse:
     await csrf_protect.validate_csrf(request)
     key = AuthKey(key_value=uuid.uuid4().hex, description=description or None, created_at=datetime.now())

--- a/x/gitea/pr_gate/policy_server_fastapi.py
+++ b/x/gitea/pr_gate/policy_server_fastapi.py
@@ -69,7 +69,7 @@ DURATION = Histogram("pr_quota_request_seconds", "PR quota check latency in seco
 def get_resources(request: Request) -> AppResources:
     resources = getattr(request.app.state, "resources", None)
     if not isinstance(resources, AppResources):
-        raise TypeError("App resources not initialized")
+        raise RuntimeError("App resources not initialized")
     return resources
 
 


### PR DESCRIPTION
## Summary
This PR adds a new `bbapi target log` command to download test logs for specific targets, improves artifact discovery with better error messages and hints, and fixes exception types throughout the codebase to use semantically correct error classes.

## Key Changes

### BuildBuddy CLI Enhancements
- **New `target log` subcommand**: Downloads and prints test.log for a specific target from BES artifacts
  - Matches targets by substring against "label/name" format
  - Supports custom artifact names via `--artifact` flag
  - Provides helpful suggestions when no matches found
  
- **Workflow invocation auto-resolution**: Added `resolveInvocationIDs()` helper that automatically resolves workflow invocations to their child invocations
  - Applies to `artifact` and `target log` commands
  - Displays which child invocation is being used
  
- **Improved artifact discovery**: Enhanced error messages in `downloadArtifact()` to show available labels as hints when no matches found
  
- **Invocation details enhancement**: Display child invocation IDs for workflow invocations in `bbapi invocation` output

### Documentation Updates
- Updated SKILL.md with comprehensive guide for investigating failed CI builds
- Added examples and explanations of workflow vs child invocations
- Documented artifact name matching behavior with examples
- Reorganized command reference for better discoverability

### Exception Type Corrections
Fixed incorrect exception types throughout the codebase to use semantically correct error classes:
- Changed `TypeError` to `RuntimeError` for state validation failures (mount not active, resources not initialized)
- Changed `TypeError` to `ValueError` for action state validation
- Changed `TypeError` to `RuntimeError` for Matrix alias resolution failures
- Updated ruff configuration to disable TRY004 rule with explanation of why state validation errors should not be TypeError

### Test Infrastructure
- Updated `test_post_tool_use_ruff_e2e.py` to properly resolve ruff binary via `RUFF_BIN` environment variable with Runfiles fallback
- Added `RUFF_BIN` environment variable to Bazel test configuration

### FastAPI Parameter Fixes
- Fixed FastAPI dependency injection parameter ordering and Cookie() default value syntax in multiple files to comply with current FastAPI API

## Implementation Details
- The `targetLogSubCmd()` function filters artifacts by both target label substring and artifact name, with detailed error reporting
- Workflow resolution is transparent to users—they can pass either workflow or child invocation IDs
- Artifact matching uses substring matching against "label/name" combined format for flexibility

https://claude.ai/code/session_01NEWi2dFkfsx8pZmauajaXG