### PR TITLE
Add end-to-end browser tests and fix sync edge cases

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
@@ -18,6 +18,12 @@ entries:
       authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
       access_token_validity: "days=30"
+      # The PWA manifest is fetched by the browser in background contexts
+      # (e.g. during installation) without session cookies, causing Authentik
+      # to redirect it to the OAuth authorize endpoint — a cross-origin URL
+      # that triggers a CORS error. Allow the manifest without auth.
+      unauthenticated_paths:
+        - /manifest.webmanifest
 
   - model: authentik_core.application
     id: study-casino-app

--- a/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
+++ b/devinfra/codex_cloud/codex_cloud_agent_configuration_plan.md
@@ -21,6 +21,7 @@ Primary source: OpenAI Codex Cloud docs and changelog.
 - Container caching keeps setup state for up to 12 hours. Follow-up tasks may resume cached state, and cache is invalidated by setup/maintenance script changes and env/secret changes.
 
 References:
+
 - https://developers.openai.com/codex/cloud/environments
 - https://developers.openai.com/codex/cloud/internet-access
 - https://developers.openai.com/codex/changelog
@@ -34,12 +35,13 @@ References:
 - AGENTS.md is explicitly documented and is used for repository-specific instructions.
 
 References:
+
 - https://developers.openai.com/codex/config-basic
 - https://developers.openai.com/codex/config-reference
 - https://developers.openai.com/codex/hooks
 - https://developers.openai.com/codex/guides/agents-md
 
-## 2.2 What is *not* clearly documented for Cloud
+## 2.2 What is _not_ clearly documented for Cloud
 
 I could not find explicit OpenAI documentation stating that delegated Cloud runs execute project/user `hooks.json` from `.codex` inside the Cloud container.
 
@@ -61,6 +63,7 @@ From hooks docs (general Codex hooks surface):
 - Matchers: specific tool names, shell matchers, and event-specific filters
 
 Reference:
+
 - https://developers.openai.com/codex/hooks
 
 ## 2.4 Additional online signals checked
@@ -70,6 +73,7 @@ Reference:
 - Therefore, for Cloud planning in this repo, hooks should be considered experimental until empirically validated in our own environment.
 
 References:
+
 - https://github.com/openai/codex/issues?q=is%3Aissue+hooks+is%3Aopen
 - https://github.com/openai/codex/issues/16226
 - https://github.com/openai/codex/issues/16301
@@ -85,6 +89,7 @@ From this repository's AGENTS/README and current infra:
 - Existing repo script `devinfra/setup_buildbuddy.sh` configures BuildBuddy based on `BUILDBUDDY_API_KEY`.
 
 References:
+
 - `AGENTS.md`
 - `README.md`
 - `flake.nix`

--- a/x/auragon_study_casino/frontend/BUILD.bazel
+++ b/x/auragon_study_casino/frontend/BUILD.bazel
@@ -116,7 +116,10 @@ js_run_binary(
     args = ["dist"],
     chdir = package_name(),
     tool = ":build_bundle",
-    visibility = ["//x/auragon_study_casino:__pkg__"],
+    visibility = [
+        "//x/auragon_study_casino:__pkg__",
+        "//x/auragon_study_casino/tests:__pkg__",
+    ],
 )
 
 # ── Visual regression test ────────────────────────────────────────────────────

--- a/x/auragon_study_casino/frontend/src/sync.js
+++ b/x/auragon_study_casino/frontend/src/sync.js
@@ -253,7 +253,7 @@ class CasinoSync {
         // bounce it back at the server.
         Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
       } catch (e) {
-        this.status.set({ kind: "offline", reason: `corrupt server update: ${e.message}` });
+        this.status.set({ kind: "offline", reason: `corrupt server update: ${e.message ?? String(e)}` });
         return;
       }
     }

--- a/x/auragon_study_casino/frontend/src/sync.js
+++ b/x/auragon_study_casino/frontend/src/sync.js
@@ -112,6 +112,16 @@ class CasinoSync {
       this._startPolling();
       this._scheduleSync();
     });
+    // Fallback: if IDB "synced" hasn't fired within 3 s (e.g. headless Chrome
+    // in a container where IDB initialisation stalls), start polling anyway so
+    // the app stays functional. _startPolling is idempotent; calling it a
+    // second time after the real "synced" event is a no-op.
+    setTimeout(() => {
+      if (!this._pollTimer) {
+        this._startPolling();
+        this._scheduleSync();
+      }
+    }, 3000);
 
     // Trigger a debounced push on every locally-originated mutation so the
     // server hears about user actions promptly. Updates we just applied
@@ -157,8 +167,11 @@ class CasinoSync {
   /** Run one round-trip against /sync. Errors land in `this.status`. */
   async syncOnce() {
     this.status.set({ kind: "syncing" });
-    const sv = this.lastServerSV ?? new Uint8Array();
-    const update = Y.encodeStateAsUpdate(this.doc, sv);
+    // Y.encodeStateAsUpdate(doc, new Uint8Array()) throws in yjs 13.6/lib0 0.2 —
+    // an explicitly empty Uint8Array triggers a bounds-check failure when decoding
+    // the state vector. Pass undefined (= no state vector = full update) for the
+    // first sync when we haven't heard from the server yet.
+    const update = Y.encodeStateAsUpdate(this.doc, this.lastServerSV?.byteLength ? this.lastServerSV : undefined);
 
     let response;
     try {
@@ -235,11 +248,17 @@ class CasinoSync {
 
     const serverUpdate = b64ToBytes(body.update_b64);
     if (serverUpdate.byteLength > 0) {
-      // Apply with a remote origin tag so our own update listener doesn't
-      // bounce it back at the server.
-      Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
+      try {
+        // Apply with a remote origin tag so our own update listener doesn't
+        // bounce it back at the server.
+        Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
+      } catch (e) {
+        this.status.set({ kind: "offline", reason: `corrupt server update: ${e.message}` });
+        return;
+      }
     }
-    this.lastServerSV = b64ToBytes(body.state_vector_b64);
+    const sv = b64ToBytes(body.state_vector_b64);
+    this.lastServerSV = sv.byteLength > 0 ? sv : null;
     this.status.set({ kind: "ok", lastSyncedAt: Date.now() });
   }
 

--- a/x/auragon_study_casino/tests/BUILD.bazel
+++ b/x/auragon_study_casino/tests/BUILD.bazel
@@ -16,3 +16,33 @@ py_test(
         "@pypi//uvicorn",
     ],
 )
+
+py_test(
+    name = "test_e2e_browser",
+    srcs = [
+        "conftest.py",
+        "test_e2e_browser.py",
+    ],
+    data = [
+        "//x/auragon_study_casino/frontend:bundle",
+        "@playwright_browsers//:chromium-headless-shell",
+    ],
+    env = {
+        "CHROMIUM_HEADLESS_SHELL": "$(rootpath @playwright_browsers//:chromium-headless-shell)",
+    },
+    # Browser tests need system libraries (libatk, libnss, etc.) that the
+    # linux-sandbox doesn't expose. Disable sandbox so headless_shell can
+    # resolve its shared library dependencies from the RBE worker image.
+    tags = ["no-sandbox"],
+    deps = [
+        "//util:net",
+        "//util:playwright",
+        "//util/bazel:runfiles",
+        "//x/auragon_study_casino:app",
+        "//x/auragon_study_casino:config",
+        "@pypi//playwright",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+        "@pypi//uvicorn",
+    ],
+)

--- a/x/auragon_study_casino/tests/BUILD.bazel
+++ b/x/auragon_study_casino/tests/BUILD.bazel
@@ -19,6 +19,7 @@ py_test(
 
 py_test(
     name = "test_e2e_browser",
+    size = "medium",
     srcs = [
         "conftest.py",
         "test_e2e_browser.py",
@@ -30,10 +31,6 @@ py_test(
     env = {
         "CHROMIUM_HEADLESS_SHELL": "$(rootpath @playwright_browsers//:chromium-headless-shell)",
     },
-    # Browser tests need system libraries (libatk, libnss, etc.) that the
-    # linux-sandbox doesn't expose. Disable sandbox so headless_shell can
-    # resolve its shared library dependencies from the RBE worker image.
-    tags = ["no-sandbox"],
     deps = [
         "//util:net",
         "//util:playwright",

--- a/x/auragon_study_casino/tests/conftest.py
+++ b/x/auragon_study_casino/tests/conftest.py
@@ -1,0 +1,1 @@
+from util.playwright import playwright_sync

--- a/x/auragon_study_casino/tests/test_e2e_browser.py
+++ b/x/auragon_study_casino/tests/test_e2e_browser.py
@@ -73,6 +73,8 @@ def casino_server(tmp_path: Path) -> Iterator[str]:
     while time.monotonic() < deadline and not server.started:
         time.sleep(0.05)
     if not server.started:
+        server.should_exit = True
+        t.join(timeout=5.0)
         raise RuntimeError("backend did not start within 10s")
     try:
         yield f"http://127.0.0.1:{port}"

--- a/x/auragon_study_casino/tests/test_e2e_browser.py
+++ b/x/auragon_study_casino/tests/test_e2e_browser.py
@@ -1,0 +1,156 @@
+"""End-to-end browser tests: real Playwright browser against real uvicorn backend.
+
+Scenarios:
+1. App loads, first sync round-trip completes, syncing banner disappears.
+2. Server returns a malformed Yjs update — status transitions to `offline`
+   (not stuck on `syncing`), exercising the Y.applyUpdate error-handling path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_bazel
+import uvicorn
+
+from util.bazel.runfiles import get_required_path
+from util.net import pick_free_port
+from x.auragon_study_casino.app import create_app
+from x.auragon_study_casino.config import Settings
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Browser, Page, Playwright
+
+
+@pytest.fixture
+def browser(playwright_sync: Playwright) -> Iterator[Browser]:
+    chromium_root = os.environ.get("CHROMIUM_HEADLESS_SHELL", "")
+    executable = str(Path(chromium_root) / "chrome-linux" / "headless_shell") if chromium_root else None
+    b = playwright_sync.chromium.launch(
+        headless=True,
+        executable_path=executable,
+        # Flags needed for containerized/RBE environments (no user namespace,
+        # /dev/shm may be tiny). Without these, IndexedDB can fail to open.
+        args=["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    )
+    try:
+        yield b
+    finally:
+        b.close()
+
+
+@pytest.fixture
+def page(browser: Browser) -> Iterator[Page]:
+    context = browser.new_context()
+    pg = context.new_page()
+    try:
+        yield pg
+    finally:
+        try:
+            pg.close()
+        finally:
+            context.close()
+
+
+@pytest.fixture
+def casino_server(tmp_path: Path) -> Iterator[str]:
+    frontend_dist = get_required_path("_main/x/auragon_study_casino/frontend/dist/index.html").parent
+    settings = Settings(data_dir=tmp_path, frontend_dist_dir=frontend_dist)
+    app = create_app(settings)
+    port = pick_free_port("127.0.0.1")
+    cfg = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="warning", loop="asyncio")
+    server = uvicorn.Server(cfg)
+    t = threading.Thread(target=server.run, name="casino-uvicorn-e2e", daemon=True)
+    t.start()
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("backend did not start within 10s")
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        t.join(timeout=5.0)
+
+
+def _attach_logs(page: Page) -> list[str]:
+    logs: list[str] = []
+    page.on("pageerror", lambda e: logs.append(f"pageerror: {e}\n{getattr(e, 'stack', '')}"))
+    page.on("console", lambda m: logs.append(f"[{m.type}] {m.text}"))
+    return logs
+
+
+def test_initial_sync_completes(page: Page, casino_server: str) -> None:
+    """App loads, performs the first /sync round-trip, and clears the syncing banner."""
+    logs = _attach_logs(page)
+
+    sync_responses: list[dict] = []
+    page.on(
+        "response", lambda r: sync_responses.append({"url": r.url, "status": r.status}) if "/sync" in r.url else None
+    )
+
+    page.goto(casino_server)
+    print(f"\n[e2e] page loaded, title={page.title()!r}")
+
+    # The syncing banner renders from the initial JS state (kind: "syncing"),
+    # so it should be visible immediately after React mounts.
+    page.wait_for_selector("[data-testid='sync-banner-syncing']", state="visible", timeout=15_000)
+    print(f"[e2e] syncing banner appeared, logs so far: {logs}")
+
+    # Wait for the syncing banner to go away (sync round-trip complete or failed).
+    # 30 s gives plenty of time on slow RBE workers: IDB init + 200ms debounce +
+    # first uvicorn request cold-start + SQLite init.
+    page.wait_for_selector("[data-testid='sync-banner-syncing']", state="detached", timeout=30_000)
+    print(f"[e2e] sync completed, sync_responses={sync_responses}, logs={logs}")
+
+    assert page.locator("[data-testid='sync-banner-offline']").count() == 0, (
+        f"offline banner showing after sync\nsync_responses={sync_responses}\nlogs={logs}"
+    )
+
+
+def test_corrupt_server_update_shows_offline_not_stuck_syncing(page: Page, casino_server: str) -> None:
+    """When /sync returns bytes that are not valid Yjs, status should transition
+    to `offline` (error message surfaced) rather than remaining stuck on `syncing`.
+    This exercises the try/catch around Y.applyUpdate in sync.js."""
+    logs = _attach_logs(page)
+    sync_calls: list[str] = []
+
+    def handle_sync(route):
+        # Respond with a non-empty update_b64 whose bytes are not valid Yjs.
+        sync_calls.append("intercepted")
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "update_b64": "bm90LXlqcy1kYXRh",  # b64("not-yjs-data")
+                    "state_vector_b64": "",
+                }
+            ),
+        )
+
+    page.route("**/sync", handle_sync)
+    page.goto(casino_server)
+    print(f"\n[e2e] page loaded for corrupt test, title={page.title()!r}")
+
+    # Wait for syncing banner to appear first (confirms React mounted).
+    page.wait_for_selector("[data-testid='sync-banner-syncing']", state="visible", timeout=15_000)
+    print(f"[e2e] syncing banner appeared in corrupt test, logs so far: {logs}")
+
+    page.wait_for_selector("[data-testid='sync-banner-offline']", state="visible", timeout=30_000)
+    print(f"[e2e] offline banner appeared, sync_calls={sync_calls}, logs={logs}")
+    assert page.locator("[data-testid='sync-banner-syncing']").count() == 0, (
+        f"syncing banner still present\nsync_calls={sync_calls}\nlogs={logs}"
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
This PR adds comprehensive end-to-end browser tests for the Casino app and fixes several edge cases in the sync mechanism that were discovered during testing.

## Key Changes

### End-to-End Browser Tests
- Added `test_e2e_browser.py` with two test scenarios:
  1. **Initial sync completion**: Verifies that the app loads, performs the first `/sync` round-trip, and clears the syncing banner
  2. **Corrupt server update handling**: Ensures that malformed Yjs updates transition the status to `offline` rather than remaining stuck on `syncing`
- Added test infrastructure with fixtures for browser, page, and casino server (uvicorn backend)
- Updated BUILD.bazel to include the new test target with proper dependencies and sandbox configuration

### Sync Mechanism Fixes
- **IDB initialization fallback**: Added a 3-second timeout to start polling if IndexedDB "synced" event doesn't fire (addresses issues in containerized/headless environments)
- **Empty state vector handling**: Fixed `Y.encodeStateAsUpdate()` call to pass `undefined` instead of empty `Uint8Array` on first sync, avoiding a bounds-check failure in yjs 13.6/lib0 0.2
- **Corrupt update error handling**: Wrapped `Y.applyUpdate()` in try-catch to gracefully transition to `offline` status when the server returns invalid Yjs data
- **State vector persistence**: Changed `lastServerSV` to store `null` instead of empty `Uint8Array` for consistency

### Other Changes
- Updated Authentik SSO blueprint to allow unauthenticated access to `/manifest.webmanifest` (PWA manifest), preventing CORS errors during background installation
- Updated frontend BUILD.bazel visibility to expose the bundle to tests

## Implementation Details
- The e2e tests use Playwright with headless Chromium and include special flags for containerized environments (`--no-sandbox`, `--disable-dev-shm-usage`, etc.)
- Tests attach console and error logging for debugging
- The sync fixes are defensive: they handle edge cases that occur in real-world deployment scenarios (slow IDB initialization, network corruption)

https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY