### PR TITLE
Auto-generate buildbuddy.yaml from image push configuration

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,6 +37,7 @@ npm_link_all_packages(name = "node_modules")
 
 # Export workspace files for npm_translate_lock data tracking
 exports_files([
+    "buildbuddy.yaml",
     "mypy.ini",
     "nebula-mesh.json",
     "package.json",

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,16 +1,9 @@
-# BuildBuddy Workflows Configuration
-#
-# Runs Bazel build/test/lint on BuildBuddy RBE for faster CI.
-# Non-Bazel tasks (ansible-lint, nix-flake-check, pre-commit) remain in GitHub Actions.
+# AUTO-GENERATED from devinfra/ci/generate_buildbuddy.py - DO NOT EDIT DIRECTLY
+# Regenerate with: bazel run //devinfra/ci:generate_buildbuddy_bin
 #
 # BuildBuddy docs: https://www.buildbuddy.io/docs/workflows-config/
-#
-# RBE is NOT auto-enabled by BuildBuddy Workflows (only remote cache + BES are).
-# We pass --config=rbe (defined in .bazelrc) to enable remote execution.
-# See: https://www.buildbuddy.io/docs/rbe-setup/
-
 actions:
-  - name: "CI"
+  - name: CI
     triggers:
       push:
         branches:
@@ -18,61 +11,28 @@ actions:
           - master
           - devel
       pull_request: {}
-
-    # Use Ubuntu 24.04 for glibc 2.39 (Node.js 22.11.0 requires glibc 2.28+)
-    # BuildBuddy Workflows only supports predefined Ubuntu images, not custom images
-    # like ghcr.io/agentydragon/rbe-worker. RBE workers still use the custom image.
-    container_image: "ubuntu-24.04"
+    container_image: ubuntu-24.04
     resource_requests:
-      # Default 8GB RAM OOMs when remote cache is cold and many OCI image
-      # Merkle trees are computed simultaneously (~57k actions for //...).
-      memory: "16GB"
-      disk: "50GB"
-
+      memory: 16GB
+      disk: 50GB
     bazel_commands:
-      # 1. Run all tests (excluding live OpenAI API tests)
-      - >
-        test
-        --keep_going
-        --config=rbe
-        --build_metadata=ROLE=ci
-        --build_metadata=TAGS=test
-        --test_tag_filters=-live_openai_api
+      - test --keep_going --config=rbe --build_metadata=ROLE=ci --build_metadata=TAGS=test --test_tag_filters=-live_openai_api
         //...
-
-      # 2. Build + lint + typecheck + rust-check (all quality checks in one pass)
-      # Lint runs by default: ruff, ESLint, mypy, clippy, rustfmt.
-      # Use local strategy for mypy to avoid sandbox copying overhead.
-      - >
-        build
-        --keep_going
-        --config=rbe
-        --strategy=mypy=local
-        --build_metadata=ROLE=ci
-        --build_metadata=TAGS=check
-        //...
-
-  # Release action: test, build all artifacts, upload to GitHub Releases, dispatch GHA nix-pin.
-  # Only triggers on push to main/devel (not PRs).
-  - name: "Release"
+      - build --keep_going --config=rbe --strategy=mypy=local --build_metadata=ROLE=ci --build_metadata=TAGS=check //...
+  - name: Release
     triggers:
       push:
-        branches:
+        branches: &id001
           - main
           - devel
       workflow_dispatch: {}
-
-    container_image: "ubuntu-24.04"
+    container_image: ubuntu-24.04
     resource_requests:
-      memory: "16GB"
-      disk: "50GB"
-
+      memory: 16GB
+      disk: 50GB
     steps:
       - run: |
-          bazel test --keep_going --config=rbe \
-            --build_metadata=ROLE=ci \
-            --test_tag_filters=-live_openai_api \
-            //...
+          bazel test --keep_going --config=rbe --build_metadata=ROLE=ci --test_tag_filters=-live_openai_api //...
       - run: |
           # Install system deps for wheel builds (cairo, dbus, etc.)
           sudo apt-get update -qq && sudo apt-get install -y \
@@ -85,41 +45,113 @@ actions:
             //skills:all_skills_tar \
             //devinfra/buildbuddy_cli:bbapi
           bazel run //devinfra/ci:bb_release_bin
-
-  # Push GHCR container images (OCI images built with Bazel).
-  # Uses oci_push (crane-based, no Docker daemon needed).
-  # The CI action's `bazel build //...` populates the remote cache;
-  # bazel run here fetches built images from cache and pushes via crane.
-  - name: "Push GHCR Images"
+  - name: Push token-provisioner
     triggers:
       push:
-        branches:
-          - main
-          - devel
+        branches: *id001
       workflow_dispatch: {}
-
-    container_image: "ubuntu-24.04"
+    container_image: ubuntu-24.04
     resource_requests:
-      disk: "50GB"
-
+      disk: 50GB
     bazel_commands:
-      # Build all OCI image targets first (as a top-level bazel command so
-      # BuildBuddy injects the API key — nested bazel from `bazel run` won't
-      # have it).
-      - >
-        build
-        --config=rbe
-        --remote_download_toplevel
-        //cluster/k8s/inventree/token-provisioner:image
-        //props/backend:image
-        //airlock:image
-        //airlock/auth_proxy:image
-        //mcp_infra/exec:direct_image
-        //openclaw/exec:image
-        //homeassistant/proxy:image
-        //inventree_utils/rai_plugin:image
-        //tana/token_broker:image
-        //third_party/activitywatch:image
-
-      # Push pre-built images to GHCR (no nested bazel build needed).
-      - run --config=rbe //devinfra/ci:bb_push_images_bin
+      - build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //cluster/k8s/inventree/token-provisioner:image
+  - name: Push props-backend
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //props/backend:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //props/backend:image
+  - name: Push airlock
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //airlock:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock:image
+  - name: Push auth-proxy
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock/auth_proxy:image
+  - name: Push exec-backend
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //mcp_infra/exec:direct_image
+  - name: Push openclaw-exec
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //openclaw/exec:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //openclaw/exec:image
+  - name: Push homeassistant-proxy
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //homeassistant/proxy:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //homeassistant/proxy:image
+  - name: Push inventree
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //inventree_utils/rai_plugin:image
+  - name: Push tana-token-broker
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //tana/token_broker:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //tana/token_broker:image
+  - name: Push aw-server
+    triggers:
+      push:
+        branches: *id001
+      workflow_dispatch: {}
+    container_image: ubuntu-24.04
+    resource_requests:
+      disk: 50GB
+    bazel_commands:
+      - build --config=rbe --remote_download_toplevel //third_party/activitywatch:image
+      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //third_party/activitywatch:image

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -20,9 +20,9 @@ actions:
         //...
       - build --keep_going --config=rbe --strategy=mypy=local --build_metadata=ROLE=ci --build_metadata=TAGS=check //...
   - name: Release
-    triggers:
+    triggers: &id001
       push:
-        branches: &id001
+        branches:
           - main
           - devel
       workflow_dispatch: {}
@@ -46,112 +46,73 @@ actions:
             //devinfra/buildbuddy_cli:bbapi
           bazel run //devinfra/ci:bb_release_bin
   - name: Push token-provisioner
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
+    resource_requests: &id002
       disk: 50GB
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //cluster/k8s/inventree/token-provisioner:image
   - name: Push props-backend
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //props/backend:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //props/backend:image
   - name: Push airlock
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //airlock:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock:image
   - name: Push auth-proxy
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock/auth_proxy:image
   - name: Push exec-backend
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //mcp_infra/exec:direct_image
   - name: Push openclaw-exec
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //openclaw/exec:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //openclaw/exec:image
   - name: Push homeassistant-proxy
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //homeassistant/proxy:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //homeassistant/proxy:image
   - name: Push inventree
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //inventree_utils/rai_plugin:image
   - name: Push tana-token-broker
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //tana/token_broker:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //tana/token_broker:image
   - name: Push aw-server
-    triggers:
-      push:
-        branches: *id001
-      workflow_dispatch: {}
+    triggers: *id001
     container_image: ubuntu-24.04
-    resource_requests:
-      disk: 50GB
+    resource_requests: *id002
     bazel_commands:
       - build --config=rbe --remote_download_toplevel //third_party/activitywatch:image
       - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //third_party/activitywatch:image

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -102,5 +102,24 @@ actions:
     resource_requests:
       disk: "50GB"
 
-    steps:
-      - run: bazel run --config=rbe //devinfra/ci:bb_push_images_bin
+    bazel_commands:
+      # Build all OCI image targets first (as a top-level bazel command so
+      # BuildBuddy injects the API key — nested bazel from `bazel run` won't
+      # have it).
+      - >
+        build
+        --config=rbe
+        --remote_download_toplevel
+        //cluster/k8s/inventree/token-provisioner:image
+        //props/backend:image
+        //airlock:image
+        //airlock/auth_proxy:image
+        //mcp_infra/exec:direct_image
+        //openclaw/exec:image
+        //homeassistant/proxy:image
+        //inventree_utils/rai_plugin:image
+        //tana/token_broker:image
+        //third_party/activitywatch:image
+
+      # Push pre-built images to GHCR (no nested bazel build needed).
+      - run --config=rbe //devinfra/ci:bb_push_images_bin

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -144,6 +144,20 @@ py_library(
         "//util:env",
         "//util:oci",
         "//util/bazel:workspace",
+        "@pypi//more_itertools",
+    ],
+)
+
+py_library(
+    name = "generate_buildbuddy",
+    srcs = ["generate_buildbuddy.py"],
+    imports = ["../.."],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":bb_push_images",
+        "//devinfra:prettier",
+        "//util/bazel:workspace",
+        "@pypi//pyyaml",
     ],
 )
 
@@ -185,6 +199,13 @@ py_binary(
 )
 
 py_binary(
+    name = "generate_buildbuddy_bin",
+    imports = ["../.."],
+    main_module = "devinfra.ci.generate_buildbuddy",
+    deps = [":generate_buildbuddy"],
+)
+
+py_binary(
     name = "bb_push_images_bin",
     imports = ["../.."],
     main_module = "devinfra.ci.bb_push_images",
@@ -192,6 +213,18 @@ py_binary(
 )
 
 # === Tests ===
+
+py_test(
+    name = "test_generate_buildbuddy",
+    srcs = ["test_generate_buildbuddy.py"],
+    data = ["//:buildbuddy.yaml"],
+    imports = ["../.."],
+    deps = [
+        ":generate_buildbuddy",
+        "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
+    ],
+)
 
 py_test(
     name = "test_generate_ci",

--- a/devinfra/ci/bb_push_images.py
+++ b/devinfra/ci/bb_push_images.py
@@ -1,9 +1,11 @@
 """Push Bazel-built OCI images to GHCR and tag for Flux.
 
-Builds all OCI image targets in a single bazel build, then uses crane directly
-(from runfiles) to push, tag, and compare digests. Only creates a new pinned
-tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest actually changed,
-preventing spurious Flux repins.
+Uses crane directly (from runfiles) to push, tag, and compare digests. Only
+creates a new pinned tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest
+actually changed, preventing spurious Flux repins.
+
+Image targets must be pre-built (the BuildBuddy workflow builds them in a
+separate bazel step so the API key is available).
 """
 
 import os
@@ -84,10 +86,6 @@ def main() -> None:
     if "[skip ci]" in _git("log", "-1", "--format=%s"):
         print("Commit message contains [skip ci], skipping image push.")
         return
-
-    targets = [img.image_target for img in IMAGES]
-    print(f"Building {len(targets)} image targets...")
-    subprocess.run(["bazel", "build", "--config=rbe", "--remote_download_toplevel", *targets], check=True)
 
     bazel_bin = get_bazel_bin()
 

--- a/devinfra/ci/bb_push_images.py
+++ b/devinfra/ci/bb_push_images.py
@@ -8,11 +8,14 @@ Image targets must be pre-built (the BuildBuddy workflow builds them in a
 separate bazel step so the API key is available).
 """
 
+import argparse
 import os
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
+from more_itertools import one
 
 from util.bazel.workspace import BazelLabel, get_bazel_bin, get_build_workspace_directory
 from util.crane import Crane
@@ -81,11 +84,17 @@ class ImagePusher:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Push OCI images to GHCR")
+    parser.add_argument("--image", help="Push only the image with this Bazel target label")
+    args = parser.parse_args()
+
     os.chdir(get_build_workspace_directory())
 
     if "[skip ci]" in _git("log", "-1", "--format=%s"):
         print("Commit message contains [skip ci], skipping image push.")
         return
+
+    images = [one(img for img in IMAGES if img.image_target == args.image)] if args.image else list(IMAGES)
 
     bazel_bin = get_bazel_bin()
 
@@ -101,7 +110,7 @@ def main() -> None:
         branch=branch,
         pinned_tag=f"{branch}-{ts}-{sha}",
     )
-    for img in IMAGES:
+    for img in images:
         pusher.push_and_tag(img)
 
 

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -1,0 +1,138 @@
+"""Generate buildbuddy.yaml from the IMAGES list in bb_push_images.
+
+Per-image push actions give independent failure isolation — a broken image
+build doesn't block other images from pushing.
+
+Usage:
+    bazel run //devinfra/ci:generate_buildbuddy_bin
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from devinfra.ci.bb_push_images import IMAGES
+from devinfra.prettier import prettier_format_in_place
+from util.bazel.workspace import get_build_workspace_directory
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+BUILDBUDDY_YAML = REPO_ROOT / "buildbuddy.yaml"
+
+HEADER = """\
+# AUTO-GENERATED from devinfra/ci/generate_buildbuddy.py - DO NOT EDIT DIRECTLY
+# Regenerate with: bazel run //devinfra/ci:generate_buildbuddy_bin
+#
+# BuildBuddy docs: https://www.buildbuddy.io/docs/workflows-config/
+"""
+
+PUSH_BRANCHES = ["main", "devel"]
+
+
+def _ci_action() -> dict[str, Any]:
+    return {
+        "name": "CI",
+        "triggers": {"push": {"branches": ["main", "master", "devel"]}, "pull_request": {}},
+        "container_image": "ubuntu-24.04",
+        "resource_requests": {"memory": "16GB", "disk": "50GB"},
+        "bazel_commands": [
+            (
+                "test --keep_going --config=rbe"
+                " --build_metadata=ROLE=ci --build_metadata=TAGS=test"
+                " --test_tag_filters=-live_openai_api"
+                " //..."
+            ),
+            (
+                "build --keep_going --config=rbe"
+                " --strategy=mypy=local"
+                " --build_metadata=ROLE=ci --build_metadata=TAGS=check"
+                " //..."
+            ),
+        ],
+    }
+
+
+def _release_action() -> dict[str, Any]:
+    return {
+        "name": "Release",
+        "triggers": {"push": {"branches": PUSH_BRANCHES}, "workflow_dispatch": {}},
+        "container_image": "ubuntu-24.04",
+        "resource_requests": {"memory": "16GB", "disk": "50GB"},
+        "steps": [
+            {
+                "run": (
+                    "bazel test --keep_going --config=rbe"
+                    " --build_metadata=ROLE=ci"
+                    " --test_tag_filters=-live_openai_api"
+                    " //...\n"
+                )
+            },
+            {
+                "run": (
+                    "# Install system deps for wheel builds (cairo, dbus, etc.)\n"
+                    "sudo apt-get update -qq && sudo apt-get install -y \\\n"
+                    "  libcairo2-dev libgirepository-2.0-dev libdbus-1-dev libxcb1-dev pkg-config\n"
+                    "bazel build --config=rbe --remote_download_toplevel \\\n"
+                    "  //:wheel \\\n"
+                    "  //:claude_hooks_wheel \\\n"
+                    "  //util:wheel \\\n"
+                    "  //gterm_theme:wheel \\\n"
+                    "  //skills:all_skills_tar \\\n"
+                    "  //devinfra/buildbuddy_cli:bbapi\n"
+                    "bazel run //devinfra/ci:bb_release_bin\n"
+                )
+            },
+        ],
+    }
+
+
+def _push_image_action(image_target: str, repo_name: str) -> dict[str, Any]:
+    """Generate a per-image push action."""
+    return {
+        "name": f"Push {repo_name}",
+        "triggers": {"push": {"branches": PUSH_BRANCHES}, "workflow_dispatch": {}},
+        "container_image": "ubuntu-24.04",
+        "resource_requests": {"disk": "50GB"},
+        "bazel_commands": [
+            f"build --config=rbe --remote_download_toplevel {image_target}",
+            f"run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {image_target}",
+        ],
+    }
+
+
+def generate_buildbuddy_config() -> dict[str, Any]:
+    """Generate the complete buildbuddy.yaml config."""
+    actions: list[dict[str, Any]] = [_ci_action(), _release_action()]
+    for img in IMAGES:
+        # Extract short name from ghcr.io/agentydragon/<name>
+        repo_name = img.repository.rsplit("/", 1)[-1]
+        actions.append(_push_image_action(img.image_target, repo_name))
+    return {"actions": actions}
+
+
+def generate_buildbuddy_yml(config: dict[str, Any]) -> str:
+    """Serialize config to YAML with header."""
+
+    def str_representer(dumper: yaml.Dumper, data: str) -> yaml.Node:
+        if "\n" in data:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+    yaml.add_representer(str, str_representer)
+    yaml_content = yaml.dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True, width=120)
+    return HEADER + yaml_content
+
+
+def main() -> None:
+    config = generate_buildbuddy_config()
+    out_path = get_build_workspace_directory() / "buildbuddy.yaml"
+    out_path.write_text(generate_buildbuddy_yml(config))
+    prettier_format_in_place(out_path)
+    print(f"Generated {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -29,87 +29,83 @@ HEADER = """\
 # BuildBuddy docs: https://www.buildbuddy.io/docs/workflows-config/
 """
 
-PUSH_BRANCHES = ["main", "devel"]
-
-
-def _ci_action() -> dict[str, Any]:
-    return {
-        "name": "CI",
-        "triggers": {"push": {"branches": ["main", "master", "devel"]}, "pull_request": {}},
-        "container_image": "ubuntu-24.04",
-        "resource_requests": {"memory": "16GB", "disk": "50GB"},
-        "bazel_commands": [
-            (
-                "test --keep_going --config=rbe"
-                " --build_metadata=ROLE=ci --build_metadata=TAGS=test"
-                " --test_tag_filters=-live_openai_api"
-                " //..."
-            ),
-            (
-                "build --keep_going --config=rbe"
-                " --strategy=mypy=local"
-                " --build_metadata=ROLE=ci --build_metadata=TAGS=check"
-                " //..."
-            ),
-        ],
-    }
-
-
-def _release_action() -> dict[str, Any]:
-    return {
-        "name": "Release",
-        "triggers": {"push": {"branches": PUSH_BRANCHES}, "workflow_dispatch": {}},
-        "container_image": "ubuntu-24.04",
-        "resource_requests": {"memory": "16GB", "disk": "50GB"},
-        "steps": [
-            {
-                "run": (
-                    "bazel test --keep_going --config=rbe"
-                    " --build_metadata=ROLE=ci"
-                    " --test_tag_filters=-live_openai_api"
-                    " //...\n"
-                )
-            },
-            {
-                "run": (
-                    "# Install system deps for wheel builds (cairo, dbus, etc.)\n"
-                    "sudo apt-get update -qq && sudo apt-get install -y \\\n"
-                    "  libcairo2-dev libgirepository-2.0-dev libdbus-1-dev libxcb1-dev pkg-config\n"
-                    "bazel build --config=rbe --remote_download_toplevel \\\n"
-                    "  //:wheel \\\n"
-                    "  //:claude_hooks_wheel \\\n"
-                    "  //util:wheel \\\n"
-                    "  //gterm_theme:wheel \\\n"
-                    "  //skills:all_skills_tar \\\n"
-                    "  //devinfra/buildbuddy_cli:bbapi\n"
-                    "bazel run //devinfra/ci:bb_release_bin\n"
-                )
-            },
-        ],
-    }
-
-
-def _push_image_action(image_target: str, repo_name: str) -> dict[str, Any]:
-    """Generate a per-image push action."""
-    return {
-        "name": f"Push {repo_name}",
-        "triggers": {"push": {"branches": PUSH_BRANCHES}, "workflow_dispatch": {}},
-        "container_image": "ubuntu-24.04",
-        "resource_requests": {"disk": "50GB"},
-        "bazel_commands": [
-            f"build --config=rbe --remote_download_toplevel {image_target}",
-            f"run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {image_target}",
-        ],
-    }
-
 
 def generate_buildbuddy_config() -> dict[str, Any]:
     """Generate the complete buildbuddy.yaml config."""
-    actions: list[dict[str, Any]] = [_ci_action(), _release_action()]
+    # Shared Python objects — PyYAML emits YAML anchors/aliases for these
+    # automatically, deduplicating the repeated trigger/resource blocks.
+    push_triggers: dict[str, Any] = {"push": {"branches": ["main", "devel"]}, "workflow_dispatch": {}}
+    push_resources: dict[str, str] = {"disk": "50GB"}
+
+    actions: list[dict[str, Any]] = [
+        {
+            "name": "CI",
+            "triggers": {"push": {"branches": ["main", "master", "devel"]}, "pull_request": {}},
+            "container_image": "ubuntu-24.04",
+            "resource_requests": {"memory": "16GB", "disk": "50GB"},
+            "bazel_commands": [
+                (
+                    "test --keep_going --config=rbe"
+                    " --build_metadata=ROLE=ci --build_metadata=TAGS=test"
+                    " --test_tag_filters=-live_openai_api"
+                    " //..."
+                ),
+                (
+                    "build --keep_going --config=rbe"
+                    " --strategy=mypy=local"
+                    " --build_metadata=ROLE=ci --build_metadata=TAGS=check"
+                    " //..."
+                ),
+            ],
+        },
+        {
+            "name": "Release",
+            "triggers": push_triggers,
+            "container_image": "ubuntu-24.04",
+            "resource_requests": {"memory": "16GB", "disk": "50GB"},
+            "steps": [
+                {
+                    "run": (
+                        "bazel test --keep_going --config=rbe"
+                        " --build_metadata=ROLE=ci"
+                        " --test_tag_filters=-live_openai_api"
+                        " //...\n"
+                    )
+                },
+                {
+                    "run": (
+                        "# Install system deps for wheel builds (cairo, dbus, etc.)\n"
+                        "sudo apt-get update -qq && sudo apt-get install -y \\\n"
+                        "  libcairo2-dev libgirepository-2.0-dev libdbus-1-dev libxcb1-dev pkg-config\n"
+                        "bazel build --config=rbe --remote_download_toplevel \\\n"
+                        "  //:wheel \\\n"
+                        "  //:claude_hooks_wheel \\\n"
+                        "  //util:wheel \\\n"
+                        "  //gterm_theme:wheel \\\n"
+                        "  //skills:all_skills_tar \\\n"
+                        "  //devinfra/buildbuddy_cli:bbapi\n"
+                        "bazel run //devinfra/ci:bb_release_bin\n"
+                    )
+                },
+            ],
+        },
+    ]
+
     for img in IMAGES:
-        # Extract short name from ghcr.io/agentydragon/<name>
         repo_name = img.repository.rsplit("/", 1)[-1]
-        actions.append(_push_image_action(img.image_target, repo_name))
+        actions.append(
+            {
+                "name": f"Push {repo_name}",
+                "triggers": push_triggers,
+                "container_image": "ubuntu-24.04",
+                "resource_requests": push_resources,
+                "bazel_commands": [
+                    f"build --config=rbe --remote_download_toplevel {img.image_target}",
+                    f"run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {img.image_target}",
+                ],
+            }
+        )
+
     return {"actions": actions}
 
 

--- a/devinfra/ci/test_generate_buildbuddy.py
+++ b/devinfra/ci/test_generate_buildbuddy.py
@@ -1,0 +1,18 @@
+"""Verify generated buildbuddy.yaml is up to date with generate_buildbuddy.py."""
+
+import pytest_bazel
+import yaml
+
+from devinfra.ci.generate_buildbuddy import BUILDBUDDY_YAML, generate_buildbuddy_config
+
+
+def test_buildbuddy_yaml_up_to_date() -> None:
+    current = yaml.safe_load(BUILDBUDDY_YAML.read_text())
+    expected = generate_buildbuddy_config()
+    assert current == expected, (
+        "buildbuddy.yaml is out of date. Run 'bazel run //devinfra/ci:generate_buildbuddy_bin' to update."
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
Refactor the BuildBuddy CI configuration to be auto-generated from the image push configuration, eliminating manual maintenance of the buildbuddy.yaml file and enabling per-image push actions for better failure isolation.

## Key Changes
- **New generator script** (`devinfra/ci/generate_buildbuddy.py`): Generates buildbuddy.yaml from the IMAGES list in bb_push_images.py, ensuring the CI configuration stays in sync with the actual images being pushed
- **Per-image push actions**: Replaced the single "Push GHCR Images" action with individual actions for each image (token-provisioner, props-backend, airlock, auth-proxy, exec-backend, openclaw-exec, homeassistant-proxy, inventree, tana-token-broker, aw-server). This provides independent failure isolation — a broken image build no longer blocks other images from pushing
- **Updated bb_push_images.py**: Modified to accept `--image` flag for pushing individual images, removing the monolithic bazel build step. Images are now built separately in their respective workflow actions
- **Test coverage**: Added `test_generate_buildbuddy.py` to verify buildbuddy.yaml stays in sync with the generator
- **Build configuration**: Added py_library and py_binary targets for the generator, plus test target in BUILD.bazel

## Implementation Details
- The generator creates a header indicating the file is auto-generated with instructions to regenerate
- Branch triggers are deduplicated using YAML anchors (`&id001`, `*id001`) to reduce file size
- Each push action independently builds and pushes its image target, with consistent resource requests (16GB memory for CI/Release, 50GB disk for all)
- The generator can be run via `bazel run //devinfra/ci:generate_buildbuddy_bin`

https://claude.ai/code/session_01LhVhK8KTwyQsrKWKYt5sCX