### PR TITLE
augur: identify PE tender opportunities and policy rules in result rows

### DIFF
--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -72,6 +72,7 @@ from augur.core.scenario_set import (
     CheckingFloorSellPublicStockPolicy,
     FailureEventType,
     FinancingMode,
+    FixedAmountPrivateEquitySaleRule,
     FundingDecisionType,
     FundingSourceType,
     GenericSp500StockPosition,
@@ -92,6 +93,7 @@ from augur.core.scenario_set import (
     PrivateEquitySaleDecisionReason,
     PrivateEquitySaleOpportunityObservation,
     PrivateEquitySalePolicy,
+    PrivateEquitySaleRule,
     PropertyPurchaseEvent,
     PropertySaleBasisGainDetail,
     RentalMode,
@@ -1354,7 +1356,10 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             source_holding_id=private_equity_source_holding_id,
         )
         _record_private_equity_sale_opportunity_observations(
-            market_observations, month_index=int(month_index[month]), opportunity=market_opportunity
+            market_observations,
+            month_index=int(month_index[month]),
+            source_asset_id=private_equity_source_holding_id,
+            opportunity=market_opportunity,
         )
         market_sale_opportunity_value = market_opportunity.sale_opportunity_value_usd
         private_equity_sale_month = np.zeros(rollout_count, dtype="float64")
@@ -1413,6 +1418,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
                     policy_decisions,
                     month_index=int(month_index[month]),
                     policy_step=policy_step,
+                    source_asset_id=private_equity_source_holding_id,
                     instruction=sale_instruction,
                     opportunity=current_opportunity,
                     liquid_net_worth_usd=liquid_net_worth,
@@ -2184,7 +2190,11 @@ def _market_path_observations(
 
 
 def _record_private_equity_sale_opportunity_observations(
-    records: list[SimulationMarketObservation], *, month_index: int, opportunity: PrivateEquitySaleOpportunityBatch
+    records: list[SimulationMarketObservation],
+    *,
+    month_index: int,
+    source_asset_id: str,
+    opportunity: PrivateEquitySaleOpportunityBatch,
 ) -> None:
     active_rollouts = np.nonzero(opportunity.sale_opportunity_mask)[0].tolist()
     records.extend(
@@ -2192,6 +2202,7 @@ def _record_private_equity_sale_opportunity_observations(
             PrivateEquitySaleOpportunityObservation(
                 rollout_index=rollout_index,
                 month_index=month_index,
+                source_asset_id=source_asset_id,
                 opportunity_id=str(opportunity.opportunity_id[rollout_index]),
                 opportunity_cause_id=str(opportunity.opportunity_cause_id[rollout_index]),
                 sale_opportunity_value_usd=float(opportunity.sale_opportunity_value_usd[rollout_index]),
@@ -2266,6 +2277,7 @@ def _record_private_equity_sale_decisions(
     *,
     month_index: int,
     policy_step: ActorPolicyStep[Policy],
+    source_asset_id: str,
     instruction: PrivateEquitySaleInstructionBatch,
     opportunity: PrivateEquitySaleOpportunityBatch,
     liquid_net_worth_usd: np.ndarray,
@@ -2278,6 +2290,8 @@ def _record_private_equity_sale_decisions(
         if isinstance(policy.sale_rule, LiquidNetWorthFloorPrivateEquitySaleRule)
         else None
     )
+    sale_rule_type = policy.sale_rule.sale_rule_type
+    configured_sale_amount_usd = _private_equity_configured_sale_amount_usd(policy.sale_rule)
     records.extend(
         (
             PrivateEquitySaleDecision(
@@ -2290,6 +2304,9 @@ def _record_private_equity_sale_decisions(
                     requested_amount_usd=instruction.requested_amount_usd[rollout_index],
                     sale_opportunity_value_usd=opportunity.sale_opportunity_value_usd[rollout_index],
                 ),
+                source_asset_id=source_asset_id,
+                sale_rule_type=sale_rule_type,
+                configured_sale_amount_usd=configured_sale_amount_usd,
                 opportunity_id=instruction.opportunity_id[rollout_index],
                 opportunity_cause_id=str(instruction.opportunity_cause_id[rollout_index]),
                 requested_amount_usd=float(instruction.requested_amount_usd[rollout_index]),
@@ -2304,6 +2321,14 @@ def _record_private_equity_sale_decisions(
         )
         for rollout_index in range(instruction.requested_amount_usd.shape[0])
     )
+
+
+def _private_equity_configured_sale_amount_usd(sale_rule: PrivateEquitySaleRule) -> float:
+    if isinstance(sale_rule, FixedAmountPrivateEquitySaleRule):
+        return float(sale_rule.amount_usd)
+    if isinstance(sale_rule, LiquidNetWorthFloorPrivateEquitySaleRule):
+        return float(sale_rule.sale_amount_usd)
+    raise TypeError(f"unsupported private equity sale rule: {sale_rule!r}")
 
 
 def _private_equity_sale_decision_reason(

--- a/augur/core/scenario_engine_test.py
+++ b/augur/core/scenario_engine_test.py
@@ -23,6 +23,8 @@ from augur.core.scenario_set import (
     PayMortgageAction,
     PrivateEquitySaleDecision,
     PrivateEquitySaleDecisionReason,
+    PrivateEquitySaleOpportunityObservation,
+    PrivateEquitySaleRuleType,
     ReportMetric,
     RolloutStatusType,
     ScenarioSet,
@@ -1254,6 +1256,12 @@ def test_private_equity_fixed_sale_into_cash_requires_opportunity_and_policy() -
         and decision.decision_reason is PrivateEquitySaleDecisionReason.SALE_REQUESTED
     ]
     assert len(sale_decisions) == 2
+    assert {decision.source_asset_id for decision in sale_decisions} == {"private_equity"}
+    assert {decision.sale_rule_type for decision in sale_decisions} == {
+        PrivateEquitySaleRuleType.FIXED_AMOUNT_ON_OPPORTUNITY
+    }
+    assert {decision.configured_sale_amount_usd for decision in sale_decisions} == {20_000}
+    assert {decision.target_liquid_net_worth_floor_usd for decision in sale_decisions} == {None}
     for decision in sale_decisions:
         expected_opportunity_id = (
             f"{market_bundle.metadata.path_set_id}:path:{decision.rollout_index}:month:1:"
@@ -1337,11 +1345,23 @@ def test_private_equity_liquid_net_worth_floor_policy_sells_to_sp500_on_opportun
     assert {decision.target_liquid_net_worth_floor_usd for decision in sale_decisions} == {125_000}
     assert_allclose([decision.liquid_net_worth_usd for decision in sale_decisions], [120_000, 120_000])
     assert_allclose([decision.sale_opportunity_value_usd for decision in sale_decisions], [50_000, 50_000])
+    assert {decision.source_asset_id for decision in sale_decisions} == {"private_equity"}
+    assert {decision.sale_rule_type for decision in sale_decisions} == {
+        PrivateEquitySaleRuleType.LIQUID_NET_WORTH_FLOOR
+    }
+    assert {decision.configured_sale_amount_usd for decision in sale_decisions} == {20_000}
     for decision in sale_decisions:
         assert decision.opportunity_id == (
             f"{market_bundle.metadata.path_set_id}:path:{decision.rollout_index}:month:1:"
             "private_equity_holding:private_equity:sale_opportunity"
         )
+    opportunity_observations = [
+        obs
+        for obs in result.market_observations
+        if isinstance(obs, PrivateEquitySaleOpportunityObservation) and obs.month_index == 1
+    ]
+    assert len(opportunity_observations) == 2
+    assert {obs.source_asset_id for obs in opportunity_observations} == {"private_equity"}
 
 
 def test_private_equity_liquid_net_worth_floor_records_policy_not_triggered() -> None:
@@ -1382,6 +1402,9 @@ def test_private_equity_liquid_net_worth_floor_records_policy_not_triggered() ->
     assert_allclose(result.liquid_net_worth_usd[:, 1], [120_000, 120_000])
     assert_allclose([decision.sale_opportunity_value_usd for decision in decisions], [50_000, 50_000])
     assert_allclose([decision.liquid_net_worth_usd for decision in decisions], [120_000, 120_000])
+    assert {decision.source_asset_id for decision in decisions} == {"private_equity"}
+    assert {decision.sale_rule_type for decision in decisions} == {PrivateEquitySaleRuleType.LIQUID_NET_WORTH_FLOOR}
+    assert {decision.configured_sale_amount_usd for decision in decisions} == {20_000}
     for decision in decisions:
         expected_opportunity_id = (
             f"{market_bundle.metadata.path_set_id}:path:{decision.rollout_index}:month:1:"

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -515,6 +515,13 @@ class SellPublicStockDecision(_SimulationPolicyDecisionBase):
 class PrivateEquitySaleDecision(_SimulationPolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.PRIVATE_EQUITY_SALE] = PolicyDecisionType.PRIVATE_EQUITY_SALE
     decision_reason: PrivateEquitySaleDecisionReason
+    source_asset_id: str = Field(description="Private-equity holding the policy targeted.")
+    sale_rule_type: PrivateEquitySaleRuleType = Field(
+        description="Rule variant the policy applied to this opportunity (lets the trajectory view explain the reason)."
+    )
+    configured_sale_amount_usd: float = Field(
+        description="Rule-configured sale amount in USD. Equal to amount_usd for fixed rules and sale_amount_usd for the liquid-net-worth-floor rule."
+    )
     opportunity_id: str | None = None
     opportunity_cause_id: str
     requested_amount_usd: float
@@ -558,6 +565,7 @@ class PrivateEquitySaleOpportunityObservation(_SimulationMarketObservationBase):
     observation_type: Literal[MarketObservationType.PRIVATE_EQUITY_SALE_OPPORTUNITY] = (
         MarketObservationType.PRIVATE_EQUITY_SALE_OPPORTUNITY
     )
+    source_asset_id: str = Field(description="Private-equity holding that produced this tender opportunity.")
     opportunity_id: str
     opportunity_cause_id: str
     sale_opportunity_value_usd: float

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -47,6 +47,7 @@ from augur.core.scenario_set import (
     PrivateEquitySaleDecisionReason,
     PrivateEquitySaleOpportunityObservation,
     PrivateEquitySalePolicy,
+    PrivateEquitySaleRuleType,
     PropertyAssumptions,
     PropertySaleBasisGainDetail,
     PropertySaleEvent,
@@ -1248,6 +1249,11 @@ def test_private_equity_tender_sale_into_cash_increases_only_actual_liquid_asset
     assert {decision.decision_reason for decision in no_opportunity_decisions} == {
         PrivateEquitySaleDecisionReason.NO_SALE_OPPORTUNITY
     }
+    assert {decision.source_asset_id for decision in no_opportunity_decisions} == {"pe"}
+    assert {decision.sale_rule_type for decision in no_opportunity_decisions} == {
+        PrivateEquitySaleRuleType.FIXED_AMOUNT_ON_OPPORTUNITY
+    }
+    assert {decision.configured_sale_amount_usd for decision in no_opportunity_decisions} == {100_000}
     assert no_opportunity_decisions[-1].requested_amount_usd == 0
     assert no_opportunity_decisions[-1].sale_opportunity_value_usd == 0
     assert no_opportunity_decisions[-1].opportunity_id is None
@@ -1280,6 +1286,7 @@ def test_private_equity_tender_sale_into_cash_increases_only_actual_liquid_asset
     opportunity_observations = rollout.market_observations(PrivateEquitySaleOpportunityObservation)
     assert len(opportunity_observations) == 1
     assert opportunity_observations[0].month_index == 12
+    assert opportunity_observations[0].source_asset_id == "pe"
     expected_opportunity_id = (
         f"{opportunity_observations[0].path_set_id}:path:0:month:12:private_equity_holding:pe:sale_opportunity"
     )
@@ -1290,6 +1297,9 @@ def test_private_equity_tender_sale_into_cash_increases_only_actual_liquid_asset
         decision for decision in result.policy_decisions(PrivateEquitySaleDecision) if decision.month_index == 12
     )
     assert pe_decision.decision_reason is PrivateEquitySaleDecisionReason.SALE_REQUESTED
+    assert pe_decision.source_asset_id == "pe"
+    assert pe_decision.sale_rule_type is PrivateEquitySaleRuleType.FIXED_AMOUNT_ON_OPPORTUNITY
+    assert pe_decision.configured_sale_amount_usd == 100_000
     assert pe_decision.opportunity_id == expected_opportunity_id
     assert pe_decision.opportunity_cause_id == expected_opportunity_id
     assert pe_decision.requested_amount_usd == 100_000


### PR DESCRIPTION
## Summary

Plan B improvements for augur: make private-equity tender opportunities and policy decisions self-describing in result rows, so the trajectory view can explain each tender without consulting policy state separately.

- `PrivateEquitySaleOpportunityObservation` gains `source_asset_id` — every emitted market observation now identifies which PE holding produced the tender opportunity. Combined with the existing `opportunity_id` / `opportunity_cause_id`, each opportunity row is a stable, identified record.
- `PrivateEquitySaleDecision` gains three context fields:
  - `source_asset_id` — the PE holding the policy targeted.
  - `sale_rule_type` (`fixed_amount_on_opportunity` | `liquid_net_worth_floor`) — the rule variant applied.
  - `configured_sale_amount_usd` — the rule-configured sale amount (`amount_usd` for fixed rules, `sale_amount_usd` for the LNW-floor rule).
- Combined with the existing `decision_reason`, `liquid_net_worth_usd`, and `target_liquid_net_worth_floor_usd` fields, sale (`SALE_REQUESTED`) and non-sale (`NO_SALE_OPPORTUNITY`, `POLICY_NOT_TRIGGERED`) rows now carry enough context to explain each tender.
- `liquid_net_worth_usd` remains cash plus public liquid securities. New PE context fields refer only to PE concepts; nothing else is called "liquid."

See `augur/plans/roadmap.md` "Plan B: Make Private-Equity Opportunities And Policy Explicit".

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/app:browser_shell_test --nocache_test_results` — 3/3 pass (invocation `676b2f3b-2e87-4c83-9142-c9a18d44a078`)
- [x] `bbr test //augur/app:visual_golden_test --nocache_test_results` — pass, no golden PNG change needed (invocation `37e32fb0-ddfb-434e-a3ac-eea49f6cdbd2`)
- [x] `bbr test //augur/...` — 27/27 pass (invocation `a2eb6fb7-d074-4aa2-9b51-c2f87863491d`)
- [x] `bbr build //augur/...` — completes successfully, lint clean

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_