### PR TITLE
augur: URL state validation via sparse-overrides Pydantic mirror

### DIFF
--- a/augur/app/browser_state.py
+++ b/augur/app/browser_state.py
@@ -10,6 +10,12 @@ exists so the nested input gets the same treatment instead of being
 hand-maintained in JS via ``SCENARIO_INPUT_SECTION_FIELDS`` /
 ``FINANCING_MODE_IDS`` / ``PRIVATE_EQUITY_SALE_POLICY_IDS`` constants.
 
+Two flavors per section: the strict shape (every field required) describes
+the *normalized* layout the React app operates on after merging URL state
+with bootstrap defaults; the ``…Overrides`` mirror (every field optional)
+describes the sparse-overrides payload the URL actually stores, which lets
+``decodeScenarioSetUrlState`` validate URL state at the Zod boundary.
+
 URL state version (``URL_STATE_VERSION`` in ``scenario_set_state.js``) is the
 contract version for the encoded form. Bumping any field here is a wire-state
 break and demands a version bump.
@@ -19,9 +25,16 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from pydantic import ConfigDict
+
 from augur.core.bootstrap import ActorPolicyId, LiquidReservePolicyId, OwnerResidenceModeId, RentalUsePolicyId
 from augur.core.scenario_set import FinancingMode, MarketRequest, ReportSpec
 from augur.core.schemas import ApiModel
+
+# ---------------------------------------------------------------------------
+# Browser scenario set input — strict shape. Every field present after
+# normalizeScenarioSetInput materializes from URL state + bootstrap defaults.
+# ---------------------------------------------------------------------------
 
 
 class BrowserScenarioIdentity(ApiModel):
@@ -117,3 +130,102 @@ class BrowserScenarioSetInput(ApiModel):
     market_request: MarketRequest
     report_spec: ReportSpec
     scenarios: tuple[BrowserScenarioInput, ...]
+
+
+# ---------------------------------------------------------------------------
+# Browser scenario set input — sparse-overrides shape. What
+# ``encodeScenarioSetUrlState`` actually writes: only the fields the user
+# changed away from bootstrap defaults persist; everything else stays absent
+# and gets re-derived at decode time. Every field is optional at every depth.
+# Unknown keys are silently ignored so old URLs from before a field was added
+# don't blow up newer code.
+# ---------------------------------------------------------------------------
+
+
+class _Overrides(ApiModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+
+class BrowserScenarioIdentityOverrides(_Overrides):
+    scenario_id: str | None = None
+    label: str | None = None
+    enabled: bool | None = None
+    color: str | None = None
+
+
+class BrowserPropertyAndLocationOverrides(_Overrides):
+    property_id: str | None = None
+
+
+class BrowserActorsAndOwnershipOverrides(_Overrides):
+    actor_policy: ActorPolicyId | None = None
+    partner_payment_monthly_usd: float | None = None
+
+
+class BrowserTimelineOverrides(_Overrides):
+    hold_years: float | None = None
+
+
+class BrowserFinancingOverrides(_Overrides):
+    financing_mode: FinancingMode | None = None
+    down_payment_pct: float | None = None
+    custom_mortgage_rate: float | None = None
+    custom_mortgage_term_years: float | None = None
+    credit_score: float | None = None
+
+
+class BrowserOccupancyAndRentalOverrides(_Overrides):
+    owner_residence_mode: OwnerResidenceModeId | None = None
+    rental_use_policy: RentalUsePolicyId | None = None
+    vacancy_pct: float | None = None
+    management_fee_pct: float | None = None
+    leasing_fee_pct: float | None = None
+    rooms_rented_while_living: float | None = None
+    room_rent_monthly_usd: float | None = None
+    room_vacancy_pct: float | None = None
+
+
+class BrowserPropertyAssumptionsOverrides(_Overrides):
+    maintenance_pct: float | None = None
+    insurance_annual_usd: float | None = None
+    depreciable_basis_pct: float | None = None
+
+
+class BrowserTaxAccountingOverrides(_Overrides):
+    closing_cost_buy_pct: float | None = None
+    closing_cost_sell_pct: float | None = None
+
+
+class BrowserInitialBalanceSheetOverrides(_Overrides):
+    initial_checking_usd: float | None = None
+    starting_portfolio_usd: float | None = None
+    private_equity_units: float | None = None
+
+
+class BrowserPoliciesOverrides(_Overrides):
+    liquid_reserve_policy: LiquidReservePolicyId | None = None
+    checking_floor_usd: float | None = None
+    checking_sale_amount_usd: float | None = None
+    private_equity_sale_policy: PrivateEquitySalePolicyId | None = None
+    private_equity_liquid_net_worth_floor_usd: float | None = None
+    private_equity_tender_sale_amount_usd: float | None = None
+
+
+class BrowserScenarioInputOverrides(_Overrides):
+    identity: BrowserScenarioIdentityOverrides | None = None
+    property_and_location: BrowserPropertyAndLocationOverrides | None = None
+    actors_and_ownership: BrowserActorsAndOwnershipOverrides | None = None
+    timeline: BrowserTimelineOverrides | None = None
+    financing: BrowserFinancingOverrides | None = None
+    occupancy_and_rental: BrowserOccupancyAndRentalOverrides | None = None
+    property_assumptions: BrowserPropertyAssumptionsOverrides | None = None
+    tax_accounting: BrowserTaxAccountingOverrides | None = None
+    initial_balance_sheet: BrowserInitialBalanceSheetOverrides | None = None
+    policies: BrowserPoliciesOverrides | None = None
+
+
+class BrowserScenarioSetInputOverrides(_Overrides):
+    title: str | None = None
+    market_request: MarketRequest | None = None
+    report_spec: ReportSpec | None = None
+    scenarios: tuple[BrowserScenarioInputOverrides, ...] | None = None

--- a/augur/app/export_schema.py
+++ b/augur/app/export_schema.py
@@ -7,7 +7,7 @@ import json
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
-from augur.app.browser_state import BrowserScenarioSetInput
+from augur.app.browser_state import BrowserScenarioSetInput, BrowserScenarioSetInputOverrides
 from augur.core.bootstrap import BootstrapResponse
 from augur.core.scenario_set import ScenarioSet, ScenarioSetRunResponse
 
@@ -24,12 +24,16 @@ def create_schema_app() -> FastAPI:
         raise RuntimeError("schema-only route")
 
     # Browser-internal nested state shape. Not a real server endpoint; declared
-    # so FastAPI emits BrowserScenarioSetInput (and its section sub-models)
-    # into components.schemas, where the Zod codegen picks them up. The
-    # frontend's URL state and section validators consume the generated
-    # schemas instead of hand-maintaining parallel field lists.
+    # so FastAPI emits BrowserScenarioSetInput / *Overrides (and their section
+    # sub-models) into components.schemas, where the Zod codegen picks them
+    # up. The frontend's URL state and section validators consume the
+    # generated schemas instead of hand-maintaining parallel field lists.
     @app.post("/api/_browser_state", response_model=BrowserScenarioSetInput, include_in_schema=True)
     def _browser_state(payload: BrowserScenarioSetInput) -> BrowserScenarioSetInput:
+        raise RuntimeError("schema-only route")
+
+    @app.post("/api/_browser_state_overrides", response_model=BrowserScenarioSetInputOverrides, include_in_schema=True)
+    def _browser_state_overrides(payload: BrowserScenarioSetInputOverrides) -> BrowserScenarioSetInputOverrides:
         raise RuntimeError("schema-only route")
 
     @app.get("/healthz", response_class=PlainTextResponse)

--- a/augur/app/lib/scenario_set_state.js
+++ b/augur/app/lib/scenario_set_state.js
@@ -1,5 +1,10 @@
 import { camelizeObjectKeys, decamelizeObjectKeys, snakeToCamelKey } from "./casing.js";
-import { zBrowserScenarioInputInput, zFinancingMode, zPrivateEquitySalePolicyId } from "./api/schema.zod.mjs";
+import {
+  zBrowserScenarioInputInput,
+  zBrowserScenarioSetInputOverridesInput,
+  zFinancingMode,
+  zPrivateEquitySalePolicyId,
+} from "./api/schema.zod.mjs";
 
 export const SCENARIO_COLORS = ["#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed", "#0891b2"];
 
@@ -755,15 +760,7 @@ export function decodeScenarioSetUrlState(value) {
   if (payload?.version !== URL_STATE_VERSION) {
     throw new Error(`Unsupported augur scenario URL state version: ${payload?.version ?? "<missing>"}`);
   }
-  if (!payload.scenario_set_input || typeof payload.scenario_set_input !== "object") {
-    throw new Error("Augur scenario URL state is missing scenario_set_input");
-  }
-  // Intentionally not parsed against zBrowserScenarioSetInput: the URL stores
-  // a sparse-overrides payload (only fields the user changed away from
-  // bootstrap defaults), and the model marks every section's fields as
-  // required. normalizeScenarioSetInput below materializes the full shape
-  // from URL state + bootstrap defaults and that's what consumers see.
-  return camelizeObjectKeys(payload.scenario_set_input);
+  return camelizeObjectKeys(zBrowserScenarioSetInputOverridesInput.parse(payload.scenario_set_input));
 }
 
 export function scenarioSetInputFromUrlSearch(search) {


### PR DESCRIPTION
## Summary

Followup to #1561, which exposed the strict browser scenario shape via
Pydantic but left URL-state validation explicitly unwired (with an inline
comment) because the URL stores a sparse-overrides payload that the strict
shape rejects. This PR adds the matching all-fields-optional mirror so
`decodeScenarioSetUrlState` can validate URL state at the Zod boundary.

## What changed

`augur/app/browser_state.py` now defines, alongside each strict section
model, an `…Overrides` mirror with every field `T | None = None`:

```
BrowserScenarioSetInputOverrides
├── title: str | None
├── market_request: MarketRequest | None      (kept strict — always complete in URL)
├── report_spec: ReportSpec | None            (kept strict — always complete in URL)
└── scenarios: tuple[BrowserScenarioInputOverrides, ...] | None
    └── identity: BrowserScenarioIdentityOverrides | None
        property_and_location: …Overrides | None
        actors_and_ownership: …Overrides | None
        timeline: …Overrides | None
        financing: …Overrides | None
        occupancy_and_rental: …Overrides | None
        property_assumptions: …Overrides | None
        tax_accounting: …Overrides | None
        initial_balance_sheet: …Overrides | None
        policies: …Overrides | None
```

The `_Overrides(ApiModel)` base flips `extra` to `"ignore"` so old URLs
from before a field was added don't blow up newer code, while keeping
`frozen=True`.

Exposed via a synthetic `POST /api/_browser_state_overrides` in
`export_schema.py`. `decodeScenarioSetUrlState` now runs
`zBrowserScenarioSetInputOverridesInput.parse(payload.scenario_set_input)`
before camelizing — malformed URL state surfaces as a clean `ZodError`
caught by the existing try/catch in `augur-app.jsx` and shown as
`urlStateError`.

## Design note

Considered `create_model()` to derive the partials programmatically. The
explicit duplication wins:

- Schema names stay stable for hey-api's codegen (dynamic names confuse
  it).
- Recursion-vs-don't-recurse on backend types (`MarketRequest`,
  `ReportSpec`, which the URL always stores in full) is an obvious choice
  per-field instead of a helper-config quirk.
- File is still ~225 lines.

## Test plan

- [x] `bb test //augur/app/...` — all 5 targets pass on RBE
  (`browser_shell_test`, `catalog_test`, `config_test`, `visual_golden_test`,
  `scenario_set_state_test`).
- [x] Verified the previously-rejecting `distribution_fan` URL fixture
  parses cleanly under the overrides shape (visual_golden_test passes; this
  was the canary regression in #1561).

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_