### PR TITLE
refactor: replace pwd/cd with absolute path resolution in CI scripts

### DIFF
--- a/.github/scripts/run-ansible-lint.sh
+++ b/.github/scripts/run-ansible-lint.sh
@@ -2,18 +2,19 @@
 # Run full ansible-lint on all playbooks
 set -euo pipefail
 
-cd "$(dirname "$0")/../../ansible"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ANSIBLE_DIR="${REPO_ROOT}/ansible"
 
 # Full thorough check - no NODEPS, no --offline
 # This validates module parameters, dependencies, etc.
 export ANSIBLE_LINT_SKIP_VAULT=1
 
 # List all playbooks to lint
-playbooks=$(find . -maxdepth 1 -name "*.yaml" -type f ! -name "galaxy.yaml")
+playbooks=$(find "$ANSIBLE_DIR" -maxdepth 1 -name "*.yaml" -type f ! -name "galaxy.yaml")
 
 echo "Running full ansible-lint on playbooks:"
 echo "$playbooks"
 echo ""
 
-# Run on all playbooks
-ansible-lint --config-file ../.ansible-lint.yaml $playbooks
+# Run on all playbooks (--project-dir sets cwd for ansible-lint resolution)
+ansible-lint --project-dir "$ANSIBLE_DIR" --config-file "${REPO_ROOT}/.ansible-lint.yaml" $playbooks

--- a/devinfra/precommit/run_tflint.sh
+++ b/devinfra/precommit/run_tflint.sh
@@ -11,7 +11,7 @@ if [[ "${CLAUDE_CODE_REMOTE:-false}" == "true" ]]; then
   exit 0
 fi
 
-REPO_ROOT="$(pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG="${REPO_ROOT}/cluster/.tflint.hcl"
 
 # Initialize plugins (downloads to ~/.tflint.d/plugins/)


### PR DESCRIPTION
## Summary

Replace `$(pwd)` and `cd` patterns with deterministic absolute path resolution in CI scripts.

- `run_tflint.sh`: `$(pwd)` → `git rev-parse --show-toplevel`
- `run-ansible-lint.sh`: `cd` into ansible dir → `--project-dir` flag with absolute path from `git rev-parse --show-toplevel`

Stacked on #1116 (shares the crane fix commit as base).

## Test plan

- [ ] `pre-commit run tflint --all-files` passes
- [ ] `.github/workflows/ci.yml` ansible-lint job passes

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq