### PR TITLE
github-branch-protection: drop gaffer; document Pro-plan requirement

### DIFF
--- a/plans/branch_protection.md
+++ b/plans/branch_protection.md
@@ -2,26 +2,24 @@
 
 ## Goal
 
-Enforce that commits landing on the default branch of either repo have passed
+Enforce that commits landing on the default branch of each repo have passed
 CI checks. Concretely, gate on:
 
 - ducktape: `bazel-ci / Test & Build` and `Pre-commit checks`
-- gaffer-private: `Test & Build` and `Pre-commit checks` (PR-merge gate only —
-  see "gaffer-private trade-off" below)
+- gaffer-private: not currently enforced — see below.
 
 Plus the cheap extras: block branch deletion, force-push, non-linear merge
 commits.
 
 ## Current state
 
-- `tf/gitops/github-branch-protection/` — module landed. Two protection
-  resources, one per repo, authenticated via the existing per-repo PATs
-  (`github-secrets-sync-pat` for ducktape, `github-pat-gaffer-private-flux`
-  for gaffer).
-- ducktape main: `github_repository_ruleset` with `enforcement = "active"`.
-  No-op today because main is not the default branch (`devel` still is) and
-  nothing pushes to main. Will start gating direct pushes once the default
-  branch flips to main. Bypass actors:
+- `tf/gitops/github-branch-protection/` — manages a single
+  `github_repository_ruleset.ducktape_main` on `refs/heads/main`,
+  authenticated via `github-secrets-sync-pat` from `flux-system`.
+- ducktape main: `enforcement = "active"`. No-op today because main is not
+  the default branch (`devel` still is) and nothing pushes to main. Will
+  start gating direct pushes once the default branch flips to main.
+  Bypass actors:
   - `RepositoryRole=admin` (id 5) — covers in-cluster automations pushing as
     the owner via PAT (`claude-token-rotation`, `attic-jwt-rotation` CronJobs).
   - `Integration=ducktape-automation` (App ID 3590331) — covers GHA workflows
@@ -31,57 +29,49 @@ commits.
     direct-push workflows on ducktape (`sync-pins.yml`, `nix-flake-update.yml`,
     `container-images.yml`'s `pin-digests` job) still carry TODO markers
     about migrating when ducktape's default flips.
-- gaffer-private main: classic `github_branch_protection`. Rulesets are not
-  available on Free private repos (POST returns 403 "Upgrade to GitHub Pro
-  or make this repository public"). PR merges via the merge button are gated
-  on `Test & Build` and `Pre-commit checks` passing; deletion / force-push /
-  non-linear merges are blocked. Direct pushes from `Contents:write` actors
-  (you, the App, PAT-using CronJobs) bypass the CI gate — this is the
-  trade-off; see below.
-
-## gaffer-private trade-off
-
-Classic branch protection on Free private repos has a hard gap that
-rulesets don't have: **`required_status_checks` only enforces on PR merges,
-not on direct `git push`.** The two GitHub features that _would_ close the
-gap are both unavailable on the current plan:
-
-- **Rulesets** (modern API, supports `bypass_actors{Integration=...}` to
-  exempt the App while still gating everything else): blocked by GitHub
-  Pro requirement on private repos.
-- **`restrict_pushes` on classic protection** (whitelist of users/apps
-  allowed to push at all): blocked by Pro requirement.
-
-The remaining lever — `required_pull_request_reviews` — would force ALL
-writes through PRs, which would block Flux's `gaffer-images`
-ImageUpdateAutomation since it pushes commits directly without opening
-PRs. Net: no way on Free to gate direct pushes on CI without breaking
-Flux.
-
-We accept the gap because the set of actors with `Contents:write` on
-gaffer-private is small and trusted (you, ducktape-automation App,
-github-secrets-sync-pat for in-cluster automations). The threat
-"unauthorized actor pushes red commit" is gated by access control; the
-threat "trusted actor accidentally pushes red commit directly" is the
-residual risk.
-
-To close the gap pick one when you're ready:
-
-1. **GitHub Pro upgrade** (~$4/mo). Switch gaffer to a ruleset mirroring
-   ducktape's. Cleanest.
-2. **Migrate `gaffer-images` ImageUpdateAutomation to PR mode.** Push to a
-   feature branch + auto-open + auto-merge a PR. With direct-push
-   automation gone, classic protection's `required_pull_request_reviews`
-   becomes safe to enable, fully closing the gap on Free.
-
-Push protection (secret scanning) is independent of branch protection and
-is a separate enable-on-the-repo step worth picking up — see "Outstanding
-work" below.
+- gaffer-private main: **no protection**. See the next section.
 
 The `ducktape-automation` GitHub App is registered on the
 `agentydragon` personal account; public identifiers and permissions are
 documented at <secrets/ducktape_automation.README.md>. The private key is
 SOPS-encrypted at <secrets/ducktape-automation.2026-05-03.private-key.sops.pem>.
+
+## gaffer-private: blocked on GitHub plan
+
+Branch protection of any kind — `github_repository_ruleset` _or_ classic
+`github_branch_protection` — is **not available on Free for private
+repositories**. GitHub's pricing page lists the relevant features
+(Repository rules, code owners, multiple reviewers, etc.) under "Public
+repositories" only on Free; the Pro/Team tiers extend them to private
+repos. GitHub's plans doc confirms: "GitHub Pro includes 'Protected
+branches' as an advanced tool for private repositories, while GitHub Free
+does not list this feature."
+
+Empirically verified across two iterations:
+
+- Ruleset POST → `403 Upgrade to GitHub Pro or make this repository public
+to enable this feature.`
+- Classic `github_branch_protection` apply → identical 403 with the same
+  text.
+
+Earlier drafts of this doc claimed classic protection works on Free
+private with feature gaps; that was wrong. Both APIs are uniformly gated.
+
+To enforce protection on `gaffer-private/main`, pick one:
+
+1. **GitHub Pro upgrade** (~$4/mo for the `agentydragon` personal account).
+   Restore a `github_repository_ruleset.gaffer_main` mirroring ducktape's
+   shape, with `bypass_actors{Integration=ducktape-automation}` so Flux's
+   image automation keeps pushing cleanly. Cleanest path.
+2. **Make gaffer-private public.** Sidesteps the plan limit but conflicts
+   with the reason the repo is private (proprietary Google binaries,
+   reverse-engineered artifacts). Not a real option.
+3. **Live without it.** Trust model relies entirely on access control —
+   only the owner, the `ducktape-automation` App, and PAT-using cluster
+   automations have `Contents: write`. Currently the chosen state.
+
+Until one of those changes, `gaffer-private/main` has no enforced rules
+and the terraform module manages only ducktape.
 
 ## Flux App migration — done in commit 745532e6b
 
@@ -107,16 +97,16 @@ GitRepositories switched from `ssh://git@github.com/…` to
 
 ## Outstanding work
 
-1. **Close the gaffer direct-push gate gap** via Pro upgrade or PR-mode
-   migration of Flux image automation; see "gaffer-private trade-off" above.
+1. **Decide on gaffer protection** — Pro upgrade vs accept no enforcement.
+   See "gaffer-private: blocked on GitHub plan" above.
 
-2. **Enable secret-scanning push protection on gaffer-private.** GitHub's
-   push protection blocks pushes that contain secrets at the moment of
-   `git push`, irrespective of branch protection. Free for public repos
-   (already on for ducktape by default since 2024). On private repos it
-   historically required GitHub Advanced Security; the personal-account
-   "Secret Protection" SKU may now cover it — verify before assuming. Set
-   on the repo via the API or web UI; can be terraform-managed via
+2. **Enable secret-scanning push protection on both repos.** Independent
+   of branch protection — push protection blocks pushes that contain
+   secrets at the moment of `git push`. Free for public repos (already on
+   for ducktape by default since 2024). On private repos it historically
+   required GitHub Advanced Security; the personal-account "Secret
+   Protection" SKU may now cover gaffer-private — verify before assuming.
+   Set on the repo via the API or web UI; can be terraform-managed via
    `github_repository.security_and_analysis.secret_scanning_push_protection`.
 
 3. **Retire the legacy SSH deploy keys.** CLEANUP markers in place:
@@ -125,13 +115,14 @@ GitRepositories switched from `ssh://git@github.com/…` to
      `deploy-key-tf.yaml` and `github-pat-gaffer-private-flux.sops.yaml`
      from the kustomize resources list.
    - `tf/gitops/gaffer-private-flux/main.tf` header — strip
-     `prevent_destroy` lifecycle blocks, `tofu destroy` the module (revokes
-     the GitHub deploy key, deletes the in-cluster Secret), then delete the
-     module directory + BUILD.bazel target.
+     `prevent_destroy` lifecycle blocks, `tofu destroy` the module
+     (revokes the GitHub deploy key, deletes the in-cluster Secret), then
+     delete the module directory + BUILD.bazel target.
    - Ducktape-side `flux-system` SSH Secret + corresponding GitHub deploy
-     key on `agentydragon/ducktape`: revoke the deploy key in repo settings;
-     the in-cluster Secret is provisioned by the `flux_bootstrap_git` tofu
-     resource and needs the bootstrap config updated to stop creating it.
+     key on `agentydragon/ducktape`: revoke the deploy key in repo
+     settings; the in-cluster Secret is provisioned by the
+     `flux_bootstrap_git` tofu resource and needs the bootstrap config
+     updated to stop creating it.
 
 ## Workflow migration (also pending, ducktape-side, lower urgency)
 
@@ -171,12 +162,18 @@ additionally has a hardcoded `devel` ref + push target that has to flip to
 
 PR #1312 (commit `c23edda`, reverted) was the first attempt. It targeted
 both `devel` and `main` in one ruleset and tried to use the built-in
-`github-actions` (Integration id=15368) as a bypass actor. The latter failed
-with a 422 because GitHub doesn't expose `github-actions` as a bypass actor
-on personal-account repos — only third-party Apps (e.g. BuildBuddy) appear
-in the picker. The fix is registering our own App (`ducktape-automation`)
-and using it as the Integration bypass actor; that's the path this work
-has taken.
+`github-actions` (Integration id=15368) as a bypass actor. The latter
+failed with a 422 because GitHub doesn't expose `github-actions` as a
+bypass actor on personal-account repos — only third-party Apps (e.g.
+BuildBuddy) appear in the picker. The fix is registering our own App
+(`ducktape-automation`) and using it as the Integration bypass actor;
+that's the path this work has taken.
+
+PR #1490 then activated a `gaffer_main` ruleset; PR #1491 swapped it to
+classic `github_branch_protection` after the ruleset apply failed with
+the Pro requirement. Both gaffer-side resources have since been removed
+because the underlying constraint is the same — branch protection on
+private repos requires Pro regardless of mechanism.
 
 ## Tracking
 

--- a/tf/gitops/github-branch-protection/main.tf
+++ b/tf/gitops/github-branch-protection/main.tf
@@ -1,36 +1,26 @@
-# Branch protection for agentydragon/ducktape and agentydragon/gaffer-private
-# default branches. Two different mechanisms:
+# Branch protection for agentydragon/ducktape `main`.
 #
-# - ducktape (public repo) → `github_repository_ruleset` on `refs/heads/main`.
-#   Rulesets are GitHub's modern API, support Integration-actor bypass, and
-#   are available on public repos for free. The ducktape-automation App is
-#   wired in as a bypass actor so direct-push workflows that mint
-#   installation tokens (sync-pins, nix-flake-update, pin-digests) can keep
-#   working after ducktape's default branch flips from devel to main. Today
-#   main is not yet default and the ruleset is a no-op.
+# Implemented as `github_repository_ruleset` on `refs/heads/main`. Rulesets
+# are GitHub's modern API and support Integration-actor bypass — the
+# ducktape-automation App is wired in below so direct-push workflows that
+# mint installation tokens (sync-pins, nix-flake-update, pin-digests) keep
+# working after ducktape's default branch flips from devel to main. main
+# is not yet default; the ruleset enforces nothing today.
 #
-# - gaffer-private (private repo, Free plan) → classic
-#   `github_branch_protection` on `main`. Rulesets are not available on
-#   Free private repos (POST returns 403 "Upgrade to GitHub Pro"). Classic
-#   protection works but has weaker semantics on Free — see the comment on
-#   the gaffer_main resource and plans/branch_protection.md.
+# Gaffer-private has NO branch protection from this module. GitHub Free
+# does not include any branch protection (rulesets or classic) on private
+# repositories. Both `github_repository_ruleset` and
+# `github_branch_protection` apply attempts on gaffer-private have been
+# verified to fail with `403 Upgrade to GitHub Pro or make this repository
+# public to enable this feature`. Closing that gap requires a Pro upgrade
+# (~$4/mo). See plans/branch_protection.md.
 #
-# Auth uses the per-repo PATs already present in flux-system:
-#   - github-secrets-sync-pat (Administration:R/W on ducktape; deployed
-#     by cluster/k8s/github-secrets-sync/secrets/)
-#   - github-pat-gaffer-private-flux (Administration:R/W on gaffer-private;
-#     deployed by cluster/k8s/gaffer-private-source/)
+# Auth: github-secrets-sync-pat (Administration:R/W on ducktape; deployed
+# by cluster/k8s/github-secrets-sync/secrets/).
 
 provider "github" {
-  alias = "ducktape"
   owner = "agentydragon"
   token = data.kubernetes_secret.ducktape_pat.data["token"]
-}
-
-provider "github" {
-  alias = "gaffer"
-  owner = "agentydragon"
-  token = data.kubernetes_secret.gaffer_pat.data["token"]
 }
 
 data "kubernetes_secret" "ducktape_pat" {
@@ -40,37 +30,21 @@ data "kubernetes_secret" "ducktape_pat" {
   }
 }
 
-data "kubernetes_secret" "gaffer_pat" {
-  metadata {
-    name      = "github-pat-gaffer-private-flux"
-    namespace = "flux-system"
-  }
-}
-
 locals {
-  # GitHub built-in "Admin" RepositoryRole — covers in-cluster
-  # automations that push as the owner via PAT (Flux ImageUpdateAutomation,
-  # claude-token-rotation CronJob). Constant across all repos.
+  # GitHub built-in "Admin" RepositoryRole — covers in-cluster automations
+  # that push as the owner via PAT (Flux ImageUpdateAutomation,
+  # claude-token-rotation, attic-jwt-rotation CronJobs).
   admin_repo_role_id = 5
 
   # ducktape-automation GitHub App; see secrets/ducktape_automation.README.md.
   # Used as the Integration bypass actor so workflows authenticated via
-  # actions/create-github-app-token bypass the rulesets — github-actions
+  # actions/create-github-app-token bypass the ruleset — github-actions
   # cannot be a bypass actor on personal-account repos, which is why we
   # registered a dedicated App.
   automation_app_id = 3590331
-
-  ruleset_rules_common = {
-    # Block branch deletion + force-push + non-linear merge commits.
-    deletion                = true
-    non_fast_forward        = true
-    required_linear_history = true
-  }
 }
 
-# --- ducktape main ---
 resource "github_repository_ruleset" "ducktape_main" {
-  provider    = github.ducktape
   name        = "main-protection"
   repository  = "ducktape"
   target      = "branch"
@@ -96,9 +70,10 @@ resource "github_repository_ruleset" "ducktape_main" {
   }
 
   rules {
-    deletion                = local.ruleset_rules_common.deletion
-    non_fast_forward        = local.ruleset_rules_common.non_fast_forward
-    required_linear_history = local.ruleset_rules_common.required_linear_history
+    # Block branch deletion + force-push + non-linear merge commits.
+    deletion                = true
+    non_fast_forward        = true
+    required_linear_history = true
 
     pull_request {
       # Solo repo — no review gate, just force commits through PRs so
@@ -119,67 +94,4 @@ resource "github_repository_ruleset" "ducktape_main" {
       strict_required_status_checks_policy = false
     }
   }
-}
-
-# --- gaffer-private main ---
-#
-# Classic branch protection (not a ruleset) because rulesets are not
-# available on Free private repos. See plans/branch_protection.md for the
-# full trade-off; the short version:
-#
-# What this gives us:
-#   - Block deletion + force-push + non-linear merges
-#   - PR merges via the merge button gated on `Test & Build` and
-#     `Pre-commit checks` passing
-#
-# What this does NOT give us (gap vs ducktape's ruleset):
-#   - Direct `git push` from any actor with `Contents:write` is NOT gated
-#     on the CI checks. Classic protection's required_status_checks only
-#     enforces on PR merge buttons; pushes to the branch ref bypass it.
-#     This means a contributor (or an in-cluster automation) could shove
-#     a red commit straight to main without going through a PR.
-#
-# TODO: close that gap once one of these becomes feasible:
-#   1. Upgrade `agentydragon` to GitHub Pro (~$4/mo) → switch this resource
-#      back to a ruleset with bypass_actors{Integration=ducktape-automation}
-#      mirroring the ducktape side.
-#   2. Migrate Flux's gaffer-images ImageUpdateAutomation off direct
-#      pushes onto a PR-based flow (push to a feature branch + auto-open +
-#      auto-merge a PR). With direct pushes gone, classic protection's
-#      `required_pull_request_reviews` becomes safe to enable, which would
-#      block all non-PR pushes.
-#
-# TODO: enable GitHub secret-scanning push protection on gaffer-private.
-# Independent of branch protection — push protection blocks pushes that
-# contain secrets at the moment of `git push`. Free for public repos; on
-# private repos it requires GitHub Advanced Security, but worth checking
-# whether the personal-account "Secret Protection" SKU covers this.
-resource "github_branch_protection" "gaffer_main" {
-  #checkov:skip=CKV_GIT_5:Solo repo. There is no second reviewer to require.
-  #checkov:skip=CKV_GIT_6:Signed-commit enforcement is a separate decision; not adopting it across the board today.
-  provider      = github.gaffer
-  repository_id = "gaffer-private"
-  pattern       = "main"
-
-  enforce_admins          = false
-  required_linear_history = true
-  allows_deletions        = false
-  allows_force_pushes     = false
-
-  required_status_checks {
-    strict = false
-    # gaffer's bazel-ci and pre-commit are both top-level workflows (not
-    # invoked via workflow_call), so check_runs.name is just the job name
-    # in each case. Empirically verified on PRs #16/#17.
-    contexts = [
-      "Test & Build",
-      "Pre-commit checks",
-    ]
-  }
-
-  # Intentionally NO required_pull_request_reviews — that block makes PRs
-  # mandatory for ALL writes, including Flux's gaffer-images
-  # ImageUpdateAutomation, which pushes commits directly to main. We'd
-  # need the Pro-only `restrict_pushes` to whitelist the App, or migrate
-  # Flux off direct pushes; see TODOs above.
 }


### PR DESCRIPTION
## Summary

Drop the gaffer-side resource from `tf/gitops/github-branch-protection/`.
Branch protection of any kind — `github_repository_ruleset` *or* classic
`github_branch_protection` — is **not available on Free for private
repositories**. Two iterations (PRs #1490, #1491) both hit the same
`403 Upgrade to GitHub Pro or make this repository public to enable this
feature`. GitHub's pricing page lists branch-protection features under
"Public repositories" only on Free; Pro/Team extends them to private.
Earlier docs claimed classic protection works on Free private with feature
gaps — that was wrong, retracted.

## Why now

The Terraform CR has been hammering the GitHub API every 15 min retrying
the doomed gaffer resource. That triggered a secondary rate limit on the
gaffer PAT and was visibly the largest contributor to the user 714892
quota drain you flagged. Removing the resource stops the loop and lets
the next reconcile reach `Apply=Succeeded` (only ducktape's ruleset
remains, already live as id 15894562).

## ducktape side

Unchanged. Module simplified: dropped the gaffer provider alias, the
gaffer PAT data source, and the `ruleset_rules_common` local (only one
resource left, inlined the values).

## plans/branch_protection.md rewrite

- Drops the "gaffer-private trade-off" section (it described an
  approach that doesn't work).
- New "gaffer-private: blocked on GitHub plan" section: three options
  (Pro upgrade, make public, live without it), current state is option
  3.
- "Outstanding work" #1 reduced to "Pro upgrade vs accept no
  enforcement."
- Historical appendix records the iteration history (PRs #1490, #1491,
  this PR) so we don't re-derive in three months.

## Test plan

- [x] `pre-commit` passed locally.
- [ ] After merge: Terraform CR `github-branch-protection` reconciles to
      `Apply=True / TerraformAppliedSucceed` on next 15-min cycle.
      `ducktape main-protection` ruleset (id 15894562) is unchanged.

https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU)_