### PR TITLE
augur/core: drop fabricated value_usd on PrivateEquityPosition; units own the mark

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -119,12 +119,14 @@ second ordered roadmap.
       generator, path-set, and validation-report identities; the next step is
       durable evidence/calibration artifacts, real validation reports, and
       reviewed limitations rather than placeholder IDs.
-- [ ] Stop requiring private-equity input positions to carry both `units` and a
+- [x] Stop requiring private-equity input positions to carry both `units` and a
       marked `value_usd` when the value is determined by units plus the private
-      equity price model. The browser no longer stores an editable private
-      equity value, but the backend request still has to derive `value_usd` to
-      satisfy the generic asset-position schema. Clean this up in the backend
-      position/API model so simulation owns the mark.
+      equity price model. `PrivateEquityPosition.value_usd` is now optional;
+      when absent the simulator derives the opening mark from
+      `units × MarketBundleMetadata.current_private_equity_price_usd`. The
+      browser stops sending `value_usd`; the lot mark from
+      `PortfolioStatement.PrivateEquityLot.mark_value_usd` still flows through
+      as an explicit `value_usd` for the statement-mark path.
 - [ ] Move evidence/model-fetching shapes out of core simulator API when touched. Core should consume calibrated market/provider inputs, not source-specific evidence objects.
 
 ## Tax Follow-Ups

--- a/augur/api/http_server.py
+++ b/augur/api/http_server.py
@@ -47,18 +47,20 @@ class AugurServerConfig:
 def _make_provider(
     args: argparse.Namespace, augur_config: AugurConfig, default_market_config_path: Path
 ) -> MarketBundleProvider:
-    if args.provider == "noop":
-        return FlatMarketBundleProvider()
-    if args.provider == "simple":
-        return SimpleMarketBundleProvider()
-    # MacroMarketBundleProvider currently uses one concentrated holding's current
-    # valuation to populate private-equity source metadata.
+    # Every provider must publish the current per-unit private-equity price so the
+    # simulator can resolve units-only PrivateEquityPosition entries (the browser
+    # stores units and lets the simulator own the mark).
     holdings = augur_config.snapshot.concentrated_holdings
     if len(holdings) != 1:
-        raise ValueError(f"expected exactly one concentrated holding for the macro provider; got {len(holdings)}")
+        raise ValueError(f"expected exactly one concentrated holding for the provider; got {len(holdings)}")
+    current_private_equity_price_usd = float(holdings[0].fmv_usd_per_unit)
+    if args.provider == "noop":
+        return FlatMarketBundleProvider(current_private_equity_price_usd=current_private_equity_price_usd)
+    if args.provider == "simple":
+        return SimpleMarketBundleProvider()
     market_config_path = Path(args.market_config).resolve() if args.market_config else default_market_config_path
     return MacroMarketBundleProvider.for_label(
-        args.provider, config_path=market_config_path, current_private_equity_price_usd=holdings[0].fmv_usd_per_unit
+        args.provider, config_path=market_config_path, current_private_equity_price_usd=current_private_equity_price_usd
     )
 
 

--- a/augur/core/market_bundle.py
+++ b/augur/core/market_bundle.py
@@ -54,6 +54,16 @@ class MarketBundleMetadata(ApiModel):
     horizon_months: int
     event_stream_ids: tuple[str, ...]
     notes: tuple[str, ...] = ()
+    current_private_equity_price_usd: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Per-unit USD mark for private equity at month 0. Used by the simulator to "
+            "resolve `PrivateEquityPosition.value_usd` from `units` when the position omits "
+            "an explicit mark. Providers that drive PE valuation must set this; the flat/"
+            "noop fixtures use 0.0 and require positions to supply `value_usd` directly."
+        ),
+    )
     source_metadata: dict[str, Any] = Field(default_factory=dict)
 
     @computed_field  # type: ignore[prop-decorator]
@@ -339,6 +349,7 @@ class FlatMarketBundleProvider:
 
     mortgage_30y_rate_pct: float = 6.5
     private_equity_sale_opportunity_months: tuple[int, ...] = (12,)
+    current_private_equity_price_usd: float = 0.0
 
     def sample_market_bundle(
         self, *, rollout_count: int, horizon_months: int, seed: int, market_request: MarketRequest
@@ -372,6 +383,7 @@ class FlatMarketBundleProvider:
                 evidence_set_id="fixture:flat",
                 calibration_artifact_id="fixture:flat",
                 risk_factor_ids=CORE_MARKET_RISK_FACTOR_IDS,
+                current_private_equity_price_usd=self.current_private_equity_price_usd,
                 seed=seed,
                 rollout_count=rollout_count,
                 horizon_months=horizon_months,

--- a/augur/core/market_bundle_test_support.py
+++ b/augur/core/market_bundle_test_support.py
@@ -21,6 +21,7 @@ def constant_market_bundle(
     private_equity_value_path: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0),
     private_equity_sale_opportunity_months: tuple[int, ...] = (),
     crypto_value_path: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0),
+    current_private_equity_price_usd: float = 0.0,
     market_model_id: str = "test",
     seed: int = 0,
 ) -> MarketBundle:
@@ -65,6 +66,7 @@ def constant_market_bundle(
             rollout_count=rollout_count,
             horizon_months=horizon_months,
             event_stream_ids=(),
+            current_private_equity_price_usd=current_private_equity_price_usd,
         ),
     )
 
@@ -81,6 +83,7 @@ class NoopMarketBundleProvider:
     private_equity_value_path: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0)
     private_equity_sale_opportunity_months: tuple[int, ...] = ()
     crypto_value_path: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0)
+    current_private_equity_price_usd: float = 0.0
 
     def sample_market_bundle(
         self, *, rollout_count: int, horizon_months: int, seed: int, market_request: MarketRequest
@@ -96,6 +99,7 @@ class NoopMarketBundleProvider:
             private_equity_value_path=self.private_equity_value_path,
             private_equity_sale_opportunity_months=self.private_equity_sale_opportunity_months,
             crypto_value_path=self.crypto_value_path,
+            current_private_equity_price_usd=self.current_private_equity_price_usd,
             market_model_id=market_request.market_model_id,
             seed=seed,
         )

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -1328,8 +1328,11 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
     initial_sp500_basis = _initial_sp500_cost_basis_usd(scenario)
     initial_crypto = _initial_crypto_value_usd(scenario)
     initial_crypto_basis = _initial_crypto_cost_basis_usd(scenario)
-    initial_private_equity = _initial_private_equity_value_usd(scenario)
-    initial_private_equity_basis = _initial_private_equity_cost_basis_usd(scenario)
+    pe_unit_price_usd = float(market_bundle.metadata.current_private_equity_price_usd)
+    initial_private_equity = _initial_private_equity_value_usd(scenario, current_unit_price_usd=pe_unit_price_usd)
+    initial_private_equity_basis = _initial_private_equity_cost_basis_usd(
+        scenario, current_unit_price_usd=pe_unit_price_usd
+    )
     initial_private_equity_units = _initial_private_equity_units(scenario)
     private_equity_source_holding_id = _private_equity_source_holding_id(scenario)
     purchase_price = _purchase_price_usd(scenario)
@@ -4731,15 +4734,37 @@ def _crypto_source_holding_id(scenario: Scenario, *, actor_id: str) -> str:
     return "crypto_portfolio"
 
 
-def _initial_private_equity_value_usd(scenario: Scenario) -> float:
+def _private_equity_position_value_usd(asset: PrivateEquityPosition, *, current_unit_price_usd: float) -> float:
+    """Resolve a PE position's opening mark.
+
+    Honors an explicit `value_usd` (statement mark or manual override) when set;
+    otherwise derives `units × current_unit_price_usd`. A position with neither field
+    is rejected by `PrivateEquityPosition`'s validator before reaching the engine.
+    """
+    if asset.value_usd is not None:
+        return float(asset.value_usd)
+    if current_unit_price_usd <= 0.0:
+        raise ValueError(
+            f"PrivateEquityPosition {asset.asset_id!r} has units only but the active "
+            "MarketBundleMetadata.current_private_equity_price_usd is 0; either supply "
+            "value_usd or use a market provider that publishes a PE unit price."
+        )
+    return float(asset.units or 0.0) * current_unit_price_usd
+
+
+def _initial_private_equity_value_usd(scenario: Scenario, *, current_unit_price_usd: float) -> float:
     return sum(
-        asset.value_usd for asset in scenario.initial_balance_sheet.assets if isinstance(asset, PrivateEquityPosition)
+        _private_equity_position_value_usd(asset, current_unit_price_usd=current_unit_price_usd)
+        for asset in scenario.initial_balance_sheet.assets
+        if isinstance(asset, PrivateEquityPosition)
     )
 
 
-def _initial_private_equity_cost_basis_usd(scenario: Scenario) -> float:
+def _initial_private_equity_cost_basis_usd(scenario: Scenario, *, current_unit_price_usd: float) -> float:
     return sum(
-        asset.cost_basis_usd if asset.cost_basis_usd is not None else asset.value_usd
+        asset.cost_basis_usd
+        if asset.cost_basis_usd is not None
+        else _private_equity_position_value_usd(asset, current_unit_price_usd=current_unit_price_usd)
         for asset in scenario.initial_balance_sheet.assets
         if isinstance(asset, PrivateEquityPosition)
     )

--- a/augur/core/scenario_engine_test.py
+++ b/augur/core/scenario_engine_test.py
@@ -43,6 +43,7 @@ def _bundle(
     rent_path: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0),
     crypto_path: tuple[float, ...] | None = None,
     private_equity_sale_opportunity_month: int | None = None,
+    current_private_equity_price_usd: float = 0.0,
 ) -> MarketBundle:
     shape = (rollout_count, horizon_months + 1)
     month_index = np.arange(horizon_months + 1, dtype="int64")
@@ -65,6 +66,7 @@ def _bundle(
         rollout_count=rollout_count,
         horizon_months=horizon_months,
         event_stream_ids=("private_equity_sale_opportunity_event",),
+        current_private_equity_price_usd=current_private_equity_price_usd,
     )
     return MarketBundle(
         month_index=month_index,
@@ -110,7 +112,7 @@ def _scenario_body(
     crypto_basis_usd: float | None = None,
     crypto_quantity: float | None = None,
     crypto_asset_symbol: str = "BTC",
-    private_equity_usd: float = 50_000,
+    private_equity_usd: float | None = 50_000,
     private_equity_basis_usd: float | None = None,
     private_equity_units: float | None = None,
     property_selection: dict | None = None,
@@ -124,6 +126,18 @@ def _scenario_body(
     events: list[dict] | None = None,
     tax_regimes: list[str] | None = None,
 ) -> dict:
+    private_equity_asset: dict = {
+        "asset_id": "private_equity",
+        "asset_type": "private_equity",
+        "owner_actor_id": "owner",
+        "units": private_equity_units,
+        "cost_basis_usd": private_equity_basis_usd,
+    }
+    # value_usd is optional now: when omitted, the simulator derives the opening mark
+    # from units × MarketBundleMetadata.current_private_equity_price_usd. Keep value_usd
+    # off the dict entirely when the caller wants the units-only path.
+    if private_equity_usd is not None:
+        private_equity_asset["value_usd"] = private_equity_usd
     assets: list[dict] = [
         {
             "asset_id": "sp500",
@@ -132,14 +146,7 @@ def _scenario_body(
             "value_usd": sp500_usd,
             "cost_basis_usd": sp500_basis_usd if sp500_basis_usd is not None else sp500_usd,
         },
-        {
-            "asset_id": "private_equity",
-            "asset_type": "private_equity",
-            "owner_actor_id": "owner",
-            "value_usd": private_equity_usd,
-            "units": private_equity_units,
-            "cost_basis_usd": private_equity_basis_usd,
-        },
+        private_equity_asset,
     ]
     if crypto_usd > 0:
         assets.append(
@@ -208,6 +215,47 @@ def test_portfolio_only_baseline_uses_numpy_paths() -> None:
     assert_allclose(result.private_equity_value_usd[:, 2], 100_000)
     assert_allclose(result.net_worth_usd[:, 2], 230_000)
     assert result.monthly_columns().row_count == 8
+
+
+def test_private_equity_position_units_only_derives_value_from_market_price() -> None:
+    """A PE position with `units` only takes its month-0 mark from
+    MarketBundleMetadata.current_private_equity_price_usd. This covers the browser
+    path where the UI stores units and the backend owns the price model."""
+    scenario_set = ScenarioSet.model_validate(
+        _scenario_set_body(_scenario_body("units_only", private_equity_usd=None, private_equity_units=1_000))
+    )
+    scenario = scenario_set.scenarios[0]
+
+    result = run_scenario_vectorized(
+        scenario, _bundle(private_equity_path=(1.0, 1.5, 2.0, 2.5), current_private_equity_price_usd=50.0)
+    )
+
+    # 1_000 units × $50/unit = $50_000 month-0 mark; multiplier path scales it.
+    assert_allclose(result.private_equity_value_usd[:, 0], 50_000)
+    assert_allclose(result.private_equity_value_usd[:, 2], 100_000)
+
+
+def test_private_equity_position_explicit_value_overrides_market_price() -> None:
+    """An explicit `value_usd` on a PE position is treated as an authoritative mark
+    even when the market bundle publishes a unit price. This preserves the
+    PortfolioStatement statement-mark path where `PrivateEquityLot.mark_value_usd`
+    flows through unchanged."""
+    scenario_set = ScenarioSet.model_validate(
+        _scenario_set_body(_scenario_body("explicit_mark", private_equity_usd=200_000, private_equity_units=1_000))
+    )
+    scenario = scenario_set.scenarios[0]
+
+    result = run_scenario_vectorized(
+        scenario,
+        _bundle(
+            private_equity_path=(1.0, 1.0, 1.0, 1.0),
+            # If the engine used units × price = 1000 × 50 = 50_000 it would not match.
+            current_private_equity_price_usd=50.0,
+        ),
+    )
+
+    assert_allclose(result.private_equity_value_usd[:, 0], 200_000)
+    assert_allclose(result.private_equity_value_usd[:, 2], 200_000)
 
 
 def test_report_metrics_are_explicit_typed_views() -> None:

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -870,10 +870,35 @@ class CryptoAssetPosition(_AssetPositionBase):
     source_account_id: str | None = None
 
 
-class PrivateEquityPosition(_AssetPositionBase):
+class PrivateEquityPosition(ApiModel):
+    """An opening private-equity position.
+
+    Either `units` or `value_usd` must be supplied (often both):
+
+    - When `value_usd` is set, it is the authoritative month-0 mark — e.g. a tender-offer
+      or manual mark carried through from a `PortfolioStatement.PrivateEquityLot`.
+    - When `value_usd` is absent, the month-0 mark is derived from
+      `units × MarketBundleMetadata.current_private_equity_price_usd`. Callers without
+      an independent mark (such as the browser UI, which stores units only) should leave
+      `value_usd` unset; the simulator owns the derivation.
+    """
+
+    asset_id: str = Field(pattern=r"^[a-z0-9][a-z0-9_\-]*$")
+    owner_actor_id: str
     asset_type: Literal[AssetType.PRIVATE_EQUITY] = AssetType.PRIVATE_EQUITY
     units: NonNegativeFloat | None = None
+    value_usd: NonNegativeFloat | None = None
     cost_basis_usd: float | None = None
+    provenance: PositionProvenance = Field(default_factory=PositionProvenance)
+
+    @model_validator(mode="after")
+    def _require_units_or_value(self) -> PrivateEquityPosition:
+        if self.units is None and self.value_usd is None:
+            raise ValueError(
+                f"PrivateEquityPosition {self.asset_id!r} must set units or value_usd "
+                "(or both); the simulator needs one to derive the opening mark."
+            )
+        return self
 
 
 AssetPosition = Annotated[

--- a/augur/core/scenario_set_test.py
+++ b/augur/core/scenario_set_test.py
@@ -174,6 +174,41 @@ def test_scenario_set_rejects_unsupported_initial_asset_variants(asset_type: str
         ScenarioSet.model_validate(body)
 
 
+def test_private_equity_position_requires_units_or_value_usd() -> None:
+    """The schema must reject a PE position that supplies neither `units` nor
+    `value_usd`. The simulator needs at least one to derive the opening mark
+    (units × market price, or an explicit statement mark)."""
+    body = _scenario_set_body("sf_house")
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {"asset_id": "private_equity", "asset_type": "private_equity", "owner_actor_id": "owner", "cost_basis_usd": 0}
+    ]
+
+    with pytest.raises(ValidationError, match="must set units or value_usd"):
+        ScenarioSet.model_validate(body)
+
+
+def test_private_equity_position_accepts_units_only() -> None:
+    body = _scenario_set_body("sf_house")
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {
+            "asset_id": "private_equity",
+            "asset_type": "private_equity",
+            "owner_actor_id": "owner",
+            "units": 1_000,
+            "cost_basis_usd": 0,
+        }
+    ]
+
+    scenario_set = ScenarioSet.model_validate(body)
+    [pe] = (
+        asset
+        for asset in scenario_set.scenarios[0].initial_balance_sheet.assets
+        if asset.asset_type is AssetType.PRIVATE_EQUITY
+    )
+    assert pe.value_usd is None
+    assert pe.units == 1_000
+
+
 @pytest.mark.parametrize("liability_type", ["mortgage", "tax_liability", "actor_equity_claim"])
 def test_scenario_set_rejects_initial_liabilities(liability_type: str) -> None:
     body = _scenario_set_body("sf_house")

--- a/augur/frontend/lib/scenario_set_state.js
+++ b/augur/frontend/lib/scenario_set_state.js
@@ -531,7 +531,6 @@ function scenarioBalanceSheet(scenario, bootstrap) {
   const initialBalanceSheet = scenario.initialBalanceSheet;
   const { primary } = agentsByRole(bootstrap);
   const privateEquityUnits = Math.max(0, finiteNumber(initialBalanceSheet.privateEquityUnits, 0));
-  const privateEquityValueUsd = privateEquityValueUsdForUnits(bootstrap, privateEquityUnits);
   const assets = [
     {
       assetId: "sp500",
@@ -541,12 +540,13 @@ function scenarioBalanceSheet(scenario, bootstrap) {
       costBasisUsd: initialBalanceSheet.startingPortfolioUsd,
     },
   ];
-  if (privateEquityValueUsd > 0 || privateEquityUnits > 0) {
+  if (privateEquityUnits > 0) {
+    // The browser stores units only; the backend derives value_usd from
+    // units × MarketBundleMetadata.current_private_equity_price_usd at simulation init.
     assets.push({
       assetId: "private_equity_private",
       assetType: "private_equity",
       ownerActorId: primary.actorId,
-      valueUsd: privateEquityValueUsd,
       units: privateEquityUnits,
       costBasisUsd: 0,
     });

--- a/augur/frontend/lib/scenario_set_state_test.mjs
+++ b/augur/frontend/lib/scenario_set_state_test.mjs
@@ -286,13 +286,14 @@ test("scenario set request is canonical backend input after decamelizing", () =>
     firstScenario.events.find((event) => event.event_type.startsWith("private_equity_")),
     undefined
   );
+  // The browser stores units only; value_usd is omitted so the backend simulator
+  // derives the opening mark from units × MarketBundleMetadata.current_private_equity_price_usd.
   assert.deepEqual(
     firstScenario.initial_balance_sheet.assets.find((asset) => asset.asset_type === "private_equity"),
     {
       asset_id: "private_equity_private",
       asset_type: "private_equity",
       owner_actor_id: "alpha",
-      value_usd: 9_120,
       units: 456,
       cost_basis_usd: 0,
     }

--- a/augur/model/macro_market_bundle_provider.py
+++ b/augur/model/macro_market_bundle_provider.py
@@ -130,9 +130,9 @@ class MacroMarketBundleProvider:
                 horizon_months=horizon_months,
                 event_stream_ids=("private_equity_sale_opportunity_event",),
                 notes=("sampled by MacroMarketBundleProvider",),
+                current_private_equity_price_usd=self._current_private_equity_price_usd,
                 source_metadata={
                     "market_provider_label": self.label,
-                    "current_private_equity_price_usd": self._current_private_equity_price_usd,
                     "latest_observation_ids": list(self._evidence_latest_observation_ids),
                 },
             ),

--- a/augur/model/macro_market_bundle_provider_test.py
+++ b/augur/model/macro_market_bundle_provider_test.py
@@ -102,6 +102,9 @@ def test_sample_market_bundle_shape(provider: MacroMarketBundleProvider) -> None
     assert bundle.metadata.source_metadata["market_provider_label"] == provider.label
     assert "market_provider_seed" not in bundle.metadata.source_metadata
     assert "market_provider_horizon_months" not in bundle.metadata.source_metadata
+    # current_private_equity_price_usd is a typed metadata field, not an entry in source_metadata
+    assert "current_private_equity_price_usd" not in bundle.metadata.source_metadata
+    assert bundle.metadata.current_private_equity_price_usd == 100.0
     np.testing.assert_array_equal(bundle.month_index, np.arange(horizon_months + 1, dtype="int64"))
     for key in (
         "inflation_multipliers",


### PR DESCRIPTION
## Summary

Removes the request-mapping fabrication where the browser computed `valueUsd = units × current_price` just to satisfy `PrivateEquityPosition.value_usd`. The simulator now owns the mark when the caller only has units.

## Option chosen: **A** — `value_usd` is now optional

Why A over B (drop entirely) or C (split into two variants):

- **A vs B**: `PortfolioStatement.PrivateEquityLot.mark_value_usd` is a real statement mark (tender offer, manual mark). Keeping `value_usd` as an optional authoritative override preserves that path with zero ceremony — `_scenario_private_equity_lot` still passes `value_usd=lot.mark_value_usd` and nothing downstream changes.
- **A vs C**: a discriminated union (`PrivateEquityUnitsPosition | PrivateEquityMarkPosition`) is more "invalid states unrepresentable", but it forces every caller (engine, portfolio converter, frontend, tests) to dispatch on the variant. Option A keeps a single position type with a validator that rejects "neither field set" — same correctness guarantee with much smaller blast radius.

## Wire-format change

`PrivateEquityPosition` (`augur/core/scenario_set.py`):
- `value_usd` is now `NonNegativeFloat | None = None` (was required `float`).
- A `@model_validator(mode="after")` rejects positions that omit both `units` and `value_usd` with a clear message.
- The class no longer inherits from `_AssetPositionBase` (the base is shared with positions that always have a value); it declares its own `asset_id`, `owner_actor_id`, `provenance`.

`MarketBundleMetadata` (`augur/core/market_bundle.py`):
- New typed field `current_private_equity_price_usd: float = 0.0` (`ge=0`). Replaces the loose `source_metadata["current_private_equity_price_usd"]` that `MacroMarketBundleProvider` was using.

## Request-mapping cleanup

The fabrication line goes away in `augur/frontend/lib/scenario_set_state.js`:

```diff
   const privateEquityUnits = Math.max(0, finiteNumber(initialBalanceSheet.privateEquityUnits, 0));
-  const privateEquityValueUsd = privateEquityValueUsdForUnits(bootstrap, privateEquityUnits);
   const assets = [ /* sp500 */ ];
-  if (privateEquityValueUsd > 0 || privateEquityUnits > 0) {
+  if (privateEquityUnits > 0) {
+    // The browser stores units only; the backend derives value_usd from
+    // units × MarketBundleMetadata.current_private_equity_price_usd at simulation init.
     assets.push({
       assetId: "private_equity_private",
       assetType: "private_equity",
       ownerActorId: primary.actorId,
-      valueUsd: privateEquityValueUsd,
       units: privateEquityUnits,
       costBasisUsd: 0,
     });
   }
```

The corresponding test in `scenario_set_state_test.mjs` drops the `value_usd: 9_120` expectation. `app.jsx` still uses `privateEquityCurrentUnitPriceUsd` and `privateEquityValueUsdForUnits` for UI display (showing the user what their units are worth right now) — that's unrelated to the request payload.

## Engine derivation

`augur/core/scenario_engine.py` adds `_private_equity_position_value_usd(asset, current_unit_price_usd=...)` which:
- Returns `float(asset.value_usd)` when set (explicit mark / statement mark override).
- Otherwise returns `units × current_unit_price_usd`.
- Raises if neither is available (position has units only, but the active provider didn't publish a price) — actionable error pointing at `MarketBundleMetadata.current_private_equity_price_usd`.

`run_scenario_vectorized` reads `market_bundle.metadata.current_private_equity_price_usd` once and threads it into `_initial_private_equity_value_usd` and `_initial_private_equity_cost_basis_usd`.

## `PrivateEquityLot.mark_value_usd` behavior — unchanged

`_scenario_private_equity_lot` in `augur/core/portfolio.py` still passes `value_usd=lot.mark_value_usd`. The portfolio round-trip test (`augur/core/portfolio_test.py`) still asserts `private_equity.value_usd == 25_000` and passes unchanged. The statement-mark path is untouched.

## Provider wiring

- `FlatMarketBundleProvider` accepts an optional `current_private_equity_price_usd: float = 0.0` constructor arg.
- `MacroMarketBundleProvider` now writes the price to the typed metadata field instead of `source_metadata` (test updated accordingly).
- `augur/api/http_server.py::_make_provider` pulls the price from `augur_config.snapshot.concentrated_holdings[0].fmv_usd_per_unit` and passes it to both the noop (`FlatMarketBundleProvider`) and macro paths. This means the noop-backed gaffer deployment can accept units-only positions from the browser.
- `SimpleMarketBundleProvider` is unchanged (no constructor; default 0.0). Callers using `--provider simple` must continue to set `value_usd` on PE positions — documented in the metadata field's description.

## Test plan

- [x] `bbr test //augur/core:scenario_set_test` — new tests: validator rejects positions missing both fields; validator accepts units-only positions.
- [x] `bbr test //augur/core:scenario_engine_test` — new tests: units-only PE derives `value_usd` from `units × current_private_equity_price_usd` at month 0; explicit `value_usd` overrides the market price.
- [x] `bbr test //augur/core:portfolio_test` — statement-mark round-trip still passes (`mark_value_usd` → `value_usd`).
- [x] `bbr test //augur/core:test_e2e` — all 30+ existing scenarios pass; PE positions in those scenarios continue to set `value_usd` explicitly.
- [x] `bbr test //augur/api:browser_shell_test` — end-to-end browser flow with units-only PE position works against the noop-backed server.
- [x] `bbr test //augur/frontend/lib:scenario_set_state_test` — backend request payload no longer carries the fabricated `value_usd`.
- [x] `bbr test //augur/model:macro_market_bundle_provider_test` — typed `current_private_equity_price_usd` field is populated; removed from `source_metadata`.
- [x] `bbr test //augur/...` — 27/28 pass; `//augur/frontend:visual_golden_test` fails identically on `devel` (pre-existing, verified by stashing and re-running).
- [x] `bbr build //augur/...` — clean.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_