### PR TITLE
debundle purity: pure_members per-binding hint + plain-data Object.* calls

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -362,6 +362,31 @@ purity covers the function value, not its arguments.
 does not make `X(...)` pure, and still evaluates constructor
 arguments normally.
 
+`pure_members: [<prop>, …]` is a third trust contract on the same
+member, extending the contract from "calls of the bound Ident are
+pure" to "calls of `<binding>.<prop>(args)` for each listed
+property are pure when args evaluate pure". The intended shape is
+a vendor namespace binding (a star-import or renamed binding
+standing in for a vendor module — React, etc.) whose member
+function values are author-known to be side-effect-free even
+though the analyzer cannot inspect them.
+
+```yaml
+- name: React
+  selector:
+    binding: { name: b, kind: import_specifier }
+  pure_members: [forwardRef, lazy, memo, createContext]
+```
+
+Admission rule: only static identifier-property access fires the
+rule (`<binding>.<prop>(args)` / `<binding>?.<prop>(args)`).
+Computed access (`<binding>[expr](args)`), chained access
+(`<binding>.x.y(args)`), private fields, and non-Ident receivers
+fall back to the regular classifier path. As with `purity: pure`,
+the rule wins over the global-shadowing fallback — the spec
+author asserts THIS bound value is pure regardless of where it
+came from. Args are still classified independently.
+
 The annotation is **per-member**: a sibling member without the
 annotation stays subject to inferred classification. There is no
 "declare a whole module pure" shorthand.
@@ -389,6 +414,32 @@ both:
 The two-direction pinning prevents a future maintainer from
 misreading the read-pure entry as call-pure and incorrectly
 promoting the entry into `PURE_STATIC_CALLS`.
+
+### Argument-shape-gated whitelists
+
+`PURE_OBJECT_CALLS_ON_PLAIN_DATA` is a separate table that admits
+`Object.{keys, values, entries, freeze, fromEntries}` as Pure
+**only when the argument is syntactically a fresh plain-data
+literal** (an `Expr::Object` with `is_plain_data_prop`-passing
+props, an `Expr::Array`, or — for the non-`fromEntries` members
+— a chunk-top binding registered as `ChunkBinding::PlainData`).
+The general-arg form of these calls stays in
+`PURE_STATIC_FUNCTION_REFS` (read-pure, call-unknown), matching
+the soundness rule that we cannot admit `[[Get]]` /
+descriptor-mutation on an arbitrary receiver.
+
+New entries to `PURE_OBJECT_CALLS_ON_PLAIN_DATA` need the same
+per-entry ECMA-262 citation as `PURE_STATIC_CALLS`, plus paired
+positive and negative tests in `analysis_tests.rs`:
+
+- a positive `object_<prop>_on_plain_<shape>_classifies_pure`
+  test (`Object.<prop>({lit})` is Pure), and
+- a negative `object_<prop>_on_<non-plain>_stays_unknown` test
+  (`Object.<prop>(somefn())` is Unknown, opaque-binding form is
+  Unknown).
+
+Cycle-breaking behaviour is pinned in
+`devinfra/js/debundle/e2e/object_plain_data_calls_test.rs`.
 
 ## Testing Philosophy
 

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -2,7 +2,10 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     use crate::facts::{compute_shadowed_globals, top_level_item_views};
-    use crate::purity::{ChunkCodeGraph, Purity, RedundantPurityReason, classify_expr_purity};
+    use crate::purity::{
+        ChunkCodeGraph, Purity, RedundantPureMemberReason, RedundantPurityReason,
+        classify_expr_purity,
+    };
     use crate::*;
     use swc_common::{FileName, sync::Lrc};
     use swc_ecma_ast::*;
@@ -27,6 +30,7 @@ mod tests {
         AnalysisHints {
             declared_pure: BTreeSet::new(),
             declared_pure_new: BTreeSet::new(),
+            declared_pure_members: BTreeMap::new(),
             known_effects: BTreeMap::from([(
                 name.to_string(),
                 KnownEffect::TypescriptDecorateHelper,
@@ -786,6 +790,34 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         classify_expr_purity(init, &shadowed, &BTreeSet::new(), &graph)
     }
 
+    fn classify_with_declared_pure_members(
+        prefix: &str,
+        expr_src: &str,
+        binding: &str,
+        props: &[&str],
+    ) -> Purity {
+        let module = parse(&format!("{prefix}\nconst _ = {expr_src};"));
+        let body = top_level_item_views(&module.body);
+        let shadowed = compute_shadowed_globals(&body);
+        let declared_pure_members: BTreeMap<String, BTreeSet<String>> = BTreeMap::from([(
+            binding.to_string(),
+            props.iter().map(|s| (*s).to_string()).collect(),
+        )]);
+        let graph = ChunkCodeGraph::build_full(
+            &body,
+            &shadowed,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &declared_pure_members,
+        );
+        let var = match module.body.last().expect("non-empty body") {
+            ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+            other => panic!("expected last stmt to be `const _ = …;`, got {other:?}"),
+        };
+        let init = var.decls[0].init.as_deref().expect("init expected");
+        classify_expr_purity(init, &shadowed, &BTreeSet::new(), &graph)
+    }
+
     #[test]
     fn classify_literal_kinds_are_pure() {
         assert!((classify("42")).is_pure());
@@ -966,13 +998,21 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn static_function_ref_object_calls_remain_unknown() {
-        // The CALL form of each function-ref entry is unsafe (see
-        // `PURE_STATIC_FUNCTION_REFS` doc-comment for why each is
-        // excluded from `PURE_STATIC_CALLS`). The function-ref
-        // entry only opens the read path; the call must stay
-        // Unknown so the soundness contract holds.
+        // The CALL form of each function-ref entry is unsafe on
+        // arbitrary args (see `PURE_STATIC_FUNCTION_REFS`
+        // doc-comment for why each is excluded from
+        // `PURE_STATIC_CALLS`). The function-ref entry only opens
+        // the read path; the general call must stay Unknown so the
+        // soundness contract holds.
+        //
+        // Note: a subset of these calls (`Object.{keys, values,
+        // entries, freeze, fromEntries}`) becomes Pure when called
+        // with a syntactically plain-data argument — pinned in the
+        // `object_*` tests below. The negatives here use opaque
+        // bindings / non-literal expressions that fall outside that
+        // narrow shape, so they still classify Unknown.
         assert!(!(classify("Object.defineProperty(t, 'k', { value: 1 })")).is_pure());
-        assert!(!(classify("Object.freeze({ x: 1 })")).is_pure());
+        assert!(!(classify("Object.freeze(o)")).is_pure());
         assert!(!(classify("Object.values(o)")).is_pure());
         assert!(!(classify("Object.keys(o)")).is_pure());
     }
@@ -1209,6 +1249,255 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
                 &["PureBox"]
             ))
             .is_pure()
+        );
+    }
+
+    // --- Declared pure members (`pure_members`) ----------------------------
+
+    #[test]
+    fn declared_pure_member_call_classifies_pure() {
+        // A spec member with `pure_members: [forwardRef]` admits
+        // `<binding>.forwardRef(args)` as pure with pure args, even
+        // though the binding's body is unknown to the analyzer
+        // (the vendor namespace shape we target). Args still
+        // classified independently.
+        assert!(
+            (classify_with_declared_pure_members(
+                r#"import * as b from "vendor";"#,
+                "b.forwardRef(function () {})",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_member_call_with_impure_arg_inherits_arg_purity() {
+        // The declared-member-purity contract covers the function
+        // value; arg evaluation is independent. An impure arg makes
+        // the whole call Unknown.
+        assert!(
+            !(classify_with_declared_pure_members(
+                r#"import * as b from "vendor"; function io() { globalThis.x = 1; return 1; }"#,
+                "b.forwardRef(io())",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_member_does_not_bleed_to_other_props() {
+        // Only the listed property is treated pure. A sibling
+        // property call stays Unknown.
+        assert!(
+            !(classify_with_declared_pure_members(
+                r#"import * as b from "vendor";"#,
+                "b.unknownMethod(1)",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_member_does_not_bleed_to_other_bindings() {
+        // Only the listed binding is treated pure. A call on a
+        // different binding stays Unknown.
+        assert!(
+            !(classify_with_declared_pure_members(
+                r#"import * as b from "vendor"; import * as c from "other";"#,
+                "c.forwardRef(1)",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_member_computed_access_falls_back_to_unknown() {
+        // Computed access (`b[expr]`) is intentionally not
+        // admitted — `expr` may evaluate to a different property
+        // at runtime, breaking the spec author's trust contract.
+        assert!(
+            !(classify_with_declared_pure_members(
+                r#"import * as b from "vendor"; const key = "forwardRef";"#,
+                "b[key](1)",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    #[test]
+    fn declared_pure_member_optional_chain_call_classifies_pure() {
+        // Optional chaining (`b?.forwardRef(...)`) only adds a
+        // null/undefined short-circuit — the call itself still
+        // qualifies under the same admission rule.
+        assert!(
+            (classify_with_declared_pure_members(
+                r#"import * as b from "vendor";"#,
+                "b?.forwardRef(1)",
+                "b",
+                &["forwardRef"]
+            ))
+            .is_pure()
+        );
+    }
+
+    // --- Object.{entries,keys,values,freeze,fromEntries} on plain data -----
+
+    #[test]
+    fn object_keys_on_plain_object_literal_classifies_pure() {
+        // `Object.keys({a: 1, b: 2})` — fresh plain object literal,
+        // no accessors. Spec: §20.1.2.17 calls
+        // `EnumerableOwnPropertyNames(O, "key")` which only does
+        // `[[OwnPropertyKeys]]` and `[[GetOwnProperty]]` — no
+        // user code fires.
+        assert!((classify(r#"Object.keys({a: 1, b: 2})"#)).is_pure());
+    }
+
+    #[test]
+    fn object_values_on_plain_object_literal_classifies_pure() {
+        // `Object.values({a: 1, b: 2})` — same as keys, plus
+        // `[[Get]]` on each own key. Plain literal has only data
+        // properties, so no accessor fires.
+        assert!((classify(r#"Object.values({a: 1, b: 2})"#)).is_pure());
+    }
+
+    #[test]
+    fn object_entries_on_plain_object_literal_classifies_pure() {
+        assert!((classify(r#"Object.entries({a: 1, b: 2})"#)).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_on_plain_object_literal_classifies_pure() {
+        // `Object.freeze({a: 1})` — SetIntegrityLevel does no
+        // `[[Get]]`, only rewrites descriptors. Fresh literal has
+        // no aliases, so mutation is unobservable from outside the
+        // call.
+        assert!((classify(r#"Object.freeze({a: 1})"#)).is_pure());
+    }
+
+    #[test]
+    fn object_keys_on_plain_array_literal_classifies_pure() {
+        // Array literals are ordinary objects with integer-index
+        // own data properties — same admission as object literals.
+        assert!((classify("Object.keys([1, 2, 3])")).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_on_object_with_getter_stays_unknown() {
+        // Getter property would fire `[[Get]]` if subsequently
+        // read — and even for freeze, the rule must not admit
+        // accessor-carrying literals because the syntactic check
+        // is shared with values/entries which do `[[Get]]`. The
+        // strict `is_plain_data_prop` predicate rejects getters.
+        assert!(!(classify(r#"Object.freeze({ get x() { return 1; } })"#)).is_pure());
+    }
+
+    #[test]
+    fn object_values_on_object_with_method_stays_unknown() {
+        // A method property (`{m() {}}`) is also rejected by the
+        // strict shape predicate — admission requires
+        // `Prop::KeyValue` / `Prop::Shorthand` only.
+        assert!(!(classify(r#"Object.values({ m() { return 1; } })"#)).is_pure());
+    }
+
+    #[test]
+    fn object_entries_on_non_literal_arg_stays_unknown() {
+        // Arbitrary expression: could be a Proxy or carry user
+        // accessors. Stay Unknown.
+        assert!(!(classify("Object.entries(somefn())")).is_pure());
+        assert!(!(classify("Object.entries(x)")).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_on_object_with_proto_stays_unknown() {
+        // `{__proto__: …}` in an object literal sets the
+        // prototype — rejected by `is_plain_data_prop`.
+        assert!(!(classify(r#"Object.freeze({ __proto__: x, a: 1 })"#)).is_pure());
+    }
+
+    #[test]
+    fn object_freeze_on_object_with_spread_falls_back_to_unknown() {
+        // Object spread in an object literal is classified
+        // `ObjectSpread`-impure by the existing classifier (it
+        // doesn't track "fresh-literal source ⇒ pure" for spreads),
+        // so a literal carrying a spread doesn't classify pure
+        // overall. The plain-data call rule gates on the overall
+        // literal being pure, so the spread form falls back to
+        // Unknown until the existing spread classifier is
+        // refined.
+        assert!(!(classify(r#"Object.freeze({ ...{a: 1}, b: 2 })"#)).is_pure());
+        assert!(!(classify(r#"Object.freeze({ ...src, b: 2 })"#)).is_pure());
+    }
+
+    #[test]
+    fn object_keys_on_plain_data_binding_classifies_pure() {
+        // `Object.keys(plain)` where `plain` is a chunk-top
+        // `const plain = {…}` bound to a plain-data shape —
+        // accessor-free by `collect_plain_data_bindings` /
+        // `PlainDataWriteScanner` invariants. Same admission as
+        // a fresh literal.
+        let module = parse("const plain = { a: 1 }; const _ = Object.keys(plain);");
+        let body = top_level_item_views(&module.body);
+        let shadowed = compute_shadowed_globals(&body);
+        let graph = ChunkCodeGraph::build(&body, &shadowed, &BTreeSet::new());
+        let var = match module.body.last().expect("non-empty body") {
+            ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+            other => panic!("expected `const _ = …;`, got {other:?}"),
+        };
+        let init = var.decls[0].init.as_deref().expect("init expected");
+        assert!(classify_expr_purity(init, &shadowed, &BTreeSet::new(), &graph).is_pure());
+    }
+
+    #[test]
+    fn object_from_entries_on_array_of_pair_literals_classifies_pure() {
+        // `Object.fromEntries([[k, v], …])` — same admission as
+        // `new Map([[k, v], …])`. Array literal of 2-element Array
+        // literals with pure values.
+        assert!((classify(r#"Object.fromEntries([["a", 1], ["b", 2]])"#)).is_pure());
+    }
+
+    #[test]
+    fn object_from_entries_on_object_literal_stays_unknown() {
+        // `Object.fromEntries({...})` is a TypeError at runtime
+        // (objects aren't iterable). Stay Unknown to avoid the
+        // observable throw.
+        assert!(!(classify(r#"Object.fromEntries({a: 1})"#)).is_pure());
+    }
+
+    #[test]
+    fn object_from_entries_on_non_pair_entries_stays_unknown() {
+        // Entries that aren't 2-element Array literals don't
+        // qualify — Map/fromEntries semantics rely on indexed
+        // [0]/[1] reads on the entry being own data properties.
+        assert!(!(classify(r#"Object.fromEntries([{ "0": "k", "1": "v" }])"#)).is_pure());
+        assert!(!(classify(r#"Object.fromEntries([["a", 1, "extra"]])"#)).is_pure());
+    }
+
+    #[test]
+    fn object_calls_with_too_many_args_stay_unknown() {
+        // Single-argument form only. Multi-arg call (e.g. an
+        // accidental third arg) falls back to Unknown rather than
+        // silently admitting.
+        assert!(!(classify(r#"Object.freeze({a: 1}, true)"#)).is_pure());
+        assert!(!(classify(r#"Object.keys({a: 1}, "extra")"#)).is_pure());
+    }
+
+    #[test]
+    fn object_calls_shadowed_receiver_stays_unknown() {
+        // A chunk-top local `Object` re-bind shadows the global
+        // and the rule must fall back to Unknown — the resolved
+        // value isn't the built-in.
+        assert!(
+            !(classify_with_module("const Object = userland;", "Object.entries({a: 1})")).is_pure()
         );
     }
 
@@ -2423,6 +2712,94 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
                 "getEnv".to_string(),
                 RedundantPurityReason::InferredPureFunction
             )]
+        );
+    }
+
+    // --- Redundant `pure_members` hint detection ---------------------------
+
+    fn pure_member_hints(
+        entries: &[(&str, &[&str])],
+    ) -> Vec<(String, String, RedundantPureMemberReason)> {
+        let declared_pure_members: BTreeMap<String, BTreeSet<String>> = entries
+            .iter()
+            .map(|(binding, props)| {
+                (
+                    (*binding).to_string(),
+                    props.iter().map(|s| (*s).to_string()).collect(),
+                )
+            })
+            .collect();
+        // Minimal chunk — the redundant-pure_members check doesn't
+        // consult the chunk body (the redundancy criterion is a
+        // pure function of the hint set + `PURE_STATIC_CALLS`), so
+        // any well-formed module works.
+        let module = parse("const _ = 1;");
+        let hints = AnalysisHints {
+            declared_pure_members,
+            ..AnalysisHints::default()
+        };
+        analyze_chunk(&module, &hints, None, |_| None)
+            .redundant_pure_member_hints
+            .into_iter()
+            .map(|h| (h.binding_name, h.property, h.reason))
+            .collect()
+    }
+
+    #[test]
+    fn redundant_pure_member_on_whitelisted_static_call_is_reported() {
+        // `pure_members: [isArray]` on a binding named `Array` is a
+        // no-op — `Array.isArray(...)` is already in
+        // `PURE_STATIC_CALLS`. Spec author should drop the entry.
+        let got = pure_member_hints(&[("Array", &["isArray"])]);
+        assert_eq!(
+            got,
+            vec![(
+                "Array".to_string(),
+                "isArray".to_string(),
+                RedundantPureMemberReason::WhitelistedStaticCall,
+            )]
+        );
+    }
+
+    #[test]
+    fn load_bearing_pure_member_on_user_binding_is_not_reported() {
+        // `pure_members: [forwardRef]` on a user-named binding `b`
+        // is the load-bearing case — without it, `b.forwardRef(...)`
+        // stays Unknown (no path in the whitelist reaches a user
+        // binding). MUST NOT be flagged.
+        let got = pure_member_hints(&[("b", &["forwardRef"])]);
+        assert!(
+            got.is_empty(),
+            "load-bearing pure_members entry on user binding must not be flagged; got {got:?}",
+        );
+    }
+
+    #[test]
+    fn pure_member_on_object_freeze_is_not_reported() {
+        // `Object.freeze(...)` IS in
+        // `PURE_OBJECT_CALLS_ON_PLAIN_DATA` but NOT in
+        // `PURE_STATIC_CALLS` — the auto-pure path requires the
+        // plain-data arg shape, which the redundant check doesn't
+        // verify per-callsite. MUST NOT be flagged: the spec hint
+        // covers arbitrary arg shapes and is genuinely load-bearing
+        // for non-literal callsites.
+        let got = pure_member_hints(&[("Object", &["freeze", "entries"])]);
+        assert!(
+            got.is_empty(),
+            "pure_members entries shadowed by argument-gated rules must not be flagged; got {got:?}",
+        );
+    }
+
+    #[test]
+    fn pure_member_on_whitelist_receiver_unknown_prop_is_not_reported() {
+        // `pure_members: [unknownProp]` on `Array` — `Array.unknownProp`
+        // is not in `PURE_STATIC_CALLS`, so the hint is load-bearing
+        // (covers a call the analyzer would otherwise classify
+        // Unknown). MUST NOT be flagged.
+        let got = pure_member_hints(&[("Array", &["unknownProp"])]);
+        assert!(
+            got.is_empty(),
+            "pure_members on a non-whitelisted prop must not be flagged; got {got:?}",
         );
     }
 

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -53,6 +53,8 @@ rust_library(
         "lowering_test",
         "mini_factors_test",
         "naturalization_test",
+        "object_plain_data_calls_test",
+        "pure_members_test",
         "url_rebase_test",
         "vendor_swap_test",
         "identifier_rename_queue_test",

--- a/devinfra/js/debundle/e2e/object_plain_data_calls_test.rs
+++ b/devinfra/js/debundle/e2e/object_plain_data_calls_test.rs
@@ -1,0 +1,153 @@
+//! End-to-end pinning for the `Object.{entries, keys, values,
+//! freeze, fromEntries}` plain-data admission rule
+//! (`PURE_OBJECT_CALLS_ON_PLAIN_DATA`).
+//!
+//! These built-ins are excluded from `PURE_STATIC_CALLS` because
+//! on a general argument they call `[[Get]]` on own keys (firing
+//! user accessors) or mutate descriptors. They become Pure only
+//! when the argument is structurally a fresh plain-data
+//! object/array literal (no accessors / methods / `__proto__` /
+//! computed keys / spread of non-plain-data sources). The negative
+//! case — an opaque ident or function-call argument — stays
+//! Unknown.
+//!
+//! Companion unit tests in `analysis_tests.rs` cover the bare
+//! classifier verdicts; these end-to-end tests pin the
+//! cycle-breaking behaviour the rule enables in real specs.
+
+use debundle_e2e_support::*;
+
+/// Cycle-forcing layout for the positive case:
+///   1. `const a = (() => 1)();` — SE; stays in residual
+///   2. `const b = Object.freeze({ x: 1 });` — would be SE
+///      without the rule; peeled to b_module
+///   3. `const c = b.x + a;` — reads b at init
+///   4. `console.log(c);`
+///
+/// Without the rule: `Object.freeze({…})` classifies Unknown
+/// (the call form is excluded from `PURE_STATIC_CALLS`), `b` is
+/// SE → `b → a` s-edge → cycle after peeling `b` to b_module.
+///
+/// With the rule: the call is Pure on a fresh plain-data literal,
+/// `b` is not SE, the cycle disappears, validator accepts.
+#[test]
+fn object_freeze_on_plain_object_literal_admits() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const a = (() => 1)();
+const b = Object.freeze({ x: 1 });
+const c = b.x + a;
+console.log(c);
+export { a, b, c };
+"#,
+        vec![logical_module("b_module", &[Member::new("b")])],
+    ));
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/b_module.js",
+        &["const b = Object.freeze("],
+        &["const a"],
+    );
+    assert_entry_output(&fixture, "2\n");
+}
+
+#[test]
+fn object_entries_on_plain_object_literal_admits() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const a = (() => 1)();
+const b = Object.entries({ x: 1, y: 2 });
+const c = b.length + a;
+console.log(c);
+export { a, b, c };
+"#,
+        vec![logical_module("b_module", &[Member::new("b")])],
+    ));
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/b_module.js",
+        &["const b = Object.entries("],
+        &["const a"],
+    );
+    assert_entry_output(&fixture, "3\n");
+}
+
+#[test]
+fn object_keys_on_plain_array_literal_admits() {
+    // Array literal is also an ordinary plain-data shape — its own
+    // properties are integer-indexed data slots, no accessors.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const a = (() => 1)();
+const b = Object.keys([10, 20, 30]);
+const c = b.length + a;
+console.log(c);
+export { a, b, c };
+"#,
+        vec![logical_module("b_module", &[Member::new("b")])],
+    ));
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/b_module.js",
+        &["const b = Object.keys("],
+        &["const a"],
+    );
+    assert_entry_output(&fixture, "4\n");
+}
+
+#[test]
+fn object_from_entries_on_array_of_pair_literals_admits() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const a = (() => 1)();
+const b = Object.fromEntries([["x", 1], ["y", 2]]);
+const c = b.x + a;
+console.log(c);
+export { a, b, c };
+"#,
+        vec![logical_module("b_module", &[Member::new("b")])],
+    ));
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/b_module.js",
+        &["const b = Object.fromEntries("],
+        &["const a"],
+    );
+    assert_entry_output(&fixture, "2\n");
+}
+
+/// Negative: a non-literal argument (an IIFE call here) leaves
+/// `Object.entries(...)` classified Unknown. The side-effect cycle
+/// closes and the validator rejects.
+#[test]
+fn object_entries_on_non_literal_arg_does_not_admit() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const a = (() => 1)();
+const b = Object.entries((() => ({ x: 1 }))());
+const c = b.length + a;
+console.log(c);
+export { a, b, c };
+"#,
+            vec![logical_module("b_module", &[Member::new("b")])],
+        ),
+        &["cycle", "b_module", "residual"],
+    );
+}
+
+/// Negative: an object literal carrying a getter has accessor
+/// channels — admitting would let `Object.values`/`entries` fire
+/// user code. The strict shape predicate (`is_plain_data_prop`)
+/// rejects getter properties, so the call stays Unknown and the
+/// cycle is preserved.
+#[test]
+fn object_values_on_object_with_getter_does_not_admit() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const a = (() => 1)();
+const b = Object.values({ get x() { return 1; } });
+const c = b.length + a;
+console.log(c);
+export { a, b, c };
+"#,
+            vec![logical_module("b_module", &[Member::new("b")])],
+        ),
+        &["cycle", "b_module", "residual"],
+    );
+}

--- a/devinfra/js/debundle/e2e/pure_members_test.rs
+++ b/devinfra/js/debundle/e2e/pure_members_test.rs
@@ -1,0 +1,174 @@
+//! End-to-end pinning for the per-member `pure_members:
+//! [<prop>, …]` spec annotation.
+//!
+//! The annotation extends `purity: pure` from "calls of the bound
+//! Ident classify pure" to "calls of `<binding>.<prop>(...)` for
+//! each listed property classify pure". Targets the
+//! vendor-namespace shape — a star-import or renamed binding
+//! standing in for a vendor module (React, etc.), where member
+//! calls (`React.forwardRef`, `React.memo`, `React.lazy`,
+//! `React.createContext`) are author-asserted side-effect-free
+//! when their arguments classify pure.
+//!
+//! Same author-trust contract as `purity: pure`: the validator does
+//! not re-verify; soundness shifts to the spec author. See
+//! AGENTS.md "Declared purity".
+
+use debundle_e2e_support::*;
+use serde_json::json;
+
+/// Vendor-namespace fixture: a star-import binding `ns` whose
+/// `ns.makePure(...)` call site would force a side-effect-order
+/// edge under default classification (`ns.makePure` is a member call
+/// on an unknown receiver). With `pure_members: [makePure]` on the
+/// `ns` member, the analyzer admits the call as pure, drops the
+/// `S` edge, and the cycle-forcing fixture accepts.
+///
+/// Cycle-forcing layout:
+///   1. `const a = (() => 1)();` — SE; stays in residual
+///   2. `const b = ns.makePure({ value: 1 });` — would be SE
+///      without the rule; peeled to b_module
+///   3. `const c = b.value + a;` — reads b at init
+///   4. `console.log(c);`
+///
+/// Without the rule: `ns.makePure(...)` is Unknown → `b` is SE →
+/// `b → a` s-edge → after peeling `b` to b_module, that crosses
+/// `b_module → residual`. Combined with `residual → b_module`
+/// (`c` reads `b` at init), the spec is unrealizable.
+///
+/// With the rule: `ns.makePure(...)` is Pure → `b` is not SE →
+/// no `b → a` s-edge. Only `residual → b_module` remains. DAG.
+#[test]
+fn pure_members_admits_namespace_member_call() {
+    let opts = FixtureOpts {
+        source: r#"import * as ns from "./vendor.js";
+const a = (() => 1)();
+const b = ns.makePure({ value: 1 });
+const c = b.value + a;
+console.log(c);
+export { a, b, c };
+"#,
+        logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
+        chunk_renames: Some(json!({
+            "id": "chunk_renames__static_app",
+            "members": [
+                {
+                    "name": "React",
+                    "selector": {
+                        "binding": {
+                            "name": "ns",
+                            "kind": "import_specifier",
+                        },
+                    },
+                    "pure_members": ["makePure"],
+                },
+            ],
+        })),
+        chunk_id: "static/app",
+        unassigned_mode: unassigned_mode_catchall_file(None),
+        extra_files: &[(
+            "static/app/vendor.js",
+            "export function makePure(arg) { return arg; }\n",
+        )],
+    };
+    let fixture = run_fixture(opts);
+
+    // Peel succeeded: b is in b_module without dragging a.
+    // The fact that the build didn't error on a cycle proves
+    // that `ns.makePure(...)` was classified Pure.
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/b_module.js",
+        &["const b = "],
+        &["const a", "(()=>1)"],
+    );
+
+    // Behaviour preserved: c == b.value + a == 1 + 1 == 2.
+    assert_entry_output(&fixture, "2\n");
+}
+
+/// Companion negative: the same fixture shape but the spec lists
+/// a different property name. The actual `ns.makePure(...)` call
+/// stays Unknown (the spec didn't annotate `makePure`), the
+/// side-effect cycle closes, and the validator rejects. Pins that
+/// the annotation doesn't bleed onto sibling properties.
+#[test]
+fn pure_members_does_not_bleed_to_other_props() {
+    expect_rejection_containing_all(
+        FixtureOpts {
+            source: r#"import * as ns from "./vendor.js";
+const a = (() => 1)();
+const b = ns.makePure({ value: 1 });
+const c = b.value + a;
+console.log(c);
+export { a, b, c };
+"#,
+            logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
+            chunk_renames: Some(json!({
+                "id": "chunk_renames__static_app",
+                "members": [
+                    {
+                        "name": "React",
+                        "selector": {
+                            "binding": {
+                                "name": "ns",
+                                "kind": "import_specifier",
+                            },
+                        },
+                        // Annotated property is not the one called.
+                        "pure_members": ["somethingElse"],
+                    },
+                ],
+            })),
+            chunk_id: "static/app",
+            unassigned_mode: unassigned_mode_catchall_file(None),
+            extra_files: &[(
+                "static/app/vendor.js",
+                "export function makePure(arg) { return arg; }\n",
+            )],
+        },
+        &["cycle", "b_module", "residual"],
+    );
+}
+
+/// Args are still classified independently of the spec hint — the
+/// declared-purity contract covers the function value, not the
+/// arguments. An impure arg (an IIFE call here) keeps the call
+/// classified impure, the cycle closes, and the validator rejects.
+#[test]
+fn pure_members_call_with_impure_arg_does_not_admit() {
+    expect_rejection_containing_all(
+        FixtureOpts {
+            source: r#"import * as ns from "./vendor.js";
+const a = (() => 1)();
+const b = ns.makePure((() => globalThis.touched = 1)());
+const c = (b ? 1 : 0) + a;
+console.log(c);
+export { a, b, c };
+"#,
+            logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
+            chunk_renames: Some(json!({
+                "id": "chunk_renames__static_app",
+                "members": [
+                    {
+                        "name": "React",
+                        "selector": {
+                            "binding": {
+                                "name": "ns",
+                                "kind": "import_specifier",
+                            },
+                        },
+                        "pure_members": ["makePure"],
+                    },
+                ],
+            })),
+            chunk_id: "static/app",
+            unassigned_mode: unassigned_mode_catchall_file(None),
+            extra_files: &[(
+                "static/app/vendor.js",
+                "export function makePure(arg) { return arg; }\n",
+            )],
+        },
+        &["cycle", "b_module", "residual"],
+    );
+}

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -10,9 +10,9 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::purity::{
-    ChunkCodeGraph, Purity, PurityReason, PurityRule, RedundantPurityHint, WHITELIST_RECEIVERS,
-    class_has_static_observable, classify_expr_purity, classify_var_decl_purity,
-    detect_redundant_purity_hints,
+    ChunkCodeGraph, Purity, PurityReason, PurityRule, RedundantPureMemberHint, RedundantPurityHint,
+    WHITELIST_RECEIVERS, class_has_static_observable, classify_expr_purity,
+    classify_var_decl_purity, detect_redundant_pure_member_hints, detect_redundant_purity_hints,
 };
 use crate::{BindingName, SourceLocation, StatementOrdinal};
 
@@ -51,6 +51,13 @@ pub enum KnownEffect {
 pub struct AnalysisHints {
     pub declared_pure: BTreeSet<String>,
     pub declared_pure_new: BTreeSet<String>,
+    /// Author-declared pure member properties — keyed by binding name,
+    /// value is the set of property names whose `<binding>.<prop>(args)`
+    /// calls the spec author asserts are pure. The classifier consults
+    /// this to admit `<recv>.<prop>(args)` as pure when `recv` is the
+    /// keyed binding and `<prop>` is in the value set.
+    /// See AGENTS.md "Declared purity".
+    pub declared_pure_members: BTreeMap<String, BTreeSet<String>>,
     pub known_effects: BTreeMap<String, KnownEffect>,
 }
 
@@ -59,6 +66,7 @@ impl AnalysisHints {
         Self {
             declared_pure: declared_pure.clone(),
             declared_pure_new: BTreeSet::new(),
+            declared_pure_members: BTreeMap::new(),
             known_effects: BTreeMap::new(),
         }
     }
@@ -75,6 +83,13 @@ pub struct ChunkFactAnalysis {
     /// such that the callsite hint is a no-op. Surfaced so the spec
     /// author can prune the hint and shrink the trust surface.
     pub redundant_purity_hints: Vec<RedundantPurityHint>,
+    /// Author-declared `pure_members: [<prop>, …]` entries the
+    /// analyzer would classify pure without the hint — currently
+    /// limited to `(WHITELIST_RECEIVERS, PURE_STATIC_CALLS-prop)`
+    /// pairs (e.g. `pure_members: [isArray]` on a binding named
+    /// `Array`). Surfaced for the same trust-surface-shrinking
+    /// reason as `redundant_purity_hints`.
+    pub redundant_pure_member_hints: Vec<RedundantPureMemberHint>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -165,14 +180,17 @@ where
 {
     let body = top_level_item_views(&module.body);
     let shadowed = compute_shadowed_globals(&body);
-    let graph = ChunkCodeGraph::build_with_declared_pure_new(
+    let graph = ChunkCodeGraph::build_full(
         &body,
         &shadowed,
         &hints.declared_pure,
         &hints.declared_pure_new,
+        &hints.declared_pure_members,
     );
     let redundant_purity_hints =
         detect_redundant_purity_hints(&body, &shadowed, &hints.declared_pure);
+    let redundant_pure_member_hints =
+        detect_redundant_pure_member_hints(&hints.declared_pure_members);
     let mut top_level_await = None;
     let facts = body
         .iter()
@@ -219,6 +237,7 @@ where
         facts,
         top_level_await,
         redundant_purity_hints,
+        redundant_pure_member_hints,
     }
 }
 

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -47,7 +47,10 @@ pub use ids::{
     LogicalModuleIndex, ModuleId, StatementOrdinal,
 };
 pub use partition::Partition;
-pub use purity::{Purity, PurityReason, PurityRule, RedundantPurityHint, RedundantPurityReason};
+pub use purity::{
+    Purity, PurityReason, PurityRule, RedundantPureMemberHint, RedundantPureMemberReason,
+    RedundantPurityHint, RedundantPurityReason,
+};
 pub use report_schema::{
     BindingReport, EvaluatedPeelCandidateReport, FactorizeCell, FactorizeDiagnostic,
     FactorizeDiagnosticReason, FactorizeOptions, FactorizeReport, ModuleReportRef,

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -14,8 +14,9 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 use analysis::{
     AnalysisHints, AtomicUnitConflict, BindingKind, BindingName, DepKind, KnownEffect,
     LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId, OwnerGraphAndUnits,
-    OwnerId, RedundantPurityHint, RedundantPurityReason, Schedule, analyze_chunk,
-    compute_owner_graph_and_units, render_atomic_unit_conflict_summary, render_cycle_summary,
+    OwnerId, RedundantPureMemberReason, RedundantPurityHint, RedundantPurityReason, Schedule,
+    analyze_chunk, compute_owner_graph_and_units, render_atomic_unit_conflict_summary,
+    render_cycle_summary,
 };
 use artifact::{
     ArtifactIndexes, ArtifactSourceImportResolver, ChunkAnalysis, ChunkArtifact, ChunkBundle,
@@ -174,6 +175,13 @@ struct MemberRequest {
     /// their target class/prototype, so the analyzer can model a local
     /// effect edge instead of a global side-effect-order edge.
     effect: MemberEffect,
+    /// Property names on the bound value whose member calls
+    /// (`<binding>.<prop>(args)` / `<binding>?.<prop>(args)`) the author
+    /// asserts have no observable side effects beyond evaluating their
+    /// arguments. Same author-trust contract as `purity: pure` — see
+    /// AGENTS.md "Declared purity". Empty when the spec doesn't carry a
+    /// `pure_members` entry for this member.
+    pure_members: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -678,6 +686,13 @@ fn materialize_logical_chunk(
                     if m.purity == MemberPurity::PureNew {
                         hints.declared_pure_new.insert(m.binding.clone());
                     }
+                    if !m.pure_members.is_empty() {
+                        hints
+                            .declared_pure_members
+                            .entry(m.binding.clone())
+                            .or_default()
+                            .extend(m.pure_members.iter().cloned());
+                    }
                     if let Some(effect) = known_effect_from_member_effect(m.effect) {
                         hints.known_effects.insert(m.binding.clone(), effect);
                     }
@@ -692,6 +707,13 @@ fn materialize_logical_chunk(
                         hints
                             .declared_pure_new
                             .insert(m.selector.binding.name.clone());
+                    }
+                    if !m.pure_members.is_empty() {
+                        hints
+                            .declared_pure_members
+                            .entry(m.selector.binding.name.clone())
+                            .or_default()
+                            .extend(m.pure_members.iter().cloned());
                     }
                     if let Some(effect) = known_effect_from_member_effect(m.effect) {
                         hints
@@ -731,6 +753,19 @@ fn materialize_logical_chunk(
                         "pure (the function body classifies Pure by recursive analysis)",
                     RedundantPurityReason::InferredPlainDataBinding =>
                         "PlainData (chunk-local const/let plain literal with no chunk-wide writes through the binding)",
+                },
+            );
+        }
+        for hint in &analysis.redundant_pure_member_hints {
+            eprintln!(
+                "warning: chunk {chunk_id}: `pure_members: [{property}]` on binding `{binding}` \
+                 is redundant — the analyzer infers {reason} without the hint. \
+                 Remove the entry from the spec.",
+                binding = hint.binding_name,
+                property = hint.property,
+                reason = match hint.reason {
+                    RedundantPureMemberReason::WhitelistedStaticCall =>
+                        "pure via PURE_STATIC_CALLS (already on the global-receiver whitelist)",
                 },
             );
         }
@@ -2131,6 +2166,7 @@ fn build_members(members: &[spec::Member]) -> Vec<MemberRequest> {
                 export_name,
                 purity: m.purity,
                 effect: m.effect,
+                pure_members: m.pure_members.clone(),
             }
         })
         .collect()

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -24,6 +24,12 @@ use crate::facts::TopLevelItemView;
 pub struct ChunkCodeGraph {
     bindings: BTreeMap<String, ChunkBinding>,
     pure_new_constructors: BTreeSet<String>,
+    /// Per-binding declared-pure member-call set. Looked up by the
+    /// classifier when it sees `<recv>.<prop>(args)` — if `recv` is a
+    /// non-shadowed key here and `<prop>` is in the set, the call is
+    /// admitted as pure with args evaluated normally. Author-trust
+    /// contract; see AGENTS.md "Declared purity".
+    declared_pure_members: BTreeMap<String, BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +125,22 @@ impl ChunkCodeGraph {
         declared_pure: &BTreeSet<String>,
         declared_pure_new: &BTreeSet<String>,
     ) -> Self {
+        Self::build_full(
+            body,
+            shadowed,
+            declared_pure,
+            declared_pure_new,
+            &BTreeMap::new(),
+        )
+    }
+
+    pub(crate) fn build_full(
+        body: &[TopLevelItemView<'_>],
+        shadowed: &BTreeSet<&'static str>,
+        declared_pure: &BTreeSet<String>,
+        declared_pure_new: &BTreeSet<String>,
+        declared_pure_members: &BTreeMap<String, BTreeSet<String>>,
+    ) -> Self {
         let functions = collect_chunk_functions(body);
         let name_to_idx: BTreeMap<&str, usize> = functions
             .iter()
@@ -169,6 +191,7 @@ impl ChunkCodeGraph {
         let mut graph = ChunkCodeGraph {
             bindings,
             pure_new_constructors: declared_pure_new.clone(),
+            declared_pure_members: declared_pure_members.clone(),
         };
         // tarjan_scc emits SCCs in reverse topological order: leaves
         // (sinks — functions that don't call any chunk-top
@@ -248,6 +271,16 @@ impl ChunkCodeGraph {
     pub(crate) fn is_declared_pure_new(&self, name: &str) -> bool {
         self.pure_new_constructors.contains(name)
     }
+
+    /// Whether `<recv>.<prop>(args)` is admitted as pure by an author
+    /// `pure_members: [<prop>, …]` annotation on the binding `recv`.
+    /// Args still classified independently — declared purity covers
+    /// the function value, not its arguments.
+    pub(crate) fn is_declared_pure_member(&self, recv: &str, prop: &str) -> bool {
+        self.declared_pure_members
+            .get(recv)
+            .is_some_and(|props| props.contains(prop))
+    }
 }
 
 /// One author-declared `purity: pure` hint the analyzer determines
@@ -275,6 +308,28 @@ pub enum RedundantPurityReason {
     /// binding isn't called as `binding(...)` in any pure-relevant
     /// way that the override would gate.
     InferredPlainDataBinding,
+}
+
+/// One redundant `pure_members: [<prop>]` entry — the
+/// `<binding>.<prop>(args)` call would already classify pure
+/// without the spec hint (e.g. the receiver is `Array` and the
+/// property is `isArray`, already covered by `PURE_STATIC_CALLS`).
+/// Surfaced so spec authors can prune the redundant entry.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RedundantPureMemberHint {
+    pub binding_name: String,
+    pub property: String,
+    pub reason: RedundantPureMemberReason,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedundantPureMemberReason {
+    /// `(<binding>, <prop>)` is already in `PURE_STATIC_CALLS` AND
+    /// `<binding>` is a whitelist receiver name (e.g. `Array`,
+    /// `Number`) — the call classifies pure on its own with no
+    /// `pure_members` annotation. The hint is a no-op.
+    WhitelistedStaticCall,
 }
 
 /// For each name in `declared_pure`, ask "would the analyzer infer
@@ -328,6 +383,54 @@ pub(crate) fn detect_redundant_purity_hints(
                 binding_name: name.clone(),
                 reason,
             });
+        }
+    }
+    out
+}
+
+/// Walk `declared_pure_members` and flag entries the analyzer would
+/// classify pure without the hint. Currently the only auto-pure path
+/// for member calls is the `PURE_STATIC_CALLS` whitelist for
+/// `(WHITELIST_RECEIVERS, prop)` pairs — so an entry like
+/// `pure_members: [isArray]` on a binding named `Array` is a no-op
+/// (`Array.isArray(...)` is already in `PURE_STATIC_CALLS`).
+///
+/// The `PURE_OBJECT_CALLS_ON_PLAIN_DATA` admission rule has
+/// per-callsite argument-shape gates — without inspecting every
+/// callsite for `<binding>.<prop>(...)` arg shapes, we can't claim
+/// the spec hint is a no-op (the hint covers ALL arg shapes, while
+/// the whitelist only covers plain-data args). To stay sound under
+/// the "report only confirmed-redundant" contract, we don't flag
+/// `pure_members: [entries|keys|values|freeze|fromEntries]` on
+/// `Object` here. Spec authors can drop them manually once they've
+/// verified every callsite uses a plain-data arg.
+pub(crate) fn detect_redundant_pure_member_hints(
+    declared_pure_members: &BTreeMap<String, BTreeSet<String>>,
+) -> Vec<RedundantPureMemberHint> {
+    let mut out = Vec::new();
+    for (binding, props) in declared_pure_members {
+        // Only whitelist-receiver bindings can ride on
+        // `PURE_STATIC_CALLS`. A user-named binding (e.g. a vendor
+        // namespace `b`) doesn't reach the whitelist regardless of
+        // shadowing — so the hint is load-bearing there.
+        let recv = WHITELIST_RECEIVERS
+            .iter()
+            .copied()
+            .find(|r| *r == binding.as_str());
+        let Some(recv) = recv else {
+            continue;
+        };
+        for prop in props {
+            if PURE_STATIC_CALLS
+                .iter()
+                .any(|(r, p)| *r == recv && *p == prop.as_str())
+            {
+                out.push(RedundantPureMemberHint {
+                    binding_name: binding.clone(),
+                    property: prop.clone(),
+                    reason: RedundantPureMemberReason::WhitelistedStaticCall,
+                });
+            }
         }
     }
     out
@@ -1558,6 +1661,92 @@ const PURE_STATIC_FUNCTION_REFS: &[(&str, &str)] = &[
     ("Object", "hasOwn"),
 ];
 
+/// Static `Object` methods that are Pure when called with a single
+/// argument that is structurally a fresh plain-data object/array
+/// literal (no accessors / methods / `__proto__` / computed keys /
+/// spread of non-plain-data sources) OR a chunk-top binding that has
+/// admitted as `ChunkBinding::PlainData` (whose plain-data shape is
+/// enforced syntactically by `collect_plain_data_bindings` and whose
+/// post-init accessor-installation is rejected by
+/// `PlainDataWriteScanner`).
+///
+/// The contract is stricter than `PURE_STATIC_CALLS` because every
+/// member here either invokes `[[Get]]` on own keys (which fires user
+/// getters / Proxy traps on a general argument) or mutates descriptor
+/// state (`freeze`). Restricting the argument shape to a fresh plain-
+/// data receiver — verified syntactically at the call site — closes
+/// both holes: no own-key access can fire a user accessor (none
+/// exist), and the mutation in `freeze`'s case targets a value that
+/// is not aliased through any user-observable channel before the
+/// call.
+///
+/// Soundness contract per entry:
+///
+/// * `Object.keys(O)` — ECMA-262 §20.1.2.17 calls `ToObject(O)`
+///   (no coercion on an object), then `EnumerableOwnPropertyNames(O,
+///   "key")`. The latter calls `[[OwnPropertyKeys]]` (for an
+///   ordinary plain object: returns the integer-index keys then
+///   string keys in insertion order, no user code) and per-key
+///   `[[GetOwnProperty]]` to check `[[Enumerable]]` — also a
+///   structural read with no user code on a fresh plain literal /
+///   PlainData binding.
+/// * `Object.values(O)` / `Object.entries(O)` — same as `keys` but
+///   additionally call `[[Get]]` on each own key. For an ordinary
+///   plain-data receiver every own key resolves to a data property
+///   ($\Rightarrow$ no accessor fires). PlainData receivers carry
+///   the same guarantee by the chunk-wide write scan
+///   (`PlainDataWriteScanner` rejects any
+///   `Object.defineProperty(X, …)` /
+///   `Object.setPrototypeOf(X, …)` that could install an accessor
+///   post-init).
+/// * `Object.freeze(O)` — ECMA-262 §20.1.2.6 calls
+///   `SetIntegrityLevel(O, "frozen")` which sets `[[Extensible]]`
+///   to false and rewrites each own property descriptor to non-
+///   configurable (and non-writable for data properties). No
+///   `[[Get]]` is performed, no user code fires. The mutation is
+///   on the just-allocated literal (for the literal form) or on a
+///   binding whose only producer/consumer is the chunk being
+///   debundled (for the PlainData form), so it cannot perturb
+///   user-observable state outside the call.
+/// * `Object.fromEntries(I)` — ECMA-262 §20.1.2.7 invokes
+///   `I[@@iterator]()`. For a fresh `Array` literal with no spread,
+///   that resolves to the built-in Array iterator, which `[[Get]]`s
+///   indices `0..length` (own data properties on a fresh array,
+///   no user code) and stops. Each yielded entry must itself be a
+///   2-element Array literal whose [0]/[1] reads are own data
+///   properties (gated by `is_fresh_entry_array_for_from_entries`).
+///   Both gates together rule out the
+///   "non-iterable argument throws TypeError" path that breaks
+///   purity for arbitrary arg shapes (the throw is observable). For
+///   a PlainData Object binding the call would throw, so PlainData
+///   shapes are admitted only for the non-fromEntries methods.
+///
+/// Out of scope (not admitted here; flagged for follow-up review):
+///
+/// * `Object.assign(target, src)` — mutates `target` AND calls
+///   `[[OwnPropertyKeys]]`/`[[Get]]` on `src`. The target-mutation
+///   half rules out the literal-arg shortcut: even with two literal
+///   args, `Object.assign({}, …)` returns the first arg mutated,
+///   which is observable only if the result is captured — but the
+///   mutation itself is invisible without the capture, so this is
+///   safely pure-of-result. Skipped here to keep the rule tight;
+///   the `assign` path needs its own argument-count + result-shape
+///   analysis.
+/// * `Object.getOwnPropertyNames(O)` / `getPrototypeOf(O)` /
+///   `getOwnPropertyDescriptor(O, k)` — same shape as `keys` but
+///   produces a richer return value. Could ride on the same gate
+///   in a follow-up; out for v1 to minimize the audit surface.
+/// * `Array.from(I[, mapFn])` — sound only when `mapFn` is absent
+///   (a `mapFn` invokes user code per element). Skipped here to
+///   avoid the per-call argument-count gate.
+const PURE_OBJECT_CALLS_ON_PLAIN_DATA: &[(&str, &str)] = &[
+    ("Object", "keys"),
+    ("Object", "values"),
+    ("Object", "entries"),
+    ("Object", "freeze"),
+    ("Object", "fromEntries"),
+];
+
 /// Receiver / global-callable names whose whitelist firing depends
 /// on the chunk not having shadowed them at top level.
 /// `analyze_chunk` populates the shadowed-globals set, and
@@ -1590,14 +1779,16 @@ pub(crate) const WHITELIST_RECEIVERS: &[&str] =
 //     fresh array does not fire user code; the open question is
 //     just "could a non-primitive arg do anything observable",
 //     which a primitive-only gate avoids.
-//   - `Object.{keys, values, entries, fromEntries, freeze,
-//     getOwnPropertyNames, getOwnPropertyDescriptor, isFrozen,
-//     hasOwn, assign}` — these *do* observe user callbacks
-//     (getter on `[[Get]]`, ownKeys/getOwnPropertyDescriptor
-//     traps on `Proxy`, mutation), so they remain UNSAFE for
-//     general args. They become Pure only if the receiver is
-//     itself a fresh ordinary-object literal with no accessors —
-//     a separate, stricter analysis.
+//   - `Object.{keys, values, entries, fromEntries, freeze}` on
+//     a fresh plain-data literal / `PlainData` binding —
+//     implemented via `PURE_OBJECT_CALLS_ON_PLAIN_DATA` with a
+//     syntactic argument-shape gate (no accessors / methods /
+//     `__proto__` / computed keys / spread of non-plain sources).
+//     `getOwnPropertyNames`, `getOwnPropertyDescriptor`,
+//     `getPrototypeOf`, `isFrozen`, `hasOwn`, `assign` — the
+//     general-arg form still observes user callbacks and stays
+//     UNSAFE; the plain-data argument-shape gate could extend to
+//     them once a follow-up audits each member's ECMA-262 path.
 //
 // Adding any of these requires (a) a Purity::Primitive variant
 // (or a side analysis that classifies an Expr as
@@ -1765,6 +1956,33 @@ fn classify_fresh_array_spread_source_purity(
         ),
         _ => None,
     }
+}
+
+/// Borrow the `(recv_ident_sym, prop_sym)` pair for a static-ident
+/// member access spelled as either `recv.prop` (`Expr::Member`) or
+/// `recv?.prop` (`Expr::OptChain { base: OptChainBase::Member }`).
+/// Returns `None` for any other shape (chained member access,
+/// computed access, non-Ident receivers, private names, OptCall
+/// bases). The returned references borrow from the AST node and
+/// outlive only the surrounding match — short-lived by design,
+/// because the `pure_members` admission only needs the strings to
+/// look up the per-binding declared-pure set.
+fn static_member_obj_prop(expr: &Expr) -> Option<(&str, &str)> {
+    let member = match expr {
+        Expr::Member(member) => member,
+        Expr::OptChain(opt) => match opt.base.as_ref() {
+            OptChainBase::Member(member) => member,
+            OptChainBase::Call(_) => return None,
+        },
+        _ => return None,
+    };
+    let Expr::Ident(recv) = member.obj.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(prop) = &member.prop else {
+        return None;
+    };
+    Some((recv.sym.as_ref(), prop.sym.as_ref()))
 }
 
 /// `(receiver_ident, prop_name)` for `Receiver.prop` where
@@ -2149,6 +2367,24 @@ fn classify_callee_call(
     {
         return all_args_pure(args, shadowed, declared_pure, graph);
     }
+    // Author-declared pure member call: a binding whose spec member
+    // carries `pure_members: [<prop>, …]`. Admits
+    // `<binding>.<prop>(args)` as pure with args still classified
+    // independently. Static identifier-property only — computed
+    // access (`<binding>[expr](...)`) and private fields fall back
+    // to the regular classifier path. Both the call-then-opt form
+    // (`b?.forwardRef(args)`, callee = `Expr::OptChain(Member)`)
+    // and the opt-call form (`b.forwardRef?.(args)`, callee =
+    // `Expr::Member`) qualify under the same admission rule via
+    // `static_member_obj_prop`. As with `purity: pure` on a
+    // direct-Ident call, the annotation overrides shadowing — the
+    // spec author asserts THIS bound value is pure regardless of
+    // where it came from. See AGENTS.md "Declared purity".
+    if let Some((recv, prop)) = static_member_obj_prop(callee_expr)
+        && graph.is_declared_pure_member(recv, prop)
+    {
+        return all_args_pure(args, shadowed, declared_pure, graph);
+    }
     // Chunk-local function declaration: consult the per-chunk
     // function-body purity cache. `Pure` callee + Pure args → Pure;
     // non-Pure callee inherits its reasons (so the chain points
@@ -2165,6 +2401,24 @@ fn classify_callee_call(
         && PURE_STATIC_CALLS.contains(&(recv, prop))
     {
         return all_args_pure(args, shadowed, declared_pure, graph);
+    }
+    // `Object.{entries,keys,values,freeze}(<plain-data arg>)` /
+    // `Object.fromEntries(<entry-array literal>)` — admitted when
+    // the argument is structurally a plain ordinary literal (no
+    // accessors / methods / `__proto__` / computed keys / spread)
+    // OR a chunk-top `PlainData` binding whose accessor-free shape
+    // is enforced by `collect_plain_data_bindings` /
+    // `PlainDataWriteScanner`. See `PURE_OBJECT_CALLS_ON_PLAIN_DATA`
+    // for the per-entry soundness argument.
+    if let Expr::Member(member) = callee_expr
+        && let Some((recv, prop)) = static_member_pair(member)
+        && !shadowed.contains(recv)
+        && PURE_OBJECT_CALLS_ON_PLAIN_DATA.contains(&(recv, prop))
+        && args.len() == 1
+        && args[0].spread.is_none()
+        && is_pure_plain_data_arg_for(prop, &args[0].expr, shadowed, declared_pure, graph)
+    {
+        return Purity::Pure;
     }
     // `globalCallable(args)` against PURE_GLOBAL_CALLS.
     if let Expr::Ident(ident) = callee_expr
@@ -2215,6 +2469,100 @@ fn callee_summary(callee_expr: &Expr) -> Option<String> {
         },
         _ => None,
     }
+}
+
+/// Whether `arg` is a sound argument shape for the
+/// `PURE_OBJECT_CALLS_ON_PLAIN_DATA` admission rule at the given
+/// `Object.<prop>` callsite. Two admissible shapes:
+///
+/// * **Fresh plain-data literal.** An `Expr::Object` with only
+///   `Prop::KeyValue` / `Prop::Shorthand` (no `__proto__`, computed
+///   keys, methods, getters, setters, or `Prop::Assign`), or an
+///   `Expr::Array` (literal). The literal itself must classify
+///   pure — that catches impure value sub-expressions and spreads
+///   of non-plain-data sources (the existing
+///   `classify_array_spread_source` gate). For `Object.fromEntries`
+///   the Array form is required AND each element must itself be a
+///   2-element Array literal with pure values, paralleling the
+///   `new Map([[k, v], …])` gate.
+///
+/// * **`PlainData` chunk-top binding.** A bare `Expr::Ident` whose
+///   `name` is registered as `ChunkBinding::PlainData` in the
+///   chunk graph. `collect_plain_data_bindings` only registers
+///   bindings whose initializers pass `is_plain_data_init` (same
+///   plain-data shape predicate) AND whose chunk-wide write scan
+///   ruled out accessor installation post-init. So a PlainData
+///   binding carries the same "no accessor channels at any
+///   program point" invariant as a fresh literal.
+///
+/// Returning `false` falls back to `Unknown` — the soundness-first
+/// default.
+fn is_pure_plain_data_arg_for(
+    prop: &str,
+    arg: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let arg = strip_parens(arg);
+    if prop == "fromEntries" {
+        // `Object.fromEntries(I)` iterates I. Restrict I to a fresh
+        // Array literal whose every element is a 2-element Array
+        // literal with pure values — same admission shape as
+        // `new Map([[k, v], …])` (PURE_BUILTIN_NEW_ARRAY_ITERABLE).
+        return matches!(arg, Expr::Array(_))
+            && is_fresh_entry_array_for_from_entries(arg, shadowed, declared_pure, graph);
+    }
+    match arg {
+        // PlainData chunk-top binding read: provably plain-data
+        // shape, no accessor channels anywhere in the chunk.
+        Expr::Ident(ident) => graph.is_plain_data(ident.sym.as_ref()),
+        // Fresh object literal with no accessor channels.
+        Expr::Object(obj) => {
+            obj.props.iter().all(is_plain_data_prop)
+                && classify_expr_purity(arg, shadowed, declared_pure, graph).is_pure()
+        }
+        // Fresh array literal; element purity (including spread
+        // sources) is handled by the standard literal classifier.
+        Expr::Array(_) => classify_expr_purity(arg, shadowed, declared_pure, graph).is_pure(),
+        _ => false,
+    }
+}
+
+/// `Object.fromEntries([[k1, v1], [k2, v2], …])` admission shape.
+/// Every outer element must be a 2-element Array literal whose
+/// element expressions classify pure (key + value). No spreads at
+/// either level: a spread fires the iterable's `[Symbol.iterator]`
+/// which can call user code outside the literal-only domain we
+/// claim sound here. Matches the
+/// `PURE_BUILTIN_NEW_ARRAY_ITERABLE`-style entry test for `Map`.
+fn is_fresh_entry_array_for_from_entries(
+    arg: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let Expr::Array(outer) = arg else {
+        return false;
+    };
+    outer.elems.iter().all(|elem| {
+        let Some(elem) = elem else {
+            return false;
+        };
+        if elem.spread.is_some() {
+            return false;
+        }
+        let Expr::Array(entry) = strip_parens(&elem.expr) else {
+            return false;
+        };
+        if entry.elems.len() != 2 {
+            return false;
+        }
+        entry.elems.iter().flatten().all(|kv| {
+            kv.spread.is_none()
+                && classify_expr_purity(&kv.expr, shadowed, declared_pure, graph).is_pure()
+        })
+    })
 }
 
 /// True for AST nodes whose evaluation produces a primitive

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -446,6 +446,24 @@ pub struct Member {
     #[serde(skip_serializing_if = "is_default_member_effect")]
     #[serde(default)]
     pub effect: MemberEffect,
+    /// Property names on the bound value whose calls (`<binding>.<name>(args)`)
+    /// the author asserts have no observable side effects when their arguments
+    /// classify pure. Targets the vendor-namespace shape — a star-import or
+    /// renamed binding standing in for a vendor module like React, where
+    /// member calls (`React.forwardRef`, `React.memo`, `React.lazy`,
+    /// `React.createContext`) are pure under the same author-trust contract
+    /// as `purity: pure` extends to direct calls of the bound Ident.
+    ///
+    /// Static identifier-property access only — `<binding>.<name>(...)` and
+    /// `<binding>?.<name>(...)`. Computed access (`<binding>[expr](...)`),
+    /// chained property access (`<binding>.x.y(...)`), shadowed bindings, and
+    /// non-Ident receivers fall through to the regular classifier path.
+    ///
+    /// See AGENTS.md "Declared purity" for the soundness contract — the
+    /// validator does not re-verify; soundness shifts to the spec author.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub pure_members: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

Two purity-analyzer enhancements that unblock RE work in the gaffer Tana web bundle where vendor namespace member calls and `Object.*` builtin calls currently classify Unknown and pin owners into a 341-module residual SCC.

- **`pure_members: [<prop>, ...]` per-binding spec annotation** — extends `purity: pure` from "calls of the bound Ident classify pure" to "calls of `<binding>.<prop>(args)` classify pure when args evaluate pure". Targets the vendor-namespace shape (`b.forwardRef(...)`, `b.lazy(...)`, etc. where `b` is a star-import standing in for React). Same author-trust contract — validator does not re-verify, soundness shifts to the spec author. Optional-chain form (`b?.prop(...)`) admitted under the same rule. Computed access and chained property access fall back to the regular classifier path.
- **New `PURE_OBJECT_CALLS_ON_PLAIN_DATA` whitelist** — admits `Object.{keys, values, entries, freeze, fromEntries}` as Pure when the single argument is structurally a fresh plain-data Object/Array literal OR a chunk-top `ChunkBinding::PlainData` binding. The general-arg form stays Unknown via `PURE_STATIC_FUNCTION_REFS`. Each entry carries a per-entry ECMA-262 citation (§20.1.2.6/7/17 etc.) showing no `[[Get]]` / user-callback path fires on the restricted argument shape.
- **Redundant-hint detection extended** — `pure_members: [<prop>]` on a whitelist-receiver binding (e.g. `Array.isArray`) where `(<recv>, <prop>)` is already in `PURE_STATIC_CALLS` is flagged as redundant. Argument-gated rules deliberately do NOT trigger redundancy (the spec hint still covers arg shapes outside the gate).
- **Tests** — unit tests in `analysis_tests.rs` (positives, negatives, shadowing, computed access, opt-chain, redundant-hint) and e2e tests `pure_members_test.rs` + `object_plain_data_calls_test.rs` pinning cycle-breaking behaviour against the real `debundle` CLI.
- **Gaffer measurement context** (PR #134 zod-purity baseline): 93 React.forwardRef-class owners + 34 Object.entries/freeze owners blocked by the absence of these features.

## Test plan

- [x] `bbr test //devinfra/js/debundle/...` — 40/40 green
- [x] `bbr build //devinfra/js/debundle/...` — green
- [x] AGENTS.md updated with `pure_members` example + argument-gated whitelist soundness section
- [x] Pre-existing tests still pass (no behavior regressions on already-pure cases)
- [x] Soundness rules followed (positive + negative tests, ECMA-262 citation per new whitelist entry)

https://claude.ai/code/session_01TA3Stv6NSAAW3STvb8RpkU