### PR TITLE
Move referencedUndeclaredNames into common; dedupe slow second copy

### DIFF
--- a/devinfra/js/debundle/analysis/boundary.mjs
+++ b/devinfra/js/debundle/analysis/boundary.mjs
@@ -6,6 +6,7 @@ import * as t from "@babel/types";
 import { DEFAULT_PARSER_OPTIONS, writeJsonFile } from "../common/parser_options.mjs";
 import { getArtifactManifestChunks, getChunkEntryFile, getChunkEntryPath, requirePipelineArtifact } from "../common/artifact.mjs";
 import { formatDurationSince, logProgress, prepareOutputDir, relativeWorkspacePath, resolveWorkspacePath } from "../common/io.mjs";
+import { referencedUndeclaredNames } from "../common/program_analysis.mjs";
 
 const traverse = traverseModule.default ?? traverseModule;
 
@@ -1220,81 +1221,6 @@ function effectToReason(effect) {
     return "contains_top_level_await";
   }
   return effect;
-}
-
-// Names referenced in `node` from positions that are NOT inside a nested
-// function/method body. Equivalent semantics to a babel-traverse pass with
-// a ReferencedIdentifier visitor that filters out names with a binding in
-// scope; in our use site `node` is a VariableDeclarator init expression,
-// so the only "binding in scope" possibilities are inside nested functions
-// (which we skip anyway). Hand-rolled recursion is ~10x cheaper than
-// wrapping in a synthetic File and running traverse with scope.
-function referencedUndeclaredNames(node) {
-  if (!node) return [];
-  const names = new Set();
-  collectReferencedIdentifierNames(node, names);
-  return [...names];
-}
-
-const FUNCTION_TYPES = new Set([
-  "FunctionExpression",
-  "FunctionDeclaration",
-  "ArrowFunctionExpression",
-  "ObjectMethod",
-  "ClassMethod",
-  "ClassPrivateMethod",
-]);
-
-const NON_AST_KEYS = new Set([
-  "type",
-  "start",
-  "end",
-  "loc",
-  "extra",
-  "leadingComments",
-  "trailingComments",
-  "innerComments",
-  "comments",
-  "tokens",
-  "errors",
-]);
-
-function collectReferencedIdentifierNames(node, names) {
-  if (!node || typeof node !== "object") return;
-  if (Array.isArray(node)) {
-    for (const child of node) collectReferencedIdentifierNames(child, names);
-    return;
-  }
-  if (FUNCTION_TYPES.has(node.type)) return;
-  switch (node.type) {
-    case "Identifier":
-      names.add(node.name);
-      return;
-    case "MemberExpression":
-    case "OptionalMemberExpression":
-      collectReferencedIdentifierNames(node.object, names);
-      if (node.computed) collectReferencedIdentifierNames(node.property, names);
-      return;
-    case "ObjectProperty":
-      if (node.computed) collectReferencedIdentifierNames(node.key, names);
-      collectReferencedIdentifierNames(node.value, names);
-      return;
-    case "VariableDeclarator":
-      // node.id is the declaration target (not a reference)
-      collectReferencedIdentifierNames(node.init, names);
-      return;
-    case "ImportSpecifier":
-    case "ImportDefaultSpecifier":
-    case "ImportNamespaceSpecifier":
-    case "ExportSpecifier":
-      return;
-    default: {
-      for (const key of Object.keys(node)) {
-        if (NON_AST_KEYS.has(key)) continue;
-        collectReferencedIdentifierNames(node[key], names);
-      }
-    }
-  }
 }
 
 function sortedAccessNames(accessMap) {

--- a/devinfra/js/debundle/common/program_analysis.mjs
+++ b/devinfra/js/debundle/common/program_analysis.mjs
@@ -210,6 +210,81 @@ export function topLevelDeclarationNames(node) {
   return [];
 }
 
+// Names referenced (in expression position) inside `node` from positions
+// that are NOT inside a nested function/method body. Equivalent semantics to
+// a babel-traverse pass with a ReferencedIdentifier visitor that filters out
+// names with a binding in scope; the typical caller passes a single
+// expression whose only "binding in scope" possibilities live inside nested
+// functions (which we skip anyway). Hand-rolled recursion is ~10x cheaper
+// than wrapping in a synthetic File and running traverse with scope.
+export function referencedUndeclaredNames(node) {
+  if (!node) return [];
+  const names = new Set();
+  collectReferencedIdentifierNames(node, names);
+  return [...names];
+}
+
+const FUNCTION_TYPES = new Set([
+  "FunctionExpression",
+  "FunctionDeclaration",
+  "ArrowFunctionExpression",
+  "ObjectMethod",
+  "ClassMethod",
+  "ClassPrivateMethod",
+]);
+
+const NON_AST_KEYS = new Set([
+  "type",
+  "start",
+  "end",
+  "loc",
+  "extra",
+  "leadingComments",
+  "trailingComments",
+  "innerComments",
+  "comments",
+  "tokens",
+  "errors",
+]);
+
+function collectReferencedIdentifierNames(node, names) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) collectReferencedIdentifierNames(child, names);
+    return;
+  }
+  if (FUNCTION_TYPES.has(node.type)) return;
+  switch (node.type) {
+    case "Identifier":
+      names.add(node.name);
+      return;
+    case "MemberExpression":
+    case "OptionalMemberExpression":
+      collectReferencedIdentifierNames(node.object, names);
+      if (node.computed) collectReferencedIdentifierNames(node.property, names);
+      return;
+    case "ObjectProperty":
+      if (node.computed) collectReferencedIdentifierNames(node.key, names);
+      collectReferencedIdentifierNames(node.value, names);
+      return;
+    case "VariableDeclarator":
+      // node.id is the declaration target (not a reference)
+      collectReferencedIdentifierNames(node.init, names);
+      return;
+    case "ImportSpecifier":
+    case "ImportDefaultSpecifier":
+    case "ImportNamespaceSpecifier":
+    case "ExportSpecifier":
+      return;
+    default: {
+      for (const key of Object.keys(node)) {
+        if (NON_AST_KEYS.has(key)) continue;
+        collectReferencedIdentifierNames(node[key], names);
+      }
+    }
+  }
+}
+
 export function bindingNames(node) {
   if (!node) return [];
   if (node.type === "Identifier") return [node.name];

--- a/devinfra/js/debundle/extract/init_region.mjs
+++ b/devinfra/js/debundle/extract/init_region.mjs
@@ -1,8 +1,8 @@
 import { parse } from "@babel/parser";
-import traverseModule from "@babel/traverse";
 import * as t from "@babel/types";
 import { analyzeRuntimeBoundaryAst } from "../analysis/boundary.mjs";
 import { DEFAULT_PARSER_OPTIONS } from "../common/parser_options.mjs";
+import { referencedUndeclaredNames } from "../common/program_analysis.mjs";
 import { serializeGeneratedJsFile } from "../split/chunk.mjs";
 import {
   expandOrderedInitOwnerClosurePassOperations,
@@ -13,7 +13,6 @@ import {
   buildSelectedModuleOperations,
 } from "./planner.mjs";
 
-const traverse = traverseModule.default ?? traverseModule;
 
 export function extractOrderedInitRegionsInCode(code, operations, options = {}) {
   const ast = parse(code, options.parser ?? DEFAULT_PARSER_OPTIONS);
@@ -1443,25 +1442,6 @@ function validateVariableDeclarators(statement, operationId, ownerId) {
   }
 }
 
-function referencedUndeclaredNames(node) {
-  if (!node) {
-    return [];
-  }
-  const names = new Set();
-  const file = t.file(t.program([t.expressionStatement(t.cloneNode(node, true))]));
-  traverse(file, {
-    ReferencedIdentifier(path) {
-      if (path.scope.getBinding(path.node.name)) {
-        return;
-      }
-      if (path.findParent((parent) => parent.isFunction() || parent.isObjectMethod() || parent.isClassMethod())) {
-        return;
-      }
-      names.add(path.node.name);
-    },
-  });
-  return [...names];
-}
 
 function cloneNodes(nodes) {
   return nodes.map((node) => t.cloneNode(node, true));


### PR DESCRIPTION
init_region.mjs had a second copy of referencedUndeclaredNames that
still used the slow babel-traverse + clone-into-synthetic-File pattern;
the boundary.mjs version had been replaced earlier with a hand-rolled
recursive walker. Moved the optimized walker into
common/program_analysis.mjs and made both call sites import it.

Profile-driven attempts at the rest of the proposed Tier 1 wins:

- Removing programPath.scope.crawl() in analyzeRuntimeBoundaryAst was
  actually 30% slower: every per-visitor path.scope.getBinding() call
  triggers an ad-hoc partial crawl, which adds up to more work than
  one upfront crawl over the program. Reverted.
- The array-spread allocations in decl_graph.mjs buildStagedShellBatchPlan
  are real but each batch plan touches small (~10s of items) arrays.
  Replacing them in place doesn't move the needle on the benchmark
  wall measurably; the real cost in the planner is graph construction,
  not the spreads.

Per-chunk timings on the Excalidraw entry chunk:

  lower      454ms -> 327ms   (init_region picks up optimized walker)
  total wall ~11.1s -> ~10.9s  (within run-to-run noise)

Honest assessment: the meaningful next step is the Tier 2 rewrite
(custom AST walker replacing babel-traverse for the whole boundary
analysis). That's the path to <5s wall.

BAZEL_TEST_INVOCATIONS=local:267b200f-098c-4bcb-9a29-fbaf4065dc3e