### PR TITLE
docs(web_setup): CLEANUP tombstone for init-script / Setup-hook double-run

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -27,6 +27,18 @@
 # --impl selects the claude-hook implementation:
 #   python (default) — Python wheel (#devtools flake output)
 #   rust             — Rust static binary (#devtools-rust flake output)
+#
+# CLEANUP(2026-04-19): this script runs TWICE per session — once as the
+# init script (no user-UI env vars, always installs python default) and
+# once via the Setup hook (web_setup_hook.sh, has UI env vars, may swap
+# to rust). The first run is wasted when the user wants rust — the
+# profile install gets overwritten seconds later. Once the Setup hook
+# is confirmed to fire reliably across all session modes (new / resume
+# / resume-cached / setup-only — see devinfra/claude/README.md) and is
+# sufficient on its own, make the init-script path a no-op (or drop it
+# from the Claude Code web UI "Setup Command" field) and let the Setup
+# hook own devtools install. Remove this tombstone after ≥1 week of
+# live sessions with no "Setup hook missed firing" fallbacks needed.
 
 LOG_FILE="/tmp/web-setup.log"
 exec > >(tee -a "$LOG_FILE") 2>&1


### PR DESCRIPTION
## Summary

Add a `CLEANUP(2026-04-19)` tombstone in `web_setup.sh` documenting the double-run wastefulness: the script runs once as the init script (no UI env vars → installs python default) and once via the Setup hook (has UI env vars → may swap to rust). The first install is wasted when the user sets `DUCKTAPE_CLAUDE_HOOK_IMPL=rust`.

Removal condition: after ≥1 week of live sessions with the Setup hook reliably firing across all session modes (new / resume / resume-cached / setup-only), drop the init-script path and let the Setup hook own devtools install exclusively.

## Test plan

- [x] Documentation / comment change only

https://claude.ai/code/session_013kEZA6hzAzB7s2rnnHibbk