### PR TITLE
[LINT] Enable prefer-const (ESLint)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,7 @@ export default [
       "@typescript-eslint": tseslint,
     },
     rules: {
+      "prefer-const": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -63,6 +64,7 @@ export default [
     },
     rules: {
       ...sveltePlugin.configs.recommended.rules,
+      "prefer-const": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -84,6 +86,7 @@ export default [
     },
     rules: {
       ...sveltePlugin.configs.recommended.rules,
+      "prefer-const": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -130,6 +133,7 @@ export default [
       "no-unused-vars": "off", // Use @typescript-eslint version instead
 
       // General code quality
+      "prefer-const": "error",
       "no-console": ["warn", { allow: ["warn", "error"] }],
       "no-multiple-empty-lines": ["error", { max: 1 }],
     },
@@ -174,6 +178,7 @@ export default [
       "svelte/no-unused-svelte-ignore": "warn",
 
       // General code quality
+      "prefer-const": "error",
       "no-unused-vars": [
         "error",
         {
@@ -215,6 +220,7 @@ export default [
       "react/react-in-jsx-scope": "off", // Not needed in React 17+
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "no-unused-vars": "off",
+      "prefer-const": "error",
       "no-console": ["warn", { allow: ["warn", "error"] }],
     },
   },

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -156,9 +156,7 @@
     if (getAgentType(criticRun) !== "critic") return;
 
     const config = criticRun.type_config as CriticTypeConfig;
-    let snapshotSlug: string;
-
-    snapshotSlug = config.example.snapshot_slug;
+    const snapshotSlug = config.example.snapshot_slug;
 
     loadingSnapshot = true;
     try {


### PR DESCRIPTION
## Summary
- Add `prefer-const: "error"` to all 6 ESLint config blocks
- Fix 1 violation: `let` → `const` in `props/frontend/src/components/RunDetail.svelte`

## Test plan
- [ ] ESLint passes on all TS/Svelte projects
- [ ] Props frontend builds cleanly

https://claude.ai/code/session_01TVjKdv6UebLZt9FP7ZuAbt