### PR TITLE
devinfra/js/debundle: run ApplyPartialVendorSwaps after MaterializeLogicalModules

### DIFF
--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -184,8 +184,8 @@ pub enum PipelineStage {
     ApplyVendorAnnotations,
     RenameVendorExports,
     SwapVendorChunks,
-    ApplyPartialVendorSwaps,
     MaterializeLogicalModules,
+    ApplyPartialVendorSwaps,
     WriteJsTree,
     EmitBrowserHarness,
 }
@@ -340,38 +340,6 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
             counts.chunks -= swap_result.removed_chunk_ids.len();
             chunk_records.retain(|chunk| !swap_result.removed_chunk_ids.contains(&chunk.chunk_id));
         }
-        if spec
-            .vendor
-            .values()
-            .any(|m| matches!(m.level, VendorLevel::PartialSwap(_)))
-        {
-            // Reuse the swap-vendor output dir for the partial-swap
-            // manifest, but write to a distinct filename so the two
-            // resolution manifests don't collide. `output_wrapper_dir`
-            // isn't relevant for partial swap (no wrapper generated).
-            let partial_manifest_path = spec
-                .swap_vendor_chunks
-                .output_manifest_path
-                .as_ref()
-                .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
-                .map(|dir| dir.join("vendor_partial_swap_manifest.json"));
-            let write = spec.swap_vendor_chunks.write;
-            let partial_result =
-                run_step_with_result(&mut steps, PipelineStage::ApplyPartialVendorSwaps, || {
-                    apply_partial_vendor_swaps(
-                        artifact,
-                        &spec.vendor,
-                        &artifact_indexes,
-                        ApplyPartialVendorSwapsOptions {
-                            package_roots: &cli.package_roots,
-                            packages_root: &cli.packages_root,
-                            output_manifest_path: partial_manifest_path,
-                            write,
-                        },
-                    )
-                })?;
-            artifact = partial_result.artifact;
-        }
     }
 
     let mut module_count: usize = 0;
@@ -409,6 +377,42 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
         module_count = materialize_result.module_count;
         selected_lowerings = materialize_result.selected_lowerings;
         decomposition_by_chunk = materialize_result.decomposition_by_chunk;
+    }
+
+    // Partial-vendor-swap runs *after* materialize so the per-symbol
+    // identifier rewrite (`zodObject(...)` → `z.object(...)`) operates
+    // on the already-materialized module files. If it ran before
+    // materialize, the rewrite would erase the binding names that
+    // `binding_patches` / `logical_modules` selectors still rely on at
+    // materialize-time (e.g. `anonymous_statements: match: "ee({...})"`).
+    if !spec.vendor.is_empty()
+        && spec
+            .vendor
+            .values()
+            .any(|m| matches!(m.level, VendorLevel::PartialSwap(_)))
+    {
+        let partial_manifest_path = spec
+            .swap_vendor_chunks
+            .output_manifest_path
+            .as_ref()
+            .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
+            .map(|dir| dir.join("vendor_partial_swap_manifest.json"));
+        let write = spec.swap_vendor_chunks.write;
+        let partial_result =
+            run_step_with_result(&mut steps, PipelineStage::ApplyPartialVendorSwaps, || {
+                apply_partial_vendor_swaps(
+                    artifact,
+                    &spec.vendor,
+                    &artifact_indexes,
+                    ApplyPartialVendorSwapsOptions {
+                        package_roots: &cli.package_roots,
+                        packages_root: &cli.packages_root,
+                        output_manifest_path: partial_manifest_path,
+                        write,
+                    },
+                )
+            })?;
+        artifact = partial_result.artifact;
     }
 
     if let Some(cfg) = &spec.write_js_tree {


### PR DESCRIPTION
## Summary

Bug-fix follow-up to #1587. The partial-swap stage was wired in to run *before* `MaterializeLogicalModules`, but that's the wrong order: the per-symbol identifier rewrite (`zodObject(...)` → `z.object(...)`) erases binding names that materialize-time selectors still rely on. In particular, gaffer's `tana/re/web/spec/.../modules/features/publishing/bootstrap_schemas.yaml` carries selectors like

```yaml
anonymous_statements:
  - match: |
      ee({
        isOutdated: $e(),
        ...
      });
```

referring to the chunk's pre-rename binding names. Running partial-swap first turns `ee` into `z.object` in the AST, then materialize bails with `anonymous_statements[].match did not match any top-level statement in the chunk`. The e2e fixture in #1587 didn't expose this because it has no module-level matchers.

Move the stage to after materialize so the rewriter operates on the already-decomposed module files, where the bindings have already been renamed by `binding_patches` (`ee` → `zodObject`) and any remaining references to those locals are safe to rewrite into namespace member accesses.

Net change: one block of pipeline orchestration moved across the `materialize_logical_modules` call and the `PipelineStage` enum order adjusted to match.

## Test plan

- [x] `bbr test //devinfra/js/debundle/e2e:vendor_swap_test` — partial-swap tests still pass (no behavior change for the simple fixture; they don't go through materialize).
- [x] Verified end-to-end against gaffer-private's `//tana/re/web/spec:debundle_78d928dca7` — pipeline now runs `apply_partial_vendor_swaps` after `materialize_logical_modules`, emitted JS contains `import * as z from "zod"` + `z.object(...)` member-access call sites, and the `regen_emitted_js_78d928dca7_test` diff-test passes after refreshing the committed extracted-JS tree.

https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD)_