### PR TITLE
skills/reverse_engineer: CI-verified binary diff recipe for garbled Go binaries

### DIFF
--- a/skills/reverse_engineer/BUILD.bazel
+++ b/skills/reverse_engineer/BUILD.bazel
@@ -10,6 +10,7 @@ pkg_files(
 pkg_files(
     name = "reverse_engineer_example_files",
     srcs = [
+        "//skills/reverse_engineer/examples:binary_diff_recipe.sh",
         "//skills/reverse_engineer/examples:garble_re_recipe.sh",
         "//skills/reverse_engineer/examples:pclntool.go",
     ],

--- a/skills/reverse_engineer/NOTES.md
+++ b/skills/reverse_engineer/NOTES.md
@@ -1,0 +1,26 @@
+# Notes
+
+## `go_binary` vs `plain_binary` for v1_plain
+
+We tried switching from the custom `plain_binary` Starlark rule to the standard
+`go_binary` rule from rules_go. It doesn't work for this use case.
+
+**Root cause**: rules_go builds binaries using `go tool compile`/`go tool link`
+directly, bypassing the normal `go build` module infrastructure. The resulting
+binary embeds only the Go toolchain version (`go1.26.2`) in its buildinfo — no
+`path` or `mod` fields. So `go version -m v1_plain` outputs just:
+
+```
+v1_plain: go1.26.2
+```
+
+**Why this matters**: The binary diff recipe uses `go version -m` to contrast a
+plain binary (full module info) against a garbled one (`unknown`). A rules_go
+binary looks like neither — it defeats the demonstration.
+
+**`plain_binary` works because** it does a real `go build` with a proper
+`go.mod` (`module garble_target`), which causes Go to embed full buildinfo
+including the module path. That's also why `go version -m v1_plain | grep
+"garble_target"` works in the recipe.
+
+**Keep `plain_binary`** in `defs.bzl`. Don't switch to `go_binary`.

--- a/skills/reverse_engineer/SKILL.md
+++ b/skills/reverse_engineer/SKILL.md
@@ -225,7 +225,7 @@ magic and get garbage. This is a defeated technique: `pclntool`
 (`examples/pclntool.go`) patches each known Go magic in-memory until
 `gosym.NewTable` succeeds. See `examples/garble_re_recipe.sh` for the full
 workflow: pclntab deobfuscation → redress/GoReSym enumeration → string →
-byte offset → VMA → instruction PC → function name.
+byte offset → VMA → instruction PC → function name (see `examples/binary_diff_recipe.sh`).
 
 ### Go-Specific: Instruction-Level Analysis and String-to-Function Anchoring
 
@@ -236,15 +236,8 @@ For pclntab-based PC→function mapping, use `pclntool` (see `examples/pclntool.
 garble v0.13.0+ obfuscates the `.gopclntab` magic bytes, so standard Go tooling
 that reads pclntab won't work until the magic is repaired.
 
-**Workflow:** read `examples/garble_re_recipe.sh` — it is a runnable, CI-verified
+**Workflow:** read `examples/binary_diff_recipe.sh` — it is a runnable, CI-verified
 demonstration with inline commentary explaining each step.
-
-```bash
-# Step 6: correlate register/offset patterns to struct fields
-# LEA rdi, [rcx+0x30]  →  receiver field at offset 0x30
-# MOVQ [rsp+0x18], rax →  stack argument at position 3
-# Cross-reference with RTTI struct layouts to name the fields
-```
 
 **Reading call arguments from disassembly:**
 
@@ -400,22 +393,6 @@ the same set of strings are the same function.
 of this technique: plain v1 binary (symbols intact) vs. garble-obfuscated v2
 (new function added). The recipe shows shared-string matching identifying the
 same function across versions, and v2-only strings identifying the new function.
-
-```bash
-# 1. For old binary (has symbols): map function → strings it references
-#    nm "$OLD" gives symbol names and addresses; objdump -d gives disassembly
-#    to find which strings each function loads
-
-# 2. For new garbled binary: find all string-referencing code sites
-#    strings -t x "$NEW" gives (file-offset, string) pairs
-#    Convert offset to VMA via readelf -S, then use pclntool to map PC → garbled fn
-
-# 3. Match: old function refs {"error A", "log B"} = new function refs same strings
-#    → new garbled function = old named function
-
-# 4. Identify NEW functions: string refs in new binary with no match in old
-#    → these are new or changed code, need manual RE
-```
 
 **What to do with the mapping:**
 

--- a/skills/reverse_engineer/SKILL.md
+++ b/skills/reverse_engineer/SKILL.md
@@ -396,6 +396,11 @@ string references alone. Most application functions reference at least one
 unique string (log message, error text, format string). Functions referencing
 the same set of strings are the same function.
 
+**See `examples/binary_diff_recipe.sh` for a runnable, CI-verified demonstration**
+of this technique: plain v1 binary (symbols intact) vs. garble-obfuscated v2
+(new function added). The recipe shows shared-string matching identifying the
+same function across versions, and v2-only strings identifying the new function.
+
 ```bash
 # 1. For old binary (has symbols): map function → strings it references
 #    nm "$OLD" gives symbol names and addresses; objdump -d gives disassembly

--- a/skills/reverse_engineer/SKILL.md
+++ b/skills/reverse_engineer/SKILL.md
@@ -236,8 +236,8 @@ For pclntab-based PC→function mapping, use `pclntool` (see `examples/pclntool.
 garble v0.13.0+ obfuscates the `.gopclntab` magic bytes, so standard Go tooling
 that reads pclntab won't work until the magic is repaired.
 
-**Workflow:** read `examples/binary_diff_recipe.sh` — it is a runnable, CI-verified
-demonstration with inline commentary explaining each step.
+**Workflow:** read `examples/binary_diff_recipe.sh` — a runnable demonstration
+with inline commentary explaining each step.
 
 **Reading call arguments from disassembly:**
 

--- a/skills/reverse_engineer/TODO.md
+++ b/skills/reverse_engineer/TODO.md
@@ -35,19 +35,14 @@ the patched binary, but the names are still opaque hashes — we can't yet map
    loads each distinctive string, then assign a descriptive name from the string
    content.
 
-**Recipe sketch** (ground-skill-style):
+**Recipe** (CI-verified): `examples/binary_diff_recipe.sh` + `examples/test_scaffold_binary_diff.sh`.
 
-- Build victim_v1 plain (`go build`); build victim_v2 (adds/removes functions,
-  renames a few strings) garbled (`garble build`). Using two different versions
-  makes the match realistic: some functions are new in v2 (unmatched in v1),
-  some are renamed/changed (partial match), some are identical (high confidence).
-- Run `radiff2 -Cj victim_v1 victim_v2_garbled | python3 -c "..."` to extract
-  matched pairs with similarity scores.
-- Assert: high-similarity pairs (>0.9) share the same distinctive strings.
-- Assert: new v2 functions (no v1 counterpart) are identified and left unnamed.
-- For unmatched garbled functions: run string_vma→fn_at_vma recipe to name them
-  from their string references.
-- Verify: all strings in the garbled binary anchored to a named function.
+- Builds victim_v1 plain (`go build` from `cmd/garble_target`).
+- Builds victim_v2 garbled (`garble build` from `cmd/garble_target_v2`, which adds `validateConfig`).
+- Asserts: shared strings ("connection refused", "failed to read config file") anchor to the
+  correct named v1 functions and to distinct garbled v2 functions.
+- Asserts: v2-only string ("invalid port: must be between 1 and 65535") is absent from v1 and
+  maps to a distinct garbled function in v2 (the new `validateConfig`).
 
 ### Function/type name recovery without a reference binary
 

--- a/skills/reverse_engineer/TODO.md
+++ b/skills/reverse_engineer/TODO.md
@@ -35,15 +35,6 @@ the patched binary, but the names are still opaque hashes — we can't yet map
    loads each distinctive string, then assign a descriptive name from the string
    content.
 
-**Recipe** (CI-verified): `examples/binary_diff_recipe.sh` + `examples/test_scaffold_binary_diff.sh`.
-
-- Builds victim_v1 plain (`go build` from `cmd/garble_target`).
-- Builds victim_v2 garbled (`garble build` from `cmd/garble_target_v2`, which adds `validateConfig`).
-- Asserts: shared strings ("connection refused", "failed to read config file") anchor to the
-  correct named v1 functions and to distinct garbled v2 functions.
-- Asserts: v2-only string ("invalid port: must be between 1 and 65535") is absent from v1 and
-  maps to a distinct garbled function in v2 (the new `validateConfig`).
-
 ### Function/type name recovery without a reference binary
 
 **What's needed**: when no unobfuscated reference exists, recover human-readable

--- a/skills/reverse_engineer/cmd/garble_target_v2/BUILD.bazel
+++ b/skills/reverse_engineer/cmd/garble_target_v2/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//skills/reverse_engineer/examples:__pkg__"],
+)

--- a/skills/reverse_engineer/cmd/garble_target_v2/main.go
+++ b/skills/reverse_engineer/cmd/garble_target_v2/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// v2: same as v1, but adds validateConfig() — new function, not in v1.
+// connectToServer now calls validateConfig before returning the connection error.
+// All original strings are preserved so string-anchored matching works across versions.
+
+type ServerConfig struct {
+	Host  string `json:"host"`
+	Port  int    `json:"port"`
+	Token string `json:"token,omitempty"`
+}
+
+//go:noinline
+func validateConfig(cfg ServerConfig) error {
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return fmt.Errorf("invalid port: must be between 1 and 65535")
+	}
+	return nil
+}
+
+//go:noinline
+func connectToServer(cfg ServerConfig) error {
+	if cfg.Host == "" {
+		return fmt.Errorf("missing required field: host")
+	}
+	if err := validateConfig(cfg); err != nil {
+		return err
+	}
+	return fmt.Errorf("connection refused: server not accepting connections")
+}
+
+//go:noinline
+func loadConfig(path string) (ServerConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ServerConfig{}, fmt.Errorf("failed to read config file: %w", err)
+	}
+	var cfg ServerConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return ServerConfig{}, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return cfg, nil
+}
+
+func main() {
+	cfg, err := loadConfig("config.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "startup failed: %v\n", err)
+		os.Exit(1)
+	}
+	if err := connectToServer(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "connection error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/skills/reverse_engineer/examples/BUILD.bazel
+++ b/skills/reverse_engineer/examples/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 exports_files(
     [
+        "binary_diff_recipe.sh",
         "garble_hash_fix.patch",
         "garble_re_recipe.sh",
         "pclntool.go",
@@ -41,5 +42,26 @@ sh_test(
         "PCLNTOOL": "$(rlocationpath :pclntool)",
         "RECIPE": "$(rlocationpath garble_re_recipe.sh)",
         "REDRESS": "$(rlocationpath @com_github_goretk_redress//:redress)",
+    },
+)
+
+sh_test(
+    name = "test_binary_diff_demo",
+    srcs = ["test_scaffold_binary_diff.sh"],
+    data = [
+        "binary_diff_recipe.sh",
+        ":pclntool",
+        "//skills/reverse_engineer/cmd/garble_target:srcs",
+        "//skills/reverse_engineer/cmd/garble_target_v2:srcs",
+        "//third_party:go.mod",
+        "//third_party:go.sum",
+        "@cc_mvdan_garble//:garble",
+        "@io_bazel_rules_go//go",
+    ],
+    env = {
+        "GARBLE": "$(rlocationpath @cc_mvdan_garble//:garble)",
+        "GO": "$(rlocationpath @io_bazel_rules_go//go:go)",
+        "PCLNTOOL": "$(rlocationpath :pclntool)",
+        "RECIPE": "$(rlocationpath binary_diff_recipe.sh)",
     },
 )

--- a/skills/reverse_engineer/examples/BUILD.bazel
+++ b/skills/reverse_engineer/examples/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":defs.bzl", "garble_binary", "plain_binary")
 
 exports_files(
     [
@@ -45,23 +46,39 @@ sh_test(
     },
 )
 
+# Build v1_plain (plain go build, symbols intact) as a cached Bazel artifact.
+plain_binary(
+    name = "build_v1_plain",
+    srcs = ["//skills/reverse_engineer/cmd/garble_target:srcs"],
+    out = "v1_plain",
+)
+
+# Build v2_garbled (garble with fixed seed) as a cached Bazel artifact.
+# Fixed seed ZHVja3RhcGU= (base64 "ducktape") → deterministic obfuscated names.
+garble_binary(
+    name = "build_v2_garbled",
+    srcs = ["//skills/reverse_engineer/cmd/garble_target_v2:srcs"],
+    out = "v2_garbled",
+    seed = "ZHVja3RhcGU=",
+)
+
 sh_test(
     name = "test_binary_diff_demo",
     srcs = ["test_scaffold_binary_diff.sh"],
     data = [
         "binary_diff_recipe.sh",
+        ":build_v1_plain",
+        ":build_v2_garbled",
         ":pclntool",
-        "//skills/reverse_engineer/cmd/garble_target:srcs",
-        "//skills/reverse_engineer/cmd/garble_target_v2:srcs",
         "//third_party:go.mod",
         "//third_party:go.sum",
-        "@cc_mvdan_garble//:garble",
         "@io_bazel_rules_go//go",
     ],
     env = {
-        "GARBLE": "$(rlocationpath @cc_mvdan_garble//:garble)",
         "GO": "$(rlocationpath @io_bazel_rules_go//go:go)",
         "PCLNTOOL": "$(rlocationpath :pclntool)",
         "RECIPE": "$(rlocationpath binary_diff_recipe.sh)",
+        "V1_PLAIN": "$(rlocationpath :build_v1_plain)",
+        "V2_GARBLED": "$(rlocationpath :build_v2_garbled)",
     },
 )

--- a/skills/reverse_engineer/examples/binary_diff_recipe.sh
+++ b/skills/reverse_engineer/examples/binary_diff_recipe.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 # Recipe: cross-version binary diffing on garble-obfuscated Go binaries.
 #
-# Demonstrates string-anchored function matching: given a plain binary (v1,
-# symbols intact) and a garble-obfuscated binary (v2, names randomized), shared
-# string literals identify the same logical function across versions. v2-only
-# strings identify newly added functions with no v1 counterpart.
+# Demonstrates string-anchored function matching step-by-step against a real
+# binary pair: v1_plain (symbols intact) and v2_garbled (names randomized,
+# built with a fixed garble seed so all addresses and names are deterministic).
 #
-# The technique for the garbled binary:
+# Technique for the garbled binary:
 #   string → file offset → .rodata VMA → instruction referencing that VMA
-#   → pclntool maps the instruction PC to its garbled function name
+#   → instruction PC → pclntool maps PC to garbled function name
 #
-# For the reference binary (v1, has symbols), nm directly lists function names.
-# Shared strings confirm both binaries' functions correspond to the same source.
+# For the reference binary (v1, has symbols), nm lists function names directly.
 #
 # Prerequisites:
 #   - 'v1_plain'   in cwd — Go binary built without garble (has pclntab + symbols)
-#   - 'v2_garbled' in cwd — updated codebase built with garble (no symbols)
-#   - 'objdump', 'readelf', 'nm', 'strings' on PATH
+#   - 'v2_garbled' in cwd — same codebase (+ validateConfig) built with garble
+#                           and a fixed seed for deterministic output
+#   - 'objdump', 'readelf', 'nm', 'strings', 'go' on PATH
 #   - 'pclntool' on PATH   (build with: go build -o pclntool pclntool.go)
-#   - 'go' on PATH         (for 'go version -m')
 
 set -euo pipefail
 
@@ -27,53 +25,62 @@ fail() {
   exit 1
 }
 
-# string_vma BINARY STRING → hex VMA of STRING's bytes in .rodata
+# string_vma BINARY STRING
+#   Compute the virtual address of STRING's bytes in .rodata.
+#   Prints: file offset, .rodata bounds, and the resulting VMA.
 string_vma() {
   local binary="$1" search="$2"
-  local file_off sec_vma sec_file
+  local file_off sec_vma sec_file vma
   file_off=$(grep -obaF "$search" "$binary" | head -1 | cut -d: -f1)
   [ -n "$file_off" ] || fail "'$search' not found in $binary"
   sec_vma=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$5; exit}')
   sec_file=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$6; exit}')
-  printf "0x%x" $((sec_vma + file_off - sec_file))
+  vma=$(printf "0x%x" $((sec_vma + file_off - sec_file)))
+  echo "    file offset:     $file_off (decimal)"
+  echo "    .rodata VMA:     $sec_vma"
+  echo "    .rodata fileoff: $sec_file"
+  echo "    string VMA:      $vma"
+  echo "$vma"
 }
 
-# fn_at_vma BINARY VMA → garbled function name via pclntool.
-#
-# Garbled (PIE) binaries use RIP-relative string references; objdump annotates
-# them with '# VMA'. Plain binaries may use absolute or GOT-based addressing,
-# so this technique is not reliable for non-garbled binaries.
+# fn_at_vma BINARY VMA
+#   Find the instruction referencing VMA and map its PC to a function name.
+#   Prints the matching objdump line and the resolved function name.
 fn_at_vma() {
   local binary="$1" vma="$2"
-  local insn_line insn_addr
+  local insn_line insn_addr fn
   insn_line=$(objdump -d "$binary" 2>/dev/null | grep -E "# ${vma}( <|$)" | head -1)
   [ -n "$insn_line" ] || fail "no instruction in $binary references VMA $vma"
+  echo "    objdump line:    $insn_line"
   insn_addr=0x$(echo "$insn_line" | awk '{print $1}' | tr -d ':')
-  pclntool pc "$binary" "$insn_addr"
+  echo "    instruction PC:  $insn_addr"
+  fn=$(pclntool pc "$binary" "$insn_addr")
+  echo "    garbled name:    $fn"
+  echo "$fn"
 }
 
-# fn_for_string_v2 STRING → garbled function name in v2_garbled containing STRING
+# fn_for_string_v2 STRING
+#   Full pipeline: string → VMA → instruction → garbled function name.
 fn_for_string_v2() {
-  fn_at_vma v2_garbled "$(string_vma v2_garbled "$1")"
+  local search="$1" vma fn
+  vma=$(string_vma v2_garbled "$search" | tail -1)
+  fn=$(fn_at_vma v2_garbled "$vma" | tail -1)
+  echo "$fn"
 }
 
 echo "=== 1. Verify binary properties ==="
-
 go version -m v1_plain 2>&1 | grep -q "garble_target" \
   || fail "v1_plain does not contain expected module info"
 echo "v1_plain: symbols + module info intact"
-
 go version -m v2_garbled 2>&1 | grep -q "unknown" \
   || fail "v2_garbled does not appear to be garbled"
 echo "v2_garbled: module info stripped (garble confirmed)"
 
 echo ""
-echo "=== 2. v1 function inventory via nm (establishes ground truth) ==="
-# nm lists all TEXT symbols in the plain binary — a direct name roster.
+echo "=== 2. v1 function inventory via nm ==="
 echo "TEXT symbols in v1_plain (main package):"
 nm v1_plain 2>/dev/null | awk '$2 == "T" && $3 ~ /^main\./ {print "  " $3}'
 
-# Use awk for symbol checks (consistent with how we extracted $3 above).
 check_present() {
   local sym="$1"
   nm v1_plain 2>/dev/null | awk -v s="$sym" '$3 == s {found=1} END {exit !found}' \
@@ -87,48 +94,47 @@ check_absent() {
 
 check_present "main.connectToServer"
 check_present "main.loadConfig"
-
-# validateConfig is new in v2 — must NOT be in v1.
 check_absent "main.validateConfig"
-echo "  main.validateConfig absent from v1 (as expected — added in v2)"
+echo "  main.validateConfig absent from v1 (new in v2)"
 
 echo ""
-echo "=== 3. v2 function names via string anchoring ==="
-# 'connection refused' is in connectToServer (both v1 and v2).
-# 'failed to read config file' is in loadConfig (both v1 and v2).
-# 'invalid port' is in validateConfig (v2 only).
+echo "=== 3. String-anchored function mapping in v2_garbled ==="
 
 S1="connection refused: server not accepting connections"
-S2="failed to read config file"
-S_NEW="invalid port: must be between 1 and 65535"
-
+echo "--- '$S1' ---"
 fn1_v2=$(fn_for_string_v2 "$S1")
+
+S2="failed to read config file"
+echo "--- '$S2' ---"
 fn2_v2=$(fn_for_string_v2 "$S2")
-echo "  '$S1'"
-echo "  → v2 garbled fn: $fn1_v2  (corresponds to main.connectToServer)"
 
-echo "  '$S2'"
-echo "  → v2 garbled fn: $fn2_v2  (corresponds to main.loadConfig)"
-
-# Two distinct source functions → two distinct garbled names.
+echo ""
+echo "--- Summary so far ---"
+echo "  '$S1' → $fn1_v2"
+echo "  '$S2' → $fn2_v2"
 [ "$fn1_v2" != "$fn2_v2" ] \
-  || fail "connectToServer and loadConfig garbled to the same name ($fn1_v2)"
+  || fail "connectToServer and loadConfig garbled to same name ($fn1_v2)"
 echo "  PASS: two distinct source functions → two distinct garbled names"
 
 echo ""
-echo "=== 4. v2-only string → new function with no v1 counterpart ==="
+echo "=== 4. v2-only string identifies new function ==="
 
+S_NEW="invalid port: must be between 1 and 65535"
+echo "--- '$S_NEW' ---"
 ! grep -qaF "$S_NEW" v1_plain \
   || fail "'$S_NEW' found in v1_plain — expected only in v2"
-echo "  '$S_NEW' absent from v1 (validateConfig only exists in v2)"
-
+echo "  absent from v1"
 fn_new=$(fn_for_string_v2 "$S_NEW")
-echo "  → v2 garbled fn: $fn_new  (new validateConfig, no v1 counterpart)"
 
+echo ""
+echo "--- Summary ---"
+echo "  '$S1' → $fn1_v2   (connectToServer)"
+echo "  '$S2' → $fn2_v2   (loadConfig)"
+echo "  '$S_NEW' → $fn_new   (validateConfig, v2-only)"
 [ "$fn_new" != "$fn1_v2" ] \
-  || fail "validateConfig collides with connectToServer garbled name ($fn1_v2)"
+  || fail "validateConfig collides with connectToServer garbled name"
 [ "$fn_new" != "$fn2_v2" ] \
-  || fail "validateConfig collides with loadConfig garbled name ($fn2_v2)"
+  || fail "validateConfig collides with loadConfig garbled name"
 echo "  PASS: three distinct garbled names for three distinct source functions"
 
 echo ""

--- a/skills/reverse_engineer/examples/binary_diff_recipe.sh
+++ b/skills/reverse_engineer/examples/binary_diff_recipe.sh
@@ -3,19 +3,22 @@
 #
 # Demonstrates string-anchored function matching step-by-step against a real
 # binary pair: v1_plain (symbols intact) and v2_garbled (names randomized,
-# built with a fixed garble seed so all addresses and names are deterministic).
+# built with a fixed garble seed so all intermediate values are deterministic).
 #
 # Technique for the garbled binary:
 #   string → file offset → .rodata VMA → instruction referencing that VMA
 #   → instruction PC → pclntool maps PC to garbled function name
 #
-# For the reference binary (v1, has symbols), nm lists function names directly.
+# Golden values (seed=ZHVja3RhcGU=, i.e. base64("ducktape")):
+#   connectToServer  string VMA 0x51a851  PC 0x4dfccd  → main.h8n9KNzKUCmw
+#   loadConfig       string VMA 0x5162ef  PC 0x4dfdc2  → main.bhY2uMqP4
+#   validateConfig   string VMA 0x518f8a  PC 0x4dfb9c  → main.epq7tEoS
 #
 # Prerequisites:
 #   - 'v1_plain'   in cwd — Go binary built without garble (has pclntab + symbols)
 #   - 'v2_garbled' in cwd — same codebase (+ validateConfig) built with garble
-#                           and a fixed seed for deterministic output
-#   - 'objdump', 'readelf', 'nm', 'strings', 'go' on PATH
+#                           using a fixed seed for deterministic output
+#   - 'objdump', 'readelf', 'nm', 'go' on PATH
 #   - 'pclntool' on PATH   (build with: go build -o pclntool pclntool.go)
 
 set -euo pipefail
@@ -25,47 +28,57 @@ fail() {
   exit 1
 }
 
-# string_vma BINARY STRING
-#   Compute the virtual address of STRING's bytes in .rodata.
-#   Prints: file offset, .rodata bounds, and the resulting VMA.
+assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if [ "$got" != "$want" ]; then
+    fail "$label: expected '$want', got '$got'"
+  fi
+  echo "  ASSERT OK: $label = '$got'"
+}
+
+# string_vma BINARY STRING EXPECTED_VMA
+#   stdout: hex VMA; stderr: step trace; asserts VMA matches expected
 string_vma() {
-  local binary="$1" search="$2"
+  local binary="$1" search="$2" expected_vma="$3"
   local file_off sec_vma sec_file vma
   file_off=$(grep -obaF "$search" "$binary" | head -1 | cut -d: -f1)
   [ -n "$file_off" ] || fail "'$search' not found in $binary"
   sec_vma=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$5; exit}')
   sec_file=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$6; exit}')
   vma=$(printf "0x%x" $((sec_vma + file_off - sec_file)))
-  echo "    file offset:     $file_off (decimal)"
-  echo "    .rodata VMA:     $sec_vma"
-  echo "    .rodata fileoff: $sec_file"
-  echo "    string VMA:      $vma"
+  echo "  string file offset: $file_off" >&2
+  echo "  .rodata VMA:        $sec_vma  file offset: $sec_file" >&2
+  echo "  string VMA:         $vma" >&2
+  assert_eq "string VMA for '$search'" "$vma" "$expected_vma" >&2
   echo "$vma"
 }
 
-# fn_at_vma BINARY VMA
-#   Find the instruction referencing VMA and map its PC to a function name.
-#   Prints the matching objdump line and the resolved function name.
+# fn_at_vma BINARY VMA EXPECTED_PC EXPECTED_BYTES EXPECTED_FN
+#   stdout: garbled fn name; stderr: step trace; asserts PC, bytes, fn match expected
 fn_at_vma() {
-  local binary="$1" vma="$2"
+  local binary="$1" vma="$2" expected_pc="$3" expected_bytes="$4" expected_fn="$5"
   local insn_line insn_addr fn
   insn_line=$(objdump -d "$binary" 2>/dev/null | grep -E "# ${vma}( <|$)" | head -1)
   [ -n "$insn_line" ] || fail "no instruction in $binary references VMA $vma"
-  echo "    objdump line:    $insn_line"
+  echo "  objdump:            $insn_line" >&2
   insn_addr=0x$(echo "$insn_line" | awk '{print $1}' | tr -d ':')
-  echo "    instruction PC:  $insn_addr"
+  echo "  instruction PC:     $insn_addr" >&2
+  assert_eq "instruction PC for VMA $vma" "$insn_addr" "$expected_pc" >&2
+  # Check instruction bytes (space-separated hex from the objdump line)
+  insn_bytes=$(echo "$insn_line" | awk '{
+    s = ""; for (i=2; i<=8; i++) { if ($i ~ /^[0-9a-f][0-9a-f]$/) s = s (s ? " " : "") $i }; print s}')
+  echo "  instruction bytes:  $insn_bytes" >&2
+  assert_eq "instruction bytes for VMA $vma" "$insn_bytes" "$expected_bytes" >&2
   fn=$(pclntool pc "$binary" "$insn_addr")
-  echo "    garbled name:    $fn"
+  echo "  garbled name:       $fn" >&2
+  assert_eq "garbled name for VMA $vma" "$fn" "$expected_fn" >&2
   echo "$fn"
 }
 
-# fn_for_string_v2 STRING
-#   Full pipeline: string → VMA → instruction → garbled function name.
 fn_for_string_v2() {
-  local search="$1" vma fn
-  vma=$(string_vma v2_garbled "$search" | tail -1)
-  fn=$(fn_at_vma v2_garbled "$vma" | tail -1)
-  echo "$fn"
+  local vma
+  vma=$(string_vma v2_garbled "$1" "$2")
+  fn_at_vma v2_garbled "$vma" "$3" "$4" "$5"
 }
 
 echo "=== 1. Verify binary properties ==="
@@ -82,14 +95,12 @@ echo "TEXT symbols in v1_plain (main package):"
 nm v1_plain 2>/dev/null | awk '$2 == "T" && $3 ~ /^main\./ {print "  " $3}'
 
 check_present() {
-  local sym="$1"
-  nm v1_plain 2>/dev/null | awk -v s="$sym" '$3 == s {found=1} END {exit !found}' \
-    || fail "$sym not in v1 symbol table"
+  nm v1_plain 2>/dev/null | awk -v s="$1" '$3 == s {found=1} END {exit !found}' \
+    || fail "$1 not in v1 symbol table"
 }
 check_absent() {
-  local sym="$1"
-  nm v1_plain 2>/dev/null | awk -v s="$sym" '$3 == s {found=1} END {exit found}' \
-    || fail "$sym unexpectedly found in v1 symbol table"
+  nm v1_plain 2>/dev/null | awk -v s="$1" '$3 == s {found=1} END {exit found}' \
+    || fail "$1 unexpectedly found in v1 symbol table"
 }
 
 check_present "main.connectToServer"
@@ -99,43 +110,50 @@ echo "  main.validateConfig absent from v1 (new in v2)"
 
 echo ""
 echo "=== 3. String-anchored function mapping in v2_garbled ==="
+# Golden values are deterministic for seed ZHVja3RhcGU= (base64 "ducktape").
 
 S1="connection refused: server not accepting connections"
-echo "--- '$S1' ---"
-fn1_v2=$(fn_for_string_v2 "$S1")
-
-S2="failed to read config file"
-echo "--- '$S2' ---"
-fn2_v2=$(fn_for_string_v2 "$S2")
+echo "Locating '$S1':"
+# Expected: string VMA 0x51a851, lea at PC 0x4dfccd, bytes 48 8d 05 7d ab 03 00
+fn1_v2=$(fn_for_string_v2 "$S1" "0x51a851" "0x4dfccd" "48 8d 05 7d ab 03 00" "main.h8n9KNzKUCmw")
+echo "  → $fn1_v2"
 
 echo ""
-echo "--- Summary so far ---"
-echo "  '$S1' → $fn1_v2"
-echo "  '$S2' → $fn2_v2"
+S2="failed to read config file"
+echo "Locating '$S2':"
+# Expected: string VMA 0x5162ef, lea at PC 0x4dfdc2, bytes 48 8d 05 26 65 03 00
+fn2_v2=$(fn_for_string_v2 "$S2" "0x5162ef" "0x4dfdc2" "48 8d 05 26 65 03 00" "main.bhY2uMqP4")
+echo "  → $fn2_v2"
+
+echo ""
 [ "$fn1_v2" != "$fn2_v2" ] \
   || fail "connectToServer and loadConfig garbled to same name ($fn1_v2)"
-echo "  PASS: two distinct source functions → two distinct garbled names"
+echo "PASS: distinct source functions → distinct garbled names"
 
 echo ""
 echo "=== 4. v2-only string identifies new function ==="
 
 S_NEW="invalid port: must be between 1 and 65535"
-echo "--- '$S_NEW' ---"
 ! grep -qaF "$S_NEW" v1_plain \
   || fail "'$S_NEW' found in v1_plain — expected only in v2"
-echo "  absent from v1"
-fn_new=$(fn_for_string_v2 "$S_NEW")
+echo "'$S_NEW': absent from v1 (validateConfig only exists in v2)"
+echo "Locating '$S_NEW' in v2_garbled:"
+# Expected: string VMA 0x518f8a, lea at PC 0x4dfb9c, bytes 48 8d 05 e7 93 03 00
+fn_new=$(fn_for_string_v2 "$S_NEW" "0x518f8a" "0x4dfb9c" "48 8d 05 e7 93 03 00" "main.epq7tEoS")
+echo "  → $fn_new"
 
 echo ""
-echo "--- Summary ---"
-echo "  '$S1' → $fn1_v2   (connectToServer)"
-echo "  '$S2' → $fn2_v2   (loadConfig)"
-echo "  '$S_NEW' → $fn_new   (validateConfig, v2-only)"
 [ "$fn_new" != "$fn1_v2" ] \
   || fail "validateConfig collides with connectToServer garbled name"
 [ "$fn_new" != "$fn2_v2" ] \
   || fail "validateConfig collides with loadConfig garbled name"
-echo "  PASS: three distinct garbled names for three distinct source functions"
+echo "PASS: three distinct garbled names for three distinct source functions"
+
+echo ""
+echo "=== Summary ==="
+echo "  connectToServer  string VMA 0x51a851  PC 0x4dfccd  →  $fn1_v2"
+echo "  loadConfig       string VMA 0x5162ef  PC 0x4dfdc2  →  $fn2_v2"
+echo "  validateConfig   string VMA 0x518f8a  PC 0x4dfb9c  →  $fn_new  (v2-only)"
 
 echo ""
 echo "All assertions passed."

--- a/skills/reverse_engineer/examples/binary_diff_recipe.sh
+++ b/skills/reverse_engineer/examples/binary_diff_recipe.sh
@@ -41,10 +41,16 @@ assert_eq() {
 string_vma() {
   local binary="$1" search="$2" expected_vma="$3"
   local file_off sec_vma sec_file vma
-  file_off=$(grep -obaF "$search" "$binary" | head -1 | cut -d: -f1)
+  file_off=$(grep -obaF "$search" "$binary" | head -1 | cut -d: -f1 || true)
   [ -n "$file_off" ] || fail "'$search' not found in $binary"
-  sec_vma=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$5; exit}')
-  sec_file=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$6; exit}')
+  read -r sec_vma sec_file < <(
+    readelf -S "$binary" | awk '{
+      for (i = 1; i <= NF; i++) {
+        if ($i == ".rodata") { print "0x" $(i+2), "0x" $(i+3); exit }
+      }
+    }'
+  )
+  [ -n "${sec_vma:-}" ] && [ -n "${sec_file:-}" ] || fail "failed to locate .rodata in $binary"
   vma=$(printf "0x%x" $((sec_vma + file_off - sec_file)))
   echo "  string file offset: $file_off" >&2
   echo "  .rodata VMA:        $sec_vma  file offset: $sec_file" >&2
@@ -57,14 +63,13 @@ string_vma() {
 #   stdout: garbled fn name; stderr: step trace; asserts PC, bytes, fn match expected
 fn_at_vma() {
   local binary="$1" vma="$2" expected_pc="$3" expected_bytes="$4" expected_fn="$5"
-  local insn_line insn_addr fn
-  insn_line=$(objdump -d "$binary" 2>/dev/null | grep -E "# ${vma}( <|$)" | head -1)
+  local insn_line insn_addr insn_bytes fn
+  insn_line=$(objdump -d "$binary" 2>/dev/null | grep -E "# ${vma}( <|$)" | head -1 || true)
   [ -n "$insn_line" ] || fail "no instruction in $binary references VMA $vma"
   echo "  objdump:            $insn_line" >&2
   insn_addr=0x$(echo "$insn_line" | awk '{print $1}' | tr -d ':')
   echo "  instruction PC:     $insn_addr" >&2
   assert_eq "instruction PC for VMA $vma" "$insn_addr" "$expected_pc" >&2
-  # Check instruction bytes (space-separated hex from the objdump line)
   insn_bytes=$(echo "$insn_line" | awk '{
     s = ""; for (i=2; i<=8; i++) { if ($i ~ /^[0-9a-f][0-9a-f]$/) s = s (s ? " " : "") $i }; print s}')
   echo "  instruction bytes:  $insn_bytes" >&2
@@ -81,16 +86,14 @@ fn_for_string_v2() {
   fn_at_vma v2_garbled "$vma" "$3" "$4" "$5"
 }
 
-echo "=== 1. Verify binary properties ==="
+echo "=== verify ==="
 go version -m v1_plain 2>&1 | grep -q "garble_target" \
   || fail "v1_plain does not contain expected module info"
 echo "v1_plain: symbols + module info intact"
 go version -m v2_garbled 2>&1 | grep -q "unknown" \
   || fail "v2_garbled does not appear to be garbled"
 echo "v2_garbled: module info stripped (garble confirmed)"
-
-echo ""
-echo "=== 2. v1 function inventory via nm ==="
+echo "=== v1 nm ==="
 echo "TEXT symbols in v1_plain (main package):"
 nm v1_plain 2>/dev/null | awk '$2 == "T" && $3 ~ /^main\./ {print "  " $3}'
 
@@ -107,32 +110,21 @@ check_present "main.connectToServer"
 check_present "main.loadConfig"
 check_absent "main.validateConfig"
 echo "  main.validateConfig absent from v1 (new in v2)"
-
-echo ""
-echo "=== 3. String-anchored function mapping in v2_garbled ==="
-# Golden values are deterministic for seed ZHVja3RhcGU= (base64 "ducktape").
-
+echo "=== string→fn mapping ==="
 S1="connection refused: server not accepting connections"
 echo "Locating '$S1':"
 # Expected: string VMA 0x51a851, lea at PC 0x4dfccd, bytes 48 8d 05 7d ab 03 00
 fn1_v2=$(fn_for_string_v2 "$S1" "0x51a851" "0x4dfccd" "48 8d 05 7d ab 03 00" "main.h8n9KNzKUCmw")
 echo "  → $fn1_v2"
-
-echo ""
 S2="failed to read config file"
 echo "Locating '$S2':"
 # Expected: string VMA 0x5162ef, lea at PC 0x4dfdc2, bytes 48 8d 05 26 65 03 00
 fn2_v2=$(fn_for_string_v2 "$S2" "0x5162ef" "0x4dfdc2" "48 8d 05 26 65 03 00" "main.bhY2uMqP4")
 echo "  → $fn2_v2"
-
-echo ""
 [ "$fn1_v2" != "$fn2_v2" ] \
   || fail "connectToServer and loadConfig garbled to same name ($fn1_v2)"
 echo "PASS: distinct source functions → distinct garbled names"
-
-echo ""
-echo "=== 4. v2-only string identifies new function ==="
-
+echo "=== v2-only string ==="
 S_NEW="invalid port: must be between 1 and 65535"
 ! grep -qaF "$S_NEW" v1_plain \
   || fail "'$S_NEW' found in v1_plain — expected only in v2"
@@ -141,19 +133,13 @@ echo "Locating '$S_NEW' in v2_garbled:"
 # Expected: string VMA 0x518f8a, lea at PC 0x4dfb9c, bytes 48 8d 05 e7 93 03 00
 fn_new=$(fn_for_string_v2 "$S_NEW" "0x518f8a" "0x4dfb9c" "48 8d 05 e7 93 03 00" "main.epq7tEoS")
 echo "  → $fn_new"
-
-echo ""
 [ "$fn_new" != "$fn1_v2" ] \
   || fail "validateConfig collides with connectToServer garbled name"
 [ "$fn_new" != "$fn2_v2" ] \
   || fail "validateConfig collides with loadConfig garbled name"
 echo "PASS: three distinct garbled names for three distinct source functions"
-
-echo ""
-echo "=== Summary ==="
+echo "=== summary ==="
 echo "  connectToServer  string VMA 0x51a851  PC 0x4dfccd  →  $fn1_v2"
 echo "  loadConfig       string VMA 0x5162ef  PC 0x4dfdc2  →  $fn2_v2"
 echo "  validateConfig   string VMA 0x518f8a  PC 0x4dfb9c  →  $fn_new  (v2-only)"
-
-echo ""
 echo "All assertions passed."

--- a/skills/reverse_engineer/examples/binary_diff_recipe.sh
+++ b/skills/reverse_engineer/examples/binary_diff_recipe.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Recipe: cross-version binary diffing on garble-obfuscated Go binaries.
+#
+# Demonstrates string-anchored function matching: given a plain binary (v1,
+# symbols intact) and a garble-obfuscated binary (v2, names randomized), shared
+# string literals identify the same logical function across versions. v2-only
+# strings identify newly added functions with no v1 counterpart.
+#
+# The technique for the garbled binary:
+#   string → file offset → .rodata VMA → instruction referencing that VMA
+#   → pclntool maps the instruction PC to its garbled function name
+#
+# For the reference binary (v1, has symbols), nm directly lists function names.
+# Shared strings confirm both binaries' functions correspond to the same source.
+#
+# Prerequisites:
+#   - 'v1_plain'   in cwd — Go binary built without garble (has pclntab + symbols)
+#   - 'v2_garbled' in cwd — updated codebase built with garble (no symbols)
+#   - 'objdump', 'readelf', 'nm', 'strings' on PATH
+#   - 'pclntool' on PATH   (build with: go build -o pclntool pclntool.go)
+#   - 'go' on PATH         (for 'go version -m')
+
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# string_vma BINARY STRING → hex VMA of STRING's bytes in .rodata
+string_vma() {
+  local binary="$1" search="$2"
+  local file_off sec_vma sec_file
+  file_off=$(grep -obaF "$search" "$binary" | head -1 | cut -d: -f1)
+  [ -n "$file_off" ] || fail "'$search' not found in $binary"
+  sec_vma=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$5; exit}')
+  sec_file=$(readelf -S "$binary" | awk '/[ \t]\.rodata[ \t]/{print "0x"$6; exit}')
+  printf "0x%x" $((sec_vma + file_off - sec_file))
+}
+
+# fn_at_vma BINARY VMA → garbled function name via pclntool.
+#
+# Garbled (PIE) binaries use RIP-relative string references; objdump annotates
+# them with '# VMA'. Plain binaries may use absolute or GOT-based addressing,
+# so this technique is not reliable for non-garbled binaries.
+fn_at_vma() {
+  local binary="$1" vma="$2"
+  local insn_line insn_addr
+  insn_line=$(objdump -d "$binary" 2>/dev/null | grep -E "# ${vma}( <|$)" | head -1)
+  [ -n "$insn_line" ] || fail "no instruction in $binary references VMA $vma"
+  insn_addr=0x$(echo "$insn_line" | awk '{print $1}' | tr -d ':')
+  pclntool pc "$binary" "$insn_addr"
+}
+
+# fn_for_string_v2 STRING → garbled function name in v2_garbled containing STRING
+fn_for_string_v2() {
+  fn_at_vma v2_garbled "$(string_vma v2_garbled "$1")"
+}
+
+echo "=== 1. Verify binary properties ==="
+
+go version -m v1_plain 2>&1 | grep -q "garble_target" \
+  || fail "v1_plain does not contain expected module info"
+echo "v1_plain: symbols + module info intact"
+
+go version -m v2_garbled 2>&1 | grep -q "unknown" \
+  || fail "v2_garbled does not appear to be garbled"
+echo "v2_garbled: module info stripped (garble confirmed)"
+
+echo ""
+echo "=== 2. v1 function inventory via nm (establishes ground truth) ==="
+# nm lists all TEXT symbols in the plain binary — a direct name roster.
+echo "TEXT symbols in v1_plain (main package):"
+nm v1_plain 2>/dev/null | awk '$2 == "T" && $3 ~ /^main\./ {print "  " $3}'
+
+# Use awk for symbol checks (consistent with how we extracted $3 above).
+check_present() {
+  local sym="$1"
+  nm v1_plain 2>/dev/null | awk -v s="$sym" '$3 == s {found=1} END {exit !found}' \
+    || fail "$sym not in v1 symbol table"
+}
+check_absent() {
+  local sym="$1"
+  nm v1_plain 2>/dev/null | awk -v s="$sym" '$3 == s {found=1} END {exit found}' \
+    || fail "$sym unexpectedly found in v1 symbol table"
+}
+
+check_present "main.connectToServer"
+check_present "main.loadConfig"
+
+# validateConfig is new in v2 — must NOT be in v1.
+check_absent "main.validateConfig"
+echo "  main.validateConfig absent from v1 (as expected — added in v2)"
+
+echo ""
+echo "=== 3. v2 function names via string anchoring ==="
+# 'connection refused' is in connectToServer (both v1 and v2).
+# 'failed to read config file' is in loadConfig (both v1 and v2).
+# 'invalid port' is in validateConfig (v2 only).
+
+S1="connection refused: server not accepting connections"
+S2="failed to read config file"
+S_NEW="invalid port: must be between 1 and 65535"
+
+fn1_v2=$(fn_for_string_v2 "$S1")
+fn2_v2=$(fn_for_string_v2 "$S2")
+echo "  '$S1'"
+echo "  → v2 garbled fn: $fn1_v2  (corresponds to main.connectToServer)"
+
+echo "  '$S2'"
+echo "  → v2 garbled fn: $fn2_v2  (corresponds to main.loadConfig)"
+
+# Two distinct source functions → two distinct garbled names.
+[ "$fn1_v2" != "$fn2_v2" ] \
+  || fail "connectToServer and loadConfig garbled to the same name ($fn1_v2)"
+echo "  PASS: two distinct source functions → two distinct garbled names"
+
+echo ""
+echo "=== 4. v2-only string → new function with no v1 counterpart ==="
+
+! grep -qaF "$S_NEW" v1_plain \
+  || fail "'$S_NEW' found in v1_plain — expected only in v2"
+echo "  '$S_NEW' absent from v1 (validateConfig only exists in v2)"
+
+fn_new=$(fn_for_string_v2 "$S_NEW")
+echo "  → v2 garbled fn: $fn_new  (new validateConfig, no v1 counterpart)"
+
+[ "$fn_new" != "$fn1_v2" ] \
+  || fail "validateConfig collides with connectToServer garbled name ($fn1_v2)"
+[ "$fn_new" != "$fn2_v2" ] \
+  || fail "validateConfig collides with loadConfig garbled name ($fn2_v2)"
+echo "  PASS: three distinct garbled names for three distinct source functions"
+
+echo ""
+echo "All assertions passed."

--- a/skills/reverse_engineer/examples/defs.bzl
+++ b/skills/reverse_engineer/examples/defs.bzl
@@ -1,0 +1,106 @@
+"""Rules for building Go binaries using the rules_go SDK directly.
+
+Genrules can't use @io_bazel_rules_go//go:go (blocked as a genrule tool) and
+the go_bin_runner wrapper it provides needs runfiles that aren't available in
+genrule sandboxes. These rules use ctx.actions.run_shell with the go_bin_runner
+in `tools`, which sets up its runfiles properly so `go env GOROOT` works.
+
+Toolchain type: GO_TOOLCHAIN = "@io_bazel_rules_go//go:toolchain"
+(defined in go/private/common.bzl, declared as toolchain_type in go/BUILD.bazel)
+"""
+
+def _go_sdk_inputs(sdk):
+    """All SDK files needed for go build to access the stdlib."""
+    return depset(
+        [sdk.root_file],
+        transitive = [sdk.libs, sdk.headers, sdk.tools, sdk.srcs],
+    )
+
+def _plain_binary_impl(ctx):
+    sdk = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk
+    out = ctx.outputs.out
+    go = sdk.go
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        # sdk.go (go_bin_runner) goes in tools so Bazel sets up its runfiles,
+        # letting `go env GOROOT` succeed. SDK files go in inputs for stdlib.
+        inputs = depset(ctx.files.srcs, transitive = [_go_sdk_inputs(sdk)]),
+        tools = [go],
+        command = """
+set -euo pipefail
+# Capture absolute output path before cd-ing into the temp build dir.
+OUT="$PWD/{out}"
+GOROOT=$("{go}" env GOROOT)
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+cp {srcs} "$T/"
+printf 'module garble_target\\ngo 1.26.0\\n' > "$T/go.mod"
+export GOROOT GOCACHE="$T/.cache" GOPATH="$T/.gopath"
+cd "$T" && "$GOROOT/bin/go" build -o "$OUT" .
+""".format(
+            go = go.path,
+            srcs = " ".join(["'" + f.path + "'" for f in ctx.files.srcs]),
+            out = out.path,
+        ),
+        mnemonic = "GoPlainBinary",
+    )
+
+plain_binary = rule(
+    implementation = _plain_binary_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "out": attr.output(mandatory = True),
+    },
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)
+
+def _garble_binary_impl(ctx):
+    sdk = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk
+    out = ctx.outputs.out
+    go = sdk.go
+    garble = ctx.executable._garble
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = depset(ctx.files.srcs, transitive = [_go_sdk_inputs(sdk)]),
+        tools = [go, garble],
+        command = """
+set -euo pipefail
+# Capture absolute paths before cd-ing into the temp build dir.
+OUT="$PWD/{out}"
+GARBLE="$PWD/{garble}"
+GOROOT=$("{go}" env GOROOT)
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+cp {srcs} "$T/"
+printf 'module garble_target\\ngo 1.26.0\\n' > "$T/go.mod"
+export GOROOT
+export PATH="$GOROOT/bin:$PATH"
+export GOCACHE="$T/.cache" GOPATH="$T/.gopath" XDG_CACHE_HOME="$T/.xdg"
+mkdir -p "$T/.xdg"
+cd "$T" && "$GARBLE" -seed={seed} build -o "$OUT" .
+""".format(
+            go = go.path,
+            garble = garble.path,
+            srcs = " ".join(["'" + f.path + "'" for f in ctx.files.srcs]),
+            seed = ctx.attr.seed,
+            out = out.path,
+        ),
+        mnemonic = "GoGarbleBinary",
+    )
+
+garble_binary = rule(
+    implementation = _garble_binary_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "seed": attr.string(mandatory = True),
+        "out": attr.output(mandatory = True),
+        "_garble": attr.label(
+            default = "@cc_mvdan_garble//:garble",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    toolchains = ["@io_bazel_rules_go//go:toolchain"],
+)

--- a/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
+++ b/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
@@ -1,50 +1,31 @@
 #!/usr/bin/env bash
 # Test scaffold for binary_diff_recipe.sh.
 #
-# Builds v1_plain (symbols intact) from garble_target and v2_garbled
-# (obfuscated) from garble_target_v2, then runs the recipe.
+# Receives pre-built v1_plain and v2_garbled as Bazel runfiles (genrule outputs),
+# sets up go and pclntool on PATH, then runs the recipe.
 #
 # Env vars (set via Bazel env = {...}):
-#   GARBLE    — rlocation path to garble binary
 #   GO        — rlocation path to go_bin_runner
 #   PCLNTOOL  — rlocation path to pclntool
 #   RECIPE    — rlocation path to binary_diff_recipe.sh
+#   V1_PLAIN  — rlocation path to pre-built v1_plain binary
+#   V2_GARBLED — rlocation path to pre-built v2_garbled binary
 
 set -euo pipefail
 
 mkdir -p "$TEST_TMPDIR/bin"
-ln -s "$TEST_SRCDIR/$GO" "$TEST_TMPDIR/bin/go_bin_runner"
 ln -s "$TEST_SRCDIR/$PCLNTOOL" "$TEST_TMPDIR/bin/pclntool"
 
+# 'go version -m' is used by the recipe to verify binary properties.
+ln -s "$TEST_SRCDIR/$GO" "$TEST_TMPDIR/bin/go_bin_runner"
 export GOROOT
 GOROOT=$(cd "$TEST_SRCDIR/_main" && "$TEST_TMPDIR/bin/go_bin_runner" env GOROOT)
 ln -s "$GOROOT/bin/go" "$TEST_TMPDIR/bin/go"
 export PATH="$TEST_TMPDIR/bin:$PATH"
 
-export GOCACHE="$TEST_TMPDIR/.gocache"
-export GOPATH="$TEST_TMPDIR/.gopath"
-export XDG_CACHE_HOME="$TEST_TMPDIR/.xdg-cache"
-mkdir -p "$XDG_CACHE_HOME"
-
-GARBLE_BIN="$TEST_SRCDIR/$GARBLE"
-
-# ── Build v1_plain (no garble, symbols + module info intact) ─────────────────
-V1SRC="$TEST_TMPDIR/v1_src"
-mkdir -p "$V1SRC"
-V1_DIR="$TEST_SRCDIR/_main/skills/reverse_engineer/cmd/garble_target"
-for f in "$V1_DIR"/*.go; do cp "$f" "$V1SRC/"; done
-printf 'module garble_target\ngo 1.26.0\n' >"$V1SRC/go.mod"
-(cd "$V1SRC" && go build -o "$TEST_TMPDIR/v1_plain" .)
-
-# ── Build v2_garbled (same codebase + validateConfig, obfuscated by garble) ──
-V2SRC="$TEST_TMPDIR/v2_src"
-mkdir -p "$V2SRC"
-V2_DIR="$TEST_SRCDIR/_main/skills/reverse_engineer/cmd/garble_target_v2"
-for f in "$V2_DIR"/*.go; do cp "$f" "$V2SRC/"; done
-printf 'module garble_target\ngo 1.26.0\n' >"$V2SRC/go.mod"
-# Fixed seed → deterministic obfuscated names and addresses.
-# "ZHVja3RhcGU=" is base64("ducktape").
-(cd "$V2SRC" && "$GARBLE_BIN" -seed=ZHVja3RhcGU= build -o "$TEST_TMPDIR/v2_garbled" .)
+# Symlink pre-built binaries into cwd (recipe uses bare names v1_plain/v2_garbled).
+ln -s "$TEST_SRCDIR/$V1_PLAIN" "$TEST_TMPDIR/v1_plain"
+ln -s "$TEST_SRCDIR/$V2_GARBLED" "$TEST_TMPDIR/v2_garbled"
 
 cd "$TEST_TMPDIR"
 exec bash "$TEST_SRCDIR/$RECIPE"

--- a/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
+++ b/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
@@ -42,7 +42,9 @@ mkdir -p "$V2SRC"
 V2_DIR="$TEST_SRCDIR/_main/skills/reverse_engineer/cmd/garble_target_v2"
 for f in "$V2_DIR"/*.go; do cp "$f" "$V2SRC/"; done
 printf 'module garble_target\ngo 1.26.0\n' >"$V2SRC/go.mod"
-(cd "$V2SRC" && "$GARBLE_BIN" -seed=random build -o "$TEST_TMPDIR/v2_garbled" .)
+# Fixed seed → deterministic obfuscated names and addresses.
+# "ZHVja3RhcGU=" is base64("ducktape").
+(cd "$V2SRC" && "$GARBLE_BIN" -seed=ZHVja3RhcGU= build -o "$TEST_TMPDIR/v2_garbled" .)
 
 cd "$TEST_TMPDIR"
 exec bash "$TEST_SRCDIR/$RECIPE"

--- a/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
+++ b/skills/reverse_engineer/examples/test_scaffold_binary_diff.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Test scaffold for binary_diff_recipe.sh.
+#
+# Builds v1_plain (symbols intact) from garble_target and v2_garbled
+# (obfuscated) from garble_target_v2, then runs the recipe.
+#
+# Env vars (set via Bazel env = {...}):
+#   GARBLE    — rlocation path to garble binary
+#   GO        — rlocation path to go_bin_runner
+#   PCLNTOOL  — rlocation path to pclntool
+#   RECIPE    — rlocation path to binary_diff_recipe.sh
+
+set -euo pipefail
+
+mkdir -p "$TEST_TMPDIR/bin"
+ln -s "$TEST_SRCDIR/$GO" "$TEST_TMPDIR/bin/go_bin_runner"
+ln -s "$TEST_SRCDIR/$PCLNTOOL" "$TEST_TMPDIR/bin/pclntool"
+
+export GOROOT
+GOROOT=$(cd "$TEST_SRCDIR/_main" && "$TEST_TMPDIR/bin/go_bin_runner" env GOROOT)
+ln -s "$GOROOT/bin/go" "$TEST_TMPDIR/bin/go"
+export PATH="$TEST_TMPDIR/bin:$PATH"
+
+export GOCACHE="$TEST_TMPDIR/.gocache"
+export GOPATH="$TEST_TMPDIR/.gopath"
+export XDG_CACHE_HOME="$TEST_TMPDIR/.xdg-cache"
+mkdir -p "$XDG_CACHE_HOME"
+
+GARBLE_BIN="$TEST_SRCDIR/$GARBLE"
+
+# ── Build v1_plain (no garble, symbols + module info intact) ─────────────────
+V1SRC="$TEST_TMPDIR/v1_src"
+mkdir -p "$V1SRC"
+V1_DIR="$TEST_SRCDIR/_main/skills/reverse_engineer/cmd/garble_target"
+for f in "$V1_DIR"/*.go; do cp "$f" "$V1SRC/"; done
+printf 'module garble_target\ngo 1.26.0\n' >"$V1SRC/go.mod"
+(cd "$V1SRC" && go build -o "$TEST_TMPDIR/v1_plain" .)
+
+# ── Build v2_garbled (same codebase + validateConfig, obfuscated by garble) ──
+V2SRC="$TEST_TMPDIR/v2_src"
+mkdir -p "$V2SRC"
+V2_DIR="$TEST_SRCDIR/_main/skills/reverse_engineer/cmd/garble_target_v2"
+for f in "$V2_DIR"/*.go; do cp "$f" "$V2SRC/"; done
+printf 'module garble_target\ngo 1.26.0\n' >"$V2SRC/go.mod"
+(cd "$V2SRC" && "$GARBLE_BIN" -seed=random build -o "$TEST_TMPDIR/v2_garbled" .)
+
+cd "$TEST_TMPDIR"
+exec bash "$TEST_SRCDIR/$RECIPE"

--- a/third_party/go.MODULE.bazel
+++ b/third_party/go.MODULE.bazel
@@ -16,6 +16,8 @@ go_deps.from_file(go_mod = "//third_party:go.mod")
 # Patch garble's decodeBuildIDHash to pad short hashes (<15 bytes) instead
 # of panicking. Bazel-built Go binaries embed "redacted" (6 decoded bytes)
 # in their build ID ELF note, which is shorter than garble's expected 15.
+# This affects even -seed=random builds: garble reads its own build ID in
+# toolexecCmd regardless of the seed source.
 go_deps.module_override(
     patch_strip = 1,
     patches = ["//skills/reverse_engineer/examples:garble_hash_fix.patch"],


### PR DESCRIPTION
## Summary

- Adds `binary_diff_recipe.sh`: a self-documenting shell script that demonstrates the full string-anchored function matching technique against a real garble-obfuscated Go binary pair
- Adds `garble_target_v2` Go victim binary (v1 has `connectToServer` + `loadConfig`; v2 adds `validateConfig`)
- Builds v1 plain (symbols intact) and v2 garbled with a fixed seed (`ZHVja3RhcGU=` = base64("ducktape")) for deterministic output
- Wires everything as a `sh_test` Bazel target (`//skills/reverse_engineer/examples:test_binary_diff_demo`)

## Technique demonstrated

```
string literal → file offset → .rodata VMA → objdump RIP-relative annotation
  → instruction PC → pclntool pc → garbled function name
```

## Golden assertions (all exact, deterministic for the fixed seed)

| source fn | string VMA | instruction PC | bytes | garbled name |
|---|---|---|---|---|
| `connectToServer` | `0x51a851` | `0x4dfccd` | `48 8d 05 7d ab 03 00` | `main.h8n9KNzKUCmw` |
| `loadConfig` | `0x5162ef` | `0x4dfdc2` | `48 8d 05 26 65 03 00` | `main.bhY2uMqP4` |
| `validateConfig` | `0x518f8a` | `0x4dfb9c` | `48 8d 05 e7 93 03 00` | `main.epq7tEoS` |

## Test plan

- [x] `bbr test //skills/reverse_engineer/examples:test_binary_diff_demo` passes (BuildBuddy invocation `4fde8aea-a3d6-426c-aa2d-3df20ce14c4f`)
- [x] All 12 `ASSERT OK` lines fire (string VMA, instruction PC, instruction bytes, garbled name for each of 3 functions)
- [x] `check_present`/`check_absent` assertions on v1 nm symbol table pass

https://claude.ai/code/session_01TRvwMDg9D6Yz6n8N8bFNTh