### PR TITLE
Add OpenEBS LVM LocalPV storage provisioner to wyrm2

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - hcloud-csi/flux-kustomization.yaml
   - talos-cloud-controller-manager/flux-kustomization.yaml
   - local-path-provisioner/flux-kustomization.yaml
+  - openebs-lvm/flux-kustomization.yaml
   - longhorn/flux-kustomization.yaml
   - metrics-server/flux-kustomization.yaml
   - vpa/flux-kustomization.yaml

--- a/cluster/k8s/openebs-lvm/flux-kustomization.yaml
+++ b/cluster/k8s/openebs-lvm/flux-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openebs-lvm
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./cluster/k8s/openebs-lvm"
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: openebs-lvm-localpv
+      namespace: openebs

--- a/cluster/k8s/openebs-lvm/helmrelease.yaml
+++ b/cluster/k8s/openebs-lvm/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: openebs-lvm-localpv
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://openebs.github.io/lvm-localpv
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openebs-lvm-localpv
+  namespace: openebs
+spec:
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: lvm-localpv
+      version: "1.8.1"
+      sourceRef:
+        kind: HelmRepository
+        name: openebs-lvm-localpv
+        namespace: flux-system
+  values:
+    lvmNode:
+      nodeSelector:
+        kubernetes.io/hostname: wyrm2
+    lvmController:
+      nodeSelector:
+        topology.kubernetes.io/region: proxmox

--- a/cluster/k8s/openebs-lvm/kustomization.yaml
+++ b/cluster/k8s/openebs-lvm/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml
+  - sc-lvm-proxmox.yaml

--- a/cluster/k8s/openebs-lvm/namespace.yaml
+++ b/cluster/k8s/openebs-lvm/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/cluster/k8s/openebs-lvm/sc-lvm-proxmox.yaml
+++ b/cluster/k8s/openebs-lvm/sc-lvm-proxmox.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: lvm-proxmox
+provisioner: local.csi.openebs.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  storage: "lvm"
+  volgroup: "openebs-lvmvg"
+  fstype: "ext4"
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: topology.kubernetes.io/region
+        values:
+          - proxmox

--- a/cluster/terraform/main/proxmox-vms.tf
+++ b/cluster/terraform/main/proxmox-vms.tf
@@ -88,6 +88,7 @@ module "wyrm2" {
     { interface = "scsi30", size_gb = 200 },  # containerd (/var/lib/containerd)
     { interface = "virtio0", size_gb = 500 }, # local-path provisioner (/var/local-path-provisioner)
     { interface = "virtio1", size_gb = 100 }, # Longhorn (/var/mnt/longhorn)
+    { interface = "virtio2", size_gb = 500 }, # OpenEBS LVM (VG openebs-lvmvg)
   ]
 
   proxmox_node_name = var.proxmox_node_name

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -131,6 +131,32 @@ in
     autoResize = true;
   };
 
+  # LVM for OpenEBS LVM LocalPV — thin-provisioned volumes with snapshot support.
+  # virtio2 (/dev/vdc) is a dedicated 500GB Proxmox disk for the LVM VG.
+  # OpenEBS node agent runs privileged and uses host LVM tools via nsenter.
+  boot.kernelModules = [ "dm_thin_pool" ];
+  environment.systemPackages = [ pkgs.lvm2 ];
+
+  # Create LVM PV + VG on the OpenEBS disk (idempotent oneshot)
+  systemd.services.openebs-lvm-setup = {
+    description = "Initialize LVM VG for OpenEBS on /dev/vdc";
+    wantedBy = [ "multi-user.target" ];
+    before = [ "kubelet.service" ];
+    after = [ "systemd-udev-settle.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeShellScript "openebs-lvm-setup" ''
+        if ${pkgs.lvm2}/bin/vgs openebs-lvmvg >/dev/null 2>&1; then
+          echo "VG openebs-lvmvg already exists, skipping"
+          exit 0
+        fi
+        ${pkgs.lvm2}/bin/pvcreate /dev/vdc
+        ${pkgs.lvm2}/bin/vgcreate openebs-lvmvg /dev/vdc
+      '';
+    };
+  };
+
   # TODO: Create /mnt/tankshare/shared/{pip-cache,uv-cache} via systemd.tmpfiles.rules
   # and configure pip/uv to use them as cache directories
 


### PR DESCRIPTION
## Summary
This PR adds OpenEBS LVM LocalPV as a storage provisioner to the wyrm2 node, enabling thin-provisioned volumes with snapshot support via LVM.

## Key Changes
- **Kubernetes manifests** (`cluster/k8s/openebs-lvm/`):
  - Added Flux HelmRepository and HelmRelease for OpenEBS LVM LocalPV (v1.8.1)
  - Created `lvm-proxmox` StorageClass with LVM provisioner backend
  - Added openebs namespace with privileged pod security policy
  - Integrated OpenEBS LVM into Flux CD via Kustomization

- **NixOS configuration** (`nix/nixos/hosts/wyrm2/default.nix`):
  - Loaded `dm_thin_pool` kernel module for LVM thin provisioning
  - Added `lvm2` package to system packages
  - Created idempotent systemd oneshot service to initialize LVM physical volume and volume group on `/dev/vdc`
  - Service runs before kubelet to ensure LVM is ready for OpenEBS agent

- **Infrastructure** (`cluster/terraform/main/proxmox-vms.tf`):
  - Added 500GB virtio2 disk to wyrm2 VM dedicated for OpenEBS LVM volume group

## Implementation Details
- The LVM setup is idempotent—it checks if the `openebs-lvmvg` volume group already exists before attempting creation
- OpenEBS node agent is constrained to wyrm2 via nodeSelector on `kubernetes.io/hostname`
- Controller is constrained to proxmox region via topology selector
- StorageClass uses `WaitForFirstConsumer` binding mode and supports volume expansion

https://claude.ai/code/session_01694iG6R4nashQBu3watR2s