### PR TITLE
[RUFF] Enable TRY203 rule (remove useless try-except re-raise)

### DIFF
--- a/ember/matrix_client.py
+++ b/ember/matrix_client.py
@@ -199,30 +199,27 @@ class MatrixClient:
         return {RoomID(room_id) for room_id in (response.rooms or [])}
 
     async def _sync_loop(self) -> None:
-        try:
-            while not self._stop_event.is_set():
-                if (response := await self._sync_once()) is None:
-                    await asyncio.sleep(5)
-                    continue
+        while not self._stop_event.is_set():
+            if (response := await self._sync_once()) is None:
+                await asyncio.sleep(5)
+                continue
 
-                await self._process_sync_with_client(response)
+            await self._process_sync_with_client(response)
 
-                logger.debug(
-                    "Matrix sync succeeded; next_batch=%s, joined=%d, invite=%d, leave=%d",
-                    response.next_batch,
-                    len(response.rooms.join or {}),
-                    len(response.rooms.invite or {}),
-                    len(response.rooms.leave or {}),
-                )
+            logger.debug(
+                "Matrix sync succeeded; next_batch=%s, joined=%d, invite=%d, leave=%d",
+                response.next_batch,
+                len(response.rooms.join or {}),
+                len(response.rooms.invite or {}),
+                len(response.rooms.leave or {}),
+            )
 
-                self._since = response.next_batch
-                self._persist_since_token(response.next_batch)
-                await self._handle_invites(response)
-                await self._handle_joined_rooms(response)
-                await self._handle_left_rooms(response)
-                await self._crypto_housekeeping()
-        except asyncio.CancelledError:
-            raise
+            self._since = response.next_batch
+            self._persist_since_token(response.next_batch)
+            await self._handle_invites(response)
+            await self._handle_joined_rooms(response)
+            await self._handle_left_rooms(response)
+            await self._crypto_housekeeping()
 
     async def _handle_invites(self, response: SyncResponse) -> None:
         if not (invites := response.rooms.invite):

--- a/ruff.toml
+++ b/ruff.toml
@@ -69,6 +69,7 @@ select = [
     # a mount being in the wrong lifecycle state is a RuntimeError, not a type error.
     "EXE",   # shebang/executable consistency
     "TRY401", # redundant exception object in logging.exception
+    "TRY203", # useless try-except (just re-raises)
     "RUF"    # ruff-specific
 ]
 # Keep these off globally; handled case-by-case or via constants

--- a/x/agent_server/e2e/test_abort.py
+++ b/x/agent_server/e2e/test_abort.py
@@ -36,11 +36,7 @@ def test_ui_abort_sampling(e2e_page, run_server, responses_factory):
         # Simulate a long-running first sampling call that should be cancelled by Abort
         state["i"] += 1
         if state["i"] == 1:
-            try:
-                await asyncio.sleep(5.0)
-            except asyncio.CancelledError:
-                # Propagate cancellation so the agent treats this as aborted
-                raise
+            await asyncio.sleep(5.0)
             # If not cancelled (unexpected), return a message
             return responses_factory.make_assistant_message("too-late")
         return responses_factory.make_assistant_message("done")

--- a/x/rspcache/admin_app.py
+++ b/x/rspcache/admin_app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import os
 from collections.abc import AsyncIterator
 from datetime import datetime
@@ -214,11 +213,8 @@ async def get_frames(
 @admin_app.get("/api/responses/live")
 async def live_updates(db: Db) -> StreamingResponse:
     async def event_generator() -> AsyncIterator[str]:
-        try:
-            async for event in db.subscribe_events():
-                yield f"data: {event.model_dump_json()}\n\n"
-        except asyncio.CancelledError:
-            raise
+        async for event in db.subscribe_events():
+            yield f"data: {event.model_dump_json()}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 


### PR DESCRIPTION
## Summary
- Enable `TRY203` in `ruff.toml`
- Fix 4 violations: remove useless try/except blocks that just re-raise (e.g. `except CancelledError: raise`)

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF