### PR TITLE
fix(util/crane): surface stderr/stdout in failed subprocess errors

### DIFF
--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,7 +1,7 @@
 """Shared utility libraries."""
 
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
-load("//devinfra/python:defs.bzl", "py_library")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "otel",
@@ -82,6 +82,16 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//util/bazel:runfiles",
+    ],
+)
+
+py_test(
+    name = "test_crane",
+    srcs = ["test_crane.py"],
+    deps = [
+        ":crane",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/util/crane.py
+++ b/util/crane.py
@@ -40,6 +40,22 @@ class BazelImage:
     image_rlocation: str
 
 
+def _format_crane_error(args: tuple[str, ...], returncode: int | None, stderr: str, stdout: str) -> str:
+    """Build a multiline message describing a failed crane subprocess.
+
+    Used by both the sync and async wrappers so failures look the same
+    regardless of which path raised. crane writes its error messages to
+    stderr; stdout is included for the rare case where it carries useful
+    context (e.g. a partial push trace).
+    """
+    parts = [f"crane {' '.join(args)} failed (exit {returncode})"]
+    if stderr.strip():
+        parts.append(f"stderr:\n{stderr.rstrip()}")
+    if stdout.strip():
+        parts.append(f"stdout:\n{stdout.rstrip()}")
+    return "\n".join(parts)
+
+
 class Crane:
     """Typed wrapper around the crane CLI.
 
@@ -66,7 +82,17 @@ class Crane:
             self._env = {**os.environ, "DOCKER_CONFIG": self._config_dir.name}
 
     def _run(self, *args: str) -> str:
-        result = subprocess.run([str(self._path), *args], check=True, capture_output=True, text=True, env=self._env)
+        try:
+            result = subprocess.run([str(self._path), *args], check=True, capture_output=True, text=True, env=self._env)
+        except subprocess.CalledProcessError as e:
+            # Surface stderr/stdout in the exception message. By default
+            # `CalledProcessError.__str__` only prints `cmd` and `returncode`,
+            # which makes errors from `check=True, capture_output=True` show up
+            # as the useless `Command '[...]' returned non-zero exit status N.`
+            # in tracebacks. Without the captured streams we can't tell whether
+            # crane hit a 401 from GHCR, a network blip during a blob upload,
+            # or anything else.
+            raise RuntimeError(_format_crane_error(args, e.returncode, e.stderr or "", e.stdout or "")) from e
         return result.stdout.strip()
 
     async def _arun(self, *args: str) -> str:
@@ -75,7 +101,7 @@ class Crane:
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"crane {args[0]} failed: {stderr.decode()}")
+            raise RuntimeError(_format_crane_error(args, proc.returncode, stderr.decode(), stdout.decode()))
         return stdout.decode().strip()
 
     def digest(self, image_ref: str) -> str:

--- a/util/test_crane.py
+++ b/util/test_crane.py
@@ -1,0 +1,108 @@
+"""Tests for util.crane.
+
+Focused on `_format_crane_error` and the `Crane._run` / `_arun` failure paths,
+since those are the bits that determine how a failed crane subprocess shows
+up in tracebacks. The original code wrapped the subprocess in
+`subprocess.run(check=True, capture_output=True)` and let the resulting
+`CalledProcessError` propagate, which only renders as the exit code — losing
+the actual error message. These tests pin the new behavior: stderr (and
+stdout, when present) are visible in the raised exception's message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_bazel
+
+from util.crane import Crane, _format_crane_error
+
+
+def test_format_crane_error_includes_stderr_and_stdout() -> None:
+    msg = _format_crane_error(("push", "img", "repo:tag"), 1, "DENIED: insufficient_scope\n", "uploading layer\n")
+    assert "crane push img repo:tag failed (exit 1)" in msg
+    assert "DENIED: insufficient_scope" in msg
+    assert "uploading layer" in msg
+
+
+def test_format_crane_error_omits_empty_streams() -> None:
+    msg = _format_crane_error(("digest", "x"), 2, "", "")
+    assert msg == "crane digest x failed (exit 2)"
+    assert "stderr" not in msg
+    assert "stdout" not in msg
+
+
+def test_format_crane_error_includes_only_nonempty_stream() -> None:
+    msg = _format_crane_error(("ls", "ghcr.io/foo"), 1, "  \t\n", "tag1\ntag2\n")
+    assert "stderr" not in msg
+    assert "stdout:\ntag1\ntag2" in msg
+
+
+def test_run_wraps_called_process_error_with_full_context() -> None:
+    """Sync `_run` must re-raise as RuntimeError whose message contains stderr/stdout.
+
+    Crucial: the previous behavior was a bare CalledProcessError that hides
+    the captured streams in `__str__`, so trying to debug `crane push` failures
+    from a Bazel `bb run` log gave you only `exit status 1`.
+    """
+    crane = Crane(path=Path("/nonexistent/crane"))
+
+    fake_error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["/nonexistent/crane", "push", "img", "ref"],
+        output="partial-stdout\n",
+        stderr="DENIED: requested access to the resource is denied\n",
+    )
+
+    with patch("subprocess.run", side_effect=fake_error), pytest.raises(RuntimeError) as exc_info:
+        crane._run("push", "img", "ref")
+
+    msg = str(exc_info.value)
+    assert "crane push img ref failed (exit 1)" in msg
+    assert "DENIED: requested access to the resource is denied" in msg
+    assert "partial-stdout" in msg
+    # The original CalledProcessError should be chained for tracebacks.
+    assert isinstance(exc_info.value.__cause__, subprocess.CalledProcessError)
+
+
+def test_run_handles_calledprocesserror_with_none_streams() -> None:
+    """`subprocess.CalledProcessError` may carry `stderr=None` if capture wasn't requested."""
+    crane = Crane(path=Path("/nonexistent/crane"))
+    fake_error = subprocess.CalledProcessError(returncode=1, cmd=["crane", "tag", "x", "y"])
+    with patch("subprocess.run", side_effect=fake_error), pytest.raises(RuntimeError) as exc_info:
+        crane._run("tag", "x", "y")
+    assert "crane tag x y failed (exit 1)" in str(exc_info.value)
+
+
+def test_arun_raises_with_stderr_and_stdout() -> None:
+    """Async `_arun` is symmetric: stderr is in the message, stdout when nonempty."""
+    crane = Crane(path=Path("/nonexistent/crane"))
+
+    class _FakeProc:
+        returncode = 1
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return (b"some output\n", b"AUTH_FAILED: token expired\n")
+
+    async def _fake_create(*args: object, **kwargs: object) -> _FakeProc:
+        return _FakeProc()
+
+    async def _go() -> None:
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_create):
+            await crane._arun("push", "img", "registry/foo:bar")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(_go())
+
+    msg = str(exc_info.value)
+    assert "crane push img registry/foo:bar failed (exit 1)" in msg
+    assert "AUTH_FAILED: token expired" in msg
+    assert "some output" in msg
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
`Crane._run` wrapped its `crane` subprocess as `subprocess.run(check=True, capture_output=True)`, then let the resulting `CalledProcessError` propagate unchanged. The default `__str__` of `CalledProcessError` only prints `cmd` and `returncode`, so users debugging a failed push only saw

    subprocess.CalledProcessError: Command '[...]' returned non-zero exit status 1.

…and had no idea whether crane hit a GHCR 401, a transient blob upload TLS blip, a permission-denied on the local OCI layout dir, or anything else. We literally just hit this on `//devinfra/firecracker/vm_pod:push_ghcr` in the push-images CI run for #1254 and could not see the actual error from the workflow log.

Both the sync wrapper (`Crane._run`) and the async wrapper (`Crane._arun`) now produce a uniform multi-line `RuntimeError` via a new `_format_crane_error` helper:

    crane push <image-dir> <ref> failed (exit 1)
    stderr:
    DENIED: requested access to the resource is denied
    stdout:
    <whatever crane wrote on its way out>

Empty streams are omitted to keep the message tight. The sync path `raise … from e` chains the original `CalledProcessError` so the full traceback still points at the subprocess invocation, but the visible message contains the captured streams.

Adds `util/test_crane.py` with five tests covering both sync and async failure paths plus the formatter helper, including the `stderr=None` case on `CalledProcessError` (since `subprocess.CalledProcessError` may carry `None` streams when capture wasn't requested).

BAZEL_TEST_INVOCATIONS=buildbuddy:f6ec11f3-3e5e-4686-987f-30aefe26fc06

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo