### PR TITLE
Unify Determinate Nix installer, enhance logging, and extend Codex Cloud setup (bazelrcs, kubeconfig, bb packaging)

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -45,6 +45,14 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 
 set -euo pipefail
 
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+warn() {
+  log "WARNING: $*" >&2
+}
+
 # Hook implementation: python (default) or rust.
 HOOK_IMPL="${DUCKTAPE_CLAUDE_HOOK_IMPL:-python}"
 for arg in "$@"; do
@@ -54,14 +62,14 @@ case "$HOOK_IMPL" in
   python) DEVTOOLS_OUTPUT="devtools" ;;
   rust) DEVTOOLS_OUTPUT="devtools-rust" ;;
   *)
-    echo "Unknown --impl=$HOOK_IMPL (expected python or rust)" >&2
+    warn "Unknown --impl=$HOOK_IMPL (expected python or rust)"
     DEVTOOLS_OUTPUT="devtools"
     ;;
 esac
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
-echo "[$(date -Iseconds)] web_setup.sh commit: $SETUP_COMMIT"
+log "web_setup.sh commit: $SETUP_COMMIT"
 
 # --- Step 1: Install Nix (Determinate Systems installer) ---
 # Uses the Determinate Systems installer instead of the official one because:
@@ -71,60 +79,32 @@ echo "[$(date -Iseconds)] web_setup.sh commit: $SETUP_COMMIT"
 #     installer's nix-env tries to read from a TTY that doesn't exist
 #   - --init none skips systemd/launchd (not available in containers)
 # Pinned binary from GitHub releases, SHA256-verified.
-echo "[$(date -Iseconds)] Installing Nix (Determinate installer)..."
-NIX_INSTALLER_VERSION="v3.17.3"
-NIX_INSTALLER_URL="https://github.com/DeterminateSystems/nix-installer/releases/download/${NIX_INSTALLER_VERSION}/nix-installer-x86_64-linux"
-NIX_INSTALLER_SHA256="4a84424a0a598b671de21fca1602ea3e74af214d823020afe7aac0056dc032ac"
-NIX_INSTALLER_BIN="/tmp/nix-installer"
-curl -fsSL "$NIX_INSTALLER_URL" -o "$NIX_INSTALLER_BIN"
-echo "${NIX_INSTALLER_SHA256}  ${NIX_INSTALLER_BIN}" | sha256sum -c
-chmod +x "$NIX_INSTALLER_BIN"
-# Ensure $USER is set — nix profile sourcing is a no-op when $USER is empty.
-_saved_user="${USER:-}"
-export USER="${USER:-$(id -u -n)}"
-# --no-confirm: fully non-interactive
-# --init none: no systemd/launchd (container environment)
-# --extra-conf: gVisor needs sandbox=false (no kernel namespaces/cgroups),
-#   max-jobs=auto for local symlinkJoin/buildEnv builds not in cache.
-# CLEANUP(2026-03-27): cache.allegedly.works is currently down (503). Falling back to
-#   cache.nixos.org only. Restore once the cache is back:
-#     --extra-conf "substituters = https://cache.allegedly.works/main https://cache.nixos.org"
-#     --extra-conf "trusted-public-keys = cache.allegedly.works-1:OX/cis8G1W13DALkGvhdUZ1OY3yGATbXw8+tIc8J7oA= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-"$NIX_INSTALLER_BIN" install linux \
-  --no-confirm \
-  --init none \
-  --extra-conf "sandbox = false" \
-  --extra-conf "max-jobs = auto" \
-  --extra-conf "system-features =" \
-  --extra-conf "substituters = https://cache.nixos.org" \
-  --extra-conf "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+log "Installing Nix (Determinate installer)..."
+bash "${FLAKE#path:}/devinfra/install_nix_determinate.sh"
 # shellcheck disable=SC1091
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-# Restore $USER to its original state so we don't leak a side-effect.
-if [ -z "$_saved_user" ]; then unset USER; else USER="$_saved_user"; fi
-unset _saved_user
-echo "[$(date -Iseconds)] Nix installation complete."
+log "Nix installation complete."
 
 # --- Step 2: Install web session tools ---
 # Debug: dump environment keys for proxy/cert diagnostics (no values — avoids logging JWTs).
-echo "--- environment keys ---"
+log "--- environment keys ---"
 env | cut -d= -f1 | sort
-echo "---"
+log "---"
 
-echo "Connectivity check (cache.nixos.org)..."
-curl -fsSL --max-time 10 https://cache.nixos.org/nix-cache-info || echo "WARNING: cache.nixos.org check failed — continuing anyway" >&2
+log "Connectivity check (cache.nixos.org)..."
+curl -fsSL --max-time 10 https://cache.nixos.org/nix-cache-info || warn "cache.nixos.org check failed — continuing anyway"
 
-echo "--- nix.conf ---"
+log "--- nix.conf ---"
 cat /etc/nix/nix.conf
-echo "--- nix show-config ---"
+log "--- nix show-config ---"
 nix show-config 2>/dev/null | grep -E "max-jobs|sandbox|build-users" || true
-echo "---"
+log "---"
 
-echo "[$(date -Iseconds)] Installing web session tools..."
-echo "  FLAKE=${FLAKE}"
-echo "  pwd=$(pwd)"
-echo "  flake.nix exists: $(test -f flake.nix && echo yes || echo no)"
-echo "  ls pwd:"
+log "Installing web session tools..."
+log "  FLAKE=${FLAKE}"
+log "  pwd=$(pwd)"
+log "  flake.nix exists: $(test -f flake.nix && echo yes || echo no)"
+log "  ls pwd:"
 ls -la
 # Pass --max-jobs explicitly to override any nix.conf misconfiguration.
 #
@@ -145,7 +125,7 @@ ls -la
 nix profile remove devtools 2>/dev/null || true
 nix profile remove devtools-rust 2>/dev/null || true
 nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
-echo "[$(date -Iseconds)] Dev tools installed (impl=$HOOK_IMPL)."
+log "Dev tools installed (impl=$HOOK_IMPL)."
 
 # Symlink all Nix-installed binaries into /usr/local/bin so they're on PATH.
 # Claude Code is launched directly (not via login shell), so the Nix profile bin
@@ -174,26 +154,26 @@ PROJECT_DIR="${FLAKE#path:}"
 # Value must be a remote NAME (not a URL) — bb resolves the URL from git config.
 GITHUB_REMOTE_URL="https://github.com/agentydragon/ducktape"
 if git -C "$PROJECT_DIR" remote get-url github-no-proxy &>/dev/null; then
-  echo "[$(date -Iseconds)] git remote 'github-no-proxy' already exists, skipping."
+  log "git remote 'github-no-proxy' already exists, skipping."
 else
   git -C "$PROJECT_DIR" remote add github-no-proxy "$GITHUB_REMOTE_URL"
-  echo "[$(date -Iseconds)] Added git remote 'github-no-proxy' -> $GITHUB_REMOTE_URL"
+  log "Added git remote 'github-no-proxy' -> $GITHUB_REMOTE_URL"
 fi
 git -C "$PROJECT_DIR" config buildbuddy.remote-bazel-remote-name github-no-proxy
-echo "[$(date -Iseconds)] Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
+log "Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
 
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.
-echo "Deploying skills to ~/.claude/skills/..."
+log "Deploying skills to ~/.claude/skills/..."
 mkdir -p ~/.claude/skills
 for skill in "${NIX_PROFILE}"/share/claude-hooks/skills/*/; do
   ln -sfn "$skill" ~/.claude/skills/"$(basename "$skill")"
 done
 
-echo "[$(date -Iseconds)] Setup complete. Log: ${LOG_FILE}"
+log "Setup complete. Log: ${LOG_FILE}"
 
 if [ "${DUCKTAPE_WEB_SETUP_UPLOAD_LOG:-0}" = "1" ]; then
   UPLOAD_URL=$(curl -s -F "f:1=@${LOG_FILE}" ix.io 2>/dev/null || echo "upload failed")
-  echo "[$(date -Iseconds)] Log uploaded: ${UPLOAD_URL}"
+  log "Log uploaded: ${UPLOAD_URL}"
 fi

--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -45,22 +45,23 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
 1. Detects repo root and logs commit identity.
 2. Installs Nix (Determinate installer) if missing.
 3. Installs the repo `.#devtools` profile.
-4. Persists nix profile sourcing in `~/.bashrc` and `~/.bash_profile` so agent Bash sessions get Nix tools on `PATH`.
-5. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
-6. Configures BuildBuddy remote selection:
+4. Installs repo pre-commit Git hooks (`pre-commit install --install-hooks`).
+5. Persists nix profile sourcing in `~/.bashrc` and `~/.bash_profile` so agent Bash sessions get Nix tools on `PATH`.
+6. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
+7. Configures BuildBuddy remote selection:
    - uses `origin` when it already points directly to GitHub
    - falls back to `github-no-proxy` when `origin` is proxied/non-GitHub
    - if `origin` is missing, creates `github-no-proxy` and selects it
-7. Writes Codex Bazel config files:
+8. Writes Codex Bazel config files:
    - `~/.config/bazel/bbr.bazelrc` for BuildBuddy metadata (`ROLE`, session tag)
    - `~/.config/bazel/codex.bazelrc` with `try-import` wiring for BuildBuddy + bbr metadata
    - `~/.bazelrc` `try-import` entry for `~/.config/bazel/codex.bazelrc`
-8. Ensures local `devel` branch exists (from `github-no-proxy/devel` or `origin/devel` when available) so `bbr` base-branch detection works.
-9. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
-10. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
+9. Ensures local `devel` branch exists (from `github-no-proxy/devel` or `origin/devel` when available) so `bbr` base-branch detection works.
+10. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
+11. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
 
-Maintenance refreshes git remotes, BuildBuddy config, and devtools profile,
-then validates `bb` / `bbr` availability.
+Maintenance refreshes git remotes, BuildBuddy config, devtools profile, and
+pre-commit hooks, then validates `bb` / `bbr` availability.
 
 ## Known gaps / risks
 

--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -33,8 +33,9 @@ For this repo:
   `cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml` when
   `SOPS_AGE_KEY` is available.
 
-If `SOPS_AGE_KEY` is present during setup, `setup.sh` appends an export to
-`~/.bashrc` so Bash tool sessions inherit it.
+If `SOPS_AGE_KEY` is present during setup, `setup.sh` appends exports to
+`~/.bashrc` and `~/.bash_profile` so both interactive and login shell sessions
+inherit it.
 
 This is intentional: Codex Cloud docs state setup runs in a separate Bash
 session and recommend `~/.bashrc` for persistence into the agent phase.
@@ -44,12 +45,19 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
 1. Detects repo root and logs commit identity.
 2. Installs Nix (Determinate installer) if missing.
 3. Installs the repo `.#devtools` profile.
-4. Persists nix profile sourcing in `~/.bashrc` so agent Bash sessions get Nix tools on `PATH`.
+4. Persists nix profile sourcing in `~/.bashrc` and `~/.bash_profile` so agent Bash sessions get Nix tools on `PATH`.
 5. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
 6. Configures BuildBuddy remote selection:
    - uses `origin` when it already points directly to GitHub
-   - falls back to `github-no-proxy` only when `origin` is proxied/non-GitHub
-7. Persists `SOPS_AGE_KEY` into `~/.bashrc` when provided.
+   - falls back to `github-no-proxy` when `origin` is proxied/non-GitHub
+   - if `origin` is missing, creates `github-no-proxy` and selects it
+7. Writes Codex Bazel config files:
+   - `~/.config/bazel/bbr.bazelrc` for BuildBuddy metadata (`ROLE`, session tag)
+   - `~/.config/bazel/codex.bazelrc` with `try-import` wiring for BuildBuddy + bbr metadata
+   - `~/.bazelrc` `try-import` entry for `~/.config/bazel/codex.bazelrc`
+8. Ensures local `devel` branch exists (from `github-no-proxy/devel` or `origin/devel` when available) so `bbr` base-branch detection works.
+9. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
+10. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
 
 Maintenance refreshes git remotes, BuildBuddy config, and devtools profile,
 then validates `bb` / `bbr` availability.
@@ -72,7 +80,7 @@ then validates `bb` / `bbr` availability.
    - If setup exceeds practical time limits, fall back to non-Nix Stage A tooling.
 
 4. **Cloud image assumptions**
-   - Scripts assume Linux x86_64 and that Codex agent Bash sessions source `~/.bashrc` (as documented).
+   - Scripts assume Linux x86_64 and that Codex agent Bash sessions execute shell startup files.
    - If image changes, update install script accordingly.
 
 ## Validation command (inside repo)

--- a/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
+++ b/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
@@ -21,6 +21,7 @@ Primary source: OpenAI Codex Cloud docs and changelog.
 - Container caching keeps setup state for up to 12 hours. Follow-up tasks may resume cached state, and cache is invalidated by setup/maintenance script changes and env/secret changes.
 
 References:
+
 - https://developers.openai.com/codex/cloud/environments
 - https://developers.openai.com/codex/cloud/internet-access
 - https://developers.openai.com/codex/changelog
@@ -34,12 +35,13 @@ References:
 - AGENTS.md is explicitly documented and is used for repository-specific instructions.
 
 References:
+
 - https://developers.openai.com/codex/config-basic
 - https://developers.openai.com/codex/config-reference
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/guides/agents-md
 
-## 2.2 What is *not* clearly documented for Cloud
+## 2.2 What is _not_ clearly documented for Cloud
 
 I could not find explicit OpenAI documentation stating that delegated Cloud runs execute project/user `hooks.json` from `.codex` inside the Cloud container.
 
@@ -61,6 +63,7 @@ From hooks docs (general Codex hooks surface):
 - Matchers: specific tool names, shell matchers, and event-specific filters
 
 Reference:
+
 - https://developers.openai.com/codex/hooks
 
 ## 2.4 Additional online signals checked
@@ -70,6 +73,7 @@ Reference:
 - Therefore, for Cloud planning in this repo, hooks should be considered experimental until empirically validated in our own environment.
 
 References:
+
 - https://github.com/openai/codex/issues?q=is%3Aissue+hooks+is%3Aopen
 - https://github.com/openai/codex/issues/16226
 - https://github.com/openai/codex/issues/16301
@@ -85,6 +89,7 @@ From this repository's AGENTS/README and current infra:
 - Existing repo script `devinfra/setup_buildbuddy.sh` configures BuildBuddy based on `BUILDBUDDY_API_KEY`.
 
 References:
+
 - `AGENTS.md`
 - `README.md`
 - `flake.nix`

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -147,6 +147,11 @@ run_buildbuddy_setup() {
   fi
 }
 
+install_precommit_hooks() {
+  log "installing pre-commit hooks"
+  pre-commit install --install-hooks
+}
+
 materialize_kubeconfig_if_possible() {
   local nix_python="${HOME}/.nix-profile/bin/python3"
   if [ "$SOPS_RUNTIME_READY" -ne 1 ]; then
@@ -219,6 +224,7 @@ persist_agent_shell_init() {
 run_common_setup_steps() {
   run_buildbuddy_setup
   install_or_refresh_devtools
+  install_precommit_hooks
   write_codex_bazelrcs
   reconcile_buildbuddy_remote
   ensure_bbr_base_branch

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -23,40 +23,53 @@ log() {
   printf '[codex-cloud %s] %s\n' "$MODE" "$*"
 }
 
+readonly NIX_DAEMON_PROFILE_SH="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+readonly BAZELRC_DIR="${HOME}/.config/bazel"
+readonly BBR_BAZELRC_PATH="${BAZELRC_DIR}/bbr.bazelrc"
+readonly CODEX_BAZELRC_PATH="${BAZELRC_DIR}/codex.bazelrc"
+readonly USER_BAZELRC_PATH="${HOME}/.bazelrc"
+
+SOPS_RUNTIME_READY=0
+
 ensure_line() {
   local line="$1"
   local file="$2"
   grep -Fqx "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
 }
 
+init_sops_runtime_prereqs() {
+  if [ -z "${SOPS_AGE_KEY:-}" ]; then
+    log "SOPS_AGE_KEY not set; SOPS-dependent setup steps will be skipped"
+    SOPS_RUNTIME_READY=0
+    return 0
+  fi
+  SOPS_RUNTIME_READY=1
+}
+
 load_agent_secrets() {
+  if [ "$SOPS_RUNTIME_READY" -ne 1 ]; then
+    return 0
+  fi
   # Source the same env script claude-web uses. The codex-cloud-agent age key
   # is a recipient on every SOPS file web_env.sh decrypts, so this populates
   # BUILDBUDDY_API_KEY, GITHUB_TOKEN, DUCKTAPE_OTEL_BEARER_TOKEN, and
   # DUCKTAPE_CI_READ_GITHUB_TOKEN.
-  if [ -z "${SOPS_AGE_KEY:-}" ]; then
-    log "SOPS_AGE_KEY not set; skipping secret decryption"
-    return 0
-  fi
-  if ! command -v sops >/dev/null 2>&1; then
-    log "sops missing on PATH; skipping secret decryption"
-    return 0
-  fi
   log "sourcing devinfra/secrets/web_env.sh"
   # shellcheck source=../secrets/web_env.sh
   source "${REPO_ROOT}/devinfra/secrets/web_env.sh"
 }
 
 source_nix_profile_if_present() {
-  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  if [ -f "$NIX_DAEMON_PROFILE_SH" ]; then
     # shellcheck disable=SC1091
-    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    . "$NIX_DAEMON_PROFILE_SH"
   fi
 }
 
 reconcile_buildbuddy_remote() {
   # Prefer origin when it already points directly at GitHub. Fallback to
   # github-no-proxy only for proxied origin URLs.
+  local github_remote_url="https://github.com/agentydragon/ducktape"
   if git remote get-url origin >/dev/null 2>&1; then
     local origin_url
     origin_url="$(git remote get-url origin)"
@@ -64,7 +77,6 @@ reconcile_buildbuddy_remote() {
       log "origin is GitHub; using origin for BuildBuddy remote"
       git config buildbuddy.remote-bazel-remote-name origin
     else
-      local github_remote_url="https://github.com/agentydragon/ducktape"
       if git remote get-url github-no-proxy >/dev/null 2>&1; then
         log "origin is proxied; github-no-proxy already present"
       else
@@ -74,8 +86,37 @@ reconcile_buildbuddy_remote() {
       git config buildbuddy.remote-bazel-remote-name github-no-proxy
     fi
   else
-    log "origin remote missing; leaving buildbuddy.remote-bazel-remote-name unchanged"
+    if git remote get-url github-no-proxy >/dev/null 2>&1; then
+      log "origin remote missing; github-no-proxy already present"
+    else
+      git remote add github-no-proxy "$github_remote_url"
+      log "origin remote missing; added github-no-proxy remote"
+    fi
+    git config buildbuddy.remote-bazel-remote-name github-no-proxy
+    log "origin remote missing; using github-no-proxy for BuildBuddy remote"
   fi
+}
+
+ensure_bbr_base_branch() {
+  # bbr expects a local `devel` branch reference for base-branch calculations.
+  if git rev-parse --verify devel >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local remote_ref=""
+  if git show-ref --verify --quiet refs/remotes/github-no-proxy/devel; then
+    remote_ref="github-no-proxy/devel"
+  elif git show-ref --verify --quiet refs/remotes/origin/devel; then
+    remote_ref="origin/devel"
+  fi
+
+  if [ -z "$remote_ref" ]; then
+    log "local 'devel' branch missing and no remote devel ref found; bbr may fail"
+    return 0
+  fi
+
+  git branch devel "$remote_ref" >/dev/null 2>&1 || true
+  log "created local 'devel' branch from ${remote_ref} for bbr compatibility"
 }
 
 install_nix_if_missing() {
@@ -85,29 +126,9 @@ install_nix_if_missing() {
   fi
 
   log "nix not found; installing Determinate Nix installer"
-  local nix_installer_version="v3.17.3"
-  local nix_installer_url="https://github.com/DeterminateSystems/nix-installer/releases/download/${nix_installer_version}/nix-installer-x86_64-linux"
-  local nix_installer_sha256="4a84424a0a598b671de21fca1602ea3e74af214d823020afe7aac0056dc032ac"
-  local nix_installer_bin="/tmp/nix-installer"
-
-  curl -fsSL "$nix_installer_url" -o "$nix_installer_bin"
-  echo "${nix_installer_sha256}  ${nix_installer_bin}" | sha256sum -c
-  chmod +x "$nix_installer_bin"
-
-  local saved_user="${USER:-}"
-  export USER="${USER:-$(id -u -n)}"
-  "$nix_installer_bin" install linux \
-    --no-confirm \
-    --init none \
-    --extra-conf "sandbox = false" \
-    --extra-conf "max-jobs = auto" \
-    --extra-conf "system-features =" \
-    --extra-conf "substituters = https://cache.nixos.org" \
-    --extra-conf "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+  bash "${REPO_ROOT}/devinfra/install_nix_determinate.sh"
 
   source_nix_profile_if_present
-
-  if [ -z "$saved_user" ]; then unset USER; else USER="$saved_user"; fi
 }
 
 install_or_refresh_devtools() {
@@ -126,38 +147,94 @@ run_buildbuddy_setup() {
   fi
 }
 
+materialize_kubeconfig_if_possible() {
+  local nix_python="${HOME}/.nix-profile/bin/python3"
+  if [ "$SOPS_RUNTIME_READY" -ne 1 ]; then
+    log "skipping kubeconfig materialization (SOPS prerequisites unavailable)"
+    return 0
+  fi
+  log "materializing ~/.kube/config from SOPS-encrypted JWT"
+  CLAUDE_PROJECT_DIR="${REPO_ROOT}" "$nix_python" "${REPO_ROOT}/devinfra/k8s/kubeconfig.py" --write "${HOME}/.kube/config"
+}
+
+write_codex_bazelrcs() {
+  local session_tag="${CODEX_SESSION_ID:-codex-cloud}"
+
+  mkdir -p "$BAZELRC_DIR"
+
+  cat >"$BBR_BAZELRC_PATH" <<EOF
+# Auto-generated by devinfra/codex_cloud/setup.sh
+build --build_metadata=ROLE=codex-cloud
+build --build_metadata=TAGS=session:${session_tag}
+EOF
+
+  cat >"$CODEX_BAZELRC_PATH" <<EOF
+# Auto-generated by devinfra/codex_cloud/setup.sh
+test --test_tag_filters=-live_openai_api
+try-import ${HOME}/.config/bazel/buildbuddy.bazelrc
+try-import ${BBR_BAZELRC_PATH}
+common --config=ai_agent
+EOF
+}
+
 persist_agent_shell_init() {
-  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
-    log "persisting nix-daemon profile sourcing into ~/.bashrc"
-    ensure_line '. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ~/.bashrc
+  local bashrc="${HOME}/.bashrc"
+  local bash_profile="${HOME}/.bash_profile"
+  local shell_startup_files=("$bashrc" "$bash_profile")
+  local shell_file
+
+  for shell_file in "${shell_startup_files[@]}"; do
+    touch "$shell_file"
+  done
+  touch "$USER_BAZELRC_PATH"
+
+  # Ensure login shells (used by many agent command runners) load ~/.bashrc.
+  ensure_line '[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"' "$bash_profile"
+
+  if [ -f "$NIX_DAEMON_PROFILE_SH" ]; then
+    log "persisting nix-daemon profile sourcing into shell startup files"
+    for shell_file in "${shell_startup_files[@]}"; do
+      ensure_line ". ${NIX_DAEMON_PROFILE_SH}" "$shell_file"
+    done
   fi
 
   if [ -n "${SOPS_AGE_KEY:-}" ]; then
-    log "persisting SOPS_AGE_KEY into ~/.bashrc for agent shells"
-    ensure_line "export SOPS_AGE_KEY='${SOPS_AGE_KEY}'" ~/.bashrc
+    log "persisting SOPS_AGE_KEY into shell startup files for agent shells"
+    for shell_file in "${shell_startup_files[@]}"; do
+      ensure_line "export SOPS_AGE_KEY='${SOPS_AGE_KEY}'" "$shell_file"
+    done
   else
     log "SOPS_AGE_KEY not set (expected unless configured in Codex environment vars)"
   fi
+
+  log "persisting web_env.sh sourcing into shell startup files for runtime secret hydration"
+  for shell_file in "${shell_startup_files[@]}"; do
+    ensure_line "[ -n \"\${SOPS_AGE_KEY:-}\" ] && [ -f \"${REPO_ROOT}/devinfra/secrets/web_env.sh\" ] && source \"${REPO_ROOT}/devinfra/secrets/web_env.sh\" >/dev/null 2>&1 || true" "$shell_file"
+    ensure_line "export BBR_BAZELRC='${BBR_BAZELRC_PATH}'" "$shell_file"
+    ensure_line "export SESSION_BAZELRC='${CODEX_BAZELRC_PATH}'" "$shell_file"
+  done
+  ensure_line "try-import ${CODEX_BAZELRC_PATH}" "$USER_BAZELRC_PATH"
+}
+
+run_common_setup_steps() {
+  run_buildbuddy_setup
+  install_or_refresh_devtools
+  write_codex_bazelrcs
+  reconcile_buildbuddy_remote
+  ensure_bbr_base_branch
+  materialize_kubeconfig_if_possible
 }
 
 validate_core_tools() {
-  if command -v bb >/dev/null 2>&1; then
-    bb --version >/dev/null
-    log "bb present"
-  else
-    log "WARNING: bb missing"
-  fi
-
-  if command -v bbr >/dev/null 2>&1; then
-    bbr --help >/dev/null
-    log "bbr present"
-  else
-    log "WARNING: bbr missing"
-  fi
+  bb --version >/dev/null
+  log "bb present"
+  bbr --help >/dev/null
+  log "bbr present"
 }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
+init_sops_runtime_prereqs
 
 log "repo=$REPO_ROOT"
 log "commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
@@ -165,18 +242,14 @@ log "commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 case "$MODE" in
   install)
     install_nix_if_missing
-    install_or_refresh_devtools
-    run_buildbuddy_setup
-    reconcile_buildbuddy_remote
+    run_common_setup_steps
     persist_agent_shell_init
     ;;
   maintenance)
     source_nix_profile_if_present
     log "refreshing git remotes"
     git fetch --all --prune
-    run_buildbuddy_setup
-    reconcile_buildbuddy_remote
-    install_or_refresh_devtools
+    run_common_setup_steps
     validate_core_tools
     ;;
   *)

--- a/devinfra/install_nix_determinate.sh
+++ b/devinfra/install_nix_determinate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared Determinate Nix installer wrapper used by Codex Cloud and Claude web setup.
+
+set -euo pipefail
+
+NIX_INSTALLER_VERSION="v3.17.3"
+NIX_INSTALLER_URL="https://github.com/DeterminateSystems/nix-installer/releases/download/${NIX_INSTALLER_VERSION}/nix-installer-x86_64-linux"
+NIX_INSTALLER_SHA256="4a84424a0a598b671de21fca1602ea3e74af214d823020afe7aac0056dc032ac"
+NIX_INSTALLER_BIN="/tmp/nix-installer"
+
+curl -fsSL "$NIX_INSTALLER_URL" -o "$NIX_INSTALLER_BIN"
+echo "${NIX_INSTALLER_SHA256}  ${NIX_INSTALLER_BIN}" | sha256sum -c
+chmod +x "$NIX_INSTALLER_BIN"
+
+# Ensure $USER is set — some profile setup paths no-op when it's empty.
+saved_user="${USER:-}"
+export USER="${USER:-$(id -u -n)}"
+
+"$NIX_INSTALLER_BIN" install linux \
+  --no-confirm \
+  --init none \
+  --extra-conf "sandbox = false" \
+  --extra-conf "max-jobs = auto" \
+  --extra-conf "system-features =" \
+  --extra-conf "substituters = https://cache.nixos.org" \
+  --extra-conf "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+
+if [ -z "$saved_user" ]; then
+  unset USER
+else
+  export USER="$saved_user"
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -278,6 +278,9 @@
         pkgs.gofumpt
         ducktapePkgs.prettier
         pkgs.openssl
+        # Codex setup materializes kubeconfig via devinfra/k8s/kubeconfig.py;
+        # include a guaranteed Python runtime with pyyaml for that path.
+        (pkgs.python3.withPackages (ps: [ ps.pyyaml ]))
         # Infrastructure tools
         pkgs.gh
         pkgs.kubectl

--- a/nix/packages/bb.nix
+++ b/nix/packages/bb.nix
@@ -1,0 +1,27 @@
+{
+  artifacts,
+  lib,
+  pkgs,
+}:
+pkgs.stdenv.mkDerivation {
+  pname = "bb";
+  version = "5.0.339";
+  src = artifacts.bb;
+  dontUnpack = true;
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/bb
+    chmod +x $out/bin/bb
+    mv $out/bin/bb $out/bin/.bb-real
+    makeWrapper $out/bin/.bb-real $out/bin/bb \
+      --prefix PATH : ${lib.makeBinPath [ pkgs.file ]}
+  '';
+  meta = {
+    description = "BuildBuddy CLI (remote bazel, etc.)";
+    homepage = "https://github.com/buildbuddy-io/bazel";
+    license = lib.licenses.mit;
+    mainProgram = "bb";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -227,25 +227,7 @@ in
   prettier = pkgs.callPackage ./prettier/prettier.nix { };
   kubernetes-mcp-server = pkgs.callPackage ./kubernetes-mcp-server.nix { };
   bebas-neue-font = pkgs.callPackage ./bebas-neue-font.nix { };
-
-  bb = pkgs.stdenv.mkDerivation {
-    pname = "bb";
-    version = "5.0.339";
-    src = artifacts.bb;
-    dontUnpack = true;
-    installPhase = ''
-      mkdir -p $out/bin
-      cp $src $out/bin/bb
-      chmod +x $out/bin/bb
-    '';
-    meta = {
-      description = "BuildBuddy CLI (remote bazel, etc.)";
-      homepage = "https://github.com/buildbuddy-io/bazel";
-      license = lib.licenses.mit;
-      mainProgram = "bb";
-      platforms = [ "x86_64-linux" ];
-    };
-  };
+  bb = pkgs.callPackage ./bb.nix { inherit artifacts; };
 
   bbapi = pkgs.stdenv.mkDerivation {
     pname = "bbapi";


### PR DESCRIPTION
### Motivation

- Reduce duplicated Nix installer logic and improve observability of web-agent setup by centralizing the Determinate Nix installer and adding structured logging and warnings.
- Make Codex Cloud setup more robust for agent runtime use by persisting runtime env/shell wiring, ensuring BuildBuddy remote compatibility, and materializing kubeconfig when possible.
- Ensure necessary runtime tooling (Python+PyYAML) is available for kubeconfig materialization and package a stable `bb` CLI derivation for reproducible tooling in Nix.

### Description

- Introduces a shared Determinate Nix installer wrapper at `devinfra/install_nix_determinate.sh` and updates `devinfra/claude/web_setup.sh` and `devinfra/codex_cloud/setup.sh` to call it instead of duplicating installer logic.
- Adds structured logging helpers (`log`, `warn`) and replaces many noisy `echo` lines with `log`/`warn` in `devinfra/claude/web_setup.sh` and other scripts, and ensures non-fatal warnings are emitted when connectivity or other checks fail.
- Extends `devinfra/codex_cloud/setup.sh` with SOPS runtime readiness handling, consolidated setup steps (`run_common_setup_steps`), improved BuildBuddy remote reconciliation, creation of a local `devel` branch if needed (`ensure_bbr_base_branch`), materialization of `~/.kube/config` via a Nix-managed Python runtime, and automated generation of Bazel config files (`bbr.bazelrc`, `codex.bazelrc`) plus startup-file persistence for both `~/.bashrc` and `~/.bash_profile`.
- Updates flake to include a Python runtime with `pyyaml` in the shared devtools so kubeconfig materialization works predictably, and adds a dedicated `nix/packages/bb.nix` derivation for the BuildBuddy `bb` CLI while updating `nix/packages/default.nix` to use it.
- README updates in `devinfra/codex_cloud/README.md` to document the new shell-startup persistence and the additional Bazel/kubeconfig behavior.

### Testing

- Performed shell syntax checks with `bash -n` on modified scripts (`devinfra/codex_cloud/setup.sh`, `devinfra/claude/web_setup.sh`, `devinfra/install_nix_determinate.sh`), which succeeded.
- Evaluated the flake with `nix flake show` to verify the flake still evaluates after adding the Python-with-pyyaml and `bb` packaging changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0d567fd883319dee1da245593c6a)