### PR TITLE
debundle purity: P-2 — `new DeclaredPureNew(<primitive-literal-args>)` admission

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -1223,25 +1223,124 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         );
     }
 
+    // --- P-2 `singleton_instance_with_listener_blocking_pure_alias` ----------
+    //
+    // The `declared_pure_new` annotation admits
+    // `new <SimpleIdent>(<primitive-literal-args>)` as Pure. The
+    // contract is intentionally narrow: only primitive literals
+    // (string / number / boolean / null / bigint) are allowed as
+    // arguments, because identifier reads, fresh object/array
+    // literals, and member/call expressions can all hide
+    // getters, Proxies, or other user code that would fire when
+    // the constructor coerces them.
+    //
+    // See `oversize_closure_patterns.md` P-2 for the
+    // residual-shrinking motivation and `classify_new_expr_purity`
+    // in `purity.rs` for the implementation.
+
     #[test]
-    fn declared_pure_new_ident_new_classifies_pure_with_pure_args() {
+    fn declared_pure_new_no_args_is_pure() {
+        // `const X = new C();` — the singleton form. Constructor
+        // is annotated `pure_new` so the spec author asserts the
+        // body has no observable side effects.
+        assert!(
+            (classify_with_declared_pure_new("class C { constructor() {} }", "new C()", &["C"]))
+                .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_new_primitive_literal_args_is_pure() {
+        // Primitive-literal args are the strictly-conservative
+        // admission shape: a string + a number can't fire user
+        // code on coercion.
         assert!(
             (classify_with_declared_pure_new(
-                "class PureBox { constructor(value) { globalThis.notAnalyzed = value; } }",
-                "new PureBox({ value: 1, later() { globalThis.later = true; } })",
-                &["PureBox"]
+                "class C { constructor(a, b) {} }",
+                "new C(1, \"x\")",
+                &["C"]
             ))
             .is_pure()
         );
     }
 
     #[test]
-    fn declared_pure_new_requires_pure_args() {
+    fn declared_pure_new_identifier_arg_is_not_pure() {
+        // `new C(otherIdentifier)` — the identifier read could
+        // resolve to a getter, a Proxy-trapped binding, or
+        // anything else with observable side effects when the
+        // constructor accesses it. P-2 rejects this even when
+        // `C` is declared pure-new.
         assert!(
             !(classify_with_declared_pure_new(
-                "class PureBox { constructor(value) { this.value = value; } }",
-                "new PureBox(makeValue())",
-                &["PureBox"]
+                "class C { constructor(value) {} }",
+                "new C(otherIdentifier)",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_new_object_literal_arg_is_not_pure() {
+        // Even a fresh object literal is rejected: an object
+        // property value could be a getter, a method that runs
+        // on enumeration, or a shorthand that names a binding
+        // we have no purity claim over. Strict literal-args
+        // keeps the contract narrow and easy to audit.
+        assert!(
+            !(classify_with_declared_pure_new(
+                "class C { constructor(opts) {} }",
+                "new C({ value: 1 })",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_new_call_arg_is_not_pure() {
+        // A nested call argument is always non-literal; the
+        // call itself can have side effects regardless of `C`'s
+        // purity annotation.
+        assert!(
+            !(classify_with_declared_pure_new(
+                "class C { constructor(value) {} }",
+                "new C(makeValue())",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn undeclared_new_is_not_pure() {
+        // No `declared_pure_new` annotation → fall through to
+        // the default `UnknownNew` verdict. Distinguishes the
+        // P-2 admission from "any zero-arg `new` is pure",
+        // which would be unsound.
+        assert!(
+            !(classify_with_declared_pure_new(
+                "class C { constructor() { globalThis.tag = true; } }",
+                "new C()",
+                &[] // C not in declared_pure_new
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_new_method_chain_is_not_pure() {
+        // `new C().foo()` — even when `new C()` itself is Pure
+        // under P-2, the `.foo()` invocation goes through the
+        // call classifier on a non-whitelisted method shape
+        // (receiver isn't an Ident in `static_member_pair`),
+        // so the overall expression is NotPure.
+        assert!(
+            !(classify_with_declared_pure_new(
+                "class C { constructor() {} foo() { globalThis.tag = true; } }",
+                "new C().foo()",
+                &["C"]
             ))
             .is_pure()
         );
@@ -1249,6 +1348,11 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn declared_pure_new_does_not_apply_to_plain_call() {
+        // The pure-new annotation gates `new C(...)` only.
+        // A plain `C(...)` call does not get admitted because
+        // there's no `[[Construct]]`-vs-`[[Call]]` distinction
+        // in the spec annotation; spec authors who want a
+        // function-call admission use `purity: pure` instead.
         assert!(
             !(classify_with_declared_pure_new(
                 "function PureBox(value) { globalThis.value = value; return { value }; }",

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -1799,7 +1799,10 @@ fn static_member_pair(member: &MemberExpr) -> Option<(&'static str, &'static str
 ///   * No-arg form against `PURE_BUILTIN_NEW_NO_ARGS`.
 ///   * 1-arg Array-literal-iterable form against
 ///     `PURE_BUILTIN_NEW_ARRAY_ITERABLE` (`Set` / `Map`).
-///   * Spec-declared `purity: pure_new` bindings, with all args pure.
+///   * Spec-declared `purity: pure_new` bindings, with every
+///     argument a primitive literal (no spreads, no identifiers,
+///     no nested calls, no object/array literals). See P-2 in
+///     `oversize_closure_patterns.md`.
 ///
 /// Everything else (non-Ident callees, shadowed names, tagged
 /// templates, other arg shapes) falls through to `Unknown`.
@@ -1859,20 +1862,32 @@ fn classify_new_expr_purity(
         .worst(inner);
     }
     if graph.is_declared_pure_new(callee.sym.as_ref()) {
+        // P-2 `singleton_instance_with_listener_blocking_pure_alias`:
+        // admit `new <DeclaredPureNew>(<primitive-literal-args>)`
+        // as Pure. The literal-arg constraint is strictly
+        // narrower than `all_args_pure` — bindings, member
+        // reads, calls, and even fresh object/array literals
+        // can hide getters, Proxies, or side-effecting
+        // expressions on coercion; restricting to primitive
+        // literals (string / number / boolean / null / bigint)
+        // guarantees the constructor's argument evaluation
+        // fires no user code. This matches the conservative
+        // contract documented in P-7 for `Object.freeze(<literal>)`.
         let args = new_expr.args.as_deref().unwrap_or(&[]);
-        let arg_purity = all_args_pure(args, shadowed, declared_pure, graph);
-        if arg_purity.is_pure() {
+        if args
+            .iter()
+            .all(|arg| arg.spread.is_none() && is_primitive_literal(&arg.expr))
+        {
             return Purity::Pure;
         }
         return Purity::from_reason_with_detail(
             PurityRule::UnknownNew,
             new_expr.span,
             format!(
-                "new {}(...) has impure argument(s) despite pure_new annotation",
+                "new {}(...) has non-literal argument(s); P-2 admits only primitive-literal args",
                 callee.sym
             ),
-        )
-        .worst(arg_purity);
+        );
     }
     Purity::from_reason_with_detail(
         PurityRule::UnknownNew,


### PR DESCRIPTION
## Summary

Implements **P-2 `singleton_instance_with_listener_blocking_pure_alias`** from `devinfra/js/debundle/debug/oversize_closure_patterns.md`.

A `pure_new` annotation asserts only that a constructor *body* is side-effect-free; the *arguments* still need to be trivially evaluated for the whole `new` expression to be Pure. The previous check used `all_args_pure`, which admitted any Pure-classified argument — including identifier reads (`Purity::Pure` by default), member expressions, fresh object/array literals with methods, and similar shapes whose evaluation can hide getters, Proxy traps, or other observable behavior on coercion.

P-2 tightens this admission to require every argument be a **primitive literal** (`Lit::Str`/`Lit::Num`/`Lit::Bool`/`Lit::Null`/`Lit::BigInt`, no spreads). This matches the conservative contract P-7 (#1564) documents for `Object.freeze(<literal>)`. Anything else falls through to `UnknownNew` even when the constructor is declared pure-new.

## Shapes now Pure (when `C` ∈ `declared_pure_new`)
- `new C()` — no-arg singleton (the motivating P-2 shape: `const uJ = new cJ();`)
- `new C(1, "x", true, null, 0n)` — any combo of primitive literals

## Shapes now (still) NotPure
- `new C(otherIdentifier)` — identifier read could be a getter/Proxy trap
- `new C({ value: 1 })` — object literal could expose accessors or shorthand identifier reads
- `new C(makeValue())` — nested call may have side effects
- `new C().foo()` — method-chain after `new` goes through the call classifier, which rejects non-whitelisted methods on a non-Ident receiver
- `new C()` where `C` ∉ `declared_pure_new` — no annotation, default `UnknownNew`

## Test plan
- [x] Added 7 P-2 tests in `analysis_tests.rs` (`declared_pure_new_no_args_is_pure`, `..._primitive_literal_args_is_pure`, `..._identifier_arg_is_not_pure`, `..._object_literal_arg_is_not_pure`, `..._call_arg_is_not_pure`, `..._method_chain_is_not_pure`, `undeclared_new_is_not_pure`) plus kept the `..._does_not_apply_to_plain_call` regression. All pass.
- [x] Removed two prior tests whose admission scope (`pure args` rather than `primitive-literal args`) the tightening obsoletes.
- [x] `SKIP=prettier bazelisk test --config=rbe //devinfra/js/debundle:all` — 14/14 green.

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_