### PR TITLE
Implement content-addressed release tagging for claude-hooks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,9 +64,10 @@ build:rbe --experimental_profile_include_primary_output
 # Formatting: use bazel run //devinfra/format (fix) or //devinfra/format.check (check)
 # Supports: prettier (JS/TS/CSS/HTML/MD), ruff (Python), shfmt (Shell), buildifier (Bazel), rustfmt (Rust)
 
-# Stamping - embeds build metadata (commit hash, etc.) into build artifacts
-# Only targets that depend on ctx.info_file (like build_info_gen) are invalidated on commit change
-build --stamp --workspace_status_command=devinfra/stamp.sh
+# Workspace status command populates volatile metadata (repo URL, branch, user)
+# for BuildBuddy UI. Stamping is off by default for hermeticity; release builds
+# opt in with --stamp to embed commit/content info via expand_template rules.
+build --workspace_status_command=devinfra/stamp.sh
 
 # Use shell-based bootstrap instead of system_python.  The default
 # (system_python) starts with `#!/usr/bin/env python3` which picks up whatever

--- a/.github/actions/release-artifact/action.yml
+++ b/.github/actions/release-artifact/action.yml
@@ -23,18 +23,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build artifact
+    # Build 1: unstamped (default, --stamp off) — deterministic, for skip decision
+    - name: Build artifact (unstamped)
       uses: ./.github/actions/bb-remote
       with:
         args: build ${{ inputs.bazel_target }}
         rbe_image: ${{ inputs.rbe_image }}
 
-    - name: Release
+    - name: Check content hash
+      id: check
       shell: bash
       env:
         GH_TOKEN: ${{ env.GH_RELEASE_PAT }}
         PKG: ${{ inputs.pkg }}
-        RETENTION_DAYS: ${{ inputs.retention_days }}
       run: |
         set -euo pipefail
 
@@ -42,6 +43,7 @@ runs:
         subject=$(git log -1 --format=%s)
         if [[ "$subject" == *"[skip ci]"* ]]; then
           echo "$PKG: commit has [skip ci], skipping"
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
@@ -52,29 +54,54 @@ runs:
           exit 1
         fi
 
-        # Compute SHA256 (base64, matching npins format)
-        sha=$(openssl dgst -sha256 -binary "$artifact" | base64 -w0)
+        # Content-addressed skip check: tag by hash of the unstamped wheel.
+        # If a release with this tag already exists, the content hasn't changed.
+        content_sha=$(sha256sum "$artifact" | awk '{print $1}')
+        tag="${PKG}-${content_sha:0:12}"
 
-        # Compare against pinned value
-        pinned_sha=$(jq -r ".pins.\"$PKG\".sha256 // empty" npins/sources.json)
-        if [[ "$sha" == "$pinned_sha" ]]; then
-          echo "$PKG: unchanged, skipping"
+        if gh release view "$tag" >/dev/null 2>&1; then
+          echo "$PKG: unchanged (release $tag exists), skipping"
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        short_sha=$(git rev-parse --short=7 HEAD)
-        tag="${PKG}-${short_sha}"
+        echo "should_release=true" >> "$GITHUB_OUTPUT"
+        echo "content_sha=${content_sha}" >> "$GITHUB_OUTPUT"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+    # Build 2: stamped — injects GIT_COMMIT via expand_template.
+    # Only _build_info_gen + wheel targets re-run; everything else is cache-hit.
+    - name: Build artifact (stamped)
+      if: steps.check.outputs.should_release == 'true'
+      uses: ./.github/actions/bb-remote
+      with:
+        args: build ${{ inputs.bazel_target }} --stamp
+        rbe_image: ${{ inputs.rbe_image }}
+
+    - name: Upload release
+      if: steps.check.outputs.should_release == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ env.GH_RELEASE_PAT }}
+        PKG: ${{ inputs.pkg }}
+        RETENTION_DAYS: ${{ inputs.retention_days }}
+      run: |
+        set -euo pipefail
+
+        tag="${{ steps.check.outputs.tag }}"
+        artifact="${{ inputs.bazel_output }}"
+
         echo "$PKG: content changed, creating release $tag"
 
         gh release create "$tag" "$artifact" \
-          --title "$PKG ($short_sha)" \
+          --title "$PKG (${tag#"${PKG}"-})" \
           --notes "$PKG release" \
           --latest=false
 
-        # Prune old releases for this package
+        # Prune old releases for this package (content-addressed 12-char hex tags)
         cutoff=$(date -u -d "-${RETENTION_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
         gh release list --json tagName,createdAt -L 200 \
-          --jq ".[] | select(.tagName | test(\"^${PKG}-[0-9a-f]{7}$\")) | select(.createdAt < \"${cutoff}\") | .tagName" \
+          --jq ".[] | select(.tagName | test(\"^${PKG}-[0-9a-f]{12}$\")) | select(.createdAt < \"${cutoff}\") | .tagName" \
           | while read -r old_tag; do
               [[ "$old_tag" == "$tag" ]] && continue
               echo "  pruning $old_tag"

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -25,12 +25,15 @@ class Sources(BaseModel):
     pins: dict[str, Pin]
 
 
-_TAG_RE = re.compile(r"-[0-9a-f]{7}$")
+_HEX_SUFFIX_RE = re.compile(r"^[0-9a-f]{7}$|^[0-9a-f]{12}$")
 
 
 def is_tag_for_pkg(tag: str, pkg: str) -> bool:
-    """Match `{pkg}-{7hex}` exactly, avoiding prefix collisions like ducktape/ducktape-util."""
-    return tag.startswith(f"{pkg}-") and _TAG_RE.search(tag) is not None and len(tag) == len(pkg) + 8
+    """Match `{pkg}-{7hex}` or `{pkg}-{12hex}` exactly, avoiding prefix collisions."""
+    prefix = f"{pkg}-"
+    if not tag.startswith(prefix):
+        return False
+    return _HEX_SUFFIX_RE.match(tag[len(prefix) :]) is not None
 
 
 class Artifact(BaseModel, frozen=True):

--- a/devinfra/claude/AGENTS.md
+++ b/devinfra/claude/AGENTS.md
@@ -66,13 +66,13 @@ cat "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/bazelrc"
 # Check supervisor status (container runtime only)
 python -m supervisor.supervisorctl -c "$DUCKTAPE_CLAUDE_HOOKS_SESSION_DIR/supervisor/supervisord.conf" status
 
-# Check installed claude-hooks vs the pin in the working tree — catches
-# "container reuse froze the wheel at an old pin" situations on Firecracker.
-readlink /nix/var/nix/profiles/default/bin/claude-hook
-python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
+# Check installed claude-hooks vs the pin — git= shows the commit the wheel was built from
+claude-hook --version
+jq -r '.pins["claude-hooks"].url' npins/sources.json
 ```
 
-If these disagree on the claude-hooks commit sha, the installed wheel has
-drifted behind the pin — re-run `bash devinfra/claude/web_setup.sh` to pull
-forward. See <docs/web-setup-debug.md> "Pin drift on persistent rootfs" for
-the underlying cause.
+If the version shows `git=dev` (unstamped) or an old commit, the installed
+wheel has drifted behind the pin — re-run
+`bash devinfra/claude/web_setup.sh` to pull forward. See
+<docs/web-setup-debug.md> "Pin drift on persistent rootfs" for the underlying
+cause.

--- a/devinfra/claude/docs/web-setup-debug.md
+++ b/devinfra/claude/docs/web-setup-debug.md
@@ -247,16 +247,13 @@ cache when the pin hasn't actually moved.
 **How to diagnose future occurrences**:
 
 ```bash
-# Compare installed vs pinned claude-hooks commit
-readlink /nix/var/nix/profiles/default/bin/claude-hook  # → /nix/store/<hash>-claude-hooks-<ver>/bin/claude-hook
-# Then match <hash> against `git log --all --oneline` of claude-hooks source commits,
-# or check `devinfra/_build_status.txt` bundled inside the wheel if present.
+# Compare installed vs pinned — check the git commit the installed wheel was built from
+claude-hook --version
+# The npins URL contains the content-addressed release tag (12-hex hash prefix)
+jq -r '.pins["claude-hooks"].url' npins/sources.json
 
 # Check the daemon error log for Mako/pydantic complaints
 tail -100 ~/.claude/session-env/*/hook-daemon/daemon.err.log
-
-# Check what npins says is current
-python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
 ```
 
 **Lessons**:

--- a/devinfra/claude/hook_daemon/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/BUILD.bazel
@@ -1,4 +1,25 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+
+expand_template(
+    name = "_build_info_gen",
+    out = "_build_info.py",
+    stamp = -1,
+    stamp_substitutions = {
+        "{{GIT_COMMIT}}": "{{STABLE_BUILD_COMMIT}}",
+    },
+    substitutions = {
+        "{{GIT_COMMIT}}": "dev",
+    },
+    template = "build_info.tpl",
+)
+
+py_library(
+    name = "_build_info",
+    srcs = [":_build_info_gen"],
+    imports = ["../../.."],
+    visibility = ["//visibility:public"],
+)
 
 py_library(
     name = "config",
@@ -269,6 +290,7 @@ py_library(
     srcs = ["hook_dispatch.py"],
     visibility = ["//visibility:public"],
     deps = [
+        ":_build_info",
         ":client",
         ":shim_lib",
         ":write_kubeconfig_cli",

--- a/devinfra/claude/hook_daemon/build_info.tpl
+++ b/devinfra/claude/hook_daemon/build_info.tpl
@@ -1,0 +1,1 @@
+GIT_COMMIT: str = "{{GIT_COMMIT}}"

--- a/devinfra/claude/hook_daemon/docs/session_start_recovery.md
+++ b/devinfra/claude/hook_daemon/docs/session_start_recovery.md
@@ -156,10 +156,9 @@ freezes at first-boot.
 **Diagnose**:
 
 ```bash
-# 1. Confirm wheel drift
-readlink /nix/var/nix/profiles/default/bin/claude-hook
-python3 -c "import json; p=json.load(open('npins/sources.json'))['pins']['claude-hooks']; print(p['url'])"
-# The hash on the readlink line and the commit SHA in the URL should match.
+# 1. Confirm wheel drift — git= shows the commit the wheel was built from
+claude-hook --version
+jq -r '.pins["claude-hooks"].url' npins/sources.json
 
 # 2. Confirm the specific crash
 tail -100 ~/.claude/session-env/*/hook-daemon/daemon.err.log

--- a/devinfra/claude/hook_daemon/hook_dispatch.py
+++ b/devinfra/claude/hook_daemon/hook_dispatch.py
@@ -16,6 +16,7 @@ from mako.template import Template
 from pydantic import TypeAdapter
 
 from devinfra.claude.claude_api.hooks.dispatch_input import AnyHookInput
+from devinfra.claude.hook_daemon._build_info import GIT_COMMIT
 from devinfra.claude.hook_daemon.client import DaemonHttpError, DaemonStartError, call_daemon
 from devinfra.claude.hook_daemon.shim import run_shim
 from devinfra.claude.hook_daemon.shim_install import SHIM_SESSION_ID_ENV
@@ -50,6 +51,10 @@ def _log_event(direction: str, raw_json: str | None, *, hook_name: str = "", ses
 
 
 def main() -> None:
+    if len(sys.argv) >= 2 and sys.argv[1] in ("--version", "-V", "version"):
+        print(f"claude-hook 0.1.0 git={GIT_COMMIT}")
+        return
+
     # Shim subcommand: `claude-hook shim <shim_name> [args...]`
     # New-style shim wrappers exec into here instead of python -m shim,
     # so the profile symlink resolves the interpreter at invocation time.

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -357,8 +357,7 @@ print('pinned:', m.group(1) if m else 'unknown')
 git -C /home/user/ducktape log --oneline -5 -- devinfra/claude/ npins/sources.json
 
 # (b) Installed wheel vs pin
-INSTALLED=$(readlink /nix/var/nix/profiles/default/bin/claude-hook 2>/dev/null)
-echo "installed: $INSTALLED"  # /nix/store/<hash>-claude-hooks-<ver>/bin/claude-hook
+claude-hook --version  # git= shows the commit the installed wheel was built from
 # Check daemon.err.log for template/schema crashes that indicate drift
 tail -50 ~/.claude/session-env/*/hook-daemon/daemon.err.log 2>/dev/null
 ```


### PR DESCRIPTION
## Summary

This PR refactors the release artifact workflow to use content-addressed tagging instead of commit-based tagging. Releases are now tagged by a hash of the unstamped wheel content, enabling skip detection when the actual artifact hasn't changed. Build stamping is moved to an opt-in second build step that only runs when a release is needed.

## Key Changes

- **Release artifact workflow** (`release-artifact/action.yml`):
  - Split build into two stages: unstamped (for skip detection) and stamped (for release)
  - Changed tagging from commit-based (`PKG-<7-char-commit>`) to content-addressed (`PKG-<12-char-content-hash>`)
  - Refactored release logic into separate "Check content hash" and "Upload release" steps
  - Skip detection now checks if a release with the content hash tag already exists
  - Updated tag pruning regex to match 12-character hex tags instead of 7-character

- **Build configuration** (`.bazelrc`):
  - Removed `--stamp` from default build flags for hermeticity
  - Updated comments to clarify that stamping is opt-in for release builds
  - Workspace status command remains enabled for BuildBuddy UI metadata

- **Hook daemon build** (`hook_daemon/BUILD.bazel`):
  - Added `expand_template` rule to generate `_build_info.py` with git commit info
  - New `_build_info` library target that injects `GIT_COMMIT` into the wheel
  - Updated `hook_dispatch` to depend on `_build_info`

- **Version reporting** (`hook_dispatch.py`):
  - Added `--version` flag support that prints `claude-hook 0.1.0 git=<commit>`
  - Enables users to verify installed wheel matches the pinned version

- **Documentation updates**:
  - Updated diagnostic instructions to use `claude-hook --version` instead of readlink/nix paths
  - Simplified version checking workflow in AGENTS.md, web-setup-debug.md, and session_start_recovery.md
  - Updated SKILL.md selfcheck instructions

## Implementation Details

- The unstamped build is deterministic and used purely for content hashing and skip detection
- The stamped build (with `--stamp`) only runs when content has changed, injecting `GIT_COMMIT` via `expand_template`
- Content hash uses SHA256 truncated to 12 hex characters for tag naming
- The `_build_info.tpl` template allows substitution of git commit at build time while maintaining a sensible default for non-stamped builds

https://claude.ai/code/session_01VNYWh8nJmjvLRGL8AUojZr