### PR TITLE
debundle: drop ResidualEntry variant; residual becomes a synthesized logical module

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -193,13 +193,23 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     }
 
     fn logical(idx: usize) -> ModuleId {
-        ModuleId::Logical(LogicalModuleIndex(idx))
+        ModuleId(LogicalModuleIndex(idx))
+    }
+
+    /// Test-helper residual destination: the synthesized residual
+    /// logical module always sits at the highest index appended by
+    /// `schedule_for` / `schedule_with_residual_module`. Tests use this
+    /// instead of the historical `ModuleId::ResidualEntry` literal.
+    fn residual() -> ModuleId {
+        ModuleId::logical(usize::MAX)
     }
 
     fn render(id: ModuleId) -> String {
-        match id {
-            ModuleId::Logical(LogicalModuleIndex(idx)) => format!("mod_{idx}"),
-            ModuleId::ResidualEntry => "<residual>".to_string(),
+        let LogicalModuleIndex(idx) = id.0;
+        if idx == usize::MAX {
+            "<residual>".to_string()
+        } else {
+            format!("mod_{idx}")
         }
     }
 
@@ -234,7 +244,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         binding_assignment.insert("A".to_string(), logical(0));
         binding_assignment.insert("B".to_string(), logical(1));
         let owner_graph = build_owner_graph(&facts);
-        let partition = Partition::from_binding_assignment(&owner_graph, &binding_assignment);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
         let graph = build_module_quotient(&owner_graph, &partition);
         let report = validate_schedule(&graph, &render);
         assert_eq!(report.cycles.len(), 1);
@@ -250,7 +261,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         binding_assignment.insert("B".to_string(), logical(1));
         binding_assignment.insert("C".to_string(), logical(2));
         let owner_graph = build_owner_graph(&facts);
-        let partition = Partition::from_binding_assignment(&owner_graph, &binding_assignment);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
         let graph = build_module_quotient(&owner_graph, &partition);
         let report = validate_schedule(&graph, &render);
         assert!(
@@ -278,7 +290,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         binding_assignment.insert("readB".to_string(), logical(0));
         binding_assignment.insert("B".to_string(), logical(1));
         let owner_graph = build_owner_graph(&facts);
-        let partition = Partition::from_binding_assignment(&owner_graph, &binding_assignment);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
         let graph = build_module_quotient(&owner_graph, &partition);
         let report = validate_schedule(&graph, &render);
         assert_eq!(
@@ -328,7 +341,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         binding_assignment.insert("a2".to_string(), logical(0));
         binding_assignment.insert("b1".to_string(), logical(1));
         let owner_graph = build_owner_graph(&facts);
-        let partition = Partition::from_binding_assignment(&owner_graph, &binding_assignment);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
         let graph = build_module_quotient(&owner_graph, &partition);
         let report = validate_schedule(&graph, &render);
         assert_eq!(report.cycles.len(), 1);
@@ -362,7 +376,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         binding_assignment.insert("helperB".to_string(), logical(1));
         binding_assignment.insert("B".to_string(), logical(1));
         let owner_graph = build_owner_graph(&facts);
-        let partition = Partition::from_binding_assignment(&owner_graph, &binding_assignment);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
         let graph = build_module_quotient(&owner_graph, &partition);
         let report = validate_schedule(&graph, &render);
         assert!(
@@ -380,7 +395,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     fn cross_destination_lazy_write_is_rejected() {
         let schedule = schedule_for(
             "let A = 0; function B() { A = 1; }",
-            &[("A", logical(0)), ("B", ModuleId::ResidualEntry)],
+            &[("A", logical(0)), ("B", residual())],
         );
         let report = schedule.validate();
         assert_eq!(
@@ -389,12 +404,11 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
             "expected one atomic-unit conflict (A and B share a LazyRebind atomic unit but the spec splits them): {report:?}",
         );
         let conflict = &report.atomic_unit_conflicts[0];
+        // Residual is now the synthesized logical module at index 1
+        // (the explicit `mod_0` is at index 0).
         assert_eq!(
             distinct_claim_modules(conflict),
-            vec![
-                ModuleId::Logical(LogicalModuleIndex(0)),
-                ModuleId::ResidualEntry
-            ],
+            vec![ModuleId::logical(0), ModuleId::logical(1)],
         );
     }
 
@@ -427,18 +441,39 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         );
     }
 
+    /// Resolve a sentinel `residual()` ModuleId to the real residual
+    /// logical-module index. Helper for `schedule_for`: in the new
+    /// no-variant world the residual is just a logical module, so
+    /// tests that used to write `ModuleId::ResidualEntry` now write
+    /// `residual()` (a `usize::MAX`-indexed sentinel) and let the
+    /// builder remap it.
+    fn resolve_test_module_id(id: ModuleId, residual_idx: usize) -> ModuleId {
+        if id.0.0 == usize::MAX {
+            ModuleId::logical(residual_idx)
+        } else {
+            id
+        }
+    }
+
     fn schedule_for(source: &str, ownership: &[(&str, ModuleId)]) -> Schedule {
         let module = parse(source);
         let facts = analyze_facts(&module);
-        let mut bindings = HashMap::new();
-        let mut max_idx = 0usize;
-        for (name, id) in ownership {
-            bindings.insert(name.to_string(), BindingKind::Owned { owner: *id });
-            if let ModuleId::Logical(LogicalModuleIndex(i)) = id {
-                max_idx = max_idx.max(*i);
+        let mut max_idx: Option<usize> = None;
+        for (_, id) in ownership {
+            let LogicalModuleIndex(i) = id.0;
+            if i == usize::MAX {
+                continue;
             }
+            max_idx = Some(max_idx.map_or(i, |m| m.max(i)));
         }
-        let logical_modules: Vec<LogicalModule> = (0..=max_idx)
+        let explicit_count = max_idx.map_or(0, |i| i + 1);
+        let residual_idx = explicit_count;
+        let mut bindings = HashMap::new();
+        for (name, id) in ownership {
+            let resolved = resolve_test_module_id(*id, residual_idx);
+            bindings.insert(name.to_string(), BindingKind::Owned { owner: resolved });
+        }
+        let mut logical_modules: Vec<LogicalModule> = (0..explicit_count)
             .map(|i| LogicalModule {
                 id: format!("mod_{i}"),
                 target_file: format!("mod_{i}.js"),
@@ -447,12 +482,20 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
                 anonymous_statement_ordinals: Vec::new(),
             })
             .collect();
+        logical_modules.push(LogicalModule {
+            id: "residual".to_string(),
+            target_file: "residual/unhandled.js".to_string(),
+            residual: true,
+            rename_map: HashMap::new(),
+            anonymous_statement_ordinals: Vec::new(),
+        });
         Schedule::build(
             "test_chunk".to_string(),
             facts,
             bindings,
             logical_modules,
             HashMap::new(),
+            ModuleId::logical(residual_idx),
         )
     }
 
@@ -494,6 +537,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
             bindings,
             logical_modules,
             HashMap::new(),
+            residual,
         )
     }
 
@@ -511,11 +555,13 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
             }),
             "owner graph should retain the unassigned declared provider edge",
         );
+        // The residual is the synthesized logical module at index 1
+        // (after the explicit `mod_0` at index 0).
         assert!(
             schedule
                 .dep_graph
                 .graph
-                .contains_edge(logical(0), ModuleId::ResidualEntry),
+                .contains_edge(logical(0), ModuleId::logical(1)),
             "the quotient should expose the logical-module -> residual read",
         );
 
@@ -525,7 +571,11 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
             .iter()
             .find(|node| node.id == "owner:1")
             .expect("X owner should be reported");
-        assert_eq!(residual_owner.destination.id, "residual");
+        assert!(
+            residual_owner.destination.residual,
+            "residual owner should land on the synthesized residual module: {:?}",
+            residual_owner.destination,
+        );
     }
 
     #[test]
@@ -2766,8 +2816,8 @@ mutable = mutable + 1;"#,
         );
         // No cross-module read edges should exist: A's init is
         // pure, B reads X (same module).
-        let mod_0 = ModuleId::Logical(LogicalModuleIndex(0));
-        let mod_1 = ModuleId::Logical(LogicalModuleIndex(1));
+        let mod_0 = ModuleId(LogicalModuleIndex(0));
+        let mod_1 = ModuleId(LogicalModuleIndex(1));
         assert!(
             !schedule.dep_graph.graph.contains_edge(mod_0, mod_1),
             "no edge mod_0 → mod_1 expected, got: {:?}",
@@ -3093,7 +3143,16 @@ mutable = mutable + 1;"#,
                 } else {
                     declared.join(",")
                 };
-                (key, render(schedule.partition.of(node.id)))
+                let dest = schedule.partition.of(node.id);
+                // Residual modules render as `<residual>` so this
+                // summary stays stable across residual-index changes;
+                // explicit modules use their `mod_<idx>` label.
+                let LogicalModuleIndex(idx) = dest.0;
+                let label = match schedule.logical_module(LogicalModuleIndex(idx)) {
+                    Some(m) if m.residual => "<residual>".to_string(),
+                    _ => render(dest),
+                };
+                (key, label)
             })
             .collect();
         out.sort();
@@ -3132,12 +3191,11 @@ mutable = mutable + 1;"#,
             1,
             "expected the half-claimed EagerUse cycle to surface as an atomic-unit conflict: {report:?}",
         );
+        // Residual is the synthesized logical module appended after
+        // the explicit `mod_0`.
         assert_eq!(
             distinct_claim_modules(&report.atomic_unit_conflicts[0]),
-            vec![
-                ModuleId::Logical(LogicalModuleIndex(0)),
-                ModuleId::ResidualEntry
-            ],
+            vec![ModuleId::logical(0), ModuleId::logical(1)],
         );
     }
 
@@ -3175,10 +3233,7 @@ mutable = mutable + 1;"#,
         let conflict = &report.atomic_unit_conflicts[0];
         assert_eq!(
             distinct_claim_modules(conflict),
-            vec![
-                ModuleId::Logical(LogicalModuleIndex(0)),
-                ModuleId::Logical(LogicalModuleIndex(1)),
-            ],
+            vec![ModuleId::logical(0), ModuleId::logical(1)],
         );
     }
 

--- a/devinfra/js/debundle/factor_assembly.rs
+++ b/devinfra/js/debundle/factor_assembly.rs
@@ -51,14 +51,19 @@ pub struct AssemblyOutcome {
 /// best-effort when conflicts exist (first-seen claim wins per unit)
 /// so downstream owner-graph/report code keeps working — the
 /// conflict list is what surfaces the rejection to the user.
+///
+/// `default_destination` is the residual logical module id that
+/// unclaimed owners fall back to (and the conflict detector reports as
+/// the effective destination of unclaimed unit members).
 pub fn assemble_partition(
     owner_graph: &OwnerGraph,
     atomic_units: &[AtomicUnit],
     bindings: &HashMap<BindingName, BindingKind>,
     logical_modules: &[LogicalModule],
+    default_destination: ModuleId,
 ) -> AssemblyOutcome {
     let claims = compute_owner_claims(owner_graph, bindings, logical_modules);
-    let mut partition = Partition::new(owner_graph);
+    let mut partition = Partition::new(owner_graph, default_destination);
     for (idx, claim) in claims.iter().enumerate() {
         if let Some(dest) = claim {
             partition.set(OwnerId(idx), *dest);
@@ -66,7 +71,9 @@ pub fn assemble_partition(
     }
     let mut conflicts = Vec::<AtomicUnitConflict>::new();
     for unit in atomic_units {
-        if let Some(conflict) = detect_unit_conflict(unit, &claims, owner_graph) {
+        if let Some(conflict) =
+            detect_unit_conflict(unit, &claims, owner_graph, default_destination)
+        {
             conflicts.push(conflict);
         }
     }
@@ -95,7 +102,7 @@ fn compute_owner_claims(
         }
     }
     for (idx, module) in logical_modules.iter().enumerate() {
-        let dest = ModuleId::Logical(LogicalModuleIndex(idx));
+        let dest = ModuleId(LogicalModuleIndex(idx));
         for ordinal in &module.anonymous_statement_ordinals {
             if let Some(node) = owner_graph
                 .nodes
@@ -113,6 +120,7 @@ fn detect_unit_conflict(
     unit: &AtomicUnit,
     claims: &[Option<ModuleId>],
     owner_graph: &OwnerGraph,
+    default_destination: ModuleId,
 ) -> Option<AtomicUnitConflict> {
     // Each member's effective destination: explicit claim or
     // residual fallback. Two or more distinct destinations is
@@ -120,7 +128,7 @@ fn detect_unit_conflict(
     let resolved: Vec<(OwnerId, ModuleId)> = unit
         .members
         .iter()
-        .map(|owner| (*owner, claims[owner.0].unwrap_or(ModuleId::ResidualEntry)))
+        .map(|owner| (*owner, claims[owner.0].unwrap_or(default_destination)))
         .collect();
     let mut first: Option<ModuleId> = None;
     let mut has_distinct = false;

--- a/devinfra/js/debundle/ids.rs
+++ b/devinfra/js/debundle/ids.rs
@@ -8,15 +8,25 @@ use serde::{Deserialize, Serialize};
 #[serde(transparent)]
 pub struct LogicalModuleIndex(pub usize);
 
-/// Identity of a module the graph/schedule analysis reasons about. The
-/// residual entry is a first-class variant rather than a sentinel
-/// index, so callers can't accidentally treat it as a normal logical
-/// module.
+/// Identity of a module the graph/schedule analysis reasons about.
+/// Wraps a [`LogicalModuleIndex`] pointing into the schedule's
+/// `logical_modules` list. The residual catch-all is just a logical
+/// module flagged `residual: true` — synthesized by the materializer
+/// before `Schedule::build` for chunks that need a default
+/// destination (every `InlineInEntry` and `CatchallFile` chunk; the
+/// `MiniFactors` synthesizer handles assignments itself).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ModuleId {
-    Logical(LogicalModuleIndex),
-    ResidualEntry,
+#[serde(transparent)]
+pub struct ModuleId(pub LogicalModuleIndex);
+
+impl ModuleId {
+    pub fn logical(idx: usize) -> Self {
+        Self(LogicalModuleIndex(idx))
+    }
+
+    pub fn index(self) -> LogicalModuleIndex {
+        self.0
+    }
 }
 
 /// Position of a top-level statement in a chunk's source body.

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -464,25 +464,23 @@ fn materialize_logical_chunk(
             anonymous_ordinal_assignment.insert(*ordinal, index);
         }
         let dest_target_file = target_file_for_request(target_dir, &request.target_path)?;
-        let module_id = ModuleId::Logical(LogicalModuleIndex(index));
+        let module_id = ModuleId(LogicalModuleIndex(index));
         for member in &request.members {
             if let Some(existing_kind) = bindings_catalogue.get(&member.binding) {
                 let existing_id = match existing_kind {
                     BindingKind::Owned {
-                        owner: ModuleId::Logical(LogicalModuleIndex(owner_index)),
+                        owner: ModuleId(LogicalModuleIndex(owner_index)),
                     } => module_plans
                         .get(*owner_index)
                         .map(|plan| plan.id.clone())
                         .unwrap_or_else(|| format!("<plan#{owner_index}>")),
-                    BindingKind::Owned { owner } => format!("{owner:?}"),
                     BindingKind::Imported {
-                        re_exporter: ModuleId::Logical(LogicalModuleIndex(re_index)),
+                        re_exporter: ModuleId(LogicalModuleIndex(re_index)),
                         ..
                     } => module_plans
                         .get(*re_index)
                         .map(|plan| plan.id.clone())
                         .unwrap_or_else(|| format!("<plan#{re_index}>")),
-                    BindingKind::Imported { re_exporter, .. } => format!("{re_exporter:?}"),
                 };
                 bail!(
                     "Duplicate binding claim for {:?} in chunk {chunk_id:?}: already \
@@ -555,7 +553,7 @@ fn materialize_logical_chunk(
         let Some(&owner_index) = binding_assignment.get(claimed_name) else {
             continue;
         };
-        let owner_id = ModuleId::Logical(LogicalModuleIndex(owner_index));
+        let owner_id = ModuleId(LogicalModuleIndex(owner_index));
         for sibling in sibling_set {
             if sibling == claimed_name {
                 continue;
@@ -594,7 +592,7 @@ fn materialize_logical_chunk(
     let catchall_target_for_overflow = chunk_unassigned_mode.catchall_file_target();
     if let Some(residual) = &residual_request {
         let residual_index = module_plans.len();
-        let residual_module_id = ModuleId::Logical(LogicalModuleIndex(residual_index));
+        let residual_module_id = ModuleId(LogicalModuleIndex(residual_index));
         let mut residual_bindings = HashMap::<String, String>::new();
         for decl in &declarations {
             for name in &decl.names {
@@ -634,7 +632,7 @@ fn materialize_logical_chunk(
             .iter()
             .position(|plan| plan.target_path == catchall_target);
         if let Some(owner_index) = owner_index {
-            let owner_id = ModuleId::Logical(LogicalModuleIndex(owner_index));
+            let owner_id = ModuleId(LogicalModuleIndex(owner_index));
             let owner_plan = &mut module_plans[owner_index];
             owner_plan.explicit = false;
             for decl in &declarations {
@@ -762,7 +760,7 @@ fn materialize_logical_chunk(
                 )
             })?;
         }
-        let logical_modules: Vec<ScheduleLogicalModule> =
+        let mut logical_modules: Vec<ScheduleLogicalModule> =
             time_phase!(timings, "project_schedule_modules", {
                 module_plans
                     .iter()
@@ -790,6 +788,32 @@ fn materialize_logical_chunk(
                     })
                     .collect()
             });
+        // Commit 1 transitional behavior: the partition's "default
+        // destination" — the module owners with no claim fall back to —
+        // is a schedule-only sentinel logical module appended past
+        // `module_plans.len()`. The emit loop iterates `module_plans`,
+        // so the sentinel never gets emitted as a file. Anonymous
+        // statements without an explicit logical-module
+        // `anonymous_statements` match thus stay in the sentinel,
+        // preserving the pre-refactor split where anon-fallback was a
+        // distinct destination from the residual logical module (which
+        // only held named-unclaimed bindings). Commit 2 collapses this
+        // sentinel back into the residual module via explicit
+        // `anonymous_statement_ordinals` routing.
+        let sentinel_residual_target = chunk_unassigned_mode
+            .catchall_file_target()
+            .map(|t| target_file_for_request(target_dir, t))
+            .transpose()?
+            .unwrap_or_else(|| target_file.clone());
+        let sentinel_idx = logical_modules.len();
+        logical_modules.push(ScheduleLogicalModule {
+            id: format!("{chunk_id}::anon_residual_sentinel"),
+            target_file: sentinel_residual_target,
+            residual: true,
+            rename_map: HashMap::new(),
+            anonymous_statement_ordinals: Vec::new(),
+        });
+        let default_destination = ModuleId(LogicalModuleIndex(sentinel_idx));
         let redundant_purity_hints = analysis.redundant_purity_hints;
         let schedule = time_phase!(timings, "build_schedule", {
             Schedule::build_with(
@@ -799,6 +823,7 @@ fn materialize_logical_chunk(
                 bindings_catalogue,
                 logical_modules,
                 chunk_renames_map.clone(),
+                default_destination,
             )
             .with_pre_existing_entry_exports(pre_existing_entry_exports.clone())
         });
@@ -1393,7 +1418,7 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
     // ties (e.g. when two providers have no dep-graph relation).
     entry_imports.sort_by_key(|(idx, _)| {
         schedule
-            .linker_position(ModuleId::Logical(LogicalModuleIndex(*idx)))
+            .linker_position(ModuleId(LogicalModuleIndex(*idx)))
             .unwrap_or(usize::MAX)
     });
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();
@@ -1966,7 +1991,7 @@ fn synthesize_mini_factor_plans(
 
     for (idx, members) in unclaimed_units.into_iter().enumerate() {
         let synthetic_idx = module_plans.len();
-        let synthetic_module_id = ModuleId::Logical(LogicalModuleIndex(synthetic_idx));
+        let synthetic_module_id = ModuleId(LogicalModuleIndex(synthetic_idx));
         let target_path = format!("__auto/mini/{idx:04}");
         let target_file = target_file_for_request(target_dir, &target_path)?;
         let mut bindings = HashMap::<String, String>::new();
@@ -2545,9 +2570,7 @@ fn collect_imported_reexports_by_module(
         else {
             continue;
         };
-        let ModuleId::Logical(LogicalModuleIndex(index)) = re_exporter else {
-            continue;
-        };
+        let ModuleId(LogicalModuleIndex(index)) = re_exporter;
         let Some(reexports) = by_module.get_mut(*index) else {
             continue;
         };
@@ -2572,8 +2595,7 @@ fn plan_module_reference_needs<'a>(
 ) -> ModuleReferenceNeeds<'a> {
     let mut needs = ModuleReferenceNeeds::default();
     for name in &body_facts.referenced_idents {
-        if let Some(ModuleId::Logical(LogicalModuleIndex(provider_index))) = schedule.owner_of(name)
-        {
+        if let Some(ModuleId(LogicalModuleIndex(provider_index))) = schedule.owner_of(name) {
             if provider_index != module_index
                 && let Some(provider) = schedule.logical_module(LogicalModuleIndex(provider_index))
                 && let Some(exported_name) = provider.rename_map.get(name)
@@ -2629,7 +2651,7 @@ fn cross_module_imports_for_plan(
     let mut providers: Vec<usize> = imports_by_provider.keys().copied().collect();
     providers.sort_by_key(|&idx| {
         schedule
-            .linker_position(ModuleId::Logical(LogicalModuleIndex(idx)))
+            .linker_position(ModuleId(LogicalModuleIndex(idx)))
             .unwrap_or(usize::MAX)
     });
     providers

--- a/devinfra/js/debundle/partition.rs
+++ b/devinfra/js/debundle/partition.rs
@@ -6,7 +6,9 @@ use crate::{BindingName, ModuleId, OwnerGraph, OwnerId};
 ///
 /// Conceptually the **partition** of the chunk's program-dependence
 /// graph into output modules. Indexing is dense by [`OwnerId`]; every
-/// owner has an assignment (defaulting to [`ModuleId::ResidualEntry`]).
+/// owner has an assignment (defaulting to the caller-supplied
+/// `default_destination` — typically the chunk's synthesized residual
+/// module).
 ///
 /// The partition is the spec's primary input to the realizability gate,
 /// the quotient construction, and the peelability search. It's stored
@@ -20,10 +22,14 @@ pub struct Partition {
 
 impl Partition {
     /// Build a partition keyed by `owner_graph.nodes.len()` slots,
-    /// each defaulting to `ModuleId::ResidualEntry`.
-    pub fn new(owner_graph: &OwnerGraph) -> Self {
+    /// each defaulting to `default_destination`. Callers pass the
+    /// chunk's residual logical-module id (synthesized by the
+    /// materializer); MiniFactors callers can pass any placeholder
+    /// because every owner gets a concrete claim from the mini-factor
+    /// synthesizer before the partition is consulted.
+    pub fn new(owner_graph: &OwnerGraph, default_destination: ModuleId) -> Self {
         Self {
-            of: vec![ModuleId::ResidualEntry; owner_graph.nodes.len()],
+            of: vec![default_destination; owner_graph.nodes.len()],
         }
     }
 
@@ -31,7 +37,7 @@ impl Partition {
     /// `Owned` binding it declares, looked up by name in
     /// `binding_assignment`. Owners with no declared bindings — or
     /// whose declared bindings are absent from the assignment — stay
-    /// at [`ModuleId::ResidualEntry`].
+    /// at `default_destination`.
     ///
     /// Bindings get the first declaring owner's destination if more
     /// than one owner declares the same name (which the chunk
@@ -40,8 +46,9 @@ impl Partition {
     pub fn from_binding_assignment(
         owner_graph: &OwnerGraph,
         binding_assignment: &HashMap<BindingName, ModuleId>,
+        default_destination: ModuleId,
     ) -> Self {
-        let mut p = Self::new(owner_graph);
+        let mut p = Self::new(owner_graph, default_destination);
         for node in &owner_graph.nodes {
             for binding_id in &node.declared {
                 let Some(name) = owner_graph.binding_table.name(*binding_id) else {

--- a/devinfra/js/debundle/peelability.rs
+++ b/devinfra/js/debundle/peelability.rs
@@ -354,9 +354,8 @@ impl<'a> PeelabilityContext<'a> {
         quotient_edges: &[QuotientEdgeReport],
     ) -> Self {
         let mut modules = BTreeSet::<ModuleId>::new();
-        modules.insert(ModuleId::ResidualEntry);
         for idx in 0..schedule.logical_modules.len() {
-            modules.insert(ModuleId::Logical(LogicalModuleIndex(idx)));
+            modules.insert(ModuleId(LogicalModuleIndex(idx)));
         }
         for (_, module) in schedule.partition.iter() {
             modules.insert(module);

--- a/devinfra/js/debundle/report_schema.rs
+++ b/devinfra/js/debundle/report_schema.rs
@@ -320,20 +320,21 @@ pub struct FactorizeDiagnostic {
     pub extends_module_id: Option<String>,
 }
 
-/// Stable value of [`ModuleReportRef::id`] for the implicit
-/// `<residual_entry>` module — the catch-all that holds bindings
-/// the spec hasn't assigned to a logical module. Consumed by
-/// downstream analyzers (factorizer, peel inventory) to gate
-/// residual-entry-only predicates without string-matching the
-/// label (which carries the user-facing `<residual_entry>` form).
-/// SSOT for the `module_key(ModuleId::ResidualEntry)` constant in
-/// `reports::module_key`.
+/// Conventional JSON-key value for the residual catch-all module
+/// across the report schema and downstream consumers (factorizer,
+/// peel inventory). Kept as an SSOT constant so consumers that key
+/// off "the residual module" by id can still pattern-match — but the
+/// debundler itself stopped using it as a discriminator: residual is
+/// just a `ModuleReportRef` whose `residual: bool` flag is `true`,
+/// and the synthesized module's id is `module_key(ModuleId)` (e.g.
+/// `logical:7`).
 pub const RESIDUAL_ENTRY_MODULE_ID: &str = "residual";
 
-/// Human-facing display label for the implicit residual entry
-/// (i.e. [`ModuleReportRef::label`] when the module id is
-/// [`RESIDUAL_ENTRY_MODULE_ID`]). SSOT for the constant in
-/// `schedule::module_name`'s `ModuleId::ResidualEntry` arm.
+/// Conventional human-facing label some downstream tooling still
+/// renders for the residual catch-all module. Production reports now
+/// emit the synthesized residual logical module's own id (e.g.
+/// `<chunk>::residual`); this constant remains for fixture
+/// helpers that need a fallback label.
 pub const RESIDUAL_ENTRY_LABEL: &str = "<residual_entry>";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/devinfra/js/debundle/reports.rs
+++ b/devinfra/js/debundle/reports.rs
@@ -7,7 +7,7 @@ use crate::peelability::build_peelability_report;
 use crate::{
     BindingId, BindingName, BindingReport, DepKind, LogicalModuleIndex, ModuleId, ModuleReportRef,
     OwnerGraphEdgeReport, OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport,
-    OwnerId, QuotientEdgeReport, QuotientSccReport, RESIDUAL_ENTRY_MODULE_ID, Schedule,
+    OwnerId, QuotientEdgeReport, QuotientSccReport, Schedule,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -103,9 +103,8 @@ where
 
 fn build_quotient_node_reports(schedule: &Schedule) -> Vec<ModuleReportRef> {
     let mut modules = BTreeSet::<ModuleId>::new();
-    modules.insert(ModuleId::ResidualEntry);
     for idx in 0..schedule.logical_modules.len() {
-        modules.insert(ModuleId::Logical(LogicalModuleIndex(idx)));
+        modules.insert(ModuleId(LogicalModuleIndex(idx)));
     }
     for (_, module) in schedule.partition.iter() {
         modules.insert(module);
@@ -225,14 +224,17 @@ fn quotient_edge_indices_by_source(
     by_source
 }
 
+/// True iff `id` refers to a logical module whose `residual` flag is
+/// set — the chunk's catch-all destination synthesized before
+/// `Schedule::build`. Used by peelability and the destination
+/// projection in reports to gate residual-only predicates without
+/// string-matching module ids or labels.
 pub(crate) fn is_residual_destination(schedule: &Schedule, id: ModuleId) -> bool {
-    match id {
-        ModuleId::ResidualEntry => true,
-        ModuleId::Logical(LogicalModuleIndex(idx)) => schedule
-            .logical_modules
-            .get(idx)
-            .is_some_and(|module| module.residual),
-    }
+    let LogicalModuleIndex(idx) = id.0;
+    schedule
+        .logical_modules
+        .get(idx)
+        .is_some_and(|module| module.residual)
 }
 
 pub(crate) fn owner_key(id: OwnerId) -> String {
@@ -240,34 +242,24 @@ pub(crate) fn owner_key(id: OwnerId) -> String {
 }
 
 pub(crate) fn module_key(id: ModuleId) -> String {
-    match id {
-        ModuleId::ResidualEntry => RESIDUAL_ENTRY_MODULE_ID.to_string(),
-        ModuleId::Logical(LogicalModuleIndex(idx)) => format!("logical:{idx}"),
-    }
+    let LogicalModuleIndex(idx) = id.0;
+    format!("logical:{idx}")
 }
 
 pub(crate) fn module_id_from_key(key: &str) -> Option<ModuleId> {
-    if key == RESIDUAL_ENTRY_MODULE_ID {
-        return Some(ModuleId::ResidualEntry);
-    }
     key.strip_prefix("logical:")
         .and_then(|idx| idx.parse::<usize>().ok())
-        .map(|idx| ModuleId::Logical(LogicalModuleIndex(idx)))
+        .map(|idx| ModuleId(LogicalModuleIndex(idx)))
 }
 
 pub(crate) fn module_report_ref(schedule: &Schedule, id: ModuleId) -> ModuleReportRef {
-    let logical = match id {
-        ModuleId::Logical(LogicalModuleIndex(idx)) => schedule
-            .logical_modules
-            .get(idx)
-            .map(|module| (idx, module)),
-        ModuleId::ResidualEntry => None,
-    };
+    let LogicalModuleIndex(idx) = id.0;
+    let logical = schedule.logical_modules.get(idx);
     ModuleReportRef {
         id: module_key(id),
         label: schedule.module_name(id),
         residual: is_residual_destination(schedule, id),
-        index: logical.map(|(idx, _)| idx),
-        target_file: logical.map(|(_, module)| module.target_file.clone()),
+        index: logical.map(|_| idx),
+        target_file: logical.map(|module| module.target_file.clone()),
     }
 }

--- a/devinfra/js/debundle/schedule.rs
+++ b/devinfra/js/debundle/schedule.rs
@@ -11,8 +11,7 @@ use crate::reports::{build_owner_graph_report, owner_key};
 use crate::validation::validate_schedule;
 use crate::{
     BindingId, BindingKind, BindingName, LogicalModule, LogicalModuleIndex, ModuleId,
-    ModuleQuotient, OwnerGraph, OwnerGraphReport, RESIDUAL_ENTRY_LABEL, ScheduleReport,
-    StatementFacts,
+    ModuleQuotient, OwnerGraph, OwnerGraphReport, ScheduleReport, StatementFacts,
 };
 
 /// Single per-chunk schedule. Carries everything downstream code
@@ -108,6 +107,7 @@ impl Schedule {
         bindings: HashMap<BindingName, BindingKind>,
         logical_modules: Vec<LogicalModule>,
         chunk_renames: HashMap<BindingName, BindingName>,
+        default_destination: ModuleId,
     ) -> Self {
         let precomputed = compute_owner_graph_and_units(&facts);
         Self::build_with(
@@ -117,6 +117,7 @@ impl Schedule {
             bindings,
             logical_modules,
             chunk_renames,
+            default_destination,
         )
     }
 
@@ -131,12 +132,19 @@ impl Schedule {
         bindings: HashMap<BindingName, BindingKind>,
         logical_modules: Vec<LogicalModule>,
         chunk_renames: HashMap<BindingName, BindingName>,
+        default_destination: ModuleId,
     ) -> Self {
         let OwnerGraphAndUnits {
             owner_graph,
             atomic_units,
         } = precomputed;
-        let outcome = assemble_partition(&owner_graph, &atomic_units, &bindings, &logical_modules);
+        let outcome = assemble_partition(
+            &owner_graph,
+            &atomic_units,
+            &bindings,
+            &logical_modules,
+            default_destination,
+        );
         let partition = outcome.partition;
         let assembly_conflicts = outcome.conflicts;
         let owner_report_ids_by_binding = Self::build_owner_report_ids_by_binding(&owner_graph);
@@ -177,10 +185,11 @@ impl Schedule {
     pub fn with_pre_existing_entry_exports(mut self, exports: BTreeSet<BindingName>) -> Self {
         let mut cache: HashSet<BindingName> = exports.iter().cloned().collect();
         for (name, kind) in &self.bindings {
-            if let BindingKind::Owned {
-                owner: ModuleId::Logical(_),
-            } = kind
-            {
+            // Every owner is a logical module now (the residual is
+            // just a logical module flagged `residual: true`); include
+            // all owned bindings so peelability's emit-resolvability
+            // projection sees the full moved-binding export surface.
+            if let BindingKind::Owned { .. } = kind {
                 cache.insert(name.clone());
             }
         }
@@ -242,14 +251,11 @@ impl Schedule {
 
     /// Render `id` to a human-readable label (used in cycle reports).
     pub fn module_name(&self, id: ModuleId) -> String {
-        match id {
-            ModuleId::ResidualEntry => RESIDUAL_ENTRY_LABEL.to_string(),
-            ModuleId::Logical(LogicalModuleIndex(idx)) => self
-                .logical_modules
-                .get(idx)
-                .map(|m| m.id.clone())
-                .unwrap_or_else(|| format!("<module#{idx}>")),
-        }
+        let LogicalModuleIndex(idx) = id.0;
+        self.logical_modules
+            .get(idx)
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| format!("<module#{idx}>"))
     }
 
     /// Which logical module owns a binding (by local name), if any.
@@ -358,7 +364,7 @@ fn build_export_name_by_binding(
     for (name, kind) in bindings {
         let export = match kind {
             BindingKind::Owned {
-                owner: ModuleId::Logical(LogicalModuleIndex(idx)),
+                owner: ModuleId(LogicalModuleIndex(idx)),
             } => logical_modules
                 .get(*idx)
                 .and_then(|module| module.rename_map.get(name))
@@ -403,9 +409,8 @@ fn compute_linker_order(
     // Add every module the schedule knows about so the order
     // covers them even if they have no dep-graph edges (singleton
     // leaves still need a deterministic position for emit ordering).
-    graph.add_node(ModuleId::ResidualEntry);
     for idx in 0..logical_modules.len() {
-        graph.add_node(ModuleId::Logical(LogicalModuleIndex(idx)));
+        graph.add_node(ModuleId(LogicalModuleIndex(idx)));
     }
     for (from, to, _) in dep_graph.iter_edges() {
         graph.add_node(from);


### PR DESCRIPTION
## Summary

- Collapses `ModuleId` from a two-variant enum (`Logical(LogicalModuleIndex) | ResidualEntry`) to a single-field struct wrapping `LogicalModuleIndex`. Every `Partition` caller now threads a `default_destination: ModuleId`; no more implicit `ResidualEntry` sentinel anywhere in the analyzer.
- The residual catch-all is now an ordinary `LogicalModule` flagged `residual: true`. The materializer synthesizes a schedule-only `<chunk>::anon_residual_sentinel` logical module past `module_plans.len()` for use as `Partition::new`'s `default_destination`, preserving the pre-refactor split where named-unclaimed bindings and anonymous fallback statements live in distinct dep-graph destinations.
- Supersedes the `claude/catchall-file-anon-stmts` band-aid branch (just pushed, no PR yet). Both attempt to fix the same gaffer-spec anon-stmt-with-cross-module-dep symptom but this branch tackles the underlying variant-as-special-case debt.

## Why stop at one commit

The plan called for three commits:

1. **Variant removal** (landed, `4a3f111b6`): `ModuleId` collapse, `Partition::new` API change, sentinel preservation. `bbr test //devinfra/js/debundle/...` is green (35/35).
2. **Always synthesize residual + anon-stmt routing** (deferred): widen `logical_requests_for_chunk` to synthesize unconditionally for `InlineInEntry` + `CatchallFile`; sweep unclaimed anonymous side-effect statements into the residual module's `anonymous_statement_ordinals`.
3. **Peelability cleanup** (deferred): consolidate the supernode-tied call sites the Stage 3 subagent flagged.

I prototyped commit 2 (~210 LoC) but the anon-stmt sweep produces module-quotient cycles that didn't exist when anonymous statements stayed in entry. The cycle shape: an anonymous statement reads a binding owned by an explicit logical module → after the sweep, residual depends on that module at-init; the explicit module also reads a residual-owned binding at-init → cycle. In the pre-refactor world the anon stmt lived in entry, which isn't a tracked module in the dep graph. Tests under `unassigned_mode: catchall_file` (the suite default) hit this in ~11 cases. The `chunk_renames`-applies-in-entry tests also regressed because bindings the lowerer used to rewrite in place now live in the synthesized residual plan instead.

Per the task's stop-signal rule ("10 tests still failing after commit 2 and I can't figure out why quickly → stop and report") I reverted commit 2 rather than ship regressions. Commit 1 alone is the variant-removal half and is independently valuable — every analysis-layer call site now uses the field-access syntax and there's a single uniform residual destination.

## Suspicions for the commit-2 follow-up

- The validator's `has_init_order_constraining_edge` cycle test may need a relaxation for residual modules whose only cross-module edges come from anonymous side-effect statements (those statements are guaranteed to run after the named bindings they read, via the residual module's import order on entry).
- Or: anon stmts should only sweep into residual when they have no cross-module init reads, leaving the rest in entry's body. That preserves OLD CatchallFile semantics for the failure-prone case while still claiming the easy ones (the gaffer-spec shape).
- For `chunk_renames`, the lowerer needs to apply renames to bindings whose decl moves into the synthesized residual plan, not just those staying in entry's body. Today the `cross_module_chunk_renames` filter (`binding_assignment.contains_key`) excludes them.
- The new e2e test for `unassigned_mode: catchall_file` + anon-stmt-Sequenced-bound-to-named-binding (the gaffer bug shape) is also deferred; it should drive the design of whichever relaxation lands.

## Tests still failing on the band-aid PR (`claude/catchall-file-anon-stmts`)

For reference, that branch failed: `anonymous_statement_test`, `catchall_anon_statement_test`, `chunk_rename_cross_module_test`, `comma_list_owner_split_test`, `cross_module_emission_test`, `lowering_test`, `naturalization_test`, `owner_graph_purity_reason_test`, `purity_test`, `realizability_test`, `residual_member_rename_test`, `source_order_emit_test`. This PR's commit-2 prototype had a different but overlapping failure set.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 35/35 green on commit 1 (invocation `f478fe12-3d05-4f7a-a869-05d5bbd8a602`).

https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2sF75vhtHFb3t9y2LuZEk)_