### PR TITLE
debundle: narrow lazy_rebind + at-init promotion to first-order body

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -158,6 +158,52 @@ mod tests {
         assert_eq!(facts[1].body_calls, BTreeSet::from(["g".to_string()]),);
     }
 
+    /// A binding rebind inside a function's immediate body
+    /// shows up in both `lazy_rebinds` and `first_order_lazy_rebinds`.
+    /// At-init promotion and the direct `lazy_rebind` owner edge
+    /// both read from the first-order subset.
+    #[test]
+    fn first_order_lazy_rebind_in_immediate_body() {
+        let module = parse("let s = 0; function f() { s = 1; }");
+        let facts = analyze_facts(&module);
+        // f's decl: body rebinds s at depth 1.
+        assert_eq!(facts[1].lazy_rebinds, BTreeSet::from(["s".to_string()]));
+        assert_eq!(
+            facts[1].first_order_lazy_rebinds,
+            BTreeSet::from(["s".to_string()])
+        );
+    }
+
+    /// A binding rebind inside a nested closure (depth ≥ 2) shows
+    /// up in `lazy_rebinds` but NOT in `first_order_lazy_rebinds`
+    /// — invoking the outer function synchronously only stashes
+    /// the closure; the rebind doesn't fire. See
+    /// `at_init_promotion_nested_closure_test`.
+    #[test]
+    fn first_order_lazy_rebind_skips_nested_closure() {
+        let module = parse(
+            "let s = 0; \
+             function f() { globalThis.fire = () => { s = 1; }; }",
+        );
+        let facts = analyze_facts(&module);
+        assert_eq!(facts[1].lazy_rebinds, BTreeSet::from(["s".to_string()]));
+        assert!(facts[1].first_order_lazy_rebinds.is_empty());
+    }
+
+    /// Same depth distinction for calls: a call in the immediate
+    /// body fires when the function is invoked, but a call inside
+    /// a nested closure only fires when the nested closure fires.
+    #[test]
+    fn first_order_body_call_skips_nested_closure() {
+        let module = parse(
+            "function g() {} \
+             function f() { globalThis.fire = () => { g(); }; }",
+        );
+        let facts = analyze_facts(&module);
+        assert_eq!(facts[1].body_calls, BTreeSet::from(["g".to_string()]));
+        assert!(facts[1].first_order_body_calls.is_empty());
+    }
+
     #[test]
     fn function_body_reads_are_lazy() {
         let module = parse("function f() { return X; } const Y = 1;");

--- a/devinfra/js/debundle/e2e/at_init_promotion_nested_closure_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_nested_closure_test.rs
@@ -1,28 +1,18 @@
-//! RED test: at-init call promotion is over-conservative for
-//! rebinds that lexically appear inside a nested closure but never
-//! fire at module-initialization time.
+//! Regression test: at-init call promotion (and the direct
+//! `lazy_rebind` owner edge) must not propagate rebinds that
+//! lexically appear inside a nested closure but never fire at
+//! module-initialization time.
 //!
 //! Background: DESIGN.md "At-init call promotion" makes the
 //! caller-statement of an at-init call inherit its callee's
-//! transitive `lazy_reads` and `lazy_rebinds`. The classifier behind
-//! `lazy_rebinds` (`BindingWriteCollector` + `LazyBoundary` in
-//! `facts.rs:691-790`) sets `in_lazy = true` at the **first**
-//! function boundary it crosses and never resets it. Rebinds inside
-//! a function body that is itself nested inside an outer function
-//! body (e.g. an arrow function returned/stashed by the outer
-//! function) are recorded as `lazy_rebinds` of the OUTER function.
-//!
-//! That's correct for clause 3 ("any rebind inside any function
-//! body is lazy from the chunk's top-level perspective"), but it's
-//! too coarse for at-init promotion. Promotion's intended semantics
-//! is "the at-init caller statement runs the part of the callee's
-//! body that executes synchronously when the call returns". A
-//! rebind inside a nested arrow function returned by the callee
-//! does NOT execute synchronously — it only fires when something
-//! later invokes the returned closure. Treating it as an at-init
-//! rebind manufactures a cross-module `eager_rebind` edge that
-//! doesn't exist at runtime, which then surfaces as an
-//! `atomic-factor-unit conflict` during materialize.
+//! transitive `lazy_reads` and `lazy_rebinds`. The classifier in
+//! `facts.rs` now tracks a `lazy_depth` counter on each
+//! `LazyBoundary` visitor, with `first_order_lazy_*` collected
+//! when the visitor sits directly inside a function body (depth 1)
+//! and the coarse `lazy_*` covering any depth ≥1. Promotion and
+//! the direct `lazy_rebind` edge use the first-order subset so a
+//! rebind inside a nested arrow doesn't manufacture a cross-module
+//! constraint that nothing actually fires.
 //!
 //! ## Fixture
 //!
@@ -54,55 +44,28 @@
 //! The materializer can emit this spec and Node will run it
 //! correctly. The ESM linker has no ordering problem to solve.
 //!
-//! ## What ducktape does today
+//! ## Implementation
 //!
-//! `facts.rs::analyze_chunk` builds `setupHandler.lazy_rebinds =
-//! {"state"}` because the arrow body's `state = "updated"` write is
-//! lexically inside setupHandler's body (and `BindingWriteCollector`
-//! flips `in_lazy` at the outer function boundary; it never
-//! distinguishes between setupHandler's first-order body and a
-//! nested arrow inside it).
+//! `BindingWriteCollector`, `LazyReadCollector`, and `CallCollector`
+//! each track a `lazy_depth: u32` counter. `descend_lazy` increments
+//! on entry to a function/arrow/method body and decrements on exit.
+//! Each collector exposes a `first_order_*` subset whose entries
+//! were recorded while `lazy_depth == 1`. Two graph sites consume
+//! the subset:
 //!
-//! At-init call promotion in `graph.rs::promote_at_init_calls` then
-//! resolves residual's `setupHandler()` at-init call, walks
-//! `setupHandler.reachable_lazy_rebinds = {"state"}`, and emits an
-//! `eager_rebind` owner edge from the residual call-statement to
-//! `state`'s owner. Because `state` lives in `mod_state` and the
-//! call-statement lives in residual, the edge is cross-module.
-//!
-//! The factorize-assembly machinery (called from
-//! `materialize_logical_modules`) sees this rebind as a clause-2
-//! violation (cross-destination rebinding writes are never
-//! importable) and groups residual + mod_state + mod_handler into
-//! one inseparable atomic unit, rejecting the spec with an
-//! `atomic-factor-unit conflict` error.
-//!
-//! This test asserts the correct behavior (entry prints
-//! "initial"). It currently fails at `run_fixture` because the
-//! materializer rejects the spec before any JS is emitted.
-//!
-//! ## Suggested fix family
-//!
-//! `BindingWriteCollector` and `LazyReadCollector` need a finer
-//! state than the current binary `in_lazy`. A clean
-//! implementation: distinguish "in callee's executable body" from
-//! "in a nested function inside callee's executable body". Two
-//! options:
-//!
-//! 1. Add a third state (`InFirstOrderBody` vs `InNestedClosure`)
-//!    to `LazyBoundary`. Collect rebinds in the first-order set
-//!    only; promotion uses the first-order set.
-//! 2. Split into two separate collectors with different boundary
-//!    rules — one for clause 3 (any function body counts as lazy),
-//!    one for promotion (only the immediate body counts; nested
-//!    closures don't).
+//! - `graph.rs::push_binding_edge` for `EdgeReason::lazy_rebind` —
+//!   so a rebind inside a nested closure no longer creates the
+//!   bidirectional G_atomic constraint at `atomic_units.rs:82-85`.
+//! - `graph.rs::promote_at_init_calls` for the call graph and its
+//!   per-owner rebind/read seeds — so an at-init call only inherits
+//!   the synchronous part of the callee's body.
 //!
 //! Production observation: gaffer-private's Tana chunk
-//! `static/index-DI2GynTv` produces 22 cross-module
+//! `static/index-DI2GynTv` produced 22 cross-module
 //! `eager_rebind` edges all sharing `statement_ordinal: 9705`
 //! (the top-level `try { ... Age(...) ... }` bootstrap), creating a
 //! 690-owner SCC spanning 11 modules. Every promoted rebind in
-//! that SCC traces back to deferred-callback writes inside event
+//! that SCC traced back to deferred-callback writes inside event
 //! handlers nested in the bootstrap's call graph — none of them
 //! fire at module init.
 

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -34,6 +34,15 @@ pub struct StatementFacts {
     /// excluded: mutating an imported object is legal, but rebinding
     /// the imported binding cell is not.
     pub lazy_rebinds: BTreeSet<BindingName>,
+    /// Subset of `lazy_reads` whose read sites sit in a function's
+    /// **first-order** body (depth 1 from this statement). Used by
+    /// at-init call promotion: a synchronous call to the function
+    /// only runs its immediate body, so reads inside nested
+    /// function/arrow definitions don't promote to the caller.
+    pub first_order_lazy_reads: BTreeSet<BindingName>,
+    /// Subset of `lazy_rebinds` whose write sites sit in a function's
+    /// first-order body. See `first_order_lazy_reads`.
+    pub first_order_lazy_rebinds: BTreeSet<BindingName>,
     /// Target-local mutations produced by recognized trusted helper
     /// calls. Each binding is the class/prototype owner that must
     /// co-locate with the mutating statement.
@@ -54,6 +63,12 @@ pub struct StatementFacts {
     /// (e.g. `function f() { g(); } f();` at top level promotes
     /// through `g`'s body too).
     pub body_calls: BTreeSet<BindingName>,
+    /// Subset of `body_calls` whose call sites sit in a function's
+    /// **first-order** body. The promotion call graph uses this so
+    /// that calls lexically nested inside a closure of the body
+    /// don't appear as direct callees of the outer function — they
+    /// don't fire when the outer function is invoked synchronously.
+    pub first_order_body_calls: BTreeSet<BindingName>,
     pub purity: Purity,
     pub kind: StatementKind,
 }
@@ -390,9 +405,12 @@ fn analyze_item(
         eager_rebinds: writes.at_init,
         lazy_reads: lazy.names,
         lazy_rebinds: writes.lazy,
+        first_order_lazy_reads: lazy.first_order,
+        first_order_lazy_rebinds: writes.first_order_lazy,
         local_effects,
         at_init_calls: calls.at_init,
         body_calls: calls.lazy,
+        first_order_body_calls: calls.first_order_lazy,
         purity,
         kind,
     }
@@ -687,14 +705,27 @@ impl Visit for AtInitReadCollector {
     }
 }
 
-/// Shared trait for visitors that track a lazy/eager syntactic boundary.
+/// Shared trait for visitors that track lazy nesting depth.
+///
+/// Depth semantics:
+/// - `0` — eager (outside any function body).
+/// - `1` — first-order lazy (inside the immediate body of a function).
+/// - `≥2` — nested lazy (inside a function nested in another function body).
+///
+/// At-init call promotion only inherits reads/rebinds/calls from a
+/// callee's first-order body, because a synchronous invocation of the
+/// callee runs only its immediate body; statements lexically inside
+/// nested function/arrow definitions are not executed until something
+/// later invokes the nested closure. The general `lazy_*` sets stay
+/// coarse (any depth ≥1) because, from the chunk's top-level POV, any
+/// rebind inside any function body remains "lazy".
 trait LazyBoundary: Visit {
-    fn in_lazy_mut(&mut self) -> &mut bool;
+    fn lazy_depth_mut(&mut self) -> &mut u32;
 
     fn descend_lazy<F: FnOnce(&mut Self)>(&mut self, f: F) {
-        let prev = std::mem::replace(self.in_lazy_mut(), true);
+        *self.lazy_depth_mut() += 1;
         f(self);
-        *self.in_lazy_mut() = prev;
+        *self.lazy_depth_mut() -= 1;
     }
 }
 
@@ -702,22 +733,32 @@ trait LazyBoundary: Visit {
 /// positions only — function bodies, method bodies, constructor
 /// bodies, instance class-field initializers, getter/setter bodies.
 /// Inverse boundary semantics from `AtInitReadCollector`.
+///
+/// `first_order` is the subset of `names` whose read sites sit
+/// directly inside the function body the read collector is visiting
+/// (depth 1); deeper closures don't contribute. Used by at-init call
+/// promotion.
 #[derive(Default)]
 struct LazyReadCollector {
     names: BTreeSet<String>,
-    in_lazy: bool,
+    first_order: BTreeSet<String>,
+    lazy_depth: u32,
 }
 
 impl LazyBoundary for LazyReadCollector {
-    fn in_lazy_mut(&mut self) -> &mut bool {
-        &mut self.in_lazy
+    fn lazy_depth_mut(&mut self) -> &mut u32 {
+        &mut self.lazy_depth
     }
 }
 
 impl Visit for LazyReadCollector {
     fn visit_ident(&mut self, node: &Ident) {
-        if self.in_lazy {
-            self.names.insert(node.sym.to_string());
+        if self.lazy_depth == 0 {
+            return;
+        }
+        self.names.insert(node.sym.to_string());
+        if self.lazy_depth == 1 {
+            self.first_order.insert(node.sym.to_string());
         }
     }
 
@@ -752,25 +793,34 @@ impl Visit for LazyReadCollector {
 /// Visitor that collects rebinding writes to identifier bindings,
 /// split by whether the write runs at module initialization or only
 /// from a lazy syntactic position.
+///
+/// `first_order_lazy` is the subset of `lazy` whose write sites sit
+/// directly inside the function body the collector is visiting
+/// (depth 1); deeper closures don't contribute. Used by at-init call
+/// promotion.
 #[derive(Default)]
 struct BindingWriteCollector {
     at_init: BTreeSet<String>,
     lazy: BTreeSet<String>,
-    in_lazy: bool,
+    first_order_lazy: BTreeSet<String>,
+    lazy_depth: u32,
 }
 
 impl LazyBoundary for BindingWriteCollector {
-    fn in_lazy_mut(&mut self) -> &mut bool {
-        &mut self.in_lazy
+    fn lazy_depth_mut(&mut self) -> &mut u32 {
+        &mut self.lazy_depth
     }
 }
 
 impl BindingWriteCollector {
     fn record_write(&mut self, name: &str) {
-        if self.in_lazy {
-            self.lazy.insert(name.to_string());
-        } else {
+        if self.lazy_depth == 0 {
             self.at_init.insert(name.to_string());
+            return;
+        }
+        self.lazy.insert(name.to_string());
+        if self.lazy_depth == 1 {
+            self.first_order_lazy.insert(name.to_string());
         }
     }
 }
@@ -857,12 +907,13 @@ impl Visit for BindingWriteCollector {
 struct CallCollector {
     at_init: BTreeSet<String>,
     lazy: BTreeSet<String>,
-    in_lazy: bool,
+    first_order_lazy: BTreeSet<String>,
+    lazy_depth: u32,
 }
 
 impl LazyBoundary for CallCollector {
-    fn in_lazy_mut(&mut self) -> &mut bool {
-        &mut self.in_lazy
+    fn lazy_depth_mut(&mut self) -> &mut u32 {
+        &mut self.lazy_depth
     }
 }
 
@@ -873,12 +924,15 @@ impl Visit for CallCollector {
 
     fn visit_call_expr(&mut self, node: &CallExpr) {
         if let Some(callee) = call_callee_ident(node) {
-            let bucket = if self.in_lazy {
-                &mut self.lazy
+            let name = callee.to_string();
+            if self.lazy_depth == 0 {
+                self.at_init.insert(name);
             } else {
-                &mut self.at_init
-            };
-            bucket.insert(callee.to_string());
+                self.lazy.insert(name.clone());
+                if self.lazy_depth == 1 {
+                    self.first_order_lazy.insert(name);
+                }
+            }
         }
         // Always recurse into args + callee so nested calls are seen.
         node.visit_children_with(self);

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -366,7 +366,18 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
                 stmt.ordinal,
             );
         }
-        for binding in &stmt.lazy_rebinds {
+        // Only first-order body rebinds emit a constraining
+        // `LazyRebind` edge. A rebind inside a nested closure
+        // (e.g. an arrow stashed on `globalThis` by the body)
+        // doesn't fire when the function is invoked synchronously;
+        // emitting an edge for it manufactures a bidirectional
+        // G_atomic constraint (atomic_units.rs:82-85) that forces
+        // co-location with the rebind target even though no
+        // synchronous-trace rebind exists. See the e2e test
+        // `at_init_promotion_nested_closure_test` for the
+        // rationale; the same first-order narrowing is what
+        // promote_at_init_calls uses.
+        for binding in &stmt.first_order_lazy_rebinds {
             push_binding_edge(
                 &mut raw_edges,
                 from,
@@ -493,27 +504,33 @@ fn promote_at_init_calls(
     raw_edges: &mut Vec<(OwnerId, OwnerId, EdgeReason)>,
 ) {
     // 1. Build the call graph: owner → owner edges for each
-    //    chunk-declared function callee reachable via body_calls.
-    //    Add every owner whose body has any lazy reads / rebinds /
-    //    calls as a node — those are the callable owners whose body
-    //    closures we may need to promote, even if the body itself
-    //    makes no calls (e.g. `function readB() { return B; }`).
+    //    chunk-declared function callee reachable via *first-order*
+    //    body_calls. Nested-closure calls (e.g. inside an arrow
+    //    returned by the body) don't fire when the body is invoked
+    //    synchronously, so they don't belong on the promotion call
+    //    graph — see DESIGN.md "At-init call promotion" and the e2e
+    //    test `at_init_promotion_nested_closure_test`.
+    //
+    //    Add every owner whose body has any first-order lazy reads /
+    //    rebinds / calls as a node — those are the callable owners
+    //    whose body closures we may need to promote, even if the body
+    //    itself makes no calls (e.g. `function readB() { return B; }`).
     let mut call_graph: DiGraphMap<OwnerId, ()> = DiGraphMap::new();
     for stmt in facts {
         let owner = OwnerId(stmt.ordinal.0);
-        if !stmt.body_calls.is_empty()
-            || !stmt.lazy_reads.is_empty()
-            || !stmt.lazy_rebinds.is_empty()
+        if !stmt.first_order_body_calls.is_empty()
+            || !stmt.first_order_lazy_reads.is_empty()
+            || !stmt.first_order_lazy_rebinds.is_empty()
         {
             call_graph.add_node(owner);
         }
     }
     for stmt in facts {
-        if stmt.body_calls.is_empty() {
+        if stmt.first_order_body_calls.is_empty() {
             continue;
         }
         let caller = OwnerId(stmt.ordinal.0);
-        for callee_name in &stmt.body_calls {
+        for callee_name in &stmt.first_order_body_calls {
             let Some(binding_id) = binding_table.get(callee_name) else {
                 continue;
             };
@@ -578,14 +595,14 @@ fn promote_at_init_calls(
             let Some(stmt) = stmt_by_owner.get(owner) else {
                 continue;
             };
-            for name in &stmt.lazy_reads {
+            for name in &stmt.first_order_lazy_reads {
                 if let Some(id) = binding_table.get(name)
                     && !target_is_hoisted(id)
                 {
                     reads.insert(id);
                 }
             }
-            for name in &stmt.lazy_rebinds {
+            for name in &stmt.first_order_lazy_rebinds {
                 if let Some(id) = binding_table.get(name) {
                     rebinds.insert(id);
                 }


### PR DESCRIPTION
## Summary

Fixes the at-init-promotion over-rejection pinned by #1642.

The classifier behind `lazy_rebinds` / `lazy_reads` / `body_calls` flipped `in_lazy = true` at the first function boundary and never reset it, so rebinds/reads/calls lexically inside a nested closure (an arrow returned/stashed by the outer body) were attributed to the outer function. That produced two phantom constraints:

- A direct `lazy_rebind` owner edge from the outer function to the rebind target, which `compute_atomic_units` treats as a bidirectional `G_atomic` edge (`atomic_units.rs:82-85`) — forcing both owners into the same atomic factor unit even when the nested closure never fires.
- An at-init-promoted `eager_rebind` edge from any caller of the outer function to the rebind target, which surfaces as a cross-module rebind during materialize even though invoking the outer function synchronously only stashes the closure.

The `LazyBoundary` trait now tracks a `lazy_depth: u32` counter, incremented on entry to each function/arrow/method body and decremented on exit. Each `LazyBoundary` collector (`LazyReadCollector`, `BindingWriteCollector`, `CallCollector`) exposes a `first_order_*` subset whose entries were recorded at depth 1. Two graph sites switch to the first-order subset:

- `graph.rs`'s direct `EdgeReason::lazy_rebind` edge — so a nested-closure rebind no longer creates the bidirectional `G_atomic` constraint.
- `graph.rs::promote_at_init_calls` (call graph + per-owner rebind/read seeds) — so an at-init call only inherits the synchronous part of the callee's body.

The coarse `lazy_*` sets stay intact for chunk-level lazy classification (clause 3: "any rebind inside any function body is lazy from the chunk's top-level perspective").

Flips `devinfra/js/debundle/e2e/at_init_promotion_nested_closure_test` from RED to GREEN.

## Production motivation

gaffer-private's Tana chunk `static/index-DI2GynTv` produced 22 cross-module `eager_rebind` edges all sharing `statement_ordinal: 9705` (the top-level `try { ... Age(...) ... }` bootstrap), creating a 690-owner SCC across 11 modules. Every promoted rebind in that SCC traced back to deferred-callback writes inside event handlers nested in the bootstrap's call graph — none of them fire at module init.

## Test plan

- [x] `bazel test //devinfra/js/debundle/...` — 50/50 GREEN (was 49/50 with the RED test from #1642).
- [x] Three new unit tests in `analysis_tests.rs` pin the `first_order_*` vs coarse-set semantics for rebinds and body calls.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_