### PR TITLE
Suspend Gitea and Grocy flux kustomizations

### DIFF
--- a/cluster/k8s/authentik/blueprints/gitea-secret/flux-kustomization.yaml
+++ b/cluster/k8s/authentik/blueprints/gitea-secret/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: authentik-blueprint-gitea-secret
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/gitea/admin-token/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/admin-token/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea-admin-token
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/gitea/app/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/app/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/gitea/db/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/db/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea-db
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/gitea/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/namespace/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea-namespace
   namespace: flux-system
 spec:
+  suspend: true
   interval: 1h
   path: ./cluster/k8s/gitea/namespace
   prune: false

--- a/cluster/k8s/gitea/secrets/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/secrets/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea-secrets
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   path: ./cluster/k8s/gitea/secrets

--- a/cluster/k8s/gitea/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/gitea/servicemonitor/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gitea-servicemonitor
   namespace: flux-system
 spec:
+  suspend: true
   interval: 10m
   path: ./cluster/k8s/gitea/servicemonitor
   prune: true

--- a/cluster/k8s/grocy/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: grocy
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m


### PR DESCRIPTION
## Summary

- Add `suspend: true` to all Gitea flux kustomizations (namespace, db, secrets, app, admin-token, servicemonitor) and the authentik gitea-secret blueprint
- Add `suspend: true` to Grocy flux kustomization
- Both were listed as suspended in `cluster/docs/plan.md` but lacked the actual `suspend: true` in their flux-kustomization.yaml files

## Test plan

- [ ] Verify `flux get kustomizations` shows Gitea and Grocy kustomizations as suspended
- [ ] Verify no Gitea or Grocy pods are running after reconciliation

https://claude.ai/code/session_016c2abVKFnRjU4YbLuJTbgi