### PR TITLE
debundle/lowering: complete spec → Id boundary migration

### DIFF
--- a/devinfra/js/debundle/lowering/chunk_ast.rs
+++ b/devinfra/js/debundle/lowering/chunk_ast.rs
@@ -9,13 +9,14 @@ use super::*;
 pub(super) struct TopLevelDecl {
     pub(super) ordinal: usize,
     pub(super) names: Vec<String>,
+    pub(super) ids: Vec<Id>,
     pub(super) exported: bool,
 }
 
 pub(super) struct ChunkAstAnalysis {
     pub(super) runtime_import_facts: RuntimeImportFacts,
     pub(super) declarations: Vec<TopLevelDecl>,
-    pub(super) declaration_by_name: BTreeMap<String, usize>,
+    pub(super) declaration_by_name: HashMap<Id, usize>,
     /// Sibling sets for top-level destructuring declarators only.
     /// For a destructuring declarator like `const { x, y } = obj`
     /// both `x` and `y` map to the set `{x, y}`. Plain
@@ -28,30 +29,32 @@ pub(super) struct ChunkAstAnalysis {
     /// `split_var_decl` moves a destructuring declarator as one
     /// atomic unit.
     pub(super) destructure_siblings: BTreeMap<String, BTreeSet<String>>,
-    /// Names that the source chunk's entry already exports (via
+    /// Bindings that the source chunk's entry already exports (via
     /// `export { foo, bar }` re-exports of local bindings, or
     /// `export const foo = …` style declarations). The materializer
     /// consults this set in `auto_grown_residual_exports` so the
     /// auto-grown `export { name }` block doesn't duplicate an
     /// existing source-level export — emitting a duplicate would be
     /// a `SyntaxError: Duplicate export of 'name'` at load time.
-    pub(super) pre_existing_entry_exports: BTreeSet<String>,
+    pub(super) pre_existing_entry_exports: HashSet<Id>,
 }
 
 pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
     let mut imports = HashMap::<Id, RuntimeImportInfo>::new();
     let mut declarations = Vec::new();
-    let mut pre_existing_entry_exports = BTreeSet::<String>::new();
+    let mut pre_existing_entry_exports = HashSet::<Id>::new();
     let mut destructure_siblings = BTreeMap::<String, BTreeSet<String>>::new();
     for (ordinal, item) in module.body.iter().enumerate() {
         let (names, exported) = top_level_declaration_names(item);
+        let ids = top_level_declaration_ids(item);
         if !names.is_empty() {
             if exported {
-                pre_existing_entry_exports.extend(names.iter().cloned());
+                pre_existing_entry_exports.extend(ids.iter().cloned());
             }
             declarations.push(TopLevelDecl {
                 ordinal,
                 names,
+                ids,
                 exported,
             });
         }
@@ -61,8 +64,8 @@ pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
     }
     let declaration_by_name = declarations
         .iter()
-        .flat_map(|decl| decl.names.iter().map(|name| (name.clone(), decl.ordinal)))
-        .collect::<BTreeMap<_, _>>();
+        .flat_map(|decl| decl.ids.iter().map(|id| (id.clone(), decl.ordinal)))
+        .collect::<HashMap<_, _>>();
     ChunkAstAnalysis {
         runtime_import_facts: RuntimeImportFacts { imports },
         declarations,
@@ -107,8 +110,8 @@ pub(super) fn record_destructure_sibling_groups(
 /// of locally-declared bindings. `export … from …` is excluded
 /// because those don't bind a local name in entry. `ExportDecl`
 /// (e.g. `export const foo = …`) is already covered by
-/// `top_level_declaration_names` returning `(names, exported = true)`.
-pub(super) fn record_pre_existing_named_exports(item: &ModuleItem, out: &mut BTreeSet<String>) {
+/// `top_level_declaration_ids` returning `(ids, exported = true)`.
+pub(super) fn record_pre_existing_named_exports(item: &ModuleItem, out: &mut HashSet<Id>) {
     let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
         return;
     };
@@ -122,8 +125,8 @@ pub(super) fn record_pre_existing_named_exports(item: &ModuleItem, out: &mut BTr
         // The exported value is the local binding (`orig`); the
         // public name (`exported`) is irrelevant to the
         // emit-resolvability check, which keys off the local name.
-        if let Some(local) = module_export_ident_name(&specifier.orig) {
-            out.insert(local);
+        if let ModuleExportName::Ident(ident) = &specifier.orig {
+            out.insert(ident.to_id());
         }
     }
 }

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -120,13 +120,13 @@ pub(super) fn export_named_for_bindings(bindings: &BTreeMap<String, String>) -> 
 
 pub(super) fn entry_exports_for_moved_bindings(
     declarations: &[TopLevelDecl],
-    binding_assignment: &BTreeMap<String, usize>,
+    binding_assignment: &HashMap<Id, usize>,
     entry_renames: &BTreeMap<String, String>,
 ) -> Vec<ModuleItem> {
     let mut exports = BTreeMap::<String, String>::new();
     for decl in declarations.iter().filter(|decl| decl.exported) {
-        for name in &decl.names {
-            if binding_assignment.contains_key(name) {
+        for (name, id) in decl.names.iter().zip(&decl.ids) {
+            if binding_assignment.contains_key(id) {
                 let final_local = entry_renames
                     .get(name)
                     .cloned()
@@ -171,7 +171,7 @@ pub(super) fn entry_exports_for_moved_bindings(
 pub(super) fn auto_grown_residual_exports(
     selected_by_module: &[Vec<ModuleItem>],
     declaration_by_name: &HashMap<Id, usize>,
-    binding_assignment: &BTreeMap<String, usize>,
+    binding_assignment: &HashMap<Id, usize>,
     pre_existing_entry_exports: &HashSet<Id>,
     entry_renames: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
@@ -179,13 +179,10 @@ pub(super) fn auto_grown_residual_exports(
     for body in selected_by_module {
         let facts = collect_module_body_facts(body);
         for id in &facts.referenced_idents {
-            // `binding_assignment` is still String-keyed (spec-derived);
-            // `declaration_by_name` and `pre_existing_entry_exports` are
-            // now `Id`-keyed alongside `provided_locals` / referenced_idents.
             if facts.provided_locals.contains(id) {
                 continue;
             }
-            if binding_assignment.contains_key(id.0.as_ref()) {
+            if binding_assignment.contains_key(id) {
                 continue;
             }
             if !declaration_by_name.contains_key(id) {

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -170,31 +170,31 @@ pub(super) fn entry_exports_for_moved_bindings(
 ///   entry.
 pub(super) fn auto_grown_residual_exports(
     selected_by_module: &[Vec<ModuleItem>],
-    declaration_by_name: &BTreeMap<String, usize>,
+    declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &BTreeMap<String, usize>,
-    pre_existing_entry_exports: &BTreeSet<String>,
+    pre_existing_entry_exports: &HashSet<Id>,
     entry_renames: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     let mut needed = BTreeSet::<String>::new();
     for body in selected_by_module {
         let facts = collect_module_body_facts(body);
         for id in &facts.referenced_idents {
-            // Spec-derived `*_by_name` maps are still keyed by sym;
-            // `provided_locals` / `imported_locals` are Id-keyed.
-            let name_str = id.0.as_ref();
+            // `binding_assignment` is still String-keyed (spec-derived);
+            // `declaration_by_name` and `pre_existing_entry_exports` are
+            // now `Id`-keyed alongside `provided_locals` / referenced_idents.
             if facts.provided_locals.contains(id) {
                 continue;
             }
-            if binding_assignment.contains_key(name_str) {
+            if binding_assignment.contains_key(id.0.as_ref()) {
                 continue;
             }
-            if !declaration_by_name.contains_key(name_str) {
+            if !declaration_by_name.contains_key(id) {
                 continue;
             }
-            if pre_existing_entry_exports.contains(name_str) {
+            if pre_existing_entry_exports.contains(id) {
                 continue;
             }
-            needed.insert(name_str.to_string());
+            needed.insert(id.0.as_ref().to_string());
         }
     }
     needed

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -75,12 +75,13 @@ pub(super) fn residual_entry_imports_for_moved_body(
 pub(super) fn collect_entry_exports_by_original_local(
     entry_body: &[ModuleItem],
     entry_renames: &BTreeMap<String, String>,
-) -> BTreeMap<String, EntryExport> {
+    chunk_top_level_mark: swc_common::Mark,
+) -> HashMap<Id, EntryExport> {
     let final_to_original = entry_renames
         .iter()
         .map(|(original, final_name)| (final_name.clone(), original.clone()))
         .collect::<BTreeMap<_, _>>();
-    let mut exports = BTreeMap::<String, EntryExport>::new();
+    let mut exports = HashMap::<Id, EntryExport>::new();
     for item in entry_body {
         match item {
             ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) if named.src.is_none() => {
@@ -100,10 +101,12 @@ pub(super) fn collect_entry_exports_by_original_local(
                         .get(&final_local)
                         .cloned()
                         .unwrap_or_else(|| final_local.clone());
-                    exports.entry(original).or_insert(EntryExport {
-                        local_name: final_local,
-                        exported_name,
-                    });
+                    exports
+                        .entry(top_level_id(&original, chunk_top_level_mark))
+                        .or_insert(EntryExport {
+                            local_name: final_local,
+                            exported_name,
+                        });
                 }
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
@@ -112,10 +115,12 @@ pub(super) fn collect_entry_exports_by_original_local(
                         .get(&final_local)
                         .cloned()
                         .unwrap_or_else(|| final_local.clone());
-                    exports.entry(original).or_insert(EntryExport {
-                        local_name: final_local.clone(),
-                        exported_name: final_local,
-                    });
+                    exports
+                        .entry(top_level_id(&original, chunk_top_level_mark))
+                        .or_insert(EntryExport {
+                            local_name: final_local.clone(),
+                            exported_name: final_local,
+                        });
                 }
             }
             _ => {}

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -28,7 +28,7 @@ pub(super) struct LowerChunkInputs<'a> {
     pub(super) chunk_id: &'a str,
     pub(super) source_path: &'a str,
     pub(super) declarations: &'a [TopLevelDecl],
-    pub(super) declaration_by_name: &'a BTreeMap<String, usize>,
+    pub(super) declaration_by_name: &'a HashMap<Id, usize>,
     pub(super) module_plans: &'a [ModulePlan],
     pub(super) binding_assignment: &'a BTreeMap<String, usize>,
     /// Top-level statement ordinal → module_plan index for owners
@@ -45,12 +45,12 @@ pub(super) struct LowerChunkInputs<'a> {
     /// undefined; the validation pass sorts by binding name before
     /// iterating so any spec errors are deterministic.
     pub(super) chunk_renames: &'a HashMap<String, String>,
-    /// Names the source chunk's entry exports verbatim
+    /// Bindings the source chunk's entry exports verbatim
     /// (`record_pre_existing_named_exports`). Consulted by
     /// `auto_grown_residual_exports` so the auto-grow pass doesn't
     /// emit a `Duplicate export of 'name'` clash with an existing
     /// source export.
-    pub(super) pre_existing_entry_exports: &'a BTreeSet<String>,
+    pub(super) pre_existing_entry_exports: &'a HashSet<Id>,
 }
 
 pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -342,7 +342,11 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         trim_dead_named_specifiers(&mut entry_body, &schedule.bindings);
     });
     let entry_exports_by_original_local = time_phase!(timings, "collect_entry_exports", {
-        collect_entry_exports_by_original_local(&entry_body, &entry_binding_renames)
+        collect_entry_exports_by_original_local(
+            &entry_body,
+            &entry_binding_renames,
+            chunk_top_level_mark,
+        )
     });
     let imported_reexports_by_module = time_phase!(timings, "collect_imported_reexports", {
         collect_imported_reexports_by_module(schedule, module_plans.len())

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -30,7 +30,8 @@ pub(super) struct LowerChunkInputs<'a> {
     pub(super) declarations: &'a [TopLevelDecl],
     pub(super) declaration_by_name: &'a HashMap<Id, usize>,
     pub(super) module_plans: &'a [ModulePlan],
-    pub(super) binding_assignment: &'a BTreeMap<String, usize>,
+    pub(super) binding_assignment: &'a HashMap<Id, usize>,
+    pub(super) chunk_top_level_mark: swc_common::Mark,
     /// Top-level statement ordinal → module_plan index for owners
     /// the spec claimed as anonymous-statement members. See
     /// `ModulePlan::anonymous_statement_ordinals`.
@@ -66,6 +67,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         declaration_by_name,
         module_plans,
         binding_assignment,
+        chunk_top_level_mark,
         anonymous_ordinal_assignment,
         schedule,
         runtime_import_facts,
@@ -77,9 +79,9 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         let mut selected_ordinals = BTreeSet::new();
         for decl in declarations {
             if decl
-                .names
+                .ids
                 .iter()
-                .any(|name| binding_assignment.contains_key(name))
+                .any(|id| binding_assignment.contains_key(id))
             {
                 selected_ordinals.insert(decl.ordinal);
             }
@@ -107,7 +109,9 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             let exports: BTreeMap<String, String> = plan
                 .bindings
                 .iter()
-                .filter(|(name, _)| binding_assignment.contains_key(*name))
+                .filter(|(name, _)| {
+                    binding_assignment.contains_key(&top_level_id(name, chunk_top_level_mark))
+                })
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             if !exports.is_empty() {
@@ -169,7 +173,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // identifier) bail rather than producing invalid JS silently.
     let mut renamed_away = BTreeSet::<String>::new();
     for binding in chunk_renames.keys() {
-        if binding_assignment.contains_key(binding) {
+        if binding_assignment.contains_key(&top_level_id(binding, chunk_top_level_mark)) {
             continue;
         }
         renamed_away.insert(binding.clone());
@@ -186,7 +190,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     sorted_renames.sort_by(|a, b| a.0.cmp(b.0));
     let mut errors = Vec::<String>::new();
     for (binding, export_name) in sorted_renames {
-        if binding_assignment.contains_key(binding) {
+        if binding_assignment.contains_key(&top_level_id(binding, chunk_top_level_mark)) {
             continue;
         }
         if !is_valid_js_identifier(export_name) {
@@ -237,7 +241,9 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         let live_bindings: BTreeMap<String, String> = plan
             .bindings
             .iter()
-            .filter(|(name, _)| binding_assignment.contains_key(*name))
+            .filter(|(name, _)| {
+                binding_assignment.contains_key(&top_level_id(name, chunk_top_level_mark))
+            })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         if live_bindings.is_empty() {
@@ -251,7 +257,8 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         // body refs continue to resolve to whichever binding owned the
         // original local name.
         for (local, fresh) in emit_renames {
-            if binding_assignment.get(&local).copied() == Some(module_index) {
+            let local_id = top_level_id(&local, chunk_top_level_mark);
+            if binding_assignment.get(&local_id).copied() == Some(module_index) {
                 body_renames.insert(local, fresh);
             }
         }
@@ -377,7 +384,9 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // chunk_renames; the per-module renamer is then a no-op.
     let cross_module_chunk_renames: BTreeMap<String, String> = chunk_renames
         .iter()
-        .filter(|(binding, _)| !binding_assignment.contains_key(*binding))
+        .filter(|(binding, _)| {
+            !binding_assignment.contains_key(&top_level_id(binding, chunk_top_level_mark))
+        })
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
 

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -122,7 +122,7 @@ pub(super) fn materialize_logical_chunk(
     let residual_request = requests.iter().find(|request| request.residual).cloned();
 
     let build_module_plans_started = Instant::now();
-    let mut binding_assignment = BTreeMap::<String, usize>::new();
+    let mut binding_assignment = HashMap::<Id, usize>::new();
     let mut anonymous_ordinal_assignment = BTreeMap::<usize, usize>::new();
     let mut module_plans = Vec::new();
     let mut bindings_catalogue = HashMap::<Id, BindingKind>::new();
@@ -212,7 +212,7 @@ pub(super) fn materialize_logical_chunk(
         for binding in bindings.keys() {
             let binding_id = top_level_id(binding, chunk_top_level_mark);
             if declaration_by_name.contains_key(&binding_id) {
-                binding_assignment.insert(binding.clone(), index);
+                binding_assignment.insert(binding_id.clone(), index);
                 bindings_catalogue.insert(binding_id, BindingKind::Owned { owner: module_id });
             }
         }
@@ -243,7 +243,8 @@ pub(super) fn materialize_logical_chunk(
     // its full name set together regardless. Conflicting claims
     // (two siblings claimed by different modules) are rejected.
     for (claimed_name, sibling_set) in &destructure_siblings {
-        let Some(&owner_index) = binding_assignment.get(claimed_name) else {
+        let claimed_id = top_level_id(claimed_name, chunk_top_level_mark);
+        let Some(&owner_index) = binding_assignment.get(&claimed_id) else {
             continue;
         };
         let owner_id = ModuleId(LogicalModuleIndex(owner_index));
@@ -251,13 +252,11 @@ pub(super) fn materialize_logical_chunk(
             if sibling == claimed_name {
                 continue;
             }
-            match binding_assignment.get(sibling).copied() {
+            let sibling_id = top_level_id(sibling, chunk_top_level_mark);
+            match binding_assignment.get(&sibling_id).copied() {
                 None => {
-                    binding_assignment.insert(sibling.clone(), owner_index);
-                    bindings_catalogue.insert(
-                        top_level_id(sibling, chunk_top_level_mark),
-                        BindingKind::Owned { owner: owner_id },
-                    );
+                    binding_assignment.insert(sibling_id.clone(), owner_index);
+                    bindings_catalogue.insert(sibling_id, BindingKind::Owned { owner: owner_id });
                     let plan = &mut module_plans[owner_index];
                     plan.bindings.insert(sibling.clone(), sibling.clone());
                 }
@@ -290,12 +289,12 @@ pub(super) fn materialize_logical_chunk(
         let residual_module_id = ModuleId(LogicalModuleIndex(residual_index));
         let mut residual_bindings = HashMap::<String, String>::new();
         for decl in &declarations {
-            for name in &decl.names {
-                if !binding_assignment.contains_key(name) {
-                    binding_assignment.insert(name.clone(), residual_index);
+            for (name, id) in decl.names.iter().zip(&decl.ids) {
+                if !binding_assignment.contains_key(id) {
+                    binding_assignment.insert(id.clone(), residual_index);
                     residual_bindings.insert(name.clone(), name.clone());
                     bindings_catalogue.insert(
-                        top_level_id(name, chunk_top_level_mark),
+                        id.clone(),
                         BindingKind::Owned {
                             owner: residual_module_id,
                         },
@@ -331,17 +330,15 @@ pub(super) fn materialize_logical_chunk(
             let owner_plan = &mut module_plans[owner_index];
             owner_plan.explicit = false;
             for decl in &declarations {
-                for name in &decl.names {
-                    if !binding_assignment.contains_key(name) {
-                        binding_assignment.insert(name.clone(), owner_index);
+                for (name, id) in decl.names.iter().zip(&decl.ids) {
+                    if !binding_assignment.contains_key(id) {
+                        binding_assignment.insert(id.clone(), owner_index);
                         owner_plan
                             .bindings
                             .entry(name.clone())
                             .or_insert_with(|| name.clone());
-                        bindings_catalogue.insert(
-                            top_level_id(name, chunk_top_level_mark),
-                            BindingKind::Owned { owner: owner_id },
-                        );
+                        bindings_catalogue
+                            .insert(id.clone(), BindingKind::Owned { owner: owner_id });
                     }
                 }
             }
@@ -633,6 +630,7 @@ pub(super) fn materialize_logical_chunk(
             declaration_by_name: &declaration_by_name,
             module_plans: &module_plans,
             binding_assignment: &binding_assignment,
+            chunk_top_level_mark,
             anonymous_ordinal_assignment: &anonymous_ordinal_assignment,
             schedule: &schedule,
             chunk_renames: &chunk_renames_map,

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -210,12 +210,10 @@ pub(super) fn materialize_logical_chunk(
             }
         }
         for binding in bindings.keys() {
-            if declaration_by_name.contains_key(binding) {
+            let binding_id = top_level_id(binding, chunk_top_level_mark);
+            if declaration_by_name.contains_key(&binding_id) {
                 binding_assignment.insert(binding.clone(), index);
-                bindings_catalogue.insert(
-                    top_level_id(binding, chunk_top_level_mark),
-                    BindingKind::Owned { owner: module_id },
-                );
+                bindings_catalogue.insert(binding_id, BindingKind::Owned { owner: module_id });
             }
         }
         module_plans.push(ModulePlan {

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -51,8 +51,8 @@ mod visitors;
 use anonymous::resolve_anonymous_statement_ordinals;
 use body_facts::{ModuleBodyFacts, RefCollector, collect_module_body_facts};
 use chunk_ast::{
-    ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_names, declaration_names,
-    top_level_declaration_ids,
+    ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_ids, binding_names, declaration_ids,
+    declaration_names, top_level_declaration_ids,
 };
 use chunk_renames::collect_chunk_renames;
 use exports::{

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -61,7 +61,7 @@ use exports::{
 };
 use imports_cross::{
     collect_entry_exports_by_original_local, cross_module_imports_for_plan, final_module_exports,
-    module_export_ident_name, residual_entry_imports_for_moved_body,
+    residual_entry_imports_for_moved_body,
 };
 use imports_runtime::{
     import_decl_module_item, resolve_imported_binding, source_chunk_imports_for_moved_body,

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -138,7 +138,7 @@ pub(super) fn plan_module_reference_needs<'a>(
     schedule: &Schedule,
     declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &HashMap<Id, usize>,
-    entry_exports_by_original_local: &BTreeMap<String, EntryExport>,
+    entry_exports_by_original_local: &HashMap<Id, EntryExport>,
     runtime_imports: RuntimeImportLookup<'a>,
 ) -> ModuleReferenceNeeds<'a> {
     let mut needs = ModuleReferenceNeeds::default();
@@ -173,7 +173,7 @@ pub(super) fn plan_module_reference_needs<'a>(
             && !binding_assignment.contains_key(body_id)
             && declaration_by_name.contains_key(body_id)
         {
-            if let Some(entry_export) = entry_exports_by_original_local.get(name_str) {
+            if let Some(entry_export) = entry_exports_by_original_local.get(body_id) {
                 needs
                     .residual_entry_imports
                     .insert(name_str.to_string(), entry_export.clone());

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -137,7 +137,7 @@ pub(super) fn plan_module_reference_needs<'a>(
     body_facts: &ModuleBodyFacts,
     schedule: &Schedule,
     declaration_by_name: &HashMap<Id, usize>,
-    binding_assignment: &BTreeMap<String, usize>,
+    binding_assignment: &HashMap<Id, usize>,
     entry_exports_by_original_local: &BTreeMap<String, EntryExport>,
     runtime_imports: RuntimeImportLookup<'a>,
 ) -> ModuleReferenceNeeds<'a> {
@@ -170,7 +170,7 @@ pub(super) fn plan_module_reference_needs<'a>(
         }
 
         if !body_facts.provided_locals.contains(body_id)
-            && !binding_assignment.contains_key(name_str)
+            && !binding_assignment.contains_key(body_id)
             && declaration_by_name.contains_key(body_id)
         {
             if let Some(entry_export) = entry_exports_by_original_local.get(name_str) {

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -136,7 +136,7 @@ pub(super) fn plan_module_reference_needs<'a>(
     module_index: usize,
     body_facts: &ModuleBodyFacts,
     schedule: &Schedule,
-    declaration_by_name: &BTreeMap<String, usize>,
+    declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &BTreeMap<String, usize>,
     entry_exports_by_original_local: &BTreeMap<String, EntryExport>,
     runtime_imports: RuntimeImportLookup<'a>,
@@ -171,7 +171,7 @@ pub(super) fn plan_module_reference_needs<'a>(
 
         if !body_facts.provided_locals.contains(body_id)
             && !binding_assignment.contains_key(name_str)
-            && declaration_by_name.contains_key(name_str)
+            && declaration_by_name.contains_key(body_id)
         {
             if let Some(entry_export) = entry_exports_by_original_local.get(name_str) {
                 needs

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -158,7 +158,7 @@ pub(super) fn synthesize_mini_factor_plans(
     body: &[ModuleItem],
     residual_plan_index: Option<usize>,
     module_plans: &mut Vec<ModulePlan>,
-    binding_assignment: &mut BTreeMap<String, usize>,
+    binding_assignment: &mut HashMap<Id, usize>,
     bindings_catalogue: &mut HashMap<Id, BindingKind>,
     anonymous_ordinal_assignment: &mut BTreeMap<usize, usize>,
     chunk_top_level_mark: swc_common::Mark,
@@ -192,7 +192,8 @@ pub(super) fn synthesize_mini_factor_plans(
             .map(Vec::as_slice)
             .unwrap_or(&[]);
         for name in names {
-            match binding_assignment.get(name).copied() {
+            let id = top_level_id(name, chunk_top_level_mark);
+            match binding_assignment.get(&id).copied() {
                 None => continue,
                 Some(idx) if Some(idx) == residual_plan_index => continue,
                 Some(_) => return false,
@@ -247,20 +248,20 @@ pub(super) fn synthesize_mini_factor_plans(
             }
             for name in names {
                 bindings.insert(name.clone(), name.clone());
+                let id = top_level_id(name, chunk_top_level_mark);
                 // Move the binding out of the residual plan (if it was
                 // staged there by the sweep above) into the synthesized
                 // plan. The residual plan's bindings/anonymous-ordinal
                 // maps are pruned so it doesn't double-claim members.
-                if let Some(prev) = binding_assignment.get(name).copied() {
-                    if Some(prev) == residual_plan_index {
-                        if let Some(residual_idx) = residual_plan_index {
-                            module_plans[residual_idx].bindings.remove(name);
-                        }
-                    }
+                if let Some(prev) = binding_assignment.get(&id).copied()
+                    && Some(prev) == residual_plan_index
+                    && let Some(residual_idx) = residual_plan_index
+                {
+                    module_plans[residual_idx].bindings.remove(name);
                 }
-                binding_assignment.insert(name.clone(), synthetic_idx);
+                binding_assignment.insert(id.clone(), synthetic_idx);
                 bindings_catalogue.insert(
-                    top_level_id(name, chunk_top_level_mark),
+                    id,
                     BindingKind::Owned {
                         owner: synthetic_module_id,
                     },

--- a/devinfra/js/debundle/lowering/util.rs
+++ b/devinfra/js/debundle/lowering/util.rs
@@ -112,7 +112,7 @@ pub(super) fn normalize_optional_relative_dir(value: &str) -> Result<String> {
 
 pub(super) fn remaining_item_after_selection(
     item: &ModuleItem,
-    binding_assignment: &BTreeMap<String, usize>,
+    binding_assignment: &HashMap<Id, usize>,
     selected_by_module: &mut [Vec<ModuleItem>],
 ) -> Result<Vec<ModuleItem>> {
     match item {
@@ -122,8 +122,8 @@ pub(super) fn remaining_item_after_selection(
         ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => match &export_decl.decl {
             Decl::Var(var) => split_var_decl(var, true, binding_assignment, selected_by_module),
             decl => {
-                let names = declaration_names(decl);
-                if let Some(module_index) = assigned_module_for_names(&names, binding_assignment) {
+                let ids = declaration_ids(decl);
+                if let Some(module_index) = assigned_module_for_ids(&ids, binding_assignment) {
                     selected_by_module[module_index]
                         .push(ModuleItem::Stmt(Stmt::Decl(decl.clone())));
                     Ok(Vec::new())
@@ -133,8 +133,8 @@ pub(super) fn remaining_item_after_selection(
             }
         },
         ModuleItem::Stmt(Stmt::Decl(decl)) => {
-            let names = declaration_names(decl);
-            if let Some(module_index) = assigned_module_for_names(&names, binding_assignment) {
+            let ids = declaration_ids(decl);
+            if let Some(module_index) = assigned_module_for_ids(&ids, binding_assignment) {
                 selected_by_module[module_index].push(item.clone());
                 Ok(Vec::new())
             } else {
@@ -148,13 +148,13 @@ pub(super) fn remaining_item_after_selection(
 pub(super) fn split_var_decl(
     var: &VarDecl,
     was_exported: bool,
-    binding_assignment: &BTreeMap<String, usize>,
+    binding_assignment: &HashMap<Id, usize>,
     selected_by_module: &mut [Vec<ModuleItem>],
 ) -> Result<Vec<ModuleItem>> {
     let mut residual_decls = Vec::new();
     for declarator in &var.decls {
-        let names = binding_names(&declarator.name);
-        if let Some(module_index) = assigned_module_for_names(&names, binding_assignment) {
+        let ids = binding_ids(&declarator.name);
+        if let Some(module_index) = assigned_module_for_ids(&ids, binding_assignment) {
             let selected_var = VarDecl {
                 span: var.span,
                 ctxt: var.ctxt,
@@ -193,13 +193,12 @@ pub(super) fn split_var_decl(
     }
 }
 
-pub(super) fn assigned_module_for_names(
-    names: &[String],
-    binding_assignment: &BTreeMap<String, usize>,
+pub(super) fn assigned_module_for_ids(
+    ids: &[Id],
+    binding_assignment: &HashMap<Id, usize>,
 ) -> Option<usize> {
-    names
-        .iter()
-        .filter_map(|name| binding_assignment.get(name).copied())
+    ids.iter()
+        .filter_map(|id| binding_assignment.get(id).copied())
         .next()
 }
 


### PR DESCRIPTION
## Summary

Completes the spec → Id boundary migration tracked under `debundle/TODO.md` "Pending: spec → Id boundary". After PR #1639 landed the foundation and chunk-scoped maps (`RuntimeImportFacts.imports`, `Schedule.{bindings, chunk_renames, export_name_by_binding}`, `ScheduleLogicalModule.rename_map`) as `Id`-keyed, four `BindingName`-keyed maps in the lowering pipeline remained as String:

| Map | Old type | New type |
|---|---|---|
| `ChunkAstAnalysis.declaration_by_name` | `BTreeMap<String, usize>` | `HashMap<Id, usize>` |
| `ChunkAstAnalysis.pre_existing_entry_exports` | `BTreeSet<String>` | `HashSet<Id>` |
| `binding_assignment` (lowering threaded) | `BTreeMap<String, usize>` | `HashMap<Id, usize>` |
| `entry_exports_by_original_local` | `BTreeMap<String, EntryExport>` | `HashMap<Id, EntryExport>` |

This PR migrates all four. Each commit is one map; behavior is unchanged.

## Per-commit breakdown

1. **`declaration_by_name` + `pre_existing_entry_exports`** — AST-derived only; the builder switches from `declaration_names` to the already-existing parallel `declaration_ids` walk, and `record_pre_existing_named_exports` reads `specifier.orig` as an `Ident` and stores `.to_id()`. `TopLevelDecl` gains an `ids: Vec<Id>` alongside `names`. Three call sites (`auto_grown_residual_exports`, `plan_module_reference_needs`, the materializer's bindings-claim check) drop their `id.0.as_ref()` sym-bridging.

2. **`binding_assignment`** — Spec-derived; `LowerChunkInputs` gains `chunk_top_level_mark: Mark` so per-binding lookups in the lowering loop mint the canonical top-level `Id` from spec strings. `util.rs` helpers (`remaining_item_after_selection`, `split_var_decl`, the renamed `assigned_module_for_ids`) drive off `declaration_ids` / `binding_ids` so they look up the AST-resolved `Id` directly. `entry_exports_for_moved_bindings` iterates `decl.names.zip(decl.ids)` so the export name stays a `String` while the assignment lookup uses the binding's `Id`.

3. **`entry_exports_by_original_local`** — Entry-side; `collect_entry_exports_by_original_local` takes `chunk_top_level_mark` and computes the `Id` for the "original" name at construction time. The lookup site in `plan_module_reference_needs` uses `body_id` directly (`.get(body_id)` instead of `.get(name_str)`), so the chunk's mark doesn't need to thread there.

## What's not in this PR

- **The PR #1633 reverse-lookup bridge** in `plan_module_reference_needs` (`(body_id.0.clone(), body_id.1)` reconstruction). It survives unchanged in spirit — only the `entry_exports_by_original_local` lookup it was working around is now Id-keyed. The bridge itself will be retired by PR2's `RenameLedger`.
- **Disk schemas / spec YAML.** No changes to the on-disk surface; all renderings still emit String identifier text.

## Test plan

- [x] `bazel build //devinfra/js/debundle:lowering` — green per-commit and at HEAD.
- [x] `bazel test //devinfra/js/debundle/...` — 50/50 GREEN at HEAD, no regression.
- [ ] **Megachunk validation deferred.** gaffer-private's `MODULE.bazel` pins a specific ducktape commit; a real megachunk run requires either bumping the pin to this PR's merge commit or path-overriding. The e2e suite (which covers the spec-resolution paths) is the closest proxy and is fully green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_