### PR TITLE
Disable Harbor Trivy vulnerability scanner

### DIFF
--- a/cluster/k8s/harbor/app/helmrelease.yaml
+++ b/cluster/k8s/harbor/app/helmrelease.yaml
@@ -70,8 +70,7 @@ spec:
         redis:
           storageClass: longhorn
           size: 1Gi
-        trivy:
-          size: 5Gi
+        # trivy PVC removed — trivy disabled below
 
     # Admin password from Password generator (bootstrap phase)
     # TODO: Migrate to Vault-backed harbor-secrets once SSO is configured
@@ -141,17 +140,11 @@ spec:
             memory: 512Mi
             cpu: 200m
 
+    # Trivy is Harbor's built-in container image vulnerability scanner
+    # (CVE database download + on-push scanning). Disabled — we don't
+    # consume scan results and it wastes 5Gi storage + ~1Gi memory limit.
     trivy:
-      enabled: true
-      nodeSelector:
-        topology.kubernetes.io/region: proxmox
-      resources:
-        requests:
-          cpu: 20m
-          memory: 64Mi
-        limits:
-          cpu: 1000m
-          memory: 1Gi
+      enabled: false
 
     # Notary (optional)
     notary:


### PR DESCRIPTION
## Summary

- Disable Harbor's built-in Trivy container image vulnerability scanner
- Remove the 5Gi Trivy PVC and associated resource requests/limits/nodeSelector
- Add comment explaining what Trivy is and why it's disabled

Trivy downloads a CVE database and scans images on push, but we don't consume the scan results. Disabling saves 5Gi PVC storage and frees ~1Gi memory limit on the Proxmox worker.

## Test plan

- [ ] Verify Harbor reconciles successfully after Flux picks up the change
- [ ] Confirm Trivy pod is terminated and PVC can be reclaimed

https://claude.ai/code/session_014khGtBFk1byf1j9ZhcU9WN