### PR TITLE
feat(web_setup): add github-no-proxy remote + fix rootfs tuning

### DIFF
--- a/.claude_hooks/web.yaml
+++ b/.claude_hooks/web.yaml
@@ -36,7 +36,16 @@ background_commands:
       apt-get install -y -qq libgirepository-2.0-dev libcairo2-dev libdbus-1-dev
     timeout: 300
   - name: rootfs tuning
-    command: /sbin/tune2fs -m 1 /dev/vda
+    command: |
+      if ! test -b /dev/vda; then
+        echo "rootfs tuning: /dev/vda not present (not a Firecracker VM?), skipping"
+        exit 0
+      fi
+      BEFORE=$(tune2fs -l /dev/vda | awk '/Reserved block count:/ {print $NF}')
+      TOTAL=$(tune2fs -l /dev/vda | awk '/Block count:/ {print $NF}')
+      PCT=$(awk "BEGIN {printf \"%.1f\", $BEFORE * 100 / $TOTAL}")
+      echo "Reserved blocks before tuning: $BEFORE / $TOTAL ($PCT%)"
+      /sbin/tune2fs -m 1 /dev/vda
     timeout: 30
   - name: pre-commit setup
     command: pre-commit install --install-hooks

--- a/.claude_hooks/web.yaml
+++ b/.claude_hooks/web.yaml
@@ -41,11 +41,11 @@ background_commands:
         echo "rootfs tuning: /dev/vda not present (not a Firecracker VM?), skipping"
         exit 0
       fi
-      BEFORE=$(tune2fs -l /dev/vda | awk '/Reserved block count:/ {print $NF}')
-      TOTAL=$(tune2fs -l /dev/vda | awk '/Block count:/ {print $NF}')
-      PCT=$(awk "BEGIN {printf \"%.1f\", $BEFORE * 100 / $TOTAL}")
-      echo "Reserved blocks before tuning: $BEFORE / $TOTAL ($PCT%)"
-      /sbin/tune2fs -m 1 /dev/vda
+      echo "--- tune2fs -l /dev/vda (before) ---"
+      tune2fs -l /dev/vda
+      tune2fs -m 1 /dev/vda
+      echo "--- tune2fs -l /dev/vda (after) ---"
+      tune2fs -l /dev/vda
     timeout: 30
   - name: pre-commit setup
     command: pre-commit install --install-hooks

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -133,15 +133,14 @@ echo "[$(date -Iseconds)] Wrote profile + secrets to ${SETTINGS_LOCAL}"
 # Fix: add a 'github-no-proxy' remote that points directly at GitHub. Set
 # buildbuddy.remote-bazel-remote-name so 'bb remote' uses it without
 # prompting interactively (the prompt would get EOF in non-TTY sessions).
-REPO_DIR="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$PROJECT_DIR")"
 GITHUB_REMOTE_URL="https://github.com/agentydragon/ducktape"
-if git -C "$REPO_DIR" remote get-url github-no-proxy &>/dev/null; then
+if git -C "$PROJECT_DIR" remote get-url github-no-proxy &>/dev/null; then
   echo "[$(date -Iseconds)] git remote 'github-no-proxy' already exists, skipping."
 else
-  git -C "$REPO_DIR" remote add github-no-proxy "$GITHUB_REMOTE_URL"
+  git -C "$PROJECT_DIR" remote add github-no-proxy "$GITHUB_REMOTE_URL"
   echo "[$(date -Iseconds)] Added git remote 'github-no-proxy' -> $GITHUB_REMOTE_URL"
 fi
-git -C "$REPO_DIR" config buildbuddy.remote-bazel-remote-name github-no-proxy
+git -C "$PROJECT_DIR" config buildbuddy.remote-bazel-remote-name github-no-proxy
 echo "[$(date -Iseconds)] Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
 
 # --- Step 5: Symlink skills into ~/.claude/skills/ ---

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -123,7 +123,28 @@ Path(os.environ["SETTINGS_LOCAL"]).write_text(
 PYEOF
 echo "[$(date -Iseconds)] Wrote profile + secrets to ${SETTINGS_LOCAL}"
 
-# --- Step 4: Symlink skills into ~/.claude/skills/ ---
+# --- Step 4: Add github-no-proxy remote for bbr ---
+# Claude Code web sessions use a local git proxy as 'origin'
+# (http://127.0.0.1:<port>/git/...). When 'bb remote' sends a RunRequest to
+# the BuildBuddy cloud runner, it embeds the selected remote's URL in
+# RepoState.repo.url. The runner then fetches from that URL. The local proxy
+# URL is unreachable from the cloud runner, so bbr fails.
+#
+# Fix: add a 'github-no-proxy' remote that points directly at GitHub. Set
+# buildbuddy.remote-bazel-remote-name so 'bb remote' uses it without
+# prompting interactively (the prompt would get EOF in non-TTY sessions).
+REPO_DIR="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$PROJECT_DIR")"
+GITHUB_REMOTE_URL="https://github.com/agentydragon/ducktape"
+if git -C "$REPO_DIR" remote get-url github-no-proxy &>/dev/null; then
+  echo "[$(date -Iseconds)] git remote 'github-no-proxy' already exists, skipping."
+else
+  git -C "$REPO_DIR" remote add github-no-proxy "$GITHUB_REMOTE_URL"
+  echo "[$(date -Iseconds)] Added git remote 'github-no-proxy' -> $GITHUB_REMOTE_URL"
+fi
+git -C "$REPO_DIR" config buildbuddy.remote-bazel-remote-name github-no-proxy
+echo "[$(date -Iseconds)] Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
+
+# --- Step 5: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.
 echo "Deploying skills to ~/.claude/skills/..."


### PR DESCRIPTION
## Summary

**`web_setup.sh`: add `github-no-proxy` remote for `bbr`**

Claude Code web sessions proxy all git traffic through a local sidecar
(`origin` = `http://127.0.0.1:<port>/git/...`). When `bb remote` builds
a `RunRequest`, it embeds the selected remote's URL so the cloud runner
knows where to fetch. The local proxy URL is unreachable from the runner,
so `bbr build`/`bbr test` fail.

`web_setup.sh` now:
- Adds a `github-no-proxy` remote pointing directly at GitHub
- Sets `buildbuddy.remote-bazel-remote-name=github-no-proxy` in `.git/config`
  so `bb remote` uses it without an interactive prompt (which gets EOF in
  non-TTY hook subprocesses)

**`web.yaml`: defensive rootfs tuning**

- Guard `tune2fs -m 1 /dev/vda` with `test -b /dev/vda` so gVisor sessions
  (9p root, no block device) skip cleanly instead of failing with exit 1
- Print `Reserved blocks before tuning: N / M (X%)` before changing, so the
  daemon log records the initial state

## Test plan

- [ ] `web_setup.sh` adds remote idempotently (re-run is safe — skips if already present)
- [ ] `bbr build //...` no longer prompts for remote selection after setup
- [ ] Rootfs tuning step passes on gVisor (no `/dev/vda`) and Firecracker (has `/dev/vda`)

https://claude.ai/code/session_01T2LVw83yXBEArNGcPw2dS4