### PR TITLE
Fix import planning to account for heuristic renames

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -206,6 +206,94 @@ mock browser bundle. Extend to:
 - Unusual dynamic import forms.
 - HTML/runtime asset layouts outside the current corpus.
 
+## Rename pipeline: collect → validate → execute _once_
+
+The naturalizer / lowerer currently mutates identifiers in place across
+several independently-discovered passes and lets every downstream consumer
+(import planning, cross-module binding lookup, fact collection,
+source-map fragment emission, export tables) read whatever name happens
+to exist when _it_ runs. PR #1627 (`object_literal_import_collapse_test`,
+fixed by e0b9c7f) and PR #1631
+(`object_literal_return_shorthand_drops_import_test`, fixed by the
+heuristic-rename reverse-lookup at
+`logical_modules.rs::plan_module_reference_needs`) are both symptoms of
+the same shape: a rename happened in one layer and a downstream layer
+keyed off the wrong-era name. Each fix has been a localized defensive
+patch on the consumer side, which leaves the same trap waiting for the
+next consumer that doesn't yet know about the rename.
+
+The proposed architectural fix is a single **collect → validate → execute
+(once)** rename pipeline:
+
+- **Collect**: every rename contributor submits _intents_ into a single
+  buffer instead of mutating the AST. Contributors include explicit
+  spec-specified renames, naturalizer heuristics (return-object alias
+  inference, shorthand-collapse readback, future readable-name
+  autonaming), import-induced renames (`{ sA as propKeyA }`),
+  collision-resolution renames, and chunk-level renames produced by
+  factorize. Each intent is `(scope, original_name, new_name, reason,
+priority, invariants_it_assumes)`.
+
+- **Validate**: resolve conflicts deterministically before any AST
+  mutation. Priority order is explicit > import-induced > heuristic.
+  Surface contradictions (`sA → propKeyA` _and_ `sA → propKeyB` in the
+  same scope) as hard errors at validation time, not as silent
+  last-write-wins behavior at AST mutation time. Output is a stable,
+  read-only mapping `(scope, original_name) → final_name` and the
+  inverse `(scope, final_name) → original_name`.
+
+- **Execute once**: one pass applies the resolved mapping to the AST
+  _and_ updates every fact table (`runtime_imports`, `referenced_idents`,
+  export tables, source-map fragments, cross-module binding indexes) in
+  lockstep, keyed by the original name. After execute, no later pass
+  invents a rename — every consumer that needs to bridge between
+  pre-rename and post-rename names consults the same finalized mapping.
+
+Direct consequence: the family of "X-layer renamed it, Y-layer didn't
+notice" bugs collapses to one architectural seam. The
+`plan_module_reference_needs` reverse-lookup that fixes #1631 becomes
+dead code (the final mapping makes both the body AST and the
+`runtime_imports` map agree on a single set of names before planning
+runs), and similarly `normalize_relative_module_specifier` from the
+#1627 fix could rejoin a normal path-building step rather than living as
+a defensive sanitizer at the usage site.
+
+Prerequisite work before designing the pipeline:
+
+1. Inventory every current rename contributor in `logical_modules.rs`
+   and adjacent files. Examples already known:
+   `collect_return_object_alias_renames` (line ~3044),
+   `collect_naturalization_renames_from_function` (~2982), the
+   `RenameAndShorthandNaturalizer` `VisitMut` (~3172),
+   `naturalize_object_literal_shorthand` (~3226),
+   `disambiguate_import_locals` (~3668), the chunk-level
+   `chunk_renames` map that flows out of factorize, and any
+   collision-resolution code path that mutates `module_import_renames`
+   at the orchestration site. Capture each contributor's _kind_
+   (explicit / heuristic / collision / chunk-level), _scope_ (function
+   / module / chunk / cross-chunk), and _current side-effect surface_.
+
+2. Inventory every downstream consumer that today reads identifier
+   names off the AST or off pre-rename fact maps. Same call sites that
+   currently need defensive bridging.
+
+3. Decide on the scope model. Per-function naturalizer renames don't
+   need to be visible at chunk scope; chunk_renames don't need to
+   reach per-function naturalizer collection. The intent buffer should
+   reject cross-scope writes by construction.
+
+4. Design must not block on landing #1631-style defensive fixes — those
+   should land case by case as they're discovered, with this TODO
+   updated to note when a defensive patch becomes architecturally
+   redundant. Removing the defensive patches is part of the
+   pipeline-landing cleanup, not the architecture work itself.
+
+Likely multiple PRs. Should land _after_ the `Schedule` →
+`ChunkFactorization` rename below, because the partition-and-factorize
+surface is where the chunk-level rename intents already live and
+restructuring on top of the renamed type is cheaper than restructuring
+twice.
+
 ## Rename `Schedule` → `ChunkFactorization`
 
 `schedule.rs::Schedule` is, after the factorize rewrite, just a

--- a/devinfra/js/debundle/e2e/object_literal_return_shorthand_drops_import_test.rs
+++ b/devinfra/js/debundle/e2e/object_literal_return_shorthand_drops_import_test.rs
@@ -1,21 +1,17 @@
-//! RED test pinning the lowerer's object-literal shorthand-collapse +
-//! import-planning bug noted in the PR #1627 / #1630 thread.
+//! Regression test for the lowerer's object-literal shorthand-collapse +
+//! import-planning bug originally pinned RED in PR #1631 alongside the
+//! PR #1627 / #1630 path-normalization thread.
 //!
 //! ## Context
 //!
 //! PR #1630 fixed the path-normalization layer in
 //! `source_chunk_imports_for_moved_body` so peeled modules emit
-//! canonical `"../foo.js"` instead of `".././foo.js"`. The PR body
-//! explicitly noted a companion bug it didn't address:
+//! canonical `"../foo.js"` instead of `".././foo.js"`. The companion
+//! bug — `object_literal_import_collapse_test`'s synthetic fixture
+//! deliberately doesn't repro it — is the import-dropping shape
+//! covered here.
 //!
-//! > A companion bug affecting object-literal shorthand collapse and
-//! > import-planning is noted but not addressed in this change.
-//!
-//! The synthetic fixture in `object_literal_import_collapse_test`
-//! deliberately doesn't repro that shape — it pins only the path
-//! normalization. This file pins the import-dropping bug.
-//!
-//! ## Failure mode
+//! ## Failure mode (pre-fix)
 //!
 //! When the heuristic naturalizer (`collect_return_object_alias_renames`)
 //! scans a peeled function body and finds `return { key: value }`, it
@@ -27,15 +23,25 @@
 //!    value }` becomes `{ key: key }`).
 //! 2. Collapses `{ key: key }` to the shorthand `{ key }`.
 //!
-//! After this pass, `collect_module_body_facts` walks the body and
-//! sees `key` referenced — but the source chunk's `runtime_imports`
+//! After this pass, `collect_module_body_facts` walked the body and
+//! saw `key` referenced — but the source chunk's `runtime_imports`
 //! map is keyed by the original local name `value`. The planner
-//! looks up `key` in `runtime_imports`, misses, and emits no import
-//! for it.
+//! looked up `key` in `runtime_imports`, missed, and emitted no
+//! import for it. The emitted module had
+//! `function makeConfig() { return { key }; }` with `key` as a free
+//! variable. Node threw `ReferenceError: key is not defined` at
+//! module-load time.
 //!
-//! The emitted module has `function makeConfig() { return { key }; }`
-//! with `key` as a free variable. Node throws `ReferenceError: key is
-//! not defined` at module-load time.
+//! ## Fix
+//!
+//! `plan_module_reference_needs` now takes the heuristic-rename map
+//! produced by `naturalize_module_body` and, on a miss for a
+//! post-rename name, reverse-resolves to the pre-rename original and
+//! looks *that* up in `runtime_imports`. The carried `RuntimeImportInfo`
+//! still has `imported = "value"`, so emit produces
+//! `import { value as key } from "../provider.js"`. See the
+//! "Rename pipeline" entry in <devinfra/js/debundle/TODO.md> for the
+//! architectural follow-up that would let this defensive bridge retire.
 //!
 //! ## Repro shape
 //!
@@ -43,27 +49,6 @@
 //! minified import locals, `propKeyA`/`propKeyB` are the readable
 //! property keys that drive the heuristic rename. The exact shape the
 //! Tana `getActionEventLimits` peel hit.
-//!
-//! ## Fix sketch (for whoever picks this up)
-//!
-//! The plan_module_reference_needs / import-planning step must learn
-//! about the heuristic renames the naturalizer applied. Two options:
-//!
-//! - **Symmetric rename**: after collecting heuristic renames, also
-//!   re-key `runtime_imports` so `runtime_imports[key] =
-//!   runtime_imports[value]` (with `imported_name = value`). Then the
-//!   planner finds the import under the post-rename name and emits
-//!   `import { value as key } from "../provider.js"`.
-//! - **Collect facts pre-naturalize**: capture
-//!   `runtime_imports`-relevant references before renames apply, then
-//!   plan imports off the pre-rename names. Trickier — the post-
-//!   naturalize body still needs to reference `key`, so the import
-//!   has to land as `import { value as key }`.
-//!
-//! Drop a regression assertion (canonical import path + a re-import
-//! for every still-referenced original local) into
-//! `object_literal_import_collapse_test` once fixed, and flip this
-//! test from RED to GREEN.
 
 use debundle_e2e_support::*;
 use std::fs;

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1593,6 +1593,7 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
                 binding_assignment,
                 &entry_exports_by_original_local,
                 runtime_import_facts,
+                &local_renames,
             )
         });
         let mut module_import_renames = BTreeMap::<String, String>::new();
@@ -2656,6 +2657,14 @@ fn plan_module_reference_needs<'a>(
     binding_assignment: &BTreeMap<String, usize>,
     entry_exports_by_original_local: &BTreeMap<String, EntryExport>,
     runtime_import_facts: &'a RuntimeImportFacts,
+    // original_local → post-rename local, produced by naturalize_module_body.
+    // `runtime_import_facts.imports` is keyed by original locals (built before
+    // naturalization), but `body_facts.referenced_idents` is post-rename, so
+    // direct lookup misses for any binding the naturalizer touched. Threading
+    // this in is a defensive bridge between two rename eras; the long-term fix
+    // is the collect→validate→execute-once rename pipeline tracked in
+    // <devinfra/js/debundle/TODO.md> ("Rename pipeline").
+    heuristic_renames: &BTreeMap<String, String>,
 ) -> ModuleReferenceNeeds<'a> {
     let mut needs = ModuleReferenceNeeds::default();
     for name in &body_facts.referenced_idents {
@@ -2690,7 +2699,21 @@ fn plan_module_reference_needs<'a>(
         if body_facts.imported_locals.contains(name) {
             continue;
         }
-        if let Some(info) = runtime_import_facts.imports.get(name) {
+        // Direct hit when the body still uses the original local. Fall back to
+        // a reverse lookup through `heuristic_renames` when a naturalizer pass
+        // renamed the binding (e.g. `sA` → `propKeyA` from a return-object
+        // alias collapse): the body now references `propKeyA`, but the source
+        // chunk's import map is still keyed by `sA`. The recovered
+        // `RuntimeImportInfo` keeps `imported = "sA"`, so emit produces
+        // `import { sA as propKeyA } from "<src>"` via
+        // `runtime_reimport_specifier`'s local-vs-imported branch.
+        let info = runtime_import_facts.imports.get(name).or_else(|| {
+            heuristic_renames
+                .iter()
+                .find(|(_, post)| post.as_str() == name)
+                .and_then(|(pre, _)| runtime_import_facts.imports.get(pre))
+        });
+        if let Some(info) = info {
             needs.runtime_reimports.insert(name.clone(), info);
         }
     }


### PR DESCRIPTION
## Summary

Fix a bug where the import planner fails to emit imports for bindings that were renamed by the naturalizer's heuristic passes (e.g., return-object alias inference). The planner was looking up post-rename names in a map keyed by pre-rename names, causing it to miss imports and emit modules with unresolved free variables.

## Changes

- **logical_modules.rs**: Thread the heuristic rename map from `naturalize_module_body` into `plan_module_reference_needs`. When a direct lookup of a referenced identifier fails in `runtime_import_facts`, perform a reverse lookup through the heuristic renames to find the original pre-rename name, then look that up in the import map. This ensures imports are emitted with the correct `import { original as renamed }` form.

- **object_literal_return_shorthand_drops_import_test.rs**: Update test documentation to reflect that this is now a passing regression test (was RED, now GREEN). Clarify the failure mode, the fix applied, and note that this is a defensive bridge pending the architectural rename pipeline redesign.

- **TODO.md**: Add comprehensive "Rename pipeline: collect → validate → execute _once_" entry documenting the architectural issue. This defensive fix is a symptom of the same underlying problem as PR #1627/#1631 — multiple independent rename passes mutate the AST without coordinating with downstream consumers. The TODO outlines a proposed single-pass pipeline that would eliminate this class of bugs entirely and make this defensive bridge unnecessary.

## Implementation Details

The fix is a targeted defensive patch that reverse-resolves post-rename names back to their pre-rename originals when the direct lookup misses. This allows the import planner to find the correct `RuntimeImportInfo` and emit proper import statements like `import { sA as propKeyA }` when the naturalizer has renamed `sA` to `propKeyA` in the function body.

The long-term architectural fix (collect → validate → execute rename pipeline) is tracked in the TODO and should land after the `Schedule` → `ChunkFactorization` rename, as that rename affects the partition-and-factorize surface where chunk-level rename intents already live.

https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF