### PR TITLE
function learning: harder functions, prompt caching fix, multi-run runner

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -69,7 +69,17 @@ actions:
             --build_metadata=ROLE=ci \
             --test_tag_filters=-live_openai_api \
             //...
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh && ~/.local/bin/uv run devinfra/ci/bb_release.py
+      - run: |
+          # Install system deps for wheel builds (cairo, dbus, etc.)
+          sudo apt-get update -qq && sudo apt-get install -y \
+            libcairo2-dev libgirepository-2.0-dev libdbus-1-dev libxcb1-dev pkg-config
+          bazel build --config=rbe --remote_download_toplevel \
+            //:wheel \
+            //:claude_hooks_wheel \
+            //gterm_theme:wheel \
+            //skills:all_skills_tar \
+            //devinfra/buildbuddy_cli:bbapi
+          bazel run //devinfra/ci:bb_release_bin
 
   # Push Harbor container images (OCI images built with Bazel).
   # Uses oci_push (crane-based, no Docker daemon needed).

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -113,6 +113,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":artifacts",
+        "@pypi//pygit2",
         "@pypi//pygithub",
     ],
 )

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -113,6 +113,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":artifacts",
+        "@pypi//more-itertools",
         "@pypi//pygit2",
         "@pypi//pygithub",
     ],

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -13,8 +13,7 @@ SOURCES_PATH = Path("npins/sources.json")
 
 class Pin(BaseModel):
     url: str
-    hash: str  # SRI format: "sha256-<base64>"
-    fetch: str = "file"
+    sha256: str
 
 
 class Sources(BaseModel):
@@ -82,12 +81,10 @@ def _sha256_of_chunks(chunks: Iterable[bytes]) -> str:
 
 
 def file_sha256(path: Path) -> str:
-    """Return SRI-format SHA-256 hash of a local file."""
     with path.open("rb") as f:
-        return "sha256-" + _sha256_of_chunks(iter(lambda: f.read(65536), b""))
+        return _sha256_of_chunks(iter(lambda: f.read(65536), b""))
 
 
 def url_sha256(url: str) -> str:
-    """Return SRI-format SHA-256 hash of a URL's raw content."""
     with urllib.request.urlopen(url) as response:
-        return "sha256-" + _sha256_of_chunks(iter(lambda: response.read(65536), b""))
+        return _sha256_of_chunks(iter(lambda: response.read(65536), b""))

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -3,32 +3,30 @@
 import base64
 import hashlib
 import urllib.request
-from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 SOURCES_PATH = Path("npins/sources.json")
 
 
 class Pin(BaseModel):
     url: str
-    sha256: str
+    hash: str  # SRI format: "sha256-<base64>"
+    fetch: str = "file"
 
 
 class Sources(BaseModel):
     pins: dict[str, Pin]
 
 
-@dataclass(frozen=True)
-class Artifact:
-    pkg: str
-    bazel_target: str
-    src_glob: str  # path glob under bazel-bin/
-    dest: str  # destination path or directory under dist/
-    notes: str  # GitHub release body
-    filename: str  # artifact filename attached to the GitHub release
+class Artifact(BaseModel, frozen=True):
+    pkg: str = Field(description="npins package name")
+    bazel_target: str = Field(description="Bazel target that builds this artifact")
+    src_glob: str = Field(description="Path glob under bazel-bin/")
+    dest: str = Field(description="Destination path or directory under dist/")
+    notes: str = Field(description="GitHub release body")
+    filename: str = Field(description="Artifact filename attached to the GitHub release")
 
 
 ARTIFACTS = [
@@ -75,18 +73,19 @@ ARTIFACTS = [
 ]
 
 
-def _sha256_of_chunks(chunks: Iterable[bytes]) -> str:
-    h = hashlib.sha256()
-    for chunk in chunks:
-        h.update(chunk)
-    return base64.b64encode(h.digest()).decode()
-
-
 def file_sha256(path: Path) -> str:
+    """Return SRI-format SHA-256 hash of a local file."""
+    h = hashlib.sha256()
     with path.open("rb") as f:
-        return _sha256_of_chunks(iter(lambda: f.read(65536), b""))
+        while chunk := f.read(65536):
+            h.update(chunk)
+    return "sha256-" + base64.b64encode(h.digest()).decode()
 
 
 def url_sha256(url: str) -> str:
+    """Return SRI-format SHA-256 hash of a URL's raw content."""
+    h = hashlib.sha256()
     with urllib.request.urlopen(url) as response:
-        return _sha256_of_chunks(iter(lambda: response.read(65536), b""))
+        while chunk := response.read(65536):
+            h.update(chunk)
+    return "sha256-" + base64.b64encode(h.digest()).decode()

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -3,6 +3,7 @@
 import base64
 import hashlib
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -73,19 +74,20 @@ ARTIFACTS = [
 ]
 
 
+def _sha256_of_chunks(chunks: Iterable[bytes]) -> str:
+    h = hashlib.sha256()
+    for chunk in chunks:
+        h.update(chunk)
+    return base64.b64encode(h.digest()).decode()
+
+
 def file_sha256(path: Path) -> str:
     """Return SRI-format SHA-256 hash of a local file."""
-    h = hashlib.sha256()
     with path.open("rb") as f:
-        while chunk := f.read(65536):
-            h.update(chunk)
-    return "sha256-" + base64.b64encode(h.digest()).decode()
+        return "sha256-" + _sha256_of_chunks(iter(lambda: f.read(65536), b""))
 
 
 def url_sha256(url: str) -> str:
     """Return SRI-format SHA-256 hash of a URL's raw content."""
-    h = hashlib.sha256()
     with urllib.request.urlopen(url) as response:
-        while chunk := response.read(65536):
-            h.update(chunk)
-    return "sha256-" + base64.b64encode(h.digest()).decode()
+        return "sha256-" + _sha256_of_chunks(iter(lambda: response.read(65536), b""))

--- a/devinfra/ci/bb_release.py
+++ b/devinfra/ci/bb_release.py
@@ -1,95 +1,64 @@
-#!/usr/bin/env -S uv run
-# /// script
-# requires-python = ">=3.12"
-# dependencies = ["pydantic", "PyGithub", "pygit2"]
-# ///
-# Run standalone: uv run --project . devinfra/ci/bb_release.py
-"""BB Release step: build dist, create GitHub releases for changed artifacts.
+"""BB Release step: create GitHub releases for changed artifacts.
 
+Assumes artifacts are already built by `bazel build` in the calling workflow.
 Expects: GH_RELEASE_PAT env var.
 """
 
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
 import pygit2
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
 from github import Auth, Github
+from more_itertools import one
 
 from devinfra.ci.artifacts import ARTIFACTS, SOURCES_PATH, Sources, file_sha256
 
 REPO = "agentydragon/ducktape"
 
 
-def run(*cmd: str, **kwargs) -> None:
-    subprocess.run(cmd, check=True, **kwargs)
-
-
-def install_deps() -> None:
-    # System deps for wheel builds only.
-    run("sudo", "apt-get", "update", "-qq")
-    run(
-        "sudo",
-        "apt-get",
-        "install",
-        "-y",
-        "libcairo2-dev",
-        "libgirepository-2.0-dev",
-        "libdbus-1-dev",
-        "libxcb1-dev",
-        "pkg-config",
-    )
-
-
 def copy_artifact_to_dist(src_glob: str, dest: str) -> Path:
     src_path = Path(src_glob)
-    matches = sorted(src_path.parent.glob(src_path.name))
-    if not matches:
-        raise FileNotFoundError(f"No files matching: {src_glob}")
+    match = one(src_path.parent.glob(src_path.name))
     dest_path = Path(dest)
     if dest_path.is_dir():
-        dest_path = dest_path / matches[0].name
-    shutil.copy2(matches[0], dest_path)
+        dest_path = dest_path / match.name
+    shutil.copy2(match, dest_path)
     return dest_path
 
 
 def main() -> None:
-    repo_obj = pygit2.Repository(".")
-    subject = repo_obj.head.peel(pygit2.Commit).message.splitlines()[0]
+    repo = pygit2.Repository(pygit2.discover_repository("."))
+    head = repo.head.peel(pygit2.Commit)
+    subject = head.message.split("\n")[0]
     if "[skip ci]" in subject:
         print("Commit message contains [skip ci], skipping release.")
         return
 
     gh_token = os.environ.get("GH_RELEASE_PAT")
     if not gh_token:
-        raise RuntimeError("Missing required env var: GH_RELEASE_PAT (configure as a BuildBuddy Workflow secret)")
+        print("ERROR: Missing required env var: GH_RELEASE_PAT", file=sys.stderr)
+        print("Configure this as a BuildBuddy Workflow secret.", file=sys.stderr)
+        sys.exit(1)
 
-    install_deps()
-
-    run("bazel", "build", "--config=rbe", "--remote_download_toplevel", *[a.bazel_target for a in ARTIFACTS])
+    short_sha = str(head.id)[:7]
 
     Path("dist").mkdir(exist_ok=True)
 
-    short_sha = str(repo_obj.head.target)[:7]
-
     sources = Sources.model_validate_json(SOURCES_PATH.read_text())
-    repo = Github(auth=Auth.Token(gh_token)).get_repo(REPO)
+    gh_repo = Github(auth=Auth.Token(gh_token)).get_repo(REPO)
 
     changed = []
     for artifact in ARTIFACTS:
         dist_path = copy_artifact_to_dist(artifact.src_glob, artifact.dest)
         pin = sources.pins.get(artifact.pkg)
-        if pin and file_sha256(dist_path) == pin.sha256:
+        if pin and file_sha256(dist_path) == pin.hash:
             print(f"{artifact.pkg}: unchanged, skipping")
             continue
         tag = f"{artifact.pkg}-{short_sha}"
         print(f"{artifact.pkg}: content changed, creating release {tag}")
-        release = repo.create_git_release(
+        release = gh_repo.create_git_release(
             tag=tag, name=f"{artifact.pkg} ({short_sha})", message=artifact.notes, make_latest="false"
         )
         release.upload_asset(str(dist_path))

--- a/devinfra/ci/bb_release.py
+++ b/devinfra/ci/bb_release.py
@@ -6,7 +6,6 @@ Expects: GH_RELEASE_PAT env var.
 
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import pygit2
@@ -29,7 +28,7 @@ def copy_artifact_to_dist(src_glob: str, dest: str) -> Path:
 
 
 def main() -> None:
-    repo = pygit2.Repository(pygit2.discover_repository("."))
+    repo = pygit2.Repository(".")
     head = repo.head.peel(pygit2.Commit)
     subject = head.message.split("\n")[0]
     if "[skip ci]" in subject:
@@ -38,9 +37,7 @@ def main() -> None:
 
     gh_token = os.environ.get("GH_RELEASE_PAT")
     if not gh_token:
-        print("ERROR: Missing required env var: GH_RELEASE_PAT", file=sys.stderr)
-        print("Configure this as a BuildBuddy Workflow secret.", file=sys.stderr)
-        sys.exit(1)
+        raise RuntimeError("Missing required env var: GH_RELEASE_PAT (configure as a BuildBuddy Workflow secret)")
 
     short_sha = str(head.id)[:7]
 

--- a/devinfra/ci/bb_release.py
+++ b/devinfra/ci/bb_release.py
@@ -50,7 +50,7 @@ def main() -> None:
     for artifact in ARTIFACTS:
         dist_path = copy_artifact_to_dist(artifact.src_glob, artifact.dest)
         pin = sources.pins.get(artifact.pkg)
-        if pin and file_sha256(dist_path) == pin.hash:
+        if pin and file_sha256(dist_path) == pin.sha256:
             print(f"{artifact.pkg}: unchanged, skipping")
             continue
         tag = f"{artifact.pkg}-{short_sha}"

--- a/devinfra/ci/sync_pins.py
+++ b/devinfra/ci/sync_pins.py
@@ -1,22 +1,13 @@
-#!/usr/bin/env -S uv run
-# /// script
-# requires-python = ">=3.12"
-# dependencies = ["pydantic", "PyGithub"]
-# ///
-# Run standalone: uv run --project . devinfra/ci/sync_pins.py
 """Sync npins/sources.json with the latest GitHub Release for each package.
 
 For each pinned package, finds the latest release tag, compares the URL
 against the current pin, and updates npins/sources.json if the pin is stale.
 
-Expects: GH_TOKEN env var.
+Expects: GH_TOKEN env var. For fetch=unpack artifacts, requires nix in PATH.
 """
 
 import os
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import subprocess
 
 from github import Auth, Github
 
@@ -24,6 +15,22 @@ from devinfra.ci.artifacts import ARTIFACTS, SOURCES_PATH, Sources, url_sha256
 
 REPO = "agentydragon/ducktape"
 BASE = f"https://github.com/{REPO}/releases/download"
+
+
+def nix_unpack_hash(url: str) -> str:
+    """Return the NAR hash for a tarball URL (for fetch=unpack pins in flake.nix)."""
+    raw = subprocess.run(
+        ["nix-prefetch-url", "--unpack", url], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return subprocess.run(
+        ["nix", "hash", "to-sri", f"sha256:{raw}"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def fetch_hash(url: str, fetch: str) -> str:
+    if fetch == "unpack":
+        return nix_unpack_hash(url)
+    return url_sha256(url)
 
 
 def main() -> None:
@@ -42,15 +49,16 @@ def main() -> None:
             continue
 
         url = f"{BASE}/{tag}/{artifact.filename}"
-        if url == sources.pins[artifact.pkg].url:
+        pin = sources.pins[artifact.pkg]
+        if url == pin.url:
             print(f"{artifact.pkg}: up to date ({tag})")
             continue
 
         print(f"{artifact.pkg}: updating to {tag}")
-        sha256 = url_sha256(url)
-        sources.pins[artifact.pkg].url = url
-        sources.pins[artifact.pkg].sha256 = sha256
-        print(f"{artifact.pkg}: {sha256}")
+        new_hash = fetch_hash(url, pin.fetch)
+        pin.url = url
+        pin.hash = new_hash
+        print(f"{artifact.pkg}: {new_hash}")
         updated.append(artifact.pkg)
 
     if not updated:

--- a/devinfra/ci/sync_pins.py
+++ b/devinfra/ci/sync_pins.py
@@ -40,7 +40,7 @@ def main() -> None:
         print(f"{artifact.pkg}: updating to {tag}")
         new_hash = url_sha256(url)
         pin.url = url
-        pin.hash = new_hash
+        pin.sha256 = new_hash
         print(f"{artifact.pkg}: {new_hash}")
         updated.append(artifact.pkg)
 

--- a/devinfra/ci/sync_pins.py
+++ b/devinfra/ci/sync_pins.py
@@ -3,11 +3,10 @@
 For each pinned package, finds the latest release tag, compares the URL
 against the current pin, and updates npins/sources.json if the pin is stale.
 
-Expects: GH_TOKEN env var. For fetch=unpack artifacts, requires nix in PATH.
+Expects: GH_TOKEN env var.
 """
 
 import os
-import subprocess
 
 from github import Auth, Github
 
@@ -15,22 +14,6 @@ from devinfra.ci.artifacts import ARTIFACTS, SOURCES_PATH, Sources, url_sha256
 
 REPO = "agentydragon/ducktape"
 BASE = f"https://github.com/{REPO}/releases/download"
-
-
-def nix_unpack_hash(url: str) -> str:
-    """Return the NAR hash for a tarball URL (for fetch=unpack pins in flake.nix)."""
-    raw = subprocess.run(
-        ["nix-prefetch-url", "--unpack", url], capture_output=True, text=True, check=True
-    ).stdout.strip()
-    return subprocess.run(
-        ["nix", "hash", "to-sri", f"sha256:{raw}"], capture_output=True, text=True, check=True
-    ).stdout.strip()
-
-
-def fetch_hash(url: str, fetch: str) -> str:
-    if fetch == "unpack":
-        return nix_unpack_hash(url)
-    return url_sha256(url)
 
 
 def main() -> None:
@@ -55,7 +38,7 @@ def main() -> None:
             continue
 
         print(f"{artifact.pkg}: updating to {tag}")
-        new_hash = fetch_hash(url, pin.fetch)
+        new_hash = url_sha256(url)
         pin.url = url
         pin.hash = new_hash
         print(f"{artifact.pkg}: {new_hash}")

--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -76,6 +76,7 @@ py_library(
     deps = [
         ":function_learning",
         "@pypi//aiodocker",
+        "@pypi//anyio",
         "@pypi//fastmcp",
     ],
 )

--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -59,6 +59,7 @@ py_library(
         "@pypi//autogen_core",
         "@pypi//autogen_ext",
         "@pypi//fastmcp",
+        "@pypi//pydantic",
     ],
 )
 
@@ -78,6 +79,7 @@ py_library(
         "@pypi//aiodocker",
         "@pypi//anyio",
         "@pypi//fastmcp",
+        "@pypi//pydantic",
     ],
 )
 
@@ -86,6 +88,24 @@ py_binary(
     imports = ["../../../.."],
     main_module = "skills.info_gathering.evals.function_learning.run_all_evals",
     deps = [":run_all_evals_lib"],
+)
+
+py_library(
+    name = "analyze_lib",
+    srcs = ["analyze.py"],
+    imports = ["../../../.."],
+    deps = [
+        ":functions",
+        ":run_all_evals_lib",
+        "@pypi//numpy",
+    ],
+)
+
+py_binary(
+    name = "analyze",
+    imports = ["../../../.."],
+    main_module = "skills.info_gathering.evals.function_learning.analyze",
+    deps = [":analyze_lib"],
 )
 
 py_test(

--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -69,6 +69,24 @@ py_binary(
     deps = [":function_learning"],
 )
 
+py_library(
+    name = "run_all_evals_lib",
+    srcs = ["run_all_evals.py"],
+    imports = ["../../../.."],
+    deps = [
+        ":function_learning",
+        "@pypi//aiodocker",
+        "@pypi//fastmcp",
+    ],
+)
+
+py_binary(
+    name = "run_all_evals",
+    imports = ["../../../.."],
+    main_module = "skills.info_gathering.evals.function_learning.run_all_evals",
+    deps = [":run_all_evals_lib"],
+)
+
 py_test(
     name = "test_functions",
     srcs = ["test_functions.py"],

--- a/skills/info_gathering/evals/function_learning/analyze.py
+++ b/skills/info_gathering/evals/function_learning/analyze.py
@@ -32,6 +32,12 @@ def load_records(path: Path) -> list[RunRecord]:
 
 
 def print_stats(records: list[RunRecord]) -> None:
+    models = sorted({r.model for r in records})
+    if len(models) > 1:
+        print(f"Models: {', '.join(models)}\n")
+    else:
+        print(f"Model: {models[0]}\n")
+
     cells: dict[tuple[str, str], list[RunRecord]] = defaultdict(list)
     for r in records:
         cells[(r.function, r.arm)].append(r)
@@ -78,13 +84,28 @@ def _print_cost(records: list[RunRecord]) -> None:
     out = sum(r.output_tokens for r in records)
     cr = sum(r.cache_read_tokens for r in records)
     cw = sum(r.cache_creation_tokens for r in records)
+    print(f"  tokens: inp={inp:,} out={out:,} cache_write={cw:,} cache_read={cr:,}\n")
 
-    print(f"{'Model':<30} {'Cost':>8}")
-    print("-" * 40)
+    # Actual cost per model used in this run (grouped by model)
+    by_model: dict[str, list[RunRecord]] = defaultdict(list)
+    for r in records:
+        by_model[r.model].append(r)
+
+    print(f"{'Model':<30} {'Actual':>8}  (projected)")
+    print("-" * 55)
     for model, (ir, or_, cwr, crr) in _PRICING.items():
-        cost = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
-        print(f"{model:<30} ${cost:>7.3f}")
-    print(f"\n  tokens: inp={inp:,} out={out:,} cache_write={cw:,} cache_read={cr:,}")
+        actual_records = by_model.get(model, [])
+        if actual_records:
+            ai = sum(r.input_tokens for r in actual_records)
+            ao = sum(r.output_tokens for r in actual_records)
+            acr = sum(r.cache_read_tokens for r in actual_records)
+            acw = sum(r.cache_creation_tokens for r in actual_records)
+            actual = ai / 1e6 * ir + ao / 1e6 * or_ + acw / 1e6 * cwr + acr / 1e6 * crr
+            projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
+            print(f"{model:<30} ${actual:>7.3f}  (${projected:.3f})")
+        else:
+            projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
+            print(f"{model:<30} {'—':>8}  (${projected:.3f})")
 
 
 def write_report(records: list[RunRecord], path: Path) -> None:

--- a/skills/info_gathering/evals/function_learning/analyze.py
+++ b/skills/info_gathering/evals/function_learning/analyze.py
@@ -1,0 +1,172 @@
+"""Analyze function learning eval results from a runs.jsonl file.
+
+Reads RunRecord lines, computes per-cell statistics with numpy, prints a
+summary table, and optionally writes a report.md.
+
+Usage:
+    bazel run //skills/info_gathering/evals/function_learning:analyze -- \\
+        --runs path/to/runs.jsonl [--report path/to/report.md]
+"""
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
+from skills.info_gathering.evals.function_learning.run_all_evals import RunRecord
+
+FUNCTIONS_LIST = list(FUNCTIONS.keys())
+
+# Pricing per million tokens: (input, output, cache_write, cache_read)
+_PRICING: dict[str, tuple[float, float, float, float]] = {
+    "claude-haiku-4-5-20251001": (0.80, 4.00, 1.00, 0.08),
+    "claude-sonnet-4-6": (3.00, 15.00, 3.75, 0.30),
+    "claude-opus-4-6": (15.00, 75.00, 18.75, 1.50),
+}
+
+
+def load_records(path: Path) -> list[RunRecord]:
+    return [RunRecord.model_validate_json(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def print_stats(records: list[RunRecord]) -> None:
+    cells: dict[tuple[str, str], list[RunRecord]] = defaultdict(list)
+    for r in records:
+        cells[(r.function, r.arm)].append(r)
+
+    header = f"{'Function':<20} {'Arm':<10} {'Mean':>6} {'Std':>5} {'Min':>4} {'Max':>4} {'Solved':>7} {'Turns':>6}"
+    print(header)
+    print("-" * len(header))
+
+    for fn in FUNCTIONS_LIST:
+        for arm in ["skill", "no_skill"]:
+            runs = cells.get((fn, arm), [])
+            if not runs:
+                continue
+            losses = np.array([r.total_hamming_loss for r in runs])
+            turns = np.array([r.turns for r in runs])
+            solved = sum(1 for r in runs if r.solved_at_turn is not None)
+            print(
+                f"{fn:<20} {arm:<10} {losses.mean():>6.1f} {losses.std():>5.1f}"
+                f" {losses.min():>4} {losses.max():>4} {solved:>3}/{len(runs):<3} {turns.mean():>6.1f}"
+            )
+
+    print()
+    _print_skill_vs_noskill(cells)
+    print()
+    _print_cost(records)
+
+
+def _print_skill_vs_noskill(cells: dict[tuple[str, str], list[RunRecord]]) -> None:
+    print(f"{'Function':<20} {'Skill loss':>10} {'No-skill loss':>13} {'Winner':<10}")
+    print("-" * 58)
+    for fn in FUNCTIONS_LIST:
+        skill_runs = cells.get((fn, "skill"), [])
+        noskill_runs = cells.get((fn, "no_skill"), [])
+        if not skill_runs or not noskill_runs:
+            continue
+        skill_mean = np.mean([r.total_hamming_loss for r in skill_runs])
+        noskill_mean = np.mean([r.total_hamming_loss for r in noskill_runs])
+        winner = "skill" if skill_mean < noskill_mean else "no_skill" if noskill_mean < skill_mean else "tie"
+        print(f"{fn:<20} {skill_mean:>10.1f} {noskill_mean:>13.1f} {winner:<10}")
+
+
+def _print_cost(records: list[RunRecord]) -> None:
+    inp = sum(r.input_tokens for r in records)
+    out = sum(r.output_tokens for r in records)
+    cr = sum(r.cache_read_tokens for r in records)
+    cw = sum(r.cache_creation_tokens for r in records)
+
+    print(f"{'Model':<30} {'Cost':>8}")
+    print("-" * 40)
+    for model, (ir, or_, cwr, crr) in _PRICING.items():
+        cost = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
+        print(f"{model:<30} ${cost:>7.3f}")
+    print(f"\n  tokens: inp={inp:,} out={out:,} cache_write={cw:,} cache_read={cr:,}")
+
+
+def write_report(records: list[RunRecord], path: Path) -> None:
+    cells: dict[tuple[str, str], list[RunRecord]] = defaultdict(list)
+    for r in records:
+        cells[(r.function, r.arm)].append(r)
+
+    lines: list[str] = [
+        "# Function Learning Benchmark Results",
+        "",
+        f"**Runs:** {len(records)}  ",
+        "",
+        "## Results by Cell",
+        "",
+        "| Function | Arm | Mean Loss | Std | Min | Max | Solved | Mean Turns |",
+        "|----------|-----|----------:|----:|----:|----:|-------:|-----------:|",
+    ]
+    for fn in FUNCTIONS_LIST:
+        for arm in ["skill", "no_skill"]:
+            runs = cells.get((fn, arm), [])
+            if not runs:
+                continue
+            losses = np.array([r.total_hamming_loss for r in runs])
+            turns = np.array([r.turns for r in runs])
+            solved = sum(1 for r in runs if r.solved_at_turn is not None)
+            lines.append(
+                f"| {fn} | {arm} | {losses.mean():.1f} | {losses.std():.1f}"
+                f" | {losses.min()} | {losses.max()} | {solved}/{len(runs)} | {turns.mean():.1f} |"
+            )
+
+    lines += [
+        "",
+        "## Skill vs No-Skill",
+        "",
+        "| Function | Skill | No-Skill | Winner |",
+        "|----------|------:|---------:|--------|",
+    ]
+    for fn in FUNCTIONS_LIST:
+        skill = cells.get((fn, "skill"), [])
+        noskill = cells.get((fn, "no_skill"), [])
+        if not skill or not noskill:
+            continue
+        sm = np.mean([r.total_hamming_loss for r in skill])
+        nm = np.mean([r.total_hamming_loss for r in noskill])
+        winner = "skill" if sm < nm else "no_skill" if nm < sm else "tie"
+        lines.append(f"| {fn} | {sm:.1f} | {nm:.1f} | {winner} |")
+
+    lines += ["", "## Token Usage & Cost", ""]
+    inp = sum(r.input_tokens for r in records)
+    out = sum(r.output_tokens for r in records)
+    cr = sum(r.cache_read_tokens for r in records)
+    cw = sum(r.cache_creation_tokens for r in records)
+    lines += [
+        f"Input tokens: {inp:,}  ",
+        f"Output tokens: {out:,}  ",
+        f"Cache write tokens: {cw:,}  ",
+        f"Cache read tokens: {cr:,}  ",
+        "",
+        "| Model | Cost |",
+        "|-------|-----:|",
+    ]
+    for model, (ir, or_, cwr, crr) in _PRICING.items():
+        cost = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
+        lines.append(f"| `{model}` | ${cost:.3f} |")
+
+    path.write_text("\n".join(lines) + "\n")
+    print(f"Report written to {path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze function learning eval results")
+    parser.add_argument("--runs", type=Path, required=True, metavar="runs.jsonl")
+    parser.add_argument("--report", type=Path, default=None, metavar="report.md")
+    args = parser.parse_args()
+
+    records = load_records(args.runs)
+    print(f"Loaded {len(records)} run records from {args.runs}\n")
+    print_stats(records)
+
+    if args.report:
+        write_report(records, args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/info_gathering/evals/function_learning/debug/prompt_caching.md
+++ b/skills/info_gathering/evals/function_learning/debug/prompt_caching.md
@@ -10,63 +10,96 @@ caching the conversation prefix. But `cache_read_input_tokens` was always 0.
 
 ### 1. Prompt caching requires explicit `cache_control` markers
 
-Caching does **not** happen automatically. The Anthropic API requires explicit
-`cache_control: {"type": "ephemeral"}` on content blocks or as a top-level
-parameter. Without it, `cache_creation_input_tokens` and `cache_read_input_tokens`
-are always 0.
+Caching does **not** happen automatically. Unlike OpenAI (which caches long prompts
+automatically), the Anthropic API requires explicit `cache_control: {"type": "ephemeral"}`
+to activate caching. Without it, `cache_creation_input_tokens` and `cache_read_input_tokens`
+are always 0, regardless of prompt size.
 
-### 2. autogen doesn't pass `cache_control` to the Anthropic API
+Confirmed via live API test (2026-03-28) with a 21,878-token system prompt on
+`claude-haiku-4-5-20251001`:
 
-`AnthropicChatCompletionClient` builds `request_args` by cherry-picking specific
-params (`top_p`, `top_k`, `stop_sequences`, `metadata`). `cache_control` is not in
-the list and gets silently dropped. Even passing it via `extra_create_args` doesn't
-work because it's not in the forwarding whitelist.
+| Approach                          | `input` | `cache_create` | `cache_read` |
+| --------------------------------- | ------- | -------------- | ------------ |
+| No `cache_control`, call 1        | 21,878  | 0              | 0            |
+| No `cache_control`, call 2        | 21,878  | 0              | 0            |
+| Top-level `cache_control`, call 1 | 3       | 21,875         | 0            |
+| Top-level `cache_control`, call 2 | 3       | 0              | **21,875**   |
+| Per-block `cache_control`, call 1 | 7       | 21,871         | 0            |
+| Per-block `cache_control`, call 2 | 7       | **21,871**     | **0**        |
 
-**Fix:** Monkey-patch `raw_client.messages.create` to inject `cache_control` on the
-system message and the last conversation message.
+### 2. Per-block `cache_control` never produces cache reads (creates new entry every call)
 
-### 3. Haiku 4.5's minimum cacheable prefix is ~4096 tokens, not 1024
+The original implementation injected `cache_control` on the system message block and the
+last conversation message block individually. This causes the Anthropic API to compute a
+new cache key on every call (because the last-message block changes every turn), writing a
+new cache entry rather than reading the existing one.
 
-The docs say "model-dependent (typically 1024-2048 tokens)." Empirically tested
-with `curl` against the raw API using a personal Anthropic API key:
+**Fix:** Use a single top-level `cache_control={"type": "ephemeral"}` parameter. This
+activates Anthropic's automatic cache breakpoint management: the API places the cache
+breakpoint at the last cacheable block and moves it forward as the conversation grows.
+Each call correctly reads the prefix cached by the previous call.
 
-| System prompt tokens | `cache_creation_input_tokens` |
-| -------------------- | ----------------------------- |
-| 609                  | 0                             |
-| 1209                 | 0                             |
-| 3009                 | 0                             |
-| 3909                 | 0                             |
-| 4209                 | **4202** (caching activated)  |
+### 3. autogen doesn't pass `cache_control` to the Anthropic API
 
-Haiku 4.5 (`claude-haiku-4-5-20251001`) requires ~4096 tokens before caching
-activates. Prefixes shorter than this silently don't cache (no error, just 0 in
-the usage fields).
+`AnthropicChatCompletionClient` builds `request_args` by cherry-picking specific params
+(`top_p`, `top_k`, `stop_sequences`, `metadata`). `cache_control` is not in the list and
+gets silently dropped, even via `extra_create_args`.
 
-This means our ~1500 token system prompt alone won't cache. But the conversation
-prefix (system + tools + prior turns) exceeds 4096 tokens by turn ~5, so caching
-the last message block caches the growing prefix for subsequent turns.
+**Fix:** Monkey-patch `raw_client.messages.create` to inject `cache_control` on every call.
+This is implemented in `CachedAnthropicClient` in `../prompt_caching.py`.
 
-### 4. Cache hits confirmed with large enough prefix
+### 4. autogen's `RequestUsage` doesn't expose cache token fields
 
+`autogen_core.models.RequestUsage` is a plain dataclass with only `prompt_tokens` and
+`completion_tokens`. autogen's Anthropic client extracts `result.usage.input_tokens` and
+`result.usage.output_tokens` from the raw Anthropic response and discards
+`cache_creation_input_tokens` and `cache_read_input_tokens`.
+
+**Fix:** The `cached_create` wrapper captures cache tokens from the raw `Message.usage`
+response and `CachedAnthropicClient.create()` attaches them as dynamic attributes on the
+returned `RequestUsage` object:
+
+```python
+result.usage.cache_read_tokens = self._last_cache_read
+result.usage.cache_creation_tokens = self._last_cache_creation
 ```
-Call 1: input=9, cache_read=0, cache_create=24002   (wrote to cache)
-Call 2: input=9, cache_read=24002, cache_create=0    (cache HIT)
-```
+
+`function_learning.py` then reads them via `getattr(result.usage, "cache_read_tokens", 0)`.
+
+### 5. Minimum cacheable prefix is ~4096 tokens for Haiku 4.5
+
+Anthropic's documentation says "model-dependent (typically 1024-4096 tokens)." Empirically:
+
+| Model               | Min tokens |
+| ------------------- | ---------- |
+| Claude Opus 4.5/4.6 | 4096       |
+| Claude Sonnet 4.6   | 2048       |
+| Claude Haiku 4.5    | 4096       |
+| Claude Haiku 3.5    | 2048       |
+
+Shorter prompts are processed normally without caching (no error, just 0 in usage fields).
+The ~1500 token system prompt alone won't cache, but the growing conversation prefix
+(system + tools + prior turns) exceeds 4096 tokens by turn ~5 and caches from there.
+
+## Why skill-arm input_tokens was low in the 2026-03-28 run
+
+The per-block injection was creating new cache entries every turn (issue #2 above), which
+means caching WAS activating but always writing, never reading. The Anthropic API reports
+only non-cached tokens in `input_tokens` — so the ~250 input_tokens across 50 turns in the
+skill arm reflected that most of the prefix was being written to cache each turn (but
+wastefully, since it was never re-read). The cache write tokens weren't captured due to
+issue #4.
 
 ## Implementation
 
-`_enable_prompt_caching()` in `function_learning.py` monkey-patches the Anthropic
-client to:
+`CachedAnthropicClient` in `../prompt_caching.py`:
 
-1. Convert system message from string to content block with `cache_control`
-2. Place `cache_control` on the last message in the conversation
+1. Wraps `raw_client.messages.create` to inject `cache_control={"type":"ephemeral"}` as a
+   top-level parameter and capture cache token counts from the raw response
+2. Overrides `create()` to attach the captured counts to `RequestUsage` as dynamic attrs
 
-This ensures the conversation prefix is cached once it exceeds the minimum threshold.
+## Cost Impact (estimated, 30-turn run on Haiku 4.5)
 
-## Cost Impact (estimated)
-
-For a 30-turn run on Haiku 4.5:
-
-- **Without caching:** ~600K input tokens @ $1/1M = $0.60/run
-- **With caching (turns 5-30):** ~150K uncached + ~450K cached @ $0.10/1M = $0.20/run
+- **Without caching:** ~600K input tokens @ $0.80/1M = $0.48/run
+- **With caching (turns 5-30):** ~150K non-cached + ~450K cache-read @ $0.08/1M = ~$0.16/run
 - **Savings:** ~67%

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -53,6 +53,7 @@ _MAX_STEPS = 200
 class GameContext:
     turn_limit: int
     turn: int = 0
+    solved: bool = False
     turn_results: list[TurnResult] = field(default_factory=list)
     log_entries: list[dict[str, object]] = field(default_factory=list)
     total_input_tokens: int = 0
@@ -62,7 +63,7 @@ class GameContext:
 
     @property
     def finished(self) -> bool:
-        return self.turn >= self.turn_limit
+        return self.turn >= self.turn_limit or self.solved
 
     def record(self, player: Literal["agent", "scaffold"], content: str) -> None:
         self.log_entries.append({"timestamp": datetime.now(UTC).isoformat(), "player": player, "content": content})
@@ -91,6 +92,9 @@ def _make_play_turn_tool(
         scoring = await evaluate_program(scoring_container, program, secret_fn)
         score = scoring.score
 
+        if score.hamming_loss == 0:
+            game.solved = True
+
         game.turn_results.append(TurnResult(turn=game.turn, query=query, query_result=query_result, score=score))
         game.record(
             "scaffold", f"Turn {game.turn}: hamming_loss={score.hamming_loss} (eval {scoring.total_eval_s:.1f}s)"
@@ -104,6 +108,8 @@ def _make_play_turn_tool(
             "hamming_loss": score.hamming_loss,
             "total_possible_loss": (secret_fn.max_input + 1) * secret_fn.m,
         }
+        if game.solved:
+            response["game_over"] = "Solved! Your program is correct for all inputs."
         if score.has_errors:
             response["error_summary"] = {
                 "parse_errors": score.parse_errors,
@@ -223,10 +229,14 @@ async def run_game(
             exec_results.append(FunctionExecutionResult(call_id=fc.id, content=content, name=fc.name))
         history.append(FunctionExecutionResultMessage(content=exec_results))
 
-    # Build result.
+    # Build result. Pad with zeros for turns saved by early termination so
+    # per_turn_losses always has length == turn_limit.
     per_turn = [tr.score.hamming_loss for tr in game.turn_results]
+    per_turn += [0] * (effective_turn_limit - len(per_turn))
     total_hamming = sum(per_turn)
-    fl_result = FunctionLearningResult(total_hamming_loss=total_hamming, per_turn_losses=per_turn)
+    fl_result = FunctionLearningResult(
+        total_hamming_loss=total_hamming, per_turn_losses=per_turn, solved_at_turn=game.turn if game.solved else None
+    )
 
     calls_path, summary_path = run_output_paths(f"fl_{variant_name}", output_dir)
     with calls_path.open("w") as f:

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -154,6 +154,7 @@ def _build_model_client(*, api: str, model: str) -> ChatCompletionClient:
 async def run_game(
     *,
     variant_name: str,
+    turn_limit: int,
     model: str,
     api: str,
     output_dir: Path,
@@ -161,23 +162,19 @@ async def run_game(
     scoring_container: aiodocker.docker.DockerContainer,
     model_client: ChatCompletionClient | None = None,
     no_skill: bool = False,
-    turn_limit: int | None = None,
 ) -> RunSummary:
     """Execute one function learning game and persist results."""
     variant = VARIANTS[variant_name]
     secret_fn = variant.function
-    effective_turn_limit = turn_limit if turn_limit is not None else variant.turn_limit
 
     system = build_system_prompt(skill="" if no_skill else load_skill_prompt(), has_scratch=exec_tool is not None)
-    opening = first_user_message(
-        secret_fn, effective_turn_limit, variant.function_description, eval_timeout_s=EVAL_TIMEOUT_S
-    )
+    opening = first_user_message(secret_fn, turn_limit, variant.function_description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     owns_client = model_client is None
     if model_client is None:
         model_client = _build_model_client(api=api, model=model)
 
-    game = GameContext(turn_limit=effective_turn_limit)
+    game = GameContext(turn_limit=turn_limit)
 
     # Tools: play_turn (game) + optional exec (scratch).
     play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
@@ -232,7 +229,7 @@ async def run_game(
     # Build result. Pad with zeros for turns saved by early termination so
     # per_turn_losses always has length == turn_limit.
     per_turn = [tr.score.hamming_loss for tr in game.turn_results]
-    per_turn += [0] * (effective_turn_limit - len(per_turn))
+    per_turn += [0] * (turn_limit - len(per_turn))
     total_hamming = sum(per_turn)
     fl_result = FunctionLearningResult(
         total_hamming_loss=total_hamming, per_turn_losses=per_turn, solved_at_turn=game.turn if game.solved else None
@@ -307,7 +304,7 @@ def main() -> None:
     parser.add_argument("--api", choices=["openai", "anthropic"], default="anthropic")
     parser.add_argument("--output-dir", default=None)
     parser.add_argument("--no-skill", action="store_true")
-    parser.add_argument("--turn-limit", type=int, default=None, help="Override variant turn limit")
+    parser.add_argument("--turn-limit", type=int, required=True)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -13,7 +13,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
+from typing import IO, Literal
 
 import aiodocker
 from autogen_core import CancellationToken
@@ -29,6 +29,7 @@ from autogen_core.tools import FunctionTool
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from fastmcp.client import Client
 from mcp.types import TextContent
+from pydantic import BaseModel
 
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS, SecretFunction
@@ -49,13 +50,64 @@ logger = logging.getLogger(__name__)
 _MAX_STEPS = 200
 
 
+# --- Structured log entry types (written to calls.jsonl) ---
+
+
+class GameStartLog(BaseModel):
+    kind: Literal["game_start"] = "game_start"
+    timestamp: str
+    function_name: str
+    n_bits: int
+    m_bits: int
+    no_skill: bool
+    system_prompt: str
+    opening_message: str
+
+
+class FunctionCallLog(BaseModel):
+    id: str
+    name: str
+    arguments: str  # raw JSON string as returned by the model
+
+
+class LlmResponseLog(BaseModel):
+    kind: Literal["llm_response"] = "llm_response"
+    timestamp: str
+    text: str | None
+    tool_calls: list[FunctionCallLog] | None
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+
+
+class ToolResultLog(BaseModel):
+    kind: Literal["tool_result"] = "tool_result"
+    timestamp: str
+    tool_name: str
+    call_id: str
+    arguments: dict
+    result: str
+
+
+class GameEndLog(BaseModel):
+    kind: Literal["game_end"] = "game_end"
+    timestamp: str
+    turns: int
+    solved_at_turn: int | None
+    total_hamming_loss: int
+
+
+# --- Game state ---
+
+
 @dataclass
 class GameContext:
     turn_limit: int
+    _log_file: IO[str] | None = field(default=None, init=False)
     turn: int = 0
     solved: bool = False
     turn_results: list[TurnResult] = field(default_factory=list)
-    log_entries: list[dict[str, object]] = field(default_factory=list)
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cache_read_tokens: int = 0
@@ -65,8 +117,17 @@ class GameContext:
     def finished(self) -> bool:
         return self.turn >= self.turn_limit or self.solved
 
-    def record(self, player: Literal["agent", "scaffold"], content: str) -> None:
-        self.log_entries.append({"timestamp": datetime.now(UTC).isoformat(), "player": player, "content": content})
+    def attach_log(self, f: IO[str]) -> None:
+        self._log_file = f
+
+    def log(self, entry: BaseModel) -> None:
+        if self._log_file is not None:
+            self._log_file.write(entry.model_dump_json() + "\n")
+            self._log_file.flush()
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
 
 
 def _make_play_turn_tool(
@@ -84,8 +145,6 @@ def _make_play_turn_tool(
             return json.dumps({"error": f"query must be in [0, {secret_fn.max_input}], got {query}"})
 
         game.turn += 1
-        game.record("agent", f"Turn {game.turn}: query={query}")
-
         query_result = secret_fn.evaluate(query)
         logger.info("Turn %d: query=%d -> %d", game.turn, query, query_result)
 
@@ -96,9 +155,6 @@ def _make_play_turn_tool(
             game.solved = True
 
         game.turn_results.append(TurnResult(turn=game.turn, query=query, query_result=query_result, score=score))
-        game.record(
-            "scaffold", f"Turn {game.turn}: hamming_loss={score.hamming_loss} (eval {scoring.total_eval_s:.1f}s)"
-        )
         logger.info("Turn %d: hamming_loss=%d (eval %.1fs)", game.turn, score.hamming_loss, scoring.total_eval_s)
 
         response: dict[str, object] = {
@@ -185,63 +241,107 @@ async def run_game(
     tool_schemas = [t.schema for t in all_tools]
     tool_map = {t.name: t for t in all_tools}
 
-    history: list[SystemMessage | UserMessage | AssistantMessage | FunctionExecutionResultMessage] = [
-        SystemMessage(content=system),
-        UserMessage(content=opening, source="user"),
-    ]
+    calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
 
-    for _ in range(_MAX_STEPS):
-        if game.finished:
-            break
+    with calls_path.open("w") as log_f:
+        game.attach_log(log_f)
+        game.log(
+            GameStartLog(
+                timestamp=_now(),
+                function_name=function_name,
+                n_bits=secret_fn.n,
+                m_bits=secret_fn.m,
+                no_skill=no_skill,
+                system_prompt=system,
+                opening_message=opening,
+            )
+        )
 
-        result = await model_client.create(history, tools=tool_schemas, tool_choice="required")
+        history: list[SystemMessage | UserMessage | AssistantMessage | FunctionExecutionResultMessage] = [
+            SystemMessage(content=system),
+            UserMessage(content=opening, source="user"),
+        ]
 
-        # Track token usage (including cache metrics when available).
-        game.total_input_tokens += result.usage.prompt_tokens
-        game.total_output_tokens += result.usage.completion_tokens
-        game.total_cache_read_tokens += getattr(result.usage, "cache_read_tokens", 0)
-        game.total_cache_creation_tokens += getattr(result.usage, "cache_creation_tokens", 0)
+        for _ in range(_MAX_STEPS):
+            if game.finished:
+                break
 
-        if isinstance(result.content, str):
-            history.append(AssistantMessage(content=result.content, source="agent"))
-            continue
+            result = await model_client.create(history, tools=tool_schemas, tool_choice="required")
 
-        function_calls = result.content
-        history.append(AssistantMessage(content=function_calls, source="agent"))
+            cache_read = getattr(result.usage, "cache_read_tokens", 0)
+            cache_creation = getattr(result.usage, "cache_creation_tokens", 0)
+            game.total_input_tokens += result.usage.prompt_tokens
+            game.total_output_tokens += result.usage.completion_tokens
+            game.total_cache_read_tokens += cache_read
+            game.total_cache_creation_tokens += cache_creation
 
-        exec_results: list[FunctionExecutionResult] = []
-        for fc in function_calls:
-            tool = tool_map.get(fc.name)
-            if tool is None:
-                content = f"Error: unknown tool '{fc.name}'"
-                logger.warning("Unknown tool name: %s", fc.name)
-                exec_results.append(FunctionExecutionResult(call_id=fc.id, content=content, name=fc.name))
+            if isinstance(result.content, str):
+                game.log(
+                    LlmResponseLog(
+                        timestamp=_now(),
+                        text=result.content,
+                        tool_calls=None,
+                        input_tokens=result.usage.prompt_tokens,
+                        output_tokens=result.usage.completion_tokens,
+                        cache_read_tokens=cache_read,
+                        cache_creation_tokens=cache_creation,
+                    )
+                )
+                history.append(AssistantMessage(content=result.content, source="agent"))
                 continue
-            args = json.loads(fc.arguments) if isinstance(fc.arguments, str) else fc.arguments
-            try:
-                tool_result = await tool.run_json(args, CancellationToken())
-                content = tool.return_value_as_string(tool_result)
-            except Exception as e:
-                content = f"Error: {e}"
-                logger.warning("Tool %s error: %s", fc.name, e)
-            exec_results.append(FunctionExecutionResult(call_id=fc.id, content=content, name=fc.name))
-        history.append(FunctionExecutionResultMessage(content=exec_results))
 
-    # Build result. Pad with zeros for turns saved by early termination so
-    # per_turn_losses always has length == turn_limit.
-    per_turn = [tr.score.hamming_loss for tr in game.turn_results]
-    per_turn += [0] * (turn_limit - len(per_turn))
-    total_hamming = sum(per_turn)
+            function_calls = result.content
+            game.log(
+                LlmResponseLog(
+                    timestamp=_now(),
+                    text=None,
+                    tool_calls=[
+                        FunctionCallLog(id=fc.id, name=fc.name, arguments=fc.arguments) for fc in function_calls
+                    ],
+                    input_tokens=result.usage.prompt_tokens,
+                    output_tokens=result.usage.completion_tokens,
+                    cache_read_tokens=cache_read,
+                    cache_creation_tokens=cache_creation,
+                )
+            )
+            history.append(AssistantMessage(content=function_calls, source="agent"))
+
+            exec_results: list[FunctionExecutionResult] = []
+            for fc in function_calls:
+                tool = tool_map.get(fc.name)
+                args = json.loads(fc.arguments) if isinstance(fc.arguments, str) else fc.arguments
+                if tool is None:
+                    content = f"Error: unknown tool '{fc.name}'"
+                    logger.warning("Unknown tool name: %s", fc.name)
+                else:
+                    try:
+                        tool_result = await tool.run_json(args, CancellationToken())
+                        content = tool.return_value_as_string(tool_result)
+                    except Exception as e:
+                        content = f"Error: {e}"
+                        logger.warning("Tool %s error: %s", fc.name, e)
+                game.log(
+                    ToolResultLog(timestamp=_now(), tool_name=fc.name, call_id=fc.id, arguments=args, result=content)
+                )
+                exec_results.append(FunctionExecutionResult(call_id=fc.id, content=content, name=fc.name))
+            history.append(FunctionExecutionResultMessage(content=exec_results))
+
+        per_turn = [tr.score.hamming_loss for tr in game.turn_results]
+        per_turn += [0] * (turn_limit - len(per_turn))
+        total_hamming = sum(per_turn)
+
+        game.log(
+            GameEndLog(
+                timestamp=_now(),
+                turns=game.turn,
+                solved_at_turn=game.turn if game.solved else None,
+                total_hamming_loss=total_hamming,
+            )
+        )
+
     fl_result = FunctionLearningResult(
         total_hamming_loss=total_hamming, per_turn_losses=per_turn, solved_at_turn=game.turn if game.solved else None
     )
-
-    calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
-    with calls_path.open("w") as f:
-        for entry in game.log_entries:
-            f.write(json.dumps(entry) + "\n")
-        for tr in game.turn_results:
-            f.write(tr.model_dump_json() + "\n")
 
     summary = RunSummary(
         eval_name=function_name,
@@ -275,7 +375,6 @@ async def _async_main(args: argparse.Namespace) -> None:
     async with scratch_exec_server() as scratch_server, Client(scratch_server) as scratch_client:
         exec_tool = _make_exec_tool(scratch_client)
 
-        # Scoring container: plain aiodocker, no MCP.
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:
             container = await docker.containers.run(

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -31,7 +31,7 @@ from fastmcp.client import Client
 from mcp.types import TextContent
 
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
-from skills.info_gathering.evals.function_learning.functions import VARIANTS, SecretFunction
+from skills.info_gathering.evals.function_learning.functions import FUNCTIONS, SecretFunction
 from skills.info_gathering.evals.function_learning.prompts import build_system_prompt, first_user_message
 from skills.info_gathering.evals.function_learning.result_types import (
     FunctionLearningResult,
@@ -151,24 +151,28 @@ def _build_model_client(*, api: str, model: str) -> ChatCompletionClient:
     raise ValueError(f"Unsupported API: {api!r}")
 
 
+_NO_HINT = "The function class is unknown. You must discover its structure from queries alone."
+
+
 async def run_game(
     *,
-    variant_name: str,
+    function_name: str,
+    hint: bool,
     turn_limit: int,
     model: str,
     api: str,
     output_dir: Path,
-    exec_tool: FunctionTool | None = None,
+    exec_tool: FunctionTool,
     scoring_container: aiodocker.docker.DockerContainer,
     model_client: ChatCompletionClient | None = None,
     no_skill: bool = False,
 ) -> RunSummary:
     """Execute one function learning game and persist results."""
-    variant = VARIANTS[variant_name]
-    secret_fn = variant.function
+    secret_fn = FUNCTIONS[function_name]
+    description = secret_fn.description if hint else _NO_HINT
 
-    system = build_system_prompt(skill="" if no_skill else load_skill_prompt(), has_scratch=exec_tool is not None)
-    opening = first_user_message(secret_fn, turn_limit, variant.function_description, eval_timeout_s=EVAL_TIMEOUT_S)
+    system = build_system_prompt(skill="" if no_skill else load_skill_prompt(), has_scratch=True)
+    opening = first_user_message(secret_fn, turn_limit, description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     owns_client = model_client is None
     if model_client is None:
@@ -176,11 +180,8 @@ async def run_game(
 
     game = GameContext(turn_limit=turn_limit)
 
-    # Tools: play_turn (game) + optional exec (scratch).
     play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
-    all_tools: list[FunctionTool] = [play_turn_tool]
-    if exec_tool:
-        all_tools.append(exec_tool)
+    all_tools = [play_turn_tool, exec_tool]
     tool_schemas = [t.schema for t in all_tools]
     tool_map = {t.name: t for t in all_tools}
 
@@ -235,7 +236,7 @@ async def run_game(
         total_hamming_loss=total_hamming, per_turn_losses=per_turn, solved_at_turn=game.turn if game.solved else None
     )
 
-    calls_path, summary_path = run_output_paths(f"fl_{variant_name}", output_dir)
+    calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
     with calls_path.open("w") as f:
         for entry in game.log_entries:
             f.write(json.dumps(entry) + "\n")
@@ -243,7 +244,7 @@ async def run_game(
             f.write(tr.model_dump_json() + "\n")
 
     summary = RunSummary(
-        eval_name=variant_name,
+        eval_name=function_name,
         framework="autogen",
         model=model,
         api=api,
@@ -282,7 +283,8 @@ async def _async_main(args: argparse.Namespace) -> None:
             )
             try:
                 summary = await run_game(
-                    variant_name=args.variant,
+                    function_name=args.function,
+                    hint=not args.no_hint,
                     model=args.model,
                     api=args.api,
                     output_dir=output_dir,
@@ -299,7 +301,8 @@ async def _async_main(args: argparse.Namespace) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Function Learning Eval — AutoGen")
-    parser.add_argument("--variant", choices=list(VARIANTS), required=True)
+    parser.add_argument("--function", choices=list(FUNCTIONS), required=True)
+    parser.add_argument("--no-hint", action="store_true")
     parser.add_argument("--model", required=True)
     parser.add_argument("--api", choices=["openai", "anthropic"], default="anthropic")
     parser.add_argument("--output-dir", default=None)

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -104,7 +104,7 @@ class GameEndLog(BaseModel):
 @dataclass
 class GameContext:
     turn_limit: int
-    _log_file: IO[str] | None = field(default=None, init=False)
+    log_file: IO[str]
     turn: int = 0
     solved: bool = False
     turn_results: list[TurnResult] = field(default_factory=list)
@@ -117,13 +117,9 @@ class GameContext:
     def finished(self) -> bool:
         return self.turn >= self.turn_limit or self.solved
 
-    def attach_log(self, f: IO[str]) -> None:
-        self._log_file = f
-
     def log(self, entry: BaseModel) -> None:
-        if self._log_file is not None:
-            self._log_file.write(entry.model_dump_json() + "\n")
-            self._log_file.flush()
+        self.log_file.write(entry.model_dump_json() + "\n")
+        self.log_file.flush()
 
 
 def _now() -> str:
@@ -234,17 +230,14 @@ async def run_game(
     if model_client is None:
         model_client = _build_model_client(api=api, model=model)
 
-    game = GameContext(turn_limit=turn_limit)
-
-    play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
-    all_tools = [play_turn_tool, exec_tool]
-    tool_schemas = [t.schema for t in all_tools]
-    tool_map = {t.name: t for t in all_tools}
-
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
 
     with calls_path.open("w") as log_f:
-        game.attach_log(log_f)
+        game = GameContext(turn_limit=turn_limit, log_file=log_f)
+        play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
+        all_tools = [play_turn_tool, exec_tool]
+        tool_schemas = [t.schema for t in all_tools]
+        tool_map = {t.name: t for t in all_tools}
         game.log(
             GameStartLog(
                 timestamp=_now(),

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -183,7 +183,7 @@ def _make_play_turn_tool(
     )
 
 
-def _make_exec_tool(mcp_client: Client) -> FunctionTool:
+def make_exec_tool(mcp_client: Client) -> FunctionTool:
     async def exec(cmd: list[str], timeout_ms: int = 30000) -> str:
         """Run a command in a scratch container for computation."""
         arguments: dict[str, object] = {"cmd": cmd, "timeout_ms": timeout_ms}
@@ -261,8 +261,8 @@ async def run_game(
 
             result = await model_client.create(history, tools=tool_schemas, tool_choice="required")
 
-            cache_read = getattr(result.usage, "cache_read_tokens", 0)
-            cache_creation = getattr(result.usage, "cache_creation_tokens", 0)
+            cache_read = getattr(result, "cache_read_tokens", 0)
+            cache_creation = getattr(result, "cache_creation_tokens", 0)
             game.total_input_tokens += result.usage.prompt_tokens
             game.total_output_tokens += result.usage.completion_tokens
             game.total_cache_read_tokens += cache_read
@@ -284,6 +284,7 @@ async def run_game(
                 continue
 
             function_calls = result.content
+            assert len(function_calls) == 1, f"expected 1 tool call, got {len(function_calls)}"
             game.log(
                 LlmResponseLog(
                     timestamp=_now(),
@@ -302,7 +303,7 @@ async def run_game(
             exec_results: list[FunctionExecutionResult] = []
             for fc in function_calls:
                 tool = tool_map.get(fc.name)
-                args = json.loads(fc.arguments) if isinstance(fc.arguments, str) else fc.arguments
+                args = json.loads(fc.arguments)
                 if tool is None:
                     content = f"Error: unknown tool '{fc.name}'"
                     logger.warning("Unknown tool name: %s", fc.name)
@@ -366,7 +367,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     async with scratch_exec_server() as scratch_server, Client(scratch_server) as scratch_client:
-        exec_tool = _make_exec_tool(scratch_client)
+        exec_tool = make_exec_tool(scratch_client)
 
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:

--- a/skills/info_gathering/evals/function_learning/functions.py
+++ b/skills/info_gathering/evals/function_learning/functions.py
@@ -151,7 +151,6 @@ _NO_HINT = "The function class is unknown. You must discover its structure from 
 @dataclass(frozen=True)
 class Variant:
     function: SecretFunction
-    turn_limit: int
     description_override: str | None = None
 
     @property
@@ -391,28 +390,28 @@ AES_FIELD_AFFINE = AESFieldAffine()
 
 VARIANTS: dict[str, Variant] = {
     # 8-bit, with hints.
-    "linear_simple": Variant(function=LINEAR_SIMPLE, turn_limit=12),
-    "junta_3": Variant(function=JUNTA_3, turn_limit=12),
-    "parity_groups": Variant(function=PARITY_GROUPS, turn_limit=12),
+    "linear_simple": Variant(function=LINEAR_SIMPLE),
+    "junta_3": Variant(function=JUNTA_3),
+    "parity_groups": Variant(function=PARITY_GROUPS),
     # 8-bit, without hints.
-    "linear_nohint": Variant(function=LINEAR_SIMPLE, turn_limit=12, description_override=_NO_HINT),
-    "junta_nohint": Variant(function=JUNTA_3, turn_limit=12, description_override=_NO_HINT),
-    "parity_nohint": Variant(function=PARITY_GROUPS, turn_limit=12, description_override=_NO_HINT),
+    "linear_nohint": Variant(function=LINEAR_SIMPLE, description_override=_NO_HINT),
+    "junta_nohint": Variant(function=JUNTA_3, description_override=_NO_HINT),
+    "parity_nohint": Variant(function=PARITY_GROUPS, description_override=_NO_HINT),
     # 7-bit (128 inputs), with hints.
-    "linear_7": Variant(function=LINEAR_7, turn_limit=30),
-    "junta_7": Variant(function=JUNTA_7, turn_limit=30),
-    "parity_7": Variant(function=PARITY_7, turn_limit=30),
+    "linear_7": Variant(function=LINEAR_7),
+    "junta_7": Variant(function=JUNTA_7),
+    "parity_7": Variant(function=PARITY_7),
     # 7-bit, without hints.
-    "linear_7_nohint": Variant(function=LINEAR_7, turn_limit=30, description_override=_NO_HINT),
-    "junta_7_nohint": Variant(function=JUNTA_7, turn_limit=30, description_override=_NO_HINT),
-    "parity_7_nohint": Variant(function=PARITY_7, turn_limit=30, description_override=_NO_HINT),
+    "linear_7_nohint": Variant(function=LINEAR_7, description_override=_NO_HINT),
+    "junta_7_nohint": Variant(function=JUNTA_7, description_override=_NO_HINT),
+    "parity_7_nohint": Variant(function=PARITY_7, description_override=_NO_HINT),
     # 7-bit degree-3 Reed-Muller polynomial (harder: linear probing does not suffice).
-    "rm3_7": Variant(function=REED_MULLER_3, turn_limit=30),
-    "rm3_7_nohint": Variant(function=REED_MULLER_3, turn_limit=30, description_override=_NO_HINT),
+    "rm3_7": Variant(function=REED_MULLER_3),
+    "rm3_7_nohint": Variant(function=REED_MULLER_3, description_override=_NO_HINT),
     # 8-bit vectorial bent function (hard: maximally nonlinear, multiplicative structure).
-    "bent": Variant(function=BENT_INNER_PRODUCT, turn_limit=30),
-    "bent_nohint": Variant(function=BENT_INNER_PRODUCT, turn_limit=30, description_override=_NO_HINT),
+    "bent": Variant(function=BENT_INNER_PRODUCT),
+    "bent_nohint": Variant(function=BENT_INNER_PRODUCT, description_override=_NO_HINT),
     # 8-bit GF(2^8) affine function (medium: affine over GF(2) but compact GF(2^8) structure).
-    "aes_affine": Variant(function=AES_FIELD_AFFINE, turn_limit=20),
-    "aes_affine_nohint": Variant(function=AES_FIELD_AFFINE, turn_limit=20, description_override=_NO_HINT),
+    "aes_affine": Variant(function=AES_FIELD_AFFINE),
+    "aes_affine_nohint": Variant(function=AES_FIELD_AFFINE, description_override=_NO_HINT),
 }

--- a/skills/info_gathering/evals/function_learning/functions.py
+++ b/skills/info_gathering/evals/function_learning/functions.py
@@ -6,7 +6,6 @@ fully reproducible across runs.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import ClassVar
 
 
@@ -143,22 +142,6 @@ class ParityGroups(SecretFunction):
 
 
 # -- Variant registry --
-
-
-_NO_HINT = "The function class is unknown. You must discover its structure from queries alone."
-
-
-@dataclass(frozen=True)
-class Variant:
-    function: SecretFunction
-    description_override: str | None = None
-
-    @property
-    def function_description(self) -> str:
-        """Description shown to the model — may hide the function class."""
-        if self.description_override is not None:
-            return self.description_override
-        return self.function.description
 
 
 LINEAR_SIMPLE = LinearSimple()
@@ -388,30 +371,17 @@ REED_MULLER_3 = ReedMuller3()
 BENT_INNER_PRODUCT = BentInnerProduct()
 AES_FIELD_AFFINE = AESFieldAffine()
 
-VARIANTS: dict[str, Variant] = {
-    # 8-bit, with hints.
-    "linear_simple": Variant(function=LINEAR_SIMPLE),
-    "junta_3": Variant(function=JUNTA_3),
-    "parity_groups": Variant(function=PARITY_GROUPS),
-    # 8-bit, without hints.
-    "linear_nohint": Variant(function=LINEAR_SIMPLE, description_override=_NO_HINT),
-    "junta_nohint": Variant(function=JUNTA_3, description_override=_NO_HINT),
-    "parity_nohint": Variant(function=PARITY_GROUPS, description_override=_NO_HINT),
-    # 7-bit (128 inputs), with hints.
-    "linear_7": Variant(function=LINEAR_7),
-    "junta_7": Variant(function=JUNTA_7),
-    "parity_7": Variant(function=PARITY_7),
-    # 7-bit, without hints.
-    "linear_7_nohint": Variant(function=LINEAR_7, description_override=_NO_HINT),
-    "junta_7_nohint": Variant(function=JUNTA_7, description_override=_NO_HINT),
-    "parity_7_nohint": Variant(function=PARITY_7, description_override=_NO_HINT),
-    # 7-bit degree-3 Reed-Muller polynomial (harder: linear probing does not suffice).
-    "rm3_7": Variant(function=REED_MULLER_3),
-    "rm3_7_nohint": Variant(function=REED_MULLER_3, description_override=_NO_HINT),
-    # 8-bit vectorial bent function (hard: maximally nonlinear, multiplicative structure).
-    "bent": Variant(function=BENT_INNER_PRODUCT),
-    "bent_nohint": Variant(function=BENT_INNER_PRODUCT, description_override=_NO_HINT),
-    # 8-bit GF(2^8) affine function (medium: affine over GF(2) but compact GF(2^8) structure).
-    "aes_affine": Variant(function=AES_FIELD_AFFINE),
-    "aes_affine_nohint": Variant(function=AES_FIELD_AFFINE, description_override=_NO_HINT),
+FUNCTIONS: dict[str, SecretFunction] = {
+    # 8-bit (256 inputs).
+    "linear_simple": LINEAR_SIMPLE,
+    "junta_3": JUNTA_3,
+    "parity_groups": PARITY_GROUPS,
+    # 7-bit (128 inputs).
+    "linear_7": LINEAR_7,
+    "junta_7": JUNTA_7,
+    "parity_7": PARITY_7,
+    # Harder functions.
+    "rm3_7": REED_MULLER_3,
+    "bent": BENT_INNER_PRODUCT,
+    "aes_affine": AES_FIELD_AFFINE,
 }

--- a/skills/info_gathering/evals/function_learning/functions.py
+++ b/skills/info_gathering/evals/function_learning/functions.py
@@ -240,6 +240,155 @@ LINEAR_7 = Linear7()
 JUNTA_7 = Junta7()
 PARITY_7 = Parity7()
 
+
+# -- Reed-Muller degree-3 polynomial over GF(2)^7 --
+# Each output bit is the XOR of monomials of degree ≤ 3.
+# Monomials are tuples of bit indices (0 = MSB). Empty tuple () = constant 1.
+# Optimal strategy (linear probing) fails; higher-order differences are needed.
+
+
+class ReedMuller3(SecretFunction):
+    """7→4 degree-3 Boolean polynomial. Each output bit has at least one cubic term.
+
+    Standard linear probing (query x=0 and powers of 2) does not recover the
+    degree-2 and degree-3 terms. Discovering the full polynomial requires
+    systematic higher-order finite-difference queries.
+    """
+
+    name = "rm3_7"
+    description = (
+        "The function is a Reed-Muller degree-3 polynomial over GF(2): each output bit "
+        "is the XOR of Boolean monomials of degree at most 3 in the 7 input bits. "
+        "There are C(7,1)+C(7,2)+C(7,3) = 63 possible non-constant monomials."
+    )
+    n = 7
+    m = 4
+
+    # Each row is a list of monomials. () = constant 1, (i,) = x_i, (i,j) = x_i·x_j, etc.
+    # Row 0 (MSB): x0·x1·x2 ⊕ x3·x5 ⊕ x6 ⊕ 1
+    # Row 1:       x1·x3·x5 ⊕ x0·x4 ⊕ x2
+    # Row 2:       x0·x2·x4 ⊕ x1·x6 ⊕ x3·x5 ⊕ 1
+    # Row 3 (LSB): x2·x4·x6 ⊕ x0·x3 ⊕ x1·x5 ⊕ x4
+    _polynomials: ClassVar[list[list[tuple[int, ...]]]] = [
+        [(0, 1, 2), (3, 5), (6,), ()],
+        [(1, 3, 5), (0, 4), (2,)],
+        [(0, 2, 4), (1, 6), (3, 5), ()],
+        [(2, 4, 6), (0, 3), (1, 5), (4,)],
+    ]
+
+    def evaluate(self, x: int) -> int:
+        result = 0
+        for i, terms in enumerate(self._polynomials):
+            bit = 0
+            for monomial in terms:
+                val = 1
+                for idx in monomial:
+                    val &= (x >> (self.n - 1 - idx)) & 1
+                bit ^= val
+            result |= bit << (self.m - 1 - i)
+        return result
+
+
+# -- Bent function: vectorial inner product --
+# Split x into a = x >> 4 (top 4 bits) and b = x & 0xF (bottom 4 bits).
+# Output bit i = inner_product(a, rot4(b, i)), where rot4 is a 4-bit left rotation.
+# Each output bit is a bent Boolean function (maximally nonlinear).
+# Standard linear probing recovers only zero information.
+
+
+class BentInnerProduct(SecretFunction):
+    """8→4 vectorial bent function based on the rotated inner product construction.
+
+    f_i(a, b) = ⟨a, rot4(b, i)⟩ = popcount(a & rot4(b, i)) mod 2.
+    Each component is a bent function: all Walsh-Hadamard coefficients equal +-16.
+    Linear probing (query 0 and powers of 2) yields only 0 outputs and reveals
+    nothing about the function -- the interactions are all multiplicative.
+    """
+
+    name = "bent"
+    description = (
+        "The function is a vectorial bent Boolean function. "
+        "The input x is split into top half a = x >> 4 and bottom half b = x & 0xF. "
+        "Output bit i is the inner product (mod 2) of a and a 4-bit left rotation of b by i positions. "
+        "Bent functions are maximally nonlinear: standard linear probing does not apply."
+    )
+    n = 8
+    m = 4
+
+    @staticmethod
+    def _rot4(b: int, i: int) -> int:
+        """Left-rotate a 4-bit value by i positions."""
+        return ((b << i) | (b >> (4 - i))) & 0xF
+
+    def evaluate(self, x: int) -> int:
+        a = x >> 4
+        b = x & 0xF
+        result = 0
+        for i in range(self.m):
+            bit = (a & self._rot4(b, i)).bit_count() & 1
+            result |= bit << (self.m - 1 - i)
+        return result
+
+
+# -- Affine function over GF(2^8) --
+# f(x) = (alpha * x XOR beta) & 0xF, where * is GF(2^8) multiplication
+# using the AES irreducible polynomial x^8 + x^4 + x^3 + x + 1 (0x11b).
+# alpha = 0x57, beta = 0x83. Output is the lower 4 bits of the full 8-bit product.
+#
+# GF(2^8) multiplication by a constant is a linear map over GF(2), so the
+# function IS affine over GF(2). However, the 8x8 matrix has very specific
+# structure: all entries are determined by the single byte alpha. An agent that
+# knows GF(2^8) arithmetic can recover alpha in 2-3 queries; a naive linear
+# probing approach needs ~8 queries to recover the same information.
+
+
+class AESFieldAffine(SecretFunction):
+    """8->4 affine function over GF(2^8) with the AES field polynomial.
+
+    f(x) = (alpha * x XOR beta) mod 16, where * is GF(2^8) multiplication.
+    alpha = 0x57, beta = 0x83 (both unknown to the model). Output is lower 4 bits.
+
+    The function is affine over GF(2): f(x XOR y) = f(x) XOR f(y) XOR f(0).
+    But the algebraic structure is far more compact than a generic affine map:
+    only one byte (alpha) determines the entire linear component.
+    """
+
+    name = "aes_affine"
+    description = (
+        "The function computes f(x) = (alpha * x XOR beta) mod 16, where * denotes "
+        "multiplication in GF(2^8) with the AES irreducible polynomial "
+        "x^8 + x^4 + x^3 + x + 1, and alpha, beta in GF(2^8) are unknown constants. "
+        "The output is the lower 4 bits of the full 8-bit result."
+    )
+    n = 8
+    m = 4
+
+    _alpha: ClassVar[int] = 0x57
+    _beta: ClassVar[int] = 0x83
+    # AES irreducible polynomial: x^8 + x^4 + x^3 + x + 1.
+    _poly: ClassVar[int] = 0x11B
+
+    @classmethod
+    def _gf_mul(cls, a: int, b: int) -> int:
+        """Multiply two GF(2^8) elements using the AES polynomial."""
+        result = 0
+        for _ in range(8):
+            if b & 1:
+                result ^= a
+            a <<= 1
+            if a & 0x100:
+                a ^= cls._poly
+            b >>= 1
+        return result
+
+    def evaluate(self, x: int) -> int:
+        return (self._gf_mul(self._alpha, x) ^ self._beta) & self.max_output
+
+
+REED_MULLER_3 = ReedMuller3()
+BENT_INNER_PRODUCT = BentInnerProduct()
+AES_FIELD_AFFINE = AESFieldAffine()
+
 VARIANTS: dict[str, Variant] = {
     # 8-bit, with hints.
     "linear_simple": Variant(function=LINEAR_SIMPLE, turn_limit=12),
@@ -257,4 +406,13 @@ VARIANTS: dict[str, Variant] = {
     "linear_7_nohint": Variant(function=LINEAR_7, turn_limit=30, description_override=_NO_HINT),
     "junta_7_nohint": Variant(function=JUNTA_7, turn_limit=30, description_override=_NO_HINT),
     "parity_7_nohint": Variant(function=PARITY_7, turn_limit=30, description_override=_NO_HINT),
+    # 7-bit degree-3 Reed-Muller polynomial (harder: linear probing does not suffice).
+    "rm3_7": Variant(function=REED_MULLER_3, turn_limit=30),
+    "rm3_7_nohint": Variant(function=REED_MULLER_3, turn_limit=30, description_override=_NO_HINT),
+    # 8-bit vectorial bent function (hard: maximally nonlinear, multiplicative structure).
+    "bent": Variant(function=BENT_INNER_PRODUCT, turn_limit=30),
+    "bent_nohint": Variant(function=BENT_INNER_PRODUCT, turn_limit=30, description_override=_NO_HINT),
+    # 8-bit GF(2^8) affine function (medium: affine over GF(2) but compact GF(2^8) structure).
+    "aes_affine": Variant(function=AES_FIELD_AFFINE, turn_limit=20),
+    "aes_affine_nohint": Variant(function=AES_FIELD_AFFINE, turn_limit=20, description_override=_NO_HINT),
 }

--- a/skills/info_gathering/evals/function_learning/result_types.py
+++ b/skills/info_gathering/evals/function_learning/result_types.py
@@ -37,6 +37,9 @@ class FunctionLearningResult(BaseModel):
     kind: Literal["completed"] = "completed"
     total_hamming_loss: int
     per_turn_losses: list[int]
+    solved_at_turn: int | None = Field(
+        default=None, description="Turn on which 0 loss was first achieved; None if never solved"
+    )
 
 
 class TokenUsage(BaseModel):

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -1,21 +1,15 @@
-"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill).
-
-Supports multiple runs per cell (--runs-per-cell N) to compute mean/std.
-Generates a combined_results.json and a report.md with cost projections.
-"""
+"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill)."""
 
 import argparse
 import asyncio
-import json
 import logging
-import statistics
 import uuid
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import aiodocker
 import anyio
 from fastmcp.client import Client
+from pydantic import BaseModel
 
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
 from skills.info_gathering.evals.function_learning.function_learning import _make_exec_tool, run_game
@@ -25,18 +19,10 @@ logger = logging.getLogger(__name__)
 
 FUNCTIONS_LIST = list(FUNCTIONS.keys())
 
-# Pricing per million tokens: (input, output, cache_write, cache_read)
-_PRICING: dict[str, tuple[float, float, float, float]] = {
-    "claude-haiku-4-5-20251001": (0.80, 4.00, 1.00, 0.08),
-    "claude-sonnet-4-6": (3.00, 15.00, 3.75, 0.30),
-    "claude-opus-4-6": (15.00, 75.00, 18.75, 1.50),
-}
 
-
-@dataclass
-class RunRecord:
+class RunRecord(BaseModel):
     function: str
-    arm: str
+    arm: str  # "skill" or "no_skill"
     run_idx: int
     total_hamming_loss: int
     per_turn_losses: list[int]
@@ -46,49 +32,6 @@ class RunRecord:
     output_tokens: int
     cache_read_tokens: int
     cache_creation_tokens: int
-
-
-@dataclass
-class CellStats:
-    function: str
-    arm: str
-    runs: list[RunRecord] = field(default_factory=list)
-
-    @property
-    def losses(self) -> list[int]:
-        return [r.total_hamming_loss for r in self.runs]
-
-    @property
-    def mean_loss(self) -> float:
-        return statistics.mean(self.losses)
-
-    @property
-    def std_loss(self) -> float:
-        return statistics.stdev(self.losses) if len(self.losses) > 1 else 0.0
-
-    @property
-    def solved_count(self) -> int:
-        return sum(1 for r in self.runs if r.solved_at_turn is not None)
-
-    @property
-    def mean_turns(self) -> float:
-        return statistics.mean(r.turns for r in self.runs)
-
-    @property
-    def total_input_tokens(self) -> int:
-        return sum(r.input_tokens for r in self.runs)
-
-    @property
-    def total_output_tokens(self) -> int:
-        return sum(r.output_tokens for r in self.runs)
-
-    @property
-    def total_cache_read_tokens(self) -> int:
-        return sum(r.cache_read_tokens for r in self.runs)
-
-    @property
-    def total_cache_creation_tokens(self) -> int:
-        return sum(r.cache_creation_tokens for r in self.runs)
 
 
 async def run_one(
@@ -101,7 +44,7 @@ async def run_one(
     model: str,
     turn_limit: int,
     output_dir: Path,
-) -> RunRecord | dict:
+) -> RunRecord | None:
     arm = "no_skill" if arm_no_skill else "skill"
     label = f"{function_name}/{arm}[{run_idx}]"
     print(f"  START {label}", flush=True)
@@ -139,106 +82,7 @@ async def run_one(
         except Exception as e:
             print(f"  ERROR {label}: {e}", flush=True)
             logger.exception("Error running %s", label)
-            return {"function": function_name, "arm": arm, "run_idx": run_idx, "error": str(e)}
-
-
-def _compute_cost(cells: list[CellStats], model: str) -> dict[str, float]:
-    """Compute total cost in USD for the given cells at the given model's pricing."""
-    inp_rate, out_rate, cw_rate, cr_rate = _PRICING.get(model, _PRICING["claude-haiku-4-5-20251001"])
-    total_inp = sum(c.total_input_tokens for c in cells)
-    total_out = sum(c.total_output_tokens for c in cells)
-    total_cr = sum(c.total_cache_read_tokens for c in cells)
-    total_cw = sum(c.total_cache_creation_tokens for c in cells)
-    return {
-        "input_tokens": total_inp,
-        "output_tokens": total_out,
-        "cache_read_tokens": total_cr,
-        "cache_creation_tokens": total_cw,
-        "cost_usd": (
-            total_inp / 1e6 * inp_rate
-            + total_out / 1e6 * out_rate
-            + total_cr / 1e6 * cr_rate
-            + total_cw / 1e6 * cw_rate
-        ),
-    }
-
-
-def _generate_report(cells: list[CellStats], model: str, runs_per_cell: int) -> str:
-    lines = [
-        "# Function Learning Benchmark Results",
-        "",
-        f"**Model:** `{model}`  ",
-        f"**Runs per cell:** {runs_per_cell}  ",
-        f"**Functions:** {len(FUNCTIONS_LIST)}  ",
-        "**Arms:** skill / no-skill  ",
-        "",
-        "## Results by Function",
-        "",
-        "| Function | Arm | Mean Loss | Std | Min | Max | Solved | Mean Turns |",
-        "|----------|-----|----------:|----:|----:|----:|-------:|-----------:|",
-    ]
-    for c in cells:
-        solved_rate = f"{c.solved_count}/{runs_per_cell}"
-        losses = c.losses
-        lines.append(
-            f"| {c.function} | {c.arm} "
-            f"| {c.mean_loss:.0f} | {c.std_loss:.0f} "
-            f"| {min(losses)} | {max(losses)} "
-            f"| {solved_rate} | {c.mean_turns:.1f} |"
-        )
-
-    lines += [
-        "",
-        "## Skill vs No-Skill",
-        "",
-        "| Function | Skill Mean Loss | No-Skill Mean Loss | Winner |",
-        "|----------|----------------:|-------------------:|--------|",
-    ]
-    by_fn: dict[str, dict[str, CellStats]] = {}
-    for c in cells:
-        by_fn.setdefault(c.function, {})[c.arm] = c
-    for fn in FUNCTIONS_LIST:
-        arms = by_fn.get(fn, {})
-        skill = arms.get("skill")
-        noskill = arms.get("no_skill")
-        if skill and noskill:
-            winner = "skill" if skill.mean_loss < noskill.mean_loss else "no_skill"
-            lines.append(f"| {fn} | {skill.mean_loss:.0f} | {noskill.mean_loss:.0f} | {winner} |")
-
-    lines += ["", "## Token Usage & Cost", ""]
-
-    actual_cost = _compute_cost(cells, model)
-    lines += [
-        f"Actual run ({model}):",
-        "",
-        "| Metric | Value |",
-        "|--------|------:|",
-        f"| Input tokens | {actual_cost['input_tokens']:,} |",
-        f"| Output tokens | {actual_cost['output_tokens']:,} |",
-        f"| Cache creation tokens | {actual_cost['cache_creation_tokens']:,} |",
-        f"| Cache read tokens | {actual_cost['cache_read_tokens']:,} |",
-        f"| **Total cost** | **${actual_cost['cost_usd']:.3f}** |",
-        "",
-    ]
-
-    # Project costs for other models using same token mix
-    total_inp = actual_cost["input_tokens"]
-    total_out = actual_cost["output_tokens"]
-    total_cr = actual_cost["cache_read_tokens"]
-    total_cw = actual_cost["cache_creation_tokens"]
-
-    lines += [
-        "Cost projections (same token mix, different models):",
-        "",
-        "| Model | Input $/M | Output $/M | Cache Write $/M | Cache Read $/M | Projected Cost |",
-        "|-------|----------:|-----------:|----------------:|---------------:|---------------:|",
-    ]
-    for proj_model, (ir, or_, cwr, crr) in _PRICING.items():
-        cost = total_inp / 1e6 * ir + total_out / 1e6 * or_ + total_cw / 1e6 * cwr + total_cr / 1e6 * crr
-        lines.append(f"| `{proj_model}` | ${ir} | ${or_} | ${cwr} | ${crr} | **${cost:.2f}** |")
-
-    lines += ["", "*(Projections assume same number of tokens; actual costs may differ by model.)*", ""]
-    return "\n".join(lines)
+            return None
 
 
 async def _async_main(args: argparse.Namespace) -> None:
@@ -277,68 +121,17 @@ async def _async_main(args: argparse.Namespace) -> None:
                 await scoring_container.stop()
                 await scoring_container.delete(force=True)
 
-    # Group into cells
-    cell_map: dict[tuple[str, str], CellStats] = {}
-    errors = []
-    for r in raw_results:
-        if isinstance(r, RunRecord):
-            key = (r.function, r.arm)
-            if key not in cell_map:
-                cell_map[key] = CellStats(function=r.function, arm=r.arm)
-            cell_map[key].runs.append(r)
-        else:
-            errors.append(r)
+    records = [r for r in raw_results if r is not None]
+    error_count = len(raw_results) - len(records)
 
-    cells = list(cell_map.values())
+    runs_path = output_dir / "runs.jsonl"
+    with runs_path.open("w") as f:
+        for r in records:
+            f.write(r.model_dump_json() + "\n")
 
-    # Serialize
-    combined: list[dict] = []
-    for c in cells:
-        entry: dict = {
-            "function": c.function,
-            "arm": c.arm,
-            "n_runs": len(c.runs),
-            "mean_loss": c.mean_loss,
-            "std_loss": c.std_loss,
-            "min_loss": min(c.losses),
-            "max_loss": max(c.losses),
-            "solved_count": c.solved_count,
-            "mean_turns": c.mean_turns,
-            "total_input_tokens": c.total_input_tokens,
-            "total_output_tokens": c.total_output_tokens,
-            "total_cache_read_tokens": c.total_cache_read_tokens,
-            "total_cache_creation_tokens": c.total_cache_creation_tokens,
-            "runs": [
-                {
-                    "run_idx": r.run_idx,
-                    "total_hamming_loss": r.total_hamming_loss,
-                    "per_turn_losses": r.per_turn_losses,
-                    "solved_at_turn": r.solved_at_turn,
-                    "turns": r.turns,
-                    "input_tokens": r.input_tokens,
-                    "output_tokens": r.output_tokens,
-                    "cache_read_tokens": r.cache_read_tokens,
-                    "cache_creation_tokens": r.cache_creation_tokens,
-                }
-                for r in c.runs
-            ],
-        }
-        combined.append(entry)
-    if errors:
-        combined.append({"errors": errors})
-
-    combined_path = output_dir / "combined_results.json"
-    combined_path.write_text(json.dumps(combined, indent=2))
-
-    report = _generate_report(cells, args.model, args.runs_per_cell)
-    report_path = output_dir / "report.md"
-    report_path.write_text(report)
-
-    print("\nAll done.")
-    print(f"  Results: {combined_path}")
-    print(f"  Report:  {report_path}")
-    if errors:
-        print(f"  Errors:  {len(errors)} run(s) failed — see combined_results.json")
+    print(f"\nAll done: {len(records)} runs saved to {runs_path}")
+    if error_count:
+        print(f"  {error_count} run(s) failed (see stderr above)")
 
 
 if __name__ == "__main__":

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -24,6 +24,7 @@ class RunRecord(BaseModel):
     function: str
     arm: str  # "skill" or "no_skill"
     run_idx: int
+    model: str
     total_hamming_loss: int
     per_turn_losses: list[int]
     solved_at_turn: int | None
@@ -65,6 +66,7 @@ async def run_one(
                 function=function_name,
                 arm=arm,
                 run_idx=run_idx,
+                model=summary.model,
                 total_hamming_loss=summary.result.total_hamming_loss,
                 per_turn_losses=summary.result.per_turn_losses,
                 solved_at_turn=summary.result.solved_at_turn,

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -1,0 +1,130 @@
+"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill)."""
+
+import argparse
+import asyncio
+import json
+import logging
+import uuid
+from pathlib import Path
+
+import aiodocker
+from fastmcp.client import Client
+
+from skills.info_gathering.evals.docker_exec import scratch_exec_server
+from skills.info_gathering.evals.function_learning.function_learning import _make_exec_tool, run_game
+from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
+
+logger = logging.getLogger(__name__)
+
+FUNCTIONS_LIST = list(FUNCTIONS.keys())
+
+
+async def run_one(
+    function_name: str,
+    no_skill: bool,
+    exec_tool,
+    scoring_container,
+    sem: asyncio.Semaphore,
+    model: str,
+    turn_limit: int,
+    output_dir: Path,
+) -> dict:
+    arm = "no_skill" if no_skill else "skill"
+    print(f"  START {function_name}/{arm}", flush=True)
+    async with sem:
+        try:
+            summary = await run_game(
+                function_name=function_name,
+                hint=False,
+                turn_limit=turn_limit,
+                model=model,
+                api="anthropic",
+                output_dir=output_dir,
+                exec_tool=exec_tool,
+                scoring_container=scoring_container,
+                no_skill=no_skill,
+            )
+            print(
+                f"  DONE  {function_name}/{arm} "
+                f"loss={summary.result.total_hamming_loss} "
+                f"turns={summary.turns} "
+                f"solved={summary.result.solved_at_turn}",
+                flush=True,
+            )
+            return {"function": function_name, "arm": arm, "summary": summary}
+        except Exception as e:
+            print(f"  ERROR {function_name}/{arm}: {e}", flush=True)
+            logger.exception("Error running %s/%s", function_name, arm)
+            return {"function": function_name, "arm": arm, "error": str(e)}
+
+
+async def _async_main(args: argparse.Namespace) -> None:
+    output_dir = Path(args.output_dir)
+    Path.mkdir(output_dir, parents=True, exist_ok=True)
+
+    sem = asyncio.Semaphore(args.concurrency)
+
+    async with scratch_exec_server() as scratch_server, Client(scratch_server) as scratch_client:
+        exec_tool = _make_exec_tool(scratch_client)
+
+        async with aiodocker.Docker() as docker:
+            container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
+            scoring_container = await docker.containers.run(
+                config={"Image": "python:3.13-slim", "Cmd": ["sleep", "7200"]}, name=container_name
+            )
+            try:
+                tasks = [
+                    run_one(
+                        fn_name,
+                        no_skill,
+                        exec_tool,
+                        scoring_container,
+                        sem,
+                        model=args.model,
+                        turn_limit=args.turn_limit,
+                        output_dir=output_dir,
+                    )
+                    for fn_name in FUNCTIONS_LIST
+                    for no_skill in [False, True]
+                ]
+
+                results = await asyncio.gather(*tasks)
+            finally:
+                await scoring_container.stop()
+                await scoring_container.delete(force=True)
+
+    out = []
+    for r in results:
+        if "summary" in r:
+            s = r["summary"]
+            out.append(
+                {
+                    "function": r["function"],
+                    "arm": r["arm"],
+                    "total_hamming_loss": s.result.total_hamming_loss,
+                    "per_turn_losses": s.result.per_turn_losses,
+                    "solved_at_turn": s.result.solved_at_turn,
+                    "turns": s.turns,
+                    "input_tokens": s.usage.input_tokens,
+                    "output_tokens": s.usage.output_tokens,
+                    "cache_read_tokens": s.usage.cache_read_input_tokens,
+                    "cache_creation_tokens": s.usage.cache_creation_input_tokens,
+                }
+            )
+        else:
+            out.append(r)
+
+    combined = output_dir / "combined_results.json"
+    combined.write_text(json.dumps(out, indent=2))
+    print("\nAll done. Results written to", combined)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARNING)
+    parser = argparse.ArgumentParser(description="Run all function learning evals")
+    parser.add_argument("--model", default="claude-haiku-4-5-20251001")
+    parser.add_argument("--turn-limit", type=int, required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--concurrency", type=int, default=3)
+    args = parser.parse_args()
+    asyncio.run(_async_main(args))

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -1,10 +1,16 @@
-"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill)."""
+"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill).
+
+Supports multiple runs per cell (--runs-per-cell N) to compute mean/std.
+Generates a combined_results.json and a report.md with cost projections.
+"""
 
 import argparse
 import asyncio
 import json
 import logging
+import statistics
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import aiodocker
@@ -18,19 +24,86 @@ logger = logging.getLogger(__name__)
 
 FUNCTIONS_LIST = list(FUNCTIONS.keys())
 
+# Pricing per million tokens: (input, output, cache_write, cache_read)
+_PRICING: dict[str, tuple[float, float, float, float]] = {
+    "claude-haiku-4-5-20251001": (0.80, 4.00, 1.00, 0.08),
+    "claude-sonnet-4-6": (3.00, 15.00, 3.75, 0.30),
+    "claude-opus-4-6": (15.00, 75.00, 18.75, 1.50),
+}
+
+
+@dataclass
+class RunRecord:
+    function: str
+    arm: str
+    run_idx: int
+    total_hamming_loss: int
+    per_turn_losses: list[int]
+    solved_at_turn: int | None
+    turns: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+
+
+@dataclass
+class CellStats:
+    function: str
+    arm: str
+    runs: list[RunRecord] = field(default_factory=list)
+
+    @property
+    def losses(self) -> list[int]:
+        return [r.total_hamming_loss for r in self.runs]
+
+    @property
+    def mean_loss(self) -> float:
+        return statistics.mean(self.losses)
+
+    @property
+    def std_loss(self) -> float:
+        return statistics.stdev(self.losses) if len(self.losses) > 1 else 0.0
+
+    @property
+    def solved_count(self) -> int:
+        return sum(1 for r in self.runs if r.solved_at_turn is not None)
+
+    @property
+    def mean_turns(self) -> float:
+        return statistics.mean(r.turns for r in self.runs)
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(r.input_tokens for r in self.runs)
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(r.output_tokens for r in self.runs)
+
+    @property
+    def total_cache_read_tokens(self) -> int:
+        return sum(r.cache_read_tokens for r in self.runs)
+
+    @property
+    def total_cache_creation_tokens(self) -> int:
+        return sum(r.cache_creation_tokens for r in self.runs)
+
 
 async def run_one(
     function_name: str,
-    no_skill: bool,
+    arm_no_skill: bool,
+    run_idx: int,
     exec_tool,
     scoring_container,
     sem: asyncio.Semaphore,
     model: str,
     turn_limit: int,
     output_dir: Path,
-) -> dict:
-    arm = "no_skill" if no_skill else "skill"
-    print(f"  START {function_name}/{arm}", flush=True)
+) -> RunRecord | dict:
+    arm = "no_skill" if arm_no_skill else "skill"
+    label = f"{function_name}/{arm}[{run_idx}]"
+    print(f"  START {label}", flush=True)
     async with sem:
         try:
             summary = await run_game(
@@ -42,20 +115,129 @@ async def run_one(
                 output_dir=output_dir,
                 exec_tool=exec_tool,
                 scoring_container=scoring_container,
-                no_skill=no_skill,
+                no_skill=arm_no_skill,
+            )
+            record = RunRecord(
+                function=function_name,
+                arm=arm,
+                run_idx=run_idx,
+                total_hamming_loss=summary.result.total_hamming_loss,
+                per_turn_losses=summary.result.per_turn_losses,
+                solved_at_turn=summary.result.solved_at_turn,
+                turns=summary.turns,
+                input_tokens=summary.usage.input_tokens,
+                output_tokens=summary.usage.output_tokens,
+                cache_read_tokens=summary.usage.cache_read_input_tokens,
+                cache_creation_tokens=summary.usage.cache_creation_input_tokens,
             )
             print(
-                f"  DONE  {function_name}/{arm} "
-                f"loss={summary.result.total_hamming_loss} "
-                f"turns={summary.turns} "
-                f"solved={summary.result.solved_at_turn}",
+                f"  DONE  {label} loss={record.total_hamming_loss} turns={record.turns} solved={record.solved_at_turn}",
                 flush=True,
             )
-            return {"function": function_name, "arm": arm, "summary": summary}
+            return record
         except Exception as e:
-            print(f"  ERROR {function_name}/{arm}: {e}", flush=True)
-            logger.exception("Error running %s/%s", function_name, arm)
-            return {"function": function_name, "arm": arm, "error": str(e)}
+            print(f"  ERROR {label}: {e}", flush=True)
+            logger.exception("Error running %s", label)
+            return {"function": function_name, "arm": arm, "run_idx": run_idx, "error": str(e)}
+
+
+def _compute_cost(cells: list[CellStats], model: str) -> dict[str, float]:
+    """Compute total cost in USD for the given cells at the given model's pricing."""
+    inp_rate, out_rate, cw_rate, cr_rate = _PRICING.get(model, _PRICING["claude-haiku-4-5-20251001"])
+    total_inp = sum(c.total_input_tokens for c in cells)
+    total_out = sum(c.total_output_tokens for c in cells)
+    total_cr = sum(c.total_cache_read_tokens for c in cells)
+    total_cw = sum(c.total_cache_creation_tokens for c in cells)
+    return {
+        "input_tokens": total_inp,
+        "output_tokens": total_out,
+        "cache_read_tokens": total_cr,
+        "cache_creation_tokens": total_cw,
+        "cost_usd": (
+            total_inp / 1e6 * inp_rate
+            + total_out / 1e6 * out_rate
+            + total_cr / 1e6 * cr_rate
+            + total_cw / 1e6 * cw_rate
+        ),
+    }
+
+
+def _generate_report(cells: list[CellStats], model: str, runs_per_cell: int) -> str:
+    lines = [
+        "# Function Learning Benchmark Results",
+        "",
+        f"**Model:** `{model}`  ",
+        f"**Runs per cell:** {runs_per_cell}  ",
+        f"**Functions:** {len(FUNCTIONS_LIST)}  ",
+        "**Arms:** skill / no-skill  ",
+        "",
+        "## Results by Function",
+        "",
+        "| Function | Arm | Mean Loss | Std | Min | Max | Solved | Mean Turns |",
+        "|----------|-----|----------:|----:|----:|----:|-------:|-----------:|",
+    ]
+    for c in cells:
+        solved_rate = f"{c.solved_count}/{runs_per_cell}"
+        losses = c.losses
+        lines.append(
+            f"| {c.function} | {c.arm} "
+            f"| {c.mean_loss:.0f} | {c.std_loss:.0f} "
+            f"| {min(losses)} | {max(losses)} "
+            f"| {solved_rate} | {c.mean_turns:.1f} |"
+        )
+
+    lines += [
+        "",
+        "## Skill vs No-Skill",
+        "",
+        "| Function | Skill Mean Loss | No-Skill Mean Loss | Winner |",
+        "|----------|----------------:|-------------------:|--------|",
+    ]
+    by_fn: dict[str, dict[str, CellStats]] = {}
+    for c in cells:
+        by_fn.setdefault(c.function, {})[c.arm] = c
+    for fn in FUNCTIONS_LIST:
+        arms = by_fn.get(fn, {})
+        skill = arms.get("skill")
+        noskill = arms.get("no_skill")
+        if skill and noskill:
+            winner = "skill" if skill.mean_loss < noskill.mean_loss else "no_skill"
+            lines.append(f"| {fn} | {skill.mean_loss:.0f} | {noskill.mean_loss:.0f} | {winner} |")
+
+    lines += ["", "## Token Usage & Cost", ""]
+
+    actual_cost = _compute_cost(cells, model)
+    lines += [
+        f"Actual run ({model}):",
+        "",
+        "| Metric | Value |",
+        "|--------|------:|",
+        f"| Input tokens | {actual_cost['input_tokens']:,} |",
+        f"| Output tokens | {actual_cost['output_tokens']:,} |",
+        f"| Cache creation tokens | {actual_cost['cache_creation_tokens']:,} |",
+        f"| Cache read tokens | {actual_cost['cache_read_tokens']:,} |",
+        f"| **Total cost** | **${actual_cost['cost_usd']:.3f}** |",
+        "",
+    ]
+
+    # Project costs for other models using same token mix
+    total_inp = actual_cost["input_tokens"]
+    total_out = actual_cost["output_tokens"]
+    total_cr = actual_cost["cache_read_tokens"]
+    total_cw = actual_cost["cache_creation_tokens"]
+
+    lines += [
+        "Cost projections (same token mix, different models):",
+        "",
+        "| Model | Input $/M | Output $/M | Cache Write $/M | Cache Read $/M | Projected Cost |",
+        "|-------|----------:|-----------:|----------------:|---------------:|---------------:|",
+    ]
+    for proj_model, (ir, or_, cwr, crr) in _PRICING.items():
+        cost = total_inp / 1e6 * ir + total_out / 1e6 * or_ + total_cw / 1e6 * cwr + total_cr / 1e6 * crr
+        lines.append(f"| `{proj_model}` | ${ir} | ${or_} | ${cwr} | ${crr} | **${cost:.2f}** |")
+
+    lines += ["", "*(Projections assume same number of tokens; actual costs may differ by model.)*", ""]
+    return "\n".join(lines)
 
 
 async def _async_main(args: argparse.Namespace) -> None:
@@ -77,6 +259,7 @@ async def _async_main(args: argparse.Namespace) -> None:
                     run_one(
                         fn_name,
                         no_skill,
+                        run_idx,
                         exec_tool,
                         scoring_container,
                         sem,
@@ -86,37 +269,75 @@ async def _async_main(args: argparse.Namespace) -> None:
                     )
                     for fn_name in FUNCTIONS_LIST
                     for no_skill in [False, True]
+                    for run_idx in range(args.runs_per_cell)
                 ]
-
-                results = await asyncio.gather(*tasks)
+                raw_results = await asyncio.gather(*tasks)
             finally:
                 await scoring_container.stop()
                 await scoring_container.delete(force=True)
 
-    out = []
-    for r in results:
-        if "summary" in r:
-            s = r["summary"]
-            out.append(
-                {
-                    "function": r["function"],
-                    "arm": r["arm"],
-                    "total_hamming_loss": s.result.total_hamming_loss,
-                    "per_turn_losses": s.result.per_turn_losses,
-                    "solved_at_turn": s.result.solved_at_turn,
-                    "turns": s.turns,
-                    "input_tokens": s.usage.input_tokens,
-                    "output_tokens": s.usage.output_tokens,
-                    "cache_read_tokens": s.usage.cache_read_input_tokens,
-                    "cache_creation_tokens": s.usage.cache_creation_input_tokens,
-                }
-            )
+    # Group into cells
+    cell_map: dict[tuple[str, str], CellStats] = {}
+    errors = []
+    for r in raw_results:
+        if isinstance(r, RunRecord):
+            key = (r.function, r.arm)
+            if key not in cell_map:
+                cell_map[key] = CellStats(function=r.function, arm=r.arm)
+            cell_map[key].runs.append(r)
         else:
-            out.append(r)
+            errors.append(r)
 
-    combined = output_dir / "combined_results.json"
-    combined.write_text(json.dumps(out, indent=2))
-    print("\nAll done. Results written to", combined)
+    cells = list(cell_map.values())
+
+    # Serialize
+    combined: list[dict] = []
+    for c in cells:
+        entry: dict = {
+            "function": c.function,
+            "arm": c.arm,
+            "n_runs": len(c.runs),
+            "mean_loss": c.mean_loss,
+            "std_loss": c.std_loss,
+            "min_loss": min(c.losses),
+            "max_loss": max(c.losses),
+            "solved_count": c.solved_count,
+            "mean_turns": c.mean_turns,
+            "total_input_tokens": c.total_input_tokens,
+            "total_output_tokens": c.total_output_tokens,
+            "total_cache_read_tokens": c.total_cache_read_tokens,
+            "total_cache_creation_tokens": c.total_cache_creation_tokens,
+            "runs": [
+                {
+                    "run_idx": r.run_idx,
+                    "total_hamming_loss": r.total_hamming_loss,
+                    "per_turn_losses": r.per_turn_losses,
+                    "solved_at_turn": r.solved_at_turn,
+                    "turns": r.turns,
+                    "input_tokens": r.input_tokens,
+                    "output_tokens": r.output_tokens,
+                    "cache_read_tokens": r.cache_read_tokens,
+                    "cache_creation_tokens": r.cache_creation_tokens,
+                }
+                for r in c.runs
+            ],
+        }
+        combined.append(entry)
+    if errors:
+        combined.append({"errors": errors})
+
+    combined_path = output_dir / "combined_results.json"
+    combined_path.write_text(json.dumps(combined, indent=2))
+
+    report = _generate_report(cells, args.model, args.runs_per_cell)
+    report_path = output_dir / "report.md"
+    report_path.write_text(report)
+
+    print("\nAll done.")
+    print(f"  Results: {combined_path}")
+    print(f"  Report:  {report_path}")
+    if errors:
+        print(f"  Errors:  {len(errors)} run(s) failed — see combined_results.json")
 
 
 if __name__ == "__main__":
@@ -126,5 +347,6 @@ if __name__ == "__main__":
     parser.add_argument("--turn-limit", type=int, required=True)
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--runs-per-cell", type=int, default=1)
     args = parser.parse_args()
     asyncio.run(_async_main(args))

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -12,7 +12,7 @@ from fastmcp.client import Client
 from pydantic import BaseModel
 
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
-from skills.info_gathering.evals.function_learning.function_learning import _make_exec_tool, run_game
+from skills.info_gathering.evals.function_learning.function_learning import make_exec_tool, run_game
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     sem = asyncio.Semaphore(args.concurrency)
 
     async with scratch_exec_server() as scratch_server, Client(scratch_server) as scratch_client:
-        exec_tool = _make_exec_tool(scratch_client)
+        exec_tool = make_exec_tool(scratch_client)
 
         async with aiodocker.Docker() as docker:
             container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import aiodocker
+import anyio
 from fastmcp.client import Client
 
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
@@ -242,7 +243,7 @@ def _generate_report(cells: list[CellStats], model: str, runs_per_cell: int) -> 
 
 async def _async_main(args: argparse.Namespace) -> None:
     output_dir = Path(args.output_dir)
-    Path.mkdir(output_dir, parents=True, exist_ok=True)
+    await anyio.Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     sem = asyncio.Semaphore(args.concurrency)
 

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -265,7 +265,7 @@ async def _async_main(args: argparse.Namespace) -> None:
                         sem,
                         model=args.model,
                         turn_limit=args.turn_limit,
-                        output_dir=output_dir,
+                        output_dir=output_dir / fn_name / ("no_skill" if no_skill else "skill") / f"run_{run_idx}",
                     )
                     for fn_name in FUNCTIONS_LIST
                     for no_skill in [False, True]

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -12,6 +12,7 @@ import aiodocker
 import pytest_bazel
 from autogen_core import FunctionCall
 from autogen_core.models import CreateResult, RequestUsage
+from autogen_core.tools import FunctionTool
 from autogen_ext.models.replay import ReplayChatCompletionClient
 
 from skills.info_gathering.evals.function_learning.function_learning import run_game
@@ -20,6 +21,15 @@ from skills.info_gathering.evals.function_learning.result_types import RunSummar
 
 _ZERO_USAGE = RequestUsage(prompt_tokens=0, completion_tokens=0)
 _TEST_TURNS = 3
+
+
+def _dummy_exec_tool() -> FunctionTool:
+    """Exec tool that is never called — replay client only issues play_turn calls."""
+
+    async def exec(cmd: list[str], timeout_ms: int = 30000) -> str:
+        raise RuntimeError("exec should not be called in replay tests")
+
+    return FunctionTool(exec, name="exec", description="dummy")
 
 
 def _play_turn_call(query: int, program: str) -> CreateResult:
@@ -37,7 +47,8 @@ async def _run_with_replay(
     *,
     completions: list[CreateResult],
     tmp_path: Path,
-    variant_name: str = "parity_groups",
+    function_name: str = "parity_groups",
+    hint: bool = True,
     turn_limit: int = _TEST_TURNS,
 ) -> RunSummary:
     client = ReplayChatCompletionClient(
@@ -57,10 +68,12 @@ async def _run_with_replay(
         )
         try:
             return await run_game(
-                variant_name=variant_name,
+                function_name=function_name,
+                hint=hint,
                 model="test-model",
                 api="openai",
                 output_dir=tmp_path,
+                exec_tool=_dummy_exec_tool(),
                 model_client=client,
                 scoring_container=container,
                 turn_limit=turn_limit,

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -164,5 +164,25 @@ async def test_output_files_written(tmp_path: Path) -> None:
     _check_output_files(tmp_path)
 
 
+async def test_early_termination_on_zero_loss(tmp_path: Path) -> None:
+    """Game ends after turn 1 when 0 loss is achieved; remaining turns are imputed as 0."""
+    perfect_program = (
+        "for x in range(256):\n"
+        "    bits = [(x >> (7 - i)) & 1 for i in range(8)]\n"
+        "    r = sum((bits[i] ^ bits[i+1]) << (3 - i//2) for i in range(0, 8, 2))\n"
+        "    print(r)"
+    )
+    # Supply more completions than should be consumed — game should stop after turn 1.
+    completions = [_play_turn_call(0, perfect_program)] * _TEST_TURNS
+
+    summary = await _run_with_replay(completions=completions, tmp_path=tmp_path, turn_limit=_TEST_TURNS)
+
+    assert summary.turns == 1, "Game should have stopped after solving on turn 1"
+    assert summary.result.solved_at_turn == 1
+    assert len(summary.result.per_turn_losses) == _TEST_TURNS, "per_turn_losses padded to turn_limit"
+    assert summary.result.per_turn_losses == [0, 0, 0]
+    assert summary.result.total_hamming_loss == 0
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/skills/info_gathering/evals/function_learning/test_functions.py
+++ b/skills/info_gathering/evals/function_learning/test_functions.py
@@ -2,7 +2,14 @@
 
 import pytest_bazel
 
-from skills.info_gathering.evals.function_learning.functions import JUNTA_3, LINEAR_SIMPLE, PARITY_GROUPS
+from skills.info_gathering.evals.function_learning.functions import (
+    AES_FIELD_AFFINE,
+    BENT_INNER_PRODUCT,
+    JUNTA_3,
+    LINEAR_SIMPLE,
+    PARITY_GROUPS,
+    REED_MULLER_3,
+)
 
 
 def test_linear_evaluates_in_range() -> None:
@@ -55,14 +62,96 @@ def test_parity_groups_correct() -> None:
     assert PARITY_GROUPS.evaluate(0b11111111) == 0b0000
 
 
+def test_rm3_evaluates_in_range() -> None:
+    for x in REED_MULLER_3.all_inputs():
+        out = REED_MULLER_3.evaluate(x)
+        assert 0 <= out <= REED_MULLER_3.max_output
+
+
+def test_rm3_has_cubic_terms() -> None:
+    """The 3rd-order finite difference w.r.t. the cubic-term variables must be 1.
+
+    For output bit 0 (MSB), the cubic term is x0*x1*x2. Setting e_i = 1 << (n-1-i),
+    the 3rd-order derivative D_{e0}D_{e1}D_{e2}f_0 must equal 1 (the coefficient).
+    """
+    n = REED_MULLER_3.n
+    e0, e1, e2 = 1 << (n - 1), 1 << (n - 2), 1 << (n - 3)
+
+    def f0(x: int) -> int:
+        return REED_MULLER_3.evaluate(x) >> (REED_MULLER_3.m - 1)
+
+    derivative = f0(0) ^ f0(e0) ^ f0(e1) ^ f0(e2) ^ f0(e0 ^ e1) ^ f0(e0 ^ e2) ^ f0(e1 ^ e2) ^ f0(e0 ^ e1 ^ e2)
+    assert derivative == 1, "MSB output has no genuine degree-3 term"
+
+
+def test_bent_evaluates_in_range() -> None:
+    for x in BENT_INNER_PRODUCT.all_inputs():
+        out = BENT_INNER_PRODUCT.evaluate(x)
+        assert 0 <= out <= BENT_INNER_PRODUCT.max_output
+
+
+def test_bent_known_values() -> None:
+    """Spot-check specific input/output pairs derived from the inner product formula."""
+    # a=0 or b=0 -> all inner products 0 -> output 0.
+    assert BENT_INNER_PRODUCT.evaluate(0x00) == 0
+    assert BENT_INNER_PRODUCT.evaluate(0x10) == 0  # a=1, b=0
+    assert BENT_INNER_PRODUCT.evaluate(0x01) == 0  # a=0, b=1
+    # a=0xF, b=0xF: every rotation of 0xF in 4 bits is still 0xF, popcount=4 (even) -> 0.
+    assert BENT_INNER_PRODUCT.evaluate(0xFF) == 0
+    # a=1, b=1: only i=0 rotation gives nonzero inner product (1&1=1, popcount=1 odd).
+    assert BENT_INNER_PRODUCT.evaluate(0x11) == 0b1000
+
+
+def test_bent_linear_probing_yields_nothing() -> None:
+    """Querying 0 and all powers of 2 gives output 0 for every query.
+
+    This confirms the standard linear probing strategy is useless: when either
+    the top half (a) or the bottom half (b) of x is 0, every inner product is 0.
+    """
+    probes = [0] + [1 << i for i in range(BENT_INNER_PRODUCT.n)]
+    for x in probes:
+        assert BENT_INNER_PRODUCT.evaluate(x) == 0, f"Expected 0 for probe x={x:#x}"
+
+
+def test_aes_affine_evaluates_in_range() -> None:
+    for x in AES_FIELD_AFFINE.all_inputs():
+        out = AES_FIELD_AFFINE.evaluate(x)
+        assert 0 <= out <= AES_FIELD_AFFINE.max_output
+
+
+def test_aes_affine_known_values() -> None:
+    """Spot-check values derived from alpha=0x57, beta=0x83."""
+    # f(0) = beta & 0xF = 0x83 & 0xF = 3.
+    assert AES_FIELD_AFFINE.evaluate(0) == 3
+    # f(1) = (alpha XOR beta) & 0xF = 0xD4 & 0xF = 4.
+    assert AES_FIELD_AFFINE.evaluate(1) == 4
+    # f(2) = (xtime(alpha) XOR beta) & 0xF = (0xAE XOR 0x83) & 0xF = 0x2D & 0xF = 13.
+    assert AES_FIELD_AFFINE.evaluate(2) == 13
+
+
+def test_aes_affine_is_affine() -> None:
+    """f(x XOR y) = f(x) XOR f(y) XOR f(0) because GF(2^8) mult by a constant is linear."""
+    f0 = AES_FIELD_AFFINE.evaluate(0)
+    inputs = AES_FIELD_AFFINE.all_inputs()
+    for x in inputs[:16]:
+        for y in inputs[:16]:
+            fx = AES_FIELD_AFFINE.evaluate(x)
+            fy = AES_FIELD_AFFINE.evaluate(y)
+            fxy = AES_FIELD_AFFINE.evaluate(x ^ y)
+            assert fxy == fx ^ fy ^ f0, f"Affine property failed for x={x}, y={y}"
+
+
 def test_all_functions_have_correct_dimensions() -> None:
-    for fn in [LINEAR_SIMPLE, JUNTA_3, PARITY_GROUPS]:
+    for fn in [LINEAR_SIMPLE, JUNTA_3, PARITY_GROUPS, BENT_INNER_PRODUCT, AES_FIELD_AFFINE]:
         assert fn.n == 8
         assert fn.m == 4
         assert len(fn.all_inputs()) == 256
         for x in fn.all_inputs():
             out = fn.evaluate(x)
             assert 0 <= out <= fn.max_output, f"{fn.name}: output {out} out of range for input {x}"
+    assert REED_MULLER_3.n == 7
+    assert REED_MULLER_3.m == 4
+    assert len(REED_MULLER_3.all_inputs()) == 128
 
 
 if __name__ == "__main__":

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -1,15 +1,19 @@
 """Prompt-caching Anthropic client for autogen evals.
 
 autogen's AnthropicChatCompletionClient doesn't forward cache_control to the
-Anthropic API. This module provides a subclass that injects cache_control
-markers on the system message and the last conversation message.
+Anthropic API. This module provides a subclass that injects a top-level
+cache_control marker and surfaces cache token counts through RequestUsage.
 
 See function_learning/debug/prompt_caching.md for the full investigation.
 """
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
+from autogen_core import CancellationToken
+from autogen_core.models import CreateResult
+from autogen_core.tools import Tool, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
 
 logger = logging.getLogger(__name__)
@@ -23,21 +27,31 @@ _ANTHROPIC_MODEL_INFO: dict[str, Any] = {
     "multiple_system_messages": False,
 }
 
-_CACHE_CONTROL = {"type": "ephemeral"}
-
 
 class CachedAnthropicClient(AnthropicChatCompletionClient):
     """AnthropicChatCompletionClient with prompt caching enabled.
 
-    Places cache_control on the system message AND the last conversation message.
-    Haiku 4.5's minimum cacheable prefix is ~4096 tokens (not 1024 as documented).
-    The system prompt alone (~1500 tokens) won't cache, but the growing conversation
-    prefix caches from ~turn 5 onwards.
+    Injects top-level cache_control={"type":"ephemeral"} on every request so
+    the Anthropic API automatically places the cache breakpoint at the last
+    cacheable block and moves it forward as the conversation grows.
+
+    Also captures cache_creation_input_tokens and cache_read_input_tokens from
+    the raw Anthropic response and attaches them to the returned RequestUsage
+    as dynamic attributes (cache_creation_tokens, cache_read_tokens), since
+    autogen's RequestUsage dataclass only has prompt_tokens/completion_tokens.
+
+    Caching behavior confirmed via live API testing (2026-03-28):
+    - Anthropic does NOT auto-cache without cache_control (unlike OpenAI)
+    - Top-level cache_control works: first call creates cache, subsequent calls read it
+    - Per-block cache_control (old approach) creates a new cache entry every call
+    - Haiku 4.5 minimum cacheable prefix: 4096 tokens
     """
 
     def __init__(self, *, model: str, **kwargs: Any) -> None:
         kwargs.setdefault("model_info", _ANTHROPIC_MODEL_INFO)
         super().__init__(model=model, **kwargs)
+        self._last_cache_read: int = 0
+        self._last_cache_creation: int = 0
         self._wrap_messages_create()
 
     def _wrap_messages_create(self) -> None:
@@ -46,39 +60,36 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
             return
         original_create = raw_client.messages.create
 
-        async def cached_create(
-            *, model: str, messages: list[dict], max_tokens: int, system: Any = None, **rest: Any
-        ) -> object:
-            return await original_create(
-                model=model,
-                messages=_add_cache_to_last_message(messages),
-                max_tokens=max_tokens,
-                system=_add_cache_to_system(system),
-                **rest,
-            )
+        async def cached_create(*, model: str, messages: list[dict], max_tokens: int, **rest: Any) -> object:
+            rest["cache_control"] = {"type": "ephemeral"}
+            response = await original_create(model=model, messages=messages, max_tokens=max_tokens, **rest)
+            # Capture cache tokens from the raw Anthropic Message.usage.
+            self._last_cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            self._last_cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            return response
 
         raw_client.messages.create = cached_create
 
-
-def _add_cache_to_system(system: Any) -> Any:
-    """Convert system string to content block with cache_control."""
-    if isinstance(system, str):
-        return [{"type": "text", "text": system, "cache_control": _CACHE_CONTROL}]
-    return system
-
-
-def _add_cache_to_last_message(messages: list[dict]) -> list[dict]:
-    """Place cache_control on the last content block of the last message."""
-    if not messages:
-        return messages
-    last_msg = messages[-1]
-    if not isinstance(last_msg, dict):
-        return messages
-    content = last_msg.get("content")
-    if isinstance(content, list) and content:
-        last_block = content[-1]
-        if isinstance(last_block, dict) and "cache_control" not in last_block:
-            last_block["cache_control"] = _CACHE_CONTROL
-    elif isinstance(content, str):
-        last_msg["content"] = [{"type": "text", "text": content, "cache_control": _CACHE_CONTROL}]
-    return messages
+    async def create(
+        self,
+        messages: Any,
+        *,
+        tools: Sequence[Tool | ToolSchema] = (),
+        tool_choice: Any = "auto",
+        json_output: Any = None,
+        extra_create_args: Any = None,
+        cancellation_token: CancellationToken | None = None,
+    ) -> CreateResult:
+        result = await super().create(
+            messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            json_output=json_output,
+            extra_create_args=extra_create_args or {},
+            cancellation_token=cancellation_token,
+        )
+        # Attach cache counts as dynamic attrs on the RequestUsage dataclass so
+        # callers can use getattr(result.usage, "cache_read_tokens", 0).
+        result.usage.cache_read_tokens = self._last_cache_read  # type: ignore[attr-defined]
+        result.usage.cache_creation_tokens = self._last_cache_creation  # type: ignore[attr-defined]
+        return result

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -2,11 +2,13 @@
 
 autogen's AnthropicChatCompletionClient doesn't forward cache_control to the
 Anthropic API. This module provides a subclass that injects a top-level
-cache_control marker and surfaces cache token counts through RequestUsage.
+cache_control marker, disables parallel tool use (so each turn has exactly one
+tool call), and surfaces cache token counts in a typed CreateResult subclass.
 
 See function_learning/debug/prompt_caching.md for the full investigation.
 """
 
+import asyncio
 import logging
 from collections.abc import Sequence
 from typing import Any
@@ -28,17 +30,22 @@ _ANTHROPIC_MODEL_INFO: dict[str, Any] = {
 }
 
 
+class CachedCreateResult(CreateResult):
+    """CreateResult extended with Anthropic prompt-caching token counts."""
+
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+
 class CachedAnthropicClient(AnthropicChatCompletionClient):
-    """AnthropicChatCompletionClient with prompt caching enabled.
+    """AnthropicChatCompletionClient with prompt caching and single-tool-call enforcement.
 
-    Injects top-level cache_control={"type":"ephemeral"} on every request so
-    the Anthropic API automatically places the cache breakpoint at the last
-    cacheable block and moves it forward as the conversation grows.
-
-    Also captures cache_creation_input_tokens and cache_read_input_tokens from
-    the raw Anthropic response and attaches them to the returned RequestUsage
-    as dynamic attributes (cache_creation_tokens, cache_read_tokens), since
-    autogen's RequestUsage dataclass only has prompt_tokens/completion_tokens.
+    - Injects top-level cache_control={"type":"ephemeral"} so the API places
+      the cache breakpoint at the last cacheable block each turn.
+    - Sets disable_parallel_tool_use=True on tool_choice so the model emits
+      exactly one tool call per turn.
+    - Returns CachedCreateResult with typed cache_read_tokens /
+      cache_creation_tokens instead of attaching dynamic attributes.
 
     Caching behavior confirmed via live API testing (2026-03-28):
     - Anthropic does NOT auto-cache without cache_control (unlike OpenAI)
@@ -50,8 +57,9 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
     def __init__(self, *, model: str, **kwargs: Any) -> None:
         kwargs.setdefault("model_info", _ANTHROPIC_MODEL_INFO)
         super().__init__(model=model, **kwargs)
-        self._last_cache_read: int = 0
-        self._last_cache_creation: int = 0
+        # Queue receives (cache_read, cache_creation) from the interceptor before
+        # create() returns, so get_nowait() is always safe after super().create().
+        self._cache_token_queue: asyncio.Queue[tuple[int, int]] = asyncio.Queue()
         self._wrap_messages_create()
 
     def _wrap_messages_create(self) -> None:
@@ -59,13 +67,18 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
         if raw_client is None:
             return
         original_create = raw_client.messages.create
+        queue = self._cache_token_queue
 
         async def cached_create(*, model: str, messages: list[dict], max_tokens: int, **rest: Any) -> object:
             rest["cache_control"] = {"type": "ephemeral"}
+            # Disable parallel tool use so the model emits exactly one tool call.
+            tc = rest.get("tool_choice")
+            if isinstance(tc, dict) and tc.get("type") == "any":
+                rest["tool_choice"] = {**tc, "disable_parallel_tool_use": True}
             response = await original_create(model=model, messages=messages, max_tokens=max_tokens, **rest)
-            # Capture cache tokens from the raw Anthropic Message.usage.
-            self._last_cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
-            self._last_cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            await queue.put((cache_read, cache_creation))
             return response
 
         raw_client.messages.create = cached_create
@@ -79,7 +92,7 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
         json_output: Any = None,
         extra_create_args: Any = None,
         cancellation_token: CancellationToken | None = None,
-    ) -> CreateResult:
+    ) -> CachedCreateResult:
         result = await super().create(
             messages,
             tools=tools,
@@ -88,8 +101,7 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
             extra_create_args=extra_create_args or {},
             cancellation_token=cancellation_token,
         )
-        # Attach cache counts as dynamic attrs on the RequestUsage dataclass so
-        # callers can use getattr(result.usage, "cache_read_tokens", 0).
-        result.usage.cache_read_tokens = self._last_cache_read  # type: ignore[attr-defined]
-        result.usage.cache_creation_tokens = self._last_cache_creation  # type: ignore[attr-defined]
-        return result
+        cache_read, cache_creation = self._cache_token_queue.get_nowait()
+        return CachedCreateResult(
+            **result.model_dump(), cache_read_tokens=cache_read, cache_creation_tokens=cache_creation
+        )


### PR DESCRIPTION
## Summary

- **New benchmark functions**: Add RM degree-3 (Reed-Muller), bent inner product, and GF(2^8) affine functions to the function learning eval — harder targets that test whether the agent can learn non-linear Boolean functions
- **Early termination**: End game immediately when Hamming loss reaches 0 (no point using remaining turns)
- **Refactors**: Move `turn_limit` from `Variant` to CLI arg; remove `Variant` abstraction (hint is now a CLI flag, exec_tool is non-nullable)
- **`run_all_evals.py`**: Batch runner with `--runs-per-cell N` for mean/std estimates, markdown report generation with cost projections for Haiku/Sonnet/Opus
- **Fix prompt caching**: Switch from per-block `cache_control` injection (which was creating a new cache entry every call, never reading) to top-level `cache_control={"type":"ephemeral"}`; capture cache tokens from raw Anthropic response and expose on `RequestUsage` as dynamic attrs

## Caching fix details

The previous per-block approach was broken: because the last message changes every turn, the cache key changed every call, so each call wrote a new entry and never got a cache read. Switching to top-level `cache_control` lets Anthropic manage the breakpoint automatically. Confirmed via live API tests (see `debug/prompt_caching.md`).

A 10-turn smoke test showed: `input=276, cache_read=616152, cache_create=34551` — caching is working.

## Test plan

- [ ] `bazel build //skills/info_gathering/evals/function_learning/...`
- [ ] `bazel test //skills/info_gathering/evals/function_learning:test_functions`
- [ ] `bazel test //skills/info_gathering/evals/function_learning:test_function_learning`
- [ ] Run a short eval with `--no-skill` and verify `cache_read_input_tokens > 0` in summary after turn ~5

https://claude.ai/code/session_01BiMHzYqjsSBvS3hWAcQn7q