### PR TITLE
fix: precommit_runner early return [] → {} to match dict return type

### DIFF
--- a/devinfra/claude/hook_daemon/precommit_runner.py
+++ b/devinfra/claude/hook_daemon/precommit_runner.py
@@ -111,7 +111,7 @@ def _run_hooks(
     config = load_config(str(config_path))
     hooks = [h for h in all_hooks(config, store) if not h.stages or "pre-commit" in h.stages]
     if not hooks:
-        return [], []
+        return {}, []
 
     install_hook_envs(hooks, store)
 


### PR DESCRIPTION
## Summary

- Fix early return in `_run_hooks` returning `[]` instead of `{}` after #1056 changed the return type to `dict[str, HookOutcome]`

## Test plan

- [x] Last CI run had this as the only remaining mypy error; all 422 tests pass

https://claude.ai/code/session_01NEWi2dFkfsx8pZmauajaXG