### PR TITLE
fix(authentik-mcp-poc): drop /mcp from OIDCProxy base_url to fix metadata doubling

### DIFF
--- a/cluster/terraform/gitops/authentik-mcp-poc/main.tf
+++ b/cluster/terraform/gitops/authentik-mcp-poc/main.tf
@@ -108,7 +108,11 @@ resource "authentik_provider_oauth2" "mcp_poc" {
   allowed_redirect_uris = [
     {
       matching_mode = "strict"
-      url           = "https://authentik-mcp-poc.allegedly.works/mcp/auth/callback"
+      # OIDCProxy's redirect path defaults to "/auth/callback" relative to the
+      # FastMCP server's `base_url`. We deliberately set `base_url` to the bare
+      # public URL (no /mcp) in x/authentik_mcp_poc/server.py so OAuth metadata
+      # URLs collapse correctly — see the comment in `_build_auth` for why.
+      url = "https://authentik-mcp-poc.allegedly.works/auth/callback"
     },
   ]
 }

--- a/x/authentik_mcp_poc/server.py
+++ b/x/authentik_mcp_poc/server.py
@@ -29,14 +29,27 @@ logger = logging.getLogger(__name__)
 def _build_auth(settings: ServerSettings) -> AuthProvider:
     """OIDCProxy (for DCR + MCP OAuth endpoints) + JWTVerifier (for tool calls).
 
-    Modeled on airlock/app.py::_build_auth.
+    Modeled on airlock/app.py::_build_auth, with one important difference:
+    airlock wraps FastMCP under FastAPI and `app.mount("/mcp", mcp_app)`s it,
+    so airlock's FastMCP internal path is "/" and `base_url` includes "/mcp"
+    (the FastAPI mount adds the prefix externally). We serve uvicorn directly
+    on `mcp.http_app(path="/mcp")`, so FastMCP's internal path IS "/mcp" and
+    `base_url` must NOT include "/mcp" — otherwise:
+
+      - `_get_resource_url(mcp_path)` doubles to `<base_url>/mcp/mcp`
+      - AS metadata `authorization_endpoint` becomes `<base_url>/authorize` =
+        `https://server/mcp/authorize`, but the actual route is at root
+        `/authorize` (FastMCP mounts auth routes flat, not under streamable_http_path)
+
+    With `base_url = settings.public_base_url` (no /mcp), both the resource
+    URL and the OAuth endpoint URLs collapse to the right thing.
     """
     issuer = settings.normalized_issuer()
     proxy = OIDCProxy(
         config_url=f"{issuer}/.well-known/openid-configuration",
         client_id=settings.oidc_client_id,
         client_secret=settings.oidc_client_secret,
-        base_url=f"{settings.normalized_public_base_url()}/mcp",
+        base_url=settings.normalized_public_base_url(),
         require_authorization_consent=True,
     )
     # OIDCProxy's DCR endpoint rejects scopes it doesn't know about; allow the


### PR DESCRIPTION
## Context

#1261 fixed the actual startup crashes; the server now boots and serves traffic. But the OAuth metadata it advertises has two related path-doubling bugs that would prevent claude.ai from completing the discovery dance:

### 1. Resource URL doubled

The protected-resource metadata advertised:
```json
{
  "resource": "https://authentik-mcp-poc.allegedly.works/mcp/mcp",
  ...
}
```
Note the `/mcp/mcp`. FastMCP's `_get_resource_url(mcp_path)` is literally:
```python
return AnyHttpUrl(f"{prefix}/{suffix}")  # base_url + mcp_path
```
With `base_url=".../mcp"` and `mcp_path="/mcp"`, it concatenates to `.../mcp/mcp`.

### 2. AS metadata advertised wrong endpoint paths

`/.well-known/oauth-authorization-server` says:
```json
{
  "authorization_endpoint": "https://.../mcp/authorize",
  "token_endpoint":         "https://.../mcp/token",
  "registration_endpoint":  "https://.../mcp/register"
}
```
…but `create_streamable_http_app` in fastmcp/server/http.py extends `server_routes` with the OAuth routes verbatim — they're mounted at root (`/authorize`, `/token`, `/register`), NOT under the streamable_http_path prefix. Confirmed by curl: `/authorize` → 400, `/mcp/authorize` → 404. claude.ai would follow the metadata to a 404 and bail out.

Both stem from `base_url` having `/mcp` baked in. Airlock can get away with it because airlock wraps FastMCP under FastAPI and `app.mount("/mcp", mcp_app)`-s it — the mount adds the `/mcp` prefix externally while FastMCP's internal path stays `/`. We serve uvicorn directly on `mcp.http_app(path="/mcp")`, so the prefix is already inside FastMCP and `base_url` must NOT add it again.

## Changes

- `x/authentik_mcp_poc/server.py`: `base_url=settings.public_base_url` (was `+ "/mcp"`). Long comment in `_build_auth` explains the airlock-vs-direct-uvicorn divergence.
- `cluster/terraform/gitops/authentik-mcp-poc/main.tf`: `allowed_redirect_uris[0].url` from `https://.../mcp/auth/callback` → `https://.../auth/callback`. OIDCProxy's redirect path is `base_url + redirect_path`, so dropping `/mcp` from `base_url` also drops it from the callback URL Authentik whitelists.

## After this lands

URLs collapse to the right thing:

| metadata field          | new value                                |
| ----------------------- | ---------------------------------------- |
| `resource`              | `https://.../mcp`                        |
| `authorization_endpoint`| `https://.../authorize`                  |
| `token_endpoint`        | `https://.../token`                      |
| `registration_endpoint` | `https://.../register`                   |
| OIDCProxy callback URI  | `https://.../auth/callback`              |

## Test plan

- [x] `bbr test //x/authentik_mcp_poc/... //cluster/terraform/gitops/authentik-mcp-poc/...` — 4/4 (test_backend, format, lint, validate) green.
- [ ] After Flux + TF reconcile, re-curl the metadata endpoints and verify they all collapse correctly. Then add to claude.ai and run `whoami_via_backend` end-to-end.

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo