### PR TITLE
Fix BuildBuddy API key in image push, split into per-image actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -50,69 +50,79 @@ actions:
     container_image: ubuntu-24.04
     resource_requests: &id002
       disk: 50GB
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //cluster/k8s/inventree/token-provisioner:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //cluster/k8s/inventree/token-provisioner:image
   - name: Push props-backend
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //props/backend:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //props/backend:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //props/backend:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //props/backend:image
   - name: Push airlock
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //airlock:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //airlock:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock:image
   - name: Push auth-proxy
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock/auth_proxy:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock/auth_proxy:image
   - name: Push exec-backend
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //mcp_infra/exec:direct_image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //mcp_infra/exec:direct_image
   - name: Push openclaw-exec
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //openclaw/exec:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //openclaw/exec:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //openclaw/exec:image
   - name: Push homeassistant-proxy
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //homeassistant/proxy:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //homeassistant/proxy:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //homeassistant/proxy:image
   - name: Push inventree
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //inventree_utils/rai_plugin:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //inventree_utils/rai_plugin:image
   - name: Push tana-token-broker
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //tana/token_broker:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //tana/token_broker:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //tana/token_broker:image
   - name: Push aw-server
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
-    bazel_commands:
-      - build --config=rbe --remote_download_toplevel //third_party/activitywatch:image
-      - run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //third_party/activitywatch:image
+    steps:
+      - run: |
+          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:image
+          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //third_party/activitywatch:image

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -93,15 +93,22 @@ def generate_buildbuddy_config() -> dict[str, Any]:
 
     for img in IMAGES:
         repo_name = img.repository.rsplit("/", 1)[-1]
+        # Single shell step: build + push in the same shell so (1) BuildBuddy's
+        # bazel wrapper injects the API key for both commands and (2) the image
+        # tree artifacts from `bazel build` persist for `bazel run`.
         actions.append(
             {
                 "name": f"Push {repo_name}",
                 "triggers": push_triggers,
                 "container_image": "ubuntu-24.04",
                 "resource_requests": push_resources,
-                "bazel_commands": [
-                    f"build --config=rbe --remote_download_toplevel {img.image_target}",
-                    f"run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {img.image_target}",
+                "steps": [
+                    {
+                        "run": (
+                            f"bazel build --config=rbe --remote_download_toplevel {img.image_target}\n"
+                            f"bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {img.image_target}\n"
+                        )
+                    }
                 ],
             }
         )


### PR DESCRIPTION
## Summary

- **Fix BuildBuddy API key missing in image push workflow**: The `Push GHCR Images` action ran `bazel run bb_push_images_bin` which internally spawned a nested `bazel build`. BuildBuddy injects the API key only into top-level bazel commands (via its shell wrapper), so the nested invocation failed with `PERMISSION_DENIED: Missing API key`. Moved the build out of the Python script into the workflow shell step.
- **Split into per-image push actions**: Each of the 10 OCI images now has its own BuildBuddy workflow action, so a broken image build doesn't block other images from pushing.
- **Generate `buildbuddy.yaml` from Python**: `generate_buildbuddy.py` produces `buildbuddy.yaml` from the `IMAGES` list in `bb_push_images.py` (single source of truth). PyYAML auto-deduplicates shared trigger/resource blocks via YAML anchors. Parity test (`test_generate_buildbuddy.py`) ensures the YAML stays in sync.
- **Add `--image` flag to `bb_push_images.py`**: Filters push to a single image target, used by the per-image workflow actions.

## Test plan

- [x] `bazel test //devinfra/ci:test_generate_buildbuddy` — parity test passes
- [x] `bazel test //devinfra/ci:test_generate_ci` — existing CI gen test still passes
- [x] pre-commit passes (ruff, prettier, buildifier)
- [ ] Squash-merge to devel and verify per-image push actions succeed on BuildBuddy

https://claude.ai/code/session_01LhVhK8KTwyQsrKWKYt5sCX