### PR TITLE
claude_hook: race-free daemon-startup detection via readiness pipe

### DIFF
--- a/devinfra/claude/claude_hook/daemon_lifecycle.rs
+++ b/devinfra/claude/claude_hook/daemon_lifecycle.rs
@@ -272,9 +272,16 @@ pub async fn ensure_daemon(sock_path: &Path, daemon_dir: &Path) -> Result<(), St
         }
     }
 
-    let daemon_pid = crate::fork_daemon(daemon_dir, sock_path);
+    let forked = crate::fork_daemon(daemon_dir, sock_path);
 
-    match crate::wait_for_sock(sock_path, &pidfile, daemon_pid, Duration::from_secs(10)).await {
+    match crate::wait_for_sock(
+        sock_path,
+        &pidfile,
+        forked.ready_read,
+        Duration::from_secs(10),
+    )
+    .await
+    {
         Ok(()) => {
             clear_startup_failure(daemon_dir);
             Ok(())

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -63,6 +63,13 @@ enum Command {
         sock: PathBuf,
         #[arg(long)]
         daemon_dir: PathBuf,
+        /// File descriptor inherited from the launcher. The daemon writes
+        /// "READY\n" to it (and closes it) once the UDS listener is bound.
+        /// If the daemon dies before signaling ready, the kernel closes
+        /// the FD on process exit and the launcher reads EOF — race-free
+        /// pre-bind crash detection, independent of zombie-reap timing.
+        #[arg(long)]
+        ready_fd: Option<i32>,
     },
 }
 
@@ -553,7 +560,7 @@ async fn handle_mailbox(
 // Daemon entry point
 // ---------------------------------------------------------------------------
 
-async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf) {
+async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf, ready_fd: Option<i32>) {
     let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
         .map(PathBuf::from)
         .expect("CLAUDE_PROJECT_DIR must be set");
@@ -626,6 +633,20 @@ async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf) {
     );
     let listener = UnixListener::bind(&sock).expect("failed to bind UDS");
 
+    // Signal readiness to the launcher (see `Command::Daemon::ready_fd`).
+    // Order matters: bind must precede this so any client that connects
+    // immediately after the launcher returns sees a kernel-queued socket.
+    if let Some(fd) = ready_fd {
+        let n = unsafe { libc::write(fd, b"READY\n".as_ptr() as *const _, 6) };
+        if n != 6 {
+            eprintln!(
+                "daemon: ready signal write returned {n} (errno={:?})",
+                io::Error::last_os_error().raw_os_error()
+            );
+        }
+        unsafe { libc::close(fd) };
+    }
+
     // Idle watchdog: SIGTERM after 30min of no requests.
     if state.profile.idle_watchdog {
         let wstate = state.clone();
@@ -651,42 +672,80 @@ async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf) {
 // Client: double-fork + UDS request
 // ---------------------------------------------------------------------------
 
-pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> i32 {
+/// Returned by `fork_daemon`: the daemon's pid plus the read end of the
+/// readiness pipe. The caller awaits a `"READY"` write or EOF on the read
+/// end via `wait_for_sock`.
+pub(crate) struct DaemonFork {
+    /// PID of the double-forked daemon process. Retained for diagnostics
+    /// (e.g. surfacing in error messages) even though the readiness pipe
+    /// supersedes `kill(pid, 0)` polling for liveness checks.
+    #[allow(dead_code)]
+    pub pid: i32,
+    pub ready_read: OwnedFd,
+}
+
+pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> DaemonFork {
     let log_out = daemon_dir.join("daemon.log");
     let log_err = daemon_dir.join("daemon.err.log");
 
     let self_exe = std::env::current_exe().expect("cannot determine own exe path");
 
-    let mut pipe_fds = [0i32; 2];
-    unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
-    let (read_fd, write_fd) = (pipe_fds[0], pipe_fds[1]);
+    // Pipe 1: first child reports the double-forked grandchild's pid back.
+    let mut pid_pipe = [0i32; 2];
+    unsafe { libc::pipe(pid_pipe.as_mut_ptr()) };
+    let (pid_read, pid_write) = (pid_pipe[0], pid_pipe[1]);
+
+    // Pipe 2: daemon (post-exec) signals readiness. Write end is inherited
+    // across exec (no CLOEXEC); read end stays here. If the daemon dies
+    // before writing READY, the kernel closes its FDs and the launcher
+    // reads EOF — race-free pre-bind crash detection.
+    let mut ready_pipe = [0i32; 2];
+    unsafe { libc::pipe(ready_pipe.as_mut_ptr()) };
+    let (ready_read, ready_write) = (ready_pipe[0], ready_pipe[1]);
 
     let pid = unsafe { libc::fork() };
     if pid > 0 {
-        unsafe { libc::close(write_fd) };
+        unsafe {
+            libc::close(pid_write);
+            libc::close(ready_write);
+        }
         unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
         let mut buf = [0u8; 32];
-        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
-        unsafe { libc::close(read_fd) };
-        if n <= 0 {
+        let n = unsafe { libc::read(pid_read, buf.as_mut_ptr() as *mut _, buf.len()) };
+        unsafe { libc::close(pid_read) };
+        let daemon_pid = if n <= 0 {
             eprintln!("claude-hook: daemon startup pipe returned no data");
-            return -1;
-        }
-        let s = std::str::from_utf8(&buf[..n as usize]).unwrap_or("").trim();
-        return s.parse().unwrap_or(-1);
+            -1
+        } else {
+            let s = std::str::from_utf8(&buf[..n as usize]).unwrap_or("").trim();
+            s.parse().unwrap_or(-1)
+        };
+        return DaemonFork {
+            pid: daemon_pid,
+            ready_read: unsafe { OwnedFd::from_raw_fd(ready_read) },
+        };
     }
 
-    unsafe { libc::close(read_fd) };
+    unsafe {
+        libc::close(pid_read);
+        libc::close(ready_read);
+    }
     unsafe { libc::setsid() };
     let pid2 = unsafe { libc::fork() };
     if pid2 > 0 {
         let msg = pid2.to_string();
-        unsafe { libc::write(write_fd, msg.as_ptr() as *const _, msg.len()) };
-        unsafe { libc::close(write_fd) };
+        unsafe { libc::write(pid_write, msg.as_ptr() as *const _, msg.len()) };
+        unsafe {
+            libc::close(pid_write);
+            // First child does not write to the readiness pipe; close so the
+            // grandchild is the only remaining writer.
+            libc::close(ready_write);
+        };
         std::process::exit(0);
     }
 
-    unsafe { libc::close(write_fd) };
+    unsafe { libc::close(pid_write) };
+    // ready_write stays open across exec so the daemon can write "READY".
 
     let fd_out = std::fs::OpenOptions::new()
         .create(true)
@@ -712,6 +771,8 @@ pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> i32 {
             sock_path.to_str().unwrap(),
             "--daemon-dir",
             daemon_dir.to_str().unwrap(),
+            "--ready-fd",
+            &ready_write.to_string(),
         ])
         .exec();
     panic!("exec failed: {err}");
@@ -720,32 +781,53 @@ pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> i32 {
 pub(crate) async fn wait_for_sock(
     sock_path: &Path,
     pidfile: &Path,
-    daemon_pid: i32,
+    ready_read: OwnedFd,
     timeout: Duration,
 ) -> Result<(), String> {
-    let deadline = std::time::Instant::now() + timeout;
-    while std::time::Instant::now() < deadline {
-        if sock_path.exists() && UnixStream::connect(sock_path).await.is_ok() {
-            return Ok(());
+    // Poll the readiness pipe non-blocking alongside the 100ms tick loop.
+    let fd = ready_read.as_raw_fd();
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags >= 0 {
+            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
         }
-        // Post-pidfile crash detection: daemon wrote pidfile then died.
+    }
+    let deadline = std::time::Instant::now() + timeout;
+    let mut buf = [0u8; 16];
+    while std::time::Instant::now() < deadline {
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+        if n > 0 {
+            // Daemon signaled ready. Verify the socket also accepts a
+            // connection — cheap belt-and-suspenders against a daemon that
+            // wrote READY but somehow lost the listener.
+            if sock_path.exists() && UnixStream::connect(sock_path).await.is_ok() {
+                return Ok(());
+            }
+            return Err("Daemon signaled ready but socket connect failed".into());
+        }
+        if n == 0 {
+            return Err(
+                "Daemon process died during startup (readiness pipe closed without signal)".into(),
+            );
+        }
+        let errno = std::io::Error::last_os_error().raw_os_error();
+        if errno != Some(libc::EAGAIN)
+            && errno != Some(libc::EWOULDBLOCK)
+            && errno != Some(libc::EINTR)
+        {
+            return Err(format!("readiness pipe read error: errno={errno:?}"));
+        }
+        // Late-crash detection: daemon wrote pidfile (which happens before
+        // the ready signal in `run_daemon`) but died before binding. The
+        // readiness EOF normally covers this, but the pidfile flock check
+        // catches the daemon dying after it sent READY too.
         if pidfile.exists() && !daemon_lifecycle::is_pidfile_locked(pidfile) {
             return Err("Daemon died during startup (pidfile unlocked)".into());
         }
-        // Pre-pidfile crash detection: daemon died before writing pidfile.
-        let rc = unsafe { libc::kill(daemon_pid, 0) };
-        if rc != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
-            return Err("Daemon process died during startup (pre-pidfile)".into());
-        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    let note = if sock_path.exists() {
-        "socket appeared but connect never succeeded"
-    } else {
-        "socket never appeared"
-    };
     Err(format!(
-        "Daemon did not become reachable within {}s ({note})",
+        "Daemon did not become reachable within {}s (no READY signal)",
         timeout.as_secs()
     ))
 }
@@ -878,8 +960,12 @@ async fn main() {
     let cli = Cli::parse();
     match cli.command {
         Some(Command::Shim { name, args }) => shim_runtime::run_shim(name, args).await,
-        Some(Command::Daemon { sock, daemon_dir }) => {
-            run_daemon(sock, daemon_dir).await;
+        Some(Command::Daemon {
+            sock,
+            daemon_dir,
+            ready_fd,
+        }) => {
+            run_daemon(sock, daemon_dir, ready_fd).await;
         }
         None => dispatch_hook().await,
     }


### PR DESCRIPTION
## Summary

Replace the `kill(pid, 0) == ESRCH` polling in `wait_for_sock` with an explicit readiness pipe — race-free regardless of zombie-reap timing.

## Motivation

The respawn fix in #1641 added pre-pidfile crash detection via `libc::kill(daemon_pid, 0)` polled every 100ms (main.rs:735). When the daemon panics very early — e.g. `CLAUDE_PROJECT_DIR must be set` at main.rs:559, which I hit in a live session — the grandchild becomes a zombie awaiting init reaping. During the zombie window, `kill(pid, 0)` returns **0** (success), not `ESRCH`, so detection misses the death and `wait_for_sock` times out 10s later. Worse, if the cause is deterministic (missing env var, broken profile YAML), each retry repeats the full 10s wait. Diagnosed live in this session; see commit message for the full trace.

## Approach

Standard daemonize pattern (`systemd-notify`, `daemonize` libs all use it):

- `fork_daemon` opens a second pipe before forking. Read end stays in the launcher; write FD survives `exec` (no `CLOEXEC`) and is passed to the daemon child via a new `--ready-fd N` CLI arg.
- `run_daemon` writes `"READY\n"` right after `UnixListener::bind` succeeds, then closes the FD.
- `wait_for_sock` polls non-blocking reads on the readiness FD:
  - `n > 0` → daemon ready (verify socket connect as belt-and-suspenders)
  - `n == 0` → EOF (kernel closed the daemon's FD on process exit) → daemon died pre-bind
  - `EAGAIN` → keep waiting up to the deadline

The pidfile-unlocked check stays — it now covers crashes **after** the READY signal (daemon bound, served briefly, then died). The `kill(pid, 0)` ESRCH fallback is removed; the pipe covers what it covered, race-free.

## Test plan

- [x] `bazelisk build //devinfra/claude/claude_hook:claude_hook` — clean.
- [x] `bazelisk test //devinfra/claude/claude_hook:claude_hook_test` — pass.
- [ ] On a fresh session with intentionally-broken daemon (e.g. unset `CLAUDE_PROJECT_DIR`), confirm `bbr` reports "Daemon process died during startup (readiness pipe closed without signal)" within ~200ms instead of timing out at 10s, and that the circuit breaker opens after a couple of failures.
- [ ] Smoke: regular `bbr test` against a healthy session still works (daemon writes READY, launcher accepts).

https://claude.ai/code/session_01LKTL9joXudJydoRVKKGUHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTL9joXudJydoRVKKGUHu)_