### PR TITLE
ci: push container images to GHCR instead of Harbor

### DIFF
--- a/.github/actions/ghcr-build-push/action.yml
+++ b/.github/actions/ghcr-build-push/action.yml
@@ -1,9 +1,9 @@
-name: Harbor Build and Push
-description: Compute image tags, login to Harbor, and build+push a Docker image.
+name: GHCR Build and Push
+description: Compute image tags, login to GHCR, and build+push a Docker image.
 
 inputs:
   image:
-    description: Full image name (e.g. registry.allegedly.works/foo/bar)
+    description: Full image name (e.g. ghcr.io/agentydragon/foo)
     required: true
   context:
     description: Docker build context path
@@ -12,11 +12,8 @@ inputs:
     description: Path to Dockerfile (optional; defaults to {context}/Dockerfile)
     required: false
     default: ""
-  harbor_robot_username:
-    description: Harbor robot account username
-    required: true
-  harbor_robot_token:
-    description: Harbor robot account token
+  github_token:
+    description: GitHub token for GHCR authentication
     required: true
 
 outputs:
@@ -44,12 +41,12 @@ runs:
         echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
         echo "semver_tag=$PINNED_TAG" >> "$GITHUB_OUTPUT"
 
-    - name: Login to Harbor
+    - name: Login to GHCR
       uses: docker/login-action@v3
       with:
-        registry: registry.allegedly.works
-        username: ${{ inputs.harbor_robot_username }}
-        password: ${{ inputs.harbor_robot_token }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
 
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/.github/workflows/openclaw-image.yml
+++ b/.github/workflows/openclaw-image.yml
@@ -1,4 +1,4 @@
-# Build and push the custom OpenClaw+matrix container image to Harbor.
+# Build and push the custom OpenClaw+matrix container image to GHCR.
 #
 # Derives from upstream ghcr.io/openclaw/openclaw with the matrix channel
 # plugin and its native crypto binary pre-installed.
@@ -18,6 +18,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-and-push:
@@ -33,10 +34,9 @@ jobs:
       - name: Stage plugin tar for Docker
         run: cp bazel-bin/airlock/openclaw/plugin_tar.tar openclaw/airlock-plugin.tar
 
-      - uses: ./.github/actions/harbor-build-push
+      - uses: ./.github/actions/ghcr-build-push
         with:
-          image: registry.allegedly.works/ducktape/openclaw-matrix
+          image: ghcr.io/${{ github.repository_owner }}/openclaw-matrix
           context: .
           file: openclaw/Dockerfile
-          harbor_robot_username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
-          harbor_robot_token: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tana-mcp-image.yml
+++ b/.github/workflows/tana-mcp-image.yml
@@ -1,4 +1,4 @@
-# Build and push the Tana MCP Desktop image to Harbor.
+# Build and push the Tana MCP Desktop image to GHCR.
 #
 # Triggers:
 #   - push to devel changing tana/mcp_server/** (tags :latest too)
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-and-push:
@@ -28,9 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/harbor-build-push
+      - uses: ./.github/actions/ghcr-build-push
         with:
-          image: registry.allegedly.works/ducktape/tana-desktop
+          image: ghcr.io/${{ github.repository_owner }}/tana-desktop
           context: tana/mcp_server
-          harbor_robot_username: ${{ secrets.HARBOR_ROBOT_USERNAME }}
-          harbor_robot_token: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/airlock/BUILD.bazel
+++ b/airlock/BUILD.bazel
@@ -162,7 +162,7 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/airlock",
+    repository = "ghcr.io/agentydragon/airlock",
 )
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/airlock/auth_proxy/BUILD.bazel
+++ b/airlock/auth_proxy/BUILD.bazel
@@ -62,7 +62,7 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/auth-proxy",
+    repository = "ghcr.io/agentydragon/auth-proxy",
 )
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -85,11 +85,11 @@ actions:
             //devinfra/buildbuddy_cli:bbapi
           bazel run //devinfra/ci:bb_release_bin
 
-  # Push Harbor container images (OCI images built with Bazel).
+  # Push GHCR container images (OCI images built with Bazel).
   # Uses oci_push (crane-based, no Docker daemon needed).
   # The CI action's `bazel build //...` populates the remote cache;
   # bazel run here fetches built images from cache and pushes via crane.
-  - name: "Push Harbor Images"
+  - name: "Push GHCR Images"
     triggers:
       push:
         branches:

--- a/cluster/k8s/inventree/token-provisioner/BUILD.bazel
+++ b/cluster/k8s/inventree/token-provisioner/BUILD.bazel
@@ -46,5 +46,5 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/token-provisioner",
+    repository = "ghcr.io/agentydragon/token-provisioner",
 )

--- a/devinfra/ci/bb_push_images.sh
+++ b/devinfra/ci/bb_push_images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# BB Push Harbor Images step: authenticate, push OCI images, tag for Flux.
+# BB Push GHCR Images step: authenticate, push OCI images, tag for Flux.
 #
-# Expects: HARBOR_ROBOT_USERNAME, HARBOR_ROBOT_TOKEN env vars.
+# Expects: GHCR_USERNAME, GHCR_TOKEN env vars.
 set -euo pipefail
 
 # Honor [skip ci] — BuildBuddy Workflows doesn't natively support it.
@@ -12,20 +12,20 @@ fi
 
 # Validate required secrets.
 missing=()
-[[ -z "${HARBOR_ROBOT_USERNAME:-}" ]] && missing+=(HARBOR_ROBOT_USERNAME)
-[[ -z "${HARBOR_ROBOT_TOKEN:-}" ]] && missing+=(HARBOR_ROBOT_TOKEN)
+[[ -z "${GHCR_USERNAME:-}" ]] && missing+=(GHCR_USERNAME)
+[[ -z "${GHCR_TOKEN:-}" ]] && missing+=(GHCR_TOKEN)
 if [[ ${#missing[@]} -gt 0 ]]; then
   echo "ERROR: Missing required env vars: ${missing[*]}" >&2
   echo "Configure these as BuildBuddy Workflow secrets." >&2
   exit 1
 fi
 
-# Authenticate crane to Harbor registry.
+# Authenticate crane to GHCR.
 # oci_push reads ~/.docker/config.json for credentials.
 mkdir -p ~/.docker
-AUTH=$(echo -n "${HARBOR_ROBOT_USERNAME}:${HARBOR_ROBOT_TOKEN}" | base64 -w0)
+AUTH=$(echo -n "${GHCR_USERNAME}:${GHCR_TOKEN}" | base64 -w0)
 cat >~/.docker/config.json <<ENDJSON
-{"auths":{"registry.allegedly.works":{"auth":"${AUTH}"}}}
+{"auths":{"ghcr.io":{"auth":"${AUTH}"}}}
 ENDJSON
 
 # Build crane from Bazel cache (already cached from CI action).
@@ -49,13 +49,13 @@ push_and_tag() {
   $CRANE tag "${repo}:latest" "${PINNED_TAG}"
 }
 
-push_and_tag //cluster/k8s/inventree/token-provisioner:push registry.allegedly.works/ducktape/token-provisioner
-push_and_tag //props/backend:push registry.allegedly.works/ducktape/props-backend
-push_and_tag //airlock:push registry.allegedly.works/ducktape/airlock
-push_and_tag //airlock/auth_proxy:push registry.allegedly.works/ducktape/auth-proxy
-push_and_tag //mcp_infra/exec:direct_push registry.allegedly.works/ducktape/exec-backend
-push_and_tag //openclaw/exec:push registry.allegedly.works/ducktape/openclaw-exec
-push_and_tag //homeassistant/proxy:push registry.allegedly.works/ducktape/homeassistant-proxy
-push_and_tag //inventree_utils/rai_plugin:push registry.allegedly.works/ducktape/inventree
-push_and_tag //tana/token_broker:push registry.allegedly.works/ducktape/tana-token-broker
-push_and_tag //third_party/activitywatch:push registry.allegedly.works/ducktape/aw-server
+push_and_tag //cluster/k8s/inventree/token-provisioner:push ghcr.io/agentydragon/token-provisioner
+push_and_tag //props/backend:push ghcr.io/agentydragon/props-backend
+push_and_tag //airlock:push ghcr.io/agentydragon/airlock
+push_and_tag //airlock/auth_proxy:push ghcr.io/agentydragon/auth-proxy
+push_and_tag //mcp_infra/exec:direct_push ghcr.io/agentydragon/exec-backend
+push_and_tag //openclaw/exec:push ghcr.io/agentydragon/openclaw-exec
+push_and_tag //homeassistant/proxy:push ghcr.io/agentydragon/homeassistant-proxy
+push_and_tag //inventree_utils/rai_plugin:push ghcr.io/agentydragon/inventree
+push_and_tag //tana/token_broker:push ghcr.io/agentydragon/tana-token-broker
+push_and_tag //third_party/activitywatch:push ghcr.io/agentydragon/aw-server

--- a/homeassistant/proxy/BUILD.bazel
+++ b/homeassistant/proxy/BUILD.bazel
@@ -91,7 +91,7 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/homeassistant-proxy",
+    repository = "ghcr.io/agentydragon/homeassistant-proxy",
 )
 
 # =============================================================================

--- a/inventree_utils/rai_plugin/BUILD.bazel
+++ b/inventree_utils/rai_plugin/BUILD.bazel
@@ -66,5 +66,5 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/inventree",
+    repository = "ghcr.io/agentydragon/inventree",
 )

--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -107,7 +107,7 @@ oci_push(
     name = "direct_push",
     image = ":direct_image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/exec-backend",
+    repository = "ghcr.io/agentydragon/exec-backend",
 )
 
 # macOS seatbelt sandbox exec MCP server

--- a/openclaw/exec/BUILD.bazel
+++ b/openclaw/exec/BUILD.bazel
@@ -61,5 +61,5 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/openclaw-exec",
+    repository = "ghcr.io/agentydragon/openclaw-exec",
 )

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -302,5 +302,5 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/props-backend",
+    repository = "ghcr.io/agentydragon/props-backend",
 )

--- a/tana/token_broker/BUILD.bazel
+++ b/tana/token_broker/BUILD.bazel
@@ -77,7 +77,7 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/tana-token-broker",
+    repository = "ghcr.io/agentydragon/tana-token-broker",
 )
 
 # =============================================================================

--- a/third_party/activitywatch/BUILD.bazel
+++ b/third_party/activitywatch/BUILD.bazel
@@ -67,5 +67,5 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "registry.allegedly.works/ducktape/aw-server",
+    repository = "ghcr.io/agentydragon/aw-server",
 )


### PR DESCRIPTION
## Summary

Step 1/3 of Harbor→GHCR migration. Switches all CI image push targets from `registry.allegedly.works/ducktape/*` to `ghcr.io/agentydragon/*`.

- BuildBuddy push script (`bb_push_images.sh`): GHCR auth (`GHCR_USERNAME`/`GHCR_TOKEN`), all repos → `ghcr.io/agentydragon/*`
- Rename `.github/actions/harbor-build-push` → `ghcr-build-push` (GHCR login via `github.actor` + `GITHUB_TOKEN`)
- `openclaw-image.yml` + `tana-mcp-image.yml`: use `ghcr-build-push`, add `packages: write`
- All 10 Bazel `oci_push` targets: `repository` → `ghcr.io/agentydragon/*`

Props agent images (critic, grader, etc.) are **not** migrated — they use a separate registry proxy and stay on Harbor.

## Stacked PRs

1. **This PR** — CI writes to GHCR
2. K8s manifests read from GHCR (after GHCR is populated)
3. Docs/Terraform cleanup TODOs

## Test plan

- [ ] Merge and push to devel to trigger BuildBuddy "Push GHCR Images" workflow
- [ ] Verify images appear at `ghcr.io/agentydragon/*` with correct tags
- [ ] Verify `openclaw-image` and `tana-mcp-image` GH Actions workflows succeed on next trigger
- [ ] Configure `GHCR_USERNAME` + `GHCR_TOKEN` as BuildBuddy Workflow secrets before merge

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq