### PR TITLE
debundle purity: add `declared_pure_new_with_pure_args` (relaxed P-2 opt-in)

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -27,6 +27,7 @@ mod tests {
         AnalysisHints {
             declared_pure: BTreeSet::new(),
             declared_pure_new: BTreeSet::new(),
+            declared_pure_new_with_pure_args: BTreeSet::new(),
             known_effects: BTreeMap::from([(
                 name.to_string(),
                 KnownEffect::TypescriptDecorateHelper,
@@ -736,6 +737,34 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         classify_expr_purity(init, &shadowed, &BTreeSet::new(), &graph)
     }
 
+    /// Like `classify_with_declared_pure_new`, but seeds the
+    /// `declared_pure_new_with_pure_args` set instead — the
+    /// relaxed P-2 variant that admits any `Pure`-classified arg.
+    fn classify_with_pure_new_with_pure_args(
+        prefix: &str,
+        expr_src: &str,
+        relaxed: &[&str],
+    ) -> Purity {
+        let module = parse(&format!("{prefix}\nconst _ = {expr_src};"));
+        let body = top_level_item_views(&module.body);
+        let shadowed = compute_shadowed_globals(&body);
+        let declared_pure_new_with_pure_args: BTreeSet<String> =
+            relaxed.iter().map(|s| (*s).to_string()).collect();
+        let graph = ChunkCodeGraph::build_with_pure_new_sets(
+            &body,
+            &shadowed,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &declared_pure_new_with_pure_args,
+        );
+        let var = match module.body.last().expect("non-empty body") {
+            ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+            other => panic!("expected last stmt to be `const _ = …;`, got {other:?}"),
+        };
+        let init = var.decls[0].init.as_deref().expect("init expected");
+        classify_expr_purity(init, &shadowed, &BTreeSet::new(), &graph)
+    }
+
     #[test]
     fn classify_literal_kinds_are_pure() {
         assert!((classify("42")).is_pure());
@@ -1358,6 +1387,127 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
                 "function PureBox(value) { globalThis.value = value; return { value }; }",
                 "PureBox(1)",
                 &["PureBox"]
+            ))
+            .is_pure()
+        );
+    }
+
+    // --- P-2 relaxed: `declared_pure_new_with_pure_args` --------------------
+    //
+    // Opt-in variant of `declared_pure_new` that admits `new C(<args>)`
+    // as Pure whenever every argument *classifies* `Pure` — not just
+    // primitive literals. Motivated by the Tana web `new Fx(...)`
+    // family of factory calls (`new Fx(n, new IJ(), …)`) where args
+    // are bindings / fresh `new`s that already classify Pure but
+    // strict P-2 rejects on literal-ness. The strict
+    // `declared_pure_new` set remains unchanged.
+
+    #[test]
+    fn pure_new_with_pure_args_no_args_is_pure() {
+        // Zero-args is trivially safe: no arg evaluation can
+        // fire user code.
+        assert!(
+            (classify_with_pure_new_with_pure_args(
+                "class C { constructor() {} }",
+                "new C()",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_pure_binding_is_pure() {
+        // `new C(pureBinding)` — bare identifier reads classify
+        // `Pure` (the analyzer treats them as load-time observable
+        // values), so the relaxed admission accepts. Strict P-2
+        // would reject this same callsite for non-literal arg.
+        assert!(
+            (classify_with_pure_new_with_pure_args(
+                "class C { constructor(v) {} }\nconst pureBinding = 1;",
+                "new C(pureBinding)",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_nested_pure_new_is_pure() {
+        // `new C(new D())` where both are in the relaxed set —
+        // the inner `new D()` itself classifies Pure under the
+        // same admission, so the outer args-are-Pure check passes
+        // recursively. This is the exact shape of the Tana
+        // celebrity case `new Fx(n, new IJ(), …)`.
+        assert!(
+            (classify_with_pure_new_with_pure_args(
+                "class C { constructor(d) {} } class D { constructor() {} }",
+                "new C(new D())",
+                &["C", "D"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_impure_arg_is_not_pure() {
+        // `new C(makeValue())` — the nested call classifies
+        // NotPure, so the args-are-Pure predicate fails and the
+        // overall `new` is NotPure regardless of the relaxed
+        // annotation.
+        assert!(
+            !(classify_with_pure_new_with_pure_args(
+                "class C { constructor(v) {} }",
+                "new C(makeValue())",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_strict_set_still_rejects_non_literal() {
+        // Strict `declared_pure_new` (the old set) still rejects
+        // non-literal args — the relaxed extension does not leak
+        // into the strict set. Spec authors who want non-literal
+        // admission must opt their constructor into the new set.
+        assert!(
+            !(classify_with_declared_pure_new(
+                "class C { constructor(v) {} }\nconst pureBinding = 1;",
+                "new C(pureBinding)",
+                &["C"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_unannotated_is_not_pure() {
+        // Constructor in neither set falls through to the
+        // default `UnknownNew` verdict, even with a Pure-
+        // classified arg. Mirrors `undeclared_new_is_not_pure`
+        // for the relaxed admission.
+        assert!(
+            !(classify_with_pure_new_with_pure_args(
+                "class C { constructor(v) {} }\nconst pureBinding = 1;",
+                "new C(pureBinding)",
+                &[] // C in neither set
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn pure_new_with_pure_args_spread_arg_is_not_pure() {
+        // Spread args fire `[Symbol.iterator]` — even when the
+        // source classifies Pure, the iterator protocol runs
+        // user code. Relaxed admission rejects spread regardless
+        // of source shape (matches strict P-2's spread rejection).
+        assert!(
+            !(classify_with_pure_new_with_pure_args(
+                "class C { constructor() {} }\nconst args = [];",
+                "new C(...args)",
+                &["C"]
             ))
             .is_pure()
         );

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -68,7 +68,21 @@ pub enum KnownEffect {
 #[derive(Debug, Clone, Default)]
 pub struct AnalysisHints {
     pub declared_pure: BTreeSet<String>,
+    /// Strict P-2: `new C(<primitive-literal-args>)` admits as Pure.
+    /// Identifier reads, fresh literals, calls, etc. are rejected
+    /// because they can hide getters / Proxies / coercion side
+    /// effects that the constructor's argument evaluation would
+    /// fire. See `classify_new_expr_purity`.
     pub declared_pure_new: BTreeSet<String>,
+    /// Relaxed P-2: `new C(<args>)` admits as Pure when every arg
+    /// classifies `Purity::Pure` (not just primitive literals). The
+    /// spec author opts in per constructor — only safe for
+    /// constructors whose bodies do not read arguments through
+    /// getters / Proxy traps / coercion. Disjoint from
+    /// `declared_pure_new` in semantics (this set strictly relaxes
+    /// the argument-shape predicate); spec authors should pick the
+    /// narrowest set that admits their callsites.
+    pub declared_pure_new_with_pure_args: BTreeSet<String>,
     pub known_effects: BTreeMap<String, KnownEffect>,
 }
 
@@ -77,6 +91,7 @@ impl AnalysisHints {
         Self {
             declared_pure: declared_pure.clone(),
             declared_pure_new: BTreeSet::new(),
+            declared_pure_new_with_pure_args: BTreeSet::new(),
             known_effects: BTreeMap::new(),
         }
     }
@@ -183,11 +198,12 @@ where
 {
     let body = top_level_item_views(&module.body);
     let shadowed = compute_shadowed_globals(&body);
-    let graph = ChunkCodeGraph::build_with_declared_pure_new(
+    let graph = ChunkCodeGraph::build_with_pure_new_sets(
         &body,
         &shadowed,
         &hints.declared_pure,
         &hints.declared_pure_new,
+        &hints.declared_pure_new_with_pure_args,
     );
     let redundant_purity_hints =
         detect_redundant_purity_hints(&body, &shadowed, &hints.declared_pure);

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -680,6 +680,11 @@ fn materialize_logical_chunk(
                     if m.purity == MemberPurity::PureNew {
                         hints.declared_pure_new.insert(m.binding.clone());
                     }
+                    if m.purity == MemberPurity::PureNewWithPureArgs {
+                        hints
+                            .declared_pure_new_with_pure_args
+                            .insert(m.binding.clone());
+                    }
                     if let Some(effect) = known_effect_from_member_effect(m.effect) {
                         hints.known_effects.insert(m.binding.clone(), effect);
                     }
@@ -693,6 +698,11 @@ fn materialize_logical_chunk(
                     if m.purity == MemberPurity::PureNew {
                         hints
                             .declared_pure_new
+                            .insert(m.selector.binding.name.clone());
+                    }
+                    if m.purity == MemberPurity::PureNewWithPureArgs {
+                        hints
+                            .declared_pure_new_with_pure_args
                             .insert(m.selector.binding.name.clone());
                     }
                     if let Some(effect) = known_effect_from_member_effect(m.effect) {

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -23,7 +23,14 @@ use crate::facts::TopLevelItemView;
 #[derive(Debug, Default, Clone)]
 pub struct ChunkCodeGraph {
     bindings: BTreeMap<String, ChunkBinding>,
+    /// Strict P-2 set: `new <name>(<primitive-literal-args>)` only.
     pure_new_constructors: BTreeSet<String>,
+    /// Relaxed P-2 set: `new <name>(<pure-args>)` — every arg must
+    /// classify `Purity::Pure`, but identifier reads / fresh
+    /// literals / nested constructors are admitted. Opt-in per
+    /// constructor for the case where the body does not read its
+    /// arguments through getters / Proxies / coercion.
+    pure_new_with_pure_args_constructors: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -110,7 +117,13 @@ impl ChunkCodeGraph {
         shadowed: &BTreeSet<&'static str>,
         declared_pure: &BTreeSet<String>,
     ) -> Self {
-        Self::build_with_declared_pure_new(body, shadowed, declared_pure, &BTreeSet::new())
+        Self::build_with_pure_new_sets(
+            body,
+            shadowed,
+            declared_pure,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        )
     }
 
     pub(crate) fn build_with_declared_pure_new(
@@ -118,6 +131,22 @@ impl ChunkCodeGraph {
         shadowed: &BTreeSet<&'static str>,
         declared_pure: &BTreeSet<String>,
         declared_pure_new: &BTreeSet<String>,
+    ) -> Self {
+        Self::build_with_pure_new_sets(
+            body,
+            shadowed,
+            declared_pure,
+            declared_pure_new,
+            &BTreeSet::new(),
+        )
+    }
+
+    pub(crate) fn build_with_pure_new_sets(
+        body: &[(TopLevelItemView<'_>, Option<usize>)],
+        shadowed: &BTreeSet<&'static str>,
+        declared_pure: &BTreeSet<String>,
+        declared_pure_new: &BTreeSet<String>,
+        declared_pure_new_with_pure_args: &BTreeSet<String>,
     ) -> Self {
         let functions = collect_chunk_functions(body);
         let name_to_idx: BTreeMap<&str, usize> = functions
@@ -169,6 +198,7 @@ impl ChunkCodeGraph {
         let mut graph = ChunkCodeGraph {
             bindings,
             pure_new_constructors: declared_pure_new.clone(),
+            pure_new_with_pure_args_constructors: declared_pure_new_with_pure_args.clone(),
         };
         // tarjan_scc emits SCCs in reverse topological order: leaves
         // (sinks — functions that don't call any chunk-top
@@ -247,6 +277,10 @@ impl ChunkCodeGraph {
 
     pub(crate) fn is_declared_pure_new(&self, name: &str) -> bool {
         self.pure_new_constructors.contains(name)
+    }
+
+    pub(crate) fn is_declared_pure_new_with_pure_args(&self, name: &str) -> bool {
+        self.pure_new_with_pure_args_constructors.contains(name)
     }
 }
 
@@ -1803,6 +1837,13 @@ fn static_member_pair(member: &MemberExpr) -> Option<(&'static str, &'static str
 ///     argument a primitive literal (no spreads, no identifiers,
 ///     no nested calls, no object/array literals). See P-2 in
 ///     `oversize_closure_patterns.md`.
+///   * Spec-declared `purity: pure_new_with_pure_args` bindings —
+///     a relaxed opt-in variant of `pure_new` that admits any
+///     argument shape whose purity classifies `Pure` (identifier
+///     reads, fresh literals, nested `new`s of other admitted
+///     constructors). Strict `pure_new` remains the safe default
+///     for getter-blocking / Proxy-trapped argument paths; the
+///     relaxed set is opt-in per constructor.
 ///
 /// Everything else (non-Ident callees, shadowed names, tagged
 /// templates, other arg shapes) falls through to `Unknown`.
@@ -1861,6 +1902,46 @@ fn classify_new_expr_purity(
         )
         .worst(inner);
     }
+    if graph.is_declared_pure_new_with_pure_args(callee.sym.as_ref()) {
+        // P-2 (relaxed): admit `new <DeclaredPureNewWithPureArgs>(<args>)`
+        // as Pure when every arg classifies `Purity::Pure`. Unlike
+        // strict `declared_pure_new`, this admits identifier reads,
+        // fresh object/array literals, and nested `new`s whose own
+        // purity is established by the analyzer. The spec author
+        // opts in per constructor — only safe when the constructor
+        // body does not read its arguments through getters / Proxy
+        // traps / coercion side effects. Strict `declared_pure_new`
+        // remains the safe default; this set is a separate opt-in
+        // for constructors whose body is known not to fire user
+        // code on its arguments.
+        let args = new_expr.args.as_deref().unwrap_or(&[]);
+        let mut worst = Purity::Pure;
+        let mut has_spread = false;
+        for arg in args {
+            if arg.spread.is_some() {
+                has_spread = true;
+                break;
+            }
+            worst = worst.worst(classify_expr_purity(
+                &arg.expr,
+                shadowed,
+                declared_pure,
+                graph,
+            ));
+        }
+        if !has_spread && worst.is_pure() {
+            return Purity::Pure;
+        }
+        return Purity::from_reason_with_detail(
+            PurityRule::UnknownNew,
+            new_expr.span,
+            format!(
+                "new {}(...) has impure or spread argument(s); pure-args P-2 admits only Pure-classified args",
+                callee.sym
+            ),
+        )
+        .worst(worst);
+    }
     if graph.is_declared_pure_new(callee.sym.as_ref()) {
         // P-2 `singleton_instance_with_listener_blocking_pure_alias`:
         // admit `new <DeclaredPureNew>(<primitive-literal-args>)`
@@ -1873,6 +1954,8 @@ fn classify_new_expr_purity(
         // guarantees the constructor's argument evaluation
         // fires no user code. This matches the conservative
         // contract documented in P-7 for `Object.freeze(<literal>)`.
+        // Constructors that need to admit non-literal args opt
+        // in to `declared_pure_new_with_pure_args` instead.
         let args = new_expr.args.as_deref().unwrap_or(&[]);
         if args
             .iter()

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -410,6 +410,15 @@ pub enum MemberPurity {
     /// still requires every argument expression to classify pure; this
     /// annotation does not affect ordinary `<binding>(...)` calls.
     PureNew,
+    /// Relaxed variant of `PureNew`: author additionally asserts that
+    /// the constructor body does not read its arguments through
+    /// getters / Proxy traps / coercion that could fire user code,
+    /// so the analyzer admits `new <binding>(<args>)` as Pure whenever
+    /// every argument *classifies* `Pure` — not just primitive
+    /// literals. Use only when the constructor is known to store args
+    /// via plain assignment (no `String(opts)` / `+opts` / spread copy
+    /// off `opts`); otherwise prefer the stricter `PureNew`.
+    PureNewWithPureArgs,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, Eq, PartialEq)]


### PR DESCRIPTION
## Motivation — Tana web's `new Fx(...)` celebrity blockers

P-2 (#1565) tightened `declared_pure_new` to require every arg be a primitive
literal — bindings, fresh literals, and nested `new`s are rejected because
they can hide getters / Proxy traps / coercion. Conservative and correct as a
default, but it leaves a large win on the table:

10 of the top 12 celebrity blockers in Tana web's current `owner_graph.json`
are `new Fx(...)` factory calls — the `Zt`, `ft`, `Se`, `uf` helpers around
`runtime.js` lines 30800-30812, each returning `new Fx(n, new IJ(), …)`.
Combined cycle-blocker incidence: ~5,500. Every blocked owner carries the
diagnostic `new Fx(...) has non-literal argument(s); P-2 admits only
primitive-literal args`. The args aren't primitive literals — but they ARE
already classified `Pure` by the analyzer (bindings, fresh `new`s of other
known-pure constructors); the only reason they're rejected is strict P-2's
literal-ness gate.

## Design

Add a parallel opt-in annotation set, `declared_pure_new_with_pure_args`,
that admits `new C(<args>)` as Pure when every arg classifies `Purity::Pure`
(not just primitive literals). Strict `declared_pure_new` is untouched and
remains the safe default. Spec authors opt in per constructor when the body
is known not to read args through accessor channels (no `String(opts)` /
`+opts` / spread copy off `opts`).

- New `MemberPurity::PureNewWithPureArgs` spec variant
- New `AnalysisHints::declared_pure_new_with_pure_args` field
- New admission branch in `classify_new_expr_purity` that checks the relaxed
  set *before* the strict set; spread args still rejected (iterator can run
  user code regardless of source shape)
- Strict path preserved verbatim — same diagnostic, same literal-only gate

## Tests

`analysis_tests.rs`: 7 new tests (205 total, all pass). Helper
`classify_with_pure_new_with_pure_args` seeds only the new set.

- `pure_new_with_pure_args_no_args_is_pure` — zero-args trivially safe
- `pure_new_with_pure_args_pure_binding_is_pure` — `new C(pureBinding)` admits
  (rejected by strict P-2)
- `pure_new_with_pure_args_nested_pure_new_is_pure` — `new C(new D())` admits
  recursively (the Tana `new Fx(n, new IJ(), …)` shape)
- `pure_new_with_pure_args_impure_arg_is_not_pure` — impure call arg rejects
- `pure_new_with_pure_args_spread_arg_is_not_pure` — spread rejects
- `pure_new_with_pure_args_unannotated_is_not_pure` — constructor in neither
  set still rejects
- `pure_new_with_pure_args_strict_set_still_rejects_non_literal` — strict
  `declared_pure_new` preserved (P-2 behavior unchanged)

Full `//devinfra/js/debundle:all` suite passes (14 test targets).

## Follow-up

The gaffer-side annotation seeding (adding `Fx` et al. to the new set in the
Tana spec to actually fire the ~5.5k cycle-blocker reduction) is a separate
PR. This change is analyzer-only; without spec opt-ins, no constructor uses
the new branch, so existing pipelines are unaffected.

## Test plan
- [x] `bazelisk test //devinfra/js/debundle:all` passes
- [x] All 7 new tests pass; 205 total analysis tests pass (up from 198)
- [x] Strict `declared_pure_new` tests unchanged
- [ ] Follow-up gaffer PR opts `Fx` (and friends) into the new set; verify
  owner_graph residual closures drop

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU)_