### PR TITLE
Add GitHub repository rulesets for branch protection

### DIFF
--- a/cluster/k8s/github-repo-rulesets/flux-kustomization.yaml
+++ b/cluster/k8s/github-repo-rulesets/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: github-repo-rulesets
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  path: ./cluster/k8s/github-repo-rulesets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 10m
+  wait: true
+  healthChecks:
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: github-repo-rulesets
+      namespace: flux-system
+  dependsOn:
+    - name: tofu-controller
+    - name: github-secrets-sync-secrets

--- a/cluster/k8s/github-repo-rulesets/kustomization.yaml
+++ b/cluster/k8s/github-repo-rulesets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - terraform.yaml

--- a/cluster/k8s/github-repo-rulesets/terraform.yaml
+++ b/cluster/k8s/github-repo-rulesets/terraform.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: github-repo-rulesets
+  namespace: flux-system
+spec:
+  interval: 15m
+  path: ./cluster/terraform/gitops/github-repo-rulesets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  serviceAccountName: tf-runner
+  approvePlan: "auto"
+
+  backendConfig:
+    customConfiguration: |
+      backend "kubernetes" {
+        secret_suffix = "github-repo-rulesets"
+        namespace     = "flux-system"
+      }

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -263,6 +263,9 @@ resources:
   - github-secrets-sync/secrets/flux-kustomization.yaml
   - github-secrets-sync/flux-kustomization.yaml
 
+  # --- github-repo-rulesets ---
+  - github-repo-rulesets/flux-kustomization.yaml
+
   # --- standalone applications ---
   - buildbuddy-executor/flux-kustomization.yaml
   - website/flux-kustomization.yaml

--- a/cluster/terraform/gitops/github-repo-rulesets/BUILD.bazel
+++ b/cluster/terraform/gitops/github-repo-rulesets/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
+
+tf_providers_versions(
+    name = "providers",
+    providers = {
+        "github": "integrations/github:~>6.6",
+        "kubernetes": "hashicorp/kubernetes:~>2.35",
+    },
+    tf_version = "1.9.8",
+)
+
+tf_module(
+    name = "github-repo-rulesets",
+    providers = [
+        "github",
+        "kubernetes",
+    ],
+    providers_versions = ":providers",
+)

--- a/cluster/terraform/gitops/github-repo-rulesets/main.tf
+++ b/cluster/terraform/gitops/github-repo-rulesets/main.tf
@@ -1,0 +1,103 @@
+# GitHub repository rulesets for agentydragon/ducktape
+#
+# Enforces PR-gated merges into devel (current default) and main (future
+# default after a planned rename), with required status checks from the
+# Pre-commit and Bazel CI workflows. Direct pushes are blocked for everyone
+# except explicit bypass actors.
+#
+# Bypass actors (bypass_mode = always):
+#   - Repository admin role: covers the owner (agentydragon). The fine-grained
+#     PAT in `github-secrets-sync-pat` is owned by the admin user, so all
+#     automations pushing via that PAT — Flux ImageUpdateAutomation and the
+#     claude-token-rotation CronJob — inherit this bypass.
+#   - github-actions GitHub App (id 15368): covers workflows that direct-push
+#     via GITHUB_TOKEN, specifically sync-pins.yml, nix-flake-update.yml, and
+#     the pin-digests job in container-images.yml.
+#
+# Status check contexts are written from first principles based on the
+# workflow/job names in .github/workflows/. They must be verified against an
+# actual PR check run and corrected if GitHub reports different strings —
+# rulesets match on the literal context string, so a mismatch silently makes
+# the check non-required. See the CLEANUP note below.
+#
+# Auth: fine-grained GitHub PAT stored as K8s Secret (SOPS-deployed by Flux).
+
+provider "github" {
+  owner = "agentydragon"
+  token = data.kubernetes_secret.github_secrets_sync_pat.data["token"]
+}
+
+data "kubernetes_secret" "github_secrets_sync_pat" {
+  metadata {
+    name      = "github-secrets-sync-pat"
+    namespace = "flux-system"
+  }
+}
+
+resource "github_repository_ruleset" "protect_default_branches" {
+  name        = "protect-default-branches"
+  repository  = "ducktape"
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      # Both devel (current default) and main (future default after rename) —
+      # keeping both in the include list means protection follows the default
+      # branch across a rename with no gap.
+      include = ["refs/heads/devel", "refs/heads/main"]
+      exclude = []
+    }
+  }
+
+  # Repository admin (actor_id = 5) — covers the owner and anything pushing
+  # with a PAT owned by the admin user (Flux image automation, claude token
+  # rotation cronjob, manual emergencies).
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
+  # github-actions GitHub App (well-known integration id 15368) — covers
+  # workflows that direct-push via GITHUB_TOKEN.
+  bypass_actors {
+    actor_id    = 15368
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Block branch deletion and force pushes. Linear history forces
+    # squash/rebase merges, matching the existing monorepo convention.
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
+
+    pull_request {
+      # Solo-maintained repo — requiring approvals would just block me.
+      # The safety comes from required status checks, not review gating.
+      required_approving_review_count   = 0
+      required_review_thread_resolution = true
+      dismiss_stale_reviews_on_push     = false
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+    }
+
+    required_status_checks {
+      # Branches must be up to date with the target before merging, so the
+      # required checks reflect the post-merge state.
+      strict_required_status_checks_policy = true
+
+      # CLEANUP(2026-04-15): Verify these context strings against an actual
+      # PR check run on github.com and correct if the reported names differ.
+      # Reusable workflow jobs render as `<caller> / <job-id> / <job-name>`.
+      required_check {
+        context = "Pre-commit checks / Pre-commit checks"
+      }
+      required_check {
+        context = "CI / bazel-ci / Test & Build"
+      }
+    }
+  }
+}

--- a/cluster/terraform/gitops/github-repo-rulesets/terraform.tf
+++ b/cluster/terraform/gitops/github-repo-rulesets/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+
+  backend "kubernetes" {
+    secret_suffix = "github-repo-rulesets"
+    namespace     = "flux-system"
+  }
+}

--- a/cluster/terraform/gitops/github-repo-rulesets/variables.tf
+++ b/cluster/terraform/gitops/github-repo-rulesets/variables.tf
@@ -1,0 +1,1 @@
+# No variables — all inputs are read from K8s secrets.


### PR DESCRIPTION
## Summary
Implement automated GitHub repository branch protection rules for the ducktape repository using Terraform, managed through Flux GitOps.

## Key Changes
- **Terraform configuration** (`cluster/terraform/gitops/github-repo-rulesets/`):
  - Define repository ruleset protecting `devel` and `main` branches
  - Enforce PR-gated merges with required status checks from Pre-commit and Bazel CI workflows
  - Block direct pushes except for repository admin role and github-actions GitHub App
  - Configure linear history requirement (squash/rebase merges only)
  - Require thread resolution on pull requests

- **Flux GitOps integration** (`cluster/k8s/github-repo-rulesets/`):
  - Add Terraform resource definition for Flux to manage the ruleset
  - Configure Kubernetes backend for Terraform state storage
  - Add Kustomization to integrate into cluster deployment
  - Set up dependencies on tofu-controller and github-secrets-sync-secrets

- **Build configuration**:
  - Add Bazel build rules for Terraform module validation
  - Specify provider versions (GitHub ~6.6, Kubernetes ~2.35, Terraform 1.9.8)

## Notable Implementation Details
- Authentication uses a fine-grained GitHub PAT stored as a Kubernetes Secret (SOPS-deployed by Flux)
- Bypass actors configured for:
  - Repository admin role (covers owner and admin-owned PATs for automation)
  - github-actions GitHub App (covers workflows using GITHUB_TOKEN)
- Status check contexts derived from workflow definitions with a cleanup note for future verification
- Protection spans both current default branch (`devel`) and future default (`main`) to handle planned rename without gaps

https://claude.ai/code/session_01BHvkkYjYT4A75EauvXJgXa