### PR TITLE
Standardize sandbox layout: /skill, /work, /input

### DIFF
--- a/skills/eval_infra/BUILD.bazel
+++ b/skills/eval_infra/BUILD.bazel
@@ -48,6 +48,7 @@ py_library(
     name = "eval_prompt",
     srcs = ["eval_prompt.py"],
     visibility = ["//skills:__subpackages__"],
+    deps = [":eval_sandbox"],
 )
 
 py_library(

--- a/skills/eval_infra/eval_prompt.py
+++ b/skills/eval_infra/eval_prompt.py
@@ -2,35 +2,32 @@
 
 `compose_system_prompt` joins three pieces with `\\n\\n---\\n\\n` separators:
 
-1. An eval-specific preamble (what game / task is being played).
-2. A skill block — inlined SKILL.md plus a one-line pointer at the in-container
-   skill mount. Included whenever `skill_md` is non-empty or `skill_files_path`
-   is not None. The off-arm of a mounted-skill rollout passes empty `skill_md`
-   and a real `skill_files_path`, so the block stays present (consistent
-   sandbox shape) but the inlined `<skill>` payload is empty.
-3. An optional eval-specific scratch-tool note.
+1. An eval-specific preamble (what task is being performed).
+2. A skill block — generic skill-intro line + inlined SKILL.md + a one-line
+   pointer at the in-container skill mount. Included whenever `skill_md` is
+   non-empty or `skill_files_path` is not None. The off-arm of a
+   mounted-skill rollout passes empty `skill_md` and a real
+   `skill_files_path`, so the block stays present (consistent sandbox shape)
+   but the inlined `<skill>` payload is empty. The intro wording is fixed:
+   any eval introducing any skill should phrase it the same way.
+3. An optional eval-specific scratch-tool / submit-tool note.
 
-TQ's `build_guesser_system` and FL's `build_system_prompt` are thin wrappers
-around this. RE's prompt has a different structural shape and does not use it.
+Used by TQ's `build_guesser_system`, FL's `build_system_prompt`, and RE's
+`_build_system_prompt` to give every eval the same skill-block shape.
 """
 
 from pathlib import Path
 
-_SKILL_INTRO = "Follow this information-gathering skill throughout."
+_SKILL_INTRO = "Follow this skill throughout the task."
 
 
 def compose_system_prompt(
-    *,
-    preamble: str,
-    skill_md: str,
-    skill_files_path: Path | None,
-    scratch_note: str | None,
-    skill_intro: str = _SKILL_INTRO,
+    *, preamble: str, skill_md: str, skill_files_path: Path | None, scratch_note: str | None
 ) -> str:
     """See module docstring."""
     parts: list[str] = [preamble]
     if skill_md or skill_files_path is not None:
-        skill_block = f"{skill_intro}\n\n<skill>\n{skill_md}\n</skill>"
+        skill_block = f"{_SKILL_INTRO}\n\n<skill>\n{skill_md}\n</skill>"
         if skill_files_path is not None:
             skill_block += (
                 f"\n\nThe full skill (SKILL.md and any referenced example files) is "

--- a/skills/eval_infra/eval_prompt.py
+++ b/skills/eval_infra/eval_prompt.py
@@ -4,8 +4,8 @@
 
 1. An eval-specific preamble (what task is being performed).
 2. A skill block — generic skill-intro line + inlined SKILL.md + a one-line
-   pointer at the in-container skill mount. The skill is always mounted
-   (the off-arm of a mounted-skill rollout uses the empty-skill tar; the
+   pointer at the in-container skill mount (always `SKILL_PATH`; the
+   off-arm of a mounted-skill rollout uses the empty-skill tar so the
    inlined `<skill>` payload is empty but the path note still applies).
    The intro wording is fixed: any eval introducing any skill should
    phrase it the same way.
@@ -19,7 +19,7 @@ Used by TQ's `build_guesser_system`, FL's `build_system_prompt`, and RE's
 shape.
 """
 
-from pathlib import Path
+from skills.eval_infra.eval_sandbox import SKILL_PATH
 
 _SKILL_INTRO = "Follow this skill throughout the task."
 
@@ -31,12 +31,12 @@ _EXEC_TOOL_NOTE = (
 )
 
 
-def compose_system_prompt(*, preamble: str, skill_md: str, skill_files_path: Path, tool_guidance: str | None) -> str:
+def compose_system_prompt(*, preamble: str, skill_md: str, tool_guidance: str | None) -> str:
     """See module docstring."""
     skill_block = (
         f"{_SKILL_INTRO}\n\n<skill>\n{skill_md}\n</skill>\n\n"
         f"The full skill (SKILL.md and any referenced example files) is available in the "
-        f"container at {skill_files_path}/."
+        f"container at {SKILL_PATH}/."
     )
     parts: list[str] = [preamble, skill_block, _EXEC_TOOL_NOTE]
     if tool_guidance is not None:

--- a/skills/eval_infra/eval_prompt.py
+++ b/skills/eval_infra/eval_prompt.py
@@ -4,15 +4,14 @@
 
 1. An eval-specific preamble (what task is being performed).
 2. A skill block — generic skill-intro line + inlined SKILL.md + a one-line
-   pointer at the in-container skill mount. Included whenever `skill_md` is
-   non-empty or `skill_files_path` is not None. The off-arm of a
-   mounted-skill rollout passes empty `skill_md` and a real
-   `skill_files_path`, so the block stays present (consistent sandbox shape)
-   but the inlined `<skill>` payload is empty. The intro wording is fixed:
-   any eval introducing any skill should phrase it the same way.
+   pointer at the in-container skill mount. The skill is always mounted
+   (the off-arm of a mounted-skill rollout uses the empty-skill tar; the
+   inlined `<skill>` payload is empty but the path note still applies).
+   The intro wording is fixed: any eval introducing any skill should
+   phrase it the same way.
 3. A generic `exec`-tool description — describes the sandbox container that
    every rollout exposes via `eval_sandbox` / `scratch_exec_server`. Always
-   appended (`compose_system_prompt` assumes the rollout has an exec tool).
+   appended; every caller has an exec tool sandbox.
 4. Optional eval-specific tool guidance (game tools, submit, etc.).
 
 Used by TQ's `build_guesser_system`, FL's `build_system_prompt`, and RE's
@@ -32,20 +31,14 @@ _EXEC_TOOL_NOTE = (
 )
 
 
-def compose_system_prompt(
-    *, preamble: str, skill_md: str, skill_files_path: Path | None, tool_guidance: str | None
-) -> str:
+def compose_system_prompt(*, preamble: str, skill_md: str, skill_files_path: Path, tool_guidance: str | None) -> str:
     """See module docstring."""
-    parts: list[str] = [preamble]
-    if skill_md or skill_files_path is not None:
-        skill_block = f"{_SKILL_INTRO}\n\n<skill>\n{skill_md}\n</skill>"
-        if skill_files_path is not None:
-            skill_block += (
-                f"\n\nThe full skill (SKILL.md and any referenced example files) is "
-                f"available in the container at {skill_files_path}/."
-            )
-        parts.append(skill_block)
-    parts.append(_EXEC_TOOL_NOTE)
+    skill_block = (
+        f"{_SKILL_INTRO}\n\n<skill>\n{skill_md}\n</skill>\n\n"
+        f"The full skill (SKILL.md and any referenced example files) is available in the "
+        f"container at {skill_files_path}/."
+    )
+    parts: list[str] = [preamble, skill_block, _EXEC_TOOL_NOTE]
     if tool_guidance is not None:
         parts.append(tool_guidance)
     return "\n\n---\n\n".join(parts)

--- a/skills/eval_infra/eval_prompt.py
+++ b/skills/eval_infra/eval_prompt.py
@@ -1,6 +1,6 @@
 """Shared assembly of skill-eval system prompts.
 
-`compose_system_prompt` joins three pieces with `\\n\\n---\\n\\n` separators:
+`compose_system_prompt` joins four pieces with `\\n\\n---\\n\\n` separators:
 
 1. An eval-specific preamble (what task is being performed).
 2. A skill block — generic skill-intro line + inlined SKILL.md + a one-line
@@ -10,19 +10,30 @@
    `skill_files_path`, so the block stays present (consistent sandbox shape)
    but the inlined `<skill>` payload is empty. The intro wording is fixed:
    any eval introducing any skill should phrase it the same way.
-3. An optional eval-specific scratch-tool / submit-tool note.
+3. A generic `exec`-tool description — describes the sandbox container that
+   every rollout exposes via `eval_sandbox` / `scratch_exec_server`. Always
+   appended (`compose_system_prompt` assumes the rollout has an exec tool).
+4. Optional eval-specific tool guidance (game tools, submit, etc.).
 
 Used by TQ's `build_guesser_system`, FL's `build_system_prompt`, and RE's
-`_build_system_prompt` to give every eval the same skill-block shape.
+`_build_system_prompt` to give every eval the same skill-block + exec-note
+shape.
 """
 
 from pathlib import Path
 
 _SKILL_INTRO = "Follow this skill throughout the task."
 
+_EXEC_TOOL_NOTE = (
+    "You have shell access via the `exec` tool — `cmd` is a list of strings, no shell "
+    "expansion. Stdout and stderr are returned together. The container is "
+    "`python:3.13-slim` (Debian-based) with internet access; install whatever you need "
+    "(`apt-get install -y ...`, `pip install ...`, `curl ...`)."
+)
+
 
 def compose_system_prompt(
-    *, preamble: str, skill_md: str, skill_files_path: Path | None, scratch_note: str | None
+    *, preamble: str, skill_md: str, skill_files_path: Path | None, tool_guidance: str | None
 ) -> str:
     """See module docstring."""
     parts: list[str] = [preamble]
@@ -34,6 +45,7 @@ def compose_system_prompt(
                 f"available in the container at {skill_files_path}/."
             )
         parts.append(skill_block)
-    if scratch_note is not None:
-        parts.append(scratch_note)
+    parts.append(_EXEC_TOOL_NOTE)
+    if tool_guidance is not None:
+        parts.append(tool_guidance)
     return "\n\n---\n\n".join(parts)

--- a/skills/eval_infra/eval_sandbox.py
+++ b/skills/eval_infra/eval_sandbox.py
@@ -6,9 +6,9 @@ Conventional in-container layout: every eval rollout's scratch container has
   empty-skill placeholder; eval_sandbox always mounts this).
 - ``/work``  (`WORK_PATH`)   — read-write workspace bind; the agent's default
   cwd; persisted on the host so the eval can harvest outputs after the run.
-- ``/input/<name>`` (`INPUT_PATH / name`) — read-only mounts for
-  eval-specific inputs (e.g. RE's target binary). Caller-driven via the
-  ``inputs`` mapping.
+- ``/input`` (`INPUT_PATH`)  — read-only bind of an eval-specific inputs
+  directory (e.g. RE's `target` binary lives at `/input/target`).
+  Optional — pass ``inputs=None`` for evals with no inputs (TQ, FL).
 
 `eval_sandbox` builds an `MCPStdioTool` that launches the
 `mcp_infra.exec.docker.launcher` CLI as a subprocess (which boots a
@@ -17,16 +17,15 @@ natively — no FastMCP client, no hand-rolled `FunctionTool` bridge.
 
 Usage:
 
-    async with eval_sandbox(skill=staged, workspace=ws_dir) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=ws_dir, inputs=None) as exec_tool:
         agent = Agent(client=..., tools=[exec_tool, ...])
         await agent.run(...)
 """
 
 import os
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from types import MappingProxyType
 
 from agent_framework import MCPStdioTool
 
@@ -41,7 +40,6 @@ WORK_PATH = Path("/work")
 INPUT_PATH = Path("/input")
 
 _LAUNCHER_RLOCATION = "_main/mcp_infra/exec/docker_launcher"
-_NO_INPUTS: Mapping[str, Path] = MappingProxyType({})
 
 
 def _proxy_env() -> dict[str, str]:
@@ -55,12 +53,7 @@ def _proxy_env() -> dict[str, str]:
 
 @asynccontextmanager
 async def eval_sandbox(
-    *,
-    skill: StagedSkill,
-    workspace: Path,
-    inputs: Mapping[str, Path] = _NO_INPUTS,
-    image: str = "python:3.13-slim",
-    name: str = "exec",
+    *, skill: StagedSkill, workspace: Path, inputs: Path | None, image: str = "python:3.13-slim", name: str = "exec"
 ) -> AsyncGenerator[MCPStdioTool]:
     """Yield an `MCPStdioTool` exposing `exec` against a scratch container.
 
@@ -68,8 +61,9 @@ async def eval_sandbox(
         skill: Staged skill to bind read-only at `SKILL_PATH`.
         workspace: Host directory bound read-write at `WORK_PATH`. Becomes the
             container cwd; the eval harvests anything the agent writes here.
-        inputs: name → host path mapping; each entry is bound read-only at
-            `INPUT_PATH / name`. The host path may be a file or a directory.
+        inputs: Host directory bound read-only at `INPUT_PATH`, or ``None``
+            for evals with no inputs. Caller is responsible for assembling
+            this directory's contents before entering the context.
         image: Container image. Defaults to `python:3.13-slim`.
         name: MCPStdioTool tool name (defaults to ``"exec"``).
 
@@ -80,8 +74,8 @@ async def eval_sandbox(
         BindMount(host_path=skill.files_path.resolve(), container_path=SKILL_PATH, mode="ro"),
         BindMount(host_path=workspace.resolve(), container_path=WORK_PATH, mode="rw"),
     ]
-    for sub, host_path in inputs.items():
-        binds.append(BindMount(host_path=host_path.resolve(), container_path=INPUT_PATH / sub, mode="ro"))
+    if inputs is not None:
+        binds.append(BindMount(host_path=inputs.resolve(), container_path=INPUT_PATH, mode="ro"))
 
     config = ContainerExecServerConfig(
         image=image,

--- a/skills/eval_infra/eval_sandbox.py
+++ b/skills/eval_infra/eval_sandbox.py
@@ -1,36 +1,47 @@
 """Standardized scratch-container exec sandbox for skill-eval rollouts.
 
+Conventional in-container layout: every eval rollout's scratch container has
+
+- ``/skill`` (`SKILL_PATH`)  — read-only bind of the staged skill (real or
+  empty-skill placeholder; eval_sandbox always mounts this).
+- ``/work``  (`WORK_PATH`)   — read-write workspace bind; the agent's default
+  cwd; persisted on the host so the eval can harvest outputs after the run.
+- ``/input/<name>`` (`INPUT_PATH / name`) — read-only mounts for
+  eval-specific inputs (e.g. RE's target binary). Caller-driven via the
+  ``inputs`` mapping.
+
 `eval_sandbox` builds an `MCPStdioTool` that launches the
 `mcp_infra.exec.docker.launcher` CLI as a subprocess (which boots a
-`ContainerExecServer`) and binds the staged skill at the conventional
-`SKILL_FILES_PATH` plus any eval-specific extra binds. The launcher
-speaks MCP over stdio; AF drives tool dispatch natively — no FastMCP
-client, no hand-rolled `FunctionTool` bridge.
-
-Every rollout mounts its skill (real or empty-skill placeholder) at the
-same in-container path, so the agent sees a uniform sandbox shape
-across `--skill on/off` arms and across evals. Eval-specific binds
-(target binary, writable workspace, etc.) flow through `extra_binds`.
+`ContainerExecServer`) and speaks MCP over stdio; AF drives tool dispatch
+natively — no FastMCP client, no hand-rolled `FunctionTool` bridge.
 
 Usage:
 
-    async with eval_sandbox(skill=staged) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=ws_dir) as exec_tool:
         agent = Agent(client=..., tools=[exec_tool, ...])
         await agent.run(...)
 """
 
 import os
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, Mapping
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import MappingProxyType
 
 from agent_framework import MCPStdioTool
 
 from mcp_infra.exec.docker.types import AlwaysSetTo, BindMount, ContainerExecServerConfig
-from skills.eval_infra.skill_staging import SKILL_FILES_PATH, StagedSkill
+from skills.eval_infra.skill_staging import StagedSkill
 from util.bazel.runfiles import get_required_path
 
+# In-container path conventions. Hardcoded — standardizing across rollouts is
+# the whole point of `eval_infra`. See module docstring for the layout.
+SKILL_PATH = Path("/skill")
+WORK_PATH = Path("/work")
+INPUT_PATH = Path("/input")
+
 _LAUNCHER_RLOCATION = "_main/mcp_infra/exec/docker_launcher"
+_NO_INPUTS: Mapping[str, Path] = MappingProxyType({})
 
 
 def _proxy_env() -> dict[str, str]:
@@ -46,29 +57,40 @@ def _proxy_env() -> dict[str, str]:
 async def eval_sandbox(
     *,
     skill: StagedSkill,
-    extra_binds: Sequence[BindMount] = (),
-    working_dir: Path = Path("/tmp"),
+    workspace: Path,
+    inputs: Mapping[str, Path] = _NO_INPUTS,
     image: str = "python:3.13-slim",
     name: str = "exec",
 ) -> AsyncGenerator[MCPStdioTool]:
-    """Yield an `MCPStdioTool` exposing `exec` against a scratch container with
-    `skill` bind-mounted read-only at `SKILL_FILES_PATH` plus any `extra_binds`.
+    """Yield an `MCPStdioTool` exposing `exec` against a scratch container.
+
+    Args:
+        skill: Staged skill to bind read-only at `SKILL_PATH`.
+        workspace: Host directory bound read-write at `WORK_PATH`. Becomes the
+            container cwd; the eval harvests anything the agent writes here.
+        inputs: name → host path mapping; each entry is bound read-only at
+            `INPUT_PATH / name`. The host path may be a file or a directory.
+        image: Container image. Defaults to `python:3.13-slim`.
+        name: MCPStdioTool tool name (defaults to ``"exec"``).
 
     The container has host networking, proxy env wired, and `cwd`/`user`/`env`
     fields hidden from the model.
     """
     binds: list[BindMount] = [
-        BindMount(host_path=skill.files_path.resolve(), container_path=SKILL_FILES_PATH, mode="ro"),
-        *extra_binds,
+        BindMount(host_path=skill.files_path.resolve(), container_path=SKILL_PATH, mode="ro"),
+        BindMount(host_path=workspace.resolve(), container_path=WORK_PATH, mode="rw"),
     ]
+    for sub, host_path in inputs.items():
+        binds.append(BindMount(host_path=host_path.resolve(), container_path=INPUT_PATH / sub, mode="ro"))
+
     config = ContainerExecServerConfig(
         image=image,
-        working_dir=working_dir,
+        working_dir=WORK_PATH,
         network_mode="host",
         environment=_proxy_env(),
         allow_user_field=False,
         allow_env_field=False,
-        cwd_policy=AlwaysSetTo(value=working_dir),
+        cwd_policy=AlwaysSetTo(value=WORK_PATH),
         binds=binds,
     )
     launcher = get_required_path(_LAUNCHER_RLOCATION)

--- a/skills/eval_infra/eval_sandbox.py
+++ b/skills/eval_infra/eval_sandbox.py
@@ -61,6 +61,7 @@ async def eval_sandbox(
         skill: Staged skill to bind read-only at `SKILL_PATH`.
         workspace: Host directory bound read-write at `WORK_PATH`. Becomes the
             container cwd; the eval harvests anything the agent writes here.
+            Created (with parents) if missing — start-empty is the norm.
         inputs: Host directory bound read-only at `INPUT_PATH`, or ``None``
             for evals with no inputs. Caller is responsible for assembling
             this directory's contents before entering the context.
@@ -70,6 +71,7 @@ async def eval_sandbox(
     The container has host networking, proxy env wired, and `cwd`/`user`/`env`
     fields hidden from the model.
     """
+    workspace.mkdir(parents=True, exist_ok=True)
     binds: list[BindMount] = [
         BindMount(host_path=skill.files_path.resolve(), container_path=SKILL_PATH, mode="ro"),
         BindMount(host_path=workspace.resolve(), container_path=WORK_PATH, mode="rw"),

--- a/skills/eval_infra/skill_staging.py
+++ b/skills/eval_infra/skill_staging.py
@@ -5,7 +5,7 @@ A `SkillSpec` names a packaged skill: the runfiles location of its
 `skill_package` Bazel macro auto-generates a ``<name>_skill_spec`` py
 module exporting a ``SPEC: SkillSpec`` constant; eval rollouts pick a
 SPEC and call `stage_skill` to extract the tar into a host directory ready
-to bind into the agent's scratch container at `SKILL_FILES_PATH`.
+to bind into the agent's scratch container (see `eval_sandbox.SKILL_PATH`).
 
 Extraction lives in this module — there is no per-skill staging code.
 """
@@ -15,12 +15,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from util.bazel.runfiles import get_required_path
-
-# Conventional in-container path where every eval rollout bind-mounts its
-# staged skill. Single source of truth — callers should import this rather
-# than rewriting the path string. Hardcoded by design: standardizing across
-# rollouts is the whole point of `eval_infra`.
-SKILL_FILES_PATH = Path("/work/.skill")
 
 
 @dataclass(frozen=True)

--- a/skills/eval_infra/transcript.py
+++ b/skills/eval_infra/transcript.py
@@ -5,16 +5,16 @@ as a drop-in replacement for the auto-attached in-memory history (preserving
 multi-turn coherence inside an `Agent.run()`) while *also* writing every
 newly-stored Message to a JSONL audit log via `Message.to_json()`.
 
-By default AF calls `save_messages` once at the end of each `agent.run()`
-(or per LLM round-trip when the agent is constructed with
-`require_per_service_call_history_persistence=True`) — both call paths leave
-the transcript intact even when middleware raises `MiddlewareTermination`,
-because all three middleware pipelines suppress that exception internally.
+Pair this with `Agent(require_per_service_call_history_persistence=True)`
+so AF calls `save_messages` after every LLM round-trip — that's how the
+transcript stays current as the agent runs (rather than only being flushed
+at the end). All three middleware pipelines suppress `MiddlewareTermination`
+internally, so termination via tool-side middleware doesn't drop the final
+batch either.
 
-AF's "instructions" (system prompt) do not flow through the Message stream,
-so the convenience factory `JsonlTranscriptProvider.opened(path, ...)` opens
-the JSONL file, seeds it with a synthetic `Message("system", [...])` line,
-and yields a configured provider — used by FL and RE rollouts.
+The convenience factory `JsonlTranscriptProvider.opened(path)` opens the
+JSONL file and yields a configured provider — saves callers from juggling
+the file handle.
 """
 
 from collections.abc import Iterator, Sequence
@@ -40,15 +40,9 @@ class JsonlTranscriptProvider(InMemoryHistoryProvider):
 
     @classmethod
     @contextmanager
-    def opened(cls, path: Path, *, system_prompt: str) -> Iterator[Self]:
-        """Open `path` for writing, seed with a system Message, yield a provider.
-
-        Single-call replacement for the open-file + manual-system-seed +
-        construct-provider boilerplate every rollout repeats.
-        """
+    def opened(cls, path: Path) -> Iterator[Self]:
+        """Open `path` for writing and yield a provider bound to the file."""
         with path.open("w") as log_file:
-            log_file.write(Message("system", [system_prompt]).to_json() + "\n")
-            log_file.flush()
             yield cls(log_file)
 
     async def save_messages(

--- a/skills/eval_infra/transcript.py
+++ b/skills/eval_infra/transcript.py
@@ -28,9 +28,13 @@ from agent_framework import InMemoryHistoryProvider, Message
 class JsonlTranscriptProvider(InMemoryHistoryProvider):
     """`InMemoryHistoryProvider` that writes each newly-stored Message to JSONL.
 
-    Tracks a per-instance write cursor against the session's stored messages so
-    repeated `save_messages` calls (per-service-call persistence mode) emit only
-    the delta — no duplicates even when AF re-passes earlier inputs.
+    With per-service-call persistence, AF's `_split_service_call_messages`
+    (`agent_framework/_sessions.py:535`) gives `save_messages` an `input_messages`
+    slice that is the *cumulative* unattributed messages — it includes tool-result
+    Messages the agent loop appended in earlier rounds. `InMemoryHistoryProvider`
+    just appends, so to avoid emitting the same message multiple times, we track
+    how much of the underlying `state["messages"]` we've already written and emit
+    only the new tail per call.
     """
 
     def __init__(self, log_file: IO[str], source_id: str | None = None) -> None:

--- a/skills/eval_infra/transcript.py
+++ b/skills/eval_infra/transcript.py
@@ -11,13 +11,16 @@ By default AF calls `save_messages` once at the end of each `agent.run()`
 the transcript intact even when middleware raises `MiddlewareTermination`,
 because all three middleware pipelines suppress that exception internally.
 
-Note that AF's "instructions" (system prompt) do not flow through the Message
-stream — callers wanting the system prompt in the transcript should write a
-synthetic `Message("system", [...])` line at the top of the JSONL themselves.
+AF's "instructions" (system prompt) do not flow through the Message stream,
+so the convenience factory `JsonlTranscriptProvider.opened(path, ...)` opens
+the JSONL file, seeds it with a synthetic `Message("system", [...])` line,
+and yields a configured provider — used by FL and RE rollouts.
 """
 
-from collections.abc import Sequence
-from typing import IO, Any
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Any, Self
 
 from agent_framework import InMemoryHistoryProvider, Message
 
@@ -34,6 +37,19 @@ class JsonlTranscriptProvider(InMemoryHistoryProvider):
         super().__init__(source_id=source_id)
         self._log_file = log_file
         self._written_count = 0
+
+    @classmethod
+    @contextmanager
+    def opened(cls, path: Path, *, system_prompt: str) -> Iterator[Self]:
+        """Open `path` for writing, seed with a system Message, yield a provider.
+
+        Single-call replacement for the open-file + manual-system-seed +
+        construct-provider boilerplate every rollout repeats.
+        """
+        with path.open("w") as log_file:
+            log_file.write(Message("system", [system_prompt]).to_json() + "\n")
+            log_file.flush()
+            yield cls(log_file)
 
     async def save_messages(
         self, session_id: str | None, messages: Sequence[Message], *, state: dict[str, Any] | None = None, **kwargs: Any

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -40,8 +40,8 @@ from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_S
 from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
-from skills.eval_infra.eval_sandbox import eval_sandbox
-from skills.eval_infra.skill_staging import SKILL_FILES_PATH, SkillSpec, stage_skill
+from skills.eval_infra.eval_sandbox import SKILL_PATH, eval_sandbox
+from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.eval_infra.transcript import JsonlTranscriptProvider
 from skills.info_gathering.evals.function_learning.functions import FUNCTIONS, SecretFunction
@@ -193,13 +193,13 @@ async def run_game(
     The caller owns `model_client`'s lifecycle; this function neither
     constructs nor closes it. The caller also owns staging the skill
     (extracting the tar, mounting the dir into `exec_tool`'s container at
-    `SKILL_FILES_PATH`); `skill_md` is the SKILL.md text to inline (empty
+    `SKILL_PATH`); `skill_md` is the SKILL.md text to inline (empty
     string for the off-arm — the empty-skill tar has an empty SKILL.md).
     """
     secret_fn = FUNCTIONS[function_name]
     description = secret_fn.description if hint else _NO_HINT
 
-    system = build_system_prompt(skill=skill_md, has_scratch=True, skill_files_path=SKILL_FILES_PATH)
+    system = build_system_prompt(skill=skill_md, has_scratch=True, skill_files_path=SKILL_PATH)
     opening = first_user_message(secret_fn, turn_limit, description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
@@ -265,8 +265,10 @@ async def _async_main(args: argparse.Namespace) -> None:
     )
 
     staged = stage_skill(SKILL_BY_ARM[args.skill], output_dir / "skill_extract")
+    workspace = output_dir / "work"
+    workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:
             container = await docker.containers.run(

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -33,7 +33,6 @@ from agent_framework import (
     ChatResponse,
     FunctionTool,
     MCPStdioTool,
-    Message,
     MiddlewareTermination,
 )
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
@@ -204,20 +203,15 @@ async def run_game(
 
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)
 
-    with calls_path.open("w") as log_f:
-        # AF "instructions" don't flow through the Message stream — seed it
-        # manually so the JSONL transcript has the full context at the top.
-        log_f.write(Message("system", [system]).to_json() + "\n")
-        log_f.flush()
+    game = GameContext(turn_limit=turn_limit)
+    play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
 
-        game = GameContext(turn_limit=turn_limit)
-        play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
-
+    with JsonlTranscriptProvider.opened(calls_path, system_prompt=system) as transcript:
         agent = Agent(
             client=model_client,
             instructions=system,
             tools=[play_turn_tool, exec_tool],
-            context_providers=[JsonlTranscriptProvider(log_f)],
+            context_providers=[transcript],
             middleware=[_TokenUsageTracker(game), terminate_when(lambda: game.finished, reason="game finished")],
             default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
         )
@@ -265,10 +259,8 @@ async def _async_main(args: argparse.Namespace) -> None:
     )
 
     staged = stage_skill(SKILL_BY_ARM[args.skill], output_dir / "skill_extract")
-    workspace = output_dir / "work"
-    workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=output_dir / "work", inputs=None) as exec_tool:
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:
             container = await docker.containers.run(

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -15,7 +15,6 @@ individual `Message` objects.
 
 import argparse
 import asyncio
-import contextlib
 import json
 import logging
 import uuid
@@ -34,7 +33,6 @@ from agent_framework import (
     FunctionTool,
     MCPStdioTool,
     Message,
-    MiddlewareTermination,
 )
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
@@ -217,9 +215,9 @@ async def run_game(
             require_per_service_call_history_persistence=True,
         )
 
-        # `terminate_when` raises `MiddlewareTermination` once `game.finished`.
-        with contextlib.suppress(MiddlewareTermination):
-            await agent.run([Message("system", [system]), Message("user", [opening])], session=AgentSession())
+        # `terminate_when` raises `MiddlewareTermination` once `game.finished`;
+        # AF's tool loop catches it internally so `agent.run` returns normally.
+        await agent.run([Message("system", [system]), Message("user", [opening])], session=AgentSession())
 
     per_turn = [tr.score.hamming_loss for tr in game.turn_results]
     per_turn += [0] * (turn_limit - len(per_turn))

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -33,6 +33,7 @@ from agent_framework import (
     ChatResponse,
     FunctionTool,
     MCPStdioTool,
+    Message,
     MiddlewareTermination,
 )
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
@@ -206,19 +207,19 @@ async def run_game(
     game = GameContext(turn_limit=turn_limit)
     play_turn_tool = _make_play_turn_tool(game, secret_fn, scoring_container)
 
-    with JsonlTranscriptProvider.opened(calls_path, system_prompt=system) as transcript:
+    with JsonlTranscriptProvider.opened(calls_path) as transcript:
         agent = Agent(
             client=model_client,
-            instructions=system,
             tools=[play_turn_tool, exec_tool],
             context_providers=[transcript],
             middleware=[_TokenUsageTracker(game), terminate_when(lambda: game.finished, reason="game finished")],
             default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
+            require_per_service_call_history_persistence=True,
         )
 
         # `terminate_when` raises `MiddlewareTermination` once `game.finished`.
         with contextlib.suppress(MiddlewareTermination):
-            await agent.run(opening, session=AgentSession())
+            await agent.run([Message("system", [system]), Message("user", [opening])], session=AgentSession())
 
     per_turn = [tr.score.hamming_loss for tr in game.turn_results]
     per_turn += [0] * (turn_limit - len(per_turn))

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -197,7 +197,7 @@ async def run_game(
     secret_fn = FUNCTIONS[function_name]
     description = secret_fn.description if hint else _NO_HINT
 
-    system = build_system_prompt(skill=skill_md, has_scratch=True, skill_files_path=SKILL_PATH)
+    system = build_system_prompt(skill=skill_md, skill_files_path=SKILL_PATH)
     opening = first_user_message(secret_fn, turn_limit, description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -38,7 +38,7 @@ from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_S
 from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
-from skills.eval_infra.eval_sandbox import SKILL_PATH, eval_sandbox
+from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.eval_infra.transcript import JsonlTranscriptProvider
@@ -197,7 +197,7 @@ async def run_game(
     secret_fn = FUNCTIONS[function_name]
     description = secret_fn.description if hint else _NO_HINT
 
-    system = build_system_prompt(skill=skill_md, skill_files_path=SKILL_PATH)
+    system = build_system_prompt(skill=skill_md)
     opening = first_user_message(secret_fn, turn_limit, description, eval_timeout_s=EVAL_TIMEOUT_S)
 
     calls_path, summary_path = run_output_paths(f"fl_{function_name}_{'hint' if hint else 'nohint'}", output_dir)

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -268,7 +268,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     workspace = output_dir / "work"
     workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
         container_name = f"fl-scoring-{uuid.uuid4().hex[:8]}"
         async with aiodocker.Docker() as docker:
             container = await docker.containers.run(

--- a/skills/info_gathering/evals/function_learning/prompts.py
+++ b/skills/info_gathering/evals/function_learning/prompts.py
@@ -1,7 +1,5 @@
 """Prompt loading helpers for the function learning eval."""
 
-from pathlib import Path
-
 from skills.eval_infra.eval_prompt import compose_system_prompt
 from skills.info_gathering.evals.function_learning.functions import SecretFunction
 from util.bazel.runfiles import get_required_path
@@ -17,15 +15,13 @@ _BASE_PREAMBLE = (
 )
 
 
-def build_system_prompt(*, skill: str, skill_files_path: Path) -> str:
+def build_system_prompt(*, skill: str) -> str:
     """Compose the FL system prompt: preamble + skill block + exec note.
 
     The `play_turn` tool's `FunctionTool` description is enough for the agent
     to know how to use it — no eval-specific tool guidance text needed here.
     """
-    return compose_system_prompt(
-        preamble=_BASE_PREAMBLE, skill_md=skill, skill_files_path=skill_files_path, tool_guidance=None
-    )
+    return compose_system_prompt(preamble=_BASE_PREAMBLE, skill_md=skill, tool_guidance=None)
 
 
 def first_user_message(fn: SecretFunction, turn_limit: int, function_description: str, eval_timeout_s: int) -> str:

--- a/skills/info_gathering/evals/function_learning/prompts.py
+++ b/skills/info_gathering/evals/function_learning/prompts.py
@@ -17,7 +17,7 @@ _BASE_PREAMBLE = (
 )
 
 
-def build_system_prompt(*, skill: str, skill_files_path: Path | None) -> str:
+def build_system_prompt(*, skill: str, skill_files_path: Path) -> str:
     """Compose the FL system prompt: preamble + skill block + exec note.
 
     The `play_turn` tool's `FunctionTool` description is enough for the agent

--- a/skills/info_gathering/evals/function_learning/prompts.py
+++ b/skills/info_gathering/evals/function_learning/prompts.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from skills.eval_infra.eval_prompt import compose_system_prompt
 from skills.info_gathering.evals.function_learning.functions import SecretFunction
-from skills.info_gathering.evals.twenty_questions.prompts import load_scratch_system_note
 from util.bazel.runfiles import get_required_path
 
 _FIRST_USER_MSG_RLOCATION = "_main/skills/info_gathering/evals/function_learning/first_user_message.txt"
@@ -18,13 +17,14 @@ _BASE_PREAMBLE = (
 )
 
 
-def build_system_prompt(*, skill: str, has_scratch: bool, skill_files_path: Path | None) -> str:
-    """Compose the FL system prompt: preamble + skill block + (optional) scratch note."""
+def build_system_prompt(*, skill: str, skill_files_path: Path | None) -> str:
+    """Compose the FL system prompt: preamble + skill block + exec note.
+
+    The `play_turn` tool's `FunctionTool` description is enough for the agent
+    to know how to use it — no eval-specific tool guidance text needed here.
+    """
     return compose_system_prompt(
-        preamble=_BASE_PREAMBLE,
-        skill_md=skill,
-        skill_files_path=skill_files_path,
-        scratch_note=load_scratch_system_note() if has_scratch else None,
+        preamble=_BASE_PREAMBLE, skill_md=skill, skill_files_path=skill_files_path, tool_guidance=None
     )
 
 

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -100,7 +100,7 @@ async def _async_main(args: argparse.Namespace) -> None:
             staged = stage_skill(SKILL_BY_ARM[arm], output_dir / f"skill_extract_{arm}")
             workspace = output_dir / f"work_{arm}"
             workspace.mkdir(parents=True, exist_ok=True)
-            exec_tool = await stack.enter_async_context(eval_sandbox(skill=staged, workspace=workspace))
+            exec_tool = await stack.enter_async_context(eval_sandbox(skill=staged, workspace=workspace, inputs=None))
             arms[arm] = (exec_tool, staged.md_text)
 
         docker = await stack.enter_async_context(aiodocker.Docker())

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -98,9 +98,9 @@ async def _async_main(args: argparse.Namespace) -> None:
     async with AsyncExitStack() as stack:
         for arm in ("on", "off"):
             staged = stage_skill(SKILL_BY_ARM[arm], output_dir / f"skill_extract_{arm}")
-            workspace = output_dir / f"work_{arm}"
-            workspace.mkdir(parents=True, exist_ok=True)
-            exec_tool = await stack.enter_async_context(eval_sandbox(skill=staged, workspace=workspace, inputs=None))
+            exec_tool = await stack.enter_async_context(
+                eval_sandbox(skill=staged, workspace=output_dir / f"work_{arm}", inputs=None)
+            )
             arms[arm] = (exec_tool, staged.md_text)
 
         docker = await stack.enter_async_context(aiodocker.Docker())

--- a/skills/info_gathering/evals/function_learning/run_all_evals.py
+++ b/skills/info_gathering/evals/function_learning/run_all_evals.py
@@ -98,7 +98,9 @@ async def _async_main(args: argparse.Namespace) -> None:
     async with AsyncExitStack() as stack:
         for arm in ("on", "off"):
             staged = stage_skill(SKILL_BY_ARM[arm], output_dir / f"skill_extract_{arm}")
-            exec_tool = await stack.enter_async_context(eval_sandbox(skill=staged))
+            workspace = output_dir / f"work_{arm}"
+            workspace.mkdir(parents=True, exist_ok=True)
+            exec_tool = await stack.enter_async_context(eval_sandbox(skill=staged, workspace=workspace))
             arms[arm] = (exec_tool, staged.md_text)
 
         docker = await stack.enter_async_context(aiodocker.Docker())

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -64,10 +64,11 @@ async def _run_with_replay(
     # Stage the empty skill so the sandbox shape matches production: prompt
     # claims `SKILL_PATH` is mounted, and it really is.
     staged = stage_skill(EMPTY_SKILL_SPEC, tmp_path / "skill_extract")
-    workspace = tmp_path / "work"
-    workspace.mkdir()
 
-    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool, aiodocker.Docker() as docker:
+    async with (
+        eval_sandbox(skill=staged, workspace=tmp_path / "work", inputs=None) as exec_tool,
+        aiodocker.Docker() as docker,
+    ):
         container = await docker.containers.run(
             config={"Image": image_tag, "Cmd": ["sleep", "300"]}, name=f"fl-test-{uuid.uuid4().hex[:8]}"
         )

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -67,7 +67,7 @@ async def _run_with_replay(
     workspace = tmp_path / "work"
     workspace.mkdir()
 
-    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool, aiodocker.Docker() as docker:
+    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool, aiodocker.Docker() as docker:
         container = await docker.containers.run(
             config={"Image": image_tag, "Cmd": ["sleep", "300"]}, name=f"fl-test-{uuid.uuid4().hex[:8]}"
         )

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -62,10 +62,12 @@ async def _run_with_replay(
     image_tag = load_oci_image(PYTHON_3_13_SLIM)
 
     # Stage the empty skill so the sandbox shape matches production: prompt
-    # claims `SKILL_FILES_PATH` is mounted, and it really is.
+    # claims `SKILL_PATH` is mounted, and it really is.
     staged = stage_skill(EMPTY_SKILL_SPEC, tmp_path / "skill_extract")
+    workspace = tmp_path / "work"
+    workspace.mkdir()
 
-    async with eval_sandbox(skill=staged) as exec_tool, aiodocker.Docker() as docker:
+    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool, aiodocker.Docker() as docker:
         container = await docker.containers.run(
             config={"Image": image_tag, "Cmd": ["sleep", "300"]}, name=f"fl-test-{uuid.uuid4().hex[:8]}"
         )

--- a/skills/info_gathering/evals/twenty_questions/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/BUILD.bazel
@@ -23,7 +23,6 @@ py_library(
         "first_user_message.txt",
         "scratch_system_note.txt",
         "sim.txt",
-        "//skills/info_gathering:SKILL.md",
     ],
     visibility = ["//skills/info_gathering/evals:__subpackages__"],
     deps = [

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -32,19 +32,21 @@ def load_scratch_system_note() -> str:
     return get_required_path(_SCRATCH_NOTE_RLOCATION).read_text().strip()
 
 
-def build_guesser_system(*, skill: str, has_scratch: bool, skill_files_path: Path | None) -> str:
+def build_guesser_system(*, skill: str, skill_files_path: Path | None) -> str:
     """Compose the guesser's system prompt: preamble + skill block + exec note + game-tools note.
 
-    `skill_files_path=None` is for the four non-AF framework variants that
-    don't mount the skill into a sandbox; AF rollouts always pass a real path.
-    `has_scratch=True` adds the TQ-specific game-tools guidance (the generic
-    exec-tool description is always appended by `compose_system_prompt`).
+    The TQ guesser always has an `exec` container (`compose_system_prompt`
+    appends the generic exec-tool description) and always has the
+    `ask_yes_no_question` / `guess_answer` game tools (this function appends
+    `load_scratch_system_note()` as tool guidance). `skill_files_path=None`
+    is for the four non-AF framework variants that don't mount the skill
+    into the sandbox; AF rollouts always pass a real path.
     """
     return compose_system_prompt(
         preamble=_BASE_GUESSER_PREAMBLE,
         skill_md=skill,
         skill_files_path=skill_files_path,
-        tool_guidance=load_scratch_system_note() if has_scratch else None,
+        tool_guidance=load_scratch_system_note(),
     )
 
 

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -4,8 +4,6 @@ Loads shared prompt templates from text files via Bazel runfiles, providing a
 single source of truth used by all implementations (Python, Rust, Go).
 """
 
-from pathlib import Path
-
 from skills.eval_infra.eval_prompt import compose_system_prompt
 from util.bazel.runfiles import get_required_path
 
@@ -27,20 +25,17 @@ def load_scratch_system_note() -> str:
     return get_required_path(_SCRATCH_NOTE_RLOCATION).read_text().strip()
 
 
-def build_guesser_system(*, skill: str, skill_files_path: Path) -> str:
+def build_guesser_system(*, skill: str) -> str:
     """Compose the guesser's system prompt: preamble + skill block + exec note + game-tools note.
 
     The TQ guesser always has an `exec` container with the skill mounted at
-    `skill_files_path` (`compose_system_prompt` appends the generic exec-tool
+    `SKILL_PATH` (`compose_system_prompt` appends the generic exec-tool
     description and the skill files-path note) plus the
     `ask_yes_no_question` / `guess_answer` game tools (this function appends
     `load_scratch_system_note()` as tool guidance).
     """
     return compose_system_prompt(
-        preamble=_BASE_GUESSER_PREAMBLE,
-        skill_md=skill,
-        skill_files_path=skill_files_path,
-        tool_guidance=load_scratch_system_note(),
+        preamble=_BASE_GUESSER_PREAMBLE, skill_md=skill, tool_guidance=load_scratch_system_note()
     )
 
 

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -33,16 +33,18 @@ def load_scratch_system_note() -> str:
 
 
 def build_guesser_system(*, skill: str, has_scratch: bool, skill_files_path: Path | None) -> str:
-    """Compose the guesser's system prompt: preamble + skill block + (optional) scratch note.
+    """Compose the guesser's system prompt: preamble + skill block + exec note + game-tools note.
 
     `skill_files_path=None` is for the four non-AF framework variants that
     don't mount the skill into a sandbox; AF rollouts always pass a real path.
+    `has_scratch=True` adds the TQ-specific game-tools guidance (the generic
+    exec-tool description is always appended by `compose_system_prompt`).
     """
     return compose_system_prompt(
         preamble=_BASE_GUESSER_PREAMBLE,
         skill_md=skill,
         skill_files_path=skill_files_path,
-        scratch_note=load_scratch_system_note() if has_scratch else None,
+        tool_guidance=load_scratch_system_note() if has_scratch else None,
     )
 
 

--- a/skills/info_gathering/evals/twenty_questions/prompts.py
+++ b/skills/info_gathering/evals/twenty_questions/prompts.py
@@ -10,7 +10,6 @@ from skills.eval_infra.eval_prompt import compose_system_prompt
 from util.bazel.runfiles import get_required_path
 
 _SIM_RLOCATION = "_main/skills/info_gathering/evals/twenty_questions/sim.txt"
-_SKILL_RLOCATION = "_main/skills/info_gathering/SKILL.md"
 _SCRATCH_NOTE_RLOCATION = "_main/skills/info_gathering/evals/twenty_questions/scratch_system_note.txt"
 _FIRST_USER_MSG_RLOCATION = "_main/skills/info_gathering/evals/twenty_questions/first_user_message.txt"
 
@@ -24,23 +23,18 @@ def load_sim_prompt(*, secret: str, turn_limit: int) -> str:
     return template.format(secret=secret, turn_limit=turn_limit)
 
 
-def load_skill_prompt() -> str:
-    return get_required_path(_SKILL_RLOCATION).read_text()
-
-
 def load_scratch_system_note() -> str:
     return get_required_path(_SCRATCH_NOTE_RLOCATION).read_text().strip()
 
 
-def build_guesser_system(*, skill: str, skill_files_path: Path | None) -> str:
+def build_guesser_system(*, skill: str, skill_files_path: Path) -> str:
     """Compose the guesser's system prompt: preamble + skill block + exec note + game-tools note.
 
-    The TQ guesser always has an `exec` container (`compose_system_prompt`
-    appends the generic exec-tool description) and always has the
+    The TQ guesser always has an `exec` container with the skill mounted at
+    `skill_files_path` (`compose_system_prompt` appends the generic exec-tool
+    description and the skill files-path note) plus the
     `ask_yes_no_question` / `guess_answer` game tools (this function appends
-    `load_scratch_system_note()` as tool guidance). `skill_files_path=None`
-    is for the four non-AF framework variants that don't mount the skill
-    into the sandbox; AF rollouts always pass a real path.
+    `load_scratch_system_note()` as tool guidance).
     """
     return compose_system_prompt(
         preamble=_BASE_GUESSER_PREAMBLE,

--- a/skills/info_gathering/evals/twenty_questions/scratch_system_note.txt
+++ b/skills/info_gathering/evals/twenty_questions/scratch_system_note.txt
@@ -1,3 +1,3 @@
-You have access to an `exec` tool — a private Docker container (Python 3.13, Debian-based, with internet access) for scratch computation. Use it freely: run Python code, track hypothesis spaces, write notes, organize your reasoning. Calling `exec` does NOT use up one of your turns.
+Calling `exec` does NOT use up one of your turns; use it freely to run Python code, track your hypothesis space, write notes, or organize your reasoning.
 
 To play the game, use `ask_yes_no_question` to ask a yes/no question, or `guess_answer` to make your guess. Each of these DOES use a turn.

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
@@ -86,7 +86,7 @@ async def _run_with_replay(
     workspace = tmp_path / "work"
     workspace.mkdir()
 
-    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
         return await run_game(
             variant_name=variant_name,
             model="test-model",

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
@@ -83,10 +83,8 @@ async def _run_with_replay(
     load_oci_image(PYTHON_3_13_SLIM)
 
     staged = stage_skill(EMPTY_SKILL_SPEC, tmp_path / "skill_extract")
-    workspace = tmp_path / "work"
-    workspace.mkdir()
 
-    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=tmp_path / "work", inputs=None) as exec_tool:
         return await run_game(
             variant_name=variant_name,
             model="test-model",

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
@@ -74,17 +74,19 @@ async def _run_with_replay(
     [guesser_tool_call_1, simulator_tool_call_1, guesser_tool_call_2, simulator_tool_call_2, ...]
 
     Stages the empty skill and binds it into a real `eval_sandbox` so the
-    test mirrors production: the agent sees a populated `SKILL_FILES_PATH`
-    and an exec MCP tool wired to a real launcher subprocess. Replay
-    scripts don't call exec, but the wiring fails loud if the launcher /
-    MCP layer breaks.
+    test mirrors production: the agent sees a populated `SKILL_PATH` and
+    an exec MCP tool wired to a real launcher subprocess. Replay scripts
+    don't call exec, but the wiring fails loud if the launcher / MCP
+    layer breaks.
     """
     client = ReplayChatClient(responses=completions)
     load_oci_image(PYTHON_3_13_SLIM)
 
     staged = stage_skill(EMPTY_SKILL_SPEC, tmp_path / "skill_extract")
+    workspace = tmp_path / "work"
+    workspace.mkdir()
 
-    async with eval_sandbox(skill=staged) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
         return await run_game(
             variant_name=variant_name,
             model="test-model",

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -274,7 +274,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     workspace = output_dir / "work"
     workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
         summary = await run_game(
             variant_name=args.variant,
             model=args.model,

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -38,7 +38,7 @@ from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_S
 from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
-from skills.eval_infra.eval_sandbox import SKILL_PATH, eval_sandbox
+from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.info_gathering.evals.twenty_questions.prompts import (
@@ -214,7 +214,7 @@ async def run_game(
     """
     variant = VARIANTS[variant_name]
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=skill_md, skill_files_path=SKILL_PATH)
+    guesser_system = build_guesser_system(skill=skill_md)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     game = GameContext(turn_limit=variant.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -214,7 +214,7 @@ async def run_game(
     """
     variant = VARIANTS[variant_name]
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=skill_md, has_scratch=True, skill_files_path=SKILL_PATH)
+    guesser_system = build_guesser_system(skill=skill_md, skill_files_path=SKILL_PATH)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     game = GameContext(turn_limit=variant.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -39,8 +39,8 @@ from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_S
 from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
-from skills.eval_infra.eval_sandbox import eval_sandbox
-from skills.eval_infra.skill_staging import SKILL_FILES_PATH, SkillSpec, stage_skill
+from skills.eval_infra.eval_sandbox import SKILL_PATH, eval_sandbox
+from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
@@ -204,12 +204,12 @@ async def run_game(
     The caller owns `model_client`'s lifecycle; this function neither
     constructs nor closes it. The caller also owns staging the skill
     (extracting the tar, mounting the dir into `exec_tool`'s container at
-    `SKILL_FILES_PATH`); `skill_md` is the SKILL.md text to inline (empty
+    `SKILL_PATH`); `skill_md` is the SKILL.md text to inline (empty
     string for the off-arm — the empty-skill tar has an empty SKILL.md).
     """
     variant = VARIANTS[variant_name]
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=skill_md, has_scratch=True, skill_files_path=SKILL_FILES_PATH)
+    guesser_system = build_guesser_system(skill=skill_md, has_scratch=True, skill_files_path=SKILL_PATH)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     game = GameContext(turn_limit=variant.turn_limit)
@@ -271,8 +271,10 @@ async def _async_main(args: argparse.Namespace) -> None:
     )
 
     staged = stage_skill(_SKILL_BY_ARM[args.skill], output_dir / "skill_extract")
+    workspace = output_dir / "work"
+    workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=workspace) as exec_tool:
         summary = await run_game(
             variant_name=args.variant,
             model=args.model,

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -18,7 +18,6 @@ context window.
 
 import argparse
 import asyncio
-import contextlib
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -129,10 +128,16 @@ def _make_sim_tools(game: GameContext) -> list[FunctionTool]:
 
 
 def _make_game_tools(*, game: GameContext, sim_agent: Agent, sim_session: AgentSession) -> list[FunctionTool]:
+    # CLEANUP(2026-04-26): Consider replacing this closure-based dispatch with
+    # `sim_agent.as_tool(propagate_session=True)` plumbed into the guesser's
+    # tool list. Would expose the simulator as a typed tool with a real
+    # schema, drop the `last_sim_response` shared-state passing, and let AF
+    # manage session inheritance natively. Bigger restructuring — separate PR.
     async def _drive_simulator(text: str) -> None:
-        # Simulator middleware terminates after the single tool call by design.
-        with contextlib.suppress(MiddlewareTermination):
-            await sim_agent.run(text, session=sim_session)
+        # `_SimulatorEndMiddleware` raises `MiddlewareTermination` after the
+        # single tool dispatch; AF's tool loop catches it internally so
+        # `sim_agent.run()` returns normally.
+        await sim_agent.run(text, session=sim_session)
 
     async def ask_yes_no_question(question: str) -> str:
         """Ask a yes/no question. Uses one turn."""
@@ -237,9 +242,9 @@ async def run_game(
     )
     guesser_session = AgentSession()
 
-    # Game-end middleware terminates once `game.result` is set.
-    with contextlib.suppress(MiddlewareTermination):
-        await guesser_agent.run(opening, session=guesser_session)
+    # `terminate_when` raises `MiddlewareTermination` once `game.result` is set;
+    # AF's tool loop catches it internally so this returns normally.
+    await guesser_agent.run(opening, session=guesser_session)
 
     if game.result is None:
         game.result = Timeout(limit=game.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -271,10 +271,8 @@ async def _async_main(args: argparse.Namespace) -> None:
     )
 
     staged = stage_skill(_SKILL_BY_ARM[args.skill], output_dir / "skill_extract")
-    workspace = output_dir / "work"
-    workspace.mkdir(parents=True, exist_ok=True)
 
-    async with eval_sandbox(skill=staged, workspace=workspace, inputs=None) as exec_tool:
+    async with eval_sandbox(skill=staged, workspace=output_dir / "work", inputs=None) as exec_tool:
         summary = await run_game(
             variant_name=args.variant,
             model=args.model,

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/BUILD.bazel
@@ -4,7 +4,11 @@ py_library(
     name = "twenty_questions",
     srcs = ["twenty_questions.py"],
     deps = [
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:docker_exec",
+        "//skills/eval_infra:eval_sandbox",
+        "//skills/eval_infra:skill_staging",
+        "//skills/info_gathering:info_gathering_skill_spec",
         "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions:result_types",
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
@@ -389,7 +389,7 @@ def _run_main(args: argparse.Namespace, *, staged: StagedSkill, exec_tool: ExecT
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
+    guesser_system = build_guesser_system(skill=staged.md_text)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
@@ -383,7 +383,7 @@ def _run_main(args: argparse.Namespace, *, exec_tool: ExecTool | None = None) ->
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
@@ -23,13 +23,16 @@ from crewai import Agent, Crew, Process, Task
 from crewai.tools import BaseTool
 from fastmcp.client import Client
 from pydantic import BaseModel, Field, PrivateAttr
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.docker_exec import scratch_exec_server
+from skills.eval_infra.eval_sandbox import SKILL_PATH
+from skills.eval_infra.skill_staging import StagedSkill, stage_skill
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
     load_sim_prompt,
-    load_skill_prompt,
 )
 from skills.info_gathering.evals.twenty_questions.result_types import Correct, LogEntry, RunSummary, Timeout
 from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
@@ -342,29 +345,32 @@ def run_twenty_questions_crewai(
     return summary
 
 
-async def _setup_and_run(loop: asyncio.AbstractEventLoop, ready: threading.Event, state: dict[str, Any]) -> None:
+async def _setup_and_run(
+    loop: asyncio.AbstractEventLoop, ready: threading.Event, state: dict[str, Any], skill_bind: BindMount
+) -> None:
     """Enter async context managers for the MCP server+client on *loop*.
 
     Signals *ready* once the client is available in *state*, then waits for
     *state["done"]* to be set before tearing down.
     """
-    async with scratch_exec_server() as server, Client(server) as mcp_client:
+    async with scratch_exec_server(binds=[skill_bind]) as server, Client(server) as mcp_client:
         state["mcp_client"] = mcp_client
         ready.set()
         done_event: asyncio.Event = state["done_event"]
         await done_event.wait()
 
 
-def _run_with_exec(args: argparse.Namespace) -> None:
+def _run_with_exec(args: argparse.Namespace, *, staged: StagedSkill) -> None:
     """Set up an MCP exec bridge on a background event loop, then run the game."""
     bg_loop = asyncio.new_event_loop()
     ready = threading.Event()
     done_async = asyncio.Event()
     state: dict[str, Any] = {"done_event": done_async}
+    skill_bind = BindMount(host_path=staged.files_path.resolve(), container_path=SKILL_PATH, mode="ro")
 
     def _run_bg() -> None:
         asyncio.set_event_loop(bg_loop)
-        bg_loop.run_until_complete(_setup_and_run(bg_loop, ready, state))
+        bg_loop.run_until_complete(_setup_and_run(bg_loop, ready, state, skill_bind))
 
     bg_thread = threading.Thread(target=_run_bg, daemon=True)
     bg_thread.start()
@@ -372,18 +378,18 @@ def _run_with_exec(args: argparse.Namespace) -> None:
 
     try:
         exec_tool = ExecTool(mcp_client=state["mcp_client"], loop=bg_loop)
-        _run_main(args, exec_tool=exec_tool)
+        _run_main(args, staged=staged, exec_tool=exec_tool)
     finally:
         bg_loop.call_soon_threadsafe(done_async.set)
         bg_thread.join(timeout=10)
         bg_loop.close()
 
 
-def _run_main(args: argparse.Namespace, *, exec_tool: ExecTool | None = None) -> None:
+def _run_main(args: argparse.Namespace, *, staged: StagedSkill, exec_tool: ExecTool | None = None) -> None:
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
+    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)
@@ -416,7 +422,8 @@ def main() -> None:
     args = p.parse_args()
     resolve_args(args)
 
-    _run_with_exec(args)
+    staged = stage_skill(INFO_GATHERING_SKILL_SPEC, output_dir_from_args(args) / "skill_extract")
+    _run_with_exec(args, staged=staged)
 
 
 if __name__ == "__main__":

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/BUILD.bazel
@@ -5,7 +5,11 @@ py_library(
     srcs = ["twenty_questions.py"],
     deps = [
         "//mcp_infra/exec:docker",
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:docker_exec",
+        "//skills/eval_infra:eval_sandbox",
+        "//skills/eval_infra:skill_staging",
+        "//skills/info_gathering:info_gathering_skill_spec",
         "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions:result_types",
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
@@ -549,7 +549,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     staged = stage_skill(INFO_GATHERING_SKILL_SPEC, output_dir / "skill_extract")
     skill_bind = BindMount(host_path=staged.files_path.resolve(), container_path=SKILL_PATH, mode="ro")
 
-    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
+    guesser_system = build_guesser_system(skill=staged.md_text)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
 

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
@@ -33,14 +33,17 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel, Field
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.docker_exec import scratch_exec_server
+from skills.eval_infra.eval_sandbox import SKILL_PATH
+from skills.eval_infra.skill_staging import stage_skill
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
     load_sim_prompt,
-    load_skill_prompt,
 )
 from skills.info_gathering.evals.twenty_questions.result_types import Correct, LogEntry, Result, RunSummary, Timeout
 from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
@@ -541,17 +544,20 @@ async def run_twenty_questions_langgraph(
 async def _async_main(args: argparse.Namespace) -> None:
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
+    output_dir = output_dir_from_args(args)
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
+    staged = stage_skill(INFO_GATHERING_SKILL_SPEC, output_dir / "skill_extract")
+    skill_bind = BindMount(host_path=staged.files_path.resolve(), container_path=SKILL_PATH, mode="ro")
+
+    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
-    output_dir = output_dir_from_args(args)
 
     logger.info("=" * 60)
     logger.info("  %s  |  %s  |  %s (langgraph)", name, args.model, args.api)
     logger.info("=" * 60)
 
-    async with scratch_exec_server() as exec_server:
+    async with scratch_exec_server(binds=[skill_bind]) as exec_server:
         summary = await run_twenty_questions_langgraph(
             name=name,
             api=args.api,

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
@@ -542,7 +542,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     v = VARIANTS[args.variant]
     name = f"20q_{args.variant}"
 
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
     sim_system = load_sim_prompt(secret=v.secret, turn_limit=v.turn_limit)
     first_msg = first_user_message(v.domain_description, v.turn_limit)
     output_dir = output_dir_from_args(args)

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/BUILD.bazel
@@ -5,7 +5,11 @@ py_library(
     srcs = ["twenty_questions.py"],
     deps = [
         "//mcp_infra/exec:docker",
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:docker_exec",
+        "//skills/eval_infra:eval_sandbox",
+        "//skills/eval_infra:skill_staging",
+        "//skills/info_gathering:info_gathering_skill_spec",
         "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions:result_types",
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
@@ -117,7 +117,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
+    guesser_system = build_guesser_system(skill=staged.md_text)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     state = GameState(turn_limit=variant.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
@@ -113,7 +113,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
+    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     state = GameState(turn_limit=variant.turn_limit)

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
@@ -26,14 +26,17 @@ from agents import (
 )
 from fastmcp.client import Client
 from mcp.types import TextContent
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.docker_exec import scratch_exec_server
+from skills.eval_infra.eval_sandbox import SKILL_PATH
+from skills.eval_infra.skill_staging import StagedSkill, stage_skill
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
     load_sim_prompt,
-    load_skill_prompt,
 )
 from skills.info_gathering.evals.twenty_questions.result_types import Correct, LogEntry, RunSummary, Timeout
 from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
@@ -107,13 +110,14 @@ async def run_twenty_questions(
     variant_name: str,
     api: str,
     output_dir: Path,
+    staged: StagedSkill,
     exec_server: ContainerExecServer | None = None,
 ) -> RunSummary:
     variant = VARIANTS[variant_name]
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_system = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_system = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
+    guesser_system = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     state = GameState(turn_limit=variant.turn_limit)
@@ -252,18 +256,21 @@ async def run_twenty_questions(
 async def _async_main(args: argparse.Namespace) -> None:
     name = f"20q_{args.variant}"
     output_dir = output_dir_from_args(args)
+    staged = stage_skill(INFO_GATHERING_SKILL_SPEC, output_dir / "skill_extract")
+    skill_bind = BindMount(host_path=staged.files_path.resolve(), container_path=SKILL_PATH, mode="ro")
 
     logger.info("=" * 60)
     logger.info("  %s  |  %s  |  openai_agents", name, args.model)
     logger.info("=" * 60)
 
-    async with scratch_exec_server() as server:
+    async with scratch_exec_server(binds=[skill_bind]) as server:
         summary = await run_twenty_questions(
             name=name,
             model=args.model,
             variant_name=args.variant,
             api=args.api,
             output_dir=output_dir,
+            staged=staged,
             exec_server=server,
         )
     logger.info("%s", summary)

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/BUILD.bazel
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/BUILD.bazel
@@ -5,7 +5,11 @@ py_library(
     srcs = ["twenty_questions.py"],
     deps = [
         "//mcp_infra/exec:docker",
+        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:docker_exec",
+        "//skills/eval_infra:eval_sandbox",
+        "//skills/eval_infra:skill_staging",
+        "//skills/info_gathering:info_gathering_skill_spec",
         "//skills/info_gathering/evals/twenty_questions:prompts",
         "//skills/info_gathering/evals/twenty_questions:result_types",
         "//skills/info_gathering/evals/twenty_questions/x/shared:cli",

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
@@ -231,7 +231,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_instructions = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_instructions = build_guesser_system(skill=load_skill_prompt(), has_scratch=True, skill_files_path=None)
+    guesser_instructions = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     guesser_toolsets: list[AbstractToolset[None]] | None = None

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
@@ -235,7 +235,7 @@ async def run_twenty_questions(
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_instructions = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_instructions = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
+    guesser_instructions = build_guesser_system(skill=staged.md_text)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     guesser_toolsets: list[AbstractToolset[None]] | None = None

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
@@ -20,14 +20,17 @@ from pydantic_ai.result import RunContext
 from pydantic_ai.toolsets import AbstractToolset
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 from pydantic_ai.toolsets.function import FunctionToolset
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
+from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.docker_exec import scratch_exec_server
+from skills.eval_infra.eval_sandbox import SKILL_PATH
+from skills.eval_infra.skill_staging import StagedSkill, stage_skill
 from skills.info_gathering.evals.twenty_questions.prompts import (
     build_guesser_system,
     first_user_message,
     load_sim_prompt,
-    load_skill_prompt,
 )
 from skills.info_gathering.evals.twenty_questions.result_types import Correct, LogEntry, Result, RunSummary, Timeout
 from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
@@ -225,13 +228,14 @@ async def run_twenty_questions(
     api: str,
     variant_name: str,
     output_dir: Path,
+    staged: StagedSkill,
     exec_server: ContainerExecServer | None = None,
 ) -> RunSummary:
     variant = VARIANTS[variant_name]
     calls_path, summary_path = run_output_paths(name, output_dir)
 
     sim_instructions = load_sim_prompt(secret=variant.secret, turn_limit=variant.turn_limit)
-    guesser_instructions = build_guesser_system(skill=load_skill_prompt(), skill_files_path=None)
+    guesser_instructions = build_guesser_system(skill=staged.md_text, skill_files_path=SKILL_PATH)
     opening = first_user_message(variant.domain_description, variant.turn_limit)
 
     guesser_toolsets: list[AbstractToolset[None]] | None = None
@@ -268,12 +272,14 @@ async def _async_main(args: argparse.Namespace) -> None:
     name = f"20q_{args.variant}"
     output_dir = output_dir_from_args(args)
     model_id = _make_model_id(args.api, args.model)
+    staged = stage_skill(INFO_GATHERING_SKILL_SPEC, output_dir / "skill_extract")
+    skill_bind = BindMount(host_path=staged.files_path.resolve(), container_path=SKILL_PATH, mode="ro")
 
     logger.info("=" * 60)
     logger.info("  %s  |  %s  |  %s (pydantic_ai)", name, args.model, args.api)
     logger.info("=" * 60)
 
-    async with scratch_exec_server() as exec_server:
+    async with scratch_exec_server(binds=[skill_bind]) as exec_server:
         summary = await run_twenty_questions(
             name=name,
             model_id=model_id,
@@ -281,6 +287,7 @@ async def _async_main(args: argparse.Namespace) -> None:
             api=args.api,
             variant_name=args.variant,
             output_dir=output_dir,
+            staged=staged,
             exec_server=exec_server,
         )
     logger.info("%s", summary)

--- a/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
+++ b/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
@@ -5,7 +5,6 @@ py_binary(
     srcs = ["re_rollout.py"],
     data = ["//skills/reverse_engineer/evals/specimens/go_crypto_server:go_crypto_server_garbled"],
     deps = [
-        "//mcp_infra/exec:docker_types",
         "//skills/eval_infra:af_chat_client",
         "//skills/eval_infra:eval_sandbox",
         "//skills/eval_infra:skill_staging",

--- a/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
+++ b/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
@@ -6,6 +6,7 @@ py_binary(
     data = ["//skills/reverse_engineer/evals/specimens/go_crypto_server:go_crypto_server_garbled"],
     deps = [
         "//skills/eval_infra:af_chat_client",
+        "//skills/eval_infra:eval_prompt",
         "//skills/eval_infra:eval_sandbox",
         "//skills/eval_infra:skill_staging",
         "//skills/eval_infra:termination",

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -35,7 +35,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from agent_framework import Agent, AgentSession, FunctionTool, MiddlewareTermination
+from agent_framework import Agent, AgentSession, FunctionTool, Message, MiddlewareTermination
 from pydantic import BaseModel
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
@@ -67,10 +67,9 @@ _SKILL_BY_ARM: dict[str, SkillSpec] = {"on": REVERSE_ENGINEER_SKILL_SPEC, "off":
 class RunSummary(BaseModel):
     model: str
     skill_on: bool
-    end_reason: Literal["submit", "step_cap", "wall_timeout", "error"]
+    end_reason: Literal["submit", "step_cap", "wall_timeout"]
     wall_seconds: float
     submit_summary: str | None = None
-    error: str | None = None
 
 
 # -- Prompts --
@@ -164,31 +163,30 @@ async def _async_main(args: argparse.Namespace) -> int:
         api="anthropic", model=args.model, function_invocation_configuration={"max_iterations": args.max_steps}
     )
     t_start = time.monotonic()
-    error_msg: str | None = None
-    end_reason: Literal["submit", "step_cap", "wall_timeout", "error"] = "error"
+    end_reason: Literal["submit", "step_cap", "wall_timeout"]
 
-    try:
-        with JsonlTranscriptProvider.opened(transcript_path, system_prompt=system_prompt) as transcript:
-            async with eval_sandbox(skill=staged, workspace=workspace, inputs=inputs_dir) as exec_tool:
-                agent = Agent(
-                    client=model_client,
-                    instructions=system_prompt,
-                    tools=[exec_tool, submit_tool],
-                    context_providers=[transcript],
-                    middleware=[terminate_when(lambda: submit_state.summary is not None, reason="submit called")],
-                    default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
-                )
-                try:
-                    with contextlib.suppress(MiddlewareTermination):
-                        await asyncio.wait_for(
-                            agent.run(_FIRST_USER_MESSAGE, session=AgentSession()), timeout=args.wall_timeout
-                        )
-                    end_reason = "submit" if submit_state.summary is not None else "step_cap"
-                except TimeoutError:
-                    end_reason = "wall_timeout"
-    except Exception as e:
-        logger.exception("Rollout infrastructure failure")
-        error_msg = repr(e)
+    with JsonlTranscriptProvider.opened(transcript_path) as transcript:
+        async with eval_sandbox(skill=staged, workspace=workspace, inputs=inputs_dir) as exec_tool:
+            agent = Agent(
+                client=model_client,
+                tools=[exec_tool, submit_tool],
+                context_providers=[transcript],
+                middleware=[terminate_when(lambda: submit_state.summary is not None, reason="submit called")],
+                default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
+                require_per_service_call_history_persistence=True,
+            )
+            try:
+                with contextlib.suppress(MiddlewareTermination):
+                    await asyncio.wait_for(
+                        agent.run(
+                            [Message("system", [system_prompt]), Message("user", [_FIRST_USER_MESSAGE])],
+                            session=AgentSession(),
+                        ),
+                        timeout=args.wall_timeout,
+                    )
+                end_reason = "submit" if submit_state.summary is not None else "step_cap"
+            except TimeoutError:
+                end_reason = "wall_timeout"
 
     summary = RunSummary(
         model=args.model,
@@ -196,12 +194,11 @@ async def _async_main(args: argparse.Namespace) -> int:
         end_reason=end_reason,
         wall_seconds=round(time.monotonic() - t_start, 2),
         submit_summary=submit_state.summary,
-        error=error_msg,
     )
     summary_path.write_text(summary.model_dump_json(indent=2))
     logger.info("Rollout finished. Output dir: %s", out_dir)
     logger.info("Summary: %s", summary.model_dump_json())
-    return 0 if end_reason != "error" else 1
+    return 0
 
 
 def main() -> None:

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -41,6 +41,7 @@ from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_S
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
+from skills.eval_infra.eval_prompt import compose_system_prompt
 from skills.eval_infra.eval_sandbox import INPUT_PATH, SKILL_PATH, WORK_PATH, eval_sandbox
 from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
@@ -78,29 +79,29 @@ class RunSummary(BaseModel):
 _TARGET_PATH = INPUT_PATH / "target"
 
 
+_RE_PREAMBLE = (
+    f"You are reverse-engineering a stripped Go binary located at {_TARGET_PATH}.\n"
+    f"Recover its source as Go files under {WORK_PATH}/ (your working directory)."
+)
+
+_RE_SCRATCH_NOTE = (
+    "You have shell access via the `exec` tool — `cmd` is a list of strings, no shell\n"
+    "expansion. Stdout and stderr are returned together. Install whatever you need\n"
+    "(apt-get install -y ..., pip install ..., curl ...). The container has internet.\n"
+    "When you have gone as far as you can, call `submit` with a one-paragraph summary\n"
+    "of what the program does and which parts you are confident vs unsure about."
+)
+
+
 def _build_system_prompt(*, skill_md_text: str) -> str:
-    """Compose the RE system prompt.
+    """Compose the RE system prompt via the shared scaffold.
 
     `skill_md_text` is inlined verbatim. The off-arm passes an empty string
     (the empty-skill tar's SKILL.md is blank), keeping the sandbox shape
     uniform across arms.
     """
-    return (
-        f"You are reverse-engineering a stripped Go binary located at {_TARGET_PATH}.\n"
-        f"Recover its source as Go files under {WORK_PATH}/ (your working directory).\n"
-        "You have shell access via the `exec` tool — `cmd` is a list of strings, no shell\n"
-        "expansion. Stdout and stderr are returned together. Install whatever you need\n"
-        "(apt-get install -y ..., pip install ..., curl ...). The container has internet.\n"
-        "When you have gone as far as you can, call `submit` with a one-paragraph summary\n"
-        "of what the program does and which parts you are confident vs unsure about.\n\n"
-        f"A reverse-engineering skill is available. Its SKILL.md is included below verbatim.\n"
-        f"The files SKILL.md references (e.g. examples/pclntool.go, examples/garble_re_recipe.sh)\n"
-        f"live inside the container at {SKILL_PATH}/. You can read them with "
-        f"`cat {SKILL_PATH}/...`, run scripts with `bash {SKILL_PATH}/examples/...`,\n"
-        f"build Go helpers with `go run {SKILL_PATH}/examples/pclntool.go ...`, etc.\n\n"
-        "--- BEGIN SKILL.md ---\n"
-        f"{skill_md_text}\n"
-        "--- END SKILL.md ---\n"
+    return compose_system_prompt(
+        preamble=_RE_PREAMBLE, skill_md=skill_md_text, skill_files_path=SKILL_PATH, scratch_note=_RE_SCRATCH_NOTE
     )
 
 
@@ -136,7 +137,7 @@ def _make_submit_tool(state: _SubmitState) -> FunctionTool:
 # -- Main --
 
 
-async def _async_main(args: argparse.Namespace) -> int:
+async def _async_main(args: argparse.Namespace) -> None:
     skill_on = args.skill == "on"
     suffix = "skill_on" if skill_on else "skill_off"
     out_dir: Path = args.output_dir
@@ -198,7 +199,6 @@ async def _async_main(args: argparse.Namespace) -> int:
     summary_path.write_text(summary.model_dump_json(indent=2))
     logger.info("Rollout finished. Output dir: %s", out_dir)
     logger.info("Summary: %s", summary.model_dump_json())
-    return 0
 
 
 def main() -> None:
@@ -218,7 +218,7 @@ def main() -> None:
         sys.exit("ANTHROPIC_API_KEY is not set; refusing to run.")
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
-    sys.exit(asyncio.run(_async_main(args)))
+    asyncio.run(_async_main(args))
 
 
 if __name__ == "__main__":

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -41,7 +41,7 @@ from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_
 
 from skills.eval_infra.af_chat_client import build_model_client
 from skills.eval_infra.eval_prompt import compose_system_prompt
-from skills.eval_infra.eval_sandbox import INPUT_PATH, SKILL_PATH, WORK_PATH, eval_sandbox
+from skills.eval_infra.eval_sandbox import INPUT_PATH, WORK_PATH, eval_sandbox
 from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.eval_infra.transcript import JsonlTranscriptProvider
@@ -96,9 +96,7 @@ def _build_system_prompt(*, skill_md_text: str) -> str:
     (the empty-skill tar's SKILL.md is blank), keeping the sandbox shape
     uniform across arms.
     """
-    return compose_system_prompt(
-        preamble=_RE_PREAMBLE, skill_md=skill_md_text, skill_files_path=SKILL_PATH, tool_guidance=_RE_TOOL_GUIDANCE
-    )
+    return compose_system_prompt(preamble=_RE_PREAMBLE, skill_md=skill_md_text, tool_guidance=_RE_TOOL_GUIDANCE)
 
 
 _FIRST_USER_MESSAGE = (

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -3,7 +3,7 @@
 Hands a Haiku agent the garbled go_crypto_server binary plus the
 reverse_engineer skill, gives it shell access via MCP exec inside a stock
 python:3.13-slim container, runs for up to 10 minutes, and writes the
-transcript + the agent's recovered/ workspace to --output-dir.
+transcript + the agent's /work workspace to --output-dir.
 
 `Agent.run()` drives the tool-dispatch loop. JSONL transcript writes go
 through `JsonlTranscriptProvider` (AF's standard `HistoryProvider`-shaped
@@ -15,7 +15,7 @@ around `agent.run()`.
 No assertions about the agent's output — this is a manual-inspection
 harness. Outputs:
   <output-dir>/transcript_<variant>.jsonl    — AF Message stream
-  <output-dir>/recovered_<variant>/          — host-side bind of /work/recovered
+  <output-dir>/work_<variant>/               — host-side bind of /work
   <output-dir>/summary_<variant>.json        — end_reason, wall_seconds, submit text
 
 Run with:
@@ -39,10 +39,9 @@ from pydantic import BaseModel
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
 
-from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.af_chat_client import build_model_client
-from skills.eval_infra.eval_sandbox import eval_sandbox
-from skills.eval_infra.skill_staging import SKILL_FILES_PATH, SkillSpec, stage_skill
+from skills.eval_infra.eval_sandbox import INPUT_PATH, SKILL_PATH, WORK_PATH, eval_sandbox
+from skills.eval_infra.skill_staging import SkillSpec, stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.eval_infra.transcript import JsonlTranscriptProvider
 from util.bazel.runfiles import get_required_path
@@ -76,6 +75,9 @@ class RunSummary(BaseModel):
 # -- Prompts --
 
 
+_TARGET_PATH = INPUT_PATH / "target"
+
+
 def _build_system_prompt(*, skill_md_text: str) -> str:
     """Compose the RE system prompt.
 
@@ -84,8 +86,8 @@ def _build_system_prompt(*, skill_md_text: str) -> str:
     uniform across arms.
     """
     return (
-        "You are reverse-engineering a stripped Go binary located at /work/target.\n"
-        "Recover its source as Go files under /work/recovered/ (your working directory).\n"
+        f"You are reverse-engineering a stripped Go binary located at {_TARGET_PATH}.\n"
+        f"Recover its source as Go files under {WORK_PATH}/ (your working directory).\n"
         "You have shell access via the `exec` tool — `cmd` is a list of strings, no shell\n"
         "expansion. Stdout and stderr are returned together. Install whatever you need\n"
         "(apt-get install -y ..., pip install ..., curl ...). The container has internet.\n"
@@ -93,9 +95,9 @@ def _build_system_prompt(*, skill_md_text: str) -> str:
         "of what the program does and which parts you are confident vs unsure about.\n\n"
         f"A reverse-engineering skill is available. Its SKILL.md is included below verbatim.\n"
         f"The files SKILL.md references (e.g. examples/pclntool.go, examples/garble_re_recipe.sh)\n"
-        f"live inside the container at {SKILL_FILES_PATH}/. You can read them with "
-        f"`cat {SKILL_FILES_PATH}/...`, run scripts with `bash {SKILL_FILES_PATH}/examples/...`,\n"
-        f"build Go helpers with `go run {SKILL_FILES_PATH}/examples/pclntool.go ...`, etc.\n\n"
+        f"live inside the container at {SKILL_PATH}/. You can read them with "
+        f"`cat {SKILL_PATH}/...`, run scripts with `bash {SKILL_PATH}/examples/...`,\n"
+        f"build Go helpers with `go run {SKILL_PATH}/examples/pclntool.go ...`, etc.\n\n"
         "--- BEGIN SKILL.md ---\n"
         f"{skill_md_text}\n"
         "--- END SKILL.md ---\n"
@@ -103,8 +105,8 @@ def _build_system_prompt(*, skill_md_text: str) -> str:
 
 
 _FIRST_USER_MESSAGE = (
-    "Reverse-engineer the binary at /work/target. Recover its source as Go files under "
-    "/work/recovered/. You have a 10-minute wall-clock budget and at most 200 turns. "
+    f"Reverse-engineer the binary at {_TARGET_PATH}. Recover its source as Go files under "
+    f"{WORK_PATH}/. You have a 10-minute wall-clock budget and at most 200 turns. "
     "When done, call `submit` with a one-paragraph summary."
 )
 
@@ -140,7 +142,7 @@ async def _async_main(args: argparse.Namespace) -> int:
     out_dir: Path = args.output_dir
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    workspace = out_dir / f"recovered_{suffix}"
+    workspace = out_dir / f"work_{suffix}"
     workspace.mkdir(parents=True, exist_ok=True)
     transcript_path = out_dir / f"transcript_{suffix}.jsonl"
     summary_path = out_dir / f"summary_{suffix}.json"
@@ -167,14 +169,7 @@ async def _async_main(args: argparse.Namespace) -> int:
             transcript_f.write(Message("system", [system_prompt]).to_json() + "\n")
             transcript_f.flush()
 
-            async with eval_sandbox(
-                skill=staged,
-                extra_binds=[
-                    BindMount(host_path=target_path.resolve(), container_path=Path("/work/target"), mode="ro"),
-                    BindMount(host_path=workspace.resolve(), container_path=Path("/work/recovered"), mode="rw"),
-                ],
-                working_dir=Path("/work/recovered"),
-            ) as exec_tool:
+            async with eval_sandbox(skill=staged, workspace=workspace, inputs={"target": target_path}) as exec_tool:
                 agent = Agent(
                     client=model_client,
                     instructions=system_prompt,
@@ -213,10 +208,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--skill", choices=["on", "off"], default="on")
     parser.add_argument(
-        "--output-dir",
-        type=Path,
-        required=True,
-        help="Directory for transcript, recovered/, summary. Created if missing.",
+        "--output-dir", type=Path, required=True, help="Directory for transcript, work/, summary. Created if missing."
     )
     parser.add_argument("--model", default=_DEFAULT_MODEL)
     parser.add_argument("--max-steps", type=int, default=_DEFAULT_MAX_STEPS)

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -83,11 +83,8 @@ _RE_PREAMBLE = (
     f"Recover its source as Go files under {WORK_PATH}/ (your working directory)."
 )
 
-_RE_SCRATCH_NOTE = (
-    "You have shell access via the `exec` tool — `cmd` is a list of strings, no shell\n"
-    "expansion. Stdout and stderr are returned together. Install whatever you need\n"
-    "(apt-get install -y ..., pip install ..., curl ...). The container has internet.\n"
-    "When you have gone as far as you can, call `submit` with a one-paragraph summary\n"
+_RE_TOOL_GUIDANCE = (
+    "When you have gone as far as you can, call `submit` with a one-paragraph summary "
     "of what the program does and which parts you are confident vs unsure about."
 )
 
@@ -100,7 +97,7 @@ def _build_system_prompt(*, skill_md_text: str) -> str:
     uniform across arms.
     """
     return compose_system_prompt(
-        preamble=_RE_PREAMBLE, skill_md=skill_md_text, skill_files_path=SKILL_PATH, scratch_note=_RE_SCRATCH_NOTE
+        preamble=_RE_PREAMBLE, skill_md=skill_md_text, skill_files_path=SKILL_PATH, tool_guidance=_RE_TOOL_GUIDANCE
     )
 
 

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -35,7 +35,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from agent_framework import Agent, AgentSession, FunctionTool, Message, MiddlewareTermination
+from agent_framework import Agent, AgentSession, FunctionTool, MiddlewareTermination
 from pydantic import BaseModel
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
@@ -144,7 +144,6 @@ async def _async_main(args: argparse.Namespace) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     workspace = out_dir / f"work_{suffix}"
-    workspace.mkdir(parents=True, exist_ok=True)
     transcript_path = out_dir / f"transcript_{suffix}.jsonl"
     summary_path = out_dir / f"summary_{suffix}.json"
 
@@ -169,18 +168,13 @@ async def _async_main(args: argparse.Namespace) -> int:
     end_reason: Literal["submit", "step_cap", "wall_timeout", "error"] = "error"
 
     try:
-        with transcript_path.open("w") as transcript_f:
-            # AF "instructions" don't flow through the Message stream — seed it
-            # manually so the JSONL transcript has the full context at the top.
-            transcript_f.write(Message("system", [system_prompt]).to_json() + "\n")
-            transcript_f.flush()
-
+        with JsonlTranscriptProvider.opened(transcript_path, system_prompt=system_prompt) as transcript:
             async with eval_sandbox(skill=staged, workspace=workspace, inputs=inputs_dir) as exec_tool:
                 agent = Agent(
                     client=model_client,
                     instructions=system_prompt,
                     tools=[exec_tool, submit_tool],
-                    context_providers=[JsonlTranscriptProvider(transcript_f)],
+                    context_providers=[transcript],
                     middleware=[terminate_when(lambda: submit_state.summary is not None, reason="submit called")],
                     default_options={"tool_choice": "required", "allow_multiple_tool_calls": False},
                 )

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -29,6 +29,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -147,7 +148,12 @@ async def _async_main(args: argparse.Namespace) -> int:
     transcript_path = out_dir / f"transcript_{suffix}.jsonl"
     summary_path = out_dir / f"summary_{suffix}.json"
 
-    target_path = get_required_path(_TARGET_BINARY_RLOCATION)
+    # Assemble the inputs dir: copy the runfiles target binary in under the
+    # name the prompt promises (`/input/target`). Per-run dir so concurrent
+    # rollouts don't collide.
+    inputs_dir = out_dir / f"inputs_{suffix}"
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(get_required_path(_TARGET_BINARY_RLOCATION), inputs_dir / "target")
 
     staged = stage_skill(_SKILL_BY_ARM[args.skill], out_dir / f"skill_extract_{suffix}")
     system_prompt = _build_system_prompt(skill_md_text=staged.md_text)
@@ -169,7 +175,7 @@ async def _async_main(args: argparse.Namespace) -> int:
             transcript_f.write(Message("system", [system_prompt]).to_json() + "\n")
             transcript_f.flush()
 
-            async with eval_sandbox(skill=staged, workspace=workspace, inputs={"target": target_path}) as exec_tool:
+            async with eval_sandbox(skill=staged, workspace=workspace, inputs=inputs_dir) as exec_tool:
                 agent = Agent(
                     client=model_client,
                     instructions=system_prompt,

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -26,7 +26,6 @@ Run with:
 
 import argparse
 import asyncio
-import contextlib
 import logging
 import os
 import shutil
@@ -35,7 +34,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from agent_framework import Agent, AgentSession, FunctionTool, Message, MiddlewareTermination
+from agent_framework import Agent, AgentSession, FunctionTool, Message
 from pydantic import BaseModel
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
@@ -177,14 +176,16 @@ async def _async_main(args: argparse.Namespace) -> None:
                 require_per_service_call_history_persistence=True,
             )
             try:
-                with contextlib.suppress(MiddlewareTermination):
-                    await asyncio.wait_for(
-                        agent.run(
-                            [Message("system", [system_prompt]), Message("user", [_FIRST_USER_MESSAGE])],
-                            session=AgentSession(),
-                        ),
-                        timeout=args.wall_timeout,
-                    )
+                # `terminate_when` raises `MiddlewareTermination` once submit is
+                # called; AF's tool loop catches it internally so `agent.run`
+                # returns normally.
+                await asyncio.wait_for(
+                    agent.run(
+                        [Message("system", [system_prompt]), Message("user", [_FIRST_USER_MESSAGE])],
+                        session=AgentSession(),
+                    ),
+                    timeout=args.wall_timeout,
+                )
                 end_reason = "submit" if submit_state.summary is not None else "step_cap"
             except TimeoutError:
                 end_reason = "wall_timeout"


### PR DESCRIPTION
## Summary

Stacked on #1395. Centralizes the in-container path convention as constants on `eval_sandbox`:

- `SKILL_PATH = /skill` — read-only skill mount (was `/work/.skill`).
- `WORK_PATH = /work` — read-write workspace, agent's cwd, output dir. Always present; `eval_sandbox` now requires a `workspace=` host dir.
- `INPUT_PATH = /input` — read-only mounts for eval-specific inputs, bound at `/input/<name>` via the new `inputs={name: host_path}` arg.

`eval_sandbox`'s API tightens accordingly: `workspace: Path` is now required, and `extra_binds` / `working_dir` are gone — replaced by the typed `inputs: Mapping[str, Path]` slot. The agent's cwd is hardcoded to `WORK_PATH`. Per the user's "no free-form binds" guidance.

**Per-rollout shape**:
- TQ AF + FL: allocate `output_dir/work/` host dir, pass as `workspace`.
- RE: target binary moves from `/work/target` → `/input/target` (via `inputs={"target": ...}`); workspace simplifies from `/work/recovered` to just `/work`. Prompt text updated. The host-side dir under `output_dir/` renames `recovered_<variant>/` → `work_<variant>/`.
- Tests: allocate a `tmp_path/work/` workspace dir.

`SKILL_FILES_PATH` constant in `skill_staging.py` is gone — replaced by `SKILL_PATH` in `eval_sandbox.py` (the source of truth for sandbox layout).

## Test plan

- [x] `bbr test //skills/info_gathering/evals/twenty_questions/x/agent_framework:test_twenty_questions //skills/info_gathering/evals/function_learning:test_function_learning --config=ci` — both pass (invocation `4961f225-665f-42c3-abb6-90349cf6e7a7`)
- [x] `bbr build //skills/... --config=ci` — green with lint
- [ ] End-to-end RE rollout requires API key — covered by reviewer's `bb run` job

https://claude.ai/code/session_01BcMHaLnwEFUdNKmZpJvht8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcMHaLnwEFUdNKmZpJvht8)_