### PR TITLE
[RUFF] Enable TRY401 rule (redundant exception in logging.exception)

### DIFF
--- a/ember/matrix_client.py
+++ b/ember/matrix_client.py
@@ -411,8 +411,8 @@ class MatrixClient:
         self._apply_access_token()
         try:
             response = await self._client.sync(timeout=30_000, since=self._since)
-        except Exception as exc:
-            logger.exception("Matrix sync failed: %s", exc)
+        except Exception:
+            logger.exception("Matrix sync failed")
             return None
 
         if isinstance(response, SyncError):

--- a/ruff.toml
+++ b/ruff.toml
@@ -68,6 +68,7 @@ select = [
     # TRY004 blindly converts these to TypeError, which is semantically wrong —
     # a mount being in the wrong lifecycle state is a RuntimeError, not a type error.
     "EXE",   # shebang/executable consistency
+    "TRY401", # redundant exception object in logging.exception
     "RUF"    # ruff-specific
 ]
 # Keep these off globally; handled case-by-case or via constants

--- a/x/agent_server/mcp/matrix_server.py
+++ b/x/agent_server/mcp/matrix_server.py
@@ -187,8 +187,8 @@ class _MatrixClient:
                     task.add_done_callback(lambda t: t.exception() if t.done() and not t.cancelled() else None)
                 except Exception as notify_exc:
                     logger.warning("matrix notify failed: %s", notify_exc)
-            except Exception as exc:
-                logger.exception("matrix on_message callback failed: %s", exc)
+            except Exception:
+                logger.exception("matrix on_message callback failed")
 
         c.add_event_handler(EventType.ROOM_MESSAGE, _on_message)
 

--- a/x/claude_hooks/base.py
+++ b/x/claude_hooks/base.py
@@ -119,8 +119,8 @@ class HookBase[InputT: BaseHookInput, OutputT: HookAction](ABC):
             self.logger.info(f"Output JSON: {output_json}")
             print(output_json)
             sys.exit(0)
-        except Exception as e:
-            self.logger.exception(f"Fatal error in run_hook: {e}")
+        except Exception:
+            self.logger.exception("Fatal error in run_hook")
             # Still need to output something to not break Claude
             fallback = PostToolContinue()
             print(json.dumps(fallback.to_protocol()))

--- a/x/claude_hooks/precommit_autofix.py
+++ b/x/claude_hooks/precommit_autofix.py
@@ -181,7 +181,7 @@ class PreCommitAutoFixerHook(PostToolUseHook):
             # (SubprocessError), and any unexpected errors from dependencies like pre-commit itself.
             # The broad catch ensures users get actionable feedback with logs and tracebacks
             # rather than cryptic tool failures.
-            self.logger.exception(f"Pre-commit autofix failed: {e}")
+            self.logger.exception("Pre-commit autofix failed")
             # Show feedback for unexpected exceptions with debugging guidance
             tb_str = traceback.format_exc()
             invocation_id = get_current_invocation_id() or "unknown"
@@ -252,8 +252,8 @@ class PreCommitAutoFixerHook(PostToolUseHook):
             # Exit code 3: "An unexpected error", 130: "interrupted by ^C", etc.
             self.logger.warning(f"Pre-commit unexpected exit code {result.returncode}")
             return Crashed(stdout=result.stdout, stderr=result.stderr, exit_code=result.returncode)
-        except Exception as e:
-            self.logger.exception(f"Error in _run_precommit_autofix: {e}")
+        except Exception:
+            self.logger.exception("Error in _run_precommit_autofix")
             # Re-raise exceptions that aren't pre-commit failures
             raise
 


### PR DESCRIPTION
## Summary
- Enable `TRY401` in `ruff.toml`
- Fix 5 violations: remove redundant exception object from `logger.exception()` calls (it already includes the traceback automatically)

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF