### PR TITLE
Refactor shim wrappers to resolve claude-hook via PATH

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -72,13 +72,18 @@ The hook runs at the start of each Claude Code web session and:
 ### PATH Shims (via `hook_daemon/shim_install.py`)
 
 7. Bazelisk binary provided by Nix devShell (on PATH)
-8. Installs PATH shims at `<session_dir>/bin/{bazelisk,git,bazel,bb,bbr}` — thin
-   scripts that report to the hook daemon via `/shim-exec` RPC before exec'ing the
+8. Installs PATH shims at `<session_dir>/bin/{bazelisk,git,bazel,bb,bbr}` — two-line
+   shell scripts that `exec claude-hook shim <name>` (PATH-resolved at invocation
+   time), which reports to the hook daemon via `/shim-exec` RPC before exec'ing the
    real binary. The daemon handles proxy credential refresh, `--bazelrc` injection
    (bazelisk), and configurable git safety checks (blocking `git add -A`,
    `git stash`, `git commit --amend` — controlled by `git_shim` in profile config,
    enabled in CLI mode, disabled in web mode). `bazel`, `bb`, `bbr` shims are
    currently no-op passthrough.
+
+   Because `claude-hook` is resolved via PATH at exec time (not baked as a store
+   path at install time), `nix profile install` / `home-manager switch` takes
+   effect for all subsequent shim invocations without restarting the session.
 
 ### Git Hooks
 

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -197,8 +197,6 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//devinfra/claude:session_paths",
-        "//devinfra/claude:settings",
-        "//util/bazel:subprocess",
     ],
 )
 
@@ -228,6 +226,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":client",
+        ":shim_lib",
         "//devinfra/claude:session_paths",
         "//devinfra/claude/claude_api/hooks:dispatch_input",
         "@pypi//mako",

--- a/devinfra/claude/hook_daemon/hook_dispatch.py
+++ b/devinfra/claude/hook_daemon/hook_dispatch.py
@@ -17,6 +17,8 @@ from pydantic import TypeAdapter
 
 from devinfra.claude.claude_api.hooks.dispatch_input import AnyHookInput
 from devinfra.claude.hook_daemon.client import DaemonHttpError, DaemonStartError, call_daemon
+from devinfra.claude.hook_daemon.shim import run_shim
+from devinfra.claude.hook_daemon.shim_install import SHIM_SESSION_ID_ENV
 from devinfra.claude.session_paths import SessionPaths
 
 _adapter: TypeAdapter[AnyHookInput] = TypeAdapter(AnyHookInput)
@@ -47,6 +49,20 @@ def _log_event(direction: str, raw_json: str | None, *, hook_name: str = "", ses
 
 
 def main() -> None:
+    # Shim subcommand: `claude-hook shim <shim_name> [args...]`
+    # New-style shim wrappers exec into here instead of python -m shim,
+    # so the profile symlink resolves the interpreter at invocation time.
+    if len(sys.argv) > 2 and sys.argv[1] == "shim":
+        shim_name = sys.argv[2]
+        session_id = os.environ.get(SHIM_SESSION_ID_ENV)
+        if not session_id:
+            print(f"claude-hook shim: {SHIM_SESSION_ID_ENV} not set", file=sys.stderr)
+            sys.exit(1)
+        # Adjust argv so run_shim sees [shim_name, <original args>]
+        sys.argv = [shim_name, *sys.argv[3:]]
+        run_shim(shim_name, session_id)
+        return
+
     raw = sys.stdin.buffer.read()
     raw_str = raw.decode("utf-8", errors="replace")
 

--- a/devinfra/claude/hook_daemon/hook_dispatch.py
+++ b/devinfra/claude/hook_daemon/hook_dispatch.py
@@ -52,7 +52,10 @@ def main() -> None:
     # Shim subcommand: `claude-hook shim <shim_name> [args...]`
     # New-style shim wrappers exec into here instead of python -m shim,
     # so the profile symlink resolves the interpreter at invocation time.
-    if len(sys.argv) > 2 and sys.argv[1] == "shim":
+    if len(sys.argv) >= 2 and sys.argv[1] == "shim":
+        if len(sys.argv) < 3:
+            print("usage: claude-hook shim <shim-name> [args...]", file=sys.stderr)
+            sys.exit(1)
         shim_name = sys.argv[2]
         session_id = os.environ.get(SHIM_SESSION_ID_ENV)
         if not session_id:

--- a/devinfra/claude/hook_daemon/shim.py
+++ b/devinfra/claude/hook_daemon/shim.py
@@ -68,9 +68,9 @@ def _report_shim(shim: str, session_id: str, paths: SessionPaths) -> list[str]:
 def run_shim(shim_name: str, session_id: str) -> None:
     """Run the shim: report to daemon, resolve real binary, exec it.
 
-    sys.argv must be set to [shim_name, <original args...>] before calling.
-    Called from the `claude-hook shim` subcommand (new style) and from
-    main() for legacy python -m invocations.
+    Expects sys.argv[1:] to be the arguments for the real binary.
+    Both callers (hook_dispatch shim subcommand and legacy main()) normalize
+    sys.argv before calling here.
     """
     paths = SessionPaths.from_env(session_id, dict(os.environ))
     _setup_logging(shim_name, paths)
@@ -99,6 +99,10 @@ def main() -> None:
             f"Shim env vars not set ({SHIM_NAME_ENV}, {SHIM_SESSION_ID_ENV}) "
             f"— shim must be installed via shim_install.install()"
         )
+    # Normalize sys.argv so run_shim sees [shim_name, <original args>].
+    # In a python -m invocation sys.argv[0] is the module file path, not the
+    # shim name; replace it so argv[1:] is unambiguously the args to forward.
+    sys.argv = [shim_name, *sys.argv[1:]]
     run_shim(shim_name, session_id)
 
 

--- a/devinfra/claude/hook_daemon/shim.py
+++ b/devinfra/claude/hook_daemon/shim.py
@@ -3,8 +3,10 @@
 All shim-specific logic (git blocking, bazelisk --bazelrc injection) lives
 server-side. This is the shared runtime entrypoint for all PATH shims.
 
-The shim name and session ID are read from env vars baked into the shell
-wrapper at install time by shim_install.install().
+Invoked as `claude-hook shim <shim_name> [args...]` (new style, via the
+profile-symlink binary that auto-follows nix profile refreshes) or via
+`python -m devinfra.claude.hook_daemon.shim` with env vars (legacy style for
+old-format shim wrappers written before this change).
 """
 
 import logging
@@ -63,29 +65,41 @@ def _report_shim(shim: str, session_id: str, paths: SessionPaths) -> list[str]:
     return response.argv
 
 
-def main() -> None:
-    shim_name = os.environ.get(SHIM_NAME_ENV)
-    session_id = os.environ.get(SHIM_SESSION_ID_ENV)
-    session_dir_str = os.environ.get(ENV_SESSION_DIR)
-    if not shim_name or not session_id or not session_dir_str:
-        raise RuntimeError(
-            f"Shim env vars not set ({SHIM_NAME_ENV}, {SHIM_SESSION_ID_ENV}, {ENV_SESSION_DIR}) "
-            f"— shim must be installed via shim_install.install()"
-        )
+def run_shim(shim_name: str, session_id: str) -> None:
+    """Run the shim: report to daemon, resolve real binary, exec it.
 
+    sys.argv must be set to [shim_name, <original args...>] before calling.
+    Called from the `claude-hook shim` subcommand (new style) and from
+    main() for legacy python -m invocations.
+    """
     paths = SessionPaths.from_env(session_id, dict(os.environ))
     _setup_logging(shim_name, paths)
     log_entrypoint_debug(f"{shim_name}_shim")
 
     argv = _report_shim(shim_name, session_id, paths)
 
+    # Propagate session dir to subprocesses of the real binary (e.g. bazel_wrapper).
+    os.environ[ENV_SESSION_DIR] = str(paths.session_dir)
+
     try:
-        real = resolve_real_binary(shim_name)
+        real = resolve_real_binary(shim_name, paths.wrapper_dir)
     except FileNotFoundError:
         print(f"{shim_name}: command not found", file=sys.stderr)
         raise SystemExit(127)
     logger.info("Execing %s", real)
     os.execvp(real, [real, *argv[1:]])
+
+
+def main() -> None:
+    """Entry point for legacy python -m invocation (old-style shim wrappers)."""
+    shim_name = os.environ.get(SHIM_NAME_ENV)
+    session_id = os.environ.get(SHIM_SESSION_ID_ENV)
+    if not shim_name or not session_id:
+        raise RuntimeError(
+            f"Shim env vars not set ({SHIM_NAME_ENV}, {SHIM_SESSION_ID_ENV}) "
+            f"— shim must be installed via shim_install.install()"
+        )
+    run_shim(shim_name, session_id)
 
 
 if __name__ == "__main__":

--- a/devinfra/claude/hook_daemon/shim_install.py
+++ b/devinfra/claude/hook_daemon/shim_install.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 # Shim-internal env vars (baked into shell wrappers at install time).
 # Double-underscore prefix = private, not part of the public DUCKTAPE_CLAUDE_HOOKS_* namespace.
-SHIM_DIR_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_DIR"
 SHIM_NAME_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_NAME"
 SHIM_SESSION_ID_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_SESSION_ID"
 
@@ -39,17 +38,10 @@ def install(shim_name: str, paths: SessionPaths) -> Path:
     return shim_path
 
 
-def resolve_real_binary(binary_name: str, shim_dir: Path | None = None) -> str:
-    """Find the real binary on PATH, skipping the shim directory.
-
-    shim_dir: directory to exclude (the session wrapper_dir). When None, falls
-    back to the legacy SHIM_DIR_ENV env var set by old-style shim wrappers.
-    """
-    if shim_dir is None:
-        shim_dir_str = os.environ.get(SHIM_DIR_ENV, "")
-        shim_dir = Path(shim_dir_str) if shim_dir_str else None
+def resolve_real_binary(binary_name: str, shim_dir: Path) -> str:
+    """Find the real binary on PATH, excluding shim_dir (the session wrapper_dir)."""
     for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if shim_dir and Path(directory).resolve() == shim_dir.resolve():
+        if Path(directory).resolve() == shim_dir.resolve():
             continue
         candidate = Path(directory) / binary_name
         if candidate.is_file() and os.access(candidate, os.X_OK):

--- a/devinfra/claude/hook_daemon/shim_install.py
+++ b/devinfra/claude/hook_daemon/shim_install.py
@@ -2,11 +2,10 @@
 
 import logging
 import os
+import shlex
 from pathlib import Path
 
 from devinfra.claude.session_paths import SessionPaths
-from devinfra.claude.settings import ENV_SESSION_DIR
-from util.bazel.subprocess import write_shell_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +15,6 @@ SHIM_DIR_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_DIR"
 SHIM_NAME_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_NAME"
 SHIM_SESSION_ID_ENV = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_SESSION_ID"
 
-SHIM_MODULE = "devinfra.claude.hook_daemon.shim"
-
 
 def install(shim_name: str, paths: SessionPaths) -> Path:
     """Install a shell shim at paths.wrapper_dir/<shim_name>."""
@@ -26,23 +23,33 @@ def install(shim_name: str, paths: SessionPaths) -> Path:
 
     wrapper_dir.mkdir(parents=True, exist_ok=True)
 
-    baked_env: dict[str, str | Path] = {
-        ENV_SESSION_DIR: str(paths.session_dir),
-        SHIM_SESSION_ID_ENV: paths.session_id,
-        SHIM_NAME_ENV: shim_name,
-    }
-    extra_lines = f'export {SHIM_DIR_ENV}="$(cd "$(dirname "$0")" && pwd)"'
-    write_shell_wrapper(shim_path, SHIM_MODULE, baked_env=baked_env, extra_lines=extra_lines)
+    # `exec claude-hook` resolves via PATH at wrapper exec time, not at install
+    # time, so `nix profile install` (or home-manager switch) takes effect for
+    # all subsequent shim invocations without rewriting shims or restarting the
+    # session.  Only the session ID is baked in; everything else is derived.
+    content = (
+        "#!/bin/sh\n"
+        f"export {SHIM_SESSION_ID_ENV}={shlex.quote(paths.session_id)}\n"
+        f'exec claude-hook shim {shlex.quote(shim_name)} "$@"\n'
+    )
+    shim_path.write_text(content)
+    shim_path.chmod(0o755)
     logger.info("Installed %s shim at %s", shim_name, shim_path)
 
     return shim_path
 
 
-def resolve_real_binary(binary_name: str) -> str:
-    """Find the real binary on PATH, skipping the shim directory."""
-    shim_dir = os.environ.get(SHIM_DIR_ENV, "")
+def resolve_real_binary(binary_name: str, shim_dir: Path | None = None) -> str:
+    """Find the real binary on PATH, skipping the shim directory.
+
+    shim_dir: directory to exclude (the session wrapper_dir). When None, falls
+    back to the legacy SHIM_DIR_ENV env var set by old-style shim wrappers.
+    """
+    if shim_dir is None:
+        shim_dir_str = os.environ.get(SHIM_DIR_ENV, "")
+        shim_dir = Path(shim_dir_str) if shim_dir_str else None
     for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if shim_dir and Path(directory).resolve() == Path(shim_dir).resolve():
+        if shim_dir and Path(directory).resolve() == shim_dir.resolve():
             continue
         candidate = Path(directory) / binary_name
         if candidate.is_file() and os.access(candidate, os.X_OK):

--- a/devinfra/claude/hook_daemon/test_shim.py
+++ b/devinfra/claude/hook_daemon/test_shim.py
@@ -1,5 +1,6 @@
 """Tests for shim binary resolution."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -29,7 +30,7 @@ def test_resolve_real_binary_skips_shim_dir(monkeypatch: pytest.MonkeyPatch, tmp
         b.write_text("#!/bin/sh\n")
         b.chmod(0o755)
 
-    monkeypatch.setenv("PATH", f"{shim_dir}:{real_dir}")
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(real_dir)]))
 
     result = resolve_real_binary("bazelisk", shim_dir)
     assert result == str(real_dir / "bazelisk")

--- a/devinfra/claude/hook_daemon/test_shim.py
+++ b/devinfra/claude/hook_daemon/test_shim.py
@@ -1,5 +1,7 @@
 """Tests for shim binary resolution."""
 
+from pathlib import Path
+
 import pytest
 import pytest_bazel
 
@@ -13,6 +15,45 @@ def test_resolve_real_binary_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(FileNotFoundError, match="bazelisk"):
         resolve_real_binary("bazelisk")
+
+
+def test_resolve_real_binary_skips_shim_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """resolve_real_binary with shim_dir excludes that directory, finding binary elsewhere."""
+    shim_dir = tmp_path / "shims"
+    shim_dir.mkdir()
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+
+    # Place "bazelisk" in both dirs; shim_dir version should be skipped.
+    for d in (shim_dir, real_dir):
+        b = d / "bazelisk"
+        b.write_text("#!/bin/sh\n")
+        b.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{shim_dir}:{real_dir}")
+    monkeypatch.delenv(SHIM_DIR_ENV, raising=False)
+
+    result = resolve_real_binary("bazelisk", shim_dir=shim_dir)
+    assert result == str(real_dir / "bazelisk")
+
+
+def test_resolve_real_binary_shim_dir_env_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without shim_dir arg, SHIM_DIR_ENV env var is used as fallback (legacy shim wrappers)."""
+    shim_dir = tmp_path / "shims"
+    shim_dir.mkdir()
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+
+    for d in (shim_dir, real_dir):
+        b = d / "bazelisk"
+        b.write_text("#!/bin/sh\n")
+        b.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{shim_dir}:{real_dir}")
+    monkeypatch.setenv(SHIM_DIR_ENV, str(shim_dir))
+
+    result = resolve_real_binary("bazelisk")
+    assert result == str(real_dir / "bazelisk")
 
 
 if __name__ == "__main__":

--- a/devinfra/claude/hook_daemon/test_shim.py
+++ b/devinfra/claude/hook_daemon/test_shim.py
@@ -5,20 +5,19 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 
-from devinfra.claude.hook_daemon.shim_install import SHIM_DIR_ENV, resolve_real_binary
+from devinfra.claude.hook_daemon.shim_install import resolve_real_binary
 
 
-def test_resolve_real_binary_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_real_binary_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """When no binary is on PATH, raises FileNotFoundError."""
     monkeypatch.setenv("PATH", "/nonexistent")
-    monkeypatch.delenv(SHIM_DIR_ENV, raising=False)
 
     with pytest.raises(FileNotFoundError, match="bazelisk"):
-        resolve_real_binary("bazelisk")
+        resolve_real_binary("bazelisk", tmp_path)
 
 
 def test_resolve_real_binary_skips_shim_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """resolve_real_binary with shim_dir excludes that directory, finding binary elsewhere."""
+    """resolve_real_binary excludes shim_dir, finding the binary elsewhere on PATH."""
     shim_dir = tmp_path / "shims"
     shim_dir.mkdir()
     real_dir = tmp_path / "real"
@@ -31,28 +30,8 @@ def test_resolve_real_binary_skips_shim_dir(monkeypatch: pytest.MonkeyPatch, tmp
         b.chmod(0o755)
 
     monkeypatch.setenv("PATH", f"{shim_dir}:{real_dir}")
-    monkeypatch.delenv(SHIM_DIR_ENV, raising=False)
 
-    result = resolve_real_binary("bazelisk", shim_dir=shim_dir)
-    assert result == str(real_dir / "bazelisk")
-
-
-def test_resolve_real_binary_shim_dir_env_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Without shim_dir arg, SHIM_DIR_ENV env var is used as fallback (legacy shim wrappers)."""
-    shim_dir = tmp_path / "shims"
-    shim_dir.mkdir()
-    real_dir = tmp_path / "real"
-    real_dir.mkdir()
-
-    for d in (shim_dir, real_dir):
-        b = d / "bazelisk"
-        b.write_text("#!/bin/sh\n")
-        b.chmod(0o755)
-
-    monkeypatch.setenv("PATH", f"{shim_dir}:{real_dir}")
-    monkeypatch.setenv(SHIM_DIR_ENV, str(shim_dir))
-
-    result = resolve_real_binary("bazelisk")
+    result = resolve_real_binary("bazelisk", shim_dir)
     assert result == str(real_dir / "bazelisk")
 
 


### PR DESCRIPTION
## Summary
Refactor PATH shim installation to use simple shell scripts that exec `claude-hook shim` (resolved at invocation time) instead of baking Python module paths and environment variables into generated wrappers. This allows `nix profile install` and `home-manager switch` to take effect immediately without restarting the session or rewriting shims.

## Key Changes

- **shim_install.py**: Simplified wrapper generation from complex shell scripts with baked environment variables to minimal two-line scripts that `exec claude-hook shim <name>`. Only the session ID is baked in; the wrapper directory is now passed as an argument to `resolve_real_binary()`.

- **shim.py**: Extracted core shim execution logic into `run_shim()` function to support both legacy `python -m` invocations and new `claude-hook shim` subcommand invocations. The `main()` function now only handles the legacy entry point.

- **hook_dispatch.py**: Added `shim` subcommand handler that intercepts `claude-hook shim <name> [args...]` invocations, validates the session ID, and delegates to `run_shim()`.

- **resolve_real_binary()**: Changed signature to accept `shim_dir: Path` as an explicit parameter instead of reading from `SHIM_DIR_ENV`, making the function more testable and removing environment variable coupling.

- **Tests**: Updated `test_shim.py` to pass `shim_dir` explicitly and added test coverage for the shim directory exclusion logic.

- **Documentation**: Updated README to clarify the new two-line wrapper format and explain how PATH resolution enables seamless profile updates.

## Implementation Details

The refactoring maintains backward compatibility with legacy shim wrappers (via `python -m devinfra.claude.hook_daemon.shim`) while enabling new-style wrappers that resolve the `claude-hook` binary at invocation time. This decouples the shim wrapper from the Nix store path, allowing profile updates to take effect immediately for all subsequent invocations.

https://claude.ai/code/session_01XFkzbuDhTfv9QnvDLdgygz