### PR TITLE
rbac: grant Claude sandbox pods/log read in study-casino

### DIFF
--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -37,7 +37,7 @@ bound via `shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml`:
 
 Namespaced Roles + RoleBindings for specific namespaces:
 
-- Namespace diagnostics (pods, logs, services, configmaps, PVCs, events, deployments, replicasets, statefulsets) in harbor, gatus, authentik-mcp-poc, csi-proxmox, openebs, proxmox-proxy, cnpg-system, nvidia-device-plugin, node-feature-discovery, local-path-storage, cert-manager, litellm, docker-ci, matrix, grocy-sf, grocy-vallejo
+- Namespace diagnostics (pods, logs, services, configmaps, PVCs, events, deployments, replicasets, statefulsets) in harbor, gatus, authentik-mcp-poc, csi-proxmox, openebs, proxmox-proxy, cnpg-system, nvidia-device-plugin, node-feature-discovery, local-path-storage, cert-manager, litellm, docker-ci, matrix, grocy-sf, grocy-vallejo, study-casino
 - Extended read in langfuse, ollama (read + consumer), openclaw, props (+ jobs, constrained secrets)
 - Logs/configmaps in monitoring, kube-system, longhorn-system, flux-system, grocy-sf, grocy-vallejo, airlock, authentik
 

--- a/cluster/k8s/agents/shared-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -224,3 +224,17 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-namespace-diagnostics-reader
+  namespace: study-casino
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-diagnostics-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Binds the existing `namespace-diagnostics-reader` ClusterRole in the `study-casino` namespace for the `oidc-ksbx-groups:kubectl-sandbox-users` group.

Grants: pods, pods/log, services, configmaps, PVCs, events, deployments, replicasets, statefulsets (get/list/watch).

Needed so Claude can read study-casino pod logs directly via `kubectl-local` MCP without having to fall back to shell exec.

https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY

---
_Generated by [Claude Code](https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY)_