### PR TITLE
Bind agent service account to Grocy application

### DIFF
--- a/cluster/terraform/gitops/agent-machine-access/main.tf
+++ b/cluster/terraform/gitops/agent-machine-access/main.tf
@@ -72,14 +72,13 @@ resource "kubernetes_secret" "agent_bearer_token" {
 # --- Application Bindings ---
 # Each binding grants the agent service account access to a proxied application.
 # To add a new app: look up by slug, add a policy binding.
-# Example:
-#
-# data "authentik_application" "myapp" {
-#   slug = "myapp"
-# }
-#
-# resource "authentik_policy_binding" "agent_myapp" {
-#   target = data.authentik_application.myapp.id
-#   user   = authentik_user.agent_sa.id
-#   order  = 10
-# }
+
+data "authentik_application" "grocy" {
+  slug = "grocy"
+}
+
+resource "authentik_policy_binding" "agent_grocy" {
+  target = data.authentik_application.grocy.id
+  user   = authentik_user.agent_sa.id
+  order  = 10
+}


### PR DESCRIPTION
## Summary

- Add `authentik_policy_binding` granting the agent service account access to Grocy
- Agents can now use the bearer token to access `grocy.allegedly.works` through the Authentik proxy outpost
- Depends on #1212 (already merged)

## Test plan

- [ ] `bbr build //cluster/terraform/gitops/agent-machine-access` passes
- [ ] tofu-controller reconciles successfully
- [ ] `curl -H 'Authorization: Bearer <token>' https://grocy.allegedly.works/api/system/info` returns Grocy info (once Grocy is unsuspended)

https://claude.ai/code/session_01UH89sEjbCdDjtY4u9w2Zam