### PR TITLE
fix: add missing mypy deps for mcp and playwright

### DIFF
--- a/x/agent_server/e2e/BUILD.bazel
+++ b/x/agent_server/e2e/BUILD.bazel
@@ -77,6 +77,7 @@ py_library(
         "//x/agent_server:agent_types",
         "//x/agent_server/server:app",
         "//x/agent_server/testing:helpers",
+        "@pypi//playwright",
         "@pypi//pytest",
     ],
 )

--- a/x/agent_server/server/BUILD.bazel
+++ b/x/agent_server/server/BUILD.bazel
@@ -36,6 +36,7 @@ py_test(
         ":state",
         "//x/agent_server:conftest",
         "//x/agent_server/testing:typed_asserts",
+        "@pypi//mcp",
         "@pypi//pyhamcrest",
         "@pypi//pytest_bazel",
     ],
@@ -54,6 +55,7 @@ py_test(
         "//mcp_infra:prefix",
         "//x/agent_server:conftest",
         "//x/agent_server/testing:typed_asserts",
+        "@pypi//mcp",
         "@pypi//pytest_bazel",
     ],
 )
@@ -74,6 +76,7 @@ py_test(
         "//mcp_infra/exec:models",
         "//x/agent_server:conftest",
         "//x/agent_server/testing:typed_asserts",
+        "@pypi//mcp",
         "@pypi//pyhamcrest",
         "@pypi//pytest_bazel",
     ],


### PR DESCRIPTION
## Summary

- Add `@pypi//mcp` to 3 test targets in `x/agent_server/server/` that include `conftest.py` in `srcs` — mypy needs the dep directly since transitive deps from the `:conftest` library aren't visible to the mypy aspect
- Add `@pypi//playwright` to `x/agent_server/e2e:conftest` — `TYPE_CHECKING` import of `playwright.sync_api` needs the dep for mypy

These are the last 2 mypy errors on devel. 414 tests pass, 0 test failures.

## Test plan

- [x] Pre-commit passes
- CI should show 0 mypy errors after merge

https://claude.ai/code/session_01NEWi2dFkfsx8pZmauajaXG