### PR TITLE
augur/TODO.md: promote crypto + tender-aware PE funding to its own follow-on

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -83,15 +83,15 @@ second ordered roadmap.
       fields should update `augur/model/market_config_test.py`, remain
       Pydantic-parsed at load time, and avoid stale simulation knobs already
       owned by `MarketRequest`.
-- [ ] Define a generic deployment-supplied portfolio YAML contract for real
-      financial inputs. The public schema should cover accounts/cash, public
-      securities, crypto holdings, private-equity lots/marks/tender windows,
-      cost basis, custody/source metadata, and valuation provenance; downstream
-      private repos own the actual values.
-      First public contract: `augur/core/portfolio.py` with
-      `augur/core/testdata/portfolio.example.yaml`. Next step: teach runtime
-      funding policies to consume crypto and tender-window-aware private equity
-      positions instead of only preserving those holdings in typed input data.
+- [ ] Teach runtime funding policies to consume the crypto and
+      tender-window-aware private equity positions modeled in the public
+      portfolio YAML contract (`augur/core/portfolio.py`,
+      `augur/core/testdata/portfolio.example.yaml`). Today
+      `PortfolioStatement.to_initial_balance_sheet()` maps cash + generic S&P 500
+      lots + opaque PE marks into the existing `InitialBalanceSheet` shape and
+      drops crypto holdings and tender windows; the simulator should grow first-
+      class handling for those positions instead of only preserving them in
+      typed input data.
 - [ ] Persist and harden model-governance artifacts for market providers. The
       runtime now attaches typed model card, evidence, calibration, scenario
       generator, path-set, and validation-report identities; the next step is


### PR DESCRIPTION
## Summary

The generic deployment-supplied portfolio YAML contract this branch was scoped
to add already landed on `devel` in commit `bb4d8b681` ("augur: add public
portfolio yaml contract"). That commit shipped:

- `augur/core/portfolio.py` — `PortfolioStatement` plus `PortfolioAccount`,
  `PublicSecurityPosition`, `CryptoHolding`, `PrivateEquityLot` (with
  `PrivateEquityTenderWindow`), `CustodyMetadata`, `ValuationProvenance`,
  `CostBasis`, the various enums (`PortfolioAccountType`, `PublicSecurityKind`,
  `ValuationMethod`, `PrivateEquityLiquidity`, `TenderWindowStatus`), plus
  `load_portfolio_yaml` / `load_portfolio_resource` and a
  `to_initial_balance_sheet()` adapter that maps cash + generic-S&P-500 lots +
  opaque PE marks into the existing `InitialBalanceSheet` shape.
- `augur/core/testdata/portfolio.example.yaml` exercising all position types:
  checking + brokerage + crypto-exchange + private-equity-platform accounts,
  an SP500 ETF, BTC + ETH crypto holdings, and a private-equity lot with a
  scheduled tender window.
- `augur/core/portfolio_test.py` covering YAML round-trip, conversion to
  `InitialBalanceSheet`, and Pydantic-validation rejection of missing custody
  and unknown account references.
- `augur/core/BUILD.bazel` entries `:portfolio_py` and `:portfolio_test` (with
  the example YAML as `data`).

The only thing left from the original task description was the TODO bookkeeping
the task asked me to do "after opening" the PR: rewrite the
`augur/TODO.md` bullet that defined the contract so it reflects the
contract being delivered and clearly surfaces the next-step funding-policy
work (crypto + tender-aware PE consumption) as its own follow-on bullet.

This PR therefore contains only that TODO edit. No code changes are needed —
runtime consumption of crypto holdings and tender-window-aware private equity
remains explicitly out of scope and is now the standalone TODO bullet.

Position-type tree carried by the existing contract:

```
PortfolioStatement
├── accounts: PortfolioAccount[]                 (checking, cash_management,
│                                                 taxable_brokerage,
│                                                 crypto_exchange,
│                                                 private_equity_platform)
├── public_securities: PublicSecurityPosition[]  (etf/stock/mutual_fund/...)
├── crypto_holdings: CryptoHolding[]             (asset_symbol + network)
└── private_equity_lots: PrivateEquityLot[]
        └── tender_windows: PrivateEquityTenderWindow[]
                            (status, opens_on, closes_on, tenderable_units)
```

Every position carries `CustodyMetadata` (custodian, source_id,
external_account_id, external_position_id) and `ValuationProvenance`
(source_id, as_of, method ∈ {statement, market_quote, manual_mark,
tender_offer, model}, snapshot_id, notes). Cost basis is `CostBasis`
(amount_usd, source_id, as_of).

## Validation

- `bbr test //augur/core:portfolio_test --nocache_test_results` — PASSED
  (invocation `16ac0bc7-0350-4ac1-a835-29967045a31a`)
- `bbr build //augur/core:portfolio_py //augur/core:portfolio_test` — built
  cleanly (invocation `186b3dc8-b6e7-48b4-9892-46cdc86d9b60`)
- `bbr test //augur/core/... --nocache_test_results` — 14/14 passed
  (invocation `a7941e60-dee7-491e-8b59-c246e1e0e87d`)

## Out of scope (explicit next step)

Teaching runtime funding policies to consume the crypto holdings and
tender-window-aware private-equity positions the YAML contract already carries
is now the standalone TODO bullet this PR promotes. Today
`PortfolioStatement.to_initial_balance_sheet()` drops crypto holdings and
tender windows when mapping into the legacy `InitialBalanceSheet` shape; the
simulator should grow first-class handling for those positions in a follow-up.

## Test plan

- [x] `bbr test //augur/core:portfolio_test --nocache_test_results`
- [x] `bbr build //augur/core:portfolio_py //augur/core:portfolio_test`
- [x] `bbr test //augur/core/... --nocache_test_results`

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_