### PR TITLE
debundle: trim TODO — move parser-ownership principle to AGENTS, drop speculative items

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -253,6 +253,23 @@ SWC-parsed input. Do not use raw text rewrites, string scanning, regex
 rewriting, ad hoc source patching, or other text-based mutation as a
 substitute for AST transformations.
 
+Syntax-derived facts likewise come from the SWC-backed parse/analysis
+path and flow through artifact manifests / indexes — not from
+phase-local rescans. The pipeline parses each chunk once in
+`prepare_js_chunks` and records imports, exports, dynamic-import
+shape, etc. on `ChunkManifest`; downstream stages (vendor renaming,
+specifier rewriting, owner-graph construction) consume those manifest
+facts through the centralized `ArtifactIndexes` query API
+(`resolve_runtime_import_reference`, `manifest_imports_targeting_chunk`,
+etc.) rather than re-walking the AST to answer "which chunk does this
+import resolve to" or "which chunks import this binding". Mutation
+passes still need an AST visitor to apply the rewrite — that's
+unavoidable — but the resolution decision is fed in from the
+manifest, not rebuilt per stage. If a new pipeline question can't
+be answered by the existing manifest schema, extend the shallow
+analysis once instead of discovering the same fact again in another
+stage.
+
 ## Working Rule
 
 If a proposed change improves a test result without improving real

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -154,32 +154,6 @@ Tighten before the next large Tana peel loop:
   `(file, role)` pairs into a typed map if the output consumers do not
   depend on order. Keep the manifest easy to diff and easy to read.
 
-## Parser / analysis ownership audit followups
-
-Syntax-derived facts should come from the SWC-backed parse/analysis path and
-then flow through artifact manifests or indexes. Do not add phase-local string
-scans, regexes, or miniature JavaScript parsers to answer questions the real
-parser already answered.
-
-Known cleanup targets:
-
-- Keep import/specifier facts downstream of `prepare_js_chunks`: the pipeline
-  should parse/analyze chunks once, then derive vendor-caller and chunk-reference
-  decisions from `ChunkManifest.imports` / artifact indexes. No pre-parse source
-  scanning for import strings.
-- `vendor.rs` still has AST-local import alignment and vendor import-renaming
-  walks. The mutation pass needs an AST visitor, but the "which source imports
-  which chunk / which named bindings" facts should be fed from artifact import
-  indexes rather than rebuilt by ad hoc per-stage AST scans.
-- `program_analysis.rs` currently records dynamic-import count but not dynamic
-  import source records. If later pipeline decisions need dynamic import
-  sources, extend the shallow analysis schema once instead of discovering them
-  again in another stage.
-- `rewrite_specifiers.rs` and vendor import rewriting duplicate source
-  resolution logic around relative/source import references. Centralize the
-  resolution/index query API so mutation stages ask the same typed question and
-  differ only in how they rewrite the matched AST node.
-
 ## Analysis semantics breadth
 
 The focused fixtures exercise the core access model. Validate or extend
@@ -231,8 +205,3 @@ mock browser bundle. Extend to:
 - Large vendor-heavy graphs.
 - Unusual dynamic import forms.
 - HTML/runtime asset layouts outside the current corpus.
-
-## Authoring config: browser-harness asset root
-
-Add a separate browser-harness asset root only if a real corpus needs static
-asset inputs to come from somewhere other than `inputs.root`.


### PR DESCRIPTION
## Summary

Two TODO sections drop entirely; the parser-ownership principle moves to `debundle/AGENTS.md`.

### `## Parser / analysis ownership audit followups` → AGENTS.md

Section held a principle paragraph + 4 bullets, every one of which is **already implemented** or **speculative-conditional**:

- "No pre-parse source scanning for import strings" — survey finds no offenders today (pipeline parses chunks once in `prepare_js_chunks`).
- "`vendor.rs` AST-local import alignment" — already consumes `references.manifest_imports_targeting_chunk` (artifact index) in `build_import_alignment_index`, not a per-stage rescan.
- "`program_analysis.rs` dynamic-import source records" — speculative ("if later pipeline decisions need them"). No current consumer.
- "`rewrite_specifiers.rs` and vendor import rewriting duplicate source resolution logic" — both already call the centralized `references.resolve_runtime_import_reference`.

The opening principle (facts flow through manifests / indexes, don't re-walk the AST per stage) is **good standing guidance** but isn't a TODO item. Moved into `debundle/AGENTS.md` `## AST Requirement` as a second paragraph extending the "no text scanning" rule with the parallel "no fact re-derivation" rule.

### `## Authoring config: browser-harness asset root` → drop

One-sentence conditional: "Add a separate browser-harness asset root only if a real corpus needs static asset inputs to come from somewhere other than `inputs.root`." That's a design note for a hypothetical, not a TODO. Re-add when a corpus motivates it.

## Test plan

- [x] Doc-only consolidation; no behavior change.
- [x] Both removed sections' content is either already-implemented (covered by existing tests) or speculative (no consumer).

The TODO file is now: Excalidraw smoke, logical materialization breadth, materialize-stage hot-loop, graph-pass performance, analysis semantics breadth, cross-module purity (deferred with rationale), corpus breadth. All concrete or with explicit deferral rationale.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_