### PR TITLE
fix(grocy_mcp): leak-free init dir, cleanup on _serve_mcp startup failure

### DIFF
--- a/x/grocy_mcp/eval/run.py
+++ b/x/grocy_mcp/eval/run.py
@@ -56,22 +56,25 @@ async def _serve_mcp(grocy_base_url: str) -> AsyncGenerator[str]:
 
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
-
     serve_task = asyncio.create_task(server.serve())
-    for _ in range(50):
-        await asyncio.sleep(0.1)
-        if server.started:
-            break
-    else:
-        raise TimeoutError("MCP server did not start within 5s")
-
-    mcp_url = f"http://127.0.0.1:{port}/mcp"
-    logger.info("MCP server ready at %s", mcp_url)
     try:
+        for _ in range(50):
+            await asyncio.sleep(0.1)
+            if server.started:
+                break
+        else:
+            raise TimeoutError("MCP server did not start within 5s")
+
+        mcp_url = f"http://127.0.0.1:{port}/mcp"
+        logger.info("MCP server ready at %s", mcp_url)
         yield mcp_url
     finally:
         server.should_exit = True
-        await serve_task
+        try:
+            await asyncio.wait_for(serve_task, timeout=5.0)
+        except TimeoutError:
+            serve_task.cancel()
+            await asyncio.gather(serve_task, return_exceptions=True)
         await http_client.aclose()
 
 

--- a/x/grocy_mcp/grocy_container.py
+++ b/x/grocy_mcp/grocy_container.py
@@ -24,31 +24,36 @@ def make_settings(grocy_url: str) -> ServerSettings:
     return ServerSettings(grocy_url=grocy_url)
 
 
-def _prepare_custom_init_dir() -> str:
-    """Create a dir with a script that strips IPv6 listen directives from nginx config.
+@contextmanager
+def grocy_custom_init_dir() -> Generator[str]:
+    """Yield a tempdir containing an init script that strips IPv6 listen directives.
 
     LinuxServer s6-overlay runs scripts in /custom-cont-init.d/ after
     migrations (which generate the nginx config) but before services start.
+    The dir is bind-mounted read-only into the container and removed on exit
+    so repeated calls (e.g. from the eval CLI) don't leak under /tmp.
     """
-    init_dir = tempfile.mkdtemp(prefix="grocy-custom-init-")
-    script = Path(init_dir) / "disable-ipv6.sh"
-    script.write_text(
-        "#!/bin/bash\n"
-        "echo 'disable-ipv6: patching nginx configs'\n"
-        "sed -i '/listen \\[/d' /config/nginx/site-confs/*.conf\n"
-        "echo 'disable-ipv6: done, resulting config:'\n"
-        "cat /config/nginx/site-confs/default.conf\n"
-    )
-    script.chmod(0o755)
-    return init_dir
+    with tempfile.TemporaryDirectory(prefix="grocy-custom-init-") as d:
+        script = Path(d) / "disable-ipv6.sh"
+        script.write_text(
+            "#!/bin/bash\n"
+            "echo 'disable-ipv6: patching nginx configs'\n"
+            "sed -i '/listen \\[/d' /config/nginx/site-confs/*.conf\n"
+            "echo 'disable-ipv6: done, resulting config:'\n"
+            "cat /config/nginx/site-confs/default.conf\n"
+        )
+        script.chmod(0o755)
+        yield d
 
 
-def configure_grocy_container(container: DockerContainer, *, data_dir: Path | None) -> None:
+def configure_grocy_container(container: DockerContainer, *, init_dir: str, data_dir: Path | None) -> None:
     """Apply the env / volume / port config every Grocy test container needs.
 
-    If `data_dir` is provided, it's bind-mounted to Grocy's `/config/data`, so
-    the SQLite DB lives at `data_dir/grocy.db` on the host throughout the run
-    — no post-hoc copy needed. LinuxServer chowns the mount point on startup.
+    `init_dir` is the tempdir from `grocy_custom_init_dir()`; it must stay
+    alive until the container exits. If `data_dir` is provided, it's
+    bind-mounted to Grocy's `/config/data`, so the SQLite DB lives at
+    `data_dir/grocy.db` on the host throughout the run — no post-hoc copy
+    needed. LinuxServer chowns the mount point on startup.
     """
     container.with_exposed_ports(80)
     container.with_env("PUID", "1000")
@@ -56,7 +61,7 @@ def configure_grocy_container(container: DockerContainer, *, data_dir: Path | No
     container.with_env("TZ", "UTC")
     container.with_env("GROCY_MODE", "production")
     container.with_env("GROCY_DISABLE_AUTH", "true")
-    container.with_volume_mapping(_prepare_custom_init_dir(), "/custom-cont-init.d", "ro")
+    container.with_volume_mapping(init_dir, "/custom-cont-init.d", "ro")
     if data_dir is not None:
         data_dir.mkdir(parents=True, exist_ok=True)
         container.with_volume_mapping(str(data_dir), "/config/data")
@@ -91,8 +96,9 @@ def wait_for_grocy_ready(container: DockerContainer, *, timeout_s: float = 90) -
 def run_grocy_container(*, data_dir: Path | None = None) -> Generator[DockerContainer]:
     """Run a fresh Grocy container with auth disabled; yield it once ready."""
     load_oci_image(GROCY)
-    container = DockerContainer(GROCY.tag)
-    configure_grocy_container(container, data_dir=data_dir)
-    with container:
-        wait_for_grocy_ready(container)
-        yield container
+    with grocy_custom_init_dir() as init_dir:
+        container = DockerContainer(GROCY.tag)
+        configure_grocy_container(container, init_dir=init_dir, data_dir=data_dir)
+        with container:
+            wait_for_grocy_ready(container)
+            yield container

--- a/x/grocy_mcp/grocy_fixtures.py
+++ b/x/grocy_mcp/grocy_fixtures.py
@@ -15,17 +15,23 @@ import pytest
 from third_party.containers.rlocations import GROCY
 from util.oci import load_oci_image
 from util.testing.container_logs import LoggedContainer
-from x.grocy_mcp.grocy_container import configure_grocy_container, grocy_url, wait_for_grocy_ready
+from x.grocy_mcp.grocy_container import (
+    configure_grocy_container,
+    grocy_custom_init_dir,
+    grocy_url,
+    wait_for_grocy_ready,
+)
 
 
 @contextmanager
 def run_logged_grocy_container() -> Generator[LoggedContainer]:
     load_oci_image(GROCY)
-    container = LoggedContainer(GROCY.tag, test_name="grocy")
-    configure_grocy_container(container, data_dir=None)
-    with container:
-        wait_for_grocy_ready(container)
-        yield container
+    with grocy_custom_init_dir() as init_dir:
+        container = LoggedContainer(GROCY.tag, test_name="grocy")
+        configure_grocy_container(container, init_dir=init_dir, data_dir=None)
+        with container:
+            wait_for_grocy_ready(container)
+            yield container
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Two small robustness fixes caught by Copilot review on #1337 that weren't tractable against the older commit it was pointed at but still apply to the merged code.

## Summary

- `_prepare_custom_init_dir` used `tempfile.mkdtemp()` and never removed the dir. Each call to `run_grocy_container()` — so each eval CLI run — leaked a dir under `/tmp`. Replaced with `grocy_custom_init_dir()`, a context manager wrapping `tempfile.TemporaryDirectory`, entered alongside the container so the dir's lifetime tracks the container's.
- `_serve_mcp` raised `TimeoutError` from the startup-wait loop before entering its `try/finally`, so a failed uvicorn start left the serve task and httpx client behind. Moved the wait loop inside the `try`; the cleanup path now cancels the serve task with a 5s timeout fallback before closing the httpx client.

## Test plan

- [x] `bbr test //x/grocy_mcp:test_e2e` (exercises the tempdir-cleanup path through the fixture) — invocation `f200518a-1380-42c8-b0fc-7f4d06e15866`
- [x] `bbr build //x/grocy_mcp/eval:cli //x/grocy_mcp/eval:run` — clean

https://claude.ai/code/session_01NecLqNpehWwz9iDvpwCEx2