### PR TITLE
claude/session_start: route bazelisk through system java for CA-bundle access

### DIFF
--- a/devinfra/claude/config/bazelrc.mako
+++ b/devinfra/claude/config/bazelrc.mako
@@ -14,13 +14,30 @@ startup --host_jvm_args=-Xmx8g
 % elif platform.is_gvisor:
 startup --host_jvm_args=-Xmx4g
 % endif
+% if system_java_home:
+# Route the Bazel server through the system OpenJDK so it inherits the OS's
+# CA truststore. Debian's openjdk-*-jre-headless package symlinks
+# $JAVA_HOME/lib/security/cacerts -> /etc/ssl/certs/java/cacerts, which
+# ca-certificates-java keeps in sync with /etc/ssl/certs/ca-certificates.crt.
+# That bundle contains Anthropic's TLS-inspection CA on Claude Code web, so
+# direct HTTPS fetches (BCR, gazelle fetch_repo, etc.) just work — no
+# javax.net.ssl.trustStore override needed.
+# This is a startup flag: changing it after the server is running forces a
+# server restart on the next command. The session_start hook also exports
+# JAVA_HOME so non-bazelrc paths (`bb`, direct `java` invocations) see the
+# same JDK.
+startup --server_javabase=${system_java_home | sh}
+% endif
 % if truststore_path:
-# JVM truststore for Bazel's bundled JDK. Bazel's own cacerts lacks custom
-# CAs (e.g. Anthropic's TLS inspection CA on Claude Code web), so direct
-# HTTPS fetches (BCR, gazelle fetch_repo, etc.) fail with PKIX path building
-# failed. /etc/ssl/certs/java/cacerts is kept in sync with
-# /etc/ssl/certs/ca-certificates.crt by Debian's ca-certificates-java on web
-# containers; None means no override (CLI/NixOS, bundled JDK cacerts works).
+# Fallback: even when --server_javabase points at a system JDK above, keep
+# explicit truststore args on the bundled JDK code path. They cover the
+# window where a stale Bazel server is still running with the bundled JDK
+# (option mismatch triggers a restart, but inflight fetches may already
+# have failed) and the case where no system JDK is installed.
+# /etc/ssl/certs/java/cacerts is the Debian-managed Java truststore;
+# ca-certificates-java keeps it in sync with /etc/ssl/certs/ca-certificates.crt.
+# None means no override (CLI/NixOS without a system JDK — bundled cacerts
+# works since there's no MITM CA to worry about).
 startup --host_jvm_args=-Djavax.net.ssl.trustStore=${truststore_path | sh}
 startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=${truststore_password | sh}
 % endif

--- a/devinfra/claude/env_file.py
+++ b/devinfra/claude/env_file.py
@@ -91,6 +91,15 @@ class EnvVars:
     # Extra shell script content from config.yaml (appended verbatim)
     extra_env_script: str | None = None
 
+    # System OpenJDK home, when one was found on the host. Exported as
+    # JAVA_HOME so that `bb` (which doesn't read the session bazelrc) and any
+    # other Java-launcher consumer pick up the same system JDK as Bazel's
+    # server. On a system JDK, $JAVA_HOME/lib/security/cacerts is the OS-
+    # managed truststore (Debian: symlink to /etc/ssl/certs/java/cacerts), so
+    # HTTPS clients running under that JVM trust whatever CAs are in
+    # /etc/ssl/certs/ca-certificates.crt — including a TLS-inspection CA.
+    system_java_home: Path | None = None
+
 
 def write_env_file(env_file: Path, vars: EnvVars) -> None:
     """Write environment variables to file.
@@ -141,6 +150,16 @@ def write_env_file(env_file: Path, vars: EnvVars) -> None:
     if vars.bbr_bazelrc:
         exports.extend(["", "# bbr session bazelrc (BuildBuddy invocation metadata)"])
         exports.extend(exports_from_dict({"BBR_BAZELRC": vars.bbr_bazelrc}))
+
+    if vars.system_java_home is not None:
+        # Export JAVA_HOME (and PATH-prefix its bin) so that consumers that
+        # bypass the session bazelrc (notably `bb`, which does not source
+        # <session_dir>/bazelrc) still pick up the system OpenJDK and its
+        # OS-synced cacerts truststore. The session bazelrc separately wires
+        # `startup --server_javabase=<system_java_home>` for the Bazel server.
+        exports.extend(["", "# System OpenJDK with OS-managed cacerts (for bb and direct java callers)"])
+        exports.extend(exports_from_dict({"JAVA_HOME": vars.system_java_home}))
+        exports.append(f'export PATH="{vars.system_java_home}/bin:$PATH"')
 
     if vars.env_overlay:
         exports.extend(["", "# Secrets from startup_env_script"])

--- a/devinfra/claude/hook_daemon/session_start/BUILD.bazel
+++ b/devinfra/claude/hook_daemon/session_start/BUILD.bazel
@@ -90,6 +90,15 @@ py_library(
 )
 
 py_test(
+    name = "test_detect_system_java_home",
+    srcs = ["test_detect_system_java_home.py"],
+    deps = [
+        ":session_start_lib",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_session_context",
     srcs = ["test_session_context.py"],
     data = ["__snapshots__/test_session_context.ambr"],

--- a/devinfra/claude/hook_daemon/session_start/handler.py
+++ b/devinfra/claude/hook_daemon/session_start/handler.py
@@ -395,22 +395,33 @@ async def handle(
     )
     write_config(bbr_bazelrc, bbr_bazelrc_content, "bbr bazelrc")
 
-    # Pick a JVM truststore for Bazel's bundled JDK. Debian's
-    # /etc/ssl/certs/java/cacerts is kept in sync with /etc/ssl/certs/ca-certificates.crt
-    # by ca-certificates-java, so on web containers it already contains
-    # Anthropic's TLS inspection CA. None means no override (CLI/NixOS, bundled
-    # JDK cacerts works since there's no MITM).
-    system_java_cacerts = Path("/etc/ssl/certs/java/cacerts")
-    truststore_path: Path | None
-    truststore_password: str | None
-    if system_java_cacerts.exists():
-        truststore_path = system_java_cacerts
-        # ca-certificates-java uses the JDK default storepass; documented in
-        # /etc/default/cacerts (storepass='' means default = 'changeit').
-        truststore_password = "changeit"
+    # Route Bazel's server JVM through the system OpenJDK when available so it
+    # inherits the OS's CA truststore. Bazel's bundled JDK ships its own
+    # cacerts that does NOT include locally added CAs (e.g. Anthropic's TLS
+    # inspection CA on Claude Code web), so direct HTTPS fetches (BCR,
+    # gazelle fetch_repo, etc.) fail with `PKIX path building failed`.
+    #
+    # Two complementary mechanisms (belt + suspenders):
+    #   1. --server_javabase=<system_jdk>: makes the Bazel server *be* the
+    #      system JVM. On Debian/Ubuntu, the system OpenJDK's
+    #      $JAVA_HOME/lib/security/cacerts is a symlink to
+    #      /etc/ssl/certs/java/cacerts, which ca-certificates-java keeps in
+    #      sync with /etc/ssl/certs/ca-certificates.crt. No HTTP-client config
+    #      needed — TLS just works.
+    #   2. -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts: kept as a
+    #      fallback for the case where (1) didn't apply (no system JDK at the
+    #      expected path), or where the bundled-JDK server is still in use
+    #      because of an in-flight --host_jvm_args mismatch and a stale server.
+    #
+    # When neither is available (e.g. NixOS), both are None and we fall
+    # through to Bazel's bundled JDK + its bundled cacerts. That's fine where
+    # there is no MITM CA to worry about.
+    system_java_home = _detect_system_java_home()
+    if system_java_home is None:
+        logger.info("No system OpenJDK found; Bazel will use its bundled JDK + truststore fallback")
     else:
-        truststore_path = None
-        truststore_password = None
+        logger.info("Routing Bazel through system OpenJDK at %s", system_java_home)
+    truststore_path, truststore_password = _detect_jvm_truststore()
 
     # Render session bazelrc
     with tracer.start_as_current_span("render_bazelrc", context=root_ctx):
@@ -418,6 +429,7 @@ async def handle(
             CONFIG_FILES.joinpath("bazelrc.mako").read_text(), imports=["from shlex import quote as sh"]
         )
         bazelrc_content: str = bazelrc_template.render(
+            system_java_home=system_java_home,
             truststore_path=truststore_path,
             truststore_password=truststore_password,
             bazel_bes_proxy_sock=session.paths.bazel_bes_proxy_sock if session.bes_interceptor else None,
@@ -458,6 +470,7 @@ async def handle(
             bbr_bazelrc=bbr_bazelrc,
             env_overlay=startup.env_overlay,
             extra_env_script=extra_env,
+            system_java_home=system_java_home,
         )
         env_file.write_env_file(ctx.env_file_path, env_vars)
     logger.info("Wrote environment to %s", ctx.env_file_path)
@@ -502,6 +515,65 @@ def _build_extra_env_script(profile: ProfileConfig) -> str | None:
     """Build extra inline env content from profile's env_exports."""
     if profile.env_exports:
         return profile.env_exports.rstrip()
+    return None
+
+
+# Well-known paths for a system OpenJDK on Debian/Ubuntu (and a generic
+# `default-java` alternative). Ordered from most to least specific; the first
+# entry with a working `bin/java` wins.
+#
+# We prefer 21 over older LTS releases because the Claude Code web image
+# currently ships `openjdk-21-jre-headless`; older versions are kept as
+# fallbacks for older base images. NixOS has no `/usr/lib/jvm/...` at all so
+# detection returns None there and we fall through to Bazel's bundled JDK.
+_SYSTEM_JAVA_HOME_CANDIDATES: tuple[Path, ...] = (
+    Path("/usr/lib/jvm/java-21-openjdk-amd64"),
+    Path("/usr/lib/jvm/java-21-openjdk-arm64"),
+    Path("/usr/lib/jvm/java-17-openjdk-amd64"),
+    Path("/usr/lib/jvm/java-17-openjdk-arm64"),
+    Path("/usr/lib/jvm/java-11-openjdk-amd64"),
+    Path("/usr/lib/jvm/java-11-openjdk-arm64"),
+    Path("/usr/lib/jvm/default-java"),
+)
+
+
+def _detect_jvm_truststore() -> tuple[Path | None, str | None]:
+    """Return ``(truststore_path, password)`` for the Debian-managed Java truststore.
+
+    On Debian/Ubuntu, ``ca-certificates-java`` keeps
+    ``/etc/ssl/certs/java/cacerts`` in sync with
+    ``/etc/ssl/certs/ca-certificates.crt`` — including any
+    locally-installed inspection CA (e.g. Anthropic's on Claude Code web).
+    Used as a fallback for the bundled-JDK code path; on hosts without
+    that file (NixOS, plain CLI) we return ``(None, None)`` and the bazelrc
+    template emits no `-Djavax.net.ssl.trustStore` override.
+    """
+    system_java_cacerts = Path("/etc/ssl/certs/java/cacerts")
+    if system_java_cacerts.exists():
+        # ca-certificates-java uses the JDK default storepass; documented in
+        # /etc/default/cacerts (storepass='' means default = 'changeit').
+        return system_java_cacerts, "changeit"
+    return None, None
+
+
+def _detect_system_java_home() -> Path | None:
+    """Return the path to a usable system OpenJDK, or None if none found.
+
+    A path is "usable" when ``<path>/bin/java`` exists and is executable —
+    that's enough for both ``JAVA_HOME=<path>`` and Bazel's
+    ``--server_javabase=<path>`` to work. We deliberately do NOT spawn the JVM
+    to verify (slow, and `java -version` writes to stderr making it hard to
+    capture cleanly).
+
+    On Debian/Ubuntu the system OpenJDK package symlinks
+    ``$JAVA_HOME/lib/security/cacerts`` to ``/etc/ssl/certs/java/cacerts``,
+    so a server JVM running out of this path automatically picks up the OS
+    CA bundle — including any locally-installed inspection CA.
+    """
+    for candidate in _SYSTEM_JAVA_HOME_CANDIDATES:
+        java_bin = candidate / "bin" / "java"
+        if java_bin.is_file() and os.access(java_bin, os.X_OK):
+            return candidate
     return None
 
 

--- a/devinfra/claude/hook_daemon/session_start/test_detect_system_java_home.py
+++ b/devinfra/claude/hook_daemon/session_start/test_detect_system_java_home.py
@@ -1,0 +1,68 @@
+"""Tests for system JDK detection used by the session start hook.
+
+The detection drives both --server_javabase in the session bazelrc and the
+JAVA_HOME export in the env file, so it must be:
+
+  * permissive (any /usr/lib/jvm/...-openjdk-* path with a working bin/java)
+  * fail-closed (no false positives — a directory missing bin/java is None)
+  * NixOS-safe (no /usr/lib/jvm/... at all returns None, falling back to the
+    bundled JDK)
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest_bazel
+
+from devinfra.claude.hook_daemon.session_start import handler
+
+
+def test_detects_first_candidate_with_executable_java(tmp_path: Path) -> None:
+    """The first candidate with an executable bin/java wins."""
+    jdk = tmp_path / "java-21-openjdk-amd64"
+    bin_dir = jdk / "bin"
+    bin_dir.mkdir(parents=True)
+    java = bin_dir / "java"
+    java.write_text("#!/bin/sh\nexec true\n")
+    java.chmod(0o755)
+
+    with patch.object(handler, "_SYSTEM_JAVA_HOME_CANDIDATES", (jdk,)):
+        assert handler._detect_system_java_home() == jdk
+
+
+def test_returns_none_when_no_candidate_exists(tmp_path: Path) -> None:
+    """NixOS / CLI hosts without /usr/lib/jvm: fall back to bundled JDK."""
+    missing = tmp_path / "does-not-exist"
+    with patch.object(handler, "_SYSTEM_JAVA_HOME_CANDIDATES", (missing,)):
+        assert handler._detect_system_java_home() is None
+
+
+def test_skips_directory_without_executable_java(tmp_path: Path) -> None:
+    """A JDK directory with non-executable java is not usable."""
+    jdk = tmp_path / "broken-jdk"
+    bin_dir = jdk / "bin"
+    bin_dir.mkdir(parents=True)
+    java = bin_dir / "java"
+    java.write_text("# not executable")
+    java.chmod(0o644)
+
+    with patch.object(handler, "_SYSTEM_JAVA_HOME_CANDIDATES", (jdk,)):
+        assert handler._detect_system_java_home() is None
+
+
+def test_prefers_earlier_candidate(tmp_path: Path) -> None:
+    """When multiple candidates exist, the first one in the tuple wins."""
+    preferred = tmp_path / "java-21-openjdk-amd64"
+    fallback = tmp_path / "java-11-openjdk-amd64"
+    for jdk in (preferred, fallback):
+        (jdk / "bin").mkdir(parents=True)
+        java = jdk / "bin" / "java"
+        java.write_text("#!/bin/sh\nexec true\n")
+        java.chmod(0o755)
+
+    with patch.object(handler, "_SYSTEM_JAVA_HOME_CANDIDATES", (preferred, fallback)):
+        assert handler._detect_system_java_home() == preferred
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/devinfra/claude/test_envrc_propagation.py
+++ b/devinfra/claude/test_envrc_propagation.py
@@ -69,5 +69,38 @@ def test_no_direnv_without_extra_env(env_file: Path, wrapper_dir: Path, bazelrc:
     assert "direnv export" not in content
 
 
+def test_system_java_home_exports_java_home_and_path(
+    env_file: Path, wrapper_dir: Path, bazelrc: Path, tmp_path: Path
+) -> None:
+    """When system_java_home is set, env file exports JAVA_HOME and prefixes bin/ to PATH.
+
+    Consumers that bypass the session bazelrc (notably `bb`, which does not
+    source <session_dir>/bazelrc) rely on JAVA_HOME to pick up the system
+    OpenJDK and its OS-managed cacerts truststore.
+    """
+    java_home = tmp_path / "jdk"
+    (java_home / "bin").mkdir(parents=True)
+    vars = EnvVars(shims_dir=wrapper_dir, session_bazelrc=bazelrc, system_java_home=java_home)
+
+    write_env_file(env_file, vars)
+
+    content = env_file.read_text()
+    assert f"JAVA_HOME={java_home}" in content
+    assert f'PATH="{java_home}/bin:$PATH"' in content
+
+
+def test_no_java_home_when_system_java_home_missing(env_file: Path, wrapper_dir: Path, bazelrc: Path) -> None:
+    """Without system_java_home, env file does not export JAVA_HOME.
+
+    On NixOS / CLI hosts without an /usr/lib/jvm JDK, the bundled Bazel JDK
+    is fine and we should leave JAVA_HOME alone so the user's own JDK choice
+    (or absence of one) is preserved.
+    """
+    write_env_file(env_file, _cli_env_vars(wrapper_dir, bazelrc))
+
+    content = env_file.read_text()
+    assert "JAVA_HOME=" not in content
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
## Symptom

PR #1547 verification on a gaffer-private workspace failed with:

```
ERROR: Error computing the main repository mapping:
Error accessing registry https://bcr.bazel.build/:
Failed to fetch registry file https://bcr.bazel.build/modules/protobuf/34.0.bcr.1/MODULE.bazel:
(certificate_unknown) PKIX path building failed:
sun.security.provider.certpath.SunCertPathBuilderException:
unable to find valid certification path to requested target
```

Reproducible inside a fresh Claude Code web Firecracker container by running plain `bazelisk build //...` from a clean state.

## Root cause

Bazel ships a bundled JDK with its own `cacerts` truststore. That bundled truststore does **not** include Anthropic's TLS-inspection CA, so any direct HTTPS fetch from the Bazel server JVM (Bazel module registry, gazelle `fetch_repo`, `@rules_*` http_archive without a cache hit, etc.) fails with `PKIX path building failed` against `bcr.bazel.build` and friends.

The session_start hook tried to paper over this by injecting

```
startup --host_jvm_args=-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit
```

into `<session_dir>/bazelrc`, and the bazelisk shim auto-injects `--bazelrc=<session_dir>/bazelrc`. In theory that should fix it. In practice this path is brittle:

- `--host_jvm_args` is part of the Bazel server's startup-flag identity. If a stale Bazel server is already running with different startup args, Bazel restarts it — but inflight fetches that have already started against the stale server (with bundled cacerts) fail with PKIX before the restart takes effect.
- `bb` deliberately doesn't source the session bazelrc (see `devinfra/claude/AGENTS.md`, "bb ignores the session bazelrc"). Anything that invokes Bazel through `bb` therefore misses the truststore override entirely.
- Sessions whose `Setup`/`SessionStart` got mismatched session IDs (the known issue documented in `devinfra/claude/AGENTS.md`, "Observed: `Setup` and `SessionStart` Use Different Session IDs") have an empty session-env and no per-session bazelrc at all, so even the `--bazelrc=<session_dir>/bazelrc` injection points at a non-existent file.

## Fix

Switch the Bazel server to the system OpenJDK whenever one is available. On Debian/Ubuntu the system OpenJDK's `$JAVA_HOME/lib/security/cacerts` is a symlink to `/etc/ssl/certs/java/cacerts`, kept in sync with `/etc/ssl/certs/ca-certificates.crt` by `ca-certificates-java`. A server JVM running out of that path automatically trusts whatever the OS trusts — no extra HTTP-client config needed.

Two complementary mechanisms:

1. **`startup --server_javabase=<system_jdk>`** in the session bazelrc. Makes the Bazel server *be* the system JVM whenever it's available. `_detect_system_java_home()` probes `/usr/lib/jvm/java-21-openjdk-amd64` (the openjdk-21-jre-headless install path on the current Claude Code web image), falling back to 17/11 and `default-java`.
2. **`export JAVA_HOME=<system_jdk>`** (plus `$JAVA_HOME/bin` PATH prefix) in the session env file. Covers `bb` and any other Java-launcher consumer that bypasses the session bazelrc.

The pre-existing `-Djavax.net.ssl.trustStore` injection is kept as belt + suspenders for the bundled-JDK code path on hosts where no system JDK was detected but `/etc/ssl/certs/java/cacerts` does exist.

On NixOS / hosts without `/usr/lib/jvm/...`, both probes return `None` and Bazel falls through to its bundled JDK + bundled cacerts. That's fine on those hosts because there's no MITM CA to worry about.

## Files

- `devinfra/claude/hook_daemon/session_start/handler.py` — add `_detect_system_java_home()` and `_detect_jvm_truststore()` helpers; pass `system_java_home` into the bazelrc template **and** the env file.
- `devinfra/claude/config/bazelrc.mako` — emit `startup --server_javabase=...` when `system_java_home` is set; keep `--host_jvm_args=-Djavax.net.ssl.trustStore=...` as a fallback.
- `devinfra/claude/env_file.py` — new `EnvVars.system_java_home` field; exports `JAVA_HOME=...` and PATH-prefixes its `bin/` so `bb` picks it up.
- `devinfra/claude/test_envrc_propagation.py` — two new tests: `JAVA_HOME` is exported when `system_java_home` is set and is absent when it isn't.
- `devinfra/claude/hook_daemon/session_start/test_detect_system_java_home.py` (new) — unit tests for `_detect_system_java_home`: prefers first candidate, ignores non-executable `bin/java`, returns `None` when no candidate exists (NixOS-safe).

## Test plan

- [x] Reproduce: with the previous bazelrc + bundled JDK, `bazelisk build` fails with PKIX on BCR.
- [x] Verify fix: `bazelisk --server_javabase=/usr/lib/jvm/java-21-openjdk-amd64 test //devinfra/claude:test_envrc_propagation //devinfra/claude/hook_daemon/session_start:test_detect_system_java_home` succeeds — BCR fetch goes through and both tests pass.
- [x] Wider sanity: `bazelisk --server_javabase=... test //devinfra/claude/hook_daemon/...` — 8/9 pass; only `test_container_e2e` fails locally for the documented Docker-on-RBE reason.
- [x] `pre-commit` clean (ruff, ruff-format, buildifier, bazel test enforcement).
- [ ] In CI (RBE): `bbr test //devinfra/claude/...` stays green.

## NixOS / `bb` safety

- `_detect_system_java_home()` returns `None` on hosts without `/usr/lib/jvm/...-openjdk-*`, so NixOS gets the previous bundled-JDK behavior — no `--server_javabase` emitted, no `JAVA_HOME` exported.
- `bb` reads `JAVA_HOME` from the session env file (it sources `CLAUDE_ENV_FILE` like any other tool), so it now picks up the system JDK and its OS-synced cacerts truststore on web containers.

Co-developed-by: agentic bazelisk-system-java fix

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_