### PR TITLE
augur/core: split scenario_tax_defaults out so local_regulation stays a leaf

### DIFF
--- a/augur/app/BUILD.bazel
+++ b/augur/app/BUILD.bazel
@@ -66,10 +66,10 @@ py_library(
         ":config_py",
         "//augur/core:api_py",
         "//augur/core:bootstrap_py",
-        "//augur/core:local_regulation_py",
         "//augur/core:market_bundle_py",
         "//augur/core:scenario_engine_py",
         "//augur/core:scenario_set_py",
+        "//augur/core:scenario_tax_defaults_py",
         "//augur/core:schemas_py",
     ],
 )

--- a/augur/app/augur_backend.py
+++ b/augur/app/augur_backend.py
@@ -11,10 +11,10 @@ from augur.app.catalog import build_bootstrap_payload
 from augur.app.config import AugurConfig
 from augur.core.api import simulate_set
 from augur.core.bootstrap import Property
-from augur.core.local_regulation import scenario_with_location_tax_defaults
 from augur.core.market_bundle import HorizonBoundMarketBundleProvider, MarketBundleProvider
 from augur.core.scenario_engine import MONTHS_PER_YEAR
 from augur.core.scenario_set import Scenario, ScenarioSet, ScenarioSetRunResponse
+from augur.core.scenario_tax_defaults import scenario_with_location_tax_defaults
 from augur.core.schemas import ScenarioKnobs
 
 

--- a/augur/core/BUILD.bazel
+++ b/augur/core/BUILD.bazel
@@ -72,6 +72,15 @@ py_library(
 )
 
 py_library(
+    name = "scenario_tax_defaults_py",
+    srcs = ["scenario_tax_defaults.py"],
+    deps = [
+        ":local_regulation_py",
+        ":scenario_set_py",
+    ],
+)
+
+py_library(
     name = "market_bundle_py",
     srcs = ["market_bundle.py"],
     deps = [
@@ -274,10 +283,20 @@ py_test(
         ":local_regulation_py",
         ":market_bundle_test_support_py",
         ":property_tax_py",
-        ":scenario_set_py",
         "@pypi//numpy",
         "@pypi//pydantic",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "scenario_tax_defaults_test",
+    srcs = ["scenario_tax_defaults_test.py"],
+    deps = [
+        ":local_regulation_py",
+        ":scenario_set_py",
+        ":scenario_tax_defaults_py",
         "@pypi//pytest_bazel",
     ],
 )

--- a/augur/core/local_regulation.py
+++ b/augur/core/local_regulation.py
@@ -2,18 +2,12 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import yaml
 from pydantic import Field, NonNegativeFloat, model_validator
 
 from augur.core.schemas import ApiModel, Percentage
-
-if TYPE_CHECKING:
-    # scenario_set imports LocalRegulation/TaxRegime from this module, so the
-    # OccupancyMode/RentalMode imports below have to stay TYPE_CHECKING-only at
-    # module load time and lazy at runtime.
-    from augur.core.scenario_set import OccupancyMode, RentalMode, Scenario
 
 _LOCAL_REGULATION_DATA_PATH = Path(__file__).with_name("local_regulation.yaml")
 _BUILTIN_LOCATION_DATA_PATH = Path(__file__).with_name("builtin_locations.yaml")
@@ -158,27 +152,16 @@ def local_regulation_for_location(location_id: LocationId | str) -> LocalRegulat
     return LOCAL_REGULATION_BY_LOCATION[known_id]
 
 
-def tax_regimes_for_scenario(
+def tax_regimes_for_local_regulation(
     local_regulation: LocalRegulation,
     *,
-    occupancy_mode: OccupancyMode,
-    rental_mode: RentalMode,
     existing_tax_regimes: tuple[TaxRegime, ...] = (),
+    owner_occupied: bool,
+    rented: bool,
 ) -> tuple[TaxRegime, ...]:
-    """Combine a location's modeled tax-regime defaults with scenario-level
-    owner-occupancy and rental signals.
-
-    A property the owner lives in *and* rents whole is treated as an
-    investment property for tax-regime purposes; rooms-rented-while-living
-    keeps the owner-occupied treatment."""
-    # scenario_set imports LocalRegulation/TaxRegime from this module, so
-    # OccupancyMode/RentalMode have to be resolved lazily here.
-    from augur.core.scenario_set import OccupancyMode, RentalMode  # noqa: PLC0415
-
-    owner_occupied = (
-        occupancy_mode is OccupancyMode.OWNER_LIVES_IN_PROPERTY and rental_mode is not RentalMode.RENT_WHOLE_PROPERTY
-    )
-    rented = rental_mode is not RentalMode.NOT_RENTED
+    """Combine a location's modeled tax-regime defaults with caller-derived
+    owner-occupancy and rental signals. Pure regulation logic — no scenario
+    types — so this module stays a leaf in the augur/core dependency graph."""
     regimes = [
         *existing_tax_regimes,
         *local_regulation.default_tax_regimes,
@@ -190,22 +173,3 @@ def tax_regimes_for_scenario(
         regimes.append(TaxRegime.RENTAL_DEPRECIATION)
         regimes.append(TaxRegime.DEPRECIATION_RECAPTURE)
     return tuple(dict.fromkeys(regimes))
-
-
-def scenario_with_location_tax_defaults(scenario: Scenario, local_regulation: LocalRegulation) -> Scenario:
-    """Backfill a scenario's `property_selection.tax_regime` and `tax_regimes`
-    from the location's modeled defaults, leaving any caller-supplied values
-    untouched."""
-    selection = scenario.property_selection.model_copy(
-        update={
-            "tax_regime": scenario.property_selection.tax_regime or local_regulation.property_tax_regime,
-            "local_regulation": scenario.property_selection.local_regulation or local_regulation,
-        }
-    )
-    tax_regimes = tax_regimes_for_scenario(
-        local_regulation,
-        occupancy_mode=scenario.occupancy_plan.occupancy_mode,
-        rental_mode=scenario.rental_plan.rental_mode,
-        existing_tax_regimes=scenario.tax_regimes,
-    )
-    return scenario.model_copy(update={"property_selection": selection, "tax_regimes": tax_regimes})

--- a/augur/core/local_regulation_test.py
+++ b/augur/core/local_regulation_test.py
@@ -13,21 +13,10 @@ from augur.core.local_regulation import (
     _validate_local_regulation_data,
     known_location_id,
     local_regulation_for_location,
-    scenario_with_location_tax_defaults,
-    tax_regimes_for_scenario,
+    tax_regimes_for_local_regulation,
 )
 from augur.core.market_bundle_test_support import constant_market_bundle
 from augur.core.property_tax import monthly_property_tax_usd
-from augur.core.scenario_set import (
-    Actor,
-    ActorRole,
-    NotRentedRentalPlan,
-    OccupancyMode,
-    OccupancyPlan,
-    PropertySelection,
-    RentalMode,
-    Scenario,
-)
 
 
 def _valid_payload() -> dict[str, dict[str, dict[str, object]]]:
@@ -94,14 +83,10 @@ def test_loaded_builtin_regulation_drives_property_tax() -> None:
     np.testing.assert_allclose(taxes[:, 1], 100_000 * 0.024 / 12)
 
 
-def test_loaded_builtin_regulation_drives_tax_regime_defaults() -> None:
+def test_owner_occupied_with_rooms_rented_keeps_owner_occupied_treatment() -> None:
     regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
 
-    regimes = tax_regimes_for_scenario(
-        regulation,
-        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
-        rental_mode=RentalMode.RENT_ROOMS_WHILE_OWNER_LIVES_THERE,
-    )
+    regimes = tax_regimes_for_local_regulation(regulation, owner_occupied=True, rented=True)
 
     assert regulation.property_tax_regime is TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX
     assert TaxRegime.SAN_FRANCISCO_TRANSFER_TAX in regimes
@@ -110,12 +95,10 @@ def test_loaded_builtin_regulation_drives_tax_regime_defaults() -> None:
     assert TaxRegime.CALIFORNIA_OWNER_OCCUPIED in regimes
 
 
-def test_whole_property_rental_with_owner_residence_treated_as_investment() -> None:
+def test_investment_property_treatment_when_owner_does_not_occupy() -> None:
     regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
 
-    regimes = tax_regimes_for_scenario(
-        regulation, occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_mode=RentalMode.RENT_WHOLE_PROPERTY
-    )
+    regimes = tax_regimes_for_local_regulation(regulation, owner_occupied=False, rented=True)
 
     assert TaxRegime.CALIFORNIA_INVESTMENT_PROPERTY in regimes
     assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION not in regimes
@@ -125,58 +108,15 @@ def test_whole_property_rental_with_owner_residence_treated_as_investment() -> N
 def test_existing_tax_regimes_are_preserved_and_deduplicated() -> None:
     regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
 
-    regimes = tax_regimes_for_scenario(
+    regimes = tax_regimes_for_local_regulation(
         regulation,
-        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
-        rental_mode=RentalMode.NOT_RENTED,
+        owner_occupied=True,
+        rented=False,
         existing_tax_regimes=(TaxRegime.CALIFORNIA_PROP13, TaxRegime.MARE_ISLAND_SPECIAL_ASSESSMENTS),
     )
 
     assert TaxRegime.MARE_ISLAND_SPECIAL_ASSESSMENTS in regimes
     assert regimes.count(TaxRegime.CALIFORNIA_PROP13) == 1
-
-
-def _bare_scenario(
-    *,
-    occupancy_mode: OccupancyMode,
-    rental_plan: NotRentedRentalPlan,
-    tax_regime: TaxRegime | None = None,
-    existing_tax_regimes: tuple[TaxRegime, ...] = (),
-) -> Scenario:
-    return Scenario(
-        scenario_id="fixture",
-        label="Fixture",
-        actors=(Actor(actor_id="owner", label="Owner", role=ActorRole.PRIMARY_OWNER),),
-        property_selection=PropertySelection(tax_regime=tax_regime),
-        occupancy_plan=OccupancyPlan(occupancy_mode=occupancy_mode),
-        rental_plan=rental_plan,
-        tax_regimes=existing_tax_regimes,
-    )
-
-
-def test_scenario_with_location_tax_defaults_backfills_property_tax_regime() -> None:
-    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
-    scenario = _bare_scenario(occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_plan=NotRentedRentalPlan())
-
-    enriched = scenario_with_location_tax_defaults(scenario, regulation)
-
-    assert enriched.property_selection.tax_regime is TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX
-    assert enriched.property_selection.local_regulation == regulation
-    assert TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX in enriched.tax_regimes
-    assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION in enriched.tax_regimes
-
-
-def test_scenario_with_location_tax_defaults_preserves_caller_overrides() -> None:
-    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
-    scenario = _bare_scenario(
-        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
-        rental_plan=NotRentedRentalPlan(),
-        tax_regime=TaxRegime.VALLEJO_PROPERTY_TAX,
-    )
-
-    enriched = scenario_with_location_tax_defaults(scenario, regulation)
-
-    assert enriched.property_selection.tax_regime is TaxRegime.VALLEJO_PROPERTY_TAX
 
 
 def test_local_regulation_data_requires_all_builtin_locations() -> None:

--- a/augur/core/scenario_tax_defaults.py
+++ b/augur/core/scenario_tax_defaults.py
@@ -1,0 +1,44 @@
+"""Glue between scenario shapes and per-location tax-regime defaults.
+
+`augur.core.local_regulation` owns the regulation data and pure-regulation
+logic (`tax_regimes_for_local_regulation` takes bool occupancy/rental signals).
+`augur.core.scenario_set` owns the scenario shape. This module is the only
+place that imports both — it converts scenario occupancy/rental enums into
+the bool signals the regulation API expects, and backfills the scenario's
+`property_selection` + `tax_regimes` from the location's modeled defaults.
+
+Keeping this glue out of either side keeps `augur/core` acyclic:
+`local_regulation` ← `scenario_set` ← `scenario_tax_defaults`.
+"""
+
+from __future__ import annotations
+
+from augur.core.local_regulation import LocalRegulation, tax_regimes_for_local_regulation
+from augur.core.scenario_set import OccupancyMode, RentalMode, Scenario
+
+
+def scenario_with_location_tax_defaults(scenario: Scenario, local_regulation: LocalRegulation) -> Scenario:
+    """Backfill `scenario.property_selection.tax_regime`,
+    `scenario.property_selection.local_regulation`, and `scenario.tax_regimes`
+    from the location's modeled defaults, leaving any caller-supplied values
+    untouched.
+
+    A property the owner lives in *and* rents whole is treated as an
+    investment property for tax-regime purposes; rooms-rented-while-living
+    keeps the owner-occupied treatment.
+    """
+    owner_occupied = (
+        scenario.occupancy_plan.occupancy_mode is OccupancyMode.OWNER_LIVES_IN_PROPERTY
+        and scenario.rental_plan.rental_mode is not RentalMode.RENT_WHOLE_PROPERTY
+    )
+    rented = scenario.rental_plan.rental_mode is not RentalMode.NOT_RENTED
+    selection = scenario.property_selection.model_copy(
+        update={
+            "tax_regime": scenario.property_selection.tax_regime or local_regulation.property_tax_regime,
+            "local_regulation": scenario.property_selection.local_regulation or local_regulation,
+        }
+    )
+    tax_regimes = tax_regimes_for_local_regulation(
+        local_regulation, existing_tax_regimes=scenario.tax_regimes, owner_occupied=owner_occupied, rented=rented
+    )
+    return scenario.model_copy(update={"property_selection": selection, "tax_regimes": tax_regimes})

--- a/augur/core/scenario_tax_defaults_test.py
+++ b/augur/core/scenario_tax_defaults_test.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest_bazel
+
+from augur.core.local_regulation import LocationId, TaxRegime, local_regulation_for_location
+from augur.core.scenario_set import (
+    Actor,
+    ActorRole,
+    NotRentedRentalPlan,
+    OccupancyMode,
+    OccupancyPlan,
+    PropertySelection,
+    RentalPlan,
+    Scenario,
+    WholePropertyRentalPlan,
+)
+from augur.core.scenario_tax_defaults import scenario_with_location_tax_defaults
+
+
+def _bare_scenario(
+    *,
+    occupancy_mode: OccupancyMode,
+    rental_plan: RentalPlan,
+    tax_regime: TaxRegime | None = None,
+    existing_tax_regimes: tuple[TaxRegime, ...] = (),
+) -> Scenario:
+    return Scenario(
+        scenario_id="fixture",
+        label="Fixture",
+        actors=(Actor(actor_id="owner", label="Owner", role=ActorRole.PRIMARY_OWNER),),
+        property_selection=PropertySelection(tax_regime=tax_regime),
+        occupancy_plan=OccupancyPlan(occupancy_mode=occupancy_mode),
+        rental_plan=rental_plan,
+        tax_regimes=existing_tax_regimes,
+    )
+
+
+def test_backfills_property_tax_regime_and_regimes_from_location_defaults() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+    scenario = _bare_scenario(occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_plan=NotRentedRentalPlan())
+
+    enriched = scenario_with_location_tax_defaults(scenario, regulation)
+
+    assert enriched.property_selection.tax_regime is TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX
+    assert enriched.property_selection.local_regulation == regulation
+    assert TaxRegime.SAN_FRANCISCO_SECURED_PROPERTY_TAX in enriched.tax_regimes
+    assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION in enriched.tax_regimes
+
+
+def test_preserves_caller_supplied_tax_regime() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+    scenario = _bare_scenario(
+        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY,
+        rental_plan=NotRentedRentalPlan(),
+        tax_regime=TaxRegime.VALLEJO_PROPERTY_TAX,
+    )
+
+    enriched = scenario_with_location_tax_defaults(scenario, regulation)
+
+    assert enriched.property_selection.tax_regime is TaxRegime.VALLEJO_PROPERTY_TAX
+
+
+def test_whole_property_rental_with_owner_residence_treated_as_investment() -> None:
+    regulation = local_regulation_for_location(LocationId.SAN_FRANCISCO_CA)
+    scenario = _bare_scenario(
+        occupancy_mode=OccupancyMode.OWNER_LIVES_IN_PROPERTY, rental_plan=WholePropertyRentalPlan(monthly_rent_usd=3000)
+    )
+
+    enriched = scenario_with_location_tax_defaults(scenario, regulation)
+
+    assert TaxRegime.CALIFORNIA_INVESTMENT_PROPERTY in enriched.tax_regimes
+    assert TaxRegime.PRIMARY_RESIDENCE_EXCLUSION not in enriched.tax_regimes
+    assert TaxRegime.RENTAL_DEPRECIATION in enriched.tax_regimes
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

#1566 (Plan F) moved `tax_regimes_for_scenario` and `scenario_with_location_tax_defaults` into `augur/core/local_regulation.py` — but those functions take `OccupancyMode`, `RentalMode`, and `Scenario` parameters from `augur/core/scenario_set.py`, which in turn imports `LocalRegulation`/`TaxRegime` from `local_regulation`. That introduced a cycle that #1566 papered over with a `TYPE_CHECKING` import shim plus a function-local `from augur.core.scenario_set import …  # noqa: PLC0415`.

This PR breaks the cycle for real and gets imports back to the top of every file.

## The fix

The dep graph is now acyclic:

```
local_regulation  (regulation data + bool-API tax_regimes_for_local_regulation)
        ↑
        │
scenario_set      (imports LocalRegulation, TaxRegime from above)
        ↑
        │
scenario_tax_defaults  ← new leaf; only place that imports both
   (scenario_with_location_tax_defaults: scenario→bool conversion + backfill)
```

Concretely:

- **`augur/core/local_regulation.py`** — reverted to no `scenario_set` imports. `tax_regimes_for_scenario(occupancy_mode, rental_mode, …)` becomes `tax_regimes_for_local_regulation(owner_occupied: bool, rented: bool, …)` again (the pre-#1566 signature). `scenario_with_location_tax_defaults` is gone from this module. No `TYPE_CHECKING` shim, no function-local imports.

- **New `augur/core/scenario_tax_defaults.py`** — holds `scenario_with_location_tax_defaults`, which inlines the `OccupancyMode`/`RentalMode` → bool conversion that used to live in `tax_regimes_for_scenario`. All imports at module top.

- **`augur/app/augur_backend.py`** — imports `scenario_with_location_tax_defaults` from the new module.

## Test split mirrors the module split

- `local_regulation_test.py` keeps only bool-API tests: `tax_regimes_for_local_regulation(owner_occupied=…, rented=…)`. Drops the `scenario_set` import and the `_bare_scenario` helper.
- New `scenario_tax_defaults_test.py` covers the scenario-layer behavior the #1566 tests were after — backfill, caller-supplied tax-regime preservation, and the rent-whole-with-owner-residence → investment treatment.

## Test plan

- [x] `bbr test //augur/core:local_regulation_test //augur/core:scenario_tax_defaults_test //augur/core:scenario_set_test //augur/core:test_e2e //augur/app:catalog_test //augur/app:config_test //augur/app:browser_shell_test` — all green on RBE.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_