### PR TITLE
chore(flux-webhook): post-decoupling cleanup

### DIFF
--- a/cluster/docs/bootstrap_dependencies.md
+++ b/cluster/docs/bootstrap_dependencies.md
@@ -172,6 +172,17 @@ decryptable (L5) and on dependency chains between kustomizations (cert-manager
 Services with external credentials read them from `*.sops.yaml` files
 decrypted by Flux. See [App Credentials](#app-credentials) for the full list.
 
+### flux-webhook-token
+
+The `flux-webhook-token` tofu-controller module creates the `github-webhook-token` k8s
+secret (consumed by the Flux `github` Receiver) and the GitHub repository webhook on
+`ducktape`. It reads `github-secrets-sync-pat` (provided by `github-secrets-sync-secrets`).
+The `flux-webhook` Kustomization depends on `flux-webhook-token`.
+
+**If `flux-webhook` receiver stops working after bootstrap**: Check `flux-webhook-token`
+reconciliation. The token and webhook URL use `ignore_changes` and are stable across
+re-applies — only resource recreation changes them.
+
 ## L7: NixOS Worker Integration
 
 wyrm2 and rugged join the cluster via kubelet TLS bootstrap over Nebula mesh.

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -9,7 +9,7 @@
 # an ImageRepository scan on a git push is a no-op, and a GitRepository reconciliation
 # on an image push is a no-op.
 #
-# The GitHub webhook is auto-configured by terraform/gitops/harbor-ci
+# The GitHub webhook is auto-configured by terraform/gitops/flux-webhook-token
 # (github_repository_webhook with events = ["push", "registry_package"]).
 #
 # Requirement for registry_package: each GHCR package must be linked to the

--- a/cluster/k8s/github-secrets-sync/flux-kustomization.yaml
+++ b/cluster/k8s/github-secrets-sync/flux-kustomization.yaml
@@ -20,6 +20,5 @@ spec:
       namespace: flux-system
   dependsOn:
     - name: tofu-controller
-    - name: harbor-ci
     - name: agent-shared-secrets
     - name: github-secrets-sync-secrets


### PR DESCRIPTION
Follow-up to #1291 (decouple flux-webhook from harbor).

## Changes

- **Remove stale `harbor-ci` dependsOn from `github-secrets-sync`** — this dependency was never needed; `github-secrets-sync` only needs `github-secrets-sync-secrets` (which provides the PAT secret). The stale dep would block reconciliation if Harbor was unhealthy.
- **Fix comment in `github-webhook-receiver.yaml`** — line 12 still said the webhook was managed by `terraform/gitops/harbor-ci`; updated to `flux-webhook-token`.
- **Document `flux-webhook-token` in `bootstrap_dependencies.md`** — AGENTS.md requires keeping this file up to date when adding tofu modules.

## Test plan

- [ ] Pre-commit hooks pass (markdownlint, prettier, kubeconform)
- [ ] No functional changes — documentation and dependency graph cleanup only

https://claude.ai/code/session_01JG5swpyXdfff7xLarv9CBG