### PR TITLE
Surface shim log file path only on block, not on startup

### DIFF
--- a/devinfra/claude/hook_daemon/shim.py
+++ b/devinfra/claude/hook_daemon/shim.py
@@ -29,7 +29,7 @@ def _setup_logging(shim: str, paths: SessionPaths) -> Path:
 
     Does not print the log file path to stderr: the real binary's stderr is
     consumed (and often concatenated with stdout via Go's CombinedOutput) by
-    callers that parse the output. The shim path surfaces only on block
+    callers that parse the output. The log file path surfaces only on block
     (see _report_shim) where the user has a reason to look.
     """
     formatter = logging.Formatter(f"[{shim}-shim] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")

--- a/devinfra/claude/hook_daemon/shim.py
+++ b/devinfra/claude/hook_daemon/shim.py
@@ -24,8 +24,14 @@ from devinfra.claude.settings import ENV_SESSION_DIR
 logger = logging.getLogger(__name__)
 
 
-def _setup_logging(shim: str, paths: SessionPaths) -> None:
-    """Configure logging to stderr and file."""
+def _setup_logging(shim: str, paths: SessionPaths) -> Path:
+    """Configure logging to stderr and file. Returns the log file path.
+
+    Does not print the log file path to stderr: the real binary's stderr is
+    consumed (and often concatenated with stdout via Go's CombinedOutput) by
+    callers that parse the output. The shim path surfaces only on block
+    (see _report_shim) where the user has a reason to look.
+    """
     formatter = logging.Formatter(f"[{shim}-shim] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
 
     stderr_handler = logging.StreamHandler(sys.stderr)
@@ -42,15 +48,15 @@ def _setup_logging(shim: str, paths: SessionPaths) -> None:
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)
     root_logger.addHandler(file_handler)
-    print(f"[{shim}-shim] log: {log_file}", file=sys.stderr)
 
     logger.info("%s shim started", shim)
+    return log_file
 
 
-def _report_shim(shim: str, session_id: str, paths: SessionPaths) -> list[str]:
+def _report_shim(shim: str, session_id: str, paths: SessionPaths, log_file: Path) -> list[str]:
     """Report to daemon, handle blocks, return argv to exec with.
 
-    On block: prints message to stderr and exits 1.
+    On block: prints message + log path to stderr and exits 1.
     On daemon unreachable: logs error, returns original sys.argv (fallback).
     """
     report = ShimExecRequest(
@@ -60,7 +66,7 @@ def _report_shim(shim: str, session_id: str, paths: SessionPaths) -> list[str]:
     if response is None:
         return sys.argv  # Fallback: daemon unreachable
     if isinstance(response, ShimBlocked):
-        print(f"[{shim}-shim] BLOCKED: {response.message}", file=sys.stderr)
+        print(f"[{shim}-shim] BLOCKED: {response.message}\n[{shim}-shim] log: {log_file}", file=sys.stderr)
         raise SystemExit(1)
     return response.argv
 
@@ -73,10 +79,10 @@ def run_shim(shim_name: str, session_id: str) -> None:
     sys.argv before calling here.
     """
     paths = SessionPaths.from_env(session_id, dict(os.environ))
-    _setup_logging(shim_name, paths)
+    log_file = _setup_logging(shim_name, paths)
     log_entrypoint_debug(f"{shim_name}_shim")
 
-    argv = _report_shim(shim_name, session_id, paths)
+    argv = _report_shim(shim_name, session_id, paths, log_file)
 
     # Propagate session dir to subprocesses of the real binary (e.g. bazel_wrapper).
     os.environ[ENV_SESSION_DIR] = str(paths.session_dir)


### PR DESCRIPTION
## Summary
Modified the shim logging setup to defer printing the log file path until a block occurs, rather than printing it unconditionally at startup. This prevents log file paths from polluting stderr output that callers may parse.

## Key Changes
- Changed `_setup_logging()` to return the log file path instead of printing it to stderr
- Updated `_report_shim()` to accept the log file path as a parameter and print it only when a block response is received
- Modified `run_shim()` to capture the returned log file path and pass it to `_report_shim()`
- Updated docstrings to clarify the new behavior and rationale

## Implementation Details
The log file path is now only surfaced to users when the shim blocks execution, which is when they have a reason to investigate logs. This prevents the path from being included in stderr output that Go's `CombinedOutput` and other callers may parse, while still making it easily accessible when debugging is needed.

https://claude.ai/code/session_01R7P154FKofNy6citjSJUdY