### PR TITLE
Refactor OCI image loading to use native docker load instead of crane

### DIFF
--- a/skills/freecad/BUILD.bazel
+++ b/skills/freecad/BUILD.bazel
@@ -41,6 +41,18 @@ oci_layout_rloc(
     image = "@freecad_test_linux_amd64",
 )
 
+py_library(
+    name = "conftest",
+    testonly = True,
+    srcs = ["conftest.py"],
+    imports = ["../.."],
+    deps = [
+        "//util:oci",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 py_test(
     name = "test_container_primitives",
     size = "medium",
@@ -51,6 +63,7 @@ py_test(
     ],
     requires_docker = True,
     deps = [
+        ":conftest",
         "//third_party/containers:rlocations",
         "//util:oci",
         "//util/bazel:runfiles",
@@ -89,6 +102,7 @@ py_test(
     ],
     requires_docker = True,
     deps = [
+        ":conftest",
         "//util:oci",
         "//util/bazel:runfiles",
         "//util/testing:container_logs",
@@ -113,6 +127,7 @@ py_test(
     ],
     requires_docker = True,
     deps = [
+        ":conftest",
         "//skills/freecad/testing:compare",
         "//util:oci",
         "//util/bazel:runfiles",

--- a/skills/freecad/conftest.py
+++ b/skills/freecad/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for FreeCAD tests."""
+
+import pytest
+import pytest_bazel
+
+from util.oci import OciImage, load_oci_image
+
+FREECAD_TEST = OciImage("_main/skills/freecad/freecad_test.rloc", "freecad-test:pinned")
+
+
+@pytest.fixture(scope="session")
+def freecad_image() -> str:
+    """Load FreeCAD test image into Docker daemon and return its tag."""
+    return load_oci_image(FREECAD_TEST)

--- a/skills/freecad/test_container_primitives.py
+++ b/skills/freecad/test_container_primitives.py
@@ -12,39 +12,34 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from third_party.debian_slim.rlocations import IMAGE_TAG as DEBIAN_IMAGE_TAG, TARBALL as DEBIAN_TARBALL
-from util.oci import load_image
+from skills.freecad.conftest import FREECAD_TEST
+from third_party.containers.rlocations import DEBIAN_SLIM
+from util.oci import OciImage, load_oci_image
 from util.testing.container_logs import LoggedContainer
 
-_FREECAD_IMAGE_TAG = "freecad-test:pinned"
-_FREECAD_TARBALL = "_main/skills/freecad/freecad_test_load/tarball.tar"
-
-_IMAGES = [
-    pytest.param((DEBIAN_TARBALL, DEBIAN_IMAGE_TAG), id="debian-slim"),
-    pytest.param((_FREECAD_TARBALL, _FREECAD_IMAGE_TAG), id="freecad-test"),
-]
+_IMAGES = [pytest.param(DEBIAN_SLIM, id="debian-slim"), pytest.param(FREECAD_TEST, id="freecad-test")]
 
 
 @pytest.fixture(params=_IMAGES)
-def container_image(request: pytest.FixtureRequest) -> tuple[str, str]:
-    """Load image and return (tarball, tag) for parametrized tests."""
-    tarball, tag = request.param
-    load_image(tarball)
-    return tarball, tag
+def container_image(request: pytest.FixtureRequest) -> OciImage:
+    """Load image and return OciImage for parametrized tests."""
+    image: OciImage = request.param
+    load_oci_image(image)
+    return image
 
 
-def test_exec(container_image: tuple[str, str]) -> None:
+def test_exec(container_image: OciImage) -> None:
     """Verify exec runs a command and returns output."""
-    _, tag = container_image
+    tag = container_image.tag
     with LoggedContainer(tag, test_name=f"exec-{tag}", command="sleep infinity") as container:
         result = container.exec("echo EXEC_OK")
         assert result.exit_code == 0
         assert b"EXEC_OK" in result.output
 
 
-def test_volume_mount_read(container_image: tuple[str, str], tmp_path: Path) -> None:
+def test_volume_mount_read(container_image: OciImage, tmp_path: Path) -> None:
     """Verify container can read a host-mounted file."""
-    _, tag = container_image
+    tag = container_image.tag
     test_file = tmp_path / "input.txt"
     test_file.write_text("MOUNT_READ_OK")
     with LoggedContainer(
@@ -58,9 +53,9 @@ def test_volume_mount_read(container_image: tuple[str, str], tmp_path: Path) -> 
         assert b"MOUNT_READ_OK" in result.output
 
 
-def test_volume_mount_write(container_image: tuple[str, str], tmp_path: Path) -> None:
+def test_volume_mount_write(container_image: OciImage, tmp_path: Path) -> None:
     """Verify container can write a file visible on the host via volume mount."""
-    _, tag = container_image
+    tag = container_image.tag
     with LoggedContainer(
         tag, test_name=f"mount-write-{tag}", command="sleep infinity", volumes=[(str(tmp_path), "/output", "rw")]
     ) as container:
@@ -69,9 +64,9 @@ def test_volume_mount_write(container_image: tuple[str, str], tmp_path: Path) ->
     assert (tmp_path / "test.txt").read_text().strip() == "MOUNT_WRITE_OK"
 
 
-def test_put_archive_and_cat(container_image: tuple[str, str]) -> None:
+def test_put_archive_and_cat(container_image: OciImage) -> None:
     """Verify put_archive copies a file in and cat reads it back."""
-    _, tag = container_image
+    tag = container_image.tag
     with LoggedContainer(tag, test_name=f"put-cat-{tag}", command="sleep infinity") as container:
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w") as tar:

--- a/skills/freecad/test_export_formats.py
+++ b/skills/freecad/test_export_formats.py
@@ -6,14 +6,13 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
+from skills.freecad.conftest import FREECAD_TEST
 from skills.freecad.testing.compare import assert_dxf_equal, assert_pdf_equal, assert_svg_equal
 from util.bazel.runfiles import get_required_path
-from util.oci import load_image
+from util.oci import load_oci_image
 from util.testing.container_logs import LoggedContainer
 from util.testing.undeclared_outputs import undeclared_outputs_dir
 
-_IMAGE_TAG = "freecad-test:pinned"
-_TARBALL = "_main/skills/freecad/freecad_test_load/tarball.tar"
 _PARAMETRIC_RECT = "_main/skills/freecad/parametric_rect.py"
 _EXPORT_PAGE = "_main/skills/freecad/export_page.py"
 _GOLDEN_DXF = "_main/skills/freecad/golden/rect.dxf"
@@ -33,11 +32,11 @@ def _exec(container: LoggedContainer, cmd: str) -> None:
 @pytest.fixture(scope="module")
 def export_outputs(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Run parametric_rect.py then export_page.py and return the output directory."""
-    load_image(_TARBALL)
+    load_oci_image(FREECAD_TEST)
     tmp_path = tmp_path_factory.mktemp("freecad-export")
 
     with LoggedContainer(
-        _IMAGE_TAG,
+        FREECAD_TEST.tag,
         test_name="freecad-export-formats",
         command="sleep infinity",
         volumes=[

--- a/skills/freecad/test_render_3d.py
+++ b/skills/freecad/test_render_3d.py
@@ -6,13 +6,12 @@ from pathlib import Path
 import pytest_bazel
 from PIL import Image
 
+from skills.freecad.conftest import FREECAD_TEST
 from util.bazel.runfiles import get_required_path
-from util.oci import load_image
+from util.oci import load_oci_image
 from util.testing.container_logs import LoggedContainer
 from util.testing.undeclared_outputs import undeclared_outputs_dir
 
-_IMAGE_TAG = "freecad-test:pinned"
-_TARBALL = "_main/skills/freecad/freecad_test_load/tarball.tar"
 _BUILD_SCRIPT = "_main/skills/freecad/build_cube_with_hole.py"
 _RENDER_SCRIPT = "_main/skills/freecad/render_fcstd.py"
 _GOLDEN = "_main/skills/freecad/golden/cube_with_hole.png"
@@ -22,13 +21,13 @@ _MAX_DIFF_FRACTION = 0.02
 
 
 def test_render_3d(tmp_path: Path) -> None:
-    load_image(_TARBALL)
+    load_oci_image(FREECAD_TEST)
     build_script = get_required_path(_BUILD_SCRIPT)
     render_script = get_required_path(_RENDER_SCRIPT)
     golden_path = get_required_path(_GOLDEN)
 
     with LoggedContainer(
-        _IMAGE_TAG,
+        FREECAD_TEST.tag,
         test_name="freecad-3d-build",
         command="sleep infinity",
         volumes=[(str(build_script), "/work/build_cube_with_hole.py", "ro"), (str(tmp_path), "/output", "rw")],
@@ -43,7 +42,7 @@ def test_render_3d(tmp_path: Path) -> None:
     assert fcstd.exists(), "FCStd not generated — check container logs"
 
     with LoggedContainer(
-        _IMAGE_TAG,
+        FREECAD_TEST.tag,
         test_name="freecad-3d-render",
         command="sleep infinity",
         volumes=[

--- a/util/crane.py
+++ b/util/crane.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
 import json
 import logging
 import os
+import shutil
 import subprocess
+import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -112,5 +115,39 @@ def _parse_crane_digest(stdout: str, dest: str) -> str:
 
 
 def push_to_daemon(oci_layout: Path, tag: str) -> None:
-    """Push an OCI layout directory into the local Docker daemon via crane."""
-    Crane().push(oci_layout, f"daemon://{tag}")
+    """Load an OCI layout directory into the local Docker daemon.
+
+    Converts the OCI layout to a Docker-format tarball and pipes it to
+    ``docker load``. This is equivalent to what rules_oci's oci_load does.
+    """
+    index = json.loads((oci_layout / "index.json").read_text())
+    manifest_digest: str = index["manifests"][0]["digest"]
+    manifest_blob = oci_layout / "blobs" / manifest_digest.replace(":", "/")
+    manifest = json.loads(manifest_blob.read_text())
+
+    config_digest: str = manifest["config"]["digest"]
+    config_blob_rel = "blobs/" + config_digest.replace(":", "/")
+    layer_rels = ["blobs/" + layer["digest"].replace(":", "/") for layer in manifest["layers"]]
+
+    docker_manifest = [{"Config": config_blob_rel, "RepoTags": [tag], "Layers": layer_rels}]
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        # Add manifest.json
+        manifest_data = json.dumps(docker_manifest).encode()
+        info = tarfile.TarInfo(name="manifest.json")
+        info.size = len(manifest_data)
+        tar.addfile(info, io.BytesIO(manifest_data))
+        # Add config blob
+        tar.add(oci_layout / config_blob_rel, arcname=config_blob_rel)
+        # Add layer blobs
+        for layer_rel in layer_rels:
+            tar.add(oci_layout / layer_rel, arcname=layer_rel)
+
+    docker = shutil.which("docker") or shutil.which("podman")
+    if not docker:
+        raise RuntimeError("Neither docker nor podman CLI found")
+    buf.seek(0)
+    result = subprocess.run([docker, "load"], input=buf.read(), check=False, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"docker load failed: {result.stderr.decode()}")

--- a/util/crane.py
+++ b/util/crane.py
@@ -119,6 +119,11 @@ def push_to_daemon(oci_layout: Path, tag: str) -> None:
 
     Converts the OCI layout to a Docker-format tarball and pipes it to
     ``docker load``. This is equivalent to what rules_oci's oci_load does.
+
+    TODO: The Docker daemon has no API for loading OCI layouts directly —
+    every path (crane, skopeo, regctl, rules_oci's oci_load) ends up
+    building a Docker-format tarball and piping it to ``docker load``.
+    If Docker ever adds native OCI layout loading, replace this.
     """
     index = json.loads((oci_layout / "index.json").read_text())
     manifest_digest: str = index["manifests"][0]["digest"]

--- a/util/testing/BUILD.bazel
+++ b/util/testing/BUILD.bazel
@@ -26,12 +26,12 @@ py_library(
 py_test(
     name = "test_container_logs",
     srcs = ["test_container_logs.py"],
-    data = ["//third_party/debian_slim:tarball"],
+    data = ["//third_party/containers:debian_slim"],
     requires_docker = True,
     deps = [
         ":container_logs",
         ":undeclared_outputs",
-        "//third_party/debian_slim:rlocations",
+        "//third_party/containers:rlocations",
         "//util:oci",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/util/testing/test_container_logs.py
+++ b/util/testing/test_container_logs.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from third_party.debian_slim.rlocations import IMAGE_TAG as DEBIAN_IMAGE_TAG, TARBALL as DEBIAN_TARBALL
-from util.oci import load_image
+from third_party.containers.rlocations import DEBIAN_SLIM
+from util.oci import load_oci_image
 from util.testing.container_logs import LoggedContainer
 from util.testing.undeclared_outputs import undeclared_outputs_dir
 
@@ -17,8 +17,8 @@ def _logs_dir(test_name: str) -> Path:
 
 def test_logs_collected_on_success() -> None:
     """Verify LoggedContainer persists main process logs on success."""
-    load_image(DEBIAN_TARBALL)
-    with LoggedContainer(DEBIAN_IMAGE_TAG, test_name="logs-success", command="echo SUCCESS_LOG_LINE"):
+    load_oci_image(DEBIAN_SLIM)
+    with LoggedContainer(DEBIAN_SLIM.tag, test_name="logs-success", command="echo SUCCESS_LOG_LINE"):
         pass  # container exits after echo
 
     stdout = _logs_dir("logs-success") / "stdout.log"
@@ -28,10 +28,10 @@ def test_logs_collected_on_success() -> None:
 
 def test_logs_collected_on_exec_failure() -> None:
     """Verify LoggedContainer persists logs even when an assertion fails inside the with block."""
-    load_image(DEBIAN_TARBALL)
+    load_oci_image(DEBIAN_SLIM)
 
     def _run() -> None:
-        with LoggedContainer(DEBIAN_IMAGE_TAG, test_name="logs-failure", command="sleep infinity") as container:
+        with LoggedContainer(DEBIAN_SLIM.tag, test_name="logs-failure", command="sleep infinity") as container:
             container.exec("echo FAILURE_LOG_LINE")
             raise AssertionError("deliberate failure")
 
@@ -44,8 +44,8 @@ def test_logs_collected_on_exec_failure() -> None:
 
 def test_logs_collected_on_container_error() -> None:
     """Verify LoggedContainer persists logs when the container command fails."""
-    load_image(DEBIAN_TARBALL)
-    with LoggedContainer(DEBIAN_IMAGE_TAG, test_name="logs-error", command="bash -c 'echo ERROR_LINE && exit 1'"):
+    load_oci_image(DEBIAN_SLIM)
+    with LoggedContainer(DEBIAN_SLIM.tag, test_name="logs-error", command="bash -c 'echo ERROR_LINE && exit 1'"):
         pass  # container exits immediately with error
 
     stdout = _logs_dir("logs-error") / "stdout.log"


### PR DESCRIPTION
## Summary
This PR refactors the OCI image loading mechanism to use Docker's native `docker load` command instead of crane's daemon push. It introduces a new `OciImage` abstraction to standardize how container images are referenced and loaded across the codebase.

## Key Changes

- **Replaced crane-based image loading**: Changed `push_to_daemon()` in `util/crane.py` to manually construct a Docker-format tarball and pipe it to `docker load`, eliminating the dependency on crane for loading images into the daemon. This approach is equivalent to what `rules_oci`'s `oci_load` does.

- **Introduced OciImage abstraction**: Created a new `OciImage` class to encapsulate image metadata (rlocation path and tag), providing a cleaner API for image references throughout the codebase.

- **Updated image loading API**: Replaced `load_image(tarball_path)` calls with `load_oci_image(oci_image)` that accepts `OciImage` objects, simplifying test setup and reducing string-based configuration.

- **Centralized FreeCAD test image configuration**: Created `skills/freecad/conftest.py` to define `FREECAD_TEST` as a shared constant, eliminating duplicate image tag and path definitions across multiple test files.

- **Consolidated container image references**: Updated all test files to use the new `OciImage` abstraction, removing hardcoded tarball paths and tags in favor of centralized definitions.

- **Reorganized third-party container references**: Migrated Debian image references from `third_party/debian_slim` to `third_party/containers` with the new `DEBIAN_SLIM` `OciImage` constant.

## Implementation Details

- The new `push_to_daemon()` implementation:
  - Parses the OCI layout's index.json and manifest files
  - Constructs a Docker-compatible manifest.json
  - Creates a tarball containing the manifest and all blob files
  - Pipes the tarball to `docker load` (or `podman load` as fallback)
  - Provides better error messages when the load command fails

- Added imports for tarfile, io, and shutil modules to support the new tarball construction logic
- All test fixtures now return `OciImage` objects instead of tuples, improving type safety and readability

https://claude.ai/code/session_01MCoy1gFfhX7NSv7wWeNr2j