### PR TITLE
Add ground_skill: guide for creating tested, runnable skill examples

### DIFF
--- a/skills/BUILD.bazel
+++ b/skills/BUILD.bazel
@@ -14,6 +14,7 @@ pkg_tar(
         "//skills/followups:followups_tar",
         "//skills/forensic_surgeon:forensic_surgeon_tar",
         "//skills/freecad:freecad_tar",
+        "//skills/ground_skill:ground_skill_tar",
         "//skills/hetzner_vnc_screenshot:hetzner_vnc_screenshot_tar",
         "//skills/info_gathering:info_gathering_tar",
         "//skills/lint_audit:lint_audit_tar",

--- a/skills/ground_skill/BUILD.bazel
+++ b/skills/ground_skill/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//skills:defs.bzl", "skill_package")
+
+skill_package(
+    name = "ground_skill",
+    srcs = ["SKILL.md"],
+)

--- a/skills/ground_skill/SKILL.md
+++ b/skills/ground_skill/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ground-skill
+description: >
+  Ground a skill in tested, runnable examples. Use when creating a new skill or
+  upgrading an existing skill to have CI-verified recipes. Triggers when the user
+  asks to create a skill, add examples to a skill, or verify a skill has tested
+  recipes.
+---
+
+# Ground a Skill
+
+A **grounded skill** backs its claims with runnable code that CI verifies continuously.
+Prose rots; tests catch it. The agent using the skill reads the same recipe files that
+the tests execute.
+
+## Skill types and grounding approach
+
+| Type           | Examples                  | Grounding                                      |
+| -------------- | ------------------------- | ---------------------------------------------- |
+| Tool/API       | freecad, buildbuddy_api   | Runnable recipe scripts + output golden tests  |
+| Workflow/meta  | followups, verify_docs    | Eval harness: task scenario + scored checklist |
+| Pure reasoning | superforecaster, readback | Eval harness if testable; otherwise minimal    |
+
+Tool/API skills are the highest-value target. They have real, deterministic outputs that
+can be diffed against golden files. Workflow skills use the eval harness pattern (below).
+
+## Process: new skill
+
+1. **Enumerate atomic operations** the skill needs to teach. What are the primitives?
+   What compositions matter?
+2. **Write one recipe per operation** — real, runnable code demonstrating exactly one
+   thing. Put recipes in `examples/`.
+3. **Write a shared helper library** (`examples/helpers.py` or similar) for setup/teardown
+   patterns that repeat across recipes. Recipes import helpers; they don't copy them.
+4. **Write a test per recipe** that actually executes it and asserts on the outputs.
+5. **Commit golden outputs** (images, JSON, text files) alongside the tests so diffs are
+   machine-checked.
+6. **Reference recipes in the skill doc** — every non-obvious pattern should say
+   "see `examples/foo.py`" and that file should be in the tarball the agent receives.
+7. **Wire into Bazel** — `skill_package` target in the skill's `BUILD.bazel`, entry in
+   `skills/BUILD.bazel`'s `all_skills_tar`.
+
+## Process: upgrading an existing skill
+
+1. **Audit the claims** — list every pattern, API call, or command the skill describes.
+2. **Check what's tested** — which claims have runnable recipes? Which are prose-only?
+3. **Identify the highest-value gaps** — untested claims most likely to mislead if stale.
+4. **Add recipes and tests for the gaps**, following the new skill process above.
+5. **Update the skill doc** to reference the new recipe files.
+
+## Recipe quality
+
+- **Atomic**: one recipe, one concept. Two things → split.
+- **Real**: runs against the actual tool/API/environment. No mocks.
+- **Crisp**: minimal setup, direct demonstration. Skip boilerplate the reader can infer.
+- **Self-contained**: imports from helpers, not from other recipes.
+- **Referenced**: the skill doc says "see `examples/foo.py`" and that file exists in
+  the deployed tarball.
+
+Recipes can be Python scripts, shell scripts, or any executable that runs in a container.
+The form follows the skill's domain.
+
+## Test quality
+
+- **Runs the actual recipe** — invokes it against the real tool.
+- **Checks actual output** — assert on output content, not just exit code. The right
+  assertion style depends on the recipe: normal `assert` statements, golden file diffs
+  (syrupy snapshots or committed files), or inspecting side effects in a container.
+- **Fails loudly** — no swallowed exceptions. A broken recipe → a red test.
+
+## Bazel wiring
+
+```python
+# examples/BUILD.bazel — Python recipe
+py_library(name = "my_recipe", srcs = ["my_recipe.py"], deps = [...])
+
+py_test(
+    name = "test_my_recipe",
+    srcs = ["test_my_recipe.py"],
+    data = ["//skills/myskill/conda:tool_binary"],
+    deps = [":my_recipe", "//skills/myskill:conftest", ...],
+)
+
+# examples/BUILD.bazel — shell recipe tested in a Docker container
+sh_test(
+    name = "test_my_script",
+    srcs = ["test_my_script.sh"],
+    data = ["my_script.sh"],
+    # requires_docker = True if needed
+)
+
+# myskill/BUILD.bazel
+load("//skills:defs.bzl", "skill_package")
+
+skill_package(
+    name = "myskill",
+    srcs = [
+        "SKILL.md",
+        "//skills/myskill/examples:my_recipe.py",
+    ],
+)
+```
+
+Add the `myskill_tar` to `skills/BUILD.bazel`'s `all_skills_tar` deps.
+
+## Eval harness (workflow/reasoning skills)
+
+For skills where outputs aren't deterministic, use the eval harness pattern:
+
+```
+skills/myskill/eval/
+  README.md          # how to run the eval
+  scenario_name/
+    TASK.md          # prompt given to the agent
+    CHECKLIST.md     # scored rubric the judge fills out (0/1/2 per criterion)
+  run_eval.py        # launches agent with skill + MCP tools, records transcript
+  BUILD.bazel
+```
+
+The eval is a `py_binary` target (`run_eval`) that agents or humans run manually.
+CI does not gate on it (non-deterministic), but it provides a repeatable benchmark
+for skill improvements.
+
+## Reference
+
+See `//skills/freecad` for the canonical example of a fully grounded tool/API skill:
+recipes in `examples/`, tests with golden outputs, `conftest.py` for container fixtures,
+and an eval harness in `eval/`.

--- a/skills/ground_skill/SKILL.md
+++ b/skills/ground_skill/SKILL.md
@@ -110,7 +110,7 @@ All tests must fail loudly — no swallowed exceptions. A broken recipe → a re
 
 ## Bazel wiring
 
-```python
+```starlark
 # examples/BUILD.bazel
 py_library(name = "my_recipe", srcs = ["my_recipe.py"], deps = [...])
 
@@ -118,16 +118,56 @@ py_test(
     name = "test_my_recipe",
     srcs = ["test_my_recipe.py"],
     data = ["golden.png", "//skills/myskill/conda:tool_binary"],
-    deps = [":my_recipe", "//skills/myskill:conftest", ...],
+    deps = [":my_recipe", "//skills/myskill:conftest", "@pypi//pytest_bazel", ...],
+)
+```
+
+Every `py_test` must include a `pytest_bazel.main()` entry point — without it Bazel
+exits 0 without running any tests (see AGENTS.md):
+
+```python
+import pytest_bazel
+# ... tests ...
+if __name__ == "__main__":
+    pytest_bazel.main()
+```
+
+**Packaging recipes from a subpackage**: `skill_package` uses `strip_prefix.from_pkg()`,
+which drops subdirectory structure for cross-package sources — a recipe from
+`//skills/myskill/examples:my_recipe.py` would land at the skill root, not in
+`examples/`. Use explicit `pkg_files` targets with `prefix` instead (the freecad pattern):
+
+```starlark
+# myskill/BUILD.bazel — when recipes live in examples/
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+pkg_files(
+    name = "myskill_local_files",
+    srcs = ["SKILL.md"],
+    strip_prefix = strip_prefix.from_pkg(),
 )
 
-# myskill/BUILD.bazel
+pkg_files(
+    name = "myskill_example_files",
+    srcs = ["//skills/myskill/examples:my_recipe.py"],
+    prefix = "examples",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_tar(
+    name = "myskill_tar",
+    srcs = [":myskill_local_files", ":myskill_example_files"],
+    package_dir = "myskill",
+    visibility = ["//visibility:public"],
+)
+```
+
+For skills with only a `SKILL.md` and no subpackage recipes, `skill_package` is fine:
+
+```starlark
 load("//skills:defs.bzl", "skill_package")
-
-skill_package(
-    name = "myskill",
-    srcs = ["SKILL.md", "//skills/myskill/examples:my_recipe.py"],
-)
+skill_package(name = "myskill", srcs = ["SKILL.md"])
 ```
 
 Add `myskill_tar` to `skills/BUILD.bazel`'s `all_skills_tar` deps.

--- a/skills/ground_skill/SKILL.md
+++ b/skills/ground_skill/SKILL.md
@@ -21,72 +21,104 @@ the tests execute.
 | Workflow/meta  | followups, verify_docs    | Eval harness: task scenario + scored checklist |
 | Pure reasoning | superforecaster, readback | Eval harness if testable; otherwise minimal    |
 
-Tool/API skills are the highest-value target. They have real, deterministic outputs that
-can be diffed against golden files. Workflow skills use the eval harness pattern (below).
+Tool/API skills are the highest-value target — deterministic outputs that can be asserted
+against. Workflow skills use the eval harness pattern (below).
 
-## Process: new skill
+## Recipes are scaffold-free; tests provide the scaffold
 
-1. **Enumerate atomic operations** the skill needs to teach. What are the primitives?
-   What compositions matter?
-2. **Write one recipe per operation** — real, runnable code demonstrating exactly one
-   thing. Put recipes in `examples/`.
-3. **Write a shared helper library** (`examples/helpers.py` or similar) for setup/teardown
-   patterns that repeat across recipes. Recipes import helpers; they don't copy them.
-4. **Write a test per recipe** that actually executes it and asserts on the outputs.
-5. **Commit golden outputs** (images, JSON, text files) alongside the tests so diffs are
-   machine-checked.
-6. **Reference recipes in the skill doc** — every non-obvious pattern should say
-   "see `examples/foo.py`" and that file should be in the tarball the agent receives.
-7. **Wire into Bazel** — `skill_package` target in the skill's `BUILD.bazel`, entry in
-   `skills/BUILD.bazel`'s `all_skills_tar`.
+Recipes in the skill should contain only the **interesting logic** — the thing the agent
+needs to learn. Boilerplate (starting a process, setting env vars, spinning up a container,
+creating temp dirs) belongs in the test scaffold, not the recipe.
 
-## Process: upgrading an existing skill
+The skill doc explains the required scaffolding **once**, globally. Example: "All FreeCAD
+scripts assume a running FreeCAD instance under Xvfb with `QT_QPA_PLATFORM=offscreen`."
+Agents understand this applies to every recipe without re-reading it each time.
 
-1. **Audit the claims** — list every pattern, API call, or command the skill describes.
-2. **Check what's tested** — which claims have runnable recipes? Which are prose-only?
-3. **Identify the highest-value gaps** — untested claims most likely to mislead if stale.
-4. **Add recipes and tests for the gaps**, following the new skill process above.
-5. **Update the skill doc** to reference the new recipe files.
+Tests add the scaffolding programmatically: start the tool, inject the recipe, tear down.
+The recipe itself stays clean — just the meaty steps — so agents burn no context on setup
+noise and still get fully tested code.
+
+Shared boilerplate across recipes goes in a helper library (`examples/helpers.py` or
+similar). Recipes import helpers; they never copy them.
+
+## Workflow: writing a tested example
+
+Follow this sequence when adding a recipe for something new:
+
+1. **Decide what the example demonstrates** — one atomic operation, one composition.
+2. **Research and figure out how to do it** — read docs, look at existing code, search.
+3. **Try it yourself with fast iteration** — install prerequisites, use the actual tool
+   interactively, the same way the recipe will use it. Don't write the recipe yet.
+4. **When things don't work, document the trap** — wrong assumptions, misleading docs,
+   gotchas you hit. These are exactly the pitfalls the skill should warn about. Add them
+   to the skill's gotchas section as you find them.
+5. **Once it works correctly** (you've verified the output is right — visually, formally,
+   or informally) — write the recipe following the steps you just did.
+6. **Run the recipe** as the agent would run it, including any scaffolding.
+7. **If something breaks, repeat from step 3** — fix the recipe, document any new
+   gotchas, iterate until it runs cleanly.
+8. **Formalize into a test** — add scaffolding in the test harness, write assertions,
+   commit any golden outputs.
+
+The key insight: step 3 (hands-on iteration) is where you discover what the skill needs
+to say. Skipping it and writing the recipe from docs alone produces untested assumptions.
 
 ## Recipe quality
 
 - **Atomic**: one recipe, one concept. Two things → split.
 - **Real**: runs against the actual tool/API/environment. No mocks.
-- **Crisp**: minimal setup, direct demonstration. Skip boilerplate the reader can infer.
-- **Self-contained**: imports from helpers, not from other recipes.
-- **Referenced**: the skill doc says "see `examples/foo.py`" and that file exists in
-  the deployed tarball.
+- **Scaffold-free**: contains only the logic; scaffolding lives in tests and is explained
+  once in the skill doc.
+- **Deduplicated**: shared setup goes into a helper library, not copy-pasted.
+- **Referenced**: the skill doc says "see `examples/foo.py`" and that file is in the
+  deployed tarball.
 
 Recipes can be Python scripts, shell scripts, or any executable that runs in a container.
 The form follows the skill's domain.
 
-## Test quality
+## Test quality and assertion styles
 
-- **Runs the actual recipe** — invokes it against the real tool.
-- **Checks actual output** — assert on output content, not just exit code. The right
-  assertion style depends on the recipe: normal `assert` statements, golden file diffs
-  (syrupy snapshots or committed files), or inspecting side effects in a container.
-- **Fails loudly** — no swallowed exceptions. A broken recipe → a red test.
+Choose the assertion style that gives the best signal-to-noise for the recipe's output:
+
+**Normal assertions** — for structured outputs where you know exactly what to check:
+
+```python
+result = run_recipe(input)
+assert result["count"] == 42
+assert "error" not in result
+```
+
+**Visual golden tests** — for 2D/3D renders, drawings, or any image output. Commit the
+expected image alongside the test. GitHub diffs make pixel drift immediately visible in
+code review. Use a perceptual diff (not byte equality) to tolerate minor rendering
+variation.
+
+**Loose text matching** — for outputs where exact text varies by tool version but key
+content is stable. Check for the presence of known good strings and absence of known bad
+ones rather than full golden equality. Makes tests robust to minor version changes:
+
+```python
+output = run_recipe(binary, test_data)
+assert "foo" in output       # known bool var in test data
+assert "bar" not in output   # known string var, should not appear
+```
+
+**Container side-effects** — for recipes that mutate a file, database, or service: run
+the recipe in a container, then inspect the container state.
+
+All tests must fail loudly — no swallowed exceptions. A broken recipe → a red test.
 
 ## Bazel wiring
 
 ```python
-# examples/BUILD.bazel — Python recipe
+# examples/BUILD.bazel
 py_library(name = "my_recipe", srcs = ["my_recipe.py"], deps = [...])
 
 py_test(
     name = "test_my_recipe",
     srcs = ["test_my_recipe.py"],
-    data = ["//skills/myskill/conda:tool_binary"],
+    data = ["golden.png", "//skills/myskill/conda:tool_binary"],
     deps = [":my_recipe", "//skills/myskill:conftest", ...],
-)
-
-# examples/BUILD.bazel — shell recipe tested in a Docker container
-sh_test(
-    name = "test_my_script",
-    srcs = ["test_my_script.sh"],
-    data = ["my_script.sh"],
-    # requires_docker = True if needed
 )
 
 # myskill/BUILD.bazel
@@ -94,14 +126,11 @@ load("//skills:defs.bzl", "skill_package")
 
 skill_package(
     name = "myskill",
-    srcs = [
-        "SKILL.md",
-        "//skills/myskill/examples:my_recipe.py",
-    ],
+    srcs = ["SKILL.md", "//skills/myskill/examples:my_recipe.py"],
 )
 ```
 
-Add the `myskill_tar` to `skills/BUILD.bazel`'s `all_skills_tar` deps.
+Add `myskill_tar` to `skills/BUILD.bazel`'s `all_skills_tar` deps.
 
 ## Eval harness (workflow/reasoning skills)
 
@@ -112,17 +141,25 @@ skills/myskill/eval/
   README.md          # how to run the eval
   scenario_name/
     TASK.md          # prompt given to the agent
-    CHECKLIST.md     # scored rubric the judge fills out (0/1/2 per criterion)
+    CHECKLIST.md     # scored rubric (0/1/2 per criterion)
   run_eval.py        # launches agent with skill + MCP tools, records transcript
   BUILD.bazel
 ```
 
-The eval is a `py_binary` target (`run_eval`) that agents or humans run manually.
-CI does not gate on it (non-deterministic), but it provides a repeatable benchmark
-for skill improvements.
+The eval is a `py_binary` run manually by agents or humans. CI does not gate on it
+(non-deterministic), but it provides a repeatable benchmark for skill improvements.
+
+## Process: upgrading an existing skill
+
+1. **Audit the claims** — list every pattern, API call, or command the skill describes.
+2. **Check what's tested** — which claims have runnable recipes? Which are prose-only?
+3. **Identify the highest-value gaps** — untested claims most likely to mislead if stale.
+4. **Add recipes and tests for the gaps**, following the workflow above.
+5. **Update the skill doc** to reference the new recipe files.
 
 ## Reference
 
 See `//skills/freecad` for the canonical example of a fully grounded tool/API skill:
-recipes in `examples/`, tests with golden outputs, `conftest.py` for container fixtures,
-and an eval harness in `eval/`.
+scaffold-free recipes in `examples/`, shared helpers in `freecad_helpers.py`, tests with
+visual and structural golden outputs, `conftest.py` for container fixtures, and an eval
+harness in `eval/`.

--- a/skills/ground_skill/SKILL.md
+++ b/skills/ground_skill/SKILL.md
@@ -13,16 +13,12 @@ A **grounded skill** backs its claims with runnable code that CI verifies contin
 Prose rots; tests catch it. The agent using the skill reads the same recipe files that
 the tests execute.
 
-## Skill types and grounding approach
-
-| Type           | Examples                  | Grounding                                      |
-| -------------- | ------------------------- | ---------------------------------------------- |
-| Tool/API       | freecad, buildbuddy_api   | Runnable recipe scripts + output golden tests  |
-| Workflow/meta  | followups, verify_docs    | Eval harness: task scenario + scored checklist |
-| Pure reasoning | superforecaster, readback | Eval harness if testable; otherwise minimal    |
-
-Tool/API skills are the highest-value target — deterministic outputs that can be asserted
-against. Workflow skills use the eval harness pattern (below).
+The tests are a **correctness certificate** for the skill's advice. They don't have to
+judge end-to-end output quality — they just prove that the runnable examples in the skill
+actually work. Even FreeCAD, which produces complex visual outputs that are hard to
+evaluate holistically, has CI tests that certify the examples are correct. That's the bar:
+if the recipes run and produce the expected structural outputs, the skill's claims are
+grounded.
 
 ## Recipes are scaffold-free; tests provide the scaffold
 
@@ -172,23 +168,6 @@ skill_package(name = "myskill", srcs = ["SKILL.md"])
 
 Add `myskill_tar` to `skills/BUILD.bazel`'s `all_skills_tar` deps.
 
-## Eval harness (workflow/reasoning skills)
-
-For skills where outputs aren't deterministic, use the eval harness pattern:
-
-```
-skills/myskill/eval/
-  README.md          # how to run the eval
-  scenario_name/
-    TASK.md          # prompt given to the agent
-    CHECKLIST.md     # scored rubric (0/1/2 per criterion)
-  run_eval.py        # launches agent with skill + MCP tools, records transcript
-  BUILD.bazel
-```
-
-The eval is a `py_binary` run manually by agents or humans. CI does not gate on it
-(non-deterministic), but it provides a repeatable benchmark for skill improvements.
-
 ## Process: upgrading an existing skill
 
 1. **Audit the claims** — list every pattern, API call, or command the skill describes.
@@ -199,7 +178,6 @@ The eval is a `py_binary` run manually by agents or humans. CI does not gate on 
 
 ## Reference
 
-See `//skills/freecad` for the canonical example of a fully grounded tool/API skill:
+See `//skills/freecad` for the canonical example of a fully grounded skill:
 scaffold-free recipes in `examples/`, shared helpers in `freecad_helpers.py`, tests with
-visual and structural golden outputs, `conftest.py` for container fixtures, and an eval
-harness in `eval/`.
+visual and structural golden outputs, and `conftest.py` for container fixtures.


### PR DESCRIPTION
## Summary
Introduces a new meta-skill that documents best practices for grounding skills in tested, runnable examples. This skill provides comprehensive guidance on creating CI-verified recipes that prevent documentation rot through continuous testing.

## Key Changes
- **New skill: `ground_skill`** — A meta-skill documenting the methodology for creating and upgrading skills with tested examples
  - Covers skill types (Tool/API, Workflow/meta, Pure reasoning) and appropriate grounding approaches for each
  - Explains the philosophy of scaffold-free recipes where boilerplate lives in tests, not recipe code
  - Provides a detailed workflow for writing tested examples (research → hands-on iteration → formalization)
  - Documents recipe quality standards (atomic, real, scaffold-free, deduplicated, referenced)
  - Describes multiple assertion styles: normal assertions, visual golden tests, loose text matching, and container side-effects
  - Includes Bazel wiring examples and eval harness pattern for non-deterministic skills
  - References `freecad` skill as the canonical fully-grounded example

- **Build configuration** — Added `ground_skill` to the skills package in `skills/BUILD.bazel`

## Notable Details
The skill emphasizes that hands-on iteration (step 3 in the workflow) is critical for discovering what documentation needs to say, preventing untested assumptions. It advocates for shared boilerplate in helper libraries rather than copy-pasted setup code, keeping recipes focused on the interesting logic agents need to learn.

https://claude.ai/code/session_01Aj6ifFgdHnCcVZoFAeVwfN