### PR TITLE
debundle/spec_modules: drop unused `BTreeSet` from lib-scope imports

### DIFF
--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -14,7 +14,7 @@
 //! debundler and the analysis tools always agree on the spec's
 //! on-disk layout.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -174,6 +174,7 @@ pub fn load_deferred_groups(modules_root: &Path) -> Result<BTreeMap<String, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use tempfile::TempDir;
 
     fn write(root: &Path, rel: &str, body: &str) {


### PR DESCRIPTION
## Summary

#1536 left a top-level `use std::collections::{BTreeMap, BTreeSet}` in `spec_modules.rs` where only `BTreeMap` is consumed by the lib's main code path (`load_active_claims` and `load_deferred_groups` both return `BTreeMap<String, String>`). `BTreeSet` is only used inside `#[cfg(test)] mod tests` via test-fixture assertions.

The Clippy lint at `-D unused-imports` catches this when the production lib build runs (without `#[cfg(test)]` activating the test module). The lint **did not trip** during #1536's own test runs because those built the `spec_modules_test` target — which IS the test crate, so the import is used. Whole-repo `bbr test //...` on devel catches it.

## Fix

Keep `BTreeMap` at lib scope (used by both lib and tests). Move `BTreeSet` into the test module's local imports.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 33/33 green.
- [ ] CI whole-repo `bbr test //...` — the original failure pattern is reachable; this fix should clear it.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_