### PR TITLE
Migrate PowerDNS records from Terraform to Kubernetes CRDs

### DIFF
--- a/cluster/k8s/dns-automation/dns-records-tf.yaml
+++ b/cluster/k8s/dns-automation/dns-records-tf.yaml
@@ -24,16 +24,6 @@ spec:
   vars:
     - name: route53_zone_id
       value: "Z02901943N8ZFQFOD9P5I"
-    - name: powerdns_url
-      value: "http://powerdns-api.dns-system:8081"
-
-  # Secrets - PowerDNS API key from existing secret
-  varsFrom:
-    - kind: Secret
-      name: powerdns-api-key
-      varsKeys:
-        - powerdns_api_key
-      optional: false
 
   # AWS credentials as environment variables
   runnerPodTemplate:

--- a/cluster/k8s/dns-automation/flux-kustomization.yaml
+++ b/cluster/k8s/dns-automation/flux-kustomization.yaml
@@ -19,5 +19,3 @@ spec:
   dependsOn:
     - name: tofu-controller
     - name: sealed-secrets # aws-credentials-sealed.yaml
-    - name: powerdns # PowerDNS must be running (API endpoint)
-    - name: reflector # Reflector must copy powerdns-api-key to flux-system

--- a/cluster/k8s/powerdns/zones/dns-records.yaml
+++ b/cluster/k8s/powerdns/zones/dns-records.yaml
@@ -1,0 +1,104 @@
+---
+# Nebula lighthouse A records — resolve lighthouse cert names to VPS public IPs.
+# Used by non-lighthouse nodes (wyrm2, rugged) to find lighthouses before joining
+# the mesh. IPs substituted by Flux postBuild from cluster-info ConfigMap.
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: nebula-talos-vps-cp-0
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: talos-vps-cp-0.nebula.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps0}"
+---
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: nebula-talos-vps-cp-1
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: talos-vps-cp-1.nebula.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps1}"
+---
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: nebula-talos-vps-worker-0
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: talos-vps-worker-0.nebula.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps_worker0}"
+---
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: nebula-talos-vps-worker-1
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: talos-vps-worker-1.nebula.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps_worker1}"
+---
+# Nameserver A records (within the zone)
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: ns1
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: ns1.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps0}"
+---
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: ns2
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: ns2.allegedly.works.
+  type: A
+  ttl: 3600
+  records:
+    - "${vps_ip_vps1}"
+---
+# Kubernetes API endpoint (round-robin to CP nodes)
+apiVersion: dns.cav.enablers.ob/v1alpha2
+kind: ClusterRRset
+metadata:
+  name: api
+spec:
+  zoneRef:
+    kind: ClusterZone
+    name: allegedly.works
+  name: api.allegedly.works.
+  type: A
+  ttl: 300
+  records:
+    - "${vps_ip_vps0}"
+    - "${vps_ip_vps1}"

--- a/cluster/k8s/powerdns/zones/flux-kustomization.yaml
+++ b/cluster/k8s/powerdns/zones/flux-kustomization.yaml
@@ -13,6 +13,10 @@ spec:
     kind: GitRepository
     name: flux-system
   wait: true
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-info
   # Health check ensures DNS zone is created before external-dns tries to manage records
   healthChecks:
     - apiVersion: dns.k8s.codesink.net/v1alpha1
@@ -20,4 +24,5 @@ spec:
       name: allegedly-works
   dependsOn:
     - name: powerdns-operator
+    - name: reflector
   timeout: 5m

--- a/cluster/k8s/powerdns/zones/kustomization.yaml
+++ b/cluster/k8s/powerdns/zones/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 resources:
   - clusterzone.yaml
   - soa-record.yaml
-  # nameserver-glue-records.yaml removed - now managed by dns-automation tofu-controller
+  - dns-records.yaml

--- a/cluster/terraform/gitops/dns-records/main.tf
+++ b/cluster/terraform/gitops/dns-records/main.tf
@@ -1,3 +1,12 @@
+# Route 53 glue records and domain registration.
+#
+# PowerDNS zone records (NS, nebula lighthouse, API endpoint) are managed
+# declaratively as ClusterRRset CRDs in k8s/powerdns/zones/dns-records.yaml
+# with IPs substituted by Flux from the cluster-info ConfigMap.
+#
+# This module handles only the AWS side: glue records at the registrar level
+# and nameserver delegation, which require the AWS API (not PowerDNS).
+
 terraform {
   required_version = ">= 1.0"
 
@@ -5,10 +14,6 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
-    }
-    powerdns = {
-      source  = "pan-net/powerdns"
-      version = "~> 1.5"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -18,7 +23,6 @@ terraform {
 }
 
 # Read VPS IPs from ConfigMap created by infrastructure terraform
-# Note: ConfigMap is in kube-system (always exists during infra layer)
 data "kubernetes_config_map" "cluster_info" {
   metadata {
     name      = "cluster-info"
@@ -27,13 +31,9 @@ data "kubernetes_config_map" "cluster_info" {
 }
 
 locals {
-  # CP nodes — for NS records, API endpoint, nameserver registration
   vps_cp_nodes = jsondecode(data.kubernetes_config_map.cluster_info.data["vps_cp_nodes"])
-  # All VPS nodes — for Nebula lighthouse DNS
-  vps_nodes = jsondecode(data.kubernetes_config_map.cluster_info.data["vps_nodes"])
-  domain    = "allegedly.works"
+  domain       = "allegedly.works"
 
-  # Map CP nodes to nameserver numbers: vps0 -> ns1, vps1 -> ns2, etc.
   ns_records = {
     for k, v in local.vps_cp_nodes : k => {
       ns_name = "ns${tonumber(substr(k, 3, -1)) + 1}" # vps0 -> ns1, vps1 -> ns2
@@ -46,12 +46,6 @@ locals {
 provider "aws" {
   region = var.aws_region
   # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from environment
-}
-
-# PowerDNS provider
-provider "powerdns" {
-  server_url = var.powerdns_url
-  api_key    = var.powerdns_api_key
 }
 
 # Route 53 glue records (at registrar level)
@@ -67,38 +61,6 @@ resource "aws_route53_record" "ns_glue" {
   ttl             = 300
   records         = [each.value.ip]
   allow_overwrite = true
-}
-
-# PowerDNS NS A records (within the zone)
-resource "powerdns_record" "ns" {
-  for_each = local.ns_records
-
-  zone    = "${local.domain}."
-  name    = "${each.value.ns_name}.${local.domain}."
-  type    = "A"
-  ttl     = 3600
-  records = [each.value.ip]
-}
-
-# Nebula lighthouse DNS records — all VPS nodes (CPs + workers) are lighthouses.
-# Uses node names: talos-vps-cp-0.nebula.allegedly.works, talos-vps-worker-0.nebula.allegedly.works
-resource "powerdns_record" "nebula_lighthouse" {
-  for_each = local.vps_nodes
-
-  zone    = "${local.domain}."
-  name    = "${each.value.name}.nebula.${local.domain}."
-  type    = "A"
-  ttl     = 3600
-  records = [each.value.ip]
-}
-
-# Kubernetes API endpoint (round-robin to CP nodes only)
-resource "powerdns_record" "api" {
-  zone    = "${local.domain}."
-  name    = "api.${local.domain}."
-  type    = "A"
-  ttl     = 300
-  records = [for k, v in local.vps_cp_nodes : v.ip]
 }
 
 # Import: domain registration persists across cluster lifecycles.

--- a/cluster/terraform/gitops/dns-records/variables.tf
+++ b/cluster/terraform/gitops/dns-records/variables.tf
@@ -8,15 +8,3 @@ variable "route53_zone_id" {
   type        = string
   description = "Route 53 hosted zone ID for allegedly.works"
 }
-
-variable "powerdns_url" {
-  type        = string
-  default     = "http://powerdns-api.dns-system:8081"
-  description = "PowerDNS API URL (cluster-internal)"
-}
-
-variable "powerdns_api_key" {
-  type        = string
-  sensitive   = true
-  description = "PowerDNS API key for record management"
-}


### PR DESCRIPTION
## Summary
Migrate DNS record management for PowerDNS from Terraform (via powerdns provider) to Kubernetes-native ClusterRRset CRDs, while keeping Route 53 glue records in Terraform. This simplifies the gitops workflow by eliminating the need for PowerDNS API credentials in Terraform and leveraging Flux for declarative DNS record management.

## Key Changes

- **New Kubernetes DNS records manifest** (`cluster/k8s/powerdns/zones/dns-records.yaml`):
  - Defines ClusterRRset CRDs for Nebula lighthouse A records (talos-vps-cp-0, talos-vps-cp-1, talos-vps-worker-0, talos-vps-worker-1)
  - Defines nameserver A records (ns1, ns2) within the zone
  - Defines Kubernetes API endpoint (api.allegedly.works) with round-robin to CP nodes
  - Uses Flux variable substitution (`${vps_ip_*}`) for IP addresses from cluster-info ConfigMap

- **Terraform refactoring** (`cluster/terraform/gitops/dns-records/`):
  - Removed PowerDNS provider and all related resources (ns, nebula_lighthouse, api records)
  - Kept only Route 53 glue records (AWS-side nameserver delegation)
  - Removed powerdns_url and powerdns_api_key variables
  - Updated module documentation to clarify scope: AWS glue records only

- **Flux configuration updates**:
  - Added `postBuild.substituteFrom` to powerdns zones kustomization to inject IPs from cluster-info ConfigMap
  - Removed powerdns-api-key secret reference from dns-automation tofu-controller
  - Removed powerdns and reflector dependencies from dns-automation kustomization
  - Updated powerdns zones kustomization to include new dns-records.yaml

## Implementation Details

- IP substitution is handled by Flux's postBuild feature, eliminating the need for Terraform to manage PowerDNS API calls
- Route 53 glue records remain in Terraform since they require AWS API access and persist across cluster lifecycles
- The separation of concerns is now clearer: Terraform handles registrar-level records (AWS), Kubernetes handles zone-level records (PowerDNS)
- All DNS records use appropriate TTLs (3600 for static records, 300 for API endpoint to support faster failover)

https://claude.ai/code/session_012nTLRdpdTosrD1aUx8vCCz