### PR TITLE
debundle/lowering: per-sibling util imports + private time_phase! + tighter top_level_id

### DIFF
--- a/devinfra/js/debundle/ids.rs
+++ b/devinfra/js/debundle/ids.rs
@@ -10,10 +10,9 @@ use swc_ecma_ast::Id;
 /// to every top-level binding in a parsed `Module`. Spec-derived
 /// String names (which carry no ctxt) are resolved to their `Id` by
 /// pairing the sym with this canonical ctxt.
-#[allow(dead_code)] // CLEANUP(2026-05-18): remove once logical_modules.rs spec→Id boundary lands.
-pub fn top_level_id(sym: impl Into<Atom>, top_level_mark: Mark) -> Id {
+pub fn top_level_id(sym: &str, top_level_mark: Mark) -> Id {
     (
-        sym.into(),
+        Atom::from(sym),
         SyntaxContext::empty().apply_mark(top_level_mark),
     )
 }

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -2,6 +2,9 @@
 //! Both call `disambiguate_*_import_locals` (util.rs) to mint fresh
 //! locals when names collide with already-occupied bindings.
 
+use super::util::{
+    disambiguate_import_locals, disambiguate_residual_entry_import_locals, import_decl_for_plan,
+};
 use super::*;
 
 pub(super) fn cross_module_imports_for_plan(

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -4,6 +4,11 @@
 //! level orchestration that wraps this lives in mod.rs's
 //! `materialize_logical_chunk`.
 
+use super::util::{
+    collect_local_binding_names, collect_occupied_local_names, disambiguate_import_locals,
+    import_decl_for_plan, is_valid_js_identifier, preserve_export_specifier_names, relative_source,
+    remaining_item_after_selection,
+};
 use super::*;
 use crate::time_phase;
 

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -3,6 +3,10 @@
 //! files/applied/report are spliced into the artifact by
 //! `apply_materialized_logical_chunks`.
 
+use super::util::{
+    render_atomic_unit_cause_guidance, statement_ordinal_for_body_index, target_file_for_request,
+    write_chunk_report_json,
+};
 use super::*;
 use crate::time_phase;
 
@@ -193,7 +197,7 @@ pub(super) fn materialize_logical_chunk(
                     &mut imported_from_by_src,
                 )?;
                 bindings_catalogue.insert(
-                    top_level_id(member.binding.as_str(), chunk_top_level_mark),
+                    top_level_id(&member.binding, chunk_top_level_mark),
                     BindingKind::Imported {
                         imported_name,
                         imported_from,
@@ -209,7 +213,7 @@ pub(super) fn materialize_logical_chunk(
             if declaration_by_name.contains_key(binding) {
                 binding_assignment.insert(binding.clone(), index);
                 bindings_catalogue.insert(
-                    top_level_id(binding.as_str(), chunk_top_level_mark),
+                    top_level_id(binding, chunk_top_level_mark),
                     BindingKind::Owned { owner: module_id },
                 );
             }
@@ -253,7 +257,7 @@ pub(super) fn materialize_logical_chunk(
                 None => {
                     binding_assignment.insert(sibling.clone(), owner_index);
                     bindings_catalogue.insert(
-                        top_level_id(sibling.as_str(), chunk_top_level_mark),
+                        top_level_id(sibling, chunk_top_level_mark),
                         BindingKind::Owned { owner: owner_id },
                     );
                     let plan = &mut module_plans[owner_index];
@@ -293,7 +297,7 @@ pub(super) fn materialize_logical_chunk(
                     binding_assignment.insert(name.clone(), residual_index);
                     residual_bindings.insert(name.clone(), name.clone());
                     bindings_catalogue.insert(
-                        top_level_id(name.as_str(), chunk_top_level_mark),
+                        top_level_id(name, chunk_top_level_mark),
                         BindingKind::Owned {
                             owner: residual_module_id,
                         },
@@ -337,7 +341,7 @@ pub(super) fn materialize_logical_chunk(
                             .entry(name.clone())
                             .or_insert_with(|| name.clone());
                         bindings_catalogue.insert(
-                            top_level_id(name.as_str(), chunk_top_level_mark),
+                            top_level_id(name, chunk_top_level_mark),
                             BindingKind::Owned { owner: owner_id },
                         );
                     }
@@ -497,7 +501,7 @@ pub(super) fn materialize_logical_chunk(
                             .iter()
                             .map(|(local, exported)| {
                                 (
-                                    top_level_id(local.as_str(), chunk_top_level_mark),
+                                    top_level_id(local, chunk_top_level_mark),
                                     exported.as_str().into(),
                                 )
                             })
@@ -552,7 +556,7 @@ pub(super) fn materialize_logical_chunk(
             .iter()
             .map(|(local, exported)| {
                 (
-                    top_level_id(local.as_str(), chunk_top_level_mark),
+                    top_level_id(local, chunk_top_level_mark),
                     exported.as_str().into(),
                 )
             })

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -85,14 +85,9 @@ use runtime_imports::{
     RuntimeImportFacts, RuntimeImportInfo, RuntimeImportKind, imported_binding_named_specifier,
     record_runtime_imports, runtime_reimport_specifier,
 };
-#[allow(unused_imports)]
 use util::{
-    body_index_for_statement_ordinal, collect_local_binding_names, collect_occupied_local_names,
-    disambiguate_import_locals, disambiguate_residual_entry_import_locals, import_decl_for_plan,
-    is_identifier_like, is_valid_js_identifier, normalize_optional_relative_dir,
-    prepare_output_dir, preserve_export_specifier_names, prune_artifact_to_chunk_ids,
-    relative_source, remaining_item_after_selection, render_atomic_unit_cause_guidance,
-    statement_ordinal_for_body_index, target_file_for_request, write_chunk_report_json,
+    normalize_optional_relative_dir, prepare_output_dir, prune_artifact_to_chunk_ids,
+    write_chunk_report_json,
 };
 use visitors::{IdentifierRenamer, RenameAndShorthandNaturalizer, ShorthandNaturalizer};
 
@@ -100,7 +95,6 @@ const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";
 const LOWERING_GENERATOR_HEADER: &str = "// @ducktape-generator selected_module_lowering";
 
-#[macro_export]
 macro_rules! time_phase {
     ($timings:expr, $name:expr, $body:block) => {{
         let phase_started = std::time::Instant::now();
@@ -109,6 +103,7 @@ macro_rules! time_phase {
         value
     }};
 }
+pub(crate) use time_phase;
 
 #[derive(Debug, Default, Clone)]
 struct PhaseTimings {

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -6,6 +6,7 @@
 //! `naturalize_module_body` is the public entry; everything else is a
 //! contributor of rename intents that get merged via `drop_target_collisions`.
 
+use super::util::is_identifier_like;
 use super::*;
 
 pub(super) fn naturalize_module_body(

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -2,6 +2,7 @@
 //! convert spec entries into `LogicalRequest`s and synthesize
 //! mini-factor plans for unclaimed atomic units.
 
+use super::util::{body_index_for_statement_ordinal, target_file_for_request};
 use super::*;
 
 #[derive(Debug, Clone)]
@@ -259,7 +260,7 @@ pub(super) fn synthesize_mini_factor_plans(
                 }
                 binding_assignment.insert(name.clone(), synthetic_idx);
                 bindings_catalogue.insert(
-                    top_level_id(name.as_str(), chunk_top_level_mark),
+                    top_level_id(name, chunk_top_level_mark),
                     BindingKind::Owned {
                         owner: synthetic_module_id,
                     },


### PR DESCRIPTION
## Summary

Three contained cleanups motivated by the lowering split (PR #1643) and the Id migration (PR #1639):

1. **Per-sibling `util` imports.** `lowering/mod.rs` carried `#[allow(unused_imports)]` on its `use util::{...}` block because most items were consumed by siblings (`lower.rs`, `materialize.rs`, `plans.rs`, `imports_cross.rs`, `naturalize.rs`) through Rust's parent-name resolution rather than by `mod.rs` itself. Replace with explicit `use super::util::{...}` per sibling; `mod.rs`'s util import trims to the four items it consumes directly. Drop the `#[allow]`.
2. **Private `time_phase!`.** The macro was `#[macro_export]`ed so `lower.rs` / `materialize.rs` could `use crate::time_phase;`. That leaked it into the lowering crate's public API. Switch to the standard `pub(crate) use time_phase;` pattern at the definition site; the consumers stay the same.
3. **Tighter `top_level_id` signature.** Accepted `impl Into<Atom>`, so every caller wrote `name.as_str()` to coax `&String` into a `&str`. Tighten to `&str` directly — `&String` deref-coerces and the 8 call sites drop `.as_str()`. Stale `#[allow(dead_code)]` tombstone removed — the function has 8 callers and isn't dead.

These cover items from `debundle/TODO.md` "Id-migration code-reduction follow-ups" (the `top_level_id` invocation repetition) and "lowering/ module ergonomics" (the `allow(unused_imports)` and `#[macro_export]` wart). The 14 `with_swc_globals` test-wrap sites stay as-is — the per-test wrap was a deliberate design choice in the original Id migration to keep mark-identity-across-calls explicit.

## Validation against the megachunk

Built `//tana/re/web/spec:debundle_78d928dca7` (the gaffer-private Tana chunk that was the original motivation for the nested-closure fix in #1646) — succeeds with the post-#1646 + cleanup pipeline. Before #1646 this would have failed `materialize_logical_modules` with a 690-owner atomic-factor-unit conflict on the `try { ... Age(...) ... }` bootstrap statement; it now materializes cleanly.

## Test plan

- [x] `bazel build //devinfra/js/debundle:lowering` — green
- [x] `bazel test //devinfra/js/debundle/...` — 50/50 GREEN, no regression
- [x] `bazel build //tana/re/web/spec:debundle_78d928dca7` (gaffer-private) — green


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_