### PR TITLE
docs: explain bb-out/bazel-out path + matrix-completeness followup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,18 @@ branch.
 
 **Downloading build outputs from RBE**: `--config=rbe` sets `--remote_download_minimal`,
 so build artifacts aren't downloaded by default. To force-download specific outputs,
-add `--remote_download_regex='<java regex>'` (e.g., `--remote_download_regex='.*\.whl$'`).
-This is additive with `--remote_download_minimal`. For `bbr`, pass the flag before
-the target: `bbr build //target --remote_download_regex='.*\.whl$'`.
+add `--remote_download_regex='<java regex>'` (e.g., `--remote_download_regex='.*\.whl$'`)
+or `--remote_download_outputs=toplevel` to fetch just the direct outputs of the
+requested targets. This is additive with `--remote_download_minimal`. For `bbr`, pass
+the flag before the target: `bbr build //target --remote_download_regex='.*\.whl$'`.
+
+**Downloaded artifacts land at `bb-out/bazel-out/<config>/bin/<pkg>/<name>`**, not
+`bb-out/bazel-bin/<pkg>/<name>`. The `bazel-bin/` convenience symlink only exists in
+local Bazel workspaces — `bb remote` does not create it on the runner side. For our
+standard RBE build (`--config=rbe --config=ci` from `.github/actions/bb-remote/`) the
+config is `k8-fastbuild`, so outputs land at `bb-out/bazel-out/k8-fastbuild/bin/...`.
+Workflows consuming bb-remote-built artifacts on the runner side (e.g. `push-images.yml`)
+must use the full path. See <devinfra/docs/bb_remote_internals.md> for details.
 
 **Requirements:** `bb` on PATH and `BUILDBUDDY_API_KEY` set (both provided by session
 start hook).

--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,7 @@
 - [ ] Migrate all Python packages to Bazel monorepo style (colocated tests, flat structure like `git_commit_ai/`)
 - [ ] Re-enable `bazel coverage` in CI once compatible with remote execution (RBE). Currently disabled because the Java-based `remote_coverage_tools` can't locate its runfiles on BuildBuddy workers, causing all tests to be marked as failed. See `bazel-test.yml`.
 - [ ] Remove `--per_file_copt=external/protobuf[+]/.*@-Wno-deprecated-declarations` from `.bazelrc` once protobuf cleans up its internal deprecated API usage (`FieldOptions::weak()`, `RepeatedPtrField(Arena*)`). These are in `external/protobuf+/src/google/protobuf/` and `compiler/cpp/`. Currently `protobuf 33.1`.
+- [ ] Pre-commit lint for `.github/workflows/push-images.yml` matrix completeness: fail if any in-cluster `oci_image` target lacks a matrix row, and warn on rows whose `image` label points at a non-existent target. Would have caught `airlock`/`fc-vm-pod`-style coverage gaps during the runner-side push rewrite (PR #1290). Easiest implementation: a `py_test` that loads `push-images.yml`, parses the `image:` fields, runs `bazel query 'kind("oci_image_rule", //...)'`, and diffs the two sets.
 
 ## Terraform
 

--- a/devinfra/docs/bb_remote_internals.md
+++ b/devinfra/docs/bb_remote_internals.md
@@ -340,6 +340,34 @@ Interactive mode (detected via `terminal.IsTTY(os.Stdin) && terminal.IsTTY(os.St
 3. **`--script` + file redirect** — redirect bazel output to a file on the
    runner, download via `--remote_download_regex`
 
+## Downloaded artifacts land under `bb-out/bazel-out/`, NOT `bb-out/bazel-bin/`
+
+When `bb remote build //pkg:name --remote_download_outputs=toplevel` (or
+`--remote_download_regex=...`) fetches build outputs back to the local
+workspace, they land at:
+
+```
+bb-out/bazel-out/<config>/bin/<pkg>/<name>
+```
+
+The `<config>` for our standard Linux x86_64 RBE builds (via
+`--config=rbe --config=ci` from `.github/actions/bb-remote/`) is
+`k8-fastbuild`. So `bb remote build //x/grocy_mcp:server_image.digest`
+lands at `bb-out/bazel-out/k8-fastbuild/bin/x/grocy_mcp/server_image.json.sha256`.
+
+**There is NO `bb-out/bazel-bin/<pkg>/<name>` convenience symlink.** That
+symlink only exists in local Bazel workspaces — it's created by Bazel's
+local runner, not by `bb remote`. Workflows that consume bb-remote-built
+artifacts on the runner side (e.g. `push-images.yml` after PR #1290)
+must use the full `bb-out/bazel-out/k8-fastbuild/bin/...` path.
+
+`bbr` follows the same layout, as shown in `CLAUDE.md`:
+
+```bash
+bbr build //:requirements --remote_download_regex='.*requirements\.out'
+cp bb-out/bazel-out/k8-fastbuild/bin/requirements.out requirements_bazel.txt
+```
+
 ## Key source files
 
 All paths relative to <https://github.com/buildbuddy-io/buildbuddy>.


### PR DESCRIPTION
Three small followups from the runner-side image push work in #1290:

1. `AGENTS.md`: expand the "Downloading build outputs from RBE" note to mention `--remote_download_outputs=toplevel` (simpler than the regex form when you want "just the direct outputs of these targets"), and document that artifacts land at `bb-out/bazel-out/<config>/bin/...`, NOT `bb-out/bazel-bin/...`. The `bazel-bin/` symlink only exists in local workspaces — `bb remote` does not create it on the runner side. Caught this mid-PR-development when the workflow pointed at the wrong path and `cat` failed; writing it down so the next consumer of bb-remote-built artifacts doesn't pay the same debug cost.

2. `devinfra/docs/bb_remote_internals.md`: same content, longer form, with the explicit `k8-fastbuild` config name under our standard `--config=rbe --config=ci` shape and a concrete example path for `//x/grocy_mcp:server_image.digest`.

3. `TODO.md` "Build System" section: file a TODO for a pre-commit lint that cross-checks `.github/workflows/push-images.yml`'s matrix against the set of in-cluster `oci_image` targets. Would have caught coverage gaps (airlock, fc-vm-pod missing from the new matrix during rewrite, or pointing at non-existent labels). Sketch implementation in the TODO entry.

No code changes, no test changes, no CI changes.

BAZEL_TEST_INVOCATIONS=none: docs + TODO only