### PR TITLE
feat(skills): add /cihealth skill and extend /web_selfcheck with runner recycling check

### DIFF
--- a/skills/BUILD.bazel
+++ b/skills/BUILD.bazel
@@ -9,6 +9,7 @@ pkg_tar(
         "//skills/backtrace:backtrace_tar",
         "//skills/branch_splitter:branch_splitter_tar",
         "//skills/buildbuddy_api:buildbuddy_api_tar",
+        "//skills/cihealth:cihealth_tar",
         "//skills/cluster_health:cluster_health_tar",
         "//skills/followups:followups_tar",
         "//skills/forensic_surgeon:forensic_surgeon_tar",

--- a/skills/cihealth/BUILD.bazel
+++ b/skills/cihealth/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//skills:defs.bzl", "skill_package")
+
+skill_package(
+    name = "cihealth",
+    srcs = ["SKILL.md"],
+)

--- a/skills/cihealth/SKILL.md
+++ b/skills/cihealth/SKILL.md
@@ -18,22 +18,14 @@ diagnosis plans for anything that needs deeper investigation.
 
 ## Setup — GitHub Authentication
 
-Authenticate with GitHub before running any `gh` commands. Check for the CI
-read token in the environment, falling back to SOPS decryption:
+Set `GITHUB_TOKEN` for `gh` commands. In a Claude Code web session the token
+is already in the environment as `DUCKTAPE_CI_READ_GITHUB_TOKEN` (exported by
+`devinfra/secrets/web_env.sh` via the session start hook). Outside that
+context, decrypt `secrets/github-ci-read-pat.yaml` with the SOPS age key —
+see `devinfra/secrets/web_env.sh` for the exact pattern.
 
-```bash
-# Prefer already-exported token
-if [ -n "${DUCKTAPE_CI_READ_GITHUB_TOKEN:-}" ]; then
-  export GITHUB_TOKEN="$DUCKTAPE_CI_READ_GITHUB_TOKEN"
-elif [ -n "${SOPS_AGE_KEY:-}" ]; then
-  export GITHUB_TOKEN=$(sops --extract '["github_token"]' \
-    -d /home/user/ducktape/secrets/github-ci-read-pat.yaml 2>/dev/null)
-fi
-echo "GitHub auth: $([ -n "${GITHUB_TOKEN:-}" ] && echo OK || echo MISSING)"
-```
-
-If auth is unavailable, continue with public API (rate-limited, no private data)
-but note it in the report.
+If auth is unavailable, continue with the public API (rate-limited) and note
+it in the report.
 
 ## Phase 1 — Discover CI Organisation
 
@@ -92,78 +84,19 @@ For any workflow whose **most recent run** is not `success`:
 
 ### 2b. Release Artifact Staleness
 
-Compare each pinned artifact's commit against devel HEAD to compute how many
-commits and how much time it lags:
+For each entry in `npins/sources.json`, the URL encodes the pinned commit:
+ducktape-produced pins follow the pattern
+`.../releases/download/<artifact>-<sha7>/<filename>`. Extract that sha7,
+count how many commits `origin/devel` is ahead of it, and report the age of
+the pinned commit.
 
-```bash
-cd /home/user/ducktape
+External pins (e.g. `bb` from buildbuddy-io) have semantic version tags
+instead — just report the version.
 
-# Get current devel HEAD
-DEVEL_HEAD=$(git rev-parse origin/devel)
-echo "devel HEAD: $DEVEL_HEAD"
-
-# For each pin in npins/sources.json, extract the short commit from the URL
-python3 - <<'EOF'
-import json, re, subprocess, sys
-
-pins = json.load(open("npins/sources.json"))["pins"]
-devel_head = subprocess.check_output(
-    ["git", "rev-parse", "origin/devel"], text=True).strip()
-
-for name, pin in sorted(pins.items()):
-    url = pin.get("url", "")
-    # Extract short commit from URL pattern: releases/download/<name>-<sha7>/<file>
-    m = re.search(r'/releases/download/[^/]+-([0-9a-f]{7,})/[^/]+$', url)
-    if not m:
-        # External pin (e.g. bb from buildbuddy-io) — extract version differently
-        m2 = re.search(r'/releases/download/([^/]+)/', url)
-        ver = m2.group(1) if m2 else "unknown"
-        print(f"  {name}: {ver} (external, no commit)")
-        continue
-    pin_short = m.group(1)
-    # Find how many commits on devel are ahead of this pin
-    try:
-        result = subprocess.check_output(
-            ["git", "log", "--oneline", f"{pin_short}..origin/devel",
-             "--", "--"],
-            text=True, stderr=subprocess.DEVNULL).strip()
-        commits_behind = len(result.splitlines()) if result else 0
-        if commits_behind == 0:
-            print(f"  {name}: up-to-date ({pin_short})")
-        else:
-            # Get timestamp of when pin commit was made
-            ts = subprocess.check_output(
-                ["git", "log", "-1", "--format=%cr", pin_short],
-                text=True, stderr=subprocess.DEVNULL).strip()
-            print(f"  {name}: {commits_behind} commits behind devel "
-                  f"(pinned={pin_short}, {ts})")
-    except subprocess.CalledProcessError:
-        print(f"  {name}: commit {pin_short} not found locally "
-              f"(may need git fetch --all)")
-EOF
-```
-
-Also check `devinfra/image_pins.json` for Dockerfile-based image staleness:
-
-```bash
-python3 - <<'EOF'
-import json, subprocess, datetime
-
-try:
-    pins = json.load(open("devinfra/image_pins.json"))
-except FileNotFoundError:
-    print("devinfra/image_pins.json not found")
-    raise SystemExit
-
-# Check when each image was last updated vs devel tip date
-devel_date = subprocess.check_output(
-    ["git", "log", "-1", "--format=%ai", "origin/devel"], text=True).strip()
-print(f"devel tip: {devel_date}")
-
-for image, digest in sorted(pins.items()):
-    print(f"  {image}: {str(digest)[:40]}...")
-EOF
-```
+Also read `devinfra/image_pins.json` for Dockerfile-based image digests
+(rbe-worker, freecad-test). These are updated by `container-images.yml` only
+when the relevant Dockerfiles change, so staleness is expected unless those
+paths were recently touched.
 
 ### 2c. Scheduled Workflow Health
 
@@ -286,9 +219,8 @@ For every failure found in Phase 2:
    - **Pin/release stuck**: artifact not being released or pinned — trace the
      release pipeline (ci.yml → release.yml → sync-pins.yml) to find the break
 
-3. **For trivial fixes**: implement them directly, commit on a new branch
-   (`claude/cihealth-fix-<topic>`), push, and open a PR targeting `devel`.
-   Report the PR URL in the health report.
+3. **For trivial fixes**: implement them directly, commit, push a branch, and
+   open a PR targeting `devel`. Report the PR URL in the health report.
 
 4. **For non-trivial issues**: write a diagnosis plan with specific commands
    the user can run to confirm the root cause, followed by proposed fixes.
@@ -358,9 +290,13 @@ Produce a single markdown report. Healthy items get one line. Issues get details
   something is wrong with the scheduler or the workflow itself is failing
 - **Release blocked**: if `ci.yml` succeeded but `release.yml` sub-job failed,
   artifacts won't update and pins will grow stale
-- **Artifact drift**: if pins are >3 commits behind devel AND sync-pins is
-  running successfully, there may be a release test failure silently blocking
-  the release matrix for that artifact
+- **Artifact drift with healthy pipeline**: pins can legitimately lag by
+  several commits while a CI run is still in progress (commits often land
+  while the release job is building). To assess whether drift is a problem,
+  trace the pipeline: did `ci.yml` complete successfully for the commits since
+  the pin? Did the `release` sub-job succeed for that specific artifact's test
+  matrix entry? Did `sync-pins.yml` run after that release completed? If all
+  three happened and the pin still hasn't moved, something is stuck upstream
 - **Prettier / formatting churn**: if pre-commit fails on the same file
   repeatedly across different commits, the file likely has an ongoing formatting
   conflict (contributor not running `pre-commit` locally)

--- a/skills/cihealth/SKILL.md
+++ b/skills/cihealth/SKILL.md
@@ -18,11 +18,14 @@ diagnosis plans for anything that needs deeper investigation.
 
 ## Setup — GitHub Authentication
 
-Set `GITHUB_TOKEN` for `gh` commands. In a Claude Code web session the token
-is already in the environment as `DUCKTAPE_CI_READ_GITHUB_TOKEN` (exported by
-`devinfra/secrets/web_env.sh` via the session start hook). Outside that
-context, decrypt `secrets/github-ci-read-pat.yaml` with the SOPS age key —
-see `devinfra/secrets/web_env.sh` for the exact pattern.
+`gh` reads `GITHUB_TOKEN`. In a Claude Code web session, the read-only token
+is already available in the environment as
+`DUCKTAPE_CI_READ_GITHUB_TOKEN` (exported by `devinfra/secrets/web_env.sh`
+via the session start hook), so export
+`GITHUB_TOKEN="$DUCKTAPE_CI_READ_GITHUB_TOKEN"` before running `gh`
+commands. Outside that context, decrypt
+`secrets/github-ci-read-pat.yaml` with the SOPS age key and export it as
+`GITHUB_TOKEN`; see `devinfra/secrets/web_env.sh` for the exact pattern.
 
 If auth is unavailable, continue with the public API (rate-limited) and note
 it in the report.

--- a/skills/cihealth/SKILL.md
+++ b/skills/cihealth/SKILL.md
@@ -49,6 +49,7 @@ git -C /home/user/ducktape log --oneline origin/devel | head -1  # current HEAD
 ```
 
 From the discovery, build a mental model of:
+
 - Which workflows run on push to devel (per-commit checks)
 - Which workflows run on a schedule (repinning, attic push)
 - Which workflows are triggered manually only
@@ -79,6 +80,7 @@ done
 ```
 
 For any workflow whose **most recent run** is not `success`:
+
 - Read the failure log: `gh run view <id> --repo $REPO --log-failed 2>&1 | tail -100`
 - Identify exactly what failed (hook name, step name, error message, diff)
 
@@ -128,6 +130,7 @@ gh run list --repo $REPO --workflow nix-flake-update.yml \
 ```
 
 **sync-pins health criteria:**
+
 - Should have a `success` run within the last 45 minutes
 - If last success is >60 min ago: warn; if >2 hours: flag as stuck
 - If recent runs are failing: read failure log and diagnose
@@ -238,23 +241,23 @@ Produce a single markdown report. Healthy items get one line. Issues get details
 
 ## Per-Commit Checks (devel)
 
-| Workflow           | Status | Last run       | Note                    |
-| ------------------ | ------ | -------------- | ----------------------- |
-| pre-commit         | ✅     | 2026-04-13 06:19 |                        |
-| bazel-ci           | ✅     | 2026-04-13 06:19 |                        |
-| release            | ✅     | 2026-04-13 06:19 | all 6 artifacts released |
-| push-images        | ✅     | 2026-04-13 06:15 |                        |
-| ansible-lint       | ✅     | 2026-04-12 14:03 |                        |
-| nix-attic-push     | ⚠️     | 2026-04-12 10:00 | 28h ago, timed out     |
-| container-images   | ✅     | 2026-04-11 08:00 | no Dockerfile changes  |
-| <other>            | ...    | ...            | ...                     |
+| Workflow         | Status | Last run         | Note                     |
+| ---------------- | ------ | ---------------- | ------------------------ |
+| pre-commit       | ✅     | 2026-04-13 06:19 |                          |
+| bazel-ci         | ✅     | 2026-04-13 06:19 |                          |
+| release          | ✅     | 2026-04-13 06:19 | all 6 artifacts released |
+| push-images      | ✅     | 2026-04-13 06:15 |                          |
+| ansible-lint     | ✅     | 2026-04-12 14:03 |                          |
+| nix-attic-push   | ⚠️     | 2026-04-12 10:00 | 28h ago, timed out       |
+| container-images | ✅     | 2026-04-11 08:00 | no Dockerfile changes    |
+| <other>          | ...    | ...              | ...                      |
 
 ## Scheduled Jobs
 
-| Job           | Schedule     | Last success       | Status |
-| ------------- | ------------ | ------------------ | ------ |
-| sync-pins     | every 30 min | 2026-04-13 06:32   | ✅     |
-| nix-flake-update | manual    | 2026-04-10 (manual) | ✅    |
+| Job              | Schedule     | Last success        | Status |
+| ---------------- | ------------ | ------------------- | ------ |
+| sync-pins        | every 30 min | 2026-04-13 06:32    | ✅     |
+| nix-flake-update | manual       | 2026-04-10 (manual) | ✅     |
 
 ## Artifact Pin Staleness
 
@@ -268,10 +271,10 @@ Produce a single markdown report. Healthy items get one line. Issues get details
 
 ## Dockerfile Image Pins
 
-| Image      | Pin age  | Status |
-| ---------- | -------- | ------ |
-| rbe-worker | current  | ✅     |
-| freecad-test | current | ✅    |
+| Image        | Pin age | Status |
+| ------------ | ------- | ------ |
+| rbe-worker   | current | ✅     |
+| freecad-test | current | ✅     |
 
 ## Issues Found
 

--- a/skills/cihealth/SKILL.md
+++ b/skills/cihealth/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: cihealth
+description: >
+  Check the health of the CI/CD pipeline — devel branch status, per-commit
+  checks, release artifacts, artifact pin staleness, image publishing, scheduled
+  jobs, repinning cadence. Autonomously creates fix PRs for trivial issues
+  (formatting, etc.) or proposes a diagnosis plan for deeper problems. Use when
+  you suspect CI is broken, main is red, releases are lagging, repinning is
+  stuck, or images are falling behind.
+---
+
+# CI Health Check
+
+Comprehensive CI/CD pipeline health audit for the `agentydragon/ducktape`
+repository. Gather data in parallel, then produce a single structured report.
+Autonomously fix trivial issues (e.g. prettier formatting failures); propose
+diagnosis plans for anything that needs deeper investigation.
+
+## Setup — GitHub Authentication
+
+Authenticate with GitHub before running any `gh` commands. Check for the CI
+read token in the environment, falling back to SOPS decryption:
+
+```bash
+# Prefer already-exported token
+if [ -n "${DUCKTAPE_CI_READ_GITHUB_TOKEN:-}" ]; then
+  export GITHUB_TOKEN="$DUCKTAPE_CI_READ_GITHUB_TOKEN"
+elif [ -n "${SOPS_AGE_KEY:-}" ]; then
+  export GITHUB_TOKEN=$(sops --extract '["github_token"]' \
+    -d /home/user/ducktape/secrets/github-ci-read-pat.yaml 2>/dev/null)
+fi
+echo "GitHub auth: $([ -n "${GITHUB_TOKEN:-}" ] && echo OK || echo MISSING)"
+```
+
+If auth is unavailable, continue with public API (rate-limited, no private data)
+but note it in the report.
+
+## Phase 1 — Discover CI Organisation
+
+**Don't hardcode checks.** Read what the repo actually defines:
+
+```bash
+# List all workflows
+ls /home/user/ducktape/.github/workflows/
+
+# Read devinfra/ci/artifacts.py to understand what gets released
+cat /home/user/ducktape/devinfra/ci/artifacts.py 2>/dev/null | head -80
+
+# Read npins/sources.json to see what's pinned
+cat /home/user/ducktape/npins/sources.json
+
+# Read devinfra/image_pins.json for Dockerfile-based image pinning
+cat /home/user/ducktape/devinfra/image_pins.json 2>/dev/null
+
+# Count commits on devel since last pin update for each artifact
+git -C /home/user/ducktape log --oneline origin/devel | head -1  # current HEAD
+```
+
+From the discovery, build a mental model of:
+- Which workflows run on push to devel (per-commit checks)
+- Which workflows run on a schedule (repinning, attic push)
+- Which workflows are triggered manually only
+- What artifacts are released and pinned back into the repo
+
+## Phase 2 — Gather Data (Run in Parallel)
+
+Run all data-gathering commands in parallel.
+
+### 2a. Per-commit Workflow Status on devel
+
+For each push-triggered workflow, fetch the last 5 runs on devel:
+
+```bash
+REPO=agentydragon/ducktape
+
+# Per-commit workflows to check:
+for wf in pre-commit ci bazel-ci ansible-lint nix-attic-push \
+           push-images props-images container-images \
+           openclaw-image tana-mcp-image; do
+  echo "=== $wf ==="
+  gh run list --repo $REPO --workflow "${wf}.yml" \
+    --branch devel --limit 5 \
+    --json headBranch,status,conclusion,displayTitle,createdAt,databaseId \
+    --jq '.[] | [.conclusion, .createdAt[:16], .displayTitle[:60]] | @tsv' \
+    2>/dev/null || echo "(no runs or workflow not found)"
+done
+```
+
+For any workflow whose **most recent run** is not `success`:
+- Read the failure log: `gh run view <id> --repo $REPO --log-failed 2>&1 | tail -100`
+- Identify exactly what failed (hook name, step name, error message, diff)
+
+### 2b. Release Artifact Staleness
+
+Compare each pinned artifact's commit against devel HEAD to compute how many
+commits and how much time it lags:
+
+```bash
+cd /home/user/ducktape
+
+# Get current devel HEAD
+DEVEL_HEAD=$(git rev-parse origin/devel)
+echo "devel HEAD: $DEVEL_HEAD"
+
+# For each pin in npins/sources.json, extract the short commit from the URL
+python3 - <<'EOF'
+import json, re, subprocess, sys
+
+pins = json.load(open("npins/sources.json"))["pins"]
+devel_head = subprocess.check_output(
+    ["git", "rev-parse", "origin/devel"], text=True).strip()
+
+for name, pin in sorted(pins.items()):
+    url = pin.get("url", "")
+    # Extract short commit from URL pattern: releases/download/<name>-<sha7>/<file>
+    m = re.search(r'/releases/download/[^/]+-([0-9a-f]{7,})/[^/]+$', url)
+    if not m:
+        # External pin (e.g. bb from buildbuddy-io) — extract version differently
+        m2 = re.search(r'/releases/download/([^/]+)/', url)
+        ver = m2.group(1) if m2 else "unknown"
+        print(f"  {name}: {ver} (external, no commit)")
+        continue
+    pin_short = m.group(1)
+    # Find how many commits on devel are ahead of this pin
+    try:
+        result = subprocess.check_output(
+            ["git", "log", "--oneline", f"{pin_short}..origin/devel",
+             "--", "--"],
+            text=True, stderr=subprocess.DEVNULL).strip()
+        commits_behind = len(result.splitlines()) if result else 0
+        if commits_behind == 0:
+            print(f"  {name}: up-to-date ({pin_short})")
+        else:
+            # Get timestamp of when pin commit was made
+            ts = subprocess.check_output(
+                ["git", "log", "-1", "--format=%cr", pin_short],
+                text=True, stderr=subprocess.DEVNULL).strip()
+            print(f"  {name}: {commits_behind} commits behind devel "
+                  f"(pinned={pin_short}, {ts})")
+    except subprocess.CalledProcessError:
+        print(f"  {name}: commit {pin_short} not found locally "
+              f"(may need git fetch --all)")
+EOF
+```
+
+Also check `devinfra/image_pins.json` for Dockerfile-based image staleness:
+
+```bash
+python3 - <<'EOF'
+import json, subprocess, datetime
+
+try:
+    pins = json.load(open("devinfra/image_pins.json"))
+except FileNotFoundError:
+    print("devinfra/image_pins.json not found")
+    raise SystemExit
+
+# Check when each image was last updated vs devel tip date
+devel_date = subprocess.check_output(
+    ["git", "log", "-1", "--format=%ai", "origin/devel"], text=True).strip()
+print(f"devel tip: {devel_date}")
+
+for image, digest in sorted(pins.items()):
+    print(f"  {image}: {str(digest)[:40]}...")
+EOF
+```
+
+### 2c. Scheduled Workflow Health
+
+Check that scheduled jobs are running and succeeding:
+
+```bash
+REPO=agentydragon/ducktape
+
+# sync-pins runs every 30 minutes — should have a recent success
+echo "=== sync-pins (every 30 min) ==="
+gh run list --repo $REPO --workflow sync-pins.yml \
+  --limit 5 \
+  --json status,conclusion,createdAt,databaseId \
+  --jq '.[] | [.conclusion, .createdAt[:16]] | @tsv' 2>/dev/null
+
+# nix-attic-push runs on push
+echo "=== nix-attic-push (on push) ==="
+gh run list --repo $REPO --workflow nix-attic-push.yml \
+  --branch devel --limit 3 \
+  --json status,conclusion,createdAt,displayTitle \
+  --jq '.[] | [.conclusion, .createdAt[:16], .displayTitle[:50]] | @tsv' 2>/dev/null
+
+# nix-flake-update is manual — just report last run
+echo "=== nix-flake-update (manual) ==="
+gh run list --repo $REPO --workflow nix-flake-update.yml \
+  --limit 3 \
+  --json status,conclusion,createdAt \
+  --jq '.[] | [.conclusion, .createdAt[:16]] | @tsv' 2>/dev/null
+```
+
+**sync-pins health criteria:**
+- Should have a `success` run within the last 45 minutes
+- If last success is >60 min ago: warn; if >2 hours: flag as stuck
+- If recent runs are failing: read failure log and diagnose
+
+### 2d. Release Pipeline Status
+
+Check that the release job ran and released all expected artifacts after the
+most recent devel push:
+
+```bash
+REPO=agentydragon/ducktape
+
+echo "=== ci.yml (main pipeline) ==="
+gh run list --repo $REPO --workflow ci.yml \
+  --branch devel --limit 5 \
+  --json status,conclusion,createdAt,displayTitle,databaseId \
+  --jq '.[] | [.conclusion, .createdAt[:16], .displayTitle[:60]] | @tsv' 2>/dev/null
+
+# Latest release artifacts on GitHub
+echo "=== Latest GitHub releases ==="
+gh release list --repo $REPO --limit 20 2>/dev/null \
+  | head -30
+```
+
+Cross-reference: after the most recent successful `ci.yml` run, there should be
+GitHub releases for all 6 release artifacts (`claude-hooks`, `ducktape-util`,
+`ducktape`, `gterm-theme`, `skills`, `bbapi`). If any are absent or older than
+the CI run, the release job may have failed silently.
+
+### 2e. Container Image Currency
+
+```bash
+REPO=agentydragon/ducktape
+
+echo "=== container-images (rbe-worker, freecad-test) ==="
+gh run list --repo $REPO --workflow container-images.yml \
+  --branch devel --limit 5 \
+  --json conclusion,createdAt,displayTitle \
+  --jq '.[] | [.conclusion, .createdAt[:16], .displayTitle[:50]] | @tsv' 2>/dev/null
+
+echo "=== push-images (14 OCI images) ==="
+gh run list --repo $REPO --workflow push-images.yml \
+  --branch devel --limit 3 \
+  --json conclusion,createdAt,displayTitle \
+  --jq '.[] | [.conclusion, .createdAt[:16]] | @tsv' 2>/dev/null
+
+echo "=== openclaw-image ==="
+gh run list --repo $REPO --workflow openclaw-image.yml \
+  --branch devel --limit 3 \
+  --json conclusion,createdAt \
+  --jq '.[] | [.conclusion, .createdAt[:16]] | @tsv' 2>/dev/null
+
+echo "=== tana-mcp-image ==="
+gh run list --repo $REPO --workflow tana-mcp-image.yml \
+  --branch devel --limit 3 \
+  --json conclusion,createdAt \
+  --jq '.[] | [.conclusion, .createdAt[:16]] | @tsv' 2>/dev/null
+```
+
+### 2f. Anything Else the Repo Defines
+
+After running the above, glance at `.github/workflows/` for any workflows not
+covered above. Spot-check their last run status.
+
+Also check for signs of CI health issues beyond GitHub Actions:
+
+```bash
+# Are there uncommitted pin updates stuck in a PR?
+gh pr list --repo agentydragon/ducktape --limit 10 \
+  --json title,state,createdAt,headRefName \
+  --jq '.[] | [.state, .createdAt[:10], .headRefName[:40], .title[:50]] | @tsv' \
+  2>/dev/null | grep -iE 'pin|sync|chore.*sync' | head -10
+```
+
+## Phase 3 — Diagnose Failures
+
+For every failure found in Phase 2:
+
+1. **Read the failure log** (already done for per-commit checks above). If not
+   yet read, do it now: `gh run view <id> --repo ... --log-failed 2>&1 | tail -150`
+
+2. **Classify the failure**:
+   - **Trivial / auto-fixable**: prettier formatting, trailing whitespace,
+     import ordering, minor linting — create a fix commit and open a PR
+   - **Test failure**: a specific test broke — read the test output, identify
+     the cause, decide if it's a one-line fix or needs deeper investigation
+   - **Infrastructure failure**: runner can't reach a dependency, SOPS key
+     missing, cache full, external API down — propose diagnosis steps
+   - **Pin/release stuck**: artifact not being released or pinned — trace the
+     release pipeline (ci.yml → release.yml → sync-pins.yml) to find the break
+
+3. **For trivial fixes**: implement them directly, commit on a new branch
+   (`claude/cihealth-fix-<topic>`), push, and open a PR targeting `devel`.
+   Report the PR URL in the health report.
+
+4. **For non-trivial issues**: write a diagnosis plan with specific commands
+   the user can run to confirm the root cause, followed by proposed fixes.
+
+## Phase 4 — Report
+
+Produce a single markdown report. Healthy items get one line. Issues get details.
+
+```markdown
+# CI Health Report — <date> <time UTC>
+
+## Summary
+
+<one-liner: all green / N issues found>
+
+## Per-Commit Checks (devel)
+
+| Workflow           | Status | Last run       | Note                    |
+| ------------------ | ------ | -------------- | ----------------------- |
+| pre-commit         | ✅     | 2026-04-13 06:19 |                        |
+| bazel-ci           | ✅     | 2026-04-13 06:19 |                        |
+| release            | ✅     | 2026-04-13 06:19 | all 6 artifacts released |
+| push-images        | ✅     | 2026-04-13 06:15 |                        |
+| ansible-lint       | ✅     | 2026-04-12 14:03 |                        |
+| nix-attic-push     | ⚠️     | 2026-04-12 10:00 | 28h ago, timed out     |
+| container-images   | ✅     | 2026-04-11 08:00 | no Dockerfile changes  |
+| <other>            | ...    | ...            | ...                     |
+
+## Scheduled Jobs
+
+| Job           | Schedule     | Last success       | Status |
+| ------------- | ------------ | ------------------ | ------ |
+| sync-pins     | every 30 min | 2026-04-13 06:32   | ✅     |
+| nix-flake-update | manual    | 2026-04-10 (manual) | ✅    |
+
+## Artifact Pin Staleness
+
+| Artifact      | Behind devel | Pinned commit | Age        |
+| ------------- | ------------ | ------------- | ---------- |
+| claude-hooks  | 0 commits    | 35b400e       | up-to-date |
+| skills        | 2 commits    | 2de0bf8       | 1 hour ago |
+| ducktape      | 0 commits    | 071dad5       | up-to-date |
+| bbapi         | 0 commits    | 1710bc6       | up-to-date |
+| bb (external) | n/a          | 5.0.339       | external   |
+
+## Dockerfile Image Pins
+
+| Image      | Pin age  | Status |
+| ---------- | -------- | ------ |
+| rbe-worker | current  | ✅     |
+| freecad-test | current | ✅    |
+
+## Issues Found
+
+### <severity>: <title>
+
+**Workflow**: <name>
+**Run**: <id> at <time>
+**Error**: <brief description>
+**Root cause**: <if determinable>
+**Fix**: <action taken (link to PR) or proposed steps>
+```
+
+## Important Patterns to Detect
+
+- **sync-pins not running**: if last `sync-pins.yml` success is >1h ago,
+  something is wrong with the scheduler or the workflow itself is failing
+- **Release blocked**: if `ci.yml` succeeded but `release.yml` sub-job failed,
+  artifacts won't update and pins will grow stale
+- **Artifact drift**: if pins are >3 commits behind devel AND sync-pins is
+  running successfully, there may be a release test failure silently blocking
+  the release matrix for that artifact
+- **Prettier / formatting churn**: if pre-commit fails on the same file
+  repeatedly across different commits, the file likely has an ongoing formatting
+  conflict (contributor not running `pre-commit` locally)
+- **Container image stuck**: if `container-images.yml` last ran weeks ago and
+  the Dockerfiles haven't changed, this is expected — only flag if the image
+  should have updated based on path changes in recent commits
+- **nix-attic-push timeout**: the job has a 120-minute timeout; timeouts are
+  not uncommon for large Nix builds but should be retried

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -454,12 +454,12 @@ fi
 
 **Interpreting results:**
 
-| Warm / Cold ratio | Interpretation |
-| --- | --- |
-| < 33% | ✅ Runner recycling and analysis cache are working |
-| 33–70% | ⚠️ Partial benefit; runner may be rotating |
-| > 70% | ⚠️ Likely no recycling — but check again, high FP rate |
-| Cold < 5s | ❓ Ambiguous — build graph too small or poisoning ineffective |
+| Warm / Cold ratio | Interpretation                                                |
+| ----------------- | ------------------------------------------------------------- |
+| < 33%             | ✅ Runner recycling and analysis cache are working            |
+| 33–70%            | ⚠️ Partial benefit; runner may be rotating                    |
+| > 70%             | ⚠️ Likely no recycling — but check again, high FP rate        |
+| Cold < 5s         | ❓ Ambiguous — build graph too small or poisoning ineffective |
 
 **If consistently warm ≈ cold across two runs**: check the BuildBuddy run UI
 (`bbapi invocation <id>`) to see if runner IDs differ between invocations. If

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -411,10 +411,12 @@ echo "$POISON_MARKER" >> MODULE.bazel
 
 # Step 2: Cold build. MODULE.bazel changed → Bazel must re-analyse everything.
 # --nobuild skips compilation; we only care about analysis time.
-# Cap at 3 minutes — bail if bbr itself is hung.
+# Cold analysis of //... can take 5–20 minutes on this repo — be patient.
+# If it hangs with no output for >10 minutes, abort (Ctrl-C), restore
+# MODULE.bazel with `git checkout -- MODULE.bazel`, and skip this check.
 echo "--- Cold build (poisoned MODULE.bazel) ---"
 T1_START=$(date +%s%N)
-timeout 180 bbr build //... --nobuild 2>&1 | tail -5
+bbr build //... --nobuild 2>&1 | tail -5
 BBR_EXIT=$?
 T1_END=$(date +%s%N)
 T1_SEC=$(( (T1_END - T1_START) / 1000000000 ))
@@ -422,12 +424,12 @@ echo "Cold build: ${T1_SEC}s (exit $BBR_EXIT)"
 
 if [ $BBR_EXIT -ne 0 ]; then
   git checkout -- MODULE.bazel
-  echo "SKIP: Cold build failed or timed out — skipping cache warmth check."
+  echo "SKIP: Cold build failed — skipping cache warmth check."
 else
   # Step 3: Warm build. Same poisoned MODULE.bazel, same runner expected.
   echo "--- Warm build (same inputs, runner should be recycled) ---"
   T2_START=$(date +%s%N)
-  timeout 180 bbr build //... --nobuild 2>&1 | tail -5
+  bbr build //... --nobuild 2>&1 | tail -5
   T2_SEC=$(( ($(date +%s%N) - T2_START) / 1000000000 ))
   echo "Warm build: ${T2_SEC}s"
 

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -384,6 +384,89 @@ fix above.
 
 ---
 
+### 6b. BuildBuddy Runner Recycling & Analysis Cache
+
+**Goal**: Confirm that `bbr` reuses the same BuildBuddy runner VM between
+invocations so the Bazel analysis cache is warm for subsequent builds. A
+recycled runner means the second build completes analysis significantly faster
+than the first cold build.
+
+**Calibration note**: This is a low-precision, high-recall sensor with a high
+false-positive rate. A single "not recycling" result may be transient (runner
+rotation, BB server restart, cache eviction). Report the finding but don't act
+on a single failure. Stop early rather than spending many minutes trying.
+
+**Method — cache poisoning**: Append a comment to `MODULE.bazel` so the first
+build is guaranteed cold even if the runner was already warm, then measure
+whether the immediately-following identical build is significantly faster.
+
+```bash
+cd /home/user/ducktape
+
+# Step 1: Poison the analysis cache.
+# Any uncommmitted change to MODULE.bazel forces Bazel to re-analyse from
+# scratch on the runner, even if it was already warm.
+POISON_MARKER="# selfcheck-poison-$(date +%s)"
+echo "$POISON_MARKER" >> MODULE.bazel
+
+# Step 2: Cold build. MODULE.bazel changed → Bazel must re-analyse everything.
+# --nobuild skips compilation; we only care about analysis time.
+# Cap at 3 minutes — bail if bbr itself is hung.
+echo "--- Cold build (poisoned MODULE.bazel) ---"
+T1_START=$(date +%s%N)
+timeout 180 bbr build //... --nobuild 2>&1 | tail -5
+BBR_EXIT=$?
+T1_END=$(date +%s%N)
+T1_SEC=$(( (T1_END - T1_START) / 1000000000 ))
+echo "Cold build: ${T1_SEC}s (exit $BBR_EXIT)"
+
+if [ $BBR_EXIT -ne 0 ]; then
+  git checkout -- MODULE.bazel
+  echo "SKIP: Cold build failed or timed out — skipping cache warmth check."
+else
+  # Step 3: Warm build. Same poisoned MODULE.bazel, same runner expected.
+  echo "--- Warm build (same inputs, runner should be recycled) ---"
+  T2_START=$(date +%s%N)
+  timeout 180 bbr build //... --nobuild 2>&1 | tail -5
+  T2_SEC=$(( ($(date +%s%N) - T2_START) / 1000000000 ))
+  echo "Warm build: ${T2_SEC}s"
+
+  # Step 4: Restore MODULE.bazel.
+  git checkout -- MODULE.bazel
+
+  # Step 5: Assess.
+  echo "--- Result: cold=${T1_SEC}s  warm=${T2_SEC}s ---"
+  if [ "$T1_SEC" -lt 5 ]; then
+    echo "AMBIGUOUS: Cold build was <5s — build graph may be too small to"
+    echo "           measure, or poisoning had no effect on this runner."
+  elif [ "$T2_SEC" -lt $(( T1_SEC / 3 )) ]; then
+    echo "OK: Warm build (${T2_SEC}s) < 1/3 of cold (${T1_SEC}s)."
+    echo "    Runner recycling + analysis cache reuse is working."
+  else
+    echo "WARN: Warm build (${T2_SEC}s) is not much faster than cold (${T1_SEC}s)."
+    echo "      Runner may not be recycled, or analysis cache is evicted."
+    echo "      High false-positive rate — verify with a second run before diagnosing."
+  fi
+fi
+```
+
+**Interpreting results:**
+
+| Warm / Cold ratio | Interpretation |
+| --- | --- |
+| < 33% | ✅ Runner recycling and analysis cache are working |
+| 33–70% | ⚠️ Partial benefit; runner may be rotating |
+| > 70% | ⚠️ Likely no recycling — but check again, high FP rate |
+| Cold < 5s | ❓ Ambiguous — build graph too small or poisoning ineffective |
+
+**If consistently warm ≈ cold across two runs**: check the BuildBuddy run UI
+(`bbapi invocation <id>`) to see if runner IDs differ between invocations. If
+they do, BB is not reusing runners — this may be a BB configuration or quota
+issue. If runner IDs are the same but analysis is still slow, the Bazel server
+on the runner may be restarting between invocations.
+
+---
+
 ### 7. Ducktape Git Hooks
 
 **Goal**: confirm pre-commit hooks actually pass when committing. Hooks break in
@@ -553,6 +636,7 @@ After running all checks, produce:
 | Secret: k8s-token            | OK/FAIL| decrypts / API <http_code>          |
 | Secret: otlp-token           | OK/FAIL| decrypts / API <http_code>          |
 | bbr / BuildBuddy RBE         | OK/FAIL| ...                                 |
+| bbr runner recycling         | OK/WARN/AMBIG | cold=Xs warm=Ys ratio=Z%     |
 | Git hooks (pre-commit)       | OK/FAIL| backend=LOCAL/bbr; live commit pass/fail |
 | Git hooks (commit-msg)       | OK/FAIL| pass_filenames ok; ENFORCE_TEST_TAG state |
 


### PR DESCRIPTION
## Summary

- Adds new `/cihealth` skill (`skills/cihealth/`) for auditing CI/CD pipeline health: per-commit workflow status, artifact/pin staleness (tracing the full pipeline rather than commit counting), scheduled job health, release pipeline, and container image currency. Auto-fixes trivial issues (formatting PRs) or proposes diagnosis plans for deeper problems.
- Extends `/web_selfcheck` with **Section 6b: BuildBuddy Runner Recycling & Analysis Cache** — poisons `MODULE.bazel` to force a cold build, measures warm follow-up, reports the ratio. Low-precision/high-recall sensor, no hard timeout.
- Fixes prettier formatting on both skill files (trailing whitespace, table alignment) that was caught by CI.

## Test plan

- [ ] Skill files pass prettier (verified locally with `/root/.nix-profile/bin/prettier --write`)
- [ ] `skill_package` BUILD targets build successfully via CI
- [ ] `/cihealth` and `/web_selfcheck` skills are functionally correct — invoke manually after merge and `web_setup.sh` redeploy

https://claude.ai/code/session_01HSvLpsis8AoiyVTjYvHyfa