### PR TITLE
Migrate Harbor PostgreSQL to CNPG

### DIFF
--- a/cluster/k8s/harbor/app/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/app/flux-kustomization.yaml
@@ -21,6 +21,7 @@ spec:
       namespace: harbor
   dependsOn:
     - name: harbor-namespace
+    - name: harbor-db
     - name: gateway
     - name: harbor-secrets
     - name: monitoring-stack

--- a/cluster/k8s/harbor/app/helmrelease.yaml
+++ b/cluster/k8s/harbor/app/helmrelease.yaml
@@ -67,8 +67,6 @@ spec:
         jobservice:
           storageClass: longhorn
           size: 1Gi
-        database:
-          size: 1Gi
         redis:
           storageClass: longhorn
           size: 1Gi
@@ -121,18 +119,14 @@ spec:
           cpu: 200m
 
     database:
-      type: internal
-      internal:
-        nodeSelector:
-          topology.kubernetes.io/region: proxmox
-        password: "changeit"
-        resources:
-          requests:
-            memory: 128Mi
-            cpu: 35m
-          limits:
-            memory: 512Mi
-            cpu: 200m
+      type: external
+      external:
+        host: harbor-db-rw
+        port: "5432"
+        username: harbor
+        coreDatabase: registry
+        existingSecret: harbor-db-app
+        # CNPG auto-generates this secret; Harbor chart reads "password" key
 
     redis:
       type: internal

--- a/cluster/k8s/harbor/db/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/db/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: harbor-db
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/harbor/db
+  prune: true
+  wait: true
+  dependsOn:
+    - name: harbor-namespace
+    - name: cnpg
+    - name: proxmox-csi

--- a/cluster/k8s/harbor/db/kustomization.yaml
+++ b/cluster/k8s/harbor/db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - postgres-cluster.yaml

--- a/cluster/k8s/harbor/db/postgres-cluster.yaml
+++ b/cluster/k8s/harbor/db/postgres-cluster.yaml
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: harbor-db
+  namespace: harbor
+spec:
+  instances: 1
+
+  probes:
+    liveness:
+      isolationCheck:
+        enabled: false
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
+  storage:
+    storageClass: proxmox-csi-retain
+    size: 5Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  bootstrap:
+    initdb:
+      database: registry
+      owner: harbor
+      # CNPG auto-generates credentials in secret harbor-db-app


### PR DESCRIPTION
## Summary

- Create CNPG cluster `harbor-db` (5Gi, `proxmox-csi-retain`, DB: `registry`, owner: `harbor`)
- Switch `database.type` from `internal` to `external`, pointing at `harbor-db-rw`
- Use `harbor-db-app` secret (CNPG auto-generated) instead of hardcoded `"changeit"` password
- Remove internal DB PVC config from persistence section
- Add `harbor-db` dependency to app flux-kustomization

## Test plan

- [ ] Verify `harbor-db` CNPG cluster comes up healthy
- [ ] Verify Harbor core connects to external DB
- [ ] Verify Harbor chart no longer deploys internal postgres pod

https://claude.ai/code/session_01EEKx82da6Z7bQ2CrXCEEtt