### PR TITLE
Cargo.Bazel.lock: repin checksums against current rules_rust + tools

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "bf4645046f70e0f961db5f7066add4acd9a6932ca762c37530ead91c95c61741",
+  "checksum": "0e7f86e6dfb1a5e4c36bd657880aff522fd02d07efd5b8c89755fdefbf30d873",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",

--- a/third_party/activitywatch/Cargo.Bazel.lock
+++ b/third_party/activitywatch/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3a0d2a20f9d154cc034162e48b9e7f863753c1e1f7b821c4fb2134737dcca2fa",
+  "checksum": "8c954b4bc3439e94abb4e34c819f2e8b406d7693feb5645efbfe16aa2535a7cf",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

Repins the digest fields at the head of both `Cargo.Bazel.lock` files
against the current rules_rust 0.69.0 + cargo/rustc tool versions.
The crate metadata is byte-identical; only line 2's checksum field
changes in each file.

- `Cargo.Bazel.lock` (`crates`): `bf4645…` → `0e7f86…`
- `third_party/activitywatch/Cargo.Bazel.lock` (`aw_server_crates`):
  `3a0d2a20…` → `8c954b4b…`

## Why

Surfaced when consuming this branch from gaffer-private as an
`archive_override`: the freshly-computed digest from the rules_rust
crate_universe extension's `query` subcommand differed from what the
lockfiles record, causing analysis to fail with

```
Error: Digests do not match:
  Current  Digest("bf4645046f70…")
  Expected Digest("0e7f86e6dfb1…")
The current `lockfile` is out of date for 'crates'.
```

…and the same shape for `aw_server_crates`. Repinning ducktape's own
crates lockfiles fixes the downstream consumer without changing any
actual dependency resolution.

## Test plan

- [x] `bazelisk build //tana/re/web/transforms:debundle_78d928dca7` in
      gaffer-private (with the matching pin bump in
      `agentydragon/gaffer-private#$claude/restructure-tana-modules-86jQc`)
      passes without `CARGO_BAZEL_REPIN=true` — clean 6-stage debundle
      pipeline run in 15.3s, full build 212s / 933 actions.
- [x] `bazelisk test //tana/re/web/transforms:generate_transform_spec_test`
      passes.

https://claude.ai/code/session_01382gXVcqreESnGFw3MGgxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01382gXVcqreESnGFw3MGgxq)_