### PR TITLE
fix(casino): WinBurst animation covers full viewport

### DIFF
--- a/x/auragon_study_casino/frontend/src/study_casino.jsx
+++ b/x/auragon_study_casino/frontend/src/study_casino.jsx
@@ -2762,11 +2762,11 @@ function WinBurst({ amount }) {
   return (
     <div
       style={{
-        position: "absolute",
+        position: "fixed",
         inset: 0,
         pointerEvents: "none",
         overflow: "hidden",
-        zIndex: 30,
+        zIndex: 100,
       }}
     >
       <div


### PR DESCRIPTION
The win particle burst was scoped to its parent container (position: absolute) which clipped it to whatever section of the page triggered the win. Change to position: fixed so the burst fills the entire viewport regardless of where the triggering element lives.

BAZEL_TEST_INVOCATIONS=none: frontend-only visual change, no backend tests affected https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY