### PR TITLE
augur/core: drop Simulation prefix from internal class names

### DIFF
--- a/augur/core/accounting.py
+++ b/augur/core/accounting.py
@@ -116,7 +116,7 @@ class AccountingCause(ApiModel):
     market_observation_id: str | None = None
 
 
-class SimulationJournalEntry(ApiModel):
+class JournalEntry(ApiModel):
     journal_entry_id: str
     rollout_index: NonNegativeInt
     month_index: NonNegativeInt
@@ -133,7 +133,7 @@ class SimulationJournalEntry(ApiModel):
     projection_trajectory_id: str | None = None
 
 
-class SimulationPosting(ApiModel):
+class Posting(ApiModel):
     posting_id: str
     journal_entry_id: str
     rollout_index: NonNegativeInt
@@ -150,13 +150,13 @@ class SimulationPosting(ApiModel):
     projection_trajectory_id: str | None = None
 
     @model_validator(mode="after")
-    def _positive_amount(self) -> SimulationPosting:
+    def _positive_amount(self) -> Posting:
         if self.amount_usd <= 0:
             raise ValueError("posting amount_usd must be positive")
         return self
 
 
-class SimulationBalanceSnapshot(ApiModel):
+class BalanceSnapshot(ApiModel):
     rollout_index: NonNegativeInt
     month_index: NonNegativeInt
     chart_account_id: str
@@ -213,15 +213,15 @@ class AccountingValidationError(ValueError):
     pass
 
 
-def debit_amount(posting: SimulationPosting) -> float:
+def debit_amount(posting: Posting) -> float:
     return posting.amount_usd if posting.side is PostingSide.DEBIT else 0.0
 
 
-def credit_amount(posting: SimulationPosting) -> float:
+def credit_amount(posting: Posting) -> float:
     return posting.amount_usd if posting.side is PostingSide.CREDIT else 0.0
 
 
-def signed_balance_delta(posting: SimulationPosting, account: ChartAccount) -> float:
+def signed_balance_delta(posting: Posting, account: ChartAccount) -> float:
     normal_debit = account.account_type in {ChartAccountType.ASSET, ChartAccountType.EXPENSE}
     if posting.side is PostingSide.DEBIT:
         return posting.amount_usd if normal_debit else -posting.amount_usd
@@ -231,8 +231,8 @@ def signed_balance_delta(posting: SimulationPosting, account: ChartAccount) -> f
 def validate_accounting_trace(
     *,
     chart_accounts: tuple[ChartAccount, ...],
-    journal_entries: tuple[SimulationJournalEntry, ...],
-    postings: tuple[SimulationPosting, ...],
+    journal_entries: tuple[JournalEntry, ...],
+    postings: tuple[Posting, ...],
     tolerance_usd: float = 0.005,
 ) -> None:
     account_ids = [account.chart_account_id for account in chart_accounts]
@@ -247,7 +247,7 @@ def validate_accounting_trace(
         raise AccountingValidationError(f"duplicate journal entry ids: {duplicate_journals}")
     journal_by_id = {entry.journal_entry_id: entry for entry in journal_entries}
 
-    postings_by_journal: dict[str, list[SimulationPosting]] = defaultdict(list)
+    postings_by_journal: dict[str, list[Posting]] = defaultdict(list)
     posting_ids: list[str] = []
     for posting in postings:
         posting_ids.append(posting.posting_id)

--- a/augur/core/accounting_test.py
+++ b/augur/core/accounting_test.py
@@ -10,10 +10,10 @@ from augur.core.accounting import (
     ChartAccount,
     ChartAccountRole,
     ChartAccountType,
+    JournalEntry,
     JournalEntryType,
+    Posting,
     PostingSide,
-    SimulationJournalEntry,
-    SimulationPosting,
     chart_account_id,
     validate_accounting_trace,
 )
@@ -40,7 +40,7 @@ def test_validate_accounting_trace_accepts_balanced_journal() -> None:
             ),
         ),
         journal_entries=(
-            SimulationJournalEntry(
+            JournalEntry(
                 journal_entry_id="monthly_spend:rollout:0:month:1",
                 rollout_index=0,
                 month_index=1,
@@ -54,7 +54,7 @@ def test_validate_accounting_trace_accepts_balanced_journal() -> None:
             ),
         ),
         postings=(
-            SimulationPosting(
+            Posting(
                 posting_id="monthly_spend:rollout:0:month:1:debit",
                 journal_entry_id="monthly_spend:rollout:0:month:1",
                 rollout_index=0,
@@ -63,7 +63,7 @@ def test_validate_accounting_trace_accepts_balanced_journal() -> None:
                 side=PostingSide.DEBIT,
                 amount_usd=100,
             ),
-            SimulationPosting(
+            Posting(
                 posting_id="monthly_spend:rollout:0:month:1:credit",
                 journal_entry_id="monthly_spend:rollout:0:month:1",
                 rollout_index=0,
@@ -97,20 +97,19 @@ def test_validate_accounting_trace_rejects_unbalanced_journal() -> None:
                 ),
             ),
             journal_entries=(
-                SimulationJournalEntry(
+                JournalEntry(
                     journal_entry_id="broken",
                     rollout_index=0,
                     month_index=1,
                     journal_entry_type=JournalEntryType.CASH_EXPENSE,
                     actor_id="owner",
                     cause=AccountingCause(
-                        cause_type=AccountingCauseType.POLICY_DECISION,
-                        cause_id="policy:spend:rollout:0:month:1",
+                        cause_type=AccountingCauseType.POLICY_DECISION, cause_id="policy:spend:rollout:0:month:1"
                     ),
                 ),
             ),
             postings=(
-                SimulationPosting(
+                Posting(
                     posting_id="broken:debit",
                     journal_entry_id="broken",
                     rollout_index=0,
@@ -119,7 +118,7 @@ def test_validate_accounting_trace_rejects_unbalanced_journal() -> None:
                     side=PostingSide.DEBIT,
                     amount_usd=100,
                 ),
-                SimulationPosting(
+                Posting(
                     posting_id="broken:credit",
                     journal_entry_id="broken",
                     rollout_index=0,
@@ -137,20 +136,17 @@ def test_validate_accounting_trace_rejects_unknown_account() -> None:
         validate_accounting_trace(
             chart_accounts=(),
             journal_entries=(
-                SimulationJournalEntry(
+                JournalEntry(
                     journal_entry_id="entry",
                     rollout_index=0,
                     month_index=0,
                     journal_entry_type=JournalEntryType.OPENING_BALANCE,
                     actor_id="owner",
-                    cause=AccountingCause(
-                        cause_type=AccountingCauseType.OPENING_BALANCE,
-                        cause_id="opening:owner",
-                    ),
+                    cause=AccountingCause(cause_type=AccountingCauseType.OPENING_BALANCE, cause_id="opening:owner"),
                 ),
             ),
             postings=(
-                SimulationPosting(
+                Posting(
                     posting_id="entry:posting",
                     journal_entry_id="entry",
                     rollout_index=0,

--- a/augur/core/api.py
+++ b/augur/core/api.py
@@ -6,16 +6,16 @@ from typing import Any, TypeVar, overload
 import numpy as np
 
 from augur.core.accounting import (
+    BalanceSnapshot,
     ChartAccount,
     ChartAccountRole,
+    JournalEntry,
     JournalEntryType,
     LiabilityState,
     LotAssetClass,
     LotDisposition,
+    Posting,
     PostingSide,
-    SimulationBalanceSnapshot,
-    SimulationJournalEntry,
-    SimulationPosting,
     TaxLot,
 )
 from augur.core.market_bundle import (
@@ -33,10 +33,14 @@ from augur.core.provenance import (
 )
 from augur.core.scenario_engine import ScenarioRunArrays, report_metric_array, run_scenario_vectorized
 from augur.core.scenario_set import (
+    AccountingDetail,
+    Action,
     ActorRole,
     EventType,
     ExogenousPathIdentity,
+    MarketObservation,
     PartnerEquityAccrualPolicy,
+    PolicyDecision,
     ProjectionTrajectoryIdentity,
     RentalMode,
     ReportMetric,
@@ -48,10 +52,6 @@ from augur.core.scenario_set import (
     ScenarioResult,
     ScenarioSet,
     ScenarioSetRunResponse,
-    SimulationAccountingDetail,
-    SimulationAction,
-    SimulationMarketObservation,
-    SimulationPolicyDecision,
 )
 
 ActionT = TypeVar("ActionT")
@@ -60,7 +60,7 @@ DecisionT = TypeVar("DecisionT")
 ObservationT = TypeVar("ObservationT")
 
 
-class SimulationValidationError(ValueError):
+class ScenarioValidationError(ValueError):
     """Raised when a typed scenario is internally inconsistent."""
 
 
@@ -79,7 +79,7 @@ class RolloutDetail:
     def actions(self, action_type: type[ActionT]) -> tuple[ActionT, ...]: ...
 
     @overload
-    def actions(self, action_type: None = None) -> tuple[SimulationAction, ...]: ...
+    def actions(self, action_type: None = None) -> tuple[Action, ...]: ...
 
     def actions(self, action_type: type[Any] | None = None) -> tuple[Any, ...]:
         return self.scenario_run.actions(action_type, rollout=self.rollout_index)
@@ -88,7 +88,7 @@ class RolloutDetail:
     def policy_decisions(self, decision_type: type[DecisionT]) -> tuple[DecisionT, ...]: ...
 
     @overload
-    def policy_decisions(self, decision_type: None = None) -> tuple[SimulationPolicyDecision, ...]: ...
+    def policy_decisions(self, decision_type: None = None) -> tuple[PolicyDecision, ...]: ...
 
     def policy_decisions(self, decision_type: type[Any] | None = None) -> tuple[Any, ...]:
         return self.scenario_run.policy_decisions(decision_type, rollout=self.rollout_index)
@@ -97,22 +97,18 @@ class RolloutDetail:
     def market_observations(self, observation_type: type[ObservationT]) -> tuple[ObservationT, ...]: ...
 
     @overload
-    def market_observations(self, observation_type: None = None) -> tuple[SimulationMarketObservation, ...]: ...
+    def market_observations(self, observation_type: None = None) -> tuple[MarketObservation, ...]: ...
 
     def market_observations(self, observation_type: type[Any] | None = None) -> tuple[Any, ...]:
         return self.scenario_run.market_observations(observation_type, rollout=self.rollout_index)
 
-    def journal_entries(
-        self, *, journal_entry_type: JournalEntryType | None = None
-    ) -> tuple[SimulationJournalEntry, ...]:
+    def journal_entries(self, *, journal_entry_type: JournalEntryType | None = None) -> tuple[JournalEntry, ...]:
         return self.scenario_run.journal_entries(journal_entry_type=journal_entry_type, rollout=self.rollout_index)
 
-    def postings(
-        self, *, role: ChartAccountRole | None = None, side: PostingSide | None = None
-    ) -> tuple[SimulationPosting, ...]:
+    def postings(self, *, role: ChartAccountRole | None = None, side: PostingSide | None = None) -> tuple[Posting, ...]:
         return self.scenario_run.postings(role=role, side=side, rollout=self.rollout_index)
 
-    def balance_snapshots(self, *, role: ChartAccountRole | None = None) -> tuple[SimulationBalanceSnapshot, ...]:
+    def balance_snapshots(self, *, role: ChartAccountRole | None = None) -> tuple[BalanceSnapshot, ...]:
         return self.scenario_run.balance_snapshots(role=role, rollout=self.rollout_index)
 
     def lot_dispositions(self, *, asset_class: LotAssetClass | None = None) -> tuple[LotDisposition, ...]:
@@ -122,7 +118,7 @@ class RolloutDetail:
     def accounting_details(self, detail_type: type[AccountingDetailT]) -> tuple[AccountingDetailT, ...]: ...
 
     @overload
-    def accounting_details(self, detail_type: None = None) -> tuple[SimulationAccountingDetail, ...]: ...
+    def accounting_details(self, detail_type: None = None) -> tuple[AccountingDetail, ...]: ...
 
     def accounting_details(self, detail_type: type[Any] | None = None) -> tuple[Any, ...]:
         return self.scenario_run.accounting_details(detail_type, rollout=self.rollout_index)
@@ -171,7 +167,7 @@ class ScenarioRun:
     def actions(self, action_type: type[ActionT], *, rollout: int | None = None) -> tuple[ActionT, ...]: ...
 
     @overload
-    def actions(self, action_type: None = None, *, rollout: int | None = None) -> tuple[SimulationAction, ...]: ...
+    def actions(self, action_type: None = None, *, rollout: int | None = None) -> tuple[Action, ...]: ...
 
     def actions(self, action_type: type[Any] | None = None, *, rollout: int | None = None) -> tuple[Any, ...]:
         if self.arrays is None:
@@ -192,7 +188,7 @@ class ScenarioRun:
     @overload
     def policy_decisions(
         self, decision_type: None = None, *, rollout: int | None = None
-    ) -> tuple[SimulationPolicyDecision, ...]: ...
+    ) -> tuple[PolicyDecision, ...]: ...
 
     def policy_decisions(
         self, decision_type: type[Any] | None = None, *, rollout: int | None = None
@@ -215,7 +211,7 @@ class ScenarioRun:
     @overload
     def market_observations(
         self, observation_type: None = None, *, rollout: int | None = None
-    ) -> tuple[SimulationMarketObservation, ...]: ...
+    ) -> tuple[MarketObservation, ...]: ...
 
     def market_observations(
         self, observation_type: type[Any] | None = None, *, rollout: int | None = None
@@ -242,7 +238,7 @@ class ScenarioRun:
 
     def journal_entries(
         self, *, journal_entry_type: JournalEntryType | None = None, rollout: int | None = None
-    ) -> tuple[SimulationJournalEntry, ...]:
+    ) -> tuple[JournalEntry, ...]:
         if self.arrays is None:
             return ()
         entries = self.arrays.journal_entries
@@ -255,7 +251,7 @@ class ScenarioRun:
 
     def postings(
         self, *, role: ChartAccountRole | None = None, side: PostingSide | None = None, rollout: int | None = None
-    ) -> tuple[SimulationPosting, ...]:
+    ) -> tuple[Posting, ...]:
         if self.arrays is None:
             return ()
         postings = self.arrays.postings
@@ -271,7 +267,7 @@ class ScenarioRun:
 
     def balance_snapshots(
         self, *, role: ChartAccountRole | None = None, rollout: int | None = None
-    ) -> tuple[SimulationBalanceSnapshot, ...]:
+    ) -> tuple[BalanceSnapshot, ...]:
         if self.arrays is None:
             return ()
         snapshots = self.arrays.balance_snapshots
@@ -319,7 +315,7 @@ class ScenarioRun:
     @overload
     def accounting_details(
         self, detail_type: None = None, *, rollout: int | None = None
-    ) -> tuple[SimulationAccountingDetail, ...]: ...
+    ) -> tuple[AccountingDetail, ...]: ...
 
     def accounting_details(
         self, detail_type: type[Any] | None = None, *, rollout: int | None = None
@@ -406,7 +402,7 @@ class ScenarioRun:
 
 
 @dataclass(frozen=True)
-class SimulationRun:
+class ScenarioSetRun:
     scenario_set: ScenarioSet
     market_bundle: MarketBundle
     scenario_runs: tuple[ScenarioRun, ...]
@@ -452,7 +448,7 @@ def simulate_set(
     *,
     market_provider: MarketBundleProvider | None = None,
     market_bundle: MarketBundle | None = None,
-) -> SimulationRun:
+) -> ScenarioSetRun:
     """Simulate a typed scenario set and return a distribution-first result object."""
 
     if market_provider is not None and market_bundle is not None:
@@ -469,7 +465,7 @@ def simulate_set(
             scenario_runs.append(ScenarioRun(scenario=scenario, arrays=None))
             continue
         scenario_runs.append(ScenarioRun(scenario=scenario, arrays=run_scenario_vectorized(scenario, market_bundle)))
-    return SimulationRun(scenario_set=scenario_set, market_bundle=market_bundle, scenario_runs=tuple(scenario_runs))
+    return ScenarioSetRun(scenario_set=scenario_set, market_bundle=market_bundle, scenario_runs=tuple(scenario_runs))
 
 
 def _exogenous_path_identities(metadata: Any) -> tuple[ExogenousPathIdentity, ...]:
@@ -524,7 +520,7 @@ def validate_scenario_set(scenario_set: ScenarioSet) -> None:
     for scenario_index, scenario in enumerate(scenario_set.scenarios):
         errors.extend(_validate_scenario(scenario, f"scenarios[{scenario_index}]"))
     if errors:
-        raise SimulationValidationError("; ".join(errors))
+        raise ScenarioValidationError("; ".join(errors))
 
 
 def _validate_scenario(scenario: Scenario, path: str) -> list[str]:
@@ -651,7 +647,7 @@ def _validate_market_bundle_matches_request(scenario_set: ScenarioSet, market_bu
             f"{market_bundle.horizon_months} does not match market_request.horizon_months {request.horizon_months}"
         )
     if errors:
-        raise SimulationValidationError("; ".join(errors))
+        raise ScenarioValidationError("; ".join(errors))
 
 
 def _accepted_summary(scenario: Scenario) -> ScenarioAcceptedSummary:

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -10,17 +10,17 @@ import numpy as np
 from augur.core.accounting import (
     AccountingCause,
     AccountingCauseType,
+    BalanceSnapshot,
     ChartAccount,
     ChartAccountRole,
+    JournalEntry,
     JournalEntryType,
     LiabilityState,
     LiabilityType,
     LotAssetClass,
     LotDisposition,
+    Posting,
     PostingSide,
-    SimulationBalanceSnapshot,
-    SimulationJournalEntry,
-    SimulationPosting,
     TaxLot,
     chart_account_id,
     chart_account_type_for_role,
@@ -64,28 +64,35 @@ from augur.core.property_tax import monthly_property_tax_usd
 from augur.core.provenance import policy_program_set_id, projection_trajectory_id, scenario_input_id
 from augur.core.scenario_set import (
     AccountBalance,
+    AccountingDetail,
     AccountingDetailType,
     AccountType,
+    Action,
     ActorRole,
     AssetType,
     CheckingFloorSellPublicStockPolicy,
     CryptoAssetPosition,
+    FailureEvent,
     FailureEventType,
     FinancingMode,
     FixedAmountPrivateEquitySaleRule,
+    FundingDecision,
     FundingDecisionType,
     FundingSourceType,
     GenericSp500StockPosition,
     LiquidNetWorthFloorPrivateEquitySaleRule,
+    MarketObservation,
     MarketPathObservation,
     MonthlySpendDecision,
     MonthlySpendPolicy,
+    Obligation,
     ObligationStatus,
     ObligationType,
     OccupancyMode,
     PartnerContributionDecision,
     PartnerEquityAccrualPolicy,
     Policy,
+    PolicyDecision,
     PrivateEquityPosition,
     PrivateEquitySaleDecision,
     PrivateEquitySaleDecisionReason,
@@ -103,16 +110,9 @@ from augur.core.scenario_set import (
     SellPrivateEquityAction,
     SellPublicStockDecision,
     SellSp500Action,
+    SettlementResult,
     SettlementStatus,
     SettlePropertySaleAction,
-    SimulationAccountingDetail,
-    SimulationAction,
-    SimulationFailureEvent,
-    SimulationFundingDecision,
-    SimulationMarketObservation,
-    SimulationObligation,
-    SimulationPolicyDecision,
-    SimulationSettlementResult,
     SpecialAssessmentEvent,
     TaxPaymentAllocationDetail,
 )
@@ -200,21 +200,21 @@ class ScenarioRunArrays:
     net_worth_usd: np.ndarray
     partner_present: np.ndarray
     monthly_spend_usd: np.ndarray
-    actions: tuple[SimulationAction, ...]
-    policy_decisions: tuple[SimulationPolicyDecision, ...]
-    market_observations: tuple[SimulationMarketObservation, ...]
+    actions: tuple[Action, ...]
+    policy_decisions: tuple[PolicyDecision, ...]
+    market_observations: tuple[MarketObservation, ...]
     chart_accounts: tuple[ChartAccount, ...]
-    journal_entries: tuple[SimulationJournalEntry, ...]
-    postings: tuple[SimulationPosting, ...]
-    balance_snapshots: tuple[SimulationBalanceSnapshot, ...]
+    journal_entries: tuple[JournalEntry, ...]
+    postings: tuple[Posting, ...]
+    balance_snapshots: tuple[BalanceSnapshot, ...]
     tax_lots: tuple[TaxLot, ...]
     lot_dispositions: tuple[LotDisposition, ...]
     liabilities: tuple[LiabilityState, ...]
-    accounting_details: tuple[SimulationAccountingDetail, ...]
-    obligations: tuple[SimulationObligation, ...]
-    funding_decisions: tuple[SimulationFundingDecision, ...]
-    settlement_results: tuple[SimulationSettlementResult, ...]
-    failure_events: tuple[SimulationFailureEvent, ...]
+    accounting_details: tuple[AccountingDetail, ...]
+    obligations: tuple[Obligation, ...]
+    funding_decisions: tuple[FundingDecision, ...]
+    settlement_results: tuple[SettlementResult, ...]
+    failure_events: tuple[FailureEvent, ...]
 
     @property
     def rollout_count(self) -> int:
@@ -842,9 +842,9 @@ class CryptoObligationFundingPolicyApplication:
 class AccountingTraceBuilder:
     def __init__(self) -> None:
         self.chart_accounts_by_id: dict[str, ChartAccount] = {}
-        self.journal_entries: list[SimulationJournalEntry] = []
-        self.postings: list[SimulationPosting] = []
-        self.balance_snapshots: list[SimulationBalanceSnapshot] = []
+        self.journal_entries: list[JournalEntry] = []
+        self.postings: list[Posting] = []
+        self.balance_snapshots: list[BalanceSnapshot] = []
 
     def record_entry(
         self, *, month_index: int | np.ndarray, entry: JournalEntryBatch, amount_multiplier: np.ndarray | None = None
@@ -867,7 +867,7 @@ class AccountingTraceBuilder:
                 else None
             )
             self.journal_entries.append(
-                SimulationJournalEntry(
+                JournalEntry(
                     journal_entry_id=journal_entry_id,
                     rollout_index=rollout_index,
                     month_index=month,
@@ -892,7 +892,7 @@ class AccountingTraceBuilder:
                     continue
                 chart_account = self._chart_account(posting)
                 self.postings.append(
-                    SimulationPosting(
+                    Posting(
                         posting_id=f"{journal_entry_id}:posting:{posting_index}:{posting.side.value}",
                         journal_entry_id=journal_entry_id,
                         rollout_index=rollout_index,
@@ -924,7 +924,7 @@ class AccountingTraceBuilder:
         rollout_indexes, month_positions = np.nonzero(amount_usd != 0)
         for rollout_index, month_position in zip(rollout_indexes.tolist(), month_positions.tolist(), strict=True):
             self.balance_snapshots.append(
-                SimulationBalanceSnapshot(
+                BalanceSnapshot(
                     rollout_index=rollout_index,
                     month_index=int(month_index[month_position]),
                     chart_account_id=chart_account.chart_account_id,
@@ -1424,18 +1424,18 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         np.full(rollout_count, initial_cash - down_payment, dtype="float64")
         - disposition.purchase_closing_cost_usd[:, 0]
     )
-    actions: list[SimulationAction] = []
-    policy_decisions: list[SimulationPolicyDecision] = []
-    market_observations: list[SimulationMarketObservation] = list(_market_path_observations(scenario, market_bundle))
+    actions: list[Action] = []
+    policy_decisions: list[PolicyDecision] = []
+    market_observations: list[MarketObservation] = list(_market_path_observations(scenario, market_bundle))
     accounting = AccountingTraceBuilder()
     tax_lots: list[TaxLot] = []
     lot_dispositions: list[LotDisposition] = []
     liabilities: list[LiabilityState] = []
-    accounting_details: list[SimulationAccountingDetail] = []
-    obligations: list[SimulationObligation] = []
-    funding_decisions: list[SimulationFundingDecision] = []
-    settlement_results: list[SimulationSettlementResult] = []
-    failure_events: list[SimulationFailureEvent] = []
+    accounting_details: list[AccountingDetail] = []
+    obligations: list[Obligation] = []
+    funding_decisions: list[FundingDecision] = []
+    settlement_results: list[SettlementResult] = []
+    failure_events: list[FailureEvent] = []
     sp500_sale_action_records: list[Sp500SaleActionRecord] = []
     crypto_sale_action_records: list[CryptoSaleActionRecord] = []
     private_equity_sale_action_records: list[PrivateEquitySaleActionRecord] = []
@@ -2349,12 +2349,10 @@ def _copy_with_trajectory_identity(record: Any, identity_by_rollout: Mapping[int
     return record.model_copy(update=identity_by_rollout[int(record.rollout_index)])
 
 
-def _market_path_observations(
-    scenario: Scenario, market_bundle: MarketBundle
-) -> tuple[SimulationMarketObservation, ...]:
+def _market_path_observations(scenario: Scenario, market_bundle: MarketBundle) -> tuple[MarketObservation, ...]:
     home_multiplier = market_bundle.home_value_multipliers(scenario.location_id)
     rent_multiplier = market_bundle.rent_multipliers(scenario.location_id)
-    observations: list[SimulationMarketObservation] = []
+    observations: list[MarketObservation] = []
     rollout_indexes, month_positions = np.indices(
         (market_bundle.rollout_count, market_bundle.horizon_months + 1), sparse=False
     )
@@ -2383,7 +2381,7 @@ def _market_path_observations(
 
 
 def _record_private_equity_sale_opportunity_observations(
-    records: list[SimulationMarketObservation],
+    records: list[MarketObservation],
     *,
     month_index: int,
     source_asset_id: str,
@@ -2409,7 +2407,7 @@ def _record_private_equity_sale_opportunity_observations(
 
 
 def _record_monthly_spend_decisions(
-    records: list[SimulationPolicyDecision],
+    records: list[PolicyDecision],
     *,
     month_index: int,
     policy_step: ActorPolicyStep[Policy],
@@ -2437,7 +2435,7 @@ def _record_monthly_spend_decisions(
 
 
 def _record_sell_public_stock_decisions(
-    records: list[SimulationPolicyDecision],
+    records: list[PolicyDecision],
     *,
     month_index: int,
     policy_step: ActorPolicyStep[Policy],
@@ -2466,7 +2464,7 @@ def _record_sell_public_stock_decisions(
 
 
 def _record_private_equity_sale_decisions(
-    records: list[SimulationPolicyDecision],
+    records: list[PolicyDecision],
     *,
     month_index: int,
     policy_step: ActorPolicyStep[Policy],
@@ -2535,7 +2533,7 @@ def _private_equity_sale_decision_reason(
 
 
 def _record_partner_contribution_decisions(
-    records: list[SimulationPolicyDecision], *, month_index: np.ndarray, partner_equity: PartnerEquityArrays
+    records: list[PolicyDecision], *, month_index: np.ndarray, partner_equity: PartnerEquityArrays
 ) -> None:
     for agreement in partner_equity.agreements:
         policy = agreement.policy
@@ -2651,7 +2649,7 @@ def _mortgage_liability_id(property_id: str) -> str:
 
 
 def _accounting_detail_amount_matrix(
-    records: list[SimulationAccountingDetail],
+    records: list[AccountingDetail],
     *,
     rollout_count: int,
     month_index: np.ndarray,
@@ -2776,7 +2774,7 @@ def _record_property_sale_journal_entries(
 
 
 def _record_property_sale_accounting_details(
-    records: list[SimulationAccountingDetail], *, scenario: Scenario, disposition: PropertyDispositionArrays
+    records: list[AccountingDetail], *, scenario: Scenario, disposition: PropertyDispositionArrays
 ) -> None:
     if disposition.sale_event is None or disposition.sale_month is None:
         return
@@ -2818,7 +2816,7 @@ def _record_property_sale_accounting_details(
 
 
 def _record_tax_payment_allocation_details(
-    records: list[SimulationAccountingDetail],
+    records: list[AccountingDetail],
     *,
     scenario: Scenario,
     month_index: np.ndarray,
@@ -3001,7 +2999,7 @@ def _record_partner_agreement_accounting_detail(
     _record_balance_snapshot_batches(accounting, month_index=month_index, entries=partner_equity.balance_snapshots)
 
 
-def _sorted_policy_decisions(records: list[SimulationPolicyDecision]) -> tuple[SimulationPolicyDecision, ...]:
+def _sorted_policy_decisions(records: list[PolicyDecision]) -> tuple[PolicyDecision, ...]:
     return tuple(
         sorted(
             records,
@@ -3017,7 +3015,7 @@ def _sorted_policy_decisions(records: list[SimulationPolicyDecision]) -> tuple[S
     )
 
 
-def _sorted_market_observations(records: list[SimulationMarketObservation]) -> tuple[SimulationMarketObservation, ...]:
+def _sorted_market_observations(records: list[MarketObservation]) -> tuple[MarketObservation, ...]:
     return tuple(
         sorted(
             records,
@@ -3030,7 +3028,7 @@ def _sorted_chart_accounts(records: list[ChartAccount]) -> tuple[ChartAccount, .
     return tuple(sorted(records, key=lambda account: account.chart_account_id))
 
 
-def _sorted_journal_entries(records: list[SimulationJournalEntry]) -> tuple[SimulationJournalEntry, ...]:
+def _sorted_journal_entries(records: list[JournalEntry]) -> tuple[JournalEntry, ...]:
     return tuple(
         sorted(
             records,
@@ -3046,7 +3044,7 @@ def _sorted_journal_entries(records: list[SimulationJournalEntry]) -> tuple[Simu
     )
 
 
-def _sorted_postings(records: list[SimulationPosting]) -> tuple[SimulationPosting, ...]:
+def _sorted_postings(records: list[Posting]) -> tuple[Posting, ...]:
     return tuple(
         sorted(
             records,
@@ -3060,7 +3058,7 @@ def _sorted_postings(records: list[SimulationPosting]) -> tuple[SimulationPostin
     )
 
 
-def _sorted_balance_snapshots(records: list[SimulationBalanceSnapshot]) -> tuple[SimulationBalanceSnapshot, ...]:
+def _sorted_balance_snapshots(records: list[BalanceSnapshot]) -> tuple[BalanceSnapshot, ...]:
     return tuple(sorted(records, key=lambda entry: (entry.month_index, entry.rollout_index, entry.chart_account_id)))
 
 
@@ -3086,7 +3084,7 @@ def _sorted_liabilities(records: list[LiabilityState]) -> tuple[LiabilityState, 
     return tuple(sorted(records, key=lambda liability: liability.liability_id))
 
 
-def _sorted_accounting_details(records: list[SimulationAccountingDetail]) -> tuple[SimulationAccountingDetail, ...]:
+def _sorted_accounting_details(records: list[AccountingDetail]) -> tuple[AccountingDetail, ...]:
     return tuple(
         sorted(
             records,
@@ -3103,7 +3101,7 @@ def _sorted_accounting_details(records: list[SimulationAccountingDetail]) -> tup
     )
 
 
-def _sorted_obligations(records: list[SimulationObligation]) -> tuple[SimulationObligation, ...]:
+def _sorted_obligations(records: list[Obligation]) -> tuple[Obligation, ...]:
     return tuple(
         sorted(
             records,
@@ -3117,7 +3115,7 @@ def _sorted_obligations(records: list[SimulationObligation]) -> tuple[Simulation
     )
 
 
-def _sorted_funding_decisions(records: list[SimulationFundingDecision]) -> tuple[SimulationFundingDecision, ...]:
+def _sorted_funding_decisions(records: list[FundingDecision]) -> tuple[FundingDecision, ...]:
     return tuple(
         sorted(
             records,
@@ -3133,7 +3131,7 @@ def _sorted_funding_decisions(records: list[SimulationFundingDecision]) -> tuple
     )
 
 
-def _sorted_settlement_results(records: list[SimulationSettlementResult]) -> tuple[SimulationSettlementResult, ...]:
+def _sorted_settlement_results(records: list[SettlementResult]) -> tuple[SettlementResult, ...]:
     return tuple(
         sorted(
             records,
@@ -3147,7 +3145,7 @@ def _sorted_settlement_results(records: list[SimulationSettlementResult]) -> tup
     )
 
 
-def _sorted_failure_events(records: list[SimulationFailureEvent]) -> tuple[SimulationFailureEvent, ...]:
+def _sorted_failure_events(records: list[FailureEvent]) -> tuple[FailureEvent, ...]:
     return tuple(
         sorted(
             records,
@@ -3162,7 +3160,7 @@ def _sorted_failure_events(records: list[SimulationFailureEvent]) -> tuple[Simul
 
 
 def _record_property_sale_actions(
-    actions: list[SimulationAction],
+    actions: list[Action],
     *,
     scenario: Scenario,
     disposition: PropertyDispositionArrays,
@@ -3213,7 +3211,7 @@ def _record_property_sale_actions(
 
 
 def _record_sp500_sale_actions(
-    actions: list[SimulationAction],
+    actions: list[Action],
     *,
     month_index: int,
     policy: Policy,
@@ -3310,7 +3308,7 @@ def _record_crypto_sale_journal_entries(
 
 
 def _record_crypto_sale_actions(
-    actions: list[SimulationAction],
+    actions: list[Action],
     *,
     month_index: int,
     policy: Policy,
@@ -3342,7 +3340,7 @@ def _record_crypto_sale_actions(
 
 
 def _record_private_equity_sale_actions(
-    actions: list[SimulationAction],
+    actions: list[Action],
     *,
     month_index: int,
     instruction: PrivateEquitySaleInstructionBatch,
@@ -3477,10 +3475,10 @@ def _settle_required_cash_obligations(
     crypto_sale_usd: np.ndarray,
     crypto_sale_basis_usd: np.ndarray,
     checking_floor_shortfall_usd: np.ndarray,
-    obligations: list[SimulationObligation],
-    funding_decisions: list[SimulationFundingDecision],
-    settlement_results: list[SimulationSettlementResult],
-    failure_events: list[SimulationFailureEvent],
+    obligations: list[Obligation],
+    funding_decisions: list[FundingDecision],
+    settlement_results: list[SettlementResult],
+    failure_events: list[FailureEvent],
     accounting: AccountingTraceBuilder,
     sp500_sale_action_records: list[Sp500SaleActionRecord],
     crypto_sale_action_records: list[CryptoSaleActionRecord],
@@ -3930,7 +3928,7 @@ def _apply_crypto_checking_floor_obligation_funding_policy(
 
 
 def _record_obligation_cash_funding_decisions(
-    records: list[SimulationFundingDecision],
+    records: list[FundingDecision],
     *,
     obligation_type: ObligationType,
     actor_id: str,
@@ -3942,7 +3940,7 @@ def _record_obligation_cash_funding_decisions(
 ) -> None:
     records.extend(
         (
-            SimulationFundingDecision(
+            FundingDecision(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=_obligation_id(obligation_type, rollout_index=rollout_index, month_index=month_index),
@@ -3964,7 +3962,7 @@ def _record_obligation_cash_funding_decisions(
 
 
 def _record_obligation_sale_funding_decisions(
-    records: list[SimulationFundingDecision],
+    records: list[FundingDecision],
     *,
     obligation_type: ObligationType,
     actor_id: str,
@@ -3979,7 +3977,7 @@ def _record_obligation_sale_funding_decisions(
     policy = policy_step.policy
     records.extend(
         (
-            SimulationFundingDecision(
+            FundingDecision(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=_obligation_id(obligation_type, rollout_index=rollout_index, month_index=month_index),
@@ -4002,7 +4000,7 @@ def _record_obligation_sale_funding_decisions(
 
 
 def _record_obligation_crypto_sale_funding_decisions(
-    records: list[SimulationFundingDecision],
+    records: list[FundingDecision],
     *,
     obligation_type: ObligationType,
     actor_id: str,
@@ -4018,7 +4016,7 @@ def _record_obligation_crypto_sale_funding_decisions(
     policy = policy_step.policy
     records.extend(
         (
-            SimulationFundingDecision(
+            FundingDecision(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=_obligation_id(obligation_type, rollout_index=rollout_index, month_index=month_index),
@@ -4043,7 +4041,7 @@ def _record_obligation_crypto_sale_funding_decisions(
 
 
 def _record_unfunded_obligation_decisions(
-    records: list[SimulationFundingDecision],
+    records: list[FundingDecision],
     *,
     obligation_type: ObligationType,
     actor_id: str,
@@ -4053,7 +4051,7 @@ def _record_unfunded_obligation_decisions(
 ) -> None:
     records.extend(
         (
-            SimulationFundingDecision(
+            FundingDecision(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=_obligation_id(obligation_type, rollout_index=rollout_index, month_index=month_index),
@@ -4071,9 +4069,9 @@ def _record_unfunded_obligation_decisions(
 
 
 def _record_obligation_settlement_rows(
-    obligations: list[SimulationObligation],
-    settlement_results: list[SimulationSettlementResult],
-    failure_events: list[SimulationFailureEvent],
+    obligations: list[Obligation],
+    settlement_results: list[SettlementResult],
+    failure_events: list[FailureEvent],
     *,
     obligation_type: ObligationType,
     actor_id: str,
@@ -4093,7 +4091,7 @@ def _record_obligation_settlement_rows(
         obligation_status = _obligation_status(amount_due_usd=due, unpaid_amount_usd=unpaid)
         settlement_status = _settlement_status(amount_due_usd=due, unpaid_amount_usd=unpaid)
         obligations.append(
-            SimulationObligation(
+            Obligation(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=obligation_id,
@@ -4109,7 +4107,7 @@ def _record_obligation_settlement_rows(
             )
         )
         settlement_results.append(
-            SimulationSettlementResult(
+            SettlementResult(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 obligation_id=obligation_id,
@@ -4123,7 +4121,7 @@ def _record_obligation_settlement_rows(
         )
         if unpaid > 0 and required:
             failure_events.append(
-                SimulationFailureEvent(
+                FailureEvent(
                     rollout_index=rollout_index,
                     month_index=month_index,
                     failure_event_id=f"{obligation_id}:failure",
@@ -4155,7 +4153,7 @@ def _settlement_status(*, amount_due_usd: float, unpaid_amount_usd: float) -> Se
     return SettlementStatus.PARTIALLY_PAID
 
 
-def _sorted_actions(actions: list[SimulationAction]) -> tuple[SimulationAction, ...]:
+def _sorted_actions(actions: list[Action]) -> tuple[Action, ...]:
     return tuple(sorted(actions, key=lambda action: (action.month_index, action.rollout_index, action.action_type)))
 
 

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -7,12 +7,12 @@ from typing import Annotated, Any, Literal
 from pydantic import Field, NonNegativeFloat, NonNegativeInt, PositiveFloat, PositiveInt, model_validator
 
 from augur.core.accounting import (
+    BalanceSnapshot,
     ChartAccount,
+    JournalEntry,
     LiabilityState,
     LotDisposition,
-    SimulationBalanceSnapshot,
-    SimulationJournalEntry,
-    SimulationPosting,
+    Posting,
     TaxLot,
 )
 from augur.core.local_regulation import LocalRegulation, TaxRegime
@@ -453,7 +453,7 @@ Policy = Annotated[
 ]
 
 
-class _SimulationTraceBase(ApiModel):
+class _TraceBase(ApiModel):
     rollout_index: NonNegativeInt
     month_index: NonNegativeInt
     path_set_id: str | None = None
@@ -462,12 +462,12 @@ class _SimulationTraceBase(ApiModel):
     projection_trajectory_id: str | None = None
 
 
-class _SimulationActionBase(_SimulationTraceBase):
+class _ActionBase(_TraceBase):
     actor_id: str
     policy_id: str
 
 
-class SellSp500Action(_SimulationActionBase):
+class SellSp500Action(_ActionBase):
     action_type: Literal[ActionType.SELL_SP500] = ActionType.SELL_SP500
     amount_usd: float
     after_tax_proceeds_usd: float
@@ -477,7 +477,7 @@ class SellSp500Action(_SimulationActionBase):
     shortfall_usd: float
 
 
-class SellCryptoAction(_SimulationActionBase):
+class SellCryptoAction(_ActionBase):
     action_type: Literal[ActionType.SELL_CRYPTO] = ActionType.SELL_CRYPTO
     source_asset_id: str
     asset_symbol: str
@@ -488,7 +488,7 @@ class SellCryptoAction(_SimulationActionBase):
     shortfall_usd: float
 
 
-class SellPrivateEquityAction(_SimulationActionBase):
+class SellPrivateEquityAction(_ActionBase):
     action_type: Literal[ActionType.SELL_PRIVATE_EQUITY] = ActionType.SELL_PRIVATE_EQUITY
     event_id: str | None = None
     event_type: EventType | None = None
@@ -504,7 +504,7 @@ class SellPrivateEquityAction(_SimulationActionBase):
     proceeds_destination: AccountType | AssetType
 
 
-class SettlePropertySaleAction(_SimulationActionBase):
+class SettlePropertySaleAction(_ActionBase):
     action_type: Literal[ActionType.SETTLE_PROPERTY_SALE] = ActionType.SETTLE_PROPERTY_SALE
     event_id: str
     event_type: Literal[EventType.PROPERTY_SALE] = EventType.PROPERTY_SALE
@@ -524,25 +524,25 @@ class SettlePropertySaleAction(_SimulationActionBase):
     proceeds_destination: AccountType = AccountType.CHECKING
 
 
-SimulationAction = Annotated[
+Action = Annotated[
     SellSp500Action | SellCryptoAction | SellPrivateEquityAction | SettlePropertySaleAction,
     Field(discriminator="action_type"),
 ]
 
 
-class _SimulationPolicyDecisionBase(_SimulationTraceBase):
+class _PolicyDecisionBase(_TraceBase):
     actor_id: str
     policy_id: str
     policy_sequence_index: NonNegativeInt
 
 
-class MonthlySpendDecision(_SimulationPolicyDecisionBase):
+class MonthlySpendDecision(_PolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.MONTHLY_SPEND] = PolicyDecisionType.MONTHLY_SPEND
     amount_usd: float
     inflation_multiplier: float = 1.0
 
 
-class SellPublicStockDecision(_SimulationPolicyDecisionBase):
+class SellPublicStockDecision(_PolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.SELL_PUBLIC_STOCK] = PolicyDecisionType.SELL_PUBLIC_STOCK
     asset_type: Literal[AssetType.GENERIC_SP500_STOCK] = AssetType.GENERIC_SP500_STOCK
     requested_amount_usd: float
@@ -550,7 +550,7 @@ class SellPublicStockDecision(_SimulationPolicyDecisionBase):
     target_cash_floor_usd: float | None = None
 
 
-class SellCryptoDecision(_SimulationPolicyDecisionBase):
+class SellCryptoDecision(_PolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.SELL_CRYPTO] = PolicyDecisionType.SELL_CRYPTO
     asset_type: Literal[AssetType.CRYPTO] = AssetType.CRYPTO
     source_asset_id: str
@@ -559,7 +559,7 @@ class SellCryptoDecision(_SimulationPolicyDecisionBase):
     target_cash_floor_usd: float | None = None
 
 
-class PrivateEquitySaleDecision(_SimulationPolicyDecisionBase):
+class PrivateEquitySaleDecision(_PolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.PRIVATE_EQUITY_SALE] = PolicyDecisionType.PRIVATE_EQUITY_SALE
     decision_reason: PrivateEquitySaleDecisionReason
     source_asset_id: str = Field(description="Private-equity holding the policy targeted.")
@@ -579,14 +579,14 @@ class PrivateEquitySaleDecision(_SimulationPolicyDecisionBase):
     proceeds_destination: AccountType | AssetType
 
 
-class PartnerContributionDecision(_SimulationPolicyDecisionBase):
+class PartnerContributionDecision(_PolicyDecisionBase):
     decision_type: Literal[PolicyDecisionType.PARTNER_CONTRIBUTION] = PolicyDecisionType.PARTNER_CONTRIBUTION
     recipient_actor_id: str
     requested_amount_usd: float
     property_id: PropertyId
 
 
-SimulationPolicyDecision = Annotated[
+PolicyDecision = Annotated[
     MonthlySpendDecision
     | SellPublicStockDecision
     | SellCryptoDecision
@@ -596,11 +596,11 @@ SimulationPolicyDecision = Annotated[
 ]
 
 
-class _SimulationMarketObservationBase(_SimulationTraceBase):
+class _MarketObservationBase(_TraceBase):
     pass
 
 
-class MarketPathObservation(_SimulationMarketObservationBase):
+class MarketPathObservation(_MarketObservationBase):
     observation_type: Literal[MarketObservationType.MARKET_PATH] = MarketObservationType.MARKET_PATH
     location_id: str | None = None
     inflation_multiplier: float
@@ -612,7 +612,7 @@ class MarketPathObservation(_SimulationMarketObservationBase):
     private_equity_sale_opportunity_event: bool
 
 
-class PrivateEquitySaleOpportunityObservation(_SimulationMarketObservationBase):
+class PrivateEquitySaleOpportunityObservation(_MarketObservationBase):
     observation_type: Literal[MarketObservationType.PRIVATE_EQUITY_SALE_OPPORTUNITY] = (
         MarketObservationType.PRIVATE_EQUITY_SALE_OPPORTUNITY
     )
@@ -623,19 +623,19 @@ class PrivateEquitySaleOpportunityObservation(_SimulationMarketObservationBase):
     private_equity_value_before_sale_usd: float
 
 
-SimulationMarketObservation = Annotated[
+MarketObservation = Annotated[
     MarketPathObservation | PrivateEquitySaleOpportunityObservation, Field(discriminator="observation_type")
 ]
 
 
-class _SimulationAccountingDetailBase(_SimulationTraceBase):
+class _AccountingDetailBase(_TraceBase):
     actor_id: str
     policy_id: str | None = None
     event_id: str | None = None
     property_id: PropertyId | None = None
 
 
-class PropertySaleBasisGainDetail(_SimulationAccountingDetailBase):
+class PropertySaleBasisGainDetail(_AccountingDetailBase):
     detail_type: Literal[AccountingDetailType.PROPERTY_SALE_BASIS_GAIN] = AccountingDetailType.PROPERTY_SALE_BASIS_GAIN
     gross_sale_usd: float
     selling_cost_usd: float
@@ -649,7 +649,7 @@ class PropertySaleBasisGainDetail(_SimulationAccountingDetailBase):
     taxable_gain_usd: float
 
 
-class TaxPaymentAllocationDetail(_SimulationAccountingDetailBase):
+class TaxPaymentAllocationDetail(_AccountingDetailBase):
     detail_type: Literal[AccountingDetailType.TAX_PAYMENT_ALLOCATION] = AccountingDetailType.TAX_PAYMENT_ALLOCATION
     tax_year_index: NonNegativeInt
     payment_timing: TaxPaymentTiming = TaxPaymentTiming.YEAR_END
@@ -668,12 +668,12 @@ class TaxPaymentAllocationDetail(_SimulationAccountingDetailBase):
     total_taxable_income_usd: float
 
 
-SimulationAccountingDetail = Annotated[
+AccountingDetail = Annotated[
     PropertySaleBasisGainDetail | TaxPaymentAllocationDetail, Field(discriminator="detail_type")
 ]
 
 
-class SimulationObligation(_SimulationTraceBase):
+class Obligation(_TraceBase):
     obligation_id: str
     obligation_type: ObligationType
     actor_id: str
@@ -686,7 +686,7 @@ class SimulationObligation(_SimulationTraceBase):
     source_policy_id: str | None = None
 
 
-class SimulationFundingDecision(_SimulationTraceBase):
+class FundingDecision(_TraceBase):
     obligation_id: str
     decision_type: FundingDecisionType
     actor_id: str
@@ -704,7 +704,7 @@ class SimulationFundingDecision(_SimulationTraceBase):
     shortfall_usd: float = 0.0
 
 
-class SimulationSettlementResult(_SimulationTraceBase):
+class SettlementResult(_TraceBase):
     obligation_id: str
     obligation_type: ObligationType
     actor_id: str
@@ -714,7 +714,7 @@ class SimulationSettlementResult(_SimulationTraceBase):
     unpaid_amount_usd: float
 
 
-class SimulationFailureEvent(_SimulationTraceBase):
+class FailureEvent(_TraceBase):
     failure_event_id: str
     failure_event_type: FailureEventType
     obligation_id: str
@@ -1002,21 +1002,21 @@ class ScenarioResult(ApiModel):
     metric_fan_columns: dict[str, ColumnarTable] = Field(default_factory=dict)
     monthly_columns: ColumnarTable | None = None
     terminal_columns: ColumnarTable | None = None
-    actions: tuple[SimulationAction, ...] = ()
-    policy_decisions: tuple[SimulationPolicyDecision, ...] = ()
-    market_observations: tuple[SimulationMarketObservation, ...] = ()
+    actions: tuple[Action, ...] = ()
+    policy_decisions: tuple[PolicyDecision, ...] = ()
+    market_observations: tuple[MarketObservation, ...] = ()
     chart_accounts: tuple[ChartAccount, ...] = ()
-    journal_entries: tuple[SimulationJournalEntry, ...] = ()
-    postings: tuple[SimulationPosting, ...] = ()
-    balance_snapshots: tuple[SimulationBalanceSnapshot, ...] = ()
+    journal_entries: tuple[JournalEntry, ...] = ()
+    postings: tuple[Posting, ...] = ()
+    balance_snapshots: tuple[BalanceSnapshot, ...] = ()
     tax_lots: tuple[TaxLot, ...] = ()
     lot_dispositions: tuple[LotDisposition, ...] = ()
     liabilities: tuple[LiabilityState, ...] = ()
-    accounting_details: tuple[SimulationAccountingDetail, ...] = ()
-    obligations: tuple[SimulationObligation, ...] = ()
-    funding_decisions: tuple[SimulationFundingDecision, ...] = ()
-    settlement_results: tuple[SimulationSettlementResult, ...] = ()
-    failure_events: tuple[SimulationFailureEvent, ...] = ()
+    accounting_details: tuple[AccountingDetail, ...] = ()
+    obligations: tuple[Obligation, ...] = ()
+    funding_decisions: tuple[FundingDecision, ...] = ()
+    settlement_results: tuple[SettlementResult, ...] = ()
+    failure_events: tuple[FailureEvent, ...] = ()
     warnings: tuple[str, ...] = ()
 
 

--- a/augur/core/schemas.py
+++ b/augur/core/schemas.py
@@ -201,7 +201,7 @@ class SaleOutcome(InternalModel):
     net_sale_proceeds_usd: float
 
 
-class SimulationTerminal(InternalModel):
+class Terminal(InternalModel):
     final_month: MonthRow
     final_home_value_usd: float
     final_loan_balance_usd: float
@@ -210,7 +210,7 @@ class SimulationTerminal(InternalModel):
     owner_net_proceeds_usd: float
 
 
-class SimulationResult(InternalModel):
+class Result(InternalModel):
     # Property + scenario knobs the simulator was driven with. Carrying the
     # typed models here lets `analysis.py` (project_summary, project_yearly_ledger,
     # …) read fields without re-deriving request state.
@@ -232,7 +232,7 @@ class SimulationResult(InternalModel):
     months: list[MonthRow]
     ledger: list[LedgerRow]
     validations: list[str]
-    terminal: SimulationTerminal
+    terminal: Terminal
 
 
 # ---------------------------------------------------------------------------

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -1681,7 +1681,7 @@ def test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface() -> N
     """Cleanup-audit item 2 invariant: every public monthly flow column is derived
     from the canonical detail surface (ledger postings, balance snapshots,
     accounting details, or market observations) — never from a parallel
-    SimulationAction recorder. This guard rebuilds each monthly metric matrix
+    Action recorder. This guard rebuilds each monthly metric matrix
     from the canonical detail rows the engine emits and asserts it equals the
     monthly array reported in the result.
 


### PR DESCRIPTION
## Summary

Inside the simulator every class is by definition simulated; the `Simulation` prefix adds noise without disambiguating. This is a pure internal rename — wire JSON keys (e.g. `simulation_actions`, `policy_decisions`) and `*_type` discriminator literals are unchanged, only Python class names move.

`ApiModel` uses explicit per-field names with no aliasing on the class name (verified by reading `augur/core/schemas.py` — `model_config = ConfigDict(extra="forbid", frozen=True)` with no `alias_generator`), so serialized output is byte-identical and the frontend Zod surface is unaffected.

## Classes renamed

| Old                                  | New                       |
| ------------------------------------ | ------------------------- |
| `SimulationAction`                   | `Action`                  |
| `SimulationPolicyDecision`           | `PolicyDecision`          |
| `SimulationMarketObservation`        | `MarketObservation`       |
| `SimulationJournalEntry`             | `JournalEntry`            |
| `SimulationPosting`                  | `Posting`                 |
| `SimulationBalanceSnapshot`          | `BalanceSnapshot`         |
| `SimulationAccountingDetail`         | `AccountingDetail`        |
| `SimulationObligation`               | `Obligation`              |
| `SimulationFundingDecision`          | `FundingDecision`         |
| `SimulationSettlementResult`         | `SettlementResult`        |
| `SimulationFailureEvent`             | `FailureEvent`            |
| `SimulationResult`                   | `Result`                  |
| `SimulationTerminal`                 | `Terminal`                |
| `SimulationRun`                      | `ScenarioSetRun`          |
| `SimulationValidationError`          | `ScenarioValidationError` |
| `_SimulationTraceBase`               | `_TraceBase`              |
| `_SimulationActionBase`              | `_ActionBase`             |
| `_SimulationPolicyDecisionBase`      | `_PolicyDecisionBase`     |
| `_SimulationMarketObservationBase`   | `_MarketObservationBase`  |
| `_SimulationAccountingDetailBase`    | `_AccountingDetailBase`   |

### Collision-driven prefixes

- `SimulationRun` -> `ScenarioSetRun` (not bare `Run`) — `api.py` already has `ScenarioRun` and `ProjectionRun`; bare `Run` would be ambiguous. `ScenarioSetRun` mirrors the type it holds: a scenario set + the resulting per-scenario `ScenarioRun`s.
- `SimulationValidationError` -> `ScenarioValidationError` (not bare `ValidationError`) — avoids clash with the very common `pydantic.ValidationError` import.

`Result` and `Terminal` are kept as plain (un-prefixed) names: both live in `augur/core/schemas.py`, neither has a local collision, and `SimulationResult`/`SimulationTerminal` have no references anywhere else in the tree.

## Wire format

Unchanged. `ApiModel` does not alias on class name; every model field is declared with an explicit snake_case name, and discriminator literals (`obligation_type`, `decision_type`, etc.) carry their own enum values. The Zod surface (`augur/frontend/lib/api/schema.zod.mjs`) and the frontend serializer don't reference any of the renamed Python class names — they consume the snake_case wire fields directly. No `alias=` was needed.

## Test plan

- [x] `bbr test //augur/...` — 27/28 pass; the only failure (`//augur/frontend:visual_golden_test`) reproduces on `origin/devel` and is unrelated to this rename (no files under `augur/frontend/` are touched here; the failure follows the Mantine migration in #1583).
- [x] `bbr build //augur/...` — passes.
- [x] `//augur/frontend/lib:scenario_set_state_test` passes — confirms the Zod-driven frontend serializer still parses wire JSON exactly as before.
- [x] Pre-commit hooks (ruff-check, ruff-format, mypy via Bazel lint aspect) all pass.

## Heads-up

A sibling branch (`claude/plan-c-unified-obligations`) is editing `core/scenario_engine.py`, `policy_runtime.py`, `scenario_set.py`. Whichever PR lands second will need to re-apply the rename (or this one will need to re-apply the new flows). The diff here is a single focused commit to keep that rebase mechanical.


---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_