### PR TITLE
devinfra/js/debundle: partial-swap named kind

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -735,6 +735,7 @@ fn partial_swap_namespace_kind_replaces_whole_import() {
         caller_source: "import { a as React, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return React.useState() + kept(); }\n",
         upstream_source: "export const useState = () => 1;\nexport const useEffect = () => 2;\n",
         chunk_export: "a",
+        upstream_export: None,
     });
 
     assert!(
@@ -775,6 +776,7 @@ fn partial_swap_default_kind_replaces_whole_import() {
         caller_source: "import { aQ as z, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return z(\"a\", \"b\") + kept(); }\n",
         upstream_source: "export default (...args) => args.join(' ');\n",
         chunk_export: "aQ",
+        upstream_export: None,
     });
 
     assert!(
@@ -799,8 +801,80 @@ fn partial_swap_default_kind_replaces_whole_import() {
     );
 }
 
+#[test]
+fn partial_swap_named_kind_replaces_whole_import() {
+    // Caller has `import { o as mobxObserver } from "../megachunk/entry.js"`
+    // where the chunk export `o` is a single named export of the package
+    // (e.g. `mobx-react-lite#observer`). References call the local
+    // binding directly (`mobxObserver(...)`), which must stay intact.
+    // Only the import statement should change to
+    // `import { observer as mobxObserver } from "mobx-react-lite"`.
+    let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
+        kind: "named",
+        package_name: "mobx-react-lite",
+        package_version: "4.0.7",
+        subpath: "dist/index.js",
+        chunk_source: "export const o = (Component) => Component;\nexport const keepMe = () => 7;\n",
+        caller_source: "import { o as mobxObserver, keepMe as kept } from \"../megachunk/entry.js\";\nexport function go() { return mobxObserver(\"X\") + kept(); }\n",
+        upstream_source: "export const observer = (Component) => Component;\n",
+        chunk_export: "o",
+        upstream_export: Some("observer"),
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("import { observer as mobxObserver } from \"mobx-react-lite\""),
+        "caller should emit a named import using the upstream export:\n{caller}",
+    );
+    assert!(
+        caller.contains("mobxObserver(\"X\")"),
+        "caller's call-site references must stay intact:\n{caller}",
+    );
+    assert!(
+        caller.contains("keepMe as kept"),
+        "non-swapped specifiers stay in the residual import:\n{caller}",
+    );
+}
+
+#[test]
+fn partial_swap_named_kind_drops_alias_when_local_matches_upstream() {
+    // When the caller-side local binding already matches the upstream
+    // export name, the emitted import should drop the `as` alias.
+    let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
+        kind: "named",
+        package_name: "mobx-react-lite",
+        package_version: "4.0.7",
+        subpath: "dist/index.js",
+        chunk_source: "export const o = (Component) => Component;\n",
+        caller_source: "import { o as observer } from \"../megachunk/entry.js\";\nexport function go() { return observer(\"X\"); }\n",
+        upstream_source: "export const observer = (Component) => Component;\n",
+        chunk_export: "o",
+        upstream_export: Some("observer"),
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("import { observer } from \"mobx-react-lite\""),
+        "no `as` alias when local matches upstream export:\n{caller}",
+    );
+}
+
 struct PartialSwapKindFixtureArgs<'a> {
-    /// "namespace" or "default"
+    /// "namespace", "default", or "named"
     kind: &'a str,
     package_name: &'a str,
     package_version: &'a str,
@@ -809,6 +883,8 @@ struct PartialSwapKindFixtureArgs<'a> {
     caller_source: &'a str,
     upstream_source: &'a str,
     chunk_export: &'a str,
+    /// Required for `kind: named`. None for `namespace` / `default`.
+    upstream_export: Option<&'a str>,
 }
 
 fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> PartialSwapFixture {
@@ -851,6 +927,12 @@ fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> Partia
     );
     write_text_file(&package_root.join(args.subpath), args.upstream_source);
 
+    let mut symbol_obj = serde_json::Map::new();
+    symbol_obj.insert("package".to_string(), Value::from(args.package_name));
+    symbol_obj.insert("kind".to_string(), Value::from(args.kind));
+    if let Some(upstream_export) = args.upstream_export {
+        symbol_obj.insert("upstream_export".to_string(), Value::from(upstream_export));
+    }
     let spec_path = root.path().join("transform_spec.yaml");
     let spec = json!({
         "vendor": {
@@ -864,7 +946,7 @@ fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> Partia
                     },
                 },
                 "symbols": {
-                    args.chunk_export: { "package": args.package_name, "kind": args.kind },
+                    args.chunk_export: Value::Object(symbol_obj),
                 },
             },
         },

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -326,9 +326,11 @@ pub struct PartialSwapSymbol {
     /// [`PartialSwapKind`].
     #[serde(default, skip_serializing_if = "is_default_partial_swap_kind")]
     pub kind: PartialSwapKind,
-    /// `kind: member` only: upstream package's export name (becomes
-    /// the member accessed off the namespace import). Forbidden for
-    /// `kind: namespace` / `kind: default`.
+    /// `kind: member` and `kind: named` only: upstream package's
+    /// export name. For `member` it becomes the member accessed off
+    /// the namespace import; for `named` it becomes the imported name
+    /// in `import { <upstream_export> as <local_binding> } from "<pkg>"`.
+    /// Forbidden for `kind: namespace` / `kind: default`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upstream_export: Option<String>,
 }
@@ -355,6 +357,15 @@ pub enum PartialSwapKind {
     /// `import <local_binding> from "<package>"`; leaves every
     /// `<local_binding>(...)` reference alone.
     Default,
+    /// Named import. The chunk's export is a single named export of
+    /// the package (e.g. `import { o as mobxObserver } from
+    /// "../chunk"` where `o` is `mobx-react-lite`'s `observer`).
+    /// Rewrites the import to
+    /// `import { <upstream_export> as <local_binding> } from "<package>"`
+    /// (or `import { <name> } from "<package>"` when the local
+    /// binding name matches the upstream export); leaves every
+    /// `<local_binding>(...)` reference alone.
+    Named,
 }
 
 fn is_default_partial_swap_kind(kind: &PartialSwapKind) -> bool {

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1523,13 +1523,14 @@ pub fn apply_partial_vendor_swaps(
             }
         }
 
-        // Per-symbol shape validation: `kind: member` requires
-        // `upstream_export`; `kind: namespace` / `kind: default`
+        // Per-symbol shape validation: `kind: member` and `kind: named`
+        // require `upstream_export`; `kind: namespace` / `kind: default`
         // forbid it.
         for (chunk_export, symbol) in &partial.symbols {
             match (symbol.kind, symbol.upstream_export.as_deref()) {
-                (PartialSwapKind::Member, None) => bail!(
-                    "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` (kind=member) missing required `upstream_export`",
+                (PartialSwapKind::Member | PartialSwapKind::Named, None) => bail!(
+                    "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` (kind={:?}) missing required `upstream_export`",
+                    symbol.kind
                 ),
                 (PartialSwapKind::Namespace | PartialSwapKind::Default, Some(_)) => bail!(
                     "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` (kind={:?}) must not set `upstream_export`",
@@ -1924,6 +1925,20 @@ fn rewrite_partial_swap_in_file(
                         .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
                         .or_insert(0) += 1;
                 }
+                PartialSwapKind::Named => {
+                    let upstream_export = target
+                        .upstream_export
+                        .as_deref()
+                        .expect("kind=named validated to carry upstream_export");
+                    decl_local_imports.push(DeferredImport::Named {
+                        package: target.package.clone(),
+                        local: local_sym,
+                        upstream_export: upstream_export.to_string(),
+                    });
+                    *references_by_symbol
+                        .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
+                        .or_insert(0) += 1;
+                }
             }
         }
 
@@ -1968,6 +1983,13 @@ enum DeferredImport {
     Namespace { package: String, local: String },
     /// `import <local> from "<package>"`
     Default { package: String, local: String },
+    /// `import { <upstream_export> as <local> } from "<package>"`,
+    /// or `import { <name> } from "<package>"` when local == upstream.
+    Named {
+        package: String,
+        local: String,
+        upstream_export: String,
+    },
 }
 
 impl DeferredImport {
@@ -1975,6 +1997,11 @@ impl DeferredImport {
         match self {
             DeferredImport::Namespace { package, local } => make_namespace_import(&package, &local),
             DeferredImport::Default { package, local } => make_default_import(&package, &local),
+            DeferredImport::Named {
+                package,
+                local,
+                upstream_export,
+            } => make_named_import(&package, &local, &upstream_export),
         }
     }
 }
@@ -2046,6 +2073,34 @@ fn make_default_import(package: &str, local: &str) -> ModuleItem {
         specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
             span: DUMMY_SP,
             local: Ident::new_no_ctxt(local.into(), DUMMY_SP),
+        })],
+        src: Box::new(Str {
+            span: DUMMY_SP,
+            value: package.into(),
+            raw: None,
+        }),
+        type_only: false,
+        with: None,
+        phase: ImportPhase::Evaluation,
+    }))
+}
+
+fn make_named_import(package: &str, local: &str, upstream_export: &str) -> ModuleItem {
+    let imported = if local == upstream_export {
+        None
+    } else {
+        Some(ModuleExportName::Ident(Ident::new_no_ctxt(
+            upstream_export.into(),
+            DUMMY_SP,
+        )))
+    };
+    ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+        span: DUMMY_SP,
+        specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new_no_ctxt(local.into(), DUMMY_SP),
+            imported,
+            is_type_only: false,
         })],
         src: Box::new(Str {
             span: DUMMY_SP,


### PR DESCRIPTION
## Summary

Adds `kind: named` to `PartialSwapSymbol`, the fourth shape for partial-vendor-swap rewrites alongside the existing `member` / `namespace` / `default`. Use for chunk exports that re-export a **single named export** of an upstream package (rather than a whole namespace, default value, or one member of a member-access cluster).

```yaml
# zod (kind: member, default)            — z.object(...)
# React  (kind: namespace)               — React.useState(...)
# clsx   (kind: default)                 — z(...)

# mobx-react-lite#observer (kind: named) — observer(...) / mobxObserver(...)
o: { package: mobx-react-lite, kind: named, upstream_export: observer }
```

Output shape:

```js
import { <upstream_export> as <local_binding> } from "<package>";
```

When the caller-side local binding already matches the upstream export name, the `as` alias is dropped:

```js
import { observer } from "mobx-react-lite";
```

The local binding is left intact in references — call sites like `mobxObserver(Component)` / `observer(Component)` stay the same; only the import target moves from the chunk to the real npm package.

## Use case

`mobx-react-lite#observer` is co-bundled in Tana's `vendor-BPNhzNbc` megachunk under chunk export `o` and called heavily (521 references through the `B` / `mobxObserver` local binding). With `kind: member` the call sites would become `mobxReact.observer(...)` which is verbose; `kind: named` keeps them as `mobxObserver(...)` while still routing the import through `mobx-react-lite`.

Same shape works for `mobx#observable` (used as a function and as a property bag via `.array`, `.box`, `.map`, …).

## E2E coverage

- `partial_swap_named_kind_replaces_whole_import` — `import { o as mobxObserver } from "../megachunk/entry.js"; mobxObserver(...)` becomes `import { observer as mobxObserver } from "mobx-react-lite"; mobxObserver(...)`.
- `partial_swap_named_kind_drops_alias_when_local_matches_upstream` — verifies the no-alias path when `local == upstream`.

## Test plan

- [x] `bbr test //devinfra/js/debundle/e2e:vendor_swap_test` — all 7 partial-swap test functions PASSED
- [x] End-to-end against gaffer-private's `vendor-BPNhzNbc` megachunk: emitted JS now reads `import { observer as B } from "mobx-react-lite"` and `import { observable as Z } from "mobx"` with call sites and property-bag access (`Z.array(...)`) unchanged.

https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD)_