### PR TITLE
Refactor Nix formatting and simplify attribute inheritance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -270,7 +270,7 @@
             inherit system;
             config.allowUnfree = true;
           };
-          lib = pkgs.lib;
+          inherit (pkgs) lib;
         in
         rec {
           tana = pkgs.callPackage ./nix/home/packages/tana.nix { };

--- a/nix/ducktape/default.nix
+++ b/nix/ducktape/default.nix
@@ -38,13 +38,13 @@ let
         buildInputs
         ;
       doCheck = false;
-      meta =
-        {
-          inherit description;
-          homepage = "https://github.com/agentydragon/ducktape";
-          license = lib.licenses.agpl3Only;
-        }
-        // lib.optionalAttrs (mainProgram != null) { inherit mainProgram; };
+      dontUsePytestCheck = true;
+      meta = {
+        inherit description;
+        homepage = "https://github.com/agentydragon/ducktape";
+        license = lib.licenses.agpl3Only;
+      }
+      // lib.optionalAttrs (mainProgram != null) { inherit mainProgram; };
     };
 
   compact-json = pkgs.callPackage ./compact-json.nix { };
@@ -101,33 +101,35 @@ in
     wheelFilename = "claude_hooks-0.1.0-py3-none-any.whl";
     description = "Claude Code session hooks (statusline, session-start, auth proxy)";
     mainProgram = "claude-hook";
-    propagatedBuildInputs = with pkgs.python3Packages; [
-      anyio
-      cryptography
-      fastapi
-      httpx
-      kubernetes
-      mako
-      opentelemetry-api
-      opentelemetry-exporter-otlp-proto-http
-      opentelemetry-sdk
-      platformdirs
-      psutil
-      pydantic
-      pydantic-settings
-      pygit2
-      pyjwt
-      pyyaml
-      rich
-      structlog
-      supervisor
-      tenacity
-      uvicorn
-    ]
-    ++ [
-      pkgs.pre-commit
-      pyrage
-    ];
+    propagatedBuildInputs =
+      with pkgs.python3Packages;
+      [
+        anyio
+        cryptography
+        fastapi
+        httpx
+        kubernetes
+        mako
+        opentelemetry-api
+        opentelemetry-exporter-otlp-proto-http
+        opentelemetry-sdk
+        platformdirs
+        psutil
+        pydantic
+        pydantic-settings
+        pygit2
+        pyjwt
+        pyyaml
+        rich
+        structlog
+        supervisor
+        tenacity
+        uvicorn
+      ]
+      ++ [
+        pkgs.pre-commit
+        pyrage
+      ];
   };
 
   gterm-theme = mkDucktapeWheel {


### PR DESCRIPTION
This PR contains formatting improvements and minor refactoring across Nix configuration files.

**Key changes:**

- **ducktape/default.nix**: 
  - Added `dontUsePytestCheck = true` to the ducktape derivation to explicitly disable pytest-based checks
  - Reformatted the `meta` attribute set for improved readability, moving from multi-line parenthesized style to standard attribute set syntax
  - Reformatted `claude_hooks` propagatedBuildInputs list with improved indentation and line breaks for better readability

- **flake.nix**:
  - Simplified `lib` attribute assignment from `lib = pkgs.lib;` to `inherit (pkgs) lib;` for more idiomatic Nix code

These changes improve code consistency and readability without altering functionality.

https://claude.ai/code/session_012ms2pUqC5GtHqQFNkRuMPB