### PR TITLE
debundle: peel_horizon — share spec_tree::ModuleFile parser

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -199,6 +199,7 @@ rust_library(
     deps = [
         ":analysis",
         ":spec",
+        ":spec_tree",
         "@crates//:anyhow",
         "@crates//:serde",
         "@crates//:serde_json",

--- a/devinfra/js/debundle/peel_horizon.rs
+++ b/devinfra/js/debundle/peel_horizon.rs
@@ -4,10 +4,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use analysis::{BindingReport, OwnerGraphReport};
-use spec::{BindingSourceKind, Member};
+use spec::BindingSourceKind;
+use spec_tree::ModuleFile;
 
 #[derive(Debug, Clone)]
 pub struct PeelHorizonOptions {
@@ -89,13 +90,6 @@ struct DeferredModule {
     file: PathBuf,
     bindings: BTreeSet<String>,
     owners: BTreeSet<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ModuleFile {
-    #[serde(default)]
-    members: Vec<Member>,
 }
 
 pub fn analyze_peel_horizon(options: &PeelHorizonOptions) -> Result<PeelHorizonReport> {
@@ -748,6 +742,39 @@ mod tests {
                 .map(|row| row.path.as_str())
                 .collect::<Vec<_>>(),
             vec!["near"]
+        );
+    }
+
+    #[test]
+    fn ignores_anonymous_statements_top_level_field() {
+        // Spec authoring sometimes co-locates top-level side-effect
+        // statements with declared members (e.g. mobx decorator
+        // applications, the size-100 app/bootstrap/types_and_models
+        // closure peel). peel_horizon does not consume them, but it
+        // shares ModuleFile with spec_tree so any field the canonical
+        // parser accepts must also parse here without breaking the
+        // helper.
+        let temp = tempfile::tempdir().unwrap();
+        let modules = temp.path().join("modules");
+        let graph = temp.path().join("owner_graph.json");
+        graph_fixture(&graph);
+        write_file(
+            &modules.join("with_side_effects.yaml.deferred"),
+            &format!(
+                "{}\nanonymous_statements:\n  - match: 'window.foo;'\n    note: smoke test\n",
+                module_yaml(&[("a", "variable_declarator")]),
+            ),
+        );
+
+        let report = analyze_peel_horizon(&options(&modules, &graph)).unwrap();
+
+        assert_eq!(
+            report
+                .full
+                .iter()
+                .map(|row| row.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["with_side_effects"]
         );
     }
 

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -75,13 +75,20 @@ enum VendorLevelSource {
     Swap,
 }
 
+/// Authoring shape of a single per-module YAML under
+/// `modules/**/<path>.yaml{,.deferred}`. Re-exported so
+/// `peel_horizon` (and any other consumer that ranks deferred YAMLs)
+/// parses them through exactly the same schema the canonical
+/// `compile_spec_tree` path uses — every additive field landed here
+/// is automatically accepted by those consumers and stays in lockstep
+/// with the on-disk YAML the debundler itself reads.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct ModuleFile {
+pub struct ModuleFile {
     #[serde(default)]
-    members: Vec<Member>,
+    pub members: Vec<Member>,
     #[serde(default)]
-    anonymous_statements: Vec<AnonymousStatement>,
+    pub anonymous_statements: Vec<AnonymousStatement>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary

`peel_horizon` declared its own copy of the per-module authoring YAML schema:

```rust
#[serde(deny_unknown_fields)]
struct ModuleFile { #[serde(default)] members: Vec<Member> }
```

That copy didn't know about `spec_tree::ModuleFile`'s `anonymous_statements:` field, so any spec edit that adopted top-level side-effect statements (e.g. the size-100 `app/bootstrap/types_and_models` closure peel over in gaffer) tipped `peel_horizon_cli` into

```
parsing modules/.../foo.yaml: unknown field
  `anonymous_statements`, expected `members`
```

while the actual debundler kept consuming the same file just fine. Two parallel struct definitions, both with `deny_unknown_fields`, will silently drift again every time the spec gains a new top-level authoring field.

This PR promotes `spec_tree::ModuleFile` (and its two fields) to `pub` and has `peel_horizon` consume the canonical struct directly. The helper still only reads `data.members` — `anonymous_statements` is not part of the peel hypergraph — but parsing is now wired through exactly the schema the debundler runs against the same on-disk YAML, so any future additive field lands here for free.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle:peel_horizon_test //devinfra/js/debundle:spec_tree_test` — both pass.
- [x] `bazelisk build //devinfra/js/debundle/...` — green (56 s, 2,415 actions).
- [x] New regression test `ignores_anonymous_statements_top_level_field` writes a deferred YAML carrying both `members:` and `anonymous_statements:` and asserts the helper still ranks it as a fully peelable singleton.
- [ ] Bazel CI on this branch passes.

## Context

Found while running the next iteration of the deferred-first peel loop on gaffer (`workspace/system/bootstrap/{schema,keyword_catalog}.yaml.deferred`). Worked around in that PR by reading `peelability.minimal_peel_sets[]` directly from `owner_graph.json` with `jq`; this PR removes the workaround for future iterations.

https://claude.ai/code/session_01EiVmNAgEUEERsbsXAsBMyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiVmNAgEUEERsbsXAsBMyj)_