### PR TITLE
debundle: extract spec_modules — shared YAML walk + ModuleFile serde

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -199,6 +199,7 @@ rust_library(
     deps = [
         ":analysis",
         ":spec",
+        ":spec_modules",
         ":spec_tree",
         "@crates//:anyhow",
         "@crates//:serde",
@@ -225,6 +226,26 @@ rust_binary(
         "@crates//:clap",
         "@crates//:serde_json",
     ],
+)
+
+rust_library(
+    name = "spec_modules",
+    srcs = ["spec_modules.rs"],
+    crate_root = "spec_modules.rs",
+    edition = "2024",
+    deps = [
+        ":spec",
+        "@crates//:anyhow",
+        "@crates//:serde",
+        "@crates//:serde_yaml",
+    ],
+)
+
+rust_test(
+    name = "spec_modules_test",
+    crate = ":spec_modules",
+    edition = "2024",
+    deps = ["@crates//:tempfile"],
 )
 
 rust_library(
@@ -266,6 +287,7 @@ rust_library(
     edition = "2024",
     deps = [
         ":spec",
+        ":spec_modules",
         "@crates//:anyhow",
         "@crates//:serde",
         "@crates//:serde_yaml",

--- a/devinfra/js/debundle/peel_horizon.rs
+++ b/devinfra/js/debundle/peel_horizon.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 
 use analysis::{BindingReport, OwnerGraphReport};
 use spec::BindingSourceKind;
-use spec_tree::ModuleFile;
+use spec_modules::{
+    collect_module_files, is_deferred_yaml, module_path_from_file, read_module_file,
+};
 
 #[derive(Debug, Clone)]
 pub struct PeelHorizonOptions {
@@ -234,10 +236,8 @@ fn load_modules_and_symbols(
 ) -> Result<(DeferredModules, SymbolHomesByBinding)> {
     let mut deferred_modules = Vec::new();
     let mut symbols: BTreeMap<String, Vec<SymbolHome>> = BTreeMap::new();
-    let mut files = Vec::new();
-    collect_module_files(root, &mut files)?;
 
-    for path in files {
+    for path in collect_module_files(root)? {
         let (module, module_symbols) = parse_module_file(&path, root, owner_by_binding)?;
         if is_deferred_yaml(&path) {
             deferred_modules.push(module);
@@ -250,31 +250,13 @@ fn load_modules_and_symbols(
     Ok((deferred_modules, symbols))
 }
 
-fn collect_module_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(root).with_context(|| format!("reading {}", root.display()))? {
-        let path = entry
-            .with_context(|| format!("walking {}", root.display()))?
-            .path();
-        if path.is_dir() {
-            collect_module_files(&path, out)?;
-        } else if is_module_yaml(&path) {
-            out.push(path);
-        }
-    }
-    out.sort();
-    Ok(())
-}
-
 fn parse_module_file(
     path: &Path,
     root: &Path,
     owner_by_binding: &BTreeMap<String, String>,
 ) -> Result<(DeferredModule, BTreeMap<String, SymbolHome>)> {
     let is_deferred = is_deferred_yaml(path);
-    let data: ModuleFile = serde_yaml::from_str(
-        &fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?,
-    )
-    .with_context(|| format!("parsing {}", path.display()))?;
+    let data = read_module_file(path)?;
     let module_path = module_path_from_file(path, root, is_deferred);
 
     let mut bindings = BTreeSet::new();
@@ -539,35 +521,6 @@ fn push_companion_table(out: &mut String, title: &str, rows: &[ModuleCoverage], 
             companions
         ));
     }
-}
-
-fn is_module_yaml(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".yaml") || name.ends_with(".yaml.deferred"))
-}
-
-fn is_deferred_yaml(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".yaml.deferred"))
-}
-
-fn module_path_from_file(path: &Path, root: &Path, is_deferred: bool) -> String {
-    let relative = path
-        .strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .replace('\\', "/");
-    let suffix = if is_deferred {
-        ".yaml.deferred"
-    } else {
-        ".yaml"
-    };
-    relative
-        .strip_suffix(suffix)
-        .unwrap_or(&relative)
-        .to_string()
 }
 
 #[cfg(test)]

--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -1,0 +1,144 @@
+//! Shared helpers for walking a debundle spec's `modules/` directory.
+//!
+//! The main debundler (`spec_tree`) and the analysis CLIs
+//! (`peel_horizon`, and forthcoming siblings) all need to:
+//!
+//! * Enumerate `*.yaml` (active) and `*.yaml.deferred` (parked)
+//!   files under a spec's modules root.
+//! * Deserialize each file's body via the canonical `ModuleFile`
+//!   shape (members + anonymous statements).
+//! * Ask path-level questions like "is this active or deferred?"
+//!   and "what module path does this file represent?".
+//!
+//! This crate is the single source of truth for the above so the
+//! debundler and the analysis tools always agree on the spec's
+//! on-disk layout.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use spec::{AnonymousStatement, Member};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModuleFile {
+    #[serde(default)]
+    pub members: Vec<Member>,
+    #[serde(default)]
+    pub anonymous_statements: Vec<AnonymousStatement>,
+}
+
+pub fn is_module_yaml(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".yaml") || name.ends_with(".yaml.deferred"))
+}
+
+pub fn is_deferred_yaml(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".yaml.deferred"))
+}
+
+pub fn module_path_from_file(path: &Path, root: &Path, is_deferred: bool) -> String {
+    let relative = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    let suffix = if is_deferred {
+        ".yaml.deferred"
+    } else {
+        ".yaml"
+    };
+    relative
+        .strip_suffix(suffix)
+        .unwrap_or(&relative)
+        .to_string()
+}
+
+pub fn collect_module_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    collect_module_files_into(root, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_module_files_into(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).with_context(|| format!("reading {}", root.display()))? {
+        let path = entry
+            .with_context(|| format!("walking {}", root.display()))?
+            .path();
+        if path.is_dir() {
+            collect_module_files_into(&path, out)?;
+        } else if is_module_yaml(&path) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+pub fn read_module_file(path: &Path) -> Result<ModuleFile> {
+    serde_yaml::from_str(
+        &fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?,
+    )
+    .with_context(|| format!("parsing {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(root: &Path, rel: &str, body: &str) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn collect_module_files_picks_yaml_and_deferred_skips_other_files() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        write(root, "ui/a.yaml", "members: []\n");
+        write(root, "ui/b.yaml.deferred", "members: []\n");
+        write(root, "ui/c.txt", "ignored\n");
+        write(root, "ui/d.yaml.bak", "ignored\n");
+        let files = collect_module_files(root).unwrap();
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["ui/a.yaml", "ui/b.yaml.deferred"]);
+    }
+
+    #[test]
+    fn module_path_from_file_strips_yaml_suffixes() {
+        let root = Path::new("/spec");
+        assert_eq!(
+            module_path_from_file(Path::new("/spec/ui/list.yaml"), root, false),
+            "ui/list",
+        );
+        assert_eq!(
+            module_path_from_file(Path::new("/spec/ui/list.yaml.deferred"), root, true),
+            "ui/list",
+        );
+    }
+
+    #[test]
+    fn read_module_file_round_trips_members_and_anonymous_statements() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("x.yaml");
+        fs::write(
+            &path,
+            "members:\n  - selector: { binding: { name: a } }\nanonymous_statements: []\n",
+        )
+        .unwrap();
+        let module = read_module_file(&path).unwrap();
+        assert_eq!(module.members.len(), 1);
+        assert_eq!(module.members[0].selector.binding.name, "a");
+    }
+}

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -10,6 +10,9 @@ use spec::{
     MaterializeLogicalModulesConfig, Member, SwapMark, SwapVendorChunksConfig, TransformSpec,
     VendorLevel, VendorMark, VendorRole, WrapperShape,
 };
+use spec_modules::{
+    collect_module_files, is_deferred_yaml, module_path_from_file, read_module_file,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompileSpecTreeOptions {
@@ -73,22 +76,6 @@ enum VendorLevelSource {
     Suppress,
     BoundaryRename,
     Swap,
-}
-
-/// Authoring shape of a single per-module YAML under
-/// `modules/**/<path>.yaml{,.deferred}`. Re-exported so
-/// `peel_horizon` (and any other consumer that ranks deferred YAMLs)
-/// parses them through exactly the same schema the canonical
-/// `compile_spec_tree` path uses — every additive field landed here
-/// is automatically accepted by those consumers and stays in lockstep
-/// with the on-disk YAML the debundler itself reads.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ModuleFile {
-    #[serde(default)]
-    pub members: Vec<Member>,
-    #[serde(default)]
-    pub anonymous_statements: Vec<AnonymousStatement>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -186,25 +173,15 @@ fn load_main_chunk_modules(
 ) -> Result<(Vec<ModuleSource>, Vec<Member>)> {
     let mut active = Vec::new();
     let mut deferred_members = Vec::new();
-    let mut files = Vec::new();
-    collect_module_files(modules_root, &mut files)?;
-    for path in files {
+    for path in collect_module_files(modules_root)? {
         let is_deferred = is_deferred_yaml(&path);
-        let module_path = module_path_from_file(
-            &path,
-            modules_root,
-            if is_deferred {
-                ".yaml.deferred"
-            } else {
-                ".yaml"
-            },
-        );
-        let data: ModuleFile = read_yaml(&path)?;
+        let module_path = module_path_from_file(&path, modules_root, is_deferred);
+        let data = read_module_file(&path)?;
         if is_deferred {
-            deferred_members.extend(data.members);
             // Deferred files don't get materialized; their
             // anonymous_statements (if any) are dropped on the
             // floor — there's no logical module to attach them to.
+            deferred_members.extend(data.members);
         } else {
             active.push(ModuleSource {
                 chunk_id: main_chunk_id.to_string(),
@@ -216,21 +193,6 @@ fn load_main_chunk_modules(
     }
     active.sort_by(|left, right| left.path.cmp(&right.path));
     Ok((active, deferred_members))
-}
-
-fn collect_module_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(root).with_context(|| format!("reading {}", root.display()))? {
-        let path = entry
-            .with_context(|| format!("walking {}", root.display()))?
-            .path();
-        if path.is_dir() {
-            collect_module_files(&path, out)?;
-        } else if is_module_yaml(&path) {
-            out.push(path);
-        }
-    }
-    out.sort();
-    Ok(())
 }
 
 fn vendor_map(sources: Vec<VendorMarkSource>) -> Result<BTreeMap<String, VendorMark>> {
@@ -333,30 +295,6 @@ fn chunk_renames_map(
             members: deferred_members,
         },
     )])
-}
-
-fn is_module_yaml(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".yaml") || name.ends_with(".yaml.deferred"))
-}
-
-fn is_deferred_yaml(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".yaml.deferred"))
-}
-
-fn module_path_from_file(path: &Path, root: &Path, suffix: &str) -> String {
-    let relative = path
-        .strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .replace('\\', "/");
-    relative
-        .strip_suffix(suffix)
-        .unwrap_or(&relative)
-        .to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`spec_tree` (the main debundler) and `peel_horizon` independently reimplemented the same code for walking `modules/<...>/*.yaml{,.deferred}` files. Both had identical `is_module_yaml` / `is_deferred_yaml` / `module_path_from_file` / `collect_module_files` private helpers, plus their own ad-hoc `serde_yaml::from_str -> ModuleFile` callsite.

Lifts the shared surface into a new `spec_modules` lib that is now the single source of truth:

- `ModuleFile` (moved here from `spec_tree`; its body is just `Vec<Member> + Vec<AnonymousStatement>`, both already in `spec`).
- `is_module_yaml`, `is_deferred_yaml`, `module_path_from_file`, `collect_module_files`.
- `read_module_file` — single owning `serde_yaml::from_str` callsite.

Both consumers now route through `spec_modules`; their duplicated helpers are deleted.

## Why now

The follow-up that motivated this lift is `peel_factorize` — an algorithmic peel proposer that reads `owner_graph.json` + the spec module tree to suggest module partitions (see <https://github.com/agentydragon/gaffer-private/blob/main/tana/x/research/graph_factorization_tool.md>). It'll consume the same helpers when it lands, so all three tools see exactly the same view of the spec. Pre-landing the shared lift keeps that future PR focused on the algorithm itself.

## Test plan

- [x] No behavior change — same files walked, same serde, same path mapping.
- [x] `bbr test //devinfra/js/debundle/...` — 32/32 pass.
- [x] New `spec_modules_test` adds 3 unit tests pinning the file-walk / path-strip / round-trip contracts.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_