### PR TITLE
ci(ghcr-push): use workflow-scoped GITHUB_TOKEN, drop GHCR PAT + visibility-patch

### DIFF
--- a/.github/actions/setup-ci-secrets/action.yml
+++ b/.github/actions/setup-ci-secrets/action.yml
@@ -38,13 +38,16 @@ runs:
         SOPS_AGE_KEY: ${{ inputs.sops_age_key }}
       run: |
         eval "$(devinfra/secrets/ci_env.sh)"
-        # Mask secret values so they don't appear in logs
-        for var in BUILDBUDDY_API_KEY GITHUB_TOKEN ATTIC_TOKEN \
-                   PROPS_REGISTRY_PASSWORD GHCR_TOKEN GH_RELEASE_PAT; do
+        # Mask secret values so they don't appear in logs.
+        # GITHUB_TOKEN / GHCR_TOKEN are intentionally absent — GHCR pushes
+        # now use the workflow-scoped secrets.GITHUB_TOKEN plumbed directly
+        # through bb remote env_overrides (see push-images.yml).
+        for var in BUILDBUDDY_API_KEY ATTIC_TOKEN \
+                   PROPS_REGISTRY_PASSWORD GH_RELEASE_PAT; do
           val="${!var:-}"
           if [ -n "$val" ]; then
             echo "::add-mask::$val"
           fi
         done
         # Export to GITHUB_ENV for subsequent steps
-        env | grep -E '^(BUILDBUDDY_API_KEY|GITHUB_TOKEN|ATTIC_TOKEN|PROPS_REGISTRY_USERNAME|PROPS_REGISTRY_PASSWORD|GHCR_USERNAME|GHCR_TOKEN|GH_RELEASE_PAT)=' >> "$GITHUB_ENV"
+        env | grep -E '^(BUILDBUDDY_API_KEY|ATTIC_TOKEN|PROPS_REGISTRY_USERNAME|PROPS_REGISTRY_PASSWORD|GH_RELEASE_PAT)=' >> "$GITHUB_ENV"

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -88,6 +88,16 @@ jobs:
         with:
           args: run --remote_download_toplevel ${{ matrix.target }}
           rbe_image: ${{ inputs.rbe_image }}
+          # GHCR auth: forward the workflow-scoped GITHUB_TOKEN via bb remote
+          # env-overrides so crane push inside the runner VM logs in as the
+          # workflow. Advantages over a long-lived PAT:
+          #   * The `permissions: packages: write` block above is enforced per
+          #     run instead of relying on secret scope.
+          #   * First-push packages are automatically linked to this repo and
+          #     inherit its (public) visibility — no post-push API PATCH.
+          #   * The token rotates per job, not per manual rotation.
+          # Username is literally `x-access-token`; that's the conventional
+          # form GHCR accepts alongside a workflow token.
           env_overrides: |
-            GHCR_TOKEN=${{ env.GHCR_TOKEN }}
-            GHCR_USERNAME=${{ env.GHCR_USERNAME }}
+            GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GHCR_USERNAME=x-access-token

--- a/devinfra/ghcr_push/ghcr_push_lib.py
+++ b/devinfra/ghcr_push/ghcr_push_lib.py
@@ -9,8 +9,7 @@ through `bb remote`'s `x-buildbuddy-platform.env-overrides` into the runner
 VM's environment. Because the token is issued by GitHub Actions for the
 current workflow run, new packages created by a push are automatically linked
 to the source repository and inherit its visibility — for a public repo like
-this one, the package is created public without any follow-up API call. See
-<docs/ci-ghcr-auth.md> for the full wiring diagram.
+this one, the package is created public without any follow-up API call.
 """
 
 import argparse

--- a/devinfra/ghcr_push/ghcr_push_lib.py
+++ b/devinfra/ghcr_push/ghcr_push_lib.py
@@ -3,15 +3,20 @@
 Uses crane to compare local vs remote digests before pushing. Only creates a
 new pinned tag (branch-YYYYMMDDHHMMSS-sha7) when the image digest actually
 changed, preventing spurious Flux repins.
+
+Authenticates to GHCR with the workflow-scoped `secrets.GITHUB_TOKEN` forwarded
+through `bb remote`'s `x-buildbuddy-platform.env-overrides` into the runner
+VM's environment. Because the token is issued by GitHub Actions for the
+current workflow run, new packages created by a push are automatically linked
+to the source repository and inherit its visibility — for a public repo like
+this one, the package is created public without any follow-up API call. See
+<docs/ci-ghcr-auth.md> for the full wiring diagram.
 """
 
 import argparse
-import json
 import logging
 import os
 import subprocess
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -41,41 +46,11 @@ def _image_runfiles_dir(image_target: str) -> Path:
     return get_required_path(f"_main/{label.package}/{label.name}")
 
 
-def _ensure_package_public(package_name: str, token: str) -> None:
-    """Set GHCR package visibility to public via GitHub API.
-
-    Idempotent — already-public packages return 200. This is needed because
-    packages pushed via crane (BuildBuddy CI) default to private, unlike
-    packages pushed via GitHub Actions GITHUB_TOKEN which auto-inherit repo
-    visibility.
-    """
-    url = f"https://api.github.com/user/packages/container/{package_name}"
-    data = json.dumps({"visibility": "public"}).encode()
-    req = urllib.request.Request(
-        url,
-        data=data,
-        method="PATCH",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        urllib.request.urlopen(req)
-        logger.info("%s: package visibility set to public", package_name)
-    except urllib.error.HTTPError as e:
-        # 404 = package doesn't exist yet (first push in progress), will be
-        # set on next CI run. Don't fail the push for this.
-        logger.warning("%s: failed to set package visibility (HTTP %d): %s", package_name, e.code, e.reason)
-
-
 class ImagePusher:
-    def __init__(self, crane: Crane, branch: str, pinned_tag: str, ghcr_token: str) -> None:
+    def __init__(self, crane: Crane, branch: str, pinned_tag: str) -> None:
         self.crane = crane
         self.branch = branch
         self.pinned_tag = pinned_tag
-        self.ghcr_token = ghcr_token
 
     def _latest_pinned_tag(self, repo: str) -> str | None:
         try:
@@ -101,10 +76,6 @@ class ImagePusher:
         print(f"{img.repository}: tagging {self.pinned_tag}")
         self.crane.tag(ref, self.pinned_tag)
 
-        # Extract package name from "ghcr.io/owner/name" → "name"
-        package_name = img.repository.rsplit("/", 1)[-1]
-        _ensure_package_public(package_name, self.ghcr_token)
-
 
 def main() -> None:
     """Push a single OCI image to GHCR if its digest changed."""
@@ -123,12 +94,16 @@ def main() -> None:
     ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     sha = _git("rev-parse", "--short=7", "HEAD")
 
-    ghcr_token = get_required_env("GHCR_TOKEN")
+    # GHCR_USERNAME/GHCR_TOKEN are forwarded by .github/workflows/push-images.yml
+    # via `bb remote --remote_run_header=x-buildbuddy-platform.env-overrides=…`.
+    # The token is the workflow-scoped secrets.GITHUB_TOKEN; the username is
+    # the conventional "x-access-token" that GHCR accepts for workflow tokens.
     pusher = ImagePusher(
-        crane=Crane(registry="ghcr.io", username=get_required_env("GHCR_USERNAME"), password=ghcr_token),
+        crane=Crane(
+            registry="ghcr.io", username=get_required_env("GHCR_USERNAME"), password=get_required_env("GHCR_TOKEN")
+        ),
         branch=branch,
         pinned_tag=f"{branch}-{ts}-{sha}",
-        ghcr_token=ghcr_token,
     )
     pusher.push_and_tag(GhcrImage(image_target=args.image_target, repository=args.repository))
 

--- a/devinfra/secrets/ci_env.sh
+++ b/devinfra/secrets/ci_env.sh
@@ -1,19 +1,31 @@
 #!/usr/bin/env bash
-# CI environment: common secrets + machine-user identity + registry/release credentials.
+# CI environment: common secrets + registry/release credentials.
 # Usage: eval "$(devinfra/secrets/ci_env.sh)"
 #
 # Age recipients: ci (+ admin via _common.sh)
-#   github-pat-agentydragon-agent.yaml: admin, all user keys, claude-web, ci
 #   secrets/ci/*.sops.yaml:             admin, ci
 #
 # Consumed by:
 #   - .github/actions/setup-ci-secrets (GitHub Actions)
+#
+# GITHUB_TOKEN is NOT sourced from SOPS here. GHCR pushes and any other
+# workflow-run-scoped GitHub API use `${{ secrets.GITHUB_TOKEN }}` (the
+# workflow-scoped token GitHub Actions provisions per run) plumbed through
+# `bb remote`'s `x-buildbuddy-platform.env-overrides`. See
+# .github/workflows/push-images.yml for the wiring.
+#
+# TODO: secrets/github-pat-agentydragon-agent.yaml is still read by non-CI
+# consumers (devinfra/claude/ web sessions, devinfra/secrets/web_env.sh,
+# wt/server/github_client.py). When those are migrated off the machine-user
+# PAT, the SOPS file + PAT can be rotated out entirely.
+#
+# TODO: secrets/ci/ghcr-credentials.sops.yaml is no longer consumed by any
+# CI workflow after the migration to secrets.GITHUB_TOKEN. It can be deleted
+# once no out-of-tree consumer depends on it; keeping it temporarily so the
+# change is trivially revertible.
 
 # shellcheck source=_common.sh
 source "$(dirname "$0")/_common.sh"
-
-# Machine-user GitHub PAT (agentydragon-agent)
-try_export GITHUB_TOKEN "$REPO_ROOT/secrets/github-pat-agentydragon-agent.yaml" '["github_token"]'
 
 # Attic binary cache token
 try_export ATTIC_TOKEN "$REPO_ROOT/secrets/ci/attic-token.sops.yaml" '["token"]'
@@ -21,10 +33,6 @@ try_export ATTIC_TOKEN "$REPO_ROOT/secrets/ci/attic-token.sops.yaml" '["token"]'
 # Harbor CI robot
 try_export PROPS_REGISTRY_USERNAME "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["username"]'
 try_export PROPS_REGISTRY_PASSWORD "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["password"]'
-
-# GHCR (crane push, package visibility)
-try_export GHCR_USERNAME "$REPO_ROOT/secrets/ci/ghcr-credentials.sops.yaml" '["username"]'
-try_export GHCR_TOKEN "$REPO_ROOT/secrets/ci/ghcr-credentials.sops.yaml" '["token"]'
 
 # GitHub releases (agentydragon account, contents:write on ducktape)
 try_export GH_RELEASE_PAT "$REPO_ROOT/secrets/ci/gh-release-pat.sops.yaml" '["token"]'


### PR DESCRIPTION
## Summary

Replace the SOPS-decrypted long-lived GHCR PAT with `${{ secrets.GITHUB_TOKEN }}` (the workflow-scoped token GitHub Actions provisions per run) for `push-images.yml`, and delete the post-push GitHub API PATCH workaround that only existed because the PAT didn't trigger automatic visibility inheritance.

Net result: one fewer long-lived secret, one fewer API hop on every push, first-push packages go public automatically, and the token rotates per job.

## Mechanism (end-to-end verified against BuildBuddy OSS)

`push-images.yml` forwards the workflow token through `bb remote` via `env_overrides`:

```yaml
env_overrides: |
  GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }}
  GHCR_USERNAME=x-access-token
```

The propagation path — traced in the `buildbuddy-io/buildbuddy` source before making the change:

1. `.github/actions/bb-remote/action.yml:48` writes each `env_overrides` line as `--remote_run_header="x-buildbuddy-platform.env-overrides=KEY=VALUE"` on the `bb remote` invocation.
2. BuildBuddy's workflow service (`enterprise/server/workflow/service/service.go:1725-1731` — `withEnvOverrides`) reads the header from the RPC context and attaches it as a `platform.EnvOverridesPropertyName = "env-overrides"` platform property on the `ExecutionTask`.
3. The executor platform layer (`enterprise/server/remote_execution/executorplatform/executorplatform.go:319`) unconditionally splits each `KEY=VALUE` entry and appends it to the child command's `EnvironmentVariables` list.
4. `bb remote run //…:push_ghcr` executes the `py_binary` **on the runner VM** (not on an RBE executor). Env vars set on the runner command are visible to the Python subprocess via `os.getenv`, so `ghcr_push_lib.py`'s `Crane.login` picks up the workflow token.

Because the caller identity is `secrets.GITHUB_TOKEN`, GitHub automatically links new packages to the source repo and inherits its (public) visibility. That obviates the `_ensure_package_public()` post-push PATCH `/user/packages/container/<name>` call that the PAT required. The function, its imports, and the `ImagePusher.ghcr_token` field are deleted.

## Files changed

- **`.github/workflows/push-images.yml`** — `env_overrides` now carries `GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }}` + `GHCR_USERNAME=x-access-token`, with a comment block explaining the mechanism, the `packages: write` permission dependency, and the auto-visibility behaviour.
- **`devinfra/ghcr_push/ghcr_push_lib.py`** — deleted `_ensure_package_public()`, its `urllib`/`json` imports, the `ghcr_token` field on `ImagePusher`, and the PATCH call in `push_and_tag`. Module docstring rewritten to describe the workflow-token path.
- **`devinfra/secrets/ci_env.sh`** — removed `try_export` for `GITHUB_TOKEN`, `GHCR_USERNAME`, `GHCR_TOKEN`. Header comment updated with TODOs noting:
  - `secrets/github-pat-agentydragon-agent.yaml` is still read by non-CI consumers (web_env.sh, `devinfra/claude/hook_daemon`, `wt/server/github_client.py`), so the PAT file stays.
  - `secrets/ci/ghcr-credentials.sops.yaml` is unused after the migration and can be deleted once we're confident no out-of-tree consumer depends on it — kept temporarily so the change is trivially revertible.
- **`.github/actions/setup-ci-secrets/action.yml`** — removed the three dropped vars from both the mask loop and the `$GITHUB_ENV` export grep.

## What stays put

- `secrets/github-pat-agentydragon-agent.yaml` — machine-user PAT, kept for the non-CI consumers listed above.
- `secrets/ci/ghcr-credentials.sops.yaml` — left on disk with the TODO. Safe to delete in a follow-up.
- `release.yml` / `GH_RELEASE_PAT` — different codepath, different token; out of scope for this PR.

## Test plan

- [x] `bbr build //devinfra/ghcr_push/... //airlock:push_ghcr //grocy/auth_proxy:push_ghcr` — green (lint aspects included).
- [x] BuildBuddy OSS source traced end-to-end to confirm `env_overrides` reach the runner VM command env.
- [ ] Real verification happens on the first `push-images.yml` run after this lands on `devel` — any image with a test gate will exercise the full path. No backfill needed: existing public packages are already public; auto-visibility only affects new packages.

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo