### PR TITLE
Drop Vault dependency from harbor-config TF module

### DIFF
--- a/cluster/k8s/harbor/oidc-config/tf.yaml
+++ b/cluster/k8s/harbor/oidc-config/tf.yaml
@@ -26,5 +26,3 @@ spec:
       value: "https://auth.allegedly.works"
     - name: harbor_url
       value: "http://harbor-core.harbor:80"
-    - name: vault_address
-      value: "http://instance.vault.svc.cluster.local:8200"

--- a/cluster/terraform/gitops/sso/harbor-config/BUILD.bazel
+++ b/cluster/terraform/gitops/sso/harbor-config/BUILD.bazel
@@ -5,7 +5,6 @@ tf_providers_versions(
     providers = {
         "harbor": "goharbor/harbor:~>3.11",
         "kubernetes": "hashicorp/kubernetes:~>2.38.0",
-        "vault": "hashicorp/vault:~>5.7.0",
     },
     tf_version = "1.9.8",
 )
@@ -15,7 +14,6 @@ tf_module(
     providers = [
         "harbor",
         "kubernetes",
-        "vault",
     ],
     providers_versions = ":providers",
 )

--- a/cluster/terraform/gitops/sso/harbor-config/main.tf
+++ b/cluster/terraform/gitops/sso/harbor-config/main.tf
@@ -10,24 +10,11 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.38.0"
     }
-    vault = {
-      source  = "hashicorp/vault"
-      version = "~> 5.7.0"
-    }
   }
 
   backend "kubernetes" {
     secret_suffix = "harbor-oidc-config"
     namespace     = "flux-system"
-  }
-}
-
-provider "vault" {
-  address = var.vault_address
-  auth_login_jwt {
-    mount = "kubernetes"
-    role  = "tf-runner"
-    jwt   = fileexists("/var/run/secrets/kubernetes.io/serviceaccount/token") ? file("/var/run/secrets/kubernetes.io/serviceaccount/token") : "not-in-cluster"
   }
 }
 
@@ -45,10 +32,12 @@ provider "harbor" {
   password = data.kubernetes_secret.harbor_admin_password.data["HARBOR_ADMIN_PASSWORD"]
 }
 
-# Read OIDC credentials stored by harbor SSO provider module
-data "vault_kv_secret_v2" "harbor_oidc" {
-  mount = "kv"
-  name  = "sso/harbor"
+# OIDC credentials from ESO-synced K8s secret (source: kv/sso/harbor in Vault)
+data "kubernetes_secret" "harbor_oidc" {
+  metadata {
+    name      = "harbor-oauth-client-secret"
+    namespace = "harbor"
+  }
 }
 
 # Configure Harbor OIDC authentication with Authentik
@@ -57,8 +46,8 @@ resource "harbor_config_auth" "oidc" {
 
   oidc_name          = "Authentik"
   oidc_endpoint      = "${var.authentik_url}/application/o/harbor/"
-  oidc_client_id     = jsondecode(data.vault_kv_secret_v2.harbor_oidc.data_json)["client_id"]
-  oidc_client_secret = jsondecode(data.vault_kv_secret_v2.harbor_oidc.data_json)["client_secret"]
+  oidc_client_id     = data.kubernetes_secret.harbor_oidc.data["client_id"]
+  oidc_client_secret = data.kubernetes_secret.harbor_oidc.data["client_secret"]
   oidc_scope         = "openid,email,profile"
   oidc_verify_cert   = true
 

--- a/cluster/terraform/gitops/sso/harbor-config/variables.tf
+++ b/cluster/terraform/gitops/sso/harbor-config/variables.tf
@@ -9,7 +9,3 @@ variable "authentik_url" {
   type        = string
 }
 
-variable "vault_address" {
-  description = "Vault server address"
-  type        = string
-}


### PR DESCRIPTION
## Summary

- Read OIDC client credentials from K8s Secret `harbor-oauth-client-secret` (ESO-synced from Vault) instead of hitting Vault directly
- Remove `vault` provider, `vault_address` variable, and JWT auth boilerplate
- The TF runner already has K8s access, so the Vault round-trip was unnecessary

## Test plan

- [ ] `bbr build //cluster/terraform/gitops/sso/harbor-config` passes
- [ ] tofu-controller reconciles `harbor-oidc-config` successfully
- [ ] Harbor OIDC login still works after reconciliation

https://claude.ai/code/session_01UH89sEjbCdDjtY4u9w2Zam