### PR TITLE
re(env-manager): implement processSources, fill in shared embedded co…

### DIFF
--- a/devinfra/claude/web_env/re/environment_manager/REVERSE_ENGINEERING_TODOS.md
+++ b/devinfra/claude/web_env/re/environment_manager/REVERSE_ENGINEERING_TODOS.md
@@ -38,6 +38,16 @@ See `BINDIFF_RESULTS.md` for full analysis. Key findings:
 - CLI flags and sandbox settings
 - Heartbeat/lease response structure
 
+## Completed (2026-04-12)
+
+- **`shared.DefaultSettingsJSON` and `shared.StopHookScript`**: Recovered from the
+  live container at `/home/claude/.claude/settings.json` and
+  `/home/claude/.claude/stop-hook-git-check.sh`. Filled in `envtype/shared/shared.go`.
+- **`Initialize()` Step 2 (sources processing)**: Implemented `processSources()` method
+  on `anthropicEnvironmentType` — creates a `SourceHandlerManager` and calls
+  `ProcessSources()` + `SetupGitProxyAfterSourcesProcessed()`. Parameters that can't
+  be recovered from the garble-obfuscated binary are marked `TODO(re)`.
+
 ## Remaining Work
 
 - **Obfuscated env vars**: `CLAUDE_CODE_*` constants are garbled in the new binary
@@ -59,3 +69,6 @@ See `BINDIFF_RESULTS.md` for full analysis. Key findings:
      `environment_id` — likely a work assignment or event record.
      Exact usage of both structs is garble-obfuscated; cannot recover without runtime
      observation.
+- **`processSources()` parameters**: `gitProxyConfig`, `outcomes`, and
+  `activityRecorder` passed to `NewSourceHandlerManager` are garble-obfuscated;
+  cannot recover their sources without runtime observation.

--- a/devinfra/claude/web_env/re/environment_manager/REVERSE_ENGINEERING_TODOS.md
+++ b/devinfra/claude/web_env/re/environment_manager/REVERSE_ENGINEERING_TODOS.md
@@ -38,16 +38,6 @@ See `BINDIFF_RESULTS.md` for full analysis. Key findings:
 - CLI flags and sandbox settings
 - Heartbeat/lease response structure
 
-## Completed (2026-04-12)
-
-- **`shared.DefaultSettingsJSON` and `shared.StopHookScript`**: Recovered from the
-  live container at `/home/claude/.claude/settings.json` and
-  `/home/claude/.claude/stop-hook-git-check.sh`. Filled in `envtype/shared/shared.go`.
-- **`Initialize()` Step 2 (sources processing)**: Implemented `processSources()` method
-  on `anthropicEnvironmentType` — creates a `SourceHandlerManager` and calls
-  `ProcessSources()` + `SetupGitProxyAfterSourcesProcessed()`. Parameters that can't
-  be recovered from the garble-obfuscated binary are marked `TODO(re)`.
-
 ## Remaining Work
 
 - **Obfuscated env vars**: `CLAUDE_CODE_*` constants are garbled in the new binary

--- a/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/anthropic/anthropic.go
+++ b/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/anthropic/anthropic.go
@@ -61,6 +61,7 @@ import (
 	"github.com/anthropics/anthropic/api-go/environment-manager/internal/envtype/shared"
 	"github.com/anthropics/anthropic/api-go/environment-manager/internal/o11y"
 	"github.com/anthropics/anthropic/api-go/environment-manager/internal/process"
+	"github.com/anthropics/anthropic/api-go/environment-manager/internal/sources"
 )
 
 // Registration is the global registration for the anthropic environment type.
@@ -338,8 +339,17 @@ func (e *anthropicEnvironmentType) Initialize(ctx context.Context) error {
 			return err
 		}
 
-		// Step 2: Sources processing is handled by the SourceHandlerManager
+		// Step 2: Process sources (git repos) via SourceHandlerManager.
 		// (via RecordFunction.func2 at 0xafdf60)
+		//
+		// The exact parameters passed to NewSourceHandlerManager for the
+		// anthropic new/setup path are garble-obfuscated in 495ea204; the
+		// implementation below is a best-effort reconstruction based on the
+		// available struct fields. Compare with byoc.handleBranchCheckout()
+		// which uses the same mechanism for resume mode.
+		if err := e.processSources(ctx); err != nil {
+			return err
+		}
 	} else if isNewOrSetup {
 		// Step 1 only: Install languages without git
 		if err := e.installLanguages(ctx); err != nil {
@@ -542,6 +552,58 @@ func (e *anthropicEnvironmentType) installLanguage(ctx context.Context, name, ve
 		"duration", result.Duration,
 		"is_resume", e.sessionMode == "resume",
 	)
+
+	return nil
+}
+
+// processSources creates a SourceHandlerManager and processes the git sources
+// from the startup context. Called during Initialize() Step 2 when
+// isNewOrSetup && hasSources.
+//
+// Binary address: wrapped by RecordFunction.func2 at 0xafdf60 in 495ea204.
+// Source file: anthropic.go
+//
+// TODO(re): Exact parameters to NewSourceHandlerManager are garble-obfuscated
+// in 495ea204. The session ID, gitProxyConfig, outcomes, and activityRecorder
+// bindings are reconstructed from struct fields; the processMode string and
+// exact error wrapping messages cannot be verified without runtime observation.
+// Compare with byoc.handleBranchCheckout() for the resume-mode analog.
+func (e *anthropicEnvironmentType) processSources(ctx context.Context) error {
+	// TODO(re): sessionID source — likely e.startupContext.SessionID
+	sessionID := ""
+	if e.startupContext != nil {
+		sessionID = e.startupContext.SessionID
+	}
+
+	// TODO(re): gitProxyConfig source — likely from e.authContext or nil
+	// TODO(re): outcomes source — likely e.startupContext.Outcomes or nil
+	// TODO(re): activityRecorder source — likely nil or from startupContext
+	mgr, err := sources.NewSourceHandlerManager(
+		e.logger,
+		e.cwd,
+		sessionID,
+		nil,                   // gitProxyConfig — TODO(re): source garble-obfuscated
+		nil,                   // outcomes — TODO(re): source garble-obfuscated
+		nil,                   // activityRecorder — TODO(re): source garble-obfuscated
+		string(e.sessionMode), // processMode
+		false,                 // isResume — false for new/setup-only
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create source handler manager: %w", err)
+	}
+
+	if _, err := mgr.ProcessSources(ctx, e.logger, e.startupContext.Sources); err != nil {
+		// TODO(re): exact error message garble-obfuscated in 495ea204
+		return fmt.Errorf("failed to process sources: %w", err)
+	}
+
+	if result, err := mgr.SetupGitProxyAfterSourcesProcessed(ctx, e.logger, e.startupContext.Sources); err != nil {
+		// Non-fatal: log at Warn, consistent with byoc.handleBranchCheckout
+		e.logger.Warn("Failed to setup git proxy after sources processed",
+			"error", err,
+			"result", result,
+		)
+	}
 
 	return nil
 }

--- a/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/shared/shared.go
+++ b/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/shared/shared.go
@@ -9,17 +9,91 @@
 //   - shared.DefaultSettingsJSON (0x15adda0)
 //   - shared.StopHookScript      (0x15addb0)
 //
-// TODO(re): Actual byte content is not recoverable from the garble-obfuscated
-// 495ea204 binary. The variables are declared here to match the package
-// structure; their values are nil until recovered via runtime observation.
+// Content recovered via runtime observation of the live container: the binary
+// writes these files to /home/claude/.claude/ during environment initialization.
+// DefaultSettingsJSON is written to .claude/settings.json; StopHookScript is
+// written to the path specified by StopHookPath in anthropicConfig (mode 0755).
 package shared
 
 // DefaultSettingsJSON is the default Claude Code settings JSON written to
 // .claude/settings.json during environment initialization.
 // Shared by both the anthropic and byoc environment types.
-var DefaultSettingsJSON []byte
+//
+// Content recovered from /home/claude/.claude/settings.json in the live container.
+var DefaultSettingsJSON = []byte(`{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "hooks": {
+        "Stop": [
+            {
+                "matcher": "",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/stop-hook-git-check.sh"
+                    }
+                ]
+            }
+        ]
+    },
+    "permissions": {
+        "allow": ["Skill"]
+    }
+}`)
 
 // StopHookScript is the stop hook shell script written to the hooks directory
 // during environment initialization (mode 0755).
 // Shared by both the anthropic and byoc environment types.
-var StopHookScript []byte
+//
+// Content recovered from /home/claude/.claude/stop-hook-git-check.sh in the live container.
+var StopHookScript = []byte(`#!/bin/bash
+
+# Read the JSON input from stdin
+input=$(cat)
+
+# Check if stop hook is already active (recursion prevention)
+stop_hook_active=$(echo "$input" | jq -r '.stop_hook_active')
+if [[ "$stop_hook_active" = "true" ]]; then
+  exit 0
+fi
+
+# Check if we're in a git repository - bail if not
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+no_pr_reminder="Do not create a pull request unless the user has explicitly asked for one."
+
+# Check for uncommitted changes (both staged and unstaged)
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "There are uncommitted changes in the repository. Please commit and push these changes to the remote branch. $no_pr_reminder" >&2
+  exit 2
+fi
+
+# Check for untracked files that might be important
+untracked_files=$(git ls-files --others --exclude-standard)
+if [[ -n "$untracked_files" ]]; then
+  echo "There are untracked files in the repository. Please commit and push these changes to the remote branch. $no_pr_reminder" >&2
+  exit 2
+fi
+
+current_branch=$(git branch --show-current)
+if [[ -n "$current_branch" ]]; then
+  if git rev-parse "origin/$current_branch" >/dev/null 2>&1; then
+    # Branch exists on remote - compare against it
+    unpushed=$(git rev-list "origin/$current_branch..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "There are $unpushed unpushed commit(s) on branch '$current_branch'. Please push these changes to the remote repository. $no_pr_reminder" >&2
+      exit 2
+    fi
+  else
+    # Branch doesn't exist on remote - compare against default branch
+    unpushed=$(git rev-list "origin/HEAD..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "Branch '$current_branch' has $unpushed unpushed commit(s) and no remote branch. Please push these changes to the remote repository. $no_pr_reminder" >&2
+      exit 2
+    fi
+  fi
+fi
+
+exit 0
+`)


### PR DESCRIPTION
All three components (ActionList, ActionDetail, and secondary routes)
each defined their own <header>, but only the defaultHeader snippet
included nav links. ActionList and ActionDetail headers had no nav,
making Backends and OAuth pages unreachable from the default view.

Move all header rendering into App.svelte as a single unconditional
block. Route-specific content (breadcrumb for action detail, pending
badge for list view) is handled inline. Remove <header> from
ActionList.svelte and ActionDetail.svelte — both are now pure
content components.

https://claude.ai/code/session_01AuHXB3W1yss6VEj1PoWnaZ…ntent

- shared.go: fill in DefaultSettingsJSON and StopHookScript with actual
  content recovered from live container (/home/claude/.claude/)
- anthropic.go: implement Initialize() Step 2 — add processSources() method
  that creates a SourceHandlerManager and calls ProcessSources() +
  SetupGitProxyAfterSourcesProcessed(), mirroring byoc.handleBranchCheckout()
- REVERSE_ENGINEERING_TODOS.md: mark completed items, add remaining gap for
  garble-obfuscated NewSourceHandlerManager parameters

Parameters to NewSourceHandlerManager that can't be recovered from the
garble-obfuscated 495ea204 binary without runtime observation are marked
with TODO(re) comments.

https://claude.ai/code/session_016oyNSqecaNUfyJqMaMg8K4