### PR TITLE
augur/core: outside-rent obligations for OWNER_RENTS_ELSEWHERE (Plan C slice 3)

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -30,26 +30,13 @@ second ordered roadmap.
       distribution. Model design is part of the same pass as PE above
       (joint vs independent fit is a design question; deployment evidence
       is private and stays downstream).
-- [ ] Plan C remaining slices (foundation landed in
-      `claude/plan-c-unified-obligations`): the `ObligationType` enum now
-      covers every variant called out in `plans/roadmap.md` (annual tax,
-      estimated tax, mortgage, property tax, HOA dues, insurance,
-      maintenance, outside rent, special assessment, partner
-      contribution); `_CashDebitObligationKind` provides the generic
-      pipeline shape with a `required: bool` knob; `SpecialAssessmentEvent`
-      is wired end-to-end as the first non-tax / non-mortgage cash demand
-      that routes through `_settle_required_cash_obligations`. Still
-      pending: (a) refactor `apply_property_operating_cash_flows` so
-      property tax / HOA / insurance / maintenance emit obligations
-      instead of debiting cash directly; (b) route the contributing-side
-      partner contribution through the obligation pipeline so a
-      cash-strapped partner produces FAILED; (c) add quarterly estimated
-      tax obligations on the standard Apr/Jun/Sep/Jan-next schedule with
-      100%/110% safe-harbor (90% first year), with the year-end true-up
-      reduced by estimated payments actually made; (d) outside-rent
-      obligations for `OccupancyMode.OWNER_RENTS_ELSEWHERE` (currently
-      not modeled — leave a tombstone at the call site until rent
-      modeling lands).
+- [ ] Plan C remaining slices: the unified obligation pipeline is fully
+      wired — `_CashDebitObligationKind` + `_PartnerContributionObligationKind`
+      route every required cash demand through
+      `_settle_required_cash_obligations`. Slices 1, 2, 4, 5, 6, 3 (foundation
+      through outside rent) have all landed. The only items still on the
+      roadmap are slice 7 ("Generalize failure tests") and inflation-indexed
+      outside rent (today the monthly amount is flat).
 - [ ] Drop the `Simulation` prefix from internal class names. Inside a
       simulator every class is by definition simulated; the prefix adds
       noise without disambiguating. Survey hit (after trace-surface collapse

--- a/augur/core/accounting.py
+++ b/augur/core/accounting.py
@@ -38,6 +38,7 @@ class ChartAccountRole(StrEnum):
     HOA_EXPENSE = "hoa_expense"
     INSURANCE_EXPENSE = "insurance_expense"
     MAINTENANCE_EXPENSE = "maintenance_expense"
+    OUTSIDE_RENT_EXPENSE = "outside_rent_expense"
     RENTAL_INCOME = "rental_income"
     RENTAL_MANAGEMENT_FEE_EXPENSE = "rental_management_fee_expense"
     RENTAL_LEASING_FEE_EXPENSE = "rental_leasing_fee_expense"

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -131,6 +131,7 @@ PROPERTY_TAX_POLICY_ID = "property_tax_obligation"
 HOA_DUES_POLICY_ID = "hoa_dues_obligation"
 INSURANCE_POLICY_ID = "insurance_premium_obligation"
 MAINTENANCE_POLICY_ID = "maintenance_obligation"
+OUTSIDE_RENT_POLICY_ID = "outside_rent_obligation"
 PARTNER_CONTRIBUTION_POLICY_ID = "partner_contribution_obligation"
 
 # IRS quarterly estimated tax due dates expressed as month offsets within a
@@ -2030,6 +2031,41 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             ),
             creditor_id="hoa",
             source_policy_id=SPECIAL_ASSESSMENT_POLICY_ID,
+            cash_usd=cash,
+            generic_sp500_value_usd=generic_sp500_value,
+            remaining_sp500_units_by_month=remaining_sp500_units_by_month,
+            remaining_sp500_basis_by_month=remaining_sp500_basis_by_month,
+            crypto_value_usd=crypto_value,
+            remaining_crypto_quantity_by_month=remaining_crypto_quantity_by_month,
+            remaining_crypto_basis_by_month=remaining_crypto_basis_by_month,
+            crypto_sale_usd=crypto_sale_usd,
+            crypto_sale_basis_usd=crypto_sale_basis_usd,
+            checking_floor_shortfall_usd=checking_floor_shortfall,
+            obligations=obligations,
+            funding_decisions=funding_decisions,
+            settlement_results=settlement_results,
+            failure_events=failure_events,
+            accounting=accounting,
+            sp500_sale_action_records=sp500_sale_action_records,
+            crypto_sale_action_records=crypto_sale_action_records,
+        )
+    # Outside-rent obligations: when occupancy_mode is OWNER_RENTS_ELSEWHERE, the
+    # primary owner pays a flat monthly rent for each month in the occupancy span.
+    # Settled through the same pipeline so a cash-strapped renter (no rescue
+    # policy) flips the rollout to FAILED.
+    outside_rent_due = _outside_rent_obligation_due_usd(scenario, rollout_count=rollout_count, month_index=month_index)
+    if np.any(outside_rent_due > 0):
+        _settle_required_cash_obligations(
+            scenario=scenario,
+            market_bundle=market_bundle,
+            month_index=month_index,
+            policy_steps=policy_steps,
+            obligation_amount_usd=outside_rent_due,
+            obligation_kind=_CashDebitObligationKind(
+                obligation_type=ObligationType.OUTSIDE_RENT, expense_role=ChartAccountRole.OUTSIDE_RENT_EXPENSE
+            ),
+            creditor_id="landlord",
+            source_policy_id=OUTSIDE_RENT_POLICY_ID,
             cash_usd=cash,
             generic_sp500_value_usd=generic_sp500_value,
             remaining_sp500_units_by_month=remaining_sp500_units_by_month,
@@ -5455,6 +5491,30 @@ def _partner_initial_funding_cash_usd(
     ):
         return explicit_cash
     return configured_contribution_total_usd
+
+
+def _outside_rent_obligation_due_usd(scenario: Scenario, *, rollout_count: int, month_index: np.ndarray) -> np.ndarray:
+    """Build a (rollout, month) matrix of outside-rent dues from the occupancy plan.
+
+    Each month in [start_month, end_month or last in-horizon month] contributes
+    `outside_rent_monthly_usd` when `occupancy_mode is OWNER_RENTS_ELSEWHERE`.
+    Zero rent or any other occupancy mode returns an all-zero matrix (callers can
+    short-circuit on `np.any(... > 0)`). Every rollout pays the same flat rent —
+    outside rent is a deterministic occupancy choice today, not a stochastic input.
+    Inflation indexing is a deliberate follow-up.
+    """
+    matrix = np.zeros((rollout_count, month_index.size), dtype="float64")
+    plan = scenario.occupancy_plan
+    if (
+        plan.occupancy_mode is not OccupancyMode.OWNER_RENTS_ELSEWHERE
+        or plan.outside_rent_monthly_usd <= 0
+        or month_index.size == 0
+    ):
+        return matrix
+    end_inclusive = plan.end_month if plan.end_month is not None else int(month_index.max())
+    span_mask = (month_index >= int(plan.start_month)) & (month_index <= int(end_inclusive))
+    matrix[:, span_mask] = float(plan.outside_rent_monthly_usd)
+    return matrix
 
 
 def _special_assessment_obligation_due_usd(

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -247,12 +247,6 @@ PropertyId = str
 class OccupancyMode(StrEnum):
     OWNER_LIVES_IN_PROPERTY = "owner_lives_in_property"
     OWNER_LIVES_IN_OTHER_OWNED_PROPERTY = "owner_lives_in_other_owned_property"
-    # CLEANUP(2026-05-17): `OWNER_RENTS_ELSEWHERE` is not modeled — the
-    #   engine has no per-month rent debit for the owner-as-tenant role and
-    #   no rent-policy schema. Plan C slice 3 (`augur/plans/roadmap.md`)
-    #   reserves `ObligationType.OUTSIDE_RENT` for the moment a rent policy
-    #   lands and starts emitting the obligation. Remove this comment when
-    #   that slice ships.
     OWNER_RENTS_ELSEWHERE = "owner_rents_elsewhere"
     NO_OWNER_OCCUPANCY = "no_owner_occupancy"
 
@@ -782,11 +776,25 @@ class OccupancyPlan(ApiModel):
     owner_residence_property_id: PropertyId | None = None
     start_month: NonNegativeInt = 0
     end_month: NonNegativeInt | None = None
+    # Flat monthly outside-rent the primary owner pays while the occupancy mode is
+    # OWNER_RENTS_ELSEWHERE. Accrues as a required OUTSIDE_RENT obligation every
+    # month in [start_month, end_month or horizon]. Inflation indexing is a
+    # deliberate follow-up; today this is a flat value.
+    outside_rent_monthly_usd: NonNegativeFloat = 0
 
     @model_validator(mode="after")
     def _end_after_start(self) -> OccupancyPlan:
         if self.end_month is not None and self.end_month < self.start_month:
             raise ValueError("end_month must be greater than or equal to start_month")
+        return self
+
+    @model_validator(mode="after")
+    def _outside_rent_requires_owner_rents_elsewhere(self) -> OccupancyPlan:
+        if self.outside_rent_monthly_usd > 0 and self.occupancy_mode is not OccupancyMode.OWNER_RENTS_ELSEWHERE:
+            raise ValueError(
+                "outside_rent_monthly_usd > 0 requires occupancy_mode = OWNER_RENTS_ELSEWHERE; "
+                f"got {self.occupancy_mode}"
+            )
         return self
 
 

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -40,6 +40,8 @@ from augur.core.scenario_set import (
     MonthlySpendPolicy,
     ObligationStatus,
     ObligationType,
+    OccupancyMode,
+    OccupancyPlan,
     PartnerContributionDecision,
     PartnerEquityAccrualPolicy,
     PrivateEquityPosition,
@@ -2693,6 +2695,204 @@ def test_pydantic_rejects_private_equity_sale_policy_without_rule() -> None:
                 ],
             }
         )
+
+
+def _outside_rent_scenario(
+    *,
+    scenario_id: str,
+    initial_cash_usd: float,
+    monthly_rent_usd: float = 3_000,
+    end_month: int | None = None,
+    policies: tuple = (),
+    sp500_value_usd: float = 0,
+) -> Scenario:
+    """A minimal `OWNER_RENTS_ELSEWHERE` scenario for the outside-rent obligation path.
+
+    No property is selected — outside rent flows from the occupancy plan alone, not
+    from a property the actor owns. SP500 is optional so the rescue-policy test can
+    show a sale path.
+    """
+    assets: tuple = ()
+    if sp500_value_usd > 0:
+        assets = (
+            GenericSp500StockPosition(
+                asset_id="sp500", owner_actor_id="alpha", value_usd=sp500_value_usd, cost_basis_usd=sp500_value_usd
+            ),
+        )
+    return Scenario(
+        scenario_id=scenario_id,
+        label=scenario_id.replace("_", " ").title(),
+        actors=(_simple_actor(),),
+        occupancy_plan=OccupancyPlan(
+            occupancy_mode=OccupancyMode.OWNER_RENTS_ELSEWHERE,
+            outside_rent_monthly_usd=monthly_rent_usd,
+            end_month=end_month,
+        ),
+        policies=policies,
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking",
+                    account_type=AccountType.CHECKING,
+                    owner_actor_id="alpha",
+                    balance_usd=initial_cash_usd,
+                ),
+            ),
+            assets=assets,
+        ),
+    )
+
+
+def test_outside_rent_obligation_settles_when_cash_available() -> None:
+    """Happy path: `OWNER_RENTS_ELSEWHERE` + $3000/mo rent over 12 months emits one
+    PAID `OUTSIDE_RENT` obligation per month and the cash trajectory dips by $3000
+    each month."""
+    horizon_months = 12
+    scenario = _outside_rent_scenario(scenario_id="outside_rent_paid", initial_cash_usd=100_000, monthly_rent_usd=3_000)
+    result = _run_scenario(scenario, horizon_months=horizon_months)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    outside_rent_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.OUTSIDE_RENT
+    )
+    # Rent accrues every month from 0 through horizon (inclusive of the snapshot
+    # month) — the engine treats month_index values 0..horizon as 13 columns and
+    # the occupancy span spans the full horizon by default.
+    assert len(outside_rent_obligations) == horizon_months + 1
+    assert {obligation.status for obligation in outside_rent_obligations} == {ObligationStatus.PAID}
+    assert {obligation.amount_due_usd for obligation in outside_rent_obligations} == {3_000}
+    # Settlement journal entries credit cash for $3000 every month.
+    assert_allclose(
+        _posting_matrix(
+            result,
+            role=ChartAccountRole.OUTSIDE_RENT_EXPENSE,
+            side=PostingSide.DEBIT,
+            journal_entry_type=JournalEntryType.OBLIGATION_SETTLEMENT,
+        ),
+        np.full((1, horizon_months + 1), 3_000.0, dtype="float64"),
+    )
+    # Cash trajectory: $100k starting, $3000 settles at every snapshot month
+    # (including month 0 — rent is due upfront for the snapshot period, unlike
+    # property carrying costs which exclude month 0).
+    cash_series = result.rollout(0).series(ReportMetric.CASH_USD)
+    expected_cash = [100_000 - 3_000 * (month + 1) for month in range(horizon_months + 1)]
+    assert_allclose(cash_series, expected_cash)
+    # The new enum variant carries a creditor and a unique obligation_id per month.
+    creditors = {decision.creditor_id for decision in outside_rent_obligations}
+    assert creditors == {"landlord"}
+
+
+def test_outside_rent_obligation_fails_rollout_when_unfundable() -> None:
+    """Cash-strapped renter with no rescue policy: the first month's OUTSIDE_RENT
+    obligation flips the rollout to FAILED and emits a FailureEvent keyed to
+    OUTSIDE_RENT."""
+    scenario = _outside_rent_scenario(
+        scenario_id="outside_rent_unfundable", initial_cash_usd=500, monthly_rent_usd=3_000
+    )
+    horizon_months = 4
+    result = _run_scenario(scenario, horizon_months=horizon_months)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.FAILED
+    rent_failures = tuple(
+        event for event in result.arrays.failure_events if event.obligation_id.startswith("outside_rent")
+    )
+    # Every rent month after cash dries up emits a failure event. With $500 cash
+    # and $3000 monthly rent, the very first month is already a shortfall.
+    assert len(rent_failures) == horizon_months + 1
+    assert rent_failures[0].month_index == 0
+    assert all(event.unpaid_amount_usd > 0 for event in rent_failures)
+    unfunded = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("outside_rent") and decision.decision_type is FundingDecisionType.UNFUNDED
+    )
+    assert len(unfunded) == horizon_months + 1
+    assert all(decision.shortfall_usd > 0 for decision in unfunded)
+
+
+def test_outside_rent_shortfall_can_be_rescued_by_checking_floor_sale_policy() -> None:
+    """A `CheckingFloorSellPublicStockPolicy` rescues an outside-rent shortfall by
+    selling SP500 stock to make rent. The rollout stays ACTIVE; the funding decision
+    is `SELL_PUBLIC_STOCK` against the OUTSIDE_RENT obligation."""
+    scenario = _outside_rent_scenario(
+        scenario_id="outside_rent_rescued",
+        initial_cash_usd=500,
+        monthly_rent_usd=3_000,
+        sp500_value_usd=100_000,
+        policies=(
+            # `sale_amount_usd` must clear the full $3000 rent in a single sale —
+            # partial covers still leave a shortfall on a required obligation,
+            # which the engine treats as FAILED.
+            CheckingFloorSellPublicStockPolicy(
+                policy_id="rent_funding_sale", actor_id="alpha", floor_usd=0, sale_amount_usd=5_000
+            ),
+        ),
+    )
+    horizon_months = 3
+    result = _run_scenario(scenario, horizon_months=horizon_months)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    rent_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.OUTSIDE_RENT
+    )
+    assert len(rent_obligations) == horizon_months + 1
+    assert {obligation.status for obligation in rent_obligations} == {ObligationStatus.PAID}
+    assert tuple(event for event in result.arrays.failure_events) == ()
+    sale_funding = tuple(
+        decision
+        for decision in result.arrays.funding_decisions
+        if decision.obligation_id.startswith("outside_rent")
+        and decision.decision_type is FundingDecisionType.SELL_PUBLIC_STOCK
+    )
+    assert len(sale_funding) >= 1
+    assert {decision.policy_id for decision in sale_funding} == {"rent_funding_sale"}
+    assert all(decision.funded_cash_usd > 0 for decision in sale_funding)
+
+
+def test_outside_rent_stops_when_occupancy_span_ends() -> None:
+    """Occupancy span ending mid-rollout (end_month=5) stops rent accrual at month
+    6 onward; only months 0-5 produce OUTSIDE_RENT obligations."""
+    scenario = _outside_rent_scenario(
+        scenario_id="outside_rent_span_ends", initial_cash_usd=100_000, monthly_rent_usd=3_000, end_month=5
+    )
+    horizon_months = 12
+    result = _run_scenario(scenario, horizon_months=horizon_months)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    rent_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.OUTSIDE_RENT
+    )
+    # Months 0..5 inclusive = 6 obligations.
+    assert len(rent_obligations) == 6
+    assert {obligation.month_index for obligation in rent_obligations} == {0, 1, 2, 3, 4, 5}
+    assert {obligation.status for obligation in rent_obligations} == {ObligationStatus.PAID}
+    # Cash stops dipping once rent stops: months 6..12 hold steady at the post-rent balance.
+    cash_series = result.rollout(0).series(ReportMetric.CASH_USD)
+    expected_post_rent_cash = 100_000 - 3_000 * 6
+    assert_allclose(cash_series[6:], expected_post_rent_cash)
+
+
+def test_outside_rent_zero_amount_produces_no_obligations() -> None:
+    """`outside_rent_monthly_usd=0` skips the accrual entirely — no obligations, no
+    settlements. Zero-amount obligations would be noise on the trace."""
+    scenario = _outside_rent_scenario(scenario_id="outside_rent_zero", initial_cash_usd=10_000, monthly_rent_usd=0)
+    result = _run_scenario(scenario, horizon_months=6)
+    assert result.arrays is not None
+    assert result.rollout(0).status().status == RolloutStatusType.ACTIVE
+    outside_rent_obligations = tuple(
+        obligation
+        for obligation in result.arrays.obligations
+        if obligation.obligation_type is ObligationType.OUTSIDE_RENT
+    )
+    assert outside_rent_obligations == ()
+    # Cash is unchanged because no obligation accrues.
+    assert_allclose(result.rollout(0).series(ReportMetric.CASH_USD), 10_000)
 
 
 if __name__ == "__main__":

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -498,9 +498,14 @@ Generalize the shape so **one** pattern handles every immediate cash demand:
    Today this isn't first-class. Add a `RentalPaymentPolicy` (or extend
    `OccupancyDecisionPolicy`) that accrues monthly rent as a required
    obligation. Verify against existing tests.
-   **Pending.** Today `OWNER_RENTS_ELSEWHERE` does not model the
-   tenant-side rent cash demand at all (no direct cash debit either);
-   the `OUTSIDE_RENT` enum value is reserved for when rent modeling lands.
+   **Landed.** `OccupancyPlan.outside_rent_monthly_usd` is a flat monthly
+   knob (inflation indexing deferred); each month in the occupancy span
+   accrues an `OUTSIDE_RENT` obligation on the primary owner via
+   `_CashDebitObligationKind(expense_role=ChartAccountRole.OUTSIDE_RENT_EXPENSE)`
+   and routes through `_settle_required_cash_obligations` with
+   `creditor_id="landlord"`. Cash-strapped renters without a rescue
+   policy flip the rollout to `FAILED`; a `CheckingFloorSellPublicStockPolicy`
+   rescues by selling SP500.
 4. **Partner-contribution obligations**. Today
    `apply_partner_house_cost_contribution` debits cash unconditionally. The
    contributing actor's failure to fund their share of housing costs is a


### PR DESCRIPTION
## Summary

Slice 3 of Plan C: make `ObligationType.OUTSIDE_RENT` a live cash demand instead of dead enum metadata.

**Schema decision**: `outside_rent_monthly_usd: NonNegativeFloat = 0` lives on `OccupancyPlan` (next to `occupancy_mode`, `start_month`, `end_month`). The post-init validator rejects `outside_rent_monthly_usd > 0` when `occupancy_mode` is not `OWNER_RENTS_ELSEWHERE`, so misuse fails fast. Inflation indexing is documented as a deliberate follow-up; today the rent is a flat value.

**Obligation kind reuse**: reuses the existing `_CashDebitObligationKind` with a new `ChartAccountRole.OUTSIDE_RENT_EXPENSE`. No new dataclass — outside rent has the exact same shape as HOA/insurance/maintenance (single expense debit against cash on the settlement JE). Settles through `_settle_required_cash_obligations` with `creditor_id="landlord"` and `source_policy_id=OUTSIDE_RENT_POLICY_ID`. Required = True; cash-strapped renters without a rescue policy flip the rollout to FAILED.

**Trace placement**: called after the special-assessment block and before the partner-contribution block in `run_scenario_vectorized`. The new `_outside_rent_obligation_due_usd` helper builds a `(rollout, month)` matrix from the occupancy plan; every rollout pays the same flat rent because outside rent is a deterministic occupancy choice today, not a stochastic input. Months outside `[start_month, end_month]` zero out, so a mode-change scenario (`end_month=5`) stops accruing at month 6.

**Tests added** in `augur/core/test_e2e.py`:

1. `test_outside_rent_obligation_settles_when_cash_available` — 12-month happy path with $3000/mo rent + $100k cash, asserts 13 PAID OUTSIDE_RENT obligations, OUTSIDE_RENT_EXPENSE postings, and monthly $3000 cash dips.
2. `test_outside_rent_obligation_fails_rollout_when_unfundable` — $500 cash + $3000 rent + no rescue policy → FAILED with FailureEvent rows tagged to OUTSIDE_RENT.
3. `test_outside_rent_shortfall_can_be_rescued_by_checking_floor_sale_policy` — same shortfall but with a `CheckingFloorSellPublicStockPolicy(sale_amount_usd=5_000)` → rollout stays ACTIVE, SP500 sells to cover rent. Documents the gotcha that the sale chunk must clear the full monthly rent (partial covers leave the required obligation in shortfall, which still fails).
4. `test_outside_rent_stops_when_occupancy_span_ends` — `OccupancyPlan(end_month=5)` produces 6 obligations (months 0..5), then cash holds steady through month 12.
5. `test_outside_rent_zero_amount_produces_no_obligations` — `outside_rent_monthly_usd=0` skips the accrual entirely (no zero-amount obligations on the trace).

**Tombstone removed**: the `CLEANUP(2026-05-17)` comment on `OccupancyMode.OWNER_RENTS_ELSEWHERE` in `scenario_set.py` is deleted. The `OUTSIDE_RENT` enum variant is no longer dead code. `augur/TODO.md` Plan C entry trimmed to reflect everything-but-slice-7 has landed; `augur/plans/roadmap.md` slice 3 marked Landed with a brief design recap.

**Out of scope** per the plan: inflation indexing on the monthly amount, federal tax treatment (rent isn't deductible federally anyway), browser/UI for the new knob (follow-up), partial-month rent on mid-month mode flips (month-boundary changes only).

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:policy_runtime_test //augur/api:browser_shell_test` — all green
- [x] `bbr test //augur/...` — all green except `//augur/frontend:visual_golden_test`, which is pre-existing red on `devel` itself (Playwright timeouts on frontend, unrelated to the obligation pipeline)
- [x] `bbr build //augur/...` — green
- [x] Tombstone removed
- [x] `ObligationType.OUTSIDE_RENT` enum variant referenced from production code (no longer dead)

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_