### PR TITLE
fix(cluster): add missing dependsOn for sealed-secrets and ESO

### DIFF
--- a/cluster/k8s/agents/airlock/flux-kustomization.yaml
+++ b/cluster/k8s/agents/airlock/flux-kustomization.yaml
@@ -20,3 +20,5 @@ spec:
       namespace: airlock
   dependsOn:
     - name: gateway
+    - name: sealed-secrets
+    - name: external-secrets-config

--- a/cluster/k8s/agents/homeassistant-proxy/flux-kustomization.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/flux-kustomization.yaml
@@ -18,4 +18,6 @@ spec:
       kind: Deployment
       name: homeassistant-proxy
       namespace: homeassistant-proxy
-  dependsOn: []
+  dependsOn:
+    - name: sealed-secrets
+    - name: external-secrets-config


### PR DESCRIPTION
## Summary

- `homeassistant-proxy` and `airlock` use SealedSecret and ExternalSecret resources but didn't declare `dependsOn` for `sealed-secrets` and `external-secrets-config`
- Adds the missing dependencies to both flux-kustomization.yaml files

## Test plan

- [ ] `bazel test //cluster/validation:test_cluster_integration` — `test_no_dependency_errors` passes

https://claude.ai/code/session_01Wo8ypQxab8CgyQJeEt3hyM