### PR TITLE
debundle: drop id fields redundant to map keys; use json_comments crate

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "232663b809fc8f0fd91f3917c2f0f71306fe8ec31948ad2a2f932e8d0df34b0c",
+  "checksum": "115bb40e76a1cc3db8288658dee099d1d37ae0a50f4a5e9a4197b41d7a628539",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",
@@ -5268,6 +5268,10 @@
             {
               "id": "hyper-util 0.1.20",
               "target": "hyper_util"
+            },
+            {
+              "id": "json_comments 0.2.2",
+              "target": "json_comments"
             },
             {
               "id": "jsonwebtoken 9.3.1",
@@ -10947,6 +10951,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "json_comments 0.2.2": {
+      "name": "json_comments",
+      "version": "0.2.2",
+      "package_url": "https://github.com/tmccombs/json-comments-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/json_comments/0.2.2/download",
+          "sha256": "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "json_comments",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "json_comments",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.2.2"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
     },
     "jsonwebtoken 9.3.1": {
       "name": "jsonwebtoken",
@@ -32576,6 +32618,7 @@
     "http-body-util 0.1.3",
     "hyper 1.9.0",
     "hyper-util 0.1.20",
+    "json_comments 0.2.2",
     "jsonwebtoken 9.3.1",
     "libc 0.2.186",
     "log 0.4.29",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
+ "json_comments",
  "jsonwebtoken",
  "libc",
  "log",
@@ -1797,6 +1798,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json_comments"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonwebtoken"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ bytes = "^1.11.0"
 parking_lot = "^0.12.5"
 libc = "^0.2.172"
 jsonwebtoken = "^9.3.1"
+json_comments = "^0.2.2"
 # x/twenty_questions_frameworks/rig
 anyhow = "^1.0"
 # rig-core's default `reqwest-rustls` feature pulls aws-lc-rs → aws-lc-sys (needs cmake).

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -221,6 +221,7 @@ rust_library(
         ":write_tree",
         "@crates//:anyhow",
         "@crates//:clap",
+        "@crates//:json_comments",
         "@crates//:serde",
         "@crates//:serde_json",
         "@rules_rust//tools/runfiles",

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -117,14 +117,12 @@ export { aH };
             (
                 "mod_a".to_string(),
                 json!({
-                    "id": "logical__mod_a",
                     "members": [{ "name": "readableA", "selector": { "binding": { "name": "aH" } } }],
                 }),
             ),
             (
                 "mod_b".to_string(),
                 json!({
-                    "id": "logical__mod_b",
                     "members": [{ "name": "plainAh", "selector": { "binding": { "name": "aH" } } }],
                 }),
             ),
@@ -165,7 +163,6 @@ export { aH };
         vec![(
             "mod_a".to_string(),
             json!({
-                "id": "logical__mod_a",
                 "members": [{ "name": "readableA", "selector": { "binding": { "name": "aH" } } }],
             }),
         )],
@@ -240,7 +237,6 @@ export { a };
         vec![(
             "mod_x".to_string(),
             json!({
-                "id": "logical__mod_x",
                 "members": [{
                     "name": "Readable",
                     "selector": {
@@ -286,7 +282,6 @@ export { a };
             (
                 "mod_jsx_runtime".to_string(),
                 json!({
-                    "id": "logical__mod_jsx_runtime",
                     "members": [{
                         "name": "jsxRuntime",
                         "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
@@ -296,7 +291,6 @@ export { a };
             (
                 "mod_dunder_jsx".to_string(),
                 json!({
-                    "id": "logical__mod_dunder_jsx",
                     "members": [{
                         "name": "__jsx",
                         "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
@@ -341,7 +335,6 @@ export { bridge };
         vec![(
             "mod_x".to_string(),
             json!({
-                "id": "logical__mod_x",
                 "members": [{ "name": "bridge", "selector": { "binding": { "name": "bridge" } } }],
             }),
         )],
@@ -391,7 +384,6 @@ export { bridge };
             (
                 "mod_a".to_string(),
                 json!({
-                    "id": "logical__mod_a",
                     "members": [{
                         "name": "Re",
                         "selector": { "binding": { "name": "a", "kind": "ImportSpecifier" } },
@@ -401,7 +393,6 @@ export { bridge };
             (
                 "mod_b".to_string(),
                 json!({
-                    "id": "logical__mod_b",
                     "members": [{ "name": "bridge", "selector": { "binding": { "name": "bridge" } } }],
                 }),
             ),
@@ -453,7 +444,6 @@ export { composed };
             (
                 "mod_x".to_string(),
                 json!({
-                    "id": "logical__mod_x",
                     "members": [{
                         "name": "Composed",
                         "selector": { "binding": { "name": "composed" } },
@@ -463,7 +453,6 @@ export { composed };
             (
                 "mod_dep".to_string(),
                 json!({
-                    "id": "logical__mod_dep",
                     "members": [{
                         "name": "Dep",
                         "selector": { "binding": { "name": "dep", "kind": "ImportSpecifier" } },

--- a/devinfra/js/debundle/e2e/missing_binding_member_test.rs
+++ b/devinfra/js/debundle/e2e/missing_binding_member_test.rs
@@ -22,7 +22,6 @@ export { a };
         vec![(
             "mod_x".to_string(),
             json!({
-                "id": "logical__mod_x",
                 "members": [
                     { "name": "Foo", "selector": { "binding": { "name": "a" } } },
                     { "name": "Bar", "selector": { "binding": { "name": "b" } } },

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -59,7 +59,6 @@
 //!
 //! ```jsonc
 //! {
-//!   "id": "m_define_component",
 //!   "name": "defineComponent",
 //!   "selector": { "binding": { "name": "B" } },
 //!   "purity": "pure"   // ← new optional field
@@ -377,7 +376,6 @@ export { A, B, C, dispatcher };
             (
                 "mod_a".to_string(),
                 json!({
-                    "id": "logical__mod_a",
                     "members": [
                         { "name": "A", "selector": { "binding": { "name": "A" } } },
                         { "name": "C", "selector": { "binding": { "name": "C" } } },
@@ -396,7 +394,6 @@ export { A, B, C, dispatcher };
             (
                 "mod_b".to_string(),
                 json!({
-                    "id": "logical__mod_b",
                     "members": [
                         { "name": "B", "selector": { "binding": { "name": "B" } } },
                     ],
@@ -428,7 +425,6 @@ export { A, B, D, wrap };
                 (
                     "mod_a".to_string(),
                     json!({
-                        "id": "logical__mod_a",
                         "members": [
                             { "name": "A", "selector": { "binding": { "name": "A" } } },
                             { "name": "D", "selector": { "binding": { "name": "D" } } },
@@ -445,7 +441,6 @@ export { A, B, D, wrap };
                 (
                     "mod_b".to_string(),
                     json!({
-                        "id": "logical__mod_b",
                         "members": [
                             { "name": "B", "selector": { "binding": { "name": "B" } } },
                         ],
@@ -489,7 +484,6 @@ export { A, B, C, pureWrap, impureWrap };
             (
                 "mod_a".to_string(),
                 json!({
-                    "id": "logical__mod_a",
                     "members": [
                         { "name": "A", "selector": { "binding": { "name": "A" } } },
                         { "name": "C", "selector": { "binding": { "name": "C" } } },
@@ -510,7 +504,6 @@ export { A, B, C, pureWrap, impureWrap };
             (
                 "mod_b".to_string(),
                 json!({
-                    "id": "logical__mod_b",
                     "members": [
                         { "name": "B", "selector": { "binding": { "name": "B" } } },
                     ],
@@ -546,7 +539,6 @@ export { A, B, C, pureWrap, impureWrap };
                 (
                     "mod_a".to_string(),
                     json!({
-                        "id": "logical__mod_a",
                         "members": [
                             { "name": "A", "selector": { "binding": { "name": "A" } } },
                             { "name": "C", "selector": { "binding": { "name": "C" } } },
@@ -566,7 +558,6 @@ export { A, B, C, pureWrap, impureWrap };
                 (
                     "mod_b".to_string(),
                     json!({
-                        "id": "logical__mod_b",
                         "members": [
                             { "name": "B", "selector": { "binding": { "name": "B" } } },
                         ],

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -28,7 +28,6 @@ export { A, B, C, D };
             (
                 "mod_x".to_string(),
                 json!({
-                    "id": "logical__mod_x",
                     "members": [
                         { "name": "A", "selector": { "binding": { "name": "A" } } },
                         { "name": "D", "selector": { "binding": { "name": "D" } } },
@@ -38,7 +37,6 @@ export { A, B, C, D };
             (
                 "mod_y".to_string(),
                 json!({
-                    "id": "logical__mod_y",
                     "members": [
                         { "name": "B", "selector": { "binding": { "name": "B" } } },
                         { "name": "C", "selector": { "binding": { "name": "C" } } },
@@ -128,7 +126,6 @@ export { x1, y, x2 };
             (
                 "mod_a".to_string(),
                 json!({
-                    "id": "logical__mod_a",
                     "members": [
                         { "name": "x1", "selector": { "binding": { "name": "x1" } } },
                         { "name": "x2", "selector": { "binding": { "name": "x2" } } },
@@ -138,7 +135,6 @@ export { x1, y, x2 };
             (
                 "mod_b".to_string(),
                 json!({
-                    "id": "logical__mod_b",
                     "members": [
                         { "name": "y", "selector": { "binding": { "name": "y" } } },
                     ],

--- a/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
+++ b/devinfra/js/debundle/e2e/sibling_declarator_steal_test.rs
@@ -27,14 +27,12 @@ export { a, b, c };
             (
                 "mod_x".to_string(),
                 json!({
-                    "id": "logical__mod_x",
                     "members": [{ "name": "readableA", "selector": { "binding": { "name": "a" } } }],
                 }),
             ),
             (
                 "mod_y".to_string(),
                 json!({
-                    "id": "logical__mod_y",
                     "members": [{ "name": "readableC", "selector": { "binding": { "name": "c" } } }],
                 }),
             ),

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -55,11 +55,10 @@ impl Member {
 }
 
 /// One entry of the spec's `logicalModules[chunkId]` map: the target path
-/// (the map key) plus its body (id + members).
+/// (the map key) plus its body (members).
 pub type LogicalModuleEntry = (String, Value);
 
 pub fn logical_module(path: &str, members: &[Member]) -> LogicalModuleEntry {
-    let id = format!("logical__{}", path.replace('/', "_"));
     let member_values: Vec<Value> = members
         .iter()
         .map(|m| {
@@ -70,10 +69,7 @@ pub fn logical_module(path: &str, members: &[Member]) -> LogicalModuleEntry {
             })
         })
         .collect();
-    (
-        path.to_string(),
-        json!({ "id": id, "members": member_values }),
-    )
+    (path.to_string(), json!({ "members": member_values }))
 }
 
 pub struct FixtureOpts<'a> {
@@ -118,7 +114,6 @@ pub fn residual_module(target: &str, members: &[Member]) -> Value {
         })
         .collect();
     json!({
-        "id": "logical__residual_unhandled",
         "target": target,
         "members": member_values,
     })
@@ -411,10 +406,7 @@ fn build_spec(opts: &FixtureOpts<'_>, setup: &FixtureSetup) -> Value {
     let residual_modules = match (&opts.residual, opts.include_residual) {
         (Some(residual), _) => json!({ chunk_id: residual }),
         (None, true) => json!({
-            chunk_id: {
-                "id": "logical__residual_unhandled",
-                "target": "residual/unhandled",
-            }
+            chunk_id: { "target": "residual/unhandled" }
         }),
         (None, false) => json!({}),
     };

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -216,7 +216,6 @@ fn build_named_from_module_default_spec(args: BuildSpecArgs<'_>) -> Value {
         "kind": "js.ast_transform_spec",
         "vendor": {
             args.chunk_path: {
-                "id": "mark_vendor_lib",
                 "level": "swap",
                 "identity": format!("{}/{}", args.package_name, args.subpath),
                 "upstreamFamily": "Lib",
@@ -428,7 +427,6 @@ fn build_named_from_default_spec(args: BuildSpecArgs<'_>) -> Value {
         "kind": "js.ast_transform_spec",
         "vendor": {
             args.chunk_path: {
-                "id": "mark_vendor_lib",
                 "level": "swap",
                 "identity": format!("{}/{}", args.package_name, args.subpath),
                 "upstreamFamily": "Lib",

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -866,10 +866,7 @@ fn logical_requests_for_chunk(
     let mut requests = Vec::new();
     if let Some(by_target_path) = chunk_logical_modules {
         for (target_path, module) in by_target_path {
-            let id = module
-                .id
-                .clone()
-                .unwrap_or_else(|| default_logical_id(chunk_id, target_path));
+            let id = format!("{chunk_id}::{target_path}");
             let members = build_members(&module.members);
             reject_duplicate_export_names("logical_module", &id, &members)?;
             reject_duplicate_member_bindings("logical_module", &id, &members)?;
@@ -882,10 +879,7 @@ fn logical_requests_for_chunk(
         }
     }
     if let Some(residual) = chunk_residual {
-        let id = residual
-            .id
-            .clone()
-            .unwrap_or_else(|| default_residual_id(chunk_id));
+        let id = format!("{chunk_id}::residual");
         let target_path = residual
             .target
             .clone()
@@ -902,7 +896,7 @@ fn logical_requests_for_chunk(
     }
     if requests.is_empty() {
         requests.push(LogicalRequest {
-            id: "logical_module_0".to_string(),
+            id: format!("{chunk_id}::residual"),
             target_path: posix_join(&[target_dir, "unhandled"]),
             residual: true,
             members: Vec::new(),
@@ -928,17 +922,6 @@ fn build_members(members: &[spec::Member]) -> Vec<MemberRequest> {
             }
         })
         .collect()
-}
-
-/// Stable, human-readable id used in cycle reports / per-chunk requested
-/// summaries when the spec author leaves `id` blank. Chunk + path uniquely
-/// identifies the logical module under the new spec shape.
-fn default_logical_id(chunk_id: &str, target_path: &str) -> String {
-    format!("{chunk_id}::{target_path}")
-}
-
-fn default_residual_id(chunk_id: &str) -> String {
-    format!("{chunk_id}::residual")
 }
 
 fn collect_top_level_declarations(module: &Module) -> Vec<TopLevelDecl> {

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -294,10 +294,8 @@ fn run_step(
 }
 
 fn load_transform_spec(spec_path: &Path) -> Result<TransformSpec> {
-    let raw = fs::read_to_string(spec_path)
-        .with_context(|| format!("reading {}", spec_path.display()))?;
-    let stripped = strip_jsonc_comments(&raw);
-    serde_json::from_str(&stripped)
+    let raw = fs::read(spec_path).with_context(|| format!("reading {}", spec_path.display()))?;
+    serde_json::from_reader(json_comments::StripComments::new(raw.as_slice()))
         .with_context(|| format!("Failed to parse {} as JSONC", spec_path.display()))
 }
 
@@ -324,58 +322,6 @@ fn format_duration(duration_ms: f64) -> String {
     } else {
         format!("{duration_ms:.3}ms")
     }
-}
-
-fn strip_jsonc_comments(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
-    let mut in_string = false;
-    let mut escaping = false;
-    while let Some(ch) = chars.next() {
-        if in_string {
-            out.push(ch);
-            if escaping {
-                escaping = false;
-                continue;
-            }
-            match ch {
-                '\\' => escaping = true,
-                '"' => in_string = false,
-                _ => {}
-            }
-            continue;
-        }
-        match ch {
-            '"' => {
-                in_string = true;
-                out.push(ch);
-            }
-            '/' if matches!(chars.peek(), Some('/')) => {
-                chars.next();
-                for next in chars.by_ref() {
-                    if next == '\n' {
-                        out.push('\n');
-                        break;
-                    }
-                }
-            }
-            '/' if matches!(chars.peek(), Some('*')) => {
-                chars.next();
-                let mut prev = '\0';
-                for next in chars.by_ref() {
-                    if next == '\n' {
-                        out.push('\n');
-                    }
-                    if prev == '*' && next == '/' {
-                        break;
-                    }
-                    prev = next;
-                }
-            }
-            _ => out.push(ch),
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -151,7 +151,6 @@ fn default_true() -> bool {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VendorMark {
-    pub id: String,
     pub identity: String,
     pub evidence: Vec<Evidence>,
     #[serde(default)]
@@ -251,11 +250,6 @@ pub struct Fingerprint {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LogicalModule {
-    /// Optional human-readable id used in cycle reports and the per-chunk
-    /// requested-modules summary. Defaults to a stable derived value when
-    /// absent.
-    #[serde(default)]
-    pub id: Option<String>,
     #[serde(default)]
     pub members: Vec<Member>,
 }
@@ -263,8 +257,6 @@ pub struct LogicalModule {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ResidualModule {
-    #[serde(default)]
-    pub id: Option<String>,
     /// Logical-module path the residual catch-all writes to. Defaults to
     /// `"residual/unhandled"` when absent.
     #[serde(default)]

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -35,7 +35,6 @@ pub struct VendorAnnotationCounts {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VendorAnnotationSummary {
-    pub id: String,
     pub chunk_path: String,
     pub chunk_id: String,
     pub identity: String,
@@ -69,7 +68,7 @@ pub struct RenameVendorExportsCounts {
 
 #[derive(Debug, Clone)]
 pub struct RenameVendorExportsDetail {
-    pub op_id: String,
+    pub chunk_path: String,
     pub chunk_id: String,
     pub mapping_size: usize,
     pub rewrites: usize,
@@ -124,13 +123,12 @@ pub fn apply_vendor_annotations(
 ) -> Result<VendorAnnotationsManifest> {
     let mut summaries = Vec::with_capacity(vendor.len());
     for (chunk_path, mark) in vendor {
-        validate_evidence(mark)?;
-        let chunk_id = chunk_id_from_chunk_path(chunk_path, &mark.id, "mark_vendor")?;
+        if mark.evidence.is_empty() {
+            bail!("vendor entry {chunk_path} requires a non-empty evidence array");
+        }
+        let chunk_id = chunk_id_from_chunk_path(chunk_path, "mark_vendor")?;
         if get_chunk_entry_path(artifact, &chunk_id).is_none() {
-            bail!(
-                "mark_vendor operation {} targets missing chunk: chunkPath={chunk_path} (chunkId={chunk_id})",
-                mark.id,
-            );
+            bail!("vendor entry {chunk_path} targets missing chunk (chunkId={chunk_id})");
         }
         let (package, version, subpath) = match &mark.level {
             VendorLevel::Swap(swap) => (
@@ -141,7 +139,6 @@ pub fn apply_vendor_annotations(
             _ => (None, None, None),
         };
         summaries.push(VendorAnnotationSummary {
-            id: mark.id.clone(),
             chunk_path: chunk_path.clone(),
             chunk_id,
             identity: mark.identity.clone(),
@@ -164,16 +161,6 @@ pub fn apply_vendor_annotations(
     })
 }
 
-fn validate_evidence(mark: &VendorMark) -> Result<()> {
-    if mark.evidence.is_empty() {
-        bail!(
-            "mark_vendor operation {} requires a non-empty evidence array",
-            mark.id,
-        );
-    }
-    Ok(())
-}
-
 pub fn rename_vendor_exports(
     artifact: &mut JsPipelineArtifact,
     vendor: &BTreeMap<String, VendorMark>,
@@ -192,12 +179,12 @@ pub fn rename_vendor_exports(
     let mut chunks_with_mapping = 0usize;
     let mut details = Vec::new();
 
-    for (chunk_path, mark) in &ops {
-        let op_id = mark.id.as_str();
-        let chunk_id = chunk_id_from_chunk_path(chunk_path, op_id, "renameVendorExports")?;
+    for (chunk_path, _mark) in &ops {
+        let chunk_path_owned = (*chunk_path).clone();
+        let chunk_id = chunk_id_from_chunk_path(chunk_path, "renameVendorExports")?;
         let vendor_entry_relative_file = get_chunk_entry_path(artifact, &chunk_id).with_context(|| {
             format!(
-                "renameVendorExports operation {op_id} targets missing chunk: chunkPath={chunk_path} (chunkId={chunk_id})"
+                "renameVendorExports vendor entry {chunk_path_owned} targets missing chunk (chunkId={chunk_id})"
             )
         })?;
         let mapping = {
@@ -207,15 +194,13 @@ pub fn rename_vendor_exports(
                 .and_then(|chunk| chunk.files.get(&vendor_entry_relative_file))
                 .and_then(|file| file.ast.as_ref())
                 .with_context(|| {
-                    format!(
-                        "renameVendorExports operation {op_id} vendor chunk {chunk_id} is missing entry AST"
-                    )
+                    format!("renameVendorExports vendor chunk {chunk_id} is missing entry AST")
                 })?;
             collect_boundary_mapping(&vendor_ast.module)
         };
         if mapping.is_empty() {
             details.push(RenameVendorExportsDetail {
-                op_id: op_id.to_string(),
+                chunk_path: chunk_path_owned,
                 chunk_id,
                 mapping_size: 0,
                 rewrites: 0,
@@ -273,7 +258,7 @@ pub fn rename_vendor_exports(
 
         total_rewrites += chunk_rewrites;
         details.push(RenameVendorExportsDetail {
-            op_id: op_id.to_string(),
+            chunk_path: chunk_path_owned,
             chunk_id,
             mapping_size: mapping.len(),
             rewrites: chunk_rewrites,
@@ -310,12 +295,11 @@ pub fn swap_vendor_chunks(
     let import_alignment_index = build_import_alignment_index(artifact)?;
     let mut resolutions = BTreeMap::<String, VendorResolution>::new();
 
-    for (chunk_path, mark, swap) in &ops {
-        let op_id = mark.id.as_str();
-        let chunk_id = chunk_id_from_chunk_path(chunk_path, op_id, "swapVendorChunks")?;
+    for (chunk_path, _mark, swap) in &ops {
+        let chunk_id = chunk_id_from_chunk_path(chunk_path, "swapVendorChunks")?;
         let entry_relative_file = get_chunk_entry_path(artifact, &chunk_id).with_context(|| {
             format!(
-                "swapVendorChunks operation {op_id} targets missing chunk: chunkPath={chunk_path} (chunkId={chunk_id})"
+                "swapVendorChunks vendor entry {chunk_path} targets missing chunk (chunkId={chunk_id})"
             )
         })?;
         let entry_ast = artifact
@@ -324,7 +308,7 @@ pub fn swap_vendor_chunks(
             .and_then(|chunk| chunk.files.get(&entry_relative_file))
             .and_then(|file| file.ast.as_ref())
             .with_context(|| {
-                format!("swapVendorChunks operation {op_id} vendor chunk {chunk_id} is missing entry AST")
+                format!("swapVendorChunks vendor chunk {chunk_id} is missing entry AST")
             })?;
         let package = swap.package.as_str();
         let version = swap.version.as_str();
@@ -338,7 +322,7 @@ pub fn swap_vendor_chunks(
             .context("package metadata missing version")?;
         if installed_version != version {
             bail!(
-                "swapVendorChunks operation {op_id} version mismatch for {package}: op={version}, installed={installed_version}"
+                "swapVendorChunks vendor entry {chunk_path} version mismatch for {package}: spec={version}, installed={installed_version}"
             );
         }
         let upstream_path = resolve_package_subpath(
@@ -356,7 +340,8 @@ pub fn swap_vendor_chunks(
             Some(WrapperShape::NamedFromDefault) => {
                 let upstream_ast =
                     parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-                let object_keys = collect_default_export_object_keys(&upstream_ast.module, op_id)?;
+                let object_keys =
+                    collect_default_export_object_keys(&upstream_ast.module, chunk_path)?;
                 let non_default_exports = vendor_exports
                     .iter()
                     .filter(|name| name.as_str() != "default")
@@ -365,7 +350,7 @@ pub fn swap_vendor_chunks(
                 let missing = set_diff(&non_default_exports, &object_keys);
                 if !missing.is_empty() {
                     bail!(
-                        "swapVendorChunks operation {op_id} named-from-default wrapper shape mismatch for {package}@{version}: vendor named exports missing from upstream default object keys=[{}]",
+                        "swapVendorChunks vendor entry {chunk_path} named-from-default wrapper shape mismatch for {package}@{version}: vendor named exports missing from upstream default object keys=[{}]",
                         missing.into_iter().collect::<Vec<_>>().join(",")
                     );
                 }
@@ -381,7 +366,7 @@ pub fn swap_vendor_chunks(
             }
             Some(WrapperShape::NamedFromJsonDefault) => {
                 let upstream_json = serde_json::from_str::<Value>(&upstream_code).with_context(|| {
-                    format!("swapVendorChunks operation {op_id} named-from-json-default: upstream JSON parse failed")
+                    format!("swapVendorChunks vendor entry {chunk_path} named-from-json-default: upstream JSON parse failed")
                 })?;
                 let object = upstream_json
                     .as_object()
@@ -395,7 +380,7 @@ pub fn swap_vendor_chunks(
                 let missing = set_diff(&non_default_exports, &object_keys);
                 if !missing.is_empty() {
                     bail!(
-                        "swapVendorChunks operation {op_id} named-from-json-default wrapper shape mismatch for {package}@{version}: vendor named exports missing from upstream JSON keys=[{}]",
+                        "swapVendorChunks vendor entry {chunk_path} named-from-json-default wrapper shape mismatch for {package}@{version}: vendor named exports missing from upstream JSON keys=[{}]",
                         missing.into_iter().collect::<Vec<_>>().join(",")
                     );
                 }
@@ -415,7 +400,7 @@ pub fn swap_vendor_chunks(
                 let wrapper = generate_named_from_module_default_wrapper(
                     &upstream_ast,
                     &vendor_exports,
-                    op_id,
+                    chunk_path,
                 )?;
                 generated_wrapper_path = write_wrapper_if_requested(
                     options.write,
@@ -432,7 +417,7 @@ pub fn swap_vendor_chunks(
                 let missing = set_diff(&vendor_exports, &upstream_exports);
                 if !missing.is_empty() {
                     bail!(
-                        "swapVendorChunks operation {op_id} export shape mismatch for {package}@{version}: vendor exports not found upstream=[{}]",
+                        "swapVendorChunks vendor entry {chunk_path} export shape mismatch for {package}@{version}: vendor exports not found upstream=[{}]",
                         missing.into_iter().collect::<Vec<_>>().join(",")
                     );
                 }
@@ -445,7 +430,7 @@ pub fn swap_vendor_chunks(
                     continue;
                 }
                 bail!(
-                    "swapVendorChunks operation {op_id} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {chunk_id} (known: [{}])",
+                    "swapVendorChunks vendor entry {chunk_path} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {chunk_id} (known: [{}])",
                     record.caller_chunk_id,
                     record.caller_file,
                     imported_name,
@@ -482,7 +467,7 @@ pub fn swap_vendor_chunks(
     if let Some(root_manifest) = &mut artifact.root_manifest {
         let removed = resolutions
             .keys()
-            .map(|chunk_path| chunk_id_from_chunk_path(chunk_path, "manifest", "swapVendorChunks"))
+            .map(|chunk_path| chunk_id_from_chunk_path(chunk_path, "swapVendorChunks"))
             .collect::<Result<BTreeSet<_>>>()?;
         root_manifest.counts.chunks = chunk_count;
         root_manifest
@@ -518,12 +503,12 @@ pub fn swap_vendor_chunks(
     })
 }
 
-fn chunk_id_from_chunk_path(chunk_path: &str, op_id: &str, stage: &str) -> Result<String> {
+fn chunk_id_from_chunk_path(chunk_path: &str, stage: &str) -> Result<String> {
     if chunk_path.is_empty() {
-        bail!("{stage} operation {op_id} has invalid chunkPath: {chunk_path}");
+        bail!("{stage}: empty chunk path");
     }
     let Some(chunk_id) = chunk_path.strip_suffix(".js") else {
-        bail!("{stage} operation {op_id} chunkPath must end in .js: {chunk_path}");
+        bail!("{stage}: chunk path must end in .js: {chunk_path}");
     };
     Ok(chunk_id.to_string())
 }
@@ -898,14 +883,17 @@ fn binding_names(pattern: &Pat) -> Vec<String> {
     }
 }
 
-fn collect_default_export_object_keys(module: &Module, op_id: &str) -> Result<BTreeSet<String>> {
+fn collect_default_export_object_keys(
+    module: &Module,
+    chunk_path: &str,
+) -> Result<BTreeSet<String>> {
     for item in &module.body {
         let ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(default_expr)) = item else {
             continue;
         };
         let Expr::Object(object) = &*default_expr.expr else {
             bail!(
-                "swapVendorChunks operation {op_id} named-from-default: upstream default export is not an object literal"
+                "swapVendorChunks vendor entry {chunk_path} named-from-default: upstream default export is not an object literal"
             );
         };
         let mut keys = BTreeSet::new();
@@ -923,7 +911,7 @@ fn collect_default_export_object_keys(module: &Module, op_id: &str) -> Result<BT
         return Ok(keys);
     }
     bail!(
-        "swapVendorChunks operation {op_id} named-from-default: upstream has no export default declaration"
+        "swapVendorChunks vendor entry {chunk_path} named-from-default: upstream has no export default declaration"
     );
 }
 
@@ -996,7 +984,7 @@ fn generate_named_from_json_default_wrapper(
 fn generate_named_from_module_default_wrapper(
     upstream_ast: &ParsedJsModule,
     vendor_exports: &BTreeSet<String>,
-    op_id: &str,
+    chunk_path: &str,
 ) -> Result<String> {
     let default_local_name = "__vendor_default__";
     let mut found_default = false;
@@ -1090,12 +1078,12 @@ fn generate_named_from_module_default_wrapper(
                     }
                     let ModuleExportName::Ident(local) = &named_specifier.orig else {
                         bail!(
-                            "swapVendorChunks operation {op_id} named-from-module-default: \"export {{ ... as default }}\" must alias a local identifier"
+                            "swapVendorChunks vendor entry {chunk_path} named-from-module-default: \"export {{ ... as default }}\" must alias a local identifier"
                         );
                     };
                     if deferred_default_alias.is_some() {
                         bail!(
-                            "swapVendorChunks operation {op_id} named-from-module-default: upstream declares more than one default export"
+                            "swapVendorChunks vendor entry {chunk_path} named-from-module-default: upstream declares more than one default export"
                         );
                     }
                     found_default = true;
@@ -1120,7 +1108,7 @@ fn generate_named_from_module_default_wrapper(
     }
     if !found_default {
         bail!(
-            "swapVendorChunks operation {op_id} named-from-module-default: upstream has no default export"
+            "swapVendorChunks vendor entry {chunk_path} named-from-module-default: upstream has no default export"
         );
     }
     body.push(export_default_ident(default_local_name));


### PR DESCRIPTION
## Summary

Two cleanups for debundle's spec format:

1. **Drop the `id` slot on `VendorMark`, `LogicalModule`, and `ResidualModule`.** Each entry's identity is its map key — chunk path, `(chunkId, targetPath)`, or chunkId — so the `id` field was redundant. It was used as a label in error messages, the rename-vendor-exports manifest, and cycle reports — all replaced with the canonical key (chunk path for vendor; `<chunkId>::<targetPath>` and `<chunkId>::residual` for logical/residual). The vendor-stage helper `chunk_id_from_chunk_path` no longer needs an op-id arg either. `VendorAnnotationSummary.id` and `RenameVendorExportsDetail.op_id` likewise become `chunk_path`.

2. **Replace the hand-rolled `strip_jsonc_comments`** (54 lines) **with `json_comments::StripComments`** — a small crate that does the same thing as a `Read` adapter. `load_transform_spec` now reads the file as bytes and pipes through `serde_json::from_reader`. No behaviour change.

The on-disk vendor manifest loses its `id` entries; consumers grepping by chunk path are unaffected.

## Test plan

- [x] `bbr build //devinfra/js/debundle/...` — green
- [x] `bbr test //devinfra/js/debundle/...` — 16/16 pass (`buildbuddy:3437b221-445f-417b-afc2-7c6c0528677a`)

https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up9zNwY8UPrpKxc8kpayZx)_