### PR TITLE
debundle: resolve_workspace_path on vendor + harness output writes

### DIFF
--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -633,6 +633,45 @@ pub fn split_posix_path(path: &str) -> PathBuf {
     path.split('/').collect()
 }
 
+/// Resolve a path against the workspace root for output writes.
+///
+/// `bazel run` sets `BUILD_WORKSPACE_DIRECTORY` to the source workspace; we
+/// fall back to `BUILD_WORKING_DIRECTORY`, then `PWD`, then the process cwd.
+/// Absolute paths pass through unchanged so callers can also pass concrete
+/// destinations from outside Bazel.
+pub fn resolve_workspace_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
+        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
+        .or_else(|_| std::env::var("PWD"))
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or(std::env::current_dir()?);
+    Ok(workspace.join(path))
+}
+
+/// Render a workspace-relative path for inclusion in manifests.
+///
+/// Strips the resolved workspace root if `path` lies inside it, otherwise
+/// returns the absolute path unchanged. Always uses POSIX separators so the
+/// result is stable across platforms.
+pub fn relative_workspace_path(path: &Path) -> String {
+    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
+        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
+        .or_else(|_| std::env::var("PWD"))
+        .ok()
+        .map(PathBuf::from);
+    if let Some(workspace) = workspace
+        && let Ok(rel) = path.strip_prefix(&workspace)
+        && !rel.as_os_str().is_empty()
+    {
+        return rel.to_string_lossy().replace('\\', "/");
+    }
+    path.to_string_lossy().replace('\\', "/")
+}
+
 pub fn path_to_posix(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -435,6 +435,17 @@ fn spawn_transform(spec_path: &Path) -> CommandResult {
 /// captured stdio + exit status. Used by tests that exercise pipeline stages
 /// outside the logical-modules harness in [`run_logical_modules_e2e_fixture`].
 pub fn run_debundler(spec_path: &Path, package_roots: &[(&str, &Path)]) -> CommandResult {
+    run_debundler_with_env(spec_path, package_roots, &[])
+}
+
+/// Like [`run_debundler`], but also overrides specific environment variables
+/// on the spawned process (e.g. `BUILD_WORKSPACE_DIRECTORY` to exercise the
+/// stage-side `resolve_workspace_path` behaviour).
+pub fn run_debundler_with_env(
+    spec_path: &Path,
+    package_roots: &[(&str, &Path)],
+    env: &[(&str, &Path)],
+) -> CommandResult {
     let bin = debundler_path();
     let mut command = Command::new(&bin);
     command.arg("--spec").arg(spec_path);
@@ -442,6 +453,9 @@ pub fn run_debundler(spec_path: &Path, package_roots: &[(&str, &Path)]) -> Comma
         command
             .arg("--package-root")
             .arg(format!("{name}={}", dir.display()));
+    }
+    for (key, value) in env {
+        command.env(key, value);
     }
     let output = command
         .output()

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -2,7 +2,9 @@
 //! re-exports a synthetic upstream package, runs the swap pipeline, and
 //! asserts the generated wrapper.
 
-use debundle_e2e_support::{CommandResult, run_debundler, write_json_file, write_text_file};
+use debundle_e2e_support::{
+    CommandResult, run_debundler_with_env, write_json_file, write_text_file,
+};
 use serde_json::{Value, json};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -99,21 +101,24 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
 
     let root =
         TempDir::with_prefix("vendor-swap-named-from-module-default-").expect("create tempdir");
-    // Mirror the gaffer layout: the manifest's `generatedWrapperPath` is a
-    // workspace-relative `vendors/generated/<chunk_id>/<entry>` string, and
-    // `outputWrapperDir` must be the matching `<workspace>/vendors/generated`
-    // for the on-disk file and the recorded path to agree.
+    // The fixture passes RELATIVE output paths (`vendors/generated`,
+    // `vendors/manifest.json`, `out`) plus `BUILD_WORKSPACE_DIRECTORY` set
+    // to the test's synthetic workspace. The pipeline must resolve these
+    // against the workspace, not against the launcher's cwd, otherwise
+    // outputs land somewhere unrelated when invoked via `bazel run`.
     let workspace_root = root.path().join("workspace");
-    let extracted_root = workspace_root.join("extracted");
-    let snapshot_root = workspace_root.join("snapshot");
-    let out_root = workspace_root.join("out");
-    let wrapper_root = workspace_root.join("vendors").join("generated");
-    let manifest_path = workspace_root.join("vendors").join("manifest.json");
+    let snapshot_rel = Path::new("snapshot");
+    let extracted_rel = Path::new("extracted");
+    let out_rel = Path::new("out");
+    let wrapper_rel = Path::new("vendors/generated");
+    let manifest_rel = Path::new("vendors/manifest.json");
+    let snapshot_root = workspace_root.join(snapshot_rel);
+    let extracted_root = workspace_root.join(extracted_rel);
+    let wrapper_root = workspace_root.join(wrapper_rel);
+    let manifest_path = workspace_root.join(manifest_rel);
     let package_root = root.path().join("upstream");
     fs::create_dir_all(&extracted_root).unwrap();
     fs::create_dir_all(&snapshot_root).unwrap();
-    fs::create_dir_all(&out_root).unwrap();
-    fs::create_dir_all(&wrapper_root).unwrap();
     fs::create_dir_all(&package_root).unwrap();
     fs::create_dir_all(snapshot_root.join(Path::new(CHUNK_PATH).parent().unwrap())).unwrap();
     fs::create_dir_all(package_root.join("dist")).unwrap();
@@ -143,20 +148,25 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
         chunk_path: CHUNK_PATH,
         js_list_path: &js_list_path,
         snapshot_root: &snapshot_root,
-        out_root: &out_root,
-        manifest_path: &manifest_path,
-        wrapper_root: &wrapper_root,
+        out_root: out_rel,
+        manifest_path: manifest_rel,
+        wrapper_root: wrapper_rel,
         package_name: PACKAGE_NAME,
         package_version: PACKAGE_VERSION,
         subpath: SUBPATH,
     });
     write_json_file(&spec_path, &spec);
 
-    let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
+    let result = run_debundler_with_env(
+        &spec_path,
+        &[(PACKAGE_NAME, &package_root)],
+        &[("BUILD_WORKSPACE_DIRECTORY", &workspace_root)],
+    );
 
     // Wrapper layout: <output_wrapper_dir>/<chunk_id>/<entry_file>. chunk_id
     // is the chunk path with the trailing `.js` stripped; the normalized
-    // chunk's entry file is always `entry.js`.
+    // chunk's entry file is always `entry.js`. The pipeline resolves the
+    // relative `vendors/generated` against `BUILD_WORKSPACE_DIRECTORY`.
     let chunk_id = CHUNK_PATH.strip_suffix(".js").unwrap_or(CHUNK_PATH);
     let wrapper_path = wrapper_root.join(chunk_id).join("entry.js");
     VendorSwapFixture {
@@ -202,14 +212,8 @@ fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
                 "text": "export { x as default }",
             }],
         }],
+        "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
         "pipeline": [
-            {
-                "id": "load",
-                "operation": "load_js_chunks",
-                "args": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
-            },
-            { "id": "parse", "operation": "compute_js_asts" },
-            { "id": "normalize", "operation": "normalize_js_chunks" },
             { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
             { "id": "rename_vendor", "operation": "rename_vendor_exports" },
             {

--- a/devinfra/js/debundle/emit_harness.rs
+++ b/devinfra/js/debundle/emit_harness.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use artifact::{
     JsPipelineArtifact, chunk_id_for_js_path, materialize_artifact_scripts, path_to_posix,
-    split_posix_path,
+    resolve_workspace_path, split_posix_path,
 };
 use rewrite_specifiers::runtime_js_href;
 
@@ -76,17 +76,23 @@ pub fn emit_browser_harness(
         }
     }
 
-    prepare_harness_output_dir(&options.out_dir, options.force)?;
-    materialize_artifact_scripts(artifact, &options.out_dir)?;
-    let copied_assets = copy_snapshot_assets(&options.snapshot_root, &options.out_dir)?;
-    let bootstrap = build_bootstrap(artifact, &entry_scripts, &options.out_dir, &options.out_dir)?;
+    let resolved_out_dir = resolve_workspace_path(&options.out_dir)?;
+    prepare_harness_output_dir(&resolved_out_dir, options.force)?;
+    materialize_artifact_scripts(artifact, &resolved_out_dir)?;
+    let copied_assets = copy_snapshot_assets(&options.snapshot_root, &resolved_out_dir)?;
+    let bootstrap = build_bootstrap(
+        artifact,
+        &entry_scripts,
+        &resolved_out_dir,
+        &resolved_out_dir,
+    )?;
     let index_html =
-        rewrite_index_html(artifact, &source_html, &options.out_dir, &options.out_dir)?;
+        rewrite_index_html(artifact, &source_html, &resolved_out_dir, &resolved_out_dir)?;
 
-    fs::write(options.out_dir.join("index.html"), index_html)?;
-    fs::write(options.out_dir.join("bootstrap.js"), bootstrap)?;
+    fs::write(resolved_out_dir.join("index.html"), index_html)?;
+    fs::write(resolved_out_dir.join("bootstrap.js"), bootstrap)?;
     fs::write(
-        options.out_dir.join("chunks.manifest.json"),
+        resolved_out_dir.join("chunks.manifest.json"),
         serde_json::to_string_pretty(&serde_json::json!({
             "chunks": artifact
                 .root_manifest
@@ -101,9 +107,9 @@ pub fn emit_browser_harness(
         source_html: path_to_posix(&source_html_path),
         snapshot_root: path_to_posix(&options.snapshot_root),
         asset_summary_path: path_to_posix(&options.asset_summary_path),
-        chunks_manifest_path: path_to_posix(&options.out_dir.join("chunks.manifest.json")),
-        runtime_root: path_to_posix(&options.out_dir),
-        out_dir: path_to_posix(&options.out_dir),
+        chunks_manifest_path: path_to_posix(&resolved_out_dir.join("chunks.manifest.json")),
+        runtime_root: path_to_posix(&resolved_out_dir),
+        out_dir: path_to_posix(&resolved_out_dir),
         copied_assets,
         entry_scripts,
         module_preloads: preload_entries
@@ -111,17 +117,17 @@ pub fn emit_browser_harness(
             .map(|entry| entry.path.clone())
             .collect(),
         generated: HarnessGeneratedManifest {
-            bootstrap: path_to_posix(&options.out_dir.join("bootstrap.js")),
-            chunks_manifest: path_to_posix(&options.out_dir.join("chunks.manifest.json")),
-            index_html: path_to_posix(&options.out_dir.join("index.html")),
+            bootstrap: path_to_posix(&resolved_out_dir.join("bootstrap.js")),
+            chunks_manifest: path_to_posix(&resolved_out_dir.join("chunks.manifest.json")),
+            index_html: path_to_posix(&resolved_out_dir.join("index.html")),
         },
     };
     fs::write(
-        options.out_dir.join("manifest.json"),
+        resolved_out_dir.join("manifest.json"),
         serde_json::to_string_pretty(&manifest)? + "\n",
     )?;
     fs::write(
-        options.out_dir.join("package.json"),
+        resolved_out_dir.join("package.json"),
         "{\n  \"type\": \"module\"\n}\n",
     )?;
     Ok(())

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -14,10 +14,9 @@ use artifact::{
     ArtifactCounts, ArtifactManifest, ChunkFileRecord, ChunkLogicalModulesSummary, ChunkMetadata,
     FileMetadata, JsChunk, JsFile, JsPipelineArtifact, RootLogicalModulesSummary,
     SelectedModuleLowering, get_chunk_entry_path, normalize_relative_path, posix_join,
-    posix_relative,
+    posix_relative, resolve_workspace_path,
 };
 use js_ast::{ParsedJsModule, set_str_value, str_value};
-use write_tree::resolve_workspace_path;
 
 const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -9,8 +9,9 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use artifact::{
-    JsPipelineArtifact, get_chunk_entry_path, list_chunk_file_paths,
-    resolve_artifact_import_reference, resolve_artifact_source_import_reference, split_posix_path,
+    JsPipelineArtifact, get_chunk_entry_path, list_chunk_file_paths, relative_workspace_path,
+    resolve_artifact_import_reference, resolve_artifact_source_import_reference,
+    resolve_workspace_path, split_posix_path,
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
 
@@ -527,11 +528,12 @@ pub fn swap_vendor_chunks(
     if options.write
         && let Some(output_manifest_path) = options.output_manifest_path
     {
-        if let Some(parent) = output_manifest_path.parent() {
+        let resolved_manifest_path = resolve_workspace_path(&output_manifest_path)?;
+        if let Some(parent) = resolved_manifest_path.parent() {
             fs::create_dir_all(parent)?;
         }
         fs::write(
-            output_manifest_path,
+            resolved_manifest_path,
             serde_json::to_string_pretty(&json!({
                 "kind": "js.vendor_resolution_manifest",
                 "resolutions": resolutions,
@@ -1287,17 +1289,20 @@ fn write_wrapper_if_requested(
     entry_file: &str,
     source: &str,
 ) -> Result<Option<String>> {
-    let wrapper_rel_path = format!("vendors/generated/{chunk_id}/{entry_file}");
-    if write && let Some(output_wrapper_dir) = output_wrapper_dir {
-        let wrapper_abs_path = output_wrapper_dir
-            .join(split_posix_path(chunk_id))
-            .join(split_posix_path(entry_file));
+    let Some(output_wrapper_dir) = output_wrapper_dir else {
+        return Ok(None);
+    };
+    let resolved_dir = resolve_workspace_path(output_wrapper_dir)?;
+    let wrapper_abs_path = resolved_dir
+        .join(split_posix_path(chunk_id))
+        .join(split_posix_path(entry_file));
+    if write {
         if let Some(parent) = wrapper_abs_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(wrapper_abs_path, source)?;
+        fs::write(&wrapper_abs_path, source)?;
     }
-    Ok(Some(wrapper_rel_path))
+    Ok(Some(relative_workspace_path(&wrapper_abs_path)))
 }
 
 fn set_diff(left: &BTreeSet<String>, right: &BTreeSet<String>) -> BTreeSet<String> {

--- a/devinfra/js/debundle/write_tree.rs
+++ b/devinfra/js/debundle/write_tree.rs
@@ -1,10 +1,13 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 
-use artifact::{JsPipelineArtifact, list_chunk_file_paths, split_posix_path};
+use artifact::{
+    JsPipelineArtifact, list_chunk_file_paths, relative_workspace_path, resolve_workspace_path,
+    split_posix_path,
+};
 use js_ast::emit_js_module;
 
 #[derive(Debug, Clone, Serialize)]
@@ -96,19 +99,6 @@ pub fn write_js_tree(
     })
 }
 
-pub fn resolve_workspace_path(path: &Path) -> Result<PathBuf> {
-    if path.is_absolute() {
-        return Ok(path.to_path_buf());
-    }
-    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
-        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
-        .or_else(|_| std::env::var("PWD"))
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or(std::env::current_dir()?);
-    Ok(workspace.join(path))
-}
-
 fn prepare_output_dir(out_dir: &Path, force: bool) -> Result<()> {
     if out_dir.exists() {
         let metadata = fs::metadata(out_dir)?;
@@ -130,21 +120,4 @@ fn prepare_output_dir(out_dir: &Path, force: bool) -> Result<()> {
     }
     fs::create_dir_all(out_dir)?;
     Ok(())
-}
-
-fn relative_workspace_path(path: &Path) -> String {
-    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
-        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
-        .or_else(|_| std::env::var("PWD"))
-        .ok()
-        .map(PathBuf::from);
-    if let Some(workspace) = workspace
-        && let Ok(rel) = path.strip_prefix(&workspace)
-    {
-        if rel.as_os_str().is_empty() {
-            return path.to_string_lossy().replace('\\', "/");
-        }
-        return rel.to_string_lossy().replace('\\', "/");
-    }
-    path.to_string_lossy().replace('\\', "/")
 }


### PR DESCRIPTION
## Summary

Outputs of `swap_vendor_chunks` (manifest + per-chunk wrappers) and `emit_browser_harness` (harness manifest, bootstrap, index.html, ...) wrote straight to the path passed in args. When relative — as gaffer's spec passes them — they resolved against the launcher cwd. Under `bazel run` cwd is the runfiles tree, so the canonical Tana outputs landed in `bazel-bin/.../*.runfiles/_main/tana/re/web/out/...` and the source tree was never updated.

**Closed without merging — superseded.** Direction changed: rather than teaching the debundler to be workspace-aware, the gaffer-side analysis manifests will become Bazel outputs (consumed via labels by the live-proxy / dev tools / tests, all of which are themselves Bazel-launched). Only the emitted JS gets copied back to the source tree (via a `regen_emitted_js` target) for diff-as-review. The debundler stops doing workspace path resolution; the spec generator passes absolute paths in.

Replacement work split as: (a) ducktape — switch the manifest contract so paths are recorded relative to the manifest's own dir, drop `resolve_workspace_path` from input handling, update live-proxy to resolve against manifest dir; (b) gaffer — parameterize spec generator on `outRoot`, wrap pipeline in a Bazel rule, switch consumers, delete committed Cat A JSON, add `regen_emitted_js`. Track in follow-up PRs.