### PR TITLE
debundle: disambiguate colliding consumer-import locals after rename

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -110,58 +110,20 @@ smaller minimised e2e under `devinfra/js/debundle/e2e/`) rather than
 only fixing Tana behind the private repo. The latter loses the
 public-CI signal and the public-bug-report leverage.
 
-## Import-binding collisions after rename
+## Propagate readable rename across consumers
 
-When `define_logical_module` renames an exported scrambled symbol on a
-materialized module, the import-rewrite in consumer chunks emits the new
-export name aliased back to the original local binding (the scrambled
-name the consumer used in source). If the consumer file _also_ imports a
-distinct scrambled symbol — from a different module — that happens to
-share the same scrambled name, the local binding collides and the file
-fails to parse with `SyntaxError: Identifier '<X>' has already been
-declared`.
-
-Tana's `static/index-DI2GynTv/entry.js` currently has 429 such collisions
-across the renamed-symbol set, with the canonical pattern:
-
-```js
-import { aH } from "./ai/mcp/prompting_runtime.js";
-import { buildTaskContextPrompt as aH } from "./ai/mcp/prompting/templates.js";
-```
-
-(plus a re-export `s3t as aH` further down). Two distinct source modules
-both used the scrambled letter pair `aH` for unrelated symbols; the
-mangler-rolled chunk that became `entry.js` resolved that internally,
-but the post-debundle import-rewrite re-introduces the clash because it
-preserves the consumer-side local-binding name verbatim.
-
-**Minimal fix (do soon, separate PR):** when emitting a consumer import
-of a renamed symbol, scan the file's existing import bindings; if the
-alias-back to the original scrambled local name would collide with an
-already-bound local from another import (or with an existing top-level
-declaration / re-export name), mint a fresh local name (e.g., `aH$1`,
-`aH$2`, ...) and rewrite all references to that local in the consumer
-body to use the fresh name. Lives at the seam between rename and
-import-statement rewrite in `logical_modules.rs` / `pipeline.rs`. This
-unblocks the Tana smoke without doing the larger fold below.
-
-**Future — propagate readable rename across consumers:** the minimal
-fix above keeps the consumer-side body referring to the original
-scrambled name (just possibly suffixed). A nicer endpoint is to fold
-the new readable name through every consumer too: re-emit the
-import as plain `import { buildTaskContextPrompt }` (no alias) and
-rename every reference in the consumer body from the scrambled letter
-pair to `buildTaskContextPrompt`. That's pure readability gain across
-the whole tree once a rename lands, but it interacts with consumer
+The disambiguation pass in `logical_modules.rs` keeps the consumer-side
+body referring to the original scrambled name (with a `$N` suffix on
+collisions). A nicer endpoint is to fold the new readable name through
+every consumer too: re-emit the import as plain `import {
+buildTaskContextPrompt }` (no alias) and rename every reference in the
+consumer body from the scrambled letter pair to
+`buildTaskContextPrompt`. That's pure readability gain across the
+whole tree once a rename lands, but it interacts with consumer
 local-scope name collisions (a consumer that already has its own
 `buildTaskContextPrompt` declaration must keep an alias) and with
-chains of re-exports. Treat as a follow-up to the minimal fix — both
-phases use the same scope-tracking infrastructure.
-
-Until the minimal fix lands, `//tana/re/web/live_proxy:load_78d928dca7`
-(Tana smoke) is expected to fail at JS parse on `entry.js`, blocking
-the unauth-view selector swap and the no-console-errors /
-no-failed-asset-requests tightening (otherwise gated A4 work).
+chains of re-exports. Reuse the same scope-tracking infrastructure
+the disambiguation pass already builds.
 
 ## RE coverage side-output
 

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -32,6 +32,9 @@ rust_library(
         deps = [
             ":support",
             "@crates//:serde_json",
+            "@crates//:swc_common",
+            "@crates//:swc_ecma_ast",
+            "@crates//:swc_ecma_parser",
             "@crates//:tempfile",
             "@rules_rust//tools/runfiles",
         ],
@@ -42,5 +45,6 @@ rust_library(
         "naturalization_test",
         "url_rebase_test",
         "vendor_swap_test",
+        "import_collision_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/import_collision_test.rs
+++ b/devinfra/js/debundle/e2e/import_collision_test.rs
@@ -1,0 +1,166 @@
+//! Disambiguation of consumer-side import locals that would collide with
+//! another import already bound under the same scrambled name.
+//!
+//! Two `define_logical_module` requests that both list the same scrambled
+//! `binding` produce two `import { ... as <local> } from ...` lines into
+//! the chunk-entry body. Without disambiguation the second emit shadows
+//! the first and the file fails to parse. This regression locks down the
+//! fresh-suffix behavior introduced for that case.
+
+use debundle_e2e_support::*;
+use serde_json::json;
+use std::fs;
+
+#[test]
+fn renames_consumer_import_local_when_a_second_plan_claims_the_same_scrambled_binding() {
+    let opts = FixtureOpts::new(
+        r#"const aH = 42;
+console.log(aH);
+export { aH };
+"#,
+        vec![
+            json!({
+                "id": "logical__mod_a",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_a" },
+                "members": [{
+                    "id": "member__readableA",
+                    "name": "readableA",
+                    "selector": { "binding": { "name": "aH" } },
+                }],
+            }),
+            json!({
+                "id": "logical__mod_b",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_b" },
+                "members": [{
+                    "id": "member__plainAh",
+                    "name": "plainAh",
+                    "selector": { "binding": { "name": "aH" } },
+                }],
+            }),
+        ],
+    );
+    let fixture = run_logical_modules_e2e_fixture(opts);
+
+    let entry = fs::read_to_string(&fixture.entry_path).expect("read entry.js");
+
+    // The first emit keeps the scrambled local `aH`; the second emit must
+    // mint a fresh `aH$1` so the two `import` declarations don't collide.
+    assert!(
+        entry.contains(r#"import { readableA as aH } from "./modules/mod_a.js""#),
+        "expected unrenamed-local mod_a import; entry was:\n{entry}",
+    );
+    assert!(
+        entry.contains(r#"import { plainAh as aH$1 } from "./modules/mod_b.js""#),
+        "expected fresh-suffix mod_b import; entry was:\n{entry}",
+    );
+
+    // Body refs that resolve to the moved decl (now imported under the
+    // fresh local) must follow the rename. The decl moved to mod_b
+    // because the second plan was last to claim the binding, so refs
+    // point at `aH$1`.
+    assert!(
+        entry.contains("console.log(aH$1)"),
+        "expected console.log to be rewritten to aH$1; entry was:\n{entry}",
+    );
+
+    // Public re-export name `aH` must survive even though the local is
+    // now `aH$1`: the re-export becomes `export { aH$1 as aH }` rather
+    // than `export { aH$1 }` (which would silently change the public
+    // name downstream consumers see).
+    assert!(
+        entry.contains("aH$1 as aH"),
+        "expected re-export to preserve public name aH; entry was:\n{entry}",
+    );
+
+    // SWC parses the result without a duplicate-decl error: every named
+    // import specifier in the file binds a distinct local.
+    assert_unique_import_locals(&entry);
+}
+
+#[test]
+fn keeps_unrelated_consumer_import_locals_unchanged() {
+    // Single plan, no collision: the emitted import keeps the scrambled
+    // local verbatim and body refs are not rewritten. Sanity check that
+    // the disambiguation pass is no-op when there's nothing to fix.
+    let opts = FixtureOpts::new(
+        r#"const aH = 7;
+console.log(aH);
+export { aH };
+"#,
+        vec![json!({
+            "id": "logical__mod_a",
+            "operation": "define_logical_module",
+            "selector": { "chunkId": "static/app" },
+            "target": { "path": "mod_a" },
+            "members": [{
+                "id": "member__readableA",
+                "name": "readableA",
+                "selector": { "binding": { "name": "aH" } },
+            }],
+        })],
+    );
+    let fixture = run_logical_modules_e2e_fixture(opts);
+    let entry = fs::read_to_string(&fixture.entry_path).expect("read entry.js");
+
+    assert!(
+        entry.contains(r#"import { readableA as aH } from "./modules/mod_a.js""#),
+        "expected unrenamed mod_a import; entry was:\n{entry}",
+    );
+    assert!(
+        !entry.contains("aH$1"),
+        "no fresh-suffix should appear when there is no collision; entry was:\n{entry}",
+    );
+    assert_entry_output(&fixture, "7\n");
+}
+
+/// Parse `source` and assert that every named import specifier binds a
+/// distinct local symbol. Mirrors the duplicate-declaration check Node
+/// would perform at module-load time.
+fn assert_unique_import_locals(source: &str) {
+    use std::collections::BTreeSet;
+    use swc_common::FileName;
+    use swc_common::sync::Lrc;
+    use swc_ecma_ast::{ImportSpecifier, ModuleDecl, ModuleItem};
+    use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
+
+    let cm: Lrc<swc_common::SourceMap> = Default::default();
+    let fm = cm.new_source_file(
+        FileName::Custom("entry.js".into()).into(),
+        source.to_string(),
+    );
+    let lexer = Lexer::new(
+        Syntax::Typescript(TsSyntax {
+            tsx: true,
+            decorators: true,
+            no_early_errors: true,
+            ..Default::default()
+        }),
+        Default::default(),
+        StringInput::from(&*fm),
+        None,
+    );
+    let module = Parser::new_from(lexer)
+        .parse_module()
+        .unwrap_or_else(|err| panic!("entry must parse, got {err:?}; source:\n{source}"));
+    let mut seen = BTreeSet::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+            continue;
+        };
+        for specifier in &import.specifiers {
+            let local = match specifier {
+                ImportSpecifier::Named(named) => named.local.sym.to_string(),
+                ImportSpecifier::Default(default) => default.local.sym.to_string(),
+                ImportSpecifier::Namespace(namespace) => namespace.local.sym.to_string(),
+            };
+            assert!(
+                seen.insert(local.clone()),
+                "duplicate import local `{local}` in:\n{source}",
+            );
+        }
+    }
+}

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -476,20 +476,50 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
         }
     }
     let mut entry_imports = Vec::<ModuleItem>::new();
+    let mut occupied = collect_occupied_local_names(&entry_body);
+    let mut body_renames = BTreeMap::<String, String>::new();
     for (module_index, plan) in module_plans.iter().enumerate() {
         if plan.bindings.is_empty() {
             continue;
         }
-        let mut bindings = plan.bindings.clone();
+        let mut emit_renames = BTreeMap::<String, String>::new();
+        let mut resolved =
+            disambiguate_import_locals(&plan.bindings, &mut occupied, &mut emit_renames);
         if requires_init_by_module.contains(&module_index) {
             let init_name = init_name_for_plan(plan);
-            bindings.insert(init_name.clone(), init_name);
+            resolved.insert(init_name.clone(), init_name);
+        }
+        // A rename only propagates to consumer-body references when the
+        // moved decl actually belongs to this plan. Plans that listed a
+        // binding without owning the decl emit a dangling import; the
+        // body refs continue to resolve to whichever binding owned the
+        // original local name.
+        for (local, fresh) in emit_renames {
+            if binding_assignment.get(&local).copied() == Some(module_index) {
+                body_renames.insert(local, fresh);
+            }
         }
         entry_imports.push(import_decl_for_plan(
             entry_file,
             &plan.target_file,
-            &bindings,
+            &resolved,
         ));
+    }
+    if !body_renames.is_empty() {
+        // Re-exports `export { local }` (without `from`) collapse `local`
+        // and the public exported name into a single ident. Renaming the
+        // orig would also rename the public name, breaking downstream
+        // consumers — so rewrite them to `export { fresh as local }`
+        // before the generic renamer visits the rest.
+        for item in entry_body.iter_mut() {
+            preserve_export_specifier_names(item, &body_renames);
+        }
+        let mut renamer = IdentifierRenamer {
+            renames: body_renames,
+        };
+        for item in entry_body.iter_mut() {
+            item.visit_mut_with(&mut renamer);
+        }
     }
     for import in entry_imports.into_iter().rev() {
         entry_body.insert(import_insert_index, import);
@@ -1640,6 +1670,121 @@ fn assigned_module_for_names(
         .iter()
         .filter_map(|name| binding_assignment.get(name).copied())
         .next()
+}
+
+/// Names occupying the file-scope binding namespace of `body`.
+///
+/// Used to disambiguate consumer-side `import { exportedName as localName }`
+/// emissions whose `localName` would collide with another binding in the
+/// same scope (e.g. a surviving import or top-level declaration that
+/// already uses the scrambled name). `export { name }` re-exports without
+/// `from` are references, not bindings, so they aren't tracked here; the
+/// IdentifierRenamer pass that follows the disambiguation rewrites their
+/// `orig` ident along with every other body reference.
+fn collect_occupied_local_names(body: &[ModuleItem]) -> BTreeSet<String> {
+    let mut occupied = BTreeSet::new();
+    for item in body {
+        match item {
+            ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+                for specifier in &import.specifiers {
+                    match specifier {
+                        ImportSpecifier::Named(named) => {
+                            occupied.insert(named.local.sym.to_string());
+                        }
+                        ImportSpecifier::Default(default) => {
+                            occupied.insert(default.local.sym.to_string());
+                        }
+                        ImportSpecifier::Namespace(namespace) => {
+                            occupied.insert(namespace.local.sym.to_string());
+                        }
+                    }
+                }
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
+                for name in declaration_names(&export_decl.decl) {
+                    occupied.insert(name);
+                }
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(default_decl)) => {
+                if let DefaultDecl::Class(class) = &default_decl.decl
+                    && let Some(ident) = &class.ident
+                {
+                    occupied.insert(ident.sym.to_string());
+                }
+                if let DefaultDecl::Fn(function) = &default_decl.decl
+                    && let Some(ident) = &function.ident
+                {
+                    occupied.insert(ident.sym.to_string());
+                }
+            }
+            ModuleItem::Stmt(Stmt::Decl(decl)) => {
+                for name in declaration_names(decl) {
+                    occupied.insert(name);
+                }
+            }
+            _ => {}
+        }
+    }
+    occupied
+}
+
+/// Map plan-side `local -> exported` to `actual_local -> exported`,
+/// minting a fresh `<local>$N` whenever the requested local would collide
+/// with `occupied`. Records original-to-fresh entries in `renames` so the
+/// caller can rewrite consumer-body references after emission.
+fn disambiguate_import_locals(
+    bindings: &BTreeMap<String, String>,
+    occupied: &mut BTreeSet<String>,
+    renames: &mut BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    bindings
+        .iter()
+        .map(|(local, exported)| {
+            let actual = if occupied.contains(local) {
+                let fresh = mint_fresh_local_name(local, occupied);
+                renames.insert(local.clone(), fresh.clone());
+                fresh
+            } else {
+                local.clone()
+            };
+            occupied.insert(actual.clone());
+            (actual, exported.clone())
+        })
+        .collect()
+}
+
+/// Pre-fill `exported` on `export { local }` re-export specifiers whose
+/// `local` is about to be renamed, so the public export name survives.
+fn preserve_export_specifier_names(item: &mut ModuleItem, renames: &BTreeMap<String, String>) {
+    let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
+        return;
+    };
+    for specifier in &mut named.specifiers {
+        let ExportSpecifier::Named(spec) = specifier else {
+            continue;
+        };
+        if spec.exported.is_some() {
+            continue;
+        }
+        let ModuleExportName::Ident(orig) = &spec.orig else {
+            continue;
+        };
+        if !renames.contains_key(&orig.sym.to_string()) {
+            continue;
+        }
+        spec.exported = Some(spec.orig.clone());
+    }
+}
+
+fn mint_fresh_local_name(base: &str, occupied: &BTreeSet<String>) -> String {
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{base}${suffix}");
+        if !occupied.contains(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
 }
 
 fn import_decl_for_plan(


### PR DESCRIPTION
## Summary

Resolves the `Identifier '<X>' has already been declared` JS parse error
in materialized chunk entries when `define_logical_module` rename
emissions collide with other consumer-side imports.

### The bug

When two materialized logical modules' bindings share a scrambled
local name in the same chunk-entry, the lower step emitted both as

```js
import { aH } from "./mod_a.js";
import { buildTaskContextPrompt as aH } from "./mod_b.js";
```

— two `import` declarations binding the same local. JS parse fails.
This shape blocks the Tana smoke (`//tana/re/web/live_proxy:load_*`) on
`entry.js`, with 429 collisions across the renamed-symbol set.

### The fix

At the seam where chunk-entry imports are constructed in
`logical_modules.rs`, track the file-scope binding namespace
(`collect_occupied_local_names`: imports' locals, top-level decls,
default-export ident decls — but **not** re-export `orig` idents,
which are references rather than bindings). When a plan would emit a
local that's already taken, mint `<local>$N` (`disambiguate_import_locals`
+ `mint_fresh_local_name`).

Body references to a renamed local are rewritten only when
`binding_assignment[local] == this_plan_index` — i.e., when the
moved decl actually belonged to *this* plan. Plans that listed a
binding without owning the decl emit a dangling import; their refs in
the body continue to resolve to whichever import owns the original
local name. This avoids the failure mode where a naive
symbol-table-blind rename would incorrectly redirect refs that were
bound to a surviving import.

`export { local }` re-export specifiers (no `from`, no `as`) collapse
the local and the public exported name into a single ident, so before
the generic `IdentifierRenamer` runs, `preserve_export_specifier_names`
pre-fills `exported = local` so the public export name survives the
local rename.

### What's *not* in this PR

The TODO entry's "Future — propagate readable rename across consumers"
section is preserved as a standalone follow-up. That fold (re-emit
plain `import { buildTaskContextPrompt }` and rename refs from the
scrambled local to the readable name everywhere) reuses the same
scope-tracking infrastructure but is a separate readability change.

### Test coverage

`devinfra/js/debundle/e2e/import_collision_test.rs`:

- **Dual-plan collision**: Two `define_logical_module` requests both
  claim the scrambled binding `aH` with different export names.
  Asserts the entry has two distinct local bindings (`aH` and `aH$1`),
  the body's `console.log(aH)` is rewritten to `console.log(aH$1)`,
  the public re-export survives as `aH$1 as aH`, and SWC parses the
  result with no duplicate-decl error.
- **No-collision sanity**: Single plan, asserts no `$1` suffix is
  introduced and the entry runs cleanly under Node.

`bazelisk test --remote_executor="" //devinfra/js/debundle/...` — all
8 tests pass.

### Tana smoke

Local end-to-end Tana verification (Step 8) was not attempted in this
session — the BuildBuddy API key is unset and the gaffer-pin bump
loop requires it. The fixture-level test exercises the canonical
collision shape; the gaffer-side repin to confirm the JS parse error
is gone on `//tana/re/web/live_proxy:load_78d928dca7` will follow as a
separate gaffer PR after this lands.

## Test plan

- [x] `bazelisk test --remote_executor="" //devinfra/js/debundle/...` passes locally (8/8)
- [x] `pre-commit run --files <changed>` clean
- [ ] Tana `//tana/re/web/live_proxy:load_78d928dca7` parse error gone (gaffer-side, separate PR)

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_