### PR TITLE
debundle: manifest-relative paths; drop workspace lookup from binary

### DIFF
--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -637,6 +637,28 @@ pub fn path_to_posix(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+/// Render `target` as a path string for inclusion in a manifest serialized at
+/// `manifest_path`. If `target` is under `manifest_path`'s parent, the result
+/// is relative to that parent (so the manifest tree is portable across
+/// machines). Otherwise the absolute form is returned. Callers are expected
+/// to pass absolute paths for both arguments; relative inputs are returned
+/// verbatim.
+pub fn manifest_relative_path(manifest_path: &Path, target: &Path) -> String {
+    let Some(manifest_dir) = manifest_path.parent() else {
+        return path_to_posix(target);
+    };
+    if !manifest_dir.is_absolute() || !target.is_absolute() {
+        return path_to_posix(target);
+    }
+    if let Ok(rel) = target.strip_prefix(manifest_dir) {
+        if rel.as_os_str().is_empty() {
+            return ".".to_string();
+        }
+        return path_to_posix(rel);
+    }
+    path_to_posix(target)
+}
+
 pub fn posix_join(parts: &[&str]) -> String {
     let mut out = Vec::new();
     for raw in parts {

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -87,9 +87,10 @@ fn assert_wrapper_named_from_module_default(fixture: &VendorSwapFixture) {
         "wrapper should not re-emit the original upstream `export {{ ... as default }}` once the wrapper has its own default export:\n{wrapper_source}",
     );
 
-    // Cross-check the resolution manifest: the recorded `generatedWrapperPath`
-    // (workspace-relative) must resolve to the wrapper file the test located
-    // by following the `outputWrapperDir` convention.
+    // Cross-check the resolution manifest: `generatedWrapperPath` is recorded
+    // relative to the manifest's own directory, so resolving it against
+    // `dirname(manifest_path)` must produce the wrapper file's actual
+    // on-disk path.
     let manifest: Value =
         serde_json::from_str(&fs::read_to_string(&fixture.manifest_path).expect("manifest exists"))
             .expect("manifest parses as JSON");
@@ -99,7 +100,11 @@ fn assert_wrapper_named_from_module_default(fixture: &VendorSwapFixture) {
         .and_then(|r| r.get("generatedWrapperPath"))
         .and_then(Value::as_str)
         .expect("manifest records generatedWrapperPath");
-    let resolved = fixture.workspace_root.join(recorded);
+    let manifest_dir = fixture
+        .manifest_path
+        .parent()
+        .expect("manifest path has a parent");
+    let resolved = manifest_dir.join(recorded);
     assert_eq!(
         fs::canonicalize(&resolved).expect("resolved manifest path canonicalizes"),
         fs::canonicalize(&fixture.wrapper_path).expect("wrapper path canonicalizes"),
@@ -113,7 +118,6 @@ struct VendorSwapFixture {
     chunk_path: String,
     wrapper_path: PathBuf,
     manifest_path: PathBuf,
-    workspace_root: PathBuf,
     _root: TempDir,
 }
 
@@ -125,10 +129,11 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
 
     let root =
         TempDir::with_prefix("vendor-swap-named-from-module-default-").expect("create tempdir");
-    // Mirror the gaffer layout: the manifest's `generatedWrapperPath` is a
-    // workspace-relative `vendors/generated/<chunk_id>/<entry>` string, and
-    // `outputWrapperDir` must be the matching `<workspace>/vendors/generated`
-    // for the on-disk file and the recorded path to agree.
+    // Output paths the binary writes to are absolute (the new contract — no
+    // workspace lookup in the binary). The vendor manifest lives at
+    // `<root>/workspace/vendors/manifest.json`; wrappers go to its sibling
+    // `generated/<chunk_id>/<entry>`, so manifest-relative emission produces
+    // `generated/<chunk_id>/<entry>` strings.
     let workspace_root = root.path().join("workspace");
     let extracted_root = workspace_root.join("extracted");
     let snapshot_root = workspace_root.join("snapshot");
@@ -190,7 +195,6 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
         chunk_path: CHUNK_PATH.to_string(),
         wrapper_path,
         manifest_path,
-        workspace_root,
         _root: root,
     }
 }

--- a/devinfra/js/debundle/emit_harness.rs
+++ b/devinfra/js/debundle/emit_harness.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use artifact::{
-    JsPipelineArtifact, chunk_id_for_js_path, materialize_artifact_scripts, path_to_posix,
-    split_posix_path,
+    JsPipelineArtifact, chunk_id_for_js_path, manifest_relative_path, materialize_artifact_scripts,
+    path_to_posix, split_posix_path,
 };
 use rewrite_specifiers::runtime_js_href;
 
@@ -96,14 +96,16 @@ pub fn emit_browser_harness(
                 .clone(),
         }))? + "\n",
     )?;
+    let manifest_path = options.out_dir.join("manifest.json");
+    let rel = |target: &Path| manifest_relative_path(&manifest_path, target);
     let manifest = HarnessManifest {
         schema_version: 1,
-        source_html: path_to_posix(&source_html_path),
-        snapshot_root: path_to_posix(&options.snapshot_root),
-        asset_summary_path: path_to_posix(&options.asset_summary_path),
-        chunks_manifest_path: path_to_posix(&options.out_dir.join("chunks.manifest.json")),
-        runtime_root: path_to_posix(&options.out_dir),
-        out_dir: path_to_posix(&options.out_dir),
+        source_html: rel(&source_html_path),
+        snapshot_root: rel(&options.snapshot_root),
+        asset_summary_path: rel(&options.asset_summary_path),
+        chunks_manifest_path: rel(&options.out_dir.join("chunks.manifest.json")),
+        runtime_root: rel(&options.out_dir),
+        out_dir: rel(&options.out_dir),
         copied_assets,
         entry_scripts,
         module_preloads: preload_entries
@@ -111,13 +113,13 @@ pub fn emit_browser_harness(
             .map(|entry| entry.path.clone())
             .collect(),
         generated: HarnessGeneratedManifest {
-            bootstrap: path_to_posix(&options.out_dir.join("bootstrap.js")),
-            chunks_manifest: path_to_posix(&options.out_dir.join("chunks.manifest.json")),
-            index_html: path_to_posix(&options.out_dir.join("index.html")),
+            bootstrap: rel(&options.out_dir.join("bootstrap.js")),
+            chunks_manifest: rel(&options.out_dir.join("chunks.manifest.json")),
+            index_html: rel(&options.out_dir.join("index.html")),
         },
     };
     fs::write(
-        options.out_dir.join("manifest.json"),
+        &manifest_path,
         serde_json::to_string_pretty(&manifest)? + "\n",
     )?;
     fs::write(

--- a/devinfra/js/debundle/live_proxy/proxy.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy.mjs
@@ -1,5 +1,5 @@
 import { createReadStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { extname, isAbsolute, join, normalize, resolve, sep } from "node:path";
+import { dirname, extname, isAbsolute, join, normalize, resolve } from "node:path";
 import { createServer as createHttpsServer } from "node:https";
 import { Agent as HttpsAgent } from "node:https";
 
@@ -141,7 +141,6 @@ export function loadLiveProxyConfiguration(rawOptions) {
     : join(appRoot, "vendors", "manifest.json");
   const vendorRuntimeIndex = loadVendorRuntimeIndex({
     manifestPath: vendorManifestPath,
-    outRoot: appRoot,
     ...(options.packageRoots ? { packageRoots: options.packageRoots } : {}),
     ...(options.packagesRoot ? { packagesRoot: options.packagesRoot } : {}),
   });
@@ -200,28 +199,11 @@ function resolveAppBaseUrl({ appManifest, assetSummary, manifestContext }) {
   return sourceMetadata.baseUrl ?? null;
 }
 
-function resolveManifestReferencedPath(value, { appManifest, appManifestPath }) {
+function resolveManifestReferencedPath(value, { appManifestPath }) {
   if (isAbsolute(value)) {
     return resolvePath(value);
   }
-  const workspaceRoot = deriveManifestWorkspaceRoot(appManifestPath, appManifest);
-  if (workspaceRoot) {
-    return resolve(workspaceRoot, value);
-  }
-  return resolveWorkspacePath(value);
-}
-
-function deriveManifestWorkspaceRoot(appManifestPath, appManifest) {
-  if (!appManifestPath || !appManifest?.outDir) {
-    return null;
-  }
-  const normalizedManifestPath = resolvePath(appManifestPath).split(sep).join("/");
-  const normalizedOutDir = normalizeRelativePath(appManifest.outDir);
-  const suffix = `/${normalizedOutDir}/manifest.json`;
-  if (!normalizedManifestPath.endsWith(suffix)) {
-    return null;
-  }
-  return normalizedManifestPath.slice(0, -suffix.length);
+  return resolve(dirname(appManifestPath), value);
 }
 
 function normalizeRelativePath(value) {

--- a/devinfra/js/debundle/live_proxy/proxy_test.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy_test.mjs
@@ -283,7 +283,11 @@ test("mapLocalAssetPath serves swapped vendor chunks from package roots and gene
         version: "1.2.1",
         subpath: "sets/15/native.json",
         wrapperShape: "named-from-json-default",
-        generatedWrapperPath: "vendors/generated/static/native-B5Vb9Oiz/runtime.js",
+        // Vendor manifest sits at <root>/vendors/manifest.json; the wrapper
+        // file is its sibling under generated/. With manifest-relative
+        // resolution the recorded path is rooted at the vendor manifest's
+        // own directory.
+        generatedWrapperPath: "generated/static/native-B5Vb9Oiz/runtime.js",
       },
     },
   });
@@ -316,7 +320,7 @@ test("mapLocalAssetPath serves swapped vendor chunks from package roots and gene
 
   const wrapperHit = mapLocalAssetPath("/_debundle/live/vendor/app/static/native-B5Vb9Oiz/runtime.js", config);
   assert.equal(wrapperHit.kind, "vendor-file");
-  assert.ok(wrapperHit.filePath.endsWith("/vendors/generated/static/native-B5Vb9Oiz/runtime.js"));
+  assert.equal(wrapperHit.filePath, join(fixture.vendorsRoot, "generated", "static", "native-B5Vb9Oiz", "runtime.js"));
 
   const appHit = mapLocalAssetPath("/_debundle/live/vendor/app/static/index-Example/runtime.js", config);
   assert.equal(appHit.kind, "file");

--- a/devinfra/js/debundle/live_proxy/proxy_test.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy_test.mjs
@@ -133,16 +133,20 @@ test("loadLiveProxyConfiguration falls back to SOURCE.json for the target base U
   assert.equal(config.bootstrapUrl, "/_debundle/live/source-fallback/app/bootstrap.js");
 });
 
-test("loadLiveProxyConfiguration resolves manifest-relative workspace paths from an absolute manifest location", () => {
+test("loadLiveProxyConfiguration resolves manifest-dir-relative paths from an absolute manifest location", () => {
   const fixture = writeBaseLiveProxyFixture("debundle-live-proxy-runfiles-manifest-", {
     sourceBaseUrl: "https://app.example.com",
     uiVersion: "runfiles",
   });
   writeJsonFile(fixture.assetSummaryPath, {});
+  // The pipeline emits paths relative to the manifest's own directory.
+  // appManifest sits at <root>/app/manifest.json; outDir is the manifest's
+  // own dir, asset-summary.json is the parent dir, sourceHtml is in the
+  // sibling source/ tree.
   writeJsonFile(fixture.appManifestPath, {
-    assetSummaryPath: "asset-summary.json",
-    outDir: "app",
-    sourceHtml: "source/index.html",
+    assetSummaryPath: "../asset-summary.json",
+    outDir: ".",
+    sourceHtml: "../source/index.html",
     uiVersion: "runfiles",
   });
 

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
@@ -14,9 +14,10 @@ export function loadVendorResolutionManifest(manifestPath) {
   return raw.resolutions ?? {};
 }
 
-export function loadVendorRuntimeIndex({ manifestPath, outRoot, packageRoots, packagesRoot }) {
+export function loadVendorRuntimeIndex({ manifestPath, packageRoots, packagesRoot }) {
   const resolutions = loadVendorResolutionManifest(manifestPath);
   const byChunkId = new Map();
+  const manifestDir = dirname(manifestPath);
   for (const [resolutionChunkPath, entry] of Object.entries(resolutions)) {
     const chunkPath = entry.chunkPath ?? resolutionChunkPath;
     if (!entry.package || !entry.subpath || !entry.version) {
@@ -24,9 +25,9 @@ export function loadVendorRuntimeIndex({ manifestPath, outRoot, packageRoots, pa
     }
     const chunkId = chunkIdForChunkPath(chunkPath);
     const entryFile = resolveVendorManifestEntryFile(entry, { chunkPath, manifestPath });
-    const filePath = entry.generatedWrapperPath
-      ? resolve(outRoot ?? dirname(dirname(manifestPath)), entry.generatedWrapperPath)
-      : resolvePackageSubpath(entry.package, entry.subpath, { packageRoots, packagesRoot });
+    const wrapperAbsPath = entry.generatedWrapperPath ? resolve(manifestDir, entry.generatedWrapperPath) : null;
+    const filePath =
+      wrapperAbsPath ?? resolvePackageSubpath(entry.package, entry.subpath, { packageRoots, packagesRoot });
     const mountRoot = resolveMountRoot(filePath, entryFile);
     const mountedEntryFile = normalizeMountedRelativePath(relative(mountRoot, filePath));
     byChunkId.set(chunkId, {
@@ -39,9 +40,9 @@ export function loadVendorRuntimeIndex({ manifestPath, outRoot, packageRoots, pa
       package: entry.package,
       subpath: entry.subpath,
       version: entry.version,
-      ...(entry.generatedWrapperPath
+      ...(wrapperAbsPath
         ? {
-            generatedWrapperPath: resolve(outRoot ?? dirname(dirname(manifestPath)), entry.generatedWrapperPath),
+            generatedWrapperPath: wrapperAbsPath,
             wrapperShape: entry.wrapperShape ?? "generated-wrapper",
           }
         : {}),

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -13,11 +13,10 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use artifact::{
     ArtifactCounts, ArtifactManifest, ChunkFileRecord, ChunkLogicalModulesSummary, ChunkMetadata,
     FileMetadata, JsChunk, JsFile, JsPipelineArtifact, RootLogicalModulesSummary,
-    SelectedModuleLowering, get_chunk_entry_path, normalize_relative_path, posix_join,
-    posix_relative,
+    SelectedModuleLowering, get_chunk_entry_path, manifest_relative_path, normalize_relative_path,
+    path_to_posix, posix_join, posix_relative,
 };
 use js_ast::{ParsedJsModule, set_str_value, str_value};
-use write_tree::resolve_workspace_path;
 
 const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";
@@ -150,9 +149,8 @@ pub fn materialize_logical_modules(
 
     let mut report_out_dir = None;
     if let Some(dir) = &options.report_out_dir {
-        let resolved = resolve_workspace_path(dir)?;
-        prepare_output_dir(&resolved, options.force)?;
-        report_out_dir = Some(resolved);
+        prepare_output_dir(dir, options.force)?;
+        report_out_dir = Some(dir.clone());
     }
 
     if options.prune_other_chunks {
@@ -380,18 +378,23 @@ pub fn materialize_logical_modules(
         chunks: reports,
         duration_ms: started.elapsed().as_secs_f64() * 1000.0,
         kind: "js.logical_module_manifest",
-        report_out_dir: report_out_dir
-            .as_ref()
-            .map(|path| path.to_string_lossy().replace('\\', "/")),
+        report_out_dir: report_out_dir.as_ref().map(|path| {
+            options
+                .report_summary_path
+                .as_ref()
+                .map_or_else(|| path_to_posix(path), |s| manifest_relative_path(s, path))
+        }),
         schema_version: 1,
     };
 
     if let Some(summary_path) = options.report_summary_path {
-        let resolved = resolve_workspace_path(&summary_path)?;
-        if let Some(parent) = resolved.parent() {
+        if let Some(parent) = summary_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(resolved, serde_json::to_string_pretty(&manifest)? + "\n")?;
+        fs::write(
+            summary_path,
+            serde_json::to_string_pretty(&manifest)? + "\n",
+        )?;
     }
     Ok(manifest)
 }

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -9,7 +9,7 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use artifact::{
-    JsPipelineArtifact, get_chunk_entry_path, list_chunk_file_paths,
+    JsPipelineArtifact, get_chunk_entry_path, list_chunk_file_paths, manifest_relative_path,
     resolve_artifact_import_reference, resolve_artifact_source_import_reference, split_posix_path,
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
@@ -338,7 +338,7 @@ pub fn swap_vendor_chunks(
         let upstream_code = fs::read_to_string(&upstream_path)
             .with_context(|| format!("reading {}", upstream_path.display()))?;
         let vendor_exports = collect_exported_names(&entry_ast.module, false);
-        let mut generated_wrapper_path = None::<String>;
+        let mut generated_wrapper_path = None::<PathBuf>;
 
         match value_str(op, "wrapperShape") {
             Some("named-from-default") => {
@@ -464,10 +464,12 @@ pub fn swap_vendor_chunks(
                 Value::String(wrapper_shape.to_string()),
             );
         }
-        if let Some(path) = &generated_wrapper_path {
+        if let Some(path) = &generated_wrapper_path
+            && let Some(manifest_path) = options.output_manifest_path.as_deref()
+        {
             swap_entry.insert(
                 "generatedWrapperPath".to_string(),
-                Value::String(path.clone()),
+                Value::String(manifest_relative_path(manifest_path, path)),
             );
         }
         let mut annotation = artifact
@@ -506,8 +508,13 @@ pub fn swap_vendor_chunks(
                 Value::String(wrapper_shape.to_string()),
             );
         }
-        if let Some(path) = generated_wrapper_path {
-            resolution.insert("generatedWrapperPath".to_string(), Value::String(path));
+        if let Some(path) = generated_wrapper_path
+            && let Some(manifest_path) = options.output_manifest_path.as_deref()
+        {
+            resolution.insert(
+                "generatedWrapperPath".to_string(),
+                Value::String(manifest_relative_path(manifest_path, &path)),
+            );
         }
         resolutions.insert(chunk_path.to_string(), Value::Object(resolution));
     }
@@ -1298,18 +1305,20 @@ fn write_wrapper_if_requested(
     chunk_id: &str,
     entry_file: &str,
     source: &str,
-) -> Result<Option<String>> {
-    let wrapper_rel_path = format!("vendors/generated/{chunk_id}/{entry_file}");
-    if write && let Some(output_wrapper_dir) = output_wrapper_dir {
-        let wrapper_abs_path = output_wrapper_dir
-            .join(split_posix_path(chunk_id))
-            .join(split_posix_path(entry_file));
+) -> Result<Option<PathBuf>> {
+    let Some(output_wrapper_dir) = output_wrapper_dir else {
+        return Ok(None);
+    };
+    let wrapper_abs_path = output_wrapper_dir
+        .join(split_posix_path(chunk_id))
+        .join(split_posix_path(entry_file));
+    if write {
         if let Some(parent) = wrapper_abs_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(wrapper_abs_path, source)?;
+        fs::write(&wrapper_abs_path, source)?;
     }
-    Ok(Some(wrapper_rel_path))
+    Ok(Some(wrapper_abs_path))
 }
 
 fn set_diff(left: &BTreeSet<String>, right: &BTreeSet<String>) -> BTreeSet<String> {

--- a/devinfra/js/debundle/write_tree.rs
+++ b/devinfra/js/debundle/write_tree.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
@@ -11,6 +11,9 @@ use js_ast::emit_js_module;
 #[serde(rename_all = "camelCase")]
 pub struct WriteJsTreeManifest {
     pub kind: &'static str,
+    /// Always `"."` — the manifest sits at `<out_dir>/manifest.json`, so
+    /// `out_dir` is the manifest's own directory. Recorded explicitly so
+    /// downstream readers can confirm the manifest's role.
     pub out_dir: String,
     pub counts: WriteJsTreeCounts,
     pub files: Vec<String>,
@@ -30,8 +33,7 @@ pub fn write_js_tree(
     if out_dir.as_os_str().is_empty() {
         bail!("writeJsTree requires outDir");
     }
-    let resolved_out_dir = resolve_workspace_path(out_dir)?;
-    prepare_output_dir(&resolved_out_dir, force)?;
+    prepare_output_dir(out_dir, force)?;
 
     let chunk_ids = artifact.list_chunk_ids();
     let mut files = Vec::new();
@@ -49,7 +51,7 @@ pub fn write_js_tree(
                 .ast
                 .as_ref()
                 .with_context(|| format!("artifact file has no AST: {chunk_id}/{file_path}"))?;
-            let output_path = resolved_out_dir
+            let output_path = out_dir
                 .join(split_posix_path(chunk_id))
                 .join(split_posix_path(&file_path));
             if let Some(parent) = output_path.parent() {
@@ -62,13 +64,13 @@ pub fn write_js_tree(
 
     if let Some(root_manifest) = &artifact.root_manifest {
         fs::write(
-            resolved_out_dir.join("manifest.json"),
+            out_dir.join("manifest.json"),
             serde_json::to_string_pretty(root_manifest)? + "\n",
         )?;
     }
     for chunk_id in &chunk_ids {
         if let Some(manifest) = artifact.chunk_manifests.get(chunk_id) {
-            let manifest_path = resolved_out_dir
+            let manifest_path = out_dir
                 .join(split_posix_path(chunk_id))
                 .join("manifest.json");
             if let Some(parent) = manifest_path.parent() {
@@ -81,32 +83,19 @@ pub fn write_js_tree(
         }
     }
     fs::write(
-        resolved_out_dir.join("package.json"),
+        out_dir.join("package.json"),
         serde_json::to_string_pretty(&serde_json::json!({ "type": "module" }))? + "\n",
     )?;
 
     Ok(WriteJsTreeManifest {
         kind: "js.write_js_tree_manifest",
-        out_dir: relative_workspace_path(&resolved_out_dir),
+        out_dir: ".".to_string(),
         counts: WriteJsTreeCounts {
             chunks: chunk_ids.len(),
             files: files.len(),
         },
         files,
     })
-}
-
-pub fn resolve_workspace_path(path: &Path) -> Result<PathBuf> {
-    if path.is_absolute() {
-        return Ok(path.to_path_buf());
-    }
-    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
-        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
-        .or_else(|_| std::env::var("PWD"))
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or(std::env::current_dir()?);
-    Ok(workspace.join(path))
 }
 
 fn prepare_output_dir(out_dir: &Path, force: bool) -> Result<()> {
@@ -130,21 +119,4 @@ fn prepare_output_dir(out_dir: &Path, force: bool) -> Result<()> {
     }
     fs::create_dir_all(out_dir)?;
     Ok(())
-}
-
-fn relative_workspace_path(path: &Path) -> String {
-    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
-        .or_else(|_| std::env::var("BUILD_WORKING_DIRECTORY"))
-        .or_else(|_| std::env::var("PWD"))
-        .ok()
-        .map(PathBuf::from);
-    if let Some(workspace) = workspace
-        && let Ok(rel) = path.strip_prefix(&workspace)
-    {
-        if rel.as_os_str().is_empty() {
-            return path.to_string_lossy().replace('\\', "/");
-        }
-        return rel.to_string_lossy().replace('\\', "/");
-    }
-    path.to_string_lossy().replace('\\', "/")
 }


### PR DESCRIPTION
## Summary

Switch the debundler's manifest output convention so every path it records is relative to the manifest's own directory (or absolute, when the target is outside that tree). Each generated manifest now describes a self-contained tree; the live-proxy resolves manifest entries against `dirname(manifestPath)` without needing to know the workspace root. Removes the `BUILD_WORKSPACE_DIRECTORY` lookup the binary used to apply to spec input/output paths.

This unblocks Phase 2 in gaffer: the spec generator can pass absolute output paths from a Bazel rule, the pipeline emits to `bazel-bin/`, and consumers (live-proxy, `generate_logical_members.py`, the snapshot test) read the manifests through runfiles instead of from the source tree. After Phase 2 lands the gaffer-side committed Cat A JSON manifests are deleted; only the emitted JS stays committed (regenerated via a `regen_emitted_js` target) for diff-as-review.

### Binary

- `manifest_relative_path(manifest_path, target)` helper in `artifact.rs`. Returns target relative to `manifest_path.parent()` when under it, absolute otherwise; `.` when the two are equal.
- `vendor.rs::swap_vendor_chunks`: `generatedWrapperPath` is manifest-relative against `outputManifestPath`. `write_wrapper_if_requested` returns the absolute on-disk wrapper path; the caller computes manifest-relative for serialization. Also fixes the long-standing hardcode of `vendors/generated/...` regardless of the configured `outputWrapperDir` (Copilot flagged this on #1442).
- `emit_harness.rs`: every path on `HarnessManifest` (`outDir`, `assetSummaryPath`, `sourceHtml`, `snapshotRoot`, `chunksManifestPath`, `runtimeRoot`, `generated.{bootstrap, chunksManifest, indexHtml}`) is recorded relative to the manifest directory. `outDir` is therefore `"."`.
- `write_tree.rs` + `logical_modules.rs`: drop `resolve_workspace_path` / `relative_workspace_path`. Outputs go to the path in the spec, no workspace lookup. `WriteJsTreeManifest.out_dir` is `"."`.

### Live-proxy

- `proxy.mjs::resolveManifestReferencedPath`: relative paths resolve against `dirname(appManifestPath)`. Drops `deriveManifestWorkspaceRoot` and the workspace-env fallback. Manifest references are absolute or manifest-dir-relative, never workspace-relative.
- `vendor_runtime.mjs::loadVendorRuntimeIndex`: drops the `outRoot` parameter and resolves `generatedWrapperPath` against the vendor manifest's own directory. Wrapper paths are self-anchored to the manifest, decoupled from the app `outDir`.

### Tests

- `proxy_test.mjs` "resolves manifest-dir-relative paths from an absolute manifest location" now writes paths relative to the manifest directory (e.g. `"../source/index.html"` for a sibling tree).
- `vendor_swap_test.rs` resolves `generatedWrapperPath` against `dirname(manifest_path)` and drops the unused `workspace_root` field.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 7/7 pass.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_