### PR TITLE
fix: bazel-precommit regex, JVM heap, and container spec update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,10 +207,10 @@ repos:
         pass_filenames: true
         # Triggers on: test files (pytest-main), cluster files (validations), terraform (centralization)
         files: |
-          (?x)^(
-            .*\\.(py|tf)$|
-            cluster/
-          )$
+          (?x)(
+            \\.(py|tf)$|
+            ^cluster/
+          )
         exclude: |
           (?x)^(
             # Authentik blueprints are not K8s manifests, skip validation

--- a/devinfra/claude/AGENTS.md
+++ b/devinfra/claude/AGENTS.md
@@ -4,8 +4,8 @@
 
 - **Hook daemon logs** (includes session start): `~/.claude/session-env/<session_id>/hook-daemon/daemon.log`
 - **Supervisor logs**: `~/.claude/session-env/<session_id>/supervisor/supervisord.log` (supervisor daemon, used for container runtime)
-- **gVisor environment**: Claude Code web runs on gVisor, not real Linux. Some syscalls behave differently.
-- **9p filesystem limitation**: Root `/` is 9p. Supervisor uses TCP socket (`127.0.0.1:19001`) instead of Unix socket to avoid 9p hard link issues (EOPNOTSUPP).
+- **Firecracker environment**: Claude Code web runs on Firecracker microVMs with a real Linux kernel (not gVisor). Root filesystem is ext4 on virtio disk, not 9p. See <web_env/docs/container_spec.md> for details.
+- **Supervisor uses TCP socket**: `127.0.0.1:19001` (historical: originally to avoid 9p hard link issues, retained for simplicity).
 
 ## Debugging Commands
 

--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -2,6 +2,9 @@
 % if bazel_cache_dir:
 startup --output_user_root=${bazel_cache_dir | sh}
 % endif
+## 8Gi heap: full-monorepo `bazel query` loads 6000+ packages into Skyframe,
+## which exceeds Java's default ~4Gi auto-sized heap on 16Gi machines.
+startup --host_jvm_args=-Xmx8g
 % if web_proxy:
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}

--- a/devinfra/claude/web_env/docs/container_spec.md
+++ b/devinfra/claude/web_env/docs/container_spec.md
@@ -4,22 +4,52 @@ Runtime context for the Claude Code web environment. The reproducible container
 definition lives in the [Dockerfile](../Dockerfile); this file documents the
 parts that aren't captured there.
 
-**Captured**: 2026-03-16.
+**Captured**: 2026-03-30.
 
 ## Runtime Environment
 
-| Property     | Value                             |
-| ------------ | --------------------------------- |
-| OS           | Ubuntu 24.04.3 LTS (Noble Numbat) |
-| Kernel       | Linux 6.18.5 (gVisor sandbox)     |
-| Architecture | x86_64                            |
-| CPUs         | 4                                 |
-| Memory       | 15Gi                              |
-| Disk         | 252G root filesystem              |
-| Hostname     | runsc                             |
+| Property     | Value                                         |
+| ------------ | --------------------------------------------- |
+| OS           | Ubuntu 24.04.3 LTS (Noble Numbat)             |
+| Kernel       | Linux 6.18.5 (real kernel on Firecracker)     |
+| Architecture | x86_64                                        |
+| CPU          | Intel Xeon @ 2.10GHz (Granite/Emerald Rapids) |
+| CPUs         | 4 (no hyperthreading)                         |
+| Memory       | 16Gi (no cgroup limit)                        |
+| Swap         | None                                          |
+| Root disk    | 252G ext4 on `/dev/vda` (virtio)              |
+| Hostname     | vm                                            |
+| Hypervisor   | KVM (Firecracker microVM)                     |
+| Init         | `/process_api --firecracker-init`             |
 
-Note: Hardware specs vary by container allocation. The kernel version
-reflects the gVisor sandbox kernel, not the host kernel.
+### Storage Layout
+
+| Mountpoint         | Source     | FS Type  | Size  | Purpose                  |
+| ------------------ | ---------- | -------- | ----- | ------------------------ |
+| `/`                | `/dev/vda` | ext4     | 252G  | Root filesystem          |
+| `/opt/claude-code` | `/dev/vdb` | squashfs | 60.8M | Claude Code binary (ro)  |
+| `/opt/env-runner`  | `/dev/vdc` | squashfs | 17.5M | Environment manager (ro) |
+| `/dev/shm`         | tmpfs      | tmpfs    | 7.9G  | Shared memory            |
+
+The Bazel cache (`~/.claude/session-env/<id>/bazel-cache`) lives on the ext4
+root disk. There are **no tmpfs mounts** for Bazel cache or container storage.
+
+### Historical Note: gVisor → Firecracker Migration
+
+As of 2026-03-30, the environment runs on **Firecracker microVMs with a real
+Linux kernel**, not gVisor. The root filesystem is ext4 on a virtio block
+device, not 9p. Many gVisor-specific constraints documented elsewhere in this
+repo (no overlay, 9p slowness, `FUSE_CAP_READDIRPLUS`, PTY race conditions)
+may no longer apply. The session start hook's tmpfs mount code
+(`hook_daemon/session_start/tmpfs.py`) targets the old gVisor/9p layout and
+does not activate in this environment.
+
+### Bazel JVM Heap
+
+Java auto-sizes max heap to ~25% of physical memory (~4Gi). For full-monorepo
+`bazel query` operations (6000+ packages), this is insufficient — the Skyframe
+analysis cache alone needs ~4Gi. Add `startup --host_jvm_args=-Xmx8g` to the
+session bazelrc for workloads that load the full package graph.
 
 ## Anthropic-Specific Components
 
@@ -30,9 +60,9 @@ Proprietary binaries stored in `reference/`:
 | environment-manager | `/opt/env-runner/environment-manager` (symlink from `/usr/local/bin`) | Session orchestration, Claude Code lifecycle   |
 | process_api         | `/process_api`                                                        | Container init (PID 1), WebSocket API, VM init |
 
-As of 2026-03-16, `process_api` runs with `--firecracker-init` which adds
-Firecracker VM initialization (root mount, pivot_root, networking, FUSE,
-rclone) before starting the WebSocket listener.
+`process_api` runs with `--firecracker-init` which handles Firecracker VM
+initialization (root mount, pivot_root, networking, FUSE, rclone) before
+starting the WebSocket listener.
 
 The `sandbox-runtime` (`@anthropic-ai/sandbox-runtime`) is now **open source**
 at <https://github.com/anthropic-experimental/sandbox-runtime>.
@@ -61,13 +91,28 @@ The proxy returns non-standard HTTP 401 (not 407) with `www-authenticate` (not
 `Proxy-Authenticate`), which breaks Java's `Authenticator` class. See
 `devinfra/claude/proxy_setup.py` for the local proxy workaround.
 
-## gVisor Constraints
+| Interface | IP Address   |
+| --------- | ------------ |
+| lo        | 127.0.0.1    |
+| eth0      | 192.0.2.2/24 |
 
-- **No `/proc/self/setgroups`**: Use `--annotation run.oci.keep_original_groups=1`. See `scripts/crun-gvisor-wrapper`.
-- **SIGPIPE in `podman build`**: buildah's pipe handling causes SIGPIPE. The Dockerfile's `SHELL` directive redirects output to a log file as workaround.
-- **No overlay filesystem**: Podman must use VFS storage driver.
-- **PTY race condition**: `nix-env` fails due to gVisor EIO on `/dev/ptmx`.
-- **No `binfmt_misc`**: APE (Actually Portable Executable) needs local registry.
+Default route via 192.0.2.1. IPv6 disabled (`ipv6.disable=1`).
+
+## Installed Software
+
+| Tool    | Version                 |
+| ------- | ----------------------- |
+| Python  | 3.11.14 (system)        |
+| Java    | OpenJDK 21.0.10+7       |
+| Node.js | 22.22.0                 |
+| Go      | 1.24.7                  |
+| GCC     | 13.3.0                  |
+| Git     | 2.43.0                  |
+| Bazel   | 8.6.0 (via bazelisk)    |
+| Nix     | 2.28.3                  |
+| Docker  | 29.2.1 (CLI + BuildKit) |
+
+Nix store: ~2.9Gi on root disk.
 
 ## Users
 


### PR DESCRIPTION
## Summary

- **Fix `bazel-precommit` regex**: the `files:` pattern had a trailing `$` on the outer group, making `cluster/` only match the literal string `"cluster/"`, not paths like `cluster/k8s/kustomization.yaml`. Cluster validation (including `test_no_unwired_flux_kustomizations`) never ran on commit.
- **Add `-Xmx8g` to bazelrc template**: Java auto-sizes max heap to ~4Gi on 16Gi machines, but full-monorepo `bazel query` loads 6000+ packages into Skyframe and needs ~4Gi heap alone. Without this, the JVM gets OOM-killed during `enforce-bazel-tests` rdeps queries.
- **Update container spec for Firecracker**: the web environment migrated from gVisor (9p root) to Firecracker microVMs (real Linux kernel, ext4 on virtio). Updated `container_spec.md` with full hardware inventory, storage layout, installed software versions. Updated `AGENTS.md` to remove stale gVisor references.

## Context

Found during investigation of whether `enforce-bazel-tests` can catch unwired flux kustomizations at commit time. Key findings:

| Query scope | Cold time | Warm time |
|---|---|---|
| `//cluster/...` | ~3s | 100ms |
| Full 44-package universe | ~45min | **25ms** |

The 45-min cold start is Skyframe analysis loading 6318 packages (including massive pip/Haskell/npm packages with 47K+ targets) plus repo rule fetches through the TLS proxy. Warm queries are 25ms — the hook works once the server is warm.

## Test plan

- [x] Verified regex fix matches `cluster/k8s/kustomization.yaml` and other cluster paths
- [x] Verified `-Xmx8g` prevents OOM during full-universe queries (3.8Gi peak RSS, stable)
- [x] Pre-commit hooks pass on both commits
- [ ] Verify `bazel-precommit` now runs cluster validation when cluster YAML files are changed

https://claude.ai/code/session_01ANqoTWWCxF71H5Aq2DqwnT