### PR TITLE
fix(tf/sso-providers): import existing study-casino Authentik application

### DIFF
--- a/tf/gitops/sso-providers/provider_study_casino.tf
+++ b/tf/gitops/sso-providers/provider_study_casino.tf
@@ -38,6 +38,15 @@ resource "authentik_provider_oauth2" "study_casino" {
   ]
 }
 
+# The application was created by the blueprint before TF took over management
+# (PR #1411). Import adopts the existing object; TF will reconcile attrs.
+# Policy bindings below may create duplicates of blueprint-created bindings —
+# those orphans are harmless and can be cleaned from the Authentik admin UI.
+import {
+  to = authentik_application.study_casino
+  id = "study-casino"
+}
+
 resource "authentik_application" "study_casino" {
   name              = "Study Casino"
   slug              = "study-casino"


### PR DESCRIPTION
## Summary

- The blueprint created `authentik_application.study_casino` before TF took over management (PR #1411 landed after the blueprint had already run with a live OAuth2 provider)
- TF's apply was failing: `"Application with this slug already exists."`
- Adds an `import` block so TF adopts the existing application by slug on the next apply

## Side effect

Policy bindings created by TF may duplicate the ones the old blueprint left behind. Duplicate bindings are harmless in Authentik (additive). The orphaned blueprint-created bindings can be cleaned from the Authentik admin UI at leisure.

## Test plan

- [ ] `sso-providers` TF apply succeeds (no more "slug already exists" error)
- [ ] `https://casino.allegedly.works/auth/login` still redirects correctly (302)
- [ ] CI green

https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY

---
_Generated by [Claude Code](https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY)_