### PR TITLE
Make sync_pins.py runnable as a uv script

### DIFF
--- a/devinfra/ci/sync_pins.py
+++ b/devinfra/ci/sync_pins.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["PyGithub>=1.77", "pydantic>=2.0", "requests>=2.32"]
+# ///
 """Sync npins/sources.json with the latest GitHub Release for each package.
 
 For each pinned package, finds the latest release tag, compares the URL
@@ -7,6 +11,13 @@ Expects: GH_TOKEN env var.
 """
 
 import os
+import sys
+from pathlib import Path
+
+# Add repo root to path for devinfra.ci imports when running via uv
+_REPO_ROOT = Path(__file__).parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from github import Auth, Github
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -170,6 +170,7 @@ split-on-trailing-comma = false
 # sys.path manipulation must happen before imports in uv run scripts and pytest
 "devinfra/ci/check_release.py" = ["E402"]
 "devinfra/ci/ci_decide.py" = ["E402"]
+"devinfra/ci/sync_pins.py" = ["E402"]
 # conftest.py re-exports fixtures for pytest discovery — imports are "unused" by design
 # and fixture parameters naturally shadow the imported fixture names (F811)
 "**/conftest.py" = ["F401", "F811"]


### PR DESCRIPTION
## Summary
Convert `devinfra/ci/sync_pins.py` to be executable as a standalone uv script by adding PEP 723 script metadata and fixing import path resolution.

## Key Changes
- Added PEP 723 script metadata block specifying Python version (>=3.12) and dependencies (PyGithub, pydantic, requests)
- Added sys.path manipulation to ensure `devinfra.ci` imports work when the script is run via `uv run`
- Updated `ruff.toml` to allow E402 (module level import not at top of file) for the script, consistent with other CI scripts that perform sys.path manipulation

## Implementation Details
The script now:
1. Declares its runtime requirements in a standardized format that `uv` can parse and install
2. Dynamically adds the repository root to `sys.path` before importing from the `devinfra` package, enabling execution as a standalone script without requiring the full package to be installed
3. Follows the same pattern already established in `check_release.py` and `ci_decide.py` for handling imports in uv-executed scripts

https://claude.ai/code/session_01Mc7fmb9fxZAY1WTsq7Pysh