### PR TITLE
Allow claude-sandbox to reach Authentik API

### DIFF
--- a/cluster/k8s/authentik/app/networkpolicy.yaml
+++ b/cluster/k8s/authentik/app/networkpolicy.yaml
@@ -78,3 +78,13 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
+
+    # claude-sandbox: Claude agent reads Authentik API (events, apps, users,
+    # outposts, flows, policies) via AUTHENTIK_API_TOKEN loaded at session start
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-sandbox
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds `claude-sandbox` namespace to the `authentik-server-ingress` CiliumNetworkPolicy
- Claude agent sessions load `AUTHENTIK_API_TOKEN` at startup and call the Authentik API for read-only diagnostics (events, apps, users, outposts, flows, policies)
- Previously `claude-sandbox` was absent from the allowlist, so all API calls from session pods were silently dropped

## Test plan

- [ ] Flux reconciles the updated `CiliumNetworkPolicy` without errors
- [ ] A claude-sandbox pod can reach `http://authentik-server.authentik.svc.cluster.local/api/v3/root/config/` with the API token

https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvq32f4nDe5atYh5DAHL6b)_