### PR TITLE
cluster: switch token-provisioner from Harbor :latest to GHCR + image policy

### DIFF
--- a/cluster/k8s/flux-image-automation/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation/kustomization.yaml
@@ -20,3 +20,5 @@ resources:
   - tana-mcp-image-policy.yaml
   - tana-token-broker-image-repository.yaml
   - tana-token-broker-image-policy.yaml
+  - token-provisioner-image-repository.yaml
+  - token-provisioner-image-policy.yaml

--- a/cluster/k8s/flux-image-automation/token-provisioner-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation/token-provisioner-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: token-provisioner
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: token-provisioner
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation/token-provisioner-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/token-provisioner-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: token-provisioner
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/token-provisioner
+  interval: 5m

--- a/cluster/k8s/inventree/token-provisioner/cronjob.yaml
+++ b/cluster/k8s/inventree/token-provisioner/cronjob.yaml
@@ -21,11 +21,9 @@ spec:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: inventree-token-provisioner
-          imagePullSecrets:
-            - name: harbor-pull-robot
           containers:
             - name: provisioner
-              image: registry.allegedly.works/ducktape/token-provisioner:latest
+              image: ghcr.io/agentydragon/token-provisioner:latest # {"$imagepolicy": "flux-system:token-provisioner"}
               imagePullPolicy: Always
               env:
                 - name: INVENTREE_ADMIN_USER

--- a/cluster/k8s/inventree/token-provisioner/job.yaml
+++ b/cluster/k8s/inventree/token-provisioner/job.yaml
@@ -2,7 +2,7 @@
 # Fetches the InvenTree admin API token and writes it to the inventree namespace.
 # Reflector mirrors the Secret to openclaw-sandbox and claude-sandbox automatically
 # via the annotation-based reflection policy.
-# Script is baked into registry.allegedly.works/inventree/token-provisioner via Bazel.
+# Script is baked into ghcr.io/agentydragon/token-provisioner via Bazel.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,11 +19,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: inventree-token-provisioner
-      imagePullSecrets:
-        - name: harbor-pull-robot
       containers:
         - name: provisioner
-          image: registry.allegedly.works/ducktape/token-provisioner:latest
+          image: ghcr.io/agentydragon/token-provisioner:latest # {"$imagepolicy": "flux-system:token-provisioner"}
           imagePullPolicy: Always
           env:
             - name: INVENTREE_ADMIN_USER


### PR DESCRIPTION
## Summary

Switch token-provisioner from Harbor `:latest` to GHCR with Flux image automation.

- Add `ImageRepository` + `ImagePolicy` for `ghcr.io/agentydragon/token-provisioner`
- Update job + cronjob: GHCR image ref with `$imagepolicy` markers
- Remove `imagePullSecrets: harbor-pull-robot` (GHCR is public)
- Add to flux-image-automation kustomization

token-provisioner is already on GHCR (pushed by #1111 CI). Flux will auto-update the tag from `:latest` to the pinned `devel-YYYYMMDDHHMMSS-sha7` format.

## Test plan

- [ ] Verify Flux creates the ImageRepository + ImagePolicy
- [ ] Verify Flux auto-updates the image tag in job + cronjob

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq