### PR TITLE
[RUFF] Enable FBT002 rule (boolean default in positional args)

### DIFF
--- a/gmail_archiver/cli/labels.py
+++ b/gmail_archiver/cli/labels.py
@@ -13,7 +13,7 @@ labels_app = typer.Typer(help="Manage Gmail labels")
 
 @labels_app.command("list")
 def list_labels(
-    show_system: Annotated[bool, typer.Option("--system", "-s", help="Include system labels")] = False,
+    show_system: Annotated[bool, typer.Option("--system", "-s", help="Include system labels")] = False,  # noqa: FBT002
     token_file: TokenFileOption = None,
 ):
     """List all labels with filter usage info."""

--- a/gmail_archiver/main.py
+++ b/gmail_archiver/main.py
@@ -48,7 +48,7 @@ def print_error(console: Console, message: str) -> None:
 
 
 @app.command()
-def autoclean_inbox(dry_run: DryRunDefaultTrueOption = True, token_file: TokenFileOption = None):
+def autoclean_inbox(dry_run: DryRunDefaultTrueOption = True, token_file: TokenFileOption = None):  # noqa: FBT002
     """Automatically clean up old emails from inbox.
 
     Adds 'gmail-archiver/inbox-auto-cleaned' label and removes from inbox.
@@ -153,7 +153,7 @@ def download_matching(
         int,
         typer.Option("--batch-size", "-b", help="Number of emails to fetch per batch (reduce if hitting rate limits)"),
     ] = 10,
-    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompt")] = False,  # noqa: FBT002
     token_file: TokenFileOption = None,
 ):
     """Download all emails matching a Gmail search query.
@@ -378,7 +378,7 @@ def download_email(
 @app.command()
 def classify_event(
     eml_file: Annotated[Path, typer.Argument(help="Path to .eml file to classify", exists=True)],
-    no_cache: Annotated[bool, typer.Option("--no-cache", help="Skip cache and re-classify")] = False,
+    no_cache: Annotated[bool, typer.Option("--no-cache", help="Skip cache and re-classify")] = False,  # noqa: FBT002
 ):
     """Recognize email template and extract structured data using OpenAI.
 

--- a/inventree_utils/tasks.py
+++ b/inventree_utils/tasks.py
@@ -24,7 +24,7 @@ def _ssh(c, cmd):
 
 
 @task
-def logs(c, since="24h", hide_http_logs=True):
+def logs(c, since="24h", hide_http_logs=True):  # noqa: FBT002
     """Show server logs."""
     remote_command = f"docker logs -f --since {since} inventree-server"
     if hide_http_logs:

--- a/llm/mcp/habitify/server.py
+++ b/llm/mcp/habitify/server.py
@@ -24,7 +24,7 @@ def create_habitify(api_key: str | None = None) -> FastMCP:
         return client
 
     @server.tool()
-    async def get_habits(ctx: Context, include_archived: bool = False) -> HabitsResult:
+    async def get_habits(ctx: Context, include_archived: bool = False) -> HabitsResult:  # noqa: FBT002
         return await tools.get_habits(get_client(ctx), include_archived=include_archived)
 
     @server.tool()

--- a/props/cli/cmd_gepa.py
+++ b/props/cli/cmd_gepa.py
@@ -32,12 +32,12 @@ async def cmd_gepa(
         int, typer.Option(help="Budget for evaluations in this run (not counting historical)")
     ] = 100,
     output_dir: Annotated[Path, typer.Option(help="Output directory for results")] = Path("gepa_output"),
-    warm_start: Annotated[
+    warm_start: Annotated[  # noqa: FBT002
         bool, typer.Option(help="Load historical Pareto frontier from database to start from known good prompts")
     ] = True,
     max_parallelism: Annotated[int, typer.Option(help="Maximum concurrent critic/grader evaluations")] = 20,
     minibatch_size: Annotated[int, typer.Option(help="Number of training examples per reflection iteration")] = 3,
-    verbose: Annotated[bool, typer.Option(help="Enable verbose logging")] = False,
+    verbose: Annotated[bool, typer.Option(help="Enable verbose logging")] = False,  # noqa: FBT002
     seed: Annotated[int | None, typer.Option(help="Random seed for reproducibility (default: timestamp-based)")] = None,
 ) -> None:
     """Run GEPA optimization to evolve the critic system prompt.

--- a/props/core/gepa/gepa_adapter.py
+++ b/props/core/gepa/gepa_adapter.py
@@ -355,7 +355,7 @@ class CriticAdapter(gepa.GEPAAdapter[Example, CriticTrajectory, CriticOutput]):
         self.propose_new_texts = propose_new_texts
 
     def evaluate(
-        self, batch: list[Example], candidate: dict[str, str], capture_traces: bool = False
+        self, batch: list[Example], candidate: dict[str, str], *, capture_traces: bool = False
     ) -> gepa.EvaluationBatch[CriticTrajectory, CriticOutput]:
         """Evaluate a prompt candidate on a batch of specimens.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -73,6 +73,7 @@ select = [
     "TRY401", # redundant exception object in logging.exception
     "TRY203", # useless try-except (just re-raises)
     "TRY400", # logging.error in except → logging.exception
+    "FBT002", # boolean default in positional args
     "RUF"    # ruff-specific
 ]
 # Keep these off globally; handled case-by-case or via constants
@@ -169,3 +170,4 @@ split-on-trailing-comma = false
 # conftest.py re-exports fixtures for pytest discovery — imports are "unused" by design
 # and fixture parameters naturally shadow the imported fixture names (F811)
 "**/conftest.py" = ["F401", "F811"]
+"airlock/auth_proxy/proxy.py" = ["FBT002"]

--- a/skills/hetzner_vnc_screenshot/vnc_screenshot.py
+++ b/skills/hetzner_vnc_screenshot/vnc_screenshot.py
@@ -162,7 +162,7 @@ def main(
     password: Annotated[str | None, typer.Option(help="VNC password")] = None,
     token: Annotated[str | None, typer.Option(help="Hetzner API token (default: HCLOUD_TOKEN env)")] = None,
     output: Annotated[Path, typer.Option(help="Output image path")] = Path("screenshot.png"),
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable debug logging")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable debug logging")] = False,  # noqa: FBT002
 ):
     """Capture a screenshot from Hetzner Cloud VNC console.
 

--- a/skills/proxmox_vm/vm_interact.py
+++ b/skills/proxmox_vm/vm_interact.py
@@ -256,9 +256,9 @@ def main(
     sendkey: Annotated[
         list[str] | None, typer.Option("--sendkey", "-k", help="Send QEMU key (e.g., ctrl-c, ret, shift-a)")
     ] = None,
-    info: Annotated[bool, typer.Option("--info", "-i", help="Show VM network info")] = False,
+    info: Annotated[bool, typer.Option("--info", "-i", help="Show VM network info")] = False,  # noqa: FBT002
     sleep: Annotated[list[float] | None, typer.Option("--sleep", help="Sleep for N seconds")] = None,
-    stdin: Annotated[bool, typer.Option("--stdin", help="Read commands from stdin")] = False,
+    stdin: Annotated[bool, typer.Option("--stdin", help="Read commands from stdin")] = False,  # noqa: FBT002
     delay: Annotated[float, typer.Option("--delay", "-d", help="Delay between keys in seconds")] = 0.05,
 ) -> None:
     """Interact with Proxmox VMs via QEMU monitor.


### PR DESCRIPTION
## Summary
- Enable `FBT002` in `ruff.toml`
- Fix 77 violations:
  - 66 made keyword-only (`*` separator added, all call sites updated)
  - 11 suppressed with `# noqa: FBT002` (framework callbacks: Typer CLI options, invoke `@task`, FastMCP `@server.tool`)
  - 1 per-file-ignore (`airlock/auth_proxy/proxy.py` — httpx method override)

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF