### PR TITLE
Add Codex Cloud bootstrap: `setup.sh`, README, and agent configuration plan

### DIFF
--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -1,0 +1,82 @@
+# Codex Cloud environment bootstrap for `ducktape`
+
+This directory contains a unified Codex Cloud setup/maintenance script for this monorepo,
+modeled after the Claude web setup goals:
+
+- bootstrap from monorepo source-of-truth scripts (`devinfra/setup_buildbuddy.sh`)
+- optionally install Nix + `.#devtools` for tool parity with local workflows
+- support SOPS via `SOPS_AGE_KEY` injected through Codex environment config
+
+## Files
+
+- `setup.sh`: unified script with `--mode=install|maintenance`
+- `codex_cloud_agent_configuration_plan.md`: detailed research/plan doc collected for Cloud behavior, hooks, and rollout strategy
+
+## Codex Cloud environment configuration
+
+Recommended initial config in Codex Cloud:
+
+- **Setup script**: `bash devinfra/codex_cloud/setup.sh --mode=install`
+- **Maintenance script**: `bash devinfra/codex_cloud/setup.sh --mode=maintenance`
+
+### Environment variables vs secrets
+
+Codex Cloud behavior (per OpenAI docs):
+
+- Environment variables are available in setup and agent phases.
+- Secrets are setup-only and removed before agent execution.
+
+For this repo:
+
+- Put `SOPS_AGE_KEY` in **Environment variables** if the agent itself must run `sops`.
+- `setup.sh` decrypts the BuildBuddy key from
+  `cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml` when
+  `SOPS_AGE_KEY` is available.
+
+If `SOPS_AGE_KEY` is present during setup, `setup.sh` appends an export to
+`~/.bashrc` so Bash tool sessions inherit it.
+
+This is intentional: Codex Cloud docs state setup runs in a separate Bash
+session and recommend `~/.bashrc` for persistence into the agent phase.
+
+## What this setup does
+
+1. Detects repo root and logs commit identity.
+2. Installs Nix (Determinate installer) if missing.
+3. Installs the repo `.#devtools` profile.
+4. Persists nix profile sourcing in `~/.bashrc` so agent Bash sessions get Nix tools on `PATH`.
+5. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
+6. Configures BuildBuddy remote selection:
+   - uses `origin` when it already points directly to GitHub
+   - falls back to `github-no-proxy` only when `origin` is proxied/non-GitHub
+7. Persists `SOPS_AGE_KEY` into `~/.bashrc` when provided.
+
+Maintenance refreshes git remotes, BuildBuddy config, and devtools profile,
+then validates `bb` / `bbr` availability.
+
+## Known gaps / risks
+
+1. **Hooks in Codex Cloud are not yet guaranteed**
+   - OpenAI docs clearly describe setup/maintenance scripts and AGENTS behavior.
+   - They do not clearly confirm delegated Cloud execution of `.codex/hooks.json`.
+   - Plan as if hooks are unavailable unless validated empirically.
+
+2. **SOPS key handling trade-off**
+   - `SOPS_AGE_KEY` in environment variables makes runtime decryption possible but is less restrictive than setup-only secrets.
+   - If you do not need runtime decryption, prefer keeping key material setup-only.
+   - BuildBuddy setup now depends on being able to decrypt
+     `cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml`.
+
+3. **Nix bootstrap cost**
+   - First-run setup may be slow; cached-container resume mitigates this.
+   - If setup exceeds practical time limits, fall back to non-Nix Stage A tooling.
+
+4. **Cloud image assumptions**
+   - Scripts assume Linux x86_64 and that Codex agent Bash sessions source `~/.bashrc` (as documented).
+   - If image changes, update install script accordingly.
+
+## Validation command (inside repo)
+
+```bash
+bash -n devinfra/codex_cloud/setup.sh
+```

--- a/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
+++ b/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
@@ -1,0 +1,188 @@
+# Codex Cloud agent: environment behavior, hookability, and ducktape configuration plan
+
+_Last updated: 2026-04-27_
+
+## Status
+
+Initial implementation scaffolding now exists under `devinfra/codex_cloud/`:
+
+- `devinfra/codex_cloud/setup.sh` (`--mode=install|maintenance`)
+- `devinfra/codex_cloud/README.md`
+
+## 1) What is known (documented) about Codex Cloud environments
+
+Primary source: OpenAI Codex Cloud docs and changelog.
+
+- Codex Cloud runs tasks in an isolated container, checks out the requested branch/SHA, runs setup, then runs the agent loop.
+- Setup scripts run in a different shell session than the agent loop; shell exports from setup do not automatically carry into agent shell unless persisted (for example via shell startup files).
+- Environment variables configured in the Codex environment are available for the whole task (setup + agent).
+- Secrets are available during setup, then removed before the agent phase.
+- Setup has internet by default; agent internet is controlled by environment internet policy (off by default with explicit allow/deny options).
+- Container caching keeps setup state for up to 12 hours. Follow-up tasks may resume cached state, and cache is invalidated by setup/maintenance script changes and env/secret changes.
+
+References:
+- https://developers.openai.com/codex/cloud/environments
+- https://developers.openai.com/codex/cloud/internet-access
+- https://developers.openai.com/codex/changelog
+
+## 2) Does Codex Cloud follow `.codex` settings and hooks?
+
+## 2.1 What OpenAI docs clearly say
+
+- `.codex/config.toml` and `hooks.json` are documented as Codex config surfaces (config layers include user and project `.codex` paths).
+- Hook docs define events, matcher semantics, and configuration format.
+- AGENTS.md is explicitly documented and is used for repository-specific instructions.
+
+References:
+- https://developers.openai.com/codex/config-basic
+- https://developers.openai.com/codex/config-reference
+- https://developers.openai.com/codex/hooks
+- https://developers.openai.com/codex/guides/agents-md
+
+## 2.2 What is *not* clearly documented for Cloud
+
+I could not find explicit OpenAI documentation stating that delegated Cloud runs execute project/user `hooks.json` from `.codex` inside the Cloud container.
+
+Cloud environment docs document setup + maintenance scripts + AGENTS.md + internet policy. They do not explicitly mention hook execution in Cloud runtime.
+
+### Conclusion (confidence: medium)
+
+- **Documented, supported, and reliable for Cloud**: setup script, maintenance script, env vars, secrets (setup-only), AGENTS.md, internet policy.
+- **Not explicitly confirmed for Cloud delegated runtime**: `.codex/hooks.json` execution.
+- Treat hooks in Cloud as **unknown/unsupported until validated experimentally**.
+
+## 2.3 What is hookable where hooks are supported
+
+From hooks docs (general Codex hooks surface):
+
+- Lifecycle: `SessionStart`, `Stop`
+- Prompt/input: `UserPromptSubmit`
+- Tool interception: `PreToolUse`, `PostToolUse`
+- Matchers: specific tool names, shell matchers, and event-specific filters
+
+Reference:
+- https://developers.openai.com/codex/hooks
+
+## 2.4 Additional online signals checked
+
+- OpenAI Codex open-source issue traffic around hooks is predominantly tagged/phrased as **CLI** behavior and feature requests (event coverage, matcher semantics, platform parity), not Cloud runtime guarantees.
+- I did not find an OpenAI source that positively states: \"Cloud delegated tasks execute `.codex/hooks.json`\".
+- Therefore, for Cloud planning in this repo, hooks should be considered experimental until empirically validated in our own environment.
+
+References:
+- https://github.com/openai/codex/issues?q=is%3Aissue+hooks+is%3Aopen
+- https://github.com/openai/codex/issues/16226
+- https://github.com/openai/codex/issues/16301
+
+## 3) Repo-specific constraints relevant to Cloud setup
+
+From this repository's AGENTS/README and current infra:
+
+- Build/test convention is Bazel via `bbr` wrapper for remote execution.
+- Session setup breakage (cert/proxy/buildbuddy bootstrap) should be treated as a hard failure and recovered before proceeding.
+- SOPS behavior depends on running from repo context and having `SOPS_AGE_KEY` available.
+- Canonical local developer environment is Nix-based (`flake.nix`, home-manager, codex module under `nix/home/codex`).
+- Existing repo script `devinfra/setup_buildbuddy.sh` configures BuildBuddy based on `BUILDBUDDY_API_KEY`.
+
+References:
+- `AGENTS.md`
+- `README.md`
+- `flake.nix`
+- `nix/home/codex/default.nix`
+- `devinfra/setup_buildbuddy.sh`
+
+## 4) Practical configuration plan for Codex Cloud in this repo
+
+Goal: make Codex Cloud behave as close as feasible to our canonical Nix/devshell workflows, while remaining robust when hooks are unavailable.
+
+## 4.1 Baseline environment shape (recommended)
+
+1. **Codex Cloud environment image**: use OpenAI universal image.
+2. **Setup script**: perform deterministic bootstrap for this repo:
+   - install/enable required tooling available in Cloud context
+   - run BuildBuddy bootstrap (`devinfra/setup_buildbuddy.sh`) when key present
+   - run quick sanity checks (`bb --version`, `bbr --help`, `python --version`, etc.)
+3. **Maintenance script**: lightweight idempotent refresh for cached containers:
+   - `git fetch --all --prune`
+   - validity checks for bb auth / remote availability
+4. **Environment variables** (non-secret):
+   - repo-level defaults (`CI=1`, optionally `CODEX_AGENT=1`)
+   - any stable non-sensitive flags
+5. **Secrets / decryption inputs**:
+   - no direct `BUILDBUDDY_API_KEY` environment injection required
+   - `SOPS_AGE_KEY` available so setup/maintenance can decrypt
+     `cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml`
+   - any additional tokens needed only to install/private-fetch during setup
+6. **Internet policy**:
+   - start with allowlist mode, minimum domains required for setup/package fetch + repo infra endpoints.
+
+## 4.2 Agent behavior controls
+
+1. Keep authoritative repository guidance in `AGENTS.md` (already done).
+2. Add a repo-local document dedicated to Codex Cloud operational expectations (this file plus a short runbook link).
+3. Prefer deterministic command recipes in AGENTS over implicit hook behavior.
+
+Reasoning: AGENTS.md behavior in Cloud is documented; hooks behavior in Cloud is not.
+
+## 4.3 Hooks strategy (pending verification)
+
+Because Cloud hook execution is not explicitly documented:
+
+- Do **not** make Cloud correctness depend on `.codex/hooks.json`.
+- If desired, add an experiment suite:
+  1. commit a minimal project `.codex/hooks.json` with observable side effects,
+  2. run a no-op Cloud task,
+  3. inspect filesystem/log artifacts for hook execution,
+  4. repeat across fresh + cached container runs.
+- If hooks execute reliably, treat as optional acceleration only; keep setup+AGENTS as source of truth.
+
+## 4.4 Nix/devshell and SOPS in Cloud: practical path
+
+"Ideal" parity with local Nix devshell is desirable, but in managed Cloud containers this should be staged:
+
+### Stage A (now): tool parity without full Nix activation
+
+- Install/use repo tooling directly in setup script (bb/bbr/python/pre-commit/etc.) sufficient for agent tasks.
+- Use Bazel + RBE as the execution substrate.
+- Keep bootstrap fast to preserve container cache value.
+
+### Stage B (optional): partial Nix enablement
+
+- If Cloud image/runtime permits, install Nix in setup and pre-build needed profile/packages.
+- Cache warm-up costs may be significant; verify payoff against 12h cache behavior.
+
+### Stage C (advanced): canonical devshell parity
+
+- Attempt `nix develop` style parity only if setup-time and reliability are acceptable.
+- If this path becomes canonical, codify strict smoke tests in setup and maintenance scripts.
+
+### SOPS specifics
+
+- Provide `SOPS_AGE_KEY` via environment configuration so setup/maintenance and
+  agent tasks can decrypt as needed.
+- Use SOPS decryption of encrypted files under repo paths (for example the
+  BuildBuddy key) rather than duplicating raw secret values into environment
+  config fields.
+- Ensure decryption paths respect repository-relative creation rules.
+
+## 5) Reachable knobs checklist (Cloud-first)
+
+Use this as the operator checklist for Codex Cloud environment config:
+
+- [ ] Setup script configured and idempotent
+- [ ] Maintenance script configured and idempotent
+- [ ] Required non-secret env vars declared
+- [ ] SOPS decryption inputs declared (for encrypted repo-managed secrets)
+- [ ] Internet policy set to least privilege needed
+- [ ] AGENTS.md up to date for lint/test/build norms
+- [ ] Cache reset procedure documented for bad state
+- [ ] Hook support experimentally verified (optional; do not block rollout)
+
+## 6) Open questions / follow-up research
+
+1. Does OpenAI Codex Cloud execute `.codex/hooks.json` in delegated tasks?
+2. If yes, are all hook events supported in Cloud, or only a subset?
+3. Are hook side effects persisted in cached container resumes exactly once or per resumed session?
+4. What are current setup script timeout and resource ceilings by plan tier?
+
+Until (1)-(2) are verified, this repo should treat hooks as non-authoritative for Cloud.

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Unified setup/maintenance entrypoint for OpenAI Codex Cloud.
+#
+# Usage:
+#   bash devinfra/codex_cloud/setup.sh --mode=install
+#   bash devinfra/codex_cloud/setup.sh --mode=maintenance
+
+set -euo pipefail
+
+MODE="install"
+for arg in "$@"; do
+  case "$arg" in
+    --mode=install) MODE="install" ;;
+    --mode=maintenance) MODE="maintenance" ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+log() {
+  printf '[codex-cloud %s] %s\n' "$MODE" "$*"
+}
+
+ensure_line() {
+  local line="$1"
+  local file="$2"
+  grep -Fqx "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
+}
+
+load_buildbuddy_api_key_from_sops() {
+  local sops_file="cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml"
+  if [ -n "${BUILDBUDDY_API_KEY:-}" ]; then
+    log "BUILDBUDDY_API_KEY already set"
+    return 0
+  fi
+  if [ -z "${SOPS_AGE_KEY:-}" ]; then
+    log "SOPS_AGE_KEY not set; cannot decrypt BuildBuddy API key"
+    return 0
+  fi
+  if ! command -v sops >/dev/null 2>&1; then
+    log "sops command missing; cannot decrypt BuildBuddy API key"
+    return 0
+  fi
+  if [ ! -f "$sops_file" ]; then
+    log "BuildBuddy sops file missing at $sops_file"
+    return 0
+  fi
+
+  log "decrypting BuildBuddy API key from sops file"
+  BUILDBUDDY_API_KEY="$(
+    sops -d "$sops_file" | python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["stringData"]["api-key"])'
+  )"
+  export BUILDBUDDY_API_KEY
+}
+
+source_nix_profile_if_present() {
+  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    # shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+}
+
+reconcile_buildbuddy_remote() {
+  # Prefer origin when it already points directly at GitHub. Fallback to
+  # github-no-proxy only for proxied origin URLs.
+  if git remote get-url origin >/dev/null 2>&1; then
+    local origin_url
+    origin_url="$(git remote get-url origin)"
+    if [[ "$origin_url" == *"github.com"* ]]; then
+      log "origin is GitHub; using origin for BuildBuddy remote"
+      git config buildbuddy.remote-bazel-remote-name origin
+    else
+      local github_remote_url="https://github.com/agentydragon/ducktape"
+      if git remote get-url github-no-proxy >/dev/null 2>&1; then
+        log "origin is proxied; github-no-proxy already present"
+      else
+        git remote add github-no-proxy "$github_remote_url"
+        log "origin is proxied; added github-no-proxy remote"
+      fi
+      git config buildbuddy.remote-bazel-remote-name github-no-proxy
+    fi
+  else
+    log "origin remote missing; leaving buildbuddy.remote-bazel-remote-name unchanged"
+  fi
+}
+
+install_nix_if_missing() {
+  if command -v nix >/dev/null 2>&1; then
+    log "nix already installed"
+    return 0
+  fi
+
+  log "nix not found; installing Determinate Nix installer"
+  local nix_installer_version="v3.17.3"
+  local nix_installer_url="https://github.com/DeterminateSystems/nix-installer/releases/download/${nix_installer_version}/nix-installer-x86_64-linux"
+  local nix_installer_sha256="4a84424a0a598b671de21fca1602ea3e74af214d823020afe7aac0056dc032ac"
+  local nix_installer_bin="/tmp/nix-installer"
+
+  curl -fsSL "$nix_installer_url" -o "$nix_installer_bin"
+  echo "${nix_installer_sha256}  ${nix_installer_bin}" | sha256sum -c
+  chmod +x "$nix_installer_bin"
+
+  local saved_user="${USER:-}"
+  export USER="${USER:-$(id -u -n)}"
+  "$nix_installer_bin" install linux \
+    --no-confirm \
+    --init none \
+    --extra-conf "sandbox = false" \
+    --extra-conf "max-jobs = auto" \
+    --extra-conf "system-features =" \
+    --extra-conf "substituters = https://cache.nixos.org" \
+    --extra-conf "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+
+  source_nix_profile_if_present
+
+  if [ -z "$saved_user" ]; then unset USER; else USER="$saved_user"; fi
+}
+
+install_or_refresh_devtools() {
+  if command -v nix >/dev/null 2>&1; then
+    log "installing repo devtools profile"
+    nix profile remove devtools 2>/dev/null || true
+    nix profile install --max-jobs auto "path:${REPO_ROOT}#devtools"
+  fi
+}
+
+run_buildbuddy_setup() {
+  if [ -f devinfra/setup_buildbuddy.sh ]; then
+    load_buildbuddy_api_key_from_sops
+    log "running BuildBuddy setup"
+    bash devinfra/setup_buildbuddy.sh
+  fi
+}
+
+persist_agent_shell_init() {
+  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    log "persisting nix-daemon profile sourcing into ~/.bashrc"
+    ensure_line '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ~/.bashrc
+  fi
+
+  if [ -n "${SOPS_AGE_KEY:-}" ]; then
+    log "persisting SOPS_AGE_KEY into ~/.bashrc for agent shells"
+    ensure_line "export SOPS_AGE_KEY='${SOPS_AGE_KEY}'" ~/.bashrc
+  else
+    log "SOPS_AGE_KEY not set (expected unless configured in Codex environment vars)"
+  fi
+}
+
+validate_core_tools() {
+  if command -v bb >/dev/null 2>&1; then
+    bb --version >/dev/null
+    log "bb present"
+  else
+    log "WARNING: bb missing"
+  fi
+
+  if command -v bbr >/dev/null 2>&1; then
+    bbr --help >/dev/null
+    log "bbr present"
+  else
+    log "WARNING: bbr missing"
+  fi
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+log "repo=$REPO_ROOT"
+log "commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+
+case "$MODE" in
+  install)
+    install_nix_if_missing
+    install_or_refresh_devtools
+    run_buildbuddy_setup
+    reconcile_buildbuddy_remote
+    persist_agent_shell_init
+    ;;
+  maintenance)
+    source_nix_profile_if_present
+    log "refreshing git remotes"
+    git fetch --all --prune
+    run_buildbuddy_setup
+    reconcile_buildbuddy_remote
+    install_or_refresh_devtools
+    validate_core_tools
+    ;;
+  *)
+    echo "Unsupported mode: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+log "complete"


### PR DESCRIPTION
### Motivation

- Provide a unified, idempotent bootstrap and maintenance flow for running this repo in OpenAI Codex Cloud environments. 
- Achieve tool parity with local Nix-based developer workflows while supporting encrypted secret handling via SOPS. 
- Document operational assumptions and an experiment-first strategy for `.codex` hooks and agent behavior.

### Description

- Add `devinfra/codex_cloud/setup.sh`, a unified entrypoint supporting `--mode=install` and `--mode=maintenance` that installs Nix (Determinate installer), refreshes the repo devtools profile, decrypts BuildBuddy API key via SOPS when `SOPS_AGE_KEY` is present, reconciles BuildBuddy git remotes, and persists environment lines into `~/.bashrc` for agent shells. 
- Add `devinfra/codex_cloud/README.md` that explains usage, recommended Codex Cloud environment configuration, SOPS/secret semantics, and a quick validation command. 
- Add `devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md` capturing research, known Cloud behaviors, hooks strategy, staged Nix/devshell approach, and an operator checklist for rollout.

### Testing

- Performed a shell-syntax validation with `bash -n devinfra/codex_cloud/setup.sh`, which completed successfully. 
- No repo unit tests were modified; no additional automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed2649ff4833199a728225c172db7)