### PR TITLE
docs: warn that bb ignores the per-session bazelrc on local runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,24 @@ bbr query '...'
 bb run --remote_executor="" //devinfra:gazelle
 ```
 
+**`bb` ignores the session bazelrc; use `bazelisk` for local runs that need it.**
+The Claude Code session start hook writes per-session Bazel config (JVM
+truststore startup args, RBE headers, etc.) to
+`<session_dir>/bazelrc`. The `bazelisk` shim auto-injects
+`--bazelrc=<session_dir>/bazelrc`; the `bb` shim does **not**. `bb` also
+passes `--nohome_rc --noworkspace_rc --nosystem_rc` and reconstructs
+the workspace `.bazelrc` flags itself, but it never sources the session
+bazelrc. If the invocation requires the session config — e.g. fetching
+new external repos through TLS-inspected egress — `bb` will start a fresh
+Bazel server without the truststore and fail with
+`TLS error: (certificate_unknown) PKIX path building failed` against
+`bcr.bazel.build` and friends. Cached invocations look fine because they
+piggyback on the warmed-up `bazelisk` server, but the moment the server
+restarts (option mismatch, idle timeout, fresh repo fetch) you get cert
+errors. For local-only execution that needs session config, use
+`bazelisk run //target -- ...`. RBE-bound work (`bbr ...`) is unaffected
+because runner VMs don't depend on the session truststore.
+
 **Updating `requirements_bazel.txt`**: `bb run --remote_executor="" //:requirements.update`
 fails on NixOS (no `/bin/bash`). Use RBE instead:
 


### PR DESCRIPTION
## Summary

- The `bazelisk` shim auto-injects `--bazelrc=<session_dir>/bazelrc`; the `bb` shim does not. Verified by `strace` on this CLI session — `bazelisk`'s child `bazel` carries the session truststore host args, `bb`'s does not.
- Because startup options no longer match the warmed-up `bazelisk` server, `bb` kills+restarts it without `-Djavax.net.ssl.trustStore=...`. Any `bb` invocation that fetches a new external repo through TLS-inspected egress then fails with `PKIX path building failed` against `bcr.bazel.build` (and similar). Cached work works fine until the server next restarts.
- Recommendation in `AGENTS.md` "Bazel Commands": use `bazelisk run` for local-only execution that needs session config. `bbr` is unaffected (RBE runner VMs don't need the session truststore).

## Test plan

- [ ] `pre-commit run --all-files` (docs-only change; commit-msg hook tagged `BAZEL_TEST_INVOCATIONS=none: documentation-only change`)

https://claude.ai/code/session_01X3hqE8H5JihGJj1NvkuTL6


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3hqE8H5JihGJj1NvkuTL6)_