### PR TITLE
fix(tf): bump authentik provider to ~> 2026.2 to match server version

### DIFF
--- a/tf/gitops/sso-providers/BUILD.bazel
+++ b/tf/gitops/sso-providers/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 tf_providers_versions(
     name = "providers",
     providers = {
-        "authentik": "goauthentik/authentik:~>2025.10",
+        "authentik": "goauthentik/authentik:~>2026.2",
         "kubernetes": "hashicorp/kubernetes:~>2.35",
         "random": "hashicorp/random:~>3.6",
     },

--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     authentik = {
       source  = "goauthentik/authentik"
-      version = "~> 2025.10"
+      version = "~> 2026.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Problem

The Authentik server is running 2026.2.1 but the TF provider was locked to `~> 2025.10`.

`authentik_rbac_permission_role` in the 2025.10 provider calls:
```
POST /api/v3/rbac/permissions/assigned_by_roles/{role_id}/assign/
```
The 2026.2 server returns `405 Method Not Allowed` — either the URL uses hyphens (`assigned-by-roles`) rather than underscores, or the endpoint structure changed between versions.

The Authentik provider uses calendar versioning intended to match the server. The constraint should track the running server version.

## Fix

Pin `~> 2026.2` in both `BUILD.bazel` and `main.tf`.

## Context

This is a follow-on to #1416. That PR switched from the broken `authentik_rbac_permission_user` (no-op since 2026.1, broken retrieve endpoint in 2025.10) to `authentik_rbac_permission_role`. This PR fixes the 405 those role permission resources encounter against a 2026.2 server.

https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b)_