### PR TITLE
Migrate hook daemon to FastAPI lifespan context manager

### DIFF
--- a/devinfra/claude/hook_daemon/server.py
+++ b/devinfra/claude/hook_daemon/server.py
@@ -16,6 +16,7 @@ import signal
 import time
 import traceback
 from collections.abc import Callable
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -205,7 +206,18 @@ async def _idle_watchdog(app: FastAPI) -> None:
 
 def create_app(daemon_dir: Path, profile: ProfileConfig) -> FastAPI:
     """Create and configure the hook daemon FastAPI app."""
-    app = FastAPI()
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI):
+        if profile.idle_watchdog:
+            app.state.watchdog_task = asyncio.create_task(_idle_watchdog(app))
+        else:
+            logger.info("Idle watchdog disabled by profile config")
+        yield
+        for session in app.state.sessions.values():
+            session.stop()
+
+    app = FastAPI(lifespan=_lifespan)
 
     app.state.daemon_dir = daemon_dir
     app.state.settings = HookSettings()
@@ -319,18 +331,5 @@ def create_app(daemon_dir: Path, profile: ProfileConfig) -> FastAPI:
         for s in app.state.sessions.values():
             s.post_message(req.message)
         return {"status": "ok"}
-
-    @app.on_event("startup")
-    async def _start_idle_watchdog() -> None:
-        if not profile.idle_watchdog:
-            logger.info("Idle watchdog disabled by profile config")
-            return
-        app.state.watchdog_task = asyncio.create_task(_idle_watchdog(app))
-
-    @app.on_event("shutdown")
-    async def _stop_proxy() -> None:
-        """Stop the in-process proxies on daemon shutdown."""
-        for session in app.state.sessions.values():
-            session.stop()
 
     return app


### PR DESCRIPTION
## Summary
Migrated the hook daemon from deprecated FastAPI event handlers (`@app.on_event`) to the modern lifespan context manager pattern introduced in FastAPI 0.93+.

## Key Changes
- Added `asynccontextmanager` import from `contextlib`
- Replaced `@app.on_event("startup")` and `@app.on_event("shutdown")` handlers with a single `_lifespan` async context manager
- Moved idle watchdog initialization and session cleanup logic into the lifespan context manager
- Passed the lifespan manager to `FastAPI(lifespan=_lifespan)` constructor

## Implementation Details
The new lifespan context manager:
- Handles startup logic before `yield`: initializes the idle watchdog task if enabled via profile config
- Handles shutdown logic after `yield`: stops all active proxy sessions
- Provides better structured lifecycle management with a single entry/exit point
- Maintains identical functionality while using the recommended FastAPI pattern

https://claude.ai/code/session_01Vu2atXUBrkkQkGzW3iHfjp