### PR TITLE
Revert rules_rust 0.69 → 0.70 bump (fixes devel bazel-ci)

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c32168d5e4a13c74eee9b818bf943e3a743ef2a24ce60bcb8cdf4b20f5ccc290",
+  "checksum": "115bb40e76a1cc3db8288658dee099d1d37ae0a50f4a5e9a4197b41d7a628539",
   "crates": {
     "ahash 0.7.8": {
       "name": "ahash",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -531,7 +531,7 @@ use_repo(buildbuddy, "buildbuddy_toolchain")
 register_toolchains("@buildbuddy_toolchain//:ubuntu_cc_toolchain")
 
 # Rust rules
-bazel_dep(name = "rules_rust", version = "0.70.0")
+bazel_dep(name = "rules_rust", version = "0.69.0")
 
 # — rust toolchains —
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

--- a/third_party/activitywatch/Cargo.Bazel.lock
+++ b/third_party/activitywatch/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b86187e26ecf6d7ca90114dc78840a294c98bf2269eaa4d93df3d877bfed7ffd",
+  "checksum": "3a0d2a20f9d154cc034162e48b9e7f863753c1e1f7b821c4fb2134737dcca2fa",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

Devel `bazel-ci` has been red since #1511 + #1513 landed:

```
Error: Digests do not match: Current Digest("115bb40e…")
  != Expected Digest("c32168d5…")
```

`Current` is the OLD 0.69-era checksum; `Expected` is what 0.70's `cargo-bazel` computes from current inputs. Locally the build succeeds in a fresh `output_base` — so the issue is the BB worker cache: the `recycle-runner=true` snapshot has an `@rules_rust+` external repo (or `@crates` output) populated by an earlier 0.69-era run, and something in that cache makes `cargo-bazel` read the OLD lockfile content even though `git checkout --force -B devel <new sha>` updates the source tree to the new lockfile.

I couldn't pin down which BB-worker cache layer is sticky and don't have admin to evict it. Fastest path back to green: roll back the version bump and the lockfile regen so devel matches the pre-#1511 state that BB worker caches were built against.

**Keeps the substantive `dev_dependency = True` fix from #1511** (which is what gaffer-private needs to skip ducktape's `crate.from_cargo` digest check when consumed as a child module).

## Files

```
MODULE.bazel                                rules_rust 0.70.0 → 0.69.0
Cargo.Bazel.lock                            checksum c32168d5… → 115bb40e…
third_party/activitywatch/Cargo.Bazel.lock  checksum b86187e2… → 3a0d2a20…
```

3 lines changed.

## Test plan

- [x] Local `bazelisk build @crates//:all` analyzes successfully with the 0.69 + reverted-lockfile state.
- [ ] Devel `bazel-ci` goes green after merge.

## Followup

Re-attempting the rules_rust 0.70 bump should be a separate ticket, requires either:
- Admin-evicting the BB worker snapshot before pushing the bump.
- Migrating off `recycle-runner=true` (or supplementing with a cache-bust on Cargo files).

https://claude.ai/code/session_01NSa6ZDvdMkMm54bEctVXin