### PR TITLE
debundle/TODO: drop empty `Vendor swap edge cases` section

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -180,18 +180,6 @@ Known cleanup targets:
   resolution/index query API so mutation stages ask the same typed question and
   differ only in how they rewrite the matched AST node.
 
-## Vendor swap edge cases
-
-(No open vendor-swap-shape items as of 2026-05-12. The wrapper
-shapes covered by `swap_vendor_chunks` are:
-`named_from_default` (object-literal defaults with `KeyValue` /
-`Shorthand` props) and `named_from_module_default` (re-exported
-locals + anonymous default function/class). Class / function
-default declarations through `named_from_default` are
-intentionally out-of-scope — instance methods aren't reachable
-via `_d.K`; vendor authors needing that shape should use
-`named_from_module_default` instead.)
-
 ## Analysis semantics breadth
 
 The focused fixtures exercise the core access model. Validate or extend


### PR DESCRIPTION
Following the prior cleanup (#1531), the section held only a parenthetical "no open items" note. The TODO file convention (per the file's own opening line — "Items are written to be removed once closed; this file is not a changelog") is that closed items get removed, not tombstoned in place. Drop the section.

The shape recap (KeyValue / Shorthand for `named_from_default`, anonymous fn/class via DefaultDecl for `named_from_module_default`) belongs in code comments / wrapper-specific docs if it's worth keeping; this is a one-line TODO grooming change, no behavior impact.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_