### PR TITLE
fix(ci): claude-hook-rs artifact filename is claude_hook

### DIFF
--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -43,7 +43,7 @@ class Artifact(BaseModel, frozen=True):
 
 ARTIFACTS = [
     Artifact(pkg="claude-hooks", filename="claude_hooks-0.1.0-py3-none-any.whl"),
-    Artifact(pkg="claude-hook-rs", filename="claude-hook"),
+    Artifact(pkg="claude-hook-rs", filename="claude_hook"),
     Artifact(pkg="ducktape-util", filename="ducktape_util-0.1.0-py3-none-any.whl"),
     Artifact(pkg="ducktape", filename="ducktape-0.1.0-py3-none-any.whl"),
     Artifact(pkg="gterm-theme", filename="gterm_theme-0.1.0-py3-none-any.whl"),


### PR DESCRIPTION
## Summary

Bazel `rust_binary` target is named `claude_hook` (Rust crate naming; underscores not hyphens), so the release artifact is uploaded as `claude_hook`. `artifacts.py` registered it as `claude-hook` (hyphen) which caused sync-pins to get 404 on the `claude-hook-rs-000ca828c6df` release.

## Test plan

- [x] sync-pins workflow next run will fetch the correct URL and update `npins/sources.json`

https://claude.ai/code/session_013kEZA6hzAzB7s2rnnHibbk