### PR TITLE
Add ghcr_push Bazel macro for decentralized image pushing

### DIFF
--- a/airlock/BUILD.bazel
+++ b/airlock/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
@@ -157,6 +158,12 @@ oci_load(
     image = ":image",
     repo_tags = ["airlock:latest"],
     visibility = ["//visibility:public"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/airlock",
 )
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/airlock/auth_proxy/BUILD.bazel
+++ b/airlock/auth_proxy/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
@@ -57,6 +58,12 @@ oci_load(
     image = ":image",
     repo_tags = ["airlock-auth-proxy:latest"],
     visibility = ["//visibility:public"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/auth-proxy",
 )
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -45,84 +45,84 @@ actions:
             //skills:all_skills_tar \
             //devinfra/buildbuddy_cli:bbapi
           bazel run //devinfra/ci:bb_release_bin
-  - name: Push token-provisioner
+  - name: Push //airlock:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: &id002
       disk: 50GB
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //cluster/k8s/inventree/token-provisioner:image
-  - name: Push props-backend
+          bazel build --config=rbe --remote_download_toplevel //airlock:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/airlock/push_ghcr
+  - name: Push //airlock/auth_proxy:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //props/backend:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //props/backend:image
-  - name: Push airlock
+          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/airlock/auth_proxy/push_ghcr
+  - name: Push //cluster/k8s/inventree/token-provisioner:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //airlock:image
-  - name: Push auth-proxy
+          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/cluster/k8s/inventree/token-provisioner/push_ghcr
+  - name: Push //homeassistant/proxy:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //airlock/auth_proxy:image
-  - name: Push exec-backend
+          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/homeassistant/proxy/push_ghcr
+  - name: Push //inventree_utils/rai_plugin:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:direct_image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //mcp_infra/exec:direct_image
-  - name: Push openclaw-exec
+          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/inventree_utils/rai_plugin/push_ghcr
+  - name: Push //mcp_infra/exec:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //openclaw/exec:image
-  - name: Push homeassistant-proxy
+          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/mcp_infra/exec/push_ghcr
+  - name: Push //openclaw/exec:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //homeassistant/proxy:image
-  - name: Push inventree
+          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/openclaw/exec/push_ghcr
+  - name: Push //props/backend:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //inventree_utils/rai_plugin:image
-  - name: Push tana-token-broker
+          bazel build --config=rbe --remote_download_toplevel //props/backend:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/props/backend/push_ghcr
+  - name: Push //tana/token_broker:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //tana/token_broker:image
-  - name: Push aw-server
+          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/tana/token_broker/push_ghcr
+  - name: Push //third_party/activitywatch:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:image //devinfra/ci:bb_push_images_bin
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/devinfra/ci/bb_push_images_bin --image //third_party/activitywatch:image
+          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:push_ghcr
+          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/third_party/activitywatch/push_ghcr

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -52,77 +52,67 @@ actions:
       disk: 50GB
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/airlock/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //airlock:push_ghcr
   - name: Push //airlock/auth_proxy:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //airlock/auth_proxy:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/airlock/auth_proxy/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //airlock/auth_proxy:push_ghcr
   - name: Push //cluster/k8s/inventree/token-provisioner:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/cluster/k8s/inventree/token-provisioner/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:push_ghcr
   - name: Push //homeassistant/proxy:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //homeassistant/proxy:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/homeassistant/proxy/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //homeassistant/proxy:push_ghcr
   - name: Push //inventree_utils/rai_plugin:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/inventree_utils/rai_plugin/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //inventree_utils/rai_plugin:push_ghcr
   - name: Push //mcp_infra/exec:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //mcp_infra/exec:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/mcp_infra/exec/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //mcp_infra/exec:push_ghcr
   - name: Push //openclaw/exec:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //openclaw/exec:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/openclaw/exec/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //openclaw/exec:push_ghcr
   - name: Push //props/backend:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //props/backend:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/props/backend/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //props/backend:push_ghcr
   - name: Push //tana/token_broker:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //tana/token_broker:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/tana/token_broker/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //tana/token_broker:push_ghcr
   - name: Push //third_party/activitywatch:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04
     resource_requests: *id002
     steps:
       - run: |
-          bazel build --config=rbe --remote_download_toplevel //third_party/activitywatch:push_ghcr
-          BUILD_WORKSPACE_DIRECTORY="$PWD" ./bazel-bin/third_party/activitywatch/push_ghcr
+          bazel run --config=rbe --remote_download_toplevel //third_party/activitywatch:push_ghcr

--- a/cluster/k8s/inventree/token-provisioner/BUILD.bazel
+++ b/cluster/k8s/inventree/token-provisioner/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
 py_library(
@@ -41,4 +42,10 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = ["inventree-token-provisioner:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/token-provisioner",
 )

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -199,6 +199,7 @@ py_test(
     imports = ["../.."],
     deps = [
         ":generate_buildbuddy",
+        "//util/bazel:runfiles",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
     ],

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -135,26 +135,11 @@ py_library(
 )
 
 py_library(
-    name = "bb_push_images",
-    srcs = ["bb_push_images.py"],
-    imports = ["../.."],
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//util:crane",
-        "//util:env",
-        "//util:oci",
-        "//util/bazel:workspace",
-        "@pypi//more_itertools",
-    ],
-)
-
-py_library(
     name = "generate_buildbuddy",
     srcs = ["generate_buildbuddy.py"],
     imports = ["../.."],
     visibility = ["//:__subpackages__"],
     deps = [
-        ":bb_push_images",
         "//devinfra:prettier",
         "//util/bazel:workspace",
         "@pypi//pyyaml",
@@ -203,13 +188,6 @@ py_binary(
     imports = ["../.."],
     main_module = "devinfra.ci.generate_buildbuddy",
     deps = [":generate_buildbuddy"],
-)
-
-py_binary(
-    name = "bb_push_images_bin",
-    imports = ["../.."],
-    main_module = "devinfra.ci.bb_push_images",
-    deps = [":bb_push_images"],
 )
 
 # === Tests ===

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -1,4 +1,4 @@
-"""Generate buildbuddy.yaml from the IMAGES list in bb_push_images.
+"""Generate buildbuddy.yaml from the list of ghcr_push targets.
 
 Per-image push actions give independent failure isolation — a broken image
 build doesn't block other images from pushing.
@@ -14,9 +14,8 @@ from typing import Any
 
 import yaml
 
-from devinfra.ci.bb_push_images import IMAGES
 from devinfra.prettier import prettier_format_in_place
-from util.bazel.workspace import get_build_workspace_directory
+from util.bazel.workspace import BazelLabel, get_build_workspace_directory
 
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
@@ -28,6 +27,22 @@ HEADER = """\
 #
 # BuildBuddy docs: https://www.buildbuddy.io/docs/workflows-config/
 """
+
+# ghcr_push targets declared in BUILD files across the repo. Each creates a
+# `bazel run`-able binary that pushes to GHCR with conditional tagging.
+# Keep sorted. Validated by test_generate_buildbuddy.
+PUSH_TARGETS = [
+    BazelLabel.parse("//airlock:push_ghcr"),
+    BazelLabel.parse("//airlock/auth_proxy:push_ghcr"),
+    BazelLabel.parse("//cluster/k8s/inventree/token-provisioner:push_ghcr"),
+    BazelLabel.parse("//homeassistant/proxy:push_ghcr"),
+    BazelLabel.parse("//inventree_utils/rai_plugin:push_ghcr"),
+    BazelLabel.parse("//mcp_infra/exec:push_ghcr"),
+    BazelLabel.parse("//openclaw/exec:push_ghcr"),
+    BazelLabel.parse("//props/backend:push_ghcr"),
+    BazelLabel.parse("//tana/token_broker:push_ghcr"),
+    BazelLabel.parse("//third_party/activitywatch:push_ghcr"),
+]
 
 
 def generate_buildbuddy_config() -> dict[str, Any]:
@@ -91,14 +106,11 @@ def generate_buildbuddy_config() -> dict[str, Any]:
         },
     ]
 
-    for img in IMAGES:
-        repo_name = img.repository.rsplit("/", 1)[-1]
-        # Build image + push binary in a SINGLE `bazel build` so tree artifact
-        # contents are downloaded together. Then invoke the binary directly —
-        # separate `bazel run` doesn't see tree artifacts from a prior build.
+    for target in PUSH_TARGETS:
+        target_str = str(target)
         actions.append(
             {
-                "name": f"Push {repo_name}",
+                "name": f"Push {target_str}",
                 "triggers": push_triggers,
                 "container_image": "ubuntu-24.04",
                 "resource_requests": push_resources,
@@ -106,10 +118,9 @@ def generate_buildbuddy_config() -> dict[str, Any]:
                     {
                         "run": (
                             f"bazel build --config=rbe --remote_download_toplevel"
-                            f" {img.image_target} //devinfra/ci:bb_push_images_bin\n"
+                            f" {target_str}\n"
                             f'BUILD_WORKSPACE_DIRECTORY="$PWD"'
-                            f" ./bazel-bin/devinfra/ci/bb_push_images_bin"
-                            f" --image {img.image_target}\n"
+                            f" ./bazel-bin/{target.package}/{target.name}\n"
                         )
                     }
                 ],

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -9,17 +9,12 @@ Usage:
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import yaml
 
 from devinfra.prettier import prettier_format_in_place
 from util.bazel.workspace import BazelLabel, get_build_workspace_directory
-
-SCRIPT_DIR = Path(__file__).parent
-REPO_ROOT = SCRIPT_DIR.parent.parent
-BUILDBUDDY_YAML = REPO_ROOT / "buildbuddy.yaml"
 
 HEADER = """\
 # AUTO-GENERATED from devinfra/ci/generate_buildbuddy.py - DO NOT EDIT DIRECTLY
@@ -114,16 +109,7 @@ def generate_buildbuddy_config() -> dict[str, Any]:
                 "triggers": push_triggers,
                 "container_image": "ubuntu-24.04",
                 "resource_requests": push_resources,
-                "steps": [
-                    {
-                        "run": (
-                            f"bazel build --config=rbe --remote_download_toplevel"
-                            f" {target_str}\n"
-                            f'BUILD_WORKSPACE_DIRECTORY="$PWD"'
-                            f" ./bazel-bin/{target.package}/{target.name}\n"
-                        )
-                    }
-                ],
+                "steps": [{"run": (f"bazel run --config=rbe --remote_download_toplevel {target_str}\n")}],
             }
         )
 

--- a/devinfra/ci/test_generate_buildbuddy.py
+++ b/devinfra/ci/test_generate_buildbuddy.py
@@ -3,11 +3,14 @@
 import pytest_bazel
 import yaml
 
-from devinfra.ci.generate_buildbuddy import BUILDBUDDY_YAML, generate_buildbuddy_config
+from devinfra.ci.generate_buildbuddy import generate_buildbuddy_config
+from util.bazel.runfiles import get_required_path
+
+_BUILDBUDDY_YAML_RLOCATION = "_main/buildbuddy.yaml"
 
 
 def test_buildbuddy_yaml_up_to_date() -> None:
-    current = yaml.safe_load(BUILDBUDDY_YAML.read_text())
+    current = yaml.safe_load(get_required_path(_BUILDBUDDY_YAML_RLOCATION).read_text())
     expected = generate_buildbuddy_config()
     assert current == expected, (
         "buildbuddy.yaml is out of date. Run 'bazel run //devinfra/ci:generate_buildbuddy_bin' to update."

--- a/devinfra/ghcr_push/BUILD.bazel
+++ b/devinfra/ghcr_push/BUILD.bazel
@@ -9,6 +9,7 @@ py_library(
         "//util:crane",
         "//util:env",
         "//util:oci",
+        "//util/bazel:runfiles",
         "//util/bazel:workspace",
     ],
 )

--- a/devinfra/ghcr_push/BUILD.bazel
+++ b/devinfra/ghcr_push/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "ghcr_push_lib",
+    srcs = ["ghcr_push_lib.py"],
+    imports = ["../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//util:crane",
+        "//util:env",
+        "//util:oci",
+        "//util/bazel:workspace",
+    ],
+)

--- a/devinfra/ghcr_push/ghcr_push_lib.py
+++ b/devinfra/ghcr_push/ghcr_push_lib.py
@@ -5,13 +5,15 @@ new pinned tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest actually
 changed, preventing spurious Flux repins.
 """
 
+import argparse
 import os
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from util.bazel.workspace import BazelLabel, get_bazel_bin, get_build_workspace_directory
+from util.bazel.runfiles import get_required_path
+from util.bazel.workspace import BazelLabel, get_build_workspace_directory
 from util.crane import Crane
 from util.env import get_required_env
 from util.oci import read_oci_layout_digest
@@ -27,16 +29,17 @@ def _git(*args: str) -> str:
     return subprocess.check_output(["git", *args], text=True).strip()
 
 
+def _image_runfiles_dir(image_target: str) -> Path:
+    """Resolve the OCI layout directory from runfiles."""
+    label = BazelLabel.parse(image_target)
+    return get_required_path(f"_main/{label.package}/{label.name}")
+
+
 class ImagePusher:
-    def __init__(self, crane: Crane, bazel_bin: Path, branch: str, pinned_tag: str) -> None:
+    def __init__(self, crane: Crane, branch: str, pinned_tag: str) -> None:
         self.crane = crane
-        self.bazel_bin = bazel_bin
         self.branch = branch
         self.pinned_tag = pinned_tag
-
-    def _image_output_dir(self, image_target: str) -> Path:
-        label = BazelLabel.parse(image_target)
-        return self.bazel_bin / label.package / label.name
 
     def _latest_pinned_tag(self, repo: str) -> str | None:
         try:
@@ -47,7 +50,7 @@ class ImagePusher:
         return branch_tags[-1] if branch_tags else None
 
     def push_and_tag(self, img: GhcrImage) -> None:
-        image_dir = self._image_output_dir(img.image_target)
+        image_dir = _image_runfiles_dir(img.image_target)
         local_digest = read_oci_layout_digest(image_dir)
         ref = f"{img.repository}@{local_digest}"
 
@@ -63,15 +66,19 @@ class ImagePusher:
         self.crane.tag(ref, self.pinned_tag)
 
 
-def push_main(image_target: str, repository: str) -> None:
+def main() -> None:
     """Push a single OCI image to GHCR if its digest changed."""
+    parser = argparse.ArgumentParser(description="Push OCI image to GHCR")
+    parser.add_argument("--image-target", required=True)
+    parser.add_argument("--repository", required=True)
+    args = parser.parse_args()
+
     os.chdir(get_build_workspace_directory())
 
     if "[skip ci]" in _git("log", "-1", "--format=%s"):
         print("Commit message contains [skip ci], skipping image push.")
         return
 
-    bazel_bin = get_bazel_bin()
     branch = _git("rev-parse", "--abbrev-ref", "HEAD")
     ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     sha = _git("rev-parse", "--short=7", "HEAD")
@@ -80,8 +87,11 @@ def push_main(image_target: str, repository: str) -> None:
         crane=Crane(
             registry="ghcr.io", username=get_required_env("GHCR_USERNAME"), password=get_required_env("GHCR_TOKEN")
         ),
-        bazel_bin=bazel_bin,
         branch=branch,
         pinned_tag=f"{branch}-{ts}-{sha}",
     )
-    pusher.push_and_tag(GhcrImage(image_target=image_target, repository=repository))
+    pusher.push_and_tag(GhcrImage(image_target=args.image_target, repository=args.repository))
+
+
+if __name__ == "__main__":
+    main()

--- a/devinfra/ghcr_push/ghcr_push_lib.py
+++ b/devinfra/ghcr_push/ghcr_push_lib.py
@@ -1,21 +1,15 @@
-"""Push Bazel-built OCI images to GHCR and tag for Flux.
+"""Push an OCI image to GHCR with conditional tagging.
 
-Uses crane directly (from runfiles) to push, tag, and compare digests. Only
-creates a new pinned tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest
-actually changed, preventing spurious Flux repins.
-
-Image targets must be pre-built (the BuildBuddy workflow builds them in a
-separate bazel step so the API key is available).
+Uses crane to compare local vs remote digests before pushing. Only creates a
+new pinned tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest actually
+changed, preventing spurious Flux repins.
 """
 
-import argparse
 import os
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-
-from more_itertools import one
 
 from util.bazel.workspace import BazelLabel, get_bazel_bin, get_build_workspace_directory
 from util.crane import Crane
@@ -27,20 +21,6 @@ from util.oci import read_oci_layout_digest
 class GhcrImage:
     image_target: str
     repository: str
-
-
-IMAGES = [
-    GhcrImage("//cluster/k8s/inventree/token-provisioner:image", "ghcr.io/agentydragon/token-provisioner"),
-    GhcrImage("//props/backend:image", "ghcr.io/agentydragon/props-backend"),
-    GhcrImage("//airlock:image", "ghcr.io/agentydragon/airlock"),
-    GhcrImage("//airlock/auth_proxy:image", "ghcr.io/agentydragon/auth-proxy"),
-    GhcrImage("//mcp_infra/exec:direct_image", "ghcr.io/agentydragon/exec-backend"),
-    GhcrImage("//openclaw/exec:image", "ghcr.io/agentydragon/openclaw-exec"),
-    GhcrImage("//homeassistant/proxy:image", "ghcr.io/agentydragon/homeassistant-proxy"),
-    GhcrImage("//inventree_utils/rai_plugin:image", "ghcr.io/agentydragon/inventree"),
-    GhcrImage("//tana/token_broker:image", "ghcr.io/agentydragon/tana-token-broker"),
-    GhcrImage("//third_party/activitywatch:image", "ghcr.io/agentydragon/aw-server"),
-]
 
 
 def _git(*args: str) -> str:
@@ -83,21 +63,15 @@ class ImagePusher:
         self.crane.tag(ref, self.pinned_tag)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Push OCI images to GHCR")
-    parser.add_argument("--image", help="Push only the image with this Bazel target label")
-    args = parser.parse_args()
-
+def push_main(image_target: str, repository: str) -> None:
+    """Push a single OCI image to GHCR if its digest changed."""
     os.chdir(get_build_workspace_directory())
 
     if "[skip ci]" in _git("log", "-1", "--format=%s"):
         print("Commit message contains [skip ci], skipping image push.")
         return
 
-    images = [one(img for img in IMAGES if img.image_target == args.image)] if args.image else list(IMAGES)
-
     bazel_bin = get_bazel_bin()
-
     branch = _git("rev-parse", "--abbrev-ref", "HEAD")
     ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     sha = _git("rev-parse", "--short=7", "HEAD")
@@ -110,9 +84,4 @@ def main() -> None:
         branch=branch,
         pinned_tag=f"{branch}-{ts}-{sha}",
     )
-    for img in images:
-        pusher.push_and_tag(img)
-
-
-if __name__ == "__main__":
-    main()
+    pusher.push_and_tag(GhcrImage(image_target=image_target, repository=repository))

--- a/devinfra/ghcr_push/push.bzl
+++ b/devinfra/ghcr_push/push.bzl
@@ -20,13 +20,9 @@ def ghcr_push(name, image, repository, visibility = None):
     main_name = name + "_main"
     pkg = native.package_name()
 
-    # Resolve image label to fully qualified form
-    if image.startswith(":"):
-        image_label = "//{}{}".format(pkg, image)
-    elif image.startswith("//"):
-        image_label = image
-    else:
-        image_label = "//{}:{}".format(pkg, image)
+    # Resolve to fully qualified label for embedding in generated Python.
+    # The image arg is also passed to data= where Bazel resolves it natively.
+    image_label = str(native.package_relative_label(image))
 
     write_file(
         name = main_name,

--- a/devinfra/ghcr_push/push.bzl
+++ b/devinfra/ghcr_push/push.bzl
@@ -1,11 +1,12 @@
 """Bazel macro for pushing OCI images to GHCR with conditional tagging.
 
 Creates a `bazel run`-able py_binary that pushes an OCI image to GHCR only
-when the image digest has changed. Tagged with "ghcr_push" for discovery
-by generate_buildbuddy.py.
+when the image digest has changed. Tagged with "ghcr_push" so targets can
+be found via `bazel query 'attr(tags, "ghcr_push", //...)'`.
+generate_buildbuddy.py maintains a manual PUSH_TARGETS list that must be
+kept in sync (nested bazel query from bazel run is not feasible).
 """
 
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 def ghcr_push(name, image, repository, visibility = None):
@@ -17,35 +18,17 @@ def ghcr_push(name, image, repository, visibility = None):
         repository: Full GHCR repository (e.g., "ghcr.io/agentydragon/props-backend").
         visibility: Bazel visibility.
     """
-    main_name = name + "_main"
-    pkg = native.package_name()
-
-    # Resolve to fully qualified label for embedding in generated Python.
-    # The image arg is also passed to data= where Bazel resolves it natively.
     image_label = str(native.package_relative_label(image))
-
-    write_file(
-        name = main_name,
-        out = name + "_main.py",
-        content = [
-            "from devinfra.ghcr_push.ghcr_push_lib import push_main",
-            "",
-            "push_main(",
-            '    image_target="{}",'.format(image_label),
-            '    repository="{}",'.format(repository),
-            ")",
-        ],
-    )
-
-    # Compute imports path from package depth to repo root
-    depth = len(pkg.split("/")) if pkg else 0
-    imports_path = "/".join([".."] * depth) if depth > 0 else "."
 
     py_binary(
         name = name,
-        srcs = [":" + main_name],
-        main = name + "_main.py",
-        imports = [imports_path],
+        main_module = "devinfra.ghcr_push.ghcr_push_lib",
+        args = [
+            "--image-target",
+            image_label,
+            "--repository",
+            repository,
+        ],
         data = [image],
         deps = ["//devinfra/ghcr_push:ghcr_push_lib"],
         tags = ["ghcr_push"],

--- a/devinfra/ghcr_push/push.bzl
+++ b/devinfra/ghcr_push/push.bzl
@@ -1,0 +1,57 @@
+"""Bazel macro for pushing OCI images to GHCR with conditional tagging.
+
+Creates a `bazel run`-able py_binary that pushes an OCI image to GHCR only
+when the image digest has changed. Tagged with "ghcr_push" for discovery
+by generate_buildbuddy.py.
+"""
+
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+def ghcr_push(name, image, repository, visibility = None):
+    """Create a runnable target that pushes an OCI image to GHCR with conditional tagging.
+
+    Args:
+        name: Target name (e.g., "push_ghcr").
+        image: Label of the oci_image target.
+        repository: Full GHCR repository (e.g., "ghcr.io/agentydragon/props-backend").
+        visibility: Bazel visibility.
+    """
+    main_name = name + "_main"
+    pkg = native.package_name()
+
+    # Resolve image label to fully qualified form
+    if image.startswith(":"):
+        image_label = "//{}{}".format(pkg, image)
+    elif image.startswith("//"):
+        image_label = image
+    else:
+        image_label = "//{}:{}".format(pkg, image)
+
+    write_file(
+        name = main_name,
+        out = name + "_main.py",
+        content = [
+            "from devinfra.ghcr_push.ghcr_push_lib import push_main",
+            "",
+            "push_main(",
+            '    image_target="{}",'.format(image_label),
+            '    repository="{}",'.format(repository),
+            ")",
+        ],
+    )
+
+    # Compute imports path from package depth to repo root
+    depth = len(pkg.split("/")) if pkg else 0
+    imports_path = "/".join([".."] * depth) if depth > 0 else "."
+
+    py_binary(
+        name = name,
+        srcs = [":" + main_name],
+        main = name + "_main.py",
+        imports = [imports_path],
+        data = [image],
+        deps = ["//devinfra/ghcr_push:ghcr_push_lib"],
+        tags = ["ghcr_push"],
+        visibility = visibility,
+    )

--- a/homeassistant/proxy/BUILD.bazel
+++ b/homeassistant/proxy/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
@@ -86,6 +87,12 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = ["homeassistant-proxy:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/homeassistant-proxy",
 )
 
 # =============================================================================

--- a/inventree_utils/rai_plugin/BUILD.bazel
+++ b/inventree_utils/rai_plugin/BUILD.bazel
@@ -4,6 +4,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_python//python:packaging.bzl", "py_wheel")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 
 py_library(
     name = "plugin",
@@ -61,4 +62,10 @@ oci_load(
     image = ":image",
     repo_tags = ["inventree-custom:latest"],
     visibility = ["//visibility:public"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/inventree",
 )

--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_b
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//devinfra/deps:check.bzl", "assert_no_deps")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
@@ -102,6 +103,12 @@ oci_load(
     image = ":direct_image",
     repo_tags = ["exec-backend:latest"],
     visibility = ["//visibility:public"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":direct_image",
+    repository = "ghcr.io/agentydragon/exec-backend",
 )
 
 # macOS seatbelt sandbox exec MCP server

--- a/openclaw/exec/BUILD.bazel
+++ b/openclaw/exec/BUILD.bazel
@@ -13,6 +13,7 @@
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 
 # ── kubectl layer ─────────────────────────────────────────────────────────────
 
@@ -56,4 +57,10 @@ oci_load(
     image = ":image",
     repo_tags = ["openclaw-exec:latest"],
     visibility = ["//visibility:public"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/openclaw-exec",
 )

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 load("//props/specimens:defs.bzl", "specimen_layer_tars")
@@ -297,4 +298,10 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = ["props-backend:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/props-backend",
 )

--- a/tana/token_broker/BUILD.bazel
+++ b/tana/token_broker/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 load("//devinfra/testing:defs.bzl", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
@@ -72,6 +73,12 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = ["tana-token-broker:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/tana-token-broker",
 )
 
 # =============================================================================

--- a/third_party/activitywatch/BUILD.bazel
+++ b/third_party/activitywatch/BUILD.bazel
@@ -12,6 +12,7 @@ Load for local testing:
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
 
 # The aw-webui frontend bundle is built by @aw_webui//:dist (a js_run_binary
 # declared in aw-webui.BUILD.bazel).  It is wired into the Rust build via
@@ -59,4 +60,10 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = ["aw-server:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/aw-server",
 )


### PR DESCRIPTION
## Summary

- Add `ghcr_push()` Bazel macro (`devinfra/ghcr_push/push.bzl`) that creates a `bazel run`-able push target for each OCI image, with conditional tagging (only push + tag if digest changed)
- Each of the 10 image BUILD files now declares its own `push_ghcr` target instead of being listed in a centralized `IMAGES` list
- BuildBuddy push actions use `bazel run` directly — no more separate `bazel build` + manual binary invocation
- Delete `devinfra/ci/bb_push_images.py` (logic moved to `devinfra/ghcr_push/ghcr_push_lib.py`)
- Test reads `buildbuddy.yaml` via Bazel runfiles instead of `__file__` path hacks

## Test plan

- [x] `bazel build //airlock:push_ghcr` succeeds (verifies macro generates valid py_binary)
- [x] `bazel query 'attr(tags, "ghcr_push", //...)'` discovers all 10 push targets
- [x] `bazel test //devinfra/ci:test_generate_buildbuddy` passes (committed yaml matches generator)
- [x] `bazel build --config=rbe //...` succeeds
- [x] Pre-commit checks pass on all changed files

https://claude.ai/code/session_01DegmKELG3oJubeSaqzoJ2h