### PR TITLE
kube-api-proxy: follow-ups to #1310 (CLI profile + README)

### DIFF
--- a/cluster/k8s/kube-api-proxy/README.md
+++ b/cluster/k8s/kube-api-proxy/README.md
@@ -1,0 +1,60 @@
+# kube-api-proxy
+
+nginx reverse proxy that exposes the in-cluster Kubernetes API on
+`https://api.allegedly.works` (port 443) via the Cilium Gateway API.
+
+## Why
+
+Claude Code web sandboxes (and any other CCR v2 environment) reach the
+internet through Anthropic's TLS-inspecting egress proxy, which only
+permits port 443 outbound — non-standard ports like the apiserver's
+`:6443` (or the previous `:16443` hostPort listener) are silently
+filtered. Hook daemons running inside web sessions need the k8s API to
+write per-session kubeconfigs and (optionally) fetch the OTEL bearer
+token, so the apiserver must be reachable on `:443`.
+
+This proxy fronts the in-cluster `kubernetes.default.svc.cluster.local`
+Service, listens plaintext on `:8080`, and re-encrypts upstream over
+TLS. The Cilium Gateway terminates TLS for the wildcard cert
+`*.allegedly.works` on `:443` and forwards plain HTTP to the Service.
+
+## Topology
+
+```text
+Internet
+   │ TLS, *.allegedly.works wildcard cert
+   ▼
+Cilium Gateway (:443, hostNetwork on hil VPS)
+   │ HTTP (plain)
+   ▼
+Service kube-api-proxy/kube-api-proxy (ClusterIP :80 → :8080)
+   │
+   ▼
+Deployment kube-api-proxy/kube-api-proxy (nginx, 2 replicas, hil-pinned)
+   │ HTTPS (proxy_ssl on, SNI = kubernetes.default.svc.cluster.local)
+   ▼
+kubernetes.default.svc.cluster.local:443 (apiserver)
+```
+
+## Resources
+
+| File                      | Purpose                                                     |
+| ------------------------- | ----------------------------------------------------------- |
+| `namespace.yaml`          | `kube-api-proxy` namespace                                  |
+| `deployment.yaml`         | nginx Deployment (2 replicas, hil-pinned, no hostNetwork)   |
+| `service.yaml`            | ClusterIP `:80` → pod `:8080`                               |
+| `httproute.yaml`          | Gateway API HTTPRoute on `cluster-gateway/https-wildcard`   |
+| `config/nginx.conf`       | nginx config (plain http reverse proxy with WS upgrade map) |
+| `kustomization.yaml`      | Flux kustomization root + ConfigMap generator               |
+| `flux-kustomization.yaml` | Flux Kustomization (no `dependsOn`, health: Deployment)     |
+
+## Future direction
+
+Once the cluster is on Cilium ≥ 1.20, this Deployment can be replaced
+by a direct HTTPRoute → `kubernetes.default` backend with a
+`BackendTLSPolicy` to handle the upstream TLS handoff. Cilium 1.19.2
+(currently deployed) does not support `BackendTLSPolicy`, which is why
+the nginx hop is still required.
+
+The full rationale and lifecycle notes live in the `description`
+annotation on `deployment.yaml` — keep them in sync.

--- a/devinfra/claude/hook_daemon/profiles/cli/profile.yaml
+++ b/devinfra/claude/hook_daemon/profiles/cli/profile.yaml
@@ -3,7 +3,7 @@ otel:
   # bearer_token: sourced from .envrc (cli_env.sh → DUCKTAPE_OTEL_BEARER_TOKEN).
 
 k8s:
-  server: https://api.allegedly.works:16443
+  server: https://api.allegedly.works
   service_account: claude-code-web
   service_account_namespace: default
   namespace: claude-sandbox


### PR DESCRIPTION
## Summary

Two small follow-ups to #1310 (kube-api-proxy on `api.allegedly.works:443`):

- **`cli profile: drop :16443 from k8s server URL`** — #1310 flipped the web profile from `api.allegedly.works:16443` to `:443` when the kube-api-proxy DaemonSet on hostPort 16443 was replaced with a Cilium Gateway HTTPRoute, but `devinfra/claude/hook_daemon/profiles/cli/profile.yaml` was missed. Same one-line fix, so CLI session-start hooks stop pointing at the decommissioned listener.
- **`cluster/kube-api-proxy: add README`** — the directory had 6 manifests + a config dir but no README. Adds a short README documenting why the nginx reverse proxy exists (CCR v2 web sandboxes can only egress on :443), the Internet → Gateway → Service → nginx → apiserver topology, a file inventory, and the future direction (switch to `BackendTLSPolicy` once Cilium is ≥1.20). Points at the `deployment.yaml` description annotation as the source of truth for rationale.

## Test plan

- [x] `git log --oneline` — 2 commits, both with `BAZEL_TEST_INVOCATIONS=none` (config/docs only)
- [x] Pre-commit clean (modulo the environmental `prettier-plugin-svelte` failure tracked separately)
- [x] End-to-end `api.allegedly.works:443` path still works: `curl https://api.allegedly.works/version` → HTTP 401 with real k8s `Status` JSON, `kubectl get kustomization kube-api-proxy` reports Ready on `98c5b69`
- [ ] Next CLI session-start hook on this change will no longer hang on an unreachable `:16443` (only verifiable from a fresh CLI session after merge)