### PR TITLE
debundle purity: admit `Object.freeze(<literal>)` as Pure (P-7)

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -922,9 +922,106 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         // entry only opens the read path; the call must stay
         // Unknown so the soundness contract holds.
         assert!(!(classify("Object.defineProperty(t, 'k', { value: 1 })")).is_pure());
-        assert!(!(classify("Object.freeze({ x: 1 })")).is_pure());
+        // `Object.freeze({ x: 1 })` is admitted by the P-7
+        // frozen-table-literal rule and is covered by
+        // `object_freeze_frozen_safe_literal_is_pure`. The
+        // general `Object.freeze(<non-literal>)` form remains
+        // Unknown — see `object_freeze_non_literal_arg_stays_unknown`.
         assert!(!(classify("Object.values(o)")).is_pure());
         assert!(!(classify("Object.keys(o)")).is_pure());
+    }
+
+    // --- P-7 `frozen_object_table_literal` ---------------------------------
+    //
+    // `Object.freeze(<frozen-safe literal>)` is admitted as Pure
+    // even though the general `Object.freeze(arg)` form is
+    // Unknown. The literal-only gate is what makes this sound:
+    // the argument is a freshly-constructed ordinary object
+    // (or array) whose own properties are plain data descriptors
+    // with frozen-safe values, so the freeze fires no user code.
+    // See `is_frozen_safe_literal` in `purity.rs` for the full
+    // soundness contract.
+
+    #[test]
+    fn object_freeze_frozen_safe_literal_is_pure() {
+        // Flat object literals with primitive values: the canonical
+        // P-7 shape — a static lookup table of constants.
+        assert!((classify("Object.freeze({})")).is_pure());
+        assert!((classify("Object.freeze({ a: 1, b: 2, c: \"x\" })")).is_pure());
+        assert!((classify("Object.freeze({ a: true, b: false, c: null })")).is_pure());
+        assert!((classify("Object.freeze({ \"quoted-key\": 1, 42: 2 })")).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_nested_literal_is_pure() {
+        // Recursive literal shapes: nested objects and arrays of
+        // primitives stay frozen-safe. The freeze only walks the
+        // outer object's own properties; nested values aren't
+        // themselves frozen, but the *outer* call still fires no
+        // user code, which is what the purity classifier cares
+        // about for residual closure analysis.
+        assert!((classify("Object.freeze({ a: { b: [1, 2, 3] } })")).is_pure());
+        assert!((classify("Object.freeze({ a: [{ b: 1 }, { b: 2 }] })")).is_pure());
+        assert!((classify("Object.freeze([1, 2, [3, 4, [5]]])")).is_pure());
+        // Holes in array literals don't fire user code.
+        assert!((classify("Object.freeze([1, , 3])")).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_non_literal_arg_stays_unknown() {
+        // The general form (any arg shape that could fire user
+        // code or expose shared identity) keeps the Unknown
+        // verdict the original whitelist exclusion guaranteed.
+        // These cover the task's negative cases plus a few
+        // additional hazards.
+        assert!(!(classify("Object.freeze(otherIdentifier)")).is_pure());
+        assert!(!(classify("Object.freeze({ a: someFunc() })")).is_pure());
+        assert!(!(classify("Object.freeze({ a: new C() })")).is_pure());
+        // Identifier-valued props are excluded: the bound value
+        // could be anything (e.g. a Proxy), and freezing the
+        // table doesn't change that — but admitting it here
+        // would also bleed identifier reads into the "no user
+        // code" guarantee. Stay conservative.
+        assert!(!(classify("Object.freeze({ a: someBinding })")).is_pure());
+        // Shorthand and computed keys both fire user code:
+        // shorthand is an identifier read, computed evaluates
+        // an arbitrary expression at property-assignment time.
+        assert!(!(classify("Object.freeze({ a })")).is_pure());
+        assert!(!(classify("Object.freeze({ [k]: 1 })")).is_pure());
+        // Spread props iterate the source object's own keys and
+        // fire `[[Get]]` per key — can run user code.
+        assert!(!(classify("Object.freeze({ ...src, a: 1 })")).is_pure());
+        // Array spreads invoke the source's iterator.
+        assert!(!(classify("Object.freeze([1, ...rest])")).is_pure());
+        // Getters/setters / methods expose callables and
+        // generally fall outside the pure-data-table contract.
+        assert!(!(classify("Object.freeze({ get a() { return 1; } })")).is_pure());
+        assert!(!(classify("Object.freeze({ m() { return 1; } })")).is_pure());
+        // Multi-arg / no-arg / spread-arg forms don't match the
+        // single-literal-arg shape the P-7 rule admits.
+        assert!(!(classify("Object.freeze()")).is_pure());
+        assert!(!(classify("Object.freeze({ a: 1 }, extra)")).is_pure());
+        assert!(!(classify("Object.freeze(...args)")).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_literal_shadowed_object_stays_unknown() {
+        // If `Object` is shadowed at chunk top level (by a
+        // top-level decl or an import specifier per A8), the
+        // P-7 rule must NOT fire — the receiver no longer
+        // resolves to the built-in. This mirrors the existing
+        // shadowing fallback for `PURE_STATIC_CALLS`.
+        assert!(
+            !(classify_with_module("const Object = userland;", "Object.freeze({ a: 1 })"))
+                .is_pure()
+        );
+        assert!(
+            !(classify_with_module(
+                r#"import { Object } from "./userland.js";"#,
+                "Object.freeze({ a: 1, b: 2 })"
+            ))
+            .is_pure()
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -2166,6 +2166,27 @@ fn classify_callee_call(
     {
         return all_args_pure(args, shadowed, declared_pure, graph);
     }
+    // P-7 `frozen_object_table_literal`: `Object.freeze(<frozen-safe
+    // literal>)` is Pure. `Object.freeze` is intentionally absent
+    // from `PURE_STATIC_CALLS` because the general form mutates
+    // its argument (sets `[[Writable]]`/`[[Configurable]]` on
+    // every own property and could fire Proxy traps). The
+    // *literal* form has no such hazard: the argument is a fresh
+    // ordinary object whose own properties are plain data
+    // descriptors with frozen-safe values, so freezing it walks a
+    // statically-known property set with no user-code path. See
+    // `oversize_closure_patterns.md` P-7 for the residual-shrinking
+    // motivation.
+    if let Expr::Member(member) = callee_expr
+        && let Some(("Object", "freeze")) = static_member_pair(member)
+        && !shadowed.contains("Object")
+        && args.len() == 1
+        && let Some(arg) = args.first()
+        && arg.spread.is_none()
+        && is_frozen_safe_literal(&arg.expr)
+    {
+        return Purity::Pure;
+    }
     // `globalCallable(args)` against PURE_GLOBAL_CALLS.
     if let Expr::Ident(ident) = callee_expr
         && let Some(name) = PURE_GLOBAL_CALLS
@@ -2234,6 +2255,96 @@ fn is_primitive_literal(expr: &Expr) -> bool {
             | Expr::Lit(Lit::Null(_))
             | Expr::Lit(Lit::Num(_))
             | Expr::Lit(Lit::BigInt(_)),
+    )
+}
+
+/// True for AST nodes that, when used as the argument to
+/// `Object.freeze(...)`, fire no user-defined code and produce a
+/// fresh frozen value with no shared identity. Pattern P-7 in
+/// `oversize_closure_patterns.md`: large `Object.freeze({...})`
+/// table literals currently produce eager-use edges from every
+/// consumer of the table; admitting them as Pure lets consumers
+/// peel without dragging the table-init closure along.
+///
+/// Soundness contract — every accepted shape must satisfy ALL of:
+///   * Fresh value: the inner expression constructs a new object
+///     (or array) literal — no shared identity with anything else
+///     in the chunk, so subsequent freezing can't be observed via
+///     an alias.
+///   * No user code on construction: every property key is a
+///     non-computed string/number identifier and every property
+///     value is itself frozen-safe (recursively). Computed keys
+///     and getters/setters are rejected because they fire on
+///     property assignment / read; spread properties are rejected
+///     because they iterate the source object (`[[OwnPropertyKeys]]`
+///     + per-key `[[Get]]`) and can fire user code.
+///   * No user code on the freeze itself: `Object.freeze` per
+///     ECMA-262 §20.1.2.6 walks own-property descriptors and sets
+///     `[[Writable]]`/`[[Configurable]]` to false. For a fresh
+///     ordinary object whose own properties are plain data
+///     descriptors (which the recursive shape check above
+///     guarantees), this fires no getter, setter, or proxy trap.
+///   * Conservative on identifiers: we reject `Object.freeze(x)`
+///     (where `x` is some Ident) because the bound value could be
+///     a Proxy, a frozen object with accessor descriptors set up
+///     elsewhere, or otherwise observable. The point of P-7 is to
+///     admit *literal* tables, not arbitrary references.
+///
+/// Excluded by design:
+///   * Identifier expressions (even `undefined` — be safe).
+///   * Template strings, even zero-interpolation: not a `Lit::Str`
+///     AST shape; matches `is_primitive_literal` convention.
+///   * Regex literals: produce fresh `RegExp` objects with
+///     enumerable own props; not strictly unsafe to freeze but
+///     not part of the documented contract — keep conservative.
+///   * Function expressions, classes, member access, calls,
+///     `new`, spreads, getters/setters: any of these could fire
+///     user code during the literal's evaluation.
+fn is_frozen_safe_literal(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(Lit::Str(_))
+        | Expr::Lit(Lit::Bool(_))
+        | Expr::Lit(Lit::Null(_))
+        | Expr::Lit(Lit::Num(_))
+        | Expr::Lit(Lit::BigInt(_)) => true,
+        Expr::Object(obj) => obj.props.iter().all(|prop| match prop {
+            // Spread (`{ ...src }`) iterates `src` and fires
+            // `[[Get]]` per own key — can run user code.
+            PropOrSpread::Spread(_) => false,
+            PropOrSpread::Prop(prop) => match prop.as_ref() {
+                Prop::KeyValue(kv) => {
+                    is_frozen_safe_propname(&kv.key) && is_frozen_safe_literal(&kv.value)
+                }
+                // Shorthand / Assign reference a binding by name
+                // — that's an identifier read, which we exclude
+                // per the soundness contract.
+                Prop::Shorthand(_) | Prop::Assign(_) => false,
+                // Getters/setters/methods are functions — pure to
+                // *define*, but a frozen object containing them
+                // exposes callables to consumers; the table-shape
+                // optimisation is about pure-data tables, so
+                // reject to keep the contract narrow.
+                Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) => false,
+            },
+        }),
+        Expr::Array(arr) => arr.elems.iter().all(|elem| match elem {
+            // Holes (`[1, , 3]`) are fine — they don't fire user
+            // code; the resulting array just has an `empty` slot.
+            None => true,
+            Some(elem) => elem.spread.is_none() && is_frozen_safe_literal(&elem.expr),
+        }),
+        _ => false,
+    }
+}
+
+/// True for property-name shapes that fire no user code when used
+/// as an own-property key on a fresh object literal. Computed
+/// keys are excluded because they evaluate an arbitrary
+/// expression at object-construction time.
+fn is_frozen_safe_propname(name: &PropName) -> bool {
+    matches!(
+        name,
+        PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_)
     )
 }
 


### PR DESCRIPTION
## Summary

Implements **P-7 `frozen_object_table_literal`** from the oversize-closure pattern catalogue in `devinfra/js/debundle/debug/oversize_closure_patterns.md` (PR #1560).

Large `Object.freeze({...})` tables in the bundle currently produce eager-use edges from every consumer because `Object.freeze` is conservatively marked `NotPure` — the general form mutates its argument and could fire Proxy traps. The *literal* form has no such hazard: a freshly constructed ordinary object whose own properties are plain data descriptors with frozen-safe values can be frozen without firing user code. This change admits the literal form as Pure so consumers can refer to the table without dragging the whole init closure into residual.

## Heuristic

`classify_callee_call` (in `devinfra/js/debundle/purity.rs`) gains a single guarded branch right after the existing `PURE_STATIC_CALLS` whitelist check:

```
Object.freeze(<arg>)
  where Object is not shadowed
   and  args.len() == 1, no spread
   and  is_frozen_safe_literal(arg)
  => Purity::Pure
```

`is_frozen_safe_literal` is a recursive helper that accepts:

- Primitive `Lit` (Str/Bool/Null/Num/BigInt) — same set as the existing `is_primitive_literal`.
- `Expr::Object` with **only** `KeyValue` props whose keys are non-computed (`Ident`/`Str`/`Num`/`BigInt`) and whose values are themselves frozen-safe (recursive).
- `Expr::Array` whose elements are either holes (`None`) or non-spread `ExprOrSpread`s with frozen-safe `expr` (recursive).

Rejects (stays `NotPure`):

- Identifier args (`Object.freeze(x)`) — bound value could be a Proxy.
- Shorthand props (identifier read) and computed keys (arbitrary expression).
- Spread props/elements (iterate source, fire `[[Get]]` / `[Symbol.iterator]`).
- Getters/setters/methods (callables in a "pure data" table).
- Function calls, `new`, `Lit::Regex`, template strings, member access.
- Wrong arity (`Object.freeze()` / `Object.freeze({a:1}, extra)` / `Object.freeze(...args)`).
- Shadowed `Object` (top-level decl or import specifier).

Soundness rationale documented inline at the helper's doc-comment; mirrors the existing "Pure-call whitelist soundness" contract in `AGENTS.md`.

## Test cases

Four new tests in `devinfra/js/debundle/analysis_tests.rs`:

- `object_freeze_frozen_safe_literal_is_pure` — flat positives: empty obj, `{a:1,b:2,c:"x"}`, booleans/null, quoted/numeric keys.
- `object_freeze_nested_literal_is_pure` — recursion: `{a: {b: [1,2,3]}}`, mixed obj-in-arr, deeply nested arrays, array holes.
- `object_freeze_non_literal_arg_stays_unknown` — every negative shape from the task brief plus shorthand, computed keys, spreads, getters/methods, arity violations.
- `object_freeze_literal_shadowed_object_stays_unknown` — top-level `const Object = …` and `import { Object } from …` both disable the rule, matching the existing `PURE_STATIC_CALLS` shadowing fallback.

The existing `static_function_ref_object_calls_remain_unknown` test asserted that `Object.freeze({ x: 1 })` was Unknown; updated to point at the new P-7 coverage and dropped that single assertion. All other negative cases in that test (`Object.values(o)`, `Object.keys(o)`, etc.) are unchanged. `unsafe_static_calls_stay_unknown` still pins `Object.freeze(x)` as Unknown — the identifier-arg form is not affected.

Once `Object.freeze(<literal>)` is Pure, the `const X = Object.freeze({...})` declarator picks up `purity: pure` for free via `classify_var_decl_purity`, which lets `Object.freeze`-wrapped command tables, key-binding tables, and i18n tables peel into their own modules.

## Related pre-existing code

- `classify_expr_purity` / `classify_call_purity` / `classify_callee_call` in `devinfra/js/debundle/purity.rs` — purity classifier entry points.
- `PURE_STATIC_FUNCTION_REFS` (line ~1525) — `Object.freeze` is here as a **bare-read** entry but intentionally not in `PURE_STATIC_CALLS` because the general call form is unsafe. P-7 doesn't add it to `PURE_STATIC_CALLS`; it's a narrower literal-only admission with its own gate.
- `is_primitive_literal` — analogous helper for `PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS`; the new `is_frozen_safe_literal` extends the same pattern recursively through object/array literals.
- `static_member_pair` — reused for `Object.freeze` callee detection so the shadowing check stays consistent with the rest of the whitelist.
- The ignored e2e test `inferred_pure_schema_builder_across_modules_emits_no_s_cycle` in `e2e/purity_test.rs` covers a *wrapper-function* version of this pattern (`function schema(spec) { return Object.freeze(spec); }`), which is a different problem — left untouched.

## Test plan

- [x] `bazelisk test --config=rbe //devinfra/js/debundle:all` — all 14 test targets pass; `analysis_test` reports `188 passed; 0 failed; 0 ignored`.
- [x] Four new P-7 tests pass individually (verified with `--test_output=streamed`).
- [x] `rustfmt` pre-commit hook clean.
- [ ] Downstream impact (residual closure shrinkage on the real `78d928dca7` bundle) — to be measured by re-running the debundle pipeline after merge.

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_