### PR TITLE
devinfra/claude/TODO.md: fix prettier formatting

### DIFF
--- a/devinfra/claude/TODO.md
+++ b/devinfra/claude/TODO.md
@@ -19,14 +19,12 @@ secret. Sketch:
    an equivalent provider — re-encrypted for the `claude-web` age recipient
    on every TF apply.
 2. Swap `web_env.sh`'s `try_export_from_k8s` call for a `try_export
-   "$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]'`.
+"$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]'`.
 3. Delete the `enable_k8s_otel_bearer_token` flag on `ProfileConfig` and its
    plumbing in `hook_daemon/main.py` + `web_env.sh`.
 
 Condition to remove this tombstone: the SOPS mirror exists and `web_env.sh`
 reads the token without touching kubectl.
-
-
 
 ## Nix Installation Timeout
 

--- a/devinfra/claude/TODO.md
+++ b/devinfra/claude/TODO.md
@@ -18,8 +18,8 @@ secret. Sketch:
    the token into `secrets/alloy-otlp-bearer-token.yaml` via `sops_file` or
    an equivalent provider — re-encrypted for the `claude-web` age recipient
    on every TF apply.
-2. Swap `web_env.sh`'s `try_export_from_k8s` call for a `try_export
-"$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]'`.
+2. Swap `web_env.sh`'s `try_export_from_k8s` call for a
+   `try_export "$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]'`.
 3. Delete the `enable_k8s_otel_bearer_token` flag on `ProfileConfig` and its
    plumbing in `hook_daemon/main.py` + `web_env.sh`.
 


### PR DESCRIPTION
## Summary

Pre-existing prettier nit from #1308 that landed with prettier bypassed on
the author side (the session's pre-commit was wedged by a stale
`SSL_CERT_FILE` → pygit2 TLS failure, so the commit went through with
`core.hooksPath=/dev/null`).

`pre-commit run --all-files` in CI fails on this file, which blocks every
other open PR until it is fixed on devel.

## Test plan

- [ ] CI: `Pre-commit checks` passes
