### PR TITLE
fix(ci): resolve crane binary via bazel info execution_root

### DIFF
--- a/devinfra/ci/bb_push_images.sh
+++ b/devinfra/ci/bb_push_images.sh
@@ -28,9 +28,14 @@ cat >~/.docker/config.json <<ENDJSON
 {"auths":{"ghcr.io":{"auth":"${AUTH}"}}}
 ENDJSON
 
-# Build crane from Bazel cache (already cached from CI action).
+# Resolve crane binary to an absolute path.
+# bazel cquery --output=files returns a path relative to the execution root;
+# bazel info execution_root gives the absolute prefix.
 bazel build --config=rbe --remote_download_toplevel @crane
-CRANE=$(bazel cquery --output=files @crane 2>/dev/null)
+EXEC_ROOT="$(bazel info execution_root 2>/dev/null)"
+CRANE="${EXEC_ROOT}/$(bazel cquery --output=files @crane 2>/dev/null)"
+echo "Using crane at: $CRANE"
+"$CRANE" version
 
 # Push images sequentially. bazel run builds (hitting RBE cache
 # from the CI action) then executes crane push with :latest.


### PR DESCRIPTION
## Summary

Fixes the "Push GHCR Images" BuildBuddy workflow failing after the first image push.

`bazel cquery --output=files @crane` returns a path relative to the execution root. Use `bazel info execution_root` (absolute) as the base instead of relying on the working directory, which changes after `bazel run`.

Both runs since #1111 merged failed with:
```
devinfra/ci/bb_push_images.sh: line 49: external/+_repo_rules+crane/crane: No such file or directory
```
Only `token-provisioner` was pushed before exit.

## Test plan

- [ ] Merge, wait for next devel push to trigger "Push GHCR Images"
- [ ] Verify all 10 images appear on GHCR with correct tags

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq