### PR TITLE
Migrate Matrix Synapse PostgreSQL to CNPG

### DIFF
--- a/cluster/k8s/matrix/app/flux-kustomization.yaml
+++ b/cluster/k8s/matrix/app/flux-kustomization.yaml
@@ -21,6 +21,7 @@ spec:
       namespace: matrix
   dependsOn:
     - name: matrix-namespace
+    - name: matrix-db
     - name: gateway
     - name: cert-manager
     - name: authentik # Wait for Authentik worker to apply SSO blueprints

--- a/cluster/k8s/matrix/app/helmrelease.yaml
+++ b/cluster/k8s/matrix/app/helmrelease.yaml
@@ -55,6 +55,10 @@ spec:
     # The chart derives public_baseurl as https://<publicServerName>.
     publicServerName: matrix.allegedly.works
 
+    # Pin to Proxmox nodes
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
     # Resources
     resources:
       limits:

--- a/cluster/k8s/matrix/app/helmrelease.yaml
+++ b/cluster/k8s/matrix/app/helmrelease.yaml
@@ -104,32 +104,16 @@ spec:
         enabled: true
         port: 8448
 
-    # PostgreSQL configuration with bundled chart
+    # PostgreSQL via external CNPG cluster (matrix-db)
     postgresql:
-      enabled: true
-      auth:
-        username: synapse
-        database: synapse
-        # PostgreSQL chart auto-generates password
-      global:
-        storageClass: "proxmox-csi-retain"
-      primary:
-        # Requests right-sized from observed usage — see docs/operations/2026-02-22-memory-request-rightsizing.md
-        resources:
-          requests:
-            memory: 128Mi
-            cpu: 100m
-        persistence:
-          enabled: true
-          storageClass: "proxmox-csi-retain"
-          size: 10Gi
-        # PostgreSQL 16 compatible settings
-        extendedConfiguration: |
-          max_connections = 200
-          shared_buffers = 256MB
-        # Synapse requires C collation - set via initdb args
-        initdb:
-          args: "--locale=C"
+      enabled: false
+    externalPostgresql:
+      host: matrix-db-rw
+      port: 5432
+      username: synapse
+      database: synapse
+      existingSecret: matrix-db-app
+      existingSecretPasswordKey: password
 
     # Redis (required by chart even for single-instance setup)
     redis:
@@ -157,18 +141,3 @@ spec:
     # Service account
     serviceAccount:
       create: true
----
-# ConfigMap for PostgreSQL initialization with proper collation
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: synapse-postgres-initdb
-  namespace: matrix
-data:
-  00-init.sh: |
-    #!/bin/bash
-    set -e
-    # Ensure database has correct collation for Synapse
-    # Note: This runs as postgres user, after database creation
-    # The collation must be set during database creation instead
-    echo "Database collation check script (collation should be set during CREATE DATABASE)"

--- a/cluster/k8s/matrix/db/flux-kustomization.yaml
+++ b/cluster/k8s/matrix/db/flux-kustomization.yaml
@@ -16,4 +16,4 @@ spec:
   dependsOn:
     - name: matrix-namespace
     - name: cnpg
-    - name: proxmox-csi
+    - name: local-path-provisioner

--- a/cluster/k8s/matrix/db/flux-kustomization.yaml
+++ b/cluster/k8s/matrix/db/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: matrix-db
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/matrix/db
+  prune: true
+  wait: true
+  dependsOn:
+    - name: matrix-namespace
+    - name: cnpg
+    - name: proxmox-csi

--- a/cluster/k8s/matrix/db/kustomization.yaml
+++ b/cluster/k8s/matrix/db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - postgres-cluster.yaml

--- a/cluster/k8s/matrix/db/postgres-cluster.yaml
+++ b/cluster/k8s/matrix/db/postgres-cluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: matrix-db
+  namespace: matrix
+spec:
+  instances: 1
+
+  probes:
+    liveness:
+      isolationCheck:
+        enabled: false
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
+  storage:
+    storageClass: proxmox-csi-retain
+    size: 10Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  bootstrap:
+    initdb:
+      database: synapse
+      owner: synapse
+      localeCType: C
+      localeCollate: C
+      # CNPG auto-generates credentials in secret matrix-db-app

--- a/cluster/k8s/matrix/db/postgres-cluster.yaml
+++ b/cluster/k8s/matrix/db/postgres-cluster.yaml
@@ -11,12 +11,8 @@ spec:
       isolationCheck:
         enabled: false
 
-  affinity:
-    nodeSelector:
-      topology.kubernetes.io/region: proxmox
-
   storage:
-    storageClass: proxmox-csi-retain
+    storageClass: local-path
     size: 10Gi
 
   monitoring:

--- a/cluster/k8s/matrix/db/postgres-cluster.yaml
+++ b/cluster/k8s/matrix/db/postgres-cluster.yaml
@@ -11,6 +11,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 10Gi


### PR DESCRIPTION
## Summary

- Create CNPG cluster `matrix-db` (10Gi, `local-path`, Proxmox affinity, `localeCType: C`, `localeCollate: C`)
- Disable bundled Bitnami PostgreSQL subchart (`postgresql.enabled: false`)
- Configure `externalPostgresql` pointing at `matrix-db-rw` with `matrix-db-app` secret
- Remove `synapse-postgres-initdb` ConfigMap (collation now handled by CNPG `initdb`)
- Add `matrix-db` dependency to app flux-kustomization
- Pin Synapse app to Proxmox (media store already uses `proxmox-csi-retain`)

## Test plan

- [ ] Verify `matrix-db` CNPG cluster comes up on Proxmox with C locale
- [ ] Verify Synapse connects to external DB and starts successfully
- [ ] Verify Bitnami postgres subchart pods are no longer deployed

https://claude.ai/code/session_01EEKx82da6Z7bQ2CrXCEEtt