### PR TITLE
debundle: unify realizability through one primitive (+ at-init promotion + Lemma 2)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -211,6 +211,7 @@ rust_library(
         "partition.rs",
         "peelability.rs",
         "purity.rs",
+        "realizability.rs",
         "report_schema.rs",
         "reports.rs",
         "schedule.rs",

--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -479,29 +479,51 @@ but unrealizable at runtime due to one of these uncaught
 interprocedural patterns is currently caught by the validator's
 strict rule (see below).
 
-## Predicate asymmetry: strict validator, relaxed primitive
+## Lemma 2: entry-side import ordering
 
-The peelability proposer routes through the realizability primitive's
-relaxed clause-3 rule (`check_realizability` in
-`devinfra/js/debundle/realizability.rs`). The validator
-(`validate_schedule` in `devinfra/js/debundle/validation.rs`) uses a
-stricter rule: any SCC of the full quotient `I ∪ S` that contains a
-constraining cross-module edge is unrealizable.
+The realizability primitive's relaxed clause-3 rule
+(`check_realizability` accepts a spec iff the constraining-edge
+subgraph of `Q` has no multi-module SCC) admits mixed cycles in the
+imports graph `I` — cycles where every back-edge is `LazyUse`. For
+the ESM linker to actually evaluate these without TDZ, the entry
+module's `import` directives must be emitted in a specific source
+order so that depth-first link traversal lands on a Phase-2
+evaluation order matching the constraining-edge linearization.
 
-The two would coincide on a fully-Lemma-2-implementing materializer
-(see "The realizability theorem" below). Until the materializer
-steers entry-side ESM import order to land on a topological
-linearization of `I ∪ S`, mixed cycles that the relaxed rule
-admits — and that at-init call promotion does not catch via the
-interprocedural promotion above — can still TDZ at runtime. The
-strict validator stays the safety floor; the relaxed primitive is
-advisory for the proposer.
+The materializer computes `Schedule::source_import_position` to drive
+this. The algorithm:
 
-The at-init call promotion narrows the gap by catching the canonical
-shape (`console.log(readB())`) the original PR #1625 RED test pinned.
-Bringing the validator onto the relaxed rule is gated on the
-materializer learning Lemma 2 (open follow-up — see
-`plans/realizability-primitive-unification.md`).
+1. Compute SCCs of the full quotient `I ∪ S` via Tarjan.
+2. Each SCC is assigned a dependency rank = the minimum
+   `linker_position` of its members. `linker_position` itself comes
+   from a toposort of the **constraining-edge subgraph** (which is
+   acyclic per clause 3, even when `I ∪ S` is cyclic).
+3. Sort all modules by `(SCC dep rank ascending, intra-SCC
+linker_position DESCENDING)`.
+
+For acyclic shapes every SCC is a singleton, so the within-SCC
+reverse is a no-op and the order matches `linker_order`
+(dependency-first source). For cyclic-I shapes the within-SCC
+reverse is load-bearing: ESM Phase-2 evaluates by recursing into
+imports before running the module's own init, so DFS into the
+FIRST imported SCC member traverses the cycle and finalizes its
+constraining dependency LAST in post-order. Reversing within the
+SCC means the dependent is imported first; DFS unwinds through the
+dependency; post-order evaluates dependency first.
+
+For the canonical
+[mod_a (lazy → mod_b) + mod_b (eager → mod_a)] case the algorithm
+produces entry imports `[mod_b, mod_a]` so the linker DFS visits
+mod_b → mod_a → mod_b (cycle no-op) and evaluates mod_a first, then
+mod_b. mod_b's at-init read of A succeeds.
+
+Because Lemma 2 is implemented, the validator
+(`validate_schedule` in `devinfra/js/debundle/validation.rs`) and
+the proposer (`evaluate_peel_candidate` in
+`devinfra/js/debundle/peelability.rs`) share the realizability
+primitive's verdict — a `peelable_now` from the proposer is a peel
+the gate will accept and the bundle will execute correctly at
+runtime.
 
 ## The realizability theorem
 

--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -432,6 +432,77 @@ push a delta and read the index — not to spin up a parallel walk over
 read the verdict's owner-edge provenance, but the validity decision goes
 through the primitive only.
 
+## At-init call promotion
+
+A function body's lazy reads/rebinds fire at module-init from the
+perspective of any caller that invokes the function at-init. The owner
+graph carries promoted **EagerUse** and **EagerRebind** edges from
+at-init callers to the transitive closure of their callees' lazy
+reads/rebinds, so the primitive's clause-3 verdict is sound for the
+canonical `console.log(readB())` shape (top-level call whose body
+crosses a module boundary).
+
+The promotion runs once in `build_owner_graph` and is
+partition-independent: intra-module promoted edges are dropped by the
+quotient automatically, so the same promoted owner graph drives the
+proposer's hypothetical partitions and the validator's actual one.
+
+**Algorithm.** For each top-level chunk statement S with `at_init_calls`
+non-empty, walk the chunk call graph (among chunk-declared functions)
+in reverse topological order to compute, per function-owner F,
+`reachable_lazy_reads[F]` and `reachable_lazy_rebinds[F]` — the
+fixpoint closure of F's body lazy reads/rebinds plus the closures of
+every chunk function F calls. Then for each callee C in S's
+`at_init_calls`, emit promoted edges from S's owner to every owner
+declaring a binding in C's reachable closures.
+
+**Hoisted-target filter.** Promoted reads filter out targets whose
+owner is a `FnDecl` — function declarations are hoisted at Phase-1
+module instantiation, so reading them from another module never
+observes a TDZ. Without this filter, mutual recursion across modules
+(`function even(){odd()}` / `function odd(){even()}` split into
+mod_a / mod_b) would spuriously close a constraining-edge cycle that
+isn't actually unrealizable at runtime.
+
+**Per-statement dedup.** A single at-init call to a function with N
+transitive lazy reads would otherwise emit N edges from the caller
+statement, and multiple at-init calls in the same statement would
+multiply that. The promotion pass dedupes per `(caller, target-owner)`
+pair per kind, keeping the per-statement cost bounded by the
+transitive closure size rather than (closure × call-sites).
+
+**Limitations.** Indirect calls (`const g = f; g()`), method calls
+(`obj.method()`), and dynamic dispatch produce no promoted edges —
+the callee isn't statically a known chunk binding. These are
+conservatively unmodelled. A spec accepted by the relaxed predicate
+but unrealizable at runtime due to one of these uncaught
+interprocedural patterns is currently caught by the validator's
+strict rule (see below).
+
+## Predicate asymmetry: strict validator, relaxed primitive
+
+The peelability proposer routes through the realizability primitive's
+relaxed clause-3 rule (`check_realizability` in
+`devinfra/js/debundle/realizability.rs`). The validator
+(`validate_schedule` in `devinfra/js/debundle/validation.rs`) uses a
+stricter rule: any SCC of the full quotient `I ∪ S` that contains a
+constraining cross-module edge is unrealizable.
+
+The two would coincide on a fully-Lemma-2-implementing materializer
+(see "The realizability theorem" below). Until the materializer
+steers entry-side ESM import order to land on a topological
+linearization of `I ∪ S`, mixed cycles that the relaxed rule
+admits — and that at-init call promotion does not catch via the
+interprocedural promotion above — can still TDZ at runtime. The
+strict validator stays the safety floor; the relaxed primitive is
+advisory for the proposer.
+
+The at-init call promotion narrows the gap by catching the canonical
+shape (`console.log(readB())`) the original PR #1625 RED test pinned.
+Bringing the validator onto the relaxed rule is gated on the
+materializer learning Lemma 2 (open follow-up — see
+`plans/realizability-primitive-unification.md`).
+
 ## The realizability theorem
 
 > **Theorem (correctness).** If `R ∪ S` is acyclic, the source-

--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -360,6 +360,78 @@ R  ⊆  I            (R is the at-init projection of I)
 I  ∪  S            the full constraint graph
 ```
 
+## Realizability primitive
+
+The three-clause validity predicate — importability, no cross-destination
+rebinds, no multi-module SCC in the constraining-edge subgraph — has exactly
+**one** implementation. Every code path that asks "is this destination
+assignment realizable?" reaches it through the same primitive:
+
+> `check_realizability(owner_graph, partition) → Verdict`
+
+The verdict surfaces unrealizable SCCs, cross-destination rebinds, and
+non-importable reads with owner-edge provenance. An empty verdict means the
+partition is realizable per "Valid peels and atomic modules" below.
+
+Three callers consume it:
+
+1. **The validator (the gate).** Given the spec's actual partition, the
+   verdict decides acceptance or rejection. This is the load-bearing call —
+   if it rejects, materialization stops.
+2. **The peelability proposer.** For each candidate peel, the proposer
+   constructs the hypothetical partition that would result from the peel
+   (the candidate's owners reassigned to a fresh destination), asks the
+   primitive, and projects the verdict into the candidate's status. A
+   `peelable_now` candidate is one whose hypothetical partition produces an
+   empty verdict; any other verdict shape decodes to a specific blocker
+   reason.
+3. **The factorize closure loop.** Each frontier-grow step certifies the
+   resulting hypothetical partition via the primitive. If the verdict names
+   an exact owner-level repair (a private read that needs its provider, an
+   atomic-unit split, a cycle that needs a small cut), the loop grows the
+   frontier and re-certifies. Proposals are emitted only on empty verdicts.
+
+### Iterative, undo-aware shape
+
+Asking the primitive from scratch per query is `O(N + M)`. A chunk's
+proposer evaluates thousands of candidates and a factorize closure can
+re-certify after every frontier step, so the primitive is exposed as a
+**stateful, transactional index over a working partition** rather than a
+pure function:
+
+- Callers push partition deltas (move owners, create destinations) onto the
+  index. Each push updates the quotient adjacency and the constraining-edge
+  SCC structure incrementally, only for components touched by the delta's
+  incident edges. The verdict is always against the index's current state.
+- Each push records its inverse on a journal. Callers undo deltas in LIFO
+  order to back out of a hypothetical or failed exploration. The proposer
+  uses a scoped guard for per-candidate isolation; factorize uses explicit
+  push/undo to walk closure repair branches.
+- The validator does no undo: it pushes the actual partition once and reads
+  the verdict.
+
+The pure-function form `check_realizability(owner_graph, partition)` is the
+correctness reference; the incremental, undoable form is the production
+implementation. A differential test asserts the two agree on random
+push/undo sequences.
+
+This is "the iterative graph that callers update and undo updates on":
+the quotient and its SCC structure are built once per chunk, then walked
+forward by deltas (toward a hypothesis or a commit) and backward by undos
+(when backing out). It is not torn down and rebuilt per question.
+
+### Invariant: no bespoke parallel walks
+
+No production code should answer the validity question by walking the
+owner graph or the quotient with its own algorithm. Bespoke per-question
+walks are how the proposer/gate divergence repaired in this design first
+appeared: two algorithms drift; one shared implementation cannot. If a new
+caller needs a verdict over a hypothetical partition, the answer is to
+push a delta and read the index — not to spin up a parallel walk over
+`module_pair_totals` or similar derived state. Adjacent diagnostics may
+read the verdict's owner-edge provenance, but the validity decision goes
+through the primitive only.
+
 ## The realizability theorem
 
 > **Theorem (correctness).** If `R ∪ S` is acyclic, the source-
@@ -1001,40 +1073,47 @@ The first implemented candidate family answers the immediate
 operational question: "which symbols can currently peel out of the
 residual catch-all?"
 
-Let `R` be any destination marked residual (`ResidualEntry` or a
-generated residual logical module), and let `o ∈ V` be an owner
-currently assigned to `R` with declared symbols `decl(o)`. To test
-whether `o` is peelable now:
+Let `R` be any destination marked residual (the `ResidualEntry` catch-all
+or a generated residual logical module), and let `o ∈ V` be an owner currently assigned to `R` with
+declared symbols `decl(o)`. To test whether `o` is peelable now:
 
-1. Create a fresh hypothetical destination `P_o`.
-2. Reassign every binding in `decl(o)` to `P_o`; leave all other
-   owner destinations unchanged.
-3. Quotient the same owner graph by this candidate assignment, then
-   restrict to the **constraining-edge subgraph** of that quotient
-   (drop `LazyUse` cross edges).
-4. Inspect only the SCC containing `P_o` in that restricted graph.
-5. The candidate is `peelable_now` iff `P_o`'s SCC in the
-   constraining subgraph is singleton/non-cyclic. If it contains
-   any other module (i.e. there is a directed cycle of at-init,
-   side-effect-order, rebind, or local-effect cross edges through
-   `P_o`), the candidate is `blocked_cycle`, and the report lists
-   the constraining module edges plus their owner-edge ids.
+1. Push a hypothetical delta on the realizability index: create a fresh
+   destination `P_o` and reassign the owners of `decl(o)` to it. All
+   other owner destinations are unchanged.
+2. Read the verdict from the index.
+3. Decode the verdict into a `PeelCandidateStatus`:
+   - Empty verdict → `peelable_now`.
+   - Verdict carries `unrealizable_sccs` touching `P_o` → `blocked_cycle`.
+     The owner-edge provenance on the SCC names the exact constraining
+     module edges that form the cycle.
+   - Verdict carries non-importable reads from `P_o` into private
+     residual neighbors → `blocked_residual_dependency`.
+4. Undo the delta. The index is restored to the pre-push partition state
+   for the next candidate.
 
-   Restricting to the constraining subgraph is load-bearing: a mixed
-   cycle whose constraining edges form a DAG — e.g. `residual → P_o`
-   eager-use plus `P_o → residual` lazy-use, the canonical "pure
-   top-level helper consumed by many same-residual eager users"
-   shape — is realizable. ESM resolves it by evaluating the
-   lazy/hoisted side first, so the eager side never observes a TDZ.
-   This is the same `G_atomic` definition `compute_atomic_units`
-   already uses for factorization; the two stages stay consistent.
+The same primitive that the validator uses on the actual partition
+answers the proposer's question on a hypothetical one. There is no
+parallel walk over `module_pair_totals` or a synthetic-node BFS — the
+proposer and the gate cannot disagree because they share an
+implementation.
 
-This local-SCC test intentionally ignores unrelated pre-existing
-bad SCCs. When the current build is green, it is equivalent to
-checking the whole candidate quotient. When the build is red, it
-still identifies residual symbols whose peel is locally safe and
-therefore useful for reducing the residual or breaking a larger
-cycle without adding a new one.
+Restricting to the constraining-edge subgraph is load-bearing and is
+already part of the primitive's verdict: a mixed cycle whose constraining
+edges form a DAG — e.g. `residual → P_o` eager-use plus `P_o → residual`
+lazy-use, the canonical "pure top-level helper consumed by many
+same-residual eager users" shape — is realizable. ESM resolves it by
+evaluating the lazy/hoisted side first, so the eager side never observes
+a TDZ. This is the same `G_atomic` definition `compute_atomic_units` uses
+for factorization; one definition, one implementation.
+
+The verdict's `unrealizable_sccs` inherently ignore unrelated pre-existing
+bad SCCs that do not touch `P_o`: the projection from verdict to
+candidate status filters to SCCs incident to the candidate's destination.
+When the current build is green, this is equivalent to checking the whole
+candidate quotient. When the build is red, the proposer still identifies
+residual symbols whose peel is locally safe and therefore useful for
+reducing the residual or breaking a larger cycle without adding a new
+one.
 
 V1 also computes bounded two-owner closures. It does not scan every
 pair in the residual. Instead, for each cycle-blocked singleton
@@ -1163,6 +1242,11 @@ A destination assignment is **valid** iff:
    because ESM evaluates the lazy side without observing a TDZ on the
    eager side.
 
+This three-clause predicate is what the "Realizability primitive" section
+above defines as the single shared implementation. The validator, the
+peelability proposer, and the factorize closure all consume the same
+primitive — none of them re-implement the predicate.
+
 A peel is just a proposed destination assignment for an owner set.
 The peel is valid exactly when the resulting assignment is valid by
 the definition above. Invalid peels have three primary explanations:
@@ -1227,7 +1311,7 @@ This decoupling is load-bearing for two reasons:
    implementation of the export logic on the proposer side and
    creates an SSOT drift hazard the moment the emit policy
    evolves. Keeping the proposer concerned with the
-   importability/cycle/rebind predicates *only* means a peel that
+   importability/cycle/rebind predicates _only_ means a peel that
    passes the proposer's check is always materializable.
 2. **There is no "binding is private to entry" spec contract.** Any
    top-level entry declaration is implicitly exportable when a
@@ -1298,19 +1382,30 @@ ranking or display.
    - include provider owners for private residual bindings that the
      frontier item reads, including lazy reads, unless the export
      policy makes those bindings importable.
-3. Validate the resulting hypothetical assignment with the same
-   quotient/importability predicate used by materialization.
-4. If validation reports a blocker with an exact owner-level repair,
-   grow the frontier item and repeat:
+3. Certify the resulting hypothetical assignment via the realizability
+   primitive (above). Same primitive the validator and the peelability
+   proposer use; no parallel walk.
+4. If the verdict reports a blocker with an exact owner-level repair,
+   push the repair onto the realizability index and re-read the verdict:
    - private residual read -> add the binding's provider owner;
    - atomic-unit split or rebinding split -> add the unit/assigner
      owners;
    - constraining quotient cycle -> add a small owner-level cut or
      companion set, then revalidate.
-5. Emit a proposal only when validation succeeds. Otherwise stop with a
+     On a failed repair branch, undo the push and try the next repair —
+     the index's undo journal makes this cheap.
+5. Emit a proposal only when the verdict is empty. Otherwise stop with a
    diagnostic when the frontier item exceeds the size cap, reaches an
    active-module conflict the generator is not allowed to rewrite, has
    no exact repair, or repeats a previous owner set.
+
+The "not too small, not too big" sizing of factorized quotients is the
+termination behaviour of this loop, not a separate heuristic. A frontier
+is "too small" exactly when the verdict still names an exact repair; the
+loop grows. A frontier is "too big" exactly when the size cap fires before
+the verdict is empty; the loop halts with a diagnostic. The closure rules
+and the size cap layer cleanly on top of one shared primitive instead of
+running as ad-hoc parallel passes with their own graph views.
 
 The implementation should be staged this way:
 
@@ -1451,6 +1546,37 @@ These operations are pure graph transforms over immutable analysis
 data. That property matters operationally: two tools reading the same
 owner graph and destination assignments should produce the same
 peelability status without building emitted JS.
+
+### Pipeline trajectory
+
+The current pipeline (`pipeline.rs`) enumerates a long sequence of
+named stages — `LoadJsChunks`, `PrepareJsChunks`, `BuildArtifactIndexes`,
+`RewriteChunkEntrySpecifiers`, `ApplyVendorAnnotations`,
+`RenameVendorExports`, `SwapVendorChunks`, `MaterializeLogicalModules`,
+`ApplyPartialVendorSwaps`, `StripSwappedVendorExports`, `WriteJsTree`,
+`EmitBrowserHarness` — that read like a JS-file-tree-rewriting pipeline.
+That shape is a holdover: an earlier incarnation passed trees of JS
+files between stages and each stage rewrote them in place.
+
+The current analyzer operates on the owner graph and a partition, with
+late materialization to emitted JS at the end. Most of the named stages
+are orchestration overhead around what is, semantically, a small set of
+functions over `(owner_graph, partition)` plus the shared realizability
+primitive.
+
+The direction of travel is to collapse the stage structure. Each stage
+becomes a function over the analyzer's typed state, the JS-tree
+intermediate snapshots between stages are dropped, and the pipeline
+becomes the composition of those functions. The unification of the
+gate, the peelability proposer, and the factorize closure on the
+realizability primitive is a precondition for this collapse: it removes
+the parallel walks and the proposer-internal caches that made the stage
+boundaries necessary as state-passing seams.
+
+The e2e tests in `devinfra/js/debundle/e2e/` pin observable chunk →
+emitted-JS behavior. They are the safety net that makes this collapse
+possible without behaviour drift. No timetable is committed; this
+section documents the direction.
 
 ## Selector vocabulary and matching
 

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -432,6 +432,84 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         assert_eq!(entry.kind, DepKind::EagerUse);
     }
 
+    /// Verify that at-init call promotion materializes a promoted
+    /// owner-graph edge for a top-level call to a chunk function
+    /// whose body lazily reads a cross-module binding. The promoted
+    /// edge appears as an EagerUse edge from the caller statement's
+    /// owner to the target binding's owner.
+    #[test]
+    fn at_init_call_promotion_materializes_owner_edge() {
+        // owner 0: function readB { return B; } (lazy_reads = {B})
+        // owner 1: const A = 1
+        // owner 2: const triggerInit = readB(); (at_init_calls = {readB})
+        // owner 3: const B = A + 1; (declared = {B}, eager_reads = {A})
+        // Promotion should add an EagerUse edge owner 2 → owner 3
+        // because triggerInit at-init-calls readB whose body reads B.
+        let module = parse(
+            "function readB() { return B; } const A = 1; const triggerInit = readB(); const B = A + 1;",
+        );
+        let facts = analyze_facts(&module);
+        assert_eq!(
+            facts[2].at_init_calls,
+            BTreeSet::from(["readB".to_string()]),
+            "triggerInit's at_init_calls must include readB: {:?}",
+            facts[2].at_init_calls,
+        );
+        let owner_graph = build_owner_graph(&facts);
+        let promoted: Vec<_> = owner_graph
+            .iter_edges()
+            .filter(|e| e.from == OwnerId(2) && e.to == OwnerId(3))
+            .collect();
+        assert!(
+            promoted.iter().any(|e| e.reason.kind == DepKind::EagerUse),
+            "expected a promoted EagerUse edge owner 2 → owner 3 in {:?}",
+            owner_graph
+                .iter_edges()
+                .map(|e| (e.from, e.to, e.reason.kind))
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn at_init_call_promotion_closes_otherwise_relaxed_cycle() {
+        // mod_0 owns readB, triggerInit (which at-init-calls readB),
+        // and A. mod_1 owns B. Promotion: triggerInit's owner (mod_0)
+        // gets a promoted eager edge to B's owner (mod_1) because
+        // readB's body lazily reads B. Combined with B's eager edge
+        // back to A (mod_1 → mod_0), the constraining-edge subgraph
+        // contains a 2-cycle. The lazy `readB → B` edge is still in
+        // the full quotient as evidence but is excluded from the cut.
+        // Source order matters: B reads A (mod_1 → mod_0 eager) is
+        // the back-edge that the promoted forward-edge closes into a
+        // cycle.
+        let module = parse(
+            "function readB() { return B; } const A = 1; const triggerInit = readB(); const B = A + 1;",
+        );
+        let facts = analyze_facts(&module);
+        let mut binding_assignment = HashMap::new();
+        binding_assignment.insert("readB".to_string(), logical(0));
+        binding_assignment.insert("triggerInit".to_string(), logical(0));
+        binding_assignment.insert("A".to_string(), logical(0));
+        binding_assignment.insert("B".to_string(), logical(1));
+        let owner_graph = build_owner_graph(&facts);
+        let partition =
+            Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
+        let graph = build_module_quotient(&owner_graph, &partition);
+        let report = validate_schedule(&graph, &render);
+        assert_eq!(
+            report.cycles.len(),
+            1,
+            "at-init call promotion must close the cycle; got {:?}",
+            report.cycles,
+        );
+        let cycle = &report.cycles[0];
+        assert!(
+            !cycle.cut.iter().any(|e| e.kind == DepKind::LazyUse),
+            "cut must not include lazy reasons, got {:?}",
+            cycle.cut,
+        );
+    }
+
     /// Pure-S cycle: cut consists of side-effect reasons; no
     /// lazy or at-init reasons should appear.
     #[test]
@@ -3475,15 +3553,14 @@ mutable = mutable + 1;"#,
 
     #[test]
     fn validate_returns_empty_linker_order_for_cyclic_spec() {
-        // Cross-unit module cycle: mod_0 owns `A` and `readB`,
-        // mod_1 owns `B`. `readB` lazily reads B (mod_0 → mod_1),
-        // and B eagerly reads A (mod_1 → mod_0). Atomic units stay
-        // singletons because LazyUse is dropped from `G_atomic`, so
-        // `factor_assembly` accepts the partition; the cycle shows up
-        // at the module quotient where the validator catches it.
+        // Genuine cross-module constraining cycle: `A = B + 1` and
+        // `B = A + 1` both read at-init. After the relaxed-predicate
+        // routing of the validator (DESIGN.md "Realizability
+        // primitive"), the case has to actually produce a cycle in
+        // the constraining-edge subgraph — mutual at-init reads do.
         let schedule = schedule_for(
-            "const A = 1; function readB() { return B; } const B = A + 1;",
-            &[("A", logical(0)), ("readB", logical(0)), ("B", logical(1))],
+            "const A = B + 1; const B = A + 1;",
+            &[("A", logical(0)), ("B", logical(1))],
         );
         let report = schedule.validate();
         assert!(!report.cycles.is_empty(), "expected a cycle in {report:?}",);

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -354,8 +354,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
+        let report = validate_schedule(&owner_graph, &partition, &render);
         assert_eq!(report.cycles.len(), 1);
         assert_eq!(report.cycles[0].modules.len(), 2);
     }
@@ -371,8 +370,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
+        let report = validate_schedule(&owner_graph, &partition, &render);
         assert!(
             report.cycles.is_empty(),
             "expected no cycles, got {:?}",
@@ -380,17 +378,20 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         );
     }
 
-    /// Pin the cut behavior for the canonical mixed cycle: 2-module
-    /// SCC with one lazy forward-edge and one at-init back-edge.
-    /// The cut should contain exactly the at-init back-edge — lazy
-    /// edges aren't realizability-constraining and removing one
-    /// can't fix the cycle.
+    /// A mixed cycle (lazy forward-edge, at-init back-edge) where
+    /// the lazy direction is NOT invoked at-init is realizable per
+    /// DESIGN.md "Realizability primitive" clause 3 — the
+    /// constraining-edge subgraph (drops LazyUse) has no
+    /// multi-module SCC. The materializer's Lemma 2 steering
+    /// (Schedule::source_import_position with SCC-aware reverse)
+    /// gives entry an import order such that the ESM linker
+    /// resolves the cycle without TDZ.
     #[test]
-    fn cut_excludes_lazy_edges_in_mixed_cycle() {
-        // mod_0 owns A and readB; readB body returns B (lazy read).
-        // mod_1 owns B; B = A + 1 (at-init read of A).
-        // R-edge: mod_1 → mod_0 (kind = at-init, binding = A).
-        // L-edge: mod_0 → mod_1 (kind = lazy, binding = B).
+    fn mixed_cycle_without_at_init_call_is_realizable() {
+        // mod_0 owns A and readB; readB body returns B (lazy read,
+        // never invoked at-init). mod_1 owns B; B = A + 1
+        // (at-init read of A). Constraining subgraph: only
+        // mod_1 → mod_0 — acyclic. Relaxed clause-3 accepts.
         let module = parse("const A = 1; function readB() { return B; } const B = A + 1;");
         let facts = analyze_facts(&module);
         let mut binding_assignment = HashMap::new();
@@ -400,36 +401,12 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
-        assert_eq!(
-            report.cycles.len(),
-            1,
-            "expected one cycle, got {:?}",
+        let report = validate_schedule(&owner_graph, &partition, &render);
+        assert!(
+            report.cycles.is_empty(),
+            "mixed cycle with no at-init call should be realizable; got {:?}",
             report.cycles,
         );
-        let cycle = &report.cycles[0];
-        assert!(
-            cycle.evidence.iter().any(|e| e.kind == DepKind::LazyUse),
-            "evidence should include the lazy edge, got {:?}",
-            cycle.evidence,
-        );
-        assert!(
-            !cycle.cut.iter().any(|e| e.kind == DepKind::LazyUse),
-            "cut must not include lazy reasons, got {:?}",
-            cycle.cut,
-        );
-        assert_eq!(
-            cycle.cut.len(),
-            1,
-            "min cut for a single mixed cycle is one edge, got {:?}",
-            cycle.cut,
-        );
-        let entry = &cycle.cut[0];
-        assert_eq!(entry.from, "mod_1");
-        assert_eq!(entry.to, "mod_0");
-        assert_eq!(entry.binding.as_deref(), Some("A"));
-        assert_eq!(entry.kind, DepKind::EagerUse);
     }
 
     /// Verify that at-init call promotion materializes a promoted
@@ -494,8 +471,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
+        let report = validate_schedule(&owner_graph, &partition, &render);
         assert_eq!(
             report.cycles.len(),
             1,
@@ -529,8 +505,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
+        let report = validate_schedule(&owner_graph, &partition, &render);
         assert_eq!(report.cycles.len(), 1);
         let cycle = &report.cycles[0];
         assert!(
@@ -564,8 +539,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let graph = build_module_quotient(&owner_graph, &partition);
-        let report = validate_schedule(&graph, &render);
+        let report = validate_schedule(&owner_graph, &partition, &render);
         assert!(
             report.cycles.is_empty(),
             "lazy-only cycle is realizable; the gate must accept and emit no cycle (got {:?})",

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -46,6 +46,110 @@ mod tests {
         analyze_facts_with_hints(module, &AnalysisHints::default())
     }
 
+    /// A direct call `f()` at the chunk top level records `f` in the
+    /// statement's `at_init_calls` set. Drives at-init call promotion
+    /// per DESIGN.md "At-init call promotion".
+    #[test]
+    fn at_init_call_recorded() {
+        let module = parse("function f() {} f();");
+        let facts = analyze_facts(&module);
+        assert_eq!(facts.len(), 2);
+        // function decl: callee never recorded for the decl itself.
+        assert!(facts[0].at_init_calls.is_empty());
+        assert!(facts[0].body_calls.is_empty());
+        // call statement: f() is at-init, no body reads.
+        assert_eq!(facts[1].at_init_calls, BTreeSet::from(["f".to_string()]),);
+        assert!(facts[1].body_calls.is_empty());
+    }
+
+    /// A call inside a function body lives in `body_calls`, not
+    /// `at_init_calls`. The call only fires when the function is
+    /// invoked, so promotion treats it as a lazy edge of the
+    /// containing function.
+    #[test]
+    fn body_call_recorded() {
+        let module = parse("function f() { g(); } function g() {}");
+        let facts = analyze_facts(&module);
+        // f's decl: its body calls g lazily.
+        assert!(facts[0].at_init_calls.is_empty());
+        assert_eq!(facts[0].body_calls, BTreeSet::from(["g".to_string()]),);
+    }
+
+    /// Indirect calls (`const g = f; g()`) are skipped — the callee
+    /// isn't a direct Ident on the CallExpr. Conservative: the
+    /// proposer may miss promotion through this case.
+    #[test]
+    fn indirect_call_not_recorded() {
+        let module = parse("function f() {} const g = f; g();");
+        let facts = analyze_facts(&module);
+        // Last statement: `g()` records `g`, not `f`. (The aliasing
+        // is unmodeled; callee resolution only sees `g`.)
+        assert_eq!(facts[2].at_init_calls, BTreeSet::from(["g".to_string()]),);
+    }
+
+    /// Method calls (`obj.method()`) are skipped — callee is a
+    /// MemberExpr, not an Ident.
+    #[test]
+    fn method_call_not_recorded() {
+        let module = parse("const obj = {}; obj.method();");
+        let facts = analyze_facts(&module);
+        // Last statement: no at_init_calls. `obj` is still recorded
+        // as an eager read.
+        assert!(facts[1].at_init_calls.is_empty());
+        assert!(facts[1].eager_reads.contains("obj"));
+    }
+
+    /// Class static field initializers fire at-init (class evaluation
+    /// time). Calls in static initializers go into `at_init_calls`.
+    #[test]
+    fn class_static_init_call_is_at_init() {
+        let module = parse("function f() {} class C { static x = f(); }");
+        let facts = analyze_facts(&module);
+        assert_eq!(facts[1].at_init_calls, BTreeSet::from(["f".to_string()]),);
+        assert!(facts[1].body_calls.is_empty());
+    }
+
+    /// Class instance field initializers fire per-construction, not
+    /// at class-decl time. Calls inside them are `body_calls`,
+    /// matching how the existing read collectors treat instance
+    /// fields as lazy.
+    #[test]
+    fn class_instance_field_call_is_lazy() {
+        let module = parse("function f() {} class C { x = f(); }");
+        let facts = analyze_facts(&module);
+        assert!(facts[1].at_init_calls.is_empty());
+        assert_eq!(facts[1].body_calls, BTreeSet::from(["f".to_string()]),);
+    }
+
+    /// Nested calls in argument positions are still seen by the
+    /// collector. `console.log(readB())` records both `console` (in
+    /// eager_reads) and `readB` (in at_init_calls).
+    #[test]
+    fn nested_call_arguments_record_inner_callee() {
+        let module = parse("function readB() {} console.log(readB());");
+        let facts = analyze_facts(&module);
+        // The console.log statement: console is an eager read.
+        // readB is recorded as an at-init call. console.log is a
+        // method call, so it's NOT in at_init_calls.
+        assert!(facts[1].eager_reads.contains("console"));
+        assert_eq!(
+            facts[1].at_init_calls,
+            BTreeSet::from(["readB".to_string()]),
+        );
+    }
+
+    /// VarDecl-bound arrow functions participate in body_calls the
+    /// same way function declarations do. `const f = () => g()` is
+    /// a function carrier; the `g()` inside is lazy.
+    #[test]
+    fn vardecl_arrow_body_call_recorded() {
+        let module = parse("function g() {} const f = () => g();");
+        let facts = analyze_facts(&module);
+        // f's vardecl: g() is a lazy body call.
+        assert!(facts[1].at_init_calls.is_empty());
+        assert_eq!(facts[1].body_calls, BTreeSet::from(["g".to_string()]),);
+    }
+
     #[test]
     fn function_body_reads_are_lazy() {
         let module = parse("function f() { return X; } const Y = 1;");

--- a/devinfra/js/debundle/e2e/direct_status_overpromise_test.rs
+++ b/devinfra/js/debundle/e2e/direct_status_overpromise_test.rs
@@ -1,22 +1,28 @@
-//! RED test: pins a peelability analyzer over-promise bug.
+//! GREEN test (post-fix): pins that the peelability analyzer no
+//! longer over-promises a `direct` peel that the cycle gate refuses.
+//! Originally introduced as a RED pin alongside PR #1625; flipped in
+//! the same branch once the proposer was rerouted through the shared
+//! realizability primitive.
 //!
-//! **This test is intentionally failing.** It encodes the divergence
-//! between two predicates that the design says should agree:
+//! The two predicates the design says should agree are now backed by
+//! one implementation:
 //!
 //! 1. The peelability **proposer** (`evaluate_peel_candidate` in
-//!    `peelability.rs`) classifies a singleton residual owner `T`
-//!    as `PeelableNow` / `Direct` on the `residual_owner_horizon`.
+//!    `peelability.rs`) pushes the candidate's hypothetical
+//!    `MoveOwners` delta onto the shared `RealizabilityIndex`
+//!    (`devinfra/js/debundle/realizability.rs`) and reads the verdict.
 //! 2. The **cycle gate** (`validate_schedule` in `validation.rs`,
 //!    consumed by `materialize_logical_modules` in
-//!    `logical_modules.rs`) refuses the same peel when the spec
-//!    author actually assigns `T` to a fresh module — with a
-//!    constraining `<chunk_id>::anon_residual_sentinel → mod_t`
-//!    edge as cycle evidence.
+//!    `logical_modules.rs`) is unchanged in this PR but answers the
+//!    same three-clause validity predicate. With the proposer routed
+//!    through the same primitive, both sides cannot disagree on
+//!    whether a candidate peel produces a constraining cross-module
+//!    SCC.
 //!
-//! The proposer therefore **over-promises**: `direct` claims a peel
-//! is safe but materialization rejects it. The fix author flips the
-//! assertions in this test once the proposer's predicate is brought
-//! into line with the gate's invariant.
+//! For the synthetic shape in this file the proposer also catches a
+//! `BlockedResidualDependency` (the layered clause-1 check for moved
+//! at-init reads that would remain in the source destination), which
+//! is the assertion the post-fix `assert_ne!` rests on.
 //!
 //! ## What `direct` is supposed to mean
 //!
@@ -208,8 +214,16 @@ fn direct_status_is_emitted_for_target_binding_despite_gate_refusal() {
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let peelability = &graph.peelability;
 
-    // Bug pin 1: the analyzer emits the singleton candidate as
-    // PeelableNow. (Post-fix this should be BlockedCycle.)
+    // GREEN pin (post-fix): the analyzer no longer emits the
+    // singleton candidate as PeelableNow. With the proposer now
+    // routed through the realizability primitive (see
+    // `devinfra/js/debundle/realizability.rs` and the proposer
+    // reroute in `peelability.rs::evaluate_peel_candidate`), the
+    // proposer recognizes that moving `target_binding` alone would
+    // leave the at-init consumer with a constraining read into the
+    // residual source destination — surfaced as
+    // `BlockedResidualDependency` (the proposer's layered clause-1
+    // check) rather than `PeelableNow`.
     let target_candidate = peelability
         .evaluated_owner_sets
         .iter()
@@ -220,16 +234,16 @@ fn direct_status_is_emitted_for_target_binding_despite_gate_refusal() {
                 peelability.evaluated_owner_sets,
             )
         });
-    assert_eq!(
+    assert_ne!(
         target_candidate.status,
         PeelCandidateStatus::PeelableNow,
-        "RED pin: proposer currently over-claims target_binding peelable_now; \
-         flip this when the proposer is brought into line with the gate. \
+        "post-fix: proposer must not over-claim target_binding peelable_now \
+         (it has a residual-dependency blocker on the at-init consumer). \
          candidate: {target_candidate:#?}",
     );
 
-    // Bug pin 2: the residual horizon classifies target_binding as
-    // Direct. (Post-fix this should be Blocked or WithCompanions.)
+    // GREEN pin (post-fix): the residual horizon no longer
+    // classifies target_binding as Direct.
     let horizon = peelability
         .residual_owner_horizon
         .iter()
@@ -237,11 +251,10 @@ fn direct_status_is_emitted_for_target_binding_despite_gate_refusal() {
         .unwrap_or_else(|| {
             panic!("residual_owner_horizon must include target_binding: {peelability:#?}")
         });
-    assert_eq!(
+    assert_ne!(
         horizon.status,
         ResidualOwnerPeelStatus::Direct,
-        "RED pin: horizon currently classifies target_binding as Direct; \
-         flip this when the proposer is brought into line with the gate. \
+        "post-fix: horizon must not classify target_binding as Direct. \
          horizon entry: {horizon:#?}",
     );
 }

--- a/devinfra/js/debundle/e2e/peel_atomic_unit_test.rs
+++ b/devinfra/js/debundle/e2e/peel_atomic_unit_test.rs
@@ -180,9 +180,15 @@ export { anchor, C };
 /// `{A, B}` form a size-2 SCC.
 #[test]
 fn two_vertex_constraining_edge_scc_emits_two_owner_peel_candidate() {
+    // Note: no top-level `B()` call. After at-init call promotion
+    // (DESIGN.md "At-init call promotion") a top-level call to B
+    // would correctly merge the call statement into the atomic unit
+    // (B's body mutates A at-init), which the test would still pass
+    // as a 3-owner unit — but the historical assertion shape pinned
+    // a 2-owner unit. Keep the body-only shape so the test continues
+    // to cover the 2-vertex case it was authored for.
     let chunk_source = r#"var A = 1;
 function B() { A = 99; return A; }
-B();
 const Existing = "existing";
 console.log(Existing);
 export { A, B, Existing };

--- a/devinfra/js/debundle/e2e/peel_atomic_unit_test.rs
+++ b/devinfra/js/debundle/e2e/peel_atomic_unit_test.rs
@@ -245,6 +245,60 @@ export { A, B, Existing };
     }
 }
 
+/// At-init call promotion (DESIGN.md "At-init call promotion") makes
+/// a top-level `B()` call inherit `B`'s body's eager-rebind of `A`.
+/// `G_atomic` already symmetrizes `B`↔`A` (eager_rebind is
+/// bidirectional in the atomic-unit subgraph), and after promotion
+/// the at-init caller statement enters the same atomic SCC because
+/// the promoted edge (call-statement → A, eager_rebind) creates the
+/// bidirectional bond. The peel proposer therefore emits the
+/// 3-owner unit `{A, B, B()-call-statement}`, not the bare 2-vertex
+/// shape pinned by `two_vertex_constraining_edge_scc_emits_two_owner_peel_candidate`.
+#[test]
+fn atomic_unit_grows_when_at_init_call_promotes_rebind() {
+    let chunk_source = r#"var A = 1;
+function B() { A = 99; return A; }
+B();
+const Existing = "existing";
+console.log(Existing);
+export { A, B, Existing };
+"#;
+
+    let mut opts = FixtureOpts::new(
+        chunk_source,
+        vec![logical_module("existing", &[Member::new("Existing")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let fixture = run_fixture(opts);
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let peelability = &graph.peelability;
+
+    let ab_peel_sets: Vec<_> = peelability
+        .minimal_peel_sets
+        .iter()
+        .filter(|candidate| {
+            let names: BTreeSet<_> = candidate
+                .members
+                .iter()
+                .map(|m| m.binding.as_str())
+                .collect();
+            names == BTreeSet::from(["A", "B"])
+        })
+        .collect();
+    assert!(
+        !ab_peel_sets.is_empty(),
+        "minimal_peel_sets must include the unit covering {{A, B}}: {peelability:#?}",
+    );
+    let ab_peel = ab_peel_sets[0];
+    assert_eq!(
+        ab_peel.owner_ids.len(),
+        3,
+        "promotion must grow the unit to 3 owners (A, B, B() call): {ab_peel:#?}",
+    );
+}
+
 /// Positive: an atomic unit with only intra-residual *lazy* reads
 /// going out (no constraining out-edges to residual) is still
 /// `PeelableNow`. Per PR #1614's cycle-rule (constraining-edge

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -122,6 +122,13 @@ fn rejects_cycle_through_lazy_back_edge() {
     // `R` cross-module edge inside the SCC is enough for the
     // realizability gate to bail. (Without the bail the linker
     // would TDZ on B's initializer.)
+    //
+    // Per DESIGN.md "At-init call promotion", the proposer (via
+    // the realizability primitive's relaxed clause-3 rule) would
+    // accept this if the materializer steered the ESM linker's
+    // import order to make mod_a evaluate first. The materializer
+    // does not currently implement that steering (Lemma 2), so
+    // the validator stays on the strict rule and rejects.
     expect_rejection_containing_all(
         FixtureOpts::new(
             r#"const A = "a-value";

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -114,36 +114,31 @@ export { A, B, C, D };
 // --- I cycles via lazy back-edges ----------------------------------------
 
 #[test]
-fn rejects_cycle_through_lazy_back_edge() {
-    // mod_b reads A from mod_a at-init (B's initializer);
-    // mod_a's `readB` body reads B from mod_b lazily. `R` is
-    // acyclic by itself, but the SCC `{mod_a, mod_b}` in `I ∪ S`
-    // contains the at-init `mod_b → mod_a` edge — that single
-    // `R` cross-module edge inside the SCC is enough for the
-    // realizability gate to bail. (Without the bail the linker
-    // would TDZ on B's initializer.)
-    //
-    // Per DESIGN.md "At-init call promotion", the proposer (via
-    // the realizability primitive's relaxed clause-3 rule) would
-    // accept this if the materializer steered the ESM linker's
-    // import order to make mod_a evaluate first. The materializer
-    // does not currently implement that steering (Lemma 2), so
-    // the validator stays on the strict rule and rejects.
-    expect_rejection_containing_all(
-        FixtureOpts::new(
-            r#"const A = "a-value";
+fn mixed_cycle_with_lazy_back_edge_is_realizable() {
+    // mod_a imports B from mod_b (readB body's lazy read); mod_b
+    // imports A from mod_a (B's eager initializer). The imports
+    // graph `I` has a 2-cycle {mod_a, mod_b}, but the
+    // constraining-edge subgraph (drops LazyUse) is acyclic — only
+    // mod_b → mod_a constrains init order. The relaxed clause-3
+    // rule (DESIGN.md "Realizability primitive") accepts: per
+    // Lemma 2, the materializer's `source_import_position` puts
+    // mod_b (the cycle dependent) FIRST in entry's source, so the
+    // ESM linker's DFS unwinds the cycle through mod_a (the
+    // dependency) and post-DFS evaluation lands mod_a first. B's
+    // at-init read of A sees A defined.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const A = "a-value";
 function readB() { return B; }
 const B = A + "-postfix";
 console.log(readB());
 export { A, B, readB };
 "#,
-            vec![
-                logical_module("mod_a", &[Member::new("A"), Member::new("readB")]),
-                logical_module("mod_b", &[Member::new("B")]),
-            ],
-        ),
-        &["cycle", "mod_a", "mod_b"],
-    );
+        vec![
+            logical_module("mod_a", &[Member::new("A"), Member::new("readB")]),
+            logical_module("mod_b", &[Member::new("B")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "a-value-postfix\n");
 }
 
 #[test]
@@ -488,16 +483,20 @@ export { a, b, existing };
 
 #[test]
 fn owner_graph_report_is_written_before_rejection() {
+    // S-only cycle: three side-effecting writes interleaved across
+    // mod_a (ordinal 0, 2) and mod_b (ordinal 1). The constraining-
+    // edge subgraph has a bi-directional sequenced cycle that no
+    // entry-import order can resolve.
     let rejected = run_rejection_fixture(FixtureOpts::new(
-        r#"const A = "a-value";
-function readB() { return B; }
-const B = A + "-postfix";
-console.log(readB());
-export { A, B, readB };
+        r#"const a1 = (globalThis.tag = "a1", 1);
+const b1 = (globalThis.tag = "b1", 2);
+const a2 = (globalThis.tag = "a2", 3);
+console.log(a1, a2, b1, globalThis.tag);
+export { a1, a2, b1 };
 "#,
         vec![
-            logical_module("mod_a", &[Member::new("A"), Member::new("readB")]),
-            logical_module("mod_b", &[Member::new("B")]),
+            logical_module("mod_a", &[Member::new("a1"), Member::new("a2")]),
+            logical_module("mod_b", &[Member::new("b1")]),
         ],
     ));
     assert!(

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -38,6 +38,22 @@ pub struct StatementFacts {
     /// calls. Each binding is the class/prototype owner that must
     /// co-locate with the mutating statement.
     pub local_effects: BTreeSet<BindingName>,
+    /// Bare-identifier callees of `CallExpr` nodes seen at-init —
+    /// i.e. outside any function/arrow/method body. Used by the
+    /// owner-graph build to drive at-init call promotion: a call from
+    /// statement S to chunk-declared function `f` is treated as
+    /// transitively reading everything `f`'s body lazily reads. See
+    /// DESIGN.md "At-init call promotion". Indirect calls
+    /// (`const g = f; g()`), method calls (`obj.method()`), and
+    /// computed callees are skipped — the callee must be a direct
+    /// `Ident`.
+    pub at_init_calls: BTreeSet<BindingName>,
+    /// Same as `at_init_calls` but for calls inside lazy positions.
+    /// Used by the owner-graph build to reconstruct the chunk call
+    /// graph so that promotion can transitively follow call chains
+    /// (e.g. `function f() { g(); } f();` at top level promotes
+    /// through `g`'s body too).
+    pub body_calls: BTreeSet<BindingName>,
     pub purity: Purity,
     pub kind: StatementKind,
 }
@@ -355,6 +371,8 @@ fn analyze_item(
     item.visit_with(&mut lazy);
     let mut writes = BindingWriteCollector::default();
     item.visit_with(&mut writes);
+    let mut calls = CallCollector::default();
+    item.visit_with(&mut calls);
     let local_effects = collect_local_effects(item, &hints.known_effects);
     let purity = item_purity(
         item,
@@ -373,6 +391,8 @@ fn analyze_item(
         lazy_reads: lazy.names,
         lazy_rebinds: writes.lazy,
         local_effects,
+        at_init_calls: calls.at_init,
+        body_calls: calls.lazy,
         purity,
         kind,
     }
@@ -795,6 +815,73 @@ impl Visit for BindingWriteCollector {
         node.left.visit_with(self);
         node.right.visit_with(self);
         node.body.visit_with(self);
+    }
+
+    fn visit_function(&mut self, node: &Function) {
+        lazy_visit_function(self, node);
+    }
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        lazy_visit_arrow_expr(self, node);
+    }
+    fn visit_method_prop(&mut self, node: &MethodProp) {
+        lazy_visit_method_prop(self, node);
+    }
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        lazy_visit_getter_prop(self, node);
+    }
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        lazy_visit_setter_prop(self, node);
+    }
+
+    fn visit_class(&mut self, node: &Class) {
+        lazy_visit_class(self, node);
+    }
+
+    fn visit_class_member(&mut self, member: &ClassMember) {
+        lazy_visit_class_member(self, member);
+    }
+}
+
+/// Visitor that collects bare-identifier callees of `CallExpr` nodes,
+/// split by whether the call appears at-init (top-level chunk
+/// position, class static initializers) or only in a lazy position
+/// (function/arrow/method/getter/setter bodies, instance class fields,
+/// constructor bodies). Drives at-init call promotion in
+/// `build_owner_graph`: see DESIGN.md "At-init call promotion".
+///
+/// Only direct `f(...)` calls where the callee is an `Ident` are
+/// recorded. `obj.method()`, `(g)()`, `f()()`, computed callees, and
+/// `(const g = f, g)()` are skipped — interprocedural promotion only
+/// fires when the callee is statically a known chunk binding.
+#[derive(Default)]
+struct CallCollector {
+    at_init: BTreeSet<String>,
+    lazy: BTreeSet<String>,
+    in_lazy: bool,
+}
+
+impl LazyBoundary for CallCollector {
+    fn in_lazy_mut(&mut self) -> &mut bool {
+        &mut self.in_lazy
+    }
+}
+
+impl Visit for CallCollector {
+    fn visit_import_decl(&mut self, _node: &ImportDecl) {}
+    fn visit_named_export(&mut self, _node: &NamedExport) {}
+    fn visit_export_all(&mut self, _node: &ExportAll) {}
+
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if let Some(callee) = call_callee_ident(node) {
+            let bucket = if self.in_lazy {
+                &mut self.lazy
+            } else {
+                &mut self.at_init
+            };
+            bucket.insert(callee.to_string());
+        }
+        // Always recurse into args + callee so nested calls are seen.
+        node.visit_children_with(self);
     }
 
     fn visit_function(&mut self, node: &Function) {

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -1,5 +1,6 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
+use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
 use serde::{Deserialize, Serialize};
 
@@ -385,6 +386,27 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
         }
     }
 
+    // At-init call promotion (DESIGN.md "At-init call promotion").
+    //
+    // A function body's lazy reads/rebinds fire at-init from the
+    // perspective of any caller that invokes the function at-init.
+    // Without promotion, the realizability primitive's relaxed
+    // clause-3 predicate (constraining-edge subgraph has no
+    // multi-module SCC) is unsound for the canonical
+    // `console.log(readB())` shape: the lazy read inside `readB`'s
+    // body fires when the top-level call evaluates, but only the
+    // graph's lazy edge is recorded, so cross-module cycles that
+    // close through such a lazy edge look acyclic to the constraining
+    // subgraph. After promotion, the primitive's verdict is sound.
+    //
+    // Promoted edges are added at owner-graph level (partition-
+    // independent): intra-module promoted edges are dropped by the
+    // quotient automatically. Only direct `f(...)` callees that
+    // resolve to chunk-declared bindings are followed; indirect
+    // calls (`const g = f; g()`), method calls (`obj.method()`), and
+    // dynamic dispatch are conservatively unmodelled.
+    promote_at_init_calls(facts, &binding_table, &binding_owner, &mut raw_edges);
+
     // Side-effect ordering edges (`S` per DESIGN.md "Module dep
     // graphs"). At owner level, record the source-order chain over
     // side-effecting owners: every later side-effecting owner
@@ -449,6 +471,193 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
         edges,
         out_edges,
         in_edges,
+    }
+}
+
+/// Promote function-body lazy reads/rebinds to eager owner edges from
+/// every statement that at-init-calls the function. Transitive over
+/// the call graph among chunk-declared functions: a top-level
+/// `f()` whose `f` calls `g` in its body promotes through `g`'s lazy
+/// reads/rebinds too. See DESIGN.md "At-init call promotion".
+///
+/// Per-statement dedup: at most one promoted eager edge per
+/// (caller, target-owner) pair, and at most one promoted rebind edge
+/// per (caller, target-owner) pair. Without dedup, a single
+/// at-init call to a function with N transitive lazy reads would emit
+/// N edges from the caller, and multiple at-init calls in the same
+/// statement would multiply that further.
+fn promote_at_init_calls(
+    facts: &[StatementFacts],
+    binding_table: &BindingTable,
+    binding_owner: &[Option<OwnerId>],
+    raw_edges: &mut Vec<(OwnerId, OwnerId, EdgeReason)>,
+) {
+    // 1. Build the call graph: owner → owner edges for each
+    //    chunk-declared function callee reachable via body_calls.
+    //    Add every owner whose body has any lazy reads / rebinds /
+    //    calls as a node — those are the callable owners whose body
+    //    closures we may need to promote, even if the body itself
+    //    makes no calls (e.g. `function readB() { return B; }`).
+    let mut call_graph: DiGraphMap<OwnerId, ()> = DiGraphMap::new();
+    for stmt in facts {
+        let owner = OwnerId(stmt.ordinal.0);
+        if !stmt.body_calls.is_empty()
+            || !stmt.lazy_reads.is_empty()
+            || !stmt.lazy_rebinds.is_empty()
+        {
+            call_graph.add_node(owner);
+        }
+    }
+    for stmt in facts {
+        if stmt.body_calls.is_empty() {
+            continue;
+        }
+        let caller = OwnerId(stmt.ordinal.0);
+        for callee_name in &stmt.body_calls {
+            let Some(binding_id) = binding_table.get(callee_name) else {
+                continue;
+            };
+            let Some(Some(callee_owner)) = binding_owner.get(binding_id.0) else {
+                continue;
+            };
+            call_graph.add_node(*callee_owner);
+            call_graph.add_edge(caller, *callee_owner, ());
+        }
+    }
+    if call_graph.node_count() == 0 {
+        return;
+    }
+
+    // 2. Tarjan SCC. `tarjan_scc` returns SCCs in reverse topological
+    //    order: leaves (no outgoing edges to other SCCs) first.
+    let sccs = tarjan_scc(&call_graph);
+    let mut scc_of: BTreeMap<OwnerId, usize> = BTreeMap::new();
+    for (idx, scc) in sccs.iter().enumerate() {
+        for owner in scc {
+            scc_of.insert(*owner, idx);
+        }
+    }
+
+    // 3. Per-owner seeds: own lazy_reads / lazy_rebinds resolved to
+    //    BindingId. Filters out targets whose owner is a function
+    //    declaration — function bindings are hoisted at module
+    //    instantiation (Phase 1 of ESM linking), so a cross-module
+    //    read of a function never observes a TDZ. Promoting such
+    //    reads would spuriously close cycles for shapes like mutual
+    //    recursion across modules (`function even(){odd()}` /
+    //    `function odd(){even()}`), which are actually realizable.
+    //    Other declared kinds (VarDecl, ClassDecl) are kept: const /
+    //    let / class are TDZ-locked until their statement runs, so a
+    //    cross-module read inside an at-init-called function does
+    //    fire the realizability hazard. `var` is technically hoisted
+    //    too but is rare enough not to warrant a separate distinction
+    //    in StatementKind.
+    let mut stmt_by_owner: BTreeMap<OwnerId, &StatementFacts> = BTreeMap::new();
+    for stmt in facts {
+        stmt_by_owner.insert(OwnerId(stmt.ordinal.0), stmt);
+    }
+    let target_is_hoisted = |binding_id: BindingId| -> bool {
+        let Some(Some(target_owner)) = binding_owner.get(binding_id.0) else {
+            return false;
+        };
+        stmt_by_owner
+            .get(target_owner)
+            .map(|stmt| stmt.kind == StatementKind::FnDecl)
+            .unwrap_or(false)
+    };
+    let mut scc_reads: Vec<BTreeSet<BindingId>> = vec![BTreeSet::new(); sccs.len()];
+    let mut scc_rebinds: Vec<BTreeSet<BindingId>> = vec![BTreeSet::new(); sccs.len()];
+
+    // 4. Closure over the call graph. Iterate SCCs in
+    //    reverse-topological order (leaves first). For each SCC,
+    //    union members' own seeds plus successor SCC closures.
+    for (scc_idx, scc) in sccs.iter().enumerate() {
+        let mut reads: BTreeSet<BindingId> = BTreeSet::new();
+        let mut rebinds: BTreeSet<BindingId> = BTreeSet::new();
+        for owner in scc {
+            let Some(stmt) = stmt_by_owner.get(owner) else {
+                continue;
+            };
+            for name in &stmt.lazy_reads {
+                if let Some(id) = binding_table.get(name)
+                    && !target_is_hoisted(id)
+                {
+                    reads.insert(id);
+                }
+            }
+            for name in &stmt.lazy_rebinds {
+                if let Some(id) = binding_table.get(name) {
+                    rebinds.insert(id);
+                }
+            }
+        }
+        for owner in scc {
+            for (_, target, _) in call_graph.edges(*owner) {
+                let Some(&target_scc) = scc_of.get(&target) else {
+                    continue;
+                };
+                if target_scc == scc_idx {
+                    continue;
+                }
+                reads.extend(&scc_reads[target_scc]);
+                rebinds.extend(&scc_rebinds[target_scc]);
+            }
+        }
+        scc_reads[scc_idx] = reads;
+        scc_rebinds[scc_idx] = rebinds;
+    }
+
+    // 5. Emit promoted edges with per-statement, per-kind dedup.
+    for stmt in facts {
+        if stmt.at_init_calls.is_empty() {
+            continue;
+        }
+        let caller = OwnerId(stmt.ordinal.0);
+        let mut promoted_read_targets: BTreeSet<OwnerId> = BTreeSet::new();
+        let mut promoted_rebind_targets: BTreeSet<OwnerId> = BTreeSet::new();
+        for callee_name in &stmt.at_init_calls {
+            let Some(callee_binding) = binding_table.get(callee_name) else {
+                continue;
+            };
+            let Some(Some(callee_owner)) = binding_owner.get(callee_binding.0) else {
+                continue;
+            };
+            let Some(&scc_idx) = scc_of.get(callee_owner) else {
+                continue;
+            };
+            for &target_binding in &scc_reads[scc_idx] {
+                let Some(Some(target_owner)) = binding_owner.get(target_binding.0) else {
+                    continue;
+                };
+                if caller == *target_owner {
+                    continue;
+                }
+                if !promoted_read_targets.insert(*target_owner) {
+                    continue;
+                }
+                raw_edges.push((
+                    caller,
+                    *target_owner,
+                    EdgeReason::eager_use(stmt.ordinal, target_binding),
+                ));
+            }
+            for &target_binding in &scc_rebinds[scc_idx] {
+                let Some(Some(target_owner)) = binding_owner.get(target_binding.0) else {
+                    continue;
+                };
+                if caller == *target_owner {
+                    continue;
+                }
+                if !promoted_rebind_targets.insert(*target_owner) {
+                    continue;
+                }
+                raw_edges.push((
+                    caller,
+                    *target_owner,
+                    EdgeReason::eager_rebind(stmt.ordinal, target_binding),
+                ));
+            }
+        }
     }
 }
 

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -22,6 +22,7 @@ mod ids;
 mod partition;
 mod peelability;
 mod purity;
+mod realizability;
 mod report_schema;
 mod reports;
 mod schedule;
@@ -50,6 +51,10 @@ pub use partition::Partition;
 pub use purity::{
     Purity, PurityReason, PurityRule, RedundantPureMemberHint, RedundantPureMemberReason,
     RedundantPurityHint, RedundantPurityReason,
+};
+pub use realizability::{
+    CrossRebindEdge, DeltaHandle, PartitionDelta, RealizabilityIndex, RealizabilityVerdict,
+    UnrealizableScc, check_realizability,
 };
 pub use report_schema::{
     BindingReport, EvaluatedPeelCandidateReport, FactorizeCell, FactorizeDiagnostic,

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1595,8 +1595,10 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
                 declaration_by_name,
                 binding_assignment,
                 &entry_exports_by_original_local,
-                runtime_import_facts,
-                &local_renames,
+                RuntimeImportLookup {
+                    imports: runtime_import_facts,
+                    heuristic_renames: &local_renames,
+                },
             )
         });
         let mut module_import_renames = BTreeMap::<String, String>::new();
@@ -2652,6 +2654,19 @@ fn collect_imported_reexports_by_module(
     by_module
 }
 
+/// Bundle of the two sources `plan_module_reference_needs` consults
+/// for runtime reimports. `imports.imports` is keyed by original
+/// locals (built before naturalization); `heuristic_renames`
+/// (original_local → post-rename local, produced by
+/// `naturalize_module_body`) provides the reverse lookup when the
+/// body has been renamed. The long-term fix is the
+/// collect→validate→execute-once rename pipeline tracked in
+/// <devinfra/js/debundle/TODO.md> ("Rename pipeline").
+struct RuntimeImportLookup<'a> {
+    imports: &'a RuntimeImportFacts,
+    heuristic_renames: &'a BTreeMap<String, String>,
+}
+
 fn plan_module_reference_needs<'a>(
     module_index: usize,
     body_facts: &ModuleBodyFacts,
@@ -2659,15 +2674,7 @@ fn plan_module_reference_needs<'a>(
     declaration_by_name: &BTreeMap<String, usize>,
     binding_assignment: &BTreeMap<String, usize>,
     entry_exports_by_original_local: &BTreeMap<String, EntryExport>,
-    runtime_import_facts: &'a RuntimeImportFacts,
-    // original_local → post-rename local, produced by naturalize_module_body.
-    // `runtime_import_facts.imports` is keyed by original locals (built before
-    // naturalization), but `body_facts.referenced_idents` is post-rename, so
-    // direct lookup misses for any binding the naturalizer touched. Threading
-    // this in is a defensive bridge between two rename eras; the long-term fix
-    // is the collect→validate→execute-once rename pipeline tracked in
-    // <devinfra/js/debundle/TODO.md> ("Rename pipeline").
-    heuristic_renames: &BTreeMap<String, String>,
+    runtime_imports: RuntimeImportLookup<'a>,
 ) -> ModuleReferenceNeeds<'a> {
     let mut needs = ModuleReferenceNeeds::default();
     for name in &body_facts.referenced_idents {
@@ -2710,11 +2717,12 @@ fn plan_module_reference_needs<'a>(
         // `RuntimeImportInfo` keeps `imported = "sA"`, so emit produces
         // `import { sA as propKeyA } from "<src>"` via
         // `runtime_reimport_specifier`'s local-vs-imported branch.
-        let info = runtime_import_facts.imports.get(name).or_else(|| {
-            heuristic_renames
+        let info = runtime_imports.imports.imports.get(name).or_else(|| {
+            runtime_imports
+                .heuristic_renames
                 .iter()
                 .find(|(_, post)| post.as_str() == name)
-                .and_then(|(pre, _)| runtime_import_facts.imports.get(pre))
+                .and_then(|(pre, _)| runtime_imports.imports.imports.get(pre))
         });
         if let Some(info) = info {
             needs.runtime_reimports.insert(name.clone(), info);

--- a/devinfra/js/debundle/logical_modules.rs
+++ b/devinfra/js/debundle/logical_modules.rs
@@ -1455,13 +1455,16 @@ fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
             import_decl_for_plan(entry_file, &plan.target_file, &resolved),
         ));
     }
-    // Sort the (plan-order-disambiguated) imports by linker_order
-    // so the first import in the entry source corresponds to the
-    // earliest-in-L provider. Stable sort preserves plan-order for
-    // ties (e.g. when two providers have no dep-graph relation).
+    // Sort entry imports by Schedule::source_import_position, which
+    // implements Lemma 2 (DESIGN.md "The realizability theorem"):
+    // for acyclic imports graphs the order matches linker_order
+    // (dependency-first source), but for cyclic-I shapes accepted
+    // by the relaxed clause-3 rule the SCC members are reverse-
+    // sorted so DFS unwinds the dependency first in post-order.
+    // Stable sort preserves plan-order for ties.
     entry_imports.sort_by_key(|(idx, _)| {
         schedule
-            .linker_position(ModuleId(LogicalModuleIndex(*idx)))
+            .source_import_position(ModuleId(LogicalModuleIndex(*idx)))
             .unwrap_or(usize::MAX)
     });
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();

--- a/devinfra/js/debundle/peelability.rs
+++ b/devinfra/js/debundle/peelability.rs
@@ -1,9 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use petgraph::algo::tarjan_scc;
 use petgraph::graph::DiGraph;
 
 use crate::graph::OwnerEdge;
+use crate::realizability::{PartitionDelta, RealizabilityIndex};
 use crate::reports::{
     binding_reports, is_residual_destination, module_id_from_key, module_report_ref, owner_key,
 };
@@ -14,64 +16,28 @@ use crate::{
     ResidualOwnerPeelHorizonReport, ResidualOwnerPeelStatus, Schedule, compute_atomic_units,
 };
 
-#[derive(Debug, Clone, Default)]
-struct CandidateEdgeAccumulator {
-    constraining_owner_edge_indices: Vec<usize>,
-    constrains_init_order: bool,
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-enum CandidateEdgeDirection {
-    FromCandidate,
-    ToCandidate,
-}
-
-#[derive(Debug, Clone)]
-struct CandidateIncidentEdge {
-    direction: CandidateEdgeDirection,
-    module_idx: usize,
-    constraining_owner_edge_indices: Vec<usize>,
-    constrains_init_order: bool,
-}
-
-#[derive(Debug, Clone, Default)]
-struct ModulePairTotals {
-    constraining_reason_count: usize,
-    constraining_owner_edge_indices: Vec<usize>,
-}
-
-#[derive(Debug, Clone)]
-struct ModuleAdjEdge {
-    pair: (ModuleId, ModuleId),
-    target_idx: usize,
-}
-
-#[derive(Debug, Clone)]
-struct ReverseModuleAdjEdge {
-    pair: (ModuleId, ModuleId),
-    source_idx: usize,
-}
-
 pub(crate) struct PeelabilityContext<'a> {
     owner_edges: &'a [OwnerEdge],
     owner_out_edges: Vec<Vec<usize>>,
-    owner_in_edges: Vec<Vec<usize>>,
-    module_index: HashMap<ModuleId, usize>,
-    modules: Vec<ModuleId>,
-    forward_edges: Vec<Vec<ModuleAdjEdge>>,
-    reverse_edges: Vec<Vec<ReverseModuleAdjEdge>>,
-    module_pair_totals: HashMap<(ModuleId, ModuleId), ModulePairTotals>,
     /// Atomic units of the schedule's owner graph (SCCs of the
     /// constraining-edge subgraph `G_atomic`). Used by
-    /// `candidate_atomic_unit_split_edge_indices` to detect candidates
-    /// whose moved set would split an atomic unit across modules.
+    /// `residual_atomic_unit_candidates` to enumerate multi-owner
+    /// candidates.
     atomic_units: Vec<AtomicUnit>,
-}
-
-#[derive(Debug, Clone, Default)]
-struct CandidateGraphAdjustment {
-    removed_constraining_reason_count: HashMap<(ModuleId, ModuleId), usize>,
-    removed_owner_edge_indices: HashSet<usize>,
+    /// Single shared implementation of the validity predicate
+    /// (DESIGN.md "Realizability primitive"). `evaluate_peel_candidate`
+    /// pushes the candidate's hypothetical move onto this index, reads
+    /// the verdict, then undoes — using the same primitive the
+    /// validator runs against the actual partition. `RefCell` for
+    /// interior mutability so call sites that thread `&context` don't
+    /// need to be re-plumbed for `&mut`.
+    realizability: RefCell<RealizabilityIndex<'a>>,
+    /// Sentinel `ModuleId` reserved for the candidate's hypothetical
+    /// destination. Picked above any logical-module index that
+    /// currently appears in the chunk's partition or its logical
+    /// module list, so pushing `MoveOwners { to: fresh_destination }`
+    /// guarantees a brand-new node in the post-peel quotient.
+    fresh_destination: ModuleId,
 }
 
 #[derive(Debug, Clone)]
@@ -351,98 +317,58 @@ fn residual_declared_for_owner(schedule: &Schedule, node: &OwnerNode) -> Vec<Bin
 
 impl<'a> PeelabilityContext<'a> {
     pub(crate) fn new(
-        schedule: &Schedule,
+        schedule: &'a Schedule,
         owner_edges: &'a [OwnerEdge],
         quotient_edges: &[QuotientEdgeReport],
     ) -> Self {
-        let mut modules = BTreeSet::<ModuleId>::new();
-        for idx in 0..schedule.logical_modules.len() {
-            modules.insert(ModuleId(LogicalModuleIndex(idx)));
-        }
-        for (_, module) in schedule.partition.iter() {
-            modules.insert(module);
-        }
-        for edge in quotient_edges {
-            if let Some(source) = module_id_from_key(&edge.source) {
-                modules.insert(source);
-            }
-            if let Some(target) = module_id_from_key(&edge.target) {
-                modules.insert(target);
-            }
-        }
-        let modules: Vec<ModuleId> = modules.into_iter().collect();
-        let module_index: HashMap<ModuleId, usize> = modules
-            .iter()
-            .copied()
-            .enumerate()
-            .map(|(idx, id)| (id, idx))
-            .collect();
-
         let owner_count = schedule.owner_graph.nodes.len();
         let mut owner_out_edges = vec![Vec::new(); owner_count];
-        let mut owner_in_edges = vec![Vec::new(); owner_count];
-        let mut module_pair_totals = HashMap::<(ModuleId, ModuleId), ModulePairTotals>::new();
         for (idx, edge) in owner_edges.iter().enumerate() {
             if let Some(indices) = owner_out_edges.get_mut(edge.from.0) {
                 indices.push(idx);
             }
-            if let Some(indices) = owner_in_edges.get_mut(edge.to.0) {
-                indices.push(idx);
-            }
-
-            if schedule.owner_graph.node(edge.from).is_none()
-                || schedule.owner_graph.node(edge.to).is_none()
-            {
-                continue;
-            }
-            let from = schedule.partition.of(edge.from);
-            let to = schedule.partition.of(edge.to);
-            if from == to {
-                continue;
-            }
-            if edge.reason.constrains_init_order() {
-                let totals = module_pair_totals.entry((from, to)).or_default();
-                totals.constraining_reason_count += 1;
-                totals.constraining_owner_edge_indices.push(idx);
-            }
-        }
-
-        let mut forward_edges = vec![Vec::new(); modules.len()];
-        let mut reverse_edges = vec![Vec::new(); modules.len()];
-        for &(source, target) in module_pair_totals.keys() {
-            let Some(&source_idx) = module_index.get(&source) else {
-                continue;
-            };
-            let Some(&target_idx) = module_index.get(&target) else {
-                continue;
-            };
-            forward_edges[source_idx].push(ModuleAdjEdge {
-                pair: (source, target),
-                target_idx,
-            });
-            reverse_edges[target_idx].push(ReverseModuleAdjEdge {
-                pair: (source, target),
-                source_idx,
-            });
         }
 
         let atomic_units = compute_atomic_units(&schedule.owner_graph);
 
+        // The realizability primitive is the single shared
+        // implementation of clause 3 (and clause 2). The candidate
+        // evaluator pushes a hypothetical destination move onto this
+        // index and reads the verdict — the same verdict the
+        // validator would produce for the post-peel partition.
+        let realizability =
+            RealizabilityIndex::from_partition(&schedule.owner_graph, schedule.partition.clone());
+
+        // Reserve a module-id one past every index currently in use,
+        // so the candidate's hypothetical destination is a fresh node
+        // in the post-peel quotient. We include logical modules, the
+        // partition's actual assignments, and any module-id that
+        // appears in the quotient-edges report — covering synthesized
+        // residual sentinels and external/vendor modules.
+        let mut max_index = schedule.logical_modules.len();
+        for (_, module) in schedule.partition.iter() {
+            max_index = max_index.max(module.0.0 + 1);
+        }
+        for edge in quotient_edges {
+            for module in [
+                module_id_from_key(&edge.source),
+                module_id_from_key(&edge.target),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                max_index = max_index.max(module.0.0 + 1);
+            }
+        }
+        let fresh_destination = ModuleId(LogicalModuleIndex(max_index));
+
         Self {
             owner_edges,
             owner_out_edges,
-            owner_in_edges,
-            module_index,
-            modules,
-            forward_edges,
-            reverse_edges,
-            module_pair_totals,
             atomic_units,
+            realizability: RefCell::new(realizability),
+            fresh_destination,
         }
-    }
-
-    fn module_idx(&self, module: ModuleId) -> Option<usize> {
-        self.module_index.get(&module).copied()
     }
 
     fn owner_out_edge_indices(&self, owner_id: OwnerId) -> &[usize] {
@@ -450,29 +376,6 @@ impl<'a> PeelabilityContext<'a> {
             .get(owner_id.0)
             .map(Vec::as_slice)
             .unwrap_or(&[])
-    }
-
-    fn owner_in_edge_indices(&self, owner_id: OwnerId) -> &[usize] {
-        self.owner_in_edges
-            .get(owner_id.0)
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
-    }
-
-    fn current_edge_constrains(
-        &self,
-        pair: (ModuleId, ModuleId),
-        adjustment: &CandidateGraphAdjustment,
-    ) -> bool {
-        let Some(totals) = self.module_pair_totals.get(&pair) else {
-            return false;
-        };
-        let removed = adjustment
-            .removed_constraining_reason_count
-            .get(&pair)
-            .copied()
-            .unwrap_or(0);
-        totals.constraining_reason_count > removed
     }
 }
 
@@ -734,6 +637,13 @@ fn sorted_owner_pair(left: OwnerId, right: OwnerId) -> (OwnerId, OwnerId) {
     }
 }
 
+/// Classify a candidate peel — its yes/no, plus the owner-edge
+/// evidence consumers need for diagnostics. The verdict comes from
+/// the realizability primitive (DESIGN.md "Realizability primitive"
+/// and "Residual peel candidates"): push the hypothetical
+/// `MoveOwners` delta onto the shared index, read the verdict, undo.
+/// The same primitive backs the validator, so a `PeelableNow` here is
+/// a `PeelableNow` at the gate.
 pub(crate) fn evaluate_peel_candidate(
     schedule: &Schedule,
     context: &PeelabilityContext<'_>,
@@ -743,33 +653,89 @@ pub(crate) fn evaluate_peel_candidate(
     let moved_owners: BTreeSet<OwnerId> = owner_ids.iter().copied().collect();
     let owner_id_keys: Vec<String> = owner_ids.iter().copied().map(owner_key).collect();
     let candidate_id = format!("peel_candidate:{}", owner_id_keys.join("+"));
+
+    // Clause-1-shaped diagnostic: surface owners the candidate
+    // at-init-reads that would remain in the source destination after
+    // the peel. Layered on top of the realizability verdict because
+    // the primitive does not predict the materializer's emit policy
+    // (DESIGN.md "Emit-side responsibilities"); this stays the
+    // proposer's stricter check that flags "the moved module would
+    // need to import a same-destination at-init read", driving the
+    // residual-dependency-closure candidate family.
     let residual_dependency_blocker_owner_ids =
         candidate_source_destination_blocker_owner_ids(schedule, context, &moved_owners);
-    let has_residual_dependency = !residual_dependency_blocker_owner_ids.is_empty();
-    let atomic_unit_split_edge_indices =
-        candidate_atomic_unit_split_edge_indices(context, &moved_owners);
-    let constraining_owner_edge_indices = if has_residual_dependency {
-        BTreeSet::new()
-    } else if !atomic_unit_split_edge_indices.is_empty() {
-        atomic_unit_split_edge_indices
-    } else {
-        let (candidate_edges, adjustment) =
-            candidate_incident_edges(schedule, context, &moved_owners);
-        candidate_blocking_scc_owner_edge_indices(context, &candidate_edges, &adjustment)
-    };
+    if !residual_dependency_blocker_owner_ids.is_empty() {
+        return PeelCandidateEvaluation {
+            id: candidate_id,
+            status: PeelCandidateStatus::BlockedResidualDependency,
+            owner_ids: owner_ids.to_vec(),
+            members: declared,
+            constraining_owner_edge_indices: BTreeSet::new(),
+            residual_dependency_blocker_owner_ids,
+        };
+    }
 
-    // The emit step (`materialize_logical_modules`) is responsible
-    // for ensuring every cross-destination read in a peel resolves
-    // to an exported binding: when a moved body lazily reads a
-    // residual entry binding that isn't currently exported, emit
-    // grows entry's export list to include it. The proposer therefore
-    // does NOT model an emit-resolvability blocker — proposing the
-    // peel is always safe (DESIGN.md "Valid peels and atomic modules",
-    // importability clause: residual entry bindings are importable
-    // because the emitter auto-exports them on demand).
-    let status = if has_residual_dependency {
-        PeelCandidateStatus::BlockedResidualDependency
-    } else if !constraining_owner_edge_indices.is_empty() {
+    // Atomic-unit-split check: the materializer's
+    // `assembly_conflicts` enforcement (per DESIGN.md
+    // "Factorization proposals") rejects any spec that splits an
+    // atomic unit across destination modules. `G_atomic`
+    // (`compute_atomic_units`) symmetrizes `LocalEffect` and rebind
+    // edges, so an SCC there does not always show up as a multi-
+    // module SCC in the literal constraining-edge quotient the
+    // realizability primitive walks. Layer this check on top of
+    // the verdict so a candidate that would split a unit is
+    // surfaced as `BlockedCycle` with the unit's intra-edges as
+    // evidence, matching how the pre-unification proposer behaved.
+    let atomic_unit_split = candidate_atomic_unit_split_edge_indices(context, &moved_owners);
+    if !atomic_unit_split.is_empty() {
+        return PeelCandidateEvaluation {
+            id: candidate_id,
+            status: PeelCandidateStatus::BlockedCycle,
+            owner_ids: owner_ids.to_vec(),
+            members: declared,
+            constraining_owner_edge_indices: atomic_unit_split,
+            residual_dependency_blocker_owner_ids: Vec::new(),
+        };
+    }
+
+    // Push the hypothetical move, read the verdict against the
+    // post-peel partition, undo. This is the same predicate the
+    // validator runs — so a candidate classified `PeelableNow` here
+    // does not get rejected by the gate at materialization.
+    let fresh = context.fresh_destination;
+    let verdict = context.realizability.borrow_mut().scoped(
+        PartitionDelta::MoveOwners {
+            owners: owner_ids.to_vec(),
+            to: fresh,
+        },
+        |idx| idx.verdict(),
+    );
+
+    // Only SCCs that include the candidate's hypothetical destination
+    // are caused by *this* peel. Other unrealizable SCCs in the
+    // post-peel quotient are pre-existing problems unrelated to the
+    // candidate (DESIGN.md: "intentionally ignores unrelated
+    // pre-existing bad SCCs"). Same for cross-rebinds — only flag
+    // those that cross the candidate's destination.
+    let mut constraining_owner_edge_indices = BTreeSet::<usize>::new();
+    let mut touches_candidate = false;
+    for scc in &verdict.unrealizable_sccs {
+        if !scc.modules.contains(&fresh) {
+            continue;
+        }
+        touches_candidate = true;
+        for owner_edge_id in &scc.constraining_owner_edges {
+            constraining_owner_edge_indices.insert(owner_edge_id.0);
+        }
+    }
+    for rebind in &verdict.cross_rebinds {
+        if rebind.from == fresh || rebind.to == fresh {
+            touches_candidate = true;
+            constraining_owner_edge_indices.insert(rebind.owner_edge.0);
+        }
+    }
+
+    let status = if touches_candidate {
         PeelCandidateStatus::BlockedCycle
     } else {
         PeelCandidateStatus::PeelableNow
@@ -781,21 +747,21 @@ pub(crate) fn evaluate_peel_candidate(
         owner_ids: owner_ids.to_vec(),
         members: declared,
         constraining_owner_edge_indices,
-        residual_dependency_blocker_owner_ids,
+        residual_dependency_blocker_owner_ids: Vec::new(),
     }
 }
 
-/// Per-candidate atomic-unit check: returns the constraining owner-edge
-/// indices for every atomic unit the candidate would split across
-/// modules (at least one member moved, at least one not). Within a
-/// split unit, "constraining" means every edge with both endpoints in
-/// the unit whose `DepKind` isn't `LazyUse`. This subsumes the prior
-/// rebind-only cross-destination check: rebind edges already make
-/// `G_atomic` bidirectional between their endpoints, so any
-/// cross-boundary rebind pair was a unit split — but the unified check
-/// also catches EagerUse cycles that span the candidate boundary.
-/// `candidate_blocking_scc_owner_edge_indices` covers those too, so
-/// the verdict (Peelable / Blocked) is unchanged.
+/// Per-candidate atomic-unit-split check. Returns the constraining
+/// owner-edge indices for every atomic unit the candidate would split
+/// across modules (at least one member moved, at least one not).
+///
+/// Layered on top of the realizability primitive because `G_atomic`
+/// symmetrizes `LocalEffect` and rebind edges (see
+/// `compute_atomic_units`), so a split that the materializer's
+/// `assembly_conflicts` enforcement would reject does not always
+/// surface as a multi-module SCC in the literal constraining-edge
+/// quotient the primitive walks. Mirrors the pre-unification proposer
+/// behaviour exactly.
 fn candidate_atomic_unit_split_edge_indices(
     context: &PeelabilityContext<'_>,
     moved_owners: &BTreeSet<OwnerId>,
@@ -866,193 +832,4 @@ fn candidate_source_destination_blocker_owner_ids(
         }
     }
     blockers.into_iter().collect()
-}
-
-fn candidate_incident_edges(
-    schedule: &Schedule,
-    context: &PeelabilityContext<'_>,
-    moved_owners: &BTreeSet<OwnerId>,
-) -> (Vec<CandidateIncidentEdge>, CandidateGraphAdjustment) {
-    let mut edge_indices = BTreeSet::new();
-    for owner_id in moved_owners {
-        edge_indices.extend(context.owner_out_edge_indices(*owner_id).iter().copied());
-        edge_indices.extend(context.owner_in_edge_indices(*owner_id).iter().copied());
-    }
-
-    let mut adjustment = CandidateGraphAdjustment::default();
-    let mut accum = HashMap::<(CandidateEdgeDirection, ModuleId), CandidateEdgeAccumulator>::new();
-    let mut seen_side_effect_candidate_pairs = HashSet::<(CandidateEdgeDirection, ModuleId)>::new();
-
-    for edge_idx in edge_indices {
-        let edge = &context.owner_edges[edge_idx];
-        adjustment.removed_owner_edge_indices.insert(edge_idx);
-
-        if schedule.owner_graph.node(edge.from).is_none()
-            || schedule.owner_graph.node(edge.to).is_none()
-        {
-            continue;
-        }
-        let old_from = schedule.partition.of(edge.from);
-        let old_to = schedule.partition.of(edge.to);
-        if old_from != old_to && edge.reason.constrains_init_order() {
-            *adjustment
-                .removed_constraining_reason_count
-                .entry((old_from, old_to))
-                .or_insert(0) += 1;
-        }
-
-        let from_moved = moved_owners.contains(&edge.from);
-        let to_moved = moved_owners.contains(&edge.to);
-        if from_moved == to_moved {
-            continue;
-        }
-        let (direction, module) = if from_moved {
-            (CandidateEdgeDirection::FromCandidate, old_to)
-        } else {
-            (CandidateEdgeDirection::ToCandidate, old_from)
-        };
-        if edge.reason.is_sequenced()
-            && !seen_side_effect_candidate_pairs.insert((direction, module))
-        {
-            continue;
-        }
-        let entry = accum.entry((direction, module)).or_default();
-        if edge.reason.constrains_init_order() {
-            entry.constraining_owner_edge_indices.push(edge_idx);
-        }
-        entry.constrains_init_order |= edge.reason.constrains_init_order();
-    }
-
-    let mut candidate_edges = Vec::new();
-    for ((direction, module), entry) in accum {
-        let Some(module_idx) = context.module_idx(module) else {
-            continue;
-        };
-        candidate_edges.push(CandidateIncidentEdge {
-            direction,
-            module_idx,
-            constraining_owner_edge_indices: entry.constraining_owner_edge_indices,
-            constrains_init_order: entry.constrains_init_order,
-        });
-    }
-
-    (candidate_edges, adjustment)
-}
-
-/// Find the candidate's blocking SCC over the **constraining-edge
-/// subgraph** of the post-peel module quotient — not over the full
-/// quotient including lazy edges.
-///
-/// Per `DESIGN.md` "Valid peels and atomic modules": "Lazy read edges
-/// are non-constraining: they still contribute imports, but a cycle
-/// made entirely of lazy read edges is realizable." Equivalently, a
-/// peel is realizable iff the constraining-edge subgraph of the
-/// post-peel quotient contains no multi-module SCC that touches the
-/// candidate. A mixed cycle whose constraining edges form a DAG
-/// (e.g. `residual → P` eager + `P → residual` lazy) is realizable
-/// because ESM cycle resolution evaluates the hoisted/lazy side
-/// first, so the eager side never observes a TDZ.
-///
-/// This is consistent with `compute_atomic_units`, which builds
-/// `G_atomic` from constraining edges only. The previous
-/// implementation walked reachability over all edges (lazy plus eager
-/// plus sequenced plus rebind plus local-effect), which falsely
-/// flagged any pure-function/var/class owner in residual that had a
-/// single intra-residual lazy out-edge plus any eager-use incoming
-/// edges as `BlockedCycle`. Concretely: a Tana chunk's residual is
-/// full of mutual lazy reads, so almost every pure top-level
-/// declaration in residual with both incoming eager use and any lazy
-/// out-edge to residual ended up `BlockedCycle` with empty
-/// `peel_set_ids`.
-fn candidate_blocking_scc_owner_edge_indices(
-    context: &PeelabilityContext<'_>,
-    candidate_edges: &[CandidateIncidentEdge],
-    adjustment: &CandidateGraphAdjustment,
-) -> BTreeSet<usize> {
-    let mut forward = vec![false; context.modules.len()];
-    let mut backward = vec![false; context.modules.len()];
-    let mut queue = VecDeque::new();
-    for edge in candidate_edges.iter().filter(|edge| {
-        edge.direction == CandidateEdgeDirection::FromCandidate && edge.constrains_init_order
-    }) {
-        if !forward[edge.module_idx] {
-            forward[edge.module_idx] = true;
-            queue.push_back(edge.module_idx);
-        }
-    }
-    while let Some(source_idx) = queue.pop_front() {
-        for edge in &context.forward_edges[source_idx] {
-            if !context.current_edge_constrains(edge.pair, adjustment) {
-                continue;
-            }
-            if !forward[edge.target_idx] {
-                forward[edge.target_idx] = true;
-                queue.push_back(edge.target_idx);
-            }
-        }
-    }
-
-    queue.clear();
-    for edge in candidate_edges.iter().filter(|edge| {
-        edge.direction == CandidateEdgeDirection::ToCandidate && edge.constrains_init_order
-    }) {
-        if !backward[edge.module_idx] {
-            backward[edge.module_idx] = true;
-            queue.push_back(edge.module_idx);
-        }
-    }
-    while let Some(target_idx) = queue.pop_front() {
-        for edge in &context.reverse_edges[target_idx] {
-            if !context.current_edge_constrains(edge.pair, adjustment) {
-                continue;
-            }
-            if !backward[edge.source_idx] {
-                backward[edge.source_idx] = true;
-                queue.push_back(edge.source_idx);
-            }
-        }
-    }
-
-    let mut in_scc = vec![false; context.modules.len()];
-    let mut has_cycle = false;
-    for idx in 0..context.modules.len() {
-        in_scc[idx] = forward[idx] && backward[idx];
-        has_cycle |= in_scc[idx];
-    }
-    if !has_cycle {
-        return BTreeSet::new();
-    }
-
-    let mut constraining_owner_edge_ids = BTreeSet::new();
-
-    for edge in candidate_edges {
-        if !in_scc[edge.module_idx] {
-            continue;
-        }
-        if edge.constrains_init_order {
-            constraining_owner_edge_ids
-                .extend(edge.constraining_owner_edge_indices.iter().copied());
-        }
-    }
-
-    for (source_idx, module_edges) in context.forward_edges.iter().enumerate() {
-        if !in_scc[source_idx] {
-            continue;
-        }
-        for edge in module_edges {
-            if !in_scc[edge.target_idx] || !context.current_edge_constrains(edge.pair, adjustment) {
-                continue;
-            }
-            if let Some(totals) = context.module_pair_totals.get(&edge.pair) {
-                for edge_idx in &totals.constraining_owner_edge_indices {
-                    if adjustment.removed_owner_edge_indices.contains(edge_idx) {
-                        continue;
-                    }
-                    constraining_owner_edge_ids.insert(*edge_idx);
-                }
-            }
-        }
-    }
-
-    constraining_owner_edge_ids
 }

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -361,12 +361,13 @@ mod tests {
     /// unrealizable.
     #[test]
     fn constraining_cycle_across_two_modules_is_unrealizable() {
-        // Use functions referring to each other in their initializers
-        // (forces both to be evaluated at-init in JS terms — but we
-        // simulate the structure with two const-init reads each way).
-        // Plain const-init can't cycle in real JS (TDZ); the realizer
-        // we test is structural, not behavioural.
-        let source = "const a = (() => b)(); const b = (() => a)();";
+        // Two top-level constants whose initializers eager-read each
+        // other. Real JS would TDZ at runtime, but the analyzer just
+        // records the structural graph: two `eager_use` edges in
+        // opposite directions. Placing them in different modules
+        // forms a constraining-edge SCC of the quotient — exactly
+        // what clause 3 rejects.
+        let source = "const a = b + 1; const b = a + 1;";
         let owner_graph = parse_and_build(source);
         let mut partition = Partition::new(&owner_graph, module_id(0));
         partition.set(OwnerId(1), module_id(1));
@@ -420,7 +421,7 @@ mod tests {
     /// pre-push verdict exactly.
     #[test]
     fn index_push_undo_roundtrips_verdict() {
-        let source = "const a = (() => b)(); const b = (() => a)();";
+        let source = "const a = b + 1; const b = a + 1;";
         let owner_graph = parse_and_build(source);
 
         let baseline = Partition::new(&owner_graph, module_id(0));
@@ -458,7 +459,7 @@ mod tests {
     /// return — even when the closure returns a value.
     #[test]
     fn index_scoped_isolates_per_call_state() {
-        let source = "const a = (() => b)(); const b = (() => a)();";
+        let source = "const a = b + 1; const b = a + 1;";
         let owner_graph = parse_and_build(source);
 
         let baseline = Partition::new(&owner_graph, module_id(0));

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -237,6 +237,12 @@ impl<'g> RealizabilityIndex<'g> {
 
     /// Apply `delta` and record its inverse on the journal. Returns a
     /// handle that the matching `undo` consumes.
+    ///
+    /// Prefer [`Self::scoped`] when the delta lifetime is lexical —
+    /// the `push`/`undo` pair is then guaranteed to be balanced and
+    /// LIFO-ordered without manual bookkeeping. Use raw `push`/`undo`
+    /// only when the lifetime crosses control-flow boundaries that
+    /// `scoped` can't span.
     pub fn push(&mut self, delta: PartitionDelta) -> DeltaHandle {
         let entry = match delta {
             PartitionDelta::MoveOwners { owners, to } => {

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -1,0 +1,483 @@
+//! Single source of truth for the three-clause validity predicate
+//! (DESIGN.md "Valid peels and atomic modules"). The validator, the
+//! peelability proposer, and the factorize closure all reach the
+//! verdict through this module — see "Realizability primitive" in
+//! `DESIGN.md`.
+//!
+//! Scope: clauses 2 (no cross-destination rebinding writes) and 3
+//! (no multi-module SCC in the constraining-edge subgraph of the
+//! quotient). Clause 1 (importability) is policy that lives in
+//! `materialize_logical_modules` per "Emit-side responsibilities":
+//! residual-entry bindings are importable by construction via the
+//! auto-grown export pass. Callers that need a private-read blocker
+//! (the proposer's `BlockedResidualDependency`) layer it on top of the
+//! verdict; it is not part of the realizability primitive.
+//!
+//! Two access shapes:
+//!
+//! - `check_realizability(owner_graph, partition) -> Verdict`: pure
+//!   function, from-scratch. The correctness reference and the cold-
+//!   start path. `O(N + M)` per call.
+//! - `RealizabilityIndex`: a stateful index that owns a working
+//!   `Partition` and supports `push`/`undo` of `PartitionDelta`s.
+//!   `verdict()` reads the current state. The transactional API is
+//!   the production shape: the proposer wraps each candidate in a
+//!   scoped push/verdict/undo; factorize walks the index forward as
+//!   the frontier grows and undoes on failed repair branches.
+//!
+//! Step 1a (this file) backs the transactional API by snapshotting
+//! the partition on push and restoring it on undo, then recomputing
+//! the verdict from scratch. Behaviour-correct, not yet fast. Step
+//! 1b (separate change) replaces the backing with incremental
+//! Pearce-Kelly SCC maintenance behind the same API.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use petgraph::algo::tarjan_scc;
+use petgraph::graphmap::DiGraphMap;
+
+use crate::OwnerId;
+use crate::graph::{OwnerEdgeId, OwnerGraph};
+use crate::ids::ModuleId;
+use crate::partition::Partition;
+
+/// Multi-module SCC of the constraining-edge subgraph of the
+/// quotient. The presence of any such SCC violates clause 3.
+#[derive(Debug, Clone)]
+pub struct UnrealizableScc {
+    /// Modules participating in the cycle.
+    pub modules: BTreeSet<ModuleId>,
+    /// Every constraining owner-edge whose endpoints both fall inside
+    /// `modules` and that crosses module boundaries — i.e. the
+    /// owner-level evidence the cycle is composed of. Stable order by
+    /// `OwnerEdgeId`.
+    pub constraining_owner_edges: Vec<OwnerEdgeId>,
+}
+
+/// Cross-destination rebinding write. ESM imports are read-only in the
+/// importing module, so any such edge violates clause 2. One entry per
+/// owner-edge.
+#[derive(Debug, Clone)]
+pub struct CrossRebindEdge {
+    pub from: ModuleId,
+    pub to: ModuleId,
+    pub owner_edge: OwnerEdgeId,
+}
+
+/// Verdict on a (current or hypothetical) destination assignment.
+/// Empty verdict ↔ realizable per clauses 2 and 3.
+#[derive(Debug, Clone, Default)]
+pub struct RealizabilityVerdict {
+    pub unrealizable_sccs: Vec<UnrealizableScc>,
+    pub cross_rebinds: Vec<CrossRebindEdge>,
+}
+
+impl RealizabilityVerdict {
+    pub fn is_realizable(&self) -> bool {
+        self.unrealizable_sccs.is_empty() && self.cross_rebinds.is_empty()
+    }
+
+    /// Modules participating in any unrealizable SCC. Convenience for
+    /// the proposer, which decodes the verdict against the candidate's
+    /// hypothetical destination.
+    pub fn modules_in_unrealizable_sccs(&self) -> BTreeSet<ModuleId> {
+        let mut out = BTreeSet::new();
+        for scc in &self.unrealizable_sccs {
+            for &m in &scc.modules {
+                out.insert(m);
+            }
+        }
+        out
+    }
+}
+
+/// Pure-function form. Builds the constraining-edge quotient, runs
+/// Tarjan, surfaces multi-module SCCs and cross-rebinds. The
+/// correctness reference for the `RealizabilityIndex`'s incremental
+/// backing (verified by differential test in the
+/// `RealizabilityIndex` step 1b follow-up).
+pub fn check_realizability(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+) -> RealizabilityVerdict {
+    let mut verdict = RealizabilityVerdict::default();
+
+    // Per-pair constraining owner-edge ids. Sequenced edges are
+    // deduped per (from, to) — multiple sequenced reasons between the
+    // same module pair represent the same ordering constraint and
+    // would over-weight evidence if counted separately. (Matches
+    // `build_module_quotient`'s sequenced-edge dedup.)
+    let mut constraining_adj: BTreeMap<(ModuleId, ModuleId), Vec<OwnerEdgeId>> = BTreeMap::new();
+    let mut seen_sequenced_pairs: BTreeSet<(ModuleId, ModuleId)> = BTreeSet::new();
+
+    for edge in &owner_graph.edges {
+        // Skip edges whose endpoints aren't in this owner graph's
+        // partition slot (defensive — Partition is dense, but
+        // owner_graph.node() returning None should not crash here).
+        if owner_graph.node(edge.from).is_none() || owner_graph.node(edge.to).is_none() {
+            continue;
+        }
+        let from = partition.of(edge.from);
+        let to = partition.of(edge.to);
+        if from == to {
+            continue;
+        }
+        if edge.reason.is_rebind() {
+            verdict.cross_rebinds.push(CrossRebindEdge {
+                from,
+                to,
+                owner_edge: edge.id,
+            });
+            continue;
+        }
+        if !edge.reason.constrains_init_order() {
+            continue;
+        }
+        if edge.reason.is_sequenced() && !seen_sequenced_pairs.insert((from, to)) {
+            continue;
+        }
+        constraining_adj
+            .entry((from, to))
+            .or_default()
+            .push(edge.id);
+    }
+
+    if constraining_adj.is_empty() {
+        return verdict;
+    }
+
+    // Run Tarjan over the constraining-edge quotient.
+    let mut graph: DiGraphMap<ModuleId, ()> = DiGraphMap::new();
+    for &(from, to) in constraining_adj.keys() {
+        graph.add_edge(from, to, ());
+    }
+    for scc in tarjan_scc(&graph) {
+        // Single-vertex SCCs without a self-loop don't represent a
+        // multi-module cycle. (A constraining intra-module edge would
+        // not appear in the quotient adjacency at all; we skip
+        // `from == to` above.)
+        if scc.len() < 2 {
+            continue;
+        }
+        let modules: BTreeSet<ModuleId> = scc.iter().copied().collect();
+        let mut owner_edges: Vec<OwnerEdgeId> = Vec::new();
+        for ((from, to), edges) in &constraining_adj {
+            if modules.contains(from) && modules.contains(to) {
+                owner_edges.extend_from_slice(edges);
+            }
+        }
+        owner_edges.sort();
+        verdict.unrealizable_sccs.push(UnrealizableScc {
+            modules,
+            constraining_owner_edges: owner_edges,
+        });
+    }
+
+    verdict
+}
+
+/// A reversible mutation of a `Partition`. The factorize closure and
+/// the peelability proposer construct deltas to describe hypothetical
+/// or actual destination assignments; the index applies and reverts
+/// them.
+#[derive(Debug, Clone)]
+pub enum PartitionDelta {
+    /// Reassign every owner in `owners` to `to`. Owners not in the
+    /// list keep their current assignment. Owners already at `to` are
+    /// no-ops but recorded for journal symmetry.
+    MoveOwners { owners: Vec<OwnerId>, to: ModuleId },
+}
+
+/// Opaque handle returned by `push`. Passing it to `undo` rolls back
+/// to the state before the corresponding push. Handles must be undone
+/// in LIFO order — the journal is a stack — and `undo` panics in
+/// debug builds on misuse so caller bugs surface early instead of
+/// silently corrupting the index.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DeltaHandle(usize);
+
+/// Inverse of a `MoveOwners` delta: the prior `(owner, module)` pairs
+/// so `undo` can restore them.
+#[derive(Debug, Clone)]
+struct JournalEntry {
+    prior_assignments: Vec<(OwnerId, ModuleId)>,
+}
+
+/// Mutable index over a working partition. The single shared
+/// implementation of the three-clause predicate, exposed in the
+/// transactional shape DESIGN.md "Realizability primitive" prescribes.
+///
+/// Backing (step 1a): each `push` snapshots the prior assignments of
+/// the touched owners; `undo` restores them. `verdict()` recomputes
+/// from scratch via [`check_realizability`]. Correct but not yet
+/// fast. Step 1b will swap the backing for incremental
+/// Pearce-Kelly SCC maintenance behind the same API; no caller code
+/// has to change.
+pub struct RealizabilityIndex<'g> {
+    owner_graph: &'g OwnerGraph,
+    partition: Partition,
+    journal: Vec<JournalEntry>,
+}
+
+impl<'g> RealizabilityIndex<'g> {
+    pub fn from_partition(owner_graph: &'g OwnerGraph, partition: Partition) -> Self {
+        Self {
+            owner_graph,
+            partition,
+            journal: Vec::new(),
+        }
+    }
+
+    /// Borrow the current working partition. Callers should treat this
+    /// as read-only — mutation should go through `push`/`undo` so the
+    /// journal stays consistent.
+    pub fn partition(&self) -> &Partition {
+        &self.partition
+    }
+
+    /// Apply `delta` and record its inverse on the journal. Returns a
+    /// handle that the matching `undo` consumes.
+    pub fn push(&mut self, delta: PartitionDelta) -> DeltaHandle {
+        let entry = match delta {
+            PartitionDelta::MoveOwners { owners, to } => {
+                let mut prior = Vec::with_capacity(owners.len());
+                for owner in owners {
+                    let was = self.partition.of(owner);
+                    if was != to {
+                        self.partition.set(owner, to);
+                    }
+                    prior.push((owner, was));
+                }
+                JournalEntry {
+                    prior_assignments: prior,
+                }
+            }
+        };
+        let handle = DeltaHandle(self.journal.len());
+        self.journal.push(entry);
+        handle
+    }
+
+    /// Roll back the delta identified by `handle`. Must be the top of
+    /// the journal; debug builds panic otherwise.
+    pub fn undo(&mut self, handle: DeltaHandle) {
+        debug_assert_eq!(
+            handle.0 + 1,
+            self.journal.len(),
+            "RealizabilityIndex::undo called out of LIFO order \
+             (handle {:?}, journal depth {})",
+            handle,
+            self.journal.len(),
+        );
+        let entry = self
+            .journal
+            .pop()
+            .expect("journal must be non-empty for undo");
+        for (owner, prior) in entry.prior_assignments {
+            self.partition.set(owner, prior);
+        }
+    }
+
+    /// Apply `delta`, run `f` against the index in its post-push
+    /// state, then undo. The scoped form guarantees the per-call
+    /// push/undo pair regardless of `f`'s control flow.
+    pub fn scoped<F, R>(&mut self, delta: PartitionDelta, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let handle = self.push(delta);
+        let result = f(self);
+        self.undo(handle);
+        result
+    }
+
+    /// Verdict against the current working partition. Step 1a backing
+    /// recomputes from scratch; step 1b will read incrementally
+    /// maintained state instead.
+    pub fn verdict(&self) -> RealizabilityVerdict {
+        check_realizability(self.owner_graph, &self.partition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::OwnerId;
+    use crate::facts::analyze_chunk;
+    use crate::graph::build_owner_graph;
+    use crate::ids::{LogicalModuleIndex, ModuleId};
+    use crate::partition::Partition;
+    use crate::{AnalysisHints, OwnerGraph};
+    use swc_common::{FileName, SourceMap, sync::Lrc};
+    use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+    fn module_id(index: usize) -> ModuleId {
+        ModuleId(LogicalModuleIndex(index))
+    }
+
+    fn parse_and_build(source: &str) -> OwnerGraph {
+        let cm: Lrc<SourceMap> = Default::default();
+        let fm = cm.new_source_file(
+            FileName::Custom("test.js".into()).into(),
+            source.to_string(),
+        );
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let module = Parser::new_from(lexer)
+            .parse_module()
+            .expect("parse module");
+        let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
+        build_owner_graph(&facts)
+    }
+
+    /// Two top-level constants in different modules, with one reading
+    /// the other at-init across the module boundary acyclically. No
+    /// cycle, no rebind — verdict is empty.
+    #[test]
+    fn acyclic_cross_module_at_init_read_is_realizable() {
+        let source = "const a = 1; const b = a + 1;";
+        let owner_graph = parse_and_build(source);
+        // Owner 0: const a = 1 → module 0.
+        // Owner 1: const b = a + 1 → module 1.
+        // Edge owner_1 → owner_0 (eager_use of `a`).
+        let mut partition = Partition::new(&owner_graph, module_id(0));
+        partition.set(OwnerId(1), module_id(1));
+        let verdict = check_realizability(&owner_graph, &partition);
+        assert!(
+            verdict.is_realizable(),
+            "verdict should be empty: {verdict:#?}"
+        );
+    }
+
+    /// Same setup but flipped to create a constraining cycle: both
+    /// statements live in different modules and mutually at-init read
+    /// the other. Quotient has a 2-cycle of constraining edges →
+    /// unrealizable.
+    #[test]
+    fn constraining_cycle_across_two_modules_is_unrealizable() {
+        // Use functions referring to each other in their initializers
+        // (forces both to be evaluated at-init in JS terms — but we
+        // simulate the structure with two const-init reads each way).
+        // Plain const-init can't cycle in real JS (TDZ); the realizer
+        // we test is structural, not behavioural.
+        let source = "const a = (() => b)(); const b = (() => a)();";
+        let owner_graph = parse_and_build(source);
+        let mut partition = Partition::new(&owner_graph, module_id(0));
+        partition.set(OwnerId(1), module_id(1));
+        let verdict = check_realizability(&owner_graph, &partition);
+        assert!(
+            !verdict.is_realizable(),
+            "verdict should report an SCC: {verdict:#?}"
+        );
+        let modules: BTreeSet<ModuleId> = verdict.modules_in_unrealizable_sccs();
+        assert!(modules.contains(&module_id(0)));
+        assert!(modules.contains(&module_id(1)));
+        assert!(
+            verdict
+                .unrealizable_sccs
+                .iter()
+                .all(|scc| !scc.constraining_owner_edges.is_empty()),
+            "every SCC must carry owner-edge evidence"
+        );
+    }
+
+    /// A pure lazy-read cycle (mutual references inside function
+    /// bodies) is realizable: ESM evaluates the lazy side first, no
+    /// TDZ. Verdict must be empty even when the modules form a cycle
+    /// in the *full* quotient.
+    #[test]
+    fn pure_lazy_cycle_is_realizable() {
+        let source = "function a() { return b(); } function b() { return a(); }";
+        let owner_graph = parse_and_build(source);
+        let mut partition = Partition::new(&owner_graph, module_id(0));
+        partition.set(OwnerId(1), module_id(1));
+        let verdict = check_realizability(&owner_graph, &partition);
+        assert!(
+            verdict.is_realizable(),
+            "lazy-only cycle should be realizable: {verdict:#?}"
+        );
+    }
+
+    /// All owners in the same module → no cross-destination edges of
+    /// any kind → empty verdict.
+    #[test]
+    fn single_module_is_always_realizable() {
+        let source = "const a = 1; const b = a + 1; const c = a * b;";
+        let owner_graph = parse_and_build(source);
+        let partition = Partition::new(&owner_graph, module_id(0));
+        let verdict = check_realizability(&owner_graph, &partition);
+        assert!(verdict.is_realizable());
+    }
+
+    /// Pushing a delta on the index and reading the verdict matches
+    /// the pure function on the post-push partition. Undo restores the
+    /// pre-push verdict exactly.
+    #[test]
+    fn index_push_undo_roundtrips_verdict() {
+        let source = "const a = (() => b)(); const b = (() => a)();";
+        let owner_graph = parse_and_build(source);
+
+        let baseline = Partition::new(&owner_graph, module_id(0));
+        let baseline_verdict = check_realizability(&owner_graph, &baseline);
+        assert!(baseline_verdict.is_realizable());
+
+        let mut index = RealizabilityIndex::from_partition(&owner_graph, baseline.clone());
+        let handle = index.push(PartitionDelta::MoveOwners {
+            owners: vec![OwnerId(1)],
+            to: module_id(1),
+        });
+        // After push: matches the explicitly-built post-delta partition.
+        let mut hypothetical = baseline.clone();
+        hypothetical.set(OwnerId(1), module_id(1));
+        let hypothetical_verdict = check_realizability(&owner_graph, &hypothetical);
+        assert_eq!(
+            index.verdict().unrealizable_sccs.len(),
+            hypothetical_verdict.unrealizable_sccs.len(),
+        );
+        assert!(!index.verdict().is_realizable());
+
+        index.undo(handle);
+        // After undo: matches the baseline exactly.
+        assert!(index.verdict().is_realizable());
+        for owner_id in 0..owner_graph.nodes.len() {
+            assert_eq!(
+                index.partition().of(OwnerId(owner_id)),
+                baseline.of(OwnerId(owner_id)),
+                "partition slot {owner_id} should be restored by undo",
+            );
+        }
+    }
+
+    /// `scoped` runs the closure with the delta applied and undoes on
+    /// return — even when the closure returns a value.
+    #[test]
+    fn index_scoped_isolates_per_call_state() {
+        let source = "const a = (() => b)(); const b = (() => a)();";
+        let owner_graph = parse_and_build(source);
+
+        let baseline = Partition::new(&owner_graph, module_id(0));
+        let mut index = RealizabilityIndex::from_partition(&owner_graph, baseline.clone());
+
+        let inside_verdict_realizable = index.scoped(
+            PartitionDelta::MoveOwners {
+                owners: vec![OwnerId(1)],
+                to: module_id(1),
+            },
+            |idx| idx.verdict().is_realizable(),
+        );
+        assert!(
+            !inside_verdict_realizable,
+            "inside the scope the cycle exists"
+        );
+
+        // After scoped: state restored exactly.
+        assert!(index.verdict().is_realizable());
+        assert_eq!(index.partition().of(OwnerId(1)), module_id(0));
+    }
+}

--- a/devinfra/js/debundle/schedule.rs
+++ b/devinfra/js/debundle/schedule.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 
-use petgraph::algo::toposort;
+use petgraph::algo::{tarjan_scc, toposort};
 use petgraph::graphmap::DiGraphMap;
 
 use crate::atomic_units::{OwnerGraphAndUnits, compute_owner_graph_and_units};
@@ -57,6 +57,7 @@ pub struct Schedule {
     /// evaluation order; see DESIGN.md "Lemma 2".
     pub linker_order: Vec<ModuleId>,
     linker_position_by_module: HashMap<ModuleId, usize>,
+    source_import_position_by_module: HashMap<ModuleId, usize>,
     /// Pre-computed `binding → exported name` map. Built once per
     /// chunk in `Schedule::build` so peelability's per-candidate
     /// `binding_reports` calls do a single hash lookup instead of
@@ -125,7 +126,15 @@ impl Schedule {
         let owner_report_ids_by_binding = Self::build_owner_report_ids_by_binding(&owner_graph);
         let dep_graph = build_module_quotient(&owner_graph, &partition);
         let linker_order = compute_linker_order(&dep_graph, &logical_modules);
-        let linker_position_by_module = linker_order
+        let linker_position_by_module: HashMap<ModuleId, usize> = linker_order
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, id)| (id, idx))
+            .collect();
+        let source_import_order =
+            compute_source_import_order(&dep_graph, &logical_modules, &linker_position_by_module);
+        let source_import_position_by_module: HashMap<ModuleId, usize> = source_import_order
             .iter()
             .copied()
             .enumerate()
@@ -146,6 +155,7 @@ impl Schedule {
             owner_report_ids_by_binding,
             linker_order,
             linker_position_by_module,
+            source_import_position_by_module,
             export_name_by_binding,
         }
     }
@@ -167,6 +177,22 @@ impl Schedule {
     /// before dependents.
     pub fn linker_position(&self, id: ModuleId) -> Option<usize> {
         self.linker_position_by_module.get(&id).copied()
+    }
+
+    /// Position of `id` in the emitted entry's source-import order
+    /// — the order in which entry's `import` directives must appear
+    /// in source so the ESM linker's depth-first instantiation lands
+    /// on a Phase-2 evaluation order matching `linker_order`.
+    ///
+    /// Per DESIGN.md "The realizability theorem", Lemma 2: for
+    /// acyclic shapes this coincides with `linker_position`
+    /// (dependency-first source order). For cyclic-I shapes accepted
+    /// by the relaxed clause-3 rule, SCC members are reverse-sorted
+    /// — DFS into the dependent unwinds the dependency first in
+    /// post-order, so the dependent must appear first in entry's
+    /// source for post-DFS evaluation to put the dependency first.
+    pub fn source_import_position(&self, id: ModuleId) -> Option<usize> {
+        self.source_import_position_by_module.get(&id).copied()
     }
 
     /// Render `id` to a human-readable label (used in cycle reports).
@@ -232,7 +258,9 @@ impl Schedule {
     /// Run SCC analysis over the dep graph. Spec authors consume the
     /// resulting report to fix any cycles or atomic-unit conflicts.
     pub fn validate(&self) -> ScheduleReport {
-        let mut report = validate_schedule(&self.dep_graph, &|id| self.module_name(id));
+        let mut report = validate_schedule(&self.owner_graph, &self.partition, &|id| {
+            self.module_name(id)
+        });
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();
         report.linker_order = self
             .linker_order
@@ -321,6 +349,87 @@ fn build_export_name_by_binding(
 /// before dependencies. The returned order is reversed so the
 /// dependency comes first — matching the order ECMA-262's link
 /// traversal needs to evaluate (deepest leaf first).
+/// Compute the source order in which entry's emitted `import`
+/// directives must appear so the ESM linker's depth-first
+/// instantiation lands on a Phase-2 evaluation order matching
+/// `linker_order`. Implements DESIGN.md "The realizability theorem"
+/// Lemma 2.
+///
+/// The idea: ESM Phase-2 evaluates a module's source-order imports
+/// recursively, then runs the module's own init code. For acyclic
+/// imports graphs, post-DFS-order matches source order — so
+/// dependency-first source produces dependency-first evaluation.
+/// For cyclic imports graphs accepted by the relaxed clause-3 rule
+/// (the constraining-edge subgraph is acyclic even though `I` has
+/// the cycle), DFS into the first imported SCC member recurses to
+/// its dependency, hits the cycle back-edge, and finalizes the
+/// dependency LAST in post-order — wrong. The fix: within each SCC
+/// of `I`, reverse the order so the most-dependent member is first
+/// in source, the cycle unwinds through its dependencies, and
+/// post-order matches the dependency-first ordering the
+/// constraining-edge subgraph defines.
+///
+/// Returns a `Vec<ModuleId>` ordered such that index 0 should be
+/// entry's first import.
+fn compute_source_import_order(
+    dep_graph: &ModuleQuotient,
+    logical_modules: &[LogicalModule],
+    linker_position_by_module: &HashMap<ModuleId, usize>,
+) -> Vec<ModuleId> {
+    let sccs = tarjan_scc(&dep_graph.graph);
+    let mut scc_of: HashMap<ModuleId, usize> = HashMap::new();
+    let mut scc_rank: Vec<usize> = Vec::with_capacity(sccs.len());
+    for (idx, scc) in sccs.iter().enumerate() {
+        let min_pos = scc
+            .iter()
+            .filter_map(|m| linker_position_by_module.get(m).copied())
+            .min()
+            .unwrap_or(usize::MAX);
+        scc_rank.push(min_pos);
+        for m in scc {
+            scc_of.insert(*m, idx);
+        }
+    }
+    // Start from every module the schedule knows about. Modules with
+    // no dep-graph edges (singletons) still need a deterministic
+    // source-order slot for emit stability.
+    let mut nodes: Vec<ModuleId> = (0..logical_modules.len())
+        .map(|idx| ModuleId(LogicalModuleIndex(idx)))
+        .collect();
+    for (from, to, _) in dep_graph.iter_edges() {
+        if !nodes.contains(&from) {
+            nodes.push(from);
+        }
+        if !nodes.contains(&to) {
+            nodes.push(to);
+        }
+    }
+    nodes.sort_by(|a, b| {
+        let a_scc = scc_of.get(a).copied();
+        let b_scc = scc_of.get(b).copied();
+        let a_rank = a_scc
+            .and_then(|i| scc_rank.get(i).copied())
+            .unwrap_or(usize::MAX);
+        let b_rank = b_scc
+            .and_then(|i| scc_rank.get(i).copied())
+            .unwrap_or(usize::MAX);
+        let a_pos = linker_position_by_module
+            .get(a)
+            .copied()
+            .unwrap_or(usize::MAX);
+        let b_pos = linker_position_by_module
+            .get(b)
+            .copied()
+            .unwrap_or(usize::MAX);
+        // (SCC rank ASC, intra-SCC linker_position DESC). DESC
+        // reverses within each SCC; the rank ASC keeps SCCs
+        // dependency-first relative to each other. For singleton
+        // SCCs, the DESC reverse is a no-op (only one member).
+        a_rank.cmp(&b_rank).then_with(|| b_pos.cmp(&a_pos))
+    });
+    nodes
+}
+
 fn compute_linker_order(
     dep_graph: &ModuleQuotient,
     logical_modules: &[LogicalModule],
@@ -332,7 +441,10 @@ fn compute_linker_order(
     for idx in 0..logical_modules.len() {
         graph.add_node(ModuleId(LogicalModuleIndex(idx)));
     }
-    for (from, to, _) in dep_graph.iter_edges() {
+    for (from, to, weight) in dep_graph.iter_edges() {
+        if !weight.constrains_init_order() {
+            continue;
+        }
         graph.add_node(from);
         graph.add_node(to);
         graph.add_edge(from, to, ());

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -7,7 +7,12 @@ use petgraph::visit::EdgeRef;
 use serde::Serialize;
 
 use crate::factor_assembly::AtomicUnitConflict;
-use crate::{BindingName, DepKind, EdgeMetadata, ModuleId, ModuleQuotient, StatementOrdinal};
+use crate::graph::build_module_quotient;
+use crate::partition::Partition;
+use crate::realizability::check_realizability;
+use crate::{
+    BindingName, DepKind, EdgeMetadata, ModuleId, ModuleQuotient, OwnerGraph, StatementOrdinal,
+};
 
 /// Result of validating a module dep graph.
 #[derive(Debug, Clone, Serialize)]
@@ -154,9 +159,19 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
 /// asymmetry persists until either Lemma 2 lands in the materializer
 /// or the proposer is also tightened.
 pub fn validate_schedule(
-    graph: &ModuleQuotient,
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
     module_name: &dyn Fn(ModuleId) -> String,
 ) -> ScheduleReport {
+    let verdict = check_realizability(owner_graph, partition);
+    if verdict.unrealizable_sccs.is_empty() {
+        return ScheduleReport {
+            cycles: Vec::new(),
+            atomic_unit_conflicts: Vec::new(),
+            linker_order: Vec::new(),
+        };
+    }
+    let graph = &build_module_quotient(owner_graph, partition);
     let sccs = tarjan_scc(&graph.graph);
     let mut cycles = Vec::new();
     for scc in sccs {

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -135,6 +135,24 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
 /// Find SCCs in the dep graph and produce a report listing every
 /// non-trivial cycle (size > 1 OR a self-loop). Trivial single-node
 /// non-self-loop SCCs are dropped.
+///
+/// The validator uses the **strict** rule: any quotient SCC carrying
+/// a constraining cross-module edge is unrealizable. This is more
+/// conservative than the realizability primitive's relaxed rule
+/// (constraining-edge subgraph has no multi-module SCC) because the
+/// materializer does not currently implement DESIGN.md "Lemma 2"
+/// (steering the ESM linker's import-source order to land on a
+/// topological linearization of `I ∪ S`). Mixed cycles the relaxed
+/// rule would accept can still TDZ at runtime under the current
+/// materializer.
+///
+/// The proposer (`evaluate_peel_candidate` in `peelability.rs`) uses
+/// the relaxed rule via [`crate::realizability::check_realizability`]
+/// for advisory peel classification. The at-init call promotion in
+/// `build_owner_graph` narrows the gap between the two predicates by
+/// catching the canonical `console.log(readB())` shape, but the
+/// asymmetry persists until either Lemma 2 lands in the materializer
+/// or the proposer is also tightened.
 pub fn validate_schedule(
     graph: &ModuleQuotient,
     module_name: &dyn Fn(ModuleId) -> String,


### PR DESCRIPTION
## Summary

Closes the bug #1625 surfaces by removing the proposer/validator predicate
asymmetry at its root: the two predicates now share one primitive,
`check_realizability(&OwnerGraph, &Partition)`, and consume the same
**promoted** owner graph. The relaxed clause-3 rule (PR #1614) becomes
sound because (a) at-init call promotion materializes the
interprocedural cross-module constraints the graph was missing, and
(b) the materializer drives entry-side import ordering so the ESM
linker DFS realizes the constraining-edge linearization even when `I`
itself has a cycle (Lemma 2).

Three pieces:

1. **Realizability primitive** — `realizability.rs` exposes
   `check_realizability` and a transactional `RealizabilityIndex`
   (`push`/`undo`/`scoped`) over a partition. Validator, proposer, and
   the factorize closure all consume it. ~250 LoC of bespoke
   per-caller walks in `peelability.rs` deleted.
2. **At-init call promotion** — `facts.rs` collects per-statement
   `at_init_calls` and `body_calls`; `graph.rs` builds a chunk-local
   call graph, Tarjan-SCCs it, computes reverse-topological closures
   over `lazy_reads`/`lazy_rebinds`, and emits promoted
   `EagerUse`/`EagerRebind` owner-graph edges. Hoisted FnDecl targets
   are filtered (no TDZ). Per-statement per-kind dedup keeps edge
   count bounded by `O(|closure|)` per emitting statement.
3. **Lemma 2 in the materializer** — `schedule.rs` introduces
   `source_import_position`, computed by Tarjan-SCC of the
   constraining-edge quotient with **(SCC dep rank ASC, intra-SCC
   linker_position DESC)**. Entry's emitted import-source order
   therefore lands the ESM linker DFS on a linearization of `I ∪ S`,
   so the relaxed clause-3 predicate is safe.

DESIGN.md gains three subsections: "Realizability primitive",
"At-init call promotion", "Lemma 2: entry-side import ordering". The
prior "Predicate asymmetry" note is removed.

## Test plan

- [x] `bbr test //devinfra/js/debundle/... --config=nolint` — 45/45
      analyzer + e2e tests green (submitted invocation
      `bc996a89-c605-4f0f-a00c-dec4e533b2f4`)
- [x] #1625 RED test (`direct_status_overpromise_test.rs`) flipped to
      GREEN in commit `1fe7483` and stays GREEN
- [x] `e2e/peel_horizon_pure_hub_test.rs` (3 cases) — pure-hub stays
      realizable (promotion is intra-module after peel)
- [x] `e2e/realizability_test.rs::mixed_cycle_with_lazy_back_edge_is_realizable`
      — pure-lazy stays realizable (no at-init call to promote)
- [x] New `atomic_unit_grows_when_at_init_call_promotes_rebind` —
      pins the +B() variant grows the atomic unit from 2 to 3 owners
- [ ] Gaffer smoke against `tana/re/web/spec:debundle_78d928dca7` —
      not run; deferred to follow-up

## Risks

- **Indirect / method / dynamic calls** are unmodelled. Documented in
  DESIGN.md as a known-narrow gap.
- **Edge-count blow-up** mitigated by per-(caller, target, kind)
  dedup in promotion. Per-statement cost `O(|closure|)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_