### PR TITLE
cluster: add Flux Receiver for GHCR package events

### DIFF
--- a/cluster/k8s/flux-webhook/ghcr-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/ghcr-webhook-receiver.yaml
@@ -1,0 +1,80 @@
+---
+# Flux Receiver: GitHub package events → immediate ImageRepository rescan
+#
+# When GitHub sends a `package` webhook (triggered by GHCR image publish),
+# Flux immediately rescans all GHCR ImageRepositories instead of waiting
+# for the 5-minute poll interval.
+#
+# TODO: Provision the token and register the GitHub webhook:
+#
+#   1. Generate a random token:
+#        TOKEN=$(openssl rand -hex 20)
+#
+#   2. Store in Vault:
+#        vault kv put kv/ghcr/webhook-token token="$TOKEN"
+#
+#   3. Wait for ESO to sync (or force-sync):
+#        kubectl annotate externalsecret ghcr-webhook-token -n flux-system \
+#          force-sync=$(date +%s) --overwrite
+#
+#   4. Get the webhook path from the Receiver status:
+#        kubectl get receiver ghcr -n flux-system -o jsonpath='{.status.webhookPath}'
+#
+#   5. Register the GitHub webhook:
+#        gh api repos/agentydragon/ducktape/hooks --method POST \
+#          -f "config[url]=https://flux-webhook.allegedly.works$(kubectl get receiver ghcr -n flux-system -o jsonpath='{.status.webhookPath}')" \
+#          -f "config[secret]=$TOKEN" \
+#          -f "config[content_type]=json" \
+#          -f "events[]=package"
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Receiver
+metadata:
+  name: ghcr
+  namespace: flux-system
+spec:
+  type: github
+  events:
+    - package
+  secretRef:
+    name: ghcr-webhook-token
+  resources:
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: props-backend
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: airlock
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: auth-proxy
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: openclaw-exec
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: openclaw-matrix
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: activitywatch
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: homeassistant-proxy
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: tana-mcp
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: tana-token-broker
+      namespace: flux-system
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: token-provisioner
+      namespace: flux-system

--- a/cluster/k8s/flux-webhook/ghcr-webhook-token-secret.yaml
+++ b/cluster/k8s/flux-webhook/ghcr-webhook-token-secret.yaml
@@ -1,0 +1,29 @@
+---
+# Webhook token for the Flux GHCR Receiver.
+#
+# TODO: Store a token in Vault at kv/ghcr/webhook-token (see ghcr-webhook-receiver.yaml
+# for provisioning instructions). Until then, this ExternalSecret will fail to sync
+# and the Receiver won't be functional — Flux falls back to 5-minute polling.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-webhook-token
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-webhook-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      data:
+        token: "{{ .token }}"
+  data:
+    - secretKey: token
+      remoteRef:
+        key: kv/ghcr/webhook-token
+        property: token

--- a/cluster/k8s/flux-webhook/kustomization.yaml
+++ b/cluster/k8s/flux-webhook/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - github-webhook-token-secret.yaml
   - harbor-webhook-receiver.yaml
   - harbor-webhook-token-secret.yaml
+  - ghcr-webhook-receiver.yaml
+  - ghcr-webhook-token-secret.yaml
   - flux-webhook-httproute.yaml
   - allow-gateway-webhook-ingress.yaml
   - ntfy-alerts.yaml


### PR DESCRIPTION
## Summary

Add a Flux `Receiver` (type `github`, event `package`) that triggers immediate ImageRepository rescan when GitHub sends a package publish webhook. Eliminates the 5-minute polling delay between GHCR image push and Flux picking up the new tag.

- `ghcr-webhook-receiver.yaml`: github-type Receiver targeting all 10 GHCR ImageRepositories
- `ghcr-webhook-token-secret.yaml`: ExternalSecret reading token from Vault at `kv/ghcr/webhook-token`
- No CI script changes needed — GitHub sends the webhook automatically on package publish

## TODO: Provision the token (after merging)

```bash
# 1. Generate a random token
TOKEN=$(openssl rand -hex 20)

# 2. Store in Vault
vault kv put kv/ghcr/webhook-token token="$TOKEN"

# 3. Wait for ESO to sync (or force-sync)
kubectl annotate externalsecret ghcr-webhook-token -n flux-system \
  force-sync=$(date +%s) --overwrite

# 4. Get the webhook path from the Receiver status
kubectl get receiver ghcr -n flux-system -o jsonpath='{.status.webhookPath}'

# 5. Register the GitHub webhook
gh api repos/agentydragon/ducktape/hooks --method POST \
  -f "config[url]=https://flux-webhook.allegedly.works$(kubectl get receiver ghcr -n flux-system -o jsonpath='{.status.webhookPath}')" \
  -f "config[secret]=$TOKEN" \
  -f "config[content_type]=json" \
  -f "events[]=package"
```

Until provisioned, Flux falls back to 5-minute polling (ExternalSecret won't sync without the Vault secret).

## Test plan

- [ ] Merge and verify Receiver resource is created (will be `NotReady` until token is provisioned)
- [ ] Provision token per instructions above
- [ ] Trigger a CI push, verify GitHub sends `package` webhook
- [ ] Verify Flux rescans ImageRepositories immediately (check notification-controller logs)

https://claude.ai/code/session_01RpUxNgi6i4BkNRz5o1RQRq