### PR TITLE
github-branch-protection: gaffer enforcement=active, fix check name strings

### DIFF
--- a/plans/branch_protection.md
+++ b/plans/branch_protection.md
@@ -21,11 +21,11 @@ commits.
 - ducktape main: `enforcement = "active"`. No-op today because main is not the
   default branch (`devel` still is) and nothing pushes to main. Will start
   gating direct pushes once the default branch flips to main.
-- gaffer-private main: `enforcement = "disabled"`. **Blocker resolved** in
-  commit 745532e6b: Flux's `gaffer-images` ImageUpdateAutomation now pushes
-  via the `ducktape-automation` GitHub App, which matches the `Integration`
-  bypass actor. Flipping enforcement to `"active"` is now safe — see
-  "Outstanding work" below.
+- gaffer-private main: `enforcement = "active"`. Gates `Test & Build` and
+  `Pre-commit checks` (the latter from the workflow added in
+  `agentydragon/gaffer-private#16`). Flux's `gaffer-images`
+  ImageUpdateAutomation pushes via the `ducktape-automation` GitHub App,
+  matching the `Integration` bypass actor.
 - Bypass actors on both rulesets:
   - `RepositoryRole=admin` (id 5) — covers in-cluster automations pushing as
     the owner via PAT (`claude-token-rotation`, `attic-jwt-rotation` CronJobs).
@@ -67,17 +67,7 @@ GitRepositories switched from `ssh://git@github.com/…` to
 
 ## Outstanding work
 
-1. **Cutover verification.** After commit 745532e6b lands on `origin/devel`,
-   `flux reconcile source git flux-system && flux reconcile source git gaffer-private`,
-   then `flux reconcile image update gaffer-images`. Confirm both
-   GitRepositories reach `Ready=True` with a fresh artifact revision and that
-   a setter-driven commit on `gaffer-private/main` is attributed to the App.
-   Watch source-controller logs for `transport: authentication required`
-   events on either GitRepository.
-2. **Activate the gaffer ruleset.** Flip
-   `github_repository_ruleset.gaffer_main.enforcement` from `"disabled"` to
-   `"active"` in `tf/gitops/github-branch-protection/main.tf`. Apply.
-3. **Retire the legacy SSH deploy keys.** CLEANUP markers in place:
+1. **Retire the legacy SSH deploy keys.** CLEANUP markers in place:
    - `cluster/k8s/gaffer-private-source/deploy-key-tf.yaml` header +
      `cluster/k8s/gaffer-private-source/kustomization.yaml` inline — drop
      `deploy-key-tf.yaml` and `github-pat-gaffer-private-flux.sops.yaml`

--- a/tf/gitops/github-branch-protection/main.tf
+++ b/tf/gitops/github-branch-protection/main.tf
@@ -10,10 +10,10 @@
 # container-images:pin-digests) can keep working after migration to
 # actions/create-github-app-token. See secrets/ducktape_automation.README.md.
 #
-# On gaffer-private, main is already the default branch, but the ruleset
-# is created with enforcement = "disabled" pending the Flux App-auth
-# migration (see the NOTE on github_repository_ruleset.gaffer_main below
-# and plans/branch_protection.md).
+# On gaffer-private, main is the default branch and the ruleset enforces
+# on apply. Flux's gaffer-images ImageUpdateAutomation now pushes via the
+# ducktape-automation App (see the Integration bypass actor below), so its
+# image-pin commits land cleanly.
 #
 # Auth uses the per-repo PATs already present in flux-system:
 #   - github-secrets-sync-pat (Administration:R/W on ducktape; deployed
@@ -122,23 +122,12 @@ resource "github_repository_ruleset" "ducktape_main" {
 }
 
 # --- gaffer-private main ---
-#
-# NOTE: enforcement is "disabled" pending Flux migration to App auth.
-# main is gaffer's default branch and Flux's gaffer-images
-# ImageUpdateAutomation (cluster/k8s/gaffer-private-source/) pushes commits
-# back to main using gaffer-private-deploy-key — an SSH deploy key. Deploy
-# keys aren't a user/App identity, so neither RepositoryRole=admin nor
-# Integration=ducktape-automation matches them, and the push would be
-# rejected by an active ruleset. Flip to "active" once Flux's gaffer-private
-# GitRepository secretRef has been swapped to ducktape-automation App auth
-# (githubAppID / githubAppInstallationID / githubAppPrivateKey) — see
-# plans/branch_protection.md for the migration runbook.
 resource "github_repository_ruleset" "gaffer_main" {
   provider    = github.gaffer
   name        = "main-protection"
   repository  = "gaffer-private"
   target      = "branch"
-  enforcement = "disabled"
+  enforcement = "active"
 
   conditions {
     ref_name {
@@ -169,15 +158,14 @@ resource "github_repository_ruleset" "gaffer_main" {
     }
 
     required_status_checks {
-      # gaffer's bazel-ci.yml is a top-level workflow (not invoked via
-      # workflow_call), so the check name is `<workflow_name> /
-      # <job_name>` = `Bazel CI / Test & Build`. If the first apply
-      # surfaces a different string, adjust here.
-      #
-      # TODO: add `Pre-commit checks / Pre-commit checks` once gaffer's
-      # pre-commit workflow is created (separate PR).
+      # gaffer's bazel-ci and pre-commit are both top-level workflows
+      # (not invoked via workflow_call), so check_runs.name is just the
+      # job name in each case. Empirically verified on PRs #16/#17.
       required_check {
-        context = "Bazel CI / Test & Build"
+        context = "Test & Build"
+      }
+      required_check {
+        context = "Pre-commit checks"
       }
       strict_required_status_checks_policy = false
     }


### PR DESCRIPTION
## Summary

Three coordinated edits to `tf/gitops/github-branch-protection/main.tf`:

1. **Flip `gaffer_main.enforcement` from `"disabled"` to `"active"`.**
   The Flux App-auth migration (commit `745532e6b` + the `provider: github`
   follow-up in #1489) means image automation pushes to `gaffer/main` now
   go through `ducktape-automation`, matching the Integration bypass
   actor. Verified clean post-cutover: both GitRepositories `Ready=True`
   with fresh revisions, `gaffer-images` ImageUpdateAutomation
   `Ready=True`.

2. **Fix gaffer bazel-ci required check name** from
   `"Bazel CI / Test & Build"` → `"Test & Build"`. My prior best-guess
   was wrong: empirically the `check_runs.name` for top-level GHA
   workflows is just the job name (verified on
   `agentydragon/gaffer-private` PRs #16 / #17 via the `get_check_runs`
   API). The `<workflow> / <job>` form is just the PR-summary display
   rendering; the API name is the job name.

3. **Add `"Pre-commit checks"` as a required check on the gaffer
   ruleset.** `agentydragon/gaffer-private#16` landed the workflow,
   `#17` cleared the prettier violations, and `Pre-commit checks` is now
   running green on `main`.

Header comment + `plans/branch_protection.md` updated to reflect the new
state. The "Outstanding work" section narrows to just the deploy-key
retirement.

## Test plan

- [x] `pre-commit` (kubeconform, checkov, tflint, prettier) passed locally.
- [ ] After merge: `github-branch-protection` Terraform CR reconciles
      cleanly; verify on
      <https://github.com/agentydragon/gaffer-private/rules> that the
      `main-protection` ruleset is `Active` with both `Test & Build` and
      `Pre-commit checks` listed under required status checks.

https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU)_