### PR TITLE
props/frontend/debundle: live-browser smoke target (blocked on svelte-data-table chunk-fold)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -3,112 +3,66 @@
 Forward-looking gaps in the Rust debundler. Items are written to be removed
 once closed; this file is not a changelog.
 
-## Excalidraw live-browser smoke
+## props/frontend live-browser smoke
 
-Build an open-source analog of gaffer's `tana/re/web/live_proxy:load_*`
-test inside ducktape, against a Bazel-managed Excalidraw bundle. The
-motivation: when a Tana debundler issue surfaces (proxy crash, AST
-corruption, missing chunk, emit shape regression, optimisation
-behaviour bug), reproducing the failure on Excalidraw lets us share
-the repro in a public bug report, write a regression test that runs
-in ducktape's open CI, and avoid leaking proprietary Tana bundle
-detail. Excalidraw is open-source and broadly representative of "real
-React + vendored chunks + dynamic imports + service worker."
+The open-source analog of gaffer's `tana/re/web/live_proxy:load_*`
+lives at `//props/frontend/debundle:load_props_frontend`. It drives
+the canonical pipeline (`apply_vendor_annotations` →
+`rename_vendor_exports` → `swap_vendor_chunks` →
+`materialize_logical_modules` → identifier renames →
+`rewrite_chunk_entry_specifiers` → `emit_browser_harness`) against a
+multi-chunk smoke bundle of `props/frontend`'s real Svelte source,
+serves the harness with a tiny self-hosted Node http server (no
+MITM — `props/frontend` has no server-side dependency), and drives
+headless Chromium through it.
 
-### Bundle build
-
-Use a Bazel-managed Excalidraw build. Two viable paths:
-
-- **Pull a prebuilt deploy** (snapshot a specific `excalidraw.com`
-  publish into `tana/x/upstream/excalidraw/snapshots/<version>/`
-  — analogous to `tana/upstream/web/snapshots/`). Requires keeping
-  the snapshot fresh enough that upstream's auxiliary endpoints (if
-  any) still work. Easier to bootstrap.
-- **Build from source under Bazel** — Excalidraw's `excalidraw-app/`
-  builds with Vite; reproduce that build (npm + vite via
-  aspect_rules_js, or via a `genrule` shelling to npm) and feed the
-  output into the pipeline. More work upfront, but the bundle is
-  reproducible from a single git pin and we control the optimisation
-  level / minifier settings.
-
-Either way, the build configuration must roughly match Tana's: minify
-on, scrambled identifiers, production-tree-shaken, real chunk-split
-boundaries. A development build (with un-mangled names and source
-maps inlined) won't exercise the debundler's RE-relevant code paths.
-
-### Spec scope
-
-Not the round-trip minimum — the spec should exercise realistic-ish
-module extraction and rename paths, the same shape the Tana spec
-runs. Concretely:
-
-- `apply_vendor_annotations` + `swap_vendor_chunks` over a couple of
-  Excalidraw's actual vendor chunks (React, Roughjs, Pointers, etc.)
-  so vendor-swap edge cases (named-from-default,
-  named-from-module-default, default-only, JSON-default) get covered
-  on a real bundle, not only synthetic fixtures.
-- `materialize_logical_modules` over a handful of pre-identified
-  Excalidraw source modules — pick ones whose shape is recognisable
-  in the compiled output (a clearly-bounded React component, a pure
-  geometry helper, a state slice). Goal: prove the materialiser
-  recovers approximately the right symbols/files from a real
-  scrambled bundle.
-- A small set of `define_logical_module` rename operations on
-  identifiers visible in the compiled output. Goal: exercise the
-  rename pipeline at the same aggressiveness Tana uses.
-- `rewrite_chunk_entry_specifiers` + `emit_browser_harness` so the
-  output is a runnable app the live proxy can serve.
-
-The exact module list / rename list is part of the implementation —
-pick stable shapes that are unlikely to drift wildly when Excalidraw
-upgrades. Stale picks become a self-test: if the materialiser fails
-to find them, that's a real signal (either the bundle moved or our
-matchers regressed).
-
-### Smoke target contract
-
-- runs `bazel test //devinfra/js/debundle/excalidraw:load_test` (or
-  similar);
-- builds the Excalidraw bundle through the same pipeline rule shape
-  gaffer uses (`debundle_pipeline` from
-  `tana/re/web/transforms/pipeline.bzl` — promote to ducktape as a
-  prerequisite);
-- starts the live-proxy binary against the resulting harness;
-- drives a headless Chromium through the proxy, asserts:
-  - no failed asset requests,
-  - no console errors,
-  - the canvas toolbar is visible (e.g. `[data-testid="toolbar"]`
-    or whichever stable selector Excalidraw exposes),
-  - a small interaction works (click the rectangle tool, click on
-    the canvas, verify a shape was added — proves the React app is
-    reactive after debundle).
-
-### Hosting
-
-Self-hosted, no MITM. Tana's smoke has to MITM the live host because
-Tana auth/data is server-side; Excalidraw runs entirely in the
-browser, so a self-hosted bundle is a fully working app. Self-hosting
-removes the network dependency and CDN-rotation flakiness (the test
-stays green even when excalidraw.com is down) and matches the
-"reproduce against Excalidraw" workflow goal — a public, deterministic
-smoke that doesn't depend on third-party uptime.
-
-### Prerequisite
-
-The pipeline rule (`debundle_pipeline` in
-`tana/re/web/transforms/pipeline.bzl`) lives in gaffer-private today.
-Promote it to ducktape (likely `devinfra/js/debundle/pipeline.bzl`)
-before this work — otherwise the Excalidraw target needs a
-gaffer→ducktape→gaffer circular dep, and other open-source corpora
-can't use it without depending on gaffer.
+The smoke bundle is a parallel build to the production
+`//props/frontend:bundle`; production stays single-chunk and
+unchanged. The smoke variant adds two marker entries
+(`vendor_highlight_marker.ts`, `vendor_datatable_marker.ts`) so
+esbuild's chunk-graph algorithm puts each vendored package
+(`highlight.js`, `@careswitch/svelte-data-table`) in its own
+shared chunk — giving the pipeline distinct vendor chunks to swap
+against the upstream packages from `node_modules/`.
 
 ### Workflow rule
 
-When a Tana-side debundling issue is tractable on Excalidraw too,
-prefer landing the regression test on this Excalidraw target (or a
-smaller minimised e2e under `devinfra/js/debundle/e2e/`) rather than
-only fixing Tana behind the private repo. The latter loses the
-public-CI signal and the public-bug-report leverage.
+When a Tana-side debundling issue surfaces, prefer reproducing it
+against `props/frontend/debundle` (or a smaller minimised e2e under
+`devinfra/js/debundle/e2e/`) rather than only fixing it behind the
+private repo. The latter loses the public-CI signal and the
+public-bug-report leverage.
+
+### Open follow-ups
+
+- Esbuild emits content-hashed chunk names that differ between
+  target and exec build configs (subtle path differences in
+  runfiles trees perturb the hash). The current
+  `prepare_snapshot.mjs` writes `extracted/vendor-chunks.json`
+  classifying each chunk by metafile inspection, which the spec
+  generator reads to pin vendor `chunkPath`s — but the
+  spec-generator runs in exec config and reads its config-version
+  of the file, while the debundler runs in target config and
+  consumes the target-version snapshot. The two configs disagree on
+  chunk filenames, so the vendor-mark op rejects the chunk path it
+  was given. Either pin esbuild's chunk-name template to remove the
+  hash (`chunkNames: "[name]-shared"`), or have prepare_snapshot
+  rename the chunk files to deterministic names (e.g.
+  `dist/vendor-highlight.js`, `dist/vendor-datatable.js`) before
+  the snapshot ships out.
+- The smoke shell (`smoke_shell.svelte`) reproduces the production
+  `App.svelte` chrome (`<nav>`, `<h1>Props</h1>`, nav links) so the
+  load-test selectors stay close to the production surface, but
+  it isn't the production component. Once `//props/frontend:app`
+  is exposed to the debundle subpackage (or once the production
+  pages stop hitting the backend on mount), the smoke can mount
+  `App.svelte` directly.
+- The render targets `data-debundle-smoke="…"` attributes on the
+  smoke shell only; production source has no `data-testid`-style
+  attributes. If the load test's selectors prove unstable as the
+  shell evolves, document the alternatives (semantic selectors
+  scoped to `<header>`, `<nav>`, `<main>`) rather than reaching
+  into production source for new attributes.
 
 ## Propagate readable rename across consumers
 

--- a/props/frontend/debundle/BUILD.bazel
+++ b/props/frontend/debundle/BUILD.bazel
@@ -1,0 +1,162 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
+load("//devinfra/js/debundle:pipeline.bzl", "debundle_pipeline")
+
+# Smoke target for the debundle pipeline against props/frontend.
+#
+# Wiring mirrors gaffer's tana/re/web/transforms/BUILD.bazel:
+# spec_generator emits a transform spec that drives the canonical
+# pipeline (vendor-swap → materialize → rename → emit_browser_harness).
+# The output is a self-contained harness tree the load test serves
+# over a static-file server (no MITM — props/frontend has no
+# server-side dependency).
+#
+# The smoke ships its own UI shell (`smoke_shell.svelte`) rather than
+# reusing the production `App.svelte`. That's because:
+#   - the production library `:app` is package-private — opting it
+#     into a wider visibility for one downstream is more invasive
+#     than keeping the shell local;
+#   - the production pages all hit the backend on mount, which the
+#     static-file harness would 404 and which would pollute the
+#     load test's "no console errors" assertion;
+#   - the shell still uses the same `$lib/router` + selector shape
+#     (`nav`, `<h1>Props</h1>`, nav links) so the load test asserts
+#     against the same surface as production.
+
+# ============================================================
+# Smoke bundle: multi-chunk variant tuned for the debundle pipeline.
+# ============================================================
+
+js_library(
+    name = "smoke_lib",
+    srcs = [
+        "smoke_main.ts",
+        "smoke_shell.svelte",
+        "vendor_datatable_marker.ts",
+        "vendor_highlight_marker.ts",
+        "vendor_marker.ts",
+    ],
+    deps = [
+        "//props/frontend/src/lib:highlighting",
+        "//props/frontend/src/lib:router",
+    ],
+)
+
+js_binary(
+    name = "build_smoke_bundle_bin",
+    chdir = "props/frontend",
+    data = [
+        "esbuild.smoke.config.mjs",
+        ":smoke_lib",
+        "//props/frontend:node_modules",
+    ],
+    entry_point = "esbuild.smoke.config.mjs",
+)
+
+# Output is a tree artifact under
+# `bazel-bin/props/frontend/debundle/smoke_bundle/`. The js_binary
+# `chdir`s into `props/frontend`, so the esbuild config receives the
+# `outdir` arg relative to that CWD: `debundle/smoke_bundle`.
+js_run_binary(
+    name = "smoke_bundle",
+    srcs = [
+        "esbuild.smoke.config.mjs",
+        ":smoke_lib",
+    ],
+    args = ["debundle/smoke_bundle"],
+    out_dirs = ["smoke_bundle"],
+    tool = ":build_smoke_bundle_bin",
+)
+
+# ============================================================
+# Snapshot inputs: index.html plus extracted/asset-summary.json
+# generated from the smoke bundle's metafile.
+# ============================================================
+
+js_library(
+    name = "prepare_snapshot_lib",
+    srcs = ["prepare_snapshot.mjs"],
+)
+
+js_binary(
+    name = "prepare_snapshot_bin",
+    data = [":prepare_snapshot_lib"],
+    entry_point = "prepare_snapshot.mjs",
+)
+
+js_run_binary(
+    name = "snapshot",
+    srcs = [
+        "smoke_index.html",
+        ":smoke_bundle",
+    ],
+    outs = [
+        "extracted/asset-summary.json",
+        "extracted/js-files.txt",
+        "snapshot/index.html",
+    ],
+    args = [
+        "--bundle",
+        "$(execpath :smoke_bundle)",
+        "--index-html",
+        "$(execpath smoke_index.html)",
+        "--snapshot-out",
+        "$(RULEDIR)/snapshot",
+        "--asset-summary-out",
+        "$(execpath extracted/asset-summary.json)",
+        "--js-list-out",
+        "$(execpath extracted/js-files.txt)",
+    ],
+    out_dirs = ["snapshot/dist"],
+    tool = ":prepare_snapshot_bin",
+)
+
+filegroup(
+    name = "snapshot_dir",
+    srcs = [
+        "snapshot/dist",
+        "snapshot/index.html",
+    ],
+)
+
+filegroup(
+    name = "extracted_inputs",
+    srcs = [
+        "extracted/asset-summary.json",
+        "extracted/js-files.txt",
+    ],
+)
+
+# ============================================================
+# Spec generator + debundle pipeline.
+# ============================================================
+
+js_library(
+    name = "spec_generator_lib",
+    srcs = ["spec_generator.mjs"],
+)
+
+js_binary(
+    name = "spec_generator",
+    data = [":spec_generator_lib"],
+    entry_point = "spec_generator.mjs",
+)
+
+# Vendor packages the smoke swaps. Mirrors gaffer's swap_package_root
+# helpers in tana/re/web/vendor/defs.bzl, kept inline here so the open-source
+# corpus owns its own list.
+_SMOKE_VENDOR_PACKAGES = {
+    "//props/frontend:node_modules/highlight.js/dir": "highlight.js",
+    "//props/frontend:node_modules/@careswitch/svelte-data-table/dir": "@careswitch/svelte-data-table",
+}
+
+debundle_pipeline(
+    name = "debundle_props_frontend",
+    debundler = "//devinfra/js/debundle",
+    input_data = [
+        ":snapshot_dir",
+        ":extracted_inputs",
+    ],
+    package_roots = _SMOKE_VENDOR_PACKAGES,
+    spec_generator = ":spec_generator",
+    visibility = ["//visibility:public"],
+)

--- a/props/frontend/debundle/BUILD.bazel
+++ b/props/frontend/debundle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary", "js_test")
 load("//devinfra/js/debundle:pipeline.bzl", "debundle_pipeline")
 
 # Smoke target for the debundle pipeline against props/frontend.
@@ -165,5 +165,61 @@ debundle_pipeline(
     ],
     package_roots = _SMOKE_VENDOR_PACKAGES,
     spec_generator = ":spec_generator",
+    visibility = ["//visibility:public"],
+)
+
+# ============================================================
+# Live-browser smoke (self-hosted; no MITM).
+# ============================================================
+# props/frontend has no server-side dependency, so unlike gaffer's
+# `tana/re/web/live_proxy:load_*` (which intercepts a real upstream
+# host with an MITM proxy), this load test serves the harness over
+# a local http server and points headless Chromium at it directly.
+#
+# The `static_load_test.mjs` driver is a thin reimplementation of
+# what `js_debundle_live_proxy_load_test` does, minus the MITM
+# pieces. Reusing the macro would require a second variant skipping
+# the proxy; for the open-source corpus a self-hosted driver here
+# is simpler and avoids leaking the MITM machinery into a target
+# that doesn't need it.
+
+# Each vendor package's `:dir` filegroup gets passed verbatim
+# (`<name>=<rlocationpath>`) to the load-test binary so it can resolve
+# vendor chunks back to package files. Mirrors
+# `swap_package_root_fixed_args` in gaffer's vendor/defs.bzl.
+_VENDOR_PACKAGE_ROOT_ARGS = [
+    arg
+    for label, name in _SMOKE_VENDOR_PACKAGES.items()
+    for arg in [
+        "--package-root",
+        "{}=\"$$JS_BINARY__RUNFILES\"/$(rlocationpath {})".format(name, label),
+    ]
+]
+
+js_test(
+    name = "load_props_frontend",
+    chdir = package_name(),
+    data = [
+        "static_load_test.mjs",
+        ":debundle_props_frontend",
+        "//util/testing/frontend_visual:puppeteer_lib",
+        "@playwright_browsers//:chromium-headless-shell",
+    ] + _SMOKE_VENDOR_PACKAGES.keys(),
+    entry_point = "static_load_test.mjs",
+    env = {
+        "PUPPETEER_EXECUTABLE_PATH": "$(rootpath @playwright_browsers//:chromium-headless-shell)",
+    },
+    fixed_args = [
+        "--app-manifest",
+        "\"$$JS_BINARY__RUNFILES\"/$(rlocationpath :debundle_props_frontend)/manifest.json",
+        "--wait-for-selector",
+        "nav",
+        "--wait-timeout-ms",
+        "30000",
+        "--goto-timeout-ms",
+        "30000",
+        "--assert-nav-interaction",
+    ] + _VENDOR_PACKAGE_ROOT_ARGS,
+    tags = ["requires-network"],
     visibility = ["//visibility:public"],
 )

--- a/props/frontend/debundle/BUILD.bazel
+++ b/props/frontend/debundle/BUILD.bazel
@@ -115,10 +115,12 @@ js_run_binary(
 
 filegroup(
     name = "snapshot_dir",
-    srcs = [
-        "snapshot/dist",
-        "snapshot/index.html",
-    ],
+    # `:snapshot` declares both the `snapshot/dist` tree artifact and
+    # the `snapshot/index.html` file. Listing the parent target here
+    # picks up everything under `snapshot/` (and the extracted
+    # outputs), which is what the debundle pipeline's input_data
+    # expects.
+    srcs = [":snapshot"],
 )
 
 filegroup(

--- a/props/frontend/debundle/BUILD.bazel
+++ b/props/frontend/debundle/BUILD.bazel
@@ -92,6 +92,7 @@ js_run_binary(
     outs = [
         "extracted/asset-summary.json",
         "extracted/js-files.txt",
+        "extracted/vendor-chunks.json",
         "snapshot/index.html",
     ],
     args = [
@@ -105,6 +106,8 @@ js_run_binary(
         "$(execpath extracted/asset-summary.json)",
         "--js-list-out",
         "$(execpath extracted/js-files.txt)",
+        "--vendor-map-out",
+        "$(execpath extracted/vendor-chunks.json)",
     ],
     out_dirs = ["snapshot/dist"],
     tool = ":prepare_snapshot_bin",
@@ -123,6 +126,7 @@ filegroup(
     srcs = [
         "extracted/asset-summary.json",
         "extracted/js-files.txt",
+        "extracted/vendor-chunks.json",
     ],
 )
 
@@ -133,6 +137,7 @@ filegroup(
 js_library(
     name = "spec_generator_lib",
     srcs = ["spec_generator.mjs"],
+    data = ["extracted/vendor-chunks.json"],
 )
 
 js_binary(

--- a/props/frontend/debundle/esbuild.smoke.config.mjs
+++ b/props/frontend/debundle/esbuild.smoke.config.mjs
@@ -1,0 +1,82 @@
+// Smoke-bundle build for the debundle pipeline. Lives next to the production
+// `esbuild.config.mjs` but produces a deliberately multi-chunk artifact so
+// the pipeline's vendor-swap stage has separate vendor chunks to operate on.
+//
+// Why a separate config: production ships a single-file bundle (esbuild
+// `splitting: true` only kicks in for shared code across multiple entries
+// or for dynamic imports, neither of which the prod entry exercises). For
+// the smoke we add three entry points alongside `smoke_main.ts`:
+//   - `vendor_highlight_marker.ts`: imports highlight.js only.
+//   - `vendor_datatable_marker.ts`: imports @careswitch/svelte-data-table only.
+//   - `vendor_marker.ts`: imports both, to anchor a third entry.
+// Each marker is shared (transitively) only with the main app, so esbuild's
+// chunk-graph algorithm puts each vendor's code in its own shared chunk
+// rather than collapsing them into one large blob — giving the debundle
+// pipeline distinct vendor chunks to swap.
+//
+// The two vendor packages exercise distinct wrapper shapes:
+//   - highlight.js: a CJS package consumed via `import hljs from
+//     "highlight.js"` (named-from-default wrapper shape).
+//   - @careswitch/svelte-data-table: an ESM package with a named export
+//     (`import { DataTable } from "..."`); the wrapper renames the named
+//     re-export off the package's module-default boundary.
+
+import esbuild from "esbuild";
+import esbuildSvelte from "esbuild-svelte";
+import tailwindcss from "esbuild-plugin-tailwindcss";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const outdir = args[0] || "smoke_bundle";
+
+/** @type {esbuild.BuildOptions} */
+const config = {
+  entryPoints: {
+    main: resolve(__dirname, "smoke_main.ts"),
+    vendor_highlight_marker: resolve(__dirname, "vendor_highlight_marker.ts"),
+    vendor_datatable_marker: resolve(__dirname, "vendor_datatable_marker.ts"),
+  },
+  bundle: true,
+  outdir,
+  format: "esm",
+  splitting: true,
+  // Keep readable identifiers — the spec selectors below pin against
+  // them. Realistic-enough: the bundle still goes through the same
+  // emit shape esbuild produces for production (modules, splitting,
+  // chunk graph), just without the final identifier-renaming step.
+  minify: false,
+  sourcemap: false,
+  target: ["es2022"],
+  plugins: [
+    esbuildSvelte({
+      compilerOptions: {
+        css: "injected",
+      },
+    }),
+    tailwindcss(),
+  ],
+  alias: {
+    $lib: resolve(projectRoot, "src/lib"),
+    $components: resolve(projectRoot, "src/components"),
+  },
+  loader: {
+    ".svg": "text",
+  },
+  nodePaths: [resolve(process.cwd(), "node_modules")],
+  preserveSymlinks: false,
+  conditions: ["svelte", "browser", "module", "import"],
+  logLevel: "info",
+  logOverride: {
+    "invalid-source-mappings": "silent",
+  },
+  metafile: true,
+};
+
+const result = await esbuild.build(config);
+const fs = await import("node:fs");
+fs.writeFileSync(resolve(outdir, "metafile.json"), JSON.stringify(result.metafile, null, 2));

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -178,42 +178,14 @@ async function main() {
   if (chunkNames.length === 0) {
     throw new Error(`No .js chunks found in ${bundleDir}`);
   }
-  for (const chunkName of chunkNames) {
-    await copyFile(join(bundleDir, chunkName), join(snapshotOut, "dist", chunkName));
-  }
-  for (const auxName of ["main.css"]) {
-    try {
-      await copyFile(join(bundleDir, auxName), join(snapshotOut, "dist", auxName));
-    } catch (error) {
-      if (error?.code !== "ENOENT") throw error;
-    }
-  }
 
-  const mainChunk = chunkNames.find((name) => name === "main.js");
-  if (!mainChunk) {
-    throw new Error(`Smoke bundle is missing main.js (chunks: ${chunkNames.join(", ")})`);
-  }
-  const indexHtml = rewriteIndexHtml(await readFile(indexHtmlPath, "utf8"), `dist/${mainChunk}`);
-  await writeFile(join(snapshotOut, "index.html"), indexHtml);
-
-  const jsRelPaths = chunkNames.map((name) => `dist/${name}`);
-  await writeFile(jsListOut, `${jsRelPaths.join("\n")}\n`);
-
-  const assetSummary = {
-    counts: {
-      htmlFiles: 1,
-      jsChunks: chunkNames.length,
-      jsFiles: chunkNames.length,
-    },
-    entryPoints: {
-      html: "index.html",
-      js: [`dist/${mainChunk}`],
-    },
-  };
-  await writeFile(assetSummaryOut, `${JSON.stringify(assetSummary, null, 2)}\n`);
-
-  // Classify chunks via the metafile so the spec generator's
-  // vendor-mark ops can pin to the correct hashed chunk filenames.
+  // Classify the hashed chunks via the esbuild metafile *before*
+  // copying them out. Esbuild embeds absolute source paths in CJS
+  // helper preambles, so the same content gets a different hash in
+  // exec vs. target build configs. Renaming the relevant chunks to
+  // deterministic names here gives the spec generator (which runs in
+  // exec config) and the debundler (which runs in target config) a
+  // shared filename to pin against.
   const metafilePath = join(bundleDir, "metafile.json");
   const metafile = JSON.parse(await readFile(metafilePath, "utf8"));
   const vendorMap = classifyChunks(metafile);
@@ -227,10 +199,77 @@ async function main() {
       `Could not classify @careswitch/svelte-data-table chunk in smoke bundle metafile (chunks: ${chunkNames.join(", ")})`
     );
   }
+  const renames = new Map([
+    [vendorMap.highlight, "vendor-highlight.js"],
+    [vendorMap.datatable, "vendor-datatable.js"],
+  ]);
+  const renameTarget = (name) => renames.get(name) ?? name;
+
+  // Copy and (for vendor chunks) rename. Each chunk's own source is
+  // bytes-for-bytes preserved; only the filenames change. Cross-chunk
+  // import specifiers get rewritten in a second pass below.
+  for (const chunkName of chunkNames) {
+    await copyFile(join(bundleDir, chunkName), join(snapshotOut, "dist", renameTarget(chunkName)));
+  }
+  for (const auxName of ["main.css"]) {
+    try {
+      await copyFile(join(bundleDir, auxName), join(snapshotOut, "dist", auxName));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+
+  // Patch import specifiers across chunks to use the renamed filenames.
+  // Only the vendor chunks themselves get renamed, but the chunks
+  // that import them still hold the old hashed paths in their
+  // `import "./chunk-XXX.js"` strings.
+  for (const chunkName of chunkNames) {
+    const targetName = renameTarget(chunkName);
+    const filePath = join(snapshotOut, "dist", targetName);
+    let source = await readFile(filePath, "utf8");
+    let mutated = false;
+    for (const [oldName, newName] of renames) {
+      if (oldName === chunkName) continue;
+      const oldRef = `./${oldName}`;
+      const newRef = `./${newName}`;
+      if (source.includes(oldRef)) {
+        source = source.split(oldRef).join(newRef);
+        mutated = true;
+      }
+    }
+    if (mutated) {
+      await writeFile(filePath, source);
+    }
+  }
+
+  const renamedChunkNames = chunkNames.map(renameTarget);
+  const mainChunk = renamedChunkNames.find((name) => name === "main.js");
+  if (!mainChunk) {
+    throw new Error(`Smoke bundle is missing main.js (chunks: ${chunkNames.join(", ")})`);
+  }
+  const indexHtml = rewriteIndexHtml(await readFile(indexHtmlPath, "utf8"), `dist/${mainChunk}`);
+  await writeFile(join(snapshotOut, "index.html"), indexHtml);
+
+  const jsRelPaths = renamedChunkNames.map((name) => `dist/${name}`);
+  await writeFile(jsListOut, `${jsRelPaths.join("\n")}\n`);
+
+  const assetSummary = {
+    counts: {
+      htmlFiles: 1,
+      jsChunks: renamedChunkNames.length,
+      jsFiles: renamedChunkNames.length,
+    },
+    entryPoints: {
+      html: "index.html",
+      js: [`dist/${mainChunk}`],
+    },
+  };
+  await writeFile(assetSummaryOut, `${JSON.stringify(assetSummary, null, 2)}\n`);
+
   const vendorMapPayload = {
     chunks: {
-      "highlight.js": `dist/${vendorMap.highlight}`,
-      "@careswitch/svelte-data-table": `dist/${vendorMap.datatable}`,
+      "highlight.js": "dist/vendor-highlight.js",
+      "@careswitch/svelte-data-table": "dist/vendor-datatable.js",
     },
   };
   await writeFile(vendorMapOut, `${JSON.stringify(vendorMapPayload, null, 2)}\n`);

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -13,7 +13,7 @@
 // The shape mirrors gaffer's tana/upstream/web/{snapshots,extracted}/<version>/.
 
 import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 
 function parseArgs(argv) {
   const options = {};
@@ -66,11 +66,11 @@ function rewriteIndexHtml(html, mainHref) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const bundleDir = resolve(options.bundle);
-  const indexHtmlPath = resolve(options.index_html);
-  const snapshotOut = resolve(options.snapshot_out);
-  const assetSummaryOut = resolve(options.asset_summary_out);
-  const jsListOut = resolve(options.js_list_out);
+  const bundleDir = options.bundle;
+  const indexHtmlPath = options.index_html;
+  const snapshotOut = options.snapshot_out;
+  const assetSummaryOut = options.asset_summary_out;
+  const jsListOut = options.js_list_out;
 
   await mkdir(snapshotOut, { recursive: true });
   await mkdir(join(snapshotOut, "dist"), { recursive: true });

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Prepares the inputs the debundler expects from the smoke bundle:
+//   <snapshot_out>/index.html    — copy of the smoke index.html, with
+//                                  the <script type="module" src="/dist/main.js">
+//                                  rewritten to the smoke bundle's main entry.
+//   <snapshot_out>/dist/*.js      — chunks, copied verbatim from the smoke bundle.
+//   <asset_summary_out>            — minimal asset-summary.json the
+//                                    `emit_browser_harness` stage reads
+//                                    (entryPoints.html + counts).
+//   <js_list_out>                  — newline-delimited list of chunk paths,
+//                                    relative to <snapshot_out>.
+//
+// The shape mirrors gaffer's tana/upstream/web/{snapshots,extracted}/<version>/.
+
+import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+function parseArgs(argv) {
+  const options = {};
+  const expected = new Set(["--bundle", "--index-html", "--snapshot-out", "--asset-summary-out", "--js-list-out"]);
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!expected.has(arg)) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    const next = argv[++index];
+    if (next === undefined) {
+      throw new Error(`${arg} requires a value`);
+    }
+    const key = arg.replace(/^--/, "").replaceAll("-", "_");
+    options[key] = next;
+  }
+  for (const required of ["bundle", "index_html", "snapshot_out", "asset_summary_out", "js_list_out"]) {
+    if (!options[required]) {
+      throw new Error(`--${required.replaceAll("_", "-")} is required`);
+    }
+  }
+  return options;
+}
+
+async function listChunks(bundleDir) {
+  const entries = await readdir(bundleDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function rewriteIndexHtml(html, mainHref) {
+  // Replace the smoke `/dist/main.js` reference (and `/dist/main.css`)
+  // with paths relative to the snapshot root. Use a strict, single-purpose
+  // substring swap rather than HTML parsing — the smoke index.html is
+  // hand-written and stable; if its layout drifts the test should fail
+  // loudly rather than silently regex past the change.
+  const cssOriginal = `<link rel="stylesheet" href="/dist/main.css" />`;
+  const jsOriginal = `<script type="module" src="/dist/main.js"></script>`;
+  const cssReplacement = `<link rel="stylesheet" href="./dist/main.css" />`;
+  const jsReplacement = `<script type="module" src="./${mainHref}"></script>`;
+  if (!html.includes(cssOriginal) || !html.includes(jsOriginal)) {
+    throw new Error(
+      `smoke_index.html shape changed; expected both ${JSON.stringify(cssOriginal)} and ${JSON.stringify(jsOriginal)} substrings to be present`
+    );
+  }
+  return html.replace(cssOriginal, cssReplacement).replace(jsOriginal, jsReplacement);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const bundleDir = resolve(options.bundle);
+  const indexHtmlPath = resolve(options.index_html);
+  const snapshotOut = resolve(options.snapshot_out);
+  const assetSummaryOut = resolve(options.asset_summary_out);
+  const jsListOut = resolve(options.js_list_out);
+
+  await mkdir(snapshotOut, { recursive: true });
+  await mkdir(join(snapshotOut, "dist"), { recursive: true });
+  await mkdir(dirname(assetSummaryOut), { recursive: true });
+  await mkdir(dirname(jsListOut), { recursive: true });
+
+  const chunkNames = await listChunks(bundleDir);
+  if (chunkNames.length === 0) {
+    throw new Error(`No .js chunks found in ${bundleDir}`);
+  }
+  for (const chunkName of chunkNames) {
+    await copyFile(join(bundleDir, chunkName), join(snapshotOut, "dist", chunkName));
+  }
+  // The CSS sits next to the chunks; copy it so the harness can serve it
+  // alongside the JS once index.html references it.
+  for (const auxName of ["main.css"]) {
+    try {
+      await copyFile(join(bundleDir, auxName), join(snapshotOut, "dist", auxName));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+
+  const mainChunk = chunkNames.find((name) => name === "main.js");
+  if (!mainChunk) {
+    throw new Error(`Smoke bundle is missing main.js (chunks: ${chunkNames.join(", ")})`);
+  }
+  const indexHtml = rewriteIndexHtml(await readFile(indexHtmlPath, "utf8"), `dist/${mainChunk}`);
+  await writeFile(join(snapshotOut, "index.html"), indexHtml);
+
+  const jsRelPaths = chunkNames.map((name) => `dist/${name}`);
+  await writeFile(jsListOut, `${jsRelPaths.join("\n")}\n`);
+
+  const assetSummary = {
+    counts: {
+      htmlFiles: 1,
+      jsChunks: chunkNames.length,
+      jsFiles: chunkNames.length,
+    },
+    entryPoints: {
+      html: "index.html",
+      js: [`dist/${mainChunk}`],
+    },
+  };
+  await writeFile(assetSummaryOut, `${JSON.stringify(assetSummary, null, 2)}\n`);
+}
+
+await main();

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -9,6 +9,8 @@
 //                                    (entryPoints.html + counts).
 //   <js_list_out>                  — newline-delimited list of chunk paths,
 //                                    relative to <snapshot_out>.
+//   <vendor_map_out>              — JSON: which output chunk holds each
+//                                    swapped vendor package's code.
 //
 // The shape mirrors gaffer's tana/upstream/web/{snapshots,extracted}/<version>/.
 
@@ -17,7 +19,14 @@ import { dirname, join } from "node:path";
 
 function parseArgs(argv) {
   const options = {};
-  const expected = new Set(["--bundle", "--index-html", "--snapshot-out", "--asset-summary-out", "--js-list-out"]);
+  const expected = new Set([
+    "--bundle",
+    "--index-html",
+    "--snapshot-out",
+    "--asset-summary-out",
+    "--js-list-out",
+    "--vendor-map-out",
+  ]);
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
     if (!expected.has(arg)) {
@@ -30,7 +39,14 @@ function parseArgs(argv) {
     const key = arg.replace(/^--/, "").replaceAll("-", "_");
     options[key] = next;
   }
-  for (const required of ["bundle", "index_html", "snapshot_out", "asset_summary_out", "js_list_out"]) {
+  for (const required of [
+    "bundle",
+    "index_html",
+    "snapshot_out",
+    "asset_summary_out",
+    "js_list_out",
+    "vendor_map_out",
+  ]) {
     if (!options[required]) {
       throw new Error(`--${required.replaceAll("_", "-")} is required`);
     }
@@ -52,11 +68,6 @@ async function listChunks(bundleDir) {
 }
 
 function rewriteIndexHtml(html, mainHref) {
-  // Replace the smoke `/dist/main.js` reference (and `/dist/main.css`)
-  // with paths relative to the snapshot root. Use a strict, single-purpose
-  // substring swap rather than HTML parsing — the smoke index.html is
-  // hand-written and stable; if its layout drifts the test should fail
-  // loudly rather than silently regex past the change.
   const cssOriginal = `<link rel="stylesheet" href="/dist/main.css" />`;
   const jsOriginal = `<script type="module" src="/dist/main.js"></script>`;
   const cssReplacement = `<link rel="stylesheet" href="./dist/main.css" />`;
@@ -67,6 +78,74 @@ function rewriteIndexHtml(html, mainHref) {
     );
   }
   return html.replace(cssOriginal, cssReplacement).replace(jsOriginal, jsReplacement);
+}
+
+// Classify smoke-bundle chunks by reading the esbuild metafile. The
+// smoke build emits one entry per vendor marker and the main app
+// entry; esbuild's chunk-graph algorithm puts each vendor's code in
+// a chunk shared by exactly that marker entry and main. So a chunk
+// is identified as `<package>` iff it's imported by main and by
+// `<package>_marker.js` (and no other entry).
+function classifyChunks(metafile) {
+  const outputs = metafile.outputs ?? {};
+  const importsOf = new Map();
+  for (const [name, info] of Object.entries(outputs)) {
+    if (!name.endsWith(".js")) continue;
+    importsOf.set(name, new Set((info.imports ?? []).map((entry) => entry.path)));
+  }
+  const findEntry = (suffix) => {
+    for (const [name, info] of Object.entries(outputs)) {
+      if (info.entryPoint && info.entryPoint.endsWith(suffix)) {
+        return name;
+      }
+    }
+    return null;
+  };
+  const mainEntry = findEntry("/smoke_main.ts");
+  const highlightEntry = findEntry("/vendor_highlight_marker.ts");
+  const datatableEntry = findEntry("/vendor_datatable_marker.ts");
+  const allEntries = Object.entries(outputs)
+    .filter(([_, info]) => info.entryPoint)
+    .map(([name]) => name);
+  const sharedExclusively = (entries) => {
+    const requiredImporters = entries.filter((entry) => entry !== null);
+    if (requiredImporters.length === 0) return [];
+    const candidates = new Set(importsOf.get(requiredImporters[0]) ?? []);
+    for (const entry of requiredImporters.slice(1)) {
+      const importerSet = importsOf.get(entry) ?? new Set();
+      for (const candidate of [...candidates]) {
+        if (!importerSet.has(candidate)) {
+          candidates.delete(candidate);
+        }
+      }
+    }
+    const otherEntries = allEntries.filter((name) => !requiredImporters.includes(name));
+    for (const candidate of [...candidates]) {
+      for (const otherEntry of otherEntries) {
+        if (importsOf.get(otherEntry)?.has(candidate)) {
+          candidates.delete(candidate);
+          break;
+        }
+      }
+    }
+    return [...candidates];
+  };
+  const findVendorChunk = (markerEntry) => {
+    if (!markerEntry || !mainEntry) return null;
+    const candidates = sharedExclusively([mainEntry, markerEntry]);
+    if (candidates.length === 0) return null;
+    // Pick the largest chunk if esbuild splits the package across
+    // multiple shared chunks (e.g. CJS shim + main payload).
+    return candidates.sort((a, b) => (outputs[b]?.bytes ?? 0) - (outputs[a]?.bytes ?? 0))[0];
+  };
+  const baseName = (path) => path.split("/").pop();
+  const highlightChunk = findVendorChunk(highlightEntry);
+  const datatableChunk = findVendorChunk(datatableEntry);
+  return {
+    main: mainEntry ? baseName(mainEntry) : null,
+    highlight: highlightChunk ? baseName(highlightChunk) : null,
+    datatable: datatableChunk ? baseName(datatableChunk) : null,
+  };
 }
 
 async function main() {
@@ -87,11 +166,13 @@ async function main() {
   const snapshotOut = stripBindir(options.snapshot_out);
   const assetSummaryOut = stripBindir(options.asset_summary_out);
   const jsListOut = stripBindir(options.js_list_out);
+  const vendorMapOut = stripBindir(options.vendor_map_out);
 
   await mkdir(snapshotOut, { recursive: true });
   await mkdir(join(snapshotOut, "dist"), { recursive: true });
   await mkdir(dirname(assetSummaryOut), { recursive: true });
   await mkdir(dirname(jsListOut), { recursive: true });
+  await mkdir(dirname(vendorMapOut), { recursive: true });
 
   const chunkNames = await listChunks(bundleDir);
   if (chunkNames.length === 0) {
@@ -100,8 +181,6 @@ async function main() {
   for (const chunkName of chunkNames) {
     await copyFile(join(bundleDir, chunkName), join(snapshotOut, "dist", chunkName));
   }
-  // The CSS sits next to the chunks; copy it so the harness can serve it
-  // alongside the JS once index.html references it.
   for (const auxName of ["main.css"]) {
     try {
       await copyFile(join(bundleDir, auxName), join(snapshotOut, "dist", auxName));
@@ -132,6 +211,29 @@ async function main() {
     },
   };
   await writeFile(assetSummaryOut, `${JSON.stringify(assetSummary, null, 2)}\n`);
+
+  // Classify chunks via the metafile so the spec generator's
+  // vendor-mark ops can pin to the correct hashed chunk filenames.
+  const metafilePath = join(bundleDir, "metafile.json");
+  const metafile = JSON.parse(await readFile(metafilePath, "utf8"));
+  const vendorMap = classifyChunks(metafile);
+  if (!vendorMap.highlight) {
+    throw new Error(
+      `Could not classify highlight.js chunk in smoke bundle metafile (chunks: ${chunkNames.join(", ")})`
+    );
+  }
+  if (!vendorMap.datatable) {
+    throw new Error(
+      `Could not classify @careswitch/svelte-data-table chunk in smoke bundle metafile (chunks: ${chunkNames.join(", ")})`
+    );
+  }
+  const vendorMapPayload = {
+    chunks: {
+      "highlight.js": `dist/${vendorMap.highlight}`,
+      "@careswitch/svelte-data-table": `dist/${vendorMap.datatable}`,
+    },
+  };
+  await writeFile(vendorMapOut, `${JSON.stringify(vendorMapPayload, null, 2)}\n`);
 }
 
 await main();

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -66,11 +66,22 @@ function rewriteIndexHtml(html, mainHref) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const bundleDir = options.bundle;
-  const indexHtmlPath = options.index_html;
-  const snapshotOut = options.snapshot_out;
-  const assetSummaryOut = options.asset_summary_out;
-  const jsListOut = options.js_list_out;
+  // The js_binary launcher chdir's to `BAZEL_BINDIR` (the root of
+  // the bazel-out tree) before invoking node. Path args from
+  // `$(execpath …)` arrive execroot-relative, so we strip the
+  // `BAZEL_BINDIR/` prefix when present to get a path relative to
+  // the script's cwd.
+  const bindir = process.env.BAZEL_BINDIR;
+  const stripBindir = (path) => {
+    if (!bindir) return path;
+    const prefix = `${bindir}/`;
+    return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+  };
+  const bundleDir = stripBindir(options.bundle);
+  const indexHtmlPath = stripBindir(options.index_html);
+  const snapshotOut = stripBindir(options.snapshot_out);
+  const assetSummaryOut = stripBindir(options.asset_summary_out);
+  const jsListOut = stripBindir(options.js_list_out);
 
   await mkdir(snapshotOut, { recursive: true });
   await mkdir(join(snapshotOut, "dist"), { recursive: true });

--- a/props/frontend/debundle/prepare_snapshot.mjs
+++ b/props/frontend/debundle/prepare_snapshot.mjs
@@ -39,9 +39,14 @@ function parseArgs(argv) {
 }
 
 async function listChunks(bundleDir) {
+  // Bazel materializes tree-artifact entries as symlinks back to the
+  // execroot, so `withFileTypes: true` returns DirEntries with
+  // `isSymbolicLink() === true`. Filter on the .js extension and on
+  // either real-file or symlink — anything other than a directory is
+  // a chunk.
   const entries = await readdir(bundleDir, { withFileTypes: true });
   return entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+    .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".js"))
     .map((entry) => entry.name)
     .sort();
 }

--- a/props/frontend/debundle/smoke_index.html
+++ b/props/frontend/debundle/smoke_index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Props Smoke</title>
+    <link rel="stylesheet" href="/dist/main.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/dist/main.js"></script>
+  </body>
+</html>

--- a/props/frontend/debundle/smoke_main.ts
+++ b/props/frontend/debundle/smoke_main.ts
@@ -1,0 +1,13 @@
+// Smoke-bundle entry. Mounts the smoke shell into `#app`. Lives under the
+// debundle subpackage so the smoke bundle build can reach it without crossing
+// the production library's package boundary; the production `:app` library
+// stays package-private and untouched.
+
+import SmokeShell from "./smoke_shell.svelte";
+import { mount } from "svelte";
+
+const app = mount(SmokeShell, {
+  target: document.getElementById("app")!,
+});
+
+export default app;

--- a/props/frontend/debundle/smoke_shell.svelte
+++ b/props/frontend/debundle/smoke_shell.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  // Smoke-bundle UI shell. Mirrors the production `App.svelte` chrome
+  // (header + nav + routed main area) closely enough for the load
+  // test to assert against the same selectors (`nav`, `<h1>Props</h1>`,
+  // nav links), but without the production `App.svelte`'s dependency
+  // on backend-fed pages — those would 404 against the static-file
+  // server and pollute `console.error`.
+  //
+  // The shell exists in the debundle subpackage rather than reusing
+  // the production `App.svelte` because the production library is
+  // package-private; the smoke needs a self-contained entry under its
+  // own package.
+  import { pathname, resolve } from "$lib/router";
+  import { highlightLines } from "$lib/highlighting";
+  import { DataTable } from "@careswitch/svelte-data-table";
+
+  const navItems = [
+    { path: "/", label: "Overview" },
+    { path: "/runs", label: "Runs" },
+    { path: "/snapshots", label: "Ground Truth" },
+  ];
+
+  function isActive(path: string, currentPath: string): boolean {
+    if (path === "/") return currentPath === "/";
+    return currentPath.startsWith(path);
+  }
+
+  // Force the smoke to actually exercise the two vendor packages so
+  // the chunk graph emits them as real chunks (not eliminated by
+  // tree-shaking), and so a runtime regression (e.g., wrapper-shape
+  // mismatch breaking `hljs.highlight(...)`) surfaces as a console
+  // error.
+  const sampleLines = ["function hello(name) {", "  return `Hello, ${name}!`;", "}"];
+  const highlighted = highlightLines(sampleLines, "javascript");
+
+  const rows = [
+    { id: 1, name: "alpha" },
+    { id: 2, name: "beta" },
+  ];
+  const columns = [
+    { id: "id" as const, key: "id" as const, name: "ID", sortable: true },
+    { id: "name" as const, key: "name" as const, name: "Name", sortable: true },
+  ];
+  const dataTable = new DataTable({ data: rows, columns });
+</script>
+
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
+  <header class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <h1 class="text-xl font-bold">
+          <a href={resolve("/")} class="hover:text-blue-600">Props</a>
+        </h1>
+      </div>
+      <nav class="flex gap-1">
+        {#each navItems as { path, label } (path)}
+          <a
+            href={resolve(path)}
+            class="px-3 py-1.5 rounded text-sm font-medium transition-colors
+              {isActive(path, $pathname)
+              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+              : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-100'}"
+          >
+            {label}
+          </a>
+        {/each}
+      </nav>
+    </div>
+  </header>
+
+  <main class="p-6">
+    <p data-debundle-smoke="route">Route: <span data-debundle-smoke="pathname">{$pathname}</span></p>
+    <pre data-debundle-smoke="highlighted">{#each highlighted as line}{@html line}<br />{/each}</pre>
+    <p data-debundle-smoke="datatable-rows">{dataTable.rows.length} row(s)</p>
+  </main>
+</div>

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -1,19 +1,22 @@
 #!/usr/bin/env node
-// Stub spec generator. The full canonical pipeline (vendor-swap →
-// materialize → rename → emit_browser_harness) is wired below.
+// Spec generator for the props/frontend debundle smoke. Drives the
+// canonical pipeline (vendor-swap → materialize → rename →
+// emit_browser_harness) against the snapshot the BUILD's `:snapshot`
+// rule produces.
 //
-// The spec is parameterised by `--out-root` so the same generator
-// works for both the bazel-bin pipeline target (where `out-root` is a
-// declared tree artifact) and for ad-hoc local runs (where the
-// generator emits a JSONC blob that can be passed straight to the
-// debundler binary).
+// Pre-flight: reads `extracted/vendor-chunks.json` (also produced by
+// `:snapshot`, classified from the smoke esbuild metafile) to pin
+// each vendor mark op's `chunkPath` to the actual hashed filename
+// esbuild emitted on this build. Without this step the smoke would
+// fail every time esbuild changed its hash function.
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const SNAPSHOT_ROOT = "props/frontend/debundle/snapshot";
 const JS_LIST_PATH = "props/frontend/debundle/extracted/js-files.txt";
 const ASSET_SUMMARY_PATH = "props/frontend/debundle/extracted/asset-summary.json";
+const VENDOR_CHUNKS_PATH = "props/frontend/debundle/extracted/vendor-chunks.json";
 const DEFAULT_OUT_ROOT = "props/frontend/debundle/out";
 
 function parseArgs(argv) {
@@ -45,20 +48,35 @@ function requireValue(argv, index, flag) {
   return value;
 }
 
+function readVendorChunkMap() {
+  const workspaceRoot = process.env.BUILD_WORKSPACE_DIRECTORY ?? process.env.BUILD_WORKING_DIRECTORY ?? process.cwd();
+  // The js_binary launcher chdir's to BAZEL_BINDIR; vendor-chunks.json
+  // sits at the workspace-relative path under bazel-bin/.
+  for (const root of [process.env.BAZEL_BINDIR, workspaceRoot, "."]) {
+    if (!root) continue;
+    const candidate = resolve(root, VENDOR_CHUNKS_PATH);
+    try {
+      return JSON.parse(readFileSync(candidate, "utf8"));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  throw new Error(
+    `Could not read ${VENDOR_CHUNKS_PATH}; ensure //props/frontend/debundle:snapshot has built before invoking the spec generator.`
+  );
+}
+
 // Stable picks (props/frontend source, not upstream-rotating) for the
-// rename pipeline. These bindings live in chunks the smoke bundle
-// produces from props/frontend's real source. The selectors target
-// the un-minified shape (smoke esbuild config keeps `minify: false`),
-// so the binding name in the bundle matches the symbol name in source.
+// rename pipeline. These bindings live in the main chunk produced by
+// the smoke bundle. The selectors target the un-minified shape (the
+// smoke esbuild config keeps `minify: false`), so the binding name
+// in the bundle matches the symbol name in source.
 //
-// The "rename" arm of the pipeline is deliberately conservative: the
-// names map back to readable function/class identifiers a debundler
-// reader would recognize, rather than reaching into the chunk graph
-// for opaque internals (which would drift across upstream package
-// upgrades and create a maintenance burden).
+// The "rename" arm is deliberately conservative — names map back to
+// readable function/class identifiers a debundler reader would
+// recognize, rather than reaching into the chunk graph for opaque
+// internals (which would drift across upstream package upgrades).
 const RENAME_OPS = [
-  // From src/lib/router.ts — exported helpers; high-frequency in
-  // the bundle since every Svelte route handler imports them.
   {
     id: "rename_resolve",
     name: "resolveRoute",
@@ -74,15 +92,11 @@ const RENAME_OPS = [
     name: "parseRouteParams",
     selector: { chunkId: "dist/main", binding: { name: "parseParams", kind: "FunctionDeclaration" } },
   },
-  // From src/lib/router.ts — internal helper; only one occurrence so
-  // the rename surfaces the whole shape of the dispatcher.
   {
     id: "rename_parse_hash",
     name: "parseRouteHash",
     selector: { chunkId: "dist/main", binding: { name: "parseHash", kind: "FunctionDeclaration" } },
   },
-  // From src/lib/highlighting.ts — the only exported function in
-  // the file, used by FileViewer and the smoke shell.
   {
     id: "rename_highlight_lines",
     name: "highlightCodeLines",
@@ -133,49 +147,38 @@ const LOGICAL_MODULES = [
   },
 ];
 
-// Vendor marks. Two pre-vetted packages from props/frontend's
-// production deps. The smoke bundle's chunk-graph algorithm puts each
-// into a shared chunk shared between the main app entry and the
-// per-package marker entry — see esbuild.smoke.config.mjs.
-//
-// chunkPath uses a glob-friendly placeholder; the spec generator
-// reads the actual hashed names from the smoke bundle metafile.
-const VENDOR_OPS = [
-  {
-    id: "mark_vendor_highlight",
-    operation: "mark_vendor",
-    level: "swap",
-    // Vendor chunks share the entry-name prefix esbuild minted from
-    // the marker entry name. esbuild only mints a single shared chunk
-    // per group of importers, so highlight.js's chunk path tracks
-    // the marker entry's name. The exact hashed filename must come
-    // from the smoke bundle metafile — the spec generator reads it
-    // before writing, so this op's chunkPath is filled at runtime.
-    chunkPath: "__placeholder__/vendor_highlight_marker.js",
-    package: "highlight.js",
-    version: "11.11.1",
-    subpath: "es/index.js",
-    wrapperShape: "named-from-default",
-    confidence: "confirmed",
-    identity: "highlight.js (smoke)",
-    upstreamFamily: "highlight.js",
-    evidence: [],
-  },
-  {
-    id: "mark_vendor_datatable",
-    operation: "mark_vendor",
-    level: "swap",
-    chunkPath: "__placeholder__/vendor_datatable_marker.js",
-    package: "@careswitch/svelte-data-table",
-    version: "0.6.3",
-    subpath: "dist/index.js",
-    wrapperShape: "named-from-module-default",
-    confidence: "confirmed",
-    identity: "@careswitch/svelte-data-table (smoke)",
-    upstreamFamily: "@careswitch/svelte-data-table",
-    evidence: [],
-  },
-];
+function buildVendorOps(vendorChunkMap) {
+  return [
+    {
+      id: "mark_vendor_highlight",
+      operation: "mark_vendor",
+      level: "swap",
+      chunkPath: vendorChunkMap.chunks["highlight.js"],
+      package: "highlight.js",
+      version: "11.11.1",
+      subpath: "es/index.js",
+      wrapperShape: "named-from-default",
+      confidence: "confirmed",
+      identity: "highlight.js (smoke)",
+      upstreamFamily: "highlight.js",
+      evidence: [],
+    },
+    {
+      id: "mark_vendor_datatable",
+      operation: "mark_vendor",
+      level: "swap",
+      chunkPath: vendorChunkMap.chunks["@careswitch/svelte-data-table"],
+      package: "@careswitch/svelte-data-table",
+      version: "0.6.3",
+      subpath: "dist/index.js",
+      wrapperShape: "named-from-module-default",
+      confidence: "confirmed",
+      identity: "@careswitch/svelte-data-table (smoke)",
+      upstreamFamily: "@careswitch/svelte-data-table",
+      evidence: [],
+    },
+  ];
+}
 
 function buildPipeline(outRoot) {
   return [
@@ -190,14 +193,8 @@ function buildPipeline(outRoot) {
         reportSummaryPath: `${outRoot}/analysis/logical_modules/summary.json`,
       },
     },
-    {
-      id: "annotate_vendor_chunks",
-      operation: "apply_vendor_annotations",
-    },
-    {
-      id: "rewrite_vendor_export_imports",
-      operation: "rename_vendor_exports",
-    },
+    { id: "annotate_vendor_chunks", operation: "apply_vendor_annotations" },
+    { id: "rewrite_vendor_export_imports", operation: "rename_vendor_exports" },
     {
       id: "emit_vendor_wrappers",
       operation: "swap_vendor_chunks",
@@ -207,10 +204,7 @@ function buildPipeline(outRoot) {
         write: true,
       },
     },
-    {
-      id: "rewrite_chunk_entry_specifiers",
-      operation: "rewrite_chunk_entry_specifiers",
-    },
+    { id: "rewrite_chunk_entry_specifiers", operation: "rewrite_chunk_entry_specifiers" },
     {
       id: "emit_browser_harness",
       operation: "emit_browser_harness",
@@ -225,11 +219,12 @@ function buildPipeline(outRoot) {
 }
 
 function buildSpec(outRoot) {
+  const vendorChunkMap = readVendorChunkMap();
   return {
     schemaVersion: 1,
     kind: "js.ast_transform_spec",
     inputs: { inputRoot: SNAPSHOT_ROOT, jsListPath: JS_LIST_PATH },
-    operations: [...VENDOR_OPS, ...RENAME_OPS, ...LOGICAL_MODULES],
+    operations: [...buildVendorOps(vendorChunkMap), ...RENAME_OPS, ...LOGICAL_MODULES],
     pipeline: buildPipeline(outRoot),
   };
 }

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -170,7 +170,7 @@ function buildVendorOps(vendorChunkMap) {
       confidence: "confirmed",
       identity: "highlight.js (smoke)",
       upstreamFamily: "highlight.js",
-      evidence: [],
+      evidence: [{ path: vendorChunkMap.chunks["highlight.js"], line: 1, text: "smoke marker chunk: highlight.js" }],
     },
     {
       id: "mark_vendor_datatable",
@@ -184,7 +184,13 @@ function buildVendorOps(vendorChunkMap) {
       confidence: "confirmed",
       identity: "@careswitch/svelte-data-table (smoke)",
       upstreamFamily: "@careswitch/svelte-data-table",
-      evidence: [],
+      evidence: [
+        {
+          path: vendorChunkMap.chunks["@careswitch/svelte-data-table"],
+          line: 1,
+          text: "smoke marker chunk: @careswitch/svelte-data-table",
+        },
+      ],
     },
   ];
 }

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -186,7 +186,13 @@ function buildVendorOps(vendorChunkMap) {
       package: "@careswitch/svelte-data-table",
       version: "0.6.3",
       subpath: "dist/index.js",
-      wrapperShape: "named-from-module-default",
+      // svelte-data-table's `dist/index.js` is a plain re-export
+      // (`export { DataTable } from "./DataTable.svelte.js"`) — no
+      // default to wrap, just a same-named pass-through. Omitting
+      // `wrapperShape` selects the no-wrapper path: the debundler
+      // swaps the chunk for the upstream package directly and
+      // verifies that every vendor-side named export is present
+      // upstream.
       confidence: "confirmed",
       identity: "@careswitch/svelte-data-table (smoke)",
       upstreamFamily: "@careswitch/svelte-data-table",

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -192,7 +192,7 @@ function buildVendorOps(vendorChunkMap) {
 function buildPipeline(outRoot) {
   return [
     {
-      id: "materialize_logical_modules",
+      id: "materialize_logical_module_files",
       operation: "materialize_logical_modules",
       args: {
         chunkIds: ["dist/main"],
@@ -213,9 +213,9 @@ function buildPipeline(outRoot) {
         write: true,
       },
     },
-    { id: "rewrite_chunk_entry_specifiers", operation: "rewrite_chunk_entry_specifiers" },
+    { id: "realize_chunk_entry_specifiers", operation: "rewrite_chunk_entry_specifiers" },
     {
-      id: "emit_browser_harness",
+      id: "emit_browser_test_app",
       operation: "emit_browser_harness",
       args: {
         assetSummaryPath: ASSET_SUMMARY_PATH,

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// Stub spec generator. The full canonical pipeline (vendor-swap →
+// materialize → rename → emit_browser_harness) is wired below.
+//
+// The spec is parameterised by `--out-root` so the same generator
+// works for both the bazel-bin pipeline target (where `out-root` is a
+// declared tree artifact) and for ad-hoc local runs (where the
+// generator emits a JSONC blob that can be passed straight to the
+// debundler binary).
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const SNAPSHOT_ROOT = "props/frontend/debundle/snapshot";
+const JS_LIST_PATH = "props/frontend/debundle/extracted/js-files.txt";
+const ASSET_SUMMARY_PATH = "props/frontend/debundle/extracted/asset-summary.json";
+const DEFAULT_OUT_ROOT = "props/frontend/debundle/out";
+
+function parseArgs(argv) {
+  const options = { outPath: null, outRoot: DEFAULT_OUT_ROOT };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--out":
+        options.outPath = requireValue(argv, ++index, arg);
+        break;
+      case "--out-root":
+        options.outRoot = requireValue(argv, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (options.outPath === null) {
+    throw new Error("--out is required");
+  }
+  return options;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+// Stable picks (props/frontend source, not upstream-rotating) for the
+// rename pipeline. These bindings live in chunks the smoke bundle
+// produces from props/frontend's real source. The selectors target
+// the un-minified shape (smoke esbuild config keeps `minify: false`),
+// so the binding name in the bundle matches the symbol name in source.
+//
+// The "rename" arm of the pipeline is deliberately conservative: the
+// names map back to readable function/class identifiers a debundler
+// reader would recognize, rather than reaching into the chunk graph
+// for opaque internals (which would drift across upstream package
+// upgrades and create a maintenance burden).
+const RENAME_OPS = [
+  // From src/lib/router.ts — exported helpers; high-frequency in
+  // the bundle since every Svelte route handler imports them.
+  {
+    id: "rename_resolve",
+    name: "resolveRoute",
+    selector: { chunkId: "dist/main", binding: { name: "resolve", kind: "FunctionDeclaration" } },
+  },
+  {
+    id: "rename_goto",
+    name: "gotoRoute",
+    selector: { chunkId: "dist/main", binding: { name: "goto", kind: "FunctionDeclaration" } },
+  },
+  {
+    id: "rename_parse_params",
+    name: "parseRouteParams",
+    selector: { chunkId: "dist/main", binding: { name: "parseParams", kind: "FunctionDeclaration" } },
+  },
+  // From src/lib/router.ts — internal helper; only one occurrence so
+  // the rename surfaces the whole shape of the dispatcher.
+  {
+    id: "rename_parse_hash",
+    name: "parseRouteHash",
+    selector: { chunkId: "dist/main", binding: { name: "parseHash", kind: "FunctionDeclaration" } },
+  },
+  // From src/lib/highlighting.ts — the only exported function in
+  // the file, used by FileViewer and the smoke shell.
+  {
+    id: "rename_highlight_lines",
+    name: "highlightCodeLines",
+    selector: { chunkId: "dist/main", binding: { name: "highlightLines", kind: "FunctionDeclaration" } },
+  },
+];
+
+// Three logical modules pulled out of the main chunk. Each maps to a
+// recognisable file in props/frontend source — the smoke checks that
+// the materializer can recover the right shape from a real bundle
+// (function declarations, exported bindings, dependency closure).
+const LOGICAL_MODULES = [
+  {
+    id: "materialize_router",
+    operation: "define_logical_module",
+    chunkId: "dist/main",
+    targetPath: "lib/router",
+    members: [
+      { binding: "parseHash", exportName: "parseHash" },
+      { binding: "createRouter", exportName: "createRouter" },
+      { binding: "pathname", exportName: "pathname" },
+      { binding: "searchParams", exportName: "searchParams" },
+      { binding: "goto", exportName: "goto" },
+      { binding: "resolve", exportName: "resolve" },
+      { binding: "parseParams", exportName: "parseParams" },
+    ],
+  },
+  {
+    id: "materialize_token",
+    operation: "define_logical_module",
+    chunkId: "dist/main",
+    targetPath: "lib/token",
+    members: [
+      { binding: "needsToken", exportName: "needsToken" },
+      { binding: "getToken", exportName: "getToken" },
+      { binding: "setToken", exportName: "setToken" },
+      { binding: "clearToken", exportName: "clearToken" },
+      { binding: "captureTokenFromUrl", exportName: "captureTokenFromUrl" },
+      { binding: "onAuthFailed", exportName: "onAuthFailed" },
+    ],
+  },
+  {
+    id: "materialize_highlighting",
+    operation: "define_logical_module",
+    chunkId: "dist/main",
+    targetPath: "lib/highlighting",
+    members: [{ binding: "highlightLines", exportName: "highlightLines" }],
+  },
+];
+
+// Vendor marks. Two pre-vetted packages from props/frontend's
+// production deps. The smoke bundle's chunk-graph algorithm puts each
+// into a shared chunk shared between the main app entry and the
+// per-package marker entry — see esbuild.smoke.config.mjs.
+//
+// chunkPath uses a glob-friendly placeholder; the spec generator
+// reads the actual hashed names from the smoke bundle metafile.
+const VENDOR_OPS = [
+  {
+    id: "mark_vendor_highlight",
+    operation: "mark_vendor",
+    level: "swap",
+    // Vendor chunks share the entry-name prefix esbuild minted from
+    // the marker entry name. esbuild only mints a single shared chunk
+    // per group of importers, so highlight.js's chunk path tracks
+    // the marker entry's name. The exact hashed filename must come
+    // from the smoke bundle metafile — the spec generator reads it
+    // before writing, so this op's chunkPath is filled at runtime.
+    chunkPath: "__placeholder__/vendor_highlight_marker.js",
+    package: "highlight.js",
+    version: "11.11.1",
+    subpath: "es/index.js",
+    wrapperShape: "named-from-default",
+    confidence: "confirmed",
+    identity: "highlight.js (smoke)",
+    upstreamFamily: "highlight.js",
+    evidence: [],
+  },
+  {
+    id: "mark_vendor_datatable",
+    operation: "mark_vendor",
+    level: "swap",
+    chunkPath: "__placeholder__/vendor_datatable_marker.js",
+    package: "@careswitch/svelte-data-table",
+    version: "0.6.3",
+    subpath: "dist/index.js",
+    wrapperShape: "named-from-module-default",
+    confidence: "confirmed",
+    identity: "@careswitch/svelte-data-table (smoke)",
+    upstreamFamily: "@careswitch/svelte-data-table",
+    evidence: [],
+  },
+];
+
+function buildPipeline(outRoot) {
+  return [
+    {
+      id: "materialize_logical_modules",
+      operation: "materialize_logical_modules",
+      args: {
+        chunkIds: ["dist/main"],
+        force: true,
+        targetDir: "modules",
+        reportOutDir: `${outRoot}/analysis/logical_modules`,
+        reportSummaryPath: `${outRoot}/analysis/logical_modules/summary.json`,
+      },
+    },
+    {
+      id: "annotate_vendor_chunks",
+      operation: "apply_vendor_annotations",
+    },
+    {
+      id: "rewrite_vendor_export_imports",
+      operation: "rename_vendor_exports",
+    },
+    {
+      id: "emit_vendor_wrappers",
+      operation: "swap_vendor_chunks",
+      args: {
+        outputManifestPath: `${outRoot}/vendors/manifest.json`,
+        outputWrapperDir: `${outRoot}/vendors/generated`,
+        write: true,
+      },
+    },
+    {
+      id: "rewrite_chunk_entry_specifiers",
+      operation: "rewrite_chunk_entry_specifiers",
+    },
+    {
+      id: "emit_browser_harness",
+      operation: "emit_browser_harness",
+      args: {
+        assetSummaryPath: ASSET_SUMMARY_PATH,
+        force: true,
+        outDir: outRoot,
+        snapshotRoot: SNAPSHOT_ROOT,
+      },
+    },
+  ];
+}
+
+function buildSpec(outRoot) {
+  return {
+    schemaVersion: 1,
+    kind: "js.ast_transform_spec",
+    inputs: { inputRoot: SNAPSHOT_ROOT, jsListPath: JS_LIST_PATH },
+    operations: [...VENDOR_OPS, ...RENAME_OPS, ...LOGICAL_MODULES],
+    pipeline: buildPipeline(outRoot),
+  };
+}
+
+function writeSpec(spec, outPath) {
+  const workspaceRoot = process.env.BUILD_WORKSPACE_DIRECTORY ?? process.env.BUILD_WORKING_DIRECTORY ?? process.cwd();
+  const resolved = resolve(workspaceRoot, outPath);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(
+    resolved,
+    `// Generated transform spec for the props/frontend debundle smoke. Edit the spec generator instead.\n${JSON.stringify(spec, null, 2)}\n`
+  );
+}
+
+const options = parseArgs(process.argv.slice(2));
+writeSpec(buildSpec(options.outRoot), options.outPath);

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -197,17 +197,11 @@ function buildVendorOps(vendorChunkMap) {
 
 function buildPipeline(outRoot) {
   return [
-    {
-      id: "materialize_logical_module_files",
-      operation: "materialize_logical_modules",
-      args: {
-        chunkIds: ["dist/main"],
-        force: true,
-        targetDir: "modules",
-        reportOutDir: `${outRoot}/analysis/logical_modules`,
-        reportSummaryPath: `${outRoot}/analysis/logical_modules/summary.json`,
-      },
-    },
+    // Run vendor stages before materialize so the vendor chunks are
+    // visible at annotate time. Materialize's default settings keep
+    // other chunks intact, but reordering hedges against future
+    // materializer behavior changes — and matches the gaffer Tana
+    // pipeline order more closely.
     { id: "annotate_vendor_chunks", operation: "apply_vendor_annotations" },
     { id: "rewrite_vendor_export_imports", operation: "rename_vendor_exports" },
     {
@@ -217,6 +211,17 @@ function buildPipeline(outRoot) {
         outputManifestPath: `${outRoot}/vendors/manifest.json`,
         outputWrapperDir: `${outRoot}/vendors/generated`,
         write: true,
+      },
+    },
+    {
+      id: "materialize_logical_module_files",
+      operation: "materialize_logical_modules",
+      args: {
+        chunkIds: ["dist/main"],
+        force: true,
+        targetDir: "modules",
+        reportOutDir: `${outRoot}/analysis/logical_modules`,
+        reportSummaryPath: `${outRoot}/analysis/logical_modules/summary.json`,
       },
     },
     { id: "realize_chunk_entry_specifiers", operation: "rewrite_chunk_entry_specifiers" },

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -49,12 +49,21 @@ function requireValue(argv, index, flag) {
 }
 
 function readVendorChunkMap() {
+  // vendor-chunks.json reaches the spec generator via `data=` on
+  // `:spec_generator_lib`, surfaced in the binary's runfiles tree.
+  // The js_binary launcher chdir's to BAZEL_BINDIR (target config),
+  // but the runfiles live under the *exec*-config bin tree
+  // (`bazel-out/<exec>/bin/.../spec_generator.runfiles/_main/…`).
+  // Walk a small list of candidate roots and pick the first match.
   const workspaceRoot = process.env.BUILD_WORKSPACE_DIRECTORY ?? process.env.BUILD_WORKING_DIRECTORY ?? process.cwd();
-  // The js_binary launcher chdir's to BAZEL_BINDIR; vendor-chunks.json
-  // sits at the workspace-relative path under bazel-bin/.
-  for (const root of [process.env.BAZEL_BINDIR, workspaceRoot, "."]) {
-    if (!root) continue;
-    const candidate = resolve(root, VENDOR_CHUNKS_PATH);
+  const runfilesDir = process.env.RUNFILES_DIR;
+  const runfilesWorkspace = process.env.JS_BINARY__RUNFILES;
+  const candidates = [];
+  if (runfilesWorkspace) candidates.push(resolve(runfilesWorkspace, "_main", VENDOR_CHUNKS_PATH));
+  if (runfilesDir) candidates.push(resolve(runfilesDir, "_main", VENDOR_CHUNKS_PATH));
+  if (process.env.BAZEL_BINDIR) candidates.push(resolve(process.env.BAZEL_BINDIR, VENDOR_CHUNKS_PATH));
+  candidates.push(resolve(workspaceRoot, VENDOR_CHUNKS_PATH));
+  for (const candidate of candidates) {
     try {
       return JSON.parse(readFileSync(candidate, "utf8"));
     } catch (error) {
@@ -62,7 +71,7 @@ function readVendorChunkMap() {
     }
   }
   throw new Error(
-    `Could not read ${VENDOR_CHUNKS_PATH}; ensure //props/frontend/debundle:snapshot has built before invoking the spec generator.`
+    `Could not read ${VENDOR_CHUNKS_PATH}; tried ${candidates.join(", ")}. Ensure //props/frontend/debundle:snapshot has built before invoking the spec generator.`
   );
 }
 

--- a/props/frontend/debundle/spec_generator.mjs
+++ b/props/frontend/debundle/spec_generator.mjs
@@ -166,7 +166,13 @@ function buildVendorOps(vendorChunkMap) {
       package: "highlight.js",
       version: "11.11.1",
       subpath: "es/index.js",
-      wrapperShape: "named-from-default",
+      // highlight.js `es/index.js` is `import x from "..."; export
+      // default x;` — the named-from-module-default wrapper shape
+      // matches that pattern (rename a re-exported module default
+      // back to a named export). The named-from-default shape would
+      // require an object-literal default, which highlight.js's
+      // identifier-based default doesn't satisfy.
+      wrapperShape: "named-from-module-default",
       confidence: "confirmed",
       identity: "highlight.js (smoke)",
       upstreamFamily: "highlight.js",

--- a/props/frontend/debundle/static_load_test.mjs
+++ b/props/frontend/debundle/static_load_test.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// Self-hosted live-browser smoke for the props/frontend debundle harness.
+//
+// Unlike the gaffer Tana smoke (which MITM-proxies a real upstream host),
+// this smoke is fully self-hosted: a tiny Node http server serves the
+// debundler's harness output tree, then a headless Chromium drives it
+// through puppeteer and asserts on:
+//   1. no failed requests under the harness asset path
+//   2. no console errors / page errors
+//   3. the navbar selector is visible
+//   4. clicking a nav link navigates (URL hash + DOM update)
+//
+// The harness is a self-contained tree: index.html, bootstrap.js, the
+// transformed chunks, and (via the swap_vendor_chunks stage) generated
+// vendor wrappers + a vendor manifest. Vendor chunks resolve back to
+// the package roots passed via `--package-root` flags (same shape as
+// the live-proxy CLI).
+
+import { createReadStream, existsSync, statSync, readFileSync } from "node:fs";
+import { extname, join, normalize, resolve } from "node:path";
+import { createServer } from "node:net";
+import { createServer as createHttpServer } from "node:http";
+
+import { launchPuppeteerBrowser } from "../../../util/testing/frontend_visual/puppeteer-lib.mjs";
+
+function parseArgs(argv) {
+  const options = {
+    appManifestPath: null,
+    packageRoots: {},
+    waitForSelector: null,
+    waitTimeoutMs: 30_000,
+    gotoTimeoutMs: 30_000,
+    waitForNavInteraction: false,
+  };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--app-manifest":
+        options.appManifestPath = requireValue(argv, ++index, arg);
+        break;
+      case "--package-root": {
+        const value = requireValue(argv, ++index, arg);
+        const eq = value.indexOf("=");
+        if (eq <= 0) throw new Error(`--package-root must be <pkg>=<dir>, got ${value}`);
+        options.packageRoots[value.slice(0, eq)] = value.slice(eq + 1);
+        break;
+      }
+      case "--wait-for-selector":
+        options.waitForSelector = requireValue(argv, ++index, arg);
+        break;
+      case "--wait-timeout-ms":
+        options.waitTimeoutMs = parseInt(requireValue(argv, ++index, arg), 10);
+        break;
+      case "--goto-timeout-ms":
+        options.gotoTimeoutMs = parseInt(requireValue(argv, ++index, arg), 10);
+        break;
+      case "--assert-nav-interaction":
+        options.waitForNavInteraction = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.appManifestPath) throw new Error("--app-manifest is required");
+  return options;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function allocatePort() {
+  return new Promise((res, rej) => {
+    const s = createServer();
+    s.once("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const port = s.address().port;
+      s.close((err) => (err ? rej(err) : res(port)));
+    });
+  });
+}
+
+const CONTENT_TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+function safeJoin(root, relative) {
+  const normalized = normalize(relative).replace(/^([/\\])+/, "");
+  const resolved = resolve(root, normalized);
+  const rootResolved = resolve(root);
+  if (!resolved.startsWith(`${rootResolved}/`) && resolved !== rootResolved) {
+    throw new Error(`refusing to serve outside root: ${relative}`);
+  }
+  return resolved;
+}
+
+function startStaticServer({ appRoot, vendorIndex }) {
+  const server = createHttpServer((req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", "http://_local");
+      let path = url.pathname;
+      if (path === "/") path = "/index.html";
+      // Vendor chunk: served from the resolved package subpath (same
+      // shape the live proxy uses).
+      const pathNoLeading = path.replace(/^[/\\]+/, "");
+      const vendorMatch = vendorIndex.find((entry) => pathNoLeading.startsWith(`${entry.chunkId}/`));
+      if (vendorMatch) {
+        const suffix = pathNoLeading.slice(vendorMatch.chunkId.length + 1);
+        const filePath =
+          vendorMatch.entryFile === suffix ? vendorMatch.filePath : safeJoin(vendorMatch.mountRoot, suffix);
+        if (existsSync(filePath) && statSync(filePath).isFile()) {
+          res.setHeader("cache-control", "no-store");
+          res.setHeader("content-type", CONTENT_TYPES[extname(filePath)] ?? "application/octet-stream");
+          res.writeHead(200);
+          createReadStream(filePath).pipe(res);
+          return;
+        }
+      }
+      const filePath = safeJoin(appRoot, pathNoLeading);
+      if (existsSync(filePath) && statSync(filePath).isFile()) {
+        res.setHeader("cache-control", "no-store");
+        res.setHeader("content-type", CONTENT_TYPES[extname(filePath)] ?? "application/octet-stream");
+        res.writeHead(200);
+        createReadStream(filePath).pipe(res);
+        return;
+      }
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end(`not found: ${path}\n`);
+    } catch (error) {
+      res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      res.end(`${error?.stack ?? error}\n`);
+    }
+  });
+  return server;
+}
+
+function loadVendorIndex({ vendorManifestPath, packageRoots }) {
+  if (!existsSync(vendorManifestPath)) return [];
+  const manifest = JSON.parse(readFileSync(vendorManifestPath, "utf8"));
+  if (manifest.kind !== "js.vendor_resolution_manifest") {
+    throw new Error(`Unexpected vendor manifest kind: ${manifest.kind}`);
+  }
+  const manifestDir = resolve(vendorManifestPath, "..");
+  const entries = [];
+  for (const [chunkPathKey, entry] of Object.entries(manifest.resolutions ?? {})) {
+    const chunkPath = entry.chunkPath ?? chunkPathKey;
+    const chunkId = chunkPath.endsWith(".js") ? chunkPath.slice(0, -3) : chunkPath;
+    const wrapperPath = entry.generatedWrapperPath ? resolve(manifestDir, entry.generatedWrapperPath) : null;
+    const packageRoot = packageRoots[entry.package];
+    if (!packageRoot) {
+      throw new Error(`vendor package root not provided for ${entry.package}`);
+    }
+    const filePath = wrapperPath ?? resolve(packageRoot, entry.subpath);
+    const mountRoot = wrapperPath ? resolve(wrapperPath, "..") : packageRoot;
+    entries.push({
+      chunkId,
+      entryFile: entry.entryFile,
+      filePath,
+      mountRoot,
+    });
+  }
+  return entries;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  // Resolve the manifest via the JS_BINARY runfiles env, mirroring
+  // the live_proxy entry point.
+  const manifestRel = options.appManifestPath;
+  const manifest = JSON.parse(readFileSync(manifestRel, "utf8"));
+  const manifestDir = resolve(manifestRel, "..");
+  const appRoot = resolve(manifestDir, manifest.outDir);
+  const vendorManifestPath = manifest.vendorManifestPath
+    ? resolve(manifestDir, manifest.vendorManifestPath)
+    : join(appRoot, "vendors", "manifest.json");
+  const vendorIndex = loadVendorIndex({ vendorManifestPath, packageRoots: options.packageRoots });
+
+  const port = await allocatePort();
+  const server = startStaticServer({ appRoot, vendorIndex });
+  await new Promise((r) => server.listen(port, "127.0.0.1", r));
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await launchPuppeteerBrowser({
+    args: ["--disable-dev-shm-usage", "--disable-setuid-sandbox", "--no-sandbox"],
+    headless: true,
+  });
+
+  const page = await browser.newPage();
+  const consoleMessages = [];
+  const failedRequests = [];
+  const pageErrors = [];
+
+  page.on("console", (m) => consoleMessages.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => pageErrors.push(e.stack ?? e.message));
+  page.on("requestfailed", (req) =>
+    failedRequests.push({ url: req.url(), errorText: req.failure()?.errorText ?? "unknown" })
+  );
+
+  let assertionError = null;
+  try {
+    await page.goto(`${baseUrl}/`, { timeout: options.gotoTimeoutMs, waitUntil: "domcontentloaded" });
+    if (options.waitForSelector) {
+      await page.waitForSelector(options.waitForSelector, { timeout: options.waitTimeoutMs });
+    }
+    await new Promise((r) => setTimeout(r, 500));
+
+    const pageState = await page.evaluate(() => ({
+      title: document.title,
+      hash: location.hash,
+      navText: document.querySelector("nav")?.innerText ?? null,
+      headerText: document.querySelector("header h1")?.innerText ?? null,
+    }));
+
+    // Assertion 1: no failed asset requests.
+    if (failedRequests.length > 0) {
+      throw new Error(`failed requests:\n${JSON.stringify(failedRequests, null, 2)}`);
+    }
+
+    // Assertion 2: no console errors.
+    const consoleErrors = consoleMessages.filter((m) => m.startsWith("[error]"));
+    if (consoleErrors.length > 0 || pageErrors.length > 0) {
+      throw new Error(
+        `console/page errors:\n${[...consoleErrors, ...pageErrors].join("\n")}\n\nall console:\n${consoleMessages.join("\n")}`
+      );
+    }
+
+    // Assertion 3: navbar selector visible.
+    if (!pageState.navText) {
+      throw new Error(`expected <nav> with text content, got ${JSON.stringify(pageState)}`);
+    }
+    if (!pageState.headerText || !pageState.headerText.includes("Props")) {
+      throw new Error(`expected <h1>Props</h1>, got headerText=${JSON.stringify(pageState.headerText)}`);
+    }
+
+    // Assertion 4: clicking a nav link updates the URL hash + DOM.
+    if (options.waitForNavInteraction) {
+      await page.click('nav a[href*="/runs"]');
+      await page.waitForFunction(() => location.hash === "#/runs", { timeout: options.waitTimeoutMs });
+      const updatedPathnameText = await page.evaluate(
+        () => document.querySelector('[data-debundle-smoke="pathname"]')?.textContent ?? null
+      );
+      if (updatedPathnameText !== "/runs") {
+        throw new Error(
+          `nav click did not update DOM pathname; got ${JSON.stringify(updatedPathnameText)}, expected "/runs"`
+        );
+      }
+    }
+  } catch (error) {
+    assertionError = error;
+  } finally {
+    await browser.close();
+    await new Promise((r) => server.close(r));
+  }
+  if (assertionError) {
+    throw assertionError;
+  }
+}
+
+await main();

--- a/props/frontend/debundle/vendor_datatable_marker.ts
+++ b/props/frontend/debundle/vendor_datatable_marker.ts
@@ -1,0 +1,6 @@
+// Smoke-bundle marker for @careswitch/svelte-data-table. Forces esbuild's
+// chunk-graph algorithm to put svelte-data-table into its own shared chunk.
+
+import { DataTable } from "@careswitch/svelte-data-table";
+
+export const __dataTableAlive = DataTable;

--- a/props/frontend/debundle/vendor_highlight_marker.ts
+++ b/props/frontend/debundle/vendor_highlight_marker.ts
@@ -1,0 +1,7 @@
+// Smoke-bundle marker for highlight.js. Forces esbuild's chunk-graph
+// algorithm to put highlight.js into its own shared chunk (since this
+// marker entry shares only highlight.js with the main app entry).
+
+import hljs from "highlight.js";
+
+export const __highlightAlive = hljs;

--- a/props/frontend/debundle/vendor_marker.ts
+++ b/props/frontend/debundle/vendor_marker.ts
@@ -1,0 +1,9 @@
+// Smoke-bundle marker entry. Pins highlight.js + svelte-data-table as
+// imports a third entry shares with the main app, so esbuild keeps both
+// vendor packages alive in the chunk graph (alongside the per-package
+// markers in `vendor_highlight_marker.ts` / `vendor_datatable_marker.ts`).
+
+import hljs from "highlight.js";
+import { DataTable } from "@careswitch/svelte-data-table";
+
+export const __keepalive = { hljs, DataTable };


### PR DESCRIPTION
## Summary

Realistic-shape live-browser smoke for `props/frontend` (Svelte 5 / esbuild splitting / Tailwind), self-hosted, exercising the same debundle pipeline shape as the Tana smoke but on an open-source corpus.

**Status:** branch published, smoke does NOT pass yet — blocked on a real (preexisting) debundler bug uncovered while authoring the spec. Filing this PR so the wiring + spec + test infra get reviewed and the blocker has a public reference.

## What's wired up under `props/frontend/debundle/`

- `BUILD.bazel` — `:smoke_bundle`, `:snapshot`, `:debundle_props_frontend` (using the now-shared `debundle_pipeline`), `:load_props_frontend` (`js_test`).
- `esbuild.smoke.config.mjs` — multi-chunk smoke variant of the production esbuild config (forces vendor packages into separate shared chunks via secondary entry points).
- `prepare_snapshot.mjs` — extracts `js-files.txt`, `asset-summary.json`, `vendor-chunks.json` from the smoke metafile; renames vendor chunks to deterministic filenames so target/exec build configs agree.
- `spec_generator.mjs` — emits the canonical pipeline (apply_vendor_annotations + rename_vendor_exports + swap_vendor_chunks + materialize_logical_modules + define_logical_module + rewrite_chunk_entry_specifiers + emit_browser_harness).
- `smoke_main.ts` / `smoke_shell.svelte` / `smoke_index.html` — entry + UI shell mirroring production `App.svelte`.
- `vendor_marker.ts` / `vendor_highlight_marker.ts` / `vendor_datatable_marker.ts` — secondary entries that force esbuild's chunk-graph algorithm to put each vendor package in its own shared chunk.
- `static_load_test.mjs` — self-hosted Node http server + headless Chromium driver.

## Smoke assertions (literal)

1. `failedRequests.length > 0` → fail (no failed asset requests).
2. `consoleErrors.length > 0 || pageErrors.length > 0` → fail (no console / page errors).
3. `pageState.navText && pageState.headerText.includes("Props")` (`<nav>` + `<header h1>` carry expected text).
4. `await page.click('nav a[href*="/runs"]'); await page.waitForFunction(() => location.hash === "#/runs", ...);` plus DOM `data-debundle-smoke="pathname"` text equals `/runs` — clicking a nav link updates URL hash + DOM (no-backend interaction).

## Vendor packages picked

- `highlight.js` (`named-from-module-default` wrapper shape — `import x from "..."; export default x;`)
- `@careswitch/svelte-data-table` (no wrapper — plain re-export passthrough)

## Materialized modules

- `lib/router` (parseHash, createRouter, pathname, searchParams, goto, resolve, parseParams)
- `lib/token` (needsToken, getToken, setToken, clearToken, captureTokenFromUrl, onAuthFailed)
- `lib/highlighting` (highlightLines)

## Renames (5)

`resolve` → `resolveRoute`, `goto` → `gotoRoute`, `parseParams` → `parseRouteParams`, `parseHash` → `parseRouteHash`, `highlightLines` → `highlightCodeLines`.

## Blocker — `swap_vendor_chunks` rejects svelte-data-table

```
swapVendorChunks operation mark_vendor_datatable export shape mismatch for @careswitch/svelte-data-table@0.6.3:
vendor exports not found upstream=[append,child,derived,each,enable_legacy_mode_flag,first_child,from_html,
get,html,index,init,mount,next,pop,push,reset,set_attribute,set_class,set_text,setup_stores,sibling,
store_get,template_effect,writable]
```

Esbuild's chunk-graph algorithm folds Svelte runtime helpers into the same shared chunk as `@careswitch/svelte-data-table`. The check correctly notices the chunk re-exports more names than upstream — but leaves the user without a next step. Filing this as a separate bug with a failing-fixture e2e (work in a follow-up PR per the "minimal e2e first" discipline).

## TODO.md update

Replaces the Excalidraw entry with a forward-looking "props/frontend live-browser smoke" section describing the actual built target + workflow rule + open follow-ups.

## Test plan

- [x] `bazelisk build //props/frontend/debundle:debundle_props_frontend --remote_executor=""` — pipeline runs through `apply_vendor_annotations` + `rename_vendor_exports` + first vendor's `swap_vendor_chunks`.
- [ ] `bazelisk test //props/frontend/debundle:load_props_frontend --remote_executor=""` — fails on chunk-fold; tracked separately.
- [ ] After chunk-fold fix, smoke turns green.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_