### PR TITLE
debundle pipeline: fix --tree-source-root regression in encapsulation

### DIFF
--- a/devinfra/js/debundle/pipeline.bzl
+++ b/devinfra/js/debundle/pipeline.bzl
@@ -38,8 +38,10 @@ def _debundle_pipeline_impl(ctx):
             _shell_source_path(paths.join(pkg, ctx.attr.tree_modules)),
             "--tree-vendor-marks",
             _shell_source_path(paths.join(pkg, ctx.attr.tree_vendor_marks)),
+            # Source-relative paths embedded in the tree config YAML
+            # (e.g. `inputs.js_list_path`) resolve against the execroot.
             "--tree-source-root",
-            shell.quote("."),
+            _shell_source_path("."),
             "--out-root",
             shell.quote(out_dir.short_path),
         ]


### PR DESCRIPTION
## Summary

Follow-up to #1553. The encapsulation lost the `${OLDPWD}/.` rewriting for `--tree-source-root`, so the literal `.` got passed through to the debundler. The debundler's `Runfiles::create().resolve_runfiles_path(".")` then rebased source-relative spec paths (e.g. `inputs.js_list_path`) onto the debundler's runfiles tree instead of the execroot — reading `tana/upstream/.../js-files.txt` failed.

Fix: pass `--tree-source-root` through `_shell_source_path(".")` so it renders as `"${OLDPWD}/."` (execroot), restoring the original behavior.

## Test plan

- [x] `bazelisk test --config=rbe //tana/...` on gaffer-private with this commit pinned: web debundle pipeline + desktop debundle pipeline both run all 8 transform stages cleanly; `//tana/re/web/live_proxy:load_78d928dca7` and `//tana/re/desktop/out:regen_emitted_js_v1_515_0_test` pass (BB invocation `819b88f6-2826-46b6-b0ca-b4e917e19825`).
- [x] Before the fix, the same targets failed with `reading <runfiles>/./tana/upstream/.../js-files.txt`.

https://claude.ai/code/session_01SjZoM3tEXs3XSn5tnGHRzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjZoM3tEXs3XSn5tnGHRzf)_