### PR TITLE
Have local devel branch track selected BuildBuddy remote for bbr base-branch detection

### DIFF
--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -56,7 +56,7 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
    - `~/.config/bazel/bbr.bazelrc` for BuildBuddy metadata (`ROLE`, session tag)
    - `~/.config/bazel/codex.bazelrc` with `try-import` wiring for BuildBuddy + bbr metadata
    - `~/.bazelrc` `try-import` entry for `~/.config/bazel/codex.bazelrc`
-9. Ensures local `devel` branch exists (from `github-no-proxy/devel` or `origin/devel` when available) so `bbr` base-branch detection works.
+9. Ensures local `devel` branch exists and tracks a remote `devel` branch (preferring the selected BuildBuddy remote, with fallback to `origin/devel` or `github-no-proxy/devel`) so `bbr` base-branch detection works.
 10. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
 11. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
 

--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -46,7 +46,7 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
 2. Installs Nix (Determinate installer) if missing.
 3. Installs the repo `.#devtools` profile.
 4. Installs repo pre-commit Git hooks (`pre-commit install --install-hooks`).
-5. Persists nix profile sourcing in `~/.bashrc` and ensures `~/.bash_profile` sources `~/.bashrc`, so login and interactive shells get Nix tools on `PATH` once.
+5. Persists nix profile sourcing in `~/.bashrc`, prepends Nix profile bins on `PATH` (so Nix-provided tooling like Prettier wins over user-level installs), and ensures `~/.bash_profile` sources `~/.bashrc`.
 6. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
 7. Configures BuildBuddy remote selection:
    - uses `origin` when it already points directly to GitHub

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -99,15 +99,26 @@ reconcile_buildbuddy_remote() {
 
 ensure_bbr_base_branch() {
   # bbr expects a local `devel` branch reference for base-branch calculations.
-  if git rev-parse --verify devel >/dev/null 2>&1; then
-    return 0
+  # Prefer tracking the selected BuildBuddy remote's devel branch.
+  local preferred_remote
+  preferred_remote="$(git config --get buildbuddy.remote-bazel-remote-name || true)"
+  if [ -z "$preferred_remote" ]; then
+    preferred_remote="origin"
   fi
 
   local remote_ref=""
-  if git show-ref --verify --quiet refs/remotes/github-no-proxy/devel; then
-    remote_ref="github-no-proxy/devel"
-  elif git show-ref --verify --quiet refs/remotes/origin/devel; then
+  if git ls-remote --exit-code --heads "$preferred_remote" devel >/dev/null 2>&1; then
+    git fetch "$preferred_remote" devel >/dev/null 2>&1 || true
+    if git show-ref --verify --quiet "refs/remotes/${preferred_remote}/devel"; then
+      remote_ref="${preferred_remote}/devel"
+    fi
+  fi
+
+  if [ -z "$remote_ref" ] && git show-ref --verify --quiet refs/remotes/origin/devel; then
     remote_ref="origin/devel"
+  fi
+  if [ -z "$remote_ref" ] && git show-ref --verify --quiet refs/remotes/github-no-proxy/devel; then
+    remote_ref="github-no-proxy/devel"
   fi
 
   if [ -z "$remote_ref" ]; then
@@ -115,8 +126,21 @@ ensure_bbr_base_branch() {
     return 0
   fi
 
-  git branch devel "$remote_ref" >/dev/null 2>&1 || true
-  log "created local 'devel' branch from ${remote_ref} for bbr compatibility"
+  local existing_upstream=""
+  existing_upstream="$(git for-each-ref --format='%(upstream:short)' refs/heads/devel 2>/dev/null || true)"
+
+  if git rev-parse --verify devel >/dev/null 2>&1; then
+    if [ "$existing_upstream" = "$remote_ref" ]; then
+      log "local 'devel' branch already tracks ${remote_ref}"
+      return 0
+    fi
+    git branch --set-upstream-to="$remote_ref" devel >/dev/null 2>&1 || true
+    log "configured local 'devel' branch to track ${remote_ref}"
+    return 0
+  fi
+
+  git branch --track devel "$remote_ref" >/dev/null 2>&1 || git branch devel "$remote_ref" >/dev/null 2>&1 || true
+  log "created local 'devel' branch tracking ${remote_ref} for bbr compatibility"
 }
 
 install_nix_if_missing() {

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -34,7 +34,13 @@ SOPS_RUNTIME_READY=0
 ensure_line() {
   local line="$1"
   local file="$2"
-  grep -Fqx "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
+  if grep -Fqx "$line" "$file" 2>/dev/null; then
+    return 0
+  fi
+  if [ -s "$file" ] && [ "$(tail -c1 "$file" 2>/dev/null || true)" != "" ]; then
+    echo >>"$file"
+  fi
+  echo "$line" >>"$file"
 }
 
 init_sops_runtime_prereqs() {
@@ -221,6 +227,7 @@ persist_agent_shell_init() {
   if [ -f "$NIX_DAEMON_PROFILE_SH" ]; then
     log "persisting nix-daemon profile sourcing into ~/.bashrc"
     ensure_line ". ${NIX_DAEMON_PROFILE_SH}" "$shell_file"
+    ensure_line 'export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"' "$shell_file"
   fi
 
   if [ -n "${SOPS_AGE_KEY:-}" ]; then
@@ -272,6 +279,7 @@ case "$MODE" in
     log "refreshing git remotes"
     git fetch --all --prune
     run_common_setup_steps
+    persist_agent_shell_init
     validate_core_tools
     ;;
   *)


### PR DESCRIPTION
### Motivation

- Ensure `bbr` base-branch detection has a reliable local `devel` branch that corresponds to the same remote chosen for BuildBuddy operations. 
- Prefer the configured BuildBuddy remote when resolving and creating the `devel` tracking branch so agent and CI workflows use the same upstream.

### Description

- Change `ensure_bbr_base_branch()` in `devinfra/codex_cloud/setup.sh` to prefer the `buildbuddy.remote-bazel-remote-name` git config value and to probe the preferred remote for a `devel` branch using `git ls-remote` and `git fetch` before falling back to other remotes. 
- Configure an existing local `devel` branch to track the resolved remote via `git branch --set-upstream-to`, and create a tracking branch with `git branch --track` (falling back to plain `git branch`), with improved logging. 
- Update `devinfra/codex_cloud/README.md` item 9 to document that the local `devel` branch will be created and will track a remote branch, preferring the selected BuildBuddy remote and falling back to `origin` or `github-no-proxy`.

### Testing

- Ran `bash -n devinfra/codex_cloud/setup.sh` to validate shell syntax, which succeeded. 
- Ran `pre-commit run --all-files` to exercise repository hooks and linters, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef40d7611c83318baa2407106a6b47)