### PR TITLE
Add type safety improvements and fix resource URI handling

### DIFF
--- a/x/grocy_mcp/BUILD.bazel
+++ b/x/grocy_mcp/BUILD.bazel
@@ -150,6 +150,7 @@ py_test(
         "//util/testing:container_logs",
         "@pypi//fastmcp",
         "@pypi//httpx",
+        "@pypi//mcp",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//testcontainers",

--- a/x/grocy_mcp/server.py
+++ b/x/grocy_mcp/server.py
@@ -29,8 +29,9 @@ from fastmcp.server.auth import MultiAuth
 from fastmcp.server.auth.auth import AuthProvider
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
-from fastmcp.server.providers.openapi import MCPType, OpenAPIResource, OpenAPITool, RouteMap
+from fastmcp.server.providers.openapi import MCPType, OpenAPIResource, OpenAPIResourceTemplate, OpenAPITool, RouteMap
 from fastmcp.utilities.openapi import HTTPRoute
+from pydantic.networks import AnyUrl
 
 from util.bazel.runfiles import get_required_path
 from x.grocy_mcp.auth import AuthentikExchangeAuth
@@ -71,7 +72,8 @@ def _load_openapi_spec() -> dict[str, object]:
     :grocy_openapi_fixed genrule. See <fix_openapi_spec.py>.
     """
     spec_path = get_required_path("_main/x/grocy_mcp/grocy.openapi.fixed.json")
-    return json.loads(spec_path.read_text())
+    result: dict[str, object] = json.loads(spec_path.read_text())
+    return result
 
 
 def build_mcp(settings: ServerSettings, *, client: httpx.AsyncClient | None = None) -> FastMCP:
@@ -101,7 +103,9 @@ def build_mcp(settings: ServerSettings, *, client: httpx.AsyncClient | None = No
             return MCPType.RESOURCE
         return mcp_type
 
-    def _customize_component(route: HTTPRoute, component: OpenAPITool | OpenAPIResource) -> None:
+    def _customize_component(
+        route: HTTPRoute, component: OpenAPITool | OpenAPIResource | OpenAPIResourceTemplate
+    ) -> None:
         override = TOOL_OVERRIDES.get((route.method, route.path))
         if override is None:
             raise ValueError(
@@ -109,7 +113,7 @@ def build_mcp(settings: ServerSettings, *, client: httpx.AsyncClient | None = No
             )
         component.name = override.name
         if isinstance(component, OpenAPIResource):
-            component.uri = f"resource://{override.name}"
+            component.uri = AnyUrl(f"resource://{override.name}")
         if override.extra_description:
             component.description = f"{component.description}\n\n{override.extra_description}"
 

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 import pytest_bazel
 from fastmcp.tools import ToolResult
+from mcp.types import TextContent
 
 from third_party.containers.rlocations import GROCY
 from util.oci import load_oci_image
@@ -128,7 +129,9 @@ def _result_json(result: ToolResult) -> Any:
     if result.structured_content is not None:
         return result.structured_content
     if result.content:
-        return json.loads(result.content[0].text)
+        first = result.content[0]
+        assert isinstance(first, TextContent), f"Expected TextContent, got {type(first)}"
+        return json.loads(first.text)
     raise ValueError(f"Empty tool result: {result!r}")
 
 


### PR DESCRIPTION
## Summary
This PR improves type safety and fixes resource URI handling in the grocy MCP server implementation. The changes add explicit type annotations, import necessary types, and ensure proper type validation for content handling.

## Key Changes
- **Import additions**: Added `OpenAPIResourceTemplate` to imports and imported `AnyUrl` from pydantic.networks for proper URL type handling
- **Resource URI type fix**: Changed `component.uri` assignment from a plain string to use `AnyUrl()` constructor, ensuring proper URL validation and type compliance
- **Type annotation improvements**: 
  - Added explicit return type annotation to `_load_openapi_spec()` function
  - Extended `_customize_component()` parameter type to include `OpenAPIResourceTemplate` alongside existing types
- **Content type validation**: Added explicit type checking in `_result_json()` to assert that content is `TextContent` before accessing the `.text` attribute, improving runtime safety
- **Test dependency**: Added `@pypi//mcp` to test dependencies to support the new `TextContent` type import

## Implementation Details
The resource URI change from string to `AnyUrl` ensures that the URI is properly validated as a URL object rather than a plain string, which aligns with the expected type in the OpenAPI resource model. The content type assertion in tests prevents potential runtime errors by explicitly validating the content type before use.

https://claude.ai/code/session_01KqLkMQJVxRdDB1NCxCXC4z