### PR TITLE
docs(cluster): update plans for Alloy+Mimir migration and Longhorn progress

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -73,11 +73,11 @@ All storage is region-local — no cross-site synchronous replication.
 | StorageClass         | Provisioner            | Region  | Notes                                                         |
 | -------------------- | ---------------------- | ------- | ------------------------------------------------------------- |
 | `local-path`         | local-path-provisioner | Any     | CNPG (all databases), Gatus, MinIO, Nix cache                 |
-| `local-path-hetzner` | local-path-provisioner | Hetzner | Vault Raft, Loki, Alertmanager                                |
+| `local-path-hetzner` | local-path-provisioner | Hetzner | Vault Raft, Loki, Mimir, Alertmanager, Grafana DB             |
 | `local-path-proxmox` | local-path-provisioner | Proxmox | ActivityWatch, Scanner, Google Workspace MCP, Tana MCP        |
 | `lvm-proxmox`        | OpenEBS LVM CSI        | Proxmox | Thin provisioning, expansion: Harbor                          |
 | `proxmox-csi-retain` | Proxmox CSI            | Proxmox | Block storage via Proxmox API: Ollama, Matrix (migrating off) |
-| `longhorn`           | Longhorn               | Hetzner | Legacy — migrating off. Harbor (redis, registry)              |
+| `longhorn`           | Longhorn               | Hetzner | Legacy — orphaned PVCs only, no active workloads              |
 | `hetzner-longhorn`   | Longhorn               | Hetzner | Replicated across VPS nodes (none active yet)                 |
 | `hcloud-volumes`     | Hetzner Cloud CSI      | Hetzner | (none active)                                                 |
 

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -83,8 +83,7 @@ CloudNativePG `local-path`. See <changelog.md> for history.
       service unit) — restarts kubelet if it deadlocks
 - [ ] NVIDIA GPU monitoring: add DCGM exporter ServiceMonitor + Grafana dashboard (gnetId 12239)
 - [ ] etcd: add dedicated ServiceMonitor for full etcd metrics (current scrape is partial via apiserver)
-- [ ] Prometheus: investigate memory growth and right-size (OOM-killed 8x at 2Gi, pinned to wyrm2 at 6Gi)
-- [ ] Prometheus: unpin from wyrm2 (blocked on PriorityClasses + right-sizing + VPS headroom)
+- [x] Prometheus: replaced by Alloy+Mimir (2026-04-06). Prometheus disabled, operator kept for CRDs.
 - [ ] Enable roaming-tolerant workloads on rugged (`grocy`, `scanner`, `activitywatch`,
       `proxmox-proxy`, `props`/`props-registry`)
 - [ ] OpenClaw: obfuscation detection forces approval despite `security: full`
@@ -95,28 +94,22 @@ CloudNativePG `local-path`. See <changelog.md> for history.
 - [ ] Tandoor: verify deployment works end-to-end (DB migration, Authentik
       proxy auth, recipe import)
 - [ ] Move more PVCs to `local-path` (Proxmox CSI 29 LUN limit). Candidates:
-      `langfuse/langfuse-s3`, `monitoring/alertmanager-*`, `monitoring/prometheus-*`,
-      `monitoring/storage-tempo-0`, `monitoring/kube-prometheus-stack-grafana`,
-      `harbor/harbor-jobservice`
-- [ ] Loki + MinIO migration (replace Longhorn PVC with object storage):
-  - **Phase 1**: Deploy MinIO distributed on Hetzner VPS nodes. 4 drives across
-    2 nodes (2 per node, `local-path`), erasure coded. Provides S3-compatible
-    endpoint with node-loss tolerance.
-  - **Phase 2**: Migrate Loki from `loki-stack` (monolithic, boltdb+filesystem)
-    to `loki` chart (simple scalable mode). Point chunks+index at Hetzner MinIO.
-    Ingester `replication_factor: 3` for in-flight data. Removes `proxmox-csi`
-    dependency from Loki — unblocks the `grafana` HelmRepository (currently
-    bundled in the `loki` kustomization) for Tempo and Alloy.
+      `langfuse/langfuse-s3`, `harbor/harbor-jobservice`.
+      Done: monitoring stack now on `local-path-hetzner` (Alloy+Mimir), Grafana on CNPG,
+      Vault on `local-path-hetzner`.
+- Loki + MinIO migration:
+  - [x] **Phase 1**: MinIO deployed on Hetzner VPS nodes (`minio-hil`).
+  - [x] **Phase 2**: Loki migrated to S3 backend (MinIO). Mimir and Tempo also use MinIO.
   - [ ] Reconsider MinIO on control-plane nodes: currently 4 replicas across all
         VPS nodes (2 CP + 2 worker) with CP tolerations. Alternative: 2 replicas on
         workers only with `drivesPerNode: 2` (4 drives total, still erasure coded).
         Keeps CP nodes lighter but halves node-loss tolerance (1 node = all data).
-  - **Phase 3** (future): Deploy a second MinIO instance on Proxmox (`local-path`,
-    single-node). Set up async replication or scheduled `mc mirror` from the
-    Hetzner instance for off-site backup of log history.
-  - **Phase 4** (future): Split Loki write path by region — Proxmox node logs
-    write to Proxmox MinIO, Hetzner node logs write to Hetzner MinIO. Avoids
-    cross-site traffic for log ingestion. Grafana queries both.
+  - [ ] **Phase 3** (future): Deploy a second MinIO instance on Proxmox (`local-path`,
+        single-node). Set up async replication or scheduled `mc mirror` from the
+        Hetzner instance for off-site backup of log history.
+  - [ ] **Phase 4** (future): Split Loki write path by region — Proxmox node logs
+        write to Proxmox MinIO, Hetzner node logs write to Hetzner MinIO. Avoids
+        cross-site traffic for log ingestion. Grafana queries both.
 - [ ] Re-enable MFA (TOTP/WebAuthn) once device enrollment is set up
 - [ ] Wire `scripts/check-authentik-login.py` into bootstrap/CI
 - [ ] Gatus: Harbor robot token for authenticated `/v2/` probe
@@ -157,13 +150,14 @@ See <plans/file-sync-evaluation.md>.
 **Rule**: These services MUST work with VPS only (Proxmox completely down). No
 `proxmox-csi-retain` storage or Proxmox-pinned workloads.
 
-| Service   | Status | Storage            | Notes                     |
-| --------- | ------ | ------------------ | ------------------------- |
-| DNS       | OK     | `local-path`       | CNPG 2-instance on VPS    |
-| Website   | OK     | None (stateless)   |                           |
-| Ingress   | OK     | None (hostNetwork) | Cilium Gateway on VPS     |
-| Authentik | OK     | `local-path`       | All components pinned     |
-| Vault     | OK     | `local-path`       | Raft storage, VPS-capable |
+| Service   | Status | Storage              | Notes                                 |
+| --------- | ------ | -------------------- | ------------------------------------- |
+| DNS       | OK     | `local-path`         | CNPG 2-instance on VPS                |
+| Website   | OK     | None (stateless)     |                                       |
+| Ingress   | OK     | None (hostNetwork)   | Cilium Gateway on VPS                 |
+| Authentik | OK     | `local-path`         | All components pinned                 |
+| Vault     | OK     | `local-path-hetzner` | Raft storage, VPS-pinned              |
+| Grafana   | OK     | CNPG VPS-HA          | Moved from Longhorn PVC to PostgreSQL |
 
 **Compliance checklist** for critical-path changes:
 
@@ -172,8 +166,8 @@ See <plans/file-sync-evaluation.md>.
 3. Can schedule on VPS nodes
 4. All upstream dependencies also pass 1-3
 
-**Proxmox-dependent services** (tolerate downtime by design): Harbor, Gitea, Loki,
-Nix cache, Grafana, BuildBuddy, Ollama, InvenTree, ActivityWatch.
+**Proxmox-dependent services** (tolerate downtime by design): Harbor, Gitea,
+Nix cache, BuildBuddy, Ollama, InvenTree, ActivityWatch.
 
 ## Operational Hardening
 

--- a/cluster/docs/plans/cluster-architecture-redesign/plan.md
+++ b/cluster/docs/plans/cluster-architecture-redesign/plan.md
@@ -156,44 +156,33 @@ Legend: **bold** = decision made, normal = current state / TBD.
 
 ### Monitoring & Observability
 
-| Service         | Current      | Proposed                    | Storage    | Replication         | Notes                             |
-| --------------- | ------------ | --------------------------- | ---------- | ------------------- | --------------------------------- |
-| Prometheus      | wyrm2 (6 Gi) | **Replace with VM cluster** | —          | —                   | See VictoriaMetrics section below |
-| VictoriaMetrics | —            | **VPS workers**             | local-path | Built-in (factor=2) | 2x vmstorage on VPS workers       |
-| Grafana         | ?            | VPS workers                 | local-path | None                | Stateless-ish, rebuildable        |
-| Loki            | Proxmox      | TBD                         | MinIO?     | Via MinIO           | See <storage.md>                  |
-| Alloy           | ?            | Any                         |            |                     | DaemonSet, stateless              |
-| Tempo           | ?            | VPS workers                 | local-path | None                | Rebuildable                       |
-| AlertManager    | ?            | VPS workers                 | local-path | None                |                                   |
-| Gatus           | ?            | VPS workers                 | local-path | None                |                                   |
+| Service      | Current      | Storage                           | Replication    | Notes                                              |
+| ------------ | ------------ | --------------------------------- | -------------- | -------------------------------------------------- |
+| Alloy        | **Deployed** | none (DaemonSet)                  | n/a            | Scrapes ServiceMonitor/PodMonitor, pushes to Mimir |
+| Mimir        | **Deployed** | `local-path-hetzner`              | Built-in       | Long-term metrics storage, S3 backend (MinIO)      |
+| Grafana      | **Deployed** | CNPG VPS-HA                       | CNPG streaming | Moved from PVC to PostgreSQL                       |
+| Loki         | **Deployed** | MinIO (S3) + `local-path-hetzner` | None           | Single-binary; local PVC for WAL/cache             |
+| Tempo        | **Deployed** | S3 (MinIO)                        | None           | No local PVCs, S3 backend only                     |
+| Alertmanager | **Deployed** | `local-path-hetzner`              | 2 replicas     | Receives alerts from Mimir Ruler                   |
+| Gatus        | Deployed     | `local-path`                      | None           |                                                    |
+| Prometheus   | **Disabled** | —                                 | —              | Replaced by Alloy+Mimir (2026-04-06)               |
 
-#### VictoriaMetrics Cluster (replaces Prometheus)
+#### Alloy + Mimir (replaced Prometheus)
 
-Replace Prometheus with VictoriaMetrics cluster mode. ~3-10x less RAM
-for the same data. Built-in replication, PromQL-compatible, Grafana
-works as-is (Prometheus datasource type).
+Prometheus was disabled 2026-04-06 — it was pinned to wyrm2 with a
+broken Longhorn PVC and redundant once Mimir was deployed. The
+Prometheus Operator remains active (manages ServiceMonitor/PodMonitor/
+PrometheusRule CRDs).
 
-**Components:**
+**Current stack:**
 
-- `vmstorage` (x2): One per VPS worker, local-path storage,
-  `replicationFactor=2` — each metric written to both nodes
-- `vminsert` (x1): Receives remote-write from scrapers, distributes
-  to storage nodes. Lightweight, can run anywhere.
-- `vmselect` (x1): Serves PromQL queries, merges/deduplicates from
-  both storage nodes. Lightweight, can run anywhere.
-
-**Cross-site replication problem:** `vminsert` writes to
-`replicationFactor` nodes synchronously with no topology awareness.
-If vmstorage nodes span VPS + Proxmox, some writes cross the 20ms
-Nebula link. Plan for **vmstorage on VPS only** with 2 nodes.
-
-**Migration path:**
-
-1. Deploy VM cluster alongside Prometheus
-2. Configure dual remote-write (Alloy writes to both)
-3. Verify dashboards work against vmselect
-4. Switch Grafana datasource to vmselect
-5. Remove Prometheus
+- **Alloy** (DaemonSet): Discovers and scrapes ServiceMonitor/PodMonitor
+  targets, pushes to Mimir via remote-write.
+- **Mimir** (distributed): Long-term metrics storage with S3 backend
+  (MinIO). Ruler component evaluates alerting/recording rules. Pinned
+  to Hetzner region.
+- **Grafana**: Queries Mimir via Prometheus datasource type (PromQL-compatible).
+  State in CNPG PostgreSQL (VPS-HA, 2 replicas) instead of PVC.
 
 ### Agent / AI Services
 
@@ -232,24 +221,25 @@ Nebula link. Plan for **vmstorage on VPS only** with 2 nodes.
 
 - **Vault**: Drop (replaced by SOPS + age). See <sso.md>.
 - **SSO**: Authentik → Authelia. See <sso.md>.
-- **Prometheus**: Replace with VictoriaMetrics cluster.
-- **Longhorn**: Drop after migrating remaining PVCs. See <storage.md>.
+- **Prometheus**: Replaced by Alloy+Mimir (2026-04-06). Prometheus disabled, operator kept for CRDs.
+- **Grafana storage**: Moved from Longhorn PVC to CNPG PostgreSQL (VPS-HA).
+- **Vault storage**: Moved from Longhorn to `local-path-hetzner`.
+- **Longhorn**: No workloads remain on Longhorn storage. Operator still deployed (UI/SSO). Drop after removing operator + CRDs.
 
 ## Remaining Decisions
 
 ### Tier 1: Blocking
 
-1. **Prometheus + Loki long-term placement.** See <storage.md>.
+(None — monitoring placement resolved by Alloy+Mimir migration.)
 
 ### Tier 2: Should decide
 
-2. **Monitoring stack placement** (Grafana, Alloy, Tempo, AlertManager,
-   Gatus).
-3. **Harbor placement.** Effectively Proxmox-pinned via proxmox-csi.
-4. **tofu-state DB.** Currently VPS-HA CNPG. Stays on VPS workers?
-5. **Light services on CPs.** Candidates: PowerDNS, kube-api-proxy,
+1. **Loki long-term placement.** Currently single-binary on `local-path-hetzner`. See <storage.md>.
+2. **Harbor placement.** Effectively Proxmox-pinned via proxmox-csi.
+3. **tofu-state DB.** Currently VPS-HA CNPG. Stays on VPS workers?
+4. **Light services on CPs.** Candidates: PowerDNS, kube-api-proxy,
    Gateway/Ingress, Kyverno, CoreDNS, system DaemonSets.
-6. **Hcloud CSI.** Remove or use for VPS worker storage?
+5. **Hcloud CSI.** Remove or use for VPS worker storage?
 
 ### Tier 3: Low risk
 
@@ -280,6 +270,12 @@ Nebula link. Plan for **vmstorage on VPS only** with 2 nodes.
   HTTPRoute (`authelia.allegedly.works`), ConfigMap with OIDC provider
   config and local user backend. TODO markers for SOPS secrets, JWKS
   key, user password hash, and OIDC client definitions.
+- Monitoring migrated from Prometheus to Alloy+Mimir (2026-04-06):
+  Prometheus disabled, Alloy scrapes metrics, Mimir stores long-term
+  with S3 backend (MinIO). Mimir Ruler evaluates alert rules.
+- Grafana moved from Longhorn PVC to CNPG PostgreSQL (VPS-HA, 2 replicas)
+- Vault moved from Longhorn to `local-path-hetzner`
+- All Longhorn workload PVCs eliminated — no `storageClassName: longhorn` remains
 
 ### Phase 1: Foundation (remaining)
 
@@ -293,7 +289,9 @@ Nebula link. Plan for **vmstorage on VPS only** with 2 nodes.
    user password hash, uncomment SOPS resources in kustomization + Flux
 3. Update `cnpg-conventions.md` for region-explicit storage classes
 4. Migrate CNPG clusters + PVCs from generic `local-path` to `local-path-{region}`
-5. Migrate monitoring/vault off bare `longhorn` SC
+5. ~~Migrate monitoring/vault off bare `longhorn` SC~~ — **Done** (2026-04-06):
+   Prometheus disabled (replaced by Alloy+Mimir), Grafana moved to CNPG,
+   Vault moved to `local-path-hetzner`. No Longhorn PVCs remain.
 
 ### Phase 2: CP Isolation (remaining)
 
@@ -333,26 +331,24 @@ we want runtime self-service (password reset, profile changes)?
 For now: stick with static ConfigMap. Revisit if MFA (TOTP/WebAuthn)
 enrollment requires runtime writes.
 
-### Phase 4: Monitoring Migration (Prometheus → VictoriaMetrics)
+### Phase 4: Monitoring Migration — COMPLETE (2026-04-06)
 
-16. Deploy VictoriaMetrics cluster
-17. Configure dual remote-write
-18. Verify + switch Grafana datasource
-19. Remove Prometheus
+Prometheus replaced by Alloy+Mimir (not VictoriaMetrics as originally
+planned — Mimir was a better fit with MinIO already deployed). Grafana
+moved from Longhorn PVC to CNPG PostgreSQL (VPS-HA). Vault moved from
+Longhorn to `local-path-hetzner`.
 
 ### Phase 5: Storage (evaluate and migrate)
 
 See <storage.md> for validation plans.
 
-20. Evaluate MinIO site replication + HAProxy
-21. Evaluate Loki/Tempo on MinIO
-22. Evaluate JuiceFS OR Rook/Ceph
-23. Migrate remaining Longhorn PVCs
-24. Decommission Longhorn
+16. Evaluate MinIO site replication + HAProxy
+17. Evaluate Loki/Tempo on MinIO
+18. Evaluate JuiceFS OR Rook/Ceph
+19. Remove Longhorn operator and CRDs (no workload PVCs remain)
 
 ### Phase 6: Cleanup
 
-25. Remove Longhorn operator and CRDs
-26. Remove Vault, ESO, tofu-controller secret resources
-27. Remove Authentik namespace
-28. Update cluster docs
+20. Remove Vault, ESO, tofu-controller secret resources
+21. Remove Authentik namespace
+22. Update cluster docs

--- a/cluster/docs/plans/cluster-architecture-redesign/storage.md
+++ b/cluster/docs/plans/cluster-architecture-redesign/storage.md
@@ -46,22 +46,22 @@ at creation time rather than silently landing on a random node.
    within a site only. Cross-site protection is async backup/mirror.
 4. **CNPG stays on `local-path-{region}`.** App-level replication
    handles durability. See `cnpg-conventions.md`.
-5. **Ephemeral data is explicitly marked.** Prometheus, Grafana, Tempo
-   on `local-path-{region}` — rebuildable, not precious.
+5. **Ephemeral data is explicitly marked.** Mimir, Tempo, Alertmanager
+   on `local-path-hetzner` — rebuildable, not precious. Grafana on CNPG.
 
 ## PVC Backup / Async Cross-Site Replication
 
 Per-workload backup strategy (no one-size-fits-all):
 
-| Data Type                       | Backup Method                                          | Cross-Site? |
-| ------------------------------- | ------------------------------------------------------ | ----------- |
-| CNPG databases                  | pg_dump CronJob to remote site PVC (existing pattern)  | Yes         |
-| CNPG databases                  | (future) CNPG `ScheduledBackup` + Barman to S3/MinIO   | Yes         |
-| CNPG databases                  | (future) CNPG read-only replica cluster at remote site | Yes         |
-| Loki/Tempo (if on MinIO)        | MinIO site replication (async)                         | Yes         |
-| Harbor registry                 | MinIO site replication (if migrated) or rsync CronJob  | Possible    |
-| Ephemeral (Prometheus, Grafana) | No backup needed — rebuildable                         | No          |
-| etcd                            | talos-backup CronJob to S3 with age encryption         | Yes         |
+| Data Type                              | Backup Method                                          | Cross-Site? |
+| -------------------------------------- | ------------------------------------------------------ | ----------- |
+| CNPG databases                         | pg_dump CronJob to remote site PVC (existing pattern)  | Yes         |
+| CNPG databases                         | (future) CNPG `ScheduledBackup` + Barman to S3/MinIO   | Yes         |
+| CNPG databases                         | (future) CNPG read-only replica cluster at remote site | Yes         |
+| Loki/Tempo (if on MinIO)               | MinIO site replication (async)                         | Yes         |
+| Harbor registry                        | MinIO site replication (if migrated) or rsync CronJob  | Possible    |
+| Ephemeral (Mimir, Tempo, Alertmanager) | No backup needed — rebuildable (S3/MinIO backend)      | No          |
+| etcd                                   | talos-backup CronJob to S3 with age encryption         | Yes         |
 
 ### CNPG Cross-Site Read Replica
 
@@ -87,30 +87,34 @@ streaming replication across Nebula (20ms) causes any issues.
 
 ## Current Longhorn Usage
 
-All Longhorn PVCs (checked 2026-04-01):
+**Updated 2026-04-06**: Monitoring stack migrated off Longhorn. Prometheus
+replaced by Alloy+Mimir (S3/MinIO backend). Grafana moved to CNPG. Vault
+moved to `local-path-hetzner`. Loki and Tempo now use MinIO.
 
-| Namespace  | PVC                             | Size | Notes                      |
-| ---------- | ------------------------------- | ---- | -------------------------- |
-| gitea      | data-gitea-postgresql-0         | 10G  | Legacy, suspended          |
-| harbor     | data-harbor-redis-0             | 1G   |                            |
-| harbor     | data-harbor-trivy-0             | 5G   |                            |
-| harbor     | database-data-harbor-database-0 | 1G   | Legacy (migrated to CNPG?) |
-| harbor     | harbor-jobservice               | 1G   |                            |
-| harbor     | harbor-registry                 | 30G  |                            |
-| loki       | storage-loki-stack-0            | 20G  |                            |
-| monitoring | db-alertmanager-monitoring-0    | 1G   |                            |
-| monitoring | db-prometheus-monitoring-0      | 20G  |                            |
-| monitoring | grafana                         | 2G   |                            |
-| monitoring | storage-tempo-0                 | 10G  |                            |
-| vault      | vault-raft-instance-{0,1,2}     | 2G   | Goes away if Vault drops   |
+Remaining Longhorn PVCs (stale/orphaned — no workloads reference `storageClassName: longhorn`):
 
-None of these benefit from Longhorn's cross-node replication:
+| Namespace | PVC                             | Size | Notes                                  |
+| --------- | ------------------------------- | ---- | -------------------------------------- |
+| gitea     | data-gitea-postgresql-0         | 10G  | Legacy, suspended                      |
+| harbor    | data-harbor-redis-0             | 1G   | Orphaned (Harbor now on `lvm-proxmox`) |
+| harbor    | data-harbor-trivy-0             | 5G   | Orphaned (Harbor now on `lvm-proxmox`) |
+| harbor    | database-data-harbor-database-0 | 1G   | Orphaned (migrated to CNPG)            |
+| harbor    | harbor-jobservice               | 1G   | Orphaned (Harbor now on `lvm-proxmox`) |
+| harbor    | harbor-registry                 | 30G  | Orphaned (Harbor now on `lvm-proxmox`) |
 
-- Harbor, Loki: Proxmox-pinned (proxmox-csi would work)
-- Vault: Has its own Raft replication. Goes away if dropped.
-- Monitoring (Prometheus, Grafana, Tempo, AlertManager): Ephemeral /
-  rebuildable. local-path is fine.
-- Gitea: Suspended.
+Previously on Longhorn, now migrated:
+
+| Was                           | Migrated To          | Date       |
+| ----------------------------- | -------------------- | ---------- |
+| monitoring/db-prometheus-\*   | Prometheus disabled  | 2026-04-06 |
+| monitoring/grafana            | CNPG VPS-HA          | 2026-04-06 |
+| monitoring/storage-tempo-0    | MinIO (S3)           | 2026-04-06 |
+| monitoring/db-alertmanager-\* | `local-path-hetzner` | 2026-04-06 |
+| loki/storage-loki-stack-0     | MinIO (S3)           | 2026-04-06 |
+| vault/vault-raft-instance-\*  | `local-path-hetzner` | 2026-04-06 |
+
+All remaining Longhorn PVCs are orphaned — Harbor moved to `lvm-proxmox`,
+Gitea is suspended. After verifying nothing is mounted, these are safe to delete.
 
 ## Distributed Storage Options Considered
 


### PR DESCRIPTION
## Summary

- Update monitoring sections: Prometheus replaced by Alloy+Mimir (not VictoriaMetrics as originally planned), Grafana moved to CNPG PostgreSQL, Vault moved to `local-path-hetzner`
- Mark Phase 4 (monitoring migration) as complete, update Phase 5/6 numbering
- Update Longhorn PVC audit in `storage.md` — no workload PVCs remain, added migration tracking table
- Mark Loki+MinIO Phase 1 and Phase 2 as done (MinIO deployed, Loki on S3)
- Update `local-path-hetzner` users in README storage table (Mimir, Tempo, Grafana DB)
- Clear Tier 1 blocking decisions (monitoring placement resolved)

## Test plan

- [ ] Verify docs render correctly in GitHub markdown
- [ ] Cross-check storage table against live cluster state

https://claude.ai/code/session_011t2VUQny61Xvr62c65ocfd