### PR TITLE
fix(ci): chdir to workspace root in bb_release for bazel run

### DIFF
--- a/devinfra/ci/bb_release.py
+++ b/devinfra/ci/bb_release.py
@@ -28,6 +28,12 @@ def copy_artifact_to_dist(src_glob: str, dest: str) -> Path:
 
 
 def main() -> None:
+    # bazel run sets CWD to execroot; all paths (bazel-bin/, dist/, npins/)
+    # are relative to the workspace root.
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if workspace:
+        os.chdir(workspace)
+
     # Use git CLI instead of pygit2 — BuildBuddy does partial clones which
     # set extensions.partialclone, unsupported by libgit2/pygit2.
     subject = subprocess.check_output(["git", "log", "-1", "--format=%s"], text=True).strip()


### PR DESCRIPTION
## Summary
`bazel run` sets CWD to the execroot, not the workspace root. All paths in `bb_release` (`bazel-bin/` artifact globs, `dist/`, `npins/sources.json`) are relative to the workspace root. Add `os.chdir(BUILD_WORKSPACE_DIRECTORY)` at the start of `main()`.

Previously masked by the pygit2 crash (#1103) and then the `SOURCES_PATH` fix (#1104) — the artifact glob was the next path to fail.

## Test plan
- [ ] Release workflow completes and publishes artifacts

https://claude.ai/code/session_01742XaSmNJM34HEZvvRGYee