### PR TITLE
augur/core: implement PublicMarket and Acquisition PE liquidity regimes

### DIFF
--- a/augur/SPEC.md
+++ b/augur/SPEC.md
@@ -36,16 +36,17 @@ records what an outside observer can rely on.
 
 A discriminated union. Current variants:
 
-| Variant              | Meaning                                                                                                                                   | Status       |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `LiquidityEventOnly` | Sale only at discrete sampled liquidity opportunities. The event stream is a stochastic process with binary arrivals and per-event price. | Implemented. |
-| `PublicMarket`       | Free sale at the spot price each month, subject to optional `lockup_end_month`.                                                           | Future.      |
-| `Acquisition`        | One-shot conversion at a fixed `cash_per_unit_usd` at a sampled `event_month`.                                                            | Future.      |
+| Variant              | Meaning                                                                                                                                                                                                                                                                        | Status       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `LiquidityEventOnly` | Sale only at discrete sampled liquidity opportunities. The event stream is a stochastic process with binary arrivals and per-event price.                                                                                                                                      | Implemented. |
+| `PublicMarket`       | Free sale at the spot price each month, subject to optional `lockup_end_month`. Participates in the obligation funding-policy chain when a `CheckingFloorSellPublicStockPolicy` lists `PRIVATE_EQUITY` in `sale_asset_preference`; the default preference does not include PE. | Implemented. |
+| `Acquisition`        | One-shot forced conversion of the entire remaining position at a fixed `cash_per_unit_usd` on `event_month`. Realized gain feeds the existing annual sale-tax allocation.                                                                                                      | Implemented. |
 
 A `PrivateEquity` asset can transition between regimes via a sampled
 **regime-change event** (e.g. an IPO converts `LiquidityEventOnly` → `PublicMarket`).
-Regime changes are not currently implemented; the model carries them in the
-event-type vocabulary as a TODO.
+The discriminated-union shape supports this, but there is no runtime hook
+yet: regime changes mid-rollout are Future. Today, a position's regime is
+fixed for the whole horizon by `PrivateEquityPosition.liquidity_regime`.
 
 ### Policy types
 

--- a/augur/core/scenario_engine.py
+++ b/augur/core/scenario_engine.py
@@ -67,6 +67,7 @@ from augur.core.scenario_set import (
     AccountingDetail,
     AccountingDetailType,
     AccountType,
+    Acquisition,
     ActorRole,
     AssetType,
     CheckingFloorSellPublicStockPolicy,
@@ -80,6 +81,7 @@ from augur.core.scenario_set import (
     FundingDecisionType,
     FundingSourceType,
     GenericSp500StockPosition,
+    LiquidityEventOnly,
     LiquidNetWorthFloorPrivateEquitySaleRule,
     MarketObservation,
     MarketPathObservation,
@@ -101,6 +103,7 @@ from augur.core.scenario_set import (
     PrivateEquitySaleRule,
     PropertyPurchaseEvent,
     PropertySaleBasisGainDetail,
+    PublicMarket,
     RentalMode,
     ReportMetric,
     RolloutStatus,
@@ -864,6 +867,29 @@ class CryptoObligationFundingPolicyApplication:
     remaining_basis_usd: np.ndarray
 
 
+@dataclass(frozen=True)
+class PrivateEquityObligationFundingPolicyApplication:
+    """Result of funding an obligation by selling a `PublicMarket`-regime PE position.
+
+    Realized gain feeds the existing annual PE sale-tax allocation (long-term
+    capital gain treatment), and the lot disposition / journal entries are
+    recorded through the standard PE sale recorder.
+    """
+
+    policy_step: ActorPolicyStep[Policy]
+    instruction: SellAssetInstructionBatch
+    sale_usd: np.ndarray
+    basis_usd: np.ndarray
+    taxable_gain_usd: np.ndarray
+    funded_cash_usd: np.ndarray
+    shortfall_usd: np.ndarray
+    remaining_due_usd: np.ndarray
+    remaining_units: np.ndarray
+    remaining_basis_usd: np.ndarray
+    sold_units: np.ndarray
+    sold_fraction: np.ndarray
+
+
 class AccountingTraceBuilder:
     def __init__(self) -> None:
         self.chart_accounts_by_id: dict[str, ChartAccount] = {}
@@ -1360,6 +1386,21 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
     )
     initial_private_equity_units = _initial_private_equity_units(scenario)
     private_equity_source_holding_id = _private_equity_source_holding_id(scenario)
+    pe_liquidity_regime = _effective_pe_liquidity_regime(scenario)
+    # PublicMarket regime makes the holding freely sellable from `lockup_end_month`
+    # onward, so we widen the tender-window mask the engine uses when computing
+    # PE sale opportunities. The reported `private_equity_sale_opportunity_event`
+    # series keeps the original market-sampled mask: the widening is an
+    # engine-internal extension of "when can this position be sold", not a
+    # claim that the market emitted a tender opportunity. Tender-based scenarios
+    # (LiquidityEventOnly) keep their original mask byte-for-byte.
+    effective_pe_sale_opportunity_mask = market_bundle.private_equity_sale_opportunity_mask
+    if isinstance(pe_liquidity_regime, PublicMarket):
+        lockup_end_month = pe_liquidity_regime.lockup_end_month or 0
+        sellable_months = (month_index >= lockup_end_month).astype(np.bool_)
+        effective_pe_sale_opportunity_mask = market_bundle.private_equity_sale_opportunity_mask | np.broadcast_to(
+            sellable_months[None, :], market_bundle.private_equity_sale_opportunity_mask.shape
+        )
     purchase_price = _purchase_price_usd(scenario)
     policy_programs = actor_policy_programs(scenario)
     policy_steps = actor_policy_steps(policy_programs)
@@ -1434,6 +1475,9 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
     cash = np.zeros((rollout_count, month_count), dtype="float64")
     remaining_sp500_units_by_month = np.zeros((rollout_count, month_count), dtype="float64")
     remaining_sp500_basis_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+    remaining_private_equity_units_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+    remaining_private_equity_basis_by_month = np.zeros((rollout_count, month_count), dtype="float64")
+    private_equity_sale_usd_by_month = np.zeros((rollout_count, month_count), dtype="float64")
     private_equity_sale_opportunity_event = market_bundle.private_equity_sale_opportunity_mask.copy()
     remaining_private_equity_fraction = np.ones(rollout_count, dtype="float64")
     remaining_sp500_units = np.divide(
@@ -1590,13 +1634,74 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             remaining_crypto_quantity = remaining_crypto_quantity_by_month[:, month]
             remaining_crypto_basis = remaining_crypto_basis_by_month[:, month]
 
+        # Compute pre-acquisition value first so the downstream "value - sale"
+        # bookkeeping nets to zero rather than going negative when the entire
+        # remaining position converts.
         private_equity_value_before_sale = (
             initial_private_equity
             * remaining_private_equity_fraction
             * market_bundle.private_equity_value_multipliers[:, month]
         )
+        # Acquisition regime: forced conversion of the entire remaining PE
+        # position into cash on `event_month`. Realized gain feeds the existing
+        # annual sale-tax allocation (long-term capital gain treatment). The
+        # PE position drops to zero units after this month. We use the
+        # current spot mark (units × multiplier-driven unit price) as the
+        # accounting value reduction, but cash proceeds use
+        # `units × cash_per_unit_usd` as the contract specifies.
+        acquisition_sale_month = np.zeros(rollout_count, dtype="float64")
+        acquisition_taxable_gain_month = np.zeros(rollout_count, dtype="float64")
+        if isinstance(pe_liquidity_regime, Acquisition) and month == int(pe_liquidity_regime.event_month):
+            acquisition_proceeds = remaining_private_equity_units * float(pe_liquidity_regime.cash_per_unit_usd)
+            acquisition_basis = remaining_private_equity_basis.copy()
+            acquisition_taxable_gain = np.maximum(0.0, acquisition_proceeds - acquisition_basis)
+            acquisition_units_sold = remaining_private_equity_units.copy()
+            acquisition_sold_fraction = remaining_private_equity_fraction.copy()
+            current_cash = current_cash + acquisition_proceeds
+            acquisition_instruction = PrivateEquitySaleInstructionBatch(
+                actor_id=_primary_owner_actor_id(scenario),
+                policy_id=f"private_equity_acquisition:{private_equity_source_holding_id}",
+                requested_amount_usd=acquisition_proceeds,
+                proceeds_destination=AccountType.CHECKING,
+                opportunity_id=np.array([None] * rollout_count, dtype=object),
+                opportunity_cause_id=np.array(
+                    [
+                        f"private_equity_acquisition:{private_equity_source_holding_id}:rollout:{i}:month:"
+                        f"{int(month_index[month])}"
+                        for i in range(rollout_count)
+                    ],
+                    dtype=object,
+                ),
+            )
+            acquisition_application = PrivateEquitySaleApplication(
+                sale_usd=acquisition_proceeds,
+                basis_usd=acquisition_basis,
+                taxable_gain_usd=acquisition_taxable_gain,
+                sold_units=acquisition_units_sold,
+                sold_fraction=acquisition_sold_fraction,
+                remaining_units=np.zeros(rollout_count, dtype="float64"),
+                remaining_basis_usd=np.zeros(rollout_count, dtype="float64"),
+                remaining_fraction=np.zeros(rollout_count, dtype="float64"),
+                journal_entries=(),
+            )
+            private_equity_sale_action_records.append(
+                PrivateEquitySaleActionRecord(
+                    month_position=month,
+                    month_index=int(month_index[month]),
+                    instruction=acquisition_instruction,
+                    sale_application=acquisition_application,
+                )
+            )
+            remaining_private_equity_fraction = acquisition_application.remaining_fraction
+            remaining_private_equity_basis = acquisition_application.remaining_basis_usd
+            remaining_private_equity_units = acquisition_application.remaining_units
+            acquisition_sale_month = acquisition_proceeds
+            acquisition_taxable_gain_month = acquisition_taxable_gain
+            # Override pre-sale value to match cash proceeds for accounting
+            # parity: the PE value debit and cash credit settle to zero.
+            private_equity_value_before_sale = acquisition_proceeds
         market_opportunity = private_equity_sale_opportunity(
-            sale_opportunity_mask=market_bundle.private_equity_sale_opportunity_mask[:, month],
+            sale_opportunity_mask=effective_pe_sale_opportunity_mask[:, month],
             private_equity_value_before_sale_usd=private_equity_value_before_sale,
             path_set_id=market_bundle.metadata.path_set_id,
             month_index=int(month_index[month]),
@@ -1609,8 +1714,8 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             opportunity=market_opportunity,
         )
         market_sale_opportunity_value = market_opportunity.sale_opportunity_value_usd
-        private_equity_sale_month = np.zeros(rollout_count, dtype="float64")
-        private_equity_sale_taxable_gain_month = np.zeros(rollout_count, dtype="float64")
+        private_equity_sale_month = acquisition_sale_month.copy()
+        private_equity_sale_taxable_gain_month = acquisition_taxable_gain_month.copy()
         private_equity_sale_tax_month = np.zeros(rollout_count, dtype="float64")
         sp500_multiplier = market_bundle.generic_sp500_multipliers[:, month]
         sp500_sale = np.zeros(rollout_count, dtype="float64")
@@ -1644,7 +1749,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
                     * market_bundle.private_equity_value_multipliers[:, month]
                 )
                 current_opportunity = private_equity_sale_opportunity(
-                    sale_opportunity_mask=market_bundle.private_equity_sale_opportunity_mask[:, month],
+                    sale_opportunity_mask=effective_pe_sale_opportunity_mask[:, month],
                     private_equity_value_before_sale_usd=current_private_equity_value,
                     path_set_id=market_bundle.metadata.path_set_id,
                     month_index=int(month_index[month]),
@@ -1750,6 +1855,9 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             0.0, market_sale_opportunity_value - private_equity_sale_month
         )
         private_equity_value[:, month] = private_equity_value_before_sale - private_equity_sale_month
+        private_equity_sale_usd_by_month[:, month] = private_equity_sale_month
+        remaining_private_equity_units_by_month[:, month] = remaining_private_equity_units
+        remaining_private_equity_basis_by_month[:, month] = remaining_private_equity_basis
 
     property_tax_for_tax_allocation = property_cash_flow.property_tax_usd * property_live_mask
     net_rental_taxable_income = (
@@ -1798,6 +1906,21 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         tax_profile=scenario.tax_profile,
     )
     settlement_count_before_estimated = len(settlement_results)
+    # PE funding state is shared across all post-loop obligation settlements.
+    # Sales taken to fund obligations update remaining units/basis/value matrices
+    # in place and append to the action-record list so the standard
+    # PrivateEquitySaleActionRecord -> journal/lot/effect path runs after.
+    pe_funding_state = _PrivateEquityFundingState(
+        private_equity_value_usd=private_equity_value,
+        remaining_units_by_month=remaining_private_equity_units_by_month,
+        remaining_basis_by_month=remaining_private_equity_basis_by_month,
+        private_equity_sale_usd=private_equity_sale_usd_by_month,
+        private_equity_sale_taxable_gain_usd=private_equity_sale_taxable_gain,
+        pe_value_multipliers=market_bundle.private_equity_value_multipliers,
+        initial_private_equity=initial_private_equity,
+        source_holding_id=private_equity_source_holding_id,
+        sale_action_records=private_equity_sale_action_records,
+    )
     _settle_required_cash_obligations(
         scenario=scenario,
         market_bundle=market_bundle,
@@ -1824,6 +1947,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         accounting=accounting,
         sp500_sale_action_records=sp500_sale_action_records,
         crypto_sale_action_records=crypto_sale_action_records,
+        pe_state=pe_funding_state,
     )
     tax_year_by_position_for_credit = month_index // MONTHS_PER_YEAR
     tax_year_count_for_credit = (
@@ -1866,6 +1990,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
         accounting=accounting,
         sp500_sale_action_records=sp500_sale_action_records,
         crypto_sale_action_records=crypto_sale_action_records,
+        pe_state=pe_funding_state,
     )
 
     partner_present = np.full((rollout_count, month_count), _has_partner(scenario), dtype=np.bool_)
@@ -2014,6 +2139,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             accounting=accounting,
             sp500_sale_action_records=sp500_sale_action_records,
             crypto_sale_action_records=crypto_sale_action_records,
+            pe_state=pe_funding_state,
         )
     special_assessment_due = _special_assessment_obligation_due_usd(
         scenario, rollout_count=rollout_count, month_index=month_index
@@ -2047,6 +2173,7 @@ def run_scenario_vectorized(scenario: Scenario, market_bundle: MarketBundle) -> 
             accounting=accounting,
             sp500_sale_action_records=sp500_sale_action_records,
             crypto_sale_action_records=crypto_sale_action_records,
+            pe_state=pe_funding_state,
         )
     # Partner contribution obligations: each PartnerEquityAccrualPolicy emits a
     # required monthly PARTNER_CONTRIBUTION obligation on the contributing actor.
@@ -3860,6 +3987,7 @@ def _settle_required_cash_obligations(
     sp500_sale_action_records: list[Sp500SaleActionRecord],
     crypto_sale_action_records: list[CryptoSaleActionRecord],
     actor_id: str | None = None,
+    pe_state: _PrivateEquityFundingState | None = None,
 ) -> None:
     resolved_actor_id = actor_id if actor_id is not None else _primary_owner_actor_id(scenario)
     sources = _ObligationFundingSources.for_actor(scenario, actor_id=resolved_actor_id)
@@ -3894,15 +4022,47 @@ def _settle_required_cash_obligations(
             accounting=accounting,
             sp500_sale_action_records=sp500_sale_action_records,
             crypto_sale_action_records=crypto_sale_action_records,
+            pe_state=pe_state,
         )
+
+
+@dataclass
+class _PrivateEquityFundingState:
+    """Mutable PE state shared with the obligation funding chain.
+
+    The PE state is per-portfolio (the engine aggregates positions into one
+    `private_equity_*` path). When a `PublicMarket`-regime PE position funds
+    an obligation, this state updates the per-month matrices for downstream
+    rows (cash, PE value, sale-tax recording, etc.) and appends a
+    `PrivateEquitySaleActionRecord` to the action-record list so the same
+    journal-entry / lot-disposition / effect recorder used by
+    `PrivateEquitySalePolicy` covers the funding sale.
+
+    All matrices are shaped `(rollout, month)`. The 1D `remaining_units` /
+    `remaining_basis_usd` vectors track end-of-month state and are kept in
+    sync with the matrices.
+    """
+
+    private_equity_value_usd: np.ndarray
+    remaining_units_by_month: np.ndarray
+    remaining_basis_by_month: np.ndarray
+    private_equity_sale_usd: np.ndarray
+    private_equity_sale_taxable_gain_usd: np.ndarray
+    pe_value_multipliers: np.ndarray
+    initial_private_equity: float
+    source_holding_id: str
+    sale_action_records: list[PrivateEquitySaleActionRecord]
 
 
 @dataclass(frozen=True)
 class _ObligationFundingSources:
-    """Per-actor lookups for cash/SP500/crypto sources used in obligation settlement.
+    """Per-actor lookups for cash/SP500/crypto/PE sources used in obligation settlement.
 
     Cached once at the top of `_settle_required_cash_obligations` so the per-month
     helper does not re-scan the balance sheet for every month/obligation pair.
+    `pe_public_market_regime` is set only when the scenario's PE positions share a
+    `PublicMarket` regime, which is the only regime that can fund obligations via
+    the funding-policy chain; otherwise it is `None`.
     """
 
     cash_source_account: AccountBalance | None
@@ -3910,10 +4070,13 @@ class _ObligationFundingSources:
     crypto_source_id: str
     crypto_source_account_id: str | None
     crypto_source_symbol: str
+    pe_source_holding_id: str
+    pe_public_market_regime: PublicMarket | None
 
     @classmethod
     def for_actor(cls, scenario: Scenario, *, actor_id: str) -> _ObligationFundingSources:
         crypto_source_assets = _crypto_asset_sources(scenario, actor_id=actor_id)
+        pe_regime = _effective_pe_liquidity_regime(scenario)
         return cls(
             cash_source_account=_single_checking_account_source(scenario, actor_id=actor_id),
             sp500_source_asset=_single_sp500_asset_source(scenario, actor_id=actor_id),
@@ -3922,6 +4085,8 @@ class _ObligationFundingSources:
             crypto_source_symbol=(
                 crypto_source_assets[0].asset_symbol if len(crypto_source_assets) == 1 else "crypto_portfolio"
             ),
+            pe_source_holding_id=_private_equity_source_holding_id(scenario),
+            pe_public_market_regime=pe_regime if isinstance(pe_regime, PublicMarket) else None,
         )
 
 
@@ -3954,6 +4119,7 @@ def _settle_required_cash_obligation_at_month_position(
     accounting: AccountingTraceBuilder,
     sp500_sale_action_records: list[Sp500SaleActionRecord],
     crypto_sale_action_records: list[CryptoSaleActionRecord],
+    pe_state: _PrivateEquityFundingState | None = None,
 ) -> None:
     """Settle one obligation at a single month position.
 
@@ -4103,6 +4269,116 @@ def _settle_required_cash_obligation_at_month_position(
                         basis_usd=basis_sold,
                         quantity_sold=quantity_sold,
                         shortfall_usd=remaining_due.copy(),
+                    )
+                )
+            elif asset_type is AssetType.PRIVATE_EQUITY:
+                if sources.pe_public_market_regime is None or pe_state is None:
+                    # A scenario opted into PE funding by listing PRIVATE_EQUITY in
+                    # sale_asset_preference, but the position is not PublicMarket
+                    # (or the engine code path has no PE state available). Skip
+                    # rather than raise: the preference is a soft fallback chain.
+                    continue
+                # Unit price = current month's value / current month's units (whenever
+                # units > 0). This is the same spot mark the LiquidityEventOnly tender
+                # path uses and accurately reflects the market multiplier at this month.
+                pe_units_now = pe_state.remaining_units_by_month[:, month_position]
+                pe_value_now = pe_state.private_equity_value_usd[:, month_position]
+                pe_unit_price_now = np.where(pe_units_now > 0, pe_value_now / np.maximum(pe_units_now, 1e-12), 0.0)
+                pe_application = _apply_pe_checking_floor_obligation_funding_policy(
+                    policy_step,
+                    due_usd=due,
+                    remaining_due_usd=remaining_due,
+                    cash_usd=cash_usd[:, month_position],
+                    remaining_units=pe_units_now,
+                    remaining_basis_usd=pe_state.remaining_basis_by_month[:, month_position],
+                    pe_unit_price_usd=pe_unit_price_now,
+                    pe_regime=sources.pe_public_market_regime,
+                    current_month_index=int(due_month_index),
+                    source_holding_id=sources.pe_source_holding_id,
+                )
+                if pe_application is None:
+                    continue
+                units_sold = np.maximum(0.0, pe_units_now - pe_application.remaining_units)
+                basis_sold = np.maximum(
+                    0.0, pe_state.remaining_basis_by_month[:, month_position] - pe_application.remaining_basis_usd
+                )
+                pe_state.remaining_units_by_month[:, month_position:] = np.maximum(
+                    0.0, pe_state.remaining_units_by_month[:, month_position:] - units_sold[:, None]
+                )
+                pe_state.remaining_basis_by_month[:, month_position:] = np.maximum(
+                    0.0, pe_state.remaining_basis_by_month[:, month_position:] - basis_sold[:, None]
+                )
+                # Recompute PE value matrix from `month_position` forward:
+                # `units_remaining × unit_price × forward_multiplier_ratio`.
+                pe_state.private_equity_value_usd[:, month_position] = np.maximum(
+                    0.0, pe_value_now - pe_application.sale_usd
+                )
+                if month_position + 1 < pe_state.private_equity_value_usd.shape[1]:
+                    multiplier_at_month = pe_state.pe_value_multipliers[:, month_position]
+                    forward_ratios = np.where(
+                        multiplier_at_month[:, None] > 0,
+                        pe_state.pe_value_multipliers[:, month_position + 1 :]
+                        / np.maximum(multiplier_at_month[:, None], 1e-12),
+                        0.0,
+                    )
+                    pe_state.private_equity_value_usd[:, month_position + 1 :] = np.maximum(
+                        0.0, pe_state.private_equity_value_usd[:, month_position, None] * forward_ratios
+                    )
+                cash_usd[:, month_position:] = cash_usd[:, month_position:] + pe_application.sale_usd[:, None]
+                pe_state.private_equity_sale_usd[:, month_position] = (
+                    pe_state.private_equity_sale_usd[:, month_position] + pe_application.sale_usd
+                )
+                pe_state.private_equity_sale_taxable_gain_usd[:, month_position] = (
+                    pe_state.private_equity_sale_taxable_gain_usd[:, month_position] + pe_application.taxable_gain_usd
+                )
+                remaining_due = pe_application.remaining_due_usd
+                checking_floor_shortfall_usd[:, month_position] = np.maximum(
+                    checking_floor_shortfall_usd[:, month_position], remaining_due
+                )
+                _record_obligation_pe_sale_funding_decisions(
+                    funding_decisions,
+                    obligation_type=obligation_type,
+                    actor_id=actor_id,
+                    month_index=due_month_index,
+                    policy_step=policy_step,
+                    obligation_amount_usd=due,
+                    requested_sale_usd=pe_application.instruction.requested_amount_usd,
+                    funded_cash_usd=pe_application.funded_cash_usd,
+                    shortfall_usd=pe_application.shortfall_usd,
+                    source_asset_id=sources.pe_source_holding_id,
+                )
+                # Mirror PrivateEquitySaleApplication shape for the existing
+                # journal-entry/lot-disposition/effect recorder.
+                pe_state.sale_action_records.append(
+                    PrivateEquitySaleActionRecord(
+                        month_position=month_position,
+                        month_index=due_month_index,
+                        instruction=PrivateEquitySaleInstructionBatch(
+                            actor_id=policy.actor_id,
+                            policy_id=policy.policy_id,
+                            requested_amount_usd=pe_application.instruction.requested_amount_usd,
+                            proceeds_destination=AccountType.CHECKING,
+                            opportunity_id=np.array([None] * cash_usd.shape[0], dtype=object),
+                            opportunity_cause_id=np.array(
+                                [
+                                    f"policy:{policy.policy_id}:{obligation_type.value}:funding_pe_sale:rollout:{i}:"
+                                    f"month:{due_month_index}"
+                                    for i in range(cash_usd.shape[0])
+                                ],
+                                dtype=object,
+                            ),
+                        ),
+                        sale_application=PrivateEquitySaleApplication(
+                            sale_usd=pe_application.sale_usd,
+                            basis_usd=pe_application.basis_usd,
+                            taxable_gain_usd=pe_application.taxable_gain_usd,
+                            sold_units=pe_application.sold_units,
+                            sold_fraction=pe_application.sold_fraction,
+                            remaining_units=pe_application.remaining_units,
+                            remaining_basis_usd=pe_application.remaining_basis_usd,
+                            remaining_fraction=np.zeros_like(pe_application.sold_fraction),
+                            journal_entries=(),
+                        ),
                     )
                 )
             else:
@@ -4407,6 +4683,76 @@ def _apply_checking_floor_obligation_funding_policy(
     )
 
 
+def _apply_pe_checking_floor_obligation_funding_policy(
+    policy_step: ActorPolicyStep[Policy],
+    *,
+    due_usd: np.ndarray,
+    remaining_due_usd: np.ndarray,
+    cash_usd: np.ndarray,
+    remaining_units: np.ndarray,
+    remaining_basis_usd: np.ndarray,
+    pe_unit_price_usd: np.ndarray,
+    pe_regime: PublicMarket,
+    current_month_index: int,
+    source_holding_id: str,
+) -> PrivateEquityObligationFundingPolicyApplication | None:
+    """Sell a `PublicMarket` PE position to fund a cash obligation.
+
+    Returns `None` if the lockup has not expired or the policy did not request
+    a sale (no rollouts both short of the floor and unfunded). The caller
+    threads `remaining_units`/`remaining_basis_usd` (1D per-rollout arrays) and
+    updates them with the application's `remaining_*` fields.
+    """
+    policy = policy_step.policy
+    if not isinstance(policy, CheckingFloorSellPublicStockPolicy):
+        raise TypeError(f"checking-floor PE obligation funding handler received {type(policy).__name__}")
+    if pe_regime.lockup_end_month is not None and current_month_index < int(pe_regime.lockup_end_month):
+        return None
+    projected_cash_after_obligation = cash_usd - due_usd
+    requested_sale = np.where(
+        (remaining_due_usd > 0) & (projected_cash_after_obligation < float(policy.floor_usd)),
+        # As with crypto: cap the requested sale at remaining_due. PE is a
+        # discretionary funding source; selling more than needed leaks tax
+        # liability without further benefit.
+        np.minimum(float(policy.sale_amount_usd), remaining_due_usd),
+        0.0,
+    )
+    instruction = SellAssetInstructionBatch(
+        actor_id=policy.actor_id,
+        policy_id=policy.policy_id,
+        asset_type=AssetType.PRIVATE_EQUITY,
+        requested_amount_usd=requested_sale,
+        target_cash_floor_usd=float(policy.floor_usd),
+        source_asset_id=source_holding_id,
+    )
+    value_usd = remaining_units * pe_unit_price_usd
+    sale_usd = np.minimum(requested_sale, value_usd)
+    sold_fraction = np.divide(sale_usd, value_usd, out=np.zeros_like(sale_usd), where=value_usd > 0)
+    basis_usd = remaining_basis_usd * sold_fraction
+    taxable_gain_usd = np.maximum(0.0, sale_usd - basis_usd)
+    sold_units = remaining_units * sold_fraction
+    cash_after_sale = cash_usd + sale_usd
+    shortfall_usd = np.maximum(0.0, float(policy.floor_usd) - cash_after_sale)
+    if not np.any((requested_sale > 0) | (shortfall_usd > 0)):
+        return None
+    funded_cash = np.minimum(remaining_due_usd, sale_usd)
+    remaining_due_after_sale = np.maximum(0.0, remaining_due_usd - funded_cash)
+    return PrivateEquityObligationFundingPolicyApplication(
+        policy_step=policy_step,
+        instruction=instruction,
+        sale_usd=sale_usd,
+        basis_usd=basis_usd,
+        taxable_gain_usd=taxable_gain_usd,
+        funded_cash_usd=funded_cash,
+        shortfall_usd=remaining_due_after_sale,
+        remaining_due_usd=remaining_due_after_sale,
+        remaining_units=np.maximum(0.0, remaining_units - sold_units),
+        remaining_basis_usd=np.maximum(0.0, remaining_basis_usd - basis_usd),
+        sold_units=sold_units,
+        sold_fraction=sold_fraction,
+    )
+
+
 def _apply_crypto_checking_floor_obligation_funding_policy(
     policy_step: ActorPolicyStep[Policy],
     *,
@@ -4565,6 +4911,44 @@ def _record_obligation_crypto_sale_funding_decisions(
                 source_account_type=AccountType.CRYPTO_EXCHANGE if source_account_id is not None else None,
                 source_asset_id=source_asset_id,
                 source_asset_type=AssetType.CRYPTO,
+                available_cash_usd=0.0,
+                requested_cash_usd=float(obligation_amount_usd[rollout_index]),
+                requested_sale_usd=float(requested_sale_usd[rollout_index]),
+                funded_cash_usd=float(funded_cash_usd[rollout_index]),
+                shortfall_usd=float(shortfall_usd[rollout_index]),
+            )
+        )
+        for rollout_index in np.nonzero((requested_sale_usd > 0) | (shortfall_usd > 0))[0].tolist()
+    )
+
+
+def _record_obligation_pe_sale_funding_decisions(
+    records: list[FundingDecision],
+    *,
+    obligation_type: ObligationType,
+    actor_id: str,
+    month_index: int,
+    policy_step: ActorPolicyStep[Policy],
+    obligation_amount_usd: np.ndarray,
+    requested_sale_usd: np.ndarray,
+    funded_cash_usd: np.ndarray,
+    shortfall_usd: np.ndarray,
+    source_asset_id: str,
+) -> None:
+    policy = policy_step.policy
+    records.extend(
+        (
+            FundingDecision(
+                rollout_index=rollout_index,
+                month_index=month_index,
+                obligation_id=_obligation_id(obligation_type, rollout_index=rollout_index, month_index=month_index),
+                decision_type=FundingDecisionType.SELL_PRIVATE_EQUITY,
+                actor_id=actor_id,
+                policy_id=policy.policy_id,
+                policy_sequence_index=policy_step.sequence_index,
+                source_type=FundingSourceType.PRIVATE_EQUITY_ASSET,
+                source_asset_id=source_asset_id,
+                source_asset_type=AssetType.PRIVATE_EQUITY,
                 available_cash_usd=0.0,
                 requested_cash_usd=float(obligation_amount_usd[rollout_index]),
                 requested_sale_usd=float(requested_sale_usd[rollout_index]),
@@ -5309,6 +5693,28 @@ def _initial_private_equity_units(scenario: Scenario) -> float:
         for asset in scenario.initial_balance_sheet.assets
         if isinstance(asset, PrivateEquityPosition)
     )
+
+
+def _effective_pe_liquidity_regime(scenario: Scenario) -> LiquidityEventOnly | PublicMarket | Acquisition:
+    """Collapse the per-position liquidity regimes into a single portfolio-level regime.
+
+    The engine aggregates all PE positions into one `private_equity_*` state path
+    (units, basis, fraction). All positions must therefore share the same regime
+    type (and the same regime parameters), or the engine cannot dispatch correctly.
+    With no PE positions, defaults to `LiquidityEventOnly()`.
+    """
+    positions = tuple(
+        asset for asset in scenario.initial_balance_sheet.assets if isinstance(asset, PrivateEquityPosition)
+    )
+    if not positions:
+        return LiquidityEventOnly()
+    regimes = {position.liquidity_regime for position in positions}
+    if len(regimes) > 1:
+        raise ValueError(
+            "PrivateEquityPosition entries in initial_balance_sheet.assets must share a single "
+            f"liquidity_regime (the engine aggregates them); got {regimes}"
+        )
+    return positions[0].liquidity_regime
 
 
 def _private_equity_source_holding_id(scenario: Scenario) -> str:

--- a/augur/core/scenario_set.py
+++ b/augur/core/scenario_set.py
@@ -201,6 +201,7 @@ class FundingDecisionType(StrEnum):
     USE_CASH = "use_cash"
     SELL_PUBLIC_STOCK = "sell_public_stock"
     SELL_CRYPTO = "sell_crypto"
+    SELL_PRIVATE_EQUITY = "sell_private_equity"
     UNFUNDED = "unfunded"
 
 
@@ -208,6 +209,7 @@ class FundingSourceType(StrEnum):
     CASH_ACCOUNT = "cash_account"
     PUBLIC_MARKET_ASSET = "public_market_asset"
     CRYPTO_ASSET = "crypto_asset"
+    PRIVATE_EQUITY_ASSET = "private_equity_asset"
     UNFUNDED = "unfunded"
 
 
@@ -372,6 +374,12 @@ class CheckingFloorSellPublicStockPolicy(_PolicyBase):
     Putting `CRYPTO` in the preference lets the same policy fall through to crypto
     after SP500 is exhausted; the same obligation-funding step iterates the
     preference internally so the policy program order is unaffected.
+
+    `PRIVATE_EQUITY` is permitted only when the PE position has a
+    `PublicMarket` liquidity regime (and the current month is at or past the
+    optional lockup). The default preference does NOT include
+    `PRIVATE_EQUITY`, so existing scenarios with `LiquidityEventOnly` PE keep
+    their original behavior.
     """
 
     policy_type: Literal[PolicyType.CHECKING_FLOOR_SELL_PUBLIC_STOCK] = PolicyType.CHECKING_FLOOR_SELL_PUBLIC_STOCK
@@ -387,9 +395,10 @@ class CheckingFloorSellPublicStockPolicy(_PolicyBase):
         for asset_type in self.sale_asset_preference:
             if asset_type in seen:
                 raise ValueError(f"sale_asset_preference contains duplicate {asset_type}")
-            if asset_type not in (AssetType.GENERIC_SP500_STOCK, AssetType.CRYPTO):
+            if asset_type not in (AssetType.GENERIC_SP500_STOCK, AssetType.CRYPTO, AssetType.PRIVATE_EQUITY):
                 raise ValueError(
-                    f"sale_asset_preference only supports GENERIC_SP500_STOCK and CRYPTO; got {asset_type}"
+                    f"sale_asset_preference only supports GENERIC_SP500_STOCK, CRYPTO, and PRIVATE_EQUITY; "
+                    f"got {asset_type}"
                 )
             seen.add(asset_type)
         return self
@@ -878,6 +887,62 @@ class CryptoAssetPosition(_AssetPositionBase):
     source_account_id: str | None = None
 
 
+class LiquidityRegimeType(StrEnum):
+    LIQUIDITY_EVENT_ONLY = "liquidity_event_only"
+    PUBLIC_MARKET = "public_market"
+    ACQUISITION = "acquisition"
+
+
+class LiquidityEventOnly(ApiModel):
+    """Default PE liquidity regime: sale only at sampled tender opportunities.
+
+    The market bundle's `private_equity_sale_opportunity_mask` plus the actor's
+    `PrivateEquitySalePolicy` chain drives every sale under this regime.
+    """
+
+    regime_type: Literal[LiquidityRegimeType.LIQUIDITY_EVENT_ONLY] = LiquidityRegimeType.LIQUIDITY_EVENT_ONLY
+
+
+class PublicMarket(ApiModel):
+    """PE position that trades on a public market: freely sellable every month.
+
+    When `lockup_end_month` is set, sale is forbidden for months
+    `< lockup_end_month` (post-IPO lockup); months at or after it are freely
+    sellable at the current spot mark (`units × current PE unit price`).
+    `None` means no lockup, i.e. sellable from month 0.
+
+    `CheckingFloorSellPublicStockPolicy` is the funding-chain entry point for
+    obligation rescue: include `AssetType.PRIVATE_EQUITY` in
+    `sale_asset_preference` to let the policy fall through to a PublicMarket
+    PE holding after the earlier preferences are exhausted. The default
+    preference (`(GENERIC_SP500_STOCK,)`) does not include PE, preserving the
+    behavior of every pre-existing scenario.
+    """
+
+    regime_type: Literal[LiquidityRegimeType.PUBLIC_MARKET] = LiquidityRegimeType.PUBLIC_MARKET
+    lockup_end_month: NonNegativeInt | None = None
+
+
+class Acquisition(ApiModel):
+    """PE position that converts at a fixed price on a scheduled month.
+
+    A forced conversion: at `event_month`, the entire remaining position is
+    converted to cash at `cash_per_unit_usd`, regardless of any policy
+    decision. Realized gain (proceeds minus remaining cost basis) flows into
+    the existing annual sale-tax allocation as a long-term capital gain (the
+    `annual_sale_tax_allocation` machinery doesn't currently model
+    short-term/long-term split for PE; all PE realized gains receive
+    long-term treatment).
+    """
+
+    regime_type: Literal[LiquidityRegimeType.ACQUISITION] = LiquidityRegimeType.ACQUISITION
+    event_month: NonNegativeInt
+    cash_per_unit_usd: NonNegativeFloat
+
+
+LiquidityRegime = Annotated[LiquidityEventOnly | PublicMarket | Acquisition, Field(discriminator="regime_type")]
+
+
 class PrivateEquityPosition(ApiModel):
     """An opening private-equity position.
 
@@ -889,6 +954,12 @@ class PrivateEquityPosition(ApiModel):
       `units × MarketBundleMetadata.current_private_equity_price_usd`. Callers without
       an independent mark (such as the browser UI, which stores units only) should leave
       `value_usd` unset; the simulator owns the derivation.
+
+    `liquidity_regime` selects how the position can be sold. The default
+    `LiquidityEventOnly()` preserves the original behavior (sale only at
+    sampled tender windows). `PublicMarket` makes the holding freely sellable
+    each month (subject to a configurable lockup). `Acquisition` is a forced
+    one-shot conversion to cash at a scheduled `event_month`.
     """
 
     asset_id: str = Field(pattern=r"^[a-z0-9][a-z0-9_\-]*$")
@@ -897,6 +968,7 @@ class PrivateEquityPosition(ApiModel):
     units: NonNegativeFloat | None = None
     value_usd: NonNegativeFloat | None = None
     cost_basis_usd: float | None = None
+    liquidity_regime: LiquidityRegime = Field(default_factory=LiquidityEventOnly)
     provenance: PositionProvenance = Field(default_factory=PositionProvenance)
 
     @model_validator(mode="after")
@@ -905,6 +977,11 @@ class PrivateEquityPosition(ApiModel):
             raise ValueError(
                 f"PrivateEquityPosition {self.asset_id!r} must set units or value_usd "
                 "(or both); the simulator needs one to derive the opening mark."
+            )
+        if isinstance(self.liquidity_regime, Acquisition) and self.units is None:
+            raise ValueError(
+                f"PrivateEquityPosition {self.asset_id!r} uses Acquisition regime but "
+                "has no units; the forced conversion needs units to compute proceeds."
             )
         return self
 

--- a/augur/core/scenario_set_test.py
+++ b/augur/core/scenario_set_test.py
@@ -11,16 +11,20 @@ from pydantic import ValidationError
 from augur.core.local_regulation import LocationId
 from augur.core.scenario_set import (
     AccountType,
+    Acquisition,
     ActorRole,
     AssetType,
     FinancingMode,
     FixedAmountPrivateEquitySaleRule,
+    LiquidityEventOnly,
     LiquidNetWorthFloorPrivateEquitySaleRule,
     MarketRequest,
     OccupancyMode,
     PolicyType,
+    PrivateEquityPosition,
     PrivateEquitySalePolicy,
     PrivateEquitySaleProceedsDestination,
+    PublicMarket,
     RentalMode,
     RolloutStatus,
     RolloutStatusSummary,
@@ -207,6 +211,84 @@ def test_private_equity_position_accepts_units_only() -> None:
     )
     assert pe.value_usd is None
     assert pe.units == 1_000
+
+
+def test_private_equity_liquidity_regime_defaults_to_liquidity_event_only() -> None:
+    """Existing scenarios that omit `liquidity_regime` must continue to behave as
+    `LiquidityEventOnly` — that's the discriminated-union default, the schema
+    contract pre-existing scenarios rely on, and what `PortfolioStatement`-derived
+    positions get."""
+    body = _scenario_set_body("sf_house")
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {
+            "asset_id": "private_equity",
+            "asset_type": "private_equity",
+            "owner_actor_id": "owner",
+            "units": 1_000,
+            "cost_basis_usd": 0,
+        }
+    ]
+
+    scenario_set = ScenarioSet.model_validate(body)
+    [pe] = (
+        asset
+        for asset in scenario_set.scenarios[0].initial_balance_sheet.assets
+        if isinstance(asset, PrivateEquityPosition)
+    )
+    assert isinstance(pe.liquidity_regime, LiquidityEventOnly)
+
+
+def test_private_equity_liquidity_regime_parses_public_market_and_acquisition_variants() -> None:
+    body = _scenario_set_body("sf_house")
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {
+            "asset_id": "pe_public",
+            "asset_type": "private_equity",
+            "owner_actor_id": "owner",
+            "units": 1_000,
+            "cost_basis_usd": 0,
+            "liquidity_regime": {"regime_type": "public_market", "lockup_end_month": 12},
+        }
+    ]
+    pe_public = ScenarioSet.model_validate(body).scenarios[0].initial_balance_sheet.assets[0]
+    assert isinstance(pe_public, PrivateEquityPosition)
+    assert isinstance(pe_public.liquidity_regime, PublicMarket)
+    assert pe_public.liquidity_regime.lockup_end_month == 12
+
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {
+            "asset_id": "pe_acquired",
+            "asset_type": "private_equity",
+            "owner_actor_id": "owner",
+            "units": 100,
+            "cost_basis_usd": 0,
+            "liquidity_regime": {"regime_type": "acquisition", "event_month": 9, "cash_per_unit_usd": 750},
+        }
+    ]
+    pe_acquired = ScenarioSet.model_validate(body).scenarios[0].initial_balance_sheet.assets[0]
+    assert isinstance(pe_acquired, PrivateEquityPosition)
+    assert isinstance(pe_acquired.liquidity_regime, Acquisition)
+    assert pe_acquired.liquidity_regime.event_month == 9
+    assert pe_acquired.liquidity_regime.cash_per_unit_usd == 750
+
+
+def test_private_equity_position_with_acquisition_regime_requires_units() -> None:
+    """An `Acquisition` regime needs `units` to compute proceeds. Schema must
+    reject a PE position with `value_usd` only when the regime is `acquisition`."""
+    body = _scenario_set_body("sf_house")
+    body["scenarios"][0]["initial_balance_sheet"]["assets"] = [
+        {
+            "asset_id": "pe_acquired",
+            "asset_type": "private_equity",
+            "owner_actor_id": "owner",
+            "value_usd": 100_000,
+            "cost_basis_usd": 0,
+            "liquidity_regime": {"regime_type": "acquisition", "event_month": 6, "cash_per_unit_usd": 500},
+        }
+    ]
+
+    with pytest.raises(ValidationError, match="Acquisition regime"):
+        ScenarioSet.model_validate(body)
 
 
 @pytest.mark.parametrize("liability_type", ["mortgage", "tax_liability", "actor_equity_claim"])

--- a/augur/core/test_e2e.py
+++ b/augur/core/test_e2e.py
@@ -24,6 +24,7 @@ from augur.core.market_bundle_test_support import NoopMarketBundleProvider
 from augur.core.scenario_set import (
     AccountBalance,
     AccountType,
+    Acquisition,
     Actor,
     ActorRole,
     AssetType,
@@ -53,6 +54,7 @@ from augur.core.scenario_set import (
     PropertySaleBasisGainDetail,
     PropertySaleEvent,
     PropertySelection,
+    PublicMarket,
     RentalMode,
     ReportMetric,
     ReportSpec,
@@ -2407,6 +2409,242 @@ def test_fixed_amount_private_equity_sale_rule_sells_on_market_opportunity() -> 
     assert effects[0].event_type is None
     assert effects[0].amount_usd == 50_000
     assert_allclose(effects[0].after_tax_proceeds_usd, 50_000 - expected_tax)
+
+
+def test_public_market_pe_position_sells_freely_each_month_via_pe_sale_policy() -> None:
+    """A `PublicMarket`-regime PE position is sellable every month at the
+    spot mark — no tender opportunity needed. The `PrivateEquitySalePolicy`
+    therefore fires every month the rule triggers, draining the position
+    over time without needing the market provider to emit
+    `private_equity_sale_opportunity_months`.
+    """
+    scenario = Scenario(
+        scenario_id="public_market_pe_no_lockup",
+        label="PublicMarket PE No Lockup",
+        actors=(_simple_actor(),),
+        tax_profile=TaxProfile(),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=0
+                ),
+            ),
+            assets=(
+                PrivateEquityPosition(
+                    asset_id="pe",
+                    owner_actor_id="alpha",
+                    value_usd=600_000,
+                    cost_basis_usd=600_000,
+                    units=600,
+                    liquidity_regime=PublicMarket(),
+                ),
+            ),
+        ),
+        policies=(
+            PrivateEquitySalePolicy(
+                policy_id="pe_sale",
+                actor_id="alpha",
+                proceeds_destination="cash",
+                sale_rule=FixedAmountPrivateEquitySaleRule(amount_usd=50_000),
+            ),
+        ),
+    )
+
+    # Default provider: no tender months. With LiquidityEventOnly this would
+    # produce no sales; PublicMarket overrides the mask to every month
+    # (lockup_end_month=None ⇒ sellable from month 0).
+    result = _run_scenario(scenario, horizon_months=6)
+    rollout = result.rollout(0)
+    pe_sales = rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_USD)
+    for month in range(7):
+        assert_allclose(pe_sales[month], 50_000)
+    # Basis equals proceeds here (cost_basis == value_usd), so no taxable gain.
+    assert_allclose(np.sum(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_BASIS_USD)), 7 * 50_000)
+    assert_allclose(np.sum(rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_TAX_USD)), 0)
+
+
+def test_public_market_pe_lockup_blocks_sale_before_lockup_end_month() -> None:
+    """With `lockup_end_month=4`, a `PublicMarket` PE position cannot be sold
+    in months [0, 4); from month 4 onward sales fire normally. The
+    `PrivateEquitySalePolicy` opportunity check honors the effective mask.
+    """
+    scenario = Scenario(
+        scenario_id="public_market_pe_with_lockup",
+        label="PublicMarket PE With Lockup",
+        actors=(_simple_actor(),),
+        tax_profile=TaxProfile(),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=0
+                ),
+            ),
+            assets=(
+                PrivateEquityPosition(
+                    asset_id="pe",
+                    owner_actor_id="alpha",
+                    value_usd=200_000,
+                    cost_basis_usd=200_000,
+                    units=200,
+                    liquidity_regime=PublicMarket(lockup_end_month=4),
+                ),
+            ),
+        ),
+        policies=(
+            PrivateEquitySalePolicy(
+                policy_id="pe_sale",
+                actor_id="alpha",
+                proceeds_destination="cash",
+                sale_rule=FixedAmountPrivateEquitySaleRule(amount_usd=25_000),
+            ),
+        ),
+    )
+
+    result = _run_scenario(scenario, horizon_months=6)
+    rollout = result.rollout(0)
+    pe_sales = rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_USD)
+    # Pre-lockup-end months (0..3) must show no sale.
+    for month in range(4):
+        assert pe_sales[month] == 0, f"month {month} should be in lockup"
+    # Post-lockup months (4..6) sell.
+    for month in range(4, 7):
+        assert_allclose(pe_sales[month], 25_000)
+
+
+def test_acquisition_regime_forces_full_conversion_at_event_month() -> None:
+    """An `Acquisition`-regime PE position converts the entire remaining
+    position to cash at `event_month` regardless of any policy. Cash
+    increases by `units × cash_per_unit_usd`; PE units drop to zero;
+    realized gain feeds the existing annual sale-tax allocation.
+    """
+    scenario = Scenario(
+        scenario_id="pe_acquisition_event",
+        label="PE Acquisition Event",
+        actors=(_simple_actor(),),
+        tax_profile=TaxProfile(),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=10_000
+                ),
+            ),
+            assets=(
+                PrivateEquityPosition(
+                    asset_id="pe",
+                    owner_actor_id="alpha",
+                    value_usd=100_000,
+                    cost_basis_usd=40_000,
+                    units=100,
+                    liquidity_regime=Acquisition(event_month=6, cash_per_unit_usd=500),
+                ),
+            ),
+        ),
+        # No PE sale policy: the acquisition is a forced conversion.
+    )
+
+    result = _run_scenario(scenario, horizon_months=12)
+    rollout = result.rollout(0)
+    pe_sales = rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_USD)
+    pe_value = rollout.series(ReportMetric.PRIVATE_EQUITY_VALUE_USD)
+    cash = rollout.series(ReportMetric.CASH_USD)
+    expected_proceeds = 100 * 500  # 50_000
+    expected_basis = 40_000
+    expected_taxable_gain = 10_000
+    assert_allclose(pe_sales[6], expected_proceeds)
+    for month in (0, 1, 5):
+        assert pe_sales[month] == 0
+    for month in (7, 8, 12):
+        assert pe_sales[month] == 0
+    for month in (6, 7, 12):
+        assert_allclose(pe_value[month], 0)
+    # Sale tax is recorded at the source month by `annual_sale_tax_allocation`
+    # for visibility. Tax cash settlement happens via the quarterly estimated
+    # tax obligations (months 3/5/8/12) plus a year-end true-up at month 11,
+    # so cash[6] is full proceeds minus the Q1+Q2 estimated payments and
+    # cash[12] is full proceeds minus the full annual tax.
+    pe_sale_tax_month_6 = rollout.series(ReportMetric.PRIVATE_EQUITY_SALE_TAX_USD)[6]
+    assert pe_sale_tax_month_6 > 0
+    # The acquisition proceeds are received in cash at month 6 — verify the
+    # cash jumped by at least most of the proceeds (allowing for already-paid
+    # quarterly estimated taxes).
+    assert cash[6] > 10_000 + expected_proceeds - 1_000, f"cash[6]={cash[6]}"
+    # Year-end (month 12) cash reflects full proceeds minus the full sale tax.
+    assert_allclose(cash[12], 10_000 + expected_proceeds - pe_sale_tax_month_6, atol=1.0)
+    # Verify the SellPrivateEquityEffect carries the expected basis/gain.
+    effects = result.effects(SellPrivateEquityEffect)
+    assert len(effects) == 1
+    assert effects[0].month_index == 6
+    assert effects[0].amount_usd == expected_proceeds
+    assert effects[0].basis_usd == expected_basis
+    assert effects[0].taxable_gain_usd == expected_taxable_gain
+    assert effects[0].units_sold == 100
+    assert effects[0].sold_fraction == 1.0
+
+
+def test_acquisition_regime_short_holding_period_still_recognizes_realized_gain() -> None:
+    """The current `annual_sale_tax_allocation` treats all PE realized gain
+    as long-term capital gain (LT/ST partitioning is not modeled). This test
+    pins that behavior: an acquisition at month 3 (holding < 12 months)
+    produces a realized gain that flows through the same LT path as one at
+    month 24 — so for the same gain, the recorded sale tax matches the
+    long-term-treatment tax. When LT/ST partitioning lands, this test will
+    have to grow accordingly.
+    """
+    scenario_short = Scenario(
+        scenario_id="acquisition_short_holding",
+        label="Acquisition Short Holding",
+        actors=(_simple_actor(),),
+        tax_profile=TaxProfile(annual_ordinary_income_usd=80_000),
+        initial_balance_sheet=InitialBalanceSheet(
+            accounts=(
+                AccountBalance(
+                    account_id="checking", account_type=AccountType.CHECKING, owner_actor_id="alpha", balance_usd=0
+                ),
+            ),
+            assets=(
+                PrivateEquityPosition(
+                    asset_id="pe",
+                    owner_actor_id="alpha",
+                    value_usd=100_000,
+                    cost_basis_usd=20_000,
+                    units=100,
+                    liquidity_regime=Acquisition(event_month=3, cash_per_unit_usd=1_000),
+                ),
+            ),
+        ),
+    )
+    scenario_long = scenario_short.model_copy(
+        update={
+            "scenario_id": "acquisition_long_holding",
+            "initial_balance_sheet": InitialBalanceSheet(
+                accounts=scenario_short.initial_balance_sheet.accounts,
+                assets=(
+                    PrivateEquityPosition(
+                        asset_id="pe",
+                        owner_actor_id="alpha",
+                        value_usd=100_000,
+                        cost_basis_usd=20_000,
+                        units=100,
+                        liquidity_regime=Acquisition(event_month=24, cash_per_unit_usd=1_000),
+                    ),
+                ),
+            ),
+        }
+    )
+
+    result_short = _run_scenario(scenario_short, horizon_months=36)
+    result_long = _run_scenario(scenario_long, horizon_months=36)
+    short_effects = result_short.effects(SellPrivateEquityEffect)
+    long_effects = result_long.effects(SellPrivateEquityEffect)
+    assert len(short_effects) == 1
+    assert len(long_effects) == 1
+    # Both record the same proceeds, basis, and taxable gain; LT treatment is the
+    # existing engine convention, so the realized-gain tax is identical regardless
+    # of holding period under today's `annual_sale_tax_allocation`.
+    assert short_effects[0].amount_usd == long_effects[0].amount_usd == 100_000
+    assert short_effects[0].basis_usd == long_effects[0].basis_usd == 20_000
+    assert short_effects[0].taxable_gain_usd == long_effects[0].taxable_gain_usd == 80_000
+    assert_allclose(short_effects[0].estimated_tax_usd, long_effects[0].estimated_tax_usd)
 
 
 def test_every_monthly_flow_metric_reconciles_to_canonical_detail_surface() -> None:


### PR DESCRIPTION
## Summary

Adds the `LiquidityRegime` discriminated union on `PrivateEquityPosition` declared in `augur/SPEC.md`, with two new variants beyond the existing `LiquidityEventOnly`:

- **`LiquidityEventOnly`** (default) — existing tender-window behavior, unchanged.
- **`PublicMarket(lockup_end_month=None)`** — freely sellable each month at the spot mark from `lockup_end_month` onward (`None` = no lockup). Two ways to drive sales:
  1. The existing `PrivateEquitySalePolicy` works as-is — the engine widens the per-rollout `private_equity_sale_opportunity_mask` to include every month past lockup, so the same `FixedAmountPrivateEquitySaleRule` (or `LiquidNetWorthFloorPrivateEquitySaleRule`) drives sales without needing the market provider to emit tender windows.
  2. A `CheckingFloorSellPublicStockPolicy` that lists `AssetType.PRIVATE_EQUITY` in `sale_asset_preference` can also fund cash obligations from the PublicMarket PE position via the obligation-funding chain (mirrors the recently-landed crypto preference). **The default preference does NOT include PE**, so pre-existing scenarios keep their original behavior byte-for-byte.
- **`Acquisition(event_month, cash_per_unit_usd)`** — forced one-shot conversion of the entire remaining PE position to cash on `event_month`. The actor doesn't choose; the conversion fires regardless of policies. Cash credit is `units × cash_per_unit_usd`; PE units drop to zero.

### Tax treatment

Realized gain from both regimes flows through the existing `annual_sale_tax_allocation` path (long-term capital gain treatment). Short-term/long-term partitioning by holding period is NOT modeled by today's annual-tax machinery — all PE realized gains currently receive long-term treatment regardless of holding span. A test pins this behavior so LT/ST refinement, when it lands, has a known place to update.

### SPEC.md

`PublicMarket` and `Acquisition` flip from `Future` to `Implemented`. `RegimeChange` (mid-rollout regime transitions, e.g. IPO converting `LiquidityEventOnly → PublicMarket`) stays `Future`, with a note that the discriminated-union shape already supports it but no runtime hook exists yet.

### Engine surgery

- `_effective_pe_liquidity_regime(scenario)` collapses per-position regimes into one portfolio-level regime (the engine aggregates PE state; mixed regimes raise).
- `effective_pe_sale_opportunity_mask` extends the market-sampled mask with every-month sellability for `PublicMarket` regimes past lockup.
- `_apply_pe_checking_floor_obligation_funding_policy` mirrors the crypto helper for `PublicMarket` PE funding-chain sales.
- `_PrivateEquityFundingState` threads PE matrices into post-loop obligation settlement (estimated tax, annual tax, mortgage, special assessment). The within-loop property-cost path does NOT support PE funding (out of scope for this slice; only after-loop settlements participate).
- Forced `Acquisition` conversion runs at the top of each per-month iteration, appending a `PrivateEquitySaleActionRecord` so the existing journal/lot/effect recorder pipeline covers it without duplication.

### New tests

- `test_public_market_pe_position_sells_freely_each_month_via_pe_sale_policy` — no lockup; the `PrivateEquitySalePolicy` fires every month with no market-provided tender opportunities.
- `test_public_market_pe_lockup_blocks_sale_before_lockup_end_month` — `lockup_end_month=4`; sales fail in months 0–3 and succeed from month 4 onward.
- `test_acquisition_regime_forces_full_conversion_at_event_month` — `event_month=6`, `cash_per_unit_usd=500`; cash jumps by `units × 500` at month 6, PE units → 0, realized gain recorded, year-end tax settles.
- `test_acquisition_regime_short_holding_period_still_recognizes_realized_gain` — pins the current "all PE gain treated as LT" behavior across short (3 months) vs long (24 months) holding periods.
- Schema-level tests for the discriminated-union default + PublicMarket/Acquisition parsing + the `Acquisition`-requires-`units` guard.

## Test plan

- [x] `bbr test //augur/core:test_e2e //augur/core:scenario_engine_test //augur/core:policy_runtime_test //augur/api:browser_shell_test //augur/core:scenario_set_test`
- [x] `bbr test //augur/...` — only pre-existing red `//augur/frontend:visual_golden_test` fails (verified by stashing changes).
- [x] `bbr build //augur/...`
- [ ] Copilot review.

https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB

---
_Generated by [Claude Code](https://claude.ai/code/session_018DqchqyZixsnbKAwD2K4yB)_