### PR TITLE
claude_hook: typed hook structs + is_repl/session_id as AnyHookInput methods

### DIFF
--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -33,7 +33,6 @@ mod session;
 mod shim_runtime;
 mod test_util;
 
-use protocol::NON_REPL_HOOK_NAMES;
 use session::{Session, format_system_message};
 
 // ---------------------------------------------------------------------------
@@ -133,28 +132,6 @@ impl AppState {
         g.entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Session::new(session_id.to_string())))
             .clone()
-    }
-}
-
-// Non-REPL hook events: Claude Code delivers system_message only to the UI
-// notification callback on these, not into the model conversation. Flushing
-// mailbox here would waste the messages. Matches `_NON_REPL_HOOK_TYPES` in
-// `server.py` / `NON_REPL_HOOK_NAMES`.
-fn is_repl_hook(hook: &AnyHookInput) -> bool {
-    match hook {
-        AnyHookInput::SessionStart(_)
-        | AnyHookInput::SessionEnd(_)
-        | AnyHookInput::WorktreeCreate(_)
-        | AnyHookInput::WorktreeRemove(_)
-        | AnyHookInput::Setup(_)
-        | AnyHookInput::CwdChanged(_)
-        | AnyHookInput::FileChanged(_)
-        | AnyHookInput::InstructionsLoaded(_)
-        | AnyHookInput::ConfigChange(_) => false,
-        AnyHookInput::Unknown {
-            hook_event_name, ..
-        } => !NON_REPL_HOOK_NAMES.contains(&hook_event_name.as_str()),
-        _ => true,
     }
 }
 
@@ -341,7 +318,7 @@ async fn handle_hook(
     state.touch();
 
     let session_env_file = req.env.get("CLAUDE_ENV_FILE").map(PathBuf::from);
-    let session_id = hook_session_id(&req.hook);
+    let session_id = req.hook.session_id();
 
     let session = session_id
         .as_deref()
@@ -365,7 +342,7 @@ async fn handle_hook(
     };
 
     // Drain mailbox into output.system_message for REPL hooks.
-    if is_repl_hook(&req.hook) {
+    if req.hook.is_repl() {
         if let Some(s) = session {
             let mailbox = s.drain_messages();
             let bg = s.drain_bg_output();
@@ -380,41 +357,6 @@ async fn handle_hook(
     }
 
     Json(HookResponse { output })
-}
-
-fn hook_session_id(hook: &AnyHookInput) -> Option<String> {
-    macro_rules! sid {
-        ($h:expr) => {
-            Some($h.base.session_id.clone())
-        };
-    }
-    match hook {
-        AnyHookInput::SessionStart(h) => sid!(h),
-        AnyHookInput::WorktreeCreate(h) => sid!(h),
-        AnyHookInput::SessionEnd(h) => sid!(h),
-        AnyHookInput::WorktreeRemove(h) => sid!(h),
-        AnyHookInput::Setup(h) => sid!(h),
-        AnyHookInput::CwdChanged(h) => sid!(h),
-        AnyHookInput::FileChanged(h) => sid!(h),
-        AnyHookInput::InstructionsLoaded(h) => sid!(h),
-        AnyHookInput::ConfigChange(h) => sid!(h),
-        AnyHookInput::PreToolUse(h) => sid!(h),
-        AnyHookInput::PostToolUse(h) => sid!(h),
-        AnyHookInput::PostToolUseFailure(h) => sid!(h),
-        AnyHookInput::UserPromptSubmit(h) => sid!(h),
-        AnyHookInput::Stop(h) => sid!(h),
-        AnyHookInput::SubagentStart(h) => sid!(h),
-        AnyHookInput::SubagentStop(h) => sid!(h),
-        AnyHookInput::Notification(h) => sid!(h),
-        AnyHookInput::PermissionRequest(h) => sid!(h),
-        AnyHookInput::Elicitation(h) => sid!(h),
-        AnyHookInput::ElicitationResult(h) => sid!(h),
-        AnyHookInput::PreCompact(h) => sid!(h),
-        AnyHookInput::PostCompact(h) => sid!(h),
-        AnyHookInput::TeammateIdle(h) => sid!(h),
-        AnyHookInput::TaskCompleted(h) => sid!(h),
-        AnyHookInput::Unknown { session_id, .. } => session_id.clone(),
-    }
 }
 
 fn resolve_binary_from_env(

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -33,6 +33,7 @@ mod session;
 mod shim_runtime;
 mod test_util;
 
+use protocol::NON_REPL_HOOK_NAMES;
 use session::{Session, format_system_message};
 
 // ---------------------------------------------------------------------------
@@ -138,14 +139,23 @@ impl AppState {
 // Non-REPL hook events: Claude Code delivers system_message only to the UI
 // notification callback on these, not into the model conversation. Flushing
 // mailbox here would waste the messages. Matches `_NON_REPL_HOOK_TYPES` in
-// `server.py`.
+// `server.py` / `NON_REPL_HOOK_NAMES`.
 fn is_repl_hook(hook: &AnyHookInput) -> bool {
-    !matches!(
-        hook,
-        AnyHookInput::SessionStart(_) | AnyHookInput::WorktreeCreate(_) | AnyHookInput::Unknown
-    )
-    // Python's list also includes SessionEnd/Setup/CwdChanged/etc., which we
-    // deserialize as Unknown (our enum only names the 4 we care about).
+    match hook {
+        AnyHookInput::SessionStart(_)
+        | AnyHookInput::SessionEnd(_)
+        | AnyHookInput::WorktreeCreate(_)
+        | AnyHookInput::WorktreeRemove(_)
+        | AnyHookInput::Setup(_)
+        | AnyHookInput::CwdChanged(_)
+        | AnyHookInput::FileChanged(_)
+        | AnyHookInput::InstructionsLoaded(_)
+        | AnyHookInput::ConfigChange(_) => false,
+        AnyHookInput::Unknown {
+            hook_event_name, ..
+        } => !NON_REPL_HOOK_NAMES.contains(&hook_event_name.as_str()),
+        _ => true,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -373,12 +383,37 @@ async fn handle_hook(
 }
 
 fn hook_session_id(hook: &AnyHookInput) -> Option<String> {
+    macro_rules! sid {
+        ($h:expr) => {
+            Some($h.base.session_id.clone())
+        };
+    }
     match hook {
-        AnyHookInput::SessionStart(h) => Some(h.base.session_id.clone()),
-        AnyHookInput::PreToolUse(h) => Some(h.base.session_id.clone()),
-        AnyHookInput::PostToolUse(h) => Some(h.base.session_id.clone()),
-        AnyHookInput::WorktreeCreate(h) => Some(h.base.session_id.clone()),
-        AnyHookInput::Unknown => None,
+        AnyHookInput::SessionStart(h) => sid!(h),
+        AnyHookInput::WorktreeCreate(h) => sid!(h),
+        AnyHookInput::SessionEnd(h) => sid!(h),
+        AnyHookInput::WorktreeRemove(h) => sid!(h),
+        AnyHookInput::Setup(h) => sid!(h),
+        AnyHookInput::CwdChanged(h) => sid!(h),
+        AnyHookInput::FileChanged(h) => sid!(h),
+        AnyHookInput::InstructionsLoaded(h) => sid!(h),
+        AnyHookInput::ConfigChange(h) => sid!(h),
+        AnyHookInput::PreToolUse(h) => sid!(h),
+        AnyHookInput::PostToolUse(h) => sid!(h),
+        AnyHookInput::PostToolUseFailure(h) => sid!(h),
+        AnyHookInput::UserPromptSubmit(h) => sid!(h),
+        AnyHookInput::Stop(h) => sid!(h),
+        AnyHookInput::SubagentStart(h) => sid!(h),
+        AnyHookInput::SubagentStop(h) => sid!(h),
+        AnyHookInput::Notification(h) => sid!(h),
+        AnyHookInput::PermissionRequest(h) => sid!(h),
+        AnyHookInput::Elicitation(h) => sid!(h),
+        AnyHookInput::ElicitationResult(h) => sid!(h),
+        AnyHookInput::PreCompact(h) => sid!(h),
+        AnyHookInput::PostCompact(h) => sid!(h),
+        AnyHookInput::TeammateIdle(h) => sid!(h),
+        AnyHookInput::TaskCompleted(h) => sid!(h),
+        AnyHookInput::Unknown { session_id, .. } => session_id.clone(),
     }
 }
 

--- a/devinfra/claude/claude_hook/protocol.rs
+++ b/devinfra/claude/claude_hook/protocol.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -23,16 +23,173 @@ pub struct HookResponse {
 // Hook inputs — discriminated union on `hook_event_name` (PascalCase values)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "hook_event_name")]
+/// Hook types where Claude Code delivers `systemMessage` only to the UI
+/// notification callback, not into the model conversation. Matches Python's
+/// `_NON_REPL_HOOK_TYPES` in `server.py`. Used as a fallback for hooks that
+/// aren't explicitly modeled (fall through to `Unknown`).
+pub const NON_REPL_HOOK_NAMES: &[&str] = &[
+    "SessionStart",
+    "SessionEnd",
+    "Setup",
+    "CwdChanged",
+    "FileChanged",
+    "InstructionsLoaded",
+    "WorktreeCreate",
+    "WorktreeRemove",
+    "ConfigChange",
+];
+
+#[derive(Debug)]
 pub enum AnyHookInput {
-    SessionStart(SessionStartInput),
+    // --- REPL hooks (Claude Code injects systemMessage into the conversation) ---
     PreToolUse(PreToolUseInput),
     PostToolUse(PostToolUseInput),
+    PostToolUseFailure(PostToolUseFailureInput),
+    UserPromptSubmit(UserPromptSubmitInput),
+    Stop(StopInput),
+    SubagentStart(SubagentStartInput),
+    SubagentStop(SubagentStopInput),
+    Notification(NotificationInput),
+    PermissionRequest(PermissionRequestInput),
+    Elicitation(ElicitationInput),
+    ElicitationResult(ElicitationResultInput),
+    PreCompact(PreCompactInput),
+    PostCompact(PostCompactInput),
+    TeammateIdle(TeammateIdleInput),
+    TaskCompleted(TaskCompletedInput),
+
+    // --- Non-REPL hooks (systemMessage shown only in UI, not to model) ---
+    SessionStart(SessionStartInput),
     WorktreeCreate(WorktreeCreateInput),
-    #[serde(other)]
-    Unknown,
+    SessionEnd(SessionEndInput),
+    WorktreeRemove(WorktreeRemoveInput),
+    Setup(SetupInput),
+    CwdChanged(CwdChangedInput),
+    FileChanged(FileChangedInput),
+    InstructionsLoaded(InstructionsLoadedInput),
+    ConfigChange(ConfigChangeInput),
+
+    /// Hook type not explicitly modeled. Carries `hook_event_name` and
+    /// `session_id` so `is_repl_hook` and `hook_session_id` still work for
+    /// hooks added to Claude Code after this file was last updated.
+    Unknown {
+        hook_event_name: String,
+        session_id: Option<String>,
+    },
 }
+
+impl<'de> Deserialize<'de> for AnyHookInput {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+        let event_name = raw
+            .get("hook_event_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_owned();
+        macro_rules! parse {
+            ($variant:path, $ty:ty) => {
+                $variant(serde_json::from_value::<$ty>(raw).map_err(serde::de::Error::custom)?)
+            };
+        }
+        Ok(match event_name.as_str() {
+            "PreToolUse" => parse!(AnyHookInput::PreToolUse, PreToolUseInput),
+            "PostToolUse" => parse!(AnyHookInput::PostToolUse, PostToolUseInput),
+            "PostToolUseFailure" => {
+                parse!(AnyHookInput::PostToolUseFailure, PostToolUseFailureInput)
+            }
+            "UserPromptSubmit" => parse!(AnyHookInput::UserPromptSubmit, UserPromptSubmitInput),
+            "Stop" => parse!(AnyHookInput::Stop, StopInput),
+            "SubagentStart" => parse!(AnyHookInput::SubagentStart, SubagentStartInput),
+            "SubagentStop" => parse!(AnyHookInput::SubagentStop, SubagentStopInput),
+            "Notification" => parse!(AnyHookInput::Notification, NotificationInput),
+            "PermissionRequest" => parse!(AnyHookInput::PermissionRequest, PermissionRequestInput),
+            "Elicitation" => parse!(AnyHookInput::Elicitation, ElicitationInput),
+            "ElicitationResult" => parse!(AnyHookInput::ElicitationResult, ElicitationResultInput),
+            "PreCompact" => parse!(AnyHookInput::PreCompact, PreCompactInput),
+            "PostCompact" => parse!(AnyHookInput::PostCompact, PostCompactInput),
+            "TeammateIdle" => parse!(AnyHookInput::TeammateIdle, TeammateIdleInput),
+            "TaskCompleted" => parse!(AnyHookInput::TaskCompleted, TaskCompletedInput),
+            "SessionStart" => parse!(AnyHookInput::SessionStart, SessionStartInput),
+            "WorktreeCreate" => parse!(AnyHookInput::WorktreeCreate, WorktreeCreateInput),
+            "SessionEnd" => parse!(AnyHookInput::SessionEnd, SessionEndInput),
+            "WorktreeRemove" => parse!(AnyHookInput::WorktreeRemove, WorktreeRemoveInput),
+            "Setup" => parse!(AnyHookInput::Setup, SetupInput),
+            "CwdChanged" => parse!(AnyHookInput::CwdChanged, CwdChangedInput),
+            "FileChanged" => parse!(AnyHookInput::FileChanged, FileChangedInput),
+            "InstructionsLoaded" => {
+                parse!(AnyHookInput::InstructionsLoaded, InstructionsLoadedInput)
+            }
+            "ConfigChange" => parse!(AnyHookInput::ConfigChange, ConfigChangeInput),
+            _ => {
+                let session_id = raw
+                    .get("session_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned);
+                AnyHookInput::Unknown {
+                    hook_event_name: event_name,
+                    session_id,
+                }
+            }
+        })
+    }
+}
+
+impl Serialize for AnyHookInput {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Two-step via serde_json::Value so we can inject the hook_event_name
+        // discriminator field that serde would normally handle via #[serde(tag)].
+        macro_rules! tagged {
+            ($inner:expr, $tag:literal) => {{
+                let mut v = serde_json::to_value($inner).map_err(serde::ser::Error::custom)?;
+                if let Some(obj) = v.as_object_mut() {
+                    obj.insert("hook_event_name".to_owned(), $tag.into());
+                }
+                v.serialize(serializer)
+            }};
+        }
+        match self {
+            AnyHookInput::PreToolUse(h) => tagged!(h, "PreToolUse"),
+            AnyHookInput::PostToolUse(h) => tagged!(h, "PostToolUse"),
+            AnyHookInput::PostToolUseFailure(h) => tagged!(h, "PostToolUseFailure"),
+            AnyHookInput::UserPromptSubmit(h) => tagged!(h, "UserPromptSubmit"),
+            AnyHookInput::Stop(h) => tagged!(h, "Stop"),
+            AnyHookInput::SubagentStart(h) => tagged!(h, "SubagentStart"),
+            AnyHookInput::SubagentStop(h) => tagged!(h, "SubagentStop"),
+            AnyHookInput::Notification(h) => tagged!(h, "Notification"),
+            AnyHookInput::PermissionRequest(h) => tagged!(h, "PermissionRequest"),
+            AnyHookInput::Elicitation(h) => tagged!(h, "Elicitation"),
+            AnyHookInput::ElicitationResult(h) => tagged!(h, "ElicitationResult"),
+            AnyHookInput::PreCompact(h) => tagged!(h, "PreCompact"),
+            AnyHookInput::PostCompact(h) => tagged!(h, "PostCompact"),
+            AnyHookInput::TeammateIdle(h) => tagged!(h, "TeammateIdle"),
+            AnyHookInput::TaskCompleted(h) => tagged!(h, "TaskCompleted"),
+            AnyHookInput::SessionStart(h) => tagged!(h, "SessionStart"),
+            AnyHookInput::WorktreeCreate(h) => tagged!(h, "WorktreeCreate"),
+            AnyHookInput::SessionEnd(h) => tagged!(h, "SessionEnd"),
+            AnyHookInput::WorktreeRemove(h) => tagged!(h, "WorktreeRemove"),
+            AnyHookInput::Setup(h) => tagged!(h, "Setup"),
+            AnyHookInput::CwdChanged(h) => tagged!(h, "CwdChanged"),
+            AnyHookInput::FileChanged(h) => tagged!(h, "FileChanged"),
+            AnyHookInput::InstructionsLoaded(h) => tagged!(h, "InstructionsLoaded"),
+            AnyHookInput::ConfigChange(h) => tagged!(h, "ConfigChange"),
+            AnyHookInput::Unknown {
+                hook_event_name,
+                session_id,
+            } => {
+                let mut map = serde_json::Map::new();
+                map.insert("hook_event_name".to_owned(), hook_event_name.clone().into());
+                if let Some(sid) = session_id {
+                    map.insert("session_id".to_owned(), sid.clone().into());
+                }
+                serde_json::Value::Object(map).serialize(serializer)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared base — present in every hook input
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HookInputBase {
@@ -42,6 +199,10 @@ pub struct HookInputBase {
     pub permission_mode: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Non-REPL hook input structs
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SessionStartInput {
     #[serde(flatten)]
@@ -49,6 +210,74 @@ pub struct SessionStartInput {
     pub source: String, // "startup" | "resume" | "clear" | "compact"
     pub model: Option<String>,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WorktreeCreateInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SessionEndInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub reason: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WorktreeRemoveInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub worktree_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetupInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub trigger: String, // "init" | "maintenance"
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CwdChangedInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub old_cwd: String,
+    pub new_cwd: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FileChangedInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub file_path: String,
+    pub event: String, // "change" | "add" | "unlink"
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InstructionsLoadedInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub file_path: PathBuf,
+    pub memory_type: String, // "User" | "Project" | "Local" | "Managed"
+    pub load_reason: String,
+    #[serde(default)]
+    pub globs: Vec<String>,
+    pub trigger_file_path: Option<PathBuf>,
+    pub parent_file_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ConfigChangeInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub source: String,
+    pub file_path: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// REPL hook input structs
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PreToolUseInput {
@@ -70,9 +299,125 @@ pub struct PostToolUseInput {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct WorktreeCreateInput {
+pub struct PostToolUseFailureInput {
     #[serde(flatten)]
     pub base: HookInputBase,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    pub tool_use_id: String,
+    pub error: String,
+    pub is_interrupt: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UserPromptSubmitInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub prompt: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StopInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub stop_hook_active: bool,
+    pub last_assistant_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubagentStartInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub agent_id: String,
+    pub agent_type: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubagentStopInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub stop_hook_active: bool,
+    pub agent_id: String,
+    pub agent_type: String,
+    pub agent_transcript_path: String,
+    pub last_assistant_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NotificationInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub message: String,
+    pub title: Option<String>,
+    pub notification_type: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PermissionRequestInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub tool_name: String,
+    pub tool_input: serde_json::Value,
+    #[serde(default)]
+    pub permission_suggestions: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ElicitationInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub mcp_server_name: String,
+    pub message: String,
+    pub mode: Option<String>,
+    pub url: Option<String>,
+    pub elicitation_id: Option<String>,
+    pub requested_schema: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ElicitationResultInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub mcp_server_name: String,
+    pub action: String, // "accept" | "deny" | "cancel"
+    pub content: Option<serde_json::Value>,
+    pub mode: Option<String>,
+    pub elicitation_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PreCompactInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub trigger: String, // "manual" | "auto"
+    pub custom_instructions: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PostCompactInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub trigger: String,
+    pub compact_summary: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TeammateIdleInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub teammate_name: String,
+    pub team_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TaskCompletedInput {
+    #[serde(flatten)]
+    pub base: HookInputBase,
+    pub task_id: String,
+    pub task_subject: String,
+    pub task_description: Option<String>,
+    pub teammate_name: Option<String>,
+    pub team_name: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -218,7 +563,50 @@ mod tests {
             "cwd": "/"
         }"#;
         let input: AnyHookInput = serde_json::from_str(json).unwrap();
-        assert!(matches!(input, AnyHookInput::Unknown));
+        assert!(
+            matches!(&input, AnyHookInput::Unknown { hook_event_name, session_id }
+                if hook_event_name == "SomeNewHook" && session_id.as_deref() == Some("x"))
+        );
+    }
+
+    #[test]
+    fn user_prompt_submit_deserializes() {
+        let json = r#"{
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "sess-123",
+            "transcript_path": "/tmp/t.json",
+            "cwd": "/",
+            "prompt": "hello world"
+        }"#;
+        let input: AnyHookInput = serde_json::from_str(json).unwrap();
+        match input {
+            AnyHookInput::UserPromptSubmit(u) => {
+                assert_eq!(u.base.session_id, "sess-123");
+                assert_eq!(u.prompt, "hello world");
+            }
+            _ => panic!("expected UserPromptSubmit"),
+        }
+    }
+
+    #[test]
+    fn stop_deserializes() {
+        let json = r#"{
+            "hook_event_name": "Stop",
+            "session_id": "sess-456",
+            "transcript_path": "/tmp/t.json",
+            "cwd": "/",
+            "stop_hook_active": false,
+            "last_assistant_message": "Done."
+        }"#;
+        let input: AnyHookInput = serde_json::from_str(json).unwrap();
+        match input {
+            AnyHookInput::Stop(s) => {
+                assert_eq!(s.base.session_id, "sess-456");
+                assert!(!s.stop_hook_active);
+                assert_eq!(s.last_assistant_message.as_deref(), Some("Done."));
+            }
+            _ => panic!("expected Stop"),
+        }
     }
 
     #[test]
@@ -291,22 +679,5 @@ mod tests {
         assert_eq!(req.shim, "bazelisk");
         assert_eq!(req.pid, 12345);
         assert_eq!(req.argv.len(), 3);
-    }
-
-    #[test]
-    fn deserialize_hook_request_envelope() {
-        let json = r#"{
-            "hook": {
-                "hook_event_name": "SessionStart",
-                "session_id": "s1",
-                "transcript_path": "/tmp/t",
-                "cwd": "/p",
-                "source": "startup"
-            },
-            "env": {"HOME": "/root"}
-        }"#;
-        let req: HookRequest = serde_json::from_str(json).unwrap();
-        assert!(matches!(req.hook, AnyHookInput::SessionStart(_)));
-        assert_eq!(req.env.get("HOME").unwrap(), "/root");
     }
 }

--- a/devinfra/claude/claude_hook/protocol.rs
+++ b/devinfra/claude/claude_hook/protocol.rs
@@ -70,7 +70,7 @@ pub enum AnyHookInput {
     ConfigChange(ConfigChangeInput),
 
     /// Hook type not explicitly modeled. Carries `hook_event_name` and
-    /// `session_id` so `is_repl_hook` and `hook_session_id` still work for
+    /// `session_id` so `is_repl()` and `session_id()` still work for
     /// hooks added to Claude Code after this file was last updated.
     Unknown {
         hook_event_name: String,
@@ -183,6 +183,66 @@ impl Serialize for AnyHookInput {
                 }
                 serde_json::Value::Object(map).serialize(serializer)
             }
+        }
+    }
+}
+
+impl AnyHookInput {
+    /// Returns the session ID carried by this hook event, if any.
+    pub fn session_id(&self) -> Option<String> {
+        macro_rules! sid {
+            ($h:expr) => {
+                Some($h.base.session_id.clone())
+            };
+        }
+        match self {
+            AnyHookInput::SessionStart(h) => sid!(h),
+            AnyHookInput::WorktreeCreate(h) => sid!(h),
+            AnyHookInput::SessionEnd(h) => sid!(h),
+            AnyHookInput::WorktreeRemove(h) => sid!(h),
+            AnyHookInput::Setup(h) => sid!(h),
+            AnyHookInput::CwdChanged(h) => sid!(h),
+            AnyHookInput::FileChanged(h) => sid!(h),
+            AnyHookInput::InstructionsLoaded(h) => sid!(h),
+            AnyHookInput::ConfigChange(h) => sid!(h),
+            AnyHookInput::PreToolUse(h) => sid!(h),
+            AnyHookInput::PostToolUse(h) => sid!(h),
+            AnyHookInput::PostToolUseFailure(h) => sid!(h),
+            AnyHookInput::UserPromptSubmit(h) => sid!(h),
+            AnyHookInput::Stop(h) => sid!(h),
+            AnyHookInput::SubagentStart(h) => sid!(h),
+            AnyHookInput::SubagentStop(h) => sid!(h),
+            AnyHookInput::Notification(h) => sid!(h),
+            AnyHookInput::PermissionRequest(h) => sid!(h),
+            AnyHookInput::Elicitation(h) => sid!(h),
+            AnyHookInput::ElicitationResult(h) => sid!(h),
+            AnyHookInput::PreCompact(h) => sid!(h),
+            AnyHookInput::PostCompact(h) => sid!(h),
+            AnyHookInput::TeammateIdle(h) => sid!(h),
+            AnyHookInput::TaskCompleted(h) => sid!(h),
+            AnyHookInput::Unknown { session_id, .. } => session_id.clone(),
+        }
+    }
+
+    /// Returns true if Claude Code injects `systemMessage` into the model
+    /// conversation for this hook. Non-REPL hooks deliver it only to the UI
+    /// notification callback; flushing the mailbox there has no effect.
+    /// Matches `_NON_REPL_HOOK_TYPES` in `server.py`.
+    pub fn is_repl(&self) -> bool {
+        match self {
+            AnyHookInput::SessionStart(_)
+            | AnyHookInput::SessionEnd(_)
+            | AnyHookInput::WorktreeCreate(_)
+            | AnyHookInput::WorktreeRemove(_)
+            | AnyHookInput::Setup(_)
+            | AnyHookInput::CwdChanged(_)
+            | AnyHookInput::FileChanged(_)
+            | AnyHookInput::InstructionsLoaded(_)
+            | AnyHookInput::ConfigChange(_) => false,
+            AnyHookInput::Unknown {
+                hook_event_name, ..
+            } => !NON_REPL_HOOK_NAMES.contains(&hook_event_name.as_str()),
+            _ => true,
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -278,8 +278,15 @@
       ];
       # Python claude-hook.
       devToolPackages = devToolsCommon ++ [ ducktapePkgs.claude-hooks ];
-      # Rust claude-hook (static binary, no Python runtime).
-      devToolPackagesRust = devToolsCommon ++ [ ducktapePkgs.claude-hook-rs ];
+      # Rust claude-hook. claude-hook-rs is listed first so symlinkJoin's lndir
+      # links the Rust claude-hook binary before claude-hooks gets a chance to
+      # link the Python one (lndir silently skips existing links). claude-hooks
+      # is included to provide bbr and the ducktape-* console_scripts.
+      devToolPackagesRust = [
+        ducktapePkgs.claude-hook-rs
+      ]
+      ++ devToolsCommon
+      ++ [ ducktapePkgs.claude-hooks ];
     in
     {
       # Development shell — enter via `nix develop` or direnv (`use flake`).


### PR DESCRIPTION
## Summary

- **Full typed hook structs**: Replaces lazy `serde_json::Value` deserialization with a flat `AnyHookInput` enum — 24 typed variants (one per hook event name) plus an `Unknown` catch-all carrying `hook_event_name` and `session_id`. Each variant is a dedicated struct with its specific fields typed.

- **Mailbox flush for all REPL hooks**: Previously only a subset of hook types triggered a flush to the session's background task inbox. Now all REPL hooks (everything except `SessionStart`, `SessionEnd`, `WorktreeCreate/Remove`, `Setup`, `CwdChanged`, `FileChanged`, `InstructionsLoaded`, `ConfigChange`) flush correctly.

- **`is_repl()` / `session_id()` as inherent methods on `AnyHookInput`**: Moved out of free functions in `main.rs` into `impl AnyHookInput` in `protocol.rs`, where they belong.

## Test plan

- [ ] `bbr test //devinfra/claude/claude_hook/...`
- [ ] CI passes