### PR TITLE
debundle: drop input-loading deprecation guard from dispatch table

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -3,24 +3,6 @@
 Forward-looking gaps in the Rust debundler. Items are written to be removed
 once closed; this file is not a changelog.
 
-## Internalize input loading
-
-`load_js_chunks` / `compute_js_asts` / `normalize_js_chunks` are no longer
-exposed in the spec — PR #1443 made them auto-prepended from the spec-level
-`inputs` block — but they're still implemented as pipeline stages that the
-runner virtually inserts into the dispatch list. There is no remaining
-caller that benefits from the stage shape: the binary always runs them
-exactly once, in the same order, with args sourced from `inputs`. They
-should be plain startup code paths in `pipeline.rs` (or a small
-`load_inputs.rs`), not stages in the dispatch table or stage-id enum.
-
-Once internalized:
-
-- the `STAGE_IDS` for the three input-loading stages can be removed,
-- the dispatch arms for their `operation` strings can be deleted, and
-- the spec validator no longer needs the "auto-prepend" shim — `inputs`
-  becomes the single way these run.
-
 ## RE coverage side-output
 
 Re-introduce the deleted `extract_scrambled_identifier_frequencies` analysis

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -254,11 +254,6 @@ fn run_transform_stage(
     cli: &TransformCli,
 ) -> Result<Option<String>> {
     match operation {
-        "load_js_chunks" | "compute_js_asts" | "normalize_js_chunks" => {
-            bail!(
-                "{operation} is no longer a pipeline operation; configure inputs at the spec level"
-            )
-        }
         "rewrite_chunk_entry_specifiers" => {
             let manifest = rewrite_chunk_entry_specifiers(&mut state.artifact)?;
             Ok(Some(manifest.kind.to_string()))


### PR DESCRIPTION
## Summary

Resolves the TODO entry added in #1449.

`load_js_chunks` / `compute_js_asts` / `normalize_js_chunks` are not pipeline operations — they're called as plain startup code in `run_transform_spec` (`pipeline.rs:221-225`) before the dispatch loop runs. The dispatch arm at `pipeline.rs:257` was a transitional guard (#1443) that returned a helpful error when callers still listed them in their `pipeline` array.

Now that the only consumer (gaffer pipeline rule, gaffer #3) has migrated, the arm is dead weight. Anyone writing the operation name into `pipeline` from now on gets the standard `"No registered stage handler"` error from the default `_ =>` arm — which is correct: it's not a stage.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 7/7 pass.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_