### PR TITLE
Fix YAML formatting and add bech32 dependency

### DIFF
--- a/cluster/k8s/monitoring/loki/minio-credentials.sops.yaml
+++ b/cluster/k8s/monitoring/loki/minio-credentials.sops.yaml
@@ -1,35 +1,35 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: minio-credentials
-    namespace: loki
-    annotations:
-        description: MinIO credentials for Loki chunk/index storage
+  name: minio-credentials
+  namespace: loki
+  annotations:
+    description: MinIO credentials for Loki chunk/index storage
 type: Opaque
 stringData:
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:qqh8hA06OqBW9+umqnlgQg==,iv:W+riwDKKz5SalGlr21tT0iBzTIJ/GIeczwQu7tJE5Qw=,tag:vqDE/6IAzVkdbytRT4SX0w==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:NBkphjN9vuXlRmGPtrdcyrraFhwtbbFAf6+7EJQS42A20NdBDuUnFJiEzA==,iv:Qola12GT4iZnwnS5O/AsNhzXpa9f0kx6UV3tVo5MxEM=,tag:iUcRJ2qB99bN/bJe8ZYWNg==,type:str]
+  AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:qqh8hA06OqBW9+umqnlgQg==,iv:W+riwDKKz5SalGlr21tT0iBzTIJ/GIeczwQu7tJE5Qw=,tag:vqDE/6IAzVkdbytRT4SX0w==,type:str]
+  AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:NBkphjN9vuXlRmGPtrdcyrraFhwtbbFAf6+7EJQS42A20NdBDuUnFJiEzA==,iv:Qola12GT4iZnwnS5O/AsNhzXpa9f0kx6UV3tVo5MxEM=,tag:iUcRJ2qB99bN/bJe8ZYWNg==,type:str]
 sops:
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SkVxMzJoUjN0SDVRUkp6
-            STlhNCtvaVZTRlRUQnAzRS9QR0NBWHE0bkE4Ckl1R3NUV1MwOG05eEdUS2ZySFg2
-            cFc0aVBEaFNCajlIeDd4Z2FNYVhxTlUKLS0tIE9tYzN1NFBVdjBJdFppQXo0NUhz
-            MGpKV1hGMDQ5OFRZUWcxdzJobGRmR0kK6HyY7LV9gihQDIrXNk4Jb5VRTgmLKtLX
-            fkvbdbNknz30Q4by6REu/lNTadmdfLZhYxZwNGy10Cae+Dsey/0kQg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoS2xzWTdVdzk5QjFrYld4
-            b3BIa0l4STZoT3VxZ1NuRmlXbFJHMnFpY2o0CmU2VWkrYWpZS1N6clFqclo2VEpn
-            d1NkOWVXc2JsaXB3ZFVGNm5TZkp0SHcKLS0tIGI1bldiYkkzbmxUdEZuWFR6eXMw
-            aFUyT1NYWkZqZUtkSEhtcElUd2s5VWsKqplqhoHK4tvU84HAXS+0hF4wFsEm6rlZ
-            tpOqTQzY3MSJbEJzu8AgL464AW5nmapK485BvM4FZkIzAHX2+dhPAw==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-06T05:12:58Z"
-    mac: ENC[AES256_GCM,data:iAQ2Ah8d6yadzp9bktVgUZjU5eqspKAcWuaFKE0CMERuYU1yzg2Mw+QtmIdy87EJ10ykXgidSjKBlmzFnB80fNpRBLzRmy+RQPDVLBOdv6OkS+hNr4/MJAMRd9dcmmsGu2nWlzBr2uc3RKRujwISwvfCnt0GnF8eMHM0nClrzbg=,iv:OC+EnP7FxrJ0b5LbjWQce4Jfdfi6Yz9K9uBf3DVQGac=,tag:pPzM88ABpHVGkswVDBYfnA==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SkVxMzJoUjN0SDVRUkp6
+        STlhNCtvaVZTRlRUQnAzRS9QR0NBWHE0bkE4Ckl1R3NUV1MwOG05eEdUS2ZySFg2
+        cFc0aVBEaFNCajlIeDd4Z2FNYVhxTlUKLS0tIE9tYzN1NFBVdjBJdFppQXo0NUhz
+        MGpKV1hGMDQ5OFRZUWcxdzJobGRmR0kK6HyY7LV9gihQDIrXNk4Jb5VRTgmLKtLX
+        fkvbdbNknz30Q4by6REu/lNTadmdfLZhYxZwNGy10Cae+Dsey/0kQg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoS2xzWTdVdzk5QjFrYld4
+        b3BIa0l4STZoT3VxZ1NuRmlXbFJHMnFpY2o0CmU2VWkrYWpZS1N6clFqclo2VEpn
+        d1NkOWVXc2JsaXB3ZFVGNm5TZkp0SHcKLS0tIGI1bldiYkkzbmxUdEZuWFR6eXMw
+        aFUyT1NYWkZqZUtkSEhtcElUd2s5VWsKqplqhoHK4tvU84HAXS+0hF4wFsEm6rlZ
+        tpOqTQzY3MSJbEJzu8AgL464AW5nmapK485BvM4FZkIzAHX2+dhPAw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-06T05:12:58Z"
+  mac: ENC[AES256_GCM,data:iAQ2Ah8d6yadzp9bktVgUZjU5eqspKAcWuaFKE0CMERuYU1yzg2Mw+QtmIdy87EJ10ykXgidSjKBlmzFnB80fNpRBLzRmy+RQPDVLBOdv6OkS+hNr4/MJAMRd9dcmmsGu2nWlzBr2uc3RKRujwISwvfCnt0GnF8eMHM0nClrzbg=,iv:OC+EnP7FxrJ0b5LbjWQce4Jfdfi6Yz9K9uBf3DVQGac=,tag:pPzM88ABpHVGkswVDBYfnA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.1

--- a/cluster/k8s/monitoring/tempo/minio-credentials.sops.yaml
+++ b/cluster/k8s/monitoring/tempo/minio-credentials.sops.yaml
@@ -1,35 +1,35 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: minio-credentials
-    namespace: monitoring
-    annotations:
-        description: MinIO credentials for Tempo trace storage
+  name: minio-credentials
+  namespace: monitoring
+  annotations:
+    description: MinIO credentials for Tempo trace storage
 type: Opaque
 stringData:
-    S3_ACCESS_KEY: ENC[AES256_GCM,data:I5qmFYDDw9I5rjsUpfE0vw==,iv:hPJY9UaxyUYQ93Sj98fImbfSJ0Kl7QsbA6sVQ95ILw0=,tag:7F+nPpANpVBUO8MqRXdBEA==,type:str]
-    S3_SECRET_KEY: ENC[AES256_GCM,data:6Uti0mQyvgqyPjxgrYaho/klJhyyjz9meQNsJeax3fpoZwzmFXFKF2C1EQ==,iv:S4B5VKYlw6ja8jsmTdvrjj7zYsRluAe89X8N/jLyMJw=,tag:b8KNAdB1seSpL48lDo2AOg==,type:str]
+  S3_ACCESS_KEY: ENC[AES256_GCM,data:I5qmFYDDw9I5rjsUpfE0vw==,iv:hPJY9UaxyUYQ93Sj98fImbfSJ0Kl7QsbA6sVQ95ILw0=,tag:7F+nPpANpVBUO8MqRXdBEA==,type:str]
+  S3_SECRET_KEY: ENC[AES256_GCM,data:6Uti0mQyvgqyPjxgrYaho/klJhyyjz9meQNsJeax3fpoZwzmFXFKF2C1EQ==,iv:S4B5VKYlw6ja8jsmTdvrjj7zYsRluAe89X8N/jLyMJw=,tag:b8KNAdB1seSpL48lDo2AOg==,type:str]
 sops:
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvaG16NWlyZEVRTHVhQlR5
-            RkoxbTVETm1mdDZmSmRpdVFGVGxxTThEcGh3CmFLTlF6dUErMHVZeHpYZFpRNndw
-            cGNnVVR3Y3ZkdnhWa2ZGVlFoeUZpRnMKLS0tIG9GdmYwbGpNRFhoTDdUb0lPRVZj
-            QWNXVFJvT1BHdldTYnk0U3ZMWTArNDgKEy13Z6SBvEBa81ppxWwQRCRzreuuabIV
-            qaOopUrEvrk8UnaDQOsDa6cq34mbcx6PjIQBA5ZGnPlb0tMS1Azb9g==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLVXVwK2IxTFB4eGpKQ241
-            UjBSTU9zSXNJb3p3a2pQZGJ4Rm9HaDhkS2hrCnVlcUh3S1Q3K1pMdnJDV1laeFY4
-            aFFibVBhd2g1eTFmV2ovS0E0b3FBdW8KLS0tIGYxUTNzVEpSL0M4bVI0S3diZjNJ
-            Q3d5bXp6OEJTazFUcTA4S044SXlzTDAKS3PgNKDjmf2RUVmhRRG9BbSeYr/65XBQ
-            GH0YD9VMof93L3MrI/LCewbvKwj4ueiY1jqEk82v8rScEsJiQps0Ng==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-06T05:12:58Z"
-    mac: ENC[AES256_GCM,data:SMSW3jt/N85Jt72Iu3ikE3GY/fHtIzye4PUQ/MY85dJ/JGkFY9GYtBUpFsu5gAgd9se3ub1TccWujrGlARmC5N2yX5ikaudwwbykta8erWna8SVL/fEy1/FLbM35heDEeBVP3NbOrwJV/qBvqbztRd6zIxT/wfJOpB5gElMA2wo=,iv:w99AcgQEc7BblUoz+r6lv9xM8qJB1l5bzgSkeuv3EfM=,tag:o6JKoyABY5V2B/C5jrRCiQ==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvaG16NWlyZEVRTHVhQlR5
+        RkoxbTVETm1mdDZmSmRpdVFGVGxxTThEcGh3CmFLTlF6dUErMHVZeHpYZFpRNndw
+        cGNnVVR3Y3ZkdnhWa2ZGVlFoeUZpRnMKLS0tIG9GdmYwbGpNRFhoTDdUb0lPRVZj
+        QWNXVFJvT1BHdldTYnk0U3ZMWTArNDgKEy13Z6SBvEBa81ppxWwQRCRzreuuabIV
+        qaOopUrEvrk8UnaDQOsDa6cq34mbcx6PjIQBA5ZGnPlb0tMS1Azb9g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLVXVwK2IxTFB4eGpKQ241
+        UjBSTU9zSXNJb3p3a2pQZGJ4Rm9HaDhkS2hrCnVlcUh3S1Q3K1pMdnJDV1laeFY4
+        aFFibVBhd2g1eTFmV2ovS0E0b3FBdW8KLS0tIGYxUTNzVEpSL0M4bVI0S3diZjNJ
+        Q3d5bXp6OEJTazFUcTA4S044SXlzTDAKS3PgNKDjmf2RUVmhRRG9BbSeYr/65XBQ
+        GH0YD9VMof93L3MrI/LCewbvKwj4ueiY1jqEk82v8rScEsJiQps0Ng==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-06T05:12:58Z"
+  mac: ENC[AES256_GCM,data:SMSW3jt/N85Jt72Iu3ikE3GY/fHtIzye4PUQ/MY85dJ/JGkFY9GYtBUpFsu5gAgd9se3ub1TccWujrGlARmC5N2yX5ikaudwwbykta8erWna8SVL/fEy1/FLbM35heDEeBVP3NbOrwJV/qBvqbztRd6zIxT/wfJOpB5gElMA2wo=,iv:w99AcgQEc7BblUoz+r6lv9xM8qJB1l5bzgSkeuv3EfM=,tag:o6JKoyABY5V2B/C5jrRCiQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.1

--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -495,7 +495,7 @@ manifest:
     strict_rfc3339: strict_rfc3339
     structlog: structlog
     supervisor: supervisor
-    svgwrite: svgwrite
+    svg: svg_py
     sympy: sympy
     syrupy: syrupy
     tabulate: tabulate
@@ -600,4 +600,4 @@ manifest:
     zstandard: zstandard
   pip_repository:
     name: pypi
-integrity: 13d12ae44680c34a66e37d5a368bdd39e3289f7e9b9a6498df7c8df249928c3b
+integrity: b18fff7346f7f29f0b0317dffe9aa49915bfcd6d62378850a0cca47e27b140f8

--- a/devinfra/image_pins.json
+++ b/devinfra/image_pins.json
@@ -6,8 +6,6 @@
   "freecad_test": {
     "image": "ghcr.io/agentydragon/freecad-test",
     "digest": "sha256:692a6834fa3d57c2144a8cedb353f6bf4dfa0d036e271e279f22162fa95e97cb",
-    "platforms": [
-      "linux/amd64"
-    ]
+    "platforms": ["linux/amd64"]
   }
 }

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -117,6 +117,7 @@ py_package(
         "util.bazel",
     ],
     deps = [
+        ":bech32",
         ":env",
         ":fmt",
         ":fs",


### PR DESCRIPTION
This PR makes formatting and dependency updates across the codebase.

## Changes

- **YAML formatting**: Standardized indentation in MinIO credential secrets for Loki and Tempo from 4 spaces to 2 spaces for consistency with YAML best practices
- **JSON formatting**: Simplified the `freecad_test` image platforms array in `image_pins.json` to single-line format
- **Build dependencies**: Added `bech32` as an explicit dependency in the `util` package's `py_package` target
- **Python dependencies**: Updated `gazelle_python.yaml` manifest to use `svg_py` package instead of `svgwrite` for SVG handling

These changes improve code consistency and ensure proper dependency declarations without altering functionality.

https://claude.ai/code/session_015RSJTUYwuLMvNNPjrPwpPz