### PR TITLE
MODULE.bazel: dev_dependency=True on crate extension; rules_rust 0.69 → 0.70

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -531,7 +531,7 @@ use_repo(buildbuddy, "buildbuddy_toolchain")
 register_toolchains("@buildbuddy_toolchain//:ubuntu_cc_toolchain")
 
 # Rust rules
-bazel_dep(name = "rules_rust", version = "0.69.0")
+bazel_dep(name = "rules_rust", version = "0.70.0")
 
 # — rust toolchains —
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
@@ -544,7 +544,39 @@ use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
 
 # ─ Rust crates (crate_universe) ─────────────────────────────────────────────
-crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
+# `dev_dependency = True` ⇒ this extension only runs when ducktape is the root
+# module. When a downstream repo (e.g. gaffer-private) consumes ducktape via
+# `bazel_dep` + `archive_override`, ducktape's `crate.from_cargo` calls are
+# skipped, and the downstream's own (isolated) `crate.from_cargo` provides
+# whatever Rust crates it needs.
+#
+# Why we need this: rules_rust's `crate_universe` digest stored in
+# `Cargo.Bazel.lock`'s top-level `checksum` is computed from the lockfile +
+# the Bazel-generated `--config` and `--splicing-manifest` (see
+# `rules_rust/crate_universe/src/lockfile.rs::Digest::compute`). The
+# auto-generated config and splicing manifest reference workspace-relative
+# paths, so the digest a developer commits from
+# `<root_module_workspace>/Cargo.Bazel.lock` does not match what the BB runner
+# computes when ducktape is loaded as a dependency at
+# `<output_base>/external/ducktape+/Cargo.Bazel.lock`. The mismatch fires
+# every build, e.g. on gaffer-private's bazel-ci:
+#
+#   Error: Digests do not match: Current Digest("115bb40e…") !=
+#     Expected Digest("f45f8af2…")
+#
+# Where `Current` is exactly ducktape's stored `checksum` and `Expected` is
+# the recomputed one in gaffer's path context.
+#
+# Marking the extension `dev_dependency = True` keeps the digest check active
+# for ducktape's own builds (root-module case) and skips it for downstream
+# consumers — which is the only place it was ever wrong, since downstream
+# consumers have their own crate universes anyway. Upstream tracking:
+# bazelbuild/rules_rust (path-dependence in `cargo-bazel query`).
+crate = use_extension(
+    "@rules_rust//crate_universe:extensions.bzl",
+    "crate",
+    dev_dependency = True,
+)
 
 # If your workspace has Cargo.toml at the root:
 crate.from_cargo(


### PR DESCRIPTION
## Summary

Two changes in `MODULE.bazel`:

1. **Mark the `@rules_rust//crate_universe` extension `dev_dependency = True`.** This makes ducktape's `crate.from_cargo` calls (the main `crates` and `aw_server_crates`) run **only when ducktape is the root module**. Downstream consumers (gaffer-private, …) get to skip them entirely.

2. **Bump `rules_rust` 0.69.0 → 0.70.0.** Minor bump, no API surface change for our usage. The path-dependence bug below isn't fixed upstream there either, so the `dev_dependency = True` knob remains the load-bearing change.

## The venv-paths-in-`Cargo.Bazel.lock` problem

rules_rust's `crate_universe` digest, stored in `Cargo.Bazel.lock`'s top-level `checksum` field, is computed from:

```
Sha256(cargo-bazel version || lockfile content (no checksum) || --config || --splicing-manifest || cargo version || rustc version)
```

(see [`crate_universe/src/lockfile.rs::Digest::compute`](https://github.com/bazelbuild/rules_rust/blob/0.69.0/crate_universe/src/lockfile.rs)).

The `--config` and `--splicing-manifest` are **Bazel-generated** at build time and reference workspace-relative paths. So the digest a developer (or CI) commits from `<root_workspace>/Cargo.Bazel.lock` does not match what's recomputed when ducktape is loaded as a *child* module at `<output_base>/external/ducktape+/Cargo.Bazel.lock`. The mismatch fires every build on every downstream consumer:

```
Error: Digests do not match: Current Digest(\"115bb40e…\") != Expected Digest(\"f45f8af2…\")
```

— where `Current` is *exactly* the value at the top of ducktape's committed `Cargo.Bazel.lock`, and `Expected` is the recomputed-in-downstream's-path-context one. ducktape's own `bazel-ci` is fine because there it *is* the root module. Net effect: every consumer broke at every commit.

`dev_dependency = True` skips the extension when ducktape is non-root. Consumers ship their own (isolated) `crate.from_cargo` and don't touch ducktape's at all — they don't need to, since they only consume Bazel-side targets like `@ducktape//util/bazel:runfiles`, not ducktape's Rust crate universe.

Filing an upstream bug at `bazelbuild/rules_rust` separately to fix the path-dependence properly. Until then, this is the cleanest workaround.

## Test plan

- [ ] `bazel-ci` on this PR still green (ducktape's own crate universe still digest-checks; just now it's the only place that does).
- [ ] After merging, gaffer-private bumps its ducktape pin; gaffer's `bazel-ci` should no longer hit `Digests do not match`.

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin