### PR TITLE
fix: DockerExecMock keyword-only check_consumed + test timeout policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ if __name__ == "__main__":
 
 **No test skips for missing tools**: let the test fail. Tools come from Bazel runfiles or the RBE worker image.
 
+**Test timeouts mean hangs, not slowness**: When a test times out, assume it is wedged — an internal operation is waiting on something that will never arrive (deadlock, stuck future, container that never becomes ready, connection to a port nothing is listening on). Do NOT bump `size`/`timeout` as a fix. Instead, trace the execution to find what is blocked: run with `--test_output=streamed --test_arg=-s`, add logging around fixture setup, check for stuck containers (`docker ps`), etc. A test that ran in 35s last week and now times out at 60s is not "slow" — something broke internally.
+
 ### Updating syrupy snapshots
 
 Snapshot tests use syrupy (`.ambr` files in `__snapshots__/`). To update after intentional changes, run locally (not RBE) so syrupy can write through the execroot symlinks to the source tree:

--- a/agent_core/testing/mcp/responses.py
+++ b/agent_core/testing/mcp/responses.py
@@ -91,11 +91,15 @@ class DockerExecMock(MCPDecoratorMock):
     """
 
     def __init__(
-        self, play_fn: Callable[[DockerExecMock], PlayGen], check_consumed: bool, runtime: Mounted[ContainerExecServer]
+        self,
+        play_fn: Callable[[DockerExecMock], PlayGen],
+        runtime: Mounted[ContainerExecServer],
+        *,
+        check_consumed: bool = True,
     ) -> None:
         self._runtime = runtime
         # Safe: play() only calls play_fn with self which is DockerExecMock
-        super().__init__(play_fn, check_consumed)  # type: ignore[arg-type]
+        super().__init__(play_fn, check_consumed=check_consumed)  # type: ignore[arg-type]
 
     def exec(
         self, cmd: list[str], timeout_ms: int = 30000, cwd: str | None = None


### PR DESCRIPTION
## Summary

- Fix `DockerExecMock.__init__` passing `check_consumed` positionally to `DecoratorMock.__init__` which is now keyword-only (#1049)
- Add AGENTS.md policy: test timeouts mean hangs (wedged internal operation), not slowness — don't bump `size`/`timeout` without tracing what's blocked

## Context

The mypy lint `//agent_core/testing/mcp:responses` fails on CI because `super().__init__(play_fn, check_consumed)` passes `check_consumed` positionally after #1049 made it keyword-only. Same class of bug as #1050 but in the subclass.

## Test plan

- [x] `//editor_agent/host:test_editor_e2e_steps` passes (uses `HostDockerExecMock` → `MCPDecoratorMock` → `DecoratorMock`)
- [x] All 21 previously failing agent_core/props/mcp_infra tests pass

https://claude.ai/code/session_01NEWi2dFkfsx8pZmauajaXG