### PR TITLE
debundle: serve partial-swap packages via live-proxy importmap

### DIFF
--- a/devinfra/js/debundle/live_proxy/proxy.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy.mjs
@@ -5,7 +5,13 @@ import { Agent as HttpsAgent } from "node:https";
 
 import forge from "node-forge";
 import { Proxy } from "http-mitm-proxy";
-import { loadVendorRuntimeIndex, resolveVendorRuntimeRequest } from "./vendor_runtime.mjs";
+import {
+  buildPartialSwapImportMap,
+  loadPartialSwapRuntimeIndex,
+  loadVendorRuntimeIndex,
+  resolvePartialSwapRuntimeRequest,
+  resolveVendorRuntimeRequest,
+} from "./vendor_runtime.mjs";
 import { requireValue, resolveWorkspacePath } from "./io.mjs";
 
 const MODULE_SCRIPT_RE =
@@ -144,6 +150,20 @@ export function loadLiveProxyConfiguration(rawOptions) {
     ...(options.packageRoots ? { packageRoots: options.packageRoots } : {}),
     ...(options.packagesRoot ? { packagesRoot: options.packagesRoot } : {}),
   });
+  // Partial-swap manifest sits in the same `vendors/` directory as the
+  // regular manifest; the pipeline writes it iff at least one chunk has
+  // `level: partial_swap`. When present it lets us serve the bare-
+  // specifier imports the partial-swap stage emitted (`from "mobx"` etc.)
+  // by mounting each package under `<appAssetPrefix>/_partial_swap/...`
+  // and injecting an `<script type="importmap">` into the served HTML.
+  const partialSwapManifestPath = appManifest.vendor_partial_swap_manifest_path
+    ? resolveManifestReferencedPath(appManifest.vendor_partial_swap_manifest_path, manifestContext)
+    : join(dirname(vendorManifestPath), "vendor_partial_swap_manifest.json");
+  const partialSwapRuntimeIndex = loadPartialSwapRuntimeIndex({
+    manifestPath: partialSwapManifestPath,
+    ...(options.packageRoots ? { packageRoots: options.packageRoots } : {}),
+    ...(options.packagesRoot ? { packagesRoot: options.packagesRoot } : {}),
+  });
   const bootstrapPath = join(appRoot, "bootstrap.js");
   if (!existsSync(bootstrapPath)) {
     throw new Error(`Expected bootstrap.js at ${bootstrapPath}`);
@@ -168,6 +188,8 @@ export function loadLiveProxyConfiguration(rawOptions) {
       appAssetPrefix,
       bootstrapUrl: `${appAssetPrefix}/bootstrap.js`,
       uiVersion,
+      importMap:
+        partialSwapRuntimeIndex.size > 0 ? buildPartialSwapImportMap(partialSwapRuntimeIndex, appAssetPrefix) : null,
     }),
     internalPrefix,
     outRoot: appRoot,
@@ -182,6 +204,8 @@ export function loadLiveProxyConfiguration(rawOptions) {
     uiVersion,
     vendorManifestPath,
     vendorRuntimeIndex,
+    partialSwapManifestPath,
+    partialSwapRuntimeIndex,
   };
 }
 
@@ -214,7 +238,7 @@ function normalizeRelativePath(value) {
     .join("/");
 }
 
-export function rewriteHtmlForLiveProxy(sourceHtml, { appAssetPrefix, bootstrapUrl, uiVersion }) {
+export function rewriteHtmlForLiveProxy(sourceHtml, { appAssetPrefix, bootstrapUrl, uiVersion, importMap }) {
   let html = sourceHtml.replace(MODULE_SCRIPT_RE, "");
   html = html.replace(MODULE_PRELOAD_RE, "");
 
@@ -229,7 +253,13 @@ export function rewriteHtmlForLiveProxy(sourceHtml, { appAssetPrefix, bootstrapU
     html = rewriteSnapshotAssetUrls(html, appAssetPrefix);
   }
 
-  const injected = `${liveProxyPreludeScript({ bootstrapUrl, uiVersion })}
+  // Browsers need an importmap to resolve bare specifiers from
+  // partial-swap'd packages (`import { observer } from "mobx-react-lite"`).
+  // The importmap must precede every module script in document order, so
+  // it goes right before the prelude / bootstrap injection below.
+  const importMapScript = importMap ? `<script type="importmap">${JSON.stringify(importMap)}</script>\n    ` : "";
+
+  const injected = `${importMapScript}${liveProxyPreludeScript({ bootstrapUrl, uiVersion })}
     <script type="module" crossorigin src="${escapeHtmlAttr(bootstrapUrl)}"></script>`;
 
   if (/<\/body>/i.test(html)) {
@@ -306,6 +336,15 @@ export function mapLocalAssetPath(pathname, config) {
       contentType: contentTypeForPath(vendorRuntime.filePath),
       filePath: vendorRuntime.filePath,
       kind: "vendor-file",
+    };
+  }
+  const partialSwap = resolvePartialSwapRuntimeRequest(suffix, config.partialSwapRuntimeIndex);
+  if (partialSwap) {
+    return {
+      contentType: contentTypeForPath(partialSwap.filePath),
+      filePath: partialSwap.filePath,
+      kind: "partial-swap-file",
+      package: partialSwap.package,
     };
   }
   const appRelativePath = stripAppAssetPrefix(suffix);

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
@@ -77,6 +77,131 @@ export function resolveVendorRuntimeRequest(relativePath, vendorRuntimeIndex) {
   return null;
 }
 
+// Path segment under <appAssetPrefix> that the live proxy mounts
+// partial-swap packages under. Each partial-swap'd package gets a
+// directory rooted at `<PARTIAL_SWAP_URL_PREFIX>/<package_name>/`
+// where the package's filesystem root is served verbatim. Bare-specifier
+// imports like `from "mobx-react-lite"` are resolved by an injected
+// `<script type="importmap">` whose entries point at the package's
+// `subpath` under this prefix.
+const PARTIAL_SWAP_URL_PREFIX = "_partial_swap";
+
+export function loadPartialSwapRuntimeIndex({ manifestPath, packageRoots, packagesRoot }) {
+  const byPackage = new Map();
+  if (!manifestPath || !existsSync(manifestPath)) {
+    return byPackage;
+  }
+  const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`Partial-swap manifest must be a JSON object at ${manifestPath}`);
+  }
+  const resolutions = raw.resolutions ?? {};
+  for (const entry of Object.values(resolutions)) {
+    for (const [packageName, packageEntry] of Object.entries(entry.packages ?? {})) {
+      if (!packageEntry.subpath || !packageEntry.version) {
+        throw new Error(`Partial-swap resolution for ${packageName} is missing subpath/version in ${manifestPath}`);
+      }
+      const filePath = resolvePackageSubpath(packageName, packageEntry.subpath, {
+        packageRoots,
+        packagesRoot,
+      });
+      const mountRoot = resolvePackageMountRoot(packageName, {
+        packageRoots,
+        packagesRoot,
+        filePath,
+      });
+      byPackage.set(packageName, {
+        package: packageName,
+        version: packageEntry.version,
+        subpath: packageEntry.subpath,
+        filePath,
+        mountRoot,
+        mountedSubpath: normalizeMountedRelativePath(relative(mountRoot, filePath)),
+        urlPrefix: `${PARTIAL_SWAP_URL_PREFIX}/${packageName}`,
+      });
+    }
+  }
+  return byPackage;
+}
+
+// Build the importmap object (suitable for JSON-stringifying into a
+// `<script type="importmap">`) for a partial-swap runtime index. Each
+// package's bare specifier (`"mobx-react-lite"`) maps to the URL where
+// the live proxy serves the package's `subpath` file.
+export function buildPartialSwapImportMap(partialSwapIndex, appAssetPrefix) {
+  const imports = {};
+  for (const entry of partialSwapIndex.values()) {
+    imports[entry.package] = `${appAssetPrefix}/${entry.urlPrefix}/${entry.mountedSubpath}`;
+  }
+  return { imports };
+}
+
+// Resolve a request under the partial-swap URL prefix to an absolute
+// filesystem path. Returns `null` when the path doesn't reference a
+// partial-swap package; otherwise returns the file path, the package
+// name, and the in-package relative path so the caller can serve the
+// file with an accurate `Content-Type` and stay within the mount root.
+export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex) {
+  if (!partialSwapIndex || partialSwapIndex.size === 0) {
+    return null;
+  }
+  const normalizedPath = normalizeRelativePath(relativePath);
+  const candidatePaths = normalizedPath.startsWith("app/")
+    ? [normalizedPath, normalizedPath.slice("app/".length)]
+    : [normalizedPath];
+  for (const candidatePath of candidatePaths) {
+    const partialPrefix = `${PARTIAL_SWAP_URL_PREFIX}/`;
+    if (!candidatePath.startsWith(partialPrefix)) {
+      continue;
+    }
+    const rest = candidatePath.slice(partialPrefix.length);
+    for (const entry of partialSwapIndex.values()) {
+      const packagePrefix = `${entry.package}/`;
+      if (!rest.startsWith(packagePrefix)) {
+        continue;
+      }
+      const suffix = rest.slice(packagePrefix.length);
+      const resolvedPath = resolve(entry.mountRoot, suffix);
+      assertPathWithinRoot(
+        resolvedPath,
+        entry.mountRoot,
+        `Partial-swap request escapes mounted root for ${entry.package}: ${suffix}`
+      );
+      if (existsSync(resolvedPath)) {
+        assertRealPathWithinRoot(
+          resolvedPath,
+          entry.mountRoot,
+          `Partial-swap request realpath escapes mounted root for ${entry.package}: ${suffix}`
+        );
+      }
+      return {
+        package: entry.package,
+        version: entry.version,
+        filePath: resolvedPath,
+        requestPath: candidatePath,
+        requestSuffix: suffix,
+      };
+    }
+  }
+  return null;
+}
+
+function resolvePackageMountRoot(packageName, { packageRoots, packagesRoot, filePath }) {
+  // Walk up the package's `subpath` levels from `filePath` to find the
+  // package directory root. Using `package_tree.resolvePackageSubpath`
+  // already verified the file is within the package; this just gives
+  // us the root for relative-import sandboxing.
+  if (packageRoots && packageRoots[packageName]) {
+    return packageRoots[packageName];
+  }
+  if (packagesRoot) {
+    return resolve(packagesRoot, packageName);
+  }
+  // Fall back to deriving from filePath (less precise, but covers
+  // tests that synthesize package_roots themselves).
+  return dirname(filePath);
+}
+
 function chunkIdForChunkPath(chunkPath) {
   if (!chunkPath.endsWith(".js")) {
     throw new Error(`Expected .js chunk path, got ${chunkPath}`);

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
@@ -161,7 +161,7 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
         continue;
       }
       const suffix = rest.slice(packagePrefix.length);
-      const resolvedPath = resolve(entry.mountRoot, suffix);
+      const resolvedPath = resolvePartialSwapAssetPath(entry.mountRoot, suffix);
       assertPathWithinRoot(
         resolvedPath,
         entry.mountRoot,
@@ -184,6 +184,34 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
     }
   }
   return null;
+}
+
+// Node-style auto-extension resolution for partial-swap package files.
+// npm packages frequently emit ESM with extension-less internal imports
+// (`import "./utils"` rather than `./utils.js`); the browser doesn't
+// rewrite those, so the proxy tries `.js` / `.mjs` / `.cjs` / `/index.*`
+// in order, mirroring Node's CommonJS-influenced resolver. Returns the
+// first existing path; otherwise returns the exact path requested (the
+// caller will then surface a clean 404).
+function resolvePartialSwapAssetPath(mountRoot, suffix) {
+  const exact = resolve(mountRoot, suffix);
+  if (existsSync(exact)) {
+    return exact;
+  }
+  const extensions = [".js", ".mjs", ".cjs"];
+  for (const ext of extensions) {
+    const candidate = `${exact}${ext}`;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  for (const indexFile of extensions.map((ext) => `index${ext}`)) {
+    const candidate = resolve(exact, indexFile);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return exact;
 }
 
 function resolvePackageMountRoot(packageName, { packageRoots, packagesRoot, filePath }) {


### PR DESCRIPTION
## Summary

The `partial_swap` vendor stage already rewrites caller imports to
bare specifiers (`import { observer } from "mobx-react-lite"`) and
writes `vendor_partial_swap_manifest.json` alongside the regular
vendor manifest. But until now nothing on the runtime side consumed
that manifest — the live proxy didn't read it, no importmap was
injected, and loading a page with a partial-swap'd vendor would
silently fail before the app boots (browsers reject unresolved bare
specifiers at module-parse time).

This wires up the missing live-proxy half:

- **`live_proxy/vendor_runtime.mjs`** learns
  `loadPartialSwapRuntimeIndex`, `buildPartialSwapImportMap`, and
  `resolvePartialSwapRuntimeRequest`. The index reads the partial-
  swap manifest, resolves each package's filesystem mount root via
  the existing `package_roots`/`packages_root` machinery, and
  exposes a URL prefix
  `<appAssetPrefix>/_partial_swap/<package>/<subpath>` where the
  package directory is served verbatim (so relative imports inside
  the package resolve against the same mount).
- **`live_proxy/proxy.mjs`** loads the index (defaulting to
  `<vendor_manifest_dir>/vendor_partial_swap_manifest.json`),
  injects a `<script type="importmap">` block with one entry per
  partial-swap'd package into the served HTML, and routes
  `_partial_swap/...` asset requests through the new resolver.
  `rewriteHtmlForLiveProxy` gains an `importMap` parameter; callers
  pass `null` when no partial-swap is in scope, preserving existing
  HTML output.
- **Auto-extension resolution** for partial-swap requests: when the
  exact path doesn't exist on disk, fall back to `.js` / `.mjs` /
  `.cjs` suffixes, then `index.{js,mjs,cjs}`. npm packages
  routinely use extension-less ESM imports (`import "./utils"`),
  and the browser sends the literal URL — without the fallback the
  importmap-driven fetches 404. Every candidate is built with
  `resolve` from the mount root, so the existing
  `assertPathWithinRoot`/`assertRealPathWithinRoot` checks still
  apply.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/live_proxy:proxy_test --config=rbe` — existing proxy tests stay green
- [x] Consumer-side smoke from gaffer-private (mobx `dist/mobx.esm.production.min.js` served via importmap, fetched and parsed by the browser, mobx.esm.js loads with no `process` reference error). The mobx partial-swap experiment surfaced a separate two-mobx-instances issue at the gaffer-spec layer and that experiment was reverted there, but the runtime serving path proven out here is the prerequisite for any future partial-swap to actually boot in a browser.

https://claude.ai/code/session_013xQyPHDvjcUifWzHvz37mv


---
_Generated by [Claude Code](https://claude.ai/code/session_013xQyPHDvjcUifWzHvz37mv)_