### PR TITLE
augur/core: route property operating costs + partner contributions through obligation pipeline (Plan C slices 2 + 4)

### DIFF
--- a/augur/core/policy_runtime.py
+++ b/augur/core/policy_runtime.py
@@ -343,6 +343,16 @@ def apply_partner_house_cost_contribution(
     house_costs_usd: np.ndarray,
     mortgage_principal_usd: np.ndarray,
 ) -> PartnerHouseCostContributionApplication:
+    """Allocate a configured partner cash contribution against house costs.
+
+    Emits the contribution-allocation journal entry (PARTNER_CONTRIBUTION_USED /
+    PARTNER_UNALLOCATED_CLAIM / PARTNER_CONTRIBUTION_TRANSFER) that records how
+    much of the contribution covered shared house costs and how much remains as
+    a partner equity claim. The cross-actor cash transfer itself is settled
+    through the obligation pipeline (`ObligationType.PARTNER_CONTRIBUTION`) by
+    the engine, not by this helper — the partner's failure to fund the
+    contribution is a real-world failure mode and produces a FAILED rollout.
+    """
     contribution_used_usd = np.minimum(instruction.amount_usd, house_costs_usd)
     unallocated_excess_usd = np.maximum(0.0, instruction.amount_usd - contribution_used_usd)
     house_cost_share = np.divide(
@@ -351,32 +361,6 @@ def apply_partner_house_cost_contribution(
     principal_credit_usd = mortgage_principal_usd * house_cost_share
     owner_principal_usd = np.maximum(0.0, mortgage_principal_usd - principal_credit_usd)
     journal_entries = (
-        JournalEntryBatch(
-            journal_entry_type=JournalEntryType.PARTNER_CONTRIBUTION,
-            cause_type=AccountingCauseType.POLICY_DECISION,
-            cause_id_prefix=f"policy:{instruction.policy_id}:partner_contribution_transfer",
-            actor_id=instruction.actor_id,
-            policy_id=instruction.policy_id,
-            description="partner contribution cash transfer",
-            postings=(
-                PostingBatch(
-                    role=ChartAccountRole.CHECKING_CASH,
-                    side=PostingSide.DEBIT,
-                    amount_usd=instruction.amount_usd,
-                    actor_id=instruction.recipient_actor_id,
-                    counterparty_actor_id=instruction.actor_id,
-                    property_id=property_id,
-                ),
-                PostingBatch(
-                    role=ChartAccountRole.CHECKING_CASH,
-                    side=PostingSide.CREDIT,
-                    amount_usd=instruction.amount_usd,
-                    actor_id=instruction.actor_id,
-                    counterparty_actor_id=instruction.recipient_actor_id,
-                    property_id=property_id,
-                ),
-            ),
-        ),
         JournalEntryBatch(
             journal_entry_type=JournalEntryType.OWNERSHIP_CLAIM_ACCRUAL,
             cause_type=AccountingCauseType.ACCOUNTING_PROCESS,
@@ -595,6 +579,23 @@ def apply_property_operating_cash_flows(
     rental_management_fee_usd: np.ndarray,
     rental_leasing_fee_usd: np.ndarray,
 ) -> PropertyOperatingCashFlowApplication:
+    """Emit the property operating-cash-flow JE for rental income net of rental fees.
+
+    Property tax, HOA, insurance, and maintenance are required cash demands that
+    settle through the obligation pipeline (`_settle_required_cash_obligations`),
+    not directly through this JE. Each of those four cost lines becomes its own
+    `ObligationType` variant so the trace explains who owes what to whom and the
+    actor's funding-policy chain can attempt to rescue a shortfall. The cost
+    arrays remain on the returned application object so the engine can drive the
+    obligation calls and downstream tax/equity math.
+
+    Rental income (a receipt, not a demand) and rental management/leasing fees
+    (which scale with collected rent and are netted against it in the same
+    operating sweep) stay on the direct JE. The returned
+    `property_carrying_cost_usd` includes all six cost lines for reporting
+    parity; `net_operating_cash_flow_usd` is the portion of the carrying cost
+    handled by this JE (rental income minus rental fees).
+    """
     property_carrying_cost_usd = (
         property_tax_usd
         + hoa_usd
@@ -603,7 +604,8 @@ def apply_property_operating_cash_flows(
         + rental_management_fee_usd
         + rental_leasing_fee_usd
     )
-    net_operating_cash_flow_usd = rental_income_usd - property_carrying_cost_usd
+    direct_carrying_cost_usd = rental_management_fee_usd + rental_leasing_fee_usd
+    net_operating_cash_flow_usd = rental_income_usd - direct_carrying_cost_usd
     journal_entries = (
         JournalEntryBatch(
             journal_entry_type=JournalEntryType.PROPERTY_OPERATING,
@@ -626,27 +628,6 @@ def apply_property_operating_cash_flows(
                     actor_id=actor_id,
                 ),
                 PostingBatch(
-                    role=ChartAccountRole.PROPERTY_TAX_EXPENSE,
-                    side=PostingSide.DEBIT,
-                    amount_usd=property_tax_usd,
-                    actor_id=actor_id,
-                ),
-                PostingBatch(
-                    role=ChartAccountRole.HOA_EXPENSE, side=PostingSide.DEBIT, amount_usd=hoa_usd, actor_id=actor_id
-                ),
-                PostingBatch(
-                    role=ChartAccountRole.INSURANCE_EXPENSE,
-                    side=PostingSide.DEBIT,
-                    amount_usd=insurance_usd,
-                    actor_id=actor_id,
-                ),
-                PostingBatch(
-                    role=ChartAccountRole.MAINTENANCE_EXPENSE,
-                    side=PostingSide.DEBIT,
-                    amount_usd=maintenance_usd,
-                    actor_id=actor_id,
-                ),
-                PostingBatch(
                     role=ChartAccountRole.RENTAL_MANAGEMENT_FEE_EXPENSE,
                     side=PostingSide.DEBIT,
                     amount_usd=rental_management_fee_usd,
@@ -661,7 +642,7 @@ def apply_property_operating_cash_flows(
                 PostingBatch(
                     role=ChartAccountRole.CHECKING_CASH,
                     side=PostingSide.CREDIT,
-                    amount_usd=property_carrying_cost_usd,
+                    amount_usd=direct_carrying_cost_usd,
                     actor_id=actor_id,
                 ),
             ),

--- a/augur/core/policy_runtime_test.py
+++ b/augur/core/policy_runtime_test.py
@@ -183,17 +183,12 @@ def test_partner_contribution_instruction_applies_house_costs_and_principal_cred
     np.testing.assert_allclose(result.house_cost_share, [0.0, 0.5, 1.0])
     np.testing.assert_allclose(result.principal_credit_usd, [0.0, 200.0, 500.0])
     np.testing.assert_allclose(result.owner_principal_usd, [0.0, 200.0, 0.0])
-    assert [entry.journal_entry_type for entry in result.journal_entries] == [
-        JournalEntryType.PARTNER_CONTRIBUTION,
-        JournalEntryType.OWNERSHIP_CLAIM_ACCRUAL,
-    ]
-    transfer, allocation = result.journal_entries
-    np.testing.assert_allclose(
-        _posting_amount(transfer, ChartAccountRole.CHECKING_CASH, PostingSide.DEBIT), [0.0, 1_000.0, 3_000.0]
-    )
-    np.testing.assert_allclose(
-        _posting_amount(transfer, ChartAccountRole.CHECKING_CASH, PostingSide.CREDIT), [0.0, 1_000.0, 3_000.0]
-    )
+    # The cross-actor cash transfer is owned by the obligation pipeline
+    # (ObligationType.PARTNER_CONTRIBUTION). This helper only emits the
+    # allocation entry mapping the contribution to PARTNER_CONTRIBUTION_USED /
+    # PARTNER_UNALLOCATED_CLAIM / PARTNER_CONTRIBUTION_TRANSFER.
+    assert [entry.journal_entry_type for entry in result.journal_entries] == [JournalEntryType.OWNERSHIP_CLAIM_ACCRUAL]
+    allocation = result.journal_entries[0]
     np.testing.assert_allclose(
         _posting_amount(allocation, ChartAccountRole.PARTNER_CONTRIBUTION_USED, PostingSide.DEBIT),
         [0.0, 1_000.0, 2_000.0],
@@ -201,6 +196,12 @@ def test_partner_contribution_instruction_applies_house_costs_and_principal_cred
     np.testing.assert_allclose(
         _posting_amount(allocation, ChartAccountRole.PARTNER_UNALLOCATED_CLAIM, PostingSide.DEBIT), [0.0, 0.0, 1_000.0]
     )
+    np.testing.assert_allclose(
+        _posting_amount(allocation, ChartAccountRole.PARTNER_CONTRIBUTION_TRANSFER, PostingSide.CREDIT),
+        [0.0, 1_000.0, 3_000.0],
+    )
+    posted_roles = {posting.role for posting in allocation.postings}
+    assert ChartAccountRole.CHECKING_CASH not in posted_roles
 
 
 def test_partner_ownership_accrual_applies_freeze_and_records_ledgers() -> None:
@@ -294,6 +295,9 @@ def test_partner_ownership_aggregate_emits_owner_journal_and_snapshots() -> None
 
 
 def test_property_operating_cash_flow_application_records_balanced_journal() -> None:
+    """The operating JE handles rental income net of rental fees; property tax,
+    HOA, insurance, and maintenance are routed through the obligation pipeline
+    by the engine and do not appear on this JE."""
     result = apply_property_operating_cash_flows(
         actor_id="alpha",
         policy_id="property_operating_cash_flow",
@@ -308,8 +312,11 @@ def test_property_operating_cash_flow_application_records_balanced_journal() -> 
 
     assert result.actor_id == "alpha"
     assert result.policy_id == "property_operating_cash_flow"
+    # Carrying cost still aggregates all six cost lines for reporting parity.
     np.testing.assert_allclose(result.property_carrying_cost_usd, [0.0, 442.0])
-    np.testing.assert_allclose(result.net_operating_cash_flow_usd, [0.0, 1_458.0])
+    # net_operating_cash_flow only nets rental income against the direct rental
+    # fees; the obligation-routed cost lines are deducted elsewhere.
+    np.testing.assert_allclose(result.net_operating_cash_flow_usd, [0.0, 1_708.0])
     assert len(result.journal_entries) == 1
     journal = result.journal_entries[0]
     assert journal.journal_entry_type is JournalEntryType.PROPERTY_OPERATING
@@ -320,11 +327,21 @@ def test_property_operating_cash_flow_application_records_balanced_journal() -> 
         _posting_amount(journal, ChartAccountRole.CHECKING_CASH, PostingSide.DEBIT), [0.0, 1_900.0]
     )
     np.testing.assert_allclose(
-        _posting_amount(journal, ChartAccountRole.PROPERTY_TAX_EXPENSE, PostingSide.DEBIT), [0.0, 100.0]
+        _posting_amount(journal, ChartAccountRole.RENTAL_MANAGEMENT_FEE_EXPENSE, PostingSide.DEBIT), [0.0, 152.0]
     )
     np.testing.assert_allclose(
         _posting_amount(journal, ChartAccountRole.RENTAL_LEASING_FEE_EXPENSE, PostingSide.DEBIT), [0.0, 40.0]
     )
+    np.testing.assert_allclose(
+        _posting_amount(journal, ChartAccountRole.CHECKING_CASH, PostingSide.CREDIT), [0.0, 192.0]
+    )
+    # Property tax / HOA / insurance / maintenance no longer appear on this JE
+    # (they are emitted by the obligation pipeline by the engine).
+    posted_roles = {posting.role for posting in journal.postings}
+    assert ChartAccountRole.PROPERTY_TAX_EXPENSE not in posted_roles
+    assert ChartAccountRole.HOA_EXPENSE not in posted_roles
+    assert ChartAccountRole.INSURANCE_EXPENSE not in posted_roles
+    assert ChartAccountRole.MAINTENANCE_EXPENSE not in posted_roles
 
 
 def test_private_equity_fixed_rule_uses_opportunity_and_records_ledger() -> None:

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -124,6 +124,11 @@ PROPERTY_OPERATING_CASH_FLOW_POLICY_ID = "property_operating_cash_flow"
 PROPERTY_SALE_SETTLEMENT_POLICY_ID = "property_sale_settlement"
 ANNUAL_TAX_ACCOUNTING_POLICY_ID = "annual_tax_accounting"
 SPECIAL_ASSESSMENT_POLICY_ID = "special_assessment"
+PROPERTY_TAX_POLICY_ID = "property_tax_obligation"
+HOA_DUES_POLICY_ID = "hoa_dues_obligation"
+INSURANCE_POLICY_ID = "insurance_premium_obligation"
+MAINTENANCE_POLICY_ID = "maintenance_obligation"
+PARTNER_CONTRIBUTION_POLICY_ID = "partner_contribution_obligation"
 
 
 @dataclass(frozen=True)
@@ -1367,6 +1372,15 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
     mortgage_interest = mortgage_interest * property_live_mask
     mortgage_principal = mortgage_principal * property_live_mask
     net_property_cash_flow = property_cash_flow.net_property_cash_flow_usd * property_live_mask
+    # Per-line cost arrays settle through the obligation pipeline (in-loop, before
+    # within-month policies) so each carrying-cost line records its own
+    # obligation/settlement/funding-decision rows on the trace. Masking out
+    # post-sale months ensures the obligation amount is zero once the property is
+    # sold.
+    property_tax_obligation_due = property_cash_flow.property_tax_usd * property_live_mask
+    hoa_obligation_due = property_cash_flow.hoa_usd * property_live_mask
+    insurance_obligation_due = property_cash_flow.insurance_usd * property_live_mask
+    maintenance_obligation_due = property_cash_flow.maintenance_usd * property_live_mask
     home_equity = property_value - mortgage_balance
     partner_equity = _partner_equity_arrays(
         scenario,
@@ -1458,12 +1472,100 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         mortgage_balance_usd=mortgage_balance[:, 0],
     )
 
+    primary_owner_actor_id = _primary_owner_actor_id(scenario)
+    primary_owner_funding_sources = _ObligationFundingSources.for_actor(scenario, actor_id=primary_owner_actor_id)
+    property_cost_obligation_specs: tuple[tuple[np.ndarray, _CashDebitObligationKind, str, str], ...] = (
+        (
+            property_tax_obligation_due,
+            _CashDebitObligationKind(
+                obligation_type=ObligationType.PROPERTY_TAX, expense_role=ChartAccountRole.PROPERTY_TAX_EXPENSE
+            ),
+            "property_tax_authority",
+            PROPERTY_TAX_POLICY_ID,
+        ),
+        (
+            hoa_obligation_due,
+            _CashDebitObligationKind(
+                obligation_type=ObligationType.HOA_DUES, expense_role=ChartAccountRole.HOA_EXPENSE
+            ),
+            "hoa",
+            HOA_DUES_POLICY_ID,
+        ),
+        (
+            insurance_obligation_due,
+            _CashDebitObligationKind(
+                obligation_type=ObligationType.INSURANCE_PREMIUM, expense_role=ChartAccountRole.INSURANCE_EXPENSE
+            ),
+            "insurance_carrier",
+            INSURANCE_POLICY_ID,
+        ),
+        (
+            maintenance_obligation_due,
+            _CashDebitObligationKind(
+                obligation_type=ObligationType.MAINTENANCE, expense_role=ChartAccountRole.MAINTENANCE_EXPENSE
+            ),
+            "maintenance_vendor",
+            MAINTENANCE_POLICY_ID,
+        ),
+    )
+
     for month in range(month_count):
         current_cash = current_cash + disposition.net_property_sale_cash_flow_usd[:, month]
         if month > 0:
             current_cash = (
                 current_cash + net_property_cash_flow[:, month] + partner_equity.contribution_used_usd[:, month]
             )
+        # Settle property-cost obligations for this month BEFORE within-month
+        # policies run. This keeps within-month policy decisions (which depend on
+        # current_cash) observing the post-carrying-cost cash balance, matching
+        # the pre-refactor behavior where carrying costs were deducted via
+        # net_property_cash_flow at month start. The settlement function operates
+        # on the (rollout, month) matrices, so we round-trip current_cash and the
+        # remaining-units 1D vectors through the matrices for this month
+        # position.
+        if any(np.any(due[:, month] > 0) for due, _, _, _ in property_cost_obligation_specs):
+            cash[:, month] = current_cash
+            remaining_sp500_units_by_month[:, month] = remaining_sp500_units
+            remaining_sp500_basis_by_month[:, month] = remaining_sp500_basis
+            remaining_crypto_quantity_by_month[:, month] = remaining_crypto_quantity
+            remaining_crypto_basis_by_month[:, month] = remaining_crypto_basis
+            for due, kind, creditor_id, policy_id in property_cost_obligation_specs:
+                if not np.any(due[:, month] > 0):
+                    continue
+                _settle_required_cash_obligation_at_month_position(
+                    market_bundle=market_bundle,
+                    month_position=month,
+                    due_month_index=int(month_index[month]),
+                    policy_steps=policy_steps,
+                    obligation_amount_usd=due[:, month],
+                    obligation_kind=kind,
+                    creditor_id=creditor_id,
+                    source_policy_id=policy_id,
+                    actor_id=primary_owner_actor_id,
+                    sources=primary_owner_funding_sources,
+                    cash_usd=cash,
+                    generic_sp500_value_usd=generic_sp500_value,
+                    remaining_sp500_units_by_month=remaining_sp500_units_by_month,
+                    remaining_sp500_basis_by_month=remaining_sp500_basis_by_month,
+                    crypto_value_usd=crypto_value,
+                    remaining_crypto_quantity_by_month=remaining_crypto_quantity_by_month,
+                    remaining_crypto_basis_by_month=remaining_crypto_basis_by_month,
+                    crypto_sale_usd=crypto_sale_usd,
+                    crypto_sale_basis_usd=crypto_sale_basis_usd,
+                    checking_floor_shortfall_usd=checking_floor_shortfall,
+                    obligations=obligations,
+                    funding_decisions=funding_decisions,
+                    settlement_results=settlement_results,
+                    failure_events=failure_events,
+                    accounting=accounting,
+                    sp500_sale_action_records=sp500_sale_action_records,
+                    crypto_sale_action_records=crypto_sale_action_records,
+                )
+            current_cash = cash[:, month]
+            remaining_sp500_units = remaining_sp500_units_by_month[:, month]
+            remaining_sp500_basis = remaining_sp500_basis_by_month[:, month]
+            remaining_crypto_quantity = remaining_crypto_quantity_by_month[:, month]
+            remaining_crypto_basis = remaining_crypto_basis_by_month[:, month]
 
         private_equity_value_before_sale = (
             initial_private_equity
@@ -1875,6 +1977,31 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             sp500_sale_action_records=sp500_sale_action_records,
             crypto_sale_action_records=crypto_sale_action_records,
         )
+    # Partner contribution obligations: each PartnerEquityAccrualPolicy emits a
+    # required monthly PARTNER_CONTRIBUTION obligation on the contributing actor.
+    # Settlement is a cross-actor transfer (debit owner CHECKING_CASH, credit
+    # partner CHECKING_CASH). The partner's CHECKING_CASH balance is tracked in
+    # its own (rollout, month) array — partners aren't represented in the main
+    # `cash` array (which tracks the primary owner's checking cash). A
+    # contributing-actor shortfall produces a FailureEvent and flips the rollout
+    # to FAILED, mirroring the mortgage/tax/special-assessment paths.
+    _settle_partner_contribution_obligations(
+        scenario=scenario,
+        market_bundle=market_bundle,
+        month_index=month_index,
+        rollout_count=rollout_count,
+        month_count=month_count,
+        policy_steps=policy_steps,
+        partner_equity=partner_equity,
+        owner_actor_id=primary_owner_actor_id,
+        obligations=obligations,
+        funding_decisions=funding_decisions,
+        settlement_results=settlement_results,
+        failure_events=failure_events,
+        accounting=accounting,
+        sp500_sale_action_records=sp500_sale_action_records,
+        crypto_sale_action_records=crypto_sale_action_records,
+    )
     _record_journal_entry_batches(
         accounting,
         month_index=month_index,
@@ -3403,8 +3530,8 @@ class _CashDebitObligationKind:
     against cash on the settlement journal entry.
 
     Used for variants that don't carry their own per-line accounting nuance:
-    property tax, HOA dues, insurance, maintenance, outside rent, special
-    assessment, and partner contribution (contributing-actor side).
+    property tax, HOA dues, insurance, maintenance, outside rent, and special
+    assessment.
 
     `expense_role` is the chart-account role to debit on settlement. The credit
     side is `CHECKING_CASH`. `journal_entry_type` controls how the trace surfaces
@@ -3417,7 +3544,30 @@ class _CashDebitObligationKind:
     required: bool = True
 
 
-_ObligationKind = _AnnualTaxObligationKind | _MortgageObligationKind | _CashDebitObligationKind
+@dataclass(frozen=True)
+class _PartnerContributionObligationKind:
+    """Obligation kind for the contributing actor's monthly equity-building payment.
+
+    The settlement is a cross-actor cash transfer: the contributor's CHECKING_CASH
+    is credited (cash leaves) and the recipient owner's CHECKING_CASH is debited
+    (cash arrives). The owner's receipt is a downstream effect of the contributor
+    funding the obligation — the obligation lives on the contributing actor's
+    books, and a contributing-actor shortfall fails the rollout.
+
+    The cash side is balanced on the settlement JE itself; the engine math
+    separately credits owner cash via `partner_equity.contribution_used_usd` in
+    the month loop, which mirrors the funded amount on the happy path.
+    """
+
+    property_id: str
+    recipient_actor_id: str
+    obligation_type: ObligationType = ObligationType.PARTNER_CONTRIBUTION
+    required: bool = True
+
+
+_ObligationKind = (
+    _AnnualTaxObligationKind | _MortgageObligationKind | _CashDebitObligationKind | _PartnerContributionObligationKind
+)
 
 
 def _year_end_tax_obligation_due_usd(*, month_index: np.ndarray, source_month_tax_due_usd: np.ndarray) -> np.ndarray:
@@ -3482,205 +3632,292 @@ def _settle_required_cash_obligations(
     accounting: AccountingTraceBuilder,
     sp500_sale_action_records: list[Sp500SaleActionRecord],
     crypto_sale_action_records: list[CryptoSaleActionRecord],
+    actor_id: str | None = None,
 ) -> None:
-    obligation_type = obligation_kind.obligation_type
-    actor_id = _primary_owner_actor_id(scenario)
-    cash_source_account = _single_checking_account_source(scenario, actor_id=actor_id)
-    sp500_source_asset = _single_sp500_asset_source(scenario, actor_id=actor_id)
-    crypto_source_id = _crypto_source_holding_id(scenario, actor_id=actor_id)
-    crypto_source_assets = _crypto_asset_sources(scenario, actor_id=actor_id)
-    crypto_source_account_id = crypto_source_assets[0].source_account_id if crypto_source_assets else None
-    crypto_source_symbol = (
-        crypto_source_assets[0].asset_symbol if len(crypto_source_assets) == 1 else "crypto_portfolio"
-    )
+    resolved_actor_id = actor_id if actor_id is not None else _primary_owner_actor_id(scenario)
+    sources = _ObligationFundingSources.for_actor(scenario, actor_id=resolved_actor_id)
     for month_position, due_month_index in enumerate(month_index.tolist()):
-        due = obligation_amount_usd[:, month_position]
-        if not np.any(due > 0):
+        if not np.any(obligation_amount_usd[:, month_position] > 0):
             continue
-
-        paid_from_cash = np.minimum(np.maximum(0.0, cash_usd[:, month_position]), due)
-        remaining_due = np.maximum(0.0, due - paid_from_cash)
-        _record_obligation_cash_funding_decisions(
-            funding_decisions,
-            obligation_type=obligation_type,
-            actor_id=actor_id,
-            month_index=int(due_month_index),
-            obligation_amount_usd=due,
-            available_cash_usd=cash_usd[:, month_position],
-            funded_cash_usd=paid_from_cash,
-            source_account=cash_source_account,
-        )
-
-        for policy_step in policy_steps:
-            if not np.any(remaining_due > 0):
-                break
-            policy = policy_step.policy
-            if not isinstance(policy, CheckingFloorSellPublicStockPolicy):
-                continue
-            for asset_type in policy.sale_asset_preference:
-                if not np.any(remaining_due > 0):
-                    break
-                if asset_type is AssetType.GENERIC_SP500_STOCK:
-                    application = _apply_checking_floor_obligation_funding_policy(
-                        policy_step,
-                        due_usd=due,
-                        remaining_due_usd=remaining_due,
-                        cash_usd=cash_usd[:, month_position],
-                        remaining_units=remaining_sp500_units_by_month[:, month_position],
-                        remaining_basis_usd=remaining_sp500_basis_by_month[:, month_position],
-                        sp500_unit_price_usd=market_bundle.generic_sp500_multipliers[:, month_position],
-                        source_asset=sp500_source_asset,
-                    )
-                    if application is None:
-                        continue
-                    old_units = remaining_sp500_units_by_month[:, month_position].copy()
-                    old_basis = remaining_sp500_basis_by_month[:, month_position].copy()
-                    units_sold = np.maximum(0.0, old_units - application.remaining_units)
-                    basis_sold = np.maximum(0.0, old_basis - application.remaining_basis_usd)
-                    remaining_sp500_units_by_month[:, month_position:] = np.maximum(
-                        0.0, remaining_sp500_units_by_month[:, month_position:] - units_sold[:, None]
-                    )
-                    remaining_sp500_basis_by_month[:, month_position:] = np.maximum(
-                        0.0, remaining_sp500_basis_by_month[:, month_position:] - basis_sold[:, None]
-                    )
-                    generic_sp500_value_usd[:, month_position:] = (
-                        remaining_sp500_units_by_month[:, month_position:]
-                        * market_bundle.generic_sp500_multipliers[:, month_position:]
-                    )
-                    cash_usd[:, month_position:] = cash_usd[:, month_position:] + application.sale_usd[:, None]
-                    remaining_due = application.remaining_due_usd
-                    checking_floor_shortfall_usd[:, month_position] = np.maximum(
-                        checking_floor_shortfall_usd[:, month_position], remaining_due
-                    )
-                    _record_obligation_sale_funding_decisions(
-                        funding_decisions,
-                        obligation_type=obligation_type,
-                        actor_id=actor_id,
-                        month_index=int(due_month_index),
-                        policy_step=application.policy_step,
-                        obligation_amount_usd=due,
-                        requested_sale_usd=application.instruction.requested_amount_usd,
-                        funded_cash_usd=application.funded_cash_usd,
-                        shortfall_usd=application.shortfall_usd,
-                        source_asset=sp500_source_asset,
-                    )
-                    sp500_sale_action_records.append(
-                        Sp500SaleActionRecord(
-                            month_position=month_position,
-                            month_index=int(due_month_index),
-                            policy=application.policy_step.policy,
-                            cause_id_prefix=(
-                                f"policy:{application.policy_step.policy.policy_id}:"
-                                f"{obligation_type.value}:funding_sale"
-                            ),
-                            amount_usd=application.sale_usd,
-                            basis_usd=basis_sold,
-                            shortfall_usd=remaining_due,
-                        )
-                    )
-                elif asset_type is AssetType.CRYPTO:
-                    crypto_application = _apply_crypto_checking_floor_obligation_funding_policy(
-                        policy_step,
-                        due_usd=due,
-                        remaining_due_usd=remaining_due,
-                        cash_usd=cash_usd[:, month_position],
-                        remaining_quantity=remaining_crypto_quantity_by_month[:, month_position],
-                        remaining_basis_usd=remaining_crypto_basis_by_month[:, month_position],
-                        crypto_unit_price_usd=market_bundle.crypto_value_multipliers[:, month_position],
-                        source_asset_id=crypto_source_id,
-                    )
-                    if crypto_application is None:
-                        continue
-                    old_quantity = remaining_crypto_quantity_by_month[:, month_position].copy()
-                    old_basis = remaining_crypto_basis_by_month[:, month_position].copy()
-                    quantity_sold = np.maximum(0.0, old_quantity - crypto_application.remaining_quantity)
-                    basis_sold = np.maximum(0.0, old_basis - crypto_application.remaining_basis_usd)
-                    remaining_crypto_quantity_by_month[:, month_position:] = np.maximum(
-                        0.0, remaining_crypto_quantity_by_month[:, month_position:] - quantity_sold[:, None]
-                    )
-                    remaining_crypto_basis_by_month[:, month_position:] = np.maximum(
-                        0.0, remaining_crypto_basis_by_month[:, month_position:] - basis_sold[:, None]
-                    )
-                    crypto_value_usd[:, month_position:] = (
-                        remaining_crypto_quantity_by_month[:, month_position:]
-                        * market_bundle.crypto_value_multipliers[:, month_position:]
-                    )
-                    cash_usd[:, month_position:] = cash_usd[:, month_position:] + crypto_application.sale_usd[:, None]
-                    crypto_sale_usd[:, month_position] = (
-                        crypto_sale_usd[:, month_position] + crypto_application.sale_usd
-                    )
-                    crypto_sale_basis_usd[:, month_position] = crypto_sale_basis_usd[:, month_position] + basis_sold
-                    remaining_due = crypto_application.remaining_due_usd
-                    checking_floor_shortfall_usd[:, month_position] = np.maximum(
-                        checking_floor_shortfall_usd[:, month_position], remaining_due
-                    )
-                    _record_obligation_crypto_sale_funding_decisions(
-                        funding_decisions,
-                        obligation_type=obligation_type,
-                        actor_id=actor_id,
-                        month_index=int(due_month_index),
-                        policy_step=policy_step,
-                        obligation_amount_usd=due,
-                        requested_sale_usd=crypto_application.instruction.requested_amount_usd,
-                        funded_cash_usd=crypto_application.funded_cash_usd,
-                        shortfall_usd=crypto_application.shortfall_usd,
-                        source_asset_id=crypto_source_id,
-                        source_account_id=crypto_source_account_id,
-                    )
-                    crypto_sale_action_records.append(
-                        CryptoSaleActionRecord(
-                            month_position=month_position,
-                            month_index=int(due_month_index),
-                            policy=policy,
-                            cause_id_prefix=(f"policy:{policy.policy_id}:{obligation_type.value}:funding_crypto_sale"),
-                            source_asset_id=crypto_source_id,
-                            asset_symbol=crypto_source_symbol,
-                            amount_usd=crypto_application.sale_usd,
-                            basis_usd=basis_sold,
-                            quantity_sold=quantity_sold,
-                            shortfall_usd=remaining_due.copy(),
-                        )
-                    )
-                else:
-                    raise ValueError(
-                        f"unsupported sale_asset_preference entry {asset_type} for CheckingFloorSellPublicStockPolicy"
-                    )
-
-        amount_paid = np.minimum(due, np.maximum(0.0, cash_usd[:, month_position]))
-        unpaid = np.maximum(0.0, due - amount_paid)
-        cash_usd[:, month_position:] = cash_usd[:, month_position:] - amount_paid[:, None]
-        _record_obligation_accrual_and_settlement_entries(
-            accounting,
-            obligation_kind=obligation_kind,
+        _settle_required_cash_obligation_at_month_position(
+            market_bundle=market_bundle,
             month_position=month_position,
-            month_index=int(due_month_index),
-            actor_id=actor_id,
-            source_policy_id=source_policy_id,
-            due_usd=due,
-            amount_paid_usd=amount_paid,
-        )
-        _record_unfunded_obligation_decisions(
-            funding_decisions,
-            obligation_type=obligation_type,
-            actor_id=actor_id,
-            month_index=int(due_month_index),
-            obligation_amount_usd=due,
-            unpaid_amount_usd=unpaid,
-        )
-        _record_obligation_settlement_rows(
-            obligations,
-            settlement_results,
-            failure_events,
-            obligation_type=obligation_type,
-            actor_id=actor_id,
+            due_month_index=int(due_month_index),
+            policy_steps=policy_steps,
+            obligation_amount_usd=obligation_amount_usd[:, month_position],
+            obligation_kind=obligation_kind,
             creditor_id=creditor_id,
             source_policy_id=source_policy_id,
-            month_index=int(due_month_index),
-            amount_due_usd=due,
-            amount_paid_usd=amount_paid,
-            unpaid_amount_usd=unpaid,
-            required=obligation_kind.required,
+            actor_id=resolved_actor_id,
+            sources=sources,
+            cash_usd=cash_usd,
+            generic_sp500_value_usd=generic_sp500_value_usd,
+            remaining_sp500_units_by_month=remaining_sp500_units_by_month,
+            remaining_sp500_basis_by_month=remaining_sp500_basis_by_month,
+            crypto_value_usd=crypto_value_usd,
+            remaining_crypto_quantity_by_month=remaining_crypto_quantity_by_month,
+            remaining_crypto_basis_by_month=remaining_crypto_basis_by_month,
+            crypto_sale_usd=crypto_sale_usd,
+            crypto_sale_basis_usd=crypto_sale_basis_usd,
+            checking_floor_shortfall_usd=checking_floor_shortfall_usd,
+            obligations=obligations,
+            funding_decisions=funding_decisions,
+            settlement_results=settlement_results,
+            failure_events=failure_events,
+            accounting=accounting,
+            sp500_sale_action_records=sp500_sale_action_records,
+            crypto_sale_action_records=crypto_sale_action_records,
         )
+
+
+@dataclass(frozen=True)
+class _ObligationFundingSources:
+    """Per-actor lookups for cash/SP500/crypto sources used in obligation settlement.
+
+    Cached once at the top of `_settle_required_cash_obligations` so the per-month
+    helper does not re-scan the balance sheet for every month/obligation pair.
+    """
+
+    cash_source_account: AccountBalance | None
+    sp500_source_asset: GenericSp500StockPosition | None
+    crypto_source_id: str
+    crypto_source_account_id: str | None
+    crypto_source_symbol: str
+
+    @classmethod
+    def for_actor(cls, scenario: Scenario, *, actor_id: str) -> _ObligationFundingSources:
+        crypto_source_assets = _crypto_asset_sources(scenario, actor_id=actor_id)
+        return cls(
+            cash_source_account=_single_checking_account_source(scenario, actor_id=actor_id),
+            sp500_source_asset=_single_sp500_asset_source(scenario, actor_id=actor_id),
+            crypto_source_id=_crypto_source_holding_id(scenario, actor_id=actor_id),
+            crypto_source_account_id=crypto_source_assets[0].source_account_id if crypto_source_assets else None,
+            crypto_source_symbol=(
+                crypto_source_assets[0].asset_symbol if len(crypto_source_assets) == 1 else "crypto_portfolio"
+            ),
+        )
+
+
+def _settle_required_cash_obligation_at_month_position(
+    *,
+    market_bundle: MarketBundle,
+    month_position: int,
+    due_month_index: int,
+    policy_steps: tuple[ActorPolicyStep[Policy], ...],
+    obligation_amount_usd: np.ndarray,
+    obligation_kind: _ObligationKind,
+    creditor_id: str,
+    source_policy_id: str,
+    actor_id: str,
+    sources: _ObligationFundingSources,
+    cash_usd: np.ndarray,
+    generic_sp500_value_usd: np.ndarray,
+    remaining_sp500_units_by_month: np.ndarray,
+    remaining_sp500_basis_by_month: np.ndarray,
+    crypto_value_usd: np.ndarray,
+    remaining_crypto_quantity_by_month: np.ndarray,
+    remaining_crypto_basis_by_month: np.ndarray,
+    crypto_sale_usd: np.ndarray,
+    crypto_sale_basis_usd: np.ndarray,
+    checking_floor_shortfall_usd: np.ndarray,
+    obligations: list[Obligation],
+    funding_decisions: list[FundingDecision],
+    settlement_results: list[SettlementResult],
+    failure_events: list[FailureEvent],
+    accounting: AccountingTraceBuilder,
+    sp500_sale_action_records: list[Sp500SaleActionRecord],
+    crypto_sale_action_records: list[CryptoSaleActionRecord],
+) -> None:
+    """Settle one obligation at a single month position.
+
+    Mutates `cash_usd` (and the units/basis/sale tracking matrices) in place from
+    `month_position` forward — callers that drive this per-month inside the engine's
+    month loop must ensure the matrices already carry the start-of-month state at
+    `month_position`. The settlement records its trace rows (obligation,
+    settlement_result, funding_decision, failure_event) for this month.
+    """
+    obligation_type = obligation_kind.obligation_type
+    due = obligation_amount_usd
+    paid_from_cash = np.minimum(np.maximum(0.0, cash_usd[:, month_position]), due)
+    remaining_due = np.maximum(0.0, due - paid_from_cash)
+    _record_obligation_cash_funding_decisions(
+        funding_decisions,
+        obligation_type=obligation_type,
+        actor_id=actor_id,
+        month_index=due_month_index,
+        obligation_amount_usd=due,
+        available_cash_usd=cash_usd[:, month_position],
+        funded_cash_usd=paid_from_cash,
+        source_account=sources.cash_source_account,
+    )
+
+    for policy_step in policy_steps:
+        if not np.any(remaining_due > 0):
+            break
+        policy = policy_step.policy
+        if not isinstance(policy, CheckingFloorSellPublicStockPolicy):
+            continue
+        for asset_type in policy.sale_asset_preference:
+            if not np.any(remaining_due > 0):
+                break
+            if asset_type is AssetType.GENERIC_SP500_STOCK:
+                application = _apply_checking_floor_obligation_funding_policy(
+                    policy_step,
+                    due_usd=due,
+                    remaining_due_usd=remaining_due,
+                    cash_usd=cash_usd[:, month_position],
+                    remaining_units=remaining_sp500_units_by_month[:, month_position],
+                    remaining_basis_usd=remaining_sp500_basis_by_month[:, month_position],
+                    sp500_unit_price_usd=market_bundle.generic_sp500_multipliers[:, month_position],
+                    source_asset=sources.sp500_source_asset,
+                )
+                if application is None:
+                    continue
+                old_units = remaining_sp500_units_by_month[:, month_position].copy()
+                old_basis = remaining_sp500_basis_by_month[:, month_position].copy()
+                units_sold = np.maximum(0.0, old_units - application.remaining_units)
+                basis_sold = np.maximum(0.0, old_basis - application.remaining_basis_usd)
+                remaining_sp500_units_by_month[:, month_position:] = np.maximum(
+                    0.0, remaining_sp500_units_by_month[:, month_position:] - units_sold[:, None]
+                )
+                remaining_sp500_basis_by_month[:, month_position:] = np.maximum(
+                    0.0, remaining_sp500_basis_by_month[:, month_position:] - basis_sold[:, None]
+                )
+                generic_sp500_value_usd[:, month_position:] = (
+                    remaining_sp500_units_by_month[:, month_position:]
+                    * market_bundle.generic_sp500_multipliers[:, month_position:]
+                )
+                cash_usd[:, month_position:] = cash_usd[:, month_position:] + application.sale_usd[:, None]
+                remaining_due = application.remaining_due_usd
+                checking_floor_shortfall_usd[:, month_position] = np.maximum(
+                    checking_floor_shortfall_usd[:, month_position], remaining_due
+                )
+                _record_obligation_sale_funding_decisions(
+                    funding_decisions,
+                    obligation_type=obligation_type,
+                    actor_id=actor_id,
+                    month_index=due_month_index,
+                    policy_step=application.policy_step,
+                    obligation_amount_usd=due,
+                    requested_sale_usd=application.instruction.requested_amount_usd,
+                    funded_cash_usd=application.funded_cash_usd,
+                    shortfall_usd=application.shortfall_usd,
+                    source_asset=sources.sp500_source_asset,
+                )
+                sp500_sale_action_records.append(
+                    Sp500SaleActionRecord(
+                        month_position=month_position,
+                        month_index=due_month_index,
+                        policy=application.policy_step.policy,
+                        cause_id_prefix=(
+                            f"policy:{application.policy_step.policy.policy_id}:{obligation_type.value}:funding_sale"
+                        ),
+                        amount_usd=application.sale_usd,
+                        basis_usd=basis_sold,
+                        shortfall_usd=remaining_due,
+                    )
+                )
+            elif asset_type is AssetType.CRYPTO:
+                crypto_application = _apply_crypto_checking_floor_obligation_funding_policy(
+                    policy_step,
+                    due_usd=due,
+                    remaining_due_usd=remaining_due,
+                    cash_usd=cash_usd[:, month_position],
+                    remaining_quantity=remaining_crypto_quantity_by_month[:, month_position],
+                    remaining_basis_usd=remaining_crypto_basis_by_month[:, month_position],
+                    crypto_unit_price_usd=market_bundle.crypto_value_multipliers[:, month_position],
+                    source_asset_id=sources.crypto_source_id,
+                )
+                if crypto_application is None:
+                    continue
+                old_quantity = remaining_crypto_quantity_by_month[:, month_position].copy()
+                old_basis = remaining_crypto_basis_by_month[:, month_position].copy()
+                quantity_sold = np.maximum(0.0, old_quantity - crypto_application.remaining_quantity)
+                basis_sold = np.maximum(0.0, old_basis - crypto_application.remaining_basis_usd)
+                remaining_crypto_quantity_by_month[:, month_position:] = np.maximum(
+                    0.0, remaining_crypto_quantity_by_month[:, month_position:] - quantity_sold[:, None]
+                )
+                remaining_crypto_basis_by_month[:, month_position:] = np.maximum(
+                    0.0, remaining_crypto_basis_by_month[:, month_position:] - basis_sold[:, None]
+                )
+                crypto_value_usd[:, month_position:] = (
+                    remaining_crypto_quantity_by_month[:, month_position:]
+                    * market_bundle.crypto_value_multipliers[:, month_position:]
+                )
+                cash_usd[:, month_position:] = cash_usd[:, month_position:] + crypto_application.sale_usd[:, None]
+                crypto_sale_usd[:, month_position] = crypto_sale_usd[:, month_position] + crypto_application.sale_usd
+                crypto_sale_basis_usd[:, month_position] = crypto_sale_basis_usd[:, month_position] + basis_sold
+                remaining_due = crypto_application.remaining_due_usd
+                checking_floor_shortfall_usd[:, month_position] = np.maximum(
+                    checking_floor_shortfall_usd[:, month_position], remaining_due
+                )
+                _record_obligation_crypto_sale_funding_decisions(
+                    funding_decisions,
+                    obligation_type=obligation_type,
+                    actor_id=actor_id,
+                    month_index=due_month_index,
+                    policy_step=policy_step,
+                    obligation_amount_usd=due,
+                    requested_sale_usd=crypto_application.instruction.requested_amount_usd,
+                    funded_cash_usd=crypto_application.funded_cash_usd,
+                    shortfall_usd=crypto_application.shortfall_usd,
+                    source_asset_id=sources.crypto_source_id,
+                    source_account_id=sources.crypto_source_account_id,
+                )
+                crypto_sale_action_records.append(
+                    CryptoSaleActionRecord(
+                        month_position=month_position,
+                        month_index=due_month_index,
+                        policy=policy,
+                        cause_id_prefix=(f"policy:{policy.policy_id}:{obligation_type.value}:funding_crypto_sale"),
+                        source_asset_id=sources.crypto_source_id,
+                        asset_symbol=sources.crypto_source_symbol,
+                        amount_usd=crypto_application.sale_usd,
+                        basis_usd=basis_sold,
+                        quantity_sold=quantity_sold,
+                        shortfall_usd=remaining_due.copy(),
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"unsupported sale_asset_preference entry {asset_type} for CheckingFloorSellPublicStockPolicy"
+                )
+
+    amount_paid = np.minimum(due, np.maximum(0.0, cash_usd[:, month_position]))
+    unpaid = np.maximum(0.0, due - amount_paid)
+    cash_usd[:, month_position:] = cash_usd[:, month_position:] - amount_paid[:, None]
+    _record_obligation_accrual_and_settlement_entries(
+        accounting,
+        obligation_kind=obligation_kind,
+        month_position=month_position,
+        month_index=due_month_index,
+        actor_id=actor_id,
+        source_policy_id=source_policy_id,
+        due_usd=due,
+        amount_paid_usd=amount_paid,
+    )
+    _record_unfunded_obligation_decisions(
+        funding_decisions,
+        obligation_type=obligation_type,
+        actor_id=actor_id,
+        month_index=due_month_index,
+        obligation_amount_usd=due,
+        unpaid_amount_usd=unpaid,
+    )
+    _record_obligation_settlement_rows(
+        obligations,
+        settlement_results,
+        failure_events,
+        obligation_type=obligation_type,
+        actor_id=actor_id,
+        creditor_id=creditor_id,
+        source_policy_id=source_policy_id,
+        month_index=due_month_index,
+        amount_due_usd=due,
+        amount_paid_usd=amount_paid,
+        unpaid_amount_usd=unpaid,
+        required=obligation_kind.required,
+    )
 
 
 def _record_obligation_accrual_and_settlement_entries(
@@ -3771,6 +4008,42 @@ def _record_obligation_accrual_and_settlement_entries(
                         side=PostingSide.CREDIT,
                         amount_usd=amount_paid_usd,
                         actor_id=actor_id,
+                    ),
+                ),
+            ),
+        )
+        return
+    if isinstance(obligation_kind, _PartnerContributionObligationKind):
+        # Settlement is a balanced cross-actor cash transfer: the contributing
+        # actor's cash is credited (cash leaves) and the recipient owner's cash
+        # is debited (cash arrives). Each posting carries a counterparty actor
+        # and the property id so the ledger explains the transfer.
+        accounting.record_entry(
+            month_index=month_index,
+            entry=JournalEntryBatch(
+                journal_entry_type=JournalEntryType.PARTNER_CONTRIBUTION,
+                cause_type=AccountingCauseType.OBLIGATION_SETTLEMENT,
+                cause_id_prefix=f"policy:{source_policy_id}:{obligation_type.value}:settlement",
+                obligation_id_prefix=obligation_type.value,
+                actor_id=actor_id,
+                policy_id=source_policy_id,
+                description=obligation_type.value,
+                postings=(
+                    PostingBatch(
+                        role=ChartAccountRole.CHECKING_CASH,
+                        side=PostingSide.DEBIT,
+                        amount_usd=amount_paid_usd,
+                        actor_id=obligation_kind.recipient_actor_id,
+                        counterparty_actor_id=actor_id,
+                        property_id=obligation_kind.property_id,
+                    ),
+                    PostingBatch(
+                        role=ChartAccountRole.CHECKING_CASH,
+                        side=PostingSide.CREDIT,
+                        amount_usd=amount_paid_usd,
+                        actor_id=actor_id,
+                        counterparty_actor_id=obligation_kind.recipient_actor_id,
+                        property_id=obligation_kind.property_id,
                     ),
                 ),
             ),
@@ -4778,6 +5051,125 @@ def _scenario_hoa_monthly_usd(scenario: Scenario) -> float:
         if isinstance(event, PropertyPurchaseEvent) and event.hoa_monthly_usd is not None:
             return float(event.hoa_monthly_usd)
     return 0.0
+
+
+def _settle_partner_contribution_obligations(
+    *,
+    scenario: Scenario,
+    market_bundle: MarketBundle,
+    month_index: np.ndarray,
+    rollout_count: int,
+    month_count: int,
+    policy_steps: tuple[ActorPolicyStep[Policy], ...],
+    partner_equity: PartnerEquityArrays,
+    owner_actor_id: str,
+    obligations: list[Obligation],
+    funding_decisions: list[FundingDecision],
+    settlement_results: list[SettlementResult],
+    failure_events: list[FailureEvent],
+    accounting: AccountingTraceBuilder,
+    sp500_sale_action_records: list[Sp500SaleActionRecord],
+    crypto_sale_action_records: list[CryptoSaleActionRecord],
+) -> None:
+    """Settle each PartnerEquityAccrualPolicy's monthly contribution as an obligation
+    on the contributing actor.
+
+    Each agreement runs an independent obligation pass keyed on the contributing
+    actor's CHECKING_CASH balance. The settlement journal entry debits the
+    recipient owner's CHECKING_CASH and credits the contributor's CHECKING_CASH
+    (a balanced cross-actor transfer). The contributing actor's failure to fund
+    flips the rollout to FAILED via FailureEvent.
+
+    The owner's cash trajectory is driven by `partner_equity.contribution_used_usd`
+    added in the main month loop; on the happy path the obligation pipeline pays
+    the configured amount in full and the JE cash debit matches the owner-side
+    receipt.
+    """
+    if not partner_equity.agreements:
+        return
+    for agreement in partner_equity.agreements:
+        contributing_actor_id = agreement.policy.actor_id
+        partner_initial_cash = _partner_initial_funding_cash_usd(
+            scenario,
+            actor_id=contributing_actor_id,
+            configured_contribution_total_usd=float(np.max(np.sum(agreement.contribution_usd, axis=1))),
+        )
+        partner_cash = np.full((rollout_count, month_count), partner_initial_cash, dtype="float64")
+        # The contribution_usd matrix carries the configured monthly payment per
+        # month (zero where no payment is configured). Auxiliary state matrices
+        # (sp500 / crypto units / basis / sale tracking, checking-floor
+        # shortfall) are per-partner because they describe the partner's funding
+        # path, not the owner's.
+        partner_sp500_units_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_sp500_basis_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_sp500_value_usd = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_crypto_quantity_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_crypto_basis_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_crypto_value_usd = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_crypto_sale_usd = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_crypto_sale_basis_usd = np.zeros((rollout_count, month_count), dtype="float64")
+        partner_checking_floor_shortfall = np.zeros((rollout_count, month_count), dtype="float64")
+        obligation_kind = _PartnerContributionObligationKind(
+            property_id=agreement.property_id, recipient_actor_id=owner_actor_id
+        )
+        _settle_required_cash_obligations(
+            scenario=scenario,
+            market_bundle=market_bundle,
+            month_index=month_index,
+            policy_steps=policy_steps,
+            obligation_amount_usd=agreement.contribution_usd,
+            obligation_kind=obligation_kind,
+            creditor_id=owner_actor_id,
+            source_policy_id=agreement.policy.policy_id,
+            cash_usd=partner_cash,
+            generic_sp500_value_usd=partner_sp500_value_usd,
+            remaining_sp500_units_by_month=partner_sp500_units_by_month,
+            remaining_sp500_basis_by_month=partner_sp500_basis_by_month,
+            crypto_value_usd=partner_crypto_value_usd,
+            remaining_crypto_quantity_by_month=partner_crypto_quantity_by_month,
+            remaining_crypto_basis_by_month=partner_crypto_basis_by_month,
+            crypto_sale_usd=partner_crypto_sale_usd,
+            crypto_sale_basis_usd=partner_crypto_sale_basis_usd,
+            checking_floor_shortfall_usd=partner_checking_floor_shortfall,
+            obligations=obligations,
+            funding_decisions=funding_decisions,
+            settlement_results=settlement_results,
+            failure_events=failure_events,
+            accounting=accounting,
+            sp500_sale_action_records=sp500_sale_action_records,
+            crypto_sale_action_records=crypto_sale_action_records,
+            actor_id=contributing_actor_id,
+        )
+
+
+def _actor_initial_checking_cash_usd(scenario: Scenario, *, actor_id: str) -> float:
+    return sum(
+        account.balance_usd
+        for account in scenario.initial_balance_sheet.accounts
+        if account.account_type is AccountType.CHECKING and account.owner_actor_id == actor_id
+    )
+
+
+def _partner_initial_funding_cash_usd(
+    scenario: Scenario, *, actor_id: str, configured_contribution_total_usd: float
+) -> float:
+    """Resolve the contributing partner's starting cash for obligation settlement.
+
+    A partner with an explicitly configured CHECKING account funds the
+    obligation strictly from that balance — running out fails the rollout. A
+    partner with no configured account is assumed to fund off-trace (their
+    external income is not modeled), so default to the total configured
+    contribution amount: enough to pay every scheduled month in full. Tests
+    that want to exercise the failure path should configure a partner account
+    with an insufficient balance.
+    """
+    explicit_cash = _actor_initial_checking_cash_usd(scenario, actor_id=actor_id)
+    if any(
+        account.account_type is AccountType.CHECKING and account.owner_actor_id == actor_id
+        for account in scenario.initial_balance_sheet.accounts
+    ):
+        return explicit_cash
+    return configured_contribution_total_usd
 
 
 def _special_assessment_obligation_due_usd(

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -49,6 +49,7 @@ from augur.core.scenario_set import (
     PrivateEquitySalePolicy,
     PrivateEquitySaleRuleType,
     PropertyAssumptions,
+    PropertyPurchaseEvent,
     PropertySaleBasisGainDetail,
     PropertySaleEvent,
     PropertySelection,
@@ -506,7 +507,14 @@ def test_mortgage_shortfall_records_failed_obligation_and_failure_event() -> Non
     assert all(event.unpaid_amount_usd > 0 for event in mortgage_failures)
     status = result.rollout(0).status()
     assert status.status == RolloutStatusType.FAILED
-    assert status.failed_obligation_count == horizon_months
+    # The actor also misses the monthly property tax obligation (SF has a
+    # non-zero property tax) since cash starts at $0. The count is one mortgage
+    # failure + one property-tax failure per month.
+    property_tax_failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("property_tax")
+    )
+    assert len(property_tax_failures) == horizon_months
+    assert status.failed_obligation_count == horizon_months * 2
     assert status.first_failed_obligation_month_index == 1
     assert status.unpaid_obligation_usd > 0
     unfunded = tuple(
@@ -706,6 +714,309 @@ def test_special_assessment_event_fails_rollout_when_unfundable() -> None:
     )
     assert len(unfunded) == 1
     assert unfunded[0].shortfall_usd > 0
+
+
+def _property_obligation_scenario(
+    *,
+    scenario_id: str,
+    initial_cash_usd: float,
+    insurance_annual_usd: float = 0,
+    maintenance_pct: float = 0,
+    hoa_monthly_usd: float = 0,
+    location_id: LocationId = LocationId.SAN_FRANCISCO_CA,
+    purchase_price_usd: float = 500_000,
+    events: tuple = (),
+) -> Scenario:
+    """A minimal property scenario that exercises the property carrying-cost
+    obligation pipeline. Per-line costs (property tax, HOA, insurance,
+    maintenance) settle through `_settle_required_cash_obligations` and may
+    fail the rollout if cash and funding policies cannot cover them.
+
+    `hoa_monthly_usd` is conveyed via a `PropertyPurchaseEvent` (the canonical
+    HOA-monthly knob); 0 means HOA stays at the location default.
+    """
+    purchase_events: tuple = ()
+    if hoa_monthly_usd > 0:
+        purchase_events = (
+            PropertyPurchaseEvent(
+                event_id="purchase", month_index=0, property_id="test_property", hoa_monthly_usd=hoa_monthly_usd
+            ),
+        )
+    return Scenario(
+        scenario_id=scenario_id,
+        label=scenario_id.replace("_", " ").title(),
+        actors=(_simple_actor(),),
+        events=purchase_events + events,
+        property_selection=PropertySelection(
+            property_id="test_property", location_id=location_id, purchase_price_usd=purchase_price_usd
+        ),
+        # Cash financing: no down-payment buy-out, no mortgage obligation.
+        # This isolates the test to the carrying-cost obligation we want to
+        # exercise rather than mixing in mortgage failures.
+        financing=Financing(financing_mode=FinancingMode.CASH),
+        transaction_costs=TransactionCosts(closing_cost_buy_pct=0, closing_cost_sell_pct=0),
+        property_assumptions=PropertyAssumptions(
+            insurance_annual_usd=insurance_annual_usd, maintenance_pct=maintenance_pct
+        ),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking",
+                    account_type=AccountType.CHECKING,
+                    owner_actor_id="alpha",
+                    balance_usd=initial_cash_usd,
+                ),
+            )
+        ),
+    )
+
+
+def test_property_tax_obligation_settles_when_cash_available() -> None:
+    """Happy path: the four property carrying-cost lines (property tax, HOA,
+    insurance, maintenance) now settle as PAID obligations on the trace. The
+    cash trajectory matches the pre-refactor behavior because the in-loop
+    settlement deducts each cost from current_cash at month start (mirroring
+    the prior net_property_cash_flow math)."""
+    scenario = _property_obligation_scenario(
+        scenario_id="property_carrying_costs_paid",
+        initial_cash_usd=600_000,  # enough for $500k cash purchase + carrying costs
+        insurance_annual_usd=1_200,
+        maintenance_pct=1,
+        hoa_monthly_usd=300,
+    )
+    result = _run_scenario(scenario, horizon_months=3)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    # Each of the four cost lines emits one obligation per month-1..horizon
+    # (month 0 zeros out via the engine's first-month carry-cost zeroing).
+    obligation_types_seen = {
+        obligation.obligation_type
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type
+        in {
+            ObligationType.PROPERTY_TAX,
+            ObligationType.HOA_DUES,
+            ObligationType.INSURANCE_PREMIUM,
+            ObligationType.MAINTENANCE,
+        }
+    }
+    assert obligation_types_seen == {
+        ObligationType.PROPERTY_TAX,
+        ObligationType.HOA_DUES,
+        ObligationType.INSURANCE_PREMIUM,
+        ObligationType.MAINTENANCE,
+    }
+    # All carrying-cost obligations PAY when cash is sufficient.
+    for obligation_type in obligation_types_seen:
+        obligations = tuple(
+            obligation for obligation in result.arrays.obligations if obligation.obligation_type is obligation_type
+        )
+        assert {obligation.status for obligation in obligations} == {ObligationStatus.PAID}
+    # No failure events fired.
+    assert tuple(event for event in result.arrays.failure_events) == ()
+    # The ledger postings on the expense roles continue to reflect the actual
+    # cost (now driven by the obligation settlement JE rather than the operating
+    # cash-flow JE). This is the reconciliation contract the existing
+    # `test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface`
+    # guard depends on.
+    assert_allclose(
+        _posting_matrix(result, role=ChartAccountRole.PROPERTY_TAX_EXPENSE, side=PostingSide.DEBIT),
+        result.matrix(ReportMetric.PROPERTY_TAX_USD),
+    )
+    assert_allclose(
+        _posting_matrix(result, role=ChartAccountRole.HOA_EXPENSE, side=PostingSide.DEBIT),
+        result.matrix(ReportMetric.HOA_USD),
+    )
+    assert_allclose(
+        _posting_matrix(result, role=ChartAccountRole.INSURANCE_EXPENSE, side=PostingSide.DEBIT),
+        result.matrix(ReportMetric.INSURANCE_USD),
+    )
+    assert_allclose(
+        _posting_matrix(result, role=ChartAccountRole.MAINTENANCE_EXPENSE, side=PostingSide.DEBIT),
+        result.matrix(ReportMetric.MAINTENANCE_USD),
+    )
+
+
+def test_property_tax_obligation_fails_rollout_when_unfundable() -> None:
+    """Cash-strapped property: monthly property tax can't be paid → PROPERTY_TAX
+    obligation emits UNPAID, FailureEvent fires, rollout flips to FAILED."""
+    scenario = _property_obligation_scenario(
+        scenario_id="property_tax_unfundable",
+        initial_cash_usd=10,  # Far below the monthly property-tax obligation.
+        insurance_annual_usd=0,
+        maintenance_pct=0,
+    )
+    result = _run_scenario(scenario, horizon_months=3)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    property_tax_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.PROPERTY_TAX
+    )
+    # 3 months of unfunded property tax obligations.
+    assert len(property_tax_obligations) == 3
+    assert {obligation.status for obligation in property_tax_obligations} == {ObligationStatus.UNPAID}
+    failures = tuple(event for event in result.arrays.failure_events if event.obligation_id.startswith("property_tax"))
+    assert len(failures) == 3
+    assert all(event.unpaid_amount_usd > 0 for event in failures)
+    unfunded = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("property_tax") and decision.decision_type is FundingDecisionType.UNFUNDED
+    )
+    assert len(unfunded) == 3
+    assert all(decision.shortfall_usd > 0 for decision in unfunded)
+
+
+def test_hoa_dues_obligation_fails_rollout_when_unfundable() -> None:
+    """Cash-strapped property with explicit HOA dues: cash starts at a value
+    that covers property tax for the first month but not the HOA dues. The
+    HOA_DUES obligation flips the rollout to FAILED."""
+    # SF property tax on $100k purchase is small (≈ $100/mo). Hoa monthly $5000
+    # blows past available cash starting in month 1.
+    scenario = _property_obligation_scenario(
+        scenario_id="hoa_dues_unfundable",
+        initial_cash_usd=500,
+        insurance_annual_usd=0,
+        maintenance_pct=0,
+        hoa_monthly_usd=5_000,
+        purchase_price_usd=100_000,
+    )
+    result = _run_scenario(scenario, horizon_months=2)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    hoa_failures = tuple(event for event in result.arrays.failure_events if event.obligation_id.startswith("hoa_dues"))
+    assert len(hoa_failures) >= 1
+    assert all(event.unpaid_amount_usd > 0 for event in hoa_failures)
+    unfunded = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("hoa_dues") and decision.decision_type is FundingDecisionType.UNFUNDED
+    )
+    assert len(unfunded) >= 1
+
+
+def test_insurance_premium_obligation_fails_rollout_when_unfundable() -> None:
+    """Cash-strapped property with very high insurance: the INSURANCE_PREMIUM
+    obligation flips the rollout to FAILED."""
+    scenario = _property_obligation_scenario(
+        scenario_id="insurance_premium_unfundable",
+        initial_cash_usd=100,
+        insurance_annual_usd=120_000,  # $10k/month — far above starting cash.
+        maintenance_pct=0,
+        purchase_price_usd=100_000,
+    )
+    result = _run_scenario(scenario, horizon_months=2)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    insurance_failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("insurance_premium")
+    )
+    assert len(insurance_failures) >= 1
+    assert all(event.unpaid_amount_usd > 0 for event in insurance_failures)
+
+
+def test_maintenance_obligation_fails_rollout_when_unfundable() -> None:
+    """Cash-strapped property with very high maintenance pct: the MAINTENANCE
+    obligation flips the rollout to FAILED."""
+    # Maintenance = property_value * maintenance_pct/100 / 12 per month.
+    # 500k * 50% / 12 ≈ $20,833/month — far above starting cash.
+    scenario = _property_obligation_scenario(
+        scenario_id="maintenance_unfundable",
+        initial_cash_usd=100,
+        insurance_annual_usd=0,
+        maintenance_pct=50,
+        purchase_price_usd=500_000,
+    )
+    result = _run_scenario(scenario, horizon_months=2)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    maintenance_failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("maintenance")
+    )
+    assert len(maintenance_failures) >= 1
+    assert all(event.unpaid_amount_usd > 0 for event in maintenance_failures)
+
+
+def test_partner_contribution_obligation_fails_rollout_when_partner_cannot_fund() -> None:
+    """The contributing partner has an explicitly modeled checking account with
+    insufficient cash to cover the configured contribution. The
+    PARTNER_CONTRIBUTION obligation flips the rollout to FAILED.
+
+    When a partner has *any* configured CHECKING account, the obligation
+    settles strictly against that balance — running out fails the rollout.
+    Partners with no configured account default to off-trace funding (legacy
+    behavior preserved for existing tests).
+    """
+    horizon_months = 6
+    scenario = Scenario(
+        scenario_id="partner_contribution_unfundable",
+        label="Partner Contribution Unfundable",
+        actors=(_simple_actor(), Actor(actor_id="beta", label="Beta", role=ActorRole.EQUITY_BUILDING_OCCUPANT)),
+        property_selection=PropertySelection(
+            property_id="test_property", location_id=LocationId.VALLEJO_CA, purchase_price_usd=100_000
+        ),
+        financing=Financing(financing_mode=FinancingMode.CASH),
+        transaction_costs=TransactionCosts(closing_cost_buy_pct=0, closing_cost_sell_pct=0),
+        property_assumptions=PropertyAssumptions(insurance_annual_usd=0, maintenance_pct=0),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking",
+                    account_type=AccountType.CHECKING,
+                    owner_actor_id="alpha",
+                    balance_usd=200_000,
+                ),
+                # Partner has only $1500 — covers month 1 ($1000) but month 2's
+                # contribution ($1000) exhausts the balance ($500 left). Month 3
+                # onward have a hard shortfall.
+                AccountBalance(
+                    account_id="partner_checking",
+                    account_type=AccountType.CHECKING,
+                    owner_actor_id="beta",
+                    balance_usd=1_500,
+                ),
+            )
+        ),
+        policies=(
+            PartnerEquityAccrualPolicy(
+                policy_id="partner_equity",
+                actor_id="beta",
+                property_id="test_property",
+                base_monthly_payment_usd=1_000,
+                occupied_months=horizon_months,
+                grow_with_inflation=False,
+            ),
+        ),
+    )
+
+    result = _run_scenario(scenario, horizon_months=horizon_months)
+
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    partner_contribution_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.PARTNER_CONTRIBUTION
+    )
+    # One obligation per occupied month — month 1..6 (six in this scenario).
+    assert len(partner_contribution_obligations) == horizon_months
+    assert {obligation.actor_id for obligation in partner_contribution_obligations} == {"beta"}
+    assert {obligation.creditor_id for obligation in partner_contribution_obligations} == {"alpha"}
+    partner_failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("partner_contribution")
+    )
+    assert len(partner_failures) >= 1
+    assert all(event.unpaid_amount_usd > 0 for event in partner_failures)
+    unfunded = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("partner_contribution")
+        and decision.decision_type is FundingDecisionType.UNFUNDED
+    )
+    assert len(unfunded) >= 1
+    assert all(decision.shortfall_usd > 0 for decision in unfunded)
 
 
 def test_partner_equity_accrual_records_contributions_and_claims() -> None:


### PR DESCRIPTION
## Summary

Plan C slices 2 + 4: the remaining direct-cash-debit paths for property
operating costs and partner contributions now flow through the unified
`_settle_required_cash_obligations` pipeline.

### What's now obligation-routed

Five new `ObligationType` variants are exercised end-to-end:

- **`PROPERTY_TAX`**, **`HOA_DUES`**, **`INSURANCE_PREMIUM`**,
  **`MAINTENANCE`** — the four property carrying-cost lines settle as
  required `_CashDebitObligationKind` obligations, **in the engine's
  month loop, before within-month policy decisions** (so the proactive
  `CheckingFloorSellPublicStockPolicy` and `PrivateEquitySalePolicy`
  continue to observe post-carrying-cost cash, matching the pre-refactor
  cash trajectory). Each line emits one Obligation, SettlementResult,
  FundingDecision per occupied month; on shortfall a FailureEvent fires
  and the rollout flips to FAILED.
- **`PARTNER_CONTRIBUTION`** — a new `_PartnerContributionObligationKind`
  carries the cross-actor cash transfer on the settlement JE (debit
  recipient owner CHECKING_CASH, credit contributing partner
  CHECKING_CASH). The cash debit is removed from
  `apply_partner_house_cost_contribution`; the allocation JE
  (`PARTNER_CONTRIBUTION_USED` / `PARTNER_UNALLOCATED_CLAIM` /
  `PARTNER_CONTRIBUTION_TRANSFER`) stays unchanged.

Rental income (a receipt) and rental management/leasing fees (which scale
with collected rent and are netted against it in the same operating sweep)
stay direct on `apply_property_operating_cash_flows`.

### Cash trajectory invariants

- **Happy path: unchanged.** Property cost obligations settle in-loop,
  before within-month policy decisions, mirroring the prior
  `net_property_cash_flow` deduction order. The engine's `cash` array
  values are byte-identical on scenarios where the obligations PAY.
- **Failure mode: surfaces as FAILED + FailureEvent.** When cash + funding
  policies can't cover an obligation, the rollout flips to FAILED and
  records the unfunded amount per missed month.

Partners with an explicit CHECKING account fund the contribution strictly
from that balance — running out fails the rollout. Partners with no
configured CHECKING account default to off-trace funding (legacy behavior
preserved for tests that don't model partner cash).

### Tests

Six new tests in `augur/core/test_e2e.py`:

| Test | What it exercises |
| --- | --- |
| `test_property_tax_obligation_settles_when_cash_available` | Happy path: all four carrying-cost lines emit PAID obligations and reconcile to ledger postings |
| `test_property_tax_obligation_fails_rollout_when_unfundable` | PROPERTY_TAX shortfall → FAILED |
| `test_hoa_dues_obligation_fails_rollout_when_unfundable` | HOA_DUES shortfall → FAILED |
| `test_insurance_premium_obligation_fails_rollout_when_unfundable` | INSURANCE_PREMIUM shortfall → FAILED |
| `test_maintenance_obligation_fails_rollout_when_unfundable` | MAINTENANCE shortfall → FAILED |
| `test_partner_contribution_obligation_fails_rollout_when_partner_cannot_fund` | PARTNER_CONTRIBUTION shortfall → FAILED |

The existing reconciliation guard
(`test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface`)
still passes — postings on the property/expense roles continue to
reconcile with the canonical monthly metrics; the only change is the
journal-entry type those postings ride on.
`test_mortgage_shortfall_records_failed_obligation_and_failure_event` was
updated to also count the now-present property-tax failures.

### Refactor notes

- Extracted `_settle_required_cash_obligation_at_month_position` from the
  body of `_settle_required_cash_obligations`'s month loop so the same
  per-month logic drives both post-loop and in-loop callers.
- Cached per-actor funding-source lookups in an
  `_ObligationFundingSources` dataclass.

## Test plan

- [x] `bbr test //augur/core:test_e2e` — passes (32 tests, including 6 new + reconciliation guard)
- [x] `bbr test //augur/core:scenario_engine_test //augur/core:policy_runtime_test //augur/core:annual_tax_test` — passes
- [x] `bbr test //augur/api:browser_shell_test` — passes
- [x] `bbr test //augur/...` — 27/28 pass; only `visual_golden_test` shows 0.36% pixel diff (pre-existing on devel, confirmed by stashing changes and re-running)
- [x] `bbr build //augur/...` — clean

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_