### PR TITLE
fix: mypy return type and util wheel visibility

### DIFF
--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -105,7 +105,7 @@ def _save_session_env(env: dict[str, str]) -> None:
 
 
 @app.post("/hook")
-async def handle_hook(req: HookRequest) -> HookResponse:
+async def handle_hook(req: HookRequest) -> Response:
     app.state.last_request_time = time.monotonic()
 
     tracer = trace.get_tracer(__name__)

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -116,5 +116,6 @@ py_wheel(
     python_requires = ">=3.13",
     requires = ["tenacity"],
     version = "0.1.0",
+    visibility = ["//devinfra/claude/hook_daemon/session_start/container_e2e:__pkg__"],
     deps = [":util_pkg"],
 )


### PR DESCRIPTION
## Summary

- Fix mypy error in `server.py:159`: return type was `HookResponse` but actually returns `Response` (Starlette) with pre-serialized JSON for forward compat
- Fix `//util:wheel` visibility: `container_e2e` package needs access (broken since #1133)

Both failures appeared in BuildBuddy CI on devel tip after #1133 merge.

## Test plan

- [x] Pre-commit passes
- [ ] BuildBuddy `test //...` passes (CI)

https://claude.ai/code/session_01ANqoTWWCxF71H5Aq2DqwnT