### PR TITLE
[LINT] Remove unused pyrage dependency and mypy override

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -196,11 +196,6 @@ ignore_missing_imports = True
 [mypy-opentelemetry.proto.*]
 ignore_errors = True
 
-# Rust extension (PyO3) with no type stubs — skip analysis
-[mypy-pyrage.*]
-follow_imports = skip
-ignore_missing_imports = True
-
 # hack/cotrl uses many untyped deps (gymnasium, scipy, etc.) — pre-existing
 [mypy-x.cotrl.*]
 ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ dependencies = [
     "pproxy>=2.7",
     "pyopenssl>=24.0",
     "pyjwt>=2.8",
-    "pyrage>=1.0",
     "supervisor>=4.2",
 
     "numpy",


### PR DESCRIPTION
## Summary
- Remove `pyrage>=1.0` from `pyproject.toml` — zero Python imports in the codebase
- Remove stale `[mypy-pyrage.*]` override from `mypy.ini`

## Test plan
- [x] Verified zero `import pyrage` / `from pyrage` in the codebase
- [x] No BUILD file references to pyrage
- [ ] CI passes

https://claude.ai/code/session_01BkiseDkvop9rKPxUonmLUV