### PR TITLE
fix(cluster): wire orphaned flux-kustomization.yaml files

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -118,6 +118,7 @@ resources:
 
   # --- harbor ---
   - harbor/namespace/flux-kustomization.yaml
+  - harbor/db/flux-kustomization.yaml
   - harbor/app/flux-kustomization.yaml
   - harbor/secrets/flux-kustomization.yaml
   - harbor/proxy-cache/flux-kustomization.yaml
@@ -126,6 +127,11 @@ resources:
   - harbor/pull-secret/flux-kustomization.yaml
   - harbor/webhook/flux-kustomization.yaml
   - harbor/oidc-config/flux-kustomization.yaml
+
+  # --- firecrawl ---
+  - firecrawl/namespace/flux-kustomization.yaml
+  - firecrawl/db/flux-kustomization.yaml
+  - firecrawl/app/flux-kustomization.yaml
 
   # --- gitea ---
   - gitea/namespace/flux-kustomization.yaml
@@ -137,6 +143,7 @@ resources:
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml
+  - matrix/db/flux-kustomization.yaml
   - matrix/app/flux-kustomization.yaml
   - matrix/secrets/flux-kustomization.yaml
 
@@ -155,6 +162,7 @@ resources:
   # --- inventree ---
   - inventree/namespace/flux-kustomization.yaml
   - inventree/secrets/flux-kustomization.yaml
+  - inventree/db/flux-kustomization.yaml
   - inventree/app/flux-kustomization.yaml
   - inventree/token-provisioner/flux-kustomization.yaml
 


### PR DESCRIPTION
## Summary

- Add missing `flux-kustomization.yaml` references to the root kustomization that were added in recent CNPG PRs (#1109, #1110, #1112) but never wired in
- **firecrawl**: new section with namespace, db, app
- **harbor/db**, **matrix/db**, **inventree/db**: added between existing entries in their respective sections
- Fixes `test_no_orphaned_files` and `test_no_unwired_flux_kustomizations` in `//cluster/validation:test_cluster_integration`

## Test plan

- [ ] `bazel test //cluster/validation:test_cluster_integration` — orphan/unwired tests pass

https://claude.ai/code/session_01Wo8ypQxab8CgyQJeEt3hyM