### PR TITLE
[LINT] Enable consistent-type-imports (ESLint)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ export default [
     },
     rules: {
       "prefer-const": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -65,6 +66,7 @@ export default [
     rules: {
       ...sveltePlugin.configs.recommended.rules,
       "prefer-const": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -87,6 +89,7 @@ export default [
     rules: {
       ...sveltePlugin.configs.recommended.rules,
       "prefer-const": "error",
+      "@typescript-eslint/consistent-type-imports": "error",
       "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
@@ -123,6 +126,7 @@ export default [
       "import/no-duplicates": "error",
 
       // TypeScript
+      "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-unused-vars": [
         "warn",
         {
@@ -218,6 +222,7 @@ export default [
     },
     rules: {
       "react/react-in-jsx-scope": "off", // Not needed in React 17+
+      "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "no-unused-vars": "off",
       "prefer-const": "error",


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/consistent-type-imports: "error"` to all 5 config blocks with `@typescript-eslint` plugin
- No source changes needed — `verbatimModuleSyntax: true` already enforces this in props, airlock, and agent_server; rspcache already uses `import type` correctly
- Pure guardrail for future code

## Test plan
- [ ] ESLint passes on all TS/Svelte projects

https://claude.ai/code/session_01TVjKdv6UebLZt9FP7ZuAbt