### PR TITLE
chore: pre-commit autofix catchup (buildifier + ruff-format)

### DIFF
--- a/devinfra/js/debundle/analysis/BUILD.bazel
+++ b/devinfra/js/debundle/analysis/BUILD.bazel
@@ -12,10 +12,10 @@ js_library(
         "runtime_boundary_metadata_lib.mjs",
         "scrambled_identifier_frequency_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
     ] + _BABEL_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_test(

--- a/devinfra/js/debundle/common/BUILD.bazel
+++ b/devinfra/js/debundle/common/BUILD.bazel
@@ -23,8 +23,8 @@ js_library(
 js_test(
     name = "vendor_runtime_lib_test",
     data = [
-        ":sources",
         "vendor_runtime_lib.mjs",
+        ":sources",
         "//devinfra/js/debundle/test_support:sources",
     ],
     entry_point = "vendor_runtime_lib_test.mjs",

--- a/devinfra/js/debundle/extract/BUILD.bazel
+++ b/devinfra/js/debundle/extract/BUILD.bazel
@@ -17,12 +17,12 @@ js_library(
         "guided_selected_owner_modules_stage_lib.mjs",
         "owner_closure_plan_report_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/analysis:libs",
         "//devinfra/js/debundle/common:libs",
         "//devinfra/js/debundle/split:libs",
     ] + _BABEL_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_test(

--- a/devinfra/js/debundle/harness/BUILD.bazel
+++ b/devinfra/js/debundle/harness/BUILD.bazel
@@ -5,11 +5,11 @@ js_library(
     srcs = [
         "emit_browser_harness_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
         "//devinfra/js/debundle/split:libs",
     ],
-    visibility = ["//visibility:public"],
 )
 
 js_test(

--- a/devinfra/js/debundle/live_proxy/BUILD.bazel
+++ b/devinfra/js/debundle/live_proxy/BUILD.bazel
@@ -3,12 +3,12 @@ load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_test")
 js_library(
     name = "libs",
     srcs = ["live_proxy_lib.mjs"],
+    visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/http-mitm-proxy",
         "//:node_modules/node-forge",
         "//devinfra/js/debundle/common:libs",
     ],
-    visibility = ["//visibility:public"],
 )
 
 js_binary(

--- a/devinfra/js/debundle/rename/BUILD.bazel
+++ b/devinfra/js/debundle/rename/BUILD.bazel
@@ -12,11 +12,11 @@ js_library(
     srcs = [
         "rename_bindings_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
         "//devinfra/js/debundle/split:libs",
     ] + _BABEL_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_test(

--- a/devinfra/js/debundle/split/BUILD.bazel
+++ b/devinfra/js/debundle/split/BUILD.bazel
@@ -14,10 +14,10 @@ js_library(
         "split_js_tree_lib.mjs",
         "split_js_tree_worker.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
     ] + _BABEL_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_test(
@@ -37,8 +37,8 @@ js_test(
         "split_js_tree_lib.mjs",
         "split_js_tree_worker.mjs",
         "//devinfra/js/debundle/common:sources",
-        "//devinfra/js/debundle/transforms:libs",
         "//devinfra/js/debundle/test_support:sources",
+        "//devinfra/js/debundle/transforms:libs",
     ] + _BABEL_DEPS,
     entry_point = "split_js_tree_test.mjs",
 )

--- a/devinfra/js/debundle/test_support/BUILD.bazel
+++ b/devinfra/js/debundle/test_support/BUILD.bazel
@@ -14,11 +14,11 @@ js_library(
     srcs = [
         "fixture_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/@babel/parser",
         "//devinfra/js/debundle/common:libs",
     ],
-    visibility = ["//visibility:public"],
 )
 
 js_library(
@@ -26,10 +26,10 @@ js_library(
     srcs = [
         "pipeline_fixture_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
         "//devinfra/js/debundle/split:libs",
         "//devinfra/js/debundle/test_support:libs",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/devinfra/js/debundle/transforms/BUILD.bazel
+++ b/devinfra/js/debundle/transforms/BUILD.bazel
@@ -10,6 +10,7 @@ js_library(
         "run_transform_lib.mjs",
         "write_js_tree_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/analysis:libs",
         "//devinfra/js/debundle/common:libs",
@@ -19,14 +20,13 @@ js_library(
         "//devinfra/js/debundle/split:libs",
         "//devinfra/js/debundle/vendor:libs",
     ] + _JSONC_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_binary(
     name = "run_transform",
     data = [
-        ":libs",
         "run_transform.mjs",
+        ":libs",
     ],
     entry_point = "run_transform.mjs",
     node_options = [

--- a/devinfra/js/debundle/vendor/BUILD.bazel
+++ b/devinfra/js/debundle/vendor/BUILD.bazel
@@ -14,10 +14,10 @@ js_library(
         "rename_vendor_exports_lib.mjs",
         "swap_vendor_chunks_lib.mjs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//devinfra/js/debundle/common:libs",
     ] + _BABEL_DEPS,
-    visibility = ["//visibility:public"],
 )
 
 js_test(

--- a/x/grocy_mcp/test_retry_safety.py
+++ b/x/grocy_mcp/test_retry_safety.py
@@ -7,6 +7,7 @@ These tests mock the httpx client via respx to verify:
 """
 
 from __future__ import annotations
+
 from collections.abc import AsyncGenerator
 
 import httpx
@@ -121,10 +122,7 @@ async def test_http_errors_are_compact_and_include_status_url_and_body(mcp_clien
     """HTTP backend errors should be concise and actionable (no Python traceback)."""
     client, router = mcp_client
     error_payload = {"error_message": "Amount to be consumed cannot be > current stock amount"}
-    router.post("/stock/products/1/consume").respond(
-        status_code=400,
-        json=error_payload,
-    )
+    router.post("/stock/products/1/consume").respond(status_code=400, json=error_payload)
 
     result = await client.call_tool(
         "stock_consume", {"items": [{"product": 1, "amount": 5, "qu": "pieces", "location": "TestLoc"}]}


### PR DESCRIPTION
Devel pre-commit has been red on the last few merge commits because the formatter versions on the CI runner are newer than what was used when these files last landed. `pre-commit run --all-files` to catch up.

## Changes (autofix output only — no semantic change)

- **`devinfra/js/debundle/**/BUILD.bazel`** (10 files) — buildifier reorders `js_library` attrs (`visibility` before `deps`) and re-sorts `data` lists alphabetically.
- **`x/grocy_mcp/test_retry_safety.py`** — ruff-format adds a blank line after `from __future__ import annotations` and collapses a multi-line `respond(...)` call.

After this lands, every PR's pre-commit step turns green again. The other in-flight PRs (#1379) hit the same drift before this catchup landed.

## Test plan

- `pre-commit run --all-files` clean locally on this branch.
- CI's pre-commit step (which is exactly the same invocation) should now pass.

https://claude.ai/code/session_01KcZFgn5SZ1J3gZWZugy5Vk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcZFgn5SZ1J3gZWZugy5Vk)_