### PR TITLE
fix(pre-commit): fix ansible-syntax-check hook via Nix

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,15 +35,6 @@ jobs:
       - uses: ./.github/actions/bazel-repo-cache
         id: bazel-cache
 
-      # Use full 'ansible' package instead of 'ansible-core' to get bundled collections.
-      # This avoids Ansible Galaxy API calls entirely - Galaxy has known reliability issues:
-      # - Intermittent 500 errors (github.com/ansible/galaxy/issues/2954)
-      # - No official status page (github.com/ansible/galaxy/issues/3508)
-      # All required collections (community.docker, community.general, community.crypto,
-      # ansible.netcommon, ansible.posix) are included in the ansible package.
-      - name: Install Ansible
-        run: pip install "ansible>=10"
-
       # Cache Ansible Galaxy roles (required for syntax check - meta/main.yml dependencies)
       - name: Restore Ansible Galaxy roles cache
         id: cache-ansible-roles-restore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,8 +164,7 @@ repos:
       - id: ansible-syntax-check
         name: ansible-playbook --syntax-check
         entry: ansible/scripts/run-syntax-check.sh
-        language: python
-        additional_dependencies: [ansible]
+        language: system
         # Only root-level ansible/*.yaml (playbooks), not roles/vars/etc subdirs.
         files: "^ansible/[^/]+\\.yaml$"
         # TODO: Re-enable gpd.yaml once all machines use Nix home-manager

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,7 @@
               pkgs.shfmt
               pkgs.buildifier
               pkgs.gofumpt
+              pkgs.ansible
               # Infrastructure tools
               pkgs.gh
               pkgs.kubectl


### PR DESCRIPTION
## Summary

- Fix broken `ansible-syntax-check` pre-commit hook by switching from `language: python` to `language: system`
- Add `pkgs.ansible` to the `web-session` Nix package so `ansible-playbook` is on PATH in CI
- Remove the `pip install "ansible>=10"` step from the CI workflow (Nix now provides it)

## Root cause

The hook used `language: python` with `repo: local`, which makes pre-commit run `pip install .` from the repo root. The repo root has no `setup.py`/`pyproject.toml`, so fresh installs fail. A stale pre-commit cache was masking this; once CI's cache budget was exceeded and the venv was rebuilt fresh, every run broke.

## Cost

Adding `pkgs.ansible` to `web-session` adds ~52 MiB download / ~633 MiB unpacked to the closure (current baseline: ~253 MiB download / ~1.1 GiB unpacked).

## Test plan

- [ ] CI pre-commit job passes (ansible-syntax-check hook runs successfully)
- [ ] `nix build .#web-session` succeeds and includes `ansible-playbook`

https://claude.ai/code/session_012ms2pUqC5GtHqQFNkRuMPB