### PR TITLE
fix(cluster/tf): bump bpg/proxmox provider to ~>0.93.0, fix hotplug ws

### DIFF
--- a/cluster/terraform/main/BUILD.bazel
+++ b/cluster/terraform/main/BUILD.bazel
@@ -8,7 +8,7 @@ exports_files(
 tf_providers_versions(
     name = "providers",
     providers = {
-        "proxmox": "bpg/proxmox:~>0.91.0",
+        "proxmox": "bpg/proxmox:~>0.93.0",
         "hcloud": "hetznercloud/hcloud:~>1.45",
         "talos": "siderolabs/talos:~>0.10.0",
         "kubernetes": "hashicorp/kubernetes:~>2.38.0",

--- a/cluster/terraform/main/proxmox-vms.tf
+++ b/cluster/terraform/main/proxmox-vms.tf
@@ -80,7 +80,7 @@ resource "proxmox_virtual_environment_vm" "wyrm2" {
     usb3 = true
   }
 
-  hotplug = "network,disk,cpu,usb"  # note: memory hotplug requires NUMA
+  hotplug = "network,disk,cpu,usb" # note: memory hotplug requires NUMA
 
   vga {
     type   = "virtio"


### PR DESCRIPTION
hotplug was introduced in bpg/proxmox 0.93.0; ~>0.91.0 doesn't support it, causing //cluster/terraform/main:validate to fail.

Also fix trailing-whitespace before the comment on the hotplug line (two spaces → one), fixing //cluster/terraform/main:format.

https://claude.ai/code/session_01WgEej2fww2xUSmZHsGM5Hu