### PR TITLE
debundle: rewrite snapshot-asset HTML hrefs at the internal prefix

### DIFF
--- a/devinfra/js/debundle/live_proxy/proxy.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy.mjs
@@ -165,6 +165,7 @@ export function loadLiveProxyConfiguration(rawOptions) {
       serviceWorker: `${internalPrefix}/sw.js`,
     },
     injectedHtml: rewriteHtmlForLiveProxy(sourceHtml, {
+      appAssetPrefix,
       bootstrapUrl: `${appAssetPrefix}/bootstrap.js`,
       uiVersion,
     }),
@@ -213,9 +214,20 @@ function normalizeRelativePath(value) {
     .join("/");
 }
 
-export function rewriteHtmlForLiveProxy(sourceHtml, { bootstrapUrl, uiVersion }) {
+export function rewriteHtmlForLiveProxy(sourceHtml, { appAssetPrefix, bootstrapUrl, uiVersion }) {
   let html = sourceHtml.replace(MODULE_SCRIPT_RE, "");
   html = html.replace(MODULE_PRELOAD_RE, "");
+
+  // Re-target absolute-path static-asset references (CSS, fonts, images,
+  // service-worker bootstrap scripts) at the proxy's internal prefix so
+  // they're served from the snapshot harness instead of forwarded to
+  // upstream Tana, where the pinned hashes may have rotated. The
+  // `appAssetPrefix` is callable-conditional because old test fixtures
+  // construct manifests with absolute paths and never rewrite —
+  // skipping the rewrite leaves their behavior unchanged.
+  if (appAssetPrefix) {
+    html = rewriteSnapshotAssetUrls(html, appAssetPrefix);
+  }
 
   const injected = `${liveProxyPreludeScript({ bootstrapUrl, uiVersion })}
     <script type="module" crossorigin src="${escapeHtmlAttr(bootstrapUrl)}"></script>`;
@@ -231,6 +243,26 @@ export function rewriteHtmlForLiveProxy(sourceHtml, { bootstrapUrl, uiVersion })
     html = html.replace(/<head>/i, `<head>\n    <!-- ${comment} -->`);
   }
   return html.endsWith("\n") ? html : `${html}\n`;
+}
+
+// Path prefixes the harness mirrors from the upstream snapshot. Anything
+// matching these in an absolute-path `href`/`src` attribute should be
+// served from the harness, not forwarded to upstream where the pinned
+// hashes have likely rotated.
+const SNAPSHOT_ASSET_PREFIXES = ["/static/", "/preload/"];
+const SNAPSHOT_ASSET_RE = new RegExp(
+  `(\\b(?:href|src)\\s*=\\s*["'])((?:${SNAPSHOT_ASSET_PREFIXES.map(escapeRegex).join("|")})[^"'?#]*)(["'?#])`,
+  "gi"
+);
+
+function rewriteSnapshotAssetUrls(html, appAssetPrefix) {
+  return html.replace(SNAPSHOT_ASSET_RE, (_match, attrLead, path, suffixLead) => {
+    return `${attrLead}${appAssetPrefix}${path}${suffixLead}`;
+  });
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function isTargetDocumentRequest(request, config) {

--- a/devinfra/js/debundle/live_proxy/proxy_test.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy_test.mjs
@@ -187,6 +187,37 @@ test("loadLiveProxyConfiguration treats outDir as the app root even when it is n
   assert.equal(fileMapping.filePath, join(fixture.appRoot, "bootstrap.js"));
 });
 
+test("rewriteHtmlForLiveProxy retargets snapshot-asset paths at the internal prefix", () => {
+  // Source HTML references the upstream's static/preload paths directly.
+  // Without rewriting, the browser fetches them from the live target host
+  // — where the snapshot-pinned hashes may have rotated and the request
+  // 504s. The rewrite re-anchors them at `appAssetPrefix` so the proxy
+  // serves them from the harness tree's mirrored snapshot.
+  const sourceHtml = [
+    "<!doctype html>",
+    "<html><head>",
+    '  <link href="/preload/style.css" rel="stylesheet" />',
+    '  <link rel="stylesheet" crossorigin href="/static/index-Example.css">',
+    '  <link rel="icon" href="/favicon.ico">',
+    '  <script type="module" crossorigin src="/static/index-Example.js"></script>',
+    '</head><body><div id="app"></div></body></html>',
+  ].join("\n");
+  const rewritten = rewriteHtmlForLiveProxy(sourceHtml, {
+    appAssetPrefix: "/_debundle/live/example/app",
+    bootstrapUrl: "/_debundle/live/example/app/bootstrap.js",
+    uiVersion: "example",
+  });
+  // Snapshot-asset prefixes (`/preload/`, `/static/`) get retargeted.
+  assert.ok(rewritten.includes('href="/_debundle/live/example/app/preload/style.css"'));
+  assert.ok(rewritten.includes('href="/_debundle/live/example/app/static/index-Example.css"'));
+  // Original absolute paths to those prefixes should be gone.
+  assert.ok(!rewritten.includes('href="/preload/style.css"'));
+  assert.ok(!rewritten.includes('href="/static/index-Example.css"'));
+  // Out-of-scope absolute paths (`/favicon.ico`) stay as-is so they
+  // forward to upstream where they live.
+  assert.ok(rewritten.includes('href="/favicon.ico"'));
+});
+
 test("isTargetDocumentRequest recognizes top-level HTML navigations", () => {
   const config = {
     targetHost: "example.test",


### PR DESCRIPTION
## Summary

The live proxy injects a bootstrap script into the upstream HTML's `<head>`, but it leaves absolute-path `<link>`/`<script>` references to `/static/...` and `/preload/...` untouched. Those requests then forward to the live target host where the snapshot-pinned hashes have likely rotated; the upstream returns 504 (gateway timeout from a CDN that no longer has the file) and the page never renders. The snapshot harness already mirrors all the static assets — they should be served from there, not re-fetched from upstream.

`rewriteHtmlForLiveProxy` now retargets `href`/`src` attributes whose value starts with `/static/` or `/preload/` at the proxy's internal asset prefix, so the existing `mapLocalAssetPath` routing serves them from the harness tree. Out-of-scope absolute paths (e.g. `/favicon.ico`, `/api/*`) stay as-is and continue to forward upstream.

The rewrite is opt-in via the new `appAssetPrefix` parameter — pre-existing test fixtures that call `rewriteHtmlForLiveProxy` without it are unaffected. The wire path (`loadLiveProxyConfiguration -> rewriteHtmlForLiveProxy`) passes the prefix automatically.

## Test plan

- [x] `bbr test //devinfra/js/debundle/live_proxy:proxy_test` — passes; new test asserts retargeting and that out-of-scope paths (`/favicon.ico`) survive untouched.
- The downstream gaffer `live_proxy:load_78d928dca7` smoke (after the next gaffer pin bump) should serve the pinned CSS from the harness instead of 504-ing upstream — the missing piece for `#app > *` to actually render.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_