### PR TITLE
chore: fix prettier formatting on claude-web-k8s-cert.yaml

### DIFF
--- a/secrets/claude-web-k8s-cert.yaml
+++ b/secrets/claude-web-k8s-cert.yaml
@@ -1,67 +1,67 @@
 client_cert: ENC[AES256_GCM,data:BGk3FPMqaKAFpXYqLOwsVExRM34pIcZuUUlzmejIzbnT3An5eaPbG7NwlfBBcbcr2ps0Oc8i9PCYkw44NW6DxyO+97uqneslDSPxZrQioINS/shlQCeCmWNLpnj4n0EetsjcwVJOH+GT6S4hPs2fqveCUSALMPKeZIvCXZSZIKTN3JhW9Qkbv2iURtJ/OhCJPX/gEkvJW/dxzFYBVls2BR6QqnUaE8QncK9bxm/SK5lCEvGlBR3ieKeMbuwv2MowOt0ECkyKBroTlw2bXR8KR/1MIXn3GG4mxBQ/wo9LjVG8KO9wVgZMnWl7RSFKKu+gAzJNiOQJ3Ovz4nwa+MG0Rgc8lpYez/7PlYBpJr/sjcvoz0kvklHgBfSjRO5sg27nT0RTypnIIzf9fGFQ+gHIRV7fX5Lg9ea+mnC+ix4C5cYMXWtQAwi4jjy68VELEjcmI0lhQCaImMEFhBYSLP9MsczPhtnrGVBVsy24mKce8w3mkByc9zGejXhSlsj4aQuyHTYSQwWBmSTMfShyHEfsR15h7wm/GS5faX5yT9WI+V6KSJRLk0VyXSip2T2lz9MvKwtfUE1pzi+KQVgZrX7VRvlGlaZ77eMSe0wzsc1sty8Y4ZIC45r9FKP4HnEPzSqdkM1a2q19QP6M7TSVV2TlslWDqitid1bjOltK/cLes00vOwq7NEzzuNm1wlCXB1yvJmySy/S3fOfxRqse3ZpXiTvGg2Mm6iF2b5JWRaQHjfLDL1HYzbM7EjCiYnQmL3Oyl0tSHAwRfm0YOLlc86ptvp2ist6l87KG+RtOACEzYQPrGw7qdgXqTk/EdlIrp2aUKQyHMprtm2MMg5IE4tO5FXJrR6nCo1zQJK/+7+LNmfsM8KhlyFvKXqEjgwqa99X68jeDx0RDnmbPKRIeIq7mwlLTkcGOPdtQWFcQUl+ZgeaAAHhin6oMwGaIAcyoXzC9VSbkWvobAGydYS6ikj/pFpT7cAKiE5fQH07uaJ/P3ceI9JDHMVilddsfDY36ORHHju7Sxw++rfm2jL/49C1yLTAoEWb+5UloPotKKBbfNo3Fz3JeONfijqCT0yMmYTwm0x52efOdeeQXcP6+lcXGrgojZEKRTIkz6jG1Gl6znZuBrQmoo7/kGnrqel/oXRxEqDrPzszhFAWLP5ahVZTjsEqvHjWLGyR+ruDS7KXZEH6ChSyY2YjJYAFpuKozTKuDP3lMuA2AyRNHX1AX8sYFHGdx1bAk6981vueUQEbBAQNsAez/nrVbMgFEoS4XKQoKtimBIH8SRogWJOb0OroQRlfmPFKaEgWSgjuoxOZq8iMHsqelIOzmQcqVgm5fxBiVtXEUDssNt+lRhBLNy7x/YbIW9gqWQVk26t5M/bn7vrKfirkWDfzDkN0gaOj3uZUUtNbwctWxazT10CtjooA4WsTHR9J9xyYrk9L5MiglEChRb1dn1Sumr+lrq7+gNEkcQsGKLYb0A8OLo3rapKxK/jix3qXL+HoAcmvsTqoOJjPpujoiHJw63L1PMacccPMXRVU50HzZ1bFb30xRh9nX84vhN6OGn8cEr4yfo4xU5v3rbodpZTXmYti2xN/zgM4wDZR0DzqOfcY4sgqrEwgXFlyqH7rVNtQrXMYk01Nb0ZM2FTPDjDKCb07fSXpKQui6chRIFvA=,iv:4aQIKLdS6Ts2HHRQ4hsPRucedyuZj2sAh7VfjgzcL6Q=,tag:yDbjOWq1FQJt3G3S9CvyLg==,type:str]
 client_key: ENC[AES256_GCM,data:EV57GYj6JQOoqVmVNaZqVz6HbJruqkmECmAd1zCWvvyQbm/PQLypSZJbKhB/OTKM6TzoyHmOn46/xRN41hvuECGAdMv+xx8SIhaSc2lmFApojjmF5MwAGtMiVVUlMEldpgZB6XX/q2Jnb3Svhuy3nrmtyrxF4+W5xISfV1RQ0lo6ZjWSs8pRZd3kUmY0d02I68Ijae+c/jGVSOQarWO2fm/7JKGjUKj3X5Iv5aDwYcRbsWqukCVAisMmXNl51sRmHccSRIrR1PDwvFsYhoIpKidscob57kDY4YTIDxbqo5WfeS3Te4cj2t4nmtVq2h3ogMQdQitVZFISTGotPt5pBgd9zMT3u5T12n8D2DP5Iq7BUwOo/Z/ORdBQOh/FnA4MboiV02i8VFr2Av75VkYJ/RACcPkX8ebqHpgzeNtiZ9+0L6FypnniFveCHKm+kElntmFKS2J4roJpIM/JC6uYGtH64ISTZLZKlS/koO5eA7+jSeGfHRDqvQPYwSIAqMWw5CoMK+calvLhDp193JyCHcunQ4fkRJd2tqJOXJCXa4ysBTPdj8/uwEoT3pqXgUEMTq2Pvb7FtWmP21TWeeuJh7oQWvtAkIatQv1z6rXQwg6vqwrONfaWOa3WtRzyri6Dg4uBLE0ZKPy7k9JvGI23UKatpiWNhNahb0o5kWyayZ6OfxB12RHZmIAx1RW7M5otBGd7FtFG15wFZu8nODLufQT9gh52nmTjXWH7E9El+EU7Ogn4d+JY2+6SrZo7mrBMVEmt3LR8544vhnjJ8KZ6gxAVXSPrxCXQ/4cN9bB/gqzRjjCRIct0tY/+LOyA35YmXreR+s77Qvht6XE4gzjDvZFNvXhYrUooKx6g+iBOehv0FOFY85CeYYGF6FOVezMt1nnrPIQ8QYvAEQdXTOz9PdAiEMPrZHtXQY5N+oC4z8CA+Apm9TBd5XROI3Es8K0IOv84ZdentSrF/22a+pPzm4AJBb42mOtBOeLAL+KQikum0p6PsIau0hqqrgfgFOdOB0dAqr9+wFwUg+MgqtxIxh0rQQg7+ZEjT8iHgtbXIOITR6INkV47GWeYipHoy7mCwZ5xgdjC+9r8rKUXr23VvEeub2hRQ7XIJzDEecooSfwKH7ATzyz6qxDlW4KjsMhzHDhwD9Ndg/NRf6eTtkhcK33YgN6DXeGkq1zv5f+s9Q8Yect4A3T2duVZawL17/bYSM/mw3MsuD/VPG2oyKV3irGVOUdXO6qD6j+m9VSSI8PyhZGuupeZR48lJ/Wi1hIFZpndwasAvNQbEEw5t/AVyQexJdYY6jj4ZC7dDKEhZuqF8BUyDOttIoKKNcP4ATXbjb1oTVOnjbkt7viY4tPFbIFdtciY+Ct17mkfPbiqugfNkgoE4JUUzVi8joQO36GZYGyThlBvHbyoEd1IxPOf7upmNmM2kqZ10LqoSICe7kd72XuEXE890o+Trbt/RX8+deVi7igJmqUl/cqHa/974wzwvOnhyJwxqhEoRvfdD8QM/X3fRrV5Sw7bnzNBb2pIaX2XfQp8zWSXEMEC/YM4qPddCPJDc25Zi6PtuZCmJiSuZHvjJuZiP953OF7vxNMr+UsRqYF4SBHrYF8qt+ROZ9DPTfv53hq19WKZalFnzd5e6sAmLF147/3Tpo7QKcEid9OlRnKqoQxOIGdV8D9YtXbUJlQj745WtE+16Wh8xRhYSGaLi7z495x/yp3p2SCAZ6P0jgQxCS3xuujGcuOIjJYVxEF+ZSw3rKU5XKc8B33dHnPP3fg6LKZKNnwnp21k0+zmIluBYFG6ZPB45wUjUdGtGxGZNwboUNtamfourTs5+XYn2G8ooPacIshOCitfR8iK+8L7RItOXIO6vpHQCQZJZDe+g3GjTpHR5mhpPPAZajTTV+3rLLQ7EbMvTGt0uPkzhWlsjieY8vMSlfYyU7XgcvW5yWvsjLeNyQxvZn6SjiO6d+7ZFZXMrWzSkQ3MaY0ImElT1vGTckmhHddotb6pHHOOar7ReJaolwemXqLM3XPMpUyC3UALI6n1sRmHWwyxVXuc6hRkKCRQw/PRVxwlhLjR26kQeYLFHRmFEJFAEtbRsFHvtW1Ro2gxLfieB9IokunRzHxDd6lVwE7RyDcWUo+ly8v2A87GfMj+NggiXdpGldQ6K4FRgCKGU6xYVSKbHUbyIO3l60t13mmfeP8n4hGcEV33AjZ5jMukrQbJipO6Y0UEo57vi3Oj6DjOUQvhvHY9n20SI6egJfhNExY0oeSg0tl6Dgs6HCrIe3LckqbyHZIva62A+UEfUKWs6Qag7vmkAyG+XcMsJ5xXaetJMllSOsI+xUH7zf8ZVtJoVFJHZRhstT1JROPKcuNbpdEAouaBIU0pymlOaQREyblhFbd1WEhnJDzpVujUJbtTsFyAk+gY9trdw8KxdZAjwtmTscu3OAAKai+FC00hJz4k1pRCjYkjnCR68JyQOxjr/x+yamX9jKWreTQaWwbr9KR4wF2BekvyNVVQP1Yco1nXjGtyLvY6dyjTWeQpvVgdjpqSekibrIZd8+GZh+51HTn+PMjqd0hm5SdLk0xJi7XKLzmPEcOx5PhhIqboHeSwpAyeAhzqEqhpkILvJkrcl59EeAB4bt1XnBbDUj4q4r2zOSq4UBMqSHJiQvXtvr+NurkvYK7Npi0kPQamOV/OAqCltE9uQBDJ6jTtYtd98RSdO1MjA0gGUIe4r4lFt3ah/zqtOylIbiEq+5h6JRYOtF+pOz8IlXGnIKkhPXJ1qlJbuJUaiaBhDgsutPLhiHLc24wtCyouzImv0i5dXREtiHYw72lKjhYHLHD4ieqm4YBqxVegEzm3wJP89kNdglDZPTb/NT5YshUaKVH4YWjptDmj2crEsA3PcIbW0MyEehFss8BfU7Jm1h0g5LxfmD+pTTrWMHOsYi+I++8fgdBaL3ELhIjfggutwe6On2MGDUd5D5lSnTg8Wgz38teh6xUlUp3TeYXW+npfa+55b7RQ6k8AJ/gANjxQxlVnvHUR/wjjHuQeDWyZ65xTG3gaIFe/QJewTUkmqnxQxvzBXuOnYxnve0kXnxBASdtNn27FXoPzPUF54G98lpUMEMCYEgJi3DIOjRfuiKm+bDx3VSYUvxyEl3VFH7UZvmM4VUJ+bsGJUDUaLRBsFIfQTQvtr8akdOhd7sA4obky0ND6gn5CcJNJwAJcycDOOw+FdnvhY8hRbMPA2A6EU0+qymr6LL8AH1m9oI8bG6aJX8I7/QS0lj68OwQovj8kD98B4JIvJ189JLmlTTeAlkjDy6Y3PhETz0v5Avb5hO1RmJsnc1ns3Wsz70YFTXbeWpHrS2EogQ7oVR7VYIsbdAjQBwc6snxqgwE05LEAqd/EMReIkN5qyF9ShjBGDscDrzGnmCE97XG9XmcXiWw0RanlspBHEmRyZ3+bw+MYj/MWaI1FlKb8N6bEetK8A688i1rZrqoFyIqUXx+9/LYtYBBJrC4Xwc/DNahBL8+gnBkntwh95ZJFFWnvafiw2RUNU9heCz5+5Hr08AqEnle7mRCHdRElr0+PJC/9SFHmVtTnn7A3WGQp5aoPboz/fWhHV6/pGa7aS07je+mmPbkddnwDMEdwDb9AliZ9/UTfukNn6mPVmQPwv/ythHmU+GoTTyuDszxdkJ2LUAkmw8ijNag3h1uUURVal56G7NRPcHeJPtHaFaQtdiFPIh5WTokEEhoNMUZqcPkR/vDYdsXLcH5+h/dJGzig6KT+AfqwlcxaIdLBTFytCuAKe0uFO43XgOUaiAlYPFMJ/Wmq4t3d3CMHzoalMc1tri2v/Vt0p21rqG43/onuL5v3Msluluq2G0uDbzOQdzpZ/fsVImZG3bBFZzAgUW5OUJYvyEKAXD8fP+HwzAzk5IRiClkhSrmCnae9MvS55i0xLPTr7mxxU+CjpYZrF0d2dya8TeXEypFYr/gLL/rZZe+TydimHUItfnrmlKgrIELBRSVLrHxh61tDmW9HXFRUT+IL82LZ3r2J2HPGFZ1Ja7IZxxfgpSoYSU4QcEaUhah5IvsL+B4PysvVBiaD0HDDlQ2x5dNV3cWwvwrKCGaQtqbEapRLwA7s4XmN+GHjodwGqvsnMCTbAaqyuW37eDmDvzpafK8AH27UGN3kx8kT1YVIYLyC4RVo2bmQfXRHGBemOgHCysfhntb/BvSQkvr026+tf6uy48899GJNwiL8UoOxmrk8vNJBxrIurmxpUeqqn7Mh8vKs0DKze4TeuJTseFIiqfmmO2waa34VFLjpqP+e2nmw/repY726AfvhQDEPgupnS4HTF3aH6V3JiMHVll4D47IATKVHeZYinJPTEvM+Temvftg=,iv:ltB28v2/n7z4XiUZp/Ll3NBR9wECQsHBJapP8/7/BJs=,tag:hdrLr39esAq6UgF074w4Cg==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3cENKaTdNME0xdGdYWjA2
-            QkRYVzIvbVdwVmJ5MWI4a2tMdVIyNEVpR1FBCitDaitXeVhUTU83bmpIVmZpUjRT
-            aFZjUDNpb1MrQ05nMHNLcWduN0pBVDAKLS0tIFRkNFp3UWJKZ2tjOXJkaHdtaU12
-            OVlGSnFkdWlmYk95emtrQ2pHUW5XQk0Kq/1beJoVa1cnrkvrfUlqQN/IfUCDrmZP
-            jYs9hgm4Kr4sSw1uqW/cox8Kj8BVeKOeYuSxBhuOP2bBNBmqpIUr+w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJeTFRakQ5dGFiWFFsS0h3
-            MmYramxsSHorcE9laHJYYlo5cW1HbVMzQWpVCm54TXNuMTJwVG40RFRXNWdUUUNF
-            aUZqZ1pnRHQxSkFsTWtqK1V3bForakkKLS0tIDJYMENIeFJrQjNZQ2Z1dGpabXNX
-            Nk9nU3VPVFpZSzRoMHZvOHNKWHZyY00KPmCdX1dyhTHADQufTLe0g/yr8DGDJ3v3
-            Z8PZox69B4fu4trOPBfIovxBTHtikGo+W6GGUrVlH/V7eRAXBWhMXQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTkVGWHk4VUNTVW9TL3ZX
-            WHJFQVBiT2d0SVhSdWJ5cE0rVi9laGdxMG40CkdrcVZmNklJdHJzUlA1V2JPOHdH
-            UE1zejlZaFBtMmdIYitGQ2djQ0NDVWsKLS0tIE1NUEpoanFXampUUC9EREpxMktP
-            OFI1L0ZSNDdGYWxlODRHMXJQMW9heWsKKZkbtBUs5xMij3a5syvJWTVfhL9nUYDa
-            fm7UcIjkRhxXSGZW7xy2Y3GuZTOcQ4Us04Mkm30gu7OkazmFxTSb7Q==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3NDNSdnJtc3hjYWZ5ZStK
-            clBQRE1Fb0NscGVnU1ZqOFdVY1pBRGprUHdnCk9ZdEIrL1BwRzlmd3RocE41VHc1
-            M3p2c21iYk9VdHZFUW5BMVBOS29VS2cKLS0tIHIzMUdYYTRzcUhMQW5PUlZCdU1u
-            VkxmNEl1TUp2NHBVTmpVTTNRT1VqSlUKTCme1hVJRvWT0Ay2r+CLsuMKaC8kZwDi
-            /yMQO8zxhLRsCTAuJLc+0GH9OjKutZszc9aoC0op3o3v38iSEjU2FQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGUk1sUkFiZHN4WEhrSDBP
-            Qm9BcExBQVMxT1BGWCtvSkEwaVRzZ0ZZTVZvCjRVQUdKQ015Ym8rSHd0UFpSR3pi
-            OUxaK1pIS09yZ2hVOXRmZXRvSkVPdE0KLS0tIEFyOVl2VE9RNmJHa0FteWpscnlo
-            WHRNY0hnSG4vSnZxSVF0NVVWTmlTWG8KI9Rr5HCJqCrqKZWi6B5dKNgZh4DMAig7
-            lfDeyyNpspg8693duv98eqLsRRrW6clCVJWuYEjFaC+ngqSkKlWkTw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2N0laZXVpMnJJRGVBR2Jy
-            aUpFTkxSbmFkenJzOGJLOU45Y2lLcjhWMjFZCmtranE4SGtvNkFhTmpyS0I1RHBs
-            T1pFVk5WMC9VbDRvOFdSNWx3eXpVRGMKLS0tIEhxQnJYYVdzNHhkNGZjSmNJc3Nx
-            L205Mkk3NE5wOG1NdTZYSzVWYll2QTQKXN1NA2TpdG6J0nfP7wgvRY+KpFNMAPml
-            cfcVkpPlDC0TLQzUz/ZMTjrzeGntrD8D5vGjVmiAzoDpIS/j0yJNOg==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T10:10:20Z"
-    mac: ENC[AES256_GCM,data:CAIpNQQI86tHLi/oAZ1qX76SVnz6AprBByBk7OQsBCbyVp65tDUam9go2BHOagnlYhiJvdibbC5POToNHLtGcvVV9POtijX32aKSElTZ2FwtDu8Sllib6F1kubABlp2tQtHKviNFa4QxahBQxQ+G/KzT1BDN617PEL8pVzf+w6E=,iv:qPdw5WxSPtpN58lblILHEu44/d4WNY/HXKLyWx2tg1w=,tag:H2akmqZOGqQjbJ/8gxOZ0w==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3cENKaTdNME0xdGdYWjA2
+        QkRYVzIvbVdwVmJ5MWI4a2tMdVIyNEVpR1FBCitDaitXeVhUTU83bmpIVmZpUjRT
+        aFZjUDNpb1MrQ05nMHNLcWduN0pBVDAKLS0tIFRkNFp3UWJKZ2tjOXJkaHdtaU12
+        OVlGSnFkdWlmYk95emtrQ2pHUW5XQk0Kq/1beJoVa1cnrkvrfUlqQN/IfUCDrmZP
+        jYs9hgm4Kr4sSw1uqW/cox8Kj8BVeKOeYuSxBhuOP2bBNBmqpIUr+w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJeTFRakQ5dGFiWFFsS0h3
+        MmYramxsSHorcE9laHJYYlo5cW1HbVMzQWpVCm54TXNuMTJwVG40RFRXNWdUUUNF
+        aUZqZ1pnRHQxSkFsTWtqK1V3bForakkKLS0tIDJYMENIeFJrQjNZQ2Z1dGpabXNX
+        Nk9nU3VPVFpZSzRoMHZvOHNKWHZyY00KPmCdX1dyhTHADQufTLe0g/yr8DGDJ3v3
+        Z8PZox69B4fu4trOPBfIovxBTHtikGo+W6GGUrVlH/V7eRAXBWhMXQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTkVGWHk4VUNTVW9TL3ZX
+        WHJFQVBiT2d0SVhSdWJ5cE0rVi9laGdxMG40CkdrcVZmNklJdHJzUlA1V2JPOHdH
+        UE1zejlZaFBtMmdIYitGQ2djQ0NDVWsKLS0tIE1NUEpoanFXampUUC9EREpxMktP
+        OFI1L0ZSNDdGYWxlODRHMXJQMW9heWsKKZkbtBUs5xMij3a5syvJWTVfhL9nUYDa
+        fm7UcIjkRhxXSGZW7xy2Y3GuZTOcQ4Us04Mkm30gu7OkazmFxTSb7Q==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3NDNSdnJtc3hjYWZ5ZStK
+        clBQRE1Fb0NscGVnU1ZqOFdVY1pBRGprUHdnCk9ZdEIrL1BwRzlmd3RocE41VHc1
+        M3p2c21iYk9VdHZFUW5BMVBOS29VS2cKLS0tIHIzMUdYYTRzcUhMQW5PUlZCdU1u
+        VkxmNEl1TUp2NHBVTmpVTTNRT1VqSlUKTCme1hVJRvWT0Ay2r+CLsuMKaC8kZwDi
+        /yMQO8zxhLRsCTAuJLc+0GH9OjKutZszc9aoC0op3o3v38iSEjU2FQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGUk1sUkFiZHN4WEhrSDBP
+        Qm9BcExBQVMxT1BGWCtvSkEwaVRzZ0ZZTVZvCjRVQUdKQ015Ym8rSHd0UFpSR3pi
+        OUxaK1pIS09yZ2hVOXRmZXRvSkVPdE0KLS0tIEFyOVl2VE9RNmJHa0FteWpscnlo
+        WHRNY0hnSG4vSnZxSVF0NVVWTmlTWG8KI9Rr5HCJqCrqKZWi6B5dKNgZh4DMAig7
+        lfDeyyNpspg8693duv98eqLsRRrW6clCVJWuYEjFaC+ngqSkKlWkTw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2N0laZXVpMnJJRGVBR2Jy
+        aUpFTkxSbmFkenJzOGJLOU45Y2lLcjhWMjFZCmtranE4SGtvNkFhTmpyS0I1RHBs
+        T1pFVk5WMC9VbDRvOFdSNWx3eXpVRGMKLS0tIEhxQnJYYVdzNHhkNGZjSmNJc3Nx
+        L205Mkk3NE5wOG1NdTZYSzVWYll2QTQKXN1NA2TpdG6J0nfP7wgvRY+KpFNMAPml
+        cfcVkpPlDC0TLQzUz/ZMTjrzeGntrD8D5vGjVmiAzoDpIS/j0yJNOg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-18T10:10:20Z"
+  mac: ENC[AES256_GCM,data:CAIpNQQI86tHLi/oAZ1qX76SVnz6AprBByBk7OQsBCbyVp65tDUam9go2BHOagnlYhiJvdibbC5POToNHLtGcvVV9POtijX32aKSElTZ2FwtDu8Sllib6F1kubABlp2tQtHKviNFa4QxahBQxQ+G/KzT1BDN617PEL8pVzf+w6E=,iv:qPdw5WxSPtpN58lblILHEu44/d4WNY/HXKLyWx2tg1w=,tag:H2akmqZOGqQjbJ/8gxOZ0w==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
## Summary

- SOPS re-emitted `secrets/claude-web-k8s-cert.yaml` with 4-space indentation on the encrypted-keys metadata when the cert was rotated in `698cff3`. Prettier wants 2-space.
- Every PR branching off devel currently fails the Pre-commit CI check on this file. Run prettier to re-indent; no content change.

## Test plan

- [x] `pre-commit run --files secrets/claude-web-k8s-cert.yaml` passes locally.
- [ ] Pre-commit CI on this PR goes green.
