### PR TITLE
fix(MODULE.bazel): bump proxmox mirror to 0.93.0 to match cluster/terraform/main constraint

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -92,7 +92,7 @@ tf.download(
         "libvirt": "dmacvicar/libvirt:0.9.3",
         "local": "hashicorp/local:2.5.3",
         "null": "hashicorp/null:3.2.4",
-        "proxmox": "bpg/proxmox:0.91.0",
+        "proxmox": "bpg/proxmox:0.93.0",
         "random": "hashicorp/random:3.7.2",
         "sops": "carlpett/sops:1.4.1",
         "talos": "siderolabs/talos:0.10.1",


### PR DESCRIPTION
The proxmox provider was bumped to ~>0.93.0 in BUILD.bazel (#1362) but the
mirror version in MODULE.bazel was left at 0.91.0, causing tofu validate to
fail for all providers since the mirror couldn't satisfy the constraint.

BAZEL_TEST_INVOCATIONS=buildbuddy:a9161e22-49f2-4171-9b95-5c9db2e4fc10

https://claude.ai/code/session_017AvG3b4zn3HYhEZU3N6WQ2