### PR TITLE
NixOS rootfs configuration for Firecracker dev VMs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -280,6 +280,10 @@
           # Build: nix build .#lxc-k8s-test-lxc
           # Upload: scp result/*.tar.xz root@atlas:/var/lib/vz/template/cache/
           lxc-k8s-test-lxc = self.nixosConfigurations.lxc-k8s-test.config.system.build.tarball;
+          # Firecracker dev VM rootfs (ext4) and kernel (vmlinux).
+          # Build: nix build .#fc-dev-rootfs  /  nix build .#fc-dev-kernel
+          fc-dev-rootfs = self.nixosConfigurations.fc-dev.config.system.build.ext4;
+          fc-dev-kernel = self.nixosConfigurations.fc-dev.config.boot.kernelPackages.kernel;
         };
 
       homeConfigurations = {
@@ -382,6 +386,13 @@
             ./nix/nixos/hosts/bazel-test
             home-manager.nixosModules.home-manager
           ];
+        };
+
+        # Firecracker dev VM — NixOS rootfs for Bazel development.
+        # Not a real host — produces ext4 image for Firecracker microVMs.
+        fc-dev = nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [ ./nix/nixos/hosts/fc_dev ];
         };
       };
     };

--- a/nix/nixos/hosts/fc_dev/default.nix
+++ b/nix/nixos/hosts/fc_dev/default.nix
@@ -1,0 +1,108 @@
+# fc-dev — NixOS configuration for Firecracker dev VMs.
+# Not a real host — produces an ext4 rootfs image for Firecracker microVMs.
+#
+# Build rootfs: nix build .#fc-dev-rootfs
+# Build kernel: nix build .#fc-dev-kernel
+#
+# The VM runs systemd as init, starts sshd on boot, and includes the full
+# Bazel development toolchain from bazel-dev.nix.
+{
+  modulesPath,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  imports = [
+    ../../modules/bazel-dev.nix
+    (modulesPath + "/profiles/minimal.nix")
+    ./make-rootfs.nix
+  ];
+
+  # Firecracker boots the kernel directly — no bootloader.
+  boot.loader.grub.enable = false;
+  boot.initrd.enable = false;
+  boot.isContainer = false;
+  boot.kernelParams = [
+    "console=ttyS0"
+    "reboot=k"
+    "panic=1"
+  ];
+
+  # Minimal kernel modules for virtio (Firecracker's device model).
+  boot.initrd.availableKernelModules = lib.mkForce [ ];
+  boot.kernelModules = [
+    "virtio_blk"
+    "virtio_net"
+    "virtio_pci"
+    "virtio_mmio"
+  ];
+
+  networking.hostName = "fc-dev";
+  # Static network config — set by the VM pod entrypoint via kernel cmdline
+  # or DHCP. For simplicity, use a static config matching the TAP subnet.
+  networking.useDHCP = false;
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [
+      {
+        address = "10.0.0.2";
+        prefixLength = 30;
+      }
+    ];
+  };
+  networking.defaultGateway = {
+    address = "10.0.0.1";
+    interface = "eth0";
+  };
+  networking.nameservers = [
+    "8.8.8.8"
+    "1.1.1.1"
+  ];
+
+  # SSH access — the only way into the VM.
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+    };
+  };
+  # Placeholder key — real key injected via process_api CreateProcess or
+  # written to ~/.ssh/authorized_keys via WS command after boot.
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAA-placeholder-replaced-at-runtime"
+  ];
+
+  # Dev tools beyond bazel-dev.nix
+  environment.systemPackages = with pkgs; [
+    bazelisk
+    python313
+    clang
+    openssh
+    curl
+    wget
+    jq
+    htop
+    # Dev headers for pip wheel builds
+    pkg-config
+    openssl.dev
+    cairo.dev
+    dbus.dev
+  ];
+
+  # systemd: fast boot, no unnecessary services.
+  services.getty.autologinUser = "root";
+  systemd.services."serial-getty@ttyS0".enable = true;
+
+  # Firecracker VMs have limited resources — keep it lean.
+  documentation.enable = false;
+  programs.command-not-found.enable = false;
+
+  # Nix itself (for nix-shell, nix build inside the VM).
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  system.stateVersion = "25.11";
+}

--- a/nix/nixos/hosts/fc_dev/make-rootfs.nix
+++ b/nix/nixos/hosts/fc_dev/make-rootfs.nix
@@ -1,0 +1,38 @@
+# Produces system.build.ext4 — an ext4 filesystem image containing the
+# full NixOS system closure, suitable for Firecracker's virtio-blk rootfs.
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
+let
+  make-ext4-fs = import (modulesPath + "/../lib/make-ext4-fs.nix");
+in
+{
+  system.build.ext4 = make-ext4-fs {
+    inherit pkgs lib;
+    inherit (pkgs)
+      e2fsprogs
+      libfaketime
+      perl
+      fakeroot
+      zstd
+      ;
+    storePaths = [ config.system.build.toplevel ];
+    compressImage = false;
+    volumeLabel = "fc-dev-rootfs";
+    populateImageCommands = ''
+      # System profile symlink — the only way to find the system closure.
+      # process_api spawns /nix/var/nix/profiles/system/init to start systemd,
+      # which then runs NixOS activation (creates /etc, /tmp, etc.).
+      mkdir -p ./files/nix/var/nix/profiles
+      ln -s ${config.system.build.toplevel} ./files/nix/var/nix/profiles/system
+
+      # NixOS activation checks for this marker.
+      mkdir -p ./files/etc
+      touch ./files/etc/NIXOS
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

NixOS configuration for the Firecracker guest rootfs (`fc_dev`):

- `default.nix`: NixOS system config importing `bazel-dev.nix` module (Bazel 8, Python 3.13, GCC, Clang, JDK 21, Git, nix-ld, envfs, openssh)
- `make-rootfs.nix`: ext4 image via `make-ext4-fs` with system profile symlink and `/etc/NIXOS` marker. NixOS activation creates `/etc`, `/tmp`, etc. when systemd starts.
- Flake outputs: `fc-dev-rootfs` (ext4 image), `fc-dev-kernel` (vmlinux)

Provisioned on wyrm2 via `provision-rootfs.sh` (in #1165): `nix build` + `dd` to LVM thin LV.

Split from #1159.

## Test plan

- [ ] `nix build .#fc-dev-rootfs` produces ext4 image
- [ ] `nix build .#fc-dev-kernel` produces vmlinux

https://claude.ai/code/session_01GemRyThW5cmqXS5zYN5YLn