### PR TITLE
debundle/analysis: SSOT factorize in OwnerGraphReport + Bucket-F per-declarator spans

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -156,6 +156,7 @@ rust_library(
     name = "analysis",
     srcs = [
         "analysis_tests.rs",
+        "factorize.rs",
         "facts.rs",
         "graph.rs",
         "ids.rs",

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -2267,6 +2267,112 @@ mod tests {
     }
 
     #[test]
+    fn split_comma_list_assigns_per_declarator_source_ranges() {
+        // Multi-declarator var statement spread across three source
+        // lines. After Bucket-F splits the comma list, each resulting
+        // single-declarator owner must report just its declarator's
+        // line range — not the full parent statement's range. The
+        // factorizer's `size_lines_estimate` and the lane workers'
+        // `body_extraction` per-owner snippets both rely on this.
+        let cm: Lrc<swc_common::SourceMap> = Default::default();
+        let source = "const A = 1,\n      B = 2,\n      C = 3;\n";
+        let fm = cm.new_source_file(
+            FileName::Custom("test.js".into()).into(),
+            source.to_string(),
+        );
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let module = Parser::new_from(lexer).parse_module().unwrap();
+        let cm_clone = cm.clone();
+        let line_range_for_span = move |span: swc_common::Span| -> Option<(usize, usize)> {
+            if span == swc_common::DUMMY_SP {
+                return None;
+            }
+            let lo = cm_clone.lookup_char_pos(span.lo()).line;
+            let hi = cm_clone.lookup_char_pos(span.hi()).line;
+            Some((lo, hi))
+        };
+        let analysis = analyze_chunk_with_source_locations(
+            &module,
+            &BTreeSet::new(),
+            Some("test.js"),
+            line_range_for_span,
+        );
+        assert_eq!(analysis.facts.len(), 3);
+        let lines: Vec<(usize, usize)> = analysis
+            .facts
+            .iter()
+            .map(|f| {
+                let loc = f
+                    .source_location
+                    .as_ref()
+                    .expect("source_location should be populated");
+                (loc.start_line, loc.end_line)
+            })
+            .collect();
+        assert_eq!(
+            lines,
+            vec![(1, 1), (2, 2), (3, 3)],
+            "each declarator should report only its own line, got {lines:?}",
+        );
+    }
+
+    #[test]
+    fn split_export_comma_list_assigns_per_declarator_source_ranges() {
+        // Same fix applies to `export const A = 1, B = 2;`: the
+        // outer `ExportDecl` wrapper's span gets replaced by the
+        // declarator's span on each post-split item.
+        let cm: Lrc<swc_common::SourceMap> = Default::default();
+        let source = "export const A = 1,\n             B = 2,\n             C = 3;\n";
+        let fm = cm.new_source_file(
+            FileName::Custom("test.js".into()).into(),
+            source.to_string(),
+        );
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let module = Parser::new_from(lexer).parse_module().unwrap();
+        let cm_clone = cm.clone();
+        let line_range_for_span = move |span: swc_common::Span| -> Option<(usize, usize)> {
+            if span == swc_common::DUMMY_SP {
+                return None;
+            }
+            let lo = cm_clone.lookup_char_pos(span.lo()).line;
+            let hi = cm_clone.lookup_char_pos(span.hi()).line;
+            Some((lo, hi))
+        };
+        let analysis = analyze_chunk_with_source_locations(
+            &module,
+            &BTreeSet::new(),
+            Some("test.js"),
+            line_range_for_span,
+        );
+        let lines: Vec<(usize, usize)> = analysis
+            .facts
+            .iter()
+            .map(|f| {
+                let loc = f
+                    .source_location
+                    .as_ref()
+                    .expect("source_location should be populated");
+                (loc.start_line, loc.end_line)
+            })
+            .collect();
+        assert_eq!(
+            lines,
+            vec![(1, 1), (2, 2), (3, 3)],
+            "each exported declarator should report only its own line, got {lines:?}",
+        );
+    }
+
+    #[test]
     fn split_comma_list_surfaces_real_cross_declarator_cycle() {
         // `const A = X, B = 1;` — A → mod_a, B → mod_b, X → mod_b.
         // mod_a's `A` reads X from mod_b → R-edge mod_a → mod_b.

--- a/devinfra/js/debundle/factorize.rs
+++ b/devinfra/js/debundle/factorize.rs
@@ -1,0 +1,444 @@
+//! Algorithmic peel proposer that uses the materializer's
+//! gate predicate (single source of truth) inline.
+//!
+//! Reads the in-memory `Schedule` directly so per-cell verdicts
+//! come from the same `evaluate_residual_peel_candidate` predicate
+//! the analyzer's peelability pass uses (cycle, lazy-rebind,
+//! emit-resolvability). Cells that the predicate flags as blocked
+//! get auto-grown by absorbing the specific owners the predicate
+//! pointed at — adjacent anonymous side-effect statements, owners
+//! of emit-blocked free-reference bindings, etc. The output cells
+//! are therefore proposals the materializer will accept, including
+//! cells whose members mix top-level bindings with the side-effect
+//! statements they need to travel with.
+//!
+//! Compared to the JSON-only factorizer (`@ducktape//peel_factorize`),
+//! this module:
+//! - Calls into the analyzer's SSOT predicate instead of replicating
+//!   the gate logic against the serialized owner-graph shape.
+//! - Auto-grows cells via the same predicate when blockers point at
+//!   addressable absorption targets.
+//! - Emits its report as a side-channel of `OwnerGraphReport` so
+//!   downstream consumers (the CLI) read pre-computed proposals
+//!   instead of rebuilding them.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use petgraph::algo::tarjan_scc;
+use petgraph::graphmap::DiGraphMap;
+
+use crate::peelability::{
+    PeelCandidateEvaluation, PeelabilityContext, evaluate_residual_peel_candidate,
+};
+use crate::reports::{build_quotient_edge_reports, module_key, owner_key};
+use crate::{
+    BindingName, DepKind, FactorizeCell, FactorizeOptions, FactorizeReport, ModuleId, OwnerId,
+    PeelCandidateStatus, Schedule,
+};
+
+pub fn build_factorize_report(schedule: &Schedule, options: &FactorizeOptions) -> FactorizeReport {
+    let owner_edges = &schedule.owner_graph.edges;
+    let quotient_edges = build_quotient_edge_reports(schedule, owner_edges);
+    let context = PeelabilityContext::new(schedule, owner_edges, &quotient_edges);
+
+    // Residual owners = those whose partition is `ModuleId::ResidualEntry`.
+    // Matches the analyzer's SSOT residual definition.
+    let residual: BTreeSet<OwnerId> = schedule
+        .owner_graph
+        .iter_nodes()
+        .filter(|node| matches!(schedule.partition.of(node.id), ModuleId::ResidualEntry))
+        .map(|node| node.id)
+        .collect();
+    let residual_owner_count = residual.len();
+
+    // Owner → declared bindings, used to seed the predicate's `declared`
+    // input and to compute the cell's binding membership list.
+    let bindings_by_owner: HashMap<OwnerId, Vec<BindingName>> = schedule
+        .owner_graph
+        .iter_nodes()
+        .map(|node| {
+            let names: Vec<BindingName> = node
+                .declared
+                .iter()
+                .map(|bid| schedule.binding_name(*bid).clone())
+                .collect();
+            (node.id, names)
+        })
+        .collect();
+
+    let owner_for_binding: HashMap<BindingName, OwnerId> = bindings_by_owner
+        .iter()
+        .flat_map(|(&owner_id, names)| names.iter().cloned().map(move |name| (name, owner_id)))
+        .collect();
+
+    // Initial cell formation: SCC condensation on the constraining
+    // edge subgraph between residual owners, then a rebind-edge
+    // union to fold cross-cell rebind targets together.
+    let sccs = strongly_connected_components(&residual, owner_edges);
+    let mut cells: Vec<BTreeSet<OwnerId>> = sccs.into_iter().collect();
+    apply_rebind_union(&mut cells, &residual, owner_edges);
+
+    // Greedy agglomerative merge: pair cells with the strongest
+    // constraining-edge connection, merge if combined lines fit
+    // under the cap. Loop until no admissible merge remains.
+    agglomerate(
+        &mut cells,
+        &residual,
+        owner_edges,
+        schedule,
+        options.size_cap_lines,
+    );
+
+    // Per-cell evaluation + auto-grow.
+    let mut emitted: Vec<FactorizeCell> = Vec::with_capacity(cells.len());
+    for (idx, cell_owners) in cells.iter().enumerate() {
+        let (final_owners, verdict, iterations) = evaluate_and_grow(
+            schedule,
+            &context,
+            cell_owners.clone(),
+            &bindings_by_owner,
+            &owner_for_binding,
+            &residual,
+            options,
+        );
+        let proposed_module_id = format!("auto_partition_{idx:04}");
+        emitted.push(make_cell(
+            proposed_module_id,
+            final_owners,
+            &verdict,
+            &bindings_by_owner,
+            schedule,
+            iterations,
+            options.size_cap_lines,
+        ));
+    }
+
+    // Stable sort: landable cells first, then by source line.
+    emitted.sort_by(|a, b| {
+        b.landable_today.cmp(&a.landable_today).then_with(|| {
+            let al = a.source_line_range.map(|r| r[0]).unwrap_or(usize::MAX);
+            let bl = b.source_line_range.map(|r| r[0]).unwrap_or(usize::MAX);
+            al.cmp(&bl)
+        })
+    });
+    // Renumber after sort.
+    for (idx, cell) in emitted.iter_mut().enumerate() {
+        cell.proposed_module_id = format!("auto_partition_{idx:04}");
+    }
+
+    FactorizeReport {
+        size_cap_lines: options.size_cap_lines,
+        residual_owner_count,
+        cells: emitted,
+    }
+}
+
+/// Per-cell evaluate-and-grow loop. Calls the SSOT predicate; if
+/// blocked by an addressable category (emit-resolvability, cycle
+/// through another residual cell), tries absorbing the owners the
+/// blocker pointed at and re-evaluates. Bounded by
+/// `options.max_grow_iterations`.
+fn evaluate_and_grow(
+    schedule: &Schedule,
+    context: &PeelabilityContext<'_>,
+    mut cell: BTreeSet<OwnerId>,
+    bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
+    owner_for_binding: &HashMap<BindingName, OwnerId>,
+    residual: &BTreeSet<OwnerId>,
+    options: &FactorizeOptions,
+) -> (BTreeSet<OwnerId>, PeelCandidateEvaluation, usize) {
+    let mut iterations = 0;
+    loop {
+        let owners: Vec<OwnerId> = cell.iter().copied().collect();
+        let declared: Vec<BindingName> = owners
+            .iter()
+            .flat_map(|o| bindings_by_owner.get(o).cloned().unwrap_or_default())
+            .collect();
+        let verdict = evaluate_residual_peel_candidate(schedule, context, &owners, declared);
+        if iterations >= options.max_grow_iterations {
+            return (cell, verdict, iterations);
+        }
+        match verdict.status {
+            PeelCandidateStatus::PeelableNow => return (cell, verdict, iterations),
+            PeelCandidateStatus::BlockedEmitResolvability => {
+                // Absorb the owners declaring each emit-blocked binding.
+                let mut grew = false;
+                for binding in &verdict.emit_blocked_residual_bindings {
+                    if let Some(&owner) = owner_for_binding.get(binding)
+                        && residual.contains(&owner)
+                        && !cell.contains(&owner)
+                    {
+                        cell.insert(owner);
+                        grew = true;
+                    }
+                }
+                if !grew {
+                    return (cell, verdict, iterations);
+                }
+            }
+            PeelCandidateStatus::BlockedCycle | PeelCandidateStatus::BlockedResidualDependency => {
+                // Absorb residual neighbors flagged as blockers.
+                let mut grew = false;
+                for owner in &verdict.residual_dependency_blocker_owner_ids {
+                    if residual.contains(owner) && !cell.contains(owner) {
+                        cell.insert(*owner);
+                        grew = true;
+                    }
+                }
+                // Cycle blockers — absorb the constraining-edge endpoints
+                // not in this cell.
+                for &edge_idx in &verdict.constraining_owner_edge_indices {
+                    let edge = &schedule.owner_graph.edges[edge_idx];
+                    for endpoint in [edge.from, edge.to] {
+                        if residual.contains(&endpoint) && !cell.contains(&endpoint) {
+                            cell.insert(endpoint);
+                            grew = true;
+                        }
+                    }
+                }
+                if !grew {
+                    return (cell, verdict, iterations);
+                }
+            }
+        }
+        iterations += 1;
+    }
+}
+
+fn make_cell(
+    proposed_module_id: String,
+    owners: BTreeSet<OwnerId>,
+    verdict: &PeelCandidateEvaluation,
+    bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
+    schedule: &Schedule,
+    auto_grow_iterations: usize,
+    size_cap_lines: usize,
+) -> FactorizeCell {
+    let mut owner_ids: Vec<String> = owners.iter().copied().map(owner_key).collect();
+    owner_ids.sort();
+
+    let mut anonymous_statement_owner_ids: Vec<String> = Vec::new();
+    let mut binding_ids_set: BTreeSet<BindingName> = BTreeSet::new();
+    let mut start_line = usize::MAX;
+    let mut end_line: usize = 0;
+    let mut have_loc = false;
+    let mut min_ordinal = usize::MAX;
+    let mut max_ordinal = 0usize;
+    let mut size_lines: usize = 0;
+    let empty_vec: Vec<BindingName> = Vec::new();
+    for owner_id in &owners {
+        let Some(node) = schedule.owner_graph.node(*owner_id) else {
+            continue;
+        };
+        let declared_bindings: &Vec<BindingName> =
+            bindings_by_owner.get(owner_id).unwrap_or(&empty_vec);
+        if declared_bindings.is_empty() {
+            anonymous_statement_owner_ids.push(owner_key(*owner_id));
+        }
+        for b in declared_bindings {
+            binding_ids_set.insert(b.clone());
+        }
+        if let Some(loc) = &node.source_location {
+            have_loc = true;
+            start_line = start_line.min(loc.start_line);
+            end_line = end_line.max(loc.end_line);
+            size_lines = size_lines.saturating_add(loc.end_line + 1 - loc.start_line);
+        }
+        min_ordinal = min_ordinal.min(node.statement_ordinal.0);
+        max_ordinal = max_ordinal.max(node.statement_ordinal.0);
+    }
+    anonymous_statement_owner_ids.sort();
+
+    let cycle_blocker_owner_ids: Vec<String> = verdict
+        .constraining_owner_edge_indices
+        .iter()
+        .flat_map(|&idx| {
+            let edge = &schedule.owner_graph.edges[idx];
+            [edge.from, edge.to]
+        })
+        .filter(|o| !owners.contains(o))
+        .map(owner_key)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    // Outgoing constraining edges to non-cell owners that landed in
+    // non-residual destinations — these are the "active modules
+    // referenced" the cell would import from after promotion.
+    let mut active_modules_referenced: BTreeSet<String> = BTreeSet::new();
+    for &owner_id in &owners {
+        for edge in schedule.owner_graph.edges.iter() {
+            if edge.from != owner_id {
+                continue;
+            }
+            if owners.contains(&edge.to) {
+                continue;
+            }
+            if !edge.reason.constrains_init_order() {
+                continue;
+            }
+            let dest = schedule.partition.of(edge.to);
+            if matches!(dest, ModuleId::ResidualEntry) {
+                continue;
+            }
+            active_modules_referenced.insert(module_key(dest));
+        }
+    }
+
+    let landable_today = matches!(verdict.status, PeelCandidateStatus::PeelableNow);
+    FactorizeCell {
+        proposed_module_id,
+        owner_ids,
+        binding_ids: binding_ids_set.into_iter().collect(),
+        anonymous_statement_owner_ids,
+        size_lines_estimate: size_lines,
+        size_members: owners.len(),
+        source_line_range: if have_loc {
+            Some([start_line, end_line])
+        } else {
+            None
+        },
+        ordinal_span: max_ordinal.saturating_sub(min_ordinal),
+        status: verdict.status,
+        landable_today,
+        oversize: size_lines > size_cap_lines,
+        emit_blocked_residual_bindings: verdict.emit_blocked_residual_bindings.clone(),
+        cycle_blocker_owner_ids,
+        active_modules_referenced: active_modules_referenced.into_iter().collect(),
+        auto_grow_iterations,
+    }
+}
+
+fn strongly_connected_components(
+    residual: &BTreeSet<OwnerId>,
+    edges: &[crate::graph::OwnerEdge],
+) -> Vec<BTreeSet<OwnerId>> {
+    let mut graph = DiGraphMap::<OwnerId, ()>::new();
+    for &owner in residual {
+        graph.add_node(owner);
+    }
+    for edge in edges {
+        if !residual.contains(&edge.from) || !residual.contains(&edge.to) {
+            continue;
+        }
+        if !edge.reason.constrains_init_order() {
+            continue;
+        }
+        if edge.from == edge.to {
+            continue;
+        }
+        graph.add_edge(edge.from, edge.to, ());
+    }
+    tarjan_scc(&graph)
+        .into_iter()
+        .map(|scc| scc.into_iter().collect())
+        .collect()
+}
+
+fn apply_rebind_union(
+    cells: &mut Vec<BTreeSet<OwnerId>>,
+    residual: &BTreeSet<OwnerId>,
+    edges: &[crate::graph::OwnerEdge],
+) {
+    // Build owner → cell index map.
+    let mut cell_of: HashMap<OwnerId, usize> = HashMap::new();
+    for (idx, cell) in cells.iter().enumerate() {
+        for &o in cell {
+            cell_of.insert(o, idx);
+        }
+    }
+    let mut parent: Vec<usize> = (0..cells.len()).collect();
+    fn find(parent: &mut [usize], i: usize) -> usize {
+        if parent[i] != i {
+            let r = find(parent, parent[i]);
+            parent[i] = r;
+        }
+        parent[i]
+    }
+    for edge in edges {
+        if !matches!(edge.reason.kind, DepKind::EagerRebind | DepKind::LazyRebind) {
+            continue;
+        }
+        if !residual.contains(&edge.from) || !residual.contains(&edge.to) {
+            continue;
+        }
+        let (Some(&ci), Some(&cj)) = (cell_of.get(&edge.from), cell_of.get(&edge.to)) else {
+            continue;
+        };
+        let ri = find(&mut parent, ci);
+        let rj = find(&mut parent, cj);
+        if ri != rj {
+            parent[rj] = ri;
+        }
+    }
+    // Coalesce by root.
+    let mut grouped: BTreeMap<usize, BTreeSet<OwnerId>> = BTreeMap::new();
+    for (idx, cell) in cells.drain(..).enumerate() {
+        let root = find(&mut parent, idx);
+        grouped.entry(root).or_default().extend(cell);
+    }
+    cells.extend(grouped.into_values());
+}
+
+fn agglomerate(
+    cells: &mut Vec<BTreeSet<OwnerId>>,
+    residual: &BTreeSet<OwnerId>,
+    edges: &[crate::graph::OwnerEdge],
+    schedule: &Schedule,
+    size_cap_lines: usize,
+) {
+    let line_count = |cell: &BTreeSet<OwnerId>| -> usize {
+        cell.iter()
+            .filter_map(|o| schedule.owner_graph.node(*o))
+            .filter_map(|n| n.source_location.as_ref())
+            .map(|l| l.end_line + 1 - l.start_line)
+            .sum()
+    };
+    loop {
+        let mut cell_of: HashMap<OwnerId, usize> = HashMap::new();
+        for (idx, cell) in cells.iter().enumerate() {
+            for &o in cell {
+                cell_of.insert(o, idx);
+            }
+        }
+        // Count inter-cell constraining edges per pair.
+        let mut pair_edges: BTreeMap<(usize, usize), usize> = BTreeMap::new();
+        for edge in edges {
+            if !edge.reason.constrains_init_order() {
+                continue;
+            }
+            if !residual.contains(&edge.from) || !residual.contains(&edge.to) {
+                continue;
+            }
+            let (Some(&ci), Some(&cj)) = (cell_of.get(&edge.from), cell_of.get(&edge.to)) else {
+                continue;
+            };
+            if ci == cj {
+                continue;
+            }
+            let key = if ci < cj { (ci, cj) } else { (cj, ci) };
+            *pair_edges.entry(key).or_insert(0) += 1;
+        }
+        // Find the pair with the most shared edges whose merged size
+        // still fits the cap.
+        let mut best: Option<((usize, usize), usize)> = None;
+        for (&pair, &count) in &pair_edges {
+            let merged_lines = line_count(&cells[pair.0]) + line_count(&cells[pair.1]);
+            if merged_lines > size_cap_lines {
+                continue;
+            }
+            match best {
+                Some((_, best_count)) if best_count >= count => {}
+                _ => best = Some((pair, count)),
+            }
+        }
+        let Some(((i, j), _)) = best else {
+            return;
+        };
+        // Remove the higher-index cell first so the lower index stays
+        // valid; merge its members into the lower-index cell.
+        let (lo, hi) = if i < j { (i, j) } else { (j, i) };
+        let other = cells.swap_remove(hi);
+        cells[lo].extend(other);
+    }
+}

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -241,7 +241,7 @@ pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<
             ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) if var.decls.len() > 1 => {
                 for decl in &var.decls {
                     let single = VarDecl {
-                        span: var.span,
+                        span: decl.span,
                         ctxt: var.ctxt,
                         kind: var.kind,
                         declare: var.declare,
@@ -257,7 +257,7 @@ pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<
                     Decl::Var(var) if var.decls.len() > 1 => {
                         for decl in &var.decls {
                             let single = VarDecl {
-                                span: var.span,
+                                span: decl.span,
                                 ctxt: var.ctxt,
                                 kind: var.kind,
                                 declare: var.declare,
@@ -265,7 +265,7 @@ pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<
                             };
                             out.push(TopLevelItemView::Owned(ModuleItem::ModuleDecl(
                                 ModuleDecl::ExportDecl(ExportDecl {
-                                    span: export_decl.span,
+                                    span: decl.span,
                                     decl: Decl::Var(Box::new(single)),
                                 }),
                             )));

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -13,6 +13,7 @@
 //! 5. Validate realizability, derive peelability, and emit reports from that
 //!    same graph model.
 
+mod factorize;
 mod facts;
 mod graph;
 mod ids;
@@ -24,6 +25,7 @@ mod reports;
 mod schedule;
 mod validation;
 
+pub use factorize::build_factorize_report;
 pub use facts::{
     ChunkFactAnalysis, StatementFacts, StatementKind, analyze_chunk_facts,
     analyze_chunk_facts_with_source_locations, analyze_chunk_with_source_locations,
@@ -40,10 +42,10 @@ pub use ids::{
 pub use partition::Partition;
 pub use purity::{Purity, PurityReason, PurityRule, RedundantPurityHint, RedundantPurityReason};
 pub use report_schema::{
-    BindingReport, EvaluatedPeelCandidateReport, ModuleReportRef, OwnerGraphEdgeReport,
-    OwnerGraphNodeReport, OwnerGraphPeelSetReport, OwnerGraphPeelabilityReport,
-    OwnerGraphQuotientReport, OwnerGraphReport, PeelCandidateStatus, QuotientEdgeReport,
-    QuotientSccReport, RESIDUAL_ENTRY_LABEL, RESIDUAL_ENTRY_MODULE_ID,
+    BindingReport, EvaluatedPeelCandidateReport, FactorizeCell, FactorizeOptions, FactorizeReport,
+    ModuleReportRef, OwnerGraphEdgeReport, OwnerGraphNodeReport, OwnerGraphPeelSetReport,
+    OwnerGraphPeelabilityReport, OwnerGraphQuotientReport, OwnerGraphReport, PeelCandidateStatus,
+    QuotientEdgeReport, QuotientSccReport, RESIDUAL_ENTRY_LABEL, RESIDUAL_ENTRY_MODULE_ID,
     ResidualOwnerCompanionOptionReport, ResidualOwnerPeelHorizonReport, ResidualOwnerPeelStatus,
     SourceLocation,
 };

--- a/devinfra/js/debundle/peel_factorize.rs
+++ b/devinfra/js/debundle/peel_factorize.rs
@@ -1115,6 +1115,7 @@ mod tests {
                 evaluated_owner_sets: vec![],
             },
             pre_existing_entry_exports: vec![],
+            factorize: analysis::FactorizeReport::default(),
         }
     }
 
@@ -1342,6 +1343,7 @@ mod tests {
                 evaluated_owner_sets: vec![],
             },
             pre_existing_entry_exports: vec![],
+            factorize: analysis::FactorizeReport::default(),
         };
         let report = factorize(&graph, &no_claims(), &no_claims(), 2000);
         let consumer_cell = report
@@ -1393,6 +1395,7 @@ mod tests {
                 evaluated_owner_sets: vec![],
             },
             pre_existing_entry_exports: vec!["dep".to_string()],
+            factorize: analysis::FactorizeReport::default(),
         };
         let report = factorize(&graph, &no_claims(), &no_claims(), 2000);
         let consumer_cell = report

--- a/devinfra/js/debundle/peel_horizon.rs
+++ b/devinfra/js/debundle/peel_horizon.rs
@@ -608,6 +608,7 @@ mod tests {
                 evaluated_owner_sets: Vec::new(),
             },
             pre_existing_entry_exports: Vec::new(),
+            factorize: analysis::FactorizeReport::default(),
         }
     }
 

--- a/devinfra/js/debundle/peel_inventory.rs
+++ b/devinfra/js/debundle/peel_inventory.rs
@@ -570,6 +570,7 @@ mod tests {
                 evaluated_owner_sets: Vec::new(),
             },
             pre_existing_entry_exports: Vec::new(),
+            factorize: analysis::FactorizeReport::default(),
         }
     }
 

--- a/devinfra/js/debundle/peelability.rs
+++ b/devinfra/js/debundle/peelability.rs
@@ -53,7 +53,7 @@ struct ReverseModuleAdjEdge {
     source_idx: usize,
 }
 
-struct PeelabilityContext<'a> {
+pub(crate) struct PeelabilityContext<'a> {
     owner_edges: &'a [OwnerEdge],
     owner_out_edges: Vec<Vec<usize>>,
     owner_in_edges: Vec<Vec<usize>>,
@@ -72,22 +72,22 @@ struct CandidateGraphAdjustment {
 }
 
 #[derive(Debug, Clone)]
-struct PeelCandidateEvaluation {
-    id: String,
-    status: PeelCandidateStatus,
-    owner_ids: Vec<OwnerId>,
-    members: Vec<BindingName>,
-    constraining_owner_edge_indices: BTreeSet<usize>,
+pub(crate) struct PeelCandidateEvaluation {
+    pub(crate) id: String,
+    pub(crate) status: PeelCandidateStatus,
+    pub(crate) owner_ids: Vec<OwnerId>,
+    pub(crate) members: Vec<BindingName>,
+    pub(crate) constraining_owner_edge_indices: BTreeSet<usize>,
     /// Owner ids whose residual dependency forced the candidate into
     /// `BlockedResidualDependency`. Empty for other statuses. Surfaces
     /// in `evaluated_owner_sets[].residual_dependency_blockers` so
     /// callers can pinpoint which residual neighbor blocked the peel.
-    residual_dependency_blocker_owner_ids: Vec<OwnerId>,
+    pub(crate) residual_dependency_blocker_owner_ids: Vec<OwnerId>,
     /// Residual binding names that the candidate's moved bodies
     /// reference but entry doesn't export — populated only when
     /// `status == BlockedEmitResolvability`. SSOT'd via
     /// [`peel_emit_blocked_residual_bindings`] in `graph.rs`.
-    emit_blocked_residual_bindings: Vec<BindingName>,
+    pub(crate) emit_blocked_residual_bindings: Vec<BindingName>,
 }
 
 pub(crate) fn build_peelability_report(
@@ -344,7 +344,7 @@ fn residual_declared_for_owner(schedule: &Schedule, node: &OwnerNode) -> Vec<Bin
 }
 
 impl<'a> PeelabilityContext<'a> {
-    fn new(
+    pub(crate) fn new(
         schedule: &Schedule,
         owner_edges: &'a [OwnerEdge],
         quotient_edges: &[QuotientEdgeReport],
@@ -678,7 +678,7 @@ fn sorted_owner_pair(left: OwnerId, right: OwnerId) -> (OwnerId, OwnerId) {
     }
 }
 
-fn evaluate_residual_peel_candidate(
+pub(crate) fn evaluate_residual_peel_candidate(
     schedule: &Schedule,
     context: &PeelabilityContext<'_>,
     owner_ids: &[OwnerId],

--- a/devinfra/js/debundle/report_schema.rs
+++ b/devinfra/js/debundle/report_schema.rs
@@ -38,6 +38,15 @@ pub struct OwnerGraphReport {
     /// real pipeline runs always populate it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pre_existing_entry_exports: Vec<BindingName>,
+    /// Algorithmic peel proposer output. Always populated by
+    /// `Schedule::owner_graph_report`; empty `cells` when there
+    /// are no residual owners. Each cell carries a verdict from
+    /// the SSOT predicate in
+    /// `peelability::evaluate_residual_peel_candidate`, so
+    /// `cells[].landable_today == true` matches what
+    /// `materialize_logical_modules` would actually accept.
+    #[serde(default)]
+    pub factorize: FactorizeReport,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -193,6 +202,88 @@ pub enum PeelCandidateStatus {
     /// exported by entry" rejection — agents read this to skip
     /// candidates the materializer would reject.
     BlockedEmitResolvability,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FactorizeOptions {
+    /// Hard ceiling (in summed source-line counts) per emitted
+    /// factorizer cell. Cells exceeding the cap are emitted whole
+    /// with `oversize: true`; the algorithm never manufactures
+    /// structural splits.
+    pub size_cap_lines: usize,
+    /// Maximum number of auto-grow iterations per cell before the
+    /// factorizer gives up and reports the cell with its current
+    /// blockers. Each iteration absorbs at most a few owners.
+    pub max_grow_iterations: usize,
+}
+
+impl Default for FactorizeOptions {
+    fn default() -> Self {
+        Self {
+            size_cap_lines: 2000,
+            max_grow_iterations: 16,
+        }
+    }
+}
+
+/// Side-channel output of `crate::factorize::build_factorize_report`,
+/// embedded in [`OwnerGraphReport::factorize`]. Carries proposed
+/// module partitions over the residual owner surface, each
+/// evaluated by the same predicate `materialize_logical_modules`
+/// uses (SSOT via `peelability::evaluate_residual_peel_candidate`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FactorizeReport {
+    pub size_cap_lines: usize,
+    pub residual_owner_count: usize,
+    #[serde(default)]
+    pub cells: Vec<FactorizeCell>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FactorizeCell {
+    pub proposed_module_id: String,
+    pub owner_ids: Vec<String>,
+    pub binding_ids: Vec<BindingName>,
+    /// Owner ids in this cell whose `declared_bindings` is empty
+    /// (anonymous side-effect statements). Lane workers materialize
+    /// these via `anonymous_statements:` entries quoting the
+    /// statement source verbatim.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub anonymous_statement_owner_ids: Vec<String>,
+    pub size_lines_estimate: usize,
+    pub size_members: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_line_range: Option<[usize; 2]>,
+    pub ordinal_span: usize,
+    /// Verdict from `peelability::evaluate_residual_peel_candidate`
+    /// applied to the cell's final owner set (after auto-grow).
+    pub status: PeelCandidateStatus,
+    /// `true` iff `status == PeelableNow`. Mirrors the materializer's
+    /// accept-this-spec predicate; a `true` cell can be promoted to
+    /// an active `.yaml` right now.
+    pub landable_today: bool,
+    /// `true` when the cell's total source-line count exceeds
+    /// `size_cap_lines` (structurally indivisible at this snapshot).
+    pub oversize: bool,
+    /// Bindings referenced by the cell's bodies that aren't on
+    /// entry's export set and the auto-grow loop couldn't absorb.
+    /// Populated only when `status == BlockedEmitResolvability`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub emit_blocked_residual_bindings: Vec<BindingName>,
+    /// Other residual owners (by owner-graph id) the cycle gate
+    /// pointed at as blockers. Populated only when
+    /// `status == BlockedCycle` or `BlockedResidualDependency`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cycle_blocker_owner_ids: Vec<String>,
+    /// Active-module ids (as in [`ModuleReportRef::id`]) the cell's
+    /// outgoing constraining edges target. Safe references — entry
+    /// auto-exports those bindings. Informational.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_modules_referenced: Vec<String>,
+    /// Number of auto-grow iterations the factorizer ran on this
+    /// cell before either converging (`landable_today: true`) or
+    /// hitting `max_grow_iterations`.
+    pub auto_grow_iterations: usize,
 }
 
 /// Stable value of [`ModuleReportRef::id`] for the implicit

--- a/devinfra/js/debundle/reports.rs
+++ b/devinfra/js/debundle/reports.rs
@@ -66,6 +66,13 @@ pub(crate) fn build_owner_graph_report(schedule: &Schedule) -> OwnerGraphReport 
         },
         peelability,
         pre_existing_entry_exports,
+        // Filled in by
+        // `Schedule::owner_graph_report_with_factorize_options`
+        // after this function returns. The default value is the
+        // empty report (no cells); the schedule unconditionally
+        // overwrites it with the real factorize verdict so JSON
+        // consumers always see a populated `factorize` block.
+        factorize: crate::FactorizeReport::default(),
     }
 }
 
@@ -113,7 +120,7 @@ fn build_quotient_node_reports(schedule: &Schedule) -> Vec<ModuleReportRef> {
         .collect()
 }
 
-fn build_quotient_edge_reports(
+pub(crate) fn build_quotient_edge_reports(
     schedule: &Schedule,
     owner_edges: &[OwnerEdge],
 ) -> Vec<QuotientEdgeReport> {

--- a/devinfra/js/debundle/schedule.rs
+++ b/devinfra/js/debundle/schedule.rs
@@ -280,8 +280,24 @@ impl Schedule {
     /// High-fidelity node-link view of the fine owner graph plus
     /// its current module quotient. Written as
     /// `<chunk_id>/owner_graph.json` for downstream peel tooling.
+    /// Always includes the factorizer report computed with
+    /// [`crate::FactorizeOptions::default`]; downstream CLIs read
+    /// the precomputed cells from disk rather than reproducing the
+    /// algorithm against the serialized owner graph.
     pub fn owner_graph_report(&self) -> OwnerGraphReport {
-        build_owner_graph_report(self)
+        self.owner_graph_report_with_factorize_options(&crate::FactorizeOptions::default())
+    }
+
+    /// Like [`Self::owner_graph_report`] but with caller-chosen
+    /// `FactorizeOptions` (e.g. to widen `size_cap_lines` for an
+    /// exploratory pipeline run).
+    pub fn owner_graph_report_with_factorize_options(
+        &self,
+        factorize_options: &crate::FactorizeOptions,
+    ) -> OwnerGraphReport {
+        let mut report = build_owner_graph_report(self);
+        report.factorize = crate::build_factorize_report(self, factorize_options);
+        report
     }
 }
 


### PR DESCRIPTION
## Summary

- **SSOT factorize**: New `analysis::factorize` module calls `evaluate_residual_peel_candidate` directly so cell verdicts come from the same predicate the materializer's peelability pass uses (cycle / lazy-rebind / emit-resolvability). Cells the predicate flags as blocked by an addressable issue auto-grow by absorbing the specific owners the verdict pointed at (emit-blocked free references, cycle endpoints, residual blockers), bounded by `max_grow_iterations`. The verdict rides inside `OwnerGraphReport.factorize` (non-`Option`, default-populated) so downstream consumers read precomputed cells rather than replicating gate logic against the serialized graph.
- **Bucket-F per-declarator spans**: The pre-split synthesized single-declarator `VarDecl` / outer `ExportDecl` wrapper now carries the declarator's own `span` instead of the parent statement's. Downstream `source_location` (factorizer `size_lines_estimate`, lane-worker body extraction, peel inventory) now reports each shard's own line range instead of the full statement.

Two new `analysis_tests` parse multi-line `const A=1,\n  B=2,\n  C=3;` (bare and `export`-prefixed) with a real `SourceMap` and assert per-line `source_location`.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 34 tests pass on RBE (analysis_test, peel_factorize_test, peel_horizon_test, peel_inventory_test, pipeline_test, 18 e2e tests, etc.)
- [ ] Follow-up PR: rewrite `peel_factorize` CLI to read precomputed `factorize` cells from JSON instead of recomputing
- [ ] Follow-up PR: run against gaffer 78d928dca7 to validate real-data output

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_