### PR TITLE
Add Study Casino: habit-tracking PWA with cross-device sync

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -88,6 +88,11 @@ jobs:
               test_target: "//x/authentik_mcp_poc/...",
             }
           - { image: "//x/grocy_mcp:server_image", image_name: grocy-mcp, test_target: "//x/grocy_mcp/..." }
+          - {
+              image: "//x/auragon_study_casino:image",
+              image_name: study-casino,
+              test_target: "//x/auragon_study_casino/...",
+            }
           # Untested images: always-push if content changed. Explicit
           # `test_target: ""` so the `matrix.test_target != ''` check on
           # the test step evaluates the same as on test-gated rows —

--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -35,3 +35,4 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, authentik-mcp-poc-backend]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, sdr]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, adsb]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, study-casino]]

--- a/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
@@ -1,0 +1,39 @@
+version: 1
+metadata:
+  name: SSO - Study Casino
+  labels:
+    blueprints.goauthentik.io/description: "Study Casino proxy provider, application, and outpost"
+
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    id: study-casino-provider
+    state: present
+    identifiers:
+      name: study-casino
+    attrs:
+      external_host: "https://casino.allegedly.works"
+      internal_host: "http://study-casino.study-casino.svc.cluster.local:8080"
+      mode: proxy
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: "days=30"
+
+  - model: authentik_core.application
+    id: study-casino-app
+    state: present
+    identifiers:
+      slug: study-casino
+    attrs:
+      name: Study Casino
+      provider: !KeyOf study-casino-provider
+      meta_description: "Habit-tracking casino (personal)"
+      meta_launch_url: "https://casino.allegedly.works"
+      open_in_new_tab: true
+
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !KeyOf study-casino-app
+      group: !Find [authentik_core.group, [name, authentik Admins]]
+      order: 0

--- a/cluster/k8s/authentik/app/kustomization.yaml
+++ b/cluster/k8s/authentik/app/kustomization.yaml
@@ -28,4 +28,5 @@ configMapGenerator:
       - blueprints/claude-code-airlock-oauth2.yaml
       - blueprints/sdr-sso.yaml
       - blueprints/adsb-sso.yaml
+      - blueprints/study-casino-sso.yaml
     namespace: authentik

--- a/cluster/k8s/authentik/proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik/proxy-routes/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - authentik-mcp-poc-backend-httproute.yaml
   - sdr-httproute.yaml
   - adsb-httproute.yaml
+  - study-casino-httproute.yaml

--- a/cluster/k8s/authentik/proxy-routes/study-casino-httproute.yaml
+++ b/cluster/k8s/authentik/proxy-routes/study-casino-httproute.yaml
@@ -1,0 +1,18 @@
+# HTTPRoute for Study Casino via the shared embedded Authentik proxy outpost.
+# Traffic: Gateway → outpost (auth) → study-casino.study-casino.svc:8080.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: study-casino
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "casino.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -40,3 +40,5 @@ resources:
   - kubernetes-mcp-server-image-policy.yaml
   - rtl-tcp-image-repository.yaml
   - rtl-tcp-image-policy.yaml
+  - study-casino-image-repository.yaml
+  - study-casino-image-policy.yaml

--- a/cluster/k8s/flux-image-automation-ghcr/study-casino-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/study-casino-image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: study-casino
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: study-casino
+  filterTags:
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/study-casino-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/study-casino-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: study-casino
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/study-casino
+  interval: 5m

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -76,6 +76,9 @@ spec:
       name: tana-mcp-facade
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
+      name: study-casino
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
       name: tana-token-broker
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -252,3 +252,7 @@ resources:
 
   # --- sdr ---
   - sdr/flux-kustomization.yaml
+
+  # --- study-casino ---
+  - study-casino/namespace/flux-kustomization.yaml
+  - study-casino/app/flux-kustomization.yaml

--- a/cluster/k8s/study-casino/app/deployment.yaml
+++ b/cluster/k8s/study-casino/app/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: study-casino
+  namespace: study-casino
+  labels:
+    app.kubernetes.io/name: study-casino
+  annotations:
+    description: "Single-user habit-tracking casino app. Serves PWA + /state JSON store behind Authentik outpost forward-auth."
+spec:
+  # Single replica because the PVC is RWO and SQLite WAL doesn't tolerate
+  # concurrent writers across processes.
+  replicas: 1
+  strategy:
+    # Recreate instead of RollingUpdate so the old pod releases the PVC
+    # before the new one tries to mount it.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: study-casino
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: study-casino
+    spec:
+      # Don't auto-inject `<SERVICE>_PORT=tcp://...` env vars. The same-namespace
+      # `study-casino` Service would inject `STUDY_CASINO_PORT=tcp://...`, which
+      # collides with the `port: int` field on Settings (env_prefix
+      # `STUDY_CASINO_`) and crashes pydantic-settings on startup.
+      enableServiceLinks: false
+      containers:
+        - name: app
+          image: ghcr.io/agentydragon/study-casino:devel-20260424030000-0000000 # {"$imagepolicy": "flux-system:study-casino"}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: STUDY_CASINO_DATA_DIR
+              value: /data
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "25m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: study-casino-data

--- a/cluster/k8s/study-casino/app/flux-kustomization.yaml
+++ b/cluster/k8s/study-casino/app/flux-kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: study-casino
+  namespace: flux-system
+spec:
+  suspend: false
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/study-casino/app
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: study-casino
+      namespace: study-casino
+  dependsOn:
+    - name: gateway
+    - name: study-casino-namespace

--- a/cluster/k8s/study-casino/app/kustomization.yaml
+++ b/cluster/k8s/study-casino/app/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Namespace is owned by the sibling `namespace/` Kustomization (layer 1).
+# This `app/` Kustomization is layer 2 and fills the namespace with the
+# runtime objects.
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/cluster/k8s/study-casino/app/pvc.yaml
+++ b/cluster/k8s/study-casino/app/pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: study-casino-data
+  namespace: study-casino
+  annotations:
+    description: "SQLite state.db for the Study Casino backend."
+spec:
+  accessModes:
+    - ReadWriteOnce
+  # local-path is fine — state is a tiny JSON blob, single-replica app, and
+  # this data is hobby-grade: losing it just resets my casino credits. No
+  # cross-region replication needed.
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 128Mi

--- a/cluster/k8s/study-casino/app/service.yaml
+++ b/cluster/k8s/study-casino/app/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: study-casino
+  namespace: study-casino
+spec:
+  selector:
+    app.kubernetes.io/name: study-casino
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/cluster/k8s/study-casino/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/study-casino/namespace/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: study-casino-namespace
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/study-casino/namespace
+  prune: false
+  wait: true

--- a/cluster/k8s/study-casino/namespace/kustomization.yaml
+++ b/cluster/k8s/study-casino/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/k8s/study-casino/namespace/namespace.yaml
+++ b/cluster/k8s/study-casino/namespace/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: study-casino
+  labels:
+    name: study-casino
+    # Single-pod personal app; opt out of Goldilocks/VPA recommendations.
+    goldilocks.fairwinds.com/enabled: "false"

--- a/devinfra/docs/bb_bazelrc_startup.md
+++ b/devinfra/docs/bb_bazelrc_startup.md
@@ -1,0 +1,134 @@
+# `bb build` silently drops startup directives from bazelrc
+
+## TL;DR
+
+`bb build` / `bb test` (the direct-local path, not `bb remote`) invokes Bazel with
+`--nohome_rc --noworkspace_rc --nosystem_rc` — disabling **every** implicit
+bazelrc source. `bb` re-extracts command-level directives (`common`, `build`,
+`test`, …) from those files and inlines them as command-line flags, **but it does
+not forward `startup` directives.** The only way to make a `startup` directive
+survive `bb` is to pass the bazelrc explicitly via `--bazelrc=<path>`, which
+Bazel reads in full (including startup lines).
+
+This is a BuildBuddy CLI behavior — not something we configure. The matching
+`bb remote` behavior is in <bb_remote_internals.md>; this doc covers the
+local-Bazel path that trips people up.
+
+## What the strace looks like
+
+`bb version` resolves bazel and invokes it directly with:
+
+```
+execve(".../bazelisk/downloads/.../bin/bazel",
+  [".../bin/bazel",
+   "--nohome_rc", "--noworkspace_rc", "--nosystem_rc",
+   "version",
+   "--enable_bzlmod",
+   "--lockfile_mode=off",
+   "--@rules_python//python/config_settings:...",
+   "--tool_tag=buildbuddy-cli-5.0.339", ...])
+```
+
+Notice:
+
+- `--nohome_rc --noworkspace_rc --nosystem_rc` are _startup_ flags (before the
+  subcommand). Bazel reads **no** implicit rc.
+- `--enable_bzlmod`, `--lockfile_mode=off`, etc. come _after_ the subcommand.
+  `bb` extracted these from workspace `.bazelrc` `common` lines and re-emitted
+  them as command-level flags.
+- **No `--host_jvm_args=...` anywhere.** Startup directives like
+  `startup --host_jvm_args=-Xmx4g` do not make it through.
+
+## What this breaks
+
+### JVM trust store (the Claude-session case)
+
+Bazel's embedded JDK ships with its own `cacerts` (231 certs) that does **not**
+include Anthropic's TLS-inspection CA. The system JDK cacerts at
+`/etc/ssl/certs/java/cacerts` (305 certs) does. The claude-hook session-start
+writes a session bazelrc with:
+
+```
+startup --host_jvm_args=-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+```
+
+The `bazel`/`bazelisk` shims at `<session_dir>/bin/{bazel,bazelisk}` ask the
+daemon (`/shim-exec`) to inject `--bazelrc=<session-rc>` into argv, and Bazel
+honors it. So direct `bazelisk build //…` works.
+
+`bb`/`bbr` shims hit a different `/shim-exec` branch that does **not** inject
+`--bazelrc`. bb then runs bazel with `--no*_rc`, bazel uses the embedded JDK's
+cacerts, and any bzlmod fetch from bcr.bazel.build fails with
+`PKIX path building failed` as soon as it routes through the TLS-inspection
+proxy (i.e., in Anthropic Claude Code sessions).
+
+See <../claude/claude_hook/main.rs> function `shim_exec_decision` line ~508 —
+the bazel/bazelisk branch injects, the bb/bbr fall-through doesn't.
+
+### Anything else that relies on startup options from a bazelrc
+
+Same failure class: `--host_jvm_args=-Xmx…`, `--output_base`,
+`--output_user_root`, `--server_javabase`, `--max_idle_secs`, etc. If it's
+written as `startup --foo` in home/workspace/system rc, `bb build` silently
+drops it.
+
+## Workarounds
+
+**Per-invocation**: `bb --bazelrc=<path> build //target …`. `bb` forwards the
+explicit `--bazelrc` to bazel verbatim, bazel reads the file in full. For
+Claude sessions:
+
+```bash
+bb --bazelrc="$HOME/.claude/session-env/$(
+  ps aux | grep hook_daemon | grep -v grep |
+  grep -oP '(?<=--sock /tmp/claude-hd/)[^/]+'
+)/bazelrc" build //target
+```
+
+**Or fix the shim once** — extend the `bazelisk | bazel` match in
+`devinfra/claude/claude_hook/main.rs` (`shim_exec_decision`) to also match
+`bb` and `bbr`:
+
+```rust
+"bazelisk" | "bazel" | "bb" | "bbr" => {
+    let mut argv = req.argv;
+    if bazelrc_path.exists() {
+        argv.insert(1, format!("--bazelrc={}", bazelrc_path.display()));
+    }
+    resolve_execve(&req.shim, argv, shim_dir, &req.env)
+}
+```
+
+`bb` accepts `--bazelrc=<path>` as a startup flag (empirically verified).
+`bbr` is `bb remote` under the hood and accepts the same flag; it just never
+needs it today because `bb remote` bypasses all local rc handling anyway
+(see <bb_remote_internals.md>).
+
+## Why `bb` does this at all
+
+BuildBuddy's CLI has its own rc parser so it can peek at the workspace
+`.bazelrc` for plugin configuration, BES backend defaults, and auto-config
+decoration (`--config=buildbuddy_bes_backend` etc.). It passes `--no*_rc` to
+Bazel to prevent double-loading. The design assumes startup directives live
+in the _user's_ home rc or the workspace rc; it doesn't anticipate a
+third-party session bazelrc that the user has no opportunity to "merge"
+into workspace rc.
+
+## Verifying the behavior
+
+Minimal repro, outside a Claude session:
+
+```bash
+# Put something observable in workspace .bazelrc:
+echo 'startup --host_jvm_args=-Dclaude.canary=yes' >> /home/user/ducktape/.bazelrc
+
+# Run through direct bazelisk (shim injection path):
+bazelisk info server_pid
+ps -o args= -p $(bazelisk info server_pid) | grep -c claude.canary   # 1
+
+# Run through bb:
+bb info server_pid
+ps -o args= -p $(bb info server_pid) | grep -c claude.canary         # 0
+```
+
+(Remove the test line after.)

--- a/devinfra/docs/bb_remote_internals.md
+++ b/devinfra/docs/bb_remote_internals.md
@@ -29,7 +29,11 @@ through literally to the runner.
 > `--nohome_rc --noworkspace_rc --nosystem_rc`. The "no longer being read"
 > warning from Bazel is triggered by these `--no*_rc` flags — Bazel's legacy
 > transition check (`option_processor.cc`) sees that `.bazelrc` exists but isn't
-> in the read set and warns. Harmless — `bb` already consumed those files.
+> in the read set and warns. Mostly harmless — `bb` already inlined
+> command-level directives — but **`startup` directives are silently dropped**,
+> which bites anyone relying on `startup --host_jvm_args=…` from a bazelrc
+> (notably Claude sessions, where the session-installed trust store never
+> loads). Workaround + proper shim fix in <bb_bazelrc_startup.md>.
 
 **bb remote flags** (partial list): `--runner_exec_properties`,
 `--run_from_commit`, `--run_from_branch`, `--remote_run_header`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,22 @@ importers:
         specifier: ^2.1.1
         version: 2.1.9(@types/node@24.12.2)(jsdom@25.0.1)(lightningcss@1.32.0)
 
+  x/auragon_study_casino/frontend:
+    dependencies:
+      idb-keyval:
+        specifier: ^6.2.1
+        version: 6.2.2
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      esbuild:
+        specifier: '>=0.21.0'
+        version: 0.28.0
+
   x/rspcache/admin_ui: {}
 
 packages:
@@ -998,89 +1014,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1202,30 +1234,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
@@ -1325,30 +1362,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -1461,24 +1503,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
     resolution: {integrity: sha512-E199LPijo98yrLjPCmETx8EF43sZf9t3guSrLee/ej1rCCc3zDVTR4xFfN9BRAapGVl7/8hYqbbiQPTkv73kUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA==}
@@ -1543,66 +1589,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2048,24 +2107,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2292,41 +2355,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2591,6 +2662,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -3700,6 +3772,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -4059,24 +4134,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -9830,6 +9909,8 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.9):
     dependencies:
       postcss: 8.5.9
+
+  idb-keyval@6.2.2: {}
 
   ieee754@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "x/agent_server/web"
+  - "x/auragon_study_casino/frontend"
   - "airlock/frontend"
   - "airlock/openclaw"
   - "third_party/mcporter"

--- a/x/auragon_study_casino/AGENTS.md
+++ b/x/auragon_study_casino/AGENTS.md
@@ -1,0 +1,1 @@
+@README.md

--- a/x/auragon_study_casino/BUILD.bazel
+++ b/x/auragon_study_casino/BUILD.bazel
@@ -1,0 +1,96 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "config",
+    srcs = ["config.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pydantic_settings",
+    ],
+)
+
+py_library(
+    name = "storage",
+    srcs = ["storage.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "app",
+    srcs = ["app.py"],
+    data = ["//x/auragon_study_casino/frontend:bundle"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        ":storage",
+        "@pypi//fastapi",
+        "@pypi//uvicorn",
+    ],
+)
+
+py_binary(
+    name = "server",
+    main_module = "x.auragon_study_casino.app",
+    visibility = ["//visibility:public"],
+    deps = [":app"],
+)
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+py_test(
+    name = "test_storage",
+    srcs = ["test_storage.py"],
+    deps = [
+        ":storage",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_app",
+    srcs = ["test_app.py"],
+    deps = [
+        ":app",
+        "@pypi//fastapi",
+        "@pypi//httpx",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+# ── OCI image ─────────────────────────────────────────────────────────────────
+
+aspect_py_binary(
+    name = "server_bin",
+    main = "app.py",
+    deps = [":app"],
+)
+
+py_image_layer(
+    name = "server_layers",
+    binary = ":server_bin",
+    group = "1000",
+    owner = "1000",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("server_bin"),
+    env = py_image_env(binary_name = "server_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [":server_layers"],
+    user = "1000:1000",
+    visibility = ["//visibility:public"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["study-casino:latest"],
+)

--- a/x/auragon_study_casino/CLAUDE.md
+++ b/x/auragon_study_casino/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/x/auragon_study_casino/README.md
+++ b/x/auragon_study_casino/README.md
@@ -1,0 +1,64 @@
+# auragon_study_casino
+
+Single-user habit-tracking "casino" — study for a session, earn credits,
+spend credits on self-chosen prizes. Frontend is a React PWA installable
+on Windows (Edge/Chrome) and iPhone (Safari → Add to Home Screen).
+
+Lives at <https://casino.allegedly.works>.
+
+## Layout
+
+| Path                                   | What it is                                             |
+| -------------------------------------- | ------------------------------------------------------ |
+| `app.py`                               | FastAPI backend: `/state` GET/PUT + static PWA mount   |
+| `config.py`                            | Pydantic settings (DATA_DIR, host, port)               |
+| `storage.py`                           | SQLite state store with content-addressed ETag         |
+| `test_app.py`, `test_storage.py`       | pytest smoke tests                                     |
+| `frontend/src/study_casino.jsx`        | The React component (originally a claude.ai artifact)  |
+| `frontend/src/storage.js`              | Offline-first state sync (IndexedDB + backend PUT)     |
+| `frontend/src/main.jsx`                | Entry — renders into `#root`, registers service worker |
+| `frontend/index.html`                  | App shell (manifest link, theme color, apple-\* meta)  |
+| `frontend/manifest.webmanifest`        | PWA manifest                                           |
+| `frontend/sw.js`                       | Service worker (cache app shell, network-only /state)  |
+| `frontend/icon.svg`                    | App icon                                               |
+| `frontend/esbuild.config.mjs`          | Production bundler config                              |
+| `BUILD.bazel` / `frontend/BUILD.bazel` | Bazel wiring                                           |
+
+## Auth
+
+Forward-auth via Authentik's embedded proxy outpost. The backend reads
+`X-Authentik-Username` purely for logging; there is no per-user scoping
+because this is a single-user app. See
+`cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml` for the
+proxy provider, and
+`cluster/k8s/authentik/proxy-routes/study-casino-httproute.yaml` for the
+public hostname route.
+
+## State sync
+
+The frontend writes to IndexedDB immediately for snappy UX, then pushes
+to the backend's `PUT /state` with an `If-Match` ETag. On 412 (another
+device wrote since our last read) the frontend pulls the remote copy and
+reloads — "last device to edit wins", which is the right trade-off for
+a single user with two devices and no expectation of simultaneous edits.
+
+The service worker serves the app shell offline but is configured to
+bypass the cache for `/state` so a stale GET can't defeat cross-device
+sync.
+
+## Build
+
+```bash
+bbr test //x/auragon_study_casino/...
+bbr build //x/auragon_study_casino:image
+```
+
+Local dev (requires node_modules linked via Bazel):
+
+```bash
+# Iterate on the frontend, auto-rebuild:
+cd x/auragon_study_casino/frontend && node esbuild.config.mjs dist --watch
+
+# Run the backend against the local dist:
+bb run --remote_executor="" //x/auragon_study_casino:server
+```

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -1,0 +1,88 @@
+"""Study Casino backend.
+
+Serves a React PWA from `frontend/dist/` and exposes a GET/PUT `/state` endpoint
+for cross-device sync of the app's state blob. Sits behind an Authentik proxy
+outpost (forward-auth mode); does not re-validate the JWT. The outpost's
+`X-Authentik-Username` header is logged for observability only — since this is
+a single-user app there is no per-user scoping.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import uvicorn
+from fastapi import FastAPI, Header, HTTPException, Request, Response
+from fastapi.staticfiles import StaticFiles
+
+from x.auragon_study_casino.config import Settings
+from x.auragon_study_casino.storage import StateStore
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(settings: Settings) -> FastAPI:
+    store = StateStore(settings.data_dir / "state.db")
+    frontend_dist = settings.frontend_dist_dir or (Path(__file__).parent / "frontend" / "dist")
+
+    app = FastAPI(title="Study Casino", docs_url=None, redoc_url=None)
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/state")
+    def get_state(request: Request, x_authentik_username: Annotated[str | None, Header()] = None) -> Response:
+        record = store.load()
+        if record is None:
+            # First run: 200 with empty object so the frontend just starts fresh
+            # without needing to special-case 404.
+            return Response(
+                content=b"{}", media_type="application/json", headers={"ETag": '"empty"', "Cache-Control": "no-store"}
+            )
+        return Response(
+            content=record.blob,
+            media_type="application/json",
+            headers={"ETag": record.etag, "Cache-Control": "no-store"},
+        )
+
+    @app.put("/state")
+    async def put_state(
+        request: Request,
+        x_authentik_username: Annotated[str | None, Header()] = None,
+        if_match: Annotated[str | None, Header()] = None,
+    ) -> Response:
+        body = await request.body()
+        if not body:
+            raise HTTPException(status_code=400, detail="Empty body")
+        current = store.load()
+        current_etag = current.etag if current else '"empty"'
+        if if_match is not None and if_match != current_etag:
+            raise HTTPException(status_code=412, detail="ETag mismatch")
+        record = store.save(body)
+        logger.info("state updated by user=%s size=%d", x_authentik_username, len(body))
+        return Response(content=b"", status_code=204, headers={"ETag": record.etag})
+
+    # Static frontend is mounted last so /state and /healthz take precedence.
+    # The PWA is a single-page app; unknown paths fall through to index.html so
+    # deep links like /settings still load the shell.
+    if frontend_dist.exists():
+        app.mount("/", StaticFiles(directory=str(frontend_dist), html=True), name="frontend")
+    else:
+        logger.warning("frontend dist dir %s not found — serving API only", frontend_dist)
+
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s", stream=sys.stderr)
+    settings = Settings()
+    logger.info("study casino listening on %s:%d, data_dir=%s", settings.host, settings.port, settings.data_dir)
+    uvicorn.run(create_app(settings), host=settings.host, port=settings.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/x/auragon_study_casino/config.py
+++ b/x/auragon_study_casino/config.py
@@ -1,0 +1,28 @@
+"""Settings for the Study Casino backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="STUDY_CASINO_")
+
+    data_dir: Path = Field(
+        default=Path("/data"),
+        description="Directory containing the SQLite state database. "
+        "Should be backed by a PersistentVolume in production.",
+    )
+    host: str = "0.0.0.0"
+    port: int = 8080
+    frontend_dist_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Directory containing the built frontend bundle (index.html, main.js, "
+            "sw.js, manifest.webmanifest, icon.svg). Defaults to `./frontend/dist` "
+            "next to this module; override for tests or alternate layouts."
+        ),
+    )

--- a/x/auragon_study_casino/frontend/BUILD.bazel
+++ b/x/auragon_study_casino/frontend/BUILD.bazel
@@ -1,0 +1,66 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
+load("@npm_ducktape//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
+# ── Per-file source libraries ──────────────────────────────────────────────────
+
+js_library(
+    name = "storage",
+    srcs = ["src/storage.js"],
+    deps = [":node_modules/idb-keyval"],
+)
+
+js_library(
+    name = "study_casino",
+    srcs = ["src/study_casino.jsx"],
+    deps = [
+        ":node_modules/react",
+        ":storage",
+    ],
+)
+
+js_library(
+    name = "main",
+    srcs = ["src/main.jsx"],
+    deps = [
+        ":node_modules/react",
+        ":node_modules/react-dom",
+        ":study_casino",
+    ],
+)
+
+# ── Production bundle ──────────────────────────────────────────────────────────
+
+_BUNDLE_STATIC = [
+    "index.html",
+    "sw.js",
+    "manifest.webmanifest",
+    "icon.svg",
+]
+
+js_binary(
+    name = "build_bundle",
+    data = _BUNDLE_STATIC + [
+        ":main",
+        ":node_modules",
+    ],
+    entry_point = "esbuild.config.mjs",
+)
+
+js_run_binary(
+    name = "bundle",
+    srcs = _BUNDLE_STATIC + [":main"],
+    outs = [
+        "dist/icon.svg",
+        "dist/index.html",
+        "dist/main.js",
+        "dist/main.js.map",
+        "dist/manifest.webmanifest",
+        "dist/sw.js",
+    ],
+    args = ["dist"],
+    chdir = package_name(),
+    tool = ":build_bundle",
+    visibility = ["//x/auragon_study_casino:__pkg__"],
+)

--- a/x/auragon_study_casino/frontend/esbuild.config.mjs
+++ b/x/auragon_study_casino/frontend/esbuild.config.mjs
@@ -1,0 +1,55 @@
+// Production bundle for the Study Casino PWA.
+//
+// Bundles src/main.jsx → dist/main.js. Copies static assets (index.html,
+// sw.js, manifest.webmanifest, icon.svg) verbatim to dist/.
+//
+// Service worker is NOT bundled because it imports nothing and must be
+// served at a stable top-level path (`/sw.js`) so its scope covers the
+// whole origin.
+
+import esbuild from "esbuild";
+import { copyFile, mkdir } from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const args = process.argv.slice(2);
+const outdir = resolve(args[0] || "dist");
+const watch = args.includes("--watch");
+
+await mkdir(outdir, { recursive: true });
+
+const buildOptions = {
+  entryPoints: [resolve(__dirname, "src/main.jsx")],
+  bundle: true,
+  outdir,
+  format: "esm",
+  minify: !watch,
+  sourcemap: true,
+  target: ["es2022"],
+  jsx: "automatic",
+  loader: { ".js": "jsx" },
+  // Resolve node_modules from Bazel's sandboxed layout.
+  nodePaths: [resolve(process.cwd(), "node_modules")],
+  preserveSymlinks: false,
+  logLevel: "info",
+};
+
+const STATIC_ASSETS = ["index.html", "sw.js", "manifest.webmanifest", "icon.svg"];
+
+async function copyStatic() {
+  await Promise.all(
+    STATIC_ASSETS.map((name) => copyFile(resolve(__dirname, name), resolve(outdir, name))),
+  );
+}
+
+if (watch) {
+  const ctx = await esbuild.context(buildOptions);
+  await ctx.watch();
+  await copyStatic();
+  console.log("watching for changes…");
+} else {
+  await esbuild.build(buildOptions);
+  await copyStatic();
+}

--- a/x/auragon_study_casino/frontend/icon.svg
+++ b/x/auragon_study_casino/frontend/icon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="felt" cx="50%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#1f4a2e"/>
+      <stop offset="60%" stop-color="#0f2918"/>
+      <stop offset="100%" stop-color="#06140d"/>
+    </radialGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f3d27a"/>
+      <stop offset="50%" stop-color="#e8b84a"/>
+      <stop offset="100%" stop-color="#a07b1c"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#felt)"/>
+  <circle cx="256" cy="256" r="168" fill="none" stroke="url(#gold)" stroke-width="8"/>
+  <circle cx="256" cy="256" r="148" fill="none" stroke="url(#gold)" stroke-width="2" opacity="0.55"/>
+  <g font-family="Georgia, 'Playfair Display', serif" font-weight="700" fill="url(#gold)" text-anchor="middle">
+    <text x="256" y="226" font-size="92" font-style="italic">S</text>
+    <text x="256" y="326" font-size="92" font-style="italic">C</text>
+  </g>
+  <g fill="url(#gold)">
+    <circle cx="256" cy="88" r="10"/>
+    <circle cx="256" cy="424" r="10"/>
+    <circle cx="88" cy="256" r="10"/>
+    <circle cx="424" cy="256" r="10"/>
+  </g>
+</svg>

--- a/x/auragon_study_casino/frontend/index.html
+++ b/x/auragon_study_casino/frontend/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Study Casino</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
+    <meta name="theme-color" content="#0f1f14" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Study Casino" />
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+        background: #0f1f14;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/x/auragon_study_casino/frontend/manifest.webmanifest
+++ b/x/auragon_study_casino/frontend/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Study Casino",
+  "short_name": "Study Casino",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f1f14",
+  "theme_color": "#0f1f14",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/x/auragon_study_casino/frontend/package.json
+++ b/x/auragon_study_casino/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "auragon-study-casino-frontend",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "idb-keyval": "^6.2.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.1"
+  }
+}

--- a/x/auragon_study_casino/frontend/src/main.jsx
+++ b/x/auragon_study_casino/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import StudyCasino from "./study_casino.jsx";
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.warn("service worker registration failed", err);
+    });
+  });
+}
+
+createRoot(document.getElementById("root")).render(<StudyCasino />);

--- a/x/auragon_study_casino/frontend/src/storage.js
+++ b/x/auragon_study_casino/frontend/src/storage.js
@@ -1,0 +1,80 @@
+// Offline-first state storage.
+//
+// Reads:  backend first (cross-device sync), IndexedDB fallback on network fail.
+// Writes: IndexedDB immediately, backend in background with ETag-based conflict
+//         detection. On 409 Precedition Failed we pull the server copy, merge
+//         top-level fields by their `updatedAt` if present, and retry.
+//
+// The state blob is stored under a single IndexedDB key `state-v1`. Along with
+// it we track `etag-v1`, the ETag last seen from the backend, so PUT can use
+// If-Match and the backend can reject stale writes.
+
+import { get as idbGet, set as idbSet } from "idb-keyval";
+
+const STATE_KEY = "state-v1";
+const ETAG_KEY = "etag-v1";
+const BACKEND_URL = "/state";
+
+export async function loadState() {
+  try {
+    const response = await fetch(BACKEND_URL, { credentials: "same-origin" });
+    if (response.ok) {
+      const etag = response.headers.get("ETag");
+      const remote = await response.json();
+      await idbSet(STATE_KEY, remote);
+      if (etag) await idbSet(ETAG_KEY, etag);
+      return remote;
+    }
+    // 404 on first run — no state yet on the backend. Fall through to IDB.
+  } catch (e) {
+    // Offline or backend down — fall back to IndexedDB.
+  }
+  return (await idbGet(STATE_KEY)) ?? null;
+}
+
+let pendingSync = null;
+
+export async function saveState(state) {
+  await idbSet(STATE_KEY, state);
+  // Coalesce rapid successive saves into a single backend PUT.
+  if (!pendingSync) {
+    pendingSync = (async () => {
+      // Let the microtask queue settle so the last saveState() wins.
+      await new Promise((r) => setTimeout(r, 0));
+      pendingSync = null;
+      await pushToBackend(await idbGet(STATE_KEY));
+    })();
+  }
+}
+
+async function pushToBackend(state) {
+  const etag = await idbGet(ETAG_KEY);
+  const headers = { "Content-Type": "application/json" };
+  if (etag) headers["If-Match"] = etag;
+  try {
+    const response = await fetch(BACKEND_URL, {
+      method: "PUT",
+      credentials: "same-origin",
+      headers,
+      body: JSON.stringify(state),
+    });
+    if (response.ok) {
+      const newEtag = response.headers.get("ETag");
+      if (newEtag) await idbSet(ETAG_KEY, newEtag);
+    } else if (response.status === 412) {
+      // Conflict — another device wrote since our last read. Reload + retry.
+      // Simplest correct behavior: pull remote, let the user's next edit
+      // overwrite. Since this is a single-user app, conflicts only happen
+      // across devices. We accept "last device to edit wins" — the
+      // alternative (per-field updatedAt merge) is needlessly complex.
+      const remote = await (await fetch(BACKEND_URL, { credentials: "same-origin" })).json();
+      await idbSet(STATE_KEY, remote);
+      // Note: the caller's in-memory React state is now stale. A full reload
+      // is the cleanest recovery and rare in practice.
+      window.location.reload();
+    }
+  } catch (e) {
+    // Offline — IDB already has the write; next successful saveState will
+    // push the latest blob.
+  }
+}

--- a/x/auragon_study_casino/frontend/src/storage.js
+++ b/x/auragon_study_casino/frontend/src/storage.js
@@ -2,17 +2,25 @@
 //
 // Reads:  backend first (cross-device sync), IndexedDB fallback on network fail.
 // Writes: IndexedDB immediately, backend in background with ETag-based conflict
-//         detection. On 409 Precedition Failed we pull the server copy, merge
-//         top-level fields by their `updatedAt` if present, and retry.
+//         detection. On 412 Precondition Failed (another device wrote between
+//         our read and our write) we pull the server copy into IDB and reload
+//         the page — last-device-wins, no merge. A per-field merge would be
+//         the "right" answer but this is a single-user app, so the simpler
+//         behavior is fine.
 //
 // The state blob is stored under a single IndexedDB key `state-v1`. Along with
 // it we track `etag-v1`, the ETag last seen from the backend, so PUT can use
-// If-Match and the backend can reject stale writes.
+// If-Match and the backend can reject stale writes. When we have never seen a
+// server ETag (first-launch-offline-then-online) we send If-Match: "empty" so
+// the first PUT can't blind-clobber state another device already wrote — the
+// backend's empty-state ETag is "empty", so this matches a genuinely-empty
+// server and 412s otherwise.
 
 import { get as idbGet, set as idbSet } from "idb-keyval";
 
 const STATE_KEY = "state-v1";
 const ETAG_KEY = "etag-v1";
+const EMPTY_ETAG = '"empty"';
 const BACKEND_URL = "/state";
 
 export async function loadState() {
@@ -39,18 +47,29 @@ export async function saveState(state) {
   // Coalesce rapid successive saves into a single backend PUT.
   if (!pendingSync) {
     pendingSync = (async () => {
-      // Let the microtask queue settle so the last saveState() wins.
-      await new Promise((r) => setTimeout(r, 0));
-      pendingSync = null;
-      await pushToBackend(await idbGet(STATE_KEY));
+      try {
+        // Let the microtask queue settle so the last saveState() wins.
+        await new Promise((r) => setTimeout(r, 0));
+        await pushToBackend(await idbGet(STATE_KEY));
+      } catch (e) {
+        // pushToBackend swallows network errors, so reaching here means
+        // something unexpected (IDB failure, etc.). Log rather than letting
+        // it surface as an unhandled rejection — the next saveState will
+        // retry the push anyway.
+        console.error("sync failed", e);
+      } finally {
+        pendingSync = null;
+      }
     })();
   }
 }
 
 async function pushToBackend(state) {
-  const etag = await idbGet(ETAG_KEY);
-  const headers = { "Content-Type": "application/json" };
-  if (etag) headers["If-Match"] = etag;
+  // Default to the backend's empty-store ETag so we always send If-Match.
+  // Omitting it would let an offline-first-launch blind-overwrite whatever
+  // another device wrote while we were disconnected.
+  const etag = (await idbGet(ETAG_KEY)) ?? EMPTY_ETAG;
+  const headers = { "Content-Type": "application/json", "If-Match": etag };
   try {
     const response = await fetch(BACKEND_URL, {
       method: "PUT",

--- a/x/auragon_study_casino/frontend/src/study_casino.jsx
+++ b/x/auragon_study_casino/frontend/src/study_casino.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { loadState, saveState } from "./storage.js";
 
 const SUBJECTS = [
   "Biochemistry",
@@ -150,19 +151,14 @@ export default function StudyCasino() {
   // Load from storage
   useEffect(() => {
     (async () => {
-      try {
-        const r = await window.storage.get("study-casino-v1");
-        if (r?.value) {
-          const d = JSON.parse(r.value);
-          setCredits(d.credits || 0);
-          setTokens(d.tokens || 0);
-          setSessions(d.sessions || []);
-          setPrizes(d.prizes || DEFAULT_PRIZES);
-          setPrizeLog(d.prizeLog || []);
-          setActiveSession(d.activeSession || null);
-        }
-      } catch (e) {
-        /* first load */
+      const d = await loadState();
+      if (d) {
+        setCredits(d.credits || 0);
+        setTokens(d.tokens || 0);
+        setSessions(d.sessions || []);
+        setPrizes(d.prizes || DEFAULT_PRIZES);
+        setPrizeLog(d.prizeLog || []);
+        setActiveSession(d.activeSession || null);
       }
       setLoaded(true);
     })();
@@ -174,17 +170,7 @@ export default function StudyCasino() {
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(async () => {
       try {
-        await window.storage.set(
-          "study-casino-v1",
-          JSON.stringify({
-            credits,
-            tokens,
-            sessions,
-            prizes,
-            prizeLog,
-            activeSession,
-          })
-        );
+        await saveState({ credits, tokens, sessions, prizes, prizeLog, activeSession });
         setShowSaved(true);
         if (savedTimer.current) clearTimeout(savedTimer.current);
         savedTimer.current = setTimeout(() => setShowSaved(false), 1400);

--- a/x/auragon_study_casino/frontend/sw.js
+++ b/x/auragon_study_casino/frontend/sw.js
@@ -1,0 +1,48 @@
+// Study Casino service worker.
+//
+// Cache strategy:
+//   - App shell (/, /main.js, /manifest.webmanifest, /icon.svg): cache-first,
+//     so the app launches offline instantly.
+//   - /state: NETWORK-ONLY. The PWA writes to IndexedDB locally and pushes to
+//     /state; a cached GET could silently hand back stale data and defeat
+//     the whole point of having a backend for cross-device sync.
+//
+// Bump CACHE_VERSION to invalidate the shell cache on deploy. main.js content
+// hashes would be nicer but esbuild-in-Bazel doesn't emit them by default,
+// and for a single-user app a manual bump is fine.
+
+const CACHE_VERSION = "v1";
+const SHELL_CACHE = `study-casino-shell-${CACHE_VERSION}`;
+const SHELL_URLS = ["/", "/main.js", "/manifest.webmanifest", "/icon.svg"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_URLS)));
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== SHELL_CACHE).map((k) => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname === "/state") return; // network-only
+  if (event.request.method !== "GET") return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request).then((response) => {
+        if (response.ok) {
+          const copy = response.clone();
+          caches.open(SHELL_CACHE).then((cache) => cache.put(event.request, copy));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/x/auragon_study_casino/storage.py
+++ b/x/auragon_study_casino/storage.py
@@ -7,8 +7,10 @@ clobbering concurrent edits from another device.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import sqlite3
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -38,10 +40,17 @@ class StateStore:
                 ")"
             )
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextlib.contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        # sqlite3.Connection's own `__exit__` only commits/rolls back — it does
+        # NOT call close(), so the bare `with sqlite3.connect(...)` pattern
+        # leaks file descriptors across calls in a long-running process.
         conn = sqlite3.connect(self._db_path, isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")
-        return conn
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            yield conn
+        finally:
+            conn.close()
 
     def load(self) -> StateRecord | None:
         with self._connect() as conn:

--- a/x/auragon_study_casino/storage.py
+++ b/x/auragon_study_casino/storage.py
@@ -1,0 +1,61 @@
+"""SQLite-backed single-row state store.
+
+The app's state is a single opaque JSON blob keyed nowhere (singleton). We store
+it alongside a content-addressed ETag so the frontend can use If-Match to avoid
+clobbering concurrent edits from another device.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class StateRecord:
+    blob: bytes
+    etag: str
+
+
+def _compute_etag(blob: bytes) -> str:
+    # Weak ETag semantics are fine — the blob is already the state, so any
+    # byte-identical blob is interchangeable. Using sha256 of the body.
+    return f'"{hashlib.sha256(blob).hexdigest()[:16]}"'
+
+
+class StateStore:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS state ("
+                "  id INTEGER PRIMARY KEY CHECK (id = 1),"
+                "  blob BLOB NOT NULL,"
+                "  etag TEXT NOT NULL"
+                ")"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def load(self) -> StateRecord | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT blob, etag FROM state WHERE id = 1").fetchone()
+        if row is None:
+            return None
+        return StateRecord(blob=row[0], etag=row[1])
+
+    def save(self, blob: bytes) -> StateRecord:
+        etag = _compute_etag(blob)
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO state (id, blob, etag) VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET blob = excluded.blob, etag = excluded.etag",
+                (blob, etag),
+            )
+        return StateRecord(blob=blob, etag=etag)

--- a/x/auragon_study_casino/test_app.py
+++ b/x/auragon_study_casino/test_app.py
@@ -1,0 +1,69 @@
+"""Backend smoke tests — state round-trip, ETag handling, static 404 behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import pytest_bazel
+from fastapi.testclient import TestClient
+
+from x.auragon_study_casino.app import create_app
+from x.auragon_study_casino.config import Settings
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    settings = Settings(data_dir=tmp_path, frontend_dist_dir=tmp_path / "nonexistent_dist")
+    return TestClient(create_app(settings))
+
+
+def test_healthz(client: TestClient) -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_get_state_empty_returns_empty_object(client: TestClient) -> None:
+    response = client.get("/state")
+    assert response.status_code == 200
+    assert response.json() == {}
+    assert response.headers["etag"] == '"empty"'
+
+
+def test_put_then_get_roundtrip(client: TestClient) -> None:
+    payload = {"credits": 42, "sessions": []}
+    put_response = client.put("/state", content=json.dumps(payload))
+    assert put_response.status_code == 204
+    etag = put_response.headers["etag"]
+    assert etag
+
+    get_response = client.get("/state")
+    assert get_response.status_code == 200
+    assert get_response.json() == payload
+    assert get_response.headers["etag"] == etag
+
+
+def test_if_match_rejects_stale_write(client: TestClient) -> None:
+    client.put("/state", content=json.dumps({"credits": 1}))
+    stale_response = client.put("/state", content=json.dumps({"credits": 2}), headers={"If-Match": '"bogus"'})
+    assert stale_response.status_code == 412
+    # The first blob must still be there.
+    assert client.get("/state").json() == {"credits": 1}
+
+
+def test_if_match_accepts_matching_etag(client: TestClient) -> None:
+    first = client.put("/state", content=json.dumps({"credits": 1}))
+    second = client.put("/state", content=json.dumps({"credits": 2}), headers={"If-Match": first.headers["etag"]})
+    assert second.status_code == 204
+    assert client.get("/state").json() == {"credits": 2}
+
+
+def test_empty_body_rejected(client: TestClient) -> None:
+    response = client.put("/state", content=b"")
+    assert response.status_code == 400
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/x/auragon_study_casino/test_storage.py
+++ b/x/auragon_study_casino/test_storage.py
@@ -1,0 +1,50 @@
+"""SQLite state store tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest_bazel
+
+from x.auragon_study_casino.storage import StateStore
+
+
+def test_load_before_save_returns_none(tmp_path: Path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    assert store.load() is None
+
+
+def test_save_and_load(tmp_path: Path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    record = store.save(b'{"credits":1}')
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.blob == b'{"credits":1}'
+    assert loaded.etag == record.etag
+
+
+def test_save_overwrites(tmp_path: Path) -> None:
+    store = StateStore(tmp_path / "state.db")
+    first = store.save(b'{"credits":1}')
+    second = store.save(b'{"credits":2}')
+    assert first.etag != second.etag
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.blob == b'{"credits":2}'
+
+
+def test_etag_is_deterministic(tmp_path: Path) -> None:
+    a = StateStore(tmp_path / "a.db").save(b'{"credits":1}')
+    b = StateStore(tmp_path / "b.db").save(b'{"credits":1}')
+    assert a.etag == b.etag
+
+
+def test_data_dir_autocreated(tmp_path: Path) -> None:
+    db_path = tmp_path / "nested" / "dir" / "state.db"
+    store = StateStore(db_path)
+    store.save(b'{"credits":1}')
+    assert db_path.exists()
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

Introduces Study Casino, a single-user habit-tracking "casino" app where users earn credits by studying and spend them on self-chosen prizes. The app is a React PWA with offline-first state sync, deployed to Kubernetes behind Authentik forward-auth.

## Key Changes

### Backend (FastAPI + SQLite)
- **`x/auragon_study_casino/app.py`**: FastAPI server with `/healthz` health check and `/state` GET/PUT endpoints for state sync
- **`x/auragon_study_casino/storage.py`**: SQLite-backed state store with content-addressed ETags for optimistic concurrency control
- **`x/auragon_study_casino/config.py`**: Pydantic settings for data directory, host, and port configuration
- **`x/auragon_study_casino/test_app.py` & `test_storage.py`**: Comprehensive pytest test suite covering state round-trips, ETag conflict detection, and storage operations

### Frontend (React PWA)
- **`x/auragon_study_casino/frontend/src/study_casino.jsx`**: React component implementing the casino UI (study sessions, credit tracking, prize redemption)
- **`x/auragon_study_casino/frontend/src/storage.js`**: Offline-first sync layer using IndexedDB for local writes and backend PUT with If-Match ETags for conflict resolution
- **`x/auragon_study_casino/frontend/src/main.jsx`**: Entry point with service worker registration
- **`x/auragon_study_casino/frontend/sw.js`**: Service worker with cache-first strategy for app shell and network-only for `/state`
- **`x/auragon_study_casino/frontend/esbuild.config.mjs`**: Production bundler configuration
- **Static assets**: `index.html`, `manifest.webmanifest`, `icon.svg` for PWA installation

### Kubernetes Deployment
- **`cluster/k8s/study-casino/app/`**: Deployment (single replica with Recreate strategy for SQLite WAL), Service, and PVC for persistent state
- **`cluster/k8s/study-casino/namespace/`**: Namespace with Goldilocks opt-out for single-pod personal app
- **`cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml`**: Authentik proxy provider and application configuration
- **`cluster/k8s/authentik/proxy-routes/study-casino-httproute.yaml`**: HTTPRoute for `casino.allegedly.works` via Authentik outpost
- **Flux automation**: Image repository/policy and Kustomization resources for GitOps deployment

### Documentation & Configuration
- **`x/auragon_study_casino/README.md`**: Comprehensive guide covering layout, auth, state sync, and deployment
- **`devinfra/docs/bb_bazelrc_startup.md`**: Technical documentation on BuildBuddy CLI's handling of bazelrc startup directives (context for Claude session integration)
- **Build configuration**: Bazel BUILD files for Python libraries, tests, and OCI image; npm workspace integration

## Notable Implementation Details

- **Conflict resolution**: Frontend uses If-Match ETags; on 412 conflict, pulls server state and triggers reload (last-device-wins semantics suitable for single-user app)
- **State sync strategy**: IndexedDB writes immediately for snappy UX, background PUT with coalescing for rapid successive saves
- **Service worker caching**: App shell cached for offline launch; `/state` network-only to prevent stale cross-device data
- **Kubernetes constraints**: Single replica with RWO PVC and SQLite WAL to avoid concurrent writer issues; `enableServiceLinks: false` to prevent env var collision with pydantic-settings
- **Auth model**: Forward-auth via Authentik outpost; `X-Authentik-Username` header logged for observability only (no per-user scoping)

https://claude.ai/code/session_01E5E8YibqvzQoxE3iBNC9Z7