### PR TITLE
Persist DUCKTAPE_CLAUDE_HOOKS_PROFILE via Claude settings file

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -95,7 +95,11 @@ for bin in "${NIX_PROFILE}"/bin/*; do
 done
 
 # --- Step 3: Set profile for web mode ---
-export DUCKTAPE_CLAUDE_HOOKS_PROFILE=.claude_hooks/web.yaml
+# Write to .claude/settings.local.json so Claude Code injects the env var into
+# hook processes — the export below only covers the current shell process.
+SETTINGS_LOCAL="${FLAKE#path:}/.claude/settings.local.json"
+echo '{"env":{"DUCKTAPE_CLAUDE_HOOKS_PROFILE":".claude_hooks/web.yaml"}}' > "$SETTINGS_LOCAL"
+echo "[$(date -Iseconds)] Wrote DUCKTAPE_CLAUDE_HOOKS_PROFILE to ${SETTINGS_LOCAL}"
 
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's


### PR DESCRIPTION
## Summary
Updated the web setup script to persist the `DUCKTAPE_CLAUDE_HOOKS_PROFILE` environment variable through Claude's settings file instead of relying on shell exports, ensuring the configuration is properly injected into hook processes.

## Key Changes
- Replaced shell `export` statement with writing to `.claude/settings.local.json`
- The settings file now contains the environment variable configuration in JSON format: `{"env":{"DUCKTAPE_CLAUDE_HOOKS_PROFILE":".claude_hooks/web.yaml"}}`
- Added logging to track when the settings file is written with a timestamp
- Added explanatory comment clarifying why this approach is necessary (shell exports only affect the current process, not child hook processes)

## Implementation Details
- The settings file path is constructed using the `FLAKE` variable with the `path:` prefix stripped
- Uses `echo` to write the JSON configuration atomically
- Includes ISO 8601 formatted timestamp in the log output for debugging purposes

https://claude.ai/code/session_01QZaQdptu4LixaBDi1kc65z