### PR TITLE
debundle: drop unused snapshotRoot field; add self-contained-paths regression

### DIFF
--- a/devinfra/js/debundle/emit_harness.rs
+++ b/devinfra/js/debundle/emit_harness.rs
@@ -114,7 +114,6 @@ pub fn emit_browser_harness(
     let manifest = HarnessManifest {
         schema_version: 1,
         source_html: rel(&source_html_in_tree),
-        snapshot_root: rel(&options.snapshot_root),
         asset_summary_path: rel(&asset_summary_in_tree),
         chunks_manifest_path: rel(&options.out_dir.join("chunks.manifest.json")),
         runtime_root: rel(&options.out_dir),
@@ -147,7 +146,6 @@ pub fn emit_browser_harness(
 struct HarnessManifest {
     schema_version: u8,
     source_html: String,
-    snapshot_root: String,
     asset_summary_path: String,
     chunks_manifest_path: String,
     runtime_root: String,

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -561,6 +561,35 @@ mod tests {
         assert!(out.join("manifest.json").exists());
         let entry = fs::read_to_string(out.join("static/index-DuckMock/entry.js"))?;
         assert!(entry.contains("../chunk-DuckMock/entry.js"));
+
+        // The harness tree must be self-contained: every path the manifest
+        // records resolves to a file inside `out_dir`, with no leakage to
+        // the original `extracted/` or `snapshots/` input trees. Consumers
+        // (live proxy, downstream tools) may receive the manifest through
+        // runfiles where the original input trees aren't co-located.
+        let manifest: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(out.join("manifest.json"))?)?;
+        for field in [
+            "sourceHtml",
+            "assetSummaryPath",
+            "chunksManifestPath",
+            "runtimeRoot",
+            "outDir",
+        ] {
+            let value = manifest
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| panic!("manifest is missing {field}"));
+            assert!(
+                !value.starts_with('/') && !value.starts_with(".."),
+                "manifest.{field} = {value:?} escapes the harness tree"
+            );
+            let resolved = out.join(value);
+            assert!(
+                resolved.exists(),
+                "manifest.{field} = {value:?} resolves to {resolved:?} which does not exist"
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1452 review feedback (Copilot):

- **Drop unused `snapshotRoot` field.** It was the last field on `HarnessManifest` still recording an out-of-tree path. Nothing reads it — the live proxy, `proxy_test.mjs`, the spec generator, and downstream gaffer tools all touch other fields. With it dropped, every path the harness manifest serializes resolves inside `outDir`.
- **Add self-contained-paths regression test.** The existing `pipeline_test::run_transform_cli_writes_spec_pipeline_outputs` only checked that `manifest.json` and `bootstrap.js` exist. Extended it to assert each path-shaped field on the harness manifest (`sourceHtml`, `assetSummaryPath`, `chunksManifestPath`, `runtimeRoot`, `outDir`) is non-absolute, doesn't escape via `..`, and resolves to a file under `outDir`. Would have caught both the snapshotRoot regression and any future drift where the manifest references the spec-input trees.

## Test plan

- [x] `bbr test //devinfra/js/debundle:pipeline_test //devinfra/js/debundle/live_proxy:proxy_test //devinfra/js/debundle/e2e:vendor_swap_test` — 3/3 pass.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_