### PR TITLE
hook daemon: gate OTEL bearer token fetch behind profile flag

### DIFF
--- a/devinfra/claude/TODO.md
+++ b/devinfra/claude/TODO.md
@@ -1,5 +1,33 @@
 # claude_hooks TODO
 
+## OTEL bearer token: mirror into SOPS
+
+**CLEANUP(2026-04-15)**: today `devinfra/secrets/web_env.sh` fetches
+`DUCKTAPE_OTEL_BEARER_TOKEN` from the `alloy-otlp-bearer-token` K8s Secret via
+`kubectl get secret`. On CCR v2 web sandboxes (and any env where the k8s API
+is unreachable) this blocks the daemon's `startup_env_script` for ~30s per
+retry and wedges session startup — so the call is now gated behind the
+`enable_k8s_otel_bearer_token` profile flag (off by default, see
+`ProfileConfig`).
+
+The real fix is to mirror the Authentik-generated token into a SOPS-encrypted
+file and `try_export` from it, matching the pattern used for every other
+secret. Sketch:
+
+1. Extend `cluster/terraform/gitops/alloy-otlp-bearer-token/` to also write
+   the token into `secrets/alloy-otlp-bearer-token.yaml` via `sops_file` or
+   an equivalent provider — re-encrypted for the `claude-web` age recipient
+   on every TF apply.
+2. Swap `web_env.sh`'s `try_export_from_k8s` call for a `try_export
+   "$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]'`.
+3. Delete the `enable_k8s_otel_bearer_token` flag on `ProfileConfig` and its
+   plumbing in `hook_daemon/main.py` + `web_env.sh`.
+
+Condition to remove this tombstone: the SOPS mirror exists and `web_env.sh`
+reads the token without touching kubectl.
+
+
+
 ## Nix Installation Timeout
 
 **Problem**: Installing nix on Claude Code web times out because downloading nixpkgs takes >2 minutes (session start hook timeout).

--- a/devinfra/claude/hook_daemon/config.py
+++ b/devinfra/claude/hook_daemon/config.py
@@ -140,6 +140,16 @@ class ProfileConfig(BaseModel):
         "New/changed vars are merged into os.environ before any session starts. "
         "Used by the web profile to decrypt SOPS secrets when SOPS_AGE_KEY is available.",
     )
+    enable_k8s_otel_bearer_token: bool = Field(
+        default=False,
+        description="If true, startup_env_script fetches DUCKTAPE_OTEL_BEARER_TOKEN from the "
+        "alloy-otlp-bearer-token Secret via kubectl. Default off because kubectl hangs for "
+        "~30s per call when the k8s API is unreachable (e.g. CCR v2 web sandboxes that can "
+        "only reach port 443), which wedges daemon startup. The flag is exported to the script "
+        "environment as DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN=1|0. "
+        "CLEANUP: remove once alloy-otlp-bearer-token is mirrored into SOPS — see "
+        "devinfra/claude/TODO.md.",
+    )
     context_template: str | None = Field(
         default=None, description="Repo-relative path to a Mako template rendered into the session context output."
     )

--- a/devinfra/claude/hook_daemon/main.py
+++ b/devinfra/claude/hook_daemon/main.py
@@ -19,7 +19,7 @@ from devinfra.claude.settings import HookSettings
 logger = logging.getLogger(__name__)
 
 
-def _source_env_script(script_path: Path) -> StartupResult:
+def _source_env_script(script_path: Path, extra_env: dict[str, str] | None = None) -> StartupResult:
     """Run a startup env script and collect env var patches without mutating os.environ.
 
     The script must print `export VAR=value` lines to stdout (as try_export does).
@@ -27,6 +27,10 @@ def _source_env_script(script_path: Path) -> StartupResult:
     evals its stdout, then dumps the final env via null-delimited pairs. Returns
     the vars the script added or changed relative to the current env; callers
     apply them explicitly rather than relying on a global mutation.
+
+    extra_env is merged into the subprocess environment (and into the baseline
+    used to compute the overlay, so the flags themselves are not reported as
+    new vars). Use it to pass profile toggles down into the script.
     """
     if not script_path.exists():
         msg = f"startup_env_script not found: {script_path}"
@@ -35,6 +39,8 @@ def _source_env_script(script_path: Path) -> StartupResult:
 
     logger.info("Running startup_env_script: %s", script_path)
     initial_env = dict(os.environ)
+    if extra_env:
+        initial_env.update(extra_env)
     proc = subprocess.run(
         ["bash", "-c", f'eval "$({shlex.quote(str(script_path))})" && env -0'],
         capture_output=True,
@@ -128,7 +134,10 @@ def main() -> None:
 
     startup = StartupResult()
     if profile.startup_env_script:
-        startup = _source_env_script(project_dir / profile.startup_env_script)
+        startup = _source_env_script(
+            project_dir / profile.startup_env_script,
+            extra_env={"DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN": "1" if profile.enable_k8s_otel_bearer_token else "0"},
+        )
 
     otel_config = _resolve_otel_config(profile, startup.env_overlay)
 

--- a/devinfra/secrets/web_env.sh
+++ b/devinfra/secrets/web_env.sh
@@ -42,7 +42,18 @@ rm -f "$_kube_stderr"
 
 # OTEL bearer token (Grafana Alloy via Authentik) — canonical source is Authentik,
 # TF writes it into this K8s Secret (cluster/terraform/gitops/alloy-otlp-bearer-token).
-try_export_from_k8s DUCKTAPE_OTEL_BEARER_TOKEN claude-sandbox alloy-otlp-bearer-token token "OTEL bearer token — traces to Grafana Alloy"
+#
+# Gated because `kubectl get secret` blocks for ~30s per retry when the k8s API
+# is unreachable (e.g. CCR v2 web sandboxes can only reach port 443; the API
+# lives on :16443). Unconditional call → wedged daemon startup → dispatcher
+# timeout loop → no secrets in the agent env at all. Default off.
+# CLEANUP: mirror alloy-otlp-bearer-token into SOPS and `try_export` it instead;
+# see devinfra/claude/TODO.md "OTEL bearer token: mirror into SOPS".
+if [ "${DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN:-0}" = "1" ]; then
+  try_export_from_k8s DUCKTAPE_OTEL_BEARER_TOKEN claude-sandbox alloy-otlp-bearer-token token "OTEL bearer token — traces to Grafana Alloy"
+else
+  echo "secrets: DUCKTAPE_OTEL_BEARER_TOKEN: skipped (DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN != 1)" >&2
+fi
 
 # CI read-only fine-grained PAT (personal, agentydragon — read GHA runs/artifacts)
 try_export DUCKTAPE_CI_READ_GITHUB_TOKEN "$REPO_ROOT/secrets/github-ci-read-pat.yaml" '["github_token"]' "CI read PAT (agentydragon) — read GHA runs and artifacts"


### PR DESCRIPTION
## Summary

`devinfra/secrets/web_env.sh` (invoked as the daemon's `startup_env_script`) called `kubectl get secret -n claude-sandbox alloy-otlp-bearer-token` unconditionally. On CCR v2 web sandboxes — and any environment where the k8s API is unreachable — kubectl blocks for ~30s per retry and wedges daemon startup: the 5s dispatcher timeout fires, a new daemon is spawned, the cycle repeats, and no secrets (`BUILDBUDDY_API_KEY`, `GITHUB_TOKEN`, …) ever land in the agent env.

- Add `enable_k8s_otel_bearer_token: bool = Field(default=False, ...)` to `ProfileConfig`.
- `_source_env_script` now accepts an `extra_env` dict so profile toggles can be threaded into the subprocess env. The flag is exported as `DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN=1|0`.
- `web_env.sh` wraps the `try_export_from_k8s DUCKTAPE_OTEL_BEARER_TOKEN ...` call in an `if [ "${DUCKTAPE_ENABLE_K8S_OTEL_BEARER_TOKEN:-0}" = "1" ]` guard, with the skip logged to stderr.
- `devinfra/claude/TODO.md` gets a `CLEANUP(2026-04-15)` tombstone tracking the real fix: mirror the Authentik-issued token into SOPS via `cluster/terraform/gitops/alloy-otlp-bearer-token/` and `try_export` it, then drop the flag.

This is step 1 of 3 from the plan — unblocks daemon startup immediately. Steps 2 (kubeconfig unification) and 3 (cluster-side k8s API on 443) follow in separate PRs.

## Test plan

- [ ] `bazel build //devinfra/claude/hook_daemon:...`
- [ ] Start a fresh Claude Code web session; confirm `$BUILDBUDDY_API_KEY` / `$GITHUB_TOKEN` are present and no stuck bash children from `web_env.sh`.
- [ ] `tail ~/.claude/session-env/<sid>/hook-daemon/daemon.log` — `startup_env_script` completes, no retry loop.
- [ ] Confirm the context banner now shows `DUCKTAPE_OTEL_BEARER_TOKEN: skipped ...` instead of the 30s kubectl timeout.

https://claude.ai/code/session_01QBQnGxpDPw3jsTtSRxSKwj