### PR TITLE
fix(ci): use bazel run @crane for tagging in GHCR push script

### DIFF
--- a/devinfra/ci/bb_push_images.sh
+++ b/devinfra/ci/bb_push_images.sh
@@ -28,18 +28,9 @@ cat >~/.docker/config.json <<ENDJSON
 {"auths":{"ghcr.io":{"auth":"${AUTH}"}}}
 ENDJSON
 
-# Resolve crane binary to an absolute path.
-# bazel cquery --output=files returns a path relative to the execution root;
-# bazel info execution_root gives the absolute prefix.
-bazel build --config=rbe --remote_download_toplevel @crane
-EXEC_ROOT="$(bazel info execution_root 2>/dev/null)"
-CRANE="${EXEC_ROOT}/$(bazel cquery --output=files @crane 2>/dev/null)"
-echo "Using crane at: $CRANE"
-"$CRANE" version
-
 # Push images sequentially. bazel run builds (hitting RBE cache
 # from the CI action) then executes crane push with :latest.
-# After each push, crane tags with {branch}-YYYYMMDDHHMMSS-{sha7}
+# After each push, `bazel run @crane -- tag` adds the pinned tag
 # so Flux ImagePolicy can track deployable versions.
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 TS=$(date -u +%Y%m%d%H%M%S)
@@ -51,7 +42,7 @@ push_and_tag() {
   echo "Pushing $target"
   bazel run --config=rbe --remote_download_toplevel "$target"
   echo "Tagging ${repo}:latest -> ${repo}:${PINNED_TAG}"
-  $CRANE tag "${repo}:latest" "${PINNED_TAG}"
+  bazel run --config=rbe --remote_download_toplevel @crane -- tag "${repo}:latest" "${PINNED_TAG}"
 }
 
 push_and_tag //cluster/k8s/inventree/token-provisioner:push ghcr.io/agentydragon/token-provisioner


### PR DESCRIPTION
## Summary

`bazel run` of push targets re-symlinks the execroot, deleting the crane binary resolved from `@crane`. All three "Push GHCR Images" runs since #1111 failed after pushing `token-provisioner` (first in the list) because crane disappeared.

Fix: use `bazel run @crane -- tag` instead of resolving and calling the binary directly. Bazel handles path resolution internally on each invocation.

Only `token-provisioner` has made it to GHCR so far. This unblocks the remaining 9 images.

## Test plan

- [ ] Merge, wait for next devel push
- [ ] Verify all 10 images pushed to GHCR with pinned tags

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq