### PR TITLE
debundle: P-1 splitter — drop inter-sibling Sequenced edges in comma-list var decls

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -1260,7 +1260,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let body = top_level_item_views(&module.body);
         let shadowed = compute_shadowed_globals(&body);
         let graph = ChunkCodeGraph::build(&body, &shadowed, &BTreeSet::new());
-        let var = match body[1].as_module_item() {
+        let var = match body[1].0.as_module_item() {
             ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
             other => panic!("expected VarDecl, got {other:?}"),
         };
@@ -3076,6 +3076,181 @@ mutable = mutable + 1;"#,
         let units = atomic_units_for("let A = 0; function B() { A = 1; }");
         assert_partitions_all_owners(&units, 2);
         assert_eq!(unit_sizes(&units), vec![2]);
+    }
+
+    // --- P-1 comma-chain sibling-Sequenced suppression ------------------------
+    //
+    // Each test below grounds the splitter behavior described in
+    // `oversize_closure_patterns.md` §P-1: side-effecting siblings of
+    // the same `VariableDeclaration` comma-list must not get the
+    // direct `Sequenced` edge that would otherwise chain them, so
+    // every sibling can peel into its own logical module. Reads
+    // across siblings still produce `EagerUse` edges and so still
+    // force co-location when actually warranted.
+
+    #[test]
+    fn comma_chain_sibling_group_propagated_to_facts() {
+        // The split items carry a shared `comma_sibling_group` key
+        // and items outside the comma-list don't.
+        let module = parse("const X = 1; const a = 1, b = 2, c = 3; const Y = 2;");
+        let facts = analyze_facts(&module);
+        let groups: Vec<Option<usize>> = facts
+            .iter()
+            .map(|f| f.comma_sibling_group.map(|o| o.0))
+            .collect();
+        assert_eq!(
+            groups,
+            vec![None, Some(1), Some(1), Some(1), None],
+            "siblings of a single comma-list share a group key; non-comma items have None",
+        );
+    }
+
+    #[test]
+    fn comma_chain_pure_siblings_split_with_data_dep_keeps_co_location() {
+        // Fixture from the task brief: `const a = 1, b = a + 1, c = 99;`.
+        // The splitter should:
+        //   * give `a`, `b`, `c` independent owners,
+        //   * leave `a` and `c` in their own atomic units (no edges
+        //     between them), and
+        //   * keep `b` co-located with `a` because `b` reads `a`.
+        // EagerUse `b → a` is one-way (no cycle), so they stay
+        // singletons too — `b` only co-locates via the partition
+        // step, not via `G_atomic`. So strictly we expect three
+        // singleton units. Verify the read edge and no-edge facts
+        // explicitly on the owner graph.
+        let module = parse("const a = 1, b = a + 1, c = 99;");
+        let facts = analyze_facts(&module);
+        let graph = build_owner_graph(&facts);
+        let a = owner_for_binding(&graph, "a");
+        let b = owner_for_binding(&graph, "b");
+        let c = owner_for_binding(&graph, "c");
+        // `b` reads `a` → exactly one EagerUse edge `b → a`.
+        let b_to_a_edges: Vec<_> = graph
+            .iter_edges()
+            .filter(|e| e.from == b && e.to == a)
+            .collect();
+        assert_eq!(
+            b_to_a_edges.len(),
+            1,
+            "b should have one EagerUse edge to a, got {b_to_a_edges:?}",
+        );
+        assert_eq!(b_to_a_edges[0].reason.kind, DepKind::EagerUse);
+        // `a` and `c` have no edges between them.
+        assert!(
+            graph.iter_edges().all(|e| !(e.from == a && e.to == c)),
+            "no edge a → c expected",
+        );
+        assert!(
+            graph.iter_edges().all(|e| !(e.from == c && e.to == a)),
+            "no edge c → a expected",
+        );
+        // Atomic units: three singletons.
+        let units = compute_atomic_units(&graph);
+        assert_partitions_all_owners(&units, 3);
+        assert_eq!(unit_sizes(&units), vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn comma_chain_pure_siblings_are_independent_atomic_units() {
+        // `const a = 1, b = 2;` — both pure singletons, no reads
+        // across siblings; the splitter should produce two
+        // independent atomic units.
+        let units = atomic_units_for("const a = 1, b = 2;");
+        assert_partitions_all_owners(&units, 2);
+        assert_eq!(unit_sizes(&units), vec![1, 1]);
+    }
+
+    #[test]
+    fn comma_chain_non_pure_siblings_drop_inter_sibling_sequenced_edge() {
+        // The P-1 owner-graph fingerprint: a comma-list of factory
+        // calls. Without `compute_call`'s body, each sibling
+        // classifies non-pure (`unknown_call`), so under the old
+        // builder each sibling would chain `Sequenced` back to the
+        // previous sibling and the chain would block every
+        // diagnostic reaching into the comma-list. The splitter
+        // suppresses those sibling edges.
+        let module = parse(
+            "const before = compute(); const x = compute(), y = compute(), z = compute(); const after = compute();",
+        );
+        let facts = analyze_facts(&module);
+        let graph = build_owner_graph(&facts);
+        let before = owner_for_binding(&graph, "before");
+        let x = owner_for_binding(&graph, "x");
+        let y = owner_for_binding(&graph, "y");
+        let z = owner_for_binding(&graph, "z");
+        let after = owner_for_binding(&graph, "after");
+        let sequenced_edge = |from, to| -> bool {
+            graph
+                .iter_edges()
+                .any(|e| e.from == from && e.to == to && e.reason.kind == DepKind::Sequenced)
+        };
+        // No inter-sibling Sequenced edges.
+        assert!(
+            !sequenced_edge(y, x),
+            "inter-sibling Sequenced edge y → x must be suppressed (P-1)",
+        );
+        assert!(
+            !sequenced_edge(z, y),
+            "inter-sibling Sequenced edge z → y must be suppressed (P-1)",
+        );
+        // Every sibling still sequences back to the pre-group
+        // predecessor `before`, so non-pure ordering with respect to
+        // statements outside the comma-list is preserved.
+        assert!(
+            sequenced_edge(x, before),
+            "first sibling must sequence to the pre-group predecessor",
+        );
+        assert!(
+            sequenced_edge(y, before),
+            "second sibling must sequence to the pre-group predecessor (not to its sibling)",
+        );
+        assert!(
+            sequenced_edge(z, before),
+            "third sibling must sequence to the pre-group predecessor (not to its sibling)",
+        );
+        // The post-group owner sequences to the most recent
+        // non-pure owner (the last sibling), so the chain to
+        // post-group statements is intact.
+        assert!(
+            sequenced_edge(after, z),
+            "post-group owner must sequence to the last sibling, got edges {:?}",
+            graph
+                .iter_edges()
+                .filter(|e| e.from == after)
+                .map(|e| (e.to, e.reason.kind))
+                .collect::<Vec<_>>(),
+        );
+        // Atomic units: every owner is independent (Sequenced
+        // alone never forces co-location).
+        let units = compute_atomic_units(&graph);
+        assert_partitions_all_owners(&units, 5);
+        assert_eq!(unit_sizes(&units), vec![1, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn comma_chain_non_pure_siblings_reading_earlier_sibling_keep_eager_use() {
+        // Mixed case: `b` reads `a` by name. The Sequenced sibling
+        // edge is still suppressed (we don't sequence b → a for
+        // ordering), but the EagerUse edge from b's `eager_reads` is
+        // still emitted because the read is real.
+        let module = parse("const a = compute(), b = a + compute();");
+        let facts = analyze_facts(&module);
+        let graph = build_owner_graph(&facts);
+        let a = owner_for_binding(&graph, "a");
+        let b = owner_for_binding(&graph, "b");
+        let edges_b_to_a: Vec<DepKind> = graph
+            .iter_edges()
+            .filter(|e| e.from == b && e.to == a)
+            .map(|e| e.reason.kind)
+            .collect();
+        assert!(
+            edges_b_to_a.contains(&DepKind::EagerUse),
+            "data-dep read must still produce EagerUse b → a, got {edges_b_to_a:?}",
+        );
+        assert!(
+            !edges_b_to_a.contains(&DepKind::Sequenced),
+            "inter-sibling Sequenced b → a must be suppressed (P-1), got {edges_b_to_a:?}",
+        );
     }
 
     fn partition_summary(schedule: &Schedule) -> Vec<(String, String)> {

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -40,6 +40,24 @@ pub struct StatementFacts {
     pub local_effects: BTreeSet<BindingName>,
     pub purity: Purity,
     pub kind: StatementKind,
+    /// Sibling-group key for multi-declarator `var/let/const`
+    /// comma-lists post-split. All single-declarator facts produced
+    /// from the same original `VariableDeclaration` AST node share
+    /// this key (the [`StatementOrdinal`] of the first sibling).
+    /// Single-declarator statements get `None`.
+    ///
+    /// Consumed by [`crate::graph::build_owner_graph`] to suppress
+    /// the source-order `Sequenced` edge between siblings of the
+    /// same comma-list: each declarator's RHS is evaluated
+    /// left-to-right by JS semantics, but the side effects of one
+    /// sibling never depend on observation by another (they share
+    /// no live state — the sibling's binding doesn't exist until
+    /// after its own initializer runs). The actual data-dependency
+    /// case — declarator N reads a binding declared by an earlier
+    /// declarator — is still captured by the regular `EagerUse`
+    /// edge from declarator N's `eager_reads`, so suppressing the
+    /// `Sequenced` edge does not lose any read constraint.
+    pub comma_sibling_group: Option<StatementOrdinal>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -121,7 +139,7 @@ pub enum StatementKind {
 /// the module a top-level-await module.
 pub fn find_top_level_await(module: &Module) -> Option<StatementOrdinal> {
     let body = top_level_item_views(&module.body);
-    for (ordinal, item) in body.iter().enumerate() {
+    for (ordinal, (item, _group)) in body.iter().enumerate() {
         let mut finder = TopLevelAwaitFinder::default();
         item.as_module_item().visit_with(&mut finder);
         if finder.found {
@@ -177,7 +195,7 @@ where
     let facts = body
         .iter()
         .enumerate()
-        .map(|(ordinal, item)| {
+        .map(|(ordinal, (item, group))| {
             let item = item.as_module_item();
             if top_level_await.is_none() {
                 let mut finder = TopLevelAwaitFinder::default();
@@ -186,7 +204,15 @@ where
                     top_level_await = Some(StatementOrdinal(ordinal));
                 }
             }
-            let mut fact = analyze_item(StatementOrdinal(ordinal), item, &shadowed, hints, &graph);
+            let comma_sibling_group = group.map(StatementOrdinal);
+            let mut fact = analyze_item(
+                StatementOrdinal(ordinal),
+                item,
+                comma_sibling_group,
+                &shadowed,
+                hints,
+                &graph,
+            );
             fact.source_location = source_path.and_then(|source_path| {
                 line_range_for_span(item.span()).map(|(start_line, end_line)| SourceLocation {
                     source_path: source_path.to_string(),
@@ -241,47 +267,54 @@ impl TopLevelItemView<'_> {
 /// single-declarator statements preserving source order; unchanged
 /// statements stay borrowed so the analyzer does not clone the whole
 /// app chunk just to get per-declarator ownership.
-pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<'_>> {
+///
+/// The returned `Option<usize>` per item is the sibling-group key:
+/// `Some(g)` for every single-declarator item produced from a
+/// multi-declarator comma-list (the position of the first sibling in
+/// the output `Vec`), `None` for unsplit items. `analyze_chunk` maps
+/// the key into a `StatementOrdinal` on
+/// [`StatementFacts::comma_sibling_group`].
+pub(crate) fn top_level_item_views(
+    body: &[ModuleItem],
+) -> Vec<(TopLevelItemView<'_>, Option<usize>)> {
     let mut out = Vec::with_capacity(body.len());
+    let push_split_var =
+        |var: &VarDecl,
+         wrap: &dyn Fn(VarDecl) -> ModuleItem,
+         out: &mut Vec<(TopLevelItemView<'_>, Option<usize>)>| {
+            let group = out.len();
+            for decl in &var.decls {
+                let single = VarDecl {
+                    span: decl.span,
+                    ctxt: var.ctxt,
+                    kind: var.kind,
+                    declare: var.declare,
+                    decls: vec![decl.clone()],
+                };
+                out.push((TopLevelItemView::Owned(wrap(single)), Some(group)));
+            }
+        };
     for item in body {
         match item {
             ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) if var.decls.len() > 1 => {
-                for decl in &var.decls {
-                    let single = VarDecl {
-                        span: decl.span,
-                        ctxt: var.ctxt,
-                        kind: var.kind,
-                        declare: var.declare,
-                        decls: vec![decl.clone()],
-                    };
-                    out.push(TopLevelItemView::Owned(ModuleItem::Stmt(Stmt::Decl(
-                        Decl::Var(Box::new(single)),
-                    ))));
-                }
+                let wrap = |v: VarDecl| ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(v))));
+                push_split_var(var.as_ref(), &wrap, &mut out);
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
                 match &export_decl.decl {
                     Decl::Var(var) if var.decls.len() > 1 => {
-                        for decl in &var.decls {
-                            let single = VarDecl {
-                                span: decl.span,
-                                ctxt: var.ctxt,
-                                kind: var.kind,
-                                declare: var.declare,
-                                decls: vec![decl.clone()],
-                            };
-                            out.push(TopLevelItemView::Owned(ModuleItem::ModuleDecl(
-                                ModuleDecl::ExportDecl(ExportDecl {
-                                    span: decl.span,
-                                    decl: Decl::Var(Box::new(single)),
-                                }),
-                            )));
-                        }
+                        let wrap = |v: VarDecl| {
+                            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                                span: v.span,
+                                decl: Decl::Var(Box::new(v)),
+                            }))
+                        };
+                        push_split_var(var.as_ref(), &wrap, &mut out);
                     }
-                    _ => out.push(TopLevelItemView::Borrowed(item)),
+                    _ => out.push((TopLevelItemView::Borrowed(item), None)),
                 }
             }
-            _ => out.push(TopLevelItemView::Borrowed(item)),
+            _ => out.push((TopLevelItemView::Borrowed(item), None)),
         }
     }
     out
@@ -295,14 +328,16 @@ pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<
 /// shadows — `const Math = …` and
 /// `import { Math } from "./userland"` both make `Math.PI` an
 /// Unknown read, not the global constant. See DESIGN.md A8.
-pub(crate) fn compute_shadowed_globals(body: &[TopLevelItemView<'_>]) -> BTreeSet<&'static str> {
+pub(crate) fn compute_shadowed_globals(
+    body: &[(TopLevelItemView<'_>, Option<usize>)],
+) -> BTreeSet<&'static str> {
     let mut shadowed = BTreeSet::new();
     let try_shadow = |name: &str, into: &mut BTreeSet<&'static str>| {
         if let Some(global) = WHITELIST_RECEIVERS.iter().copied().find(|r| *r == name) {
             into.insert(global);
         }
     };
-    for item in body {
+    for (item, _group) in body {
         let item = item.as_module_item();
         for name in collect_declared_names(item) {
             try_shadow(name.as_str(), &mut shadowed);
@@ -324,6 +359,7 @@ pub(crate) fn compute_shadowed_globals(body: &[TopLevelItemView<'_>]) -> BTreeSe
 fn analyze_item(
     ordinal: StatementOrdinal,
     item: &ModuleItem,
+    comma_sibling_group: Option<StatementOrdinal>,
     shadowed: &BTreeSet<&'static str>,
     hints: &AnalysisHints,
     graph: &ChunkCodeGraph,
@@ -356,6 +392,7 @@ fn analyze_item(
         local_effects,
         purity,
         kind,
+        comma_sibling_group,
     }
 }
 

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -400,10 +400,43 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
     // that precision the cross-module S graph would be dense
     // enough to reject realistic specs for trivially pure const
     // sequences.
+    //
+    // Sibling exception (P-1 comma-chain splitter): if two adjacent
+    // non-pure owners both originate from the same source
+    // `VariableDeclaration` comma-list (same `comma_sibling_group`),
+    // skip the direct `Sequenced` edge between them and instead
+    // sequence every sibling back to the same predecessor as the
+    // first sibling of the group. JS evaluates the declarators
+    // left-to-right, but each RHS is a self-contained value
+    // computation: a sibling's side effects don't depend on
+    // observing a prior sibling's side effects (the sibling's
+    // binding doesn't even exist until after its own initializer
+    // returns). The data-dependency case where a later declarator
+    // reads a name introduced by an earlier one is still captured
+    // precisely by the `EagerUse` edge produced from
+    // `eager_reads`. Suppressing the sibling chain drops a stale
+    // at-init-order constraint without losing any read constraint
+    // (same soundness argument as the existing pure-owner filter).
+    // Sequencing all siblings to the pre-group predecessor keeps
+    // each non-pure sibling correctly ordered with respect to
+    // non-pure work that happened before the comma-list. See
+    // `oversize_closure_patterns.md` §P-1.
     let mut previous_side_effect_owner: Option<OwnerId> = None;
+    let mut current_group: Option<StatementOrdinal> = None;
+    let mut group_predecessor: Option<OwnerId> = None;
     for stmt in facts.iter().filter(|s| !s.purity.is_pure()) {
         let from = OwnerId(stmt.ordinal.0);
-        if let Some(to) = previous_side_effect_owner
+        let in_existing_group = stmt
+            .comma_sibling_group
+            .is_some_and(|g| current_group == Some(g));
+        let predecessor = if in_existing_group {
+            group_predecessor
+        } else {
+            current_group = stmt.comma_sibling_group;
+            group_predecessor = previous_side_effect_owner;
+            previous_side_effect_owner
+        };
+        if let Some(to) = predecessor
             && from != to
         {
             raw_edges.push((from, to, EdgeReason::sequenced(stmt.ordinal)));

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -106,7 +106,7 @@ impl ChunkCodeGraph {
     ///    and total work is `O(N · body_size)` for the whole
     ///    chunk regardless of recursion depth.
     pub(crate) fn build(
-        body: &[TopLevelItemView<'_>],
+        body: &[(TopLevelItemView<'_>, Option<usize>)],
         shadowed: &BTreeSet<&'static str>,
         declared_pure: &BTreeSet<String>,
     ) -> Self {
@@ -114,7 +114,7 @@ impl ChunkCodeGraph {
     }
 
     pub(crate) fn build_with_declared_pure_new(
-        body: &[TopLevelItemView<'_>],
+        body: &[(TopLevelItemView<'_>, Option<usize>)],
         shadowed: &BTreeSet<&'static str>,
         declared_pure: &BTreeSet<String>,
         declared_pure_new: &BTreeSet<String>,
@@ -307,7 +307,7 @@ pub enum RedundantPurityReason {
 /// hint counts (single digits per chunk) this is negligible
 /// compared to the per-chunk analysis itself.
 pub(crate) fn detect_redundant_purity_hints(
-    body: &[TopLevelItemView<'_>],
+    body: &[(TopLevelItemView<'_>, Option<usize>)],
     shadowed: &BTreeSet<&'static str>,
     declared_pure: &BTreeSet<String>,
 ) -> Vec<RedundantPurityHint> {
@@ -386,10 +386,10 @@ impl ChunkFunction<'_> {
 }
 
 fn collect_chunk_functions<'a, 'item>(
-    body: &'a [TopLevelItemView<'item>],
+    body: &'a [(TopLevelItemView<'item>, Option<usize>)],
 ) -> Vec<ChunkFunction<'a>> {
     let mut out = Vec::new();
-    for item in body {
+    for (item, _group) in body {
         match item.as_module_item() {
             ModuleItem::Stmt(Stmt::Decl(Decl::Fn(fn_decl))) => push_fn_decl(fn_decl, &mut out),
             ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => push_var_functions(var, &mut out),
@@ -490,13 +490,13 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
 ///
 /// Returns the list of qualified names; the caller registers them as
 /// `ChunkBinding::PlainData` in the graph.
-fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
+fn collect_plain_data_bindings(body: &[(TopLevelItemView<'_>, Option<usize>)]) -> Vec<String> {
     // Aggregate every chunk-top init expression per binding name.
     // The same name can have multiple inits for `var`-bound bindings
     // (`var X = a; var X = b;`); every init must independently pass
     // the plain-literal shape check or the name disqualifies.
     let mut inits_by_name: BTreeMap<String, Vec<(&Expr, VarDeclKind)>> = BTreeMap::new();
-    for item in body {
+    for (item, _group) in body {
         for (name, init, kind) in plain_data_var_candidates(item.as_module_item()) {
             inits_by_name.entry(name).or_default().push((init, kind));
         }
@@ -529,7 +529,7 @@ fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
         disqualified: BTreeSet::new(),
         shadowing_scopes: Vec::new(),
     };
-    for item in body {
+    for (item, _group) in body {
         item.as_module_item().visit_with(&mut scanner);
     }
     let disqualified = scanner.disqualified;


### PR DESCRIPTION
## Summary

Implements the **P-1 `comma_chain_var_decl_eager_sibling_use`** analyzer
improvement from
`devinfra/js/debundle/debug/oversize_closure_patterns.md` (open PR #1560,
research doc).

Top-level `var/let/const` comma-list statements are already pre-split into
one fact per declarator (`facts::top_level_item_views`). However, when the
declarator RHSs are conservatively classified as non-pure (e.g. they call
an unknown helper like `h0(...)` in the doc's owners 5158–5161 fingerprint),
the source-order edge emitter in `graph::build_owner_graph` chained each
sibling to the previous one with a `Sequenced` edge. That edge constrains
init order, so every diagnostic reaching into the comma-list saw the
siblings as one inseparable chain. The doc estimates ~12 celebrity
blockers of this shape each anchor 480+ exceeds-size-cap diagnostics on
Tana web (~800+ total).

### What changes

* `StatementFacts` gains `comma_sibling_group: Option<StatementOrdinal>`,
  populated at the post-split point in `top_level_item_views`. All
  single-declarator facts from the same source `VariableDeclaration` share
  the key.
* `build_owner_graph`'s side-effect-ordering pass tracks the predecessor
  *outside* the current sibling group: every non-pure sibling sequences
  back to that pre-group predecessor instead of to its left sibling. The
  post-group owner still sequences to the most-recent (last) sibling, so
  ordering with respect to statements before and after the comma-list is
  preserved.
* Data-dependency reads across siblings still produce `EagerUse` edges
  (already attributed per-declarator via `eager_reads`), so the case
  where a later sibling reads an earlier sibling's binding by name is
  unchanged.

### Soundness

Each declarator's RHS is a self-contained value computation: a sibling's
binding does not exist until its own initializer returns, so a later
sibling's side effects cannot observe an earlier sibling's side effects
through a JS-language data path. The order edges between siblings encoded
a transitive ordering that isn't needed for ESM realizability — same
argument that exempts pure owners from `S`. Real data deps remain caught
by `EagerUse`.

### Tests

Five new unit tests in `analysis_tests.rs`:

* `comma_chain_sibling_group_propagated_to_facts` — the new field is
  populated correctly for siblings and `None` for non-comma items.
* `comma_chain_pure_siblings_split_with_data_dep_keeps_co_location` —
  the brief's fixture `const a = 1, b = a + 1, c = 99;`: `a` and `c`
  independent, `b → a` via `EagerUse`, three singleton atomic units.
* `comma_chain_pure_siblings_are_independent_atomic_units` —
  `const a = 1, b = 2;` produces two singletons.
* `comma_chain_non_pure_siblings_drop_inter_sibling_sequenced_edge` —
  the P-1 owner-graph fingerprint: a comma-list of unknown calls.
  Verifies sibling `Sequenced` edges are suppressed AND every sibling
  still sequences to the pre-group predecessor AND the post-group owner
  still sequences to the last sibling.
* `comma_chain_non_pure_siblings_reading_earlier_sibling_keep_eager_use`
  — when a non-pure sibling reads an earlier sibling, the `EagerUse`
  edge is still emitted; only the `Sequenced` edge is suppressed.

All 39 existing `//devinfra/js/debundle/...` tests pass with the new
edge-emission rule, including the e2e suite under
`devinfra/js/debundle/e2e/` (notably
`comma_list_owner_split_test`, `sibling_declarator_steal_test`,
`realizability_test`, `peelability_test`).

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` (39/39 pass locally)
- [x] New P-1 unit tests verify the splitter behavior on both pure-RHS
      and impure-RHS comma chains
- [ ] Post-merge: rerun `debundle_agent_cli plan-work` on Tana web to
      confirm the expected ~800 diagnostic drop from the 1,467 baseline
- [ ] Soak with follow-up PRs implementing P-2 / P-3

## Notes

I did not attempt the optional `debundle_agent_cli plan-work` diagnostic
recount in step 7 of the brief — the gaffer repinning isn't reachable from
this worktree without separate setup. The doc-level estimate of 800
diagnostics is based on the celebrity blocker fan-out and should be
verified after merge.

Stays focused on P-1 — does not touch P-2 (trivial-alias purity exception)
or P-7 (table-shape array literal demotion).

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_