### PR TITLE
debundle: include chunk_renames keys in materialise_chunk_ids (fixes chunk_renames_test)

### DIFF
--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -399,7 +399,7 @@ pub fn materialize_logical_modules(
 
         let chunk_renames_map = chunk_renames
             .get(&chunk_id)
-            .map(|cr| collect_chunk_renames(cr))
+            .map(collect_chunk_renames)
             .transpose()?
             .unwrap_or_default();
         let lowered = lower_chunk(LowerChunkInputs {
@@ -671,7 +671,7 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
     // or by another chunk_renames entry, or invalid as an
     // identifier) bail rather than producing invalid JS silently.
     let mut renamed_away = BTreeSet::<String>::new();
-    for (binding, _) in chunk_renames {
+    for binding in chunk_renames.keys() {
         if binding_assignment.contains_key(binding) {
             continue;
         }

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -218,6 +218,7 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
         .logical_modules
         .keys()
         .chain(spec.residual_modules.keys())
+        .chain(spec.chunk_renames.keys())
         .cloned()
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()


### PR DESCRIPTION
## Summary

`bazel-ci` on `devel` has been red on every commit since #1501 merged: `//devinfra/js/debundle/e2e:chunk_renames_test` panics with

```
static/app/entry.js did not contain \"let payload =\"
--- static/app/entry.js ---
let x = (globalThis.__touched = true, \"x-value\");
```

i.e. the entry source comes out unrenamed.

## Root cause

#1503 ("derive materialise chunk ids") built `materialise_chunk_ids` from `spec.logical_modules.keys() ∪ spec.residual_modules.keys()` only:

```rust
let materialise_chunk_ids: Vec<String> = spec
    .logical_modules.keys()
    .chain(spec.residual_modules.keys())
    .cloned()
    .collect::<BTreeSet<_>>()
    ...;
if !materialise_chunk_ids.is_empty() {
    ...
    materialize_logical_modules(...);
}
```

#1501 (chunk_renames) landed AFTER #1503 with a test that exercises a chunk that has only `chunk_renames` entries (no logical / residual — that's the whole point of the op, per #1501's commit message). For such a chunk, `materialise_chunk_ids` is empty, the whole block is skipped, `materialize_logical_modules` never runs, and entry.js comes through unchanged.

Fix: add `chunk_renames.keys()` to the chain.

```diff
 let materialise_chunk_ids: Vec<String> = spec
     .logical_modules.keys()
     .chain(spec.residual_modules.keys())
+    .chain(spec.chunk_renames.keys())
     .cloned()
     .collect::<BTreeSet<_>>()
```

## Drive-by clippy fixes

Two pre-existing lint errors in `logical_modules.rs` (also from #1501) surface as `[ROOT CAUSE] FAILED_TO_BUILD //devinfra/js/debundle:logical_modules` once the crate is rebuilt — they were masked in CI by action-cache hits on logical_modules.rs that predated #1501. Fixed inline so the bazel-ci aspect goes green:

- `redundant_closure` at line 402: `.map(|cr| collect_chunk_renames(cr))` → `.map(collect_chunk_renames)`
- `for_kv_map` at line 674: `for (binding, _) in chunk_renames` → `for binding in chunk_renames.keys()`

## Test plan

- [x] `bbr test //devinfra/js/debundle/e2e:chunk_renames_test` — invocation `5ca728b1-7bf3-4305-83f8-bd5b54abab6f`, PASSED.
- [x] `bbr test //devinfra/js/debundle/...` — invocation `48639ada-c53a-4d78-b424-5e1571634c07`, all e2e tests PASSED (chunk_renames + cross_module_emission + lowering + missing_binding_member + naturalization + purity + realizability + residual_member_rename + scrambled_id_frequencies + sibling_declarator_steal + source_order_emit + url_rebase).

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin