### PR TITLE
debundle: address Copilot review on #1460 (collision counting + var-decl test)

### DIFF
--- a/devinfra/js/debundle/e2e/import_collision_test.rs
+++ b/devinfra/js/debundle/e2e/import_collision_test.rs
@@ -246,8 +246,9 @@ fn assert_export_named_specifier(
 }
 
 /// Assert that no function-body scope in `source` declares `target_name`
-/// more than once (counting destructured params and `let/const/var`
-/// decls). Mirrors Node's lexical-binding duplicate check.
+/// more than once (counting destructured params and `let`/`const` decls;
+/// `var` is excluded because it allows redeclaration in the same scope).
+/// Mirrors Node's lexical-binding duplicate check.
 fn assert_unique_lexical_decls_per_scope(source: &str, target_name: &str) {
     use swc_ecma_ast::{
         BindingIdent, BlockStmtOrExpr, Decl, Expr, FnDecl, Function, ModuleItem, ObjectPatProp,
@@ -339,7 +340,9 @@ fn assert_unique_lexical_decls_per_scope(source: &str, target_name: &str) {
                 }
                 if let BlockStmtOrExpr::BlockStmt(block) = &*arrow.body {
                     for stmt in &block.stmts {
-                        if let Stmt::Decl(Decl::Var(var)) = stmt {
+                        if let Stmt::Decl(Decl::Var(var)) = stmt
+                            && matches!(var.kind, VarDeclKind::Let | VarDeclKind::Const)
+                        {
                             for declarator in &var.decls {
                                 if pat_binds(&declarator.name, target) {
                                     count += 1;

--- a/devinfra/js/debundle/e2e/import_collision_test.rs
+++ b/devinfra/js/debundle/e2e/import_collision_test.rs
@@ -251,7 +251,7 @@ fn assert_export_named_specifier(
 fn assert_unique_lexical_decls_per_scope(source: &str, target_name: &str) {
     use swc_ecma_ast::{
         BindingIdent, BlockStmtOrExpr, Decl, Expr, FnDecl, Function, ModuleItem, ObjectPatProp,
-        Pat, Stmt, VarDeclarator,
+        Pat, Stmt, VarDeclKind, VarDeclarator,
     };
 
     fn pat_binds(pat: &Pat, target: &str) -> bool {
@@ -284,7 +284,12 @@ fn assert_unique_lexical_decls_per_scope(source: &str, target_name: &str) {
             }
         }
         for stmt in &body.stmts {
-            if let Stmt::Decl(Decl::Var(var)) = stmt {
+            // `var` allows redeclaration in the same scope (and `function f(a){var a;}`
+            // is legal); only `let`/`const`/`class`/`function` are subject to the
+            // "Identifier 'X' has already been declared" lexical check.
+            if let Stmt::Decl(Decl::Var(var)) = stmt
+                && matches!(var.kind, VarDeclKind::Let | VarDeclKind::Const)
+            {
                 for declarator in &var.decls {
                     if pat_binds(&declarator.name, target) {
                         count += 1;

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1048,8 +1048,18 @@ fn drop_target_collisions(
     mut plan_driven: BTreeMap<String, String>,
     heuristic: BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
+    // Only effective heuristic mappings (locals not already in plan_driven)
+    // contribute to the collision count. Counting skipped entries inflates
+    // counts[target] and can drop unrelated heuristic mappings that have only
+    // one effective claimant.
     let mut counts = BTreeMap::<String, usize>::new();
-    for target in plan_driven.values().chain(heuristic.values()) {
+    for target in plan_driven.values() {
+        *counts.entry(target.clone()).or_default() += 1;
+    }
+    for (local, target) in &heuristic {
+        if plan_driven.contains_key(local) {
+            continue;
+        }
         *counts.entry(target.clone()).or_default() += 1;
     }
     for (local, target) in heuristic {


### PR DESCRIPTION
## Summary

Two follow-up fixes for #1460 (already merged). Both are valid Copilot review comments on real bugs in the merged code.

### Fix 1 — `drop_target_collisions` over-counted heuristic targets

The previous loop counted every heuristic mapping toward `counts[target]`, including mappings whose `local` is already in `plan_driven` (which are then skipped in the apply loop because plan-driven wins). When two heuristic mappings share a target but only one is effective (the other's `local` is plan-driven and therefore the heuristic entry would never apply), the count was 2 and the *effective* one was incorrectly dropped.

Fix: build `counts` from `plan_driven` targets plus only the heuristic mappings whose `local` is not already in `plan_driven`.

### Fix 2 — `assert_unique_lexical_decls_per_scope` over-counted `var` decls

The test helper claimed to mirror Node's lexical-binding duplicate check but counted every `Decl::Var` regardless of `var.kind`. `var` allows redeclaration in the same scope (and `function f(a){var a;}` is legal); only `let`/`const`/`class`/`function` are subject to the `Identifier 'X' has already been declared` check.

Fix: only count when `var.kind` is `Let` or `Const`.

## Test plan

- [x] `bazelisk test --remote_executor="" //devinfra/js/debundle/e2e:import_collision_test` passes (the existing assertions still hold; the helper change is strictly less strict on `var` shapes which we don't currently emit but might in the future).
- [x] All `//devinfra/js/debundle/...` tests pass locally (8/8 against the post-#1460 / post-#1459 devel base).

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_