### PR TITLE
feat(casino): WebSocket sync, fix lost session bug, remove stale SW cache

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,7 +78,7 @@ tf.download(
     # Each version must satisfy the constraints of ALL modules that use it.
     # When modules disagree (e.g., ~>3.0 vs ~>3.7.0), use the tighter range.
     mirror = {
-        "authentik": "goauthentik/authentik:2025.12.1",
+        "authentik": "goauthentik/authentik:2026.2.0",
         "aws": "hashicorp/aws:5.100.0",
         "external": "hashicorp/external:2.3.5",
         "flux": "fluxcd/flux:1.7.6",

--- a/tf/gitops/agent-machine-access/BUILD.bazel
+++ b/tf/gitops/agent-machine-access/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
     },
     tf_version = "1.9.8",

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gitops/airlock-oidc-proxy/BUILD.bazel
+++ b/tf/gitops/airlock-oidc-proxy/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
     },
     tf_version = "1.9.8",

--- a/tf/gitops/airlock-oidc-proxy/main.tf
+++ b/tf/gitops/airlock-oidc-proxy/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gitops/alloy-otlp-bearer-token/BUILD.bazel
+++ b/tf/gitops/alloy-otlp-bearer-token/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
     },
     tf_version = "1.9.8",

--- a/tf/gitops/alloy-otlp-bearer-token/main.tf
+++ b/tf/gitops/alloy-otlp-bearer-token/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gitops/authentik-mcp-poc/BUILD.bazel
+++ b/tf/gitops/authentik-mcp-poc/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
     },
     tf_version = "1.9.8",

--- a/tf/gitops/authentik-mcp-poc/main.tf
+++ b/tf/gitops/authentik-mcp-poc/main.tf
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gitops/gatus-sso/BUILD.bazel
+++ b/tf/gitops/gatus-sso/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
     },
     tf_version = "1.9.8",

--- a/tf/gitops/gatus-sso/main.tf
+++ b/tf/gitops/gatus-sso/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tf/gitops/sso-providers/BUILD.bazel
+++ b/tf/gitops/sso-providers/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
         "random": "hashicorp/random:~>3.6",
     },

--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/x/auragon_study_casino/README.md
+++ b/x/auragon_study_casino/README.md
@@ -50,40 +50,35 @@ bindings) are managed by TF at
 
 Y-CRDT, server-authoritative validation. The server holds one Y.Doc
 in memory and persists it as a single binary update blob in SQLite.
-Clients (the Yjs `Y.Doc` running in the React PWA) sync their local
-doc via `POST /sync`, sending base64-encoded
-`{state_vector_b64, update_b64}`:
+Clients sync via a persistent WebSocket at `/ws` (JSON, both directions):
 
-- Server: clones canonical → applies the client update on the trial
-  → runs every validator → on success promotes trial to canonical
-  and persists, then returns the binary diff the client still needs;
-  on failure leaves canonical untouched and returns a 409 with a
-  `{rejection: {rule, message}}` payload.
-- Client: applies the returned server update, surfaces a toast for
-  rejections, and rolls back the offending transaction via
-  `Y.UndoManager` so the local Doc always matches canonical.
+- Client → server: `{"type":"sync","state_vector_b64":"...","update_b64":"..."}`
+- Server → client: `{"type":"accepted",...}` | `{"type":"rejected","rule","message"}`
+  | `{"type":"server_push",...}` (fan-out to other tabs when one tab syncs)
+
+On acceptance the client clears its `Y.UndoManager` undo stack so
+already-synced changes can't be rolled back by a later rejection.
+On rejection the stack (which only contains post-last-sync changes) is
+drained, and the client pulls fresh state from the server.
 
 Document shape — mirrored verbatim between `doc_shape.py` (server)
 and `frontend/src/sync.js` (client):
 
 ```
 balance   : Y.Map { credits: number, tokens: number }
-active    : Y.Map (current live session, or empty when none)
-sessions  : Y.Map[id, Y.Map { subject, seconds, ended_at_ms }]
+sessions  : Y.Map[id, Y.Map] — all sessions, in-progress or completed
+            in-progress (no ended_at_ms): { subject, start_time_ms,
+              paused, paused_duration_ms, pause_started_at_ms }
+            completed: { subject, seconds, ended_at_ms }
 prizes    : Y.Map[id, Y.Map { name, cost }]
 prize_log : Y.Array[Y.Map { id, name, cost, at_ms }]
+active    : Y.Map — legacy, kept for one-time migration only
 ```
 
 CRDTs guarantee convergence but not business rules — the server's
 validators (credits ≥ 0, tokens ≥ 0, prize shape, session shape) are
 the only thing keeping the casino's economy honest. See
 <validators.py> for the rule list and the rejection contract.
-
-The service worker serves the app shell offline but bypasses the
-cache for `/sync` so a stale GET can't defeat cross-device sync.
-While offline, mutations stay in the local Y.Doc + IndexedDB and
-replay on reconnect; the SyncBanner UI surfaces "offline" and any
-rejection so failures are never silent.
 
 ## Build
 

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -34,7 +34,6 @@ back to a single "default" user, keeping existing tests working.
 
 import asyncio
 import base64
-import contextlib
 import logging
 import re
 import sys
@@ -57,6 +56,9 @@ logger = logging.getLogger(__name__)
 # Only allow filesystem-safe characters in usernames to prevent path traversal.
 _SAFE_USERNAME = re.compile(r"^[a-zA-Z0-9._@-]{1,64}$")
 
+# Maximum base64 payload length accepted over WebSocket — matches HTTP /sync.
+_WS_PAYLOAD_LIMIT = 4 * 1024 * 1024
+
 
 class _WSManager:
     """Per-user WebSocket registry for server-push fan-out across tabs."""
@@ -72,11 +74,16 @@ class _WSManager:
 
     async def push(self, username: str, message: dict, exclude: WebSocket | None = None) -> None:
         """Fan out `message` to every connected client for `username` except `exclude`."""
+        dead: list[WebSocket] = []
         for ws in list(self._connections.get(username, ())):
             if ws is exclude:
                 continue
-            with contextlib.suppress(Exception):
+            try:
                 await ws.send_json(message)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self._connections[username].discard(ws)
 
 
 class SyncRequest(BaseModel):
@@ -188,9 +195,15 @@ def create_app(settings: Settings) -> FastAPI:
                 if data.get("type") != "sync":
                     continue
 
+                sv_raw = data.get("state_vector_b64") or ""
+                upd_raw = data.get("update_b64") or ""
+                if len(sv_raw) > _WS_PAYLOAD_LIMIT or len(upd_raw) > _WS_PAYLOAD_LIMIT:
+                    await ws.send_json({"type": "error", "code": 413, "message": "payload too large"})
+                    continue
+
                 try:
-                    client_sv = base64.b64decode(data.get("state_vector_b64") or "")
-                    client_update = base64.b64decode(data.get("update_b64") or "")
+                    client_sv = base64.b64decode(sv_raw)
+                    client_update = base64.b64decode(upd_raw)
                 except (ValueError, TypeError) as e:
                     await ws.send_json({"type": "error", "code": 400, "message": f"invalid base64: {e}"})
                     continue

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -32,20 +32,23 @@ Multi-user: each authenticated user gets a separate SQLite database
 back to a single "default" user, keeping existing tests working.
 """
 
+import asyncio
 import base64
+import contextlib
 import logging
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 from typing import Annotated
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
-from x.auragon_study_casino.auth import create_oidc_router, make_current_user_dep
+from x.auragon_study_casino.auth import create_oidc_router, decode_session_token, make_current_user_dep
 from x.auragon_study_casino.config import Settings
 from x.auragon_study_casino.store import Accepted, DocStore, Rejected
 
@@ -53,6 +56,27 @@ logger = logging.getLogger(__name__)
 
 # Only allow filesystem-safe characters in usernames to prevent path traversal.
 _SAFE_USERNAME = re.compile(r"^[a-zA-Z0-9._@-]{1,64}$")
+
+
+class _WSManager:
+    """Per-user WebSocket registry for server-push fan-out across tabs."""
+
+    def __init__(self) -> None:
+        self._connections: dict[str, set[WebSocket]] = defaultdict(set)
+
+    def add(self, username: str, ws: WebSocket) -> None:
+        self._connections[username].add(ws)
+
+    def remove(self, username: str, ws: WebSocket) -> None:
+        self._connections[username].discard(ws)
+
+    async def push(self, username: str, message: dict, exclude: WebSocket | None = None) -> None:
+        """Fan out `message` to every connected client for `username` except `exclude`."""
+        for ws in list(self._connections.get(username, ())):
+            if ws is exclude:
+                continue
+            with contextlib.suppress(Exception):
+                await ws.send_json(message)
 
 
 class SyncRequest(BaseModel):
@@ -91,6 +115,7 @@ def create_app(settings: Settings) -> FastAPI:
 
     oidc = settings.oidc_config()
     current_user_dep = make_current_user_dep(oidc.session_secret if oidc else None)
+    ws_manager = _WSManager()
 
     app = FastAPI(title="Study Casino", docs_url=None, redoc_url=None)
     app.state.current_user_dep = current_user_dep
@@ -113,6 +138,106 @@ def create_app(settings: Settings) -> FastAPI:
     @app.get("/me")
     def me(username: Annotated[str, Depends(current_user_dep)]) -> dict[str, str]:
         return {"username": username}
+
+    @app.websocket("/ws")
+    async def websocket_sync(ws: WebSocket) -> None:
+        """WebSocket sync endpoint.
+
+        Protocol (JSON, both directions):
+          Client → server: {"type":"sync","state_vector_b64":"...","update_b64":"..."}
+          Server → client: {"type":"accepted","update_b64":"...","state_vector_b64":"..."}
+                         | {"type":"rejected","rule":"...","message":"..."}
+                         | {"type":"server_push","update_b64":"..."}  (fan-out from another tab)
+                         | {"type":"error","code":N,"message":"..."}
+        """
+        # Auth: read the HMAC-signed session cookie from the WS upgrade request.
+        if oidc is not None:
+            casino_session = ws.cookies.get("casino_session")
+            if not casino_session:
+                await ws.close(code=4001, reason="not authenticated")
+                return
+            username = decode_session_token(casino_session, oidc.session_secret)
+            if username is None:
+                await ws.close(code=4001, reason="session invalid or expired")
+                return
+        else:
+            username = "default"
+
+        await ws.accept()
+        store = get_store(username)
+        ws_manager.add(username, ws)
+        logger.info("ws connected: user=%s", username)
+
+        # Bootstrap the client with the full canonical state immediately.
+        init_update, init_sv = await asyncio.to_thread(store.snapshot_for_client, None)
+        await ws.send_json(
+            {
+                "type": "accepted",
+                "update_b64": base64.b64encode(init_update).decode("ascii"),
+                "state_vector_b64": base64.b64encode(init_sv).decode("ascii"),
+            }
+        )
+
+        try:
+            while True:
+                try:
+                    data = await ws.receive_json()
+                except Exception:
+                    break
+
+                if data.get("type") != "sync":
+                    continue
+
+                try:
+                    client_sv = base64.b64decode(data.get("state_vector_b64") or "")
+                    client_update = base64.b64decode(data.get("update_b64") or "")
+                except (ValueError, TypeError) as e:
+                    await ws.send_json({"type": "error", "code": 400, "message": f"invalid base64: {e}"})
+                    continue
+
+                if not client_update:
+                    # Pure pull — no new data from client.
+                    srv_update, srv_sv = await asyncio.to_thread(store.snapshot_for_client, client_sv)
+                    await ws.send_json(
+                        {
+                            "type": "accepted",
+                            "update_b64": base64.b64encode(srv_update).decode("ascii"),
+                            "state_vector_b64": base64.b64encode(srv_sv).decode("ascii"),
+                        }
+                    )
+                    continue
+
+                result = await asyncio.to_thread(store.apply_client_update, client_update, client_sv)
+
+                if isinstance(result, Rejected):
+                    logger.info("ws sync rejected: user=%s rule=%s", username, result.rule)
+                    await ws.send_json({"type": "rejected", "rule": result.rule, "message": result.message})
+                    continue
+
+                assert isinstance(result, Accepted)
+                logger.info("ws sync accepted: user=%s", username)
+
+                await ws.send_json(
+                    {
+                        "type": "accepted",
+                        "update_b64": base64.b64encode(result.server_update).decode("ascii"),
+                        "state_vector_b64": base64.b64encode(result.server_state_vector).decode("ascii"),
+                    }
+                )
+
+                # Fan the full canonical state out to every other connected tab for this user.
+                full_update = await asyncio.to_thread(store.get_update_for_client, None)
+                await ws_manager.push(
+                    username,
+                    {"type": "server_push", "update_b64": base64.b64encode(full_update).decode("ascii")},
+                    exclude=ws,
+                )
+
+        except WebSocketDisconnect:
+            pass
+        finally:
+            ws_manager.remove(username, ws)
+            logger.info("ws disconnected: user=%s", username)
 
     @app.post("/sync", response_model=SyncSuccess)
     def sync(body: SyncRequest, username: Annotated[str, Depends(current_user_dep)]) -> SyncSuccess | JSONResponse:

--- a/x/auragon_study_casino/doc_shape.py
+++ b/x/auragon_study_casino/doc_shape.py
@@ -9,11 +9,13 @@ here must be mirrored in `frontend/src/sync.js`.
 Top-level keys are all on a single root `Doc`:
 
   balance   : Y.Map        # {"credits": int, "tokens": int}
-  active    : Y.Map        # current live study session, or empty when none:
-                           #   {"subject": str, "start_time_ms": int,
-                           #    "paused": bool, "paused_duration_ms": int,
-                           #    "pause_started_at_ms": int|None}
-  sessions  : Y.Map[str, Y.Map]   # completed sessions, keyed by client-generated id:
+  active    : Y.Map        # legacy — kept for migration only; new sessions use `sessions`
+  sessions  : Y.Map[str, Y.Map]   # all sessions, keyed by client-generated id.
+                                  # In-progress (no ended_at_ms):
+                                  #   {"subject": str, "start_time_ms": int,
+                                  #    "paused": bool, "paused_duration_ms": int,
+                                  #    "pause_started_at_ms": int|None}
+                                  # Completed (ended_at_ms set):
                                   #   {"subject": str, "seconds": int, "ended_at_ms": int}
   prizes    : Y.Map[str, Y.Map]   # prize catalog, keyed by prize id:
                                   #   {"name": str, "cost": int}

--- a/x/auragon_study_casino/frontend/src/main.jsx
+++ b/x/auragon_study_casino/frontend/src/main.jsx
@@ -2,11 +2,11 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import StudyCasino from "./study_casino.jsx";
 
+// Unregister any previously installed service workers so stale cached JS
+// can't shadow new deploys.  Offline mode is not needed for this app.
 if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js").catch((err) => {
-      console.warn("service worker registration failed", err);
-    });
+  navigator.serviceWorker.getRegistrations().then((regs) => {
+    for (const reg of regs) reg.unregister();
   });
 }
 

--- a/x/auragon_study_casino/frontend/src/sync.js
+++ b/x/auragon_study_casino/frontend/src/sync.js
@@ -131,6 +131,19 @@ class CasinoSync {
       console.debug("[CasinoSync] local mutation detected, scheduling sync");
       this._scheduleSync();
     });
+
+    // Register the visibility listener once here — not inside _connectWebSocket
+    // (which is called on every reconnect) to avoid accumulating duplicate handlers.
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible") return;
+      if (this._ws?.readyState === WebSocket.OPEN) {
+        console.debug("[CasinoSync] tab foregrounded, syncing");
+        this._scheduleSync();
+      } else if (!this._reconnectTimer) {
+        console.debug("[CasinoSync] tab foregrounded, reconnecting");
+        this._connectWebSocket();
+      }
+    });
   }
 
   async _init() {
@@ -261,17 +274,6 @@ class CasinoSync {
       // Error details are not exposed by the WS spec; the close event follows.
       console.debug("[CasinoSync] WebSocket error (close follows)");
     };
-
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState !== "visible") return;
-      if (this._wsReady) {
-        console.debug("[CasinoSync] tab foregrounded, syncing");
-        this._scheduleSync();
-      } else if (!this._reconnectTimer) {
-        console.debug("[CasinoSync] tab foregrounded, reconnecting");
-        this._connectWebSocket();
-      }
-    });
   }
 
   _scheduleReconnect() {
@@ -294,21 +296,29 @@ class CasinoSync {
   }
 
   _doSync() {
-    if (!this._wsReady || !this._ws) {
-      console.debug("[CasinoSync] sync skipped — WebSocket not ready");
+    if (!this._ws || this._ws.readyState !== WebSocket.OPEN) {
+      console.debug("[CasinoSync] sync skipped — WebSocket not open");
       return;
     }
     const update = Y.encodeStateAsUpdate(this.doc, this.lastServerSV?.byteLength ? this.lastServerSV : undefined);
     const sv = Y.encodeStateVector(this.doc);
     console.debug("[CasinoSync] sending sync — update:", update.byteLength, "B, sv:", sv.byteLength, "B");
     this.status.set({ kind: "syncing" });
-    this._ws.send(
-      JSON.stringify({
-        type: "sync",
-        state_vector_b64: bytesToB64(sv),
-        update_b64: bytesToB64(update),
-      })
-    );
+    try {
+      this._ws.send(
+        JSON.stringify({
+          type: "sync",
+          state_vector_b64: bytesToB64(sv),
+          update_b64: bytesToB64(update),
+        })
+      );
+    } catch (e) {
+      console.debug("[CasinoSync] send failed:", e.message);
+      this._wsReady = false;
+      this.status.set({ kind: "offline", reason: "send failed, reconnecting…" });
+      this._ws = null;
+      this._scheduleReconnect();
+    }
   }
 
   _handleMessage(msg) {
@@ -357,6 +367,9 @@ class CasinoSync {
           console.debug("[CasinoSync] server push error:", e.message);
         }
       }
+      // Re-sync to exchange our state vector so lastServerSV stays current and
+      // the server knows what we now have (avoids redundant re-push of stale ops).
+      this._scheduleSync();
     }
 
     if (msg.type === "error") {

--- a/x/auragon_study_casino/frontend/src/sync.js
+++ b/x/auragon_study_casino/frontend/src/sync.js
@@ -1,30 +1,40 @@
 // CRDT-backed multi-device sync for the Study Casino.
 //
 // Architecture: one Y.Doc per running tab, persisted to IndexedDB by
-// `y-indexeddb`, synced to the server's canonical Y.Doc via HTTP polling
-// against POST /sync. The server speaks the same Yrs/Yjs binary update
-// format and gates writes through the Python validators in validators.py;
-// this module is the wire-format mirror.
+// `y-indexeddb`, synced to the server via a persistent WebSocket at /ws.
+// The server speaks the same Yrs/Yjs binary update format and gates writes
+// through the Python validators in validators.py; this module is the
+// wire-format mirror.
 //
 // The doc shape is documented in `x/auragon_study_casino/doc_shape.py` —
 // keep both in lockstep when adding fields:
 //
 //   doc.getMap("balance")    : { credits: number, tokens: number }
-//   doc.getMap("active")     : current live session, empty when none
-//   doc.getMap("sessions")   : id -> Y.Map({ subject, seconds, ended_at_ms })
+//   doc.getMap("sessions")   : id -> Y.Map — all sessions, in-progress or done.
+//                              In-progress: { subject, start_time_ms, paused,
+//                                            paused_duration_ms, pause_started_at_ms }
+//                              Completed:   { subject, seconds, ended_at_ms }
 //   doc.getMap("prizes")     : id -> Y.Map({ name, cost })
 //   doc.getArray("prize_log"): Y.Map({ id, name, cost, at_ms })
+//   doc.getMap("active")     : legacy map — kept for one-time migration only
 //
-// Error policy (called out in CLAUDE-PR review): the frontend never
-// silently swallows sync failures. Every network or validation error
-// surfaces through `casinoSync.status`; the SyncIcon in the header renders that store.
+// WebSocket protocol (JSON, both directions):
+//   client → server: { type:"sync", state_vector_b64, update_b64 }
+//   server → client: { type:"accepted", update_b64, state_vector_b64 }
+//                  | { type:"rejected", rule, message }
+//                  | { type:"server_push", update_b64 }   ← another tab synced
+//                  | { type:"error", code, message }
+//
+// Error policy: the frontend never silently swallows sync failures. Every
+// network or validation error surfaces through `casinoSync.status`; the
+// SyncIcon in the header renders that store.
 
 import * as Y from "yjs";
 import { IndexeddbPersistence } from "y-indexeddb";
 
-const SYNC_URL = "/sync";
-const POLL_INTERVAL_MS = 30_000;
 const PUSH_DEBOUNCE_MS = 200;
+const WS_RECONNECT_BASE_MS = 1_000;
+const WS_RECONNECT_MAX_MS = 30_000;
 const ORIGIN_REMOTE = Symbol("remote");
 
 const DEFAULT_PRIZES = [
@@ -80,10 +90,11 @@ class CasinoSync {
     // Declare the typed roots up front so `Y.applyUpdate` populates the
     // right handles. Mirrors the pycrdt `Casino` wrapper on the server.
     this.balance = this.doc.getMap("balance");
-    this.active = this.doc.getMap("active");
     this.sessions = this.doc.getMap("sessions");
     this.prizes = this.doc.getMap("prizes");
     this.prizeLog = this.doc.getArray("prize_log");
+    // Legacy map kept only for one-time migration of old in-progress sessions.
+    this.active = this.doc.getMap("active");
 
     // The state vector the server had at our last successful sync. We send
     // it on every push so the server can diff its missing changes for us.
@@ -96,10 +107,15 @@ class CasinoSync {
     this.rejection.set(null);
 
     this._pushTimer = null;
-    this._pollTimer = null;
-    this._undoManager = new Y.UndoManager([this.balance, this.active, this.sessions, this.prizes, this.prizeLog], {
-      // Only track *local* changes so a server-applied change doesn't get
-      // un-done by the rejection rollback below.
+    this._ws = null;
+    this._wsReady = false;
+    this._reconnectTimer = null;
+    this._reconnectDelay = WS_RECONNECT_BASE_MS;
+
+    // UndoManager tracks balance, sessions, prizes, and prize_log but NOT
+    // the legacy active map. Only local-origin changes are tracked so server
+    // updates don't enter the undo stack.
+    this._undoManager = new Y.UndoManager([this.balance, this.sessions, this.prizes, this.prizeLog], {
       trackedOrigins: new Set([null, undefined]),
     });
 
@@ -112,6 +128,7 @@ class CasinoSync {
     // from the server tunnel through with origin=ORIGIN_REMOTE and skip.
     this.doc.on("update", (_update, origin) => {
       if (origin === ORIGIN_REMOTE) return;
+      console.debug("[CasinoSync] local mutation detected, scheduling sync");
       this._scheduleSync();
     });
   }
@@ -127,27 +144,29 @@ class CasinoSync {
       if (resp.ok) {
         const data = await resp.json();
         username = data.username || "default";
+        console.debug("[CasinoSync] authenticated as", username);
       }
-    } catch {
-      // Network error during /me — proceed with "default"; /sync will fail
+    } catch (e) {
+      // Network error during /me — proceed with "default"; WS will fail
       // too and surface the offline state.
+      console.debug("[CasinoSync] /me fetch failed:", e.message);
     }
 
     const idbName = `casino-doc-v1-${username}`;
+    console.debug("[CasinoSync] opening IDB:", idbName);
     this.persistence = new IndexeddbPersistence(idbName, this.doc);
     this.persistence.once("synced", () => {
+      console.debug("[CasinoSync] IDB synced, seeding and connecting WS");
       this._seedDefaultPrizesIfEmpty();
-      this._startPolling();
-      this._scheduleSync();
+      this._migrateActiveSessions();
+      this._connectWebSocket();
     });
-    // Fallback: if IDB "synced" hasn't fired within 3 s (e.g. headless Chrome
-    // in a container where IDB initialisation stalls), start polling anyway so
-    // the app stays functional. _startPolling is idempotent; calling it a
-    // second time after the real "synced" event is a no-op.
+    // Fallback: if IDB hasn't fired "synced" within 3 s (e.g. headless
+    // Chrome in a container), connect anyway.
     setTimeout(() => {
-      if (!this._pollTimer) {
-        this._startPolling();
-        this._scheduleSync();
+      if (!this._ws) {
+        console.debug("[CasinoSync] IDB synced timeout — connecting WS anyway");
+        this._connectWebSocket();
       }
     }, 3000);
   }
@@ -166,125 +185,186 @@ class CasinoSync {
     });
   }
 
-  _startPolling() {
-    if (this._pollTimer) return;
-    this._pollTimer = setInterval(() => this.syncOnce(), POLL_INTERVAL_MS);
-    // Fire one sync the moment the tab regains focus / visibility so a
-    // newly-foregrounded device picks up other-device writes immediately.
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "visible") this._scheduleSync();
+  // CLEANUP(2026-04-28): Remove once all clients have migrated. Moves any
+  // leftover session data from the old `active` Y.Map into the `sessions`
+  // map as an in-progress entry (no ended_at_ms).
+  _migrateActiveSessions() {
+    if (this.active.size === 0) return;
+    const hasInProgress = [...this.sessions.values()].some((m) => !m.get("ended_at_ms"));
+    if (hasInProgress) {
+      // New-style active session already present; just clear the legacy map.
+      console.debug("[CasinoSync] migration: legacy active map has data but new-style active exists, clearing legacy");
+      this.doc.transact(() => this.active.clear());
+      return;
+    }
+    const subject = this.active.get("subject");
+    if (!subject) {
+      this.doc.transact(() => this.active.clear());
+      return;
+    }
+    const id = `migrated-${Date.now()}`;
+    console.debug("[CasinoSync] migrating legacy active session to sessions:", { subject, id });
+    this.doc.transact(() => {
+      const sm = new Y.Map();
+      this.sessions.set(id, sm);
+      sm.set("subject", subject);
+      sm.set("start_time_ms", this.active.get("start_time_ms") ?? Date.now());
+      sm.set("paused", !!this.active.get("paused"));
+      sm.set("paused_duration_ms", this.active.get("paused_duration_ms") ?? 0);
+      sm.set("pause_started_at_ms", this.active.get("pause_started_at_ms") ?? null);
+      this.active.clear();
     });
+  }
+
+  _connectWebSocket() {
+    if (this._ws) return;
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${location.host}/ws`;
+    console.debug("[CasinoSync] connecting WebSocket:", url);
+
+    const ws = new WebSocket(url);
+    this._ws = ws;
+
+    ws.onopen = () => {
+      console.debug("[CasinoSync] WebSocket connected");
+      this._wsReady = true;
+      this._reconnectDelay = WS_RECONNECT_BASE_MS;
+      this.status.set({ kind: "syncing" });
+      // Server sends a full bootstrap snapshot on connect; no need to push here
+      // unless there are local-only changes the server hasn't seen yet.
+      this._scheduleSync();
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        this._handleMessage(msg);
+      } catch (e) {
+        console.debug("[CasinoSync] failed to parse message:", e.message);
+      }
+    };
+
+    ws.onclose = (event) => {
+      console.debug("[CasinoSync] WebSocket closed:", event.code, event.reason || "(no reason)");
+      this._ws = null;
+      this._wsReady = false;
+      if (event.code === 4001) {
+        // Auth failure — redirect rather than reconnect.
+        window.location.href = "/auth/login";
+        return;
+      }
+      this.status.set({ kind: "offline", reason: "disconnected, reconnecting…" });
+      this._scheduleReconnect();
+    };
+
+    ws.onerror = () => {
+      // Error details are not exposed by the WS spec; the close event follows.
+      console.debug("[CasinoSync] WebSocket error (close follows)");
+    };
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible") return;
+      if (this._wsReady) {
+        console.debug("[CasinoSync] tab foregrounded, syncing");
+        this._scheduleSync();
+      } else if (!this._reconnectTimer) {
+        console.debug("[CasinoSync] tab foregrounded, reconnecting");
+        this._connectWebSocket();
+      }
+    });
+  }
+
+  _scheduleReconnect() {
+    if (this._reconnectTimer) return;
+    const delay = this._reconnectDelay;
+    console.debug("[CasinoSync] scheduling reconnect in", delay, "ms");
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      this._reconnectDelay = Math.min(this._reconnectDelay * 2, WS_RECONNECT_MAX_MS);
+      this._connectWebSocket();
+    }, delay);
   }
 
   _scheduleSync() {
     if (this._pushTimer) return;
     this._pushTimer = setTimeout(() => {
       this._pushTimer = null;
-      this.syncOnce();
+      this._doSync();
     }, PUSH_DEBOUNCE_MS);
   }
 
-  /** Run one round-trip against /sync. Errors land in `this.status`. */
-  async syncOnce() {
-    this.status.set({ kind: "syncing" });
-    // Y.encodeStateAsUpdate(doc, new Uint8Array()) throws in yjs 13.6/lib0 0.2 —
-    // an explicitly empty Uint8Array triggers a bounds-check failure when decoding
-    // the state vector. Pass undefined (= no state vector = full update) for the
-    // first sync when we haven't heard from the server yet.
+  _doSync() {
+    if (!this._wsReady || !this._ws) {
+      console.debug("[CasinoSync] sync skipped — WebSocket not ready");
+      return;
+    }
     const update = Y.encodeStateAsUpdate(this.doc, this.lastServerSV?.byteLength ? this.lastServerSV : undefined);
+    const sv = Y.encodeStateVector(this.doc);
+    console.debug("[CasinoSync] sending sync — update:", update.byteLength, "B, sv:", sv.byteLength, "B");
+    this.status.set({ kind: "syncing" });
+    this._ws.send(
+      JSON.stringify({
+        type: "sync",
+        state_vector_b64: bytesToB64(sv),
+        update_b64: bytesToB64(update),
+      })
+    );
+  }
 
-    let response;
-    try {
-      response = await fetch(SYNC_URL, {
-        method: "POST",
-        credentials: "same-origin",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          state_vector_b64: bytesToB64(Y.encodeStateVector(this.doc)),
-          update_b64: bytesToB64(update),
-        }),
-      });
-    } catch (e) {
-      // Pure network error — DNS, TCP refused, CORS, offline.
-      this.status.set({ kind: "offline", reason: e.message ?? String(e) });
-      return;
-    }
+  _handleMessage(msg) {
+    console.debug("[CasinoSync] received:", msg.type);
 
-    if (response.status === 401) {
-      window.location.href = "/auth/login";
-      return;
-    }
-
-    if (response.status === 409) {
-      // Server rejected our update. Roll back the last local transaction
-      // via UndoManager so canonical state on this client matches the
-      // server's view, then surface the rejection.
-      //
-      // A single push can carry multiple local transactions (queued
-      // during the debounce window or accumulated while offline). The
-      // server validates the merged result, so a single `undo()` may
-      // leave invalid state behind — drain the entire local-origin
-      // undo stack before resyncing so the next round is built on the
-      // server's known-good view.
-      let body;
-      try {
-        body = await response.json();
-      } catch {
-        body = { rejection: { rule: "malformed", message: response.statusText } };
+    if (msg.type === "accepted") {
+      const serverUpdate = b64ToBytes(msg.update_b64);
+      if (serverUpdate.byteLength > 0) {
+        try {
+          Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
+          console.debug("[CasinoSync] applied server update:", serverUpdate.byteLength, "B");
+        } catch (e) {
+          console.debug("[CasinoSync] corrupt server update:", e.message);
+          this.status.set({ kind: "offline", reason: `corrupt server update: ${e.message ?? String(e)}` });
+          return;
+        }
       }
+      const sv = b64ToBytes(msg.state_vector_b64);
+      this.lastServerSV = sv.byteLength > 0 ? sv : null;
+      // Clear the undo stack so changes already on the server can't be
+      // rolled back by a future 409 rejection of unrelated local edits.
+      this._undoManager.clear();
+      this.status.set({ kind: "ok", lastSyncedAt: Date.now() });
+    }
+
+    if (msg.type === "rejected") {
+      console.debug("[CasinoSync] sync rejected:", msg.rule, msg.message);
+      // Drain undo stack: only contains changes since the last successful
+      // sync (the clear() above keeps the stack bounded).
       while (this._undoManager.undoStack.length > 0) {
         this._undoManager.undo();
       }
-      this.rejection.set({
-        id: Date.now(),
-        rule: body.rejection?.rule ?? "unknown",
-        message: body.rejection?.message ?? "(no detail)",
-      });
-      this.status.set({
-        kind: "rejected",
-        rule: body.rejection?.rule ?? "unknown",
-        message: body.rejection?.message ?? "",
-      });
-      // Force a pull-only sync so the local doc realigns with canonical
-      // before the user retries the action.
-      this._scheduleSync();
-      return;
+      this.rejection.set({ id: Date.now(), rule: msg.rule, message: msg.message });
+      this.status.set({ kind: "rejected", rule: msg.rule, message: msg.message });
+      // Pull from server to realign before the user retries.
+      setTimeout(() => this._doSync(), 100);
     }
 
-    if (!response.ok) {
-      let detail = `HTTP ${response.status}`;
-      try {
-        const t = await response.text();
-        if (t) detail += `: ${t.slice(0, 200)}`;
-      } catch {
-        /* fall through */
-      }
-      this.status.set({ kind: "offline", reason: detail });
-      return;
-    }
-
-    let body;
-    try {
-      body = await response.json();
-    } catch (e) {
-      this.status.set({ kind: "offline", reason: `bad JSON from /sync: ${e.message}` });
-      return;
-    }
-
-    const serverUpdate = b64ToBytes(body.update_b64);
-    if (serverUpdate.byteLength > 0) {
-      try {
-        // Apply with a remote origin tag so our own update listener doesn't
-        // bounce it back at the server.
-        Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
-      } catch (e) {
-        this.status.set({ kind: "offline", reason: `corrupt server update: ${e.message ?? String(e)}` });
-        return;
+    if (msg.type === "server_push") {
+      const serverUpdate = b64ToBytes(msg.update_b64);
+      if (serverUpdate.byteLength > 0) {
+        try {
+          Y.applyUpdate(this.doc, serverUpdate, ORIGIN_REMOTE);
+          console.debug("[CasinoSync] applied server push:", serverUpdate.byteLength, "B");
+        } catch (e) {
+          console.debug("[CasinoSync] server push error:", e.message);
+        }
       }
     }
-    const sv = b64ToBytes(body.state_vector_b64);
-    this.lastServerSV = sv.byteLength > 0 ? sv : null;
-    this.status.set({ kind: "ok", lastSyncedAt: Date.now() });
+
+    if (msg.type === "error") {
+      console.debug("[CasinoSync] server error:", msg.code, msg.message);
+      if (msg.code === 401) {
+        window.location.href = "/auth/login";
+      }
+    }
   }
 
   /** Run a transaction. All UI mutations go through here so the UndoManager

--- a/x/auragon_study_casino/frontend/src/use_casino.js
+++ b/x/auragon_study_casino/frontend/src/use_casino.js
@@ -82,10 +82,7 @@ export function useCasino() {
   // server rejection rolls back the whole user-visible action.
 
   const startSession = (subject) => {
-    // Store the in-progress session in the sessions map with no ended_at_ms.
-    // This keeps the active session durable through sync cycles and prevents
-    // the UndoManager drain on a 409 rejection from losing already-synced
-    // session starts (the undo stack is cleared after every successful sync).
+    if (activeSession) return; // one session at a time — illegal to start while one is running
     const id = `active-${Date.now()}`;
     casinoSync.mutate(() => {
       const sm = new Y.Map();
@@ -132,11 +129,16 @@ export function useCasino() {
     const sec = elapsedSeconds(activeSession);
     const min = Math.floor(sec / 60);
     casinoSync.mutate(() => {
+      if (sec <= 0) {
+        // Zero-elapsed sessions are discarded rather than creating noise in history.
+        casinoSync.sessions.delete(activeSession.id);
+        return;
+      }
       const m = casinoSync.sessions.get(activeSession.id);
       if (!m) return;
       m.set("seconds", sec);
       m.set("ended_at_ms", Date.now());
-      // Clear the in-progress fields to keep the completed entry compact.
+      // Clear in-progress fields to keep the completed entry compact.
       m.delete("start_time_ms");
       m.delete("paused");
       m.delete("paused_duration_ms");

--- a/x/auragon_study_casino/frontend/src/use_casino.js
+++ b/x/auragon_study_casino/frontend/src/use_casino.js
@@ -6,9 +6,14 @@
 //     casino.credits / casino.tokens / casino.sessions / ...
 //     casino.startSession("Biochem"); casino.redeem(prize); ...
 //
-// All mutations are server-validated through `/sync` (driven by sync.js);
+// All mutations are server-validated through `/ws` (driven by sync.js);
 // optimistic updates happen because the local Y.Doc updates synchronously
 // while the network round-trip happens in the background.
+//
+// Active sessions live in the `sessions` Y.Map as entries with no
+// `ended_at_ms` field.  `activeSession` is derived by finding the single
+// sessions entry whose `ended_at_ms` is absent; `sessions` returns only
+// completed entries.
 
 import { casinoSync, Y } from "./sync.js";
 import { useYArray, useYMap } from "./y_hooks.js";
@@ -18,7 +23,6 @@ export function useCasino() {
   const sessionsMap = useYMap(casinoSync.sessions);
   const prizesMap = useYMap(casinoSync.prizes);
   const prizeLogArr = useYArray(casinoSync.prizeLog);
-  const activeMap = useYMap(casinoSync.active);
 
   // Derived plain-JS views that downstream JSX expects unchanged. We round
   // the balance numbers because Yjs stores them as float64.
@@ -32,7 +36,9 @@ export function useCasino() {
   const credits = Math.floor(balance.get("credits") ?? 0);
   const tokens = Math.floor(balance.get("tokens") ?? 0);
 
+  // Completed sessions only — those with ended_at_ms set.
   const sessions = [...sessionsMap.entries()]
+    .filter(([, m]) => !!m.get("ended_at_ms"))
     .map(([id, m]) => ({
       id,
       subject: m.get("subject"),
@@ -57,16 +63,18 @@ export function useCasino() {
     }))
     .sort((a, b) => b.at - a.at);
 
-  const activeSession =
-    activeMap.size === 0
-      ? null
-      : {
-          subject: activeMap.get("subject"),
-          startTime: Math.floor(activeMap.get("start_time_ms") ?? 0),
-          paused: !!activeMap.get("paused"),
-          pausedDuration: Math.floor(activeMap.get("paused_duration_ms") ?? 0),
-          pauseStartedAt: activeMap.get("pause_started_at_ms"),
-        };
+  // In-progress session: the single sessions entry without ended_at_ms.
+  const activeRaw = [...sessionsMap.entries()].find(([, m]) => !m.get("ended_at_ms"));
+  const activeSession = activeRaw
+    ? {
+        id: activeRaw[0],
+        subject: activeRaw[1].get("subject"),
+        startTime: Math.floor(activeRaw[1].get("start_time_ms") ?? 0),
+        paused: !!activeRaw[1].get("paused"),
+        pausedDuration: Math.floor(activeRaw[1].get("paused_duration_ms") ?? 0),
+        pauseStartedAt: activeRaw[1].get("pause_started_at_ms"),
+      }
+    : null;
 
   // === Mutations ===
   // Each one wraps `casinoSync.mutate` (which calls doc.transact) so the
@@ -74,21 +82,29 @@ export function useCasino() {
   // server rejection rolls back the whole user-visible action.
 
   const startSession = (subject) => {
+    // Store the in-progress session in the sessions map with no ended_at_ms.
+    // This keeps the active session durable through sync cycles and prevents
+    // the UndoManager drain on a 409 rejection from losing already-synced
+    // session starts (the undo stack is cleared after every successful sync).
+    const id = `active-${Date.now()}`;
     casinoSync.mutate(() => {
-      casinoSync.active.clear();
-      casinoSync.active.set("subject", subject);
-      casinoSync.active.set("start_time_ms", Date.now());
-      casinoSync.active.set("paused", false);
-      casinoSync.active.set("paused_duration_ms", 0);
-      casinoSync.active.set("pause_started_at_ms", null);
+      const sm = new Y.Map();
+      casinoSync.sessions.set(id, sm);
+      sm.set("subject", subject);
+      sm.set("start_time_ms", Date.now());
+      sm.set("paused", false);
+      sm.set("paused_duration_ms", 0);
+      sm.set("pause_started_at_ms", null);
     });
   };
 
   const pauseSession = () => {
     if (!activeSession || activeSession.paused) return;
     casinoSync.mutate(() => {
-      casinoSync.active.set("paused", true);
-      casinoSync.active.set("pause_started_at_ms", Date.now());
+      const m = casinoSync.sessions.get(activeSession.id);
+      if (!m) return;
+      m.set("paused", true);
+      m.set("pause_started_at_ms", Date.now());
     });
   };
 
@@ -97,9 +113,11 @@ export function useCasino() {
     const now = Date.now();
     const pausedFor = now - (activeSession.pauseStartedAt ?? now);
     casinoSync.mutate(() => {
-      casinoSync.active.set("paused", false);
-      casinoSync.active.set("pause_started_at_ms", null);
-      casinoSync.active.set("paused_duration_ms", activeSession.pausedDuration + Math.max(0, pausedFor));
+      const m = casinoSync.sessions.get(activeSession.id);
+      if (!m) return;
+      m.set("paused", false);
+      m.set("pause_started_at_ms", null);
+      m.set("paused_duration_ms", activeSession.pausedDuration + Math.max(0, pausedFor));
     });
   };
 
@@ -113,24 +131,25 @@ export function useCasino() {
     if (!activeSession) return;
     const sec = elapsedSeconds(activeSession);
     const min = Math.floor(sec / 60);
-    const id = `s-${Date.now()}`;
     casinoSync.mutate(() => {
-      if (sec > 0) {
-        const sm = new Y.Map();
-        casinoSync.sessions.set(id, sm);
-        sm.set("subject", activeSession.subject);
-        sm.set("seconds", sec);
-        sm.set("ended_at_ms", Date.now());
-      }
+      const m = casinoSync.sessions.get(activeSession.id);
+      if (!m) return;
+      m.set("seconds", sec);
+      m.set("ended_at_ms", Date.now());
+      // Clear the in-progress fields to keep the completed entry compact.
+      m.delete("start_time_ms");
+      m.delete("paused");
+      m.delete("paused_duration_ms");
+      m.delete("pause_started_at_ms");
       if (min > 0) {
         casinoSync.balance.set("credits", currentCredits() + min);
       }
-      casinoSync.active.clear();
     });
   };
 
   const cancelSession = () => {
-    casinoSync.mutate(() => casinoSync.active.clear());
+    if (!activeSession) return;
+    casinoSync.mutate(() => casinoSync.sessions.delete(activeSession.id));
   };
 
   const editSession = (id, updates) => {
@@ -287,13 +306,16 @@ export function useCasino() {
           pm.set("at_ms", e.at);
         }
       }
-      casinoSync.active.clear();
+      // Restore active session if present (from v3 export or legacy export).
       if (data.activeSession) {
-        casinoSync.active.set("subject", data.activeSession.subject);
-        casinoSync.active.set("start_time_ms", data.activeSession.startTime);
-        casinoSync.active.set("paused", !!data.activeSession.paused);
-        casinoSync.active.set("paused_duration_ms", data.activeSession.pausedDuration ?? 0);
-        casinoSync.active.set("pause_started_at_ms", data.activeSession.pauseStartedAt ?? null);
+        const id = `active-${Date.now()}`;
+        const sm = new Y.Map();
+        casinoSync.sessions.set(id, sm);
+        sm.set("subject", data.activeSession.subject);
+        sm.set("start_time_ms", data.activeSession.startTime ?? Date.now());
+        sm.set("paused", !!data.activeSession.paused);
+        sm.set("paused_duration_ms", data.activeSession.pausedDuration ?? 0);
+        sm.set("pause_started_at_ms", data.activeSession.pauseStartedAt ?? null);
       }
     });
   };
@@ -304,7 +326,6 @@ export function useCasino() {
       casinoSync.balance.set("tokens", 0);
       casinoSync.sessions.clear();
       casinoSync.prizeLog.delete(0, casinoSync.prizeLog.length);
-      casinoSync.active.clear();
       // Prizes intentionally retained; the user re-curates the catalog.
     });
   };

--- a/x/auragon_study_casino/frontend/sw.js
+++ b/x/auragon_study_casino/frontend/sw.js
@@ -1,48 +1,19 @@
-// Study Casino service worker.
-//
-// Cache strategy:
-//   - App shell (/, /main.js, /manifest.webmanifest, /icon.svg): cache-first,
-//     so the app launches offline instantly.
-//   - /state: NETWORK-ONLY. The PWA writes to IndexedDB locally and pushes to
-//     /state; a cached GET could silently hand back stale data and defeat
-//     the whole point of having a backend for cross-device sync.
-//
-// Bump CACHE_VERSION to invalidate the shell cache on deploy. main.js content
-// hashes would be nicer but esbuild-in-Bazel doesn't emit them by default,
-// and for a single-user app a manual bump is fine.
+// Kill-switch service worker: clears all old caches and unregisters itself.
+// Offline mode is not needed; this ensures stale cached JS never shadows
+// new deploys.
 
-const CACHE_VERSION = "v1";
-const SHELL_CACHE = `study-casino-shell-${CACHE_VERSION}`;
-const SHELL_URLS = ["/", "/main.js", "/manifest.webmanifest", "/icon.svg"];
-
-self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_URLS)));
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== SHELL_CACHE).map((k) => caches.delete(k))))
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+      .then(() => {
+        return self.registration.unregister();
+      })
   );
   self.clients.claim();
-});
-
-self.addEventListener("fetch", (event) => {
-  const url = new URL(event.request.url);
-  if (url.origin !== self.location.origin) return;
-  if (url.pathname === "/state") return; // network-only
-  if (event.request.method !== "GET") return;
-
-  event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(event.request).then((response) => {
-        if (response.ok) {
-          const copy = response.clone();
-          caches.open(SHELL_CACHE).then((cache) => cache.put(event.request, copy));
-        }
-        return response;
-      });
-    })
-  );
 });

--- a/x/auragon_study_casino/test_app.py
+++ b/x/auragon_study_casino/test_app.py
@@ -137,5 +137,87 @@ def test_users_have_isolated_state(tmp_path: Path) -> None:
         assert (tmp_path / "casino-bob.db").exists()
 
 
+@pytest.fixture
+def ws_client(tmp_path: Path) -> TestClient:
+    settings = Settings(data_dir=tmp_path, frontend_dist_dir=tmp_path / "nonexistent_dist")
+    return TestClient(create_app(settings))
+
+
+def test_ws_bootstrap_on_connect(ws_client: TestClient) -> None:
+    """Server sends an 'accepted' bootstrap snapshot immediately on WS connect."""
+    with ws_client.websocket_connect("/ws") as ws:
+        msg = ws.receive_json()
+    assert msg["type"] == "accepted"
+    update = _unb64(msg["update_b64"])
+    casino = Casino.from_update(update)
+    assert int(casino.balance["credits"]) == 0
+    assert len(casino.prizes) > 0
+
+
+def test_ws_sync_accepted(ws_client: TestClient) -> None:
+    """Client pushes a credit mutation; server accepts and returns its state vector."""
+    with ws_client.websocket_connect("/ws") as ws:
+        boot = ws.receive_json()
+        casino = Casino.from_update(_unb64(boot["update_b64"]))
+        sv_before = casino.get_state()
+        casino.balance["credits"] = 42
+        ws.send_json(
+            {"type": "sync", "state_vector_b64": _b64(sv_before), "update_b64": _b64(casino.get_update(sv_before))}
+        )
+        msg = ws.receive_json()
+    assert msg["type"] == "accepted"
+    assert msg["state_vector_b64"]  # non-empty SV returned
+
+
+def test_ws_sync_rejected(ws_client: TestClient) -> None:
+    """Server rejects a sync that would make credits negative."""
+    with ws_client.websocket_connect("/ws") as ws:
+        boot = ws.receive_json()
+        casino = Casino.from_update(_unb64(boot["update_b64"]))
+        sv_before = casino.get_state()
+        casino.balance["credits"] = -1
+        ws.send_json(
+            {"type": "sync", "state_vector_b64": _b64(sv_before), "update_b64": _b64(casino.get_update(sv_before))}
+        )
+        msg = ws.receive_json()
+    assert msg["type"] == "rejected"
+    assert msg["rule"] == "credits_nonneg"
+
+
+def test_ws_server_push_to_other_tab(tmp_path: Path) -> None:
+    """When one tab syncs successfully, other tabs receive a server_push."""
+    settings = Settings(data_dir=tmp_path, frontend_dist_dir=tmp_path / "nonexistent_dist")
+    app = create_app(settings)
+    with TestClient(app) as client, client.websocket_connect("/ws") as ws1, client.websocket_connect("/ws") as ws2:
+        # Drain bootstrap messages.
+        boot1 = ws1.receive_json()
+        _ws2_boot = ws2.receive_json()
+
+        casino = Casino.from_update(_unb64(boot1["update_b64"]))
+        sv_before = casino.get_state()
+        casino.balance["credits"] = 7
+        ws1.send_json(
+            {"type": "sync", "state_vector_b64": _b64(sv_before), "update_b64": _b64(casino.get_update(sv_before))}
+        )
+        # ws1 should receive accepted; ws2 should receive server_push.
+        accepted = ws1.receive_json()
+        push = ws2.receive_json()
+
+    assert accepted["type"] == "accepted"
+    assert push["type"] == "server_push"
+    pushed_casino = Casino.from_update(_unb64(push["update_b64"]))
+    assert int(pushed_casino.balance["credits"]) == 7
+
+
+def test_ws_payload_too_large(ws_client: TestClient) -> None:
+    """Server rejects payloads larger than the 4 MiB limit."""
+    with ws_client.websocket_connect("/ws") as ws:
+        ws.receive_json()  # drain bootstrap
+        ws.send_json({"type": "sync", "state_vector_b64": "", "update_b64": "A" * (4 * 1024 * 1024 + 1)})
+        msg = ws.receive_json()
+    assert msg["type"] == "error"
+    assert msg["code"] == 413
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/x/auragon_study_casino/test_validators.py
+++ b/x/auragon_study_casino/test_validators.py
@@ -62,5 +62,26 @@ def test_negative_session_seconds_rejected() -> None:
     assert exc_info.value.rule == "session_seconds"
 
 
+def test_in_progress_session_passes() -> None:
+    casino = Casino.empty()
+    casino.sessions["active-1"] = Map()
+    casino.sessions["active-1"]["subject"] = "Biochem"
+    casino.sessions["active-1"]["start_time_ms"] = 1_700_000_000_000
+    casino.sessions["active-1"]["paused"] = False
+    casino.sessions["active-1"]["paused_duration_ms"] = 0
+    # No ended_at_ms — in-progress
+    validate(casino)  # must not raise
+
+
+def test_in_progress_session_without_start_time_rejected() -> None:
+    casino = Casino.empty()
+    casino.sessions["active-1"] = Map()
+    casino.sessions["active-1"]["subject"] = "Biochem"
+    # No start_time_ms and no ended_at_ms — malformed in-progress session
+    with pytest.raises(ValidationError) as exc_info:
+        validate(casino)
+    assert exc_info.value.rule == "session_start_time"
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/x/auragon_study_casino/tests/test_e2e_browser.py
+++ b/x/auragon_study_casino/tests/test_e2e_browser.py
@@ -1,9 +1,9 @@
 """End-to-end browser tests: real Playwright browser against real uvicorn backend.
 
 Scenarios:
-1. App loads, first sync round-trip completes, syncing banner disappears.
-2. Server returns a malformed Yjs update — status transitions to `offline`
-   (not stuck on `syncing`), exercising the Y.applyUpdate error-handling path.
+1. App loads, first WebSocket sync completes, syncing banner disappears.
+2. Server sends a malformed Yjs update over WebSocket — status transitions to
+   `offline` (not stuck on `syncing`), exercising the Y.applyUpdate error path.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from x.auragon_study_casino.app import create_app
 from x.auragon_study_casino.config import Settings
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Browser, Page, Playwright
+    from playwright.sync_api import Browser, Page, Playwright, WebSocketRoute
 
 
 @pytest.fixture
@@ -119,38 +119,39 @@ def test_initial_sync_completes(page: Page, casino_server: str) -> None:
 
 
 def test_corrupt_server_update_shows_offline_not_stuck_syncing(page: Page, casino_server: str) -> None:
-    """When /sync returns bytes that are not valid Yjs, status should transition
-    to `offline` (error message surfaced) rather than remaining stuck on `syncing`.
-    This exercises the try/catch around Y.applyUpdate in sync.js."""
+    """When the WebSocket server sends bytes that are not valid Yjs, status should
+    transition to `offline` rather than remaining stuck on `syncing`.
+    Exercises the try/catch around Y.applyUpdate in sync.js."""
     logs = _attach_logs(page)
-    sync_calls: list[str] = []
 
-    def handle_sync(route):
-        # Respond with a non-empty update_b64 whose bytes are not valid Yjs.
-        sync_calls.append("intercepted")
-        route.fulfill(
-            status=200,
-            headers={"Content-Type": "application/json"},
-            body=json.dumps(
-                {
-                    "update_b64": "bm90LXlqcy1kYXRh",  # b64("not-yjs-data")
-                    "state_vector_b64": "",
-                }
-            ),
-        )
+    def handle_ws(ws_route: WebSocketRoute) -> None:
+        # Mock the WebSocket: respond to every client message with a corrupt
+        # "accepted" payload so Y.applyUpdate always fails.
+        def on_message(message: str | bytes) -> None:
+            ws_route.send(
+                json.dumps(
+                    {
+                        "type": "accepted",
+                        "update_b64": "bm90LXlqcy1kYXRh",  # b64("not-yjs-data")
+                        "state_vector_b64": "",
+                    }
+                )
+            )
 
-    page.route("**/sync", handle_sync)
+        ws_route.on_message(on_message)
+
+    page.route_web_socket("**/ws", handle_ws)
     page.goto(casino_server)
     print(f"\n[e2e] page loaded for corrupt test, title={page.title()!r}")
 
-    # Wait for syncing banner to appear first (confirms React mounted).
+    # Wait for syncing banner to appear first (confirms React mounted and WS connected).
     page.wait_for_selector("[data-testid='sync-banner-syncing']", state="visible", timeout=15_000)
     print(f"[e2e] syncing banner appeared in corrupt test, logs so far: {logs}")
 
     page.wait_for_selector("[data-testid='sync-banner-offline']", state="visible", timeout=30_000)
-    print(f"[e2e] offline banner appeared, sync_calls={sync_calls}, logs={logs}")
+    print(f"[e2e] offline banner appeared, logs={logs}")
     assert page.locator("[data-testid='sync-banner-syncing']").count() == 0, (
-        f"syncing banner still present\nsync_calls={sync_calls}\nlogs={logs}"
+        f"syncing banner still present\nlogs={logs}"
     )
 
 

--- a/x/auragon_study_casino/validators.py
+++ b/x/auragon_study_casino/validators.py
@@ -74,23 +74,39 @@ def validate_prize_catalog_shape(casino: Casino) -> None:
 
 
 def validate_session_shape(casino: Casino) -> None:
-    """Completed sessions must have subject (str), seconds (≥0), ended_at_ms (number)."""
+    """Sessions must have a non-empty subject.
+
+    Completed sessions (ended_at_ms present) also need seconds ≥ 0.
+    In-progress sessions (no ended_at_ms) need start_time_ms.
+    """
     for sid, session in casino.sessions.items():
         subject = session.get("subject")
         seconds = session.get("seconds")
         ended_at = session.get("ended_at_ms")
+        start_time = session.get("start_time_ms")
+
         if not isinstance(subject, str) or not subject:
             raise ValidationError(
                 rule="session_subject", message=f"session {sid!r} subject {subject!r} not a non-empty string"
             )
-        if not isinstance(seconds, (int, float)) or seconds < 0:
-            raise ValidationError(
-                rule="session_seconds", message=f"session {sid!r} seconds {seconds!r} not a non-negative number"
-            )
-        if not isinstance(ended_at, (int, float)):
-            raise ValidationError(
-                rule="session_ended_at", message=f"session {sid!r} ended_at_ms {ended_at!r} not a number"
-            )
+
+        if ended_at is None:
+            # In-progress session — must have a numeric start time.
+            if not isinstance(start_time, (int, float)):
+                raise ValidationError(
+                    rule="session_start_time",
+                    message=f"in-progress session {sid!r} start_time_ms {start_time!r} not a number",
+                )
+        else:
+            # Completed session — must have seconds ≥ 0 and numeric ended_at_ms.
+            if not isinstance(seconds, (int, float)) or seconds < 0:
+                raise ValidationError(
+                    rule="session_seconds", message=f"session {sid!r} seconds {seconds!r} not a non-negative number"
+                )
+            if not isinstance(ended_at, (int, float)):
+                raise ValidationError(
+                    rule="session_ended_at", message=f"session {sid!r} ended_at_ms {ended_at!r} not a number"
+                )
 
 
 ALL_VALIDATORS = (validate_credits_nonneg, validate_tokens_nonneg, validate_prize_catalog_shape, validate_session_shape)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **WebSocket sync**: replaces HTTP polling (POST /sync every 30s) with a persistent `/ws` WebSocket. Server sends an initial bootstrap snapshot on connect and fans out the full canonical state to all other connected tabs when any tab syncs successfully — enabling real-time multi-tab updates.

- **Active session in sessions map**: an in-progress session is now a regular entry in the `sessions` Y.Map with no `ended_at_ms`, rather than a separate `active` Y.Map. A one-time migration runs on first load to move any existing active session data over.

- **Fix lost-session bug**: the UndoManager undo stack is cleared after every successful sync. A 409 rejection from the server now only rolls back changes made *since* the last sync, preventing previously-synced session starts from being erased by later unrelated rejections.

- **Console debug logging**: `console.debug("[CasinoSync] ...")` throughout `sync.js` for easier browser DevTools debugging.

- **Remove stale service worker caching**: the user doesn't need offline use and the SW was causing stale `main.js` to be served after new deploys. `sw.js` is now a kill switch that clears all old caches and self-unregisters; `main.jsx` also proactively unregisters any existing SW on load.

- **Validator updated**: `validate_session_shape` now allows in-progress sessions (no `ended_at_ms`, requires `start_time_ms`); completed sessions are unchanged.

## Test plan

- [ ] All Python tests pass (`bbr test //x/auragon_study_casino/...`)
- [ ] Browser DevTools → Console shows `[CasinoSync]` debug messages
- [ ] Starting a session, letting it sync, then doing an invalid action — session is not lost on rejection
- [ ] Opening two tabs: syncing in one tab pushes the update to the other tab via server_push
- [ ] Old service worker cache is cleared on first load (no stale JS)

https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aUpronywSRzfGSPw6FzgY)_