### PR TITLE
skills/freecad: remove runtime locale workaround from test

### DIFF
--- a/skills/freecad/test_parametric_sketch.py
+++ b/skills/freecad/test_parametric_sketch.py
@@ -18,7 +18,6 @@ _GOLDEN_DXF = "_main/skills/freecad/golden/bracket.dxf"
 _GOLDEN_SVG = "_main/skills/freecad/golden/bracket.svg"
 _GOLDEN_PDF = "_main/skills/freecad/golden/bracket.pdf"
 
-_ENV = "export LANG=C.UTF-8 LC_ALL=C.UTF-8;"
 _XVFB = 'xvfb-run -a -s \\"-screen 0 1024x768x24\\"'
 
 
@@ -40,10 +39,9 @@ def export_outputs(tmp_path_factory: pytest.TempPathFactory) -> Path:
         ],
         docker_client_kw={"timeout": 120},
     ) as container:
-        freecad_exec(container, f'bash -c "{_ENV} OUTDIR=/output {_XVFB} freecadcmd /work/parametric_sketch.py"')
+        freecad_exec(container, f'bash -c "OUTDIR=/output {_XVFB} freecadcmd /work/parametric_sketch.py"')
         freecad_exec(
-            container,
-            f'bash -c "{_ENV} INPUT=/output/bracket.FCStd OUTDIR=/output {_XVFB} freecadcmd /work/export_page.py"',
+            container, f'bash -c "INPUT=/output/bracket.FCStd OUTDIR=/output {_XVFB} freecadcmd /work/export_page.py"'
         )
 
     return out_dir


### PR DESCRIPTION
## Summary

- Remove per-command `export LANG=C.UTF-8 LC_ALL=C.UTF-8;` prefix from test — the Docker image now sets these at build time

## Test plan

- [x] `bazel test //skills/freecad:test_parametric_sketch` passes on RBE (DXF, SVG, PDF golden)

https://claude.ai/code/session_016B8kx7sTtkSsRJ3Cm1CjwU