### PR TITLE
[LINT] Add types-psutil stubs to BUILD deps, remove mypy.ini override

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/BUILD.bazel
@@ -106,7 +106,10 @@ py_library(
     srcs = ["tmpfs.py"],
     imports = ["../../../.."],
     visibility = ["//visibility:public"],
-    deps = ["@pypi//psutil"],
+    deps = [
+        "@pypi//psutil",
+        "@pypi//types_psutil",
+    ],
 )
 
 py_library(

--- a/mypy.ini
+++ b/mypy.ini
@@ -58,12 +58,6 @@ ignore_missing_imports = True
 [mypy-inventree.*]
 ignore_missing_imports = True
 
-# psutil 7.2.2: C extension, no py.typed. types-psutil stubs exist
-# (types-psutil 7.2.2.20260130) but are not added to deps.
-# CLEANUP(2026-03-27): Add @pypi//types_psutil to deps and remove this override.
-[mypy-psutil.*]
-ignore_missing_imports = True
-
 # google-api-python-client 2.192.0: no py.typed, no stubs.
 [mypy-googleapiclient.*]
 ignore_missing_imports = True

--- a/wt/client/BUILD.bazel
+++ b/wt/client/BUILD.bazel
@@ -45,6 +45,7 @@ py_library(
         "@pypi//click",
         "@pypi//more_itertools",
         "@pypi//psutil",
+        "@pypi//types_psutil",
     ],
 )
 
@@ -79,6 +80,7 @@ py_library(
         "@pypi//psutil",
         "@pypi//pydantic",
         "@pypi//pygit2",
+        "@pypi//types_psutil",
     ],
 )
 

--- a/wt/server/BUILD.bazel
+++ b/wt/server/BUILD.bazel
@@ -196,6 +196,7 @@ py_library(
         "//wt/shared:protocol",
         "@pypi//psutil",
         "@pypi//pygit2",
+        "@pypi//types_psutil",
     ],
 )
 

--- a/x/gatelet/BUILD.bazel
+++ b/x/gatelet/BUILD.bazel
@@ -13,6 +13,7 @@ py_library(
         "@pypi//psutil",
         "@pypi//pydantic",
         "@pypi//tomlkit",
+        "@pypi//types_psutil",
     ],
 )
 


### PR DESCRIPTION
## Summary
- Add `@pypi//types_psutil` to BUILD deps for all 5 targets using `@pypi//psutil` (`wt/server`, `wt/client` ×2, `x/gatelet`, `devinfra/claude/hook_daemon/session_start`)
- Remove `[mypy-psutil.*] ignore_missing_imports = True` override from `mypy.ini`

`types-psutil` was already present in `pyproject.toml` and `requirements_bazel.txt` — the stubs just weren't wired into BUILD deps.

Resolves `CLEANUP(2026-03-27)` tombstone in `mypy.ini`.

https://claude.ai/code/session_01JK5VzY7KmUWDJVQtDsSJfa