### PR TITLE
Add ducktape-util dependency to Nix configuration

### DIFF
--- a/nix/ducktape/default.nix
+++ b/nix/ducktape/default.nix
@@ -98,6 +98,7 @@ in
       pillow
       websockets
       asyncvnc
+      ducktape-util
     ];
   };
 
@@ -135,6 +136,7 @@ in
       ++ [
         pkgs.pre-commit
         pyrage
+        ducktape-util
       ];
   };
 


### PR DESCRIPTION
## Summary
This change adds the `ducktape-util` package as a dependency in the Nix configuration for the ducktape project.

## Key Changes
- Added `ducktape-util` to the Python dependencies in the main ducktape package definition
- Added `ducktape-util` to the development environment dependencies

## Details
The `ducktape-util` package is now included in two locations within the Nix configuration:
1. As a runtime dependency in the main package's Python environment
2. As a development dependency in the development shell environment

This ensures the utility is available both when using the package and during development.

https://claude.ai/code/session_016m2FXWXGwpWXPMMUzSBmx8