### PR TITLE
devinfra/js/debundle: kind=named auto-renames local binding

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -802,13 +802,14 @@ fn partial_swap_default_kind_replaces_whole_import() {
 }
 
 #[test]
-fn partial_swap_named_kind_replaces_whole_import() {
+fn partial_swap_named_kind_auto_renames_local_binding() {
     // Caller has `import { o as mobxObserver } from "../megachunk/entry.js"`
     // where the chunk export `o` is a single named export of the package
-    // (e.g. `mobx-react-lite#observer`). References call the local
-    // binding directly (`mobxObserver(...)`), which must stay intact.
-    // Only the import statement should change to
-    // `import { observer as mobxObserver } from "mobx-react-lite"`.
+    // (e.g. `mobx-react-lite#observer`). The local alias `mobxObserver`
+    // is whatever the chunker emitted — the partial-swap rewrites both
+    // the import (no alias) AND every reference in the file to use the
+    // upstream export name. So `mobxObserver(...)` becomes
+    // `observer(...)`.
     let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
         kind: "named",
         package_name: "mobx-react-lite",
@@ -830,12 +831,16 @@ fn partial_swap_named_kind_replaces_whole_import() {
     );
     let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
     assert!(
-        caller.contains("import { observer as mobxObserver } from \"mobx-react-lite\""),
-        "caller should emit a named import using the upstream export:\n{caller}",
+        caller.contains("import { observer } from \"mobx-react-lite\""),
+        "caller should emit a bare named import using the upstream export:\n{caller}",
     );
     assert!(
-        caller.contains("mobxObserver(\"X\")"),
-        "caller's call-site references must stay intact:\n{caller}",
+        caller.contains("observer(\"X\")"),
+        "caller's call-site references should be renamed to the upstream export:\n{caller}",
+    );
+    assert!(
+        !caller.contains("mobxObserver"),
+        "caller should not retain the original local alias:\n{caller}",
     );
     assert!(
         caller.contains("keepMe as kept"),
@@ -844,9 +849,10 @@ fn partial_swap_named_kind_replaces_whole_import() {
 }
 
 #[test]
-fn partial_swap_named_kind_drops_alias_when_local_matches_upstream() {
+fn partial_swap_named_kind_no_rewrite_when_local_already_matches() {
     // When the caller-side local binding already matches the upstream
-    // export name, the emitted import should drop the `as` alias.
+    // export name, the emitted import drops the `as` alias and no
+    // identifier rewrite is needed.
     let fixture = run_partial_swap_kind_fixture(PartialSwapKindFixtureArgs {
         kind: "named",
         package_name: "mobx-react-lite",
@@ -870,6 +876,10 @@ fn partial_swap_named_kind_drops_alias_when_local_matches_upstream() {
     assert!(
         caller.contains("import { observer } from \"mobx-react-lite\""),
         "no `as` alias when local matches upstream export:\n{caller}",
+    );
+    assert!(
+        caller.contains("observer(\"X\")"),
+        "call sites unchanged:\n{caller}",
     );
 }
 

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1890,7 +1890,7 @@ fn rewrite_partial_swap_in_file(
                         .expect("kind=member validated to have package.namespace");
                     bindings.insert(
                         local_sym,
-                        IdentRewriteTarget {
+                        IdentRewriteTarget::Member {
                             namespace: namespace.to_string(),
                             upstream_export: upstream_export.to_string(),
                             chunk_name: chunk_mapping.chunk_id.clone(),
@@ -1930,14 +1930,31 @@ fn rewrite_partial_swap_in_file(
                         .upstream_export
                         .as_deref()
                         .expect("kind=named validated to carry upstream_export");
+                    // Always emit `import { <upstream_export> } from "<pkg>"`
+                    // (no alias). If the caller's original local binding
+                    // already matched the upstream export name, no further
+                    // rewrite is needed; otherwise queue an identifier
+                    // rename so every `<local_sym>` reference in the file
+                    // becomes `<upstream_export>`.
                     decl_local_imports.push(DeferredImport::Named {
                         package: target.package.clone(),
-                        local: local_sym,
+                        local: upstream_export.to_string(),
                         upstream_export: upstream_export.to_string(),
                     });
-                    *references_by_symbol
-                        .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
-                        .or_insert(0) += 1;
+                    if local_sym != upstream_export {
+                        bindings.insert(
+                            local_sym,
+                            IdentRewriteTarget::Rename {
+                                upstream_export: upstream_export.to_string(),
+                                chunk_name: chunk_mapping.chunk_id.clone(),
+                                chunk_export: imported_name_lookup.clone(),
+                            },
+                        );
+                    } else {
+                        *references_by_symbol
+                            .entry((chunk_mapping.chunk_id.clone(), imported_name_lookup.clone()))
+                            .or_insert(0) += 1;
+                    }
                 }
             }
         }
@@ -2007,11 +2024,21 @@ impl DeferredImport {
 }
 
 #[derive(Debug, Clone)]
-struct IdentRewriteTarget {
-    namespace: String,
-    upstream_export: String,
-    chunk_name: String,
-    chunk_export: String,
+enum IdentRewriteTarget {
+    /// kind=member: rewrite `<local>` references to `<namespace>.<upstream_export>`.
+    Member {
+        namespace: String,
+        upstream_export: String,
+        chunk_name: String,
+        chunk_export: String,
+    },
+    /// kind=named auto-rename: rewrite `<local>` references to a bare
+    /// `<upstream_export>` identifier (matching the new no-alias import).
+    Rename {
+        upstream_export: String,
+        chunk_name: String,
+        chunk_export: String,
+    },
 }
 
 struct PartialSwapIdentRewriter<'a> {
@@ -2031,20 +2058,38 @@ impl VisitMut for PartialSwapIdentRewriter<'_> {
         let Some(target) = self.bindings.get(ident.sym.as_ref()) else {
             return;
         };
-        *expr = Expr::Member(MemberExpr {
-            span: DUMMY_SP,
-            obj: Box::new(Expr::Ident(Ident::new_no_ctxt(
-                target.namespace.clone().into(),
-                DUMMY_SP,
-            ))),
-            prop: MemberProp::Ident(IdentName::new(
-                target.upstream_export.clone().into(),
-                DUMMY_SP,
-            )),
-        });
+        let (chunk_name, chunk_export) = match target {
+            IdentRewriteTarget::Member {
+                namespace,
+                upstream_export,
+                chunk_name,
+                chunk_export,
+            } => {
+                *expr = Expr::Member(MemberExpr {
+                    span: DUMMY_SP,
+                    obj: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                        namespace.clone().into(),
+                        DUMMY_SP,
+                    ))),
+                    prop: MemberProp::Ident(IdentName::new(
+                        upstream_export.clone().into(),
+                        DUMMY_SP,
+                    )),
+                });
+                (chunk_name, chunk_export)
+            }
+            IdentRewriteTarget::Rename {
+                upstream_export,
+                chunk_name,
+                chunk_export,
+            } => {
+                *expr = Expr::Ident(Ident::new_no_ctxt(upstream_export.clone().into(), DUMMY_SP));
+                (chunk_name, chunk_export)
+            }
+        };
         *self
             .references_by_symbol
-            .entry((target.chunk_name.clone(), target.chunk_export.clone()))
+            .entry((chunk_name.clone(), chunk_export.clone()))
             .or_insert(0) += 1;
     }
 }


### PR DESCRIPTION
## Summary

Previously, `kind: named` emitted

```js
import { <upstream_export> as <local_binding> } from "<package>";
```

and left every reference to the local binding intact. That kept the chunker's minified alias (often a single letter like `B`) in the caller, even though we now know its semantic name.

This PR makes `kind: named` automatically rename the local binding to the upstream export. The output becomes

```js
import { observer } from "mobx-react-lite";
observer(Component);
```

instead of

```js
import { observer as B } from "mobx-react-lite";
B(Component);
```

When the caller-side local binding already matches the upstream name (e.g. the chunker happened to emit it as `observer`, or a preceding binding-patches rename did the same), the no-alias import is emitted and no identifier rewrite is needed.

## Why

Per-file the chunker assigns minified aliases (`B`, `O`, `gt`, `Ze`, …) to imported chunk exports. With `kind: named` we know which upstream named export each one actually is, so we can promote those names back into the calling code. The previous behavior used the rich name for the import statement only; this PR threads it through to the references too, so the swap doesn't leave the file half-readable.

## E2E coverage

- `partial_swap_named_kind_auto_renames_local_binding` — `import { o as mobxObserver } from "../megachunk/entry.js"; mobxObserver("X")` becomes `import { observer } from "mobx-react-lite"; observer("X")`. No leftover `mobxObserver` references.
- `partial_swap_named_kind_no_rewrite_when_local_already_matches` — when local matches upstream (`o as observer`), the no-alias import is emitted and no identifier rewrite is needed.

## Test plan

- [x] `bbr test //devinfra/js/debundle/e2e:vendor_swap_test --nocache_test_results` — PASSED (all 8 partial-swap test functions)
- [x] End-to-end against gaffer-private's `vendor-BPNhzNbc` megachunk: 700 `runInAction(...)` calls, plus all `observer(...)` / `makeObservable(...)` / `when(...)` calls, now read as the natural mobx API instead of the minified `O(...)`, `B(...)`, `gt(...)`, `Ze(...)`.

https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKtbM4mDYGfL1iEgJ7wkcD)_