### PR TITLE
Cargo.Bazel.lock: repin checksums against current crate_universe metadata

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0e7f86e6dfb1a5e4c36bd657880aff522fd02d07efd5b8c89755fdefbf30d873",
+  "checksum": "bf4645046f70e0f961db5f7066add4acd9a6932ca762c37530ead91c95c61741",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",

--- a/third_party/activitywatch/Cargo.Bazel.lock
+++ b/third_party/activitywatch/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8c954b4bc3439e94abb4e34c819f2e8b406d7693feb5645efbfe16aa2535a7cf",
+  "checksum": "3a0d2a20f9d154cc034162e48b9e7f863753c1e1f7b821c4fb2134737dcca2fa",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

Both `Cargo.Bazel.lock` files at the repo carried stale
`crate_universe` checksums after the latest `rules_rust` /
cargo metadata roll. RBE builds were failing with

```
Error: Digests do not match: Current Digest("0e7f86e6...") != Expected Digest("bf4645...")
```

from the `crate_universe` extension. Sessions had been working
around it with `--repo_env=CARGO_BAZEL_REPIN=true` on every
`bbr` invocation, which only fixes the repin transiently —
the on-disk checksum stays stale.

## Fix

Regenerated locally per <README.md>:

```bash
CARGO_BAZEL_REPIN=1 bb build --remote_executor="" @crates//:all
```

Both lockfiles get a single-line checksum bump; no crate-set
or version changes. Diff:

```
 Cargo.Bazel.lock                           | 2 +-
 third_party/activitywatch/Cargo.Bazel.lock | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## Test plan

- [x] `bbr build //devinfra/js/debundle:schedule_validator`
      completes clean without `--repo_env=CARGO_BAZEL_REPIN=true`.
- [ ] Once CI runs on the PR: confirm `bazel-ci / Test & Build`
      passes without the repin flag (the bbr workflow's
      `bazel_args` won't carry it).

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_