### PR TITLE
augur/frontend: replace hand-maintained scenario serializer with Zod-driven projection

### DIFF
--- a/augur/frontend/lib/BUILD.bazel
+++ b/augur/frontend/lib/BUILD.bazel
@@ -37,6 +37,7 @@ js_test(
     data = [
         ":scenario_set_state",
         ":schema_zod",
+        "//:node_modules/zod",
     ],
     entry_point = "scenario_set_state_test.mjs",
 )

--- a/augur/frontend/lib/scenario_set_state.js
+++ b/augur/frontend/lib/scenario_set_state.js
@@ -638,89 +638,45 @@ export function scenarioSetInputToRequest(input, bootstrap) {
   };
 }
 
-function serializableScenario(scenario) {
-  const {
-    identity,
-    propertyAndLocation,
-    actorsAndOwnership,
-    timeline,
-    financing,
-    occupancyAndRental,
-    propertyAssumptions,
-    taxAccounting,
-    initialBalanceSheet,
-    policies,
-  } = scenario;
-  return {
-    identity: {
-      scenarioId: identity.scenarioId,
-      label: identity.label,
-      enabled: identity.enabled,
-      color: identity.color,
-    },
-    propertyAndLocation: {
-      propertyId: propertyAndLocation.propertyId,
-    },
-    actorsAndOwnership: {
-      actorPolicy: actorsAndOwnership.actorPolicy,
-      partnerPaymentMonthlyUsd: actorsAndOwnership.partnerPaymentMonthlyUsd,
-    },
-    timeline: {
-      holdYears: timeline.holdYears,
-    },
-    financing: {
-      financingMode: financing.financingMode,
-      downPaymentPct: financing.downPaymentPct,
-      ...(financing.financingMode === "custom"
-        ? {
-            customMortgageRate: financing.customMortgageRate,
-            customMortgageTermYears: financing.customMortgageTermYears,
-          }
-        : {}),
-      creditScore: financing.creditScore,
-    },
-    occupancyAndRental: {
-      ownerResidenceMode: occupancyAndRental.ownerResidenceMode,
-      rentalUsePolicy: occupancyAndRental.rentalUsePolicy,
-      vacancyPct: occupancyAndRental.vacancyPct,
-      managementFeePct: occupancyAndRental.managementFeePct,
-      leasingFeePct: occupancyAndRental.leasingFeePct,
-      roomsRentedWhileLiving: occupancyAndRental.roomsRentedWhileLiving,
-      roomRentMonthlyUsd: occupancyAndRental.roomRentMonthlyUsd,
-      roomVacancyPct: occupancyAndRental.roomVacancyPct,
-    },
-    propertyAssumptions: {
-      maintenancePct: propertyAssumptions.maintenancePct,
-      insuranceAnnualUsd: propertyAssumptions.insuranceAnnualUsd,
-      depreciableBasisPct: propertyAssumptions.depreciableBasisPct,
-    },
-    taxAccounting: {
-      closingCostBuyPct: taxAccounting.closingCostBuyPct,
-      closingCostSellPct: taxAccounting.closingCostSellPct,
-    },
-    initialBalanceSheet: {
-      initialCheckingUsd: initialBalanceSheet.initialCheckingUsd,
-      startingPortfolioUsd: initialBalanceSheet.startingPortfolioUsd,
-      privateEquityUnits: initialBalanceSheet.privateEquityUnits,
-    },
-    policies: {
-      liquidReservePolicy: policies.liquidReservePolicy,
-      checkingFloorUsd: policies.checkingFloorUsd,
-      checkingSaleAmountUsd: policies.checkingSaleAmountUsd,
-      privateEquitySalePolicy: policies.privateEquitySalePolicy,
-      privateEquityLiquidNetWorthFloorUsd: policies.privateEquityLiquidNetWorthFloorUsd,
-      privateEquityTenderSaleAmountUsd: policies.privateEquityTenderSaleAmountUsd,
-    },
-  };
+// Conditional fields the wire format hides outside their applicable variant.
+// Today only ``financing.customMortgageRate`` / ``customMortgageTermYears``
+// fall into this bucket: they only apply when ``financingMode === "custom"``.
+// Anything else here would need a Zod discriminated-union mirror on the
+// Pydantic side; right now the schema treats every override as flatly
+// optional, so the projection has to encode this caveat itself.
+const FINANCING_CUSTOM_ONLY_FIELDS = ["customMortgageRate", "customMortgageTermYears"];
+function dropInapplicableScenarioFields(scenario) {
+  const financing = scenario?.financing;
+  if (!financing || financing.financingMode === "custom") return scenario;
+  const keepFinancing = Object.fromEntries(
+    Object.entries(financing).filter(([key]) => !FINANCING_CUSTOM_ONLY_FIELDS.includes(key))
+  );
+  return { ...scenario, financing: keepFinancing };
 }
 
-function serializableScenarioSetInput(input) {
-  return {
+// Project a scenario-set input down to the schema-known snake_case shape used
+// in the encoded URL state.
+//
+// Parses against ``zBrowserScenarioSetInputOverridesInput`` so the schema —
+// not a hand-maintained field list — defines what survives. Zod
+// ``.object(...)`` strips unknown keys; ``.nullish()`` fields drop out
+// naturally when absent. Any new field added to ``BrowserScenarioInputOverrides``
+// on the Pydantic side surfaces in the wire payload the moment
+// ``//augur/frontend/lib:schema_zod`` regenerates. The old hand-maintained
+// field list silently dropped new fields until somebody noticed; this
+// projection cannot.
+//
+// ``schema`` is parameterizable so the stale-field guard test can drive the
+// same flow through a hypothetically-extended schema; production callers
+// always use the generated default.
+function projectScenarioSetForUrlState(input, schema = zBrowserScenarioSetInputOverridesInput) {
+  const camelDraft = {
     title: input.title,
     marketRequest: input.marketRequest,
     reportSpec: normalizeReportSpec(input.reportSpec),
-    scenarios: (input.scenarios ?? []).map(serializableScenario),
+    scenarios: (input.scenarios ?? []).map(dropInapplicableScenarioFields),
   };
+  return schema.parse(decamelizeObjectKeys(camelDraft));
 }
 
 function bytesToBase64Url(bytes) {
@@ -746,21 +702,21 @@ function base64UrlToBytes(value) {
   return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }
 
-export function encodeScenarioSetUrlState(input) {
+export function encodeScenarioSetUrlState(input, schema = zBrowserScenarioSetInputOverridesInput) {
   const payload = {
     version: URL_STATE_VERSION,
-    scenario_set_input: decamelizeObjectKeys(serializableScenarioSetInput(input)),
+    scenario_set_input: projectScenarioSetForUrlState(input, schema),
   };
   return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
 }
 
-export function decodeScenarioSetUrlState(value) {
+export function decodeScenarioSetUrlState(value, schema = zBrowserScenarioSetInputOverridesInput) {
   if (!value) return null;
   const payload = JSON.parse(new TextDecoder().decode(base64UrlToBytes(value)));
   if (payload?.version !== URL_STATE_VERSION) {
     throw new Error(`Unsupported augur scenario URL state version: ${payload?.version ?? "<missing>"}`);
   }
-  return camelizeObjectKeys(zBrowserScenarioSetInputOverridesInput.parse(payload.scenario_set_input));
+  return camelizeObjectKeys(schema.parse(payload.scenario_set_input));
 }
 
 export function scenarioSetInputFromUrlSearch(search) {

--- a/augur/frontend/lib/scenario_set_state_test.mjs
+++ b/augur/frontend/lib/scenario_set_state_test.mjs
@@ -10,7 +10,13 @@ import {
   scenarioSetInputToRequest,
 } from "./scenario_set_state.js";
 import { decamelizeObjectKeys } from "./casing.js";
-import { zScenarioSetInput } from "./api/schema.zod.mjs";
+import {
+  zBrowserFinancingOverrides,
+  zBrowserScenarioInputOverridesInput,
+  zBrowserScenarioSetInputOverridesInput,
+  zScenarioSetInput,
+} from "./api/schema.zod.mjs";
+import { z } from "zod";
 
 const bootstrap = {
   defaultPropertyId: "location_a_property",
@@ -382,6 +388,39 @@ test("URL state round-trips rich scenario controls in camelCase", () => {
   assert.equal(decoded.scenarios[0].policies.privateEquitySalePolicy, "liquid_net_worth_floor");
   assert.equal(decoded.scenarios[0].policies.privateEquityLiquidNetWorthFloorUsd, 250_000);
   assert.equal(decoded.scenarios[0].policies.privateEquityTenderSaleAmountUsd, 60_000);
+});
+
+// Stale-field guard: if a future schema gets a new override field, the
+// projection must carry it through the URL state unchanged. The old
+// hand-maintained ``serializableScenario`` silently dropped any field not
+// listed by hand; the schema-driven projection cannot, because it just calls
+// ``schema.parse(...)``. We simulate "a new schema field" by extending the
+// override schemas with a fictional ``futureKnob`` and asserting it survives
+// encode → decode.
+test("URL state preserves fields added to the Zod overrides schema", () => {
+  const extendedFinancing = zBrowserFinancingOverrides.extend({
+    future_knob_pct: z.number().nullish(),
+  });
+  const extendedScenario = zBrowserScenarioInputOverridesInput.extend({
+    financing: extendedFinancing.nullish(),
+  });
+  const extendedSet = zBrowserScenarioSetInputOverridesInput.extend({
+    scenarios: z.array(extendedScenario).nullish(),
+  });
+
+  const input = normalizeScenarioSetInput(createDefaultScenarioSetInput(bootstrap), bootstrap);
+  input.scenarios[0] = patchScenarioInputSection(input.scenarios[0], "financing", {
+    financingMode: "custom",
+    futureKnobPct: 42.5,
+  });
+
+  // Default schema (production behavior) drops the unknown field today.
+  const decodedDefault = decodeScenarioSetUrlState(encodeScenarioSetUrlState(input));
+  assert.equal(decodedDefault.scenarios[0].financing.futureKnobPct, undefined);
+
+  // Extended schema (simulating a future Pydantic addition) preserves it.
+  const decodedExtended = decodeScenarioSetUrlState(encodeScenarioSetUrlState(input, extendedSet), extendedSet);
+  assert.equal(decodedExtended.scenarios[0].financing.futureKnobPct, 42.5);
 });
 
 test("URL state normalizes missing trajectory seed to deterministic default", () => {


### PR DESCRIPTION
## Summary

`serializableScenario` / `serializableScenarioSetInput` in
`augur/frontend/lib/scenario_set_state.js` used to hand-enumerate every
browser-scenario field before JSON-encoding to URL state. Any new field
added to the Pydantic `BrowserScenarioInput` (and propagated into the
Zod schema via the existing OpenAPI → Zod pipeline) silently dropped
out of URL state until somebody noticed and updated the field list by
hand. Now the projection is driven by the generated Zod schema.

## Option A vs B decision

**Picked Option A.** The Pydantic `_Overrides` mirrors all set
`extra="ignore"` and every field is `... | None = None`, which generates
to `z.object({...}).nullish()` everywhere in `schema.zod.mjs`. Zod 4's
`.object(...).parse(...)` already does exactly what the projection
needs: it strips unknown keys, passes through `.nullish()` fields, and
errors on type mismatches. So instead of building a "project to known
keys" helper (Option B) that would just reimplement what `parse()`
gives us for free, the projection simply calls
`zBrowserScenarioSetInputOverridesInput.parse(...)`.

The only carve-out: today's wire format drops
`financing.customMortgageRate` / `customMortgageTermYears` outside
`financingMode === "custom"`. That's the one piece of conditional
shape the Zod schema can't express (the override mirrors are flat
optionals, not a discriminated union — and reasonably so, since
`_Overrides` exists to permit *anything* missing). This is preserved
as a tiny `dropInapplicableScenarioFields` preprocessor that runs
before parse; if that semantics ever needs to broaden, the right fix is
to make the schema represent it on the Pydantic side, not to grow the
JS-side allowlist.

## What changed

- `serializableScenario` (~75 lines of hand-enumeration) and
  `serializableScenarioSetInput` deleted.
- Replaced by `projectScenarioSetForUrlState(input, schema)`, which:
  1. Drops `customMortgageRate` / `customMortgageTermYears` when mode
     isn't `custom`.
  2. Decamelizes camelCase → snake_case for the wire shape.
  3. Calls `schema.parse(...)` — by default
     `zBrowserScenarioSetInputOverridesInput`.
- `encodeScenarioSetUrlState` / `decodeScenarioSetUrlState` take an
  optional `schema` parameter (defaulting to the generated one) so the
  guard test can drive the same flow against an `.extend(...)`ed
  schema.

## Stale-field guard test

New test `URL state preserves fields added to the Zod overrides
schema`:

```js
const extendedFinancing = zBrowserFinancingOverrides.extend({
  future_knob_pct: z.number().nullish(),
});
// …compose all the way up to an extendedSet schema…

input.scenarios[0] = patchScenarioInputSection(input.scenarios[0], "financing", {
  financingMode: "custom",
  futureKnobPct: 42.5,
});

// Default (production) schema drops the unknown field today:
const decodedDefault = decodeScenarioSetUrlState(encodeScenarioSetUrlState(input));
assert.equal(decodedDefault.scenarios[0].financing.futureKnobPct, undefined);

// Extended schema (simulating a future Pydantic addition) preserves it:
const decodedExtended = decodeScenarioSetUrlState(
  encodeScenarioSetUrlState(input, extendedSet),
  extendedSet,
);
assert.equal(decodedExtended.scenarios[0].financing.futureKnobPct, 42.5);
```

If a future change moves `customMortgageRate` (or any other field) out
from under the schema, or if the projection grows a fresh
hand-maintained allowlist that doesn't follow the schema, this test
catches it: extending the schema would no longer change what
round-trips. The default-vs-extended contrast is the load-bearing
assertion.

## Test plan

- [x] `bbr test //augur/frontend/lib:scenario_set_state_test` — existing
  URL-state round-trip tests pass without modification; new
  stale-field guard test passes.
- [x] `bbr test //augur/frontend/lib:scenario_set_state_test
  //augur/api:browser_shell_test //augur/frontend:visual_golden_test`
  — all green.
- [x] `bbr test //augur/...` — 28/28 tests pass.
- [x] `bbr build //augur/...` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_