### PR TITLE
fix(cluster): handle key=filename in configMapGenerator files

### DIFF
--- a/cluster/validation/kustomize.py
+++ b/cluster/validation/kustomize.py
@@ -51,9 +51,17 @@ class KustomizeFile(_CamelCaseModel):
     def resolved_patches(self) -> list[Path]:
         return [self._resolve(p.path) for p in self.patches if p.path]
 
+    @staticmethod
+    def _strip_configmap_key(p: Path) -> Path:
+        """Handle `key=filename` format in configMapGenerator files entries."""
+        name = str(p)
+        if "=" in name:
+            return Path(name.split("=", 1)[1])
+        return p
+
     @property
     def resolved_generator_files(self) -> list[Path]:
-        return [self._resolve(f) for entry in self.config_map_generator for f in entry.files]
+        return [self._resolve(self._strip_configmap_key(f)) for entry in self.config_map_generator for f in entry.files]
 
     @property
     def all_referenced_files(self) -> set[Path]:


### PR DESCRIPTION
## Summary

- Fix false positive in orphan file check: `configMapGenerator.files` entries can use `key=filename` format (e.g., `config.yaml=proxy-config.yaml`), but the validator resolved the whole string as a path
- Strip the `key=` prefix before resolving, so `litellm/app/proxy-config.yaml` is correctly recognized as referenced

## Test plan

- [ ] `bazel test //cluster/validation:test_cluster_integration` — `proxy-config.yaml` no longer flagged as orphaned
- [ ] Pre-commit `cluster-validate` no longer reports the litellm orphan

https://claude.ai/code/session_01Wo8ypQxab8CgyQJeEt3hyM