### PR TITLE
Wire up Flux image automation for claude-token-rotation

### DIFF
--- a/cluster/k8s/flux-image-automation/claude-token-rotation-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation/claude-token-rotation-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: claude-token-rotation
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: claude-token-rotation
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation/claude-token-rotation-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation/claude-token-rotation-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: claude-token-rotation
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/claude-token-rotation
+  interval: 5m

--- a/cluster/k8s/flux-image-automation/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation/kustomization.yaml
@@ -22,3 +22,5 @@ resources:
   - tana-token-broker-image-policy.yaml
   - token-provisioner-image-repository.yaml
   - token-provisioner-image-policy.yaml
+  - claude-token-rotation-image-repository.yaml
+  - claude-token-rotation-image-policy.yaml


### PR DESCRIPTION
## Summary

- `ImageRepository` scans `ghcr.io/agentydragon/claude-token-rotation` every 5m
- `ImagePolicy` selects `devel-*` tags (alphabetical == chronological)
- `ImageUpdateAutomation` will auto-update the CronJob image tag once it lands

## Test plan

- [ ] After merge, verify `kubectl get imagerepository claude-token-rotation -n flux-system`
- [ ] After first image push, verify `kubectl get imagepolicy claude-token-rotation -n flux-system` shows a selected tag

https://claude.ai/code/session_01LTe4mq1eTWPPesrJNph5o2