### PR TITLE
Fix import paths and dependency naming in prompt caching module

### DIFF
--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -97,7 +97,7 @@ py_library(
     deps = [
         ":run_all_evals_lib",
         "@pypi//pandas",
-        "@pypi//pandas-stubs",
+        "@pypi//pandas_stubs",
     ],
 )
 

--- a/skills/info_gathering/evals/prompt_caching.py
+++ b/skills/info_gathering/evals/prompt_caching.py
@@ -15,8 +15,8 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 from anthropic.types import Usage
-from autogen_core import CancellationToken
-from autogen_core.models import CreateResult, FunctionCall, FunctionExecutionResultMessage, LLMMessage, RequestUsage
+from autogen_core import CancellationToken, FunctionCall
+from autogen_core.models import CreateResult, FunctionExecutionResultMessage, LLMMessage, RequestUsage
 from autogen_core.tools import Tool, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
 from autogen_ext.models.anthropic._anthropic_client import (


### PR DESCRIPTION
## Summary
This PR fixes import organization and corrects a dependency name reference in the prompt caching evaluation module.

## Key Changes
- **Import reorganization**: Moved `FunctionCall` import from `autogen_core.models` to `autogen_core` in `prompt_caching.py`, aligning with the correct module structure
- **Dependency naming**: Corrected the Bazel dependency reference from `pandas-stubs` to `pandas_stubs` to match the actual package naming convention

## Implementation Details
The changes ensure that:
1. The `FunctionCall` class is imported from its proper location in the `autogen_core` package
2. The `RequestUsage` import remains in `autogen_core.models` where it belongs
3. Bazel build dependencies use the correct underscore-based naming for the pandas type stubs package

https://claude.ai/code/session_01RD4eaqwWCcxbATVGrwKtLA