### PR TITLE
Clarify secrets flow: decryption only in hook daemon, not setup

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -248,18 +248,12 @@ bash ducktape/devinfra/claude/web_setup.sh
 This runs <web_setup.sh> which installs:
 
 1. Nix + devtools (`claude-hooks` wheel, `bbapi`, `gh`, `sops`, skills)
-2. Writes decrypted secrets into `.claude/settings.local.json` for MCP servers
+2. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
 3. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
 
-Secrets (`GITHUB_TOKEN`, `BUILDBUDDY_API_KEY`, `DUCKTAPE_OTEL_BEARER_TOKEN`, etc.) are
-decrypted in **two places** because different consumers read from different sources:
-
-- **`web_setup.sh`** → `settings.local.json`: the only path that reaches **MCP server**
-  processes. Claude Code injects `settings.local.json["env"]` into MCP servers directly.
-- **Hook daemon `startup_env_script`** → session env file: the path for **hook
-  subprocesses**, which source the session env file written by `SessionStart`.
-
-The kube MCP server (`claude-sandbox-kubectl`) is special: it self-decrypts via
-`kube_from_sops.sh` at startup and does not read from `settings.local.json`.
+Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
+delivered only to the interactive Claude Code process — not to the setup script. All
+decryption happens in the hook daemon via `startup_env_script` (`web_env.sh`) at
+daemon startup, once `SOPS_AGE_KEY` is available in the inherited env.
 
 See <docs/secrets_env_flow.md> for the full picture.

--- a/devinfra/claude/docs/secrets_env_flow.md
+++ b/devinfra/claude/docs/secrets_env_flow.md
@@ -3,53 +3,47 @@
 How secrets (API keys, tokens) and user-facing environment variables reach
 Claude Code and its subprocesses in a web session.
 
-## The Problem
+## Why Decryption Only Happens in the Hook Daemon
 
-`SOPS_AGE_KEY` is a pod-level container env var — available to all processes
-from the moment the container starts, including `web_setup.sh`. Both decryption
-paths therefore work reliably.
+`SOPS_AGE_KEY` is set via the Claude Code web UI "Environment Variables" knob
+(`startup_context.environment_variables`). This path delivers the key only to
+the interactive Claude Code process and its subprocesses — **not** to the init
+script (`web_setup.sh`) or to `claude --init-only`, both of which run before the
+interactive session and receive only the container env (plus `anthropicConfig.EnvironmentVariables`
+for `claude --init-only`), but not the user's UI vars.
 
-The need for **two paths** is not about secret availability — it's about which
-consumers can read from which sources:
+As a result, `web_setup.sh` cannot decrypt SOPS secrets. Decryption happens
+exclusively in the hook daemon via `startup_env_script`.
 
-- **`settings.local.json["env"]`** is injected by Claude Code into MCP server
-  processes. Hook subprocesses do NOT read from it.
-- **Session env file** (written by `SessionStart`) is sourced by hook subprocesses.
-  MCP servers never see it.
-
-The old approach used only `settings.local.json` and added a per-secret
-`_decrypt_sops_secret()` fallback directly in the session handler — duplicated
-logic that was fragile to maintain. The `startup_env_script` path eliminates
-that fallback: secrets are decrypted once into `os.environ` at daemon startup
-and flow naturally into the session env file.
+**Why this architecture?** Storing secrets as SOPS-encrypted files in the repo means
+rotation is a single `sops` edit — no pasting new values into multiple UIs. Without
+hook-daemon decryption, each secret would need to be entered separately into every
+consumer (Claude Code web UI environment variables, other frontends). With it, a single
+`SOPS_AGE_KEY` in the Claude Code web UI is the only credential to manage there.
 
 ## Current Architecture
 
-Two parallel paths decrypt the same secrets for different consumers:
-
 ```
-Container starts (SOPS_AGE_KEY in container env from the start)
+Container starts
 │
-├── environment-manager runs setup via `claude --init-only`: web_setup.sh
+├── environment-manager runs web_setup.sh (init script, direct bash via ExecuteScript)
 │   ├── Installs Nix + devtools (sops now on PATH)
-│   ├── Runs web_env.sh → decrypts all SOPS secrets
-│   └── Writes settings.local.json:
-│       { "env": { "DUCKTAPE_CLAUDE_HOOKS_PROFILE": "...",
-│                  "BUILDBUDDY_API_KEY": "...",          ← for pre-commit
-│                  "GITHUB_TOKEN": "...", ... } }
+│   └── Adds github-no-proxy remote + bbr config
+│       (inherits container env only; SOPS_AGE_KEY not available — no decryption)
+│
+├── environment-manager runs `claude --init-only` (fires Setup+SessionStart hooks)
+│   (non-fatal; these hooks fire again when the interactive session starts)
 │
 └── environment-manager starts Claude Code (interactive)
-    │   Claude Code reads settings.local.json["env"] and injects it into:
-    │     - All hook subprocesses (including the hook daemon)
-    │     - MCP server processes  ← only path that reaches them
-    │   (kube MCP server self-decrypts via kube_from_sops.sh — not listed here)
+    │   Inherits container env + user UI vars (including SOPS_AGE_KEY)
     │
     └── First hook dispatch → `claude-hook` entrypoint → Hook daemon starts
-        │   (inherits SOPS_AGE_KEY + settings.local.json["env"] from Claude Code)
+        │   (inherits SOPS_AGE_KEY from Claude Code process env)
         ├── Loads profile (profiles/web/profile.yaml)
         │
         ├── Runs startup_env_script: devinfra/secrets/web_env.sh
         │   → Decrypts all SOPS secrets into daemon os.environ
+        │   → Side effect: writes ~/.kube/config from K8S_TOKEN
         │
         ├── Session starts (SessionStart hook fires)
         │   ├── Reads secrets from os.environ
@@ -68,122 +62,79 @@ The following is based on best-effort RE of the `environment-manager` binary (Bu
 `495ea204`) — see `web_env/re/environment_manager/src/` for RE source. The RE is a
 reconstruction and may have gaps; the running binary is the ground truth.
 
-**`claude --init-only`** (runs `web_setup.sh`):
+**Init script** (`web_setup.sh`, run by environment-manager via `process.ExecuteScript`):
 
-- Inherits environment-manager's full process env via `syscall.Environ()` — includes
-  `SOPS_AGE_KEY` from the k8s pod secret, `HTTPS_PROXY`, and all other container-level vars
-- Plus `anthropicConfig.EnvironmentVariables` (from the `environment.environment_variables`
-  API field) appended as `key=value` pairs
-- Does **not** receive `startup_context.environment_variables` (the user's UI vars)
+- Inherits environment-manager's process env (container env)
+- Does **not** receive `anthropicConfig.EnvironmentVariables` (only appended to `claude --init-only`)
+- Does **not** receive `startup_context.environment_variables` (user's UI vars)
+- Therefore: `SOPS_AGE_KEY` (a UI var) is **not** available here
 
-RE evidence: `claude/init.go:RunInit` starts `claude --init-only` with
-`cmd.Env = syscall.Environ()` then appends `anthropicConfig.EnvironmentVariables`.
+**`claude --init-only`** (run by environment-manager after the init script):
+
+- Inherits environment-manager's full process env via `syscall.Environ()`
+- Plus `anthropicConfig.EnvironmentVariables` (internal Anthropic config field)
+- Does **not** receive `startup_context.environment_variables` (user's UI vars)
+- Therefore: `SOPS_AGE_KEY` (a UI var) is **not** available here either
 
 **Claude Code** (interactive session):
 
-- Inherits environment-manager's full process env via `os.Environ()` — same container
-  env as above
+- Inherits environment-manager's full process env via `os.Environ()`
 - Plus `startup_context.environment_variables` (user's "Environment Variables" UI knob)
-  appended as `key=value` pairs
-- Plus fixed vars: `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_SESSION_ID`,
-  `CLAUDE_CODE_REMOTE_SESSION_ID`, `CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION`,
-  `CLAUDE_CODE_DIAGNOSTICS_FILE`
+  — this includes `SOPS_AGE_KEY` and `DUCKTAPE_CLAUDE_HOOKS_PROFILE`
+- Plus fixed vars: `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_SESSION_ID`, etc.
 
-RE evidence: `claude/claude_code_executor.go:Execute` starts with `envVars = os.Environ()`
-then appends `e.Config.EnvironmentVariables` (= `StartupContext.EnvironmentVariables`).
-`cmd/cmd_task_run.go` creates the executor with `parsedCtx.StartupContext` after
-`Manager.Run()` returns.
+### What reaches each consumer
 
-### Why two paths?
+| Consumer                 | Gets secrets from                           |
+| ------------------------ | ------------------------------------------- |
+| kube MCP server          | `kube_from_sops.sh` (self-decrypts)         |
+| Cloud MCP servers        | Anthropic-managed — no local secrets needed |
+| Hook daemon subprocesses | session env file (via startup_env_script)   |
+| Claude Code process      | session env file (sourced by env hooks)     |
 
-`settings.local.json` and `startup_env_script` serve different consumers:
-
-| Consumer                 | Gets env from                                   | Path                            |
-| ------------------------ | ----------------------------------------------- | ------------------------------- |
-| kube MCP server          | `kube_from_sops.sh` (self-decrypts at startup)  | `claude-sandbox-kubectl-mcp.sh` |
-| Other MCP servers        | `settings.local.json["env"]`                    | web_setup.sh                    |
-| Hook daemon subprocesses | session env file                                | startup_env_script              |
-| Claude Code process      | `settings.local.json["env"]` + session env file | both                            |
-
-The kube MCP server (`claude-sandbox-kubectl-mcp.sh`) is self-sufficient: it
-calls `kube_from_sops.sh` to decrypt the token and write a temp kubeconfig,
-runs `kubernetes-mcp-server` as a subprocess (not exec), then the EXIT trap
-deletes the temp file. `CLAUDE_SANDBOX_K8S_TOKEN` is no longer needed in
-`settings.local.json` or anywhere in the env.
-
-`~/.kube/config` is written by `web_env.sh` (as a side effect, via
-`kube_from_sops.sh`) so that bare `kubectl` commands Claude runs also work
-without `KUBECONFIG` being set. Web sessions have no pre-existing user
-kubeconfig so this is safe.
-
-Both paths use `web_env.sh` with `SOPS_AGE_KEY` available and `sops` on PATH
-(installed in Step 2 of `web_setup.sh`). The `web_setup.sh` call uses `|| true`
-for robustness — if it fails unexpectedly, hook subprocesses still work via
-the session env file, but MCP servers would lose their secrets. The
-`startup_env_script` path forwards any failure as a warning to session mailboxes.
+`settings.local.json` is no longer written by `web_setup.sh` — it was always
+written empty because `SOPS_AGE_KEY` was unavailable at setup time.
 
 ## Two Separate `environment_variables` Maps
 
 There are two distinct `environment_variables` maps in the session, sourced from
-different places and delivered to different processes:
+different places and delivered to different processes.
 
 ### 1. User's "Environment Variables" UI knob → Claude Code process only
-
-These come from the sessions API response: `startup_context.environment_variables`.
 
 Flow:
 
 1. Sessions API: `GET /v1/sessions/<id>/context` → `startup_context.environment_variables`
 2. `v1_parser.go:buildStartupContext()` → `config.StartupContext.EnvironmentVariables`
-3. `cmd/cmd_task_run.go` creates `ClaudeCodeExecutor{Config: parsedCtx.StartupContext}` after `Manager.Run()`
+3. `cmd/cmd_task_run.go` creates `ClaudeCodeExecutor{Config: parsedCtx.StartupContext}`
 4. `claude_code_executor.go:Execute()` → appended to Claude Code subprocess env
 
-**Result**: Claude and everything it spawns (hook daemon calls, tools) sees these vars.
-`SOPS_AGE_KEY` set here is available to Claude and the hook daemon's tool calls.
+**Result**: Claude and everything it spawns (hook daemon, tool calls) sees these vars.
+`SOPS_AGE_KEY` set here is available to the hook daemon's decryption.
 
-### 2. Internal Anthropic config → setup script subprocess only
-
-These come from: `environment.environment_variables` in the same API response.
+### 2. Internal Anthropic config → `claude --init-only` subprocess only
 
 Flow:
 
 1. Sessions API response: `environment.environment_variables` (internal Anthropic config)
-2. `v1_parser.go:buildEnvironmentResponse()` → raw JSON for `anthropicConfig`
-3. `anthropic.go:Initialize()` → `claude.RunInit(..., e.config.EnvironmentVariables)`
-4. `RunInit()` (RE: `claude/init.go`) runs `claude --init-only` with `syscall.Environ()`
-   (full process env, including `SOPS_AGE_KEY` from k8s pod secret) plus these vars appended
+2. `anthropic.go:Initialize()` → `claude.RunInit(..., e.config.EnvironmentVariables)`
+3. `RunInit()` runs `claude --init-only` with `syscall.Environ()` plus these vars appended
 
-**Result**: The setup script sees the full container environment plus
-`anthropicConfig.EnvironmentVariables`. It does **not** receive
-`startup_context.environment_variables` (the user's UI vars).
-This is why `SOPS_AGE_KEY` set via the "Environment Variables" UI knob is **not**
-available during `web_setup.sh` — the UI vars go to path 1 (Claude Code), not here.
+**Result**: `claude --init-only` sees the full container environment plus
+`anthropicConfig.EnvironmentVariables`. The init script (`web_setup.sh`) does **not**
+receive these — it runs before `claude --init-only` via `process.ExecuteScript` and
+only inherits the container env. Neither subprocess receives the user's UI vars.
 
-## startup_env_script: The Right Hook
+## startup_env_script: The Decryption Hook
 
-`ProfileConfig.startup_env_script` solves the timing problem cleanly:
+`ProfileConfig.startup_env_script` is the sole decryption path on web:
 
 - Configured in `profiles/web/profile.yaml` as `devinfra/secrets/web_env.sh`
 - Run by `main.py` at daemon startup, after the profile is loaded
-- By daemon startup, SOPS_AGE_KEY is in the container env → decryption works
-- `eval "$(web_env.sh)" && env -0` captures the exported vars, diffs against
-  initial env, and merges new/changed vars into `os.environ`
+- By daemon startup, `SOPS_AGE_KEY` is in the inherited env → decryption works
+- `eval "$(web_env.sh)" && env -0` captures exported vars, diffs against
+  initial `os.environ`, and merges new/changed vars into `os.environ`
 - All subsequent session start logic reads secrets directly from `os.environ`
-
-## What Lives Where
-
-| Secret                          | `settings.local.json` (for MCP)                                           | Session env file (for hooks)                                   |
-| ------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `BUILDBUDDY_API_KEY`            | web_setup.sh                                                              | startup_env_script (reliable)                                  |
-| `GITHUB_TOKEN`                  | web_setup.sh                                                              | startup_env_script (reliable)                                  |
-| `K8S_TOKEN`                     | web_setup.sh                                                              | startup_env_script (reliable)                                  |
-| `CLAUDE_SANDBOX_K8S_TOKEN`      | n/a — MCP launcher decrypts directly                                      | n/a — `~/.kube/config` written by web_env.sh                   |
-| `DUCKTAPE_OTEL_BEARER_TOKEN`    | web_setup.sh                                                              | startup_env_script (reliable)                                  |
-| `DUCKTAPE_CI_READ_GITHUB_TOKEN` | web_setup.sh                                                              | startup_env_script (reliable)                                  |
-| `DUCKTAPE_CLAUDE_HOOKS_PROFILE` | web_setup.sh (**required** — daemon needs this before startup_env_script) | n/a                                                            |
-| User env vars (UI knob)         | n/a                                                                       | Sessions API `startup_context` → Claude Code only              |
-| Setup-script env vars           | n/a                                                                       | Sessions API `environment` → setup script (`--init-only`) only |
-| `SOPS_AGE_KEY`                  | n/a (k8s container env, available to all)                                 | n/a                                                            |
 
 ## CLI Profile
 

--- a/devinfra/claude/hook_daemon/config.py
+++ b/devinfra/claude/hook_daemon/config.py
@@ -5,9 +5,8 @@ The daemon loads exactly one profile at startup, selected by the
 DUCKTAPE_CLAUDE_HOOKS_PROFILE env var.
 
 Secrets are not handled here.
-Web: sourced via startup_env_script (web_env.sh) at daemon startup; also partially written
-to settings.local.json by web_setup.sh (runs before SOPS_AGE_KEY injection, so typically
-only DUCKTAPE_CLAUDE_HOOKS_PROFILE lands there reliably).
+Web: sourced via startup_env_script (web_env.sh) at daemon startup (SOPS_AGE_KEY
+is available in the daemon's inherited env from Claude Code).
 CLI: sourced via .envrc (eval "$(devinfra/secrets/cli_env.sh)") before daemon starts.
 """
 

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -4,11 +4,22 @@
 # Installs:
 #   1. Nix (Determinate Systems installer, designed for non-interactive/CI use)
 #   2. devtools — claude-hooks, bbapi, gh, skills; from flake via attic binary cache
-#   3. secrets + profile — decrypt SOPS secrets into .claude/settings.local.json
+#   3. git remote + bbr config for BuildBuddy remote execution
 #   4. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
 #
+# Secrets are NOT decrypted here. SOPS_AGE_KEY is a user UI env var and is
+# only available to Claude Code and its subprocesses — not to this setup script.
+# This script is run directly by environment-manager as a bash init script
+# (process.ExecuteScript → temp file "init-script-*.sh"), inheriting only the
+# container env. `claude --init-only` (which fires Setup+SessionStart hooks) runs
+# separately afterward. Neither step receives user UI vars.
+# Decryption happens exclusively in the claude-hook daemon via startup_env_script.
+#
 # IMPORTANT: This script always exits 0 so the session starts even if setup
-# fails. Failures are logged to /tmp/web-setup.log and uploaded to ix.io.
+# fails. Failures are logged to /tmp/web-setup.log.
+#
+# Set DUCKTAPE_WEB_SETUP_UPLOAD_LOG=1 to upload the log to ix.io on completion
+# (useful for debugging sessions where you can't read the log directly).
 #
 # Usage (Claude Code web UI setup command):
 #   bash ducktape/devinfra/claude/web_setup.sh
@@ -97,38 +108,9 @@ for bin in "${NIX_PROFILE}"/bin/*; do
   ln -sfn "$bin" /usr/local/bin/"$(basename "$bin")"
 done
 
-# --- Step 3: Decrypt secrets and write settings.local.json ---
-# sops is now on PATH (installed by devtools in Step 2).
-# These secrets are used by Claude Code itself and any non-kube MCP servers.
-# The kube MCP server (claude-sandbox-kubectl) self-decrypts via kube_from_sops.sh
-# and does not read from settings.local.json. See docs/secrets_env_flow.md.
-#
-# The hook daemon also decrypts independently via startup_env_script at daemon
-# startup — the reliable path for hook subprocesses.
 PROJECT_DIR="${FLAKE#path:}"
-eval "$("$PROJECT_DIR/devinfra/secrets/web_env.sh" 2>/tmp/web-env-stderr.log)" || true
-cat /tmp/web-env-stderr.log >&2
 
-# Python writes the JSON — safe quoting, no shell escaping footguns.
-# Note: DUCKTAPE_CLAUDE_HOOKS_PROFILE is not written here; configure it as an
-# env var in the Claude Code web UI (along with the SOPS_AGE_KEY age private key).
-SETTINGS_LOCAL="$PROJECT_DIR/.claude/settings.local.json"
-SETTINGS_LOCAL="$SETTINGS_LOCAL" python3 <<'PYEOF'
-import json, os, sys
-from pathlib import Path
-
-keys = ["BUILDBUDDY_API_KEY", "DUCKTAPE_OTEL_BEARER_TOKEN",
-        "GITHUB_TOKEN", "K8S_TOKEN", "DUCKTAPE_CI_READ_GITHUB_TOKEN"]
-present = {k: v for k in keys if (v := os.environ.get(k))}
-missing = [k for k in keys if k not in present]
-if missing:
-    print(f"NOTE: secrets not yet available for settings.local.json: {missing}", file=sys.stderr)
-    print("      Hook daemon will decrypt via startup_env_script at session start.", file=sys.stderr)
-Path(os.environ["SETTINGS_LOCAL"]).write_text(json.dumps({"env": present}))
-PYEOF
-echo "[$(date -Iseconds)] Wrote secrets to ${SETTINGS_LOCAL}"
-
-# --- Step 4: Add github-no-proxy remote for bbr ---
+# --- Step 3: Add github-no-proxy remote for bbr ---
 # Claude Code web sessions use a local git proxy as 'origin'
 # (http://127.0.0.1:<port>/git/...). When 'bb remote' sends a RunRequest to
 # the BuildBuddy cloud runner, it embeds the selected remote's URL in
@@ -153,7 +135,7 @@ fi
 git -C "$PROJECT_DIR" config buildbuddy.remote-bazel-remote-name github-no-proxy
 echo "[$(date -Iseconds)] Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
 
-# --- Step 5: Symlink skills into ~/.claude/skills/ ---
+# --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.
 echo "Deploying skills to ~/.claude/skills/..."
@@ -163,3 +145,8 @@ for skill in "${NIX_PROFILE}"/share/claude-hooks/skills/*/; do
 done
 
 echo "[$(date -Iseconds)] Setup complete. Log: ${LOG_FILE}"
+
+if [ "${DUCKTAPE_WEB_SETUP_UPLOAD_LOG:-0}" = "1" ]; then
+  UPLOAD_URL=$(curl -s -F "f:1=@${LOG_FILE}" ix.io 2>/dev/null || echo "upload failed")
+  echo "[$(date -Iseconds)] Log uploaded: ${UPLOAD_URL}"
+fi

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -64,8 +64,13 @@ skills may not match what the current code expects.
 ls -la /tmp/web-setup.log 2>/dev/null || echo "MISSING"
 # Did it succeed? (last line should be "Setup complete.")
 tail -5 /tmp/web-setup.log 2>/dev/null
-# Was it recent? (mtime)
-stat -c '%y' /tmp/web-setup.log 2>/dev/null
+# When did it run, and how long ago?
+SETUP_MTIME=$(stat -c '%Y' /tmp/web-setup.log 2>/dev/null)
+if [ -n "$SETUP_MTIME" ]; then
+  NOW=$(date +%s)
+  AGO=$(( (NOW - SETUP_MTIME) / 60 ))
+  echo "web_setup.sh ran: $(stat -c '%y' /tmp/web-setup.log) (${AGO} minutes ago)"
+fi
 # Did Nix install?
 nix --version 2>/dev/null || echo "nix not found"
 # Is the devtools profile active?
@@ -91,6 +96,10 @@ fi
 grep -A200 'environment keys' /tmp/web-setup.log 2>/dev/null | grep -B200 '^---$' | grep -v '^---'
 ```
 
+If the log is present and non-empty, show more context on failure. Print the
+last 40 lines of `/tmp/web-setup.log` when anything looks wrong — setup scripts
+often log the exact error before the failure.
+
 **Failure indicators**: log missing, last line not "Setup complete", nix not
 found, devtools not in profile list, setup commit doesn't match HEAD.
 
@@ -99,11 +108,6 @@ found, devtools not in profile list, setup commit doesn't match HEAD.
 ```
 bash ducktape/devinfra/claude/web_setup.sh
 ```
-
-If re-running, note that `SOPS_AGE_KEY` is typically not available when
-`web_setup.sh` runs — all SOPS decryptions will fail. Secrets are instead
-decrypted by the session start hook daemon (which inherits `SOPS_AGE_KEY`
-from the container after k8s injects it). This is expected and not a bug.
 
 ---
 
@@ -227,6 +231,110 @@ common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
 build --config=rbe
 EOF
 ```
+
+---
+
+### 3b. Daemon & Hook Logs
+
+**Goal**: when the session start hook failed (or anything looks wrong with hook
+processing), read the full set of relevant log files to find the root cause.
+Run all reads in parallel.
+
+#### Daemon log (`daemon.log` / `daemon.err.log`)
+
+The hook daemon writes structured Python `logging` output. Every hook event
+it processes appears as `hook <HookName> → {output}`. A missing `SessionStart`
+line in the log means the daemon never received (or never processed) that event.
+
+```bash
+LIVE=$(ps aux | grep hook_daemon | grep -v grep | grep -oP '(?<=--sock /tmp/claude-hd/)[^/]+' | head -1)
+DAEMON_LOG=~/.claude/session-env/$LIVE/hook-daemon/daemon.log
+DAEMON_ERR=~/.claude/session-env/$LIVE/hook-daemon/daemon.err.log
+
+echo "=== daemon.log (first 60 lines) ==="
+head -60 "$DAEMON_LOG" 2>/dev/null || echo "MISSING"
+
+echo "=== daemon.log (errors + SessionStart mentions) ==="
+grep -n -E 'ERROR|Exception|Traceback|SessionStart|sessionstart|FileNotFoundError|session_dir' \
+  "$DAEMON_LOG" 2>/dev/null | head -40 || echo "(no matches)"
+
+echo "=== daemon.err.log (last 30 lines) ==="
+tail -30 "$DAEMON_ERR" 2>/dev/null || echo "MISSING"
+```
+
+**Interpreting `daemon.log`**:
+
+- First lines show: startup env var keys, settings (`profile`, `k8s_token`,
+  `session_dir`), tracing config, server bind address.
+- `settings: { ..., 'session_dir': None }` means the daemon didn't know its
+  session directory at startup — the env file path was not provided to it.
+  This is normal when the hook framework passes `CLAUDE_ENV_FILE` per-request;
+  it's NOT normal if `SessionStart` never arrives.
+- `hook SessionStart → {...}` should appear within the first few lines of hook
+  processing. If the first hook logged is `UserPromptSubmit`, SessionStart was
+  never sent — the daemon started after the event fired (race condition / VM
+  reuse), or the shim failed silently.
+- Any `ERROR` or `Traceback` during `SessionStart` processing explains why
+  the env file was not written even if the event arrived.
+
+#### Hook event trace (`/tmp/claude-hook-events.jsonl`)
+
+The `claude-hook` entrypoint shim writes every hook invocation (input and
+output) to this file as JSONL. This is the ground truth of what events the
+shim saw, regardless of whether the daemon processed them.
+
+Each line is a JSON object with fields: `ts` (Unix float), `pid`, `dir`
+(`"input"` or `"output"`), `hook` (event name), `session_id`, `data` (raw
+hook payload string or null). Print a compact timeline of the last 20 events
+and count `SessionStart` input vs output occurrences.
+
+```bash
+tail -20 /tmp/claude-hook-events.jsonl 2>/dev/null || echo "MISSING"
+grep '"SessionStart"' /tmp/claude-hook-events.jsonl 2>/dev/null | grep -c '"dir": *"input"' || echo 0
+grep '"SessionStart"' /tmp/claude-hook-events.jsonl 2>/dev/null | grep -c '"dir": *"output"' || echo 0
+```
+
+**Interpreting `/tmp/claude-hook-events.jsonl`**:
+
+- Each hook event appears twice: once as `input` (shim received it) and once
+  as `output` (shim returned result). If `SessionStart` appears as `input` but
+  not `output`, the daemon timed out or the shim crashed processing it.
+- If `SessionStart` doesn't appear at all, the event was never fired for this
+  session — this happens on VM reuse where Claude Code skips startup hooks
+  (see `env-manager.log` below).
+- Multiple session IDs in the file are normal (prior + current session).
+
+#### Environment manager logs (`/tmp/env-manager.log`, `/tmp/environment-manager-*.diag.log`)
+
+The environment manager (Anthropic's session init process) logs its work here.
+This is the most authoritative source for whether `web_setup.sh` was skipped.
+
+`/tmp/env-manager.log` is JSONL. Each line has `event` (or `message`),
+`timestamp` (or `time`), and `data` (or `attributes`) fields. Parse and print
+it as a compact timeline. Then show the tail of the most recent
+`/tmp/environment-manager-*.diag.log`.
+
+```bash
+cat /tmp/env-manager.log 2>/dev/null || echo "MISSING"
+DIAG=$(ls -t /tmp/environment-manager-*.diag.log 2>/dev/null | head -1)
+[ -n "$DIAG" ] && tail -30 "$DIAG" || echo "no diag log"
+```
+
+**Key events to look for in `env-manager.log`**:
+
+| Event                                                    | Meaning                                                                          |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `git_clone_completed`                                    | Repo cloned fresh                                                                |
+| `init_script_skipped` with `session_mode: resume-cached` | VM reuse — `web_setup.sh` was NOT re-run; `/tmp` carries over from prior session |
+| `init_script_started` / `init_script_completed`          | `web_setup.sh` ran this session                                                  |
+| `env_init_completed`                                     | Env setup finished (good or bad)                                                 |
+
+When `session_mode: resume-cached` appears, the `/tmp/web-setup.log` is from
+a prior session. Its contents may differ from what the current `web_setup.sh`
+would produce. The daemon may also be the one from the prior session.
+
+Report the `session_mode` and whether `web_setup.sh` ran in this session
+vs was inherited from a prior VM.
 
 ---
 
@@ -617,30 +725,47 @@ failing hook directly (7c) to isolate which hook is broken.
 
 After running all checks, produce:
 
+**Timestamps rule**: whenever you report a date/time (web_setup.sh ran, daemon
+started, last git commit, hook event time, etc.) always include how long ago
+that was relative to now. Use a human-readable form: "2026-04-12T09:01Z
+(25 hours ago)" or "2026-04-13T21:08Z (3 minutes ago)". Never report a
+bare timestamp without the relative age — it forces the reader to do mental
+arithmetic to assess staleness.
+
 ```
-# Web Session Selfcheck — <timestamp>
+# Web Session Selfcheck — <timestamp> (now)
 
 ## Summary
 <one-line: healthy / degraded / broken>
 
 ## Checks
 
-| Check                        | Status   | Detail                                          |
-| ---------------------------- | -------- | ----------------------------------------------- |
-| web_setup.sh ran             | OK/FAIL  | ...                                             |
-| web_setup.sh commit          | OK/STALE | setup=<sha12> head=<sha12> (VM reuse risk)      |
-| claude-hooks daemon version  | OK/STALE | pinned=<sha> head=<sha> N commits behind; CI status |
-| Session start hook           | OK/FAIL  | CANARY present / FileNotFoundError              |
-| SOPS_AGE_KEY                 | OK/FAIL  | age public key matches .sops.yaml               |
-| Secret: buildbuddy.yaml      | OK/FAIL| decrypts / API <http_code>          |
-| Secret: github-agent-pat     | OK/FAIL| decrypts / login=agentydragon-agent |
-| Secret: github-ci-read-pat   | OK/FAIL| decrypts / login=agentydragon       |
-| Secret: k8s-token            | OK/FAIL| decrypts / API <http_code>          |
-| Secret: otlp-token           | OK/FAIL| decrypts / API <http_code>          |
-| bbr / BuildBuddy RBE         | OK/FAIL| ...                                 |
-| bbr runner recycling         | OK/WARN/AMBIG | cold=Xs warm=Ys ratio=Z%     |
-| Git hooks (pre-commit)       | OK/FAIL| backend=LOCAL/bbr; live commit pass/fail |
-| Git hooks (commit-msg)       | OK/FAIL| pass_filenames ok; ENFORCE_TEST_TAG state |
+| Check                          | Status        | Detail                                                      |
+| ------------------------------ | ------------- | ----------------------------------------------------------- |
+| web_setup.sh ran               | OK/FAIL       | <ISO timestamp> (<N> hours ago); last line "Setup complete" |
+| web_setup.sh VM reuse          | OK/SKIPPED    | session_mode=resume-cached / init_script_ran                |
+| web_setup.sh commit            | OK/STALE      | setup=<sha12> head=<sha12>                                  |
+| claude-hooks daemon version    | OK/STALE      | pinned=<sha> head=<sha> N commits behind; CI status         |
+| Session start hook             | OK/FAIL       | CANARY present / env file missing; first hook event logged  |
+| Daemon log: SessionStart       | OK/FAIL/NEVER | processed <ISO> (<N> min ago) / not in log / error          |
+| Hook trace: SessionStart       | OK/MISSING    | input+output seen / input only (daemon timeout) / absent    |
+| Env manager: init mode         | OK/INFO       | resume-cached (setup skipped) / fresh (setup ran)           |
+| SOPS_AGE_KEY                   | OK/FAIL       | age public key matches .sops.yaml                           |
+| SOPS: buildbuddy.yaml          | OK/FAIL       | decrypts                                                    |
+| SOPS: github-agent-pat         | OK/FAIL       | decrypts                                                    |
+| SOPS: github-ci-read-pat       | OK/FAIL       | decrypts                                                    |
+| SOPS: k8s-token                | OK/FAIL       | decrypts                                                    |
+| SOPS: otlp-token               | OK/FAIL       | decrypts                                                    |
+| SOPS: docker-ci client key     | OK/FAIL       | decrypts                                                    |
+| API: BuildBuddy                | OK/FAIL       | HTTP <code> (200/400=auth OK, 401/403=invalid key)          |
+| API: github-agent-pat          | OK/FAIL       | login=agentydragon-agent                                    |
+| API: github-ci-read-pat        | OK/FAIL       | login=agentydragon                                          |
+| API: k8s token                 | OK/FAIL       | HTTP <code> (200=OK, 401=rotated)                           |
+| API: otlp token                | OK/FAIL       | HTTP <code> (200/400=auth OK, 401=rotated)                  |
+| bbr / BuildBuddy RBE           | OK/FAIL       | ...                                                         |
+| bbr runner recycling           | OK/WARN/AMBIG | cold=Xs warm=Ys ratio=Z%                                    |
+| Git hooks (pre-commit)         | OK/FAIL       | backend=LOCAL/bbr; live commit pass/fail                    |
+| Git hooks (commit-msg)         | OK/FAIL       | pass_filenames ok; ENFORCE_TEST_TAG state                   |
 
 ## Issues & Remediation
 


### PR DESCRIPTION
## Summary

This PR clarifies the architecture of secret decryption in Claude Code web sessions. The key insight is that `SOPS_AGE_KEY` is a user-provided environment variable (via the Claude Code web UI) that is only available to the interactive Claude Code process and its subprocesses — not to the setup script (`web_setup.sh`) or `claude --init-only`. As a result, all SOPS secret decryption happens exclusively in the hook daemon via `startup_env_script`, not during setup.

## Changes

**Documentation updates** (`docs/secrets_env_flow.md`):
- Renamed section from "The Problem" to "Why Decryption Only Happens in the Hook Daemon" to clarify the actual constraint
- Removed the misleading claim that `SOPS_AGE_KEY` is available at setup time (it's not — it's a UI var)
- Simplified the architecture diagram to show that `web_setup.sh` does not decrypt secrets
- Removed the complex two-path table and replaced it with a clearer explanation of which consumers get secrets from where
- Clarified that `settings.local.json` is no longer written by `web_setup.sh` (it was always empty)
- Explained the rationale: storing secrets as SOPS-encrypted files means a single `SOPS_AGE_KEY` in the UI is the only credential to manage, enabling rotation via a single `sops` edit

**Setup script** (`web_setup.sh`):
- Removed Step 3 (decrypt secrets and write `settings.local.json`) — this was unreliable because `SOPS_AGE_KEY` was unavailable
- Removed the Python code that wrote `settings.local.json`
- Removed the call to `web_env.sh` during setup
- Renumbered remaining steps (Step 4 → Step 3, Step 5 → Step 4)
- Added comments explaining why secrets are not decrypted here and where decryption actually happens
- Made log upload optional via `DUCKTAPE_WEB_SETUP_UPLOAD_LOG=1` env var

**Selfcheck skill** (`skills/web_selfcheck/SKILL.md`):
- Enhanced web_setup.sh log inspection to show relative time ("N minutes ago")
- Added new section "3b. Daemon & Hook Logs" with detailed instructions for reading:
  - `daemon.log` (hook daemon structured logs)
  - `/tmp/claude-hook-events.jsonl` (hook event trace)
  - `/tmp/env-manager.log` (environment manager logs)
- Added interpretation guide for each log file
- Updated the selfcheck output table to include daemon/hook-specific checks with timestamps and relative ages
- Added "Timestamps rule": all reported times must include relative age (e.g., "2026-04-13T21:08Z (3 minutes ago)")

**README** (`devinfra/claude/README.md`):
- Simplified the explanation of what `web_setup.sh` does (removed the two-path secret decryption description)
- Clarified that secrets are not decrypted by setup, only by the hook daemon

**Config** (`hook_daemon/config.py`):
- Updated comment to reflect that secrets come only from `startup_env_script`, not from `settings.local.json`

## Rationale

The previous documentation suggested that secrets were decrypted in two places (`web_setup.sh` and the hook daemon), but this was misleading. In practice, `web_setup.sh` cannot decrypt because `SOPS_AGE_KEY` is only available to Claude Code and its subprocesses. The hook daemon is the sole reliable decryption path. This PR corrects the documentation and removes the dead code from `web_setup.sh` that attempted (and failed) to decrypt secrets.

The enhanced selfcheck skill provides better debugging tools for diagnosing session startup issues by correlating logs from the environment manager, hook daemon, and hook event trace.

https://claude.ai/code/session_018u5vBdqSee7AZVn7hf93zC