### PR TITLE
ci: fix duplicate Authorization header in App-attributed pushes (unblocks sync-pins)

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -226,7 +226,11 @@ jobs:
             exit 1
           fi
 
-          # Override actions/checkout's url-specific extraheader with the
-          # App installation token so the push is App-attributed.
-          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
-            push origin "HEAD:${BRANCH}"
+          # Replace actions/checkout's url-specific extraheader with the App
+          # installation token so the push is App-attributed. `git -c` appends
+          # to extraheader (multi-valued) rather than replacing — both headers
+          # would go on the wire and GitHub returns "Duplicate header:
+          # Authorization" 400. Unset, then set fresh.
+          git config --unset-all 'http.https://github.com/.extraheader' || true
+          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
+          git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -66,7 +66,11 @@ jobs:
           # printed verbatim in the trace. (GHA masks tokens registered via
           # ::add-mask::, but disabling xtrace here is belt-and-braces.)
           set +x
-          # Override actions/checkout's url-specific extraheader with the
-          # App installation token so the push is App-attributed.
-          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
-            push origin "HEAD:${BRANCH}"
+          # Replace actions/checkout's url-specific extraheader with the App
+          # installation token so the push is App-attributed. `git -c` appends
+          # to extraheader (multi-valued) rather than replacing — both headers
+          # would go on the wire and GitHub returns "Duplicate header:
+          # Authorization" 400. Unset, then set fresh.
+          git config --unset-all 'http.https://github.com/.extraheader' || true
+          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
+          git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/sync-pins.yml
+++ b/.github/workflows/sync-pins.yml
@@ -53,7 +53,11 @@ jobs:
           fi
           git commit -m "chore: sync artifact pins (${{ steps.sync.outputs.updated }})"
           git pull --rebase origin devel
-          # Override actions/checkout's url-specific extraheader with the
-          # App installation token so the push is App-attributed.
-          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
-            push origin "HEAD:devel"
+          # Replace actions/checkout's url-specific extraheader with the App
+          # installation token so the push is App-attributed. `git -c` appends
+          # to extraheader (multi-valued) rather than replacing — both headers
+          # would go on the wire and GitHub returns "Duplicate header:
+          # Authorization" 400. Unset, then set fresh.
+          git config --unset-all 'http.https://github.com/.extraheader' || true
+          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
+          git push origin "HEAD:devel"


### PR DESCRIPTION
## Summary

PR #1496 migrated three workflows (sync-pins, container-images, nix-flake-update) to push as the ducktape-automation App. The `git -c http.https://github.com/.extraheader=Authorization: Bearer …` line **appends** to the multi-valued extraheader rather than overriding actions/checkout's basic auth header; both Authorization headers ship on the wire and GitHub returns:

```
remote: Duplicate header: "Authorization"
fatal: … The requested URL returned error: 400
```

`sync-pins.yml` runs every ~hour and has been failing on **every** cron tick since `3fe4275` landed (~16 h of pin drift on `devel`). `container-images.yml` and `nix-flake-update.yml` were spared only because their push step is gated on a content diff that hasn't fired yet — but they have the same bug.

Fix: unset the existing url-specific extraheader before re-setting it. Three identical edits, one per workflow.

```diff
-          git -c "http.https://github.com/.extraheader=Authorization: Bearer ${APP_TOKEN}" \
-            push origin "HEAD:devel"
+          git config --unset-all 'http.https://github.com/.extraheader' || true
+          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
+          git push origin "HEAD:devel"
```

## Test plan

- [ ] sync-pins cron tick after merge succeeds (next run within ~30 min should commit any pending pin updates as `ducktape-automation[bot]`).
- [ ] Next time `container-images.yml` has a digest to commit, the push succeeds.
- [ ] Next manual `nix-flake-update.yml` dispatch with flake changes succeeds.

(The bug is push-only and has no unit-test surface; verification has to be the live cron.)

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin