### PR TITLE
Rotate github-secrets-sync PAT (contents:write added)

### DIFF
--- a/cluster/k8s/github-secrets-sync/secrets/github-secrets-sync-pat.sops.yaml
+++ b/cluster/k8s/github-secrets-sync/secrets/github-secrets-sync-pat.sops.yaml
@@ -11,28 +11,28 @@ metadata:
     reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: default
 type: Opaque
 stringData:
-  token: ENC[AES256_GCM,data:gHOI5OcvqhIcQ3i+YDsgoMAiyGnc7Ny53ZqPKeBNG3AHSfkR9jFlAxqcrEhWBw8/oyTIXNZ/DrNtLH9LDR7T/jCc0j8ix9nGB5wQYE/IRBgJ88r2lbBOW62qZA4I,iv:BDdN3d6ta6F/exmXX1FVDWHFrNsYgz855cL7pUwgdFU=,tag:tzzzybbvMhd/l8QRsY9kAg==,type:str]
+  token: ENC[AES256_GCM,data:Tmnit6ry4ydAdY4wkIlmqVe8e7dffOJvjwuEjT6bJUgfCm+dp/joqTVOiaAexxdELcDiJ49NA1gHQ8UWFIeylmGgmeEFc0NHKXb/ytYAB+B2+Qa7IVHO9dySG3ae,iv:VCFzf6xE38cG4JwDZfsTxoRfbI4ONUWPdXC9By/i29Y=,tag:A258j2mTQVIvyP2bP4c/IA==,type:str]
 sops:
   age:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIYWFHV0ZiZmhXbldqUzZt
-        OGVxNEQ1SnFqQUdPRHJVWkJ0dkc0bVZTc2drCksrZFJHMlFVZDBMMWdzRWkxRnNh
-        dUtZRDVHQ2xWN3hVSnBSMHhsbmpoS1UKLS0tIDlDVytXMGJyazVTZG56YTBweHgr
-        TldMTmZDbC9ab0lWQlBJTytNN3BBTDAKDAK/CeVFD3u1WhRB3PzgsCEqqRT/zrfS
-        3Az2xoveu1sI8rojjRSEOWe+6GR28yH94X/wS1+dnYTTCX+rX7FLdA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrblh6eXJOS3piZ3BxdlE1
+        bnZ2bUNUbWdCUWlaMk9mQWxMZWYvcWxuYjJBCm43dU4razBYQjIzMTRnaTEwdlJn
+        TWFKNXEvS2NtYmRLeE85cWY0N3drOVUKLS0tIGNFWUtCZWw0N0piYUI0SFh4bi9K
+        M2JHOUdoTStQajRINmh2eE95bnFGd2cKyDKCCdqMF+CGjN+/Kvlmp8QlNJ8Fp+kk
+        XrNuVEzGdsiGSeII0VS1q7jsKUNy78yyY/BpIrIUZH56UAyXtjxLwQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhRlpXZDlBYmVidHRMaUs3
-        Y2t0V0s2NHVxTjBJaExOK2w1NjRRU1ZuYUhNCndlbDZIbm5aRmdzblZLeGUwa3E3
-        TFlqcm9qb25MTnVFbFIzeWVBYzFOUEkKLS0tIE9rTTVwRkMyMnBPNnpQZlJyVG9K
-        T3hZSzBOcmRUaEdjR0ZSTzNycnJOVXcK9EF0XEv/mZYxtFMpVa/8K5ijSj9A7NP5
-        JHknMFUfg0ijHvDRIJhwS2suiixFgKeAjgjRCbRGLbFr4+xvwbR0UQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpRGtVajd0VUpuSXkxSzE1
+        WXJrc245dDlPbFR6ZzRZTFRLc2s0aUdmWFhZCkFLU0FwUmV0ZVUybndOcEFTanZR
+        MUR0NzExMmlHbzdsc1J6WjIxT3p5WG8KLS0tICs0VkxhNFZXSTNFTzYvZ0NLOXhZ
+        NnhvNFh5ZmZqT1E2Mlg4TEFTZElEV3cKjuzV/mpk4hpWYSx5LAF1RPJuAwdQGoUK
+        ABfimNey6rM1n+QUZy7ad1FQZ0nfl7T/MEH4JXzwIu804VINtu2KJg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-05T22:08:58Z"
-  mac: ENC[AES256_GCM,data:aHA1qhwoum9jjsqL5NL8UH7xWbyRLKA3R3SAfu/qPW9xmhdtsg/90ars9rA/9/iRX2gwmPR0Wjk5dBlUYfKUkJAFb7yl/Eh9BBZFzVB0TsdMWq35G/JJXMQENerZm8m3AeOB3Q27NAuofWPNRl24nkc9MOd5wOp8MzG471vvcCo=,iv:o513bc7Xsu6wVKzLMxUNPMO6JBF1QQS9QIDAR/jWM10=,tag:UGkqIMjIAGqQCelS1gkZQA==,type:str]
+  lastmodified: "2026-04-06T00:00:39Z"
+  mac: ENC[AES256_GCM,data:4crVqQ2DKbcvzTajI7CHa6/KmrruLGkoRhitvlJ0NFoo26goA5NiN43crytEmVtQMhYITRsfc6qSiWjq/gxLZjIImS16Z55gPIOIRGDPpJe37WjGQDFZxxTVy7wXIRqBjxHwhr1kktD5r/rGjFRQYf9nRO3nPMHsRqDkygi9bs8=,iv:spUu15fkxkPebelm8pkG8G6rZWIIvtZdMmXmYEvXwWY=,tag:LEa68X5ZSNCopLVlNwN7Rw==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.12.1


### PR DESCRIPTION
## Summary

- Re-encrypt `github-secrets-sync-pat` with new PAT that has `contents:write` scope (needed for the token rotation CronJob to git push)

## Test plan

- [ ] After merge, verify `kubectl get secret github-secrets-sync-pat -n flux-system` has the updated token
- [ ] Verify Reflector mirrors it to `default` namespace

https://claude.ai/code/session_01LTe4mq1eTWPPesrJNph5o2