### PR TITLE
codex_cloud: persist Nix PATH, track remote devel branch, fix shell init, and document env passing

### DIFF
--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -46,7 +46,7 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
 2. Installs Nix (Determinate installer) if missing.
 3. Installs the repo `.#devtools` profile.
 4. Installs repo pre-commit Git hooks (`pre-commit install --install-hooks`).
-5. Persists nix profile sourcing in `~/.bashrc` and ensures `~/.bash_profile` sources `~/.bashrc`, so login and interactive shells get Nix tools on `PATH` once.
+5. Persists nix profile sourcing in `~/.bashrc`, prepends Nix profile bins on `PATH` (so Nix-provided tooling like Prettier wins over user-level installs), and ensures `~/.bash_profile` sources `~/.bashrc`.
 6. Decrypts BuildBuddy API key from SOPS (when possible) and runs `devinfra/setup_buildbuddy.sh`.
 7. Configures BuildBuddy remote selection:
    - uses `origin` when it already points directly to GitHub
@@ -56,7 +56,7 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
    - `~/.config/bazel/bbr.bazelrc` for BuildBuddy metadata (`ROLE`, session tag)
    - `~/.config/bazel/codex.bazelrc` with `try-import` wiring for BuildBuddy + bbr metadata
    - `~/.bazelrc` `try-import` entry for `~/.config/bazel/codex.bazelrc`
-9. Ensures local `devel` branch exists (from `github-no-proxy/devel` or `origin/devel` when available) so `bbr` base-branch detection works.
+9. Ensures local `devel` branch exists and tracks a remote `devel` branch (preferring the selected BuildBuddy remote, with fallback to `origin/devel` or `github-no-proxy/devel`) so `bbr` base-branch detection works.
 10. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
 11. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
 
@@ -88,4 +88,40 @@ pre-commit hooks, then validates `bb` / `bbr` availability.
 
 ```bash
 bash -n devinfra/codex_cloud/setup.sh
+```
+
+## Passing env vars in Codex command runs
+
+In this Codex execution environment, each command runs in a fresh non-login
+shell process. That means:
+
+- `export FOO=bar` in one command does **not** persist to the next command.
+- `~/.bashrc` updates are persisted to disk, but are not automatically loaded by
+  subsequent command executions.
+
+Practical implication: pass required env vars per command invocation (or via a
+wrapper script that sets env and executes the command) rather than relying on a
+previous command's `export`.
+
+Examples:
+
+```bash
+# One-off per command
+SOPS_AGE_KEY="$SOPS_AGE_KEY" bbr test //path/to:target
+
+# Multiple vars, single invocation
+BUILDBUDDY_API_KEY="$BUILDBUDDY_API_KEY" \
+BBR_BAZELRC="$HOME/.config/bazel/bbr.bazelrc" \
+bbr build //devinfra:bbr
+
+# Wrapper script pattern
+cat > /tmp/run-with-env.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+export BBR_BAZELRC="$HOME/.config/bazel/bbr.bazelrc"
+export SESSION_BAZELRC="$HOME/.config/bazel/codex.bazelrc"
+exec "$@"
+EOF
+chmod +x /tmp/run-with-env.sh
+/tmp/run-with-env.sh bbr test //devinfra:all
 ```

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -34,7 +34,13 @@ SOPS_RUNTIME_READY=0
 ensure_line() {
   local line="$1"
   local file="$2"
-  grep -Fqx "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
+  if grep -Fqx "$line" "$file" 2>/dev/null; then
+    return 0
+  fi
+  if [ -s "$file" ] && [ "$(tail -c1 "$file" 2>/dev/null || true)" != "" ]; then
+    echo >>"$file"
+  fi
+  echo "$line" >>"$file"
 }
 
 init_sops_runtime_prereqs() {
@@ -99,15 +105,26 @@ reconcile_buildbuddy_remote() {
 
 ensure_bbr_base_branch() {
   # bbr expects a local `devel` branch reference for base-branch calculations.
-  if git rev-parse --verify devel >/dev/null 2>&1; then
-    return 0
+  # Prefer tracking the selected BuildBuddy remote's devel branch.
+  local preferred_remote
+  preferred_remote="$(git config --get buildbuddy.remote-bazel-remote-name || true)"
+  if [ -z "$preferred_remote" ]; then
+    preferred_remote="origin"
   fi
 
   local remote_ref=""
-  if git show-ref --verify --quiet refs/remotes/github-no-proxy/devel; then
-    remote_ref="github-no-proxy/devel"
-  elif git show-ref --verify --quiet refs/remotes/origin/devel; then
+  if git ls-remote --exit-code --heads "$preferred_remote" devel >/dev/null 2>&1; then
+    git fetch "$preferred_remote" devel >/dev/null 2>&1 || true
+    if git show-ref --verify --quiet "refs/remotes/${preferred_remote}/devel"; then
+      remote_ref="${preferred_remote}/devel"
+    fi
+  fi
+
+  if [ -z "$remote_ref" ] && git show-ref --verify --quiet refs/remotes/origin/devel; then
     remote_ref="origin/devel"
+  fi
+  if [ -z "$remote_ref" ] && git show-ref --verify --quiet refs/remotes/github-no-proxy/devel; then
+    remote_ref="github-no-proxy/devel"
   fi
 
   if [ -z "$remote_ref" ]; then
@@ -115,8 +132,21 @@ ensure_bbr_base_branch() {
     return 0
   fi
 
-  git branch devel "$remote_ref" >/dev/null 2>&1 || true
-  log "created local 'devel' branch from ${remote_ref} for bbr compatibility"
+  local existing_upstream=""
+  existing_upstream="$(git for-each-ref --format='%(upstream:short)' refs/heads/devel 2>/dev/null || true)"
+
+  if git rev-parse --verify devel >/dev/null 2>&1; then
+    if [ "$existing_upstream" = "$remote_ref" ]; then
+      log "local 'devel' branch already tracks ${remote_ref}"
+      return 0
+    fi
+    git branch --set-upstream-to="$remote_ref" devel >/dev/null 2>&1 || true
+    log "configured local 'devel' branch to track ${remote_ref}"
+    return 0
+  fi
+
+  git branch --track devel "$remote_ref" >/dev/null 2>&1 || git branch devel "$remote_ref" >/dev/null 2>&1 || true
+  log "created local 'devel' branch tracking ${remote_ref} for bbr compatibility"
 }
 
 install_nix_if_missing() {
@@ -197,6 +227,7 @@ persist_agent_shell_init() {
   if [ -f "$NIX_DAEMON_PROFILE_SH" ]; then
     log "persisting nix-daemon profile sourcing into ~/.bashrc"
     ensure_line ". ${NIX_DAEMON_PROFILE_SH}" "$shell_file"
+    ensure_line 'export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"' "$shell_file"
   fi
 
   if [ -n "${SOPS_AGE_KEY:-}" ]; then
@@ -248,6 +279,7 @@ case "$MODE" in
     log "refreshing git remotes"
     git fetch --all --prune
     run_common_setup_steps
+    persist_agent_shell_init
     validate_core_tools
     ;;
   *)


### PR DESCRIPTION
### Motivation

- Ensure Nix-provided tooling (e.g. Prettier) wins over user-level installs by prepending Nix profile bins to `PATH` in persisted shell init.
- Make `bbr` base-branch detection more robust by creating a local `devel` branch that tracks the appropriate remote (prefer the selected BuildBuddy remote).
- Fix stray-line and newline handling when appending lines into shell files to avoid malformed shell startup files.
- Document how environment variables are (not) persisted across Codex Cloud command invocations and show practical invocation patterns.

### Description

- Updated `devinfra/codex_cloud/README.md` to note Nix PATH precedence, added a new section explaining that each Codex command runs in a fresh shell and gave example invocation patterns for passing env vars.
- Hardened `ensure_line()` in `devinfra/codex_cloud/setup.sh` to avoid duplicate entries and to ensure a newline is inserted before appending when the file does not end with one.
- Extended `ensure_bbr_base_branch()` to prefer the BuildBuddy-configured remote, fetch the remote `devel` ref, and create/configure a local `devel` branch that tracks the chosen remote branch.
- Persisted Nix profile bins precedence by adding `export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"` into `~/.bashrc` and ensured `persist_agent_shell_init` is invoked during `--mode=maintenance` as well.

### Testing

- Ran a syntax check with `bash -n devinfra/codex_cloud/setup.sh` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef40d7611c83318baa2407106a6b47)