### PR TITLE
Add K8s Secret for Harbor CI robot credentials

### DIFF
--- a/cluster/terraform/gitops/harbor-ci/main.tf
+++ b/cluster/terraform/gitops/harbor-ci/main.tf
@@ -140,6 +140,19 @@ resource "vault_kv_secret_v2" "harbor_ci_robot" {
   })
 }
 
+# K8s Secret for consumers that don't need Vault (e.g., github-secrets-sync).
+resource "kubernetes_secret" "harbor_ci_robot" {
+  metadata {
+    name      = "harbor-ci-robot"
+    namespace = "flux-system"
+  }
+
+  data = {
+    username = harbor_robot_account.ci.full_name
+    password = harbor_robot_account.ci.secret
+  }
+}
+
 resource "vault_kv_secret_v2" "harbor_pull_robot" {
   mount = "kv"
   name  = "harbor/pull-robot"


### PR DESCRIPTION
## Summary

- `harbor-ci` TF module now also creates a `kubernetes_secret` (`harbor-ci-robot` in `flux-system`) alongside the existing Vault KV entry
- Enables consumers like `github-secrets-sync` to read Harbor CI robot credentials directly from K8s instead of requiring a Vault provider

## Test plan

- [ ] `bazel build //cluster/terraform/gitops/harbor-ci` passes
- [ ] After deploy, verify `kubectl get secret harbor-ci-robot -n flux-system` exists with `username` and `password` keys
- [ ] `github-secrets-sync` can be updated to read from K8s instead of Vault (follow-up)

https://claude.ai/code/session_01LTe4mq1eTWPPesrJNph5o2