### PR TITLE
debundle/spec: require unassigned_mode per chunk

### DIFF
--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -53,7 +53,7 @@ export { a, b, c };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: Some(unassigned_mode_catchall_file(None)),
+        unassigned_mode: unassigned_mode_catchall_file(None),
         extra_files: &[(
             "static/app/vendor.js",
             "export function f() { return 1; }\n",

--- a/devinfra/js/debundle/e2e/chunk_renames_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_renames_test.rs
@@ -61,7 +61,7 @@ export { x };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: None,
+        unassigned_mode: unassigned_mode_inline(),
         extra_files: &[],
     };
     let fixture = run_fixture(opts);
@@ -104,7 +104,7 @@ export { x };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: None,
+        unassigned_mode: unassigned_mode_inline(),
         extra_files: &[(
             "static/vendor/entry.js",
             r#"export const x = "dep-x";
@@ -155,7 +155,7 @@ export { helper, run };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: None,
+        unassigned_mode: unassigned_mode_inline(),
         extra_files: &[],
     };
     let fixture = run_fixture(opts);
@@ -209,7 +209,7 @@ export { run };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: None,
+        unassigned_mode: unassigned_mode_inline(),
         extra_files: &[],
     };
 
@@ -244,7 +244,7 @@ export { alpha, bravo, charlie, delta };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: None,
+        unassigned_mode: unassigned_mode_inline(),
         extra_files: &[],
     };
 

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -57,7 +57,7 @@ export { a };
 "#,
         vec![logical_module("state", &[Member::new("a")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     expect_rejection_containing_all(
         opts,
         &["assignment", "assigner", "mutable", "cross-destination"],
@@ -75,7 +75,7 @@ export { Text };
 "#,
         vec![logical_module("shared/ui/text", &[Member::new("Text")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     assert_module_source(
         &fixture.out_root,
@@ -108,7 +108,7 @@ export { Text };
 "#,
         vec![logical_module("shared/ui/text", &[Member::new("Text")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     assert_module_source(
         &fixture.out_root,

--- a/devinfra/js/debundle/e2e/mini_factors_test.rs
+++ b/devinfra/js/debundle/e2e/mini_factors_test.rs
@@ -22,7 +22,7 @@ fn catchall_keeps_unclaimed_bindings_in_residual() {
         logical_modules: vec![],
         chunk_renames: None,
         chunk_id: "static/app",
-        unassigned_mode: Some(unassigned_mode_catchall_file(None)),
+        unassigned_mode: unassigned_mode_catchall_file(None),
         extra_files: &[],
     };
     let fixture = run_fixture(opts);
@@ -47,7 +47,7 @@ fn mini_factors_synthesizes_one_module_per_unclaimed_unit() {
         logical_modules: vec![],
         chunk_renames: None,
         chunk_id: "static/app",
-        unassigned_mode: Some(unassigned_mode_mini_factors()),
+        unassigned_mode: unassigned_mode_mini_factors(),
         extra_files: &[],
     };
     let fixture = run_fixture(opts);

--- a/devinfra/js/debundle/e2e/peel_factorize_landability_test.rs
+++ b/devinfra/js/debundle/e2e/peel_factorize_landability_test.rs
@@ -64,7 +64,7 @@ export { a, b, c };
         chunk_source,
         vec![logical_module("anchors/a", &[Member::new("a")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
@@ -123,7 +123,7 @@ fn factorizer_flags_emit_blocked_cell_not_landable_with_blocker_binding() {
     // `anchor` exists so the chunk has at least one active logical
     // module (the spec rejects all-residual chunks); `dep` and
     // `consumer` stay in the residual entry via
-    // `unassigned_mode = None` (the default `InlineInEntry`).
+    // `unassigned_mode_inline()` (`InlineInEntry`).
     let chunk_source = r#"const anchor = "anchor";
 const dep = "secret";
 function consumer() { return dep; }
@@ -134,7 +134,7 @@ export { anchor, consumer };
         chunk_source,
         vec![logical_module("anchors/anchor", &[Member::new("anchor")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));

--- a/devinfra/js/debundle/e2e/peelability_test.rs
+++ b/devinfra/js/debundle/e2e/peelability_test.rs
@@ -71,7 +71,7 @@ export { Leaf, Dep, Existing };
 "#,
         vec![logical_module("existing", &[Member::new("Existing")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     assert_entry_output(&fixture, "existing\n");
 
@@ -166,7 +166,7 @@ export { X, Existing };
 "#,
         vec![logical_module("existing", &[Member::new("Existing")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
 
     let graph: OwnerGraphReport =
@@ -228,9 +228,9 @@ fn three_vertex_constraining_scc_should_be_peelable_as_one_owner_closure() {
     // candidate in `minimal_peel_sets`.
     //
     // `Existing` is an already-extracted module so the residual
-    // peel pipeline has work to do. `unassigned_mode = None`
-    // (default `InlineInEntry`) keeps unclaimed bindings inline
-    // in entry rather than emitting a separate residual file.
+    // peel pipeline has work to do. `unassigned_mode_inline()`
+    // keeps unclaimed bindings inline in entry rather than emitting
+    // a separate residual file.
     let mut opts = FixtureOpts::new(
         r#"var A = B;
 var B = C;
@@ -241,7 +241,7 @@ export { A, B, C, Existing };
 "#,
         vec![logical_module("existing", &[Member::new("Existing")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
 
     let graph: OwnerGraphReport =
@@ -320,7 +320,7 @@ export { Existing };
 "#,
         vec![logical_module("existing", &[Member::new("Existing")])],
     );
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     assert_entry_output(&fixture, "existing\n");
 

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -807,7 +807,7 @@ export { a, b, c };
             ],
         })),
         chunk_id: "static/app",
-        unassigned_mode: Some(unassigned_mode_catchall_file(None)),
+        unassigned_mode: unassigned_mode_catchall_file(None),
         extra_files: &[(
             "static/app/vendor.js",
             "export function f() { return 1; }\n",

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -409,7 +409,7 @@ export { Leaf, Dep, Existing };
             { "name": "ReadableDep", "selector": { "binding": { "name": "Dep" } } }
         ],
     }));
-    opts.unassigned_mode = None;
+    opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
     assert_entry_output(&fixture, "existing\n");
 

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -31,7 +31,7 @@ export { a, b };
         )],
         chunk_renames: None,
         chunk_id: "static/app",
-        unassigned_mode: Some(unassigned_mode_catchall_file(None)),
+        unassigned_mode: unassigned_mode_catchall_file(None),
         extra_files: &[],
     };
     let fixture = run_fixture(opts);

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -186,27 +186,40 @@ pub struct FixtureOpts<'a> {
     /// them.
     pub chunk_renames: Option<Value>,
     pub chunk_id: &'a str,
-    /// Optional `unassigned_mode` setting for this chunk. `None` is
-    /// equivalent to the default `inline_in_entry` variant —
-    /// unclaimed bindings stay inline in entry. `Some(mode)`
-    /// renders as a YAML object with `kind: <discriminant>` plus
-    /// any variant-specific fields. Use [`unassigned_mode_catchall_file`]
-    /// or [`unassigned_mode_mini_factors`] to build typical bodies.
-    pub unassigned_mode: Option<Value>,
+    /// `unassigned_mode` setting for this chunk. Required — every
+    /// chunk listed in `logical_modules` or `chunk_renames` must
+    /// declare an explicit mode (the spec validator enforces this).
+    /// Renders as a YAML object with `kind: <discriminant>` plus
+    /// any variant-specific fields. Use [`unassigned_mode_inline`],
+    /// [`unassigned_mode_catchall_file`], or
+    /// [`unassigned_mode_mini_factors`] to build typical bodies.
+    pub unassigned_mode: Value,
     pub extra_files: &'a [(&'a str, &'a str)],
 }
 
 impl<'a> FixtureOpts<'a> {
     pub fn new(source: &'a str, logical_modules: Vec<LogicalModuleEntry>) -> Self {
+        // Default mode is `catchall_file` — most fixtures exercise the
+        // residual-module emission path and rely on
+        // `static/app/modules/residual/unhandled.js` being written.
+        // Tests that exercise `InlineInEntry` semantics override with
+        // [`unassigned_mode_inline`]; tests that exercise mini factors
+        // override with [`unassigned_mode_mini_factors`].
         Self {
             source,
             logical_modules,
             chunk_renames: None,
             chunk_id: "static/app",
-            unassigned_mode: Some(unassigned_mode_catchall_file(None)),
+            unassigned_mode: unassigned_mode_catchall_file(None),
             extra_files: &[],
         }
     }
+}
+
+/// Build the JSON body for an `unassigned_mode: inline_in_entry`
+/// entry — unclaimed bindings stay inline in the chunk's entry file.
+pub fn unassigned_mode_inline() -> Value {
+    serde_json::json!({ "kind": "inline_in_entry" })
 }
 
 /// Build the JSON body for an `unassigned_mode: catchall_file` entry.
@@ -530,9 +543,7 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
     }
 
     let mut unassigned_mode = BTreeMap::new();
-    if let Some(mode) = &opts.unassigned_mode {
-        unassigned_mode.insert(chunk_id.to_string(), mode.clone());
-    }
+    unassigned_mode.insert(chunk_id.to_string(), opts.unassigned_mode.clone());
 
     TransformSpecFixture {
         inputs: TransformInputsFixture {

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -359,7 +359,13 @@ fn materialize_logical_chunk(
         report_out_dir,
         chunk_id,
     } = inputs;
-    let chunk_unassigned_mode = unassigned_mode.get(chunk_id).cloned().unwrap_or_default();
+    // The spec validator (`validate_transform_spec`) enforces that
+    // every materialised chunk has an `unassigned_mode` entry, so
+    // this lookup must not miss. Missing here is a bug in the
+    // validator, not a recoverable spec error.
+    let chunk_unassigned_mode = unassigned_mode.get(chunk_id).cloned().with_context(|| {
+        format!("materialize_logical_modules missing unassigned_mode for chunk: {chunk_id}")
+    })?;
     let chunk_id_interned = artifact
         .chunk_table
         .get(chunk_id)

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -451,6 +451,30 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
     if spec.inputs.js_list_path.as_os_str().is_empty() {
         bail!("Transform spec inputs.js_list_path must not be empty");
     }
+    // Every chunk listed in `logical_modules` (and `chunk_renames`)
+    // must have an explicit `unassigned_mode` entry. There is no
+    // implicit default — the spec author must state how unclaimed
+    // top-level statements get handled per chunk. Chunks that appear
+    // only in `unassigned_mode` (e.g. catch-all-only chunks) are
+    // valid; the asymmetry is intentional.
+    let missing: BTreeSet<&String> = spec
+        .logical_modules
+        .keys()
+        .chain(spec.chunk_renames.keys())
+        .filter(|chunk_id| !spec.unassigned_mode.contains_key(*chunk_id))
+        .collect();
+    if !missing.is_empty() {
+        let names = missing
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "Transform spec is missing `unassigned_mode` entries for chunk(s): {names}. \
+             Every chunk listed in `logical_modules` or `chunk_renames` must declare its \
+             unassigned_mode explicitly (no implicit default)."
+        );
+    }
     Ok(())
 }
 

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -54,8 +54,11 @@ pub struct TransformSpec {
     pub chunk_renames: BTreeMap<String, ChunkRenames>,
     /// Per-chunk control over what happens to top-level statements
     /// the spec doesn't explicitly claim for any logical module.
-    /// See [`UnassignedMode`]; absent entries default to
-    /// [`UnassignedMode::InlineInEntry`].
+    /// See [`UnassignedMode`]. Every chunk that appears in
+    /// `logical_modules` must also appear here — there is no implicit
+    /// default; spec authors must state the policy explicitly. The
+    /// outer map itself may be omitted (`#[serde(default)]`) only when
+    /// the spec processes no chunks at all (e.g. vendor-only specs).
     #[serde(default)]
     pub unassigned_mode: BTreeMap<String, UnassignedMode>,
 
@@ -229,15 +232,14 @@ pub enum VendorLevel {
 /// `residual_modules` map: today's `CatchallFile` variant covers
 /// the case the standalone map used to express ("emit unclaimed
 /// code to a separate file at `target`").
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum UnassignedMode {
-    /// Default. Unclaimed bindings stay inline in the chunk's entry
-    /// file (owned by `ModuleId::ResidualEntry`); no separate
-    /// residual module is emitted. Renames against unclaimed
-    /// bindings come from [`TransformSpec::chunk_renames`] and are
-    /// applied in-place by the lowerer.
-    #[default]
+    /// Unclaimed bindings stay inline in the chunk's entry file
+    /// (owned by `ModuleId::ResidualEntry`); no separate residual
+    /// module is emitted. Renames against unclaimed bindings come
+    /// from [`TransformSpec::chunk_renames`] and are applied in-place
+    /// by the lowerer.
     InlineInEntry,
     /// Unclaimed bindings emit to a separate logical module at
     /// `target` (defaults to [`DEFAULT_RESIDUAL_MODULE_PATH`]). The

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use spec::{
     AnonymousStatement, ChunkRenames, EmitBrowserHarnessConfig, LoadJsChunksArgs, LogicalModule,
     MaterializeLogicalModulesConfig, Member, SwapMark, SwapVendorChunksConfig, TransformSpec,
-    VendorLevel, VendorMark, VendorRole, WrapperShape,
+    UnassignedMode, VendorLevel, VendorMark, VendorRole, WrapperShape,
 };
 use spec_modules::{
     collect_module_files, is_deferred_yaml, module_path_from_file, read_module_file,
@@ -30,6 +30,12 @@ struct AuthoringConfig {
     main_chunk_id: String,
     inputs: AuthoringInputs,
     browser_harness: BrowserHarnessPolicy,
+    /// Per-chunk `unassigned_mode` policy. Required: every chunk this
+    /// authoring tree materialises must appear here. The downstream
+    /// pipeline validator enforces the same invariant on the compiled
+    /// `TransformSpec`; declaring it in the authoring config keeps
+    /// the policy next to the modules tree it governs.
+    unassigned_mode: BTreeMap<String, UnassignedMode>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -107,7 +113,7 @@ pub fn compile_spec_tree(options: &CompileSpecTreeOptions) -> Result<TransformSp
         vendor: vendor_map(read_yaml::<VendorMarksFile>(&options.vendor_marks_path)?.vendor_marks)?,
         logical_modules: logical_modules_map(module_sources)?,
         chunk_renames: chunk_renames_map(&config.main_chunk_id, deferred_members),
-        unassigned_mode: BTreeMap::new(),
+        unassigned_mode: config.unassigned_mode,
         swap_vendor_chunks: SwapVendorChunksConfig {
             output_manifest_path: Some(layout.vendor_manifest_path.clone()),
             output_wrapper_dir: Some(layout.vendor_wrapper_root.clone()),
@@ -321,6 +327,9 @@ inputs:
   js_list_path: extracted/js-files.txt
 browser_harness:
   asset_summary_path: extracted/asset-summary.json
+unassigned_mode:
+  static/main:
+    kind: inline_in_entry
 "#,
         );
         write_file(


### PR DESCRIPTION
## Summary

`UnassignedMode` no longer derives `Default`, and the `TransformSpec`
spec validator now rejects any spec that lists a chunk in
`logical_modules` or `chunk_renames` without a matching
`unassigned_mode` entry. Spec authors must state explicitly how
unclaimed top-level statements get handled per chunk — no implicit
`InlineInEntry` default.

### Why

The previous behavior silently substituted `InlineInEntry` when a
chunk was missing from `unassigned_mode`. That made the policy
ambient and easy to get wrong — a spec author dropping a chunk into
`logical_modules` would inherit a behavior they never declared.
Forcing an explicit declaration keeps the spec self-describing and
prevents accidental reliance on the default.

### Breaking change

This is a breaking change for any external spec or authoring config
that omits `unassigned_mode` entries for chunks in `logical_modules` /
`chunk_renames`. Downstream consumers (e.g. gaffer) need to add an
explicit `unassigned_mode:` map.

### What changes

- `spec.rs`: drop `Default` from `UnassignedMode`; doc that
  `TransformSpec::unassigned_mode` is required per chunk.
- `pipeline.rs::validate_transform_spec`: enforce
  `logical_modules.keys() ∪ chunk_renames.keys() ⊆ unassigned_mode.keys()`
  with a clear error message naming the missing chunks. Chunks listed
  only in `unassigned_mode` remain valid (e.g. catch-all-only chunks).
- `logical_modules.rs`: tighten per-chunk lookup; missing entry is now
  an internal bug, not a recoverable spec error.
- `spec_tree.rs::AuthoringConfig`: add a required `unassigned_mode:`
  YAML field, propagated through to the compiled `TransformSpec`.
- `e2e/support.rs`: `FixtureOpts::unassigned_mode` is now `Value`
  (no `Option`); add `unassigned_mode_inline()` helper. Test sites
  that passed `None` now use the explicit helper.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — all 35 tests pass
      (invocation `e8f155ee-8f34-4941-8ace-4620804eac30`).
- [ ] Companion gaffer change adds the now-required `unassigned_mode`
      entry to `tana/re/web/spec/78d928dca7/spec_config.yaml`.

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_