### PR TITLE
Update CNPG compliance table

### DIFF
--- a/cluster/docs/cnpg-conventions.md
+++ b/cluster/docs/cnpg-conventions.md
@@ -48,10 +48,6 @@ pinned DBs or vice versa. This prevents cross-site write latency.
 
 ## Current Compliance
 
-**Note**: Some clusters on `devel` still use `proxmox-csi-retain` — the `local-path`
-migration is tracked in PR #1112. The table below reflects the target state after all
-in-flight PRs land.
-
 | Cluster       | Profile        | Compliant | Notes                                                                      |
 | ------------- | -------------- | --------- | -------------------------------------------------------------------------- |
 | authentik-db  | VPS-HA         | Yes       |                                                                            |
@@ -62,12 +58,13 @@ in-flight PRs land.
 | inventree-db  | Proxmox-single | Yes       |                                                                            |
 | harbor-db     | Proxmox-single | Yes       |                                                                            |
 | gitea-db      | Proxmox-single | Yes       |                                                                            |
-| props-db      | Proxmox-single | **No**    | Missing Proxmox `nodeSelector`                                             |
+| props-db      | Proxmox-single | Yes       |                                                                            |
+| matrix-db     | Proxmox-single | Yes       |                                                                            |
+| firecrawl-db  | Proxmox-single | Yes       |                                                                            |
 | attic-db      | —              | **No**    | 1 instance on Hetzner (documented exception: blocked on containerd 2.2.3+) |
 
 ## TODO
 
-- [ ] Fix `props-db`: add Proxmox `nodeSelector`
 - [ ] Fix `attic-db`: upgrade to VPS-HA (2 instances) once the Hetzner pin is
       appropriate, or move to Proxmox-single once containerd blocker resolves
 - [ ] Set up off-site backups for Proxmox-single clusters (see "CNPG Backup


### PR DESCRIPTION
## Summary

- Update CNPG compliance table: `props-db` is now compliant (fixed in #1112)
- Add `matrix-db` and `firecrawl-db` to the table (landed in #1109, #1110)
- Remove stale note about in-flight PRs and `props-db` TODO

Only remaining violation: `attic-db` (1 instance on Hetzner, documented exception).

## Test plan

- [x] Verified `props-db` has Proxmox `nodeSelector` on devel

https://claude.ai/code/session_01EEKx82da6Z7bQ2CrXCEEtt