### PR TITLE
fix: pass check_consumed as keyword arg in DecoratorMock.mock()

### DIFF
--- a/agent_core/testing/responses.py
+++ b/agent_core/testing/responses.py
@@ -288,7 +288,7 @@ class DecoratorMock(GeneratorMock):
         def decorator(fn: Callable[[T], PlayGen]) -> T:
             # fn: Callable[[T], ...] stored as Callable[[DecoratorMock], ...] - safe
             # because play() only calls it with self (which is T at runtime)
-            return cls(fn, check_consumed, *args, **kwargs)  # type: ignore[arg-type]
+            return cls(fn, *args, check_consumed=check_consumed, **kwargs)  # type: ignore[arg-type]
 
         return decorator
 


### PR DESCRIPTION
## Summary

- Fix `DecoratorMock.mock()` to pass `check_consumed` as keyword argument, matching the keyword-only `__init__` signature from #1049

## Context

The keyword-only refactor in df4b992 (#1049) made `DecoratorMock.__init__`'s `check_consumed` parameter keyword-only (`*`), but the `.mock()` classmethod on line 291 still passed it positionally. This caused all 22 agent_core/props/mcp_infra/editor_agent test failures on devel.

## Test plan

- [x] All 21 previously failing tests pass locally via RBE

https://claude.ai/code/session_01NEWi2dFkfsx8pZmauajaXG