### PR TITLE
debundle: collapse BindingKind::Imported re_exported_by to single re_exporter

### DIFF
--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -18,8 +18,8 @@
 > init-wrapper machinery, no closure pass, no implicit binding
 > pulls — every owned binding is named explicitly in the spec,
 > and `Imported` bindings flow through `Schedule.bindings` /
-> `BindingKind::Imported`, with multi-module re-exports
-> accumulating into one entry's `re_exported_by` map.
+> `BindingKind::Imported`, carrying the single re-exporter
+> `ModuleId` and public name that claimed it.
 > Anonymous (empty-`declared`) top-level statements have no name
 > to address as a member; a parallel `anonymous_statements`
 > selector list addresses each by its AST shape (verbatim source,
@@ -155,12 +155,14 @@ pub enum BindingKind {
     Imported {
         imported_from: ChunkId,
         imported_name: String,
-        /// Each module that re-exports this binding, mapped to
-        /// the public name it gives the export. Different modules
-        /// may pick different names for the same imported binding
-        /// (e.g. one module surfaces `vendor.j` as `jsxRuntime`,
-        /// another as `__jsx`).
-        re_exported_by: BTreeMap<ModuleId, BindingName>,
+        /// The single logical module that claims this imported
+        /// binding via a `kind: import_specifier` member, and the
+        /// public name it gives the export. The spec's
+        /// duplicate-claim check rejects two modules claiming the
+        /// same import — a consumer that wants the symbol under a
+        /// different local name aliases at its own import site.
+        re_exporter: ModuleId,
+        public_name: BindingName,
     },
 }
 ```
@@ -169,9 +171,9 @@ Distinguishing the two kinds in the data model is what gives
 the validator and emitter a single source of truth for binding
 ownership: an `Owned` entry says "this logical module
 contributes this binding to the chunk's namespace"; an
-`Imported` entry says "this binding originates elsewhere; these
-modules just re-export it." Without the distinction the spec
-needs a parallel side-channel to express re-export semantics.
+`Imported` entry says "this binding originates elsewhere; this
+module re-exports it." Without the distinction the spec needs a
+parallel side-channel to express re-export semantics.
 
 ### Statements
 
@@ -1938,8 +1940,8 @@ Everything downstream needs is here:
   `owner_graph.nodes.filter(dest(owner) == M)`.
 - "What does M export" = bindings whose `Owned.owner == M`
   (under their original or rename-pass-rewritten name) plus
-  bindings whose `Imported.re_exported_by` has key `M` (under
-  the public name that map's value gives).
+  bindings whose `Imported.re_exporter == M` (under
+  `Imported.public_name`).
 - "What imports does M need" =
   - For each owner-level read edge from an owner with `dest == M`:
     - If `b` is `Owned { owner: other }`: `import b from <other>`.
@@ -1954,23 +1956,20 @@ Everything downstream needs is here:
   external chunks our schedule talks to; that's the
   `ExternalChunk(_)` nodes in `dep_graph`.
 
-The two reasons to make `BindingKind` explicit (rather than
+The reason to make `BindingKind` explicit (rather than
 collapsing imports into the same `Owned` map):
 
-1. **Re-export semantics aren't ownership.** A logical module
-   that re-exports `import { Y as X } from "<vendor>"` does
-   not own `X` — modifying our spec to "claim" `X` should not
-   rename `Y` in the vendor chunk; it should emit a re-export
-   in our logical module. A flat `BindingName → ModuleId` map
-   conflates these two cases; tagging via `Owned` vs `Imported`
-   keeps them distinct.
-2. **Multiple modules can re-export the same imported binding,
-   under different names.** Two logical modules in the same
-   chunk could both want to surface `vendor.j` (the JSX runtime),
-   one as `jsxRuntime` and another as `__jsx`. With
-   `Owned { owner }` the data model forbids this entirely; with
-   `Imported { re_exported_by: BTreeMap<ModuleId, BindingName> }`
-   each module picks its own export name independently.
+**Re-export semantics aren't ownership.** A logical module that
+re-exports `import { Y as X } from "<vendor>"` does not own
+`X` — modifying our spec to "claim" `X` should not rename `Y`
+in the vendor chunk; it should emit a re-export in our logical
+module. A flat `BindingName → ModuleId` map conflates these
+two cases; tagging via `Owned` vs `Imported` keeps them
+distinct. The validator additionally rejects duplicate claims
+of either kind, so each imported binding has exactly one
+re-exporter (a consumer that wants a different local name
+aliases at its own import site instead of authoring a separate
+re-export module).
 
 ### Identifiers are typed, not stringly-typed
 

--- a/devinfra/js/debundle/ids.rs
+++ b/devinfra/js/debundle/ids.rs
@@ -123,9 +123,9 @@ pub enum BindingKind {
     Owned { owner: ModuleId },
     /// Introduced by an `import { imported_name as <local> } from
     /// "<source>"` in the chunk's top-level body. The value lives in
-    /// another chunk; logical modules can re-export it under their
-    /// own public name. Multiple modules may re-export the same
-    /// imported binding (under different public names).
+    /// another chunk; exactly one logical module re-exports it under
+    /// its chosen public name (the spec's duplicate-claim check
+    /// rejects two modules claiming the same import).
     Imported {
         /// The original imported name from the source chunk (e.g. "j"
         /// for `import { j as a } from "..."`).
@@ -136,14 +136,11 @@ pub enum BindingKind {
         /// emit-time path resolution is just `relative(dest_dir,
         /// imported_from)`.
         imported_from: String,
-        /// `module → public export name` for each logical module that
-        /// re-exports this binding. Empty when no logical module
-        /// re-exports it (read-only references stay implicit and are
-        /// resolved by `source_chunk_imports_for_moved_body`).
-        /// Iteration order is undefined; emit sites sort the entries
-        /// before consuming them so the emitted import/export shape
-        /// stays deterministic.
-        re_exported_by: HashMap<ModuleId, BindingName>,
+        /// Logical module that claimed this imported binding via a
+        /// `kind: import_specifier` member.
+        re_exporter: ModuleId,
+        /// Public export name that re-exporter assigned to it.
+        public_name: BindingName,
     },
 }
 

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -458,15 +458,14 @@ fn materialize_logical_chunk(
                         .map(|plan| plan.id.clone())
                         .unwrap_or_else(|| format!("<plan#{owner_index}>")),
                     BindingKind::Owned { owner } => format!("{owner:?}"),
-                    BindingKind::Imported { re_exported_by, .. } => re_exported_by
-                        .keys()
-                        .find_map(|m| match m {
-                            ModuleId::Logical(LogicalModuleIndex(i)) => {
-                                module_plans.get(*i).map(|p| p.id.clone())
-                            }
-                            _ => None,
-                        })
-                        .unwrap_or_else(|| "<imported>".to_string()),
+                    BindingKind::Imported {
+                        re_exporter: ModuleId::Logical(LogicalModuleIndex(re_index)),
+                        ..
+                    } => module_plans
+                        .get(*re_index)
+                        .map(|plan| plan.id.clone())
+                        .unwrap_or_else(|| format!("<plan#{re_index}>")),
+                    BindingKind::Imported { re_exporter, .. } => format!("{re_exporter:?}"),
                 };
                 bail!(
                     "Duplicate binding claim for {:?} in chunk {chunk_id:?}: already \
@@ -490,14 +489,13 @@ fn materialize_logical_chunk(
                     &member.binding,
                     &mut imported_from_by_src,
                 )?;
-                let mut re_exported_by = HashMap::new();
-                re_exported_by.insert(module_id, member.export_name.clone());
                 bindings_catalogue.insert(
                     member.binding.clone(),
                     BindingKind::Imported {
                         imported_name,
                         imported_from,
-                        re_exported_by,
+                        re_exporter: module_id,
+                        public_name: member.export_name.clone(),
                     },
                 );
             } else {
@@ -2263,38 +2261,34 @@ fn collect_imported_reexports_by_module(
     module_count: usize,
 ) -> Vec<Vec<ImportedReexport>> {
     let mut by_module: Vec<Vec<ImportedReexport>> = (0..module_count).map(|_| Vec::new()).collect();
-    // Stable iteration order on both `schedule.bindings` (HashMap)
-    // and the inner `re_exported_by` (HashMap) — the recorded
-    // sequence determines the emit order of `import { ... }`
-    // statements per module body and we want that source-level
-    // shape pinned.
+    // Stable iteration order on `schedule.bindings` (HashMap): the
+    // recorded sequence determines the emit order of
+    // `import { ... }` statements per module body and we want that
+    // source-level shape pinned.
     let mut sorted_bindings: Vec<(&BindingName, &BindingKind)> = schedule.bindings.iter().collect();
     sorted_bindings.sort_by(|a, b| a.0.cmp(b.0));
     for (local, kind) in sorted_bindings {
         let BindingKind::Imported {
             imported_name,
             imported_from,
-            re_exported_by,
+            re_exporter,
+            public_name,
         } = kind
         else {
             continue;
         };
-        let mut sorted_reexports: Vec<(&ModuleId, &BindingName)> = re_exported_by.iter().collect();
-        sorted_reexports.sort_by_key(|(id, _)| **id);
-        for (module_id, public_name) in sorted_reexports {
-            let ModuleId::Logical(LogicalModuleIndex(index)) = module_id else {
-                continue;
-            };
-            let Some(reexports) = by_module.get_mut(*index) else {
-                continue;
-            };
-            reexports.push(ImportedReexport {
-                local: local.clone(),
-                imported_name: imported_name.clone(),
-                imported_from: imported_from.clone(),
-                public_name: public_name.clone(),
-            });
-        }
+        let ModuleId::Logical(LogicalModuleIndex(index)) = re_exporter else {
+            continue;
+        };
+        let Some(reexports) = by_module.get_mut(*index) else {
+            continue;
+        };
+        reexports.push(ImportedReexport {
+            local: local.clone(),
+            imported_name: imported_name.clone(),
+            imported_from: imported_from.clone(),
+            public_name: public_name.clone(),
+        });
     }
     by_module
 }


### PR DESCRIPTION
## Why

Follow-up to #1538. The duplicate-binding-claim validator now guarantees every `BindingKind::Imported` entry has exactly one claiming module — so the `re_exported_by: HashMap<ModuleId, BindingName>` field that used to hold "every module re-exporting this import" always has exactly one entry. Replace it with two flat fields.

## Before / after

```rust
// Before:
Imported {
    imported_name: BindingName,
    imported_from: String,
    re_exported_by: HashMap<ModuleId, BindingName>,
}

// After:
Imported {
    imported_name: BindingName,
    imported_from: String,
    re_exporter: ModuleId,
    public_name: BindingName,
}
```

`collect_imported_reexports_by_module` becomes a single push per binding (no inner sort, no map iteration). All `BindingKind::Imported { .. }` patterns in `schedule.rs`, `peelability.rs`, etc. already used `..` and need no edits.

## DESIGN.md

Drops the "Multiple modules can re-export the same imported binding under different names" rationale and the matching `re_exported_by: BTreeMap` snippet. Reframes the "What does M export" recipe to use `re_exporter == M` / `public_name` lookups instead of map-key probing.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 33/33 pass.
- [ ] BB CI green.

No behavioural change.

https://claude.ai/code/session_01EiVmNAgEUEERsbsXAsBMyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiVmNAgEUEERsbsXAsBMyj)_