### PR TITLE
Add agent service account for Authentik proxy bearer token auth

### DIFF
--- a/cluster/k8s/agents/machine-access-tf/agent-machine-access-tf.yaml
+++ b/cluster/k8s/agents/machine-access-tf/agent-machine-access-tf.yaml
@@ -1,0 +1,21 @@
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: agent-machine-access
+  namespace: flux-system
+spec:
+  interval: 15m
+  approvePlan: "auto"
+  path: ./cluster/terraform/gitops/agent-machine-access
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  serviceAccountName: tf-runner
+  backendConfig:
+    customConfiguration: |
+      backend "kubernetes" {
+        secret_suffix    = "agent-machine-access"
+        namespace        = "flux-system"
+      }
+  vars: []

--- a/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
+++ b/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agent-machine-access-tf
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  path: ./cluster/k8s/agents/machine-access-tf
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  healthChecks:
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: agent-machine-access
+      namespace: flux-system
+  timeout: 10m
+  dependsOn:
+    - name: tofu-controller
+    - name: authentik

--- a/cluster/k8s/agents/machine-access-tf/kustomization.yaml
+++ b/cluster/k8s/agents/machine-access-tf/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - agent-machine-access-tf.yaml

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -55,6 +55,7 @@ resources:
   - agents/openclaw/gateway/flux-kustomization.yaml
   - agents/openclaw/sandbox/flux-kustomization.yaml
   - agents/openclaw/sandbox-secrets/flux-kustomization.yaml
+  - agents/machine-access-tf/flux-kustomization.yaml
 
   # --- kyverno ---
   - kyverno/app/flux-kustomization.yaml

--- a/cluster/terraform/gitops/agent-machine-access/BUILD.bazel
+++ b/cluster/terraform/gitops/agent-machine-access/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
+
+tf_providers_versions(
+    name = "providers",
+    providers = {
+        "authentik": "goauthentik/authentik:~>2025.10.0",
+        "kubernetes": "hashicorp/kubernetes:~>2.35",
+    },
+    tf_version = "1.9.8",
+)
+
+tf_module(
+    name = "agent-machine-access",
+    providers = [
+        "authentik",
+        "kubernetes",
+    ],
+    providers_versions = ":providers",
+)

--- a/cluster/terraform/gitops/agent-machine-access/main.tf
+++ b/cluster/terraform/gitops/agent-machine-access/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    authentik = {
+      source  = "goauthentik/authentik"
+      version = "~> 2025.10.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+
+  backend "kubernetes" {
+    secret_suffix = "agent-machine-access"
+    namespace     = "flux-system"
+  }
+}
+
+# Read the Authentik bootstrap token from the K8s Secret (populated by ESO from Vault).
+data "kubernetes_secret" "authentik_bootstrap" {
+  metadata {
+    name      = "authentik-bootstrap"
+    namespace = "authentik"
+  }
+}
+
+provider "authentik" {
+  url   = "http://authentik-server.authentik.svc.cluster.local"
+  token = data.kubernetes_secret.authentik_bootstrap.data["AUTHENTIK_BOOTSTRAP_TOKEN"]
+}
+
+# --- Service Account ---
+# Shared service account for Claude/OpenClaw sandbox agents.
+# Add authentik_policy_binding resources below to grant access to more apps.
+
+resource "authentik_user" "agent_sa" {
+  username = "agent-service-account"
+  name     = "Agent Service Account"
+  type     = "service_account"
+  path     = "goauthentik.io/service-accounts"
+}
+
+resource "authentik_token" "agent_sa_token" {
+  identifier   = "agent-api-key"
+  user         = authentik_user.agent_sa.id
+  intent       = "api"
+  expiring     = false
+  retrieve_key = true
+  description  = "Bearer token for Claude/OpenClaw sandbox agents"
+}
+
+# K8s secret in claude-sandbox with Reflector annotations for openclaw-sandbox.
+resource "kubernetes_secret" "agent_bearer_token" {
+  metadata {
+    name      = "agent-bearer-token"
+    namespace = "claude-sandbox"
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "openclaw-sandbox"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "openclaw-sandbox"
+    }
+  }
+
+  data = {
+    token = authentik_token.agent_sa_token.key
+  }
+}
+
+# --- Application Bindings ---
+# Each binding grants the agent service account access to a proxied application.
+# To add a new app: look up by slug, add a policy binding.
+# Example:
+#
+# data "authentik_application" "myapp" {
+#   slug = "myapp"
+# }
+#
+# resource "authentik_policy_binding" "agent_myapp" {
+#   target = data.authentik_application.myapp.id
+#   user   = authentik_user.agent_sa.id
+#   order  = 10
+# }


### PR DESCRIPTION
## Summary

- Terraform module creating a shared Authentik service account + bearer token for Claude/OpenClaw sandbox agents
- Authentik generates the token key; Terraform reads it back and writes to K8s Secret in `claude-sandbox` with Reflector to `openclaw-sandbox`
- Reads API token from K8s Secret (ESO-synced from Vault) — no direct Vault dependency
- No application bindings yet — add `authentik_policy_binding` resources to grant access to specific proxied apps (e.g., Grocy)
- First use of the Authentik Terraform provider in the codebase

## Test plan

- [ ] `bbr build //cluster/terraform/gitops/agent-machine-access` passes
- [ ] tofu-controller reconciles `agent-machine-access` successfully
- [ ] `kubectl get secret agent-bearer-token -n claude-sandbox` contains a token
- [ ] `kubectl get secret agent-bearer-token -n openclaw-sandbox` exists (Reflector)

https://claude.ai/code/session_01UH89sEjbCdDjtY4u9w2Zam