### PR TITLE
function learning: embed result/usage, pandas analyze, custom Anthropic client

### DIFF
--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -103,7 +103,10 @@ py_library(
     srcs = ["artifacts.py"],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
-    deps = ["@pypi//pydantic"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//requests",
+    ],
 )
 
 py_library(

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -2,10 +2,10 @@
 
 import base64
 import hashlib
-import urllib.request
 from collections.abc import Iterable
 from pathlib import Path
 
+import requests
 from pydantic import BaseModel, Field
 
 SOURCES_PATH = Path("npins/sources.json")
@@ -86,5 +86,6 @@ def file_sha256(path: Path) -> str:
 
 
 def url_sha256(url: str) -> str:
-    with urllib.request.urlopen(url) as response:
-        return _sha256_of_chunks(iter(lambda: response.read(65536), b""))
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        return _sha256_of_chunks(response.iter_content(65536))

--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -95,9 +95,9 @@ py_library(
     srcs = ["analyze.py"],
     imports = ["../../../.."],
     deps = [
-        ":functions",
         ":run_all_evals_lib",
-        "@pypi//numpy",
+        "@pypi//pandas",
+        "@pypi//pandas-stubs",
     ],
 )
 

--- a/skills/info_gathering/evals/function_learning/analyze.py
+++ b/skills/info_gathering/evals/function_learning/analyze.py
@@ -1,7 +1,7 @@
 """Analyze function learning eval results from a runs.jsonl file.
 
-Reads RunRecord lines, computes per-cell statistics with numpy, prints a
-summary table, and optionally writes a report.md.
+Reads RunRecord lines, computes per-cell statistics, prints a summary table,
+and optionally writes a report.md.
 
 Usage:
     bazel run //skills/info_gathering/evals/function_learning:analyze -- \\
@@ -9,15 +9,11 @@ Usage:
 """
 
 import argparse
-from collections import defaultdict
 from pathlib import Path
 
-import numpy as np
+import pandas as pd
 
-from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
 from skills.info_gathering.evals.function_learning.run_all_evals import RunRecord
-
-FUNCTIONS_LIST = list(FUNCTIONS.keys())
 
 # Pricing per million tokens: (input, output, cache_write, cache_read)
 _PRICING: dict[str, tuple[float, float, float, float]] = {
@@ -31,76 +27,92 @@ def load_records(path: Path) -> list[RunRecord]:
     return [RunRecord.model_validate_json(line) for line in path.read_text().splitlines() if line.strip()]
 
 
-def print_stats(records: list[RunRecord]) -> None:
-    models = sorted({r.model for r in records})
-    if len(models) > 1:
-        print(f"Models: {', '.join(models)}\n")
-    else:
-        print(f"Model: {models[0]}\n")
+def _records_to_df(records: list[RunRecord]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "function": r.function,
+            "arm": r.arm,
+            "model": r.model,
+            "loss": r.result.total_hamming_loss,
+            "turns": r.turns,
+            "solved": r.result.solved_at_turn is not None,
+            "input_tokens": r.usage.input_tokens,
+            "output_tokens": r.usage.output_tokens,
+            "cache_read": r.usage.cache_read_input_tokens,
+            "cache_write": r.usage.cache_creation_input_tokens,
+        }
+        for r in records
+    )
 
-    cells: dict[tuple[str, str], list[RunRecord]] = defaultdict(list)
-    for r in records:
-        cells[(r.function, r.arm)].append(r)
+
+def print_stats(records: list[RunRecord]) -> None:
+    df = _records_to_df(records)
+
+    models = sorted(df["model"].unique())
+    print(f"Model{'s' if len(models) > 1 else ''}: {', '.join(models)}\n")
+
+    stats = (
+        df.groupby(["function", "arm"])
+        .agg(
+            mean_loss=("loss", "mean"),
+            std_loss=("loss", "std"),
+            min_loss=("loss", "min"),
+            max_loss=("loss", "max"),
+            solved=("solved", "sum"),
+            n=("loss", "count"),
+            mean_turns=("turns", "mean"),
+        )
+        .reset_index()
+    )
 
     header = f"{'Function':<20} {'Arm':<10} {'Mean':>6} {'Std':>5} {'Min':>4} {'Max':>4} {'Solved':>7} {'Turns':>6}"
     print(header)
     print("-" * len(header))
-
-    for fn in FUNCTIONS_LIST:
-        for arm in ["skill", "no_skill"]:
-            runs = cells.get((fn, arm), [])
-            if not runs:
-                continue
-            losses = np.array([r.result.total_hamming_loss for r in runs])
-            turns = np.array([r.turns for r in runs])
-            solved = sum(1 for r in runs if r.result.solved_at_turn is not None)
-            print(
-                f"{fn:<20} {arm:<10} {losses.mean():>6.1f} {losses.std():>5.1f}"
-                f" {losses.min():>4} {losses.max():>4} {solved:>3}/{len(runs):<3} {turns.mean():>6.1f}"
-            )
+    for _, row in stats.iterrows():
+        print(
+            f"{row['function']:<20} {row['arm']:<10} {row['mean_loss']:>6.1f} {row['std_loss']:>5.1f}"
+            f" {int(row['min_loss']):>4} {int(row['max_loss']):>4}"
+            f" {int(row['solved']):>3}/{int(row['n']):<3} {row['mean_turns']:>6.1f}"
+        )
 
     print()
-    _print_skill_vs_noskill(cells)
+    _print_skill_vs_noskill(df)
     print()
-    _print_cost(records)
+    _print_cost(df)
 
 
-def _print_skill_vs_noskill(cells: dict[tuple[str, str], list[RunRecord]]) -> None:
+def _print_skill_vs_noskill(df: pd.DataFrame) -> None:
+    pivot = df.pivot_table(index="function", columns="arm", values="loss", aggfunc="mean")
     print(f"{'Function':<20} {'Skill loss':>10} {'No-skill loss':>13} {'Winner':<10}")
     print("-" * 58)
-    for fn in FUNCTIONS_LIST:
-        skill_runs = cells.get((fn, "skill"), [])
-        noskill_runs = cells.get((fn, "no_skill"), [])
-        if not skill_runs or not noskill_runs:
+    for fn, row in pivot.iterrows():
+        skill = row.get("skill", float("nan"))
+        noskill = row.get("no_skill", float("nan"))
+        if pd.isna(skill) or pd.isna(noskill):
             continue
-        skill_mean = np.mean([r.result.total_hamming_loss for r in skill_runs])
-        noskill_mean = np.mean([r.result.total_hamming_loss for r in noskill_runs])
-        winner = "skill" if skill_mean < noskill_mean else "no_skill" if noskill_mean < skill_mean else "tie"
-        print(f"{fn:<20} {skill_mean:>10.1f} {noskill_mean:>13.1f} {winner:<10}")
+        winner = "skill" if skill < noskill else "no_skill" if noskill < skill else "tie"
+        print(f"{fn:<20} {skill:>10.1f} {noskill:>13.1f} {winner:<10}")
 
 
-def _print_cost(records: list[RunRecord]) -> None:
-    inp = sum(r.usage.input_tokens for r in records)
-    out = sum(r.usage.output_tokens for r in records)
-    cr = sum(r.usage.cache_read_input_tokens for r in records)
-    cw = sum(r.usage.cache_creation_input_tokens for r in records)
+def _print_cost(df: pd.DataFrame) -> None:
+    inp = df["input_tokens"].sum()
+    out = df["output_tokens"].sum()
+    cr = df["cache_read"].sum()
+    cw = df["cache_write"].sum()
     print(f"  tokens: inp={inp:,} out={out:,} cache_write={cw:,} cache_read={cr:,}\n")
-
-    # Actual cost per model used in this run (grouped by model)
-    by_model: dict[str, list[RunRecord]] = defaultdict(list)
-    for r in records:
-        by_model[r.model].append(r)
 
     print(f"{'Model':<30} {'Actual':>8}  (projected)")
     print("-" * 55)
     for model, (ir, or_, cwr, crr) in _PRICING.items():
         projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
-        actual_records = by_model.get(model, [])
-        if actual_records:
-            ai = sum(r.usage.input_tokens for r in actual_records)
-            ao = sum(r.usage.output_tokens for r in actual_records)
-            acr = sum(r.usage.cache_read_input_tokens for r in actual_records)
-            acw = sum(r.usage.cache_creation_input_tokens for r in actual_records)
+        model_df = df[df["model"] == model]
+        if not model_df.empty:
+            ai, ao, acr, acw = (
+                model_df["input_tokens"].sum(),
+                model_df["output_tokens"].sum(),
+                model_df["cache_read"].sum(),
+                model_df["cache_write"].sum(),
+            )
             actual = ai / 1e6 * ir + ao / 1e6 * or_ + acw / 1e6 * cwr + acr / 1e6 * crr
             print(f"{model:<30} ${actual:>7.3f}  (${projected:.3f})")
         else:
@@ -108,9 +120,21 @@ def _print_cost(records: list[RunRecord]) -> None:
 
 
 def write_report(records: list[RunRecord], path: Path) -> None:
-    cells: dict[tuple[str, str], list[RunRecord]] = defaultdict(list)
-    for r in records:
-        cells[(r.function, r.arm)].append(r)
+    df = _records_to_df(records)
+
+    stats = (
+        df.groupby(["function", "arm"])
+        .agg(
+            mean_loss=("loss", "mean"),
+            std_loss=("loss", "std"),
+            min_loss=("loss", "min"),
+            max_loss=("loss", "max"),
+            solved=("solved", "sum"),
+            n=("loss", "count"),
+            mean_turns=("turns", "mean"),
+        )
+        .reset_index()
+    )
 
     lines: list[str] = [
         "# Function Learning Benchmark Results",
@@ -122,18 +146,11 @@ def write_report(records: list[RunRecord], path: Path) -> None:
         "| Function | Arm | Mean Loss | Std | Min | Max | Solved | Mean Turns |",
         "|----------|-----|----------:|----:|----:|----:|-------:|-----------:|",
     ]
-    for fn in FUNCTIONS_LIST:
-        for arm in ["skill", "no_skill"]:
-            runs = cells.get((fn, arm), [])
-            if not runs:
-                continue
-            losses = np.array([r.result.total_hamming_loss for r in runs])
-            turns = np.array([r.turns for r in runs])
-            solved = sum(1 for r in runs if r.result.solved_at_turn is not None)
-            lines.append(
-                f"| {fn} | {arm} | {losses.mean():.1f} | {losses.std():.1f}"
-                f" | {losses.min()} | {losses.max()} | {solved}/{len(runs)} | {turns.mean():.1f} |"
-            )
+    for _, row in stats.iterrows():
+        lines.append(
+            f"| {row['function']} | {row['arm']} | {row['mean_loss']:.1f} | {row['std_loss']:.1f}"
+            f" | {int(row['min_loss'])} | {int(row['max_loss'])} | {int(row['solved'])}/{int(row['n'])} | {row['mean_turns']:.1f} |"
+        )
 
     lines += [
         "",
@@ -142,22 +159,23 @@ def write_report(records: list[RunRecord], path: Path) -> None:
         "| Function | Skill | No-Skill | Winner |",
         "|----------|------:|---------:|--------|",
     ]
-    for fn in FUNCTIONS_LIST:
-        skill = cells.get((fn, "skill"), [])
-        noskill = cells.get((fn, "no_skill"), [])
-        if not skill or not noskill:
+    pivot = df.pivot_table(index="function", columns="arm", values="loss", aggfunc="mean")
+    for fn, row in pivot.iterrows():
+        skill = row.get("skill", float("nan"))
+        noskill = row.get("no_skill", float("nan"))
+        if pd.isna(skill) or pd.isna(noskill):
             continue
-        sm = np.mean([r.result.total_hamming_loss for r in skill])
-        nm = np.mean([r.result.total_hamming_loss for r in noskill])
-        winner = "skill" if sm < nm else "no_skill" if nm < sm else "tie"
-        lines.append(f"| {fn} | {sm:.1f} | {nm:.1f} | {winner} |")
+        winner = "skill" if skill < noskill else "no_skill" if noskill < skill else "tie"
+        lines.append(f"| {fn} | {skill:.1f} | {noskill:.1f} | {winner} |")
 
-    lines += ["", "## Token Usage & Cost", ""]
-    inp = sum(r.usage.input_tokens for r in records)
-    out = sum(r.usage.output_tokens for r in records)
-    cr = sum(r.usage.cache_read_input_tokens for r in records)
-    cw = sum(r.usage.cache_creation_input_tokens for r in records)
+    inp = df["input_tokens"].sum()
+    out = df["output_tokens"].sum()
+    cr = df["cache_read"].sum()
+    cw = df["cache_write"].sum()
     lines += [
+        "",
+        "## Token Usage & Cost",
+        "",
         f"Input tokens: {inp:,}  ",
         f"Output tokens: {out:,}  ",
         f"Cache write tokens: {cw:,}  ",

--- a/skills/info_gathering/evals/function_learning/analyze.py
+++ b/skills/info_gathering/evals/function_learning/analyze.py
@@ -51,9 +51,9 @@ def print_stats(records: list[RunRecord]) -> None:
             runs = cells.get((fn, arm), [])
             if not runs:
                 continue
-            losses = np.array([r.total_hamming_loss for r in runs])
+            losses = np.array([r.result.total_hamming_loss for r in runs])
             turns = np.array([r.turns for r in runs])
-            solved = sum(1 for r in runs if r.solved_at_turn is not None)
+            solved = sum(1 for r in runs if r.result.solved_at_turn is not None)
             print(
                 f"{fn:<20} {arm:<10} {losses.mean():>6.1f} {losses.std():>5.1f}"
                 f" {losses.min():>4} {losses.max():>4} {solved:>3}/{len(runs):<3} {turns.mean():>6.1f}"
@@ -73,17 +73,17 @@ def _print_skill_vs_noskill(cells: dict[tuple[str, str], list[RunRecord]]) -> No
         noskill_runs = cells.get((fn, "no_skill"), [])
         if not skill_runs or not noskill_runs:
             continue
-        skill_mean = np.mean([r.total_hamming_loss for r in skill_runs])
-        noskill_mean = np.mean([r.total_hamming_loss for r in noskill_runs])
+        skill_mean = np.mean([r.result.total_hamming_loss for r in skill_runs])
+        noskill_mean = np.mean([r.result.total_hamming_loss for r in noskill_runs])
         winner = "skill" if skill_mean < noskill_mean else "no_skill" if noskill_mean < skill_mean else "tie"
         print(f"{fn:<20} {skill_mean:>10.1f} {noskill_mean:>13.1f} {winner:<10}")
 
 
 def _print_cost(records: list[RunRecord]) -> None:
-    inp = sum(r.input_tokens for r in records)
-    out = sum(r.output_tokens for r in records)
-    cr = sum(r.cache_read_tokens for r in records)
-    cw = sum(r.cache_creation_tokens for r in records)
+    inp = sum(r.usage.input_tokens for r in records)
+    out = sum(r.usage.output_tokens for r in records)
+    cr = sum(r.usage.cache_read_input_tokens for r in records)
+    cw = sum(r.usage.cache_creation_input_tokens for r in records)
     print(f"  tokens: inp={inp:,} out={out:,} cache_write={cw:,} cache_read={cr:,}\n")
 
     # Actual cost per model used in this run (grouped by model)
@@ -94,17 +94,16 @@ def _print_cost(records: list[RunRecord]) -> None:
     print(f"{'Model':<30} {'Actual':>8}  (projected)")
     print("-" * 55)
     for model, (ir, or_, cwr, crr) in _PRICING.items():
+        projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
         actual_records = by_model.get(model, [])
         if actual_records:
-            ai = sum(r.input_tokens for r in actual_records)
-            ao = sum(r.output_tokens for r in actual_records)
-            acr = sum(r.cache_read_tokens for r in actual_records)
-            acw = sum(r.cache_creation_tokens for r in actual_records)
+            ai = sum(r.usage.input_tokens for r in actual_records)
+            ao = sum(r.usage.output_tokens for r in actual_records)
+            acr = sum(r.usage.cache_read_input_tokens for r in actual_records)
+            acw = sum(r.usage.cache_creation_input_tokens for r in actual_records)
             actual = ai / 1e6 * ir + ao / 1e6 * or_ + acw / 1e6 * cwr + acr / 1e6 * crr
-            projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
             print(f"{model:<30} ${actual:>7.3f}  (${projected:.3f})")
         else:
-            projected = inp / 1e6 * ir + out / 1e6 * or_ + cw / 1e6 * cwr + cr / 1e6 * crr
             print(f"{model:<30} {'—':>8}  (${projected:.3f})")
 
 
@@ -128,9 +127,9 @@ def write_report(records: list[RunRecord], path: Path) -> None:
             runs = cells.get((fn, arm), [])
             if not runs:
                 continue
-            losses = np.array([r.total_hamming_loss for r in runs])
+            losses = np.array([r.result.total_hamming_loss for r in runs])
             turns = np.array([r.turns for r in runs])
-            solved = sum(1 for r in runs if r.solved_at_turn is not None)
+            solved = sum(1 for r in runs if r.result.solved_at_turn is not None)
             lines.append(
                 f"| {fn} | {arm} | {losses.mean():.1f} | {losses.std():.1f}"
                 f" | {losses.min()} | {losses.max()} | {solved}/{len(runs)} | {turns.mean():.1f} |"
@@ -148,16 +147,16 @@ def write_report(records: list[RunRecord], path: Path) -> None:
         noskill = cells.get((fn, "no_skill"), [])
         if not skill or not noskill:
             continue
-        sm = np.mean([r.total_hamming_loss for r in skill])
-        nm = np.mean([r.total_hamming_loss for r in noskill])
+        sm = np.mean([r.result.total_hamming_loss for r in skill])
+        nm = np.mean([r.result.total_hamming_loss for r in noskill])
         winner = "skill" if sm < nm else "no_skill" if nm < sm else "tie"
         lines.append(f"| {fn} | {sm:.1f} | {nm:.1f} | {winner} |")
 
     lines += ["", "## Token Usage & Cost", ""]
-    inp = sum(r.input_tokens for r in records)
-    out = sum(r.output_tokens for r in records)
-    cr = sum(r.cache_read_tokens for r in records)
-    cw = sum(r.cache_creation_tokens for r in records)
+    inp = sum(r.usage.input_tokens for r in records)
+    out = sum(r.usage.output_tokens for r in records)
+    cr = sum(r.usage.cache_read_input_tokens for r in records)
+    cw = sum(r.usage.cache_creation_input_tokens for r in records)
     lines += [
         f"Input tokens: {inp:,}  ",
         f"Output tokens: {out:,}  ",

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -41,7 +41,7 @@ from skills.info_gathering.evals.function_learning.result_types import (
     TurnResult,
 )
 from skills.info_gathering.evals.function_learning.scoring import EVAL_TIMEOUT_S, evaluate_program
-from skills.info_gathering.evals.prompt_caching import CachedAnthropicClient
+from skills.info_gathering.evals.prompt_caching import CachedAnthropicClient, CachedCreateResult
 from skills.info_gathering.evals.twenty_questions.prompts import load_skill_prompt
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths
 
@@ -77,8 +77,8 @@ class LlmResponseLog(BaseModel):
     tool_calls: list[FunctionCallLog] | None
     input_tokens: int
     output_tokens: int
-    cache_read_tokens: int
-    cache_creation_tokens: int
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
 
 
 class ToolResultLog(BaseModel):
@@ -260,13 +260,12 @@ async def run_game(
                 break
 
             result = await model_client.create(history, tools=tool_schemas, tool_choice="required")
+            assert isinstance(result, CachedCreateResult), f"expected CachedCreateResult, got {type(result)}"
 
-            cache_read = getattr(result, "cache_read_tokens", 0)
-            cache_creation = getattr(result, "cache_creation_tokens", 0)
             game.total_input_tokens += result.usage.prompt_tokens
             game.total_output_tokens += result.usage.completion_tokens
-            game.total_cache_read_tokens += cache_read
-            game.total_cache_creation_tokens += cache_creation
+            game.total_cache_read_tokens += result.cache_read_tokens or 0
+            game.total_cache_creation_tokens += result.cache_creation_tokens or 0
 
             if isinstance(result.content, str):
                 game.log(
@@ -276,8 +275,10 @@ async def run_game(
                         tool_calls=None,
                         input_tokens=result.usage.prompt_tokens,
                         output_tokens=result.usage.completion_tokens,
-                        cache_read_tokens=cache_read,
-                        cache_creation_tokens=cache_creation,
+                        cache_read_tokens=result.cache_read_tokens if isinstance(result, CachedCreateResult) else None,
+                        cache_creation_tokens=result.cache_creation_tokens
+                        if isinstance(result, CachedCreateResult)
+                        else None,
                     )
                 )
                 history.append(AssistantMessage(content=result.content, source="agent"))
@@ -294,8 +295,8 @@ async def run_game(
                     ],
                     input_tokens=result.usage.prompt_tokens,
                     output_tokens=result.usage.completion_tokens,
-                    cache_read_tokens=cache_read,
-                    cache_creation_tokens=cache_creation,
+                    cache_read_tokens=result.cache_read_tokens,
+                    cache_creation_tokens=result.cache_creation_tokens,
                 )
             )
             history.append(AssistantMessage(content=function_calls, source="agent"))

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from skills.info_gathering.evals.docker_exec import scratch_exec_server
 from skills.info_gathering.evals.function_learning.function_learning import make_exec_tool, run_game
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
+from skills.info_gathering.evals.function_learning.result_types import FunctionLearningResult, TokenUsage
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +26,9 @@ class RunRecord(BaseModel):
     arm: str  # "skill" or "no_skill"
     run_idx: int
     model: str
-    total_hamming_loss: int
-    per_turn_losses: list[int]
-    solved_at_turn: int | None
     turns: int
-    input_tokens: int
-    output_tokens: int
-    cache_read_tokens: int
-    cache_creation_tokens: int
+    result: FunctionLearningResult
+    usage: TokenUsage
 
 
 async def run_one(
@@ -67,17 +63,12 @@ async def run_one(
                 arm=arm,
                 run_idx=run_idx,
                 model=summary.model,
-                total_hamming_loss=summary.result.total_hamming_loss,
-                per_turn_losses=summary.result.per_turn_losses,
-                solved_at_turn=summary.result.solved_at_turn,
                 turns=summary.turns,
-                input_tokens=summary.usage.input_tokens,
-                output_tokens=summary.usage.output_tokens,
-                cache_read_tokens=summary.usage.cache_read_input_tokens,
-                cache_creation_tokens=summary.usage.cache_creation_input_tokens,
+                result=summary.result,
+                usage=summary.usage,
             )
             print(
-                f"  DONE  {label} loss={record.total_hamming_loss} turns={record.turns} solved={record.solved_at_turn}",
+                f"  DONE  {label} loss={record.result.total_hamming_loss} turns={record.turns} solved={record.result.solved_at_turn}",
                 flush=True,
             )
             return record

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -11,12 +11,12 @@ See function_learning/debug/prompt_caching.md for the full investigation.
 
 import json
 import logging
-from collections.abc import Sequence
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
 
 from anthropic.types import Usage
 from autogen_core import CancellationToken
-from autogen_core.models import CreateResult, FunctionCall, FunctionExecutionResultMessage, RequestUsage
+from autogen_core.models import CreateResult, FunctionCall, FunctionExecutionResultMessage, LLMMessage, RequestUsage
 from autogen_core.tools import Tool, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
 from autogen_ext.models.anthropic._anthropic_client import (
@@ -25,6 +25,7 @@ from autogen_ext.models.anthropic._anthropic_client import (
     normalize_stop_reason,
     to_anthropic_type,
 )
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +42,8 @@ _ANTHROPIC_MODEL_INFO: dict[str, Any] = {
 class CachedCreateResult(CreateResult):
     """CreateResult extended with Anthropic prompt-caching token counts."""
 
-    cache_read_tokens: int = 0
-    cache_creation_tokens: int = 0
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
 
 
 class CachedAnthropicClient(AnthropicChatCompletionClient):
@@ -71,12 +72,12 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
 
     async def create(
         self,
-        messages: Any,
+        messages: Sequence[LLMMessage],
         *,
         tools: Sequence[Tool | ToolSchema] = (),
-        tool_choice: Any = "auto",
-        json_output: Any = None,
-        extra_create_args: Any = None,
+        tool_choice: Tool | Literal["auto", "required", "none"] = "auto",
+        json_output: bool | type[BaseModel] | None = None,
+        extra_create_args: Mapping[str, Any] | None = None,
         cancellation_token: CancellationToken | None = None,
     ) -> CachedCreateResult:
         system_message = None
@@ -94,6 +95,7 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
 
         request_args: dict[str, Any] = {
             **self._create_args,
+            **(extra_create_args or {}),
             "messages": anthropic_messages,
             "max_tokens": self._create_args.get("max_tokens", 4096),
             "cache_control": {"type": "ephemeral"},
@@ -137,10 +139,6 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
             content=content,
             usage=usage,
             cached=False,
-            cache_read_tokens=response.usage.cache_read_input_tokens
-            if response.usage.cache_read_input_tokens is not None
-            else 0,
-            cache_creation_tokens=response.usage.cache_creation_input_tokens
-            if response.usage.cache_creation_input_tokens is not None
-            else 0,
+            cache_read_tokens=response.usage.cache_read_input_tokens,
+            cache_creation_tokens=response.usage.cache_creation_input_tokens,
         )

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -20,7 +20,6 @@ from autogen_core.models import CreateResult, FunctionCall, FunctionExecutionRes
 from autogen_core.tools import Tool, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
 from autogen_ext.models.anthropic._anthropic_client import (
-    _add_usage,
     convert_tool_choice_anthropic,
     convert_tools,
     normalize_stop_reason,
@@ -131,16 +130,17 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
         else:
             content = "".join(b.text for b in response.content if b.type == "text")
 
-        usage = RequestUsage(prompt_tokens=response.usage.input_tokens, completion_tokens=response.usage.output_tokens)
-        self._total_usage = _add_usage(self._total_usage, usage)
-        self._actual_usage = _add_usage(self._actual_usage, usage)
-
         assert isinstance(response.usage, Usage)
+        usage = RequestUsage(prompt_tokens=response.usage.input_tokens, completion_tokens=response.usage.output_tokens)
         return CachedCreateResult(
             finish_reason=normalize_stop_reason(response.stop_reason),
             content=content,
             usage=usage,
             cached=False,
-            cache_read_tokens=response.usage.cache_read_input_tokens or 0,
-            cache_creation_tokens=response.usage.cache_creation_input_tokens or 0,
+            cache_read_tokens=response.usage.cache_read_input_tokens
+            if response.usage.cache_read_input_tokens is not None
+            else 0,
+            cache_creation_tokens=response.usage.cache_creation_input_tokens
+            if response.usage.cache_creation_input_tokens is not None
+            else 0,
         )

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -8,11 +8,11 @@ tool call), and surfaces cache token counts in a typed CreateResult subclass.
 See function_learning/debug/prompt_caching.md for the full investigation.
 """
 
-import asyncio
 import logging
 from collections.abc import Sequence
 from typing import Any
 
+from anthropic.types import Usage
 from autogen_core import CancellationToken
 from autogen_core.models import CreateResult
 from autogen_core.tools import Tool, ToolSchema
@@ -57,31 +57,6 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
     def __init__(self, *, model: str, **kwargs: Any) -> None:
         kwargs.setdefault("model_info", _ANTHROPIC_MODEL_INFO)
         super().__init__(model=model, **kwargs)
-        # Queue receives (cache_read, cache_creation) from the interceptor before
-        # create() returns, so get_nowait() is always safe after super().create().
-        self._cache_token_queue: asyncio.Queue[tuple[int, int]] = asyncio.Queue()
-        self._wrap_messages_create()
-
-    def _wrap_messages_create(self) -> None:
-        raw_client = getattr(self, "_client", None)
-        if raw_client is None:
-            return
-        original_create = raw_client.messages.create
-        queue = self._cache_token_queue
-
-        async def cached_create(*, model: str, messages: list[dict], max_tokens: int, **rest: Any) -> object:
-            rest["cache_control"] = {"type": "ephemeral"}
-            # Disable parallel tool use so the model emits exactly one tool call.
-            tc = rest.get("tool_choice")
-            if isinstance(tc, dict) and tc.get("type") == "any":
-                rest["tool_choice"] = {**tc, "disable_parallel_tool_use": True}
-            response = await original_create(model=model, messages=messages, max_tokens=max_tokens, **rest)
-            cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
-            cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
-            await queue.put((cache_read, cache_creation))
-            return response
-
-        raw_client.messages.create = cached_create
 
     async def create(
         self,
@@ -93,15 +68,43 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
         extra_create_args: Any = None,
         cancellation_token: CancellationToken | None = None,
     ) -> CachedCreateResult:
-        result = await super().create(
-            messages,
-            tools=tools,
-            tool_choice=tool_choice,
-            json_output=json_output,
-            extra_create_args=extra_create_args or {},
-            cancellation_token=cancellation_token,
-        )
-        cache_read, cache_creation = self._cache_token_queue.get_nowait()
+        raw_client = getattr(self, "_client", None)
+        original_create = raw_client.messages.create if raw_client is not None else None
+        captured: tuple[int, int] = (0, 0)
+
+        if original_create is not None:
+
+            async def intercepted(*, model: str, messages: list[dict], max_tokens: int, **rest: Any) -> object:
+                nonlocal captured
+                rest["cache_control"] = {"type": "ephemeral"}
+                # Disable parallel tool use so the model emits exactly one tool call.
+                tc = rest.get("tool_choice")
+                if isinstance(tc, dict) and tc.get("type") == "any":
+                    rest["tool_choice"] = {**tc, "disable_parallel_tool_use": True}
+                response = await original_create(model=model, messages=messages, max_tokens=max_tokens, **rest)
+                assert isinstance(response.usage, Usage)
+                captured = (
+                    response.usage.cache_read_input_tokens or 0,
+                    response.usage.cache_creation_input_tokens or 0,
+                )
+                return response
+
+            raw_client.messages.create = intercepted
+
+        try:
+            result = await super().create(
+                messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                json_output=json_output,
+                extra_create_args=extra_create_args or {},
+                cancellation_token=cancellation_token,
+            )
+        finally:
+            if original_create is not None:
+                raw_client.messages.create = original_create
+
+        cache_read, cache_creation = captured
         return CachedCreateResult(
             **result.model_dump(), cache_read_tokens=cache_read, cache_creation_tokens=cache_creation
         )

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -1,22 +1,31 @@
 """Prompt-caching Anthropic client for autogen evals.
 
-autogen's AnthropicChatCompletionClient doesn't forward cache_control to the
-Anthropic API. This module provides a subclass that injects a top-level
-cache_control marker, disables parallel tool use (so each turn has exactly one
-tool call), and surfaces cache token counts in a typed CreateResult subclass.
+autogen's AnthropicChatCompletionClient doesn't surface cache token counts or
+enforce single-tool-call-per-turn. This module provides a subclass that overrides
+create() to call the raw Anthropic API directly, injecting cache_control and
+disable_parallel_tool_use, then returning a CachedCreateResult with typed cache
+token fields.
 
 See function_learning/debug/prompt_caching.md for the full investigation.
 """
 
+import json
 import logging
 from collections.abc import Sequence
 from typing import Any
 
 from anthropic.types import Usage
 from autogen_core import CancellationToken
-from autogen_core.models import CreateResult
+from autogen_core.models import CreateResult, FunctionCall, FunctionExecutionResultMessage, RequestUsage
 from autogen_core.tools import Tool, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
+from autogen_ext.models.anthropic._anthropic_client import (
+    _add_usage,
+    convert_tool_choice_anthropic,
+    convert_tools,
+    normalize_stop_reason,
+    to_anthropic_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +49,15 @@ class CachedCreateResult(CreateResult):
 class CachedAnthropicClient(AnthropicChatCompletionClient):
     """AnthropicChatCompletionClient with prompt caching and single-tool-call enforcement.
 
+    Overrides create() to call self._client.messages.create() directly, giving
+    clean access to cache token counts without any monkey-patching.
+
     - Injects top-level cache_control={"type":"ephemeral"} so the API places
       the cache breakpoint at the last cacheable block each turn.
     - Sets disable_parallel_tool_use=True on tool_choice so the model emits
       exactly one tool call per turn.
     - Returns CachedCreateResult with typed cache_read_tokens /
-      cache_creation_tokens instead of attaching dynamic attributes.
+      cache_creation_tokens.
 
     Caching behavior confirmed via live API testing (2026-03-28):
     - Anthropic does NOT auto-cache without cache_control (unlike OpenAI)
@@ -68,43 +80,67 @@ class CachedAnthropicClient(AnthropicChatCompletionClient):
         extra_create_args: Any = None,
         cancellation_token: CancellationToken | None = None,
     ) -> CachedCreateResult:
-        raw_client = getattr(self, "_client", None)
-        original_create = raw_client.messages.create if raw_client is not None else None
-        captured: tuple[int, int] = (0, 0)
+        system_message = None
+        anthropic_messages: list[Any] = []
+        for msg in messages:
+            converted = to_anthropic_type(msg)
+            if isinstance(converted, str):  # SystemMessage
+                system_message = converted
+            elif isinstance(converted, list):  # FunctionExecutionResultMessage
+                anthropic_messages.extend(converted)
+            else:
+                anthropic_messages.append(converted)
 
-        if original_create is not None:
+        has_tool_results = any(isinstance(msg, FunctionExecutionResultMessage) for msg in messages)
 
-            async def intercepted(*, model: str, messages: list[dict], max_tokens: int, **rest: Any) -> object:
-                nonlocal captured
-                rest["cache_control"] = {"type": "ephemeral"}
-                # Disable parallel tool use so the model emits exactly one tool call.
-                tc = rest.get("tool_choice")
-                if isinstance(tc, dict) and tc.get("type") == "any":
-                    rest["tool_choice"] = {**tc, "disable_parallel_tool_use": True}
-                response = await original_create(model=model, messages=messages, max_tokens=max_tokens, **rest)
-                assert isinstance(response.usage, Usage)
-                captured = (
-                    response.usage.cache_read_input_tokens or 0,
-                    response.usage.cache_creation_input_tokens or 0,
+        request_args: dict[str, Any] = {
+            **self._create_args,
+            "messages": anthropic_messages,
+            "max_tokens": self._create_args.get("max_tokens", 4096),
+            "cache_control": {"type": "ephemeral"},
+        }
+        if system_message is not None:
+            request_args["system"] = system_message
+
+        if tools:
+            converted_tools = convert_tools(tools)
+            self._last_used_tools = converted_tools
+            request_args["tools"] = converted_tools
+        elif has_tool_results:
+            request_args["tools"] = self._last_used_tools
+
+        if tools or has_tool_results:
+            tc = convert_tool_choice_anthropic(tool_choice)
+            # Disable parallel tool use so the model emits exactly one tool call per turn.
+            if isinstance(tc, dict) and tc.get("type") == "any":
+                tc = {**tc, "disable_parallel_tool_use": True}
+            request_args["tool_choice"] = tc
+
+        response = await self._client.messages.create(**request_args)
+
+        tool_uses = [b for b in response.content if b.type == "tool_use"]
+        if tool_uses:
+            content: str | list[FunctionCall] = [
+                FunctionCall(
+                    id=b.id,
+                    name=b.name,
+                    arguments=json.dumps(b.input) if isinstance(b.input, dict) else str(b.input or ""),
                 )
-                return response
+                for b in tool_uses
+            ]
+        else:
+            content = "".join(b.text for b in response.content if b.type == "text")
 
-            raw_client.messages.create = intercepted
+        usage = RequestUsage(prompt_tokens=response.usage.input_tokens, completion_tokens=response.usage.output_tokens)
+        self._total_usage = _add_usage(self._total_usage, usage)
+        self._actual_usage = _add_usage(self._actual_usage, usage)
 
-        try:
-            result = await super().create(
-                messages,
-                tools=tools,
-                tool_choice=tool_choice,
-                json_output=json_output,
-                extra_create_args=extra_create_args or {},
-                cancellation_token=cancellation_token,
-            )
-        finally:
-            if original_create is not None:
-                raw_client.messages.create = original_create
-
-        cache_read, cache_creation = captured
+        assert isinstance(response.usage, Usage)
         return CachedCreateResult(
-            **result.model_dump(), cache_read_tokens=cache_read, cache_creation_tokens=cache_creation
+            finish_reason=normalize_stop_reason(response.stop_reason),
+            content=content,
+            usage=usage,
+            cached=False,
+            cache_read_tokens=response.usage.cache_read_input_tokens or 0,
+            cache_creation_tokens=response.usage.cache_creation_input_tokens or 0,
         )


### PR DESCRIPTION
## Summary

- **`RunRecord` cleanup**: embed `FunctionLearningResult` and `TokenUsage` directly instead of flattening all fields; construction and access sites updated
- **`prompt_caching` custom client**: override `create()` to call `self._client.messages.create()` directly using autogen_ext's conversion helpers (`to_anthropic_type`, `convert_tools`, etc.) — no monkey-patching, no side channels, clean direct access to `response.usage.cache_read_input_tokens`
- **`analyze.py` rewrite**: replace numpy + manual `defaultdict(list)` groupby with pandas `groupby/agg` and `pivot_table` for skill-vs-no_skill comparison
- **`url_sha256`**: use `requests` instead of `urllib.request.urlopen` (drops `# noqa: S310`)

## Test plan

- [ ] `bazel build //skills/info_gathering/evals/function_learning/...`
- [ ] `bazel test //skills/info_gathering/evals/function_learning:test_function_learning`
- [ ] Run `analyze` against an existing `runs.jsonl` to verify stats table and pivot output

https://claude.ai/code/session_01BiMHzYqjsSBvS3hWAcQn7q