### PR TITLE
style(nix): format home.nix with nixfmt

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -80,9 +80,21 @@ let
   zshInit = builtins.readFile ./shell/zsh-init.zsh;
 
   ducktapePackages = import ../ducktape {
-    inherit lib pkgs ducktape-wheel claude-hooks-wheel gterm-theme-wheel ducktape-util-wheel;
+    inherit
+      lib
+      pkgs
+      ducktape-wheel
+      claude-hooks-wheel
+      gterm-theme-wheel
+      ducktape-util-wheel
+      ;
   };
-  inherit (ducktapePackages) ducktape-util ducktape claude-hooks gterm-theme;
+  inherit (ducktapePackages)
+    ducktape-util
+    ducktape
+    claude-hooks
+    gterm-theme
+    ;
 
   # bbapi - BuildBuddy API CLI
   bbapi = pkgs.callPackage ./packages/bbapi.nix { inherit bbapi-binary; };


### PR DESCRIPTION
## Summary

- Fix `nix/home/home.nix` formatting to pass `nixfmt` pre-commit hook
- The `inherit` statements were on single lines; nixfmt expands them to multi-line

This was causing the pre-commit CI job to fail on every devel commit.

https://claude.ai/code/session_012ms2pUqC5GtHqQFNkRuMPB