### PR TITLE
Mount info_gathering skill into TQ + FL containers; standardize --skill on/off

### DIFF
--- a/skills/eval_infra/BUILD.bazel
+++ b/skills/eval_infra/BUILD.bazel
@@ -1,4 +1,17 @@
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//devinfra/python:defs.bzl", "py_library")
+
+# A skill tar that contains nothing but an empty SKILL.md, used as the
+# "skill off" arm in skill-eval rollouts. Mounting an empty skill keeps
+# the sandbox shape uniform across arms — there's no skill_on/off branch
+# in the rollout code, just a different tar.
+pkg_tar(
+    name = "empty_skill_tar",
+    srcs = ["empty_skill/SKILL.md"],
+    package_dir = "empty_skill",
+    strip_prefix = "empty_skill",
+    visibility = ["//skills:__subpackages__"],
+)
 
 py_library(
     name = "docker_exec",

--- a/skills/info_gathering/evals/function_learning/BUILD.bazel
+++ b/skills/info_gathering/evals/function_learning/BUILD.bazel
@@ -41,15 +41,20 @@ py_library(
 py_library(
     name = "function_learning",
     srcs = ["function_learning.py"],
+    data = [
+        "//skills/eval_infra:empty_skill_tar",
+        "//skills/info_gathering:info_gathering_tar",
+    ],
     deps = [
         ":functions",
         ":prompts",
         ":result_types",
         ":scoring",
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:af_chat_client",
         "//skills/eval_infra:af_scratch_mcp",
-        "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions/x/shared:output",
+        "//util/bazel:runfiles",
         # agent_framework's __init__.py references openai/anthropic stubs.
         "@pypi//agent_framework_anthropic",
         "@pypi//agent_framework_claude",
@@ -71,8 +76,13 @@ py_library(
     srcs = ["run_all_evals.py"],
     deps = [
         ":function_learning",
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:af_chat_client",
         "//skills/eval_infra:af_scratch_mcp",
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
         "@pypi//aiodocker",
         "@pypi//anyio",
         "@pypi//pydantic",
@@ -117,12 +127,16 @@ py_test(
         "conftest.py",
         "test_function_learning.py",
     ],
+    data = ["//third_party/containers:python_3_13_slim"],
     requires_docker = True,
     deps = [
         ":function_learning",
         ":functions",
         ":result_types",
+        "//skills/eval_infra:af_scratch_mcp",
         "//skills/info_gathering/evals:replay_client",
+        "//third_party/containers:rlocations",
+        "//util:oci",
         # agent_framework's __init__.py references openai/anthropic stubs.
         "@pypi//agent_framework_anthropic",
         "@pypi//agent_framework_claude",

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -73,7 +73,7 @@ def _load_skill(tar_rlocation: str, package_name: str, extract_dir: Path) -> tup
     """Extract a skill tar; return (host dir to bind-mount, SKILL.md text)."""
     tar_path = get_required_path(tar_rlocation)
     with tarfile.open(tar_path) as tf:
-        tf.extractall(extract_dir)
+        tf.extractall(extract_dir, filter="data")
     skill_dir = extract_dir / package_name
     skill_md = (skill_dir / "SKILL.md").read_text()
     return skill_dir, skill_md

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -18,6 +18,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import tarfile
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,6 +40,7 @@ from agent_framework import (
     MiddlewareTermination,
 )
 
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.af_chat_client import build_model_client
 from skills.eval_infra.af_scratch_mcp import scratch_exec_mcp_tool
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS, SecretFunction
@@ -50,12 +52,31 @@ from skills.info_gathering.evals.function_learning.result_types import (
     TurnResult,
 )
 from skills.info_gathering.evals.function_learning.scoring import EVAL_TIMEOUT_S, evaluate_program
-from skills.info_gathering.evals.twenty_questions.prompts import load_skill_prompt
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths
+from util.bazel.runfiles import get_required_path
 
 logger = logging.getLogger(__name__)
 
 _MAX_STEPS = 200
+_SKILL_FILES_PATH = "/work/.skill"
+
+# Maps the --skill CLI value to (rlocation, package_name) of the tar to mount
+# into the scratch container. The "off" arm uses an empty SKILL.md so the
+# sandbox shape is uniform across arms — there is no `if skill_on:` branch.
+_SKILL_TARS: dict[str, tuple[str, str]] = {
+    "on": ("_main/skills/info_gathering/info_gathering_tar.tar", "info_gathering"),
+    "off": ("_main/skills/eval_infra/empty_skill_tar.tar", "empty_skill"),
+}
+
+
+def _load_skill(tar_rlocation: str, package_name: str, extract_dir: Path) -> tuple[Path, str]:
+    """Extract a skill tar; return (host dir to bind-mount, SKILL.md text)."""
+    tar_path = get_required_path(tar_rlocation)
+    with tarfile.open(tar_path) as tf:
+        tf.extractall(extract_dir)
+    skill_dir = extract_dir / package_name
+    skill_md = (skill_dir / "SKILL.md").read_text()
+    return skill_dir, skill_md
 
 
 # --- Game state ---
@@ -201,17 +222,22 @@ async def run_game(
     exec_tool: MCPStdioTool | FunctionTool,
     scoring_container: aiodocker.docker.DockerContainer,
     model_client: BaseChatClient[Any],
-    no_skill: bool = False,
+    skill_md: str,
+    skill_files_path: str,
 ) -> RunSummary:
     """Execute one function learning game and persist results.
 
     The caller owns `model_client`'s lifecycle; this function neither
-    constructs nor closes it.
+    constructs nor closes it. The caller also owns staging the skill
+    (extracting the tar, mounting the dir into `exec_tool`'s container);
+    `skill_md` is the SKILL.md text to inline (empty string for the
+    off-arm — the empty-skill tar has an empty SKILL.md), and
+    `skill_files_path` is the in-container path the agent can `cat`/`ls`.
     """
     secret_fn = FUNCTIONS[function_name]
     description = secret_fn.description if hint else _NO_HINT
 
-    system = build_system_prompt(skill="" if no_skill else load_skill_prompt(), has_scratch=True)
+    system = build_system_prompt(skill=skill_md, has_scratch=True, skill_files_path=skill_files_path)
     opening = first_user_message(secret_fn, turn_limit, description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
@@ -274,7 +300,11 @@ async def _async_main(args: argparse.Namespace) -> None:
         api=args.api, model=args.model, function_invocation_configuration={"max_iterations": _MAX_STEPS}
     )
 
-    async with scratch_exec_mcp_tool() as exec_tool:
+    tar_rlocation, package_name = _SKILL_TARS[args.skill]
+    skill_dir, skill_md = _load_skill(tar_rlocation, package_name, output_dir / "skill_extract")
+    skill_bind = BindMount(host_path=skill_dir.resolve(), container_path=Path(_SKILL_FILES_PATH), mode="ro")
+
+    async with scratch_exec_mcp_tool(binds=[skill_bind]) as exec_tool:
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:
             container = await docker.containers.run(
@@ -290,7 +320,8 @@ async def _async_main(args: argparse.Namespace) -> None:
                     exec_tool=exec_tool,
                     scoring_container=container,
                     model_client=model_client,
-                    no_skill=args.no_skill,
+                    skill_md=skill_md,
+                    skill_files_path=_SKILL_FILES_PATH,
                     turn_limit=args.turn_limit,
                 )
             finally:
@@ -305,7 +336,12 @@ def main() -> None:
     parser.add_argument("--model", required=True)
     parser.add_argument("--api", choices=["openai", "anthropic"], default="anthropic")
     parser.add_argument("--output-dir", default=None)
-    parser.add_argument("--no-skill", action="store_true")
+    parser.add_argument(
+        "--skill",
+        choices=["on", "off"],
+        default="on",
+        help="Skill arm: 'on' mounts info_gathering, 'off' mounts an empty skill tar.",
+    )
     parser.add_argument("--turn-limit", type=int, required=True)
     args = parser.parse_args()
 

--- a/skills/info_gathering/evals/function_learning/prompts.py
+++ b/skills/info_gathering/evals/function_learning/prompts.py
@@ -15,23 +15,27 @@ _BASE_PREAMBLE = (
 )
 
 
-def build_system_prompt(*, skill: str, has_scratch: bool, skill_files_path: str) -> str:
+def build_system_prompt(*, skill: str, has_scratch: bool, skill_files_path: str | None) -> str:
     """Compose the system prompt for the function learning guesser.
 
     Args:
-        skill: SKILL.md text to inline. Empty string for the off-arm
-               (the empty-skill tar is still mounted; SKILL.md is just blank).
+        skill: SKILL.md text to inline. Empty string for the off-arm of a
+               mounted-skill rollout (the empty-skill tar's SKILL.md is blank).
         has_scratch: Include the scratch container exec tool note.
         skill_files_path: In-container path where the skill tar is bind-mounted
-                          (e.g. ``/work/.skill``). Always non-empty — every
-                          rollout mounts a skill (real or empty).
+                          (e.g. ``/work/.skill``), or ``None`` when the rollout
+                          doesn't mount the skill into a sandbox. Pass it
+                          explicitly.
     """
     parts: list[str] = [_BASE_PREAMBLE]
-    parts.append(
-        f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>\n\n"
-        f"The full skill (SKILL.md and any referenced example files) is available "
-        f"in the container at {skill_files_path}/."
-    )
+    if skill or skill_files_path is not None:
+        skill_block = f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>"
+        if skill_files_path is not None:
+            skill_block += (
+                f"\n\nThe full skill (SKILL.md and any referenced example files) is available "
+                f"in the container at {skill_files_path}/."
+            )
+        parts.append(skill_block)
     if has_scratch:
         parts.append(load_scratch_system_note())
     return "\n\n---\n\n".join(parts)

--- a/skills/info_gathering/evals/function_learning/prompts.py
+++ b/skills/info_gathering/evals/function_learning/prompts.py
@@ -15,16 +15,25 @@ _BASE_PREAMBLE = (
 )
 
 
-def build_system_prompt(*, skill: str, has_scratch: bool) -> str:
-    """Compose the system prompt for the function learning guesser."""
+def build_system_prompt(*, skill: str, has_scratch: bool, skill_files_path: str) -> str:
+    """Compose the system prompt for the function learning guesser.
+
+    Args:
+        skill: SKILL.md text to inline. Empty string for the off-arm
+               (the empty-skill tar is still mounted; SKILL.md is just blank).
+        has_scratch: Include the scratch container exec tool note.
+        skill_files_path: In-container path where the skill tar is bind-mounted
+                          (e.g. ``/work/.skill``). Always non-empty — every
+                          rollout mounts a skill (real or empty).
+    """
     parts: list[str] = [_BASE_PREAMBLE]
-
-    if skill:
-        parts.append(f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>")
-
+    parts.append(
+        f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>\n\n"
+        f"The full skill (SKILL.md and any referenced example files) is available "
+        f"in the container at {skill_files_path}/."
+    )
     if has_scratch:
         parts.append(load_scratch_system_note())
-
     return "\n\n---\n\n".join(parts)
 
 

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -1,18 +1,27 @@
-"""Run all function learning eval games: 9 functions x 2 arms (skill/no-skill)."""
+"""Run all function learning eval games: 9 functions x 2 arms (skill/no_skill)."""
 
 import argparse
 import asyncio
 import logging
 import uuid
+from contextlib import AsyncExitStack
 from pathlib import Path
 
 import aiodocker
 import anyio
+from agent_framework import MCPStdioTool
 from pydantic import BaseModel
 
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.af_chat_client import build_model_client
 from skills.eval_infra.af_scratch_mcp import scratch_exec_mcp_tool
-from skills.info_gathering.evals.function_learning.function_learning import _MAX_STEPS, run_game
+from skills.info_gathering.evals.function_learning.function_learning import (
+    _MAX_STEPS,
+    _SKILL_FILES_PATH,
+    _SKILL_TARS,
+    _load_skill,
+    run_game,
+)
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS
 from skills.info_gathering.evals.function_learning.result_types import FunctionLearningResult, TokenUsage
 
@@ -23,7 +32,7 @@ FUNCTIONS_LIST = list(FUNCTIONS.keys())
 
 class RunRecord(BaseModel):
     function: str
-    arm: str  # "skill" or "no_skill"
+    arm: str  # "on" or "off"
     run_idx: int
     model: str
     turns: int
@@ -33,9 +42,10 @@ class RunRecord(BaseModel):
 
 async def run_one(
     function_name: str,
-    arm_no_skill: bool,
+    arm: str,
     run_idx: int,
-    exec_tool,
+    exec_tool: MCPStdioTool,
+    skill_md: str,
     scoring_container,
     model_client,
     sem: asyncio.Semaphore,
@@ -44,7 +54,6 @@ async def run_one(
     turn_limit: int,
     output_dir: Path,
 ) -> RunRecord | None:
-    arm = "no_skill" if arm_no_skill else "skill"
     label = f"{function_name}/{arm}[{run_idx}]"
     print(f"  START {label}", flush=True)
     async with sem:
@@ -59,7 +68,8 @@ async def run_one(
                 exec_tool=exec_tool,
                 scoring_container=scoring_container,
                 model_client=model_client,
-                no_skill=arm_no_skill,
+                skill_md=skill_md,
+                skill_files_path=_SKILL_FILES_PATH,
             )
             record = RunRecord(
                 function=function_name,
@@ -90,7 +100,17 @@ async def _async_main(args: argparse.Namespace) -> None:
         api=args.api, model=args.model, function_invocation_configuration={"max_iterations": _MAX_STEPS}
     )
 
-    async with scratch_exec_mcp_tool() as exec_tool, aiodocker.Docker() as docker:
+    # Extract each arm's skill tar once and spin up one exec_tool per arm.
+    arms: dict[str, tuple[MCPStdioTool, str]] = {}
+    async with AsyncExitStack() as stack:
+        for arm in ("on", "off"):
+            tar_rlocation, package_name = _SKILL_TARS[arm]
+            skill_dir, skill_md = _load_skill(tar_rlocation, package_name, output_dir / f"skill_extract_{arm}")
+            skill_bind = BindMount(host_path=skill_dir.resolve(), container_path=Path(_SKILL_FILES_PATH), mode="ro")
+            exec_tool = await stack.enter_async_context(scratch_exec_mcp_tool(binds=[skill_bind]))
+            arms[arm] = (exec_tool, skill_md)
+
+        docker = await stack.enter_async_context(aiodocker.Docker())
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         scoring_container = await docker.containers.run(
             config={"Image": "python:3.13-slim", "Cmd": ["sleep", "7200"]}, name=container_name
@@ -99,19 +119,20 @@ async def _async_main(args: argparse.Namespace) -> None:
             tasks = [
                 run_one(
                     fn_name,
-                    no_skill,
+                    arm,
                     run_idx,
-                    exec_tool,
+                    arms[arm][0],
+                    arms[arm][1],
                     scoring_container,
                     model_client,
                     sem,
                     model=args.model,
                     api=args.api,
                     turn_limit=args.turn_limit,
-                    output_dir=output_dir / fn_name / ("no_skill" if no_skill else "skill") / f"run_{run_idx}",
+                    output_dir=output_dir / fn_name / arm / f"run_{run_idx}",
                 )
                 for fn_name in FUNCTIONS_LIST
-                for no_skill in [False, True]
+                for arm in ("on", "off")
                 for run_idx in range(args.runs_per_cell)
             ]
             raw_results = await asyncio.gather(*tasks)

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -1,4 +1,4 @@
-"""Run all function learning eval games: 9 functions x 2 arms (skill/no_skill)."""
+"""Run all function learning eval games: 9 functions x 2 arms (skill on/off)."""
 
 import argparse
 import asyncio

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -1,7 +1,16 @@
 """Tests for the function learning game loop.
 
 Uses ReplayChatClient for scripted LLM responses, but runs real
-Docker-based program evaluation (no mocking of evaluate_program).
+Docker-based program evaluation (no mocking of evaluate_program) and a
+real `scratch_exec_mcp_tool()` exec tool — the replay scripts don't
+call exec, but wiring it up to the real MCP launcher means the test
+fails loud if that surface breaks.
+
+Loads `python:3.13-slim` into the Docker daemon up-front via
+`load_oci_image` (matches the pattern in
+`skills/info_gathering/evals/docker_scratch.py`) so neither the test's
+scoring container nor the launcher subprocess hits a 404 on a worker
+without the image cached.
 """
 
 import json
@@ -10,23 +19,17 @@ from pathlib import Path
 
 import aiodocker
 import pytest_bazel
-from agent_framework import ChatResponse, Content, FunctionTool, Message
+from agent_framework import ChatResponse, Content, Message
 
+from skills.eval_infra.af_scratch_mcp import scratch_exec_mcp_tool
 from skills.info_gathering.evals.function_learning.function_learning import run_game
 from skills.info_gathering.evals.function_learning.functions import PARITY_GROUPS
 from skills.info_gathering.evals.function_learning.result_types import RunSummary
 from skills.info_gathering.evals.replay_client import ReplayChatClient
+from third_party.containers.rlocations import PYTHON_3_13_SLIM
+from util.oci import load_oci_image
 
 _TEST_TURNS = 3
-
-
-def _dummy_exec_tool() -> FunctionTool:
-    """Exec tool that is never called — replay client only issues play_turn calls."""
-
-    async def exec(cmd: list[str], timeout_ms: int = 30000) -> str:
-        raise RuntimeError("exec should not be called in replay tests")
-
-    return FunctionTool(name="exec", description="dummy", func=exec)
 
 
 def _play_turn_call(query: int, program: str) -> ChatResponse:
@@ -54,10 +57,11 @@ async def _run_with_replay(
     turn_limit: int = _TEST_TURNS,
 ) -> RunSummary:
     client = ReplayChatClient(responses=completions)
+    image_tag = load_oci_image(PYTHON_3_13_SLIM)
 
-    async with aiodocker.Docker() as docker:
+    async with scratch_exec_mcp_tool() as exec_tool, aiodocker.Docker() as docker:
         container = await docker.containers.run(
-            config={"Image": "python:3.13-slim", "Cmd": ["sleep", "300"]}, name=f"fl-test-{uuid.uuid4().hex[:8]}"
+            config={"Image": image_tag, "Cmd": ["sleep", "300"]}, name=f"fl-test-{uuid.uuid4().hex[:8]}"
         )
         try:
             return await run_game(
@@ -66,9 +70,11 @@ async def _run_with_replay(
                 model="test-model",
                 api="openai",
                 output_dir=tmp_path,
-                exec_tool=_dummy_exec_tool(),
+                exec_tool=exec_tool,
                 model_client=client,
                 scoring_container=container,
+                skill_md="",
+                skill_files_path="/work/.skill",
                 turn_limit=turn_limit,
             )
         finally:

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -29,21 +29,25 @@ def load_scratch_system_note() -> str:
     return get_required_path(_SCRATCH_NOTE_RLOCATION).read_text().strip()
 
 
-def build_guesser_system(*, skill: str, has_scratch: bool) -> str:
+def build_guesser_system(*, skill: str, has_scratch: bool, skill_files_path: str) -> str:
     """Compose the guesser's system prompt from independent pieces.
 
     Args:
-        skill: Skill text to include. Empty string = no skill.
+        skill: Skill text to inline. Empty string for the off-arm
+               (the empty-skill tar is still mounted; SKILL.md is just blank).
         has_scratch: Include the scratch container exec tool note.
+        skill_files_path: In-container path where the skill tar is bind-mounted
+                          (e.g. ``/work/.skill``). Always non-empty — every
+                          rollout mounts a skill (real or empty).
     """
     parts: list[str] = [_BASE_GUESSER_PREAMBLE]
-
-    if skill:
-        parts.append(f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>")
-
+    parts.append(
+        f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>\n\n"
+        f"The full skill (SKILL.md and any referenced example files) is available "
+        f"in the container at {skill_files_path}/."
+    )
     if has_scratch:
         parts.append(load_scratch_system_note())
-
     return "\n\n---\n\n".join(parts)
 
 

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -29,23 +29,27 @@ def load_scratch_system_note() -> str:
     return get_required_path(_SCRATCH_NOTE_RLOCATION).read_text().strip()
 
 
-def build_guesser_system(*, skill: str, has_scratch: bool, skill_files_path: str) -> str:
+def build_guesser_system(*, skill: str, has_scratch: bool, skill_files_path: str | None) -> str:
     """Compose the guesser's system prompt from independent pieces.
 
     Args:
-        skill: Skill text to inline. Empty string for the off-arm
-               (the empty-skill tar is still mounted; SKILL.md is just blank).
+        skill: Skill text to inline. Empty string for the off-arm of a
+               mounted-skill rollout (the empty-skill tar's SKILL.md is blank).
         has_scratch: Include the scratch container exec tool note.
         skill_files_path: In-container path where the skill tar is bind-mounted
-                          (e.g. ``/work/.skill``). Always non-empty — every
-                          rollout mounts a skill (real or empty).
+                          (e.g. ``/work/.skill``), or ``None`` when the rollout
+                          doesn't mount the skill into a sandbox (the four
+                          non-AF framework variants today). Pass it explicitly.
     """
     parts: list[str] = [_BASE_GUESSER_PREAMBLE]
-    parts.append(
-        f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>\n\n"
-        f"The full skill (SKILL.md and any referenced example files) is available "
-        f"in the container at {skill_files_path}/."
-    )
+    if skill or skill_files_path is not None:
+        skill_block = f"Follow this information-gathering skill throughout.\n\n<skill>\n{skill}\n</skill>"
+        if skill_files_path is not None:
+            skill_block += (
+                f"\n\nThe full skill (SKILL.md and any referenced example files) is available "
+                f"in the container at {skill_files_path}/."
+            )
+        parts.append(skill_block)
     if has_scratch:
         parts.append(load_scratch_system_note())
     return "\n\n---\n\n".join(parts)

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/BUILD.bazel
@@ -3,7 +3,12 @@ load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 py_library(
     name = "twenty_questions",
     srcs = ["twenty_questions.py"],
+    data = [
+        "//skills/eval_infra:empty_skill_tar",
+        "//skills/info_gathering:info_gathering_tar",
+    ],
     deps = [
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:af_chat_client",
         "//skills/eval_infra:af_scratch_mcp",
         "//skills/info_gathering/evals/twenty_questions:prompts",
@@ -11,6 +16,7 @@ py_library(
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",
         "//skills/info_gathering/evals/twenty_questions/x/shared:output",
         "//skills/info_gathering/evals/twenty_questions/x/shared:variants",
+        "//util/bazel:runfiles",
         # The agent_framework core package's openai/anthropic stub modules
         # reference these sibling packages; mypy needs them on the dep graph.
         "@pypi//agent_framework_anthropic",

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
@@ -58,10 +58,6 @@ def _patch_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
         "skills.info_gathering.evals.twenty_questions.x.agent_framework.twenty_questions.load_sim_prompt",
         MagicMock(return_value="You are the simulator."),
     )
-    monkeypatch.setattr(
-        "skills.info_gathering.evals.twenty_questions.x.agent_framework.twenty_questions.load_skill_prompt",
-        MagicMock(return_value="You are skilled."),
-    )
 
 
 async def _run_with_replay(
@@ -74,7 +70,13 @@ async def _run_with_replay(
     """
     client = ReplayChatClient(responses=completions)
     return await run_game(
-        variant_name=variant_name, model="test-model", api="openai", output_dir=tmp_path, model_client=client
+        variant_name=variant_name,
+        model="test-model",
+        api="openai",
+        output_dir=tmp_path,
+        model_client=client,
+        skill_md="You are skilled.",
+        skill_files_path="/work/.skill",
     )
 
 

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -73,7 +73,7 @@ def _load_skill(tar_rlocation: str, package_name: str, extract_dir: Path) -> tup
     """Extract a skill tar; return (host dir to bind-mount, SKILL.md text)."""
     tar_path = get_required_path(tar_rlocation)
     with tarfile.open(tar_path) as tf:
-        tf.extractall(extract_dir)
+        tf.extractall(extract_dir, filter="data")
     skill_dir = extract_dir / package_name
     skill_md = (skill_dir / "SKILL.md").read_text()
     return skill_dir, skill_md

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import contextlib
 import logging
+import tarfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -36,13 +37,13 @@ from agent_framework import (
     MiddlewareTermination,
 )
 
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.af_chat_client import build_model_client
 from skills.eval_infra.af_scratch_mcp import scratch_exec_mcp_tool
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
     load_sim_prompt,
-    load_skill_prompt,
 )
 from skills.info_gathering.evals.twenty_questions.result_types import Correct, LogEntry, Result, RunSummary, Timeout
 from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
@@ -52,10 +53,30 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from util.bazel.runfiles import get_required_path
 
 logger = logging.getLogger(__name__)
 
 _MAX_STEPS = 200
+_SKILL_FILES_PATH = "/work/.skill"
+
+# Maps the --skill CLI value to (rlocation, package_name) of the tar to mount
+# into the scratch container. The "off" arm uses an empty SKILL.md so the
+# sandbox shape is uniform across arms — there is no `if skill_on:` branch.
+_SKILL_TARS: dict[str, tuple[str, str]] = {
+    "on": ("_main/skills/info_gathering/info_gathering_tar.tar", "info_gathering"),
+    "off": ("_main/skills/eval_infra/empty_skill_tar.tar", "empty_skill"),
+}
+
+
+def _load_skill(tar_rlocation: str, package_name: str, extract_dir: Path) -> tuple[Path, str]:
+    """Extract a skill tar; return (host dir to bind-mount, SKILL.md text)."""
+    tar_path = get_required_path(tar_rlocation)
+    with tarfile.open(tar_path) as tf:
+        tf.extractall(extract_dir)
+    skill_dir = extract_dir / package_name
+    skill_md = (skill_dir / "SKILL.md").read_text()
+    return skill_dir, skill_md
 
 
 # -- Game state --
@@ -200,18 +221,23 @@ async def run_game(
     api: str,
     output_dir: Path,
     model_client: BaseChatClient[Any],
+    skill_md: str,
+    skill_files_path: str,
     exec_tool: MCPStdioTool | None = None,
-    no_skill: bool = False,
 ) -> RunSummary:
     """Execute one Twenty Questions game and persist results.
 
     The caller owns `model_client`'s lifecycle; this function neither
-    constructs nor closes it.
+    constructs nor closes it. The caller also owns staging the skill
+    (extracting the tar, mounting the dir into `exec_tool`'s container);
+    `skill_md` is the SKILL.md text to inline (empty string for the
+    off-arm — the empty-skill tar has an empty SKILL.md), and
+    `skill_files_path` is the in-container path the agent can `cat`/`ls`.
     """
     variant = VARIANTS[variant_name]
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
     guesser_system = build_guesser_system(
-        skill="" if no_skill else load_skill_prompt(), has_scratch=exec_tool is not None
+        skill=skill_md, has_scratch=exec_tool is not None, skill_files_path=skill_files_path
     )
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
@@ -273,15 +299,21 @@ async def _async_main(args: argparse.Namespace) -> None:
     model_client = build_model_client(
         api=args.api, model=args.model, function_invocation_configuration={"max_iterations": _MAX_STEPS}
     )
-    async with scratch_exec_mcp_tool() as exec_tool:
+
+    tar_rlocation, package_name = _SKILL_TARS[args.skill]
+    skill_dir, skill_md = _load_skill(tar_rlocation, package_name, output_dir / "skill_extract")
+    skill_bind = BindMount(host_path=skill_dir.resolve(), container_path=Path(_SKILL_FILES_PATH), mode="ro")
+
+    async with scratch_exec_mcp_tool(binds=[skill_bind]) as exec_tool:
         summary = await run_game(
             variant_name=args.variant,
             model=args.model,
             api=args.api,
             output_dir=output_dir,
             model_client=model_client,
+            skill_md=skill_md,
+            skill_files_path=_SKILL_FILES_PATH,
             exec_tool=exec_tool,
-            no_skill=getattr(args, "no_skill", False),
         )
     logger.info("Result: %s", summary.result.model_dump_json())
 
@@ -289,7 +321,12 @@ async def _async_main(args: argparse.Namespace) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Twenty Questions — Agent Framework")
     add_common_args(parser)
-    parser.add_argument("--no-skill", action="store_true", help="Run without info-gathering skill prompt (baseline)")
+    parser.add_argument(
+        "--skill",
+        choices=["on", "off"],
+        default="on",
+        help="Skill arm: 'on' mounts info_gathering, 'off' mounts an empty skill tar.",
+    )
     args = parser.parse_args()
     resolve_args(args)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
@@ -383,7 +383,7 @@ def _run_main(args: argparse.Namespace, *, exec_tool: ExecTool | None = None) ->
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
@@ -542,7 +542,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
@@ -113,7 +113,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     state = GameState(turn_limit=variant.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
@@ -231,7 +231,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_instructions = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_instructions = build_guesser_system(skill=load_skill_prompt(), has_scratch=True)
+    guesser_instructions = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     guesser_toolsets: list[AbstractToolset[None]] | None = None


### PR DESCRIPTION
## Summary

The reverse_engineer rollout (PR #1383) mounts its skill tar at `/work/.skill/` inside the scratch container so the agent can `cat /work/.skill/SKILL.md` and run any referenced example scripts. The two info_gathering skill evals (twenty_questions's AF variant and function_learning) only inlined SKILL.md text into the system prompt — no in-container files. This stage erases that asymmetry.

This is **stage 1** of a planned framework refactor — every rollout's sandbox/prompt shape becomes identical, which sets up stage 2 to extract the shared `eval_infra/` modules cleanly.

## What changes

**Per consumer rollout** (TQ AF variant, function_learning):

1. **Sandbox**: every rollout always mounts a skill tar at `/work/.skill/`. The "off" arm is data, not a code path — it's a new `//skills/eval_infra:empty_skill_tar` (single empty SKILL.md, lives under `eval_infra/` so it's not in `all_skills_tar` deployment). The "on" arm mounts `info_gathering_tar`. There's no `if skill_on:` branch in sandbox or prompt code — both arms run the same path, only the tar differs.

2. **CLI**: `--no-skill` becomes `--skill {on,off}` (default `on`), uniform across rollouts.

**Prompt builders** (`build_guesser_system`, `build_system_prompt`) lose their `if skill:` branches and gain a required `skill_files_path` parameter that's always non-empty. The note pointing the agent at `/work/.skill/` is unconditional — for the off-arm, SKILL.md is empty so the inlined block is empty, but the "files live at" pointer still appears (it's true; the empty skill *is* mounted).

**`run_all_evals.py`** extracts both skill tars once at startup and spins up two `scratch_exec_mcp_tool` subprocesses (one per arm), then dispatches each parallel rollout to the right `exec_tool` based on its arm.

**`test_function_learning`** now uses a real `scratch_exec_mcp_tool()` instead of a dummy FunctionTool — the replay scripts don't call exec, but wiring it through the real MCP launcher means the test fails loud if that surface breaks. Loads `python:3.13-slim` into the local Docker daemon up-front via `load_oci_image` (matching the `docker_scratch.py` pattern) so neither the test's scoring container nor the launcher subprocess hits a 404 on workers without the image cached.

## Out of scope

- The RE rollout (PR #1383) gets the same mount-the-empty-skill treatment in its own branch; RE's files don't exist on `devel` yet.
- Stage 2: extracting `skill_staging.py` / `eval_prompt.py` / `eval_sandbox.py` / `transcript_middleware.py` / `termination.py` / `eval_run.py` into `//skills/eval_infra/`. With every rollout's surface now uniform, those abstractions fall out cleanly. Separate PR.
- Migrating the 4 non-AF TQ framework variants (crewai, langgraph, openai_agents, pydantic_ai) — they don't use `scratch_exec_mcp_tool` and have different shapes.

## Test plan

- [x] `bbr test //skills/info_gathering/evals/twenty_questions/x/agent_framework:test_twenty_questions //skills/info_gathering/evals/function_learning:test_function_learning --config=ci --nocache_test_results` — both pass on RBE ([invocation `46367479`](https://app.buildbuddy.io/invocation/46367479-94c4-49de-8e53-2055d04424b9))
- [x] Lint (ruff + mypy + buildifier via pre-commit)

End-to-end "skill actually mounted and visible to the agent" needs an API key — reviewer's `bb run` job. Not in automated CI for this PR.

https://claude.ai/code/session_01BcMHaLnwEFUdNKmZpJvht8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcMHaLnwEFUdNKmZpJvht8)_