### PR TITLE
feat(grocy): deploy grocy-mcp behind Airlock with auth proxy sidecar

### DIFF
--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -3,6 +3,8 @@ backends:
     url: http://kubeapi-admin-exec-mcp.airlock.svc.cluster.local:8766/mcp
   google_workspace_mcp:
     url: http://google-workspace-mcp.google-workspace-mcp.svc.cluster.local:8000/mcp
+  grocy:
+    url: http://grocy-mcp.grocy-mcp.svc.cluster.local:3000/mcp
 
 public_base_url: "https://airlock.allegedly.works"
 oidc_issuer: "https://auth.allegedly.works/application/o/airlock/"

--- a/cluster/k8s/agents/grocy-mcp/deployment.yaml
+++ b/cluster/k8s/agents/grocy-mcp/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grocy-mcp
+  namespace: grocy-mcp
+  labels:
+    app: grocy-mcp
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grocy-mcp
+  template:
+    metadata:
+      labels:
+        app: grocy-mcp
+    spec:
+      containers:
+        # Sidecar: translates GROCY-API-KEY requests into Bearer JWT via
+        # Authentik M2M token exchange.
+        - name: grocy-auth-proxy
+          image: ghcr.io/agentydragon/grocy-auth-proxy:latest # {"$imagepolicy": "flux-system:grocy-auth-proxy"}
+          imagePullPolicy: Always
+          ports:
+            - name: proxy
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8080"
+            - name: UPSTREAM_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grocy-machine-credentials
+                  key: upstream_url
+            - name: TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grocy-machine-credentials
+                  key: token_url
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: grocy-machine-credentials
+                  key: client_id
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: grocy-machine-credentials
+                  key: username
+            - name: APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grocy-machine-credentials
+                  key: app_password
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+        # MCP server: saya6k/mcp-grocy-api (40+ Grocy tools over streamable HTTP)
+        - name: grocy-mcp
+          image: ghcr.io/saya6k/mcp-grocy-api:latest
+          imagePullPolicy: Always
+          ports:
+            - name: mcp
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: GROCY_BASE_URL
+              value: "http://localhost:8080"
+            - name: GROCY_APIKEY_VALUE
+              value: "proxy-handles-auth"
+            - name: ENABLE_HTTP_SERVER
+              value: "true"
+            - name: HTTP_SERVER_PORT
+              value: "3000"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml
+++ b/cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy-mcp
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/agents/grocy-mcp
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: grocy-mcp
+      namespace: grocy-mcp
+  dependsOn:
+    - name: machine-access-tf
+    - name: reflector

--- a/cluster/k8s/agents/grocy-mcp/kustomization.yaml
+++ b/cluster/k8s/agents/grocy-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/cluster/k8s/agents/grocy-mcp/namespace.yaml
+++ b/cluster/k8s/agents/grocy-mcp/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grocy-mcp
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/agents/grocy-mcp/service.yaml
+++ b/cluster/k8s/agents/grocy-mcp/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grocy-mcp
+  namespace: grocy-mcp
+spec:
+  selector:
+    app: grocy-mcp
+  ports:
+    - name: mcp
+      port: 3000
+      targetPort: 3000
+      protocol: TCP

--- a/cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: grocy-auth-proxy
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: grocy-auth-proxy
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: grocy-auth-proxy
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/grocy-auth-proxy
+  interval: 5m

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -24,3 +24,5 @@ resources:
   - token-provisioner-image-policy.yaml
   - claude-token-rotation-image-repository.yaml
   - claude-token-rotation-image-policy.yaml
+  - grocy-auth-proxy-image-repository.yaml
+  - grocy-auth-proxy-image-policy.yaml

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -47,6 +47,7 @@ resources:
   - agents/kagent/namespace/flux-kustomization.yaml
   - agents/kagent/secrets/flux-kustomization.yaml
   - agents/kagent/app/flux-kustomization.yaml
+  - agents/grocy-mcp/flux-kustomization.yaml
   - agents/homeassistant-proxy/flux-kustomization.yaml
   - agents/openclaw/operator/flux-kustomization.yaml
   - agents/openclaw/gateway-namespace/flux-kustomization.yaml

--- a/cluster/terraform/gitops/agent-machine-access/main.tf
+++ b/cluster/terraform/gitops/agent-machine-access/main.tf
@@ -87,22 +87,22 @@ resource "kubernetes_secret" "agent_bearer_token" {
   }
 }
 
-# --- Grocy (proxy provider + machine auth via client_credentials) ---
+# --- Grocy (proxy provider + machine auth via M2M app password) ---
 # Replaces the grocy-sso.yaml blueprint. TF is the sole manager.
-# Humans authenticate via OIDC (browser session through the proxy outpost).
-# Agents exchange client_id + client_secret for a JWT via client_credentials,
-# then use the JWT as Bearer token against grocy.allegedly.works.
-# The proxy outpost only accepts JWTs from its own provider, so both flows
-# must go through the same provider.
+# Humans authenticate via browser session through the proxy outpost.
+# Agents authenticate via Authentik M2M: POST to /application/o/token/
+# with grant_type=client_credentials, client_id, username, password
+# (app_password) → JWT → Bearer token against grocy.allegedly.works.
+# The proxy outpost only accepts JWTs from its own provider.
 
 resource "authentik_provider_proxy" "grocy" {
-  name               = "grocy"
-  external_host      = "https://grocy.allegedly.works"
-  internal_host      = "http://grocy.grocy.svc.cluster.local:80"
-  mode               = "proxy"
-  authentication_flow = data.authentik_flow.authentication.id
-  authorization_flow  = data.authentik_flow.implicit_consent.id
-  invalidation_flow   = data.authentik_flow.invalidation.id
+  name                  = "grocy"
+  external_host         = "https://grocy.allegedly.works"
+  internal_host         = "http://grocy.grocy.svc.cluster.local:80"
+  mode                  = "proxy"
+  authentication_flow   = data.authentik_flow.authentication.id
+  authorization_flow    = data.authentik_flow.implicit_consent.id
+  invalidation_flow     = data.authentik_flow.invalidation.id
   access_token_validity = "hours=24"
 }
 
@@ -123,13 +123,21 @@ resource "authentik_policy_binding" "grocy_admins" {
   order  = 0
 }
 
-# Machine access: pre-create the service account that client_credentials
-# auto-generates (ak-<provider-slug>-client_credentials) so we can bind it.
+# Machine access: service account for agent M2M auth via app password.
 resource "authentik_user" "grocy_machine_sa" {
-  username = "ak-grocy-client_credentials"
-  name     = "Grocy Machine (client_credentials)"
+  username = "grocy-machine"
+  name     = "Grocy Machine Agent"
   type     = "service_account"
   path     = "goauthentik.io/service-accounts"
+}
+
+resource "authentik_token" "grocy_machine_app_password" {
+  identifier   = "grocy-machine-app-password"
+  user         = authentik_user.grocy_machine_sa.id
+  intent       = "app_password"
+  expiring     = true
+  retrieve_key = true
+  description  = "App password for Grocy machine auth (M2M via proxy provider)"
 }
 
 resource "authentik_policy_binding" "grocy_machine_sa" {
@@ -138,7 +146,9 @@ resource "authentik_policy_binding" "grocy_machine_sa" {
   order  = 10
 }
 
-# K8s secret with the proxy provider's OAuth2 credentials for agents.
+# K8s secret with M2M credentials for agents to authenticate to Grocy.
+# Flow: POST /application/o/token/ with grant_type=client_credentials,
+# client_id, username, password (app_password) → JWT → Bearer token.
 resource "kubernetes_secret" "grocy_machine_credentials" {
   metadata {
     name      = "grocy-machine-credentials"
@@ -152,7 +162,9 @@ resource "kubernetes_secret" "grocy_machine_credentials" {
   }
 
   data = {
-    client_id     = authentik_provider_proxy.grocy.client_id
-    client_secret = authentik_provider_proxy.grocy.client_secret
+    client_id    = authentik_provider_proxy.grocy.client_id
+    username     = authentik_user.grocy_machine_sa.username
+    app_password = authentik_token.grocy_machine_app_password.key
+    token_url    = "https://auth.allegedly.works/application/o/token/"
   }
 }

--- a/cluster/terraform/gitops/agent-machine-access/main.tf
+++ b/cluster/terraform/gitops/agent-machine-access/main.tf
@@ -155,9 +155,9 @@ resource "kubernetes_secret" "grocy_machine_credentials" {
     namespace = "claude-sandbox"
     annotations = {
       "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
-      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "openclaw-sandbox"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "openclaw-sandbox,grocy-mcp"
       "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
-      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "openclaw-sandbox"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "openclaw-sandbox,grocy-mcp"
     }
   }
 
@@ -166,5 +166,6 @@ resource "kubernetes_secret" "grocy_machine_credentials" {
     username     = authentik_user.grocy_machine_sa.username
     app_password = authentik_token.grocy_machine_app_password.key
     token_url    = "https://auth.allegedly.works/application/o/token/"
+    upstream_url = "https://grocy.allegedly.works"
   }
 }


### PR DESCRIPTION
## Summary

Deploy the grocy auth proxy image (merged in #1236) alongside a third-party
Grocy MCP server (`saya6k/mcp-grocy-api`) behind Airlock, with credentials
provisioned by Terraform.

- **Terraform (`cluster/terraform/gitops/agent-machine-access/main.tf`)**:
  switch the Grocy machine auth flow from the blocked `client_id +
  client_secret` approach to Authentik's intended M2M flow. The proxy
  provider TF resource doesn't export `client_secret`, so instead:
  - Rename the service account to `grocy-machine`
  - Create an `authentik_token` with `intent = "app_password"` for it
  - The K8s secret now carries `client_id` + `username` + `app_password` +
    `token_url` + `upstream_url`
  - Reflector annotations mirror the secret to `openclaw-sandbox` and
    `grocy-mcp` namespaces
- **Kubernetes (`cluster/k8s/agents/grocy-mcp/`)**: new namespace with a
  single Deployment that runs two containers in one pod:
  - `grocy-auth-proxy` (port 8080) — our Python proxy, pulling Authentik
    M2M credentials from `grocy-machine-credentials` and forwarding to
    `https://grocy.allegedly.works` with Bearer JWT
  - `grocy-mcp` (port 3000) — `ghcr.io/saya6k/mcp-grocy-api:latest` with
    `ENABLE_HTTP_SERVER=true`, `GROCY_BASE_URL=http://localhost:8080`.
    Sends a dummy `GROCY-API-KEY` that the auth proxy strips.
  - ClusterIP service exposes port 3000 for Airlock to reach.
- **Airlock (`cluster/k8s/agents/airlock/config.yaml`)**: register the
  new backend — tools become `grocy_*`.
- **Flux image automation** (`cluster/k8s/flux-image-automation-ghcr/`):
  watch `ghcr.io/agentydragon/grocy-auth-proxy` with the same tag pattern
  used for our other images.
- **Root kustomization**: wire `agents/grocy-mcp/flux-kustomization.yaml`
  in under the agents section.

## TODO / followups

- The `grocy-mcp` Service currently has no authentication beyond the
  namespace-level CiliumNetworkPolicy that should restrict ingress to the
  airlock namespace. Token-based auth between Airlock and the MCP server
  should be added before any other consumer is granted access.
- Predicate rules for auto-approving read-only Grocy operations (e.g.
  `grocy_get_stock`) can be added to `airlock/predicate.py` later as the
  tool surface stabilizes.

## Test plan

- [ ] `bbr build //cluster/k8s/agents/grocy-mcp/...` — manifests parse
- [ ] `flux reconcile ks grocy-mcp -n flux-system` on deploy
- [ ] `kubectl logs -n grocy-mcp deploy/grocy-mcp -c grocy-auth-proxy` —
      confirm the auth proxy fetches a JWT on first upstream request
- [ ] `grocy_*` tools appear in Airlock and a read-only call succeeds

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU