### PR TITLE
Firecracker dev VM implementation: manager, VM pods, process_api client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -270,6 +270,7 @@ repos:
             cluster/k8s/gatus/app/config\.yaml|
             cluster/k8s/agents/airlock/config\.yaml|
             cluster/k8s/agents/homeassistant-proxy/config\.yaml|
+            cluster/k8s/agents/claude-sandbox-firecracker/config\.yaml|
             cluster/k8s/litellm/app/proxy-config\.yaml|
             # Helm values files consumed via configMapGenerator, not K8s manifests
             cluster/k8s/.*/ccm-values\.yaml

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -249,7 +249,14 @@ apt.install(
     lock = "//devinfra/claude/hook_daemon/session_start/container_e2e:trixie_e2e.lock.json",
     manifest = "//devinfra/claude/hook_daemon/session_start/container_e2e:trixie_e2e.yaml",
 )
-use_repo(apt, "trixie_e2e")
+
+# Firecracker VM pod: iproute2, iptables, mount, procps, openssh-client on debian:bookworm-slim.
+apt.install(
+    name = "bookworm_fc_vm_pod",
+    lock = "//devinfra/firecracker/vm_pod:bookworm_fc_vm_pod.lock.json",
+    manifest = "//devinfra/firecracker/vm_pod:bookworm_fc_vm_pod.yaml",
+)
+use_repo(apt, "bookworm_fc_vm_pod", "trixie_e2e")
 
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
@@ -712,6 +719,16 @@ http_file(
     executable = True,
     sha256 = "fd8fdff418a1758887520fa42da7e6ae39aefc788cf5e7f7bb8db6934d279fc4",
     urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64"],
+)
+
+# Firecracker v1.12.1 — microVM VMM binary for Firecracker dev VMs on wyrm2.
+# The tarball contains the firecracker binary + jailer + tools. We extract
+# just the firecracker binary in devinfra/firecracker/BUILD.bazel.
+http_archive(
+    name = "firecracker_release",
+    build_file_content = 'exports_files(["release-v1.12.1-x86_64/firecracker-v1.12.1-x86_64"])',
+    sha256 = "0a75e67ef6e4c540a2cf248b06822b0be9820cbba9fe19f9e0321200fe76ff6b",
+    urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.12.1/firecracker-v1.12.1-x86_64.tgz"],
 )
 
 # Node.js v22.11.0 LTS linux-x64 — provides the 'node' binary for the

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -67,6 +67,20 @@ actions:
     steps:
       - run: |
           bazel run --config=rbe --remote_download_toplevel //cluster/k8s/inventree/token-provisioner:push_ghcr
+  - name: Push //devinfra/firecracker/manager:push_ghcr
+    triggers: *id001
+    container_image: ubuntu-24.04
+    resource_requests: *id002
+    steps:
+      - run: |
+          bazel run --config=rbe --remote_download_toplevel //devinfra/firecracker/manager:push_ghcr
+  - name: Push //devinfra/firecracker/vm_pod:push_ghcr
+    triggers: *id001
+    container_image: ubuntu-24.04
+    resource_requests: *id002
+    steps:
+      - run: |
+          bazel run --config=rbe --remote_download_toplevel //devinfra/firecracker/vm_pod:push_ghcr
   - name: Push //homeassistant/proxy:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -30,6 +30,8 @@ PUSH_TARGETS = [
     BazelLabel.parse("//airlock:push_ghcr"),
     BazelLabel.parse("//airlock/auth_proxy:push_ghcr"),
     BazelLabel.parse("//cluster/k8s/inventree/token-provisioner:push_ghcr"),
+    BazelLabel.parse("//devinfra/firecracker/manager:push_ghcr"),
+    BazelLabel.parse("//devinfra/firecracker/vm_pod:push_ghcr"),
     BazelLabel.parse("//homeassistant/proxy:push_ghcr"),
     BazelLabel.parse("//inventree_utils/rai_plugin:push_ghcr"),
     BazelLabel.parse("//mcp_infra/exec:push_ghcr"),

--- a/devinfra/firecracker/AGENTS.md
+++ b/devinfra/firecracker/AGENTS.md
@@ -1,0 +1,26 @@
+@README.md
+
+## Agent Instructions
+
+### Creating a VM
+
+```bash
+kubectl port-forward -n claude-sandbox svc/fc-manager 8080:8080 &
+TOKEN=$(kubectl get secret -n claude-sandbox fc-manager-auth-token \
+  -o jsonpath='{.data.token}' | base64 -d)
+curl -s -H "Authorization: Bearer $TOKEN" localhost:8080/vms -XPOST \
+  -d '{"cpus": 2, "mem_mib": 4096}'
+```
+
+### SSH into a VM
+
+```bash
+kubectl port-forward -n claude-sandbox pod/fc-vm-<id> 2222:22 &
+ssh -p 2222 -o StrictHostKeyChecking=no root@localhost "<command>"
+```
+
+### Destroying a VM
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" localhost:8080/vms/<id> -XDELETE
+```

--- a/devinfra/firecracker/BUILD.bazel
+++ b/devinfra/firecracker/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+# Firecracker binary — packaged as a tar layer for the VM pod OCI image.
+# The binary comes from @firecracker_release (http_archive in MODULE.bazel).
+pkg_tar(
+    name = "firecracker_layer",
+    srcs = ["@firecracker_release//:release-v1.12.1-x86_64/firecracker-v1.12.1-x86_64"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+    remap_paths = {"release-v1.12.1-x86_64/firecracker-v1.12.1-x86_64": "firecracker"},
+    visibility = ["//devinfra/firecracker:__subpackages__"],
+)

--- a/devinfra/firecracker/DESIGN.md
+++ b/devinfra/firecracker/DESIGN.md
@@ -1,0 +1,455 @@
+# Firecracker Dev VMs — Design Document
+
+Warm Firecracker microVMs on the home cluster for Claude Code development.
+
+## Problem
+
+Claude Code web sessions run inside Anthropic's Firecracker VMs with:
+
+- ~41G usable disk (256G ext4 with 84% reserved blocks — fixable via `tune2fs`)
+- Bazel cold start: 11-29s (JVM startup + module extension eval + BCR fetches)
+- First warm Bazel query: ~6s (Starlark eval: pip 3.4s, npm 2.2s, go_sdk 1.1s)
+- Subsequent warm queries: ~0.3s (filesystem diff scanning)
+- Session start overhead: ~13s (proxy setup, Bazel warmup, env config)
+- Disk fills up from accumulated session Bazel caches (2-12G each)
+
+Builds execute remotely via BuildBuddy RBE — the local VM is effectively
+just an expensive JVM host. Profiling data: <devinfra/precommit/enforce_bazel_tests/debug/>.
+
+## Goal
+
+Run Firecracker microVMs on wyrm2 (bare metal NixOS, 32 CPU, 94G RAM, KVM,
+2x RTX 5090) that Claude Code sessions can SSH into. VMs have:
+
+- Internet access (for git clone, BCR fetches, BuildBuddy RBE)
+- Bazel + Python 3.13 + full build toolchain
+- Fast startup via snapshot/restore (~28ms vs ~15s cold boot)
+- Persistent caches across sessions
+
+## Non-Goals
+
+- Replacing Anthropic's Firecracker VMs (those handle Claude Code itself)
+- Running untrusted code (VMs run our own toolchain, not user code)
+- Multi-tenant isolation (single user, trusted workloads)
+
+## Requirements
+
+### Functional
+
+1. Claude Code session can create a VM via authenticated API call
+2. Claude Code session can SSH into the VM and run commands
+3. VM has internet access (git, curl, Bazel BCR, BuildBuddy)
+4. VM has Bazel, Python 3.13, JDK 21, Git, build-essential
+5. VM rootfs is reproducible (Nix-built)
+6. Multiple VMs can run concurrently (separate pods)
+7. VMs can be snapshotted and restored with warm Bazel state
+
+### Non-Functional
+
+1. VM creation: <60s cold, <5s from snapshot
+2. SSH latency: <50ms within cluster
+3. No full privileged pods — only `/dev/kvm` + `NET_ADMIN`
+4. GitOps-managed (Flux) for all cluster resources
+5. CI-published images (rootfs, manager, VM pod)
+
+### Acceptance Criteria
+
+- [ ] Device plugin exposes `/dev/kvm` on wyrm2
+- [ ] `nix build .#fc-dev-rootfs` produces bootable ext4 + vmlinux
+- [ ] Initramfs with process_api boots, pivot_roots to NixOS on /dev/vda
+- [ ] API: `POST /vms` creates a VM pod, returns WebSocket endpoint
+- [ ] WebSocket `CreateProcess` runs commands, streams I/O
+- [ ] `curl ifconfig.me` inside VM returns an IP (guest networking works)
+- [ ] `bazel info` inside VM succeeds (JVM starts, finds workspace)
+- [ ] `bazel test //util/bazel/...` passes inside VM (RBE works)
+- [ ] Snapshot: warm Bazel, snapshot, restore — query takes ~0.3s not ~15s
+- [ ] All k8s resources reconcile via Flux without manual intervention
+
+## Architecture
+
+### Storage: LVM thin provisioning via OpenEBS LVM LocalPV
+
+All VM storage lives on a single LVM thin pool on wyrm2. OpenEBS LVM
+LocalPV is a lightweight CSI driver (single DaemonSet) that wraps LVM
+commands. Two volume modes from the same VG:
+
+| Resource     | volumeMode   | Provisioning             | Why                                                                                                                                                               |
+| ------------ | ------------ | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rootfs**   | `Block`      | Thin snapshot of base LV | Firecracker drives API accepts block devices. Instant CoW clone. No filesystem overhead.                                                                          |
+| **Snapshot** | `Filesystem` | Thin-provisioned, ext4   | Firecracker's snapshot code uses `ftruncate()` + `metadata().len()` — requires regular files (see below). One PVC per snapshot holds both `memory` and `vmstate`. |
+
+#### Why rootfs is Block but snapshots are Filesystem
+
+Firecracker's drive API (`PUT /drives/{id}`) accepts `path_on_host` as
+either a regular file or a block device — both work.
+
+Firecracker's snapshot API does **not** work with block devices:
+
+- **Create** (`PUT /snapshot/create`): calls `ftruncate()` to size the
+  memory file → `EINVAL` on block devices.
+- **Load** (`PUT /snapshot/load`): calls `file.metadata().len()` which
+  returns 0 for block devices → fails size check before reaching `mmap`.
+
+The actual I/O (write, mmap MAP_PRIVATE) would work on block devices —
+it's only the Rust file metadata + truncation assumptions that break.
+(Source: `firecracker/src/vmm/src/vstate/vm.rs` snapshot_memory_to_file,
+`src/vmm/src/vstate/memory.rs` snapshot_file.)
+
+#### PVC lifecycle
+
+Each VM gets two PVCs:
+
+- **Rootfs** (`Block`): thin clone of base
+- **Work** (`Filesystem`): thin-provisioned, holds snapshot files at `/work/snapshots/`
+
+```
+POST /vms → manager creates:
+  1. Rootfs PVC (Block, dataSource: base) → instant CoW
+  2. Work PVC (Filesystem, thin) → mounted at /work
+  3. Pod with rootfs as /dev/rootfs, work at /work
+
+POST /vms/{id}/snapshot {name} →
+  4. Firecracker writes memory + vmstate to /work/snapshots/{name}/
+     (files persist on the VM's work PVC)
+
+POST /snapshots/{name}/restore →
+  5. New rootfs PVC (clone of source VM's rootfs)
+  6. New snapshot PVC (clone of source VM's work PVC) → CoW, not shared
+  7. New work PVC (fresh, for the restored VM's own use)
+  8. New pod: rootfs as /dev/rootfs, snapshot at /snapshots, work at /work
+
+DELETE /vms/{id} → deletes pod + all per-VM PVCs
+```
+
+#### Fork-resume (one snapshot → N VMs)
+
+Each restored VM gets its own CoW clone of the snapshot PVC — no PVC
+sharing between VMs. LVM thin snapshots are instant and CoW at the
+block level, so N restores from one snapshot create N thin LVs that
+share physical extents until written.
+
+Inside the guest, Firecracker mmaps the memory file with `MAP_PRIVATE`
+(CoW at the page level). Each VM gets its own dirty pages while sharing
+the base memory via the LVM thin snapshot underneath.
+
+#### Base rootfs provisioning
+
+The NixOS rootfs is built via Nix on wyrm2 (which has the repo and Nix
+available). No OCI wrapping — just `nix build` + `dd` to the base LV:
+
+```bash
+./devinfra/firecracker/provision-rootfs.sh
+```
+
+The script builds `.#fc-dev-rootfs` (fetches from binary cache if
+available), finds the ext4 image in the output, and `dd`s it into the
+base LV. Re-run when Nix config changes. The rootfs updates infrequently
+(kernel, NixOS modules, toolchain packages).
+
+#### Setup
+
+1. Attach a block device to wyrm2 (Proxmox virtual disk, ~100GB)
+2. Create VG + thin pool (OpenEBS LVM LocalPV is deployed, VG: `openebs-lvmvg`)
+3. Create block-mode StorageClass `lvm-proxmox-block` (same VG, no fstype)
+4. Create base rootfs LV and run `provision-rootfs.sh`
+
+### Guest init: process_api via initramfs
+
+Anthropic's `process_api` is a ~3.3MB static Rust binary that serves as
+PID 1 in Claude Code web Firecracker VMs. Full reverse-engineered source
+(5,752 lines, 10 modules) at <devinfra/claude/web_env/re/process_api/>.
+
+We use it as our guest init, following Anthropic's architecture:
+
+```
+VM pod entrypoint (host side)
+  │
+  │ Firecracker API:
+  │   PUT /boot-source  {kernel, initrd_path: initramfs.cpio}
+  │   PUT /drives/rootfs {path_on_host: nixos-rootfs.ext4}  → /dev/vda
+  │   PUT /actions       {InstanceStart}
+  │
+  ▼
+┌─ Firecracker guest ────────────────────────────────┐
+│                                                     │
+│  Kernel boots → unpacks initramfs to tmpfs          │
+│  Runs /init (process_api --firecracker-init)        │
+│                                                     │
+│  process_api:                                       │
+│    1. mount /proc, /sys, /dev, /dev/pts, cgroup2    │
+│    2. configure networking (IP, gateway, DNS)       │
+│    3. mount /dev/vda (ext4) → /mnt                  │
+│    4. pivot_root /mnt /mnt/oldroot                  │
+│    5. umount /oldroot (initramfs freed)             │
+│    6. start WebSocket listener (vsock or TCP)       │
+│    7. start HTTP control server                     │
+│                                                     │
+│  Guest is now running NixOS from /dev/vda with      │
+│  process_api as PID 1 managing processes via WS.    │
+│                                                     │
+│  /init in /proc/1/exe → points to initramfs path    │
+│  (filesystem gone after pivot_root — invisible)     │
+└─────────────────────────────────────────────────────┘
+```
+
+**Two filesystem images:**
+
+1. **Initramfs** (~5MB cpio): contains just `process_api` as `/init`.
+   Built as a cpio archive, baked into the VM pod OCI image. The kernel
+   unpacks it into tmpfs at boot. After pivot_root the tmpfs is freed.
+
+2. **NixOS rootfs** (~2-4GB ext4): full dev environment. Exposed to
+   guest as `/dev/vda` via Firecracker's drive API. Delivery mechanism
+   is an open decision (see Storage section).
+
+**What process_api provides:**
+
+- **Process execution over WebSocket**: spawn processes, forward I/O as
+  binary frames, reattachable sessions that survive disconnects
+- **vsock + TCP + UDS transports**: same protocol over any transport
+- **HTTP control server**: `/health`, `/shutdown`, `/fs_freeze`,
+  `/fs_thaw`, `/mount_root` (snapstart — apply per-session config on
+  snapshot restore)
+- **Cgroup v1/v2 resource limits**: per-process memory/OOM monitoring
+- **JWT auth**: Ed25519-verified tokens (optional — accepts all if no key)
+
+**Trade-off**: proprietary binary we can't rebuild. If a Firecracker or
+kernel update breaks compatibility, fallback is reimplementing the subset
+we need (vsock readiness + command exec + fs_freeze/thaw) as a custom
+agent. The RE source serves as the spec.
+
+**SSH remains available** in the NixOS rootfs for interactive access from
+Claude Code sessions. process_api handles the machine-to-machine control
+plane (readiness, process exec, snapshot coordination).
+
+### Pod-per-VM
+
+Each Firecracker VM runs as its own k8s pod. The pod is infrastructure-only
+(Firecracker process + networking + port proxies). The manager service is
+the VMM brain — it creates pods, drives boot/restore via the FC API proxy,
+and tracks VM state.
+
+```
+Claude Code session (Anthropic Firecracker VM)
+  │
+  │ 1. POST /vms → manager creates PVC (cloned from base) + pod
+  │ 2. POST /vms/{id}/boot → manager configures FC via API proxy
+  │ 3. Manager returns pod IP + ports
+  │ 4. Claude Code connects to process_api WS on pod_ip:2024
+  │
+  ├──── Manager API ──────────────────────────────────┐
+  │     POST /vms, POST /vms/{id}/boot                │
+  │     POST /vms/{id}/snapshot, POST /vms/{id}/restore│
+  │     DELETE /vms/{id}, GET /vms                     │
+  └───────────────────────────────────────────────────┘
+  │
+  │ Manager drives boot/restore via FC API proxy (:2026)
+  │ Manager waits for guest /health via control proxy (:2025)
+  │ Claude Code connects to WS proxy (:2024)
+  ▼
+┌─ VM Pod (infrastructure only) ──────────────────────┐
+│ entrypoint:                                          │
+│   1. Create TAP + NAT (pyroute2 + nft)              │
+│   2. Start Firecracker process (no VM config)       │
+│   3. Proxy ports onto pod network:                  │
+│        :2024 → guest:2024 (process_api WS)          │
+│        :2025 → guest:2025 (process_api HTTP)        │
+│        :2026 → FC Unix socket (management API)      │
+│   4. Block until Firecracker exits                  │
+│                                                      │
+│ ┌─ Firecracker VM ─────────────────────────────────┐│
+│ │ process_api (PID 1, from initramfs)              ││
+│ │   ├─ WebSocket :2024 — process execution         ││
+│ │   ├─ HTTP :2025 — /health, /shutdown, /fs_freeze ││
+│ │   └─ pivot_root to NixOS on /dev/vda             ││
+│ │                                                   ││
+│ │ NixOS guest (sshd for interactive access)        ││
+│ │ Bazel + Python 3.13 + JDK 21 + Git              ││
+│ │ eth0 → TAP → pod eth0 → internet                ││
+│ └───────────────────────────────────────────────────┘│
+│                                                      │
+│ /dev/kvm (via device plugin)                         │
+│ NET_ADMIN (for TAP + NAT)                            │
+│ PVC: rootfs (cloned from base by manager)            │
+│ emptyDir: /work (snapshots, runtime)                 │
+└──────────────────────────────────────────────────────┘
+```
+
+### Command execution
+
+Claude Code drives the VM via **process_api's WebSocket API** (port 2024),
+the same protocol Anthropic uses in their own Claude Code web VMs:
+
+1. Manager creates VM pod, waits for process_api `/health` to respond
+2. Manager returns WebSocket connection info (pod IP + port) to caller
+3. Claude Code connects to process_api WebSocket directly
+4. Sends `CreateProcess` with command, args, env, uid/gid, timeout
+5. process_api spawns the process, streams stdout/stderr as binary frames
+6. Client sends stdin, signals (SIGINT, SIGTERM)
+7. Sessions are **reattachable** — if the WebSocket disconnects, the
+   process keeps running. Client reconnects with `ProcessConnection`.
+
+SSH remains available in the NixOS guest for interactive/ad-hoc access,
+but the primary machine-to-machine interface is the WebSocket API.
+
+### Networking
+
+Each VM pod gets a CNI-assigned IP. Inside the pod, the entrypoint:
+
+1. Creates a TAP device
+2. NATs via nftables MASQUERADE (pyroute2 for TAP, `nft` for NAT)
+3. Firecracker attaches the TAP as a virtio-net device
+4. Guest gets an IP on the TAP subnet, routes through pod's `eth0`
+5. process_api listens on TCP :2024 (WebSocket) and :2025 (HTTP control)
+
+Claude Code sessions reach VMs via `kubectl port-forward` to the VM pod
+(port 2024 for WebSocket, port 22 for SSH).
+
+### Authentication
+
+Manager service uses bearer token auth. Token stored as k8s Secret in
+`claude-sandbox`, available to Claude Code sessions via the existing
+kubeconfig (ServiceAccount `claude-code-web` has Secret read access).
+
+process_api supports optional JWT auth (Ed25519). With no key configured
+it accepts all tokens — sufficient for our single-user trusted setup.
+Can be hardened later by injecting an auth key via the manager config.
+
+### Snapshot/Restore
+
+Firecracker's snapshot API (`PUT /snapshot/create`, `PUT /snapshot/load`)
+captures full VM state (memory + vCPU registers + device state). Restore
+uses `userfaultfd` lazy memory loading — pages are demand-faulted from the
+snapshot file, achieving ~28ms restore time.
+
+Workflow:
+
+1. Boot VM, clone repo, `bazel query 'tests(//...)'` (warms Skyframe)
+2. Pause VM: `PUT /vm` with `state: Paused`
+3. Snapshot: `PUT /snapshot/create` → memory + state files on PVC
+4. Restore: new pod starts Firecracker with `--restore-from-snapshot`
+5. Fixups: re-seed entropy, reconnect SSH, `git pull`
+
+Post-restore, Bazel queries take ~0.3s (warm Skyframe) instead of ~15s.
+
+### Gotchas on Snapshot Restore
+
+| Issue             | Cause                                 | Fix                              |
+| ----------------- | ------------------------------------- | -------------------------------- |
+| Entropy           | RNG state identical across clones     | Re-seed via virtio-rng or vsock  |
+| Clock skew        | Guest clock frozen at snapshot time   | `ntpdate` or inject via serial   |
+| Stale connections | TCP connections dead post-restore     | Reconnect (sshd restarts accept) |
+| Git state         | Repo at snapshot-time commit          | `git fetch && git checkout`      |
+| Unique identity   | MAC, instance ID shared across clones | Re-randomize on restore          |
+| Filesystem        | Rootfs must match snapshot state      | CoW clone from snapshot's rootfs |
+
+## Prior Art
+
+### Anthropic's Snapstart
+
+Anthropic's own `process_api` (reverse-engineered in
+`devinfra/claude/web_env/re/process_api/`) implements this exact pattern:
+
+- **Template mode**: Boot VM, run full init, write `"SNAPSTART_READY\n"` to
+  serial port. Host snapshots the frozen VM.
+- **Resume mode**: Restore snapshot, thaw filesystem (FITHAW ioctl), call
+  `POST /mount_root` to apply per-session config (mounts, env vars).
+- Communication via vsock + Unix domain sockets.
+
+This validates the architecture — Anthropic uses warm VM pools in production
+for Claude Code web.
+
+### ForgeVM
+
+Go binary orchestrating Firecracker sandboxes with 28ms snapshot restore.
+Built for AI agent code execution. Uses vsock + custom guest agent (author
+regrets not using gRPC). Memory-efficient: 50 VMs from one snapshot share
+most pages via CoW. Not k8s-native, no published GitHub repo yet.
+
+Source: [DEV Community writeup](https://dev.to/adwitiya/how-i-built-sandboxes-that-boot-in-28ms-using-firecracker-snapshots-i0k)
+
+### vHive
+
+Research framework (Edinburgh/NTU) for serverless experimentation.
+Most mature open-source Firecracker snapshot implementation on k8s
+(via Knative). Supports their REAP mechanism — records guest memory
+working set and proactively prefetches on restore (reduces page fault
+overhead by 95%). Research-grade, not production infra. Requires owning
+the entire k8s cluster.
+
+Source: [github.com/vhive-serverless/vHive](https://github.com/vhive-serverless/vHive)
+
+### Kata Containers
+
+Production k8s runtime supporting Firecracker as a VMM backend. But
+snapshot/restore within Kata+Firecracker is not first-class — the
+VM cache feature works mainly with QEMU/Cloud Hypervisor. The
+Kata+Firecracker stack is reported as difficult to configure (devmapper
+snapshotter requirements, stale docs).
+
+### Rejected Alternatives
+
+| Project   | Why rejected                                                 |
+| --------- | ------------------------------------------------------------ |
+| KubeVirt  | Too heavy: virt-handler leaks to 7-12GB, wraps VMs in QEMU   |
+| Hocus     | Abandoned, replaced Firecracker with QEMU for dev envs       |
+| Flintlock | Archived (Weaveworks shutdown), no snapshot support          |
+| Daytona   | Docker-based (not Firecracker), no VM-level snapshot/restore |
+| E2B       | SaaS only, data leaves machine                               |
+
+### firecracker-containerd
+
+AWS's containerd integration. Provides the devmapper snapshotter for
+exposing container images as block devices to Firecracker VMs. However,
+snapshot/restore of VMs is not exposed through containerd's API — you'd
+need to call the Firecracker socket directly. In maintenance mode.
+
+We don't need the containerd integration because we're not running OCI
+containers inside Firecracker — we're running a NixOS guest directly.
+
+## Key Decisions
+
+| Decision            | Choice                              | Rationale                                            |
+| ------------------- | ----------------------------------- | ---------------------------------------------------- |
+| Device access       | Generic device plugin               | Lightest option, no KubeVirt overhead                |
+| VM isolation        | Pod-per-VM                          | k8s lifecycle, resource accounting, standard tooling |
+| Rootfs build        | Nix                                 | Reuses `bazel-dev.nix`, shares with wyrm2 config     |
+| Manager             | FastAPI service                     | Orchestrates pods via k8s API, lightweight           |
+| Manager image build | Bazel rules_oci                     | Consistent with repo, mypy checked                   |
+| Firecracker binary  | Bazel http_file dep                 | Pinned, reproducible, baked into image               |
+| Command execution   | process_api WebSocket               | Same protocol as Anthropic's VMs, reattachable       |
+| Network             | TAP + NAT in pod                    | Pod gets CNI networking, VM NATs through it          |
+| Auth                | Bearer token (manager), JWT (guest) | k8s Secret for manager, optional Ed25519 for WS      |
+| Guest init          | process_api via initramfs           | Production-hardened, vsock, snapstart support        |
+| Boot                | Kernel + initramfs + /dev/vda drive | Initramfs has process_api; rootfs on /dev/vda        |
+
+### Open decisions
+
+| Decision         | Options                                | See                                    |
+| ---------------- | -------------------------------------- | -------------------------------------- |
+| Rootfs delivery  | OCI layer / CSI clone / init-container | Storage section                        |
+| Snapshot storage | CSI PVCs / local filesystem            | Storage section (snapshot/fork-resume) |
+
+## Security Model
+
+- `/dev/kvm` via device plugin (not full privileged mode)
+- `NET_ADMIN` capability for TAP/NAT (scoped, not `CAP_SYS_ADMIN`)
+- Firecracker provides hardware isolation (separate kernel per VM)
+- SSH keys managed via k8s Secret
+- Bearer token auth on manager API
+- All images are CI-built from this repo (not third-party)
+- VM pods schedule on any node with `/dev/kvm` (via device plugin)
+
+## Resource Budget
+
+wyrm2: 32 CPU, 94G RAM. Current usage: 19% CPU, 19% memory.
+
+| Component        | CPU request | Memory request | Count |
+| ---------------- | ----------- | -------------- | ----- |
+| Manager pod      | 100m        | 256Mi          | 1     |
+| VM pod (default) | 2           | 4Gi            | 1-3   |
+| Device plugin    | 50m         | 64Mi           | 1     |
+| **Total**        | ~6.2        | ~12.3Gi        | 3-5   |
+
+Fits comfortably within wyrm2's capacity and the claude-sandbox
+ResourceQuota (8 CPU, 16Gi, 20 pods).

--- a/devinfra/firecracker/README.md
+++ b/devinfra/firecracker/README.md
@@ -1,0 +1,50 @@
+# Firecracker Dev VMs
+
+Warm Firecracker microVMs on wyrm2 for Claude Code development. See
+<DESIGN.md> for architecture, prior art, and decisions.
+
+## Components
+
+| Component          | Path                                             | Purpose                            |
+| ------------------ | ------------------------------------------------ | ---------------------------------- |
+| Design doc         | `DESIGN.md`                                      | Architecture, goals, prior art     |
+| VM pod             | `vm_pod/`                                        | Entrypoint for Firecracker VM pods |
+| Manager service    | `manager/`                                       | FastAPI VMM, creates VM pods       |
+| NixOS rootfs       | `nix/nixos/hosts/fc_dev/`                        | NixOS config for guest rootfs      |
+| Rootfs provisioner | `provision-rootfs.sh`                            | Build rootfs via Nix, dd to LV     |
+| K8s manifests      | `cluster/k8s/agents/claude-sandbox-firecracker/` | Flux-managed deployment            |
+| KVM plugin         | `cluster/k8s/kvm-device-plugin/`                 | Device plugin for `/dev/kvm`       |
+
+## Quick Start
+
+```bash
+# Provision base rootfs on wyrm2 (requires Nix + LVM thin pool)
+./devinfra/firecracker/provision-rootfs.sh
+
+# Create a VM (from a Claude Code session)
+kubectl port-forward -n claude-sandbox svc/firecracker-manager 8080:8080 &
+TOKEN="..."
+curl -H "Authorization: Bearer $TOKEN" localhost:8080/vms -XPOST \
+  -d '{"cpus": 2, "mem_mib": 4096}'
+# Boot it
+curl -H "Authorization: Bearer $TOKEN" localhost:8080/vms/<id>/boot -XPOST
+```
+
+## VM Guest Contents
+
+The NixOS rootfs includes (via `bazel-dev.nix`):
+
+- Bazel 8 + Bazelisk
+- Python 3.13, GCC, Clang, Git
+- nix-ld (dynamically-linked Bazel toolchains)
+- envfs (`/bin/bash` for Bazel sandbox)
+- openssh-server
+- Dev headers (libssl, libcairo, libdbus)
+
+## Snapshot/Restore
+
+Firecracker supports snapshotting VM memory + CPU state to disk and
+restoring from it in ~28ms. A "warm" snapshot with a hot Bazel JVM +
+Skyframe cache would make queries take ~0.3s instead of ~15s cold.
+
+See `manager/snapshots.py` and `manager/clients.py` for the implementation.

--- a/devinfra/firecracker/TODO.md
+++ b/devinfra/firecracker/TODO.md
@@ -1,0 +1,73 @@
+# Firecracker Dev VMs — TODO
+
+## Architecture
+
+The pod is infrastructure-only: Firecracker process + networking + port
+proxies. The manager is the VMM brain — it creates PVCs + pods, then
+drives boot/restore through the Firecracker API proxy on each pod.
+
+Storage: LVM thin provisioning via OpenEBS LVM LocalPV on wyrm2. Rootfs
+PVCs are `volumeMode: Block` (Firecracker uses raw LV as drive). Work
+and snapshot PVCs are `volumeMode: Filesystem` (Firecracker snapshot API
+requires regular files — uses `ftruncate` + `metadata().len()`). All
+cloning is CoW via LVM thin snapshots. No PVC sharing between VMs.
+
+See <DESIGN.md> for full architecture, <vm_alternatives.md> for decision
+rationale.
+
+## Next Steps (in priority order)
+
+1. **Block-mode StorageClass for LVM**: OpenEBS LVM LocalPV is deployed
+   on wyrm2 (VG: `openebs-lvmvg`, SC: `lvm-proxmox`). Need a second SC
+   `lvm-proxmox-block` for `volumeMode: Block` PVCs (same VG, no fstype).
+   Also ensure the VG uses thin provisioning (`lvcreate --thinpool`).
+   _Owner: manual setup in devel, not on this branch._
+
+2. **Base rootfs LV**: Create the base thin LV, then run
+   `./devinfra/firecracker/provision-rootfs.sh` on wyrm2 to build
+   the NixOS rootfs via Nix and `dd` it into the LV.
+
+3. **Rootfs boot test on wyrm2**: Boot kernel + initramfs + rootfs with
+   raw Firecracker CLI on wyrm2 (has `/dev/kvm`). Verify process_api
+   starts, pivot_roots to NixOS, WebSocket listener accepts connections.
+   First real end-to-end validation.
+
+4. **Manager auth token Secret**: Create `firecracker-manager-auth-token`
+   via SOPS in `claude-sandbox`.
+
+5. **Firecracker binary in VM pod**: Verify `@firecracker_release`
+   http_archive extracts correctly and `firecracker_layer` pkg_tar
+   places the binary at `/usr/local/bin/firecracker`.
+
+6. **Reconciliation loop**: Manager watches pod status, drives boot when
+   a pod reaches Running, handles pod failures/restarts, cleans up
+   orphaned PVCs. Currently boot is a manual `POST /vms/{id}/boot`.
+   Also drives restore-boot for pods created via
+   `POST /snapshots/{name}/restore`.
+
+## Done
+
+- [x] Initramfs with process_api (3.2MB binary, cpio archive, OCI layer)
+- [x] Networking aligned with process_api (192.0.2.0/24)
+- [x] Dumb entrypoint (Firecracker + TAP/NAT + 3 TCP proxies)
+- [x] Smart manager (boot/restore via Firecracker API proxy)
+- [x] Typed client classes (FirecrackerClient, ProcessApiControl, K8sVMClient)
+- [x] process_api WS client (streaming async, typed protocol)
+- [x] Snapshot workflow (freeze → pause → snapshot → thaw → resume)
+- [x] Restore via CoW PVC cloning (rootfs + snapshot + work, no sharing)
+- [x] Per-VM PVCs: rootfs (Block), work (Filesystem), snapshot clone (Filesystem)
+- [x] OCI image push targets in CI (manager + vm_pod)
+- [x] Rootfs provisioning script (Nix build + dd on wyrm2)
+- [x] NixOS rootfs config (Bazel, Python, JDK, no /init symlink)
+- [x] K8s manifests (manager deployment, RBAC, KVM device plugin)
+- [x] Storage design: LVM thin (block device findings, volumeMode selection)
+
+## Future
+
+- [ ] Warm snapshot script: boot VM, clone repo,
+      `bazel query 'tests(//...)'`, snapshot. Automate as manager endpoint.
+- [ ] Restore fixups: re-seed entropy, update clock, refresh tokens.
+- [ ] Auto-cleanup: reconciler GCs Failed/Completed pods + orphaned PVCs.
+- [ ] Multiple VM support: allocate from subnet pool instead of fixed
+      192.0.2.0/24.
+- [ ] CRD controller: `FirecrackerVM` CRD if this grows beyond prototype.

--- a/devinfra/firecracker/initramfs/BUILD.bazel
+++ b/devinfra/firecracker/initramfs/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+# Build a cpio initramfs containing the RE process_api as /init.
+# Firecracker boots the kernel with this initramfs; process_api (PID 1)
+# mounts /dev/vda (NixOS rootfs), pivot_roots, and starts the WebSocket +
+# HTTP control server.
+genrule(
+    name = "initramfs",
+    srcs = ["//devinfra/claude/web_env/re/process_api/91c789ff:process_api_re"],
+    outs = ["initramfs.cpio"],
+    cmd = """
+        WORK=$$(mktemp -d)
+        cp $(location //devinfra/claude/web_env/re/process_api/91c789ff:process_api_re) $$WORK/init
+        chmod 755 $$WORK/init
+        (cd $$WORK && find . | cpio -o -H newc --quiet) > $@
+        rm -rf $$WORK
+    """,
+    visibility = ["//devinfra/firecracker:__subpackages__"],
+)
+
+# Tar layer for the VM pod OCI image — places the initramfs at a known path.
+pkg_tar(
+    name = "initramfs_layer",
+    srcs = [":initramfs"],
+    package_dir = "/opt/firecracker",
+    visibility = ["//devinfra/firecracker:__subpackages__"],
+)

--- a/devinfra/firecracker/manager/BUILD.bazel
+++ b/devinfra/firecracker/manager/BUILD.bazel
@@ -1,0 +1,125 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "models",
+    srcs = ["models.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = ["@pypi//pydantic"],
+)
+
+py_library(
+    name = "config",
+    srcs = ["config.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_library(
+    name = "clients",
+    srcs = ["clients.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//httpx",
+        "@pypi//tenacity",
+    ],
+)
+
+py_library(
+    name = "k8s_client",
+    srcs = ["k8s_client.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":models",
+        "@pypi//kubernetes",
+    ],
+)
+
+py_library(
+    name = "protocol",
+    srcs = ["protocol.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = ["@pypi//pydantic"],
+)
+
+py_library(
+    name = "process_api_client",
+    srcs = ["process_api_client.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protocol",
+        "@pypi//websockets",
+    ],
+)
+
+py_library(
+    name = "snapshots",
+    srcs = ["snapshots.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [":clients"],
+)
+
+py_library(
+    name = "service_lib",
+    srcs = ["service.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":clients",
+        ":config",
+        ":k8s_client",
+        ":models",
+        ":snapshots",
+        "@pypi//fastapi",
+        "@pypi//uvicorn",
+    ],
+)
+
+py_binary(
+    name = "service",
+    imports = ["../../.."],
+    main_module = "devinfra.firecracker.manager.service",
+    deps = [":service_lib"],
+)
+
+# ── OCI Image ────────────────────────────────────────────────────────────────
+
+aspect_py_binary(
+    name = "service_bin",
+    imports = ["../../.."],
+    main = "service.py",
+    deps = [":service_lib"],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":service_bin",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("service_bin"),
+    env = py_image_env(binary_name = "service_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [":layers"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/firecracker-manager",
+)

--- a/devinfra/firecracker/manager/clients.py
+++ b/devinfra/firecracker/manager/clients.py
@@ -1,0 +1,164 @@
+"""HTTP clients for Firecracker API and process_api control server.
+
+Each client wraps an httpx.Client targeting a specific pod IP + port.
+The manager creates these after a pod reaches Running state.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
+
+logger = logging.getLogger(__name__)
+
+FIRECRACKER_API_PORT = 2026
+PROCESS_API_CONTROL_PORT = 2025
+PROCESS_API_WS_PORT = 2024
+
+_TIMEOUT = 10.0
+_HEALTH_TIMEOUT = 2.0
+
+
+class _NotReadyError(Exception):
+    pass
+
+
+class FirecrackerClient:
+    """HTTP client for the Firecracker management API (proxied on :2026)."""
+
+    def __init__(self, pod_ip: str, port: int = FIRECRACKER_API_PORT) -> None:
+        self._base = f"http://{pod_ip}:{port}"
+        self._client = httpx.Client(timeout=_TIMEOUT)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def put(self, path: str, body: dict) -> None:
+        self._client.put(f"{self._base}{path}", json=body).raise_for_status()
+
+    def patch(self, path: str, body: dict) -> None:
+        self._client.patch(f"{self._base}{path}", json=body).raise_for_status()
+
+    def boot(
+        self,
+        *,
+        kernel_path: str,
+        rootfs_path: str,
+        initramfs_path: str | None = None,
+        vcpus: int = 2,
+        mem_mib: int = 4096,
+        boot_args: str = "console=ttyS0 reboot=k panic=1 pci=off",
+        guest_mac: str = "AA:FC:00:00:00:01",
+        tap_name: str = "tap0",
+    ) -> None:
+        """Configure and start a fresh VM."""
+        boot_source: dict[str, str] = {"kernel_image_path": kernel_path, "boot_args": boot_args}
+        if initramfs_path:
+            boot_source["initrd_path"] = initramfs_path
+        self.put("/boot-source", boot_source)
+
+        self.put(
+            "/drives/rootfs",
+            {
+                "drive_id": "rootfs",
+                "path_on_host": rootfs_path,
+                "is_root_device": initramfs_path is None,
+                "is_read_only": False,
+            },
+        )
+        self.put("/machine-config", {"vcpu_count": vcpus, "mem_size_mib": mem_mib})
+        self.put("/network-interfaces/eth0", {"iface_id": "eth0", "host_dev_name": tap_name, "guest_mac": guest_mac})
+        self.put("/actions", {"action_type": "InstanceStart"})
+        logger.info("Firecracker VM started via API on %s", self._base)
+
+    def pause(self) -> None:
+        self.put("/vm", {"state": "Paused"})
+
+    def resume(self) -> None:
+        self.put("/vm", {"state": "Resumed"})
+
+    def create_snapshot(self, *, snapshot_path: str, mem_file_path: str) -> None:
+        self.put(
+            "/snapshot/create",
+            {"snapshot_type": "Full", "snapshot_path": snapshot_path, "mem_file_path": mem_file_path},
+        )
+
+    def load_snapshot(self, *, snapshot_path: str, mem_file_path: str, resume: bool = True) -> None:
+        self.put(
+            "/snapshot/load",
+            {
+                "snapshot_path": snapshot_path,
+                "mem_backend": {"backend_type": "File", "backend_path": mem_file_path},
+                "enable_diff_snapshots": False,
+                "resume_vm": resume,
+            },
+        )
+
+    def wait_ready(self, timeout_secs: int = 30) -> None:
+        """Wait for the Firecracker API proxy to accept connections."""
+
+        @retry(
+            retry=retry_if_exception_type(_NotReadyError),
+            stop=stop_after_delay(timeout_secs),
+            wait=wait_fixed(1),
+            reraise=True,
+        )
+        def _poll() -> None:
+            try:
+                resp = self._client.get(f"{self._base}/", timeout=_HEALTH_TIMEOUT)
+                if resp.status_code >= 500:
+                    raise _NotReadyError(f"Firecracker API returned {resp.status_code}")
+            except httpx.HTTPError as e:
+                raise _NotReadyError(str(e)) from e
+
+        try:
+            _poll()
+        except _NotReadyError:
+            raise TimeoutError(f"Firecracker API proxy not ready at {self._base} after {timeout_secs}s") from None
+
+
+class ProcessApiControl:
+    """HTTP client for process_api's control server (proxied on :2025)."""
+
+    def __init__(self, pod_ip: str, port: int = PROCESS_API_CONTROL_PORT) -> None:
+        self._base = f"http://{pod_ip}:{port}"
+        self._client = httpx.Client(timeout=_TIMEOUT)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def health(self) -> bool:
+        try:
+            resp = self._client.get(f"{self._base}/health", timeout=_HEALTH_TIMEOUT)
+            return resp.status_code == 200
+        except httpx.HTTPError:
+            return False
+
+    def freeze_filesystem(self) -> None:
+        self._client.post(f"{self._base}/fs_freeze").raise_for_status()
+
+    def thaw_filesystem(self) -> None:
+        self._client.post(f"{self._base}/fs_thaw").raise_for_status()
+
+    def shutdown(self) -> None:
+        self._client.post(f"{self._base}/shutdown")
+
+    def wait_ready(self, timeout_secs: int = 60) -> None:
+        """Wait for /health to respond."""
+
+        @retry(
+            retry=retry_if_exception_type(_NotReadyError),
+            stop=stop_after_delay(timeout_secs),
+            wait=wait_fixed(1),
+            reraise=True,
+        )
+        def _poll() -> None:
+            if not self.health():
+                raise _NotReadyError("not healthy")
+
+        try:
+            _poll()
+        except _NotReadyError:
+            raise TimeoutError(f"process_api not ready at {self._base} after {timeout_secs}s") from None

--- a/devinfra/firecracker/manager/config.py
+++ b/devinfra/firecracker/manager/config.py
@@ -1,0 +1,25 @@
+"""Manager configuration loaded from a YAML file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class ManagerConfig(BaseModel):
+    """Configuration for the Firecracker VM manager service."""
+
+    vm_image: str = Field(description="OCI image for VM pods")
+    base_rootfs_pvc: str = Field(description="Base PVC to clone for each VM's rootfs")
+    node_selector: dict[str, str] | None = Field(
+        default=None, description="Node selector for VM pods. None = schedule anywhere."
+    )
+    port: int = Field(default=8080, description="HTTP port for the manager API")
+
+
+def load_config(path: Path) -> ManagerConfig:
+    """Load manager config from a YAML file."""
+    data = yaml.safe_load(path.read_text())
+    return ManagerConfig.model_validate(data)

--- a/devinfra/firecracker/manager/k8s_client.py
+++ b/devinfra/firecracker/manager/k8s_client.py
@@ -1,0 +1,324 @@
+"""Kubernetes client for managing Firecracker VM pods.
+
+Each VM gets two PVCs from the LVM thin pool:
+  1. Rootfs (volumeMode: Block) — thin snapshot of base, Firecracker drive
+  2. Work (volumeMode: Filesystem) — thin-provisioned, holds snapshot files
+
+The manager drives VM configuration (boot, snapshot/restore) through
+the Firecracker API proxy on port 2026 after the pod is running.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Any
+
+from kubernetes import client, config
+
+from devinfra.firecracker.manager.models import VMInfo, VMStatus
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACE = "claude-sandbox"
+_VM_LABEL = "app.kubernetes.io/managed-by"
+_VM_LABEL_VALUE = "firecracker-manager"
+_VM_ID_LABEL = "firecracker-vm-id"
+_SNAPSHOT_LABEL = "firecracker-snapshot"
+
+# Pod-internal paths. The manager references these when calling the
+# Firecracker API to configure drives and snapshot paths.
+ROOTFS_DEVICE_PATH = "/dev/rootfs"
+WORK_MOUNT = "/work"
+SNAPSHOT_MOUNT = "/snapshots"
+KERNEL_PATH = "/opt/firecracker/vmlinux"
+INITRAMFS_PATH = "/opt/firecracker/initramfs.cpio"
+
+# StorageClass names — both from LVM thin pool on wyrm2 (VG: openebs-lvmvg).
+# lvm-proxmox exists in devel (Filesystem). lvm-proxmox-block needs to be
+# created (same VG, no fstype, volumeMode: Block support).
+_BLOCK_SC = "lvm-proxmox-block"
+_FS_SC = "lvm-proxmox"
+
+
+class K8sVMClient:
+    """Manages Firecracker VM pods and PVCs via the Kubernetes API."""
+
+    def __init__(self) -> None:
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()
+        self._core = client.CoreV1Api()
+
+    # ── VM lifecycle ─────────────────────────────────────────────────────
+
+    def create_vm(
+        self, *, vm_image: str, base_rootfs_pvc: str, cpus: int, mem_mib: int, node_selector: dict[str, str] | None
+    ) -> VMInfo:
+        """Create a VM's PVCs + pod and return its info."""
+        vm_id = secrets.token_hex(4)
+        rootfs_pvc = self._create_pvc(
+            _rootfs_pvc_name(vm_id),
+            volume_mode="Block",
+            storage_class=_BLOCK_SC,
+            size="10Gi",
+            labels={_VM_ID_LABEL: vm_id},
+            data_source=base_rootfs_pvc,
+        )
+        work_pvc = self._create_pvc(
+            _work_pvc_name(vm_id),
+            volume_mode="Filesystem",
+            storage_class=_FS_SC,
+            size="10Gi",
+            labels={_VM_ID_LABEL: vm_id},
+        )
+        spec = self._pod_spec(
+            vm_id,
+            vm_image=vm_image,
+            rootfs_pvc=rootfs_pvc,
+            work_pvc=work_pvc,
+            cpus=cpus,
+            mem_mib=mem_mib,
+            node_selector=node_selector,
+        )
+
+        logger.info("Creating VM pod %s (cpus=%d, mem=%dMiB)", _pod_name(vm_id), cpus, mem_mib)
+        self._core.create_namespaced_pod(namespace=_NAMESPACE, body=spec)
+        return VMInfo(id=vm_id, pod_name=_pod_name(vm_id), status=VMStatus.CREATING)
+
+    def delete_vm(self, vm_id: str) -> None:
+        """Delete a VM pod and all its PVCs (rootfs, work, snapshot clone)."""
+        logger.info("Deleting VM %s", vm_id)
+        self._delete_if_exists("pod", _pod_name(vm_id))
+        self._delete_if_exists("pvc", _rootfs_pvc_name(vm_id))
+        self._delete_if_exists("pvc", _work_pvc_name(vm_id))
+        self._delete_if_exists("pvc", f"firecracker-snap-{vm_id}")
+
+    def list_vms(self) -> list[VMInfo]:
+        pods = self._core.list_namespaced_pod(namespace=_NAMESPACE, label_selector=f"{_VM_LABEL}={_VM_LABEL_VALUE}")
+        return [_vm_info_from_pod(pod) for pod in pods.items]
+
+    def get_vm(self, vm_id: str) -> VMInfo | None:
+        try:
+            pod = self._core.read_namespaced_pod(name=_pod_name(vm_id), namespace=_NAMESPACE)
+        except client.ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+        return _vm_info_from_pod(pod)
+
+    # ── Snapshot lifecycle ───────────────────────────────────────────────
+
+    def create_snapshot_pvc(self, snapshot_name: str, size: str = "8Gi") -> str:
+        """Create a filesystem PVC for snapshot memory + vmstate files."""
+        return self._create_pvc(
+            _snapshot_pvc_name(snapshot_name),
+            volume_mode="Filesystem",
+            storage_class=_FS_SC,
+            size=size,
+            labels={_SNAPSHOT_LABEL: snapshot_name},
+        )
+
+    def label_snapshot(self, vm_id: str, snapshot_name: str) -> None:
+        """Record the source VM's rootfs PVC on the work PVC for restore."""
+        self._core.patch_namespaced_persistent_volume_claim(
+            name=_work_pvc_name(vm_id),
+            namespace=_NAMESPACE,
+            body={
+                "metadata": {
+                    "labels": {_SNAPSHOT_LABEL: snapshot_name, "firecracker-source-rootfs": _rootfs_pvc_name(vm_id)}
+                }
+            },
+        )
+
+    def get_snapshot_rootfs_pvc(self, snapshot_name: str) -> str:
+        """Look up which rootfs PVC a snapshot was taken from."""
+        pvcs = self._core.list_namespaced_persistent_volume_claim(
+            namespace=_NAMESPACE, label_selector=f"{_SNAPSHOT_LABEL}={snapshot_name}"
+        )
+        for pvc in pvcs.items:
+            source = pvc.metadata.labels.get("firecracker-source-rootfs")
+            if source:
+                return source
+        raise RuntimeError(f"No rootfs PVC found for snapshot {snapshot_name}")
+
+    def delete_snapshot(self, snapshot_name: str) -> None:
+        self._delete_if_exists("pvc", _snapshot_pvc_name(snapshot_name))
+
+    def create_restored_vm(
+        self,
+        *,
+        vm_image: str,
+        source_rootfs_pvc: str,
+        snapshot_name: str,
+        cpus: int,
+        mem_mib: int,
+        node_selector: dict[str, str] | None,
+    ) -> VMInfo:
+        """Create a VM pod for snapshot restore.
+
+        All PVCs are CoW clones — the source VM's PVCs are never shared:
+        - Rootfs: thin clone of source VM's rootfs LV
+        - Snapshot: thin clone of the snapshot PVC (has memory + vmstate)
+        - Work: fresh thin LV for the restored VM's own use
+        """
+        vm_id = secrets.token_hex(4)
+        rootfs_pvc = self._create_pvc(
+            _rootfs_pvc_name(vm_id),
+            volume_mode="Block",
+            storage_class=_BLOCK_SC,
+            size="10Gi",
+            labels={_VM_ID_LABEL: vm_id},
+            data_source=source_rootfs_pvc,
+        )
+        # CoW clone of the snapshot PVC — each restored VM gets its own copy.
+        snapshot_clone_pvc = self._create_pvc(
+            f"firecracker-snap-{vm_id}",
+            volume_mode="Filesystem",
+            storage_class=_FS_SC,
+            size="8Gi",
+            labels={_VM_ID_LABEL: vm_id, _SNAPSHOT_LABEL: snapshot_name},
+            data_source=_snapshot_pvc_name(snapshot_name),
+        )
+        work_pvc = self._create_pvc(
+            _work_pvc_name(vm_id),
+            volume_mode="Filesystem",
+            storage_class=_FS_SC,
+            size="10Gi",
+            labels={_VM_ID_LABEL: vm_id},
+        )
+        spec = self._pod_spec(
+            vm_id,
+            vm_image=vm_image,
+            rootfs_pvc=rootfs_pvc,
+            work_pvc=work_pvc,
+            snapshot_pvc=snapshot_clone_pvc,
+            cpus=cpus,
+            mem_mib=mem_mib,
+            node_selector=node_selector,
+        )
+
+        logger.info("Creating restored VM pod %s from snapshot %s", _pod_name(vm_id), snapshot_name)
+        self._core.create_namespaced_pod(namespace=_NAMESPACE, body=spec)
+        return VMInfo(id=vm_id, pod_name=_pod_name(vm_id), status=VMStatus.CREATING)
+
+    # ── Internal ─────────────────────────────────────────────────────────
+
+    def _create_pvc(
+        self,
+        name: str,
+        *,
+        volume_mode: str,
+        storage_class: str,
+        size: str,
+        labels: dict[str, str],
+        data_source: str | None = None,
+    ) -> str:
+        spec: dict[str, Any] = {
+            "volumeMode": volume_mode,
+            "storageClassName": storage_class,
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": size}},
+        }
+        if data_source:
+            spec["dataSource"] = {"kind": "PersistentVolumeClaim", "name": data_source}
+
+        pvc = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {"name": name, "namespace": _NAMESPACE, "labels": {_VM_LABEL: _VM_LABEL_VALUE, **labels}},
+            "spec": spec,
+        }
+        logger.info("Creating PVC %s (mode=%s, class=%s)", name, volume_mode, storage_class)
+        self._core.create_namespaced_persistent_volume_claim(namespace=_NAMESPACE, body=pvc)
+        return name
+
+    def _delete_if_exists(self, kind: str, name: str) -> None:
+        try:
+            if kind == "pod":
+                self._core.delete_namespaced_pod(name=name, namespace=_NAMESPACE)
+            elif kind == "pvc":
+                self._core.delete_namespaced_persistent_volume_claim(name=name, namespace=_NAMESPACE)
+        except client.ApiException as e:
+            if e.status != 404:
+                raise
+            logger.debug("%s %s already deleted", kind, name)
+
+    def _pod_spec(
+        self,
+        vm_id: str,
+        *,
+        vm_image: str,
+        rootfs_pvc: str,
+        work_pvc: str,
+        cpus: int,
+        mem_mib: int,
+        node_selector: dict[str, str] | None,
+        snapshot_pvc: str | None = None,
+    ) -> dict[str, Any]:
+        volume_devices = [{"name": "rootfs", "devicePath": ROOTFS_DEVICE_PATH}]
+        volume_mounts = [{"name": "work", "mountPath": WORK_MOUNT}]
+        volumes: list[dict[str, Any]] = [
+            {"name": "rootfs", "persistentVolumeClaim": {"claimName": rootfs_pvc}},
+            {"name": "work", "persistentVolumeClaim": {"claimName": work_pvc}},
+        ]
+
+        if snapshot_pvc:
+            volume_mounts.append({"name": "snapshot", "mountPath": SNAPSHOT_MOUNT, "readOnly": True})
+            volumes.append({"name": "snapshot", "persistentVolumeClaim": {"claimName": snapshot_pvc, "readOnly": True}})
+
+        spec: dict[str, Any] = {
+            "containers": [
+                {
+                    "name": "vm",
+                    "image": vm_image,
+                    "securityContext": {"capabilities": {"add": ["NET_ADMIN"]}},
+                    "resources": {
+                        "requests": {"cpu": str(cpus), "memory": f"{mem_mib}Mi", "squat.ai/kvm": "1"},
+                        "limits": {"cpu": str(cpus), "memory": f"{mem_mib}Mi", "squat.ai/kvm": "1"},
+                    },
+                    "ports": [{"containerPort": 2026, "name": "firecracker-api"}],
+                    "volumeDevices": volume_devices,
+                    "volumeMounts": volume_mounts,
+                }
+            ],
+            "volumes": volumes,
+            "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 10,
+        }
+        if node_selector:
+            spec["nodeSelector"] = node_selector
+
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": _pod_name(vm_id),
+                "namespace": _NAMESPACE,
+                "labels": {_VM_LABEL: _VM_LABEL_VALUE, _VM_ID_LABEL: vm_id, "app": "firecracker-vm"},
+            },
+            "spec": spec,
+        }
+
+
+def _pod_name(vm_id: str) -> str:
+    return f"firecracker-vm-{vm_id}"
+
+
+def _rootfs_pvc_name(vm_id: str) -> str:
+    return f"firecracker-rootfs-{vm_id}"
+
+
+def _work_pvc_name(vm_id: str) -> str:
+    return f"firecracker-work-{vm_id}"
+
+
+def _snapshot_pvc_name(snapshot_name: str) -> str:
+    return f"firecracker-snapshot-{snapshot_name}"
+
+
+def _vm_info_from_pod(pod: client.V1Pod) -> VMInfo:
+    vm_id = pod.metadata.labels.get(_VM_ID_LABEL, "unknown")
+    phase = VMStatus(pod.status.phase) if pod.status else VMStatus.UNKNOWN
+    return VMInfo(id=vm_id, pod_name=pod.metadata.name, status=phase, pod_ip=pod.status.pod_ip if pod.status else None)

--- a/devinfra/firecracker/manager/models.py
+++ b/devinfra/firecracker/manager/models.py
@@ -1,0 +1,48 @@
+"""Pydantic models for the Firecracker VM manager API."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class VMStatus(StrEnum):
+    """VM lifecycle status. Includes k8s pod phases + our custom states."""
+
+    CREATING = "creating"
+    PENDING = "Pending"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    UNKNOWN = "Unknown"
+
+
+class CreateVMRequest(BaseModel):
+    cpus: int = Field(default=2, description="Number of vCPUs")
+    mem_mib: int = Field(default=4096, description="Memory in MiB")
+
+
+class VMInfo(BaseModel):
+    id: str
+    pod_name: str
+    status: VMStatus
+    pod_ip: str | None = Field(default=None, description="Pod IP — all ports proxied from here")
+
+
+class CreateVMResponse(BaseModel):
+    vm: VMInfo
+
+
+class ListVMsResponse(BaseModel):
+    vms: list[VMInfo]
+
+
+class SnapshotRequest(BaseModel):
+    name: str = Field(description="Name for the snapshot")
+
+
+class RestoreRequest(BaseModel):
+    name: str | None = Field(default=None, description="Name for the restored VM. None = auto-generated.")
+    cpus: int = Field(default=2, description="Number of vCPUs")
+    mem_mib: int = Field(default=4096, description="Memory in MiB")

--- a/devinfra/firecracker/manager/process_api_client.py
+++ b/devinfra/firecracker/manager/process_api_client.py
@@ -1,0 +1,159 @@
+"""Minimal WebSocket client for Anthropic's process_api.
+
+process_api is the PID 1 binary in Claude Code's Firecracker VMs. It
+exposes a WebSocket server on port 2024 for spawning and attaching to
+processes inside the guest.
+
+Protocol summary (from RE of process_api binary):
+  1. Client sends JWT token as first text frame (eyJ... prefix)
+  2. Client sends CreateProcess JSON
+  3. Server responds with ProcessCreated/ProcessCreatedV2
+  4. I/O forwarded as text frames (ExpectStdOut/ExpectStdErr) + binary data
+  5. ProcessExited text frame when process terminates
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+import websockets.asyncio.client
+
+from devinfra.firecracker.manager.protocol import (
+    NOOP_TAGS,
+    CreateProcess,
+    Exited,
+    InfraError,
+    OOMKilled,
+    ProcessEvent,
+    ProcessExited,
+    ProcessTimedOut,
+    ServerMessageKey,
+    ServerTag,
+    Stderr,
+    Stdout,
+    TimedOut,
+)
+
+logger = logging.getLogger(__name__)
+
+_DUMMY_JWT = "eyJ" + base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=") + ".e30.stub"
+
+
+async def run_process(
+    host: str,
+    command: str,
+    args: list[str] | None = None,
+    *,
+    port: int = 2024,
+    env_vars: dict[str, str] | None = None,
+    uid: int = 0,
+    gid: int = 0,
+    timeout_secs: int = 300,
+    jwt: str = _DUMMY_JWT,
+) -> AsyncIterator[ProcessEvent]:
+    """Run a command via process_api, yielding output events.
+
+    Yields Stdout/Stderr chunks as they arrive, then a terminal event
+    (Exited, TimedOut, OOMKilled, or InfraError).
+    """
+    uri = f"ws://{host}:{port}"
+    async with websockets.asyncio.client.connect(uri, max_size=2**20) as ws:
+        await ws.send(jwt)
+
+        msg = CreateProcess(name=command, args=args or [], uid=uid, gid=gid, timeout=timeout_secs, env_vars=env_vars)
+        await ws.send(msg.model_dump_json(exclude_none=True))
+
+        expecting_stdout = False
+        expecting_stderr = False
+
+        async for message in ws:
+            if isinstance(message, bytes):
+                if expecting_stdout:
+                    yield Stdout(data=message)
+                    expecting_stdout = False
+                elif expecting_stderr:
+                    yield Stderr(data=message)
+                    expecting_stderr = False
+                continue
+
+            parsed = json.loads(message)
+
+            if isinstance(parsed, str):
+                if parsed == ServerTag.EXPECT_STDOUT:
+                    expecting_stdout = True
+                elif parsed == ServerTag.EXPECT_STDERR:
+                    expecting_stderr = True
+                elif parsed not in NOOP_TAGS:
+                    logger.debug("Unknown tag: %s", parsed)
+                continue
+
+            if not isinstance(parsed, dict):
+                continue
+
+            if event := _parse_server_message(parsed):
+                yield event
+                if isinstance(event, Exited | TimedOut | OOMKilled | InfraError):
+                    return
+
+
+async def spawn_systemd(host: str, *, port: int = 2024, jwt: str = _DUMMY_JWT) -> None:
+    """Start NixOS systemd inside the guest via process_api.
+
+    Sends CreateProcess for /nix/var/nix/profiles/system/init, sets it
+    as reattachable (so it survives WebSocket disconnect), and returns
+    immediately without waiting for exit.
+    """
+    uri = f"ws://{host}:{port}"
+    async with websockets.asyncio.client.connect(uri, max_size=2**20) as ws:
+        await ws.send(jwt)
+
+        msg = CreateProcess(name="/nix/var/nix/profiles/system/init", reattachable=True, allow_process_id_reuse=False)
+        await ws.send(msg.model_dump_json(exclude_none=True))
+
+        async for message in ws:
+            if isinstance(message, bytes):
+                continue
+            parsed = json.loads(message)
+            if isinstance(parsed, dict) and (
+                ServerMessageKey.PROCESS_CREATED in parsed or ServerMessageKey.PROCESS_CREATED_V2 in parsed
+            ):
+                logger.info("systemd started via process_api on %s", host)
+                return
+            if isinstance(parsed, dict) and ServerMessageKey.INFRA_ERROR in parsed:
+                raise RuntimeError(f"Failed to start systemd: {parsed[ServerMessageKey.INFRA_ERROR]}")
+
+        raise RuntimeError("WebSocket closed before ProcessCreated received")
+
+
+def _parse_server_message(msg: dict[str, Any]) -> ProcessEvent | None:
+    """Parse a server→client JSON dict message into a ProcessEvent.
+
+    Returns None for known non-event messages (ProcessCreated, ConnectionCapabilities).
+    Raises for unknown message types.
+    """
+    key = next(iter(msg))
+    match key:
+        case ServerMessageKey.PROCESS_CREATED | ServerMessageKey.PROCESS_CREATED_V2:
+            return None
+        case ServerMessageKey.PROCESS_EXITED:
+            exited = ProcessExited.model_validate(msg[key])
+            return Exited(status=exited.status, details=exited.details)
+        case ServerMessageKey.PROCESS_TIMED_OUT:
+            timed_out = ProcessTimedOut.model_validate(msg[key])
+            return TimedOut(timeout_secs=timed_out.timeout_secs, details=timed_out.details)
+        case ServerMessageKey.PROCESS_OUT_OF_MEMORY | ServerMessageKey.CONTAINER_OUT_OF_MEMORY:
+            return OOMKilled()
+        case ServerMessageKey.INFRA_ERROR:
+            return InfraError(message=str(msg[key]))
+        case (
+            ServerMessageKey.CONNECTION_CAPABILITIES
+            | ServerMessageKey.ATTACHED_TO_PROCESS
+            | ServerMessageKey.ATTACHED_TO_PROCESS_V2
+        ):
+            return None
+        case _:
+            raise ValueError(f"Unknown server message key: {key!r} in {msg!r}")

--- a/devinfra/firecracker/manager/protocol.py
+++ b/devinfra/firecracker/manager/protocol.py
@@ -1,0 +1,123 @@
+"""process_api WebSocket protocol types (from RE of the binary).
+
+These model the messages exchanged over the WebSocket connection to
+process_api (Anthropic's PID 1 binary in Firecracker VMs). See
+devinfra/claude/web_env/re/process_api/ for the full reverse-engineered
+source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+# ── Client → Server ─────────────────────────────────────────────────────────
+
+
+class CreateProcess(BaseModel):
+    """Spawn a new process."""
+
+    name: str = Field(description="Command to execute; also used as process ID")
+    args: list[str] = Field(default_factory=list)
+    env_vars: dict[str, str] | None = None
+    clear_env: bool = False
+    uid: int = 0
+    gid: int = 0
+    reattachable: bool = False
+    allow_process_id_reuse: bool = True
+    timeout: int | None = Field(default=None, description="Kill after N seconds")
+    memory_limit_bytes: int | None = None
+
+
+class ProcessConnection(BaseModel):
+    """Reattach to an existing process."""
+
+    process_id: str
+    reattach: bool = True
+    expected_container_name: str | None = None
+    want_trace_events: bool = False
+
+
+# ── Server → Client (JSON dicts with a single key) ──────────────────────────
+
+
+class ServerMessageKey(StrEnum):
+    """Top-level keys in server→client JSON dict messages."""
+
+    PROCESS_CREATED = "ProcessCreated"
+    PROCESS_CREATED_V2 = "ProcessCreatedV2"
+    PROCESS_EXITED = "ProcessExited"
+    PROCESS_TIMED_OUT = "ProcessTimedOut"
+    PROCESS_OUT_OF_MEMORY = "ProcessOutOfMemory"
+    CONTAINER_OUT_OF_MEMORY = "ContainerOutOfMemory"
+    INFRA_ERROR = "InfraError"
+    CONNECTION_CAPABILITIES = "ConnectionCapabilities"
+    ATTACHED_TO_PROCESS = "AttachedToProcess"
+    ATTACHED_TO_PROCESS_V2 = "AttachedToProcessV2"
+
+
+class ProcessExited(BaseModel):
+    status: int
+    details: str
+
+
+class ProcessTimedOut(BaseModel):
+    timeout_secs: int
+    details: str
+
+
+# ── Server → Client (bare JSON strings) ─────────────────────────────────────
+
+
+class ServerTag(StrEnum):
+    """Server→client messages sent as bare JSON strings (not dicts)."""
+
+    EXPECT_STDOUT = "ExpectStdOut"
+    EXPECT_STDERR = "ExpectStdErr"
+    STDOUT_EOF = "StdOutEOF"
+    STDERR_EOF = "StdErrEOF"
+    KEEPALIVE = "KeepAlive"
+    CLOSED = "Closed"
+
+
+NOOP_TAGS = frozenset({ServerTag.STDOUT_EOF, ServerTag.STDERR_EOF, ServerTag.KEEPALIVE, ServerTag.CLOSED})
+
+
+# ── Stream events (used by the client to yield typed output) ─────────────────
+
+
+@dataclass
+class Stdout:
+    data: bytes
+
+
+@dataclass
+class Stderr:
+    data: bytes
+
+
+@dataclass
+class Exited:
+    status: int
+    details: str
+
+
+@dataclass
+class TimedOut:
+    timeout_secs: int
+    details: str
+
+
+@dataclass
+class OOMKilled:
+    pass
+
+
+@dataclass
+class InfraError:
+    message: str
+
+
+ProcessEvent = Stdout | Stderr | Exited | TimedOut | OOMKilled | InfraError

--- a/devinfra/firecracker/manager/service.py
+++ b/devinfra/firecracker/manager/service.py
@@ -1,0 +1,185 @@
+"""Firecracker VM manager — FastAPI service.
+
+Orchestrates Firecracker VM pods via the Kubernetes API. The manager is
+the VMM brain: it creates pods (infrastructure), then drives boot or
+restore through the Firecracker API proxy on each pod.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Annotated
+
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from devinfra.firecracker.manager.clients import FirecrackerClient, ProcessApiControl
+from devinfra.firecracker.manager.config import ManagerConfig, load_config
+from devinfra.firecracker.manager.k8s_client import INITRAMFS_PATH, KERNEL_PATH, ROOTFS_DEVICE_PATH, K8sVMClient
+from devinfra.firecracker.manager.models import (
+    CreateVMRequest,
+    CreateVMResponse,
+    ListVMsResponse,
+    RestoreRequest,
+    SnapshotRequest,
+    VMInfo,
+)
+from devinfra.firecracker.manager.snapshots import snapshot_vm
+
+logger = logging.getLogger(__name__)
+
+_auth_scheme = HTTPBearer()
+_AUTH_TOKEN = os.environ.get("FC_MANAGER_AUTH_TOKEN", "")
+
+
+async def _require_auth(request: Request) -> None:
+    if not _AUTH_TOKEN:
+        return
+    credentials: HTTPAuthorizationCredentials | None = await _auth_scheme(request)
+    if credentials is None or not secrets.compare_digest(credentials.credentials, _AUTH_TOKEN):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+app = FastAPI(title="Firecracker VM Manager", dependencies=[Depends(_require_auth)])
+
+
+# ── Dependencies ─────────────────────────────────────────────────────────────
+
+
+def _config(request: Request) -> ManagerConfig:
+    return request.app.state.config
+
+
+def _k8s(request: Request) -> K8sVMClient:
+    return request.app.state.k8s
+
+
+def _require_vm_with_ip(vm_id: str, k8s: K8s) -> VMInfo:
+    vm = k8s.get_vm(vm_id)
+    if vm is None:
+        raise HTTPException(status_code=404, detail=f"VM {vm_id} not found")
+    if vm.pod_ip is None:
+        raise HTTPException(status_code=409, detail=f"VM {vm_id} has no pod IP yet")
+    return vm
+
+
+def _firecracker_client(vm: RunningVM) -> Iterator[FirecrackerClient]:
+    client = FirecrackerClient(vm.pod_ip)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _control_client(vm: RunningVM) -> Iterator[ProcessApiControl]:
+    client = ProcessApiControl(vm.pod_ip)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+Config = Annotated[ManagerConfig, Depends(_config)]
+K8s = Annotated[K8sVMClient, Depends(_k8s)]
+RunningVM = Annotated[VMInfo, Depends(_require_vm_with_ip)]
+Firecracker = Annotated[FirecrackerClient, Depends(_firecracker_client)]
+Control = Annotated[ProcessApiControl, Depends(_control_client)]
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/vms")
+async def create_vm(req: CreateVMRequest, config: Config, k8s: K8s) -> CreateVMResponse:
+    """Create a new Firecracker VM: PVCs + pod."""
+    vm = k8s.create_vm(
+        vm_image=config.vm_image,
+        base_rootfs_pvc=config.base_rootfs_pvc,
+        cpus=req.cpus,
+        mem_mib=req.mem_mib,
+        node_selector=config.node_selector,
+    )
+    return CreateVMResponse(vm=vm)
+
+
+@app.post("/vms/{vm_id}/boot")
+async def boot(vm_id: str, firecracker: Firecracker, control: Control) -> dict[str, str]:
+    """Boot a VM that has a running pod but hasn't been started yet."""
+    firecracker.wait_ready()
+    firecracker.boot(kernel_path=KERNEL_PATH, rootfs_path=ROOTFS_DEVICE_PATH, initramfs_path=INITRAMFS_PATH)
+    control.wait_ready()
+    return {"status": "booted", "vm_id": vm_id}
+
+
+@app.get("/vms")
+async def list_vms(k8s: K8s) -> ListVMsResponse:
+    return ListVMsResponse(vms=k8s.list_vms())
+
+
+@app.get("/vms/{vm_id}")
+async def get_vm(vm_id: str, k8s: K8s) -> VMInfo:
+    vm = k8s.get_vm(vm_id)
+    if vm is None:
+        raise HTTPException(status_code=404, detail=f"VM {vm_id} not found")
+    return vm
+
+
+@app.delete("/vms/{vm_id}")
+async def destroy_vm(vm_id: str, k8s: K8s) -> dict[str, str]:
+    k8s.delete_vm(vm_id)
+    return {"status": "deleted", "vm_id": vm_id}
+
+
+@app.post("/vms/{vm_id}/snapshot")
+async def snapshot(
+    vm_id: str, req: SnapshotRequest, firecracker: Firecracker, control: Control, k8s: K8s
+) -> dict[str, str]:
+    snapshot_vm(firecracker, control, snapshot_name=req.name)
+    # Record source VM's rootfs PVC for restore cloning.
+    k8s.label_snapshot(vm_id, req.name)
+    return {"status": "snapshot_created", "name": req.name, "vm_id": vm_id}
+
+
+@app.post("/snapshots/{snapshot_name}/restore")
+async def restore(snapshot_name: str, req: RestoreRequest, config: Config, k8s: K8s) -> CreateVMResponse:
+    """Create a new VM restored from a snapshot."""
+    source_rootfs_pvc = k8s.get_snapshot_rootfs_pvc(snapshot_name)
+    vm = k8s.create_restored_vm(
+        vm_image=config.vm_image,
+        source_rootfs_pvc=source_rootfs_pvc,
+        snapshot_name=snapshot_name,
+        cpus=req.cpus,
+        mem_mib=req.mem_mib,
+        node_selector=config.node_selector,
+    )
+    # TODO: wait for pod to be Running, then call restore_vm().
+    return CreateVMResponse(vm=vm)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/etc/firecracker-manager/config.yaml")
+    logger.info("Loading config from %s", config_path)
+
+    config = load_config(config_path)
+    app.state.config = config
+    app.state.k8s = K8sVMClient()
+
+    logger.info("Starting Firecracker VM manager on port %d", config.port)
+    uvicorn.run(app, host="0.0.0.0", port=config.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/devinfra/firecracker/manager/snapshots.py
+++ b/devinfra/firecracker/manager/snapshots.py
@@ -1,0 +1,60 @@
+"""Snapshot and restore operations for Firecracker VMs.
+
+All operations go through the pod IP — the entrypoint proxies guest ports
+(2024, 2025) and the Firecracker API socket (2026) onto the pod network.
+
+Snapshot:
+  1. Manager creates a snapshot PVC (filesystem, thin-provisioned)
+  2. control.freeze_filesystem() — flush writes, freeze guest fs
+  3. firecracker.pause()
+  4. firecracker.create_snapshot() — writes memory + vmstate to /work/snapshots/
+  5. control.thaw_filesystem() + firecracker.resume()
+  Note: snapshot files live on the VM's work PVC. The separate snapshot
+  PVC is for restore — a Job copies files from work PVC to snapshot PVC
+  so the source VM's work PVC isn't tied up.
+
+Restore:
+  1. Manager creates a new pod with snapshot PVC mounted at /snapshots
+  2. firecracker.load_snapshot() — loads from /snapshots/<name>/
+  3. control.thaw_filesystem()
+"""
+
+from __future__ import annotations
+
+import logging
+
+from devinfra.firecracker.manager.clients import FirecrackerClient, ProcessApiControl
+from devinfra.firecracker.manager.k8s_client import SNAPSHOT_MOUNT, WORK_MOUNT
+
+logger = logging.getLogger(__name__)
+
+
+def snapshot_vm(firecracker: FirecrackerClient, control: ProcessApiControl, *, snapshot_name: str) -> None:
+    """Snapshot a running VM. Files are written to the work PVC."""
+    snapshot_dir = f"{WORK_MOUNT}/snapshots/{snapshot_name}"
+
+    logger.info("Freezing guest filesystem")
+    control.freeze_filesystem()
+
+    try:
+        logger.info("Pausing VM")
+        firecracker.pause()
+
+        logger.info("Creating snapshot %s", snapshot_name)
+        firecracker.create_snapshot(snapshot_path=f"{snapshot_dir}/vmstate", mem_file_path=f"{snapshot_dir}/memory")
+    finally:
+        logger.info("Thawing guest filesystem")
+        control.thaw_filesystem()
+
+    logger.info("Resuming VM")
+    firecracker.resume()
+
+
+def restore_vm(firecracker: FirecrackerClient, control: ProcessApiControl, *, snapshot_name: str) -> None:
+    """Restore a VM from a snapshot PVC mounted at /snapshots."""
+    snapshot_dir = f"{SNAPSHOT_MOUNT}/{snapshot_name}"
+
+    firecracker.wait_ready()
+    firecracker.load_snapshot(snapshot_path=f"{snapshot_dir}/vmstate", mem_file_path=f"{snapshot_dir}/memory")
+    control.wait_ready()
+    control.thaw_filesystem()

--- a/devinfra/firecracker/provision-rootfs.sh
+++ b/devinfra/firecracker/provision-rootfs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Provision the base rootfs for Firecracker VMs on wyrm2.
+#
+# Builds the NixOS rootfs via Nix (fetches from binary cache if available),
+# then writes it to the base LVM thin LV. The kernel and initramfs are baked
+# into the VM pod OCI image, not stored on LVM.
+#
+# Prerequisites:
+#   - Run on wyrm2 (has Nix, the ducktape repo, and the LVM VG)
+#   - The base LV must exist:
+#       lvcreate -V 10G -T openebs-lvmvg/thin-pool -n fc-base-rootfs
+#
+# Usage:
+#   cd ~/code/ducktape
+#   ./devinfra/firecracker/provision-rootfs.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ROOTFS_LV="${ROOTFS_LV:-/dev/openebs-lvmvg/fc-base-rootfs}"
+
+echo "Building NixOS rootfs..."
+# make-ext4-fs produces a single file derivation — the ext4 image itself.
+ROOTFS_FILE="$(nix build "$REPO_ROOT#fc-dev-rootfs" --print-out-paths --no-link)"
+
+if [ ! -f "$ROOTFS_FILE" ]; then
+  echo "ERROR: Nix build output is not a file: $ROOTFS_FILE" >&2
+  exit 1
+fi
+
+ROOTFS_SIZE="$(stat -c%s "$ROOTFS_FILE")"
+echo "Rootfs: $ROOTFS_FILE ($(numfmt --to=iec "$ROOTFS_SIZE"))"
+
+if [ ! -b "$ROOTFS_LV" ]; then
+  echo "ERROR: LV $ROOTFS_LV does not exist. Create it first:" >&2
+  echo "  lvcreate -V 10G -T openebs-lvmvg/thin-pool -n fc-base-rootfs" >&2
+  exit 1
+fi
+
+LV_SIZE="$(blockdev --getsize64 "$ROOTFS_LV")"
+if [ "$ROOTFS_SIZE" -gt "$LV_SIZE" ]; then
+  echo "ERROR: Rootfs ($ROOTFS_SIZE) is larger than LV ($LV_SIZE). Extend the LV:" >&2
+  echo "  lvextend -L +$((ROOTFS_SIZE - LV_SIZE))b $ROOTFS_LV" >&2
+  exit 1
+fi
+
+echo "Writing rootfs to $ROOTFS_LV..."
+dd if="$ROOTFS_FILE" of="$ROOTFS_LV" bs=4M status=progress conv=fsync
+
+echo "Done. Base rootfs written to $ROOTFS_LV"
+echo "VMs will thin-snapshot this LV for their own rootfs PVCs."

--- a/devinfra/firecracker/vm_alternatives.md
+++ b/devinfra/firecracker/vm_alternatives.md
@@ -1,0 +1,255 @@
+# VM Orchestration Alternatives
+
+Comparison of systems that can run VMs or sandboxed workloads on k8s,
+focused on **snapshot/restore** and **fork-resume** (restoring one snapshot
+into multiple independent instances).
+
+## Requirements
+
+1. **Save full state to disk**: memory + CPU registers + device state
+2. **Restore from disk**: resume a saved VM without cold-booting
+3. **Fork-resume**: one snapshot → N resumed instances (each diverges independently)
+4. **Fast restore**: target <100ms for the VMM restore operation
+5. **k8s integration**: manageable from k8s (CRD, RuntimeClass, or API)
+
+## Comparison
+
+| System                   | Save to disk                     | Restore               | Fork-resume                               | Restore latency                | k8s integration                  |
+| ------------------------ | -------------------------------- | --------------------- | ----------------------------------------- | ------------------------------ | -------------------------------- |
+| Firecracker (standalone) | Yes (vmstate + memory file)      | Yes                   | Yes, first-class (COW mmap)               | ~5–10ms VMM + demand-paged mem | None (need Kata or custom)       |
+| Kata + Firecracker       | **No** (FC APIs not wired up)    | Boot template only    | Boot template only (COW)                  | ~100–200ms                     | High (shimv2 CRI)                |
+| Kata + QEMU              | Boot template only (`-incoming`) | Boot template only    | Boot template only (COW)                  | ~100–200ms                     | Highest (default Kata config)    |
+| Cloud Hypervisor         | Yes (snapshot API)               | Yes                   | Yes (manual, no built-in COW)             | ~50–200ms                      | Moderate (via Kata)              |
+| QEMU/microvm             | Yes (migration/savevm)           | Yes                   | Yes (via `-incoming`)                     | ~100–500ms                     | Low (experimental Kata)          |
+| KubeVirt                 | Disk only (CSI VolumeSnapshot)   | Disk only (cold boot) | Disk clone only (VirtualMachineClone CRD) | Cold boot (seconds)            | High (CRD/operator)              |
+| gVisor                   | Yes (runsc checkpoint)           | Yes                   | Partial (not first-class)                 | ~50–200ms                      | High (runtime), low (checkpoint) |
+
+## Detailed Notes
+
+### Firecracker (standalone)
+
+The gold standard for fork-resume. Used at AWS Lambda to snapshot a warmed
+function and restore it across thousands of workers. Snapshot = vmstate file
+
+- memory file. The memory file can be mmap'd COW so clones share base pages
+  and only allocate for dirty pages. Restore is ~5–10ms for the VMM operation;
+  memory is demand-paged from the file.
+
+**Diff snapshots** are supported: after restoring, enable dirty-page tracking
+and take a diff snapshot that only contains pages modified since restore.
+
+No k8s integration — needs a controller (what we're building) or Kata.
+
+### Kata Containers
+
+Kata has two acceleration mechanisms, both in the `[factory]` section of
+`configuration.toml`. Neither exposes arbitrary-point snapshots.
+
+#### VM Templating (`enable_template = true`)
+
+**QEMU-only.** Uses QMP migration, not Firecracker snapshots.
+
+Step by step:
+
+1. Boot a VM with kernel + initrd + kata-agent
+2. Pause via QMP once agent is ready
+3. Save memory + device state to `template_path` (default `/run/vc/vm/template`)
+   via QEMU's incoming migration mechanism
+4. New sandboxes restore from the template with COW memory mapping — shared
+   read-only base pages, private dirty pages per VM
+
+Results: ~73% reduction in startup latency, ~80% reduction in memory per
+container (shared kernel/agent pages). In a 100-container test with 128MB
+guests: ~9GB total memory saved.
+
+Constraints:
+
+- Requires `initrd=` (not `image=`)
+- Must NOT use `shared_fs = "virtio-fs"` (incompatible)
+- QEMU >= v4.1.0
+- Security: shared read-only memory mapping is vulnerable to cross-VM
+  side-channel attacks (CVE-2015-2877). Not for multi-tenant.
+
+**Key limitation: only captures post-boot, pre-workload state.** You cannot
+snapshot a pod after your application has been running. The template is the
+kernel+agent boot state, not your warmed-up Bazel JVM.
+
+#### VM Cache (`vm_cache_number > 0`)
+
+Pre-creates a pool of booted VMs held ready via a gRPC server on
+`vm_cache_endpoint` (default `/var/run/kata-containers/cache.sock`).
+New sandboxes grab a pre-warmed VM from the pool instead of booting.
+
+Reportedly broken in Kata 2.x+ (issue #1106), limited maintenance.
+
+#### `configuration.toml` keys
+
+| Key                 | Default                               | Description                    |
+| ------------------- | ------------------------------------- | ------------------------------ |
+| `enable_template`   | `false`                               | Clone from pre-booted template |
+| `template_path`     | `/run/vc/vm/template`                 | Where template state is saved  |
+| `vm_cache_number`   | `0`                                   | Pre-warmed VM pool size        |
+| `vm_cache_endpoint` | `/var/run/kata-containers/cache.sock` | gRPC socket for cache          |
+
+#### CLI
+
+```bash
+kata-runtime factory init      # create template (or: auto-created on first container)
+kata-runtime factory destroy   # destroy template
+kata-ctl factory ...           # same, Rust runtime (v3.23.0+)
+```
+
+No commands for snapshotting running sandboxes, listing snapshots, or restoring.
+
+#### Kata + Firecracker: no snapshot passthrough
+
+Despite Firecracker having `PUT /snapshot/create` and `PUT /snapshot/load`
+APIs, **Kata does not wire them up.** The `configuration-fc.toml` has a
+`[factory]` section with `enable_template` but the underlying implementation
+uses QEMU QMP migration, which Firecracker does not support. Kata's
+Limitations.md explicitly states: "The runtime does not provide checkpoint
+and restore commands."
+
+#### Per-pod configuration
+
+Different pods can use different Kata configs via separate `RuntimeClass`
+objects (each pointing to a different `configuration.toml`). But there is no
+per-pod annotation to override `enable_template` or `template_path`. Template
+config is per-RuntimeClass, not per-pod.
+
+#### Recent developments (2024–2025)
+
+- **runtime-rs VM templating** (v3.23.0): The Rust runtime gained VM
+  templating support (PR #11828). Same QEMU QMP mechanism as the Go runtime.
+  ~73% startup latency reduction, ~80% memory savings.
+- **Koyeb's custom fork**: Koyeb patched the Kata shim to add
+  `pause_with_snapshot` / `resume_from_snapshot` for Cloud Hypervisor,
+  achieving ~200ms wake times for scale-to-zero. **Custom fork, not upstream.**
+- **No upstream checkpoint/restore RFC**: No design document for full VM
+  state snapshots exists in upstream Kata.
+
+#### What Kata cannot do that raw Firecracker can
+
+| Capability                           | Raw Firecracker | Kata                                |
+| ------------------------------------ | --------------- | ----------------------------------- |
+| Snapshot running VM with workload    | Yes             | **No**                              |
+| Restore from arbitrary snapshot      | Yes             | **No** (boot template only)         |
+| Fork-resume (snapshot → N instances) | Yes (COW mmap)  | Boot template only                  |
+| Firecracker snapshot passthrough     | N/A             | **No** (APIs not wired up)          |
+| Per-pod snapshot config              | N/A             | **No** (per-RuntimeClass)           |
+| Checkpoint/restore (CRIU-like)       | N/A             | **No** (excluded in Limitations.md) |
+
+### Cloud Hypervisor
+
+Intel-originated VMM (now Linux Foundation). Cleaner codebase than QEMU,
+more features than Firecracker (PCI, VFIO, vhost-user, hotplug). Snapshot
+API (`PUT /vm.snapshot`, `PUT /vm.restore`) saves to a directory.
+
+Fork-resume works (restore the same snapshot directory N times) but there's
+no built-in COW memory sharing — each restore loads its own copy. You'd need
+filesystem-level COW (btrfs/XFS reflinks) to share base pages across clones.
+
+#### k8s integration
+
+Cloud Hypervisor runs on k8s via **Kata Containers** (`kata-clh` runtime
+class). But Kata doesn't expose CH's snapshot APIs either — same limitation
+as with Firecracker. Kata only uses CH for boot-time VM templating.
+
+For arbitrary-point snapshots + fork-resume, you'd need a custom controller
+(same as with Firecracker). The workflow would be structurally identical:
+
+#### Workflow comparison: Cloud Hypervisor vs Firecracker
+
+**Firecracker (what we have):**
+
+1. VM pod starts `firecracker --api-sock /tmp/fc.sock`
+2. Configure via REST: `PUT /boot-source`, `PUT /drives/rootfs`, etc.
+3. Snapshot: `PUT /snapshot/create {"snapshot_type": "Full", ...}`
+   → vmstate file + memory file
+4. Fork-resume: new pod starts `firecracker --api-sock ...`,
+   then `PUT /snapshot/load` with memory file mmap'd COW
+5. Diff snapshots: enable dirty-page tracking, take incremental snapshot
+
+**Cloud Hypervisor (hypothetical):**
+
+1. VM pod starts `cloud-hypervisor --api-socket /tmp/ch.sock`
+   (or via `ch-remote` CLI for all API calls)
+2. Configure via REST or CLI:
+   `PUT /vm.create {"payload": {"kernel": ..., "initramfs": ...}, ...}`
+   `PUT /vm.boot`
+3. Snapshot: `PUT /vm.snapshot {"destination_url": "/data/snapshots/warm"}`
+   → directory with config.json + memory region files + device state
+4. Fork-resume: new pod starts
+   `cloud-hypervisor --api-socket ... --restore "source_url=/data/snapshots/warm"`
+   Each restore loads its own copy of memory (no built-in COW mmap).
+   For COW sharing: store snapshots on XFS/btrfs, use reflinks when
+   copying to each pod's working directory.
+5. No diff snapshots — each snapshot is a full dump.
+
+#### Tradeoffs vs Firecracker
+
+| Feature                  | Firecracker               | Cloud Hypervisor             |
+| ------------------------ | ------------------------- | ---------------------------- |
+| Fork-resume COW          | Built-in (mmap mem file)  | Manual (fs reflinks or copy) |
+| Restore latency          | ~5–10ms VMM               | ~50–200ms                    |
+| Diff snapshots           | Yes (dirty-page tracking) | No                           |
+| virtio-fs                | No                        | Yes                          |
+| PCI / VFIO passthrough   | No                        | Yes                          |
+| Hotplug (CPU, mem, disk) | No                        | Yes                          |
+| Live migration           | No                        | Yes                          |
+| Binary size              | ~3MB                      | ~10MB                        |
+| Device model             | Minimal (virtio-mmio)     | Rich (PCI, ACPI, IOAPIC)     |
+
+**When CH would be better**: if we needed virtio-fs (sharing host dirs into
+guest without baking into rootfs), GPU/VFIO passthrough, or live migration
+between hosts. None of these are currently needed.
+
+**When Firecracker is better**: fork-resume speed and memory efficiency are
+the primary differentiators. 5–10ms vs 50–200ms restore, plus built-in COW
+memory sharing means N forked VMs from the same snapshot share base pages
+automatically. With CH you'd need to orchestrate reflinks yourself and each
+VM still pays the full restore cost.
+
+### KubeVirt
+
+The only system with a full k8s-native CRD experience (VirtualMachine,
+VirtualMachineSnapshot, VirtualMachineClone). But **snapshots are disk-only**
+via CSI VolumeSnapshot. There is no memory state capture. Restore means
+cold-booting from the snapshotted disk. VirtualMachineClone creates a new VM
+from a snapshot with deduplicated identity (new MAC, UUID).
+
+KubeVirt uses QEMU/libvirt underneath, which _does_ support `virsh save`
+(memory to file), but KubeVirt's orchestration layer has not exposed this.
+Pause/unpause keeps RAM allocated (not saved to disk).
+
+Not suitable for our fork-resume use case.
+
+### gVisor
+
+Not a VM — a user-space kernel that intercepts syscalls. `runsc checkpoint`
+saves full process state (memory, FDs, network, kernel state) to a file.
+Restore via `runsc restore`. Used by Google Cloud Run for instance pre-warming.
+
+Fork-resume is technically possible (restore the same checkpoint N times) but
+is not a promoted use case. May have issues with duplicate network state.
+Checkpoint/restore is not exposed via k8s APIs (separate from the k8s
+Forensic Container Checkpointing KEP which uses CRIU).
+
+## Assessment for Our Use Case
+
+We want to: boot a NixOS dev VM, warm up Bazel (JVM + Skyframe cache),
+snapshot, then fork-resume into multiple sessions that each start from the
+warm state.
+
+**Best fit: Firecracker standalone with a custom controller** (what we have).
+Firecracker's snapshot/restore is purpose-built for this, with the fastest
+restore (~5ms VMM + demand-paged memory) and first-class COW fork-resume.
+The tradeoff is building our own orchestration.
+
+**Runner-up: Cloud Hypervisor** has full snapshot/restore and fork-resume,
+with a richer device model than Firecracker. No built-in COW sharing, but
+filesystem-level reflinks could substitute. Available as a Kata backend.
+
+**Not suitable: Kata** (only exposes boot-time templating, no arbitrary-point
+snapshots, Firecracker snapshot APIs not wired up), **KubeVirt** (no memory
+snapshots), **gVisor** (fork-resume not first-class).

--- a/devinfra/firecracker/vm_pod/BUILD.bazel
+++ b/devinfra/firecracker/vm_pod/BUILD.bazel
@@ -1,0 +1,98 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+# Apt manifest + lockfile for rules_distroless (referenced from MODULE.bazel).
+exports_files([
+    "bookworm_fc_vm_pod.yaml",
+    "bookworm_fc_vm_pod.lock.json",
+])
+
+py_library(
+    name = "networking",
+    srcs = ["networking.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = ["@pypi//pyroute2"],
+)
+
+py_library(
+    name = "firecracker_process",
+    srcs = ["firecracker_process.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "config",
+    srcs = ["config.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_library(
+    name = "proxy",
+    srcs = ["proxy.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "entrypoint_lib",
+    srcs = ["entrypoint.py"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        ":firecracker_process",
+        ":networking",
+        ":proxy",
+    ],
+)
+
+py_binary(
+    name = "entrypoint",
+    imports = ["../../.."],
+    main_module = "devinfra.firecracker.vm_pod.entrypoint",
+    deps = [":entrypoint_lib"],
+)
+
+# ── OCI Image ────────────────────────────────────────────────────────────────
+
+aspect_py_binary(
+    name = "entrypoint_bin",
+    imports = ["../../.."],
+    main = "entrypoint.py",
+    deps = [":entrypoint_lib"],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":entrypoint_bin",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("entrypoint_bin"),
+    env = py_image_env(binary_name = "entrypoint_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [
+        "@bookworm_fc_vm_pod//:flat",
+        ":layers",
+        "//devinfra/firecracker:firecracker_layer",
+        "//devinfra/firecracker/initramfs:initramfs_layer",
+    ],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/fc-vm-pod",
+)

--- a/devinfra/firecracker/vm_pod/bookworm_fc_vm_pod.lock.json
+++ b/devinfra/firecracker/vm_pod/bookworm_fc_vm_pod.lock.json
@@ -1,0 +1,225 @@
+{
+  "packages": [
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "libedit2_3.1-20221030-2_amd64",
+          "name": "libedit2",
+          "version": "3.1-20221030-2"
+        },
+        {
+          "key": "libtinfo6_6.4-4_amd64",
+          "name": "libtinfo6",
+          "version": "6.4-4"
+        },
+        {
+          "key": "libc6_2.36-9-p-deb12u13_amd64",
+          "name": "libc6",
+          "version": "2.36-9+deb12u13"
+        },
+        {
+          "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+          "name": "libgcc-s1",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+          "name": "gcc-12-base",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "libbsd0_0.11.7-2_amd64",
+          "name": "libbsd0",
+          "version": "0.11.7-2"
+        },
+        {
+          "key": "libmd0_1.0.4-2_amd64",
+          "name": "libmd0",
+          "version": "1.0.4-2"
+        },
+        {
+          "key": "libnftables1_1.0.6-2-p-deb12u2_amd64",
+          "name": "libnftables1",
+          "version": "1.0.6-2+deb12u2"
+        },
+        {
+          "key": "libxtables12_1.8.9-2_amd64",
+          "name": "libxtables12",
+          "version": "1.8.9-2"
+        },
+        {
+          "key": "libnftnl11_1.2.4-2_amd64",
+          "name": "libnftnl11",
+          "version": "1.2.4-2"
+        },
+        {
+          "key": "libmnl0_1.0.4-3_amd64",
+          "name": "libmnl0",
+          "version": "1.0.4-3"
+        },
+        {
+          "key": "libjansson4_2.14-2_amd64",
+          "name": "libjansson4",
+          "version": "2.14-2"
+        },
+        {
+          "key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+          "name": "libgmp10",
+          "version": "2:6.2.1+dfsg1-1.1"
+        }
+      ],
+      "key": "nftables_1.0.6-2-p-deb12u2_amd64",
+      "name": "nftables",
+      "sha256": "966ff20ce58c17163a771c02ddbca264291408f94c512bd85dd18da0ebdbe88c",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/nftables/nftables_1.0.6-2+deb12u2_amd64.deb"
+      ],
+      "version": "1.0.6-2+deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libedit2_3.1-20221030-2_amd64",
+      "name": "libedit2",
+      "sha256": "1cf14abf2716d3279db12d0657a5737cf70074a1e71d3bdf73206625e3c89ce6",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libe/libedit/libedit2_3.1-20221030-2_amd64.deb"
+      ],
+      "version": "3.1-20221030-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libtinfo6_6.4-4_amd64",
+      "name": "libtinfo6",
+      "sha256": "072d908f38f51090ca28ca5afa3b46b2957dc61fe35094c0b851426859a49a51",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
+      ],
+      "version": "6.4-4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libc6_2.36-9-p-deb12u13_amd64",
+      "name": "libc6",
+      "sha256": "3d8072c73b017e907bbf44b7db870687888a991961d74f1ecbba6b9458f32a2c",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/glibc/libc6_2.36-9+deb12u13_amd64.deb"
+      ],
+      "version": "2.36-9+deb12u13"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+      "name": "libgcc-s1",
+      "sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+      "name": "gcc-12-base",
+      "sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libbsd0_0.11.7-2_amd64",
+      "name": "libbsd0",
+      "sha256": "bb31cc8b40f962a85b2cec970f7f79cc704a1ae4bad24257a822055404b2c60b",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libb/libbsd/libbsd0_0.11.7-2_amd64.deb"
+      ],
+      "version": "0.11.7-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libmd0_1.0.4-2_amd64",
+      "name": "libmd0",
+      "sha256": "03539fd30c509e27101d13a56e52eda9062bdf1aefe337c07ab56def25a13eab",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libm/libmd/libmd0_1.0.4-2_amd64.deb"
+      ],
+      "version": "1.0.4-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libnftables1_1.0.6-2-p-deb12u2_amd64",
+      "name": "libnftables1",
+      "sha256": "3a8223f9bfba99d97bf25296ac83de307ab036e1df63e5965f88809266851947",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/nftables/libnftables1_1.0.6-2+deb12u2_amd64.deb"
+      ],
+      "version": "1.0.6-2+deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libxtables12_1.8.9-2_amd64",
+      "name": "libxtables12",
+      "sha256": "cb841d66950a43af4a398625313d2f3da9065299c9738538de6c2c3495857040",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/i/iptables/libxtables12_1.8.9-2_amd64.deb"
+      ],
+      "version": "1.8.9-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libnftnl11_1.2.4-2_amd64",
+      "name": "libnftnl11",
+      "sha256": "9e619e1470a1915264e906020f3bfc046fd8458043b1342686d997b5078213af",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libn/libnftnl/libnftnl11_1.2.4-2_amd64.deb"
+      ],
+      "version": "1.2.4-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libmnl0_1.0.4-3_amd64",
+      "name": "libmnl0",
+      "sha256": "4581f42e3373cb72f9ea4e88163b17873afca614a6c6f54637e95aa75983ea7c",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb"
+      ],
+      "version": "1.0.4-3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libjansson4_2.14-2_amd64",
+      "name": "libjansson4",
+      "sha256": "3fc9742f9f1a37bcb9931df6074b4d1483419ef832ad5349f47323e75fc27864",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/j/jansson/libjansson4_2.14-2_amd64.deb"
+      ],
+      "version": "2.14-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+      "name": "libgmp10",
+      "sha256": "187aedef2ed763f425c1e523753b9719677633c7eede660401739e9c893482bd",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg1-1.1_amd64.deb"
+      ],
+      "version": "2:6.2.1+dfsg1-1.1"
+    }
+  ],
+  "version": 1
+}

--- a/devinfra/firecracker/vm_pod/bookworm_fc_vm_pod.yaml
+++ b/devinfra/firecracker/vm_pod/bookworm_fc_vm_pod.yaml
@@ -1,0 +1,22 @@
+# Deb packages layered on debian:bookworm-slim for the Firecracker VM pod.
+#
+# Most system tools are replaced by pure Python (pyroute2 for TAP/IP,
+# ctypes for mount/umount, socket for SSH readiness). Only nftables
+# is needed as a binary for the NAT MASQUERADE rule.
+#
+# Regenerate the lock file after any change:
+#   bazel run @bookworm_fc_vm_pod//:lock
+version: 1
+
+sources:
+  - channel: bookworm main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: bookworm-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  # nft CLI — NAT MASQUERADE rule for guest networking
+  - "nftables"

--- a/devinfra/firecracker/vm_pod/config.py
+++ b/devinfra/firecracker/vm_pod/config.py
@@ -1,0 +1,30 @@
+"""VM pod configuration loaded from a YAML file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class VMPodConfig(BaseModel):
+    """Configuration for the Firecracker VM pod entrypoint.
+
+    The pod is infrastructure-only: it starts Firecracker, sets up
+    networking, and exposes the FC API on :2026. All VM configuration
+    (boot, drives, snapshot/load) is done by the manager via the proxy.
+
+    The rootfs PVC is created and attached by the manager before the pod
+    starts — the entrypoint doesn't need to know about it.
+    """
+
+    firecracker_bin: Path = Field(
+        default=Path("/usr/local/bin/firecracker"), description="Path to the Firecracker binary"
+    )
+
+
+def load_config(path: Path) -> VMPodConfig:
+    """Load VM pod config from a YAML file."""
+    data = yaml.safe_load(path.read_text())
+    return VMPodConfig.model_validate(data)

--- a/devinfra/firecracker/vm_pod/entrypoint.py
+++ b/devinfra/firecracker/vm_pod/entrypoint.py
@@ -1,0 +1,59 @@
+"""Entrypoint for Firecracker VM pods — infrastructure only.
+
+The pod is deliberately dumb. It:
+1. Sets up TAP + NAT networking
+2. Starts the Firecracker process (no VM config — just the process + API)
+3. Proxies guest and FC API ports onto the pod network
+4. Blocks until Firecracker exits
+
+All VM configuration (boot-source, drives, machine-config, InstanceStart,
+snapshot/load) is done by the manager through the proxied ports.
+The rootfs PVC is created and mounted by the manager before the pod starts.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from pathlib import Path
+
+from devinfra.firecracker.vm_pod.config import load_config
+from devinfra.firecracker.vm_pod.firecracker_process import start_firecracker
+from devinfra.firecracker.vm_pod.networking import GUEST_IP, setup_tap_and_nat
+from devinfra.firecracker.vm_pod.proxy import start_tcp_to_tcp_proxy, start_tcp_to_unix_proxy
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/etc/fc-vm-pod/config.yaml")
+    logger.info("Loading config from %s", config_path)
+    cfg = load_config(config_path)
+
+    setup_tap_and_nat()
+    fc = start_firecracker(cfg.firecracker_bin)
+
+    # Proxy all services onto the pod network so the manager can reach them.
+    start_tcp_to_tcp_proxy(2024, GUEST_IP, 2024)  # process_api WebSocket
+    start_tcp_to_tcp_proxy(2025, GUEST_IP, 2025)  # process_api HTTP control
+    start_tcp_to_unix_proxy(fc.api_socket, 2026)  # Firecracker API
+
+    logger.info("Pod ready: WS :2024, control :2025, FC API :2026")
+
+    def _shutdown(signum, _frame):
+        logger.info("Received signal %d, shutting down...", signum)
+        fc.process.terminate()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    rc = fc.process.wait()
+    logger.info("Firecracker exited with code %d", rc)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devinfra/firecracker/vm_pod/firecracker_process.py
+++ b/devinfra/firecracker/vm_pod/firecracker_process.py
@@ -1,0 +1,47 @@
+"""Start a Firecracker process and expose its API.
+
+The entrypoint is infrastructure-only: it starts the Firecracker process,
+waits for the API socket, and returns a handle. All VM configuration
+(boot-source, drives, machine-config, InstanceStart, snapshot/load) is
+done by the manager via the FC API proxy on port 2026.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FirecrackerProcess:
+    """A running Firecracker process with its API socket."""
+
+    process: subprocess.Popen
+    api_socket: Path
+
+
+def start_firecracker(firecracker_bin: Path, api_socket: Path | None = None) -> FirecrackerProcess:
+    """Start the Firecracker process and wait for its API socket."""
+    if api_socket is None:
+        api_socket = Path(tempfile.mkdtemp(prefix="firecracker-")) / "api.sock"
+
+    logger.info("Starting Firecracker: bin=%s, socket=%s", firecracker_bin, api_socket)
+    proc = subprocess.Popen(
+        [firecracker_bin, "--api-sock", api_socket], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+    for _ in range(50):
+        if api_socket.exists():
+            break
+        time.sleep(0.1)
+    else:
+        raise RuntimeError(f"Firecracker API socket {api_socket} did not appear")
+
+    logger.info("Firecracker API ready (pid=%d)", proc.pid)
+    return FirecrackerProcess(process=proc, api_socket=api_socket)

--- a/devinfra/firecracker/vm_pod/networking.py
+++ b/devinfra/firecracker/vm_pod/networking.py
@@ -1,0 +1,111 @@
+"""TAP device and NAT setup for Firecracker VM networking.
+
+Creates a TAP device bridged to the pod's network, with NAT (MASQUERADE)
+so the guest VM can reach the internet through the pod's eth0.
+
+Uses pyroute2 (netlink) for TAP/IP and nft CLI for NAT. The only system
+binary needed is ``nft`` from the nftables package — all other networking
+(TAP creation, IP assignment, link up, sysctl) is pure Python.
+
+Network layout:
+  Pod eth0 (CNI-assigned IP)
+    └─ nftables MASQUERADE
+  tap0 (10.0.0.1/30)
+    └─ Firecracker VM eth0 (10.0.0.2/30, gw 10.0.0.1)
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from pyroute2 import IPRoute
+
+logger = logging.getLogger(__name__)
+
+# Must match process_api's hardcoded networking (firecracker_init.rs):
+# guest IP 192.0.2.2/24, gateway 192.0.2.1, MTU 1400.
+TAP_NAME = "tap0"
+TAP_IP = "192.0.2.1"
+GUEST_IP = "192.0.2.2"
+SUBNET = "192.0.2.0/24"
+PREFIX_LEN = 24
+HOST_IFACE = "eth0"
+
+_NFT_TABLE = "fc-nat"
+
+
+@dataclass(frozen=True)
+class NetworkSetup:
+    """Result of TAP + NAT setup."""
+
+    tap_name: str
+    tap_ip: str
+    guest_ip: str
+    guest_gateway: str
+    guest_netmask: str
+
+
+def _enable_ip_forward() -> None:
+    Path("/proc/sys/net/ipv4/ip_forward").write_text("1")
+    logger.debug("Enabled ip_forward")
+
+
+def _create_tap(ipr: IPRoute) -> None:
+    """Create TAP device, assign IP, bring up via netlink."""
+    ipr.link("add", ifname=TAP_NAME, kind="tuntap", tuntap_mode="tap")
+    idx = ipr.link_lookup(ifname=TAP_NAME)[0]
+    ipr.addr("add", index=idx, address=TAP_IP, prefixlen=PREFIX_LEN)
+    ipr.link("set", index=idx, state="up")
+    logger.debug("Created TAP %s (%s/%d)", TAP_NAME, TAP_IP, PREFIX_LEN)
+
+
+def _setup_nat() -> None:
+    """Create nftables MASQUERADE rule for guest → internet NAT.
+
+    Uses the nft CLI — the only system binary this module needs.
+    The pyroute2 NFTables class exposes raw netlink but doesn't have a
+    high-level API for building nft expressions, so the CLI is simpler.
+    """
+    # Single atomic nft command that creates table + chain + rule.
+    ruleset = f"""
+table ip {_NFT_TABLE} {{
+    chain postrouting {{
+        type nat hook postrouting priority 100; policy accept;
+        ip saddr {SUBNET} oifname "{HOST_IFACE}" masquerade
+    }}
+}}
+"""
+    subprocess.run(["nft", "-f", "-"], input=ruleset, check=True, text=True, capture_output=True)
+    logger.debug("NAT: %s via %s → MASQUERADE", SUBNET, HOST_IFACE)
+
+
+def _teardown_nat() -> None:
+    subprocess.run(["nft", "delete", "table", "ip", _NFT_TABLE], check=False, capture_output=True, text=True)
+
+
+def setup_tap_and_nat() -> NetworkSetup:
+    """Create TAP device, assign IP, enable forwarding, set up NAT."""
+    _enable_ip_forward()
+    with IPRoute() as ipr:
+        _create_tap(ipr)
+    _setup_nat()
+
+    logger.info("Network ready: TAP=%s (%s), guest=%s, NAT via %s", TAP_NAME, TAP_IP, GUEST_IP, HOST_IFACE)
+    return NetworkSetup(
+        tap_name=TAP_NAME, tap_ip=TAP_IP, guest_ip=GUEST_IP, guest_gateway=TAP_IP, guest_netmask="255.255.255.0"
+    )
+
+
+def teardown_tap_and_nat() -> None:
+    """Remove TAP device and NAT rules. Best-effort, logs errors."""
+    _teardown_nat()
+    try:
+        with IPRoute() as ipr:
+            links = ipr.link_lookup(ifname=TAP_NAME)
+            if links:
+                ipr.link("del", index=links[0])
+    except Exception:
+        logger.warning("Failed to remove TAP %s", TAP_NAME, exc_info=True)

--- a/devinfra/firecracker/vm_pod/proxy.py
+++ b/devinfra/firecracker/vm_pod/proxy.py
@@ -1,0 +1,106 @@
+"""TCP proxies for exposing VM services on the pod network.
+
+The Firecracker guest runs in its own network namespace (TAP bridge).
+Services inside the guest (process_api on 2024/2025) are only reachable
+via the guest IP (192.0.2.2). The Firecracker API is a Unix socket.
+
+These proxies make everything reachable from the pod IP so the manager
+can talk to both Firecracker and the guest without kubectl exec.
+
+  Pod :2024 → guest 192.0.2.2:2024  (process_api WebSocket)
+  Pod :2025 → guest 192.0.2.2:2025  (process_api HTTP control)
+  Pod :2026 → Firecracker Unix socket (FC management API)
+"""
+
+from __future__ import annotations
+
+import logging
+import selectors
+import socket
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_BUFFER_SIZE = 65536
+
+
+def start_tcp_to_unix_proxy(api_socket: Path, listen_port: int) -> threading.Thread:
+    """Proxy TCP connections to a Unix domain socket."""
+    thread = threading.Thread(target=_proxy_loop, args=(listen_port, lambda: _connect_unix(api_socket)), daemon=True)
+    thread.start()
+    logger.info("Proxy :%d → %s", listen_port, api_socket)
+    return thread
+
+
+def start_tcp_to_tcp_proxy(listen_port: int, target_host: str, target_port: int) -> threading.Thread:
+    """Proxy TCP connections to a remote TCP address."""
+    thread = threading.Thread(
+        target=_proxy_loop, args=(listen_port, lambda: _connect_tcp(target_host, target_port)), daemon=True
+    )
+    thread.start()
+    logger.info("Proxy :%d → %s:%d", listen_port, target_host, target_port)
+    return thread
+
+
+def _connect_unix(path: Path) -> socket.socket:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(str(path))
+    return sock
+
+
+def _connect_tcp(host: str, port: int) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, port))
+    return sock
+
+
+def _proxy_loop(listen_port: int, connect_fn: Callable[[], socket.socket]) -> None:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # Bind to all interfaces — the manager reaches these ports via the pod IP.
+    server.bind(("0.0.0.0", listen_port))
+    server.listen(4)
+
+    while True:
+        tcp_conn, addr = server.accept()
+        # Handle each connection in its own thread so we can serve
+        # concurrent WebSocket + HTTP connections.
+        threading.Thread(target=_handle_connection, args=(tcp_conn, connect_fn, addr), daemon=True).start()
+
+
+def _handle_connection(tcp_conn: socket.socket, connect_fn: Callable[[], socket.socket], addr: tuple) -> None:
+    try:
+        backend = connect_fn()
+    except OSError:
+        logger.warning("Proxy: backend connection failed for %s", addr)
+        tcp_conn.close()
+        return
+
+    sel = selectors.DefaultSelector()
+    sel.register(tcp_conn, selectors.EVENT_READ)
+    sel.register(backend, selectors.EVENT_READ)
+
+    try:
+        while True:
+            events = sel.select(timeout=60)
+            if not events:
+                continue
+            for key, _ in events:
+                if key.fileobj is tcp_conn:
+                    data = tcp_conn.recv(_BUFFER_SIZE)
+                    if not data:
+                        return
+                    backend.sendall(data)
+                else:
+                    data = backend.recv(_BUFFER_SIZE)
+                    if not data:
+                        return
+                    tcp_conn.sendall(data)
+    except OSError:
+        logger.debug("Proxy connection closed for %s", addr)
+    finally:
+        sel.close()
+        backend.close()
+        tcp_conn.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
     # Docker
     "docker>=7.0.0",
 
+    # Firecracker VM pod networking (TAP/IP via netlink)
+    "pyroute2>=0.9.0",
+
     # Data
     "pandas>=2.2.0",
     "PyYAML>=6.0",

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -4902,6 +4902,10 @@ pyrage-stubs==1.3.1 \
     --hash=sha256:4e38b7ec6d89977147b7d213f931b0a0198918369144eec6df03c5eb83aabf1c \
     --hash=sha256:cf1a4473eee584314d396b87550c0a5d84e4b0e3f0ec54e4cae6d896ae50c2ba
     # via ducktape (pyproject.toml)
+pyroute2==0.9.5 \
+    --hash=sha256:a198ccbe545b031b00b10da4b44df33d548db04af944be8107c05a215ba03872 \
+    --hash=sha256:e7d485ce8274cbf473e9092fa65585faf8a3df5fe05ecf497cb9c5b1516ba09f
+    # via ducktape (pyproject.toml)
 pytest==9.0.2 \
     --hash=sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b \
     --hash=sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11


### PR DESCRIPTION
## Summary

Custom VMM for warm Firecracker VMs on wyrm2, targeting ~28ms restore from snapshot vs ~15s cold Bazel startup.

- **VM pod** (entrypoint): starts Firecracker process, sets up TAP+NAT networking, proxies ports onto pod network (:2024 WS, :2025 control, :2026 FC API). No VM configuration — pure infra.
- **Manager** (FastAPI): creates per-VM PVCs (rootfs Block + work Filesystem, CoW-cloned via LVM thin snapshots), creates pods, drives boot/restore through the FC API proxy. Typed HTTP clients (`FirecrackerClient`, `ProcessApiControl`, `K8sVMClient`), FastAPI DI, no global state.
- **process_api client**: streaming async WebSocket client with StrEnum protocol types (`ServerTag`, `ServerMessageKey`). Uses RE reimplementation as Bazel dep (no binary in git).
- **Storage**: LVM thin provisioning. Rootfs as `volumeMode: Block` (Firecracker drive). Work/snapshot as `Filesystem` (Firecracker snapshot API uses `ftruncate` — block devices fail).
- **Snapshot**: freeze → pause → create → thaw → resume. Restore via CoW PVC cloning (no sharing).

See `DESIGN.md` for architecture, `vm_alternatives.md` for Kata/KubeVirt/gVisor/Cloud Hypervisor comparison.

Split from #1159. K8s deployment in separate PR, Nix rootfs in separate PR.

## Test plan

- [ ] `bazel build //devinfra/firecracker/manager:image //devinfra/firecracker/vm_pod:image`
- [ ] Boot test on wyrm2 with raw Firecracker (pending LVM + rootfs setup)

https://claude.ai/code/session_01GemRyThW5cmqXS5zYN5YLn