### PR TITLE
Fix YAML indentation in attic-main-writer secrets file

### DIFF
--- a/secrets/ci/attic-main-writer.sops.yaml
+++ b/secrets/ci/attic-main-writer.sops.yaml
@@ -1,31 +1,31 @@
 expires_unencrypted: "2027-05-04T06:45:11Z"
 attic_token: ENC[AES256_GCM,data:KHuid80p6trMRwWkbUbPEyx04D/m5/OdHrrHzqz992nh3p2vxwe1pt9nateWBORz7WXsHTi1Ds/S5+jWmRQHqTCg583CswQmv/OP5saGQdTdmc8hcga/PVaISGnZoBgQ5LVSitO/jc2nUDVsUHI3ndS1trIOCWeYTZvFfq3mdWQv/nrTUZdfRzcn7tcw6H4G41cS7GdnQdf71DiM/h5LHpEVDKd/lj9zYUdt6BlOcuqVOLAc1IIehM4SJup0r5UPhIvu+qx7LAukv1rPHkGufCoT0JDDeFvVZH+5JbX5jJBC2JntnPbSuYlM9g==,iv:SW9wULzGq3QNJkzBnLB2t2inNXWOlONDxe/5OLDF3XY=,tag:bNVMLRZ1twSDNio387mZpw==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByaFVrbDZkQTBZR3dUaXI0
-            QWh3VFJBUjRJTHRzcGs0eG43clVXWWtqbEIwCjVublRxV2I4UFovTHZwMkJMeG0r
-            elJxUFhzV090U1kvTHQxMVd3OFY0aHMKLS0tIFF4a3J5MG9JaUErajNlQUljYWpp
-            Tk1sNFBnZ0xnaXd3Ni9xTGhGeDJnQTgKriPKIYnz+IEEPsWWbfAh51VFqJai36+Z
-            cKFZamWcrHIyxJxVdW2CMwEfY1oZHPLsJkEFg5zzLWru8VShGpTrjQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4eXlxZUN6OGpmdlZZeHgw
-            YzR6NHZxakl6bEZYR244VjluUHlkQmdlOEVFClg4amk4NDA3cmJkUFlIdjFZdU1u
-            ZnVoSmp2c3h5eU9VdHA1dTFiMG9zWkEKLS0tIE9CTTc2VlBkK0FLN21QM05CM3lI
-            am9BcUxtZENuT0JERFd2ZzBibUk1N3MKXCUPITSN0ebi/v1FhipYBisQgxgyimz0
-            oND53kc5cc0x85vLsvZi2CnL83aQEv7zhyn4J2rGaWGlmGX7+bvWbQ==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-04T00:45:11Z"
-    mac: ENC[AES256_GCM,data:ggI2TR/lR2QAO5kV9WWLwein6TqqWn1jtlKNRixjz2nheXA6YZATwyR6UO+Mk91j2Yg8Fm7JwmBCboq9lvFsBGa1zLdo8cH0fy4dWxyXQE+uyR7nI7EnXW6GZMMyg6Sezh9uHdInl1EXNMhEqIM3efb15TUVPmmkmZQGe9iokKE=,iv:Pf95TsNXcJVrsSQqMAbMrrfuLz+xuIK0yku+KXm8LY8=,tag:N3nbaRrS2CLOPzflC20xwg==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByaFVrbDZkQTBZR3dUaXI0
+        QWh3VFJBUjRJTHRzcGs0eG43clVXWWtqbEIwCjVublRxV2I4UFovTHZwMkJMeG0r
+        elJxUFhzV090U1kvTHQxMVd3OFY0aHMKLS0tIFF4a3J5MG9JaUErajNlQUljYWpp
+        Tk1sNFBnZ0xnaXd3Ni9xTGhGeDJnQTgKriPKIYnz+IEEPsWWbfAh51VFqJai36+Z
+        cKFZamWcrHIyxJxVdW2CMwEfY1oZHPLsJkEFg5zzLWru8VShGpTrjQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4eXlxZUN6OGpmdlZZeHgw
+        YzR6NHZxakl6bEZYR244VjluUHlkQmdlOEVFClg4amk4NDA3cmJkUFlIdjFZdU1u
+        ZnVoSmp2c3h5eU9VdHA1dTFiMG9zWkEKLS0tIE9CTTc2VlBkK0FLN21QM05CM3lI
+        am9BcUxtZENuT0JERFd2ZzBibUk1N3MKXCUPITSN0ebi/v1FhipYBisQgxgyimz0
+        oND53kc5cc0x85vLsvZi2CnL83aQEv7zhyn4J2rGaWGlmGX7+bvWbQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-04T00:45:11Z"
+  mac: ENC[AES256_GCM,data:ggI2TR/lR2QAO5kV9WWLwein6TqqWn1jtlKNRixjz2nheXA6YZATwyR6UO+Mk91j2Yg8Fm7JwmBCboq9lvFsBGa1zLdo8cH0fy4dWxyXQE+uyR7nI7EnXW6GZMMyg6Sezh9uHdInl1EXNMhEqIM3efb15TUVPmmkmZQGe9iokKE=,iv:Pf95TsNXcJVrsSQqMAbMrrfuLz+xuIK0yku+KXm8LY8=,tag:N3nbaRrS2CLOPzflC20xwg==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
## Summary
This PR corrects the YAML indentation in the `secrets/ci/attic-main-writer.sops.yaml` file to follow consistent formatting standards.

## Changes
- Standardized indentation in the `sops` section from 4 spaces to 2 spaces
- Adjusted all nested keys (`kms`, `gcp_kms`, `azure_kv`, `hc_vault`, `age`, `lastmodified`, `mac`, `pgp`, `unencrypted_suffix`, `version`) to use consistent 2-space indentation
- Updated the `age` recipients and their `enc` values to maintain proper YAML structure with aligned indentation

## Details
The encrypted content and token values remain unchanged; only the whitespace formatting of the YAML structure has been corrected to improve consistency and readability.

https://claude.ai/code/session_01Fs3a6rcGiWovWXYrLP2eva