### PR TITLE
debundle: write cycle evidence as side output; bail with compact summary

### DIFF
--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -19,7 +19,7 @@ use artifact::{
 use js_ast::{ParsedJsModule, set_str_value, str_value};
 use schedule_validator::{
     BindingKind, BindingName, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
-    Schedule, analyze_chunk_facts, find_top_level_await,
+    Schedule, analyze_chunk_facts, find_top_level_await, render_cycle_summary,
 };
 
 const LOWERING_FILE_PRAGMA: &str =
@@ -359,14 +359,25 @@ pub fn materialize_logical_modules(
         let schedule_report = schedule.validate();
 
         // Hard gate: a cyclic spec is unrealizable; refuse to emit
-        // instead of producing a runtime-broken bundle. Cycles are
-        // reported with the responsible (statement, binding) pairs
-        // so the spec author can locate and break each cycle.
+        // instead of producing a runtime-broken bundle. The full
+        // cycle evidence is written as `<chunk_id>.cycles.json` for
+        // downstream tooling; stderr gets a compact summary so the
+        // bail message stays under the typical CI log-tail
+        // threshold (Bazel truncates at ~1 MiB by default).
         if !schedule_report.cycles.is_empty() {
-            let serialized = serde_json::to_string_pretty(&schedule_report.cycles)
-                .unwrap_or_else(|_| "<failed to serialize cycles>".to_string());
+            if let Some(report_out_dir) = &report_out_dir {
+                let cycles_path = report_out_dir.join(format!("{chunk_id}.cycles.json"));
+                if let Some(parent) = cycles_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(
+                    &cycles_path,
+                    serde_json::to_string_pretty(&schedule_report.cycles)? + "\n",
+                )?;
+            }
+            let summary = render_cycle_summary(&schedule_report.cycles);
             bail!(
-                "materialize_logical_modules: chunk {chunk_id} has {} cycle(s) in the at-init module dep graph; spec is unrealizable. Resolve by colocating cyclically-coupled bindings or making the offending reads lazy. Cycle evidence:\n{serialized}",
+                "materialize_logical_modules: chunk {chunk_id} has {} cycle(s) in the imports + side-effect module dep graph; spec is unrealizable. Resolve by colocating cyclically-coupled bindings or making the offending reads lazy. Full cycle evidence written to <reports>/{chunk_id}.cycles.json. Summary:\n{summary}",
                 schedule_report.cycles.len(),
             );
         }

--- a/devinfra/js/debundle/schedule_validator.rs
+++ b/devinfra/js/debundle/schedule_validator.rs
@@ -1956,6 +1956,70 @@ pub enum RecommendationReadKind {
     LazyOnly,
 }
 
+/// Render a compact human-readable summary of cycle reports for the
+/// bail message. The full per-cycle evidence + cut goes to a side-
+/// output file (`<chunk_id>.cycles.json`); the summary stays under
+/// the typical CI log-tail threshold so the bail-message version
+/// fits in stderr without truncation.
+///
+/// Per cycle, the summary lists:
+/// - SCC size (modules) and total evidence-edge count.
+/// - Top-5 modules by in-degree within the SCC — these are the
+///   hubs whose incoming edges drive most of the cycle weight.
+/// - Top-5 cut edges by reason count — the highest-leverage
+///   `(from, to)` pairs to break.
+/// - Cut total size (number of constraining reasons selected by
+///   the FAS heuristic).
+pub fn render_cycle_summary(cycles: &[CycleReport]) -> String {
+    use std::collections::HashMap;
+    let mut out = String::new();
+    for (i, cycle) in cycles.iter().enumerate() {
+        let mut in_degree: HashMap<&str, usize> = HashMap::new();
+        for edge in &cycle.evidence {
+            *in_degree.entry(edge.to.as_str()).or_insert(0) += 1;
+        }
+        let mut top_in: Vec<(&str, usize)> = in_degree.into_iter().collect();
+        top_in.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+        top_in.truncate(5);
+
+        let mut cut_pairs: HashMap<(&str, &str), usize> = HashMap::new();
+        for edge in &cycle.cut {
+            *cut_pairs
+                .entry((edge.from.as_str(), edge.to.as_str()))
+                .or_insert(0) += 1;
+        }
+        let mut top_cut: Vec<((&str, &str), usize)> = cut_pairs.into_iter().collect();
+        top_cut.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        top_cut.truncate(5);
+
+        out.push_str(&format!(
+            "Cycle #{i}: {} modules, {} evidence edges, cut {} reasons across {} (from, to) pairs.\n",
+            cycle.modules.len(),
+            cycle.evidence.len(),
+            cycle.cut.len(),
+            cut_pairs_count(&cycle.cut),
+        ));
+        out.push_str("  Top in-degree hubs (incoming evidence edges):\n");
+        for (m, n) in &top_in {
+            out.push_str(&format!("    {n:>6}  {m}\n"));
+        }
+        out.push_str("  Top cut edges (R/S reasons to break):\n");
+        for ((f, t), n) in &top_cut {
+            out.push_str(&format!("    {n:>6}  {f}  ->  {t}\n"));
+        }
+    }
+    out
+}
+
+fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
+    use std::collections::HashSet;
+    let mut seen: HashSet<(&str, &str)> = HashSet::new();
+    for edge in cut {
+        seen.insert((edge.from.as_str(), edge.to.as_str()));
+    }
+    seen.len()
+}
+
 /// Find SCCs in the dep graph and produce a report listing every
 /// non-trivial cycle (size > 1 OR a self-loop). Trivial single-node
 /// non-self-loop SCCs are dropped.


### PR DESCRIPTION
## Summary

When `materialize_logical_modules` rejects for cycle violations, the full cycles JSON moves from the bail message to a side-output file `<chunk_id>.cycles.json` (alongside the existing `<chunk_id>.schedule.json`). The bail message now carries a compact human-readable summary that fits within typical CI log-tail thresholds.

## Motivation

The previous unstructured JSON in stderr was **~10 MiB on production-sized chunks** (Tana's 260-module SCC produces 28k evidence edges + 10k cut reasons in pretty-printed JSON). Bazel truncates stderr at ~1 MiB by default, so spec authors saw a clipped JSON they couldn't parse. Even when un-truncated (e.g., reading the action's stderr file directly from the bazel cache), 10 MiB of pretty-printed JSON is the wrong shape for "what's the high-leverage edge to cut?"

## What you see now

Per cycle, the bail-message summary lists:

- SCC size (modules) and total evidence-edge count
- **Top-5 modules by in-degree** within the SCC — the hubs whose incoming edges drive most of the cycle weight
- **Top-5 cut edges by reason count** — the highest-leverage `(from, to)` pairs to break
- Cut total size (R/S reasons selected by the FAS heuristic) and number of unique `(from, to)` pairs

Example summary on the Tana spec:

```
materialize_logical_modules: chunk static/index-DI2GynTv has 1 cycle(s) ...
Full cycle evidence written to <reports>/static/index-DI2GynTv.cycles.json. Summary:
Cycle #0: 259 modules, 28359 evidence edges, cut 10094 reasons across 9091 (from, to) pairs.
  Top in-degree hubs (incoming evidence edges):
       3061  logical__static_index_DI2GynTv__ai_mcp_prompting_runtime
       2434  logical__static_index_DI2GynTv__runtime_app_state_search_commands_core
        664  logical__static_index_DI2GynTv__graph_core_node_model
        ...
  Top cut edges (R/S reasons to break):
        377  ...runtime_app_state_search_commands_core  ->  ...commands_framework_definition
        153  ...ui_navigation_node                       ->  ...runtime_app_state_search_commands_core
        ...
```

## Side output

`<chunk_id>.cycles.json` contains the full per-edge evidence + cut detail, same shape as before, just on disk instead of stderr. Downstream tooling (cycle visualizers, spec-author triage scripts, CI annotations) reads from there.

## Tests

15/15 existing debundle tests pass. No behavior change on the acceptance path; this is rejection-path output formatting only.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` passes (15/15).
- [ ] Downstream gaffer-private repins to this commit; the cycle bail in CI is human-skimmable.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01382gXVcqreESnGFw3MGgxq)

---
_Generated by [Claude Code](https://claude.ai/code/session_01382gXVcqreESnGFw3MGgxq)_