### PR TITLE
fix(grocy-mcp): correct dependsOn name to agent-machine-access-tf

### DIFF
--- a/cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml
+++ b/cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml
@@ -19,5 +19,5 @@ spec:
       name: grocy-mcp
       namespace: grocy-mcp
   dependsOn:
-    - name: machine-access-tf
+    - name: agent-machine-access-tf
     - name: reflector


### PR DESCRIPTION
## Summary

Follow-up fix to #1238. The Flux Kustomization `grocy-mcp` has a stale `dependsOn`
name that blocks reconciliation:

```
dependency 'flux-system/machine-access-tf' not found: kustomizations.kustomize.toolkit.fluxcd.io "machine-access-tf" not found
```

The actual Kustomization in `cluster/k8s/kustomization.yaml` is
`agent-machine-access-tf` (see `cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml`).

## Verification

After merge, `grocy-mcp` should move from `False: dependency not found` to `True:
Applied revision: ...` and the `grocy-mcp` namespace + pods should come up.

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU