### PR TITLE
study-casino/config: fix admin_users env parsing (NoDecode)

### DIFF
--- a/x/auragon_study_casino/BUILD.bazel
+++ b/x/auragon_study_casino/BUILD.bazel
@@ -121,6 +121,16 @@ py_library(
 )
 
 py_test(
+    name = "test_config",
+    srcs = ["test_config.py"],
+    deps = [
+        ":config",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_store",
     srcs = ["test_store.py"],
     requires_docker = True,

--- a/x/auragon_study_casino/config.py
+++ b/x/auragon_study_casino/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated
 
 from pydantic import BeforeValidator, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 @dataclass(frozen=True)
@@ -31,7 +31,14 @@ def _parse_csv_users(value: object) -> frozenset[str]:
     raise TypeError(f"cannot parse admin_users from {value!r}")
 
 
-AdminUsers = Annotated[frozenset[str], BeforeValidator(_parse_csv_users)]
+# `NoDecode` disables pydantic-settings' default behaviour of running `json.loads`
+# on env-var values for "complex" types (set/frozenset/list/dict/etc.) before any
+# validators run. Without it, `STUDY_CASINO_ADMIN_USERS=agentydragon` would try
+# to JSON-decode `agentydragon` (not a valid JSON literal) and crash at startup
+# with `SettingsError: error parsing value for field "admin_users"` long before
+# `_parse_csv_users` gets a chance to see the string. With NoDecode the raw env
+# string flows straight to the BeforeValidator.
+AdminUsers = Annotated[frozenset[str], NoDecode, BeforeValidator(_parse_csv_users)]
 
 
 class Settings(BaseSettings):

--- a/x/auragon_study_casino/test_config.py
+++ b/x/auragon_study_casino/test_config.py
@@ -1,0 +1,44 @@
+"""Settings tests that go through the env-source path.
+
+The bulk of admin-related tests construct `Settings(admin_users={...})`
+directly, which bypasses pydantic-settings' env parser entirely. These
+tests cover the env-source path so we don't regress on the production
+config style (`STUDY_CASINO_ADMIN_USERS=...`).
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_bazel
+
+from x.auragon_study_casino.config import Settings
+
+_DUMMY_URL = "postgresql+psycopg://u:p@host/db"
+
+
+def test_admin_users_from_env_single(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STUDY_CASINO_DATABASE_URL", _DUMMY_URL)
+    monkeypatch.setenv("STUDY_CASINO_ADMIN_USERS", "agentydragon")
+    assert Settings().admin_users == frozenset({"agentydragon"})
+
+
+def test_admin_users_from_env_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STUDY_CASINO_DATABASE_URL", _DUMMY_URL)
+    monkeypatch.setenv("STUDY_CASINO_ADMIN_USERS", "rai, auragon ,foo")
+    assert Settings().admin_users == frozenset({"rai", "auragon", "foo"})
+
+
+def test_admin_users_env_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STUDY_CASINO_DATABASE_URL", _DUMMY_URL)
+    monkeypatch.setenv("STUDY_CASINO_ADMIN_USERS", "")
+    assert Settings().admin_users == frozenset()
+
+
+def test_admin_users_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STUDY_CASINO_DATABASE_URL", _DUMMY_URL)
+    monkeypatch.delenv("STUDY_CASINO_ADMIN_USERS", raising=False)
+    assert Settings().admin_users == frozenset()
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

`STUDY_CASINO_ADMIN_USERS=agentydragon` crashes the pod on startup:

```
pydantic_settings.exceptions.SettingsError: error parsing value for
field "admin_users" from source "EnvSettingsSource"
...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

pydantic-settings has special handling for "complex" types (`frozenset`,
`set`, `list`, `dict`, …): before any validators run, it tries
`json.loads(value)` on the raw env string. For
`STUDY_CASINO_ADMIN_USERS=agentydragon` that fails (`agentydragon` is
not a JSON literal), the exception propagates as `SettingsError`, and
the deployment can't roll forward. Existing tests passed because they
construct `Settings(admin_users={"default"})` directly — that path
bypasses the env source entirely, so the JSON pre-decode is never
attempted.

**Production effect (right now):** the new RS for image
`devel-20260517055129-4025338` has been in `CrashLoopBackOff` for ~3h,
while the old RS (image `devel-20260516090042-4d4e90a`,
pre-admin-rewards) keeps serving the single replica. That's why
@agentydragon (the user) doesn't see any admin affordance in the UI —
the binary serving them is the pre-#1595 build.

## Fix

Annotate `AdminUsers` with `NoDecode` so pydantic-settings skips the
JSON pre-decode and hands the raw env string straight to
`_parse_csv_users`.

```python
AdminUsers = Annotated[frozenset[str], NoDecode, BeforeValidator(_parse_csv_users)]
```

## Regression coverage

Adds `test_config.py` covering the env-source path (single value, CSV,
empty string, unset). Without `NoDecode` these tests fail; with it they
pass.

## Validation

- `bbr test //x/auragon_study_casino:test_config //x/auragon_study_casino:test_app //x/auragon_study_casino:test_store`
  green — invocation `b587c36f-f9dd-4e4f-80be-863ec6d5bce5`.

## Test plan

- [ ] After merge: `kubectl get pods -n study-casino -l
      app.kubernetes.io/name=study-casino` shows a single Running pod
      from the new ReplicaSet (image bumps via Flux image automation).
- [ ] `kubectl logs deploy/study-casino -n study-casino | head -5`
      shows the startup banner with `admin_users=['agentydragon']`.
- [ ] `curl https://casino.allegedly.works/me` (with agentydragon
      session) returns `{"username": "agentydragon", "is_admin": true}`.
- [ ] An "Admin" tab appears in the casino nav for agentydragon.

https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGrVnGGptDo62wHUFpKAgP)_