### PR TITLE
feat(devinfra): extract ducktape-git-hooks wheel from claude-hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,11 @@ jobs:
           - pkg: claude-hooks
             target: //:claude_hooks_wheel
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl
-            tests: //devinfra/claude/... //devinfra/precommit/... //cluster/validation/...
+            tests: //devinfra/claude/...
+          - pkg: ducktape-git-hooks
+            target: //:ducktape_git_hooks_wheel
+            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl
+            tests: //devinfra/precommit/... //cluster/validation/...
           - pkg: claude-hook-rs
             target: //devinfra/claude/claude_hook:claude_hook
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/devinfra/claude/claude_hook/claude_hook

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -176,31 +176,86 @@ py_wheel(
     deps = [":bbr_pkg"],
 )
 
-# Claude hooks wheel - Claude Code session hooks, statusline
+# Git hooks wheel — ducktape-* console scripts, precommit runners, cluster validation.
+# Installed in both Python and Rust devtools so the ducktape-* git hooks are always
+# available regardless of whether the Python or Rust claude-hook daemon is in use.
 py_package(
-    name = "claude_hooks_pkg",
+    name = "ducktape_git_hooks_pkg",
     packages = [
         "cluster.validation",
         "devinfra",
+        "devinfra.precommit",
+        "devinfra.precommit.enforce_bazel_tests",
+        # Generated proto packages.
+        # google.api + proto: reachable via //devinfra/precommit:git_hook (test_tag deps).
+        # google.devtools.build.v1: needed by the daemon BES interceptor at runtime
+        #   (claude-hooks depends on ducktape-git-hooks for proto access).
+        # google.rpc + google.longrunning: imported by proto/cache_pb2.py and
+        #   proto/remote_execution_pb2.py respectively; must be bundled, not external deps.
+        "google.api",
+        "google.devtools.build.v1",
+        "google.longrunning",
+        "google.rpc",
+        "proto",
+    ],
+    deps = [
+        "//devinfra/precommit:git_hook",
+        # Provides google.devtools.build.v1 (not reachable via precommit alone).
+        "//third_party/googleapis:build_v1_py_proto",
+        # Provides google.rpc and google.longrunning (imported by bundled proto files).
+        "//third_party/googleapis:rpc_status_py_proto",
+        "//third_party/googleapis:longrunning_operations_py_proto",
+    ],
+)
+
+py_wheel(
+    name = "ducktape_git_hooks_wheel",
+    distribution = "ducktape_git_hooks",
+    entry_points = {
+        "console_scripts": [
+            "ducktape-precommit = devinfra.precommit.git_hook:main_pre_commit",
+            "ducktape-pytest-main-check = devinfra.precommit.git_hook:main_pytest_main_check",
+            "ducktape-prepare-commit-msg = devinfra.precommit.git_hook:main_prepare_commit_msg",
+            "ducktape-commit-msg = devinfra.precommit.git_hook:main_commit_msg",
+            "ducktape-enforce-bazel-tests = devinfra.precommit.git_hook:main_enforce_bazel_tests",
+        ],
+    },
+    python_requires = ">=3.13",
+    # SYNC: This list must match propagatedBuildInputs in nix/packages/default.nix
+    # (ducktape-git-hooks). When adding a dependency, update BOTH places.
+    requires = [
+        "httpx",
+        "networkx",
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "protobuf>=6.33",
+        "pygit2>=1.14",
+        "pydantic>=2.0",
+        "pyyaml",
+        "ducktape-util",
+    ],
+    version = "0.1.0",
+    visibility = ["//visibility:public"],
+    deps = [":ducktape_git_hooks_pkg"],
+)
+
+# Claude hooks wheel — Claude Code session daemon and statusline.
+# Runtime proto access (for BES interceptor) is provided by ducktape-git-hooks.
+py_package(
+    name = "claude_hooks_pkg",
+    packages = [
         "devinfra.claude",
         "devinfra.claude.claude_api",
         "devinfra.claude.claude_api.hooks",
         "devinfra.claude.hook_daemon",
         "devinfra.claude.hook_daemon.session_start",
         "devinfra.claude.supervisor",
-        "devinfra.precommit",
-        "devinfra.precommit.enforce_bazel_tests",
-        # Generated proto packages for BES interceptor
-        "google.api",
-        "google.devtools.build.v1",
-        "proto",
     ],
     deps = [
         "//devinfra/claude/hook_daemon:hook_dispatch_lib",
         "//devinfra/claude/hook_daemon:main_lib",
         "//devinfra/claude/hook_daemon:shim_lib",
         "//devinfra/claude/statusline:statusline_lib",
-        "//devinfra/precommit:git_hook",
     ],
 )
 
@@ -211,11 +266,6 @@ py_wheel(
         "console_scripts": [
             "claude-hook = devinfra.claude.hook_daemon.hook_dispatch:main",
             "claude-statusline = devinfra.claude.statusline:main",
-            "ducktape-precommit = devinfra.precommit.git_hook:main_pre_commit",
-            "ducktape-pytest-main-check = devinfra.precommit.git_hook:main_pytest_main_check",
-            "ducktape-prepare-commit-msg = devinfra.precommit.git_hook:main_prepare_commit_msg",
-            "ducktape-commit-msg = devinfra.precommit.git_hook:main_commit_msg",
-            "ducktape-enforce-bazel-tests = devinfra.precommit.git_hook:main_enforce_bazel_tests",
         ],
     },
     python_requires = ">=3.13",
@@ -223,8 +273,8 @@ py_wheel(
     # (claude-hooks). The Nix derivation provides these at runtime on NixOS/devShell.
     # When adding a dependency, update BOTH places.
     #
-    # `grpcio` + `protobuf` are required for the BES interceptor that surfaces
-    # the "use `bb remote`" nudge.
+    # `grpcio` + `protobuf` are required for the BES interceptor; proto Python files
+    # (google.*, proto.*) come from the ducktape-git-hooks dep at runtime.
     requires = [
         "anyio",
         "fastapi>=0.115.0",
@@ -232,7 +282,6 @@ py_wheel(
         "grpcio",
         "httpx",
         "mako>=1.3",
-        "networkx",
         "opentelemetry-api",
         "opentelemetry-exporter-otlp-proto-http",
         "opentelemetry-sdk",
@@ -252,6 +301,7 @@ py_wheel(
         "tenacity",
         "uvicorn>=0.30.0",
         "ducktape-util",
+        "ducktape-git-hooks",
     ],
     version = "0.1.0",
     visibility = ["//visibility:public"],

--- a/devinfra/ci/artifacts.py
+++ b/devinfra/ci/artifacts.py
@@ -45,6 +45,7 @@ ARTIFACTS = [
     Artifact(pkg="bbr", filename="bbr-0.1.0-py3-none-any.whl"),
     Artifact(pkg="claude-hooks", filename="claude_hooks-0.1.0-py3-none-any.whl"),
     Artifact(pkg="claude-hook-rs", filename="claude_hook"),
+    Artifact(pkg="ducktape-git-hooks", filename="ducktape_git_hooks-0.1.0-py3-none-any.whl"),
     Artifact(pkg="ducktape-util", filename="ducktape_util-0.1.0-py3-none-any.whl"),
     Artifact(pkg="ducktape", filename="ducktape-0.1.0-py3-none-any.whl"),
     Artifact(pkg="gterm-theme", filename="gterm_theme-0.1.0-py3-none-any.whl"),

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/BUILD.bazel
@@ -16,6 +16,7 @@ pkg_tar(
     testonly = True,
     srcs = [
         "//:claude_hooks_wheel",
+        "//:ducktape_git_hooks_wheel",
         "//util:wheel",
     ],
     package_dir = "/wheel",

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -13,17 +13,29 @@ assertion set. Both implementations must pass the full contract.
 Exercises the real secret-decryption + kubeconfig path end-to-end.
 """
 
+import io
+import json
+import os
+import shlex
 import shutil
+import tarfile
 from collections.abc import Iterator
 from pathlib import Path
 
+import docker
+import docker.models.containers
 import pytest
 import pytest_bazel
 import yaml
 
 from devinfra.claude.env_file import parse_env_null_delimited
-from devinfra.claude.testing import container_e2e
 from util.bazel.runfiles import get_required_path
+from util.oci import OciImage, load_oci_image
+from util.testing.undeclared_outputs import undeclared_outputs_dir
+
+# Wheels + tools (bazelisk, sops, curl) are baked into the e2e_container image
+# via pkg_tar layers / the trixie_e2e apt manifest (see BUILD.bazel).
+_WHEEL_DIR = "/wheel"
 
 # Runfiles paths.
 _TEST_WORKSPACE_MODULE = "_main/devinfra/claude/testdata/test_workspace/MODULE.bazel"
@@ -32,6 +44,7 @@ _COMMON_SH = "_main/devinfra/secrets/_common.sh"
 _WRITE_KUBECONFIG = "_main/devinfra/claude/scripts/write_kubeconfig.py"
 _TEST_PROFILE = "_main/devinfra/claude/hook_daemon/session_start/container_e2e/test_profile.yaml"
 _SECRETS_DIR_MARKER = "_main/devinfra/claude/hook_daemon/testdata/e2e_secrets/test_age.key"
+_RUST_BINARY = "_main/devinfra/claude/claude_hook/claude_hook"
 
 _TEST_SECRET_FILES = [
     "buildbuddy.yaml",
@@ -40,18 +53,61 @@ _TEST_SECRET_FILES = [
     "claude-web-k8s-cert.yaml",
 ]
 
+_E2E = OciImage(
+    "_main/devinfra/claude/hook_daemon/session_start/container_e2e/e2e_container.rloc", "e2e-container:pinned"
+)
+
 _CONTAINER_NAME = "ducktape-container-e2e"
 _SESSION_ID = "container-e2e-test"
 _ENV_FILE = f"/root/.claude/session-env/{_SESSION_ID}/sessionstart-hook-0.sh"
+_SESSION_DIR = f"/root/.claude/session-env/{_SESSION_ID}"
 # Daemon UDS lives under /tmp/claude-hd/<session_id>/ (AF_UNIX 108-byte limit).
 _DAEMON_SOCK = f"/tmp/claude-hd/{_SESSION_ID}/d.sock"
 
 
+def _save_output(impl: str, name: str, content: str) -> None:
+    out_dir = undeclared_outputs_dir() / f"container-e2e-{impl}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / name).write_text(content)
+
+
+def _exec(
+    container: docker.models.containers.Container, cmd: list[str], *, workdir: str | None = None, check: bool = True
+) -> tuple[int, bytes, bytes]:
+    result = container.exec_run(cmd, demux=True, workdir=workdir)
+    stdout, stderr = result.output
+    stdout = stdout or b""
+    stderr = stderr or b""
+    if check:
+        assert result.exit_code == 0, (
+            f"Command failed: {cmd!r}\nexit_code={result.exit_code}\n"
+            f"stdout:\n{stdout.decode(errors='replace')}\nstderr:\n{stderr.decode(errors='replace')}"
+        )
+    return result.exit_code, stdout, stderr
+
+
 def _exec_under_env(
-    c: container_e2e.E2EContainer, shell_cmd: str, *, workdir: str | None = None, check: bool = True
+    container: docker.models.containers.Container, shell_cmd: str, *, workdir: str | None = None, check: bool = True
 ) -> tuple[int, bytes, bytes]:
     """Run a shell command after sourcing the session env file (agent's Bash behavior)."""
-    return c.exec(["bash", "-c", f"source {_ENV_FILE} && {shell_cmd}"], workdir=workdir, check=check)
+    return _exec(container, ["bash", "-c", f"source {_ENV_FILE} && {shell_cmd}"], workdir=workdir, check=check)
+
+
+def _docker_cp(
+    container: docker.models.containers.Container, src_path: str, dest_path: str, *, mode: int = 0o755
+) -> None:
+    """Copy a local file into a running container via put_archive."""
+    dest = Path(dest_path)
+    with Path(src_path).open("rb") as f:
+        data = f.read()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name=dest.name)
+        info.size = len(data)
+        info.mode = mode
+        tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    container.put_archive(str(dest.parent), buf)
 
 
 # ---------------------------------------------------------------------------
@@ -59,14 +115,34 @@ def _exec_under_env(
 # ---------------------------------------------------------------------------
 
 
-def _install_rust(c: container_e2e.E2EContainer) -> None:
-    c.install_rust()
-    # write_kubeconfig.py (bg command) imports yaml; the Rust impl has no
-    # Python runtime deps, so install PyYAML explicitly.
-    c.exec(["pip", "install", "--break-system-packages", "pyyaml"])
+def _install_python_wheel(container: docker.models.containers.Container) -> None:
+    _exec(
+        container,
+        [
+            "pip",
+            "install",
+            "-v",
+            "--break-system-packages",
+            "--find-links",
+            _WHEEL_DIR,
+            f"{_WHEEL_DIR}/ducktape_util-0.1.0-py3-none-any.whl",
+            f"{_WHEEL_DIR}/ducktape_git_hooks-0.1.0-py3-none-any.whl",
+            f"{_WHEEL_DIR}/claude_hooks-0.1.0-py3-none-any.whl",
+        ],
+    )
 
 
-_IMPLS = {"python": container_e2e.E2EContainer.install_python, "rust": _install_rust}
+def _install_rust_binary(container: docker.models.containers.Container) -> None:
+    rust_binary = get_required_path(_RUST_BINARY)
+    _docker_cp(container, str(rust_binary), "/usr/local/bin/claude-hook")
+    # The Rust binary has no Python runtime deps; write_kubeconfig.py
+    # (invoked as a bg command) imports yaml. The Python impl gets PyYAML
+    # transitively via the claude_hooks wheel; the Rust impl must install
+    # it explicitly.
+    _exec(container, ["pip", "install", "--break-system-packages", "pyyaml"])
+
+
+_IMPLS = {"python": _install_python_wheel, "rust": _install_rust_binary}
 
 
 @pytest.fixture(params=list(_IMPLS.keys()))
@@ -119,26 +195,43 @@ def test_age_key() -> str:
 
 
 @pytest.fixture
+def e2e_image() -> str:
+    return load_oci_image(_E2E)
+
+
+@pytest.fixture
 def container(
     impl: str, staged_project: Path, test_age_key: str, e2e_image: str
-) -> Iterator[container_e2e.E2EContainer]:
+) -> Iterator[docker.models.containers.Container]:
     env = {
         "CLAUDE_PROJECT_DIR": "/project",
         "CLAUDE_ENV_FILE": _ENV_FILE,
         "DUCKTAPE_CLAUDE_HOOKS_PROFILE": "profile.yaml",
         "SOPS_AGE_KEY": test_age_key,
     }
-    with container_e2e.run_e2e_container(
+    c = docker.from_env().containers.run(
         e2e_image,
-        f"{_CONTAINER_NAME}-{impl}",
-        env,
-        staged_project,
-        f"container-e2e-{impl}",
-        _SESSION_ID,
-        extra_session_files=["sessionstart-hook-0.sh", "bazelrc"],
-        extra_rust_files=["daemon.pid"],
-    ) as c:
+        command=["sleep", "infinity"],
+        name=f"{_CONTAINER_NAME}-{impl}-{os.getpid()}",
+        environment=env,
+        volumes={str(staged_project): {"bind": "/project", "mode": "ro"}},
+        detach=True,
+    )
+    try:
         yield c
+    finally:
+        _save_output(impl, "container-stdout.log", c.logs(stdout=True, stderr=False).decode(errors="replace"))
+        _save_output(impl, "container-stderr.log", c.logs(stdout=False, stderr=True).decode(errors="replace"))
+        for log_file in ["hook-daemon/daemon.log", "hook-daemon/daemon.err.log", "sessionstart-hook-0.sh", "bazelrc"]:
+            rc, content, _ = _exec(c, ["cat", f"{_SESSION_DIR}/{log_file}"], check=False)
+            if rc == 0:
+                _save_output(impl, log_file.replace("/", "-"), content.decode(errors="replace"))
+        # Rust daemon writes logs under the short session dir.
+        for log_file in ["daemon.log", "daemon.err.log", "daemon.pid"]:
+            rc, content, _ = _exec(c, ["cat", f"/tmp/claude-hd/{_SESSION_ID}/{log_file}"], check=False)
+            if rc == 0:
+                _save_output(impl, f"rust-{log_file}", content.decode(errors="replace"))
+        c.remove(force=True)
 
 
 # ---------------------------------------------------------------------------
@@ -146,16 +239,16 @@ def container(
 # ---------------------------------------------------------------------------
 
 
-def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None:
+def test_container_e2e(impl: str, container: docker.models.containers.Container) -> None:
     """SessionStart contract test, parameterized over python/rust impls."""
     # Install whichever claude-hook impl this run is for.
     _IMPLS[impl](container)
-    container.exec(["which", "claude-hook"])
-    container.exec(["which", "sops"])
-    container.exec(["which", "curl"])
+    _exec(container, ["which", "claude-hook"])
+    _exec(container, ["which", "sops"])
+    _exec(container, ["which", "curl"])
 
     # Run SessionStart.
-    container.send_hook(
+    hook_input = json.dumps(
         {
             "hook_event_name": "SessionStart",
             "session_id": _SESSION_ID,
@@ -166,9 +259,10 @@ def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None
             "model": "claude-sonnet-4-6",
         }
     )
+    _exec(container, ["bash", "-c", f"echo {shlex.quote(hook_input)} | claude-hook"])
 
     # Env file exists.
-    container.exec(["test", "-f", _ENV_FILE])
+    _exec(container, ["test", "-f", _ENV_FILE])
     _, stdout, _ = _exec_under_env(container, "env -0")
     agent_env = parse_env_null_delimited(stdout)
 
@@ -181,7 +275,7 @@ def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None
     assert agent_env["DUCKTAPE_CI_READ_GITHUB_TOKEN"] == "test-fake-ci-read-token"
 
     # Daemon alive on UDS.
-    _, stdout, _ = container.exec(["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
+    _, stdout, _ = _exec(container, ["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
     assert b'"status":"ok"' in stdout
 
     # PATH shims: passthrough.
@@ -189,15 +283,17 @@ def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None
     assert b"git version" in stdout
 
     # Kubeconfig (written by bg command).
-    container.poll_file("/root/.kube/config", timeout=30)
-    _, kubeconfig_raw, _ = container.exec(["cat", "/root/.kube/config"])
+    _exec(
+        container, ["bash", "-c", "for i in $(seq 60); do [ -f /root/.kube/config ] && exit 0; sleep 0.5; done; exit 1"]
+    )
+    _, kubeconfig_raw, _ = _exec(container, ["cat", "/root/.kube/config"])
     kube = yaml.safe_load(kubeconfig_raw)
     assert kube["current-context"] == "claude-code-web"
     user_data = kube["users"][0]["user"]
     assert "client-certificate-data" in user_data
     assert "client-key-data" in user_data
     assert kube["clusters"][0]["cluster"]["server"] == "https://api.allegedly.works"
-    _, stat_out, _ = container.exec(["stat", "-c", "%a", "/root/.kube/config"])
+    _, stat_out, _ = _exec(container, ["stat", "-c", "%a", "/root/.kube/config"])
     assert stat_out.strip() == b"600"
 
     # git shim matrix: verify block vs passthrough decisions for a
@@ -205,13 +301,14 @@ def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None
     # cases (git log, git status) succeed instead of failing on missing
     # HEAD. Block-expected cases short-circuit before real git runs so
     # they don't depend on repo state.
-    container.exec(
+    _exec(
+        container,
         [
             "bash",
             "-c",
             "cd /tmp && git init -q shim-test && cd shim-test && "
             "git -c user.email=t@e.co -c user.name=t commit -q --allow-empty -m initial",
-        ]
+        ],
     )
     # (command, should_block)
     git_shim_tests = [

--- a/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
+++ b/devinfra/claude/hook_daemon/session_start/container_e2e/test_container_e2e.py
@@ -13,29 +13,17 @@ assertion set. Both implementations must pass the full contract.
 Exercises the real secret-decryption + kubeconfig path end-to-end.
 """
 
-import io
-import json
-import os
-import shlex
 import shutil
-import tarfile
 from collections.abc import Iterator
 from pathlib import Path
 
-import docker
-import docker.models.containers
 import pytest
 import pytest_bazel
 import yaml
 
 from devinfra.claude.env_file import parse_env_null_delimited
+from devinfra.claude.testing import container_e2e
 from util.bazel.runfiles import get_required_path
-from util.oci import OciImage, load_oci_image
-from util.testing.undeclared_outputs import undeclared_outputs_dir
-
-# Wheels + tools (bazelisk, sops, curl) are baked into the e2e_container image
-# via pkg_tar layers / the trixie_e2e apt manifest (see BUILD.bazel).
-_WHEEL_DIR = "/wheel"
 
 # Runfiles paths.
 _TEST_WORKSPACE_MODULE = "_main/devinfra/claude/testdata/test_workspace/MODULE.bazel"
@@ -44,7 +32,6 @@ _COMMON_SH = "_main/devinfra/secrets/_common.sh"
 _WRITE_KUBECONFIG = "_main/devinfra/claude/scripts/write_kubeconfig.py"
 _TEST_PROFILE = "_main/devinfra/claude/hook_daemon/session_start/container_e2e/test_profile.yaml"
 _SECRETS_DIR_MARKER = "_main/devinfra/claude/hook_daemon/testdata/e2e_secrets/test_age.key"
-_RUST_BINARY = "_main/devinfra/claude/claude_hook/claude_hook"
 
 _TEST_SECRET_FILES = [
     "buildbuddy.yaml",
@@ -53,61 +40,18 @@ _TEST_SECRET_FILES = [
     "claude-web-k8s-cert.yaml",
 ]
 
-_E2E = OciImage(
-    "_main/devinfra/claude/hook_daemon/session_start/container_e2e/e2e_container.rloc", "e2e-container:pinned"
-)
-
 _CONTAINER_NAME = "ducktape-container-e2e"
 _SESSION_ID = "container-e2e-test"
 _ENV_FILE = f"/root/.claude/session-env/{_SESSION_ID}/sessionstart-hook-0.sh"
-_SESSION_DIR = f"/root/.claude/session-env/{_SESSION_ID}"
 # Daemon UDS lives under /tmp/claude-hd/<session_id>/ (AF_UNIX 108-byte limit).
 _DAEMON_SOCK = f"/tmp/claude-hd/{_SESSION_ID}/d.sock"
 
 
-def _save_output(impl: str, name: str, content: str) -> None:
-    out_dir = undeclared_outputs_dir() / f"container-e2e-{impl}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / name).write_text(content)
-
-
-def _exec(
-    container: docker.models.containers.Container, cmd: list[str], *, workdir: str | None = None, check: bool = True
-) -> tuple[int, bytes, bytes]:
-    result = container.exec_run(cmd, demux=True, workdir=workdir)
-    stdout, stderr = result.output
-    stdout = stdout or b""
-    stderr = stderr or b""
-    if check:
-        assert result.exit_code == 0, (
-            f"Command failed: {cmd!r}\nexit_code={result.exit_code}\n"
-            f"stdout:\n{stdout.decode(errors='replace')}\nstderr:\n{stderr.decode(errors='replace')}"
-        )
-    return result.exit_code, stdout, stderr
-
-
 def _exec_under_env(
-    container: docker.models.containers.Container, shell_cmd: str, *, workdir: str | None = None, check: bool = True
+    c: container_e2e.E2EContainer, shell_cmd: str, *, workdir: str | None = None, check: bool = True
 ) -> tuple[int, bytes, bytes]:
     """Run a shell command after sourcing the session env file (agent's Bash behavior)."""
-    return _exec(container, ["bash", "-c", f"source {_ENV_FILE} && {shell_cmd}"], workdir=workdir, check=check)
-
-
-def _docker_cp(
-    container: docker.models.containers.Container, src_path: str, dest_path: str, *, mode: int = 0o755
-) -> None:
-    """Copy a local file into a running container via put_archive."""
-    dest = Path(dest_path)
-    with Path(src_path).open("rb") as f:
-        data = f.read()
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w") as tar:
-        info = tarfile.TarInfo(name=dest.name)
-        info.size = len(data)
-        info.mode = mode
-        tar.addfile(info, io.BytesIO(data))
-    buf.seek(0)
-    container.put_archive(str(dest.parent), buf)
+    return c.exec(["bash", "-c", f"source {_ENV_FILE} && {shell_cmd}"], workdir=workdir, check=check)
 
 
 # ---------------------------------------------------------------------------
@@ -115,34 +59,14 @@ def _docker_cp(
 # ---------------------------------------------------------------------------
 
 
-def _install_python_wheel(container: docker.models.containers.Container) -> None:
-    _exec(
-        container,
-        [
-            "pip",
-            "install",
-            "-v",
-            "--break-system-packages",
-            "--find-links",
-            _WHEEL_DIR,
-            f"{_WHEEL_DIR}/ducktape_util-0.1.0-py3-none-any.whl",
-            f"{_WHEEL_DIR}/ducktape_git_hooks-0.1.0-py3-none-any.whl",
-            f"{_WHEEL_DIR}/claude_hooks-0.1.0-py3-none-any.whl",
-        ],
-    )
+def _install_rust(c: container_e2e.E2EContainer) -> None:
+    c.install_rust()
+    # write_kubeconfig.py (bg command) imports yaml; the Rust impl has no
+    # Python runtime deps, so install PyYAML explicitly.
+    c.exec(["pip", "install", "--break-system-packages", "pyyaml"])
 
 
-def _install_rust_binary(container: docker.models.containers.Container) -> None:
-    rust_binary = get_required_path(_RUST_BINARY)
-    _docker_cp(container, str(rust_binary), "/usr/local/bin/claude-hook")
-    # The Rust binary has no Python runtime deps; write_kubeconfig.py
-    # (invoked as a bg command) imports yaml. The Python impl gets PyYAML
-    # transitively via the claude_hooks wheel; the Rust impl must install
-    # it explicitly.
-    _exec(container, ["pip", "install", "--break-system-packages", "pyyaml"])
-
-
-_IMPLS = {"python": _install_python_wheel, "rust": _install_rust_binary}
+_IMPLS = {"python": container_e2e.E2EContainer.install_python, "rust": _install_rust}
 
 
 @pytest.fixture(params=list(_IMPLS.keys()))
@@ -195,43 +119,26 @@ def test_age_key() -> str:
 
 
 @pytest.fixture
-def e2e_image() -> str:
-    return load_oci_image(_E2E)
-
-
-@pytest.fixture
 def container(
     impl: str, staged_project: Path, test_age_key: str, e2e_image: str
-) -> Iterator[docker.models.containers.Container]:
+) -> Iterator[container_e2e.E2EContainer]:
     env = {
         "CLAUDE_PROJECT_DIR": "/project",
         "CLAUDE_ENV_FILE": _ENV_FILE,
         "DUCKTAPE_CLAUDE_HOOKS_PROFILE": "profile.yaml",
         "SOPS_AGE_KEY": test_age_key,
     }
-    c = docker.from_env().containers.run(
+    with container_e2e.run_e2e_container(
         e2e_image,
-        command=["sleep", "infinity"],
-        name=f"{_CONTAINER_NAME}-{impl}-{os.getpid()}",
-        environment=env,
-        volumes={str(staged_project): {"bind": "/project", "mode": "ro"}},
-        detach=True,
-    )
-    try:
+        f"{_CONTAINER_NAME}-{impl}",
+        env,
+        staged_project,
+        f"container-e2e-{impl}",
+        _SESSION_ID,
+        extra_session_files=["sessionstart-hook-0.sh", "bazelrc"],
+        extra_rust_files=["daemon.pid"],
+    ) as c:
         yield c
-    finally:
-        _save_output(impl, "container-stdout.log", c.logs(stdout=True, stderr=False).decode(errors="replace"))
-        _save_output(impl, "container-stderr.log", c.logs(stdout=False, stderr=True).decode(errors="replace"))
-        for log_file in ["hook-daemon/daemon.log", "hook-daemon/daemon.err.log", "sessionstart-hook-0.sh", "bazelrc"]:
-            rc, content, _ = _exec(c, ["cat", f"{_SESSION_DIR}/{log_file}"], check=False)
-            if rc == 0:
-                _save_output(impl, log_file.replace("/", "-"), content.decode(errors="replace"))
-        # Rust daemon writes logs under the short session dir.
-        for log_file in ["daemon.log", "daemon.err.log", "daemon.pid"]:
-            rc, content, _ = _exec(c, ["cat", f"/tmp/claude-hd/{_SESSION_ID}/{log_file}"], check=False)
-            if rc == 0:
-                _save_output(impl, f"rust-{log_file}", content.decode(errors="replace"))
-        c.remove(force=True)
 
 
 # ---------------------------------------------------------------------------
@@ -239,16 +146,16 @@ def container(
 # ---------------------------------------------------------------------------
 
 
-def test_container_e2e(impl: str, container: docker.models.containers.Container) -> None:
+def test_container_e2e(impl: str, container: container_e2e.E2EContainer) -> None:
     """SessionStart contract test, parameterized over python/rust impls."""
     # Install whichever claude-hook impl this run is for.
     _IMPLS[impl](container)
-    _exec(container, ["which", "claude-hook"])
-    _exec(container, ["which", "sops"])
-    _exec(container, ["which", "curl"])
+    container.exec(["which", "claude-hook"])
+    container.exec(["which", "sops"])
+    container.exec(["which", "curl"])
 
     # Run SessionStart.
-    hook_input = json.dumps(
+    container.send_hook(
         {
             "hook_event_name": "SessionStart",
             "session_id": _SESSION_ID,
@@ -259,10 +166,9 @@ def test_container_e2e(impl: str, container: docker.models.containers.Container)
             "model": "claude-sonnet-4-6",
         }
     )
-    _exec(container, ["bash", "-c", f"echo {shlex.quote(hook_input)} | claude-hook"])
 
     # Env file exists.
-    _exec(container, ["test", "-f", _ENV_FILE])
+    container.exec(["test", "-f", _ENV_FILE])
     _, stdout, _ = _exec_under_env(container, "env -0")
     agent_env = parse_env_null_delimited(stdout)
 
@@ -275,7 +181,7 @@ def test_container_e2e(impl: str, container: docker.models.containers.Container)
     assert agent_env["DUCKTAPE_CI_READ_GITHUB_TOKEN"] == "test-fake-ci-read-token"
 
     # Daemon alive on UDS.
-    _, stdout, _ = _exec(container, ["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
+    _, stdout, _ = container.exec(["curl", "-sf", "--unix-socket", _DAEMON_SOCK, "http://localhost/health"])
     assert b'"status":"ok"' in stdout
 
     # PATH shims: passthrough.
@@ -283,17 +189,15 @@ def test_container_e2e(impl: str, container: docker.models.containers.Container)
     assert b"git version" in stdout
 
     # Kubeconfig (written by bg command).
-    _exec(
-        container, ["bash", "-c", "for i in $(seq 60); do [ -f /root/.kube/config ] && exit 0; sleep 0.5; done; exit 1"]
-    )
-    _, kubeconfig_raw, _ = _exec(container, ["cat", "/root/.kube/config"])
+    container.poll_file("/root/.kube/config", timeout=30)
+    _, kubeconfig_raw, _ = container.exec(["cat", "/root/.kube/config"])
     kube = yaml.safe_load(kubeconfig_raw)
     assert kube["current-context"] == "claude-code-web"
     user_data = kube["users"][0]["user"]
     assert "client-certificate-data" in user_data
     assert "client-key-data" in user_data
     assert kube["clusters"][0]["cluster"]["server"] == "https://api.allegedly.works"
-    _, stat_out, _ = _exec(container, ["stat", "-c", "%a", "/root/.kube/config"])
+    _, stat_out, _ = container.exec(["stat", "-c", "%a", "/root/.kube/config"])
     assert stat_out.strip() == b"600"
 
     # git shim matrix: verify block vs passthrough decisions for a
@@ -301,14 +205,13 @@ def test_container_e2e(impl: str, container: docker.models.containers.Container)
     # cases (git log, git status) succeed instead of failing on missing
     # HEAD. Block-expected cases short-circuit before real git runs so
     # they don't depend on repo state.
-    _exec(
-        container,
+    container.exec(
         [
             "bash",
             "-c",
             "cd /tmp && git init -q shim-test && cd shim-test && "
             "git -c user.email=t@e.co -c user.name=t commit -q --allow-empty -m initial",
-        ],
+        ]
     )
     # (command, should_block)
     git_shim_tests = [

--- a/devinfra/claude/testing/container_e2e.py
+++ b/devinfra/claude/testing/container_e2e.py
@@ -69,7 +69,10 @@ class E2EContainer:
                 "install",
                 "-q",
                 "--break-system-packages",
+                "--find-links",
+                WHEEL_DIR,
                 f"{WHEEL_DIR}/ducktape_util-0.1.0-py3-none-any.whl",
+                f"{WHEEL_DIR}/ducktape_git_hooks-0.1.0-py3-none-any.whl",
                 f"{WHEEL_DIR}/claude_hooks-0.1.0-py3-none-any.whl",
             ]
         )

--- a/flake.nix
+++ b/flake.nix
@@ -251,6 +251,7 @@
         ducktapePkgs.bb
         ducktapePkgs.bbapi
         ducktapePkgs.bbr
+        ducktapePkgs.ducktape-git-hooks
         ducktapePkgs.skills
         # Dev tools
         pkgs.pre-commit

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -61,9 +61,31 @@ let
     ];
   };
 
+  ducktape-git-hooks = mkWheel {
+    pname = "ducktape-git-hooks";
+    description = "Git hooks: ducktape-precommit, ducktape-commit-msg, cluster validation";
+    mainProgram = "ducktape-precommit";
+    # SYNC: This list must match `requires` in //:ducktape_git_hooks_wheel (BUILD.bazel).
+    # When adding a dependency, update BOTH places.
+    propagatedBuildInputs =
+      with pkgs.python3Packages;
+      [
+        httpx
+        networkx
+        opentelemetry-api
+        opentelemetry-sdk
+        protobuf
+        pygit2
+        pydantic
+        pyyaml
+      ]
+      ++ [ ducktape-util ];
+  };
+
 in
 {
   inherit ducktape-util;
+  inherit ducktape-git-hooks;
 
   bbr = mkWheel {
     pname = "bbr";
@@ -111,10 +133,6 @@ in
     ];
   };
 
-  # NOTE: Installed in BOTH home-manager (home.nix) and devShell (flake.nix).
-  # Both add PYTHONPATH entries. If one is updated but not the other, the stale
-  # version's namespace packages (cluster.validation) shadow the new one,
-  # causing ImportError in ducktape-precommit. Keep both in sync.
   claude-hooks = mkWheel {
     pname = "claude-hooks";
     description = "Claude Code session hooks (statusline, session-start)";
@@ -123,8 +141,8 @@ in
     # The wheel declares pip-level deps; this list provides Nix-level equivalents.
     # When adding a dependency, update BOTH places.
     #
-    # `grpcio` + `protobuf` are required for the BES interceptor that surfaces
-    # the "use `bb remote`" nudge.
+    # `grpcio` + `protobuf` are required for the BES interceptor; the generated
+    # proto Python files (google.*, proto.*) come from ducktape-git-hooks at runtime.
     propagatedBuildInputs =
       with pkgs.python3Packages;
       [
@@ -153,9 +171,9 @@ in
       ]
       ++ [
         ducktape-util
+        ducktape-git-hooks
         pkgs.pre-commit
         pyrage
-        pkgs.python3Packages.networkx
       ];
   };
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -16,6 +16,10 @@
       "url": "https://github.com/agentydragon/ducktape/releases/download/claude-hooks-30e001a3348d/claude_hooks-0.1.0-py3-none-any.whl",
       "sha256": "rujaeLGC3B0FCfoT5opyJo43bNhX3eb8GGxPNGsnvh8="
     },
+    "ducktape-git-hooks": {
+      "url": "https://github.com/agentydragon-agent/ducktape/releases/download/ducktape-git-hooks-cd75f3ab26ef/ducktape_git_hooks-0.1.0-py3-none-any.whl",
+      "sha256": "zXXzqybvZznlx3Kg6VX6KmEgcxN9cK+w79g0EHQoT7o="
+    },
     "ducktape-util": {
       "url": "https://github.com/agentydragon/ducktape/releases/download/ducktape-util-ecf076cb91b5/ducktape_util-0.1.0-py3-none-any.whl",
       "sha256": "7PB2y5G1A3FXBc/0y0OlTEe/ngioKfzwg6Co3Q28aTQ="


### PR DESCRIPTION
Moves the `ducktape-precommit` and related git hook console scripts out of the `claude-hooks` Python wheel into a new `ducktape-git-hooks` wheel. This allows the Rust devtools variant to include `ducktape-git-hooks` (for git hooks) without pulling in the Python `claude-hooks` daemon.

## Changes

- **BUILD.bazel**: add `ducktape_git_hooks_pkg` + `ducktape_git_hooks_wheel` targets; bundle `google.rpc` + `google.longrunning` (imported by bundled proto files); move git hook scripts out of `claude_hooks_pkg`; add `ducktape-git-hooks` to `claude_hooks_wheel` requires
- **nix/packages/default.nix**: add `ducktape-git-hooks` derivation; update `claude-hooks` `propagatedBuildInputs` (remove `networkx`, add `ducktape-git-hooks`)
- **flake.nix**: add `ducktape-git-hooks` to `devToolsCommon` (devShell only, not home-manager)
- **devinfra/ci/artifacts.py**: register `ducktape-git-hooks` as a CI artifact
- **.github/workflows/release.yml**: add `ducktape-git-hooks` build/test/release matrix entry
- **container_e2e**: install `ducktape-git-hooks` wheel alongside `claude-hooks` in E2E test
- **npins/sources.json**: bootstrap pin from fork release (CI will create canonical release after merge)

## Notes

The `npins` entry currently points at a bootstrap release in the `agentydragon-agent` fork. After this merges and `release.yml` creates the canonical `agentydragon/ducktape` release, the pin should be updated via `npins update`.

BAZEL_TEST_INVOCATIONS=buildbuddy:3ad062ba-8d98-48ba-b66b-c0308340ac90

https://claude.ai/code/session_01WgEej2fww2xUSmZHsGM5Hu