### PR TITLE
Remove gaffer-private stub and update solarized.nvim

### DIFF
--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -2,36 +2,19 @@
 # Build all Nix flake outputs and push closures to Attic binary cache.
 set -euo pipefail
 
-# gaffer-private is a private repo. CI doesn't need access — stub it out
-# with a no-op module so Nix doesn't try to fetch it.
-stub_path=$(mktemp -d)
-cat >"$stub_path/flake.nix" <<'STUB'
-{
-  outputs = { ... }: {
-    homeManagerModules.google-drive = { lib, ... }: {
-      options.services.google-drive.enable = lib.mkEnableOption "stub";
-    };
-  };
-}
-STUB
-git -C "$stub_path" init -q
-git -C "$stub_path" add .
-git -C "$stub_path" -c user.email=ci@localhost -c user.name=CI commit -qm stub
-
-OVERRIDE="--override-input gaffer-private path:$stub_path"
 out_paths=$(mktemp)
 
 # NixOS configurations
-for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames $OVERRIDE | jq -r '.[]'); do
-  nix build --impure $OVERRIDE \
+for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames | jq -r '.[]'); do
+  nix build --impure \
     ".#nixosConfigurations.$host.config.system.build.toplevel" \
     --no-link --print-out-paths >>"$out_paths"
 done
 
-# Home configurations (google-drive disabled via extendModules +
-# gaffer-private stubbed out so the private binary is never fetched)
-for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.attrNames $OVERRIDE | jq -r '.[]'); do
-  nix build --impure $OVERRIDE --expr "
+# Home configurations (google-drive disabled via extendModules so the private
+# gaffer-private binary is never fetched at eval time)
+for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.attrNames | jq -r '.[]'); do
+  nix build --impure --expr "
     let flake = builtins.getFlake \"path:$(pwd)\";
     in (flake.homeConfigurations.$host.extendModules {
       modules = [{ services.google-drive.enable = false; }];
@@ -40,7 +23,7 @@ for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.att
 done
 
 # Other outputs
-nix build --impure $OVERRIDE \
+nix build --impure \
   .#packages.x86_64-linux.devtools \
   --no-link --print-out-paths >>"$out_paths"
 

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -41,12 +41,12 @@ let
 
   solarizedNvim = pkgs.vimUtils.buildVimPlugin {
     pname = "solarized.nvim";
-    version = "2024-11-26";
+    version = "2026-04-17";
     src = pkgs.fetchFromGitHub {
       owner = "maxmx03";
       repo = "solarized.nvim";
-      rev = "main";
-      sha256 = "1fz1wc569w26aanmj3hhsc17xrx29g6bfsjsbgssa7jq76aavp3w";
+      rev = "a8085e29883ddcfb39bd46197eb32ef00df05368";
+      sha256 = "0psgwfnd5fi0p60pknzz9li70ryxqqjz7gxxvqr0q3q1kzpdhr7q";
     };
   };
 


### PR DESCRIPTION
## Summary
This PR removes the gaffer-private input stubbing logic from the CI build script and updates the solarized.nvim plugin to use a pinned commit instead of tracking the main branch.

## Key Changes
- **CI script simplification**: Removed the temporary stub flake creation for `gaffer-private` and all associated `--override-input` flags from `nix_attic_build_and_push.sh`. The google-drive service is now disabled solely through `extendModules` in the home configuration build step.
- **solarized.nvim update**: Updated from tracking the `main` branch to using a pinned commit (`a8085e29883ddcfb39bd46197eb32ef00df05368`), with corresponding version and hash updates.

## Implementation Details
- The gaffer-private dependency is still handled gracefully by disabling the google-drive service via `extendModules` during the home configuration build, eliminating the need for input overrides.
- Updated comments in the CI script to reflect that google-drive is disabled at eval time through module extension rather than input stubbing.
- The solarized.nvim pin ensures reproducible builds and prevents unexpected changes from upstream main branch updates.

https://claude.ai/code/session_018DtS7MWer7aCnp23jufZzs