### PR TITLE
fix(grocy-mcp): move request_headers_to_remove to RouteConfiguration

### DIFF
--- a/cluster/k8s/agents/grocy-mcp/envoy.yaml
+++ b/cluster/k8s/agents/grocy-mcp/envoy.yaml
@@ -29,10 +29,12 @@
 #   kubelet readiness probes to /health never depend on the OAuth token
 #   being available. Otherwise the pod would never go Ready while Envoy is
 #   trying to fetch its first token.
-# - The HCM's request_headers_to_remove drops any inbound Authorization or
-#   GROCY-API-KEY headers so the off-the-shelf Grocy MCP server can send
-#   its dummy GROCY-API-KEY safely, and clients can't bypass the Bearer
-#   injection by supplying their own Authorization.
+# - The RouteConfiguration's request_headers_to_remove drops any inbound
+#   Authorization or GROCY-API-KEY headers so the off-the-shelf Grocy MCP
+#   server can send its dummy GROCY-API-KEY safely, and clients can't
+#   bypass the Bearer injection by supplying their own Authorization.
+#   (request_headers_to_remove is NOT a valid field on HttpConnectionManager
+#   — it only exists on RouteConfiguration/VirtualHost/Route.)
 # - client_secret_b64 is base64("username:app_password") — Authentik's M2M
 #   flow for proxy providers accepts this as an equivalent form of the
 #   username+app_password credential, so it plugs directly into Envoy's
@@ -66,12 +68,12 @@ static_resources:
                   - name: envoy.access_loggers.stdout
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-                request_headers_to_remove:
-                  - GROCY-API-KEY
-                  - Authorization
-                  - Proxy-Authorization
                 route_config:
                   name: local_route
+                  request_headers_to_remove:
+                    - GROCY-API-KEY
+                    - Authorization
+                    - Proxy-Authorization
                   virtual_hosts:
                     - name: grocy
                       domains: ["*"]


### PR DESCRIPTION
## Summary

- `request_headers_to_remove` is not a valid field on `HttpConnectionManager` — it only lives on `RouteConfiguration`/`VirtualHost`/`Route`. With the field at HCM level, every new grocy-mcp Envoy pod CrashLoops at startup with `no such field: 'request_headers_to_remove'`.
- Move the field into `route_config:` where it is valid and add a comment so we don't regress.
- The old Python proxy pod from the previous ReplicaSet is still serving traffic (Flux health check is the only thing noticing the stall), so grocy-mcp is partially functional — but the Envoy rollout has been wedged since #1256.

## Error currently blocking the rollout

```
error initializing config '/etc/envoy/envoy.yaml': Protobuf message
(type envoy.config.bootstrap.v3.Bootstrap reason INVALID_ARGUMENT:
invalid JSON in envoy.config.bootstrap.v3.Bootstrap @
static_resources.listeners[0].filter_chains[0].filters[0].typed_config.<any>:
message envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager,
near 1:3099 (offset 3098): no such field: 'request_headers_to_remove')
has unknown fields
```

## Test plan

- [ ] CI green
- [ ] After merge, Flux reconciles `grocy-mcp`, new Envoy pod passes readiness, old Python pod is replaced
- [ ] `claude-sandbox-kubectl get pods -n grocy-mcp` shows a single fresh ReplicaSet 2/2 Ready
- [ ] Grocy MCP tool call through Airlock returns data

https://claude.ai/code/session_017AdPb4khrg5HUyypk8sEEU