### PR TITLE
diag(authentik-mcp-poc): FallbackToLogsOnError + claude-code-web log reader

### DIFF
--- a/cluster/k8s/agents/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/agents/claude-rbac/kustomization.yaml
@@ -17,4 +17,6 @@ resources:
   - rolebinding-openclaw-reader.yaml
   - role-harbor-reader.yaml
   - rolebinding-harbor-reader.yaml
+  - role-authentik-mcp-poc-reader.yaml
+  - rolebinding-authentik-mcp-poc-reader.yaml
   - role-logs-configmaps-reader.yaml

--- a/cluster/k8s/agents/claude-rbac/role-authentik-mcp-poc-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/role-authentik-mcp-poc-reader.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: authentik-mcp-poc-reader
+  namespace: authentik-mcp-poc
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - persistentvolumeclaims
+      - events
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: ["get", "list", "watch"]

--- a/cluster/k8s/agents/claude-rbac/rolebinding-authentik-mcp-poc-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-authentik-mcp-poc-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: claude-authentik-mcp-poc-reader
+  namespace: authentik-mcp-poc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: authentik-mcp-poc-reader
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-web
+    namespace: default


### PR DESCRIPTION
## Context

After #1250 merged and #1254 pushed the first public images via the new workflow-token auth, both `authentik-mcp-poc-server` and `-backend` pods flipped from `ImagePullBackOff` → `Running` → `Error (exit code 1)` → CrashLoopBackOff. The new GHCR auth path worked — the images pulled successfully — but the containers themselves are crashing right at startup.

I can't `kubectl -n authentik-mcp-poc logs` from the `claude-code-web` SA because that namespace wasn't in its reader bindings. This PR unblocks that.

## Changes

1. **`terminationMessagePolicy: FallbackToLogsOnError`** on both container specs. Kubelet then captures the last 4KB of stderr into the Pod's `.status.containerStatuses[*].lastState.terminated.message`, visible via `kubectl describe pod` / `kubectl get pod -o yaml`. This is a plain kube-native diagnostics channel that doesn't need `pods/log` RBAC. Keeping it going forward so future crashes are self-diagnosing.

2. **Namespace-scoped `Role` + `RoleBinding`** under `cluster/k8s/agents/claude-rbac/` mirroring the existing `harbor-reader` / `gatus-reader` pattern exactly:
   - `role-authentik-mcp-poc-reader.yaml` — get/list/watch on `pods`, `pods/log`, `services`, `configmaps`, `pvcs`, `events`, plus apps `deployments`/`replicasets`/`statefulsets` in the `authentik-mcp-poc` namespace.
   - `rolebinding-authentik-mcp-poc-reader.yaml` — binds the role to `ServiceAccount default/claude-code-web`.
   - Both added to `cluster/k8s/agents/claude-rbac/kustomization.yaml` in dep order.

No application-code changes — root-causing the crash is for a follow-up PR once we can see a traceback.

## Test plan

- [x] `bbr test //cluster/validation/...` — 8/8 green (`test_cluster_integration`, `test_kyverno_policies`, etc.)
- [ ] After Flux reconciles: `kubectl -n authentik-mcp-poc logs deploy/authentik-mcp-poc-server` should work, and `kubectl describe pod` should show the captured startup traceback.

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo