### PR TITLE
Add batch tools for efficient multi-item Grocy operations

### DIFF
--- a/devinfra/claude/hook_daemon/profiles/web/profile.yaml
+++ b/devinfra/claude/hook_daemon/profiles/web/profile.yaml
@@ -59,13 +59,13 @@ background_commands:
     timeout: 300
   - name: git remote info
     command: |
-      echo "Git remotes:"
-      echo "  origin        — Anthropic's local git proxy (routes to GitHub). Use this for pushing: git push origin <branch>."
-      echo "  github-no-proxy — Direct GitHub URL (https://github.com/agentydragon/ducktape)."
-      echo "                    Exists ONLY as a bbr shim: BB's RBE runner runs on their cloud and cannot reach"
-      echo "                    the local proxy URL (127.0.0.1:51318) that 'origin' uses. bbr selects this remote"
-      echo "                    so the runner can fetch the repo from GitHub directly."
-      echo "                    Do NOT push to github-no-proxy — it uses a read-only PAT. Always push to origin."
+      echo "Git remotes (set up by web_setup.sh):"
+      echo "  origin          — Anthropic's local git proxy (routes to GitHub). Push here: git push origin <branch>."
+      echo "  github-no-proxy — Plain GitHub HTTPS URL, no credentials."
+      echo "                    Exists ONLY as a bbr shim: BB's RBE runner runs on their cloud and cannot"
+      echo "                    reach the local proxy URL (127.0.0.1:51318) that 'origin' uses. bbr selects"
+      echo "                    this remote so the cloud runner can fetch the repo from GitHub directly."
+      echo "                    Do NOT push to github-no-proxy — no push credentials. Always push to origin."
     timeout: 10
   - name: fork remote setup
     command: |

--- a/devinfra/claude/hook_daemon/profiles/web/profile.yaml
+++ b/devinfra/claude/hook_daemon/profiles/web/profile.yaml
@@ -29,6 +29,9 @@ setup_docker: true
 env_exports: |
   export DUCKTAPE_PRECOMMIT_ENFORCE_BAZEL_TESTS=0
   export DUCKTAPE_PRECOMMIT_ENFORCE_TEST_TAG=1
+  # Nix devtools (prettier with svelte plugin, pre-commit, ruff, etc.) must
+  # come before /opt/node22/bin so the nix versions are preferred.
+  export PATH="${HOME}/.nix-profile/bin:${PATH}"
 bazel_remote_proxy:
   target: remote.buildbuddy.io:443
 bazel_bes_proxy:

--- a/devinfra/claude/hook_daemon/profiles/web/profile.yaml
+++ b/devinfra/claude/hook_daemon/profiles/web/profile.yaml
@@ -57,6 +57,16 @@ background_commands:
   - name: pre-commit setup
     command: pre-commit install --install-hooks
     timeout: 300
+  - name: git remote info
+    command: |
+      echo "Git remotes:"
+      echo "  origin        — Anthropic's local git proxy (routes to GitHub). Use this for pushing: git push origin <branch>."
+      echo "  github-no-proxy — Direct GitHub URL (https://github.com/agentydragon/ducktape)."
+      echo "                    Exists ONLY as a bbr shim: BB's RBE runner runs on their cloud and cannot reach"
+      echo "                    the local proxy URL (127.0.0.1:51318) that 'origin' uses. bbr selects this remote"
+      echo "                    so the runner can fetch the repo from GitHub directly."
+      echo "                    Do NOT push to github-no-proxy — it uses a read-only PAT. Always push to origin."
+    timeout: 10
   - name: fork remote setup
     command: |
       if [ -z "${GITHUB_TOKEN:-}" ]; then

--- a/x/grocy_mcp/BUILD.bazel
+++ b/x/grocy_mcp/BUILD.bazel
@@ -54,12 +54,24 @@ py_library(
 )
 
 py_library(
+    name = "batch_tools",
+    srcs = ["batch_tools.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//fastmcp",
+        "@pypi//httpx",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "server",
     srcs = ["server.py"],
     data = [":grocy_openapi_fixed"],
     visibility = ["//visibility:public"],
     deps = [
         ":auth",
+        ":batch_tools",
         ":config",
         ":tool_metadata",
         "//util/bazel:runfiles",
@@ -149,9 +161,8 @@ py_test(
         "//util/testing:container_logs",
         "@pypi//fastmcp",
         "@pypi//httpx",
-        "@pypi//jsonschema",
-        "@pypi//mcp",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
         "@pypi//testcontainers",
     ],

--- a/x/grocy_mcp/BUILD.bazel
+++ b/x/grocy_mcp/BUILD.bazel
@@ -130,16 +130,13 @@ py_test(
     ],
 )
 
-py_test(
-    name = "test_dump_tool",
-    srcs = ["test_dump_tool.py"],
+py_binary(
+    name = "dump_tools",
+    srcs = ["dump_tools.py"],
+    main_module = "x.grocy_mcp.dump_tools",
     deps = [
         ":config",
-        ":conftest",
         ":server",
-        "//util/testing:undeclared_outputs",
-        "@pypi//pytest",
-        "@pypi//pytest_bazel",
     ],
 )
 

--- a/x/grocy_mcp/BUILD.bazel
+++ b/x/grocy_mcp/BUILD.bazel
@@ -149,6 +149,7 @@ py_test(
         "//util/testing:container_logs",
         "@pypi//fastmcp",
         "@pypi//httpx",
+        "@pypi//jsonschema",
         "@pypi//mcp",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/x/grocy_mcp/README.md
+++ b/x/grocy_mcp/README.md
@@ -61,15 +61,15 @@ These replace the equivalent single-shot OpenAPI routes to enable efficient
 multi-item operations via `asyncio.gather`. Each failed item is collected with
 `ok=False`; failures do not abort the others.
 
-| Tool | Replaces | Description |
-|---|---|---|
-| `create_entities` | `create_entity` | Create N entities of any type in one call |
-| `list_entities` | `list_entities` | Fetch N entity types concurrently |
-| `get_entities` | `get_entity` | Fetch N objects of one type by ID |
-| `get_stock` | `list_stock` | Stock list with optional QU + location enrichment |
-| `add_stock` | `add_product_stock` | Add stock for N products; returns `new_amount` per item |
-| `consume_stock` | `consume_product_stock` | Consume stock for N products |
-| `inventory_products` | `inventory_product` | Set absolute amounts for N products |
+| Tool                 | Replaces                | Description                                             |
+| -------------------- | ----------------------- | ------------------------------------------------------- |
+| `create_entities`    | `create_entity`         | Create N entities of any type in one call               |
+| `list_entities`      | `list_entities`         | Fetch N entity types concurrently                       |
+| `get_entities`       | `get_entity`            | Fetch N objects of one type by ID                       |
+| `get_stock`          | `list_stock`            | Stock list with optional QU + location enrichment       |
+| `add_stock`          | `add_product_stock`     | Add stock for N products; returns `new_amount` per item |
+| `consume_stock`      | `consume_product_stock` | Consume stock for N products                            |
+| `inventory_products` | `inventory_product`     | Set absolute amounts for N products                     |
 
 Stock operations return `transaction_id` per item for per-operation undo via the
 `undo_transaction` tool. There is no cross-item atomicity — Grocy has no

--- a/x/grocy_mcp/README.md
+++ b/x/grocy_mcp/README.md
@@ -47,8 +47,8 @@ Grocy traverses the outpost.
 
 As of 2026-04-14, claude.ai does not expose MCP resources to the AI. Everything
 the AI needs to invoke must be a tool. `get_system_info` (from `GET /system/info`)
-is currently exposed as an MCP resource and is therefore invisible to the AI —
-it is informational only. New capabilities should be added as tools.
+is exposed as a tool and is available to the AI. New capabilities should be
+added as tools, not resources.
 
 ## Tool surface
 
@@ -85,7 +85,8 @@ All remaining enabled routes from `/objects/*` and `/stock/*`:
 the full list.
 
 Explicitly excluded: `/chores`, `/batteries`, `/recipes`, `/tasks`, `/calendar`,
-`/print`, `/files`, `/users`, `/user`, `/userfields`, `/system`. Add a
+`/print`, `/files`, `/users`, `/user`, `/userfields`, and most `/system/*` routes
+(except `get_system_info` and `get_db_changed_time`). Add a
 `RouteMap(pattern=..., mcp_type=MCPType.TOOL)` in <server.py> to re-enable any.
 
 ## Why `FastMCP.from_openapi` and not hand-written tools?

--- a/x/grocy_mcp/README.md
+++ b/x/grocy_mcp/README.md
@@ -43,24 +43,50 @@ OAuth directly against OIDCProxy, which requires RFC 7591 DCR and PKCE to
 its own redirect URI, not a forward-auth 302. Only the downstream call into
 Grocy traverses the outpost.
 
+## MCP resources vs tools
+
+As of 2026-04-14, claude.ai does not expose MCP resources to the AI. Everything
+the AI needs to invoke must be a tool. `get_system_info` (from `GET /system/info`)
+is currently exposed as an MCP resource and is therefore invisible to the AI —
+it is informational only. New capabilities should be added as tools.
+
 ## Tool surface
 
-Generated from <grocy_openapi.json> (Grocy 4.6.0 OpenAPI 3.1 spec from
-<https://demo.grocy.info/api/openapi/specification>). Filtered via
-`ROUTE_MAPS` in <server.py> to just `/objects/*` and `/stock/*`, which
-covers the bootstrap path "empty Grocy → populated inventory":
+The tool surface combines OpenAPI-generated tools (from Grocy's spec) with custom
+batch tools registered by `register_batch_tools` in <batch_tools.py>.
 
-- `/objects/{entity}` — generic CRUD over quantity units, locations,
-  product groups, products, quantity-unit conversions, etc. Discoverable
-  entities: see the `entity` path parameter in Grocy's docs.
-- `/stock` — current stock listing.
-- `/stock/products/{id}/{add,consume,inventory,...}` — stock manipulation.
+### Batch tools (custom, in <batch_tools.py>)
 
-Explicitly excluded: `/chores`, `/batteries`, `/recipes`, `/tasks`,
-`/calendar`, `/print`, `/files`, `/users`, `/user`, `/userfields`,
-`/system`. If you later want any of these, add a
-`RouteMap(pattern=..., mcp_type=MCPType.TOOL)` higher in the list in
-<server.py>.
+These replace the equivalent single-shot OpenAPI routes to enable efficient
+multi-item operations via `asyncio.gather`. Each failed item is collected with
+`ok=False`; failures do not abort the others.
+
+| Tool | Replaces | Description |
+|---|---|---|
+| `create_entities` | `create_entity` | Create N entities of any type in one call |
+| `list_entities` | `list_entities` | Fetch N entity types concurrently |
+| `get_entities` | `get_entity` | Fetch N objects of one type by ID |
+| `get_stock` | `list_stock` | Stock list with optional QU + location enrichment |
+| `add_stock` | `add_product_stock` | Add stock for N products; returns `new_amount` per item |
+| `consume_stock` | `consume_product_stock` | Consume stock for N products |
+| `inventory_products` | `inventory_product` | Set absolute amounts for N products |
+
+Stock operations return `transaction_id` per item for per-operation undo via the
+`undo_transaction` tool. There is no cross-item atomicity — Grocy has no
+client-initiated batch transaction API.
+
+### OpenAPI-generated tools (from Grocy spec)
+
+All remaining enabled routes from `/objects/*` and `/stock/*`:
+`update_entity`, `delete_entity`, `get_product_stock`, `transfer_product_stock`,
+`open_product_stock`, `list_product_stock_entries`, `list_product_locations`,
+`merge_products`, `list_location_stock`, `get_stock_entry`, `edit_stock_entry`,
+`list_volatile_stock`, `shopping_list_*`, and others. See <tool_metadata.py> for
+the full list.
+
+Explicitly excluded: `/chores`, `/batteries`, `/recipes`, `/tasks`, `/calendar`,
+`/print`, `/files`, `/users`, `/user`, `/userfields`, `/system`. Add a
+`RouteMap(pattern=..., mcp_type=MCPType.TOOL)` in <server.py> to re-enable any.
 
 ## Why `FastMCP.from_openapi` and not hand-written tools?
 

--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import httpx
 from fastmcp import FastMCP
@@ -19,40 +19,40 @@ from pydantic import BaseModel, Field
 class EntityType(StrEnum):
     """Grocy entity type names exposed through the /objects/{entity} API."""
 
-    products = "products"
-    chores = "chores"
-    product_barcodes = "product_barcodes"
-    batteries = "batteries"
-    locations = "locations"
-    quantity_units = "quantity_units"
-    quantity_unit_conversions = "quantity_unit_conversions"
-    shopping_list = "shopping_list"
-    shopping_lists = "shopping_lists"
-    shopping_locations = "shopping_locations"
-    recipes = "recipes"
-    recipes_pos = "recipes_pos"
-    recipes_nestings = "recipes_nestings"
-    tasks = "tasks"
-    task_categories = "task_categories"
-    product_groups = "product_groups"
-    equipment = "equipment"
-    api_keys = "api_keys"
-    userfields = "userfields"
-    userentities = "userentities"
-    userobjects = "userobjects"
-    meal_plan = "meal_plan"
-    stock_log = "stock_log"
-    stock = "stock"
-    stock_current_locations = "stock_current_locations"
-    chores_log = "chores_log"
-    meal_plan_sections = "meal_plan_sections"
-    products_last_purchased = "products_last_purchased"
-    products_average_price = "products_average_price"
-    quantity_unit_conversions_resolved = "quantity_unit_conversions_resolved"
-    recipes_pos_resolved = "recipes_pos_resolved"
-    battery_charge_cycles = "battery_charge_cycles"
-    product_barcodes_view = "product_barcodes_view"
-    permission_hierarchy = "permission_hierarchy"
+    PRODUCTS = "products"
+    CHORES = "chores"
+    PRODUCT_BARCODES = "product_barcodes"
+    BATTERIES = "batteries"
+    LOCATIONS = "locations"
+    QUANTITY_UNITS = "quantity_units"
+    QUANTITY_UNIT_CONVERSIONS = "quantity_unit_conversions"
+    SHOPPING_LIST = "shopping_list"
+    SHOPPING_LISTS = "shopping_lists"
+    SHOPPING_LOCATIONS = "shopping_locations"
+    RECIPES = "recipes"
+    RECIPES_POS = "recipes_pos"
+    RECIPES_NESTINGS = "recipes_nestings"
+    TASKS = "tasks"
+    TASK_CATEGORIES = "task_categories"
+    PRODUCT_GROUPS = "product_groups"
+    EQUIPMENT = "equipment"
+    API_KEYS = "api_keys"
+    USERFIELDS = "userfields"
+    USERENTITIES = "userentities"
+    USEROBJECTS = "userobjects"
+    MEAL_PLAN = "meal_plan"
+    STOCK_LOG = "stock_log"
+    STOCK = "stock"
+    STOCK_CURRENT_LOCATIONS = "stock_current_locations"
+    CHORES_LOG = "chores_log"
+    MEAL_PLAN_SECTIONS = "meal_plan_sections"
+    PRODUCTS_LAST_PURCHASED = "products_last_purchased"
+    PRODUCTS_AVERAGE_PRICE = "products_average_price"
+    QUANTITY_UNIT_CONVERSIONS_RESOLVED = "quantity_unit_conversions_resolved"
+    RECIPES_POS_RESOLVED = "recipes_pos_resolved"
+    BATTERY_CHARGE_CYCLES = "battery_charge_cycles"
+    PRODUCT_BARCODES_VIEW = "product_barcodes_view"
+    PERMISSION_HIERARCHY = "permission_hierarchy"
 
 
 # ── Shared input/output types ──────────────────────────────────────────────
@@ -60,22 +60,40 @@ class EntityType(StrEnum):
 
 class CreateItem(BaseModel):
     entity_type: EntityType
+    # TODO: discriminated union per entity_type for body (avoids having to know per-entity field names)
     body: dict[str, Any]
 
 
-class CreateResult(BaseModel):
+class CreateOk(BaseModel):
+    kind: Literal["ok"] = "ok"
     index: int
-    ok: bool
     created_object_id: int | None = None
-    error: str | None = None
 
 
-class GetResult(BaseModel):
+class CreateError(BaseModel):
+    kind: Literal["error"] = "error"
     index: int
+    error: str
+
+
+CreateResult = Annotated[CreateOk | CreateError, Field(discriminator="kind")]
+
+
+class GetOk(BaseModel):
+    kind: Literal["ok"] = "ok"
+    entity_type: EntityType
     object_id: int
-    ok: bool
-    data: dict[str, Any] | None = None
-    error: str | None = None
+    data: dict[str, Any]
+
+
+class GetError(BaseModel):
+    kind: Literal["error"] = "error"
+    entity_type: EntityType
+    object_id: int
+    error: str
+
+
+GetResult = Annotated[GetOk | GetError, Field(discriminator="kind")]
 
 
 class StockEnrichedEntry(BaseModel):
@@ -103,7 +121,15 @@ class ConsumeItem(BaseModel):
     product_id: int
     amount: float
     spoiled: bool = False
-    location_id: int | None = Field(default=None, description="Omit → consume from any location.")
+    location_id: int | None = Field(
+        default=None,
+        description=(
+            "Which location to consume from. Omit → consume from any location (Grocy picks). "
+            # TODO: consider requiring explicit location_id when the product has stock in multiple locations,
+            # to avoid silently consuming from the wrong place. For now, rely on callers to check.
+            "If the product has stock in multiple locations, specify location_id to be explicit."
+        ),
+    )
     allow_subproduct_substitution: bool = False
 
 
@@ -143,7 +169,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         """Create multiple Grocy entities in one call.
 
         Sends one POST /objects/{entity_type} per item concurrently. Failed items
-        are collected with ok=False and error set; they do not abort others.
+        are collected as CreateError; they do not abort others.
         """
 
         async def _one(i: int, item: CreateItem) -> CreateResult:
@@ -152,9 +178,9 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
                 r.raise_for_status()
                 data = r.json()
                 raw_id = data.get("created_object_id")
-                return CreateResult(index=i, ok=True, created_object_id=int(raw_id) if raw_id is not None else None)
+                return CreateOk(index=i, created_object_id=int(raw_id) if raw_id is not None else None)
             except Exception as e:
-                return CreateResult(index=i, ok=False, error=str(e))
+                return CreateError(index=i, error=str(e))
 
         return list(await asyncio.gather(*[_one(i, item) for i, item in enumerate(items)]))
 
@@ -178,19 +204,20 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
     async def get_entities(entity_type: EntityType, object_ids: list[int]) -> list[GetResult]:
         """Fetch multiple Grocy objects of the same entity type by ID.
 
-        Returns one GetResult per ID. Failed fetches set ok=False with error
-        details; they do not abort others.
+        Returns one GetResult per ID, each carrying entity_type and object_id for
+        unambiguous identification without index-matching. Failed fetches are
+        returned as GetError and do not abort others.
         """
 
-        async def _one(i: int, object_id: int) -> GetResult:
+        async def _one(object_id: int) -> GetResult:
             try:
                 r = await client.get(f"/objects/{entity_type}/{object_id}")
                 r.raise_for_status()
-                return GetResult(index=i, object_id=object_id, ok=True, data=r.json())
+                return GetOk(entity_type=entity_type, object_id=object_id, data=r.json())
             except Exception as e:
-                return GetResult(index=i, object_id=object_id, ok=False, error=str(e))
+                return GetError(entity_type=entity_type, object_id=object_id, error=str(e))
 
-        return list(await asyncio.gather(*[_one(i, oid) for i, oid in enumerate(object_ids)]))
+        return list(await asyncio.gather(*[_one(oid) for oid in object_ids]))
 
     @mcp.tool()
     async def get_stock(

--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -183,7 +183,8 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         """Fetch multiple Grocy entity types in one call.
 
         Returns a mapping of entity_type → list of entity objects, fetched
-        concurrently. Raises if any fetch fails.
+        concurrently. Raises on the first failed fetch (fail-fast). Use
+        separate calls if partial failure tolerance is needed.
         """
 
         async def _fetch(entity_type: EntityType) -> tuple[str, list[Any]]:
@@ -385,8 +386,12 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
                 tx_id = entries[0]["transaction_id"] if entries else None
                 amount_delta = sum(float(e.get("amount", 0)) for e in entries) if entries else None
 
+                stock_r = await client.get(f"/stock/products/{item.product_id}")
+                stock_r.raise_for_status()
+                new_amount = float(stock_r.json().get("stock_amount", 0))
+
                 return StockOpResult(
-                    index=i, ok=True, transaction_id=tx_id, amount_delta=amount_delta, new_amount=item.new_amount
+                    index=i, ok=True, transaction_id=tx_id, amount_delta=amount_delta, new_amount=new_amount
                 )
             except Exception as e:
                 return StockOpResult(index=i, ok=False, error=str(e))

--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 
 import httpx
 from fastmcp import FastMCP
@@ -76,9 +76,6 @@ class CreateError(BaseModel):
     error: str
 
 
-CreateResult = Annotated[CreateOk | CreateError, Field(discriminator="kind")]
-
-
 class GetOk(BaseModel):
     kind: Literal["ok"] = "ok"
     entity_type: EntityType
@@ -91,9 +88,6 @@ class GetError(BaseModel):
     entity_type: EntityType
     object_id: int
     error: str
-
-
-GetResult = Annotated[GetOk | GetError, Field(discriminator="kind")]
 
 
 class StockEnrichedEntry(BaseModel):
@@ -165,14 +159,14 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
     """Register custom batch tools on an existing FastMCP instance."""
 
     @mcp.tool()
-    async def create_entities(items: list[CreateItem]) -> list[CreateResult]:
+    async def create_entities(items: list[CreateItem]) -> list[CreateOk | CreateError]:
         """Create multiple Grocy entities in one call.
 
         Sends one POST /objects/{entity_type} per item concurrently. Failed items
         are collected as CreateError; they do not abort others.
         """
 
-        async def _one(i: int, item: CreateItem) -> CreateResult:
+        async def _one(i: int, item: CreateItem) -> CreateOk | CreateError:
             try:
                 r = await client.post(f"/objects/{item.entity_type}", json=item.body)
                 r.raise_for_status()
@@ -201,7 +195,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         return dict(pairs)
 
     @mcp.tool()
-    async def get_entities(entity_type: EntityType, object_ids: list[int]) -> list[GetResult]:
+    async def get_entities(entity_type: EntityType, object_ids: list[int]) -> list[GetOk | GetError]:
         """Fetch multiple Grocy objects of the same entity type by ID.
 
         Returns one GetResult per ID, each carrying entity_type and object_id for
@@ -209,7 +203,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         returned as GetError and do not abort others.
         """
 
-        async def _one(object_id: int) -> GetResult:
+        async def _one(object_id: int) -> GetOk | GetError:
             try:
                 r = await client.get(f"/objects/{entity_type}/{object_id}")
                 r.raise_for_status()

--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -1,0 +1,373 @@
+"""Batch operation tools for Grocy MCP server.
+
+Custom tools that replace several single-shot OpenAPI-generated tools with
+batch/enriched versions. Each operation fans out concurrently via asyncio.gather
+and collects results (continue-and-collect, never fail-fast).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from enum import StrEnum
+from typing import Any
+
+import httpx
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+
+class EntityType(StrEnum):
+    """Grocy entity type names exposed through the /objects/{entity} API."""
+
+    products = "products"
+    chores = "chores"
+    product_barcodes = "product_barcodes"
+    batteries = "batteries"
+    locations = "locations"
+    quantity_units = "quantity_units"
+    quantity_unit_conversions = "quantity_unit_conversions"
+    shopping_list = "shopping_list"
+    shopping_lists = "shopping_lists"
+    shopping_locations = "shopping_locations"
+    recipes = "recipes"
+    recipes_pos = "recipes_pos"
+    recipes_nestings = "recipes_nestings"
+    tasks = "tasks"
+    task_categories = "task_categories"
+    product_groups = "product_groups"
+    equipment = "equipment"
+    api_keys = "api_keys"
+    userfields = "userfields"
+    userentities = "userentities"
+    userobjects = "userobjects"
+    meal_plan = "meal_plan"
+    stock_log = "stock_log"
+    stock = "stock"
+    stock_current_locations = "stock_current_locations"
+    chores_log = "chores_log"
+    meal_plan_sections = "meal_plan_sections"
+    products_last_purchased = "products_last_purchased"
+    products_average_price = "products_average_price"
+    quantity_unit_conversions_resolved = "quantity_unit_conversions_resolved"
+    recipes_pos_resolved = "recipes_pos_resolved"
+    battery_charge_cycles = "battery_charge_cycles"
+    product_barcodes_view = "product_barcodes_view"
+    permission_hierarchy = "permission_hierarchy"
+
+
+# ── Shared input/output types ──────────────────────────────────────────────
+
+
+class CreateItem(BaseModel):
+    entity_type: EntityType
+    body: dict[str, Any]
+
+
+class CreateResult(BaseModel):
+    index: int
+    ok: bool
+    created_object_id: int | None = None
+    error: str | None = None
+
+
+class GetResult(BaseModel):
+    index: int
+    object_id: int
+    ok: bool
+    data: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class StockEnrichedEntry(BaseModel):
+    product_id: int
+    amount: float
+    amount_aggregated: float
+    amount_opened: float
+    best_before_date: str | None = None
+    is_aggregated_amount: bool
+    product: dict[str, Any]
+    quantity_unit: dict[str, Any] | None = None
+    location: dict[str, Any] | None = None
+
+
+class AddItem(BaseModel):
+    product_id: int
+    amount: float
+    best_before_date: str | None = Field(default=None, description="ISO date. Omit → today.")
+    price: float | None = Field(default=None, description="Omit → last recorded price for product.")
+    location_id: int | None = Field(default=None, description="Omit → product's default location.")
+    note: str | None = None
+
+
+class ConsumeItem(BaseModel):
+    product_id: int
+    amount: float
+    spoiled: bool = False
+    location_id: int | None = Field(default=None, description="Omit → consume from any location.")
+    allow_subproduct_substitution: bool = False
+
+
+class InventoryItem(BaseModel):
+    product_id: int
+    new_amount: float = Field(description="Absolute target stock amount. Grocy adds or removes to reach it.")
+    best_before_date: str | None = Field(
+        default=None, description="Applies only to units being added. Omit → no due date for added units."
+    )
+    location_id: int | None = Field(
+        default=None, description="Applies only to units being added. Omit → product's default location."
+    )
+    price: float | None = Field(
+        default=None, description="Applies only to units being added. Omit → last recorded price."
+    )
+
+
+class StockOpResult(BaseModel):
+    index: int
+    ok: bool
+    transaction_id: str | None = Field(default=None, description="Grocy transaction ID for per-operation undo.")
+    amount_delta: float | None = Field(
+        default=None, description="Net stock change applied (negative for consume/removal)."
+    )
+    new_amount: float | None = Field(default=None, description="Resulting stock amount after the operation.")
+    error: str | None = None
+
+
+# ── Tool registration ──────────────────────────────────────────────────────
+
+
+def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
+    """Register custom batch tools on an existing FastMCP instance."""
+
+    @mcp.tool()
+    async def create_entities(items: list[CreateItem]) -> list[CreateResult]:
+        """Create multiple Grocy entities in one call.
+
+        Sends one POST /objects/{entity_type} per item concurrently. Failed items
+        are collected with ok=False and error set; they do not abort others.
+        """
+
+        async def _one(i: int, item: CreateItem) -> CreateResult:
+            try:
+                r = await client.post(f"/objects/{item.entity_type}", json=item.body)
+                r.raise_for_status()
+                data = r.json()
+                raw_id = data.get("created_object_id")
+                return CreateResult(index=i, ok=True, created_object_id=int(raw_id) if raw_id is not None else None)
+            except Exception as e:
+                return CreateResult(index=i, ok=False, error=str(e))
+
+        return list(await asyncio.gather(*[_one(i, item) for i, item in enumerate(items)]))
+
+    @mcp.tool()
+    async def list_entities(entity_types: list[EntityType]) -> dict[str, list[Any]]:
+        """Fetch multiple Grocy entity types in one call.
+
+        Returns a mapping of entity_type → list of entity objects, fetched
+        concurrently. Raises if any fetch fails.
+        """
+
+        async def _fetch(entity_type: EntityType) -> tuple[str, list[Any]]:
+            r = await client.get(f"/objects/{entity_type}")
+            r.raise_for_status()
+            return str(entity_type), r.json()
+
+        pairs = await asyncio.gather(*[_fetch(et) for et in entity_types])
+        return dict(pairs)
+
+    @mcp.tool()
+    async def get_entities(entity_type: EntityType, object_ids: list[int]) -> list[GetResult]:
+        """Fetch multiple Grocy objects of the same entity type by ID.
+
+        Returns one GetResult per ID. Failed fetches set ok=False with error
+        details; they do not abort others.
+        """
+
+        async def _one(i: int, object_id: int) -> GetResult:
+            try:
+                r = await client.get(f"/objects/{entity_type}/{object_id}")
+                r.raise_for_status()
+                return GetResult(index=i, object_id=object_id, ok=True, data=r.json())
+            except Exception as e:
+                return GetResult(index=i, object_id=object_id, ok=False, error=str(e))
+
+        return list(await asyncio.gather(*[_one(i, oid) for i, oid in enumerate(object_ids)]))
+
+    @mcp.tool()
+    async def get_stock(
+        include_quantity_unit: bool = False, include_location: bool = False
+    ) -> list[StockEnrichedEntry]:
+        """Return current stock with optional quantity-unit and location enrichment.
+
+        The product object is always included (already embedded in the /stock response).
+        Pass include_quantity_unit=True or include_location=True to attach the matching
+        quantity_unit or location dict to each entry. Enrichment data is fetched in
+        parallel with the main stock request and joined in Python by
+        product.qu_id_stock / product.location_id.
+        """
+        coros = [client.get("/stock")]
+        if include_quantity_unit:
+            coros.append(client.get("/objects/quantity_units"))
+        if include_location:
+            coros.append(client.get("/objects/locations"))
+
+        responses = await asyncio.gather(*coros)
+        for r in responses:
+            r.raise_for_status()
+
+        stock_data: list[dict[str, Any]] = responses[0].json()
+
+        qu_map: dict[int, dict[str, Any]] = {}
+        loc_map: dict[int, dict[str, Any]] = {}
+
+        idx = 1
+        if include_quantity_unit:
+            qu_map = {int(qu["id"]): qu for qu in responses[idx].json()}
+            idx += 1
+        if include_location:
+            loc_map = {int(loc["id"]): loc for loc in responses[idx].json()}
+
+        result = []
+        for entry in stock_data:
+            product = entry.get("product") or {}
+            qu_id_raw = product.get("qu_id_stock")
+            loc_id_raw = product.get("location_id")
+            qu_id = int(qu_id_raw) if qu_id_raw is not None else None
+            loc_id = int(loc_id_raw) if loc_id_raw is not None else None
+            result.append(
+                StockEnrichedEntry(
+                    product_id=entry["product_id"],
+                    amount=entry["amount"],
+                    amount_aggregated=entry["amount_aggregated"],
+                    amount_opened=entry["amount_opened"],
+                    best_before_date=entry.get("best_before_date"),
+                    is_aggregated_amount=entry["is_aggregated_amount"],
+                    product=product,
+                    quantity_unit=qu_map.get(qu_id) if qu_id is not None else None,
+                    location=loc_map.get(loc_id) if loc_id is not None else None,
+                )
+            )
+        return result
+
+    @mcp.tool()
+    async def add_stock(items: list[AddItem]) -> list[StockOpResult]:
+        """Add stock for multiple products in one call.
+
+        Each item fires a POST /stock/products/{id}/add. Results are collected
+        concurrently; a failure on one item does not affect others.
+
+        Each result includes transaction_id (for per-operation undo via the
+        undo_transaction tool), amount_delta (net change from the stock log), and
+        new_amount (resulting stock, fetched via an extra GET per product after the add).
+        """
+
+        async def _one(i: int, item: AddItem) -> StockOpResult:
+            try:
+                body: dict[str, Any] = {"amount": item.amount}
+                if item.best_before_date is not None:
+                    body["best_before_date"] = item.best_before_date
+                if item.price is not None:
+                    body["price"] = item.price
+                if item.location_id is not None:
+                    body["location_id"] = item.location_id
+                if item.note is not None:
+                    body["note"] = item.note
+
+                r = await client.post(f"/stock/products/{item.product_id}/add", json=body)
+                r.raise_for_status()
+                entries: list[dict[str, Any]] = r.json()
+                tx_id = entries[0]["transaction_id"] if entries else None
+                amount_delta = sum(float(e.get("amount", 0)) for e in entries) if entries else None
+
+                stock_r = await client.get(f"/stock/products/{item.product_id}")
+                stock_r.raise_for_status()
+                new_amount = float(stock_r.json().get("stock_amount", 0))
+
+                return StockOpResult(
+                    index=i, ok=True, transaction_id=tx_id, amount_delta=amount_delta, new_amount=new_amount
+                )
+            except Exception as e:
+                return StockOpResult(index=i, ok=False, error=str(e))
+
+        return list(await asyncio.gather(*[_one(i, item) for i, item in enumerate(items)]))
+
+    @mcp.tool()
+    async def consume_stock(items: list[ConsumeItem]) -> list[StockOpResult]:
+        """Consume stock for multiple products in one call.
+
+        Each item fires a POST /stock/products/{id}/consume. Results are
+        collected concurrently; a failure on one item does not affect others.
+
+        Each result includes transaction_id, amount_delta (typically negative),
+        and new_amount (resulting stock after the consume).
+        """
+
+        async def _one(i: int, item: ConsumeItem) -> StockOpResult:
+            try:
+                body: dict[str, Any] = {
+                    "amount": item.amount,
+                    "spoiled": item.spoiled,
+                    "allow_subproduct_substitution": item.allow_subproduct_substitution,
+                }
+                if item.location_id is not None:
+                    body["location_id"] = item.location_id
+
+                r = await client.post(f"/stock/products/{item.product_id}/consume", json=body)
+                r.raise_for_status()
+                entries: list[dict[str, Any]] = r.json()
+                tx_id = entries[0]["transaction_id"] if entries else None
+                amount_delta = sum(float(e.get("amount", 0)) for e in entries) if entries else None
+
+                stock_r = await client.get(f"/stock/products/{item.product_id}")
+                stock_r.raise_for_status()
+                new_amount = float(stock_r.json().get("stock_amount", 0))
+
+                return StockOpResult(
+                    index=i, ok=True, transaction_id=tx_id, amount_delta=amount_delta, new_amount=new_amount
+                )
+            except Exception as e:
+                return StockOpResult(index=i, ok=False, error=str(e))
+
+        return list(await asyncio.gather(*[_one(i, item) for i, item in enumerate(items)]))
+
+    @mcp.tool()
+    async def inventory_products(items: list[InventoryItem]) -> list[StockOpResult]:
+        """Set absolute stock amounts for multiple products in one call.
+
+        Each item fires a POST /stock/products/{id}/inventory. Grocy computes how
+        much to add or remove to reach new_amount and applies it atomically per product.
+        Results are collected concurrently.
+
+        Semantics of optional fields:
+        - best_before_date, location_id, price apply ONLY to units being added. If Grocy
+          removes units (because current stock > new_amount), existing entries keep their
+          original dates, locations, and prices.
+        - Omitting location_id uses the product's configured default location for added units.
+        - Omitting best_before_date leaves added units without a due date.
+        - Omitting price uses the product's last recorded price for added units.
+        - Each item produces its own transaction_id; there is no cross-item atomicity — a
+          failure on one product does not roll back others.
+        """
+
+        async def _one(i: int, item: InventoryItem) -> StockOpResult:
+            try:
+                body: dict[str, Any] = {"new_amount": item.new_amount}
+                if item.best_before_date is not None:
+                    body["best_before_date"] = item.best_before_date
+                if item.location_id is not None:
+                    body["location_id"] = item.location_id
+                if item.price is not None:
+                    body["price"] = item.price
+
+                r = await client.post(f"/stock/products/{item.product_id}/inventory", json=body)
+                r.raise_for_status()
+                entries: list[dict[str, Any]] = r.json()
+                tx_id = entries[0]["transaction_id"] if entries else None
+                amount_delta = sum(float(e.get("amount", 0)) for e in entries) if entries else None
+
+                return StockOpResult(
+                    index=i, ok=True, transaction_id=tx_id, amount_delta=amount_delta, new_amount=item.new_amount
+                )
+            except Exception as e:
+                return StockOpResult(index=i, ok=False, error=str(e))
+
+        return list(await asyncio.gather(*[_one(i, item) for i, item in enumerate(items)]))

--- a/x/grocy_mcp/dump_tools.py
+++ b/x/grocy_mcp/dump_tools.py
@@ -1,12 +1,14 @@
-"""Dump all MCP tool definitions to undeclared test outputs."""
+"""Dev tool: dump all MCP tool definitions to stdout as JSON.
+
+Usage:
+    bb run //x/grocy_mcp:dump_tools
+"""
 
 from __future__ import annotations
 
+import asyncio
 import json
 
-import pytest_bazel
-
-from util.testing.undeclared_outputs import undeclared_outputs_dir
 from x.grocy_mcp.config import ServerSettings
 from x.grocy_mcp.server import build_mcp
 
@@ -22,16 +24,12 @@ def _settings() -> ServerSettings:
     )
 
 
-async def test_dump_all_tools() -> None:
+async def _main() -> None:
     mcp = build_mcp(_settings())
     tools = await mcp.list_tools()
     all_tools = [tool.to_mcp_tool().model_dump(mode="json") for tool in tools]
-    out = undeclared_outputs_dir() / "all_tools.json"
-    out.write_text(json.dumps(all_tools, indent=2))
-    print(f"Wrote {len(all_tools)} tools to {out}")
-    for tool in all_tools:
-        print(f"  {tool['name']}")
+    print(json.dumps(all_tools, indent=2))
 
 
 if __name__ == "__main__":
-    pytest_bazel.main()
+    asyncio.run(_main())

--- a/x/grocy_mcp/fix_openapi_spec.py
+++ b/x/grocy_mcp/fix_openapi_spec.py
@@ -12,7 +12,11 @@ Grocy's published spec has two classes of issues that prevent FastMCP's
    drops parameters it can't resolve, making ``/objects/{entity}`` tools
    unusable (no ``entity`` parameter).
 
-This script reads the raw spec, applies both fixups, and writes the
+Additionally, routes replaced by batch tools (``batch_tools.py``) are
+stripped from the spec entirely so FastMCP never generates competing
+single-item tool stubs for them.
+
+This script reads the raw spec, applies all fixups, and writes the
 corrected spec. It runs as a Bazel genrule so the server loads a
 pre-fixed spec at runtime with no patching logic.
 """
@@ -70,33 +74,39 @@ def fix_entity_refs(spec: dict[str, object]) -> None:
         }
 
 
-def fix_created_object_id(spec: dict[str, object]) -> None:
-    """Widen created_object_id to accept string or integer.
+# Routes replaced by custom batch tools in batch_tools.py.
+# Stripped from the spec so FastMCP never generates competing stubs for them.
+_REPLACED_ROUTES: set[tuple[str, str]] = {
+    ("get", "/objects/{entity}"),
+    ("post", "/objects/{entity}"),
+    ("get", "/objects/{entity}/{objectId}"),
+    ("get", "/stock"),
+    ("post", "/stock/products/{productId}/add"),
+    ("post", "/stock/products/{productId}/consume"),
+    ("post", "/stock/products/{productId}/inventory"),
+}
 
-    Grocy returns created_object_id as a string despite the spec declaring it
-    as integer, causing FastMCP output validation to fail.
+
+def strip_replaced_routes(spec: dict[str, object]) -> None:
+    """Remove routes replaced by batch_tools.py from the spec.
+
+    Keeps the path entry if other HTTP methods remain; removes the path
+    entirely if all its methods are stripped.
     """
     paths = spec.get("paths")
     if not isinstance(paths, dict):
         return
-    entity_route = paths.get("/objects/{entity}")
-    if not isinstance(entity_route, dict):
-        return
-    post_op = entity_route.get("post")
-    if not isinstance(post_op, dict):
-        return
-    try:
-        props = post_op["responses"]["200"]["content"]["application/json"]["schema"]["properties"]
-    except (KeyError, TypeError):
-        return
-    if not isinstance(props, dict):
-        return
-    field = props.get("created_object_id")
-    if isinstance(field, dict) and field.get("type") == "integer":
-        props["created_object_id"] = {
-            "anyOf": [{"type": "integer"}, {"type": "string"}],
-            "description": field.get("description", "The id of the created object"),
-        }
+    empty_paths = []
+    for path, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        for method in list(path_item):
+            if (method, path) in _REPLACED_ROUTES:
+                del path_item[method]
+        if not any(m in path_item for m in ("get", "post", "put", "patch", "delete")):
+            empty_paths.append(path)
+    for path in empty_paths:
+        del paths[path]
 
 
 def main() -> None:
@@ -107,7 +117,7 @@ def main() -> None:
     spec: dict[str, object] = json.loads(Path(sys.argv[1]).read_text())
     strip_empty_enums(spec)
     fix_entity_refs(spec)
-    fix_created_object_id(spec)
+    strip_replaced_routes(spec)
     Path(sys.argv[2]).write_text(json.dumps(spec, indent=2))
 
 

--- a/x/grocy_mcp/fix_openapi_spec.py
+++ b/x/grocy_mcp/fix_openapi_spec.py
@@ -70,6 +70,35 @@ def fix_entity_refs(spec: dict[str, object]) -> None:
         }
 
 
+def fix_created_object_id(spec: dict[str, object]) -> None:
+    """Widen created_object_id to accept string or integer.
+
+    Grocy returns created_object_id as a string despite the spec declaring it
+    as integer, causing FastMCP output validation to fail.
+    """
+    paths = spec.get("paths")
+    if not isinstance(paths, dict):
+        return
+    entity_route = paths.get("/objects/{entity}")
+    if not isinstance(entity_route, dict):
+        return
+    post_op = entity_route.get("post")
+    if not isinstance(post_op, dict):
+        return
+    try:
+        props = post_op["responses"]["200"]["content"]["application/json"]["schema"]["properties"]
+    except (KeyError, TypeError):
+        return
+    if not isinstance(props, dict):
+        return
+    field = props.get("created_object_id")
+    if isinstance(field, dict) and field.get("type") == "integer":
+        props["created_object_id"] = {
+            "anyOf": [{"type": "integer"}, {"type": "string"}],
+            "description": field.get("description", "The id of the created object"),
+        }
+
+
 def main() -> None:
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} <input.json> <output.json>", file=sys.stderr)
@@ -78,6 +107,7 @@ def main() -> None:
     spec: dict[str, object] = json.loads(Path(sys.argv[1]).read_text())
     strip_empty_enums(spec)
     fix_entity_refs(spec)
+    fix_created_object_id(spec)
     Path(sys.argv[2]).write_text(json.dumps(spec, indent=2))
 
 

--- a/x/grocy_mcp/server.py
+++ b/x/grocy_mcp/server.py
@@ -35,6 +35,7 @@ from pydantic.networks import AnyUrl
 
 from util.bazel.runfiles import get_required_path
 from x.grocy_mcp.auth import AuthentikExchangeAuth
+from x.grocy_mcp.batch_tools import register_batch_tools
 from x.grocy_mcp.config import ServerSettings
 from x.grocy_mcp.tool_metadata import TOOL_OVERRIDES
 
@@ -117,7 +118,7 @@ def build_mcp(settings: ServerSettings, *, client: httpx.AsyncClient | None = No
         if override.extra_description:
             component.description = f"{component.description}\n\n{override.extra_description}"
 
-    return FastMCP.from_openapi(
+    mcp = FastMCP.from_openapi(
         openapi_spec=spec,
         client=client,
         name="Grocy",
@@ -125,6 +126,8 @@ def build_mcp(settings: ServerSettings, *, client: httpx.AsyncClient | None = No
         route_map_fn=_filter_disabled,
         mcp_component_fn=_customize_component,
     )
+    register_batch_tools(mcp, client)
+    return mcp
 
 
 def build_server(settings: ServerSettings) -> FastMCP:

--- a/x/grocy_mcp/test_dump_tool.py
+++ b/x/grocy_mcp/test_dump_tool.py
@@ -25,7 +25,7 @@ def _settings() -> ServerSettings:
 async def test_dump_all_tools() -> None:
     mcp = build_mcp(_settings())
     tools = await mcp.list_tools()
-    all_tools = [tool.model_dump(mode="json") for tool in tools]
+    all_tools = [tool.to_mcp_tool().model_dump(mode="json") for tool in tools]
     out = undeclared_outputs_dir() / "all_tools.json"
     out.write_text(json.dumps(all_tools, indent=2))
     print(f"Wrote {len(all_tools)} tools to {out}")

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -3,26 +3,27 @@
 Starts a real Grocy container (LinuxServer image, auth disabled, demo mode),
 wires the MCP server to it, and exercises a realistic sequence of tool calls
 that mirrors how an LLM would bootstrap a Grocy inventory from scratch.
+
+All tool calls go through the full MCP protocol via fastmcp.Client with
+FastMCPTransport. This ensures output schema validation and error propagation
+match what real MCP clients (e.g. Claude) experience.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import tempfile
 import time
 import uuid
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from pathlib import Path
-from typing import Any
 
 import httpx
-import jsonschema
 import pytest
 import pytest_bazel
 from fastmcp import FastMCP
-from fastmcp.tools import ToolResult
-from mcp.types import TextContent
+from fastmcp.client import Client
+from fastmcp.client.transports import FastMCPTransport
 
 from third_party.containers.rlocations import GROCY
 from util.oci import load_oci_image
@@ -32,6 +33,17 @@ from x.grocy_mcp.server import build_mcp
 from x.grocy_mcp.tool_metadata import TOOL_OVERRIDES
 
 logger = logging.getLogger(__name__)
+
+# Names of the custom batch tools registered by register_batch_tools.
+CUSTOM_TOOL_NAMES = {
+    "create_entities",
+    "list_entities",
+    "get_entities",
+    "get_stock",
+    "add_stock",
+    "consume_stock",
+    "inventory_products",
+}
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────
@@ -118,55 +130,27 @@ def grocy_base_url(grocy_container: LoggedContainer) -> str:
     return f"http://{host}:{port}"
 
 
-def _make_grocy_client(grocy_base_url: str) -> httpx.AsyncClient:
-    """Create a fresh async httpx client for the Grocy API."""
-    return httpx.AsyncClient(base_url=f"{grocy_base_url}/api", timeout=30.0)
+@pytest.fixture(scope="session")
+def grocy_mcp(grocy_base_url: str) -> FastMCP:
+    client = httpx.AsyncClient(base_url=f"{grocy_base_url}/api", timeout=30.0)
+    return build_mcp(_settings(grocy_base_url), client=client)
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────
-
-
-def _result_json(result: ToolResult) -> Any:
-    """Extract parsed JSON from a FastMCP ToolResult."""
-    if result.structured_content is not None:
-        return result.structured_content
-    if result.content:
-        first = result.content[0]
-        assert isinstance(first, TextContent), f"Expected TextContent, got {type(first)}"
-        return json.loads(first.text)
-    raise ValueError(f"Empty tool result: {result!r}")
-
-
-async def _call(mcp: FastMCP, tool_name: str, args: dict | None = None) -> Any:
-    """Call a tool and validate the result against the tool's declared output schema.
-
-    This mirrors what the MCP client (e.g. Claude) does: after receiving a
-    CallToolResult with structuredContent, it validates the content against the
-    tool's declared outputSchema. Calling mcp.call_tool() directly skips that
-    client-side validation, so we replicate it here to catch schema mismatches
-    (e.g. Grocy returning "9" where the spec says integer).
-    """
-    result = await mcp.call_tool(tool_name, args or {})
-    data = _result_json(result)
-
-    tool = await mcp.get_tool(tool_name)
-    if tool is not None and tool.output_schema is not None and result.structured_content is not None:
-        try:
-            jsonschema.validate(result.structured_content, tool.output_schema)
-        except jsonschema.ValidationError as e:
-            pytest.fail(f"Output schema validation failed for {tool_name!r}: {e.message}")
-
-    return data
+@pytest.fixture(scope="session")
+async def mcp_client(grocy_mcp: FastMCP) -> AsyncGenerator[Client]:
+    """Session-scoped MCP client exercising the full MCP protocol in-process."""
+    async with Client(FastMCPTransport(grocy_mcp)) as client:
+        yield client
 
 
 # ── Tool name coverage ───────────────────────────────────────────────────
 
 
-async def test_all_tool_names_are_customized(grocy_base_url: str) -> None:
-    """Every tool exposed by the MCP server has a name from TOOL_OVERRIDES."""
-    mcp = build_mcp(_settings(grocy_base_url), client=_make_grocy_client(grocy_base_url))
-    tools = await mcp.list_tools()
+async def test_all_tool_names_are_customized(mcp_client: Client) -> None:
+    """Every tool exposed by the MCP server has a name from TOOL_OVERRIDES or CUSTOM_TOOL_NAMES."""
+    tools = await mcp_client.list_tools()
     expected_names = {o.name for o in TOOL_OVERRIDES.values() if o.enabled and not o.resource}
+    expected_names |= CUSTOM_TOOL_NAMES
     actual_names = {t.name for t in tools}
     assert actual_names == expected_names, (
         f"Mismatch: extra={actual_names - expected_names}, missing={expected_names - actual_names}"
@@ -176,22 +160,19 @@ async def test_all_tool_names_are_customized(grocy_base_url: str) -> None:
 # ── MCP resource ─────────────────────────────────────────────────────────
 
 
-async def test_system_info_resource(grocy_base_url: str) -> None:
+async def test_system_info_resource(mcp_client: Client) -> None:
     """GET /system/info is exposed as an MCP resource, not a tool."""
-    mcp = build_mcp(_settings(grocy_base_url), client=_make_grocy_client(grocy_base_url))
-
-    tools = await mcp.list_tools()
+    tools = await mcp_client.list_tools()
     tool_names = {t.name for t in tools}
     assert "get_system_info" not in tool_names, "system_info should be a resource, not a tool"
 
-    resources = await mcp.list_resources()
+    resources = await mcp_client.list_resources()
     resource_uris = {str(r.uri): r for r in resources}
     matching = [uri for uri in resource_uris if "system_info" in uri]
     assert matching, f"system_info resource not found in {list(resource_uris.keys())}"
 
-    # Read the resource — should return Grocy version info.
     resource_uri = matching[0]
-    content = await mcp.read_resource(resource_uri)
+    content = await mcp_client.read_resource(resource_uri)
     assert content, "system_info resource returned empty content"
     text = str(content)
     assert "grocy_version" in text.lower() or "Grocy" in text, f"Unexpected resource content: {text[:200]}"
@@ -200,78 +181,92 @@ async def test_system_info_resource(grocy_base_url: str) -> None:
 # ── Inventory bootstrap workflow ─────────────────────────────────────────
 
 
-async def test_inventory_bootstrap(grocy_base_url: str) -> None:
-    """Full inventory workflow: create entities → add stock → query → consume."""
-    mcp = build_mcp(_settings(grocy_base_url), client=_make_grocy_client(grocy_base_url))
-
-    # Use unique names to avoid collision with Grocy's seed data.
+async def test_inventory_bootstrap(mcp_client: Client) -> None:
+    """Full batch inventory workflow: create entities → add → get enriched → consume → inventory."""
     suffix = uuid.uuid4().hex[:6]
 
-    # 1. Create a location
-    loc = await _call(mcp, "create_entity", {"entity": "locations", "body": {"name": f"TestLoc-{suffix}"}})
-    loc_id = loc["created_object_id"]
-
-    # 2. Create a quantity unit
-    qu = await _call(
-        mcp,
-        "create_entity",
-        {"entity": "quantity_units", "body": {"name": f"TestUnit-{suffix}", "name_plural": f"TestUnits-{suffix}"}},
-    )
-    qu_id = qu["created_object_id"]
-
-    # 3. Create a product
-    product = await _call(
-        mcp,
-        "create_entity",
+    # 1. Create location and quantity unit in one batch call
+    result = await mcp_client.call_tool(
+        "create_entities",
         {
-            "entity": "products",
-            "body": {
-                "name": f"TestRice-{suffix}",
-                "location_id": loc_id,
-                "qu_id_purchase": qu_id,
-                "qu_id_stock": qu_id,
-            },
+            "items": [
+                {"entity_type": "locations", "body": {"name": f"TestLoc-{suffix}"}},
+                {
+                    "entity_type": "quantity_units",
+                    "body": {"name": f"TestUnit-{suffix}", "name_plural": f"TestUnits-{suffix}"},
+                },
+            ]
         },
     )
-    product_id = product["created_object_id"]
+    created = result.structured_content["result"]
+    assert created[0]["ok"], f"location create failed: {created[0].get('error')}"
+    assert created[1]["ok"], f"quantity_unit create failed: {created[1].get('error')}"
+    loc_id = created[0]["created_object_id"]
+    qu_id = created[1]["created_object_id"]
 
-    # 4. Add stock
-    add_result = await _call(
-        mcp, "add_product_stock", {"productId": product_id, "amount": 5, "best_before_date": "2030-01-01"}
+    # 2. Create a product
+    result = await mcp_client.call_tool(
+        "create_entities",
+        {
+            "items": [
+                {
+                    "entity_type": "products",
+                    "body": {
+                        "name": f"TestRice-{suffix}",
+                        "location_id": loc_id,
+                        "qu_id_purchase": qu_id,
+                        "qu_id_stock": qu_id,
+                    },
+                }
+            ]
+        },
     )
-    # FastMCP wraps the response in {"result": [...]}.
-    transactions = add_result["result"] if isinstance(add_result, dict) and "result" in add_result else add_result
-    assert isinstance(transactions, list), f"Expected transaction list, got {add_result!r}"
+    product_id = result.structured_content["result"][0]["created_object_id"]
+    assert product_id is not None
 
-    # 5. Verify stock shows up
-    stock_raw = await _call(mcp, "list_stock")
-    stock = stock_raw["result"] if isinstance(stock_raw, dict) and "result" in stock_raw else stock_raw
-    assert isinstance(stock, list)
-    # product_id may be str or int depending on Grocy version — compare loosely.
-    product_stock = [s for s in stock if str(s.get("product_id")) == str(product_id)]
-    assert len(product_stock) == 1
+    # 3. Add stock
+    result = await mcp_client.call_tool(
+        "add_stock", {"items": [{"product_id": product_id, "amount": 5, "best_before_date": "2030-01-01"}]}
+    )
+    op = result.structured_content["result"][0]
+    assert op["ok"], f"add_stock failed: {op.get('error')}"
+    assert op["new_amount"] == 5.0
+
+    # 4. Get enriched stock — verify product + QU + location attached
+    result = await mcp_client.call_tool("get_stock", {"include_quantity_unit": True, "include_location": True})
+    stock = result.structured_content["result"]
+    product_stock = [s for s in stock if str(s["product_id"]) == str(product_id)]
+    assert len(product_stock) == 1, f"product {product_id} not found in stock"
     assert float(product_stock[0]["amount"]) == 5.0
+    assert product_stock[0]["quantity_unit"] is not None, "quantity_unit not enriched"
+    assert product_stock[0]["location"] is not None, "location not enriched"
 
-    # 6. Get product details
-    details = await _call(mcp, "get_product_stock", {"productId": product_id})
-    assert float(details["stock_amount"]) == 5.0
+    # 5. Consume some stock
+    result = await mcp_client.call_tool("consume_stock", {"items": [{"product_id": product_id, "amount": 2}]})
+    op = result.structured_content["result"][0]
+    assert op["ok"], f"consume_stock failed: {op.get('error')}"
+    assert op["new_amount"] == 3.0
 
-    # 7. Consume some stock
-    await _call(mcp, "consume_product_stock", {"productId": product_id, "amount": 2})
+    # 6. Inventory — set absolute amount
+    result = await mcp_client.call_tool("inventory_products", {"items": [{"product_id": product_id, "new_amount": 10}]})
+    op = result.structured_content["result"][0]
+    assert op["ok"], f"inventory_products failed: {op.get('error')}"
+    assert op["new_amount"] == 10.0
 
-    # 8. Verify reduced stock
-    stock_after_raw = await _call(mcp, "list_stock")
-    stock_after = (
-        stock_after_raw["result"]
-        if isinstance(stock_after_raw, dict) and "result" in stock_after_raw
-        else stock_after_raw
-    )
-    product_stock_after = [s for s in stock_after if str(s.get("product_id")) == str(product_id)]
-    assert float(product_stock_after[0]["amount"]) == 3.0
+    # 7. List entities — fetch products, locations, quantity_units in one call
+    result = await mcp_client.call_tool("list_entities", {"entity_types": ["products", "locations", "quantity_units"]})
+    data = result.structured_content
+    assert "products" in data
+    assert "locations" in data
+    assert "quantity_units" in data
+    product_names = [p["name"] for p in data["products"]]
+    assert f"TestRice-{suffix}" in product_names
 
-    # 9. Verify entity CRUD — read back the product
-    product_obj = await _call(mcp, "get_entity", {"entity": "products", "objectId": product_id})
-    assert product_obj["name"] == f"TestRice-{suffix}"
+    # 8. Get specific entity by ID
+    result = await mcp_client.call_tool("get_entities", {"entity_type": "products", "object_ids": [product_id]})
+    entities = result.structured_content["result"]
+    assert entities[0]["ok"], f"get_entities failed: {entities[0].get('error')}"
+    assert entities[0]["data"]["name"] == f"TestRice-{suffix}"
 
 
 if __name__ == "__main__":

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -136,9 +136,15 @@ def grocy_mcp(grocy_base_url: str) -> FastMCP:
     return build_mcp(_settings(grocy_base_url), client=client)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 async def mcp_client(grocy_mcp: FastMCP) -> AsyncGenerator[Client]:
-    """Session-scoped MCP client exercising the full MCP protocol in-process."""
+    """Function-scoped MCP client exercising the full MCP protocol in-process.
+
+    Function scope (not session) ensures the client and its transport share the same
+    event loop as the test function. pytest-asyncio creates a new event loop per test
+    function; a session-scoped async fixture would run in a different loop and the
+    client's internal asyncio primitives would deadlock when used from the test loop.
+    """
     async with Client(FastMCPTransport(grocy_mcp)) as client:
         yield client
 
@@ -198,7 +204,9 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
             ]
         },
     )
-    created = result.structured_content["result"]
+    sc = result.structured_content
+    assert sc is not None
+    created = sc["result"]
     assert created[0]["ok"], f"location create failed: {created[0].get('error')}"
     assert created[1]["ok"], f"quantity_unit create failed: {created[1].get('error')}"
     loc_id = created[0]["created_object_id"]
@@ -221,20 +229,26 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
             ]
         },
     )
-    product_id = result.structured_content["result"][0]["created_object_id"]
+    sc = result.structured_content
+    assert sc is not None
+    product_id = sc["result"][0]["created_object_id"]
     assert product_id is not None
 
     # 3. Add stock
     result = await mcp_client.call_tool(
         "add_stock", {"items": [{"product_id": product_id, "amount": 5, "best_before_date": "2030-01-01"}]}
     )
-    op = result.structured_content["result"][0]
+    sc = result.structured_content
+    assert sc is not None
+    op = sc["result"][0]
     assert op["ok"], f"add_stock failed: {op.get('error')}"
     assert op["new_amount"] == 5.0
 
     # 4. Get enriched stock — verify product + QU + location attached
     result = await mcp_client.call_tool("get_stock", {"include_quantity_unit": True, "include_location": True})
-    stock = result.structured_content["result"]
+    sc = result.structured_content
+    assert sc is not None
+    stock = sc["result"]
     product_stock = [s for s in stock if str(s["product_id"]) == str(product_id)]
     assert len(product_stock) == 1, f"product {product_id} not found in stock"
     assert float(product_stock[0]["amount"]) == 5.0
@@ -243,19 +257,24 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
 
     # 5. Consume some stock
     result = await mcp_client.call_tool("consume_stock", {"items": [{"product_id": product_id, "amount": 2}]})
-    op = result.structured_content["result"][0]
+    sc = result.structured_content
+    assert sc is not None
+    op = sc["result"][0]
     assert op["ok"], f"consume_stock failed: {op.get('error')}"
     assert op["new_amount"] == 3.0
 
     # 6. Inventory — set absolute amount
     result = await mcp_client.call_tool("inventory_products", {"items": [{"product_id": product_id, "new_amount": 10}]})
-    op = result.structured_content["result"][0]
+    sc = result.structured_content
+    assert sc is not None
+    op = sc["result"][0]
     assert op["ok"], f"inventory_products failed: {op.get('error')}"
     assert op["new_amount"] == 10.0
 
     # 7. List entities — fetch products, locations, quantity_units in one call
     result = await mcp_client.call_tool("list_entities", {"entity_types": ["products", "locations", "quantity_units"]})
     data = result.structured_content
+    assert data is not None
     assert "products" in data
     assert "locations" in data
     assert "quantity_units" in data
@@ -264,7 +283,9 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
 
     # 8. Get specific entity by ID
     result = await mcp_client.call_tool("get_entities", {"entity_type": "products", "object_ids": [product_id]})
-    entities = result.structured_content["result"]
+    sc = result.structured_content
+    assert sc is not None
+    entities = sc["result"]
     assert entities[0]["ok"], f"get_entities failed: {entities[0].get('error')}"
     assert entities[0]["data"]["name"] == f"TestRice-{suffix}"
 

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -17,8 +17,10 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import jsonschema
 import pytest
 import pytest_bazel
+from fastmcp import FastMCP
 from fastmcp.tools import ToolResult
 from mcp.types import TextContent
 
@@ -135,6 +137,28 @@ def _result_json(result: ToolResult) -> Any:
     raise ValueError(f"Empty tool result: {result!r}")
 
 
+async def _call(mcp: FastMCP, tool_name: str, args: dict | None = None) -> Any:
+    """Call a tool and validate the result against the tool's declared output schema.
+
+    This mirrors what the MCP client (e.g. Claude) does: after receiving a
+    CallToolResult with structuredContent, it validates the content against the
+    tool's declared outputSchema. Calling mcp.call_tool() directly skips that
+    client-side validation, so we replicate it here to catch schema mismatches
+    (e.g. Grocy returning "9" where the spec says integer).
+    """
+    result = await mcp.call_tool(tool_name, args or {})
+    data = _result_json(result)
+
+    tool = await mcp.get_tool(tool_name)
+    if tool is not None and tool.output_schema is not None and result.structured_content is not None:
+        try:
+            jsonschema.validate(result.structured_content, tool.output_schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(f"Output schema validation failed for {tool_name!r}: {e.message}")
+
+    return data
+
+
 # ── Tool name coverage ───────────────────────────────────────────────────
 
 
@@ -180,26 +204,24 @@ async def test_inventory_bootstrap(grocy_base_url: str) -> None:
     """Full inventory workflow: create entities → add stock → query → consume."""
     mcp = build_mcp(_settings(grocy_base_url), client=_make_grocy_client(grocy_base_url))
 
-    async def call(tool_name: str, args: dict | None = None) -> Any:
-        result = await mcp.call_tool(tool_name, args or {})
-        return _result_json(result)
-
     # Use unique names to avoid collision with Grocy's seed data.
     suffix = uuid.uuid4().hex[:6]
 
     # 1. Create a location
-    loc = await call("create_entity", {"entity": "locations", "body": {"name": f"TestLoc-{suffix}"}})
+    loc = await _call(mcp, "create_entity", {"entity": "locations", "body": {"name": f"TestLoc-{suffix}"}})
     loc_id = loc["created_object_id"]
 
     # 2. Create a quantity unit
-    qu = await call(
+    qu = await _call(
+        mcp,
         "create_entity",
         {"entity": "quantity_units", "body": {"name": f"TestUnit-{suffix}", "name_plural": f"TestUnits-{suffix}"}},
     )
     qu_id = qu["created_object_id"]
 
     # 3. Create a product
-    product = await call(
+    product = await _call(
+        mcp,
         "create_entity",
         {
             "entity": "products",
@@ -214,15 +236,15 @@ async def test_inventory_bootstrap(grocy_base_url: str) -> None:
     product_id = product["created_object_id"]
 
     # 4. Add stock
-    add_result = await call(
-        "add_product_stock", {"productId": product_id, "amount": 5, "best_before_date": "2030-01-01"}
+    add_result = await _call(
+        mcp, "add_product_stock", {"productId": product_id, "amount": 5, "best_before_date": "2030-01-01"}
     )
     # FastMCP wraps the response in {"result": [...]}.
     transactions = add_result["result"] if isinstance(add_result, dict) and "result" in add_result else add_result
     assert isinstance(transactions, list), f"Expected transaction list, got {add_result!r}"
 
     # 5. Verify stock shows up
-    stock_raw = await call("list_stock")
+    stock_raw = await _call(mcp, "list_stock")
     stock = stock_raw["result"] if isinstance(stock_raw, dict) and "result" in stock_raw else stock_raw
     assert isinstance(stock, list)
     # product_id may be str or int depending on Grocy version — compare loosely.
@@ -231,14 +253,14 @@ async def test_inventory_bootstrap(grocy_base_url: str) -> None:
     assert float(product_stock[0]["amount"]) == 5.0
 
     # 6. Get product details
-    details = await call("get_product_stock", {"productId": product_id})
+    details = await _call(mcp, "get_product_stock", {"productId": product_id})
     assert float(details["stock_amount"]) == 5.0
 
     # 7. Consume some stock
-    await call("consume_product_stock", {"productId": product_id, "amount": 2})
+    await _call(mcp, "consume_product_stock", {"productId": product_id, "amount": 2})
 
     # 8. Verify reduced stock
-    stock_after_raw = await call("list_stock")
+    stock_after_raw = await _call(mcp, "list_stock")
     stock_after = (
         stock_after_raw["result"]
         if isinstance(stock_after_raw, dict) and "result" in stock_after_raw
@@ -248,7 +270,7 @@ async def test_inventory_bootstrap(grocy_base_url: str) -> None:
     assert float(product_stock_after[0]["amount"]) == 3.0
 
     # 9. Verify entity CRUD — read back the product
-    product_obj = await call("get_entity", {"entity": "products", "objectId": product_id})
+    product_obj = await _call(mcp, "get_entity", {"entity": "products", "objectId": product_id})
     assert product_obj["name"] == f"TestRice-{suffix}"
 
 

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -161,25 +161,16 @@ async def test_all_tool_names_are_customized(mcp_client: Client) -> None:
     )
 
 
-# ── MCP resource ─────────────────────────────────────────────────────────
+# ── System info tool ─────────────────────────────────────────────────────
 
 
-async def test_system_info_resource(mcp_client: Client) -> None:
-    """GET /system/info is exposed as an MCP resource, not a tool."""
-    tools = await mcp_client.list_tools()
-    tool_names = {t.name for t in tools}
-    assert "get_system_info" not in tool_names, "system_info should be a resource, not a tool"
-
-    resources = await mcp_client.list_resources()
-    resource_uris = {str(r.uri): r for r in resources}
-    matching = [uri for uri in resource_uris if "system_info" in uri]
-    assert matching, f"system_info resource not found in {list(resource_uris.keys())}"
-
-    resource_uri = matching[0]
-    content = await mcp_client.read_resource(resource_uri)
-    assert content, "system_info resource returned empty content"
-    text = str(content)
-    assert "grocy_version" in text.lower() or "Grocy" in text, f"Unexpected resource content: {text[:200]}"
+async def test_system_info_tool(mcp_client: Client) -> None:
+    """GET /system/info is exposed as an MCP tool (claude.ai does not expose MCP resources to the AI)."""
+    result = await mcp_client.call_tool("get_system_info", {})
+    sc = result.structured_content
+    assert sc is not None
+    text = str(sc)
+    assert "grocy_version" in text.lower() or "grocy" in text.lower(), f"Unexpected tool result: {text[:200]}"
 
 
 # ── Inventory bootstrap workflow ─────────────────────────────────────────
@@ -205,8 +196,8 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
     sc = result.structured_content
     assert sc is not None
     created = sc["result"]
-    assert created[0]["ok"], f"location create failed: {created[0].get('error')}"
-    assert created[1]["ok"], f"quantity_unit create failed: {created[1].get('error')}"
+    assert created[0]["kind"] == "ok", f"location create failed: {created[0].get('error')}"
+    assert created[1]["kind"] == "ok", f"quantity_unit create failed: {created[1].get('error')}"
     loc_id = created[0]["created_object_id"]
     qu_id = created[1]["created_object_id"]
 
@@ -229,7 +220,9 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
     )
     sc = result.structured_content
     assert sc is not None
-    product_id = sc["result"][0]["created_object_id"]
+    product_create = sc["result"][0]
+    assert product_create["kind"] == "ok", f"product create failed: {product_create.get('error')}"
+    product_id = product_create["created_object_id"]
     assert product_id is not None
 
     # 3. Add stock
@@ -284,7 +277,7 @@ async def test_inventory_bootstrap(mcp_client: Client) -> None:
     sc = result.structured_content
     assert sc is not None
     entities = sc["result"]
-    assert entities[0]["ok"], f"get_entities failed: {entities[0].get('error')}"
+    assert entities[0]["kind"] == "ok", f"get_entities failed: {entities[0].get('error')}"
     assert entities[0]["data"]["name"] == f"TestRice-{suffix}"
 
 

--- a/x/grocy_mcp/test_e2e.py
+++ b/x/grocy_mcp/test_e2e.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import httpx
 import pytest
 import pytest_bazel
-from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.client.transports import FastMCPTransport
 
@@ -130,23 +129,22 @@ def grocy_base_url(grocy_container: LoggedContainer) -> str:
     return f"http://{host}:{port}"
 
 
-@pytest.fixture(scope="session")
-def grocy_mcp(grocy_base_url: str) -> FastMCP:
-    client = httpx.AsyncClient(base_url=f"{grocy_base_url}/api", timeout=30.0)
-    return build_mcp(_settings(grocy_base_url), client=client)
-
-
 @pytest.fixture
-async def mcp_client(grocy_mcp: FastMCP) -> AsyncGenerator[Client]:
+async def mcp_client(grocy_base_url: str) -> AsyncGenerator[Client]:
     """Function-scoped MCP client exercising the full MCP protocol in-process.
 
-    Function scope (not session) ensures the client and its transport share the same
-    event loop as the test function. pytest-asyncio creates a new event loop per test
-    function; a session-scoped async fixture would run in a different loop and the
-    client's internal asyncio primitives would deadlock when used from the test loop.
+    A fresh httpx.AsyncClient is created per test so connection pools don't carry
+    sockets from a previous test's (now-closed) event loop. Session-scoping the
+    httpx client caused "Event loop is closed" on the third test because asyncio
+    transports are pinned to the loop that opened them.
     """
-    async with Client(FastMCPTransport(grocy_mcp)) as client:
-        yield client
+    http_client = httpx.AsyncClient(base_url=f"{grocy_base_url}/api", timeout=30.0)
+    try:
+        mcp = build_mcp(_settings(grocy_base_url), client=http_client)
+        async with Client(FastMCPTransport(mcp)) as client:
+            yield client
+    finally:
+        await http_client.aclose()
 
 
 # ── Tool name coverage ───────────────────────────────────────────────────

--- a/x/grocy_mcp/test_fix_openapi_spec.py
+++ b/x/grocy_mcp/test_fix_openapi_spec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest_bazel
 
-from x.grocy_mcp.fix_openapi_spec import fix_created_object_id, fix_entity_refs, strip_empty_enums
+from x.grocy_mcp.fix_openapi_spec import fix_entity_refs, strip_empty_enums, strip_replaced_routes
 
 
 def test_strip_empty_enums_removes_empty_enum() -> None:
@@ -37,64 +37,32 @@ def test_fix_entity_refs_materializes_missing_schemas() -> None:
     assert schemas["ExposedEntity_IncludingUserEntities_NotIncludingNotEditable"]["enum"] == ["locations", "products"]
 
 
-def test_fix_created_object_id_widens_integer_to_anyof() -> None:
+def test_strip_replaced_routes_removes_replaced_methods() -> None:
     spec: dict = {
         "paths": {
-            "/objects/{entity}": {
-                "post": {
-                    "responses": {
-                        "200": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "properties": {
-                                            "created_object_id": {
-                                                "type": "integer",
-                                                "description": "The id of the created object",
-                                            }
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            "/objects/{entity}": {"get": {"summary": "list"}, "post": {"summary": "create"}},
+            "/objects/{entity}/{objectId}": {
+                "get": {"summary": "get one"},
+                "put": {"summary": "update"},
+                "delete": {"summary": "delete"},
+            },
+            "/stock": {"get": {"summary": "stock"}},
         }
     }
-    fix_created_object_id(spec)
-    field = spec["paths"]["/objects/{entity}"]["post"]["responses"]["200"]["content"]["application/json"]["schema"][
-        "properties"
-    ]["created_object_id"]
-    assert field == {"anyOf": [{"type": "integer"}, {"type": "string"}], "description": "The id of the created object"}
+    strip_replaced_routes(spec)
+    paths = spec["paths"]
 
+    # GET and POST on /objects/{entity} both replaced — path should be gone entirely.
+    assert "/objects/{entity}" not in paths
 
-def test_fix_created_object_id_noop_when_already_widened() -> None:
-    existing = {"anyOf": [{"type": "integer"}, {"type": "string"}], "description": "The id of the created object"}
-    spec: dict = {
-        "paths": {
-            "/objects/{entity}": {
-                "post": {
-                    "responses": {
-                        "200": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {"type": "object", "properties": {"created_object_id": existing}}
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    fix_created_object_id(spec)
-    # Should be unchanged — no "type": "integer" to replace.
-    field = spec["paths"]["/objects/{entity}"]["post"]["responses"]["200"]["content"]["application/json"]["schema"][
-        "properties"
-    ]["created_object_id"]
-    assert field == existing
+    # Only GET replaced on /objects/{entity}/{objectId} — PUT and DELETE remain.
+    assert "/objects/{entity}/{objectId}" in paths
+    assert "get" not in paths["/objects/{entity}/{objectId}"]
+    assert "put" in paths["/objects/{entity}/{objectId}"]
+    assert "delete" in paths["/objects/{entity}/{objectId}"]
+
+    # /stock GET replaced — path gone.
+    assert "/stock" not in paths
 
 
 if __name__ == "__main__":

--- a/x/grocy_mcp/test_fix_openapi_spec.py
+++ b/x/grocy_mcp/test_fix_openapi_spec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest_bazel
 
-from x.grocy_mcp.fix_openapi_spec import fix_entity_refs, strip_empty_enums
+from x.grocy_mcp.fix_openapi_spec import fix_created_object_id, fix_entity_refs, strip_empty_enums
 
 
 def test_strip_empty_enums_removes_empty_enum() -> None:
@@ -35,6 +35,66 @@ def test_fix_entity_refs_materializes_missing_schemas() -> None:
     assert schemas["ExposedEntity_NotIncludingNotListable"]["enum"] == ["locations", "products", "stock_log"]
     assert schemas["ExposedEntity_IncludingUserEntities"]["enum"] == ["locations", "products", "stock_log"]
     assert schemas["ExposedEntity_IncludingUserEntities_NotIncludingNotEditable"]["enum"] == ["locations", "products"]
+
+
+def test_fix_created_object_id_widens_integer_to_anyof() -> None:
+    spec: dict = {
+        "paths": {
+            "/objects/{entity}": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "created_object_id": {
+                                                "type": "integer",
+                                                "description": "The id of the created object",
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fix_created_object_id(spec)
+    field = spec["paths"]["/objects/{entity}"]["post"]["responses"]["200"]["content"]["application/json"]["schema"][
+        "properties"
+    ]["created_object_id"]
+    assert field == {"anyOf": [{"type": "integer"}, {"type": "string"}], "description": "The id of the created object"}
+
+
+def test_fix_created_object_id_noop_when_already_widened() -> None:
+    existing = {"anyOf": [{"type": "integer"}, {"type": "string"}], "description": "The id of the created object"}
+    spec: dict = {
+        "paths": {
+            "/objects/{entity}": {
+                "post": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "properties": {"created_object_id": existing}}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fix_created_object_id(spec)
+    # Should be unchanged — no "type": "integer" to replace.
+    field = spec["paths"]["/objects/{entity}"]["post"]["responses"]["200"]["content"]["application/json"]["schema"][
+        "properties"
+    ]["created_object_id"]
+    assert field == existing
 
 
 if __name__ == "__main__":

--- a/x/grocy_mcp/tool_metadata.py
+++ b/x/grocy_mcp/tool_metadata.py
@@ -135,7 +135,9 @@ TOOL_OVERRIDES: dict[tuple[str, str], ToolOverride] = {
     ("GET", "/userfields/{entity}/{objectId}"): _D("get_userfields"),
     ("PUT", "/userfields/{entity}/{objectId}"): _D("set_userfields"),
     # ── System ───────────────────────────────────────────────────────
-    ("GET", "/system/info"): _E("get_system_info", resource=True),
+    ("GET", "/system/info"): _E(
+        "get_system_info"
+    ),  # tool, not resource: claude.ai doesn't expose MCP resources to the AI
     ("GET", "/system/time"): _D("get_system_time"),
     ("GET", "/system/db-changed-time"): _E("get_db_changed_time"),
     ("GET", "/system/config"): _D("get_system_config"),

--- a/x/grocy_mcp/tool_metadata.py
+++ b/x/grocy_mcp/tool_metadata.py
@@ -33,13 +33,13 @@ _D = lambda name, **kw: ToolOverride(name, enabled=False, **kw)  # noqa: E731
 
 TOOL_OVERRIDES: dict[tuple[str, str], ToolOverride] = {
     # ── Generic entity CRUD ──────────────────────────────────────────
-    ("GET", "/objects/{entity}"): _E("list_entities"),
-    ("POST", "/objects/{entity}"): _E("create_entity"),
-    ("GET", "/objects/{entity}/{objectId}"): _E("get_entity"),
+    ("GET", "/objects/{entity}"): _D("list_entities"),  # replaced by batch list_entities
+    ("POST", "/objects/{entity}"): _D("create_entity"),  # replaced by batch create_entities
+    ("GET", "/objects/{entity}/{objectId}"): _D("get_entity"),  # replaced by batch get_entities
     ("PUT", "/objects/{entity}/{objectId}"): _E("update_entity"),
     ("DELETE", "/objects/{entity}/{objectId}"): _E("delete_entity"),
     # ── Stock overview ───────────────────────────────────────────────
-    ("GET", "/stock"): _E("list_stock"),
+    ("GET", "/stock"): _D("list_stock"),  # replaced by batch get_stock
     ("GET", "/stock/volatile"): _E(
         "list_volatile_stock", "Returns products that are due soon, overdue, expired, or below min stock."
     ),
@@ -49,12 +49,10 @@ TOOL_OVERRIDES: dict[tuple[str, str], ToolOverride] = {
     ("GET", "/stock/entry/{entryId}/printlabel"): _D("print_stock_entry_label"),
     # ── Product stock operations (by ID) ─────────────────────────────
     ("GET", "/stock/products/{productId}"): _E("get_product_stock"),
-    ("POST", "/stock/products/{productId}/add"): _E("add_product_stock"),
-    ("POST", "/stock/products/{productId}/consume"): _E("consume_product_stock"),
+    ("POST", "/stock/products/{productId}/add"): _D("add_product_stock"),  # replaced by batch add_stock
+    ("POST", "/stock/products/{productId}/consume"): _D("consume_product_stock"),  # replaced by batch consume_stock
     ("POST", "/stock/products/{productId}/transfer"): _E("transfer_product_stock"),
-    ("POST", "/stock/products/{productId}/inventory"): _E(
-        "inventory_product", "Set absolute stock amount — Grocy adds or removes to reach the target."
-    ),
+    ("POST", "/stock/products/{productId}/inventory"): _D("inventory_product"),  # replaced by batch inventory_products
     ("POST", "/stock/products/{productId}/open"): _E("open_product_stock"),
     ("GET", "/stock/products/{productId}/entries"): _E("list_product_stock_entries"),
     ("GET", "/stock/products/{productId}/locations"): _E("list_product_locations"),

--- a/x/grocy_mcp/tool_metadata.py
+++ b/x/grocy_mcp/tool_metadata.py
@@ -33,13 +33,12 @@ _D = lambda name, **kw: ToolOverride(name, enabled=False, **kw)  # noqa: E731
 
 TOOL_OVERRIDES: dict[tuple[str, str], ToolOverride] = {
     # ── Generic entity CRUD ──────────────────────────────────────────
-    ("GET", "/objects/{entity}"): _D("list_entities"),  # replaced by batch list_entities
-    ("POST", "/objects/{entity}"): _D("create_entity"),  # replaced by batch create_entities
-    ("GET", "/objects/{entity}/{objectId}"): _D("get_entity"),  # replaced by batch get_entities
+    # GET /objects/{entity}, POST /objects/{entity}, GET /objects/{entity}/{objectId}
+    # and GET /stock are stripped from the OpenAPI spec by fix_openapi_spec.py;
+    # they are replaced by batch tools in batch_tools.py.
     ("PUT", "/objects/{entity}/{objectId}"): _E("update_entity"),
     ("DELETE", "/objects/{entity}/{objectId}"): _E("delete_entity"),
     # ── Stock overview ───────────────────────────────────────────────
-    ("GET", "/stock"): _D("list_stock"),  # replaced by batch get_stock
     ("GET", "/stock/volatile"): _E(
         "list_volatile_stock", "Returns products that are due soon, overdue, expired, or below min stock."
     ),
@@ -49,10 +48,9 @@ TOOL_OVERRIDES: dict[tuple[str, str], ToolOverride] = {
     ("GET", "/stock/entry/{entryId}/printlabel"): _D("print_stock_entry_label"),
     # ── Product stock operations (by ID) ─────────────────────────────
     ("GET", "/stock/products/{productId}"): _E("get_product_stock"),
-    ("POST", "/stock/products/{productId}/add"): _D("add_product_stock"),  # replaced by batch add_stock
-    ("POST", "/stock/products/{productId}/consume"): _D("consume_product_stock"),  # replaced by batch consume_stock
+    # POST /stock/products/{productId}/add, /consume, /inventory stripped from
+    # OpenAPI spec; replaced by batch add_stock, consume_stock, inventory_products.
     ("POST", "/stock/products/{productId}/transfer"): _E("transfer_product_stock"),
-    ("POST", "/stock/products/{productId}/inventory"): _D("inventory_product"),  # replaced by batch inventory_products
     ("POST", "/stock/products/{productId}/open"): _E("open_product_stock"),
     ("GET", "/stock/products/{productId}/entries"): _E("list_product_stock_entries"),
     ("GET", "/stock/products/{productId}/locations"): _E("list_product_locations"),


### PR DESCRIPTION
## Summary

Introduces custom batch tools to replace single-shot OpenAPI-generated tools, enabling efficient concurrent multi-item operations via `asyncio.gather`. Each batch tool collects results without fail-fast semantics—failed items are returned with `ok=False` while others continue.

## Key Changes

- **New `batch_tools.py` module** with 7 custom batch tools:
  - `create_entities`: Create N entities of any type concurrently
  - `list_entities`: Fetch N entity types in parallel
  - `get_entities`: Fetch N objects of one type by ID
  - `get_stock`: Stock list with optional quantity-unit and location enrichment
  - `add_stock`, `consume_stock`, `inventory_products`: Batch stock operations returning `transaction_id` and `new_amount` per item

- **OpenAPI spec filtering** (`fix_openapi_spec.py`):
  - Added `strip_replaced_routes()` to remove routes replaced by batch tools from the spec
  - Prevents FastMCP from generating competing single-item tool stubs
  - Strips: `GET/POST /objects/{entity}`, `GET /objects/{entity}/{objectId}`, `GET /stock`, and stock operation routes

- **Tool metadata updates** (`tool_metadata.py`):
  - Removed overrides for routes now handled by batch tools
  - Added comments explaining the replacement strategy

- **End-to-end test rewrite** (`test_e2e.py`):
  - Migrated from direct MCP server calls to full MCP protocol via `fastmcp.Client` with `FastMCPTransport`
  - Ensures output schema validation and error propagation match real MCP clients (e.g., Claude)
  - Tests complete inventory bootstrap workflow: create → add → get enriched → consume → inventory
  - Validates batch tool results with structured content assertions

- **Build system updates** (`BUILD.bazel`):
  - Added `batch_tools` library target
  - Converted `test_dump_tool.py` to `dump_tools.py` binary for dev use
  - Updated test dependencies to use `pytest_asyncio` instead of `mcp` package

- **Documentation** (`README.md`):
  - Added note on MCP resources vs tools (claude.ai doesn't expose resources to AI)
  - Added batch tools reference table with tool names and descriptions
  - Clarified that stock operations return per-item `transaction_id` for undo

## Implementation Details

- Batch tools use `asyncio.gather()` with continue-and-collect semantics (never fail-fast)
- Stock operations fetch `new_amount` via an extra `GET /stock/products/{id}` per item after the operation
- `get_stock` enrichment fetches quantity_units and locations in parallel with the main stock request, then joins by ID in Python
- All result types use discriminated unions (`kind: "ok" | "error"`) for unambiguous error handling
- Test fixture creates a fresh `httpx.AsyncClient` per test to avoid event loop closure issues with session-scoped clients

https://claude.ai/code/session_01QxnUJnGahXvfbY5GCmXqFG