### PR TITLE
Bump claude-sandbox resource limits

### DIFF
--- a/cluster/k8s/agents/claude-rbac/limitrange.yaml
+++ b/cluster/k8s/agents/claude-rbac/limitrange.yaml
@@ -7,8 +7,8 @@ spec:
   limits:
     # Default limits for containers without specified limits
     - max:
-        cpu: "2"
-        memory: 4Gi
+        cpu: "4"
+        memory: 8Gi
       min:
         cpu: 10m
         memory: 16Mi
@@ -19,8 +19,7 @@ spec:
         cpu: 100m
         memory: 128Mi
       type: Container
-    # Pod limits
     - max:
-        cpu: "4"
-        memory: 8Gi
+        cpu: "8"
+        memory: 16Gi
       type: Pod

--- a/cluster/k8s/agents/claude-rbac/resourcequota.yaml
+++ b/cluster/k8s/agents/claude-rbac/resourcequota.yaml
@@ -5,14 +5,12 @@ metadata:
   namespace: claude-sandbox
 spec:
   hard:
-    # Limit total resources in namespace
-    requests.cpu: "4"
-    requests.memory: 8Gi
+    requests.cpu: "8"
+    requests.memory: 16Gi
     limits.cpu: "8"
     limits.memory: 16Gi
-    # Limit number of objects
-    pods: "10"
+    pods: "20"
     services: "5"
     configmaps: "20"
-    persistentvolumeclaims: "5"
+    persistentvolumeclaims: "10"
     requests.storage: 50Gi


### PR DESCRIPTION
## Summary

- **LimitRange**: raise per-container max to 4 CPU / 8Gi, per-pod max to 8 CPU / 16Gi
- **ResourceQuota**: raise requests.cpu to 8, pods to 20, PVCs to 10

Needed for Firecracker VM pods (each VM: 2-4 CPU, 4-8Gi) and general headroom.

https://claude.ai/code/session_01GemRyThW5cmqXS5zYN5YLn