### PR TITLE
Rust hook daemon: explicit PreToolUse/PostToolUse mailbox-drain handlers

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "115bb40e76a1cc3db8288658dee099d1d37ae0a50f4a5e9a4197b41d7a628539",
+  "checksum": "c32168d5e4a13c74eee9b818bf943e3a743ef2a24ce60bcb8cdf4b20f5ccc290",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -410,6 +410,10 @@ async fn handle_hook(
                 Some(HookOutput::default())
             }
         }
+        // PreToolUse / PostToolUse: no per-hook logic; output is built entirely
+        // from the mailbox drain below. Listed explicitly so the dispatch table
+        // reads as "these are handled" rather than falling into the noop arm.
+        (AnyHookInput::PreToolUse(_) | AnyHookInput::PostToolUse(_), _) => None,
         _ => None,
     };
 

--- a/devinfra/claude/claude_hook/test_mailbox_delivery_e2e.py
+++ b/devinfra/claude/claude_hook/test_mailbox_delivery_e2e.py
@@ -71,8 +71,7 @@ _SESSION_START = {
     "model": "claude-sonnet-4-6",
 }
 
-_PRE_TOOL_USE = {
-    "hook_event_name": "PreToolUse",
+_REPL_BASE: dict[str, object] = {
     "session_id": _SESSION_ID,
     "cwd": "/project",
     "transcript_path": "/tmp/transcript.json",
@@ -82,8 +81,17 @@ _PRE_TOOL_USE = {
     "tool_input": {},
 }
 
+_PRE_TOOL_USE: dict[str, object] = {**_REPL_BASE, "hook_event_name": "PreToolUse"}
+_POST_TOOL_USE: dict[str, object] = {**_REPL_BASE, "hook_event_name": "PostToolUse", "tool_response": ""}
 
-def test_mailbox_delivery(impl: str, container: container_e2e.E2EContainer) -> None:
+
+@pytest.fixture(params=["PreToolUse", "PostToolUse"])
+def repl_hook(request: pytest.FixtureRequest) -> dict[str, object]:
+    """Drain happens identically on every REPL hook; parameterize to prove it."""
+    return {"PreToolUse": _PRE_TOOL_USE, "PostToolUse": _POST_TOOL_USE}[request.param]
+
+
+def test_mailbox_delivery(impl: str, container: container_e2e.E2EContainer, repl_hook: dict[str, object]) -> None:
     """Background task output is delivered once via REPL hook systemMessage, then drained."""
     _IMPLS[impl](container)
     container.send_hook(_SESSION_START)
@@ -93,19 +101,19 @@ def test_mailbox_delivery(impl: str, container: container_e2e.E2EContainer) -> N
     # we see the sentinel, output_X is guaranteed in the daemon's buffer.
     container.poll_file("/tmp/task_ready")
 
-    out1 = container.send_hook(_PRE_TOOL_USE)
+    out1 = container.send_hook(repl_hook)
     msg1 = out1.get("systemMessage", "")
     assert "output_X" in msg1, f"[{impl}] expected output_X, got: {msg1!r}"
 
     # Drain is destructive: second hook must not re-deliver output_X.
-    out2 = container.send_hook(_PRE_TOOL_USE)
+    out2 = container.send_hook(repl_hook)
     msg2 = out2.get("systemMessage") or ""
     assert "output_X" not in msg2, f"[{impl}] output_X re-delivered: {msg2!r}"
 
     container.exec(["touch", "/tmp/signal"])
     container.poll_file("/tmp/task_done")
 
-    out3 = container.send_hook(_PRE_TOOL_USE)
+    out3 = container.send_hook(repl_hook)
     msg3 = out3.get("systemMessage", "")
     assert "output_Y" in msg3, f"[{impl}] expected output_Y, got: {msg3!r}"
     assert "output_X" not in msg3, f"[{impl}] output_X re-appeared in phase-2 message: {msg3!r}"

--- a/third_party/activitywatch/Cargo.Bazel.lock
+++ b/third_party/activitywatch/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3a0d2a20f9d154cc034162e48b9e7f863753c1e1f7b821c4fb2134737dcca2fa",
+  "checksum": "b86187e26ecf6d7ca90114dc78840a294c98bf2269eaa4d93df3d877bfed7ffd",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

Add an explicit `PreToolUse | PostToolUse` arm to the Rust hook dispatch match so the table reflects "these hooks are handled — by mailbox drain only." The drain itself was already happening unconditionally on every REPL hook below the match (`if req.hook.is_repl()`), so this is no functional change, just a clarity refactor that aligns with the Python daemon's post-#1512 shape.

Parameterize `test_mailbox_delivery_e2e.py` on the hook type so PostToolUse drain is exercised explicitly. Matrix is now `python|rust × PreToolUse|PostToolUse` = 4 cases. Test passed on RBE: invocation `149b3df1`.

## Bundled fix: Cargo.Bazel.lock checksums

The rules_rust 0.69→0.70 upgrade in #1511 changed how the lockfile checksum is computed but did not update `Cargo.Bazel.lock` or `third_party/activitywatch/Cargo.Bazel.lock`, so `bazel build //devinfra/claude/claude_hook:claude_hook` fails on `devel` with `Error: Digests do not match`. This PR refreshes both checksums (no actual crate version changes — just the digest fields). Bundled because the e2e test in this PR can't pass without it.

## Test plan

- [x] `bbr test //devinfra/claude/claude_hook:test_mailbox_delivery_e2e` — passes 4/4 (invocation `149b3df1`)
- [x] `CARGO_BAZEL_REPIN=true bazelisk build //devinfra/claude/claude_hook:claude_hook` — succeeds locally with refreshed lockfile

https://claude.ai/code/session_01R9mLHNtYH3Bd3LjCJsZjwT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9mLHNtYH3Bd3LjCJsZjwT)_