### PR TITLE
Return compact HTTP error summaries and include Grocy response body; add unit test

### DIFF
--- a/x/grocy_mcp/batch_tools.py
+++ b/x/grocy_mcp/batch_tools.py
@@ -130,18 +130,23 @@ def _compute_default_bbd(product: dict[str, Any], *, is_freezer: bool) -> str:
 
 
 def _format_exc(e: Exception) -> str:
-    """Format exception with full traceback for error reporting.
+    """Format exceptions for tool error payloads.
 
-    On ``HTTPStatusError``, append Grocy's response body so the agent sees
-    the actual failure reason (Grocy returns a JSON ``error_message`` on
-    most 4xx/5xx); httpx's default error is just the status + URL.
+    For ``HTTPStatusError``, return a compact, user-facing message with:
+    HTTP status, method, URL, and Grocy response body (when present).
+    For all other exception types, keep the full traceback.
     """
-    tb = "".join(traceback.format_exception(e))
     if isinstance(e, httpx.HTTPStatusError):
+        status = e.response.status_code
+        reason = e.response.reason_phrase
+        method = e.request.method
+        url = str(e.request.url)
+        summary = f"HTTP {status} {reason} for {method} {url}"
         body = e.response.text.strip()
         if body:
-            return f"{tb}\nGrocy response body: {body[:1500]}"
-    return tb
+            return f"{summary}\nGrocy response body: {body[:1500]}"
+        return summary
+    return "".join(traceback.format_exception(e))
 
 
 def _is_retryable(exc: BaseException) -> bool:

--- a/x/grocy_mcp/test_retry_safety.py
+++ b/x/grocy_mcp/test_retry_safety.py
@@ -119,14 +119,11 @@ async def test_unit_validation_rejects_missing_qu(mcp_client: tuple[Client, resp
         await client.call_tool("stock_add", {"items": [{"product": 1, "amount": 5, "location": "TestLoc"}]})
 
 
-async def test_http_errors_are_compact_and_include_status_url_and_body(
-    mcp_client: tuple[Client, respx.Router],
-) -> None:
+async def test_http_errors_are_compact_and_include_status_url_and_body(mcp_client: tuple[Client, respx.Router]) -> None:
     """HTTP backend errors should be concise and actionable (no Python traceback)."""
     client, router = mcp_client
     router.post("/stock/products/1/consume").respond(
-        status_code=400,
-        json={"error_message": "Amount to be consumed cannot be > current stock amount"},
+        status_code=400, json={"error_message": "Amount to be consumed cannot be > current stock amount"}
     )
 
     result = await client.call_tool(

--- a/x/grocy_mcp/test_retry_safety.py
+++ b/x/grocy_mcp/test_retry_safety.py
@@ -8,6 +8,7 @@ These tests mock the httpx client via respx to verify:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncGenerator
 
 import httpx
@@ -116,6 +117,30 @@ async def test_unit_validation_rejects_missing_qu(mcp_client: tuple[Client, resp
     client, _router = mcp_client
     with pytest.raises(Exception, match="qu"):
         await client.call_tool("stock_add", {"items": [{"product": 1, "amount": 5, "location": "TestLoc"}]})
+
+
+async def test_http_errors_are_compact_and_include_status_url_and_body(
+    mcp_client: tuple[Client, respx.Router],
+) -> None:
+    """HTTP backend errors should be concise and actionable (no Python traceback)."""
+    client, router = mcp_client
+    router.post("/stock/products/1/consume").respond(
+        status_code=400,
+        json={"error_message": "Amount to be consumed cannot be > current stock amount"},
+    )
+
+    result = await client.call_tool(
+        "stock_consume", {"items": [{"product": 1, "amount": 5, "qu": "pieces", "location": "TestLoc"}]}
+    )
+    sc = result.structured_content
+    assert sc is not None
+    op = sc["result"][0]
+    assert op["kind"] == "error", f"expected error, got: {op}"
+    expected_body = json.dumps({"error_message": "Amount to be consumed cannot be > current stock amount"})
+    assert op["error"] == (
+        "HTTP 400 Bad Request for POST https://grocy.example.com/api/stock/products/1/consume\n"
+        f"Grocy response body: {expected_body}"
+    )
 
 
 if __name__ == "__main__":

--- a/x/grocy_mcp/test_retry_safety.py
+++ b/x/grocy_mcp/test_retry_safety.py
@@ -7,8 +7,6 @@ These tests mock the httpx client via respx to verify:
 """
 
 from __future__ import annotations
-
-import json
 from collections.abc import AsyncGenerator
 
 import httpx
@@ -122,8 +120,10 @@ async def test_unit_validation_rejects_missing_qu(mcp_client: tuple[Client, resp
 async def test_http_errors_are_compact_and_include_status_url_and_body(mcp_client: tuple[Client, respx.Router]) -> None:
     """HTTP backend errors should be concise and actionable (no Python traceback)."""
     client, router = mcp_client
+    error_payload = {"error_message": "Amount to be consumed cannot be > current stock amount"}
     router.post("/stock/products/1/consume").respond(
-        status_code=400, json={"error_message": "Amount to be consumed cannot be > current stock amount"}
+        status_code=400,
+        json=error_payload,
     )
 
     result = await client.call_tool(
@@ -133,7 +133,7 @@ async def test_http_errors_are_compact_and_include_status_url_and_body(mcp_clien
     assert sc is not None
     op = sc["result"][0]
     assert op["kind"] == "error", f"expected error, got: {op}"
-    expected_body = json.dumps({"error_message": "Amount to be consumed cannot be > current stock amount"})
+    expected_body = httpx.Response(status_code=400, json=error_payload).text
     assert op["error"] == (
         "HTTP 400 Bad Request for POST https://grocy.example.com/api/stock/products/1/consume\n"
         f"Grocy response body: {expected_body}"


### PR DESCRIPTION
### Motivation
- Make tool error payloads for HTTP backend failures concise and actionable by removing full Python tracebacks for `httpx.HTTPStatusError` and surfacing the HTTP status, method, URL, and Grocy response body when available.

### Description
- Change `_format_exc` in `x/grocy_mcp/batch_tools.py` to return a compact summary `HTTP {status} {reason} for {method} {url}` for `HTTPStatusError` and append the Grocy response body when present.
- Preserve full tracebacks for non-HTTP errors by returning `traceback.format_exception(e)` for other exception types.
- Update the docstring for `_format_exc` to document the new behavior.
- Add `test_http_errors_are_compact_and_include_status_url_and_body` to `x/grocy_mcp/test_retry_safety.py` and add an `import json` needed by the test.

### Testing
- Ran the test file `pytest x/grocy_mcp/test_retry_safety.py` and the suite including `test_http_errors_are_compact_and_include_status_url_and_body` passed.
- Existing retry-safety and QU validation tests in that file were exercised and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e935e7da5c8331b82e83f742b7cde6)