### PR TITLE
debundle/purity: admit chunk-top `var` plain literals as PlainData

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -1143,12 +1143,105 @@ mod tests {
     }
 
     #[test]
-    fn plain_data_var_object_literal_is_not_tracked() {
-        // `var`'s hoisting + redeclaration semantics aren't worth
-        // the analysis complexity for the shape this admission
-        // targets (bundler-emitted config tables). Keep `var` out
-        // of the candidate set.
-        assert!(!is_plain_data("var TA = { a: 1 };", "TA"));
+    fn plain_data_var_object_literal_is_tracked() {
+        // `var X = { … }` at chunk top admits as PlainData on the
+        // same terms as `let`: every init must be plain-literal,
+        // and no chunk-wide member writes / hostile builtin calls /
+        // non-plain ident reassigns. Hoisting: pre-init reads see
+        // `undefined` and `undefined.k` throws a spec-mandated
+        // TypeError — engine-emitted, not user-defined, so the
+        // read-purity claim still holds.
+        assert!(is_plain_data("var TA = { a: 1 };", "TA"));
+        assert!(is_plain_data("var TA = [1, 2, 3];", "TA"));
+    }
+
+    #[test]
+    fn plain_data_var_multi_decl_all_plain_is_tracked() {
+        // Multiple chunk-top `var X = init` redeclarations are
+        // legal; every init must independently pass the plain-
+        // literal shape rule. Both inits are plain-objects → X
+        // admits as PlainData.
+        let src = r#"
+            var X = { a: 1 };
+            var X = { b: 2 };
+        "#;
+        assert!(is_plain_data(src, "X"));
+    }
+
+    #[test]
+    fn plain_data_var_multi_decl_with_one_non_plain_init_is_not_tracked() {
+        // First decl init is plain, second is `io()` → the second
+        // init's runtime value could carry accessor properties, so
+        // reads on X after the second decl could fire user code.
+        // Disqualify even though the first decl is fine.
+        let src = r#"
+            var X = { a: 1 };
+            var X = io();
+        "#;
+        assert!(!is_plain_data(src, "X"));
+    }
+
+    #[test]
+    fn plain_data_var_member_write_disqualifies() {
+        // Same write-scan rule as let/const — `X.k = v` in any
+        // chunk body disqualifies.
+        assert!(!is_plain_data(
+            "var X = { a: 1 }; function mut() { X.b = 2; }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_var_non_plain_ident_assign_disqualifies() {
+        // `X = nonPlain` ident assign on a candidate disqualifies
+        // (existing PlainDataWriteScanner rule applies to var
+        // candidates unchanged).
+        assert!(!is_plain_data(
+            "var X = { a: 1 }; function bad() { X = someFn(); }",
+            "X"
+        ));
+    }
+
+    #[test]
+    fn plain_data_var_uninitialized_decl_alone_is_not_tracked() {
+        // `var X;` with no initializer contributes nothing to the
+        // candidate set. Without a chunk-top plain init, X has no
+        // admission evidence, so reading X.k could see whatever
+        // an external assignment installed.
+        assert!(!is_plain_data("var X;", "X"));
+    }
+
+    #[test]
+    fn plain_data_var_uninitialized_then_initialized_is_tracked() {
+        // `var X;` followed by `var X = { … }` (or `X = { … }`)
+        // contributes the plain init for the binding. The first
+        // no-init decl is hoisting noise; the second declares the
+        // shape. Admits as PlainData.
+        let src = r#"
+            var X;
+            var X = { a: 1 };
+        "#;
+        assert!(is_plain_data(src, "X"));
+    }
+
+    #[test]
+    fn plain_data_var_unblocks_embedded_build_env_config_shape() {
+        // The gaffer `embeddedBuildEnvConfig` (`var mr = { … }`)
+        // shape: bundler-emitted `var` plain-object literal with no
+        // writes elsewhere in the chunk. Pre-this-extension, `mr`
+        // was excluded from PlainData (const/let only), making
+        // `mr.FUNCTIONS_EMULATOR` flag `unknown_member` and
+        // forcing a load-bearing `purity: pure` hint on the
+        // downstream `isEmulatorEnv` accessor. With `var`
+        // admission, `mr` is PlainData → `mr.FUNCTIONS_EMULATOR`
+        // pure → `isEmulatorEnv` body classifies pure with zero
+        // hints.
+        let src = r#"
+            var mr = { FUNCTIONS_EMULATOR: false, OTHER: "x" };
+            const isEmulatorEnv = () => mr.FUNCTIONS_EMULATOR;
+        "#;
+        assert!(is_plain_data(src, "mr"));
+        assert_eq!(fn_purity(src, "isEmulatorEnv"), Some(true));
     }
 
     #[test]

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -32,11 +32,13 @@ enum ChunkBinding {
     /// by fixed-point iteration over all chunk-top functions.
     Function { purity: Purity },
     /// Chunk-top `const X = <plain literal>` (immutable cell) OR
-    /// `let X = <plain literal>` whose only assignments anywhere in
-    /// the chunk re-bind X to another plain literal (whole-object
-    /// replacement; no in-place mutation). Property reads `X.k` /
-    /// `X[k]` (k pure) on such a binding are pure regardless of when
-    /// they fire:
+    /// `let X = <plain literal>` / `var X = <plain literal>` whose
+    /// only assignments anywhere in the chunk re-bind X to another
+    /// plain literal (whole-object replacement; no in-place
+    /// mutation). For `var`, multiple chunk-top `var X = init_n`
+    /// declarations are also admitted as long as every init is
+    /// plain-literal. Property reads `X.k` / `X[k]` (k pure) on
+    /// such a binding are pure regardless of when they fire:
     ///
     /// * **No accessor channels at any program point.** The initial
     ///   init is a syntactic plain literal — no
@@ -435,24 +437,54 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
     }
 }
 
-/// Collect chunk-top `const`-bound bindings whose initializer is a
-/// plain-literal data shape (plain object literal with no accessors /
-/// methods / spreads / computed keys / `__proto__`, or plain array
-/// literal with no spreads) AND whose binding cell is never written
+/// Collect chunk-top `const` / `let` / `var`-bound bindings whose
+/// initializer(s) are plain-literal data shapes (plain object literal
+/// with no accessors/methods/spreads/computed keys/`__proto__`, or
+/// plain array literal) AND whose binding cell is never written
 /// through anywhere in the chunk's AST. See `ChunkBinding::PlainData`
 /// for the soundness argument.
+///
+/// `var` admission notes:
+///
+/// * `var X = init` at chunk top is hoisted but the initializer
+///   evaluates at the source line. Pre-init reads on `X` see
+///   `undefined`; member access `undefined.k` throws a TypeError —
+///   a spec-mandated throw that fires no user-defined code, so
+///   classifying member reads on `X` as pure remains sound (the
+///   "pure" claim is "fires no user code", not "always succeeds").
+/// * Multiple `var X = init_n` statements at chunk top are legal:
+///   each is a no-op redeclaration of the binding cell plus an
+///   assignment at the init line. Every init must independently be
+///   a plain-literal shape; if any decl's init is non-plain, the
+///   name is disqualified. The same name appearing both via a
+///   `var X = plain` and later via `X = nonPlain` (ident assign)
+///   is caught by the regular `PlainDataWriteScanner` ident-assign
+///   check.
+/// * `var X;` with no initializer contributes nothing to the
+///   candidate; if accompanied by a later `var X = plain` /
+///   `X = plain` write the binding still admits (init from the
+///   plain decl/assign). If alone, X stays undefined forever and
+///   isn't admitted (member-reads on `undefined` throw —
+///   technically still pure, but uninteresting).
 ///
 /// Returns the list of qualified names; the caller registers them as
 /// `ChunkBinding::PlainData` in the graph.
 fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
-    let mut candidates: BTreeSet<String> = BTreeSet::new();
+    // Aggregate every chunk-top init expression per binding name.
+    // The same name can have multiple inits for `var`-bound bindings
+    // (`var X = a; var X = b;`); every init must independently pass
+    // the plain-literal shape check or the name disqualifies.
+    let mut inits_by_name: BTreeMap<String, Vec<&Expr>> = BTreeMap::new();
     for item in body {
-        for (name, init) in plain_data_const_candidates(item.as_module_item()) {
-            if is_plain_data_init(init) {
-                candidates.insert(name);
-            }
+        for (name, init) in plain_data_var_candidates(item.as_module_item()) {
+            inits_by_name.entry(name).or_default().push(init);
         }
     }
+    let candidates: BTreeSet<String> = inits_by_name
+        .into_iter()
+        .filter(|(_, inits)| inits.iter().all(|init| is_plain_data_init(init)))
+        .map(|(name, _)| name)
+        .collect();
     if candidates.is_empty() {
         return Vec::new();
     }
@@ -481,25 +513,31 @@ fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
         .collect()
 }
 
-/// Yield `(name, init)` pairs for each chunk-top single-declarator
-/// `const X = <init>` or `let X = <init>` whose initializer is NOT a
-/// function/arrow expression (those go through `Function`). `var` is
-/// excluded — the hoisting + redeclaration semantics complicate the
-/// chunk-wide write scan, and bundlers practically don't emit
-/// chunk-top `var X = …` for the config-object shape this analysis
-/// targets. Comma-list declarations are pre-split by
+/// Yield `(name, init)` pairs for every chunk-top single-declarator
+/// `const X = <init>` / `let X = <init>` / `var X = <init>` whose
+/// initializer is NOT a function/arrow expression (those go through
+/// `Function`). Comma-list declarations are pre-split by
 /// `top_level_item_views`, so each `VarDecl` we see here has exactly
 /// one `decl`.
 ///
-/// Both `const` and `let` candidates flow through the same scanner;
-/// the scanner's check is uniform ("no member writes or hostile
-/// builtin calls, all ident writes have plain-literal RHS"), so the
+/// All three keyword forms flow through the same scanner; the
+/// scanner's check is uniform ("no member writes or hostile builtin
+/// calls, all ident writes have plain-literal RHS"), so the
 /// distinction is only at the candidate-collection stage:
-/// `const` is admitted automatically (its binding cell is immutable
-/// at the language level; only the chunk-wide checks for accessor
-/// installation post-init matter); `let` additionally relies on
-/// every `X = rhs` ident assign having a plain-literal RHS.
-fn plain_data_const_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
+///
+/// * `const` — binding cell is immutable at the language level; only
+///   the chunk-wide checks for accessor installation post-init
+///   matter.
+/// * `let` — every `X = rhs` ident assign anywhere in the chunk must
+///   have a plain-literal RHS (enforced by `PlainDataWriteScanner`).
+/// * `var` — same as `let`, PLUS multiple chunk-top `var X = init`
+///   redeclarations are valid; the caller checks every init for a
+///   given name against the plain-literal shape rule. Pre-init reads
+///   on a hoisted `var X` see `undefined` and `undefined.k` throws a
+///   spec-mandated TypeError — sound for the read-purity claim ("no
+///   user code fires") because the throw is engine-emitted, not a
+///   user getter.
+fn plain_data_var_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
     let var = match item {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
         ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => match &export.decl {
@@ -508,9 +546,6 @@ fn plain_data_const_candidates(item: &ModuleItem) -> Vec<(String, &Expr)> {
         },
         _ => return Vec::new(),
     };
-    if !matches!(var.kind, VarDeclKind::Const | VarDeclKind::Let) {
-        return Vec::new();
-    }
     let mut out = Vec::new();
     for decl in &var.decls {
         let Pat::Ident(binding) = &decl.name else {


### PR DESCRIPTION
## Summary

Extends the PlainData admission rule landed in #1521 / #1524 to chunk-top `var X = <plain literal>` declarations. The motivating shape is gaffer-private's `embeddedBuildEnvConfig` — `var embeddedBuildEnvConfig = { REACT_APP_ENV: …, FUNCTIONS_EMULATOR: …, … }` — a bundler-emitted static config table whose `var` keyword is a Vite/esbuild artifact, not semantically meaningful. Pre-this-PR `var` was excluded from PlainData, leaving `embeddedBuildEnvConfig.FUNCTIONS_EMULATOR` flagging `unknown_member` and forcing a load-bearing `purity: pure` hint on the downstream `isEmulatorEnv` accessor in the spec.

## Soundness for debundle reshuffle

`var` carries two semantics beyond `let`/`const` that need an explicit story:

1. **Hoisting**. `var X` is hoisted to the chunk top; the initializer runs at the source line. Pre-init reads on `X` see `undefined`. Member access `undefined.k` throws a **spec-mandated TypeError** — engine-emitted, fires no user-defined code. So the "reads on X fire no user code" claim still holds: an engine-emitted throw isn't a getter call. Same story as `let` TDZ (which also engine-emits a ReferenceError on pre-init access).

2. **Redeclaration**. Multiple chunk-top `var X = init_n` statements are legal: same binding cell, each init runs in order. Sound admission requires **every** init to be plain-literal; if any decl carries a non-plain-literal init the binding can transiently hold an accessor-bearing value and we disqualify. The collector now aggregates all chunk-top inits per name and requires `is_plain_data_init` to pass on every one.

The chunk-wide `PlainDataWriteScanner` rules (no member writes, no hostile builtin calls, ident assigns must be plain-literal RHS) carry over unchanged.

## Adversarial cases

| Case                                                                       | Verdict | Tested by                                                          |
| -------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------ |
| `var X = { a: 1 }`                                                         | admit   | `plain_data_var_object_literal_is_tracked`                         |
| `var X = { a: 1 }; var X = { b: 2 };`                                      | admit   | `plain_data_var_multi_decl_all_plain_is_tracked`                   |
| `var X = { a: 1 }; var X = io();`                                          | reject  | `plain_data_var_multi_decl_with_one_non_plain_init_is_not_tracked` |
| `var X = { a: 1 }; function bad() { X = someFn(); }`                       | reject  | `plain_data_var_non_plain_ident_assign_disqualifies`               |
| `var X = { a: 1 }; function mut() { X.b = 2; }`                            | reject  | `plain_data_var_member_write_disqualifies`                         |
| `var X;` (alone, no init)                                                  | reject  | `plain_data_var_uninitialized_decl_alone_is_not_tracked`           |
| `var X; var X = { a: 1 };`                                                 | admit   | `plain_data_var_uninitialized_then_initialized_is_tracked`         |
| `var mr = {…}; const isEmulatorEnv = () => mr.FUNCTIONS_EMULATOR;` (gaffer regression) | admit + isEmulatorEnv pure | `plain_data_var_unblocks_embedded_build_env_config_shape` |

## Test plan

- [x] `bbr test //devinfra/js/debundle:analysis_test` — 8 new `var`-specific cases pass; existing `var`-rejection test flipped to admission with the new soundness story inline.
- [x] `bbr test //devinfra/js/debundle/...` — 31/31 pass; no regressions.

## Companion gaffer-private PR

After this lands and gaffer's ducktape pin advances, the `isEmulatorEnv` ($i) hint in `runtime/environment/env_config.yaml` becomes mechanically removable (the existing inline tombstone in #50 cites this exact unblock condition). That leaves only the two `mobx/*.yaml.deferred` hints — the legitimate use case for the spec-side override (genuinely-impure-but-init-safe vendor wrappers), which recursive purity is intentionally not addressing.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_