### PR TITLE
Add nodes/proxy read permission to cluster diagnostics reader role

### DIFF
--- a/cluster/k8s/agents/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agents/claude-rbac/clusterrole-cluster-diagnostics-reader.yaml
@@ -111,6 +111,14 @@ rules:
       - pods
       - nodes
     verbs: ["get", "list", "watch"]
+  # nodes/proxy allows GET requests proxied through the apiserver to the kubelet HTTP API.
+  # Enables: /stats/summary (resource usage), /metrics, /pods, /logs/<filename> (node system logs).
+  # get-only: dangerous kubelet operations (exec, run, attach, portforward) use POST → require
+  # the "create" verb, which is intentionally not granted here.
+  - apiGroups: [""]
+    resources:
+      - nodes/proxy
+    verbs: ["get"]
   - apiGroups: ["monitoring.coreos.com"]
     resources:
       - prometheuses


### PR DESCRIPTION
## Summary
This change grants the cluster diagnostics reader role permission to access the kubelet proxy endpoint, enabling diagnostic tools to retrieve resource usage metrics and logs from nodes.

## Key Changes
- Added `nodes/proxy` resource with `get` verb to the cluster diagnostics reader ClusterRole
- Included detailed comments explaining the purpose and security implications of this permission

## Implementation Details
The `nodes/proxy` permission allows GET requests to be proxied through the Kubernetes API server to the kubelet HTTP API. This enables access to:
- `/stats/summary` - node resource usage statistics
- `/metrics` - node metrics
- `/pods` - pod information on the node
- `/logs/<filename>` - node system logs

The permission is intentionally limited to the `get` verb only. Dangerous kubelet operations (exec, run, attach, portforward) require the `create` verb via POST requests, which is not granted to this role, maintaining security boundaries.

https://claude.ai/code/session_01EjLMtdfQ4AfuvjUPZK9Vj1