### PR TITLE
debundle: resolve runfiles in-binary, drop unused spec fields

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -86,3 +86,28 @@ them with typed structs and enums.
 The public spec format consumed by `--spec` and the on-disk artifact
 manifests are external contracts — be deliberate about changing them.
 Internal intermediate types have no such constraint.
+
+## Path Resolution Contract
+
+The CLI accepts relative or absolute paths for `--spec`, `--package-root
+<pkg>=<dir>`, and `--packages-root`. When the binary runs inside a Bazel
+runfiles context (`bazel run`, `bb run`, or otherwise with `RUNFILES_DIR` /
+`RUNFILES_MANIFEST_FILE` set), each relative path is first resolved through
+runfiles via the standard `runfiles` crate; if the resolution points at an
+existing file the runfiles path is used, otherwise the path is left as-is for
+the caller's filesystem semantics. Outside Bazel the binary behaves as a
+plain CLI — runfiles resolution is opt-in by environment, not a build-time
+mode.
+
+This lets downstream Bazel targets compose absolute-equivalent paths with
+just `$(rlocationpath <label>)` (no shell wrappers, no `$$RUNFILES_DIR`
+substitutions) while keeping the binary usable as a standalone tool outside
+the Bazel tree.
+
+## Materialize logical-modules `targetDir`
+
+`materialize_logical_modules` accepts an optional `targetDir`. Absent or
+empty means "no subdirectory" — lowered files land directly under their
+chunk root (`<out_dir>/<chunkId>/<target.path>.js`). A non-empty value adds
+that prefix (`<out_dir>/<chunkId>/<targetDir>/<target.path>.js`). Tests that
+want the legacy `modules/` layout pass `"targetDir": "modules"` explicitly.

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -156,6 +156,7 @@ rust_library(
         "@crates//:anyhow",
         "@crates//:serde",
         "@crates//:serde_json",
+        "@rules_rust//tools/runfiles",
     ],
 )
 

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -154,6 +154,7 @@ rust_library(
         ":vendor",
         ":write_tree",
         "@crates//:anyhow",
+        "@crates//:clap",
         "@crates//:serde",
         "@crates//:serde_json",
         "@rules_rust//tools/runfiles",
@@ -175,5 +176,6 @@ rust_binary(
     deps = [
         ":pipeline",
         "@crates//:anyhow",
+        "@crates//:clap",
     ],
 )

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -3,6 +3,20 @@
 Forward-looking gaps in the Rust debundler. Items are written to be removed
 once closed; this file is not a changelog.
 
+## RE coverage side-output
+
+Re-introduce the deleted `extract_scrambled_identifier_frequencies` analysis
+(JS source of truth was `analysis/identifier_frequency.mjs`, ~600 LOC) as a
+**side output of every pipeline run** rather than a separate stage with its
+own `force` / `limit` / `excludedSymbolFiles` knobs. The intent: emit a
+machine-readable coverage summary that ranks the still-scrambled top-level
+symbols by frequency, so RE workflows can see "% of bundle understood" and
+prioritize the next rename wave. Keep the report keyed by stable selector
+identity so it stays meaningful across upstream version bumps.
+
+Until this lands, downstream specs should not invoke a scrambled-identifier
+stage; gaffer-private's spec generator currently drops it.
+
 ## Logical materialization breadth
 
 The current `materialize_logical_modules` covers top-level

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -360,7 +360,7 @@ fn build_spec(
             {
                 "id": "logical",
                 "operation": "materialize_logical_modules",
-                "args": { "chunkIds": [chunk_id], "pruneOtherChunks": false },
+                "args": { "chunkIds": [chunk_id], "pruneOtherChunks": false, "targetDir": "modules" },
             },
             { "id": "write", "operation": "write_js_tree", "args": { "force": true, "outDir": out_root } },
         ],

--- a/devinfra/js/debundle/emit_harness.rs
+++ b/devinfra/js/debundle/emit_harness.rs
@@ -14,7 +14,6 @@ pub struct EmitBrowserHarnessOptions {
     pub asset_summary_path: PathBuf,
     pub force: bool,
     pub out_dir: PathBuf,
-    pub script_source: String,
     pub snapshot_root: PathBuf,
 }
 
@@ -39,9 +38,6 @@ pub fn emit_browser_harness(
     artifact: &JsPipelineArtifact,
     options: &EmitBrowserHarnessOptions,
 ) -> Result<()> {
-    if options.script_source != "split" {
-        bail!("Unsupported scriptSource: {}", options.script_source);
-    }
     let asset_summary: AssetSummary = serde_json::from_str(
         &fs::read_to_string(&options.asset_summary_path)
             .with_context(|| format!("reading {}", options.asset_summary_path.display()))?,
@@ -102,7 +98,6 @@ pub fn emit_browser_harness(
     )?;
     let manifest = HarnessManifest {
         schema_version: 1,
-        script_source: "split".to_string(),
         source_html: path_to_posix(&source_html_path),
         snapshot_root: path_to_posix(&options.snapshot_root),
         asset_summary_path: path_to_posix(&options.asset_summary_path),
@@ -136,7 +131,6 @@ pub fn emit_browser_harness(
 #[serde(rename_all = "camelCase")]
 struct HarnessManifest {
     schema_version: u8,
-    script_source: String,
     source_html: String,
     snapshot_root: String,
     asset_summary_path: String,

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -90,15 +90,12 @@ pub struct RequestedLogicalModule {
 
 #[derive(Debug, Clone)]
 pub struct MaterializeLogicalModulesOptions {
-    pub boundary_analysis_dir: Option<PathBuf>,
     pub chunk_ids: Vec<String>,
     pub file: Option<String>,
     pub prune_other_chunks: bool,
     pub force: bool,
     pub report_out_dir: Option<PathBuf>,
     pub report_summary_path: Option<PathBuf>,
-    pub selected_owner_ids_by_chunk_path: Option<PathBuf>,
-    pub selected_owner_ids_by_chunk: Option<Value>,
     pub target_dir: String,
 }
 
@@ -396,21 +393,6 @@ pub fn materialize_logical_modules(
         }
         fs::write(resolved, serde_json::to_string_pretty(&manifest)? + "\n")?;
     }
-    if let Some(path) = options.selected_owner_ids_by_chunk_path {
-        let resolved = resolve_workspace_path(&path)?;
-        if let Some(parent) = resolved.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(
-            resolved,
-            serde_json::to_string_pretty(&json!({
-                "chunkOwnerIds": options.selected_owner_ids_by_chunk.unwrap_or_else(|| json!({})),
-                "kind": "js.selected_owner_ids_cache",
-                "schemaVersion": 1,
-            }))? + "\n",
-        )?;
-    }
-    let _ = options.boundary_analysis_dir;
     Ok(manifest)
 }
 
@@ -671,7 +653,7 @@ fn logical_requests_for_chunk(
     if requests.is_empty() {
         requests.push(LogicalRequest {
             id: "logical_module_0".to_string(),
-            target_path: format!("{target_dir}/unhandled"),
+            target_path: posix_join(&[target_dir, "unhandled"]),
             residual: true,
             members: Vec::new(),
         });
@@ -1319,16 +1301,10 @@ impl RuntimeSourceRewriter {
             .and_then(Path::to_str)
             .unwrap_or("")
             .replace('\\', "/");
-        let runtime_dir = if target_dir == "modules" || target_dir.starts_with("modules/") {
-            String::new()
-        } else {
-            self.target_file
-                .split_once("/modules/")
-                .map(|(chunk_root, _)| chunk_root.to_string())
-                .unwrap_or_else(|| target_dir.clone())
-        };
-        let original_abs = posix_join(&[&runtime_dir, &original]);
-        let mut rel = posix_relative(&target_dir, &original_abs);
+        // Original import sources in lowered module bodies are chunk-root-relative;
+        // the lowered file lives at <target_dir>/<basename> within the chunk, so the
+        // rewritten specifier walks up out of target_dir to chunk root.
+        let mut rel = posix_relative(&target_dir, &original);
         if !rel.starts_with('.') {
             rel = format!("./{rel}");
         }
@@ -1556,6 +1532,9 @@ fn target_file_for_request(target_dir: &str, target_path: &str) -> Result<String
 }
 
 fn normalize_optional_relative_dir(value: &str) -> Result<String> {
+    if value.is_empty() {
+        return Ok(String::new());
+    }
     normalize_relative_path(value)
 }
 

--- a/devinfra/js/debundle/main.rs
+++ b/devinfra/js/debundle/main.rs
@@ -1,8 +1,7 @@
 use std::process::ExitCode;
 
-use pipeline::{
-    self, ParsedTransformCli, parse_transform_cli_args, render_transform_summary, run_transform_cli,
-};
+use clap::Parser;
+use pipeline::{TransformArgs, render_transform_summary, run_transform_cli};
 
 fn main() -> ExitCode {
     match real_main() {
@@ -15,16 +14,8 @@ fn main() -> ExitCode {
 }
 
 fn real_main() -> anyhow::Result<ExitCode> {
-    let argv = std::env::args().skip(1).collect::<Vec<_>>();
-    match parse_transform_cli_args(&argv)? {
-        ParsedTransformCli::Help => {
-            print!("{}", pipeline::transform_cli_help());
-            Ok(ExitCode::SUCCESS)
-        }
-        ParsedTransformCli::Run(cli) => {
-            let summary = run_transform_cli(&cli)?;
-            print!("{}", render_transform_summary(&summary));
-            Ok(ExitCode::SUCCESS)
-        }
-    }
+    let cli = TransformArgs::parse().resolve();
+    let summary = run_transform_cli(&cli)?;
+    print!("{}", render_transform_summary(&summary));
+    Ok(ExitCode::SUCCESS)
 }

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
+use clap::Parser;
 use runfiles::{Runfiles, rlocation};
 use serde::{Deserialize, Serialize};
 
@@ -24,10 +25,65 @@ pub struct TransformCli {
     pub packages_root: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ParsedTransformCli {
-    Help,
-    Run(TransformCli),
+/// Command-line arguments for the debundle transform pipeline.
+///
+/// Use [`TransformArgs::resolve`] to obtain a [`TransformCli`] with paths
+/// resolved against Bazel runfiles when running as a `bazel run` target.
+#[derive(Parser, Debug)]
+#[command(
+    name = "debundle",
+    version,
+    about = "Run the debundle transform pipeline described by --spec.",
+    long_about = "Runs the transform pipeline described by the spec. Pipeline stages \
+                  dispatch directly to registered functions; this target does not invoke \
+                  Bazel from inside the pipeline. Specs are parsed as JSON with comments."
+)]
+pub struct TransformArgs {
+    /// Path to the transform spec (JSON with comments).
+    #[arg(long)]
+    pub spec: PathBuf,
+    /// Map a package name to its source directory: `<pkg>=<dir>`. May be repeated.
+    #[arg(long = "package-root", value_parser = parse_package_root_kv)]
+    pub package_roots: Vec<(String, PathBuf)>,
+    /// Root directory containing per-package sources (alternative to repeated --package-root).
+    #[arg(long)]
+    pub packages_root: Option<PathBuf>,
+}
+
+impl TransformArgs {
+    /// Resolve all path arguments against Bazel runfiles (when present) and
+    /// collapse `--package-root` pairs into a `HashMap`.
+    pub fn resolve(self) -> TransformCli {
+        let runfiles = Runfiles::create().ok();
+        TransformCli {
+            spec_path: resolve_runfiles_path(self.spec, runfiles.as_ref()),
+            package_roots: self
+                .package_roots
+                .into_iter()
+                .map(|(name, dir)| (name, resolve_runfiles_path(dir, runfiles.as_ref())))
+                .collect(),
+            packages_root: self
+                .packages_root
+                .map(|dir| resolve_runfiles_path(dir, runfiles.as_ref())),
+        }
+    }
+}
+
+fn parse_package_root_kv(value: &str) -> Result<(String, PathBuf), String> {
+    let Some(separator) = value.find('=') else {
+        return Err(format!(
+            "--package-root must be in <package>=<dir> form, got {value}"
+        ));
+    };
+    if separator == 0 || separator == value.len() - 1 {
+        return Err(format!(
+            "--package-root must be in <package>=<dir> form, got {value}"
+        ));
+    }
+    Ok((
+        value[..separator].to_string(),
+        PathBuf::from(&value[separator + 1..]),
+    ))
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -105,59 +161,6 @@ struct WriteJsTreeArgs {
 #[derive(Default)]
 struct TransformState {
     artifact: JsPipelineArtifact,
-}
-
-pub fn transform_cli_help() -> &'static str {
-    "Usage:\n  debundle --spec <spec.jsonc> [--package-root <pkg>=<dir>]... [--packages-root <dir>]\n\nRuns the transform pipeline described by the spec. Pipeline stages\ndispatch directly to registered functions; this target does not invoke Bazel\nfrom inside the pipeline. Specs are parsed as JSON with comments.\n"
-}
-
-pub fn parse_transform_cli_args(argv: &[String]) -> Result<ParsedTransformCli> {
-    let runfiles = Runfiles::create().ok();
-    let mut package_roots = HashMap::new();
-    let mut packages_root = None;
-    let mut spec_path = None;
-    let mut index = 0usize;
-    while index < argv.len() {
-        match argv[index].as_str() {
-            "--spec" => {
-                index += 1;
-                let value = require_arg_value(argv, index, "--spec")?;
-                spec_path = Some(resolve_runfiles_path(
-                    PathBuf::from(value),
-                    runfiles.as_ref(),
-                ));
-            }
-            "--package-root" => {
-                index += 1;
-                let value = require_arg_value(argv, index, "--package-root")?;
-                let (package_name, package_root) =
-                    parse_package_root_arg(&value, "--package-root")?;
-                package_roots.insert(
-                    package_name,
-                    resolve_runfiles_path(package_root, runfiles.as_ref()),
-                );
-            }
-            "--packages-root" => {
-                index += 1;
-                let value = require_arg_value(argv, index, "--packages-root")?;
-                packages_root = Some(resolve_runfiles_path(
-                    PathBuf::from(value),
-                    runfiles.as_ref(),
-                ));
-            }
-            "--help" | "-h" => return Ok(ParsedTransformCli::Help),
-            arg => bail!("Unknown argument: {arg}"),
-        }
-        index += 1;
-    }
-    let Some(spec_path) = spec_path else {
-        bail!("--spec is required");
-    };
-    Ok(ParsedTransformCli::Run(TransformCli {
-        spec_path,
-        package_roots,
-        packages_root,
-    }))
 }
 
 /// Resolve a path through Bazel runfiles when present, otherwise pass through.
@@ -374,25 +377,6 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
     Ok(())
 }
 
-fn require_arg_value(argv: &[String], index: usize, flag: &str) -> Result<String> {
-    argv.get(index)
-        .cloned()
-        .with_context(|| format!("{flag} requires a value"))
-}
-
-fn parse_package_root_arg(value: &str, flag: &str) -> Result<(String, PathBuf)> {
-    let Some(separator) = value.find('=') else {
-        bail!("{flag} must be in <package>=<dir> form, got {value}");
-    };
-    if separator == 0 || separator == value.len() - 1 {
-        bail!("{flag} must be in <package>=<dir> form, got {value}");
-    }
-    Ok((
-        value[..separator].to_string(),
-        PathBuf::from(&value[separator + 1..]),
-    ))
-}
-
 fn elapsed_ms(started: Instant) -> f64 {
     started.elapsed().as_secs_f64() * 1000.0
 }
@@ -476,18 +460,17 @@ mod tests {
 
     #[test]
     fn parse_transform_cli_args_matches_js_surface() {
-        let parsed = parse_transform_cli_args(&[
-            "--spec".to_string(),
-            "spec.jsonc".to_string(),
-            "--package-root".to_string(),
-            "pkg=/tmp/pkg".to_string(),
-            "--packages-root".to_string(),
-            "/tmp/packages".to_string(),
+        let args = TransformArgs::try_parse_from([
+            "debundle",
+            "--spec",
+            "spec.jsonc",
+            "--package-root",
+            "pkg=/tmp/pkg",
+            "--packages-root",
+            "/tmp/packages",
         ])
         .expect("parse cli");
-        let ParsedTransformCli::Run(cli) = parsed else {
-            panic!("expected run cli");
-        };
+        let cli = args.resolve();
         assert_eq!(cli.spec_path, PathBuf::from("spec.jsonc"));
         assert_eq!(
             cli.package_roots.get("pkg"),

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
+use runfiles::{Runfiles, rlocation};
 use serde::{Deserialize, Serialize};
 
 use artifact::{JsPipelineArtifact, compute_js_asts, load_js_chunks};
@@ -55,8 +56,6 @@ struct TransformSpec {
 struct TransformStage {
     id: Option<String>,
     operation: Option<String>,
-    disabled: Option<bool>,
-    implementation: Option<serde_json::Value>,
     args: Option<serde_json::Value>,
 }
 
@@ -69,18 +68,10 @@ struct LoadJsChunksArgs {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct NormalizeJsChunksArgs {
-    jobs: Option<usize>,
-    entry_file: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct EmitBrowserHarnessArgs {
     asset_summary_path: PathBuf,
     force: Option<bool>,
     out_dir: PathBuf,
-    script_source: Option<String>,
     snapshot_root: PathBuf,
 }
 
@@ -95,15 +86,12 @@ struct SwapVendorChunksArgs {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MaterializeLogicalModulesArgs {
-    boundary_analysis_dir: Option<PathBuf>,
     chunk_ids: Vec<String>,
     file: Option<String>,
     prune_other_chunks: Option<bool>,
     force: Option<bool>,
     report_out_dir: Option<PathBuf>,
     report_summary_path: Option<PathBuf>,
-    selected_owner_ids_by_chunk_path: Option<PathBuf>,
-    selected_owner_ids_by_chunk: Option<serde_json::Value>,
     target_dir: Option<String>,
 }
 
@@ -124,6 +112,7 @@ pub fn transform_cli_help() -> &'static str {
 }
 
 pub fn parse_transform_cli_args(argv: &[String]) -> Result<ParsedTransformCli> {
+    let runfiles = Runfiles::create().ok();
     let mut package_roots = HashMap::new();
     let mut packages_root = None;
     let mut spec_path = None;
@@ -132,22 +121,29 @@ pub fn parse_transform_cli_args(argv: &[String]) -> Result<ParsedTransformCli> {
         match argv[index].as_str() {
             "--spec" => {
                 index += 1;
-                spec_path = Some(require_arg_value(argv, index, "--spec")?);
+                let value = require_arg_value(argv, index, "--spec")?;
+                spec_path = Some(resolve_runfiles_path(
+                    PathBuf::from(value),
+                    runfiles.as_ref(),
+                ));
             }
             "--package-root" => {
                 index += 1;
                 let value = require_arg_value(argv, index, "--package-root")?;
                 let (package_name, package_root) =
                     parse_package_root_arg(&value, "--package-root")?;
-                package_roots.insert(package_name, package_root);
+                package_roots.insert(
+                    package_name,
+                    resolve_runfiles_path(package_root, runfiles.as_ref()),
+                );
             }
             "--packages-root" => {
                 index += 1;
-                packages_root = Some(PathBuf::from(require_arg_value(
-                    argv,
-                    index,
-                    "--packages-root",
-                )?));
+                let value = require_arg_value(argv, index, "--packages-root")?;
+                packages_root = Some(resolve_runfiles_path(
+                    PathBuf::from(value),
+                    runfiles.as_ref(),
+                ));
             }
             "--help" | "-h" => return Ok(ParsedTransformCli::Help),
             arg => bail!("Unknown argument: {arg}"),
@@ -158,10 +154,32 @@ pub fn parse_transform_cli_args(argv: &[String]) -> Result<ParsedTransformCli> {
         bail!("--spec is required");
     };
     Ok(ParsedTransformCli::Run(TransformCli {
-        spec_path: PathBuf::from(spec_path),
+        spec_path,
         package_roots,
         packages_root,
     }))
+}
+
+/// Resolve a path through Bazel runfiles when present, otherwise pass through.
+///
+/// Lets the binary work as a standalone CLI (filesystem paths) and as a
+/// Bazel-run target (runfiles-relative paths produced by `$(rlocationpath ...)`)
+/// without a launcher wrapper. A path is treated as runfiles-relative only
+/// when it actually resolves to a file inside the runfiles tree; otherwise
+/// it's left for the caller's filesystem semantics.
+fn resolve_runfiles_path(path: PathBuf, runfiles: Option<&Runfiles>) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    let Some(runfiles) = runfiles else {
+        return path;
+    };
+    let Some(s) = path.to_str() else {
+        return path;
+    };
+    rlocation!(runfiles, s)
+        .filter(|resolved| resolved.exists())
+        .unwrap_or(path)
 }
 
 pub fn render_transform_summary(summary: &TransformRunSummary) -> String {
@@ -198,15 +216,6 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
     for stage in pipeline {
         let id = stage.id.unwrap_or_default();
         let operation = stage.operation.unwrap_or_default();
-        if stage.disabled.unwrap_or(false) {
-            steps.push(TransformStepSummary {
-                id,
-                operation,
-                duration_ms: Some(0.0),
-                manifest_kind: None,
-            });
-            continue;
-        }
         let stage_started = Instant::now();
         let manifest_kind =
             run_transform_stage(&mut state, &operation, stage.args, &operations, cli)?;
@@ -245,19 +254,7 @@ fn run_transform_stage(
             Ok(Some(manifest.kind.to_string()))
         }
         "normalize_js_chunks" => {
-            let args = args
-                .map(serde_json::from_value::<NormalizeJsChunksArgs>)
-                .transpose()?
-                .unwrap_or(NormalizeJsChunksArgs {
-                    jobs: None,
-                    entry_file: None,
-                });
-            if args.entry_file.is_some() {
-                bail!(
-                    "normalizeJsChunks no longer accepts entryFile; normalized chunks always use entry.js"
-                );
-            }
-            let _ = args.jobs;
+            let _ = args;
             let artifact = std::mem::take(&mut state.artifact);
             let (artifact, _manifest) = normalize_js_chunks(artifact)?;
             state.artifact = artifact;
@@ -304,16 +301,13 @@ fn run_transform_stage(
                 &mut state.artifact,
                 operations,
                 MaterializeLogicalModulesOptions {
-                    boundary_analysis_dir: args.boundary_analysis_dir,
                     chunk_ids: args.chunk_ids,
                     file: args.file,
                     prune_other_chunks: args.prune_other_chunks.unwrap_or(true),
                     force: args.force.unwrap_or(false),
                     report_out_dir: args.report_out_dir,
                     report_summary_path: args.report_summary_path,
-                    selected_owner_ids_by_chunk_path: args.selected_owner_ids_by_chunk_path,
-                    selected_owner_ids_by_chunk: args.selected_owner_ids_by_chunk,
-                    target_dir: args.target_dir.unwrap_or_else(|| "modules".to_string()),
+                    target_dir: args.target_dir.unwrap_or_default(),
                 },
             )?;
             Ok(Some(manifest.kind.to_string()))
@@ -334,7 +328,6 @@ fn run_transform_stage(
                     asset_summary_path: args.asset_summary_path,
                     force: args.force.unwrap_or(false),
                     out_dir: args.out_dir,
-                    script_source: args.script_source.unwrap_or_else(|| "split".to_string()),
                     snapshot_root: args.snapshot_root,
                 },
             )?;
@@ -376,11 +369,6 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
         }
         if !seen_stage_ids.insert(id.to_string()) {
             bail!("Duplicate pipeline stage id: {id}");
-        }
-        if stage.implementation.is_some() {
-            bail!(
-                "Pipeline stage {id} uses legacy implementation wiring; stages now dispatch by operation only"
-            );
         }
     }
     Ok(())
@@ -583,7 +571,6 @@ mod tests {
                             "assetSummaryPath": extracted.join("asset-summary.json"),
                             "force": true,
                             "outDir": out,
-                            "scriptSource": "split",
                             "snapshotRoot": snapshot,
                         },
                     },


### PR DESCRIPTION
## Summary

- Make `--spec` / `--package-root` / `--packages-root` runfiles-aware via the `runfiles` crate so Bazel callers can compose paths with just `$(rlocationpath ...)` (no shell launcher, no `$JS_BINARY__RUNFILES`-style substitution dance). Resolution is opt-in by environment: outside Bazel the binary keeps working as a plain CLI on filesystem paths.
- Make `materialize_logical_modules`'s `targetDir` mean "no subdirectory" when absent or empty (lowered files land directly under the chunk root) and simplify `RuntimeSourceRewriter` accordingly — the former hardcoded "modules" gate was an unnecessary special case. e2e fixtures now pass `"targetDir": "modules"` explicitly to keep the test layout.
- Drop spec fields with no live consumers: `TransformStage.{disabled,implementation}`, `NormalizeJsChunksArgs.{jobs,entryFile}`, `EmitBrowserHarnessArgs.scriptSource` (and the matching harness-manifest field), `MaterializeLogicalModulesArgs.{boundaryAnalysisDir,selectedOwnerIdsByChunk,selectedOwnerIdsByChunkPath}`. The deleted `selectedOwnerIds` writer was only emitting an empty file.
- Document the path-resolution and `targetDir` contracts in `devinfra/js/debundle/AGENTS.md`.
- Capture the deferred scrambled-identifier coverage report (former `analysis/identifier_frequency.mjs`, ~600 LOC) in `TODO.md` — should come back as a per-run side output, not as a separate stage.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — all 6 tests pass (`pipeline_test`, `cross_module_test`, `lowering_test`, `naturalization_test`, `url_rebase_test`, `proxy_test`).
- [x] Standalone-binary contract preserved: `Runfiles::create()` returns `Err` outside Bazel and the binary falls through to filesystem paths; the resolution is also gated by `resolved.exists()` so test fixtures with relative paths that don't live in runfiles aren't accidentally rewritten.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_