### PR TITLE
devinfra: wire bbr nix package, remove from claude-hooks wheel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -196,7 +196,6 @@ py_package(
         "proto",
     ],
     deps = [
-        "//devinfra:bbr",
         "//devinfra/claude/hook_daemon:hook_dispatch_lib",
         "//devinfra/claude/hook_daemon:main_lib",
         "//devinfra/claude/hook_daemon:shim_lib",
@@ -210,7 +209,6 @@ py_wheel(
     distribution = "claude_hooks",
     entry_points = {
         "console_scripts": [
-            "bbr = devinfra.bbr:main",
             "claude-hook = devinfra.claude.hook_daemon.hook_dispatch:main",
             "claude-statusline = devinfra.claude.statusline:main",
             "ducktape-precommit = devinfra.precommit.git_hook:main_pre_commit",

--- a/flake.nix
+++ b/flake.nix
@@ -250,6 +250,7 @@
       devToolsCommon = [
         ducktapePkgs.bb
         ducktapePkgs.bbapi
+        ducktapePkgs.bbr
         ducktapePkgs.skills
         # Dev tools
         pkgs.pre-commit

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -65,6 +65,13 @@ in
 {
   inherit ducktape-util;
 
+  bbr = mkWheel {
+    pname = "bbr";
+    description = "bb remote wrapper with repo-level config from devinfra/bbr.json";
+    mainProgram = "bbr";
+    propagatedBuildInputs = with pkgs.python3Packages; [ pygit2 ];
+  };
+
   ducktape = mkWheel {
     pname = "ducktape";
     description = "CLI tools (git-commit-ai, difftree, gmail-archiver)";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,5 +1,9 @@
 {
   "pins": {
+    "bbr": {
+      "url": "https://github.com/agentydragon/ducktape/releases/download/bbr-62d5929da0cf/bbr-0.1.0-py3-none-any.whl",
+      "sha256": "YtWSnaDPTXmwVQu4KZeGkDZ4dp9w+foVYxPhXiOfGzk="
+    },
     "bb": {
       "url": "https://github.com/buildbuddy-io/bazel/releases/download/5.0.339/bazel-5.0.339-linux-x86_64",
       "sha256": "TgfSB1u2oIO519Ew320bvQGBBurJ9hp8xmdyM7QEXCE="


### PR DESCRIPTION
$(cat <<'EOF'
Follow-up to #1356. Now that the `bbr-62d5929da0cf` release exists, wire up the nix packaging and remove the temporary `bbr` entry point from `claude_hooks_wheel`.

## Summary

- `npins/sources.json`: add pin for `bbr-62d5929da0cf` wheel
- `nix/packages/default.nix`: add `bbr` `mkWheel` derivation
- `flake.nix`: add `ducktapePkgs.bbr` to `devToolsCommon` (available in both Python and Rust devshell profiles)
- `BUILD.bazel`: remove `bbr` from `claude_hooks_wheel` entry_points and `claude_hooks_pkg` deps — it now lives exclusively in `bbr_wheel`/`bbr_pkg`

## Test plan

- [ ] Pre-commit (nixfmt/statix) passes — the npins URL is now a real release
- [ ] `nix profile install .#devtools` resolves `bbr` from the dedicated package
- [ ] `bbr` binary available in both devshell profiles after `home-manager switch`
EOF
)