### PR TITLE
re_rollout: move task framing out of system prompt into first user message

### DIFF
--- a/skills/eval_infra/eval_prompt.py
+++ b/skills/eval_infra/eval_prompt.py
@@ -1,8 +1,11 @@
 """Shared assembly of skill-eval system prompts.
 
-`compose_system_prompt` joins four pieces with `\\n\\n---\\n\\n` separators:
+`compose_system_prompt` joins up to four pieces with `\\n\\n---\\n\\n`
+separators:
 
-1. An eval-specific preamble (what task is being performed).
+1. An optional eval-specific preamble (what task is being performed).
+   Some evals (RE) put task framing entirely in the first user message
+   instead, so the preamble is omitted from the system prompt.
 2. A skill block — generic skill-intro line + inlined SKILL.md + a one-line
    pointer at the in-container skill mount (always `SKILL_PATH`; the
    off-arm of a mounted-skill rollout uses the empty-skill tar so the
@@ -15,7 +18,7 @@
 4. Optional eval-specific tool guidance (game tools, submit, etc.).
 
 Used by TQ's `build_guesser_system`, FL's `build_system_prompt`, and RE's
-`_build_system_prompt` to give every eval the same skill-block + exec-note
+`re_rollout._async_main` to give every eval the same skill-block + exec-note
 shape.
 """
 
@@ -31,14 +34,18 @@ _EXEC_TOOL_NOTE = (
 )
 
 
-def compose_system_prompt(*, preamble: str, skill_md: str, tool_guidance: str | None) -> str:
+def compose_system_prompt(*, preamble: str | None = None, skill_md: str, tool_guidance: str | None = None) -> str:
     """See module docstring."""
     skill_block = (
         f"{_SKILL_INTRO}\n\n<skill>\n{skill_md}\n</skill>\n\n"
         f"The full skill (SKILL.md and any referenced example files) is available in the "
         f"container at {SKILL_PATH}/."
     )
-    parts: list[str] = [preamble, skill_block, _EXEC_TOOL_NOTE]
+    parts: list[str] = []
+    if preamble is not None:
+        parts.append(preamble)
+    parts.append(skill_block)
+    parts.append(_EXEC_TOOL_NOTE)
     if tool_guidance is not None:
         parts.append(tool_guidance)
     return "\n\n---\n\n".join(parts)

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -78,31 +78,20 @@ class RunSummary(BaseModel):
 _TARGET_PATH = INPUT_PATH / "target"
 
 
-_RE_PREAMBLE = (
-    f"You are reverse-engineering a stripped Go binary located at {_TARGET_PATH}.\n"
-    f"Recover its source as Go files under {WORK_PATH}/ (your working directory)."
-)
-
-_RE_TOOL_GUIDANCE = (
-    "When you have gone as far as you can, call `submit` with a one-paragraph summary "
-    "of what the program does and which parts you are confident vs unsure about."
-)
-
-
-def _build_system_prompt(*, skill_md_text: str) -> str:
-    """Compose the RE system prompt via the shared scaffold.
-
-    `skill_md_text` is inlined verbatim. The off-arm passes an empty string
-    (the empty-skill tar's SKILL.md is blank), keeping the sandbox shape
-    uniform across arms.
-    """
-    return compose_system_prompt(preamble=_RE_PREAMBLE, skill_md=skill_md_text, tool_guidance=_RE_TOOL_GUIDANCE)
-
-
+# All RE-specific task framing lives in the first user message — the system
+# prompt carries only the shared skill block + exec-tool note from
+# `compose_system_prompt`. Wall-clock and per-turn budgets are enforced by
+# the harness (asyncio.wait_for around agent.run; AF caps consecutive tool
+# calls) and are NOT disclosed to the agent to avoid biasing it toward
+# early submission.
 _FIRST_USER_MESSAGE = (
-    f"Reverse-engineer the binary at {_TARGET_PATH}. Recover its source as Go files under "
-    f"{WORK_PATH}/. You have a 10-minute wall-clock budget and at most {_DEFAULT_MAX_STEPS} turns. "
-    "When done, call `submit` with a one-paragraph summary."
+    f"Reverse-engineer the stripped Go binary at {_TARGET_PATH} into a complete, "
+    f"human-readable Go source tree under {WORK_PATH}/ (your working directory). "
+    "The recovered source should compile and be behaviorally equivalent to the binary — "
+    "same protocol, same endpoints, same crypto/encoding/MAC/storage semantics — not "
+    "stubs, placeholders, or TODOs. Pick reasonable, idiomatic Go names where the "
+    "binary's were obfuscated. When done, call `submit` with a one-paragraph summary "
+    "noting which parts you are confident vs unsure about."
 )
 
 
@@ -149,7 +138,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     shutil.copy(get_required_path(_TARGET_BINARY_RLOCATION), inputs_dir / "target")
 
     staged = stage_skill(_SKILL_BY_ARM[args.skill], out_dir / f"skill_extract_{suffix}")
-    system_prompt = _build_system_prompt(skill_md_text=staged.md_text)
+    system_prompt = compose_system_prompt(skill_md=staged.md_text)
 
     submit_state = _SubmitState()
     submit_tool = _make_submit_tool(submit_state)


### PR DESCRIPTION
## Summary

Rewrites the RE rollout's prompt structure so that all eval-specific task framing — what the binary is, what to produce, the quality bar, the submit hand-off — lives in the first user message. The system prompt becomes just the shared skill block + exec-tool note from `compose_system_prompt`.

**Concrete changes:**

1. `compose_system_prompt`: `preamble` becomes optional (`str | None = None`); when `None`, it's omitted entirely. `tool_guidance` was already optional.
2. `re_rollout`: drops `_RE_PREAMBLE`, `_RE_TOOL_GUIDANCE`, and the trivial `_build_system_prompt` wrapper; calls `compose_system_prompt(skill_md=...)` directly.
3. **First user message:**
   - Drops the *"10-minute wall-clock budget and at most 1000 turns"* disclosure. Both numbers are enforced by the harness (`asyncio.wait_for` around `agent.run`; AF `max_iterations`) and shouldn't leak into the prompt — they bias the agent toward early submission and tie the prompt to the harness's *default* values, even though both are CLI-configurable.
   - Demands *"a complete, human-readable Go source tree"* that compiles and is behaviorally equivalent to the binary (same protocol, same endpoints, same crypto/encoding/MAC/storage semantics) — *not* stubs, placeholders, or TODOs. Requests idiomatic Go names where the binary's were obfuscated.
   - Folds in the "stripped Go binary" + "(your working directory)" details that previously lived in the system preamble.

The first Haiku 4.5 rollout (skill on, 600 s budget) submitted at 84.7 s with handler stubs returning `"ok"`; both the no-budget and quality-bar edits target that failure mode.

Other `compose_system_prompt` callers (TQ, FL) are unaffected — they pass `preamble=...` explicitly.

## Test plan

- [ ] No Bazel targets affected — `BAZEL_TEST_INVOCATIONS=none` in the commit. Manual verification: re-run the rollout and confirm:
  - The system prompt no longer leads with "You are reverse-engineering a stripped Go binary..."
  - The first user message demands non-stubbed equivalent source and doesn't mention budgets.

https://claude.ai/code/session_01X3hqE8H5JihGJj1NvkuTL6
