### PR TITLE
Normalize relative import paths in peeled modules

### DIFF
--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -1293,6 +1293,21 @@ pub fn relative_module_path(from_dir: &str, to_path: &str) -> String {
     }
 }
 
+/// Normalize a module specifier that may have been built by string
+/// concatenation (e.g. `"../" + "./foo.js"` → `".././foo.js"`). Collapses
+/// `./` segments and resolves interior `..` traversals, returning a
+/// canonical spelling like `"../foo.js"`. Unlike [`normalize_module_path`]
+/// this preserves leading `..` components — they are legal in a relative
+/// import specifier.
+pub fn normalize_relative_module_specifier(value: &str) -> String {
+    let normalized = RelativePath::new(value).normalize().to_string();
+    if normalized.is_empty() {
+        ".".to_string()
+    } else {
+        normalized
+    }
+}
+
 pub fn chunk_id_for_js_path(js_path: &str) -> Result<String> {
     let normalized = normalize_asset_path(js_path)?;
     Ok(normalized

--- a/devinfra/js/debundle/e2e/import_coalescing_test.rs
+++ b/devinfra/js/debundle/e2e/import_coalescing_test.rs
@@ -105,7 +105,7 @@ fn moved_body_reimports_three_same_source_specifiers_in_one_statement() {
     // locals, so the materializer must emit re-imports in the
     // destination module — one ImportDecl per binding would mean
     // three separate statements; the emitter consolidates them into
-    // ONE `import { a as x, b as y, c as z } from ".././vendor.js"`.
+    // ONE `import { a as x, b as y, c as z } from "../vendor.js"`.
     let mut opts = FixtureOpts::new(
         r#"import { a as x } from "./vendor.js";
 import { b as y } from "./vendor.js";
@@ -132,13 +132,13 @@ export { bridge };
     let mod_bridge = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_bridge.js"))
         .expect("read mod_bridge.js");
 
-    let (named, _namespace, _side_effect) = count_imports_from(&mod_bridge, ".././vendor.js");
+    let (named, _namespace, _side_effect) = count_imports_from(&mod_bridge, "../vendor.js");
     assert_eq!(
         named, 1,
-        "expected one consolidated `import {{ ... }} from \".././vendor.js\";` statement, got {named}; mod_bridge was:\n{mod_bridge}",
+        "expected one consolidated `import {{ ... }} from \"../vendor.js\";` statement, got {named}; mod_bridge was:\n{mod_bridge}",
     );
 
-    let bindings = collect_import_bindings(&mod_bridge, ".././vendor.js");
+    let bindings = collect_import_bindings(&mod_bridge, "../vendor.js");
     assert_eq!(
         bindings,
         vec![
@@ -187,12 +187,12 @@ export { bridge };
     let mod_bridge = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_bridge.js"))
         .expect("read mod_bridge.js");
 
-    let (named, _namespace, _side_effect) = count_imports_from(&mod_bridge, ".././vendor.js");
+    let (named, _namespace, _side_effect) = count_imports_from(&mod_bridge, "../vendor.js");
     assert_eq!(
         named, 1,
         "expected default + named imports to consolidate into one statement; got {named} in:\n{mod_bridge}",
     );
-    let bindings = collect_import_bindings(&mod_bridge, ".././vendor.js");
+    let bindings = collect_import_bindings(&mod_bridge, "../vendor.js");
     assert_eq!(
         bindings,
         vec![
@@ -239,14 +239,14 @@ export { bridge };
     let mod_bridge = fs::read_to_string(fixture.out_root.join("static/app/modules/mod_bridge.js"))
         .expect("read mod_bridge.js");
 
-    let (named, namespace, _side_effect) = count_imports_from(&mod_bridge, ".././vendor.js");
+    let (named, namespace, _side_effect) = count_imports_from(&mod_bridge, "../vendor.js");
     assert_eq!(
         (named, namespace),
         (1, 1),
         "expected one consolidated named-import ImportDecl plus one namespace-only ImportDecl; got named={named} namespace={namespace} in:\n{mod_bridge}",
     );
 
-    let bindings = collect_import_bindings(&mod_bridge, ".././vendor.js");
+    let bindings = collect_import_bindings(&mod_bridge, "../vendor.js");
     assert_eq!(
         bindings,
         vec![

--- a/devinfra/js/debundle/e2e/object_literal_import_collapse_test.rs
+++ b/devinfra/js/debundle/e2e/object_literal_import_collapse_test.rs
@@ -1,83 +1,33 @@
-//! RED test: pins a lowerer object-literal import-collapse bug.
+//! Regression: lowerer emits a canonical relative import path when a
+//! peeled module references imports from a sibling source-chunk module.
 //!
-//! **This test is intentionally failing.** It encodes the divergence
-//! between two things that the design says should agree:
+//! Before the fix in `source_chunk_imports_for_moved_body`
+//! (<devinfra/js/debundle/logical_modules.rs:3821>), the fallback branch
+//! that runs when the source-chunk resolver can't locate the import
+//! built the rewritten specifier by raw string concatenation —
+//! `format!("{}{}", "../".repeat(depth), info.src)` — and `info.src`
+//! itself often starts with `./`. The result was a non-canonical
+//! `".././provider_module.js"` spelling. Node tolerates it for
+//! resolution, but it's a smell, and the synthetic fixture below pins
+//! it. The fix normalizes the constructed path through
+//! `normalize_relative_module_specifier` so the emitted import path
+//! is canonical.
 //!
-//! 1. The peelability gate accepts a spec that moves an object-literal
-//!    `const targetConst` (whose initializer reads bindings imported
-//!    from another source-chunk module) into its own logical module.
-//! 2. The emitted JS for that logical module must remain runtime-loadable
-//!    — i.e., every free identifier in the emitted body must resolve to
-//!    either a local declaration or a top-level `import` declaration in
-//!    the same module.
+//! ## Companion bug (not pinned here)
 //!
-//! For an object literal `{ keyA: providerExportA, keyB: providerExportB,
-//! ... }` whose value identifiers are imports from a sibling module, the
-//! current lowerer:
-//!
-//! 1. Picks up the property keys as if they were the imported
-//!    identifiers (i.e. its "what identifiers does this body reference"
-//!    pass conflates shorthand key/value with a key-only property name).
-//! 2. Naturalizes object-literal shorthand
-//!    (<devinfra/js/debundle/logical_modules.rs:3259>
-//!    `naturalize_object_literal_shorthand`) so `{ providerExportA:
-//!    providerExportA }` collapses to `{ providerExportA }`. With the
-//!    collapsed form, the import-planning pass no longer sees the
-//!    cross-module identifier reference at all.
-//! 3. Does NOT emit `import { providerExportA, providerExportB,
-//!    providerExportC } from "../provider_module.js"` in the new
-//!    module.
-//!
-//! Result: cycle gate accepts the spec but the emitted JS references
-//! identifiers that don't exist in scope. The module is runtime-broken
-//! (Node throws `ReferenceError: providerExportA is not defined` at
-//! module-load time).
-//!
-//! ## Distinction from PR #1625 (`direct_status_overpromise_test.rs`)
-//!
-//! That earlier RED test pins the **analyzer/proposer** side of a
-//! related discrepancy — the analyzer over-claims `Direct` for peels
-//! the gate later refuses. This test pins a **lowerer/emitter** bug
-//! one step further down the pipeline: the gate accepts the peel but
-//! the emitted JS has a missing import. Both bugs were independently
-//! observable while peeling Tana's web bundle.
-//!
-//! ## Production observation
-//!
-//! Reproduced while peeling Tana's `getActionEventLimits` (an
-//! object-literal `const` mapping readable property names to imports
-//! from a sibling `sync_timing` module): the resulting standalone
-//! module had no `import` directive for the three referenced bindings,
-//! and Node refused to load it.
-//!
-//! ## Suggested fix family
-//!
-//! Either:
-//!
-//! 1. The import-planning pass walks object-literal values **before**
-//!    shorthand naturalization, so it sees the actual identifier
-//!    references and emits imports for cross-module ones.
-//! 2. The shorthand naturalizer refuses to collapse a `{ key: value }`
-//!    property whose `value` resolves to an imported binding when the
-//!    owning module does not declare `value` locally.
-//!
-//! ## How to flip when the fix lands
-//!
-//! Once the lowerer emits the missing import, the test becomes GREEN
-//! by construction — the assertions then describe correct behavior and
-//! the file can drop the "RED pin" framing.
-//!
-//! ## Under-reproduction note
-//!
-//! The two-line synthetic source below doesn't repro the full Tana
-//! failure shape (no missing import). It does, however, expose a path-
-//! normalization smell in exactly the rebase layer the Tana case
-//! exercises — the lowerer emits `".././provider_module.js"` instead
-//! of the canonical `"../provider_module.js"`. The fix author should
-//! re-confirm against the Tana `getActionEventLimits` peel that the
-//! full collapse-and-drop chain is also addressed; this fixture pins
-//! only the partial (1-of-2) shape that did reproduce in the
-//! synthetic harness.
+//! While peeling Tana's `getActionEventLimits` (an object-literal
+//! `const` mapping readable property names to imports from a sibling
+//! `sync_timing` module), a related but separate failure was observed
+//! where the lowerer's import-planning pass walks object-literal
+//! property values AFTER `naturalize_object_literal_shorthand`
+//! (<devinfra/js/debundle/logical_modules.rs:3259>) has already
+//! collapsed `{ key: value }` to `{ key }`. The collapsed form hides
+//! the cross-module identifier reference, and the missing import is
+//! dropped entirely — Node throws `ReferenceError` at module-load
+//! time. The synthetic two-line source below does NOT repro that
+//! shape; it only exercises the path-normalization layer. See PR
+//! #1625's analyzer-side companion bug for the proposer/gate side of
+//! the same Tana session.
 
 use debundle_e2e_support::*;
 use std::fs;
@@ -118,22 +68,10 @@ export const sC = "c";
 /// `import { sA, sB, sC } from "../provider_module.js"` directive whose
 /// path resolves correctly from the moved module's location — otherwise
 /// the object-literal initializer references three free variables and
-/// Node refuses to load the module.
-///
-/// RED pin (under-reproduction). The two-line minimal shape doesn't
-/// repro the full Tana failure on its own: with the synthetic fixture
-/// the lowerer DOES emit the cross-module import. But it emits the
-/// import with a malformed relative path (`".././provider_module.js"`,
-/// double-dot-slash-dot-slash) that — while Node tolerates it for
-/// resolution — is a leading indicator that the rebase logic is fragile
-/// in exactly the layer that the Tana case hits. The Tana repro adds
-/// (i) naturalization renaming the value-side scrambled idents (`sA →
-/// propKeyA`), (ii) the resulting shorthand collapse, and (iii) an
-/// import-planning pass that decides the renamed identifiers are
-/// "already in scope" because the property key matches. We pin a one-
-/// of-two assertion until we can recreate the full chain in the
-/// fixture — see PR #1625's analyzer-side companion bug for the
-/// proposer/gate side of the same Tana session.
+/// Node refuses to load the module. The path must be the canonical
+/// `"../provider_module.js"` spelling, not the non-canonical
+/// `".././provider_module.js"` that the pre-fix lowerer emitted by
+/// concatenating `"../"` with `info.src = "./provider_module.js"`.
 #[test]
 fn peeled_object_literal_emits_well_formed_import_for_value_identifiers() {
     let mut opts = FixtureOpts::new(
@@ -165,24 +103,21 @@ fn peeled_object_literal_emits_well_formed_import_for_value_identifiers() {
          positions; got:\n{target_src}",
     );
 
-    // RED pin (1 of 2): the rebased import path must be the canonical
-    // `../provider_module.js`, not a malformed `.././provider_module.js`
-    // form. The double-dot-slash-dot-slash spelling is what the lowerer
-    // currently emits — a smell of the same rebase code path the full
-    // Tana failure exercises. Flip when the lowerer normalizes its
-    // emitted relative paths.
+    // The rebased import path must be the canonical
+    // `../provider_module.js`, not the non-canonical
+    // `.././provider_module.js` the pre-fix lowerer emitted.
     assert!(
         target_src.contains(r#"from "../provider_module.js""#),
-        "RED pin (1 of 2, lowerer-side): target_module.js must emit a \
-         normalized relative import path; got:\n{target_src}",
+        "target_module.js must emit a normalized relative import \
+         path; got:\n{target_src}",
     );
 
-    // RED pin (2 of 2): the emitted module must actually load under
-    // Node and produce the chunk's original stdout. `assert_entry_output`
-    // surfaces a `ReferenceError` (missing import) or any other module-
-    // load failure as a non-zero node exit. If the lowerer's
-    // import-emission ever regresses to dropping the cross-module
-    // values (per the Tana `getActionEventLimits` discovery), this
+    // The emitted module must actually load under Node and produce the
+    // chunk's original stdout. `assert_entry_output` surfaces a
+    // `ReferenceError` (missing import) or any other module-load
+    // failure as a non-zero node exit. If the lowerer's import-emission
+    // ever regresses to dropping the cross-module values (per the Tana
+    // `getActionEventLimits` companion bug noted above), this
     // assertion catches it.
     assert_entry_output(&fixture, "a:b:c\n");
 }

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -23,7 +23,8 @@ use artifact::{
     ChunkDecompositionOutput, ChunkFileRecord, ChunkId, ChunkLogicalModulesSummary, ChunkMetadata,
     ChunkTable, FileMetadata, FileRole, JsChunk, JsFile, JsFileBody, SelectedModuleLowering,
     get_chunk_entry_path, join_module_path, manifest_relative_path, module_path_dirname,
-    module_path_from_path, normalize_module_path, relative_module_path,
+    module_path_from_path, normalize_module_path, normalize_relative_module_specifier,
+    relative_module_path,
 };
 use js_ast::{ParsedJsModule, set_str_value, str_value};
 use spec::{
@@ -3838,12 +3839,26 @@ fn source_chunk_imports_for_moved_body(
                 rel = format!("./{rel}");
             }
             rel
-        } else {
+        } else if info.src.starts_with('.') {
+            // Relative specifier that didn't resolve through the chunk
+            // artifact (e.g. it points at an extra_files asset). Walk up
+            // to the chunk root then re-attach `info.src`. Naive string
+            // concatenation can yield non-canonical spellings like
+            // `".././foo.js"` when `info.src` itself starts with `./`,
+            // so normalize before emitting.
             let depth = std::path::Path::new(dest_target_file)
                 .parent()
                 .map(|parent| parent.iter().count())
                 .unwrap_or(0);
-            format!("{}{}", "../".repeat(depth), info.src)
+            let raw = format!("{}{}", "../".repeat(depth), info.src);
+            let mut rel = normalize_relative_module_specifier(&raw);
+            if !rel.starts_with('.') {
+                rel = format!("./{rel}");
+            }
+            rel
+        } else {
+            // Bare specifier (npm package etc.) — pass through unchanged.
+            info.src.clone()
         };
         let specifier = runtime_reimport_specifier(&local, info);
         let group_index = *index_by_source


### PR DESCRIPTION
## Summary

Fix the lowerer to emit canonical relative import paths when a peeled module references imports from a sibling source-chunk module. Previously, naive string concatenation could produce non-canonical spellings like `".././provider_module.js"` instead of `"../provider_module.js"`.

## Changes

- **artifact.rs**: Added `normalize_relative_module_specifier()` function to canonicalize relative module specifiers that may have been built through string concatenation. This function collapses `./` segments and resolves interior `..` traversals while preserving leading `..` components.

- **logical_modules.rs**: Updated `source_chunk_imports_for_moved_body()` to normalize the constructed relative import path through the new `normalize_relative_module_specifier()` function. The fix applies to the fallback branch that handles relative specifiers not resolving through the chunk artifact (e.g., extra_files assets). Also added explicit handling for bare specifiers (npm packages) to pass through unchanged.

- **Test updates**: 
  - Refactored `object_literal_import_collapse_test.rs` from a RED (intentionally failing) test to a passing regression test. Updated documentation to focus on the path-normalization fix rather than the broader object-literal shorthand collapse issue.
  - Updated `import_coalescing_test.rs` to expect canonical `"../vendor.js"` paths instead of the non-canonical `".././vendor.js"` form.

## Implementation Details

The fix normalizes paths constructed by `format!("{}{}", "../".repeat(depth), info.src)` where `info.src` may start with `./`. The `normalize_relative_module_specifier()` function uses `RelativePath::normalize()` to produce canonical spellings while preserving the relative nature of the specifier (leading `..` components are retained).

A companion bug affecting object-literal shorthand collapse and import-planning is noted but not addressed in this change—see PR #1625 for the analyzer-side aspect of that issue.

https://claude.ai/code/session_01DRnPH4PhUTXZtoUsAjUeKu