### PR TITLE
debundle: drop dead relativeWorkspacePath helper from live_proxy/io.mjs

### DIFF
--- a/devinfra/js/debundle/live_proxy/io.mjs
+++ b/devinfra/js/debundle/live_proxy/io.mjs
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 export function requireValue(argv, index, flag) {
   const value = argv[index];
@@ -41,18 +41,6 @@ export function ensureOutputDir(outDir) {
     throw new Error(`Output path exists and is not a directory: ${outDir}`);
   }
   mkdirSync(outDir, { recursive: true });
-}
-
-export function relativeWorkspacePath(path) {
-  const workspace = process.env.BUILD_WORKSPACE_DIRECTORY ?? process.env.BUILD_WORKING_DIRECTORY ?? process.env.PWD;
-  if (!workspace) {
-    return path;
-  }
-  const rel = relative(workspace, path);
-  if (rel === "" || rel.startsWith("..")) {
-    return path;
-  }
-  return rel.split(sep).join("/");
 }
 
 export function logProgress(message) {


### PR DESCRIPTION
## Summary

Drops `relativeWorkspacePath` from `live_proxy/io.mjs` and the now-unused `node:path` imports `relative` and `sep`. The helper was last used by `write_tree.rs` and `logical_modules.rs` to render paths in their stage manifests against the workspace root; PR #1447 switched both to `manifest_relative_path` (rendering against the manifest's own dir) and removed the helper from the Rust side, but left the JS counterpart and its imports orphaned in `io.mjs`.

`resolveWorkspacePath` is kept — it still anchors CLI `--app-manifest` relative-path arguments against `BUILD_WORKSPACE_DIRECTORY` for the `bazel run //...:serve_v_*` use case, where the launcher cwd is the runfiles tree, not the workspace.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 7/7 pass.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_