### PR TITLE
debundle: catch duplicate-export emit at pipeline time

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -146,6 +146,26 @@ rust_test(
 )
 
 rust_library(
+    name = "validate_emitted_exports",
+    srcs = ["validate_emitted_exports.rs"],
+    crate_root = "validate_emitted_exports.rs",
+    edition = "2024",
+    deps = [
+        ":artifact",
+        ":js_ast",
+        "@crates//:anyhow",
+        "@crates//:swc_common",
+        "@crates//:swc_ecma_ast",
+    ],
+)
+
+rust_test(
+    name = "validate_emitted_exports_test",
+    crate = ":validate_emitted_exports",
+    edition = "2024",
+)
+
+rust_library(
     name = "emit_harness",
     srcs = ["emit_harness.rs"],
     crate_root = "emit_harness.rs",
@@ -453,6 +473,7 @@ rust_library(
         ":spec",
         ":spec_tree",
         ":strip_swapped_vendor_exports",
+        ":validate_emitted_exports",
         ":vendor",
         ":write_tree",
         "@crates//:anyhow",

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -75,6 +75,7 @@ rust_library(
         "import_coalescing_test",
         "peel_emit_resolvability_test",
         "object_literal_import_collapse_test",
+        "duplicate_export_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/duplicate_export_test.rs
+++ b/devinfra/js/debundle/e2e/duplicate_export_test.rs
@@ -1,0 +1,34 @@
+//! Pipeline rejects emitted JS that would link-fail on duplicate
+//! exports.
+//!
+//! `validate_emitted_exports` runs after materialize / strip and bails
+//! before any file hits disk. Without it, a chunk that ships two
+//! exports under the same public name would silently make it through
+//! the pipeline, get written, and then fail at module-link time in
+//! the browser — Chromium reports it as a synthetic empty `pageerror`
+//! with no further child-chunk loads, which is essentially silent.
+//!
+//! Pin the contract: the pipeline must bail with a message that
+//! names the file and the offending public name.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn rejects_duplicate_export_from_source() {
+    // Two exports of the same public name `av`: one from an inline
+    // `export const`, the other from a `export { … as av }` of a
+    // separate local. swc parses this fine; the runtime spec rejects
+    // it at module-link time.
+    let opts = FixtureOpts::new(
+        r#"export const av = 1;
+const helper = 2;
+export { helper as av };
+console.log(av, helper);
+"#,
+        vec![],
+    );
+    expect_rejection_containing_all(
+        opts,
+        &["validate_emitted_exports", "duplicate", "`av`", "entry.js"],
+    );
+}

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -18,6 +18,7 @@ use rewrite_specifiers::rewrite_chunk_entry_specifiers;
 use spec::{MaterializeLogicalModulesConfig, SwapVendorChunksConfig, TransformSpec, VendorLevel};
 use spec_tree::{CompileSpecTreeOptions, compile_spec_tree};
 use strip_swapped_vendor_exports::strip_swapped_vendor_exports;
+use validate_emitted_exports::validate_emitted_exports;
 use vendor::{
     ApplyPartialVendorSwapsOptions, SwapVendorOptions, apply_partial_vendor_swaps,
     apply_vendor_annotations, rename_vendor_exports, swap_vendor_chunks,
@@ -188,6 +189,7 @@ pub enum PipelineStage {
     MaterializeLogicalModules,
     ApplyPartialVendorSwaps,
     StripSwappedVendorExports,
+    ValidateEmittedExports,
     WriteJsTree,
     EmitBrowserHarness,
 }
@@ -426,6 +428,17 @@ pub fn run_transform_cli(cli: &TransformCli) -> Result<TransformRunSummary> {
             })?;
         artifact = strip_result.artifact;
     }
+
+    // Final emit-shape check: every JS file that came out of the
+    // materialize / strip pipeline must have unique public export
+    // names per file. Catching a duplicate here turns a downstream
+    // browser-link failure (which Chromium reports as a silent empty
+    // pageerror) into an immediate build-time error pointing at the
+    // exact file, name, and source lines. Runs unconditionally so
+    // pipelines without vendor swaps still benefit.
+    run_step(&mut steps, PipelineStage::ValidateEmittedExports, || {
+        validate_emitted_exports(&artifact)
+    })?;
 
     if let Some(cfg) = &spec.write_js_tree {
         let out_dir = cfg.out_dir.clone();
@@ -721,13 +734,14 @@ mod tests {
             force: false,
         })?;
 
-        assert_eq!(summary.steps.len(), 2);
+        assert_eq!(summary.steps.len(), 3);
         assert_eq!(summary.preparation_steps.len(), 5);
         let rendered_summary = render_transform_summary(&summary);
         assert!(rendered_summary.contains("- load_transform_spec"));
         assert!(rendered_summary.contains("- prepare_js_chunks"));
         assert!(rendered_summary.contains("- build_artifact_indexes"));
         assert!(rendered_summary.contains("- rewrite_chunk_entry_specifiers"));
+        assert!(rendered_summary.contains("- validate_emitted_exports"));
         assert!(rendered_summary.contains("- emit_browser_harness"));
         assert!(out.join("bootstrap.js").exists());
         assert!(out.join("manifest.json").exists());

--- a/devinfra/js/debundle/validate_emitted_exports.rs
+++ b/devinfra/js/debundle/validate_emitted_exports.rs
@@ -1,0 +1,440 @@
+//! Catch `SyntaxError: Duplicate export of '<name>'` at pipeline time.
+//!
+//! ES modules reject any file that declares the same public export name
+//! twice. Browsers and Node both bail at module-link time (before any
+//! body evaluates) — but the failure surfaces differently depending on
+//! the runtime:
+//!
+//! - Node: `SyntaxError: Duplicate export of '<name>'`, line/column.
+//! - Chromium: a synthetic `pageerror` event whose `Error` carries an
+//!   empty stack and message. No console output, no failed network
+//!   requests, and the module's static `import` graph never starts
+//!   fetching. The page silently hangs blank.
+//!
+//! The second failure mode is what motivated this stage. A pipeline
+//! regen that flips two unrelated emit paths into both contributing
+//! the same public name (e.g. `BackgroundPattern as av` from chunk
+//! renames + `av` from the auto-grown residual export block) produces
+//! a chunk that link-fails inside the browser smoke without leaving a
+//! useful trace. Failing here turns that into a build-time error that
+//! names the file, the colliding public name, and the line of each
+//! offending `export …` statement.
+//!
+//! The check is purely a static read over the in-memory artifact —
+//! every JS file with an AST body is walked once and each export
+//! statement's public name(s) are recorded. Files stored as raw
+//! `JsFileBody::Source` (no AST) are skipped: those didn't go through
+//! materialization or strip, so this pass has no leverage on them and
+//! the upstream chunk shape itself is the upstream's contract.
+//!
+//! This stage doesn't *fix* the underlying generation bug — the
+//! emit-side paths that produced the duplicate still need patching
+//! (the immediate one is `auto_grown_residual_exports` in
+//! `logical_modules.rs`, which compares local binding names to
+//! `pre_existing_entry_exports` but never checks whether the public
+//! name it's about to grow would collide with an existing alias's
+//! public name). It just makes the failure mode unmissable.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Result, bail};
+use swc_common::Spanned;
+use swc_ecma_ast::*;
+
+use artifact::ChunkBundle;
+use js_ast::SourceLineIndex;
+
+pub fn validate_emitted_exports(artifact: &ChunkBundle) -> Result<()> {
+    let mut findings: Vec<FileFinding> = Vec::new();
+    for chunk in &artifact.chunks {
+        let chunk_name = artifact.chunk_table.name(chunk.chunk_id).to_string();
+        for file in &chunk.js.files {
+            let Some(ast) = file.ast() else {
+                continue;
+            };
+            let lines = ast.line_index();
+            let duplicates = duplicates_in_module(&ast.module, &lines);
+            if !duplicates.is_empty() {
+                findings.push(FileFinding {
+                    chunk: chunk_name.clone(),
+                    file: file.path.clone(),
+                    duplicates,
+                });
+            }
+        }
+    }
+    if findings.is_empty() {
+        return Ok(());
+    }
+
+    let mut msg = String::from(
+        "validate_emitted_exports: emitted JS contains duplicate `export` names — \
+         ES module link error. Browsers and Node refuse modules with two \
+         exports sharing one public name (`SyntaxError: Duplicate export of '<name>'`). \
+         In Chromium this surfaces as a silent empty `pageerror` with no further \
+         child-chunk loads — the page renders blank with no useful console output, \
+         which is hard to debug downstream.\n",
+    );
+    for finding in &findings {
+        msg.push_str(&format!(
+            "\n  chunk {} file {}:\n",
+            finding.chunk, finding.file,
+        ));
+        for dup in &finding.duplicates {
+            msg.push_str(&format!(
+                "    `{}` exported {}× at {}\n",
+                dup.name,
+                dup.sites.len(),
+                render_sites(&dup.sites),
+            ));
+        }
+    }
+    bail!(msg);
+}
+
+#[derive(Debug, Clone)]
+struct FileFinding {
+    chunk: String,
+    file: String,
+    duplicates: Vec<DuplicateExport>,
+}
+
+#[derive(Debug, Clone)]
+struct DuplicateExport {
+    name: String,
+    sites: Vec<ExportSite>,
+}
+
+#[derive(Debug, Clone)]
+struct ExportSite {
+    line: Option<usize>,
+    /// Short tag describing which AST shape contributed the export
+    /// (`decl`, `named`, `default`, `namespace`). Helps the reader
+    /// distinguish e.g. an `export function av()` from a bare
+    /// `export { av }`.
+    shape: &'static str,
+}
+
+fn render_sites(sites: &[ExportSite]) -> String {
+    sites
+        .iter()
+        .map(|s| match s.line {
+            Some(line) => format!("L{line} ({})", s.shape),
+            None => format!("L? ({})", s.shape),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn duplicates_in_module(module: &Module, lines: &SourceLineIndex) -> Vec<DuplicateExport> {
+    let mut sites: BTreeMap<String, Vec<ExportSite>> = BTreeMap::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+            continue;
+        };
+        record_decl(decl, lines, &mut sites);
+    }
+    sites
+        .into_iter()
+        .filter(|(_, s)| s.len() > 1)
+        .map(|(name, sites)| DuplicateExport { name, sites })
+        .collect()
+}
+
+fn record_decl(
+    decl: &ModuleDecl,
+    lines: &SourceLineIndex,
+    sites: &mut BTreeMap<String, Vec<ExportSite>>,
+) {
+    match decl {
+        ModuleDecl::ExportDefaultDecl(d) => {
+            sites
+                .entry("default".to_string())
+                .or_default()
+                .push(ExportSite {
+                    line: lines.line_for_span(d.span()),
+                    shape: "default",
+                });
+        }
+        ModuleDecl::ExportDefaultExpr(d) => {
+            sites
+                .entry("default".to_string())
+                .or_default()
+                .push(ExportSite {
+                    line: lines.line_for_span(d.span()),
+                    shape: "default",
+                });
+        }
+        ModuleDecl::ExportDecl(d) => {
+            let line = lines.line_for_span(d.span());
+            for name in exported_decl_names(&d.decl) {
+                sites.entry(name).or_default().push(ExportSite {
+                    line,
+                    shape: "decl",
+                });
+            }
+        }
+        ModuleDecl::ExportNamed(named) => {
+            let line = lines.line_for_span(named.span());
+            for spec in &named.specifiers {
+                match spec {
+                    ExportSpecifier::Named(n) => {
+                        let public = n
+                            .exported
+                            .as_ref()
+                            .map(module_export_atom)
+                            .unwrap_or_else(|| module_export_atom(&n.orig));
+                        sites.entry(public).or_default().push(ExportSite {
+                            line,
+                            shape: "named",
+                        });
+                    }
+                    ExportSpecifier::Namespace(ns) => {
+                        sites
+                            .entry(module_export_atom(&ns.name))
+                            .or_default()
+                            .push(ExportSite {
+                                line,
+                                shape: "namespace",
+                            });
+                    }
+                    ExportSpecifier::Default(d) => {
+                        sites
+                            .entry(d.exported.sym.to_string())
+                            .or_default()
+                            .push(ExportSite {
+                                line,
+                                shape: "default",
+                            });
+                    }
+                }
+            }
+        }
+        // `export * from "..."` re-exports a star — the concrete names
+        // come from the source module at link time. Spec rejection is
+        // about literal-name collisions, so star re-exports can't
+        // create a duplicate on their own and we skip them here.
+        // Imports and TS-only declarations don't contribute exports.
+        _ => {}
+    }
+}
+
+fn exported_decl_names(decl: &Decl) -> Vec<String> {
+    let mut out = Vec::new();
+    match decl {
+        Decl::Fn(f) => out.push(f.ident.sym.to_string()),
+        Decl::Class(c) => out.push(c.ident.sym.to_string()),
+        Decl::Var(v) => {
+            for d in &v.decls {
+                collect_pat_names(&d.name, &mut out);
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+fn collect_pat_names(pat: &Pat, out: &mut Vec<String>) {
+    match pat {
+        Pat::Ident(b) => out.push(b.id.sym.to_string()),
+        Pat::Array(arr) => {
+            for elem in arr.elems.iter().flatten() {
+                collect_pat_names(elem, out);
+            }
+        }
+        Pat::Object(obj) => {
+            for prop in &obj.props {
+                match prop {
+                    ObjectPatProp::KeyValue(kv) => collect_pat_names(&kv.value, out),
+                    ObjectPatProp::Assign(a) => out.push(a.key.sym.to_string()),
+                    ObjectPatProp::Rest(r) => collect_pat_names(&r.arg, out),
+                }
+            }
+        }
+        Pat::Rest(r) => collect_pat_names(&r.arg, out),
+        Pat::Assign(a) => collect_pat_names(&a.left, out),
+        _ => {}
+    }
+}
+
+fn module_export_atom(name: &ModuleExportName) -> String {
+    name.atom().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use artifact::{
+        ChunkAnalysis, ChunkArtifact, ChunkBundle, ChunkMetadata, ChunkTable, FileMetadata,
+        FileRole, JsChunk, JsFile, JsFileBody,
+    };
+    use js_ast::parse_js_module;
+
+    use super::*;
+
+    fn bundle_with_file(chunk_name: &str, file_name: &str, source: &str) -> ChunkBundle {
+        let mut bundle = ChunkBundle {
+            chunks: Vec::new(),
+            chunk_table: ChunkTable::default(),
+        };
+        insert_file(&mut bundle, chunk_name, file_name, source, FileRole::Entry);
+        bundle
+    }
+
+    fn insert_file(
+        bundle: &mut ChunkBundle,
+        chunk_name: &str,
+        file_name: &str,
+        source: &str,
+        role: FileRole,
+    ) {
+        let parsed = parse_js_module(&format!("{chunk_name}/{file_name}"), source).expect("parse");
+        let chunk_id = bundle.chunk_table.intern(chunk_name.to_string());
+        let file = JsFile {
+            path: file_name.to_string(),
+            body: JsFileBody::Ast(parsed),
+            header_lines: Vec::new(),
+            metadata: FileMetadata {
+                chunk_id: chunk_name.to_string(),
+                chunk_file: file_name.to_string(),
+                role,
+                source_path: format!("{chunk_name}.js"),
+                generated_by_selected_module_lowering: false,
+            },
+        };
+        if let Some(existing) = bundle.chunks.iter_mut().find(|c| c.chunk_id == chunk_id) {
+            existing.js.files.push(file);
+            return;
+        }
+        bundle.chunks.push(ChunkArtifact {
+            chunk_id,
+            js: JsChunk {
+                entry_file: file_name.to_string(),
+                files: vec![file],
+                metadata: ChunkMetadata {
+                    source_path: Some(format!("{chunk_name}.js")),
+                },
+            },
+            analysis: ChunkAnalysis {
+                chunk_id: chunk_name.to_string(),
+                source_path: format!("{chunk_name}.js"),
+                parser: Default::default(),
+                entry_file: file_name.to_string(),
+                counts: Default::default(),
+                files: Vec::new(),
+                imports: Vec::new(),
+                export_aliases: Vec::new(),
+                unresolved_exports: Vec::new(),
+                kept_top_level_declarations: Vec::new(),
+            },
+        });
+    }
+
+    #[test]
+    fn passes_on_clean_module() {
+        let bundle = bundle_with_file(
+            "ok",
+            "entry.js",
+            "const a = 1;\nconst b = 2;\nexport { a, b };\n",
+        );
+        validate_emitted_exports(&bundle).expect("clean module passes");
+    }
+
+    #[test]
+    fn flags_named_alias_colliding_with_local_export() {
+        // The Chromium-silent failure mode the tana smoke hit:
+        // one `export {...}` block ships `BackgroundPattern as av`,
+        // a separate block ships the local `av` directly.
+        let source = "\
+const BackgroundPattern = () => null;\n\
+function av() {}\n\
+export { BackgroundPattern as av };\n\
+export { av };\n";
+        let bundle = bundle_with_file("chunk", "entry.js", source);
+        let err = validate_emitted_exports(&bundle).expect_err("duplicate av should be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("`av` exported 2×"), "missing count: {msg}");
+        assert!(msg.contains("entry.js"), "missing file: {msg}");
+        assert!(msg.contains("chunk chunk"), "missing chunk: {msg}");
+    }
+
+    #[test]
+    fn flags_export_decl_vs_named_block_duplicate() {
+        let source = "\
+export const x = 1;\n\
+const y = 2;\n\
+export { y as x };\n";
+        let bundle = bundle_with_file("c", "f.js", source);
+        let err = validate_emitted_exports(&bundle).expect_err("duplicate x");
+        let msg = format!("{err}");
+        assert!(msg.contains("`x` exported 2×"), "{msg}");
+        assert!(msg.contains("(decl)"), "decl shape missing: {msg}");
+        assert!(msg.contains("(named)"), "named shape missing: {msg}");
+    }
+
+    #[test]
+    fn flags_two_default_exports() {
+        let source = "\
+export default 1;\n\
+const fallback = 2;\n\
+export { fallback as default };\n";
+        let bundle = bundle_with_file("c", "f.js", source);
+        let err = validate_emitted_exports(&bundle).expect_err("duplicate default");
+        let msg = format!("{err}");
+        assert!(msg.contains("`default` exported 2×"), "{msg}");
+    }
+
+    #[test]
+    fn star_reexport_does_not_count() {
+        // `export *` re-exports whatever the source module exports;
+        // the local `export { foo }` is the only literal-name export
+        // in this file and link-time conflicts from `*` collisions
+        // are diagnosed by the source module's check.
+        let source = "\
+const foo = 1;\n\
+export { foo };\n\
+export * from \"./sibling.js\";\n";
+        let bundle = bundle_with_file("c", "f.js", source);
+        validate_emitted_exports(&bundle).expect("star re-export does not duplicate");
+    }
+
+    #[test]
+    fn checks_every_file_in_chunk() {
+        // Two files in the same chunk; only one has duplicates.
+        let mut bundle = bundle_with_file("c", "good.js", "export const a = 1;\n");
+        insert_file(
+            &mut bundle,
+            "c",
+            "bad.js",
+            "export const z = 1;\nconst zz = 2;\nexport { zz as z };\n",
+            FileRole::Module,
+        );
+        let err = validate_emitted_exports(&bundle).expect_err("bad file flagged");
+        let msg = format!("{err}");
+        assert!(msg.contains("bad.js"), "{msg}");
+        assert!(!msg.contains("good.js"), "good.js should not appear: {msg}");
+    }
+
+    #[test]
+    fn source_only_files_are_skipped() {
+        // Files stored as raw source (no AST) are skipped — the pass
+        // walks the in-memory AST and has nothing to inspect for raw
+        // bodies. This is intentional: such files came from upstream
+        // verbatim, not from a pipeline emit path.
+        let mut bundle = bundle_with_file("c", "ok.js", "export const a = 1;\n");
+        bundle.chunks[0].js.files.push(JsFile {
+            path: "raw.js".to_string(),
+            body: JsFileBody::Source(
+                "export const x = 1;\nconst y = 2;\nexport { y as x };\n".to_string(),
+            ),
+            header_lines: Vec::new(),
+            metadata: FileMetadata {
+                chunk_id: "c".to_string(),
+                chunk_file: "raw.js".to_string(),
+                role: FileRole::Module,
+                source_path: "c.js".to_string(),
+                generated_by_selected_module_lowering: false,
+            },
+        });
+        validate_emitted_exports(&bundle).expect("source-only file skipped");
+    }
+}


### PR DESCRIPTION
## Summary

Add a `ValidateEmittedExports` pipeline stage that bails before
`write_js_tree` when any emitted JS file would ship two exports under
the same public name.

## Motivation

Hit this in the gaffer tana RE smoke today: the pipeline emitted
`tana/re/web/out/.../index-DI2GynTv/entry.js` with two exports of the
public name `av` — one from a `BackgroundPattern as av` alias in the
chunk renames, the other a bare `av` for a local function added by
the auto-grown residual export block. The two are produced by
unrelated emit paths and the collision wasn't detected anywhere along
the pipeline.

Chromium's failure mode for `SyntaxError: Duplicate export of '<name>'`
at module-link time is particularly hostile to debugging:

- a synthetic `pageerror` event whose `Error` has empty stack and message;
- **no** console output, **no** failed network requests, **no** child-chunk loads;
- the page renders blank and the smoke test eventually times out.

`node --input-type=module -e 'import(...)'` is the only diagnostic
that surfaces the actual error. Once you know to look, it takes ~30s
to localize. Without that hint the symptom is "the browser test
hangs and shows a blank page" and bisecting through 60 commits of
spec edits to find the culprit takes a few hours.

This PR makes the failure mode unmissable: the pipeline bails at
build time with a message naming the chunk, file, public name, count,
and source line of every offending `export …` statement.

## What the check does

Walks every AST-bodied JS file in the artifact after materialize +
strip and counts each `export` statement's contributions to the
public-name set per file. Bails with an `anyhow::Error` listing every
duplicate. Skips raw `JsFileBody::Source` files (they came verbatim
from upstream — not a pipeline-emit problem). Runs unconditionally
so pipelines without vendor swaps still benefit.

```text
validate_emitted_exports: emitted JS contains duplicate `export` names — ES module link error. Browsers and Node refuse modules with two exports sharing one public name (`SyntaxError: Duplicate export of '<name>'`). In Chromium this surfaces as a silent empty `pageerror` with no further child-chunk loads — the page renders blank with no useful console output, which is hard to debug downstream.

  chunk static/app file entry.js:
    `av` exported 2× at L1 (decl), L3 (named)
```

## What this PR does NOT do

Doesn't fix the underlying generation bug. The obvious next fix is
teaching `auto_grown_residual_exports` in `logical_modules.rs` to
check public-name collisions against existing aliased exports, not
just local-binding collisions against `pre_existing_entry_exports`
— but that's a separate change and this guard is valuable even after
that lands (will catch any future emit-side path that re-introduces
the same class of bug).

## Test plan

- [x] `bbr test //devinfra/js/debundle:validate_emitted_exports_test` — 6 new unit tests covering the named-alias-vs-local case, `export const` vs `export {}` collision, two `default` exports, star re-exports skipped, per-file isolation, source-only files skipped
- [x] `bbr test //devinfra/js/debundle/e2e:duplicate_export_test` — end-to-end pipeline run that asserts rejection with the expected message
- [x] `bbr test //devinfra/js/debundle:pipeline_test` — existing fixture re-pinned to count the new stage (steps.len 2→3)
- [x] `bbr test //devinfra/js/debundle/...` — full suite green (the one pre-existing failure, `direct_status_overpromise_test`, is the RED test from #1625 and unrelated)

https://claude.ai/code/session_01RjeAMaGRnpDsPaVw1hL37E

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjeAMaGRnpDsPaVw1hL37E)_