### PR TITLE
augur/core: replace bare-string metric lookup with typed ReportMetric callers

### DIFF
--- a/augur/AGENTS.md
+++ b/augur/AGENTS.md
@@ -3,3 +3,9 @@
 Augur is pre-production. Do not add compatibility shims for older URL state
 versions, request schemas, or serialized payloads unless the user explicitly
 asks for backward compatibility.
+
+When calling `ScenarioRun.{series,matrix,terminal}` or
+`RolloutDetail.{series,terminal}`, always pass a `ReportMetric` enum member
+(e.g. `ReportMetric.CASH_USD`), never a bare string. The signatures already
+enforce this; documenting it here keeps the rule visible to new callers and
+to LLM agents drafting tests.

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -86,7 +86,6 @@ second ordered roadmap.
       this period and receives this equity/share/claim in return" should be a
       modeled agreement between agents, not a scenario-level enum that activates a
       hardcoded partner-ownership hack. The exact representation still needs design.
-- [ ] Make result inspection typed and local. String metric names via `series("cash_usd")` are acceptable as a compatibility layer, but primary callers should get discoverable typed metric/rollout/detail helpers.
 - [ ] Separate rollout stochastic inputs in the API/data model. Today a rollout
       is effectively a sampled market environment plus deterministic policy. Make
       that explicit, and consider separate structures/identifiers for market


### PR DESCRIPTION
## Summary

This slice was scoped to (a) replace any remaining bare-string `series("cash_usd")`-style call sites with typed `ReportMetric.X` calls, (b) add typed convenience helpers where the call-site count justifies it, and (c) document the convention.

After surveying `augur/` with grep across `.py`, `.js`, `.jsx`, `.mjs`, `.ts`, `.tsx`:

- **Bare-string call sites changed: 0.** Exhaustive grep for `series("...")`, `matrix("...")`, `terminal("...")` (and the single-quote variants) returned no matches. The prior cleanup (#1571) tightened the `ScenarioRun.{series,matrix,terminal}` and `RolloutDetail.{series,terminal}` signatures to `ReportMetric` only, and at the same time every caller in `augur/core/test_e2e.py`, `augur/core/scenario_engine_test.py`, etc. was already converted to `ReportMetric.X` enum members. The "remaining caller-side work" the TODO referred to is already done.
- **New typed helpers added: 0.** The heaviest call site is `series(ReportMetric.CASH_USD)` at 18 occurrences (followed by `matrix(ReportMetric.CASH_USD)` at 11), but per the task guidance ("Don't add a helper per enum member — that's overkill and just shifts the duplication") and the architecture constraint ("No grab-bag helper module"), adding `result.cash_usd_series()` for the top metric while leaving the other 60+ enum members in the typed-call form would create exactly the parallel surface the task warned against. The current `result.series(ReportMetric.CASH_USD)` already gets full IDE/mypy discovery after the user types `ReportMetric.`, which is the discoverability the TODO wanted.
- **AGENTS.md updated**: `augur/AGENTS.md` now records the convention so future contributors and LLM agents drafting tests keep passing `ReportMetric.X` rather than string literals.
- **TODO.md updated**: retired the corresponding entry — the engine surface is typed, every caller passes a `ReportMetric` member, and the discoverability goal is met by the enum + signature combination.
- **Wire JSON format unchanged.** No code in `augur/core/api.py`, `augur/core/scenario_engine.py`, or any frontend file was touched; the frontend continues to read metric values from the JSON response by snake-case key (`cash_usd`) as before.

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:policy_runtime_test //augur/core:property_sale_test` — no Python changes, but ran the explicit task test budget for safety.
- [ ] Reviewer: confirm grep `grep -rEn '\.(series|matrix|terminal)\(["'"'"']' augur/` returns zero hits on this branch (and on `devel`).
- [ ] Reviewer: confirm the AGENTS.md note matches the prevailing style in the file.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_