### PR TITLE
fix(bazel): suppress protobuf internal -Wdeprecated-declarations warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,14 @@ common --experimental_isolated_extension_usages
 # from leaking to RBE workers. Default in Bazel 9 but not Bazel 8.
 build --incompatible_strict_action_env
 
+# Suppress -Wdeprecated-declarations from protobuf's own internal usage of its
+# deprecated APIs (FieldOptions::weak(), RepeatedPtrField(Arena*), etc.).
+# All warnings are within external/protobuf+/ — protobuf using APIs that it
+# itself deprecated, not fixable from this repo.
+# Applied to both target and exec (host) configs since protoc runs in exec.
+build --per_file_copt=external/protobuf[+]/.*@-Wno-deprecated-declarations
+build --host_per_file_copt=external/protobuf[+]/.*@-Wno-deprecated-declarations
+
 # Reduce runfiles disk usage (prevents "No space left on device" on CI runners).
 # Each py_test creates a runfiles tree with ~2,458 symlinks for the Python toolchain;
 # with many targets this exhausts the default 20 GB BuildBuddy disk.

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 - [ ] [#787](https://github.com/agentydragon/ducktape/issues/787): Fork PRs (from `agentydragon-agent`) don't receive `BUILDBUDDY_API_KEY`, so `bazel-check`/`bazel-test` are skipped on fork PRs. Fix by converting `BUILDBUDDY_API_KEY` to a repo variable (available to forks) or adding `agentydragon-agent` as a collaborator.
 - [ ] Migrate all Python packages to Bazel monorepo style (colocated tests, flat structure like `git_commit_ai/`)
 - [ ] Re-enable `bazel coverage` in CI once compatible with remote execution (RBE). Currently disabled because the Java-based `remote_coverage_tools` can't locate its runfiles on BuildBuddy workers, causing all tests to be marked as failed. See `bazel-test.yml`.
-- [ ] Upgrade protobuf once UPB uninitialized variable warnings are fixed upstream. Currently on `protobuf 34.0.bcr.1` (latest in BCR as of March 2026). GCC emits `-Wmaybe-uninitialized` warnings from `external/protobuf+/upb/wire/decode.c` (lines 281, 732, 1089: `upb_StringView sv` used uninitialized). These are false positives from GCC's static analysis failing to prove the variable is always set before use. Upstream issues: [#17052](https://github.com/protocolbuffers/protobuf/issues/17052), [PR #18805](https://github.com/protocolbuffers/protobuf/pull/18805). Also `src/google/protobuf/compiler/rust/message.cc` triggers `-Wdeprecated-declarations` for `FieldOptions::weak()`. Monitor protobuf releases >34.0 for fixes.
+- [ ] Remove `--per_file_copt=external/protobuf[+]/.*@-Wno-deprecated-declarations` from `.bazelrc` once protobuf cleans up its internal deprecated API usage (`FieldOptions::weak()`, `RepeatedPtrField(Arena*)`). These are in `external/protobuf+/src/google/protobuf/` and `compiler/cpp/`. Currently `protobuf 33.1`.
 
 ## Terraform
 


### PR DESCRIPTION
## Summary

- Protobuf 33.1 uses its own deprecated APIs internally (`FieldOptions::weak()`, `RepeatedPtrField(Arena*)`, `FieldDescriptor::has_optional_keyword()`), generating ~68 `-Wdeprecated-declarations` warnings per build
- All warnings are within `external/protobuf+/` — not fixable from this repo
- Add `--per_file_copt` / `--host_per_file_copt` in `.bazelrc` with regex `external/protobuf[+]/.*` to suppress for both target and exec (host) configs (protoc runs in exec config)
- `host_per_file_copt` is needed because protoc compiles in the exec configuration
- `[+]` is required instead of `\+` — Bazel's `.bazelrc` parser strips backslashes before passing the regex to Java `Pattern.compile()`
- Also cleans up a stale TODO entry that referenced the wrong protobuf version (`34.0.bcr.1`) and wrong upstream issue

## Test plan

- [x] Build `//devinfra/claude/hook_daemon:bes_interceptor` with flags: 270 remote executions, 0 compiler warnings (down from 68)
- [x] `//devinfra/claude/hook_daemon:test_hook_daemon` and `//devinfra/claude/hook_daemon:test_hook_daemon_restart` pass (`c679311c-b0bf-4a8e-a0d1-d62949fb289f`)

https://claude.ai/code/session_01Vu2atXUBrkkQkGzW3iHfjp