### PR TITLE
feat(rbe): add xvfb + fuse to RBE worker image; document Docker proxy behavior

### DIFF
--- a/devinfra/claude/docs/docker_evaluation_results.md
+++ b/devinfra/claude/docs/docker_evaluation_results.md
@@ -97,14 +97,30 @@ docker build --network=host -t image-name .
 ### 🔍 Needs Investigation (RESOLVED)
 
 1. **~~DNS in build containers~~** - SOLVED
-   - Initial error: `DNS: transient error (try again later)`
-   - Root cause: TLS certificate trust issue, not DNS
-   - The TLS-inspecting egress proxy injects its own certificate
-   - Alpine's apk reports "DNS error" when TLS validation fails (misleading)
-   - Solution: Use `apk --no-check-certificate` for builds
-   - Test: `RUN apk --no-check-certificate add curl` - PASSED
-   - Proxy environment variables work: `http_proxy`, `https_proxy` are respected
-   - For production: Would inject combined CA bundle into base images
+   - Initial error: `DNS: transient error (try again later)` / `Temporary failure resolving 'archive.ubuntu.com'`
+   - Root cause: the TLS-inspecting egress proxy intercepts outbound connections; containers don't have the proxy's CA cert and can't authenticate
+   - Alpine `apk` reports "DNS error" when TLS validation fails (misleading error message)
+   - Ubuntu `apt-get` reports "Temporary failure resolving" for the same reason
+   - **Solution for docker build**: pass proxy env vars as build args — BuildKit forwards them automatically to RUN steps:
+     ```bash
+     docker build --network=host \
+       --build-arg HTTP_PROXY="$HTTP_PROXY" \
+       --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
+       --build-arg http_proxy="$http_proxy" \
+       --build-arg https_proxy="$https_proxy" \
+       -f Dockerfile .
+     ```
+     The Dockerfile does NOT need `ARG HTTP_PROXY` — BuildKit's predefined proxy ARGs are forwarded automatically.
+   - **Solution for docker run**: pass proxy env vars with `-e`:
+     ```bash
+     docker run --rm --network=host \
+       -e http_proxy="$http_proxy" \
+       -e https_proxy="$https_proxy" \
+       ubuntu:24.04 apt-get update
+     ```
+   - Note: `--build-arg` and `-e` work differently. `--build-arg` in docker build sets build-time variables handled by BuildKit. `-e` in docker run sets runtime environment variables. For `docker build`, use `--build-arg`; for `docker run`, use `-e`.
+   - Alpine solution: `apk --no-check-certificate add ...` (skips TLS) — works but bypasses cert validation
+   - Ubuntu `apt-get` solution: pass proxy env vars via `--build-arg` as above
 
 2. **Keyring quota**
    - Haven't tested 100+ layers yet (hit overlay limit first at 35)

--- a/devinfra/rbe_image/Dockerfile
+++ b/devinfra/rbe_image/Dockerfile
@@ -36,6 +36,12 @@ RUN sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.li
         # qemu-system-x86: QEMU emulator + firmware/BIOS for integration tests
         # (TCG software emulation, no KVM needed)
         qemu-system-x86 \
+        # xvfb: virtual framebuffer for headless GUI tests (e.g. FreeCAD 3D rendering with OpenGL)
+        xvfb \
+        # fuse3 + libfuse2: AppImage FUSE mounting (AppImages fall back to extraction without
+        # fusermount, but FUSE mounting avoids tmpfs write overhead on every run)
+        fuse3 \
+        libfuse2 \
         # Chromium headless shell shared library dependencies
         libasound2t64 \
         libatk-bridge2.0-0t64 \


### PR DESCRIPTION
## Summary

- **`devinfra/rbe_image/Dockerfile`**: add `xvfb` (required for FreeCAD TechDraw HLR rendering — the HLR thread needs OpenGL, which the `offscreen` Qt platform doesn't provide; `xvfb-run` gives it a virtual X11/OpenGL context), and `fuse3`/`libfuse2` (for AppImage FUSE mounting, avoiding tmpfs write overhead on every run)
- **`devinfra/claude/docs/docker_evaluation_results.md`**: document that apparent "DNS errors" in Docker build/run containers are actually caused by the TLS-inspecting egress proxy; fix requires `--build-arg HTTP_PROXY/HTTPS_PROXY` for `docker build` and `-e http_proxy/https_proxy` for `docker run`

## Why

FreeCAD's TechDraw HLR (Hidden Line Removal) thread requires an OpenGL context. When running `freecadcmd` with `QT_QPA_PLATFORM=offscreen`, Qt doesn't provide an OpenGL-capable context → the HLR thread hangs indefinitely → 120s test timeout. Using `xvfb-run -a freecadcmd` provides a virtual X11 display with OpenGL support, matching the pattern already used in `test_bearing_block.py`.

## Test plan

- [ ] CI builds and pushes new RBE image on merge to `devel`
- [ ] CI auto-updates `image_pins.json` with new digest (`chore: update rbe image [skip ci]` commit)
- [ ] After pin update, FreeCAD tests (`test_parametric_sketch`, `test_compound`) pass on RBE with `xvfb-run`

https://claude.ai/code/session_015up5iYtuUGEhTg7ihjshrG