### PR TITLE
fix(cluster): correct Talos extraVolumes readOnly key casing

### DIFF
--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -137,7 +137,7 @@ locals {
       {
         hostPath  = "/etc/kubernetes/auth"
         mountPath = "/etc/kubernetes/auth"
-        readonly  = true
+        readOnly  = true
       }
     ]
   }


### PR DESCRIPTION
Talos machine config uses camelCase (`readOnly`), not lowercase (`readonly`). The lowercase form is silently ignored by Talos config validation, which would prevent /etc/kubernetes/auth from being mounted into the kube-apiserver static pod and break the
AuthenticationConfiguration load entirely.

Flagged by copilot-pull-request-reviewer on #1304 (squash-merged before the comment was resolved).

https://claude.ai/code/session_01JuQqMjrz319WdLn8MzSwdb