### PR TITLE
Fix stdlib shadowing in Bazel venv subprocesses

### DIFF
--- a/debug/explicit_init_py_investigation.md
+++ b/debug/explicit_init_py_investigation.md
@@ -1,6 +1,20 @@
 # `--incompatible_default_to_explicit_init_py` sys.path breakage
 
-## Status: root cause found
+## Status: fixed
+
+Resolved by two successive fixes in `util/bazel/subprocess.py`:
+
+1. Commit 5fb25de — `python_env(inherit=True)` stopped propagating PYTHONPATH
+   in a Bazel venv (venv activation handles sys.path via `pyvenv.cfg`).
+2. Follow-up — `python_env(inherit=False)` stopped propagating PYTHONPATH as
+   well, and now forwards `RUNFILES_DIR` / `RUNFILES_MANIFEST_FILE` /
+   `TEST_SRCDIR` / `JAVA_RUNFILES` so that `_bazel_site_init` in the
+   child can still locate the runfiles root. Without the runfiles env vars,
+   the child venv Python activates but `bazel.pth` cannot find repo-local
+   packages. Fixed `//mcp_infra/exec:test_mcp_integration` (the
+   `stdio_echo_spec` fixture uses `inherit=False`).
+
+The original investigation is kept below for historical context.
 
 ## Problem
 

--- a/util/bazel/subprocess.py
+++ b/util/bazel/subprocess.py
@@ -58,24 +58,35 @@ def _merge_pythonpath() -> str:
     return os.pathsep.join(merged)
 
 
+#: Environment variables that ``_bazel_site_init`` reads to locate runfiles
+#: when a child venv Python is launched. Without at least one of these the
+#: venv's ``bazel.pth`` site hook cannot resolve the runfiles root, so the
+#: child fails to import any repo-local module.
+_BAZEL_RUNFILES_ENV = ("RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "JAVA_RUNFILES", "TEST_SRCDIR")
+
+
 def python_env(*, inherit: bool = True) -> dict[str, str]:
     """Environment dict for spawning Python subprocesses.
 
-    In a Bazel venv with ``inherit=True``, omits PYTHONPATH — the child
-    inherits the venv (pyvenv.cfg → _bazel_site_init) and gets correct
-    sys.path automatically.
+    In a Bazel venv, omits PYTHONPATH — ``sys.executable`` points at the venv
+    python, so the child activates the venv via ``pyvenv.cfg`` discovery
+    (``site.py`` → ``bazel.pth`` → ``_bazel_site_init``) and gets the correct
+    sys.path without PYTHONPATH. With ``inherit=False`` we still forward the
+    Bazel runfiles pointers so that venv activation can find the runfiles root.
 
-    PYTHONPATH is still propagated when:
-    - ``inherit=False``: minimal env, child needs explicit paths since
-      env vars like RUNFILES_DIR (needed by _bazel_site_init) are missing.
-    - Outside Bazel (Nix wheel): no venv, child needs PYTHONPATH to find
-      Nix-managed packages.
+    Outside Bazel (Nix wheel, hook daemon), PYTHONPATH is propagated so the
+    child can find Nix-managed packages — there is no venv to activate.
+
+    Propagating PYTHONPATH inside a Bazel venv is actively harmful: with
+    ``--incompatible_default_to_explicit_init_py``, the rules_python bootstrap
+    prepends the test's package directory to ``sys.path[0]``, which leaks into
+    PYTHONPATH and causes stdlib shadowing when a local file collides with a
+    stdlib module (e.g., ``mcp_infra/exec/subprocess.py`` shadowing stdlib
+    ``subprocess`` in any subprocess spawned from a test in that package).
+    See <debug/explicit_init_py_investigation.md>.
     """
-    env = os.environ.copy() if inherit else {}
-    if _in_bazel_venv() and inherit:
-        # Venv activation handles sys.path in the child. Don't propagate
-        # PYTHONPATH — it includes the bootstrap's sys.path[0] prepend
-        # which causes stdlib shadowing.
+    env = os.environ.copy() if inherit else {k: v for k in _BAZEL_RUNFILES_ENV if (v := os.environ.get(k)) is not None}
+    if _in_bazel_venv():
         env.pop("PYTHONPATH", None)
     else:
         env["PYTHONPATH"] = _merge_pythonpath()
@@ -145,8 +156,11 @@ def generate_shell_wrapper(
         extra_lines: Raw shell lines inserted after exports and before the ``exec``
                      (use for dynamic expressions like ``$(...)``).
     """
-    pythonpath = python_env(inherit=False)["PYTHONPATH"]
-    env: dict[str, str | Path] = {"PYTHONPATH": pythonpath}
+    # Shell wrappers run outside any Bazel venv (e.g., installed shims in Nix
+    # environments) and must bake the full sys.path so the launched Python can
+    # find its packages. Call _merge_pythonpath() directly instead of going
+    # through python_env(), which omits PYTHONPATH in a Bazel venv context.
+    env: dict[str, str | Path] = {"PYTHONPATH": _merge_pythonpath()}
     if baked_env:
         env.update(baked_env)
     parts = ["#!/bin/sh", *exports_from_dict(env)]

--- a/util/bazel/test_subprocess.py
+++ b/util/bazel/test_subprocess.py
@@ -27,16 +27,16 @@ def test_python_env_no_inherit_minimal():
 
 
 def test_python_env_bazel_venv_omits_pythonpath():
-    """In a Bazel venv, PYTHONPATH is omitted (venv handles sys.path)."""
+    """In a Bazel venv, PYTHONPATH is omitted regardless of ``inherit``.
+
+    The child activates the venv via ``pyvenv.cfg`` discovery (``sys.executable``
+    points at the venv python), so propagating PYTHONPATH is both unnecessary and
+    harmful — it leaks the rules_python bootstrap's poisoned ``sys.path[0]``
+    (the test's package directory) and causes stdlib shadowing.
+    """
     assert _in_bazel_venv(), "test must run in a Bazel venv"
-    env = python_env(inherit=True)
-    assert "PYTHONPATH" not in env
-
-
-def test_python_env_inherit_false_always_has_pythonpath():
-    """inherit=False always includes PYTHONPATH (child env is too minimal for venv discovery)."""
-    env = python_env(inherit=False)
-    assert "PYTHONPATH" in env
+    assert "PYTHONPATH" not in python_env(inherit=True)
+    assert "PYTHONPATH" not in python_env(inherit=False)
 
 
 def test_python_env_sets_safe_path():


### PR DESCRIPTION
## Summary

Fix stdlib module shadowing that occurs when spawning Python subprocesses from Bazel venv tests. The issue arises because `PYTHONPATH` propagation leaks the rules_python bootstrap's poisoned `sys.path[0]` (the test's package directory) into child processes, causing local files to shadow stdlib modules.

## Key Changes

- **Unconditionally omit PYTHONPATH in Bazel venvs**: Both `inherit=True` and `inherit=False` now skip PYTHONPATH propagation. The venv activates automatically via `pyvenv.cfg` discovery when `sys.executable` points to the venv python, so PYTHONPATH is unnecessary and harmful.

- **Forward Bazel runfiles environment variables**: When `inherit=False`, now explicitly forwards `RUNFILES_DIR`, `RUNFILES_MANIFEST_FILE`, `JAVA_RUNFILES`, and `TEST_SRCDIR` so that `_bazel_site_init` in the child venv can locate the runfiles root and resolve repo-local modules.

- **Extract runfiles env var names**: Added `_BAZEL_RUNFILES_ENV` constant to document which environment variables are required for venv activation in child processes.

- **Fix shell wrapper generation**: Updated `generate_shell_wrapper()` to call `_merge_pythonpath()` directly instead of relying on `python_env(inherit=False)`, with clarifying comments about the different context (shell wrappers run outside Bazel venvs).

- **Update tests**: Consolidated test cases to verify that PYTHONPATH is omitted in Bazel venvs regardless of the `inherit` parameter, and updated documentation to reflect the fix.

## Implementation Details

The fix addresses the root cause identified in `--incompatible_default_to_explicit_init_py` investigation: the bootstrap's `sys.path[0]` prepend (test package directory) was leaking into PYTHONPATH and being inherited by subprocesses. By omitting PYTHONPATH entirely in Bazel venvs and relying on venv activation instead, we prevent this poisoning while still enabling venv discovery in child processes through the runfiles environment variables.

https://claude.ai/code/session_01QJnEJTeWDwRWUKDaxRh7ss