### PR TITLE
debundle: flatten swap_vendor_chunks config; derive materialise chunk ids

### DIFF
--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -424,7 +424,6 @@ fn build_spec(opts: &FixtureOpts<'_>, setup: &FixtureSetup) -> Value {
         "logicalModules": logical_modules,
         "residualModules": residual_modules,
         "materializeLogicalModules": {
-            "chunkIds": [chunk_id],
             "pruneOtherChunks": false,
             "targetDir": "modules",
         },

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -192,12 +192,11 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
             .values()
             .any(|m| matches!(m.level, VendorLevel::Swap(_)))
         {
-            let cfg = spec.swap_vendor_chunks.clone().unwrap_or_default();
             let SwapVendorChunksConfig {
                 output_manifest_path,
                 output_wrapper_dir,
                 write,
-            } = cfg;
+            } = spec.swap_vendor_chunks.clone();
             run_step(&mut steps, "swap_vendor_chunks", || {
                 swap_vendor_chunks(
                     &mut state.artifact,
@@ -215,23 +214,30 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
         }
     }
 
-    if let Some(cfg) = &spec.materialize_logical_modules {
+    let materialise_chunk_ids: Vec<String> = spec
+        .logical_modules
+        .keys()
+        .chain(spec.residual_modules.keys())
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    if !materialise_chunk_ids.is_empty() {
         let MaterializeLogicalModulesConfig {
-            chunk_ids,
             file,
             prune_other_chunks,
             force,
             report_out_dir,
             report_summary_path,
             target_dir,
-        } = cfg.clone();
+        } = spec.materialize_logical_modules.clone();
         run_step(&mut steps, "materialize_logical_modules", || {
             materialize_logical_modules(
                 &mut state.artifact,
                 &spec.logical_modules,
                 &spec.residual_modules,
                 MaterializeLogicalModulesOptions {
-                    chunk_ids,
+                    chunk_ids: materialise_chunk_ids,
                     file,
                     prune_other_chunks,
                     force,

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -9,14 +9,12 @@
 //!   [`ResidualModule`]). At most one residual per chunk — encoded by the
 //!   map shape.
 //!
-//! Each pipeline stage that needs configuration gets its own optional
-//! top-level field ([`TransformSpec::materialize_logical_modules`],
-//! [`TransformSpec::write_js_tree`], [`TransformSpec::emit_browser_harness`],
-//! [`TransformSpec::swap_vendor_chunks`]). Stages run in a fixed canonical
-//! order, gated by the presence of their config (or — for the vendor
-//! stages and `rewriteChunkEntrySpecifiers` — by an explicit boolean
-//! toggle and the contents of the declarative maps). There is no
-//! user-supplied pipeline list.
+//! Pipeline stages run in a fixed canonical order; each stage is gated
+//! either by the contents of those maps or by an explicit boolean toggle
+//! (`rewriteChunkEntrySpecifiers`) or by the presence of a per-stage
+//! config field ([`TransformSpec::write_js_tree`],
+//! [`TransformSpec::emit_browser_harness`]). There is no user-supplied
+//! pipeline list.
 //!
 //! All consumers see typed structs; nothing here returns
 //! `serde_json::Value` for a known field.
@@ -40,20 +38,24 @@ pub struct TransformSpec {
     #[serde(default)]
     pub residual_modules: BTreeMap<String, ResidualModule>,
 
-    // --- per-stage configuration (presence gates the stage) ---
+    // --- per-stage configuration ---
     /// When `true`, run `rewrite_chunk_entry_specifiers` after the
     /// always-on startup steps. The stage takes no arguments.
     #[serde(default)]
     pub rewrite_chunk_entry_specifiers: bool,
-    /// Optional output configuration for `swap_vendor_chunks`. The stage
-    /// itself runs whenever `vendor` contains any `level: swap` entries;
-    /// this field only adds output paths and a `write` toggle.
+    /// Output configuration for `swap_vendor_chunks`. The stage runs
+    /// whenever `vendor` contains any `level: swap` entries; this field
+    /// only adds output paths and a `write` toggle. All inner fields
+    /// have defaults, so omitting `swapVendorChunks` is identical to
+    /// supplying an empty object.
     #[serde(default)]
-    pub swap_vendor_chunks: Option<SwapVendorChunksConfig>,
-    /// When set, run `materialize_logical_modules`. `chunkIds` is
-    /// required.
+    pub swap_vendor_chunks: SwapVendorChunksConfig,
+    /// Configuration for `materialize_logical_modules`. The stage runs
+    /// whenever `logicalModules ∪ residualModules` is non-empty; the
+    /// chunk ids it processes are exactly the union of those maps'
+    /// keys. This field only carries auxiliary options.
     #[serde(default)]
-    pub materialize_logical_modules: Option<MaterializeLogicalModulesConfig>,
+    pub materialize_logical_modules: MaterializeLogicalModulesConfig,
     /// When set, persist the artifact tree to `outDir`.
     #[serde(default)]
     pub write_js_tree: Option<WriteJsTreeConfig>,
@@ -85,11 +87,13 @@ pub struct SwapVendorChunksConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MaterializeLogicalModulesConfig {
-    pub chunk_ids: Vec<String>,
+    /// Optional override for the entry-file path to read per chunk.
+    /// Absent means "use the chunk's recorded entry file".
     #[serde(default)]
     pub file: Option<String>,
-    /// Defaults to `true` — drop chunks not in `chunkIds` before
-    /// materialising. Set `false` to keep them.
+    /// Defaults to `true` — drop chunks outside the materialised set
+    /// (the union of `logicalModules` and `residualModules` keys)
+    /// before materialising. Set `false` to keep them.
     #[serde(default = "default_true")]
     pub prune_other_chunks: bool,
     #[serde(default)]
@@ -100,6 +104,19 @@ pub struct MaterializeLogicalModulesConfig {
     pub report_summary_path: Option<PathBuf>,
     #[serde(default)]
     pub target_dir: String,
+}
+
+impl Default for MaterializeLogicalModulesConfig {
+    fn default() -> Self {
+        Self {
+            file: None,
+            prune_other_chunks: true,
+            force: false,
+            report_out_dir: None,
+            report_summary_path: None,
+            target_dir: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary

Two follow-up simplifications to the spec shape after #1502:

1. **`swap_vendor_chunks: Option<SwapVendorChunksConfig>` → `#[serde(default)] SwapVendorChunksConfig`.** All three inner fields (`outputManifestPath`, `outputWrapperDir`, `write`) already default. The `Option` wrapper meant nothing because the stage's run/skip is gated by `vendor` having `level: swap` entries, not by the config's presence. Spec author writes `swapVendorChunks: { write: false }` either way.

2. **Drop `chunkIds` from `MaterializeLogicalModulesConfig`** — derive the set from `logicalModules ∪ residualModules` keys instead. The chunk ids were duplicated (once as map keys, once in `chunkIds`); now they live in one place. Materialize runs iff the union is non-empty, matching the data-gating pattern the vendor stages already use. The remaining options (`file`, `pruneOtherChunks`, `force`, `reportOutDir`, `reportSummaryPath`, `targetDir`) collapse onto an unconditional `#[serde(default)]` field.

## Test plan

- [x] `bbr build //devinfra/js/debundle/...` — green
- [x] `bbr test //devinfra/js/debundle/...` — 16/16 pass (`buildbuddy:46c9a882-4624-4373-aab1-39b8000e7abe`)

https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx)_