### PR TITLE
ci: migrate three direct-push workflows to ducktape-automation App

### DIFF
--- a/.github/actions/mint-automation-token/action.yml
+++ b/.github/actions/mint-automation-token/action.yml
@@ -1,0 +1,84 @@
+name: Mint ducktape-automation App token
+description: |
+  Mints a short-lived installation token for the ducktape-automation
+  GitHub App. Use this in workflows that need to push to a branch
+  protected by the main-protection ruleset — `GITHUB_TOKEN`
+  (the github-actions Integration) cannot be a bypass actor on a
+  personal-account repo, but the App is registered as one.
+
+  The repo must already be checked out (the App PEM lives at
+  secrets/ducktape-automation.<date>.private-key.sops.pem).
+
+  Outputs are scoped to the composite action; the PEM does not leak to
+  the parent workflow.
+
+inputs:
+  sops_age_key:
+    description: SOPS age key for decrypting the App PEM (typically secrets.SOPS_AGE_KEY)
+    required: true
+
+outputs:
+  token:
+    description: |
+      Installation token (~1h lifetime). actions/create-github-app-token@v1
+      adds the value to GHA's mask list, so it's redacted as `***` in logs
+      even when expanded into command-line arguments. Don't `echo` or
+      otherwise round-trip it back into a non-masked field.
+    value: ${{ steps.app-token.outputs.token }}
+  app_slug:
+    description: App slug (e.g. "ducktape-automation"); use as `<slug>[bot]` in `git config user.name`.
+    value: ${{ steps.app-token.outputs.app-slug }}
+  user_id:
+    description: Bot user numeric id; use in the noreply email as `<id>+<slug>[bot]@users.noreply.github.com`.
+    value: ${{ steps.user-id.outputs.user_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install sops
+      shell: bash
+      run: |
+        if command -v sops >/dev/null 2>&1; then
+          echo "sops already on PATH: $(sops --version)"
+          exit 0
+        fi
+        SOPS_VERSION="3.9.4"
+        curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o /usr/local/bin/sops
+        chmod +x /usr/local/bin/sops
+        sops --version
+
+    - name: Decrypt App PEM
+      id: pem
+      shell: bash
+      env:
+        SOPS_AGE_KEY: ${{ inputs.sops_age_key }}
+      run: |
+        set -euo pipefail
+        PEM=$(sops -d secrets/ducktape-automation.2026-05-03.private-key.sops.pem)
+        # Mask the PEM line-by-line so it never appears in any subsequent
+        # step's logs even if the workflow runs `set -x`.
+        while IFS= read -r line; do
+          [ -n "$line" ] && echo "::add-mask::$line"
+        done <<<"$PEM"
+        {
+          echo "private_key<<__PEM_EOF__"
+          echo "$PEM"
+          echo "__PEM_EOF__"
+        } >>"$GITHUB_OUTPUT"
+
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: "3590331"
+        private-key: ${{ steps.pem.outputs.private_key }}
+
+    - name: Look up bot user id
+      id: user-id
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+      run: |
+        set -euo pipefail
+        user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+        echo "user_id=${user_id}" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -149,14 +149,10 @@ jobs:
           cache_from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rtl-tcp:buildcache
           cache_to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rtl-tcp:buildcache,mode=max
 
-  # TODO(branch-protection): when the default branch flips to main and
-  # the main ruleset starts gating direct pushes, replace github.token
-  # with an installation token from the ducktape-automation GitHub App
-  # (actions/create-github-app-token) — see
-  # secrets/ducktape_automation.README.md. The App is registered as a
-  # ruleset bypass actor; github-actions can't be on personal-account
-  # repos. The job already pushes to ${GITHUB_REF_NAME} so no devel→main
-  # string change is needed here.
+  # `pin-digests` pushes via the ducktape-automation GitHub App so the commit
+  # bypasses the main-protection ruleset (github-actions can't bypass on
+  # personal-account repos). The GHCR docker login below stays on github.token
+  # — registry auth is unaffected by branch protection.
   pin-digests:
     name: Pin Digests
     needs: [rbe-image, freecad-image]
@@ -166,6 +162,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+
+      - uses: ./.github/actions/mint-automation-token
+        id: app
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
       - uses: ./.github/actions/setup-nix-devtools
         with:
@@ -192,9 +193,13 @@ jobs:
           python3 devinfra/update_image_pin.py freecad_test --digest "$DIGEST"
 
       - name: Commit and push
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          APP_SLUG: ${{ steps.app.outputs.app_slug }}
+          APP_USER_ID: ${{ steps.app.outputs.user_id }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           git add devinfra/image_pins.json devinfra/bbr.json
 
@@ -221,4 +226,7 @@ jobs:
             exit 1
           fi
 
-          git push origin "HEAD:${BRANCH}"
+          # Override actions/checkout's url-specific extraheader with the
+          # App installation token so the push is App-attributed.
+          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
+            push origin "HEAD:${BRANCH}"

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -2,14 +2,9 @@
 # CI-released inputs (ducktape-wheel, claude-hooks-wheel, etc.) are updated
 # automatically by the release.yml update-downstream job.
 #
-# TODO(branch-protection): when the default branch flips to main and the
-# main ruleset starts gating direct pushes, replace GITHUB_TOKEN with an
-# installation token from the ducktape-automation GitHub App
-# (actions/create-github-app-token) — see
-# secrets/ducktape_automation.README.md. The App is registered as a
-# ruleset bypass actor; github-actions can't be on personal-account
-# repos. Workflow already takes ${{ github.ref_name }} so no devel→main
-# string change is needed here.
+# Pushes via the ducktape-automation GitHub App so the commit bypasses the
+# main-protection ruleset (github-actions can't bypass on personal-account
+# repos).
 name: Update Nix flake inputs
 
 on:
@@ -29,15 +24,24 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
+      - uses: ./.github/actions/mint-automation-token
+        id: app
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
       - name: Update inputs and push
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          APP_SLUG: ${{ steps.app.outputs.app_slug }}
+          APP_USER_ID: ${{ steps.app.outputs.user_id }}
         run: |
           set -x
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
           BRANCH="${{ github.ref_name }}"
 
@@ -58,4 +62,11 @@ jobs:
             exit 1
           fi
 
-          git push origin "HEAD:${BRANCH}"
+          # Disable xtrace before the push so the token doesn't get
+          # printed verbatim in the trace. (GHA masks tokens registered via
+          # ::add-mask::, but disabling xtrace here is belt-and-braces.)
+          set +x
+          # Override actions/checkout's url-specific extraheader with the
+          # App installation token so the push is App-attributed.
+          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
+            push origin "HEAD:${BRANCH}"

--- a/.github/workflows/sync-pins.yml
+++ b/.github/workflows/sync-pins.yml
@@ -3,14 +3,10 @@ name: Sync artifact pins
 # Replaces per-commit dispatch from bb_release.py — one commit per cycle
 # regardless of how many releases landed since the last sync.
 #
-# TODO(branch-protection): switch hardcoded `devel` (ref + push target)
-# to `main` when the default branch flips, and replace
-# secrets.GITHUB_TOKEN with an installation token minted from the
-# ducktape-automation GitHub App (actions/create-github-app-token) —
-# see secrets/ducktape_automation.README.md. Required because
-# github-actions can't be a ruleset bypass actor on personal-account
-# repos, so once main is gated this workflow's direct push will fail
-# until it pushes as the App.
+# Pushes via the ducktape-automation GitHub App so the commit is bypass-actor
+# eligible for the main-protection ruleset (github-actions can't bypass on
+# personal-account repos). The hardcoded `devel` ref + push target will need
+# to flip to `main` when ducktape's default branch flips.
 "on":
   schedule:
     # GitHub throttles scheduled workflows to ~30 min intervals regardless of cron.
@@ -30,18 +26,26 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: devel
-          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/mint-automation-token
+        id: app
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
       - name: Sync pins with latest releases
         id: sync
         run: pip install uv && uv run devinfra/ci/sync_pins.py
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
 
       - name: Commit and push if changed
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          APP_SLUG: ${{ steps.app.outputs.app_slug }}
+          APP_USER_ID: ${{ steps.app.outputs.user_id }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add npins/sources.json
           if git diff --cached --quiet; then
             echo "No pin changes"
@@ -49,4 +53,7 @@ jobs:
           fi
           git commit -m "chore: sync artifact pins (${{ steps.sync.outputs.updated }})"
           git pull --rebase origin devel
-          git push origin "HEAD:devel"
+          # Override actions/checkout's url-specific extraheader with the
+          # App installation token so the push is App-attributed.
+          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
+            push origin "HEAD:devel"

--- a/secrets/ci/attic-gaffer-writer.sops.yaml
+++ b/secrets/ci/attic-gaffer-writer.sops.yaml
@@ -1,31 +1,31 @@
 expires_unencrypted: "2027-05-04T06:55:10Z"
 attic_token: ENC[AES256_GCM,data:TZm30cHFfDfJd2jORo8EVCbht5SvNkSvkuhWTn4fygIxm3DITT87nhIoF8T/4ieqzBCRp4zLpK6IkB0hYAFoUQXcK8wT7XQcPRHF54+Y2AYbJMcasdi1qPbgBeZlh8Y9zoPXtLOF0jGH6BDInG5pVUVkV4LCQ/22gx95JRtxU39K+3n2bzwT3ToEcR2FcF5Zybw7AKtPPJv+mAMEbROAUKZfEtSYh3cQeBouSXEXHrVdKgUoSlt5MgBhaZ5Q9nNcHGdSXgIr9Kmy9tLOXBt2H2f2SEMTVZd8tb3uBdJ+KWb2XZg+Tu63Y1q03A==,iv:R+T8nWpYRmJj5Uw56gmpqOlOtnUaOrAz8ncLhLGFt34=,tag:dkw+AFgwlL8RmH42NiRSxw==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSanBZeWpUWGZRaytTNmF6
-            d2FjNFZJTmdwUFRpeklEOHNYNno5Ykd6ZlMwCklsNHJKNFVRYW1mVnVKVHR1RzB3
-            UE9GUmtNNVJPbEpBUTh6cHNvQ3lrS1kKLS0tIDFhOHhwcVlGYXVVdk5xb3FDZ0NS
-            bFpLMTlra3d6VmtzQURhcXdVZUZ6QUkK0W8zYftH+Gmy+GQEyl1hJ5fAYBjSp5EL
-            1cL8rgg1xyYVUtNonGUDxwtg6uw11RZCIT61ELxvyWFQZAIn746FUg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRk9rYXNsampoWXNlTllN
-            cFZERStPL25MbWxkd3hjZ1FaS3djZWwwUEZFCkJmNUlsVm03aWVKb2Z2Vm1aN2dJ
-            UWxYQjlGbUFKejQydEVLVC9ybWd3ck0KLS0tIGpuRk5jMGZmVlRoR0VReTRrWUFk
-            cHkzZnBQNWVxUlN5ZllSL08rZ2NRWjgKTy5ItlFn+lKGJj/YsXKSrN60Al8mhA8f
-            sxXKGM8Ju6KLdvatscSAc3g+wfBmqUX3I4oAJmbh6TSmE3Znjq08qw==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-04T00:55:10Z"
-    mac: ENC[AES256_GCM,data:guGDIjFd6c0i0OJuOyEqC92xzZx2F3k4PujogtkNEuELgGH2vGYJxVOCKjyutiHbvYoaMFogBaagW12CGSiI/bcVNgdFpw5oSo90aX1vA9gDGQBNxzMaz04g19ptwkM0z9LREX2zLsa/zozjEnblu/N+XX6wVB0qVmFZsta1mqU=,iv:0wpZOjetKjs+HloWAOcZZJQlL5FIofPr2XUNmABca8A=,tag:b1xdJyR5hP1K9u0j2AYyFA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSanBZeWpUWGZRaytTNmF6
+        d2FjNFZJTmdwUFRpeklEOHNYNno5Ykd6ZlMwCklsNHJKNFVRYW1mVnVKVHR1RzB3
+        UE9GUmtNNVJPbEpBUTh6cHNvQ3lrS1kKLS0tIDFhOHhwcVlGYXVVdk5xb3FDZ0NS
+        bFpLMTlra3d6VmtzQURhcXdVZUZ6QUkK0W8zYftH+Gmy+GQEyl1hJ5fAYBjSp5EL
+        1cL8rgg1xyYVUtNonGUDxwtg6uw11RZCIT61ELxvyWFQZAIn746FUg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRk9rYXNsampoWXNlTllN
+        cFZERStPL25MbWxkd3hjZ1FaS3djZWwwUEZFCkJmNUlsVm03aWVKb2Z2Vm1aN2dJ
+        UWxYQjlGbUFKejQydEVLVC9ybWd3ck0KLS0tIGpuRk5jMGZmVlRoR0VReTRrWUFk
+        cHkzZnBQNWVxUlN5ZllSL08rZ2NRWjgKTy5ItlFn+lKGJj/YsXKSrN60Al8mhA8f
+        sxXKGM8Ju6KLdvatscSAc3g+wfBmqUX3I4oAJmbh6TSmE3Znjq08qw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-04T00:55:10Z"
+  mac: ENC[AES256_GCM,data:guGDIjFd6c0i0OJuOyEqC92xzZx2F3k4PujogtkNEuELgGH2vGYJxVOCKjyutiHbvYoaMFogBaagW12CGSiI/bcVNgdFpw5oSo90aX1vA9gDGQBNxzMaz04g19ptwkM0z9LREX2zLsa/zozjEnblu/N+XX6wVB0qVmFZsta1mqU=,iv:0wpZOjetKjs+HloWAOcZZJQlL5FIofPr2XUNmABca8A=,tag:b1xdJyR5hP1K9u0j2AYyFA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/hosts/wyrm2-attic.yaml
+++ b/secrets/hosts/wyrm2-attic.yaml
@@ -1,40 +1,40 @@
 expires_unencrypted: "2027-05-04T07:25:10Z"
 attic_token: ENC[AES256_GCM,data:Ara+DW9nGIxqD7d6KvMZDYPuxxrD6T25XWIuDWJ2ZqgjbRqRVOMa4mfC7opLj9rS91QIx9Ncw38IIF205waUng1SlPeTl2j+wTgkGYVNbUOS4BWXyAr8ppop4hXg/pu8X0cAWYqEFlfb0KtObyrqaRPMPU0OjKruETfLv2/CGfUHSlmt6qoFPg4A1pqB9rB5zs4DNUPzNujK7jy9vaWAYjFdBVhs3qnoPNpiSbvAIOb+jUyWHc78O5jGvLWOMEmaBdAdN3xkHvoMzq7JNsA+GwbYQ0+eetJXqMw80QRAlVaXMFkZMV+Ek3JSGbVa31uagw==,iv:6bX/FJtYRDFEnxN5OuHlpc5AiHwW/uAG68XeolVLpB8=,tag:Ih0ZB5+DYes6nZ1K/txusw==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCdFZkQmZudUVkNmpXNno4
-            My9MVHhIekNBZnVYbnVTSG8yZTJoSGNUZmhZCkpuWmNOemNjOFFCUmNJbkdMMm1q
-            dzROWU5Rd2UwdEdIVlMyYzFjb05LZTAKLS0tIDJ6eWRTaVdGYksvSVVSOWZ2OG1X
-            MHVqa0lDOTN2MTBXTDFLOXVib2gxQWcKpmYd5hkhhtZ5lQSeEmCi+BCt0y5jVBG8
-            hasjohT0zlunaHqmhAZjghg6ecuD/XVo1P1Ljsi1prg2fn4HzDLucA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPWVFvQ2RVckNNdTV6dzcz
-            SEg1TjV5MUJieEt5eDQzRkRURitYUVZ4c1FvCk1PZC9OWWJ0N2duTzdtN0Jzamhw
-            cGthdExUVGIvcWEySUhIZDNGK3g4U3MKLS0tIExQU3ZTRTB0elpVNEhUZ1JJVTRJ
-            dEpqQ1NjOUFZMWRrYnczd2ovZVVNaDQKLDvbF85aAJejpNL/i+QuohsSWVARaX8F
-            dJBVcYXoeY3pci+fQuSFmZc7mSAaZvOyDANqHDeITp6NKCqC4r7Jng==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhM3pHdW9acVpVL1JSbDc4
-            Q2JCSjZVZ2hCcDE5TlRwSzBSWnJXT1gzTzJJClJUL2FTQXVlZVd5bjNqcEZFNDBE
-            bWdVU21QTWdNV0U3RUEwVFpiNnhOa3MKLS0tIFg4VTcyVnZTRkEzOENZNUhrci9O
-            THdVQ0FBMUNzUHg5aDFyR00yRjV1VkkKnCgdJ4oeyJoEecZftCGT5gek2WpDSTg0
-            JTr7aDFmMxNsZcg4ErKhADFtcgiOweN9FM1TcPekXsDIGkktBAMOTg==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-04T01:25:10Z"
-    mac: ENC[AES256_GCM,data:5W7jzUO1JPzk1/CkCCZIIhGWSvTPRpaF04oX0q3OMmCv9qfnjguZ4pyoFbDS6vMK/vdh0wG8C8NMcPiWKOJA4uvO7fxmMY5GnuHzK+No4+b+8m+TuGFAhFEJaEUGBznf3a9ORCKtB6ySoVfA4Q8WAbNByxU4Z0VJcjeKReoaeEs=,iv:wKIwEDv+n0dILqKrlXMnjbBwbdUuj7rLamaSubUSIUg=,tag:jvZTQHiXF/Eb50QwoMiFRw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCdFZkQmZudUVkNmpXNno4
+        My9MVHhIekNBZnVYbnVTSG8yZTJoSGNUZmhZCkpuWmNOemNjOFFCUmNJbkdMMm1q
+        dzROWU5Rd2UwdEdIVlMyYzFjb05LZTAKLS0tIDJ6eWRTaVdGYksvSVVSOWZ2OG1X
+        MHVqa0lDOTN2MTBXTDFLOXVib2gxQWcKpmYd5hkhhtZ5lQSeEmCi+BCt0y5jVBG8
+        hasjohT0zlunaHqmhAZjghg6ecuD/XVo1P1Ljsi1prg2fn4HzDLucA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPWVFvQ2RVckNNdTV6dzcz
+        SEg1TjV5MUJieEt5eDQzRkRURitYUVZ4c1FvCk1PZC9OWWJ0N2duTzdtN0Jzamhw
+        cGthdExUVGIvcWEySUhIZDNGK3g4U3MKLS0tIExQU3ZTRTB0elpVNEhUZ1JJVTRJ
+        dEpqQ1NjOUFZMWRrYnczd2ovZVVNaDQKLDvbF85aAJejpNL/i+QuohsSWVARaX8F
+        dJBVcYXoeY3pci+fQuSFmZc7mSAaZvOyDANqHDeITp6NKCqC4r7Jng==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhM3pHdW9acVpVL1JSbDc4
+        Q2JCSjZVZ2hCcDE5TlRwSzBSWnJXT1gzTzJJClJUL2FTQXVlZVd5bjNqcEZFNDBE
+        bWdVU21QTWdNV0U3RUEwVFpiNnhOa3MKLS0tIFg4VTcyVnZTRkEzOENZNUhrci9O
+        THdVQ0FBMUNzUHg5aDFyR00yRjV1VkkKnCgdJ4oeyJoEecZftCGT5gek2WpDSTg0
+        JTr7aDFmMxNsZcg4ErKhADFtcgiOweN9FM1TcPekXsDIGkktBAMOTg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-04T01:25:10Z"
+  mac: ENC[AES256_GCM,data:5W7jzUO1JPzk1/CkCCZIIhGWSvTPRpaF04oX0q3OMmCv9qfnjguZ4pyoFbDS6vMK/vdh0wG8C8NMcPiWKOJA4uvO7fxmMY5GnuHzK+No4+b+8m+TuGFAhFEJaEUGBznf3a9ORCKtB6ySoVfA4Q8WAbNByxU4Z0VJcjeKReoaeEs=,iv:wKIwEDv+n0dILqKrlXMnjbBwbdUuj7rLamaSubUSIUg=,tag:jvZTQHiXF/Eb50QwoMiFRw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
## Summary

Adds a composite action `.github/actions/mint-automation-token` and
migrates the three direct-push GHA workflows to use it instead of
`GITHUB_TOKEN` for git pushes. After this lands, the ducktape ruleset
target can be extended to also cover `refs/heads/devel` without
breaking these workflows.

## Composite action

Decrypts the App PEM from `secrets/ducktape-automation.<date>.private-key.sops.pem`
using the CI age key (`secrets.SOPS_AGE_KEY`), mints a short-lived
installation token via `actions/create-github-app-token@v1`, and looks
up the bot's user id so callers can construct the canonical
`<user_id>+<app_slug>[bot]@users.noreply.github.com` author email.

Outputs: `token`, `app_slug`, `user_id`. The PEM is masked line-by-line
before going through `$GITHUB_OUTPUT` so it doesn't appear in any
downstream step's logs even with `set -x`.

## Workflow changes

| Workflow | Pushes to | Cadence |
| --- | --- | --- |
| `sync-pins.yml` | hardcoded `devel` | every 30 min |
| `nix-flake-update.yml` | `${{ github.ref_name }}` | manual |
| `container-images.yml` (`pin-digests`) | `${{ github.ref_name }}` | on image push |

Each migrated to:

1. Drop the inline TODO comment about the migration.
2. Call `./.github/actions/mint-automation-token` after the initial
   checkout (the PEM lives in the repo, so checkout has to come first).
3. Author commits as `<app_slug>[bot]` with the proper noreply email so
   the contribution graph reflects App attribution.
4. Push via `git -c http.https://github.com/.extraheader=Authorization:
   Bearer ${APP_TOKEN}` — overrides the URL-specific extraheader that
   `actions/checkout` sets for `github.token`, scoped to the single push
   command.

`container-images.yml`'s GHCR `docker/login-action` keeps using
`github.token` — registry auth is unaffected by branch protection.

Permissions blocks intentionally left at `contents: write` even though
`GITHUB_TOKEN` no longer writes; tightening those is a separate cleanup.

## Test plan

- [ ] On this PR's first run, the workflows triggered by the PR (none of
      these three are PR-triggered) won't exercise the change. The real
      verification happens after merge — `sync-pins.yml`'s next 30-min
      tick should commit-and-push as `ducktape-automation[bot]`.
- [ ] After merge: confirm the next sync-pins commit on `devel` is
      authored by `ducktape-automation[bot]`. If not, the App-token push
      path didn't take effect — easiest revert is reverting this PR;
      Flux's image automation is unaffected.
- [ ] Manual: trigger `nix-flake-update.yml` workflow_dispatch and
      verify the resulting commit (if any) is App-authored.

## Follow-up

After verification is clean, a one-line PR extends
`tf/gitops/github-branch-protection/main.tf`'s ducktape ruleset
`ref_name.include` from `["refs/heads/main"]` to
`["refs/heads/main", "refs/heads/devel"]` to actually gate `devel`.

https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4uk4XKJrp54LUaACNfkU)_