### PR TITLE
re_eval: enable Anthropic strict tool calling + detailed tool-arg errors

### DIFF
--- a/mcp_infra/exec/BUILD.bazel
+++ b/mcp_infra/exec/BUILD.bazel
@@ -313,6 +313,19 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_exec_input_schema",
+    srcs = ["test_exec_input_schema.py"],
+    deps = [
+        ":docker",
+        ":docker_types",
+        ":models",
+        "@pypi//pydantic",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 live_openai_py_test(
     name = "test_exec_roundtrip",
     srcs = ["test_exec_roundtrip.py"],

--- a/mcp_infra/exec/docker/server.py
+++ b/mcp_infra/exec/docker/server.py
@@ -9,12 +9,12 @@ FastMCP server: per-session Docker container exec.
 from __future__ import annotations
 
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Annotated, Any
 
 import aiodocker
 import mcp.types as mcp_types
 from fastmcp.server.context import Context
-from pydantic import Field, create_model
+from pydantic import Field, WithJsonSchema, create_model
 
 from mcp_infra.enhanced.server import EnhancedFastMCP
 from mcp_infra.exec.docker.container_session import (
@@ -90,7 +90,13 @@ def _make_exec_input_model(*, allow_user: bool, allow_env: bool, cwd_policy: Cwd
             ),
         ),
         "timeout_ms": (
-            TimeoutMs,
+            # ``TimeoutMs`` is ``Annotated[int, Field(gt=0, le=MAX_EXEC_TIMEOUT_MS)]``,
+            # which lands in the JSON Schema as ``exclusiveMinimum`` / ``maximum``.
+            # Anthropic's strict tool-use mode rejects integer constraints
+            # (``"For 'integer' type, properties exclusiveMinimum, maximum are not
+            # supported"``), so we override the schema to a plain ``{"type": "integer"}``
+            # while keeping the Pydantic runtime validators that ``TimeoutMs`` carries.
+            Annotated[TimeoutMs, WithJsonSchema({"type": "integer"})],
             Field(description="Timeout in milliseconds; sends TERM (exit status becomes TimedOut)"),
         ),
     }

--- a/mcp_infra/exec/test_exec_input_schema.py
+++ b/mcp_infra/exec/test_exec_input_schema.py
@@ -1,0 +1,63 @@
+"""Schema-shape and runtime-validation tests for the exec MCP tool's input model.
+
+The exec input model wraps ``timeout_ms`` in
+``Annotated[TimeoutMs, WithJsonSchema({"type": "integer"})]`` so the Pydantic
+runtime validators on ``TimeoutMs`` (``gt=0`` / ``le=MAX_EXEC_TIMEOUT_MS``) keep
+firing while the JSON Schema sent to Anthropic stays free of the integer-bound
+keys (``exclusiveMinimum`` / ``maximum``) that Anthropic strict tool-use mode
+rejects with ``"For 'integer' type, properties exclusiveMinimum, maximum are
+not supported"``. These tests pin both halves of that contract.
+"""
+
+from pathlib import Path
+
+import pytest
+import pytest_bazel
+from pydantic import ValidationError
+
+from mcp_infra.exec.docker.server import _make_exec_input_model
+from mcp_infra.exec.docker.types import AlwaysSetTo
+from mcp_infra.exec.models import MAX_EXEC_TIMEOUT_MS
+
+
+@pytest.fixture
+def exec_input_cls() -> type:
+    return _make_exec_input_model(allow_user=False, allow_env=False, cwd_policy=AlwaysSetTo(value=Path("/work")))
+
+
+def test_timeout_ms_schema_omits_integer_bounds(exec_input_cls: type) -> None:
+    """Anthropic strict mode rejects exclusiveMinimum/maximum on integer types."""
+    schema = exec_input_cls.model_json_schema()
+    timeout_schema = schema["properties"]["timeout_ms"]
+    assert timeout_schema["type"] == "integer"
+    for forbidden in ("exclusiveMinimum", "exclusiveMaximum", "minimum", "maximum"):
+        assert forbidden not in timeout_schema, f"{forbidden} leaks into the strict-mode tool schema: {timeout_schema}"
+
+
+def test_timeout_ms_schema_is_strict_mode_compatible(exec_input_cls: type) -> None:
+    """The full input schema must be strict-mode-compatible for Anthropic strict tool use."""
+    schema = exec_input_cls.model_json_schema()
+    assert schema.get("additionalProperties") is False
+    # Both required fields land in `required` (OpenAIStrictModeBaseModel's contract).
+    assert set(schema["required"]) >= {"cmd", "timeout_ms"}
+
+
+def test_timeout_ms_runtime_rejects_zero(exec_input_cls: type) -> None:
+    """gt=0 still fires at validation time even though it's hidden from the schema."""
+    with pytest.raises(ValidationError):
+        exec_input_cls(cmd=["true"], timeout_ms=0)
+
+
+def test_timeout_ms_runtime_rejects_above_max(exec_input_cls: type) -> None:
+    """le=MAX_EXEC_TIMEOUT_MS still fires at validation time."""
+    with pytest.raises(ValidationError):
+        exec_input_cls(cmd=["true"], timeout_ms=MAX_EXEC_TIMEOUT_MS + 1)
+
+
+def test_timeout_ms_runtime_accepts_in_range(exec_input_cls: type) -> None:
+    instance = exec_input_cls(cmd=["true"], timeout_ms=1000)
+    assert instance.timeout_ms == 1000
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/skills/eval_infra/af_chat_client.py
+++ b/skills/eval_infra/af_chat_client.py
@@ -5,8 +5,20 @@ applied at construction time so callers don't have to mutate the client
 afterwards. AF chat clients have no `close()` / async context manager
 hooks (verified against the Anthropic / OpenAI / Base classes); the
 underlying SDK clients are released by Python's GC at process exit.
+
+`strict_tools=True` engages Anthropic's grammar-constrained sampling for
+tool calls (https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use):
+``strict: true`` is set on every custom tool definition the client
+sends. AF's stock `_prepare_tools_for_anthropic` doesn't emit it, so we
+subclass and post-process. Tool input schemas must already be
+strict-compatible (``additionalProperties: false``, all fields in
+``required``); use ``OpenAIStrictModeBaseModel`` from
+``openai_utils.pydantic_strict_mode`` as the input model base. The
+schema constraint is the same one OpenAI structured outputs uses, hence
+the shared base class.
 """
 
+from collections.abc import Mapping
 from typing import Any
 
 from agent_framework import BaseChatClient, FunctionInvocationConfiguration
@@ -14,14 +26,40 @@ from agent_framework.anthropic import AnthropicClient
 from agent_framework.openai import OpenAIChatCompletionClient
 
 
+class _StrictAnthropicClient(AnthropicClient):
+    """AnthropicClient that turns on Anthropic's strict tool-use mode.
+
+    Stock AF emits tools as ``{"type": "custom", "name": ..., "input_schema": ...}``
+    without ``strict``; we walk the prepared tool list and inject
+    ``"strict": True`` on every custom entry. Server-side tools (web_search,
+    code_execution, etc.) are not affected.
+    """
+
+    def _prepare_tools_for_anthropic(self, options: Mapping[str, Any]) -> dict[str, Any] | None:
+        result = super()._prepare_tools_for_anthropic(options)
+        if result is None:
+            return None
+        for tool in result.get("tools") or []:
+            if isinstance(tool, dict) and tool.get("type") == "custom":
+                tool["strict"] = True
+        return result
+
+
 def build_model_client(
-    *, api: str, model: str, function_invocation_configuration: FunctionInvocationConfiguration | None = None
+    *,
+    api: str,
+    model: str,
+    function_invocation_configuration: FunctionInvocationConfiguration | None = None,
+    strict_tools: bool = False,
 ) -> BaseChatClient[Any]:
     kwargs: dict[str, Any] = {"model": model}
     if function_invocation_configuration is not None:
         kwargs["function_invocation_configuration"] = function_invocation_configuration
     if api == "openai":
+        if strict_tools:
+            raise ValueError("strict_tools=True is only wired for the Anthropic adapter so far.")
         return OpenAIChatCompletionClient(**kwargs)
     if api == "anthropic":
-        return AnthropicClient(**kwargs)
+        cls = _StrictAnthropicClient if strict_tools else AnthropicClient
+        return cls(**kwargs)
     raise ValueError(f"Unsupported API: {api!r}")

--- a/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
+++ b/skills/reverse_engineer/evals/runs/agent_framework/BUILD.bazel
@@ -5,6 +5,7 @@ py_binary(
     srcs = ["re_rollout.py"],
     data = ["//skills/reverse_engineer/evals/specimens/go_crypto_server:go_crypto_server_garbled"],
     deps = [
+        "//openai_utils:pydantic_strict_mode",
         "//skills/eval_infra:af_chat_client",
         "//skills/eval_infra:eval_prompt",
         "//skills/eval_infra:eval_sandbox",

--- a/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/runs/agent_framework/re_rollout.py
@@ -35,10 +35,11 @@ from pathlib import Path
 from typing import Literal
 
 from agent_framework import Agent, AgentSession, FunctionTool, Message
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
 
+from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 from skills.eval_infra.af_chat_client import build_model_client
 from skills.eval_infra.eval_prompt import compose_system_prompt
 from skills.eval_infra.eval_sandbox import INPUT_PATH, WORK_PATH, eval_sandbox
@@ -102,6 +103,15 @@ class _SubmitState:
     summary: str | None = None
 
 
+# Strict-mode-compatible input schema (additionalProperties: false, summary
+# in `required`) so the submit tool can ride alongside `exec` under
+# Anthropic's grammar-constrained tool-use mode. Without this, AF's
+# default schema-from-signature would emit a non-strict shape and the
+# whole request would 400 once strict mode is engaged.
+class _SubmitInput(OpenAIStrictModeBaseModel):
+    summary: str = Field(description="One-paragraph summary noting which parts you are confident vs unsure about.")
+
+
 def _make_submit_tool(state: _SubmitState) -> FunctionTool:
     async def submit(summary: str) -> str:
         """Mark the rollout complete with a final summary."""
@@ -110,10 +120,9 @@ def _make_submit_tool(state: _SubmitState) -> FunctionTool:
 
     return FunctionTool(
         name="submit",
-        description=(
-            "Call when reverse engineering is complete (or you are stuck). Pass a one-paragraph summary of the program."
-        ),
+        description="Call when reverse engineering is complete (or you are stuck).",
         func=submit,
+        input_model=_SubmitInput,
     )
 
 
@@ -144,7 +153,25 @@ async def _async_main(args: argparse.Namespace) -> None:
     submit_tool = _make_submit_tool(submit_state)
 
     model_client = build_model_client(
-        api="anthropic", model=args.model, function_invocation_configuration={"max_iterations": args.max_steps}
+        api="anthropic",
+        model=args.model,
+        function_invocation_configuration={
+            "max_iterations": args.max_steps,
+            # AF defaults to a terse "Error: Argument parsing failed." for tool-arg
+            # validation errors, stashing the actual reason on Content.exception
+            # but never relaying it to the model. Flipping this on inlines the
+            # detail (e.g. "Missing required argument(s) for 'exec': cmd, timeout_ms")
+            # so the model has something concrete to self-correct against. See
+            # agent_framework/_tools.py:1387-1396.
+            "include_detailed_errors": True,
+        },
+        # Anthropic's grammar-constrained tool-use mode — ``strict: true`` on every
+        # custom tool. Makes a malformed call like ``exec({})`` literally impossible
+        # for the model to emit, rather than only post-hoc-rejected by Pydantic.
+        # Requires every tool's input_schema to be strict-compatible
+        # (additionalProperties: false, all fields in `required`); _SubmitInput
+        # above and the exec MCP tool both already use OpenAIStrictModeBaseModel.
+        strict_tools=True,
     )
     t_start = time.monotonic()
     end_reason: Literal["submit", "agent_returned", "wall_timeout"]


### PR DESCRIPTION
## Summary

The Sonnet 4.6 RE rollout died near the wall budget cycling on `exec({})` — empty-argument tool calls — because nothing was constraining the JSON to the schema and the harness was hiding the validation reason. Three coordinated changes:

1. **`include_detailed_errors=True`** in re_rollout's `FunctionInvocationConfiguration`. AF defaults to a useless `"Error: Argument parsing failed."` for tool-arg validation errors; the actual reason (`"Missing required argument(s) for 'exec': cmd, timeout_ms"`) sits on `Content.exception` but is never relayed to the model (`agent_framework/_tools.py:1387-1396`). Flipping this on inlines the detail.
2. **`strict_tools=True`** on the Anthropic client. New `_StrictAnthropicClient` wrapper in `skills/eval_infra/af_chat_client.py` post-processes AF's prepared tool list and injects `strict: true` on every custom entry — engaging Anthropic's grammar-constrained sampling (`https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use`). Both tools (`exec`, `submit`) now have strict-compatible input schemas: exec already uses `OpenAIStrictModeBaseModel`, the new `_SubmitInput` does too.
3. **Mask integer-bound JSON Schema keys on `timeout_ms`.** Anthropic strict mode rejects `exclusiveMinimum`/`maximum` (`"For 'integer' type, properties exclusiveMinimum, maximum are not supported"`). `TimeoutMs` carries those bounds; `_make_exec_input_model` now wraps the field in `Annotated[TimeoutMs, WithJsonSchema({"type": "integer"})]` so the schema is plain `{type: integer}` while Pydantic runtime validators stay in place.

## Effect

Sonnet's `exec({})` failure mode is now structurally impossible — Anthropic rejects any tool input that doesn't match the schema before it even leaves the API.

## Test plan

- [x] `bazelisk build //skills/eval_infra:af_chat_client //skills/reverse_engineer/evals/runs/agent_framework:re_rollout //mcp_infra/exec:docker` — green.
- [x] Smoke-run with Haiku 4.5 and a 90 s budget. First version (without timeout_ms WithJsonSchema) returned the strict-mode 400 error confirming strict was engaged. After the schema fix, Anthropic accepts the request and Haiku dispatches well-formed `exec` calls until the transcript hits Haiku's 200 k context window (unrelated).
- [ ] Sonnet rollout with strict mode — reasonable next step but not blocked on this PR.

`BAZEL_TEST_INVOCATIONS=none` in commit (manual verification).

https://claude.ai/code/session_01X3hqE8H5JihGJj1NvkuTL6


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3hqE8H5JihGJj1NvkuTL6)_