### PR TITLE
claude: add Setup hook to reinstall devtools on web sessions before S…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "Setup": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash devinfra/claude/web_setup_hook.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/devinfra/claude/web_setup_hook.sh
+++ b/devinfra/claude/web_setup_hook.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# web_setup_hook.sh — Claude Code Setup hook entry point.
+#
+# Runs web_setup.sh on web sessions to ensure the claude-hooks wheel is fresh
+# before SessionStart fires. This closes the "stale wheel on resume-cached
+# sessions" gap: the init_script (web_setup.sh) that normally re-installs
+# devtools is NOT sent by Anthropic's backend for resume-cached sessions, so
+# without this hook the installed wheel can lag behind npins/sources.json by
+# many hours (however long the Firecracker VM stays alive between new sessions).
+#
+# No-ops on CLI sessions (CLAUDE_CODE_REMOTE unset) — web_setup.sh is
+# web-only (Nix flake install, git remote, etc.) and must not run on NixOS.
+#
+# IMPORTANT: this script must NOT call claude-hook. The Setup hook fires with
+# the new post-compaction session ID while SessionStart uses the old ID.
+# Starting the daemon here would create a daemon for the wrong session ID and
+# trigger a second daemon start when SessionStart arrives. A raw bash script
+# that never calls claude-hook is safe.
+
+set -euo pipefail
+
+# Append to the same log file web_setup.sh uses so one file covers both.
+LOG_FILE="/tmp/web-setup.log"
+exec >>"$LOG_FILE" 2>&1
+
+# Read stdin first — Claude Code hooks always receive JSON on stdin; consuming
+# it avoids a broken pipe if Claude closes the write end before we exit.
+# Logged verbatim so we can observe what (if anything) Setup hooks receive.
+STDIN_DATA=$(cat)
+echo "[$(date -Iseconds)] web_setup_hook.sh: cwd=$(pwd) BASH_SOURCE=${BASH_SOURCE[0]}"
+echo "[$(date -Iseconds)] web_setup_hook.sh: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} IS_SANDBOX=${IS_SANDBOX:-<unset>}"
+echo "[$(date -Iseconds)] web_setup_hook.sh: stdin=${STDIN_DATA:-(empty)}"
+
+if [ -z "${CLAUDE_CODE_REMOTE:-}" ]; then
+  echo "[$(date -Iseconds)] web_setup_hook.sh: CLI session (CLAUDE_CODE_REMOTE unset) — skipping"
+  exit 0
+fi
+
+echo "[$(date -Iseconds)] web_setup_hook.sh: web session detected — delegating to web_setup.sh"
+exec bash "$(dirname "${BASH_SOURCE[0]}")/web_setup.sh"


### PR DESCRIPTION
…essionStart

Observed that `resume-cached` sessions do not re-run web_setup.sh (the init_script is empty for resume sessions per Anthropic's backend), leaving the installed claude-hooks wheel stale for however long the Firecracker VM persists.

Fix: add a Setup hook (fires before SessionStart) that runs web_setup.sh on web sessions (CLAUDE_CODE_REMOTE set). web_setup.sh does `nix profile remove devtools && nix profile install` unconditionally, ensuring the wheel matches the current npins pin before the daemon starts.

CLI guard: no-ops when CLAUDE_CODE_REMOTE is unset.

Also logs: cwd, BASH_SOURCE, stdin (to observe what Setup hooks receive), and the guard decision — all appended to /tmp/web-setup.log.

https://claude.ai/code/session_01PgjHAGCUgz58jtyV2753iM