### PR TITLE
debundle: drop user-supplied pipeline[] for canonical-order stages

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -383,16 +383,13 @@ the Bazel tree.
 ## Spec-level `inputs`
 
 `load_js_chunks`, `compute_js_asts`, and `normalize_js_chunks` are always-on
-startup steps run before the pipeline loop — they are not pipeline operations.
-The spec configures them via a top-level `inputs: { inputRoot, jsListPath }`
-object. Listing any of these three operations as a pipeline stage is a hard
-error.
+startup steps run before the rest of the pipeline. The spec configures them
+via a top-level `inputs: { inputRoot, jsListPath }` object.
 
 ## Spec-level declarative sections
 
-The spec carries three declarative top-level maps. There is no `operations[]`
-array; pipeline stages read these maps directly via typed serde structs in
-<spec.rs>.
+The spec carries three declarative top-level maps. Pipeline stages read these
+maps directly via typed serde structs in <spec.rs>.
 
 - `vendor` — keyed by chunk path (`"static/lib.js"` → `VendorMark`). The
   `level` discriminator selects between `suppress` / `boundary-rename` /
@@ -404,6 +401,10 @@ array; pipeline stages read these maps directly via typed serde structs in
   `(chunkId, targetPath)` uniqueness a parser property.
 - `residualModules` — keyed by chunk id (`"static/app"` → `ResidualModule`).
   The map shape encodes the "at most one residual per chunk" invariant.
+
+Stages run in a fixed canonical order, gated by the data sections and the
+optional per-stage config fields on [`spec::TransformSpec`]. There is no
+user-supplied pipeline list.
 
 ## Materialize logical-modules `targetDir`
 

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -423,14 +423,12 @@ fn build_spec(opts: &FixtureOpts<'_>, setup: &FixtureSetup) -> Value {
         "inputs": { "inputRoot": setup.snapshot_root, "jsListPath": setup.js_list_path },
         "logicalModules": logical_modules,
         "residualModules": residual_modules,
-        "pipeline": [
-            {
-                "id": "logical",
-                "operation": "materialize_logical_modules",
-                "args": { "chunkIds": [chunk_id], "pruneOtherChunks": false, "targetDir": "modules" },
-            },
-            { "id": "write", "operation": "write_js_tree", "args": { "force": true, "outDir": setup.out_root } },
-        ],
+        "materializeLogicalModules": {
+            "chunkIds": [chunk_id],
+            "pruneOtherChunks": false,
+            "targetDir": "modules",
+        },
+        "writeJsTree": { "force": true, "outDir": setup.out_root },
     })
 }
 

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -233,24 +233,12 @@ fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
             },
         },
         "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
-        "pipeline": [
-            { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
-            { "id": "rename_vendor", "operation": "rename_vendor_exports" },
-            {
-                "id": "swap_vendor",
-                "operation": "swap_vendor_chunks",
-                "args": {
-                    "outputManifestPath": args.manifest_path,
-                    "outputWrapperDir": args.wrapper_root,
-                    "write": true,
-                },
-            },
-            {
-                "id": "write",
-                "operation": "write_js_tree",
-                "args": { "force": true, "outDir": args.out_root },
-            },
-        ],
+        "swapVendorChunks": {
+            "outputManifestPath": args.manifest_path,
+            "outputWrapperDir": args.wrapper_root,
+            "write": true,
+        },
+        "writeJsTree": { "force": true, "outDir": args.out_root },
     })
 }
 
@@ -457,23 +445,11 @@ fn build_named_from_default_spec(args: BuildSpecArgs<'_>) -> Value {
             },
         },
         "inputs": { "inputRoot": args.snapshot_root, "jsListPath": args.js_list_path },
-        "pipeline": [
-            { "id": "annotate_vendor", "operation": "apply_vendor_annotations" },
-            { "id": "rename_vendor", "operation": "rename_vendor_exports" },
-            {
-                "id": "swap_vendor",
-                "operation": "swap_vendor_chunks",
-                "args": {
-                    "outputManifestPath": args.manifest_path,
-                    "outputWrapperDir": args.wrapper_root,
-                    "write": true,
-                },
-            },
-            {
-                "id": "write",
-                "operation": "write_js_tree",
-                "args": { "force": true, "outDir": args.out_root },
-            },
-        ],
+        "swapVendorChunks": {
+            "outputManifestPath": args.manifest_path,
+            "outputWrapperDir": args.wrapper_root,
+            "write": true,
+        },
+        "writeJsTree": { "force": true, "outDir": args.out_root },
     })
 }

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -6,14 +6,14 @@ use std::time::Instant;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use runfiles::{Runfiles, rlocation};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use artifact::{JsPipelineArtifact, compute_js_asts, load_js_chunks};
 use emit_harness::{EmitBrowserHarnessOptions, emit_browser_harness};
 use logical_modules::{MaterializeLogicalModulesOptions, materialize_logical_modules};
 use normalize::normalize_js_chunks;
 use rewrite_specifiers::rewrite_chunk_entry_specifiers;
-use spec::TransformSpec;
+use spec::{MaterializeLogicalModulesConfig, SwapVendorChunksConfig, TransformSpec, VendorLevel};
 use vendor::{
     SwapVendorOptions, apply_vendor_annotations, rename_vendor_exports, swap_vendor_chunks,
 };
@@ -96,46 +96,9 @@ pub struct TransformRunSummary {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TransformStepSummary {
-    pub id: String,
     pub operation: String,
     pub duration_ms: Option<f64>,
     pub manifest_kind: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct EmitBrowserHarnessArgs {
-    asset_summary_path: PathBuf,
-    force: Option<bool>,
-    out_dir: PathBuf,
-    snapshot_root: PathBuf,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SwapVendorChunksArgs {
-    output_manifest_path: Option<PathBuf>,
-    output_wrapper_dir: Option<PathBuf>,
-    write: Option<bool>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct MaterializeLogicalModulesArgs {
-    chunk_ids: Vec<String>,
-    file: Option<String>,
-    prune_other_chunks: Option<bool>,
-    force: Option<bool>,
-    report_out_dir: Option<PathBuf>,
-    report_summary_path: Option<PathBuf>,
-    target_dir: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WriteJsTreeArgs {
-    force: Option<bool>,
-    out_dir: PathBuf,
 }
 
 #[derive(Default)]
@@ -174,8 +137,7 @@ pub fn render_transform_summary(summary: &TransformRunSummary) -> String {
     );
     for step in &summary.steps {
         out.push_str(&format!(
-            "- {}: {} ({}){}\n",
-            step.id,
+            "- {} ({}){}\n",
             step.operation,
             format_duration(step.duration_ms.unwrap_or(0.0)),
             step.manifest_kind
@@ -200,15 +162,107 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
     state.artifact = artifact;
     let mut steps = Vec::new();
 
-    for stage in &spec.pipeline {
-        let stage_started = Instant::now();
-        let manifest_kind = run_transform_stage(&mut state, stage, &spec, cli)?;
-        steps.push(TransformStepSummary {
-            id: stage.id.clone(),
-            operation: stage.operation.clone(),
-            duration_ms: Some(elapsed_ms(stage_started)),
-            manifest_kind,
-        });
+    if spec.rewrite_chunk_entry_specifiers {
+        run_step(&mut steps, "rewrite_chunk_entry_specifiers", || {
+            rewrite_chunk_entry_specifiers(&mut state.artifact).map(|m| Some(m.kind.to_string()))
+        })?;
+    }
+
+    // Vendor stages: each is internally filtered by `level`, so it's
+    // safe to always invoke them when `vendor` carries any entries.
+    // `apply` runs unconditionally; `rename` and `swap` short-circuit
+    // to no-ops when no entry has the right level.
+    if !spec.vendor.is_empty() {
+        run_step(&mut steps, "apply_vendor_annotations", || {
+            apply_vendor_annotations(&state.artifact, &spec.vendor)
+                .map(|m| Some(m.kind.to_string()))
+        })?;
+        if spec
+            .vendor
+            .values()
+            .any(|m| matches!(m.level, VendorLevel::BoundaryRename | VendorLevel::Swap(_)))
+        {
+            run_step(&mut steps, "rename_vendor_exports", || {
+                rename_vendor_exports(&mut state.artifact, &spec.vendor)
+                    .map(|m| Some(m.kind.to_string()))
+            })?;
+        }
+        if spec
+            .vendor
+            .values()
+            .any(|m| matches!(m.level, VendorLevel::Swap(_)))
+        {
+            let cfg = spec.swap_vendor_chunks.clone().unwrap_or_default();
+            let SwapVendorChunksConfig {
+                output_manifest_path,
+                output_wrapper_dir,
+                write,
+            } = cfg;
+            run_step(&mut steps, "swap_vendor_chunks", || {
+                swap_vendor_chunks(
+                    &mut state.artifact,
+                    &spec.vendor,
+                    SwapVendorOptions {
+                        package_roots: &cli.package_roots,
+                        packages_root: &cli.packages_root,
+                        output_manifest_path,
+                        output_wrapper_dir,
+                        write,
+                    },
+                )
+                .map(|m| Some(m.kind.to_string()))
+            })?;
+        }
+    }
+
+    if let Some(cfg) = &spec.materialize_logical_modules {
+        let MaterializeLogicalModulesConfig {
+            chunk_ids,
+            file,
+            prune_other_chunks,
+            force,
+            report_out_dir,
+            report_summary_path,
+            target_dir,
+        } = cfg.clone();
+        run_step(&mut steps, "materialize_logical_modules", || {
+            materialize_logical_modules(
+                &mut state.artifact,
+                &spec.logical_modules,
+                &spec.residual_modules,
+                MaterializeLogicalModulesOptions {
+                    chunk_ids,
+                    file,
+                    prune_other_chunks,
+                    force,
+                    report_out_dir,
+                    report_summary_path,
+                    target_dir,
+                },
+            )
+            .map(|m| Some(m.kind.to_string()))
+        })?;
+    }
+
+    if let Some(cfg) = &spec.write_js_tree {
+        let out_dir = cfg.out_dir.clone();
+        let force = cfg.force;
+        run_step(&mut steps, "write_js_tree", || {
+            write_js_tree(&state.artifact, &out_dir, force).map(|m| Some(m.kind.to_string()))
+        })?;
+    }
+
+    if let Some(cfg) = &spec.emit_browser_harness {
+        let opts = EmitBrowserHarnessOptions {
+            asset_summary_path: cfg.asset_summary_path.clone(),
+            force: cfg.force,
+            out_dir: cfg.out_dir.clone(),
+            snapshot_root: cfg.snapshot_root.clone(),
+        };
+        run_step(&mut steps, "emit_browser_harness", || {
+            emit_browser_harness(&state.artifact, &opts)?;
+            Ok(None)
+        })?;
     }
 
     Ok(TransformRunSummary {
@@ -218,91 +272,19 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
     })
 }
 
-fn run_transform_stage(
-    state: &mut TransformState,
-    stage: &spec::TransformStage,
-    spec: &TransformSpec,
-    cli: &TransformCli,
-) -> Result<Option<String>> {
-    let args = stage.args.clone();
-    let operation = stage.operation.as_str();
-    match operation {
-        "rewrite_chunk_entry_specifiers" => {
-            let manifest = rewrite_chunk_entry_specifiers(&mut state.artifact)?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "apply_vendor_annotations" => {
-            let manifest = apply_vendor_annotations(&state.artifact, &spec.vendor)?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "rename_vendor_exports" => {
-            let manifest = rename_vendor_exports(&mut state.artifact, &spec.vendor)?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "swap_vendor_chunks" => {
-            let args = args
-                .map(serde_json::from_value::<SwapVendorChunksArgs>)
-                .transpose()?
-                .unwrap_or(SwapVendorChunksArgs {
-                    output_manifest_path: None,
-                    output_wrapper_dir: None,
-                    write: None,
-                });
-            let manifest = swap_vendor_chunks(
-                &mut state.artifact,
-                &spec.vendor,
-                SwapVendorOptions {
-                    package_roots: &cli.package_roots,
-                    packages_root: &cli.packages_root,
-                    output_manifest_path: args.output_manifest_path,
-                    output_wrapper_dir: args.output_wrapper_dir,
-                    write: args.write.unwrap_or(true),
-                },
-            )?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "materialize_logical_modules" => {
-            let args: MaterializeLogicalModulesArgs =
-                serde_json::from_value(args.context("materialize_logical_modules requires args")?)?;
-            let manifest = materialize_logical_modules(
-                &mut state.artifact,
-                &spec.logical_modules,
-                &spec.residual_modules,
-                MaterializeLogicalModulesOptions {
-                    chunk_ids: args.chunk_ids,
-                    file: args.file,
-                    prune_other_chunks: args.prune_other_chunks.unwrap_or(true),
-                    force: args.force.unwrap_or(false),
-                    report_out_dir: args.report_out_dir,
-                    report_summary_path: args.report_summary_path,
-                    target_dir: args.target_dir.unwrap_or_default(),
-                },
-            )?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "write_js_tree" => {
-            let args: WriteJsTreeArgs =
-                serde_json::from_value(args.context("write_js_tree requires args")?)?;
-            let manifest =
-                write_js_tree(&state.artifact, &args.out_dir, args.force.unwrap_or(false))?;
-            Ok(Some(manifest.kind.to_string()))
-        }
-        "emit_browser_harness" => {
-            let args: EmitBrowserHarnessArgs =
-                serde_json::from_value(args.context("emit_browser_harness requires args")?)?;
-            emit_browser_harness(
-                &state.artifact,
-                &EmitBrowserHarnessOptions {
-                    asset_summary_path: args.asset_summary_path,
-                    force: args.force.unwrap_or(false),
-                    out_dir: args.out_dir,
-                    snapshot_root: args.snapshot_root,
-                },
-            )?;
-            Ok(None)
-        }
-        _ => bail!("No registered stage handler for operation {operation}"),
-    }
+fn run_step(
+    steps: &mut Vec<TransformStepSummary>,
+    name: &'static str,
+    body: impl FnOnce() -> Result<Option<String>>,
+) -> Result<()> {
+    let started = Instant::now();
+    let manifest_kind = body()?;
+    steps.push(TransformStepSummary {
+        operation: name.to_string(),
+        duration_ms: Some(elapsed_ms(started)),
+        manifest_kind,
+    });
+    Ok(())
 }
 
 fn load_transform_spec(spec_path: &Path) -> Result<TransformSpec> {
@@ -322,19 +304,6 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
     }
     if spec.inputs.js_list_path.as_os_str().is_empty() {
         bail!("Transform spec inputs.jsListPath must not be empty");
-    }
-    let mut seen_stage_ids = HashSet::new();
-    for stage in &spec.pipeline {
-        if stage.id == stage.operation {
-            bail!(
-                "Pipeline stage {} must differ from operation {}",
-                stage.id,
-                stage.operation,
-            );
-        }
-        if !seen_stage_ids.insert(stage.id.clone()) {
-            bail!("Duplicate pipeline stage id: {}", stage.id);
-        }
     }
     Ok(())
 }
@@ -492,22 +461,13 @@ mod tests {
                     "inputRoot": snapshot,
                     "jsListPath": extracted.join("js-files.txt"),
                 },
-                "pipeline": [
-                    {
-                        "id": "rewrite",
-                        "operation": "rewrite_chunk_entry_specifiers",
-                    },
-                    {
-                        "id": "emit",
-                        "operation": "emit_browser_harness",
-                        "args": {
-                            "assetSummaryPath": extracted.join("asset-summary.json"),
-                            "force": true,
-                            "outDir": out,
-                            "snapshotRoot": snapshot,
-                        },
-                    },
-                ],
+                "rewriteChunkEntrySpecifiers": true,
+                "emitBrowserHarness": {
+                    "assetSummaryPath": extracted.join("asset-summary.json"),
+                    "force": true,
+                    "outDir": out,
+                    "snapshotRoot": snapshot,
+                },
             }))?,
         )?;
 

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -1,14 +1,22 @@
 //! Typed deserialisation surface for `js.ast_transform_spec` JSONC files.
 //!
-//! The spec carries three declarative top-level maps consumed by pipeline
-//! stages:
+//! Three declarative top-level maps describe what the spec wants applied:
 //!
 //! - `vendor` keyed by chunk path (`"static/lib.js"` → [`VendorMark`]).
-//! - `logical_modules` keyed by chunk id, then target path
+//! - `logicalModules` keyed by chunk id, then target path
 //!   (`"static/app"` → `"foo/bar/baz.js"` → [`LogicalModule`]).
-//! - `residual_modules` keyed by chunk id (`"static/app"` →
+//! - `residualModules` keyed by chunk id (`"static/app"` →
 //!   [`ResidualModule`]). At most one residual per chunk — encoded by the
 //!   map shape.
+//!
+//! Each pipeline stage that needs configuration gets its own optional
+//! top-level field ([`TransformSpec::materialize_logical_modules`],
+//! [`TransformSpec::write_js_tree`], [`TransformSpec::emit_browser_harness`],
+//! [`TransformSpec::swap_vendor_chunks`]). Stages run in a fixed canonical
+//! order, gated by the presence of their config (or — for the vendor
+//! stages and `rewriteChunkEntrySpecifiers` — by an explicit boolean
+//! toggle and the contents of the declarative maps). There is no
+//! user-supplied pipeline list.
 //!
 //! All consumers see typed structs; nothing here returns
 //! `serde_json::Value` for a known field.
@@ -19,26 +27,39 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TransformSpec {
     pub kind: String,
     pub inputs: LoadJsChunksArgs,
-    pub pipeline: Vec<TransformStage>,
+
+    // --- declarative data sections ---
     #[serde(default)]
     pub vendor: BTreeMap<String, VendorMark>,
     #[serde(default)]
     pub logical_modules: BTreeMap<String, BTreeMap<String, LogicalModule>>,
     #[serde(default)]
     pub residual_modules: BTreeMap<String, ResidualModule>,
-}
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransformStage {
-    pub id: String,
-    pub operation: String,
+    // --- per-stage configuration (presence gates the stage) ---
+    /// When `true`, run `rewrite_chunk_entry_specifiers` after the
+    /// always-on startup steps. The stage takes no arguments.
     #[serde(default)]
-    pub args: Option<serde_json::Value>,
+    pub rewrite_chunk_entry_specifiers: bool,
+    /// Optional output configuration for `swap_vendor_chunks`. The stage
+    /// itself runs whenever `vendor` contains any `level: swap` entries;
+    /// this field only adds output paths and a `write` toggle.
+    #[serde(default)]
+    pub swap_vendor_chunks: Option<SwapVendorChunksConfig>,
+    /// When set, run `materialize_logical_modules`. `chunkIds` is
+    /// required.
+    #[serde(default)]
+    pub materialize_logical_modules: Option<MaterializeLogicalModulesConfig>,
+    /// When set, persist the artifact tree to `outDir`.
+    #[serde(default)]
+    pub write_js_tree: Option<WriteJsTreeConfig>,
+    /// When set, emit a browser-runtime harness alongside the artifact.
+    #[serde(default)]
+    pub emit_browser_harness: Option<EmitBrowserHarnessConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +67,61 @@ pub struct TransformStage {
 pub struct LoadJsChunksArgs {
     pub input_root: PathBuf,
     pub js_list_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SwapVendorChunksConfig {
+    #[serde(default)]
+    pub output_manifest_path: Option<PathBuf>,
+    #[serde(default)]
+    pub output_wrapper_dir: Option<PathBuf>,
+    /// Defaults to `true` — actually write the manifest / wrapper files
+    /// to disk. Set `false` for dry-run.
+    #[serde(default = "default_true")]
+    pub write: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MaterializeLogicalModulesConfig {
+    pub chunk_ids: Vec<String>,
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Defaults to `true` — drop chunks not in `chunkIds` before
+    /// materialising. Set `false` to keep them.
+    #[serde(default = "default_true")]
+    pub prune_other_chunks: bool,
+    #[serde(default)]
+    pub force: bool,
+    #[serde(default)]
+    pub report_out_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub report_summary_path: Option<PathBuf>,
+    #[serde(default)]
+    pub target_dir: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WriteJsTreeConfig {
+    pub out_dir: PathBuf,
+    #[serde(default)]
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EmitBrowserHarnessConfig {
+    pub asset_summary_path: PathBuf,
+    pub out_dir: PathBuf,
+    pub snapshot_root: PathBuf,
+    #[serde(default)]
+    pub force: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 // --- Vendor ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #1500. After the spec cutover to typed top-level sections, the user-supplied `pipeline[]` array mostly retold what the typed sections already imply — the vendor stages are gated by which `level` values appear in `vendor`; materialize/write/emit each need their own args anyway. Drop `pipeline[]` entirely.

Stages now run in a fixed canonical order, gated by:

- `rewriteChunkEntrySpecifiers: bool` — toggle.
- `vendor` non-empty → `apply_vendor_annotations` runs.
- any vendor entry has level `boundary-rename` or `swap` → `rename_vendor_exports`.
- any vendor entry has level `swap` → `swap_vendor_chunks` (config in optional `swapVendorChunks: { outputManifestPath, outputWrapperDir, write }` field).
- `materializeLogicalModules: { chunkIds, ... }` present → `materialize_logical_modules`.
- `writeJsTree: { outDir, ... }` present → `write_js_tree`.
- `emitBrowserHarness: { ... }` present → `emit_browser_harness`.

Each stage's args become a typed `Option<StageConfig>` field on `TransformSpec`; presence of the option gates the stage. No more hand-rolled per-stage `serde_json::from_value` calls in `pipeline.rs`; no more `pipeline: [{id, operation, args}, ...]` array. `TransformStepSummary` loses its `id` field — there's no user-supplied id anymore, just the canonical operation name.

## Test plan

- [x] `bbr build //devinfra/js/debundle/...` — green
- [x] `bbr test //devinfra/js/debundle/...` — 16/16 pass (`buildbuddy:db159992-740f-445c-bdc5-4dda353b6dc6`)

https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx)_