### PR TITLE
devinfra/js/debundle: partial-swap namespace + default kinds

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -718,3 +718,177 @@ fn run_partial_swap_fixture(args: PartialSwapFixtureArgs<'_>) -> PartialSwapFixt
         _root: root,
     }
 }
+
+#[test]
+fn partial_swap_namespace_kind_replaces_whole_import() {
+    // Caller has `import { a as React } from "../megachunk/entry.js"`
+    // where the chunk export `a` is the package's whole namespace
+    // object. References use member access (`React.useState(...)`),
+    // which must stay intact post-swap. Only the import statement
+    // should change to `import * as React from "react"`.
+    let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
+        kind: "namespace",
+        package_name: "react",
+        package_version: "18.3.1",
+        subpath: "index.js",
+        chunk_source: "export const a = { useState: () => 1, useEffect: () => 2 };\nexport const keepMe = () => 7;\n",
+        caller_source: "import { a as React, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return React.useState() + kept(); }\n",
+        upstream_source: "export const useState = () => 1;\nexport const useEffect = () => 2;\n",
+        chunk_export: "a",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("import * as React from \"react\""),
+        "caller should emit a namespace import for the package:\n{caller}",
+    );
+    assert!(
+        caller.contains("React.useState()"),
+        "caller's member-access references must stay intact:\n{caller}",
+    );
+    assert!(
+        caller.contains("keepMe as kept"),
+        "non-swapped specifiers stay in the residual import:\n{caller}",
+    );
+}
+
+#[test]
+fn partial_swap_default_kind_replaces_whole_import() {
+    // Caller has `import { aQ as z } from "../megachunk/entry.js"`
+    // where the chunk export `aQ` is the package's default export
+    // (e.g. clsx). References call the local binding directly
+    // (`z(...)`), which must stay intact. Only the import statement
+    // should change to `import z from "clsx"`.
+    let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
+        kind: "default",
+        package_name: "clsx",
+        package_version: "2.1.1",
+        subpath: "dist/clsx.mjs",
+        chunk_source: "export const aQ = (...args) => args.join(' ');\nexport const keepMe = () => 7;\n",
+        caller_source: "import { aQ as z, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return z(\"a\", \"b\") + kept(); }\n",
+        upstream_source: "export default (...args) => args.join(' ');\n",
+        chunk_export: "aQ",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("import z from \"clsx\""),
+        "caller should emit a default import for the package:\n{caller}",
+    );
+    assert!(
+        caller.contains("z(\"a\", \"b\")"),
+        "caller's call-site references must stay intact:\n{caller}",
+    );
+    assert!(
+        caller.contains("keepMe as kept"),
+        "non-swapped specifiers stay in the residual import:\n{caller}",
+    );
+}
+
+struct PartialSwapKindFixtureArgs<'a> {
+    /// "namespace" or "default"
+    kind: &'a str,
+    package_name: &'a str,
+    package_version: &'a str,
+    subpath: &'a str,
+    chunk_source: &'a str,
+    caller_source: &'a str,
+    upstream_source: &'a str,
+    chunk_export: &'a str,
+}
+
+fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> PartialSwapFixture {
+    const MEGACHUNK_PATH: &str = "static/megachunk.js";
+    const CALLER_PATH: &str = "static/app.js";
+
+    let root = TempDir::with_prefix("vendor-partial-swap-kind-").expect("create tempdir");
+    let workspace_root = root.path().join("workspace");
+    let extracted_root = workspace_root.join("extracted");
+    let snapshot_root = workspace_root.join("snapshot");
+    let out_root = workspace_root.join("out");
+    let wrapper_root = workspace_root.join("vendors").join("generated");
+    let manifest_path = workspace_root.join("vendors").join("manifest.json");
+    let package_root = root.path().join("upstream").join(args.package_name);
+    fs::create_dir_all(&extracted_root).unwrap();
+    fs::create_dir_all(&snapshot_root).unwrap();
+    fs::create_dir_all(&out_root).unwrap();
+    fs::create_dir_all(&wrapper_root).unwrap();
+    fs::create_dir_all(&package_root).unwrap();
+    fs::create_dir_all(snapshot_root.join("static")).unwrap();
+    if let Some(parent) = Path::new(args.subpath).parent() {
+        fs::create_dir_all(package_root.join(parent)).unwrap();
+    }
+
+    write_text_file(&snapshot_root.join(MEGACHUNK_PATH), args.chunk_source);
+    write_text_file(&snapshot_root.join(CALLER_PATH), args.caller_source);
+    let js_list_path = extracted_root.join("js-files.txt");
+    write_text_file(&js_list_path, &format!("{MEGACHUNK_PATH}\n{CALLER_PATH}\n"));
+
+    write_text_file(
+        &package_root.join("package.json"),
+        &format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "name": args.package_name,
+                "version": args.package_version,
+            }))
+            .unwrap(),
+        ),
+    );
+    write_text_file(&package_root.join(args.subpath), args.upstream_source);
+
+    let spec_path = root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            MEGACHUNK_PATH: {
+                "level": "partial_swap",
+                "identity": format!("megachunk {} swap fixture", args.kind),
+                "packages": {
+                    args.package_name: {
+                        "version": args.package_version,
+                        "subpath": args.subpath,
+                    },
+                },
+                "symbols": {
+                    args.chunk_export: { "package": args.package_name, "kind": args.kind },
+                },
+            },
+        },
+        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
+        "swap_vendor_chunks": {
+            "output_manifest_path": &manifest_path,
+            "output_wrapper_dir": &wrapper_root,
+            "write": true,
+        },
+        "write_js_tree": { "force": true, "out_dir": &out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+
+    let result = run_debundler(&spec_path, &[(args.package_name, &package_root)]);
+
+    let caller_emitted_path = out_root.join("static/app").join("entry.js");
+    let megachunk_emitted_path = out_root.join("static/megachunk").join("entry.js");
+
+    PartialSwapFixture {
+        result,
+        megachunk_chunk_path: MEGACHUNK_PATH.to_string(),
+        caller_emitted_path,
+        megachunk_emitted_path,
+        manifest_path,
+        _root: root,
+    }
+}

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -291,16 +291,17 @@ pub struct SwapMark {
 }
 
 /// Per-symbol vendor swap on a mixed chunk. The chunk stays on disk
-/// (residual exports keep working), but each listed export gets its
-/// caller-side references rewritten to a namespace member access
-/// (`zodObject(…)` → `z.object(…)`) and a single
-/// `import * as <namespace> from "<package>"` is added per file that
-/// uses the package. Multiple upstream packages can share one chunk.
+/// (residual exports keep working). Each listed export is rewritten
+/// according to its [`PartialSwapKind`] — see the variants for the
+/// three supported shapes (`member` for per-symbol member-access
+/// rewrites à la zod; `namespace` and `default` for libraries the
+/// chunk re-exports as a whole namespace or as a default value).
+/// Multiple upstream packages can share one chunk.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PartialSwapMark {
-    /// package_name → upstream coordinates and namespace alias.
+    /// package_name → upstream coordinates.
     pub packages: BTreeMap<String, PartialSwapPackage>,
-    /// chunk_export_name → which package + which upstream export.
+    /// chunk_export_name → which package + how to rewrite it.
     pub symbols: BTreeMap<String, PartialSwapSymbol>,
 }
 
@@ -309,20 +310,55 @@ pub struct PartialSwapPackage {
     pub version: String,
     pub subpath: String,
     /// Local identifier used in the emitted
-    /// `import * as <namespace> from "<package>"`. Must be a valid JS
-    /// identifier; uniqueness within a file is the caller's contract
-    /// (when multiple partial-swap chunks share a package in the same
-    /// file, identical namespace strings dedupe into one import).
-    pub namespace: String,
+    /// `import * as <namespace> from "<package>"` for symbols with
+    /// `kind: member`. Ignored for `kind: namespace` and
+    /// `kind: default`, which use the caller-side local binding name
+    /// for the import alias instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PartialSwapSymbol {
     /// Key into the enclosing [`PartialSwapMark::packages`] map.
     pub package: String,
-    /// Upstream package's export name (becomes the member accessed
-    /// off the namespace import).
-    pub upstream_export: String,
+    /// How to rewrite references to the caller's local binding. See
+    /// [`PartialSwapKind`].
+    #[serde(default, skip_serializing_if = "is_default_partial_swap_kind")]
+    pub kind: PartialSwapKind,
+    /// `kind: member` only: upstream package's export name (becomes
+    /// the member accessed off the namespace import). Forbidden for
+    /// `kind: namespace` / `kind: default`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_export: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PartialSwapKind {
+    /// Per-symbol member-access rewrite (zod-style). Emits one
+    /// `import * as <namespace> from "<package>"` per file that uses
+    /// the package and rewrites each `<local_binding>(...)` reference
+    /// to `<namespace>.<upstream_export>(...)`.
+    #[default]
+    Member,
+    /// Whole-namespace import. The chunk's export is itself the
+    /// package's namespace object (e.g. `import { a as React } from
+    /// "../chunk"` where `a` is React's default-namespace export and
+    /// callers use `React.useState(...)` etc.). Rewrites the import
+    /// to `import * as <local_binding> from "<package>"`; leaves
+    /// every `<local_binding>.xxx` reference alone.
+    Namespace,
+    /// Default import. The chunk's export is the package's default
+    /// (e.g. `import { aQ as z } from "../chunk"` where `z` is
+    /// clsx's default function). Rewrites the import to
+    /// `import <local_binding> from "<package>"`; leaves every
+    /// `<local_binding>(...)` reference alone.
+    Default,
+}
+
+fn is_default_partial_swap_kind(kind: &PartialSwapKind) -> bool {
+    matches!(kind, PartialSwapKind::Member)
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, Eq, PartialEq)]

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -16,8 +16,8 @@ use artifact::{
 };
 use js_ast::{ParsedJsModule, emit_js_module, parse_js_module, str_value};
 use spec::{
-    PartialSwapMark, PartialSwapPackage, SwapMark, VendorLevel, VendorMark, VendorRole,
-    WrapperShape,
+    PartialSwapKind, PartialSwapMark, PartialSwapPackage, SwapMark, VendorLevel, VendorMark,
+    VendorRole, WrapperShape,
 };
 
 // These manifests are returned by the vendor stages but the pipeline
@@ -1420,7 +1420,8 @@ pub struct ChunkPartialSwapResolution {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PartialSwapPackageResolution {
-    pub namespace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
     pub version: String,
     pub subpath: String,
 }
@@ -1428,7 +1429,9 @@ pub struct PartialSwapPackageResolution {
 #[derive(Debug, Clone, Serialize)]
 pub struct PartialSwapSymbolResolution {
     pub package: String,
-    pub upstream_export: String,
+    pub kind: PartialSwapKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_export: Option<String>,
     pub references_rewritten: usize,
 }
 
@@ -1464,7 +1467,9 @@ struct ChunkPartialSwapMapping {
 #[derive(Debug, Clone)]
 struct PartialSwapSymbolTarget {
     package: String,
-    upstream_export: String,
+    kind: PartialSwapKind,
+    /// Only Some(_) when `kind == Member`.
+    upstream_export: Option<String>,
 }
 
 pub fn apply_partial_vendor_swaps(
@@ -1518,17 +1523,41 @@ pub fn apply_partial_vendor_swaps(
             }
         }
 
+        // Per-symbol shape validation: `kind: member` requires
+        // `upstream_export`; `kind: namespace` / `kind: default`
+        // forbid it.
+        for (chunk_export, symbol) in &partial.symbols {
+            match (symbol.kind, symbol.upstream_export.as_deref()) {
+                (PartialSwapKind::Member, None) => bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` (kind=member) missing required `upstream_export`",
+                ),
+                (PartialSwapKind::Namespace | PartialSwapKind::Default, Some(_)) => bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` (kind={:?}) must not set `upstream_export`",
+                    symbol.kind
+                ),
+                _ => {}
+            }
+        }
+
         // Per-package validation: installed version + upstream subpath
         // exists + every declared upstream_export is actually a named
         // export of the upstream subpath.
         let mut package_resolutions: BTreeMap<String, PartialSwapPackageResolution> =
             BTreeMap::new();
         for (package_name, package) in &partial.packages {
-            if !is_valid_identifier(&package.namespace) {
-                bail!(
-                    "apply_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` namespace `{}` is not a valid JS identifier",
-                    package.namespace
-                );
+            let any_member_for_package = partial
+                .symbols
+                .values()
+                .any(|s| s.package == *package_name && matches!(s.kind, PartialSwapKind::Member));
+            if any_member_for_package {
+                let namespace = package.namespace.as_deref().with_context(|| format!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` is referenced by a kind=member symbol but is missing `namespace`",
+                ))?;
+                if !is_valid_identifier(namespace) {
+                    bail!(
+                        "apply_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` namespace `{namespace}` is not a valid JS identifier",
+                    );
+                }
             }
             let installed = read_installed_package_metadata(
                 package_name,
@@ -1570,13 +1599,19 @@ pub fn apply_partial_vendor_swaps(
                 if symbol.package != *package_name {
                     continue;
                 }
+                // Only kind=member symbols cite an upstream named
+                // export; kind=namespace/default replace the whole
+                // import with a namespace/default reference, no
+                // member-name lookup needed.
+                let Some(upstream_export) = symbol.upstream_export.as_deref() else {
+                    continue;
+                };
                 if upstream_has_export_star {
                     continue;
                 }
-                if !upstream_exports.contains(&symbol.upstream_export) {
+                if !upstream_exports.contains(upstream_export) {
                     bail!(
-                        "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` targets {package_name}#{} but upstream does not export it (known: [{}])",
-                        symbol.upstream_export,
+                        "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` targets {package_name}#{upstream_export} but upstream does not export it (known: [{}])",
                         upstream_exports
                             .iter()
                             .cloned()
@@ -1602,6 +1637,7 @@ pub fn apply_partial_vendor_swaps(
                 chunk_export.clone(),
                 PartialSwapSymbolResolution {
                     package: symbol.package.clone(),
+                    kind: symbol.kind,
                     upstream_export: symbol.upstream_export.clone(),
                     references_rewritten: 0,
                 },
@@ -1610,6 +1646,7 @@ pub fn apply_partial_vendor_swaps(
                 chunk_export.clone(),
                 PartialSwapSymbolTarget {
                     package: symbol.package.clone(),
+                    kind: symbol.kind,
                     upstream_export: symbol.upstream_export.clone(),
                 },
             );
@@ -1772,13 +1809,16 @@ fn rewrite_partial_swap_in_file(
     let module = &mut job.ast.module;
 
     // Pass A: scan ImportDecls. For each ImportSpecifier::Named on a
-    // partial-swap chunk import, record the local-binding sym and
-    // remove the specifier. Track which packages need a namespace
-    // import in this file and which (chunk, chunk_export) was hit so
-    // the manifest aggregates per-symbol counts.
+    // partial-swap chunk import:
+    //   - kind=member: record the local-binding sym for Pass B's
+    //     member-access rewrite; queue one shared
+    //     `import * as <pkg.namespace> from "<pkg>"` for the file.
+    //   - kind=namespace: queue a per-binding
+    //     `import * as <local> from "<pkg>"`; no identifier rewrite.
+    //   - kind=default: queue a per-binding
+    //     `import <local> from "<pkg>"`; no identifier rewrite.
     let mut bindings: BTreeMap<String, IdentRewriteTarget> = BTreeMap::new();
-    let mut needed_namespace_imports: Vec<(String, String)> = Vec::new();
-    let mut emitted_namespace_for: BTreeSet<String> = BTreeSet::new();
+    let mut emitted_member_namespace_for: BTreeSet<String> = BTreeSet::new();
     let mut references_by_symbol: BTreeMap<(String, String), usize> = BTreeMap::new();
 
     let original_body = std::mem::take(&mut module.body);
@@ -1810,7 +1850,9 @@ fn rewrite_partial_swap_in_file(
         };
 
         let mut retained_specifiers: Vec<ImportSpecifier> = Vec::new();
-        let mut packages_emitted_here: BTreeSet<String> = BTreeSet::new();
+        // Imports introduced by this decl; emitted in front of the
+        // residual decl below to preserve relative source order.
+        let mut decl_local_imports: Vec<DeferredImport> = Vec::new();
         for specifier in std::mem::take(&mut import_decl.specifiers) {
             let imported_name_lookup = match &specifier {
                 ImportSpecifier::Named(named) => named
@@ -1835,37 +1877,60 @@ fn rewrite_partial_swap_in_file(
                 unreachable!("classified named above");
             };
             let local_sym = named.local.sym.to_string();
-            bindings.insert(
-                local_sym,
-                IdentRewriteTarget {
-                    namespace: package_coords.namespace.clone(),
-                    upstream_export: target.upstream_export.clone(),
-                    chunk_name: chunk_mapping.chunk_id.clone(),
-                    chunk_export: imported_name_lookup.clone(),
-                },
-            );
-            if emitted_namespace_for.insert(target.package.clone()) {
-                needed_namespace_imports
-                    .push((target.package.clone(), package_coords.namespace.clone()));
+            match target.kind {
+                PartialSwapKind::Member => {
+                    let upstream_export = target
+                        .upstream_export
+                        .as_deref()
+                        .expect("kind=member validated to carry upstream_export");
+                    let namespace = package_coords
+                        .namespace
+                        .as_deref()
+                        .expect("kind=member validated to have package.namespace");
+                    bindings.insert(
+                        local_sym,
+                        IdentRewriteTarget {
+                            namespace: namespace.to_string(),
+                            upstream_export: upstream_export.to_string(),
+                            chunk_name: chunk_mapping.chunk_id.clone(),
+                            chunk_export: imported_name_lookup.clone(),
+                        },
+                    );
+                    // One member-mode namespace import per (file, package).
+                    if emitted_member_namespace_for.insert(target.package.clone()) {
+                        decl_local_imports.push(DeferredImport::Namespace {
+                            package: target.package.clone(),
+                            local: namespace.to_string(),
+                        });
+                    }
+                }
+                PartialSwapKind::Namespace => {
+                    decl_local_imports.push(DeferredImport::Namespace {
+                        package: target.package.clone(),
+                        local: local_sym,
+                    });
+                    // Count one "reference rewrite" per import so the
+                    // manifest can show progress per chunk_export.
+                    *references_by_symbol
+                        .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
+                        .or_insert(0) += 1;
+                }
+                PartialSwapKind::Default => {
+                    decl_local_imports.push(DeferredImport::Default {
+                        package: target.package.clone(),
+                        local: local_sym,
+                    });
+                    *references_by_symbol
+                        .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
+                        .or_insert(0) += 1;
+                }
             }
-            packages_emitted_here.insert(target.package.clone());
         }
 
-        // Emit namespace imports for any packages this decl introduced
-        // but that haven't already been written out at an earlier
-        // position. Walking in source order preserves grouping.
-        for package_name in &packages_emitted_here {
-            // Only emit at this position if this is the first time we're
-            // touching the package. (The `emitted_namespace_for` set was
-            // updated above; we already added to needed_namespace_imports.)
-            // We pop the matching entry and emit it here.
-            if let Some(position) = needed_namespace_imports
-                .iter()
-                .position(|(pkg, _)| pkg == package_name)
-            {
-                let (pkg, namespace) = needed_namespace_imports.remove(position);
-                new_body.push(make_namespace_import(&pkg, &namespace));
-            }
+        // Emit the deferred imports introduced by this decl in front
+        // of the residual import (if any). Source-order preserved.
+        for deferred in decl_local_imports.drain(..) {
+            new_body.push(deferred.into_module_item());
         }
 
         if !retained_specifiers.is_empty() {
@@ -1874,21 +1939,12 @@ fn rewrite_partial_swap_in_file(
         }
     }
 
-    // Anything still in needed_namespace_imports has no anchor decl
-    // (shouldn't happen given the loop above) — emit at top as a
-    // fallback. In practice this stays empty.
-    let mut prepend: Vec<ModuleItem> = Vec::new();
-    for (pkg, namespace) in needed_namespace_imports.drain(..) {
-        prepend.push(make_namespace_import(&pkg, &namespace));
-    }
-    if !prepend.is_empty() {
-        prepend.append(&mut new_body);
-        new_body = prepend;
-    }
     module.body = new_body;
 
     // Pass B: rewrite every Expr::Ident reference to a tracked local
-    // binding into `<namespace>.<upstream_export>`.
+    // binding into `<namespace>.<upstream_export>`. Only kind=member
+    // populates `bindings`; kind=namespace and kind=default leave the
+    // local-binding references intact.
     if !bindings.is_empty() {
         let mut rewriter = PartialSwapIdentRewriter {
             bindings: &bindings,
@@ -1904,6 +1960,22 @@ fn rewrite_partial_swap_in_file(
         parts: job.parts,
         ast: job.ast,
         references_by_symbol,
+    }
+}
+
+enum DeferredImport {
+    /// `import * as <local> from "<package>"`
+    Namespace { package: String, local: String },
+    /// `import <local> from "<package>"`
+    Default { package: String, local: String },
+}
+
+impl DeferredImport {
+    fn into_module_item(self) -> ModuleItem {
+        match self {
+            DeferredImport::Namespace { package, local } => make_namespace_import(&package, &local),
+            DeferredImport::Default { package, local } => make_default_import(&package, &local),
+        }
     }
 }
 
@@ -1956,6 +2028,24 @@ fn make_namespace_import(package: &str, namespace: &str) -> ModuleItem {
         specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
             span: DUMMY_SP,
             local: Ident::new_no_ctxt(namespace.into(), DUMMY_SP),
+        })],
+        src: Box::new(Str {
+            span: DUMMY_SP,
+            value: package.into(),
+            raw: None,
+        }),
+        type_only: false,
+        with: None,
+        phase: ImportPhase::Evaluation,
+    }))
+}
+
+fn make_default_import(package: &str, local: &str) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+        span: DUMMY_SP,
+        specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new_no_ctxt(local.into(), DUMMY_SP),
         })],
         src: Box::new(Str {
             span: DUMMY_SP,


### PR DESCRIPTION
## Summary

Extends `level: partial_swap` with two new `kind:` values alongside the existing default `member`:

- **`namespace`**: chunk export is the package's whole namespace object. Rewrites the import to `import * as <local_binding> from "<package>"`; leaves every `<local_binding>.xxx` reference alone. Use for libraries the megachunk re-exports as a whole namespace (e.g. Tana's `vendor-BPNhzNbc` re-exports React via `import { a as React } from "../chunk"; React.useState()`).

- **`default`**: chunk export is the package's default export. Rewrites the import to `import <local_binding> from "<package>"`; leaves every `<local_binding>(...)` reference alone. Use for libraries with a single default function (e.g. `clsx`).

Both new kinds use the caller-side local binding as the import alias (per-file), so two files can give the same chunk export different names without conflicting. `package.namespace` becomes optional in the spec — only required when at least one symbol on that package uses `kind: member`.

```yaml
# zod (existing — kind: member, the default)
e6: { package: zod, upstream_export: boolean }

# React's namespace under chunk export `a`
a: { package: react, kind: namespace }

# clsx's default under chunk export `aQ`
aQ: { package: clsx, kind: default }
```

## E2E coverage

- `partial_swap_namespace_kind_replaces_whole_import` — `import { a as React } from "../megachunk/entry.js"; React.useState()` becomes `import * as React from "react"; React.useState()` (call sites intact, residual specifiers preserved).
- `partial_swap_default_kind_replaces_whole_import` — `import { aQ as z } from "../megachunk/entry.js"; z("a", "b")` becomes `import z from "clsx"; z("a", "b")`.
- The existing zod tests still cover `kind: member` (the default).

## Test plan

- [x] `bbr test //devinfra/js/debundle/e2e:vendor_swap_test` — PASSED (all 5 partial-swap test functions)
- [x] End-to-end against gaffer-private's `vendor-BPNhzNbc` megachunk: emitted JS now reads `import * as React from "react"`, `import * as jsxRuntime from "react/jsx-runtime"`, `import z from "clsx"` with member-access / call-site references unchanged.

https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD)_