### PR TITLE
Fix gnome-shell keybindings gvariant type syntax

### DIFF
--- a/nix/home/modules/gnome-shell-keybindings.nix
+++ b/nix/home/modules/gnome-shell-keybindings.nix
@@ -13,7 +13,7 @@
 #   https://github.com/pop-os/shell/blob/master_noble/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
 { lib, ... }:
 let
-  emptyStrArray = lib.hm.gvariant.mkEmptyArray (lib.hm.gvariant.type.string);
+  emptyStrArray = lib.hm.gvariant.mkEmptyArray lib.hm.gvariant.type.string;
 in
 {
   dconf.settings = {


### PR DESCRIPTION
## Summary
Fixed incorrect function call syntax in the gnome-shell keybindings configuration by removing unnecessary parentheses around the type argument.

## Changes
- Corrected `mkEmptyArray (lib.hm.gvariant.type.string)` to `mkEmptyArray lib.hm.gvariant.type.string` in the emptyStrArray definition
- This aligns with the proper Nix function application syntax where the type argument is passed directly without parentheses

## Details
The `mkEmptyArray` function expects a type argument passed as a direct parameter. The previous syntax with parentheses around the type was incorrect and has been fixed to follow the proper function call convention in Nix.

https://claude.ai/code/session_01AqTBKveqyQc4Q6bZ8xZ3j7