### PR TITLE
pre-commit: remove pass_filenames:false from ducktape-commit-msg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -232,7 +232,6 @@ repos:
         name: ducktape commit-msg
         entry: ducktape-commit-msg
         language: system
-        pass_filenames: false
         always_run: true
         stages: [commit-msg]
 


### PR DESCRIPTION
## Summary

- Removes `pass_filenames: false` from the `ducktape-commit-msg` pre-commit hook entry

## Why

Pre-commit passes the commit message file path as the sole argument to `commit-msg` stage hooks. With `pass_filenames: false` set, that argument was suppressed, leaving `sys.argv[1:]` empty. When `DUCKTAPE_PRECOMMIT_ENFORCE_TEST_TAG=1` (set by the session start hook), `_run_commit_msg` hits the early-exit guard and returns 1 with "commit message file path required as argument" — breaking all commits in web sessions.

Removing the line restores the default behaviour: pre-commit passes the commit-msg file, the hook can read and validate it.

https://claude.ai/code/session_01T2LVw83yXBEArNGcPw2dS4