### PR TITLE
augur/core: Plan C foundation — unified obligation surface + SpecialAssessment

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -10,17 +10,6 @@ Priority ordering and cross-repo consolidation live in
 `plans/roadmap.md`. Keep this file as the public generic backlog rather than a
 second ordered roadmap.
 
-## In Flight
-
-- Funding policies consume crypto + tender-window-aware PE — extend the
-  obligation-funding policy chain so `CheckingFloorSellPublicStockPolicy`
-  (and siblings) can liquidate crypto holdings and tender-eligible PE
-  alongside SP500. Branch `claude/funding-policies-crypto-tender`. This
-  slice covers the runtime asset + funding side only; the stochastic
-  price-path side is the priority-3 follow-on below.
-- Mantine migration of remaining frontend controls. Branch
-  `claude/augur-frontend-mantine-migration`.
-
 ## Next
 
 - [ ] **PE should actually be simulated** (Priority 3 in `plans/roadmap.md`).

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -30,10 +30,26 @@ second ordered roadmap.
       distribution. Model design is part of the same pass as PE above
       (joint vs independent fit is a design question; deployment evidence
       is private and stays downstream).
-- [ ] Plan C in `plans/roadmap.md`: unified obligation/funding semantics
-      for all immediate cash demands (property tax, HOA, insurance,
-      maintenance, outside rent, partner contributions, special assessments,
-      quarterly estimated taxes).
+- [ ] Plan C remaining slices (foundation landed in
+      `claude/plan-c-unified-obligations`): the `ObligationType` enum now
+      covers every variant called out in `plans/roadmap.md` (annual tax,
+      estimated tax, mortgage, property tax, HOA dues, insurance,
+      maintenance, outside rent, special assessment, partner
+      contribution); `_CashDebitObligationKind` provides the generic
+      pipeline shape with a `required: bool` knob; `SpecialAssessmentEvent`
+      is wired end-to-end as the first non-tax / non-mortgage cash demand
+      that routes through `_settle_required_cash_obligations`. Still
+      pending: (a) refactor `apply_property_operating_cash_flows` so
+      property tax / HOA / insurance / maintenance emit obligations
+      instead of debiting cash directly; (b) route the contributing-side
+      partner contribution through the obligation pipeline so a
+      cash-strapped partner produces FAILED; (c) add quarterly estimated
+      tax obligations on the standard Apr/Jun/Sep/Jan-next schedule with
+      100%/110% safe-harbor (90% first year), with the year-end true-up
+      reduced by estimated payments actually made; (d) outside-rent
+      obligations for `OccupancyMode.OWNER_RENTS_ELSEWHERE` (currently
+      not modeled — leave a tombstone at the call site until rent
+      modeling lands).
 - [ ] Drop the `Simulation` prefix from internal class names. Inside a
       simulator every class is by definition simulated; the prefix adds
       noise without disambiguating. Survey hit (after trace-surface collapse

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -113,6 +113,7 @@ from augur.core.scenario_set import (
     SimulationObligation,
     SimulationPolicyDecision,
     SimulationSettlementResult,
+    SpecialAssessmentEvent,
     TaxPaymentAllocationDetail,
 )
 from augur.core.schemas import ColumnarTable
@@ -122,6 +123,7 @@ MORTGAGE_SERVICING_POLICY_ID = "mortgage_servicing"
 PROPERTY_OPERATING_CASH_FLOW_POLICY_ID = "property_operating_cash_flow"
 PROPERTY_SALE_SETTLEMENT_POLICY_ID = "property_sale_settlement"
 ANNUAL_TAX_ACCOUNTING_POLICY_ID = "annual_tax_accounting"
+SPECIAL_ASSESSMENT_POLICY_ID = "special_assessment"
 
 
 @dataclass(frozen=True)
@@ -1840,6 +1842,39 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             sp500_sale_action_records=sp500_sale_action_records,
             crypto_sale_action_records=crypto_sale_action_records,
         )
+    special_assessment_due = _special_assessment_obligation_due_usd(
+        scenario, rollout_count=rollout_count, month_index=month_index
+    )
+    if np.any(special_assessment_due > 0):
+        _settle_required_cash_obligations(
+            scenario=scenario,
+            market_bundle=market_bundle,
+            month_index=month_index,
+            policy_steps=policy_steps,
+            obligation_amount_usd=special_assessment_due,
+            obligation_kind=_CashDebitObligationKind(
+                obligation_type=ObligationType.SPECIAL_ASSESSMENT, expense_role=ChartAccountRole.HOA_EXPENSE
+            ),
+            creditor_id="hoa",
+            source_policy_id=SPECIAL_ASSESSMENT_POLICY_ID,
+            cash_usd=cash,
+            generic_sp500_value_usd=generic_sp500_value,
+            remaining_sp500_units_by_month=remaining_sp500_units_by_month,
+            remaining_sp500_basis_by_month=remaining_sp500_basis_by_month,
+            crypto_value_usd=crypto_value,
+            remaining_crypto_quantity_by_month=remaining_crypto_quantity_by_month,
+            remaining_crypto_basis_by_month=remaining_crypto_basis_by_month,
+            crypto_sale_usd=crypto_sale_usd,
+            crypto_sale_basis_usd=crypto_sale_basis_usd,
+            checking_floor_shortfall_usd=checking_floor_shortfall,
+            obligations=obligations,
+            funding_decisions=funding_decisions,
+            settlement_results=settlement_results,
+            failure_events=failure_events,
+            accounting=accounting,
+            sp500_sale_action_records=sp500_sale_action_records,
+            crypto_sale_action_records=crypto_sale_action_records,
+        )
     _record_journal_entry_batches(
         accounting,
         month_index=month_index,
@@ -3352,6 +3387,7 @@ def _tax_share_for_sale_action(
 @dataclass(frozen=True)
 class _AnnualTaxObligationKind:
     obligation_type: ObligationType = ObligationType.ANNUAL_TAX_PAYMENT
+    required: bool = True
 
 
 @dataclass(frozen=True)
@@ -3360,9 +3396,30 @@ class _MortgageObligationKind:
     principal_usd: np.ndarray
     property_id: str
     obligation_type: ObligationType = ObligationType.MORTGAGE_PAYMENT
+    required: bool = True
 
 
-_ObligationKind = _AnnualTaxObligationKind | _MortgageObligationKind
+@dataclass(frozen=True)
+class _CashDebitObligationKind:
+    """Generic obligation kind for cash demands that settle as a single expense debit
+    against cash on the settlement journal entry.
+
+    Used for variants that don't carry their own per-line accounting nuance:
+    property tax, HOA dues, insurance, maintenance, outside rent, special
+    assessment, and partner contribution (contributing-actor side).
+
+    `expense_role` is the chart-account role to debit on settlement. The credit
+    side is `CHECKING_CASH`. `journal_entry_type` controls how the trace surfaces
+    the settlement entry (typically `OBLIGATION_SETTLEMENT`).
+    """
+
+    obligation_type: ObligationType
+    expense_role: ChartAccountRole
+    journal_entry_type: JournalEntryType = JournalEntryType.OBLIGATION_SETTLEMENT
+    required: bool = True
+
+
+_ObligationKind = _AnnualTaxObligationKind | _MortgageObligationKind | _CashDebitObligationKind
 
 
 def _year_end_tax_obligation_due_usd(*, month_index: np.ndarray, source_month_tax_due_usd: np.ndarray) -> np.ndarray:
@@ -3624,6 +3681,7 @@ def _settle_required_cash_obligations(
             amount_due_usd=due,
             amount_paid_usd=amount_paid,
             unpaid_amount_usd=unpaid,
+            required=obligation_kind.required,
         )
 
 
@@ -3681,6 +3739,34 @@ def _record_obligation_accrual_and_settlement_entries(
                         amount_usd=amount_paid_usd,
                         actor_id=actor_id,
                         liability_id=f"tax:{obligation_type.value}",
+                    ),
+                    PostingBatch(
+                        role=ChartAccountRole.CHECKING_CASH,
+                        side=PostingSide.CREDIT,
+                        amount_usd=amount_paid_usd,
+                        actor_id=actor_id,
+                    ),
+                ),
+            ),
+        )
+        return
+    if isinstance(obligation_kind, _CashDebitObligationKind):
+        accounting.record_entry(
+            month_index=month_index,
+            entry=JournalEntryBatch(
+                journal_entry_type=obligation_kind.journal_entry_type,
+                cause_type=AccountingCauseType.OBLIGATION_SETTLEMENT,
+                cause_id_prefix=f"policy:{source_policy_id}:{obligation_type.value}:settlement",
+                obligation_id_prefix=obligation_type.value,
+                actor_id=actor_id,
+                policy_id=source_policy_id,
+                description=obligation_type.value,
+                postings=(
+                    PostingBatch(
+                        role=obligation_kind.expense_role,
+                        side=PostingSide.DEBIT,
+                        amount_usd=amount_paid_usd,
+                        actor_id=actor_id,
                     ),
                     PostingBatch(
                         role=ChartAccountRole.CHECKING_CASH,
@@ -3997,6 +4083,7 @@ def _record_obligation_settlement_rows(
     amount_due_usd: np.ndarray,
     amount_paid_usd: np.ndarray,
     unpaid_amount_usd: np.ndarray,
+    required: bool = True,
 ) -> None:
     for rollout_index in np.nonzero(amount_due_usd > 0)[0].tolist():
         due = float(amount_due_usd[rollout_index])
@@ -4034,7 +4121,7 @@ def _record_obligation_settlement_rows(
                 unpaid_amount_usd=unpaid,
             )
         )
-        if unpaid > 0:
+        if unpaid > 0 and required:
             failure_events.append(
                 SimulationFailureEvent(
                     rollout_index=rollout_index,
@@ -4693,6 +4780,31 @@ def _scenario_hoa_monthly_usd(scenario: Scenario) -> float:
         if isinstance(event, PropertyPurchaseEvent) and event.hoa_monthly_usd is not None:
             return float(event.hoa_monthly_usd)
     return 0.0
+
+
+def _special_assessment_obligation_due_usd(
+    scenario: Scenario, *, rollout_count: int, month_index: np.ndarray
+) -> np.ndarray:
+    """Build a (rollout, month) matrix of special-assessment dues from scenario events.
+
+    Each `SpecialAssessmentEvent` in `scenario.events` contributes its `amount_usd` to
+    the matrix column corresponding to its `month_index`. Events whose `month_index`
+    falls outside the simulation horizon are clamped to the last in-horizon month so
+    the cash impact lands within the simulation (mirrors the year-end tax fallback).
+    Each row of the matrix is identical across rollouts: a special assessment is a
+    deterministic scheduled event, not a per-rollout stochastic input.
+    """
+    matrix = np.zeros((rollout_count, month_index.size), dtype="float64")
+    if month_index.size == 0:
+        return matrix
+    last_position = month_index.size - 1
+    for event in scenario.events:
+        if not isinstance(event, SpecialAssessmentEvent):
+            continue
+        event_positions = np.nonzero(month_index == int(event.month_index))[0]
+        position = int(event_positions[0]) if event_positions.size > 0 else last_position
+        matrix[:, position] = matrix[:, position] + float(event.amount_usd)
+    return matrix
 
 
 def _required_local_regulation(scenario: Scenario) -> LocalRegulation:

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -30,6 +30,7 @@ class EventType(StrEnum):
     PORTFOLIO_TRADE = "portfolio_trade"
     PRIVATE_EQUITY_IPO = "private_equity_ipo"
     PRIVATE_EQUITY_ACQUISITION = "private_equity_acquisition"
+    SPECIAL_ASSESSMENT = "special_assessment"
 
 
 class PolicyType(StrEnum):
@@ -179,7 +180,15 @@ class TaxPaymentTiming(StrEnum):
 
 class ObligationType(StrEnum):
     ANNUAL_TAX_PAYMENT = "annual_tax_payment"
+    ESTIMATED_TAX_PAYMENT = "estimated_tax_payment"
     MORTGAGE_PAYMENT = "mortgage_payment"
+    PROPERTY_TAX = "property_tax"
+    HOA_DUES = "hoa_dues"
+    INSURANCE_PREMIUM = "insurance_premium"
+    MAINTENANCE = "maintenance"
+    OUTSIDE_RENT = "outside_rent"
+    SPECIAL_ASSESSMENT = "special_assessment"
+    PARTNER_CONTRIBUTION = "partner_contribution"
 
 
 class ObligationStatus(StrEnum):
@@ -238,6 +247,12 @@ PropertyId = str
 class OccupancyMode(StrEnum):
     OWNER_LIVES_IN_PROPERTY = "owner_lives_in_property"
     OWNER_LIVES_IN_OTHER_OWNED_PROPERTY = "owner_lives_in_other_owned_property"
+    # CLEANUP(2026-05-17): `OWNER_RENTS_ELSEWHERE` is not modeled — the
+    #   engine has no per-month rent debit for the owner-as-tenant role and
+    #   no rent-policy schema. Plan C slice 3 (`augur/plans/roadmap.md`)
+    #   reserves `ObligationType.OUTSIDE_RENT` for the moment a rent policy
+    #   lands and starts emitting the obligation. Remove this comment when
+    #   that slice ships.
     OWNER_RENTS_ELSEWHERE = "owner_rents_elsewhere"
     NO_OWNER_OCCUPANCY = "no_owner_occupancy"
 
@@ -315,6 +330,18 @@ class PrivateEquityAcquisitionEvent(_EventBase):
     event_type: Literal[EventType.PRIVATE_EQUITY_ACQUISITION] = EventType.PRIVATE_EQUITY_ACQUISITION
 
 
+class SpecialAssessmentEvent(_EventBase):
+    """One-shot HOA / association special assessment due in `month_index`.
+
+    Routes through the unified obligation pipeline as a `SPECIAL_ASSESSMENT`
+    obligation. `amount_usd` is the assessment amount; if `actor_id` is unset
+    the obligation is billed to the scenario's primary owner.
+    """
+
+    event_type: Literal[EventType.SPECIAL_ASSESSMENT] = EventType.SPECIAL_ASSESSMENT
+    amount_usd: PositiveFloat
+
+
 Event = Annotated[
     PropertyPurchaseEvent
     | PropertySaleEvent
@@ -324,7 +351,8 @@ Event = Annotated[
     | StopRentalEvent
     | PortfolioTradeEvent
     | PrivateEquityIpoEvent
-    | PrivateEquityAcquisitionEvent,
+    | PrivateEquityAcquisitionEvent
+    | SpecialAssessmentEvent,
     Field(discriminator="event_type"),
 ]
 

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -62,6 +62,7 @@ from augur.core.scenario_set import (
     SellPublicStockDecision,
     SellSp500Action,
     SettlePropertySaleAction,
+    SpecialAssessmentEvent,
     TaxFilingStatus,
     TaxPaymentAllocationDetail,
     TaxPaymentTiming,
@@ -627,6 +628,84 @@ def test_mortgage_obligation_continues_projection_after_failure() -> None:
     # One failure per scheduled mortgage month (1..6).
     assert len(mortgage_failures) == horizon_months
     assert {event.month_index for event in mortgage_failures} == set(range(1, horizon_months + 1))
+
+
+def test_special_assessment_event_settles_as_obligation_when_cash_available() -> None:
+    """A `SpecialAssessmentEvent` produces a `SPECIAL_ASSESSMENT` obligation due in
+    the event month. When cash covers the amount, the obligation settles PAID and
+    the rollout stays ACTIVE; cash drops by the assessment amount in that month."""
+    scenario = Scenario(
+        scenario_id="special_assessment_happy",
+        label="Special Assessment Happy",
+        actors=(_simple_actor(),),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=50_000
+                ),
+            )
+        ),
+        events=(SpecialAssessmentEvent(event_id="hoa_assessment", month_index=3, amount_usd=10_000),),
+    )
+    result = _run_scenario(scenario, horizon_months=6)
+    assert result.arrays is not None
+    special_assessment_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.SPECIAL_ASSESSMENT
+    )
+    assert len(special_assessment_obligations) == 1
+    assessment = special_assessment_obligations[0]
+    assert assessment.month_index == 3
+    assert assessment.amount_due_usd == 10_000
+    assert assessment.status is ObligationStatus.PAID
+    assert tuple(event for event in result.arrays.failure_events) == ()
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    cash_series = result.rollout(0).series(ReportMetric.CASH_USD)
+    assert cash_series[2] == 50_000
+    assert cash_series[3] == 40_000
+
+
+def test_special_assessment_event_fails_rollout_when_unfundable() -> None:
+    """A required `SPECIAL_ASSESSMENT` obligation that can't be funded fails the
+    rollout: emits a `FailureEvent`, flips status to FAILED, and records an
+    UNFUNDED funding decision."""
+    scenario = Scenario(
+        scenario_id="special_assessment_unfundable",
+        label="Special Assessment Unfundable",
+        actors=(_simple_actor(),),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=500
+                ),
+            )
+        ),
+        events=(SpecialAssessmentEvent(event_id="hoa_assessment", month_index=2, amount_usd=25_000),),
+    )
+    result = _run_scenario(scenario, horizon_months=6)
+    assert result.arrays is not None
+    special_assessment_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.SPECIAL_ASSESSMENT
+    )
+    assert len(special_assessment_obligations) == 1
+    assert special_assessment_obligations[0].status is ObligationStatus.PARTIALLY_PAID
+    failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("special_assessment")
+    )
+    assert len(failures) == 1
+    assert failures[0].unpaid_amount_usd > 0
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    unfunded = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("special_assessment")
+        and decision.decision_type is FundingDecisionType.UNFUNDED
+    )
+    assert len(unfunded) == 1
+    assert unfunded[0].shortfall_usd > 0
 
 
 def test_partner_equity_accrual_records_contributions_and_claims() -> None:

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -479,24 +479,35 @@ Generalize the shape so **one** pattern handles every immediate cash demand:
 1. **Expand `ObligationType`** beyond `ANNUAL_TAX_PAYMENT` /
    `MORTGAGE_PAYMENT`. Add: `PROPERTY_TAX`, `HOA_DUES`, `INSURANCE_PREMIUM`,
    `MAINTENANCE`, `OUTSIDE_RENT`, `SPECIAL_ASSESSMENT`,
-   `PARTNER_CONTRIBUTION`. Each variant declares `required: bool` — required
-   obligations produce `FAILED` on shortfall; discretionary obligations are
-   best-effort and produce a settlement row but not a failure event.
+   `PARTNER_CONTRIBUTION`, `ESTIMATED_TAX_PAYMENT`. Each variant declares
+   `required: bool` — required obligations produce `FAILED` on shortfall;
+   discretionary obligations are best-effort and produce a settlement row
+   but not a failure event.
+   **Landed (foundation PR).** Enum members exist; the obligation-kind
+   dataclasses (`_AnnualTaxObligationKind`, `_MortgageObligationKind`, new
+   generic `_CashDebitObligationKind`) carry `required: bool`;
+   `_record_obligation_settlement_rows` honors the flag so a discretionary
+   variant produces a settlement row without a failure event.
 2. **Refactor `apply_property_operating_cash_flows`** (<augur/core/policy_runtime.py>)
    to emit obligations instead of directly debiting cash. Same accrual
    amounts, same months, same chart-account roles — the only visible change
    is new obligation/settlement rows on the trace. Cash trajectories should
    match the current behavior on the happy path.
+   **Pending.** Hardest slice; touches the property cash-flow pipeline.
 3. **Outside-rent obligations** for `OccupancyMode.OWNER_RENTS_ELSEWHERE`.
    Today this isn't first-class. Add a `RentalPaymentPolicy` (or extend
    `OccupancyDecisionPolicy`) that accrues monthly rent as a required
    obligation. Verify against existing tests.
+   **Pending.** Today `OWNER_RENTS_ELSEWHERE` does not model the
+   tenant-side rent cash demand at all (no direct cash debit either);
+   the `OUTSIDE_RENT` enum value is reserved for when rent modeling lands.
 4. **Partner-contribution obligations**. Today
    `apply_partner_house_cost_contribution` debits cash unconditionally. The
    contributing actor's failure to fund their share of housing costs is a
    real-world failure mode and should produce `FAILED`. Move the cash debit
    to the obligation pipeline. The owner side (which credits cash) stays
    direct since it's a receipt, not a demand.
+   **Pending.** The `PARTNER_CONTRIBUTION` enum value is reserved.
 5. **Quarterly estimated tax payments** on top of the year-end obligation.
    Standard schedule: Apr 15, Jun 15, Sep 15, Jan 15 of the following year
    (clamped to horizon). Safe-harbor: 100% of prior-year tax (110% when AGI
@@ -504,16 +515,26 @@ Generalize the shape so **one** pattern handles every immediate cash demand:
    estimated payments. First year (no prior-year tax): use 90% of estimated
    current-year tax. The year-end obligation amount reduces by the sum of
    estimated payments actually made.
+   **Pending.** The `ESTIMATED_TAX_PAYMENT` enum value is reserved.
 6. **Special-assessment events**. Add a `SpecialAssessment` event variant
    for one-shot HOA assessments, surfaced through the existing event
    pipeline. Each event produces a `SPECIAL_ASSESSMENT` obligation due in
    the event month.
+   **Landed (foundation PR).** `SpecialAssessmentEvent` lives next to the
+   other event variants; the scenario engine builds a (rollout, month)
+   obligation matrix and routes it through `_settle_required_cash_obligations`
+   with a `_CashDebitObligationKind` carrying `ChartAccountRole.HOA_EXPENSE`.
+   Two `test_e2e.py` cases cover the happy path and the FAILED rollout
+   path. This is the proving ground for the unified pipeline shape.
 7. **Generalize failure tests**. One `RolloutStatusType.FAILED` test per
    obligation type proving the funding-policy chain runs, can be rescued
    by an asset sale, and fails the rollout when no rescue is available.
    Extend `test_e2e.py` with a "cash-strapped rental scenario" and a
    "cash-strapped owner-rents-elsewhere scenario" that fail on the right
    obligation.
+   **Partially landed.** `test_special_assessment_event_fails_rollout_when_unfundable`
+   covers the new variant; the rest follow naturally as slices 2–5 land
+   their pipelines.
 
 #### Out of scope (defer to a follow-on)
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -402,34 +402,23 @@ Work:
    normalization and request mapping, then split app/frontend/server packages
    after the core contracts and server cleanup settle.
 
-## In Flight
-
-- **Funding policies consume crypto + tender-window-aware PE** —
-  `PortfolioStatement.to_initial_balance_sheet()` currently drops crypto
-  holdings and tender windows. First-class runtime handling: a new
-  `AssetType.CRYPTO`, tender-window-driven `private_equity_sale_opportunity_mask`,
-  and extension of `CheckingFloorSellPublicStockPolicy` (and the
-  obligation-funding chain) to liquidate crypto and tender-eligible PE.
-  This slice covers the runtime asset + funding side; Priority 3 covers
-  the stochastic price-path side for both PE and crypto.
-- **Mantine migration of remaining frontend controls** — `augur/frontend/`.
-  `augur/frontend/app.jsx` form/table elements move to Mantine equivalents.
-
 ## Next Lanes (parallelism + sequencing)
 
-- **Priority 3 — stochastic PE/crypto/tender** (high impact, large variance
-  source currently ignored by the simulator). Three concurrent sub-slices,
-  all in `augur/model/`, isolated from `augur/core/scenario_engine.py`:
-  - Per-asset sampled PE price paths (replace flat `np.ones(...)` multiplier).
-  - Stochastic tender-arrival process (replace deterministic 12-month mask).
-  - Sampled crypto price paths (consume the runtime asset class the
-    in-flight funding-policy slice is adding).
+- **Priority 3 — sampled PE / sampled tender timing / sampled crypto**
+  (open design work; see the priority section above). Joint fit with
+  SP500 / inflation / per-location housing factors on sparse evidence.
+  Lives entirely in `augur/model/`, isolated from
+  `augur/core/scenario_engine.py`.
 - **Plan C (unified obligation/funding semantics)** — see below.
-  Sequence after the crypto/tender-PE funding slice lands, since they share
-  `scenario_engine.py`.
+  Generalize property tax, HOA, insurance, maintenance, outside rent,
+  partner contributions, and special assessments through the existing
+  obligation/funding/settlement pipeline; layer quarterly estimated
+  taxes on top. Touches `augur/core/scenario_engine.py`.
 - **Persist model-governance artifacts** — durable evidence / calibration
   / validation-report storage for market providers. `augur/model/`.
   Self-contained, can run in parallel with anything.
+- **Simulation-prefix scrub** — internal rename across 6 files in
+  `augur/core/`. Mechanical; no wire-format change.
 
 ## Next Work Plans
 


### PR DESCRIPTION
## Summary

This PR lands the **foundation** for Plan C (unified obligation/funding semantics for all immediate cash demands). It does **not** land the full plan — slices 2, 3, 4, and 5 are pending in follow-on PRs. The PR title reflects this scope honestly rather than overclaiming.

What does land:

- **Slice 1 (full)** — `ObligationType` now covers every variant from the Plan C slice list: `ANNUAL_TAX_PAYMENT`, `ESTIMATED_TAX_PAYMENT`, `MORTGAGE_PAYMENT`, `PROPERTY_TAX`, `HOA_DUES`, `INSURANCE_PREMIUM`, `MAINTENANCE`, `OUTSIDE_RENT`, `SPECIAL_ASSESSMENT`, `PARTNER_CONTRIBUTION`. New generic `_CashDebitObligationKind` dataclass extends the obligation-kind union with a single shape that fits any "demand cash, debit expense role, credit checking" variant. All three obligation-kind dataclasses now carry `required: bool`, and `_record_obligation_settlement_rows` honors the flag so a future PR can toggle a variant discretionary without an enum or pipeline change.
- **Slice 6 (full)** — `SpecialAssessmentEvent` is the first non-tax / non-mortgage cash demand routed through `_settle_required_cash_obligations`. The engine builds a (rollout, month) obligation matrix from `scenario.events`, settles via cash + checking-floor sale chain, records `ObligationType.SPECIAL_ASSESSMENT` settlement rows, and emits the same accounting entries as any other obligation. This slice is the proving ground for the unified pipeline shape.
- **Slice 7 (partial)** — Two new `test_e2e.py` cases prove the happy path (`test_special_assessment_event_settles_as_obligation_when_cash_available`) and the FAILED-rollout path (`test_special_assessment_event_fails_rollout_when_unfundable`) for `SPECIAL_ASSESSMENT`. The remaining per-variant FAILED tests come with the corresponding pipeline slices.

What does not land in this PR (still in scope for Plan C, tracked in `augur/TODO.md` and `augur/plans/roadmap.md`):

- **Slice 2** — refactor `apply_property_operating_cash_flows` to emit obligations instead of debiting cash directly for property tax / HOA / insurance / maintenance. The biggest behavior change; deferred so the foundation lands separately.
- **Slice 3** — outside-rent obligations for `OccupancyMode.OWNER_RENTS_ELSEWHERE`. `OWNER_RENTS_ELSEWHERE` is currently not modeled at all (no rent debit, no rent policy schema). A `CLEANUP(2026-05-17)` tombstone at the enum definition names the reserved `OUTSIDE_RENT` obligation type so the slice-3 follow-on has a clear hook point.
- **Slice 4** — move the contributing-actor side of `apply_partner_house_cost_contribution` through the obligation pipeline.
- **Slice 5** — quarterly estimated tax payments (Apr 15 / Jun 15 / Sep 15 / Jan 15 next-year, clamped to horizon; 100%/110% safe-harbor, 90% first year; year-end true-up reduced by estimated payments made).

## Quarterly estimated tax schedule (reserved for Slice 5)

Documented here so the follow-on PR has a clear contract:

- Months (Jan-anchor horizon): Apr 15 → month 3, Jun 15 → month 5, Sep 15 → month 8, Jan 15 of the following year → month 12 of that tax year. Clamped to the simulation horizon.
- Safe-harbor amount: 100% of prior-year total tax, or 110% when prior-year AGI exceeds $150k single / $75k MFS. First year (no prior-year tax): 90% of estimated current-year tax.
- Year-end annual-tax obligation amount reduces by the sum of estimated payments actually made — year-end is the true-up.

## Outside-rent decision (Slice 3)

**Tombstoned, not modeled.** Surveyed `augur/core/` for any existing rent-out-of-pocket cash debit and found none — `OWNER_RENTS_ELSEWHERE` has no behavioral handler at all today. Adding a half-modeled rent path here would be worse than leaving the enum value reserved. A `CLEANUP(2026-05-17)` comment at `OccupancyMode.OWNER_RENTS_ELSEWHERE` names the reserved obligation type and the slice that lands the actual rent policy.

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:policy_runtime_test //augur/core:annual_tax_test` — all pass
- [x] `bbr test //augur/core:scenario_set_test` — passes
- [x] `bbr test //augur/api:browser_shell_test` — passes
- [x] `bbr test //augur/...` — 27/28 pass; only `//augur/frontend:visual_golden_test` fails (`distribution_fan` 0.26% pixel diff at 0% tolerance). **This is a pre-existing flake** — the same failure reproduces on `devel` base with my changes stashed, so this PR does not introduce the visual diff.
- [x] `bbr build //augur/...` — clean

## Visual golden delta

None introduced by this PR. The one failing visual golden (`distribution_fan`) is pre-existing on `devel` and unrelated to Plan C.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_