### PR TITLE
debundle: split comma-list var-decls before fact analysis

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -10,36 +10,6 @@ including the `BindingKind::Imported` collapse that closes out
 the parallel `import_members` channel. The items in this file
 are smaller, mostly-orthogonal cleanups.
 
-## Comma-list owner attribution in `build_module_dep_graph`
-
-`build_module_dep_graph` (in `schedule_validator.rs`) computes
-`stmt_owner` once per `StatementFacts`, taking the owner of the
-first declared name. The emit-time pipeline splits comma-list
-`var/let/const` declarations into per-declarator statements
-(`split_var_decl` in `logical_modules.rs:1512`), so a chunk like
-`const a = 1, b = c, d = e;` with `a → mod_x`, `b → mod_y`, `d
-→ mod_z` lands `b` and `d` in different modules than `a`.
-
-The validator never sees that split — it builds edges as if the
-whole comma-list lived with `a`'s owner. Reads from `b`'s and
-`d`'s initializers (e.g. `c`, `e`) are attributed to mod_x's
-home, even though `b` and `d` actually emit into mod_y and
-mod_z. SCC detection can therefore miss real cross-module
-cycles or invent fake ones.
-
-Fix shape: split comma-list var-decls _before_ `analyze_chunk_facts`
-so each declarator has its own `StatementFacts` row with one
-declared name. This requires either:
-
-1. running the splitter on the chunk's `Module` ahead of fact
-   analysis (preferred — the emitter then operates on already-
-   split body), or
-2. teaching `StatementFacts` and `stmt_owner` about per-declarator
-   owners (more invasive).
-
-Surfaced as Copilot review comment on PR #1478:
-<https://github.com/agentydragon/ducktape/pull/1478#discussion_r3178610097>.
-
 ## `source_chunk_imports_for_moved_body` skip filter is too broad
 
 In `logical_modules.rs` (~line 1805), the skip

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -57,5 +57,6 @@ rust_library(
         "multi_module_re_export_test",
         "lazy_back_edge_cycle_test",
         "side_effect_ordering_test",
+        "comma_list_split_owners_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/comma_list_split_owners_test.rs
+++ b/devinfra/js/debundle/e2e/comma_list_split_owners_test.rs
@@ -1,0 +1,94 @@
+//! Per-declarator owner attribution for comma-list var-decls.
+//!
+//! Pre-fix, `build_module_dep_graph` computed `stmt_owner` once
+//! per `StatementFacts` by picking the first declared name's
+//! owner. The emitter's `split_var_decl` splits comma-lists per
+//! declarator at lower-time, so a chunk like
+//! `const A = 1, B = X;` with `A → mod_x` and `B → mod_y` would
+//! attribute `B`'s reads to `mod_x`'s home in the validator,
+//! even though `B` actually emits into `mod_y`. The two
+//! observable failures: invented cycles (validator rejects a
+//! realisable spec) and missed cycles (validator accepts an
+//! unrealisable spec). The pre-analysis split in
+//! `analyze_chunk_facts` aligns the validator's view with the
+//! emitter's per-declarator placement.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn comma_list_split_does_not_invent_cross_module_cycle() {
+    // `a_in_x` is in mod_x; `B = X` is in mod_y reading mod_y's
+    // own X (no edge). `Y = a_in_x` is in mod_y reading mod_x's
+    // a_in_x (R-edge mod_y → mod_x). Pre-fix, `stmt_owner`
+    // picked A's owner (mod_x) for the whole comma-list and
+    // attributed B's read of X to mod_x → spurious R-edge
+    // mod_x → mod_y, plus the real mod_y → mod_x edge → cycle.
+    // Validator rejected. Post-fix, B's row owns just B and
+    // reads X within its own module (no cross-module edge), so
+    // only mod_y → mod_x remains. Spec realises and runs.
+    let fixture = run_logical_modules_e2e_fixture(FixtureOpts::new(
+        r#"const a_in_x = "x";
+const X = 42;
+const A = 1, B = X;
+const Y = a_in_x;
+console.log(A, B, X, Y);
+export { A, B, X, Y, a_in_x };
+"#,
+        vec![
+            logical_module("mod_x", &[Member::new("A"), Member::new("a_in_x")]),
+            logical_module(
+                "mod_y",
+                &[Member::new("B"), Member::new("X"), Member::new("Y")],
+            ),
+        ],
+    ));
+    // Original chunk evaluates left-to-right: a_in_x="x", X=42,
+    // A=1, B=42, Y="x" → log "1 42 42 x". Post-fix emit
+    // preserves it (mod_x evaluates first; mod_y reads a_in_x
+    // already initialised).
+    assert_entry_output(&fixture, "1 42 42 x\n");
+}
+
+#[test]
+fn comma_list_split_surfaces_missed_cross_module_cycle() {
+    // Mirror of the previous fixture: now `B`'s read crosses
+    // modules instead of staying within mod_y. `a_in_x` is in
+    // mod_x; `B = a_in_x` is in mod_y reading mod_x → R-edge
+    // mod_y → mod_x. `fromB = B` is in mod_x reading mod_y →
+    // R-edge mod_x → mod_y. Cycle.
+    //
+    // Pre-fix: `stmt_owner` picks A's owner (mod_x) for the
+    // whole `const A = 1, B = a_in_x;` line. The read of
+    // `a_in_x` is attributed to mod_x → owner(a_in_x) = mod_x.
+    // Same module, no edge. The mod_y → mod_x edge is missed.
+    // Only `fromB` reads B → mod_x → mod_y. No cycle. Validator
+    // accepts a spec that TDZs at runtime.
+    //
+    // Post-fix: B's row owns just B and is in mod_y, so reads
+    // of `a_in_x` correctly attribute to mod_y. Both edges
+    // present, validator rejects.
+    expect_logical_modules_e2e_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const a_in_x = "x";
+const A = 1, B = a_in_x;
+const fromB = B;
+console.log(A, B, fromB);
+export { A, B, fromB, a_in_x };
+"#,
+            vec![
+                logical_module(
+                    "mod_x",
+                    &[
+                        Member::new("A"),
+                        Member::new("a_in_x"),
+                        Member::new("fromB"),
+                    ],
+                ),
+                logical_module("mod_y", &[Member::new("B")]),
+            ],
+        ),
+        // The cycle report must name both modules so the spec
+        // author knows which split to fix.
+        &["cycle", "mod_x", "mod_y"],
+    );
+}

--- a/devinfra/js/debundle/schedule_validator.rs
+++ b/devinfra/js/debundle/schedule_validator.rs
@@ -235,13 +235,69 @@ pub enum StatementKind {
 
 /// Walk the chunk's module body and produce one `StatementFacts`
 /// entry per top-level statement, in source order.
+///
+/// Multi-declarator `var/let/const` statements are split into
+/// per-declarator entries before analysis, so each row declares
+/// a single name and `stmt_owner` (in `build_module_dep_graph`)
+/// returns an unambiguous owner. Without the split, a chunk like
+/// `const A = 1, B = readsX;` with `{A → mod_a, B → mod_b}`
+/// would attribute `B`'s read of `X` to `mod_a` (the first
+/// declared name's owner), inventing or hiding cycles. The
+/// emitter splits the same comma-lists separately at lower-time
+/// (`split_var_decl` in `logical_modules.rs`); this pre-split
+/// just teaches the analyzer the same view.
 pub fn analyze_chunk_facts(module: &Module) -> Vec<StatementFacts> {
-    module
-        .body
-        .iter()
+    let body = split_comma_list_var_decls(&module.body);
+    body.iter()
         .enumerate()
         .map(|(ordinal, item)| analyze_item(StatementOrdinal(ordinal), item))
         .collect()
+}
+
+/// Replace every multi-declarator top-level `var/let/const`
+/// (including the form nested in an `export` decl) with N
+/// single-declarator statements preserving source order. Other
+/// statement kinds pass through unchanged.
+fn split_comma_list_var_decls(body: &[ModuleItem]) -> Vec<ModuleItem> {
+    let mut out = Vec::with_capacity(body.len());
+    for item in body {
+        match item {
+            ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) if var.decls.len() > 1 => {
+                for decl in &var.decls {
+                    let single = VarDecl {
+                        span: var.span,
+                        ctxt: var.ctxt,
+                        kind: var.kind,
+                        declare: var.declare,
+                        decls: vec![decl.clone()],
+                    };
+                    out.push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(single)))));
+                }
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
+                match &export_decl.decl {
+                    Decl::Var(var) if var.decls.len() > 1 => {
+                        for decl in &var.decls {
+                            let single = VarDecl {
+                                span: var.span,
+                                ctxt: var.ctxt,
+                                kind: var.kind,
+                                declare: var.declare,
+                                decls: vec![decl.clone()],
+                            };
+                            out.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                                span: export_decl.span,
+                                decl: Decl::Var(Box::new(single)),
+                            })));
+                        }
+                    }
+                    _ => out.push(item.clone()),
+                }
+            }
+            _ => out.push(item.clone()),
+        }
+    }
+    out
 }
 
 fn analyze_item(ordinal: StatementOrdinal, item: &ModuleItem) -> StatementFacts {
@@ -1558,13 +1614,168 @@ mod tests {
 
     #[test]
     fn multi_declarator_var_decl_is_side_effecting_if_any_init_is() {
+        // After the comma-list pre-split, a multi-declarator
+        // var-decl becomes one row per declarator. So a
+        // mixed-purity comma-list produces both a Pure row and
+        // an Impure row, not a single conservative row.
         assert_eq!(
             has_side_effect_for("const A = 1, B = compute();"),
-            vec![true]
+            vec![false, true]
         );
         assert_eq!(
             has_side_effect_for("const A = 1, B = 2, C = 3;"),
-            vec![false]
+            vec![false, false, false]
+        );
+    }
+
+    // --- Comma-list splitter -------------------------------------------------
+
+    fn statement_kinds(source: &str) -> Vec<StatementKind> {
+        let module = parse(source);
+        analyze_chunk_facts(&module)
+            .into_iter()
+            .map(|f| f.kind)
+            .collect()
+    }
+
+    fn declared_per_statement(source: &str) -> Vec<Vec<String>> {
+        let module = parse(source);
+        analyze_chunk_facts(&module)
+            .into_iter()
+            .map(|f| f.declared.into_iter().collect::<Vec<_>>())
+            .collect()
+    }
+
+    #[test]
+    fn split_two_declarator_const() {
+        assert_eq!(
+            statement_kinds("const A = 1, B = 2;"),
+            vec![StatementKind::VarDecl, StatementKind::VarDecl]
+        );
+        assert_eq!(
+            declared_per_statement("const A = 1, B = 2;"),
+            vec![vec!["A".to_string()], vec!["B".to_string()]]
+        );
+    }
+
+    #[test]
+    fn split_three_declarator_let() {
+        assert_eq!(
+            declared_per_statement("let A = 1, B = 2, C = 3;"),
+            vec![
+                vec!["A".to_string()],
+                vec!["B".to_string()],
+                vec!["C".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn split_export_const_with_comma_list() {
+        // `export const A = 1, B = 2;` splits into two ExportDecls,
+        // each declaring one name. Kind stays VarDecl (per
+        // classify_item, ExportDecl-of-Var classifies as VarDecl).
+        assert_eq!(
+            statement_kinds("export const A = 1, B = 2;"),
+            vec![StatementKind::VarDecl, StatementKind::VarDecl]
+        );
+        assert_eq!(
+            declared_per_statement("export const A = 1, B = 2;"),
+            vec![vec!["A".to_string()], vec!["B".to_string()]]
+        );
+    }
+
+    #[test]
+    fn single_declarator_var_decl_is_unchanged() {
+        assert_eq!(statement_kinds("var A;"), vec![StatementKind::VarDecl]);
+        assert_eq!(
+            declared_per_statement("var A;"),
+            vec![vec!["A".to_string()]]
+        );
+    }
+
+    #[test]
+    fn non_var_decl_statements_are_not_split() {
+        // function / class declarations have no comma-list shape.
+        // Mixed source: const + function + class + bare expression.
+        assert_eq!(
+            statement_kinds("const A = 1; function f() {} class C {} 'side-effecting-string';"),
+            vec![
+                StatementKind::VarDecl,
+                StatementKind::FnDecl,
+                StatementKind::ClassDecl,
+                StatementKind::SideEffect,
+            ]
+        );
+    }
+
+    // --- Comma-list owner attribution in build_module_dep_graph -------------
+
+    #[test]
+    fn split_comma_list_attributes_reads_per_declarator() {
+        // `const A = 1, B = X;` — A → mod_0, B → mod_1, X → mod_1.
+        // Pre-split, `stmt_owner` would pick A's owner (mod_0)
+        // for the whole comma-list and attribute `B`'s read of X
+        // to mod_0, creating an R-edge mod_0 → mod_1 even though
+        // the actual emitted module for B is mod_1. Post-split,
+        // each declarator is its own statement: A's row owns
+        // nothing readwise (literal init), B's row owns the read
+        // of X but its home is mod_1 — so no edge (B reads X
+        // within its own module).
+        let schedule = schedule_for(
+            "const A = 1, B = X; const X = 42;",
+            &[("A", logical(0)), ("B", logical(1)), ("X", logical(1))],
+        );
+        let edges = &schedule.dep_graph.edges;
+        // No cross-module read edges should exist: A's init is
+        // pure, B reads X (same module).
+        let mod_0 = ModuleId::Logical(LogicalModuleIndex(0));
+        let mod_1 = ModuleId::Logical(LogicalModuleIndex(1));
+        assert!(
+            edges
+                .get(&mod_0)
+                .is_none_or(|targets| !targets.contains(&mod_1)),
+            "no edge mod_0 → mod_1 expected, got: {:?}",
+            edges.get(&mod_0),
+        );
+        assert!(
+            edges
+                .get(&mod_1)
+                .is_none_or(|targets| !targets.contains(&mod_0)),
+            "no edge mod_1 → mod_0 expected, got: {:?}",
+            edges.get(&mod_1),
+        );
+    }
+
+    #[test]
+    fn split_comma_list_surfaces_real_cross_declarator_cycle() {
+        // `const A = X, B = 1;` — A → mod_a, B → mod_b, X → mod_b.
+        // mod_a's `A` reads X from mod_b → R-edge mod_a → mod_b.
+        // Now also `const Y = A;` in mod_b reads A from mod_a:
+        // → R-edge mod_b → mod_a. Cycle.
+        //
+        // Pre-split, the comma-list `const A = X, B = 1;` would
+        // attribute the read of X to mod_a (A is declared first,
+        // owner mod_a). So the edge is mod_a → mod_b. mod_b's
+        // `Y = A` adds mod_b → mod_a. Cycle detected (correctly,
+        // by accident). Post-split, A's row attributes the read
+        // to mod_a, B's row to mod_b — same edges, same cycle.
+        // This case demonstrates the split doesn't *miss* real
+        // cycles either: the bug bit when multiple declarators
+        // had differently-owned reads on the same line.
+        let schedule = schedule_for(
+            "const A = X, B = 1; const X = 42; const Y = A;",
+            &[
+                ("A", logical(0)),
+                ("B", logical(1)),
+                ("X", logical(1)),
+                ("Y", logical(1)),
+            ],
+        );
+        let report = schedule.validate();
+        assert!(
+            !report.cycles.is_empty(),
+            "expected a real cycle to be reported"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes the comma-list owner-attribution bug Copilot flagged on
#1478 (filed in `devinfra/js/debundle/TODO.md`).

`build_module_dep_graph` computed `stmt_owner` once per
`StatementFacts` by picking the first declared name's owner.
The emitter (`split_var_decl` in `logical_modules.rs`) splits
comma-list `var/let/const` per declarator at lower-time, so a
chunk like `const A = 1, B = X;` with `{A → mod_x, B → mod_y}`
attributed `B`'s reads to `mod_x` in the validator even though
the emit places `B` in `mod_y`. Two failure modes:

- **Invented cycles** — pre-fix attributes `B`'s read to mod_x.
  If anything in mod_y reads from mod_x, the validator sees a
  spurious mod_x → mod_y edge plus the real mod_y → mod_x edge
  → cycle. Validator rejects a realisable spec.
- **Missed cycles** — pre-fix misattributes `B`'s read so the
  real mod_y → mod_x edge isn't recorded. The cycle in the
  emitted bundle goes undetected; the bundle TDZs at runtime.

## What changes

- `split_comma_list_var_decls(&[ModuleItem]) -> Vec<...>` walks
  the body and replaces every multi-declarator `var/let/const`
  (including the form nested in an `ExportDecl`) with N
  single-declarator statements preserving source order.
- `analyze_chunk_facts` runs over the split body, so each row
  declares one name and `stmt_owner` returns an unambiguous
  owner.
- The emitter is unchanged. Its emit-time `split_var_decl`
  continues to split comma-lists per declarator. The
  validator's view (split) and the emitter's per-declarator
  placement now agree on edge attribution.

## Tests

- Splitter unit tests: 2/3-declarator const/let, exported
  comma-list, single-declarator passthrough, mixed body with
  non-VarDecl statements.
- Dep-graph unit tests: split keeps cross-module edges accurate
  (no spurious edges from a same-module comma-list; real
  cross-module cycles still surface).
- New e2e `comma_list_split_owners_test`:
  - `comma_list_split_does_not_invent_cross_module_cycle` —
    invented-cycle scenario; pre-fix would have rejected,
    post-fix runs to completion
    (`assert_entry_output("1 42 42 x")`).
  - `comma_list_split_surfaces_missed_cross_module_cycle` —
    missed-cycle scenario; pre-fix would have accepted (and
    TDZ'd at runtime), post-fix rejects with cycle evidence
    naming both modules.

All 22 `//devinfra/js/debundle/...` tests pass on RBE.

## TODO.md

Dropped the resolved entry.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_