### PR TITLE
devinfra/js/debundle: per-symbol vendor partial-swap on mixed chunks

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -477,3 +477,244 @@ fn build_named_from_default_spec(args: BuildSpecArgs<'_>) -> Value {
         "write_js_tree": { "force": true, "out_dir": args.out_root },
     })
 }
+
+// ─── partial_swap ───────────────────────────────────────────────────────
+//
+// `level: partial_swap` rewrites per-symbol imports out of a chunk that
+// the spec wants to keep on disk (un-swapped symbols stay imported from
+// the chunk). Each rewritten symbol gets its local references replaced
+// with `<namespace>.<upstream_export>` and one
+// `import * as <namespace> from "<package>"` is emitted per file.
+
+#[test]
+fn partial_swap_basic_rewrites_to_namespace_member() {
+    let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
+        chunk_source: "export const e6 = () => true;\nexport const keepMe = () => 7;\n",
+        caller_source: "import { e6 as zodBoolean, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return zodBoolean() && kept(); }\n",
+        upstream_source: "export const boolean = () => true;\n",
+        symbols: vec![("e6", "zod", "boolean")],
+        upstream_version: "3.23.8",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+
+    let caller_emitted = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller_emitted.contains("import * as z from \"zod\""),
+        "caller should namespace-import the package:\n{caller_emitted}",
+    );
+    assert!(
+        caller_emitted.contains("z.boolean()"),
+        "caller should call z.boolean() instead of zodBoolean():\n{caller_emitted}",
+    );
+    assert!(
+        !caller_emitted.contains("zodBoolean"),
+        "caller should not retain the original local-alias identifier:\n{caller_emitted}",
+    );
+    assert!(
+        caller_emitted.contains("keepMe as kept"),
+        "caller should retain non-swapped imports unchanged:\n{caller_emitted}",
+    );
+    assert!(
+        caller_emitted.contains("kept()"),
+        "caller should still reference the kept import by its local name:\n{caller_emitted}",
+    );
+}
+
+#[test]
+fn partial_swap_keeps_megachunk_on_disk() {
+    // Partial swap leaves the chunk in place so its non-swapped exports
+    // remain reachable. Contrast with `level: swap` which removes the
+    // chunk entirely. The megachunk file (`<out_dir>/static/megachunk/entry.js`)
+    // must still exist after the pipeline runs.
+    let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
+        chunk_source: "export const e6 = () => true;\nexport const keepMe = () => 7;\n",
+        caller_source: "import { e6 as zodBoolean, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return zodBoolean() && kept(); }\n",
+        upstream_source: "export const boolean = () => true;\n",
+        symbols: vec![("e6", "zod", "boolean")],
+        upstream_version: "3.23.8",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.megachunk_emitted_path.exists(),
+        "megachunk should still be emitted: {:?}",
+        fixture.megachunk_emitted_path,
+    );
+
+    let partial_manifest_path = fixture.partial_manifest_path();
+    let manifest: Value = serde_json::from_str(
+        &fs::read_to_string(&partial_manifest_path).expect("partial manifest"),
+    )
+    .expect("partial manifest parses");
+    let symbol_resolution = manifest
+        .get("resolutions")
+        .and_then(|r| r.get(&fixture.megachunk_chunk_path))
+        .and_then(|r| r.get("symbols"))
+        .and_then(|r| r.get("e6"))
+        .expect("manifest records e6 symbol resolution");
+    assert_eq!(
+        symbol_resolution
+            .get("references_rewritten")
+            .and_then(Value::as_u64),
+        Some(1),
+        "partial-swap manifest should count rewritten references:\n{manifest:#}",
+    );
+}
+
+#[test]
+fn partial_swap_rejects_version_mismatch() {
+    let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
+        chunk_source: "export const e6 = () => true;\n",
+        caller_source: "import { e6 as zodBoolean } from \"../megachunk/entry.js\";\nexport function go() { return zodBoolean(); }\n",
+        upstream_source: "export const boolean = () => true;\n",
+        symbols: vec![("e6", "zod", "boolean")],
+        // Mismatch: spec wants 9.9.9 but the on-disk package.json below
+        // pins to 3.23.8.
+        upstream_version: "9.9.9",
+    });
+
+    assert!(
+        !fixture.result.status.success(),
+        "debundler should fail on partial-swap version mismatch",
+    );
+    assert!(
+        fixture.result.stderr.contains("version mismatch"),
+        "expected version-mismatch error in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+struct PartialSwapFixtureArgs<'a> {
+    chunk_source: &'a str,
+    caller_source: &'a str,
+    upstream_source: &'a str,
+    /// (chunk_export, package_name, upstream_export) tuples. The package
+    /// `zod` is wired by the fixture below.
+    symbols: Vec<(&'a str, &'a str, &'a str)>,
+    upstream_version: &'a str,
+}
+
+struct PartialSwapFixture {
+    result: CommandResult,
+    megachunk_chunk_path: String,
+    caller_emitted_path: PathBuf,
+    megachunk_emitted_path: PathBuf,
+    manifest_path: PathBuf,
+    _root: TempDir,
+}
+
+impl PartialSwapFixture {
+    /// Partial-swap resolutions are written to a sibling JSON file in
+    /// the same directory as the main vendor swap manifest.
+    fn partial_manifest_path(&self) -> PathBuf {
+        self.manifest_path
+            .parent()
+            .expect("manifest path has a parent")
+            .join("vendor_partial_swap_manifest.json")
+    }
+}
+
+fn run_partial_swap_fixture(args: PartialSwapFixtureArgs<'_>) -> PartialSwapFixture {
+    const PACKAGE_NAME: &str = "zod";
+    const SUBPATH: &str = "lib/index.mjs";
+    const MEGACHUNK_PATH: &str = "static/megachunk.js";
+    const CALLER_PATH: &str = "static/app.js";
+
+    let root = TempDir::with_prefix("vendor-partial-swap-").expect("create tempdir");
+    let workspace_root = root.path().join("workspace");
+    let extracted_root = workspace_root.join("extracted");
+    let snapshot_root = workspace_root.join("snapshot");
+    let out_root = workspace_root.join("out");
+    let wrapper_root = workspace_root.join("vendors").join("generated");
+    let manifest_path = workspace_root.join("vendors").join("manifest.json");
+    let package_root = root.path().join("upstream").join(PACKAGE_NAME);
+    fs::create_dir_all(&extracted_root).unwrap();
+    fs::create_dir_all(&snapshot_root).unwrap();
+    fs::create_dir_all(&out_root).unwrap();
+    fs::create_dir_all(&wrapper_root).unwrap();
+    fs::create_dir_all(&package_root).unwrap();
+    fs::create_dir_all(snapshot_root.join("static")).unwrap();
+    fs::create_dir_all(package_root.join("lib")).unwrap();
+
+    write_text_file(&snapshot_root.join(MEGACHUNK_PATH), args.chunk_source);
+    write_text_file(&snapshot_root.join(CALLER_PATH), args.caller_source);
+    let js_list_path = extracted_root.join("js-files.txt");
+    write_text_file(&js_list_path, &format!("{MEGACHUNK_PATH}\n{CALLER_PATH}\n"));
+
+    // Pin the on-disk upstream to 3.23.8 regardless of what the spec
+    // requests — the version-mismatch test relies on this so the spec
+    // can declare a different version and trigger the strict check.
+    write_text_file(
+        &package_root.join("package.json"),
+        &format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "name": PACKAGE_NAME,
+                "version": "3.23.8",
+            }))
+            .unwrap(),
+        ),
+    );
+    write_text_file(&package_root.join(SUBPATH), args.upstream_source);
+
+    let mut symbols_json = serde_json::Map::new();
+    for (chunk_export, package, upstream_export) in &args.symbols {
+        symbols_json.insert(
+            (*chunk_export).to_string(),
+            json!({ "package": package, "upstream_export": upstream_export }),
+        );
+    }
+
+    let spec_path = root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            MEGACHUNK_PATH: {
+                "level": "partial_swap",
+                "identity": "megachunk partial swap fixture",
+                "packages": {
+                    PACKAGE_NAME: {
+                        "namespace": "z",
+                        "version": args.upstream_version,
+                        "subpath": SUBPATH,
+                    },
+                },
+                "symbols": Value::Object(symbols_json),
+            },
+        },
+        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
+        "swap_vendor_chunks": {
+            "output_manifest_path": &manifest_path,
+            "output_wrapper_dir": &wrapper_root,
+            "write": true,
+        },
+        "write_js_tree": { "force": true, "out_dir": &out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+
+    let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
+
+    let caller_emitted_path = out_root.join("static/app").join("entry.js");
+    let megachunk_emitted_path = out_root.join("static/megachunk").join("entry.js");
+
+    PartialSwapFixture {
+        result,
+        megachunk_chunk_path: MEGACHUNK_PATH.to_string(),
+        caller_emitted_path,
+        megachunk_emitted_path,
+        manifest_path,
+        _root: root,
+    }
+}

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -18,7 +18,8 @@ use rewrite_specifiers::rewrite_chunk_entry_specifiers;
 use spec::{MaterializeLogicalModulesConfig, SwapVendorChunksConfig, TransformSpec, VendorLevel};
 use spec_tree::{CompileSpecTreeOptions, compile_spec_tree};
 use vendor::{
-    SwapVendorOptions, apply_vendor_annotations, rename_vendor_exports, swap_vendor_chunks,
+    ApplyPartialVendorSwapsOptions, SwapVendorOptions, apply_partial_vendor_swaps,
+    apply_vendor_annotations, rename_vendor_exports, swap_vendor_chunks,
 };
 use write_tree::{WriteTreeInput, write_js_tree};
 
@@ -183,6 +184,7 @@ pub enum PipelineStage {
     ApplyVendorAnnotations,
     RenameVendorExports,
     SwapVendorChunks,
+    ApplyPartialVendorSwaps,
     MaterializeLogicalModules,
     WriteJsTree,
     EmitBrowserHarness,
@@ -337,6 +339,38 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
             artifact = swap_result.artifact;
             counts.chunks -= swap_result.removed_chunk_ids.len();
             chunk_records.retain(|chunk| !swap_result.removed_chunk_ids.contains(&chunk.chunk_id));
+        }
+        if spec
+            .vendor
+            .values()
+            .any(|m| matches!(m.level, VendorLevel::PartialSwap(_)))
+        {
+            // Reuse the swap-vendor output dir for the partial-swap
+            // manifest, but write to a distinct filename so the two
+            // resolution manifests don't collide. `output_wrapper_dir`
+            // isn't relevant for partial swap (no wrapper generated).
+            let partial_manifest_path = spec
+                .swap_vendor_chunks
+                .output_manifest_path
+                .as_ref()
+                .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
+                .map(|dir| dir.join("vendor_partial_swap_manifest.json"));
+            let write = spec.swap_vendor_chunks.write;
+            let partial_result =
+                run_step_with_result(&mut steps, PipelineStage::ApplyPartialVendorSwaps, || {
+                    apply_partial_vendor_swaps(
+                        artifact,
+                        &spec.vendor,
+                        &artifact_indexes,
+                        ApplyPartialVendorSwapsOptions {
+                            package_roots: &cli.package_roots,
+                            packages_root: &cli.packages_root,
+                            output_manifest_path: partial_manifest_path,
+                            write,
+                        },
+                    )
+                })?;
+            artifact = partial_result.artifact;
         }
     }
 

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -222,6 +222,7 @@ pub enum VendorLevel {
     Suppress,
     BoundaryRename,
     Swap(SwapMark),
+    PartialSwap(PartialSwapMark),
 }
 
 /// What [`TransformSpec::unassigned_mode`] means for a chunk's
@@ -287,6 +288,41 @@ pub struct SwapMark {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub wrapper_shape: Option<WrapperShape>,
+}
+
+/// Per-symbol vendor swap on a mixed chunk. The chunk stays on disk
+/// (residual exports keep working), but each listed export gets its
+/// caller-side references rewritten to a namespace member access
+/// (`zodObject(…)` → `z.object(…)`) and a single
+/// `import * as <namespace> from "<package>"` is added per file that
+/// uses the package. Multiple upstream packages can share one chunk.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PartialSwapMark {
+    /// package_name → upstream coordinates and namespace alias.
+    pub packages: BTreeMap<String, PartialSwapPackage>,
+    /// chunk_export_name → which package + which upstream export.
+    pub symbols: BTreeMap<String, PartialSwapSymbol>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PartialSwapPackage {
+    pub version: String,
+    pub subpath: String,
+    /// Local identifier used in the emitted
+    /// `import * as <namespace> from "<package>"`. Must be a valid JS
+    /// identifier; uniqueness within a file is the caller's contract
+    /// (when multiple partial-swap chunks share a package in the same
+    /// file, identical namespace strings dedupe into one import).
+    pub namespace: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PartialSwapSymbol {
+    /// Key into the enclosing [`PartialSwapMark::packages`] map.
+    pub package: String,
+    /// Upstream package's export name (becomes the member accessed
+    /// off the namespace import).
+    pub upstream_export: String,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, Eq, PartialEq)]

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 
 use spec::{
     AnonymousStatement, ChunkRenames, EmitBrowserHarnessConfig, LoadJsChunksArgs, LogicalModule,
-    MaterializeLogicalModulesConfig, Member, MemberEffect, MemberPurity, SwapMark,
-    SwapVendorChunksConfig, TransformSpec, UnassignedMode, VendorLevel, VendorMark, VendorRole,
-    WrapperShape,
+    MaterializeLogicalModulesConfig, Member, MemberEffect, MemberPurity, PartialSwapMark,
+    PartialSwapPackage, PartialSwapSymbol, SwapMark, SwapVendorChunksConfig, TransformSpec,
+    UnassignedMode, VendorLevel, VendorMark, VendorRole, WrapperShape,
 };
 use spec_modules::{
     collect_module_files, load_binding_patch_members, module_path_from_file, read_module_file,
@@ -75,6 +75,12 @@ struct VendorMarkSource {
     subpath: Option<String>,
     #[serde(default)]
     wrapper_shape: Option<WrapperShape>,
+    /// `partial_swap`-only: per-package upstream coordinates.
+    #[serde(default)]
+    packages: Option<BTreeMap<String, PartialSwapPackage>>,
+    /// `partial_swap`-only: per-chunk-export upstream-export mapping.
+    #[serde(default)]
+    symbols: Option<BTreeMap<String, PartialSwapSymbol>>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -83,6 +89,7 @@ enum VendorLevelSource {
     Suppress,
     BoundaryRename,
     Swap,
+    PartialSwap,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -228,24 +235,58 @@ impl VendorMarkSource {
         match self.level {
             VendorLevelSource::Suppress => {
                 self.ensure_no_swap_payload()?;
+                self.ensure_no_partial_swap_payload()?;
                 Ok(VendorLevel::Suppress)
             }
             VendorLevelSource::BoundaryRename => {
                 self.ensure_no_swap_payload()?;
+                self.ensure_no_partial_swap_payload()?;
                 Ok(VendorLevel::BoundaryRename)
             }
-            VendorLevelSource::Swap => Ok(VendorLevel::Swap(SwapMark {
-                package: self
-                    .package
-                    .with_context(|| format!("vendor mark {} missing package", self.chunk_path))?,
-                version: self
-                    .version
-                    .with_context(|| format!("vendor mark {} missing version", self.chunk_path))?,
-                subpath: self
-                    .subpath
-                    .with_context(|| format!("vendor mark {} missing subpath", self.chunk_path))?,
-                wrapper_shape: self.wrapper_shape,
-            })),
+            VendorLevelSource::Swap => {
+                self.ensure_no_partial_swap_payload()?;
+                Ok(VendorLevel::Swap(SwapMark {
+                    package: self.package.with_context(|| {
+                        format!("vendor mark {} missing package", self.chunk_path)
+                    })?,
+                    version: self.version.with_context(|| {
+                        format!("vendor mark {} missing version", self.chunk_path)
+                    })?,
+                    subpath: self.subpath.with_context(|| {
+                        format!("vendor mark {} missing subpath", self.chunk_path)
+                    })?,
+                    wrapper_shape: self.wrapper_shape,
+                }))
+            }
+            VendorLevelSource::PartialSwap => {
+                self.ensure_no_swap_payload()?;
+                let packages = self.packages.clone().with_context(|| {
+                    format!(
+                        "vendor mark {} (partial_swap) missing `packages`",
+                        self.chunk_path
+                    )
+                })?;
+                let symbols = self.symbols.clone().with_context(|| {
+                    format!(
+                        "vendor mark {} (partial_swap) missing `symbols`",
+                        self.chunk_path
+                    )
+                })?;
+                for (chunk_export, symbol) in &symbols {
+                    if !packages.contains_key(&symbol.package) {
+                        bail!(
+                            "vendor mark {} (partial_swap) symbol {} references unknown package `{}`",
+                            self.chunk_path,
+                            chunk_export,
+                            symbol.package
+                        );
+                    }
+                }
+                Ok(VendorLevel::PartialSwap(PartialSwapMark {
+                    packages,
+                    symbols,
+                }))
+            }
         }
     }
 
@@ -257,6 +298,16 @@ impl VendorMarkSource {
         {
             bail!(
                 "vendor mark {} has swap-only fields but level is not swap",
+                self.chunk_path
+            );
+        }
+        Ok(())
+    }
+
+    fn ensure_no_partial_swap_payload(&self) -> Result<()> {
+        if self.packages.is_some() || self.symbols.is_some() {
+            bail!(
+                "vendor mark {} has partial_swap-only fields (`packages`/`symbols`) but level is not partial_swap",
                 self.chunk_path
             );
         }

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -15,7 +15,10 @@ use artifact::{
     get_chunk_entry_path, list_chunk_file_paths, manifest_relative_path, path_from_module_path,
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
-use spec::{SwapMark, VendorLevel, VendorMark, VendorRole, WrapperShape};
+use spec::{
+    PartialSwapMark, PartialSwapPackage, PartialSwapSymbol, SwapMark, VendorLevel, VendorMark,
+    VendorRole, WrapperShape,
+};
 
 // These manifests are returned by the vendor stages but the pipeline
 // orchestrator only reads `kind` for stage logging. They are not
@@ -53,6 +56,7 @@ pub enum VendorAnnotationLevel {
     Suppress,
     BoundaryRename,
     Swap,
+    PartialSwap,
 }
 
 #[derive(Debug, Clone)]
@@ -152,6 +156,10 @@ pub fn apply_vendor_annotations(
                 (VendorAnnotationLevel::BoundaryRename, None, None, None)
             }
             VendorLevel::Suppress => (VendorAnnotationLevel::Suppress, None, None, None),
+            // Partial-swap is heterogeneous — multiple packages may live in
+            // one chunk. The summary line records the level only; per-symbol
+            // resolution detail surfaces through the partial-swap manifest.
+            VendorLevel::PartialSwap(_) => (VendorAnnotationLevel::PartialSwap, None, None, None),
         };
         summaries.push(VendorAnnotationSummary {
             chunk_path: chunk_path.clone(),
@@ -1357,6 +1365,579 @@ fn const_init_with_expr(alias: &str, init: Expr) -> ModuleItem {
 
 fn module_export_name(name: &ModuleExportName) -> String {
     name.atom().to_string()
+}
+
+// === partial vendor swap =================================================
+//
+// `swap_vendor_chunks` operates on a *whole* chunk — it wraps the chunk's
+// upstream, rewrites caller imports to point at the wrapper, and removes
+// the chunk from the artifact. That doesn't work for mixed chunks: Vite
+// commonly bundles several packages (zod + @sentry/browser + react +
+// lodash + katex + mermaid) into one ESM chunk. Removing it would drop
+// every co-bundled package.
+//
+// `apply_partial_vendor_swaps` is the per-symbol variant: it leaves the
+// chunk on disk and rewrites each listed caller-side import specifier
+// against an upstream package, then replaces every reference to the
+// imported local binding with a namespace member access. The chunk's
+// un-swapped exports keep working through the residual import.
+
+#[derive(Debug, Clone)]
+pub struct ApplyPartialVendorSwapsResult {
+    pub artifact: ChunkBundle,
+    pub manifest: PartialSwapResolutionManifest,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartialSwapResolutionManifest {
+    pub resolutions: BTreeMap<String, ChunkPartialSwapResolution>,
+    pub counts: PartialSwapResolutionCounts,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkPartialSwapResolution {
+    pub chunk_id: String,
+    pub chunk_path: String,
+    pub packages: BTreeMap<String, PartialSwapPackageResolution>,
+    pub symbols: BTreeMap<String, PartialSwapSymbolResolution>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PartialSwapPackageResolution {
+    pub namespace: String,
+    pub version: String,
+    pub subpath: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PartialSwapSymbolResolution {
+    pub package: String,
+    pub upstream_export: String,
+    pub references_rewritten: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartialSwapResolutionCounts {
+    pub chunks: usize,
+    pub symbols: usize,
+    pub references_rewritten: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyPartialVendorSwapsOptions<'a> {
+    pub package_roots: &'a std::collections::HashMap<String, PathBuf>,
+    pub packages_root: &'a Option<PathBuf>,
+    pub output_manifest_path: Option<PathBuf>,
+    pub write: bool,
+}
+
+/// Per-chunk in-memory mapping built once and shared across parallel
+/// per-file rewriters. Keyed by chunk name.
+type PartialSwapMappings = BTreeMap<String, ChunkPartialSwapMapping>;
+
+#[derive(Debug, Clone)]
+struct ChunkPartialSwapMapping {
+    chunk_path: String,
+    chunk_id: String,
+    /// package_name -> namespace + upstream coords.
+    packages: BTreeMap<String, PartialSwapPackage>,
+    /// chunk_export -> which package + upstream export.
+    symbols: BTreeMap<String, PartialSwapSymbolTarget>,
+}
+
+#[derive(Debug, Clone)]
+struct PartialSwapSymbolTarget {
+    package: String,
+    upstream_export: String,
+}
+
+pub fn apply_partial_vendor_swaps(
+    mut artifact: ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    references: &ArtifactIndexes,
+    options: ApplyPartialVendorSwapsOptions<'_>,
+) -> Result<ApplyPartialVendorSwapsResult> {
+    let ops: Vec<(&String, &PartialSwapMark)> = vendor
+        .iter()
+        .filter_map(|(chunk_path, mark)| match &mark.level {
+            VendorLevel::PartialSwap(partial) => Some((chunk_path, partial)),
+            _ => None,
+        })
+        .collect();
+    let chunk_table = artifact.chunk_table.clone();
+
+    let mut mappings: PartialSwapMappings = BTreeMap::new();
+    let mut resolutions: BTreeMap<String, ChunkPartialSwapResolution> = BTreeMap::new();
+
+    for (chunk_path, partial) in &ops {
+        let chunk_name = chunk_id_from_chunk_path(chunk_path, "apply_partial_vendor_swaps")?;
+        let chunk_id = chunk_table.get(&chunk_name).with_context(|| {
+            format!(
+                "apply_partial_vendor_swaps vendor entry {chunk_path} targets unknown chunk: {chunk_name}"
+            )
+        })?;
+        let entry_relative_file = get_chunk_entry_path(&artifact, chunk_id).with_context(|| {
+            format!(
+                "apply_partial_vendor_swaps vendor entry {chunk_path} targets missing chunk (chunk_id={chunk_name})"
+            )
+        })?;
+        let entry_ast = artifact
+            .js_chunk(chunk_id)?
+            .get_file(&entry_relative_file)
+            .and_then(|file| file.ast())
+            .with_context(|| {
+                format!("apply_partial_vendor_swaps vendor chunk {chunk_name} is missing entry AST")
+            })?;
+        let chunk_exports = collect_exported_names(&entry_ast.module, false);
+
+        // Validate every declared chunk_export exists as an actual export
+        // on the chunk; otherwise the per-symbol rewrite would silently
+        // miss the binding.
+        for chunk_export in partial.symbols.keys() {
+            if !chunk_exports.contains(chunk_export) {
+                bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: chunk {chunk_name} does not export `{chunk_export}` (known exports: [{}])",
+                    chunk_exports.iter().cloned().collect::<Vec<_>>().join(",")
+                );
+            }
+        }
+
+        // Per-package validation: installed version + upstream subpath
+        // exists + every declared upstream_export is actually a named
+        // export of the upstream subpath.
+        let mut package_resolutions: BTreeMap<String, PartialSwapPackageResolution> =
+            BTreeMap::new();
+        for (package_name, package) in &partial.packages {
+            if !is_valid_identifier(&package.namespace) {
+                bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` namespace `{}` is not a valid JS identifier",
+                    package.namespace
+                );
+            }
+            let installed = read_installed_package_metadata(
+                package_name,
+                options.package_roots,
+                options.packages_root,
+            )
+            .with_context(|| format!("reading metadata for package {package_name}"))?;
+            let installed_version = installed
+                .get("version")
+                .and_then(Value::as_str)
+                .context("package metadata missing version")?;
+            if installed_version != package.version {
+                bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path} version mismatch for {package_name}: spec={}, installed={installed_version}",
+                    package.version,
+                );
+            }
+            let upstream_path = resolve_package_subpath(
+                package_name,
+                &package.subpath,
+                options.package_roots,
+                options.packages_root,
+            )?;
+            let upstream_code = fs::read_to_string(&upstream_path)
+                .with_context(|| format!("reading {}", upstream_path.display()))?;
+            let upstream_ast =
+                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
+            let upstream_exports = collect_exported_names(&upstream_ast.module, true);
+            for (chunk_export, symbol) in &partial.symbols {
+                if symbol.package != *package_name {
+                    continue;
+                }
+                if !upstream_exports.contains(&symbol.upstream_export) {
+                    bail!(
+                        "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` targets {package_name}#{} but upstream does not export it (known: [{}])",
+                        symbol.upstream_export,
+                        upstream_exports
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    );
+                }
+            }
+            package_resolutions.insert(
+                package_name.clone(),
+                PartialSwapPackageResolution {
+                    namespace: package.namespace.clone(),
+                    version: package.version.clone(),
+                    subpath: package.subpath.clone(),
+                },
+            );
+        }
+
+        let mut symbol_resolutions: BTreeMap<String, PartialSwapSymbolResolution> = BTreeMap::new();
+        let mut chunk_targets: BTreeMap<String, PartialSwapSymbolTarget> = BTreeMap::new();
+        for (chunk_export, symbol) in &partial.symbols {
+            symbol_resolutions.insert(
+                chunk_export.clone(),
+                PartialSwapSymbolResolution {
+                    package: symbol.package.clone(),
+                    upstream_export: symbol.upstream_export.clone(),
+                    references_rewritten: 0,
+                },
+            );
+            chunk_targets.insert(
+                chunk_export.clone(),
+                PartialSwapSymbolTarget {
+                    package: symbol.package.clone(),
+                    upstream_export: symbol.upstream_export.clone(),
+                },
+            );
+        }
+
+        mappings.insert(
+            chunk_name.clone(),
+            ChunkPartialSwapMapping {
+                chunk_path: (*chunk_path).clone(),
+                chunk_id: chunk_name.clone(),
+                packages: partial.packages.clone(),
+                symbols: chunk_targets,
+            },
+        );
+        resolutions.insert(
+            (*chunk_path).clone(),
+            ChunkPartialSwapResolution {
+                chunk_id: chunk_name,
+                chunk_path: (*chunk_path).clone(),
+                packages: package_resolutions,
+                symbols: symbol_resolutions,
+            },
+        );
+    }
+
+    if mappings.is_empty() {
+        return Ok(ApplyPartialVendorSwapsResult {
+            artifact,
+            manifest: PartialSwapResolutionManifest {
+                resolutions,
+                counts: PartialSwapResolutionCounts {
+                    chunks: 0,
+                    symbols: 0,
+                    references_rewritten: 0,
+                },
+            },
+        });
+    }
+
+    let mut jobs = Vec::new();
+    for (caller_chunk_index, chunk_artifact) in artifact.chunks.iter_mut().enumerate() {
+        let caller_chunk_id = chunk_artifact.chunk_id;
+        let caller_chunk_name = chunk_table.name(caller_chunk_id).to_string();
+        for file_path in list_chunk_file_paths(&chunk_artifact.js) {
+            let has_ast = chunk_artifact
+                .js
+                .get_file(&file_path)
+                .and_then(|file| file.ast())
+                .is_some();
+            if !has_ast {
+                continue;
+            }
+            let (parts, ast) = chunk_artifact
+                .js
+                .remove_file(&file_path)
+                .and_then(|file| file.into_ast_parts())
+                .with_context(|| format!("missing AST for {caller_chunk_name}/{file_path}"))?;
+            jobs.push(PartialSwapFileJob {
+                caller_chunk_index,
+                caller_chunk_id,
+                caller_chunk_name: caller_chunk_name.clone(),
+                file_path,
+                parts,
+                ast,
+            });
+        }
+    }
+
+    let chunk_table_ref = &chunk_table;
+    let mappings_ref = &mappings;
+    let results: Vec<PartialSwapFileResult> = jobs
+        .into_par_iter()
+        .map(|job| rewrite_partial_swap_in_file(job, references, mappings_ref, chunk_table_ref))
+        .collect();
+
+    let mut total_references = 0usize;
+    for result in results {
+        for ((chunk_name, chunk_export), count) in &result.references_by_symbol {
+            let mapping = mappings_ref
+                .get(chunk_name)
+                .expect("symbol rewritten against a chunk that wasn't in the mappings");
+            if let Some(resolution) = resolutions.get_mut(&mapping.chunk_path)
+                && let Some(symbol_resolution) = resolution.symbols.get_mut(chunk_export)
+            {
+                symbol_resolution.references_rewritten += count;
+            }
+            total_references += count;
+        }
+        artifact
+            .chunks
+            .get_mut(result.caller_chunk_index)
+            .with_context(|| format!("missing chunk index {}", result.caller_chunk_index))?
+            .js
+            .insert_file(JsFile::from_ast_parts(result.parts, result.ast));
+    }
+
+    if options.write
+        && let Some(output_manifest_path) = options.output_manifest_path.as_deref()
+    {
+        if let Some(parent) = output_manifest_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        #[derive(Serialize)]
+        struct OnDiskPartialManifest<'a> {
+            resolutions: &'a BTreeMap<String, ChunkPartialSwapResolution>,
+        }
+        fs::write(
+            output_manifest_path,
+            serde_json::to_string_pretty(&OnDiskPartialManifest {
+                resolutions: &resolutions,
+            })? + "\n",
+        )?;
+    }
+
+    let total_symbols: usize = resolutions
+        .values()
+        .map(|resolution| resolution.symbols.len())
+        .sum();
+    Ok(ApplyPartialVendorSwapsResult {
+        artifact,
+        manifest: PartialSwapResolutionManifest {
+            resolutions,
+            counts: PartialSwapResolutionCounts {
+                chunks: ops.len(),
+                symbols: total_symbols,
+                references_rewritten: total_references,
+            },
+        },
+    })
+}
+
+struct PartialSwapFileJob {
+    caller_chunk_index: usize,
+    caller_chunk_id: ChunkId,
+    caller_chunk_name: String,
+    file_path: String,
+    parts: JsFileAstParts,
+    ast: ParsedJsModule,
+}
+
+struct PartialSwapFileResult {
+    caller_chunk_index: usize,
+    #[allow(dead_code)]
+    caller_chunk_name: String,
+    #[allow(dead_code)]
+    file_path: String,
+    parts: JsFileAstParts,
+    ast: ParsedJsModule,
+    /// (chunk_name, chunk_export) -> count of rewritten references in
+    /// this file.
+    references_by_symbol: BTreeMap<(String, String), usize>,
+}
+
+fn rewrite_partial_swap_in_file(
+    mut job: PartialSwapFileJob,
+    references: &ArtifactIndexes,
+    mappings: &PartialSwapMappings,
+    chunk_table: &ChunkTable,
+) -> PartialSwapFileResult {
+    let module = &mut job.ast.module;
+
+    // Pass A: scan ImportDecls. For each ImportSpecifier::Named on a
+    // partial-swap chunk import, record the local-binding sym and
+    // remove the specifier. Track which packages need a namespace
+    // import in this file and which (chunk, chunk_export) was hit so
+    // the manifest aggregates per-symbol counts.
+    let mut bindings: BTreeMap<String, IdentRewriteTarget> = BTreeMap::new();
+    let mut needed_namespace_imports: Vec<(String, String)> = Vec::new();
+    let mut emitted_namespace_for: BTreeSet<String> = BTreeSet::new();
+    let mut references_by_symbol: BTreeMap<(String, String), usize> = BTreeMap::new();
+
+    let original_body = std::mem::take(&mut module.body);
+    let mut new_body: Vec<ModuleItem> = Vec::with_capacity(original_body.len() + 4);
+
+    for item in original_body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(mut import_decl)) = item else {
+            new_body.push(item);
+            continue;
+        };
+        let source = str_value(&import_decl.src);
+        let Some(resolved) = references.resolve_runtime_import_reference(
+            &source,
+            job.caller_chunk_id,
+            &job.file_path,
+            chunk_table,
+        ) else {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)));
+            continue;
+        };
+        if resolved.target_chunk_id == job.caller_chunk_id {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)));
+            continue;
+        }
+        let target_chunk_name = chunk_table.name(resolved.target_chunk_id).to_string();
+        let Some(chunk_mapping) = mappings.get(&target_chunk_name) else {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)));
+            continue;
+        };
+
+        let mut retained_specifiers: Vec<ImportSpecifier> = Vec::new();
+        let mut packages_emitted_here: BTreeSet<String> = BTreeSet::new();
+        for specifier in std::mem::take(&mut import_decl.specifiers) {
+            let imported_name_lookup = match &specifier {
+                ImportSpecifier::Named(named) => named
+                    .imported
+                    .as_ref()
+                    .map(module_export_name)
+                    .unwrap_or_else(|| named.local.sym.to_string()),
+                _ => {
+                    retained_specifiers.push(specifier);
+                    continue;
+                }
+            };
+            let Some(target) = chunk_mapping.symbols.get(&imported_name_lookup) else {
+                retained_specifiers.push(specifier);
+                continue;
+            };
+            let Some(package_coords) = chunk_mapping.packages.get(&target.package) else {
+                retained_specifiers.push(specifier);
+                continue;
+            };
+            let ImportSpecifier::Named(named) = specifier else {
+                unreachable!("classified named above");
+            };
+            let local_sym = named.local.sym.to_string();
+            bindings.insert(
+                local_sym,
+                IdentRewriteTarget {
+                    namespace: package_coords.namespace.clone(),
+                    upstream_export: target.upstream_export.clone(),
+                    chunk_name: chunk_mapping.chunk_id.clone(),
+                    chunk_export: imported_name_lookup.clone(),
+                },
+            );
+            if emitted_namespace_for.insert(target.package.clone()) {
+                needed_namespace_imports
+                    .push((target.package.clone(), package_coords.namespace.clone()));
+            }
+            packages_emitted_here.insert(target.package.clone());
+        }
+
+        // Emit namespace imports for any packages this decl introduced
+        // but that haven't already been written out at an earlier
+        // position. Walking in source order preserves grouping.
+        for package_name in &packages_emitted_here {
+            // Only emit at this position if this is the first time we're
+            // touching the package. (The `emitted_namespace_for` set was
+            // updated above; we already added to needed_namespace_imports.)
+            // We pop the matching entry and emit it here.
+            if let Some(position) = needed_namespace_imports
+                .iter()
+                .position(|(pkg, _)| pkg == package_name)
+            {
+                let (pkg, namespace) = needed_namespace_imports.remove(position);
+                new_body.push(make_namespace_import(&pkg, &namespace));
+            }
+        }
+
+        if !retained_specifiers.is_empty() {
+            import_decl.specifiers = retained_specifiers;
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)));
+        }
+    }
+
+    // Anything still in needed_namespace_imports has no anchor decl
+    // (shouldn't happen given the loop above) — emit at top as a
+    // fallback. In practice this stays empty.
+    let mut prepend: Vec<ModuleItem> = Vec::new();
+    for (pkg, namespace) in needed_namespace_imports.drain(..) {
+        prepend.push(make_namespace_import(&pkg, &namespace));
+    }
+    if !prepend.is_empty() {
+        prepend.append(&mut new_body);
+        new_body = prepend;
+    }
+    module.body = new_body;
+
+    // Pass B: rewrite every Expr::Ident reference to a tracked local
+    // binding into `<namespace>.<upstream_export>`.
+    if !bindings.is_empty() {
+        let mut rewriter = PartialSwapIdentRewriter {
+            bindings: &bindings,
+            references_by_symbol: &mut references_by_symbol,
+        };
+        module.visit_mut_with(&mut rewriter);
+    }
+
+    PartialSwapFileResult {
+        caller_chunk_index: job.caller_chunk_index,
+        caller_chunk_name: job.caller_chunk_name,
+        file_path: job.file_path,
+        parts: job.parts,
+        ast: job.ast,
+        references_by_symbol,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IdentRewriteTarget {
+    namespace: String,
+    upstream_export: String,
+    chunk_name: String,
+    chunk_export: String,
+}
+
+struct PartialSwapIdentRewriter<'a> {
+    bindings: &'a BTreeMap<String, IdentRewriteTarget>,
+    references_by_symbol: &'a mut BTreeMap<(String, String), usize>,
+}
+
+impl VisitMut for PartialSwapIdentRewriter<'_> {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        // Recurse first so nested matches (e.g., the obj of a member
+        // expression, the callee of a call) are rewritten before we
+        // inspect this node.
+        expr.visit_mut_children_with(self);
+        let Expr::Ident(ident) = expr else {
+            return;
+        };
+        let Some(target) = self.bindings.get(ident.sym.as_ref()) else {
+            return;
+        };
+        *expr = Expr::Member(MemberExpr {
+            span: DUMMY_SP,
+            obj: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                target.namespace.clone().into(),
+                DUMMY_SP,
+            ))),
+            prop: MemberProp::Ident(IdentName::new(
+                target.upstream_export.clone().into(),
+                DUMMY_SP,
+            )),
+        });
+        *self
+            .references_by_symbol
+            .entry((target.chunk_name.clone(), target.chunk_export.clone()))
+            .or_insert(0) += 1;
+    }
+}
+
+fn make_namespace_import(package: &str, namespace: &str) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+        span: DUMMY_SP,
+        specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new_no_ctxt(namespace.into(), DUMMY_SP),
+        })],
+        src: Box::new(Str {
+            span: DUMMY_SP,
+            value: package.into(),
+            raw: None,
+        }),
+        type_only: false,
+        with: None,
+        phase: ImportPhase::Evaluation,
+    }))
 }
 
 fn is_valid_identifier(name: &str) -> bool {

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -923,6 +923,23 @@ fn assert_path_within_root(path: &Path, root: &Path, message: &str) -> Result<()
     bail!("{message}: {}", path.display());
 }
 
+fn module_has_export_star(module: &Module) -> bool {
+    module.body.iter().any(|item| match item {
+        // `export * from "./other.js";`
+        ModuleItem::ModuleDecl(ModuleDecl::ExportAll(_)) => true,
+        // `export * as ns from "./other.js";` — still re-exports the
+        // whole namespace, just under one name.
+        ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) => {
+            named.src.is_some()
+                && named
+                    .specifiers
+                    .iter()
+                    .any(|s| matches!(s, ExportSpecifier::Namespace(_)))
+        }
+        _ => false,
+    })
+}
+
 fn collect_exported_names(module: &Module, include_default: bool) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     for item in &module.body {
@@ -1540,8 +1557,20 @@ pub fn apply_partial_vendor_swaps(
             let upstream_ast =
                 parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
             let upstream_exports = collect_exported_names(&upstream_ast.module, true);
+            // Packages that re-export everything from a sibling module
+            // (`export * from "./other.js"`) can't be fully enumerated
+            // by a single-file `collect_exported_names`. Skip the strict
+            // name check in that case — the caller's spec is responsible
+            // for naming a real upstream symbol. (zod's `index.js` is the
+            // canonical example: `export * from "./v4/classic/external.js"`
+            // is the only way the named schemas like `object`, `array`
+            // become visible.)
+            let upstream_has_export_star = module_has_export_star(&upstream_ast.module);
             for (chunk_export, symbol) in &partial.symbols {
                 if symbol.package != *package_name {
+                    continue;
+                }
+                if upstream_has_export_star {
                     continue;
                 }
                 if !upstream_exports.contains(&symbol.upstream_export) {

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -16,8 +16,8 @@ use artifact::{
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
 use spec::{
-    PartialSwapMark, PartialSwapPackage, PartialSwapSymbol, SwapMark, VendorLevel, VendorMark,
-    VendorRole, WrapperShape,
+    PartialSwapMark, PartialSwapPackage, SwapMark, VendorLevel, VendorMark, VendorRole,
+    WrapperShape,
 };
 
 // These manifests are returned by the vendor stages but the pipeline
@@ -1382,7 +1382,6 @@ fn module_export_name(name: &ModuleExportName) -> String {
 // imported local binding with a namespace member access. The chunk's
 // un-swapped exports keep working through the residual import.
 
-#[derive(Debug, Clone)]
 pub struct ApplyPartialVendorSwapsResult {
     pub artifact: ChunkBundle,
     pub manifest: PartialSwapResolutionManifest,


### PR DESCRIPTION
## Summary

Adds a new `level: partial_swap` vendor mark for mixed chunks. Unlike `level: swap` which wraps the chunk's upstream and removes the chunk from the artifact, partial-swap leaves the chunk on disk and per-symbol:

- rewrites caller-side imports from `{ chunk_export as localAlias } from "../chunk/entry.js"` to a namespace import `import * as <ns> from "<package>"`,
- rewrites every reference to the local binding to the namespace member access `<ns>.<upstream_export>`.

The use case is Vite-emitted megachunks that bundle several packages into one ESM file (e.g. Tana's `vendor-BPNhzNbc.js` co-bundles zod + `@sentry/browser` + React + react-dom + lodash + katex + mermaid). A whole-chunk `level: swap` would drop every co-bundled library; partial-swap peels packages out one at a time. The mechanism is generic — a single chunk mark can carry multiple upstream packages, each with its own namespace alias.

YAML shape:

```yaml
- level: partial_swap
  identity: zod + React.memo inside vendor-BPNhzNbc megachunk
  chunk_path: static/vendor-BPNhzNbc.js
  packages:
    zod:   { namespace: z,     version: 4.1.12, subpath: index.js }
    react: { namespace: React, version: 18.3.1, subpath: index.js }
  symbols:
    ee: { package: zod,   upstream_export: object }
    Ie: { package: zod,   upstream_export: array }
    Ci: { package: react, upstream_export: memo }
```

A new pipeline stage `ApplyPartialVendorSwaps` runs after `SwapVendorChunks` and writes a sibling resolution manifest (`vendor_partial_swap_manifest.json`).

Packages whose entry uses `export * from "./other.js"` (zod's `index.js` is the canonical case) are accepted without enumerating every re-exported name — the strict upstream-export check is skipped when an `export *` is detected on the upstream module.

## Test plan

- [x] `bbr build //devinfra/js/debundle:vendor` — green
- [x] `bbr build //devinfra/js/debundle/...` — green (77 targets)
- [x] `bbr test //devinfra/js/debundle/e2e:vendor_swap_test` — PASSED
- [x] New e2e tests:
  - `partial_swap_basic_rewrites_to_namespace_member` — verifies `zodBoolean()` → `z.boolean()` rewrite and that the non-swapped `keepMe` specifier stays intact
  - `partial_swap_keeps_megachunk_on_disk` — verifies the chunk file still exists after the pipeline runs and the manifest records `references_rewritten: 1`
  - `partial_swap_rejects_version_mismatch` — verifies the strict version check still fires

https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD)_