### PR TITLE
kyverno: stop injecting mitmproxy into claude-sandbox

### DIFF
--- a/cluster/k8s/kyverno/policies/inject-mitmproxy.yaml
+++ b/cluster/k8s/kyverno/policies/inject-mitmproxy.yaml
@@ -3,6 +3,15 @@
 # turnkey with HTTP_PROXY, HTTPS_PROXY, SSL trust, and the CA cert mounted,
 # without the pod spec needing to know about the proxy.
 #
+# claude-sandbox is intentionally excluded for now (2026-05-17): the
+# openclaw-mitmproxy Flux Kustomization is suspended, so the source
+# `mitmproxy-ca-cert` ConfigMap doesn't exist → Reflector has nothing to
+# copy → every pod the policy mutated got stuck on a missing volume mount.
+# claude-sandbox is still egress-restricted (no `toEntities: world`) by
+# `sandbox-force-proxy-egress` CCNP, so dropping the injection here doesn't
+# open new external internet access — it just lets pods start. Revisit
+# alongside the mitmproxy / agents-mitmproxy redesign (cluster/k8s/TODO.md).
+#
 # Uses RFC 6902 JSON patches (not patchStrategicMerge) to avoid volume merge
 # conflicts with Kyverno autogen + Flux server-side dry-run on Deployments.
 #
@@ -31,7 +40,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Mutates pods in claude-sandbox and openclaw-sandbox to automatically
+      Mutates pods in openclaw-sandbox and openclaw-gateway to automatically
       inject mitmproxy proxy env vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY,
       SSL_CERT_FILE, CURL_CA_BUNDLE, REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS)
       and mount the mitmproxy CA cert at /mitmproxy-ca/ca-cert.pem.
@@ -43,7 +52,7 @@ spec:
         any:
           - resources:
               kinds: [Pod]
-              namespaces: [claude-sandbox, openclaw-sandbox, openclaw-gateway]
+              namespaces: [openclaw-sandbox, openclaw-gateway]
               operations: [CREATE]
       mutate:
         patchesJson6902: |-
@@ -59,7 +68,7 @@ spec:
         any:
           - resources:
               kinds: [Pod]
-              namespaces: [claude-sandbox, openclaw-sandbox, openclaw-gateway]
+              namespaces: [openclaw-sandbox, openclaw-gateway]
               operations: [CREATE]
       mutate:
         foreach:
@@ -112,7 +121,7 @@ spec:
         any:
           - resources:
               kinds: [Pod]
-              namespaces: [claude-sandbox, openclaw-sandbox, openclaw-gateway]
+              namespaces: [openclaw-sandbox, openclaw-gateway]
               operations: [CREATE]
       preconditions:
         any:

--- a/cluster/validation/__snapshots__/test_kyverno_policies.ambr
+++ b/cluster/validation/__snapshots__/test_kyverno_policies.ambr
@@ -19,7 +19,7 @@
   kind: Pod
   metadata:
     name: test-existing-volumes
-    namespace: claude-sandbox
+    namespace: openclaw-sandbox
   spec:
     containers:
     - env:
@@ -63,7 +63,7 @@
   kind: Pod
   metadata:
     name: test-with-init
-    namespace: claude-sandbox
+    namespace: openclaw-sandbox
   spec:
     containers:
     - env:
@@ -126,7 +126,7 @@
   kind: Pod
   metadata:
     name: test-no-init
-    namespace: claude-sandbox
+    namespace: openclaw-sandbox
   spec:
     containers:
     - env:

--- a/cluster/validation/testdata/kyverno/pod_no_init_containers.yaml
+++ b/cluster/validation/testdata/kyverno/pod_no_init_containers.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-no-init
-  namespace: claude-sandbox
+  namespace: openclaw-sandbox
 spec:
   containers:
     - name: app

--- a/cluster/validation/testdata/kyverno/pod_with_existing_volumes.yaml
+++ b/cluster/validation/testdata/kyverno/pod_with_existing_volumes.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-existing-volumes
-  namespace: claude-sandbox
+  namespace: openclaw-sandbox
 spec:
   containers:
     - name: manager

--- a/cluster/validation/testdata/kyverno/pod_with_init_containers.yaml
+++ b/cluster/validation/testdata/kyverno/pod_with_init_containers.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-with-init
-  namespace: claude-sandbox
+  namespace: openclaw-sandbox
 spec:
   initContainers:
     - name: init-setup


### PR DESCRIPTION
## Summary

The mitmproxy stack lives under `openclaw-mitmproxy` but is currently
suspended via Flux, so the `mitmproxy-ca-cert` ConfigMap that the
Kyverno `inject-mitmproxy` ClusterPolicy mounts into every
`claude-sandbox` pod doesn't exist. Net effect: every new pod in
`claude-sandbox` sits in `ContainerCreating` forever waiting on a
missing ConfigMap volume mount. (Discovered while trying to smoketest
the read-only Postgres creds for study-casino from a sandbox pod.)

Drop `claude-sandbox` from the policy's `match.namespaces` for now. The
namespace's outbound egress is still constrained by the existing
`sandbox-force-proxy-egress` CCNP (which allows kube-dns, in-cluster
endpoints, kube-apiserver, and mitmproxy — but no `toEntities: world`),
so dropping the injection **does not open external internet access**;
it just lets pods start again.

Migrate the kyverno-policy test fixtures and snapshots from
`claude-sandbox` to `openclaw-sandbox` (the policy still applies there
plus to `openclaw-gateway`).

Revisit alongside the broader mitmproxy / agents-mitmproxy redesign
tracked in `cluster/k8s/TODO.md` (the section rewritten in PR #1602).

## Test plan

- [x] `bbr test //cluster/validation:test_kyverno_policies //cluster/validation:test_cluster_integration`
      (invocation `8d2c83f3-68aa-42f2-aeee-1576a7c93a1a`).
- [ ] After merge: `kubectl run --rm -it --image=curlimages/curl
      --restart=Never -n claude-sandbox testpod -- /bin/sh` should
      actually start.
- [ ] After merge: external internet from claude-sandbox should still
      be blocked (CCNP).

https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP)_