### PR TITLE
debundle/vendor: accept Shorthand props in `named_from_default` upstream

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -182,23 +182,15 @@ Known cleanup targets:
 
 ## Vendor swap edge cases
 
-- `named_from_default`: documented acceptance contract is "upstream
-  default export is an object literal whose keys are `Prop::KeyValue`
-  with `Ident` or `Str` names". `e2e/vendor_swap_test.rs` pins the
-  accepted shape and explicitly rejects two adjacent shapes:
-  - **Shorthand props** (`export default { ping, pong }` where `ping`
-    and `pong` are local refs) are silently skipped by
-    `collect_default_export_object_keys` and the wrapper fails the
-    missing-keys check. Real-world vendor `index.mjs` files commonly
-    use shorthand, so accepting them is a useful relaxation. Fix:
-    extend the prop-walk to read shorthand keys from the prop's own
-    name. Should be a few-line change with one new accepted-shape
-    test.
+- `named_from_default`: accepted shape is "upstream default export is
+  an object literal whose props are either `Prop::KeyValue` with
+  `Ident`/`Str` keys or `Prop::Shorthand`". One adjacent shape is
+  still rejected:
   - **Class / function default declarations** (`export default class
-{}`) don't surface as `ExportDefaultExpr` and bail with "no
-    export default declaration". Open whether to accept (less common
-    for `named_from_default` wrapper shape) or document as
-    intentionally out-of-scope.
+{}`) don't surface as `ExportDefaultExpr` and bail with "no export
+    default declaration". Open whether to accept (less common for
+    `named_from_default` wrapper shape) or document as intentionally
+    out-of-scope.
 
 - `named_from_module_default`: handle anonymous default function/class
   declarations (currently rejected).

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -276,16 +276,15 @@ fn named_from_default_handles_object_literal_with_keyvalue_props() {
 }
 
 #[test]
-fn named_from_default_rejects_shorthand_props_silently_today() {
-    // Documented gap: `collect_default_export_object_keys` only walks
-    // `Prop::KeyValue` props, so `Prop::Shorthand` (`{ ping, pong }`)
-    // is silently skipped — the wrapper fails the missing-keys check
-    // because the upstream "object" yields zero detectable keys.
-    //
-    // This test pins the current behavior so a future relaxation
-    // (accepting Shorthand) flips it from failing-with-missing-keys to
-    // succeeding. Until then, vendor authors must use explicit
-    // `KeyValue` props in the upstream `export default`.
+fn named_from_default_accepts_shorthand_props() {
+    // Shorthand object-literal props (`{ ping, pong }` — local
+    // binding names used directly as both key and value) produce
+    // the same wrapper shape as `KeyValue` props: each shorthand
+    // key reflects a data property on the default export whose
+    // value is the local binding, so `export const K = _d.K;`
+    // re-exports the right value. Real-world vendor `index.mjs`
+    // files use shorthand commonly; accepting it removes an
+    // otherwise-unmotivated authoring requirement.
     let upstream_source = r#"const ping = () => "pong";
 const pong = () => "ping";
 export default { ping, pong };
@@ -297,19 +296,52 @@ export default { ping, pong };
     });
 
     assert!(
-        !fixture.result.status.success(),
-        "debundler should fail on shorthand-only object today:\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
         fixture.result.stdout,
         fixture.result.stderr,
     );
+
+    let wrapper_source = fs::read_to_string(&fixture.wrapper_path).expect("wrapper exists");
     assert!(
-        fixture
-            .result
-            .stderr
-            .contains("named-from-default wrapper shape mismatch"),
-        "expected wrapper-shape-mismatch error; got stderr:\n{}",
+        wrapper_source.contains("export const ping = _d.ping"),
+        "wrapper should emit a named-export pull for `ping`:\n{wrapper_source}",
+    );
+    assert!(
+        wrapper_source.contains("export const pong = _d.pong"),
+        "wrapper should emit a named-export pull for `pong`:\n{wrapper_source}",
+    );
+    assert!(
+        wrapper_source.contains("export default _d"),
+        "wrapper should preserve the default export:\n{wrapper_source}",
+    );
+}
+
+#[test]
+fn named_from_default_accepts_mixed_keyvalue_and_shorthand_props() {
+    // Mixed shape — KeyValue + Shorthand in the same default
+    // export. Both shapes contribute their keys to the wrapper's
+    // named-export set.
+    let upstream_source = r#"const ping = () => "pong";
+export default { ping, "pong": () => "ping" };
+"#;
+
+    let fixture = run_named_from_default_fixture(NamedFromDefaultFixtureArgs {
+        upstream_source,
+        chunk_source: "export { ping, pong } from \"lib\";\n",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
         fixture.result.stderr,
     );
+    let wrapper_source = fs::read_to_string(&fixture.wrapper_path).expect("wrapper exists");
+    assert!(wrapper_source.contains("export const ping = _d.ping"));
+    assert!(wrapper_source.contains("export const pong = _d.pong"));
 }
 
 #[test]

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1006,10 +1006,21 @@ fn collect_default_export_object_keys(
             let PropOrSpread::Prop(prop) = prop else {
                 continue;
             };
-            let Prop::KeyValue(key_value) = &**prop else {
-                continue;
+            // Two accepted prop shapes — both produce the same wrapper
+            // (`export const K = _d.K;`):
+            // * `KeyValue` with `Ident` or `Str` key (`{ ping: fn, "pong": fn }`).
+            // * `Shorthand` (`{ ping, pong }`) where the local binding name
+            //   is the property name; `_d.ping` re-exports the same value
+            //   because object-literal shorthand assigns the binding's
+            //   value as a data property under the binding's name.
+            // Real-world vendor `index.mjs` files use shorthand commonly;
+            // both shapes are emit-equivalent for the wrapper's purposes.
+            let key = match &**prop {
+                Prop::KeyValue(key_value) => prop_name(&key_value.key),
+                Prop::Shorthand(ident) => Some(ident.sym.to_string()),
+                _ => None,
             };
-            if let Some(key) = prop_name(&key_value.key) {
+            if let Some(key) = key {
                 keys.insert(key);
             }
         }


### PR DESCRIPTION
## Summary

Real-world vendor `index.mjs` files commonly emit `export default { ping, pong };` (shorthand props referencing local bindings) rather than the explicit `export default { ping: ping, pong: pong };` keyvalue form. Pre-this-PR `collect_default_export_object_keys` walked only `Prop::KeyValue` props and silently skipped `Prop::Shorthand`, leaving the wrapper to fail the missing-keys check with a `"named-from-default wrapper shape mismatch"` error.

This was called out in `devinfra/js/debundle/TODO.md` as a one-line fix with a known rejection-pinning test ready to be flipped to acceptance.

## Why this is sound

Object-literal shorthand `{ ping }` is spec-defined as exactly equivalent to `{ ping: ping }`: the shorthand creates a data property on the new object whose key is the binding's name and whose value is the binding's current value. So `_d.ping` resolves to the same value as the local `ping` binding at the default-export evaluation point, and `export const ping = _d.ping;` re-exports the right thing.

Both prop shapes are emit-equivalent for the wrapper's purposes:

```js
// KeyValue (already accepted)
export default { ping: () => "pong", "pong": () => "ping" };

// Shorthand (newly accepted)
const ping = () => "pong";
const pong = () => "ping";
export default { ping, pong };

// Mixed (newly accepted)
const ping = () => "pong";
export default { ping, "pong": () => "ping" };
```

## Test plan

- [x] `named_from_default_accepts_shorthand_props` — flipped from the prior rejection-pinning test (`named_from_default_rejects_shorthand_props_silently_today`), now asserts wrapper success + the three expected `export const X = _d.X;` lines.
- [x] `named_from_default_accepts_mixed_keyvalue_and_shorthand_props` — new test pinning that mixed prop kinds in one default export both contribute to the wrapper's named-export set.
- [x] `bbr test //devinfra/js/debundle/...` — 31/31 pass.

The `named_from_default_rejects_non_object_literal_default` test (for `export default class {}`) is unchanged — that's a separate shape (`ExportDefaultDecl` vs `ExportDefaultExpr`) and is called out in the trimmed TODO entry as the remaining open case in this neighborhood.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_