### PR TITLE
cluster/seaweedfs: add retryInterval to operator kustomization

### DIFF
--- a/cluster/k8s/seaweedfs/operator/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/operator/flux-kustomization.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   suspend: false
   interval: 10m
+  retryInterval: 1m
   path: ./cluster/k8s/seaweedfs/operator
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary

`cluster/k8s/seaweedfs/operator/flux-kustomization.yaml` was added by
the recent SeaweedFS migration (commits 8d31507, 6bc5d0f) with
`wait: true` but no `retryInterval`. That trips
`cluster/validation:test_cluster_integration::test_retry_policy`:

```
seaweedfs-operator: has async health checks or wait: true but no retryInterval.
Set retryInterval (e.g. 1m) in ./cluster/k8s/seaweedfs/operator/flux-kustomization.yaml.
```

`test_cluster_integration` runs in every PR's `bazel-ci`, so the failure
is currently blocking unrelated PRs (e.g. agentydragon/ducktape#1602).
Add `retryInterval: 1m`, matching the convention used elsewhere
(study-casino-db, props, etc.).

## Test plan

- [ ] `bbr test //cluster/validation:test_cluster_integration` passes.
- [ ] PR #1602 (and other in-flight PRs) go green on the bazel-ci check.

https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP)_