### PR TITLE
debundle/purity: extend PlainData to `let` with whole-object replacement

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -212,6 +212,40 @@ behavior for:
 - Replayable side-effect attachment.
 - Top-level side-effect classification across uncommon initializer shapes.
 
+## Cross-module / imported-binding purity (recursive purity Part 3)
+
+`ChunkCodeGraph` tracks chunk-local function/PlainData purity within
+a single source chunk. Imported callees from a different source chunk
+(vendor chunks, vite chunk splits) fall through to `unknown_call`
+because the importer has no per-function purity for the exporter's
+bindings. The downstream cost is each cross-chunk pure-helper needing
+a `purity: pure` spec hint in gaffer-private even though its body
+would classify pure if it were chunk-local.
+
+Sketch (deferred until residual hint set is dominated by cross-chunk
+shapes):
+
+- Per-chunk analysis emits a side-output manifest with each chunk-top
+  `Function` and `PlainData` binding's classification.
+- When analyzing chunk B that imports `helper` from chunk A's output,
+  read A's manifest and seed B's `ChunkCodeGraph` bindings with A's
+  per-name verdict.
+- Soundness gate: only admit cross-chunk facts when the importer's
+  import-specifier names match A's exported chunk-top binding shape
+  (e.g. `import { helper }` matches `export const helper = () => …`
+  but not a re-export from elsewhere).
+
+Today only one residual cluster in gaffer-private's `78d928dca7`
+spec sits cross-chunk (mobx wrappers in `infra/mobx/*.yaml.deferred`)
+and that cluster is the legitimate user of the spec-side
+`purity: pure` override — genuinely-impure-but-init-safe vendor
+shape, not a pure-by-derivation chain. So Part 3 isn't load-bearing
+yet. Land if a future snapshot grows a cross-chunk pure-helper
+chain.
+
+Context: <gaffer-private/tana/x/research/ducktape_purity_recursive.md>
+"Part 3 — cross-module purity" section.
+
 ## Corpus breadth
 
 Current passing surface is centered on small synthetic fixtures and the

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -1133,14 +1133,141 @@ mod tests {
     }
 
     #[test]
-    fn plain_data_let_object_literal_is_not_tracked() {
-        // `let` allows reassignment between graph construction and a
-        // member-read callsite; the cached `PlainData` would lie if
-        // a subsequent `TA = newObj` swapped in an object with
-        // getters. Constness is load-bearing — `let` and `var` are
-        // intentionally excluded.
-        assert!(!is_plain_data("let TA = { a: 1 };", "TA"));
+    fn plain_data_let_object_literal_with_no_writes_is_tracked() {
+        // `let TA = {…}` is admissible even though re-assignment
+        // is syntactically allowed: the chunk-wide write scan
+        // confirms no `TA = rhs` assigns exist anywhere, so the
+        // post-init value is invariant just like a `const`.
+        assert!(is_plain_data("let TA = { a: 1 };", "TA"));
+        assert!(is_plain_data("let TA = [1, 2, 3];", "TA"));
+    }
+
+    #[test]
+    fn plain_data_var_object_literal_is_not_tracked() {
+        // `var`'s hoisting + redeclaration semantics aren't worth
+        // the analysis complexity for the shape this admission
+        // targets (bundler-emitted config tables). Keep `var` out
+        // of the candidate set.
         assert!(!is_plain_data("var TA = { a: 1 };", "TA"));
+    }
+
+    #[test]
+    fn plain_data_let_with_plain_literal_replacement_is_tracked() {
+        // The `applySystemConfigOverrides` shape from gaffer-private:
+        // `let envConfig = {…}` with every reassignment being
+        // `envConfig = { ...envConfig, ...n }`. Object spread in the
+        // RHS is admitted — `CopyDataProperties` writes data
+        // descriptors regardless of source shape, so the post-write
+        // value still has no accessor channels.
+        let src = r#"
+            let envConfig = { REACT_APP_ENV: "production", FOO: 1 };
+            const applyOverrides = (n) => {
+                envConfig = { ...envConfig, ...n };
+            };
+            const getEnv = (k) => envConfig[k];
+        "#;
+        assert!(is_plain_data(src, "envConfig"));
+        assert_eq!(fn_purity(src, "getEnv"), Some(true));
+    }
+
+    #[test]
+    fn plain_data_let_with_non_literal_rhs_assign_disqualifies() {
+        // A re-bind whose RHS is not a syntactic plain literal could
+        // produce an accessor-bearing value at runtime — `someFn()`
+        // might return `Object.defineProperty(...)`-installed
+        // getters, `other` might be such a value already, `X || {}`
+        // shortcircuits to either operand. Each of these must
+        // disqualify.
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function reassign() { X = someFn(); }",
+            "X"
+        ));
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function reassign(other) { X = other; }",
+            "X"
+        ));
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function reassign() { X = X || {}; }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_let_with_accessor_rhs_assign_disqualifies() {
+        // Even though the binding is `let` and the RHS is a literal,
+        // the literal carries a getter — assigning it gives X
+        // accessor channels. Disqualify.
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function bad() { X = { get a() { return io(); } }; }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_let_with_member_write_disqualifies() {
+        // `let X = {…}; X.k = v` is a member write — installs a
+        // property in place. The conservative rule rejects it (the
+        // resulting object is still plain-data, but the chunk-wide
+        // invariant is simpler if we forbid all member writes
+        // uniformly across `const` and `let`).
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function mut() { X.b = 2; }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_let_with_update_disqualifies() {
+        // `X++` rewrites X to a number — definitely not a
+        // plain-literal data shape. Reject.
+        assert!(!is_plain_data(
+            "let X = { a: 1 }; function bad() { X++; }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_let_chain_collapses_env_config_walkthrough_shape() {
+        // The full gaffer-private chain-of-hints shape, end to end:
+        //
+        //   let envConfig = { REACT_APP_ENV: …, FUNCTIONS_EMULATOR: false, … };
+        //   const applySystemConfigOverrides = (n) => { envConfig = { ...envConfig, ...n }; };
+        //   const getEnv = (n) => envConfig[n];
+        //   const isEmulatorEnv = () =>
+        //       (mr.FUNCTIONS_EMULATOR ? true : getEnv("REACT_APP_ENV") === "emulator");
+        //   const getSystemConfig = () => envConfig;
+        //
+        // Today (pre-this-extension) the spec author needed
+        // `purity: pure` hints on `getEnv` / `isEmulatorEnv` /
+        // `getSystemConfig` in
+        // `runtime/environment/{env_config,config}.yaml` because
+        // `envConfig` was `let` and member access on it flagged
+        // `unknown_member`. With the let+mutator extension every
+        // helper in the chain classifies pure with zero hints.
+        let src = r#"
+            const mr = { FUNCTIONS_EMULATOR: false };
+            let envConfig = {
+                REACT_APP_ENV: "production",
+                REACT_APP_FIREBASE_API_KEY: "x",
+            };
+            const applySystemConfigOverrides = (n) => {
+                envConfig = { ...envConfig, ...n };
+            };
+            const getEnv = (n) => envConfig[n];
+            const isEmulatorEnv = () =>
+                (mr.FUNCTIONS_EMULATOR ? true : getEnv("REACT_APP_ENV") === "emulator");
+            const getSystemConfig = () => envConfig;
+        "#;
+        assert!(is_plain_data(src, "envConfig"));
+        assert!(is_plain_data(src, "mr"));
+        assert_eq!(fn_purity(src, "getEnv"), Some(true));
+        assert_eq!(fn_purity(src, "isEmulatorEnv"), Some(true));
+        assert_eq!(fn_purity(src, "getSystemConfig"), Some(true));
+        // `applySystemConfigOverrides` itself is impure (it writes
+        // to envConfig); call sites still need to anchor it via
+        // S-edges. Confirm the impurity is detected, so the
+        // debundler doesn't accidentally classify the mutator pure.
+        assert_eq!(fn_purity(src, "applySystemConfigOverrides"), Some(false));
     }
 
     #[test]
@@ -1157,17 +1284,20 @@ mod tests {
     }
 
     #[test]
-    fn plain_data_const_with_spread_is_not_tracked() {
-        // Object spread inherits enumerable own properties from
-        // another object — including accessor descriptors copied
-        // via `Object.defineProperty`-style construction on the
-        // source. Reject to keep the "no accessors in this shape"
-        // invariant tight.
-        assert!(!is_plain_data("const X = { ...other, a: 1 };", "X"));
-        // Array spread iterates the source's `[Symbol.iterator]` at
-        // init, which already counts as impure; the literal also
-        // can't be guaranteed plain.
-        assert!(!is_plain_data("const X = [1, ...other];", "X"));
+    fn plain_data_const_with_spread_is_tracked() {
+        // Object/array spread inside the literal init is admitted:
+        // `CopyDataProperties` and array spread both write the
+        // source's *values* via `CreateDataPropertyOrThrow`, which
+        // produces data descriptors regardless of the source's
+        // descriptor shape. The resulting receiver has only data
+        // properties, so member reads on it fire no user code.
+        // The spread itself fires source getters AT INIT — that
+        // impurity belongs to the surrounding statement (classified
+        // independently via `ObjectSpread`/`ArraySpread` rules) and
+        // is orthogonal to whether subsequent reads on the binding
+        // are pure.
+        assert!(is_plain_data("const X = { ...other, a: 1 };", "X"));
+        assert!(is_plain_data("const X = [1, ...other];", "X"));
     }
 
     #[test]

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -31,24 +31,49 @@ enum ChunkBinding {
     /// `purity` is the worst purity reachable from the body, computed
     /// by fixed-point iteration over all chunk-top functions.
     Function { purity: Purity },
-    /// `const X = <plain object/array literal>` whose binding cell
-    /// is never written through anywhere in the chunk. Property reads
-    /// `X.k` / `X[k]` (k pure) on such a binding are pure:
-    /// * `const` blocks reassignment of the binding cell.
-    /// * The plain-literal init shape has no accessor properties
-    ///   (no getters/setters, no methods, no spreads, no computed
-    ///   keys, no `__proto__`).
-    /// * The chunk-wide "never written through" check rules out
-    ///   `Object.defineProperty(X, ...)` / `Object.setPrototypeOf(X, ...)`
-    ///   etc. that could install an accessor or change the prototype
-    ///   to one with accessors.
+    /// Chunk-top `const X = <plain literal>` (immutable cell) OR
+    /// `let X = <plain literal>` whose only assignments anywhere in
+    /// the chunk re-bind X to another plain literal (whole-object
+    /// replacement; no in-place mutation). Property reads `X.k` /
+    /// `X[k]` (k pure) on such a binding are pure regardless of when
+    /// they fire:
+    ///
+    /// * **No accessor channels at any program point.** The initial
+    ///   init is a syntactic plain literal — no
+    ///   getters/setters/methods/computed keys/`__proto__`, so the
+    ///   value carries only data properties. Every re-bind (`let`
+    ///   case) writes another plain-literal value, so the post-write
+    ///   value still has only data properties. Object/array spread
+    ///   inside the literal (`{...src}`, `[...src]`) is permitted:
+    ///   `CopyDataProperties` copies values via
+    ///   `CreateDataPropertyOrThrow` regardless of the source's
+    ///   descriptor shape — the result is plain.
+    /// * **No post-init accessor installation.** The chunk-wide
+    ///   write scan rejects any member write (`X.k = …`,
+    ///   `X[k] = …`), member update, member delete, or call to
+    ///   `Object.{defineProperty,defineProperties,setPrototypeOf,assign}`
+    ///   / `Reflect.{defineProperty,set,setPrototypeOf,deleteProperty}`
+    ///   with `X` as first arg. Plain-ident writes whose RHS is not
+    ///   a plain-literal also disqualify.
+    /// * **Re-bind soundness for `let`.** Reads on `X` after a
+    ///   re-bind see the new plain-literal value; reads before still
+    ///   saw the old plain-literal value. At no program point does
+    ///   `X` hold an accessor-carrying value, so member reads fire
+    ///   no user code regardless of write/read interleaving. The
+    ///   re-bind statement itself is independently classified impure
+    ///   (the existing `AssignOrUpdate` rule on `Expr::Assign`), so
+    ///   it keeps its `S`-edge and the debundler cannot move it past
+    ///   sequenced points.
     ///
     /// Sound enabler for the recursive-purity claim "`x` reads on
     /// `x.k` / `x[pure]` are pure iff `x` is bound to a plain-data
     /// shape that has no accessor channels". Eliminates the
     /// chain-of-hints needed when a chunk-local helper's body is
-    /// just a property read on a chunk-local config object
-    /// (`const Me = (n) => TA[n]`).
+    /// just a property read on a chunk-local config object —
+    /// including the `let envConfig = {...}` /
+    /// `envConfig = {...envConfig, ...n}` pattern that the
+    /// `runtime/environment/env_config.yaml` spec hints in
+    /// gaffer-private were a workaround for.
     PlainData,
 }
 
@@ -373,11 +398,24 @@ fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
         .collect()
 }
 
-/// Yield `(name, init)` pairs for each chunk-top `const`-bound
-/// single-declarator binding with an explicit initializer that's NOT
-/// a function/arrow expression (those go through `Function`). Comma-
-/// list declarations are pre-split by `top_level_item_views`, so each
-/// `VarDecl` we see here has exactly one `decl`.
+/// Yield `(name, init)` pairs for each chunk-top single-declarator
+/// `const X = <init>` or `let X = <init>` whose initializer is NOT a
+/// function/arrow expression (those go through `Function`). `var` is
+/// excluded — the hoisting + redeclaration semantics complicate the
+/// chunk-wide write scan, and bundlers practically don't emit
+/// chunk-top `var X = …` for the config-object shape this analysis
+/// targets. Comma-list declarations are pre-split by
+/// `top_level_item_views`, so each `VarDecl` we see here has exactly
+/// one `decl`.
+///
+/// Both `const` and `let` candidates flow through the same scanner;
+/// the scanner's check is uniform ("no member writes or hostile
+/// builtin calls, all ident writes have plain-literal RHS"), so the
+/// distinction is only at the candidate-collection stage:
+/// `const` is admitted automatically (its binding cell is immutable
+/// at the language level; only the chunk-wide checks for accessor
+/// installation post-init matter); `let` additionally relies on
+/// every `X = rhs` ident assign having a plain-literal RHS.
 fn plain_data_const_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
     let var = match item {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
@@ -387,7 +425,7 @@ fn plain_data_const_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
         },
         _ => return Vec::new(),
     };
-    if var.kind != VarDeclKind::Const {
+    if !matches!(var.kind, VarDeclKind::Const | VarDeclKind::Let) {
         return Vec::new();
     }
     let mut out = Vec::new();
@@ -407,25 +445,44 @@ fn plain_data_const_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
 }
 
 /// Pure syntactic check for "plain-literal data shape": an object
-/// literal whose properties are exclusively `KeyValue`/`Shorthand`
-/// with non-computed, non-`__proto__` keys, or an array literal with
-/// no spreads (holes are fine — they read as `undefined`, no getter).
+/// literal whose own properties are exclusively `KeyValue` /
+/// `Shorthand` / object spread (`{...src}`) with non-computed,
+/// non-`__proto__` keys, or an array literal whose own elements are
+/// values or array spreads (holes are fine — they read as
+/// `undefined`, no getter).
+///
+/// **Spreads are permitted.** `{...src}` evaluates `src`'s own
+/// enumerable properties via `CopyDataProperties` and writes the
+/// resulting values to the target via `CreateDataPropertyOrThrow` —
+/// which always produces a data descriptor, regardless of the
+/// source's descriptor shape. So even `{...sourceWithGetters}`
+/// yields a plain-data target. The spread itself fires source
+/// getters AT INIT (impure event, classified independently by the
+/// existing `ObjectSpread`/`ArraySpread` rules), but the resulting
+/// receiver has no accessor channels, which is what this check
+/// gates.
+///
 /// Value sub-expressions are intentionally NOT validated here: the
-/// init's at-init purity is the surrounding statement's concern, and
-/// the safety of post-init member reads depends only on the receiver's
-/// shape (no accessors at init + no post-init accessor installation,
-/// the latter enforced by `PlainDataWriteScanner`).
+/// surrounding statement's at-init purity is the existing
+/// classifier's concern, and the safety of post-init member reads
+/// depends only on the receiver's shape (no accessors at init + no
+/// post-init accessor installation, the latter enforced by
+/// `PlainDataWriteScanner`).
 fn is_plain_data_init(expr: &Expr) -> bool {
     match expr {
+        Expr::Paren(p) => is_plain_data_init(&p.expr),
         Expr::Object(obj) => obj.props.iter().all(is_plain_data_prop),
-        Expr::Array(arr) => arr.elems.iter().flatten().all(|e| e.spread.is_none()),
+        Expr::Array(_) => true,
         _ => false,
     }
 }
 
 fn is_plain_data_prop(prop: &PropOrSpread) -> bool {
     let PropOrSpread::Prop(prop) = prop else {
-        return false; // Object spread: rejected.
+        // `PropOrSpread::Spread` is the `{...src}` form — permitted
+        // (see `is_plain_data_init` doc-comment for the
+        // CopyDataProperties soundness argument).
+        return true;
     };
     match prop.as_ref() {
         Prop::Shorthand(_) => true,
@@ -433,6 +490,9 @@ fn is_plain_data_prop(prop: &PropOrSpread) -> bool {
             // `{__proto__: X}` in an object literal SETS the prototype
             // (ES262 §13.2.5.5); if X carries accessor properties, reads
             // on the parent literal fire them. Reject explicitly.
+            // The computed form `{["__proto__"]: X}` does NOT set the
+            // prototype (per spec), but it's a computed key — rejected
+            // below.
             PropName::Ident(ident) => ident.sym.as_ref() != "__proto__",
             PropName::Str(s) => s.value.to_string_lossy() != "__proto__",
             PropName::Num(_) | PropName::BigInt(_) => true,
@@ -453,6 +513,24 @@ fn is_plain_data_prop(prop: &PropOrSpread) -> bool {
 struct PlainDataWriteScanner<'a> {
     candidates: &'a BTreeSet<String>,
     disqualified: BTreeSet<String>,
+}
+
+/// Defensive visitor that collects candidate-named idents in a
+/// compound assignment target (e.g. inside `[a, ...rest] = …` or
+/// `({x} = …)`) so the scanner can disqualify them. The scanner
+/// uses this only on shapes outside the explicit Member / Simple-Ident
+/// arms — destructuring etc.
+struct IdentVisitor<'a> {
+    candidates: &'a BTreeSet<String>,
+    hit: BTreeSet<String>,
+}
+
+impl Visit for IdentVisitor<'_> {
+    fn visit_ident(&mut self, node: &Ident) {
+        if self.candidates.contains(node.sym.as_ref()) {
+            self.hit.insert(node.sym.to_string());
+        }
+    }
 }
 
 impl PlainDataWriteScanner<'_> {
@@ -511,15 +589,78 @@ const PLAIN_DATA_HOSTILE_BUILTINS: &[(&str, &str)] = &[
 
 impl Visit for PlainDataWriteScanner<'_> {
     fn visit_assign_expr(&mut self, node: &AssignExpr) {
-        if let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &node.left
-            && let Expr::Ident(recv) = member.obj.as_ref()
-        {
-            self.disqualify_if_candidate(recv.sym.as_ref());
+        match &node.left {
+            // `X.k = …` / `X[k] = …` — member write. Disqualify
+            // regardless of RHS shape: even when the RHS is a
+            // plain literal, the write installs a property on the
+            // existing `X` object (whose other reads we were
+            // promising to keep pure post-init). Plain data writes
+            // are sound for read-purity but the conservative rule
+            // is "X must never be written through" so the chunk-
+            // wide invariant reads simply.
+            AssignTarget::Simple(SimpleAssignTarget::Member(member)) => {
+                if let Expr::Ident(recv) = member.obj.as_ref() {
+                    self.disqualify_if_candidate(recv.sym.as_ref());
+                }
+            }
+            // `X = rhs` — plain identifier reassignment. Only
+            // candidates registered as `let` can encounter this
+            // legitimately (`const` re-assign is a syntax error).
+            // Admit only when `rhs` is itself a plain-literal data
+            // shape — anything else (a call, an Ident referencing
+            // an unknown source, a binary op, etc.) could produce
+            // an accessor-bearing value at runtime, which would
+            // break the read-purity invariant for subsequent
+            // member reads on `X`.
+            //
+            // For non-`let` candidates this branch can still fire
+            // (e.g. an inner-scope shadow assignment in a function
+            // body) but disqualifying conservatively is safe —
+            // false negatives never violate soundness, and tracking
+            // scopes here would be a larger lift than the case
+            // requires.
+            AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) => {
+                if self.candidates.contains(binding.sym.as_ref())
+                    && !is_plain_data_init(&node.right)
+                {
+                    self.disqualify_if_candidate(binding.sym.as_ref());
+                }
+            }
+            // Compound assignment targets (paren wrappers, opt-chains)
+            // and destructuring targets (`AssignTarget::Pat`) don't
+            // come up in chunk-top binding mutator patterns we
+            // intend to admit; disqualify defensively if they
+            // mention a candidate name.
+            _ => {
+                let mut idents = IdentVisitor {
+                    candidates: self.candidates,
+                    hit: BTreeSet::new(),
+                };
+                node.left.visit_with(&mut idents);
+                for name in idents.hit {
+                    self.disqualified.insert(name);
+                }
+            }
         }
-        node.visit_children_with(self);
+        // For `=` the RHS still needs to descend (e.g. an inner
+        // nested write to a candidate inside the RHS expression).
+        // For compound `+=` etc., even on an admitted plain-RHS
+        // shape, the read-modify-write semantics make it unsafe;
+        // SWC's `AssignExpr` carries `op`, but we already
+        // disqualified all simple-Ident assigns whose RHS isn't a
+        // plain literal — and any compound op produces a non-literal
+        // value at runtime (`X += {a:1}` is `X = X + {a:1}` which
+        // is a string/number). So no further check needed.
+        node.right.visit_with(self);
     }
 
     fn visit_update_expr(&mut self, node: &UpdateExpr) {
+        // `X++` / `--X` on the binding cell itself produces a
+        // number; not a plain-literal shape. Disqualify Ident
+        // targets in addition to the existing Member-target rule.
+        if let Expr::Ident(ident) = node.arg.as_ref() {
+            self.disqualify_if_candidate(ident.sym.as_ref());
+        }
         self.disqualify_member_receiver(&node.arg);
         node.visit_children_with(self);
     }


### PR DESCRIPTION
## Summary

Builds on the `const`-PlainData path landed in #1521 to admit chunk-top `let X = <plain literal>` whose chunk-wide writes are all whole-object replacement (`X = <plain literal>`). The motivating shape — and the one that gated four of the five `purity: pure` spec hints surviving in gaffer-private after #1521 — is the gaffer config-object pattern:

```js
let envConfig = { REACT_APP_ENV: …, REACT_APP_FIREBASE_API_KEY: …, … };
const applySystemConfigOverrides = (n) => {
    envConfig = { ...envConfig, ...n };
};
const getEnv = (n) => envConfig[n];
const isEmulatorEnv = () => mr.FUNCTIONS_EMULATOR
    ? true
    : getEnv("REACT_APP_ENV") === "emulator";
const getSystemConfig = () => envConfig;
```

Pre-this-PR: `envConfig` is `let`, so `envConfig[n]` flagged `unknown_member` → `getEnv` impure → every callsite impure. The spec author had to drop a `purity: pure` hint on `getEnv` / `isEmulatorEnv` / `getSystemConfig` per round (chain-of-hints).

Post-this-PR: `envConfig` admits as `PlainData` because every write is to a plain-literal RHS (the `{ ...envConfig, ...n }` re-bind). Reads on `envConfig` classify pure. The four helper hints in gaffer-private's `runtime/environment/{env_config,config}.yaml` become removable.

Also extends the shape rule to **permit object/array spreads inside admitted literals** (in both initial init and re-bind RHS): `CopyDataProperties` writes data descriptors regardless of source shape, so the resulting receiver always has data properties only. The spread itself fires source getters AT INIT (impure event, classified independently via `ObjectSpread` / `ArraySpread` / `AssignOrUpdate`), but the *receiver* is plain — which is what gates member-read purity.

## Soundness for debundle reshuffle

Classifying `X.k` / `X[pure]` as `Pure` drops the `S`-edge that would otherwise anchor the reading statement; the validator must still emit a debundled bundle that runs correctly under any spec it accepts. For `let X = init` + writes to qualify, chunk-wide:

1. Initial init is a syntactic plain literal — no getters/setters/methods/computed keys/`__proto__`. Object/array spread inside the literal is permitted (see above).
2. Every Ident-target assignment `X = rhs` has `rhs` itself a plain-literal data shape. Non-literal RHS (`X = someFn()`, `X = other`, `X = X || {}`, `++X`, `X--`) disqualifies.
3. No member write/update/delete on `X.k` / `X[k]`.
4. No call to `Object.{defineProperty,defineProperties,setPrototypeOf,assign}` or `Reflect.{defineProperty,set,setPrototypeOf,deleteProperty}` with `X` as first arg (existing rules from #1521 unchanged).

**Re-bind soundness**: at every program point, `X` holds a value built from a plain-literal evaluation. Member reads on `X` fire no user code regardless of write/read interleaving. The re-bind statement itself classifies impure independently (existing `AssignOrUpdate` rule on `Expr::Assign`), keeping its `S`-edge so the debundler cannot move it past sequenced points.

**False-negative tolerance**: the scanner walks the AST without scope tracking. Nested-scope shadows (`function f() { let X = …; X = nonLiteral; }`) conservatively disqualify the chunk-top X even when the writes target an inner-scope X. Sound — never false positive.

`var` stays excluded — hoisting + redeclaration semantics complicate the chunk-wide write scan, and the targeted bundler emit shapes use `let` or `const`.

## Test plan

- [x] `bbr test //devinfra/js/debundle:analysis_test --test_arg=plain_data` — 22/22 (15 from #1521 + 7 new `let`-specific including the gaffer env-config walkthrough end-to-end).
- [x] `bbr test //devinfra/js/debundle/...` — 31/31 pass; no regressions in e2e suite (including the new `comma_list_owner_split_test` from #1522 which composes with this).
- [x] Adversarial fixtures: `X = someFn()`, `X = other`, `X = X || {}`, `X = {get foo()…}`, `X++`, `X.k = v` — all confirmed to disqualify the binding from PlainData.
- [x] `bbr build //devinfra/js/debundle/...` — clippy + rustfmt clean.

## Followups (also in this PR)

- `devinfra/js/debundle/TODO.md` — adds a "Cross-module / imported-binding purity (recursive purity Part 3)" entry with sketch + deferral rationale. Today only one residual cross-chunk hint cluster exists in gaffer-private (`infra/mobx/*.yaml.deferred`), and that cluster is the legitimate user of the spec-side `purity: pure` override anyway — genuinely-impure-but-init-safe vendor shape, not pure-by-derivation. Part 3 lands when a future snapshot grows a cross-chunk pure-helper chain.

Companion change documenting what becomes removable in gaffer-private after this PR is pinned: agentydragon/gaffer-private branch `claude/recursive-purity-analyzer-D9qNa`.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_