### PR TITLE
cluster: switch k8s image pulls from Harbor to GHCR

### DIFF
--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -159,13 +159,16 @@ kustomization, SSO client secrets under `authentik/blueprints/`).
 
 @docs/lessons_learned/2025-11-28-eso-password-generator-desync.md
 
-## Harbor CI
+## Container Images
 
-Single `ducktape` project at `registry.allegedly.works/ducktape/<image>`.
-Managed by `terraform/gitops/harbor-ci/main.tf`.
+Ducktape project images are published to GHCR at `ghcr.io/agentydragon/<image>`.
+CI pushes via BuildBuddy Workflows (`devinfra/ci/bb_push_images.sh`) and GitHub
+Actions (openclaw-image, tana-mcp-image workflows). GHCR packages are public (no
+pull credentials needed).
 
-**Gotcha -- removing Harbor projects**: Use `removed` blocks with `lifecycle { destroy = false }`
-to orphan from state (can't destroy projects with repositories without `force_destroy`).
+Props agent images are still published to Harbor (`registry.allegedly.works`).
+The Harbor Terraform (`terraform/gitops/harbor-ci/`) and pull robot credentials
+remain active for props.
 
 **Gotcha -- Flux image automation race**: When renaming image paths, push at least one
 image to the new path before updating `ImageRepository` resources. Otherwise Flux reverts

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -125,7 +125,7 @@ No built-in auth; Nebula mesh membership is the trust boundary.
 
 - **Server**: `aw-server-rust` on Proxmox, SQLite on `proxmox-csi-retain` (1Gi PVC)
 - **Sidecar**: Nebula container joins the mesh (`10.42.0.40`, cert name `activitywatch`)
-- **Image**: `registry.allegedly.works/ducktape/aw-server`, pushed via BuildBuddy Workflows (`buildbuddy.yaml`)
+- **Image**: `ghcr.io/agentydragon/aw-server`, pushed via BuildBuddy Workflows (`buildbuddy.yaml`)
 - **Certs**: SealedSecret from `terraform/main/nebula-activitywatch-sealed.tf`
 - **Read-only proxy**: nginx sidecar on port 5601 (Service `activitywatch-readonly`),
   allows GET + POST `/api/0/query` only. `openclaw-sandbox` and `claude-sandbox` namespaces

--- a/cluster/docs/operations/2026-02-24-openclaw-matrix-plugin.md
+++ b/cluster/docs/operations/2026-02-24-openclaw-matrix-plugin.md
@@ -203,8 +203,8 @@ paths, heap limits, crypto binary download).
   `--ignore-scripts` so the crypto native binary downloads automatically via postinstall.
   Skips `plugins install` entirely to avoid HOME path issues (`USER root` → HOME=/root,
   operator overrides HOME=/home/openclaw at runtime — neither matches /home/node).
-- **CI**: `.github/workflows/openclaw-image.yml` — builds and pushes to Harbor
-- **Registry**: `registry.allegedly.works/openclaw/openclaw-matrix`
+- **CI**: `.github/workflows/openclaw-image.yml` — builds and pushes to GHCR
+- **Registry**: `ghcr.io/agentydragon/openclaw-matrix`
 - **Auto-update**: Flux ImagePolicy + ImageUpdateAutomation updates tag in
   `openclawinstance.yaml` when CI pushes a new image
 

--- a/cluster/k8s/activitywatch/flux-kustomization.yaml
+++ b/cluster/k8s/activitywatch/flux-kustomization.yaml
@@ -14,6 +14,4 @@ spec:
   prune: true
   wait: true
   dependsOn:
-    - name: harbor-pull-secret
     - name: proxmox-csi
-    - name: harbor # Image hosted on registry.allegedly.works

--- a/cluster/k8s/agents/airlock/flux-kustomization.yaml
+++ b/cluster/k8s/agents/airlock/flux-kustomization.yaml
@@ -19,5 +19,4 @@ spec:
       name: airlock
       namespace: airlock
   dependsOn:
-    - name: harbor-pull-secret
     - name: gateway

--- a/cluster/k8s/agents/homeassistant-proxy/flux-kustomization.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/flux-kustomization.yaml
@@ -18,6 +18,4 @@ spec:
       kind: Deployment
       name: homeassistant-proxy
       namespace: homeassistant-proxy
-  dependsOn:
-    - name: harbor-pull-secret
-    - name: harbor # Image hosted on registry.allegedly.works
+  dependsOn: []

--- a/cluster/k8s/agents/openclaw/gateway/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/gateway/flux-kustomization.yaml
@@ -15,7 +15,5 @@ spec:
     - name: openclaw-operator
     - name: openclaw-gateway-namespace
     - name: openclaw-gateway-secrets
-    - name: harbor-pull-secret
     - name: openclaw-mitmproxy
     - name: authentik # Wait for Authentik worker to apply SSO blueprints
-    - name: harbor # Images hosted on registry.allegedly.works

--- a/cluster/k8s/agents/tana-mcp/flux-kustomization.yaml
+++ b/cluster/k8s/agents/tana-mcp/flux-kustomization.yaml
@@ -18,6 +18,4 @@ spec:
       kind: Deployment
       name: tana-mcp
       namespace: tana-mcp
-  dependsOn:
-    - name: harbor-pull-secret
-    - name: harbor # Image hosted on registry.allegedly.works
+  dependsOn: []

--- a/cluster/k8s/flux-image-automation/activitywatch-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/activitywatch-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: activitywatch
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/aw-server
+  image: ghcr.io/agentydragon/aw-server
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/airlock-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/airlock-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: airlock
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/airlock
+  image: ghcr.io/agentydragon/airlock
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/auth-proxy-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/auth-proxy-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: auth-proxy
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/auth-proxy
+  image: ghcr.io/agentydragon/auth-proxy
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/homeassistant-proxy-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/homeassistant-proxy-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: homeassistant-proxy
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/homeassistant-proxy
+  image: ghcr.io/agentydragon/homeassistant-proxy
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/openclaw-exec-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/openclaw-exec-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: openclaw-exec
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/openclaw-exec
+  image: ghcr.io/agentydragon/openclaw-exec
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/openclaw-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/openclaw-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: openclaw-matrix
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/openclaw-matrix
+  image: ghcr.io/agentydragon/openclaw-matrix
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/props-backend-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/props-backend-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: props-backend
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/props-backend
+  image: ghcr.io/agentydragon/props-backend
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/tana-mcp-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/tana-mcp-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: tana-mcp
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/tana-desktop
+  image: ghcr.io/agentydragon/tana-desktop
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/flux-image-automation/tana-token-broker-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/tana-token-broker-image-repository.yaml
@@ -4,7 +4,5 @@ metadata:
   name: tana-token-broker
   namespace: flux-system
 spec:
-  image: registry.allegedly.works/ducktape/tana-token-broker
+  image: ghcr.io/agentydragon/tana-token-broker
   interval: 5m
-  secretRef:
-    name: harbor-pull-robot

--- a/cluster/k8s/inventree/app/flux-kustomization.yaml
+++ b/cluster/k8s/inventree/app/flux-kustomization.yaml
@@ -23,7 +23,6 @@ spec:
     - name: inventree-namespace
     - name: inventree-db
     - name: inventree-secrets
-    - name: harbor-pull-secret
     - name: authentik-blueprint-inventree-secret
     - name: gateway
     - name: external-dns

--- a/cluster/k8s/props/app/flux-kustomization.yaml
+++ b/cluster/k8s/props/app/flux-kustomization.yaml
@@ -15,10 +15,8 @@ spec:
   dependsOn:
     - name: props-namespace
     - name: props-secrets
-    - name: harbor-pull-secret
     - name: props-db
     - name: gateway
-    - name: harbor # Props image hosted on registry.allegedly.works
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment

--- a/cluster/terraform/gitops/harbor-ci/main.tf
+++ b/cluster/terraform/gitops/harbor-ci/main.tf
@@ -1,8 +1,13 @@
 # Harbor CI infrastructure
 #
+# CLEANUP(2026-03-30): Ducktape project images migrated to GHCR. The CI robot
+# account is no longer used for pushing. The pull robot is still needed by props
+# (agent images pulled from Harbor). Once props also migrates off Harbor, suspend
+# this Terraform resource and orphan with `removed` blocks.
+#
 # Creates:
 #   - ducktape project (private, single project for all CI-pushed images)
-#   - ci robot account with push+pull on the ducktape project (CI push)
+#   - ci robot account with push+pull on the ducktape project (CI push) — NO LONGER USED
 #   - pull robot account with read-only access (imagePullSecrets in app namespaces)
 #   - webhook token for the Flux harbor Receiver
 #   - github webhook token for the Flux github Receiver

--- a/cluster/terraform/gitops/harbor-webhook/main.tf
+++ b/cluster/terraform/gitops/harbor-webhook/main.tf
@@ -1,5 +1,9 @@
 # Harbor webhook notification → Flux Receiver
 #
+# CLEANUP(2026-03-30): Ducktape project images migrated to GHCR. This webhook
+# is no longer needed for ducktape images (Flux now watches GHCR directly).
+# Keep alive until props also migrates, then suspend/remove.
+#
 # Configures the Harbor `ducktape` project to send push_artifact events to the
 # Flux webhook receiver, eliminating the 5-minute ImageRepository poll lag.
 #


### PR DESCRIPTION
## Summary

Point Flux image automation at GHCR so it auto-updates deployment manifests.

- 9 Flux `ImageRepository` resources → watch `ghcr.io/agentydragon/*`, remove `secretRef` (public)
- Remove `harbor`/`harbor-pull-secret` `dependsOn` from 7 flux kustomizations
- `CLEANUP(2026-03-30)` TODOs on harbor-ci and harbor-webhook Terraform
- Update cluster AGENTS.md, README, openclaw operations docs

**Not changed** (left for Flux to handle or follow-up cleanup):
- Deployment `image:` fields — Flux ImageUpdateAutomation rewrites these automatically
- `imagePullSecrets` — harmless until Flux switches images, clean up after
- Harbor pull-secret ExternalSecret — still needed until all images switch

## Test plan

- [ ] Verify GHCR images exist with tags (from CI pushes after #1116)
- [ ] After merge, verify Flux ImageUpdateAutomation commits image updates
- [ ] Verify pods pull successfully from GHCR after Flux updates

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq