### PR TITLE
debundle: relax manifest_relative_path absolute-path guard

### DIFF
--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -639,17 +639,15 @@ pub fn path_to_posix(path: &Path) -> String {
 
 /// Render `target` as a path string for inclusion in a manifest serialized at
 /// `manifest_path`. If `target` is under `manifest_path`'s parent, the result
-/// is relative to that parent (so the manifest tree is portable across
-/// machines). Otherwise the absolute form is returned. Callers are expected
-/// to pass absolute paths for both arguments; relative inputs are returned
-/// verbatim.
+/// is relative to that parent (so the manifest tree is portable). Otherwise
+/// `target` is returned verbatim. The two paths must share an anchor —
+/// either both absolute or both relative to the same cwd; mixing the two
+/// produces a degenerate "no common prefix" result and `target` falls
+/// through unchanged.
 pub fn manifest_relative_path(manifest_path: &Path, target: &Path) -> String {
     let Some(manifest_dir) = manifest_path.parent() else {
         return path_to_posix(target);
     };
-    if !manifest_dir.is_absolute() || !target.is_absolute() {
-        return path_to_posix(target);
-    }
     if let Ok(rel) = target.strip_prefix(manifest_dir) {
         if rel.as_os_str().is_empty() {
             return ".".to_string();


### PR DESCRIPTION
## Summary

`manifest_relative_path` previously bailed out and returned the target verbatim whenever either path was non-absolute. The guard was overly defensive — `Path::strip_prefix` works equivalently for two absolute paths or two relative paths against the same anchor; only the mixed-anchor case gives a degenerate result, and that case still falls through to the returned-verbatim branch via `strip_prefix` failing.

Removing the guard makes the helper usable from callers that hand it relative paths anchored to the same cwd — e.g. a Bazel rule running the debundler under `cd $BAZEL_BINDIR` with bin-dir-relative `outputManifestPath` / `outputWrapperDir`. Without this, the manifest's own `outDir` would be stored verbatim (`"tana/re/web/transforms/debundle.out"`) instead of the expected `"."`.

This unblocks the gaffer-side Bazel pipeline rule, which feeds bin-dir-relative paths into the debundler.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 7/7 pass.
- [x] Absolute-input call sites are unchanged: `strip_prefix` on two absolute paths still produces `"."` or the relative-from-prefix form. The mixed-anchor case still falls through to the verbatim-target branch.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_