### PR TITLE
debundle: add TransformSpec.chunk_renames for in-place entry rewrites

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -49,6 +49,7 @@ rust_library(
         "vendor_swap_test",
         "scrambled_id_frequencies_test",
         "sibling_declarator_steal_test",
+        "chunk_renames_test",
         "missing_binding_member_test",
         "residual_member_rename_test",
         "source_order_emit_test",

--- a/devinfra/js/debundle/e2e/chunk_renames_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_renames_test.rs
@@ -1,0 +1,87 @@
+//! `TransformSpec.chunk_renames` applies in-place renames to bindings
+//! staying in entry's body without creating an explicit `Logical(R)`
+//! module that would form a 2-module SCC with `ResidualEntry`.
+//!
+//! ## Background — the bug this op was added to fix
+//!
+//! Previously, the gaffer-side `.yaml.deferred` workflow stuffed its
+//! rename ops into `residualModules[chunkId].members` so the
+//! residual-member-rename path applied them. That works mechanically
+//! but the residual-member-rename path needs a `Logical(R)` module,
+//! which the validator treats as a distinct node from
+//! `ModuleId::ResidualEntry`. When the chunk interleaves orphan
+//! top-level statements (`console.log(x)` etc., owner =
+//! `ResidualEntry`) with side-effecting initializers on residual-
+//! owned decls (owner = `Logical(R)`), the S-edge ordering loop
+//! produces a 2-module SCC. Both nodes emit into files that evaluate
+//! in the chunk's same init phase — the cycle is a validator
+//! artifact, not a real evaluation hazard, but the gate still
+//! rejects.
+//!
+//! ## What `chunk_renames` does
+//!
+//! Carries `members[]` with rename info, like a `LogicalModule`, but
+//! doesn't create a logical module. The materializer collects the
+//! renames into a `binding_name -> export_name` map and the lowerer
+//! applies them in-place during entry-body emission for any binding
+//! *not* claimed by a logical module. Bindings claimed by a logical
+//! module take their rename from the module plan; the
+//! `chunk_renames` entry (if any) is dropped for those.
+//!
+//! With no `Logical(R)` to interleave against, the orphan stmts and
+//! unowned decls share `ResidualEntry` ownership; no cycle.
+
+use debundle_e2e_support::*;
+use serde_json::json;
+
+#[test]
+fn chunk_renames_renames_residual_bindings_in_entry() {
+    let opts = FixtureOpts {
+        // S1 (orphan-S):       console.log("before")
+        // S2 (decl with S):    let x = (..., "x-value")  -- stays in entry
+        // S3 (orphan-R+S):     console.log(x)            -- reads x at-init
+        //
+        // No `residualModules` entry; `x` stays in `ResidualEntry`-land.
+        // `chunkRenames` renames `x` -> `payload`. The lowerer rewrites
+        // the in-entry references; the export statement carries the
+        // new name.
+        source: r#"console.log("before");
+let x = (globalThis.__touched = true, "x-value");
+console.log(x);
+export { x };
+"#,
+        logical_modules: vec![],
+        residual: None,
+        chunk_renames: Some(json!({
+            "id": "chunk_renames__static_app",
+            "members": [
+                {
+                    "name": "payload",
+                    "selector": { "binding": { "name": "x" } },
+                },
+            ],
+        })),
+        chunk_id: "static/app",
+        include_residual: false,
+        extra_files: &[],
+    };
+    let fixture = run_logical_modules_e2e_fixture(opts);
+    // The chunk evaluates: orphan logs "before", x's init runs (sets
+    // globalThis.__touched and binds "x-value"), orphan logs the
+    // value. With the in-place rename, the entry source emits
+    // `let payload = ...` and `console.log(payload)`; runtime
+    // semantics are unchanged.
+    assert_entry_output(&fixture, "before\nx-value\n");
+    // Pin the in-entry rename: entry.js should reference the new
+    // name and not the original binding.
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/entry.js",
+        &[
+            "let payload =",
+            "console.log(payload)",
+            "export { payload as x }",
+        ],
+        &["let x =", "console.log(x)"],
+    );
+}

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -25,6 +25,7 @@ export { a, b };
             "residual/unhandled",
             &[Member::renamed("FirstFn", "a")],
         )),
+        chunk_renames: None,
         chunk_id: "static/app",
         include_residual: false,
         extra_files: &[],

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -83,6 +83,12 @@ pub struct FixtureOpts<'a> {
     /// `include_residual` is ignored. Use the [`residual_module`] helper
     /// to build typical bodies.
     pub residual: Option<Value>,
+    /// Optional `chunk_renames` entry for this chunk. When set, the
+    /// spec's top-level `chunkRenames` map carries the rename
+    /// members; the materializer applies them in-place to bindings
+    /// staying in entry's body without creating a `Logical(R)` for
+    /// them.
+    pub chunk_renames: Option<Value>,
     pub chunk_id: &'a str,
     /// When `residual` is `None` and this is `true`, the harness emits an
     /// empty residual module (`target: "residual/unhandled"`) for this
@@ -97,6 +103,7 @@ impl<'a> FixtureOpts<'a> {
             source,
             logical_modules,
             residual: None,
+            chunk_renames: None,
             chunk_id: "static/app",
             include_residual: true,
             extra_files: &[],
@@ -418,11 +425,16 @@ fn build_spec(opts: &FixtureOpts<'_>, setup: &FixtureSetup) -> Value {
         }),
         (None, false) => json!({}),
     };
+    let chunk_renames = match &opts.chunk_renames {
+        Some(renames) => json!({ chunk_id: renames }),
+        None => json!({}),
+    };
     json!({
         "kind": "js.ast_transform_spec",
         "inputs": { "inputRoot": setup.snapshot_root, "jsListPath": setup.js_list_path },
         "logicalModules": logical_modules,
         "residualModules": residual_modules,
+        "chunkRenames": chunk_renames,
         "materializeLogicalModules": {
             "chunkIds": [chunk_id],
             "pruneOtherChunks": false,

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -662,9 +662,51 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
     // module plan via the disambiguate-imports pass below;
     // chunk_renames entries for those bindings are silently
     // dropped here (the logical-module rename wins).
+    //
+    // Each accepted target name is reserved in `occupied` before the
+    // import-disambiguation pass runs, so a later cross-module
+    // import doesn't mint a fresh local that collides with one of
+    // the chunk_renames' targets. Conflicting targets (target name
+    // already taken by a body local that isn't being renamed away,
+    // or by another chunk_renames entry, or invalid as an
+    // identifier) bail rather than producing invalid JS silently.
+    let mut renamed_away = BTreeSet::<String>::new();
+    for (binding, _) in chunk_renames {
+        if binding_assignment.contains_key(binding) {
+            continue;
+        }
+        renamed_away.insert(binding.clone());
+    }
     for (binding, export_name) in chunk_renames {
         if binding_assignment.contains_key(binding) {
             continue;
+        }
+        if !is_valid_js_identifier(export_name) {
+            bail!(
+                "chunk_renames target {export_name} for binding {binding} is not a valid JS identifier",
+            );
+        }
+        if export_name != binding {
+            // A body local that's also being renamed away vacates
+            // its slot in `occupied` — it's safe to reuse. Anything
+            // else still in `occupied` would collide.
+            let target_already_taken =
+                occupied.contains(export_name) && !renamed_away.contains(export_name);
+            if target_already_taken {
+                bail!(
+                    "chunk_renames target {export_name} for binding {binding} collides with an existing top-level local",
+                );
+            }
+        }
+        if !occupied.insert(export_name.clone()) && export_name != binding {
+            // `occupied.insert` returns false if already present;
+            // for the rename-to-self case (export_name == binding)
+            // that's expected. For any other case the target was
+            // already chosen by a previous chunk_renames entry —
+            // duplicate target.
+            bail!(
+                "chunk_renames target {export_name} for binding {binding} duplicates an earlier rename target",
+            );
         }
         body_renames.insert(binding.clone(), export_name.clone());
     }
@@ -951,6 +993,24 @@ fn logical_requests_for_chunk(
 /// map. Bindings that appear more than once across `members` fail
 /// fast — silently last-write-wins on a binding rename is the same
 /// hazard as duplicate logical-module member bindings.
+/// True iff `s` is a valid JavaScript identifier — start char is
+/// `[A-Za-z_$]` and rest is `[A-Za-z0-9_$]`. Reserved words are not
+/// rejected (a target named e.g. `class` or `let` would still trip
+/// at parse time downstream, but that's a louder failure than this
+/// shallow check would catch). The intent is to filter typos
+/// (`with-dash`, `0digit`, empty string) from spec authors.
+fn is_valid_js_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
 fn collect_chunk_renames(chunk_renames: &ChunkRenames) -> Result<BTreeMap<String, String>> {
     let mut renames = BTreeMap::<String, String>::new();
     let id = chunk_renames.id.as_deref().unwrap_or("chunk_renames");

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -21,7 +21,7 @@ use schedule_validator::{
     BindingKind, BindingName, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
     Schedule, analyze_chunk_facts, find_top_level_await, render_cycle_summary,
 };
-use spec::{BindingSourceKind, LogicalModule, MemberPurity, ResidualModule};
+use spec::{BindingSourceKind, ChunkRenames, LogicalModule, MemberPurity, ResidualModule};
 
 const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";
@@ -156,6 +156,7 @@ pub fn materialize_logical_modules(
     artifact: &mut JsPipelineArtifact,
     logical_modules: &BTreeMap<String, BTreeMap<String, LogicalModule>>,
     residual_modules: &BTreeMap<String, ResidualModule>,
+    chunk_renames: &BTreeMap<String, ChunkRenames>,
     options: MaterializeLogicalModulesOptions,
 ) -> Result<LogicalModuleManifest> {
     if options.chunk_ids.is_empty() {
@@ -217,6 +218,7 @@ pub fn materialize_logical_modules(
         let requests = logical_requests_for_chunk(
             logical_modules.get(&chunk_id),
             residual_modules.get(&chunk_id),
+            chunk_renames.contains_key(&chunk_id),
             &chunk_id,
             &target_dir,
         )?;
@@ -395,6 +397,11 @@ pub fn materialize_logical_modules(
             );
         }
 
+        let chunk_renames_map = chunk_renames
+            .get(&chunk_id)
+            .map(|cr| collect_chunk_renames(cr))
+            .transpose()?
+            .unwrap_or_default();
         let lowered = lower_chunk(LowerChunkInputs {
             artifact,
             runtime_ast,
@@ -406,6 +413,7 @@ pub fn materialize_logical_modules(
             module_plans: &module_plans,
             binding_assignment: &binding_assignment,
             schedule: &schedule,
+            chunk_renames: &chunk_renames_map,
         })?;
 
         let mut files = BTreeMap::new();
@@ -565,6 +573,12 @@ struct LowerChunkInputs<'a> {
     module_plans: &'a [ModulePlan],
     binding_assignment: &'a BTreeMap<String, usize>,
     schedule: &'a Schedule,
+    /// In-place renames from `TransformSpec::chunk_renames`. Applied
+    /// to bindings staying in entry's body — i.e. those *not* in
+    /// `binding_assignment`. Bindings claimed by a logical module
+    /// take their rename from the module plan; entries here for
+    /// those bindings are silently dropped.
+    chunk_renames: &'a BTreeMap<String, String>,
 }
 
 fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
@@ -579,6 +593,7 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
         module_plans,
         binding_assignment,
         schedule,
+        chunk_renames,
     } = inputs;
     let mut selected_ordinals = BTreeSet::new();
     for decl in declarations {
@@ -641,6 +656,18 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
     let mut entry_imports: Vec<(usize, ModuleItem)> = Vec::new();
     let mut occupied = collect_occupied_local_names(&entry_body);
     let mut body_renames = BTreeMap::<String, String>::new();
+    // Seed body_renames with `chunk_renames` entries for bindings
+    // staying in entry's body (not claimed by any logical module).
+    // Bindings owned by a logical module take their rename from the
+    // module plan via the disambiguate-imports pass below;
+    // chunk_renames entries for those bindings are silently
+    // dropped here (the logical-module rename wins).
+    for (binding, export_name) in chunk_renames {
+        if binding_assignment.contains_key(binding) {
+            continue;
+        }
+        body_renames.insert(binding.clone(), export_name.clone());
+    }
     for (module_index, plan) in module_plans.iter().enumerate() {
         if plan.bindings.is_empty() {
             continue;
@@ -860,6 +887,7 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
 fn logical_requests_for_chunk(
     chunk_logical_modules: Option<&BTreeMap<String, LogicalModule>>,
     chunk_residual: Option<&ResidualModule>,
+    chunk_renames_present: bool,
     chunk_id: &str,
     target_dir: &str,
 ) -> Result<Vec<LogicalRequest>> {
@@ -900,7 +928,15 @@ fn logical_requests_for_chunk(
             members,
         });
     }
-    if requests.is_empty() {
+    // Fallback: when the spec is silent about this chunk (no
+    // `logical_modules` or `residual_modules` entry), inject a
+    // memberless residual so the materializer has at least one
+    // module to point unowned decls at. Skipped when the spec has
+    // any `chunk_renames` for the chunk — that signals the spec
+    // wants bindings to stay in `ResidualEntry`-land (no
+    // `Logical(R)` module, no separate residual file emitted), with
+    // renames applied in-place by the lowerer.
+    if requests.is_empty() && !chunk_renames_present {
         requests.push(LogicalRequest {
             id: "logical_module_0".to_string(),
             target_path: posix_join(&[target_dir, "unhandled"]),
@@ -909,6 +945,30 @@ fn logical_requests_for_chunk(
         });
     }
     Ok(requests)
+}
+
+/// Collect a `ChunkRenames` block into a `binding_name -> export_name`
+/// map. Bindings that appear more than once across `members` fail
+/// fast — silently last-write-wins on a binding rename is the same
+/// hazard as duplicate logical-module member bindings.
+fn collect_chunk_renames(chunk_renames: &ChunkRenames) -> Result<BTreeMap<String, String>> {
+    let mut renames = BTreeMap::<String, String>::new();
+    let id = chunk_renames.id.as_deref().unwrap_or("chunk_renames");
+    for member in &chunk_renames.members {
+        let binding = member.selector.binding.name.clone();
+        let export_name = member.name.clone().unwrap_or_else(|| binding.clone());
+        if let Some(existing) = renames.get(&binding) {
+            if existing != &export_name {
+                bail!(
+                    "chunk_renames {id}: binding {binding} already renamed to \
+                     {existing}; refusing to overwrite with {export_name}"
+                );
+            }
+        } else {
+            renames.insert(binding, export_name);
+        }
+    }
+    Ok(renames)
 }
 
 fn build_members(members: &[spec::Member]) -> Vec<MemberRequest> {

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -230,6 +230,7 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
                 &mut state.artifact,
                 &spec.logical_modules,
                 &spec.residual_modules,
+                &spec.chunk_renames,
                 MaterializeLogicalModulesOptions {
                     chunk_ids,
                     file,

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -39,6 +39,23 @@ pub struct TransformSpec {
     pub logical_modules: BTreeMap<String, BTreeMap<String, LogicalModule>>,
     #[serde(default)]
     pub residual_modules: BTreeMap<String, ResidualModule>,
+    /// Per-chunk in-place renames for bindings staying in entry's
+    /// body (i.e. *not* assigned to a logical module and not pulled
+    /// into the explicit residual). The materializer collects these
+    /// into a `binding_name -> export_name` map; the lowerer rewrites
+    /// identifiers in entry's source AST during chunk lowering. No
+    /// `Logical(R)` module is created for these bindings, no separate
+    /// residual file is emitted, and the orphan-statement node
+    /// (`ModuleId::ResidualEntry`) keeps owning the bindings — which
+    /// avoids the 2-module SCC the residual-member-rename path would
+    /// otherwise create when orphan stmts and residual decls
+    /// interleave with side-effecting initializers.
+    ///
+    /// Bindings claimed by a logical module take their rename from
+    /// the module plan; the `chunk_renames` entry (if any) is dropped
+    /// for those.
+    #[serde(default)]
+    pub chunk_renames: BTreeMap<String, ChunkRenames>,
 
     // --- per-stage configuration (presence gates the stage) ---
     /// When `true`, run `rewrite_chunk_entry_specifiers` after the
@@ -118,6 +135,17 @@ pub struct EmitBrowserHarnessConfig {
     pub snapshot_root: PathBuf,
     #[serde(default)]
     pub force: bool,
+}
+
+/// Container for per-chunk in-place renames; see
+/// [`TransformSpec::chunk_renames`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ChunkRenames {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub members: Vec<Member>,
 }
 
 fn default_true() -> bool {


### PR DESCRIPTION
## Summary

Adds a new top-level field `chunkRenames` to `TransformSpec`, a `BTreeMap<chunkId, ChunkRenames>` carrying rename info for bindings that should stay in the chunk's entry file (no logical module created, no separate residual file emitted, and the orphan-statement node `ModuleId::ResidualEntry` keeps owning the bindings — which avoids the 2-module SCC the residual-member-rename path would otherwise create when orphan stmts and residual decls interleave with side-effecting initializers).

Bindings claimed by a logical module take their rename from the module plan; the `chunk_renames` entry (if any) is dropped for those.

## Why this op exists

The gaffer-side `.yaml.deferred` workflow (per gaffer PR #29) parks SCC bindings in residual to clear the cycle gate while keeping their readable names. Previously the rename info rode on `residualModules[chunkId].members` so PR #1499's residual-member-rename support applied them. That works mechanically but the residual-member-rename path needs a `Logical(R)` module, which the validator treats as a distinct node from `ModuleId::ResidualEntry`. When the chunk interleaves orphan top-level statements (`console.log(x)`, owner = `ResidualEntry`) with side-effecting initializers on residual-owned decls (owner = `Logical(R)`), the S-edge ordering loop produces a 2-module SCC. Both nodes emit into files that evaluate in the chunk's same init phase — the cycle is a validator artifact — but the gate still rejects.

`chunk_renames` decouples renames from module ownership.

## Auto-residual fallback

`logical_requests_for_chunk` previously injected a memberless residual when the chunk had no `logical_modules` or `residual_modules` entry. That fallback now skips when the chunk has any `chunk_renames` entry — the spec is explicitly asking for "no logical residual; let bindings stay in the entry file."

## Rebase note

This PR replaces an earlier flat-op shape (`apply_main_chunk_renames`) that targeted the pre-#1500 spec format. PR #1500's typed-spec refactor moved away from `operations: [...]` to top-level typed maps; `chunkRenames` is the corresponding shape under that new design.

## Test plan

- [x] `bazel test //devinfra/js/debundle/...` — 17/17 pass.
- [x] **`chunk_renames_test`**: 4-statement fixture (orphan side-effect → residual decl with side-effecting init → orphan side-effect that reads it → export). With `chunkRenames` renaming the residual decl, the spec is realizable, the entry source is rewritten in-place (`let x = ...` → `let payload = ...`), and the chunk runs to completion with the new name.
- [x] Old behavior (the residual-member-rename path with explicit `residualModules[chunkId].members`) remains supported: `residual_member_rename_test` still passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)