### PR TITLE
feat(claude-hook): Rust hook daemon — full SessionStart parity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
             target: //:claude_hooks_wheel
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl
             tests: //devinfra/claude/... //devinfra/precommit/... //cluster/validation/...
+          - pkg: claude-hook-rs
+            target: //devinfra/claude/claude_hook:claude_hook
+            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/devinfra/claude/claude_hook/claude_hook
+            tests: //devinfra/claude/claude_hook/...
           - pkg: ducktape-util
             target: //util:wheel
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0d382ef8e0fd60fcfd04414c2d3107c113adf991635b965ec50e45c8bb65d4d7",
+  "checksum": "7739d742e923d973c055ef2a93a806fc898b98ca380d257545bd7c3a4773ed88",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",
@@ -1097,6 +1097,257 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "axum 0.8.9": {
+      "name": "axum",
+      "version": "0.8.9",
+      "package_url": "https://github.com/tokio-rs/axum",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/axum/0.8.9/download",
+          "sha256": "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "axum",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "axum",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "form",
+            "http1",
+            "json",
+            "matched-path",
+            "original-uri",
+            "query",
+            "tokio",
+            "tower-log",
+            "tracing"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "axum-core 0.5.6",
+              "target": "axum_core"
+            },
+            {
+              "id": "bytes 1.11.0",
+              "target": "bytes"
+            },
+            {
+              "id": "form_urlencoded 1.2.2",
+              "target": "form_urlencoded"
+            },
+            {
+              "id": "futures-util 0.3.31",
+              "target": "futures_util"
+            },
+            {
+              "id": "http 1.4.0",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "http-body-util 0.1.3",
+              "target": "http_body_util"
+            },
+            {
+              "id": "hyper 1.8.1",
+              "target": "hyper"
+            },
+            {
+              "id": "hyper-util 0.1.19",
+              "target": "hyper_util"
+            },
+            {
+              "id": "itoa 1.0.17",
+              "target": "itoa"
+            },
+            {
+              "id": "matchit 0.8.4",
+              "target": "matchit"
+            },
+            {
+              "id": "memchr 2.7.6",
+              "target": "memchr"
+            },
+            {
+              "id": "mime 0.3.17",
+              "target": "mime"
+            },
+            {
+              "id": "percent-encoding 2.3.2",
+              "target": "percent_encoding"
+            },
+            {
+              "id": "pin-project-lite 0.2.16",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "serde_core 1.0.228",
+              "target": "serde_core"
+            },
+            {
+              "id": "serde_json 1.0.149",
+              "target": "serde_json"
+            },
+            {
+              "id": "serde_path_to_error 0.1.20",
+              "target": "serde_path_to_error"
+            },
+            {
+              "id": "serde_urlencoded 0.7.1",
+              "target": "serde_urlencoded"
+            },
+            {
+              "id": "sync_wrapper 1.0.2",
+              "target": "sync_wrapper"
+            },
+            {
+              "id": "tokio 1.49.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tower 0.5.3",
+              "target": "tower"
+            },
+            {
+              "id": "tower-layer 0.3.3",
+              "target": "tower_layer"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
+            },
+            {
+              "id": "tracing 0.1.44",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.9"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "axum-core 0.5.6": {
+      "name": "axum-core",
+      "version": "0.5.6",
+      "package_url": "https://github.com/tokio-rs/axum",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/axum-core/0.5.6/download",
+          "sha256": "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "axum_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "axum_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "tracing"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bytes 1.11.0",
+              "target": "bytes"
+            },
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "http 1.4.0",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "http-body-util 0.1.3",
+              "target": "http_body_util"
+            },
+            {
+              "id": "mime 0.3.17",
+              "target": "mime"
+            },
+            {
+              "id": "pin-project-lite 0.2.16",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "sync_wrapper 1.0.2",
+              "target": "sync_wrapper"
+            },
+            {
+              "id": "tower-layer 0.3.3",
+              "target": "tower_layer"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
+            },
+            {
+              "id": "tracing 0.1.44",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.6"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "base64 0.21.7": {
       "name": "base64",
       "version": "0.21.7",
@@ -1269,6 +1520,18 @@
           "common": [],
           "selects": {
             "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
               "std"
             ]
           }
@@ -4287,6 +4550,10 @@
               "target": "anyhow"
             },
             {
+              "id": "axum 0.8.9",
+              "target": "axum"
+            },
+            {
               "id": "bollard 0.20.2",
               "target": "bollard"
             },
@@ -4407,8 +4674,16 @@
               "target": "shellexpand"
             },
             {
+              "id": "shlex 1.3.0",
+              "target": "shlex"
+            },
+            {
               "id": "structopt 0.3.26",
               "target": "structopt"
+            },
+            {
+              "id": "tempfile 3.24.0",
+              "target": "tempfile"
             },
             {
               "id": "term-table 1.4.0",
@@ -4425,6 +4700,10 @@
             {
               "id": "tokio-vsock 0.7.2",
               "target": "tokio_vsock"
+            },
+            {
+              "id": "tower 0.5.3",
+              "target": "tower"
             },
             {
               "id": "url 2.5.8",
@@ -4800,10 +5079,22 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "std"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [],
@@ -7901,6 +8192,8 @@
             "client-legacy",
             "default",
             "http1",
+            "server",
+            "service",
             "tokio"
           ],
           "selects": {
@@ -9724,6 +10017,17 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "auxvec",
+            "elf",
+            "errno",
+            "general",
+            "ioctl",
+            "no_std"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
         "version": "0.11.0"
       },
@@ -9967,6 +10271,51 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "matchit 0.8.4": {
+      "name": "matchit",
+      "version": "0.8.4",
+      "package_url": "https://github.com/ibraheemdev/matchit",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/matchit/0.8.4/download",
+          "sha256": "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "matchit",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "matchit",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.8.4"
+      },
+      "license": "MIT AND BSD-3-Clause",
+      "license_ids": [
+        "BSD-3-Clause",
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "memchr 2.7.6": {
       "name": "memchr",
@@ -16685,20 +17034,22 @@
               "target": "bitflags"
             },
             {
-              "id": "errno 0.3.14",
-              "target": "errno",
-              "alias": "libc_errno"
-            },
-            {
-              "id": "libc 0.2.180",
-              "target": "libc"
-            },
-            {
               "id": "rustix 1.1.3",
               "target": "build_script_build"
             }
           ],
           "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "errno 0.3.14",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.180",
+                "target": "libc"
+              }
+            ],
             "cfg(all(any(target_os = \"linux\", target_os = \"android\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
                 "id": "linux-raw-sys 0.11.0",
@@ -16711,10 +17062,37 @@
                 "target": "linux_raw_sys"
               }
             ],
+            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+              {
+                "id": "errno 0.3.14",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.180",
+                "target": "libc"
+              }
+            ],
             "cfg(windows)": [
+              {
+                "id": "errno 0.3.14",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
               {
                 "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
+              }
+            ],
+            "wasm32-wasip1": [
+              {
+                "id": "errno 0.3.14",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.180",
+                "target": "libc"
               }
             ]
           }
@@ -18275,6 +18653,7 @@
           "common": [
             "alloc",
             "default",
+            "raw_value",
             "std"
           ],
           "selects": {}
@@ -18324,6 +18703,65 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "serde_path_to_error 0.1.20": {
+      "name": "serde_path_to_error",
+      "version": "0.1.20",
+      "package_url": "https://github.com/dtolnay/path-to-error",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/serde_path_to_error/0.1.20/download",
+          "sha256": "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "serde_path_to_error",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "serde_path_to_error",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "itoa 1.0.17",
+              "target": "itoa"
+            },
+            {
+              "id": "serde_core 1.0.228",
+              "target": "serde_core"
+            }
+          ],
+          "selects": {
+            "cfg(any())": [
+              {
+                "id": "serde 1.0.228",
+                "target": "serde"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.1.20"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -20135,15 +20573,23 @@
               "target": "fastrand"
             },
             {
-              "id": "getrandom 0.3.4",
-              "target": "getrandom"
-            },
-            {
               "id": "once_cell 1.21.3",
               "target": "once_cell"
             }
           ],
           "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
+              }
+            ],
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
                 "id": "rustix 1.1.3",
@@ -20154,6 +20600,30 @@
               {
                 "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
+              }
+            ],
+            "wasm32-wasip1": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "getrandom 0.3.4",
+                "target": "getrandom"
               }
             ]
           }
@@ -21842,14 +22312,36 @@
           "common": [
             "futures-core",
             "futures-util",
+            "log",
+            "make",
             "pin-project-lite",
-            "retry",
             "sync_wrapper",
-            "timeout",
             "tokio",
+            "tracing",
             "util"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "retry",
+              "timeout"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "retry",
+              "timeout"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "retry",
+              "timeout"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "retry",
+              "timeout"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "retry",
+              "timeout"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -21880,6 +22372,10 @@
             {
               "id": "tower-service 0.3.3",
               "target": "tower_service"
+            },
+            {
+              "id": "tracing 0.1.44",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -28251,6 +28747,11 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
+    "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+      "aarch64-apple-darwin",
+      "wasm32-unknown-unknown",
+      "wasm32-wasip1"
+    ],
     "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu"
@@ -28404,6 +28905,7 @@
     "alphavantage 0.7.1",
     "anyhow 1.0.102",
     "async-trait 0.1.89",
+    "axum 0.8.9",
     "bollard 0.20.2",
     "bytes 1.11.0",
     "chrono 0.4.43",
@@ -28435,11 +28937,14 @@
     "serde_json 1.0.149",
     "serde_yaml 0.9.34+deprecated",
     "shellexpand 3.1.1",
+    "shlex 1.3.0",
     "structopt 0.3.26",
+    "tempfile 3.24.0",
     "term-table 1.4.0",
     "tokio 1.49.0",
     "tokio-tungstenite 0.29.0",
     "tokio-vsock 0.7.2",
+    "tower 0.5.3",
     "url 2.5.8",
     "uuid 1.19.0",
     "warp 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +753,7 @@ dependencies = [
  "alphavantage",
  "anyhow",
  "async-trait",
+ "axum",
  "bollard",
  "bytes",
  "chrono",
@@ -732,11 +785,14 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
+ "shlex",
  "structopt",
+ "tempfile",
  "term-table",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tokio-vsock",
+ "tower",
  "url",
  "uuid",
  "warp",
@@ -1640,6 +1696,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2911,6 +2973,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3573,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = "^0.1.89"
 rust_decimal_macros = "^1.40.0"
 term-table = "^1.4.0"
 uuid = { version="^1.19.0", features=["v4"] }
+shlex = "^1.3.0"
 glob = "^0.3.3"
 csv = "^1.4.0"
 scraper = "^0.26.0"
@@ -47,6 +48,10 @@ http = "^1.4.0"
 http-body-util = "^0.1.3"
 clap = { version = "^4.5.58", features = ["derive", "env"] }
 nix = { version = "^0.31.1", features = ["signal", "process", "fs"] }
+# claude-hook (Rust hook daemon)
+axum = { version = "^0.8.4", features = ["json"] }
+tower = "^0.5.2"
+tempfile = "^3.20.0"
 bytes = "^1.11.0"
 parking_lot = "^0.12.5"
 libc = "^0.2.172"

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -43,6 +43,7 @@ class Artifact(BaseModel, frozen=True):
 
 ARTIFACTS = [
     Artifact(pkg="claude-hooks", filename="claude_hooks-0.1.0-py3-none-any.whl"),
+    Artifact(pkg="claude-hook-rs", filename="claude-hook"),
     Artifact(pkg="ducktape-util", filename="ducktape_util-0.1.0-py3-none-any.whl"),
     Artifact(pkg="ducktape", filename="ducktape-0.1.0-py3-none-any.whl"),
     Artifact(pkg="gterm-theme", filename="gterm_theme-0.1.0-py3-none-any.whl"),

--- a/devinfra/claude/claude_hook/BUILD.bazel
+++ b/devinfra/claude/claude_hook/BUILD.bazel
@@ -1,0 +1,122 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+
+rust_library(
+    name = "protocol",
+    srcs = ["protocol.rs"],
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:serde",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "protocol_test",
+    crate = ":protocol",
+)
+
+rust_library(
+    name = "config",
+    srcs = ["config.rs"],
+    crate_name = "claude_hook_config",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:serde",
+        "@crates//:serde_yaml",
+    ],
+)
+
+rust_test(
+    name = "config_test",
+    crate = ":config",
+)
+
+rust_library(
+    name = "env_script",
+    srcs = ["env_script.rs"],
+    crate_name = "claude_hook_env_script",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "env_script_test",
+    crate = ":env_script",
+    deps = ["@crates//:tempfile"],
+)
+
+rust_library(
+    name = "env_file",
+    srcs = ["env_file.rs"],
+    crate_name = "claude_hook_env_file",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:shlex",
+        "@crates//:tempfile",
+    ],
+)
+
+rust_test(
+    name = "env_file_test",
+    crate = ":env_file",
+)
+
+rust_library(
+    name = "shim_install",
+    srcs = ["shim_install.rs"],
+    crate_name = "claude_hook_shim_install",
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = ["@crates//:shlex"],
+)
+
+rust_test(
+    name = "shim_install_test",
+    crate = ":shim_install",
+    deps = ["@crates//:tempfile"],
+)
+
+rust_binary(
+    name = "claude_hook",
+    srcs = [
+        "bg_command.rs",
+        "daemon_lifecycle.rs",
+        "git_shim.rs",
+        "main.rs",
+        "session.rs",
+        "shim_runtime.rs",
+    ],
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        ":env_file",
+        ":env_script",
+        ":protocol",
+        ":shim_install",
+        "@crates//:axum",
+        "@crates//:clap",
+        "@crates//:http-body-util",
+        "@crates//:hyper",
+        "@crates//:hyper-util",
+        "@crates//:libc",
+        "@crates//:nix",
+        "@crates//:serde",
+        "@crates//:serde_json",
+        "@crates//:shlex",
+        "@crates//:tempfile",
+        "@crates//:tokio",
+        "@crates//:tower",
+    ],
+)
+
+rust_test(
+    name = "claude_hook_test",
+    crate = ":claude_hook",
+    deps = [
+        "@crates//:tempfile",
+    ],
+)

--- a/devinfra/claude/claude_hook/bg_command.rs
+++ b/devinfra/claude/claude_hook/bg_command.rs
@@ -1,0 +1,126 @@
+//! Background command execution — ports
+//! `devinfra/claude/hook_daemon/session_start/handler.py::_launch_background_command`.
+//!
+//! Each bg command spawns a `bash -c` subprocess with:
+//!
+//!   - `cwd = project_dir`
+//!   - `env = os::environ + env_overlay + HOOK_DAEMON_SOCK=<sock>`
+//!   - stdout/stderr piped and read line-by-line into the session's bg
+//!     buffers, so a REPL hook can drain them without waiting for the
+//!     process to finish
+//!   - a watcher task that either reports completion (exit code) or
+//!     timeout (kills the process, posts a message) to the session
+//!     mailbox.
+//!
+//! `after_env: true` commands source the session env file first.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+use claude_hook_config::BackgroundCommand;
+
+use crate::session::{BgStream, Session};
+
+/// Spawn one background command and wire stdout/stderr → session buffers +
+/// a watcher that reports completion / timeout via the mailbox.
+pub fn launch(
+    session: Arc<Session>,
+    cmd: BackgroundCommand,
+    sock_path: PathBuf,
+    env_file_path: Option<PathBuf>,
+    project_dir: PathBuf,
+    env_overlay: HashMap<String, String>,
+) {
+    tokio::spawn(async move {
+        session.post_message(format!("Task [{}] started.", cmd.name));
+
+        let shell_cmd = if cmd.after_env {
+            if let Some(envf) = env_file_path.as_ref() {
+                format!(
+                    "source {} && {}",
+                    shlex::try_quote(envf.to_str().unwrap_or("")).unwrap(),
+                    cmd.command
+                )
+            } else {
+                cmd.command.clone()
+            }
+        } else {
+            cmd.command.clone()
+        };
+
+        let mut proc = match spawn(&shell_cmd, &project_dir, &sock_path, &env_overlay) {
+            Ok(p) => p,
+            Err(e) => {
+                session.post_message(format!("Task [{}] failed to spawn: {e}", cmd.name));
+                return;
+            }
+        };
+
+        let stdout = proc.stdout.take().expect("stdout piped");
+        let stderr = proc.stderr.take().expect("stderr piped");
+
+        let s_out = session.clone();
+        let task_out = cmd.name.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                s_out.push_bg_line(&task_out, BgStream::Stdout, line);
+            }
+        });
+
+        let s_err = session.clone();
+        let task_err = cmd.name.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                s_err.push_bg_line(&task_err, BgStream::Stderr, line);
+            }
+        });
+
+        match tokio::time::timeout(Duration::from_secs(cmd.timeout), proc.wait()).await {
+            Ok(Ok(status)) => {
+                let rc = status.code().unwrap_or(-1);
+                session.post_message(format!("Task [{}] exited {rc}.", cmd.name));
+            }
+            Ok(Err(e)) => {
+                session.post_message(format!("Task [{}] wait failed: {e}", cmd.name));
+            }
+            Err(_) => {
+                if let Err(e) = proc.kill().await {
+                    eprintln!("bg [{}]: kill failed: {e}", cmd.name);
+                }
+                session.post_message(format!(
+                    "Task [{}] timed out after {}s.",
+                    cmd.name, cmd.timeout
+                ));
+            }
+        }
+    });
+}
+
+fn spawn(
+    shell_cmd: &str,
+    project_dir: &Path,
+    sock_path: &Path,
+    env_overlay: &HashMap<String, String>,
+) -> std::io::Result<tokio::process::Child> {
+    let mut c = Command::new("bash");
+    c.arg("-c")
+        .arg(shell_cmd)
+        .current_dir(project_dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .stdin(std::process::Stdio::null());
+
+    // Inherit daemon env + overlay + HOOK_DAEMON_SOCK.
+    for (k, v) in env_overlay {
+        c.env(k, v);
+    }
+    c.env("HOOK_DAEMON_SOCK", sock_path);
+    c.spawn()
+}

--- a/devinfra/claude/claude_hook/config.rs
+++ b/devinfra/claude/claude_hook/config.rs
@@ -1,0 +1,151 @@
+//! Profile YAML configuration.
+//!
+//! The profile is **repo-generic**: unknown fields are ignored so
+//! repo-specific keys (k8s, bazel_bes_proxy, setup_docker, pre_commit, etc.)
+//! don't break parsing. They're consumed by the repo's scripts, not the
+//! daemon.
+
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct ProfileConfig {
+    /// Repo-relative path to a shell script sourced once at daemon startup.
+    /// The env delta (new/changed vars) becomes the env overlay, applied
+    /// deliberately to the session env file + background commands.
+    #[serde(default)]
+    pub startup_env_script: Option<String>,
+
+    /// Inline shell appended verbatim to the session env file.
+    #[serde(default)]
+    pub env_exports: Option<String>,
+
+    /// Shell commands to run in the background during session start.
+    #[serde(default)]
+    pub background_commands: Vec<BackgroundCommand>,
+
+    /// Enable idle watchdog (SIGTERM after N seconds of inactivity).
+    #[serde(default)]
+    pub idle_watchdog: bool,
+
+    /// Repo-relative path to a Tera template for the session context banner.
+    #[serde(default)]
+    pub context_template: Option<String>,
+
+    /// Git shim behavior toggles (block dangerous git commands).
+    #[serde(default)]
+    pub git_shim: GitShimConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BackgroundCommand {
+    pub name: String,
+    pub command: String,
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
+    /// If true, delay until after the session env file is written and source
+    /// it before running. Otherwise run immediately.
+    #[serde(default)]
+    pub after_env: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct GitShimConfig {
+    #[serde(default)]
+    pub block_add_all: bool,
+    #[serde(default)]
+    pub block_stash: bool,
+    #[serde(default)]
+    pub block_amend: bool,
+}
+
+fn default_timeout() -> u64 {
+    300
+}
+
+impl ProfileConfig {
+    pub fn load(path: &std::path::Path) -> Result<Self, String> {
+        let raw =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        serde_yaml::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal() {
+        let yaml = "idle_watchdog: false\n";
+        let cfg: ProfileConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!cfg.idle_watchdog);
+        assert!(cfg.background_commands.is_empty());
+    }
+
+    #[test]
+    fn parse_with_unknown_fields_ignored() {
+        let yaml = r#"
+startup_env_script: devinfra/secrets/web_env.sh
+env_exports: |
+  export FOO=bar
+idle_watchdog: false
+k8s:
+  server: https://api.example
+  service_account: sa
+  namespace: ns
+bazel_bes_proxy:
+  target: remote.buildbuddy.io:443
+setup_docker: true
+pre_commit:
+  auto_apply_hooks: [ruff-format]
+background_commands:
+  - name: hello
+    command: echo hi
+    timeout: 10
+    after_env: true
+"#;
+        let cfg: ProfileConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.startup_env_script.as_deref(),
+            Some("devinfra/secrets/web_env.sh")
+        );
+        assert!(cfg.env_exports.is_some());
+        assert_eq!(cfg.background_commands.len(), 1);
+        assert_eq!(cfg.background_commands[0].name, "hello");
+        assert!(cfg.background_commands[0].after_env);
+        assert_eq!(cfg.background_commands[0].timeout, 10);
+    }
+
+    #[test]
+    fn background_command_default_timeout() {
+        let yaml = r#"
+background_commands:
+  - name: x
+    command: echo x
+"#;
+        let cfg: ProfileConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.background_commands[0].timeout, 300);
+        assert!(!cfg.background_commands[0].after_env);
+    }
+
+    #[test]
+    fn git_shim_defaults_to_all_false() {
+        let cfg: ProfileConfig = serde_yaml::from_str("").unwrap();
+        assert!(!cfg.git_shim.block_add_all);
+        assert!(!cfg.git_shim.block_stash);
+        assert!(!cfg.git_shim.block_amend);
+    }
+
+    #[test]
+    fn git_shim_parses() {
+        let yaml = r#"
+git_shim:
+  block_add_all: true
+  block_stash: true
+"#;
+        let cfg: ProfileConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.git_shim.block_add_all);
+        assert!(cfg.git_shim.block_stash);
+        assert!(!cfg.git_shim.block_amend);
+    }
+}

--- a/devinfra/claude/claude_hook/daemon_lifecycle.rs
+++ b/devinfra/claude/claude_hook/daemon_lifecycle.rs
@@ -1,0 +1,383 @@
+//! Client-side daemon lifecycle management.
+//!
+//! Ports `devinfra/claude/hook_daemon/client.py::_ensure_daemon`. Provides:
+//!
+//!   - **Pidfile flock probe** — non-blocking `flock(LOCK_EX|LOCK_NB)` to
+//!     detect whether a daemon process holds the pidfile lock (PID-reuse safe).
+//!   - **Cross-process startup lock** (`daemon.lock`) — prevents concurrent
+//!     clients from racing to start multiple daemons.
+//!   - **Kill stale daemon** — SIGTERM → 500ms grace → SIGKILL → 10s reap.
+//!   - **Circuit breaker** — file-based exponential backoff on repeated startup
+//!     failures, cleared on success.
+//!   - **`ensure_daemon`** — the full lifecycle orchestration.
+
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use http_body_util::Empty;
+use hyper::body::Bytes;
+use hyper_util::rt::TokioIo;
+use serde::{Deserialize, Serialize};
+
+const STARTUP_FAILURE_FILE: &str = "startup_failure.json";
+const CIRCUIT_BREAKER_BASE_SECS: u64 = 2;
+const CIRCUIT_BREAKER_MAX_SECS: u64 = 120;
+
+// ---------------------------------------------------------------------------
+// Pidfile flock probe
+// ---------------------------------------------------------------------------
+
+/// Non-blocking flock probe on the pidfile. Returns `true` if a daemon holds
+/// the lock (i.e., a live daemon is running).
+pub fn is_pidfile_locked(pidfile: &Path) -> bool {
+    let fd = match std::fs::File::open(pidfile) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let raw = fd.as_raw_fd();
+    let rc = unsafe { libc::flock(raw, libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        unsafe { libc::flock(raw, libc::LOCK_UN) };
+        false
+    } else {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process startup lock (daemon.lock)
+// ---------------------------------------------------------------------------
+
+/// RAII guard that holds an exclusive flock on `daemon.lock`. Released on drop.
+pub struct DaemonLockGuard {
+    _fd: std::fs::File,
+}
+
+impl Drop for DaemonLockGuard {
+    fn drop(&mut self) {
+        unsafe { libc::flock(self._fd.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+/// Acquire an exclusive blocking flock on `<daemon_dir>/daemon.lock`.
+pub fn acquire_daemon_lock(daemon_dir: &Path) -> DaemonLockGuard {
+    let fd = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(daemon_dir.join("daemon.lock"))
+        .expect("open daemon.lock");
+    let rc = unsafe { libc::flock(fd.as_raw_fd(), libc::LOCK_EX) };
+    assert!(
+        rc == 0,
+        "flock daemon.lock failed: {}",
+        std::io::Error::last_os_error()
+    );
+    DaemonLockGuard { _fd: fd }
+}
+
+// ---------------------------------------------------------------------------
+// Kill stale daemon
+// ---------------------------------------------------------------------------
+
+fn read_pidfile(pidfile: &Path) -> Option<i32> {
+    std::fs::read_to_string(pidfile).ok()?.trim().parse().ok()
+}
+
+/// Kill the daemon identified by pidfile: SIGTERM, 500ms grace, then SIGKILL.
+pub fn kill_daemon_by_pidfile(pidfile: &Path) {
+    let Some(pid) = read_pidfile(pidfile) else {
+        return;
+    };
+    let nix_pid = nix::unistd::Pid::from_raw(pid);
+
+    if nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGTERM).is_err() {
+        return;
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    if let Err(e) = nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGKILL) {
+        eprintln!("lifecycle: SIGKILL pid={pid} failed: {e}");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if nix::sys::signal::kill(nix_pid, None).is_err() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    eprintln!("lifecycle: pid={pid} still alive after SIGTERM+SIGKILL");
+}
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct StartupFailure {
+    consecutive_failures: u32,
+    last_failure_epoch: u64,
+}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn read_startup_failure(daemon_dir: &Path) -> Option<StartupFailure> {
+    let path = daemon_dir.join(STARTUP_FAILURE_FILE);
+    let data = match std::fs::read(&path) {
+        Ok(d) => d,
+        Err(_) => return None,
+    };
+    match serde_json::from_slice(&data) {
+        Ok(f) => Some(f),
+        Err(_) => {
+            if let Err(e) = std::fs::remove_file(&path) {
+                eprintln!(
+                    "lifecycle: failed to remove corrupt {}: {e}",
+                    path.display()
+                );
+            }
+            None
+        }
+    }
+}
+
+/// Returns `Err` with a message if the circuit breaker is open (cooldown not elapsed).
+pub fn check_circuit_breaker(daemon_dir: &Path) -> Result<(), String> {
+    let Some(failure) = read_startup_failure(daemon_dir) else {
+        return Ok(());
+    };
+    let backoff_factor = 1u64
+        .checked_shl(failure.consecutive_failures)
+        .unwrap_or(u64::MAX);
+    let cooldown = CIRCUIT_BREAKER_BASE_SECS
+        .saturating_mul(backoff_factor)
+        .min(CIRCUIT_BREAKER_MAX_SECS);
+    let elapsed = now_epoch().saturating_sub(failure.last_failure_epoch);
+    if elapsed < cooldown {
+        let remaining = cooldown - elapsed;
+        return Err(format!(
+            "Circuit breaker open: {} consecutive startup failure(s), next attempt in {remaining}s",
+            failure.consecutive_failures
+        ));
+    }
+    Ok(())
+}
+
+pub fn record_startup_failure(daemon_dir: &Path) {
+    let prev = read_startup_failure(daemon_dir);
+    let count = prev.map_or(1, |p| p.consecutive_failures + 1);
+    let data = StartupFailure {
+        consecutive_failures: count,
+        last_failure_epoch: now_epoch(),
+    };
+    let path = daemon_dir.join(STARTUP_FAILURE_FILE);
+    if let Ok(json) = serde_json::to_vec(&data) {
+        if let Ok(mut tmp) = tempfile::NamedTempFile::new_in(daemon_dir) {
+            use std::io::Write;
+            tmp.write_all(&json).ok();
+            if let Err(e) = tmp.persist(&path) {
+                eprintln!("lifecycle: failed to persist {}: {e}", path.display());
+            }
+        }
+    }
+}
+
+pub fn clear_startup_failure(daemon_dir: &Path) {
+    if let Err(e) = std::fs::remove_file(daemon_dir.join(STARTUP_FAILURE_FILE)) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            eprintln!("lifecycle: failed to clear startup_failure.json: {e}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+async fn health_check(sock_path: &Path) -> bool {
+    let Ok(stream) = tokio::net::UnixStream::connect(sock_path).await else {
+        return false;
+    };
+    let io = TokioIo::new(stream);
+    let Ok((mut sender, conn)) = hyper::client::conn::http1::handshake(io).await else {
+        return false;
+    };
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let req = hyper::Request::builder()
+        .method("GET")
+        .uri("/health")
+        .header("host", "localhost")
+        .body(Empty::<Bytes>::new());
+    let Ok(req) = req else { return false };
+    let Ok(resp) = tokio::time::timeout(Duration::from_secs(2), sender.send_request(req)).await
+    else {
+        return false;
+    };
+    resp.is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// ensure_daemon orchestration
+// ---------------------------------------------------------------------------
+
+/// Full lifecycle: lock → health → circuit breaker → flock probe → kill
+/// stale → clean state → fork → wait (with crash detection) → circuit
+/// breaker update → unlock.
+///
+/// Calls `crate::fork_daemon` and `crate::wait_for_sock` directly.
+pub async fn ensure_daemon(sock_path: &Path, daemon_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(daemon_dir).ok();
+    let pidfile = daemon_dir.join("daemon.pid");
+
+    // Fast path: healthy daemon already running (no lock needed).
+    if sock_path.exists() && health_check(sock_path).await {
+        return Ok(());
+    }
+
+    // Slow path: acquire daemon.lock to prevent concurrent races.
+    let _lock = acquire_daemon_lock(daemon_dir);
+
+    // Re-check after lock — another client may have won the race.
+    if sock_path.exists() && health_check(sock_path).await {
+        return Ok(());
+    }
+
+    check_circuit_breaker(daemon_dir)?;
+
+    if is_pidfile_locked(&pidfile) {
+        eprintln!("lifecycle: pidfile locked but daemon unhealthy — killing stale daemon");
+        kill_daemon_by_pidfile(&pidfile);
+    }
+
+    // Clean stale state.
+    if sock_path.exists() {
+        if let Err(e) = std::fs::remove_file(sock_path) {
+            eprintln!("lifecycle: failed to remove stale socket: {e}");
+        }
+    }
+    if pidfile.exists() {
+        if let Err(e) = std::fs::remove_file(&pidfile) {
+            eprintln!("lifecycle: failed to remove stale pidfile: {e}");
+        }
+    }
+
+    let daemon_pid = crate::fork_daemon(daemon_dir, sock_path);
+
+    match crate::wait_for_sock(sock_path, &pidfile, daemon_pid, Duration::from_secs(10)).await {
+        Ok(()) => {
+            clear_startup_failure(daemon_dir);
+            Ok(())
+        }
+        Err(e) => {
+            record_startup_failure(daemon_dir);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circuit_breaker_noop_when_no_failures() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(check_circuit_breaker(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn circuit_breaker_blocks_after_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_startup_failure(tmp.path());
+        assert!(check_circuit_breaker(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn circuit_breaker_clears_on_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_startup_failure(tmp.path());
+        assert!(check_circuit_breaker(tmp.path()).is_err());
+        clear_startup_failure(tmp.path());
+        assert!(check_circuit_breaker(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn circuit_breaker_increments_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_startup_failure(tmp.path());
+        record_startup_failure(tmp.path());
+        let f = read_startup_failure(tmp.path()).unwrap();
+        assert_eq!(f.consecutive_failures, 2);
+    }
+
+    #[test]
+    fn circuit_breaker_handles_corrupt_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(STARTUP_FAILURE_FILE), b"not json").unwrap();
+        assert!(check_circuit_breaker(tmp.path()).is_ok());
+        assert!(!tmp.path().join(STARTUP_FAILURE_FILE).exists());
+    }
+
+    #[test]
+    fn circuit_breaker_allows_after_cooldown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data = StartupFailure {
+            consecutive_failures: 1,
+            last_failure_epoch: now_epoch() - 300,
+        };
+        let json = serde_json::to_vec(&data).unwrap();
+        std::fs::write(tmp.path().join(STARTUP_FAILURE_FILE), json).unwrap();
+        assert!(check_circuit_breaker(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn is_pidfile_locked_returns_false_for_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!is_pidfile_locked(&tmp.path().join("nonexistent.pid")));
+    }
+
+    #[test]
+    fn is_pidfile_locked_returns_false_for_unlocked_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pidfile = tmp.path().join("daemon.pid");
+        std::fs::write(&pidfile, "12345").unwrap();
+        assert!(!is_pidfile_locked(&pidfile));
+    }
+
+    #[test]
+    fn daemon_lock_guard_releases_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        {
+            let _g = acquire_daemon_lock(tmp.path());
+            // Lock held — a second non-blocking attempt should fail.
+            let fd2 = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(tmp.path().join("daemon.lock"))
+                .unwrap();
+            let rc = unsafe { libc::flock(fd2.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            assert_ne!(rc, 0, "should not acquire while guard held");
+        }
+        // Guard dropped — lock should be available.
+        let fd3 = std::fs::OpenOptions::new()
+            .read(true)
+            .open(tmp.path().join("daemon.lock"))
+            .unwrap();
+        let rc = unsafe { libc::flock(fd3.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        assert_eq!(rc, 0, "should acquire after guard dropped");
+        unsafe { libc::flock(fd3.as_raw_fd(), libc::LOCK_UN) };
+    }
+}

--- a/devinfra/claude/claude_hook/env_file.rs
+++ b/devinfra/claude/claude_hook/env_file.rs
@@ -1,0 +1,108 @@
+//! Write the session env file (`CLAUDE_ENV_FILE`) — the single write point
+//! for all env vars the agent's Bash tool sees.
+//!
+//! Ports `devinfra/claude/env_file.py::write_env_file`. Order matters:
+//! secrets and `env_exports` from the profile are written BEFORE the final
+//! `PATH="<shims_dir>:$PATH"` prepend, so the shims dir always wins even if
+//! the profile or overlay mangled PATH.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+pub fn write_env_file(
+    env_file: &Path,
+    shims_dir: &Path,
+    env_overlay: &HashMap<String, String>,
+    extra_env_script: Option<&str>,
+) {
+    let mut lines: Vec<String> = vec!["# Environment configured by session start hook".to_string()];
+
+    if !env_overlay.is_empty() {
+        lines.push(String::new());
+        lines.push("# Secrets from startup_env_script".to_string());
+        // Sort for determinism in tests + diffs.
+        let mut keys: Vec<&String> = env_overlay.keys().collect();
+        keys.sort();
+        for k in keys {
+            lines.push(format!(
+                "export {k}={}",
+                shlex::try_quote(&env_overlay[k]).unwrap()
+            ));
+        }
+    }
+
+    if let Some(extra) = extra_env_script {
+        let trimmed = extra.trim_end();
+        if !trimmed.is_empty() {
+            lines.push(String::new());
+            lines.push("# Extra env script from profile".to_string());
+            lines.push(trimmed.to_string());
+        }
+    }
+
+    // Session bin dir must be first on PATH regardless of what env_overlay or
+    // extra_env_script did above. Emit this last so it always wins.
+    lines.push(String::new());
+    lines.push(format!("export PATH=\"{}:$PATH\"", shims_dir.display()));
+
+    let content = format!("{}\n", lines.join("\n"));
+
+    if let Some(parent) = env_file.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("env_file: failed to create parent dir: {e}");
+        }
+    }
+
+    // Atomic write via tempfile + persist; set 0o600 since the file
+    // contains decrypted secrets.
+    use std::os::unix::fs::PermissionsExt;
+    let mut tmp =
+        tempfile::NamedTempFile::new_in(env_file.parent().unwrap()).expect("create env tmp");
+    std::io::Write::write_all(&mut tmp, content.as_bytes()).expect("write env tmp");
+    if let Err(e) = tmp
+        .as_file()
+        .set_permissions(std::fs::Permissions::from_mode(0o600))
+    {
+        eprintln!("env_file: failed to set permissions: {e}");
+    }
+    tmp.persist(env_file).expect("persist env file");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_env_file_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env_file = tmp.path().join("env.sh");
+        let shims_dir = tmp.path().join("bin");
+        let mut overlay = HashMap::new();
+        overlay.insert("FOO".to_string(), "bar".to_string());
+        overlay.insert("GITHUB_TOKEN".to_string(), "secret".to_string());
+
+        write_env_file(&env_file, &shims_dir, &overlay, Some("export EXTRA=x\n"));
+
+        let content = std::fs::read_to_string(&env_file).unwrap();
+        assert!(content.contains("export FOO=bar"));
+        assert!(content.contains("export GITHUB_TOKEN=secret"));
+        assert!(content.contains("export EXTRA=x"));
+        // Final PATH export always wins.
+        let last_line = content.lines().last().unwrap();
+        assert_eq!(
+            last_line,
+            &format!("export PATH=\"{}:$PATH\"", shims_dir.display())
+        );
+    }
+
+    #[test]
+    fn write_env_file_no_overlay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env_file = tmp.path().join("env.sh");
+        let shims_dir = tmp.path().join("bin");
+        write_env_file(&env_file, &shims_dir, &HashMap::new(), None);
+
+        let content = std::fs::read_to_string(&env_file).unwrap();
+        assert!(content.contains("export PATH="));
+    }
+}

--- a/devinfra/claude/claude_hook/env_script.rs
+++ b/devinfra/claude/claude_hook/env_script.rs
@@ -1,0 +1,169 @@
+//! Source a shell script and capture the env delta (the "env overlay").
+//!
+//! Runs `bash -c 'source "$1" >&2 && env -0' _ <script>`:
+//! - `source "$1"` with positional arg avoids shell-injection via the script
+//!   path (paths with spaces/metacharacters are fine).
+//! - `>&2` redirects the script's stdout to stderr so it doesn't mix with
+//!   the `env -0` output on stdout.
+//! - `env -0` writes NUL-delimited `KEY=VALUE` records.
+//!
+//! We diff the parsed output against the initial env; the diff (new or
+//! changed vars) is the overlay. No mutation of the daemon's own env.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Default)]
+pub struct StartupResult {
+    pub env_overlay: HashMap<String, String>,
+    pub exit_code: Option<i32>,
+    pub output: String,
+}
+
+/// Parse `env -0` output (NUL-delimited `KEY=VALUE`) into a dict.
+pub fn parse_env_null_delimited(raw: &[u8]) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    for item in raw.split(|&b| b == 0) {
+        if item.is_empty() {
+            continue;
+        }
+        let Some(eq) = item.iter().position(|&b| b == b'=') else {
+            continue;
+        };
+        let key = String::from_utf8_lossy(&item[..eq]).into_owned();
+        let val = String::from_utf8_lossy(&item[eq + 1..]).into_owned();
+        result.insert(key, val);
+    }
+    result
+}
+
+pub fn source_env_script(script_path: &Path, extra_env: &HashMap<String, String>) -> StartupResult {
+    if !script_path.exists() {
+        return StartupResult {
+            exit_code: Some(1),
+            output: format!("startup_env_script not found: {}", script_path.display()),
+            ..Default::default()
+        };
+    }
+
+    // Initial env = daemon's env + extra_env (profile-level flags). The overlay
+    // is what the script ADDED on top of this baseline.
+    let mut initial_env: HashMap<String, String> = std::env::vars().collect();
+    for (k, v) in extra_env {
+        initial_env.insert(k.clone(), v.clone());
+    }
+
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c")
+        .arg(r#"source "$1" >&2 && env -0"#)
+        .arg("_") // $0
+        .arg(script_path)
+        .env_clear();
+    for (k, v) in &initial_env {
+        cmd.env(k, v);
+    }
+
+    let output = match cmd.output() {
+        Ok(o) => o,
+        Err(e) => {
+            return StartupResult {
+                exit_code: Some(1),
+                output: format!("bash invocation failed: {e}"),
+                ..Default::default()
+            };
+        }
+    };
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_code = output.status.code();
+
+    if !output.status.success() {
+        return StartupResult {
+            exit_code,
+            output: stderr,
+            env_overlay: HashMap::new(),
+        };
+    }
+
+    let after = parse_env_null_delimited(&output.stdout);
+    let overlay: HashMap<String, String> = after
+        .into_iter()
+        .filter(|(k, v)| initial_env.get(k) != Some(v))
+        .collect();
+
+    StartupResult {
+        env_overlay: overlay,
+        exit_code,
+        output: stderr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_null_delimited_basic() {
+        let raw = b"FOO=bar\0BAZ=qux\0";
+        let m = parse_env_null_delimited(raw);
+        assert_eq!(m.get("FOO").unwrap(), "bar");
+        assert_eq!(m.get("BAZ").unwrap(), "qux");
+        assert_eq!(m.len(), 2);
+    }
+
+    #[test]
+    fn parse_env_null_delimited_with_newline_in_value() {
+        // Values can contain newlines; only NUL separates records.
+        let raw = b"FOO=line1\nline2\0BAR=x\0";
+        let m = parse_env_null_delimited(raw);
+        assert_eq!(m.get("FOO").unwrap(), "line1\nline2");
+        assert_eq!(m.get("BAR").unwrap(), "x");
+    }
+
+    #[test]
+    fn parse_env_null_delimited_with_equals_in_value() {
+        let raw = b"FOO=a=b=c\0";
+        let m = parse_env_null_delimited(raw);
+        assert_eq!(m.get("FOO").unwrap(), "a=b=c");
+    }
+
+    #[test]
+    fn source_script_missing_file() {
+        let r = source_env_script(Path::new("/tmp/does-not-exist-xyz"), &HashMap::new());
+        assert_eq!(r.exit_code, Some(1));
+        assert!(r.env_overlay.is_empty());
+    }
+
+    #[test]
+    fn source_script_captures_overlay() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "export MY_OVERLAY_VAR=hello").unwrap();
+        writeln!(tmp, "export PATH=\"/overridden:$PATH\"").unwrap();
+        tmp.flush().unwrap();
+
+        let r = source_env_script(tmp.path(), &HashMap::new());
+        assert_eq!(r.exit_code, Some(0));
+        assert_eq!(r.env_overlay.get("MY_OVERLAY_VAR").unwrap(), "hello");
+        // PATH was modified → should be in overlay.
+        assert!(r.env_overlay.contains_key("PATH"));
+    }
+
+    #[test]
+    fn extra_env_not_in_overlay() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        // Script doesn't touch FROM_PROFILE; it comes from extra_env so should
+        // NOT appear in the overlay.
+        writeln!(tmp, "export ADDED_BY_SCRIPT=yes").unwrap();
+        tmp.flush().unwrap();
+
+        let mut extra = HashMap::new();
+        extra.insert("FROM_PROFILE".to_string(), "1".to_string());
+        let r = source_env_script(tmp.path(), &extra);
+        assert_eq!(r.exit_code, Some(0));
+        assert!(r.env_overlay.contains_key("ADDED_BY_SCRIPT"));
+        assert!(!r.env_overlay.contains_key("FROM_PROFILE"));
+    }
+}

--- a/devinfra/claude/claude_hook/git_shim.rs
+++ b/devinfra/claude/claude_hook/git_shim.rs
@@ -1,0 +1,185 @@
+//! Git shim block logic — ports `server.py::_handle_git_shim`.
+//!
+//! Given the original argv and the git shim config, decide whether to
+//! pass through (`Ok(argv)`) or block (`Err(message)`). Callers propagate
+//! `Err` into a `ShimResponse::Blocked`.
+
+use claude_hook_config::GitShimConfig;
+
+const GIT_GLOBAL_VALUE_OPTIONS: &[&str] = &[
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+];
+
+/// Parse git global options to find the subcommand and its args.
+/// Returns (subcommand, sub_args).
+fn extract_subcommand(args: &[String]) -> (Option<&str>, &[String]) {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg.starts_with("--") && arg.contains('=') {
+            let key = arg.split_once('=').unwrap().0;
+            if GIT_GLOBAL_VALUE_OPTIONS.contains(&key) {
+                i += 1;
+                continue;
+            }
+        }
+        if GIT_GLOBAL_VALUE_OPTIONS.contains(&arg.as_str()) {
+            i += 2;
+            continue;
+        }
+        if arg.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        return (Some(arg.as_str()), &args[i + 1..]);
+    }
+    (None, &[])
+}
+
+/// Evaluate the git shim policy. `argv` is the full invocation (argv[0] =
+/// "git"); sub-args are everything after the subcommand name.
+pub fn evaluate(argv: &[String], cfg: &GitShimConfig) -> Result<(), String> {
+    if argv.len() < 2 {
+        return Ok(());
+    }
+    let (subcommand, sub_args) = extract_subcommand(&argv[1..]);
+    let Some(sub) = subcommand else { return Ok(()) };
+
+    if cfg.block_add_all && sub == "add" {
+        let blocked = if sub_args.iter().any(|a| a == "--all") {
+            Some("git add --all")
+        } else if sub_args.iter().any(|a| a == "-A") {
+            Some("git add -A")
+        } else if let Some(arg) = sub_args
+            .iter()
+            .find(|a| a.starts_with('-') && !a.starts_with("--") && a.contains('A'))
+        {
+            return Err(format!(
+                "git add {arg} (contains -A)\n  Use 'git add <specific-files>' instead of staging everything."
+            ));
+        } else if sub_args.iter().any(|a| a == ".") {
+            Some("git add .")
+        } else {
+            None
+        };
+        if let Some(cmd) = blocked {
+            return Err(format!(
+                "{cmd}\n  Use 'git add <specific-files>' instead of staging everything."
+            ));
+        }
+    }
+
+    if cfg.block_stash && sub == "stash" {
+        let first_positional = sub_args.iter().find(|a| !a.starts_with('-'));
+        match first_positional.map(|s| s.as_str()) {
+            Some("list") | Some("show") => {}
+            _ => {
+                return Err(
+                    "git stash\n  Do not use git stash. Find other approaches for dirty worktrees."
+                        .into(),
+                );
+            }
+        }
+    }
+
+    if cfg.block_amend && sub == "commit" && sub_args.iter().any(|a| a == "--amend") {
+        return Err("git commit --amend\n  Create a new commit instead of amending.".into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn block_add_all() -> GitShimConfig {
+        GitShimConfig {
+            block_add_all: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn add_file_passes() {
+        assert!(evaluate(&argv(&["git", "add", "foo.txt"]), &block_add_all()).is_ok());
+    }
+
+    #[test]
+    fn add_dash_a_blocks() {
+        let e = evaluate(&argv(&["git", "add", "-A"]), &block_add_all()).unwrap_err();
+        assert!(e.contains("git add -A"));
+    }
+
+    #[test]
+    fn add_dashall_blocks() {
+        let e = evaluate(&argv(&["git", "add", "--all"]), &block_add_all()).unwrap_err();
+        assert!(e.contains("git add --all"));
+    }
+
+    #[test]
+    fn add_dot_blocks() {
+        let e = evaluate(&argv(&["git", "add", "."]), &block_add_all()).unwrap_err();
+        assert!(e.contains("git add ."));
+    }
+
+    #[test]
+    fn add_combined_short_flag_with_a_blocks() {
+        let e = evaluate(&argv(&["git", "add", "-Av"]), &block_add_all()).unwrap_err();
+        assert!(e.contains("-Av"));
+    }
+
+    #[test]
+    fn global_options_skipped() {
+        // -C <dir> consumes the next arg as a value; parser should still find "add".
+        let e = evaluate(&argv(&["git", "-C", "/tmp", "add", "-A"]), &block_add_all()).unwrap_err();
+        assert!(e.contains("git add -A"));
+    }
+
+    #[test]
+    fn stash_list_allowed() {
+        let cfg = GitShimConfig {
+            block_stash: true,
+            ..Default::default()
+        };
+        assert!(evaluate(&argv(&["git", "stash", "list"]), &cfg).is_ok());
+        assert!(evaluate(&argv(&["git", "stash", "show"]), &cfg).is_ok());
+    }
+
+    #[test]
+    fn stash_push_blocked() {
+        let cfg = GitShimConfig {
+            block_stash: true,
+            ..Default::default()
+        };
+        assert!(evaluate(&argv(&["git", "stash"]), &cfg).is_err());
+        assert!(evaluate(&argv(&["git", "stash", "push"]), &cfg).is_err());
+    }
+
+    #[test]
+    fn commit_amend_blocked() {
+        let cfg = GitShimConfig {
+            block_amend: true,
+            ..Default::default()
+        };
+        assert!(evaluate(&argv(&["git", "commit", "--amend"]), &cfg).is_err());
+        assert!(evaluate(&argv(&["git", "commit", "-m", "x"]), &cfg).is_ok());
+    }
+
+    #[test]
+    fn disabled_config_allows_everything() {
+        let cfg = GitShimConfig::default();
+        assert!(evaluate(&argv(&["git", "add", "-A"]), &cfg).is_ok());
+        assert!(evaluate(&argv(&["git", "stash"]), &cfg).is_ok());
+        assert!(evaluate(&argv(&["git", "commit", "--amend"]), &cfg).is_ok());
+    }
+}

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -1,0 +1,806 @@
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use std::os::unix::io::AsRawFd;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use clap::{Parser, Subcommand};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper_util::rt::TokioIo;
+use protocol::{
+    AnyHookInput, AnyHookSpecificOutput, HookOutput, HookRequest, HookResponse,
+    SessionStartSpecificOutput, ShimExecRequest, ShimResponse,
+};
+use serde::Deserialize;
+use tokio::net::{UnixListener, UnixStream};
+
+use claude_hook_config::ProfileConfig;
+use claude_hook_env_file::write_env_file;
+use claude_hook_env_script::{StartupResult, source_env_script};
+use claude_hook_shim_install::install_all_shims;
+
+mod bg_command;
+mod daemon_lifecycle;
+mod git_shim;
+mod session;
+mod shim_runtime;
+
+use session::{Session, format_system_message};
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(Parser)]
+#[command(name = "claude-hook", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// PATH shim runtime: report to daemon, resolve real binary, exec.
+    Shim {
+        name: String,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Internal: run as daemon server (started by self-fork).
+    #[command(hide = true)]
+    Daemon {
+        #[arg(long)]
+        sock: PathBuf,
+        #[arg(long)]
+        daemon_dir: PathBuf,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Session paths (mirrors devinfra/claude/session_paths.py)
+// ---------------------------------------------------------------------------
+
+fn short_session_dir(session_id: &str) -> PathBuf {
+    PathBuf::from("/tmp/claude-hd").join(session_id)
+}
+
+pub(crate) fn daemon_sock_path(session_id: &str) -> PathBuf {
+    short_session_dir(session_id).join("d.sock")
+}
+
+fn daemon_dir_path(session_id: &str) -> PathBuf {
+    short_session_dir(session_id)
+}
+
+fn session_id_from_env() -> Option<String> {
+    let env_file = std::env::var("CLAUDE_ENV_FILE").ok()?;
+    let p = Path::new(&env_file);
+    // CLAUDE_ENV_FILE = ~/.claude/session-env/<session_id>/sessionstart-hook-0.sh
+    p.parent()?.file_name()?.to_str().map(String::from)
+}
+
+pub(crate) fn home_session_dir(session_id: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    PathBuf::from(home)
+        .join(".claude")
+        .join("session-env")
+        .join(session_id)
+}
+
+// ---------------------------------------------------------------------------
+// Daemon state
+// ---------------------------------------------------------------------------
+
+struct AppState {
+    last_request: AtomicU64,
+    profile: ProfileConfig,
+    startup: StartupResult,
+    project_dir: PathBuf,
+    sock_path: PathBuf,
+    sessions: RwLock<HashMap<String, Arc<Session>>>,
+}
+
+impl AppState {
+    fn touch(&self) {
+        self.last_request.store(Self::now(), Ordering::Relaxed);
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn get_or_create_session(&self, session_id: &str) -> Arc<Session> {
+        {
+            let g = self.sessions.read().unwrap();
+            if let Some(s) = g.get(session_id) {
+                return s.clone();
+            }
+        }
+        let mut g = self.sessions.write().unwrap();
+        g.entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(Session::new(session_id.to_string())))
+            .clone()
+    }
+}
+
+// Non-REPL hook events: Claude Code delivers system_message only to the UI
+// notification callback on these, not into the model conversation. Flushing
+// mailbox here would waste the messages. Matches `_NON_REPL_HOOK_TYPES` in
+// `server.py`.
+fn is_repl_hook(hook: &AnyHookInput) -> bool {
+    !matches!(
+        hook,
+        AnyHookInput::SessionStart(_) | AnyHookInput::WorktreeCreate(_) | AnyHookInput::Unknown
+    )
+    // Python's list also includes SessionEnd/Setup/CwdChanged/etc., which we
+    // deserialize as Unknown (our enum only names the 4 we care about).
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+fn write_session_bazelrc(
+    bazelrc: &Path,
+    bbr_bazelrc: &Path,
+    env_overlay: &HashMap<String, String>,
+) {
+    let mut lines = vec![
+        "# Per-session Bazel configuration (auto-generated by claude-hook daemon)".to_string(),
+    ];
+
+    // JVM truststore: Debian's /etc/ssl/certs/java/cacerts contains the
+    // system CAs (including Anthropic's TLS inspection CA on web containers).
+    let system_cacerts = Path::new("/etc/ssl/certs/java/cacerts");
+    if system_cacerts.exists() {
+        lines.push(format!(
+            "startup --host_jvm_args=-Djavax.net.ssl.trustStore={}",
+            shlex::try_quote(&system_cacerts.display().to_string()).unwrap()
+        ));
+        lines.push("startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit".into());
+    }
+
+    lines.push(String::new());
+    lines.push("test --test_tag_filters=-live_openai_api".into());
+
+    // BuildBuddy remote cache (API key written by startup_env_script).
+    if env_overlay.contains_key("BUILDBUDDY_API_KEY") {
+        let bb_bazelrc = Path::new("/root/.config/bazel/buildbuddy.bazelrc");
+        if bb_bazelrc.exists() {
+            lines.push(String::new());
+            lines.push(format!("try-import {}", bb_bazelrc.display()));
+        }
+    }
+
+    lines.push(format!("try-import {}", bbr_bazelrc.display()));
+    lines.push(String::new());
+    lines.push("common --config=ai_agent".into());
+
+    let content = format!("{}\n", lines.join("\n"));
+    if let Err(e) = std::fs::write(bazelrc, content) {
+        eprintln!("SessionStart: failed to write bazelrc: {e}");
+    }
+}
+
+fn render_context_banner(state: &AppState, session_id: &str, daemon_log: &Path) -> String {
+    let startup = &state.startup;
+    let profile = &state.profile;
+    let mut lines: Vec<String> = Vec::new();
+
+    lines.push("# Claude Code session start hook — OK".into());
+    lines.push(String::new());
+    lines.push("**Environment:** CLI (local)".into());
+
+    if startup.exit_code.is_some() {
+        let n = startup.env_overlay.len();
+        let mut var_summary = format!("yielded {n} vars");
+        if !startup.env_overlay.is_empty() {
+            let mut keys: Vec<&str> = startup.env_overlay.keys().map(|s| s.as_str()).collect();
+            keys.sort();
+            var_summary += &format!(": {}", keys.join(", "));
+        }
+        let status = if startup.exit_code == Some(0) {
+            "succeeded"
+        } else {
+            "FAILED"
+        };
+        lines.push(format!(
+            "**startup_env_script** `{}` {status} — {var_summary}",
+            profile.startup_env_script.as_deref().unwrap_or("(none)")
+        ));
+        let trimmed = startup.output.trim();
+        if !trimmed.is_empty() {
+            lines.push("```".into());
+            lines.push(trimmed.into());
+            lines.push("```".into());
+        }
+    }
+
+    if !profile.background_commands.is_empty() {
+        lines.push(String::new());
+        lines.push("## Background tasks".into());
+        for cmd in &profile.background_commands {
+            let suffix = if cmd.after_env { " (after env)" } else { "" };
+            lines.push(format!("- {}{suffix}", cmd.name));
+        }
+    }
+
+    let bb_key = startup.env_overlay.contains_key("BUILDBUDDY_API_KEY");
+    if bb_key {
+        lines.push(String::new());
+        lines.push("## BuildBuddy".into());
+        lines.push("Bazel builds and tests by default execute remotely via BuildBuddy.".into());
+        lines.push(
+            "Use BuildBuddy API (key in `~/.config/bazel/buildbuddy.bazelrc`) to download undeclared test outputs, profiles, search invocations.".into()
+        );
+        if !session_id.is_empty() && session_id != "unknown" {
+            lines.push(format!(
+                "Your `bbr` invocations are tagged `session:{session_id}`. To list your builds:"
+            ));
+            lines.push(format!(
+                "`bbapi invocation list --tag session:{session_id}`"
+            ));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(format!("Session start log: `{}`", daemon_log.display()));
+
+    lines.join("\n")
+}
+
+fn handle_session_start(
+    state: &AppState,
+    session: &Arc<Session>,
+    session_env_file: &Path,
+    caller_session_id: &str,
+) -> HookOutput {
+    let session_dir = home_session_dir(&session.session_id);
+    let shims_dir = session_dir.join("bin");
+
+    if let Err(e) = install_all_shims(&shims_dir, &session.session_id) {
+        eprintln!("SessionStart: install_all_shims failed: {e}");
+    }
+
+    write_env_file(
+        session_env_file,
+        &shims_dir,
+        &state.startup.env_overlay,
+        state.profile.env_exports.as_deref(),
+    );
+
+    // Write bbr bazelrc (metadata tags for BuildBuddy invocation filtering).
+    let bbr_bazelrc = session_dir.join("bbr.bazelrc");
+    let bbr_content = format!(
+        "# Auto-generated by session start hook\n\
+         build --build_metadata=ROLE=claude-code\n\
+         build --build_metadata=TAGS=session:{caller_session_id}\n"
+    );
+    if let Err(e) = std::fs::write(&bbr_bazelrc, &bbr_content) {
+        eprintln!("SessionStart: failed to write bbr bazelrc: {e}");
+    }
+
+    // Write session bazelrc (injected via --bazelrc by the bazel/bazelisk shim).
+    let session_bazelrc = session_dir.join("bazelrc");
+    write_session_bazelrc(&session_bazelrc, &bbr_bazelrc, &state.startup.env_overlay);
+
+    // Launch background commands. `after_env: false` runs immediately (no
+    // env file sourced); `after_env: true` sources the session env file.
+    for cmd in &state.profile.background_commands {
+        let env_file_for_bg = cmd.after_env.then(|| session_env_file.to_path_buf());
+        bg_command::launch(
+            session.clone(),
+            cmd.clone(),
+            state.sock_path.clone(),
+            env_file_for_bg,
+            state.project_dir.clone(),
+            state.startup.env_overlay.clone(),
+        );
+    }
+
+    let daemon_log = state.sock_path.parent().unwrap().join("daemon.err.log");
+    let banner = render_context_banner(state, caller_session_id, &daemon_log);
+
+    HookOutput {
+        hook_specific_output: Some(AnyHookSpecificOutput::SessionStart(
+            SessionStartSpecificOutput {
+                additional_context: Some(banner),
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    }
+}
+
+async fn handle_hook(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<HookRequest>,
+) -> Json<HookResponse> {
+    state.touch();
+
+    let session_env_file = req.env.get("CLAUDE_ENV_FILE").map(PathBuf::from);
+    let session_id = hook_session_id(&req.hook);
+
+    let session = session_id
+        .as_deref()
+        .map(|id| state.get_or_create_session(id));
+
+    let mut output = match (&req.hook, session.as_ref()) {
+        (AnyHookInput::SessionStart(_), Some(s)) => {
+            if let Some(env_file) = session_env_file {
+                let caller_sid = req
+                    .env
+                    .get("CLAUDE_CODE_SESSION_ID")
+                    .map(|s| s.as_str())
+                    .unwrap_or("unknown");
+                Some(handle_session_start(&state, s, &env_file, caller_sid))
+            } else {
+                eprintln!("SessionStart: CLAUDE_ENV_FILE not in request env");
+                Some(HookOutput::default())
+            }
+        }
+        _ => None,
+    };
+
+    // Drain mailbox into output.system_message for REPL hooks.
+    if is_repl_hook(&req.hook) {
+        if let Some(s) = session {
+            let mailbox = s.drain_messages();
+            let bg = s.drain_bg_output();
+            if let Some(msg) = format_system_message(mailbox, bg) {
+                let out = output.get_or_insert_with(HookOutput::default);
+                out.system_message = Some(match out.system_message.take() {
+                    Some(existing) if !existing.is_empty() => format!("{existing}\n\n{msg}"),
+                    _ => msg,
+                });
+            }
+        }
+    }
+
+    Json(HookResponse { output })
+}
+
+fn hook_session_id(hook: &AnyHookInput) -> Option<String> {
+    match hook {
+        AnyHookInput::SessionStart(h) => Some(h.base.session_id.clone()),
+        AnyHookInput::PreToolUse(h) => Some(h.base.session_id.clone()),
+        AnyHookInput::PostToolUse(h) => Some(h.base.session_id.clone()),
+        AnyHookInput::WorktreeCreate(h) => Some(h.base.session_id.clone()),
+        AnyHookInput::Unknown => None,
+    }
+}
+
+fn resolve_binary_from_env(
+    binary: &str,
+    shim_dir: &Path,
+    env: &HashMap<String, String>,
+) -> Option<PathBuf> {
+    let path = env.get("PATH")?;
+    let shim_canon = shim_dir.canonicalize().ok();
+    for dir in path.split(':') {
+        if dir.is_empty() {
+            continue;
+        }
+        let dir_path = Path::new(dir);
+        if let (Some(a), Ok(b)) = (shim_canon.as_ref(), dir_path.canonicalize()) {
+            if a == &b {
+                continue;
+            }
+        }
+        let candidate = dir_path.join(binary);
+        if candidate.is_file() {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(m) = std::fs::metadata(&candidate) {
+                if m.permissions().mode() & 0o111 != 0 {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn handle_shim_exec(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ShimExecRequest>,
+) -> Json<ShimResponse> {
+    state.touch();
+    let _session = state.get_or_create_session(&req.session_id);
+    let session_dir = home_session_dir(&req.session_id);
+    let shim_dir = session_dir.join("bin");
+    let bazelrc_path = session_dir.join("bazelrc");
+
+    let resp = match req.shim.as_str() {
+        "git" => match git_shim::evaluate(&req.argv, &state.profile.git_shim) {
+            Ok(()) => resolve_execve(&req.shim, req.argv, &shim_dir, &req.env),
+            Err(message) => ShimResponse::Blocked { message },
+        },
+        "bazelisk" | "bazel" => {
+            let mut argv = req.argv;
+            if bazelrc_path.exists() {
+                argv.insert(1, format!("--bazelrc={}", bazelrc_path.display()));
+            }
+            resolve_execve(&req.shim, argv, &shim_dir, &req.env)
+        }
+        _ => resolve_execve(&req.shim, req.argv, &shim_dir, &req.env),
+    };
+    Json(resp)
+}
+
+fn resolve_execve(
+    shim: &str,
+    mut argv: Vec<String>,
+    shim_dir: &Path,
+    env: &HashMap<String, String>,
+) -> ShimResponse {
+    match resolve_binary_from_env(shim, shim_dir, env) {
+        Some(real) => {
+            argv[0] = real.to_string_lossy().into_owned();
+            ShimResponse::Execve { argv }
+        }
+        None => ShimResponse::Blocked {
+            message: format!("{shim}: command not found (not on PATH outside shim directory)"),
+        },
+    }
+}
+
+async fn handle_health() -> &'static str {
+    r#"{"status":"ok"}"#
+}
+
+#[derive(Deserialize)]
+struct MailboxRequest {
+    message: String,
+}
+
+async fn handle_mailbox(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<MailboxRequest>,
+) -> &'static str {
+    state.touch();
+    // Post to every registered session's mailbox (matches server.py).
+    let g = state.sessions.read().unwrap();
+    for s in g.values() {
+        s.post_message(req.message.clone());
+    }
+    r#"{"status":"ok"}"#
+}
+
+// ---------------------------------------------------------------------------
+// Daemon entry point
+// ---------------------------------------------------------------------------
+
+async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf) {
+    let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+        .map(PathBuf::from)
+        .expect("CLAUDE_PROJECT_DIR must be set");
+
+    let profile_rel = std::env::var("DUCKTAPE_CLAUDE_HOOKS_PROFILE")
+        .expect("DUCKTAPE_CLAUDE_HOOKS_PROFILE must be set");
+    let profile_path = project_dir.join(&profile_rel);
+    let profile = ProfileConfig::load(&profile_path).unwrap_or_else(|e| {
+        eprintln!("failed to load profile {}: {e}", profile_path.display());
+        std::process::exit(1);
+    });
+
+    let startup = if let Some(script_rel) = &profile.startup_env_script {
+        let script_path = project_dir.join(script_rel);
+        eprintln!(
+            "daemon: sourcing startup_env_script {}",
+            script_path.display()
+        );
+        let r = source_env_script(&script_path, &HashMap::new());
+        if let Some(code) = r.exit_code {
+            if code != 0 {
+                eprintln!("startup_env_script exited {code}: {}", r.output);
+            } else if !r.output.is_empty() {
+                eprintln!("startup_env_script output:\n{}", r.output);
+            }
+        }
+        eprintln!(
+            "daemon: env overlay captured ({} vars: {:?})",
+            r.env_overlay.len(),
+            r.env_overlay.keys().collect::<Vec<_>>()
+        );
+        r
+    } else {
+        StartupResult::default()
+    };
+
+    let state = Arc::new(AppState {
+        last_request: AtomicU64::new(AppState::now()),
+        profile,
+        startup,
+        project_dir,
+        sock_path: sock.clone(),
+        sessions: RwLock::new(HashMap::new()),
+    });
+
+    let app = Router::new()
+        .route("/hook", post(handle_hook))
+        .route("/shim-exec", post(handle_shim_exec))
+        .route("/health", get(handle_health))
+        .route("/mailbox", post(handle_mailbox))
+        .with_state(state.clone());
+
+    // Write pidfile and acquire exclusive flock (held for daemon lifetime).
+    // Kernel releases the flock on process death, making client-side
+    // is_pidfile_locked() probes authoritative for liveness detection.
+    let pidfile = daemon_dir.join("daemon.pid");
+    std::fs::write(&pidfile, std::process::id().to_string()).unwrap();
+    let pidfile_fd = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&pidfile)
+        .expect("reopen pidfile for flock");
+    unsafe { libc::flock(pidfile_fd.as_raw_fd(), libc::LOCK_EX) };
+    // pidfile_fd must outlive the server — keep it alive here.
+
+    eprintln!(
+        "claude-hook daemon pid={} sock={}",
+        std::process::id(),
+        sock.display()
+    );
+    let listener = UnixListener::bind(&sock).expect("failed to bind UDS");
+
+    // Idle watchdog: SIGTERM after 30min of no requests.
+    if state.profile.idle_watchdog {
+        let wstate = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                let idle = AppState::now() - wstate.last_request.load(Ordering::Relaxed);
+                if idle >= 1800 {
+                    eprintln!("Idle timeout reached ({idle}s), shutting down");
+                    unsafe { libc::raise(libc::SIGTERM) };
+                    return;
+                }
+            }
+        });
+    }
+
+    axum::serve(listener, app).await.unwrap();
+    drop(pidfile_fd); // explicit: flock released here (or on process death)
+}
+
+// ---------------------------------------------------------------------------
+// Client: double-fork + UDS request
+// ---------------------------------------------------------------------------
+
+pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> i32 {
+    let log_out = daemon_dir.join("daemon.log");
+    let log_err = daemon_dir.join("daemon.err.log");
+
+    let self_exe = std::env::current_exe().expect("cannot determine own exe path");
+
+    let mut pipe_fds = [0i32; 2];
+    unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
+    let (read_fd, write_fd) = (pipe_fds[0], pipe_fds[1]);
+
+    let pid = unsafe { libc::fork() };
+    if pid > 0 {
+        unsafe { libc::close(write_fd) };
+        unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+        let mut buf = [0u8; 32];
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+        unsafe { libc::close(read_fd) };
+        if n <= 0 {
+            eprintln!("claude-hook: daemon startup pipe returned no data");
+            return -1;
+        }
+        let s = std::str::from_utf8(&buf[..n as usize]).unwrap_or("").trim();
+        return s.parse().unwrap_or(-1);
+    }
+
+    unsafe { libc::close(read_fd) };
+    unsafe { libc::setsid() };
+    let pid2 = unsafe { libc::fork() };
+    if pid2 > 0 {
+        let msg = pid2.to_string();
+        unsafe { libc::write(write_fd, msg.as_ptr() as *const _, msg.len()) };
+        unsafe { libc::close(write_fd) };
+        std::process::exit(0);
+    }
+
+    unsafe { libc::close(write_fd) };
+
+    let fd_out = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_out)
+        .expect("open daemon.log");
+    let fd_err = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_err)
+        .expect("open daemon.err.log");
+    unsafe {
+        libc::dup2(std::os::unix::io::AsRawFd::as_raw_fd(&fd_out), 1);
+        libc::dup2(std::os::unix::io::AsRawFd::as_raw_fd(&fd_err), 2);
+    }
+    drop(fd_out);
+    drop(fd_err);
+
+    let err = std::process::Command::new(&self_exe)
+        .args([
+            "daemon",
+            "--sock",
+            sock_path.to_str().unwrap(),
+            "--daemon-dir",
+            daemon_dir.to_str().unwrap(),
+        ])
+        .exec();
+    panic!("exec failed: {err}");
+}
+
+pub(crate) async fn wait_for_sock(
+    sock_path: &Path,
+    pidfile: &Path,
+    daemon_pid: i32,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if sock_path.exists() && UnixStream::connect(sock_path).await.is_ok() {
+            return Ok(());
+        }
+        // Post-pidfile crash detection: daemon wrote pidfile then died.
+        if pidfile.exists() && !daemon_lifecycle::is_pidfile_locked(pidfile) {
+            return Err("Daemon died during startup (pidfile unlocked)".into());
+        }
+        // Pre-pidfile crash detection: daemon died before writing pidfile.
+        let rc = unsafe { libc::kill(daemon_pid, 0) };
+        if rc != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            return Err("Daemon process died during startup (pre-pidfile)".into());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let note = if sock_path.exists() {
+        "socket appeared but connect never succeeded"
+    } else {
+        "socket never appeared"
+    };
+    Err(format!(
+        "Daemon did not become reachable within {}s ({note})",
+        timeout.as_secs()
+    ))
+}
+
+pub(crate) async fn post_json_over_uds(
+    sock_path: &Path,
+    path: &str,
+    body: Vec<u8>,
+) -> Result<Bytes, String> {
+    tokio::time::timeout(
+        Duration::from_secs(300),
+        post_json_over_uds_inner(sock_path, path, body),
+    )
+    .await
+    .map_err(|_| "daemon request timed out (300s)".to_string())?
+}
+
+async fn post_json_over_uds_inner(
+    sock_path: &Path,
+    path: &str,
+    body: Vec<u8>,
+) -> Result<Bytes, String> {
+    let stream = UnixStream::connect(sock_path)
+        .await
+        .map_err(|e| format!("connect: {e}"))?;
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
+        .await
+        .map_err(|e| format!("http1 handshake: {e}"))?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("uds connection driver: {e}");
+        }
+    });
+
+    let req = hyper::Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(body)))
+        .map_err(|e| format!("build request: {e}"))?;
+
+    let resp = sender
+        .send_request(req)
+        .await
+        .map_err(|e| format!("send request: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("daemon returned HTTP {}", resp.status()));
+    }
+
+    resp.collect()
+        .await
+        .map_err(|e| format!("read body: {e}"))
+        .map(|c| c.to_bytes())
+}
+
+async fn dispatch_hook() {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap();
+
+    let hook: AnyHookInput = match serde_json::from_str(&input) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("claude-hook: failed to parse hook input: {e}");
+            std::process::exit(1);
+        }
+    };
+    let env: HashMap<String, String> = std::env::vars().collect();
+    let req = HookRequest { hook, env };
+
+    let session_id = match session_id_from_env() {
+        Some(id) => id,
+        None => {
+            eprintln!("claude-hook: cannot determine session_id (CLAUDE_ENV_FILE not set)");
+            print!("{{}}");
+            return;
+        }
+    };
+
+    let sock_path = daemon_sock_path(&session_id);
+    let daemon_dir = daemon_dir_path(&session_id);
+
+    if let Err(e) = daemon_lifecycle::ensure_daemon(&sock_path, &daemon_dir).await {
+        eprintln!("claude-hook: {e}");
+        print!("{{}}");
+        return;
+    }
+
+    let body = serde_json::to_vec(&req).unwrap();
+    match post_json_over_uds(&sock_path, "/hook", body).await {
+        Ok(resp_body) => {
+            // The daemon returns a HookResponse envelope; Claude Code expects
+            // just the HookOutput on stdout (no wrapper).
+            match serde_json::from_slice::<HookResponse>(&resp_body) {
+                Ok(resp) => {
+                    if let Some(output) = resp.output {
+                        let out = serde_json::to_vec(&output).unwrap();
+                        io::stdout().write_all(&out).unwrap();
+                    }
+                }
+                Err(e) => {
+                    eprintln!("claude-hook: failed to parse daemon response: {e}");
+                    io::stdout().write_all(&resp_body).unwrap();
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("claude-hook: daemon request failed: {e}");
+            print!("{{}}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Some(Command::Shim { name, args }) => shim_runtime::run_shim(name, args).await,
+        Some(Command::Daemon { sock, daemon_dir }) => {
+            run_daemon(sock, daemon_dir).await;
+        }
+        None => dispatch_hook().await,
+    }
+}

--- a/devinfra/claude/claude_hook/protocol.rs
+++ b/devinfra/claude/claude_hook/protocol.rs
@@ -1,0 +1,312 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Hook request / response envelope (daemon's /hook HTTP endpoint)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HookRequest {
+    pub hook: AnyHookInput,
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<HookOutput>,
+}
+
+// ---------------------------------------------------------------------------
+// Hook inputs — discriminated union on `hook_event_name` (PascalCase values)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "hook_event_name")]
+pub enum AnyHookInput {
+    SessionStart(SessionStartInput),
+    PreToolUse(PreToolUseInput),
+    PostToolUse(PostToolUseInput),
+    WorktreeCreate(WorktreeCreateInput),
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HookInputBase {
+    pub session_id: String,
+    pub transcript_path: PathBuf,
+    pub cwd: PathBuf,
+    pub permission_mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SessionStartInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub source: String, // "startup" | "resume" | "clear" | "compact"
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PreToolUseInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_use_id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PostToolUseInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_use_id: String,
+    pub tool_response: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WorktreeCreateInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+}
+
+// ---------------------------------------------------------------------------
+// Hook output (camelCase, skip None fields)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HookOutput {
+    #[serde(rename = "continue", skip_serializing_if = "Option::is_none")]
+    pub continue_: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suppress_output: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hook_specific_output: Option<AnyHookSpecificOutput>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "hookEventName")]
+pub enum AnyHookSpecificOutput {
+    SessionStart(SessionStartSpecificOutput),
+    PreToolUse(PreToolUseSpecificOutput),
+    PostToolUse(PostToolUseSpecificOutput),
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStartSpecificOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_user_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch_paths: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PreToolUseSpecificOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_decision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_decision_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PostToolUseSpecificOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Shim exec RPC (/shim-exec endpoint) — snake_case on the wire
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ShimExecRequest {
+    pub shim: String,
+    pub session_id: String,
+    pub cwd: PathBuf,
+    pub argv: Vec<String>,
+    pub pid: u32,
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum ShimResponse {
+    #[serde(rename = "blocked")]
+    Blocked { message: String },
+    #[serde(rename = "execve")]
+    Execve { argv: Vec<String> },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_session_start_input() {
+        let json = r#"{
+            "hook_event_name": "SessionStart",
+            "session_id": "test-123",
+            "transcript_path": "/tmp/transcript.json",
+            "cwd": "/project",
+            "permission_mode": "default",
+            "source": "startup",
+            "model": "claude-sonnet-4-6"
+        }"#;
+        let input: AnyHookInput = serde_json::from_str(json).unwrap();
+        match input {
+            AnyHookInput::SessionStart(s) => {
+                assert_eq!(s.base.session_id, "test-123");
+                assert_eq!(s.source, "startup");
+                assert_eq!(s.model.as_deref(), Some("claude-sonnet-4-6"));
+            }
+            _ => panic!("expected SessionStart"),
+        }
+    }
+
+    #[test]
+    fn deserialize_pre_tool_use_input() {
+        let json = r#"{
+            "hook_event_name": "PreToolUse",
+            "session_id": "test-456",
+            "transcript_path": "/tmp/t.json",
+            "cwd": "/project",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "tool_001"
+        }"#;
+        let input: AnyHookInput = serde_json::from_str(json).unwrap();
+        match input {
+            AnyHookInput::PreToolUse(p) => {
+                assert_eq!(p.tool_name, "Bash");
+                assert_eq!(p.tool_use_id, "tool_001");
+            }
+            _ => panic!("expected PreToolUse"),
+        }
+    }
+
+    #[test]
+    fn unknown_hook_deserializes() {
+        let json = r#"{
+            "hook_event_name": "SomeNewHook",
+            "session_id": "x",
+            "transcript_path": "/tmp/t.json",
+            "cwd": "/"
+        }"#;
+        let input: AnyHookInput = serde_json::from_str(json).unwrap();
+        assert!(matches!(input, AnyHookInput::Unknown));
+    }
+
+    #[test]
+    fn serialize_hook_output_omits_none() {
+        let output = HookOutput::default();
+        let json = serde_json::to_string(&output).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn serialize_hook_output_with_session_start() {
+        let output = HookOutput {
+            hook_specific_output: Some(AnyHookSpecificOutput::SessionStart(
+                SessionStartSpecificOutput {
+                    additional_context: Some("hello".into()),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "SessionStart");
+        assert_eq!(v["hookSpecificOutput"]["additionalContext"], "hello");
+        // None fields must not appear
+        assert!(v.get("continue").is_none());
+        assert!(v.get("decision").is_none());
+    }
+
+    #[test]
+    fn serialize_hook_response_empty() {
+        let resp = HookResponse { output: None };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn serialize_shim_response_blocked() {
+        let resp = ShimResponse::Blocked {
+            message: "nope".into(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["kind"], "blocked");
+        assert_eq!(v["message"], "nope");
+    }
+
+    #[test]
+    fn serialize_shim_response_execve() {
+        let resp = ShimResponse::Execve {
+            argv: vec!["git".into(), "status".into()],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["kind"], "execve");
+        assert_eq!(v["argv"], serde_json::json!(["git", "status"]));
+    }
+
+    #[test]
+    fn deserialize_shim_exec_request() {
+        let json = r#"{
+            "shim": "bazelisk",
+            "session_id": "test-789",
+            "cwd": "/project",
+            "argv": ["bazelisk", "build", "//..."],
+            "pid": 12345,
+            "env": {"PATH": "/usr/bin"}
+        }"#;
+        let req: ShimExecRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.shim, "bazelisk");
+        assert_eq!(req.pid, 12345);
+        assert_eq!(req.argv.len(), 3);
+    }
+
+    #[test]
+    fn deserialize_hook_request_envelope() {
+        let json = r#"{
+            "hook": {
+                "hook_event_name": "SessionStart",
+                "session_id": "s1",
+                "transcript_path": "/tmp/t",
+                "cwd": "/p",
+                "source": "startup"
+            },
+            "env": {"HOME": "/root"}
+        }"#;
+        let req: HookRequest = serde_json::from_str(json).unwrap();
+        assert!(matches!(req.hook, AnyHookInput::SessionStart(_)));
+        assert_eq!(req.env.get("HOME").unwrap(), "/root");
+    }
+}

--- a/devinfra/claude/claude_hook/session.rs
+++ b/devinfra/claude/claude_hook/session.rs
@@ -1,0 +1,174 @@
+//! Per-session daemon state: mailbox + background command output buffers.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BgStream {
+    Stdout,
+    Stderr,
+}
+
+impl BgStream {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BgStream::Stdout => "stdout",
+            BgStream::Stderr => "stderr",
+        }
+    }
+}
+
+pub struct Session {
+    pub session_id: String,
+    inner: Mutex<SessionInner>,
+}
+
+#[derive(Default)]
+struct SessionInner {
+    mailbox: Vec<String>,
+    bg: HashMap<(String, BgStream), Vec<String>>,
+}
+
+impl Session {
+    pub fn new(session_id: String) -> Self {
+        Self {
+            session_id,
+            inner: Mutex::new(SessionInner::default()),
+        }
+    }
+
+    pub fn post_message(&self, msg: String) {
+        self.inner.lock().unwrap().mailbox.push(msg);
+    }
+
+    pub fn push_bg_line(&self, task: &str, stream: BgStream, line: String) {
+        self.inner
+            .lock()
+            .unwrap()
+            .bg
+            .entry((task.to_string(), stream))
+            .or_default()
+            .push(line);
+    }
+
+    pub fn drain_messages(&self) -> Vec<String> {
+        std::mem::take(&mut self.inner.lock().unwrap().mailbox)
+    }
+
+    pub fn drain_bg_output(&self) -> HashMap<(String, BgStream), Vec<String>> {
+        std::mem::take(&mut self.inner.lock().unwrap().bg)
+    }
+}
+
+/// Render drained mailbox + bg output as `HookOutput.system_message`,
+/// matching the Python format in `server.py::_apply_mailbox`.
+pub fn format_system_message(
+    mailbox: Vec<String>,
+    bg: HashMap<(String, BgStream), Vec<String>>,
+) -> Option<String> {
+    if mailbox.is_empty() && bg.is_empty() {
+        return None;
+    }
+    let mut parts: Vec<String> = Vec::new();
+
+    if !bg.is_empty() {
+        // Group by task name, preserving per-stream order.
+        let mut by_task: Vec<(String, HashMap<BgStream, Vec<String>>)> = Vec::new();
+        for ((task, stream), lines) in bg {
+            if let Some((_, streams)) = by_task.iter_mut().find(|(t, _)| t == &task) {
+                streams.insert(stream, lines);
+            } else {
+                let mut streams = HashMap::new();
+                streams.insert(stream, lines);
+                by_task.push((task, streams));
+            }
+        }
+        let task_blocks: Vec<String> = by_task
+            .into_iter()
+            .map(|(task, streams)| {
+                let inner: String = streams
+                    .into_iter()
+                    .map(|(s, lines)| {
+                        let name = s.as_str();
+                        format!("<{name}>{}</{name}>", lines.join("\n"))
+                    })
+                    .collect();
+                format!("<task {task}>{inner}</task>")
+            })
+            .collect();
+        parts.push(format!(
+            "Background task output:\n{}",
+            task_blocks.join("\n")
+        ));
+    }
+
+    if !mailbox.is_empty() {
+        let bullets: Vec<String> = mailbox.into_iter().map(|m| format!("- {m}")).collect();
+        parts.push(format!(
+            "Messages from hook daemon mailbox:\n{}",
+            bullets.join("\n")
+        ));
+    }
+
+    Some(parts.join("\n\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mailbox_roundtrip() {
+        let s = Session::new("s1".into());
+        s.post_message("hello".into());
+        s.post_message("world".into());
+        assert_eq!(s.drain_messages(), vec!["hello", "world"]);
+        assert!(s.drain_messages().is_empty());
+    }
+
+    #[test]
+    fn bg_lines_grouped_by_task_and_stream() {
+        let s = Session::new("s1".into());
+        s.push_bg_line("t1", BgStream::Stdout, "l1".into());
+        s.push_bg_line("t1", BgStream::Stderr, "e1".into());
+        s.push_bg_line("t1", BgStream::Stdout, "l2".into());
+        s.push_bg_line("t2", BgStream::Stdout, "m1".into());
+
+        let out = s.drain_bg_output();
+        assert_eq!(out[&("t1".into(), BgStream::Stdout)], vec!["l1", "l2"]);
+        assert_eq!(out[&("t1".into(), BgStream::Stderr)], vec!["e1"]);
+        assert_eq!(out[&("t2".into(), BgStream::Stdout)], vec!["m1"]);
+        assert!(s.drain_bg_output().is_empty());
+    }
+
+    #[test]
+    fn format_mailbox_only() {
+        let s = format_system_message(vec!["hi".into(), "there".into()], HashMap::new()).unwrap();
+        assert!(s.contains("Messages from hook daemon mailbox:"));
+        assert!(s.contains("- hi"));
+    }
+
+    #[test]
+    fn format_bg_only() {
+        let mut bg = HashMap::new();
+        bg.insert(("kubeconfig".into(), BgStream::Stdout), vec!["done".into()]);
+        let s = format_system_message(vec![], bg).unwrap();
+        assert!(s.contains("Background task output:"));
+        assert!(s.contains("<task kubeconfig><stdout>done</stdout></task>"));
+    }
+
+    #[test]
+    fn format_empty_is_none() {
+        assert!(format_system_message(vec![], HashMap::new()).is_none());
+    }
+
+    #[test]
+    fn format_both_sections_ordered() {
+        let mut bg = HashMap::new();
+        bg.insert(("t".into(), BgStream::Stdout), vec!["o".into()]);
+        let s = format_system_message(vec!["m".into()], bg).unwrap();
+        let a = s.find("Background task output:").unwrap();
+        let b = s.find("Messages from hook daemon mailbox:").unwrap();
+        assert!(a < b, "bg before mailbox in {s}");
+    }
+}

--- a/devinfra/claude/claude_hook/shim_install.rs
+++ b/devinfra/claude/claude_hook/shim_install.rs
@@ -1,0 +1,71 @@
+//! Install PATH shims: two-line shell wrappers in `<session_dir>/bin/`
+//! that `exec claude-hook shim <name> "$@"`.
+//!
+//! Ports `devinfra/claude/hook_daemon/shim_install.py`. `claude-hook` is
+//! resolved via PATH at exec time (not baked in) so the wrapper keeps
+//! working across binary upgrades without restarting the session.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub const SHIM_NAMES: &[&str] = &["bazelisk", "git", "bazel", "bb", "bbr"];
+pub const SHIM_SESSION_ID_ENV: &str = "__DUCKTAPE_CLAUDE_HOOKS_SHIM_SESSION_ID";
+
+pub fn install_shim(wrapper_dir: &Path, shim_name: &str, session_id: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(wrapper_dir)?;
+    let path = wrapper_dir.join(shim_name);
+    let content = format!(
+        "#!/bin/sh\nexport {SHIM_SESSION_ID_ENV}={}\nexec claude-hook shim {} \"$@\"\n",
+        shlex::try_quote(session_id).unwrap(),
+        shlex::try_quote(shim_name).unwrap()
+    );
+    std::fs::write(&path, content)?;
+    let mut perms = std::fs::metadata(&path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms)?;
+    Ok(())
+}
+
+pub fn install_all_shims(wrapper_dir: &Path, session_id: &str) -> std::io::Result<()> {
+    for name in SHIM_NAMES {
+        install_shim(wrapper_dir, name, session_id)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_writes_executable_wrapper() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_shim(tmp.path(), "git", "session-abc").unwrap();
+
+        let shim = tmp.path().join("git");
+        let content = std::fs::read_to_string(&shim).unwrap();
+        assert!(content.starts_with("#!/bin/sh\n"));
+        assert!(content.contains("__DUCKTAPE_CLAUDE_HOOKS_SHIM_SESSION_ID=session-abc"));
+        assert!(content.contains("exec claude-hook shim git \"$@\""));
+
+        let mode = std::fs::metadata(&shim).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+
+    #[test]
+    fn install_all_shims_creates_all_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_all_shims(tmp.path(), "s1").unwrap();
+        for name in SHIM_NAMES {
+            assert!(tmp.path().join(name).exists(), "missing shim: {name}");
+        }
+    }
+
+    #[test]
+    fn install_quotes_session_id_with_spaces() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_shim(tmp.path(), "git", "weird id").unwrap();
+        let content = std::fs::read_to_string(tmp.path().join("git")).unwrap();
+        assert!(content.contains("'weird id'"));
+    }
+}

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -1,0 +1,62 @@
+//! `claude-hook shim <name> [args...]` runtime.
+//!
+//! The shim sends a `ShimExecRequest` to the daemon's `/shim-exec` endpoint.
+//! The daemon resolves the real binary, applies policy (git block, bazelrc
+//! injection), and returns either `Blocked` (shim prints message, exits 1)
+//! or `Execve` with a fully resolved argv (shim just exec's it).
+
+use std::collections::HashMap;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+
+use claude_hook_shim_install::SHIM_SESSION_ID_ENV;
+use protocol::{ShimExecRequest, ShimResponse};
+
+pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
+    let session_id = std::env::var(SHIM_SESSION_ID_ENV).unwrap_or_else(|_| {
+        eprintln!("claude-hook shim: {SHIM_SESSION_ID_ENV} not set in env — shim wrapper broken?");
+        std::process::exit(2);
+    });
+
+    let mut argv = vec![name.clone()];
+    argv.extend(forwarded);
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    let env: HashMap<String, String> = std::env::vars().collect();
+    let pid = std::process::id();
+
+    let report = ShimExecRequest {
+        shim: name.clone(),
+        session_id: session_id.clone(),
+        cwd,
+        argv: argv.clone(),
+        pid,
+        env,
+    };
+
+    let sock_path = crate::daemon_sock_path(&session_id);
+
+    let approved_argv = match call_daemon(&sock_path, &report).await {
+        Ok(ShimResponse::Blocked { message }) => {
+            eprintln!("[{name}-shim] BLOCKED: {message}");
+            std::process::exit(1);
+        }
+        Ok(ShimResponse::Execve { argv }) => argv,
+        Err(e) => {
+            eprintln!("[{name}-shim] daemon unreachable: {e} — passing through");
+            argv
+        }
+    };
+
+    let err = std::process::Command::new(&approved_argv[0])
+        .args(&approved_argv[1..])
+        .exec();
+    eprintln!("{name}: exec failed: {err}");
+    std::process::exit(126);
+}
+
+async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse, String> {
+    let body = serde_json::to_vec(req).map_err(|e| format!("serialize: {e}"))?;
+    let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body).await?;
+    serde_json::from_slice(&resp_bytes).map_err(|e| format!("parse response: {e}"))
+}

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
@@ -63,11 +63,12 @@ oci_layout_rloc(
 
 py_test(
     name = "test_container_e2e",
-    size = "large",
+    size = "medium",
     srcs = ["test_container_e2e.py"],
     data = [
         "test_profile.yaml",
         ":e2e_container",
+        "//devinfra/claude/claude_hook",
         "//devinfra/claude/hook_daemon/testdata/e2e_secrets:e2e_secrets_files",
         "//devinfra/claude/scripts:write_kubeconfig.py",
         "//devinfra/claude/testdata/test_workspace:workspace_files",

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -1,30 +1,24 @@
 """Container E2E test for the hook daemon's session-start flow.
 
-Exercises the real secret-decryption + kubeconfig path end-to-end inside an
-isolated Docker container:
+Parameterized over two implementations:
 
-  - Stages a /project tree with the real devinfra/secrets/web_env.sh,
-    the real _common.sh, a web-style profile (testdata/e2e_secrets/profile.yaml),
-    and test-encrypted SOPS secrets (testdata/e2e_secrets/*.yaml) at the same
-    repo-relative paths the real scripts expect.
-  - Installs the claude_hooks wheel in the container.
-  - Runs SessionStart. The daemon sources web_env.sh (decrypts the fake
-    secrets with the test age key), writes ~/.kube/config via the real
-    kubeconfig writer, and sets up PATH shims + bazelrc.
-  - Asserts the agent's contract: after `source <ENV_FILE>`, BUILDBUDDY_API_KEY,
-    GITHUB_TOKEN, DUCKTAPE_CI_READ_GITHUB_TOKEN are set; ~/.kube/config is a
-    valid kubeconfig with the decrypted token; PATH shims work; bazel build
-    succeeds.
+  - ``python``: install the ``claude_hooks`` Python wheel (the current prod
+    path).
+  - ``rust``: copy the ``claude-hook`` Rust binary into ``/usr/local/bin``.
 
-The test age key is generated once and committed to testdata/e2e_secrets/test_age.key.
-It only decrypts the fake secret fixtures in that directory; no real secrets
-are involved.
+Both use the same container image, the same staged `/project` (real
+`web_env.sh`, real SOPS fixtures, test profile, etc.), and the same
+assertion set. Both implementations must pass the full contract.
+
+Exercises the real secret-decryption + kubeconfig path end-to-end.
 """
 
+import io
 import json
 import os
 import shlex
 import shutil
+import tarfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -43,16 +37,15 @@ from util.testing.undeclared_outputs import undeclared_outputs_dir
 # via pkg_tar layers / the trixie_e2e apt manifest (see BUILD.bazel).
 _WHEEL_DIR = "/wheel"
 
-# Runfiles paths for real scripts + test fixtures.
+# Runfiles paths.
 _TEST_WORKSPACE_MODULE = "_main/devinfra/claude/testdata/test_workspace/MODULE.bazel"
 _WEB_ENV_SH = "_main/devinfra/secrets/web_env.sh"
 _COMMON_SH = "_main/devinfra/secrets/_common.sh"
 _WRITE_KUBECONFIG = "_main/devinfra/claude/scripts/write_kubeconfig.py"
 _TEST_PROFILE = "_main/devinfra/claude/hook_daemon/session_start/container_e2e/test_profile.yaml"
 _SECRETS_DIR_MARKER = "_main/devinfra/claude/hook_daemon/testdata/e2e_secrets/test_age.key"
+_RUST_BINARY = "_main/devinfra/claude/claude_hook/claude_hook"
 
-# Test SOPS files live at these repo-relative paths inside /project (matching
-# what web_env.sh and write_kubeconfig.py look for in the real repo).
 _TEST_SECRET_FILES = [
     "buildbuddy.yaml",
     "github-pat-agentydragon-agent.yaml",
@@ -68,14 +61,12 @@ _CONTAINER_NAME = "ducktape-container-e2e"
 _SESSION_ID = "container-e2e-test"
 _ENV_FILE = f"/root/.claude/session-env/{_SESSION_ID}/sessionstart-hook-0.sh"
 _SESSION_DIR = f"/root/.claude/session-env/{_SESSION_ID}"
-# Daemon UDS lives under /tmp/claude-hd/<session_id>/ (short path — AF_UNIX
-# has a 108-byte sun_path limit; see devinfra/claude/session_paths.py).
+# Daemon UDS lives under /tmp/claude-hd/<session_id>/ (AF_UNIX 108-byte limit).
 _DAEMON_SOCK = f"/tmp/claude-hd/{_SESSION_ID}/d.sock"
 
 
-def _save_output(name: str, content: str) -> None:
-    """Save content to undeclared test outputs."""
-    out_dir = undeclared_outputs_dir() / "container-e2e"
+def _save_output(impl: str, name: str, content: str) -> None:
+    out_dir = undeclared_outputs_dir() / f"container-e2e-{impl}"
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / name).write_text(content)
 
@@ -83,7 +74,6 @@ def _save_output(name: str, content: str) -> None:
 def _exec(
     container: docker.models.containers.Container, cmd: list[str], *, workdir: str | None = None, check: bool = True
 ) -> tuple[int, bytes, bytes]:
-    """Run a command in the container via docker exec."""
     result = container.exec_run(cmd, demux=True, workdir=workdir)
     stdout, stderr = result.output
     stdout = stdout or b""
@@ -99,116 +89,33 @@ def _exec(
 def _exec_under_env(
     container: docker.models.containers.Container, shell_cmd: str, *, workdir: str | None = None, check: bool = True
 ) -> tuple[int, bytes, bytes]:
-    """Run a shell command inside the container after sourcing the session env file.
-
-    Simulates what the agent's Bash tool does: Claude Code sources the session
-    env file before every Bash call.
-    """
+    """Run a shell command after sourcing the session env file (agent's Bash behavior)."""
     return _exec(container, ["bash", "-c", f"source {_ENV_FILE} && {shell_cmd}"], workdir=workdir, check=check)
 
 
-@pytest.fixture
-def staged_project(tmp_path: Path) -> Path:
-    """A /project tree mirroring the real repo layout (for bind-mount into the container).
-
-    /project/
-      MODULE.bazel, BUILD.bazel, .bazelrc, .bazelversion   (test workspace)
-      profile.yaml                                          (web-style test profile)
-      devinfra/secrets/{web_env.sh,_common.sh}              (real scripts)
-      secrets/{buildbuddy,github-pat-...,
-               github-ci-read-pat,
-               claude-web-k8s-cert}.yaml                    (test-encrypted)
-      .git/                                                 (pre-commit needs a repo)
-    """
-    project = tmp_path / "project"
-    project.mkdir()
-
-    test_workspace = get_required_path(_TEST_WORKSPACE_MODULE).parent
-    for src in test_workspace.iterdir():
-        if src.name == "profile.yaml":
-            # Overridden by the e2e_secrets profile below.
-            continue
-        if src.is_file():
-            shutil.copy2(src, project / src.name)
-
-    # Real scripts at their real repo paths.
-    secrets_dir = project / "devinfra" / "secrets"
-    secrets_dir.mkdir(parents=True)
-    shutil.copy2(get_required_path(_WEB_ENV_SH), secrets_dir / "web_env.sh")
-    shutil.copy2(get_required_path(_COMMON_SH), secrets_dir / "_common.sh")
-    scripts_dir = project / "devinfra" / "claude" / "scripts"
-    scripts_dir.mkdir(parents=True)
-    shutil.copy2(get_required_path(_WRITE_KUBECONFIG), scripts_dir / "write_kubeconfig.py")
-
-    # Test profile (sibling of this test) + test-encrypted SOPS fixtures.
-    shutil.copy2(get_required_path(_TEST_PROFILE), project / "profile.yaml")
-    secrets_fixtures = get_required_path(_SECRETS_DIR_MARKER).parent
-    project_secrets = project / "secrets"
-    project_secrets.mkdir()
-    for name in _TEST_SECRET_FILES:
-        shutil.copy2(secrets_fixtures / name, project_secrets / name)
-
-    (project / ".git").mkdir()  # pre-commit wants a git repo
-
-    return project
+def _docker_cp(
+    container: docker.models.containers.Container, src_path: str, dest_path: str, *, mode: int = 0o755
+) -> None:
+    """Copy a local file into a running container via put_archive."""
+    dest = Path(dest_path)
+    with Path(src_path).open("rb") as f:
+        data = f.read()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name=dest.name)
+        info.size = len(data)
+        info.mode = mode
+        tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    container.put_archive(str(dest.parent), buf)
 
 
-@pytest.fixture
-def test_age_key() -> str:
-    """Test-only age private key from testdata/e2e_secrets/test_age.key.
-
-    Decrypts the fake SOPS fixtures in that directory; does not unlock any real
-    secrets. Passed to the container as SOPS_AGE_KEY so the real web_env.sh and
-    kubeconfig writer can read the fixtures.
-    """
-    raw = get_required_path(_SECRETS_DIR_MARKER).read_text()
-    # The file has a "# public key: ..." header and the AGE-SECRET-KEY-* line.
-    return next(line.strip() for line in raw.splitlines() if line.startswith("AGE-SECRET-KEY-"))
+# ---------------------------------------------------------------------------
+# Parameterization: python (wheel install) vs rust (binary copy)
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def e2e_image() -> str:
-    """Load the e2e container OCI image into Docker."""
-    return load_oci_image(_E2E)
-
-
-@pytest.fixture
-def container(staged_project: Path, test_age_key: str, e2e_image: str) -> Iterator[docker.models.containers.Container]:
-    """Start the e2e container with the staged project bind-mounted at /project.
-
-    Teardown saves container logs + daemon logs to undeclared outputs for
-    post-mortem analysis, then force-removes the container.
-    """
-    env = {
-        "CLAUDE_PROJECT_DIR": "/project",
-        "CLAUDE_ENV_FILE": _ENV_FILE,
-        "DUCKTAPE_CLAUDE_HOOKS_PROFILE": "profile.yaml",
-        "SOPS_AGE_KEY": test_age_key,
-    }
-    c = docker.from_env().containers.run(
-        e2e_image,
-        command=["sleep", "infinity"],
-        name=f"{_CONTAINER_NAME}-{os.getpid()}",
-        environment=env,
-        volumes={str(staged_project): {"bind": "/project", "mode": "ro"}},
-        detach=True,
-    )
-    try:
-        yield c
-    finally:
-        _save_output("container-stdout.log", c.logs(stdout=True, stderr=False).decode(errors="replace"))
-        _save_output("container-stderr.log", c.logs(stdout=False, stderr=True).decode(errors="replace"))
-        for log_file in ["hook-daemon/daemon.log", "hook-daemon/daemon.err.log", "sessionstart-hook-0.sh", "bazelrc"]:
-            rc, content, _ = _exec(c, ["cat", f"{_SESSION_DIR}/{log_file}"], check=False)
-            if rc == 0:
-                _save_output(log_file.replace("/", "-"), content.decode(errors="replace"))
-        c.remove(force=True)
-
-
-def test_container_e2e(container: docker.models.containers.Container) -> None:
-    """SessionStart contract test: secrets, kubeconfig, shims, bazel all work."""
-    # Install claude_hooks wheel from the image's /wheel/ dir.
-    _exec(container, ["ls", "-la", _WHEEL_DIR])
+def _install_python_wheel(container: docker.models.containers.Container) -> None:
     _exec(
         container,
         [
@@ -220,11 +127,124 @@ def test_container_e2e(container: docker.models.containers.Container) -> None:
             f"{_WHEEL_DIR}/claude_hooks-0.1.0-py3-none-any.whl",
         ],
     )
+
+
+def _install_rust_binary(container: docker.models.containers.Container) -> None:
+    rust_binary = get_required_path(_RUST_BINARY)
+    _docker_cp(container, str(rust_binary), "/usr/local/bin/claude-hook")
+    # The Rust binary has no Python runtime deps; write_kubeconfig.py
+    # (invoked as a bg command) imports yaml. The Python impl gets PyYAML
+    # transitively via the claude_hooks wheel; the Rust impl must install
+    # it explicitly.
+    _exec(container, ["pip", "install", "--break-system-packages", "pyyaml"])
+
+
+_IMPLS = {"python": _install_python_wheel, "rust": _install_rust_binary}
+
+
+@pytest.fixture(params=list(_IMPLS.keys()))
+def impl(request: pytest.FixtureRequest) -> str:
+    param: str = request.param
+    return param
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def staged_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    test_workspace = get_required_path(_TEST_WORKSPACE_MODULE).parent
+    for src in test_workspace.iterdir():
+        if src.name == "profile.yaml":
+            continue
+        if src.is_file():
+            shutil.copy2(src, project / src.name)
+
+    secrets_dir = project / "devinfra" / "secrets"
+    secrets_dir.mkdir(parents=True)
+    shutil.copy2(get_required_path(_WEB_ENV_SH), secrets_dir / "web_env.sh")
+    shutil.copy2(get_required_path(_COMMON_SH), secrets_dir / "_common.sh")
+
+    scripts_dir = project / "devinfra" / "claude" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(get_required_path(_WRITE_KUBECONFIG), scripts_dir / "write_kubeconfig.py")
+
+    shutil.copy2(get_required_path(_TEST_PROFILE), project / "profile.yaml")
+    secrets_fixtures = get_required_path(_SECRETS_DIR_MARKER).parent
+    project_secrets = project / "secrets"
+    project_secrets.mkdir()
+    for name in _TEST_SECRET_FILES:
+        shutil.copy2(secrets_fixtures / name, project_secrets / name)
+
+    (project / ".git").mkdir()
+    return project
+
+
+@pytest.fixture
+def test_age_key() -> str:
+    raw = get_required_path(_SECRETS_DIR_MARKER).read_text()
+    return next(line.strip() for line in raw.splitlines() if line.startswith("AGE-SECRET-KEY-"))
+
+
+@pytest.fixture
+def e2e_image() -> str:
+    return load_oci_image(_E2E)
+
+
+@pytest.fixture
+def container(
+    impl: str, staged_project: Path, test_age_key: str, e2e_image: str
+) -> Iterator[docker.models.containers.Container]:
+    env = {
+        "CLAUDE_PROJECT_DIR": "/project",
+        "CLAUDE_ENV_FILE": _ENV_FILE,
+        "DUCKTAPE_CLAUDE_HOOKS_PROFILE": "profile.yaml",
+        "SOPS_AGE_KEY": test_age_key,
+    }
+    c = docker.from_env().containers.run(
+        e2e_image,
+        command=["sleep", "infinity"],
+        name=f"{_CONTAINER_NAME}-{impl}-{os.getpid()}",
+        environment=env,
+        volumes={str(staged_project): {"bind": "/project", "mode": "ro"}},
+        detach=True,
+    )
+    try:
+        yield c
+    finally:
+        _save_output(impl, "container-stdout.log", c.logs(stdout=True, stderr=False).decode(errors="replace"))
+        _save_output(impl, "container-stderr.log", c.logs(stdout=False, stderr=True).decode(errors="replace"))
+        for log_file in ["hook-daemon/daemon.log", "hook-daemon/daemon.err.log", "sessionstart-hook-0.sh", "bazelrc"]:
+            rc, content, _ = _exec(c, ["cat", f"{_SESSION_DIR}/{log_file}"], check=False)
+            if rc == 0:
+                _save_output(impl, log_file.replace("/", "-"), content.decode(errors="replace"))
+        # Rust daemon writes logs under the short session dir.
+        for log_file in ["daemon.log", "daemon.err.log", "daemon.pid"]:
+            rc, content, _ = _exec(c, ["cat", f"/tmp/claude-hd/{_SESSION_ID}/{log_file}"], check=False)
+            if rc == 0:
+                _save_output(impl, f"rust-{log_file}", content.decode(errors="replace"))
+        c.remove(force=True)
+
+
+# ---------------------------------------------------------------------------
+# Contract test
+# ---------------------------------------------------------------------------
+
+
+def test_container_e2e(impl: str, container: docker.models.containers.Container) -> None:
+    """SessionStart contract test, parameterized over python/rust impls."""
+    # Install whichever claude-hook impl this run is for.
+    _IMPLS[impl](container)
     _exec(container, ["which", "claude-hook"])
     _exec(container, ["which", "sops"])
     _exec(container, ["which", "curl"])
 
-    # Run SessionStart hook.
+    # Run SessionStart.
     hook_input = json.dumps(
         {
             "hook_event_name": "SessionStart",
@@ -238,11 +258,7 @@ def test_container_e2e(container: docker.models.containers.Container) -> None:
     )
     _exec(container, ["bash", "-c", f"echo {shlex.quote(hook_input)} | claude-hook"])
 
-    # ------------------------------------------------------------------
-    # Agent contract assertions — what the agent's Bash tool calls see
-    # after `source $CLAUDE_ENV_FILE`.
-    # ------------------------------------------------------------------
-
+    # Env file exists.
     _exec(container, ["test", "-f", _ENV_FILE])
     _, stdout, _ = _exec_under_env(container, "env -0")
     agent_env = parse_env_null_delimited(stdout)
@@ -250,13 +266,20 @@ def test_container_e2e(container: docker.models.containers.Container) -> None:
     # env_exports from profile.
     assert agent_env["E2E_TEST_MARKER"] == "1"
 
-    # Secrets decrypted by real web_env.sh (_common.sh → BUILDBUDDY_API_KEY;
-    # web_env.sh → GITHUB_TOKEN, DUCKTAPE_CI_READ_GITHUB_TOKEN).
+    # Secrets decrypted by real web_env.sh.
     assert agent_env["BUILDBUDDY_API_KEY"] == "test-fake-bb-key"
     assert agent_env["GITHUB_TOKEN"] == "test-fake-gh-agent-token"
     assert agent_env["DUCKTAPE_CI_READ_GITHUB_TOKEN"] == "test-fake-ci-read-token"
 
-    # Kubeconfig written by the write_kubeconfig bg command (async — poll).
+    # Daemon alive on UDS.
+    _, stdout, _ = _exec(container, ["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
+    assert b'"status":"ok"' in stdout
+
+    # PATH shims: passthrough.
+    _, stdout, _ = _exec_under_env(container, "git --version")
+    assert b"git version" in stdout
+
+    # Kubeconfig (written by bg command).
     _exec(
         container, ["bash", "-c", "for i in $(seq 60); do [ -f /root/.kube/config ] && exit 0; sleep 0.5; done; exit 1"]
     )
@@ -270,15 +293,7 @@ def test_container_e2e(container: docker.models.containers.Container) -> None:
     _, stat_out, _ = _exec(container, ["stat", "-c", "%a", "/root/.kube/config"])
     assert stat_out.strip() == b"600"
 
-    # Daemon alive on UDS.
-    _, stdout, _ = _exec(container, ["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
-    assert b'"status":"ok"' in stdout
-
-    # PATH shims: passthrough.
-    _, stdout, _ = _exec_under_env(container, "git --version")
-    assert b"git version" in stdout
-
-    # git shim blocks `git add -A` (profile has block_add_all=true).
+    # git shim blocks `git add -A`.
     rc, _, stderr = _exec_under_env(container, "git add -A", check=False)
     assert rc != 0
     assert b"BLOCKED" in stderr

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -22,12 +22,30 @@
 # (useful for debugging sessions where you can't read the log directly).
 #
 # Usage (Claude Code web UI setup command):
-#   bash ducktape/devinfra/claude/web_setup.sh
+#   bash ducktape/devinfra/claude/web_setup.sh [--impl=<python|rust>]
+#
+# --impl selects the claude-hook implementation:
+#   python (default) — Python wheel (#devtools flake output)
+#   rust             — Rust static binary (#devtools-rust flake output)
 
 LOG_FILE="/tmp/web-setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 set -euo pipefail
+
+# Hook implementation: python (default) or rust.
+HOOK_IMPL="${DUCKTAPE_CLAUDE_HOOK_IMPL:-python}"
+for arg in "$@"; do
+  case "$arg" in --impl=*) HOOK_IMPL="${arg#--impl=}" ;; esac
+done
+case "$HOOK_IMPL" in
+  python) DEVTOOLS_OUTPUT="devtools" ;;
+  rust) DEVTOOLS_OUTPUT="devtools-rust" ;;
+  *)
+    echo "Unknown --impl=$HOOK_IMPL (expected python or rust)" >&2
+    DEVTOOLS_OUTPUT="devtools"
+    ;;
+esac
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
@@ -113,8 +131,9 @@ ls -la
 #
 # See <devinfra/claude/docs/web-setup-debug.md> ("Pin drift on persistent rootfs").
 nix profile remove devtools 2>/dev/null || true
-nix profile install --max-jobs auto "${FLAKE}#devtools"
-echo "[$(date -Iseconds)] Dev tools installed."
+nix profile remove devtools-rust 2>/dev/null || true
+nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
+echo "[$(date -Iseconds)] Dev tools installed (impl=$HOOK_IMPL)."
 
 # Symlink all Nix-installed binaries into /usr/local/bin so they're on PATH.
 # Claude Code is launched directly (not via login shell), so the Nix profile bin

--- a/devinfra/claude/web_setup_hook.sh
+++ b/devinfra/claude/web_setup_hook.sh
@@ -8,6 +8,14 @@
 # without this hook the installed wheel can lag behind npins/sources.json by
 # many hours (however long the Firecracker VM stays alive between new sessions).
 #
+# Unlike the init_script invocation of web_setup.sh (which runs BEFORE claude
+# and does not see user-UI env vars), this Setup hook fires as a subprocess of
+# `claude` and inherits the full user-UI env — including
+# DUCKTAPE_CLAUDE_HOOK_IMPL, which selects Python or Rust claude-hook. Set
+# DUCKTAPE_CLAUDE_HOOK_IMPL=rust in the Claude Code web UI to switch impls
+# without branching or modifying settings.json. web_setup.sh reads the var,
+# removes the stale devtools profile, and reinstalls the selected flake output.
+#
 # No-ops on CLI sessions (CLAUDE_CODE_REMOTE unset) — web_setup.sh is
 # web-only (Nix flake install, git remote, etc.) and must not run on NixOS.
 #
@@ -28,7 +36,7 @@ exec >>"$LOG_FILE" 2>&1
 # Logged verbatim so we can observe what (if anything) Setup hooks receive.
 STDIN_DATA=$(cat)
 echo "[$(date -Iseconds)] web_setup_hook.sh: cwd=$(pwd) BASH_SOURCE=${BASH_SOURCE[0]}"
-echo "[$(date -Iseconds)] web_setup_hook.sh: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} IS_SANDBOX=${IS_SANDBOX:-<unset>}"
+echo "[$(date -Iseconds)] web_setup_hook.sh: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} IS_SANDBOX=${IS_SANDBOX:-<unset>} DUCKTAPE_CLAUDE_HOOK_IMPL=${DUCKTAPE_CLAUDE_HOOK_IMPL:-<unset>}"
 echo "[$(date -Iseconds)] web_setup_hook.sh: stdin=${STDIN_DATA:-(empty)}"
 
 if [ -z "${CLAUDE_CODE_REMOTE:-}" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -232,9 +232,8 @@
       ];
       # System libraries matching RBE worker image (devinfra/rbe_image/Dockerfile).
       systemLibs = import ./nix/packages/system-libs.nix { inherit pkgs; };
-      devToolPackages = [
-        # Repo-specific tools (bbr is provided by claude-hooks wheel)
-        ducktapePkgs.claude-hooks
+      # Common dev tools shared by both Python and Rust hook implementations.
+      devToolsCommon = [
         ducktapePkgs.bb
         ducktapePkgs.bbapi
         ducktapePkgs.skills
@@ -262,6 +261,10 @@
         pkgs.ssh-to-age
         ducktapePkgs.kubernetes-mcp-server
       ];
+      # Python claude-hook (bbr provided by the wheel's console_scripts).
+      devToolPackages = devToolsCommon ++ [ ducktapePkgs.claude-hooks ];
+      # Rust claude-hook (static binary, no Python runtime).
+      devToolPackagesRust = devToolsCommon ++ [ ducktapePkgs.claude-hook-rs ];
     in
     {
       # Development shell — enter via `nix develop` or direnv (`use flake`).
@@ -281,9 +284,15 @@
           ];
         };
         # Installable package for `nix profile install .#devtools` (used by web_setup.sh).
+        # Default: Python claude-hook. Use #devtools-rust for the Rust binary.
         devtools = pkgs.symlinkJoin {
           name = "ducktape-devtools";
           paths = devToolPackages ++ localOnlyPackages;
+        };
+        # Rust claude-hook variant (selected via `web_setup.sh --impl=rust`).
+        devtools-rust = pkgs.symlinkJoin {
+          name = "ducktape-devtools-rust";
+          paths = devToolPackagesRust ++ localOnlyPackages;
         };
         # Lean devtools for RBE worker image (no rustfmt, ansible).
         rbetools = pkgs.symlinkJoin {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -152,6 +152,26 @@ in
       ];
   };
 
+  # Rust claude-hook binary — static, no runtime deps.
+  # Provides the same `claude-hook` binary name as the Python wheel so it's a
+  # drop-in replacement. Installed into a separate flake output (#claude-hooks-rs)
+  # and selected via `web_setup.sh --impl=rust`.
+  claude-hook-rs = pkgs.stdenvNoCC.mkDerivation {
+    pname = "claude-hook-rs";
+    version = "latest";
+    src = artifacts.claude-hook-rs;
+    dontUnpack = true;
+    installPhase = ''
+      install -Dm755 $src $out/bin/claude-hook
+    '';
+    meta = {
+      description = "Claude Code hook daemon (Rust)";
+      homepage = "https://github.com/agentydragon/ducktape";
+      license = lib.licenses.agpl3Only;
+      mainProgram = "claude-hook";
+    };
+  };
+
   gterm-theme = mkWheel {
     pname = "gterm-theme";
     description = "GNOME Terminal theme follower";

--- a/x/rust_hook_daemon/CUTOVER_CHECKLIST.md
+++ b/x/rust_hook_daemon/CUTOVER_CHECKLIST.md
@@ -1,0 +1,40 @@
+# Rust Hook Daemon — Cutover Readiness Checklist
+
+Before flipping the default to `rust`, validate on a live Claude Code web
+session with `DUCKTAPE_CLAUDE_HOOK_IMPL=rust` set in the web UI env vars.
+
+## Must pass (blocks cutover)
+
+- [ ] Session starts without errors (no 500, no daemon timeout)
+- [ ] `claude-hook --version` shows Rust binary (not Python wheel)
+- [ ] `/web_selfcheck` skill passes all SPEC acceptance tests
+- [ ] `env -0` under session env shows decrypted secrets
+      (`BUILDBUDDY_API_KEY`, `GITHUB_TOKEN`, `DUCKTAPE_CI_READ_GITHUB_TOKEN`)
+- [ ] `git --version` via shim works (passthrough)
+- [ ] `git add -A` blocked with `BLOCKED` message (git shim policy)
+- [ ] `bazelisk build //:hello` succeeds via shim
+- [ ] `~/.kube/config` exists with correct server + token (bg command)
+- [ ] `bbr test //devinfra/claude/...` completes (RBE works via bbr)
+- [ ] Context banner visible in session transcript (`additionalContext`)
+- [ ] Daemon log at expected path, no unhandled panics
+- [ ] Second `SessionStart` (compaction) reuses existing daemon (no race)
+- [ ] Idle watchdog fires after 30min (testable with short timeout override)
+
+## Should verify (non-blocking but important)
+
+- [ ] Daemon restart after SIGKILL (client kills stale, forks new)
+- [ ] Circuit breaker blocks rapid re-fork after daemon crash
+- [ ] `/mailbox` POST from bg command delivers to next REPL hook
+- [ ] Multiple concurrent hook invocations → single daemon (daemon.lock)
+- [ ] `curl --unix-socket $HOOK_DAEMON_SOCK http://localhost/health` returns ok
+- [ ] Env file has 0o600 permissions
+
+## How to run the live test
+
+1. In Claude Code web UI → Settings → Environment Variables:
+   set `DUCKTAPE_CLAUDE_HOOK_IMPL=rust`
+2. Open a new session on `devel` (after this PR merges)
+3. Setup hook fires → `web_setup.sh` reads the env var → installs
+   `#claude-hooks-rs` flake output → Rust `claude-hook` on PATH
+4. Walk the checklist above
+5. Unset `DUCKTAPE_CLAUDE_HOOK_IMPL` to revert to Python

--- a/x/rust_hook_daemon/PLAN.md
+++ b/x/rust_hook_daemon/PLAN.md
@@ -1,0 +1,69 @@
+# Rust Hook Daemon v0
+
+Rewrite the Claude Code hook daemon (`devinfra/claude/hook_daemon/`) in Rust.
+Single static binary, wire-compatible with Claude Code's JSON protocol.
+
+Reference implementation: `devinfra/claude/hook_daemon/` (Python, ~6k LOC).
+Rust implementation: `devinfra/claude/claude_hook/` (12 modules, ~4.3k lines).
+
+## Status
+
+| Phase                                                           | Status      |
+| --------------------------------------------------------------- | ----------- |
+| 1. Container E2E contract test                                  | **Done**    |
+| 2. Kubeconfig extraction to standalone script                   | **Done**    |
+| 3. Rust scaffolding + client dispatch + double-fork             | **Done**    |
+| 4. SessionStart parity (env, shims, bg cmds, lifecycle, banner) | **Done**    |
+| 5. Release pipeline + flake wiring + `--impl` switch            | **Done**    |
+| 6. Cutover (flip default, delete Python daemon)                 | Not started |
+
+Both `python` and `rust` parameterizations of the container E2E pass the
+same assertion set on RBE.
+
+## Release pipeline
+
+- `release.yml` matrix entry builds `//devinfra/claude/claude_hook:claude_hook`
+  and publishes to GitHub Releases with tag `claude-hook-rs-<12hex>`.
+- `sync-pins.yml` auto-updates `npins/sources.json` every 30min.
+- `nix/packages/default.nix` has `claude-hook-rs` derivation (static binary,
+  no runtime deps; installs as `$out/bin/claude-hook`).
+
+## Flake outputs
+
+```
+#devtools       → devToolsCommon + Python claude-hooks wheel (default)
+#devtools-rust  → devToolsCommon + Rust claude-hook-rs binary
+```
+
+`web_setup.sh --impl=<python|rust>` selects which output to install.
+Default is `python`. Both remove the other profile before installing.
+
+## Testing the Rust impl live
+
+No branch needed. The Setup hook (`web_setup_hook.sh`) runs as a `claude`
+subprocess and inherits user-UI env vars. Set
+`DUCKTAPE_CLAUDE_HOOK_IMPL=rust` in the Claude Code web UI environment
+settings; `web_setup.sh` reads it, removes the default `#devtools`
+profile, and installs `#devtools-rust` instead. Open a session, validate
+with `/web_selfcheck`. Unset the var (or set to `python`) to revert.
+
+Two parallel Claude Code web environments — one with the var set, one
+without — give you side-by-side testing on the same branch.
+
+## Remaining gaps
+
+1. **Per-profile context template** (Mako→Tera). Test profile doesn't use it.
+2. **Real PreToolUse / PostToolUse handlers**. Both return noop in Rust.
+3. **OpenTelemetry tracing**. Deferred.
+4. **Skip re-exec in double-fork**. The grandchild currently `exec`s
+   itself (`claude-hook daemon --sock --daemon-dir`) for a clean process
+   image. Since the tokio runtime hasn't been created before fork, the
+   grandchild could call `run_daemon()` directly — saves ~1ms and one
+   exec. Alternatively, split into separate client/daemon binaries.
+
+Cutover readiness checklist: <CUTOVER_CHECKLIST.md>
+
+## Next goal
+
+**Phase 6 — cutover**: flip `web_setup.sh` default to `rust`, delete
+Python daemon code. Gate on all "must pass" items above being verified.


### PR DESCRIPTION
## Summary

Single static Rust binary (`devinfra/claude/claude_hook/`) replacing the Python `claude-hook` for all three modes: hook dispatch, shim runtime, and daemon server. Passes the same parameterized container E2E as the Python impl.

### Rust binary (12 modules, ~4.3k lines)
- Wire-compatible with Claude Code's JSON protocol (camelCase output, snake_case input)
- Profile YAML loading, `startup_env_script` sourcing, env overlay capture
- Env file write (0o600 perms, atomic via `tempfile::persist`)
- PATH shim install + shim runtime (execvp via `Command::exec()`)
- Git shim policy (block `add -A/--all/.`, `stash`, `commit --amend`)
- Background commands with timeout + line-streaming + mailbox drain
- Session bazelrc rendering + `--bazelrc` injection via bazel/bazelisk shim
- Context banner (`additionalContext` on SessionStart)
- Daemon lifecycle: pidfile flock, `daemon.lock`, kill-stale (SIGTERM→SIGKILL), file-based circuit breaker (`checked_shl`, `min(2*2^n,120)s`), crash detection (pre/post-pidfile), idle watchdog
- Client extracts `HookOutput` from `HookResponse` envelope
- Uses `shlex` crate for shell quoting, `nix` for signals, `tempfile` for atomic writes

### Release pipeline
- `release.yml` matrix entry for `claude-hook-rs` (builds `//devinfra/claude/claude_hook:claude_hook`)
- `artifacts.py`: `Artifact(pkg="claude-hook-rs", filename="claude-hook")`
- `nix/packages/default.nix`: `claude-hook-rs` derivation (static binary, no runtime deps)

### Flake restructuring
- `devToolsCommon`: shared tools (bbapi, gh, sops, skills, pre-commit, ...)
- `#devtools`: devToolsCommon + Python `claude-hooks` wheel (default)
- `#devtools-rust`: devToolsCommon + Rust `claude-hook-rs` binary
- `web_setup.sh --impl=<python|rust>` selects which flake output to install

### Testing the Rust impl live
1. Branch off `devel`, edit `.claude/settings.json` Setup hook: `bash devinfra/claude/web_setup.sh --impl=rust`
2. Open Claude Code web session on the branch
3. Validate with `/web_selfcheck`

## Test plan

- [x] `bbr test //devinfra/claude/claude_hook/...` — 6 Rust test targets pass
- [x] `bbr test //devinfra/claude/hook_daemon/session_start/container_e2e:test_container_e2e` — python + rust both pass

https://claude.ai/code/session_013kEZA6hzAzB7s2rnnHibbk