### PR TITLE
Fix git config handling for GitHub App token authentication

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -226,11 +226,14 @@ jobs:
             exit 1
           fi
 
-          # Replace actions/checkout's url-specific extraheader with the App
-          # installation token so the push is App-attributed. `git -c` appends
-          # to extraheader (multi-valued) rather than replacing — both headers
-          # would go on the wire and GitHub returns "Duplicate header:
-          # Authorization" 400. Unset, then set fresh.
-          git config --unset-all 'http.https://github.com/.extraheader' || true
+          # Replace actions/checkout's basic-auth Authorization header with the
+          # App installation token so the push is App-attributed. See the
+          # corresponding comment in .github/workflows/sync-pins.yml — the
+          # includeif-pulled credentials file means a plain `git config
+          # --unset-all` doesn't reach the existing value, so we drop the
+          # includeif entries first and only then set our own extraheader.
+          for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
+            git config --local --unset-all "$key"
+          done
           git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
           git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -66,11 +66,14 @@ jobs:
           # printed verbatim in the trace. (GHA masks tokens registered via
           # ::add-mask::, but disabling xtrace here is belt-and-braces.)
           set +x
-          # Replace actions/checkout's url-specific extraheader with the App
-          # installation token so the push is App-attributed. `git -c` appends
-          # to extraheader (multi-valued) rather than replacing — both headers
-          # would go on the wire and GitHub returns "Duplicate header:
-          # Authorization" 400. Unset, then set fresh.
-          git config --unset-all 'http.https://github.com/.extraheader' || true
+          # Replace actions/checkout's basic-auth Authorization header with the
+          # App installation token so the push is App-attributed. See the
+          # corresponding comment in .github/workflows/sync-pins.yml — the
+          # includeif-pulled credentials file means a plain `git config
+          # --unset-all` doesn't reach the existing value, so we drop the
+          # includeif entries first and only then set our own extraheader.
+          for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
+            git config --local --unset-all "$key"
+          done
           git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
           git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/sync-pins.yml
+++ b/.github/workflows/sync-pins.yml
@@ -53,11 +53,22 @@ jobs:
           fi
           git commit -m "chore: sync artifact pins (${{ steps.sync.outputs.updated }})"
           git pull --rebase origin devel
-          # Replace actions/checkout's url-specific extraheader with the App
-          # installation token so the push is App-attributed. `git -c` appends
-          # to extraheader (multi-valued) rather than replacing — both headers
-          # would go on the wire and GitHub returns "Duplicate header:
-          # Authorization" 400. Unset, then set fresh.
-          git config --unset-all 'http.https://github.com/.extraheader' || true
+          # Replace actions/checkout's basic-auth Authorization header with the
+          # App installation token so the push is App-attributed.
+          #
+          # actions/checkout writes its `http.https://github.com/.extraheader`
+          # value into a temp file under $RUNNER_TEMP and pulls it in via
+          # `includeif.gitdir:<repo>.path = <temp file>` entries in the local
+          # config. `git config --unset-all` only edits the local config, so
+          # it cannot remove a value that lives in an includeif'd file —
+          # adding our own value alongside results in TWO Authorization
+          # headers on the wire and GitHub returns "Duplicate header:
+          # Authorization" 400.
+          #
+          # Drop the includeif entries first to disconnect the credentials
+          # file, then set our own extraheader in the local config.
+          for key in $(git config --local --name-only --get-regexp '^includeif\.gitdir:.*\.path$' || true); do
+            git config --local --unset-all "$key"
+          done
           git config 'http.https://github.com/.extraheader' "Authorization: Bearer ${APP_TOKEN}"
           git push origin "HEAD:devel"


### PR DESCRIPTION
## Summary
Updates three GitHub Actions workflows to properly handle git credential configuration when replacing `actions/checkout`'s basic-auth header with a GitHub App installation token. The previous approach failed because `actions/checkout` stores credentials in a temporary file referenced via `includeif` directives, which `git config --unset-all` cannot modify.

## Key Changes
- **sync-pins.yml**: Replace simple `git config --unset-all` with logic that first removes all `includeif.gitdir:*.path` entries from local config, then sets the App token header
- **container-images.yml**: Apply the same fix with a reference comment pointing to sync-pins.yml for detailed explanation
- **nix-flake-update.yml**: Apply the same fix with a reference comment pointing to sync-pins.yml for detailed explanation

## Implementation Details
The fix addresses a "Duplicate header: Authorization" 400 error that occurred when pushing with git. The root cause is that `actions/checkout` writes its credentials to a temporary file and references it via `includeif.gitdir:<repo>.path` entries in the local git config. Since `git config --unset-all` only modifies the local config file, it cannot remove values pulled in from includeif'd files.

The solution:
1. Query all `includeif.gitdir:*.path` entries in the local config
2. Unset each of these entries to disconnect the credentials file
3. Set the App token as a fresh `http.https://github.com/.extraheader` value in the local config

This ensures only one Authorization header is sent on the wire, allowing the push to be properly attributed to the GitHub App.

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin