### PR TITLE
Suppress dead_code warnings in aw-models and aw-datastore

### DIFF
--- a/third_party/activitywatch/aw-server-rust.BUILD.bazel
+++ b/third_party/activitywatch/aw-server-rust.BUILD.bazel
@@ -25,6 +25,9 @@ rust_library(
     srcs = glob(["aw-models/src/**/*.rs"]),
     crate_root = "aw-models/src/lib.rs",
     edition = "2021",
+    # Suppress dead_code warning for TryParse::Unparsed field in tryvec.rs
+    # (external code we don't control).
+    rustc_flags = ["-Adead_code"],
     visibility = ["//visibility:public"],
     deps = [
         "@aw_server_crates//:chrono",
@@ -61,6 +64,9 @@ rust_library(
     srcs = glob(["aw-datastore/src/**/*.rs"]),
     crate_root = "aw-datastore/src/lib.rs",
     edition = "2021",
+    # Suppress dead_code warnings for LegacyDatastoreImportError fields in
+    # legacy_import.rs (external code we don't control).
+    rustc_flags = ["-Adead_code"],
     visibility = ["//visibility:public"],
     deps = [
         ":aw_models",


### PR DESCRIPTION
## Summary
This PR suppresses `dead_code` compiler warnings in two external Rust crates that are included in the ActivityWatch server build. The warnings are for unused fields in code we don't control and don't need to fix.

## Changes
- Added `rustc_flags = ["-Adead_code"]` to the `aw_models` library target to suppress warnings for the `TryParse::Unparsed` field in `tryvec.rs`
- Added `rustc_flags = ["-Adead_code"]` to the `aw_datastore` library target to suppress warnings for `LegacyDatastoreImportError` fields in `legacy_import.rs`

## Details
Both warnings originate from external code within the ActivityWatch crates that we don't maintain. Rather than modifying the upstream code, we suppress these specific warnings at the Bazel build level to keep the build clean while maintaining the integrity of the external dependencies.

https://claude.ai/code/session_01Wvgk6CFWeUcjmainsdRhG5