### PR TITLE
augur: roadmap Plan A — browser nested scenario shape into the Pydantic SSOT

### DIFF
--- a/augur/app/BUILD.bazel
+++ b/augur/app/BUILD.bazel
@@ -89,9 +89,20 @@ py_library(
 )
 
 py_library(
+    name = "browser_state_py",
+    srcs = ["browser_state.py"],
+    deps = [
+        "//augur/core:bootstrap_py",
+        "//augur/core:scenario_set_py",
+        "//augur/core:schemas_py",
+    ],
+)
+
+py_library(
     name = "export_schema_py",
     srcs = ["export_schema.py"],
     deps = [
+        ":browser_state_py",
         "//augur/core:bootstrap_py",
         "//augur/core:scenario_set_py",
         "@pypi//fastapi",

--- a/augur/app/browser_state.py
+++ b/augur/app/browser_state.py
@@ -1,0 +1,119 @@
+"""Pydantic models for the augur frontend's nested URL/browser scenario state.
+
+These shapes are the source of truth for the UI-organized layout the React app
+maintains and round-trips through the URL. The wire-facing
+``augur.core.scenario_set.ScenarioSet`` is a *different* shape: flat lists of
+actors, events, and policies derived from this nested input by the frontend's
+``scenarioSetInputToRequest`` mapper. Both shapes need a generated Zod schema;
+the wire shape's came along for free with the SSOT pipeline, this module
+exists so the nested input gets the same treatment instead of being
+hand-maintained in JS via ``SCENARIO_INPUT_SECTION_FIELDS`` /
+``FINANCING_MODE_IDS`` / ``PRIVATE_EQUITY_SALE_POLICY_IDS`` constants.
+
+URL state version (``URL_STATE_VERSION`` in ``scenario_set_state.js``) is the
+contract version for the encoded form. Bumping any field here is a wire-state
+break and demands a version bump.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from augur.core.bootstrap import ActorPolicyId, LiquidReservePolicyId, OwnerResidenceModeId, RentalUsePolicyId
+from augur.core.scenario_set import FinancingMode, MarketRequest, ReportSpec
+from augur.core.schemas import ApiModel
+
+
+class BrowserScenarioIdentity(ApiModel):
+    scenario_id: str
+    label: str
+    enabled: bool
+    color: str
+
+
+class BrowserPropertyAndLocation(ApiModel):
+    property_id: str
+
+
+class BrowserActorsAndOwnership(ApiModel):
+    actor_policy: ActorPolicyId
+    partner_payment_monthly_usd: float
+
+
+class BrowserTimeline(ApiModel):
+    hold_years: float
+
+
+class BrowserFinancing(ApiModel):
+    financing_mode: FinancingMode
+    down_payment_pct: float
+    custom_mortgage_rate: float | None = None
+    custom_mortgage_term_years: float | None = None
+    credit_score: float | None = None
+
+
+class BrowserOccupancyAndRental(ApiModel):
+    owner_residence_mode: OwnerResidenceModeId
+    rental_use_policy: RentalUsePolicyId
+    vacancy_pct: float
+    management_fee_pct: float
+    leasing_fee_pct: float
+    rooms_rented_while_living: float
+    room_rent_monthly_usd: float
+    room_vacancy_pct: float
+
+
+class BrowserPropertyAssumptions(ApiModel):
+    maintenance_pct: float
+    insurance_annual_usd: float
+    depreciable_basis_pct: float
+
+
+class BrowserTaxAccounting(ApiModel):
+    closing_cost_buy_pct: float
+    closing_cost_sell_pct: float
+
+
+class BrowserInitialBalanceSheet(ApiModel):
+    initial_checking_usd: float
+    starting_portfolio_usd: float
+    private_equity_units: float
+
+
+# Browser-side switch for whether the private-equity sale policy is enabled,
+# and which sale rule shape applies. The backend's analogous Pydantic models
+# (``PrivateEquitySalePolicy`` and its ``PrivateEquitySaleRule`` discriminated
+# union) describe the policy *instance* the simulator runs — not the
+# off/on/which-rule selector this enum drives.
+class PrivateEquitySalePolicyId(StrEnum):
+    NONE = "none"
+    LIQUID_NET_WORTH_FLOOR = "liquid_net_worth_floor"
+
+
+class BrowserPolicies(ApiModel):
+    liquid_reserve_policy: LiquidReservePolicyId
+    checking_floor_usd: float
+    checking_sale_amount_usd: float
+    private_equity_sale_policy: PrivateEquitySalePolicyId
+    private_equity_liquid_net_worth_floor_usd: float
+    private_equity_tender_sale_amount_usd: float
+
+
+class BrowserScenarioInput(ApiModel):
+    identity: BrowserScenarioIdentity
+    property_and_location: BrowserPropertyAndLocation
+    actors_and_ownership: BrowserActorsAndOwnership
+    timeline: BrowserTimeline
+    financing: BrowserFinancing
+    occupancy_and_rental: BrowserOccupancyAndRental
+    property_assumptions: BrowserPropertyAssumptions
+    tax_accounting: BrowserTaxAccounting
+    initial_balance_sheet: BrowserInitialBalanceSheet
+    policies: BrowserPolicies
+
+
+class BrowserScenarioSetInput(ApiModel):
+    title: str
+    market_request: MarketRequest
+    report_spec: ReportSpec
+    scenarios: tuple[BrowserScenarioInput, ...]

--- a/augur/app/export_schema.py
+++ b/augur/app/export_schema.py
@@ -7,6 +7,7 @@ import json
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
+from augur.app.browser_state import BrowserScenarioSetInput
 from augur.core.bootstrap import BootstrapResponse
 from augur.core.scenario_set import ScenarioSet, ScenarioSetRunResponse
 
@@ -20,6 +21,15 @@ def create_schema_app() -> FastAPI:
 
     @app.post("/api/scenario_sets/run", response_model=ScenarioSetRunResponse)
     def run_scenario_set(scenario_set: ScenarioSet) -> ScenarioSetRunResponse:
+        raise RuntimeError("schema-only route")
+
+    # Browser-internal nested state shape. Not a real server endpoint; declared
+    # so FastAPI emits BrowserScenarioSetInput (and its section sub-models)
+    # into components.schemas, where the Zod codegen picks them up. The
+    # frontend's URL state and section validators consume the generated
+    # schemas instead of hand-maintaining parallel field lists.
+    @app.post("/api/_browser_state", response_model=BrowserScenarioSetInput, include_in_schema=True)
+    def _browser_state(payload: BrowserScenarioSetInput) -> BrowserScenarioSetInput:
         raise RuntimeError("schema-only route")
 
     @app.get("/healthz", response_class=PlainTextResponse)

--- a/augur/app/lib/BUILD.bazel
+++ b/augur/app/lib/BUILD.bazel
@@ -26,7 +26,10 @@ js_library(
 js_library(
     name = "scenario_set_state",
     srcs = ["scenario_set_state.js"],
-    deps = [":casing"],
+    deps = [
+        ":casing",
+        ":schema_zod",
+    ],
 )
 
 js_test(

--- a/augur/app/lib/scenario_set_state.js
+++ b/augur/app/lib/scenario_set_state.js
@@ -1,4 +1,5 @@
-import { camelizeObjectKeys, decamelizeObjectKeys } from "./casing.js";
+import { camelizeObjectKeys, decamelizeObjectKeys, snakeToCamelKey } from "./casing.js";
+import { zBrowserScenarioInputInput, zFinancingMode, zPrivateEquitySalePolicyId } from "./api/schema.zod.mjs";
 
 export const SCENARIO_COLORS = ["#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed", "#0891b2"];
 
@@ -16,43 +17,9 @@ const DEFAULT_REPORT_SPEC = {
   includeMonthlyColumns: true,
 };
 
-const FINANCING_MODE_IDS = new Set(["cash", "fixed_30", "fixed_15", "custom"]);
-const PRIVATE_EQUITY_SALE_POLICY_IDS = new Set(["none", "liquid_net_worth_floor"]);
-
-const SCENARIO_INPUT_SECTION_FIELDS = Object.freeze({
-  identity: Object.freeze(["scenarioId", "label", "enabled", "color"]),
-  propertyAndLocation: Object.freeze(["propertyId"]),
-  actorsAndOwnership: Object.freeze(["actorPolicy", "partnerPaymentMonthlyUsd"]),
-  timeline: Object.freeze(["holdYears"]),
-  financing: Object.freeze([
-    "financingMode",
-    "downPaymentPct",
-    "customMortgageRate",
-    "customMortgageTermYears",
-    "creditScore",
-  ]),
-  occupancyAndRental: Object.freeze([
-    "ownerResidenceMode",
-    "rentalUsePolicy",
-    "vacancyPct",
-    "managementFeePct",
-    "leasingFeePct",
-    "roomsRentedWhileLiving",
-    "roomRentMonthlyUsd",
-    "roomVacancyPct",
-  ]),
-  propertyAssumptions: Object.freeze(["maintenancePct", "insuranceAnnualUsd", "depreciableBasisPct"]),
-  taxAccounting: Object.freeze(["closingCostBuyPct", "closingCostSellPct"]),
-  initialBalanceSheet: Object.freeze(["initialCheckingUsd", "startingPortfolioUsd", "privateEquityUnits"]),
-  policies: Object.freeze([
-    "liquidReservePolicy",
-    "checkingFloorUsd",
-    "checkingSaleAmountUsd",
-    "privateEquitySalePolicy",
-    "privateEquityLiquidNetWorthFloorUsd",
-    "privateEquityTenderSaleAmountUsd",
-  ]),
-});
+const FINANCING_MODE_IDS = new Set(zFinancingMode.options);
+const PRIVATE_EQUITY_SALE_POLICY_IDS = new Set(zPrivateEquitySalePolicyId.options);
+const SCENARIO_INPUT_SECTIONS = new Set(Object.keys(zBrowserScenarioInputInput.shape).map(snakeToCamelKey));
 
 function finiteNumber(value, defaultValue) {
   const number = Number(value);
@@ -121,7 +88,7 @@ function scenarioIdFromIndex(index) {
 }
 
 export function patchScenarioInputSection(scenario, section, patch) {
-  if (!Object.hasOwn(SCENARIO_INPUT_SECTION_FIELDS, section)) {
+  if (!SCENARIO_INPUT_SECTIONS.has(section)) {
     throw new Error(`Unknown Augur scenario input section: ${section}`);
   }
   return {
@@ -791,6 +758,11 @@ export function decodeScenarioSetUrlState(value) {
   if (!payload.scenario_set_input || typeof payload.scenario_set_input !== "object") {
     throw new Error("Augur scenario URL state is missing scenario_set_input");
   }
+  // Intentionally not parsed against zBrowserScenarioSetInput: the URL stores
+  // a sparse-overrides payload (only fields the user changed away from
+  // bootstrap defaults), and the model marks every section's fields as
+  // required. normalizeScenarioSetInput below materializes the full shape
+  // from URL state + bootstrap defaults and that's what consumers see.
   return camelizeObjectKeys(payload.scenario_set_input);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1557. That PR put the **wire shape** in the Pydantic SSOT;
this one does the same for the augur React app's **nested-UI input shape**
— exactly what `augur/plans/roadmap.md` Plan A asks for:

> Wire `augur/app/lib/scenario_set_state.js` and tests to consume the
> generated Augur OpenAPI/browser schema target instead of hand-maintaining
> boundary field lists and ad hoc object probes. […] If Zod is used, it
> should be generated from the Python schema.

## What's in the SSOT now

New `augur/app/browser_state.py` defines the React app's nested layout as
Pydantic models — one per UI section:

```
BrowserScenarioSetInput
└── scenarios: [BrowserScenarioInput
    ├── identity:               BrowserScenarioIdentity
    ├── property_and_location:  BrowserPropertyAndLocation
    ├── actors_and_ownership:   BrowserActorsAndOwnership
    ├── timeline:               BrowserTimeline
    ├── financing:              BrowserFinancing
    ├── occupancy_and_rental:   BrowserOccupancyAndRental
    ├── property_assumptions:   BrowserPropertyAssumptions
    ├── tax_accounting:         BrowserTaxAccounting
    ├── initial_balance_sheet:  BrowserInitialBalanceSheet
    └── policies:               BrowserPolicies]
```

Reuses backend enums (`FinancingMode`, `ActorPolicyId`,
`RentalUsePolicyId`, `OwnerResidenceModeId`, `LiquidReservePolicyId`)
and types (`MarketRequest`, `ReportSpec`). Adds one new enum,
`PrivateEquitySalePolicyId` (`"none" | "liquid_net_worth_floor"`) — the
browser-side on/off + which-rule selector, distinct from the backend's
`PrivateEquitySalePolicy` policy *instance*.

Exposed via a synthetic `POST /api/_browser_state` in `export_schema.py`
so FastAPI emits the models into `components.schemas` and `@hey-api/openapi-ts`
picks them up automatically.

## What got deleted in JS

`scenario_set_state.js` no longer owns any schema definitions:

| Before                                                       | After                                                                                |
| ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| `SCENARIO_INPUT_SECTION_FIELDS = Object.freeze({…})` (33 lines, camelCase section names + unused field arrays) | `SCENARIO_INPUT_SECTIONS = new Set(Object.keys(zBrowserScenarioInputInput.shape).map(snakeToCamelKey))` (1 line) |
| `FINANCING_MODE_IDS = new Set(["cash", "fixed_30", …])`      | `FINANCING_MODE_IDS = new Set(zFinancingMode.options)`                               |
| `PRIVATE_EQUITY_SALE_POLICY_IDS = new Set(["none", "liquid_net_worth_floor"])` | `PRIVATE_EQUITY_SALE_POLICY_IDS = new Set(zPrivateEquitySalePolicyId.options)`       |

A new UI section, financing mode, or PE sale policy added server-side
propagates to JS validators **without touching the JS**. Adding the wrong
section name to `patchScenarioInputSection` still throws.

## What's explicitly *not* in scope

**URL state validation** (which I almost wired in but bailed on): the URL
stores a sparse-overrides payload — only fields the user changed from
bootstrap defaults persist; `normalizeScenarioSetInput` materializes the
full shape at render time. `zBrowserScenarioSetInput.parse` rejects every
fixture URL because most sections are intentionally missing from the
encoded form. To validate URL state we'd need a separate
"all-fields-optional" shape in Pydantic. Left as a follow-up; the existing
`URL_STATE_VERSION` gate already filters malformed payloads. Comment in
source explains.

The frontend's manual shape adapters (`scenarioToBackendScenario`,
`scenarioActors`, `scenarioEvents`, `scenarioPolicies`, …) also stay —
they're domain logic mapping between two genuinely different shapes, not
schema validation.

## Test plan

- [x] `bb test //augur/app/...` — all 5 targets pass on RBE
  (`browser_shell_test`, `catalog_test`, `config_test`,
  `visual_golden_test`, `scenario_set_state_test`).
- [x] Caught a real shape-mismatch bug during development: my first cut
  also wired `zBrowserScenarioSetInput.parse` into `decodeScenarioSetUrlState`.
  That rejected the `distribution_fan` visual fixture's sparse URL → the
  frontend silently fell back to default scenarios via the existing
  try/catch → PNG size mismatch (1280×3566 vs 1280×3644). Reverted with a
  comment explaining why URL state can't use the strict schema.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_