### PR TITLE
chore(claude-hooks): drop unused cryptography/pyjwt from wheel deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -204,13 +204,10 @@ py_wheel(
     # (claude-hooks). The Nix derivation provides these at runtime on NixOS/devShell.
     # When adding a dependency, update BOTH places.
     #
-    # CLEANUP: the auth_proxy subsystem was removed; audit whether `cryptography`
-    # (was CA extraction) and `pyjwt` (was JWT expiry check) are still needed.
-    # `grpcio` + `protobuf` are still required for the BES interceptor that
-    # surfaces the "use `bb remote`" nudge.
+    # `grpcio` + `protobuf` are required for the BES interceptor that surfaces
+    # the "use `bb remote`" nudge.
     requires = [
         "anyio",
-        "cryptography",
         "fastapi>=0.115.0",
         "filelock",
         "grpcio",
@@ -228,7 +225,6 @@ py_wheel(
         "pydantic-settings",
         "pygit2>=1.14",
         "pyrage>=1.0.0",
-        "pyjwt",
         "pyyaml",
         "requests",
         "rich",

--- a/devinfra/claude/TODO.md
+++ b/devinfra/claude/TODO.md
@@ -1,27 +1,5 @@
 # claude_hooks TODO
 
-## Audit claude-hooks wheel deps after auth_proxy removal
-
-**CLEANUP(2026-04-16)**: The `auth_proxy` subsystem was removed in the
-followup to PR #1325. A few Python runtime deps may now be unused:
-
-- `cryptography` — previously for CA extraction / x509 parsing
-- `pyjwt` — previously for proxy JWT credential expiry checks
-
-(`grpcio` + `protobuf` are still used by the BES interceptor that surfaces
-the "use `bb remote`" nudge — keep.)
-
-Check whether anything else in the wheel imports them (e.g. via transitive
-use by FastAPI/uvicorn/etc.) and drop the ones that are truly unused.
-
-Files to update in lockstep:
-
-1. `//:claude_hooks_wheel` `requires` in root `BUILD.bazel`
-2. `claude-hooks` `propagatedBuildInputs` in `nix/packages/default.nix`
-
-Condition to remove this tombstone: deps audited and pruned, or confirmed
-still needed by indirect usage.
-
 ## OTEL bearer token: mirror into SOPS
 
 **CLEANUP(2026-04-15)**: today `devinfra/secrets/web_env.sh` fetches

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -5,13 +5,16 @@ container. Exercises the pip-install + session-start path end-to-end so that
 wheel packaging bugs (missing deps, bad entry points, ImportError at runtime)
 surface in CI rather than in a live session.
 
-Current containers have direct internet via a transparent proxy — no egress
-proxy setup. Earlier versions of this test stood up a mitmproxy sidecar and
-an isolated Docker network to exercise the legacy `auth_proxy` subsystem;
-that machinery was removed when we stopped supporting explicit
-`HTTPS_PROXY`-based setups (see `devinfra/claude/README.md` "Historical:
-Explicit Egress Proxy"). The test now runs against the default Docker bridge
-with direct internet, same as real web containers.
+Current containers reach the internet without any per-tool proxy
+configuration (no `HTTPS_PROXY` env vars); whether that's via a
+transparent network-layer MITM or direct egress is not something the
+session start hook tries to distinguish. Earlier versions of this test
+stood up a mitmproxy sidecar and an isolated Docker network to exercise
+the legacy `auth_proxy` subsystem; that machinery was removed when we
+stopped supporting explicit `HTTPS_PROXY`-based setups (see
+`devinfra/claude/README.md` "Historical: Explicit Egress Proxy"). The
+test now runs against the default Docker bridge with direct internet,
+same as real web containers.
 """
 
 import json

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -116,14 +116,12 @@ in
     # The wheel declares pip-level deps; this list provides Nix-level equivalents.
     # When adding a dependency, update BOTH places.
     #
-    # CLEANUP: auth_proxy subsystem removed — audit cryptography, grpcio,
-    # protobuf, pyjwt for whether anything still uses them and drop the unused
-    # ones (matching BUILD.bazel).
+    # `grpcio` + `protobuf` are required for the BES interceptor that surfaces
+    # the "use `bb remote`" nudge.
     propagatedBuildInputs =
       with pkgs.python3Packages;
       [
         anyio
-        cryptography
         fastapi
         filelock
         grpcio
@@ -138,7 +136,6 @@ in
         pydantic
         pydantic-settings
         pygit2
-        pyjwt
         pyyaml
         requests
         rich


### PR DESCRIPTION
## Summary

Post-#1326 followup:
- `cryptography` and `pyjwt` have zero imports in `devinfra/claude/` after the `auth_proxy` subsystem removal. Dropped from both `//:claude_hooks_wheel` `requires` and the `claude-hooks` Nix derivation's `propagatedBuildInputs`. Kept in `requirements_bazel.txt` because `airlock` and `x/webhook_inbox` still use them.
- Removed the matching CLEANUP tombstone from `devinfra/claude/TODO.md`.
- Softened the "transparent proxy" wording in `test_container_e2e.py:8` to match the neutral phrasing already used in `connectivity.py` and `devinfra/claude/README.md` — the hook daemon doesn't try to distinguish transparent MITM from direct egress.

## Test plan

- [x] `bbr build //:claude_hooks_wheel` — succeeded (invocation `6eb4cf7b-71d0-4b91-a055-c588f7e8a210`)
- [x] `bbr test //devinfra/claude/...` — 23/23 passed (invocation `95d60664-eeb8-4a26-8bf3-e8f06cf42bc5`), including container E2E
- [ ] Post-merge pin sync picks up the slimmer deps; no runtime ImportErrors on web sessions