### PR TITLE
debundle: partial-swap auto-extension fixes (directories + 301-redirect)

### DIFF
--- a/devinfra/js/debundle/live_proxy/proxy.mjs
+++ b/devinfra/js/debundle/live_proxy/proxy.mjs
@@ -340,6 +340,19 @@ export function mapLocalAssetPath(pathname, config) {
   }
   const partialSwap = resolvePartialSwapRuntimeRequest(suffix, config.partialSwapRuntimeIndex);
   if (partialSwap) {
+    // If the auto-extension fallback rewrote the suffix (e.g.
+    // `./platform` → `./platform/index.js`), 301 the browser to the
+    // resolved URL so its module base URL tracks the actually-served
+    // file. Without this, a relative `import "./node"` inside that
+    // file would resolve against the originally-requested URL and
+    // fetch the wrong sibling.
+    if (partialSwap.resolvedSuffix && partialSwap.resolvedSuffix !== partialSwap.requestSuffix) {
+      return {
+        kind: "partial-swap-redirect",
+        redirectTo:
+          `${config.internalPrefix}/app/_partial_swap/` + `${partialSwap.package}/${partialSwap.resolvedSuffix}`,
+      };
+    }
     return {
       contentType: contentTypeForPath(partialSwap.filePath),
       filePath: partialSwap.filePath,
@@ -465,6 +478,11 @@ function createHttpsAssetServer(config, tlsMaterial) {
         }
 
         response.setHeader("cache-control", "no-store");
+        if (resolved.kind === "partial-swap-redirect") {
+          response.writeHead(301, { location: resolved.redirectTo });
+          response.end();
+          return;
+        }
         response.setHeader("content-type", resolved.contentType);
         if (resolved.kind === "live-index" || resolved.kind === "service-worker") {
           response.writeHead(200);

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
@@ -161,15 +161,15 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
         continue;
       }
       const suffix = rest.slice(packagePrefix.length);
-      const resolvedPath = resolvePartialSwapAssetPath(entry.mountRoot, suffix);
+      const { filePath, resolvedSuffix } = resolvePartialSwapAssetPath(entry.mountRoot, suffix);
       assertPathWithinRoot(
-        resolvedPath,
+        filePath,
         entry.mountRoot,
         `Partial-swap request escapes mounted root for ${entry.package}: ${suffix}`
       );
-      if (existsSync(resolvedPath)) {
+      if (existsSync(filePath)) {
         assertRealPathWithinRoot(
-          resolvedPath,
+          filePath,
           entry.mountRoot,
           `Partial-swap request realpath escapes mounted root for ${entry.package}: ${suffix}`
         );
@@ -177,9 +177,10 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
       return {
         package: entry.package,
         version: entry.version,
-        filePath: resolvedPath,
+        filePath,
         requestPath: candidatePath,
         requestSuffix: suffix,
+        resolvedSuffix,
       };
     }
   }
@@ -191,29 +192,38 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
 // (`import "./utils"` rather than `./utils.js`); the browser doesn't
 // rewrite those, so the proxy tries `.js` / `.mjs` / `.cjs` / `/index.*`
 // in order, mirroring Node's CommonJS-influenced resolver. Returns the
-// first existing file path; otherwise returns the exact path requested
-// (the caller will then surface a clean 404). A directory at the exact
-// path is treated as not-yet-resolved — Node would fall through to its
-// `index.*` lookup, and so do we.
+// first existing file path along with the in-package suffix that maps
+// to it; otherwise returns the exact (file-less) suffix the caller
+// requested so the proxy can surface a clean 404. A directory at the
+// exact path is treated as not-yet-resolved — Node would fall through
+// to its `index.*` lookup, and so do we.
+//
+// The returned `resolvedSuffix` may differ from the requested `suffix`
+// (e.g. when `./platform` resolves to `platform/index.js`). The caller
+// is expected to issue a 301 to the resolved URL so the browser's
+// module base URL tracks the actual served file — otherwise relative
+// imports inside that file (`./node` becoming `platform/node` vs
+// `node`) would resolve from the wrong directory.
 function resolvePartialSwapAssetPath(mountRoot, suffix) {
   const exact = resolve(mountRoot, suffix);
   if (isExistingFile(exact)) {
-    return exact;
+    return { filePath: exact, resolvedSuffix: suffix };
   }
   const extensions = [".js", ".mjs", ".cjs"];
   for (const ext of extensions) {
     const candidate = `${exact}${ext}`;
     if (isExistingFile(candidate)) {
-      return candidate;
+      return { filePath: candidate, resolvedSuffix: `${suffix}${ext}` };
     }
   }
-  for (const indexFile of extensions.map((ext) => `index${ext}`)) {
-    const candidate = resolve(exact, indexFile);
+  for (const ext of extensions) {
+    const candidate = resolve(exact, `index${ext}`);
     if (isExistingFile(candidate)) {
-      return candidate;
+      const trimmed = suffix.replace(/\/+$/, "");
+      return { filePath: candidate, resolvedSuffix: `${trimmed}/index${ext}` };
     }
   }
-  return exact;
+  return { filePath: exact, resolvedSuffix: suffix };
 }
 
 function isExistingFile(path) {

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { posix } from "node:path";
 import { assertRealPathWithinRoot, resolvePackageSubpath } from "./package_tree.mjs";
@@ -191,27 +191,40 @@ export function resolvePartialSwapRuntimeRequest(relativePath, partialSwapIndex)
 // (`import "./utils"` rather than `./utils.js`); the browser doesn't
 // rewrite those, so the proxy tries `.js` / `.mjs` / `.cjs` / `/index.*`
 // in order, mirroring Node's CommonJS-influenced resolver. Returns the
-// first existing path; otherwise returns the exact path requested (the
-// caller will then surface a clean 404).
+// first existing file path; otherwise returns the exact path requested
+// (the caller will then surface a clean 404). A directory at the exact
+// path is treated as not-yet-resolved — Node would fall through to its
+// `index.*` lookup, and so do we.
 function resolvePartialSwapAssetPath(mountRoot, suffix) {
   const exact = resolve(mountRoot, suffix);
-  if (existsSync(exact)) {
+  if (isExistingFile(exact)) {
     return exact;
   }
   const extensions = [".js", ".mjs", ".cjs"];
   for (const ext of extensions) {
     const candidate = `${exact}${ext}`;
-    if (existsSync(candidate)) {
+    if (isExistingFile(candidate)) {
       return candidate;
     }
   }
   for (const indexFile of extensions.map((ext) => `index${ext}`)) {
     const candidate = resolve(exact, indexFile);
-    if (existsSync(candidate)) {
+    if (isExistingFile(candidate)) {
       return candidate;
     }
   }
   return exact;
+}
+
+function isExistingFile(path) {
+  if (!existsSync(path)) {
+    return false;
+  }
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function resolvePackageMountRoot(packageName, { packageRoots, packagesRoot, filePath }) {


### PR DESCRIPTION
## Summary

Two related fixes to `resolvePartialSwapRuntimeRequest` discovered while partial-swapping `@opentelemetry/api` 1.9.0 in gaffer-private. Each was independently sufficient to keep that swap from booting; together they make Node-style ESM packages with extension-less internal imports and `index.*` re-exports work transparently behind the live-proxy importmap.

### 1. Treat directories as not-yet-resolved (`isExistingFile`)

The auto-extension fallback used `existsSync` to decide whether to return the exact path before trying `.js`/`.mjs`/`.cjs` and `index.*` candidates. `existsSync` returns true for directories as well as files, so when a partial-swap'd package's internal ESM did `import "./platform"` and `./platform` resolved to a directory, the fallback short-circuited on the directory hit and the proxy 404'd when the caller tried to read it as a file.

Wrap the existence check in `isExistingFile`, which combines `existsSync` with `statSync(...).isFile()`. Directories are now treated as not-yet-resolved, the fallback continues, and `/index.{js,mjs,cjs}` is tried — matching Node's CommonJS-style index resolver and what `import "./utils"` package internals actually expect.

### 2. 301-redirect when auto-extension rewrites the URL

When the fallback resolves a request like `./platform` to `./platform/index.js`, the browser previously kept the original URL (`./platform`) as the module base URL. Relative imports inside the served file (`import "./node"`) then resolved against the original URL's directory rather than the served file's directory, fetching the wrong sibling (`/platform/node` instead of `/node`).

`resolvePartialSwapAssetPath` now returns both the resolved `filePath` and the in-package `resolvedSuffix`. When the resolved suffix differs from the requested suffix, `mapLocalAssetPath` emits a `partial-swap-redirect` resolution and the HTTPS server replies with `301` + `Location`, so the browser's base URL tracks the actually-served file.

## Test plan

- [x] Existing proxy tests stay green
- [x] Gaffer-side load test (`//tana/re/web/live_proxy:load_78d928dca7`) with `@opentelemetry/api` 1.9.0 + `nanoid` 5.0.9 + `zod` 4.1.12 partial-swap entries → PASSED

https://claude.ai/code/session_013xQyPHDvjcUifWzHvz37mv

---
_Generated by [Claude Code](https://claude.ai/code/session_013xQyPHDvjcUifWzHvz37mv)_