### PR TITLE
debundle: surface Schedule.linker_order in &lt;chunk_id&gt;.schedule.json

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -116,6 +116,7 @@ rust_test(
     crate = ":schedule_validator",
     edition = "2024",
     deps = [
+        "@crates//:serde_json",
         "@crates//:swc_common",
         "@crates//:swc_ecma_parser",
     ],

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -46,22 +46,6 @@ that landed with the S-edge work (PR #1478 + S analyzer); not
 pressing until a real spec exposes a spurious S cycle from
 this gap.
 
-## Surface `Schedule.linker_order` in `<chunk_id>.schedule.json`
-
-`Schedule.linker_order` (the topological linearization of
-`I ∪ S` used to steer ECMA-262's depth-first link traversal,
-per Lemma 2 in DESIGN.md) is computed at schedule-build time
-but isn't exposed in the emitted `<chunk_id>.schedule.json`
-alongside cycle reports and recommendations. Adding it would
-make the emitter's import ordering verifiable from the
-artifact and useful for debug-tooling that wants to see the
-linker's evaluation order without re-running materialization.
-
-Shape: extend `ScheduleReport` with a
-`linker_order: Vec<String>` (module names in evaluation
-order). Empty when the dep graph has cycles (validation rejects
-anyway). No consumer change required.
-
 ## Excalidraw live-browser smoke
 
 Build an open-source live-browser smoke test for the debundler against

--- a/devinfra/js/debundle/schedule_validator.rs
+++ b/devinfra/js/debundle/schedule_validator.rs
@@ -195,6 +195,11 @@ impl Schedule {
     pub fn validate(&self) -> ScheduleReport {
         let mut report = validate_schedule(&self.dep_graph, &|id| self.module_name(id));
         report.recommendations = build_recommendations(self);
+        report.linker_order = self
+            .linker_order
+            .iter()
+            .map(|id| self.module_name(*id))
+            .collect();
         report
     }
 }
@@ -948,6 +953,13 @@ pub struct ScheduleReport {
     /// referenced by at least one logical module. Spec authors
     /// resolve each entry by copying a chosen owner into the spec.
     pub recommendations: Vec<AssignmentRecommendation>,
+    /// Topological linearization of `I ∪ S` rooted at the entry,
+    /// dependency-first. Empty when the dep graph has cycles
+    /// (validation rejects). Captured here so debug tooling can
+    /// see the linker's evaluation order without re-running
+    /// materialization. See DESIGN.md "Lemma 2".
+    #[serde(rename = "linkerOrder")]
+    pub linker_order: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1041,6 +1053,7 @@ pub fn validate_schedule(
         kind: "js.schedule_validator_report",
         cycles,
         recommendations: Vec::new(),
+        linker_order: Vec::new(),
     }
 }
 
@@ -1776,6 +1789,60 @@ mod tests {
         assert!(
             !report.cycles.is_empty(),
             "expected a real cycle to be reported"
+        );
+    }
+
+    // --- linker_order in ScheduleReport --------------------------------------
+
+    #[test]
+    fn validate_surfaces_linker_order_for_acyclic_spec() {
+        // mod_0 reads B from mod_1 at-init → mod_1 must precede
+        // mod_0 in the linker's evaluation order.
+        let schedule = schedule_for(
+            "const A = B + 1; const B = 42;",
+            &[("A", logical(0)), ("B", logical(1))],
+        );
+        let report = schedule.validate();
+        let order = &report.linker_order;
+        let pos = |name: &str| -> usize {
+            order
+                .iter()
+                .position(|m| m == name)
+                .unwrap_or_else(|| panic!("module {name} not in {order:?}"))
+        };
+        assert!(
+            pos("mod_1") < pos("mod_0"),
+            "mod_1 must precede mod_0 in linker_order; got {order:?}",
+        );
+    }
+
+    #[test]
+    fn validate_returns_empty_linker_order_for_cyclic_spec() {
+        // mod_0 reads B (mod_1); mod_1 reads A (mod_0). Cycle.
+        let schedule = schedule_for(
+            "const A = B + 1; const B = A + 1;",
+            &[("A", logical(0)), ("B", logical(1))],
+        );
+        let report = schedule.validate();
+        assert!(!report.cycles.is_empty(), "expected a cycle in {report:?}",);
+        assert!(
+            report.linker_order.is_empty(),
+            "linker_order must be empty when the dep graph is cyclic; got {:?}",
+            report.linker_order,
+        );
+    }
+
+    #[test]
+    fn schedule_report_serializes_linker_order_as_camel_case() {
+        let schedule = schedule_for(
+            "const A = 1; const B = A + 1;",
+            &[("A", logical(0)), ("B", logical(1))],
+        );
+        let report = schedule.validate();
+        let json = serde_json::to_string(&report).expect("serialize ScheduleReport");
+        assert!(
+            json.contains(r#""linkerOrder""#),
+            "ScheduleReport must serialize linker_order as `linkerOrder`; got: {json}",
         );
     }
 }


### PR DESCRIPTION
## Summary

`Schedule.linker_order` (the topological linearization of `I ∪ S`
used to steer ECMA-262's depth-first link traversal — see
DESIGN.md "Lemma 2") is computed at schedule-build time but
wasn't exposed in the emitted `<chunk_id>.schedule.json`. Adding
it lets debug tooling see the linker's evaluation order without
re-running materialization.

## What changes

- `ScheduleReport` gains `linker_order: Vec<String>`, serialized
  as `linkerOrder`. Module names rendered through
  `Schedule::module_name`.
- `Schedule::validate()` populates the field from
  `self.linker_order`. Empty when the dep graph has cycles
  (validation rejects anyway).

## Tests

Three new unit tests in `schedule_validator_test`:

- Acyclic spec produces a topo order respecting dep direction
  (`mod_1` before `mod_0` when `mod_0` reads from `mod_1`).
- Cyclic spec produces an empty `linker_order`.
- `ScheduleReport` serializes the field as `linkerOrder`.

`:schedule_validator_test` BUILD target gains
`@crates//:serde_json` for the JSON-shape assertion.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 11 targets pass on
      RBE.

## TODO.md

Closes one of the queued debundler followups; entry dropped.

https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG7aincxRPqXwaZH532PJG)_