### PR TITLE
Use gitattributes for cluster manifest exclusions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,6 +42,11 @@ llm/instruct_logseq/pages/** filename-conventions-ignored=true
 # Blog posts - filenames are published URLs (date-prefixed kebab-case)
 website/posts/** filename-conventions-ignored=true
 
+# Non-K8s YAML under cluster/k8s/ - rules_distroless apt manifests for CronJob
+# images. cluster/validation/cluster.py reads this attribute via `git check-attr`
+# (pygit2) and skips the file from orphan detection + resource parsing.
+cluster/k8s/**/trixie_*.yaml cluster-manifest-ignored=true
+
 # Dotfiles/dotdirs follow their own naming conventions
 .* filename-conventions-ignored=true
 .*/** filename-conventions-ignored=true

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Exclusions require two files (pre-commit reads `.gitattributes`, ruff reads `ruf
 1. Add `path/** rules-lint-ignored=true` to `.gitattributes`
 2. If Python, also add to `ruff.toml exclude`
 
+Other gitattributes consumed by pre-commit checks:
+
+- `filename-conventions-ignored=true` — skips kebab-case filename enforcement
+  (defaulted on for `cluster/`, `terraform/`, `tf/`, and a few other trees
+  where kebab-case is conventional).
+- `cluster-manifest-ignored=true` — for YAML files under `cluster/k8s/` that
+  aren't K8s manifests (e.g. `rules_distroless` apt manifests next to a
+  CronJob image's `BUILD.bazel`). The cluster validator skips them from
+  orphan detection and resource parsing.
+
 ## CI
 
 - **BuildBuddy Workflows**: `bazel test //...` + `bazel build //...` (RBE, lint)

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -55,6 +55,7 @@ py_library(
         ":kustomize",
         "@pypi//networkx",
         "@pypi//numpy",
+        "@pypi//pygit2",
         "@pypi//types_networkx",
     ],
 )

--- a/cluster/validation/cluster.py
+++ b/cluster/validation/cluster.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import networkx as nx
+import pygit2
 
 from cluster.validation.flux import FluxKustomizationSpec, parse_flux_kustomizations
 from cluster.validation.k8s import K8sResource, parse_k8s_resource_file
@@ -13,14 +14,36 @@ from cluster.validation.kustomize import KustomizeBuildResult, KustomizeFile, pa
 
 _K8S_SUBPATH = Path("cluster/k8s")
 
-# Non-K8s YAML files that live under cluster/k8s/ but aren't manifests.
-# Excluded from orphan detection and resource parsing.
-# TODO: This list is baked into the installed ducktape-precommit binary.
-# Changes here don't take effect until the binary is rebuilt and reinstalled.
-_EXCLUDED_FILES = {
-    # rules_distroless APT manifests for CronJob images
-    "agents/claude-cert-rotation/trixie_cert_rotation.yaml"
-}
+# Gitattribute that marks a YAML file under cluster/k8s/ as "not a K8s manifest".
+# Files with this attribute set are skipped from resource parsing and orphan
+# detection. Source of truth is `.gitattributes` at the repo root, so new
+# exclusions land atomically with the file they exclude — no ducktape-git-hooks
+# wheel rebuild + npins repin + `nix profile install` cycle required.
+# Mirrors the `rules-lint-ignored` / `filename-conventions-ignored` pattern
+# already used by devinfra/precommit/git_hook.py.
+_MANIFEST_IGNORED_ATTR = "cluster-manifest-ignored"
+
+
+def _open_repo(start: Path) -> pygit2.Repository | None:
+    """Discover the git repo containing `start`, or None if not in a repo."""
+    try:
+        repo_path = pygit2.discover_repository(str(start))
+    except pygit2.GitError:
+        return None
+    if not repo_path:
+        return None
+    return pygit2.Repository(repo_path)
+
+
+def _manifest_ignored(repo: pygit2.Repository | None, path: Path) -> bool:
+    """True iff `path` has gitattribute `cluster-manifest-ignored=true`."""
+    if repo is None:
+        return False
+    try:
+        rel = path.resolve().relative_to(Path(repo.workdir).resolve())
+    except ValueError:
+        return False
+    return repo.get_attr(str(rel), _MANIFEST_IGNORED_ATTR) in (True, "true")
 
 
 @dataclass
@@ -68,6 +91,7 @@ def parse_cluster(k8s_dir: Path) -> ParsedCluster:
     flux_kustomizations: dict[str, FluxKustomizationSpec] = {}
     all_yaml_files: set[Path] = set()
     source_resources: dict[Path, list[K8sResource]] = {}
+    repo = _open_repo(k8s_dir)
 
     for yaml_file in k8s_dir.rglob("*.yaml"):
         # Skip flux-system (auto-generated)
@@ -78,12 +102,8 @@ def parse_cluster(k8s_dir: Path) -> ParsedCluster:
         if "blueprints" in yaml_file.parts:
             continue
 
-        # Skip explicitly excluded non-K8s files
-        try:
-            rel = yaml_file.relative_to(k8s_dir)
-        except ValueError:
-            rel = None
-        if rel and str(rel) in _EXCLUDED_FILES:
+        # Skip non-K8s files flagged via gitattribute (apt manifests, helm values, etc.)
+        if _manifest_ignored(repo, yaml_file):
             continue
 
         all_yaml_files.add(yaml_file.resolve())


### PR DESCRIPTION
Replace the hardcoded `_EXCLUDED_FILES` set with a gitattribute-based approach for marking non-K8s YAML files under `cluster/k8s/` that should be skipped from validation.

## Summary
This change moves the source of truth for manifest exclusions from a Python constant to `.gitattributes`, eliminating the need to rebuild and reinstall the ducktape-precommit binary when adding new exclusions.

## Key Changes
- Replace hardcoded `_EXCLUDED_FILES` set with `cluster-manifest-ignored` gitattribute
- Add `_open_repo()` helper to discover and open the git repository
- Add `_manifest_ignored()` function to check if a file has the exclusion attribute set via `pygit2`
- Update `parse_cluster()` to use the new attribute-based exclusion logic
- Add `pygit2` dependency to `cluster/validation/BUILD.bazel`
- Document the new gitattribute in `.gitattributes` and `README.md`

## Implementation Details
- Uses `pygit2.discover_repository()` and `pygit2.Repository.get_attr()` to read gitattributes at runtime
- Gracefully handles cases where the code runs outside a git repository (returns `None` for repo)
- Matches the existing pattern used by `devinfra/precommit/git_hook.py` for `rules-lint-ignored` and `filename-conventions-ignored` attributes
- Exclusion pattern `cluster/k8s/**/trixie_*.yaml` targets `rules_distroless` apt manifests for CronJob images

https://claude.ai/code/session_01KcZFgn5SZ1J3gZWZugy5Vk