### PR TITLE
test(claude_hook): shim PATH resolution + shim-exec decision + client decide()

### DIFF
--- a/devinfra/claude/claude_hook/BUILD.bazel
+++ b/devinfra/claude/claude_hook/BUILD.bazel
@@ -88,6 +88,7 @@ rust_binary(
         "main.rs",
         "session.rs",
         "shim_runtime.rs",
+        "test_util.rs",
     ],
     edition = "2024",
     visibility = ["//visibility:public"],

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -422,7 +422,7 @@ async fn handle_shim_exec(
     let shim_dir = session_dir.join("bin");
     let bazelrc_path = session_dir.join("bazelrc");
     Json(shim_exec_decision(
-        &req,
+        req,
         &state.profile,
         &shim_dir,
         &bazelrc_path,
@@ -432,25 +432,29 @@ async fn handle_shim_exec(
 /// Pure decision logic for `/shim-exec`: given a request, profile, and session
 /// paths, return the `ShimResponse` the daemon should send back. No axum/hyper
 /// types, no state mutation, no env lookups — testable in isolation.
+///
+/// Takes `req` by value so `argv` can be moved into `resolve_execve` without
+/// allocation. Only the `bazelisk`/`bazel` branch needs to clone, and only to
+/// inject `--bazelrc`.
 fn shim_exec_decision(
-    req: &ShimExecRequest,
+    req: ShimExecRequest,
     profile: &ProfileConfig,
     shim_dir: &Path,
     bazelrc_path: &Path,
 ) -> ShimResponse {
     match req.shim.as_str() {
         "git" => match git_shim::evaluate(&req.argv, &profile.git_shim) {
-            Ok(()) => resolve_execve(&req.shim, req.argv.clone(), shim_dir, &req.env),
+            Ok(()) => resolve_execve(&req.shim, req.argv, shim_dir, &req.env),
             Err(message) => ShimResponse::Blocked { message },
         },
         "bazelisk" | "bazel" => {
-            let mut argv = req.argv.clone();
+            let mut argv = req.argv;
             if bazelrc_path.exists() {
                 argv.insert(1, format!("--bazelrc={}", bazelrc_path.display()));
             }
             resolve_execve(&req.shim, argv, shim_dir, &req.env)
         }
-        _ => resolve_execve(&req.shim, req.argv.clone(), shim_dir, &req.env),
+        _ => resolve_execve(&req.shim, req.argv, shim_dir, &req.env),
     }
 }
 
@@ -952,7 +956,7 @@ mod tests {
             std::fs::write(&bazelrc, "# test\n").unwrap();
         }
         let req = make_request(shim, argv, &PathFixture::join_path(&[&real]));
-        let resp = shim_exec_decision(&req, profile, &shim_dir, &bazelrc);
+        let resp = shim_exec_decision(req, profile, &shim_dir, &bazelrc);
         (resp, real)
     }
 
@@ -1019,7 +1023,7 @@ mod tests {
         // PATH has only shim_dir → resolver excludes it → None → Blocked.
         let req = make_request("git", &["git", "status"], &shim_dir.display().to_string());
         match shim_exec_decision(
-            &req,
+            req,
             &ProfileConfig::default(),
             &shim_dir,
             &f.root.join("bazelrc"),

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -420,22 +420,37 @@ async fn handle_shim_exec(
     let session_dir = home_session_dir(&req.session_id);
     let shim_dir = session_dir.join("bin");
     let bazelrc_path = session_dir.join("bazelrc");
+    Json(shim_exec_decision(
+        &req,
+        &state.profile,
+        &shim_dir,
+        &bazelrc_path,
+    ))
+}
 
-    let resp = match req.shim.as_str() {
-        "git" => match git_shim::evaluate(&req.argv, &state.profile.git_shim) {
-            Ok(()) => resolve_execve(&req.shim, req.argv, &shim_dir, &req.env),
+/// Pure decision logic for `/shim-exec`: given a request, profile, and session
+/// paths, return the `ShimResponse` the daemon should send back. No axum/hyper
+/// types, no state mutation, no env lookups — testable in isolation.
+fn shim_exec_decision(
+    req: &ShimExecRequest,
+    profile: &ProfileConfig,
+    shim_dir: &Path,
+    bazelrc_path: &Path,
+) -> ShimResponse {
+    match req.shim.as_str() {
+        "git" => match git_shim::evaluate(&req.argv, &profile.git_shim) {
+            Ok(()) => resolve_execve(&req.shim, req.argv.clone(), shim_dir, &req.env),
             Err(message) => ShimResponse::Blocked { message },
         },
         "bazelisk" | "bazel" => {
-            let mut argv = req.argv;
+            let mut argv = req.argv.clone();
             if bazelrc_path.exists() {
                 argv.insert(1, format!("--bazelrc={}", bazelrc_path.display()));
             }
-            resolve_execve(&req.shim, argv, &shim_dir, &req.env)
+            resolve_execve(&req.shim, argv, shim_dir, &req.env)
         }
-        _ => resolve_execve(&req.shim, req.argv, &shim_dir, &req.env),
-    };
-    Json(resp)
+        _ => resolve_execve(&req.shim, req.argv.clone(), shim_dir, &req.env),
+    }
 }
 
 fn resolve_execve(
@@ -802,5 +817,301 @@ async fn main() {
             run_daemon(sock, daemon_dir).await;
         }
         None => dispatch_hook().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn make_exec(dir: &Path, name: &str) {
+        let p = dir.join(name);
+        std::fs::write(&p, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&p).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).unwrap();
+    }
+
+    fn env_with_path(path: &str) -> HashMap<String, String> {
+        let mut env = HashMap::new();
+        env.insert("PATH".into(), path.into());
+        env
+    }
+
+    #[test]
+    fn resolves_outside_shim_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&shim).unwrap();
+        std::fs::create_dir(&real).unwrap();
+        make_exec(&real, "git");
+        let path_env = format!("{}:{}", shim.display(), real.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(
+            resolve_binary_from_env("git", &shim, &env),
+            Some(real.join("git"))
+        );
+    }
+
+    #[test]
+    fn skips_shim_dir_even_first_on_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&shim).unwrap();
+        std::fs::create_dir(&real).unwrap();
+        make_exec(&shim, "git");
+        make_exec(&real, "git");
+        let path_env = format!("{}:{}", shim.display(), real.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(
+            resolve_binary_from_env("git", &shim, &env),
+            Some(real.join("git")),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_only_in_shim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let other = tmp.path().join("other");
+        std::fs::create_dir(&shim).unwrap();
+        std::fs::create_dir(&other).unwrap();
+        make_exec(&shim, "git");
+        let path_env = format!("{}:{}", shim.display(), other.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(resolve_binary_from_env("git", &shim, &env), None);
+    }
+
+    #[test]
+    fn handles_canonicalized_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_real = tmp.path().join("shim_real");
+        let shim_link = tmp.path().join("shim_link");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&shim_real).unwrap();
+        std::os::unix::fs::symlink(&shim_real, &shim_link).unwrap();
+        std::fs::create_dir(&real).unwrap();
+        make_exec(&shim_real, "git");
+        make_exec(&real, "git");
+        // PATH references shim via the symlink; resolver gets the real shim
+        // dir. Both canonicalize to shim_real, so the entry is skipped.
+        let path_env = format!("{}:{}", shim_link.display(), real.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(
+            resolve_binary_from_env("git", &shim_real, &env),
+            Some(real.join("git")),
+        );
+    }
+
+    #[test]
+    fn non_executable_file_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let stub = tmp.path().join("stub");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&shim).unwrap();
+        std::fs::create_dir(&stub).unwrap();
+        std::fs::create_dir(&real).unwrap();
+        // Non-executable "git" file in stub dir — must be skipped.
+        std::fs::write(stub.join("git"), "not a real binary").unwrap();
+        make_exec(&real, "git");
+        let path_env = format!("{}:{}:{}", shim.display(), stub.display(), real.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(
+            resolve_binary_from_env("git", &shim, &env),
+            Some(real.join("git")),
+        );
+    }
+
+    #[test]
+    fn empty_path_segment_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&shim).unwrap();
+        std::fs::create_dir(&real).unwrap();
+        make_exec(&real, "git");
+        // PATH with empty segment between colons: shim::real.
+        let path_env = format!("{}::{}", shim.display(), real.display());
+        let env = env_with_path(&path_env);
+        assert_eq!(
+            resolve_binary_from_env("git", &shim, &env),
+            Some(real.join("git")),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_path_env_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        std::fs::create_dir(&shim).unwrap();
+        let env: HashMap<String, String> = HashMap::new();
+        assert_eq!(resolve_binary_from_env("git", &shim, &env), None);
+    }
+
+    // ---- C.2: shim_exec_decision integration ----
+
+    use claude_hook_config::GitShimConfig;
+
+    fn shim_req(name: &str, argv: &[&str], path_env: &str) -> ShimExecRequest {
+        let mut env = HashMap::new();
+        env.insert("PATH".into(), path_env.into());
+        ShimExecRequest {
+            shim: name.into(),
+            session_id: "test-session".into(),
+            cwd: PathBuf::from("/tmp"),
+            argv: argv.iter().map(|s| (*s).to_string()).collect(),
+            pid: 1234,
+            env,
+        }
+    }
+
+    fn block_add_all_profile() -> ProfileConfig {
+        ProfileConfig {
+            git_shim: GitShimConfig {
+                block_add_all: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn git_add_dash_a_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc");
+        let profile = block_add_all_profile();
+        // PATH populated with a real git — shouldn't matter; block short-circuits.
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        make_exec(&real, "git");
+        let req = shim_req("git", &["git", "add", "-A"], &real.display().to_string());
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Blocked { message } => assert!(message.contains("git add -A")),
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn git_status_resolves_to_absolute_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc");
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        make_exec(&real, "git");
+        let profile = block_add_all_profile(); // block config irrelevant for `status`
+        let req = shim_req("git", &["git", "status"], &real.display().to_string());
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Execve { argv } => {
+                assert!(
+                    argv[0].starts_with('/'),
+                    "argv[0] should be absolute, got {:?}",
+                    argv[0]
+                );
+                assert_eq!(argv[0], real.join("git").display().to_string());
+                assert_eq!(&argv[1..], &["status".to_string()]);
+            }
+            other => panic!("expected Execve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn git_not_on_path_blocks_with_helpful_message() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc");
+        let profile = ProfileConfig::default();
+        // Only shim dir on PATH — shim dir is excluded from resolution, so no match.
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        let req = shim_req("git", &["git", "status"], &shim_dir.display().to_string());
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Blocked { message } => {
+                assert!(
+                    message.contains("command not found"),
+                    "got message: {message}"
+                );
+            }
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn passthrough_shim_resolves_to_absolute() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc");
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        make_exec(&real, "bb");
+        let profile = ProfileConfig::default();
+        let req = shim_req("bb", &["bb", "info"], &real.display().to_string());
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Execve { argv } => {
+                assert_eq!(argv[0], real.join("bb").display().to_string());
+                assert_eq!(&argv[1..], &["info".to_string()]);
+            }
+            other => panic!("expected Execve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bazelisk_injects_bazelrc_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc");
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        make_exec(&real, "bazelisk");
+        // Create the bazelrc file so injection activates.
+        std::fs::write(&bazelrc, "# test bazelrc\n").unwrap();
+        let profile = ProfileConfig::default();
+        let req = shim_req(
+            "bazelisk",
+            &["bazelisk", "build", "//..."],
+            &real.display().to_string(),
+        );
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Execve { argv } => {
+                // [real/bazelisk, --bazelrc=..., build, //...]
+                assert_eq!(argv[0], real.join("bazelisk").display().to_string());
+                assert_eq!(argv[1], format!("--bazelrc={}", bazelrc.display()));
+                assert_eq!(&argv[2..], &["build".to_string(), "//...".to_string()]);
+            }
+            other => panic!("expected Execve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bazelisk_skips_bazelrc_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_dir = tmp.path().join("bin");
+        let bazelrc = tmp.path().join("bazelrc"); // intentionally not created
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        make_exec(&real, "bazelisk");
+        let profile = ProfileConfig::default();
+        let req = shim_req(
+            "bazelisk",
+            &["bazelisk", "build", "//..."],
+            &real.display().to_string(),
+        );
+
+        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+            ShimResponse::Execve { argv } => {
+                assert_eq!(argv[0], real.join("bazelisk").display().to_string());
+                assert_eq!(&argv[1..], &["build".to_string(), "//...".to_string()]);
+            }
+            other => panic!("expected Execve, got {other:?}"),
+        }
     }
 }

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -31,6 +31,7 @@ mod daemon_lifecycle;
 mod git_shim;
 mod session;
 mod shim_runtime;
+mod test_util;
 
 use session::{Session, format_system_message};
 
@@ -823,83 +824,61 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::PermissionsExt;
+    use crate::test_util::{PathFixture, make_request};
+    use claude_hook_config::GitShimConfig;
 
-    fn make_exec(dir: &Path, name: &str) {
-        let p = dir.join(name);
-        std::fs::write(&p, "#!/bin/sh\nexit 0\n").unwrap();
-        let mut perms = std::fs::metadata(&p).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&p, perms).unwrap();
-    }
+    // --------- C.1: resolve_binary_from_env ---------
 
-    fn env_with_path(path: &str) -> HashMap<String, String> {
-        let mut env = HashMap::new();
-        env.insert("PATH".into(), path.into());
-        env
-    }
-
-    #[test]
-    fn resolves_outside_shim_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        let real = tmp.path().join("real");
-        std::fs::create_dir(&shim).unwrap();
-        std::fs::create_dir(&real).unwrap();
-        make_exec(&real, "git");
-        let path_env = format!("{}:{}", shim.display(), real.display());
-        let env = env_with_path(&path_env);
-        assert_eq!(
-            resolve_binary_from_env("git", &shim, &env),
-            Some(real.join("git"))
-        );
+    /// Harness for "PATH = shim:real, some dirs may contain a `git` stub" —
+    /// assert whether the resolver returns `real/git` or `None`.
+    fn assert_resolve_on_shim_real(shim_has: bool, real_has: bool, expect_real: bool) {
+        let f = PathFixture::new();
+        let shim = f.mkdir("shim");
+        let real = f.mkdir("real");
+        if shim_has {
+            f.with_exec(&shim, "git");
+        }
+        if real_has {
+            f.with_exec(&real, "git");
+        }
+        let env = f.env_with_path(&[&shim, &real]);
+        let got = resolve_binary_from_env("git", &shim, &env);
+        assert_eq!(got, expect_real.then(|| real.join("git")));
     }
 
     #[test]
-    fn skips_shim_dir_even_first_on_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        let real = tmp.path().join("real");
-        std::fs::create_dir(&shim).unwrap();
-        std::fs::create_dir(&real).unwrap();
-        make_exec(&shim, "git");
-        make_exec(&real, "git");
-        let path_env = format!("{}:{}", shim.display(), real.display());
-        let env = env_with_path(&path_env);
-        assert_eq!(
-            resolve_binary_from_env("git", &shim, &env),
-            Some(real.join("git")),
-        );
+    fn resolve_only_in_real() {
+        assert_resolve_on_shim_real(false, true, true);
     }
 
     #[test]
-    fn returns_none_when_only_in_shim() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        let other = tmp.path().join("other");
-        std::fs::create_dir(&shim).unwrap();
-        std::fs::create_dir(&other).unwrap();
-        make_exec(&shim, "git");
-        let path_env = format!("{}:{}", shim.display(), other.display());
-        let env = env_with_path(&path_env);
-        assert_eq!(resolve_binary_from_env("git", &shim, &env), None);
+    fn resolve_in_both_prefers_real() {
+        // Shim-dir hits must always be skipped even when first on PATH.
+        assert_resolve_on_shim_real(true, true, true);
     }
 
     #[test]
-    fn handles_canonicalized_paths() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_real = tmp.path().join("shim_real");
-        let shim_link = tmp.path().join("shim_link");
-        let real = tmp.path().join("real");
-        std::fs::create_dir(&shim_real).unwrap();
+    fn resolve_only_in_shim() {
+        assert_resolve_on_shim_real(true, false, false);
+    }
+
+    #[test]
+    fn resolve_in_neither() {
+        assert_resolve_on_shim_real(false, false, false);
+    }
+
+    #[test]
+    fn resolve_handles_canonicalized_paths() {
+        // PATH references shim via a symlink; resolver gets the real shim dir.
+        // Both canonicalize to the same inode, so the symlinked entry is skipped.
+        let f = PathFixture::new();
+        let shim_real = f.mkdir("shim_real");
+        let shim_link = f.root.join("shim_link");
         std::os::unix::fs::symlink(&shim_real, &shim_link).unwrap();
-        std::fs::create_dir(&real).unwrap();
-        make_exec(&shim_real, "git");
-        make_exec(&real, "git");
-        // PATH references shim via the symlink; resolver gets the real shim
-        // dir. Both canonicalize to shim_real, so the entry is skipped.
-        let path_env = format!("{}:{}", shim_link.display(), real.display());
-        let env = env_with_path(&path_env);
+        let real = f.mkdir("real");
+        f.with_exec(&shim_real, "git");
+        f.with_exec(&real, "git");
+        let env = f.env_with_path(&[&shim_link, &real]);
         assert_eq!(
             resolve_binary_from_env("git", &shim_real, &env),
             Some(real.join("git")),
@@ -907,19 +886,14 @@ mod tests {
     }
 
     #[test]
-    fn non_executable_file_skipped() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        let stub = tmp.path().join("stub");
-        let real = tmp.path().join("real");
-        std::fs::create_dir(&shim).unwrap();
-        std::fs::create_dir(&stub).unwrap();
-        std::fs::create_dir(&real).unwrap();
-        // Non-executable "git" file in stub dir — must be skipped.
-        std::fs::write(stub.join("git"), "not a real binary").unwrap();
-        make_exec(&real, "git");
-        let path_env = format!("{}:{}:{}", shim.display(), stub.display(), real.display());
-        let env = env_with_path(&path_env);
+    fn resolve_skips_non_executable_file() {
+        let f = PathFixture::new();
+        let shim = f.mkdir("shim");
+        let stub = f.mkdir("stub");
+        let real = f.mkdir("real");
+        f.with_nonexec(&stub, "git");
+        f.with_exec(&real, "git");
+        let env = f.env_with_path(&[&shim, &stub, &real]);
         assert_eq!(
             resolve_binary_from_env("git", &shim, &env),
             Some(real.join("git")),
@@ -927,16 +901,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_path_segment_ignored() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        let real = tmp.path().join("real");
-        std::fs::create_dir(&shim).unwrap();
-        std::fs::create_dir(&real).unwrap();
-        make_exec(&real, "git");
+    fn resolve_ignores_empty_path_segment() {
         // PATH with empty segment between colons: shim::real.
+        let f = PathFixture::new();
+        let shim = f.mkdir("shim");
+        let real = f.mkdir("real");
+        f.with_exec(&real, "git");
         let path_env = format!("{}::{}", shim.display(), real.display());
-        let env = env_with_path(&path_env);
+        let env = HashMap::from([("PATH".to_string(), path_env)]);
         assert_eq!(
             resolve_binary_from_env("git", &shim, &env),
             Some(real.join("git")),
@@ -944,120 +916,142 @@ mod tests {
     }
 
     #[test]
-    fn returns_none_when_path_env_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("shim");
-        std::fs::create_dir(&shim).unwrap();
-        let env: HashMap<String, String> = HashMap::new();
-        assert_eq!(resolve_binary_from_env("git", &shim, &env), None);
+    fn resolve_returns_none_without_path_env() {
+        let f = PathFixture::new();
+        let shim = f.mkdir("shim");
+        assert_eq!(resolve_binary_from_env("git", &shim, &HashMap::new()), None);
     }
 
-    // ---- C.2: shim_exec_decision integration ----
+    // --------- C.2: shim_exec_decision ---------
 
-    use claude_hook_config::GitShimConfig;
-
-    fn shim_req(name: &str, argv: &[&str], path_env: &str) -> ShimExecRequest {
-        let mut env = HashMap::new();
-        env.insert("PATH".into(), path_env.into());
-        ShimExecRequest {
-            shim: name.into(),
-            session_id: "test-session".into(),
-            cwd: PathBuf::from("/tmp"),
-            argv: argv.iter().map(|s| (*s).to_string()).collect(),
-            pid: 1234,
-            env,
-        }
-    }
-
-    fn block_add_all_profile() -> ProfileConfig {
+    fn all_blocks_profile() -> ProfileConfig {
         ProfileConfig {
             git_shim: GitShimConfig {
                 block_add_all: true,
-                ..Default::default()
+                block_stash: true,
+                block_amend: true,
             },
             ..Default::default()
         }
     }
 
-    #[test]
-    fn git_add_dash_a_blocks() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc");
-        let profile = block_add_all_profile();
-        // PATH populated with a real git — shouldn't matter; block short-circuits.
-        let real = tmp.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        make_exec(&real, "git");
-        let req = shim_req("git", &["git", "add", "-A"], &real.display().to_string());
+    /// Harness: run `shim_exec_decision` with a `real/` dir containing `shim`
+    /// and return the response so the test can match on it.
+    fn decide_with_real(
+        shim: &str,
+        argv: &[&str],
+        profile: &ProfileConfig,
+        bazelrc_exists: bool,
+    ) -> (ShimResponse, PathBuf) {
+        let f = PathFixture::new();
+        let shim_dir = f.mkdir("bin");
+        let real = f.mkdir("real");
+        f.with_exec(&real, shim);
+        let bazelrc = f.root.join("bazelrc");
+        if bazelrc_exists {
+            std::fs::write(&bazelrc, "# test\n").unwrap();
+        }
+        let req = make_request(shim, argv, &PathFixture::join_path(&[&real]));
+        let resp = shim_exec_decision(&req, profile, &shim_dir, &bazelrc);
+        (resp, real)
+    }
 
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
-            ShimResponse::Blocked { message } => assert!(message.contains("git add -A")),
+    fn assert_git_block(argv: &[&str], msg_substring: &str) {
+        // Git blocks short-circuit before PATH resolution; the real/ dir is
+        // there to prove the shim_exec_decision path doesn't accidentally
+        // hit it.
+        let (resp, _real) = decide_with_real("git", argv, &all_blocks_profile(), false);
+        match resp {
+            ShimResponse::Blocked { message } => assert!(
+                message.contains(msg_substring),
+                "missing {msg_substring:?} in: {message}"
+            ),
             other => panic!("expected Blocked, got {other:?}"),
         }
     }
 
     #[test]
-    fn git_status_resolves_to_absolute_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc");
-        let real = tmp.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        make_exec(&real, "git");
-        let profile = block_add_all_profile(); // block config irrelevant for `status`
-        let req = shim_req("git", &["git", "status"], &real.display().to_string());
+    fn git_block_add_dash_a() {
+        assert_git_block(&["git", "add", "-A"], "git add -A");
+    }
+    #[test]
+    fn git_block_add_dot() {
+        assert_git_block(&["git", "add", "."], "git add .");
+    }
+    #[test]
+    fn git_block_add_all() {
+        assert_git_block(&["git", "add", "--all"], "git add --all");
+    }
+    #[test]
+    fn git_block_stash() {
+        assert_git_block(&["git", "stash"], "git stash");
+    }
+    #[test]
+    fn git_block_commit_amend() {
+        assert_git_block(&["git", "commit", "--amend"], "git commit --amend");
+    }
 
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+    fn assert_passthrough(shim: &str, argv: &[&str], expected_suffix: &[&str]) {
+        let (resp, real) = decide_with_real(shim, argv, &all_blocks_profile(), false);
+        match resp {
             ShimResponse::Execve { argv } => {
-                assert!(
-                    argv[0].starts_with('/'),
-                    "argv[0] should be absolute, got {:?}",
-                    argv[0]
-                );
-                assert_eq!(argv[0], real.join("git").display().to_string());
-                assert_eq!(&argv[1..], &["status".to_string()]);
+                assert_eq!(argv[0], real.join(shim).display().to_string());
+                let suffix: Vec<String> = argv.into_iter().skip(1).collect();
+                assert_eq!(suffix, expected_suffix);
             }
             other => panic!("expected Execve, got {other:?}"),
         }
     }
 
     #[test]
-    fn git_not_on_path_blocks_with_helpful_message() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc");
-        let profile = ProfileConfig::default();
-        // Only shim dir on PATH — shim dir is excluded from resolution, so no match.
-        std::fs::create_dir_all(&shim_dir).unwrap();
-        let req = shim_req("git", &["git", "status"], &shim_dir.display().to_string());
+    fn passthrough_git_status() {
+        assert_passthrough("git", &["git", "status"], &["status"]);
+    }
+    #[test]
+    fn passthrough_bb_info() {
+        assert_passthrough("bb", &["bb", "info"], &["info"]);
+    }
 
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
-            ShimResponse::Blocked { message } => {
-                assert!(
-                    message.contains("command not found"),
-                    "got message: {message}"
-                );
-            }
+    #[test]
+    fn shim_exec_blocks_when_binary_only_in_shim_dir() {
+        let f = PathFixture::new();
+        let shim_dir = f.mkdir("bin");
+        // PATH has only shim_dir → resolver excludes it → None → Blocked.
+        let req = make_request("git", &["git", "status"], &shim_dir.display().to_string());
+        match shim_exec_decision(
+            &req,
+            &ProfileConfig::default(),
+            &shim_dir,
+            &f.root.join("bazelrc"),
+        ) {
+            ShimResponse::Blocked { message } => assert!(
+                message.contains("command not found"),
+                "got message: {message}"
+            ),
             other => panic!("expected Blocked, got {other:?}"),
         }
     }
 
-    #[test]
-    fn passthrough_shim_resolves_to_absolute() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc");
-        let real = tmp.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        make_exec(&real, "bb");
-        let profile = ProfileConfig::default();
-        let req = shim_req("bb", &["bb", "info"], &real.display().to_string());
-
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
+    fn assert_bazelisk_injection(bazelrc_exists: bool) {
+        let (resp, real) = decide_with_real(
+            "bazelisk",
+            &["bazelisk", "build", "//..."],
+            &ProfileConfig::default(),
+            bazelrc_exists,
+        );
+        match resp {
             ShimResponse::Execve { argv } => {
-                assert_eq!(argv[0], real.join("bb").display().to_string());
-                assert_eq!(&argv[1..], &["info".to_string()]);
+                assert_eq!(argv[0], real.join("bazelisk").display().to_string());
+                // bazelrc path is derived inside the harness; scan argv[1] for it.
+                if bazelrc_exists {
+                    assert!(
+                        argv[1].starts_with("--bazelrc="),
+                        "expected --bazelrc= injection, got argv: {argv:?}"
+                    );
+                    assert_eq!(&argv[2..], &["build".to_string(), "//...".into()]);
+                } else {
+                    assert_eq!(&argv[1..], &["build".to_string(), "//...".into()]);
+                }
             }
             other => panic!("expected Execve, got {other:?}"),
         }
@@ -1065,53 +1059,10 @@ mod tests {
 
     #[test]
     fn bazelisk_injects_bazelrc_when_present() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc");
-        let real = tmp.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        make_exec(&real, "bazelisk");
-        // Create the bazelrc file so injection activates.
-        std::fs::write(&bazelrc, "# test bazelrc\n").unwrap();
-        let profile = ProfileConfig::default();
-        let req = shim_req(
-            "bazelisk",
-            &["bazelisk", "build", "//..."],
-            &real.display().to_string(),
-        );
-
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
-            ShimResponse::Execve { argv } => {
-                // [real/bazelisk, --bazelrc=..., build, //...]
-                assert_eq!(argv[0], real.join("bazelisk").display().to_string());
-                assert_eq!(argv[1], format!("--bazelrc={}", bazelrc.display()));
-                assert_eq!(&argv[2..], &["build".to_string(), "//...".to_string()]);
-            }
-            other => panic!("expected Execve, got {other:?}"),
-        }
+        assert_bazelisk_injection(true);
     }
-
     #[test]
     fn bazelisk_skips_bazelrc_when_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_dir = tmp.path().join("bin");
-        let bazelrc = tmp.path().join("bazelrc"); // intentionally not created
-        let real = tmp.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        make_exec(&real, "bazelisk");
-        let profile = ProfileConfig::default();
-        let req = shim_req(
-            "bazelisk",
-            &["bazelisk", "build", "//..."],
-            &real.display().to_string(),
-        );
-
-        match shim_exec_decision(&req, &profile, &shim_dir, &bazelrc) {
-            ShimResponse::Execve { argv } => {
-                assert_eq!(argv[0], real.join("bazelisk").display().to_string());
-                assert_eq!(&argv[1..], &["build".to_string(), "//...".to_string()]);
-            }
-            other => panic!("expected Execve, got {other:?}"),
-        }
+        assert_bazelisk_injection(false);
     }
 }

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -12,6 +12,40 @@ use std::path::{Path, PathBuf};
 use claude_hook_shim_install::SHIM_SESSION_ID_ENV;
 use protocol::{ShimExecRequest, ShimResponse};
 
+/// The decision the shim is going to take, derived from the daemon's
+/// response (or absence thereof). Split out of `run_shim` so it can be
+/// tested without actually `exec`ing.
+#[derive(Debug)]
+pub(crate) enum ShimDecision {
+    /// Daemon said to block: print `message` to stderr and exit 1.
+    Block(String),
+    /// Daemon returned an approved argv (argv[0] is an absolute path the
+    /// daemon has already resolved) — exec it.
+    Exec(Vec<String>),
+    /// Daemon unreachable — fall back to execing the original argv.
+    Passthrough(Vec<String>),
+}
+
+/// Ask the daemon how to handle this shim invocation. Turns RPC failures
+/// into `Passthrough(original_argv)` so `run_shim` doesn't need to know
+/// anything about the daemon wire protocol.
+pub(crate) async fn decide(
+    sock: &Path,
+    req: &ShimExecRequest,
+    original_argv: Vec<String>,
+) -> ShimDecision {
+    match call_daemon(sock, req).await {
+        Ok(ShimResponse::Blocked { message }) => ShimDecision::Block(message),
+        Ok(ShimResponse::Execve { argv }) => ShimDecision::Exec(argv),
+        Err(e) => {
+            // Log the specific RPC error before we lose it — run_shim just
+            // prints a generic "passing through" to the user.
+            eprintln!("[{}-shim] daemon call failed: {e}", req.shim);
+            ShimDecision::Passthrough(original_argv)
+        }
+    }
+}
+
 pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
     let session_id = std::env::var(SHIM_SESSION_ID_ENV).unwrap_or_else(|_| {
         eprintln!("claude-hook shim: {SHIM_SESSION_ID_ENV} not set in env — shim wrapper broken?");
@@ -36,14 +70,14 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
 
     let sock_path = crate::daemon_sock_path(&session_id);
 
-    let approved_argv = match call_daemon(&sock_path, &report).await {
-        Ok(ShimResponse::Blocked { message }) => {
+    let approved_argv = match decide(&sock_path, &report, argv).await {
+        ShimDecision::Block(message) => {
             eprintln!("[{name}-shim] BLOCKED: {message}");
             std::process::exit(1);
         }
-        Ok(ShimResponse::Execve { argv }) => argv,
-        Err(e) => {
-            eprintln!("[{name}-shim] daemon unreachable: {e} — passing through");
+        ShimDecision::Exec(argv) => argv,
+        ShimDecision::Passthrough(argv) => {
+            eprintln!("[{name}-shim] daemon unreachable — passing through");
             argv
         }
     };
@@ -59,4 +93,125 @@ async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse,
     let body = serde_json::to_vec(req).map_err(|e| format!("serialize: {e}"))?;
     let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body).await?;
     serde_json::from_slice(&resp_bytes).map_err(|e| format!("parse response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Json;
+    use axum::routing::post;
+    use std::sync::Arc;
+    use tokio::net::UnixListener;
+
+    fn sample_request() -> ShimExecRequest {
+        let mut env = HashMap::new();
+        env.insert("PATH".into(), "/usr/bin".into());
+        ShimExecRequest {
+            shim: "git".into(),
+            session_id: "session-test".into(),
+            cwd: PathBuf::from("/tmp"),
+            argv: vec!["git".into(), "status".into()],
+            pid: 42,
+            env,
+        }
+    }
+
+    /// Spawn a one-shot fake daemon on a temp UDS that answers every request
+    /// with `response`. The join handle is dropped when the test ends, which
+    /// aborts the server task — but the socket path is already cleaned up by
+    /// `tempdir()`. Returns the socket path.
+    async fn spawn_fake_daemon(
+        sock: PathBuf,
+        response: ShimResponse,
+    ) -> tokio::task::JoinHandle<()> {
+        let shared = Arc::new(response);
+        let app = axum::Router::new().route(
+            "/shim-exec",
+            post({
+                let shared = shared.clone();
+                move || {
+                    let shared = shared.clone();
+                    async move {
+                        // axum's Json needs `Serialize`; ShimResponse is. Clone
+                        // the shared value into a fresh owned one for the
+                        // response (`Arc::clone` would hand out a shared ref,
+                        // but Json takes ownership).
+                        let resp: ShimResponse = match &*shared {
+                            ShimResponse::Blocked { message } => ShimResponse::Blocked {
+                                message: message.clone(),
+                            },
+                            ShimResponse::Execve { argv } => {
+                                ShimResponse::Execve { argv: argv.clone() }
+                            }
+                        };
+                        Json(resp)
+                    }
+                }
+            }),
+        );
+        let listener = UnixListener::bind(&sock).unwrap();
+        tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, app).await {
+                eprintln!("fake daemon serve error: {e}");
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn decide_blocks_on_blocked_response() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("d.sock");
+        let _server = spawn_fake_daemon(
+            sock.clone(),
+            ShimResponse::Blocked {
+                message: "nope".into(),
+            },
+        )
+        .await;
+        let req = sample_request();
+        let decision = decide(&sock, &req, req.argv.clone()).await;
+        match decision {
+            ShimDecision::Block(m) => assert_eq!(m, "nope"),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn decide_execs_absolute_path_on_execve() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("d.sock");
+        let _server = spawn_fake_daemon(
+            sock.clone(),
+            ShimResponse::Execve {
+                argv: vec!["/usr/bin/git".into(), "status".into()],
+            },
+        )
+        .await;
+        let req = sample_request();
+        let decision = decide(&sock, &req, req.argv.clone()).await;
+        match decision {
+            ShimDecision::Exec(argv) => {
+                assert!(
+                    argv[0].starts_with('/'),
+                    "argv[0] should be absolute, got {:?}",
+                    argv[0]
+                );
+                assert_eq!(argv, vec!["/usr/bin/git".to_string(), "status".into()]);
+            }
+            other => panic!("expected Exec, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn decide_passthrough_when_daemon_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("nonexistent.sock");
+        let req = sample_request();
+        let original = req.argv.clone();
+        let decision = decide(&sock, &req, original.clone()).await;
+        match decision {
+            ShimDecision::Passthrough(argv) => assert_eq!(argv, original),
+            other => panic!("expected Passthrough, got {other:?}"),
+        }
+    }
 }

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -98,28 +98,15 @@ async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::make_request;
     use axum::Json;
     use axum::routing::post;
     use std::sync::Arc;
     use tokio::net::UnixListener;
 
-    fn sample_request() -> ShimExecRequest {
-        let mut env = HashMap::new();
-        env.insert("PATH".into(), "/usr/bin".into());
-        ShimExecRequest {
-            shim: "git".into(),
-            session_id: "session-test".into(),
-            cwd: PathBuf::from("/tmp"),
-            argv: vec!["git".into(), "status".into()],
-            pid: 42,
-            env,
-        }
-    }
-
-    /// Spawn a one-shot fake daemon on a temp UDS that answers every request
-    /// with `response`. The join handle is dropped when the test ends, which
-    /// aborts the server task — but the socket path is already cleaned up by
-    /// `tempdir()`. Returns the socket path.
+    /// Spawn a fake daemon on a temp UDS that answers every `/shim-exec`
+    /// with `response`. Kept alive by the returned `JoinHandle`; the caller
+    /// holds it (`let _server = ...`) until the test ends.
     async fn spawn_fake_daemon(
         sock: PathBuf,
         response: ShimResponse,
@@ -127,25 +114,20 @@ mod tests {
         let shared = Arc::new(response);
         let app = axum::Router::new().route(
             "/shim-exec",
-            post({
+            post(move || {
                 let shared = shared.clone();
-                move || {
-                    let shared = shared.clone();
-                    async move {
-                        // axum's Json needs `Serialize`; ShimResponse is. Clone
-                        // the shared value into a fresh owned one for the
-                        // response (`Arc::clone` would hand out a shared ref,
-                        // but Json takes ownership).
-                        let resp: ShimResponse = match &*shared {
-                            ShimResponse::Blocked { message } => ShimResponse::Blocked {
-                                message: message.clone(),
-                            },
-                            ShimResponse::Execve { argv } => {
-                                ShimResponse::Execve { argv: argv.clone() }
-                            }
-                        };
-                        Json(resp)
-                    }
+                async move {
+                    // Clone inner fields — ShimResponse isn't Clone, and the
+                    // Arc holds a shared ref while Json wants ownership.
+                    let resp = match &*shared {
+                        ShimResponse::Blocked { message } => ShimResponse::Blocked {
+                            message: message.clone(),
+                        },
+                        ShimResponse::Execve { argv } => {
+                            ShimResponse::Execve { argv: argv.clone() }
+                        }
+                    };
+                    Json(resp)
                 }
             }),
         );
@@ -155,6 +137,10 @@ mod tests {
                 eprintln!("fake daemon serve error: {e}");
             }
         })
+    }
+
+    fn git_status_request() -> ShimExecRequest {
+        make_request("git", &["git", "status"], "/usr/bin")
     }
 
     #[tokio::test]
@@ -168,9 +154,8 @@ mod tests {
             },
         )
         .await;
-        let req = sample_request();
-        let decision = decide(&sock, &req, req.argv.clone()).await;
-        match decision {
+        let req = git_status_request();
+        match decide(&sock, &req, req.argv.clone()).await {
             ShimDecision::Block(m) => assert_eq!(m, "nope"),
             other => panic!("expected Block, got {other:?}"),
         }
@@ -187,9 +172,8 @@ mod tests {
             },
         )
         .await;
-        let req = sample_request();
-        let decision = decide(&sock, &req, req.argv.clone()).await;
-        match decision {
+        let req = git_status_request();
+        match decide(&sock, &req, req.argv.clone()).await {
             ShimDecision::Exec(argv) => {
                 assert!(
                     argv[0].starts_with('/'),
@@ -206,10 +190,9 @@ mod tests {
     async fn decide_passthrough_when_daemon_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let sock = tmp.path().join("nonexistent.sock");
-        let req = sample_request();
+        let req = git_status_request();
         let original = req.argv.clone();
-        let decision = decide(&sock, &req, original.clone()).await;
-        match decision {
+        match decide(&sock, &req, original.clone()).await {
             ShimDecision::Passthrough(argv) => assert_eq!(argv, original),
             other => panic!("expected Passthrough, got {other:?}"),
         }

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -22,12 +22,13 @@ pub(crate) enum ShimDecision {
     /// Daemon returned an approved argv (argv[0] is an absolute path the
     /// daemon has already resolved) — exec it.
     Exec(Vec<String>),
-    /// Daemon unreachable — fall back to execing the original argv.
-    Passthrough(Vec<String>),
+    /// Daemon unreachable — exec the original argv. `reason` carries the
+    /// RPC error so `run_shim` can surface a single user-facing message.
+    Passthrough { argv: Vec<String>, reason: String },
 }
 
 /// Ask the daemon how to handle this shim invocation. Turns RPC failures
-/// into `Passthrough(original_argv)` so `run_shim` doesn't need to know
+/// into `Passthrough { argv, reason }` so `run_shim` doesn't need to know
 /// anything about the daemon wire protocol.
 pub(crate) async fn decide(
     sock: &Path,
@@ -37,12 +38,10 @@ pub(crate) async fn decide(
     match call_daemon(sock, req).await {
         Ok(ShimResponse::Blocked { message }) => ShimDecision::Block(message),
         Ok(ShimResponse::Execve { argv }) => ShimDecision::Exec(argv),
-        Err(e) => {
-            // Log the specific RPC error before we lose it — run_shim just
-            // prints a generic "passing through" to the user.
-            eprintln!("[{}-shim] daemon call failed: {e}", req.shim);
-            ShimDecision::Passthrough(original_argv)
-        }
+        Err(reason) => ShimDecision::Passthrough {
+            argv: original_argv,
+            reason,
+        },
     }
 }
 
@@ -76,8 +75,8 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
             std::process::exit(1);
         }
         ShimDecision::Exec(argv) => argv,
-        ShimDecision::Passthrough(argv) => {
-            eprintln!("[{name}-shim] daemon unreachable — passing through");
+        ShimDecision::Passthrough { argv, reason } => {
+            eprintln!("[{name}-shim] daemon unreachable: {reason} — passing through");
             argv
         }
     };
@@ -104,9 +103,10 @@ mod tests {
     use std::sync::Arc;
     use tokio::net::UnixListener;
 
-    /// Spawn a fake daemon on a temp UDS that answers every `/shim-exec`
-    /// with `response`. Kept alive by the returned `JoinHandle`; the caller
-    /// holds it (`let _server = ...`) until the test ends.
+    /// Spawn a fake daemon on `sock` that answers every `/shim-exec` request
+    /// with `response`. Returns the server task's `JoinHandle`. The task
+    /// runs until `handle.abort()` is called or the tokio runtime ends with
+    /// the test; dropping the handle alone does NOT abort it.
     async fn spawn_fake_daemon(
         sock: PathBuf,
         response: ShimResponse,
@@ -193,7 +193,10 @@ mod tests {
         let req = git_status_request();
         let original = req.argv.clone();
         match decide(&sock, &req, original.clone()).await {
-            ShimDecision::Passthrough(argv) => assert_eq!(argv, original),
+            ShimDecision::Passthrough { argv, reason } => {
+                assert_eq!(argv, original);
+                assert!(!reason.is_empty(), "reason should carry the RPC error");
+            }
             other => panic!("expected Passthrough, got {other:?}"),
         }
     }

--- a/devinfra/claude/claude_hook/test_util.rs
+++ b/devinfra/claude/claude_hook/test_util.rs
@@ -1,0 +1,81 @@
+//! Shared test helpers for the claude_hook binary crate.
+//!
+//! Both `main.rs::tests` and `shim_runtime.rs::tests` exercise the same
+//! shim RPC types and need similar tempdir/PATH scaffolding. The helpers
+//! live here so each test module imports them instead of rolling its own.
+
+#![cfg(test)]
+
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use protocol::ShimExecRequest;
+
+/// Tempdir with convenience methods for creating PATH-like layouts.
+///
+/// The owned `TempDir` is held until this fixture drops, so tests can
+/// freely pass paths around without worrying about cleanup.
+pub(crate) struct PathFixture {
+    _tmp: tempfile::TempDir,
+    pub root: PathBuf,
+}
+
+impl PathFixture {
+    pub fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        Self { _tmp: tmp, root }
+    }
+
+    /// Create `<root>/<name>` (recursively) and return its absolute path.
+    pub fn mkdir(&self, name: &str) -> PathBuf {
+        let p = self.root.join(name);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// Place an executable stub at `<dir>/<name>` (`0755`). Returns the path.
+    pub fn with_exec(&self, dir: &Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&p).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).unwrap();
+        p
+    }
+
+    /// Write a non-executable file at `<dir>/<name>`. Returns the path.
+    pub fn with_nonexec(&self, dir: &Path, name: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, "not a real binary").unwrap();
+        p
+    }
+
+    /// Build an env map containing only `PATH=<dirs joined by ':'>`.
+    pub fn env_with_path(&self, dirs: &[&Path]) -> HashMap<String, String> {
+        HashMap::from([("PATH".into(), Self::join_path(dirs))])
+    }
+
+    /// Join directories with `:` to form a `PATH` string.
+    pub fn join_path(dirs: &[&Path]) -> String {
+        dirs.iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(":")
+    }
+}
+
+/// Build a `ShimExecRequest` with test defaults, overriding shim/argv/PATH.
+pub(crate) fn make_request(shim: &str, argv: &[&str], path_env: &str) -> ShimExecRequest {
+    let mut env = HashMap::new();
+    env.insert("PATH".into(), path_env.into());
+    ShimExecRequest {
+        shim: shim.into(),
+        session_id: "test-session".into(),
+        cwd: PathBuf::from("/tmp"),
+        argv: argv.iter().map(|s| (*s).to_string()).collect(),
+        pid: 1234,
+        env,
+    }
+}

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -293,10 +293,40 @@ def test_container_e2e(impl: str, container: docker.models.containers.Container)
     _, stat_out, _ = _exec(container, ["stat", "-c", "%a", "/root/.kube/config"])
     assert stat_out.strip() == b"600"
 
-    # git shim blocks `git add -A`.
-    rc, _, stderr = _exec_under_env(container, "git add -A", check=False)
-    assert rc != 0
-    assert b"BLOCKED" in stderr
+    # git shim matrix: verify block vs passthrough decisions for a
+    # representative set of commands. Runs in a real repo so passthrough
+    # cases (git log, git status) succeed instead of failing on missing
+    # HEAD. Block-expected cases short-circuit before real git runs so
+    # they don't depend on repo state.
+    _exec(
+        container,
+        [
+            "bash",
+            "-c",
+            "cd /tmp && git init -q shim-test && cd shim-test && "
+            "git -c user.email=t@e.co -c user.name=t commit -q --allow-empty -m initial",
+        ],
+    )
+    # (command, should_block)
+    git_shim_tests = [
+        ("git add -A", True),
+        ("git add .", True),
+        ("git add --all", True),
+        ("git commit --amend --allow-empty -m x", True),
+        ("git stash", True),
+        ("git --version", False),
+        ("git status", False),
+        ("git log --oneline -1", False),
+    ]
+    for cmd, should_block in git_shim_tests:
+        rc, _, stderr = _exec_under_env(container, cmd, workdir="/tmp/shim-test", check=False)
+        stderr_str = stderr.decode(errors="replace")
+        if should_block:
+            assert rc != 0, f"[{impl}] {cmd!r} should have been blocked but exited 0\nstderr: {stderr_str}"
+            assert b"BLOCKED" in stderr, f"[{impl}] {cmd!r} expected BLOCKED in stderr\nstderr: {stderr_str}"
+        else:
+            assert rc == 0, f"[{impl}] {cmd!r} should passthrough but exited {rc}\nstderr: {stderr_str}"
+            assert b"BLOCKED" not in stderr, f"[{impl}] {cmd!r} unexpectedly BLOCKED\nstderr: {stderr_str}"
 
     # Bazel build over the staged workspace.
     _exec_under_env(container, "bazelisk build //:hello", workdir="/project")

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_profile.yaml
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_profile.yaml
@@ -27,9 +27,14 @@ startup_env_script: devinfra/secrets/web_env.sh
 
 idle_watchdog: false
 
-# Keep the git shim exercised in the existing test (block_add_all=true).
+# Exercise the full git_shim surface in the container E2E matrix.
+# pre-commit (which invokes git stash internally) is not run in this test,
+# so block_stash=true here is safe. CLI profile leaves block_stash=false for
+# this reason — see profiles/cli/profile.yaml.
 git_shim:
   block_add_all: true
+  block_stash: true
+  block_amend: true
 
 env_exports: |
   export E2E_TEST_MARKER=1


### PR DESCRIPTION
## Summary

Adds test coverage and a small client-side refactor around the Rust shim subsystem. **No runtime behavior change** — the daemon already resolved shim argv[0] to an absolute path server-side (PR #1348, `resolve_binary_from_env`). This PR locks that contract with unit tests and expands the container E2E to cover the full git-shim decision matrix.

### Rust unit tests (+ 17 new)

- **`resolve_binary_from_env`** — 7 cases: resolves outside shim dir, skips shim dir even when first on PATH, returns `None` when only in shim, handles canonicalized paths (symlinks), skips non-executable files, ignores empty PATH segments, returns `None` when PATH env is missing.
- **`shim_exec_decision`** — new pure fn extracted from `handle_shim_exec`. 6 cases: git block short-circuits, absolute-path resolution for git/bb, `bazelisk --bazelrc` injection presence/absence, "command not found" when binary only in shim dir.
- **`shim_runtime::decide`** — new fn extracted from `run_shim`. Fake UDS daemon via axum tests `Block`/`Exec`/`Passthrough` on daemon-missing. Also logs the underlying RPC error on Passthrough instead of silently dropping it (STYLE.md: don't swallow errors).

### Container E2E expansion

Replaces the single `git add -A` assertion with a matrix of representative commands:

| Command | Expected |
|---|---|
| `git add -A` / `git add .` / `git add --all` | Block |
| `git commit --amend --allow-empty -m x` | Block |
| `git stash` | Block |
| `git --version` / `git status` / `git log --oneline -1` | Pass through |

Runs in a fresh `/tmp/shim-test` repo so passthrough cases don't hit "not a git repo" on the read-only `/project` mount. Test profile now enables `block_stash` + `block_amend` (safe in E2E — no pre-commit there).

## Test plan

- [x] `bbr test //devinfra/claude/claude_hook/... //devinfra/claude/hook_daemon/session_start/container_e2e:test_container_e2e` — all green on both `python` and `rust` parameterizations ([`f3ffe71c`](https://app.buildbuddy.io/invocation/f3ffe71c-0b08-484d-bcbe-a2866231dd21))

https://claude.ai/code/session_013kEZA6hzAzB7s2rnnHibbk