### PR TITLE
Handle network-level errors when reading Kubernetes secrets

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/secret_sources.py
+++ b/devinfra/claude/hook_daemon/session_start/secret_sources.py
@@ -58,6 +58,11 @@ def read_k8s_secret(api: CoreV1Api, namespace: str, secret_name: str, key: str) 
         logger.warning("Key %r not found in secret %s/%s", key, namespace, secret_name)
     except k8s_client.ApiException as e:
         logger.warning("Failed to read secret %s/%s: %s", namespace, secret_name, e.reason)
+    except Exception as e:
+        # Network-level errors (e.g. proxy tunnel 403, connection refused) are not
+        # wrapped in ApiException by the k8s client — catch them here so a stale
+        # or unreachable k8s API doesn't crash the session start hook.
+        logger.warning("Failed to read secret %s/%s (network error): %s", namespace, secret_name, e)
     return None
 
 


### PR DESCRIPTION
## Summary
Added exception handling for network-level errors when reading Kubernetes secrets, preventing the session start hook from crashing when the Kubernetes API is unreachable or experiencing connectivity issues.

## Key Changes
- Added a catch-all `Exception` handler in `read_k8s_secret()` to handle network-level errors that are not wrapped in `ApiException` by the Kubernetes client
- Network errors (e.g., proxy tunnel 403, connection refused) are now logged as warnings instead of causing the hook to crash
- The function continues to return `None` gracefully when network errors occur, allowing the session start process to continue

## Implementation Details
The Kubernetes Python client does not wrap all errors in `ApiException` — some network-level errors bubble up as generic exceptions. This change ensures that transient or persistent connectivity issues with the Kubernetes API don't cause the session start hook to fail unexpectedly. The error is logged with context about which secret was being accessed to aid in debugging.

https://claude.ai/code/session_01VQbxQiNd1AqJPR8XVxqmiN