### PR TITLE
Collapse Authentik auth surface: single default flow, no forced MFA

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/users.yaml
+++ b/cluster/k8s/authentik/app/blueprints/users.yaml
@@ -1,42 +1,47 @@
 version: 1
 metadata:
-  name: SSO - Users and Authentication
+  name: SSO - Default authentication customizations
   labels:
-    blueprints.goauthentik.io/description: "Custom auth flow (no MFA), user, brand"
+    blueprints.goauthentik.io/description: >
+      Patches two built-in Authentik stages so every app using
+      default-authentication-flow (which is all of them) gets the
+      "Sign in with Google" button and doesn't require MFA for users
+      who haven't enrolled.
+
+# The custom-authentication-flow that this directory used to define
+# (together with a no-MFA binding set and a brand flow_authentication
+# override) was removed in 2026-04. The simpler equivalent: use
+# Authentik's built-in default-authentication-flow for everything, and
+# patch its two relevant stages below.
+#
+# Both entries are upserts on Authentik-owned built-ins: they change one
+# field each and leave the other fields alone, which is exactly what the
+# blueprint `state: present` semantic provides. TF can't express that
+# cleanly without taking full ownership of every field — fragile across
+# Authentik upgrades that tweak built-in defaults.
 
 entries:
-  # Custom authentication flow without MFA stage.
-  # TODO: Re-enable MFA (TOTP/WebAuthn) once device enrollment is set up.
-  - model: authentik_flows.flow
-    id: custom-auth-flow
+  # Google as a source on the identification stage. Source itself is
+  # provisioned in tf/gitops/sso-providers/source_google.tf; `!Find`
+  # resolves the UUID at blueprint-apply time, which runs after the
+  # sso-providers TF Kustomization per the flux-kustomization dependsOn
+  # chain.
+  - model: authentik_stages_identification.identificationstage
     state: present
     identifiers:
-      slug: custom-authentication-flow
+      name: default-authentication-identification
     attrs:
-      name: authentication-flow
-      title: "Welcome to allegedly.works!"
-      designation: authentication
+      sources:
+        - !Find [authentik_sources_oauth.oauthsource, [slug, google]]
+      show_source_labels: false
 
-  - model: authentik_flows.flowstagebinding
+  # MFA validation stage: skip if the user has nothing enrolled, rather
+  # than denying login. Lets users without MFA proceed while still
+  # enforcing MFA for users who have it configured. Opt-in re-enablement
+  # once someone's registered a TOTP/WebAuthn device.
+  - model: authentik_stages_authenticator_validate.authenticatorvalidatestage
     state: present
     identifiers:
-      target: !KeyOf custom-auth-flow
-      stage: !Find [authentik_stages_password.passwordstage, [name, default-authentication-password]]
-      order: 20
-
-  - model: authentik_flows.flowstagebinding
-    state: present
-    identifiers:
-      target: !KeyOf custom-auth-flow
-      stage: !Find [authentik_stages_user_login.userloginstage, [name, default-authentication-login]]
-      order: 30
-
-  # Domain-matched brand for allegedly.works
-  - model: authentik_brands.brand
-    state: present
-    identifiers:
-      domain: allegedly.works
+      name: default-authentication-mfa-validation
     attrs:
-      default: false
-      flow_authentication: !KeyOf custom-auth-flow
-      branding_title: "allegedly.works"
+      not_configured_action: skip

--- a/tf/gitops/sso-providers/brand.tf
+++ b/tf/gitops/sso-providers/brand.tf
@@ -1,0 +1,17 @@
+# Domain-matched brand for allegedly.works.
+#
+# Historically paired with a `custom-authentication-flow` (no-MFA) so that
+# direct logins at auth.allegedly.works bypassed Authentik's built-in
+# `default-authentication-mfa-validation` stage. That custom flow was
+# deleted in 2026-04 in favor of the built-in `default-authentication-flow`
+# with the MFA validation stage patched to `not_configured_action: skip`
+# (see cluster/k8s/authentik/app/blueprints/users.yaml). Net effect is
+# identical for users without MFA enrolled; per-user MFA still enforces
+# when configured. With the custom flow gone, the brand no longer needs
+# `flow_authentication` — Authentik falls back to default-authentication-flow.
+
+resource "authentik_brand" "allegedly_works" {
+  domain         = "allegedly.works"
+  default        = false
+  branding_title = "allegedly.works"
+}

--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -57,10 +57,6 @@ data "authentik_flow" "implicit_consent" {
   slug = "default-provider-authorization-implicit-consent"
 }
 
-data "authentik_flow" "custom_authentication" {
-  slug = "custom-authentication-flow"
-}
-
 data "authentik_flow" "invalidation" {
   slug = "default-provider-invalidation-flow"
 }

--- a/tf/gitops/sso-providers/source_google.tf
+++ b/tf/gitops/sso-providers/source_google.tf
@@ -47,23 +47,7 @@ resource "authentik_source_oauth" "google" {
   user_matching_mode = "email_link"
 }
 
-resource "authentik_stage_identification" "google" {
-  count = local.google_client_id != "" ? 1 : 0
-
-  name                      = "google-authentication-identification"
-  user_fields               = ["email", "username"]
-  case_insensitive_matching = true
-  show_matched_user         = true
-  pretend_user_exists       = true
-  enable_remember_me        = false
-  show_source_labels        = false
-  sources                   = [authentik_source_oauth.google[0].uuid]
-}
-
-resource "authentik_flow_stage_binding" "google_identification" {
-  count = local.google_client_id != "" ? 1 : 0
-
-  target = data.authentik_flow.custom_authentication.id
-  stage  = authentik_stage_identification.google[0].id
-  order  = 10
-}
+# The Google source is wired into the login UI via a blueprint patch on the
+# built-in `default-authentication-identification` stage — see
+# cluster/k8s/authentik/app/blueprints/users.yaml. No dedicated stage or
+# binding is needed here.


### PR DESCRIPTION
## Why

Two coupled goals:
1. Consolidate Authentik state management — `users.yaml` had the flow + bindings + brand while `source_google.tf` bound its Google identification stage into the same flow. Half/half across two surfaces was hard to reason about.
2. Kill the `custom-authentication-flow` entirely. It existed only to skip MFA relative to Authentik's built-in `default-authentication-flow`. With two small patches on the built-in's stages, it's functionally identical — and it was the only consumer of the brand's `flow_authentication` override.

## Final state

**TF owns** (in `tf/gitops/sso-providers/brand.tf`): just the `allegedly.works` brand, no flow override.

**Blueprints own** (`cluster/k8s/authentik/app/blueprints/users.yaml`): two upserts on Authentik-owned built-ins:
- `default-authentication-identification` `sources: [google]` — puts the "Sign in with Google" button on every app's login page.
- `default-authentication-mfa-validation` `not_configured_action: skip` — users without MFA enrolled pass through; users who have MFA configured still get it enforced.

Both entries are upserts on built-ins, so blueprint `state: present` semantics (mutate one field, leave the rest alone) is the right tool — TF would need full ownership of every field, fragile across Authentik upgrades.

## Changes (vs. devel)

**Deleted:**
- `custom-authentication-flow` (from `users.yaml`)
- Its password + user_login bindings (from `users.yaml`)
- `authentik_stage_identification.google` + its flow binding (from `source_google.tf`)
- The brand's `flow_authentication` override
- `data "authentik_flow" "custom_authentication"` in `main.tf`

**Added:**
- `tf/gitops/sso-providers/brand.tf` (just the brand)
- `default-authentication-mfa-validation` upsert in `users.yaml`
- Google source entry in `default-authentication-identification`'s `sources`

## Migration

One tofu-controller apply:
- Deletes `custom-authentication-flow`, its bindings, the google ident stage + binding.
- Updates the brand in-place to drop `flow_authentication`.

One blueprint scan:
- Applies the two upserts on built-in stages.

No cluster rebootstrap. No manual `terraform import` expected; if the brand can't be adopted by `domain`, one-time `terraform import authentik_brand.allegedly_works <uuid>` from the tofu-controller pod.

## Test plan

- [x] `bbr test //tf/gitops/sso-providers:{format,lint,validate}` — all green (`767a5c4e-0e91-4c37-87e0-2f03403c6927`)
- [ ] After reconcile: `auth.allegedly.works` still renders with "allegedly.works" brand; login works; Google button present.
- [ ] Fresh incognito to any proxy-protected app (casino/hubble/goldilocks): login page shows Google button and doesn't prompt for MFA enrollment.
- [ ] User with MFA configured: still prompted on login.

Supersedes #1373.

https://claude.ai/code/session_01E5E8YibqvzQoxE3iBNC9Z7