### PR TITLE
flux: set `provider: github` on App-auth GitRepositories

### DIFF
--- a/cluster/k8s/flux-system/gotk-sync.yaml
+++ b/cluster/k8s/flux-system/gotk-sync.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m0s
+  provider: github
   ref:
     branch: devel
   secretRef:

--- a/cluster/k8s/gaffer-private-source/source.yaml
+++ b/cluster/k8s/gaffer-private-source/source.yaml
@@ -7,6 +7,7 @@ metadata:
     description: "Private companion monorepo. Reconciled from main branch via the ducktape-automation GitHub App (also used to push image-pin commits back here)."
 spec:
   interval: 1m
+  provider: github
   ref:
     branch: main
   secretRef:


### PR DESCRIPTION
## Summary

Cutover-verification fix for the Flux App-auth migration in commit
`745532e6b`. Both `flux-system` and `gaffer-private` GitRepositories
landed with the new `secretRef` pointing at `ducktape-automation-github-app`
but **without** `spec.provider: github`. source-controller v1.7.4
requires the field whenever the secret has GitHub App data, otherwise it
short-circuits with `InvalidProviderConfiguration` and refuses to fetch.

## Live state (before this PR)

```
GitRepository/flux-system  → Ready=False, FetchFailed=True
   secretRef 'ducktape-automation-github-app' has github app data but
   provider is not set to github
GitRepository/gaffer-private  → same
ImageUpdateAutomation/gaffer-images  → Stalled=True (downstream of source)
```

Both repos are still serving stale artifacts from their last successful
pre-migration fetches (devel @ `065b9bda1`, gaffer/main @ `3ff5fa92a1d`),
so kustomize reconciles and the cluster as a whole are still working —
but no new commits land in either dependency tree until this is fixed.

## Change

Add `provider: github` to `spec` on both GitRepositories.

## Test plan

- [x] kubeconform passed locally.
- [ ] After merge: Flux reconciles `flux-system` and `gaffer-private`
      sources. Both should hit `Ready=True` with a fresh artifact
      revision, and the `gaffer-images` ImageUpdateAutomation should
      come back online.

## Sequencing

This unblocks the pending PR to flip
`github_repository_ruleset.gaffer_main.enforcement` to `"active"` and
add the `Pre-commit checks / Pre-commit checks` required check (gaffer
PR #16's workflow exists now).

https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU)_