### PR TITLE
debundle: reject any duplicate binding claim (top-level decl or imported)

### DIFF
--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -199,61 +199,60 @@ console.log(w({ a: null, b: "d" }));
 // --- Consumer-side import-local disambiguation ---------------------------
 
 #[test]
-fn duplicate_claims_use_readable_imports() {
-    // Two plans claim the same input-bundle `binding`. Without
-    // disambiguation the second emit's import shadows the first
-    // and the file fails to parse. The materializer mints a
-    // `$N` suffix on the second.
+fn duplicate_top_level_decl_claims_are_rejected() {
+    // Regression for the gaffer Tana case: two YAMLs both claim the
+    // same input-bundle top-level binding (e.g. both `runtime.yaml`
+    // and `ai_conversation_node_accessor.yaml` export
+    // `AIConversationNodeAccessor` from binding `ho`). Previously the
+    // emitter put the body in one module and emitted
+    // `export { AIConversationNodeAccessor };` with no backing decl
+    // in the other — invalid JS that fails `import()` with
+    // "SyntaxError: Export 'X' is not defined in module".
+    //
+    // The spec author's options are: put both renames in one module,
+    // or pick one module to own the declaration. Two modules
+    // re-exporting the same source binding under different readable
+    // names is not a supported pattern for top-level decls.
+    // (Multi-re-export of an `import_specifier` binding via
+    // `re_exported_by` remains supported — see
+    // `imported_binding_re_exported_under_two_different_names`.)
+    //
+    // Different selector forms targeting the same declaration
+    // (`{name: ho}` vs `{name: ho, kind: class_declaration}`) all
+    // collapse to one `binding_assignment` entry, so the rejection
+    // catches any way to spell the duplicate.
     let opts = FixtureOpts::new(
-        r#"const aH = 42;
-console.log(aH);
-export { aH };
+        r#"class ho {
+  static isAIConversation() { return false; }
+}
+console.log(ho);
+export { ho };
 "#,
         vec![
             (
                 "mod_a".to_string(),
                 json!({
-                    "members": [{ "name": "readableA", "selector": { "binding": { "name": "aH" } } }],
+                    "members": [{
+                        "name": "AIConversationNodeAccessor",
+                        "selector": { "binding": { "name": "ho", "kind": "class_declaration" } },
+                    }],
                 }),
             ),
             (
                 "mod_b".to_string(),
                 json!({
-                    "members": [{ "name": "plainAh", "selector": { "binding": { "name": "aH" } } }],
+                    "members": [{
+                        "name": "AIConversationNodeAccessor",
+                        "selector": { "binding": { "name": "ho" } },
+                    }],
                 }),
             ),
         ],
     );
-    let fixture = run_fixture(opts);
-    let entry = fs::read_to_string(&fixture.entry_path).expect("read entry.js");
-
-    assert!(
-        entry.contains(r#"import { readableA } from "./modules/mod_a.js""#),
-        "expected readable-local mod_a import; entry was:\n{entry}",
+    expect_rejection_containing_all(
+        opts,
+        &["Duplicate binding claim", "\"ho\"", "mod_a", "mod_b"],
     );
-    assert!(
-        entry.contains(r#"import { plainAh } from "./modules/mod_b.js""#),
-        "expected readable-local mod_b import; entry was:\n{entry}",
-    );
-    let import_lines = entry
-        .lines()
-        .filter(|line| line.starts_with("import "))
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        !import_lines.contains("readableA as aH") && !import_lines.contains("plainAh as aH"),
-        "input-bundle name should not survive as an import alias; entry was:\n{entry}",
-    );
-    // Body refs to the second-claimed binding follow the readable rename.
-    assert!(
-        entry.contains("console.log(plainAh)"),
-        "expected console.log to be rewritten to plainAh; entry was:\n{entry}",
-    );
-    // Public re-export name survives: `export { plainAh as aH }`,
-    // not `export { plainAh }`. AST walk so a corrupt
-    // `plainAh as plainAh` doesn't slip past a substring match.
-    assert_export_named_specifier(&entry, "plainAh", Some("aH"));
-    assert_unique_import_locals(&entry);
 }
 
 #[test]
@@ -408,14 +407,16 @@ export { a };
     );
 }
 
-// --- Multi-module re-export of a shared imported binding ----------------
+// --- Duplicate import-specifier claims are rejected ---------------------
 
 #[test]
-fn imported_binding_re_exported_under_two_different_names() {
-    // Two logical modules each re-export the same imported
-    // binding under different public names. They share one
-    // `BindingKind::Imported` whose `re_exported_by` map carries
-    // each module's chosen public name.
+fn duplicate_import_specifier_claims_are_rejected() {
+    // Same rule as `duplicate_top_level_decl_claims_are_rejected`,
+    // but for `kind: import_specifier`. Every binding — imported or
+    // top-level — must have exactly one home in the spec. If a
+    // consumer wants to refer to a vendor symbol under a different
+    // local name, it can do so at its own import site; the spec
+    // doesn't need a separate re-export module.
     let mut opts = FixtureOpts::new(
         r#"import { j as a } from "./vendor.js";
 console.log(a());
@@ -443,19 +444,14 @@ export { a };
         ],
     );
     opts.extra_files = &[("static/vendor.js", "export const j = () => 42;\n")];
-    let fixture = run_fixture(opts);
-
-    assert_module_exports(
-        &fixture.out_root,
-        "static/app/modules/mod_jsx_runtime.js",
-        &["jsxRuntime"],
-        &["__jsx"],
-    );
-    assert_module_exports(
-        &fixture.out_root,
-        "static/app/modules/mod_dunder_jsx.js",
-        &["__jsx"],
-        &["jsxRuntime"],
+    expect_rejection_containing_all(
+        opts,
+        &[
+            "Duplicate binding claim",
+            "\"a\"",
+            "mod_jsx_runtime",
+            "mod_dunder_jsx",
+        ],
     );
 }
 

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -449,6 +449,38 @@ fn materialize_logical_chunk(
         let dest_target_file = target_file_for_request(target_dir, &request.target_path)?;
         let module_id = ModuleId::Logical(LogicalModuleIndex(index));
         for member in &request.members {
+            if let Some(existing_kind) = bindings_catalogue.get(&member.binding) {
+                let existing_id = match existing_kind {
+                    BindingKind::Owned {
+                        owner: ModuleId::Logical(LogicalModuleIndex(owner_index)),
+                    } => module_plans
+                        .get(*owner_index)
+                        .map(|plan| plan.id.clone())
+                        .unwrap_or_else(|| format!("<plan#{owner_index}>")),
+                    BindingKind::Owned { owner } => format!("{owner:?}"),
+                    BindingKind::Imported { re_exported_by, .. } => re_exported_by
+                        .keys()
+                        .find_map(|m| match m {
+                            ModuleId::Logical(LogicalModuleIndex(i)) => {
+                                module_plans.get(*i).map(|p| p.id.clone())
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| "<imported>".to_string()),
+                };
+                bail!(
+                    "Duplicate binding claim for {:?} in chunk {chunk_id:?}: already \
+                     claimed by module {existing_id} and now also claimed by module \
+                     {}. Each binding may belong to exactly one logical module. \
+                     Different selector forms (`{{name: foo}}` vs \
+                     `{{name: foo, kind: class_declaration}}`) that resolve to the \
+                     same source declaration still count as duplicates. To expose a \
+                     binding under multiple readable names, list all the renames in \
+                     one module.",
+                    member.binding,
+                    request.id,
+                );
+            }
             if member.is_import_specifier {
                 let (imported_name, imported_from) = resolve_imported_binding(
                     &mut imported_binding_resolver,
@@ -458,16 +490,16 @@ fn materialize_logical_chunk(
                     &member.binding,
                     &mut imported_from_by_src,
                 )?;
-                let entry = bindings_catalogue
-                    .entry(member.binding.clone())
-                    .or_insert_with(|| BindingKind::Imported {
-                        imported_name: imported_name.clone(),
-                        imported_from: imported_from.clone(),
-                        re_exported_by: HashMap::new(),
-                    });
-                if let BindingKind::Imported { re_exported_by, .. } = entry {
-                    re_exported_by.insert(module_id, member.export_name.clone());
-                }
+                let mut re_exported_by = HashMap::new();
+                re_exported_by.insert(module_id, member.export_name.clone());
+                bindings_catalogue.insert(
+                    member.binding.clone(),
+                    BindingKind::Imported {
+                        imported_name,
+                        imported_from,
+                        re_exported_by,
+                    },
+                );
             } else {
                 bindings.insert(member.binding.clone(), member.export_name.clone());
             }


### PR DESCRIPTION
## Why

When two logical-module plans in the same chunk both claim the same input-bundle binding, the materialiser used to put the body in one plan's emitted file and emit `export { X };` with no `X` defined in the other — invalid JS that fails `import()` at link time with `SyntaxError: Export 'X' is not defined in module`. Build was green because no test verified that emitted modules are actually loadable.

Confirmed against the live gaffer Tana spec:

- 0 active YAMLs claim the same top-level binding twice.
- 0 active YAMLs claim the same `kind: import_specifier` binding twice.

So in practice every binding already has exactly one home. The "two modules re-exporting one source binding under different readable names" pattern (previously documented by two tests) isn't used and isn't needed: a consumer that wants the symbol under a different local name aliases at its own import site (`import { jsxRuntime as h } from "./mod.js"`).

## How

Check fires at the resolution layer in `logical_modules.rs`, right where `bindings_catalogue.insert` used to silently overwrite. By that point every selector form that targets the same source binding has already collapsed to one `bindings_catalogue` key — so the check covers `{name: ho}` vs `{name: ho, kind: class_declaration}` and any other spelling. Covers both top-level decls (`BindingKind::Owned`) and import specifiers (`BindingKind::Imported`).

Error names the binding, the chunk, and both claiming modules:

```
Duplicate binding claim for "ho" in chunk "static/app": already
claimed by module mod_a and now also claimed by module mod_b. Each
binding may belong to exactly one logical module. Different selector
forms (`{name: foo}` vs `{name: foo, kind: class_declaration}`) that
resolve to the same source declaration still count as duplicates. To
expose a binding under multiple readable names, list all the renames
in one module.
```

## Tests

- New e2e `duplicate_top_level_decl_claims_are_rejected` — class decl claimed twice under the same readable name, one selector with `kind`, one without. Rejected.
- New e2e `duplicate_import_specifier_claims_are_rejected` — vendor import claimed twice under different readable names. Rejected.
- Deleted `duplicate_claims_use_readable_imports` and `imported_binding_re_exported_under_two_different_names` — documented the now-removed multi-re-export patterns. Neither validated module-body validity, so neither caught the loser-stub bug.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 33/33 pass locally.
- [ ] BB CI green.

## Followup (separate)

The `re_exported_by: HashMap<ModuleId, BindingName>` field on `BindingKind::Imported` now always carries at most one entry. The map and the per-module emit machinery that consumes it can be simplified to a single `(re_exporter, public_name)` option. Left for a follow-up since the surface area is wider and this PR is already the right behavioural fix.

https://claude.ai/code/session_01EiVmNAgEUEERsbsXAsBMyj