### PR TITLE
fix(cluster): add missing dependsOn on monitoring-stack for litellm

### DIFF
--- a/cluster/k8s/litellm/app/flux-kustomization.yaml
+++ b/cluster/k8s/litellm/app/flux-kustomization.yaml
@@ -15,3 +15,4 @@ spec:
     - name: litellm-secrets
     - name: gateway
     - name: cert-manager-environment
+    - name: monitoring-stack


### PR DESCRIPTION
## Summary

- litellm uses a `ServiceMonitor` CRD resource installed by the `monitoring-stack` (kube-prometheus-stack), but didn't declare the dependency
- Without it, Flux may try to apply the ServiceMonitor before the CRD exists

## Test plan

- [ ] Pre-commit `cluster-validate` no longer reports the litellm monitoring-stack dependency error

https://claude.ai/code/session_01Wo8ypQxab8CgyQJeEt3hyM