### PR TITLE
debundle: generalize readable-rename TODO + add fixture-minimization rule

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -46,6 +46,23 @@ the order is:
    bump away from regressing silently.
 3. **Then fix.** Land both the fixture and the fix in the same PR.
 
+### Fixture minimization
+
+A bug-reproducing fixture should be the **smallest** input that still
+triggers the bug. After the failure shape is reproduced, strip every
+feature that can be removed while the test still fails — extra
+bindings, extra modules, extra plan members, longer source bodies,
+realistic-flavored names. Use generic placeholder names (`a`, `b`,
+`mod_x`, `readable`) over names borrowed from the original
+upstream-corpus shape. A reader of a future regression should be
+able to point at the fixture and see what specifically triggers the
+bug, not have to mentally peel off layers of irrelevant detail.
+
+Don't add fixtures for invariants the materializer already upholds.
+If a candidate fixture passes against `origin/devel` before the fix
+is applied, it isn't testing the bug — drop it or move it into a
+separate PR documenting the invariant.
+
 If a bug genuinely cannot be reproduced synthetically (e.g. it depends
 on a specific upstream-bundle quirk that's hard to mimic), say so
 explicitly in the PR body and add coverage at the next-coarsest level

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -101,18 +101,30 @@ public-CI signal and the public-bug-report leverage.
 
 ## Propagate readable rename across consumers
 
-The disambiguation pass in `logical_modules.rs` keeps the consumer-side
-body referring to the original scrambled name (with a `$N` suffix on
-collisions). A nicer endpoint is to fold the new readable name through
-every consumer too: re-emit the import as plain `import {
-buildTaskContextPrompt }` (no alias) and rename every reference in the
-consumer body from the scrambled letter pair to
-`buildTaskContextPrompt`. That's pure readability gain across the
-whole tree once a rename lands, but it interacts with consumer
-local-scope name collisions (a consumer that already has its own
-`buildTaskContextPrompt` declaration must keep an alias) and with
-chains of re-exports. Reuse the same scope-tracking infrastructure
-the disambiguation pass already builds.
+When `define_logical_module` renames a scrambled binding `<scrambled>`
+to readable `<readable>`, the consumer-side import is currently
+emitted as `import { <readable> as <scrambled> } from "..."` and every
+reference in the consumer body still spells the original scrambled
+local. The disambiguation pass in `logical_modules.rs` only mints a
+fresh `<scrambled>$N` when the original local would collide.
+
+A nicer endpoint is to fold the new readable name through every
+consumer too: drop the alias (`import { <readable> }`) and rename
+every reference in the consumer body from `<scrambled>` to
+`<readable>`. That's pure readability gain — instead of `fp(x)` in a
+consumer's body, the body reads `<readable>(x)`.
+
+Edge cases the implementation must handle:
+
+- A consumer that already has its own top-level `<readable>` decl
+  must keep the alias (collision in the consumer's own scope).
+- Chains of re-exports (`export { <scrambled> } from "..."`) need the
+  re-export's `orig` rewritten too.
+- Locals that shadow `<readable>` inside a function body must not be
+  rewritten.
+
+Reuse the scope-tracking infrastructure the disambiguation pass
+already builds.
 
 ## RE coverage side-output
 


### PR DESCRIPTION
## Summary

Two doc updates surfaced from recent fixture-authoring work:

**`TODO.md`: generalize the "Propagate readable rename across consumers" entry.**
Drop the upstream-corpus-flavored example (`buildTaskContextPrompt`) for generic placeholders (`<scrambled>` / `<readable>`). Spell out the three edge cases the implementation must handle: consumer-local collision, re-export chains, and function-body shadows. The pattern, in short: today the consumer-side import emits as `import { <readable> as <scrambled> }` and references in the consumer body still spell the scrambled local. The future fold drops the alias and rewrites every body reference to the readable name — so a consumer reads `<readable>(x)` instead of `fp(x)`.

**`AGENTS.md`: fixture-minimization rule.**
Bug-reproducing fixtures should be the smallest input that still triggers the bug. Strip every feature that can be removed while the test still fails — extra bindings, extra modules, extra plan members, longer source bodies, realistic-flavored names. Use generic placeholder names (`a`, `b`, `mod_x`, `readable`) over names borrowed from the original upstream-corpus shape. If a candidate fixture passes against `origin/devel` before the fix is applied, it isn't testing the bug — drop it.

Surfaced from this session's investigation of a comma-list declarator-drop bug where my synthetic fixtures all passed against unfixed devel — they were testing invariants the materializer already upholds, not the actual bug. Per the new rule those fixtures get dropped (already done locally) until a real reproducing fixture is found.

## Test plan

Doc-only.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_