### PR TITLE
Fix forward compatibility and subprocess isolation issues

### DIFF
--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -17,6 +17,7 @@ import time
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
 from opentelemetry import trace
 from pydantic import BaseModel
 
@@ -145,12 +146,17 @@ async def handle_hook(req: HookRequest) -> HookResponse:
                 pass  # All other hooks: noop
 
         resp = HookResponse(output=output)
+        # exclude_none: the client may run an older version of the models
+        # (e.g. Nix-installed claude-hook) that uses extra="forbid" on
+        # CamelModel. New Optional fields default to None; if serialized
+        # as null they become unknown extras on the old client → ValidationError.
+        # Omitting None fields keeps the wire format forward-compatible.
         resp_json = resp.model_dump_json(by_alias=True, exclude_none=True)
 
         span.set_attribute("hook.output", resp_json)
         logger.info("hook %s → %s", hook_name, resp_json)
 
-        return resp
+        return Response(content=resp_json, media_type="application/json")
 
 
 class _UpdateProxyCredsRequest(BaseModel):

--- a/devinfra/claude/hook_daemon/test_hook_daemon.py
+++ b/devinfra/claude/hook_daemon/test_hook_daemon.py
@@ -102,6 +102,36 @@ class TestHandleHook:
         saved = json.loads(env_file.read_text())
         assert saved["MY_VAR"] == "my_value"
 
+    async def test_response_excludes_none_fields(self, client: AsyncClient, env: dict[str, str]) -> None:
+        """Response JSON omits None-valued fields for forward compatibility.
+
+        The daemon may run newer code than the client (e.g. daemon from source
+        tree, client from Nix package). CamelModel uses extra="forbid", so any
+        new Optional field serialized as null breaks older clients with a
+        ValidationError. Verify that /hook responses never contain null values.
+        """
+        hook_input = PreToolUseInput(
+            **_COMMON,
+            hook_event_name="PreToolUse",
+            tool_use_id="toolu_test",
+            tool_name="Bash",
+            tool_input={"command": "ls"},
+        )
+        req = HookRequest(hook=hook_input, env=env)
+        resp = await client.post("/hook", content=req.model_dump_json(), headers=_JSON_HEADERS)
+        assert resp.status_code == 200
+
+        def _assert_no_nulls(obj: object, path: str = "") -> None:
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    assert v is not None, f"Null value at {path}.{k} — use exclude_none=True"
+                    _assert_no_nulls(v, f"{path}.{k}")
+            elif isinstance(obj, list):
+                for i, v in enumerate(obj):
+                    _assert_no_nulls(v, f"{path}[{i}]")
+
+        _assert_no_nulls(resp.json())
+
 
 class TestHealth:
     async def test_health_returns_ok(self, client: AsyncClient) -> None:

--- a/util/bazel/subprocess.py
+++ b/util/bazel/subprocess.py
@@ -37,6 +37,12 @@ def python_env(*, inherit: bool = True) -> dict[str, str]:
             seen.add(p)
             merged.append(p)
     env["PYTHONPATH"] = os.pathsep.join(merged)
+    # Prevent Python from prepending CWD to sys.path (equivalent to -P flag).
+    # Without this, `python -m module` adds '' to sys.path[0], causing the
+    # subprocess to import from the working directory instead of PYTHONPATH —
+    # e.g. the hook daemon picks up source-tree modules instead of the
+    # Nix-installed wheel, creating client/server version skew.
+    env["PYTHONSAFEPATH"] = "1"
     return env
 
 

--- a/util/bazel/test_subprocess.py
+++ b/util/bazel/test_subprocess.py
@@ -44,6 +44,28 @@ def test_python_env_uses_sys_path_when_no_pythonpath():
         assert {p for p in sys.path if p} <= result_paths
 
 
+def test_python_env_sets_safe_path():
+    """PYTHONSAFEPATH=1 prevents subprocesses from importing from CWD."""
+    env = python_env(inherit=False)
+    assert env.get("PYTHONSAFEPATH") == "1"
+
+
+def test_subprocess_does_not_import_from_cwd(tmp_path: Path):
+    """Subprocess launched via run_python_module cannot import from CWD.
+
+    Regression test: without PYTHONSAFEPATH, `python -m module` prepends ''
+    (CWD) to sys.path, causing it to shadow installed packages with source
+    tree modules — e.g. the hook daemon imported from the git checkout
+    instead of the Nix wheel.
+    """
+    # Create a decoy module in a temp dir that would shadow a stdlib module
+    (tmp_path / "json.py").write_text("raise RuntimeError('imported from CWD!')\n")
+    result = run_python_module("json.tool", "--help", capture_output=True, text=True, check=False, cwd=tmp_path)
+    # json.tool --help should succeed (exit 0) using the real stdlib json,
+    # not the decoy. Without PYTHONSAFEPATH, it would import the decoy and crash.
+    assert result.returncode == 0, f"Subprocess imported from CWD: {result.stderr}"
+
+
 def test_run_python_module_basic():
     result = run_python_module("sys", capture_output=True, text=True, check=False)
     # python -m sys doesn't exist as runnable, but the command should execute


### PR DESCRIPTION
## Summary
This PR addresses two separate issues: ensuring hook daemon responses are forward-compatible with older clients, and preventing Python subprocesses from importing modules from the current working directory.

## Key Changes

- **Hook daemon response serialization**: Modified `server.py` to use `exclude_none=True` when serializing `HookResponse` objects and return a `Response` object directly with the serialized JSON. This prevents null-valued fields from being sent to older clients that use `extra="forbid"` validation, which would cause `ValidationError` when encountering unknown fields.

- **PYTHONSAFEPATH environment variable**: Added `PYTHONSAFEPATH=1` to the Python environment in `subprocess.py` to prevent subprocesses from importing modules from the current working directory. This prevents version skew issues where the hook daemon would import from the source tree instead of the installed Nix wheel.

- **Test coverage**: Added comprehensive tests to verify both fixes:
  - `test_response_excludes_none_fields`: Validates that hook responses contain no null values
  - `test_python_env_sets_safe_path`: Confirms `PYTHONSAFEPATH` is set in the environment
  - `test_subprocess_does_not_import_from_cwd`: Regression test ensuring subprocesses use installed packages, not CWD modules

## Implementation Details

The forward compatibility fix is necessary because the daemon may run newer code than the client (e.g., daemon from source tree, client from Nix package). By omitting None fields, the wire format remains compatible with older clients that have stricter validation rules.

The `PYTHONSAFEPATH` fix addresses a subtle but critical issue where `python -m module` prepends the current working directory to `sys.path`, allowing it to shadow installed packages with source tree modules.

https://claude.ai/code/session_01EuX5TLc4jucKvyBdxuzwPk