### PR TITLE
Fix OCI layout accessibility in tests by including transitive files

### DIFF
--- a/devinfra/oci/defs.bzl
+++ b/devinfra/oci/defs.bzl
@@ -7,8 +7,14 @@ def _oci_layout_rloc_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name + ".rloc")
     ctx.actions.write(out, to_rlocation_path(ctx, ctx.file.image))
 
-    # Merge image runfiles so the OCI layout files are accessible in tests.
-    runfiles = ctx.runfiles([out]).merge(ctx.attr.image[DefaultInfo].default_runfiles)
+    # Include the image tree artifact and its runfiles so the OCI layout is
+    # accessible in tests. Locally-built oci_image targets place the image
+    # directory only in DefaultInfo.files, not default_runfiles, so we must
+    # add it via transitive_files.
+    runfiles = ctx.runfiles(
+        [out],
+        transitive_files = ctx.attr.image[DefaultInfo].files,
+    ).merge(ctx.attr.image[DefaultInfo].default_runfiles)
     return [DefaultInfo(files = depset([out]), runfiles = runfiles)]
 
 _oci_layout_rloc = rule(


### PR DESCRIPTION
## Summary
Fixed an issue where OCI layout files were not accessible in tests when using locally-built `oci_image` targets. The problem was that these targets place the image directory only in `DefaultInfo.files` rather than `default_runfiles`.

## Key Changes
- Modified `_oci_layout_rloc_impl` to include `transitive_files` from the image's `DefaultInfo.files` when constructing runfiles
- Updated the runfiles construction to explicitly pass the image tree artifact via `transitive_files` parameter
- Enhanced comments to clarify why both `transitive_files` and `default_runfiles` are needed

## Implementation Details
The fix ensures that locally-built OCI image directories are properly included in the runfiles by:
1. Adding `transitive_files = ctx.attr.image[DefaultInfo].files` to the `ctx.runfiles()` call
2. Still merging `default_runfiles` to maintain compatibility with other image target types
3. This dual approach handles both image targets that use `default_runfiles` and those that only expose files via `DefaultInfo.files`

https://claude.ai/code/session_013hyNtXkedMwmpxU3fX7kqw