### PR TITLE
fix(tf): use authentik_rbac_permission_role instead of broken authentik_rbac_permission_user

### DIFF
--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 
   backend "kubernetes" {

--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -21,10 +21,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
-    }
   }
 
   backend "kubernetes" {

--- a/tf/gitops/sso-providers/service_account_claude.tf
+++ b/tf/gitops/sso-providers/service_account_claude.tf
@@ -37,10 +37,35 @@ locals {
   ])
 }
 
-resource "authentik_rbac_permission_user" "claude_diagnostics" {
-  for_each   = local.claude_diagnostics_permissions
-  user       = tonumber(authentik_user.claude_service_account.id)
-  permission = each.value
+# authentik_rbac_permission_user has a read-after-create bug in goauthentik/authentik
+# ~> 2025.10: POST succeeds but the immediate GET-by-ID returns 404, causing
+# "Provider produced inconsistent result after apply" on every run.
+# Work around by calling the Authentik API directly from the TF runner pod
+# (in-cluster access to authentik-server.svc) via null_resource local-exec.
+resource "null_resource" "claude_diagnostics_permissions" {
+  triggers = {
+    user_id     = authentik_user.claude_service_account.id
+    permissions = join(",", sort(tolist(local.claude_diagnostics_permissions)))
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "$PERMISSIONS" | tr ',' '\n' | while IFS= read -r perm; do
+        status=$(curl -s -o /dev/null -w "%%{http_code}" \
+          -X POST \
+          -H "Authorization: Bearer $AUTHENTIK_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "{\"user\": $USER_ID, \"permission\": \"$perm\"}" \
+          "http://authentik-server.authentik.svc.cluster.local/api/v3/rbac/permissions/users/")
+        echo "permission $perm: HTTP $status"
+      done
+    EOT
+    environment = {
+      AUTHENTIK_TOKEN = data.kubernetes_secret.authentik_bootstrap.data["AUTHENTIK_BOOTSTRAP_TOKEN"]
+      USER_ID         = tostring(tonumber(authentik_user.claude_service_account.id))
+      PERMISSIONS     = join(",", sort(tolist(local.claude_diagnostics_permissions)))
+    }
+  }
 }
 
 resource "authentik_token" "claude_api" {

--- a/tf/gitops/sso-providers/service_account_claude.tf
+++ b/tf/gitops/sso-providers/service_account_claude.tf
@@ -37,35 +37,31 @@ locals {
   ])
 }
 
-# authentik_rbac_permission_user has a read-after-create bug in goauthentik/authentik
-# ~> 2025.10: POST succeeds but the immediate GET-by-ID returns 404, causing
-# "Provider produced inconsistent result after apply" on every run.
-# Work around by calling the Authentik API directly from the TF runner pod
-# (in-cluster access to authentik-server.svc) via null_resource local-exec.
-resource "null_resource" "claude_diagnostics_permissions" {
-  triggers = {
-    user_id     = authentik_user.claude_service_account.id
-    permissions = join(",", sort(tolist(local.claude_diagnostics_permissions)))
-  }
+# authentik_rbac_permission_user is broken in ~> 2025.10: the provider's Read
+# function calls GET /api/v3/rbac/permissions/users/{id}/ but Authentik never
+# implemented a retrieve-by-ID endpoint for user permissions (list-only), so
+# every apply fails with "Provider produced inconsistent result after apply".
+# In 2026.x the maintainer acknowledged this by hollowing the resource out with
+# schema.NoopContext and marking it deprecated in favour of authentik_rbac_permission_role.
+#
+# Fix: use the role-based approach. A role is assigned permissions via
+# authentik_rbac_permission_role (which has a working retrieve endpoint), and
+# the service account is placed in a group that carries the role.
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      echo "$PERMISSIONS" | tr ',' '\n' | while IFS= read -r perm; do
-        status=$(curl -s -o /dev/null -w "%%{http_code}" \
-          -X POST \
-          -H "Authorization: Bearer $AUTHENTIK_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d "{\"user\": $USER_ID, \"permission\": \"$perm\"}" \
-          "http://authentik-server.authentik.svc.cluster.local/api/v3/rbac/permissions/users/")
-        echo "permission $perm: HTTP $status"
-      done
-    EOT
-    environment = {
-      AUTHENTIK_TOKEN = data.kubernetes_secret.authentik_bootstrap.data["AUTHENTIK_BOOTSTRAP_TOKEN"]
-      USER_ID         = tostring(tonumber(authentik_user.claude_service_account.id))
-      PERMISSIONS     = join(",", sort(tolist(local.claude_diagnostics_permissions)))
-    }
-  }
+resource "authentik_rbac_role" "claude_diagnostics" {
+  name = "claude-diagnostics"
+}
+
+resource "authentik_rbac_permission_role" "claude_diagnostics" {
+  for_each   = local.claude_diagnostics_permissions
+  role       = authentik_rbac_role.claude_diagnostics.id
+  permission = each.value
+}
+
+resource "authentik_group" "claude_diagnostics" {
+  name  = "claude-diagnostics"
+  roles = [authentik_rbac_role.claude_diagnostics.id]
+  users = [tonumber(authentik_user.claude_service_account.id)]
 }
 
 resource "authentik_token" "claude_api" {


### PR DESCRIPTION
## Problem

`authentik_rbac_permission_user` is broken in the `~> 2025.10` provider. The resource's `Read` function calls `RbacPermissionsUsersRetrieve(id)` which maps to `GET /api/v3/rbac/permissions/users/{id}/`, but Authentik's server **never implemented a retrieve-by-ID endpoint** for user permissions — only the list endpoint exists. So every post-create read returns 404, producing:

```
Error: Provider produced inconsistent result after apply
```

This is not a race condition; there is simply no such endpoint. In January 2026 the provider maintainer acknowledged this by replacing the entire implementation with `schema.NoopContext` stubs and marking the resource deprecated with `TODO: Remove in 2026.2 or later`. The deprecation notice directs users to `authentik_rbac_permission_role`.

The previous commit on this branch (`3630fc3`) worked around this with a `null_resource` + `local-exec` curl loop. That was incorrect — the proper fix is to switch to the supported role-based approach.

## Fix

- Creates `authentik_rbac_role.claude_diagnostics`
- Creates `authentik_rbac_permission_role.claude_diagnostics` (one per permission, via `for_each`) — this resource has a working retrieve-by-ID endpoint and round-trips correctly
- Creates `authentik_group.claude_diagnostics` carrying the role, with `claude_service_account` as its member
- Drops the `hashicorp/null` provider (was only needed for the curl workaround)

## Testing

Depends on the `sso-providers` Terraform module reconciling cleanly in the cluster after merge.

https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b)_