### PR TITLE
debundle: narrow source_chunk_imports skip filter to Owned bindings

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -10,28 +10,57 @@ including the `BindingKind::Imported` collapse that closes out
 the parallel `import_members` channel. The items in this file
 are smaller, mostly-orthogonal cleanups.
 
-## `source_chunk_imports_for_moved_body` skip filter is too broad
+## Top-level-await hard rejection
 
-In `logical_modules.rs` (~line 1805), the skip
-`if schedule.bindings.contains_key(&name) { continue; }` rules
-out every name in `Schedule.bindings` — including
-`BindingKind::Imported` entries that may be re-exported by some
-_other_ logical module. If moved code in the current module
-references such an imported local, this filter skips it (no
-source-chunk re-import gets emitted) and
-`cross_module_imports_for_body` won't import it either
-(`Schedule::owner_of` returns `None` for `Imported`). Result:
-free variable in the emitted module → `ReferenceError` at
-runtime.
+DESIGN.md assumption A2 ("no top-level `await` in any emitted
+module") is documented as an _input-shape assumption_, not an
+enforced check. `program_analysis.rs` marks `AwaitExpr` as
+runtime-sensitive during shallow analysis, but
+`materialize_logical_modules` doesn't refuse the chunk when it
+appears at module-top.
 
-Fix: narrow the skip to bindings actually provided via cross-
-module imports — e.g. `schedule.owner_of(name).is_some()` (the
-`Owned` case) — or skip only when the current module has
-already inserted an import for that `Imported` binding.
+Fix: scan `Module.body` for top-level `AwaitExpr` (not inside
+any `Function` / `ArrowExpr` / `MethodProp` / etc.) before fact
+analysis runs; `bail!` with a clear message naming the offending
+statement ordinal. Aligns the implementation with the proof's
+A2 guarantee.
 
-Surfaced as Copilot review comment on PR #1477:
-<https://github.com/agentydragon/ducktape/pull/1477#discussion_r3178520375>.
-Orthogonal to Phase 5 (#1478); separate small PR.
+## Pure-call whitelist in `classify_expr_purity`
+
+The S analyzer's purity classifier (`schedule_validator.rs`)
+treats `Call`, `New`, `TaggedTpl`, `Member`, `OptChain`, etc.
+as `Unknown` (treated as Impure). For built-ins that are
+demonstrably pure — `Math.X` reads, `Object.freeze`,
+`Object.assign({}, ...)`, `Symbol(...)`, `Object.keys`,
+`Array.isArray`, … — flagging Pure would tighten S-edge
+precision and reduce spurious cycle-rejections on chunks heavy
+in those calls.
+
+Implementation shape: a small allowlist consulted by
+`classify_expr_purity` for `Expr::Call` / `Expr::New` /
+`Expr::Member` whose receiver is a known global. Conservative
+on shadowing — only fire when the receiver Ident isn't bound
+by anything in `Schedule.bindings` or as a function/local in
+scope. Tracked as a follow-up to the precise-purity classifier
+that landed with the S-edge work (PR #1478 + S analyzer); not
+pressing until a real spec exposes a spurious S cycle from
+this gap.
+
+## Surface `Schedule.linker_order` in `<chunk_id>.schedule.json`
+
+`Schedule.linker_order` (the topological linearization of
+`I ∪ S` used to steer ECMA-262's depth-first link traversal,
+per Lemma 2 in DESIGN.md) is computed at schedule-build time
+but isn't exposed in the emitted `<chunk_id>.schedule.json`
+alongside cycle reports and recommendations. Adding it would
+make the emitter's import ordering verifiable from the
+artifact and useful for debug-tooling that wants to see the
+linker's evaluation order without re-running materialization.
+
+Shape: extend `ScheduleReport` with a
+`linker_order: Vec<String>` (module names in evaluation
+order). Empty when the dep graph has cycles (validation rejects
+anyway). No consumer change required.
 
 ## Excalidraw live-browser smoke
 

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -382,3 +382,69 @@ export { bridge };
         "mod_x.js body must still reference `gge.decode`; got:\n{mod_x}",
     );
 }
+
+#[test]
+fn moved_body_re_imports_specifier_re_exported_by_another_plan() {
+    // mod_a re-exports a vendor binding (`a` → public `Re`),
+    // making it `BindingKind::Imported` in `Schedule.bindings`.
+    // mod_b moves a body that references the same local `a`.
+    // The source-chunk re-import filter must NOT skip `a` just
+    // because it's in `Schedule.bindings` — `cross_module_imports_for_body`
+    // can't satisfy it (Imported bindings have `owner_of() == None`),
+    // so without the source-chunk re-import mod_b has a free
+    // variable and `ReferenceError: a is not defined` at runtime.
+    //
+    // The source chunk lives at `static/app/`; place vendor.js
+    // there too so the entry's `./vendor.js` resolves (and
+    // mod_b's emitted re-import resolves through the same
+    // chunk-relative path rewrite).
+    let mut opts = FixtureOpts::new(
+        r#"import { x as a } from "./vendor.js";
+function bridge() {
+  return a;
+}
+console.log(bridge());
+export { bridge };
+"#,
+        vec![
+            json!({
+                "id": "logical__mod_a",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_a" },
+                "members": [{
+                    "id": "m_re",
+                    "name": "Re",
+                    "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
+                }],
+            }),
+            json!({
+                "id": "logical__mod_b",
+                "operation": "define_logical_module",
+                "selector": { "chunkId": "static/app" },
+                "target": { "path": "mod_b" },
+                "members": [{
+                    "id": "m_bridge",
+                    "name": "bridge",
+                    "selector": { "binding": { "name": "bridge" } },
+                }],
+            }),
+        ],
+    );
+    opts.extra_files = &[("static/app/vendor.js", "export const x = 42;\n")];
+    let fixture = run_logical_modules_e2e_fixture(opts);
+
+    let mod_b = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_b.js"))
+        .expect("read mod_b.js");
+    // mod_b's bridge body references `a`; mod_b must carry a
+    // source-chunk re-import for `a` (the vendor binding) so the
+    // moved body resolves at link time.
+    assert!(
+        mod_b.contains("import") && mod_b.contains("vendor"),
+        "mod_b.js must re-import the vendor specifier; got:\n{mod_b}",
+    );
+    // Behaviour preservation: `bridge()` returns the imported
+    // vendor value. Without the filter narrowing this would
+    // `ReferenceError` at module-load time.
+    assert_entry_output(&fixture, "42\n");
+}

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1835,8 +1835,12 @@ fn source_chunk_imports_for_moved_body(
             if already_imported.contains(&name) {
                 continue;
             }
-            if schedule.bindings.contains_key(&name) {
-                // Provided by another plan via cross_module_imports.
+            if schedule.owner_of(&name).is_some() {
+                // Owned by some logical module — `cross_module_imports_for_body`
+                // emits a cross-module import for it. (Imported bindings have
+                // `owner_of(...) == None`; they fall through to the
+                // source-chunk re-import below since no plan can satisfy the
+                // moved code's reference cross-module.)
                 continue;
             }
             if let Some(info) = runtime_imports.get(&name) {


### PR DESCRIPTION
## Summary

Closes the last open Copilot review item from PR #1477.

`source_chunk_imports_for_moved_body` skipped any name in
`schedule.bindings` on the assumption that "another plan provides
it via `cross_module_imports`." That over-skipped:
`BindingKind::Imported` entries (re-exported by some _other_
logical module) have `Schedule::owner_of(...) == None`, so
`cross_module_imports_for_body` doesn't satisfy them either.
Result: free variable in the moved body and `ReferenceError` at
module-load time.

## Fix

Narrow the skip to `schedule.owner_of(name).is_some()` — the
`Owned` case `cross_module_imports_for_body` actually handles.
Imported bindings now fall through to the source-chunk re-import
path, which finds the original `import { ... } from "<source>"`
directive in the chunk body and emits a re-import in the moved
body's destination module.

## Test

New `moved_body_re_imports_specifier_re_exported_by_another_plan`
in `cross_module_emission_test.rs`:

- mod_a re-exports a vendor binding (`a` → public `Re`), making it
  `BindingKind::Imported`.
- mod_b moves a `bridge` body that references the same local `a`.
- Pre-fix: validator accepts the spec but mod_b emits no
  source-chunk re-import for `a` → `ReferenceError` at module
  load.
- Post-fix: mod_b carries `import { x as a } from "<source>"`,
  `bridge()` returns 42, entry stdout is `42\n`.

The runtime check (`assert_entry_output`) catches the
`ReferenceError` directly — placed `vendor.js` next to the entry
chunk so the path resolves.

## TODO.md cleanup

Dropped the resolved entry; queued three deferred follow-ups
that surfaced during the broader session:

- **Top-level-await hard rejection** in
  `materialize_logical_modules` (concrete A2 enforcement; A2 is
  documented as an assumption but not enforced today).
- **Pure-call whitelist** in `classify_expr_purity` — `Math.PI`,
  `Object.freeze`, `Symbol(...)`, etc. — to tighten S-edge
  precision.
- **Surface `Schedule.linker_order` in `<chunk_id>.schedule.json`**
  so the emitter's import ordering is verifiable from the
  artifact.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — all 14 test targets
      pass on RBE.
- [x] New e2e fixture passes with `assert_entry_output("42\n")`.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_