### PR TITLE
debundle: closure pass must not steal sibling declarators from explicit plans

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -47,5 +47,6 @@ rust_library(
         "vendor_swap_test",
         "import_collision_test",
         "scrambled_id_frequencies_test",
+        "sibling_declarator_steal_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
+++ b/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
@@ -1,0 +1,74 @@
+//! Closure-pass sibling-declarator overwrite bug.
+//!
+//! When a logical-module plan's dependency closure pulls in a binding
+//! whose declaration is part of a multi-binding `const a = 1, b = 2;`
+//! comma-list, the closure pass currently OVERWRITES the binding
+//! assignment for sibling declarators in the same comma-list — even
+//! when the siblings were explicitly claimed by another plan's spec.
+//! Result: the explicit-claim plan ends up with `export { ... }` but
+//! no declarations to back the export.
+
+use debundle_e2e_support::*;
+use serde_json::json;
+use std::fs;
+
+#[test]
+fn closure_does_not_steal_sibling_declarators_from_explicit_plan() {
+    // Comma-list `const a = 1, b = 2;` — `a` is explicitly claimed by
+    // mod_x; `b` is referenced by `c`, which mod_y owns. The closure
+    // on mod_y should pull `b` into mod_y without also claiming `a`.
+    let opts = FixtureOpts::new(
+        r#"const a = 1, b = 2;
+function c() { return b; }
+console.log(a, b);
+export { a, b, c };
+"#,
+        vec![
+            json!({
+                "id": "logical__mod_x",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_x" },
+                "members": [{
+                    "id": "m_a",
+                    "name": "readableA",
+                    "selector": { "binding": { "name": "a" } },
+                }],
+            }),
+            json!({
+                "id": "logical__mod_y",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_y" },
+                "members": [{
+                    "id": "m_c",
+                    "name": "readableC",
+                    "selector": { "binding": { "name": "c" } },
+                }],
+            }),
+        ],
+    );
+    let fixture = run_logical_modules_e2e_fixture(opts);
+
+    // mod_x must own `a`'s decl + its export.
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/mod_x.js",
+        &["readableA"],
+        &[],
+    );
+    let mod_x = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_x.js"))
+        .expect("read mod_x.js");
+    assert!(
+        mod_x.contains("readableA = 1"),
+        "mod_x.js must declare readableA = 1; got:\n{mod_x}",
+    );
+
+    // mod_y owns `c` + the closure-pulled `b`. It must NOT also have `a`.
+    let mod_y = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_y.js"))
+        .expect("read mod_y.js");
+    assert!(
+        !mod_y.contains("const a = 1") && !mod_y.contains("a = 1;"),
+        "mod_y.js must not steal `a` from mod_x; got:\n{mod_y}",
+    );
+}

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -828,9 +828,14 @@ fn expand_plan_to_transitive_dependencies(
             binding_assignment.insert(used.clone(), module_index);
             plan.bindings.insert(used.clone(), used.clone());
             if let Some(dep_decl) = declaration_by_ordinal.get(&dep_ordinal) {
+                // Sibling declarators may already be claimed by another plan's
+                // explicit spec or earlier closure. Don't steal them — split_var_decl
+                // already routes per-declarator destinations correctly.
                 for dep_name in &dep_decl.names {
-                    binding_assignment.insert(dep_name.clone(), module_index);
-                    plan.bindings.insert(dep_name.clone(), dep_name.clone());
+                    if !binding_assignment.contains_key(dep_name) {
+                        binding_assignment.insert(dep_name.clone(), module_index);
+                        plan.bindings.insert(dep_name.clone(), dep_name.clone());
+                    }
                 }
             }
             queue.push_back(dep_ordinal);


### PR DESCRIPTION
## Summary

`materialize_logical_modules`' dependency-closure pass had a sibling-declarator-stealing bug. When the closure pulled in a binding whose declaration was part of a multi-binding `const a = 1, b = 2;` comma-list, the inner sibling-claiming loop **overwrote** existing `binding_assignment` entries — even when the siblings were explicitly claimed by another plan's spec.

Result: the explicit-claim plan ended up with `export { ... }` but no declarations to back the export. In a private downstream corpus this surfaced as `Export 'X' is not defined in module` at module load time.

Minimal reproducer:
```js
const a = 1, b = 2;
function c() { return b; }
export { a, b, c };
```
Plan X claims `a` (explicit). Plan Y claims `c` (explicit); closure pulls `b` into Y. Without the fix, the closure also overwrites `a`'s assignment to Y, leaving plan X with a dangling `export { readableA }` and no decl.

## Fix

`expand_plan_to_transitive_dependencies` in `logical_modules.rs`: skip siblings that are already in `binding_assignment`. `split_var_decl` already routes per-declarator destinations correctly, so leaving the explicit assignment alone is the right call.

```rust
for dep_name in &dep_decl.names {
    if !binding_assignment.contains_key(dep_name) {
        binding_assignment.insert(dep_name.clone(), module_index);
        plan.bindings.insert(dep_name.clone(), dep_name.clone());
    }
}
```

## Test plan

- [x] New e2e fixture `sibling_declarator_steal_test.rs` with the minimal repro. **Verified the test fails on `origin/devel` without the fix** (per the bug-fix discipline).
- [x] All `//devinfra/js/debundle/...` tests pass with the fix (11/11).
- [x] **End-to-end Tana verification**: with this branch's HEAD pinned in gaffer's `MODULE.bazel`, the materialized `runtime.js` now has the previously-missing `const supportedLlmModelIds = Object.values(ae);` declaration. The `Export 'supportedLlmModelIds' is not defined in module` error at module load is gone.

## Follow-up

The Tana smoke now hits a *different* error: `Export 'React' is not defined in module` in `runtime/vendor/symbols.js`. Same surface symptom but a different root cause — the missing-named members in this case are *imported* names (not top-level decls), so they don't go through `expand_plan_to_transitive_dependencies` at all. Will file as a separate PR after investigation.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_