### PR TITLE
Add casino payout stats aggregation and UI

### DIFF
--- a/x/auragon_study_casino/BUILD.bazel
+++ b/x/auragon_study_casino/BUILD.bazel
@@ -47,6 +47,13 @@ py_library(
 )
 
 py_library(
+    name = "stats",
+    srcs = ["stats.py"],
+    visibility = ["//visibility:public"],
+    deps = ["@pypi//pydantic"],
+)
+
+py_library(
     name = "store",
     srcs = ["store.py"],
     data = glob(["migrations/**"]),
@@ -55,6 +62,7 @@ py_library(
         ":events",
         ":games",
         ":models",
+        ":stats",
         "@pypi//alembic",
         "@pypi//psycopg",
         "@pypi//sqlalchemy",
@@ -84,6 +92,7 @@ py_library(
         ":events",
         ":games",
         ":models",
+        ":stats",
         ":store",
         "@pypi//fastapi",
         "@pypi//pydantic",
@@ -137,6 +146,7 @@ py_test(
     deps = [
         ":conftest",
         ":models",
+        ":stats",
         ":store",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/x/auragon_study_casino/README.md
+++ b/x/auragon_study_casino/README.md
@@ -33,6 +33,7 @@ Lives at <https://casino.allegedly.works>.
 | `frontend/Slots.jsx`                   | Slot machine game                                                                                  |
 | `frontend/PrizesView.jsx`              | Token conversion, prize catalog, redemption log                                                    |
 | `frontend/StatsView.jsx`               | Stats, session editor, data import/export                                                          |
+| `frontend/CasinoStatsView.jsx`         | Casino payout history — per-game, per-wager-type and per-day empirical vs theoretical              |
 | `frontend/sync.js`                     | REST client + state-changed WebSocket subscriber                                                   |
 | `frontend/use_casino.js`               | Single hook exposing reactive state + every mutation                                               |
 | `frontend/SyncIcon.jsx`                | Header status icon + rejection toast                                                               |
@@ -95,6 +96,8 @@ POST /actions/import / /actions/reset — bulk replace / wipe state (snapshot sa
 POST /casino/slots/spin              — server-resolved slots
 POST /casino/roulette/spin           — server-resolved roulette
 POST /casino/blackjack/{deal,hit,stand,double} — server-resolved blackjack
+GET  /casino/stats                   — aggregated wager/payout stats for caller
+GET  /admin/casino/stats?user=<u>    — admin-only: aggregated stats for any user
 GET  /game-events / /ledger-events   — read-only audit listings
 GET  /me / /healthz                  — auth introspection / liveness
 WS   /ws                             — broadcasts {"type":"state_changed"} to every

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -17,6 +17,8 @@ Wire surface:
   POST /casino/blackjack/{deal,hit,stand,double} — server-resolved blackjack
   GET  /admin/users                     — admin-only: list known usernames
   GET  /admin/state                     — admin-only: state_dump for `?user=<u>`
+  GET  /casino/stats                    — aggregated wager/payout stats (caller)
+  GET  /admin/casino/stats              — admin-only: same, for `?user=<u>`
   GET  /game-events / /ledger-events    — read-only audit listings
   GET  /me / /healthz                   — auth introspection / liveness
   WS   /ws                              — broadcasts {"type":"state_changed"}
@@ -87,6 +89,7 @@ from x.auragon_study_casino.games import (
     spin_slots,
 )
 from x.auragon_study_casino.models import BalanceRow, BlackjackHandRow, PrizeLogRow, PrizeRow, SessionRow
+from x.auragon_study_casino.stats import CasinoStats
 from x.auragon_study_casino.store import ActionMutation, ActionRejectedError, SqlStore
 
 logger = logging.getLogger(__name__)
@@ -332,6 +335,19 @@ def create_app(settings: Settings) -> FastAPI:
         username: Annotated[str, Depends(current_user_dep)], limit: Annotated[int, Query(ge=1, le=500)] = 100
     ) -> list[GameEventRead]:
         return store.list_game_events(username, limit=limit)
+
+    @app.get("/casino/stats")
+    def get_casino_stats(username: Annotated[str, Depends(current_user_dep)]) -> CasinoStats:
+        return store.casino_stats(username)
+
+    @app.get("/admin/casino/stats")
+    def admin_casino_stats(
+        user: Annotated[str, Query(min_length=1, max_length=64)], username: Annotated[str, Depends(current_user_dep)]
+    ) -> CasinoStats:
+        require_admin(username)
+        if not store.user_exists(user):
+            raise HTTPException(status_code=404, detail=f"user {user!r} not found")
+        return store.casino_stats(user)
 
     @app.get("/ledger-events")
     def list_ledger_events(

--- a/x/auragon_study_casino/frontend/BUILD.bazel
+++ b/x/auragon_study_casino/frontend/BUILD.bazel
@@ -133,11 +133,22 @@ js_library(
 )
 
 js_library(
+    name = "casino_stats_view",
+    srcs = ["CasinoStatsView.jsx"],
+    deps = [
+        ":node_modules/react",
+        ":shared",
+        ":sync",
+    ],
+)
+
+js_library(
     name = "study_casino",
     srcs = ["study_casino.jsx"],
     deps = [
         ":admin_view",
         ":blackjack",
+        ":casino_stats_view",
         ":node_modules/react",
         ":prizes_view",
         ":roulette",

--- a/x/auragon_study_casino/frontend/CasinoStatsView.jsx
+++ b/x/auragon_study_casino/frontend/CasinoStatsView.jsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useState, useCallback } from "react";
+
+import { COLORS, SectionTitle } from "./shared.jsx";
+import { fetchCasinoStats, useCasinoState } from "./sync.js";
+
+const PCT_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const fmtPct = (v) => (v === null || v === undefined ? "—" : PCT_FORMATTER.format(v));
+const fmtRtp = (v) => (v === null || v === undefined ? "—" : `${(v * 100).toFixed(1)}%`);
+const fmtEv = (v) => {
+  if (v === null || v === undefined) return "—";
+  const sign = v >= 0 ? "+" : "";
+  return `${sign}${v.toFixed(3)}`;
+};
+const fmtInt = (n) => (n ?? 0).toLocaleString();
+
+export function CasinoStatsView({ isAdmin }) {
+  const initialTarget = new URLSearchParams(window.location.search).get("user") ?? "";
+  const [targetUser, setTargetUser] = useState(initialTarget);
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(null);
+  // The /state cache pings when any tab plays a game — use it to retrigger
+  // a stats refetch so the page live-updates without manual refresh.
+  const stateCache = useCasinoState();
+
+  const refresh = useCallback(async () => {
+    try {
+      const user = isAdmin && targetUser.trim() ? targetUser.trim() : null;
+      const result = await fetchCasinoStats(user);
+      setStats(result);
+      setError(null);
+    } catch (e) {
+      setError(e.message ?? String(e));
+      setStats(null);
+    }
+  }, [isAdmin, targetUser]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, stateCache]);
+
+  return (
+    <div>
+      <SectionTitle>Casino payout history</SectionTitle>
+
+      <div style={{ fontSize: 12, color: COLORS.creamDim, marginBottom: 16, lineHeight: 1.5 }}>
+        Empirical stats over every server-resolved spin / hand. Coverage starts{" "}
+        <span style={{ color: COLORS.gold }}>{stats?.since_date ?? "2026-05-07"}</span> (the client-reported →
+        server-resolved cutover). Wager amounts are in credits, payouts in tokens; RTP is{" "}
+        <span className="mono">returned / wagered</span>, EV / credit is{" "}
+        <span className="mono">(returned − wagered) / wagered</span>.
+      </div>
+
+      {isAdmin && (
+        <div
+          className="panel"
+          style={{ padding: 12, marginBottom: 18, display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}
+        >
+          <span style={{ color: COLORS.creamDim, fontSize: 12, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+            Viewing stats for
+          </span>
+          <input
+            value={targetUser}
+            onChange={(e) => setTargetUser(e.target.value)}
+            placeholder="(yourself)"
+            style={{ minWidth: 200 }}
+          />
+          <button className="btn" onClick={refresh}>
+            Reload
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div
+          style={{
+            background: "rgba(180,40,40,0.25)",
+            border: `1px solid ${COLORS.red}`,
+            padding: "10px 14px",
+            marginBottom: 16,
+            color: COLORS.cream,
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {stats && (
+        <>
+          <div style={{ fontSize: 12, color: COLORS.creamDim, marginBottom: 18 }}>
+            <span style={{ color: COLORS.gold }}>{fmtInt(stats.event_count)}</span> resolved games for{" "}
+            <span style={{ color: COLORS.cream }}>{stats.username}</span>.
+          </div>
+
+          {stats.games.map((g) => (
+            <GameStatsCard key={g.game} game={g} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function GameStatsCard({ game }) {
+  return (
+    <div style={{ marginBottom: 32 }}>
+      <SectionTitle small>{game.game}</SectionTitle>
+
+      {game.total.count === 0 ? (
+        <div style={{ fontSize: 13, color: COLORS.creamDim, marginBottom: 12 }}>No resolved games yet.</div>
+      ) : (
+        <>
+          <BucketTable buckets={[game.total, ...game.buckets]} />
+          {game.timeline.length > 0 && <TimelineTable timeline={game.timeline} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+function BucketTable({ buckets }) {
+  return (
+    <div className="panel" style={{ padding: 12, overflowX: "auto", marginBottom: 14 }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ color: COLORS.creamDim, textAlign: "right" }}>
+            <th style={{ textAlign: "left", padding: "6px 8px" }}>Wager</th>
+            <th style={{ padding: "6px 8px" }}>Plays</th>
+            <th style={{ padding: "6px 8px" }}>Wagered</th>
+            <th style={{ padding: "6px 8px" }}>Returned</th>
+            <th style={{ padding: "6px 8px" }}>Net</th>
+            <th style={{ padding: "6px 8px" }}>Win rate</th>
+            <th style={{ padding: "6px 8px" }}>Emp. RTP</th>
+            <th style={{ padding: "6px 8px" }}>Theor. RTP</th>
+            <th style={{ padding: "6px 8px" }}>EV / credit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((b) => (
+            <tr key={b.key} style={{ borderTop: "1px solid rgba(212,165,72,0.15)", color: COLORS.cream }}>
+              <td style={{ padding: "6px 8px", textAlign: "left" }}>{b.label}</td>
+              <td style={{ padding: "6px 8px", textAlign: "right" }} className="mono">
+                {fmtInt(b.count)}
+              </td>
+              <td style={{ padding: "6px 8px", textAlign: "right" }} className="mono">
+                {fmtInt(b.wagered)}
+              </td>
+              <td style={{ padding: "6px 8px", textAlign: "right" }} className="mono">
+                {fmtInt(b.returned)}
+              </td>
+              <td
+                style={{
+                  padding: "6px 8px",
+                  textAlign: "right",
+                  color: b.net > 0 ? COLORS.goldBright : b.net < 0 ? COLORS.red : COLORS.cream,
+                }}
+                className="mono"
+              >
+                {b.net > 0 ? "+" : ""}
+                {fmtInt(b.net)}
+              </td>
+              <td style={{ padding: "6px 8px", textAlign: "right" }} className="mono">
+                {fmtPct(b.payout_rate)}
+                {b.theoretical_payout_rate !== null && b.theoretical_payout_rate !== undefined && (
+                  <span style={{ color: COLORS.creamDim }}> / {fmtPct(b.theoretical_payout_rate)}</span>
+                )}
+              </td>
+              <td style={{ padding: "6px 8px", textAlign: "right" }} className="mono">
+                {fmtRtp(b.rtp)}
+              </td>
+              <td style={{ padding: "6px 8px", textAlign: "right", color: COLORS.creamDim }} className="mono">
+                {fmtRtp(b.theoretical_rtp)}
+              </td>
+              <td
+                style={{
+                  padding: "6px 8px",
+                  textAlign: "right",
+                  color:
+                    b.ev_per_credit === null || b.ev_per_credit === undefined
+                      ? COLORS.creamDim
+                      : b.ev_per_credit > 0
+                        ? COLORS.goldBright
+                        : b.ev_per_credit < 0
+                          ? COLORS.red
+                          : COLORS.cream,
+                }}
+                className="mono"
+              >
+                {fmtEv(b.ev_per_credit)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function TimelineTable({ timeline }) {
+  const maxAbsNet = Math.max(1, ...timeline.map((t) => Math.abs(t.net)));
+  return (
+    <div className="panel" style={{ padding: 12, overflowX: "auto" }}>
+      <div style={{ fontSize: 11, color: COLORS.creamDim, marginBottom: 8, letterSpacing: "0.1em" }}>BY DAY (UTC)</div>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ color: COLORS.creamDim, textAlign: "right" }}>
+            <th style={{ textAlign: "left", padding: "4px 8px" }}>Date</th>
+            <th style={{ padding: "4px 8px" }}>Plays</th>
+            <th style={{ padding: "4px 8px" }}>Wagered</th>
+            <th style={{ padding: "4px 8px" }}>Returned</th>
+            <th style={{ padding: "4px 8px" }}>Net</th>
+            <th style={{ padding: "4px 8px" }}>RTP</th>
+            <th style={{ textAlign: "left", padding: "4px 8px", minWidth: 160 }}>Net (visual)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {timeline.map((row) => {
+            const pct = (Math.abs(row.net) / maxAbsNet) * 100;
+            const positive = row.net >= 0;
+            return (
+              <tr key={row.date} style={{ borderTop: "1px solid rgba(212,165,72,0.1)", color: COLORS.cream }}>
+                <td style={{ padding: "4px 8px", textAlign: "left" }} className="mono">
+                  {row.date}
+                </td>
+                <td style={{ padding: "4px 8px", textAlign: "right" }} className="mono">
+                  {fmtInt(row.count)}
+                </td>
+                <td style={{ padding: "4px 8px", textAlign: "right" }} className="mono">
+                  {fmtInt(row.wagered)}
+                </td>
+                <td style={{ padding: "4px 8px", textAlign: "right" }} className="mono">
+                  {fmtInt(row.returned)}
+                </td>
+                <td
+                  style={{
+                    padding: "4px 8px",
+                    textAlign: "right",
+                    color: row.net > 0 ? COLORS.goldBright : row.net < 0 ? COLORS.red : COLORS.cream,
+                  }}
+                  className="mono"
+                >
+                  {row.net > 0 ? "+" : ""}
+                  {fmtInt(row.net)}
+                </td>
+                <td style={{ padding: "4px 8px", textAlign: "right" }} className="mono">
+                  {fmtRtp(row.rtp)}
+                </td>
+                <td style={{ padding: "4px 8px" }}>
+                  <div style={{ height: 6, background: "rgba(0,0,0,0.4)", borderRadius: 2, position: "relative" }}>
+                    <div
+                      style={{
+                        height: "100%",
+                        width: `${pct}%`,
+                        background: positive ? COLORS.gold : COLORS.red,
+                      }}
+                    />
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/x/auragon_study_casino/frontend/study_casino.jsx
+++ b/x/auragon_study_casino/frontend/study_casino.jsx
@@ -8,11 +8,15 @@ import { StudyView } from "./StudyView.jsx";
 import { PrizesView } from "./PrizesView.jsx";
 import { StatsView } from "./StatsView.jsx";
 import { AdminView } from "./AdminView.jsx";
+import { CasinoStatsView } from "./CasinoStatsView.jsx";
 import { Roulette } from "./Roulette.jsx";
 import { Blackjack } from "./Blackjack.jsx";
 import { Slots } from "./Slots.jsx";
 
-const VIEWS = ["study", "casino", "prizes", "stats", "admin"];
+// `casino-stats` is deliberately omitted from the top-nav row below — it's
+// reachable by the small "View payout history" link inside CasinoView, or by
+// hitting `?view=casino-stats` directly.
+const VIEWS = ["study", "casino", "prizes", "stats", "admin", "casino-stats"];
 
 export default function StudyCasino() {
   const [view, setView] = useUrlState("view", VIEWS, "study");
@@ -478,8 +482,10 @@ export default function StudyCasino() {
             blackjackHit={blackjackHit}
             blackjackStand={blackjackStand}
             blackjackDouble={blackjackDouble}
+            openStats={() => setView("casino-stats")}
           />
         )}
+        {view === "casino-stats" && <CasinoStatsView isAdmin={isAdmin} />}
         {view === "prizes" && (
           <PrizesView
             offline={offline}
@@ -531,6 +537,7 @@ function CasinoView({
   blackjackHit,
   blackjackStand,
   blackjackDouble,
+  openStats,
 }) {
   const [game, setGame] = useUrlState("game", GAMES, "roulette");
   const gameProps = {
@@ -571,9 +578,28 @@ function CasinoView({
       </div>
 
       <div
-        style={{ fontSize: 12, color: COLORS.creamDim, textAlign: "center", marginBottom: 18, letterSpacing: "0.1em" }}
+        style={{ fontSize: 12, color: COLORS.creamDim, textAlign: "center", marginBottom: 6, letterSpacing: "0.1em" }}
       >
         Bets pay out in <strong style={{ color: COLORS.rose }}>tokens</strong> · winnings can only be spent on prizes
+      </div>
+      <div style={{ textAlign: "center", marginBottom: 18 }}>
+        <button
+          onClick={openStats}
+          style={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            color: COLORS.creamDim,
+            fontSize: 11,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            cursor: "pointer",
+            textDecoration: "underline",
+            textUnderlineOffset: 3,
+          }}
+        >
+          View payout history →
+        </button>
       </div>
 
       {game === "roulette" && <Roulette {...gameProps} />}

--- a/x/auragon_study_casino/frontend/sync.js
+++ b/x/auragon_study_casino/frontend/sync.js
@@ -257,3 +257,16 @@ export async function fetchAdminUsers() {
 export async function fetchAdminUserState(username) {
   return adminFetch(`/admin/state?user=${encodeURIComponent(username)}`);
 }
+
+/** Fetch aggregated casino stats. With `targetUser`, hits the admin endpoint
+ *  for any user (caller must be admin); otherwise the caller's own stats. */
+export async function fetchCasinoStats(targetUser) {
+  const path = targetUser ? `/admin/casino/stats?user=${encodeURIComponent(targetUser)}` : "/casino/stats";
+  const resp = await fetch(path, { credentials: "same-origin" });
+  if (resp.status === 401) {
+    window.location.href = "/auth/login";
+    throw new Error("not authenticated");
+  }
+  if (!resp.ok) throw new Error(`${path} ${resp.status}`);
+  return resp.json();
+}

--- a/x/auragon_study_casino/games.py
+++ b/x/auragon_study_casino/games.py
@@ -258,6 +258,62 @@ def _weighted_pick(items: list[dict], rng: RandomSource) -> dict:
     return items[-1]
 
 
+def theoretical_bucket_rtp() -> dict[tuple[str, str], tuple[float, float]]:
+    """Closed-form (win_probability, rtp) per (game, bucket_key).
+
+    Derived from the same constants the live RNG uses (`WHEEL`, `RED`,
+    `SLOT_SYMBOLS` weights and the slot triple/pair payout structure), so
+    the casino stats page can show theoretical-vs-empirical side by side.
+    Blackjack is omitted — no clean closed form, only the simulator knows.
+    """
+    out: dict[tuple[str, str], tuple[float, float]] = {}
+
+    # Roulette: bet against the 37-pocket wheel.
+    n_pockets = len(WHEEL)
+    for bet_type in ("red", "black", "odd", "even", "low", "high", "dozen1", "dozen2", "dozen3", "number"):
+        wins = sum(1 for num in WHEEL if _roulette_win(num, bet_type, num if bet_type == "number" else None)[0])
+        # All winning multipliers are constant per bet_type — pull mult from any winning pocket.
+        mult = next(
+            (
+                _roulette_win(num, bet_type, num if bet_type == "number" else None)[1]
+                for num in WHEEL
+                if _roulette_win(num, bet_type, num if bet_type == "number" else None)[0]
+            ),
+            0,
+        )
+        p_win = wins / n_pockets
+        rtp = p_win * mult
+        out[("roulette", bet_type)] = (p_win, rtp)
+
+    # Slots: enumerate the joint distribution of three independent weighted picks.
+    total_weight = sum(int(sym["weight"]) for sym in SLOT_SYMBOLS)
+    p_triple = 0.0
+    rtp_triple = 0.0
+    p_pair = 0.0
+    rtp_pair = 0.0
+    for i, sym in enumerate(SLOT_SYMBOLS):
+        p_i = int(sym["weight"]) / total_weight
+        # P(triple of this symbol) = p_i^3, payout = wager * symbol.payout, so RTP contribution = p_i^3 * payout
+        p_triple += p_i**3
+        rtp_triple += (p_i**3) * int(sym["payout"])
+        # P(exactly two of this symbol over the three picks): choose 2 of 3 positions = 3 * p_i^2 * (1 - p_i),
+        # then the third pick must be any *different* symbol — already captured by (1 - p_i).
+        # Payout = floor(wager * 1.5) ≈ 1.5x.
+        for j, _sym_j in enumerate(SLOT_SYMBOLS):
+            if i == j:
+                continue
+            p_j = int(_sym_j["weight"]) / total_weight
+            # Three ordered patterns where exactly two slots are i and the third is j:
+            # (i,i,j), (i,j,i), (j,i,i).
+            p_pair += 3 * (p_i**2) * p_j
+    rtp_pair = p_pair * 1.5
+    out[("slots", "triple")] = (p_triple, rtp_triple)
+    out[("slots", "pair")] = (p_pair, rtp_pair)
+    out[("slots", "none")] = (max(0.0, 1.0 - p_triple - p_pair), 0.0)
+
+    return out
+
+
 def _roulette_win(num: int, bet_type: str, bet_number: int | None) -> tuple[bool, int]:
     if num == 0 and bet_type != "number":
         return False, 0

--- a/x/auragon_study_casino/stats.py
+++ b/x/auragon_study_casino/stats.py
@@ -1,0 +1,64 @@
+"""Aggregated casino stats — empirical payout rates / EV per wager type.
+
+Only `server_resolved` `game_events` rows are aggregated. Pre-2026-05-07
+`client_reported` rows remain in the table for ledger reconstruction but
+are excluded here because their `outcome` payload shape is not guaranteed.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+# Cutover date from `client_reported` to `server_resolved`. Empirical
+# stats only cover events from this date forward.
+SERVER_RESOLVED_SINCE_DATE = "2026-05-07"
+
+
+class WagerBucketStats(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    count: int
+    wins: int
+    wagered: int
+    returned: int
+    net: int
+    payout_rate: float | None
+    rtp: float | None
+    ev_per_credit: float | None
+    theoretical_payout_rate: float | None = None
+    theoretical_rtp: float | None = None
+    theoretical_ev_per_credit: float | None = None
+
+
+class TimeBucketStats(BaseModel):
+    """Aggregate over a single time slice (UTC day) for one game."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str  # ISO date "YYYY-MM-DD" (UTC)
+    count: int
+    wins: int
+    wagered: int
+    returned: int
+    net: int
+    rtp: float | None
+
+
+class GameStats(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    game: str
+    total: WagerBucketStats
+    buckets: list[WagerBucketStats]
+    timeline: list[TimeBucketStats]
+
+
+class CasinoStats(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    username: str
+    since_date: str
+    event_count: int
+    games: list[GameStats]

--- a/x/auragon_study_casino/store.py
+++ b/x/auragon_study_casino/store.py
@@ -9,6 +9,7 @@ rows inside one transaction and writes a `ledger_events` row keyed by
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import time
 import uuid
@@ -24,7 +25,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from x.auragon_study_casino.events import GameEventRead, LedgerEventRead, game_event_from_row, ledger_event_from_row
-from x.auragon_study_casino.games import RULES_VERSION
+from x.auragon_study_casino.games import RULES_VERSION, theoretical_bucket_rtp
 from x.auragon_study_casino.models import (
     BalanceRow,
     GameEventRow,
@@ -33,6 +34,13 @@ from x.auragon_study_casino.models import (
     PrizeRow,
     SessionRow,
     StateSnapshotRow,
+)
+from x.auragon_study_casino.stats import (
+    SERVER_RESOLVED_SINCE_DATE,
+    CasinoStats,
+    GameStats,
+    TimeBucketStats,
+    WagerBucketStats,
 )
 
 _MIGRATIONS_DIR = Path(__file__).parent / "migrations"
@@ -152,6 +160,29 @@ class SqlStore:
                 ).all()
             )
             return [ledger_event_from_row(row) for row in rows]
+
+    def casino_stats(self, username: str) -> CasinoStats:
+        """Aggregate server-resolved `game_events` into per-game / per-wager-type
+        and per-UTC-day buckets. `client_reported` rows are excluded — their
+        `outcome` payload shape is not guaranteed (legacy SQLite era)."""
+        with self._Session() as s:
+            rows = list(
+                s.scalars(
+                    select(GameEventRow)
+                    .where(GameEventRow.user_id == username, GameEventRow.source == "server_resolved")
+                    .order_by(GameEventRow.id)
+                ).all()
+            )
+        events = [game_event_from_row(row) for row in rows]
+        theoretical = theoretical_bucket_rtp()
+        games = [
+            _aggregate_game(events, "roulette", _ROULETTE_BUCKETS, _roulette_bucket_key, theoretical),
+            _aggregate_game(events, "blackjack", _BLACKJACK_BUCKETS, _blackjack_bucket_key, theoretical),
+            _aggregate_game(events, "slots", _SLOTS_BUCKETS, _slots_bucket_key, theoretical),
+        ]
+        return CasinoStats(
+            username=username, since_date=SERVER_RESOLVED_SINCE_DATE, event_count=len(events), games=games
+        )
 
     # ── Write-side ──────────────────────────────────────────────────────────
 
@@ -417,6 +448,124 @@ class SqlStore:
     @staticmethod
     def _json(value: Any) -> str:
         return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+# Buckets are listed in display order, with stable keys matching the strings
+# emitted into GameEventRow.outcome_json by games.py.
+_ROULETTE_BUCKETS: list[tuple[str, str]] = [
+    ("red", "Red"),
+    ("black", "Black"),
+    ("odd", "Odd"),
+    ("even", "Even"),
+    ("low", "Low (1-18)"),
+    ("high", "High (19-36)"),
+    ("dozen1", "1st dozen"),
+    ("dozen2", "2nd dozen"),
+    ("dozen3", "3rd dozen"),
+    ("number", "Single number"),
+]
+_SLOTS_BUCKETS: list[tuple[str, str]] = [("triple", "Triple"), ("pair", "Pair"), ("none", "No match")]
+_BLACKJACK_BUCKETS: list[tuple[str, str]] = [
+    ("blackjack", "Blackjack"),
+    ("win", "Win"),
+    ("dealerBust", "Dealer bust"),
+    ("push", "Push"),
+    ("lose", "Lose"),
+    ("bust", "Bust"),
+]
+
+
+def _roulette_bucket_key(outcome: dict[str, Any]) -> str | None:
+    bet_type = outcome.get("bet_type")
+    return bet_type if isinstance(bet_type, str) else None
+
+
+def _slots_bucket_key(outcome: dict[str, Any]) -> str | None:
+    kind = outcome.get("payout_kind")
+    return kind if isinstance(kind, str) else None
+
+
+def _blackjack_bucket_key(outcome: dict[str, Any]) -> str | None:
+    kind = outcome.get("outcome")
+    return kind if isinstance(kind, str) else None
+
+
+def _aggregate_game(
+    events: list[GameEventRead],
+    game: str,
+    bucket_defs: list[tuple[str, str]],
+    bucket_key: Callable[[dict[str, Any]], str | None],
+    theoretical: dict[tuple[str, str], tuple[float, float]],
+) -> GameStats:
+    game_events = [e for e in events if e.game == game]
+    by_key: dict[str, list[GameEventRead]] = {key: [] for key, _ in bucket_defs}
+    for e in game_events:
+        key = bucket_key(e.outcome)
+        if key is None or key not in by_key:
+            continue
+        by_key[key].append(e)
+
+    buckets = [_bucket_stats(key, label, by_key[key], theoretical.get((game, key))) for key, label in bucket_defs]
+    total = _bucket_stats("__total__", "All wagers", game_events, None)
+
+    # Timeline never crosses below the data-collection cutoff — defensive
+    # against a backfilled `server_resolved` row whose `occurred_at_ms`
+    # somehow predates 2026-05-07.
+    by_day: dict[str, list[GameEventRead]] = {}
+    for e in game_events:
+        day = _dt.datetime.fromtimestamp(e.occurred_at_ms / 1000.0, tz=_dt.UTC).date().isoformat()
+        if day < SERVER_RESOLVED_SINCE_DATE:
+            continue
+        by_day.setdefault(day, []).append(e)
+    timeline = [_time_bucket_stats(day, by_day[day]) for day in sorted(by_day)]
+
+    return GameStats(game=game, total=total, buckets=buckets, timeline=timeline)
+
+
+def _bucket_stats(
+    key: str, label: str, events: list[GameEventRead], theoretical: tuple[float, float] | None
+) -> WagerBucketStats:
+    count = len(events)
+    wins = sum(1 for e in events if e.payout_tokens > 0)
+    wagered = sum(e.wager_credits for e in events)
+    returned = sum(e.payout_tokens for e in events)
+    net = returned - wagered
+    payout_rate = (wins / count) if count > 0 else None
+    rtp = (returned / wagered) if wagered > 0 else None
+    ev = (net / wagered) if wagered > 0 else None
+    theor_p, theor_rtp = theoretical if theoretical is not None else (None, None)
+    theor_ev = (theor_rtp - 1.0) if theor_rtp is not None else None
+    return WagerBucketStats(
+        key=key,
+        label=label,
+        count=count,
+        wins=wins,
+        wagered=wagered,
+        returned=returned,
+        net=net,
+        payout_rate=payout_rate,
+        rtp=rtp,
+        ev_per_credit=ev,
+        theoretical_payout_rate=theor_p,
+        theoretical_rtp=theor_rtp,
+        theoretical_ev_per_credit=theor_ev,
+    )
+
+
+def _time_bucket_stats(date: str, events: list[GameEventRead]) -> TimeBucketStats:
+    count = len(events)
+    wins = sum(1 for e in events if e.payout_tokens > 0)
+    wagered = sum(e.wager_credits for e in events)
+    returned = sum(e.payout_tokens for e in events)
+    return TimeBucketStats(
+        date=date,
+        count=count,
+        wins=wins,
+        wagered=wagered,
+        returned=returned,
+        net=returned - wagered,
+        rtp=(returned / wagered) if wagered > 0 else None,
+    )
 
 
 _DEFAULT_PRIZES_AS_DICTS: list[dict[str, Any]] = [

--- a/x/auragon_study_casino/test_app.py
+++ b/x/auragon_study_casino/test_app.py
@@ -437,5 +437,65 @@ def test_admin_state_rejects_overlong_user_param(tmp_path: Path, db_url: str) ->
         assert c.get("/admin/state", params={"user": ""}).status_code == 422
 
 
+# ── Casino stats endpoint ────────────────────────────────────────────────────
+
+
+def test_casino_stats_returns_empty_for_fresh_user(client: TestClient) -> None:
+    r = client.get("/casino/stats")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["event_count"] == 0
+    assert body["since_date"] == "2026-05-07"
+    assert {g["game"] for g in body["games"]} == {"roulette", "blackjack", "slots"}
+
+
+def test_casino_stats_counts_a_real_spin(client: TestClient) -> None:
+    _grant_credits(client, 5)
+    r = client.post("/casino/slots/spin", json={"client_action_id": "stats-spin", "wager_credits": 1})
+    assert r.status_code == 200, r.text
+
+    body = client.get("/casino/stats").json()
+    slots = next(g for g in body["games"] if g["game"] == "slots")
+    assert slots["total"]["count"] == 1
+    assert slots["total"]["wagered"] == 1
+    assert len(slots["timeline"]) == 1
+    assert slots["timeline"][0]["count"] == 1
+
+
+def test_admin_casino_stats_returns_target_user_stats(tmp_path: Path, db_url: str) -> None:
+    app = create_app(
+        Settings(database_url=db_url, frontend_dist_dir=tmp_path / "nonexistent_dist", admin_users={"rai"})
+    )
+    dep = app.state.current_user_dep
+    with TestClient(app) as c:
+        app.dependency_overrides[dep] = lambda: "auragon"
+        _grant_credits(c, 5, action_id="auragon-stats-seed")
+        r = c.post("/casino/slots/spin", json={"client_action_id": "auragon-spin", "wager_credits": 1})
+        assert r.status_code == 200, r.text
+
+        app.dependency_overrides[dep] = lambda: "rai"
+        r = c.get("/admin/casino/stats", params={"user": "auragon"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["username"] == "auragon"
+        assert body["event_count"] == 1
+
+
+def test_admin_casino_stats_404_for_unknown_user(tmp_path: Path, db_url: str) -> None:
+    app = create_app(
+        Settings(database_url=db_url, frontend_dist_dir=tmp_path / "nonexistent_dist", admin_users={"rai"})
+    )
+    dep = app.state.current_user_dep
+    with TestClient(app) as c:
+        app.dependency_overrides[dep] = lambda: "rai"
+        c.get("/state")  # seed 'rai' so /admin/users isn't empty
+        r = c.get("/admin/casino/stats", params={"user": "ghost"})
+        assert r.status_code == 404
+
+
+def test_admin_casino_stats_403_for_non_admin(non_admin_client: TestClient) -> None:
+    assert non_admin_client.get("/admin/casino/stats?user=default").status_code == 403
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/x/auragon_study_casino/test_store.py
+++ b/x/auragon_study_casino/test_store.py
@@ -224,7 +224,7 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             10,
             20,
             {"bet_type": "red", "won": True},
-            1_746_700_000_000,
+            1_778_200_000_000,
         ),  # 2026-05-08
         (
             "ce-2",
@@ -233,7 +233,7 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             10,
             20,
             {"bet_type": "red", "won": True},
-            1_746_700_001_000,
+            1_778_200_001_000,
         ),  # 2026-05-08
         (
             "ce-3",
@@ -242,10 +242,10 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             10,
             0,
             {"bet_type": "red", "won": False},
-            1_746_800_000_000,
+            1_778_300_000_000,
         ),  # 2026-05-09
-        ("ce-4", "slots", "server_resolved", 5, 100, {"payout_kind": "triple"}, 1_746_700_002_000),  # 2026-05-08
-        ("ce-5", "blackjack", "server_resolved", 4, 8, {"outcome": "win"}, 1_746_700_003_000),  # 2026-05-08
+        ("ce-4", "slots", "server_resolved", 5, 100, {"payout_kind": "triple"}, 1_778_200_002_000),  # 2026-05-08
+        ("ce-5", "blackjack", "server_resolved", 4, 8, {"outcome": "win"}, 1_778_200_003_000),  # 2026-05-08
         ("legacy", "roulette", "client_reported", 99, 0, {"bet_type": "black"}, 1_746_000_000_000),
     ]
     # Need a balance row first (for FK / seed convention).

--- a/x/auragon_study_casino/test_store.py
+++ b/x/auragon_study_casino/test_store.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 import pytest_bazel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from x.auragon_study_casino.models import BalanceRow, StateSnapshotRow
+from x.auragon_study_casino.models import BalanceRow, GameEventRow, StateSnapshotRow
 from x.auragon_study_casino.store import ActionMutation, ActionRejectedError, ServerActionResult, SqlStore
 
 
@@ -207,6 +209,122 @@ def test_two_users_share_db_without_collision(store: SqlStore) -> None:
     # Each user's ledger lists only their own row.
     assert len(store.list_ledger_events("alice")) == 1
     assert len(store.list_ledger_events("bob")) == 1
+
+
+def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
+    """`casino_stats` buckets server_resolved game_events by wager type and
+    by UTC day, ignoring legacy `client_reported` rows entirely."""
+    # Three roulette spins on red (2 wins, 1 loss), one slots triple, one
+    # blackjack win, plus one stray `client_reported` row that must NOT count.
+    fixtures = [
+        (
+            "ce-1",
+            "roulette",
+            "server_resolved",
+            10,
+            20,
+            {"bet_type": "red", "won": True},
+            1_746_700_000_000,
+        ),  # 2026-05-08
+        (
+            "ce-2",
+            "roulette",
+            "server_resolved",
+            10,
+            20,
+            {"bet_type": "red", "won": True},
+            1_746_700_001_000,
+        ),  # 2026-05-08
+        (
+            "ce-3",
+            "roulette",
+            "server_resolved",
+            10,
+            0,
+            {"bet_type": "red", "won": False},
+            1_746_800_000_000,
+        ),  # 2026-05-09
+        ("ce-4", "slots", "server_resolved", 5, 100, {"payout_kind": "triple"}, 1_746_700_002_000),  # 2026-05-08
+        ("ce-5", "blackjack", "server_resolved", 4, 8, {"outcome": "win"}, 1_746_700_003_000),  # 2026-05-08
+        ("legacy", "roulette", "client_reported", 99, 0, {"bet_type": "black"}, 1_746_000_000_000),
+    ]
+    # Need a balance row first (for FK / seed convention).
+    store.state_dump(_U)
+    with store._Session() as s, s.begin():
+        for client_event_id, game, source, wager, payout, outcome, occurred_at_ms in fixtures:
+            s.add(
+                GameEventRow(
+                    user_id=_U,
+                    client_event_id=client_event_id,
+                    server_at_ms=occurred_at_ms,
+                    occurred_at_ms=occurred_at_ms,
+                    game=game,
+                    event_type="settle",
+                    source=source,
+                    wager_credits=wager,
+                    payout_tokens=payout,
+                    credits_before=0,
+                    credits_after=0,
+                    tokens_before=0,
+                    tokens_after=0,
+                    server_credits=0,
+                    server_tokens=0,
+                    outcome_json=json.dumps(outcome),
+                    rules_version="server-rules-v1",
+                    rng_version="server-secrets-v1",
+                )
+            )
+
+    result = store.casino_stats(_U)
+
+    assert result.username == _U
+    assert result.since_date == "2026-05-07"
+    assert result.event_count == 5  # legacy row excluded
+
+    games_by_name = {g.game: g for g in result.games}
+    roulette = games_by_name["roulette"]
+    red = next(b for b in roulette.buckets if b.key == "red")
+    assert red.count == 3
+    assert red.wins == 2
+    assert red.wagered == 30
+    assert red.returned == 40
+    assert red.net == 10
+    assert red.payout_rate == pytest.approx(2 / 3)
+    assert red.rtp == pytest.approx(40 / 30)
+    # Theoretical for red on a 37-pocket wheel: P(win) = 18/37, RTP = 36/37.
+    assert red.theoretical_payout_rate == pytest.approx(18 / 37)
+    assert red.theoretical_rtp == pytest.approx(36 / 37)
+
+    # Roulette total covers all 3 roulette spins (no black/etc.).
+    assert roulette.total.count == 3
+    # Timeline buckets across two UTC days.
+    assert [b.date for b in roulette.timeline] == ["2026-05-08", "2026-05-09"]
+    assert roulette.timeline[0].count == 2
+    assert roulette.timeline[1].count == 1
+
+    slots = games_by_name["slots"]
+    triple = next(b for b in slots.buckets if b.key == "triple")
+    assert triple.count == 1
+    assert triple.wins == 1
+    assert triple.rtp == pytest.approx(20.0)
+    assert triple.theoretical_rtp is not None
+
+    blackjack = games_by_name["blackjack"]
+    win = next(b for b in blackjack.buckets if b.key == "win")
+    assert win.count == 1
+    # No theoretical RTP for blackjack.
+    assert win.theoretical_rtp is None
+
+
+def test_casino_stats_empty_for_fresh_user(store: SqlStore) -> None:
+    result = store.casino_stats(_U)
+    assert result.event_count == 0
+    for game in result.games:
+        assert game.total.count == 0
+        assert game.timeline == []
+        for bucket in game.buckets:
+            assert bucket.count == 0
+            assert bucket.rtp is None
 
 
 def _balance_select(username: str):


### PR DESCRIPTION
## Summary
Adds empirical payout statistics tracking for casino games, aggregated by wager type and UTC day. Includes a new stats view showing win rates, RTP (return-to-player), and EV per credit alongside theoretical values for comparison.

## Key Changes

**Backend (Python)**
- New `stats.py` module with Pydantic models for aggregated casino statistics (`CasinoStats`, `GameStats`, `WagerBucketStats`, `TimeBucketStats`)
- `SqlStore.casino_stats()` method aggregates `server_resolved` game events (excluding legacy `client_reported` rows) into per-game, per-wager-type, and per-UTC-day buckets
- `games.py` adds `theoretical_bucket_rtp()` function computing closed-form win probabilities and RTP for roulette and slots from game constants
- Two new FastAPI endpoints:
  - `GET /casino/stats` — caller's own stats
  - `GET /admin/casino/stats?user=<username>` — admin-only, stats for any user
- Comprehensive test coverage in `test_store.py` and `test_app.py`

**Frontend (React/JavaScript)**
- New `CasinoStatsView.jsx` component displaying:
  - Per-game breakdown with wager-type buckets (e.g., red/black for roulette, triple/pair for slots)
  - Empirical vs. theoretical win rates and RTP side-by-side
  - Daily timeline with visual net-payout bars
  - Admin user lookup via query parameter
- `sync.js` adds `fetchCasinoStats()` helper for both user and admin endpoints
- `study_casino.jsx` integrates the new view and adds "View payout history" link from the casino view
- Build configuration updated to include new component

## Notable Implementation Details

- Only `server_resolved` events are aggregated; pre-2026-05-07 `client_reported` rows are excluded due to inconsistent outcome payload shapes
- Theoretical RTP computed from game constants (wheel pockets, symbol weights, payout multipliers) for roulette and slots; blackjack omitted (no closed form)
- Timeline defensively filters out any events predating the 2026-05-07 cutover date
- Admin stats view requires explicit user parameter; non-existent users return 404
- Formatting helpers handle null/undefined gracefully (display "—") and color-code positive/negative net payouts

https://claude.ai/code/session_01WFhpke6u6nP4LD8AHxQwDP