### PR TITLE
fix(grocy/auth_proxy): recompute content-length for decoded upstream responses

### DIFF
--- a/grocy/auth_proxy/proxy.py
+++ b/grocy/auth_proxy/proxy.py
@@ -47,6 +47,14 @@ _HOP_BY_HOP_HEADERS = frozenset(
     }
 )
 
+# httpx transparently decodes gzip/deflate/br responses into `resp.content`, so
+# the upstream's `content-encoding` and `content-length` no longer match the
+# decoded body we pass to uvicorn. If we kept the original content-length,
+# uvicorn raises "Response content longer than Content-Length" and resets the
+# connection. Strip both and let Starlette recompute `content-length` from the
+# decoded body.
+_REWRITTEN_RESPONSE_HEADERS = frozenset({"content-encoding", "content-length"})
+
 
 class AutoFetchOAuth2Client(AsyncOAuth2Client):
     """AsyncOAuth2Client that auto-fetches a token via M2M app_password flow.
@@ -125,13 +133,17 @@ def create_app(upstream_url: str, client_factory: Callable[[], AutoFetchOAuth2Cl
 
         # Construct with no headers, then assign raw_headers directly so we can
         # preserve repeated headers (e.g. multiple Set-Cookie) via multi_items.
-        # Drop hop-by-hop headers which must not cross proxies.
+        # Drop hop-by-hop headers which must not cross proxies, plus
+        # content-encoding/content-length which no longer match the decoded body.
         out = Response(content=resp.content, status_code=resp.status_code)
         out.raw_headers = [
             (k.lower().encode("latin-1"), v.encode("latin-1"))
             for k, v in resp.headers.multi_items()
-            if k.lower() not in _HOP_BY_HOP_HEADERS
+            if k.lower() not in _HOP_BY_HOP_HEADERS and k.lower() not in _REWRITTEN_RESPONSE_HEADERS
         ]
+        # Starlette's Response.__init__ already computed content-length from
+        # self.body; append it so uvicorn sees a consistent frame.
+        out.raw_headers.append((b"content-length", str(len(out.body)).encode("latin-1")))
         return out
 
     return Starlette(

--- a/grocy/auth_proxy/test_proxy.py
+++ b/grocy/auth_proxy/test_proxy.py
@@ -138,6 +138,41 @@ async def test_forwards_method_path_body():
 
 
 @respx.mock
+async def test_gzipped_response_recomputes_content_length():
+    """Gzipped upstream response: content-length is rewritten from the decoded body.
+
+    Regression for RuntimeError: Response content longer than Content-Length.
+    Authentik's 404 page is served with content-encoding: gzip and the
+    compressed content-length, but httpx auto-decodes into resp.content,
+    so passing content-length through verbatim causes uvicorn to reset the
+    connection.
+    """
+    import gzip
+
+    decoded = b"<html>decoded body!</html>"
+    encoded = gzip.compress(decoded)
+    assert len(encoded) != len(decoded)
+
+    respx.post(TOKEN_URL).mock(return_value=Response(200, json={"access_token": "tok", **_TOKEN_RESPONSE}))
+    respx.get(f"{UPSTREAM_URL}/api/stock").mock(
+        return_value=Response(
+            404,
+            headers={"content-encoding": "gzip", "content-length": str(len(encoded)), "content-type": "text/html"},
+            content=encoded,
+        )
+    )
+
+    app, _ = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as http:
+        resp = await http.get("/api/stock")
+
+    assert resp.status_code == 404
+    assert resp.content == decoded
+    assert int(resp.headers["content-length"]) == len(decoded)
+    assert "content-encoding" not in {k.lower() for k in resp.headers}
+
+
+@respx.mock
 async def test_strips_hop_by_hop_response_headers():
     """Hop-by-hop response headers (RFC 7230) are not forwarded to the caller."""
     respx.post(TOKEN_URL).mock(return_value=Response(200, json={"access_token": "tok", **_TOKEN_RESPONSE}))


### PR DESCRIPTION
## Real-world failure

When the upstream returns a gzipped response (e.g. Authentik's 404 page
with `content-encoding: gzip` + a compressed `content-length`), httpx
transparently decodes the body into `resp.content`. The decoded bytes
are longer than the upstream's `content-length`, so forwarding both
headers verbatim caused uvicorn to raise:

```
RuntimeError: Response content longer than Content-Length
```

...which tore down the connection mid-response. Clients saw "Connection
reset" instead of the proxied 404.

Discovered when the grocy-mcp `call_grocy_api` tool returned:

> Failed to call Grocy API endpoint system/info: Connection reset: The
> server unexpectedly closed the connection.

## Fix

Strip `content-encoding` and `content-length` from forwarded response
headers (they no longer describe the bytes we're sending after httpx
auto-decoding) and append a fresh `content-length` computed from the
Starlette `Response.body`.

## Regression test

`test_gzipped_response_recomputes_content_length` — gzip-encodes a real
body upstream, verifies the proxy decodes + rewrites `content-length`
and drops `content-encoding`.

Local: **11/11 tests pass** (`python3 -m pytest grocy/auth_proxy/test_proxy.py`).

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU