### PR TITLE
fix(ci): create local devel ref for bb remote base resolution in PRs

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
+      # bb remote's base resolution falls back to `git rev-parse <default-branch>`
+      # which needs a local ref. actions/checkout only creates remote tracking refs
+      # (origin/devel), not local branches, so create one for PR builds.
+      - name: Create local ref for default branch
+        if: github.event_name == 'pull_request'
+        run: git branch "$GIT_REPO_DEFAULT_BRANCH" "origin/$GIT_REPO_DEFAULT_BRANCH"
+
       - name: Test
         uses: ./.github/actions/bb-remote
         with:


### PR DESCRIPTION
bb remote's fallback base resolution runs `git rev-parse <default-branch>`
which requires a local ref. actions/checkout only creates remote tracking
refs (origin/devel), not local branches, causing PR CI to fail with
"unknown revision" when bb remote tries to resolve the base commit.

https://claude.ai/code/session_01XmsxioEHm3umeUHe1PdLpG