### PR TITLE
Make boolean params keyword-only where painless

### DIFF
--- a/agent_core/progress.py
+++ b/agent_core/progress.py
@@ -55,7 +55,7 @@ class OneLineProgressHandler(BaseHandler):
         self._render()
 
     # --- rendering ---
-    def _render(self, force: bool = False) -> None:
+    def _render(self, *, force: bool = False) -> None:
         # Throttle updates to ~20Hz to avoid noisy consoles
         now = monotonic()
         if not force and now - self._last_render < 0.05:

--- a/agent_core/test_tool_execution.py
+++ b/agent_core/test_tool_execution.py
@@ -209,6 +209,7 @@ async def _run_malformed_json_test(
     mcp_tool_provider_echo,
     recording_handler,
     make_first_turn: Callable[[ResponsesFactory], ResponsesResult],
+    *,
     parallel: bool = False,
 ) -> tuple[str, list]:
     """Helper to run malformed JSON tests with custom first turn."""

--- a/agent_core/testing/responses.py
+++ b/agent_core/testing/responses.py
@@ -271,7 +271,7 @@ class DecoratorMock(GeneratorMock):
     # "callable accepting same type as self" with classmethod factory pattern
     _play_fn: Callable[[DecoratorMock], PlayGen]
 
-    def __init__(self, play_fn: Callable[[DecoratorMock], PlayGen], check_consumed: bool = True) -> None:
+    def __init__(self, play_fn: Callable[[DecoratorMock], PlayGen], *, check_consumed: bool = True) -> None:
         self._play_fn = play_fn
         self._check_consumed = check_consumed
         super().__init__()

--- a/devinfra/claude/streaming.py
+++ b/devinfra/claude/streaming.py
@@ -12,7 +12,7 @@ HEARTBEAT_INTERVAL_SECONDS = 5
 
 
 def run_streaming(
-    cmd: list[str | Path], operation: str | None = None, check: bool = True, env: dict[str, str] | None = None
+    cmd: list[str | Path], operation: str | None = None, *, check: bool = True, env: dict[str, str] | None = None
 ) -> int:
     """Run command with real-time streaming output.
 

--- a/devinfra/claude/supervisor/client.py
+++ b/devinfra/claude/supervisor/client.py
@@ -219,11 +219,11 @@ class SupervisorClient:
         """Remove a process group. Returns True on success."""
         return bool(await self._call("supervisor.removeProcessGroup", name))
 
-    async def start_process(self, name: str, wait: bool = True) -> bool:
+    async def start_process(self, name: str, *, wait: bool = True) -> bool:
         """Start a process. Returns True on success."""
         return bool(await self._call("supervisor.startProcess", name, wait))
 
-    async def stop_process(self, name: str, wait: bool = True) -> bool:
+    async def stop_process(self, name: str, *, wait: bool = True) -> bool:
         """Stop a process. Returns True on success."""
         return bool(await self._call("supervisor.stopProcess", name, wait))
 

--- a/devinfra/claude/testing/shell_helpers.py
+++ b/devinfra/claude/testing/shell_helpers.py
@@ -9,7 +9,7 @@ HOOK_DISPATCH = "_main/devinfra/claude/hook_daemon/hook_dispatch"
 
 
 async def run_with_env_file(
-    command: str, env_file: Path, cwd: Path | None = None, check: bool = False, env: dict[str, str] | None = None
+    command: str, env_file: Path, cwd: Path | None = None, *, check: bool = False, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run command in bash with env_file sourced (mimics Claude Code behavior).
 

--- a/difftree/conftest.py
+++ b/difftree/conftest.py
@@ -29,6 +29,7 @@ ColorSystem = Literal["auto", "standard", "256", "truecolor", "windows"] | None
 def render_to_string(
     renderable,
     width: int = 80,
+    *,
     force_terminal: bool = True,
     legacy_windows: bool = False,
     color_system: ColorSystem = "standard",

--- a/difftree/test_tree.py
+++ b/difftree/test_tree.py
@@ -8,7 +8,7 @@ from difftree.parser import FileChange
 from difftree.tree import TreeNode, build_tree, sort_tree
 
 
-def _sorted_child_names(changes: list[FileChange], sort_by: SortMode, reverse: bool = True) -> list[str]:
+def _sorted_child_names(changes: list[FileChange], sort_by: SortMode, *, reverse: bool = True) -> list[str]:
     """Build tree, sort it, and return children names in order."""
     root = build_tree(changes)
     root = sort_tree(root, sort_by=sort_by, reverse=reverse)

--- a/difftree/tree.py
+++ b/difftree/tree.py
@@ -118,7 +118,7 @@ def build_tree(changes: list[FileChange]) -> TreeNode:
     return to_frozen(root)
 
 
-def sort_tree(node: TreeNode, sort_by: SortMode = SortMode.SIZE, reverse: bool = True) -> TreeNode:
+def sort_tree(node: TreeNode, sort_by: SortMode = SortMode.SIZE, *, reverse: bool = True) -> TreeNode:
     """Return a new tree with nodes sorted according to the specified mode.
 
     Since TreeNode is immutable, this creates a new tree with sorted children.
@@ -127,7 +127,7 @@ def sort_tree(node: TreeNode, sort_by: SortMode = SortMode.SIZE, reverse: bool =
         return node
 
     # Recursively sort children
-    sorted_child_nodes = {name: sort_tree(child, sort_by, reverse) for name, child in node.children.items()}
+    sorted_child_nodes = {name: sort_tree(child, sort_by, reverse=reverse) for name, child in node.children.items()}
 
     # Sort the children dict
     if sort_by == SortMode.SIZE:

--- a/gmail_archiver/event_classifier.py
+++ b/gmail_archiver/event_classifier.py
@@ -95,7 +95,7 @@ class EmailTemplateExtractor:
         self.client = openai.AsyncOpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
         self.cache = TemplateExtractionCache()
 
-    async def extract(self, email: Email, use_cache: bool = True) -> EmailTemplateExtraction:
+    async def extract(self, email: Email, *, use_cache: bool = True) -> EmailTemplateExtraction:
         if use_cache and (cached := self.cache.get(email.id)):
             return cached
 
@@ -171,7 +171,7 @@ CONFIDENCE GUIDELINES:
         return classification
 
     async def extract_batch(
-        self, emails: Sequence[Email], use_cache: bool = True, max_concurrent: int = 10
+        self, emails: Sequence[Email], *, use_cache: bool = True, max_concurrent: int = 10
     ) -> list[tuple[str, EmailTemplateExtraction]]:
         semaphore = asyncio.Semaphore(max_concurrent)
 

--- a/gmail_archiver/gmail_client.py
+++ b/gmail_archiver/gmail_client.py
@@ -230,7 +230,7 @@ class GmailClient:
         return results
 
     def get_messages_raw_batch(
-        self, message_ids: list[str], batch_size: int, retry_failures: bool = True
+        self, message_ids: list[str], batch_size: int, *, retry_failures: bool = True
     ) -> tuple[list[tuple[str, bytes]], list[tuple[str, str]]]:
         """Fetch raw message bytes using batch requests.
 
@@ -444,6 +444,7 @@ class GmailClient:
         label_name: str,
         batch_size: int = 1000,
         progress_callback: Callable[[int], None] | None = None,
+        *,
         archive: bool = False,
     ) -> tuple[list[str], list[tuple[str, str]]]:
         """Add label to multiple messages. Returns (successful_ids, failed_ids_with_errors)."""

--- a/gmail_archiver/inbox.py
+++ b/gmail_archiver/inbox.py
@@ -20,7 +20,7 @@ class GmailInbox:
     Planners use this interface to fetch messages without worrying about caching.
     """
 
-    def __init__(self, client: GmailClient, console: Console, cache_dir: Path, show_progress: bool = True):
+    def __init__(self, client: GmailClient, console: Console, cache_dir: Path, *, show_progress: bool = True):
         self.client = client
         self.console = console
         self.cache_dir = cache_dir

--- a/gmail_archiver/plan_display.py
+++ b/gmail_archiver/plan_display.py
@@ -72,7 +72,7 @@ def _collect_display_columns(actions: Iterable[PlannedAction]) -> tuple[list[tup
     return columns, hide_subject
 
 
-def _create_table(title: str | None, custom_columns: list[tuple[str, str]], show_subject: bool = True) -> Table:
+def _create_table(title: str | None, custom_columns: list[tuple[str, str]], *, show_subject: bool = True) -> Table:
     """Build a Rich table with base and custom columns."""
     table = Table(title=title)
     table.add_column("Action", style="cyan")
@@ -111,7 +111,7 @@ def _format_date(metadata: GmailMessageWithHeaders) -> str:
     return local_dt.strftime("%Y-%m-%d %H:%M")
 
 
-def display_plan(plan: Plan, inbox: GmailInbox, console: Console, dry_run: bool, group_by_category: bool = False):
+def display_plan(plan: Plan, inbox: GmailInbox, console: Console, dry_run: bool, *, group_by_category: bool = False):
     if not plan.actions:
         console.print("[yellow]No actions planned[/yellow]")
         return
@@ -134,7 +134,9 @@ def display_plan(plan: Plan, inbox: GmailInbox, console: Console, dry_run: bool,
             table = _create_table(planner_name, custom_columns, show_subject=show_subject)
 
             for message_id, planned_action in items:
-                _add_table_row(table, inbox, message_id, planned_action, dry_run, custom_columns, show_subject)
+                _add_table_row(
+                    table, inbox, message_id, planned_action, dry_run, custom_columns, show_subject=show_subject
+                )
 
             console.print(table)
             console.print()
@@ -145,7 +147,7 @@ def display_plan(plan: Plan, inbox: GmailInbox, console: Console, dry_run: bool,
         table = _create_table("Inbox Cleanup - Action Plan", custom_columns, show_subject=show_subject)
 
         for message_id, planned_action in plan.actions.items():
-            _add_table_row(table, inbox, message_id, planned_action, dry_run, custom_columns, show_subject)
+            _add_table_row(table, inbox, message_id, planned_action, dry_run, custom_columns, show_subject=show_subject)
 
         console.print(table)
 
@@ -157,6 +159,7 @@ def _add_table_row(
     planned_action: PlannedAction,
     dry_run: bool,
     custom_columns: list[tuple[str, str]],
+    *,
     show_subject: bool = True,
 ):
     # Look up message metadata from inbox cache (fetches on demand if not cached)

--- a/gmail_archiver/planners/aliexpress.py
+++ b/gmail_archiver/planners/aliexpress.py
@@ -133,7 +133,7 @@ def compute_deadline(message: Email) -> datetime | None:
     return message.internal_date.replace(tzinfo=None) + timedelta(days=30)
 
 
-def parse_aliexpress(message: Email, should_compute_deadline: bool = False) -> AliExpressEmail:
+def parse_aliexpress(message: Email, *, should_compute_deadline: bool = False) -> AliExpressEmail:
     """Parse AliExpress email, optionally computing deadline from received date."""
     parsed = parse_aliexpress_subject(message.subject)
 

--- a/inop/io/logging_utils.py
+++ b/inop/io/logging_utils.py
@@ -51,7 +51,7 @@ class DualOutputLogging:
     """Utility class for setting up structured logging with dual output."""
 
     @staticmethod
-    def setup_logging(logs_dir: str = "logs", log_filename: str = "optimizer.jsonl", verbose: bool = False) -> None:
+    def setup_logging(logs_dir: str = "logs", log_filename: str = "optimizer.jsonl", *, verbose: bool = False) -> None:
         """Configure structlog with dual output: pretty console + structured file logs.
 
         Args:

--- a/inop/runners/base.py
+++ b/inop/runners/base.py
@@ -60,7 +60,7 @@ class AgentRunner(ABC):
             RunnerEnvironment with type and data, or None if no environment.
         """
 
-    async def _clone_repository(self, git_setup: GitCloneConfig, target_dir: str, is_docker: bool = False) -> None:
+    async def _clone_repository(self, git_setup: GitCloneConfig, target_dir: str, *, is_docker: bool = False) -> None:
         """Clone a git repository using shallow clone to specific commit.
 
         This method clones directly into the target directory (workspace root),

--- a/laser/material_test/material_test.py
+++ b/laser/material_test/material_test.py
@@ -392,6 +392,7 @@ def _make_text(
     font_name: str,
     ah: HAlign = HAlign.LEFT,
     av: VAlign = VAlign.TOP,
+    *,
     rotate90ccw: bool = False,
 ) -> TextShape:
     xform = XForm.rotate90ccw(x, y) if rotate90ccw else XForm.translate(x, y)

--- a/llm/html/llm_html/server.py
+++ b/llm/html/llm_html/server.py
@@ -185,7 +185,7 @@ for page_name in MARKDOWN_PAGES:
 
 
 async def analyze_page_tokens(
-    page_id: str, markdown_path: Path, title: str, url: str, is_index: bool = False
+    page_id: str, markdown_path: Path, title: str, url: str, *, is_index: bool = False
 ) -> dict[str, Any] | None:
     """Analyze a single page's token counts by simulating the full rendering pipeline."""
     try:

--- a/llm/mcp/habitify/cli.py
+++ b/llm/mcp/habitify/cli.py
@@ -182,7 +182,7 @@ def list_habits(
     asyncio.run(_list_habits_async(include_archived=include_archived, api_key=api_key))
 
 
-async def _list_habits_async(include_archived: bool = False, api_key: str | None = None) -> None:
+async def _list_habits_async(*, include_archived: bool = False, api_key: str | None = None) -> None:
     """Async implementation of the list command."""
     # Get API key from command line or environment
     habitify_api_key = get_api_key_from_param_or_env(api_key)

--- a/llm/mcp/habitify/config.py
+++ b/llm/mcp/habitify/config.py
@@ -5,7 +5,7 @@ import os
 from dotenv import load_dotenv
 
 
-def load_api_key(exit_on_missing: bool = True) -> str | None:
+def load_api_key(*, exit_on_missing: bool = True) -> str | None:
     """Load the Habitify API key from environment.
 
     Returns the API key if found, None if not found and exit_on_missing is False.

--- a/mcp_infra/exec/test_seatbelt.py
+++ b/mcp_infra/exec/test_seatbelt.py
@@ -35,7 +35,7 @@ async def seatbelt_session():
         yield server, sess
 
 
-def make_default_restrictive_policy(trace: bool = False) -> SBPLPolicy:
+def make_default_restrictive_policy(*, trace: bool = False) -> SBPLPolicy:
     return SBPLPolicy(
         default_behavior=DefaultBehavior.DENY,
         process=ProcessRule(allow_process_star=True, allow_signal_self=True),

--- a/openai_utils/pydantic_strict_mode.py
+++ b/openai_utils/pydantic_strict_mode.py
@@ -85,7 +85,7 @@ def validate_openai_strict_mode_schema(schema: dict[str, Any], model_name: str =
     """
     errors: list[str] = []
 
-    def check_recursive(obj: Any, path: str = "", is_property_root: bool = False, inside_defs: bool = False) -> None:
+    def check_recursive(obj: Any, path: str = "", *, is_property_root: bool = False, inside_defs: bool = False) -> None:
         """Recursively check schema object for violations.
 
         Args:

--- a/props/core/gepa/gepa_adapter.py
+++ b/props/core/gepa/gepa_adapter.py
@@ -173,6 +173,7 @@ class CriticAdapter(gepa.GEPAAdapter[Example, CriticTrajectory, CriticOutput]):
         db: Database,
         run_dir: Path,
         reflection_model: str | None = None,
+        *,
         verbose: bool = False,
         max_parallelism: int = 20,
     ):
@@ -354,7 +355,7 @@ class CriticAdapter(gepa.GEPAAdapter[Example, CriticTrajectory, CriticOutput]):
         self.propose_new_texts = propose_new_texts
 
     def evaluate(
-        self, batch: list[Example], candidate: dict[str, str], capture_traces: bool = False
+        self, batch: list[Example], candidate: dict[str, str], *, capture_traces: bool = False
     ) -> gepa.EvaluationBatch[CriticTrajectory, CriticOutput]:
         """Evaluate a prompt candidate on a batch of specimens.
 

--- a/sysrw/extract_dataset_crush.py
+++ b/sysrw/extract_dataset_crush.py
@@ -126,7 +126,7 @@ def _extract_chat_messages(payload: dict[str, Any]) -> tuple[list[dict[str, Any]
     return (msgs or None), has_header
 
 
-def process_wire(path: Path, require_bad: bool = False) -> list[dict[str, Any]]:
+def process_wire(path: Path, *, require_bad: bool = False) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     lines = 0
     kept = 0

--- a/sysrw/leaderboard.py
+++ b/sysrw/leaderboard.py
@@ -222,7 +222,7 @@ def format_rich_table(rows: list[Row]) -> Table:
 
 
 def generate(
-    runs_dir: Path, sort_key: str = "mean", asc: bool = False, limit: int | None = None
+    runs_dir: Path, sort_key: str = "mean", *, asc: bool = False, limit: int | None = None
 ) -> tuple[Table, list[str], list[str]]:
     # Build mapping from packaged templates/ only (stable names)
     known = load_known_templates()

--- a/sysrw/run_eval.py
+++ b/sysrw/run_eval.py
@@ -761,7 +761,7 @@ async def run_eval(
     scores_by_source: dict[str, list[float]] = {"ccr": [], "crush": []}
     tool_stats_by_source: dict[str, ToolStats] = {"ccr": ToolStats(), "crush": ToolStats()}
 
-    def compute_and_write_summary(_final: bool = False) -> dict[str, Any]:
+    def compute_and_write_summary(*, _final: bool = False) -> dict[str, Any]:
         # Compute metrics for overall and per-source stats
         overall_metrics = tool_stats.compute_metrics()
 
@@ -835,7 +835,7 @@ async def run_eval(
                     if source in scores_by_source:
                         scores_by_source[source].append(score)
                     counters.processed += 1
-                    summary_data = compute_and_write_summary(False)
+                    summary_data = compute_and_write_summary(_final=False)
                     print(
                         json.dumps(
                             {
@@ -855,7 +855,7 @@ async def run_eval(
                     log_event({"status": "aggregate_parse_error", "error": str(e)})
 
     # Final summary after all grades
-    s_final = compute_and_write_summary(True)
+    s_final = compute_and_write_summary(_final=True)
     log_event(
         {
             "event": "summary_final",

--- a/tana/query/filters.py
+++ b/tana/query/filters.py
@@ -9,7 +9,7 @@ from tana.query.nodes import get_field_values, is_in_deleted_nodes
 
 
 def filter_nodes(
-    store: TanaGraph, predicate: Callable[[BaseNode], bool], skip_trash: bool = True, skip_deleted: bool = True
+    store: TanaGraph, predicate: Callable[[BaseNode], bool], *, skip_trash: bool = True, skip_deleted: bool = True
 ) -> Iterator[BaseNode]:
     """
     Filter nodes in a TanaGraph based on a predicate function.
@@ -38,7 +38,7 @@ def filter_nodes(
 
 
 def filter_by_tag(
-    store: TanaGraph, tag_name: str, skip_trash: bool = True, skip_deleted: bool = True
+    store: TanaGraph, tag_name: str, *, skip_trash: bool = True, skip_deleted: bool = True
 ) -> Iterator[BaseNode]:
     """
     Filter nodes by supertag.
@@ -58,7 +58,7 @@ def filter_by_tag(
     def has_tag(node: BaseNode) -> bool:
         return store.has_supertag(node.id, tag_name)
 
-    return filter_nodes(store, has_tag, skip_trash, skip_deleted)
+    return filter_nodes(store, has_tag, skip_trash=skip_trash, skip_deleted=skip_deleted)
 
 
 def filter_by_field_value(
@@ -66,6 +66,7 @@ def filter_by_field_value(
     field_name: str,
     allowed_values: set[str] | None = None,
     excluded_values: set[str] | None = None,
+    *,
     skip_trash: bool = True,
     skip_deleted: bool = True,
 ) -> Iterator[BaseNode]:
@@ -95,7 +96,7 @@ def filter_by_field_value(
 
         return not (excluded_values and values & excluded_values)
 
-    return filter_nodes(store, matches_criteria, skip_trash, skip_deleted)
+    return filter_nodes(store, matches_criteria, skip_trash=skip_trash, skip_deleted=skip_deleted)
 
 
 def filter_open_issues(store: TanaGraph) -> Iterator[NodeId]:

--- a/tana/query/search/evaluator.py
+++ b/tana/query/search/evaluator.py
@@ -25,7 +25,12 @@ class SearchEvaluator:
     """Evaluates search expressions against a TanaGraph."""
 
     def __init__(
-        self, store: TanaGraph, skip_trash: bool = True, skip_deleted: bool = True, parent_node: BaseNode | None = None
+        self,
+        store: TanaGraph,
+        *,
+        skip_trash: bool = True,
+        skip_deleted: bool = True,
+        parent_node: BaseNode | None = None,
     ):
         """
         Initialize the search evaluator.
@@ -78,7 +83,7 @@ class SearchEvaluator:
             return
 
         # Use the existing filter_by_tag function
-        yield from filter_by_tag(self.store, tag_node.name, self.skip_trash, self.skip_deleted)
+        yield from filter_by_tag(self.store, tag_node.name, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
     def _evaluate_type(self, type_node_id: NodeId) -> Iterator[BaseNode]:
         """
@@ -100,7 +105,7 @@ class SearchEvaluator:
         def matches_type(node: BaseNode) -> bool:
             return node.props.doc_type == doc_type
 
-        yield from filter_nodes(self.store, matches_type, self.skip_trash, self.skip_deleted)
+        yield from filter_nodes(self.store, matches_type, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
     def _evaluate_text(self, text: str) -> Iterator[BaseNode]:
         """
@@ -123,7 +128,7 @@ class SearchEvaluator:
         def matches_text(node: BaseNode) -> bool:
             return bool(node.name and text_lower in node.name.lower())
 
-        yield from filter_nodes(self.store, matches_text, self.skip_trash, self.skip_deleted)
+        yield from filter_nodes(self.store, matches_text, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted)
 
     def _evaluate_field(self, field_name: str, values: list[str]) -> Iterator[BaseNode]:
         """
@@ -194,7 +199,9 @@ class SearchEvaluator:
             def not_excluded(node: BaseNode) -> bool:
                 return node.id not in excluded_ids
 
-            yield from filter_nodes(self.store, not_excluded, self.skip_trash, self.skip_deleted)
+            yield from filter_nodes(
+                self.store, not_excluded, skip_trash=self.skip_trash, skip_deleted=self.skip_deleted
+            )
 
     def _get_descendants(self, node: BaseNode) -> set[NodeId]:
         """

--- a/tana/render/html_utils.py
+++ b/tana/render/html_utils.py
@@ -85,6 +85,7 @@ def process_inline_refs(
     text: str,
     node_formatter: Callable[[str], str] | None = None,
     date_formatter: Callable[[str], str] | None = None,
+    *,
     unescape: bool = True,
 ) -> str:
     """node_formatter takes node ID, date_formatter takes ISO date string."""

--- a/wt/cli.py
+++ b/wt/cli.py
@@ -119,10 +119,10 @@ def _root(
                 )
             )
         else:
-            asyncio.run(_async_main(effective_verbose))
+            asyncio.run(_async_main(verbose=effective_verbose))
 
 
-def _create_cli_dependencies(verbose: bool = False):
+def _create_cli_dependencies(*, verbose: bool = False):
     """Create common CLI dependencies."""
     config = load_config()
     formatter = ViewFormatter(daemon_log_path=config.daemon_log_file)
@@ -139,7 +139,7 @@ class ShellDispatchContext:
     ctx: typer.Context
 
 
-async def _async_main(verbose: bool = False):
+async def _async_main(*, verbose: bool = False):
     """Async main function."""
     _config, formatter, daemon_client = _create_cli_dependencies(verbose=verbose)
     await handle_status(daemon_client, formatter)
@@ -160,7 +160,7 @@ async def _cmd_rm(config, remaining_args, ctx, **_):
         click.echo("Error: rm requires a worktree name")
         ctx.exit(1)
         return
-    await handle_remove_worktree(config, name, force)
+    await handle_remove_worktree(config, name, force=force)
 
 
 async def _cmd_cp(config, remaining_args, ctx, **_):

--- a/wt/client/handlers.py
+++ b/wt/client/handlers.py
@@ -156,7 +156,7 @@ async def handle_create_worktree(config, name: str, options: CreateWorktreeOptio
     emit_cd_command(new_path, main_repo=config.main_repo)
 
 
-async def handle_remove_worktree(config, name: str, force: bool = False) -> None:
+async def handle_remove_worktree(config, name: str, *, force: bool = False) -> None:
     """Handle worktree removal."""
     click.echo(f"🔍 Checking worktree '{name}' for removal...")
 

--- a/wt/client/view_formatter.py
+++ b/wt/client/view_formatter.py
@@ -62,6 +62,7 @@ class ViewFormatter:
         self,
         pr_state: PRState,
         mergeability: Literal["mergeable", "conflicting", "unknown"],
+        *,
         is_draft: bool = False,
         merged_at: str | None = None,
     ) -> str:
@@ -109,7 +110,7 @@ class ViewFormatter:
                 lines_info = f" +{d.additions}/-{d.deletions}"
 
             pr_status_text = self.get_pr_status_text(
-                pr_state, self._mergeability_label(d.mergeable), d.draft, d.merged_at
+                pr_state, self._mergeability_label(d.mergeable), is_draft=d.draft, merged_at=d.merged_at
             )
 
             pr_status = f"{clickable_link} {pr_status_text}{lines_info}"
@@ -159,7 +160,9 @@ class ViewFormatter:
         if not isinstance(status.pr_info, PRInfoOk):
             return ""
         d = status.pr_info.pr_data
-        return self.get_pr_status_text(d.pr_state, self._mergeability_label(d.mergeable), d.draft, d.merged_at)
+        return self.get_pr_status_text(
+            d.pr_state, self._mergeability_label(d.mergeable), is_draft=d.draft, merged_at=d.merged_at
+        )
 
     def _get_pr_changes_column(self, status: StatusResult) -> str:
         """Get PR changes (+lines/-lines) column."""
@@ -283,7 +286,9 @@ class ViewFormatter:
             )
 
             # Format detailed PR status
-            status_text = self.get_pr_status_text(pr_state, self._mergeability_label(d.mergeable), d.draft, d.merged_at)
+            status_text = self.get_pr_status_text(
+                pr_state, self._mergeability_label(d.mergeable), is_draft=d.draft, merged_at=d.merged_at
+            )
             if status_text in PR_STATUS_DISPLAY_MAP:
                 icon, message = PR_STATUS_DISPLAY_MAP[status_text]
                 click.echo(f"{icon} Status: This PR {message}")

--- a/wt/server/git_manager.py
+++ b/wt/server/git_manager.py
@@ -192,7 +192,7 @@ class GitManager:
         except subprocess.CalledProcessError as e:
             raise WorktreeCreateError(f"git worktree add failed: {e.stderr.decode(errors='replace').strip()}") from e
 
-    def worktree_remove(self, path: Path, force: bool = False) -> None:
+    def worktree_remove(self, path: Path, *, force: bool = False) -> None:
         path_obj = path
         args: list[str | os.PathLike[str]] = ["worktree", "remove"]
         if force:

--- a/wt/server/worktree_service.py
+++ b/wt/server/worktree_service.py
@@ -118,7 +118,7 @@ class WorktreeService:
         """Get path for a worktree by name."""
         return config.worktrees_dir / name
 
-    async def remove_worktree(self, config: Configuration, name: str, force: bool = False) -> None:
+    async def remove_worktree(self, config: Configuration, name: str, *, force: bool = False) -> None:
         """Remove a worktree by name and clean up its directory."""
         validate_worktree_name(name)
         worktree_path = self.get_worktree_path(config, name)

--- a/wt/testing/config_factory.py
+++ b/wt/testing/config_factory.py
@@ -126,7 +126,7 @@ class ConfigBuilder:
         self._preset = preset
         return self
 
-    def with_github(self, repo: str = "test-user/test-repo", enabled: bool = True):
+    def with_github(self, repo: str = "test-user/test-repo", *, enabled: bool = True):
         """Configure GitHub integration."""
         self._overrides.update({"github_enabled": enabled, "github_repo": repo})
         return self

--- a/x/agent_server/server/conftest.py
+++ b/x/agent_server/server/conftest.py
@@ -27,47 +27,47 @@ def fresh_ui_state():
 
 
 @pytest.fixture
-def make_tool_result() -> Callable[[dict[str, Any] | None, bool], ToolResult]:
+def make_tool_result() -> Callable[..., ToolResult]:
     """Factory for ToolResult (agent_core internal type)."""
 
-    def _make(structured_content: dict[str, Any] | None = None, is_error: bool = False) -> ToolResult:
+    def _make(structured_content: dict[str, Any] | None = None, *, is_error: bool = False) -> ToolResult:
         return ToolResult(structured_content=structured_content or {}, is_error=is_error)
 
     return _make
 
 
 @pytest.fixture
-def make_call_result() -> Callable[[dict[str, Any] | None, bool], mcp.types.CallToolResult]:
+def make_call_result() -> Callable[..., mcp.types.CallToolResult]:
     """Factory for MCP CallToolResult (protocol type)."""
 
-    def _make(structured_content: dict[str, Any] | None = None, is_error: bool = False) -> mcp.types.CallToolResult:
+    def _make(structured_content: dict[str, Any] | None = None, *, is_error: bool = False) -> mcp.types.CallToolResult:
         return mcp.types.CallToolResult(content=[], structuredContent=structured_content or {}, isError=is_error)
 
     return _make
 
 
 @pytest.fixture
-def make_tool_call_output(
-    make_tool_result: Callable[[dict[str, Any] | None, bool], ToolResult],
-) -> Callable[[str, dict[str, Any] | None, bool], ToolCallOutput]:
+def make_tool_call_output(make_tool_result: Callable[..., ToolResult]) -> Callable[..., ToolCallOutput]:
     """Factory for ToolCallOutput events."""
 
-    def _make(call_id: str, structured_content: dict[str, Any] | None = None, is_error: bool = False) -> ToolCallOutput:
-        return ToolCallOutput(call_id=call_id, result=make_tool_result(structured_content, is_error))
+    def _make(
+        call_id: str, structured_content: dict[str, Any] | None = None, *, is_error: bool = False
+    ) -> ToolCallOutput:
+        return ToolCallOutput(call_id=call_id, result=make_tool_result(structured_content, is_error=is_error))
 
     return _make
 
 
 @pytest.fixture
 def make_function_output(
-    make_call_result: Callable[[dict[str, Any] | None, bool], mcp.types.CallToolResult],
-) -> Callable[[str, dict[str, Any] | None, bool], FunctionCallOutput]:
+    make_call_result: Callable[..., mcp.types.CallToolResult],
+) -> Callable[..., FunctionCallOutput]:
     """Factory for protocol FunctionCallOutput (not EventRecord)."""
 
     def _make(
-        call_id: str, structured_content: dict[str, Any] | None = None, is_error: bool = False
+        call_id: str, structured_content: dict[str, Any] | None = None, *, is_error: bool = False
     ) -> FunctionCallOutput:
-        return FunctionCallOutput(call_id=call_id, result=make_call_result(structured_content, is_error))
+        return FunctionCallOutput(call_id=call_id, result=make_call_result(structured_content, is_error=is_error))
 
     return _make
 
@@ -122,11 +122,11 @@ def make_tool_call_event(
 @pytest.fixture
 def make_function_output_event(
     make_event_record: Callable[[EventType, int | None], EventRecord],
-    make_tool_call_output: Callable[[str, dict[str, Any] | None, bool], ToolCallOutput],
+    make_tool_call_output: Callable[..., ToolCallOutput],
 ) -> Callable[[int, str, dict[str, Any] | None], EventRecord]:
     """Factory for ToolCallOutput EventRecord."""
 
     def _make(seq: int, call_id: str, structured_content: dict[str, Any] | None = None) -> EventRecord:
-        return make_event_record(make_tool_call_output(call_id, structured_content, False), seq)
+        return make_event_record(make_tool_call_output(call_id, structured_content, is_error=False), seq)
 
     return _make

--- a/x/claude_linter/config.py
+++ b/x/claude_linter/config.py
@@ -54,7 +54,7 @@ def merge_configs(user_cfg: dict[str, Any], local_cfg: dict[str, Any], fix: bool
     return merged
 
 
-def get_merged_config(paths: Sequence[str | Path], fix: bool = False) -> dict[str, Any]:
+def get_merged_config(paths: Sequence[str | Path], *, fix: bool = False) -> dict[str, Any]:
     user_config = load_user_config()
     # Get the pre-commit section, which contains repos array
     user_pre_commit: dict[str, Any] = user_config.get("pre-commit", {})

--- a/x/claude_linter_v2/check_python.py
+++ b/x/claude_linter_v2/check_python.py
@@ -10,7 +10,7 @@ from x.claude_linter_v2.pattern_matcher import PatternMatcher
 
 
 def check_python_file(
-    file_path: Path, content: str, config: ModularConfig, critical_only: bool = False
+    file_path: Path, content: str, config: ModularConfig, *, critical_only: bool = False
 ) -> list[Violation]:
     """Check a Python file for violations.
 

--- a/x/claude_linter_v2/checker.py
+++ b/x/claude_linter_v2/checker.py
@@ -16,7 +16,7 @@ class FileChecker:
     """Checks files for violations and optionally fixes them."""
 
     def __init__(
-        self, fix: bool = False, categories: list[AutofixCategory] | None = None, verbose: bool = False
+        self, *, fix: bool = False, categories: list[AutofixCategory] | None = None, verbose: bool = False
     ) -> None:
         """
         Initialize the file checker.

--- a/x/claude_linter_v2/linters/python_ast.py
+++ b/x/claude_linter_v2/linters/python_ast.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class PythonASTAnalyzer:
     """Analyzes Python AST for hard-blocked patterns."""
 
-    def __init__(self, bare_except: bool = True, getattr_setattr: bool = True, barrel_init: bool = True) -> None:
+    def __init__(self, *, bare_except: bool = True, getattr_setattr: bool = True, barrel_init: bool = True) -> None:
         """
         Initialize the analyzer.
 

--- a/x/claude_linter_v2/linters/python_ruff.py
+++ b/x/claude_linter_v2/linters/python_ruff.py
@@ -42,7 +42,7 @@ class PythonRuffLinter:
             raise RuntimeError("ruff binary not found. Set RUFF_BIN env var or add ruff to PATH.")
         self._ruff_bin: str = ruff_bin
 
-    def check_code(self, code: str, file_path: Path, critical_only: bool = True) -> list[Violation]:
+    def check_code(self, code: str, file_path: Path, *, critical_only: bool = True) -> list[Violation]:
         """Check Python code with ruff."""
         violations = []
 

--- a/x/claude_linter_v2/session/manager.py
+++ b/x/claude_linter_v2/session/manager.py
@@ -153,7 +153,7 @@ class SessionManager:
 
         return affected
 
-    def list_sessions(self, all_dirs: bool = False) -> list[SessionData]:
+    def list_sessions(self, *, all_dirs: bool = False) -> list[SessionData]:
         """List all sessions."""
         current_dir = Path.cwd().resolve()
         results = []

--- a/x/cotrl/llm_rl_experiment.py
+++ b/x/cotrl/llm_rl_experiment.py
@@ -248,7 +248,7 @@ Respond with ONLY a single integer representing your chosen action.
 Let's begin."""
 
     def _create_step_prompt(
-        self, state: np.ndarray, reward: float, action_space_size: int, first_step: bool = False
+        self, state: np.ndarray, reward: float, action_space_size: int, *, first_step: bool = False
     ) -> str:
         state_str = np.array2string(state, precision=4, suppress_small=True)
 
@@ -262,13 +262,13 @@ Available actions: {", ".join(str(i) for i in range(action_space_size))}
 Choose action:"""
 
     async def get_action(
-        self, state: np.ndarray, reward: float, action_space_size: int, first_step: bool = False
+        self, state: np.ndarray, reward: float, action_space_size: int, *, first_step: bool = False
     ) -> int:
         """Get action from LLM based on raw state data."""
         if not self.conversation_history:
             self.conversation_history.append(Message(role="system", content=self._create_initial_prompt()))
 
-        prompt = self._create_step_prompt(state, reward, action_space_size, first_step)
+        prompt = self._create_step_prompt(state, reward, action_space_size, first_step=first_step)
         self.conversation_history.append(Message(role="user", content=prompt))
 
         messages_dict = [msg.model_dump() for msg in self.conversation_history]

--- a/x/gitea/pr_gate/policy_common.py
+++ b/x/gitea/pr_gate/policy_common.py
@@ -27,7 +27,7 @@ RE_PULL_INDEX_OPTIONAL_STATUS = re.compile(
 )
 
 
-def user_headers(cookie: str = "", authz: str = "", admin: bool = False) -> dict[str, str]:
+def user_headers(cookie: str = "", authz: str = "", *, admin: bool = False) -> dict[str, str]:
     if admin and ADMIN_TOKEN:
         return {"Authorization": f"token {ADMIN_TOKEN}"}
     hdrs: dict[str, str] = {}


### PR DESCRIPTION
## Summary
Makes boolean parameters with defaults keyword-only (`*` separator) across 44 files and updates all call sites. No rule enforcement — just the easy wins.

Skipped: Typer CLI options, invoke `@task`, FastMCP `@server.tool`, httpx overrides — these need `# noqa` and aren't worth it without enforcing the rule.

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF