### PR TITLE
Add FreeCAD skill evaluation framework with baseplate task

### DIFF
--- a/mcp_infra/exec/docker/launcher.py
+++ b/mcp_infra/exec/docker/launcher.py
@@ -1,6 +1,6 @@
 """CLI to run the docker_exec MCP server via stdio transport.
 
-Accepts a single JSON config file (ContainerExecServerConfig schema).
+Accepts config as inline JSON (--config) or a JSON file path (--config-file).
 """
 
 from __future__ import annotations
@@ -22,13 +22,22 @@ app = TyperDI(help="Run docker_exec MCP over stdio")
 @app.command()
 @async_run
 async def main(
-    config_file: Annotated[Path, typer.Argument(help="JSON config file (ContainerExecServerConfig schema)")],
+    config: Annotated[str | None, typer.Option(help="Inline JSON config (ContainerExecServerConfig)")] = None,
+    config_file: Annotated[Path | None, typer.Option(help="Path to JSON config file")] = None,
 ) -> None:
     """Run docker_exec MCP server over stdio transport."""
-    config = ContainerExecServerConfig.model_validate_json(config_file.read_text())
+    if config is not None and config_file is not None:
+        raise typer.BadParameter("Specify --config or --config-file, not both.")
+    if config is not None:
+        parsed = ContainerExecServerConfig.model_validate_json(config)
+    elif config_file is not None:
+        parsed = ContainerExecServerConfig.model_validate_json(config_file.read_text())
+    else:
+        raise typer.BadParameter("Specify --config or --config-file.")
+
     docker_client = aiodocker.Docker()
     try:
-        server = ContainerExecServer(docker_client, config)
+        server = ContainerExecServer(docker_client, parsed)
         await server.run_stdio_async()
     finally:
         await docker_client.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "openai>=1.40.0",
     "anthropic",
     "claude-code-sdk>=0.0.21,<0.1",
+    "claude-agent-sdk>=0.1.0,<0.2",
     "tiktoken>=0.7.0",
     "tenacity>=8.2.0",
 

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -200,6 +200,7 @@ anyio==4.12.1 \
     # via
     #   ducktape (pyproject.toml)
     #   anthropic
+    #   claude-agent-sdk
     #   claude-code-sdk
     #   datalayer-pycrdt
     #   httpx
@@ -731,6 +732,14 @@ chromadb==1.1.1 \
     --hash=sha256:bba0096a7f5e975875ead23a91c0d41d977fbd3767f60d3305a011b0ace7afd3 \
     --hash=sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223
     # via crewai
+claude-agent-sdk==0.1.56 \
+    --hash=sha256:5934e082e1ccf975d65cd7412f2eaf2c5ffa6b9019a2ca2a9fb228310df7ddc8 \
+    --hash=sha256:824f4a10340f46dd26fee8e74aeed4fc64fec95084e327ab1ebb6058b349e1c3 \
+    --hash=sha256:9f5a7c87617101e6bb0f23408104ac6f40f9b5adec91dcfe5b8de5f65a7df73a \
+    --hash=sha256:a95bc14e59f9d6c8e7fa2e6581008a3f24f10e1b57302719823f62cfb5beccdc \
+    --hash=sha256:fe866b2119f69e99d9637acc27b588670c610fed1c4a096287874db5744d029b \
+    --hash=sha256:ff60dedc06b62b52e5937a9a2c4b0ec4ad0dd6764c20be656d01aeb8b11fba1d
+    # via ducktape (pyproject.toml)
 claude-code-sdk==0.0.25 \
     --hash=sha256:0d9e1eba432d4fe8a2f75f06ec9bb4c310f39b1d55246e7e4b2c69bfdd69eab3 \
     --hash=sha256:3d6a4ef958182f311d6050776d2675d9b39650a2db221c582a0a5156472dcee3
@@ -2859,6 +2868,7 @@ mcp[cli]==1.26.0 \
     --hash=sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66
     # via
     #   ducktape (pyproject.toml)
+    #   claude-agent-sdk
     #   claude-code-sdk
     #   crewai
     #   fastmcp

--- a/skills/freecad/eval/BUILD.bazel
+++ b/skills/freecad/eval/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/oci:defs.bzl", "oci_layout_rloc")
+
+oci_layout_rloc(
+    name = "freecad_test",
+    image = "@freecad_test_linux_amd64",
+)
+
+py_library(
+    name = "run_eval_lib",
+    srcs = ["run_eval.py"],
+    imports = ["../../.."],
+    deps = [
+        "//mcp_infra/exec:docker_types",
+        "//util:oci",
+        "//util/bazel:runfiles",
+        "@pypi//claude_agent_sdk",
+    ],
+)
+
+py_binary(
+    name = "run_eval",
+    data = [
+        "baseplate/CHECKLIST.md",
+        "baseplate/TASK.md",
+        ":freecad_test",
+        "//mcp_infra/exec:docker_launcher",
+        "//skills/freecad",
+    ],
+    imports = ["../../.."],
+    main_module = "skills.freecad.eval.run_eval",
+    deps = [":run_eval_lib"],
+)

--- a/skills/freecad/eval/README.md
+++ b/skills/freecad/eval/README.md
@@ -1,0 +1,42 @@
+# FreeCAD Skill Evaluation
+
+Evaluation tasks for testing whether an LLM agent can use the FreeCAD skill
+to produce correct parametric CAD models from natural language specifications.
+
+## Flow
+
+1. **Agent** receives `TASK.md` as the user prompt, with the FreeCAD skill
+   loaded via `~/.claude/skills/freecad/`
+2. **Agent** uses MCP tools (`exec`, `read_image`) to run FreeCAD commands
+   inside a Docker container and inspect outputs
+3. **Agent** produces a `.FCStd` file in the workspace
+4. **Judge** (human or LLM) inspects the workspace files and transcript,
+   fills out `CHECKLIST.md`
+
+## Running
+
+```bash
+ANTHROPIC_API_KEY=sk-... bazel run //skills/freecad/eval:run_eval -- /tmp/eval-output
+ANTHROPIC_API_KEY=sk-... bazel run //skills/freecad/eval:run_eval -- /tmp/eval-output --model claude-opus-4-6
+```
+
+Requires Docker (the FreeCAD container runs via the `exec` MCP server).
+
+## Output
+
+```
+/tmp/eval-output/
+├── transcript.jsonl    # Incremental JSONL log of all agent messages
+├── metadata.json       # cost_usd, duration_s, turns, model, session_id
+└── workspace/          # Agent's work files
+    ├── baseplate.py    # Agent's script (if it wrote one)
+    ├── baseplate.FCStd # The deliverable
+    └── *.svg, *.png    # Any renders
+```
+
+## Task structure
+
+Each task is a directory containing:
+
+- `TASK.md` — the prompt given to the agent
+- `CHECKLIST.md` — criteria the judge evaluates, with a scoring rubric

--- a/skills/freecad/eval/README.md
+++ b/skills/freecad/eval/README.md
@@ -6,7 +6,7 @@ to produce correct parametric CAD models from natural language specifications.
 ## Flow
 
 1. **Agent** receives `TASK.md` as the user prompt, with the FreeCAD skill
-   loaded via `~/.claude/skills/freecad/`
+   staged from `//skills/freecad` and bind-mounted into the container at `/skill`
 2. **Agent** uses MCP tools (`exec`, `read_image`) to run FreeCAD commands
    inside a Docker container and inspect outputs
 3. **Agent** produces a `.FCStd` file in the workspace

--- a/skills/freecad/eval/baseplate/CHECKLIST.md
+++ b/skills/freecad/eval/baseplate/CHECKLIST.md
@@ -1,7 +1,8 @@
 # Baseplate Evaluation Checklist
 
-Run `inspect.py` on the agent's FCStd first, then fill this out based on
-`inspection.json`, the rendered images, and the SVG export.
+Open the agent's FCStd in the FreeCAD container and inspect it (run
+FreeCAD Python to check geometry, constraints, parametric behavior).
+Review any rendered images/SVGs the agent produced in the workspace.
 
 ## Script execution
 

--- a/skills/freecad/eval/baseplate/CHECKLIST.md
+++ b/skills/freecad/eval/baseplate/CHECKLIST.md
@@ -1,0 +1,72 @@
+# Baseplate Evaluation Checklist
+
+Run `inspect.py` on the agent's FCStd first, then fill this out based on
+`inspection.json`, the rendered images, and the SVG export.
+
+## Script execution
+
+- [ ] Script ran without errors and produced `baseplate.FCStd`
+
+## Sketch quality
+
+- [ ] Sketch is fully constrained (`fully_constrained: true` in inspection)
+- [ ] Dimensional constraints are bound to spreadsheet via expressions
+      (`expression_count` > 0, expressions reference spreadsheet aliases)
+
+## Spreadsheet
+
+- [ ] Spreadsheet exists with named aliases for all 7 spec dimensions
+      (plate width/height, corner radius, hole diameter, hole inset,
+      slot width, slot height)
+- [ ] Default values match spec (200, 120, 10, 8, 20, 40, 15)
+
+## Geometry (from `inspection.json` features + rendered images)
+
+- [ ] Outer profile is a rounded rectangle with corner fillets (~10mm radius)
+- [ ] 4 mounting holes at inset corners (~4mm radius circles in `circular_edges`)
+- [ ] Central slot present and centered on the plate
+- [ ] Bounding box approximately 200 x 120
+
+## Parametric behavior
+
+To test: change the plate-width spreadsheet cell to 250 and recompute. Check:
+
+- [ ] Bounding box width updates to ~250
+- [ ] Height remains unchanged (~120)
+- [ ] Right-side holes shift rightward
+- [ ] Slot remains centered
+
+_(The inspector dumps all geometry; the judge performs this test manually
+or the parametric check can be scripted separately.)_
+
+## TechDraw
+
+- [ ] Page exists with a top-down view
+- [ ] View has visible edges (> 0)
+- [ ] At least 4 entity-referenced dimensions (`has_entity_refs: true`)
+- [ ] Dimension labels readable and not overlapping geometry (check SVG)
+
+## Visual inspection (from `top_view.svg` and `3d_render.png`)
+
+- [ ] Drawing looks like a baseplate — rounded rect with holes and slot
+- [ ] Dimension text is legible and correctly placed
+- [ ] No overlapping labels or extension lines through geometry
+
+## Problems found
+
+_Describe any issues here._
+
+## Score
+
+| Criterion         | Weight | Score (0-2) | Notes |
+| ----------------- | ------ | ----------- | ----- |
+| Runs correctly    | 1x     |             |       |
+| Fully constrained | 2x     |             |       |
+| Correct geometry  | 2x     |             |       |
+| Parametric        | 2x     |             |       |
+| TechDraw quality  | 1x     |             |       |
+| Visual quality    | 1x     |             |       |
+
+**Total: \_\_ / 18**
+
+Scoring: 0 = missing/broken, 1 = partially correct, 2 = fully correct.

--- a/skills/freecad/eval/baseplate/TASK.md
+++ b/skills/freecad/eval/baseplate/TASK.md
@@ -1,23 +1,9 @@
-# Task: Parametric Mounting Baseplate
-
-Produce a FreeCAD file `baseplate.FCStd` containing a parametric mounting
-baseplate. The model must be fully parametric — all dimensions driven by a
-spreadsheet, sketch fully constrained.
-
-## Shape
-
-A rectangular plate (200 x 120 mm) with:
+Model a fully parametric 200x120 mm mounting baseplate with:
 
 - 10 mm radius fillet on each corner
-- 4 mounting holes, 8 mm diameter, centered 20 mm from the two nearest edges
-- A rectangular slot (40 x 15 mm) centered on the plate, with the long axis
-  parallel to the plate width
+- 4 mounting holes (D=8 mm) centered 20 mm from the two nearest edges
+- 40x15 mm rectangular slot in the middle of the plate, long axis of the slot parallel to plate width
 
-## Parametric behavior
-
-Changing the plate width from 200 to 250 must widen the plate, shift the
-right-side holes, keep the slot centered, and leave the height unchanged.
-
-## TechDraw
-
+Use a spreadsheet as SSOT for all dimensions. Changes must properly propagate.
 Include a TechDraw page with a dimensioned top-down view.
+Save into baseplate.FCStd.

--- a/skills/freecad/eval/baseplate/TASK.md
+++ b/skills/freecad/eval/baseplate/TASK.md
@@ -1,0 +1,23 @@
+# Task: Parametric Mounting Baseplate
+
+Produce a FreeCAD file `baseplate.FCStd` containing a parametric mounting
+baseplate. The model must be fully parametric — all dimensions driven by a
+spreadsheet, sketch fully constrained.
+
+## Shape
+
+A rectangular plate (200 x 120 mm) with:
+
+- 10 mm radius fillet on each corner
+- 4 mounting holes, 8 mm diameter, centered 20 mm from the two nearest edges
+- A rectangular slot (40 x 15 mm) centered on the plate, with the long axis
+  parallel to the plate width
+
+## Parametric behavior
+
+Changing the plate width from 200 to 250 must widen the plate, shift the
+right-side holes, keep the slot centered, and leave the height unchanged.
+
+## TechDraw
+
+Include a TechDraw page with a dimensioned top-down view.

--- a/skills/freecad/eval/run_eval.py
+++ b/skills/freecad/eval/run_eval.py
@@ -1,0 +1,153 @@
+"""Run a FreeCAD skill eval: agent produces baseplate.FCStd, transcript logged.
+
+Usage:
+  ANTHROPIC_API_KEY=sk-... bazel run //skills/freecad/eval:run_eval -- /tmp/eval-output
+  ANTHROPIC_API_KEY=sk-... bazel run //skills/freecad/eval:run_eval -- /tmp/out --model claude-opus-4-6
+"""
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import logging
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, SystemMessage, query
+
+from mcp_infra.exec.docker.types import AlwaysSetTo, BindMount, ContainerExecServerConfig
+from util.bazel.runfiles import get_required_path
+from util.oci import OciImage, load_oci_image
+
+logger = logging.getLogger(__name__)
+
+FREECAD_TEST = OciImage("_main/skills/freecad/eval/freecad_test.rloc", "freecad-test:pinned")
+TASK_MD = "_main/skills/freecad/eval/baseplate/TASK.md"
+DOCKER_LAUNCHER = "_main/mcp_infra/exec/docker_launcher"
+SKILL_DIR = "_main/skills/freecad"
+
+SKILL_CONTAINER_DIR = "/skill"
+
+SYSTEM_PROMPT = f"""\
+You are working inside a FreeCAD Docker container via the exec and read_image MCP tools.
+
+The FreeCAD skill (SKILL.md) and all example scripts are at {SKILL_CONTAINER_DIR}/.
+Read {SKILL_CONTAINER_DIR}/SKILL.md before starting — it contains essential FreeCAD
+scripting patterns, constraints, and gotchas. The example scripts (parametric_sketch.py,
+build_compound.py, etc.) are reference implementations you can study.
+
+Your working directory is /workspace. Save all output files there.
+
+FreeCAD is available as `freecadcmd`. Use `xvfb-run -a -s "-screen 0 1024x768x24" freecadcmd`
+for any script that needs GUI/TechDraw rendering.
+
+Use the read_image tool to visually inspect PNG/SVG outputs you produce.
+"""
+
+
+async def run(output_dir: Path, model: str) -> None:
+    logger.info("Loading FreeCAD Docker image")
+    tag = load_oci_image(FREECAD_TEST)
+    logger.info("Image loaded: %s", tag)
+
+    workspace = output_dir / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    # Copy skill files to a host directory that will be bind-mounted
+    # into the container at SKILL_CONTAINER_DIR (read-only).
+    skill_src_dir = get_required_path(SKILL_DIR)
+    skill_host_dir = output_dir / "skill"
+    skill_host_dir.mkdir(parents=True, exist_ok=True)
+    for src in skill_src_dir.iterdir():
+        if src.is_file():
+            shutil.copy2(src, skill_host_dir / src.name)
+    logger.info("Skill files staged at %s", skill_host_dir)
+
+    # Read SKILL.md to include in the first user message
+    skill_md = (skill_host_dir / "SKILL.md").read_text()
+    task_text = get_required_path(TASK_MD).read_text()
+    user_prompt = f"{skill_md}\n\n---\n\n{task_text}"
+
+    launcher_binary = str(get_required_path(DOCKER_LAUNCHER))
+
+    config = ContainerExecServerConfig(
+        image=tag,
+        working_dir=Path("/workspace"),
+        binds=[
+            BindMount(host_path=workspace, container_path=Path("/workspace")),
+            BindMount(host_path=skill_host_dir, container_path=Path(SKILL_CONTAINER_DIR), mode="ro"),
+        ],
+        allow_user_field=False,
+        allow_env_field=False,
+        cwd_policy=AlwaysSetTo(value=Path("/workspace")),
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as config_file:
+        config_file.write(config.model_dump_json())
+        config_path = config_file.name
+
+    transcript_path = output_dir / "transcript.jsonl"
+    start = time.monotonic()
+    session_id: str | None = None
+    cost_usd = 0.0
+    turn_count = 0
+
+    with transcript_path.open("a") as log_f:
+        async for message in query(
+            prompt=user_prompt,
+            options=ClaudeAgentOptions(
+                cwd=str(workspace),
+                allowed_tools=["mcp__freecad__*"],
+                mcp_servers={"freecad": {"command": launcher_binary, "args": [config_path]}},
+                permission_mode="bypassPermissions",
+                max_turns=200,
+                model=model,
+                system_prompt=SYSTEM_PROMPT,
+            ),
+        ):
+            entry = dataclasses.asdict(message)
+            entry["_type"] = type(message).__name__
+            entry["_timestamp"] = time.time()
+
+            if isinstance(message, AssistantMessage):
+                turn_count += 1
+            elif isinstance(message, ResultMessage):
+                cost_usd = float(message.total_cost_usd or 0)
+                logger.info("Result: stop_reason=%s, cost=$%.4f, turns=%d", message.stop_reason, cost_usd, turn_count)
+            elif isinstance(message, SystemMessage) and message.subtype == "init":
+                session_id = message.data.get("session_id")
+                logger.info("Session: %s", session_id)
+
+            log_f.write(json.dumps(entry, default=str) + "\n")
+            log_f.flush()
+
+    duration = time.monotonic() - start
+
+    metadata = {
+        "model": model,
+        "cost_usd": cost_usd,
+        "duration_s": round(duration, 1),
+        "turns": turn_count,
+        "session_id": session_id,
+        "task": "baseplate",
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+
+    artifacts = sorted(str(p.relative_to(workspace)) for p in workspace.rglob("*") if p.is_file())
+    logger.info("Done. %d turns, $%.4f, %.0fs", turn_count, cost_usd, duration)
+    logger.info("Artifacts: %s", artifacts)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    parser = argparse.ArgumentParser(description="Run FreeCAD skill evaluation")
+    parser.add_argument("output_dir", type=Path, help="Directory for eval outputs")
+    parser.add_argument("--model", default="claude-sonnet-4-6", help="Model to use")
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    asyncio.run(run(args.output_dir, args.model))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/freecad/eval/run_eval.py
+++ b/skills/freecad/eval/run_eval.py
@@ -11,11 +11,10 @@ import dataclasses
 import json
 import logging
 import shutil
-import tempfile
 import time
 from pathlib import Path
 
-from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, SystemMessage, query
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, SystemMessage, query
 
 from mcp_infra.exec.docker.types import AlwaysSetTo, BindMount, ContainerExecServerConfig
 from util.bazel.runfiles import get_required_path
@@ -28,17 +27,18 @@ TASK_MD = "_main/skills/freecad/eval/baseplate/TASK.md"
 DOCKER_LAUNCHER = "_main/mcp_infra/exec/docker_launcher"
 SKILL_DIR = "_main/skills/freecad"
 
-SKILL_CONTAINER_DIR = "/skill"
+CONTAINER_WORKSPACE = Path("/workspace")
+CONTAINER_SKILL_DIR = Path("/skill")
 
 SYSTEM_PROMPT = f"""\
 You are working inside a FreeCAD Docker container via the exec and read_image MCP tools.
 
-The FreeCAD skill (SKILL.md) and all example scripts are at {SKILL_CONTAINER_DIR}/.
-Read {SKILL_CONTAINER_DIR}/SKILL.md before starting — it contains essential FreeCAD
+The FreeCAD skill (SKILL.md) and all example scripts are at {CONTAINER_SKILL_DIR}/.
+Read {CONTAINER_SKILL_DIR}/SKILL.md before starting — it contains essential FreeCAD
 scripting patterns, constraints, and gotchas. The example scripts (parametric_sketch.py,
 build_compound.py, etc.) are reference implementations you can study.
 
-Your working directory is /workspace. Save all output files there.
+Your working directory is {CONTAINER_WORKSPACE}. Save all output files there.
 
 FreeCAD is available as `freecadcmd`. Use `xvfb-run -a -s "-screen 0 1024x768x24" freecadcmd`
 for any script that needs GUI/TechDraw rendering.
@@ -55,51 +55,44 @@ async def run(output_dir: Path, model: str) -> None:
     workspace = output_dir / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
 
-    # Copy skill files to a host directory that will be bind-mounted
-    # into the container at SKILL_CONTAINER_DIR (read-only).
+    # Copy full skill directory (including subdirs) into a host directory
+    # that will be bind-mounted into the container at CONTAINER_SKILL_DIR.
     skill_src_dir = get_required_path(SKILL_DIR)
     skill_host_dir = output_dir / "skill"
-    skill_host_dir.mkdir(parents=True, exist_ok=True)
-    for src in skill_src_dir.iterdir():
-        if src.is_file():
-            shutil.copy2(src, skill_host_dir / src.name)
+    if skill_host_dir.exists():
+        shutil.rmtree(skill_host_dir)
+    shutil.copytree(skill_src_dir, skill_host_dir)
     logger.info("Skill files staged at %s", skill_host_dir)
 
-    # Read SKILL.md to include in the first user message
     skill_md = (skill_host_dir / "SKILL.md").read_text()
     task_text = get_required_path(TASK_MD).read_text()
     user_prompt = f"{skill_md}\n\n---\n\n{task_text}"
 
     launcher_binary = str(get_required_path(DOCKER_LAUNCHER))
-
-    config = ContainerExecServerConfig(
+    config_json = ContainerExecServerConfig(
         image=tag,
-        working_dir=Path("/workspace"),
+        working_dir=CONTAINER_WORKSPACE,
         binds=[
-            BindMount(host_path=workspace, container_path=Path("/workspace")),
-            BindMount(host_path=skill_host_dir, container_path=Path(SKILL_CONTAINER_DIR), mode="ro"),
+            BindMount(host_path=workspace, container_path=CONTAINER_WORKSPACE),
+            BindMount(host_path=skill_host_dir, container_path=CONTAINER_SKILL_DIR, mode="ro"),
         ],
         allow_user_field=False,
         allow_env_field=False,
-        cwd_policy=AlwaysSetTo(value=Path("/workspace")),
-    )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as config_file:
-        config_file.write(config.model_dump_json())
-        config_path = config_file.name
+        cwd_policy=AlwaysSetTo(value=CONTAINER_WORKSPACE),
+    ).model_dump_json()
 
     transcript_path = output_dir / "transcript.jsonl"
+    messages: list[dict] = []
     start = time.monotonic()
     session_id: str | None = None
-    cost_usd = 0.0
-    turn_count = 0
 
     with transcript_path.open("a") as log_f:
         async for message in query(
             prompt=user_prompt,
             options=ClaudeAgentOptions(
-                cwd=str(workspace),
+                cwd=workspace,
                 allowed_tools=["mcp__freecad__*"],
-                mcp_servers={"freecad": {"command": launcher_binary, "args": [config_path]}},
+                mcp_servers={"freecad": {"command": launcher_binary, "args": ["--config", config_json]}},
                 permission_mode="bypassPermissions",
                 max_turns=200,
                 model=model,
@@ -109,24 +102,24 @@ async def run(output_dir: Path, model: str) -> None:
             entry = dataclasses.asdict(message)
             entry["_type"] = type(message).__name__
             entry["_timestamp"] = time.time()
+            messages.append(entry)
 
-            if isinstance(message, AssistantMessage):
-                turn_count += 1
-            elif isinstance(message, ResultMessage):
-                cost_usd = float(message.total_cost_usd or 0)
-                logger.info("Result: stop_reason=%s, cost=$%.4f, turns=%d", message.stop_reason, cost_usd, turn_count)
-            elif isinstance(message, SystemMessage) and message.subtype == "init":
+            if isinstance(message, SystemMessage) and message.subtype == "init":
                 session_id = message.data.get("session_id")
                 logger.info("Session: %s", session_id)
+            elif isinstance(message, ResultMessage):
+                logger.info("Result: stop_reason=%s", message.stop_reason)
 
             log_f.write(json.dumps(entry, default=str) + "\n")
             log_f.flush()
 
     duration = time.monotonic() - start
+    total_cost = sum(float(m.get("total_cost_usd") or 0) for m in messages if m["_type"] == "ResultMessage")
+    turn_count = sum(1 for m in messages if m["_type"] == "AssistantMessage")
 
     metadata = {
         "model": model,
-        "cost_usd": cost_usd,
+        "cost_usd": total_cost,
         "duration_s": round(duration, 1),
         "turns": turn_count,
         "session_id": session_id,
@@ -135,7 +128,7 @@ async def run(output_dir: Path, model: str) -> None:
     (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
 
     artifacts = sorted(str(p.relative_to(workspace)) for p in workspace.rglob("*") if p.is_file())
-    logger.info("Done. %d turns, $%.4f, %.0fs", turn_count, cost_usd, duration)
+    logger.info("Done. %d turns, $%.4f, %.0fs", turn_count, total_cost, duration)
     logger.info("Artifacts: %s", artifacts)
 
 
@@ -145,8 +138,9 @@ def main() -> None:
     parser.add_argument("output_dir", type=Path, help="Directory for eval outputs")
     parser.add_argument("--model", default="claude-sonnet-4-6", help="Model to use")
     args = parser.parse_args()
-    args.output_dir.mkdir(parents=True, exist_ok=True)
-    asyncio.run(run(args.output_dir, args.model))
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    asyncio.run(run(output_dir, args.model))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR introduces a complete evaluation framework for testing LLM agents' ability to use the FreeCAD skill to produce parametric CAD models. It includes an evaluation runner, a baseplate task specification, and evaluation criteria.

## Key Changes

- **Evaluation Runner** (`run_eval.py`): Orchestrates agent evaluation by:
  - Loading a FreeCAD Docker image and setting up a containerized workspace
  - Staging skill files (SKILL.md, example scripts) as read-only mounts
  - Running the agent via Claude Agent SDK with MCP tools (exec, read_image)
  - Logging all agent messages to a transcript (JSONL format)
  - Collecting metadata (cost, duration, turn count, session ID)

- **Baseplate Task** (`baseplate/TASK.md`): Specifies a parametric mounting baseplate with:
  - 200×120 mm rectangular plate with 10 mm corner fillets
  - 4 mounting holes (8 mm diameter) at inset corners
  - Centered rectangular slot (40×15 mm)
  - All dimensions driven by spreadsheet for parametric behavior
  - TechDraw dimensioned view requirement

- **Evaluation Checklist** (`baseplate/CHECKLIST.md`): Provides human/LLM judges with:
  - Detailed criteria across script execution, sketch quality, geometry, parametric behavior, and TechDraw
  - Weighted scoring rubric (18 points total)
  - Inspection guidance referencing `inspection.json` outputs

- **Documentation** (`README.md`): Documents the evaluation flow, usage, output structure, and task organization

- **Build Configuration** (`BUILD.bazel`): Defines the evaluation binary with dependencies on FreeCAD Docker image, skill files, and MCP infrastructure

## Implementation Details

- The runner uses `ClaudeAgentOptions` with `max_turns=200` and `permission_mode="bypassPermissions"` to allow the agent full access to MCP tools
- Skill files are copied to a host directory and bind-mounted read-only into the container at `/skill`
- The system prompt guides the agent to read SKILL.md before starting and use provided example scripts as reference
- Transcript logging captures all message types (AssistantMessage, ResultMessage, SystemMessage) with timestamps for full evaluation traceability
- Output structure separates agent workspace artifacts from evaluation metadata for easy inspection and scoring

https://claude.ai/code/session_01JPccpag8X7h844Yrgs9M1Z