### PR TITLE
docs(web_setup): log git commit + env keys; selfcheck VM reuse check; bb source in AGENTS

### DIFF
--- a/devinfra/claude/AGENTS.md
+++ b/devinfra/claude/AGENTS.md
@@ -9,6 +9,10 @@ The hook daemon's runtime Python dependencies are declared in **two places** tha
 
 When adding or removing a runtime dependency, update **both** lists. A mismatch causes `ModuleNotFoundError` at daemon startup in whichever environment has the stale list. Both files have `SYNC:` comments pointing to each other.
 
+## bb CLI Source
+
+The `bb` CLI is open source at <https://github.com/buildbuddy-io/buildbuddy>. Remote Bazel logic lives in `cli/remotebazel/remotebazel.go` and `cli/storage/storage.go`. When debugging `bb remote` behavior (remote selection, flag semantics, git config keys), read the source directly.
+
 ## Agent Instructions
 
 - **Hook daemon logs** (includes session start): `~/.claude/session-env/<session_id>/hook-daemon/daemon.log`

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -19,6 +19,8 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 set -euo pipefail
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
+echo "[$(date -Iseconds)] web_setup.sh commit: $SETUP_COMMIT"
 
 # --- Step 1: Install Nix (Determinate Systems installer) ---
 # Uses the Determinate Systems installer instead of the official one because:
@@ -63,9 +65,9 @@ unset _saved_user
 echo "[$(date -Iseconds)] Nix installation complete."
 
 # --- Step 2: Install web session tools ---
-# Debug: dump environment for proxy/cert diagnostics.
-echo "--- environment ---"
-env | sed 's/^\(DUCKTAPE_CLAUDE_HOOKS_K8S_TOKEN=\).*/\1<redacted>/' | sort
+# Debug: dump environment keys for proxy/cert diagnostics (no values — avoids logging JWTs).
+echo "--- environment keys ---"
+env | cut -d= -f1 | sort
 echo "---"
 
 echo "Connectivity check (cache.nixos.org)..."
@@ -131,9 +133,14 @@ echo "[$(date -Iseconds)] Wrote profile + secrets to ${SETTINGS_LOCAL}"
 # RepoState.repo.url. The runner then fetches from that URL. The local proxy
 # URL is unreachable from the cloud runner, so bbr fails.
 #
-# Fix: add a 'github-no-proxy' remote that points directly at GitHub. Set
-# buildbuddy.remote-bazel-remote-name so 'bb remote' uses it without
-# prompting interactively (the prompt would get EOF in non-TTY sessions).
+# Fix: add a 'github-no-proxy' remote that points directly at GitHub.
+#
+# bb source: https://github.com/buildbuddy-io/buildbuddy (cli/remotebazel/)
+#
+# bb auto-selects a single remote without prompting. With 2+ remotes it
+# prompts interactively. bb >= master (post-5.0.339) caches the last-used
+# remote in buildbuddy.remote-bazel-remote-name and skips the prompt on
+# subsequent runs. We set it here so it works as soon as bb is updated.
 GITHUB_REMOTE_URL="https://github.com/agentydragon/ducktape"
 if git -C "$PROJECT_DIR" remote get-url github-no-proxy &>/dev/null; then
   echo "[$(date -Iseconds)] git remote 'github-no-proxy' already exists, skipping."

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -50,7 +50,14 @@ Run all checks in parallel where possible.
 
 ### 1. web_setup.sh
 
-**Goal**: confirm Nix and the `devtools` profile were installed successfully.
+**Goal**: confirm Nix and the `devtools` profile were installed successfully,
+and that setup ran from the current repo commit.
+
+**VM reuse warning**: Anthropic reuses Firecracker microVMs between sessions.
+`/tmp` persists across reuses, so `/tmp/web-setup.log` may be from a prior
+session running an older version of `web_setup.sh`. Always verify the setup
+commit matches the current repo HEAD — a stale setup means Nix devtools and
+skills may not match what the current code expects.
 
 ```bash
 # Was it run at all?
@@ -63,16 +70,40 @@ stat -c '%y' /tmp/web-setup.log 2>/dev/null
 nix --version 2>/dev/null || echo "nix not found"
 # Is the devtools profile active?
 nix profile list 2>/dev/null | grep -E 'devtools|claude-hooks' | head -5 || echo "no devtools profile"
+
+# What commit did web_setup.sh run from?
+grep 'web_setup.sh commit:' /tmp/web-setup.log 2>/dev/null | tail -1 || echo "commit not logged (old web_setup.sh)"
+# Current repo HEAD
+git -C /home/user/ducktape rev-parse HEAD
+
+# Do they match?
+SETUP_COMMIT=$(grep 'web_setup.sh commit:' /tmp/web-setup.log 2>/dev/null | tail -1 | grep -oE '[0-9a-f]{40}' || echo '')
+HEAD_COMMIT=$(git -C /home/user/ducktape rev-parse HEAD)
+if [ -z "$SETUP_COMMIT" ]; then
+  echo "UNKNOWN: web_setup.sh predates commit logging — assume STALE"
+elif [ "$SETUP_COMMIT" = "$HEAD_COMMIT" ]; then
+  echo "OK: setup commit matches HEAD ($HEAD_COMMIT)"
+else
+  echo "STALE: setup ran from ${SETUP_COMMIT:0:12}, HEAD is ${HEAD_COMMIT:0:12}"
+fi
+
+# What env var keys were present when web_setup.sh ran?
+grep -A200 'environment keys' /tmp/web-setup.log 2>/dev/null | grep -B200 '^---$' | grep -v '^---'
 ```
 
 **Failure indicators**: log missing, last line not "Setup complete", nix not
-found, devtools not in profile list.
+found, devtools not in profile list, setup commit doesn't match HEAD.
 
 **Fix**: re-run setup from the Claude Code web UI setup command:
 
 ```
 bash ducktape/devinfra/claude/web_setup.sh
 ```
+
+If re-running, note that `SOPS_AGE_KEY` is typically not available when
+`web_setup.sh` runs — all SOPS decryptions will fail. Secrets are instead
+decrypted by the session start hook daemon (which inherits `SOPS_AGE_KEY`
+from the container after k8s injects it). This is expected and not a bug.
 
 ---
 
@@ -512,6 +543,7 @@ After running all checks, produce:
 | Check                        | Status   | Detail                                          |
 | ---------------------------- | -------- | ----------------------------------------------- |
 | web_setup.sh ran             | OK/FAIL  | ...                                             |
+| web_setup.sh commit          | OK/STALE | setup=<sha12> head=<sha12> (VM reuse risk)      |
 | claude-hooks daemon version  | OK/STALE | pinned=<sha> head=<sha> N commits behind; CI status |
 | Session start hook           | OK/FAIL  | CANARY present / FileNotFoundError              |
 | SOPS_AGE_KEY                 | OK/FAIL  | age public key matches .sops.yaml               |


### PR DESCRIPTION
## Summary

- **`web_setup.sh`**: log the git commit it runs from at startup; change env dump to key names only (was leaking JWT proxy tokens as values); fix misleading comment on `buildbuddy.remote-bazel-remote-name`
- **`skills/web_selfcheck/SKILL.md`**: add VM reuse warning + commit-match check to Check 1; note SOPS failure at setup time is expected; add report table row
- **`devinfra/claude/AGENTS.md`**: document bb CLI source at github.com/buildbuddy-io/buildbuddy

## Motivation

Anthropic reuses Firecracker microVMs between sessions — `/tmp` persists across reuses, so `/tmp/web-setup.log` may be from a prior session running an older `web_setup.sh`. Without logging the commit, there's no way to tell whether setup is stale. The selfcheck now greps the log for the commit and compares to `HEAD`.

The old env dump logged full `key=value` pairs including `HTTPS_PROXY` with embedded JWT tokens. Switching to key-only avoids sensitive data in logs and is more useful for the "what vars does Anthropic inject?" question.

## Test plan

- [ ] Run `/web_selfcheck` in a new web session — verify "web_setup.sh commit" row appears in report with OK/STALE status
- [ ] Check `/tmp/web-setup.log` after next `web_setup.sh` run — verify commit SHA line and env keys section appear

https://claude.ai/code/session_016oyNSqecaNUfyJqMaMg8K4