### PR TITLE
fix(ci): bump CI runner memory to 16GB to prevent Bazel OOM

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -24,6 +24,9 @@ actions:
     # like ghcr.io/agentydragon/rbe-worker. RBE workers still use the custom image.
     container_image: "ubuntu-24.04"
     resource_requests:
+      # Default 8GB RAM OOMs when remote cache is cold and many OCI image
+      # Merkle trees are computed simultaneously (~57k actions for //...).
+      memory: "16GB"
       disk: "50GB"
 
     bazel_commands:
@@ -61,6 +64,7 @@ actions:
 
     container_image: "ubuntu-24.04"
     resource_requests:
+      memory: "16GB"
       disk: "50GB"
 
     steps:


### PR DESCRIPTION
## Summary
- Bump CI runner memory from default 8GB to 16GB via `resource_requests.memory`
- Applied to both CI and Release workflows

## Context
Bazel OOM'd on `0fdadd9` building Merkle trees for remote execution (~57k actions for `//...`). All 336/416 tests that completed before the crash passed — no code failures, just insufficient RAM when the remote cache was cold after adding new OCI image targets.

## Test plan
- [ ] CI workflow completes without OOM
- [ ] Release workflow completes and publishes artifacts for nix pin

https://claude.ai/code/session_01742XaSmNJM34HEZvvRGYee