### PR TITLE
Document pin drift issue and fix nix profile install on persistent rootfs

### DIFF
--- a/devinfra/claude/AGENTS.md
+++ b/devinfra/claude/AGENTS.md
@@ -25,8 +25,12 @@ The `bb` CLI is open source at <https://github.com/buildbuddy-io/buildbuddy>. Re
 ## Container Lifecycle — Reverse-Engineered Source
 
 Anthropic's `environment-manager` binary (Go, garble-obfuscated) is partially
-reverse-engineered under <web_env/re/environment_manager/>. **Read this before
-speculating about when/how session-start-adjacent things fire.** Specifically:
+reverse-engineered under <web_env/re/environment_manager/>. **The RE is
+incomplete and may be wrong in places — treat it as a starting point, not
+ground truth.** When running inside a Claude Code web session you can pull
+the live binary from the container and cross-check it against the committed
+RE (or update the RE if it's drifted). Read this before speculating about
+when/how session-start-adjacent things fire. Specifically:
 
 - **Which hook points fire on which session modes** (`new` / `resume` /
   `resume-cached` / `setup-only`): see
@@ -43,7 +47,9 @@ speculating about when/how session-start-adjacent things fire.** Specifically:
 If something in the lifecycle is unclear, grep
 `devinfra/claude/web_env/re/environment_manager/src/` for the function name
 or error string before opening an issue — there's likely already a decompiled
-source file with line-annotated binary offsets.
+source file with line-annotated binary offsets. If the RE looks wrong or
+stale, pull the live binary from the web container and verify against it
+before assuming the RE is authoritative.
 
 ## Debugging Commands
 

--- a/devinfra/claude/AGENTS.md
+++ b/devinfra/claude/AGENTS.md
@@ -16,9 +16,34 @@ The `bb` CLI is open source at <https://github.com/buildbuddy-io/buildbuddy>. Re
 ## Agent Instructions
 
 - **Hook daemon logs** (includes session start): `~/.claude/session-env/<session_id>/hook-daemon/daemon.log`
+- **Hook daemon stderr log** (unhandled exceptions / tracebacks — check this first for SessionStart crashes): `~/.claude/session-env/<session_id>/hook-daemon/daemon.err.log`
+- **Hook daemon startup failure marker** (written when the dispatcher couldn't reach the daemon at all): `~/.claude/session-env/<session_id>/hook-daemon/startup_failure.json`
 - **Supervisor logs**: `~/.claude/session-env/<session_id>/supervisor/supervisord.log` (supervisor daemon, used for container runtime)
 - **Platform detection**: Claude Code web runs on Firecracker microVMs (ext4 root, real Linux kernel). The session start hook detects the platform at runtime via `platform_detect.py`. See <web_env/docs/container_spec.md> for specs and IO benchmarks.
 - **Supervisor uses TCP**: `127.0.0.1:19001` instead of Unix socket (historical: 9p hard link issues on gVisor, kept for compatibility).
+
+## Container Lifecycle — Reverse-Engineered Source
+
+Anthropic's `environment-manager` binary (Go, garble-obfuscated) is partially
+reverse-engineered under <web_env/re/environment_manager/>. **Read this before
+speculating about when/how session-start-adjacent things fire.** Specifically:
+
+- **Which hook points fire on which session modes** (`new` / `resume` /
+  `resume-cached` / `setup-only`): see
+  <web_env/re/environment_manager/src/internal/envtype/anthropic/anthropic.go>
+  `Initialize()`. Step 1 (install languages) and Step 2 (clone sources) are
+  gated on `isNewOrSetup`. **Steps 3–6 run on every session** — including
+  Step 3 (`runInitScript`, i.e. our `web_setup.sh`) and Step 4
+  (`claude --init-only` which fires SessionStart hooks).
+- **`process_api` (PID 1) lifecycle**, WebSocket ports, orphan monitor, OOM killers:
+  <web_env/re/process_api/README.md>.
+- **CLI flags and env vars** that tune the above:
+  <web_env/re/SETUP_FLAGS_INVENTORY.md>.
+
+If something in the lifecycle is unclear, grep
+`devinfra/claude/web_env/re/environment_manager/src/` for the function name
+or error string before opening an issue — there's likely already a decompiled
+source file with line-annotated binary offsets.
 
 ## Debugging Commands
 
@@ -26,9 +51,22 @@ The `bb` CLI is open source at <https://github.com/buildbuddy-io/buildbuddy>. Re
 # Check hook daemon log (includes session start output)
 tail -100 "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/hook-daemon/daemon.log"
 
+# Check hook daemon stderr (tracebacks from unhandled exceptions in handlers)
+tail -100 "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/hook-daemon/daemon.err.log"
+
 # Check session bazelrc
 cat "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/bazelrc"
 
 # Check supervisor status (container runtime only)
 python -m supervisor.supervisorctl -c "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/supervisor/supervisord.conf" status
+
+# Check installed claude-hooks vs the pin in the working tree — catches
+# "container reuse froze the wheel at an old pin" situations on Firecracker.
+readlink /nix/var/nix/profiles/default/bin/claude-hook
+python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
 ```
+
+If these disagree on the claude-hooks commit sha, the installed wheel has
+drifted behind the pin — re-run `bash devinfra/claude/web_setup.sh` to pull
+forward. See <docs/web-setup-debug.md> "Pin drift on persistent rootfs" for
+the underlying cause.

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -200,9 +200,72 @@ curl -fsSL https://raw.githubusercontent.com/agentydragon/ducktape/680d78946bf72
 
 ## Container Environment (from RE docs)
 
-- Ubuntu 24.04 on gVisor (runsc)
+- Ubuntu 24.04 on gVisor (runsc) or Firecracker microVM (current production)
 - Egress proxy: TLS-inspecting, JWT auth in `HTTPS_PROXY` URL
 - Proxy CA at `/usr/local/share/ca-certificates/swp-ca-production.crt`
-- No open-sourced environment-manager or process_api binaries
-- Setup scripts run before Claude Code, as root, on new sessions only
+- `environment-manager` and `process_api` binaries have been reverse-engineered —
+  see <../web_env/re/environment_manager/README.md> and <../web_env/re/process_api/README.md>
+- **Setup scripts run before Claude Code, as root, on EVERY session** — not just
+  new sessions. `environment-manager`'s `Initialize` calls `runInitScript`
+  unconditionally (Step 3), regardless of session mode (`new` / `resume` /
+  `resume-cached` / `setup-only`). Steps 1 (install languages) and 2 (clone
+  sources) _are_ gated on `isNewOrSetup`, which is probably where the "new
+  sessions only" misconception came from. Verified in
+  <../web_env/re/environment_manager/src/internal/envtype/anthropic/anthropic.go>
+  Initialize(), line ~361.
 - See <../web_env/re/SETUP_FLAGS_INVENTORY.md> for full binary RE docs
+
+## Pin drift on persistent rootfs — 2026-04-14
+
+**Symptom**: agent session's SessionStart crashes during Mako template render
+with `'Undefined' object has no attribute 'kubeconfig_path'`. Alternatively:
+profile YAML fields silently no-op (e.g., `startup_env_script` ignored, secrets
+never decrypted). Container has been up for 2+ days; the install commit of
+`claude-hooks` is behind the current `npins/sources.json` pin.
+
+**Root cause**: `nix profile install "${FLAKE}#devtools"` is a no-op when the
+attrpath is already in the profile — it matches by attrpath, not by evaluated
+store hash. Firecracker microVMs persist the rootfs across sessions, and
+`environment-manager` re-runs `init_script` on every session, so `web_setup.sh`
+is called over and over — but each call hits the already-installed `devtools`
+and skips. The nix store path for `claude-hooks` freezes at whatever pin was
+current on container first-boot.
+
+Meanwhile the working tree is `git pull`'d fresh on every session (by
+environment-manager's source-handler in Step 2 for new sessions, or by our own
+git usage during the session), so `profile.yaml`, `context.mako`, and other
+repo files advance past what the installed `claude-hooks` wheel knows how to
+parse / render. The next schema-breaking change causes a silent field drop
+(Pydantic `extra="ignore"` default) or a loud template crash.
+
+**Fix**: `web_setup.sh` now runs `nix profile remove devtools || true` before
+`nix profile install`, forcing re-evaluation of `.#devtools` against the
+current flake on every session. The remove+install pair is idempotent and
+cheap (~1-2s steady state) because nix substitutes all closure paths from
+cache when the pin hasn't actually moved.
+
+**How to diagnose future occurrences**:
+
+```bash
+# Compare installed vs pinned claude-hooks commit
+readlink /nix/var/nix/profiles/default/bin/claude-hook  # → /nix/store/<hash>-claude-hooks-<ver>/bin/claude-hook
+# Then match <hash> against `git log --all --oneline` of claude-hooks source commits,
+# or check `devinfra/_build_status.txt` bundled inside the wheel if present.
+
+# Check the daemon error log for Mako/pydantic complaints
+tail -100 ~/.claude/session-env/*/hook-daemon/daemon.err.log
+
+# Check what npins says is current
+python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
+```
+
+**Lessons**:
+
+- `nix profile install` is "add if missing" not "install-or-upgrade". Always
+  pair with `nix profile remove` (or `nix profile upgrade`) on persistent
+  rootfs where the install script re-runs.
+- When schema-level changes land in a `claude-hooks` profile YAML or Mako
+  template, they will silently break agent sessions until the next container
+  rebuild unless the install script actually pulls forward the wheel.
+- Pydantic `extra="ignore"` (default) silently drops unknown fields. Consider
+  `extra="forbid"` on config models to turn silent drops into loud crashes.

--- a/devinfra/claude/hook_daemon/docs/session_start_recovery.md
+++ b/devinfra/claude/hook_daemon/docs/session_start_recovery.md
@@ -131,3 +131,52 @@ bazelisk info  # should show output_base
 
 **Do NOT** bypass certificate/proxy errors with `--noverify`, `SSL_VERIFY=false`, etc. The
 root cause is always a missing/broken session start hook. Notify the user.
+
+## Failure mode: installed wheel drifted behind the pin
+
+**Symptom**: SessionStart returns 500, and `daemon.err.log` contains one of:
+
+- `AttributeError: 'Undefined' object has no attribute '<field>'` from a Mako template render
+- `TypeError: <handler> got an unexpected keyword argument '<field>'`
+- Silently missing env vars (`BUILDBUDDY_API_KEY`, `GITHUB_TOKEN`, `KUBECONFIG`)
+  because a new `profile.yaml` field was silently dropped by Pydantic
+
+**Root cause**: the installed `claude-hooks` wheel was pinned on container
+first-boot and has never been refreshed. Meanwhile the working tree has moved
+forward and introduced schema-level changes in `profile.yaml` / `context.mako`
+/ `config.py` that the old wheel doesn't understand.
+
+This is structural — see <../../docs/web-setup-debug.md> "Pin drift on
+persistent rootfs". The short version: Firecracker rootfs is persistent, and
+`environment-manager`'s `Initialize` re-runs `init_script` (web_setup.sh) on
+every session, but `nix profile install` is a no-op if the attrpath is already
+in the profile, so without an explicit `nix profile remove` the version
+freezes at first-boot.
+
+**Diagnose**:
+
+```bash
+# 1. Confirm wheel drift
+readlink /nix/var/nix/profiles/default/bin/claude-hook
+python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
+# The hash on the readlink line and the commit SHA in the URL should match.
+
+# 2. Confirm the specific crash
+tail -100 ~/.claude/session-env/*/hook-daemon/daemon.err.log
+```
+
+**Recover**:
+
+```bash
+# Re-run web_setup.sh — this now does `nix profile remove devtools` first,
+# so it actually pulls forward to the current pin.
+bash devinfra/claude/web_setup.sh
+
+# Then re-trigger SessionStart using the Step 2 recipe above (or just start
+# a fresh session — the new wheel will be picked up automatically).
+```
+
+If the container is from before the `web_setup.sh` fix landed (pre-commit on
+devel adding `nix profile remove` before `install`), the re-run from a stale
+container will itself be stale. In that case you need a fresh container from
+the Claude Code web UI.

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -97,6 +97,22 @@ echo "  flake.nix exists: $(test -f flake.nix && echo yes || echo no)"
 echo "  ls pwd:"
 ls -la
 # Pass --max-jobs explicitly to override any nix.conf misconfiguration.
+#
+# CRITICAL: `nix profile install` is a no-op when the attribute path is already
+# in the profile — it matches by attrpath, not by evaluated store hash. On
+# persistent Firecracker rootfs `web_setup.sh` re-runs on every session
+# (environment-manager's `Initialize` fires `init_script` unconditionally —
+# verified in <devinfra/claude/web_env/re/environment_manager/src/internal/envtype/anthropic/anthropic.go>
+# Initialize(), Step 3 at line ~361 is not gated on session mode). Without an
+# explicit remove, the installed devtools derivation freezes at whatever pin
+# was current on container first-boot, even though `npins/sources.json` in
+# the working tree has moved forward. The downstream symptom is agent sessions
+# running a stale `claude-hooks` wheel against fresh profile YAML / Mako
+# templates, which crashes SessionStart as soon as the schema churns. Remove
+# first so `install` re-evaluates `.#devtools` against the current flake.
+#
+# See <devinfra/claude/docs/web-setup-debug.md> ("Pin drift on persistent rootfs").
+nix profile remove devtools 2>/dev/null || true
 nix profile install --max-jobs auto "${FLAKE}#devtools"
 echo "[$(date -Iseconds)] Dev tools installed."
 

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -57,6 +57,33 @@ approval:
 - Creating a `bazel` wrapper in the session bin that injects `--bazelrc`
   when the session bazelrc exists but the shim is missing
 
+## Log file inventory
+
+When diagnosing a broken session, these are the log files worth reading, in
+order of "most likely to contain the smoking gun":
+
+| Path                                                           | What's in it                                                                                                                                                                      |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/.claude/session-env/<sid>/hook-daemon/daemon.err.log`       | **Unhandled exceptions / tracebacks from hook handlers** — check first.                                                                                                           |
+| `~/.claude/session-env/<sid>/hook-daemon/daemon.log`           | Structured daemon log: session start output, per-hook request logs.                                                                                                               |
+| `~/.claude/session-env/<sid>/hook-daemon/startup_failure.json` | Written when the `claude-hook` client could not reach/start the daemon. Distinguishes "dispatcher timed out waiting for socket" from "daemon crashed after accepting connection". |
+| `~/.claude/session-env/<sid>/sessionstart-hook-0.sh`           | The env file the daemon wrote. Presence with the `CANARY` marker = SessionStart got far enough to write it.                                                                       |
+| `~/.claude/session-env/<sid>/supervisor/supervisord.log`       | Supervisor daemon log (only populated when the container-runtime profile is in use).                                                                                              |
+| `/tmp/web-setup.log`                                           | `web_setup.sh` output from the most recent run. First line has `web_setup.sh commit: <sha>` — use it to detect stale setup scripts.                                               |
+
+`<sid>` can be resolved with:
+
+```bash
+LIVE=$(ps aux | grep hook_daemon | grep -v grep | grep -oP '(?<=--sock /tmp/claude-hd/)[^/]+')
+echo "$LIVE"
+```
+
+or from `$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR` (the basename).
+
+Agent discipline: when a check below fails, dump the relevant log section
+verbatim into the report's "Issues & remediation" block. Do not paraphrase
+tracebacks — the exact text is what the user needs to correlate with git log.
+
 ## SPEC acceptance checks
 
 Each check below corresponds one-to-one with a numbered criterion in
@@ -276,6 +303,16 @@ docker info >/dev/null 2>&1 && echo OK || echo FAIL
 These are not in SPEC.md but catch real-world failure modes. Include them
 in the report under a separate "Diagnostics" heading.
 
+**Before running D1/D2**, skim <../../devinfra/claude/docs/web-setup-debug.md>
+— it documents the historical failure modes (SHA-pinned setup URLs, gVisor
+`max-jobs=0`, the Firecracker "pin drift on persistent rootfs" class, the
+Nix 2.34.3 SIGABRT masking issue) and is the authoritative reference for
+how `web_setup.sh` is supposed to behave. In particular, the
+**"Pin drift on persistent rootfs"** section explains why a container
+running for more than a day or two can silently have a stale `claude-hooks`
+wheel even though `web_setup.sh` re-runs every session, and gives the
+`readlink /nix/var/nix/profiles/default/bin/claude-hook` diagnostic below.
+
 ### D1 — `web_setup.sh` freshness (web only)
 
 Anthropic reuses Firecracker microVMs; `/tmp/web-setup.log` may be from a
@@ -293,10 +330,23 @@ HEAD_COMMIT=$(git -C /home/user/ducktape rev-parse HEAD)
 ### D2 — `claude-hooks` daemon pin staleness
 
 A stale installed daemon is often the root cause of session hook failures.
-Check the pinned commit against HEAD, and check whether release CI is
-passing so that the pin would move if you waited.
+There are **two** independent kinds of staleness to check:
+
+**(a) Pin in `npins/sources.json` is behind HEAD** — sync-pins.yml didn't
+run recently, or release.yml is failing. The repo itself is out of date.
+
+**(b) Installed wheel is behind the pin** — on Firecracker web sessions
+with a persistent rootfs, `nix profile install` is a no-op when devtools
+is already installed, so the on-disk wheel can freeze at first-boot even
+though `npins/sources.json` has moved forward. This is the class of
+failure described in <../../devinfra/claude/docs/web-setup-debug.md>
+"Pin drift on persistent rootfs". Typical symptom: SessionStart crashes
+with `'Undefined' object has no attribute '<field>'` in `daemon.err.log`,
+or silently missing env vars because a new `profile.yaml` field was
+dropped by Pydantic.
 
 ```bash
+# (a) Pin in npins vs HEAD
 python3 -c "
 import json, re
 pins = json.load(open('/home/user/ducktape/npins/sources.json'))['pins']
@@ -305,12 +355,23 @@ m = re.search(r'claude-hooks-([0-9a-f]+)', url)
 print('pinned:', m.group(1) if m else 'unknown')
 "
 git -C /home/user/ducktape log --oneline -5 -- devinfra/claude/ npins/sources.json
+
+# (b) Installed wheel vs pin
+INSTALLED=$(readlink /nix/var/nix/profiles/default/bin/claude-hook 2>/dev/null)
+echo "installed: $INSTALLED"  # /nix/store/<hash>-claude-hooks-<ver>/bin/claude-hook
+# Check daemon.err.log for template/schema crashes that indicate drift
+tail -50 ~/.claude/session-env/*/hook-daemon/daemon.err.log 2>/dev/null
 ```
 
-If the pin is behind HEAD, diff the installed Nix store package against
-the repo source for breaking changes (renamed classes, changed config
-paths, removed hooks). Check GitHub CI on `agentydragon/ducktape`:
+If (a) the pin is behind HEAD, diff the installed Nix store package
+against the repo source for breaking changes (renamed classes, changed
+config paths, removed hooks). Check GitHub CI on `agentydragon/ducktape`:
 recent `release.yml` and `sync-pins.yml` runs on `devel`.
+
+If (b) the installed wheel is behind the pin, the remediation is to
+re-run `bash devinfra/claude/web_setup.sh` — but do **not** do this
+unprompted per the "observe only" rule above. Report the drift in the
+Issues section with exact commit SHAs and let the user decide.
 
 ### D3 — `git remote origin` URL reachability (web only)
 


### PR DESCRIPTION
## Summary

This PR documents a critical issue where `claude-hooks` wheels become stale on persistent Firecracker rootfs containers, and implements a fix in `web_setup.sh` to prevent it. The issue occurs because `nix profile install` is a no-op when an attribute path is already in the profile, causing the installed wheel to freeze at first-boot even as the working tree advances.

## Key Changes

- **Fixed `web_setup.sh`**: Added `nix profile remove devtools` before `nix profile install` to force re-evaluation of the devtools derivation against the current flake on every session, preventing wheel staleness on persistent rootfs.

- **Documented pin drift failure mode**: Added comprehensive documentation in `web-setup-debug.md` explaining:
  - Root cause: `nix profile install` matches by attrpath, not store hash
  - Why it happens: `environment-manager` re-runs `init_script` on every session on persistent Firecracker rootfs
  - Symptoms: Mako template crashes (`'Undefined' object has no attribute`), silently dropped Pydantic fields
  - Diagnosis and recovery procedures

- **Enhanced agent debugging guides**:
  - Updated `AGENTS.md` with reverse-engineered `environment-manager` lifecycle details
  - Added debugging commands to detect wheel drift by comparing installed vs pinned commits
  - Clarified that Steps 3–6 of `environment-manager.Initialize()` run on every session, not just new sessions

- **Improved web_selfcheck diagnostics**:
  - Added "Log file inventory" section documenting all relevant log paths and their purposes
  - Expanded D2 diagnostic to distinguish two types of staleness: (a) pin behind HEAD vs (b) installed wheel behind pin
  - Added specific commands to detect and diagnose wheel drift
  - Documented the "Pin drift on persistent rootfs" failure mode in session_start_recovery.md

## Implementation Details

The fix is minimal and idempotent: `nix profile remove devtools || true` paired with `nix profile install` ensures the derivation is re-evaluated on every session. The remove+install pair is cheap (~1-2s) when the pin hasn't moved because nix substitutes all closure paths from cache.

The documentation emphasizes that this is a structural issue with how Firecracker containers persist rootfs across sessions combined with how `nix profile` works, and provides clear diagnostic procedures for detecting future occurrences.

https://claude.ai/code/session_01BFc6QxUXnEdyNZJU1XDswV