### PR TITLE
Replace hand-rolled AF tool loop and MCP bridge with native AF primitives

### DIFF
--- a/skills/eval_infra/BUILD.bazel
+++ b/skills/eval_infra/BUILD.bazel
@@ -9,3 +9,32 @@ py_library(
         "@pypi//aiodocker",
     ],
 )
+
+py_library(
+    name = "af_chat_client",
+    srcs = ["af_chat_client.py"],
+    visibility = ["//skills:__subpackages__"],
+    deps = [
+        # agent_framework_claude shows up in agent_framework.anthropic's stubs.
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
+    ],
+)
+
+py_library(
+    name = "af_scratch_mcp",
+    srcs = ["af_scratch_mcp.py"],
+    data = ["//mcp_infra/exec:docker_launcher"],
+    visibility = ["//skills:__subpackages__"],
+    deps = [
+        "//mcp_infra/exec:docker_types",
+        "//util/bazel:runfiles",
+        # agent_framework's __init__.py references openai/anthropic stubs.
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
+    ],
+)

--- a/skills/eval_infra/af_chat_client.py
+++ b/skills/eval_infra/af_chat_client.py
@@ -1,0 +1,27 @@
+"""Build a Microsoft Agent Framework chat client for an `(api, model)` pair.
+
+`function_invocation_configuration` (e.g. `{"max_iterations": 200}`) is
+applied at construction time so callers don't have to mutate the client
+afterwards. AF chat clients have no `close()` / async context manager
+hooks (verified against the Anthropic / OpenAI / Base classes); the
+underlying SDK clients are released by Python's GC at process exit.
+"""
+
+from typing import Any
+
+from agent_framework import BaseChatClient, FunctionInvocationConfiguration
+from agent_framework.anthropic import AnthropicClient
+from agent_framework.openai import OpenAIChatCompletionClient
+
+
+def build_model_client(
+    *, api: str, model: str, function_invocation_configuration: FunctionInvocationConfiguration | None = None
+) -> BaseChatClient[Any]:
+    kwargs: dict[str, Any] = {"model": model}
+    if function_invocation_configuration is not None:
+        kwargs["function_invocation_configuration"] = function_invocation_configuration
+    if api == "openai":
+        return OpenAIChatCompletionClient(**kwargs)
+    if api == "anthropic":
+        return AnthropicClient(**kwargs)
+    raise ValueError(f"Unsupported API: {api!r}")

--- a/skills/eval_infra/af_scratch_mcp.py
+++ b/skills/eval_infra/af_scratch_mcp.py
@@ -1,0 +1,66 @@
+"""Hand a Microsoft Agent Framework `Agent` an `exec` MCP tool that runs in a
+scratch Docker container.
+
+`scratch_exec_mcp_tool` builds an `MCPStdioTool` that launches the
+`mcp_infra.exec.docker.launcher` CLI as a subprocess. The launcher boots a
+`ContainerExecServer` (configured the same way `scratch_exec_server` does:
+host network, proxy env, locked-down user/env/cwd) and speaks MCP over
+stdio. AF then drives tool dispatch natively — no FastMCP client, no
+hand-rolled FunctionTool bridge.
+
+Usage:
+
+    async with scratch_exec_mcp_tool(binds=[...], working_dir=Path("/work")) as exec_tool:
+        agent = Agent(client=..., tools=[exec_tool, ...])
+        await agent.run(...)
+"""
+
+import os
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from agent_framework import MCPStdioTool
+
+from mcp_infra.exec.docker.types import AlwaysSetTo, BindMount, ContainerExecServerConfig
+from util.bazel.runfiles import get_required_path
+
+_LAUNCHER_RLOCATION = "_main/mcp_infra/exec/docker_launcher"
+
+
+def _proxy_env() -> dict[str, str]:
+    """Collect HTTP(S) proxy env vars for container networking."""
+    env: dict[str, str] = {}
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "NO_PROXY", "no_proxy"):
+        if val := os.environ.get(var):
+            env[var] = val
+    return env
+
+
+@asynccontextmanager
+async def scratch_exec_mcp_tool(
+    name: str = "exec",
+    *,
+    image: str = "python:3.13-slim",
+    binds: list[BindMount] | None = None,
+    working_dir: Path = Path("/tmp"),
+) -> AsyncGenerator[MCPStdioTool]:
+    """Yield an `MCPStdioTool` that exposes a scratch container's `exec` tool.
+
+    The container has host networking, proxy env wired, and `cwd`/`user`/`env`
+    fields hidden from the model. `binds` are mounted into the container at
+    creation; `working_dir` becomes the container cwd.
+    """
+    config = ContainerExecServerConfig(
+        image=image,
+        working_dir=working_dir,
+        network_mode="host",
+        environment=_proxy_env(),
+        allow_user_field=False,
+        allow_env_field=False,
+        cwd_policy=AlwaysSetTo(value=working_dir),
+        binds=list(binds or []),
+    )
+    launcher = get_required_path(_LAUNCHER_RLOCATION)
+    async with MCPStdioTool(name=name, command=str(launcher), args=["--config", config.model_dump_json()]) as tool:
+        yield tool

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -53,7 +53,10 @@ async def _run_with_replay(
     hint: bool = True,
     turn_limit: int = _TEST_TURNS,
 ) -> RunSummary:
-    client = ReplayChatClient(responses=completions)
+    # function_learning hand-rolls its tool-dispatch loop, so disable the
+    # FunctionInvocationLayer's auto-dispatch to keep one model_client.get_response()
+    # call per scripted response.
+    client = ReplayChatClient(responses=completions, function_invocation_configuration={"enabled": False})
 
     async with aiodocker.Docker() as docker:
         container = await docker.containers.run(

--- a/skills/info_gathering/evals/replay_client.py
+++ b/skills/info_gathering/evals/replay_client.py
@@ -1,28 +1,61 @@
 """Replay chat client for deterministic testing.
 
-Returns pre-scripted ChatResponse objects in order, replacing AutoGen's
-ReplayChatCompletionClient for the Agent Framework migration.
+A minimal Microsoft Agent Framework chat client that returns pre-scripted
+`ChatResponse` objects in order. Composed of the same layer stack as
+production AF clients (`FunctionInvocationLayer` + `ChatMiddlewareLayer` +
+`ChatTelemetryLayer` over `BaseChatClient`), so `Agent.run()` exercises
+the real tool-dispatch loop against scripted responses.
+
+Consumers that hand-roll their own tool-dispatch loop (and don't want the
+function-invocation layer to auto-dispatch tool calls between scripted
+responses) should pass `function_invocation_configuration={"enabled": False}`
+to disable the layer's loop.
 """
 
-from collections.abc import Sequence
+from collections.abc import Awaitable, Mapping, Sequence
+from typing import Any, ClassVar
 
-from agent_framework import ChatResponse
+from agent_framework import (
+    BaseChatClient,
+    ChatMiddlewareLayer,
+    ChatResponse,
+    ChatResponseUpdate,
+    FunctionInvocationConfiguration,
+    FunctionInvocationLayer,
+    Message,
+    ResponseStream,
+)
+from agent_framework.observability import ChatTelemetryLayer
 
 
-class ReplayChatClient:
-    """Chat client that replays scripted responses in order.
+class ReplayChatClient(
+    FunctionInvocationLayer[Any], ChatMiddlewareLayer[Any], ChatTelemetryLayer[Any], BaseChatClient[Any]
+):
+    """Chat client that replays scripted responses in order."""
 
-    Implements the same get_response interface as Agent Framework chat clients
-    but returns pre-configured responses instead of calling an LLM.
-    """
+    OTEL_PROVIDER_NAME: ClassVar[str] = "replay"
 
-    def __init__(self, responses: Sequence[ChatResponse]) -> None:
+    def __init__(
+        self,
+        responses: Sequence[ChatResponse],
+        *,
+        function_invocation_configuration: FunctionInvocationConfiguration | None = None,
+    ) -> None:
+        super().__init__(middleware=[], function_invocation_configuration=function_invocation_configuration)
         self._responses = list(responses)
         self._index = 0
 
-    async def get_response(self, messages: Sequence, **kwargs: object) -> ChatResponse:
-        if self._index >= len(self._responses):
-            raise RuntimeError(f"ReplayChatClient exhausted: used all {len(self._responses)} responses")
-        response = self._responses[self._index]
-        self._index += 1
-        return response
+    def _inner_get_response(
+        self, *, messages: Sequence[Message], stream: bool, options: Mapping[str, Any], **kwargs: Any
+    ) -> Awaitable[ChatResponse] | ResponseStream[ChatResponseUpdate, ChatResponse]:
+        if stream:
+            raise NotImplementedError("ReplayChatClient does not support streaming")
+
+        async def _get() -> ChatResponse:
+            if self._index >= len(self._responses):
+                raise RuntimeError(f"ReplayChatClient exhausted: used all {len(self._responses)} responses")
+            response = self._responses[self._index]
+            self._index += 1
+            return response
+
+        return _get()

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/BUILD.bazel
@@ -4,17 +4,19 @@ py_library(
     name = "twenty_questions",
     srcs = ["twenty_questions.py"],
     deps = [
-        "//skills/eval_infra:docker_exec",
+        "//skills/eval_infra:af_chat_client",
+        "//skills/eval_infra:af_scratch_mcp",
         "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions:result_types",
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",
         "//skills/info_gathering/evals/twenty_questions/x/shared:output",
         "//skills/info_gathering/evals/twenty_questions/x/shared:variants",
+        # The agent_framework core package's openai/anthropic stub modules
+        # reference these sibling packages; mypy needs them on the dep graph.
         "@pypi//agent_framework_anthropic",
         "@pypi//agent_framework_claude",
         "@pypi//agent_framework_core",
         "@pypi//agent_framework_openai",
-        "@pypi//fastmcp",
     ],
 )
 

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -1,27 +1,43 @@
-"""Twenty Questions game using Microsoft Agent Framework with structured guesser tools.
+"""Twenty Questions game using Microsoft Agent Framework's `Agent.run()`.
 
-The guesser has tool_choice=required and three tools: ask_yes_no_question,
-guess_answer, and exec (scratch computation). Game tools internally invoke the
-simulator (a single LLM call with answer/correct_answer/invalid_input tools)
-and return the result. No pub/sub messaging — just a direct tool loop.
+Two `Agent` instances share one chat client:
+
+- The simulator agent owns tools `answer`, `correct_answer`, `invalid_input`;
+  `tool_choice="required"` forces it to call exactly one per turn. A simulator-end
+  middleware raises `MiddlewareTermination` after each tool dispatch, so each
+  `sim_agent.run(...)` call resolves to one tool call (no further LLM round-trip).
+- The guesser agent owns `ask_yes_no_question`, `guess_answer`, and an optional
+  `exec` tool. The game-tool bodies invoke the simulator inline. A game-end
+  middleware terminates the loop once `game.result` is set.
+
+Both agents share an `InMemoryHistoryProvider` (auto-attached when no other
+HistoryProvider is configured). Per-agent history lives in its own
+`AgentSession` so the simulator's transcript doesn't leak into the guesser's
+context window.
 """
 
 import argparse
 import asyncio
-import json
+import contextlib
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from agent_framework import ChatResponse, Content, FunctionTool, Message
-from agent_framework.anthropic import AnthropicClient
-from agent_framework.openai import OpenAIChatCompletionClient
-from fastmcp.client import Client
-from mcp.types import TextContent
+from agent_framework import (
+    Agent,
+    AgentSession,
+    BaseChatClient,
+    FunctionInvocationContext,
+    FunctionMiddleware,
+    FunctionTool,
+    MCPStdioTool,
+    MiddlewareTermination,
+)
 
-from skills.eval_infra.docker_exec import scratch_exec_server
+from skills.eval_infra.af_chat_client import build_model_client
+from skills.eval_infra.af_scratch_mcp import scratch_exec_mcp_tool
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
@@ -39,8 +55,10 @@ from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIA
 
 logger = logging.getLogger(__name__)
 
+_MAX_STEPS = 200
 
-# -- Shared game state --
+
+# -- Game state --
 
 
 @dataclass
@@ -52,6 +70,7 @@ class GameContext:
     result: Result | None = None
     invalid_input_count: int = 0
     log_entries: list[LogEntry] = field(default_factory=list)
+    last_sim_response: str = ""
 
     def record(
         self, player: Literal["guesser", "simulator"], content: str, tool_calls: list[dict[str, object]] | None = None
@@ -61,29 +80,31 @@ class GameContext:
         )
 
 
-# -- Simulator: a stateful function, not an agent --
+# -- Simulator tools --
 
 
 def _make_sim_tools(game: GameContext) -> list[FunctionTool]:
-    """Create simulator tools that capture game state via closure."""
+    """Simulator's three terminal tools. Each updates game state and stores its
+    return value on game.last_sim_response so the guesser's tool body can read
+    it after `sim_agent.run(...)` returns."""
 
     async def answer(response: Literal["yes", "no", "sort_of"]) -> str:
-        """Answer the player's yes/no question."""
         game.record("simulator", response, [{"name": "answer", "args": {"response": response}}])
+        game.last_sim_response = response
         logger.info("Simulator: %s", response)
         return response
 
     async def correct_answer() -> str:
-        """The player correctly guessed the secret."""
         game.result = Correct(turns=game.turn)
         game.record("simulator", "", [{"name": "correct_answer", "args": {}}])
+        game.last_sim_response = "correct"
         logger.info("Correct answer on turn %d!", game.turn)
         return "correct"
 
     async def invalid_input(reason: str) -> str:
-        """The player's input is not a valid yes/no question or guess."""
         game.invalid_input_count += 1
         game.record("simulator", reason, [{"name": "invalid_input", "args": {"reason": reason}}])
+        game.last_sim_response = reason
         logger.info("Simulator: invalid_input — %s", reason)
         return reason
 
@@ -96,52 +117,14 @@ def _make_sim_tools(game: GameContext) -> list[FunctionTool]:
     ]
 
 
-def _extract_function_calls(response: ChatResponse) -> list[Content]:
-    """Extract function call Content items from a ChatResponse."""
-    msg = response.messages[0]
-    return [c for c in msg.contents if c.type == "function_call"]
+# -- Guesser game tools (invoke simulator inline) --
 
 
-async def _run_simulator(
-    *, model_client: Any, sim_history: list[Message], sim_tools: list[FunctionTool], text: str
-) -> str:
-    """Run one simulator turn: append text, call LLM with required tool use, execute tool, return result."""
-    sim_history.append(Message("user", [text]))
-    sim_tool_map = {t.name: t for t in sim_tools}
-
-    response = await model_client.get_response(
-        sim_history, options={"tools": sim_tools, "tool_choice": "required", "allow_multiple_tool_calls": False}
-    )
-
-    function_calls = _extract_function_calls(response)
-    if not function_calls:
-        text_content = response.messages[0].text
-        raise RuntimeError(f"Simulator returned text instead of tool call: {text_content!r}")
-
-    sim_history.append(response.messages[0])
-
-    results: list[Content] = []
-    tool_output = ""
-    for fc in function_calls:
-        assert fc.name is not None, f"function_call missing name: {fc}"
-        assert fc.call_id is not None, f"function_call missing call_id: {fc}"
-        tool = sim_tool_map[fc.name]
-        args = json.loads(fc.arguments) if isinstance(fc.arguments, str) else (fc.arguments or {})
-        tool_result = await tool.invoke(arguments=args)
-        tool_output = tool_result[0].text if tool_result and tool_result[0].text else ""
-        results.append(Content.from_function_result(fc.call_id, result=tool_output))
-    sim_history.append(Message("tool", results))
-
-    return tool_output
-
-
-# -- Guesser game tools --
-
-
-def _make_game_tools(
-    *, game: GameContext, model_client: Any, sim_history: list[Message], sim_tools: list[FunctionTool]
-) -> list[FunctionTool]:
-    """Create guesser game tools that internally invoke the simulator."""
+def _make_game_tools(*, game: GameContext, sim_agent: Agent, sim_session: AgentSession) -> list[FunctionTool]:
+    async def _drive_simulator(text: str) -> None:
+        # Simulator middleware terminates after the single tool call by design.
+        with contextlib.suppress(MiddlewareTermination):
+            await sim_agent.run(text, session=sim_session)
 
     async def ask_yes_no_question(question: str) -> str:
         """Ask a yes/no question. Uses one turn."""
@@ -149,21 +132,18 @@ def _make_game_tools(
         game.record("guesser", question, [{"name": "ask_yes_no_question", "args": {"question": question}}])
         logger.info("Guesser (turn %d): %s", game.turn, question[:200])
 
-        sim_response = await _run_simulator(
-            model_client=model_client, sim_history=sim_history, sim_tools=sim_tools, text=f"Question: {question}"
-        )
+        await _drive_simulator(f"Question: {question}")
 
-        # If simulator returned invalid_input, refund the turn.
-        if game.invalid_input_count > 0 and game.log_entries and game.log_entries[-1].tool_calls:
+        # Refund the turn if the simulator flagged the question as invalid.
+        if game.log_entries and game.log_entries[-1].tool_calls:
             last_call = game.log_entries[-1].tool_calls[0]
             if last_call.get("name") == "invalid_input":
                 game.turn -= 1
-                return sim_response
+                return game.last_sim_response
 
         if game.turn >= game.turn_limit and game.result is None:
             game.result = Timeout(limit=game.turn_limit)
-
-        return sim_response
+        return game.last_sim_response
 
     async def guess_answer(answer: str) -> str:
         """Guess the secret answer. Uses one turn."""
@@ -171,17 +151,13 @@ def _make_game_tools(
         game.record("guesser", answer, [{"name": "guess_answer", "args": {"answer": answer}}])
         logger.info("Guesser (turn %d) guesses: %s", game.turn, answer[:200])
 
-        sim_response = await _run_simulator(
-            model_client=model_client, sim_history=sim_history, sim_tools=sim_tools, text=f"My answer is: {answer}"
-        )
+        await _drive_simulator(f"My answer is: {answer}")
 
         if game.result is not None:
             return "Correct! You guessed it!"
-
         if game.turn >= game.turn_limit and game.result is None:
             game.result = Timeout(limit=game.turn_limit)
-
-        return sim_response  # "no" for wrong guess
+        return game.last_sim_response
 
     return [
         FunctionTool(
@@ -191,37 +167,30 @@ def _make_game_tools(
     ]
 
 
-# -- MCP exec tool bridge --
+# -- Middleware --
 
 
-def _make_exec_tool(mcp_client: Client) -> FunctionTool:
-    """Create a FunctionTool that delegates to the MCP exec tool via fastmcp.Client."""
+class _SimulatorEndMiddleware(FunctionMiddleware):
+    """Terminate the simulator's loop after every tool dispatch (one per run)."""
 
-    async def exec(cmd: list[str], timeout_ms: int = 30000) -> str:
-        """Run a command in a scratch container. cmd is a list of strings (no shell)."""
-        arguments: dict[str, object] = {"cmd": cmd, "timeout_ms": timeout_ms}
-        result = await mcp_client.call_tool("exec", arguments)
-        return "\n".join(block.text for block in result.content if isinstance(block, TextContent))
-
-    return FunctionTool(
-        name="exec", description="Run a command in a scratch container. cmd is a list of strings (no shell).", func=exec
-    )
+    async def process(self, context: FunctionInvocationContext, call_next: Any) -> None:
+        await call_next()
+        raise MiddlewareTermination("simulator turn complete")
 
 
-# -- Helpers --
+class _GameEndMiddleware(FunctionMiddleware):
+    """Terminate the guesser's loop once the game is decided (correct or timeout)."""
+
+    def __init__(self, game: GameContext) -> None:
+        self._game = game
+
+    async def process(self, context: FunctionInvocationContext, call_next: Any) -> None:
+        await call_next()
+        if self._game.result is not None:
+            raise MiddlewareTermination("game decided")
 
 
-def _build_model_client(*, api: str, model: str) -> Any:
-    if api == "openai":
-        return OpenAIChatCompletionClient(model=model)
-    if api == "anthropic":
-        return AnthropicClient(model=model)
-    raise ValueError(f"Unsupported API: {api!r}")
-
-
-# -- Main game loop --
-
-_MAX_STEPS = 200  # Safety cap to prevent infinite loops.
+# -- Main --
 
 
 async def run_game(
@@ -230,11 +199,15 @@ async def run_game(
     model: str,
     api: str,
     output_dir: Path,
-    exec_tool: FunctionTool | None = None,
-    model_client: Any | None = None,
+    model_client: BaseChatClient[Any],
+    exec_tool: MCPStdioTool | None = None,
     no_skill: bool = False,
 ) -> RunSummary:
-    """Execute one Twenty Questions game and persist results."""
+    """Execute one Twenty Questions game and persist results.
+
+    The caller owns `model_client`'s lifecycle; this function neither
+    constructs nor closes it.
+    """
     variant = VARIANTS[variant_name]
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
     guesser_system = build_guesser_system(
@@ -242,62 +215,38 @@ async def run_game(
     )
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
-    owns_client = model_client is None
-    if model_client is None:
-        model_client = _build_model_client(api=api, model=model)
-
     game = GameContext(turn_limit=variant.turn_limit)
 
-    # Simulator state
-    sim_history: list[Message] = [Message("system", [sim_system])]
-    sim_tools = _make_sim_tools(game)
+    sim_agent = Agent(
+        client=model_client,
+        instructions=sim_system,
+        tools=_make_sim_tools(game),
+        middleware=[_SimulatorEndMiddleware()],
+        default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
+    )
+    sim_session = AgentSession()
 
-    # Guesser tools = game tools + optional exec
-    game_tools = _make_game_tools(game=game, model_client=model_client, sim_history=sim_history, sim_tools=sim_tools)
-    all_guesser_tools = list(game_tools)
-    if exec_tool:
-        all_guesser_tools.append(exec_tool)
-    guesser_tool_map = {t.name: t for t in all_guesser_tools}
+    guesser_tools: list[FunctionTool | MCPStdioTool] = list(
+        _make_game_tools(game=game, sim_agent=sim_agent, sim_session=sim_session)
+    )
+    if exec_tool is not None:
+        guesser_tools.append(exec_tool)
 
-    # Guesser conversation history
-    guesser_history: list[Message] = [Message("system", [guesser_system]), Message("user", [opening])]
+    guesser_agent = Agent(
+        client=model_client,
+        instructions=guesser_system,
+        tools=guesser_tools,
+        middleware=[_GameEndMiddleware(game)],
+        default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
+    )
+    guesser_session = AgentSession()
 
-    # Main loop: call guesser LLM with tool_choice=required, execute tools, repeat.
-    for _ in range(_MAX_STEPS):
-        if game.result is not None:
-            break
-
-        response = await model_client.get_response(
-            guesser_history,
-            options={"tools": all_guesser_tools, "tool_choice": "required", "allow_multiple_tool_calls": False},
-        )
-
-        function_calls = _extract_function_calls(response)
-        if not function_calls:
-            # Shouldn't happen with tool_choice=required, but handle gracefully.
-            guesser_history.append(response.messages[0])
-            continue
-
-        guesser_history.append(response.messages[0])
-
-        results: list[Content] = []
-        for fc in function_calls:
-            assert fc.name is not None, f"function_call missing name: {fc}"
-            assert fc.call_id is not None, f"function_call missing call_id: {fc}"
-            tool = guesser_tool_map[fc.name]
-            args = json.loads(fc.arguments) if isinstance(fc.arguments, str) else (fc.arguments or {})
-            try:
-                tool_result = await tool.invoke(arguments=args)
-                content = tool_result[0].text if tool_result and tool_result[0].text else ""
-            except Exception as e:
-                content = f"Error: {e}"
-                logger.warning("Tool %s error: %s", fc.name, e)
-            results.append(Content.from_function_result(fc.call_id, result=content))
-        guesser_history.append(Message("tool", results))
+    # Game-end middleware terminates once `game.result` is set.
+    with contextlib.suppress(MiddlewareTermination):
+        await guesser_agent.run(opening, session=guesser_session)
 
     if game.result is None:
         game.result = Timeout(limit=game.turn_limit)
-
     result_val = game.result
     turns = result_val.limit if isinstance(result_val, Timeout) else result_val.turns
 
@@ -316,22 +265,21 @@ async def run_game(
         invalid_input_count=game.invalid_input_count,
     )
     save_summary(summary=summary, summary_path=summary_path)
-
-    if owns_client and hasattr(model_client, "close"):
-        await model_client.close()
     return summary
 
 
 async def _async_main(args: argparse.Namespace) -> None:
     output_dir = output_dir_from_args(args)
-
-    async with scratch_exec_server() as server, Client(server) as mcp_client:
-        exec_tool = _make_exec_tool(mcp_client)
+    model_client = build_model_client(
+        api=args.api, model=args.model, function_invocation_configuration={"max_iterations": _MAX_STEPS}
+    )
+    async with scratch_exec_mcp_tool() as exec_tool:
         summary = await run_game(
             variant_name=args.variant,
             model=args.model,
             api=args.api,
             output_dir=output_dir,
+            model_client=model_client,
             exec_tool=exec_tool,
             no_skill=getattr(args, "no_skill", False),
         )
@@ -344,9 +292,7 @@ def main() -> None:
     parser.add_argument("--no-skill", action="store_true", help="Run without info-gathering skill prompt (baseline)")
     args = parser.parse_args()
     resolve_args(args)
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
-
     asyncio.run(_async_main(args))
 
 


### PR DESCRIPTION
## Summary

Microsoft Agent Framework runs the function-tool dispatch loop internally via `Agent.run()` + `FunctionInvocationLayer`, and exposes MCP servers as agent tools natively via `MCPStdioTool`. The twenty_questions agent_framework rollout was hand-rolling both — a `for step in range(_MAX_STEPS)` calling `client.get_response()` with manual `Content.from_function_result` plumbing, and a `make_exec_tool` bridge wrapping a `fastmcp.Client` as a `FunctionTool`. Replacing both with AF primitives shrinks the rollout by ~80 LOC and removes two layers of glue we maintained ourselves.

## What changes

### Loop refactor — `twenty_questions.py`

- **Two `Agent` instances** share one chat client.
  - The **simulator** uses a `_SimulatorEndMiddleware` that raises `MiddlewareTermination` after each tool dispatch — every `sim_agent.run()` resolves to exactly one tool call, no further LLM round-trip.
  - The **guesser** uses a `_GameEndMiddleware` that terminates the loop once `game.result` is set.
- Each agent has its own `AgentSession`; AF auto-attaches an `InMemoryHistoryProvider`.
- Game tools (`ask_yes_no_question`, `guess_answer`) drive the simulator inline via `sim_agent.run()` and read its result from `game.last_sim_response` (set as a side effect by the simulator's tools).

### MCP transport refactor — `//skills/eval_infra:af_scratch_mcp`

- New `scratch_exec_mcp_tool` helper yields an `MCPStdioTool` that launches `//mcp_infra/exec:docker_launcher` as a subprocess (same defaults as `scratch_exec_server`: host network, proxy env, locked-down user/env/cwd). AF dispatches the server's `exec` tool natively — no `fastmcp.Client` and no `FunctionTool` bridge in the rollout.
- `_build_model_client` moved to `//skills/eval_infra:af_chat_client` (shared with the upcoming RE rollout refactor).
- No `af_mcp_exec.py` — `scratch_exec_mcp_tool` covers the same need with one fewer hand-rolled layer.

### Test infrastructure — `ReplayChatClient`

`ReplayChatClient` (`//skills/info_gathering/evals:replay_client`) was a trivial class with a single `get_response()`. To work with `Agent.run()`, it now extends the standard AF layer stack (`FunctionInvocationLayer` + `ChatMiddlewareLayer` + `ChatTelemetryLayer` + `BaseChatClient`) and implements `_inner_get_response`. Matches the pattern AF uses for its own `MockBaseChatClient` (`python/packages/core/tests/core/conftest.py`). `Agent.run()` now drives the real tool-dispatch loop against scripted responses — every existing test (correct guess, timeout, sort_of, invalid_input refund, log files) keeps its semantics.

The `reverse_engineer` rollout (currently on #1383) gets the same treatment in a follow-up after that PR lands; tracked in `skills/eval_infra/TODO.md`.

## Test plan

- [x] `bbr test //skills/info_gathering/evals/twenty_questions/x/agent_framework:test_twenty_questions --nocache_test_results` — 6/6 pass on RBE ([invocation `6f1f114b`](https://app.buildbuddy.io/invocation/6f1f114b-d100-47b3-ba21-3596c47a7d69))
- [x] Lint (ruff + mypy + buildifier via pre-commit)

https://claude.ai/code/session_01BcMHaLnwEFUdNKmZpJvht8