### PR TITLE
debundle: address Copilot review on #1522 (doc-only)

### DIFF
--- a/devinfra/js/debundle/e2e/comma_list_owner_split_test.rs
+++ b/devinfra/js/debundle/e2e/comma_list_owner_split_test.rs
@@ -400,10 +400,10 @@ export { x, y };
     ));
 
     let mod_xy = read(&fixture.out_root, "static/app/modules/mod_xy.js");
-    // The destructuring declarator either moves atomically (both
-    // `x` and `y` end up in mod_xy) or only `x` does and `y` lands
-    // somewhere reachable; whichever shape the materializer
-    // picks, the program must still print "10 20".
+    // Claiming `x` alone pulls the whole destructure into mod_xy
+    // (destructure-atomicity). The declarator must land here
+    // intact with both `x` and `y` bound, even though the spec
+    // only named `x`.
     assert!(
         mod_xy.contains("{ x, y }") || mod_xy.contains("{x, y}") || mod_xy.contains("{x,y}"),
         "mod_xy.js must keep the destructuring declarator intact; got:\n{mod_xy}",

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1795,15 +1795,17 @@ struct ChunkAstAnalysis {
     runtime_import_facts: RuntimeImportFacts,
     declarations: Vec<TopLevelDecl>,
     declaration_by_name: BTreeMap<String, usize>,
-    /// Per-binding-name set of names bound by the *same* declarator
-    /// pattern. For a plain `const a = 1` declarator the set is
-    /// `{a}` (size 1). For a destructuring declarator like
-    /// `const { x, y } = obj` both `x` and `y` map to the set
-    /// `{x, y}`. Used by `build_module_plans` to enforce
-    /// destructure-atomicity: claiming any one binding from a
-    /// destructure pulls the rest into the same module, because
-    /// the materializer's `split_var_decl` moves a destructuring
-    /// declarator as one atomic unit.
+    /// Sibling sets for top-level destructuring declarators only.
+    /// For a destructuring declarator like `const { x, y } = obj`
+    /// both `x` and `y` map to the set `{x, y}`. Plain
+    /// single-name declarators (`const a = 1`) are not recorded —
+    /// they don't need atomicity enforcement, and absence here is
+    /// the signal that there are no siblings to consider. Used by
+    /// `build_module_plans` to enforce destructure-atomicity:
+    /// claiming any one binding from a destructure pulls the rest
+    /// into the same module, because the materializer's
+    /// `split_var_decl` moves a destructuring declarator as one
+    /// atomic unit.
     destructure_siblings: BTreeMap<String, BTreeSet<String>>,
     /// Names that the source chunk's entry already exports (via
     /// `export { foo, bar }` re-exports of local bindings, or


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1522 addressing two Copilot review comments. Doc-only;
no code behavior changes.

- `destructure_siblings` docstring in `logical_modules.rs` claimed singleton
  `{a}` sets are present for plain `const a = 1` declarators. They aren't —
  `record_destructure_sibling_groups` only records pattern groups of size ≥2,
  and absence from the map is the signal that there are no siblings.
  Rewrote the docstring to match the implementation.
- Comment in `comma_list_owner_split_test.rs::destructure_only_declarator_…`
  suggested the destructuring declarator might split non-atomically (only
  `x` moves, `y` lands elsewhere). That contradicts both the test's intent
  and the destructure-atomicity enforcement landed in #1522. Rewrote the
  comment to state the actual contract: claiming any sibling pulls the whole
  declarator into the same module.

## Test plan

- [x] No behavior change; existing `//devinfra/js/debundle/...` suite still
  passes (verified before push).

https://claude.ai/code/session_01CH8LHDaoiKQrTZbg1opkfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CH8LHDaoiKQrTZbg1opkfv)_