### PR TITLE
Make cache.nixos.org connectivity check non-fatal

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -82,7 +82,7 @@ env | cut -d= -f1 | sort
 echo "---"
 
 echo "Connectivity check (cache.nixos.org)..."
-curl -fsSL --max-time 10 https://cache.nixos.org/nix-cache-info
+curl -fsSL --max-time 10 https://cache.nixos.org/nix-cache-info || echo "WARNING: cache.nixos.org check failed — continuing anyway" >&2
 
 echo "--- nix.conf ---"
 cat /etc/nix/nix.conf


### PR DESCRIPTION
## Summary
Modified the connectivity check for cache.nixos.org to be non-blocking, allowing the setup script to continue even if the check fails.

## Changes
- Added error handling (`|| echo ...`) to the curl command that checks cache.nixos.org connectivity
- The script now logs a warning to stderr if the check fails but continues execution instead of halting
- This prevents temporary network issues or cache unavailability from blocking the entire web setup process

## Implementation Details
- The warning message is written to stderr (`>&2`) to distinguish it from normal output
- The curl command itself remains unchanged; only the error handling behavior is modified
- This is a defensive change that improves robustness of the setup script during network instability

https://claude.ai/code/session_01CUKLns5Dz5xs1YYvBS7i86