### PR TITLE
augur: move location tax defaults from app to core

### DIFF
--- a/augur/app/augur_backend.py
+++ b/augur/app/augur_backend.py
@@ -11,10 +11,10 @@ from augur.app.catalog import build_bootstrap_payload
 from augur.app.config import AugurConfig
 from augur.core.api import simulate_set
 from augur.core.bootstrap import Property
-from augur.core.local_regulation import LocalRegulation, TaxRegime, tax_regimes_for_local_regulation
+from augur.core.local_regulation import scenario_with_location_tax_defaults
 from augur.core.market_bundle import HorizonBoundMarketBundleProvider, MarketBundleProvider
 from augur.core.scenario_engine import MONTHS_PER_YEAR
-from augur.core.scenario_set import OccupancyMode, RentalMode, Scenario, ScenarioSet, ScenarioSetRunResponse
+from augur.core.scenario_set import Scenario, ScenarioSet, ScenarioSetRunResponse
 from augur.core.schemas import ScenarioKnobs
 
 
@@ -82,36 +82,17 @@ class AugurBackend:
                 continue
             property_ = self._property_by_id[property_id]
             location = self._location_by_id[property_.location_id]
-            selection = scenario.property_selection.model_copy(
+            with_catalog_property = scenario.model_copy(
                 update={
-                    "location_id": scenario.property_selection.location_id or property_.location_id,
-                    "local_regulation": scenario.property_selection.local_regulation or location.local_regulation,
-                    "purchase_price_usd": scenario.property_selection.purchase_price_usd
-                    if scenario.property_selection.purchase_price_usd is not None
-                    else property_.price_usd,
-                    "tax_regime": scenario.property_selection.tax_regime
-                    or location.local_regulation.property_tax_regime,
+                    "property_selection": scenario.property_selection.model_copy(
+                        update={
+                            "location_id": scenario.property_selection.location_id or property_.location_id,
+                            "purchase_price_usd": scenario.property_selection.purchase_price_usd
+                            if scenario.property_selection.purchase_price_usd is not None
+                            else property_.price_usd,
+                        }
+                    )
                 }
             )
-            scenarios.append(
-                scenario.model_copy(
-                    update={
-                        "property_selection": selection,
-                        "tax_regimes": _tax_regimes_with_catalog_defaults(scenario, location.local_regulation),
-                    }
-                )
-            )
+            scenarios.append(scenario_with_location_tax_defaults(with_catalog_property, location.local_regulation))
         return scenario_set.model_copy(update={"scenarios": tuple(scenarios)})
-
-
-def _tax_regimes_with_catalog_defaults(scenario: Scenario, local_regulation: LocalRegulation) -> tuple[TaxRegime, ...]:
-    owner_occupied = (
-        scenario.occupancy_plan.occupancy_mode is OccupancyMode.OWNER_LIVES_IN_PROPERTY
-        and scenario.rental_plan.rental_mode is not RentalMode.RENT_WHOLE_PROPERTY
-    )
-    return tax_regimes_for_local_regulation(
-        local_regulation,
-        existing_tax_regimes=scenario.tax_regimes,
-        owner_occupied=owner_occupied,
-        rented=scenario.rental_plan.rental_mode is not RentalMode.NOT_RENTED,
-    )

--- a/augur/core/BUILD.bazel
+++ b/augur/core/BUILD.bazel
@@ -274,6 +274,7 @@ py_test(
         ":local_regulation_py",
         ":market_bundle_test_support_py",
         ":property_tax_py",
+        ":scenario_set_py",
         "@pypi//numpy",
         "@pypi//pydantic",
         "@pypi//pytest",

--- a/augur/core/local_regulation.py
+++ b/augur/core/local_regulation.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from pydantic import Field, NonNegativeFloat, model_validator
 
 from augur.core.schemas import ApiModel, Percentage
+
+if TYPE_CHECKING:
+    # scenario_set imports LocalRegulation/TaxRegime from this module, so the
+    # OccupancyMode/RentalMode imports below have to stay TYPE_CHECKING-only at
+    # module load time and lazy at runtime.
+    from augur.core.scenario_set import OccupancyMode, RentalMode, Scenario
 
 _LOCAL_REGULATION_DATA_PATH = Path(__file__).with_name("local_regulation.yaml")
 _BUILTIN_LOCATION_DATA_PATH = Path(__file__).with_name("builtin_locations.yaml")
@@ -152,13 +158,27 @@ def local_regulation_for_location(location_id: LocationId | str) -> LocalRegulat
     return LOCAL_REGULATION_BY_LOCATION[known_id]
 
 
-def tax_regimes_for_local_regulation(
+def tax_regimes_for_scenario(
     local_regulation: LocalRegulation,
     *,
+    occupancy_mode: OccupancyMode,
+    rental_mode: RentalMode,
     existing_tax_regimes: tuple[TaxRegime, ...] = (),
-    owner_occupied: bool,
-    rented: bool,
 ) -> tuple[TaxRegime, ...]:
+    """Combine a location's modeled tax-regime defaults with scenario-level
+    owner-occupancy and rental signals.
+
+    A property the owner lives in *and* rents whole is treated as an
+    investment property for tax-regime purposes; rooms-rented-while-living
+    keeps the owner-occupied treatment."""
+    # scenario_set imports LocalRegulation/TaxRegime from this module, so
+    # OccupancyMode/RentalMode have to be resolved lazily here.
+    from augur.core.scenario_set import OccupancyMode, RentalMode  # noqa: PLC0415
+
+    owner_occupied = (
+        occupancy_mode is OccupancyMode.OWNER_LIVES_IN_PROPERTY and rental_mode is not RentalMode.RENT_WHOLE_PROPERTY
+    )
+    rented = rental_mode is not RentalMode.NOT_RENTED
     regimes = [
         *existing_tax_regimes,
         *local_regulation.default_tax_regimes,
@@ -170,3 +190,22 @@ def tax_regimes_for_local_regulation(
         regimes.append(TaxRegime.RENTAL_DEPRECIATION)
         regimes.append(TaxRegime.DEPRECIATION_RECAPTURE)
     return tuple(dict.fromkeys(regimes))
+
+
+def scenario_with_location_tax_defaults(scenario: Scenario, local_regulation: LocalRegulation) -> Scenario:
+    """Backfill a scenario's `property_selection.tax_regime` and `tax_regimes`
+    from the location's modeled defaults, leaving any caller-supplied values
+    untouched."""
+    selection = scenario.property_selection.model_copy(
+        update={
+            "tax_regime": scenario.property_selection.tax_regime or local_regulation.property_tax_regime,
+            "local_regulation": scenario.property_selection.local_regulation or local_regulation,
+        }
+    )
+    tax_regimes = tax_regimes_for_scenario(
+        local_regulation,
+        occupancy_mode=scenario.occupancy_plan.occupancy_mode,
+        rental_mode=scenario.rental_plan.rental_mode,
+        existing_tax_regimes=scenario.tax_regimes,
+    )
+    return scenario.model_copy(update={"property_selection": selection, "tax_regimes": tax_regimes})

--- a/augur/core/local_regulation_test.py
+++ b/augur/core/local_regulation_test.py
@@ -13,10 +13,21 @@ from augur.core.local_regulation import (
     _validate_local_regulation_data,
     known_location_id,
     local_regulation_for_location,
-    tax_regimes_for_local_regulation,
+    scenario_with_location_tax_defaults,
+    tax_regimes_for_scenario,
 )
 from augur.core.market_bundle_test_support import constant_market_bundle
 from augur.core.property_tax import monthly_property_tax_usd
+from augur.core.scenario_set import (
+    Actor,
+    ActorRole,
+    NotRentedRentalPlan,
+    OccupancyMode,
+    OccupancyPlan,
+    PropertySelection,
+    RentalMode,
+    Scenario,
+)
 
 
 def _valid_payload() -> dict[str, dict[str, dict[str, object]]]:
@@ -86,12 +97,86 @@ def test_loaded_builtin_regulation_drives_property_tax() -> None:
 def test_loaded_builtin_regulation_drives_tax_regime_defaults() -> None:
     regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
 
-    regimes = tax_regimes_for_local_regulation(regulation, owner_occupied=True, rented=True)
+    regimes = tax_regimes_for_scenario(
+        regulation,
+        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
+        rental_mode=RentalMode.RENT_ROOMS_WHILE_OWNER_LIVES_THERE,
+    )
 
     assert regulation.property_tax_regime is TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX
     assert TaxRegime.SAN_FRANCISCO_TRANSFER_TAX in regimes
     assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION in regimes
     assert TaxRegime.RENTAL_DEPRECIATION in regimes
+    assert TaxRegime.CALIFORNIA_OWNER_OCCUPIED in regimes
+
+
+def test_whole_property_rental_with_owner_residence_treated_as_investment() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+
+    regimes = tax_regimes_for_scenario(
+        regulation, occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_mode=RentalMode.RENT_WHOLE_PROPERTY
+    )
+
+    assert TaxRegime.CALIFORNIA_INVESTMENT_PROPERTY in regimes
+    assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION not in regimes
+    assert TaxRegime.RENTAL_DEPRECIATION in regimes
+
+
+def test_existing_tax_regimes_are_preserved_and_deduplicated() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+
+    regimes = tax_regimes_for_scenario(
+        regulation,
+        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
+        rental_mode=RentalMode.NOT_RENTED,
+        existing_tax_regimes=(TaxRegime.CALIFORNIA_PROP13, TaxRegime.MARE_ISLAND_SPECIAL_ASSESSMENTS),
+    )
+
+    assert TaxRegime.MARE_ISLAND_SPECIAL_ASSESSMENTS in regimes
+    assert regimes.count(TaxRegime.CALIFORNIA_PROP13) == 1
+
+
+def _bare_scenario(
+    *,
+    occupancy_mode: OccupancyMode,
+    rental_plan: NotRentedRentalPlan,
+    tax_regime: TaxRegime | None = None,
+    existing_tax_regimes: tuple[TaxRegime, ...] = (),
+) -> Scenario:
+    return Scenario(
+        scenario_id="fixture",
+        label="Fixture",
+        actors=(Actor(actor_id="owner", label="Owner", role=ActorRole.PRIMARY_OWNER),),
+        property_selection=PropertySelection(tax_regime=tax_regime),
+        occupancy_plan=OccupancyPlan(occupancy_mode=occupancy_mode),
+        rental_plan=rental_plan,
+        tax_regimes=existing_tax_regimes,
+    )
+
+
+def test_scenario_with_location_tax_defaults_backfills_property_tax_regime() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+    scenario = _bare_scenario(occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_plan=NotRentedRentalPlan())
+
+    enriched = scenario_with_location_tax_defaults(scenario, regulation)
+
+    assert enriched.property_selection.tax_regime is TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX
+    assert enriched.property_selection.local_regulation == regulation
+    assert TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX in enriched.tax_regimes
+    assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION in enriched.tax_regimes
+
+
+def test_scenario_with_location_tax_defaults_preserves_caller_overrides() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+    scenario = _bare_scenario(
+        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
+        rental_plan=NotRentedRentalPlan(),
+        tax_regime=TaxRegime.VALLEJO_PROPERTY_TAX,
+    )
+
+    enriched = scenario_with_location_tax_defaults(scenario, regulation)
+
+    assert enriched.property_selection.tax_regime is TaxRegime.VALLEJO_PROPERTY_TAX
 
 
 def test_local_regulation_data_requires_all_builtin_locations() -> None:


### PR DESCRIPTION
## Summary

Implements [Plan F from `augur/plans/roadmap.md`](https://github.com/agentydragon/ducktape/blob/devel/augur/plans/roadmap.md): tax-regime defaults and the scenario → tax-regime derivation now live in `augur.core.local_regulation`; the app/server layer is a pure consumer.

### What moved

- `tax_regimes_for_local_regulation(owner_occupied: bool, rented: bool, …)` is gone. In its place, `tax_regimes_for_scenario(occupancy_mode: OccupancyMode, rental_mode: RentalMode, …)` lives in `augur/core/local_regulation.py` and owns the scenario-enum → owner-occupied/rented derivation (e.g. owner-residence + rent-whole = investment treatment) so the rule sits next to the regimes it produces.
- New `scenario_with_location_tax_defaults(scenario, local_regulation)` (also in `augur/core/local_regulation.py`) backfills `scenario.property_selection.tax_regime`, `scenario.property_selection.local_regulation`, and `scenario.tax_regimes` from the modeled location defaults.

### Before / after

Before, `AugurBackend._scenario_set_with_catalog_defaults` reached into `location.local_regulation.property_tax_regime` to backfill `tax_regime`, and a sibling helper `_tax_regimes_with_catalog_defaults` translated `Scenario` → booleans → `tax_regimes_for_local_regulation` to backfill `tax_regimes`.

After, the backend keeps only catalog-specific concerns (resolve property_id → location, backfill `purchase_price_usd` and `location_id` from `Property`) and delegates the entire tax-defaults step to `scenario_with_location_tax_defaults(scenario, location.local_regulation)`. The app no longer encodes any tax semantics — owner-occupied/rented derivation and the property-tax-regime backfill all live in core.

### Tests

- New behavior tests in `augur/core/local_regulation_test.py` cover `tax_regimes_for_scenario` under different occupancy/rental modes (rooms-while-living, rent-whole override into investment treatment, dedup of caller-supplied existing regimes) and `scenario_with_location_tax_defaults` (backfill + override preservation).
- Existing `augur/app/catalog_test.py::test_backend_applies_location_tax_defaults_to_scenario` still passes — it exercises the catalog/backend output end-to-end and proves the behavior is preserved through the refactor.

### Local-regulation lib BUILD

No new dep declared on `local_regulation_py` — the `OccupancyMode`/`RentalMode` import is function-local (`# noqa: PLC0415`) to avoid the runtime cycle with `scenario_set_py`. The test target picks up `:scenario_set_py` for the new behavior tests.

## Validation

```bash
bbr test //augur/app:catalog_test //augur/app:config_test //augur/core:local_regulation_test //augur/core:scenario_set_test --nocache_test_results
# 4 tests pass — invocation 946087ef-c9a1-4d80-9128-52f82ca60baf

bbr test //augur/app:browser_shell_test //augur/core:test_e2e --nocache_test_results
# 2 tests pass — invocation 82d10e1e-5f61-4f64-8944-dda8a3cf5bad
```

## Test plan

- [x] `//augur/app:catalog_test` passes (catalog output, end-to-end backend tax-defaults application)
- [x] `//augur/app:config_test` passes
- [x] `//augur/core:local_regulation_test` passes (new behavior tests)
- [x] `//augur/core:scenario_set_test` passes
- [x] `//augur/app:browser_shell_test` smoke-tests pass
- [x] `//augur/core:test_e2e` passes
- [ ] CI on the PR is green

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_