### PR TITLE
Add claude-token-rotation container image (Bazel OCI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -276,7 +276,9 @@ repos:
             cluster/k8s/agents/claude-sandbox-firecracker/config\.yaml|
             cluster/k8s/litellm/app/proxy-config\.yaml|
             # Helm values files consumed via configMapGenerator, not K8s manifests
-            cluster/k8s/.*/ccm-values\.yaml
+            cluster/k8s/.*/ccm-values\.yaml|
+            # APT manifest for Bazel rules_distroless, not a K8s manifest
+            cluster/k8s/agents/claude-token-rotation/bookworm_token_rotation\.yaml
           )$
         types: [yaml]
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -265,7 +265,14 @@ apt.install(
     lock = "//devinfra/firecracker/vm_pod:bookworm_fc_vm_pod.lock.json",
     manifest = "//devinfra/firecracker/vm_pod:bookworm_fc_vm_pod.yaml",
 )
-use_repo(apt, "bookworm_fc_vm_pod", "trixie_e2e")
+
+# Token rotation image: git + bash on debian:bookworm-slim for SOPS token rotation CronJob.
+apt.install(
+    name = "bookworm_token_rotation",
+    lock = "//cluster/k8s/agents/claude-token-rotation:bookworm_token_rotation.lock.json",
+    manifest = "//cluster/k8s/agents/claude-token-rotation:bookworm_token_rotation.yaml",
+)
+use_repo(apt, "bookworm_fc_vm_pod", "bookworm_token_rotation", "trixie_e2e")
 
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
@@ -694,6 +701,16 @@ http_archive(
     build_file_content = 'exports_files(["gitstatusd-linux-x86_64"])',
     sha256 = "9633816e7832109e530c9e2532b11a1edae08136d63aa7e40246c0339b7db304",
     urls = ["https://github.com/romkatv/gitstatus/releases/download/v1.5.4/gitstatusd-linux-x86_64.tar.gz"],
+)
+
+# sops - Mozilla SOPS binary for age/KMS secret encryption/decryption.
+# Used by the claude-token-rotation CronJob image.
+http_file(
+    name = "sops_linux_amd64",
+    downloaded_file_path = "sops",
+    executable = True,
+    sha256 = "5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85",
+    urls = ["https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64"],
 )
 
 # Adoptium Temurin JDK 21 — provides keytool and cacerts for claude tests.

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -60,6 +60,13 @@ actions:
     steps:
       - run: |
           bazel run --config=rbe --remote_download_toplevel //airlock/auth_proxy:push_ghcr
+  - name: Push //cluster/k8s/agents/claude-token-rotation:push_ghcr
+    triggers: *id001
+    container_image: ubuntu-24.04
+    resource_requests: *id002
+    steps:
+      - run: |
+          bazel run --config=rbe --remote_download_toplevel //cluster/k8s/agents/claude-token-rotation:push_ghcr
   - name: Push //cluster/k8s/inventree/token-provisioner:push_ghcr
     triggers: *id001
     container_image: ubuntu-24.04

--- a/cluster/k8s/agents/claude-token-rotation/BUILD.bazel
+++ b/cluster/k8s/agents/claude-token-rotation/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//devinfra/ghcr_push:push.bzl", "ghcr_push")
+
+# sops binary layer — placed at /usr/local/bin/sops.
+pkg_tar(
+    name = "sops_layer",
+    srcs = ["@sops_linux_amd64//file:sops"],
+    package_dir = "/usr/local/bin",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = ["/bin/bash"],
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [
+        "@bookworm_token_rotation//:flat",
+        ":sops_layer",
+    ],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["claude-token-rotation:latest"],
+)
+
+ghcr_push(
+    name = "push_ghcr",
+    image = ":image",
+    repository = "ghcr.io/agentydragon/claude-token-rotation",
+)

--- a/cluster/k8s/agents/claude-token-rotation/bookworm_token_rotation.lock.json
+++ b/cluster/k8s/agents/claude-token-rotation/bookworm_token_rotation.lock.json
@@ -1,0 +1,952 @@
+{
+  "packages": [
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "git-man_1-2.39.5-0-p-deb12u3_amd64",
+          "name": "git-man",
+          "version": "1:2.39.5-0+deb12u3"
+        },
+        {
+          "key": "liberror-perl_0.17029-2_amd64",
+          "name": "liberror-perl",
+          "version": "0.17029-2"
+        },
+        {
+          "key": "perl_5.36.0-7-p-deb12u3_amd64",
+          "name": "perl",
+          "version": "5.36.0-7+deb12u3"
+        },
+        {
+          "key": "libperl5.36_5.36.0-7-p-deb12u3_amd64",
+          "name": "libperl5.36",
+          "version": "5.36.0-7+deb12u3"
+        },
+        {
+          "key": "perl-modules-5.36_5.36.0-7-p-deb12u3_amd64",
+          "name": "perl-modules-5.36",
+          "version": "5.36.0-7+deb12u3"
+        },
+        {
+          "key": "perl-base_5.36.0-7-p-deb12u3_amd64",
+          "name": "perl-base",
+          "version": "5.36.0-7+deb12u3"
+        },
+        {
+          "key": "dpkg_1.21.22_amd64",
+          "name": "dpkg",
+          "version": "1.21.22"
+        },
+        {
+          "key": "tar_1.34-p-dfsg-1.2-p-deb12u1_amd64",
+          "name": "tar",
+          "version": "1.34+dfsg-1.2+deb12u1"
+        },
+        {
+          "key": "libselinux1_3.4-1-p-b6_amd64",
+          "name": "libselinux1",
+          "version": "3.4-1+b6"
+        },
+        {
+          "key": "libpcre2-8-0_10.42-1_amd64",
+          "name": "libpcre2-8-0",
+          "version": "10.42-1"
+        },
+        {
+          "key": "libc6_2.36-9-p-deb12u13_amd64",
+          "name": "libc6",
+          "version": "2.36-9+deb12u13"
+        },
+        {
+          "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+          "name": "libgcc-s1",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+          "name": "gcc-12-base",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "libacl1_2.3.1-3_amd64",
+          "name": "libacl1",
+          "version": "2.3.1-3"
+        },
+        {
+          "key": "zlib1g_1-1.2.13.dfsg-1_amd64",
+          "name": "zlib1g",
+          "version": "1:1.2.13.dfsg-1"
+        },
+        {
+          "key": "libzstd1_1.5.4-p-dfsg2-5_amd64",
+          "name": "libzstd1",
+          "version": "1.5.4+dfsg2-5"
+        },
+        {
+          "key": "libmd0_1.0.4-2_amd64",
+          "name": "libmd0",
+          "version": "1.0.4-2"
+        },
+        {
+          "key": "liblzma5_5.4.1-1_amd64",
+          "name": "liblzma5",
+          "version": "5.4.1-1"
+        },
+        {
+          "key": "libbz2-1.0_1.0.8-5-p-b1_amd64",
+          "name": "libbz2-1.0",
+          "version": "1.0.8-5+b1"
+        },
+        {
+          "key": "libcrypt1_1-4.4.33-2_amd64",
+          "name": "libcrypt1",
+          "version": "1:4.4.33-2"
+        },
+        {
+          "key": "libgdbm6_1.23-3_amd64",
+          "name": "libgdbm6",
+          "version": "1.23-3"
+        },
+        {
+          "key": "libgdbm-compat4_1.23-3_amd64",
+          "name": "libgdbm-compat4",
+          "version": "1.23-3"
+        },
+        {
+          "key": "libdb5.3_5.3.28-p-dfsg2-1_amd64",
+          "name": "libdb5.3",
+          "version": "5.3.28+dfsg2-1"
+        },
+        {
+          "key": "libexpat1_2.5.0-1-p-deb12u2_amd64",
+          "name": "libexpat1",
+          "version": "2.5.0-1+deb12u2"
+        },
+        {
+          "key": "libcurl3-gnutls_7.88.1-10-p-deb12u14_amd64",
+          "name": "libcurl3-gnutls",
+          "version": "7.88.1-10+deb12u14"
+        },
+        {
+          "key": "libssh2-1_1.10.0-3-p-b1_amd64",
+          "name": "libssh2-1",
+          "version": "1.10.0-3+b1"
+        },
+        {
+          "key": "libssl3_3.0.18-1_deb12u2_amd64",
+          "name": "libssl3",
+          "version": "3.0.18-1~deb12u2"
+        },
+        {
+          "key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_amd64",
+          "name": "librtmp1",
+          "version": "2.4+20151223.gitfa8646d.1-2+b2"
+        },
+        {
+          "key": "libnettle8_3.8.1-2_amd64",
+          "name": "libnettle8",
+          "version": "3.8.1-2"
+        },
+        {
+          "key": "libhogweed6_3.8.1-2_amd64",
+          "name": "libhogweed6",
+          "version": "3.8.1-2"
+        },
+        {
+          "key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+          "name": "libgmp10",
+          "version": "2:6.2.1+dfsg1-1.1"
+        },
+        {
+          "key": "libgnutls30_3.7.9-2-p-deb12u6_amd64",
+          "name": "libgnutls30",
+          "version": "3.7.9-2+deb12u6"
+        },
+        {
+          "key": "libunistring2_1.0-2_amd64",
+          "name": "libunistring2",
+          "version": "1.0-2"
+        },
+        {
+          "key": "libtasn1-6_4.19.0-2-p-deb12u1_amd64",
+          "name": "libtasn1-6",
+          "version": "4.19.0-2+deb12u1"
+        },
+        {
+          "key": "libp11-kit0_0.24.1-2_amd64",
+          "name": "libp11-kit0",
+          "version": "0.24.1-2"
+        },
+        {
+          "key": "libffi8_3.4.4-1_amd64",
+          "name": "libffi8",
+          "version": "3.4.4-1"
+        },
+        {
+          "key": "libidn2-0_2.3.3-1-p-b1_amd64",
+          "name": "libidn2-0",
+          "version": "2.3.3-1+b1"
+        },
+        {
+          "key": "libpsl5_0.21.2-1_amd64",
+          "name": "libpsl5",
+          "version": "0.21.2-1"
+        },
+        {
+          "key": "libnghttp2-14_1.52.0-1-p-deb12u2_amd64",
+          "name": "libnghttp2-14",
+          "version": "1.52.0-1+deb12u2"
+        },
+        {
+          "key": "libldap-2.5-0_2.5.13-p-dfsg-5_amd64",
+          "name": "libldap-2.5-0",
+          "version": "2.5.13+dfsg-5"
+        },
+        {
+          "key": "libsasl2-2_2.1.28-p-dfsg-10_amd64",
+          "name": "libsasl2-2",
+          "version": "2.1.28+dfsg-10"
+        },
+        {
+          "key": "libsasl2-modules-db_2.1.28-p-dfsg-10_amd64",
+          "name": "libsasl2-modules-db",
+          "version": "2.1.28+dfsg-10"
+        },
+        {
+          "key": "libgssapi-krb5-2_1.20.1-2-p-deb12u4_amd64",
+          "name": "libgssapi-krb5-2",
+          "version": "1.20.1-2+deb12u4"
+        },
+        {
+          "key": "libkrb5support0_1.20.1-2-p-deb12u4_amd64",
+          "name": "libkrb5support0",
+          "version": "1.20.1-2+deb12u4"
+        },
+        {
+          "key": "libkrb5-3_1.20.1-2-p-deb12u4_amd64",
+          "name": "libkrb5-3",
+          "version": "1.20.1-2+deb12u4"
+        },
+        {
+          "key": "libkeyutils1_1.6.3-2_amd64",
+          "name": "libkeyutils1",
+          "version": "1.6.3-2"
+        },
+        {
+          "key": "libk5crypto3_1.20.1-2-p-deb12u4_amd64",
+          "name": "libk5crypto3",
+          "version": "1.20.1-2+deb12u4"
+        },
+        {
+          "key": "libcom-err2_1.47.0-2-p-b2_amd64",
+          "name": "libcom-err2",
+          "version": "1.47.0-2+b2"
+        },
+        {
+          "key": "libbrotli1_1.0.9-2-p-b6_amd64",
+          "name": "libbrotli1",
+          "version": "1.0.9-2+b6"
+        }
+      ],
+      "key": "git_1-2.39.5-0-p-deb12u3_amd64",
+      "name": "git",
+      "sha256": "637a85ddd6247fab13bdd0592f2f39aff04ce4dbf0655d3ab553ac359a38ce6f",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/git/git_2.39.5-0+deb12u3_amd64.deb"
+      ],
+      "version": "1:2.39.5-0+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "git-man_1-2.39.5-0-p-deb12u3_amd64",
+      "name": "git-man",
+      "sha256": "904dbd8dbc3db34c6780fb0abfe35816d4a90a490126ef0a055a77a0c5dcab82",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/git/git-man_2.39.5-0+deb12u3_all.deb"
+      ],
+      "version": "1:2.39.5-0+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "liberror-perl_0.17029-2_amd64",
+      "name": "liberror-perl",
+      "sha256": "5a466348531b9c38c8e5ccb18c231f27a98b9fdab61b37ea22592553de5d2ced",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17029-2_all.deb"
+      ],
+      "version": "0.17029-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "perl_5.36.0-7-p-deb12u3_amd64",
+      "name": "perl",
+      "sha256": "afa50ec7d9b1a407cd0187dae033644ef13578d4f3792435e0c41b962ffec0c4",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/perl/perl_5.36.0-7+deb12u3_amd64.deb"
+      ],
+      "version": "5.36.0-7+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libperl5.36_5.36.0-7-p-deb12u3_amd64",
+      "name": "libperl5.36",
+      "sha256": "591903643119c7e1735011369287976eccab1d79b1d2f210760e2138d0a3aa46",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/perl/libperl5.36_5.36.0-7+deb12u3_amd64.deb"
+      ],
+      "version": "5.36.0-7+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "perl-modules-5.36_5.36.0-7-p-deb12u3_amd64",
+      "name": "perl-modules-5.36",
+      "sha256": "3d237ccb1ea32727b6573d43c67d78337aa928a81148d36cef54b369a07c240a",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/perl/perl-modules-5.36_5.36.0-7+deb12u3_all.deb"
+      ],
+      "version": "5.36.0-7+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "perl-base_5.36.0-7-p-deb12u3_amd64",
+      "name": "perl-base",
+      "sha256": "8ec874926e211807cde71e1b0a2311d2534ab3539dffcb2c8553633f542efc1a",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/perl/perl-base_5.36.0-7+deb12u3_amd64.deb"
+      ],
+      "version": "5.36.0-7+deb12u3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "dpkg_1.21.22_amd64",
+      "name": "dpkg",
+      "sha256": "9d97f27d8a8a06dd4800e8e0291337ca02e11cdfd7df09a4566a982a6d9fe4c4",
+      "urls": ["https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/dpkg/dpkg_1.21.22_amd64.deb"],
+      "version": "1.21.22"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "tar_1.34-p-dfsg-1.2-p-deb12u1_amd64",
+      "name": "tar",
+      "sha256": "24fb92e98c2969171f81a8b589263d705f6b1670f95d121cd74c810d4605acc3",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/t/tar/tar_1.34+dfsg-1.2+deb12u1_amd64.deb"
+      ],
+      "version": "1.34+dfsg-1.2+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libselinux1_3.4-1-p-b6_amd64",
+      "name": "libselinux1",
+      "sha256": "2b07f5287b9105f40158b56e4d70cc1652dac56a408f3507b4ab3d061eed425f",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libs/libselinux/libselinux1_3.4-1+b6_amd64.deb"
+      ],
+      "version": "3.4-1+b6"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libpcre2-8-0_10.42-1_amd64",
+      "name": "libpcre2-8-0",
+      "sha256": "030db54f4d76cdfe2bf0e8eb5f9efea0233ab3c7aa942d672c7b63b52dbaf935",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/pcre2/libpcre2-8-0_10.42-1_amd64.deb"
+      ],
+      "version": "10.42-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libc6_2.36-9-p-deb12u13_amd64",
+      "name": "libc6",
+      "sha256": "3d8072c73b017e907bbf44b7db870687888a991961d74f1ecbba6b9458f32a2c",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/glibc/libc6_2.36-9+deb12u13_amd64.deb"
+      ],
+      "version": "2.36-9+deb12u13"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+      "name": "libgcc-s1",
+      "sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+      "name": "gcc-12-base",
+      "sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libacl1_2.3.1-3_amd64",
+      "name": "libacl1",
+      "sha256": "8be9df5795114bfe90e2be3d208ef47a5edd3fc7b3e20d387a597486d444e5e2",
+      "urls": ["https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb"],
+      "version": "2.3.1-3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "zlib1g_1-1.2.13.dfsg-1_amd64",
+      "name": "zlib1g",
+      "sha256": "d7dd1d1411fedf27f5e27650a6eff20ef294077b568f4c8c5e51466dc7c08ce4",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
+      ],
+      "version": "1:1.2.13.dfsg-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libzstd1_1.5.4-p-dfsg2-5_amd64",
+      "name": "libzstd1",
+      "sha256": "6315b5ac38b724a710fb96bf1042019398cb656718b1522279a5185ed39318fa",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_amd64.deb"
+      ],
+      "version": "1.5.4+dfsg2-5"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libmd0_1.0.4-2_amd64",
+      "name": "libmd0",
+      "sha256": "03539fd30c509e27101d13a56e52eda9062bdf1aefe337c07ab56def25a13eab",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libm/libmd/libmd0_1.0.4-2_amd64.deb"
+      ],
+      "version": "1.0.4-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "liblzma5_5.4.1-1_amd64",
+      "name": "liblzma5",
+      "sha256": "d321b9502b16aac534e1c691afbe3dc5e125e5091aa35bea026c59b25ebe82e7",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/x/xz-utils/liblzma5_5.4.1-1_amd64.deb"
+      ],
+      "version": "5.4.1-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libbz2-1.0_1.0.8-5-p-b1_amd64",
+      "name": "libbz2-1.0",
+      "sha256": "54149da3f44b22d523b26b692033b84503d822cc5122fed606ea69cc83ca5aeb",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5+b1_amd64.deb"
+      ],
+      "version": "1.0.8-5+b1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libcrypt1_1-4.4.33-2_amd64",
+      "name": "libcrypt1",
+      "sha256": "f5f60a5cdfd4e4eaa9438ade5078a57741a7a78d659fcb0c701204f523e8bd29",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libx/libxcrypt/libcrypt1_4.4.33-2_amd64.deb"
+      ],
+      "version": "1:4.4.33-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgdbm6_1.23-3_amd64",
+      "name": "libgdbm6",
+      "sha256": "95fe4a1336532450e67bd067892f46eaa484139919ea8d067a9ffcbf5a4bf883",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gdbm/libgdbm6_1.23-3_amd64.deb"
+      ],
+      "version": "1.23-3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgdbm-compat4_1.23-3_amd64",
+      "name": "libgdbm-compat4",
+      "sha256": "4af36a590b68d415a78d9238b932b6a4579f515ec8a8016597498acff5b515a4",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gdbm/libgdbm-compat4_1.23-3_amd64.deb"
+      ],
+      "version": "1.23-3"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libdb5.3_5.3.28-p-dfsg2-1_amd64",
+      "name": "libdb5.3",
+      "sha256": "7dc5127b8dd0da80e992ba594954c005ae4359d839a24eb65d0d8129b5235c84",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-1_amd64.deb"
+      ],
+      "version": "5.3.28+dfsg2-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libexpat1_2.5.0-1-p-deb12u2_amd64",
+      "name": "libexpat1",
+      "sha256": "2255e62fc22a86d2c544b8a3f516da9aee19383ad5742722ab4ce7f66a30dbc8",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/e/expat/libexpat1_2.5.0-1+deb12u2_amd64.deb"
+      ],
+      "version": "2.5.0-1+deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libcurl3-gnutls_7.88.1-10-p-deb12u14_amd64",
+      "name": "libcurl3-gnutls",
+      "sha256": "15431a9d3c3ea95df9f2f77ba300a992ada486e9584edf1e88ffa8be43c0fc17",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/curl/libcurl3-gnutls_7.88.1-10+deb12u14_amd64.deb"
+      ],
+      "version": "7.88.1-10+deb12u14"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libssh2-1_1.10.0-3-p-b1_amd64",
+      "name": "libssh2-1",
+      "sha256": "d20a3ee34fa84ad8bd381e8be6e9c2c2ea32347cff5e1169c10e978d43f54f24",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libs/libssh2/libssh2-1_1.10.0-3+b1_amd64.deb"
+      ],
+      "version": "1.10.0-3+b1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libssl3_3.0.18-1_deb12u2_amd64",
+      "name": "libssl3",
+      "sha256": "ed44f11b74763cded2ad406f4de4d585ea27b0ce6377e7c8d98c2ddf2ed35cb3",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/libssl3_3.0.18-1~deb12u2_amd64.deb"
+      ],
+      "version": "3.0.18-1~deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "librtmp1_2.4-p-20151223.gitfa8646d.1-2-p-b2_amd64",
+      "name": "librtmp1",
+      "sha256": "e1f69020dc2c466e421ec6a58406b643be8b5c382abf0f8989011c1d3df91c87",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b2_amd64.deb"
+      ],
+      "version": "2.4+20151223.gitfa8646d.1-2+b2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libnettle8_3.8.1-2_amd64",
+      "name": "libnettle8",
+      "sha256": "45922e6e289ffd92f0f92d2bb9159e84236ff202d552a461bf10e5335b3f0261",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/nettle/libnettle8_3.8.1-2_amd64.deb"
+      ],
+      "version": "3.8.1-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libhogweed6_3.8.1-2_amd64",
+      "name": "libhogweed6",
+      "sha256": "ed8185c28b2cb519744a5a462dcd720d3b332c9b88a1d0002eac06dc8550cb94",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/nettle/libhogweed6_3.8.1-2_amd64.deb"
+      ],
+      "version": "3.8.1-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgmp10_2-6.2.1-p-dfsg1-1.1_amd64",
+      "name": "libgmp10",
+      "sha256": "187aedef2ed763f425c1e523753b9719677633c7eede660401739e9c893482bd",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg1-1.1_amd64.deb"
+      ],
+      "version": "2:6.2.1+dfsg1-1.1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgnutls30_3.7.9-2-p-deb12u6_amd64",
+      "name": "libgnutls30",
+      "sha256": "10deacd86b6113c0cd679491aaf7b3416365ef407e56fe93d6009710a08811de",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/g/gnutls28/libgnutls30_3.7.9-2+deb12u6_amd64.deb"
+      ],
+      "version": "3.7.9-2+deb12u6"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libunistring2_1.0-2_amd64",
+      "name": "libunistring2",
+      "sha256": "d466bbfe011d764d793c1d9d777cad9c7cf65b938e11598f27408171ad95a951",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libu/libunistring/libunistring2_1.0-2_amd64.deb"
+      ],
+      "version": "1.0-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libtasn1-6_4.19.0-2-p-deb12u1_amd64",
+      "name": "libtasn1-6",
+      "sha256": "2c27c613b69be248d09432839ea3d3382f6ee27fabaa65987aa2d884cd00afda",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/libt/libtasn1-6/libtasn1-6_4.19.0-2+deb12u1_amd64.deb"
+      ],
+      "version": "4.19.0-2+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libp11-kit0_0.24.1-2_amd64",
+      "name": "libp11-kit0",
+      "sha256": "251330faddbf013f060fcdb41f4b0c037c8a6e89ba7c09b04bfcc4e3f0807b22",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/p11-kit/libp11-kit0_0.24.1-2_amd64.deb"
+      ],
+      "version": "0.24.1-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libffi8_3.4.4-1_amd64",
+      "name": "libffi8",
+      "sha256": "6d9f6c25c30efccce6d4bceaa48ea86c329a3432abb360a141f76ac223a4c34a",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libf/libffi/libffi8_3.4.4-1_amd64.deb"
+      ],
+      "version": "3.4.4-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libidn2-0_2.3.3-1-p-b1_amd64",
+      "name": "libidn2-0",
+      "sha256": "d50716d5824083d667427817d506b45d3f59dc77e1ca52de000f3f62d4918afa",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libi/libidn2/libidn2-0_2.3.3-1+b1_amd64.deb"
+      ],
+      "version": "2.3.3-1+b1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libpsl5_0.21.2-1_amd64",
+      "name": "libpsl5",
+      "sha256": "4f0d35610204e4e754b057748719744114621f2f6f4202d846c314860a981afb",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libp/libpsl/libpsl5_0.21.2-1_amd64.deb"
+      ],
+      "version": "0.21.2-1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libnghttp2-14_1.52.0-1-p-deb12u2_amd64",
+      "name": "libnghttp2-14",
+      "sha256": "dbe3eb8c831e654ac7d5cf045d605d53fd763e8ebc238607c25f301996103bb9",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/nghttp2/libnghttp2-14_1.52.0-1+deb12u2_amd64.deb"
+      ],
+      "version": "1.52.0-1+deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libldap-2.5-0_2.5.13-p-dfsg-5_amd64",
+      "name": "libldap-2.5-0",
+      "sha256": "4b6c30f6554149c594628d945edc6003f0eea8d0cc1341638c0e71375db147ed",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb"
+      ],
+      "version": "2.5.13+dfsg-5"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libsasl2-2_2.1.28-p-dfsg-10_amd64",
+      "name": "libsasl2-2",
+      "sha256": "11ee190ad39f8d7af441d2c8347388b9449434c73acc67b4b372445ac4152efa",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg-10_amd64.deb"
+      ],
+      "version": "2.1.28+dfsg-10"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libsasl2-modules-db_2.1.28-p-dfsg-10_amd64",
+      "name": "libsasl2-modules-db",
+      "sha256": "3ac4fd6cbe3b3b06e68d24b931bf3eb9385b42f15604a37ed25310e948ca0ee6",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg-10_amd64.deb"
+      ],
+      "version": "2.1.28+dfsg-10"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgssapi-krb5-2_1.20.1-2-p-deb12u4_amd64",
+      "name": "libgssapi-krb5-2",
+      "sha256": "ae20a9d90d0998ccb062a42739c8c5c725579e2d3f44fbd16b026e336b4543bb",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u4_amd64.deb"
+      ],
+      "version": "1.20.1-2+deb12u4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libkrb5support0_1.20.1-2-p-deb12u4_amd64",
+      "name": "libkrb5support0",
+      "sha256": "5e7fac690530a3e16c0a6707d8262d869c23248eac72daee3eb7c40982c3ddfe",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/k/krb5/libkrb5support0_1.20.1-2+deb12u4_amd64.deb"
+      ],
+      "version": "1.20.1-2+deb12u4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libkrb5-3_1.20.1-2-p-deb12u4_amd64",
+      "name": "libkrb5-3",
+      "sha256": "af14ab652a7e8579c67c846dd95b987a4332c05165c8eec9790028f5aea6c2b0",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/k/krb5/libkrb5-3_1.20.1-2+deb12u4_amd64.deb"
+      ],
+      "version": "1.20.1-2+deb12u4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libkeyutils1_1.6.3-2_amd64",
+      "name": "libkeyutils1",
+      "sha256": "cfac89e6a7a54ff3c6a4f843310e25efeddaa771baeae470bd98bd588c373563",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/k/keyutils/libkeyutils1_1.6.3-2_amd64.deb"
+      ],
+      "version": "1.6.3-2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libk5crypto3_1.20.1-2-p-deb12u4_amd64",
+      "name": "libk5crypto3",
+      "sha256": "b921355ee030582117aadd95a9f08de341867921a277803ae7e520be2ac9786d",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/k/krb5/libk5crypto3_1.20.1-2+deb12u4_amd64.deb"
+      ],
+      "version": "1.20.1-2+deb12u4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libcom-err2_1.47.0-2-p-b2_amd64",
+      "name": "libcom-err2",
+      "sha256": "a2bac7015e78fbc0c504df3e441f3a22292f1d2d77f9ccda760057f3690e22f2",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2+b2_amd64.deb"
+      ],
+      "version": "1.47.0-2+b2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libbrotli1_1.0.9-2-p-b6_amd64",
+      "name": "libbrotli1",
+      "sha256": "563b4caec1aa5e876bd3355b36e7a38e1484baf5a293b48d1e8bd22db786e4d7",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b6_amd64.deb"
+      ],
+      "version": "1.0.9-2+b6"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "debianutils_5.7-0.5_deb12u1_amd64",
+          "name": "debianutils",
+          "version": "5.7-0.5~deb12u1"
+        },
+        {
+          "key": "libc6_2.36-9-p-deb12u13_amd64",
+          "name": "libc6",
+          "version": "2.36-9+deb12u13"
+        },
+        {
+          "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+          "name": "libgcc-s1",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+          "name": "gcc-12-base",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "base-files_12.4-p-deb12u13_amd64",
+          "name": "base-files",
+          "version": "12.4+deb12u13"
+        },
+        {
+          "key": "mawk_1.3.4.20200120-3.1_amd64",
+          "name": "mawk",
+          "version": "1.3.4.20200120-3.1"
+        },
+        {
+          "key": "libtinfo6_6.4-4_amd64",
+          "name": "libtinfo6",
+          "version": "6.4-4"
+        }
+      ],
+      "key": "bash_5.2.15-2-p-b10_amd64",
+      "name": "bash",
+      "sha256": "be3ab2fd057cb9a29e733d0d8c2b867468731d99af2ce62a63ec6a6c7928572f",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/b/bash/bash_5.2.15-2+b10_amd64.deb"
+      ],
+      "version": "5.2.15-2+b10"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "debianutils_5.7-0.5_deb12u1_amd64",
+      "name": "debianutils",
+      "sha256": "55f951359670eb3236c9e2ccd5fac9ccb3db734f5a22aff21589e7a30aee48c9",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/debianutils/debianutils_5.7-0.5~deb12u1_amd64.deb"
+      ],
+      "version": "5.7-0.5~deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "base-files_12.4-p-deb12u13_amd64",
+      "name": "base-files",
+      "sha256": "d0aee30a91b1283e0c724e9ad0ae7394d8e56f07d20cacfcb79b8f444daa94cd",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/b/base-files/base-files_12.4+deb12u13_amd64.deb"
+      ],
+      "version": "12.4+deb12u13"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "mawk_1.3.4.20200120-3.1_amd64",
+      "name": "mawk",
+      "sha256": "bcbc83f391854ea9d50ce2a4101aacf330de3b8b71d81a798faadba14a157f78",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/m/mawk/mawk_1.3.4.20200120-3.1_amd64.deb"
+      ],
+      "version": "1.3.4.20200120-3.1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libtinfo6_6.4-4_amd64",
+      "name": "libtinfo6",
+      "sha256": "072d908f38f51090ca28ca5afa3b46b2957dc61fe35094c0b851426859a49a51",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
+      ],
+      "version": "6.4-4"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "debconf_1.5.82_amd64",
+          "name": "debconf",
+          "version": "1.5.82"
+        },
+        {
+          "key": "openssl_3.0.18-1_deb12u2_amd64",
+          "name": "openssl",
+          "version": "3.0.18-1~deb12u2"
+        },
+        {
+          "key": "libssl3_3.0.18-1_deb12u2_amd64",
+          "name": "libssl3",
+          "version": "3.0.18-1~deb12u2"
+        },
+        {
+          "key": "libc6_2.36-9-p-deb12u13_amd64",
+          "name": "libc6",
+          "version": "2.36-9+deb12u13"
+        },
+        {
+          "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+          "name": "libgcc-s1",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+          "name": "gcc-12-base",
+          "version": "12.2.0-14+deb12u1"
+        }
+      ],
+      "key": "ca-certificates_20230311-p-deb12u1_amd64",
+      "name": "ca-certificates",
+      "sha256": "0d5f444f594e48c1e16a41d8fc628a09b24c658916a1274025c2330f2a802bed",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/ca-certificates/ca-certificates_20230311+deb12u1_all.deb"
+      ],
+      "version": "20230311+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "debconf_1.5.82_amd64",
+      "name": "debconf",
+      "sha256": "74ab14194a3762b2fc717917dcfda42929ab98e3c59295a063344dc551cd7cc8",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/debconf/debconf_1.5.82_all.deb"
+      ],
+      "version": "1.5.82"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl_3.0.18-1_deb12u2_amd64",
+      "name": "openssl",
+      "sha256": "9107c374e0f760d5d7c9c7372788d4e618e1433db4fdef9a3a25788dfd5588bb",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl_3.0.18-1~deb12u2_amd64.deb"
+      ],
+      "version": "3.0.18-1~deb12u2"
+    }
+  ],
+  "version": 1
+}

--- a/cluster/k8s/agents/claude-token-rotation/bookworm_token_rotation.yaml
+++ b/cluster/k8s/agents/claude-token-rotation/bookworm_token_rotation.yaml
@@ -1,0 +1,20 @@
+# Deb packages for the claude-token-rotation CronJob image.
+# Git + bash on debian:bookworm-slim for cloning, committing, and pushing.
+#
+# Regenerate the lock file after any change:
+#   bazel run @bookworm_token_rotation//:lock
+version: 1
+
+sources:
+  - channel: bookworm main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: bookworm-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "git"
+  - "bash"
+  - "ca-certificates"

--- a/cluster/validation/cluster.py
+++ b/cluster/validation/cluster.py
@@ -13,6 +13,13 @@ from cluster.validation.kustomize import KustomizeBuildResult, KustomizeFile, pa
 
 _K8S_SUBPATH = Path("cluster/k8s")
 
+# Non-K8s YAML files that live under cluster/k8s/ but aren't manifests.
+# Excluded from orphan detection and resource parsing.
+_EXCLUDED_FILES = {
+    # rules_distroless APT manifest for the token rotation image
+    "agents/claude-token-rotation/bookworm_token_rotation.yaml"
+}
+
 
 @dataclass
 class ParsedCluster:
@@ -71,6 +78,14 @@ def parse_cluster(k8s_dir: Path) -> ParsedCluster:
 
         # Skip blueprints directory (Authentik-specific YAML with !Env tags, not K8s resources)
         if "blueprints" in yaml_file.parts:
+            continue
+
+        # Skip explicitly excluded non-K8s files
+        try:
+            rel = yaml_file.relative_to(k8s_dir)
+        except ValueError:
+            rel = None
+        if rel and str(rel) in _EXCLUDED_FILES:
             continue
 
         all_yaml_files.add(yaml_file.resolve())

--- a/devinfra/ci/generate_buildbuddy.py
+++ b/devinfra/ci/generate_buildbuddy.py
@@ -29,6 +29,7 @@ HEADER = """\
 PUSH_TARGETS = [
     BazelLabel.parse("//airlock:push_ghcr"),
     BazelLabel.parse("//airlock/auth_proxy:push_ghcr"),
+    BazelLabel.parse("//cluster/k8s/agents/claude-token-rotation:push_ghcr"),
     BazelLabel.parse("//cluster/k8s/inventree/token-provisioner:push_ghcr"),
     BazelLabel.parse("//devinfra/firecracker/manager:push_ghcr"),
     BazelLabel.parse("//devinfra/firecracker/vm_pod:push_ghcr"),


### PR DESCRIPTION
## Summary

- Minimal `debian-slim` image with `git`, `bash`, `ca-certificates` (hermetic APT via `rules_distroless`) and `sops` binary (`http_file`) for the in-cluster CronJob that will rotate the Claude web K8s token
- `oci_image` + `ghcr_push` target — BuildBuddy CI pushes to `ghcr.io/agentydragon/claude-token-rotation`
- APT manifest YAML exclusions added to kubeconform and cluster validator (not K8s resources)

Replaces the original Dockerfile + GH Actions workflow approach.

## Test plan

- [ ] `bazel build //cluster/k8s/agents/claude-token-rotation:image` passes
- [ ] After merge, BuildBuddy pushes image to GHCR

https://claude.ai/code/session_01LTe4mq1eTWPPesrJNph5o2