### PR TITLE
augur/core: wire portfolio YAML cost basis through to runtime tax math

### DIFF
--- a/augur/core/BUILD.bazel
+++ b/augur/core/BUILD.bazel
@@ -379,10 +379,12 @@ py_test(
 py_test(
     name = "test_e2e",
     srcs = ["test_e2e.py"],
+    data = ["testdata/portfolio.example.yaml"],
     deps = [
         ":api_py",
         ":market_bundle_py",
         ":market_bundle_test_support_py",
+        ":portfolio_py",
         ":scenario_set_py",
         "@pypi//numpy",
         "@pypi//pytest",

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -1355,9 +1355,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
     initial_crypto_basis = _initial_crypto_cost_basis_usd(scenario)
     pe_unit_price_usd = float(market_bundle.metadata.current_private_equity_price_usd)
     initial_private_equity = _initial_private_equity_value_usd(scenario, current_unit_price_usd=pe_unit_price_usd)
-    initial_private_equity_basis = _initial_private_equity_cost_basis_usd(
-        scenario, current_unit_price_usd=pe_unit_price_usd
-    )
+    initial_private_equity_basis = _initial_private_equity_cost_basis_usd(scenario)
     initial_private_equity_units = _initial_private_equity_units(scenario)
     private_equity_source_holding_id = _private_equity_source_holding_id(scenario)
     purchase_price = _purchase_price_usd(scenario)
@@ -5220,11 +5218,18 @@ def _initial_sp500_value_usd(scenario: Scenario) -> float:
 
 
 def _initial_sp500_cost_basis_usd(scenario: Scenario) -> float:
-    return sum(
-        asset.cost_basis_usd if asset.cost_basis_usd is not None else asset.value_usd
-        for asset in scenario.initial_balance_sheet.assets
-        if isinstance(asset, GenericSp500StockPosition)
-    )
+    total = 0.0
+    for asset in scenario.initial_balance_sheet.assets:
+        if not isinstance(asset, GenericSp500StockPosition):
+            continue
+        if asset.cost_basis_usd is None:
+            raise ValueError(
+                f"GenericSp500StockPosition {asset.asset_id!r} has no cost_basis_usd; the simulator "
+                "needs an explicit basis to seed tax lots. Supply it on the portfolio statement "
+                "(public_securities[*].cost_basis.amount_usd) or on the constructed position."
+            )
+        total += asset.cost_basis_usd
+    return total
 
 
 def _single_sp500_asset_source(scenario: Scenario, *, actor_id: str) -> GenericSp500StockPosition | None:
@@ -5245,11 +5250,18 @@ def _initial_crypto_value_usd(scenario: Scenario) -> float:
 
 
 def _initial_crypto_cost_basis_usd(scenario: Scenario) -> float:
-    return sum(
-        asset.cost_basis_usd if asset.cost_basis_usd is not None else asset.value_usd
-        for asset in scenario.initial_balance_sheet.assets
-        if isinstance(asset, CryptoAssetPosition)
-    )
+    total = 0.0
+    for asset in scenario.initial_balance_sheet.assets:
+        if not isinstance(asset, CryptoAssetPosition):
+            continue
+        if asset.cost_basis_usd is None:
+            raise ValueError(
+                f"CryptoAssetPosition {asset.asset_id!r} has no cost_basis_usd; the simulator "
+                "needs an explicit basis to seed tax lots. Supply it on the portfolio statement "
+                "(crypto_holdings[*].cost_basis.amount_usd) or on the constructed position."
+            )
+        total += asset.cost_basis_usd
+    return total
 
 
 def _crypto_asset_sources(scenario: Scenario, *, actor_id: str) -> tuple[CryptoAssetPosition, ...]:
@@ -5293,14 +5305,19 @@ def _initial_private_equity_value_usd(scenario: Scenario, *, current_unit_price_
     )
 
 
-def _initial_private_equity_cost_basis_usd(scenario: Scenario, *, current_unit_price_usd: float) -> float:
-    return sum(
-        asset.cost_basis_usd
-        if asset.cost_basis_usd is not None
-        else _private_equity_position_value_usd(asset, current_unit_price_usd=current_unit_price_usd)
-        for asset in scenario.initial_balance_sheet.assets
-        if isinstance(asset, PrivateEquityPosition)
-    )
+def _initial_private_equity_cost_basis_usd(scenario: Scenario) -> float:
+    total = 0.0
+    for asset in scenario.initial_balance_sheet.assets:
+        if not isinstance(asset, PrivateEquityPosition):
+            continue
+        if asset.cost_basis_usd is None:
+            raise ValueError(
+                f"PrivateEquityPosition {asset.asset_id!r} has no cost_basis_usd; the simulator "
+                "needs an explicit basis to seed tax lots. Supply it on the portfolio statement "
+                "(private_equity_lots[*].cost_basis.amount_usd) or on the constructed position."
+            )
+        total += asset.cost_basis_usd
+    return total
 
 
 def _initial_private_equity_units(scenario: Scenario) -> float:

--- a/augur/core/scenario_engine_test.py
+++ b/augur/core/scenario_engine_test.py
@@ -126,14 +126,25 @@ def _scenario_body(
     events: list[dict] | None = None,
     tax_regimes: list[str] | None = None,
 ) -> dict:
+    # The engine now requires an explicit cost basis on every position (no silent
+    # default to value_usd, which used to mask sales as zero-gain). For tests that
+    # don't care, mirror the SP500/crypto helper above and default to the
+    # supplied value — preserving the historical "basis = value, zero gain" shape.
+    # Units-only callers must pass private_equity_basis_usd explicitly because
+    # the helper doesn't know the unit price ahead of the engine.
+    effective_pe_basis = (
+        private_equity_basis_usd
+        if private_equity_basis_usd is not None
+        else (private_equity_usd if private_equity_usd is not None else 0.0)
+    )
     private_equity_asset: dict = {
         "asset_id": "private_equity",
         "asset_type": "private_equity",
         "owner_actor_id": "owner",
         "units": private_equity_units,
-        "cost_basis_usd": private_equity_basis_usd,
+        "cost_basis_usd": effective_pe_basis,
     }
-    # value_usd is optional now: when omitted, the simulator derives the opening mark
+    # value_usd is optional: when omitted, the simulator derives the opening mark
     # from units × MarketBundleMetadata.current_private_equity_price_usd. Keep value_usd
     # off the dict entirely when the caller wants the units-only path.
     if private_equity_usd is not None:

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -9,6 +9,7 @@ produce.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -21,6 +22,7 @@ from augur.core.accounting import ChartAccountRole, JournalEntryType, LotAssetCl
 from augur.core.api import ScenarioRun, simulate_set
 from augur.core.local_regulation import LocationId
 from augur.core.market_bundle_test_support import NoopMarketBundleProvider
+from augur.core.portfolio import load_portfolio_yaml
 from augur.core.scenario_set import (
     AccountBalance,
     AccountType,
@@ -2678,6 +2680,135 @@ def test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface() -> N
         market_observation_event_matrix.astype("float64"),
         result.matrix(ReportMetric.PRIVATE_EQUITY_SALE_OPPORTUNITY_EVENT).astype("float64"),
     )
+
+
+_PORTFOLIO_EXAMPLE_YAML = Path(__file__).parent / "testdata" / "portfolio.example.yaml"
+
+
+def test_portfolio_yaml_cost_basis_flows_into_sp500_sale_realized_gain() -> None:
+    """End-to-end check that an explicit cost basis on the portfolio statement lands on
+    the SP500 tax lot and shapes the realized gain (and the resulting tax accrual) of a
+    sale at simulation time. The example YAML carries `wealthfront_sp500` with
+    `market_value_usd: 50_000` and `cost_basis.amount_usd: 30_000`; selling $20k with
+    proportional basis allocation realizes a $20k × ($30k / $50k) = $12k basis and an
+    $8k gain. If the YAML basis were dropped the simulator would treat the basis as
+    either $0 (gain = $20k) or $50k (gain = $0) — neither matches the bracket math
+    below."""
+    portfolio = load_portfolio_yaml(_PORTFOLIO_EXAMPLE_YAML)
+    initial_balance_sheet = portfolio.to_initial_balance_sheet()
+
+    scenario = Scenario(
+        scenario_id="portfolio_yaml_sp500_sale",
+        label="Portfolio YAML SP500 Sale",
+        actors=(Actor(actor_id="owner", label="Owner", role=ActorRole.PRIMARY_OWNER),),
+        # prior_year_tax_usd=0 opts out of quarterly estimated payments so the asserted
+        # cash trajectory below sees only the sale-month tax accrual.
+        tax_profile=TaxProfile(prior_year_tax_usd=0),
+        initial_balance_sheet=initial_balance_sheet,
+        policies=(
+            # Cash floor sits above the YAML's $12,500 checking balance so the policy fires
+            # once at month 0, raises the $20k tranche, and is satisfied for the rest of
+            # the horizon.
+            CheckingFloorSellPublicStockPolicy(
+                policy_id="raise_cash", actor_id="owner", floor_usd=25_000, sale_amount_usd=20_000
+            ),
+        ),
+    )
+
+    result = _run_scenario(scenario, horizon_months=1)
+    rollout = result.rollout(0)
+
+    # Proportional basis on a $20k slice of a $50k position with $30k basis.
+    expected_basis = 20_000 * 30_000 / 50_000
+    expected_gain = 20_000 - expected_basis
+    # Tax expense from the engine's bracket math on the $8k realized gain; if the YAML
+    # basis ever stops flowing through, this number changes the moment the gain does.
+    expected_tax = 22.94
+
+    assert_allclose(rollout.series(ReportMetric.GENERIC_SP500_SALE_USD)[0], 20_000)
+    assert_allclose(rollout.series(ReportMetric.GENERIC_SP500_SALE_BASIS_USD)[0], expected_basis)
+    assert_allclose(rollout.series(ReportMetric.GENERIC_SP500_SALE_GAIN_USD)[0], expected_gain)
+    assert_allclose(rollout.series(ReportMetric.GENERIC_SP500_SALE_TAX_USD)[0], expected_tax)
+
+    sell_effects = result.effects(SellSp500Effect)
+    assert len(sell_effects) == 1
+    assert sell_effects[0].month_index == 0
+    assert sell_effects[0].basis_usd == expected_basis
+    assert sell_effects[0].gain_usd == expected_gain
+    assert_allclose(sell_effects[0].tax_usd, expected_tax)
+
+
+def test_portfolio_yaml_cost_basis_flows_into_private_equity_sale_realized_gain() -> None:
+    """End-to-end check that an explicit cost basis on a PrivateEquityLot lands on the
+    PE tax lot and shapes the realized gain of a tender sale. The example YAML carries
+    `private_company_seed_lot` with `mark_value_usd: 25_000` and `cost_basis.amount_usd:
+    5_000`; selling $10k with proportional basis allocation realizes a $10k × ($5k /
+    $25k) = $2k basis and an $8k gain."""
+    portfolio = load_portfolio_yaml(_PORTFOLIO_EXAMPLE_YAML)
+    initial_balance_sheet = portfolio.to_initial_balance_sheet()
+
+    scenario = Scenario(
+        scenario_id="portfolio_yaml_pe_sale",
+        label="Portfolio YAML PE Sale",
+        actors=(Actor(actor_id="owner", label="Owner", role=ActorRole.PRIMARY_OWNER),),
+        tax_profile=TaxProfile(prior_year_tax_usd=0),
+        initial_balance_sheet=initial_balance_sheet,
+        policies=(
+            PrivateEquitySalePolicy(
+                policy_id="tender_sale",
+                actor_id="owner",
+                proceeds_destination="cash",
+                sale_rule=FixedAmountPrivateEquitySaleRule(amount_usd=10_000),
+            ),
+        ),
+    )
+
+    result = _run_scenario(
+        scenario,
+        horizon_months=2,
+        market_provider=NoopMarketBundleProvider(private_equity_sale_opportunity_months=(1,)),
+    )
+    rollout = result.rollout(0)
+
+    expected_basis = 10_000 * 5_000 / 25_000
+    expected_gain = 10_000 - expected_basis
+    expected_tax = 22.94
+
+    assert_allclose(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_USD)[1], 10_000)
+    assert_allclose(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_BASIS_USD)[1], expected_basis)
+    assert_allclose(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_TAX_USD)[1], expected_tax)
+
+    sell_effects = result.effects(SellPrivateEquityEffect)
+    assert len(sell_effects) == 1
+    assert sell_effects[0].basis_usd == expected_basis
+    assert sell_effects[0].taxable_gain_usd == expected_gain
+    assert_allclose(sell_effects[0].estimated_tax_usd, expected_tax)
+
+
+def test_simulator_rejects_initial_position_without_explicit_cost_basis() -> None:
+    """The engine seeds tax lots from `*Position.cost_basis_usd`; a `None` basis used to
+    silently fall back to `value_usd` (zero gain on sale) which made every concentrated
+    holding look tax-free. The scenario engine now refuses to start with a missing basis
+    and points at the position so the caller knows what to fix."""
+    scenario = Scenario(
+        scenario_id="missing_basis",
+        label="Missing Basis",
+        actors=(_simple_actor(),),
+        initial_balance_sheet=InitialBalanceSheet(
+            assets=(
+                GenericSp500StockPosition(
+                    asset_id="sp500",
+                    asset_type=AssetType.GENERIC_SP500_STOCK,
+                    owner_actor_id="alpha",
+                    value_usd=50_000,
+                    # cost_basis_usd intentionally omitted.
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(ValueError, match="GenericSp500StockPosition 'sp500' has no cost_basis_usd"):
+        _run_scenario(scenario, horizon_months=1)
 
 
 def test_pydantic_rejects_private_equity_sale_policy_without_rule() -> None:


### PR DESCRIPTION
## Summary

- The portfolio statement already carried `CostBasis` on every public security, crypto holding, and PE lot, and `PortfolioStatement.to_initial_balance_sheet()` correctly mapped `cost_basis.amount_usd` onto `*Position.cost_basis_usd`. The gap was downstream: when a position arrived at the engine with `cost_basis_usd is None`, the `_initial_*_cost_basis_usd` helpers silently defaulted the basis to `value_usd`, which made every sale look like a zero-gain disposition.
- The engine now raises a clear `ValueError` that names the offending position when it sees a missing basis at simulation init, so the failure points at the source instead of laundering it through a fake-zero gain.
- New end-to-end coverage loads the example portfolio YAML, runs a sale through the engine, and asserts the realized gain and bracket-math tax accrual match the YAML basis — proving the wire from `cost_basis.amount_usd` all the way through to `TaxLot.cost_basis_usd` and the realized-gain ledger.

## Gap found

`_initial_sp500_cost_basis_usd`, `_initial_crypto_cost_basis_usd`, and `_initial_private_equity_cost_basis_usd` in `augur/core/scenario_engine.py` previously fell back to `asset.value_usd` (and, for PE, to `units × current_unit_price_usd`) when `asset.cost_basis_usd` was `None`. That meant any caller that forgot to set a basis got "basis = value, zero gain" silently — wrong for any concentrated holding sale (e.g. an early-stage PE lot at 5x mark, or a long-held public security with embedded gain).

## Wiring fix

Each helper now iterates and raises a typed `ValueError` that names the offending `asset_id` and the YAML field the caller should set. `_initial_private_equity_cost_basis_usd` also drops the now-unused `current_unit_price_usd` parameter.

## Nullability decision

`*Position.cost_basis_usd` stays `float | None` at the schema (callers without basis info can still construct a position), but the engine refuses to start a simulation when any contributing position has `cost_basis_usd is None`. Reasoning: silent default-to-`value_usd` made concentrated-holding sales look tax-free, and silent default-to-`0` would over-estimate tax in the other direction — neither is honest. The schema-level `None` is a transitional shape; once every call site sets a basis, the field can be tightened to required.

Test helper `_scenario_body` in `scenario_engine_test.py` now mirrors the SP500/crypto pattern and defaults the PE basis to the supplied value (or `0.0` on the units-only path), so existing tests that don't care about the tax math keep their "basis = value, zero gain" shape.

## New tests

- `test_portfolio_yaml_cost_basis_flows_into_sp500_sale_realized_gain` — loads `portfolio.example.yaml` (SP500 with `market_value_usd: 50_000`, `cost_basis.amount_usd: 30_000`), forces a $20k sale via `CheckingFloorSellPublicStockPolicy`, and asserts proportional basis = $12k, gain = $8k, and the engine's bracket-math tax = $22.94.
- `test_portfolio_yaml_cost_basis_flows_into_private_equity_sale_realized_gain` — same shape for the PE lot ($25k mark, $5k basis, $10k sale → $2k basis, $8k gain, $22.94 tax).
- `test_simulator_rejects_initial_position_without_explicit_cost_basis` — asserts the engine raises a `ValueError` naming the offending position when `cost_basis_usd` is omitted.

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:portfolio_test //augur/core:policy_runtime_test //augur/api:browser_shell_test` — all green
- [x] `bbr test //augur/...` — green except pre-existing red `//augur/frontend:visual_golden_test` (failing on `devel` without these changes, confirmed via stash)
- [x] `bbr build //augur/...` — green

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_