### PR TITLE
fix(authentik-mcp-poc): bind backend proxy provider to embedded outpost

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -32,3 +32,4 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, scanner-filebrowser]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, goldilocks]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, google-workspace-mcp]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, authentik-mcp-poc-backend]]


### PR DESCRIPTION
The authentik-mcp-poc-backend host has been returning a 404 for `whoami` ever since the POC went live, and we couldn't immediately tell whether the JWT federation through the outpost was failing or whether the request even reached an outpost. Curling the host directly settles it:

    $ curl -v https://authentik-mcp-poc-backend.allegedly.works/whoami
    < HTTP/2 404
    < content-type: text/html; charset=utf-8
    < x-authentik-id: d70d5b2d5d27469b99ebb257b987e84f      ← Authentik request id
    < x-frame-options: DENY
    <title>allegedly.works</title>                          ← Authentik tenant brand

That's an Authentik-served 404 (the FastAPI backend would return `application/json` with `{"detail":"Not Found"}` and no `x-authentik-id` header). The request hits Authentik but Authentik has no proxy provider matching the host and serves its brand 404.

Root cause: `cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml` hand-curates the proxy providers the embedded outpost claims via `!Find [authentik_providers_proxy.proxyprovider, ...]`. The `authentik_provider_proxy.mcp_poc_backend` resource was created by the POC's TF module (#1250), but nothing added it to the embedded outpost's `providers:` list. The outpost host router never matched `authentik-mcp-poc-backend.allegedly.works` and Authentik's brand 404 fell through.

This is the same `!Find` line every other proxy provider gets — see `grocy`, `goldilocks`, `google-workspace-mcp` etc. on the same list.

After this lands, the Authentik blueprint controller will repopulate the embedded outpost's providers, the outpost will start serving the host, JWT federation against `authentik_provider_oauth2.mcp_poc` will accept the Bearer token from claude.ai, and the request will reach FastAPI's `/whoami` route (which returns the X-Authentik-* echo).

BAZEL_TEST_INVOCATIONS=buildbuddy:a69f25e1-e719-41a1-a75a-0546d531bb4f

https://claude.ai/code/session_01UMNNK2UZh6kUJZM8RmHZUo