### PR TITLE
fix(ci): replace pygit2 with git CLI in bb_release (partial clone compat)

### DIFF
--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -117,7 +117,6 @@ py_library(
     deps = [
         ":artifacts",
         "@pypi//more_itertools",
-        "@pypi//pygit2",
         "@pypi//pygithub",
     ],
 )

--- a/devinfra/ci/bb_release.py
+++ b/devinfra/ci/bb_release.py
@@ -6,9 +6,9 @@ Expects: GH_RELEASE_PAT env var.
 
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
-import pygit2
 from github import Auth, Github
 from more_itertools import one
 
@@ -28,9 +28,9 @@ def copy_artifact_to_dist(src_glob: str, dest: str) -> Path:
 
 
 def main() -> None:
-    repo = pygit2.Repository(".")
-    head = repo.head.peel(pygit2.Commit)
-    subject = head.message.split("\n")[0]
+    # Use git CLI instead of pygit2 — BuildBuddy does partial clones which
+    # set extensions.partialclone, unsupported by libgit2/pygit2.
+    subject = subprocess.check_output(["git", "log", "-1", "--format=%s"], text=True).strip()
     if "[skip ci]" in subject:
         print("Commit message contains [skip ci], skipping release.")
         return
@@ -39,7 +39,7 @@ def main() -> None:
     if not gh_token:
         raise RuntimeError("Missing required env var: GH_RELEASE_PAT (configure as a BuildBuddy Workflow secret)")
 
-    short_sha = str(head.id)[:7]
+    short_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"], text=True).strip()
 
     Path("dist").mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary
Replace `pygit2.Repository(".")` with `git log`/`git rev-parse` in `bb_release.py`.

pygit2 (libgit2) doesn't support `extensions.partialclone`, which BuildBuddy sets on its checkout. This was causing the Release workflow to fail with:
```
_pygit2.GitError: .: unsupported extension name extensions.partialclone
```

Only two values were read via pygit2: HEAD commit message and SHA. Replaced with `subprocess.check_output(["git", ...])`.

## Test plan
- [ ] Release workflow completes successfully on next devel push

https://claude.ai/code/session_01742XaSmNJM34HEZvvRGYee