### PR TITLE
Use keyword arguments for boolean positional values at call sites

### DIFF
--- a/ansible/action_plugins/dconf_array_edit.py
+++ b/ansible/action_plugins/dconf_array_edit.py
@@ -60,7 +60,7 @@ def _list_to_array(lst: Iterable[str]) -> str:
     ansible.builtin.dconf expects the *printed* form of a GLib variant that
     itself contains a variant of type ``as`` (array of strings).
     """
-    return GLib.Variant("v", GLib.Variant("as", list(lst))).print_(False)
+    return GLib.Variant("v", GLib.Variant("as", list(lst))).print_(type_annotate=False)
 
 
 class ActionModule(ActionBase):

--- a/debug/spice_lag/record.py
+++ b/debug/spice_lag/record.py
@@ -59,7 +59,7 @@ def start_screencast(bus: Gio.DBusConnection, fps: int, output_path: Path) -> st
     builder.add_value(GLib.Variant("s", str(output_path)))
     options_builder = GLib.VariantBuilder.new(GLib.VariantType("a{sv}"))
     options_builder.add_value(GLib.Variant("{sv}", ("framerate", GLib.Variant("i", fps))))
-    options_builder.add_value(GLib.Variant("{sv}", ("draw-cursor", GLib.Variant("b", False))))
+    options_builder.add_value(GLib.Variant("{sv}", ("draw-cursor", GLib.Variant("b", value=False))))
     builder.add_value(options_builder.end())
     params = builder.end()
 

--- a/devinfra/check_pytest_main.py
+++ b/devinfra/check_pytest_main.py
@@ -90,19 +90,19 @@ def check_file(file_path: Path, repo_root: Path, bazel_index: BazelPyTestIndex) 
     content = (repo_root / file_path).read_text()
 
     if has_pytest_bazel_main(content):
-        return CheckResult(file_path, True, "has pytest_bazel.main()")
+        return CheckResult(file_path, passed=True, reason="has pytest_bazel.main()")
 
     abs_path = (repo_root / file_path).resolve()
     if abs_path not in bazel_index.known_srcs:
-        return CheckResult(file_path, True, "not a py_test src (not a Bazel target)")
+        return CheckResult(file_path, passed=True, reason="not a py_test src (not a Bazel target)")
     if abs_path in bazel_index.exempt_srcs:
-        return CheckResult(file_path, True, "exempt: py_test uses custom main= (bazel query)")
+        return CheckResult(file_path, passed=True, reason="exempt: py_test uses custom main= (bazel query)")
 
     # Check if using pytest.main() directly (custom runner)
     if "pytest.main(" in content:
-        return CheckResult(file_path, True, "uses pytest.main() (custom runner)")
+        return CheckResult(file_path, passed=True, reason="uses pytest.main() (custom runner)")
 
-    return CheckResult(file_path, False, "missing pytest_bazel.main() entry point")
+    return CheckResult(file_path, passed=False, reason="missing pytest_bazel.main() entry point")
 
 
 async def check_files_async(files: list[Path], repo_root: Path, bazel_index: BazelPyTestIndex) -> list[CheckResult]:

--- a/ember/runtime.py
+++ b/ember/runtime.py
@@ -176,7 +176,7 @@ class EmberRuntime:
 
                 # Set typing indicator
                 if room_ids:
-                    await self._matrix_client.set_typing(room_ids, True)
+                    await self._matrix_client.set_typing(room_ids, typing=True)
 
                 try:
                     # Reset sleep handler for new conversation turn
@@ -192,7 +192,7 @@ class EmberRuntime:
                     await self._agent.run()
                 finally:
                     if room_ids:
-                        await self._matrix_client.set_typing(room_ids, False)
+                        await self._matrix_client.set_typing(room_ids, typing=False)
 
         except asyncio.CancelledError:
             raise

--- a/trilium/papers/papers_trilium_to_remarkable.py
+++ b/trilium/papers/papers_trilium_to_remarkable.py
@@ -18,7 +18,7 @@ from tqdm.auto import tqdm
 
 _ETAPI_ROOT_URL = flags.DEFINE_string("etapi_root_url", "http://localhost:37840", "ETAPI root URL")
 _TOKEN = flags.DEFINE_string("token", None, "ETAPI token")
-_PURGE = flags.DEFINE_bool("purge", False, "Purge RM side?")
+_PURGE = flags.DEFINE_bool("purge", default=False, help="Purge RM side?")
 SYNCED_DIR_PATH = platformdirs.user_cache_path("papers_trilium_to_remarkable") / "synced_dir"
 REMARKABLE_SIDE_PATH = "/papers_trilium_to_remarkable"
 FILE_PREFIX = "[f]\t"

--- a/wt/client/wt_client.py
+++ b/wt/client/wt_client.py
@@ -201,7 +201,7 @@ class WtClient:
         fcntl.fcntl(read_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
         with contextlib.suppress(Exception):
-            os.set_inheritable(write_fd, True)
+            os.set_inheritable(write_fd, inheritable=True)
 
         env = os.environ.copy()
         env["WT_HANDSHAKE_FD"] = str(write_fd)

--- a/wt/server/stores.py
+++ b/wt/server/stores.py
@@ -43,7 +43,7 @@ class DaemonStore:
 
         # Daemon config
         self._gitstatusd_config: Signal[GitstatusdConfig] = Signal(GitstatusdUnavailable(error="not initialized"))
-        self._github_enabled: Signal[bool] = Signal(True)
+        self._github_enabled: Signal[bool] = Signal(value=True)
 
         # Computed: all branches currently checked out across worktrees
         # Reads branch from GitstatusdData

--- a/x/claude_linter/conftest.py
+++ b/x/claude_linter/conftest.py
@@ -32,7 +32,7 @@ def chdir_tmp_path(tmp_path, monkeypatch):
 def chdir_tmp_path_git_repo(tmp_path, monkeypatch):
     """Change cwd to tmp_path and init a git repo via pygit2."""
     monkeypatch.chdir(tmp_path)
-    repo = pygit2.init_repository(str(tmp_path), False)
+    repo = pygit2.init_repository(str(tmp_path), bare=False)
     cfg = repo.config
     cfg["user.name"] = "test"
     cfg["user.email"] = "test@example.com"

--- a/x/claude_linter/test_hooks.py
+++ b/x/claude_linter/test_hooks.py
@@ -229,7 +229,7 @@ sys.exit(0)
         hook_script.chmod(0o755)
 
         # Initialize as git repo using pygit2
-        repo = pygit2.init_repository(str(remote_path), False)
+        repo = pygit2.init_repository(str(remote_path), bare=False)
         cfg = repo.config
         cfg["user.name"] = "test"
         cfg["user.email"] = "test@example.com"

--- a/x/cotrl/analyze_trajectories.py
+++ b/x/cotrl/analyze_trajectories.py
@@ -69,7 +69,7 @@ def plot_action_heatmap(action_counts):
                 ax.set_xlabel("Action", fontsize=9)
 
             ax.set_xticks(range(len(action_probs)))
-            ax.grid(True, alpha=0.3)
+            ax.grid(visible=True, alpha=0.3)
 
     plt.suptitle("Action Distribution by Model and Environment")
     plt.tight_layout()

--- a/x/cotrl/llm_rl_experiment.py
+++ b/x/cotrl/llm_rl_experiment.py
@@ -457,7 +457,7 @@ def plot_results(all_runs: list[Run]):
             if i == n_models - 1:
                 ax.set_xlabel("Step")
 
-            ax.grid(True, alpha=0.3)
+            ax.grid(visible=True, alpha=0.3)
 
     plt.suptitle("Language Models as RL Agents (Raw Numerical Data)", fontsize=14)
     plt.tight_layout()


### PR DESCRIPTION
## Summary
Converts bare `True`/`False` positional arguments to keyword form at call sites where the fix is unambiguous. 11 files, no enforcement.

Excludes `typer.Option`, Pydantic `Field`, and other framework-specific patterns that need more careful handling.

Examples: `init_repository(path, False)` → `bare=False`, `ax.grid(True)` → `visible=True`, `os.set_inheritable(fd, True)` → `inheritable=True`

https://claude.ai/code/session_013WcexLQ8JPJG1j79uvMfCF