### PR TITLE
debundle: vendor-swap named-from-module-default supports anonymous default fn/class

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -38,6 +38,32 @@ const lib = { ping() { return "pong"; } };
     assert_wrapper_named_from_module_default(&fixture);
 }
 
+#[test]
+fn named_from_module_default_handles_anonymous_default_function() {
+    // `export default function () { ... }` collapses into
+    // `const __vendor_default__ = function () { ... };`.
+    let upstream_source = r#"export default function () { return "ping"; }
+"#;
+
+    let fixture = run_named_from_module_default_fixture(upstream_source);
+
+    assert_wrapper_named_from_module_default(&fixture);
+}
+
+#[test]
+fn named_from_module_default_handles_anonymous_default_class() {
+    // `export default class { ... }` collapses into
+    // `const __vendor_default__ = class { ... };`.
+    let upstream_source = r#"export default class {
+  ping() { return "ping"; }
+}
+"#;
+
+    let fixture = run_named_from_module_default_fixture(upstream_source);
+
+    assert_wrapper_named_from_module_default(&fixture);
+}
+
 fn assert_wrapper_named_from_module_default(fixture: &VendorSwapFixture) {
     assert!(
         fixture.result.status.success(),
@@ -202,14 +228,8 @@ fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
                 "text": "export { x as default }",
             }],
         }],
+        "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
         "pipeline": [
-            {
-                "id": "load",
-                "operation": "load_js_chunks",
-                "args": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
-            },
-            { "id": "parse", "operation": "compute_js_asts" },
-            { "id": "normalize", "operation": "normalize_js_chunks" },
             { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
             { "id": "rename_vendor", "operation": "rename_vendor_exports" },
             {

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1183,9 +1183,15 @@ fn generate_named_from_module_default_wrapper(
                             }))));
                             body.push(const_alias(default_local_name, ident.sym.as_ref()));
                         } else {
-                            bail!(
-                                "swapVendorChunks operation {op_id} named-from-module-default: anonymous default function is unsupported by Rust AST wrapper"
-                            );
+                            // Anonymous `export default function () { ... }`
+                            // collapses to `const __vendor_default__ = function () { ... };`.
+                            body.push(const_init_with_expr(
+                                default_local_name,
+                                Expr::Fn(FnExpr {
+                                    ident: None,
+                                    function: function.function.clone(),
+                                }),
+                            ));
                         }
                     }
                     DefaultDecl::Class(class) => {
@@ -1197,9 +1203,15 @@ fn generate_named_from_module_default_wrapper(
                             }))));
                             body.push(const_alias(default_local_name, ident.sym.as_ref()));
                         } else {
-                            bail!(
-                                "swapVendorChunks operation {op_id} named-from-module-default: anonymous default class is unsupported by Rust AST wrapper"
-                            );
+                            // Anonymous `export default class { ... }` collapses
+                            // to `const __vendor_default__ = class { ... };`.
+                            body.push(const_init_with_expr(
+                                default_local_name,
+                                Expr::Class(ClassExpr {
+                                    ident: None,
+                                    class: class.class.clone(),
+                                }),
+                            ));
                         }
                     }
                     DefaultDecl::TsInterfaceDecl(_) => {}
@@ -1364,6 +1376,13 @@ fn export_const_ident(export_name: &str, local_name: &str) -> ModuleItem {
 }
 
 fn const_alias(alias: &str, target: &str) -> ModuleItem {
+    const_init_with_expr(
+        alias,
+        Expr::Ident(Ident::new_no_ctxt(target.into(), DUMMY_SP)),
+    )
+}
+
+fn const_init_with_expr(alias: &str, init: Expr) -> ModuleItem {
     ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
         span: DUMMY_SP,
         ctxt: SyntaxContext::empty(),
@@ -1375,10 +1394,7 @@ fn const_alias(alias: &str, target: &str) -> ModuleItem {
                 id: Ident::new_no_ctxt(alias.into(), DUMMY_SP),
                 type_ann: None,
             }),
-            init: Some(Box::new(Expr::Ident(Ident::new_no_ctxt(
-                target.into(),
-                DUMMY_SP,
-            )))),
+            init: Some(Box::new(init)),
             definite: false,
         }],
     }))))


### PR DESCRIPTION
## Summary

The `named-from-module-default` wrapper used to bail when the upstream's default was an anonymous function or class declaration (`export default function () { ... }` or `export default class { ... }`). The decl form has no identifier to alias, so the existing path could not emit `const __vendor_default__ = <name>;`.

Collapse those two cases into the same shape the `ExportDefaultExpr` arm already takes: emit `const __vendor_default__ = function () { ... };` or `const __vendor_default__ = class { ... };` directly. A new `const_init_with_expr` helper backs both `const_alias` and the new arms so the var-decl plumbing lives in one place.

Also: devel's `vendor_swap_test` fixture was still using the old pre-#1443 spec shape (load_js_chunks as a pipeline stage), so it failed validation with "Transform spec must contain an inputs object…". This PR brings the fixture forward to top-level `inputs`.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 7/7 pass.
- [x] Two new e2e tests cover the anonymous-default-fn and anonymous-default-class shapes alongside the existing named-default and as-default-re-export tests.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_