### PR TITLE
debundle/purity: warn on `purity: pure` hints the analyzer would infer

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -2,7 +2,7 @@ mod tests {
     use std::collections::{BTreeSet, HashMap};
 
     use crate::facts::{compute_shadowed_globals, top_level_item_views};
-    use crate::purity::{ChunkCodeGraph, Purity, classify_expr_purity};
+    use crate::purity::{ChunkCodeGraph, Purity, RedundantPurityReason, classify_expr_purity};
     use crate::*;
     use swc_common::{FileName, sync::Lrc};
     use swc_ecma_ast::*;
@@ -1497,6 +1497,185 @@ mod tests {
         "#;
         assert!(!is_plain_data(src, "TA"));
         assert_eq!(fn_purity(src, "Me"), Some(false));
+    }
+
+    // --- Redundant `purity: pure` hint detection ---------------------------
+
+    /// Run `analyze_chunk_facts` with the given hints applied, then
+    /// return the list of `(binding_name, reason)` pairs the analyzer
+    /// reports as redundant. Used by the test cases below to pin the
+    /// "the analyzer would have figured this out on its own" verdict
+    /// without depending on the wrapping warning-print format.
+    fn redundant_hints(src: &str, hints: &[&str]) -> Vec<(String, RedundantPurityReason)> {
+        let module = parse(src);
+        let declared_pure: BTreeSet<String> = hints.iter().map(|s| (*s).to_string()).collect();
+        analyze_chunk_facts_with_redundant_hints(&module, &declared_pure)
+    }
+
+    /// Wrapper that constructs a `ChunkFactAnalysis` and returns its
+    /// `redundant_purity_hints` list as `(name, reason)` pairs.
+    fn analyze_chunk_facts_with_redundant_hints(
+        module: &Module,
+        declared_pure: &BTreeSet<String>,
+    ) -> Vec<(String, RedundantPurityReason)> {
+        analyze_chunk_with_source_locations(module, declared_pure, None, |_| None)
+            .redundant_purity_hints
+            .into_iter()
+            .map(|h| (h.binding_name, h.reason))
+            .collect()
+    }
+
+    #[test]
+    fn redundant_hint_on_pure_function_is_reported() {
+        // `f` is a chunk-local arrow whose body classifies pure on
+        // its own (returns a primitive literal). The hint is a no-op
+        // — the analyzer reaches the same verdict without it.
+        let got = redundant_hints("const f = (x) => x + 1;", &["f"]);
+        assert_eq!(
+            got,
+            vec![("f".to_string(), RedundantPurityReason::InferredPureFunction)]
+        );
+    }
+
+    #[test]
+    fn load_bearing_hint_on_impure_function_is_not_reported() {
+        // `f` body writes to `globalThis`, which the analyzer flags
+        // as impure regardless of any hint. The hint here is a real
+        // author-trust assertion ("trust me, despite this body, the
+        // callsite is safe") and must NOT be reported as redundant.
+        let got = redundant_hints(
+            "function f() { globalThis.touched = true; return 1; }",
+            &["f"],
+        );
+        assert!(
+            got.is_empty(),
+            "load-bearing hint on truly-impure body must not be flagged redundant; got {got:?}",
+        );
+    }
+
+    #[test]
+    fn redundant_hint_on_plain_data_binding_is_reported() {
+        // `purity: pure` callsite hints are intended for callable
+        // bindings; when the hint sits on a chunk-local `const`
+        // plain-object literal it's a no-op (the binding admits as
+        // `PlainData`, member reads classify pure on their own, and
+        // the binding isn't called). Report it so the spec author
+        // can drop the misplaced hint.
+        let got = redundant_hints(r#"const TA = { FOO: "bar" };"#, &["TA"]);
+        assert_eq!(
+            got,
+            vec![(
+                "TA".to_string(),
+                RedundantPurityReason::InferredPlainDataBinding
+            )]
+        );
+    }
+
+    #[test]
+    fn hint_on_unknown_binding_is_not_reported() {
+        // Hint name doesn't bind anywhere in the chunk (typo,
+        // import-only, vendor binding). The analyzer can't infer
+        // anything about it, so reporting it as "redundant" would
+        // be wrong — the hint is in effect for the bound name from
+        // wherever it actually comes from, and silently flagging
+        // it would lead the author to delete a load-bearing hint.
+        let got = redundant_hints("const X = 1;", &["unknownName"]);
+        assert!(
+            got.is_empty(),
+            "hint on a name not bound at chunk top must not be flagged; got {got:?}",
+        );
+    }
+
+    #[test]
+    fn hint_chain_keeps_only_genuinely_redundant_entries() {
+        // `a` calls `b`; `b`'s body is itself pure (returns
+        // `x + 1`). Per-hint independent removal:
+        // - Drop `a`'s hint → analyzer probes `a` with declared_pure
+        //   = {b}. Inside `a`'s body, `b(x)` is hint-pure → `a`'s
+        //   body classifies pure → `a` reported redundant.
+        // - Drop `b`'s hint → analyzer probes `b` with declared_pure
+        //   = {a}. `b`'s body `x + 1` is pure on its own (no calls
+        //   at all) → `b` reported redundant.
+        // Both hints are redundant.
+        let src = r#"
+            const b = (x) => x + 1;
+            const a = (x) => b(x);
+        "#;
+        let got = redundant_hints(src, &["a", "b"]);
+        let names: BTreeSet<String> = got.iter().map(|(n, _)| n.clone()).collect();
+        assert_eq!(
+            names,
+            BTreeSet::from(["a".to_string(), "b".to_string()]),
+            "both hints in the pure chain should be flagged redundant; got {got:?}",
+        );
+    }
+
+    #[test]
+    fn hint_load_bearing_on_impure_body_reports_only_transitively_redundant_hints() {
+        // `a` calls `b`; `b`'s body writes globalThis → genuinely
+        // impure. With BOTH hints in place, removing only `a`'s
+        // hint leaves `b`'s hint shielding the `b()` call inside
+        // `a`'s body — so `a`'s body still classifies pure
+        // transitively. The analyzer correctly reports `a`'s hint
+        // as redundant **given the current hint set**.
+        //
+        // `b`'s hint is genuinely load-bearing: removing it lets
+        // `b`'s globalThis write classify the body as impure, and
+        // `b` is no longer reported as pure-by-inference. Not
+        // flagged as redundant.
+        //
+        // This is the right verdict: "given the current spec, this
+        // specific hint can come out". If the author drops both
+        // hints in sequence following two consecutive `/followups`
+        // runs, the second run will surface `a` as no-longer-pure
+        // and the author can re-add the hint or rework the body.
+        let src = r#"
+            function b() { globalThis.touched = true; return 1; }
+            function a() { return b(); }
+        "#;
+        let got = redundant_hints(src, &["a", "b"]);
+        assert_eq!(
+            got,
+            vec![("a".to_string(), RedundantPurityReason::InferredPureFunction)],
+            "with b's hint in place, a's hint is redundant; b's hint stays load-bearing",
+        );
+    }
+
+    #[test]
+    fn no_hints_produces_no_warnings() {
+        // Sanity: when no hints are declared, the warning list is
+        // empty even for chunks with plenty of pure chunk-local
+        // functions. The analyzer doesn't invent warnings about
+        // "you could have added a hint here" — it only reports
+        // existing hints that are redundant.
+        let got = redundant_hints("const f = (x) => x + 1;", &[]);
+        assert!(
+            got.is_empty(),
+            "empty declared_pure must produce no warnings; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn redundant_hint_on_let_with_whole_object_replacement_is_reported() {
+        // The gaffer env_config shape: `let X = {…}` with whole-
+        // object replacement writes; `purity: pure` on the
+        // accessor function `getX` is redundant once X admits as
+        // PlainData (Part 2). This is the test that pins the
+        // motivating downstream removal — if it fails after some
+        // future refactor, the gaffer hint-removal regresses.
+        let src = r#"
+            let envConfig = { REACT_APP_ENV: "production" };
+            const applyOverrides = (n) => { envConfig = { ...envConfig, ...n }; };
+            const getEnv = (n) => envConfig[n];
+        "#;
+        let got = redundant_hints(src, &["getEnv"]);
+        assert_eq!(
+            got,
+            vec![(
+                "getEnv".to_string(),
+                RedundantPurityReason::InferredPureFunction
+            )]
+        );
     }
 
     // --- Call-graph topology: deep chains, isolated nodes ------------------

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -10,8 +10,8 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::purity::{
-    ChunkCodeGraph, Purity, PurityReason, PurityRule, WHITELIST_RECEIVERS,
-    class_has_static_observable, classify_expr_purity,
+    ChunkCodeGraph, Purity, PurityReason, PurityRule, RedundantPurityHint, WHITELIST_RECEIVERS,
+    class_has_static_observable, classify_expr_purity, detect_redundant_purity_hints,
 };
 use crate::{BindingName, SourceLocation, StatementOrdinal};
 
@@ -41,6 +41,13 @@ pub struct StatementFacts {
 pub struct ChunkFactAnalysis {
     pub facts: Vec<StatementFacts>,
     pub top_level_await: Option<StatementOrdinal>,
+    /// Author-declared `purity: pure` spec hints the analyzer
+    /// determines would be inferred automatically by recursive
+    /// purity — e.g. the callee's body classifies `Pure` even
+    /// without the override, or the binding admits as `PlainData`
+    /// such that the callsite hint is a no-op. Surfaced so the spec
+    /// author can prune the hint and shrink the trust surface.
+    pub redundant_purity_hints: Vec<RedundantPurityHint>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -152,6 +159,7 @@ where
     let body = top_level_item_views(&module.body);
     let shadowed = compute_shadowed_globals(&body);
     let graph = ChunkCodeGraph::build(&body, &shadowed, declared_pure);
+    let redundant_purity_hints = detect_redundant_purity_hints(&body, &shadowed, declared_pure);
     let mut top_level_await = None;
     let facts = body
         .iter()
@@ -203,6 +211,7 @@ where
     ChunkFactAnalysis {
         facts,
         top_level_await,
+        redundant_purity_hints,
     }
 }
 

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -38,7 +38,7 @@ pub use ids::{
     LogicalModuleIndex, ModuleId, StatementOrdinal,
 };
 pub use partition::Partition;
-pub use purity::{Purity, PurityReason, PurityRule};
+pub use purity::{Purity, PurityReason, PurityRule, RedundantPurityHint, RedundantPurityReason};
 pub use report_schema::{
     BindingReport, EvaluatedPeelCandidateReport, ModuleReportRef, OwnerGraphEdgeReport,
     OwnerGraphNodeReport, OwnerGraphPeelSetReport, OwnerGraphPeelabilityReport,

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -13,8 +13,8 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::{
     BindingKind, BindingName, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
-    Schedule, analyze_chunk_with_source_locations, render_cross_destination_assignment_summary,
-    render_cycle_summary,
+    RedundantPurityHint, RedundantPurityReason, Schedule, analyze_chunk_with_source_locations,
+    render_cross_destination_assignment_summary, render_cycle_summary,
 };
 use artifact::{
     ArtifactIndexes, ArtifactSourceImportResolver, ChunkArtifact, ChunkFileRecord, ChunkId,
@@ -90,6 +90,11 @@ pub struct LogicalChunkReport {
     pub counts: LogicalChunkCounts,
     pub final_module_contents: Vec<FinalModuleContent>,
     pub requested_logical_modules: Vec<RequestedLogicalModule>,
+    /// `purity: pure` hints the analyzer inferred automatically.
+    /// Same content as the stderr warnings the build prints; carried
+    /// on the report so JSON consumers can pin behavior across runs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redundant_purity_hints: Vec<RedundantPurityHint>,
     pub timings: BTreeMap<String, Duration>,
 }
 
@@ -579,7 +584,7 @@ fn materialize_logical_chunk(
     })?
     .unwrap_or_default();
 
-    let schedule = {
+    let (schedule, redundant_purity_hints) = {
         // `purity: pure` hints carried on any spec entry form
         // (logical-module member, residual-module member,
         // chunk_renames member) propagate the same way: add the
@@ -624,6 +629,27 @@ fn materialize_logical_chunk(
                 |span| line_index.line_range_for_span(span),
             )
         });
+        // Per-hint warnings on stderr: each `purity: pure` spec hint
+        // the analyzer infers automatically (binding's body classifies
+        // Pure without the override, or admits as PlainData). Surfaced
+        // every build so spec authors are nudged to prune load-free
+        // hints — every such hint is an extra trust assertion the
+        // validator can't re-verify, and the shrinking trust surface
+        // is the point of recursive purity inference.
+        for hint in &analysis.redundant_purity_hints {
+            eprintln!(
+                "warning: chunk {chunk_id}: `purity: pure` hint on binding `{binding}` is redundant — \
+                 the analyzer infers {reason} for this binding without the hint and the override is a no-op. \
+                 Remove the hint from the spec.",
+                binding = hint.binding_name,
+                reason = match hint.reason {
+                    RedundantPurityReason::InferredPureFunction =>
+                        "pure (the function body classifies Pure by recursive analysis)",
+                    RedundantPurityReason::InferredPlainDataBinding =>
+                        "PlainData (chunk-local const/let plain literal with no chunk-wide writes through the binding)",
+                },
+            );
+        }
         if let Some(ord) = analysis.top_level_await {
             anyhow::bail!(
                 "materialize_logical_modules: chunk {chunk_id} has top-level `await` \
@@ -661,7 +687,8 @@ fn materialize_logical_chunk(
                     })
                     .collect()
             });
-        time_phase!(timings, "build_schedule", {
+        let redundant_purity_hints = analysis.redundant_purity_hints;
+        let schedule = time_phase!(timings, "build_schedule", {
             Schedule::build(
                 chunk_id.to_string(),
                 analysis.facts,
@@ -670,7 +697,8 @@ fn materialize_logical_chunk(
                 chunk_renames_map.clone(),
             )
             .with_pre_existing_entry_exports(pre_existing_entry_exports.clone())
-        })
+        });
+        (schedule, redundant_purity_hints)
     };
     let schedule_report = time_phase!(timings, "validate_schedule", { schedule.validate() });
     if let Some(report_out_dir) = report_out_dir {
@@ -786,6 +814,7 @@ fn materialize_logical_chunk(
                 residual: request.residual,
             })
             .collect(),
+        redundant_purity_hints,
         timings,
     };
     Ok(MaterializedLogicalChunk {

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -227,6 +227,89 @@ impl ChunkCodeGraph {
     }
 }
 
+/// One author-declared `purity: pure` hint the analyzer determines
+/// would be inferred automatically — the binding's body classifies
+/// `Pure` (or the binding admits as `PlainData`) even with the hint
+/// itself removed from `declared_pure`. Surfaced as a chunk-level
+/// warning so spec authors can delete the load-free hint and keep
+/// only the genuinely-load-bearing ones (vendor-shape impurity
+/// overrides, etc.).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RedundantPurityHint {
+    pub binding_name: String,
+    pub reason: RedundantPurityReason,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedundantPurityReason {
+    /// Chunk-local function/arrow whose body classifies `Pure` by
+    /// recursive analysis (with the hint on this binding removed
+    /// from `declared_pure`; hints on other bindings still apply).
+    InferredPureFunction,
+    /// Chunk-local binding that admits as `PlainData`. The
+    /// `purity: pure` callsite-override is a no-op because the
+    /// binding isn't called as `binding(...)` in any pure-relevant
+    /// way that the override would gate.
+    InferredPlainDataBinding,
+}
+
+/// For each name in `declared_pure`, ask "would the analyzer infer
+/// this binding as Pure without the hint on itself?" by building a
+/// fresh `ChunkCodeGraph` with that one name removed from
+/// `declared_pure` (hints on other bindings still apply) and checking
+/// the binding's classification. Hints whose answer is Yes are
+/// reported as redundant.
+///
+/// **Semantics — per-hint independent removal, hints on other names
+/// kept in place.** Removing only the hint under test catches "the
+/// analyzer would have figured this out on its own given the rest
+/// of the current spec." When a chain `a → b → c → …` carries
+/// hints at multiple points, the per-hint check correctly reports
+/// the *transitively redundant* members at the head of the chain
+/// (their inference relies on hints further down) and keeps the
+/// *load-bearing* members (the ones whose own body is what's
+/// genuinely impure). Authors removing hints in successive
+/// `/followups` rounds will see previously-redundant hints become
+/// load-bearing as the supporting hints are pruned, and the loop
+/// terminates when only genuinely impure bodies retain hints.
+///
+/// **Soundness for the surrounding debundle reshuffle:** the check
+/// has no effect on classification of statements — it only emits
+/// a warning. Dropping a hint based on the warning is the spec
+/// author's decision and re-runs the full analysis next build.
+/// The per-hint check itself is a read-only side query.
+///
+/// Cost: O(|declared_pure| × graph_build_cost). For typical spec
+/// hint counts (single digits per chunk) this is negligible
+/// compared to the per-chunk analysis itself.
+pub(crate) fn detect_redundant_purity_hints(
+    body: &[TopLevelItemView<'_>],
+    shadowed: &BTreeSet<&'static str>,
+    declared_pure: &BTreeSet<String>,
+) -> Vec<RedundantPurityHint> {
+    let mut out = Vec::new();
+    for name in declared_pure {
+        let mut without = declared_pure.clone();
+        without.remove(name);
+        let probe = ChunkCodeGraph::build(body, shadowed, &without);
+        let reason = match probe.bindings.get(name) {
+            Some(ChunkBinding::Function { purity }) if purity.is_pure() => {
+                Some(RedundantPurityReason::InferredPureFunction)
+            }
+            Some(ChunkBinding::PlainData) => Some(RedundantPurityReason::InferredPlainDataBinding),
+            _ => None,
+        };
+        if let Some(reason) = reason {
+            out.push(RedundantPurityHint {
+                binding_name: name.clone(),
+                reason,
+            });
+        }
+    }
+    out
+}
+
 /// Visitor that collects the indices of other chunk-top functions
 /// called by a function body (Ident-callee form only). Skips
 /// nested function/arrow/method bodies (those are separate lazy


### PR DESCRIPTION
## Summary

Adds a chunk-level redundancy check that surfaces every `purity: pure` spec hint the analyzer would infer on its own — so spec authors can prune load-free hints and shrink the trust surface. Every such hint is an unverifiable author trust assertion (the `purity: pure` override skips body re-verification); reducing the count is the long-run point of recursive purity inference (proposal: `gaffer-private/tana/x/research/ducktape_purity_recursive.md`).

## Mechanism

For each name `N` in the chunk's `declared_pure`, build a fresh `ChunkCodeGraph` with `N` removed from `declared_pure` (hints on **other** bindings stay in effect) and check whether the probe graph reports `N` as:

* `ChunkBinding::Function { purity: Pure }` — the binding's body classifies pure by recursive analysis. Reported as `InferredPureFunction`.
* `ChunkBinding::PlainData` — the binding admits as a plain-data shape; the `purity: pure` callsite override is a no-op because the binding isn't called as `binding(...)` in any pure-relevant way. Reported as `InferredPlainDataBinding`.

## Semantics — per-hint independent removal

When a chain `a → b → c → …` carries hints at multiple points, the per-hint check reports the *transitively redundant* members at the head of the chain (their inference relies on hints further down) and keeps the *load-bearing* members (whose own body is genuinely impure).

Authors removing flagged hints in successive rounds will see previously-redundant hints become load-bearing as the supporting hints are pruned, and the loop terminates when only genuinely impure bodies retain hints. This is the right verdict: **"given the current spec, this specific hint can come out"**.

## Soundness for debundle reshuffle

The check has no effect on statement classification — it only emits a side-output warning. Dropping a hint based on the warning is the spec author's decision and re-runs the full analysis next build. The per-hint check itself is a read-only side query: it builds extra probe graphs but doesn't alter the main analysis or the `ChunkFactAnalysis.facts` that drive owner-graph construction.

Cost: `O(|declared_pure| × graph_build_cost)`. Typical chunks carry single-digit hint counts; the overhead is negligible.

## Surfacing

* **Stderr** during the debundle build: every redundant hint prints `warning: chunk <id>: 'purity: pure' hint on binding '<name>' is redundant — …`. Spec authors see the notice without opening any report file.
* **JSON**: `LogicalChunkReport.redundant_purity_hints[]` carries the same list for downstream tools (e.g. a future lint rule that fails CI on redundant hints).

## Test plan

- [x] 8 new `analysis_tests` unit cases (`bbr test //devinfra/js/debundle:analysis_test`):
  - Pure function body — flagged.
  - Truly-impure body (`globalThis` write) — NOT flagged.
  - Plain-data binding — flagged (callsite override is a no-op).
  - Hint on unknown name (not chunk-local) — NOT flagged.
  - Chain of pure hints — all flagged.
  - Mixed pure/impure chain — only the transitively-redundant members flagged; the load-bearing impure-body hint stays.
  - Empty hint set — empty warning list.
  - `let envConfig` walkthrough (gaffer regression) — `getEnv` flagged after Part 2 makes envConfig admit as PlainData.
- [x] `bbr test //devinfra/js/debundle/...` — 31/31 pass.

## Companion gaffer-private PR

agentydragon/gaffer-private#50 — drops three now-redundant hints in `tana/re/web/spec/78d928dca7/modules/runtime/environment/` exactly because this analyzer change makes them inferrable. The kept fourth hint (`isEmulatorEnv`) carries an inline note explaining its dependency on a future PlainData-for-`var` extension; this PR would surface a stderr warning for the three removable hints if the post-merge build runs against the pre-cleanup gaffer spec.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_