### PR TITLE
debundle/factorize: drop max_grow_iterations cap, run auto-grow to fixed point

### DIFF
--- a/devinfra/js/debundle/factorize.rs
+++ b/devinfra/js/debundle/factorize.rs
@@ -99,7 +99,6 @@ pub fn build_factorize_report(schedule: &Schedule, options: &FactorizeOptions) -
             &bindings_by_owner,
             &owner_for_binding,
             &residual,
-            options,
         );
         let proposed_module_id = format!("auto_partition_{idx:04}");
         emitted.push(make_cell(
@@ -135,9 +134,17 @@ pub fn build_factorize_report(schedule: &Schedule, options: &FactorizeOptions) -
 
 /// Per-cell evaluate-and-grow loop. Calls the SSOT predicate; if
 /// blocked by an addressable category (emit-resolvability, cycle
-/// through another residual cell), tries absorbing the owners the
-/// blocker pointed at and re-evaluates. Bounded by
-/// `options.max_grow_iterations`.
+/// through another residual cell), absorbs the owners the verdict
+/// pointed at and re-evaluates. Runs to fixed point: terminates
+/// when the predicate returns `PeelableNow`, or when an iteration
+/// fails to add any new owner (no growth → no progress).
+///
+/// The cell's final owner set is the true minimum closure the
+/// materializer would accept for this seed; reporting that closure
+/// — even when it spans most of the residual surface — is the
+/// signal callers want. Capping iterations would hide that signal
+/// behind a `blocked_residual_dependency` verdict that's actually
+/// the iteration budget talking, not the graph structure.
 fn evaluate_and_grow(
     schedule: &Schedule,
     context: &PeelabilityContext<'_>,
@@ -145,7 +152,6 @@ fn evaluate_and_grow(
     bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
     owner_for_binding: &HashMap<BindingName, OwnerId>,
     residual: &BTreeSet<OwnerId>,
-    options: &FactorizeOptions,
 ) -> (BTreeSet<OwnerId>, PeelCandidateEvaluation, usize) {
     let mut iterations = 0;
     loop {
@@ -155,9 +161,6 @@ fn evaluate_and_grow(
             .flat_map(|o| bindings_by_owner.get(o).cloned().unwrap_or_default())
             .collect();
         let verdict = evaluate_residual_peel_candidate(schedule, context, &owners, declared);
-        if iterations >= options.max_grow_iterations {
-            return (cell, verdict, iterations);
-        }
         match verdict.status {
             PeelCandidateStatus::PeelableNow => return (cell, verdict, iterations),
             PeelCandidateStatus::BlockedEmitResolvability => {

--- a/devinfra/js/debundle/report_schema.rs
+++ b/devinfra/js/debundle/report_schema.rs
@@ -211,17 +211,12 @@ pub struct FactorizeOptions {
     /// with `oversize: true`; the algorithm never manufactures
     /// structural splits.
     pub size_cap_lines: usize,
-    /// Maximum number of auto-grow iterations per cell before the
-    /// factorizer gives up and reports the cell with its current
-    /// blockers. Each iteration absorbs at most a few owners.
-    pub max_grow_iterations: usize,
 }
 
 impl Default for FactorizeOptions {
     fn default() -> Self {
         Self {
             size_cap_lines: 2000,
-            max_grow_iterations: 16,
         }
     }
 }
@@ -281,8 +276,9 @@ pub struct FactorizeCell {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub active_modules_referenced: Vec<String>,
     /// Number of auto-grow iterations the factorizer ran on this
-    /// cell before either converging (`landable_today: true`) or
-    /// hitting `max_grow_iterations`.
+    /// cell before reaching a fixed point. The loop terminates when
+    /// the SSOT predicate returns `PeelableNow`, or when an
+    /// iteration adds no new owners.
     pub auto_grow_iterations: usize,
 }
 


### PR DESCRIPTION
## Summary

The 16-iter cap on `evaluate_and_grow` was hiding graph-structure information behind a `blocked_residual_dependency` verdict that's actually "iteration budget exhausted" rather than "the materializer would reject." On gaffer 78d928dca7 the cap leaves **1548 / 2742 cells (56%)** flagged blocked when sampling shows they're still adding owners each iteration (e.g. a cell that started as 1 owner ended at 39 after 16 rounds).

This change removes the cap. The loop now terminates only on convergence: `PeelableNow` from the SSOT predicate, or an iteration that adds no new owner. If a cell's closure spans most of the residual surface, that final closure size is the truth about what would need to move together — and surfacing it is more useful than reporting "blocked, idk how big the real closure is."

Knock-on: `FactorizeOptions.max_grow_iterations` is removed. `auto_grow_iterations` on each cell now reports the actual convergence count with no upper bound (some cells may report large counts; that's the signal).

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 34 tests pass on RBE
- [ ] Re-run gaffer 78d928dca7 to compare cell-size distribution and landability counts after the ducktape pin bump

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_