### PR TITLE
litellm: pin to proxmox region

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -26,6 +26,12 @@ spec:
     spec:
       serviceAccountName: litellm
       terminationGracePeriodSeconds: 90
+      # litellm proxies to local Ollama for fallback paths and lives close
+      # to ollama on the Proxmox GPU host. Pin to the proxmox region so it
+      # only schedules where it belongs (and stays Pending when those
+      # nodes are offline, rather than landing on a hil worker).
+      nodeSelector:
+        topology.kubernetes.io/region: proxmox
       containers:
         - name: litellm
           image: litellm/litellm:1.82.1


### PR DESCRIPTION
## Summary

litellm's deployment manifest was missing a `nodeSelector`. With the Proxmox nodes (`wyrm2`, `talos-pve-cp-0`) NotReady since 2026-05-10, the pod landed on `talos-vps-worker-1` — the only non-degraded VPS worker, which is currently at 99% memory requests and blocking `authentik-server`/`authentik-worker` from scheduling.

Other proxmox-scoped services (`atuin`, `proxmox-proxy`, `harbor`, `langfuse-db`, `gitea-db`, `inventree`, `firecrawl`) all use:

```yaml
spec:
  template:
    spec:
      nodeSelector:
        topology.kubernetes.io/region: proxmox
```

litellm fits the same pattern (it proxies to ollama running on the Proxmox GPU host). With the pin, it goes Pending when proxmox is offline rather than spilling onto hil capacity.

## Test plan

- [ ] After merge: `kubectl -n litellm get pods -o wide` shows litellm Pending (proxmox nodes are NotReady)
- [ ] `kubectl -n authentik get pods` — authentik-server schedules and becomes Ready as worker-1 memory frees