### PR TITLE
debundle/TODO: note plan to internalize input-loading stages

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -3,6 +3,24 @@
 Forward-looking gaps in the Rust debundler. Items are written to be removed
 once closed; this file is not a changelog.
 
+## Internalize input loading
+
+`load_js_chunks` / `compute_js_asts` / `normalize_js_chunks` are no longer
+exposed in the spec — PR #1443 made them auto-prepended from the spec-level
+`inputs` block — but they're still implemented as pipeline stages that the
+runner virtually inserts into the dispatch list. There is no remaining
+caller that benefits from the stage shape: the binary always runs them
+exactly once, in the same order, with args sourced from `inputs`. They
+should be plain startup code paths in `pipeline.rs` (or a small
+`load_inputs.rs`), not stages in the dispatch table or stage-id enum.
+
+Once internalized:
+
+- the `STAGE_IDS` for the three input-loading stages can be removed,
+- the dispatch arms for their `operation` strings can be deleted, and
+- the spec validator no longer needs the "auto-prepend" shim — `inputs`
+  becomes the single way these run.
+
 ## RE coverage side-output
 
 Re-introduce the deleted `extract_scrambled_identifier_frequencies` analysis


### PR DESCRIPTION
## Summary

Records a plan to internalize the input-loading stages (`load_js_chunks` / `compute_js_asts` / `normalize_js_chunks`). They were removed from the spec surface in #1443 (auto-prepended from spec-level `inputs`), but they're still pipeline stages internally. With no caller exercising the stage shape, they can become plain startup code paths in `pipeline.rs` and the corresponding `STAGE_IDS` entries, dispatch arms, and validator auto-prepend shim can be deleted.

Documentation-only change; no behavior shift. The actual refactor lands in a follow-up.

## Test plan

- [x] No code touched. TODO.md addition only.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_