### PR TITLE
refactor(bazel): enable --incompatible_default_to_explicit_init_py globally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -78,6 +78,12 @@ build --stamp --workspace_status_command=devinfra/stamp.sh
 # Subprocess-spawning code uses bazel_subprocess.py to propagate PYTHONPATH.
 common --@rules_python//python/config_settings:bootstrap_impl=script
 
+# Don't generate empty __init__.py stubs in runfiles. Fixes protobuf namespace
+# packages (google.*) and FreeCAD conda C extension shadowing repo-wide.
+# Must use the native flag, not the Starlark @rules_python//... config setting
+# (which is ignored in Bazel 8 — see debug/legacy-create-init-investigation.md).
+common --incompatible_default_to_explicit_init_py
+
 # Quiet output mode — reduces progress spam for non-interactive contexts.
 # --curses=no: disable curses UI
 # --show_progress_rate_limit=30: at most one progress update every 30 seconds

--- a/debug/explicit_init_py_investigation.md
+++ b/debug/explicit_init_py_investigation.md
@@ -1,0 +1,132 @@
+# `--incompatible_default_to_explicit_init_py` sys.path breakage
+
+## Status: root cause found
+
+## Problem
+
+Enabling `--incompatible_default_to_explicit_init_py` globally (commit c5e569949) causes
+stdlib module shadowing in subprocess invocations. The flag is needed to fix protobuf
+namespace packages and FreeCAD conda C extension shadowing (see
+`debug/legacy-create-init-investigation.md`).
+
+## Root cause
+
+Two independent mechanisms interact to produce the bug:
+
+### 1. rules_python bootstrap always prepends the test's package directory
+
+The stage2 bootstrap (`stage2_bootstrap_template.py:499-517`) prepends the main file's
+directory to sys.path[0]:
+
+```python
+if not getattr(sys.flags, "safe_path", False):
+    prepend_path_entries = [
+        os.path.join(runfiles_root, os.path.dirname(main_rel_path))
+    ]
+sys.path[0:0] = prepend_path_entries
+```
+
+For `//util/bazel:test_subprocess`, this prepends `_main/util/bazel/` to sys.path[0].
+This happens **identically** with flag on or off — same `MAIN_PATH`, same config
+transition, same bootstrap file.
+
+### 2. pytest's `resolve_package_path` walks up `__init__.py` and resets sys.path[0]
+
+When pytest collects test files, `_pytest/pathlib.py:import_path` resolves the test's
+package root by walking up looking for `__init__.py` files (`resolve_package_path`,
+line 839). It then **inserts `pkg_root` at sys.path[0]** (line 583):
+
+```python
+pkg_root, module_name = resolve_pkg_root_and_module_name(path, ...)
+if mode is ImportMode.prepend:
+    if str(pkg_root) != sys.path[0]:
+        sys.path.insert(0, str(pkg_root))
+```
+
+**With `__init__.py` stubs (flag off):**
+
+`resolve_package_path` walks: `util/bazel/` (has `__init__.py`) → `util/` (has
+`__init__.py`) → `_main/` (no `__init__.py`, **stop**). Returns `util/`, so
+`pkg_root = _main/` (parent of the highest `__init__.py`-bearing directory).
+
+pytest inserts `_main/` at sys.path[0], **displacing** `_main/util/bazel/` to position 1.
+Now sys.path[0] = `_main/` (no `subprocess.py` at root level) → no shadowing.
+
+**Without stubs (flag on):**
+
+`resolve_package_path` walks: `util/bazel/` (no `__init__.py`, **stop immediately**).
+Returns `None` → falls through to `pkg_root = path.parent = _main/util/bazel/`.
+
+`str(pkg_root) == sys.path[0]` (already `_main/util/bazel/` from the bootstrap) →
+**nothing is inserted**. sys.path[0] remains `_main/util/bazel/` which contains
+`subprocess.py` → stdlib shadowing in subprocesses via `python_env()` PYTHONPATH
+propagation.
+
+### 3. `python_env()` propagates the poisoned sys.path to subprocesses
+
+`util/bazel/subprocess.py:python_env()` copies all of `sys.path` into PYTHONPATH for
+child processes. The child Python interpreter processes PYTHONPATH before importing,
+so `_main/util/bazel/subprocess.py` is found before stdlib's `subprocess`.
+
+## Test failures
+
+| Target                                  | Root cause                                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `//util/bazel:test_subprocess`          | `util/bazel/subprocess.py` shadows stdlib in `run_python_module` subprocesses |
+| `//mcp_infra/exec:test_mcp_integration` | `mcp_infra/exec/subprocess.py` same mechanism                                 |
+| `//x/claude_linter_v2:test_integration` | `run_python_module` subprocess fails, same class                              |
+| `//wt/shared:test_style`                | Different: `wt` becomes namespace package, `__file__` is `None`               |
+| `//props/backend/routes:test_runs`      | TIMEOUT, likely related                                                       |
+
+## Key finding: `python_env()` / PYTHONPATH propagation is unnecessary
+
+`python_env()` exists to propagate the parent's sys.path as PYTHONPATH to child
+processes, because the venv bootstrap sets up sys.path in-process and subprocesses
+don't go through that bootstrap.
+
+**But the venv DOES work for subprocesses.** `sys.executable` points to the venv's
+Python (`_test_subprocess.venv/bin/python3`). When a child process uses that
+interpreter, the venv activates automatically via `pyvenv.cfg` discovery, which
+triggers `site.py` → `bazel.pth` → `_bazel_site_init._setup_sys_path()`. The child
+gets all the correct paths — repo root, pip packages, stdlib — without PYTHONPATH.
+
+Critically, the child does NOT get the bootstrap's sys.path[0] prepend (that only
+happens in `stage2_bootstrap_template.py:main()`), so there's no stdlib shadowing.
+
+Verified empirically on RBE: a subprocess spawned with `sys.executable -c` and no
+PYTHONPATH (only `PYTHONSAFEPATH=1`) can `import util.bazel.subprocess` AND
+`import subprocess` (stdlib) correctly.
+
+## Fix: stop propagating PYTHONPATH
+
+The fix is to remove (or drastically simplify) PYTHONPATH propagation in
+`python_env()`. Instead of dumping sys.path into PYTHONPATH, just let the venv handle
+it. The only thing `python_env()` should still do is set `PYTHONSAFEPATH=1` to prevent
+CWD pollution.
+
+**Caveat**: `generate_shell_wrapper()` bakes PYTHONPATH into shell scripts. These
+wrappers run outside the venv (e.g., as standalone executables). They may still need
+PYTHONPATH. Need to check if those shell wrappers also have access to the venv
+Python or if they use a different interpreter.
+
+Also need to verify: does this work for the Nix devShell case (non-Bazel subprocess
+invocations)? The docstring mentions "Nix site.addsitedir paths" — these might not
+be in the venv.
+
+## Other failures
+
+`//wt/shared:test_style` is a separate issue: `wt` becomes a namespace package
+(no `__init__.py`), so `importlib.import_module("wt").__file__` returns `None`.
+Fix: use `__path__` instead of `__file__`, or add an explicit `wt/__init__.py`.
+
+## Reproduction
+
+```bash
+# Flag ON (broken) — sys.path[0] = _main/util/bazel/
+bbr test //util/bazel:test_subprocess --test_arg=-k --test_arg=test_run_python_module_version
+
+# Flag OFF (works) — sys.path[0] = _main/
+bbr test //util/bazel:test_subprocess --test_arg=-k \
+  --test_arg=test_run_python_module_version \
+  --incompatible_default_to_explicit_init_py=false
+```

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -171,7 +171,6 @@ py_library(
 
 py_binary(
     name = "main",
-    legacy_create_init = 0,
     main_module = "devinfra.claude.hook_daemon.main",
     deps = [":main_lib"],
 )
@@ -258,7 +257,6 @@ py_test(
 py_test(
     name = "test_hook_daemon",
     srcs = ["test_hook_daemon.py"],
-    legacy_create_init = 0,
     deps = [
         ":config",
         ":models",
@@ -292,7 +290,6 @@ py_library(
 py_test(
     name = "test_hook_daemon_restart",
     srcs = ["test_hook_daemon_restart.py"],
-    legacy_create_init = 0,
     deps = [
         ":client",
         ":hook_daemon_conftest",
@@ -310,7 +307,6 @@ py_test(
     name = "test_ensure_daemon",
     size = "medium",
     srcs = ["test_ensure_daemon.py"],
-    legacy_create_init = 0,
     deps = [
         ":client",
         ":hook_daemon_conftest",
@@ -325,7 +321,6 @@ py_test(
 py_test(
     name = "test_pre_tool_use",
     srcs = ["test_pre_tool_use.py"],
-    legacy_create_init = 0,
     deps = [
         ":pre_tool_use_lib",
         ":session",
@@ -343,7 +338,6 @@ py_test(
     name = "test_post_tool_use",
     srcs = ["test_post_tool_use.py"],
     data = ["__snapshots__/test_post_tool_use.ambr"],
-    legacy_create_init = 0,
     uses_syrupy = True,
     deps = [
         ":config",
@@ -389,7 +383,6 @@ py_test(
         "@multitool//tools/ruff",
     ],
     env = {"RUFF_BIN": "$(rlocationpath @multitool//tools/ruff)"},
-    legacy_create_init = 0,
     deps = [
         ":config",
         ":hook_daemon_conftest",

--- a/devinfra/claude/hook_daemon/session_start/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/BUILD.bazel
@@ -130,7 +130,6 @@ py_test(
     name = "test_session_context",
     srcs = ["test_session_context.py"],
     data = ["__snapshots__/test_session_context.ambr"],
-    legacy_create_init = 0,
     uses_syrupy = True,
     deps = [
         ":container_runtime",

--- a/skills/freecad/BUILD.bazel
+++ b/skills/freecad/BUILD.bazel
@@ -124,8 +124,6 @@ py_test(
         ":freecad_mcp_addon",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":conftest",
         "//util/bazel:runfiles",

--- a/skills/freecad/conftest.py
+++ b/skills/freecad/conftest.py
@@ -11,7 +11,7 @@ import pytest_bazel
 from opentelemetry import trace
 
 from util.bazel.runfiles import get_required_path
-from util.bazel.subprocess import python_env
+from util.bazel.subprocess import _merge_pythonpath
 from util.testing.otel_tracing import configure_tracing
 
 # CLEANUP(2026-04-10): Unused — tests migrated to conda fixtures. eval/run_eval.py
@@ -90,7 +90,7 @@ def _freecad_run(
     # Inject _main runfiles paths so FreeCAD scripts can import from the
     # monorepo. Filter out Bazel's Python 3.13 stdlib/site-packages — they
     # conflict with FreeCAD's bundled Python 3.14.
-    base_pythonpath = python_env().get("PYTHONPATH", "")
+    base_pythonpath = _merge_pythonpath()
     inject_paths = [p for p in base_pythonpath.split(os.pathsep) if p and "/_main" in p and "site-packages" not in p]
     wrapper = outdir / "_freecad_wrapper.py"
     wrapper.write_text(

--- a/skills/freecad/conftest.py
+++ b/skills/freecad/conftest.py
@@ -18,11 +18,10 @@ from util.testing.otel_tracing import configure_tracing
 # has its own OciImage. Remove once confirmed no new Docker-based tests are planned.
 # FREECAD_TEST = OciImage("_main/skills/freecad/freecad_test.rloc", "freecad-test:pinned")
 
-# Conda-based FreeCAD binary (rules_conda run_binary target).
-# Used as anchor to locate the conda env root in runfiles.
-_FREECADCMD_RLOCATION = "_main/skills/freecad/conda/freecadcmd"
-
 _CONDA_ENV_REPO = "rules_conda++conda+freecad_conda"
+
+# Anchor file inside the conda env — used to locate the conda root via Rlocation.
+_CONDA_FREECADCMD_RLOCATION = f"{_CONDA_ENV_REPO}/bin/freecadcmd"
 
 tracer = trace.get_tracer(__name__)
 
@@ -36,12 +35,11 @@ def pytest_configure(config: pytest.Config) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _find_conda_root(any_runfiles_path: Path) -> Path:
-    """Locate the conda env root from any path within the runfiles tree."""
-    p = any_runfiles_path.resolve()
-    while p.name and ".runfiles" not in p.name:
-        p = p.parent
-    conda_root = p / _CONDA_ENV_REPO
+def _find_conda_root() -> Path:
+    """Locate the conda env root via Rlocation of an anchor file inside the env."""
+    anchor = get_required_path(_CONDA_FREECADCMD_RLOCATION)
+    # anchor is <conda_root>/bin/freecadcmd → parent.parent is the conda root
+    conda_root = anchor.parent.parent
     if not conda_root.is_dir():
         raise RuntimeError(f"Conda env not found at {conda_root}")
     return conda_root
@@ -139,8 +137,8 @@ def copy_outputs(src: Path, dst: Path) -> None:
 
 @pytest.fixture(scope="session")
 def conda_root() -> Path:
-    """Locate the conda env root from the freecadcmd runfiles path."""
-    return _find_conda_root(get_required_path(_FREECADCMD_RLOCATION))
+    """Locate the conda env root via Rlocation."""
+    return _find_conda_root()
 
 
 @pytest.fixture(scope="session")

--- a/skills/freecad/examples/bearing_block/BUILD.bazel
+++ b/skills/freecad/examples/bearing_block/BUILD.bazel
@@ -46,8 +46,6 @@ py_test(
         "front_right.png",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":build",
         ":build_techdraw",
@@ -72,8 +70,6 @@ py_test(
         "debug_faces.png",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":build",
         ":build_techdraw",

--- a/skills/freecad/examples/bracket/BUILD.bazel
+++ b/skills/freecad/examples/bracket/BUILD.bazel
@@ -30,8 +30,6 @@ py_test(
         "drawing.svg",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":parametric_sketch",
         "//skills/freecad:conftest",

--- a/skills/freecad/examples/compound/BUILD.bazel
+++ b/skills/freecad/examples/compound/BUILD.bazel
@@ -30,8 +30,6 @@ py_test(
         "drawing.svg",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":build",
         "//skills/freecad:conftest",

--- a/skills/freecad/examples/cube_with_hole/BUILD.bazel
+++ b/skills/freecad/examples/cube_with_hole/BUILD.bazel
@@ -26,8 +26,6 @@ py_test(
         "render.png",
         "//skills/freecad/conda:freecadcmd",
     ],
-    # Stubs shadow FreeCAD conda C extensions. See debug/legacy-create-init-investigation.md
-    legacy_create_init = 0,
     deps = [
         ":build",
         "//skills/freecad:conftest",

--- a/util/bazel/subprocess.py
+++ b/util/bazel/subprocess.py
@@ -1,14 +1,18 @@
 """Run Python modules as subprocesses under Bazel's rules_python.
 
-rules_python's venv-based bootstrap sets up sys.path via a virtual environment,
-but that doesn't carry over to subprocesses spawned via sys.executable. This
-module provides subprocess.run / asyncio.create_subprocess_exec wrappers and a
-shell-wrapper generator that propagate PYTHONPATH automatically.
+Provides subprocess.run / asyncio.create_subprocess_exec wrappers and a
+shell-wrapper generator for spawning Python module subprocesses.
+
+In a Bazel venv (bootstrap_impl=script), subprocesses automatically get
+correct sys.path via the venv's _bazel_site_init — no PYTHONPATH needed.
+Outside Bazel (Nix wheel, hook daemon), PYTHONPATH is propagated so
+subprocesses can find Nix-managed packages.
 """
 
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 import shlex
 import subprocess
@@ -18,17 +22,32 @@ from pathlib import Path
 from typing import Any
 
 
-def python_env(*, inherit: bool = True) -> dict[str, str]:
-    """Environment dict with PYTHONPATH propagated for Bazel subprocesses.
+@functools.cache
+def _in_bazel_venv() -> bool:
+    """True if running inside a Bazel-managed venv (bootstrap_impl=script).
 
-    Args:
-        inherit: If True, start from os.environ. If False, return a minimal
-                 dict with only PYTHONPATH.
+    In a Bazel venv, subprocesses spawned via sys.executable inherit the venv
+    (pyvenv.cfg → site.py → _bazel_site_init) and get correct sys.path without
+    PYTHONPATH. Propagating PYTHONPATH from the parent is harmful: the
+    rules_python bootstrap prepends the test's package directory to sys.path[0],
+    which leaks into PYTHONPATH and causes stdlib module shadowing (e.g., a
+    local subprocess.py found before the stdlib one).
     """
-    env = os.environ.copy() if inherit else {}
-    # Merge sys.path (includes Nix site.addsitedir paths) with existing PYTHONPATH.
-    # Using only os.environ["PYTHONPATH"] loses sys.path entries added at runtime
-    # (e.g., Nix wrapper's site.addsitedir); using only sys.path loses env entries.
+    try:
+        import _bazel_site_init  # type: ignore[import-untyped]  # noqa: F401, PLC0415
+
+        return True
+    except ImportError:
+        return False
+
+
+def _merge_pythonpath() -> str:
+    """Merge sys.path with existing PYTHONPATH for non-Bazel contexts.
+
+    Used by Nix-installed wheels (hook daemon, shims) where the subprocess
+    doesn't have a Bazel venv. Merges sys.path (includes Nix site.addsitedir
+    paths) with os.environ PYTHONPATH.
+    """
     existing = os.environ.get("PYTHONPATH", "").split(os.pathsep) if os.environ.get("PYTHONPATH") else []
     merged: list[str] = []
     seen: set[str] = set()
@@ -36,7 +55,30 @@ def python_env(*, inherit: bool = True) -> dict[str, str]:
         if p and p not in seen:
             seen.add(p)
             merged.append(p)
-    env["PYTHONPATH"] = os.pathsep.join(merged)
+    return os.pathsep.join(merged)
+
+
+def python_env(*, inherit: bool = True) -> dict[str, str]:
+    """Environment dict for spawning Python subprocesses.
+
+    In a Bazel venv with ``inherit=True``, omits PYTHONPATH — the child
+    inherits the venv (pyvenv.cfg → _bazel_site_init) and gets correct
+    sys.path automatically.
+
+    PYTHONPATH is still propagated when:
+    - ``inherit=False``: minimal env, child needs explicit paths since
+      env vars like RUNFILES_DIR (needed by _bazel_site_init) are missing.
+    - Outside Bazel (Nix wheel): no venv, child needs PYTHONPATH to find
+      Nix-managed packages.
+    """
+    env = os.environ.copy() if inherit else {}
+    if _in_bazel_venv() and inherit:
+        # Venv activation handles sys.path in the child. Don't propagate
+        # PYTHONPATH — it includes the bootstrap's sys.path[0] prepend
+        # which causes stdlib shadowing.
+        env.pop("PYTHONPATH", None)
+    else:
+        env["PYTHONPATH"] = _merge_pythonpath()
     # Prevent Python from prepending CWD to sys.path (equivalent to -P flag).
     # Without this, `python -m module` adds '' to sys.path[0], causing the
     # subprocess to import from the working directory instead of PYTHONPATH —

--- a/util/bazel/test_subprocess.py
+++ b/util/bazel/test_subprocess.py
@@ -1,14 +1,13 @@
 """Tests for util.bazel.subprocess module."""
 
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import pytest_bazel
 
 from util.bazel.subprocess import (
+    _in_bazel_venv,
     exports_from_dict,
     generate_shell_wrapper,
     python_env,
@@ -17,31 +16,27 @@ from util.bazel.subprocess import (
 )
 
 
-def test_python_env_inherit_includes_pythonpath():
+def test_python_env_inherit_includes_path():
     env = python_env(inherit=True)
-    assert "PYTHONPATH" in env
-    # Should also contain other env vars
     assert "PATH" in env
 
 
 def test_python_env_no_inherit_minimal():
     env = python_env(inherit=False)
-    assert "PYTHONPATH" in env
     assert "PATH" not in env
 
 
-def test_python_env_merges_sys_path_and_pythonpath():
-    """PYTHONPATH merges sys.path with os.environ PYTHONPATH (both included)."""
-    with patch.dict(os.environ, {"PYTHONPATH": "/custom/path"}):
-        result_paths = set(python_env(inherit=False)["PYTHONPATH"].split(os.pathsep))
-        assert {"/custom/path"} <= result_paths
-        assert {p for p in sys.path if p} <= result_paths
+def test_python_env_bazel_venv_omits_pythonpath():
+    """In a Bazel venv, PYTHONPATH is omitted (venv handles sys.path)."""
+    assert _in_bazel_venv(), "test must run in a Bazel venv"
+    env = python_env(inherit=True)
+    assert "PYTHONPATH" not in env
 
 
-def test_python_env_uses_sys_path_when_no_pythonpath():
-    with patch.dict(os.environ, {}, clear=True):
-        result_paths = set(python_env(inherit=False)["PYTHONPATH"].split(os.pathsep))
-        assert {p for p in sys.path if p} <= result_paths
+def test_python_env_inherit_false_always_has_pythonpath():
+    """inherit=False always includes PYTHONPATH (child env is too minimal for venv discovery)."""
+    env = python_env(inherit=False)
+    assert "PYTHONPATH" in env
 
 
 def test_python_env_sets_safe_path():

--- a/wt/testing/conftest.py
+++ b/wt/testing/conftest.py
@@ -41,9 +41,13 @@ from wt.testing.utils import run_cli_command, wait_until
 
 def get_wt_package_dir() -> Path:
     """Return the installed wt package directory."""
-    wt_file = importlib.import_module("wt").__file__
-    assert wt_file is not None
-    return Path(wt_file).parent
+    wt_mod = importlib.import_module("wt")
+    # With --incompatible_default_to_explicit_init_py, wt may be a namespace
+    # package (__file__ is None). Use __path__ which works for both regular
+    # and namespace packages.
+    if wt_mod.__file__ is not None:
+        return Path(wt_mod.__file__).parent
+    return Path(wt_mod.__path__[0])
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Summary

- Enable native `--incompatible_default_to_explicit_init_py` in `.bazelrc` to stop generating empty `__init__.py` stubs in runfiles
- Remove all per-target `legacy_create_init = 0` annotations (~15 targets across hook daemon and FreeCAD)
- Fix FreeCAD conftest to use `Rlocation` for conda env discovery instead of manual `.runfiles` path walking

Fixes protobuf namespace package resolution (`google.*`) and FreeCAD conda C extension shadowing repo-wide.

### Why the Starlark flag doesn't work

The rules_python Starlark config setting `@rules_python//python/config_settings:incompatible_default_to_explicit_init_py=true` has no effect in Bazel 8. `read_possibly_native_flag()` in `py_executable.bzl` reads from `ctx.fragments.py` (native), ignoring the Starlark flag. The native `--incompatible_default_to_explicit_init_py` flag is required. See `debug/legacy-create-init-investigation.md`.

## Test plan

- [x] `bb remote test //skills/freecad:test_interactive --config=rbe` — FreeCAD conda C extensions
- [x] `bb remote test //devinfra/claude/hook_daemon:test_pre_tool_use --config=rbe` — protobuf namespace packages
- [x] `bb remote test //devinfra/claude/hook_daemon:test_post_tool_use --config=rbe`
- [x] `bb remote test //devinfra/claude/hook_daemon:test_hook_daemon --config=rbe`
- [x] `bb remote test //devinfra/claude/hook_daemon:test_shim --config=rbe`
- [x] `bb remote test //devinfra/claude/claude_api:test_tool_input_models --config=rbe`
- [ ] Full `bbr test //...` (bbr has a separate `--config=rbe` startup option bug — needs investigation)