### PR TITLE
Work around BuildBuddy "Exhausted all peers" bug in bb remote build

### DIFF
--- a/.github/actions/bb-remote/action.yml
+++ b/.github/actions/bb-remote/action.yml
@@ -6,13 +6,34 @@
 # image itself. This action centralizes the --config=rbe flag so individual
 # workflows don't forget it (without RBE, actions run in linux-sandbox on the
 # runner VM which lacks tools like cpio).
+#
+# Two modes, mutually exclusive:
+# - `args`:   `bb remote <args> --config=rbe --config=ci ...`
+#             (e.g. args="build //..."). Triggers `bb`'s post-run
+#             `downloadOutputs` path for `build` and local `run` commands,
+#             which currently fails with "Exhausted all peers" — see
+#             devinfra/debug/bb_remote_peers_exhausted.md.
+# - `script`: `bb remote --script="<script>"`. Runs an arbitrary shell
+#             script on the runner VM. Prefer this for combined Bazel
+#             invocations and any workload that doesn't need build outputs
+#             materialized on the GHA runner. The script can reference
+#             $RBE_IMAGE (forwarded automatically) to inline
+#             `--remote_default_exec_properties=container-image=docker://$RBE_IMAGE`.
 name: bb remote
 description: Run a Bazel command via bb remote with RBE enabled
 
 inputs:
   args:
-    description: "Bazel subcommand and arguments (e.g. 'build //...' or 'run //target')"
-    required: true
+    description: "Bazel subcommand and arguments (e.g. 'build //...' or 'run //target'). Mutually exclusive with `script`."
+    required: false
+    default: ""
+  script:
+    description: >
+      Shell script to run on the BB runner instead of a single Bazel command.
+      Mutually exclusive with `args`. $RBE_IMAGE is forwarded to the runner
+      so the script can build remote-default-exec-properties dynamically.
+    required: false
+    default: ""
   env_overrides:
     description: >
       Newline-separated KEY=VALUE pairs forwarded to the runner via
@@ -44,11 +65,27 @@ runs:
   steps:
     - name: bb remote
       shell: bash
+      env:
+        INPUT_ARGS: ${{ inputs.args }}
+        INPUT_SCRIPT: ${{ inputs.script }}
+        INPUT_ENV_OVERRIDES: ${{ inputs.env_overrides }}
+        INPUT_RBE_IMAGE: ${{ inputs.rbe_image }}
+        INPUT_DISK_BYTES: ${{ inputs.disk_bytes }}
+        INPUT_COMPUTE_UNITS: ${{ inputs.compute_units }}
       run: |
+        set -euo pipefail
+
+        if [[ -n "$INPUT_ARGS" && -n "$INPUT_SCRIPT" ]]; then
+          echo "::error::bb-remote: 'args' and 'script' are mutually exclusive"; exit 1
+        fi
+        if [[ -z "$INPUT_ARGS" && -z "$INPUT_SCRIPT" ]]; then
+          echo "::error::bb-remote: one of 'args' or 'script' must be set"; exit 1
+        fi
+
         ENV_ARGS=()
         while IFS= read -r line; do
           [[ -n "$line" ]] && ENV_ARGS+=(--remote_run_header="x-buildbuddy-platform.env-overrides=$line")
-        done <<< "${{ inputs.env_overrides }}"
+        done <<< "$INPUT_ENV_OVERRIDES"
 
         # Resolve the runner + RBE executor image.
         # --container_image is a `bb remote` flag (runner VM): must come before the Bazel subcommand.
@@ -58,26 +95,41 @@ runs:
         # repo-rule resolution (pip wheel builds) runs on the custom image with system libs
         # (pkg-config, libcairo2-dev, etc.). Without this, bb remote uses BuildBuddy's
         # default image which lacks these dependencies.
-        RBE_IMAGE="${{ inputs.rbe_image }}"
+        RBE_IMAGE="$INPUT_RBE_IMAGE"
         if [[ -z "$RBE_IMAGE" ]]; then
           pin_image=$(jq -r '.rbe_worker.image' devinfra/image_pins.json)
           pin_digest=$(jq -r '.rbe_worker.digest' devinfra/image_pins.json)
           RBE_IMAGE="${pin_image}@${pin_digest}"
         fi
         BB_IMAGE_ARGS=(--container_image="docker://${RBE_IMAGE}")
-        BAZEL_IMAGE_ARGS=(--remote_default_exec_properties="container-image=docker://${RBE_IMAGE}")
 
-        bb remote \
-          --runner_exec_properties=EstimatedFreeDiskBytes=${{ inputs.disk_bytes }} \
-          --runner_exec_properties=EstimatedComputeUnits=${{ inputs.compute_units }} \
-          --runner_exec_properties=workload-isolation-type=firecracker \
-          --runner_exec_properties=init-dockerd=true \
-          --runner_exec_properties=recycle-runner=true \
-          --runner_exec_properties=remote-snapshot-save-policy=always \
-          --runner_exec_properties=snapshot-read-policy=newest \
-          "${ENV_ARGS[@]}" \
-          "${BB_IMAGE_ARGS[@]}" \
-          ${{ inputs.args }} \
-          --config=rbe \
-          --config=ci \
-          "${BAZEL_IMAGE_ARGS[@]}"
+        RUNNER_EXEC_PROPS=(
+          --runner_exec_properties=EstimatedFreeDiskBytes="$INPUT_DISK_BYTES"
+          --runner_exec_properties=EstimatedComputeUnits="$INPUT_COMPUTE_UNITS"
+          --runner_exec_properties=workload-isolation-type=firecracker
+          --runner_exec_properties=init-dockerd=true
+          --runner_exec_properties=recycle-runner=true
+          --runner_exec_properties=remote-snapshot-save-policy=always
+          --runner_exec_properties=snapshot-read-policy=newest
+        )
+
+        if [[ -n "$INPUT_SCRIPT" ]]; then
+          # Forward RBE_IMAGE so the script can interpolate it into Bazel flags.
+          ENV_ARGS+=(--remote_run_header="x-buildbuddy-platform.env-overrides=RBE_IMAGE=${RBE_IMAGE}")
+          bb remote \
+            "${RUNNER_EXEC_PROPS[@]}" \
+            "${ENV_ARGS[@]}" \
+            "${BB_IMAGE_ARGS[@]}" \
+            --script="$INPUT_SCRIPT"
+        else
+          BAZEL_IMAGE_ARGS=(--remote_default_exec_properties="container-image=docker://${RBE_IMAGE}")
+          # shellcheck disable=SC2086 # word-splitting on $INPUT_ARGS is intended
+          bb remote \
+            "${RUNNER_EXEC_PROPS[@]}" \
+            "${ENV_ARGS[@]}" \
+            "${BB_IMAGE_ARGS[@]}" \
+            $INPUT_ARGS \
+            --config=rbe \
+            --config=ci \
+            "${BAZEL_IMAGE_ARGS[@]}"
+        fi

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -46,14 +46,18 @@ jobs:
         if: github.event_name == 'pull_request'
         run: git branch "$GIT_REPO_DEFAULT_BRANCH" "origin/$GIT_REPO_DEFAULT_BRANCH"
 
-      - name: Test
+      # Combined test + build in one bb-remote `--script` invocation:
+      # - Saves one Firecracker VM allocation per CI run.
+      # - Avoids `bb remote build`'s post-run `downloadOutputs` path, which
+      #   currently fails with "Exhausted all peers" — see
+      #   devinfra/debug/bb_remote_peers_exhausted.md.
+      # `&&` matches the previous step ordering: build runs only if test passed.
+      - name: Test + Build + lint
         uses: ./.github/actions/bb-remote
         with:
-          args: test --keep_going //...
           rbe_image: ${{ inputs.rbe_image }}
-
-      - name: Build + lint
-        uses: ./.github/actions/bb-remote
-        with:
-          args: build --keep_going //...
-          rbe_image: ${{ inputs.rbe_image }}
+          script: |
+            set -euo pipefail
+            RBE_FLAGS="--config=rbe --config=ci --remote_default_exec_properties=container-image=docker://$RBE_IMAGE"
+            bazel test --keep_going $RBE_FLAGS //... && \
+              bazel build --keep_going $RBE_FLAGS //...

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,7 @@
 ## Build System
 
 - [ ] [#787](https://github.com/agentydragon/ducktape/issues/787): Fork PRs (from `agentydragon-agent`) don't receive `BUILDBUDDY_API_KEY`, so `bazel-check`/`bazel-test` are skipped on fork PRs. Fix by converting `BUILDBUDDY_API_KEY` to a repo variable (available to forks) or adding `agentydragon-agent` as a collaborator.
+- [ ] File upstream BB issue + revert `--script` workaround in `bazel-ci.yml` once fixed. See <devinfra/debug/bb_remote_peers_exhausted.md> (post-run `downloadOutputs` fails with "Exhausted all peers"). Also audit `push-images.yml` which also uses `bb remote build … --remote_download_regex=…`.
 - [ ] Migrate all Python packages to Bazel monorepo style (colocated tests, flat structure like `git_commit_ai/`)
 - [ ] Re-enable `bazel coverage` in CI once compatible with remote execution (RBE). Currently disabled because the Java-based `remote_coverage_tools` can't locate its runfiles on BuildBuddy workers, causing all tests to be marked as failed. See `bazel-test.yml`.
 - [ ] Remove `--per_file_copt=external/protobuf[+]/.*@-Wno-deprecated-declarations` from `.bazelrc` once protobuf cleans up its internal deprecated API usage (`FieldOptions::weak()`, `RepeatedPtrField(Arena*)`). These are in `external/protobuf+/src/google/protobuf/` and `compiler/cpp/`. Currently `protobuf 33.1`.

--- a/devinfra/debug/bb_remote_peers_exhausted.md
+++ b/devinfra/debug/bb_remote_peers_exhausted.md
@@ -1,0 +1,210 @@
+# `bb remote build` post-run "Exhausted all peers" — RCA + workaround
+
+**Status:** active workaround in CI; upstream BuildBuddy bug not yet filed.
+
+## Symptom
+
+`bb remote build //...` (and any other `bb remote build` / `bb remote run`)
+exits 1 immediately after the runner reports completion, with:
+
+```
+Remote run completed at 2026-05-03 00:46:52.004 UTC
+download blob: rpc error: code = FailedPrecondition desc =
+  read 66e1f2ff8901a52ba79a20ebfc3dc075a5bb8b36c61f93f8254e63393065ae00/24:
+  rpc error: code = NotFound desc = Exhausted all peers attempting to read
+  "66e1f2ff8901a52ba79a20ebfc3dc075a5bb8b36c61f93f8254e63393065ae00".
+##[error]Process completed with exit code 1.
+```
+
+The Bazel build (and tests) **succeed** on the runner — `INFO: Build completed
+successfully` appears before the failure. The crash is purely in `bb`'s
+client-side post-run download.
+
+First seen: **2026-04-30 ~10:56 UTC** on devel CI. Has been hitting almost every
+Bazel CI run since 2026-05-02. Reproducible from any session, not just CI.
+
+## Affected CI
+
+The `Build + lint` step of `.github/workflows/bazel-ci.yml`. The `Test` step
+runs `bb remote test //...` and is unaffected (see "Why" below). Sample
+failures:
+
+- Run [25266572770](https://github.com/agentydragon/ducktape/actions/runs/25266572770), job 74081984808, branch `claude/add-secret-banner-DiiPK`
+- Run [25266455677](https://github.com/agentydragon/ducktape/actions/runs/25266455677), job 74081696418, branch `claude/debundle-strip-tana`
+- Run [25265709835](https://github.com/agentydragon/ducktape/actions/runs/25265709835), job 74079772131, branch `claude/debundle-rust-use-statements`
+- Run [25265862077](https://github.com/agentydragon/ducktape/actions/runs/25265862077), job 74080175153, branch `devel`
+
+In every CI failure, the same digest is requested:
+`66e1f2ff8901a52ba79a20ebfc3dc075a5bb8b36c61f93f8254e63393065ae00/24`.
+
+## Why
+
+`bb` source [`cli/remotebazel/remotebazel.go`](https://github.com/buildbuddy-io/buildbuddy/blob/master/cli/remotebazel/remotebazel.go):
+
+```go
+if bazelCmd == "build" || (bazelCmd == "run" && !*runRemotely) {
+    fetchOutputs = true
+}
+...
+if opts.FetchOutputs && exitCode == 0 {
+    downloadOutputs(...)   // GetBlob(...) for each main output + runfiles
+}
+```
+
+`downloadOutputs` resolves output digests from the inner Bazel invocation's
+BES events (main outputs from `lookupBazelInvocationOutputs` →
+`GetInvocation`; runfiles from `RunTargetAnalyzed` events). It then calls
+`cachetools.GetBlob` for each — and that's where `download blob: …` originates.
+
+`bb remote test` doesn't set `fetchOutputs`. `bb remote --script` skips this
+path entirely. So the bug only appears when the bb CLI tries to pull build
+outputs back to the local workspace.
+
+### Why the blobs are missing
+
+The runner action is created with `DoNotCache: true` hardcoded at
+[`enterprise/server/hostedrunner/hostedrunner.go:278`](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/hostedrunner/hostedrunner.go).
+That is correct semantically — the wrapper action has unique inputs (invocation
+ID, patches, timeout) and would never hit the action cache.
+
+`DoNotCache` is supposed to disable **action result** caching only;
+content-addressed **CAS blobs** uploaded by the action should persist
+independently. But in current BuildBuddy production, every blob produced by a
+`DoNotCache` runner action becomes unreachable within ~1s of the action
+completing. Even the action's own `stderr` and `vm_log_tail.txt` blobs
+(referenced from `bb execution get`) fail with the same `Exhausted all peers`
+error. The cache-write path is uploading blobs that are not actually
+retrievable from peers.
+
+This is the upstream BuildBuddy bug. We don't have insight into PebbleCache /
+distributed cache internals.
+
+## Reproduction
+
+Any session with `BUILDBUDDY_API_KEY` set:
+
+```bash
+# Fails:
+bb remote build //devinfra:gazelle --config=rbe
+# → download blob: ... Exhausted all peers ...
+
+# Works (proves the bug is in downloadOutputs, not the runner):
+bb remote --script="bazel build //devinfra:gazelle --config=rbe"
+
+# Inspect the missing blob — same error:
+bb download <hash>/<size>
+bbapi cache metadata <hash> <size>
+```
+
+Demonstrating that even the runner's own stderr is unreachable:
+
+```bash
+bb remote --invocation_id_file=/tmp/inv.txt build //devinfra:gazelle --config=rbe
+bbapi invocation $(cat /tmp/inv.txt)              # note Child: <id>
+bbapi execution <inv-id> --json                   # find executeResponseDigest
+# pull stderr digest from the execution response
+bb download <stderr-hash>/<stderr-size>           # also "Exhausted all peers"
+```
+
+## Workaround
+
+Wrap the build command in `--script`:
+
+```bash
+bb remote --script="bazel build --config=rbe //..."
+```
+
+`--script` keeps `bb` away from `downloadOutputs`. The build still happens
+remotely and remote cache writes still occur — you just don't get the
+build outputs auto-downloaded to the local `bb-out/` tree. For CI we don't
+need the artifacts back on the GHA runner anyway (`push-images.yml` does its
+own `bb remote build … --remote_download_regex=…` and is potentially affected
+separately — see TODO below).
+
+For local `bbr` use (`bbr build //target`), users who want artifacts back can
+either (a) use `--remote_download_regex` and accept the bug for that
+invocation, or (b) `bb remote --script "bazel build //target"` then re-run
+`bazel build //target` locally — the second invocation hits the now-warm RBE
+cache and materializes outputs via Bazel's normal download path, not via
+`bb`'s broken `downloadOutputs`.
+
+## CI fix
+
+`.github/actions/bb-remote/action.yml` gained a `script` input.
+`.github/workflows/bazel-ci.yml` collapsed its two-step `Test` + `Build + lint`
+into a single `bb remote --script` invocation. Side benefit: 1 Firecracker VM
+allocation per CI run instead of 2.
+
+## Reference data (for upstream report)
+
+- Local repro invocation: `bf3aafbf-fcab-4d72-9509-57d6b4abbb68` (workflow), child `6b93e3de-51f9-4a46-98ed-a27db464ab3f`
+- Local repro execution: `bb-snapshot/uploads/79487951-4994-4eaa-9475-fc9df7adab10/blobs/blake3/4731968eedecefa557dc131e488ed915304ca474b9ed3fe5a16d0cccf5789a38/150`
+- Action mnemonic: `RemoteBazelRun`
+- Action metadata: `doNotCache: true`, `fileUploadCount: 4`, `fileUploadSizeBytes: 97472`
+- Failing CAS digests (all return `Exhausted all peers`):
+  - `71eb57bd65aa8516fcc15da1aee0cb71ca9993c92a2796b0b516c2c8f2ee2fe2/3813` (the blob `bb` wants)
+  - `8860153709b0953142f8d6f18b600cc0df32dcd8a49a966731c435384f01d090/88491` (action stderr)
+  - `a3ce63f5a76f392cc8e393fd5483ae4f700e2d7ae4107446d19a4e2c7bc30caa/8981` (vm_log_tail.txt)
+  - `af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262/0` (action stdout — empty file digest)
+
+## TODO
+
+- [ ] File upstream issue at <https://github.com/buildbuddy-io/buildbuddy/issues/new>. Draft body below.
+- [ ] Audit other `bb remote build` consumers (`.github/workflows/push-images.yml` uses `bb remote build … --remote_download_regex=…` — confirm whether it's affected and if so, switch to `--script` + a separate download step).
+- [ ] When upstream is fixed, revert the `--script` workaround in `bazel-ci.yml` and remove the `script` input from `bb-remote/action.yml`.
+
+### Draft upstream issue
+
+> **Title:** `bb remote build` post-run `downloadOutputs` fails with `Exhausted all peers` for blobs the runner just uploaded
+>
+> **Symptom**
+>
+> Every `bb remote build //target` invocation against `remote.buildbuddy.io`
+> fails after the runner reports completion:
+>
+> ```
+> Remote run completed at <ts>
+> download blob: rpc error: code = FailedPrecondition desc = read <hash>/<size>:
+>   rpc error: code = NotFound desc = Exhausted all peers attempting to read "<hash>".
+> ```
+>
+> The inner Bazel build itself succeeds — `INFO: Build completed successfully`
+> appears before the failure. `bb remote --script="bazel build …"` works
+> (skips `downloadOutputs`). `bb remote test //…` works (no `fetchOutputs`).
+>
+> **Repro**
+>
+> ```
+> bb remote build //some/target --config=rbe   # fails
+> bb remote --script="bazel build //some/target --config=rbe"   # succeeds
+> ```
+>
+> **Investigation**
+>
+> The runner action is created with `DoNotCache: true`
+> ([`hostedrunner.go:278`](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/hostedrunner/hostedrunner.go)).
+> Its execution metadata reports `fileUploadCount: 4`,
+> `fileUploadSizeBytes: 97472`, so output blobs went into CAS. But within ~1s
+> of completion, **every** referenced blob is unreachable — including action
+> stderr, `vm_log_tail.txt`, and the empty-file digest:
+>
+> ```
+> bb download 8860153709b0953142f8d6f18b600cc0df32dcd8a49a966731c435384f01d090/88491
+> # → Exhausted all peers
+> bbapi cache metadata 8860153709b0953142f8d6f18b600cc0df32dcd8a49a966731c435384f01d090 88491
+> # → Exhausted all peers
+> ```
+>
+> Hypothesis: distributed-cache (PebbleCache) writes for `DoNotCache: true`
+> action outputs are not making it to the peer set, even though the
+> `BatchUpdateBlobs` / `Write` RPCs return success during the action.
+>
+> **Reference invocations / digests** (in our org, available to BB support):
+>
+> - Workflow invocation: `bf3aafbf-fcab-4d72-9509-57d6b4abbb68`, child `6b93e3de-51f9-4a46-98ed-a27db464ab3f`
+> - Execution: `bb-snapshot/uploads/79487951-4994-4eaa-9475-fc9df7adab10/blobs/blake3/4731968eedecefa557dc131e488ed915304ca474b9ed3fe5a16d0cccf5789a38/150`
+> - Missing CAS digests: `71eb57bd…/3813`, `8860153709…/88491`, `a3ce63f5…/8981`, `af1349b9…/0`
+>
+> First seen ~2026-04-30, persists. Affects all `bb remote build` users in our
+> org; not specific to a particular target, container image, or
+> `runner_exec_properties` configuration.


### PR DESCRIPTION
## Summary

This PR documents and works around a BuildBuddy upstream bug where `bb remote build` fails with "Exhausted all peers" errors when trying to download build outputs after a successful remote execution. The workaround uses `bb remote --script` to avoid the broken `downloadOutputs` code path.

## Changes

- **devinfra/debug/bb_remote_peers_exhausted.md** (new): Comprehensive RCA document covering:
  - Symptom and reproduction steps for the "Exhausted all peers" error
  - Root cause analysis: `DoNotCache: true` runner actions produce unreachable CAS blobs
  - Why only `bb remote build` is affected (not `bb remote test` or `--script`)
  - Active workaround and reference data for upstream bug report

- **.github/actions/bb-remote/action.yml**: Enhanced to support two mutually exclusive modes:
  - `args`: Traditional Bazel subcommand (e.g., `build //...`) — triggers the broken `downloadOutputs` path
  - `script`: Shell script execution on the runner VM — avoids the bug entirely
  - Added validation to ensure exactly one of `args` or `script` is provided
  - Refactored to use environment variables for all inputs and improved quoting/escaping

- **.github/workflows/bazel-ci.yml**: 
  - Collapsed separate `Test` and `Build + lint` jobs into a single `Test + Build + lint` step using `--script`
  - Reduces Firecracker VM allocations from 2 to 1 per CI run
  - Uses inline Bazel commands with shared RBE flags instead of separate `bb remote` invocations
  - Preserves original test-before-build ordering with `&&`

## Implementation Details

The `bb-remote` action now:
- Validates mutual exclusivity of `args` and `script` inputs
- Forwards `RBE_IMAGE` to the runner environment when using `--script` so scripts can dynamically construct Bazel flags
- Maintains backward compatibility with existing `args`-based workflows
- Uses proper shell quoting and array expansion for robustness

The CI workflow change demonstrates the workaround: combining `bazel test` and `bazel build` in a single script avoids invoking `bb`'s post-run `downloadOutputs` logic twice, while still executing the build remotely with full RBE configuration.

https://claude.ai/code/session_015S8ZLmshXrwMZdGPELGCkc