### PR TITLE
Add container_logs testing utility dependency to FreeCAD skills

### DIFF
--- a/skills/freecad/BUILD.bazel
+++ b/skills/freecad/BUILD.bazel
@@ -48,6 +48,7 @@ py_library(
     imports = ["../.."],
     deps = [
         "//util:oci",
+        "//util/testing:container_logs",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],


### PR DESCRIPTION
## Summary
Added the `container_logs` testing utility as a dependency to the FreeCAD skills library to support enhanced logging capabilities in tests.

## Changes
- Added `//util/testing:container_logs` dependency to the `py_library` target in `skills/freecad/BUILD.bazel`

## Details
This change enables the FreeCAD skills tests to utilize container logging utilities, which will help with debugging and test output analysis when running tests in containerized environments.

https://claude.ai/code/session_01KGACduMWCfYnJtMa7K7puJ