### PR TITLE
cluster/openclaw-mitmproxy: un-suspend both Flux Kustomizations

### DIFF
--- a/cluster/k8s/agents/openclaw/mitmproxy-namespace/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/mitmproxy-namespace/flux-kustomization.yaml
@@ -4,7 +4,6 @@ metadata:
   name: openclaw-mitmproxy-namespace
   namespace: flux-system
 spec:
-  suspend: true
   interval: 1h
   path: ./cluster/k8s/agents/openclaw/mitmproxy-namespace
   prune: false

--- a/cluster/k8s/agents/openclaw/mitmproxy/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/mitmproxy/flux-kustomization.yaml
@@ -4,7 +4,6 @@ metadata:
   name: openclaw-mitmproxy
   namespace: flux-system
 spec:
-  suspend: true
   interval: 10m
   path: ./cluster/k8s/agents/openclaw/mitmproxy
   prune: true


### PR DESCRIPTION
## Summary

The mitmproxy stack has been `suspend: true` since its Flux
Kustomizations were introduced (commit 771751d — the suspend landed in
an unrelated commit, never explained). The two known upstream bugs in
the manifests (label-selector mismatch on `ccnp-sandbox-proxy-egress`,
missing `toEntities: cluster` on `cnp-cloud-api-egress`) were already
fixed in-tree — just unapplied because of the suspend.

This PR flips `suspend: true → false` on both Kustomizations
(`openclaw-mitmproxy-namespace`, `openclaw-mitmproxy`). Two-line diff.

Net effect on the cluster after Flux reconciles:

- Flux applies the openclaw-mitmproxy Namespace, mitmproxy Deployment,
  Service, SOPS-encrypted CA key, and the ConfigMap for the CA cert.
- Reflector mirrors `mitmproxy-ca-cert` to the sandbox namespaces
  (annotations are already on the source CM).
- The lingering `sandbox-force-proxy-egress` CCNP — which currently
  matches no mitmproxy pod because the namespace was deleted at some
  point — starts matching the freshly-recreated mitmproxy pod and
  resumes its role of forcing sandbox HTTP egress through mitmproxy.

## Pre-flight verification

- [x] `ca-cert.pem` notAfter is `2036-03-31` — 10y of headroom.
- [x] `bbr test //cluster/validation/...` green: invocation
      `7e7a0b6c-aecb-4083-8647-5e670c0bd2ff`.

## Out of scope

- Rename `openclaw-mitmproxy` → `agents-mitmproxy`: documented as a
  separate follow-up in `cluster/k8s/TODO.md` (touched by PR #1602).
- Re-enabling Kyverno injection for `claude-sandbox`: PR #1604 goes the
  other direction (disables injection while mitmproxy is down).
  Revisit once this lands and the stack is actually up.

## Test plan

- [ ] After merge: `kubectl get pods -n openclaw-mitmproxy` shows a
      running mitmproxy.
- [ ] After merge: `kubectl get cm mitmproxy-ca-cert -n claude-sandbox`
      is reflected.
- [ ] `study-casino-db` Flux Kustomization stays `Ready`.

https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP)_