### PR TITLE
fix(ci): bake wheels into e2e container image via pkg_tar

### DIFF
--- a/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//devinfra/testing:defs.bzl", "py_test")
 
 # Apt manifest + lockfile for rules_distroless (referenced from MODULE.bazel).
@@ -6,6 +7,18 @@ exports_files([
     "trixie_e2e.yaml",
     "trixie_e2e.lock.json",
 ])
+
+# Wheels baked into the container image at /wheel/ so the test can
+# `pip install --find-links /wheel/` without bind-mounting from runfiles.
+pkg_tar(
+    name = "e2e_wheels",
+    testonly = True,
+    srcs = [
+        "//:claude_hooks_wheel",
+        "//util:wheel",
+    ],
+    package_dir = "/wheel",
+)
 
 # E2E test container: python:3.13-slim base + git + JDK from rules_distroless.
 # See trixie_e2e.yaml for the deb manifest.
@@ -24,6 +37,7 @@ oci_image(
     },
     tars = [
         "@trixie_e2e//:flat",
+        ":e2e_wheels",
     ],
 )
 
@@ -47,9 +61,7 @@ py_test(
     srcs = ["test_container_e2e.py"],
     data = [
         ":e2e_container_tarball",
-        "//:claude_hooks_wheel",
         "//devinfra/claude/testdata/test_workspace:workspace_files",
-        "//util:wheel",
         "@bazelisk_linux_amd64//file",
     ],
     env_inherit = [

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
@@ -20,6 +20,15 @@ pkg_tar(
     package_dir = "/wheel",
 )
 
+# Bazelisk binary baked into /tools/ (on PATH via oci_image env).
+pkg_tar(
+    name = "e2e_bazelisk",
+    testonly = True,
+    srcs = ["@bazelisk_linux_amd64//file"],
+    package_dir = "/tools",
+    remap_paths = {"/file/bazelisk": "bazelisk"},
+)
+
 # E2E test container: python:3.13-slim base + git + JDK from rules_distroless.
 # See trixie_e2e.yaml for the deb manifest.
 #
@@ -33,11 +42,12 @@ oci_image(
     # JDK update-alternatives postinst doesn't run in rules_distroless, so
     # /usr/bin/keytool won't exist. Extend PATH to include JDK bin directly.
     env = {
-        "PATH": "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/lib/jvm/java-21-openjdk-amd64/bin",
+        "PATH": "/tools:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/lib/jvm/java-21-openjdk-amd64/bin",
     },
     tars = [
         "@trixie_e2e//:flat",
         ":e2e_wheels",
+        ":e2e_bazelisk",
     ],
 )
 
@@ -62,7 +72,6 @@ py_test(
     data = [
         ":e2e_container_tarball",
         "//devinfra/claude/testdata/test_workspace:workspace_files",
-        "@bazelisk_linux_amd64//file",
     ],
     env_inherit = [
         "DOCKER_HOST",

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
@@ -49,6 +49,7 @@ py_test(
         ":e2e_container_tarball",
         "//:claude_hooks_wheel",
         "//devinfra/claude/testdata/test_workspace:workspace_files",
+        "//util:wheel",
         "@bazelisk_linux_amd64//file",
     ],
     env_inherit = [

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -58,12 +58,9 @@ logger = logging.getLogger(__name__)
 
 pytest_plugins = ["devinfra.claude.testing.mitmproxy_fixture"]
 
-# Wheels are baked into the e2e_container image at /wheel/ via pkg_tar layer
-# (see BUILD.bazel). pip install uses --find-links to resolve local deps.
+# Wheels and bazelisk are baked into the e2e_container image via pkg_tar layers
+# (see BUILD.bazel). Wheels at /wheel/, bazelisk at /tools/bazelisk (on PATH).
 _WHEEL_DIR = "/wheel"
-
-# Rlocation for bazelisk binary (mirrors what Nix web-session provides on PATH in prod)
-_BAZELISK_RLOCATION = "bazelisk_linux_amd64/file/bazelisk"
 
 # Rlocation for a file in the test workspace (used to derive directory path)
 _TEST_WORKSPACE_MODULE = "_main/devinfra/claude/testdata/test_workspace/MODULE.bazel"
@@ -131,12 +128,6 @@ def _exec(
 
 
 @pytest.fixture
-def bazelisk_path() -> Path:
-    """Resolve the bazelisk binary from runfiles."""
-    return get_required_path(_BAZELISK_RLOCATION)
-
-
-@pytest.fixture
 def test_workspace_path() -> Path:
     """Resolve the test workspace directory from runfiles."""
     return get_required_path(_TEST_WORKSPACE_MODULE).parent
@@ -156,7 +147,6 @@ def e2e_image() -> str:
 
 def test_container_e2e(
     tmp_path: Path,
-    bazelisk_path: Path,
     test_workspace_path: Path,
     mitmproxy_proxy: MitmproxyFixture,
     isolated_net: docker.models.networks.Network,
@@ -172,9 +162,6 @@ def test_container_e2e(
     # (runfiles may be symlinks that Docker cannot resolve in gVisor)
     staging = tmp_path / "staging"
     staging.mkdir()
-    staged_bazelisk = staging / "bazelisk"
-    shutil.copy2(bazelisk_path, staged_bazelisk)
-    staged_bazelisk.chmod(0o755)
     staged_workspace = staging / "test_workspace"
     shutil.copytree(test_workspace_path, staged_workspace)
     (staged_workspace / ".git").mkdir()  # pre-commit needs a git repo
@@ -201,9 +188,6 @@ def test_container_e2e(
         "DUCKTAPE_CLAUDE_HOOKS_INSTALL_APT_PACKAGES": "false",
         "DUCKTAPE_CLAUDE_HOOKS_CONTAINER_RUNTIME": "none",
         "ANTHROPIC_CA_PATH": "/certs/mock_ca.pem",
-        # /tools is on PATH in the container; bazelisk is bind-mounted there.
-        "PATH": "/tools:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
-        ":/usr/lib/jvm/java-21-openjdk-amd64/bin",
     }
     for var in PROXY_ENV_VARS:
         env[var] = mitmproxy_proxy.container_url
@@ -217,10 +201,6 @@ def test_container_e2e(
         environment=env,
         network=isolated_net.name,
         volumes={
-            # TODO: Mount as the exact binary name the nix flake provides (bazelisk),
-            # not as an alias. Don't create unconventional symlinks in the test container.
-            # The session start hook should work starting from the nix flake dev shell env.
-            str(staged_bazelisk): {"bind": "/tools/bazelisk", "mode": "ro"},
             str(mock_ca_path): {"bind": "/certs/mock_ca.pem", "mode": "ro"},
             str(combined_ca_path): {"bind": "/certs/combined_ca.pem", "mode": "ro"},
             str(staged_workspace): {"bind": "/project", "mode": "ro"},

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -6,9 +6,9 @@ all external connectivity).
 
 Architecture:
     Host side:
-        - Builds the claude_hooks wheel via Bazel
+        - Builds the claude_hooks wheel via Bazel (baked into e2e_container image)
         - Loads mitmproxy:11 OCI image into Docker
-        - Loads e2e-container image (python:3.13-slim + git + JDK, built by Bazel)
+        - Loads e2e-container image (python:3.13-slim + git + JDK + wheels, built by Bazel)
         - Creates two Docker networks:
           - e2e-proxy (bridge): proxy container has internet access
           - e2e-isolated (internal bridge): test container <-> proxy container only
@@ -18,7 +18,8 @@ Architecture:
         - Drives test steps via docker exec calls
 
     Container side (via docker exec):
-        - Installs claude_hooks wheel (pip through proxy -> mitmproxy container)
+        - Installs claude_hooks wheel from /wheel/ (baked into image, deps fetched
+          through proxy -> mitmproxy container)
         - Runs claude-hook (session start hook) which sets up:
           auth proxy, supervisor, bazel wrapper, CA bundles, env file
         - Runs bazel build through the full proxy chain
@@ -57,13 +58,9 @@ logger = logging.getLogger(__name__)
 
 pytest_plugins = ["devinfra.claude.testing.mitmproxy_fixture"]
 
-# Rlocation for the claude_hooks wheel (built by //:claude_hooks_wheel)
-_WHEEL_RLOCATION = "_main/claude_hooks-0.1.0-py3-none-any.whl"
-_WHEEL_FILENAME = _WHEEL_RLOCATION.rsplit("/", 1)[-1]
-
-# Rlocation for the ducktape_util wheel (built by //util:wheel, runtime dep of claude_hooks)
-_UTIL_WHEEL_RLOCATION = "_main/util/ducktape_util-0.1.0-py3-none-any.whl"
-_UTIL_WHEEL_FILENAME = _UTIL_WHEEL_RLOCATION.rsplit("/", 1)[-1]
+# Wheels are baked into the e2e_container image at /wheel/ via pkg_tar layer
+# (see BUILD.bazel). pip install uses --find-links to resolve local deps.
+_WHEEL_DIR = "/wheel"
 
 # Rlocation for bazelisk binary (mirrors what Nix web-session provides on PATH in prod)
 _BAZELISK_RLOCATION = "bazelisk_linux_amd64/file/bazelisk"
@@ -134,12 +131,6 @@ def _exec(
 
 
 @pytest.fixture
-def wheel_path() -> Path:
-    """Resolve the built ducktape wheel from runfiles."""
-    return get_required_path(_WHEEL_RLOCATION)
-
-
-@pytest.fixture
 def bazelisk_path() -> Path:
     """Resolve the bazelisk binary from runfiles."""
     return get_required_path(_BAZELISK_RLOCATION)
@@ -165,7 +156,6 @@ def e2e_image() -> str:
 
 def test_container_e2e(
     tmp_path: Path,
-    wheel_path: Path,
     bazelisk_path: Path,
     test_workspace_path: Path,
     mitmproxy_proxy: MitmproxyFixture,
@@ -182,10 +172,6 @@ def test_container_e2e(
     # (runfiles may be symlinks that Docker cannot resolve in gVisor)
     staging = tmp_path / "staging"
     staging.mkdir()
-    staged_wheel = staging / _WHEEL_FILENAME
-    shutil.copy2(wheel_path, staged_wheel)
-    staged_util_wheel = staging / _UTIL_WHEEL_FILENAME
-    shutil.copy2(get_required_path(_UTIL_WHEEL_RLOCATION), staged_util_wheel)
     staged_bazelisk = staging / "bazelisk"
     shutil.copy2(bazelisk_path, staged_bazelisk)
     staged_bazelisk.chmod(0o755)
@@ -215,7 +201,6 @@ def test_container_e2e(
         "DUCKTAPE_CLAUDE_HOOKS_INSTALL_APT_PACKAGES": "false",
         "DUCKTAPE_CLAUDE_HOOKS_CONTAINER_RUNTIME": "none",
         "ANTHROPIC_CA_PATH": "/certs/mock_ca.pem",
-        "WHEEL_PATH": f"/wheel/{_WHEEL_FILENAME}",
         # /tools is on PATH in the container; bazelisk is bind-mounted there.
         "PATH": "/tools:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
         ":/usr/lib/jvm/java-21-openjdk-amd64/bin",
@@ -232,8 +217,6 @@ def test_container_e2e(
         environment=env,
         network=isolated_net.name,
         volumes={
-            str(staged_wheel): {"bind": f"/wheel/{_WHEEL_FILENAME}", "mode": "ro"},
-            str(staged_util_wheel): {"bind": f"/wheel/{_UTIL_WHEEL_FILENAME}", "mode": "ro"},
             # TODO: Mount as the exact binary name the nix flake provides (bazelisk),
             # not as an alias. Don't create unconventional symlinks in the test container.
             # The session start hook should work starting from the nix flake dev shell env.
@@ -253,14 +236,12 @@ def test_container_e2e(
         assert rc != 0, "Container should have no external internet access on --internal network"
         logger.info("Network isolation verified: container cannot reach internet directly")
 
-        # Install ducktape wheel
+        # Install claude_hooks wheel (baked into image at /wheel/).
+        # --find-links resolves ducktape-util locally; other deps fetched from PyPI via proxy.
         # TODO(container-e2e): Install via uv by reading .claude/settings.json
         # hook definition and piping the JSON into sh, instead of raw pip.
         logger.info("Installing wheel")
-        _exec(
-            container,
-            ["pip", "install", "--break-system-packages", "--find-links", "/wheel/", f"/wheel/{_WHEEL_FILENAME}"],
-        )
+        _exec(container, ["pip", "install", "--break-system-packages", "--find-links", _WHEEL_DIR, "claude-hooks"])
 
         # Run session start hook
         logger.info("Running claude-hook (session start)")

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -61,6 +61,10 @@ pytest_plugins = ["devinfra.claude.testing.mitmproxy_fixture"]
 _WHEEL_RLOCATION = "_main/claude_hooks-0.1.0-py3-none-any.whl"
 _WHEEL_FILENAME = _WHEEL_RLOCATION.rsplit("/", 1)[-1]
 
+# Rlocation for the ducktape_util wheel (built by //util:wheel, runtime dep of claude_hooks)
+_UTIL_WHEEL_RLOCATION = "_main/util/ducktape_util-0.1.0-py3-none-any.whl"
+_UTIL_WHEEL_FILENAME = _UTIL_WHEEL_RLOCATION.rsplit("/", 1)[-1]
+
 # Rlocation for bazelisk binary (mirrors what Nix web-session provides on PATH in prod)
 _BAZELISK_RLOCATION = "bazelisk_linux_amd64/file/bazelisk"
 
@@ -180,6 +184,8 @@ def test_container_e2e(
     staging.mkdir()
     staged_wheel = staging / _WHEEL_FILENAME
     shutil.copy2(wheel_path, staged_wheel)
+    staged_util_wheel = staging / _UTIL_WHEEL_FILENAME
+    shutil.copy2(get_required_path(_UTIL_WHEEL_RLOCATION), staged_util_wheel)
     staged_bazelisk = staging / "bazelisk"
     shutil.copy2(bazelisk_path, staged_bazelisk)
     staged_bazelisk.chmod(0o755)
@@ -227,6 +233,7 @@ def test_container_e2e(
         network=isolated_net.name,
         volumes={
             str(staged_wheel): {"bind": f"/wheel/{_WHEEL_FILENAME}", "mode": "ro"},
+            str(staged_util_wheel): {"bind": f"/wheel/{_UTIL_WHEEL_FILENAME}", "mode": "ro"},
             # TODO: Mount as the exact binary name the nix flake provides (bazelisk),
             # not as an alias. Don't create unconventional symlinks in the test container.
             # The session start hook should work starting from the nix flake dev shell env.
@@ -250,7 +257,10 @@ def test_container_e2e(
         # TODO(container-e2e): Install via uv by reading .claude/settings.json
         # hook definition and piping the JSON into sh, instead of raw pip.
         logger.info("Installing wheel")
-        _exec(container, ["pip", "install", "--break-system-packages", f"/wheel/{_WHEEL_FILENAME}"])
+        _exec(
+            container,
+            ["pip", "install", "--break-system-packages", "--find-links", "/wheel/", f"/wheel/{_WHEEL_FILENAME}"],
+        )
 
         # Run session start hook
         logger.info("Running claude-hook (session start)")


### PR DESCRIPTION
## Summary

- The `claude_hooks` wheel declares `ducktape-util` as a runtime dependency, but the container E2E test didn't provide it — `pip install` failed with "No matching distribution found for ducktape-util"
- Instead of staging wheels from runfiles and bind-mounting them (hardcoded rlocations, per-wheel fixtures), bake both wheels into the OCI image at `/wheel/` via a `pkg_tar` layer
- `pip install --find-links /wheel/ claude-hooks` resolves `ducktape-util` locally; other deps fetched from PyPI through the proxy

## Test plan

- [ ] `bazel test //devinfra/claude/hook_daemon/session_start/container_e2e:test_container_e2e` passes on RBE

https://claude.ai/code/session_01Wo8ypQxab8CgyQJeEt3hyM