### PR TITLE
augur/plans: trim historical baggage; keep planning docs forward-looking

### DIFF
--- a/augur/README.md
+++ b/augur/README.md
@@ -10,7 +10,7 @@ engine, real-estate / ownership / private-equity / tax math, market models,
 FastAPI scaffolding, and React shell. User-side configuration (specific
 properties, holdings, agent identities, fitted models, deployment) is
 composed in downstream user repos via the `AugurConfig` schema in
-<app/config.py>.
+<api/config.py>.
 
 See <SPEC.md> for the entity taxonomy + per-rollout evaluation loop.
 
@@ -32,8 +32,8 @@ company-/person-specific modeling assumptions.
 | `core/`         | Engine, typed entity / asset / policy / action / event model, real-estate math, scenario serialization, location regulation registry.                         |
 | `model/`        | Market models (Wilkie, VAR, VECM, DCC-GARCH, bootstrap) + macro market-bundle provider + loaders for FRED/Yahoo/Zillow public-data CSVs.                      |
 | `model/config/` | Public market-source CSVs (FRED series, Yahoo SPY adjusted-close, Zillow ZHVI) and market model config templates. Acquisition recipes in `source/SOURCES.md`. |
-| `app/`          | `AugurConfig` schema, `AugurBackend`, HTTP server, catalog/bootstrap-payload assembly, React app + Tailwind bundle build.                                     |
-| `app/lib/`      | Frontend helpers: casing conversion, columnar table marshaling, scenario-set state, backend client.                                                           |
+| `api/`          | `AugurConfig` schema, `AugurBackend`, HTTP server, catalog/bootstrap-payload assembly, OpenAPI schema export.                                                 |
+| `frontend/`     | React app + Tailwind bundle build, frontend helpers (casing conversion, columnar table marshaling, scenario-set state, backend client).                       |
 
 ## Deployment integration
 

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -15,10 +15,6 @@ second ordered roadmap.
 - Sale-tax timing slice — move sale-tax obligations off
   `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
   dates. Branch `claude/sale-tax-timing-slice`.
-- Partner ownership parallel paths (cleanup audit item 3) — collapse the
-  duplicate ledger-row reconstruction in
-  `_record_partner_agreement_ledger_detail`. Branch
-  `claude/partner-ownership-parallel-paths`.
 
 ## Next
 

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -1,6 +1,6 @@
 # Augur TODO
 
-Last design scan: 2026-05-16. Last consolidation: 2026-05-16.
+Last design scan: 2026-05-17. Last consolidation: 2026-05-17.
 
 This file tracks public, generic Augur backlog. Downstream repos should keep
 private composition, deployment, and user-/company-specific modeling assumptions
@@ -10,7 +10,31 @@ Priority ordering and cross-repo consolidation live in
 `plans/roadmap.md`. Keep this file as the public generic backlog rather than a
 second ordered roadmap.
 
-## Next
+## In Flight (Round 3, 2026-05-17)
+
+- **Sale-tax timing slice** — finish Plan C's deferred half (move sale-tax
+  obligations off `ALLOCATED_TO_SOURCE_MONTH` onto year-end /
+  estimated-payment dates). Worktree subagent on branch
+  `claude/sale-tax-timing-slice`.
+- **Partner ownership parallel paths** (cleanup audit item 3) — collapse
+  the duplicate ledger-row generation in
+  `_record_partner_agreement_ledger_detail`. Worktree subagent on branch
+  `claude/partner-ownership-parallel-paths`.
+
+## Recently Landed (Rounds 1–2, 2026-05-16/17)
+
+- Plans A (#1557 / #1561 / #1563), B (#1568), C (#1570 — mortgage slice
+  only), E (#1567), F (#1566 + cycle fix #1569), G (#1575 + gaffer-private
+  #109).
+- Cleanup audit item 7 (#1571) — `PolicyContext` already gone; typed
+  `ReportMetric` lookup replaces `_metric_array` dynamic-attribute
+  probing.
+- Plan D — already guardrailed by `market_config_test.py`; no dispatch
+  needed.
+- Portfolio YAML contract — already shipped in `bb4d8b681`; PR #1573
+  narrowed the stale TODO bullet.
+
+## Next (after Round 3 lands)
 
 - [ ] Use the generated Augur OpenAPI/browser schema target in browser state
       normalization and request mapping. Python Pydantic remains the source of

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -10,31 +10,17 @@ Priority ordering and cross-repo consolidation live in
 `plans/roadmap.md`. Keep this file as the public generic backlog rather than a
 second ordered roadmap.
 
-## In Flight (Round 3, 2026-05-17)
+## In Flight
 
-- **Sale-tax timing slice** — finish Plan C's deferred half (move sale-tax
-  obligations off `ALLOCATED_TO_SOURCE_MONTH` onto year-end /
-  estimated-payment dates). Worktree subagent on branch
-  `claude/sale-tax-timing-slice`.
-- **Partner ownership parallel paths** (cleanup audit item 3) — collapse
-  the duplicate ledger-row generation in
-  `_record_partner_agreement_ledger_detail`. Worktree subagent on branch
+- Sale-tax timing slice — move sale-tax obligations off
+  `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
+  dates. Branch `claude/sale-tax-timing-slice`.
+- Partner ownership parallel paths (cleanup audit item 3) — collapse the
+  duplicate ledger-row reconstruction in
+  `_record_partner_agreement_ledger_detail`. Branch
   `claude/partner-ownership-parallel-paths`.
 
-## Recently Landed (Rounds 1–2, 2026-05-16/17)
-
-- Plans A (#1557 / #1561 / #1563), B (#1568), C (#1570 — mortgage slice
-  only), E (#1567), F (#1566 + cycle fix #1569), G (#1575 + gaffer-private
-  #109).
-- Cleanup audit item 7 (#1571) — `PolicyContext` already gone; typed
-  `ReportMetric` lookup replaces `_metric_array` dynamic-attribute
-  probing.
-- Plan D — already guardrailed by `market_config_test.py`; no dispatch
-  needed.
-- Portfolio YAML contract — already shipped in `bb4d8b681`; PR #1573
-  narrowed the stale TODO bullet.
-
-## Next (after Round 3 lands)
+## Next
 
 - [ ] Use the generated Augur OpenAPI/browser schema target in browser state
       normalization and request mapping. Python Pydantic remains the source of

--- a/augur/plans/cleanup_audit.md
+++ b/augur/plans/cleanup_audit.md
@@ -2,12 +2,11 @@
 
 ## Executive Summary
 
-Augur is moving in the right direction: the current docs define a
-distribution-first simulator, sectioned scenario state, ordered actor policy
-programs, private-equity opportunities rather than liquidity, and
-ledger/accounting-backed reporting. The ordered actor policy runtime has landed,
-but the implementation still carries several old or parallel trace/detail paths
-that make that direction harder to enforce.
+Augur is moving in the right direction: distribution-first simulator, sectioned
+scenario state, ordered actor policy programs, private-equity opportunities
+rather than liquidity, and ledger/accounting-backed reporting. The ordered
+actor policy runtime has landed, but the implementation still carries several
+old or parallel trace/detail paths that make that direction harder to enforce.
 
 The highest-value remaining cleanup is not broad refactoring. Force the engine
 to choose one source of truth for result detail: ordered policy programs plus
@@ -22,27 +21,7 @@ hidden behind fallbacks.
 
 ## Suspicious/Needs-Design Review
 
-1. Ordered policy programs exist, and execution now uses their order.
-   (Completed)
-
-   Files/functions: `actor_policy_programs()` and `actor_policy_steps()` in
-   `augur/core/policy_runtime.py`; `run_scenario_vectorized()` builds
-   `policy_steps` from those programs and dispatches each typed policy in
-   sequence.
-
-   Why this mattered: the design invariant says actor policy programs are
-   ordered sequences. Preserving sequence metadata while executing by policy
-   class made cross-type ordering meaningless.
-
-   Completed by: `run_scenario_vectorized()` now dispatches ordered policy steps
-   through typed handlers, and the older `enabled_rules_of_type()` helper was
-   removed.
-
-   Remaining guard: keep adding policy families through the ordered dispatcher,
-   and add richer trace rows for no-op, rejected, instructed, and applied
-   decisions where trajectory inspection needs them.
-
-2. Actions, decisions, ledger entries, balance snapshots, accounting details,
+1. Actions, decisions, ledger entries, balance snapshots, accounting details,
    and monthly arrays overlap heavily.
 
    Files/classes: `SimulationAction` rows at
@@ -66,95 +45,6 @@ hidden behind fallbacks.
    Prove safe by: add reconciliation tests that every public monthly flow is
    derived from ledger/accounting rows. Then remove one action family, such as
    `PayMortgageAction`, and confirm no app or API behavior depends on it.
-
-3. Partner ownership runtime still computes parallel ledger data. (Completed 2026-05-17)
-
-   Per-agreement partner-side rows now come from `PartnerOwnershipAccrualApplication`
-   (taking `property_id` directly), and owner-side aggregate rows come from a new
-   `apply_partner_ownership_aggregate()` in `augur/core/policy_runtime.py`. The
-   engine concatenates their `journal_entries` / `balance_snapshots` and the
-   recorder writes them through verbatim — no parallel `JournalEntryBatch` /
-   `BalanceSnapshotBatch` construction inside `_partner_equity_arrays()`, no
-   filter that drops owner snapshots only to rebuild them, and no
-   `_journal_entries_for_property` / `_balance_snapshots_for_property` post-tag
-   pass.
-
-   Proved safe by: `test_partner_equity_arrays_match_rows_from_same_application`
-   in `scenario_engine_test.py` asserts that
-   `result.partner_equity_ledger_usd` / `result.owner_equity_ledger_usd` /
-   `result.partner_principal_credit_usd` / `result.owner_principal_credit_usd`
-   etc. equal the balance-snapshot / posting amounts for the corresponding
-   roles. Because the engine takes those arrays straight off the application
-   objects (and the same objects produce the rows), drift is structurally
-   impossible.
-
-4. Schema-only assets and liabilities advertise state the engine ignores. (Completed)
-
-   Removed classes: `CashAssetPosition`, `RealEstateAssetPosition`,
-   `DeferredTaxAssetPosition`, `MortgageLiability`, `TaxLiability`, and
-   `ActorEquityClaimLiability`. The engine initializes cash from accounts,
-   real estate from `property_selection`, and mortgage state from `financing`.
-
-   Why suspicious: these look like first-class balance-sheet primitives, but
-   not all of them affect simulation. That conflicts with the design goal that
-   initial accounts/assets/liabilities drive runtime state.
-
-   Completed by: remove unsupported asset/liability variants from the public
-   union. Initial cash remains account-owned, public stock/private equity
-   remain asset-owned, and mortgage behavior remains financing-owned.
-
-   Proved safe by: a scenario with one of these positions now must either be
-   rejected or change results in a tested, documented way.
-
-5. Vacancy was classified and posted as an expense. (Completed 2026-05-16)
-
-   The property-operating journal entry debited `RENTAL_VACANCY_LOSS` (an
-   account that fell through to `ChartAccountType.EXPENSE`) and credited a
-   gross-rent income account, with cash debited for the net. That treated
-   "rooms not rented" as an outflow, when it is just the absence of a rent
-   credit.
-
-   Replaced with: vacancy is now a multiplier on rent collected. The journal
-   credits a single `RENTAL_INCOME` (income) account with the actual rent
-   received and debits cash with the same amount. `RENTAL_GROSS_INCOME` and
-   `RENTAL_VACANCY_LOSS` chart-account roles and the matching `ReportMetric`
-   entries are gone; `vacancy_pct` / `room_vacancy_pct` stay as multiplier
-   knobs on the rental plan. Leasing fees now scale with actual rent
-   collected rather than gross potential, consistent with the multiplier
-   framing.
-
-6. Property-sale tax was duplicated through a flat-rate path. (Completed 2026-05-16)
-
-   `property_sale.py` computed `sale_tax` from `tax_profile.marginal_tax_rate`
-   (capped at 38.3%) and `tax_profile.cap_gains_rate`, fed it into
-   `disposition.net_proceeds`, and then `scenario_engine.py` recomputed the
-   right value via `annual_sale_tax_allocation` (bracket-aware federal + CA),
-   reconciling the difference through `tax_cash_adjustment` and
-   `obligation_tax_due`. The flat-rate value was effectively ignored for the
-   reported `property_sale_net_proceeds_usd` but still leaked into the cash
-   reconciliation.
-
-   Replaced with: `property_disposition_arrays` now reports pre-tax proceeds
-   only (`property_sale_tax_usd` is zero in the disposition; `net_proceeds =
-gross - closing - debt`). The engine drives sale tax exclusively through
-   the bracket-aware annual-tax obligation path that already settles
-   stock-sale and PE-sale tax, so all three sale types now share one
-   pipeline. `TaxProfile.marginal_tax_rate` / `cap_gains_rate` are no longer
-   consumed by the engine; see TODO for their schema-level removal.
-
-7. `PolicyContext` and dynamic metric access look like future scaffolding, not
-   current primitives. (Completed 2026-05-16)
-
-   `PolicyContext` was deleted from `augur/core/policy_runtime.py` (no
-   production callers). `ScenarioRun._metric_array()`,
-   `ScenarioRun.{matrix,series,terminal}()`, and
-   `RolloutDetail.{series,terminal}()` were tightened to accept only
-   `ReportMetric` (no longer `ReportMetric | str`). Metric lookup goes through
-   `report_metric_array(arrays, metric)` which consults the explicit
-   `_report_metric_arrays(arrays)` table mapping `ReportMetric` enum values to
-   the corresponding `ScenarioRunArrays` attributes — no `getattr` probing.
-   Tests in `test_e2e.py` and `scenario_engine_test.py` were updated to pass
-   `ReportMetric` enum values.
 
 ## Recent Work Risk Review
 
@@ -223,13 +113,12 @@ gross - closing - debt`). The engine drives sale tax exclusively through
    monthly loops, and extend policy trace rows as trajectory inspection needs
    no-op/rejected/applied decision detail.
 
-2. Pick one trace/source-of-truth path. Start by collapsing one duplicated
-   family, such as mortgage payment action rows or partner ownership rows, into
-   ledger/accounting/snapshot detail.
+2. Pick one trace/source-of-truth path. Collapse one duplicated family, such as
+   mortgage payment action rows, into ledger/accounting/snapshot detail.
 
-3. Replace temporary tax timing with obligations. Keep
-   `cash_negative` as a warning, but introduce failure only through an
-   obligation settlement result, not through raw cash-path inspection.
+3. Replace temporary tax timing with obligations. Keep `cash_negative` as a
+   warning, but introduce failure only through an obligation settlement result,
+   not through raw cash-path inspection.
 
 ## Suggested Tests/Guards
 

--- a/augur/plans/e2e_redesign.md
+++ b/augur/plans/e2e_redesign.md
@@ -112,11 +112,8 @@ Keep these as pending sketches until the obligation/settlement shape exists:
 
 ## Active Step 7: Arrays Reconcile To Ledger
 
-Current status: first-pass reconciliation coverage exists, public row-level
-detail is available, and the main recurring cash-flow, sale transaction,
-partner-contribution, and sale-tax explanation arrays now derive from
-ledger/snapshot/accounting-detail rows. The remaining work is to keep shrinking
-bespoke explanatory array math without changing monthly-column semantics.
+Goal: monthly columns remain charts, not truth. Keep shrinking bespoke
+explanatory array math without changing monthly-column semantics.
 
 Next slices:
 
@@ -195,27 +192,20 @@ verification loop.
 
 ## Next App-State Spiral
 
-The browser scenario state is now written, read, normalized, serialized, and
-mapped to backend requests by domain section. The remaining app-state risk is
-letting the browser become its own schema authority through hand-maintained
-field lists and local validation logic.
+The remaining app-state risk is letting the browser become its own schema
+authority through hand-maintained field lists and local validation logic.
 
 Next slice:
 
-1. Add an Augur schema-export target for the backend Pydantic API models,
-   likely via FastAPI/OpenAPI or a focused Pydantic JSON-schema emitter.
-2. Generate browser-consumable schema/types from that backend schema at build
-   time, following existing repo patterns such as `//devinfra/js:openapi.bzl`
-   and `//props/frontend/src/lib:schema`.
-3. Replace hand-maintained browser field lists and ad hoc boundary checks with
-   the generated artifacts. If the browser uses Zod or a similar library, it
-   should consume generated schemas rather than defining a second source of
-   truth.
-4. Do not preserve stale URL compatibility when the state shape changes again.
+1. Wire the existing OpenAPI/Zod generated artifacts (`//devinfra/js:openapi.bzl`,
+   `augur/api/openapi_schema.py`) into `augur/frontend/lib/scenario_set_state.js`
+   normalization and request mapping. Replace hand-maintained browser field lists
+   and ad hoc boundary checks with the generated schemas.
+2. Do not preserve stale URL compatibility when the state shape changes again.
 
 Acceptance checks:
 
-- There is one schema source of truth for Augur API payloads: Python Pydantic.
+- Pydantic is the single schema source of truth for Augur API payloads.
 - Browser validation/types are generated from the backend schema, not
   independently maintained.
 - Adding a new API field starts in the Pydantic model and propagates to the

--- a/augur/plans/prior_art_audit.md
+++ b/augur/plans/prior_art_audit.md
@@ -1,7 +1,5 @@
 # Augur Prior Art Audit
 
-Last updated: 2026-05-15.
-
 ## Executive Summary
 
 Augur is closest to a dynamic household microsimulation and personal-finance
@@ -12,38 +10,26 @@ an economic scenario generator input/output, `ScenarioSet` is the portfolio of
 household scenario variants, `rollout_index` selects one sampled path, and the
 policy runtime is the pathwise deterministic projector.
 
-The current architecture is directionally aligned with good practice. It already
-has `ScenarioSet`, `MarketRequest`, `MarketBundle`, seeded path generation,
-actor policies, row-level actions, policy decisions, market observations, ledger
-entries, balance snapshots, accounting details, and distribution-vs-trajectory
-result panels. That is the right raw vocabulary.
+The important gaps the rest of this audit explores:
 
-The important gaps are sharper than the code currently names:
-
-- `rollout_index` is not a sufficient trajectory identity. Augur now carries a
-  first typed path/projection identity layer; reproducibility still needs those
+- `rollout_index` is not a sufficient trajectory identity. Reproducibility needs
   IDs backed by persisted evidence/calibration artifacts, generator versions,
   scenario inputs, and any non-market event streams.
-- Policy programs now execute through the ordered actor program path. The
-  remaining gap is richer execution trace coverage for no-op, rejected,
-  instructed, and applied decisions as policy families grow.
-- Cash-under-zero and failed-rollout semantics now have a first slice: unsettled
-  required annual-tax obligations produce settlement/failure rows and failed
-  rollout status. The remaining gap is generalizing that shape to mortgages,
-  other cash demands, explicit credit/default state, and continued-vs-terminated
-  projection behavior.
-- Ledger and accounting detail are valuable but not yet accounting-grade. Many
-  arrays are now derived or reconciled, but postings are still stringly typed
-  `domain`/`category` rows rather than balanced journal entries with typed
-  accounts, lots, liabilities, cause ids, and reconciliation invariants.
-- Model governance has a first typed surface: model card, validation-report,
-  evidence, calibration, scenario-generator, and path-set identities are attached
-  to market outputs. They are not yet decision-grade governance artifacts:
+- Policy execution traces need richer coverage for no-op, rejected, instructed,
+  and applied decisions as policy families grow.
+- Cash-under-zero and failed-rollout semantics should generalize beyond the
+  annual-tax obligation slice to mortgages, other cash demands, explicit
+  credit/default state, and continued-vs-terminated projection behavior.
+- Ledger and accounting detail are valuable but not yet accounting-grade.
+  Postings are still stringly typed `domain`/`category` rows rather than
+  balanced journal entries with typed accounts, lots, liabilities, cause ids,
+  and reconciliation invariants.
+- Model governance has a first typed surface but is not yet decision-grade:
   validation is placeholder-level and evidence/calibration artifacts are not
   persisted reviewed records.
-- Calibration/evidence and projection boundaries are improving but should be
-  made explicit: evidence feeds model fitting; fitted scenario generators feed
-  `MarketBundle`; the core projector should not know source-specific evidence.
+- Calibration/evidence and projection boundaries should be explicit: evidence
+  feeds model fitting; fitted scenario generators feed `MarketBundle`; the core
+  projector should not know source-specific evidence.
 
 ## Local Architecture Grounding
 
@@ -474,25 +460,6 @@ Recommended vocabulary:
 - `MarketBundle`
 
 ## Alignment Audit
-
-### Already Matching Good Practice
-
-- Distribution-first unit: `ScenarioSet` across sampled paths is the public
-  unit, with one rollout treated as an inspection detail.
-- Shared path semantics: the same `rollout_index` is comparable across scenario
-  variants within a scenario-set run.
-- Scenario generation boundary: `MarketBundleProvider` and `MarketBundle` keep
-  market sampling separate from projection.
-- Seeded reproducibility: `MarketRequest.seed` and `MarketBundleMetadata.seed`
-  exist.
-- Typed trace surfaces: actions, policy decisions, market observations, ledger
-  entries, balance snapshots, and accounting details are present.
-- Model layer boundary: `augur/model/` handles evidence, fitting, market
-  models, and provider composition.
-- UI direction: `distribution`, `trajectory`, and `accounting_detail`
-  result-panel kinds are the right top-level result modes.
-- Ledger reconciliation direction: e2e tests now assert that important arrays
-  derive from ledger/snapshot/accounting detail.
 
 ### Too Simplistic Or Weird
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -369,66 +369,32 @@ Work:
    normalization and request mapping, then split app/frontend/server packages
    after the core contracts and server cleanup settle.
 
-## Dispatch Status (2026-05-17)
+## In Flight
 
-Worktree isolation lets parallel subagents stomp on the same files freely;
-overlap resolves at PR merge.
-
-### Round 1 — ✅ all landed
-
-- **Plan A — Consume Generated Browser Schemas** (#1557 / #1561 / #1563).
-- **Plan B — PE opportunities & policy explicit** (#1568).
-- **Plan C — Tax/Obligation settlement slice, mortgage** (#1570).
-  Sale-tax timing piece deferred (now in Round 3).
-- **Plan E — Server boundary cleanup** (#1567 — typed `BundleSource`).
-- **Plan F — Location tax defaults to model config** (#1566); cycle fix
-  (#1569).
-
-### Round 2 — ✅ all landed
-
-- **Cleanup audit item 7** — `PolicyContext` (already gone) + typed
-  `ReportMetric` lookup replacing `_metric_array` (#1571).
-- **Plan G — Split app package boundaries + drop `augur_` prefixes** —
-  ducktape #1575, gaffer-private #109. `augur/app/` → `augur/frontend/`
-  (browser bundle, `visual_golden_test.py`, `lib/`, `__screenshots__/`) +
-  `augur/api/` (Python server: `backend.py` ← `augur_backend.py`,
-  `catalog.py`, `config.py`, `http_server.py`, `server.py`,
-  `export_schema.py`, `browser_state.py`, `browser_shell_test.py`,
-  `testdata/`). Other module renames: `augur_client.js` → `client.js`,
-  `augur-app.jsx` → `app.jsx`. `AugurBackend` class name preserved.
-- **Plan D — Market configuration typed at boundary** — already
-  guardrailed by `market_config_test.py`; no dispatch needed.
-- **Portfolio YAML contract** — discovered to be already shipped in
-  `bb4d8b681`. PR #1573 narrowed the stale TODO bullet to the deferred
-  runtime-consumption work.
-
-### Round 3 — in flight
-
-- **Sale-tax timing slice** 🟡 on `claude/sale-tax-timing-slice`.
-  Finishes C's deferred half — moves sale-tax obligations off
+- **Sale-tax timing slice** — move sale-tax obligations off
   `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
-  dates. `augur/core/{annual_tax,scenario_engine}.py`; wide test churn +
-  visual-golden refresh (goldens now live under
-  `augur/frontend/__screenshots__/` after Plan G).
-- **Cleanup audit item 3 — partner ownership parallel ledger paths**
-  🟡 on `claude/partner-ownership-parallel-paths`. Collapses the
-  duplicate ledger-row reconstruction in
+  dates. `augur/core/{annual_tax,scenario_engine}.py` + visual goldens.
+- **Cleanup audit item 3 — partner ownership parallel ledger paths** —
+  collapse the duplicate ledger-row reconstruction in
   `_record_partner_agreement_ledger_detail`.
   `augur/core/{policy_runtime,scenario_engine}.py`.
 
-### Round 4 candidates (not yet dispatched)
+## Next Lanes (parallelism + sequencing)
 
-- **Generalize rollout failure semantics beyond mortgage** —
-  insurance / HOA / special assessments through the obligation pipeline.
-  Conflicts with sale-tax + partner-ownership on `scenario_engine.py`;
-  wait for Round 3.
-- **Cleanup audit item 2** — pick one source of truth for trace detail
-  (actions / decisions / ledger / snapshots / accounting / monthly arrays
-  overlap heavily). Wait for Round 3.
-- **Teach runtime funding policies to consume crypto + tender-aware PE**
-  positions from the portfolio YAML contract. Self-contained.
+- **Generalize rollout failure semantics beyond mortgage** — insurance /
+  HOA / special assessments through the obligation pipeline. Sequence
+  after sale-tax + partner-ownership (shares `scenario_engine.py`).
+- **Cleanup audit item 2 — pick one source of truth for trace detail**.
+  Actions, decisions, ledger entries, balance snapshots, accounting
+  details, monthly arrays overlap heavily. Collapse one row/decision/
+  ledger surface; document which stays. Sequence after Round 3 (shares
+  `scenario_engine.py`).
+- **Teach runtime funding policies to consume crypto + tender-window-
+  aware private-equity positions** from the portfolio YAML contract.
+  Self-contained.
 - **Persist model-governance artifacts** — durable evidence / calibration
-  / validation-report storage. `augur/model/`. Self-contained.
+  / validation-report storage for market providers. `augur/model/`.
+  Self-contained.
 
 ## Next Work Plans
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -369,6 +369,67 @@ Work:
    normalization and request mapping, then split app/frontend/server packages
    after the core contracts and server cleanup settle.
 
+## Dispatch Status (2026-05-17)
+
+Worktree isolation lets parallel subagents stomp on the same files freely;
+overlap resolves at PR merge.
+
+### Round 1 — ✅ all landed
+
+- **Plan A — Consume Generated Browser Schemas** (#1557 / #1561 / #1563).
+- **Plan B — PE opportunities & policy explicit** (#1568).
+- **Plan C — Tax/Obligation settlement slice, mortgage** (#1570).
+  Sale-tax timing piece deferred (now in Round 3).
+- **Plan E — Server boundary cleanup** (#1567 — typed `BundleSource`).
+- **Plan F — Location tax defaults to model config** (#1566); cycle fix
+  (#1569).
+
+### Round 2 — ✅ all landed
+
+- **Cleanup audit item 7** — `PolicyContext` (already gone) + typed
+  `ReportMetric` lookup replacing `_metric_array` (#1571).
+- **Plan G — Split app package boundaries + drop `augur_` prefixes** —
+  ducktape #1575, gaffer-private #109. `augur/app/` → `augur/frontend/`
+  (browser bundle, `visual_golden_test.py`, `lib/`, `__screenshots__/`) +
+  `augur/api/` (Python server: `backend.py` ← `augur_backend.py`,
+  `catalog.py`, `config.py`, `http_server.py`, `server.py`,
+  `export_schema.py`, `browser_state.py`, `browser_shell_test.py`,
+  `testdata/`). Other module renames: `augur_client.js` → `client.js`,
+  `augur-app.jsx` → `app.jsx`. `AugurBackend` class name preserved.
+- **Plan D — Market configuration typed at boundary** — already
+  guardrailed by `market_config_test.py`; no dispatch needed.
+- **Portfolio YAML contract** — discovered to be already shipped in
+  `bb4d8b681`. PR #1573 narrowed the stale TODO bullet to the deferred
+  runtime-consumption work.
+
+### Round 3 — in flight
+
+- **Sale-tax timing slice** 🟡 on `claude/sale-tax-timing-slice`.
+  Finishes C's deferred half — moves sale-tax obligations off
+  `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
+  dates. `augur/core/{annual_tax,scenario_engine}.py`; wide test churn +
+  visual-golden refresh (goldens now live under
+  `augur/frontend/__screenshots__/` after Plan G).
+- **Cleanup audit item 3 — partner ownership parallel ledger paths**
+  🟡 on `claude/partner-ownership-parallel-paths`. Collapses the
+  duplicate ledger-row reconstruction in
+  `_record_partner_agreement_ledger_detail`.
+  `augur/core/{policy_runtime,scenario_engine}.py`.
+
+### Round 4 candidates (not yet dispatched)
+
+- **Generalize rollout failure semantics beyond mortgage** —
+  insurance / HOA / special assessments through the obligation pipeline.
+  Conflicts with sale-tax + partner-ownership on `scenario_engine.py`;
+  wait for Round 3.
+- **Cleanup audit item 2** — pick one source of truth for trace detail
+  (actions / decisions / ledger / snapshots / accounting / monthly arrays
+  overlap heavily). Wait for Round 3.
+- **Teach runtime funding policies to consume crypto + tender-aware PE**
+  positions from the portfolio YAML contract. Self-contained.
+- **Persist model-governance artifacts** — durable evidence / calibration
+  / validation-report storage. `augur/model/`. Self-contained.
+
 ## Next Work Plans
 
 ### Plan A: Consume Generated Browser Schemas

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -374,10 +374,6 @@ Work:
 - **Sale-tax timing slice** — move sale-tax obligations off
   `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
   dates. `augur/core/{annual_tax,scenario_engine}.py` + visual goldens.
-- **Cleanup audit item 3 — partner ownership parallel ledger paths** —
-  collapse the duplicate ledger-row reconstruction in
-  `_record_partner_agreement_ledger_detail`.
-  `augur/core/{policy_runtime,scenario_engine}.py`.
 
 ## Next Lanes (parallelism + sequencing)
 


### PR DESCRIPTION
## Summary

Planning artifacts had accumulated `(Completed)` items, "Round X landed"
checklists, and "current alignment + gap" pairings — all backwards-looking
chronicle that git already records. This PR strips that to keep
`augur/plans/*.md` + `augur/TODO.md` looking forward only.

- **`cleanup_audit.md`**: drop six `(Completed)` items (ordered policy
  programs, partner-ownership ledger collapse, inert schema variants,
  vacancy classification, property-sale flat-rate tax path, PolicyContext
  / dynamic metric access). The remaining open item (trace-surface
  collapse) and the risk-review / guard sections stay.
- **`prior_art_audit.md`**: drop "Already Matching Good Practice"
  checklist and collapse executive-summary "Augur now has X; gap is Y"
  pairs to just the gaps. Drop "Last updated" timestamp.
- **`e2e_redesign.md`**: drop "Current status" preamble on Step 7;
  collapse the schema-generation slice to the remaining wiring step now
  that the OpenAPI/Zod generators already exist.
- **`TODO.md` + `roadmap.md`**: drop the partner-ownership "In Flight"
  entry (PR #1576 squash-merged on devel). Sale-tax timing slice is the
  only thing left in flight.
- **`README.md`**: fix stale `app/` + `app/lib/` layout rows to match
  the post-#1575 `frontend/` + `api/` split.

Net: -194 / +69 across six files. Zero behavior change.

## Test plan

- [ ] Pre-commit hooks pass (prettier, ducktape pre-commit, commit-msg) —
  already verified locally on each commit.
- [ ] No code touched, so no test targets to run.


---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_