### PR TITLE
chore(authentik): touch embedded-outpost blueprint to re-resolve grocy

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -13,6 +13,12 @@ entries:
   # proxy outposts do). It uses authentik_host for both internal communication
   # and browser-facing redirects. Internal connectivity uses localhost implicitly
   # since the outpost runs in the server process.
+  #
+  # NOTE: when a provider listed below is recreated in Authentik (e.g. by a TF
+  # destroy/apply cycle), the outpost's stored providers list keeps a dangling
+  # reference to the old DB ID until this blueprint is re-applied. Touch this
+  # file (git commit) to bump the underlying ConfigMap's resourceVersion and
+  # trigger Authentik's blueprint watcher to re-resolve the !Find refs below.
   - model: authentik_outposts.outpost
     state: present
     identifiers:


### PR DESCRIPTION
The grocy proxy provider was recreated during the M2M migration
(#1236 / #1238). Authentik's embedded outpost still holds a stale
reference to the old provider DB ID in its providers list, so every
request to `grocy.allegedly.works` returns 404 from the outpost — even
with a valid Bearer JWT obtained via the TF-provisioned M2M app
password flow.

The `embedded-outpost.yaml` blueprint uses
`!Find [authentik_providers_proxy.proxyprovider, [name, grocy]]` to
resolve the provider, so re-running the blueprint should replace the
stale DB ID with the current one. But the blueprint only re-runs when
Authentik's periodic scheduler fires or when the ConfigMap content
actually changes.

This PR bumps the ConfigMap's `resourceVersion` by adding a doc
comment to the blueprint file, which:

1. Forces Flux to re-apply the ConfigMap on the next reconcile
2. Bumps `resourceVersion`
3. Authentik's blueprint watcher picks up the file change
4. Blueprint re-applies, `!Find` re-resolves, outpost providers list
   gets the current grocy DB ID
5. `grocy.allegedly.works` starts accepting Bearer JWTs again

## Verification

After merge + reconcile, `curl https://grocy.allegedly.works/outpost.goauthentik.io/auth/nginx`
should return `302` (matching longhorn's behavior) instead of the
current `404`, and a Bearer JWT from the M2M flow should reach Grocy.

Also documents the recovery procedure inline for next time a provider
listed in the blueprint gets recreated.

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU