### PR TITLE
debundle pipeline: resolve --tree-source-root against execroot

### DIFF
--- a/devinfra/js/debundle/pipeline.bzl
+++ b/devinfra/js/debundle/pipeline.bzl
@@ -39,7 +39,7 @@ def _debundle_pipeline_impl(ctx):
             "--tree-vendor-marks",
             _shell_source_path(paths.join(pkg, ctx.attr.tree_vendor_marks)),
             "--tree-source-root",
-            shell.quote("."),
+            _shell_source_path("."),
             "--out-root",
             shell.quote(out_dir.short_path),
         ]


### PR DESCRIPTION
## Summary

Fix a regression introduced in #1553 (commit 29ed958) that broke the
debundle action when the spec references inputs by workspace-relative
path. The new pipeline.bzl wraps `--tree-config`, `--tree-modules`, and
`--tree-vendor-marks` with `_shell_source_path(...)` (`${OLDPWD}/<path>`)
but passes `--tree-source-root` through plain `shell.quote(".")`. Since
the action `cd`s to `${BAZEL_BINDIR}` before exec, `.` resolves to
`bazel-out/<config>/bin`, not the workspace root. Inputs declared via
`input_data` and staged at workspace-relative paths in execroot are
then not found, e.g.:

```
reading bazel-out/.../debundle.runfiles/./tana/upstream/desktop/snapshots/v1.515.0/js-files.txt
FAILED:
```

The previous (pre-#1553) `_TREE_SOURCE_PATH_FLAGS` map included
`--tree-source-root` so its value picked up the `${OLDPWD}/` wrapper —
the same behavior, restored.

One-line fix in `devinfra/js/debundle/pipeline.bzl`.

## Validation

Gaffer's `//tana/re/web/spec:debundle_78d928dca7` and
`//tana/re/desktop/spec:debundle_v1_515_0` both build green under this
pin (verified via a gaffer-side repin to this commit). Without the fix,
the desktop action fails as quoted above; with the fix, both succeed.

## Test plan

- [x] `bazelisk build //devinfra/js/debundle:all --config=rbe`
- [x] Gaffer-side validation: web + desktop debundle pipelines green
- [x] Gaffer-side: all 3 tana RE tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_