### PR TITLE
Fix shell script quoting issues

### DIFF
--- a/cluster/k8s/agents/devbot/docker/build.sh
+++ b/cluster/k8s/agents/devbot/docker/build.sh
@@ -15,16 +15,16 @@ fi
 
 # Build desktop image
 echo "Building desktop image..."
-docker build -t ${DESKTOP_TAG} ./desktop/
+docker build -t "${DESKTOP_TAG}" ./desktop/
 
 # Build MCP server image
 echo "Building MCP server image..."
-docker build -t ${MCP_TAG} ./mcp-server/
+docker build -t "${MCP_TAG}" ./mcp-server/
 
 if [ "$PUSH" = "true" ]; then
   echo "Pushing images to ${REGISTRY}..."
-  docker push ${DESKTOP_TAG}
-  docker push ${MCP_TAG}
+  docker push "${DESKTOP_TAG}"
+  docker push "${MCP_TAG}"
   echo "Done! Images pushed to ${REGISTRY}."
 else
   echo "Done! Images built locally."

--- a/cluster/k8s/agents/devbot/docker/desktop/entrypoint.sh
+++ b/cluster/k8s/agents/devbot/docker/desktop/entrypoint.sh
@@ -14,7 +14,7 @@ RESOLUTION=${RESOLUTION:-1920x1080}
 
 # Start VNC server
 exec vncserver :0 \
-  -geometry $RESOLUTION \
+  -geometry "$RESOLUTION" \
   -depth 24 \
   -localhost no \
   -SecurityTypes VncAuth \

--- a/nix/home/shell/bash-init.sh
+++ b/nix/home/shell/bash-init.sh
@@ -35,12 +35,12 @@ complete -cf man
 # Colored man pages (zsh has oh-my-zsh plugin for this)
 man() {
   env \
-    LESS_TERMCAP_mb=$(printf "\e[1;31m") \
-    LESS_TERMCAP_md=$(printf "\e[1;31m") \
-    LESS_TERMCAP_me=$(printf "\e[0m") \
-    LESS_TERMCAP_se=$(printf "\e[0m") \
-    LESS_TERMCAP_so=$(printf "\e[1;44;33m") \
-    LESS_TERMCAP_ue=$(printf "\e[0m") \
-    LESS_TERMCAP_us=$(printf "\e[1;32m") \
+    LESS_TERMCAP_mb="$(printf "\e[1;31m")" \
+    LESS_TERMCAP_md="$(printf "\e[1;31m")" \
+    LESS_TERMCAP_me="$(printf "\e[0m")" \
+    LESS_TERMCAP_se="$(printf "\e[0m")" \
+    LESS_TERMCAP_so="$(printf "\e[1;44;33m")" \
+    LESS_TERMCAP_ue="$(printf "\e[0m")" \
+    LESS_TERMCAP_us="$(printf "\e[1;32m")" \
     man "$@"
 }


### PR DESCRIPTION
## Summary
- `bash-init.sh`: quote `$(printf)` in LESS_TERMCAP assignments
- `build.sh`: quote `${DESKTOP_TAG}` and `${MCP_TAG}` in docker commands
- `entrypoint.sh`: quote `$RESOLUTION` in vncserver `-geometry`

Split out from #1085 (shellcheck) so the code fixes land independently of the tooling setup.

## Test plan
- [ ] Scripts still work (no behavioral change — quoting prevents word splitting on values that never contain spaces, but is correct practice)

https://claude.ai/code/session_01TVjKdv6UebLZt9FP7ZuAbt