### PR TITLE
Persist `BUILDBUDDY_API_KEY` into agent shell startup and update docs

### DIFF
--- a/devinfra/codex_cloud/README.md
+++ b/devinfra/codex_cloud/README.md
@@ -58,7 +58,7 @@ session and recommend `~/.bashrc` for persistence into the agent phase.
    - `~/.bazelrc` `try-import` entry for `~/.config/bazel/codex.bazelrc`
 9. Ensures local `devel` branch exists and tracks a remote `devel` branch (preferring the selected BuildBuddy remote, with fallback to `origin/devel` or `github-no-proxy/devel`) so `bbr` base-branch detection works.
 10. Materializes `~/.kube/config` from `secrets/claude-web-k8s-jwt.yaml` via the Nix-managed Python interpreter (`~/.nix-profile/bin/python3 devinfra/k8s/kubeconfig.py`) so `pyyaml` is present consistently.
-11. Persists `SOPS_AGE_KEY`, Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells rehydrate `BUILDBUDDY_API_KEY` and use the generated bazelrc files.
+11. Persists `SOPS_AGE_KEY`, `BUILDBUDDY_API_KEY` (when available during setup), Bazel env vars (`BBR_BAZELRC`, `SESSION_BAZELRC`), and runtime `web_env.sh` sourcing into shell startup files so agent command shells can use BuildBuddy + generated bazelrc files.
 
 Maintenance refreshes git remotes, BuildBuddy config, devtools profile, and
 pre-commit hooks, then validates `bb` / `bbr` availability.

--- a/devinfra/codex_cloud/setup.sh
+++ b/devinfra/codex_cloud/setup.sh
@@ -237,6 +237,13 @@ persist_agent_shell_init() {
     log "SOPS_AGE_KEY not set (expected unless configured in Codex environment vars)"
   fi
 
+  if [ -n "${BUILDBUDDY_API_KEY:-}" ]; then
+    log "persisting BUILDBUDDY_API_KEY into ~/.bashrc for agent shells"
+    ensure_line "export BUILDBUDDY_API_KEY='${BUILDBUDDY_API_KEY}'" "$shell_file"
+  else
+    log "BUILDBUDDY_API_KEY not set at setup time; runtime sourcing will be used when possible"
+  fi
+
   log "persisting runtime secret hydration and bazel env into ~/.bashrc"
   ensure_line "[ -n \"\${SOPS_AGE_KEY:-}\" ] && [ -f \"${REPO_ROOT}/devinfra/secrets/web_env.sh\" ] && source \"${REPO_ROOT}/devinfra/secrets/web_env.sh\" >/dev/null 2>&1 || true" "$shell_file"
   ensure_line "export BBR_BAZELRC='${BBR_BAZELRC_PATH}'" "$shell_file"


### PR DESCRIPTION
### Motivation
- Ensure the BuildBuddy API key (when available at setup time) is propagated into agent command shells so BuildBuddy tooling can authenticate and use the generated bazelrc files.

### Description
- Added logic in `persist_agent_shell_init` to persist `BUILDBUDDY_API_KEY` into `~/.bashrc` (with logging and a fallback log when the key is not present) and updated `devinfra/codex_cloud/README.md` to reflect that `BUILDBUDDY_API_KEY` may be persisted during setup.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01d25a7d08331867bacb1e70971fd)