### PR TITLE
fix(grocy-mcp): bypass s6-overlay + grant claude log-read RBAC

### DIFF
--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -38,7 +38,7 @@ bound via `shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml`:
 Namespaced Roles + RoleBindings for specific namespaces:
 
 - harbor, langfuse, ollama (read + consumer), openclaw, props, gatus
-- Logs/configmaps in monitoring, kube-system, longhorn-system, flux-system
+- Logs/configmaps in monitoring, kube-system, longhorn-system, flux-system, grocy-mcp
 
 ## ServiceAccount
 

--- a/cluster/k8s/agents/claude-rbac/role-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/role-logs-configmaps-reader.yaml
@@ -45,3 +45,15 @@ rules:
       - pods/log
       - configmaps
     verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: logs-configmaps-reader
+  namespace: grocy-mcp
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/log
+      - configmaps
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/agents/grocy-mcp/deployment.yaml
+++ b/cluster/k8s/agents/grocy-mcp/deployment.yaml
@@ -74,10 +74,23 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
-        # MCP server: saya6k/mcp-grocy-api (40+ Grocy tools over streamable HTTP)
+        # MCP server: saya6k/mcp-grocy-api (40+ Grocy tools over streamable HTTP).
+        #
+        # The ghcr.io/saya6k/mcp-grocy-api image is a Home Assistant add-on: its
+        # s6-overlay run script (`rootfs/etc/s6-overlay/app/run`) overwrites every
+        # relevant env var with `bashio::config ...` reads from an HA supervisor
+        # config.yaml we don't provide. Without HA supervisor, those reads return
+        # empty, and `set -e` kills the container on the first node check.
+        #
+        # Override entrypoint/command so we bypass s6-overlay entirely and run
+        # `node build/index.js` directly with the env vars the Pod spec already
+        # provides. /app is the WORKDIR baked into the image.
         - name: grocy-mcp
           image: ghcr.io/saya6k/mcp-grocy-api:latest
           imagePullPolicy: Always
+          command: ["node"]
+          args: ["build/index.js"]
+          workingDir: /app
           ports:
             - name: mcp
               containerPort: 3000

--- a/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -65,3 +65,20 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: grocy-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: logs-configmaps-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default
+  - kind: ServiceAccount
+    name: default
+    namespace: openclaw-sandbox


### PR DESCRIPTION
Two follow-up fixes after #1238 deployed.

## 1. Bypass s6-overlay in the grocy-mcp container

The `saya6k/mcp-grocy-api` GHCR image is built as a **Home Assistant add-on**.
Its s6-overlay run script (`rootfs/etc/s6-overlay/app/run`) unconditionally
overwrites every relevant env var with `bashio::config` reads from an HA
supervisor `config.yaml` we don't provide:

```bash
export GROCY_BASE_URL=$(bashio::config 'grocy_base_url')
export GROCY_APIKEY_VALUE=$(bashio::config 'grocy_api_key')
export ENABLE_HTTP_SERVER=$(bashio::config 'enable_http_server')
export HTTP_SERVER_PORT=$(bashio::config 'http_server_port')
...
```

Without HA supervisor, those reads return empty strings, and `set -e` in the
script kills the container on the first failed check. Pod state:

```
lastState.terminated:
  exitCode: 0
  reason: Completed
  startedAt: 2026-04-12T21:37:17Z
  finishedAt: 2026-04-12T21:37:17Z  # same second
```

**Fix**: override the container `command` / `args` / `workingDir` to run
`node build/index.js` directly in `/app`, bypassing s6-overlay and bashio
entirely. Env vars in the Pod spec now flow straight to Node.js.

## 2. Grant log-read RBAC on grocy-mcp namespace

Debugging #1 was blocked by the claude-code-web ServiceAccount not being able
to read pod logs in the `grocy-mcp` namespace (my `cluster-diagnostics-reader`
ClusterRole covers get/list on pods but not `pods/log`, which lives in
`logs-configmaps-reader` Role bindings per-namespace).

Add `grocy-mcp` to the list of namespaces that get a `logs-configmaps-reader`
Role + agent RoleBinding, matching the existing pattern for `monitoring`,
`kube-system`, `longhorn-system`, `flux-system`.

## Verification

After merge:
- Flux reconciles the deployment patch → pod restarts → `node build/index.js`
  runs with the env vars we set
- `kubectl logs -n grocy-mcp deploy/grocy-mcp -c grocy-mcp` works from my
  session, so I can actually monitor the rollout this time

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU