### PR TITLE
Cargo.Bazel.lock: regenerate for rules_rust 0.70 (fixes bazel-ci)

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "115bb40e76a1cc3db8288658dee099d1d37ae0a50f4a5e9a4197b41d7a628539",
+  "checksum": "c32168d5e4a13c74eee9b818bf943e3a743ef2a24ce60bcb8cdf4b20f5ccc290",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",

--- a/third_party/activitywatch/Cargo.Bazel.lock
+++ b/third_party/activitywatch/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3a0d2a20f9d154cc034162e48b9e7f863753c1e1f7b821c4fb2134737dcca2fa",
+  "checksum": "b86187e26ecf6d7ca90114dc78840a294c98bf2269eaa4d93df3d877bfed7ffd",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

#1511's `rules_rust` 0.69 → 0.70 bump changed cargo-bazel's digest computation. The committed `Cargo.Bazel.lock` had the 0.69-era checksum (`115bb40e…`) and `bazel-ci` on devel HEAD now fires:

```
Error: Digests do not match: Current Digest("115bb40e…")
  != Expected Digest("c32168d5…")
```

(See [run #25347013526](https://github.com/agentydragon/ducktape/actions/runs/25347013526) — `bazel-ci / Test & Build` failure on `88d950a`.)

The new `c32168d5…` is what 0.70 computes from the same inputs. Regenerated locally with `CARGO_BAZEL_REPIN=true` — only the top-level `checksum` field changes (1 line per lockfile).

Two lockfiles regenerated: `Cargo.Bazel.lock` (main) and `third_party/activitywatch/Cargo.Bazel.lock` (`aw_server_crates`).

## Test plan

- [x] Locally `bazelisk build @crates//:all` analyzes cleanly with the new lockfile.
- [ ] CI `bazel-ci` goes green again on devel after merge.

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin