### PR TITLE
fix(claude-hooks): point Bazel JVM at system Java truststore for BCR

### DIFF
--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -14,6 +14,17 @@ startup --host_jvm_args=-Xmx8g
 % elif platform.is_gvisor:
 startup --host_jvm_args=-Xmx4g
 % endif
+% if system_java_cacerts:
+# Bazel's bundled JDK uses its own cacerts which lacks Anthropic's TLS
+# inspection CA, so direct BCR fetches (e.g. bcr.bazel.build) fail with
+# PKIX path building failed under the transparent MITM proxy. Pointing the
+# JVM at /etc/ssl/certs/java/cacerts picks up the system-wide truststore,
+# which ca-certificates-java populates from /etc/ssl/certs/ca-certificates.crt
+# (and therefore contains the Anthropic CA on web containers). Emitted after
+# the setup_auth_proxy block so it overrides any session-local truststore.
+startup --host_jvm_args=-Djavax.net.ssl.trustStore=${system_java_cacerts | sh}
+startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit
+% endif
 % if setup_auth_proxy:
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}

--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -14,20 +14,18 @@ startup --host_jvm_args=-Xmx8g
 % elif platform.is_gvisor:
 startup --host_jvm_args=-Xmx4g
 % endif
-% if system_java_cacerts:
-# Bazel's bundled JDK uses its own cacerts which lacks Anthropic's TLS
-# inspection CA, so direct BCR fetches (e.g. bcr.bazel.build) fail with
-# PKIX path building failed under the transparent MITM proxy. Pointing the
-# JVM at /etc/ssl/certs/java/cacerts picks up the system-wide truststore,
-# which ca-certificates-java populates from /etc/ssl/certs/ca-certificates.crt
-# (and therefore contains the Anthropic CA on web containers). Emitted after
-# the setup_auth_proxy block so it overrides any session-local truststore.
-startup --host_jvm_args=-Djavax.net.ssl.trustStore=${system_java_cacerts | sh}
-startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit
-% endif
-% if setup_auth_proxy:
+% if truststore_path:
+# JVM truststore for Bazel's bundled JDK. Bazel's own cacerts lacks custom
+# CAs (e.g. Anthropic's TLS inspection CA on Claude Code web), so direct
+# HTTPS fetches (BCR, gazelle fetch_repo, etc.) fail with PKIX path building
+# failed. The handler picks: (1) the session-local truststore built by
+# auth_proxy setup, else (2) /etc/ssl/certs/java/cacerts (Debian's
+# ca-certificates-java keeps it in sync with /etc/ssl/certs/ca-certificates.crt),
+# else (3) no override.
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}
+% endif
+% if setup_auth_proxy:
 # BCR fetches use the native JVM proxy settings from Anthropic's
 # JAVA_TOOL_OPTIONS (proxyHost/proxyPort/proxyUser/proxyPassword). Only gRPC
 # traffic (remote execution, cache, BES) needs the UDS proxy.

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -398,8 +398,28 @@ async def handle(
     )
     write_config(bbr_bazelrc, bbr_bazelrc_content, "bbr bazelrc")
 
-    # Render session bazelrc
+    # Pick a JVM truststore: the session-local one built by auth_proxy setup
+    # has priority (explicitly tuned for the current session), else fall back to
+    # Debian's /etc/ssl/certs/java/cacerts (ca-certificates-java regenerates it
+    # from the system PEM bundle, so it picks up Anthropic's TLS inspection CA
+    # on web containers). None means no JVM truststore override — Bazel falls
+    # back to its bundled JDK cacerts (works on CLI/NixOS where no MITM happens).
     system_java_cacerts = Path("/etc/ssl/certs/java/cacerts")
+    truststore_path: Path | None
+    truststore_password: str | None
+    if profile.setup_auth_proxy and combined_ca is not None:
+        truststore_path = session.paths.auth_proxy_truststore
+        truststore_password = proxy_setup.TRUSTSTORE_PASSWORD
+    elif system_java_cacerts.exists():
+        truststore_path = system_java_cacerts
+        # ca-certificates-java uses the JDK default storepass; documented in
+        # /etc/default/cacerts (storepass='' means default = 'changeit').
+        truststore_password = "changeit"
+    else:
+        truststore_path = None
+        truststore_password = None
+
+    # Render session bazelrc
     with tracer.start_as_current_span("render_bazelrc", context=root_ctx):
         bazelrc_template = Template(
             CONFIG_FILES.joinpath("bazelrc.mako").read_text(), imports=["from shlex import quote as sh"]
@@ -408,8 +428,8 @@ async def handle(
             setup_auth_proxy=profile.setup_auth_proxy and combined_ca is not None,
             bazel_remote_proxy_sock=session.paths.bazel_remote_proxy_sock if session.uds_remote else None,
             bazel_bes_proxy_sock=session.paths.bazel_bes_proxy_sock if session.bes_interceptor else None,
-            truststore_path=session.paths.auth_proxy_truststore,
-            truststore_password=proxy_setup.TRUSTSTORE_PASSWORD,
+            truststore_path=truststore_path,
+            truststore_password=truststore_password,
             combined_ca_path=combined_ca,
             buildbuddy_bazelrc=setup.buildbuddy_setup.bazelrc_path
             if isinstance(setup.buildbuddy_setup, buildbuddy.BuildbuddyConfigured)
@@ -417,7 +437,6 @@ async def handle(
             bazel_cache_dir=setup.bazel_cache_dir,
             platform=setup.platform,
             bbr_bazelrc=bbr_bazelrc,
-            system_java_cacerts=system_java_cacerts if system_java_cacerts.exists() else None,
         )
         session_bazelrc = session.paths.session_dir / "bazelrc"
         write_config(session_bazelrc, bazelrc_content, "session bazelrc")

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -399,6 +399,7 @@ async def handle(
     write_config(bbr_bazelrc, bbr_bazelrc_content, "bbr bazelrc")
 
     # Render session bazelrc
+    system_java_cacerts = Path("/etc/ssl/certs/java/cacerts")
     with tracer.start_as_current_span("render_bazelrc", context=root_ctx):
         bazelrc_template = Template(
             CONFIG_FILES.joinpath("bazelrc.mako").read_text(), imports=["from shlex import quote as sh"]
@@ -416,6 +417,7 @@ async def handle(
             bazel_cache_dir=setup.bazel_cache_dir,
             platform=setup.platform,
             bbr_bazelrc=bbr_bazelrc,
+            system_java_cacerts=system_java_cacerts if system_java_cacerts.exists() else None,
         )
         session_bazelrc = session.paths.session_dir / "bazelrc"
         write_config(session_bazelrc, bazelrc_content, "session bazelrc")


### PR DESCRIPTION
## Summary

When the session hook's `auth_proxy` path is skipped (no `HTTPS_PROXY` — current transparent-proxy containers), Bazel's bundled JDK falls back to its own cacerts, which lacks Anthropic's TLS inspection CA. Direct BCR fetches (`bcr.bazel.build`) then fail with `PKIX path building failed: unable to find valid certification path to requested target`.

`/etc/ssl/certs/java/cacerts` is a JKS populated by Debian's `ca-certificates-java` package from the system PEM bundle (`/etc/ssl/certs/ca-certificates.crt`) via `update-ca-certificates` hooks. Anthropic's CA is in the PEM bundle, so this Java truststore already has it — we just need Bazel's JVM to read that file instead of its bundled default.

When the file exists, the session bazelrc now emits:

```
startup --host_jvm_args=-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit
```

Emitted **before** the `% if setup_auth_proxy:` block so that when `auth_proxy` is also configuring a session-local truststore (legacy path), the session-local one wins (later `--host_jvm_args` value takes precedence). No-op when the file doesn't exist (CLI profile on NixOS, where `ca-certificates-java` isn't installed but the JVM's default truststore is already correct).

Password `changeit` is the JDK-wide default and matches `ca-certificates-java`'s `/etc/default/cacerts` storepass setting. Verified in a live web session: JVM HTTPS to `bcr.bazel.build` returns HTTP 200 with this override; returns `KeyManagementException` if the password is wrong (fails closed, not open).

## Test plan

- [x] Direct JVM HTTPS test: `java -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit ...` → HTTP 200 against `bcr.bazel.build`
- [x] `keytool -list -storepass changeit` successfully enumerates `/etc/ssl/certs/java/cacerts` (10 Anthropic/swp-ca matches)
- [x] `ruff check` passes
- [ ] CI

https://claude.ai/code/session_01CKRfNdpWaCdA1FmUN62Yty