### PR TITLE
[LINT] Bump prettier 3.7.4 → 3.8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -172,7 +172,7 @@ repos:
         entry: prettier --write --ignore-unknown --list-different
         language: node
         additional_dependencies:
-          - prettier@3.7.4
+          - prettier@3.8.1
           - prettier-plugin-svelte@3.4.1
           - svelte@5.38.1
         files: "\\.(js|jsx|ts|tsx|svelte|css|md|yaml|yml|json|html)$"


### PR DESCRIPTION
## Summary
- Bump `prettier` from 3.7.4 to 3.8.1 in `.pre-commit-config.yaml`
- 3.8.0: Angular v21.1 support
- 3.8.1: plugin type declaration fix
- No formatting changes to existing files

## Test plan
- [x] `pre-commit run prettier --all-files` passes with 0 reformats
- [ ] CI passes

https://claude.ai/code/session_01BkiseDkvop9rKPxUonmLUV