### PR TITLE
claude_hook: libc→nix cleanup, parity docs, and stop respawning daemon from shim

### DIFF
--- a/devinfra/claude/claude_hook/daemon_lifecycle.rs
+++ b/devinfra/claude/claude_hook/daemon_lifecycle.rs
@@ -10,6 +10,14 @@
 //!   - **Circuit breaker** — file-based exponential backoff on repeated startup
 //!     failures, cleared on success.
 //!   - **`ensure_daemon`** — the full lifecycle orchestration.
+//!
+//! The circuit breaker shares the file path (`startup_failure.json` in the
+//! daemon dir), the algorithm (`2^N` backoff), and the tunables (base 2s, max
+//! 120s) with the Python impl. The JSON schema **diverges**: Python writes
+//! `last_failure` as an ISO-8601 string, this impl writes `last_failure_epoch`
+//! as a Unix-epoch integer. A session that swaps wheel for binary mid-flight
+//! sees the other impl's file as malformed, removes it, and starts a fresh
+//! failure count from zero — no crash, but the accumulated counter is lost.
 
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
@@ -117,6 +125,10 @@ pub fn kill_daemon_by_pidfile(pidfile: &Path) {
 // Circuit breaker
 // ---------------------------------------------------------------------------
 
+/// Schema diverges from the Python impl's `StartupFailure`
+/// (`client.py`): Python writes `last_failure` as an ISO-8601 string.
+/// `read_startup_failure` tolerates the mismatch by removing the file,
+/// so cross-impl reads degrade to "no breaker state" rather than crashing.
 #[derive(Serialize, Deserialize)]
 struct StartupFailure {
     consecutive_failures: u32,

--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -637,14 +637,13 @@ async fn run_daemon(sock: PathBuf, daemon_dir: PathBuf, ready_fd: Option<i32>) {
     // Order matters: bind must precede this so any client that connects
     // immediately after the launcher returns sees a kernel-queued socket.
     if let Some(fd) = ready_fd {
-        let n = unsafe { libc::write(fd, b"READY\n".as_ptr() as *const _, 6) };
-        if n != 6 {
-            eprintln!(
-                "daemon: ready signal write returned {n} (errno={:?})",
-                io::Error::last_os_error().raw_os_error()
-            );
+        // SAFETY: `fork_daemon` passes this FD over exec via `--ready-fd`;
+        // it is valid and uniquely owned by us at this point. Wrapping
+        // in `OwnedFd` claims ownership so `File`'s drop will close it.
+        let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+        if let Err(e) = std::fs::File::from(owned).write_all(b"READY\n") {
+            eprintln!("daemon: ready signal write failed: {e}");
         }
-        unsafe { libc::close(fd) };
     }
 
     // Idle watchdog: SIGTERM after 30min of no requests.
@@ -685,97 +684,91 @@ pub(crate) struct DaemonFork {
 }
 
 pub(crate) fn fork_daemon(daemon_dir: &Path, sock_path: &Path) -> DaemonFork {
-    let log_out = daemon_dir.join("daemon.log");
-    let log_err = daemon_dir.join("daemon.err.log");
+    use nix::sys::wait::waitpid;
+    use nix::unistd::{ForkResult, fork, pipe, setsid};
+    use std::os::fd::IntoRawFd;
+
+    let log_out = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(daemon_dir.join("daemon.log"))
+        .expect("open daemon.log");
+    let log_err = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(daemon_dir.join("daemon.err.log"))
+        .expect("open daemon.err.log");
 
     let self_exe = std::env::current_exe().expect("cannot determine own exe path");
 
     // Pipe 1: first child reports the double-forked grandchild's pid back.
-    let mut pid_pipe = [0i32; 2];
-    unsafe { libc::pipe(pid_pipe.as_mut_ptr()) };
-    let (pid_read, pid_write) = (pid_pipe[0], pid_pipe[1]);
-
+    let (pid_read, pid_write) = pipe().expect("pid pipe");
     // Pipe 2: daemon (post-exec) signals readiness. Write end is inherited
     // across exec (no CLOEXEC); read end stays here. If the daemon dies
-    // before writing READY, the kernel closes its FDs and the launcher
-    // reads EOF — race-free pre-bind crash detection.
-    let mut ready_pipe = [0i32; 2];
-    unsafe { libc::pipe(ready_pipe.as_mut_ptr()) };
-    let (ready_read, ready_write) = (ready_pipe[0], ready_pipe[1]);
+    // before writing READY, the kernel closes its FD on process exit and the
+    // launcher reads EOF — race-free pre-bind crash detection.
+    let (ready_read, ready_write) = pipe().expect("ready pipe");
 
-    let pid = unsafe { libc::fork() };
-    if pid > 0 {
-        unsafe {
-            libc::close(pid_write);
-            libc::close(ready_write);
+    // SAFETY: After fork in the child, only async-signal-safe libc calls are
+    // valid until exec. We do setsid + fork + a tiny pipe write + exit (in
+    // the first child) or exec (in the grandchild) — all async-signal-safe.
+    match unsafe { fork() }.expect("fork failed") {
+        ForkResult::Parent { child } => {
+            drop(pid_write);
+            drop(ready_write);
+            waitpid(child, None).ok();
+
+            let mut buf = String::new();
+            let daemon_pid = match std::fs::File::from(pid_read).read_to_string(&mut buf) {
+                Ok(n) if n > 0 => buf.trim().parse().unwrap_or(-1),
+                _ => {
+                    eprintln!("claude-hook: daemon startup pipe returned no data");
+                    -1
+                }
+            };
+            DaemonFork {
+                pid: daemon_pid,
+                ready_read,
+            }
         }
-        unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
-        let mut buf = [0u8; 32];
-        let n = unsafe { libc::read(pid_read, buf.as_mut_ptr() as *mut _, buf.len()) };
-        unsafe { libc::close(pid_read) };
-        let daemon_pid = if n <= 0 {
-            eprintln!("claude-hook: daemon startup pipe returned no data");
-            -1
-        } else {
-            let s = std::str::from_utf8(&buf[..n as usize]).unwrap_or("").trim();
-            s.parse().unwrap_or(-1)
-        };
-        return DaemonFork {
-            pid: daemon_pid,
-            ready_read: unsafe { OwnedFd::from_raw_fd(ready_read) },
-        };
-    }
+        ForkResult::Child => {
+            drop(pid_read);
+            drop(ready_read);
+            setsid().expect("setsid");
 
-    unsafe {
-        libc::close(pid_read);
-        libc::close(ready_read);
-    }
-    unsafe { libc::setsid() };
-    let pid2 = unsafe { libc::fork() };
-    if pid2 > 0 {
-        let msg = pid2.to_string();
-        unsafe { libc::write(pid_write, msg.as_ptr() as *const _, msg.len()) };
-        unsafe {
-            libc::close(pid_write);
-            // First child does not write to the readiness pipe; close so the
-            // grandchild is the only remaining writer.
-            libc::close(ready_write);
-        };
-        std::process::exit(0);
-    }
+            // SAFETY: same constraint as the outer fork.
+            match unsafe { fork() }.expect("second fork failed") {
+                ForkResult::Parent { child: grandchild } => {
+                    let msg = grandchild.as_raw().to_string();
+                    let _ = std::fs::File::from(pid_write).write_all(msg.as_bytes());
+                    drop(ready_write);
+                    std::process::exit(0);
+                }
+                ForkResult::Child => {
+                    drop(pid_write);
+                    // Release ownership so Drop doesn't close it — the FD must
+                    // survive `exec` for the post-exec daemon to read its
+                    // `--ready-fd` arg and signal readiness.
+                    let ready_fd = ready_write.into_raw_fd();
 
-    unsafe { libc::close(pid_write) };
-    // ready_write stays open across exec so the daemon can write "READY".
-
-    let fd_out = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_out)
-        .expect("open daemon.log");
-    let fd_err = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_err)
-        .expect("open daemon.err.log");
-    unsafe {
-        libc::dup2(std::os::unix::io::AsRawFd::as_raw_fd(&fd_out), 1);
-        libc::dup2(std::os::unix::io::AsRawFd::as_raw_fd(&fd_err), 2);
+                    let err = std::process::Command::new(&self_exe)
+                        .args([
+                            "daemon",
+                            "--sock",
+                            sock_path.to_str().unwrap(),
+                            "--daemon-dir",
+                            daemon_dir.to_str().unwrap(),
+                            "--ready-fd",
+                            &ready_fd.to_string(),
+                        ])
+                        .stdout(std::process::Stdio::from(log_out))
+                        .stderr(std::process::Stdio::from(log_err))
+                        .exec();
+                    panic!("exec failed: {err}");
+                }
+            }
+        }
     }
-    drop(fd_out);
-    drop(fd_err);
-
-    let err = std::process::Command::new(&self_exe)
-        .args([
-            "daemon",
-            "--sock",
-            sock_path.to_str().unwrap(),
-            "--daemon-dir",
-            daemon_dir.to_str().unwrap(),
-            "--ready-fd",
-            &ready_write.to_string(),
-        ])
-        .exec();
-    panic!("exec failed: {err}");
 }
 
 pub(crate) async fn wait_for_sock(
@@ -784,38 +777,37 @@ pub(crate) async fn wait_for_sock(
     ready_read: OwnedFd,
     timeout: Duration,
 ) -> Result<(), String> {
+    use nix::fcntl::{FcntlArg, OFlag, fcntl};
+
     // Poll the readiness pipe non-blocking alongside the 100ms tick loop.
-    let fd = ready_read.as_raw_fd();
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
-        if flags >= 0 {
-            libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
-        }
-    }
+    let current = fcntl(&ready_read, FcntlArg::F_GETFL).map_err(|e| format!("F_GETFL: {e}"))?;
+    let flags = OFlag::from_bits_retain(current) | OFlag::O_NONBLOCK;
+    fcntl(&ready_read, FcntlArg::F_SETFL(flags)).map_err(|e| format!("F_SETFL: {e}"))?;
+    let mut ready_file = std::fs::File::from(ready_read);
+
     let deadline = std::time::Instant::now() + timeout;
     let mut buf = [0u8; 16];
     while std::time::Instant::now() < deadline {
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut _, buf.len()) };
-        if n > 0 {
-            // Daemon signaled ready. Verify the socket also accepts a
-            // connection — cheap belt-and-suspenders against a daemon that
-            // wrote READY but somehow lost the listener.
-            if sock_path.exists() && UnixStream::connect(sock_path).await.is_ok() {
-                return Ok(());
+        match ready_file.read(&mut buf) {
+            Ok(0) => {
+                return Err(
+                    "Daemon process died during startup (readiness pipe closed without signal)"
+                        .into(),
+                );
             }
-            return Err("Daemon signaled ready but socket connect failed".into());
-        }
-        if n == 0 {
-            return Err(
-                "Daemon process died during startup (readiness pipe closed without signal)".into(),
-            );
-        }
-        let errno = std::io::Error::last_os_error().raw_os_error();
-        if errno != Some(libc::EAGAIN)
-            && errno != Some(libc::EWOULDBLOCK)
-            && errno != Some(libc::EINTR)
-        {
-            return Err(format!("readiness pipe read error: errno={errno:?}"));
+            Ok(_) => {
+                // Daemon signaled ready. Verify the socket also accepts a
+                // connection — cheap belt-and-suspenders against a daemon
+                // that wrote READY but somehow lost the listener.
+                if sock_path.exists() && UnixStream::connect(sock_path).await.is_ok() {
+                    return Ok(());
+                }
+                return Err("Daemon signaled ready but socket connect failed".into());
+            }
+            Err(e)
+                if e.kind() == io::ErrorKind::WouldBlock
+                    || e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(format!("readiness pipe read error: {e}")),
         }
         // Late-crash detection: daemon wrote pidfile (which happens before
         // the ready signal in `run_daemon`) but died before binding. The

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -4,6 +4,16 @@
 //! The daemon resolves the real binary, applies policy (git block, bazelrc
 //! injection), and returns either `Blocked` (shim prints message, exits 1)
 //! or `Execve` with a fully resolved argv (shim just exec's it).
+//!
+//! Diverges from `devinfra/claude/hook_daemon/shim.py` on the daemon-unreachable
+//! path. `shim.py` falls straight through to the original argv (`shim.py:67`);
+//! never spawns a daemon from the shim. This runtime instead calls
+//! `daemon_lifecycle::ensure_daemon` once via `decide_with_recovery` so a
+//! transiently-dead daemon recovers in-process for the very next RPC. The
+//! `startup_failure.json` circuit breaker keeps that recovery cheap when the
+//! daemon panics deterministically: after a couple of failures `ensure_daemon`
+//! short-circuits with the same cooldown (and the same on-disk format) Python's
+//! hook-dispatch path uses (see `daemon_lifecycle.rs`).
 
 use std::collections::HashMap;
 use std::future::Future;

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -5,18 +5,17 @@
 //! injection), and returns either `Blocked` (shim prints message, exits 1)
 //! or `Execve` with a fully resolved argv (shim just exec's it).
 //!
-//! Diverges from `devinfra/claude/hook_daemon/shim.py` on the daemon-unreachable
-//! path. `shim.py` falls straight through to the original argv (`shim.py:67`);
-//! never spawns a daemon from the shim. This runtime instead calls
-//! `daemon_lifecycle::ensure_daemon` once via `decide_with_recovery` so a
-//! transiently-dead daemon recovers in-process for the very next RPC. The
-//! `startup_failure.json` circuit breaker keeps that recovery cheap when the
-//! daemon panics deterministically: after a couple of failures `ensure_daemon`
-//! short-circuits with the same cooldown (and the same on-disk format) Python's
-//! hook-dispatch path uses (see `daemon_lifecycle.rs`).
+//! Mirrors `devinfra/claude/hook_daemon/shim.py`: the shim **never spawns**
+//! the daemon. Shims fire from inside tool invocations, after Claude Code's
+//! `PreToolUse` hook has already run — which is the event that owns daemon
+//! startup (`main.rs::dispatch_hook` → `daemon_lifecycle::ensure_daemon`). If
+//! the daemon is unreachable from the shim, treat it as a real outage and
+//! pass straight through to the original argv; another attempt from the shim
+//! path won't make things better and risks spinning while the user's command
+//! waits. Daemon lifecycle (kill-stale, fork, circuit breaker, etc.) lives
+//! in `daemon_lifecycle.rs`.
 
 use std::collections::HashMap;
-use std::future::Future;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -24,11 +23,13 @@ use std::time::Duration;
 use claude_hook_shim_install::SHIM_SESSION_ID_ENV;
 use protocol::{ShimExecRequest, ShimResponse};
 
-/// Whole-`run_shim` wall-clock ceiling. Covers: 2s connect + up to 10s
-/// `wait_for_sock` + 2s retry connect + slack. If the deadlock is inside
-/// the tokio runtime itself, this timer won't fire — that's a separate
-/// belt-and-braces story (`setitimer(SIGALRM)`) intentionally out of scope.
-const SHIM_BODY_TIMEOUT: Duration = Duration::from_secs(20);
+/// Whole-`run_shim` wall-clock ceiling. The body is one RPC (2s connect
+/// deadline + parse), so under normal conditions it completes in well under
+/// a second; this ceiling is a safety net against a daemon that accepted the
+/// connection then never replied. If the deadlock is inside the tokio runtime
+/// itself, this timer won't fire — that's a separate belt-and-braces story
+/// (`setitimer(SIGALRM)`) intentionally out of scope.
+const SHIM_BODY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The decision the shim is going to take, derived from the daemon's
 /// response (or absence thereof). Split out of `run_shim` so it can be
@@ -45,83 +46,17 @@ pub(crate) enum ShimDecision {
     Passthrough { argv: Vec<String>, reason: String },
 }
 
-/// Ask the daemon how to handle this shim invocation, with no recovery
-/// (see `decide_with_recovery` for the respawn-and-retry wrapper that
-/// `run_shim` uses). Kept for unit tests that exercise the pure
-/// request → decision path without faking `ensure_daemon`.
-#[cfg(test)]
+/// Ask the daemon how to handle this shim invocation. On any RPC failure —
+/// daemon unreachable, malformed response, HTTP 5xx — return Passthrough so
+/// the shim execs the original argv. The shim does not attempt to spawn or
+/// respawn the daemon; daemon lifecycle is the hook-dispatch path's job.
 async fn decide(sock: &Path, req: &ShimExecRequest, original_argv: Vec<String>) -> ShimDecision {
-    response_to_decision(call_daemon(sock, req).await, original_argv)
-}
-
-/// Why `call_daemon` failed. `Unreachable` means the shim's connect to
-/// the daemon's UDS failed fast or timed out — daemon is dead, restart
-/// candidate. `Other` means the daemon answered but the answer was
-/// unusable (handshake error, HTTP 5xx, malformed body): don't respawn,
-/// just passthrough. The inner `String` is for user-facing display.
-#[derive(Debug)]
-enum CallError {
-    Unreachable(String),
-    Other(String),
-}
-
-impl CallError {
-    fn into_reason(self) -> String {
-        match self {
-            CallError::Unreachable(r) | CallError::Other(r) => r,
-        }
-    }
-}
-
-/// Boundary classifier: the contract with `main.rs::post_json_over_uds_inner`
-/// is that every connect-failure reason starts with `"connect:"` (both the
-/// fast `ECONNREFUSED`/`ENOENT` case and the new connect-timeout case).
-/// Everything else means the daemon answered.
-fn classify_rpc_error(reason: String) -> CallError {
-    if reason.starts_with("connect:") {
-        CallError::Unreachable(reason)
-    } else {
-        CallError::Other(reason)
-    }
-}
-
-fn response_to_decision(
-    response: Result<ShimResponse, CallError>,
-    original_argv: Vec<String>,
-) -> ShimDecision {
-    match response {
+    match call_daemon(sock, req).await {
         Ok(ShimResponse::Blocked { message }) => ShimDecision::Block(message),
         Ok(ShimResponse::Execve { argv }) => ShimDecision::Exec(argv),
-        Err(e) => ShimDecision::Passthrough {
+        Err(reason) => ShimDecision::Passthrough {
             argv: original_argv,
-            reason: e.into_reason(),
-        },
-    }
-}
-
-/// `decide` + at-most-one retry after `ensure_daemon` if the first attempt
-/// looks like the daemon is unreachable. The `ensure_daemon` closure is
-/// injectable so tests can stub it without forking a real daemon.
-pub(crate) async fn decide_with_recovery<F, Fut>(
-    sock: &Path,
-    req: &ShimExecRequest,
-    original_argv: Vec<String>,
-    ensure_daemon: F,
-) -> ShimDecision
-where
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<(), String>>,
-{
-    let first = call_daemon(sock, req).await;
-    let first_unreachable = match first {
-        Err(CallError::Unreachable(reason)) => reason,
-        other => return response_to_decision(other, original_argv),
-    };
-    match ensure_daemon().await {
-        Ok(()) => response_to_decision(call_daemon(sock, req).await, original_argv),
-        Err(e) => ShimDecision::Passthrough {
-            argv: original_argv,
-            reason: format!("{first_unreachable}; ensure_daemon: {e}"),
+            reason,
         },
     }
 }
@@ -149,12 +84,9 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
     };
 
     let sock_path = crate::daemon_sock_path(&session_id);
-    let daemon_dir = crate::daemon_dir_path(&session_id);
     let original_argv = argv.clone();
 
-    let decision_fut = decide_with_recovery(&sock_path, &report, argv, || async {
-        crate::daemon_lifecycle::ensure_daemon(&sock_path, &daemon_dir).await
-    });
+    let decision_fut = decide(&sock_path, &report, argv);
 
     let decision = match tokio::time::timeout(SHIM_BODY_TIMEOUT, decision_fut).await {
         Ok(d) => d,
@@ -189,13 +121,10 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
     std::process::exit(126);
 }
 
-async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse, CallError> {
-    let body = serde_json::to_vec(req).map_err(|e| CallError::Other(format!("serialize: {e}")))?;
-    let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body)
-        .await
-        .map_err(classify_rpc_error)?;
-    serde_json::from_slice(&resp_bytes)
-        .map_err(|e| CallError::Other(format!("parse response: {e}")))
+async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse, String> {
+    let body = serde_json::to_vec(req).map_err(|e| format!("serialize: {e}"))?;
+    let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body).await?;
+    serde_json::from_slice(&resp_bytes).map_err(|e| format!("parse response: {e}"))
 }
 
 #[cfg(test)]
@@ -302,158 +231,6 @@ mod tests {
                 assert!(!reason.is_empty(), "reason should carry the RPC error");
             }
             other => panic!("expected Passthrough, got {other:?}"),
-        }
-    }
-
-    fn assert_unreachable(reason: &str) {
-        match classify_rpc_error(reason.into()) {
-            CallError::Unreachable(_) => {}
-            CallError::Other(r) => panic!("expected Unreachable for {reason:?}, got Other({r})"),
-        }
-    }
-
-    fn assert_other(reason: &str) {
-        match classify_rpc_error(reason.into()) {
-            CallError::Other(_) => {}
-            CallError::Unreachable(r) => {
-                panic!("expected Other for {reason:?}, got Unreachable({r})")
-            }
-        }
-    }
-
-    #[test]
-    fn classify_connect_errors_as_unreachable() {
-        assert_unreachable("connect: No such file or directory (os error 2)");
-        assert_unreachable("connect: Connection refused (os error 111)");
-        assert_unreachable("connect: timed out after 2s");
-    }
-
-    #[test]
-    fn classify_post_connect_errors_as_other() {
-        // Daemon answered the connect — these are not "respawn me" signals.
-        assert_other("http1 handshake: invalid frame");
-        assert_other("send request: closed");
-        assert_other("daemon returned HTTP 500");
-        assert_other("parse response: missing field");
-        assert_other("serialize: cycle");
-        assert_other("daemon request timed out (300s)");
-    }
-
-    /// When `decide` returns Passthrough with a "connect:" reason, the
-    /// recovery wrapper calls `ensure_daemon` exactly once and retries.
-    #[tokio::test]
-    async fn decide_with_recovery_invokes_ensure_on_unreachable() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let tmp = tempfile::tempdir().unwrap();
-        let sock = tmp.path().join("nonexistent.sock");
-        let req = git_status_request();
-        let original = req.argv.clone();
-
-        let calls = Arc::new(AtomicUsize::new(0));
-        let calls2 = calls.clone();
-        let decision = decide_with_recovery(&sock, &req, original.clone(), move || {
-            let calls = calls2.clone();
-            async move {
-                calls.fetch_add(1, Ordering::SeqCst);
-                // Stub: pretend respawn failed so we don't need a real daemon.
-                Err::<(), String>("test stub: no real daemon".into())
-            }
-        })
-        .await;
-
-        assert_eq!(
-            calls.load(Ordering::SeqCst),
-            1,
-            "ensure_daemon must be called exactly once"
-        );
-        match decision {
-            ShimDecision::Passthrough { argv, reason } => {
-                assert_eq!(argv, original);
-                assert!(
-                    reason.contains("ensure_daemon: test stub"),
-                    "ensure_daemon error must surface in passthrough reason, got: {reason}"
-                );
-            }
-            other => panic!("expected Passthrough, got {other:?}"),
-        }
-    }
-
-    /// When the daemon is reachable but returns Blocked, the recovery wrapper
-    /// must NOT call `ensure_daemon` and must return the Block verbatim.
-    #[tokio::test]
-    async fn decide_with_recovery_no_respawn_when_daemon_answers() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let tmp = tempfile::tempdir().unwrap();
-        let sock = tmp.path().join("d.sock");
-        let _server = spawn_fake_daemon(
-            sock.clone(),
-            ShimResponse::Blocked {
-                message: "denied".into(),
-            },
-        )
-        .await;
-        let req = git_status_request();
-
-        let calls = Arc::new(AtomicUsize::new(0));
-        let calls2 = calls.clone();
-        let decision = decide_with_recovery(&sock, &req, req.argv.clone(), move || {
-            let calls = calls2.clone();
-            async move {
-                calls.fetch_add(1, Ordering::SeqCst);
-                Ok::<(), String>(())
-            }
-        })
-        .await;
-
-        assert_eq!(
-            calls.load(Ordering::SeqCst),
-            0,
-            "ensure_daemon must not be called when the daemon answered"
-        );
-        match decision {
-            ShimDecision::Block(m) => assert_eq!(m, "denied"),
-            other => panic!("expected Block, got {other:?}"),
-        }
-    }
-
-    /// If `ensure_daemon` succeeds, the wrapper retries `decide` against the
-    /// now-live socket and surfaces whatever the daemon says.
-    #[tokio::test]
-    async fn decide_with_recovery_retries_after_ensure_succeeds() {
-        let tmp = tempfile::tempdir().unwrap();
-        let sock = tmp.path().join("d.sock");
-        let req = git_status_request();
-        let original = req.argv.clone();
-
-        // Don't bind the socket up front — the first decide() call must see
-        // connect failure. The "ensure_daemon" stub spawns the fake daemon,
-        // simulating the real respawn behavior. The retry then sees the live
-        // daemon and gets an Exec response.
-        let sock_for_stub = sock.clone();
-        let decision = decide_with_recovery(&sock, &req, original.clone(), move || async move {
-            spawn_fake_daemon(
-                sock_for_stub,
-                ShimResponse::Execve {
-                    argv: vec!["/usr/bin/git".into(), "status".into()],
-                },
-            )
-            .await;
-            // Wait briefly for axum to start accepting; without this, the
-            // retry can race the listener.
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            Ok::<(), String>(())
-        })
-        .await;
-
-        match decision {
-            ShimDecision::Exec(argv) => {
-                assert_eq!(argv, vec!["/usr/bin/git".to_string(), "status".into()]);
-            }
-            other => panic!("expected Exec after respawn, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Three follow-ups on top of merged #1648 (readiness-pipe daemon startup), against the same branch. None of them change runtime behavior in a way that depends on the others — happy to split if you'd rather review them separately.

### 1. `e100989` — libc → nix refactor

Address Copilot's review comment on #1648 about the `libc::write` partial-write footgun. Replace every `libc::{pipe,close,read,write,fcntl,dup2,waitpid,setsid}` with the `nix` safe wrappers + `OwnedFd` / `std::fs::File`. Net unsafe count in `fork_daemon` drops to 2 × `nix::unistd::fork` (inherently unsafe) plus 1 × `OwnedFd::from_raw_fd` on the daemon side; each carries a `// SAFETY` comment. `File::write_all` handles `EINTR` + partial writes internally, so the bug Copilot flagged is structurally gone.

### 2. `05b4a0b` — document Python ↔ Rust parity in module docs

Module docstrings on `shim_runtime.rs` and `daemon_lifecycle.rs` now spell out the relationship to `hook_daemon/{shim,client}.py`. Surfaces one real divergence: `StartupFailure` JSON schema is `last_failure_epoch: u64` here vs ISO-8601 string in Python. `read_startup_failure` already removes a malformed file in both impls, so a wheel↔binary swap quietly resets the failure count.

### 3. `fee8c2b` — shim never spawns the daemon

Match `hook_daemon/shim.py`. Drop `decide_with_recovery` (the in-shim `ensure_daemon` retry added in #1641); on any RPC failure, the shim falls through to the original argv. Shims fire from inside tool invocations, after Claude Code has already run `PreToolUse`, which is the event that owns daemon startup (`dispatch_hook` → `daemon_lifecycle::ensure_daemon`, with the circuit breaker + kill-stale + flock dance). Respawning from the shim re-litigates a fight the hook just lost and stalls the user's command for up to 10s of `wait_for_sock` per shim invocation.

The `CallError` enum / `classify_rpc_error` split is gone (no respawn → no need to distinguish "connect failed" from "HTTP 500"). `SHIM_BODY_TIMEOUT` drops 20s → 5s. `daemon_lifecycle::ensure_daemon` is unchanged and still called from the hook-dispatch path.

## Test plan

- [x] `bazelisk build //devinfra/claude/claude_hook:claude_hook` clean on each commit.
- [x] `bazelisk test //devinfra/claude/claude_hook:claude_hook_test` passes after final commit (0.4s).
- [ ] Smoke on a fresh session: `bbr test` works against a healthy daemon (single RPC, sub-second).
- [ ] Smoke on a session with the daemon killed mid-flight: shim prints "daemon unreachable: ... — passing through" within ~2s and execs the real binary; no spinning.

https://claude.ai/code/session_01LKTL9joXudJydoRVKKGUHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTL9joXudJydoRVKKGUHu)_