### PR TITLE
chore(claude): remove stale TODO(move-to-env-script) from session_context.mako

### DIFF
--- a/devinfra/claude/hook_daemon/templates/session_context.mako
+++ b/devinfra/claude/hook_daemon/templates/session_context.mako
@@ -51,8 +51,6 @@ ${"##"} Background tasks
 % if profile.bazel_remote_proxy and bazel_remote_proxy_sock:
 Bazel remote proxy (UDS): `${bazel_remote_proxy_sock}` → `${profile.bazel_remote_proxy.target}` (used by `--remote_proxy`/`--bes_proxy` in session bazelrc).
 % endif
-## TODO(move-to-env-script): BUILDBUDDY_API_KEY status surfaces in the startup section above.
-## The session-id-specific bbr tag line stays here until session_id is available outside the hook.
 % if buildbuddy_configured:
 
 ${"##"} BuildBuddy


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove two stale `## TODO(move-to-env-script)` comment lines from `session_context.mako`
- The TODO is now addressed: `startup_env_script` already surfaces yielded var names (including `BUILDBUDDY_API_KEY`) in the startup line via `env_overlay`

## Test plan

- [ ] No functional change — Mako template comments only, rendered output unaffected

https://claude.ai/code/session_016oyNSqecaNUfyJqMaMg8K4
EOF
)