### PR TITLE
debundle factorize: dedup diagnostics and skip oversize-closure subseeds

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -3361,6 +3361,42 @@ function consumer() { return dep_a + dep_b; }"#,
         );
     }
 
+    /// Different residual frontier starts can converge on the same closure
+    /// during blocker-driven growth. The report should contain one row per
+    /// (reason, closure) equivalence class — not one row per starting unit
+    /// — so each diagnostic's `(reason, sorted owner_ids)` must be unique.
+    /// The same invariant covers the `close_frontier` early-bail when a
+    /// seed is wholly inside a previously diagnosed oversize closure: that
+    /// path's only observable effect is "no second row for that closure."
+    #[test]
+    fn factorize_emits_each_diagnostic_closure_once() {
+        // Several consumers each pull in the same shared deps, so multiple
+        // frontier starts grow into closures that overlap heavily. Whether
+        // any pair coincides exactly depends on the residual + active-module
+        // landscape — the assertion is the invariant, not a fixed count.
+        let schedule = schedule_for(
+            r#"const dep_a = "left";
+const dep_b = "right";
+function consumer_one() { return dep_a + dep_b; }
+function consumer_two() { return dep_a + dep_b; }
+function consumer_three() { return dep_a + dep_b; }"#,
+            &[],
+        )
+        .with_pre_existing_entry_exports(BTreeSet::new());
+        let report = schedule
+            .owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 });
+
+        let mut seen: BTreeSet<(FactorizeDiagnosticReason, Vec<String>)> = BTreeSet::new();
+        for diagnostic in &report.factorize.diagnostics {
+            let mut owners = diagnostic.owner_ids.clone();
+            owners.sort();
+            assert!(
+                seen.insert((diagnostic.reason, owners)),
+                "factorize emitted duplicate diagnostic for closure: {diagnostic:#?}",
+            );
+        }
+    }
+
     #[test]
     fn schedule_report_serializes_linker_order_as_snake_case() {
         let schedule = schedule_for(

--- a/devinfra/js/debundle/factorize.rs
+++ b/devinfra/js/debundle/factorize.rs
@@ -73,19 +73,50 @@ pub fn build_factorize_report(schedule: &Schedule, options: &FactorizeOptions) -
     let mut proposals = Vec::<CertifiedProposal>::new();
     let mut diagnostics = Vec::<FactorizeDiagnostic>::new();
     let starts = build_frontier_starts(schedule, &index);
+    // Dedup diagnostics across frontier starts that converge on the same
+    // closure: each atomic unit grows independently, but different starts
+    // can reach the same blocked or oversize set. Emit one row per
+    // (reason, closure) equivalence class.
+    let mut diagnostics_seen: HashSet<(FactorizeDiagnosticReason, Vec<OwnerId>)> = HashSet::new();
+    // Owners that already appeared in an `ExceedsSizeCap` diagnostic. Growth
+    // from a seed wholly inside such a closure is forward-only and stays in
+    // that closure (blockers come from the seed's own dependency edges,
+    // which are a subset of the closure's), so any diagnostic produced
+    // there would be redundant. Skipping inside `close_frontier` avoids the
+    // growth walk too, not just the duplicate report row.
+    let mut oversize_owners = BTreeSet::<OwnerId>::new();
     for start in starts {
-        match close_frontier(schedule, &context, &index, start, options.size_cap_lines) {
+        match close_frontier(
+            schedule,
+            &context,
+            &index,
+            start,
+            options.size_cap_lines,
+            &oversize_owners,
+        ) {
             FrontierOutcome::Certified(proposal) => proposals.push(proposal),
-            FrontierOutcome::Diagnostic(diagnostic) => diagnostics.push(make_diagnostic(
-                diagnostics.len(),
-                diagnostic.owners,
-                diagnostic.extension_target,
-                &node_by_owner,
-                &diagnostic.verdict,
-                diagnostic.reason,
-                &index.bindings_by_owner,
-                schedule,
-            )),
+            FrontierOutcome::Diagnostic(diagnostic) => {
+                let key = (
+                    diagnostic.reason,
+                    diagnostic.owners.iter().copied().collect::<Vec<_>>(),
+                );
+                if !diagnostics_seen.insert(key) {
+                    continue;
+                }
+                if diagnostic.reason == FactorizeDiagnosticReason::ExceedsSizeCap {
+                    oversize_owners.extend(diagnostic.owners.iter().copied());
+                }
+                diagnostics.push(make_diagnostic(
+                    diagnostics.len(),
+                    diagnostic.owners,
+                    diagnostic.extension_target,
+                    &node_by_owner,
+                    &diagnostic.verdict,
+                    diagnostic.reason,
+                    &index.bindings_by_owner,
+                    schedule,
+                ));
+            }
             FrontierOutcome::Empty => {}
         }
     }
@@ -265,6 +296,7 @@ fn close_frontier(
     index: &FactorizeIndex,
     start: FrontierStart,
     size_cap_lines: usize,
+    oversize_owners: &BTreeSet<OwnerId>,
 ) -> FrontierOutcome {
     if start.owners.is_empty() {
         return FrontierOutcome::Empty;
@@ -318,6 +350,16 @@ fn close_frontier(
                 extension_target,
                 verdict: certified_verdict(verdict),
             });
+        }
+
+        // Bail out once the unrepaired set is wholly inside a previously
+        // diagnosed oversize closure: blocker-driven growth from here walks
+        // the same dependency edges as the original closure walked, so the
+        // final closure is a subset and the diagnostic would duplicate. Run
+        // *after* the PeelableNow check so a singleton sub-peel inside a
+        // megaclass still certifies.
+        if owners.iter().all(|owner| oversize_owners.contains(owner)) {
+            return FrontierOutcome::Empty;
         }
 
         let before = owners.clone();

--- a/devinfra/js/debundle/report_schema.rs
+++ b/devinfra/js/debundle/report_schema.rs
@@ -289,7 +289,7 @@ pub struct FactorizeCell {
     pub extension_owner_ids: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum FactorizeDiagnosticReason {
     ExceedsSizeCap,


### PR DESCRIPTION
Different residual frontier starts can grow into the same closure during
blocker-driven absorption (atomic-unit absorption mid-loop, or two
consumers reaching the same megaclass), so the report previously emitted
one row per starting unit instead of one row per (reason, closure)
equivalence class. On Tana's main chunk that's ~23% redundant rows
(2,751 → 2,121 unique owner sets observed in a recent plan-work run).

Two changes in `build_factorize_report`:

1. Track `(reason, sorted owner_ids)` of every emitted diagnostic and
   drop later frontiers that produce the same key. Pure report-layer
   cleanup; the closure data was already deterministic per closure.
2. Track the union of owners in any `ExceedsSizeCap` closure; pass it
   into `close_frontier`, which bails with `Empty` once the unrepaired
   set is wholly inside it. Growth from such a seed would walk the same
   dependency edges (blockers come from the seed's own outgoing edges,
   which are a subset of the diagnosed closure's) and produce a
   redundant or subset row — bailing skips the walk too. The check
   runs *after* the `PeelableNow` check so a singleton sub-peel inside
   a megaclass still certifies as a valid proposal.

Adds `Hash` to `FactorizeDiagnosticReason` for the dedup key and a new
invariant test asserting each diagnostic's `(reason, sorted owner_ids)`
is unique across the report.

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU