### PR TITLE
feat(casino): OIDC auth, per-user state, move app to TF

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml
@@ -2,7 +2,7 @@ version: 1
 metadata:
   name: SSO - Study Casino
   labels:
-    blueprints.goauthentik.io/description: "Study Casino OIDC SSO - application managed here, provider in TF"
+    blueprints.goauthentik.io/description: "Study Casino — application managed by TF (tf/gitops/sso-providers/provider_study_casino.tf)"
 
 entries:
   # CLEANUP(2026-04-27): Proxy provider tombstone — the casino now uses its
@@ -12,30 +12,3 @@ entries:
     state: absent
     identifiers:
       name: study-casino
-
-  - model: authentik_core.application
-    state: present
-    identifiers:
-      slug: study-casino
-    attrs:
-      name: Study Casino
-      # OAuth2 provider created by tf/gitops/sso-providers/provider_study_casino.tf
-      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, study-casino]]
-      meta_description: "Habit-tracking casino (personal)"
-      meta_launch_url: "https://casino.allegedly.works"
-      open_in_new_tab: true
-
-  - model: authentik_policies.policybinding
-    state: present
-    identifiers:
-      target: !Find [authentik_core.application, [slug, study-casino]]
-      group: !Find [authentik_core.group, [name, authentik Admins]]
-      order: 0
-
-  # The study-casino group is managed by TF (tf/gitops/sso-providers/main.tf).
-  - model: authentik_policies.policybinding
-    state: present
-    identifiers:
-      target: !Find [authentik_core.application, [slug, study-casino]]
-      group: !Find [authentik_core.group, [name, study-casino]]
-      order: 1

--- a/tf/gitops/github-secrets-sync/main.tf
+++ b/tf/gitops/github-secrets-sync/main.tf
@@ -45,25 +45,5 @@ resource "github_actions_secret" "sops_age_key_gaffer_private" {
   plaintext_value = data.kubernetes_secret.ci_age_key.data["age-key"]
 }
 
-# CLEANUP(2026-04-09): Old per-secret GHA secrets replaced by SOPS_AGE_KEY.
-# Remove these blocks once GHA workflows are confirmed working with SOPS
-# decryption and the old secrets are deleted from GitHub.
-removed {
-  from = github_actions_secret.buildbuddy_api_key
-  lifecycle { destroy = true }
-}
-removed {
-  from = github_actions_secret.props_registry_username
-  lifecycle { destroy = true }
-}
-removed {
-  from = github_actions_secret.props_registry_password
-  lifecycle { destroy = true }
-}
-removed {
-  from = github_actions_secret.attic_token
-  lifecycle { destroy = true }
-}
-
 # Data sources for harbor_ci_robot, buildbuddy_api_key, attic_push_token
 # were removed (no `removed` block needed for data sources — just delete).

--- a/tf/gitops/sso-providers/provider_study_casino.tf
+++ b/tf/gitops/sso-providers/provider_study_casino.tf
@@ -3,12 +3,9 @@
 # ============================================================================
 #
 # The casino handles its own OIDC flow (login/callback/logout endpoints),
-# so it no longer needs the Authentik embedded proxy outpost. This resource
-# creates the OAuth2 provider and writes the credentials to a k8s Secret in
-# the study-casino namespace so the pod can read them at startup.
-#
-# The Authentik application and policy bindings are managed by the blueprint
-# at cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml.
+# so it no longer needs the Authentik embedded proxy outpost. This file owns
+# the full Authentik setup: OAuth2 provider, application, and policy bindings,
+# plus the k8s Secret the pod reads for credentials.
 
 resource "random_password" "study_casino_session_secret" {
   length  = 48
@@ -39,6 +36,27 @@ resource "authentik_provider_oauth2" "study_casino" {
       url           = "https://casino.allegedly.works/auth/callback"
     }
   ]
+}
+
+resource "authentik_application" "study_casino" {
+  name              = "Study Casino"
+  slug              = "study-casino"
+  protocol_provider = authentik_provider_oauth2.study_casino.id
+  meta_description  = "Habit-tracking casino (personal)"
+  meta_launch_url   = "https://casino.allegedly.works"
+  open_in_new_tab   = true
+}
+
+resource "authentik_policy_binding" "study_casino_admins" {
+  target = authentik_application.study_casino.uuid
+  group  = data.authentik_group.admins.id
+  order  = 0
+}
+
+resource "authentik_policy_binding" "study_casino_users" {
+  target = authentik_application.study_casino.uuid
+  group  = authentik_group.study_casino.id
+  order  = 1
 }
 
 resource "kubernetes_secret" "study_casino_oidc" {

--- a/x/auragon_study_casino/README.md
+++ b/x/auragon_study_casino/README.md
@@ -39,13 +39,12 @@ Lives at <https://casino.allegedly.works>.
 
 ## Auth
 
-Forward-auth via Authentik's embedded proxy outpost. The backend reads
-`X-Authentik-Username` purely for logging; there is no per-user scoping
-because this is a single-user app. See
-`cluster/k8s/authentik/app/blueprints/study-casino-sso.yaml` for the
-proxy provider, and
-`cluster/k8s/authentik/proxy-routes/study-casino-httproute.yaml` for the
-public hostname route.
+OIDC Authorization Code flow (confidential client). The backend (`auth.py`)
+handles `/auth/login` → Authentik → `/auth/callback`, then issues an
+HMAC-signed session cookie. Per-user SQLite databases scope state to the
+authenticated user. Authentik resources (OAuth2 provider, application, policy
+bindings) are managed by TF at
+`tf/gitops/sso-providers/provider_study_casino.tf`.
 
 ## State sync
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **OIDC auth for Study Casino**: replaces the Authentik proxy outpost with a
  confidential OIDC Authorization Code flow. Backend (`auth.py`) handles
  `/auth/login` → `/auth/callback`, issues HMAC-signed session cookies.
  Per-user SQLite databases scope state to the authenticated username.
- **CORS fix**: `sync.js` now sends absolute URLs to avoid CORS preflight
  issues when the frontend origin differs from the backend.
- **Move Authentik resources to TF**: `authentik_application` and
  `authentik_policy_binding` for study-casino moved into
  `tf/gitops/sso-providers/provider_study_casino.tf`, eliminating the
  blueprint-vs-TF race condition that left the app without a provider bound
  (causing 500s on `/auth/login`). Blueprint gutted to proxy-provider
  tombstone only.
- **Remove `github-secrets-sync` tombstone**: `removed{}` blocks with
  `lifecycle { destroy = true }` already deleted the old per-secret GHA
  secrets; `bazel-ci` has been green with `SOPS_AGE_KEY` for 19 days.

## Test plan

- [ ] Flux reconciles `sso-providers` TF → Authentik gets `study-casino` application with OAuth2 provider bound
- [ ] `https://casino.allegedly.works/auth/login` redirects to Authentik instead of 500
- [ ] Login completes and session cookie is set
- [ ] `/sync` works per-user (separate state for each Authentik user)
- [ ] CI green

https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY)_