### PR TITLE
debundle: vendor-swap named-from-module-default supports export-as-default

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -32,6 +32,7 @@ rust_library(
         deps = [
             ":support",
             "@crates//:serde_json",
+            "@crates//:tempfile",
             "@rules_rust//tools/runfiles",
         ],
     )
@@ -40,5 +41,6 @@ rust_library(
         "cross_module_test",
         "naturalization_test",
         "url_rebase_test",
+        "vendor_swap_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -400,14 +400,14 @@ fn current_test_prefix() -> String {
     format!("debundle-e2e-{compact}-")
 }
 
-fn write_text_file(path: &Path, content: &str) {
+pub fn write_text_file(path: &Path, content: &str) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, content).unwrap();
 }
 
-fn write_json_file(path: &Path, value: &Value) {
+pub fn write_json_file(path: &Path, value: &Value) {
     fs::write(
         path,
         format!("{}\n", serde_json::to_string_pretty(value).unwrap()),
@@ -415,7 +415,7 @@ fn write_json_file(path: &Path, value: &Value) {
     .unwrap();
 }
 
-fn debundler_path() -> PathBuf {
+pub fn debundler_path() -> PathBuf {
     let r = Runfiles::create().expect("create runfiles");
     rlocation!(r, DEBUNDLER_RLOCATION)
         .unwrap_or_else(|| panic!("could not resolve debundler runfile: {DEBUNDLER_RLOCATION}"))
@@ -427,17 +427,29 @@ fn node_path() -> PathBuf {
         .unwrap_or_else(|| panic!("could not resolve node runfile: {NODE_RLOCATION}"))
 }
 
-struct CommandResult {
-    stdout: String,
-    stderr: String,
-    status: std::process::ExitStatus,
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub status: std::process::ExitStatus,
 }
 
 fn spawn_transform(spec_path: &Path) -> CommandResult {
+    run_debundler(spec_path, &[])
+}
+
+/// Run `debundle --spec <path> [--package-root <name>=<dir> ...]` and return its
+/// captured stdio + exit status. Used by tests that exercise pipeline stages
+/// outside the logical-modules harness in [`run_logical_modules_e2e_fixture`].
+pub fn run_debundler(spec_path: &Path, package_roots: &[(&str, &Path)]) -> CommandResult {
     let bin = debundler_path();
-    let output = Command::new(&bin)
-        .arg("--spec")
-        .arg(spec_path)
+    let mut command = Command::new(&bin);
+    command.arg("--spec").arg(spec_path);
+    for (name, dir) in package_roots {
+        command
+            .arg("--package-root")
+            .arg(format!("{name}={}", dir.display()));
+    }
+    let output = command
         .output()
         .unwrap_or_else(|e| panic!("spawn debundler {}: {e}", bin.display()));
     CommandResult {

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -1,0 +1,188 @@
+//! Vendor-swap end-to-end coverage. Builds a tiny snapshot chunk that
+//! re-exports a synthetic upstream package, runs the swap pipeline, and
+//! asserts the generated wrapper.
+
+use debundle_e2e_support::{CommandResult, run_debundler, write_json_file, write_text_file};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+#[test]
+fn named_from_module_default_handles_export_named_as_default_re_export() {
+    // Cytoscape v3.30.4 ships `export { cytoscape as default };` (a named
+    // re-export of a local) instead of a bare `export default cytoscape;`.
+    // The wrapper must accept the re-export form.
+    let upstream_source = r#"const lib = { ping() { return "pong"; } };
+const aux = "side";
+export { lib as default, aux };
+"#;
+
+    let fixture = run_named_from_module_default_fixture(NamedFromModuleDefaultOpts {
+        chunk_source: "export { x as default };\nconst x = 0;\n",
+        upstream_source,
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+
+    let wrapper_source = fs::read_to_string(&fixture.wrapper_path).expect("wrapper exists");
+    assert!(
+        wrapper_source.contains("ping"),
+        "wrapper should retain the upstream local that becomes `default`:\n{wrapper_source}",
+    );
+    assert!(
+        wrapper_source.contains("export default"),
+        "wrapper should expose a `export default ...`:\n{wrapper_source}",
+    );
+    assert!(
+        !wrapper_source.contains("as default"),
+        "wrapper should not re-emit the original upstream `export {{ ... as default }}` once the wrapper has its own default export:\n{wrapper_source}",
+    );
+}
+
+struct NamedFromModuleDefaultOpts<'a> {
+    chunk_source: &'a str,
+    upstream_source: &'a str,
+}
+
+struct VendorSwapFixture {
+    result: CommandResult,
+    wrapper_path: std::path::PathBuf,
+    _root: TempDir,
+}
+
+fn run_named_from_module_default_fixture(
+    opts: NamedFromModuleDefaultOpts<'_>,
+) -> VendorSwapFixture {
+    const PACKAGE_NAME: &str = "lib";
+    const PACKAGE_VERSION: &str = "1.0.0";
+    const SUBPATH: &str = "dist/index.mjs";
+    const CHUNK_PATH: &str = "static/lib-X.js";
+
+    let root =
+        TempDir::with_prefix("vendor-swap-named-from-module-default-").expect("create tempdir");
+    let extracted_root = root.path().join("extracted");
+    let snapshot_root = root.path().join("snapshot");
+    let out_root = root.path().join("out");
+    let wrapper_root = root.path().join("vendors");
+    let manifest_path = wrapper_root.join("manifest.json");
+    let package_root = root.path().join("upstream");
+    fs::create_dir_all(&extracted_root).unwrap();
+    fs::create_dir_all(&snapshot_root).unwrap();
+    fs::create_dir_all(&out_root).unwrap();
+    fs::create_dir_all(&wrapper_root).unwrap();
+    fs::create_dir_all(&package_root).unwrap();
+    fs::create_dir_all(snapshot_root.join(Path::new(CHUNK_PATH).parent().unwrap())).unwrap();
+    fs::create_dir_all(package_root.join("dist")).unwrap();
+
+    write_text_file(&snapshot_root.join(CHUNK_PATH), opts.chunk_source);
+    let js_list_path = extracted_root.join("js-files.txt");
+    write_text_file(&js_list_path, &format!("{CHUNK_PATH}\n"));
+
+    write_text_file(
+        &package_root.join("package.json"),
+        &format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "name": PACKAGE_NAME,
+                "version": PACKAGE_VERSION,
+            }))
+            .unwrap(),
+        ),
+    );
+    write_text_file(&package_root.join(SUBPATH), opts.upstream_source);
+
+    let spec_path = root.path().join("transform_spec.jsonc");
+    let spec = build_named_from_module_default_spec(BuildSpecArgs {
+        chunk_path: CHUNK_PATH,
+        js_list_path: &js_list_path,
+        snapshot_root: &snapshot_root,
+        out_root: &out_root,
+        manifest_path: &manifest_path,
+        wrapper_root: &wrapper_root,
+        package_name: PACKAGE_NAME,
+        package_version: PACKAGE_VERSION,
+        subpath: SUBPATH,
+    });
+    write_json_file(&spec_path, &spec);
+
+    let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
+
+    // Wrapper layout: <output_wrapper_dir>/<chunk_id>/<entry_file>. chunk_id
+    // is the chunk path with the trailing `.js` stripped; the normalized
+    // chunk's entry file is always `entry.js`.
+    let chunk_id = CHUNK_PATH.strip_suffix(".js").unwrap_or(CHUNK_PATH);
+    let wrapper_path = wrapper_root.join(chunk_id).join("entry.js");
+    VendorSwapFixture {
+        result,
+        wrapper_path,
+        _root: root,
+    }
+}
+
+struct BuildSpecArgs<'a> {
+    chunk_path: &'a str,
+    js_list_path: &'a Path,
+    snapshot_root: &'a Path,
+    out_root: &'a Path,
+    manifest_path: &'a Path,
+    wrapper_root: &'a Path,
+    package_name: &'a str,
+    package_version: &'a str,
+    subpath: &'a str,
+}
+
+fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
+    json!({
+        "kind": "js.ast_transform_spec",
+        "operations": [{
+            "id": "mark_vendor_lib",
+            "operation": "mark_vendor",
+            "level": "swap",
+            "chunkPath": args.chunk_path,
+            "identity": format!("{}/{}", args.package_name, args.subpath),
+            "upstreamFamily": "Lib",
+            "package": args.package_name,
+            "version": args.package_version,
+            "subpath": args.subpath,
+            "wrapperShape": "named-from-module-default",
+            "confidence": "confirmed",
+            "evidence": [{
+                "path": args.chunk_path,
+                "line": 1,
+                "text": "export { x as default }",
+            }],
+        }],
+        "pipeline": [
+            {
+                "id": "load",
+                "operation": "load_js_chunks",
+                "args": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
+            },
+            { "id": "parse", "operation": "compute_js_asts" },
+            { "id": "normalize", "operation": "normalize_js_chunks" },
+            { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
+            { "id": "rename_vendor", "operation": "rename_vendor_exports" },
+            {
+                "id": "swap_vendor",
+                "operation": "swap_vendor_chunks",
+                "args": {
+                    "outputManifestPath": args.manifest_path,
+                    "outputWrapperDir": args.wrapper_root,
+                    "write": true,
+                },
+            },
+            {
+                "id": "write",
+                "operation": "write_js_tree",
+                "args": { "force": true, "outDir": args.out_root },
+            },
+        ],
+    })
+}

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -5,7 +5,7 @@
 use debundle_e2e_support::{CommandResult, run_debundler, write_json_file, write_text_file};
 use serde_json::{Value, json};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 #[test]
@@ -18,11 +18,27 @@ const aux = "side";
 export { lib as default, aux };
 "#;
 
-    let fixture = run_named_from_module_default_fixture(NamedFromModuleDefaultOpts {
-        chunk_source: "export { x as default };\nconst x = 0;\n",
-        upstream_source,
-    });
+    let fixture = run_named_from_module_default_fixture(upstream_source);
 
+    assert_wrapper_named_from_module_default(&fixture);
+}
+
+#[test]
+fn named_from_module_default_handles_export_named_as_default_before_local_decl() {
+    // ESM allows `export { lib as default };` to appear *before* the local
+    // declaration. The generated wrapper's
+    // `const __vendor_default__ = lib;` must therefore live after the
+    // declaration to avoid a TDZ at module init.
+    let upstream_source = r#"export { lib as default };
+const lib = { ping() { return "pong"; } };
+"#;
+
+    let fixture = run_named_from_module_default_fixture(upstream_source);
+
+    assert_wrapper_named_from_module_default(&fixture);
+}
+
+fn assert_wrapper_named_from_module_default(fixture: &VendorSwapFixture) {
     assert!(
         fixture.result.status.success(),
         "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
@@ -44,22 +60,38 @@ export { lib as default, aux };
         !wrapper_source.contains("as default"),
         "wrapper should not re-emit the original upstream `export {{ ... as default }}` once the wrapper has its own default export:\n{wrapper_source}",
     );
-}
 
-struct NamedFromModuleDefaultOpts<'a> {
-    chunk_source: &'a str,
-    upstream_source: &'a str,
+    // Cross-check the resolution manifest: the recorded `generatedWrapperPath`
+    // (workspace-relative) must resolve to the wrapper file the test located
+    // by following the `outputWrapperDir` convention.
+    let manifest: Value =
+        serde_json::from_str(&fs::read_to_string(&fixture.manifest_path).expect("manifest exists"))
+            .expect("manifest parses as JSON");
+    let recorded = manifest
+        .get("resolutions")
+        .and_then(|r| r.get(&fixture.chunk_path))
+        .and_then(|r| r.get("generatedWrapperPath"))
+        .and_then(Value::as_str)
+        .expect("manifest records generatedWrapperPath");
+    let resolved = fixture.workspace_root.join(recorded);
+    assert_eq!(
+        fs::canonicalize(&resolved).expect("resolved manifest path canonicalizes"),
+        fs::canonicalize(&fixture.wrapper_path).expect("wrapper path canonicalizes"),
+        "manifest's generatedWrapperPath ({recorded}) must resolve to the wrapper file ({:?})",
+        fixture.wrapper_path,
+    );
 }
 
 struct VendorSwapFixture {
     result: CommandResult,
-    wrapper_path: std::path::PathBuf,
+    chunk_path: String,
+    wrapper_path: PathBuf,
+    manifest_path: PathBuf,
+    workspace_root: PathBuf,
     _root: TempDir,
 }
 
-fn run_named_from_module_default_fixture(
-    opts: NamedFromModuleDefaultOpts<'_>,
-) -> VendorSwapFixture {
+fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFixture {
     const PACKAGE_NAME: &str = "lib";
     const PACKAGE_VERSION: &str = "1.0.0";
     const SUBPATH: &str = "dist/index.mjs";
@@ -67,11 +99,16 @@ fn run_named_from_module_default_fixture(
 
     let root =
         TempDir::with_prefix("vendor-swap-named-from-module-default-").expect("create tempdir");
-    let extracted_root = root.path().join("extracted");
-    let snapshot_root = root.path().join("snapshot");
-    let out_root = root.path().join("out");
-    let wrapper_root = root.path().join("vendors");
-    let manifest_path = wrapper_root.join("manifest.json");
+    // Mirror the gaffer layout: the manifest's `generatedWrapperPath` is a
+    // workspace-relative `vendors/generated/<chunk_id>/<entry>` string, and
+    // `outputWrapperDir` must be the matching `<workspace>/vendors/generated`
+    // for the on-disk file and the recorded path to agree.
+    let workspace_root = root.path().join("workspace");
+    let extracted_root = workspace_root.join("extracted");
+    let snapshot_root = workspace_root.join("snapshot");
+    let out_root = workspace_root.join("out");
+    let wrapper_root = workspace_root.join("vendors").join("generated");
+    let manifest_path = workspace_root.join("vendors").join("manifest.json");
     let package_root = root.path().join("upstream");
     fs::create_dir_all(&extracted_root).unwrap();
     fs::create_dir_all(&snapshot_root).unwrap();
@@ -81,7 +118,10 @@ fn run_named_from_module_default_fixture(
     fs::create_dir_all(snapshot_root.join(Path::new(CHUNK_PATH).parent().unwrap())).unwrap();
     fs::create_dir_all(package_root.join("dist")).unwrap();
 
-    write_text_file(&snapshot_root.join(CHUNK_PATH), opts.chunk_source);
+    write_text_file(
+        &snapshot_root.join(CHUNK_PATH),
+        "export { x as default };\nconst x = 0;\n",
+    );
     let js_list_path = extracted_root.join("js-files.txt");
     write_text_file(&js_list_path, &format!("{CHUNK_PATH}\n"));
 
@@ -96,7 +136,7 @@ fn run_named_from_module_default_fixture(
             .unwrap(),
         ),
     );
-    write_text_file(&package_root.join(SUBPATH), opts.upstream_source);
+    write_text_file(&package_root.join(SUBPATH), upstream_source);
 
     let spec_path = root.path().join("transform_spec.jsonc");
     let spec = build_named_from_module_default_spec(BuildSpecArgs {
@@ -121,7 +161,10 @@ fn run_named_from_module_default_fixture(
     let wrapper_path = wrapper_root.join(chunk_id).join("entry.js");
     VendorSwapFixture {
         result,
+        chunk_path: CHUNK_PATH.to_string(),
         wrapper_path,
+        manifest_path,
+        workspace_root,
         _root: root,
     }
 }

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1204,6 +1204,40 @@ fn generate_named_from_module_default_wrapper(
                     DefaultDecl::TsInterfaceDecl(_) => {}
                 }
             }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named_decl)) => {
+                if named_decl.src.is_some() {
+                    body.push(item.clone());
+                    continue;
+                }
+                let mut remaining = Vec::with_capacity(named_decl.specifiers.len());
+                for specifier in &named_decl.specifiers {
+                    let ExportSpecifier::Named(named_specifier) = specifier else {
+                        remaining.push(specifier.clone());
+                        continue;
+                    };
+                    let exported_name = named_specifier
+                        .exported
+                        .as_ref()
+                        .map(module_export_name)
+                        .unwrap_or_else(|| module_export_name(&named_specifier.orig));
+                    if exported_name != "default" {
+                        remaining.push(specifier.clone());
+                        continue;
+                    }
+                    let ModuleExportName::Ident(local) = &named_specifier.orig else {
+                        bail!(
+                            "swapVendorChunks operation {op_id} named-from-module-default: \"export {{ ... as default }}\" must alias a local identifier"
+                        );
+                    };
+                    found_default = true;
+                    body.push(const_alias(default_local_name, local.sym.as_ref()));
+                }
+                if !remaining.is_empty() {
+                    let mut kept = named_decl.clone();
+                    kept.specifiers = remaining;
+                    body.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(kept)));
+                }
+            }
             _ => body.push(item.clone()),
         }
     }

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1149,6 +1149,7 @@ fn generate_named_from_module_default_wrapper(
 ) -> Result<String> {
     let default_local_name = "__vendor_default__";
     let mut found_default = false;
+    let mut deferred_default_alias: Option<String> = None;
     let mut body = Vec::new();
     for item in &upstream_ast.module.body {
         match item {
@@ -1229,8 +1230,18 @@ fn generate_named_from_module_default_wrapper(
                             "swapVendorChunks operation {op_id} named-from-module-default: \"export {{ ... as default }}\" must alias a local identifier"
                         );
                     };
+                    if deferred_default_alias.is_some() {
+                        bail!(
+                            "swapVendorChunks operation {op_id} named-from-module-default: upstream declares more than one default export"
+                        );
+                    }
                     found_default = true;
-                    body.push(const_alias(default_local_name, local.sym.as_ref()));
+                    // Defer the `const __vendor_default__ = <local>;` emission
+                    // to the end of the body. ESM allows `export { lib as default };
+                    // const lib = ...;`, so emitting the alias at the original
+                    // export position would TDZ on `lib` if the export sits before
+                    // the local declaration.
+                    deferred_default_alias = Some(local.sym.to_string());
                 }
                 if !remaining.is_empty() {
                     let mut kept = named_decl.clone();
@@ -1240,6 +1251,9 @@ fn generate_named_from_module_default_wrapper(
             }
             _ => body.push(item.clone()),
         }
+    }
+    if let Some(local) = deferred_default_alias {
+        body.push(const_alias(default_local_name, &local));
     }
     if !found_default {
         bail!(


### PR DESCRIPTION
## Summary

The `named-from-module-default` wrapper shape used to bail with `upstream has no default export` whenever the upstream's default came in through a re-export specifier (`export { foo as default }`) instead of an `export default <expr>` / `export default function/class` form. Cytoscape v3.30.4 ships exactly this pattern in `dist/cytoscape.esm.mjs`, so swapping `static/cytoscape.esm-*.js` against the npm package failed in the gaffer-private pipeline.

The fix recognises the `ExportNamed` variant in `generate_named_from_module_default_wrapper`. For each specifier that re-exports a local as `default`, drop the specifier and emit a `const __vendor_default__ = <local>;` alias; non-default specifiers in the same statement are kept verbatim. Re-exports with an explicit source (`export { default } from "..."`) are passed through unchanged.

## Test plan

New `//devinfra/js/debundle/e2e:vendor_swap_test` captures the bug end-to-end. The fixture writes a tiny snapshot chunk, a synthetic upstream package whose `dist/index.mjs` uses `export { lib as default, aux }`, runs the binary through the full vendor pipeline (`mark_vendor` → `apply_vendor_annotations` → `rename_vendor_exports` → `swap_vendor_chunks` → `write_js_tree`), and asserts the generated wrapper retains the upstream local, exposes a `export default ...`, and no longer carries the original `as default` re-export. The test fails on devel before this change ("upstream has no default export") and passes after.

- [x] `bbr test //devinfra/js/debundle/...` — all 7 tests pass (`vendor_swap_test`, `pipeline_test`, `cross_module_test`, `lowering_test`, `naturalization_test`, `url_rebase_test`, `proxy_test`).

The new test reaches into the e2e harness for raw spec running, so a few helpers in `e2e/support.rs` get pub-promoted: `run_debundler` (renamed from `spawn_transform`, with an explicit `--package-root` slice), `debundler_path`, `CommandResult`, `write_text_file`, `write_json_file`.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_