### PR TITLE
fix: build image + binary in single bazel build for push actions

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -52,77 +52,77 @@ actions:
       disk: 50GB
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //cluster/k8s/inventree/token-provisioner:image
+          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //cluster/k8s/inventree/token-provisioner:image
   - name: Push props-backend
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //props/backend:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //props/backend:image
+          bazel build --config=rbe --remote_download_toplevel //props/backend:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //props/backend:image
   - name: Push airlock
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock:image
+          bazel build --config=rbe --remote_download_toplevel //airlock:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //airlock:image
   - name: Push auth-proxy
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //airlock/auth_proxy:image
+          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //airlock/auth_proxy:image
   - name: Push exec-backend
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //mcp_infra/exec:direct_image
+          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //mcp_infra/exec:direct_image
   - name: Push openclaw-exec
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //openclaw/exec:image
+          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //openclaw/exec:image
   - name: Push homeassistant-proxy
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //homeassistant/proxy:image
+          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //homeassistant/proxy:image
   - name: Push inventree
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //inventree_utils/rai_plugin:image
+          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //inventree_utils/rai_plugin:image
   - name: Push tana-token-broker
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //tana/token_broker:image
+          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //tana/token_broker:image
   - name: Push aw-server
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:image
-          bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image //third_party/activitywatch:image
+          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:image //devinfra/ci:bb_push_images_bin
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //third_party/activitywatch:image

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -93,9 +93,9 @@ def generate_buildbuddy_config() -> dict[str, Any]:
 
     for img in IMAGES:
         repo_name = img.repository.rsplit("/", 1)[-1]
-        # Single shell step: build + push in the same shell so (1) BuildBuddy's
-        # bazel wrapper injects the API key for both commands and (2) the image
-        # tree artifacts from `bazel build` persist for `bazel run`.
+        # Build image + push binary in a SINGLE `bazel build` so tree artifact
+        # contents are downloaded together. Then invoke the binary directly —
+        # separate `bazel run` doesn't see tree artifacts from a prior build.
         actions.append(
             {
                 "name": f"Push {repo_name}",
@@ -105,8 +105,11 @@ def generate_buildbuddy_config() -> dict[str, Any]:
                 "steps": [
                     {
                         "run": (
-                            f"bazel build --config=rbe --remote_download_toplevel {img.image_target}\n"
-                            f"bazel run --config=rbe //devinfra/ci:bb_push_images_bin -- --image {img.image_target}\n"
+                            f"bazel build --config=rbe --remote_download_toplevel"
+                            f" {img.image_target} //devinfra/ci:bb_push_images_bin\n"
+                            f'BUILD_WORKSPACE_DIRECTORY="$PWD"'
+                            f" ./bazel-bin/devinfra/ci/bb_push_images_bin"
+                            f" --image {img.image_target}\n"
                         )
                     }
                 ],


### PR DESCRIPTION
## Summary

- Tree artifact contents (OCI image directories) from a prior `bazel build` aren't visible to a subsequent `bazel run` — even in the same shell step. All 10 per-image push workflows from #1151 fail with `FileNotFoundError` for `image/index.json`.
- Fix: build both the image target and `bb_push_images_bin` in a **single** `bazel build --remote_download_toplevel`, then invoke the binary directly from `./bazel-bin/` instead of via `bazel run`.

## Test plan

- [x] `bazel test //devinfra/ci:test_generate_buildbuddy` passes
- [x] pre-commit passes
- [ ] Squash-merge and verify push workflows succeed on BuildBuddy

https://claude.ai/code/session_01LhVhK8KTwyQsrKWKYt5sCX