### PR TITLE
Refactor spec parsing to use typed structs instead of JSON values

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -388,6 +388,23 @@ The spec configures them via a top-level `inputs: { inputRoot, jsListPath }`
 object. Listing any of these three operations as a pipeline stage is a hard
 error.
 
+## Spec-level declarative sections
+
+The spec carries three declarative top-level maps. There is no `operations[]`
+array; pipeline stages read these maps directly via typed serde structs in
+<spec.rs>.
+
+- `vendor` — keyed by chunk path (`"static/lib.js"` → `VendorMark`). The
+  `level` discriminator selects between `suppress` / `boundary-rename` /
+  `swap`; only `swap` requires `package`/`version`/`subpath` (parse-time
+  guarantee via the `VendorLevel::Swap` enum variant). Map-key uniqueness
+  makes "two entries target the same chunk path" unrepresentable.
+- `logicalModules` — keyed by chunk id, then target path (`"static/app"` →
+  `"foo/bar/baz.js"` → `LogicalModule`). Two-level nesting makes
+  `(chunkId, targetPath)` uniqueness a parser property.
+- `residualModules` — keyed by chunk id (`"static/app"` → `ResidualModule`).
+  The map shape encodes the "at most one residual per chunk" invariant.
+
 ## Materialize logical-modules `targetDir`
 
 `materialize_logical_modules` accepts an optional `targetDir`. Absent or

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -68,6 +68,17 @@ rust_library(
 )
 
 rust_library(
+    name = "spec",
+    srcs = ["spec.rs"],
+    crate_root = "spec.rs",
+    edition = "2024",
+    deps = [
+        "@crates//:serde",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_library(
     name = "vendor",
     srcs = ["vendor.rs"],
     crate_root = "vendor.rs",
@@ -75,7 +86,9 @@ rust_library(
     deps = [
         ":artifact",
         ":js_ast",
+        ":spec",
         "@crates//:anyhow",
+        "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:swc_common",
         "@crates//:swc_ecma_ast",
@@ -131,6 +144,7 @@ rust_library(
         ":artifact",
         ":js_ast",
         ":schedule_validator",
+        ":spec",
         ":write_tree",
         "@crates//:anyhow",
         "@crates//:serde",
@@ -202,6 +216,7 @@ rust_library(
         ":normalize",
         ":rewrite_specifiers",
         ":scrambled_id_frequencies",
+        ":spec",
         ":vendor",
         ":write_tree",
         "@crates//:anyhow",

--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -1253,9 +1253,9 @@ The pipeline is a sequence of stages over a shared `JsPipelineArtifact`:
 | Stage                            | Module                                         | Role                                                                                                                  |
 | -------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `compute_chunk_metadata`         | <program_analysis.rs>                          | Parse chunks; record top-level decls, imports, side effects, observable module effects. Pure, no spec.                |
-| `apply_vendor_annotations`       | <vendor.rs>                                    | Mark vendor packages per `mark_vendor` ops.                                                                           |
-| `rename_vendor_exports`          | <vendor.rs>                                    | Rewrite vendor symbol exports per `rename_vendor_symbols`.                                                            |
-| `swap_vendor_chunks`             | <vendor.rs>                                    | Substitute vendor chunks with package resolves.                                                                       |
+| `apply_vendor_annotations`       | <vendor.rs>                                    | Mark vendor packages from the spec's top-level `vendor` map (keyed by chunk path).                                    |
+| `rename_vendor_exports`          | <vendor.rs>                                    | Rewrite vendor symbol exports for `vendor` entries with `level: boundary-rename` or `level: swap`.                    |
+| `swap_vendor_chunks`             | <vendor.rs>                                    | Substitute vendor chunks with package resolves for `vendor` entries with `level: swap`.                               |
 | `materialize_logical_modules`    | <logical_modules.rs> + <schedule_validator.rs> | **Main split.** Computes per-statement facts, applies spec, builds `I ∪ S`, validates, emits modules in source order. |
 | `rewrite_chunk_entry_specifiers` | <rewrite_specifiers.rs>                        | Rewrite cross-chunk import paths to be relative to chunk entries.                                                     |
 | `write_js_tree`                  | <write_tree.rs>                                | Persist the artifact to disk.                                                                                         |
@@ -1287,9 +1287,9 @@ A spec entry that ends up with zero owned bindings (after
 closure) and no re-exports comes out as an effectively-empty
 file. Either:
 
-- The spec author wrote a `define_logical_module` whose explicit
-  members all turned out to be names that don't exist in the
-  chunk (typo, stale spec). The validator surfaces a
+- The spec author wrote a `logicalModules[chunkId][targetPath]`
+  entry whose explicit members all turned out to be names that
+  don't exist in the chunk (typo, stale spec). The validator surfaces a
   `MissingMember` warning per name; emit proceeds with whatever
   _did_ resolve.
 - All listed members are `Imported` bindings with no `Owned`

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -60,9 +60,9 @@ spec runs. Concretely:
   geometry helper, a state slice). Goal: prove the materialiser
   recovers approximately the right symbols/files from a real
   scrambled bundle.
-- A small set of `define_logical_module` rename operations on
-  identifiers visible in the compiled output. Goal: exercise the
-  rename pipeline at realistic aggressiveness.
+- A small set of `logicalModules` rename entries on identifiers
+  visible in the compiled output. Goal: exercise the rename pipeline
+  at realistic aggressiveness.
 - `rewrite_chunk_entry_specifiers` + `emit_browser_harness` so the
   output is a runnable app the live proxy can serve.
 
@@ -108,7 +108,7 @@ public-CI signal and the public-bug-report leverage.
 
 ## Propagate readable rename across consumers
 
-When `define_logical_module` renames a scrambled binding `<scrambled>`
+When a `logicalModules` entry renames a scrambled binding `<scrambled>`
 to readable `<readable>`, the consumer-side import is currently
 emitted as `import { <readable> as <scrambled> } from "..."` and every
 reference in the consumer body still spells the original scrambled

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -15,7 +15,6 @@ pub struct JsPipelineArtifact {
     pub chunks: BTreeMap<String, JsChunk>,
     pub root_manifest: Option<ArtifactManifest>,
     pub chunk_manifests: BTreeMap<String, ChunkManifest>,
-    pub vendor_annotations: BTreeMap<String, serde_json::Value>,
 }
 
 pub struct JsChunk {

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -114,28 +114,20 @@ console.log(aH);
 export { aH };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_a",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_a" },
-                "members": [{
-                    "id": "member__readableA",
-                    "name": "readableA",
-                    "selector": { "binding": { "name": "aH" } },
-                }],
-            }),
-            json!({
-                "id": "logical__mod_b",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_b" },
-                "members": [{
-                    "id": "member__plainAh",
-                    "name": "plainAh",
-                    "selector": { "binding": { "name": "aH" } },
-                }],
-            }),
+            (
+                "mod_a".to_string(),
+                json!({
+                    "id": "logical__mod_a",
+                    "members": [{ "name": "readableA", "selector": { "binding": { "name": "aH" } } }],
+                }),
+            ),
+            (
+                "mod_b".to_string(),
+                json!({
+                    "id": "logical__mod_b",
+                    "members": [{ "name": "plainAh", "selector": { "binding": { "name": "aH" } } }],
+                }),
+            ),
         ],
     );
     let fixture = run_logical_modules_e2e_fixture(opts);
@@ -170,17 +162,13 @@ fn keeps_unrelated_consumer_import_locals_unchanged() {
 console.log(aH);
 export { aH };
 "#,
-        vec![json!({
-            "id": "logical__mod_a",
-            "operation": "define_logical_module",
-            "selector": { "chunkId": "static/app" },
-            "target": { "path": "mod_a" },
-            "members": [{
-                "id": "member__readableA",
-                "name": "readableA",
-                "selector": { "binding": { "name": "aH" } },
-            }],
-        })],
+        vec![(
+            "mod_a".to_string(),
+            json!({
+                "id": "logical__mod_a",
+                "members": [{ "name": "readableA", "selector": { "binding": { "name": "aH" } } }],
+            }),
+        )],
     );
     let fixture = run_logical_modules_e2e_fixture(opts);
     let entry = fs::read_to_string(&fixture.entry_path).expect("read entry.js");
@@ -249,19 +237,18 @@ fn import_specifier_member_emits_reimport_in_destination() {
 console.log(a);
 export { a };
 "#,
-        vec![json!({
-            "id": "logical__mod_x",
-            "operation": "define_logical_module",
-            "selector": { "chunkId": "static/app" },
-            "target": { "path": "mod_x" },
-            "members": [{
-                "id": "m_a",
-                "name": "Readable",
-                "selector": {
-                    "binding": { "name": "a", "kind": "ImportSpecifier" },
-                },
-            }],
-        })],
+        vec![(
+            "mod_x".to_string(),
+            json!({
+                "id": "logical__mod_x",
+                "members": [{
+                    "name": "Readable",
+                    "selector": {
+                        "binding": { "name": "a", "kind": "ImportSpecifier" },
+                    },
+                }],
+            }),
+        )],
     );
     opts.extra_files = &[(
         "static/vendor.js",
@@ -296,28 +283,26 @@ console.log(a());
 export { a };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_jsx_runtime",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_jsx_runtime" },
-                "members": [{
-                    "id": "m_jsx_runtime",
-                    "name": "jsxRuntime",
-                    "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
-                }],
-            }),
-            json!({
-                "id": "logical__mod_dunder_jsx",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_dunder_jsx" },
-                "members": [{
-                    "id": "m_dunder_jsx",
-                    "name": "__jsx",
-                    "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
-                }],
-            }),
+            (
+                "mod_jsx_runtime".to_string(),
+                json!({
+                    "id": "logical__mod_jsx_runtime",
+                    "members": [{
+                        "name": "jsxRuntime",
+                        "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
+                    }],
+                }),
+            ),
+            (
+                "mod_dunder_jsx".to_string(),
+                json!({
+                    "id": "logical__mod_dunder_jsx",
+                    "members": [{
+                        "name": "__jsx",
+                        "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
+                    }],
+                }),
+            ),
         ],
     );
     opts.extra_files = &[("static/vendor.js", "export const j = () => 42;\n")];
@@ -353,17 +338,13 @@ function bridge() {
 console.log(bridge()());
 export { bridge };
 "#,
-        vec![json!({
-            "id": "logical__mod_x",
-            "operation": "define_logical_module",
-            "selector": { "chunkId": "static/app" },
-            "target": { "path": "mod_x" },
-            "members": [{
-                "id": "m_bridge",
-                "name": "bridge",
-                "selector": { "binding": { "name": "bridge" } },
-            }],
-        })],
+        vec![(
+            "mod_x".to_string(),
+            json!({
+                "id": "logical__mod_x",
+                "members": [{ "name": "bridge", "selector": { "binding": { "name": "bridge" } } }],
+            }),
+        )],
     );
     opts.extra_files = &[(
         "static/vendor.js",
@@ -407,28 +388,23 @@ console.log(bridge());
 export { bridge };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_a",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_a" },
-                "members": [{
-                    "id": "m_re",
-                    "name": "Re",
-                    "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
-                }],
-            }),
-            json!({
-                "id": "logical__mod_b",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_b" },
-                "members": [{
-                    "id": "m_bridge",
-                    "name": "bridge",
-                    "selector": { "binding": { "name": "bridge" } },
-                }],
-            }),
+            (
+                "mod_a".to_string(),
+                json!({
+                    "id": "logical__mod_a",
+                    "members": [{
+                        "name": "Re",
+                        "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
+                    }],
+                }),
+            ),
+            (
+                "mod_b".to_string(),
+                json!({
+                    "id": "logical__mod_b",
+                    "members": [{ "name": "bridge", "selector": { "binding": { "name": "bridge" } } }],
+                }),
+            ),
         ],
     );
     opts.extra_files = &[("static/app/vendor.js", "export const x = 42;\n")];
@@ -474,28 +450,26 @@ console.log(composed);
 export { composed };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_x",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_x" },
-                "members": [{
-                    "id": "m_composed",
-                    "name": "Composed",
-                    "selector": { "binding": { "name": "composed" } },
-                }],
-            }),
-            json!({
-                "id": "logical__mod_dep",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_dep" },
-                "members": [{
-                    "id": "m_dep",
-                    "name": "Dep",
-                    "selector": { "binding": { "name": "dep", "kind": "ImportSpecifier" } },
-                }],
-            }),
+            (
+                "mod_x".to_string(),
+                json!({
+                    "id": "logical__mod_x",
+                    "members": [{
+                        "name": "Composed",
+                        "selector": { "binding": { "name": "composed" } },
+                    }],
+                }),
+            ),
+            (
+                "mod_dep".to_string(),
+                json!({
+                    "id": "logical__mod_dep",
+                    "members": [{
+                        "name": "Dep",
+                        "selector": { "binding": { "name": "dep", "kind": "ImportSpecifier" } },
+                    }],
+                }),
+            ),
         ],
     );
     opts.extra_files = &[("static/app/vendor.js", "export const dep = 41;\n")];

--- a/devinfra/js/debundle/e2e/missing_binding_member_test.rs
+++ b/devinfra/js/debundle/e2e/missing_binding_member_test.rs
@@ -19,24 +19,16 @@ fn missing_binding_member_does_not_leak_undefined_export() {
 console.log(a());
 export { a };
 "#,
-        vec![json!({
-            "id": "logical__mod_x",
-            "operation": "define_logical_module",
-            "selector": { "chunkId": "static/app" },
-            "target": { "path": "mod_x" },
-            "members": [
-                {
-                    "id": "m_a",
-                    "name": "Foo",
-                    "selector": { "binding": { "name": "a" } },
-                },
-                {
-                    "id": "m_missing",
-                    "name": "Bar",
-                    "selector": { "binding": { "name": "b" } },
-                },
-            ],
-        })],
+        vec![(
+            "mod_x".to_string(),
+            json!({
+                "id": "logical__mod_x",
+                "members": [
+                    { "name": "Foo", "selector": { "binding": { "name": "a" } } },
+                    { "name": "Bar", "selector": { "binding": { "name": "b" } } },
+                ],
+            }),
+        )],
     );
     let fixture = run_logical_modules_e2e_fixture(opts);
     assert_module_exports(

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -374,35 +374,34 @@ console.log(A.handled, B.handled, C.handled);
 export { A, B, C, dispatcher };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_a",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_a" },
-                "members": [
-                    { "id": "m_a", "name": "A", "selector": { "binding": { "name": "A" } } },
-                    { "id": "m_c", "name": "C", "selector": { "binding": { "name": "C" } } },
-                    {
-                        "id": "m_dispatcher",
-                        "name": "dispatcher",
-                        "selector": { "binding": { "name": "dispatcher" } },
-                        // ↓ author asserts: calls to `dispatcher`
-                        //   have no observable side effects. Both
-                        //   call sites in mod_a (A, C) and the
-                        //   one in mod_b (B) drop their `S` edges.
-                        "purity": "pure",
-                    },
-                ],
-            }),
-            json!({
-                "id": "logical__mod_b",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_b" },
-                "members": [
-                    { "id": "m_b", "name": "B", "selector": { "binding": { "name": "B" } } },
-                ],
-            }),
+            (
+                "mod_a".to_string(),
+                json!({
+                    "id": "logical__mod_a",
+                    "members": [
+                        { "name": "A", "selector": { "binding": { "name": "A" } } },
+                        { "name": "C", "selector": { "binding": { "name": "C" } } },
+                        {
+                            "name": "dispatcher",
+                            "selector": { "binding": { "name": "dispatcher" } },
+                            // ↓ author asserts: calls to `dispatcher`
+                            //   have no observable side effects. Both
+                            //   call sites in mod_a (A, C) and the
+                            //   one in mod_b (B) drop their `S` edges.
+                            "purity": "pure",
+                        },
+                    ],
+                }),
+            ),
+            (
+                "mod_b".to_string(),
+                json!({
+                    "id": "logical__mod_b",
+                    "members": [
+                        { "name": "B", "selector": { "binding": { "name": "B" } } },
+                    ],
+                }),
+            ),
         ],
     ));
     assert_entry_output(&fixture, "alpha beta gamma\n");
@@ -426,33 +425,32 @@ console.log(B.ref, D.ref);
 export { A, B, D, wrap };
 "#,
             vec![
-                json!({
-                    "id": "logical__mod_a",
-                    "operation": "define_logical_module",
-                    "selector": { "chunkId": "static/app" },
-                    "target": { "path": "mod_a" },
-                    "members": [
-                        { "id": "m_a", "name": "A", "selector": { "binding": { "name": "A" } } },
-                        { "id": "m_d", "name": "D", "selector": { "binding": { "name": "D" } } },
-                        {
-                            "id": "m_wrap",
-                            "name": "wrap",
-                            "selector": { "binding": { "name": "wrap" } },
-                            // Author asserts purity — `S` edges
-                            // through `wrap(...)` calls go away.
-                            "purity": "pure",
-                        },
-                    ],
-                }),
-                json!({
-                    "id": "logical__mod_b",
-                    "operation": "define_logical_module",
-                    "selector": { "chunkId": "static/app" },
-                    "target": { "path": "mod_b" },
-                    "members": [
-                        { "id": "m_b", "name": "B", "selector": { "binding": { "name": "B" } } },
-                    ],
-                }),
+                (
+                    "mod_a".to_string(),
+                    json!({
+                        "id": "logical__mod_a",
+                        "members": [
+                            { "name": "A", "selector": { "binding": { "name": "A" } } },
+                            { "name": "D", "selector": { "binding": { "name": "D" } } },
+                            {
+                                "name": "wrap",
+                                "selector": { "binding": { "name": "wrap" } },
+                                // Author asserts purity — `S` edges
+                                // through `wrap(...)` calls go away.
+                                "purity": "pure",
+                            },
+                        ],
+                    }),
+                ),
+                (
+                    "mod_b".to_string(),
+                    json!({
+                        "id": "logical__mod_b",
+                        "members": [
+                            { "name": "B", "selector": { "binding": { "name": "B" } } },
+                        ],
+                    }),
+                ),
             ],
         ),
         // R-edge mod_a → mod_b (D's init reads B); R-edge
@@ -488,38 +486,36 @@ console.log(A.val, B.val, C.val);
 export { A, B, C, pureWrap, impureWrap };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_a",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_a" },
-                "members": [
-                    { "id": "m_a", "name": "A", "selector": { "binding": { "name": "A" } } },
-                    { "id": "m_c", "name": "C", "selector": { "binding": { "name": "C" } } },
-                    {
-                        "id": "m_pure_wrap",
-                        "name": "pureWrap",
-                        "selector": { "binding": { "name": "pureWrap" } },
-                        "purity": "pure",
-                    },
-                    {
-                        "id": "m_impure_wrap",
-                        "name": "impureWrap",
-                        "selector": { "binding": { "name": "impureWrap" } },
-                        // No `purity` annotation — default
-                        // (impure) classification applies.
-                    },
-                ],
-            }),
-            json!({
-                "id": "logical__mod_b",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_b" },
-                "members": [
-                    { "id": "m_b", "name": "B", "selector": { "binding": { "name": "B" } } },
-                ],
-            }),
+            (
+                "mod_a".to_string(),
+                json!({
+                    "id": "logical__mod_a",
+                    "members": [
+                        { "name": "A", "selector": { "binding": { "name": "A" } } },
+                        { "name": "C", "selector": { "binding": { "name": "C" } } },
+                        {
+                            "name": "pureWrap",
+                            "selector": { "binding": { "name": "pureWrap" } },
+                            "purity": "pure",
+                        },
+                        {
+                            "name": "impureWrap",
+                            "selector": { "binding": { "name": "impureWrap" } },
+                            // No `purity` annotation — default
+                            // (impure) classification applies.
+                        },
+                    ],
+                }),
+            ),
+            (
+                "mod_b".to_string(),
+                json!({
+                    "id": "logical__mod_b",
+                    "members": [
+                        { "name": "B", "selector": { "binding": { "name": "B" } } },
+                    ],
+                }),
+            ),
         ],
     ));
     assert_entry_output(&fixture, "a b c\n");
@@ -547,37 +543,35 @@ console.log(A.val, B.val, C.val, globalThis.lastWrap);
 export { A, B, C, pureWrap, impureWrap };
 "#,
             vec![
-                json!({
-                    "id": "logical__mod_a",
-                    "operation": "define_logical_module",
-                    "selector": { "chunkId": "static/app" },
-                    "target": { "path": "mod_a" },
-                    "members": [
-                        { "id": "m_a", "name": "A", "selector": { "binding": { "name": "A" } } },
-                        { "id": "m_c", "name": "C", "selector": { "binding": { "name": "C" } } },
-                        {
-                            "id": "m_pure_wrap",
-                            "name": "pureWrap",
-                            "selector": { "binding": { "name": "pureWrap" } },
-                            "purity": "pure",
-                        },
-                        {
-                            "id": "m_impure_wrap",
-                            "name": "impureWrap",
-                            "selector": { "binding": { "name": "impureWrap" } },
-                            // Deliberately unannotated.
-                        },
-                    ],
-                }),
-                json!({
-                    "id": "logical__mod_b",
-                    "operation": "define_logical_module",
-                    "selector": { "chunkId": "static/app" },
-                    "target": { "path": "mod_b" },
-                    "members": [
-                        { "id": "m_b", "name": "B", "selector": { "binding": { "name": "B" } } },
-                    ],
-                }),
+                (
+                    "mod_a".to_string(),
+                    json!({
+                        "id": "logical__mod_a",
+                        "members": [
+                            { "name": "A", "selector": { "binding": { "name": "A" } } },
+                            { "name": "C", "selector": { "binding": { "name": "C" } } },
+                            {
+                                "name": "pureWrap",
+                                "selector": { "binding": { "name": "pureWrap" } },
+                                "purity": "pure",
+                            },
+                            {
+                                "name": "impureWrap",
+                                "selector": { "binding": { "name": "impureWrap" } },
+                                // Deliberately unannotated.
+                            },
+                        ],
+                    }),
+                ),
+                (
+                    "mod_b".to_string(),
+                    json!({
+                        "id": "logical__mod_b",
+                        "members": [
+                            { "name": "B", "selector": { "binding": { "name": "B" } } },
+                        ],
+                    }),
+                ),
             ],
         ),
         &["cycle", "mod_a", "mod_b", "side-effect"],

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -25,26 +25,26 @@ console.log(B.ref, D.ref);
 export { A, B, C, D };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_x",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_x" },
-                "members": [
-                    { "id": "m_a", "name": "A", "selector": { "binding": { "name": "A" } } },
-                    { "id": "m_d", "name": "D", "selector": { "binding": { "name": "D" } } },
-                ],
-            }),
-            json!({
-                "id": "logical__mod_y",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_y" },
-                "members": [
-                    { "id": "m_b", "name": "B", "selector": { "binding": { "name": "B" } } },
-                    { "id": "m_c", "name": "C", "selector": { "binding": { "name": "C" } } },
-                ],
-            }),
+            (
+                "mod_x".to_string(),
+                json!({
+                    "id": "logical__mod_x",
+                    "members": [
+                        { "name": "A", "selector": { "binding": { "name": "A" } } },
+                        { "name": "D", "selector": { "binding": { "name": "D" } } },
+                    ],
+                }),
+            ),
+            (
+                "mod_y".to_string(),
+                json!({
+                    "id": "logical__mod_y",
+                    "members": [
+                        { "name": "B", "selector": { "binding": { "name": "B" } } },
+                        { "name": "C", "selector": { "binding": { "name": "C" } } },
+                    ],
+                }),
+            ),
         ],
     );
     expect_logical_modules_e2e_rejection(opts, &["cycle", "mod_x", "mod_y"]);
@@ -125,27 +125,25 @@ console.log(x1.id, y.id, x2[y.id]);
 export { x1, y, x2 };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_a",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_a" },
-                "members": [
-                    { "id": "m_x1", "name": "x1", "selector": { "binding": { "name": "x1" } } },
-                    { "id": "m_x2", "name": "x2", "selector": { "binding": { "name": "x2" } } },
-                ],
-            }),
-            json!({
-                "id": "logical__mod_b",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_b" },
-                "members": [{
-                    "id": "m_y",
-                    "name": "y",
-                    "selector": { "binding": { "name": "y" } },
-                }],
-            }),
+            (
+                "mod_a".to_string(),
+                json!({
+                    "id": "logical__mod_a",
+                    "members": [
+                        { "name": "x1", "selector": { "binding": { "name": "x1" } } },
+                        { "name": "x2", "selector": { "binding": { "name": "x2" } } },
+                    ],
+                }),
+            ),
+            (
+                "mod_b".to_string(),
+                json!({
+                    "id": "logical__mod_b",
+                    "members": [
+                        { "name": "y", "selector": { "binding": { "name": "y" } } },
+                    ],
+                }),
+            ),
         ],
     ));
     assert_entry_output(&fixture, "x1 k v\n");

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -9,7 +9,6 @@
 //! name.
 
 use debundle_e2e_support::*;
-use serde_json::json;
 
 #[test]
 fn define_residual_module_members_apply_renames() {
@@ -19,23 +18,13 @@ function b() { return 2; }
 console.log(a(), b());
 export { a, b };
 "#,
-        // No `define_logical_module` — every binding stays in residual.
-        // The residual op carries a renaming member entry for `a`. We
-        // construct the residual op explicitly here (instead of letting
-        // `include_residual: true` produce a memberless one).
-        operations: vec![json!({
-            "id": "logical__residual_unhandled",
-            "operation": "define_residual_module",
-            "selector": { "chunkId": "static/app" },
-            "target": { "path": "residual/unhandled" },
-            "members": [
-                {
-                    "id": "rename_a",
-                    "name": "FirstFn",
-                    "selector": { "binding": { "name": "a" } },
-                },
-            ],
-        })],
+        // No logical modules — every binding stays in residual. The
+        // residual carries a renaming member entry for `a`.
+        logical_modules: vec![],
+        residual: Some(residual_module(
+            "residual/unhandled",
+            &[Member::renamed("FirstFn", "a")],
+        )),
         chunk_id: "static/app",
         include_residual: false,
         extra_files: &[],

--- a/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
+++ b/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
@@ -24,28 +24,20 @@ console.log(a, b);
 export { a, b, c };
 "#,
         vec![
-            json!({
-                "id": "logical__mod_x",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_x" },
-                "members": [{
-                    "id": "m_a",
-                    "name": "readableA",
-                    "selector": { "binding": { "name": "a" } },
-                }],
-            }),
-            json!({
-                "id": "logical__mod_y",
-                "operation": "define_logical_module",
-                "selector": { "chunkId": "static/app" },
-                "target": { "path": "mod_y" },
-                "members": [{
-                    "id": "m_c",
-                    "name": "readableC",
-                    "selector": { "binding": { "name": "c" } },
-                }],
-            }),
+            (
+                "mod_x".to_string(),
+                json!({
+                    "id": "logical__mod_x",
+                    "members": [{ "name": "readableA", "selector": { "binding": { "name": "a" } } }],
+                }),
+            ),
+            (
+                "mod_y".to_string(),
+                json!({
+                    "id": "logical__mod_y",
+                    "members": [{ "name": "readableC", "selector": { "binding": { "name": "c" } } }],
+                }),
+            ),
         ],
     );
     let fixture = run_logical_modules_e2e_fixture(opts);

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -26,7 +26,7 @@ const NODE_RLOCATION: &str = "nodejs_linux_amd64/bin/node";
 static MODULE_EXPORT_PROBE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static GENERATED_MODULE_SCRIPT_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-/// One member of a `define_logical_module` request.
+/// One member of a [`LogicalModuleEntry`].
 ///
 /// `name` is the exported name in the materialized module; `binding` is the
 /// original top-level binding to extract. When `binding` is `None`, the
@@ -54,46 +54,74 @@ impl Member {
     }
 }
 
-pub fn logical_module(path: &str, members: &[Member]) -> Value {
+/// One entry of the spec's `logicalModules[chunkId]` map: the target path
+/// (the map key) plus its body (id + members).
+pub type LogicalModuleEntry = (String, Value);
+
+pub fn logical_module(path: &str, members: &[Member]) -> LogicalModuleEntry {
     let id = format!("logical__{}", path.replace('/', "_"));
     let member_values: Vec<Value> = members
         .iter()
         .map(|m| {
             let binding = m.binding.unwrap_or(m.name);
             json!({
-                "id": format!("member__{}", m.name),
+                "name": m.name,
+                "selector": { "binding": { "name": binding } },
+            })
+        })
+        .collect();
+    (
+        path.to_string(),
+        json!({ "id": id, "members": member_values }),
+    )
+}
+
+pub struct FixtureOpts<'a> {
+    pub source: &'a str,
+    pub logical_modules: Vec<LogicalModuleEntry>,
+    /// Replaces the default residual entry for this chunk. When set,
+    /// `include_residual` is ignored. Use the [`residual_module`] helper
+    /// to build typical bodies.
+    pub residual: Option<Value>,
+    pub chunk_id: &'a str,
+    /// When `residual` is `None` and this is `true`, the harness emits an
+    /// empty residual module (`target: "residual/unhandled"`) for this
+    /// chunk so unclaimed bindings still flow somewhere.
+    pub include_residual: bool,
+    pub extra_files: &'a [(&'a str, &'a str)],
+}
+
+impl<'a> FixtureOpts<'a> {
+    pub fn new(source: &'a str, logical_modules: Vec<LogicalModuleEntry>) -> Self {
+        Self {
+            source,
+            logical_modules,
+            residual: None,
+            chunk_id: "static/app",
+            include_residual: true,
+            extra_files: &[],
+        }
+    }
+}
+
+/// Build a `residualModules[chunkId]` body. `members` may contain rename
+/// directives that apply to bindings staying in the residual catch-all.
+pub fn residual_module(target: &str, members: &[Member]) -> Value {
+    let member_values: Vec<Value> = members
+        .iter()
+        .map(|m| {
+            let binding = m.binding.unwrap_or(m.name);
+            json!({
                 "name": m.name,
                 "selector": { "binding": { "name": binding } },
             })
         })
         .collect();
     json!({
-        "id": id,
-        "operation": "define_logical_module",
-        "selector": { "chunkId": "static/app" },
-        "target": { "path": path },
+        "id": "logical__residual_unhandled",
+        "target": target,
         "members": member_values,
     })
-}
-
-pub struct FixtureOpts<'a> {
-    pub source: &'a str,
-    pub operations: Vec<Value>,
-    pub chunk_id: &'a str,
-    pub include_residual: bool,
-    pub extra_files: &'a [(&'a str, &'a str)],
-}
-
-impl<'a> FixtureOpts<'a> {
-    pub fn new(source: &'a str, operations: Vec<Value>) -> Self {
-        Self {
-            source,
-            operations,
-            chunk_id: "static/app",
-            include_residual: true,
-            extra_files: &[],
-        }
-    }
 }
 
 pub struct Fixture {
@@ -109,14 +137,7 @@ pub struct Fixture {
 pub fn run_logical_modules_e2e_fixture(opts: FixtureOpts<'_>) -> Fixture {
     let setup = setup_fixture(&opts);
     let spec_path = setup.out_root.join("transform_spec.jsonc");
-    let spec = build_spec(
-        opts.chunk_id,
-        opts.include_residual,
-        &setup.js_list_path,
-        &opts.operations,
-        &setup.out_root,
-        &setup.snapshot_root,
-    );
+    let spec = build_spec(&opts, &setup);
     write_json_file(&spec_path, &spec);
 
     let result = spawn_transform(&spec_path);
@@ -199,14 +220,7 @@ pub fn expect_logical_modules_e2e_rejection_containing_all(
 fn run_and_assert_rejected(opts: &FixtureOpts<'_>) -> String {
     let setup = setup_fixture(opts);
     let spec_path = setup.out_root.join("transform_spec.jsonc");
-    let spec = build_spec(
-        opts.chunk_id,
-        opts.include_residual,
-        &setup.js_list_path,
-        &opts.operations,
-        &setup.out_root,
-        &setup.snapshot_root,
-    );
+    let spec = build_spec(opts, &setup);
     write_json_file(&spec_path, &spec);
 
     let result = spawn_transform(&spec_path);
@@ -382,34 +396,40 @@ fn setup_fixture(opts: &FixtureOpts<'_>) -> FixtureSetup {
     }
 }
 
-fn build_spec(
-    chunk_id: &str,
-    include_residual: bool,
-    js_list_path: &Path,
-    operations: &[Value],
-    out_root: &Path,
-    snapshot_root: &Path,
-) -> Value {
-    let mut all_operations: Vec<Value> = operations.to_vec();
-    if include_residual {
-        all_operations.push(json!({
-            "id": "logical__residual_unhandled",
-            "operation": "define_residual_module",
-            "selector": { "chunkId": chunk_id },
-            "target": { "path": "residual/unhandled" },
-        }));
-    }
+fn build_spec(opts: &FixtureOpts<'_>, setup: &FixtureSetup) -> Value {
+    let chunk_id = opts.chunk_id;
+    let logical_modules_for_chunk: serde_json::Map<String, Value> = opts
+        .logical_modules
+        .iter()
+        .map(|(path, body)| (path.clone(), body.clone()))
+        .collect();
+    let logical_modules = if logical_modules_for_chunk.is_empty() {
+        json!({})
+    } else {
+        json!({ chunk_id: Value::Object(logical_modules_for_chunk) })
+    };
+    let residual_modules = match (&opts.residual, opts.include_residual) {
+        (Some(residual), _) => json!({ chunk_id: residual }),
+        (None, true) => json!({
+            chunk_id: {
+                "id": "logical__residual_unhandled",
+                "target": "residual/unhandled",
+            }
+        }),
+        (None, false) => json!({}),
+    };
     json!({
         "kind": "js.ast_transform_spec",
-        "inputs": { "inputRoot": snapshot_root, "jsListPath": js_list_path },
-        "operations": all_operations,
+        "inputs": { "inputRoot": setup.snapshot_root, "jsListPath": setup.js_list_path },
+        "logicalModules": logical_modules,
+        "residualModules": residual_modules,
         "pipeline": [
             {
                 "id": "logical",
                 "operation": "materialize_logical_modules",
                 "args": { "chunkIds": [chunk_id], "pruneOtherChunks": false, "targetDir": "modules" },
             },
-            { "id": "write", "operation": "write_js_tree", "args": { "force": true, "outDir": out_root } },
+            { "id": "write", "operation": "write_js_tree", "args": { "force": true, "outDir": setup.out_root } },
         ],
     })
 }

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -214,24 +214,24 @@ struct BuildSpecArgs<'a> {
 fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
     json!({
         "kind": "js.ast_transform_spec",
-        "operations": [{
-            "id": "mark_vendor_lib",
-            "operation": "mark_vendor",
-            "level": "swap",
-            "chunkPath": args.chunk_path,
-            "identity": format!("{}/{}", args.package_name, args.subpath),
-            "upstreamFamily": "Lib",
-            "package": args.package_name,
-            "version": args.package_version,
-            "subpath": args.subpath,
-            "wrapperShape": "named-from-module-default",
-            "confidence": "confirmed",
-            "evidence": [{
-                "path": args.chunk_path,
-                "line": 1,
-                "text": "export { x as default }",
-            }],
-        }],
+        "vendor": {
+            args.chunk_path: {
+                "id": "mark_vendor_lib",
+                "level": "swap",
+                "identity": format!("{}/{}", args.package_name, args.subpath),
+                "upstreamFamily": "Lib",
+                "package": args.package_name,
+                "version": args.package_version,
+                "subpath": args.subpath,
+                "wrapperShape": "named-from-module-default",
+                "confidence": "confirmed",
+                "evidence": [{
+                    "path": args.chunk_path,
+                    "line": 1,
+                    "text": "export { x as default }",
+                }],
+            },
+        },
         "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
         "pipeline": [
             { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
@@ -438,24 +438,24 @@ fn run_named_from_default_fixture(args: NamedFromDefaultFixtureArgs<'_>) -> Vend
 fn build_named_from_default_spec(args: BuildSpecArgs<'_>) -> Value {
     json!({
         "kind": "js.ast_transform_spec",
-        "operations": [{
-            "id": "mark_vendor_lib",
-            "operation": "mark_vendor",
-            "level": "swap",
-            "chunkPath": args.chunk_path,
-            "identity": format!("{}/{}", args.package_name, args.subpath),
-            "upstreamFamily": "Lib",
-            "package": args.package_name,
-            "version": args.package_version,
-            "subpath": args.subpath,
-            "wrapperShape": "named-from-default",
-            "confidence": "confirmed",
-            "evidence": [{
-                "path": args.chunk_path,
-                "line": 1,
-                "text": "export default { ... }",
-            }],
-        }],
+        "vendor": {
+            args.chunk_path: {
+                "id": "mark_vendor_lib",
+                "level": "swap",
+                "identity": format!("{}/{}", args.package_name, args.subpath),
+                "upstreamFamily": "Lib",
+                "package": args.package_name,
+                "version": args.package_version,
+                "subpath": args.subpath,
+                "wrapperShape": "named-from-default",
+                "confidence": "confirmed",
+                "evidence": [{
+                    "path": args.chunk_path,
+                    "line": 1,
+                    "text": "export default { ... }",
+                }],
+            },
+        },
         "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
         "pipeline": [
             { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
-use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::json;
 use swc_common::{DUMMY_SP, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
@@ -21,6 +21,7 @@ use schedule_validator::{
     BindingKind, BindingName, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
     Schedule, analyze_chunk_facts, find_top_level_await, render_cycle_summary,
 };
+use spec::{BindingSourceKind, LogicalModule, MemberPurity, ResidualModule};
 
 const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";
@@ -128,14 +129,6 @@ struct MemberRequest {
     purity: MemberPurity,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum MemberPurity {
-    #[default]
-    Default,
-    Pure,
-}
-
 #[derive(Debug, Clone)]
 struct TopLevelDecl {
     ordinal: usize,
@@ -161,7 +154,8 @@ struct ModulePlan {
 
 pub fn materialize_logical_modules(
     artifact: &mut JsPipelineArtifact,
-    operations: &[Value],
+    logical_modules: &BTreeMap<String, BTreeMap<String, LogicalModule>>,
+    residual_modules: &BTreeMap<String, ResidualModule>,
     options: MaterializeLogicalModulesOptions,
 ) -> Result<LogicalModuleManifest> {
     if options.chunk_ids.is_empty() {
@@ -220,7 +214,12 @@ pub fn materialize_logical_modules(
             .clone()
             .or_else(|| artifact.chunk_source_path(&chunk_id))
             .unwrap_or_else(|| format!("{chunk_id}.js"));
-        let requests = logical_requests_for_chunk(operations, &chunk_id, &target_dir)?;
+        let requests = logical_requests_for_chunk(
+            logical_modules.get(&chunk_id),
+            residual_modules.get(&chunk_id),
+            &chunk_id,
+            &target_dir,
+        )?;
         let mut explicit_requests = requests
             .iter()
             .filter(|request| !request.residual)
@@ -858,134 +857,46 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
     })
 }
 
-/// Wire-format types for the operations array consumed by
-/// `logical_requests_for_chunk`. These are deserialized from the
-/// caller's JSON; the conversion into `LogicalRequest` /
-/// `MemberRequest` happens in one pass below.
-#[derive(Debug, Deserialize)]
-#[serde(tag = "operation", rename_all = "snake_case")]
-enum LogicalOperationSpec {
-    DefineLogicalModule(LogicalModuleSpec),
-    DefineResidualModule(LogicalModuleSpec),
-}
-
-#[derive(Debug, Deserialize)]
-struct LogicalModuleSpec {
-    #[serde(default)]
-    id: Option<String>,
-    selector: ModuleSelectorSpec,
-    #[serde(default)]
-    target: Option<ModuleTargetSpec>,
-    #[serde(default)]
-    members: Vec<MemberSpec>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModuleSelectorSpec {
-    #[serde(rename = "chunkId")]
-    chunk_id: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModuleTargetSpec {
-    path: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct MemberSpec {
-    /// Public export name. Defaults to the bound `selector.binding.name`.
-    #[serde(default)]
-    name: Option<String>,
-    selector: MemberSelectorSpec,
-    #[serde(default)]
-    purity: MemberPurity,
-}
-
-#[derive(Debug, Deserialize)]
-struct MemberSelectorSpec {
-    binding: BindingSelectorSpec,
-}
-
-#[derive(Debug, Deserialize)]
-struct BindingSelectorSpec {
-    name: String,
-    #[serde(default)]
-    kind: Option<BindingSourceKind>,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq)]
-enum BindingSourceKind {
-    /// The bound name comes from an `import` specifier in the
-    /// source chunk, not a top-level decl. Materializer rewrites
-    /// the import statement to a re-import in the destination.
-    ImportSpecifier,
-    /// Top-level `var` / `let` / `const` declaration in the source
-    /// chunk. Carried for documentation; no special materializer path.
-    VariableDeclarator,
-    /// Top-level `function` declaration in the source chunk.
-    FunctionDeclaration,
-    /// Top-level `class` declaration in the source chunk.
-    ClassDeclaration,
-}
-
 fn logical_requests_for_chunk(
-    operations: &[Value],
+    chunk_logical_modules: Option<&BTreeMap<String, LogicalModule>>,
+    chunk_residual: Option<&ResidualModule>,
     chunk_id: &str,
     target_dir: &str,
 ) -> Result<Vec<LogicalRequest>> {
     let mut requests = Vec::new();
-    for (idx, op) in operations.iter().enumerate() {
-        // Peek the operation tag before deserializing — only
-        // `define_logical_module` and `define_residual_module`
-        // are this stage's concern; other operations pass
-        // through other dispatch tables.
-        let op_kind = op.get("operation").and_then(Value::as_str);
-        if !matches!(
-            op_kind,
-            Some("define_logical_module" | "define_residual_module")
-        ) {
-            continue;
+    if let Some(by_target_path) = chunk_logical_modules {
+        for (target_path, module) in by_target_path {
+            let id = module
+                .id
+                .clone()
+                .unwrap_or_else(|| default_logical_id(chunk_id, target_path));
+            let members = build_members(&module.members);
+            reject_duplicate_export_names("logical_module", &id, &members)?;
+            reject_duplicate_member_bindings("logical_module", &id, &members)?;
+            requests.push(LogicalRequest {
+                id,
+                target_path: target_path.clone(),
+                residual: false,
+                members,
+            });
         }
-        let parsed: LogicalOperationSpec = serde_json::from_value(op.clone())
-            .with_context(|| format!("operation #{idx} ({})", op_kind.unwrap_or("?")))?;
-        let (residual, spec) = match parsed {
-            LogicalOperationSpec::DefineLogicalModule(spec) => (false, spec),
-            LogicalOperationSpec::DefineResidualModule(spec) => (true, spec),
-        };
-        if spec.selector.chunk_id != chunk_id {
-            continue;
-        }
-        let id = spec
+    }
+    if let Some(residual) = chunk_residual {
+        let id = residual
             .id
-            .unwrap_or_else(|| op_kind.unwrap_or("logical_module").to_string());
-        let target_path = spec
+            .clone()
+            .unwrap_or_else(|| default_residual_id(chunk_id));
+        let target_path = residual
             .target
-            .map(|t| t.path)
+            .clone()
             .unwrap_or_else(|| "residual/unhandled".to_string());
-        let members: Vec<MemberRequest> = spec
-            .members
-            .into_iter()
-            .map(|m| {
-                let binding = m.selector.binding.name;
-                let export_name = m.name.unwrap_or_else(|| binding.clone());
-                MemberRequest {
-                    is_import_specifier: matches!(
-                        m.selector.binding.kind,
-                        Some(BindingSourceKind::ImportSpecifier)
-                    ),
-                    binding,
-                    export_name,
-                    purity: m.purity,
-                }
-            })
-            .collect();
-        let op_kind_label = op_kind.unwrap_or("logical_module");
-        reject_duplicate_export_names(op_kind_label, &id, &members)?;
-        reject_duplicate_member_bindings(op_kind_label, &id, &members)?;
+        let members = build_members(&residual.members);
+        reject_duplicate_export_names("residual_module", &id, &members)?;
+        reject_duplicate_member_bindings("residual_module", &id, &members)?;
         requests.push(LogicalRequest {
             id,
             target_path,
-            residual,
+            residual: true,
             members,
         });
     }
@@ -998,6 +909,36 @@ fn logical_requests_for_chunk(
         });
     }
     Ok(requests)
+}
+
+fn build_members(members: &[spec::Member]) -> Vec<MemberRequest> {
+    members
+        .iter()
+        .map(|m| {
+            let binding = m.selector.binding.name.clone();
+            let export_name = m.name.clone().unwrap_or_else(|| binding.clone());
+            MemberRequest {
+                is_import_specifier: matches!(
+                    m.selector.binding.kind,
+                    Some(BindingSourceKind::ImportSpecifier)
+                ),
+                binding,
+                export_name,
+                purity: m.purity,
+            }
+        })
+        .collect()
+}
+
+/// Stable, human-readable id used in cycle reports / per-chunk requested
+/// summaries when the spec author leaves `id` blank. Chunk + path uniquely
+/// identifies the logical module under the new spec shape.
+fn default_logical_id(chunk_id: &str, target_path: &str) -> String {
+    format!("{chunk_id}::{target_path}")
+}
+
+fn default_residual_id(chunk_id: &str) -> String {
+    format!("{chunk_id}::residual")
 }
 
 fn collect_top_level_declarations(module: &Module) -> Vec<TopLevelDecl> {

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -13,6 +13,7 @@ use emit_harness::{EmitBrowserHarnessOptions, emit_browser_harness};
 use logical_modules::{MaterializeLogicalModulesOptions, materialize_logical_modules};
 use normalize::normalize_js_chunks;
 use rewrite_specifiers::rewrite_chunk_entry_specifiers;
+use spec::TransformSpec;
 use vendor::{
     SwapVendorOptions, apply_vendor_annotations, rename_vendor_exports, swap_vendor_chunks,
 };
@@ -99,28 +100,6 @@ pub struct TransformStepSummary {
     pub operation: String,
     pub duration_ms: Option<f64>,
     pub manifest_kind: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct TransformSpec {
-    kind: Option<String>,
-    inputs: Option<LoadJsChunksArgs>,
-    pipeline: Option<Vec<TransformStage>>,
-    operations: Option<Vec<serde_json::Value>>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct TransformStage {
-    id: Option<String>,
-    operation: Option<String>,
-    args: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct LoadJsChunksArgs {
-    input_root: PathBuf,
-    js_list_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -211,29 +190,22 @@ pub fn render_transform_summary(summary: &TransformRunSummary) -> String {
 pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
     let spec = load_transform_spec(&cli.spec_path)?;
     validate_transform_spec(&spec)?;
-    let inputs = spec
-        .inputs
-        .expect("validate_transform_spec ensures inputs is present");
-    let pipeline = spec.pipeline.unwrap_or_default();
-    let operations = spec.operations.unwrap_or_default();
     let started = Instant::now();
     let mut state = TransformState::default();
-    let (artifact, _load_manifest) = load_js_chunks(&inputs.input_root, &inputs.js_list_path)?;
+    let (artifact, _load_manifest) =
+        load_js_chunks(&spec.inputs.input_root, &spec.inputs.js_list_path)?;
     state.artifact = artifact;
     compute_js_asts(&mut state.artifact, true)?;
     let (artifact, _normalize_manifest) = normalize_js_chunks(std::mem::take(&mut state.artifact))?;
     state.artifact = artifact;
     let mut steps = Vec::new();
 
-    for stage in pipeline {
-        let id = stage.id.unwrap_or_default();
-        let operation = stage.operation.unwrap_or_default();
+    for stage in &spec.pipeline {
         let stage_started = Instant::now();
-        let manifest_kind =
-            run_transform_stage(&mut state, &operation, stage.args, &operations, cli)?;
+        let manifest_kind = run_transform_stage(&mut state, stage, &spec, cli)?;
         steps.push(TransformStepSummary {
-            id,
-            operation,
+            id: stage.id.clone(),
+            operation: stage.operation.clone(),
             duration_ms: Some(elapsed_ms(stage_started)),
             manifest_kind,
         });
@@ -248,22 +220,23 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
 
 fn run_transform_stage(
     state: &mut TransformState,
-    operation: &str,
-    args: Option<serde_json::Value>,
-    operations: &[serde_json::Value],
+    stage: &spec::TransformStage,
+    spec: &TransformSpec,
     cli: &TransformCli,
 ) -> Result<Option<String>> {
+    let args = stage.args.clone();
+    let operation = stage.operation.as_str();
     match operation {
         "rewrite_chunk_entry_specifiers" => {
             let manifest = rewrite_chunk_entry_specifiers(&mut state.artifact)?;
             Ok(Some(manifest.kind.to_string()))
         }
         "apply_vendor_annotations" => {
-            let manifest = apply_vendor_annotations(&mut state.artifact, operations)?;
+            let manifest = apply_vendor_annotations(&state.artifact, &spec.vendor)?;
             Ok(Some(manifest.kind.to_string()))
         }
         "rename_vendor_exports" => {
-            let manifest = rename_vendor_exports(&mut state.artifact, operations)?;
+            let manifest = rename_vendor_exports(&mut state.artifact, &spec.vendor)?;
             Ok(Some(manifest.kind.to_string()))
         }
         "swap_vendor_chunks" => {
@@ -277,7 +250,7 @@ fn run_transform_stage(
                 });
             let manifest = swap_vendor_chunks(
                 &mut state.artifact,
-                operations,
+                &spec.vendor,
                 SwapVendorOptions {
                     package_roots: &cli.package_roots,
                     packages_root: &cli.packages_root,
@@ -293,7 +266,8 @@ fn run_transform_stage(
                 serde_json::from_value(args.context("materialize_logical_modules requires args")?)?;
             let manifest = materialize_logical_modules(
                 &mut state.artifact,
-                operations,
+                &spec.logical_modules,
+                &spec.residual_modules,
                 MaterializeLogicalModulesOptions {
                     chunk_ids: args.chunk_ids,
                     file: args.file,
@@ -340,39 +314,26 @@ fn load_transform_spec(spec_path: &Path) -> Result<TransformSpec> {
 }
 
 fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
-    let kind = spec.kind.as_deref().unwrap_or("<missing>");
-    if kind != "js.ast_transform_spec" {
-        bail!("Unsupported transform spec kind: {kind}");
+    if spec.kind != "js.ast_transform_spec" {
+        bail!("Unsupported transform spec kind: {}", spec.kind);
     }
-    let inputs = spec
-        .inputs
-        .as_ref()
-        .context("Transform spec must contain an inputs object with inputRoot and jsListPath")?;
-    if inputs.input_root.as_os_str().is_empty() {
+    if spec.inputs.input_root.as_os_str().is_empty() {
         bail!("Transform spec inputs.inputRoot must not be empty");
     }
-    if inputs.js_list_path.as_os_str().is_empty() {
+    if spec.inputs.js_list_path.as_os_str().is_empty() {
         bail!("Transform spec inputs.jsListPath must not be empty");
     }
-    let pipeline = spec
-        .pipeline
-        .as_ref()
-        .context("Transform spec must contain a pipeline array")?;
     let mut seen_stage_ids = HashSet::new();
-    for stage in pipeline {
-        let id = stage
-            .id
-            .as_deref()
-            .context("Pipeline stage is missing id")?;
-        let operation = stage
-            .operation
-            .as_deref()
-            .with_context(|| format!("Pipeline stage {id} is missing operation"))?;
-        if id == operation {
-            bail!("Pipeline stage {id} must differ from operation {operation}");
+    for stage in &spec.pipeline {
+        if stage.id == stage.operation {
+            bail!(
+                "Pipeline stage {} must differ from operation {}",
+                stage.id,
+                stage.operation,
+            );
         }
-        if !seen_stage_ids.insert(id.to_string()) {
-            bail!("Duplicate pipeline stage id: {id}");
+        if !seen_stage_ids.insert(stage.id.clone()) {
+            bail!("Duplicate pipeline stage id: {}", stage.id);
         }
     }
     Ok(())

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -1,0 +1,232 @@
+//! Typed deserialisation surface for `js.ast_transform_spec` JSONC files.
+//!
+//! The spec carries three declarative top-level maps consumed by pipeline
+//! stages:
+//!
+//! - `vendor` keyed by chunk path (`"static/lib.js"` → [`VendorMark`]).
+//! - `logical_modules` keyed by chunk id, then target path
+//!   (`"static/app"` → `"foo/bar/baz.js"` → [`LogicalModule`]).
+//! - `residual_modules` keyed by chunk id (`"static/app"` →
+//!   [`ResidualModule`]). At most one residual per chunk — encoded by the
+//!   map shape.
+//!
+//! All consumers see typed structs; nothing here returns
+//! `serde_json::Value` for a known field.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformSpec {
+    pub kind: String,
+    pub inputs: LoadJsChunksArgs,
+    pub pipeline: Vec<TransformStage>,
+    #[serde(default)]
+    pub vendor: BTreeMap<String, VendorMark>,
+    #[serde(default)]
+    pub logical_modules: BTreeMap<String, BTreeMap<String, LogicalModule>>,
+    #[serde(default)]
+    pub residual_modules: BTreeMap<String, ResidualModule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformStage {
+    pub id: String,
+    pub operation: String,
+    #[serde(default)]
+    pub args: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LoadJsChunksArgs {
+    pub input_root: PathBuf,
+    pub js_list_path: PathBuf,
+}
+
+// --- Vendor ---------------------------------------------------------------
+
+/// One vendor annotation, keyed in the spec by chunk path
+/// (e.g. `"static/lib.js"`). The `level` discriminator selects between
+/// `suppress` / `boundary-rename` / `swap`; only `swap` requires the
+/// `package`/`version`/`subpath` triple, encoded as the
+/// [`VendorLevel::Swap`] variant carrying those fields.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorMark {
+    pub id: String,
+    pub identity: String,
+    pub evidence: Vec<Evidence>,
+    #[serde(default)]
+    pub role: VendorRole,
+    #[serde(default)]
+    pub upstream_family: Option<String>,
+    #[serde(default)]
+    pub confidence: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub export_shape: Option<serde_json::Map<String, serde_json::Value>>,
+    #[serde(default)]
+    pub fingerprint: Option<Fingerprint>,
+    #[serde(flatten)]
+    pub level: VendorLevel,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "level", rename_all = "kebab-case")]
+pub enum VendorLevel {
+    Suppress,
+    BoundaryRename,
+    Swap(SwapMark),
+}
+
+impl VendorLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VendorLevel::Suppress => "suppress",
+            VendorLevel::BoundaryRename => "boundary-rename",
+            VendorLevel::Swap(_) => "swap",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapMark {
+    pub package: String,
+    pub version: String,
+    pub subpath: String,
+    #[serde(default)]
+    pub wrapper_shape: Option<WrapperShape>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum VendorRole {
+    #[default]
+    Module,
+    Worker,
+}
+
+impl VendorRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VendorRole::Module => "module",
+            VendorRole::Worker => "worker",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WrapperShape {
+    NamedFromDefault,
+    NamedFromJsonDefault,
+    NamedFromModuleDefault,
+}
+
+impl WrapperShape {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WrapperShape::NamedFromDefault => "named-from-default",
+            WrapperShape::NamedFromJsonDefault => "named-from-json-default",
+            WrapperShape::NamedFromModuleDefault => "named-from-module-default",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Evidence {
+    pub path: String,
+    pub line: u64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Fingerprint {
+    pub algorithm: String,
+    pub hash: String,
+}
+
+// --- Logical / Residual modules ------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LogicalModule {
+    /// Optional human-readable id used in cycle reports and the per-chunk
+    /// requested-modules summary. Defaults to a stable derived value when
+    /// absent.
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResidualModule {
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Logical-module path the residual catch-all writes to. Defaults to
+    /// `"residual/unhandled"` when absent.
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub members: Vec<Member>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Member {
+    /// Public export name. Defaults to the bound `selector.binding.name`.
+    #[serde(default)]
+    pub name: Option<String>,
+    pub selector: MemberSelector,
+    #[serde(default)]
+    pub purity: MemberPurity,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemberSelector {
+    pub binding: BindingSelector,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BindingSelector {
+    pub name: String,
+    #[serde(default)]
+    pub kind: Option<BindingSourceKind>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq)]
+pub enum BindingSourceKind {
+    /// The bound name comes from an `import` specifier in the source
+    /// chunk, not a top-level decl. The materializer rewrites the import
+    /// statement to a re-import in the destination module.
+    ImportSpecifier,
+    /// Top-level `var` / `let` / `const` declaration in the source chunk.
+    /// Carried for documentation; no special materializer path.
+    VariableDeclarator,
+    /// Top-level `function` declaration in the source chunk.
+    FunctionDeclaration,
+    /// Top-level `class` declaration in the source chunk.
+    ClassDeclaration,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MemberPurity {
+    #[default]
+    Default,
+    /// Author asserts that calls to the bound function have no observable
+    /// side effects. Validator drops `S` edges for `<binding>(...)` call
+    /// sites. See AGENTS.md "Declared purity" + DESIGN.md A9.
+    Pure,
+}

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -3,7 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use serde_json::{Map, Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use swc_common::{DUMMY_SP, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{VisitMut, VisitMutWith};
@@ -13,6 +14,7 @@ use artifact::{
     resolve_artifact_import_reference, resolve_artifact_source_import_reference, split_posix_path,
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
+use spec::{SwapMark, VendorLevel, VendorMark, WrapperShape};
 
 // These manifests are returned by the vendor stages but the pipeline
 // orchestrator only reads `kind` for stage logging. They are not
@@ -22,14 +24,33 @@ use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
 pub struct VendorAnnotationsManifest {
     pub kind: &'static str,
     pub counts: VendorAnnotationCounts,
-    pub annotations: Vec<Value>,
+    pub annotations: Vec<VendorAnnotationSummary>,
 }
 
 #[derive(Debug, Clone)]
 pub struct VendorAnnotationCounts {
     pub annotations: usize,
-    pub considered: usize,
-    pub applied: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorAnnotationSummary {
+    pub id: String,
+    pub chunk_path: String,
+    pub chunk_id: String,
+    pub identity: String,
+    pub level: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_family: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -64,8 +85,23 @@ pub struct RenameVendorExportsCaller {
 #[derive(Debug, Clone)]
 pub struct VendorResolutionManifest {
     pub kind: &'static str,
-    pub resolutions: BTreeMap<String, Value>,
+    pub resolutions: BTreeMap<String, VendorResolution>,
     pub counts: VendorResolutionCounts,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VendorResolution {
+    pub chunk_id: String,
+    pub chunk_path: String,
+    pub entry_file: String,
+    pub package: String,
+    pub version: String,
+    pub subpath: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wrapper_shape: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated_wrapper_path: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -83,107 +119,81 @@ pub struct SwapVendorOptions<'a> {
 }
 
 pub fn apply_vendor_annotations(
-    artifact: &mut JsPipelineArtifact,
-    operations: &[Value],
+    artifact: &JsPipelineArtifact,
+    vendor: &BTreeMap<String, VendorMark>,
 ) -> Result<VendorAnnotationsManifest> {
-    let ops = mark_vendor_ops(operations)
-        .into_iter()
-        .filter(|op| value_str(op, "operation") == Some("mark_vendor"))
-        .collect::<Vec<_>>();
-    let mut seen_chunk_paths = BTreeMap::<String, String>::new();
-    artifact.vendor_annotations.clear();
-    let mut summaries = Vec::new();
-
-    for op in &ops {
-        validate_mark_vendor_op(op)?;
-        let op_id = required_str(op, "id")?;
-        let chunk_path = required_str(op, "chunkPath")?;
-        let chunk_id = chunk_id_from_chunk_path(chunk_path, op_id, "mark_vendor")?;
+    let mut summaries = Vec::with_capacity(vendor.len());
+    for (chunk_path, mark) in vendor {
+        validate_evidence(mark)?;
+        let chunk_id = chunk_id_from_chunk_path(chunk_path, &mark.id, "mark_vendor")?;
         if get_chunk_entry_path(artifact, &chunk_id).is_none() {
             bail!(
-                "mark_vendor operation {op_id} targets missing chunk: chunkPath={chunk_path} (chunkId={chunk_id})"
+                "mark_vendor operation {} targets missing chunk: chunkPath={chunk_path} (chunkId={chunk_id})",
+                mark.id,
             );
         }
-        if let Some(prior_id) = seen_chunk_paths.insert(chunk_path.to_string(), op_id.to_string()) {
-            bail!(
-                "mark_vendor operations {prior_id} and {op_id} both target chunkPath {chunk_path}"
-            );
-        }
-
-        let mut annotation = Map::new();
-        insert_required(&mut annotation, op, "id");
-        insert_required(&mut annotation, op, "level");
-        insert_required(&mut annotation, op, "chunkPath");
-        annotation.insert("chunkId".to_string(), Value::String(chunk_id.clone()));
-        insert_required(&mut annotation, op, "identity");
-        insert_required(&mut annotation, op, "evidence");
-        for key in [
-            "upstreamFamily",
-            "version",
-            "confidence",
-            "notes",
-            "package",
-            "subpath",
-            "exportShape",
-            "fingerprint",
-        ] {
-            insert_optional(&mut annotation, op, key);
-        }
-        annotation.insert(
-            "role".to_string(),
-            Value::String(value_str(op, "role").unwrap_or("module").to_string()),
-        );
-        artifact
-            .vendor_annotations
-            .insert(chunk_id.clone(), Value::Object(annotation.clone()));
-
-        let mut summary = Map::new();
-        for key in ["id", "chunkPath", "identity", "level"] {
-            insert_required(&mut summary, op, key);
-        }
-        summary.insert("chunkId".to_string(), Value::String(chunk_id));
-        for key in [
-            "upstreamFamily",
-            "version",
-            "confidence",
-            "package",
-            "subpath",
-        ] {
-            insert_optional(&mut summary, op, key);
-        }
-        summary.insert(
-            "role".to_string(),
-            Value::String(value_str(op, "role").unwrap_or("module").to_string()),
-        );
-        summaries.push(Value::Object(summary));
+        let (package, version, subpath) = match &mark.level {
+            VendorLevel::Swap(swap) => (
+                Some(swap.package.clone()),
+                Some(swap.version.clone()),
+                Some(swap.subpath.clone()),
+            ),
+            _ => (None, None, None),
+        };
+        summaries.push(VendorAnnotationSummary {
+            id: mark.id.clone(),
+            chunk_path: chunk_path.clone(),
+            chunk_id,
+            identity: mark.identity.clone(),
+            level: mark.level.as_str().to_string(),
+            role: mark.role.as_str().to_string(),
+            upstream_family: mark.upstream_family.clone(),
+            version: version.clone(),
+            confidence: mark.confidence.clone(),
+            package,
+            subpath,
+        });
     }
 
     Ok(VendorAnnotationsManifest {
         kind: "js.vendor_annotations_manifest",
         counts: VendorAnnotationCounts {
-            annotations: artifact.vendor_annotations.len(),
-            considered: operations.len(),
-            applied: ops.len(),
+            annotations: vendor.len(),
         },
         annotations: summaries,
     })
 }
 
+fn validate_evidence(mark: &VendorMark) -> Result<()> {
+    if mark.evidence.is_empty() {
+        bail!(
+            "mark_vendor operation {} requires a non-empty evidence array",
+            mark.id,
+        );
+    }
+    Ok(())
+}
+
 pub fn rename_vendor_exports(
     artifact: &mut JsPipelineArtifact,
-    operations: &[Value],
+    vendor: &BTreeMap<String, VendorMark>,
 ) -> Result<RenameVendorExportsManifest> {
-    let ops = mark_vendor_ops(operations)
-        .into_iter()
-        .filter(|op| matches!(value_str(op, "level"), Some("boundary-rename" | "swap")))
-        .collect::<Vec<_>>();
+    let ops: Vec<(&String, &VendorMark)> = vendor
+        .iter()
+        .filter(|(_, mark)| {
+            matches!(
+                mark.level,
+                VendorLevel::BoundaryRename | VendorLevel::Swap(_)
+            )
+        })
+        .collect();
+    let considered = ops.len();
     let mut total_rewrites = 0usize;
     let mut chunks_with_mapping = 0usize;
     let mut details = Vec::new();
 
-    for op in &ops {
-        let op_id = required_str(op, "id")?;
-        let chunk_path = required_str(op, "chunkPath")?;
+    for (chunk_path, mark) in &ops {
+        let op_id = mark.id.as_str();
         let chunk_id = chunk_id_from_chunk_path(chunk_path, op_id, "renameVendorExports")?;
         let vendor_entry_relative_file = get_chunk_entry_path(artifact, &chunk_id).with_context(|| {
             format!(
@@ -277,7 +287,7 @@ pub fn rename_vendor_exports(
     Ok(RenameVendorExportsManifest {
         kind: "js.rename_vendor_exports_manifest",
         counts: RenameVendorExportsCounts {
-            considered: ops.len(),
+            considered,
             chunks_with_mapping,
             rewrites: total_rewrites,
         },
@@ -287,19 +297,21 @@ pub fn rename_vendor_exports(
 
 pub fn swap_vendor_chunks(
     artifact: &mut JsPipelineArtifact,
-    operations: &[Value],
+    vendor: &BTreeMap<String, VendorMark>,
     options: SwapVendorOptions<'_>,
 ) -> Result<VendorResolutionManifest> {
-    let ops = mark_vendor_ops(operations)
-        .into_iter()
-        .filter(|op| value_str(op, "level") == Some("swap"))
-        .collect::<Vec<_>>();
+    let ops: Vec<(&String, &VendorMark, &SwapMark)> = vendor
+        .iter()
+        .filter_map(|(chunk_path, mark)| match &mark.level {
+            VendorLevel::Swap(swap) => Some((chunk_path, mark, swap)),
+            _ => None,
+        })
+        .collect();
     let import_alignment_index = build_import_alignment_index(artifact)?;
-    let mut resolutions = BTreeMap::<String, Value>::new();
+    let mut resolutions = BTreeMap::<String, VendorResolution>::new();
 
-    for op in &ops {
-        let op_id = required_str(op, "id")?;
-        let chunk_path = required_str(op, "chunkPath")?;
+    for (chunk_path, mark, swap) in &ops {
+        let op_id = mark.id.as_str();
         let chunk_id = chunk_id_from_chunk_path(chunk_path, op_id, "swapVendorChunks")?;
         let entry_relative_file = get_chunk_entry_path(artifact, &chunk_id).with_context(|| {
             format!(
@@ -314,9 +326,9 @@ pub fn swap_vendor_chunks(
             .with_context(|| {
                 format!("swapVendorChunks operation {op_id} vendor chunk {chunk_id} is missing entry AST")
             })?;
-        let package = required_str(op, "package")?;
-        let version = required_str(op, "version")?;
-        let subpath = required_str(op, "subpath")?;
+        let package = swap.package.as_str();
+        let version = swap.version.as_str();
+        let subpath = swap.subpath.as_str();
         let installed =
             read_installed_package_metadata(package, options.package_roots, options.packages_root)
                 .with_context(|| format!("reading metadata for package {package}"))?;
@@ -340,8 +352,8 @@ pub fn swap_vendor_chunks(
         let vendor_exports = collect_exported_names(&entry_ast.module, false);
         let mut generated_wrapper_path = None::<PathBuf>;
 
-        match value_str(op, "wrapperShape") {
-            Some("named-from-default") => {
+        match swap.wrapper_shape {
+            Some(WrapperShape::NamedFromDefault) => {
                 let upstream_ast =
                     parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
                 let object_keys = collect_default_export_object_keys(&upstream_ast.module, op_id)?;
@@ -367,7 +379,7 @@ pub fn swap_vendor_chunks(
                     &wrapper,
                 )?;
             }
-            Some("named-from-json-default") => {
+            Some(WrapperShape::NamedFromJsonDefault) => {
                 let upstream_json = serde_json::from_str::<Value>(&upstream_code).with_context(|| {
                     format!("swapVendorChunks operation {op_id} named-from-json-default: upstream JSON parse failed")
                 })?;
@@ -397,7 +409,7 @@ pub fn swap_vendor_chunks(
                     &wrapper,
                 )?;
             }
-            Some("named-from-module-default") => {
+            Some(WrapperShape::NamedFromModuleDefault) => {
                 let upstream_ast =
                     parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
                 let wrapper = generate_named_from_module_default_wrapper(
@@ -412,9 +424,6 @@ pub fn swap_vendor_chunks(
                     &entry_relative_file,
                     &wrapper,
                 )?;
-            }
-            Some(other) => {
-                bail!("swapVendorChunks operation {op_id} has unsupported wrapperShape {other}")
             }
             None => {
                 let upstream_ast =
@@ -450,73 +459,23 @@ pub fn swap_vendor_chunks(
             .chunk_order
             .retain(|candidate| candidate != &chunk_id);
         artifact.chunk_manifests.remove(&chunk_id);
-        let mut swap_entry = Map::new();
-        swap_entry.insert("package".to_string(), Value::String(package.to_string()));
-        swap_entry.insert("version".to_string(), Value::String(version.to_string()));
-        swap_entry.insert("subpath".to_string(), Value::String(subpath.to_string()));
-        swap_entry.insert(
-            "verification".to_string(),
-            Value::String("structural".to_string()),
-        );
-        if let Some(wrapper_shape) = value_str(op, "wrapperShape") {
-            swap_entry.insert(
-                "wrapperShape".to_string(),
-                Value::String(wrapper_shape.to_string()),
-            );
-        }
-        if let Some(path) = &generated_wrapper_path
-            && let Some(manifest_path) = options.output_manifest_path.as_deref()
-        {
-            swap_entry.insert(
-                "generatedWrapperPath".to_string(),
-                Value::String(manifest_relative_path(manifest_path, path)),
-            );
-        }
-        let mut annotation = artifact
-            .vendor_annotations
-            .get(&chunk_id)
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        annotation.insert("chunkId".to_string(), Value::String(chunk_id.clone()));
-        annotation.insert(
-            "chunkPath".to_string(),
-            Value::String(chunk_path.to_string()),
-        );
-        annotation.insert("level".to_string(), Value::String("swap".to_string()));
-        annotation
-            .entry("id".to_string())
-            .or_insert_with(|| Value::String(op_id.to_string()));
-        annotation.insert("swap".to_string(), Value::Object(swap_entry.clone()));
-        artifact
-            .vendor_annotations
-            .insert(chunk_id.clone(), Value::Object(annotation));
-
-        let mut resolution = Map::new();
-        resolution.insert("chunkId".to_string(), Value::String(chunk_id));
-        resolution.insert(
-            "chunkPath".to_string(),
-            Value::String(chunk_path.to_string()),
-        );
-        resolution.insert("entryFile".to_string(), Value::String(entry_relative_file));
-        resolution.insert("package".to_string(), Value::String(package.to_string()));
-        resolution.insert("version".to_string(), Value::String(version.to_string()));
-        resolution.insert("subpath".to_string(), Value::String(subpath.to_string()));
-        if let Some(wrapper_shape) = value_str(op, "wrapperShape") {
-            resolution.insert(
-                "wrapperShape".to_string(),
-                Value::String(wrapper_shape.to_string()),
-            );
-        }
-        if let Some(path) = generated_wrapper_path
-            && let Some(manifest_path) = options.output_manifest_path.as_deref()
-        {
-            resolution.insert(
-                "generatedWrapperPath".to_string(),
-                Value::String(manifest_relative_path(manifest_path, &path)),
-            );
-        }
-        resolutions.insert(chunk_path.to_string(), Value::Object(resolution));
+        let generated_wrapper_path_str = generated_wrapper_path.as_ref().and_then(|path| {
+            options
+                .output_manifest_path
+                .as_deref()
+                .map(|manifest_path| manifest_relative_path(manifest_path, path))
+        });
+        let resolution = VendorResolution {
+            chunk_id: chunk_id.clone(),
+            chunk_path: chunk_path.to_string(),
+            entry_file: entry_relative_file,
+            package: package.to_string(),
+            version: version.to_string(),
+            subpath: subpath.to_string(),
+            wrapper_shape: swap.wrapper_shape.map(|s| s.as_str().to_string()),
+            generated_wrapper_path: generated_wrapper_path_str,
+        };
+        resolutions.insert(chunk_path.to_string(), resolution);
     }
 
     let chunk_count = artifact.list_chunk_ids().len();
@@ -537,12 +496,17 @@ pub fn swap_vendor_chunks(
         if let Some(parent) = output_manifest_path.parent() {
             fs::create_dir_all(parent)?;
         }
+        #[derive(Serialize)]
+        struct OnDiskResolutionManifest<'a> {
+            kind: &'static str,
+            resolutions: &'a BTreeMap<String, VendorResolution>,
+        }
         fs::write(
             output_manifest_path,
-            serde_json::to_string_pretty(&json!({
-                "kind": "js.vendor_resolution_manifest",
-                "resolutions": resolutions,
-            }))? + "\n",
+            serde_json::to_string_pretty(&OnDiskResolutionManifest {
+                kind: "js.vendor_resolution_manifest",
+                resolutions: &resolutions,
+            })? + "\n",
         )?;
     }
 
@@ -552,126 +516,6 @@ pub fn swap_vendor_chunks(
         resolutions,
         counts: VendorResolutionCounts { swapped },
     })
-}
-
-fn mark_vendor_ops(operations: &[Value]) -> Vec<&Value> {
-    operations
-        .iter()
-        .filter(|op| value_str(op, "operation") == Some("mark_vendor"))
-        .collect()
-}
-
-fn validate_mark_vendor_op(op: &Value) -> Result<()> {
-    let op_id = value_str(op, "id").unwrap_or("<unknown>");
-    for field in [
-        "id",
-        "operation",
-        "level",
-        "chunkPath",
-        "identity",
-        "evidence",
-    ] {
-        if value_is_missing(op.get(field)) {
-            bail!("mark_vendor operation {op_id} is missing required field: {field}");
-        }
-    }
-    if value_str(op, "operation") != Some("mark_vendor") {
-        bail!(
-            "mark_vendor operation {} has unexpected operation: {}",
-            required_str(op, "id")?,
-            value_str(op, "operation").unwrap_or("<missing>")
-        );
-    }
-    if !matches!(
-        value_str(op, "level"),
-        Some("suppress" | "boundary-rename" | "swap")
-    ) {
-        bail!(
-            "mark_vendor operation {} has unknown level: {}",
-            required_str(op, "id")?,
-            value_str(op, "level").unwrap_or("<missing>")
-        );
-    }
-    if let Some(role) = value_str(op, "role")
-        && role != "module"
-        && role != "worker"
-    {
-        bail!(
-            "mark_vendor operation {} has invalid role: {role}",
-            required_str(op, "id")?
-        );
-    }
-    if value_str(op, "level") == Some("swap") {
-        for field in ["package", "version", "subpath"] {
-            if value_is_missing(op.get(field)) {
-                bail!(
-                    "mark_vendor operation {} level \"swap\" is missing required field: {field}",
-                    required_str(op, "id")?
-                );
-            }
-        }
-    }
-    if let Some(export_shape) = op.get("exportShape")
-        && !export_shape.is_object()
-    {
-        bail!(
-            "mark_vendor operation {} exportShape must be an object",
-            required_str(op, "id")?
-        );
-    }
-    if let Some(fp) = op.get("fingerprint")
-        && (!fp.is_object()
-            || fp.get("algorithm").and_then(Value::as_str).is_none()
-            || fp.get("hash").and_then(Value::as_str).is_none())
-    {
-        bail!(
-            "mark_vendor operation {} fingerprint must have algorithm and hash strings",
-            required_str(op, "id")?
-        );
-    }
-    if op
-        .get("evidence")
-        .and_then(Value::as_array)
-        .is_none_or(|evidence| evidence.is_empty())
-    {
-        bail!(
-            "mark_vendor operation {} requires a non-empty evidence array",
-            required_str(op, "id")?
-        );
-    }
-    Ok(())
-}
-
-fn value_is_missing(value: Option<&Value>) -> bool {
-    match value {
-        None | Some(Value::Null) => true,
-        Some(Value::String(text)) => text.is_empty(),
-        _ => false,
-    }
-}
-
-fn required_str<'a>(value: &'a Value, key: &str) -> Result<&'a str> {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .filter(|text| !text.is_empty())
-        .with_context(|| format!("missing required string field {key}"))
-}
-
-fn value_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
-    value.get(key).and_then(Value::as_str)
-}
-
-fn insert_required(target: &mut Map<String, Value>, source: &Value, key: &str) {
-    if let Some(value) = source.get(key) {
-        target.insert(key.to_string(), value.clone());
-    }
-}
-
-fn insert_optional(target: &mut Map<String, Value>, source: &Value, key: &str) {
-    if let Some(value) = source.get(key) {
-        target.insert(key.to_string(), value.clone());
-    }
 }
 
 fn chunk_id_from_chunk_path(chunk_path: &str, op_id: &str, stage: &str) -> Result<String> {


### PR DESCRIPTION
## Summary

This PR refactors the transform spec parsing to use strongly-typed Rust structs instead of passing around `serde_json::Value` objects. A new `spec.rs` module provides typed deserialization for the spec's declarative sections (`vendor`, `logical_modules`, `residual_modules`), eliminating manual JSON field extraction and improving type safety throughout the pipeline.

## Key Changes

- **New `spec.rs` module**: Introduces typed structs for the entire transform spec:
  - `TransformSpec` with top-level `vendor`, `logical_modules`, and `residual_modules` maps
  - `VendorMark` with discriminated `VendorLevel` enum (Suppress/BoundaryRename/Swap)
  - `SwapMark` for swap-specific fields (package, version, subpath, wrapper_shape)
  - `LogicalModule` and `ResidualModule` for module definitions
  - `Member`, `MemberSelector`, `BindingSelector` for member specifications
  - Enums for `VendorRole`, `WrapperShape`, `MemberPurity`, `BindingSourceKind`

- **Vendor module refactoring**:
  - `apply_vendor_annotations()` now takes `&BTreeMap<String, VendorMark>` instead of `&[Value]`
  - `rename_vendor_exports()` and `swap_vendor_chunks()` similarly updated
  - Replaced manual JSON field extraction with direct struct field access
  - New `VendorAnnotationSummary` and `VendorResolution` structs with `#[derive(Serialize)]` for output manifests
  - Removed `considered` and `applied` fields from `VendorAnnotationCounts`

- **Logical modules refactoring**:
  - `materialize_logical_modules()` now takes typed `&BTreeMap<String, BTreeMap<String, LogicalModule>>` and `&BTreeMap<String, ResidualModule>`
  - Removed `LogicalOperationSpec`, `LogicalModuleSpec`, and related wire-format deserialization types
  - `logical_requests_for_chunk()` now operates on typed structs directly
  - Moved `MemberPurity` and `BindingSourceKind` to `spec.rs` for reuse

- **Pipeline integration**:
  - `TransformSpec` moved from `pipeline.rs` to `spec.rs` with proper field validation
  - Pipeline stages now extract typed maps from spec and pass them to stage handlers
  - Removed `operations` array concept; stages read declarative maps directly

- **Test updates**:
  - Updated e2e test fixtures to use new spec format with typed maps
  - `logical_module()` helper now returns `(String, Value)` tuples (path → body)
  - `residual_module()` helper added for residual module definitions
  - Vendor swap tests updated to use `vendor` map instead of `operations` array

## Implementation Details

- Serde `#[serde(flatten)]` used for `VendorLevel` discriminator to keep `level` field in JSON
- `#[serde(skip_serializing_if = "Option::is_none")]` applied to optional fields in output manifests
- `#[serde(deny_unknown_fields)]` enforces strict schema validation for logical/residual modules
- Enum `as_str()` methods provide string representations for serialization
- Removed artifact's `vendor_annotations` field; annotations now flow through manifest only

https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx