### PR TITLE
Improve variable naming clarity in QU resolution error handling

### DIFF
--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -107,8 +107,8 @@ class QUCache:
         if qu_id is not None:
             qu = self._by_id.get(qu_id)
             if qu is None:
-                available = sorted(self._by_id.keys())
-                raise ValueError(f"unknown qu_id={qu_id}; available IDs: {available}")
+                available_ids = sorted(self._by_id.keys())
+                raise ValueError(f"unknown qu_id={qu_id}; available IDs: {available_ids}")
             return ResolvedQU(qu_id=int(qu["id"]), qu_name=str(qu["name"]))
 
         assert qu_name is not None


### PR DESCRIPTION
## Summary
Improved code clarity by using a more descriptive variable name in the quantity unit (QU) resolution error handling.

## Key Changes
- Renamed `available` to `available_ids` in the QU resolution error message to better reflect that the variable contains quantity unit IDs rather than generic "available" items
- Updated the corresponding f-string reference to use the new variable name

## Implementation Details
This change enhances code readability by making the variable's purpose more explicit. The variable contains a sorted list of available quantity unit IDs, and the new name `available_ids` makes this intent clearer to future maintainers without requiring additional context or comments.

https://claude.ai/code/session_01YWZS7ATfYyGcJFz3rvswaH