### PR TITLE
debundle: spec-level inputs (always-on load/parse/normalize)

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -104,6 +104,14 @@ just `$(rlocationpath <label>)` (no shell wrappers, no `$$RUNFILES_DIR`
 substitutions) while keeping the binary usable as a standalone tool outside
 the Bazel tree.
 
+## Spec-level `inputs`
+
+`load_js_chunks`, `compute_js_asts`, and `normalize_js_chunks` are always-on
+startup steps run before the pipeline loop — they are not pipeline operations.
+The spec configures them via a top-level `inputs: { inputRoot, jsListPath }`
+object. Listing any of these three operations as a pipeline stage is a hard
+error.
+
 ## Materialize logical-modules `targetDir`
 
 `materialize_logical_modules` accepts an optional `targetDir`. Absent or

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -348,15 +348,9 @@ fn build_spec(
     }
     json!({
         "kind": "js.ast_transform_spec",
+        "inputs": { "inputRoot": snapshot_root, "jsListPath": js_list_path },
         "operations": all_operations,
         "pipeline": [
-            {
-                "id": "load",
-                "operation": "load_js_chunks",
-                "args": { "inputRoot": snapshot_root, "jsListPath": js_list_path },
-            },
-            { "id": "parse", "operation": "compute_js_asts" },
-            { "id": "normalize", "operation": "normalize_js_chunks", "args": { "jobs": 1 } },
             {
                 "id": "logical",
                 "operation": "materialize_logical_modules",

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -104,6 +104,7 @@ pub struct TransformStepSummary {
 #[derive(Debug, Clone, Deserialize)]
 struct TransformSpec {
     kind: Option<String>,
+    inputs: Option<LoadJsChunksArgs>,
     pipeline: Option<Vec<TransformStage>>,
     operations: Option<Vec<serde_json::Value>>,
 }
@@ -210,10 +211,18 @@ pub fn render_transform_summary(summary: &TransformRunSummary) -> String {
 pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
     let spec = load_transform_spec(&cli.spec_path)?;
     validate_transform_spec(&spec)?;
+    let inputs = spec
+        .inputs
+        .expect("validate_transform_spec ensures inputs is present");
     let pipeline = spec.pipeline.unwrap_or_default();
     let operations = spec.operations.unwrap_or_default();
     let started = Instant::now();
     let mut state = TransformState::default();
+    let (artifact, _load_manifest) = load_js_chunks(&inputs.input_root, &inputs.js_list_path)?;
+    state.artifact = artifact;
+    compute_js_asts(&mut state.artifact, true)?;
+    let (artifact, _normalize_manifest) = normalize_js_chunks(std::mem::take(&mut state.artifact))?;
+    state.artifact = artifact;
     let mut steps = Vec::new();
 
     for stage in pipeline {
@@ -245,23 +254,10 @@ fn run_transform_stage(
     cli: &TransformCli,
 ) -> Result<Option<String>> {
     match operation {
-        "load_js_chunks" => {
-            let args: LoadJsChunksArgs =
-                serde_json::from_value(args.context("load_js_chunks requires args")?)?;
-            let (artifact, manifest) = load_js_chunks(&args.input_root, &args.js_list_path)?;
-            state.artifact = artifact;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "compute_js_asts" => {
-            let manifest = compute_js_asts(&mut state.artifact, true)?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "normalize_js_chunks" => {
-            let _ = args;
-            let artifact = std::mem::take(&mut state.artifact);
-            let (artifact, _manifest) = normalize_js_chunks(artifact)?;
-            state.artifact = artifact;
-            Ok(None)
+        "load_js_chunks" | "compute_js_asts" | "normalize_js_chunks" => {
+            bail!(
+                "{operation} is no longer a pipeline operation; configure inputs at the spec level"
+            )
         }
         "rewrite_chunk_entry_specifiers" => {
             let manifest = rewrite_chunk_entry_specifiers(&mut state.artifact)?;
@@ -352,6 +348,16 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
     let kind = spec.kind.as_deref().unwrap_or("<missing>");
     if kind != "js.ast_transform_spec" {
         bail!("Unsupported transform spec kind: {kind}");
+    }
+    let inputs = spec
+        .inputs
+        .as_ref()
+        .context("Transform spec must contain an inputs object with inputRoot and jsListPath")?;
+    if inputs.input_root.as_os_str().is_empty() {
+        bail!("Transform spec inputs.inputRoot must not be empty");
+    }
+    if inputs.js_list_path.as_os_str().is_empty() {
+        bail!("Transform spec inputs.jsListPath must not be empty");
     }
     let pipeline = spec
         .pipeline
@@ -526,23 +532,11 @@ mod tests {
             &spec_path,
             serde_json::to_string_pretty(&serde_json::json!({
                 "kind": "js.ast_transform_spec",
+                "inputs": {
+                    "inputRoot": snapshot,
+                    "jsListPath": extracted.join("js-files.txt"),
+                },
                 "pipeline": [
-                    {
-                        "id": "load",
-                        "operation": "load_js_chunks",
-                        "args": {
-                            "inputRoot": snapshot,
-                            "jsListPath": extracted.join("js-files.txt"),
-                        },
-                    },
-                    {
-                        "id": "parse",
-                        "operation": "compute_js_asts",
-                    },
-                    {
-                        "id": "normalize",
-                        "operation": "normalize_js_chunks",
-                    },
                     {
                         "id": "rewrite",
                         "operation": "rewrite_chunk_entry_specifiers",
@@ -567,7 +561,7 @@ mod tests {
             packages_root: None,
         })?;
 
-        assert_eq!(summary.steps.len(), 5);
+        assert_eq!(summary.steps.len(), 2);
         assert!(out.join("bootstrap.js").exists());
         assert!(out.join("manifest.json").exists());
         let entry = fs::read_to_string(out.join("static/index-DuckMock/entry.js"))?;


### PR DESCRIPTION
## Summary

- Move `load_js_chunks`, `compute_js_asts`, and `normalize_js_chunks` out of the `pipeline` array in the transform spec. They are always required, always run first, and only the loader carries config — so they don't belong as conventional pipeline entries.
- The spec now requires a top-level `inputs: { inputRoot, jsListPath }` object. The `debundle` binary always runs load -> parse -> normalize implicitly at startup, then iterates the `pipeline` array of "interesting" semantic operations.
- Listing any of the three startup operations as a pipeline stage is a hard error pointing the user at the new spec-level `inputs` field.

No CLI flag changes; the standalone-binary contract is unchanged. The gaffer-private spec generator update is a follow-up.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` (6 targets, all pass)
- [x] Updated unit test `run_transform_cli_writes_spec_pipeline_outputs` to use the new shape
- [x] Updated `e2e/support.rs build_spec` to emit the new shape; existing e2e tests exercise it

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_