### PR TITLE
ci: use URL-embedded App token for push (real-real fix for sync-pins)

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -226,14 +226,11 @@ jobs:
             exit 1
           fi
 
-          # Replace actions/checkout's basic-auth Authorization header with the
-          # App installation token so the push is App-attributed. See the
-          # corresponding comment in .github/workflows/sync-pins.yml — the
-          # includeif-pulled credentials file means a plain `git config
-          # --unset-all` doesn't reach the existing value, so we drop the
-          # includeif entries first and only then set our own extraheader.
+          # Push as the ducktape-automation App via URL-embedded HTTP Basic
+          # auth — see the corresponding comment in sync-pins.yml for why the
+          # extraheader-replacement approach didn't work.
+          set +x
           for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
             git config --local --unset-all "$key"
           done
-          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
-          git push origin "HEAD:${BRANCH}"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -62,18 +62,13 @@ jobs:
             exit 1
           fi
 
-          # Disable xtrace before the push so the token doesn't get
-          # printed verbatim in the trace. (GHA masks tokens registered via
-          # ::add-mask::, but disabling xtrace here is belt-and-braces.)
+          # Push as the ducktape-automation App via URL-embedded HTTP Basic
+          # auth — see the corresponding comment in sync-pins.yml for why the
+          # extraheader-replacement approach didn't work. `set +x` keeps the
+          # token out of the runner trace (GHA also masks via ::add-mask::,
+          # but belt-and-braces).
           set +x
-          # Replace actions/checkout's basic-auth Authorization header with the
-          # App installation token so the push is App-attributed. See the
-          # corresponding comment in .github/workflows/sync-pins.yml — the
-          # includeif-pulled credentials file means a plain `git config
-          # --unset-all` doesn't reach the existing value, so we drop the
-          # includeif entries first and only then set our own extraheader.
           for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
             git config --local --unset-all "$key"
           done
-          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
-          git push origin "HEAD:${BRANCH}"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"

--- a/.github/workflows/sync-pins.yml
+++ b/.github/workflows/sync-pins.yml
@@ -53,22 +53,23 @@ jobs:
           fi
           git commit -m "chore: sync artifact pins (${{ steps.sync.outputs.updated }})"
           git pull --rebase origin devel
-          # Replace actions/checkout's basic-auth Authorization header with the
-          # App installation token so the push is App-attributed.
+          # Push as the ducktape-automation App. actions/checkout sets a
+          # basic-auth Authorization header on github.com via an extraheader
+          # in an `includeif.gitdir:*.path` temp file. Replacing it via
+          # `git config --unset-all http.https://github.com/.extraheader`
+          # (PR #1505) was a no-op — `--unset-all` only edits the local
+          # config, not the includeif'd file. Dropping the includeif and
+          # re-setting the extraheader (PR #1508) made git stop sending
+          # any Authorization header at all (the local extraheader didn't
+          # take effect for some reason; pushes failed with "could not
+          # read Username for 'https://github.com'").
           #
-          # actions/checkout writes its `http.https://github.com/.extraheader`
-          # value into a temp file under $RUNNER_TEMP and pulls it in via
-          # `includeif.gitdir:<repo>.path = <temp file>` entries in the local
-          # config. `git config --unset-all` only edits the local config, so
-          # it cannot remove a value that lives in an includeif'd file —
-          # adding our own value alongside results in TWO Authorization
-          # headers on the wire and GitHub returns "Duplicate header:
-          # Authorization" 400.
-          #
-          # Drop the includeif entries first to disconnect the credentials
-          # file, then set our own extraheader in the local config.
+          # Working approach: push to an explicit URL with the App token as
+          # HTTP Basic auth (`x-access-token:<token>`). This bypasses the
+          # extraheader machinery entirely. `set +x` keeps the token out
+          # of the runner trace.
+          set +x
           for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
             git config --local --unset-all "$key"
           done
-          git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
-          git push origin "HEAD:devel"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:devel"


### PR DESCRIPTION
## Summary

PR #1505 (set extraheader after `--unset-all`) was a no-op against actions/checkout's includeif'd credentials file. PR #1508 (drop includeif then set extraheader) made git stop sending **any** Authorization header — pushes failed with

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Visible on:
- container-images run [`#25336491760`](https://github.com/agentydragon/ducktape/actions/runs/25336491760) (merge of PR #1508), 18:37 UTC
- sync-pins cron tick [`#25336729602`](https://github.com/agentydragon/ducktape/actions/runs/25336729602), 18:42 UTC

I don't fully understand why setting `http.https://github.com/.extraheader` after dropping the includeif didn't take effect — it's a working pattern in some repos, but evidently not here. Rather than keep debugging extraheader resolution, sidestep it.

## Fix

Push to an explicit URL with the App token as HTTP Basic auth:

```yaml
set +x
for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
  git config --local --unset-all "$key"
done
git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"
```

- The for-loop drop of includeif entries removes actions/checkout's basic-auth extraheader so we don't double up.
- `x-access-token:<App token>` is the documented way to use an App installation token as HTTP Basic auth (see [GitHub docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#authenticating-with-an-installation-access-token)).
- `set +x` keeps the token out of the trace.

Three identical edits, one per workflow.

## Test plan

- [ ] Next sync-pins cron tick (every 30 min) succeeds.
- [ ] Next container-images push (when an image digest changes) succeeds.
- [ ] Next nix-flake-update dispatch succeeds.

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin