### PR TITLE
augur/plans: replace Plan C with unified obligation/funding plan; queue Simulation-prefix scrub

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -12,13 +12,14 @@ second ordered roadmap.
 
 ## In Flight
 
-- Sale-tax timing slice — move sale-tax obligations off
-  `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
-  dates. PR #1578.
 - Funding policies consume crypto + tender-window-aware PE — extend the
   obligation-funding policy chain so `CheckingFloorSellPublicStockPolicy`
   (and siblings) can liquidate crypto holdings and tender-eligible PE
   alongside SP500. Branch `claude/funding-policies-crypto-tender`.
+- Collapse trace surfaces — cleanup-audit item 2. Make
+  ledger/accounting/snapshot rows the canonical detail surface and either
+  delete `SimulationAction` rows or narrow them to user-visible commands.
+  Branch `claude/collapse-trace-surfaces`.
 
 ## Next
 
@@ -26,7 +27,10 @@ second ordered roadmap.
       normalization and request mapping. Python Pydantic remains the source of
       truth; do not grow a second hand-maintained Zod/schema definition in
       `augur/frontend`.
-- [ ] Continue `plans/e2e_redesign.md` Step 7: quarterly estimated tax payments and underpayment safe-harbor rules on top of the existing year-end annual-tax obligation.
+- [ ] Plan C in `plans/roadmap.md`: unified obligation/funding semantics
+      for all immediate cash demands (property tax, HOA, insurance,
+      maintenance, outside rent, partner contributions, special assessments,
+      quarterly estimated taxes).
 - [ ] Make the generic Augur OCI image public-safe: no private Python config, property records, or media in image layers; deployments supply private config and assets through mounted runtime inputs.
 - [ ] Add a durable property-asset storage contract: stable property asset IDs/URLs backed by object storage or a database-like asset table, so deployments do not need to bake private media into frontend images.
 
@@ -56,10 +60,6 @@ second ordered roadmap.
       that explicit, and consider separate structures/identifiers for market
       nondeterminism, policy nondeterminism, and any future non-market random
       events so trajectory IDs do not conflate different sources of randomness.
-- [ ] Generalize rollout failure semantics beyond the first annual-tax
-      obligation settlement slice. `RolloutStatusType.FAILED` now hangs off
-      unsettled required obligations; extend that pattern to mortgages, other
-      tax/payment demands, and future default/termination behavior.
 - [ ] Decide whether negative cash is allowed only through explicit borrowing.
       If the model says an actor has overdraft, credit-line, margin, or other
       borrowing capacity, negative cash can be an accounting effect paired with
@@ -75,12 +75,6 @@ second ordered roadmap.
       contradict each other.
 - [ ] Reduce single-property/global assumptions. Scenario-level `property_selection`, `financing`, `rental_plan`, and `tax_profile` should eventually become initial positions, per-property settings, or per-actor/accounting inputs as the simulator grows.
 - [ ] Replace built-in `LocationId` enum with database-like location entities, parallel to properties. A location should carry regulation/tax/modeling knobs that downstream regulation and tax code interprets, not require hardcoded enum extension.
-- [ ] Move pure-data model inputs, catalog rows, local-regulation/tax defaults,
-      and location-to-tax-regime mappings out of app/server Python and into
-      typed configuration resources, such as Pydantic-parsed YAML loaded via
-      runfiles or `importlib.resources`. Keep Python for loading, validation,
-      and composition logic; use behavior tests around conversion/catalog
-      output rather than literal YAML mirror tests.
 - [ ] Prefer Pydantic for serde and validation at API/config boundaries. Avoid
       custom `to_json_dict()`-style conversion helpers except at narrow
       compatibility seams.
@@ -88,15 +82,6 @@ second ordered roadmap.
       fields should update `augur/model/market_config_test.py`, remain
       Pydantic-parsed at load time, and avoid stale simulation knobs already
       owned by `MarketRequest`.
-- [ ] Teach runtime funding policies to consume the crypto and
-      tender-window-aware private equity positions modeled in the public
-      portfolio YAML contract (`augur/core/portfolio.py`,
-      `augur/core/testdata/portfolio.example.yaml`). Today
-      `PortfolioStatement.to_initial_balance_sheet()` maps cash + generic S&P 500
-      lots + opaque PE marks into the existing `InitialBalanceSheet` shape and
-      drops crypto holdings and tender windows; the simulator should grow first-
-      class handling for those positions instead of only preserving them in
-      typed input data.
 - [ ] Persist and harden model-governance artifacts for market providers. The
       runtime now attaches typed model card, evidence, calibration, scenario
       generator, path-set, and validation-report identities; the next step is
@@ -109,9 +94,6 @@ second ordered roadmap.
       satisfy the generic asset-position schema. Clean this up in the backend
       position/API model so simulation owns the mark.
 - [ ] Move evidence/model-fetching shapes out of core simulator API when touched. Core should consume calibrated market/provider inputs, not source-specific evidence objects.
-- [ ] Remove redundant `augur_` prefixes from internal module names such as
-      `augur.core.augur_accounting`; inside the `augur` package they add noise
-      without clarifying ownership.
 
 ## Tax Follow-Ups
 
@@ -120,33 +102,11 @@ second ordered roadmap.
       deductible expenses, passive-loss release, SALT/property-tax treatment,
       California conformity/non-conformity, and ordinary income schedules
       beyond one annual `TaxProfile` value.
-- [ ] Layer quarterly estimated-payment timing on top of the existing
-      year-end annual-tax obligation. Sale tax now accrues per source month
-      (TaxPaymentAllocationDetail, `payment_timing=YEAR_END`) and settles in
-      a single year-end obligation collapsed onto month index `year * 12 +
-11` (clipped to horizon). Quarterly estimated payments (and the
-      safe-harbor rules around underpayment penalties) are a follow-on.
-- [ ] Prefer yearly income/tax-lot ledgers with explicit tax settlement near
-      realistic payment dates over trying to account for every tax effect at
-      the moment income or a gain occurs. The settlement workflow should also
-      model cash management: pay from cash when possible, otherwise invoke an
-      explicit sale/financing policy to raise cash for the tax bill.
-- [ ] Promote mortgage payments to the same first-class obligation/funding
-      flow as annual taxes. Today `apply_mortgage_payment` debits cash
-      unconditionally; insufficient cash silently goes negative instead of
-      raising an obligation, invoking a funding policy, and failing the
-      rollout when no policy can cover it. The natural pattern is the one
-      tax now uses (obligation -> funding decision -> settlement or failure).
+- [ ] Underpayment-penalty calculation on estimated taxes (interest on
+      quarterly shortfalls) once the estimated-payment obligations land in
+      Plan C.
 - [ ] Keep stock-sale, PE-sale, and property-sale tax reconciliation in the
       Step 7 test set.
-- [ ] Remove the unused flat tax-rate fields. `TaxProfile.marginal_tax_rate`
-      and `cap_gains_rate` no longer drive any engine computation (the
-      bracket-aware annual-tax allocation owns federal + California for
-      capital gains and depreciation recapture). The fields are still in
-      the schema, browser state, and `apply_private_equity_sale_instruction`'s
-      `cap_gains_rate_pct` parameter (always passed `0.0`). Drop them across
-      schema, app catalog defaults, browser state, and the policy-runtime
-      signature in one atomic change.
 
 ## Reporting / UI Follow-Ups
 

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -31,6 +31,19 @@ second ordered roadmap.
       for all immediate cash demands (property tax, HOA, insurance,
       maintenance, outside rent, partner contributions, special assessments,
       quarterly estimated taxes).
+- [ ] Drop the `Simulation` prefix from internal class names. Inside a
+      simulator every class is by definition simulated; the prefix adds
+      noise without disambiguating. Survey hit (after trace-surface collapse
+      lands): `SimulationAction`, `SimulationPolicyDecision`,
+      `SimulationMarketObservation`, `SimulationJournalEntry`,
+      `SimulationPosting`, `SimulationBalanceSnapshot`,
+      `SimulationAccountingDetail`, `SimulationObligation`,
+      `SimulationFundingDecision`, `SimulationSettlementResult`,
+      `SimulationFailureEvent`, `SimulationResult`, `SimulationRun`,
+      `SimulationTerminal`, `SimulationValidationError`, plus the
+      `_SimulationTraceBase` / `_SimulationActionBase` family. All
+      6 files are in `augur/core/`; the wire JSON keys do not carry the
+      prefix, so this is a purely internal rename.
 - [ ] Make the generic Augur OCI image public-safe: no private Python config, property records, or media in image layers; deployments supply private config and assets through mounted runtime inputs.
 - [ ] Add a durable property-asset storage contract: stable property asset IDs/URLs backed by object storage or a database-like asset table, so deployments do not need to bake private media into frontend images.
 

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -14,7 +14,11 @@ second ordered roadmap.
 
 - Sale-tax timing slice — move sale-tax obligations off
   `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
-  dates. Branch `claude/sale-tax-timing-slice`.
+  dates. PR #1578.
+- Funding policies consume crypto + tender-window-aware PE — extend the
+  obligation-funding policy chain so `CheckingFloorSellPublicStockPolicy`
+  (and siblings) can liquidate crypto holdings and tender-eligible PE
+  alongside SP500. Branch `claude/funding-policies-crypto-tender`.
 
 ## Next
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -371,10 +371,6 @@ Work:
 
 ## In Flight
 
-- **Sale-tax timing slice** — move sale-tax obligations off
-  `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
-  dates. `augur/core/{annual_tax,scenario_engine}.py` + visual goldens.
-  PR #1578.
 - **Funding policies consume crypto + tender-window-aware PE** —
   `PortfolioStatement.to_initial_balance_sheet()` currently drops crypto
   holdings and tender windows. First-class runtime handling: a new
@@ -382,23 +378,19 @@ Work:
   and extension of `CheckingFloorSellPublicStockPolicy` (and the
   obligation-funding chain) to liquidate crypto and tender-eligible PE.
   `augur/core/{portfolio,scenario_set,policy_runtime,scenario_engine}.py`.
+- **Collapse trace surfaces** — cleanup-audit item 2. Make
+  ledger/accounting/snapshot rows the canonical detail surface; either
+  delete `SimulationAction` rows or narrow them to user-visible commands.
+  `augur/core/{scenario_set,scenario_engine}.py`.
 
 ## Next Lanes (parallelism + sequencing)
 
-- **Generalize rollout failure semantics beyond mortgage** — insurance /
-  HOA / special assessments through the obligation pipeline. Sequence
-  after sale-tax + partner-ownership (shares `scenario_engine.py`).
-- **Cleanup audit item 2 — pick one source of truth for trace detail**.
-  Actions, decisions, ledger entries, balance snapshots, accounting
-  details, monthly arrays overlap heavily. Collapse one row/decision/
-  ledger surface; document which stays. Sequence after Round 3 (shares
-  `scenario_engine.py`).
-- **Teach runtime funding policies to consume crypto + tender-window-
-  aware private-equity positions** from the portfolio YAML contract.
-  Self-contained.
+- **Plan C (unified obligation/funding semantics)** — see below.
+  Sequence after the trace-surface collapse and crypto/tender-PE funding
+  slices land, since they all share `scenario_engine.py`.
 - **Persist model-governance artifacts** — durable evidence / calibration
   / validation-report storage for market providers. `augur/model/`.
-  Self-contained.
+  Self-contained, can run in parallel with anything.
 
 ## Next Work Plans
 
@@ -435,110 +427,94 @@ Validation:
 
 - `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-pe-plan test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/api:browser_shell_test --nocache_test_results --test_size_filters=small,medium,large`
 
-### Plan C: Tax/Obligation Settlement Slice
+### Plan C: Unified Obligation/Funding Semantics For All Immediate Cash Demands
 
-Status:
+Today, `ObligationType` only covers `ANNUAL_TAX_PAYMENT` and `MORTGAGE_PAYMENT`.
+Everything else that demands cash — property tax, HOA dues, insurance,
+maintenance, outside rent, partner contributions, special assessments — still
+debits cash directly from the operating-cash-flow appliers, with no
+obligation/funding/failure rows on the trace. That makes "rollout failed because
+the actor couldn't pay X" reachable only for tax + mortgage.
 
-- First slice landed for annual tax obligations: unsettled required obligations
-  produce settlement/failure rows and `RolloutStatusType.FAILED`; sale policy can
-  rescue the obligation.
-- Property-sale tax now flows through the same bracket-aware obligation path
-  (2026-05-16). `property_disposition_arrays` reports pre-tax proceeds only;
-  the engine drives sale tax exclusively through `annual_sale_tax_allocation`,
-  so stock-sale, PE-sale, and property-sale tax share one settlement pipeline.
-- Sale-tax obligation timing moved off the source month onto year-end
-  (2026-05-17). `TaxPaymentTiming.YEAR_END` is the new default;
-  `TaxPaymentAllocationDetail` keeps per-source-month accrual provenance,
-  but the obligation that draws cash collapses each tax year onto month
-  index `year * 12 + 11` (clipped to the simulation horizon). Property sale
-  journal entries no longer post to `TAX_EXPENSE`; the year-end tax accrual
-  - settlement journal entries do. The `CheckingFloorSellPublicStockPolicy`
-    funding-policy escape hatch still applies at the settlement month.
+Generalize the shape so **one** pattern handles every immediate cash demand:
 
-Scope:
+1. The accrual path produces a `SimulationObligation` row carrying actor_id,
+   amount_usd, due_month_index, cause_id, obligation_type, and creditor_kind.
+2. The unified `_settle_required_cash_obligations` chain attempts to settle:
+   try cash, then walk the actor's ordered funding policies until either
+   settled or exhausted.
+3. Unsettled required obligations emit `FailureEvent` + flip
+   `RolloutStatusType` to `FAILED`.
 
-- Layer quarterly estimated-payment timing on top of the year-end
-  obligation. Safe-harbor and underpayment-penalty rules are a follow-on.
-- Add tests for mortgage/payment shortfall, sale-policy rescue, explicit
-  failure/default semantics, and continued-vs-terminated projection behavior.
+#### Slices
+
+1. **Expand `ObligationType`** beyond `ANNUAL_TAX_PAYMENT` /
+   `MORTGAGE_PAYMENT`. Add: `PROPERTY_TAX`, `HOA_DUES`, `INSURANCE_PREMIUM`,
+   `MAINTENANCE`, `OUTSIDE_RENT`, `SPECIAL_ASSESSMENT`,
+   `PARTNER_CONTRIBUTION`. Each variant declares `required: bool` — required
+   obligations produce `FAILED` on shortfall; discretionary obligations are
+   best-effort and produce a settlement row but not a failure event.
+2. **Refactor `apply_property_operating_cash_flows`** (<augur/core/policy_runtime.py>)
+   to emit obligations instead of directly debiting cash. Same accrual
+   amounts, same months, same chart-account roles — the only visible change
+   is new obligation/settlement rows on the trace. Cash trajectories should
+   match the current behavior on the happy path.
+3. **Outside-rent obligations** for `OccupancyMode.OWNER_RENTS_ELSEWHERE`.
+   Today this isn't first-class. Add a `RentalPaymentPolicy` (or extend
+   `OccupancyDecisionPolicy`) that accrues monthly rent as a required
+   obligation. Verify against existing tests.
+4. **Partner-contribution obligations**. Today
+   `apply_partner_house_cost_contribution` debits cash unconditionally. The
+   contributing actor's failure to fund their share of housing costs is a
+   real-world failure mode and should produce `FAILED`. Move the cash debit
+   to the obligation pipeline. The owner side (which credits cash) stays
+   direct since it's a receipt, not a demand.
+5. **Quarterly estimated tax payments** on top of the year-end obligation.
+   Standard schedule: Apr 15, Jun 15, Sep 15, Jan 15 of the following year
+   (clamped to horizon). Safe-harbor: 100% of prior-year tax (110% when AGI
+   exceeds the $150k single / $75k MFS threshold), divided into four equal
+   estimated payments. First year (no prior-year tax): use 90% of estimated
+   current-year tax. The year-end obligation amount reduces by the sum of
+   estimated payments actually made.
+6. **Special-assessment events**. Add a `SpecialAssessment` event variant
+   for one-shot HOA assessments, surfaced through the existing event
+   pipeline. Each event produces a `SPECIAL_ASSESSMENT` obligation due in
+   the event month.
+7. **Generalize failure tests**. One `RolloutStatusType.FAILED` test per
+   obligation type proving the funding-policy chain runs, can be rescued
+   by an asset sale, and fails the rollout when no rescue is available.
+   Extend `test_e2e.py` with a "cash-strapped rental scenario" and a
+   "cash-strapped owner-rents-elsewhere scenario" that fail on the right
+   obligation.
+
+#### Out of scope (defer to a follow-on)
+
+- Underpayment-penalty calculation on estimated taxes (interest on
+  shortfalls). The estimated-payment obligations exist; the penalty
+  computation is a separate slice.
+- Discretionary-obligation deferral semantics (e.g. roll unpaid maintenance
+  into a follow-on month). For now every variant is required-or-cosmetic.
+- Explicit borrowing models (overdraft, credit line, margin) as an
+  alternative funding source. Today negative cash stays a warning; if a
+  borrowing facility is added later, it slots in as another
+  `FundingDecisionType`.
 
 Validation:
 
-- `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-obligation-plan test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:policy_runtime_test --nocache_test_results --test_size_filters=small,medium,large`
+```bash
+bbr test //augur/core:test_e2e //augur/core:scenario_engine_test \
+  //augur/core:policy_runtime_test //augur/core:annual_tax_test
+bbr test //augur/...
+bbr build //augur/...
+```
 
 ### Plan D: Keep Market Configuration Typed At The Boundary
 
-Status:
-
-- Implemented for the current macro market config. The remaining work is to
-  keep the file-contract guardrail in place as source data and downstream
-  deployment inputs grow.
-
-Scope:
-
-- Maintain the Pydantic model for the macro market config file and parse JSON
-  once at load time.
-- Keep `MacroMarketBundleProvider`, evidence loaders, and location market source
-  mapping on typed field access.
-- Keep `SourceDataConfig`, location-market-source validation, and the checked-in
-  example file under the same typed config tree, with no parallel hand-written
-  schema or compatibility path.
-- Reject stale simulation knobs at the file boundary. `MarketRequest` owns
-  rollout count, horizon, and seed; the market config should not keep a second
-  inert version of those controls.
-- Use the contract test as the review point when adding new source-data fields
-  or deployment-supplied config.
-
-Validation:
-
-- `bbr test //augur/model:market_config_test //augur/model/...`
-- `bbr test //augur/core:test_e2e`
-
-### Plan E: Server Boundary Cleanup
-
-Scope:
-
-- Replace `AugurBackend` constructor nullability with explicit dependency/config
-  objects or separate production/dev factory paths.
-- Collapse the one-function static-path helper into the HTTP server boundary
-  unless it grows real ownership.
-- Keep this as a behavior-preserving server cleanup; defer package moves until
-  the server surface is smaller.
-
-Validation:
-
-- `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-server-cleanup test //augur/api:browser_shell_test //augur/api:config_test --nocache_test_results --test_size_filters=small,medium,large`
-
-### Plan F: Move Location Tax Defaults To Model Config
-
-Scope:
-
-- Move app-owned tax-regime defaults and location-to-tax-regime mapping into
-  typed location/local-regulation configuration.
-- Keep app catalog/server code as a consumer of modeled location defaults, not
-  the place that decides tax semantics.
-- Use behavior tests around scenario conversion/catalog output rather than
-  literal YAML value change-detector tests.
-
-Validation:
-
-- `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-location-tax-config test //augur/api:catalog_test //augur/api:config_test //augur/core:local_regulation_test //augur/core:scenario_set_test --nocache_test_results --test_size_filters=small,medium,large`
-
-### Plan G: Split App Package Boundaries
-
-Scope:
-
-- Move browser code and bundle targets from `augur/app` toward an
-  `augur/frontend` package.
-- Move HTTP/API/server code from `augur/app` toward an `augur/server` or
-  `augur/api` package.
-- Run this after the server cleanup, Mantine cleanup, and visual-test helper
-  lanes land, so the split is mostly mechanical and easier to review.
-
-Validation:
-
-- `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-app-split test //augur/... --nocache_test_results`
-- `nix develop --command bazelisk --output_user_root=/tmp/bazel-augur-app-split build //augur/...`
+Guardrail, not an active slice. Keep the macro market config Pydantic-parsed
+at load time, with `market_config_test` as the review point when adding new
+source-data fields or deployment-supplied config. Reject stale simulation
+knobs at the file boundary — `MarketRequest` owns rollout count, horizon,
+and seed; the market config should not keep a second inert copy.
 
 ## Verification Loop
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -374,6 +374,14 @@ Work:
 - **Sale-tax timing slice** — move sale-tax obligations off
   `ALLOCATED_TO_SOURCE_MONTH` onto realistic year-end / estimated-payment
   dates. `augur/core/{annual_tax,scenario_engine}.py` + visual goldens.
+  PR #1578.
+- **Funding policies consume crypto + tender-window-aware PE** —
+  `PortfolioStatement.to_initial_balance_sheet()` currently drops crypto
+  holdings and tender windows. First-class runtime handling: a new
+  `AssetType.CRYPTO`, tender-window-driven `private_equity_sale_opportunity_mask`,
+  and extension of `CheckingFloorSellPublicStockPolicy` (and the
+  obligation-funding chain) to liquidate crypto and tender-eligible PE.
+  `augur/core/{portfolio,scenario_set,policy_runtime,scenario_engine}.py`.
 
 ## Next Lanes (parallelism + sequencing)
 


### PR DESCRIPTION
## Summary

Planning-artifact refresh — three commits, no code changes.

### 1. Plan C reframed (`plans/roadmap.md`)

Today only `ANNUAL_TAX_PAYMENT` and `MORTGAGE_PAYMENT` route through the
obligation/funding/settlement pipeline; everything else (property tax, HOA,
insurance, maintenance, outside rent, partner contributions, special
assessments) still debits cash directly. Generalize to **one** pattern for
every immediate cash demand, with quarterly estimated taxes stacked on top.

Slices:

1. Expand `ObligationType` beyond `ANNUAL_TAX_PAYMENT` / `MORTGAGE_PAYMENT`
   (add `PROPERTY_TAX`, `HOA_DUES`, `INSURANCE_PREMIUM`, `MAINTENANCE`,
   `OUTSIDE_RENT`, `SPECIAL_ASSESSMENT`, `PARTNER_CONTRIBUTION`), with
   required-vs-discretionary semantics.
2. Refactor `apply_property_operating_cash_flows` to emit obligations.
3. Outside-rent obligations for `OWNER_RENTS_ELSEWHERE`.
4. Partner-contribution obligations on the contributing actor.
5. Quarterly estimated tax payments — Apr/Jun/Sep/Jan schedule, safe-harbor
   100% prior-year (110% above the threshold), 90%-of-current-year for the
   first year, year-end obligation reduces by the sum of estimates paid.
6. `SpecialAssessment` event variant.
7. One `RolloutStatusType.FAILED` test per obligation type.

Out of scope: underpayment-penalty calc, discretionary deferral, explicit
borrowing facilities.

### 2. Retire landed plans

Plans E/F/G all landed on devel (#1567, #1566+#1569, #1575). Drop them
from the active plan list; D becomes a guardrail rather than an open slice.

### 3. Queue Simulation-prefix scrub

Inside a simulator every class is by definition simulated; the prefix is
dead weight. Survey: 15 classes (`SimulationAction`, `…PolicyDecision`,
`…MarketObservation`, `…JournalEntry`, `…Posting`, `…BalanceSnapshot`,
`…AccountingDetail`, `…Obligation`, `…FundingDecision`, `…SettlementResult`,
`…FailureEvent`, `…Result`, `…Run`, `…Terminal`, `…ValidationError` + the
`_SimulationTraceBase` / `_SimulationActionBase` family). 6 files, all in
`augur/core/`; wire JSON keys do not carry the prefix, so the rename is
purely internal. Sequence after the trace-surface collapse PR lands, since
that PR may delete some of these classes outright.

### 4. TODO bookkeeping

`In Flight` now lists the crypto/tender-PE funding slice and the
trace-surface collapse (both running as background subagents). Drops
items already on devel: flat-rate `TaxProfile` fields, mortgage obligation
routing, `augur_` prefix removal, scenario tax defaults move, sale-tax
timing.

## Test plan

- [x] No code changed; pre-commit hooks pass (prettier, ducktape pre-commit).


---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_