### PR TITLE
[LINT] Bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ exclude: |
   )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # Safety guard: block pushes to protected branches.
       # 'main' and 'master' are protected by default.
@@ -80,7 +80,7 @@ repos:
 
   # Markdown linting (scoped to match .markdownlint-cli2.jsonc globs)
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.22.0
     hooks:
       - id: markdownlint-cli2
         args: [--fix]
@@ -273,7 +273,7 @@ repos:
 
   # Checkov security scanner for Terraform (standalone, avoids 10s import in bazel-precommit)
   - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.2.497
+    rev: 3.2.513
     hooks:
       - id: checkov_diff
         args: ["--framework", "terraform", "--skip-check", "CKV_TF_1", "-f"]


### PR DESCRIPTION
## Summary
- **pre-commit-hooks**: v5.0.0 → v6.0.0 (dropped Python <3.9 support, removed `check-byte-order-marker` and `fix-encoding-pragma` — neither used here)
- **markdownlint-cli2**: v0.17.2 → v0.22.0 (new MD059/MD060 rules, TOML config support — 0 new violations on scoped files)
- **checkov**: 3.2.497 → 3.2.513 (bug fixes only, no new checks added)

## Compatibility notes
- pre-commit-hooks v6: only breaking change is Python 3.9+ minimum (we target 3.13+)
- markdownlint-cli2 v0.22: new MD059 (descriptive-link-text) enabled by default, verified 0 violations in `cluster/**/*.md` and `website/**/*.md`
- checkov 3.2.513: all changes are bug fixes or features in unrelated frameworks (bicep, .NET, secrets scanner)

## Test plan
- [x] `pre-commit run trailing-whitespace --all-files` passes
- [x] `pre-commit run end-of-file-fixer --all-files` passes
- [x] `pre-commit run check-toml --all-files` passes
- [x] `pre-commit run check-yaml --all-files` passes
- [x] `pre-commit run markdownlint-cli2 --all-files` passes
- [ ] CI passes

https://claude.ai/code/session_01BkiseDkvop9rKPxUonmLUV