### PR TITLE
github-branch-protection: switch gaffer to classic github_branch_protection

### DIFF
--- a/plans/branch_protection.md
+++ b/plans/branch_protection.md
@@ -6,37 +6,77 @@ Enforce that commits landing on the default branch of either repo have passed
 CI checks. Concretely, gate on:
 
 - ducktape: `bazel-ci / Test & Build` and `Pre-commit checks`
-- gaffer-private: `Bazel CI / Test & Build` (and `Pre-commit checks` once
-  gaffer's pre-commit workflow is created — separate PR)
+- gaffer-private: `Test & Build` and `Pre-commit checks` (PR-merge gate only —
+  see "gaffer-private trade-off" below)
 
 Plus the cheap extras: block branch deletion, force-push, non-linear merge
 commits.
 
 ## Current state
 
-- `tf/gitops/github-branch-protection/` — module landed. Two
-  `github_repository_ruleset` resources, both targeting `refs/heads/main`,
-  authenticated via the existing per-repo PATs (`github-secrets-sync-pat` for
-  ducktape, `github-pat-gaffer-private-flux` for gaffer).
-- ducktape main: `enforcement = "active"`. No-op today because main is not the
-  default branch (`devel` still is) and nothing pushes to main. Will start
-  gating direct pushes once the default branch flips to main.
-- gaffer-private main: `enforcement = "active"`. Gates `Test & Build` and
-  `Pre-commit checks` (the latter from the workflow added in
-  `agentydragon/gaffer-private#16`). Flux's `gaffer-images`
-  ImageUpdateAutomation pushes via the `ducktape-automation` GitHub App,
-  matching the `Integration` bypass actor.
-- Bypass actors on both rulesets:
+- `tf/gitops/github-branch-protection/` — module landed. Two protection
+  resources, one per repo, authenticated via the existing per-repo PATs
+  (`github-secrets-sync-pat` for ducktape, `github-pat-gaffer-private-flux`
+  for gaffer).
+- ducktape main: `github_repository_ruleset` with `enforcement = "active"`.
+  No-op today because main is not the default branch (`devel` still is) and
+  nothing pushes to main. Will start gating direct pushes once the default
+  branch flips to main. Bypass actors:
   - `RepositoryRole=admin` (id 5) — covers in-cluster automations pushing as
     the owner via PAT (`claude-token-rotation`, `attic-jwt-rotation` CronJobs).
-  - `Integration=ducktape-automation` (App ID 3590331) — covers any GHA
-    workflow that mints an installation token via
-    `actions/create-github-app-token`, **and as of commit 745532e6b also
-    covers Flux's source-controller and image-automation-controller pushes**
-    on both the `flux-system` and `gaffer-private` GitRepositories. The three
+  - `Integration=ducktape-automation` (App ID 3590331) — covers GHA workflows
+    that mint an installation token via `actions/create-github-app-token`,
+    **and** Flux's source-controller / image-automation-controller pushes on
+    the `flux-system` GitRepository (after commit 745532e6b). The three
     direct-push workflows on ducktape (`sync-pins.yml`, `nix-flake-update.yml`,
     `container-images.yml`'s `pin-digests` job) still carry TODO markers
     about migrating when ducktape's default flips.
+- gaffer-private main: classic `github_branch_protection`. Rulesets are not
+  available on Free private repos (POST returns 403 "Upgrade to GitHub Pro
+  or make this repository public"). PR merges via the merge button are gated
+  on `Test & Build` and `Pre-commit checks` passing; deletion / force-push /
+  non-linear merges are blocked. Direct pushes from `Contents:write` actors
+  (you, the App, PAT-using CronJobs) bypass the CI gate — this is the
+  trade-off; see below.
+
+## gaffer-private trade-off
+
+Classic branch protection on Free private repos has a hard gap that
+rulesets don't have: **`required_status_checks` only enforces on PR merges,
+not on direct `git push`.** The two GitHub features that _would_ close the
+gap are both unavailable on the current plan:
+
+- **Rulesets** (modern API, supports `bypass_actors{Integration=...}` to
+  exempt the App while still gating everything else): blocked by GitHub
+  Pro requirement on private repos.
+- **`restrict_pushes` on classic protection** (whitelist of users/apps
+  allowed to push at all): blocked by Pro requirement.
+
+The remaining lever — `required_pull_request_reviews` — would force ALL
+writes through PRs, which would block Flux's `gaffer-images`
+ImageUpdateAutomation since it pushes commits directly without opening
+PRs. Net: no way on Free to gate direct pushes on CI without breaking
+Flux.
+
+We accept the gap because the set of actors with `Contents:write` on
+gaffer-private is small and trusted (you, ducktape-automation App,
+github-secrets-sync-pat for in-cluster automations). The threat
+"unauthorized actor pushes red commit" is gated by access control; the
+threat "trusted actor accidentally pushes red commit directly" is the
+residual risk.
+
+To close the gap pick one when you're ready:
+
+1. **GitHub Pro upgrade** (~$4/mo). Switch gaffer to a ruleset mirroring
+   ducktape's. Cleanest.
+2. **Migrate `gaffer-images` ImageUpdateAutomation to PR mode.** Push to a
+   feature branch + auto-open + auto-merge a PR. With direct-push
+   automation gone, classic protection's `required_pull_request_reviews`
+   becomes safe to enable, fully closing the gap on Free.
+
+Push protection (secret scanning) is independent of branch protection and
+is a separate enable-on-the-repo step worth picking up — see "Outstanding
+work" below.
 
 The `ducktape-automation` GitHub App is registered on the
 `agentydragon` personal account; public identifiers and permissions are
@@ -67,7 +107,19 @@ GitRepositories switched from `ssh://git@github.com/…` to
 
 ## Outstanding work
 
-1. **Retire the legacy SSH deploy keys.** CLEANUP markers in place:
+1. **Close the gaffer direct-push gate gap** via Pro upgrade or PR-mode
+   migration of Flux image automation; see "gaffer-private trade-off" above.
+
+2. **Enable secret-scanning push protection on gaffer-private.** GitHub's
+   push protection blocks pushes that contain secrets at the moment of
+   `git push`, irrespective of branch protection. Free for public repos
+   (already on for ducktape by default since 2024). On private repos it
+   historically required GitHub Advanced Security; the personal-account
+   "Secret Protection" SKU may now cover it — verify before assuming. Set
+   on the repo via the API or web UI; can be terraform-managed via
+   `github_repository.security_and_analysis.secret_scanning_push_protection`.
+
+3. **Retire the legacy SSH deploy keys.** CLEANUP markers in place:
    - `cluster/k8s/gaffer-private-source/deploy-key-tf.yaml` header +
      `cluster/k8s/gaffer-private-source/kustomization.yaml` inline — drop
      `deploy-key-tf.yaml` and `github-pat-gaffer-private-flux.sops.yaml`

--- a/tf/gitops/github-branch-protection/main.tf
+++ b/tf/gitops/github-branch-protection/main.tf
@@ -1,19 +1,19 @@
-# Branch-protection rulesets for agentydragon/ducktape and
-# agentydragon/gaffer-private. Both target refs/heads/main.
+# Branch protection for agentydragon/ducktape and agentydragon/gaffer-private
+# default branches. Two different mechanisms:
 #
-# On ducktape, main is not currently the default branch; the ruleset
-# enforces nothing today and will start gating direct pushes when the
-# default flips from devel. This is the "Option C — partial protection"
-# path described in plans/branch_protection.md, with the ducktape-automation
-# GitHub App added as a bypass actor so the three GHA workflows that
-# direct-push to the default branch (sync-pins, nix-flake-update,
-# container-images:pin-digests) can keep working after migration to
-# actions/create-github-app-token. See secrets/ducktape_automation.README.md.
+# - ducktape (public repo) → `github_repository_ruleset` on `refs/heads/main`.
+#   Rulesets are GitHub's modern API, support Integration-actor bypass, and
+#   are available on public repos for free. The ducktape-automation App is
+#   wired in as a bypass actor so direct-push workflows that mint
+#   installation tokens (sync-pins, nix-flake-update, pin-digests) can keep
+#   working after ducktape's default branch flips from devel to main. Today
+#   main is not yet default and the ruleset is a no-op.
 #
-# On gaffer-private, main is the default branch and the ruleset enforces
-# on apply. Flux's gaffer-images ImageUpdateAutomation now pushes via the
-# ducktape-automation App (see the Integration bypass actor below), so its
-# image-pin commits land cleanly.
+# - gaffer-private (private repo, Free plan) → classic
+#   `github_branch_protection` on `main`. Rulesets are not available on
+#   Free private repos (POST returns 403 "Upgrade to GitHub Pro"). Classic
+#   protection works but has weaker semantics on Free — see the comment on
+#   the gaffer_main resource and plans/branch_protection.md.
 #
 # Auth uses the per-repo PATs already present in flux-system:
 #   - github-secrets-sync-pat (Administration:R/W on ducktape; deployed
@@ -122,52 +122,64 @@ resource "github_repository_ruleset" "ducktape_main" {
 }
 
 # --- gaffer-private main ---
-resource "github_repository_ruleset" "gaffer_main" {
-  provider    = github.gaffer
-  name        = "main-protection"
-  repository  = "gaffer-private"
-  target      = "branch"
-  enforcement = "active"
+#
+# Classic branch protection (not a ruleset) because rulesets are not
+# available on Free private repos. See plans/branch_protection.md for the
+# full trade-off; the short version:
+#
+# What this gives us:
+#   - Block deletion + force-push + non-linear merges
+#   - PR merges via the merge button gated on `Test & Build` and
+#     `Pre-commit checks` passing
+#
+# What this does NOT give us (gap vs ducktape's ruleset):
+#   - Direct `git push` from any actor with `Contents:write` is NOT gated
+#     on the CI checks. Classic protection's required_status_checks only
+#     enforces on PR merge buttons; pushes to the branch ref bypass it.
+#     This means a contributor (or an in-cluster automation) could shove
+#     a red commit straight to main without going through a PR.
+#
+# TODO: close that gap once one of these becomes feasible:
+#   1. Upgrade `agentydragon` to GitHub Pro (~$4/mo) → switch this resource
+#      back to a ruleset with bypass_actors{Integration=ducktape-automation}
+#      mirroring the ducktape side.
+#   2. Migrate Flux's gaffer-images ImageUpdateAutomation off direct
+#      pushes onto a PR-based flow (push to a feature branch + auto-open +
+#      auto-merge a PR). With direct pushes gone, classic protection's
+#      `required_pull_request_reviews` becomes safe to enable, which would
+#      block all non-PR pushes.
+#
+# TODO: enable GitHub secret-scanning push protection on gaffer-private.
+# Independent of branch protection — push protection blocks pushes that
+# contain secrets at the moment of `git push`. Free for public repos; on
+# private repos it requires GitHub Advanced Security, but worth checking
+# whether the personal-account "Secret Protection" SKU covers this.
+resource "github_branch_protection" "gaffer_main" {
+  #checkov:skip=CKV_GIT_5:Solo repo. There is no second reviewer to require.
+  #checkov:skip=CKV_GIT_6:Signed-commit enforcement is a separate decision; not adopting it across the board today.
+  provider      = github.gaffer
+  repository_id = "gaffer-private"
+  pattern       = "main"
 
-  conditions {
-    ref_name {
-      include = ["refs/heads/main"]
-      exclude = []
-    }
+  enforce_admins          = false
+  required_linear_history = true
+  allows_deletions        = false
+  allows_force_pushes     = false
+
+  required_status_checks {
+    strict = false
+    # gaffer's bazel-ci and pre-commit are both top-level workflows (not
+    # invoked via workflow_call), so check_runs.name is just the job name
+    # in each case. Empirically verified on PRs #16/#17.
+    contexts = [
+      "Test & Build",
+      "Pre-commit checks",
+    ]
   }
 
-  bypass_actors {
-    actor_id    = local.admin_repo_role_id
-    actor_type  = "RepositoryRole"
-    bypass_mode = "always"
-  }
-
-  bypass_actors {
-    actor_id    = local.automation_app_id
-    actor_type  = "Integration"
-    bypass_mode = "always"
-  }
-
-  rules {
-    deletion                = local.ruleset_rules_common.deletion
-    non_fast_forward        = local.ruleset_rules_common.non_fast_forward
-    required_linear_history = local.ruleset_rules_common.required_linear_history
-
-    pull_request {
-      required_approving_review_count = 0
-    }
-
-    required_status_checks {
-      # gaffer's bazel-ci and pre-commit are both top-level workflows
-      # (not invoked via workflow_call), so check_runs.name is just the
-      # job name in each case. Empirically verified on PRs #16/#17.
-      required_check {
-        context = "Test & Build"
-      }
-      required_check {
-        context = "Pre-commit checks"
-      }
-      strict_required_status_checks_policy = false
-    }
-  }
+  # Intentionally NO required_pull_request_reviews — that block makes PRs
+  # mandatory for ALL writes, including Flux's gaffer-images
+  # ImageUpdateAutomation, which pushes commits directly to main. We'd
+  # need the Pro-only `restrict_pushes` to whitelist the App, or migrate
+  # Flux off direct pushes; see TODOs above.
 }

--- a/x/auragon_study_casino/auth.py
+++ b/x/auragon_study_casino/auth.py
@@ -68,7 +68,7 @@ def decode_session_token(token: str, secret: bytes) -> str | None:
     if data.get("exp", 0) < time.time():
         return None
     sub = data.get("sub", "")
-    return sub if sub else None
+    return sub or None
 
 
 def create_oidc_router(


### PR DESCRIPTION
## Summary

Replace `github_repository_ruleset.gaffer_main` with classic
`github_branch_protection.gaffer_main`. Rulesets aren't available on Free
private repos, and `gaffer_main` ruleset apply has been failing with
`403 Upgrade to GitHub Pro` ever since #1482 landed (we just never
noticed because tofu-controller silently retried it every 15 minutes
while ducktape's ruleset worked fine).

## Live state pre-PR

- ducktape `main-protection` ruleset → already live (id 15894562). Untouched.
- gaffer `main-protection` ruleset → never created. State is empty for
  this resource; no cleanup needed.
- Terraform CR `github-branch-protection` → Apply failing on every
  reconcile. This PR makes apply succeed.

## What you get on gaffer-private after this lands

- Block deletion + force-push + non-linear merges
- PR merges via the merge button gated on `Test & Build` and
  `Pre-commit checks` passing

## What you don't get (gap vs ruleset)

Direct `git push` from any actor with `Contents:write` is **not** gated
on the CI checks. Classic protection's `required_status_checks` only
enforces on PR merge buttons; pushes to the branch ref bypass it. The
two GitHub features that would close the gap are both Pro-only:

- Rulesets with `bypass_actors{Integration=ducktape-automation}`
- Classic protection's `restrict_pushes` whitelist

`required_pull_request_reviews` is intentionally left off — it would
force ALL writes through PRs and block Flux's `gaffer-images`
ImageUpdateAutomation, which pushes commits directly. Trade-off
acceptable given the small set of trusted actors with `Contents:write`.

Inline TODOs on the resource describe the two paths to close the gap
(Pro upgrade → ruleset; or Flux PR-mode migration) plus a separate TODO
about enabling secret-scanning push protection on the repo.
`plans/branch_protection.md` rewritten to record the trade-off and
consolidate outstanding work (close gap, enable push protection, retire
deploy keys).

## Test plan

- [x] `pre-commit` (kubeconform, checkov, tflint, prettier) passed locally
      (with `checkov:skip` for CKV_GIT_5/6 — see commit message).
- [ ] After merge: Terraform CR `github-branch-protection` reconciles
      cleanly with no apply errors. Verify on
      <https://github.com/agentydragon/gaffer-private/settings/branches>
      that classic branch protection on `main` is in place.

https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU)_