### PR TITLE
augur/core: rename Action family to Effect (realized state change vs policy intent)

### DIFF
--- a/augur/core/api.py
+++ b/augur/core/api.py
@@ -34,8 +34,8 @@ from augur.core.provenance import (
 from augur.core.scenario_engine import ScenarioRunArrays, report_metric_array, run_scenario_vectorized
 from augur.core.scenario_set import (
     AccountingDetail,
-    Action,
     ActorRole,
+    Effect,
     EventType,
     ExogenousPathIdentity,
     MarketObservation,
@@ -54,7 +54,7 @@ from augur.core.scenario_set import (
     ScenarioSetRunResponse,
 )
 
-ActionT = TypeVar("ActionT")
+EffectT = TypeVar("EffectT")
 AccountingDetailT = TypeVar("AccountingDetailT")
 DecisionT = TypeVar("DecisionT")
 ObservationT = TypeVar("ObservationT")
@@ -76,13 +76,13 @@ class RolloutDetail:
         return float(self.scenario_run.terminal(metric, rollout=self.rollout_index))
 
     @overload
-    def actions(self, action_type: type[ActionT]) -> tuple[ActionT, ...]: ...
+    def effects(self, effect_type: type[EffectT]) -> tuple[EffectT, ...]: ...
 
     @overload
-    def actions(self, action_type: None = None) -> tuple[Action, ...]: ...
+    def effects(self, effect_type: None = None) -> tuple[Effect, ...]: ...
 
-    def actions(self, action_type: type[Any] | None = None) -> tuple[Any, ...]:
-        return self.scenario_run.actions(action_type, rollout=self.rollout_index)
+    def effects(self, effect_type: type[Any] | None = None) -> tuple[Any, ...]:
+        return self.scenario_run.effects(effect_type, rollout=self.rollout_index)
 
     @overload
     def policy_decisions(self, decision_type: type[DecisionT]) -> tuple[DecisionT, ...]: ...
@@ -164,21 +164,21 @@ class ScenarioRun:
         return RolloutDetail(scenario_run=self, rollout_index=rollout_index)
 
     @overload
-    def actions(self, action_type: type[ActionT], *, rollout: int | None = None) -> tuple[ActionT, ...]: ...
+    def effects(self, effect_type: type[EffectT], *, rollout: int | None = None) -> tuple[EffectT, ...]: ...
 
     @overload
-    def actions(self, action_type: None = None, *, rollout: int | None = None) -> tuple[Action, ...]: ...
+    def effects(self, effect_type: None = None, *, rollout: int | None = None) -> tuple[Effect, ...]: ...
 
-    def actions(self, action_type: type[Any] | None = None, *, rollout: int | None = None) -> tuple[Any, ...]:
+    def effects(self, effect_type: type[Any] | None = None, *, rollout: int | None = None) -> tuple[Any, ...]:
         if self.arrays is None:
             return ()
-        actions: tuple[Any, ...] = self.arrays.actions
-        if action_type is not None:
-            actions = tuple(action for action in actions if isinstance(action, action_type))
+        effects: tuple[Any, ...] = self.arrays.effects
+        if effect_type is not None:
+            effects = tuple(effect for effect in effects if isinstance(effect, effect_type))
         if rollout is not None:
             self._validate_rollout_index(rollout)
-            actions = tuple(action for action in actions if action.rollout_index == rollout)
-        return actions
+            effects = tuple(effect for effect in effects if effect.rollout_index == rollout)
+        return effects
 
     @overload
     def policy_decisions(
@@ -368,7 +368,7 @@ class ScenarioRun:
             metric_fan_columns=self.arrays.metric_fan_columns(),
             monthly_columns=self.arrays.monthly_columns() if report_spec.include_monthly_columns else None,
             terminal_columns=self.arrays.terminal_columns(),
-            actions=self.arrays.actions,
+            effects=self.arrays.effects,
             policy_decisions=self.arrays.policy_decisions,
             market_observations=self.arrays.market_observations,
             chart_accounts=self.arrays.chart_accounts,

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -67,11 +67,11 @@ from augur.core.scenario_set import (
     AccountingDetail,
     AccountingDetailType,
     AccountType,
-    Action,
     ActorRole,
     AssetType,
     CheckingFloorSellPublicStockPolicy,
     CryptoAssetPosition,
+    Effect,
     FailureEvent,
     FailureEventType,
     FinancingMode,
@@ -106,13 +106,13 @@ from augur.core.scenario_set import (
     RolloutStatus,
     RolloutStatusType,
     Scenario,
-    SellCryptoAction,
-    SellPrivateEquityAction,
+    SellCryptoEffect,
+    SellPrivateEquityEffect,
     SellPublicStockDecision,
-    SellSp500Action,
+    SellSp500Effect,
     SettlementResult,
     SettlementStatus,
-    SettlePropertySaleAction,
+    SettlePropertySaleEffect,
     SpecialAssessmentEvent,
     TaxPaymentAllocationDetail,
 )
@@ -200,7 +200,7 @@ class ScenarioRunArrays:
     net_worth_usd: np.ndarray
     partner_present: np.ndarray
     monthly_spend_usd: np.ndarray
-    actions: tuple[Action, ...]
+    effects: tuple[Effect, ...]
     policy_decisions: tuple[PolicyDecision, ...]
     market_observations: tuple[MarketObservation, ...]
     chart_accounts: tuple[ChartAccount, ...]
@@ -1424,7 +1424,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         np.full(rollout_count, initial_cash - down_payment, dtype="float64")
         - disposition.purchase_closing_cost_usd[:, 0]
     )
-    actions: list[Action] = []
+    effects: list[Effect] = []
     policy_decisions: list[PolicyDecision] = []
     market_observations: list[MarketObservation] = list(_market_path_observations(scenario, market_bundle))
     accounting = AccountingTraceBuilder()
@@ -1705,8 +1705,8 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         owner_home_equity_claim_for_net_worth = owner_home_equity_claim * unsold_mask
     liquid_net_worth = cash + generic_sp500_value + crypto_value
     net_worth = cash + generic_sp500_value + crypto_value + private_equity_value + owner_home_equity_claim_for_net_worth
-    _record_property_sale_actions(
-        actions,
+    _record_property_sale_effects(
+        effects,
         scenario=scenario,
         disposition=disposition,
         tax_usd=property_sale_tax,
@@ -1752,8 +1752,8 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             basis_usd=sp500_sale_action_record.basis_usd,
             tax_usd=source_tax,
         )
-        _record_sp500_sale_actions(
-            actions,
+        _record_sp500_sale_effects(
+            effects,
             month_index=sp500_sale_action_record.month_index,
             policy=sp500_sale_action_record.policy,
             amount_usd=sp500_sale_action_record.amount_usd,
@@ -1772,8 +1772,8 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             amount_usd=crypto_sale_action_record.amount_usd,
             basis_usd=crypto_sale_action_record.basis_usd,
         )
-        _record_crypto_sale_actions(
-            actions,
+        _record_crypto_sale_effects(
+            effects,
             month_index=crypto_sale_action_record.month_index,
             policy=crypto_sale_action_record.policy,
             source_asset_id=crypto_sale_action_record.source_asset_id,
@@ -1800,8 +1800,8 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             tax_usd=source_tax,
             source_holding_id=private_equity_source_holding_id,
         )
-        _record_private_equity_sale_actions(
-            actions,
+        _record_private_equity_sale_effects(
+            effects,
             month_index=private_equity_sale_action_record.month_index,
             instruction=private_equity_sale_action_record.instruction,
             sale_application=private_equity_sale_action_record.sale_application,
@@ -2286,7 +2286,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         net_worth_usd=net_worth,
         partner_present=partner_present,
         monthly_spend_usd=monthly_spend_from_accounting,
-        actions=_sorted_actions(_with_trajectory_identity(actions, trace_identity_by_rollout)),
+        effects=_sorted_effects(_with_trajectory_identity(effects, trace_identity_by_rollout)),
         policy_decisions=_sorted_policy_decisions(
             _with_trajectory_identity(policy_decisions, trace_identity_by_rollout)
         ),
@@ -3159,8 +3159,8 @@ def _sorted_failure_events(records: list[FailureEvent]) -> tuple[FailureEvent, .
     )
 
 
-def _record_property_sale_actions(
-    actions: list[Action],
+def _record_property_sale_effects(
+    effects: list[Effect],
     *,
     scenario: Scenario,
     disposition: PropertyDispositionArrays,
@@ -3185,8 +3185,8 @@ def _record_property_sale_actions(
         | (net_proceeds[:, month] != 0)
     )
     actor_id = sale_event.actor_id or _primary_owner_actor_id(scenario)
-    actions.extend(
-        SettlePropertySaleAction(
+    effects.extend(
+        SettlePropertySaleEffect(
             rollout_index=rollout_index,
             month_index=month,
             actor_id=actor_id,
@@ -3210,8 +3210,8 @@ def _record_property_sale_actions(
     )
 
 
-def _record_sp500_sale_actions(
-    actions: list[Action],
+def _record_sp500_sale_effects(
+    effects: list[Effect],
     *,
     month_index: int,
     policy: Policy,
@@ -3224,8 +3224,8 @@ def _record_sp500_sale_actions(
         amount = float(amount_usd[rollout_index])
         basis = float(basis_usd[rollout_index])
         tax = float(tax_usd[rollout_index])
-        actions.append(
-            SellSp500Action(
+        effects.append(
+            SellSp500Effect(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 actor_id=policy.actor_id,
@@ -3307,8 +3307,8 @@ def _record_crypto_sale_journal_entries(
         )
 
 
-def _record_crypto_sale_actions(
-    actions: list[Action],
+def _record_crypto_sale_effects(
+    effects: list[Effect],
     *,
     month_index: int,
     policy: Policy,
@@ -3322,8 +3322,8 @@ def _record_crypto_sale_actions(
     for rollout_index in np.nonzero((amount_usd > 0) | (shortfall_usd > 0))[0].tolist():
         amount = float(amount_usd[rollout_index])
         basis = float(basis_usd[rollout_index])
-        actions.append(
-            SellCryptoAction(
+        effects.append(
+            SellCryptoEffect(
                 rollout_index=rollout_index,
                 month_index=month_index,
                 actor_id=policy.actor_id,
@@ -3339,8 +3339,8 @@ def _record_crypto_sale_actions(
         )
 
 
-def _record_private_equity_sale_actions(
-    actions: list[Action],
+def _record_private_equity_sale_effects(
+    effects: list[Effect],
     *,
     month_index: int,
     instruction: PrivateEquitySaleInstructionBatch,
@@ -3348,8 +3348,8 @@ def _record_private_equity_sale_actions(
     estimated_tax_usd: np.ndarray,
 ) -> None:
     sale_tax = estimated_tax_usd
-    actions.extend(
-        SellPrivateEquityAction(
+    effects.extend(
+        SellPrivateEquityEffect(
             rollout_index=rollout_index,
             month_index=month_index,
             actor_id=instruction.actor_id,
@@ -4153,8 +4153,8 @@ def _settlement_status(*, amount_due_usd: float, unpaid_amount_usd: float) -> Se
     return SettlementStatus.PARTIALLY_PAID
 
 
-def _sorted_actions(actions: list[Action]) -> tuple[Action, ...]:
-    return tuple(sorted(actions, key=lambda action: (action.month_index, action.rollout_index, action.action_type)))
+def _sorted_effects(effects: list[Effect]) -> tuple[Effect, ...]:
+    return tuple(sorted(effects, key=lambda effect: (effect.month_index, effect.rollout_index, effect.effect_type)))
 
 
 def _property_cash_flow_arrays(

--- a/augur/core/scenario_engine_test.py
+++ b/augur/core/scenario_engine_test.py
@@ -10,8 +10,8 @@ from augur.core.market_bundle import MarketBundle, MarketBundleMetadata
 from augur.core.scenario_engine import MonthlyColumnSource, monthly_column_specs, run_scenario_vectorized
 from augur.core.scenario_set import (
     AccountType,
-    ActionType,
     AssetType,
+    EffectType,
     FundingDecisionType,
     FundingSourceType,
     MarketRequest,
@@ -28,7 +28,7 @@ from augur.core.scenario_set import (
     ScenarioSet,
     SellPublicStockDecision,
     SettlementStatus,
-    SettlePropertySaleAction,
+    SettlePropertySaleEffect,
 )
 
 
@@ -496,19 +496,19 @@ def test_terminal_property_sale_proceeds_pay_off_debt() -> None:
         result.property_sale_net_proceeds_usd[:, 3], expected_gross - expected_sale_cost - expected_debt_payoff
     )
     assert_allclose(result.net_property_sale_cash_flow_usd[:, 3], result.property_sale_net_proceeds_usd[:, 3])
-    sale_actions = [action for action in result.actions if isinstance(action, SettlePropertySaleAction)]
-    assert len(sale_actions) == 2
-    assert {action.rollout_index for action in sale_actions} == {0, 1}
-    for action in sale_actions:
-        assert action.event_id == "sale"
-        assert action.property_id == "vallejo_calhoun"
-        assert action.gross_sale_usd == expected_gross
-        assert action.selling_cost_usd == expected_sale_cost
-        assert action.adjusted_basis_usd == expected_adjusted_basis
-        assert_allclose(action.debt_payoff_usd, expected_debt_payoff[action.rollout_index])
-        assert action.capital_gain_exclusion_usd == expected_realized_gain
-        assert action.taxable_capital_gain_usd == 0
-        assert_allclose(action.net_proceeds_usd, result.property_sale_net_proceeds_usd[action.rollout_index, 3])
+    sale_effects = [effect for effect in result.effects if isinstance(effect, SettlePropertySaleEffect)]
+    assert len(sale_effects) == 2
+    assert {effect.rollout_index for effect in sale_effects} == {0, 1}
+    for effect in sale_effects:
+        assert effect.event_id == "sale"
+        assert effect.property_id == "vallejo_calhoun"
+        assert effect.gross_sale_usd == expected_gross
+        assert effect.selling_cost_usd == expected_sale_cost
+        assert effect.adjusted_basis_usd == expected_adjusted_basis
+        assert_allclose(effect.debt_payoff_usd, expected_debt_payoff[effect.rollout_index])
+        assert effect.capital_gain_exclusion_usd == expected_realized_gain
+        assert effect.taxable_capital_gain_usd == 0
+        assert_allclose(effect.net_proceeds_usd, result.property_sale_net_proceeds_usd[effect.rollout_index, 3])
 
 
 def test_location_local_regulation_drives_property_tax() -> None:
@@ -751,22 +751,22 @@ def test_checking_floor_policy_sells_public_stock_with_basis_placeholder() -> No
     assert_allclose(result.generic_sp500_value_usd[:, 0], 30_000)
     assert_allclose(result.generic_sp500_sale_usd[:, 1:], 0)
     assert np.all(result.generic_sp500_value_usd[:, 1] > result.generic_sp500_value_usd[:, 0])
-    assert len(result.actions) == 2
-    assert {action.rollout_index for action in result.actions} == {0, 1}
-    for action in result.actions:
-        assert action.action_type is ActionType.SELL_SP500
-        assert action.month_index == 0
-        assert action.actor_id == "owner"
-        assert action.policy_id == "checking_floor"
-        assert action.amount_usd == 20_000
-        assert_allclose(action.after_tax_proceeds_usd, 20_000 - 42.94)
-        assert action.basis_usd == 10_000
-        assert action.gain_usd == 10_000
-        assert_allclose(action.tax_usd, 42.94)
-        assert action.shortfall_usd == 0
+    assert len(result.effects) == 2
+    assert {effect.rollout_index for effect in result.effects} == {0, 1}
+    for effect in result.effects:
+        assert effect.effect_type is EffectType.SELL_SP500
+        assert effect.month_index == 0
+        assert effect.actor_id == "owner"
+        assert effect.policy_id == "checking_floor"
+        assert effect.amount_usd == 20_000
+        assert_allclose(effect.after_tax_proceeds_usd, 20_000 - 42.94)
+        assert effect.basis_usd == 10_000
+        assert effect.gain_usd == 10_000
+        assert_allclose(effect.tax_usd, 42.94)
+        assert effect.shortfall_usd == 0
 
 
-def test_scenario_set_response_serializes_discriminated_actions() -> None:
+def test_scenario_set_response_serializes_discriminated_effects() -> None:
     scenario_set = ScenarioSet.model_validate(
         _scenario_set_body(
             _scenario_body(
@@ -789,9 +789,9 @@ def test_scenario_set_response_serializes_discriminated_actions() -> None:
     response = simulate_set(scenario_set, market_bundle=_bundle()).to_response()
     payload = response.model_dump(mode="json")
 
-    action = payload["scenario_results"][0]["actions"][0]
-    assert action["action_type"] == "sell_sp500"
-    assert action["amount_usd"] == 20_000
+    effect = payload["scenario_results"][0]["effects"][0]
+    assert effect["effect_type"] == "sell_sp500"
+    assert effect["amount_usd"] == 20_000
 
 
 def test_checking_floor_policy_does_not_sell_when_cash_is_above_floor() -> None:
@@ -1284,7 +1284,7 @@ def test_private_equity_sale_opportunity_without_policy_does_not_sell() -> None:
     assert_allclose(result.private_equity_sale_opportunity_value_usd[:, 1], 50_000)
     assert_allclose(result.cash_usd[:, 1], 10_000)
     assert np.all(result.private_equity_sale_opportunity_event[:, 1])
-    assert result.actions == ()
+    assert result.effects == ()
 
 
 def test_private_equity_fixed_sale_into_cash_requires_opportunity_and_policy() -> None:
@@ -1309,7 +1309,7 @@ def test_private_equity_fixed_sale_into_cash_requires_opportunity_and_policy() -
 
     no_opportunity = run_scenario_vectorized(scenario_set.scenarios[0], _bundle())
     assert_allclose(no_opportunity.private_equity_sale_usd, 0)
-    assert no_opportunity.actions == ()
+    assert no_opportunity.effects == ()
     no_opportunity_decisions = [
         decision
         for decision in no_opportunity.policy_decisions
@@ -1340,26 +1340,26 @@ def test_private_equity_fixed_sale_into_cash_requires_opportunity_and_policy() -
     # but settles at the last in-horizon month belonging to the tax year.
     assert_allclose(result.cash_usd[:, 1], 30_000)
     assert_allclose(result.cash_usd[:, 3], 30_000 - expected_tax)
-    actions = [action for action in result.actions if action.action_type is ActionType.SELL_PRIVATE_EQUITY]
-    assert len(actions) == 2
-    for action in actions:
+    effects = [effect for effect in result.effects if effect.effect_type is EffectType.SELL_PRIVATE_EQUITY]
+    assert len(effects) == 2
+    for effect in effects:
         expected_opportunity_id = (
-            f"{market_bundle.metadata.path_set_id}:path:{action.rollout_index}:month:1:"
+            f"{market_bundle.metadata.path_set_id}:path:{effect.rollout_index}:month:1:"
             "private_equity_holding:private_equity:sale_opportunity"
         )
-        assert action.event_id is None
-        assert action.event_type is None
-        assert action.opportunity_id == expected_opportunity_id
-        assert action.opportunity_cause_id == expected_opportunity_id
-        assert action.actor_id == "owner"
-        assert action.policy_id == "private_equity_sale"
-        assert action.amount_usd == 20_000
-        assert_allclose(action.after_tax_proceeds_usd, 20_000 - expected_tax)
-        assert action.basis_usd == 0
-        assert_allclose(action.estimated_tax_usd, expected_tax)
-        assert action.units_sold == 40
-        assert action.sold_fraction == 0.4
-        assert action.proceeds_destination is AccountType.CHECKING
+        assert effect.event_id is None
+        assert effect.event_type is None
+        assert effect.opportunity_id == expected_opportunity_id
+        assert effect.opportunity_cause_id == expected_opportunity_id
+        assert effect.actor_id == "owner"
+        assert effect.policy_id == "private_equity_sale"
+        assert effect.amount_usd == 20_000
+        assert_allclose(effect.after_tax_proceeds_usd, 20_000 - expected_tax)
+        assert effect.basis_usd == 0
+        assert_allclose(effect.estimated_tax_usd, expected_tax)
+        assert effect.units_sold == 40
+        assert effect.sold_fraction == 0.4
+        assert effect.proceeds_destination is AccountType.CHECKING
     sale_decisions = [
         decision
         for decision in result.policy_decisions
@@ -1796,7 +1796,7 @@ def test_checking_floor_policy_falls_through_to_crypto_after_sp500_exhausted() -
     # only — verify the policy is at least recorded and crypto value tracks
     # correctly while it sits there.
     assert_allclose(result.crypto_value_usd[:, 0], 10_000)
-    assert {action.action_type for action in result.actions} >= {ActionType.SELL_SP500}
+    assert {effect.effect_type for effect in result.effects} >= {EffectType.SELL_SP500}
 
 
 def test_required_tax_obligation_funded_by_crypto_after_sp500_exhausted() -> None:
@@ -1857,7 +1857,7 @@ def test_required_tax_obligation_funded_by_crypto_after_sp500_exhausted() -> Non
         assert decision.source_type is FundingSourceType.CRYPTO_ASSET
         assert decision.source_asset_type is AssetType.CRYPTO
         assert decision.funded_cash_usd > 0
-    assert {action.action_type for action in result.actions} >= {ActionType.SELL_CRYPTO}
+    assert {effect.effect_type for effect in result.effects} >= {EffectType.SELL_CRYPTO}
 
 
 def test_checking_floor_policy_with_crypto_only_preference_sells_crypto() -> None:

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -55,14 +55,14 @@ class LiquidityReserveRuleType(StrEnum):
     PROJECTED_DEFICITS = "projected_deficits"
 
 
-class ActionType(StrEnum):
-    """Discriminator for user-visible trajectory actions.
+class EffectType(StrEnum):
+    """Discriminator for user-visible trajectory effects (realized state changes).
 
     Restricted to sale-class commands: the system-emitted accounting moves
     (mortgage settlement, partner contributions, partner-equity accruals,
     monthly spend) are derivable from ledger postings, balance snapshots, and
     accounting details — the canonical detail surface — so they are not
-    surfaced as separate action rows.
+    surfaced as separate effect rows.
     """
 
     SELL_SP500 = "sell_sp500"
@@ -462,13 +462,13 @@ class _TraceBase(ApiModel):
     projection_trajectory_id: str | None = None
 
 
-class _ActionBase(_TraceBase):
+class _EffectBase(_TraceBase):
     actor_id: str
     policy_id: str
 
 
-class SellSp500Action(_ActionBase):
-    action_type: Literal[ActionType.SELL_SP500] = ActionType.SELL_SP500
+class SellSp500Effect(_EffectBase):
+    effect_type: Literal[EffectType.SELL_SP500] = EffectType.SELL_SP500
     amount_usd: float
     after_tax_proceeds_usd: float
     basis_usd: float
@@ -477,8 +477,8 @@ class SellSp500Action(_ActionBase):
     shortfall_usd: float
 
 
-class SellCryptoAction(_ActionBase):
-    action_type: Literal[ActionType.SELL_CRYPTO] = ActionType.SELL_CRYPTO
+class SellCryptoEffect(_EffectBase):
+    effect_type: Literal[EffectType.SELL_CRYPTO] = EffectType.SELL_CRYPTO
     source_asset_id: str
     asset_symbol: str
     amount_usd: float
@@ -488,8 +488,8 @@ class SellCryptoAction(_ActionBase):
     shortfall_usd: float
 
 
-class SellPrivateEquityAction(_ActionBase):
-    action_type: Literal[ActionType.SELL_PRIVATE_EQUITY] = ActionType.SELL_PRIVATE_EQUITY
+class SellPrivateEquityEffect(_EffectBase):
+    effect_type: Literal[EffectType.SELL_PRIVATE_EQUITY] = EffectType.SELL_PRIVATE_EQUITY
     event_id: str | None = None
     event_type: EventType | None = None
     opportunity_id: str | None = None
@@ -504,8 +504,8 @@ class SellPrivateEquityAction(_ActionBase):
     proceeds_destination: AccountType | AssetType
 
 
-class SettlePropertySaleAction(_ActionBase):
-    action_type: Literal[ActionType.SETTLE_PROPERTY_SALE] = ActionType.SETTLE_PROPERTY_SALE
+class SettlePropertySaleEffect(_EffectBase):
+    effect_type: Literal[EffectType.SETTLE_PROPERTY_SALE] = EffectType.SETTLE_PROPERTY_SALE
     event_id: str
     event_type: Literal[EventType.PROPERTY_SALE] = EventType.PROPERTY_SALE
     property_id: PropertyId
@@ -524,9 +524,9 @@ class SettlePropertySaleAction(_ActionBase):
     proceeds_destination: AccountType = AccountType.CHECKING
 
 
-Action = Annotated[
-    SellSp500Action | SellCryptoAction | SellPrivateEquityAction | SettlePropertySaleAction,
-    Field(discriminator="action_type"),
+Effect = Annotated[
+    SellSp500Effect | SellCryptoEffect | SellPrivateEquityEffect | SettlePropertySaleEffect,
+    Field(discriminator="effect_type"),
 ]
 
 
@@ -1002,7 +1002,7 @@ class ScenarioResult(ApiModel):
     metric_fan_columns: dict[str, ColumnarTable] = Field(default_factory=dict)
     monthly_columns: ColumnarTable | None = None
     terminal_columns: ColumnarTable | None = None
-    actions: tuple[Action, ...] = ()
+    effects: tuple[Effect, ...] = ()
     policy_decisions: tuple[PolicyDecision, ...] = ()
     market_observations: tuple[MarketObservation, ...] = ()
     chart_accounts: tuple[ChartAccount, ...] = ()

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -58,10 +58,10 @@ from augur.core.scenario_set import (
     RolloutStatusType,
     Scenario,
     ScenarioSet,
-    SellPrivateEquityAction,
+    SellPrivateEquityEffect,
     SellPublicStockDecision,
-    SellSp500Action,
-    SettlePropertySaleAction,
+    SellSp500Effect,
+    SettlePropertySaleEffect,
     SpecialAssessmentEvent,
     TaxFilingStatus,
     TaxPaymentAllocationDetail,
@@ -440,7 +440,7 @@ def test_fixed_rate_mortgage_amortizes_and_purchase_cash_outlay_posts_at_month_z
     )
     # Mortgage payment detail is exposed via obligation + settlement rows and the
     # MORTGAGE_INTEREST/MORTGAGE_PRINCIPAL ledger postings asserted above; the
-    # standalone PayMortgageAction row has been collapsed away.
+    # standalone PayMortgageEffect row has been collapsed away.
     assert result.arrays is not None
     mortgage_obligations = tuple(
         obligation
@@ -1009,21 +1009,21 @@ def test_property_sale_records_capital_gains_tax_and_net_proceeds() -> None:
     assert len(sale_accounting_details) == 1
     assert_allclose(sale_accounting_details[0].adjusted_basis_usd, 500_000)
     assert_allclose(sale_accounting_details[0].taxable_gain_usd, taxable_gain)
-    actions = rollout.actions(SettlePropertySaleAction)
-    assert len(actions) == 1
-    action = actions[0]
-    assert action.event_id == "sale"
-    assert action.property_id == "test_property"
-    assert action.policy_id == "property_sale_settlement"
-    assert_allclose(action.gross_sale_usd, sale_value)
-    assert_allclose(action.selling_cost_usd, sale_closing_cost)
-    assert_allclose(action.debt_payoff_usd, 0)
-    assert_allclose(action.adjusted_basis_usd, 500_000)
-    assert_allclose(action.realized_gain_usd, realized_gain)
-    assert_allclose(action.capital_gain_exclusion_usd, 250_000)
-    assert_allclose(action.taxable_gain_usd, taxable_gain)
-    assert_allclose(action.tax_usd, sale_tax)
-    assert_allclose(action.net_proceeds_usd, pretax_net_proceeds)
+    effects = rollout.effects(SettlePropertySaleEffect)
+    assert len(effects) == 1
+    effect = effects[0]
+    assert effect.event_id == "sale"
+    assert effect.property_id == "test_property"
+    assert effect.policy_id == "property_sale_settlement"
+    assert_allclose(effect.gross_sale_usd, sale_value)
+    assert_allclose(effect.selling_cost_usd, sale_closing_cost)
+    assert_allclose(effect.debt_payoff_usd, 0)
+    assert_allclose(effect.adjusted_basis_usd, 500_000)
+    assert_allclose(effect.realized_gain_usd, realized_gain)
+    assert_allclose(effect.capital_gain_exclusion_usd, 250_000)
+    assert_allclose(effect.taxable_gain_usd, taxable_gain)
+    assert_allclose(effect.tax_usd, sale_tax)
+    assert_allclose(effect.net_proceeds_usd, pretax_net_proceeds)
 
 
 def test_partner_sale_claim_uses_settlement_net_proceeds() -> None:
@@ -1065,15 +1065,15 @@ def test_partner_sale_claim_uses_settlement_net_proceeds() -> None:
     )
 
     rollout = result.rollout(0)
-    sale_action = rollout.actions(SettlePropertySaleAction)[0]
-    sale_net_proceeds = sale_action.net_proceeds_usd
+    sale_effect = rollout.effects(SettlePropertySaleEffect)[0]
+    sale_net_proceeds = sale_effect.net_proceeds_usd
     ownership_pct = rollout.series(ReportMetric.PARTNER_OWNERSHIP_PCT)[sale_month]
     expected_partner_claim = sale_net_proceeds * ownership_pct
     expected_owner_claim = sale_net_proceeds - expected_partner_claim
     gross_equity_claim = rollout.series(ReportMetric.HOME_EQUITY_USD)[sale_month] * ownership_pct
 
     assert_allclose(rollout.series(ReportMetric.PROPERTY_SALE_NET_PROCEEDS_USD)[sale_month], sale_net_proceeds)
-    assert_allclose(rollout.series(ReportMetric.PROPERTY_SALE_DEBT_PAYOFF_USD)[sale_month], sale_action.debt_payoff_usd)
+    assert_allclose(rollout.series(ReportMetric.PROPERTY_SALE_DEBT_PAYOFF_USD)[sale_month], sale_effect.debt_payoff_usd)
     assert_allclose(
         _posting_matrix(
             result,
@@ -1100,11 +1100,11 @@ def test_partner_sale_claim_uses_settlement_net_proceeds() -> None:
     # from the OWNERSHIP_PARTNER_HOME_EQUITY_CLAIM balance snapshots.
 
 
-def test_simulate_set_response_serializes_sale_actions_with_tax_detail() -> None:
-    """The public response payload preserves per-rollout action details for UI inspection."""
+def test_simulate_set_response_serializes_sale_effects_with_tax_detail() -> None:
+    """The public response payload preserves per-rollout effect details for UI inspection."""
     scenario = Scenario(
-        scenario_id="serialized_sale_actions",
-        label="Serialized Sale Actions",
+        scenario_id="serialized_sale_effects",
+        label="Serialized Sale Effects",
         actors=(_simple_actor(),),
         events=(PropertySaleEvent(event_id="property_sale", month_index=2, property_id="test_property"),),
         property_selection=PropertySelection(
@@ -1152,8 +1152,8 @@ def test_simulate_set_response_serializes_sale_actions_with_tax_detail() -> None
         ),
     )
     scenario_set = ScenarioSet(
-        scenario_set_id="serialized_sale_actions_set",
-        title="Serialized Sale Actions Set",
+        scenario_set_id="serialized_sale_effects_set",
+        title="Serialized Sale Effects Set",
         market_request=MarketRequest(market_model_id="e2e_noop", rollout_count=1, horizon_months=2, seed=0),
         scenarios=(scenario,),
     )
@@ -1170,8 +1170,8 @@ def test_simulate_set_response_serializes_sale_actions_with_tax_detail() -> None
     assert {"federal_income_tax_usd", "california_income_tax_usd", "generic_sp500_sale_tax_usd"} <= set(
         result["monthly_columns"]["columns"]
     )
-    actions = {action["action_type"]: action for action in result["actions"]}
-    assert set(actions) == {"sell_sp500", "sell_private_equity", "settle_property_sale"}
+    effects = {effect["effect_type"]: effect for effect in result["effects"]}
+    assert set(effects) == {"sell_sp500", "sell_private_equity", "settle_property_sale"}
     account_by_id = {account["chart_account_id"]: account for account in result["chart_accounts"]}
     posting_roles = {account_by_id[posting["chart_account_id"]]["role"] for posting in result["postings"]}
     assert {"public_security", "private_equity", "checking_cash", "tax_expense"} <= posting_roles
@@ -1185,42 +1185,42 @@ def test_simulate_set_response_serializes_sale_actions_with_tax_detail() -> None
         detail["detail_type"] for detail in result["accounting_details"]
     }
 
-    sp500_action = actions["sell_sp500"]
-    assert sp500_action["amount_usd"] == 20_000
-    assert sp500_action["basis_usd"] == 10_000
-    assert sp500_action["gain_usd"] == 10_000
-    assert sp500_action["tax_usd"] > 0
-    assert_allclose(sp500_action["after_tax_proceeds_usd"], sp500_action["amount_usd"] - sp500_action["tax_usd"])
+    sp500_effect = effects["sell_sp500"]
+    assert sp500_effect["amount_usd"] == 20_000
+    assert sp500_effect["basis_usd"] == 10_000
+    assert sp500_effect["gain_usd"] == 10_000
+    assert sp500_effect["tax_usd"] > 0
+    assert_allclose(sp500_effect["after_tax_proceeds_usd"], sp500_effect["amount_usd"] - sp500_effect["tax_usd"])
 
-    private_equity_action = actions["sell_private_equity"]
-    assert private_equity_action["event_id"] is None
-    assert private_equity_action["event_type"] is None
-    assert private_equity_action["opportunity_id"] == (
-        f"{private_equity_action['path_set_id']}:path:0:month:1:private_equity_holding:pe:sale_opportunity"
+    private_equity_effect = effects["sell_private_equity"]
+    assert private_equity_effect["event_id"] is None
+    assert private_equity_effect["event_type"] is None
+    assert private_equity_effect["opportunity_id"] == (
+        f"{private_equity_effect['path_set_id']}:path:0:month:1:private_equity_holding:pe:sale_opportunity"
     )
-    assert private_equity_action["opportunity_cause_id"] == private_equity_action["opportunity_id"]
-    assert private_equity_action["amount_usd"] == 50_000
-    assert private_equity_action["basis_usd"] == 20_000
-    assert private_equity_action["taxable_gain_usd"] == 30_000
-    assert private_equity_action["estimated_tax_usd"] > 0
+    assert private_equity_effect["opportunity_cause_id"] == private_equity_effect["opportunity_id"]
+    assert private_equity_effect["amount_usd"] == 50_000
+    assert private_equity_effect["basis_usd"] == 20_000
+    assert private_equity_effect["taxable_gain_usd"] == 30_000
+    assert private_equity_effect["estimated_tax_usd"] > 0
     assert_allclose(
-        private_equity_action["after_tax_proceeds_usd"],
-        private_equity_action["amount_usd"] - private_equity_action["estimated_tax_usd"],
+        private_equity_effect["after_tax_proceeds_usd"],
+        private_equity_effect["amount_usd"] - private_equity_effect["estimated_tax_usd"],
     )
 
-    property_action = actions["settle_property_sale"]
-    assert property_action["event_id"] == "property_sale"
-    assert property_action["property_id"] == "test_property"
-    assert property_action["gross_sale_usd"] == 900_000
-    assert property_action["selling_cost_usd"] == 58_500
-    assert property_action["adjusted_basis_usd"] == 500_000
-    assert property_action["taxable_capital_gain_usd"] == 91_500
-    assert property_action["tax_usd"] > 0
+    property_effect = effects["settle_property_sale"]
+    assert property_effect["event_id"] == "property_sale"
+    assert property_effect["property_id"] == "test_property"
+    assert property_effect["gross_sale_usd"] == 900_000
+    assert property_effect["selling_cost_usd"] == 58_500
+    assert property_effect["adjusted_basis_usd"] == 500_000
+    assert property_effect["taxable_capital_gain_usd"] == 91_500
+    assert property_effect["tax_usd"] > 0
     # net_proceeds is the cash actually received at the sale event (pre-tax);
     # sale tax accrues to the sale month for provenance and settles at year-end.
     assert_allclose(
-        property_action["net_proceeds_usd"],
-        property_action["gross_sale_usd"] - property_action["selling_cost_usd"] - property_action["debt_payoff_usd"],
+        property_effect["net_proceeds_usd"],
+        property_effect["gross_sale_usd"] - property_effect["selling_cost_usd"] - property_effect["debt_payoff_usd"],
     )
 
 
@@ -1411,16 +1411,16 @@ def test_checking_floor_policy_sells_sp500_to_restore_cash_floor() -> None:
         result.matrix(ReportMetric.GENERIC_SP500_SALE_USD) - result.matrix(ReportMetric.GENERIC_SP500_SALE_TAX_USD),
     )
 
-    actions = result.actions(SellSp500Action)
-    assert len(actions) == 1
-    assert actions[0].month_index == 5
-    assert actions[0].policy_id == "checking_floor"
-    assert actions[0].amount_usd == 20_000
-    assert_allclose(actions[0].after_tax_proceeds_usd, 20_000 - expected_stock_sale_tax)
-    assert actions[0].basis_usd == 10_000
-    assert actions[0].gain_usd == 10_000
-    assert_allclose(actions[0].tax_usd, expected_stock_sale_tax)
-    assert actions[0].shortfall_usd == 0
+    effects = result.effects(SellSp500Effect)
+    assert len(effects) == 1
+    assert effects[0].month_index == 5
+    assert effects[0].policy_id == "checking_floor"
+    assert effects[0].amount_usd == 20_000
+    assert_allclose(effects[0].after_tax_proceeds_usd, 20_000 - expected_stock_sale_tax)
+    assert effects[0].basis_usd == 10_000
+    assert effects[0].gain_usd == 10_000
+    assert_allclose(effects[0].tax_usd, expected_stock_sale_tax)
+    assert effects[0].shortfall_usd == 0
     decisions = result.policy_decisions(SellPublicStockDecision)
     assert len(decisions) == 1
     assert decisions[0].month_index == 5
@@ -1471,7 +1471,7 @@ def test_multiple_checking_floor_rules_execute_in_policy_order() -> None:
     assert_allclose(rollout.series(ReportMetric.GENERIC_SP500_SALE_BASIS_USD)[0], 25_000)
     assert_allclose(rollout.series(ReportMetric.CHECKING_FLOOR_SHORTFALL_USD)[0], 0)
 
-    assert [(action.policy_id, action.amount_usd) for action in result.actions(SellSp500Action)] == [
+    assert [(effect.policy_id, effect.amount_usd) for effect in result.effects(SellSp500Effect)] == [
         ("primary_floor", 15_000),
         ("top_up_floor", 10_000),
     ]
@@ -1515,7 +1515,7 @@ def test_private_equity_tender_sale_into_cash_increases_only_actual_liquid_asset
     assert_allclose(no_opportunity.rollout(0).series(ReportMetric.PRIVATE_EQUITY_SALE_USD), 0)
     assert_allclose(no_opportunity.rollout(0).series(ReportMetric.CASH_USD)[12], 10_000)
     assert_allclose(no_opportunity.rollout(0).series(ReportMetric.LIQUID_NET_WORTH_USD)[12], 10_000)
-    assert no_opportunity.actions(SellPrivateEquityAction) == ()
+    assert no_opportunity.effects(SellPrivateEquityEffect) == ()
     no_opportunity_decisions = no_opportunity.policy_decisions(PrivateEquitySaleDecision)
     assert len(no_opportunity_decisions) == 13
     assert {decision.decision_reason for decision in no_opportunity_decisions} == {
@@ -1604,23 +1604,23 @@ def test_private_equity_tender_sale_into_cash_increases_only_actual_liquid_asset
         result.matrix(ReportMetric.PRIVATE_EQUITY_SALE_USD) - result.matrix(ReportMetric.PRIVATE_EQUITY_SALE_TAX_USD),
     )
 
-    actions = result.actions(SellPrivateEquityAction)
-    assert len(actions) == 1
-    assert actions[0].month_index == 12
-    assert actions[0].event_id is None
-    assert actions[0].event_type is None
-    assert actions[0].opportunity_id == expected_opportunity_id
-    assert actions[0].opportunity_cause_id == expected_opportunity_id
-    assert actions[0].actor_id == "alpha"
-    assert actions[0].policy_id == "private_equity_sale"
-    assert actions[0].amount_usd == expected_sale
-    assert actions[0].basis_usd == expected_basis
-    assert actions[0].taxable_gain_usd == expected_taxable_gain
-    assert_allclose(actions[0].estimated_tax_usd, expected_tax)
-    assert_allclose(actions[0].after_tax_proceeds_usd, expected_after_tax_proceeds)
-    assert actions[0].units_sold == 50
-    assert actions[0].sold_fraction == 0.5
-    assert actions[0].proceeds_destination is AccountType.CHECKING
+    effects = result.effects(SellPrivateEquityEffect)
+    assert len(effects) == 1
+    assert effects[0].month_index == 12
+    assert effects[0].event_id is None
+    assert effects[0].event_type is None
+    assert effects[0].opportunity_id == expected_opportunity_id
+    assert effects[0].opportunity_cause_id == expected_opportunity_id
+    assert effects[0].actor_id == "alpha"
+    assert effects[0].policy_id == "private_equity_sale"
+    assert effects[0].amount_usd == expected_sale
+    assert effects[0].basis_usd == expected_basis
+    assert effects[0].taxable_gain_usd == expected_taxable_gain
+    assert_allclose(effects[0].estimated_tax_usd, expected_tax)
+    assert_allclose(effects[0].after_tax_proceeds_usd, expected_after_tax_proceeds)
+    assert effects[0].units_sold == 50
+    assert effects[0].sold_fraction == 0.5
+    assert effects[0].proceeds_destination is AccountType.CHECKING
 
 
 def test_fixed_amount_private_equity_sale_rule_sells_on_market_opportunity() -> None:
@@ -1669,19 +1669,19 @@ def test_fixed_amount_private_equity_sale_rule_sells_on_market_opportunity() -> 
     assert_allclose(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_TAX_USD)[6], expected_tax)
     assert_allclose(rollout.series(ReportMetric.PRIVATE_EQUITY_VALUE_USD)[6], 150_000)
     assert_allclose(rollout.series(ReportMetric.CASH_USD)[6], 60_000 - expected_tax)
-    actions = result.actions(SellPrivateEquityAction)
-    assert len(actions) == 1
-    assert actions[0].event_id is None
-    assert actions[0].event_type is None
-    assert actions[0].amount_usd == 50_000
-    assert_allclose(actions[0].after_tax_proceeds_usd, 50_000 - expected_tax)
+    effects = result.effects(SellPrivateEquityEffect)
+    assert len(effects) == 1
+    assert effects[0].event_id is None
+    assert effects[0].event_type is None
+    assert effects[0].amount_usd == 50_000
+    assert_allclose(effects[0].after_tax_proceeds_usd, 50_000 - expected_tax)
 
 
 def test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface() -> None:
     """Cleanup-audit item 2 invariant: every public monthly flow column is derived
     from the canonical detail surface (ledger postings, balance snapshots,
     accounting details, or market observations) — never from a parallel
-    Action recorder. This guard rebuilds each monthly metric matrix
+    Effect recorder. This guard rebuilds each monthly metric matrix
     from the canonical detail rows the engine emits and asserts it equals the
     monthly array reported in the result.
 


### PR DESCRIPTION
## Rationale

Per `augur/plans/roadmap.md` Priority 5: the existing `Action` concept has drifted toward the realized state change after validation and accounting, while the actor's RL-like choice is closer to a policy decision/instruction. Rename `Action` to `Effect` so the vocabulary matches what the row actually represents.

`Instruction` (what policy emits before validation) and `PolicyDecision` (the trace of the policy's decision) are intentionally NOT renamed — they are already correctly named for their roles.

## Renamed symbols

- `Action` → `Effect`
- `ActionType` → `EffectType`
- `_ActionBase` → `_EffectBase`
- `SellSp500Action` → `SellSp500Effect`
- `SellCryptoAction` → `SellCryptoEffect`
- `SellPrivateEquityAction` → `SellPrivateEquityEffect`
- `SettlePropertySaleAction` → `SettlePropertySaleEffect`
- Discriminator field `action_type` → `effect_type` (on each concrete class)
- Internal helpers `_record_*_actions` → `_record_*_effects`
- `_sorted_actions` → `_sorted_effects`
- API surface: `ScenarioRun.actions(...)` / `RolloutDetail.actions(...)` → `.effects(...)`
- TypeVar `ActionT` → `EffectT`

`EffectType` string values are unchanged (`"sell_sp500"`, `"sell_crypto"`, `"sell_private_equity"`, `"settle_property_sale"`) for wire compatibility — only the Python class/enum names change.

## Wire-format change

`ScenarioResult.actions: tuple[Action, ...]` becomes `ScenarioResult.effects: tuple[Effect, ...]`. The JSON key on serialized scenario results flips from `actions` to `effects`, and inside each row the discriminator key flips from `action_type` to `effect_type`. The auto-generated OpenAPI schema and Zod schema (`augur/frontend/lib/api/schema.zod.mjs`) pick this up via the standard codegen path; no frontend consumer reads `result.actions` directly, so no frontend code change was needed.

## Intentionally NOT renamed

- `Instruction` family — already the right name for "policy emits intent".
- `PolicyDecision` family — already the right name for "trace of the policy's decision".
- `ActionType` enum string values (preserved for wire compat).
- Internal scratch dataclasses `Sp500SaleActionRecord` / `CryptoSaleActionRecord` / `PrivateEquitySaleActionRecord` — these are intermediate buffers used during vectorized execution, not the realized-state-change rows, and are out of the rename scope listed in the roadmap.
- Function names that name operations rather than the class (e.g. `apply_*_instruction`, `*_decision`).

## Validation

- `bbr test //augur/core/...` — all 14 targets pass.
- `bbr test //augur/...` — 27/28 pass. The one failure (`//augur/frontend:visual_golden_test`, `distribution_fan` case, 0.26% pixel diff) is pre-existing on `origin/devel` (verified by running the same target against `origin/devel` directly — same failure, same pixel %), unrelated to this rename.
- `bbr build //augur/...` — passes.
- Visual goldens unchanged by this rename: the frontend does not read `result.actions` / `result.effects`, only `metricFanColumns`.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_