### PR TITLE
Add Google as a source on default-authentication-identification

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/users.yaml
+++ b/cluster/k8s/authentik/app/blueprints/users.yaml
@@ -40,3 +40,19 @@ entries:
       default: false
       flow_authentication: !KeyOf custom-auth-flow
       branding_title: "allegedly.works"
+
+  # Add Google as a source on the built-in default-authentication-identification
+  # stage. That stage is bound to `default-authentication-flow` at order 10, so
+  # any app whose proxy provider points at `default-authentication-flow` gets
+  # the "Sign in with Google" button on fresh-session login. The Google source
+  # itself is provisioned in tf/gitops/sso-providers/source_google.tf.
+  # `!Find` resolves the source's UUID at blueprint-apply time, which runs
+  # after the TF kustomization (sso-providers-tf → authentik app).
+  - model: authentik_stages_identification.identificationstage
+    state: present
+    identifiers:
+      name: default-authentication-identification
+    attrs:
+      sources:
+        - !Find [authentik_sources_oauth.oauthsource, [slug, google]]
+      show_source_labels: false


### PR DESCRIPTION
## Why

"Sign in with Google" was only wired into `custom-authentication-flow` (via `tf/gitops/sso-providers/source_google.tf:66`), not the built-in `default-authentication-flow` that every SSO blueprint here actually uses. So on a fresh-session login to any app — study-casino, hubble, goldilocks, filebrowser, kagent, google-workspace-mcp, longhorn, openclaw, openclaw-mitmproxy, proxmox, sdr, adsb, tandoor — the identification page shows password-only. Google worked in practice only if you'd already logged into `auth.allegedly.works` (which uses the brand-override `flow_authentication`) in the same session; the outpost forward-auth would then skip the login step entirely.

## Fix

Add the Google OAuth source to the built-in `default-authentication-identification` stage (which is bound to `default-authentication-flow` at order 10). One upsert, no binding surgery, no touching the flow itself. `!Find` resolves the source's UUID at blueprint-apply time, which Flux runs after the `sso-providers-tf` Kustomization has created the `google` source — ordering is already enforced via `dependsOn` on the layer chain.

After reconcile, every app listed above picks up the Google button for free. No per-app blueprint edits needed.

## Test plan

- [x] Blueprint YAML parses (pre-commit passes)
- [ ] After Flux reconciles, fresh incognito → `https://casino.allegedly.works/` shows a "Sign in with Google" button on the identification page
- [ ] Repeat for one other app (e.g. `hubble.allegedly.works`) to confirm it's not casino-specific

https://claude.ai/code/session_01E5E8YibqvzQoxE3iBNC9Z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5E8YibqvzQoxE3iBNC9Z7)_