### PR TITLE
fix(authentik-mcp-poc): server FASTMCP_HOME + enableServiceLinks=false

### DIFF
--- a/cluster/k8s/agents/authentik-mcp-poc/app/backend-deployment.yaml
+++ b/cluster/k8s/agents/authentik-mcp-poc/app/backend-deployment.yaml
@@ -21,6 +21,12 @@ spec:
         app: authentik-mcp-poc
         component: backend
     spec:
+      # Don't auto-inject `<SERVICE>_PORT=tcp://...` env vars. The same-namespace
+      # `authentik-mcp-poc-backend` Service injects
+      # `AUTHENTIK_MCP_POC_BACKEND_PORT=tcp://10.x.x.x:8080`, which collides
+      # with the `port: int` field on `BackendSettings` (env_prefix
+      # `AUTHENTIK_MCP_POC_BACKEND_`) and crashes pydantic-settings on startup.
+      enableServiceLinks: false
       containers:
         - name: backend
           image: ghcr.io/agentydragon/authentik-mcp-poc-backend:devel-20260413030152-e437889 # {"$imagepolicy": "flux-system:authentik-mcp-poc-backend"}

--- a/cluster/k8s/agents/authentik-mcp-poc/app/server-deployment.yaml
+++ b/cluster/k8s/agents/authentik-mcp-poc/app/server-deployment.yaml
@@ -21,6 +21,12 @@ spec:
         app: authentik-mcp-poc
         component: server
     spec:
+      # Don't auto-inject `<SERVICE>_PORT=tcp://...` env vars from same-namespace
+      # Services. Pydantic-settings on the backend pod parses
+      # `AUTHENTIK_MCP_POC_BACKEND_PORT=tcp://...` as the `port: int` field and
+      # crashes; symmetric protection here so the server pod can't trip on the
+      # same trap if the field set ever changes.
+      enableServiceLinks: false
       containers:
         - name: server
           image: ghcr.io/agentydragon/authentik-mcp-poc-server:devel-20260413030146-e437889 # {"$imagepolicy": "flux-system:authentik-mcp-poc-server"}
@@ -30,6 +36,14 @@ spec:
               containerPort: 8765
               protocol: TCP
           env:
+            # OIDCProxy creates an encrypted DCR client store at
+            # `${FASTMCP_HOME}/oauth_proxy_client_storage/...` on init. The OCI
+            # image runs as user 1000 with no HOME set, so without this
+            # platformdirs falls back to `~/.local/share/fastmcp` which expands
+            # to `/.local/share/fastmcp` and EPERM. /tmp is writable for any
+            # user; the POC doesn't need persistent DCR registrations.
+            - name: FASTMCP_HOME
+              value: "/tmp/fastmcp"
             - name: AUTHENTIK_MCP_POC_OIDC_ISSUER
               value: "https://auth.allegedly.works/application/o/authentik-mcp-poc/"
             - name: AUTHENTIK_MCP_POC_PUBLIC_BASE_URL

--- a/debug/grocy_machine_auth.md
+++ b/debug/grocy_machine_auth.md
@@ -50,20 +50,20 @@ its Bearer JWT so clients can't bypass the M2M flow.
 
 ## Pieces in the repo
 
-| Path | Purpose |
-| --- | --- |
-| `grocy/auth_proxy/proxy.py` | Starlette + authlib reverse proxy (strip `GROCY-API-KEY`/`Authorization`, inject Bearer JWT, strip hop-by-hop response headers, preserve multi-value cookies) |
-| `grocy/auth_proxy/BUILD.bazel` | `py_library` → `py_binary` → OCI image → `ghcr_push` → `py_test` |
-| `grocy/auth_proxy/test_proxy.py` | respx-mocked unit tests |
-| `cluster/terraform/gitops/agent-machine-access/main.tf` | Authentik proxy provider + application + policy bindings + service account + app password + K8s secret |
-| `cluster/k8s/agents/grocy-mcp/deployment.yaml` | Two-container pod (auth proxy sidecar + MCP server) |
-| `cluster/k8s/agents/grocy-mcp/service.yaml` | ClusterIP on port 3000 for Airlock to reach |
-| `cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml` | Flux wiring; depends on `agent-machine-access-tf` + `reflector` |
-| `cluster/k8s/agents/airlock/config.yaml` | Registers `grocy` backend at `http://grocy-mcp.grocy-mcp.svc.cluster.local:3000/mcp` |
-| `cluster/k8s/grocy/settingoverrides.yaml` | `AUTH_CLASS=ReverseProxyAuthMiddleware`, `REVERSE_PROXY_AUTH_HEADER=X-authentik-username` |
-| `cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml` | `!Find [authentik_providers_proxy.proxyprovider, [name, grocy]]` binds grocy to the shared embedded outpost |
-| `cluster/k8s/authentik/proxy-routes/grocy-httproute.yaml` | Gateway API HTTPRoute: `grocy.allegedly.works → authentik-server:80` |
-| `cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-{repository,policy}.yaml` | Flux ImageRepository + ImagePolicy for auto-repinning the proxy image tag |
+| Path                                                                                     | Purpose                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grocy/auth_proxy/proxy.py`                                                              | Starlette + authlib reverse proxy (strip `GROCY-API-KEY`/`Authorization`, inject Bearer JWT, strip hop-by-hop response headers, preserve multi-value cookies) |
+| `grocy/auth_proxy/BUILD.bazel`                                                           | `py_library` → `py_binary` → OCI image → `ghcr_push` → `py_test`                                                                                              |
+| `grocy/auth_proxy/test_proxy.py`                                                         | respx-mocked unit tests                                                                                                                                       |
+| `cluster/terraform/gitops/agent-machine-access/main.tf`                                  | Authentik proxy provider + application + policy bindings + service account + app password + K8s secret                                                        |
+| `cluster/k8s/agents/grocy-mcp/deployment.yaml`                                           | Two-container pod (auth proxy sidecar + MCP server)                                                                                                           |
+| `cluster/k8s/agents/grocy-mcp/service.yaml`                                              | ClusterIP on port 3000 for Airlock to reach                                                                                                                   |
+| `cluster/k8s/agents/grocy-mcp/flux-kustomization.yaml`                                   | Flux wiring; depends on `agent-machine-access-tf` + `reflector`                                                                                               |
+| `cluster/k8s/agents/airlock/config.yaml`                                                 | Registers `grocy` backend at `http://grocy-mcp.grocy-mcp.svc.cluster.local:3000/mcp`                                                                          |
+| `cluster/k8s/grocy/settingoverrides.yaml`                                                | `AUTH_CLASS=ReverseProxyAuthMiddleware`, `REVERSE_PROXY_AUTH_HEADER=X-authentik-username`                                                                     |
+| `cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml`                             | `!Find [authentik_providers_proxy.proxyprovider, [name, grocy]]` binds grocy to the shared embedded outpost                                                   |
+| `cluster/k8s/authentik/proxy-routes/grocy-httproute.yaml`                                | Gateway API HTTPRoute: `grocy.allegedly.works → authentik-server:80`                                                                                          |
+| `cluster/k8s/flux-image-automation-ghcr/grocy-auth-proxy-image-{repository,policy}.yaml` | Flux ImageRepository + ImagePolicy for auto-repinning the proxy image tag                                                                                     |
 
 ## Authentik M2M flow (what the auth proxy actually does)
 


### PR DESCRIPTION
## Context

After PR #1254 pushed the first images via the new workflow-token auth path and PR #1257 added the `pods/log` reader role for `claude-code-web` in the `authentik-mcp-poc` namespace, both pods finally surfaced their startup tracebacks. Two real bugs:

### 1. Server crashed in `OIDCProxy.__init__`

```
PermissionError: [Errno 13] Permission denied: '/.local'
  File "fastmcp/server/auth/oauth_proxy/proxy.py", line 434, in __init__
    storage_dir.mkdir(parents=True, exist_ok=True)
```

The OCI image runs as user 1000 with no `HOME` set, so `platformdirs` resolves the encrypted DCR client storage path to `~/.local/share/fastmcp` → expands to `/.local/share/fastmcp` → `mkdir` fails on the read-only root.

Airlock works around this by setting `FASTMCP_HOME` to a PVC mount; the POC has no need for persistent DCR storage so we just point at `/tmp/fastmcp`, which is writable for any user without an extra volume.

### 2. Backend crashed in pydantic-settings

```
ValidationError: BackendSettings.port — input_value='tcp://10.99.245.197:8080'
```

Kubernetes auto-injects `<SERVICE>_PORT=tcp://<ip>:<port>` env vars from every Service in the namespace into every pod by default (`enableServiceLinks: true`). The `authentik-mcp-poc-backend` Service maps to env var `AUTHENTIK_MCP_POC_BACKEND_PORT`, which is **exactly** the pydantic env-var name `BackendSettings` looks up for its `port: int` field under `env_prefix="AUTHENTIK_MCP_POC_BACKEND_"`. Pydantic happily reads `tcp://...:8080` and crashes parsing as int.

Fix: `enableServiceLinks: false` on both pod specs. This kills the entire class of `<SERVICE>_*` env injection at source — defensive on the server pod too in case the field set ever changes.

## Changes

- `cluster/k8s/agents/authentik-mcp-poc/app/server-deployment.yaml`
  - Add `enableServiceLinks: false`
  - Add `FASTMCP_HOME=/tmp/fastmcp` env var
- `cluster/k8s/agents/authentik-mcp-poc/app/backend-deployment.yaml`
  - Add `enableServiceLinks: false`
- `debug/grocy_machine_auth.md` — incidental prettier reformat of a markdown table that the precommit run auto-fixed; unrelated to the bug fix but pulled along to keep the tree clean.

No Python or Terraform changes — both fixes are tiny pod-spec edits.

## Test plan

- [x] `bbr test //cluster/validation/... //x/authentik_mcp_poc/...` — 9/9 green.
- [x] All 24 pre-commit hooks pass.
- [ ] After Flux reconciles, both deployments roll over to Ready and the `whoami_via_backend` MCP tool works end-to-end.

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo