### PR TITLE
Switch CNPG clusters to local-path, co-locate with apps

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -215,6 +215,18 @@ Via `inventree-token-provisioner` Job. TF module -> Vault -> Job execs into pod,
 creates user via Django ORM -> `inventree-api-token` Secret in `openclaw-sandbox`
 and `claude-sandbox`.
 
+### CNPG Backup Strategy
+
+Single-instance Proxmox CNPG clusters (atuin, langfuse, inventree, harbor, props) rely
+on Proxmox ZFS for local reliability (checksums, snapshots). Off-site disaster recovery
+needed:
+
+- [ ] Generalize the `tofu-state` pg_dump CronJob pattern to all Proxmox CNPG clusters
+      (write dumps to VPS-hosted PVC or object storage)
+- [ ] Longer term: CNPG `ScheduledBackup` + Barman to S3-compatible store (MinIO on VPS
+      or cloud bucket) for continuous WAL archiving and point-in-time recovery
+- [ ] Verify Proxmox ZFS auto-snapshot schedule covers CNPG data directories
+
 ### Velero PVC Backup
 
 Scheduled backups of PVCs (Harbor, Gitea, Loki, Postgres). No backup strategy currently.

--- a/cluster/k8s/atuin/db/flux-kustomization.yaml
+++ b/cluster/k8s/atuin/db/flux-kustomization.yaml
@@ -16,4 +16,4 @@ spec:
   dependsOn:
     - name: atuin-namespace
     - name: cnpg
-    - name: proxmox-csi
+    - name: local-path-provisioner

--- a/cluster/k8s/atuin/db/postgres-cluster.yaml
+++ b/cluster/k8s/atuin/db/postgres-cluster.yaml
@@ -13,12 +13,8 @@ spec:
       isolationCheck:
         enabled: false
 
-  affinity:
-    nodeSelector:
-      topology.kubernetes.io/region: proxmox
-
   storage:
-    storageClass: proxmox-csi-retain
+    storageClass: local-path
     size: 2Gi
 
   monitoring:

--- a/cluster/k8s/atuin/db/postgres-cluster.yaml
+++ b/cluster/k8s/atuin/db/postgres-cluster.yaml
@@ -13,6 +13,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 2Gi

--- a/cluster/k8s/harbor/db/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/db/flux-kustomization.yaml
@@ -16,4 +16,4 @@ spec:
   dependsOn:
     - name: harbor-namespace
     - name: cnpg
-    - name: proxmox-csi
+    - name: local-path-provisioner

--- a/cluster/k8s/harbor/db/postgres-cluster.yaml
+++ b/cluster/k8s/harbor/db/postgres-cluster.yaml
@@ -11,12 +11,8 @@ spec:
       isolationCheck:
         enabled: false
 
-  affinity:
-    nodeSelector:
-      topology.kubernetes.io/region: proxmox
-
   storage:
-    storageClass: proxmox-csi-retain
+    storageClass: local-path
     size: 5Gi
 
   monitoring:

--- a/cluster/k8s/harbor/db/postgres-cluster.yaml
+++ b/cluster/k8s/harbor/db/postgres-cluster.yaml
@@ -11,6 +11,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 5Gi

--- a/cluster/k8s/inventree/db/flux-kustomization.yaml
+++ b/cluster/k8s/inventree/db/flux-kustomization.yaml
@@ -17,4 +17,4 @@ spec:
   dependsOn:
     - name: inventree-namespace
     - name: cnpg
-    - name: proxmox-csi
+    - name: local-path-provisioner

--- a/cluster/k8s/inventree/db/postgres-cluster.yaml
+++ b/cluster/k8s/inventree/db/postgres-cluster.yaml
@@ -11,12 +11,8 @@ spec:
       isolationCheck:
         enabled: false
 
-  affinity:
-    nodeSelector:
-      topology.kubernetes.io/region: proxmox
-
   storage:
-    storageClass: proxmox-csi-retain
+    storageClass: local-path
     size: 5Gi
 
   monitoring:

--- a/cluster/k8s/inventree/db/postgres-cluster.yaml
+++ b/cluster/k8s/inventree/db/postgres-cluster.yaml
@@ -11,6 +11,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 5Gi

--- a/cluster/k8s/langfuse/db/flux-kustomization.yaml
+++ b/cluster/k8s/langfuse/db/flux-kustomization.yaml
@@ -16,4 +16,4 @@ spec:
   dependsOn:
     - name: langfuse-namespace
     - name: cnpg
-    - name: proxmox-csi
+    - name: local-path-provisioner

--- a/cluster/k8s/langfuse/db/postgres-cluster.yaml
+++ b/cluster/k8s/langfuse/db/postgres-cluster.yaml
@@ -13,6 +13,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 10Gi

--- a/cluster/k8s/langfuse/db/postgres-cluster.yaml
+++ b/cluster/k8s/langfuse/db/postgres-cluster.yaml
@@ -13,12 +13,8 @@ spec:
       isolationCheck:
         enabled: false
 
-  affinity:
-    nodeSelector:
-      topology.kubernetes.io/region: proxmox
-
   storage:
-    storageClass: proxmox-csi-retain
+    storageClass: local-path
     size: 10Gi
 
   monitoring:

--- a/cluster/k8s/props/db/postgres-cluster.yaml
+++ b/cluster/k8s/props/db/postgres-cluster.yaml
@@ -13,6 +13,10 @@ spec:
       isolationCheck:
         enabled: false
 
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/region: proxmox
+
   storage:
     storageClass: local-path
     size: 10Gi


### PR DESCRIPTION
## Summary

- Switch all single-instance CNPG clusters from `proxmox-csi-retain` to `local-path`
- Restore Proxmox node affinity for clusters whose apps are Proxmox-pinned (atuin, langfuse, inventree, harbor, props) to avoid cross-site write latency over Nebula mesh
- Update flux-kustomization dependencies from `proxmox-csi` to `local-path-provisioner`
- Add CNPG backup strategy TODO to `cluster/docs/plan.md`

Clusters that already used `local-path` (gitea-db, attic-db, props-db) are unchanged. VPS-HA clusters (authentik-db, powerdns-db, tofu-state-db) are unchanged.

### Resulting CNPG layout

| Profile | Clusters | Storage | Affinity |
|---------|----------|---------|----------|
| VPS-HA (2 inst) | authentik, powerdns, tofu-state | `local-path` | Hetzner + topology spread |
| Proxmox-single | atuin, langfuse, inventree, harbor, props | `local-path` | Proxmox |
| Unconstrained-single | gitea, attic, matrix*, firecrawl* | `local-path` | none |

*matrix and firecrawl changes are in separate PRs (#1109, #1110)

## Test plan

- [ ] Verify CNPG clusters schedule on correct nodes after bootstrap
- [ ] Verify no `proxmox-csi` dependency remains in db flux-kustomizations

https://claude.ai/code/session_01EEKx82da6Z7bQ2CrXCEEtt