### PR TITLE
[LINT] Enable A006 and PGH ruff rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -63,6 +63,8 @@ select = [
     "N",     # naming
     "PERF",  # perflint
     "FAST",  # FastAPI best practices
+    "A006",  # lambda argument shadowing builtins
+    "PGH",   # pygrep-hooks (bare type: ignore / noqa without codes)
     # TRY004 disabled: isinstance() checks are used for state validation (e.g.,
     # "mount not active", "app resources not initialized"), not just type narrowing.
     # TRY004 blindly converts these to TypeError, which is semantically wrong —

--- a/trilium/papers/papers_trilium_to_remarkable.py
+++ b/trilium/papers/papers_trilium_to_remarkable.py
@@ -213,7 +213,7 @@ def sync():
     new_arxiv_ids = set(should_exist.keys()) - set(existing_arxiv_id_to_filename.keys())
     # Sort by priority.
     new_arxiv_ids = sorted(
-        new_arxiv_ids, key=lambda id: should_exist[id].priority if should_exist[id].priority is not None else 200
+        new_arxiv_ids, key=lambda aid: should_exist[aid].priority if should_exist[aid].priority is not None else 200
     )
     # TODO: WTF why is it adding new ones?
     for arxiv_id in (t := tqdm(new_arxiv_ids)):


### PR DESCRIPTION
## Summary
- Enable **A006** (lambda argument shadowing builtins) — 1 violation fixed: renamed `lambda id:` to `lambda aid:` in `trilium/papers/papers_trilium_to_remarkable.py`
- Enable **PGH** (pygrep-hooks) — 0 violations, pure guardrail. Catches bare `# type: ignore` and `# noqa` without error codes

## Test plan
- [x] `ruff check --select A006,PGH` passes with 0 violations
- [ ] CI passes

https://claude.ai/code/session_01BkiseDkvop9rKPxUonmLUV