### PR TITLE
Improve daemon startup diagnostics and logging

### DIFF
--- a/devinfra/claude/hook_daemon/client.py
+++ b/devinfra/claude/hook_daemon/client.py
@@ -27,7 +27,8 @@ _SHIM_RESPONSE_ADAPTER: TypeAdapter[ShimBlocked | ShimExecve] = TypeAdapter(Shim
 logger = logging.getLogger(__name__)
 
 # How long to wait for the daemon socket to appear after starting the daemon.
-_DAEMON_STARTUP_TIMEOUT_SECS = 5
+# Override via DUCKTAPE_CLAUDE_HOOKS_DAEMON_STARTUP_TIMEOUT_SECS for slow environments.
+_DAEMON_STARTUP_TIMEOUT_SECS = float(os.environ.get("DUCKTAPE_CLAUDE_HOOKS_DAEMON_STARTUP_TIMEOUT_SECS", "10"))
 
 # Circuit breaker: throttle restart attempts after repeated failures.
 _STARTUP_FAILURE_FILE = "startup_failure.json"
@@ -267,7 +268,12 @@ def _ensure_daemon(paths: SessionPaths) -> _UDSConnection:
     # Create daemon dir before acquiring the lock (FileLock needs the parent to exist).
     daemon_dir.mkdir(parents=True, exist_ok=True)
 
+    t_lock_start = time.monotonic()
+    logger.info("Acquiring daemon.lock at %s", daemon_dir / "daemon.lock")
     with FileLock(str(daemon_dir / "daemon.lock")):
+        t_lock_acquired = time.monotonic()
+        logger.info("daemon.lock acquired after %.2fs", t_lock_acquired - t_lock_start)
+
         # Re-check after acquiring: another client may have won the race and
         # already started a healthy daemon while we were waiting.
         conn = _UDSConnection(sock_path)
@@ -295,7 +301,9 @@ def _ensure_daemon(paths: SessionPaths) -> _UDSConnection:
         if pidfile.exists():
             pidfile.unlink()
 
+        t_fork = time.monotonic()
         daemon_pid = _fork_daemon(daemon_dir, sock_path)
+        logger.info("Daemon forked (pid=%d) after %.2fs from lock acquire", daemon_pid, time.monotonic() - t_fork)
 
         # Wait for socket while still holding daemon.lock — prevents other
         # clients from entering and trying to start a second daemon.
@@ -309,6 +317,11 @@ def _ensure_daemon(paths: SessionPaths) -> _UDSConnection:
                 raise DaemonStartError(f"{e}\n--- daemon stderr ---\n{stderr}") from e
             raise
 
+        logger.info(
+            "Daemon ready in %.2fs total (lock wait: %.2fs)",
+            time.monotonic() - t_lock_start,
+            t_lock_acquired - t_lock_start,
+        )
         _clear_startup_failure(daemon_dir)
         return conn
 
@@ -392,15 +405,26 @@ def _wait_for_sock(
     2. Pre-pidfile: os.kill(daemon_pid, 0) — covers the gap before the daemon
        acquires the flock. PID reuse in the <5s startup window is negligible.
     """
-    logger.debug("Waiting for daemon socket %s (pid=%d, timeout=%.1fs)", sock_path, daemon_pid, timeout_secs)
-    deadline = time.monotonic() + timeout_secs
+    t0 = time.monotonic()
+    logger.info("Waiting for daemon socket %s (pid=%d, timeout=%.1fs)", sock_path, daemon_pid, timeout_secs)
+    deadline = t0 + timeout_secs
+    socket_appeared_at: float | None = None
+    last_log_at = t0
     while time.monotonic() < deadline:
+        elapsed = time.monotonic() - t0
         if sock_path.exists():
+            if socket_appeared_at is None:
+                socket_appeared_at = elapsed
+                logger.info("Daemon socket file appeared after %.2fs; waiting for health check", socket_appeared_at)
             conn = _UDSConnection(sock_path)
             if conn.check_health():
-                logger.debug("Daemon socket ready at %s", sock_path)
+                logger.info("Daemon socket healthy after %.2fs", time.monotonic() - t0)
                 return conn
             conn.close()
+        elif elapsed - last_log_at >= 1.0:
+            # Log progress every second while waiting, so timeouts are easy to diagnose.
+            logger.info("Still waiting for daemon socket (%.1fs elapsed, pid=%d)", elapsed, daemon_pid)
+            last_log_at = elapsed
 
         # Post-pidfile crash detection: if the daemon died, its flock on the
         # pidfile is released by the kernel.  The stale pidfile is deleted
@@ -419,5 +443,11 @@ def _wait_for_sock(
             raise DaemonStartError("Daemon process died during startup (pre-pidfile)")
 
         time.sleep(0.1)
-    logger.warning("Daemon socket did not appear within %.1fs at %s", timeout_secs, sock_path)
-    raise DaemonStartError(f"Daemon socket did not appear within {timeout_secs}s")
+    elapsed = time.monotonic() - t0
+    sock_note = (
+        f"socket appeared at {socket_appeared_at:.2f}s but health check never passed"
+        if socket_appeared_at
+        else "socket never appeared"
+    )
+    logger.warning("Daemon did not become healthy within %.1fs at %s (%s)", elapsed, sock_path, sock_note)
+    raise DaemonStartError(f"Daemon socket did not appear within {timeout_secs}s ({sock_note})")

--- a/devinfra/claude/hook_daemon/main.py
+++ b/devinfra/claude/hook_daemon/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shlex
 import subprocess
+import time
 from pathlib import Path
 
 import uvicorn
@@ -38,22 +39,33 @@ def _source_env_script(script_path: Path, extra_env: dict[str, str] | None = Non
         return StartupResult(exit_code=1, output=msg)
 
     logger.info("Running startup_env_script: %s", script_path)
+    t0 = time.monotonic()
     initial_env = dict(os.environ)
     if extra_env:
         initial_env.update(extra_env)
+    # Pipe script stdout through `tee /dev/stderr` so the export lines are visible
+    # in proc.stderr alongside the script's own stderr. proc.stdout receives only the
+    # null-delimited `env -0` output used for env var parsing.
     proc = subprocess.run(
-        ["bash", "-c", f'eval "$({shlex.quote(str(script_path))})" && env -0'],
+        ["bash", "-c", f'eval "$({shlex.quote(str(script_path))} | tee /dev/stderr)" && env -0'],
         capture_output=True,
         env=initial_env,
         check=False,
     )
+    elapsed = time.monotonic() - t0
 
     output = proc.stderr.decode(errors="replace")
     if output.strip():
-        logger.info("startup_env_script output:\n%s", output.rstrip())
+        logger.info("startup_env_script output (%.2fs):\n%s", elapsed, output.rstrip())
+    else:
+        logger.info("startup_env_script: no output (%.2fs)", elapsed)
 
     if proc.returncode != 0:
-        logger.warning("startup_env_script exited %d — secrets may be missing from session env", proc.returncode)
+        logger.warning(
+            "startup_env_script exited %d after %.2fs — secrets may be missing from session env",
+            proc.returncode,
+            elapsed,
+        )
         return StartupResult(exit_code=proc.returncode, output=output)
 
     # Parse null-delimited KEY=VALUE pairs from `env -0`. Collect vars the script


### PR DESCRIPTION
## Summary
Enhanced observability of the Claude hooks daemon startup process by adding detailed timing information and progress logging. This helps diagnose slow or failing daemon startups in environments with performance constraints.

## Key Changes

**client.py:**
- Made daemon startup timeout configurable via `DUCKTAPE_CLAUDE_HOOKS_DAEMON_STARTUP_TIMEOUT_SECS` environment variable (default increased from 5s to 10s)
- Added timing instrumentation around lock acquisition, daemon forking, and socket readiness checks
- Upgraded socket wait logging from `debug` to `info` level for better visibility
- Added progress logging every second while waiting for daemon socket to appear
- Enhanced timeout error messages to distinguish between "socket never appeared" vs "socket appeared but health check failed"
- Track when socket file first appears separately from when it becomes healthy

**main.py:**
- Added timing measurements to startup environment script execution
- Modified script output capture to pipe stdout through `tee /dev/stderr` so export statements are visible in logs alongside script stderr
- Added elapsed time to all startup script log messages for performance tracking
- Improved error messages to include execution time

## Implementation Details
- Uses `time.monotonic()` for accurate elapsed time measurements
- Maintains backward compatibility with existing code paths
- All new logging is at `info` level to ensure visibility in standard logging configurations
- Socket health check timing is now clearly separated from socket file appearance timing, making it easier to diagnose where delays occur

https://claude.ai/code/session_01PgjHAGCUgz58jtyV2753iM