### PR TITLE
Firecracker manager k8s deployment manifests

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -67,14 +67,14 @@ CloudNativePG `local-path`. See <changelog.md> for history.
       loss caused `sso-secrets` to regenerate all `random_password` resources. Fix by
       force re-applying all SSO blueprints (clear `last_applied_hash` via `ak shell`) so
       the DB picks up the current env var values.
-- [ ] OpenEBS LVM on VPS nodes: Partition each VPS node's 160GB NVMe to carve out
-      ~60GB for an LVM volume group (`openebs-vps-vg`). Use Talos `machine.disks` or
-      `machine.volumes` (1.9+) to create the partition and VG. Expand OpenEBS LVM
-      HelmRelease `lvmNode.nodeSelector` to include VPS nodes (`region: hil`). Add a
-      `lvm-vps` StorageClass. Rolling update: drain + destroy + recreate each VPS node
-      one at a time to repartition. This gives VPS nodes a local non-replicated storage
-      option (faster than Longhorn for single-node workloads like CNPG `local-path`
-      replacements). Pairs well with CPX41 upgrade (240GB → more headroom).
+- [ ] OpenEBS LVM on Talos nodes: Currently deployed on wyrm2 (NixOS) for
+      Firecracker VM storage (thin provisioning, `volumeMode: Block` cloning).
+      If it works well on wyrm2, expand to Talos nodes: - **VPS nodes**: Partition each 160GB NVMe to carve out ~60GB for a VG
+      (`openebs-vps-vg`). Use Talos `machine.disks` or `machine.volumes`
+      (1.9+). Add `lvm-vps` StorageClass. Rolling update: drain + destroy +
+      recreate each VPS node. Gives VPS a local non-replicated option
+      (faster than Longhorn for CNPG `local-path` replacements). - **Proxmox CP**: Similar approach if needed for local storage. - Expand OpenEBS LVM HelmRelease `lvmNode.nodeSelector` to include
+      target regions. Pairs well with CPX41 upgrade (240GB → more headroom).
 - [ ] Longhorn node tags: Kyverno mutate policy sets `node.longhorn.io/default-node-tags`
       annotation, but only fires at Node admission time — nodes created before Kyverno is
       deployed (i.e., bootstrap) never get tagged. Currently patched manually. Options:

--- a/cluster/k8s/agents/claude-rbac/namespace.yaml
+++ b/cluster/k8s/agents/claude-rbac/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   labels:
     name: claude-sandbox
     environment: development
+    goldilocks.fairwinds.com/enabled: "true"

--- a/cluster/k8s/agents/claude-sandbox-firecracker/config.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/config.yaml
@@ -1,0 +1,5 @@
+vm_image: ghcr.io/agentydragon/firecracker-vm-pod:latest
+base_rootfs_pvc: firecracker-base-rootfs
+node_selector:
+  kubernetes.io/hostname: wyrm2
+port: 8080

--- a/cluster/k8s/agents/claude-sandbox-firecracker/deployment.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/deployment.yaml
@@ -37,6 +37,16 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: api
+            periodSeconds: 30
           env:
             - name: FC_MANAGER_AUTH_TOKEN
               valueFrom:

--- a/cluster/k8s/agents/claude-sandbox-firecracker/deployment.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firecracker-manager
+  namespace: claude-sandbox
+  annotations:
+    description: >-
+      Firecracker VM manager. Creates VM pods (PVC + pod), then drives
+      boot/restore via the Firecracker API proxy on each pod.
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: firecracker-manager
+  template:
+    metadata:
+      labels:
+        app: firecracker-manager
+    spec:
+      serviceAccountName: firecracker-manager
+      nodeSelector:
+        kubernetes.io/hostname: wyrm2
+      containers:
+        - name: manager
+          image: ghcr.io/agentydragon/firecracker-manager:latest
+          args:
+            - /etc/firecracker-manager/config.yaml
+          ports:
+            - containerPort: 8080
+              name: api
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          env:
+            - name: FC_MANAGER_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: firecracker-manager-auth-token
+                  key: token
+          volumeMounts:
+            - name: config
+              mountPath: /etc/firecracker-manager
+      volumes:
+        - name: config
+          configMap:
+            name: firecracker-manager-config

--- a/cluster/k8s/agents/claude-sandbox-firecracker/flux-kustomization.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/flux-kustomization.yaml
@@ -13,4 +13,5 @@ spec:
   timeout: 2m
   dependsOn:
     - name: claude-rbac
+    - name: claude-sandbox-secrets
     - name: kvm-device-plugin

--- a/cluster/k8s/agents/claude-sandbox-firecracker/flux-kustomization.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: claude-sandbox-firecracker
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/claude-sandbox-firecracker
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: claude-rbac
+    - name: kvm-device-plugin

--- a/cluster/k8s/agents/claude-sandbox-firecracker/kustomization.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
+configMapGenerator:
+  - name: firecracker-manager-config
+    namespace: claude-sandbox
+    files:
+      - config.yaml
+    options:
+      disableNameSuffixHash: true

--- a/cluster/k8s/agents/claude-sandbox-firecracker/rbac.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: firecracker-manager
+  namespace: claude-sandbox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: firecracker-manager
+  namespace: claude-sandbox
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [create, delete, get, list, watch]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [create, delete, get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: firecracker-manager
+  namespace: claude-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: firecracker-manager
+subjects:
+  - kind: ServiceAccount
+    name: firecracker-manager
+    namespace: claude-sandbox

--- a/cluster/k8s/agents/claude-sandbox-firecracker/service.yaml
+++ b/cluster/k8s/agents/claude-sandbox-firecracker/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: firecracker-manager
+  namespace: claude-sandbox
+spec:
+  selector:
+    app: firecracker-manager
+  ports:
+    - name: api
+      port: 8080
+      targetPort: 8080

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -37,6 +37,7 @@ resources:
   - agents/shared-secrets/flux-kustomization.yaml
   - agents/claude-rbac/flux-kustomization.yaml
   - agents/claude-sandbox-secrets/flux-kustomization.yaml
+  - agents/claude-sandbox-firecracker/flux-kustomization.yaml
   - agents/airlock/flux-kustomization.yaml
   - agents/google-workspace-mcp/flux-kustomization.yaml
   - agents/tana-mcp/flux-kustomization.yaml


### PR DESCRIPTION
## Summary

Flux-managed k8s manifests for the Firecracker VM manager:

- Deployment + Service (`firecracker-manager`, port 8080)
- RBAC: ServiceAccount + Role (pods + PVCs CRUD) + RoleBinding
- ConfigMap via `configMapGenerator` (vm_image, base_rootfs_pvc, node_selector)
- Auth token from k8s Secret (`FC_MANAGER_AUTH_TOKEN`)
- `claude-sandbox` namespace label update
- kubeconform exclusion for `config.yaml` (app config, not k8s resource)
- `claude-sandbox-firecracker` added to cluster kustomization

Split from #1159. Depends on #1165 (implementation code) for the container image.

## Test plan

- [ ] `kubectl apply --dry-run=server` on the manifests
- [ ] Verify kubeconform passes (config.yaml excluded)

https://claude.ai/code/session_01GemRyThW5cmqXS5zYN5YLn