### PR TITLE
fix(grocy-mcp): keep stdin alive so node reaches HTTP server startup

### DIFF
--- a/cluster/k8s/agents/grocy-mcp/deployment.yaml
+++ b/cluster/k8s/agents/grocy-mcp/deployment.yaml
@@ -76,20 +76,30 @@ spec:
               cpu: "200m"
         # MCP server: saya6k/mcp-grocy-api (40+ Grocy tools over streamable HTTP).
         #
-        # The ghcr.io/saya6k/mcp-grocy-api image is a Home Assistant add-on: its
-        # s6-overlay run script (`rootfs/etc/s6-overlay/app/run`) overwrites every
-        # relevant env var with `bashio::config ...` reads from an HA supervisor
-        # config.yaml we don't provide. Without HA supervisor, those reads return
-        # empty, and `set -e` kills the container on the first node check.
+        # Two image quirks we work around here:
         #
-        # Override entrypoint/command so we bypass s6-overlay entirely and run
-        # `node build/index.js` directly with the env vars the Pod spec already
-        # provides. /app is the WORKDIR baked into the image.
+        # 1. The ghcr.io/saya6k/mcp-grocy-api image is a Home Assistant add-on.
+        #    Its s6-overlay run script (`rootfs/etc/s6-overlay/app/run`)
+        #    overwrites every relevant env var with `bashio::config ...` reads
+        #    from an HA supervisor config.yaml we don't provide. Without HA
+        #    supervisor those reads return empty, and `set -e` kills the
+        #    container on the first failed check. Fix: bypass s6-overlay and
+        #    run `node build/index.js` directly, so env vars from this Pod
+        #    spec reach Node.js unchanged.
+        #
+        # 2. `src/index.ts::run()` unconditionally creates a StdioServerTransport
+        #    BEFORE starting the HTTP server. In Kubernetes without a TTY the
+        #    container's stdin is closed immediately, which causes the stdio
+        #    transport to see EOF, and the Node process exits before it gets
+        #    to start the HTTP server. Fix: keep stdin alive by piping from
+        #    `sleep infinity`. The sleep process never writes anything, so the
+        #    JSON-RPC stdio reader blocks harmlessly, and the HTTP server on
+        #    port 3000 starts normally for Airlock to talk to.
         - name: grocy-mcp
           image: ghcr.io/saya6k/mcp-grocy-api:latest
           imagePullPolicy: Always
-          command: ["node"]
-          args: ["build/index.js"]
+          command: ["/bin/sh", "-c"]
+          args: ["sleep infinity | node build/index.js"]
           workingDir: /app
           ports:
             - name: mcp


### PR DESCRIPTION
After #1241 bypassed the s6-overlay run script, the grocy-mcp container still
CrashLoopBackOff'd with `exitCode: 0` and **zero log output**. Not even the
startup banner on stderr was captured.

Root cause is [`src/index.ts::run()`](https://github.com/saya6k/mcp-grocy-api/blob/dev/src/index.ts#L1900):

```ts
async run() {
    await this.setupServer();

    // Start STDIO transport
    const transport = new StdioServerTransport();
    await this.server.connect(transport);
    console.error('Grocy API MCP server running on stdio');

    // Start HTTP/SSE transport
    console.error('[CONFIG] ENABLE_HTTP_SERVER:', process.env.ENABLE_HTTP_SERVER);
    const enableHttpServer = ['true', 'yes', ...].includes(...);
    if (enableHttpServer) {
        startHttpServer(this.server, port);
    }
}
```

The server **always** creates a `StdioServerTransport` before starting the
HTTP server. In Kubernetes without a TTY the container's stdin is closed
immediately, the stdio transport sees EOF, and the Node process exits before
reaching the HTTP server startup code — and apparently before even the
stderr `console.error` calls get flushed (hence the zero-line logs).

## Fix

Run via `/bin/sh -c "sleep infinity | node build/index.js"`. The `sleep infinity`
process never writes anything to its stdout, so node's stdin pipe stays
open forever. The JSON-RPC stdio reader blocks harmlessly, and the HTTP
server on port 3000 starts normally for Airlock to reach.

## Verification

After merge, the pod should go Ready=2/2 and I'll be able to
`curl http://grocy-mcp.grocy-mcp.svc.cluster.local:3000/mcp` from inside the
cluster once RBAC allows.

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU