### PR TITLE
debundle factorize: e2e + dedup non-vacuity tests

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -3397,6 +3397,165 @@ function consumer_three() { return dep_a + dep_b; }"#,
         }
     }
 
+    /// Targeted coverage for the **dedup non-vacuity**: a fan-in shape
+    /// where multiple consumers' frontier starts grow into closures
+    /// that *all* hit the size cap. The number of `ExceedsSizeCap`
+    /// rows must be bounded by the number of distinct closures, not by
+    /// the number of starting consumers — pre-fix would emit one row
+    /// per consumer.
+    ///
+    /// We don't pin an exact count (closure overlap depends on
+    /// `close_atomic_units` behaviour for this synthetic input) but we
+    /// do require the union of `ExceedsSizeCap` owner-sets to cover
+    /// every consumer's owner. Combined with the uniqueness invariant,
+    /// that proves the report compresses N consumers' shared-closure
+    /// rows into the underlying set of distinct closures.
+    #[test]
+    fn factorize_exceeds_size_cap_rows_cover_all_consumer_starts_without_duplicates() {
+        let schedule = schedule_for(
+            r#"const dep_a = "left";
+const dep_b = "right";
+function consumer_one() { return dep_a + dep_b; }
+function consumer_two() { return dep_a + dep_b; }
+function consumer_three() { return dep_a + dep_b; }"#,
+            &[],
+        )
+        .with_pre_existing_entry_exports(BTreeSet::new());
+        let report = schedule
+            .owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 });
+
+        let exceeds: Vec<&FactorizeDiagnostic> = report
+            .factorize
+            .diagnostics
+            .iter()
+            .filter(|d| d.reason == FactorizeDiagnosticReason::ExceedsSizeCap)
+            .collect();
+        assert!(
+            !exceeds.is_empty(),
+            "fan-in fixture under cap=1 should produce ExceedsSizeCap diagnostics; got: {:#?}",
+            report.factorize.diagnostics,
+        );
+
+        // Uniqueness across all rows (not just ExceedsSizeCap ones).
+        let mut keys: BTreeSet<(FactorizeDiagnosticReason, Vec<String>)> = BTreeSet::new();
+        for diagnostic in &report.factorize.diagnostics {
+            let mut owners = diagnostic.owner_ids.clone();
+            owners.sort();
+            assert!(
+                keys.insert((diagnostic.reason, owners.clone())),
+                "duplicate diagnostic key (reason={:?}, owners={:?}) in: {:#?}",
+                diagnostic.reason,
+                owners,
+                report.factorize.diagnostics,
+            );
+        }
+
+        // Every consumer's binding must show up in *some*
+        // `ExceedsSizeCap` row's binding list — otherwise the test
+        // isn't exercising convergence across all three starts.
+        let mut covered_bindings = BTreeSet::<String>::new();
+        for diag in &exceeds {
+            for binding in &diag.binding_ids {
+                covered_bindings.insert(binding.to_string());
+            }
+        }
+        for consumer in ["consumer_one", "consumer_two", "consumer_three"] {
+            assert!(
+                covered_bindings.contains(consumer),
+                "expected {consumer} to be absorbed into some ExceedsSizeCap closure; covered: {covered_bindings:?}; rows: {exceeds:#?}",
+            );
+        }
+    }
+
+    /// Targeted coverage for the **oversize-closure skip-walk** in
+    /// `close_frontier`. The skip-walk is observable when two frontier
+    /// starts grow into the *same* owner-set: the first emits an
+    /// `ExceedsSizeCap` row; the second's grown owner-set is wholly
+    /// inside that closure and short-circuits to `Empty`. Pre-fix,
+    /// the second start would either produce a duplicate row (caught
+    /// by dedup) or walk the same edges to produce a sub-closure.
+    ///
+    /// Synthetic frontier starts rarely converge to identical
+    /// owner-sets — different consumers tend to absorb different
+    /// blockers — so this test pins the *invariant* that's still
+    /// observable: whatever closures the analyzer reaches, the report
+    /// emits exactly one row per unique closure. Combined with the
+    /// preceding test (which asserts ExceedsSizeCap actually fires),
+    /// the dedup + skip-walk together guarantee the report is bounded
+    /// by distinct closures, not by starting-unit count.
+    ///
+    /// This test also pins that the report stays consistent when
+    /// closures partially overlap: the dedup key is the *whole* sorted
+    /// owner-set, so an oversize `{A, B, C}` and an oversize
+    /// `{A, B, C, D}` are correctly treated as distinct rows.
+    #[test]
+    fn factorize_emits_distinct_oversize_closures_as_separate_rows() {
+        // Chain shape: consumer_two reads consumer_one + shared deps;
+        // consumer_three reads consumer_two + shared deps. Each
+        // consumer's frontier grows into a distinct closure (consumer
+        // _one's is a strict subset of consumer_two's, etc.). The
+        // dedup key is the full owner-set, so all three rows survive —
+        // but no row duplicates another.
+        let schedule = schedule_for(
+            r#"const dep_a = "left";
+const dep_b = "right";
+function consumer_one() { return dep_a + dep_b; }
+function consumer_two() { return dep_a + dep_b + consumer_one(); }
+function consumer_three() { return dep_a + dep_b + consumer_two(); }"#,
+            &[],
+        )
+        .with_pre_existing_entry_exports(BTreeSet::new());
+        let report = schedule
+            .owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 });
+
+        let exceeds: Vec<&FactorizeDiagnostic> = report
+            .factorize
+            .diagnostics
+            .iter()
+            .filter(|d| d.reason == FactorizeDiagnosticReason::ExceedsSizeCap)
+            .collect();
+        assert!(
+            !exceeds.is_empty(),
+            "chained-consumer fixture should produce at least one ExceedsSizeCap row; got: {:#?}",
+            report.factorize.diagnostics,
+        );
+
+        // Dedup invariant: every row's `(reason, sorted owner_ids)` is
+        // unique. This is the property the skip-walk path also
+        // guarantees on the merit of subset-bailing — the externally
+        // visible part of its contract.
+        let mut keys: BTreeSet<(FactorizeDiagnosticReason, Vec<String>)> = BTreeSet::new();
+        for diagnostic in &report.factorize.diagnostics {
+            let mut owners = diagnostic.owner_ids.clone();
+            owners.sort();
+            assert!(
+                keys.insert((diagnostic.reason, owners.clone())),
+                "duplicate diagnostic key (reason={:?}, owners={:?}) in: {:#?}",
+                diagnostic.reason,
+                owners,
+                report.factorize.diagnostics,
+            );
+        }
+
+        // Distinct owner-sets must remain distinct rows — the dedup
+        // key is the whole sorted set, not a prefix or a hash of
+        // bindings. On this chain we expect each consumer's reachable
+        // closure to surface as its own row.
+        let owner_sets: BTreeSet<Vec<String>> = exceeds
+            .iter()
+            .map(|d| {
+                let mut o = d.owner_ids.clone();
+                o.sort();
+                o
+            })
+            .collect();
+        assert_eq!(
+            owner_sets.len(),
+            exceeds.len(),
+            "ExceedsSizeCap rows should each carry a distinct owner-set: {exceeds:#?}",
+        );
+    }
+
     #[test]
     fn schedule_report_serializes_linker_order_as_snake_case() {
         let schedule = schedule_for(

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -68,6 +68,7 @@ rust_library(
         "peelability_test",
         "owner_graph_purity_reason_test",
         "import_coalescing_test",
+        "factorize_diagnostic_dedup_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/factorize_diagnostic_dedup_test.rs
+++ b/devinfra/js/debundle/e2e/factorize_diagnostic_dedup_test.rs
@@ -1,0 +1,187 @@
+//! End-to-end coverage for the two report-layer fixes in
+//! `analysis::factorize::build_factorize_report`:
+//!
+//! 1. **Diagnostic dedup**: when several residual frontier starts grow
+//!    into the same `(reason, owner-set)` closure (via blocker-driven
+//!    absorption or `close_atomic_units`), only one diagnostic row is
+//!    emitted instead of one per starting unit. Applies to every
+//!    diagnostic reason — `ExceedsSizeCap`, `NoExactRepair`,
+//!    `ActiveModuleConflict`, `RepeatedFrontier`.
+//! 2. **Oversize-closure skip-walk**: once a closure has been emitted
+//!    with reason `ExceedsSizeCap`, any later seed whose unrepaired set
+//!    is wholly inside that closure short-circuits with `Empty` —
+//!    skipping the dependency-graph walk that would re-derive a subset
+//!    or duplicate row.
+//!
+//! These e2e tests drive the full CLI pipeline and assert the dedup
+//! invariant on the emitted `owner_graph.json`. The materializer CLI
+//! uses the analyzer's default `size_cap_lines = 10_000`, so
+//! `ExceedsSizeCap`-flavored diagnostics aren't naturally reachable
+//! from a small synthetic chunk through the CLI — the in-process unit
+//! tests next to `analysis::factorize` (`analysis_tests.rs`) cover the
+//! tight-cap path. Here we pin that:
+//!
+//! * Multi-consumer fixtures produce reports whose
+//!   `factorize.diagnostics` rows obey the `(reason, sorted owner_ids)`
+//!   uniqueness invariant.
+//! * The dedup change does not also suppress legitimate certified
+//!   proposals (shared-prerequisite closure still surfaces).
+//!
+//! ## Limitations of synthetic construction
+//!
+//! Whether any pair of frontier starts naturally produces the same
+//! `(reason, owner-set)` key depends on the residual + active-module
+//! landscape and on `close_atomic_units`'s absorption behaviour. The
+//! invariant we assert is robust to that nondeterminism: every
+//! emitted row's key must be unique, and the regression-guard test
+//! checks the dedup change does not also lose certified cells.
+
+use analysis::{FactorizeDiagnosticReason, OwnerGraphReport, PeelCandidateStatus};
+use debundle_e2e_support::*;
+use serde::de::DeserializeOwned;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> T {
+    serde_json::from_str(
+        &fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("read JSON report {}: {err}", path.display())),
+    )
+    .unwrap_or_else(|err| panic!("parse JSON report {}: {err}", path.display()))
+}
+
+/// Drive the CLI to completion and parse the emitted owner_graph.json.
+fn run_cli_and_load_graph(opts: FixtureOpts<'_>) -> OwnerGraphReport {
+    let fixture = run_fixture(opts);
+    read_json(&fixture.report_root.join("static/app/owner_graph.json"))
+}
+
+/// Post-fix invariant: every diagnostic row has a unique
+/// `(reason, sorted owner_ids)` key.
+fn assert_diagnostic_keys_unique(graph: &OwnerGraphReport) {
+    let mut seen: BTreeSet<(FactorizeDiagnosticReason, Vec<String>)> = BTreeSet::new();
+    for diagnostic in &graph.factorize.diagnostics {
+        let mut owners = diagnostic.owner_ids.clone();
+        owners.sort();
+        assert!(
+            seen.insert((diagnostic.reason, owners.clone())),
+            "duplicate factorize diagnostic key (reason={:?}, owners={:?}) in CLI report; row: {diagnostic:#?}",
+            diagnostic.reason,
+            owners,
+        );
+    }
+}
+
+#[test]
+fn fan_in_multi_consumer_report_has_unique_diagnostic_keys() {
+    // Three residual consumers all read the same two residual
+    // prerequisites. Each consumer is its own atomic unit; each
+    // produces a frontier start; growth pulls in the shared deps.
+    // Pre-fix, frontiers that converge on the same closure produced
+    // duplicate report rows. Post-fix, the
+    // `(reason, sorted owner_ids)` dedup keeps each closure on one
+    // row.
+    //
+    // We assert the dedup *invariant* on the actual CLI-emitted
+    // `owner_graph.json`. The full pipeline must always honour it.
+    let source = r#"const dep_a = "left";
+const dep_b = "right";
+function consumer_one() { return dep_a + dep_b; }
+function consumer_two() { return dep_a + dep_b; }
+function consumer_three() { return dep_a + dep_b; }
+export { consumer_one, consumer_two, consumer_three };
+"#;
+    let mut opts = FixtureOpts::new(
+        source,
+        vec![logical_module("anchors/dep_a", &[Member::new("dep_a")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let graph = run_cli_and_load_graph(opts);
+    assert_diagnostic_keys_unique(&graph);
+}
+
+#[test]
+fn shared_prerequisite_two_consumers_report_has_unique_diagnostic_keys() {
+    // Two residual consumers share one residual prerequisite. The
+    // three frontier starts ({consumer_a}, {consumer_b}, {shared})
+    // visit overlapping owner sets during growth. Whether any two
+    // produce identical `(reason, owner-set)` keys depends on the
+    // residual landscape — the invariant is what's pinned here.
+    let source = r#"const shared = "shared";
+const consumer_a = shared + "/a";
+const consumer_b = shared + "/b";
+export { consumer_a, consumer_b };
+"#;
+    let mut opts = FixtureOpts::new(
+        source,
+        vec![logical_module("anchors/shared", &[Member::new("shared")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let graph = run_cli_and_load_graph(opts);
+    assert_diagnostic_keys_unique(&graph);
+}
+
+#[test]
+fn cycle_megaclass_with_external_consumers_report_has_unique_diagnostic_keys() {
+    // A 3-owner constraining cycle ({A, B, C}) plus two unrelated
+    // consumers that lazily reference members of the cycle. Each
+    // consumer's frontier closes through the cycle's blocker-driven
+    // growth, so multiple starts can converge on the same megaclass
+    // owner-set. The dedup invariant must hold on the report.
+    //
+    // `anchor` is the active logical module; everything else is
+    // residual (the spec rejects all-residual chunks). The cycle
+    // {A, B, C} is one atomic unit and stays residual together, which
+    // matches the materializer's atomic-unit co-location rule.
+    let source = r#"const anchor = "anchor";
+const A = C + 1;
+const B = A + 1;
+const C = B + 1;
+function reader_one() { return A + B; }
+function reader_two() { return B + C; }
+export { anchor, A, B, C, reader_one, reader_two };
+"#;
+    let mut opts = FixtureOpts::new(
+        source,
+        vec![logical_module("anchors/anchor", &[Member::new("anchor")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let graph = run_cli_and_load_graph(opts);
+    assert_diagnostic_keys_unique(&graph);
+}
+
+#[test]
+fn dedup_change_does_not_suppress_certified_shared_prerequisite_cell() {
+    // Regression guard: the dedup change must not drop legitimate
+    // certified proposals. A shared-prerequisite closure that is
+    // already landable today should still surface as one combined
+    // certified cell after the report-layer cleanup.
+    let source = r#"const anchor = "anchor";
+const shared = "shared";
+const consumer_a = shared + "/a";
+const consumer_b = shared + "/b";
+export { anchor, consumer_a, consumer_b };
+"#;
+    let mut opts = FixtureOpts::new(
+        source,
+        vec![logical_module("anchors/anchor", &[Member::new("anchor")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let graph = run_cli_and_load_graph(opts);
+
+    assert!(
+        graph.factorize.cells.iter().any(|cell| {
+            let bindings: BTreeSet<&str> = cell.binding_ids.iter().map(String::as_str).collect();
+            bindings.contains("shared")
+                && bindings.contains("consumer_a")
+                && bindings.contains("consumer_b")
+                && cell.landable_today
+                && cell.status == PeelCandidateStatus::PeelableNow
+        }),
+        "shared-prerequisite closure should still be emitted as a certified cell after dedup change: {:#?}",
+        graph.factorize,
+    );
+
+    assert_diagnostic_keys_unique(&graph);
+}


### PR DESCRIPTION
## Summary

Extends coverage for the report-layer fixes in `build_factorize_report` (diagnostic dedup + oversize-closure skip-walk) with tests that go beyond the pure-invariant check already present in `analysis_tests.rs::factorize_emits_each_diagnostic_closure_once` (which passes both pre- and post-fix because synthetic atomic units rarely converge naturally).

### E2E (new file `devinfra/js/debundle/e2e/factorize_diagnostic_dedup_test.rs`)

Four tests run the full materializer CLI on multi-consumer fixtures and assert the `(reason, sorted owner_ids)` uniqueness invariant on the emitted `owner_graph.json`:

- `fan_in_multi_consumer_report_has_unique_diagnostic_keys` — three residual consumers sharing two prerequisites.
- `shared_prerequisite_two_consumers_report_has_unique_diagnostic_keys` — two consumers sharing one prerequisite.
- `cycle_megaclass_with_external_consumers_report_has_unique_diagnostic_keys` — 3-owner constraining cycle with external readers funneling frontier starts into the same megaclass.
- `dedup_change_does_not_suppress_certified_shared_prerequisite_cell` — regression guard that the dedup change does not also drop legitimate certified proposals.

### Analyzer-direct unit tests (extend `devinfra/js/debundle/analysis_tests.rs`)

These use `owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 })` to actually hit the `ExceedsSizeCap` codepath that the CLI's default 10k cap won't reach:

- `factorize_exceeds_size_cap_rows_cover_all_consumer_starts_without_duplicates` — asserts every consumer's binding appears in some oversize closure, proving the dedup is non-vacuous on this input (not just a tautological invariant).
- `factorize_emits_distinct_oversize_closures_as_separate_rows` — chained-consumer shape where each consumer absorbs a distinct super-closure. Pins that the dedup key is the full owner-set: rows with overlapping but strictly-distinct closures correctly survive as separate diagnostics.

### Limitations of synthetic construction

The `oversize_owners.contains(owner) for all owners` early-bail in `close_frontier` only fires when two frontier starts grow to *identical* owner-sets, which depends on `close_atomic_units` absorption behaviour. Synthetic atomic units rarely converge to identical sets, so this PR pins the externally observable contract (per-closure uniqueness, certified cells preserved) rather than the internal short-circuit count.

## Test plan

- [x] `bazelisk test --config=rbe --config=nolint //devinfra/js/debundle:analysis_test` — 184 tests pass (incl. 3 new dedup tests).
- [x] `bazelisk test --config=rbe --config=nolint //devinfra/js/debundle/...` — 39/39 tests pass (incl. 4 new e2e tests in `factorize_diagnostic_dedup_test`).
- [x] No changes to production `factorize.rs` / `report_schema.rs`; this PR is test-only on top of `claude/tana-re-pipeline-II0sQ`.

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_