### PR TITLE
Add pid field to ShimExecRequest in hook daemon tests

### DIFF
--- a/devinfra/claude/hook_daemon/test_hook_daemon.py
+++ b/devinfra/claude/hook_daemon/test_hook_daemon.py
@@ -155,7 +155,12 @@ class TestHealth:
 
 def _shim_request(shim: str, argv: list[str], env: dict[str, str] | None = None) -> ShimExecRequest:
     return ShimExecRequest(
-        shim=shim, session_id="test-session", cwd="/tmp", argv=argv, env=env or {"HOME": "/tmp", "PATH": "/usr/bin"}
+        shim=shim,
+        session_id="test-session",
+        cwd="/tmp",
+        argv=argv,
+        pid=0,
+        env=env or {"HOME": "/tmp", "PATH": "/usr/bin"},
     )
 
 


### PR DESCRIPTION
## Summary
Updated the `_shim_request` test helper function to include the `pid` field when constructing `ShimExecRequest` objects.

## Changes
- Added `pid=0` parameter to `ShimExecRequest` initialization in the `_shim_request` helper function
- Reformatted the function call to use multi-line formatting for improved readability

## Details
This change ensures that test requests include all required fields for `ShimExecRequest`. The `pid` is set to `0` as a default test value, which is appropriate for test scenarios where the actual process ID is not relevant.

https://claude.ai/code/session_01Pxj9oE3n151wbvZxkZGTSo