### PR TITLE
Add sources dependency to anthropic environment type

### DIFF
--- a/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/anthropic/BUILD.bazel
+++ b/devinfra/claude/web_env/re/environment_manager/src/internal/envtype/anthropic/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//devinfra/claude/web_env/re/environment_manager/src/internal/envtype/shared",
         "//devinfra/claude/web_env/re/environment_manager/src/internal/o11y",
         "//devinfra/claude/web_env/re/environment_manager/src/internal/process",
+        "//devinfra/claude/web_env/re/environment_manager/src/internal/sources",
     ],
 )


### PR DESCRIPTION
## Summary
Added a new dependency on the `sources` package to the anthropic environment type module.

## Changes
- Added `//devinfra/claude/web_env/re/environment_manager/src/internal/sources` to the `deps` list in the anthropic BUILD.bazel file

## Details
This change enables the anthropic environment type to access functionality from the sources package, likely to support source management or configuration capabilities within the environment manager.

https://claude.ai/code/session_01KFMyPfiBDbVrNARMn6CW4j