### PR TITLE
Add kubectl-sandbox-mcp OAuth2 server with kube-apiserver integration

### DIFF
--- a/cluster/k8s/agents/claude-rbac/rolebinding-authentik-mcp-poc-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-authentik-mcp-poc-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-harbor-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-harbor-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-langfuse-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-langfuse-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: claude-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-ollama-consumer.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-ollama-consumer.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-ollama-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-ollama-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: claude-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-openclaw-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-openclaw-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/claude-rbac/rolebinding-sandbox.yaml
+++ b/cluster/k8s/agents/claude-rbac/rolebinding-sandbox.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: claude-code-web
     namespace: default
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubectl-sandbox-mcp
+  namespace: kubectl-sandbox-mcp
+  annotations:
+    description: "containers/kubernetes-mcp-server in OAuth passthrough mode. Caller's Authentik JWT is forwarded directly to kube-apiserver; server itself is unprivileged."
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubectl-sandbox-mcp
+  template:
+    metadata:
+      labels:
+        app: kubectl-sandbox-mcp
+    spec:
+      serviceAccountName: kubectl-sandbox-mcp
+      # Prevent kubernetes-mcp-server from picking up KUBECTL_SANDBOX_MCP_* env vars
+      # injected by kube for same-namespace Services — they could confuse config parsing.
+      enableServiceLinks: false
+      containers:
+        - name: server
+          image: ghcr.io/containers/kubernetes-mcp-server:v0.0.60
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/kubectl-sandbox-mcp/config.toml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubectl-sandbox-mcp
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: config
+          secret:
+            secretName: kubectl-sandbox-mcp

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/flux-kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/flux-kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubectl-sandbox-mcp
+  namespace: flux-system
+spec:
+  suspend: false
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/agents/kubectl-sandbox-mcp/app
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: kubectl-sandbox-mcp
+      namespace: kubectl-sandbox-mcp
+  dependsOn:
+    - name: gateway
+    - name: kubectl-sandbox-mcp-namespace
+    # TF writes the kubectl-sandbox-mcp secret (with config.toml) into the namespace.
+    - name: agent-machine-access-tf

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/httproute.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/httproute.yaml
@@ -1,0 +1,22 @@
+# HTTPRoute for kubectl-sandbox-mcp.
+# NOT behind the Authentik outpost — the MCP server drives the full OAuth dance
+# (DCR, PKCE, resource metadata) internally using containers/kubernetes-mcp-server's
+# built-in OAuth2/OIDC support.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubectl-sandbox-mcp
+  namespace: kubectl-sandbox-mcp
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "kubectl-sandbox-mcp.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: kubectl-sandbox-mcp
+          port: 8080
+      timeouts:
+        request: "60s"
+        backendRequest: "60s"

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/service.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubectl-sandbox-mcp
+  namespace: kubectl-sandbox-mcp
+spec:
+  selector:
+    app: kubectl-sandbox-mcp
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  type: ClusterIP

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/app/serviceaccount.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/app/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-sandbox-mcp
+  namespace: kubectl-sandbox-mcp
+  annotations:
+    description: "Service account for kubectl-sandbox-mcp pod. No k8s permissions — server uses passthrough OAuth token for kube-apiserver calls."

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubectl-sandbox-mcp-namespace
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/agents/kubectl-sandbox-mcp/namespace
+  prune: false
+  wait: true

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/namespace.yaml
+++ b/cluster/k8s/agents/kubectl-sandbox-mcp/namespace/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubectl-sandbox-mcp
+  labels:
+    goldilocks.fairwinds.com/enabled: "false"

--- a/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
+++ b/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
@@ -23,3 +23,6 @@ spec:
     # TF writes the `grocy-mcp-oidc` secret into the `grocy-mcp-oidc`
     # namespace, so that namespace must exist first.
     - name: grocy-mcp-oidc-namespace
+    # TF writes the `kubectl-sandbox-mcp` secret into the `kubectl-sandbox-mcp`
+    # namespace, so that namespace must exist first.
+    - name: kubectl-sandbox-mcp-namespace

--- a/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -13,3 +13,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/shared-rbac/rolebinding-gatus-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-gatus-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -14,6 +14,9 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -31,6 +34,9 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -48,6 +54,9 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -65,6 +74,9 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -82,6 +94,9 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -99,3 +114,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/shared-rbac/rolebinding-props-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-props-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: default
     namespace: openclaw-sandbox
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -54,6 +54,8 @@ resources:
   - agents/grocy-mcp/flux-kustomization.yaml
   - agents/grocy-mcp-oidc/namespace/flux-kustomization.yaml
   - agents/grocy-mcp-oidc/app/flux-kustomization.yaml
+  - agents/kubectl-sandbox-mcp/namespace/flux-kustomization.yaml
+  - agents/kubectl-sandbox-mcp/app/flux-kustomization.yaml
   - agents/homeassistant-proxy/flux-kustomization.yaml
   - agents/openclaw/operator/flux-kustomization.yaml
   - agents/openclaw/gateway-namespace/flux-kustomization.yaml

--- a/cluster/terraform/gitops/agent-machine-access/main.tf
+++ b/cluster/terraform/gitops/agent-machine-access/main.tf
@@ -302,3 +302,101 @@ resource "kubernetes_secret" "grocy_mcp_oidc" {
     grocy_proxy_client_id = authentik_provider_proxy.grocy.client_id
   }
 }
+
+# ============================================================================
+# kubectl-sandbox-mcp — Sandbox kubectl MCP server with OIDC auth
+# ============================================================================
+# Users in kubectl-sandbox-users group can authenticate to the MCP server
+# and get kube-apiserver access scoped to claude-sandbox SA permissions.
+
+data "authentik_user" "agentydragon" {
+  username = "agentydragon"
+}
+
+resource "authentik_group" "kubectl_sandbox_users" {
+  name  = "kubectl-sandbox-users"
+  users = [data.authentik_user.agentydragon.id]
+}
+
+resource "authentik_provider_oauth2" "kubectl_sandbox_mcp" {
+  name               = "kubectl-sandbox-mcp"
+  client_id          = "kubectl-sandbox-mcp"
+  client_type        = "confidential"
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict"
+      # /oauth/callback is the hardcoded callback path in containers/kubernetes-mcp-server.
+      url = "https://kubectl-sandbox-mcp.allegedly.works/oauth/callback"
+    },
+  ]
+}
+
+resource "authentik_application" "kubectl_sandbox_mcp" {
+  name              = "kubectl-sandbox-mcp"
+  slug              = "kubectl-sandbox-mcp"
+  protocol_provider = authentik_provider_oauth2.kubectl_sandbox_mcp.id
+  meta_description  = "Sandbox kubectl MCP — cluster access scoped to claude-sandbox SA permissions"
+  meta_launch_url   = "https://kubectl-sandbox-mcp.allegedly.works"
+}
+
+resource "authentik_policy_binding" "kubectl_sandbox_mcp_users" {
+  target = authentik_application.kubectl_sandbox_mcp.uuid
+  group  = authentik_group.kubectl_sandbox_users.id
+  order  = 0
+}
+
+# K8s secret with complete config.toml for containers/kubernetes-mcp-server.
+# Includes sts_client_id/sts_client_secret used for the authorization-code
+# exchange with Authentik (confidential client leg). Namespace created by
+# kubectl-sandbox-mcp-namespace Flux Kustomization; agent-machine-access-tf
+# dependsOn that kustomization so TF runs after the namespace exists.
+resource "kubernetes_secret" "kubectl_sandbox_mcp" {
+  metadata {
+    name      = "kubectl-sandbox-mcp"
+    namespace = "kubectl-sandbox-mcp"
+  }
+
+  data = {
+    "config.toml" = <<-EOT
+      # OAuth is required — clients must authenticate via Authentik before calling tools.
+      require_oauth = true
+
+      # Authentik issuer URL for the kubectl-sandbox-mcp OAuth2 provider.
+      authorization_url = "https://auth.allegedly.works/application/o/kubectl-sandbox-mcp/"
+
+      # Audience must match what Authentik issues (client_id) and what kube-apiserver
+      # accepts (AuthenticationConfiguration audiences entry for kubectl-sandbox-mcp).
+      oauth_audience = "kubectl-sandbox-mcp"
+
+      # Confidential client credentials for the authorization-code exchange with Authentik.
+      sts_client_id     = "${authentik_provider_oauth2.kubectl_sandbox_mcp.client_id}"
+      sts_client_secret = "${authentik_provider_oauth2.kubectl_sandbox_mcp.client_secret}"
+
+      # passthrough: forward the caller's JWT directly to kube-apiserver. No token
+      # exchange needed because kube-apiserver is configured to accept this audience.
+      cluster_auth_mode = "passthrough"
+
+      # Use in-cluster service account discovery for the kube-apiserver endpoint.
+      cluster_provider_strategy = "in-cluster"
+
+      # Public base URL of this MCP server (for well-known OAuth metadata).
+      server_url = "https://kubectl-sandbox-mcp.allegedly.works"
+
+      # HTTP port
+      port = "8080"
+    EOT
+  }
+}

--- a/cluster/terraform/main/hetzner-nodes.tf
+++ b/cluster/terraform/main/hetzner-nodes.tf
@@ -142,6 +142,17 @@ locals {
           cloud-provider         = "external"
         }
       })
+      # Write AuthenticationConfiguration to the host filesystem so kube-apiserver
+      # can read it via the extraVolumes mount. CP nodes only — workers don't run kube-apiserver.
+      # permissions = 416 (= 0640 octal: owner rw, group r, world none)
+      files = [
+        {
+          content     = local.auth_config_content
+          path        = "/etc/kubernetes/auth/auth-config.yaml"
+          op          = "overwrite"
+          permissions = 416
+        }
+      ]
     })
     cluster = local.common_cluster_config
   })

--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -93,16 +93,53 @@ locals {
     }
   }
 
+  # AuthenticationConfiguration — supports multiple JWT issuers (headlamp + kubectl MCPs).
+  # Talos 1.12 has no dedicated authenticationConfig field (unlike authorizationConfig),
+  # so we write this file via machine.files and mount it into the kube-apiserver static pod.
+  auth_config_content = yamlencode({
+    apiVersion = "apiserver.config.k8s.io/v1beta1"
+    kind       = "AuthenticationConfiguration"
+    jwt = [
+      # Headlamp: existing single-user OIDC (migrated from --oidc-* flags)
+      {
+        issuer = {
+          url       = "https://auth.${var.cluster_domain}/application/o/headlamp/"
+          audiences = ["headlamp"]
+        }
+        claimMappings = {
+          username = { claim = "preferred_username", prefix = "oidc:" }
+          groups   = { claim = "groups", prefix = "oidc-groups:" }
+        }
+      },
+      # kubectl-sandbox-mcp: sandbox-scoped kubectl MCP server
+      {
+        issuer = {
+          url       = "https://auth.${var.cluster_domain}/application/o/kubectl-sandbox-mcp/"
+          audiences = ["kubectl-sandbox-mcp"]
+        }
+        claimMappings = {
+          username = { claim = "preferred_username", prefix = "oidc-ksbx:" }
+          groups   = { claim = "groups", prefix = "oidc-ksbx-groups:" }
+        }
+      },
+    ]
+  })
+
   # Shared kube-apiserver config for all control plane nodes (VPS + Proxmox).
   # Centralised here to avoid duplicating between hetzner-nodes.tf and proxmox-nodes.tf.
   api_server_config = {
     certSANs = ["api.${var.cluster_domain}"]
     extraArgs = {
-      "oidc-issuer-url"      = "https://auth.${var.cluster_domain}/application/o/headlamp/"
-      "oidc-client-id"       = "headlamp"
-      "oidc-username-claim"  = "preferred_username"
-      "oidc-username-prefix" = "oidc:"
+      # Structured auth replaces the old --oidc-* flags; supports multiple issuers.
+      "authentication-config" = "/etc/kubernetes/auth/auth-config.yaml"
     }
+    extraVolumes = [
+      {
+        hostPath  = "/etc/kubernetes/auth"
+        mountPath = "/etc/kubernetes/auth"
+        readonly  = true
+      }
+    ]
   }
 
   # Controlplane cluster config — includes etcd, apiServer, and inline

--- a/cluster/terraform/main/proxmox-nodes.tf
+++ b/cluster/terraform/main/proxmox-nodes.tf
@@ -174,6 +174,19 @@ locals {
     "csi.proxmox.sinextra.dev/max-volume-attachments" = "29"
   }
 
+  # AuthenticationConfiguration file for Proxmox CP nodes.
+  # Written to host filesystem; mounted into kube-apiserver via extraVolumes.
+  # CP nodes only — workers don't run kube-apiserver.
+  # permissions = 416 (= 0640 octal: owner rw, group r, world none)
+  proxmox_cp_auth_files = [
+    {
+      content     = local.auth_config_content
+      path        = "/etc/kubernetes/auth/auth-config.yaml"
+      op          = "overwrite"
+      permissions = 416
+    }
+  ]
+
 }
 
 data "talos_machine_configuration" "proxmox" {
@@ -213,6 +226,8 @@ data "talos_machine_configuration" "proxmox" {
             allowed-unsafe-sysctls = "net.ipv4.tcp_mtu_probing"
           }
         })
+        # Write AuthenticationConfiguration for CP nodes only (workers don't run kube-apiserver).
+        files = each.value.type == "controlplane" ? local.proxmox_cp_auth_files : []
       })
       })),
       # Explicit hostname — overrides HostnameConfig auto: stable (Talos v1.12+).


### PR DESCRIPTION
## Summary
This PR introduces a new kubectl Model Context Protocol (MCP) server that provides sandbox-scoped Kubernetes API access via OAuth2 authentication through Authentik. The server operates in passthrough mode, forwarding caller JWTs directly to kube-apiserver without token exchange.

## Key Changes

### Authentication Infrastructure
- **Authentik OAuth2 Provider**: Added `kubectl-sandbox-mcp` OAuth2 provider with confidential client configuration
- **User Group**: Created `kubectl-sandbox-users` group in Authentik with initial member `agentydragon`
- **kube-apiserver JWT Support**: Migrated from legacy `--oidc-*` flags to structured `AuthenticationConfiguration` supporting multiple JWT issuers (headlamp + kubectl-sandbox-mcp)
- **Talos Integration**: Added file provisioning to write `auth-config.yaml` to control plane nodes (both Hetzner and Proxmox) for kube-apiserver to consume

### kubectl-sandbox-mcp Deployment
- **Kubernetes Resources**: 
  - Namespace, ServiceAccount, Deployment, Service, and HTTPRoute for the MCP server
  - Deployment uses `ghcr.io/containers/kubernetes-mcp-server:v0.0.60` with OAuth passthrough mode
  - Server runs unprivileged with minimal resource requests (64Mi memory, 50m CPU)
- **Configuration**: Kubernetes secret containing `config.toml` with OAuth endpoints, audience, and cluster connectivity settings
- **Flux Integration**: Added Kustomizations for namespace and app deployment with proper dependency ordering

### RBAC Authorization
- **Group-based Access**: Added `oidc-ksbx-groups:kubectl-sandbox-users` group to multiple RoleBindings across:
  - Claude sandbox resources (logs, configmaps, langfuse, ollama, openclaw)
  - Shared resources (logs, configmaps, gatus, props, cluster diagnostics)
  - Claude RBAC resources (authentik-mcp-poc, harbor, ollama, openclaw, sandbox)
- This grants kubectl-sandbox-mcp users read access to sandbox resources and Claude infrastructure

## Implementation Details
- OAuth callback URL: `https://kubectl-sandbox-mcp.allegedly.works/oauth/callback`
- JWT audience: `kubectl-sandbox-mcp` (matches kube-apiserver AuthenticationConfiguration)
- Username prefix: `oidc-ksbx:` and group prefix: `oidc-ksbx-groups:` to distinguish from headlamp OIDC
- Server uses in-cluster service account discovery for kube-apiserver endpoint
- HTTPRoute not behind Authentik outpost—server drives full OAuth2/OIDC flow internally

https://claude.ai/code/session_01JuQqMjrz319WdLn8MzSwdb