### PR TITLE
debundle/purity: admit TS-enum IIFE numeric reverse-mapping shape

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -1389,6 +1389,67 @@ mod tests {
     }
 
     #[test]
+    fn plain_data_ts_enum_iife_numeric_reverse_mapping_is_tracked() {
+        // TypeScript's numeric-enum emit produces both a forward
+        // map and a reverse map via the nested-assignment shape:
+        //
+        //     n[(n.A = 0)] = "A"
+        //
+        // The inner `n.A = 0` writes 0 as a data property under
+        // key "A", then evaluates to 0, which the outer assignment
+        // uses as the computed key for the reverse map:
+        // `n[0] = "A"`. Both writes are data-property only — sound.
+        let src = r#"var E = ((n) => (n[(n.A = 0)] = "A", n))(E || {});"#;
+        assert!(is_plain_data(src, "E"));
+    }
+
+    #[test]
+    fn plain_data_ts_enum_iife_numeric_reverse_mapping_string_key_form_is_tracked() {
+        // The bracket-key inner form `n[(n["A"] = 0)] = "A"`. Same
+        // soundness story, different syntactic shape for the inner
+        // forward write.
+        let src = r#"var E = ((n) => (n[(n["A"] = 0)] = "A", n))(E || {});"#;
+        assert!(is_plain_data(src, "E"));
+    }
+
+    #[test]
+    fn plain_data_ts_enum_iife_multiple_numeric_keys_is_tracked() {
+        // Multi-key numeric-reverse-mapping IIFE — the canonical
+        // Vite/TS emit for `enum E { A, B, C }`. Pins that the
+        // recursive admission scales beyond a single key.
+        let src = r#"var E = ((n) => ((n[(n.A = 0)] = "A"), (n[(n.B = 1)] = "B"), (n[(n.C = 2)] = "C"), n))(E || {});"#;
+        assert!(is_plain_data(src, "E"));
+    }
+
+    #[test]
+    fn plain_data_ts_enum_iife_mixed_string_and_numeric_keys_is_tracked() {
+        // The same IIFE can mix forward-only writes (string enum
+        // form) and reverse-mapped writes (numeric enum form) as
+        // long as every step matches one of the admitted shapes.
+        let src = r#"var E = ((n) => (n.a = "a", n[(n.B = 1)] = "B", n))(E || {});"#;
+        assert!(is_plain_data(src, "E"));
+    }
+
+    #[test]
+    fn plain_data_ts_enum_iife_nested_key_non_param_object_is_not_tracked() {
+        // The inner assignment must target the SAME param. A nested
+        // write on a different object would put data on a different
+        // object and use the result as the outer key — sound for
+        // X's purity in isolation but not what the rule is meant
+        // to admit, and the recursive check naturally rejects it.
+        let src = r#"var X = ((n) => (n[(other.X = 0)] = "X", n))({});"#;
+        assert!(!is_plain_data(src, "X"));
+    }
+
+    #[test]
+    fn plain_data_ts_enum_iife_nested_key_non_primitive_rhs_is_not_tracked() {
+        // The inner assignment's RHS must be primitive — same
+        // stricter rule as the outer case.
+        let src = r#"var X = ((n) => (n[(n.A = io())] = "A", n))({});"#;
+        assert!(!is_plain_data(src, "X"));
+    }
+
+    #[test]
     fn plain_data_ts_enum_iife_inner_param_write_doesnt_disqualify_outer_candidate() {
         // The scanner's param-scope tracking is the key feature
         // making the shadow case work. This test pins the

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -659,12 +659,6 @@ fn is_plain_data_init(expr: &Expr) -> bool {
 ///
 /// **What is NOT admitted (and why):**
 ///
-/// * **Numeric-enum reverse-mapping** `param[param["A"] = 0] = "A"` —
-///   the inner assignment evaluates to a number used as the outer
-///   key; the property write itself is still data-only, but the
-///   nested form complicates the check. Modern TS string enums
-///   (the dominant emit since TS 5+) use the simpler form admitted
-///   here.
 /// * **Block-bodied function** `function (p) { p.A = …; return p; }` —
 ///   same logical structure; can be added as a separate match arm.
 ///   This rule starts with the arrow-comma-body shape (esbuild /
@@ -672,6 +666,13 @@ fn is_plain_data_init(expr: &Expr) -> bool {
 /// * **Multi-statement bodies** that do anything other than parameter
 ///   mutation — `console.log(p)`, `Object.defineProperty(p, …)`,
 ///   nested IIFEs, etc.
+///
+/// **Numeric-enum reverse-mapping** `param[(param.X = 0)] = "X"` IS
+/// admitted via the nested-assignment-as-computed-key branch in
+/// `is_ts_enum_iife_property_write` — the inner assignment is itself
+/// a `param.X = primLit` data-property write, the outer is a
+/// data-property write keyed by the primitive that inner evaluates
+/// to. Both writes are sound.
 fn is_ts_enum_iife_init(expr: &Expr) -> bool {
     let mut cur = expr;
     while let Expr::Paren(p) = cur {
@@ -757,13 +758,25 @@ fn strip_parens(expr: &Expr) -> &Expr {
     cur
 }
 
-/// One step of the IIFE body: `param.K = primLit` or
-/// `param[strLit] = primLit` / `param[numLit] = primLit`. Only
-/// primitive-literal RHS is accepted; non-literal RHS could
-/// theoretically return an accessor-bearing object — but the
-/// property write would still install it as a data descriptor on the
-/// param. The stricter primitive-literal RHS keeps the soundness
-/// story uniform with `is_plain_data_prop`.
+/// One step of the IIFE body:
+///
+/// * `param.K = primLit` — forward map (static key).
+/// * `param[strLit] = primLit` / `param[numLit] = primLit` —
+///   forward map (literal computed key).
+/// * `param[(param.K = primLit)] = primLit` /
+///   `param[(param["K"] = primLit)] = primLit` — TypeScript's
+///   numeric-enum reverse-mapping shape. The inner assignment is
+///   itself a `param.X = primLit` data-property write that
+///   evaluates to the assigned primitive, which then becomes the
+///   outer Member's computed key. Both writes are data-property
+///   writes on the param; reads on the post-IIFE binding see only
+///   data properties.
+///
+/// Only primitive-literal RHS is accepted at both nesting levels;
+/// non-literal RHS could theoretically return an accessor-bearing
+/// object — the property write would still install it as a data
+/// descriptor on the param, but the stricter primitive-literal RHS
+/// keeps the soundness story uniform with `is_plain_data_prop`.
 fn is_ts_enum_iife_property_write(expr: &Expr, param: &str) -> bool {
     let Expr::Assign(assign) = expr else {
         return false;
@@ -779,10 +792,17 @@ fn is_ts_enum_iife_property_write(expr: &Expr, param: &str) -> bool {
     }
     let key_ok = match &member.prop {
         MemberProp::Ident(_) => true,
-        MemberProp::Computed(c) => matches!(
-            c.expr.as_ref(),
-            Expr::Lit(Lit::Str(_)) | Expr::Lit(Lit::Num(_))
-        ),
+        MemberProp::Computed(c) => {
+            let key = strip_parens(c.expr.as_ref());
+            matches!(key, Expr::Lit(Lit::Str(_)) | Expr::Lit(Lit::Num(_)))
+                // TS numeric-enum reverse-mapping: the computed key
+                // is itself a `param.X = primLit` data-property write
+                // that evaluates to a primitive used as the outer
+                // key. Both the inner and outer writes are sound
+                // data-property writes; recurse to verify the inner
+                // matches the same shape this function admits.
+                || is_ts_enum_iife_property_write(key, param)
+        }
         MemberProp::PrivateName(_) => false,
     };
     if !key_ok {


### PR DESCRIPTION
## Summary

#1528 admitted the TS-enum IIFE shape but explicitly excluded the numeric-enum reverse-mapping form because the nested-assignment-as-computed-key syntax complicated the check. Both the modern string-enum form (`p.A = "a"`) and the numeric-enum form (`p[(p.A = 0)] = "A"`) appear in real bundler output, with the numeric form being roughly as common as the string form in TypeScript-compiled corpora.

## Admitted shape

```js
var X = ((n) => (n[(n.A = 0)] = "A", n[(n.B = 1)] = "B", n))(X || {});
```

The inner assignment `n.A = 0` writes 0 as a data property under key `"A"`, then evaluates to 0 (AssignOp::Assign returns the RHS). The outer assignment uses that 0 as the computed key for the reverse-map write `n[0] = "A"`. Both writes are data-property writes on the param; reads on the post-IIFE binding see only data properties.

## Implementation

Extends `is_ts_enum_iife_property_write` to admit one extra shape for the computed-key case: when the key expression is itself a `param.X = primLit` (or bracket-form) data-property write, the outer assignment qualifies. Recursive check on the inner expression re-uses the same rules so soundness remains uniform: **every write at every nesting level is a data-property write on the param with primitive-literal RHS**.

## Soundness

Same as the string-enum form: the param starts as a plain object (by the arg gate). Every write — inner or outer — is a `[[Set]]` on the param with a primitive-literal RHS, which on a target with no existing accessor for the key runs `CreateDataProperty` producing a data descriptor. After the IIFE returns, the binding holds a plain object with only data properties. Reads fire no user code.

## Test plan

6 new `analysis_tests`, all using generic minimal single-letter fixtures per AGENTS.md fixture-minimization rule:

- Single-key numeric reverse-mapping.
- Bracket-form inner key `n[(n["A"] = 0)] = "A"`.
- Multi-key numeric reverse-mapping (canonical 3-key enum).
- Mixed forward-string + numeric-reverse writes in one IIFE.
- Inner write on a non-param object — reject.
- Inner RHS non-primitive — reject.

- [x] `bbr test //devinfra/js/debundle/...` — 31/31 pass.

## Companion

After this lands, the downstream gaffer pipeline will admit ~20 additional TS-enum bindings in the `78d928dca7` snapshot (the numeric-reverse-mapping form is the predominant one in that corpus). The existing redundant-hint warning (from #1526) will surface any `purity: pure` spec hints on those bindings as removable; the gaffer-side cleanup is a separate PR after this merges + the pin advances.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_