### PR TITLE
[LINT] Add statix linter for Nix files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,16 @@ repos:
         language: system
         files: "\\.nix$"
 
+  # Statix - Nix anti-pattern linter — statix provided by devShell / web-session via Nix
+  - repo: local
+    hooks:
+      - id: statix
+        name: statix
+        entry: statix check
+        language: system
+        files: "\\.nix$"
+        pass_filenames: false
+
   # Markdown linting (scoped to match .markdownlint-cli2.jsonc globs)
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.22.0

--- a/flake.nix
+++ b/flake.nix
@@ -70,12 +70,12 @@
             _name: spec:
             if spec.fetch == "unpack" then
               builtins.fetchTarball {
-                url = spec.url;
+                inherit (spec) url;
                 sha256 = spec.hash;
               }
             else
               builtins.fetchurl {
-                url = spec.url;
+                inherit (spec) url;
                 sha256 = spec.hash;
               };
         in
@@ -313,6 +313,7 @@
               pkgs.pre-commit
               pkgs.bazelisk # TODO: ensure binary name matches what session start hook expects (no unconventional symlinks/aliases)
               pkgs.nixfmt-rfc-style
+              pkgs.statix
               pkgs.mkcert
               pkgs.ruff
               pkgs.shfmt

--- a/nix/home/claude_code/default.nix
+++ b/nix/home/claude_code/default.nix
@@ -399,11 +399,11 @@ in
     enable = true;
     package = pkgsUnstable.claude-code; # Use unstable for faster updates
 
-    commands = commands;
+    inherit commands;
 
     pluginSources.claude-plugins-official = {
       src = claude-plugins-official;
-      rev = claude-plugins-official.rev;
+      inherit (claude-plugins-official) rev;
     };
 
     plugins = [

--- a/nix/home/tests/claude-code-permissions.nix
+++ b/nix/home/tests/claude-code-permissions.nix
@@ -4,7 +4,7 @@
 
 let
   pkgs = import <nixpkgs> { };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 
   # Import SSOTs
   inspection = import ../../lib/inspection-commands.nix { inherit lib; };

--- a/nix/home/tests/gemini-cli-integration.nix
+++ b/nix/home/tests/gemini-cli-integration.nix
@@ -4,7 +4,7 @@
 
 let
   pkgs = import <nixpkgs> { };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 
   # Mock minimal home-manager config structure
   config = {

--- a/nix/lib/inspection-commands.nix
+++ b/nix/lib/inspection-commands.nix
@@ -781,7 +781,7 @@ let
       cmdStr = if entry ? args then "${entry.cmd} ${entry.args}" else entry.cmd;
     in
     {
-      type = entry.type;
+      inherit (entry) type;
       cmd = cmdStr;
     };
 
@@ -794,7 +794,7 @@ let
       stringified = stringifyCommand entry;
     in
     {
-      type = stringified.type;
+      inherit (stringified) type;
       cmd = "sudo ${stringified.cmd}";
     };
 in

--- a/nix/nixos/modules/bazel-nixos/default.nix
+++ b/nix/nixos/modules/bazel-nixos/default.nix
@@ -1,7 +1,6 @@
 # Install NixOS-specific Bazel flags to /etc/bazel.bazelrc.
 # System-level bazelrc is read regardless of $HOME, so it works even when
 # Claude Code's sandbox overrides HOME.
-{ ... }:
-{
+_: {
   environment.etc."bazel.bazelrc".source = ./system.bazelrc;
 }

--- a/nix/nixos/modules/timekpr.nix
+++ b/nix/nixos/modules/timekpr.nix
@@ -93,7 +93,7 @@ in
   config = lib.mkIf cfg.enable {
     services.timekpr = {
       enable = true;
-      package = cfg.package;
+      inherit (cfg) package;
     };
 
     # Autostart the client (tray icon + countdown notifications) in GNOME sessions

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,10 @@
+# Statix configuration - Nix anti-pattern linter
+# W20 (repeated keys): Disabled — the `foo.bar = ...; foo.baz = ...;` style
+# is idiomatic in home-manager configs and more readable than nested attrsets
+# for top-level option assignments.
+disabled = ["repeated_keys"]
+
+# Specimens are committed snapshots, not our source
+ignore = ["props/specimens"]
+
+nix_version = "2.24"


### PR DESCRIPTION
## Summary
- Add statix (Nix anti-pattern linter) as pre-commit hook + `statix.toml` config
- Fix 10 violations: `inherit`/`inherit (foo)` instead of redundant assignments (W03/W04), `_` instead of empty pattern (W10)
- Add `pkgs.statix` to devShell in `flake.nix`
- W20 (repeated keys) disabled — flat assignment style is idiomatic in home-manager configs

## Test plan
- [ ] `statix check` passes
- [ ] `pre-commit run statix --all-files` passes
- [ ] Nix files still evaluate correctly

https://claude.ai/code/session_01TVjKdv6UebLZt9FP7ZuAbt