### PR TITLE
feat(nix): enable GSConnect on NixOS workstations

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -746,6 +746,8 @@ in
       { package = pkgs.gnomeExtensions.panel-date-format; }
       { package = pkgs.gnomeExtensions.cronomix; }
       { package = pkgs.gnomeExtensions.pop-shell; }
+      # Phone integration (firewall ports opened by programs.kdeconnect in gui.nix).
+      { package = pkgs.gnomeExtensions.gsconnect; }
     ];
   };
 

--- a/nix/nixos/modules/gui.nix
+++ b/nix/nixos/modules/gui.nix
@@ -21,6 +21,15 @@
   # Keyring CLI (secret-tool)
   environment.systemPackages = [ pkgs.libsecret ];
 
+  # GSConnect — phone integration via GNOME Shell extension.
+  # Uses programs.kdeconnect with the gsconnect package to open the
+  # required firewall ports (TCP+UDP 1714-1764). The extension itself is
+  # enabled for the user via programs.gnome-shell.extensions in home.nix.
+  programs.kdeconnect = {
+    enable = true;
+    package = pkgs.gnomeExtensions.gsconnect;
+  };
+
   # Screen time management
   ducktape.timekpr = {
     enable = true;


### PR DESCRIPTION
Adds the gsconnect GNOME Shell extension to home-manager (picked up on
any host with GUI) and opens the required firewall ports via
programs.kdeconnect in the shared NixOS gui module, so iguana, rugged,
and wyrm2 all pick it up.

BAZEL_TEST_INVOCATIONS=none: Nix-only change; no Bazel tests cover home-manager / NixOS module evaluation.