### PR TITLE
debundle: split Schedule into ChunkAnalysis + ChunkFactorization

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -204,6 +204,8 @@ rust_library(
     srcs = [
         "analysis_tests.rs",
         "atomic_units.rs",
+        "chunk_analysis.rs",
+        "chunk_factorization.rs",
         "factor_assembly.rs",
         "factorize.rs",
         "facts.rs",
@@ -216,7 +218,6 @@ rust_library(
         "realizability.rs",
         "report_schema.rs",
         "reports.rs",
-        "schedule.rs",
         "validation.rs",
     ],
     crate_root = "lib.rs",

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -288,38 +288,7 @@ Prerequisite work before designing the pipeline:
    redundant. Removing the defensive patches is part of the
    pipeline-landing cleanup, not the architecture work itself.
 
-Likely multiple PRs. Should land _after_ the `Schedule` →
-`ChunkFactorization` rename below, because the partition-and-factorize
-surface is where the chunk-level rename intents already live and
-restructuring on top of the renamed type is cheaper than restructuring
-twice.
-
-## Rename `Schedule` → `ChunkFactorization`
-
-`schedule.rs::Schedule` is, after the factorize rewrite, just a
-per-chunk factorization: the authoritative `Partition` plus its
-derived realizability views (`dep_graph`, `linker_order`,
-`assembly_conflicts`) plus a pile of caches that hot-path callers
-read repeatedly (peelability evaluates ~1500 candidates/chunk; the
-`linker_position_by_module`, `export_name_by_binding`, and
-`entry_exported_binding_names_cache` exist to keep that loop
-cheap). The "Schedule" name dates to when the central object was
-the ECMA-262 link-time evaluation order — now the partition is the
-SSOT and everything else is derivable.
-
-Rename to `ChunkFactorization` (or similar) and update docstrings.
-Mechanical sweep: ~80 references across the crate. Should land in
-its own commit so the rename is reviewable in isolation; no
-behavioral change. Wait until any in-flight Schedule-touching work
-(the precompute-atomic-units constructor) is settled before
-starting.
-
-If a deeper restructure feels worthwhile when picking this up,
-consider splitting the type into `FactorizationInputs` (facts,
-bindings, logical_modules, chunk_renames) + `Factorization`
-(partition + dep_graph + linker_order + conflicts) +
-`FactorizationCaches`. Probably not worth the boilerplate, but
-evaluate before doing the rename.
+Likely multiple PRs.
 
 ## RenameLedger (PR2) open questions
 

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -360,7 +360,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     /// Test-helper residual destination: the synthesized residual
     /// logical module always sits at the highest index appended by
-    /// `schedule_for` / `schedule_with_residual_module`. Tests use this
+    /// `factorization_for` / `factorization_with_residual_module`. Tests use this
     /// instead of the historical `ModuleId::ResidualEntry` literal.
     fn residual() -> ModuleId {
         ModuleId::logical(usize::MAX)
@@ -607,7 +607,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     /// factorization; the materializer bails on any non-empty list.
     #[test]
     fn cross_destination_lazy_write_is_rejected() {
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "let A = 0; function B() { A = 1; }",
             &[("A", logical(0)), ("B", residual())],
         );
@@ -643,7 +643,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn same_destination_lazy_write_is_allowed() {
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "let A = 0; function B() { A = 1; }",
             &[("A", logical(0)), ("B", logical(0))],
         );
@@ -656,7 +656,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     }
 
     /// Resolve a sentinel `residual()` ModuleId to the real residual
-    /// logical-module index. Helper for `schedule_for`: in the new
+    /// logical-module index. Helper for `factorization_for`: in the new
     /// no-variant world the residual is just a logical module, so
     /// tests that used to write `ModuleId::ResidualEntry` now write
     /// `residual()` (a `usize::MAX`-indexed sentinel) and let the
@@ -669,7 +669,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         }
     }
 
-    fn schedule_for(source: &str, ownership: &[(&str, ModuleId)]) -> ChunkFactorization {
+    fn factorization_for(source: &str, ownership: &[(&str, ModuleId)]) -> ChunkFactorization {
         let module = parse(source);
         let facts = analyze_facts(&module);
         let mut max_idx: Option<usize> = None;
@@ -713,7 +713,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         )
     }
 
-    fn schedule_with_residual_module(
+    fn factorization_with_residual_module(
         source: &str,
         residual_bindings: &[&str],
         logical_bindings: &[&str],
@@ -757,7 +757,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn owner_graph_retains_reads_to_unassigned_declared_bindings() {
-        let factorization = schedule_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
+        let factorization =
+            factorization_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
 
         assert!(
             factorization.analysis.owner_graph.edges.iter().any(|edge| {
@@ -797,7 +798,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_reports_symbols_currently_peelable_from_residual() {
-        let factorization = schedule_with_residual_module(
+        let factorization = factorization_with_residual_module(
             "const Leaf = 1; const ResidualUse = Leaf + 1; const Existing = ResidualUse + 1;",
             &["Leaf", "ResidualUse"],
             &["Existing"],
@@ -837,7 +838,8 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_allows_symbol_with_lazy_only_residual_dependency() {
-        let factorization = schedule_for("function Leaf() { return Dep; } const Dep = 1;", &[]);
+        let factorization =
+            factorization_for("function Leaf() { return Dep; } const Dep = 1;", &[]);
 
         let report = factorization.owner_graph_report();
         let leaf_horizon = report
@@ -864,8 +866,11 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_blocks_residual_symbol_that_would_create_constraining_scc() {
-        let factorization =
-            schedule_with_residual_module("const A = B + 1; const B = A + 1;", &["A", "B"], &[]);
+        let factorization = factorization_with_residual_module(
+            "const A = B + 1; const B = A + 1;",
+            &["A", "B"],
+            &[],
+        );
 
         let report = factorization.owner_graph_report();
         let a_horizon = report
@@ -896,7 +901,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_does_not_overclaim_pair_when_three_owner_cycle_remains() {
-        let factorization = schedule_with_residual_module(
+        let factorization = factorization_with_residual_module(
             "const A = B + 1; const B = C + 1; const C = A + 1;",
             &["A", "B", "C"],
             &[],
@@ -3400,7 +3405,7 @@ mutable = mutable + 1;"#,
         // nothing readwise (literal init), B's row owns the read
         // of X but its home is mod_1 — so no edge (B reads X
         // within its own module).
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = 1, B = X; const X = 42;",
             &[("A", logical(0)), ("B", logical(1)), ("X", logical(1))],
         );
@@ -3542,7 +3547,7 @@ mutable = mutable + 1;"#,
         // This case demonstrates the split doesn't *miss* real
         // cycles either: the bug bit when multiple declarators
         // had differently-owned reads on the same line.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = X, B = 1; const X = 42; const Y = A;",
             &[
                 ("A", logical(0)),
@@ -3564,7 +3569,7 @@ mutable = mutable + 1;"#,
     fn validate_surfaces_linker_order_for_acyclic_spec() {
         // mod_0 reads B from mod_1 at-init → mod_1 must precede
         // mod_0 in the linker's evaluation order.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = B + 1; const B = 42;",
             &[("A", logical(0)), ("B", logical(1))],
         );
@@ -3589,7 +3594,7 @@ mutable = mutable + 1;"#,
         // routing of the validator (DESIGN.md "Realizability
         // primitive"), the case has to actually produce a cycle in
         // the constraining-edge subgraph — mutual at-init reads do.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );
@@ -3761,7 +3766,7 @@ mutable = mutable + 1;"#,
 
     #[test]
     fn factor_assembly_unclaimed_owners_default_to_residual() {
-        let factorization = schedule_for("const A = 1; const B = 2;", &[]);
+        let factorization = factorization_for("const A = 1; const B = 2;", &[]);
         let summary = partition_summary(&factorization);
         assert_eq!(
             summary,
@@ -3784,7 +3789,8 @@ mutable = mutable + 1;"#,
         // (`crate::factorize`) may suggest "extend mod_0 to include
         // B" as an advisory edit, but factor_assembly refuses to
         // silently move B for the user.
-        let factorization = schedule_for("const A = B + 1; const B = A + 1;", &[("A", logical(0))]);
+        let factorization =
+            factorization_for("const A = B + 1; const B = A + 1;", &[("A", logical(0))]);
         let report = factorization.validate();
         assert_eq!(
             report.atomic_unit_conflicts.len(),
@@ -3804,7 +3810,7 @@ mutable = mutable + 1;"#,
         // Both members of the same atomic unit claimed for the same
         // module — that's the spec author being explicit, not a
         // conflict.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(0))],
         );
@@ -3820,7 +3826,7 @@ mutable = mutable + 1;"#,
 
     #[test]
     fn factor_assembly_records_conflict_on_split_eager_use_cycle() {
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );
@@ -3847,7 +3853,7 @@ mutable = mutable + 1;"#,
         // cycle when the spec creates one through reverse claims,
         // but factor_assembly itself does not panic / record a
         // conflict here.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             r#"const a1 = (globalThis.tag = "a1", 1); const b1 = (globalThis.tag = "b1", 2); const a2 = (globalThis.tag = "a2", 3);"#,
             &[("a1", logical(0)), ("b1", logical(1)), ("a2", logical(0))],
         );
@@ -3862,7 +3868,7 @@ mutable = mutable + 1;"#,
     fn factor_assembly_independent_owners_keep_independent_claims() {
         // Three eager-use chain: A → B → C, no cycle, three atomic
         // units. Each owner's claim takes effect independently.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const C = 3; const B = C + 1; const A = B + 1;",
             &[("A", logical(0)), ("B", logical(1)), ("C", logical(0))],
         );
@@ -3888,7 +3894,7 @@ mutable = mutable + 1;"#,
     /// `module_key`, and `extension_owner_ids` carries C's owner.
     #[test]
     fn factorize_proposes_extension_for_module_with_unclaimed_cycle_member() {
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const B = 1; const A = C + 1; const C = A + 1;",
             &[("A", logical(0)), ("B", logical(0))],
         );
@@ -3947,7 +3953,7 @@ mutable = mutable + 1;"#,
         //   * EagerUse `from→to`           → Loose(Y) → Loose(X)
         //   * Sequenced `to→from` (inverted) → Loose(X) → Loose(Y)
         // ⇒ single SCC, fresh-module proposal.
-        let factorization = schedule_for("const X = init(); const Y = step(X);", &[]);
+        let factorization = factorization_for("const X = init(); const Y = step(X);", &[]);
         let report = factorization.owner_graph_report().factorize;
         let fresh: Vec<&FactorizeCell> = report
             .cells
@@ -3994,7 +4000,7 @@ mutable = mutable + 1;"#,
         // emit-resolvability redesign — entry auto-exports the
         // residual bindings, so the function consumer is
         // independently peelable.)
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             r#"const dep_a = "left";
 const dep_b = "right";
 const consumer = dep_a + dep_b;"#,
@@ -4047,7 +4053,7 @@ const consumer = dep_a + dep_b;"#,
         // `factorize_reports_size_cap_closure_as_diagnostic_not_partial_proposal`);
         // lazy reads no longer force closure growth post-emit-
         // resolvability redesign.
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             r#"const dep_a = "left";
 const dep_b = "right";
 const consumer_one = dep_a + dep_b;
@@ -4071,7 +4077,7 @@ const consumer_three = dep_a + dep_b;"#,
 
     #[test]
     fn schedule_report_serializes_linker_order_as_snake_case() {
-        let factorization = schedule_for(
+        let factorization = factorization_for(
             "const A = 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -604,14 +604,14 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     /// LazyRebind atomic-unit split: declarer and assigner of a
     /// mutable binding must materialize together. `factor_assembly`
     /// records this as an `atomic_unit_conflicts` entry on the
-    /// schedule; the materializer bails on any non-empty list.
+    /// factorization; the materializer bails on any non-empty list.
     #[test]
     fn cross_destination_lazy_write_is_rejected() {
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "let A = 0; function B() { A = 1; }",
             &[("A", logical(0)), ("B", residual())],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert_eq!(
             report.atomic_unit_conflicts.len(),
             1,
@@ -643,12 +643,12 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn same_destination_lazy_write_is_allowed() {
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "let A = 0; function B() { A = 1; }",
             &[("A", logical(0)), ("B", logical(0))],
         );
 
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert!(
             report.atomic_unit_conflicts.is_empty(),
             "same-destination rebinding writes should stay local to the emitted module: {report:?}",
@@ -757,29 +757,32 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn owner_graph_retains_reads_to_unassigned_declared_bindings() {
-        let schedule = schedule_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
+        let factorization = schedule_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
 
         assert!(
-            schedule.analysis.owner_graph.edges.iter().any(|edge| {
+            factorization.analysis.owner_graph.edges.iter().any(|edge| {
                 edge.from == OwnerId(0)
                     && edge.to == OwnerId(1)
                     && edge.reason.kind == DepKind::EagerUse
                     && edge.reason.statement_ordinal == StatementOrdinal(0)
-                    && schedule.analysis.binding_name(edge.reason.binding.unwrap()) == "X"
+                    && factorization
+                        .analysis
+                        .binding_name(edge.reason.binding.unwrap())
+                        == "X"
             }),
             "owner graph should retain the unassigned declared provider edge",
         );
         // The residual is the synthesized logical module at index 1
         // (after the explicit `mod_0` at index 0).
         assert!(
-            schedule
+            factorization
                 .dep_graph
                 .graph
                 .contains_edge(logical(0), ModuleId::logical(1)),
             "the quotient should expose the logical-module -> residual read",
         );
 
-        let report = schedule.owner_graph_report();
+        let report = factorization.owner_graph_report();
         let residual_owner = report
             .nodes
             .iter()
@@ -794,13 +797,13 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_reports_symbols_currently_peelable_from_residual() {
-        let schedule = schedule_with_residual_module(
+        let factorization = schedule_with_residual_module(
             "const Leaf = 1; const ResidualUse = Leaf + 1; const Existing = ResidualUse + 1;",
             &["Leaf", "ResidualUse"],
             &["Existing"],
         );
 
-        let report = schedule.owner_graph_report();
+        let report = factorization.owner_graph_report();
         assert_eq!(report.peelability.residual_destinations.len(), 1);
         assert_eq!(
             report.peelability.residual_destinations[0].label,
@@ -834,9 +837,9 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_allows_symbol_with_lazy_only_residual_dependency() {
-        let schedule = schedule_for("function Leaf() { return Dep; } const Dep = 1;", &[]);
+        let factorization = schedule_for("function Leaf() { return Dep; } const Dep = 1;", &[]);
 
-        let report = schedule.owner_graph_report();
+        let report = factorization.owner_graph_report();
         let leaf_horizon = report
             .peelability
             .residual_owner_horizon
@@ -861,10 +864,10 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_blocks_residual_symbol_that_would_create_constraining_scc() {
-        let schedule =
+        let factorization =
             schedule_with_residual_module("const A = B + 1; const B = A + 1;", &["A", "B"], &[]);
 
-        let report = schedule.owner_graph_report();
+        let report = factorization.owner_graph_report();
         let a_horizon = report
             .peelability
             .residual_owner_horizon
@@ -893,13 +896,13 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
 
     #[test]
     fn peelability_does_not_overclaim_pair_when_three_owner_cycle_remains() {
-        let schedule = schedule_with_residual_module(
+        let factorization = schedule_with_residual_module(
             "const A = B + 1; const B = C + 1; const C = A + 1;",
             &["A", "B", "C"],
             &[],
         );
 
-        let report = schedule.owner_graph_report();
+        let report = factorization.owner_graph_report();
         // The three-owner closure {A,B,C} is the only legitimate peel:
         // moving any strict subset leaves a back-pointer to the source
         // destination. No pair-peel is overclaimed.
@@ -3397,7 +3400,7 @@ mutable = mutable + 1;"#,
         // nothing readwise (literal init), B's row owns the read
         // of X but its home is mod_1 — so no edge (B reads X
         // within its own module).
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = 1, B = X; const X = 42;",
             &[("A", logical(0)), ("B", logical(1)), ("X", logical(1))],
         );
@@ -3406,14 +3409,14 @@ mutable = mutable + 1;"#,
         let mod_0 = ModuleId(LogicalModuleIndex(0));
         let mod_1 = ModuleId(LogicalModuleIndex(1));
         assert!(
-            !schedule.dep_graph.graph.contains_edge(mod_0, mod_1),
+            !factorization.dep_graph.graph.contains_edge(mod_0, mod_1),
             "no edge mod_0 → mod_1 expected, got: {:?}",
-            schedule.dep_graph.graph.edge_weight(mod_0, mod_1),
+            factorization.dep_graph.graph.edge_weight(mod_0, mod_1),
         );
         assert!(
-            !schedule.dep_graph.graph.contains_edge(mod_1, mod_0),
+            !factorization.dep_graph.graph.contains_edge(mod_1, mod_0),
             "no edge mod_1 → mod_0 expected, got: {:?}",
-            schedule.dep_graph.graph.edge_weight(mod_1, mod_0),
+            factorization.dep_graph.graph.edge_weight(mod_1, mod_0),
         );
     }
 
@@ -3539,7 +3542,7 @@ mutable = mutable + 1;"#,
         // This case demonstrates the split doesn't *miss* real
         // cycles either: the bug bit when multiple declarators
         // had differently-owned reads on the same line.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = X, B = 1; const X = 42; const Y = A;",
             &[
                 ("A", logical(0)),
@@ -3548,7 +3551,7 @@ mutable = mutable + 1;"#,
                 ("Y", logical(1)),
             ],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert!(
             !report.cycles.is_empty(),
             "expected a real cycle to be reported"
@@ -3561,11 +3564,11 @@ mutable = mutable + 1;"#,
     fn validate_surfaces_linker_order_for_acyclic_spec() {
         // mod_0 reads B from mod_1 at-init → mod_1 must precede
         // mod_0 in the linker's evaluation order.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = B + 1; const B = 42;",
             &[("A", logical(0)), ("B", logical(1))],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         let order = &report.linker_order;
         let pos = |name: &str| -> usize {
             order
@@ -3586,11 +3589,11 @@ mutable = mutable + 1;"#,
         // routing of the validator (DESIGN.md "Realizability
         // primitive"), the case has to actually produce a cycle in
         // the constraining-edge subgraph — mutual at-init reads do.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert!(!report.cycles.is_empty(), "expected a cycle in {report:?}",);
         assert!(
             report.linker_order.is_empty(),
@@ -3714,8 +3717,8 @@ mutable = mutable + 1;"#,
         assert_eq!(unit_sizes(&units), vec![2]);
     }
 
-    fn partition_summary(schedule: &ChunkFactorization) -> Vec<(String, String)> {
-        let mut out: Vec<(String, String)> = schedule
+    fn partition_summary(factorization: &ChunkFactorization) -> Vec<(String, String)> {
+        let mut out: Vec<(String, String)> = factorization
             .analysis
             .owner_graph
             .iter_nodes()
@@ -3724,7 +3727,7 @@ mutable = mutable + 1;"#,
                     .declared
                     .iter()
                     .filter_map(|b| {
-                        schedule
+                        factorization
                             .analysis
                             .owner_graph
                             .binding_table
@@ -3737,12 +3740,15 @@ mutable = mutable + 1;"#,
                 } else {
                     declared.join(",")
                 };
-                let dest = schedule.partition.of(node.id);
+                let dest = factorization.partition.of(node.id);
                 // Residual modules render as `<residual>` so this
                 // summary stays stable across residual-index changes;
                 // explicit modules use their `mod_<idx>` label.
                 let LogicalModuleIndex(idx) = dest.0;
-                let label = match schedule.analysis.logical_module(LogicalModuleIndex(idx)) {
+                let label = match factorization
+                    .analysis
+                    .logical_module(LogicalModuleIndex(idx))
+                {
                     Some(m) if m.residual => "<residual>".to_string(),
                     _ => render(dest),
                 };
@@ -3755,8 +3761,8 @@ mutable = mutable + 1;"#,
 
     #[test]
     fn factor_assembly_unclaimed_owners_default_to_residual() {
-        let schedule = schedule_for("const A = 1; const B = 2;", &[]);
-        let summary = partition_summary(&schedule);
+        let factorization = schedule_for("const A = 1; const B = 2;", &[]);
+        let summary = partition_summary(&factorization);
         assert_eq!(
             summary,
             vec![
@@ -3778,8 +3784,8 @@ mutable = mutable + 1;"#,
         // (`crate::factorize`) may suggest "extend mod_0 to include
         // B" as an advisory edit, but factor_assembly refuses to
         // silently move B for the user.
-        let schedule = schedule_for("const A = B + 1; const B = A + 1;", &[("A", logical(0))]);
-        let report = schedule.validate();
+        let factorization = schedule_for("const A = B + 1; const B = A + 1;", &[("A", logical(0))]);
+        let report = factorization.validate();
         assert_eq!(
             report.atomic_unit_conflicts.len(),
             1,
@@ -3798,11 +3804,11 @@ mutable = mutable + 1;"#,
         // Both members of the same atomic unit claimed for the same
         // module — that's the spec author being explicit, not a
         // conflict.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(0))],
         );
-        let summary = partition_summary(&schedule);
+        let summary = partition_summary(&factorization);
         assert_eq!(
             summary,
             vec![
@@ -3814,11 +3820,11 @@ mutable = mutable + 1;"#,
 
     #[test]
     fn factor_assembly_records_conflict_on_split_eager_use_cycle() {
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = B + 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert_eq!(
             report.atomic_unit_conflicts.len(),
             1,
@@ -3841,11 +3847,11 @@ mutable = mutable + 1;"#,
         // cycle when the spec creates one through reverse claims,
         // but factor_assembly itself does not panic / record a
         // conflict here.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             r#"const a1 = (globalThis.tag = "a1", 1); const b1 = (globalThis.tag = "b1", 2); const a2 = (globalThis.tag = "a2", 3);"#,
             &[("a1", logical(0)), ("b1", logical(1)), ("a2", logical(0))],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         assert!(
             report.atomic_unit_conflicts.is_empty(),
             "Sequenced-only chains never force co-location: {report:?}",
@@ -3856,11 +3862,11 @@ mutable = mutable + 1;"#,
     fn factor_assembly_independent_owners_keep_independent_claims() {
         // Three eager-use chain: A → B → C, no cycle, three atomic
         // units. Each owner's claim takes effect independently.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const C = 3; const B = C + 1; const A = B + 1;",
             &[("A", logical(0)), ("B", logical(1)), ("C", logical(0))],
         );
-        let summary = partition_summary(&schedule);
+        let summary = partition_summary(&factorization);
         assert_eq!(
             summary,
             vec![
@@ -3882,11 +3888,11 @@ mutable = mutable + 1;"#,
     /// `module_key`, and `extension_owner_ids` carries C's owner.
     #[test]
     fn factorize_proposes_extension_for_module_with_unclaimed_cycle_member() {
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const B = 1; const A = C + 1; const C = A + 1;",
             &[("A", logical(0)), ("B", logical(0))],
         );
-        let report = schedule.owner_graph_report().factorize;
+        let report = factorization.owner_graph_report().factorize;
         let extensions: Vec<&FactorizeCell> = report
             .cells
             .iter()
@@ -3941,8 +3947,8 @@ mutable = mutable + 1;"#,
         //   * EagerUse `from→to`           → Loose(Y) → Loose(X)
         //   * Sequenced `to→from` (inverted) → Loose(X) → Loose(Y)
         // ⇒ single SCC, fresh-module proposal.
-        let schedule = schedule_for("const X = init(); const Y = step(X);", &[]);
-        let report = schedule.owner_graph_report().factorize;
+        let factorization = schedule_for("const X = init(); const Y = step(X);", &[]);
+        let report = factorization.owner_graph_report().factorize;
         let fresh: Vec<&FactorizeCell> = report
             .cells
             .iter()
@@ -3988,13 +3994,13 @@ mutable = mutable + 1;"#,
         // emit-resolvability redesign — entry auto-exports the
         // residual bindings, so the function consumer is
         // independently peelable.)
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             r#"const dep_a = "left";
 const dep_b = "right";
 const consumer = dep_a + dep_b;"#,
             &[],
         );
-        let report = schedule
+        let report = factorization
             .owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 });
 
         assert!(
@@ -4041,7 +4047,7 @@ const consumer = dep_a + dep_b;"#,
         // `factorize_reports_size_cap_closure_as_diagnostic_not_partial_proposal`);
         // lazy reads no longer force closure growth post-emit-
         // resolvability redesign.
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             r#"const dep_a = "left";
 const dep_b = "right";
 const consumer_one = dep_a + dep_b;
@@ -4049,7 +4055,7 @@ const consumer_two = dep_a + dep_b;
 const consumer_three = dep_a + dep_b;"#,
             &[],
         );
-        let report = schedule
+        let report = factorization
             .owner_graph_report_with_factorize_options(&FactorizeOptions { size_cap_lines: 1 });
 
         let mut seen: BTreeSet<(FactorizeDiagnosticReason, Vec<String>)> = BTreeSet::new();
@@ -4065,11 +4071,11 @@ const consumer_three = dep_a + dep_b;"#,
 
     #[test]
     fn schedule_report_serializes_linker_order_as_snake_case() {
-        let schedule = schedule_for(
+        let factorization = schedule_for(
             "const A = 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],
         );
-        let report = schedule.validate();
+        let report = factorization.validate();
         let json = serde_json::to_string(&report).expect("serialize FactorizationReport");
         assert!(
             json.contains(r#""linker_order""#),

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -408,7 +408,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert_eq!(report.cycles.len(), 1);
         assert_eq!(report.cycles[0].modules.len(), 2);
     }
@@ -424,7 +424,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert!(
             report.cycles.is_empty(),
             "expected no cycles, got {:?}",
@@ -437,7 +437,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
     /// DESIGN.md "Realizability primitive" clause 3 — the
     /// constraining-edge subgraph (drops LazyUse) has no
     /// multi-module SCC. The materializer's Lemma 2 steering
-    /// (Schedule::source_import_position with SCC-aware reverse)
+    /// (ChunkFactorization::source_import_position with SCC-aware reverse)
     /// gives entry an import order such that the ESM linker
     /// resolves the cycle without TDZ.
     #[test]
@@ -455,7 +455,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert!(
             report.cycles.is_empty(),
             "mixed cycle with no at-init call should be realizable; got {:?}",
@@ -525,7 +525,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert_eq!(
             report.cycles.len(),
             1,
@@ -559,7 +559,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert_eq!(report.cycles.len(), 1);
         let cycle = &report.cycles[0];
         assert!(
@@ -593,7 +593,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let owner_graph = build_owner_graph(&facts);
         let partition =
             Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
-        let report = validate_schedule(&owner_graph, &partition, &render);
+        let report = validate_factorization(&owner_graph, &partition, &render);
         assert!(
             report.cycles.is_empty(),
             "lazy-only cycle is realizable; the gate must accept and emit no cycle (got {:?})",
@@ -669,7 +669,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         }
     }
 
-    fn schedule_for(source: &str, ownership: &[(&str, ModuleId)]) -> Schedule {
+    fn schedule_for(source: &str, ownership: &[(&str, ModuleId)]) -> ChunkFactorization {
         let module = parse(source);
         let facts = analyze_facts(&module);
         let mut max_idx: Option<usize> = None;
@@ -703,7 +703,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
             rename_map: HashMap::new(),
             anonymous_statement_ordinals: Vec::new(),
         });
-        Schedule::build(
+        ChunkFactorization::build(
             "test_chunk".to_string(),
             facts,
             bindings,
@@ -717,7 +717,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         source: &str,
         residual_bindings: &[&str],
         logical_bindings: &[&str],
-    ) -> Schedule {
+    ) -> ChunkFactorization {
         let module = parse(source);
         let facts = analyze_facts(&module);
         let residual = logical(0);
@@ -745,7 +745,7 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
                 anonymous_statement_ordinals: Vec::new(),
             },
         ];
-        Schedule::build(
+        ChunkFactorization::build(
             "test_chunk".to_string(),
             facts,
             bindings,
@@ -760,12 +760,12 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         let schedule = schedule_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
 
         assert!(
-            schedule.owner_graph.edges.iter().any(|edge| {
+            schedule.analysis.owner_graph.edges.iter().any(|edge| {
                 edge.from == OwnerId(0)
                     && edge.to == OwnerId(1)
                     && edge.reason.kind == DepKind::EagerUse
                     && edge.reason.statement_ordinal == StatementOrdinal(0)
-                    && schedule.binding_name(edge.reason.binding.unwrap()) == "X"
+                    && schedule.analysis.binding_name(edge.reason.binding.unwrap()) == "X"
             }),
             "owner graph should retain the unassigned declared provider edge",
         );
@@ -3555,7 +3555,7 @@ mutable = mutable + 1;"#,
         );
     }
 
-    // --- linker_order in ScheduleReport --------------------------------------
+    // --- linker_order in FactorizationReport --------------------------------------
 
     #[test]
     fn validate_surfaces_linker_order_for_acyclic_spec() {
@@ -3714,15 +3714,23 @@ mutable = mutable + 1;"#,
         assert_eq!(unit_sizes(&units), vec![2]);
     }
 
-    fn partition_summary(schedule: &Schedule) -> Vec<(String, String)> {
+    fn partition_summary(schedule: &ChunkFactorization) -> Vec<(String, String)> {
         let mut out: Vec<(String, String)> = schedule
+            .analysis
             .owner_graph
             .iter_nodes()
             .map(|node| {
                 let declared: Vec<String> = node
                     .declared
                     .iter()
-                    .filter_map(|b| schedule.owner_graph.binding_table.name(*b).cloned())
+                    .filter_map(|b| {
+                        schedule
+                            .analysis
+                            .owner_graph
+                            .binding_table
+                            .name(*b)
+                            .cloned()
+                    })
                     .collect();
                 let key = if declared.is_empty() {
                     format!("stmt_{}", node.statement_ordinal.0)
@@ -3734,7 +3742,7 @@ mutable = mutable + 1;"#,
                 // summary stays stable across residual-index changes;
                 // explicit modules use their `mod_<idx>` label.
                 let LogicalModuleIndex(idx) = dest.0;
-                let label = match schedule.logical_module(LogicalModuleIndex(idx)) {
+                let label = match schedule.analysis.logical_module(LogicalModuleIndex(idx)) {
                     Some(m) if m.residual => "<residual>".to_string(),
                     _ => render(dest),
                 };
@@ -4062,10 +4070,10 @@ const consumer_three = dep_a + dep_b;"#,
             &[("A", logical(0)), ("B", logical(1))],
         );
         let report = schedule.validate();
-        let json = serde_json::to_string(&report).expect("serialize ScheduleReport");
+        let json = serde_json::to_string(&report).expect("serialize FactorizationReport");
         assert!(
             json.contains(r#""linker_order""#),
-            "ScheduleReport must serialize linker_order as `linker_order`; got: {json}",
+            "FactorizationReport must serialize linker_order as `linker_order`; got: {json}",
         );
     }
 }

--- a/devinfra/js/debundle/atomic_units.rs
+++ b/devinfra/js/debundle/atomic_units.rs
@@ -42,8 +42,8 @@ pub struct AtomicUnit {
 /// Owner graph plus its precomputed atomic units. Bundled so a single
 /// chunk-level computation pays the Tarjan/SCC cost once and threads
 /// the result through `synthesize_mini_factor_plans` →
-/// [`crate::Schedule::build_with`] (peelability also re-uses the
-/// units cached on `Schedule.owner_graph` separately).
+/// [`crate::ChunkFactorization::build_with`] (peelability also re-uses the
+/// units cached on `ChunkFactorization.owner_graph` separately).
 #[derive(Debug, Clone)]
 pub struct OwnerGraphAndUnits {
     pub owner_graph: OwnerGraph,

--- a/devinfra/js/debundle/chunk_analysis.rs
+++ b/devinfra/js/debundle/chunk_analysis.rs
@@ -1,0 +1,209 @@
+//! Per-chunk analysis state: inputs, IR, and input-derived caches.
+//!
+//! [`ChunkAnalysis`] is what's known about a chunk before factorize
+//! runs — the facts harvested from the AST, the spec-supplied
+//! logical modules and chunk renames, the owner graph derived from
+//! those facts, and the small lookup caches that depend only on
+//! inputs. The factorize algorithm consumes a `ChunkAnalysis` plus
+//! a default destination to produce a
+//! [`crate::ChunkFactorization`] — the partition-and-derived state
+//! that depends on which logical-module assignment the spec chose.
+
+use std::collections::{BTreeSet, HashMap};
+
+use swc_atoms::Atom;
+use swc_ecma_ast::Id;
+
+use crate::reports::owner_key;
+use crate::{
+    BindingId, BindingKind, BindingName, LogicalModule, LogicalModuleIndex, ModuleId, OwnerGraph,
+    StatementFacts,
+};
+
+/// Per-chunk inputs + IR + input-derived caches.
+///
+/// Constructed once per chunk and held by reference (typically via
+/// `Arc<ChunkAnalysis>`) by every [`crate::ChunkFactorization`]
+/// candidate that explores a partition over the same owner graph.
+#[derive(Debug, Clone)]
+pub struct ChunkAnalysis {
+    pub chunk_id: String,
+    pub facts: Vec<StatementFacts>,
+    /// All top-level bindings of the chunk indexed by local name.
+    /// Iteration order is undefined; consumers that need a
+    /// deterministic order (emit sites, error messages) must sort
+    /// the keys themselves.
+    pub bindings: HashMap<Id, BindingKind>,
+    pub logical_modules: Vec<LogicalModule>,
+    /// In-place readability renames for bindings that stay in
+    /// entry. Iteration order is undefined; the
+    /// `materialize_logical_modules` validation pass sorts the
+    /// keys before iterating so any spec errors it emits stay
+    /// deterministic.
+    pub chunk_renames: HashMap<Id, Atom>,
+    pub owner_graph: OwnerGraph,
+    owner_report_ids_by_binding: Vec<Vec<String>>,
+    /// Pre-computed `binding → exported name` map. Built once per
+    /// chunk so peelability's per-candidate `binding_reports` calls
+    /// do a single hash lookup instead of re-walking `bindings` /
+    /// `chunk_renames` / `logical_modules[idx].rename_map` per
+    /// binding per candidate. Bindings absent from this map export
+    /// under their own name.
+    export_name_by_binding: HashMap<Id, Atom>,
+}
+
+impl ChunkAnalysis {
+    /// Build a `ChunkAnalysis` reusing a caller-supplied owner graph.
+    /// `bindings` should already have every `Owned` binding the spec
+    /// assigned and every `Imported` binding the spec re-exports.
+    pub fn build(
+        chunk_id: String,
+        facts: Vec<StatementFacts>,
+        owner_graph: OwnerGraph,
+        bindings: HashMap<Id, BindingKind>,
+        logical_modules: Vec<LogicalModule>,
+        chunk_renames: HashMap<Id, Atom>,
+    ) -> Self {
+        let owner_report_ids_by_binding = build_owner_report_ids_by_binding(&owner_graph);
+        let export_name_by_binding =
+            build_export_name_by_binding(&bindings, &chunk_renames, &logical_modules);
+        Self {
+            chunk_id,
+            facts,
+            bindings,
+            logical_modules,
+            chunk_renames,
+            owner_graph,
+            owner_report_ids_by_binding,
+            export_name_by_binding,
+        }
+    }
+
+    /// Pre-computed export name for a chunk binding, falling back
+    /// to the binding's own name. Hot-path replacement for the
+    /// previous `bindings` / `chunk_renames` / `rename_map` walk in
+    /// peelability report generation.
+    ///
+    /// Looks up by `sym`-only since the report generators pass bare
+    /// `BindingName` (no ctxt available at the call site). Within a
+    /// chunk's top-level scope, syms are unique by construction, so
+    /// the first sym match is unambiguous.
+    pub(crate) fn export_name_for(&self, binding: &str) -> BindingName {
+        self.export_name_by_binding
+            .iter()
+            .find(|(id, _)| id.0.as_ref() == binding)
+            .map(|(_, atom)| atom.to_string())
+            .unwrap_or_else(|| binding.to_string())
+    }
+
+    /// Render `id` to a human-readable label (used in cycle reports).
+    pub fn module_name(&self, id: ModuleId) -> String {
+        let LogicalModuleIndex(idx) = id.0;
+        self.logical_modules
+            .get(idx)
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| format!("<module#{idx}>"))
+    }
+
+    /// Which logical module owns a binding (by local name), if any.
+    /// Returns `None` for names that aren't `Owned` in this analysis
+    /// (e.g. globals, imported bindings, names not in the spec).
+    ///
+    /// Looks up by `sym`-only since most callers don't carry hygiene
+    /// context. Top-level binding syms are unique within a chunk, so
+    /// first sym match is unambiguous.
+    pub fn owner_of(&self, name: &str) -> Option<ModuleId> {
+        self.bindings
+            .iter()
+            .find(|(id, _)| id.0.as_ref() == name)
+            .and_then(|(_, kind)| match kind {
+                BindingKind::Owned { owner } => Some(*owner),
+                BindingKind::Imported { .. } => None,
+            })
+    }
+
+    /// Lookup a logical module by index.
+    pub fn logical_module(&self, idx: LogicalModuleIndex) -> Option<&LogicalModule> {
+        self.logical_modules.get(idx.0)
+    }
+
+    pub fn binding_name(&self, id: BindingId) -> &BindingName {
+        self.owner_graph.binding_table.required_name(id)
+    }
+
+    pub fn owner_report_ids_for_bindings<'a>(
+        &self,
+        names: impl IntoIterator<Item = &'a str>,
+    ) -> Vec<String> {
+        names
+            .into_iter()
+            .filter_map(|name| self.owner_graph.binding_table.get(name))
+            .filter_map(|binding| self.owner_report_ids_by_binding.get(binding.0))
+            .flat_map(|ids| ids.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+}
+
+fn build_owner_report_ids_by_binding(owner_graph: &OwnerGraph) -> Vec<Vec<String>> {
+    let mut by_binding = (0..owner_graph.binding_table.len())
+        .map(|_| BTreeSet::<String>::new())
+        .collect::<Vec<_>>();
+    for node in owner_graph.iter_nodes() {
+        let report_id = owner_key(node.id);
+        for binding in &node.declared {
+            if let Some(ids) = by_binding.get_mut(binding.0) {
+                ids.insert(report_id.clone());
+            }
+        }
+    }
+    by_binding
+        .into_iter()
+        .map(|ids| ids.into_iter().collect())
+        .collect()
+}
+
+/// Pre-compute every chunk binding's exported-name resolution so
+/// peelability reporting (`reports::binding_reports`) becomes a
+/// single hash lookup per binding instead of walking three maps.
+/// Resolution rule:
+/// - `Owned { Logical(idx) }` → `logical_modules[idx].rename_map[name]`
+///   if present, else the binding's own name.
+/// - Everything else → `chunk_renames[name]` if present, else the
+///   binding's own name.
+fn build_export_name_by_binding(
+    bindings: &HashMap<Id, BindingKind>,
+    chunk_renames: &HashMap<Id, Atom>,
+    logical_modules: &[LogicalModule],
+) -> HashMap<Id, Atom> {
+    let mut out = HashMap::with_capacity(bindings.len() + chunk_renames.len());
+    for (id, kind) in bindings {
+        let export = match kind {
+            BindingKind::Owned {
+                owner: ModuleId(LogicalModuleIndex(idx)),
+            } => logical_modules
+                .get(*idx)
+                .and_then(|module| module.rename_map.get(id))
+                .cloned()
+                .unwrap_or_else(|| id.0.clone()),
+            _ => chunk_renames
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| id.0.clone()),
+        };
+        if export != id.0 {
+            out.insert(id.clone(), export);
+        }
+    }
+    // Cover bindings that only show up in `chunk_renames` (no
+    // `BindingKind` entry — e.g. names referenced by reports that
+    // aren't first-class `Owned` / `Imported` bindings on the
+    // analysis).
+    for (id, export) in chunk_renames {
+        if !bindings.contains_key(id) && export != &id.0 {
+            out.insert(id.clone(), export.clone());
+        }
+    }
+    out
+}

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -1,42 +1,34 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use petgraph::algo::{tarjan_scc, toposort};
 use petgraph::graphmap::DiGraphMap;
 
 use crate::atomic_units::{OwnerGraphAndUnits, compute_owner_graph_and_units};
+use crate::chunk_analysis::ChunkAnalysis;
 use crate::factor_assembly::{AtomicUnitConflict, assemble_partition};
 use crate::graph::build_module_quotient;
 use crate::partition::Partition;
-use crate::reports::{build_owner_graph_report, owner_key};
-use crate::validation::validate_schedule;
-use swc_atoms::Atom;
-use swc_ecma_ast::Id;
+use crate::reports::build_owner_graph_report;
+use crate::validation::validate_factorization;
 
 use crate::{
-    BindingId, BindingKind, BindingName, LogicalModule, LogicalModuleIndex, ModuleId,
-    ModuleQuotient, OwnerGraph, OwnerGraphReport, ScheduleReport, StatementFacts,
+    FactorizationReport, LogicalModule, LogicalModuleIndex, ModuleId, ModuleQuotient,
+    OwnerGraphReport,
 };
 
-/// Single per-chunk schedule. Carries everything downstream code
-/// needs to validate cycles and emit modules in an order that
-/// respects `I ∪ S`.
+/// Per-chunk factorization output: the spec's partition of the
+/// owner graph, plus the realizability views derived from it
+/// (`dep_graph`, `linker_order`, `assembly_conflicts`) and small
+/// caches downstream consumers consult on the hot path.
+///
+/// Holds a reference to the [`ChunkAnalysis`] it was factorized
+/// from (`analysis`); peelability and downstream emit code reach
+/// inputs (`bindings`, `logical_modules`, etc.) through
+/// `factorization.analysis.X`.
 #[derive(Debug, Clone)]
-pub struct Schedule {
-    pub chunk_id: String,
-    pub facts: Vec<StatementFacts>,
-    /// All top-level bindings of the chunk indexed by local name.
-    /// Iteration order is undefined; consumers that need a
-    /// deterministic order (emit sites, error messages) must sort
-    /// the keys themselves.
-    pub bindings: HashMap<Id, BindingKind>,
-    pub logical_modules: Vec<LogicalModule>,
-    /// In-place readability renames for bindings that stay in
-    /// entry. Iteration order is undefined; the
-    /// `materialize_logical_modules` validation pass sorts the
-    /// keys before iterating so any spec errors it emits stay
-    /// deterministic.
-    pub chunk_renames: HashMap<Id, Atom>,
-    pub owner_graph: OwnerGraph,
+pub struct ChunkFactorization {
+    pub analysis: Arc<ChunkAnalysis>,
     /// Module assignment per owner — the spec's partition of the
     /// owner graph. Stored separately from the IR so the IR stays
     /// immutable across hypothetical refinements during peelability.
@@ -49,7 +41,6 @@ pub struct Schedule {
     /// emitting code.
     pub assembly_conflicts: Vec<AtomicUnitConflict>,
     pub dep_graph: ModuleQuotient,
-    owner_report_ids_by_binding: Vec<Vec<String>>,
     /// Topological linearization of `I ∪ S`, dependency-first
     /// (the module at index 0 must evaluate before any other; the
     /// last module — typically the residual entry — evaluates
@@ -61,20 +52,13 @@ pub struct Schedule {
     pub linker_order: Vec<ModuleId>,
     linker_position_by_module: HashMap<ModuleId, usize>,
     source_import_position_by_module: HashMap<ModuleId, usize>,
-    /// Pre-computed `binding → exported name` map. Built once per
-    /// chunk in `Schedule::build` so peelability's per-candidate
-    /// `binding_reports` calls do a single hash lookup instead of
-    /// re-walking `bindings` / `chunk_renames` /
-    /// `logical_modules[idx].rename_map` per binding per candidate.
-    /// Bindings absent from this map export under their own name.
-    export_name_by_binding: HashMap<Id, Atom>,
 }
 
-impl Schedule {
-    /// Build a schedule from chunk facts + the binding catalogue +
-    /// spec-derived logical modules. `bindings` should already have
-    /// every `Owned` binding the spec assigned and every `Imported`
-    /// binding the spec re-exports.
+impl ChunkFactorization {
+    /// Build a factorization from chunk facts plus the binding
+    /// catalogue plus spec-derived logical modules. `bindings` should
+    /// already have every `Owned` binding the spec assigned and every
+    /// `Imported` binding the spec re-exports.
     ///
     /// Convenience constructor: computes the owner graph and atomic
     /// units internally. Call sites that already have those precomputed
@@ -82,10 +66,10 @@ impl Schedule {
     /// should call [`Self::build_with`] instead.
     pub fn build(
         chunk_id: String,
-        facts: Vec<StatementFacts>,
-        bindings: HashMap<Id, BindingKind>,
+        facts: Vec<StatementFactsInput>,
+        bindings: HashMap<swc_ecma_ast::Id, crate::BindingKind>,
         logical_modules: Vec<LogicalModule>,
-        chunk_renames: HashMap<Id, Atom>,
+        chunk_renames: HashMap<swc_ecma_ast::Id, swc_atoms::Atom>,
         default_destination: ModuleId,
     ) -> Self {
         let precomputed = compute_owner_graph_and_units(&facts);
@@ -100,17 +84,17 @@ impl Schedule {
         )
     }
 
-    /// Build a schedule reusing a caller-computed owner graph + atomic
-    /// units. The materializer computes these once per chunk for
-    /// mini-factor synthesis and passes them in here so `Schedule`
-    /// doesn't redo the work.
+    /// Build a factorization reusing a caller-computed owner graph +
+    /// atomic units. The materializer computes these once per chunk
+    /// for mini-factor synthesis and passes them in here so the
+    /// factorization doesn't redo the work.
     pub fn build_with(
         chunk_id: String,
-        facts: Vec<StatementFacts>,
+        facts: Vec<StatementFactsInput>,
         precomputed: OwnerGraphAndUnits,
-        bindings: HashMap<Id, BindingKind>,
+        bindings: HashMap<swc_ecma_ast::Id, crate::BindingKind>,
         logical_modules: Vec<LogicalModule>,
-        chunk_renames: HashMap<Id, Atom>,
+        chunk_renames: HashMap<swc_ecma_ast::Id, swc_atoms::Atom>,
         default_destination: ModuleId,
     ) -> Self {
         let OwnerGraphAndUnits {
@@ -126,7 +110,6 @@ impl Schedule {
         );
         let partition = outcome.partition;
         let assembly_conflicts = outcome.conflicts;
-        let owner_report_ids_by_binding = Self::build_owner_report_ids_by_binding(&owner_graph);
         let dep_graph = build_module_quotient(&owner_graph, &partition);
         let linker_order = compute_linker_order(&dep_graph, &logical_modules);
         let linker_position_by_module: HashMap<ModuleId, usize> = linker_order
@@ -143,41 +126,23 @@ impl Schedule {
             .enumerate()
             .map(|(idx, id)| (id, idx))
             .collect();
-        let export_name_by_binding =
-            build_export_name_by_binding(&bindings, &chunk_renames, &logical_modules);
-        Self {
+        let analysis = Arc::new(ChunkAnalysis::build(
             chunk_id,
             facts,
+            owner_graph,
             bindings,
             logical_modules,
             chunk_renames,
-            owner_graph,
+        ));
+        Self {
+            analysis,
             partition,
             assembly_conflicts,
             dep_graph,
-            owner_report_ids_by_binding,
             linker_order,
             linker_position_by_module,
             source_import_position_by_module,
-            export_name_by_binding,
         }
-    }
-
-    /// Pre-computed export name for a chunk binding, falling back
-    /// to the binding's own name. Hot-path replacement for the
-    /// previous `bindings` / `chunk_renames` / `rename_map` walk in
-    /// peelability report generation.
-    ///
-    /// Looks up by `sym`-only since the report generators pass bare
-    /// `BindingName` (no ctxt available at the call site). Within a
-    /// chunk's top-level scope, syms are unique by construction, so
-    /// the first sym match is unambiguous.
-    pub(crate) fn export_name_for(&self, binding: &str) -> BindingName {
-        self.export_name_by_binding
-            .iter()
-            .find(|(id, _)| id.0.as_ref() == binding)
-            .map(|(_, atom)| atom.to_string())
-            .unwrap_or_else(|| binding.to_string())
     }
 
     /// Position of `id` in `linker_order`, if present. Used by the
@@ -204,84 +169,18 @@ impl Schedule {
         self.source_import_position_by_module.get(&id).copied()
     }
 
-    /// Render `id` to a human-readable label (used in cycle reports).
-    pub fn module_name(&self, id: ModuleId) -> String {
-        let LogicalModuleIndex(idx) = id.0;
-        self.logical_modules
-            .get(idx)
-            .map(|m| m.id.clone())
-            .unwrap_or_else(|| format!("<module#{idx}>"))
-    }
-
-    /// Which logical module owns a binding (by local name), if any.
-    /// Returns `None` for names that aren't `Owned` in this schedule
-    /// (e.g. globals, imported bindings, names not in the spec).
-    ///
-    /// Looks up by `sym`-only since most callers don't carry hygiene
-    /// context. Top-level binding syms are unique within a chunk, so
-    /// first sym match is unambiguous.
-    pub fn owner_of(&self, name: &str) -> Option<ModuleId> {
-        self.bindings
-            .iter()
-            .find(|(id, _)| id.0.as_ref() == name)
-            .and_then(|(_, kind)| match kind {
-                BindingKind::Owned { owner } => Some(*owner),
-                BindingKind::Imported { .. } => None,
-            })
-    }
-
-    /// Lookup a logical module by index.
-    pub fn logical_module(&self, idx: LogicalModuleIndex) -> Option<&LogicalModule> {
-        self.logical_modules.get(idx.0)
-    }
-
-    pub fn binding_name(&self, id: BindingId) -> &BindingName {
-        self.owner_graph.binding_table.required_name(id)
-    }
-
-    pub fn owner_report_ids_for_bindings<'a>(
-        &self,
-        names: impl IntoIterator<Item = &'a str>,
-    ) -> Vec<String> {
-        names
-            .into_iter()
-            .filter_map(|name| self.owner_graph.binding_table.get(name))
-            .filter_map(|binding| self.owner_report_ids_by_binding.get(binding.0))
-            .flat_map(|ids| ids.iter().cloned())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect()
-    }
-
-    fn build_owner_report_ids_by_binding(owner_graph: &OwnerGraph) -> Vec<Vec<String>> {
-        let mut by_binding = (0..owner_graph.binding_table.len())
-            .map(|_| BTreeSet::<String>::new())
-            .collect::<Vec<_>>();
-        for node in owner_graph.iter_nodes() {
-            let report_id = owner_key(node.id);
-            for binding in &node.declared {
-                if let Some(ids) = by_binding.get_mut(binding.0) {
-                    ids.insert(report_id.clone());
-                }
-            }
-        }
-        by_binding
-            .into_iter()
-            .map(|ids| ids.into_iter().collect())
-            .collect()
-    }
-
     /// Run SCC analysis over the dep graph. Spec authors consume the
     /// resulting report to fix any cycles or atomic-unit conflicts.
-    pub fn validate(&self) -> ScheduleReport {
-        let mut report = validate_schedule(&self.owner_graph, &self.partition, &|id| {
-            self.module_name(id)
-        });
+    pub fn validate(&self) -> FactorizationReport {
+        let mut report =
+            validate_factorization(&self.analysis.owner_graph, &self.partition, &|id| {
+                self.analysis.module_name(id)
+            });
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();
         report.linker_order = self
             .linker_order
             .iter()
-            .map(|id| self.module_name(*id))
+            .map(|id| self.analysis.module_name(*id))
             .collect();
         report
     }
@@ -310,50 +209,7 @@ impl Schedule {
     }
 }
 
-/// Pre-compute every chunk binding's exported-name resolution so
-/// peelability reporting (`reports::binding_reports`) becomes a
-/// single hash lookup per binding instead of walking three maps.
-/// Mirrors the resolution rule in the previous
-/// `reports::export_name_for_binding`:
-/// - `Owned { Logical(idx) }` → `logical_modules[idx].rename_map[name]`
-///   if present, else the binding's own name.
-/// - Everything else → `chunk_renames[name]` if present, else the
-///   binding's own name.
-fn build_export_name_by_binding(
-    bindings: &HashMap<Id, BindingKind>,
-    chunk_renames: &HashMap<Id, Atom>,
-    logical_modules: &[LogicalModule],
-) -> HashMap<Id, Atom> {
-    let mut out = HashMap::with_capacity(bindings.len() + chunk_renames.len());
-    for (id, kind) in bindings {
-        let export = match kind {
-            BindingKind::Owned {
-                owner: ModuleId(LogicalModuleIndex(idx)),
-            } => logical_modules
-                .get(*idx)
-                .and_then(|module| module.rename_map.get(id))
-                .cloned()
-                .unwrap_or_else(|| id.0.clone()),
-            _ => chunk_renames
-                .get(id)
-                .cloned()
-                .unwrap_or_else(|| id.0.clone()),
-        };
-        if export != id.0 {
-            out.insert(id.clone(), export);
-        }
-    }
-    // Cover bindings that only show up in `chunk_renames` (no
-    // `BindingKind` entry — e.g. names referenced by reports that
-    // aren't first-class `Owned` / `Imported` bindings on the
-    // schedule).
-    for (id, export) in chunk_renames {
-        if !bindings.contains_key(id) && export != &id.0 {
-            out.insert(id.clone(), export.clone());
-        }
-    }
-    out
-}
+type StatementFactsInput = crate::StatementFacts;
 
 /// Topological linearization of the dep graph, dependency-first.
 /// Empty if the graph has cycles (`tarjan_scc` plus the validator
@@ -365,6 +221,31 @@ fn build_export_name_by_binding(
 /// before dependencies. The returned order is reversed so the
 /// dependency comes first — matching the order ECMA-262's link
 /// traversal needs to evaluate (deepest leaf first).
+fn compute_linker_order(
+    dep_graph: &ModuleQuotient,
+    logical_modules: &[LogicalModule],
+) -> Vec<ModuleId> {
+    let mut graph = DiGraphMap::<ModuleId, ()>::new();
+    // Add every module the factorization knows about so the order
+    // covers them even if they have no dep-graph edges (singleton
+    // leaves still need a deterministic position for emit ordering).
+    for idx in 0..logical_modules.len() {
+        graph.add_node(ModuleId(LogicalModuleIndex(idx)));
+    }
+    for (from, to, weight) in dep_graph.iter_edges() {
+        if !weight.constrains_init_order() {
+            continue;
+        }
+        graph.add_node(from);
+        graph.add_node(to);
+        graph.add_edge(from, to, ());
+    }
+    match toposort(&graph, None) {
+        Ok(order) => order.into_iter().rev().collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
 /// Compute the source order in which entry's emitted `import`
 /// directives must appear so the ESM linker's depth-first
 /// instantiation lands on a Phase-2 evaluation order matching
@@ -406,8 +287,8 @@ fn compute_source_import_order(
             scc_of.insert(*m, idx);
         }
     }
-    // Start from every module the schedule knows about. Modules with
-    // no dep-graph edges (singletons) still need a deterministic
+    // Start from every module the factorization knows about. Modules
+    // with no dep-graph edges (singletons) still need a deterministic
     // source-order slot for emit stability.
     let mut nodes: Vec<ModuleId> = (0..logical_modules.len())
         .map(|idx| ModuleId(LogicalModuleIndex(idx)))
@@ -444,29 +325,4 @@ fn compute_source_import_order(
         a_rank.cmp(&b_rank).then_with(|| b_pos.cmp(&a_pos))
     });
     nodes
-}
-
-fn compute_linker_order(
-    dep_graph: &ModuleQuotient,
-    logical_modules: &[LogicalModule],
-) -> Vec<ModuleId> {
-    let mut graph = DiGraphMap::<ModuleId, ()>::new();
-    // Add every module the schedule knows about so the order
-    // covers them even if they have no dep-graph edges (singleton
-    // leaves still need a deterministic position for emit ordering).
-    for idx in 0..logical_modules.len() {
-        graph.add_node(ModuleId(LogicalModuleIndex(idx)));
-    }
-    for (from, to, weight) in dep_graph.iter_edges() {
-        if !weight.constrains_init_order() {
-            continue;
-        }
-        graph.add_node(from);
-        graph.add_node(to);
-        graph.add_edge(from, to, ());
-    }
-    match toposort(&graph, None) {
-        Ok(order) => order.into_iter().rev().collect(),
-        Err(_) => Vec::new(),
-    }
 }

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -392,7 +392,7 @@ export { X, Existing };
 // post-split statement ordinal N + (number of extra splits in
 // body[..N]).
 //
-// Without the conversion, the Schedule's destination override
+// Without the conversion, the ChunkFactorization's destination override
 // (which keys off `statement_ordinal`) targets the wrong owner
 // node — the materializer still emits the right body item into
 // the right module, but the realizability check sees a stale

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -412,7 +412,7 @@ fn anon_statement_after_comma_list_resolves_correct_owner() {
     // Post-split statement_ordinal is 2 (because body[0]'s
     // comma-list adds +1 to the count).
     //
-    // If the conversion is wrong, schedule.rs would override
+    // If the conversion is wrong, factorization.rs would override
     // owner with `statement_ordinal == 1` (which is `b`'s owner)
     // instead of the anon owner — `b` would be claimed by
     // x_module while the anon stays in residual, and either:

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -549,10 +549,10 @@ export { bridge };
 #[test]
 fn moved_body_re_imports_specifier_re_exported_by_another_plan() {
     // mod_a re-exports a vendor binding (`a` → public `Re`),
-    // making it `BindingKind::Imported` in `Schedule.bindings`.
+    // making it `BindingKind::Imported` in `ChunkFactorization.bindings`.
     // mod_b moves a body that references the same local `a`.
     // The source-chunk re-import filter must NOT skip `a` just
-    // because it's in `Schedule.bindings` — `cross_module_imports_for_body`
+    // because it's in `ChunkFactorization.bindings` — `cross_module_imports_for_body`
     // can't satisfy it (Imported bindings have `owner_of() == None`),
     // so without the source-chunk re-import mod_b has a free
     // variable and `ReferenceError: a is not defined` at runtime.

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -40,7 +40,7 @@ fn rejects_extracted_binding_assigned_by_residual_owner() {
     // assignment because imported ESM bindings are read-only in the
     // importing module.
     //
-    // The realizability/schedule validation phase must reject this
+    // The realizability/factorization validation phase must reject this
     // spec before emission. A binding with a cross-destination
     // assignment cannot be safely peeled unless every top-level
     // owner that may assign it is peeled into the same destination,

--- a/devinfra/js/debundle/factorize.rs
+++ b/devinfra/js/debundle/factorize.rs
@@ -1,5 +1,5 @@
 //! Certifying factorize proposal emitter. Reads the in-memory
-//! [`Schedule`] and emits only owner sets that have already passed
+//! [`ChunkFactorization`] and emits only owner sets that have already passed
 //! the same peel predicate the materializer uses.
 //!
 //! The algorithm is a monotone closure over residual frontier starts:
@@ -23,8 +23,8 @@ use crate::atomic_units::compute_atomic_units;
 use crate::peelability::{PeelCandidateEvaluation, PeelabilityContext, evaluate_peel_candidate};
 use crate::reports::{build_quotient_edge_reports, is_residual_destination, module_key, owner_key};
 use crate::{
-    BindingName, FactorizeCell, FactorizeDiagnostic, FactorizeDiagnosticReason, FactorizeOptions,
-    FactorizeReport, ModuleId, OwnerId, PeelCandidateStatus, Schedule,
+    BindingName, ChunkFactorization, FactorizeCell, FactorizeDiagnostic, FactorizeDiagnosticReason,
+    FactorizeOptions, FactorizeReport, ModuleId, OwnerId, PeelCandidateStatus,
 };
 
 /// One node of the projected factorize graph H.
@@ -37,13 +37,17 @@ enum FactorizeNode {
     Loose(OwnerId),
 }
 
-pub fn build_factorize_report(schedule: &Schedule, options: &FactorizeOptions) -> FactorizeReport {
-    let owner_edges = &schedule.owner_graph.edges;
+pub fn build_factorize_report(
+    schedule: &ChunkFactorization,
+    options: &FactorizeOptions,
+) -> FactorizeReport {
+    let owner_edges = &schedule.analysis.owner_graph.edges;
     let quotient_edges = build_quotient_edge_reports(schedule, owner_edges);
     let context = PeelabilityContext::new(schedule, owner_edges, &quotient_edges);
     let index = FactorizeIndex::new(schedule);
 
     let node_by_owner: Vec<FactorizeNode> = schedule
+        .analysis
         .owner_graph
         .iter_nodes()
         .map(|node| {
@@ -196,9 +200,9 @@ struct FactorizeIndex {
 }
 
 impl FactorizeIndex {
-    fn new(schedule: &Schedule) -> Self {
-        let atomic_units = compute_atomic_units(&schedule.owner_graph);
-        let mut unit_by_owner = vec![0usize; schedule.owner_graph.nodes.len()];
+    fn new(schedule: &ChunkFactorization) -> Self {
+        let atomic_units = compute_atomic_units(&schedule.analysis.owner_graph);
+        let mut unit_by_owner = vec![0usize; schedule.analysis.owner_graph.nodes.len()];
         let owners_by_unit: Vec<Vec<OwnerId>> = atomic_units
             .into_iter()
             .enumerate()
@@ -211,13 +215,14 @@ impl FactorizeIndex {
             })
             .collect();
         let bindings_by_owner: HashMap<OwnerId, Vec<BindingName>> = schedule
+            .analysis
             .owner_graph
             .iter_nodes()
             .map(|node| {
                 let names: Vec<BindingName> = node
                     .declared
                     .iter()
-                    .map(|bid| schedule.binding_name(*bid).clone())
+                    .map(|bid| schedule.analysis.binding_name(*bid).clone())
                     .collect();
                 (node.id, names)
             })
@@ -256,7 +261,10 @@ enum FrontierOutcome {
     Empty,
 }
 
-fn build_frontier_starts(schedule: &Schedule, index: &FactorizeIndex) -> Vec<FrontierStart> {
+fn build_frontier_starts(
+    schedule: &ChunkFactorization,
+    index: &FactorizeIndex,
+) -> Vec<FrontierStart> {
     let mut starts = BTreeSet::<FrontierStart>::new();
     for owners in &index.owners_by_unit {
         let mut residual = BTreeSet::<OwnerId>::new();
@@ -285,7 +293,7 @@ fn build_frontier_starts(schedule: &Schedule, index: &FactorizeIndex) -> Vec<Fro
 }
 
 fn close_frontier(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     start: FrontierStart,
@@ -369,7 +377,7 @@ fn close_frontier(
             }
             PeelCandidateStatus::BlockedCycle => {
                 for &edge_idx in &verdict.constraining_owner_edge_indices {
-                    let Some(edge) = schedule.owner_graph.edges.get(edge_idx) else {
+                    let Some(edge) = schedule.analysis.owner_graph.edges.get(edge_idx) else {
                         continue;
                     };
                     for endpoint in [edge.from, edge.to] {
@@ -406,7 +414,7 @@ fn close_frontier(
 }
 
 fn close_atomic_units(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     index: &FactorizeIndex,
     owners: &mut BTreeSet<OwnerId>,
     extension_target: &mut Option<ModuleId>,
@@ -437,7 +445,7 @@ fn close_atomic_units(
 }
 
 fn add_repair_owner(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     owner: OwnerId,
     owners: &mut BTreeSet<OwnerId>,
     extension_target: &mut Option<ModuleId>,
@@ -455,7 +463,7 @@ fn add_repair_owner(
 }
 
 fn evaluate_current(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     owners: &BTreeSet<OwnerId>,
@@ -489,7 +497,7 @@ fn certified_verdict(mut verdict: PeelCandidateEvaluation) -> PeelCandidateEvalu
 }
 
 fn extension_cycle_is_internal_to_target(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     owners: &BTreeSet<OwnerId>,
     extension_target: Option<ModuleId>,
     verdict: &PeelCandidateEvaluation,
@@ -504,12 +512,13 @@ fn extension_cycle_is_internal_to_target(
         return false;
     }
     verdict.constraining_owner_edge_indices.iter().all(|&idx| {
-        let Some(edge) = schedule.owner_graph.edges.get(idx) else {
+        let Some(edge) = schedule.analysis.owner_graph.edges.get(idx) else {
             return true;
         };
         [edge.from, edge.to].into_iter().all(|owner| {
             owners.contains(&owner)
                 || schedule
+                    .analysis
                     .owner_graph
                     .node(owner)
                     .is_some_and(|_| schedule.partition.of(owner) == target)
@@ -518,7 +527,7 @@ fn extension_cycle_is_internal_to_target(
 }
 
 fn coalesce_certified_proposals(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     proposals: &mut Vec<CertifiedProposal>,
@@ -576,14 +585,14 @@ fn coalesce_certified_proposals(
         let a_start = a
             .owners
             .iter()
-            .filter_map(|owner| schedule.owner_graph.node(*owner))
+            .filter_map(|owner| schedule.analysis.owner_graph.node(*owner))
             .filter_map(|node| node.source_location.as_ref().map(|loc| loc.start_line))
             .min()
             .unwrap_or(usize::MAX);
         let b_start = b
             .owners
             .iter()
-            .filter_map(|owner| schedule.owner_graph.node(*owner))
+            .filter_map(|owner| schedule.analysis.owner_graph.node(*owner))
             .filter_map(|node| node.source_location.as_ref().map(|loc| loc.start_line))
             .min()
             .unwrap_or(usize::MAX);
@@ -593,8 +602,9 @@ fn coalesce_certified_proposals(
     });
 }
 
-fn owner_line_count(schedule: &Schedule, owner: OwnerId) -> usize {
+fn owner_line_count(schedule: &ChunkFactorization, owner: OwnerId) -> usize {
     schedule
+        .analysis
         .owner_graph
         .node(owner)
         .and_then(|node| node.source_location.as_ref())
@@ -611,7 +621,7 @@ fn make_cell(
     node_by_owner: &[FactorizeNode],
     verdict: &PeelCandidateEvaluation,
     bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
 ) -> FactorizeCell {
     let mut owner_ids: Vec<String> = owners.iter().copied().map(owner_key).collect();
     owner_ids.sort();
@@ -630,7 +640,7 @@ fn make_cell(
     let mut size_lines: usize = 0;
     let empty_vec: Vec<BindingName> = Vec::new();
     for owner_id in &owners {
-        let Some(node) = schedule.owner_graph.node(*owner_id) else {
+        let Some(node) = schedule.analysis.owner_graph.node(*owner_id) else {
             continue;
         };
         let declared_bindings: &Vec<BindingName> =
@@ -658,7 +668,7 @@ fn make_cell(
         .constraining_owner_edge_indices
         .iter()
         .flat_map(|&idx| {
-            let edge = &schedule.owner_graph.edges[idx];
+            let edge = &schedule.analysis.owner_graph.edges[idx];
             [edge.from, edge.to]
         })
         .filter(|o| !owners.contains(o))
@@ -676,7 +686,7 @@ fn make_cell(
     // cell relationships in `peel_factorize.rs`).
     let mut active_modules_referenced: HashSet<String> = HashSet::new();
     for &owner_id in &owners {
-        for edge in schedule.owner_graph.edges.iter() {
+        for edge in schedule.analysis.owner_graph.edges.iter() {
             if edge.from != owner_id {
                 continue;
             }
@@ -736,7 +746,7 @@ fn make_diagnostic(
     verdict: &PeelCandidateEvaluation,
     reason: FactorizeDiagnosticReason,
     bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
 ) -> FactorizeDiagnostic {
     let mut owner_ids: Vec<String> = owners.iter().copied().map(owner_key).collect();
     owner_ids.sort();
@@ -752,7 +762,7 @@ fn make_diagnostic(
         if let Some(bindings) = bindings_by_owner.get(owner) {
             binding_ids_set.extend(bindings.iter().cloned());
         }
-        let Some(node) = schedule.owner_graph.node(*owner) else {
+        let Some(node) = schedule.analysis.owner_graph.node(*owner) else {
             continue;
         };
         if let Some(loc) = &node.source_location {
@@ -771,7 +781,7 @@ fn make_diagnostic(
         .constraining_owner_edge_indices
         .iter()
         .flat_map(|&edge_idx| {
-            let edge = &schedule.owner_graph.edges[edge_idx];
+            let edge = &schedule.analysis.owner_graph.edges[edge_idx];
             [edge.from, edge.to]
         })
         .filter(|owner| !owners.contains(owner))
@@ -792,7 +802,7 @@ fn make_diagnostic(
 
     let mut active_modules_referenced: HashSet<String> = HashSet::new();
     for &owner in &owners {
-        for edge in schedule.owner_graph.edges.iter() {
+        for edge in schedule.analysis.owner_graph.edges.iter() {
             if edge.from != owner || owners.contains(&edge.to) {
                 continue;
             }

--- a/devinfra/js/debundle/factorize.rs
+++ b/devinfra/js/debundle/factorize.rs
@@ -38,21 +38,21 @@ enum FactorizeNode {
 }
 
 pub fn build_factorize_report(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     options: &FactorizeOptions,
 ) -> FactorizeReport {
-    let owner_edges = &schedule.analysis.owner_graph.edges;
-    let quotient_edges = build_quotient_edge_reports(schedule, owner_edges);
-    let context = PeelabilityContext::new(schedule, owner_edges, &quotient_edges);
-    let index = FactorizeIndex::new(schedule);
+    let owner_edges = &factorization.analysis.owner_graph.edges;
+    let quotient_edges = build_quotient_edge_reports(factorization, owner_edges);
+    let context = PeelabilityContext::new(factorization, owner_edges, &quotient_edges);
+    let index = FactorizeIndex::new(factorization);
 
-    let node_by_owner: Vec<FactorizeNode> = schedule
+    let node_by_owner: Vec<FactorizeNode> = factorization
         .analysis
         .owner_graph
         .iter_nodes()
         .map(|node| {
-            let dest = schedule.partition.of(node.id);
-            if is_residual_destination(schedule, dest) {
+            let dest = factorization.partition.of(node.id);
+            if is_residual_destination(factorization, dest) {
                 FactorizeNode::Loose(node.id)
             } else {
                 FactorizeNode::Supernode(dest)
@@ -76,7 +76,7 @@ pub fn build_factorize_report(
 
     let mut proposals = Vec::<CertifiedProposal>::new();
     let mut diagnostics = Vec::<FactorizeDiagnostic>::new();
-    let starts = build_frontier_starts(schedule, &index);
+    let starts = build_frontier_starts(factorization, &index);
     // Dedup diagnostics across frontier starts that converge on the same
     // closure: each atomic unit grows independently, but different starts
     // can reach the same blocked or oversize set. Emit one row per
@@ -91,7 +91,7 @@ pub fn build_factorize_report(
     let mut oversize_owners = BTreeSet::<OwnerId>::new();
     for start in starts {
         match close_frontier(
-            schedule,
+            factorization,
             &context,
             &index,
             start,
@@ -118,7 +118,7 @@ pub fn build_factorize_report(
                     &diagnostic.verdict,
                     diagnostic.reason,
                     &index.bindings_by_owner,
-                    schedule,
+                    factorization,
                 ));
             }
             FrontierOutcome::Empty => {}
@@ -126,7 +126,7 @@ pub fn build_factorize_report(
     }
 
     coalesce_certified_proposals(
-        schedule,
+        factorization,
         &context,
         &index,
         &mut proposals,
@@ -161,7 +161,7 @@ pub fn build_factorize_report(
                 &node_by_owner,
                 &proposal.verdict,
                 &index.bindings_by_owner,
-                schedule,
+                factorization,
             )
         })
         .collect();
@@ -200,9 +200,9 @@ struct FactorizeIndex {
 }
 
 impl FactorizeIndex {
-    fn new(schedule: &ChunkFactorization) -> Self {
-        let atomic_units = compute_atomic_units(&schedule.analysis.owner_graph);
-        let mut unit_by_owner = vec![0usize; schedule.analysis.owner_graph.nodes.len()];
+    fn new(factorization: &ChunkFactorization) -> Self {
+        let atomic_units = compute_atomic_units(&factorization.analysis.owner_graph);
+        let mut unit_by_owner = vec![0usize; factorization.analysis.owner_graph.nodes.len()];
         let owners_by_unit: Vec<Vec<OwnerId>> = atomic_units
             .into_iter()
             .enumerate()
@@ -214,7 +214,7 @@ impl FactorizeIndex {
                 members
             })
             .collect();
-        let bindings_by_owner: HashMap<OwnerId, Vec<BindingName>> = schedule
+        let bindings_by_owner: HashMap<OwnerId, Vec<BindingName>> = factorization
             .analysis
             .owner_graph
             .iter_nodes()
@@ -222,7 +222,7 @@ impl FactorizeIndex {
                 let names: Vec<BindingName> = node
                     .declared
                     .iter()
-                    .map(|bid| schedule.analysis.binding_name(*bid).clone())
+                    .map(|bid| factorization.analysis.binding_name(*bid).clone())
                     .collect();
                 (node.id, names)
             })
@@ -262,7 +262,7 @@ enum FrontierOutcome {
 }
 
 fn build_frontier_starts(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     index: &FactorizeIndex,
 ) -> Vec<FrontierStart> {
     let mut starts = BTreeSet::<FrontierStart>::new();
@@ -270,8 +270,8 @@ fn build_frontier_starts(
         let mut residual = BTreeSet::<OwnerId>::new();
         let mut active_targets = BTreeSet::<ModuleId>::new();
         for &owner in owners {
-            let dest = schedule.partition.of(owner);
-            if is_residual_destination(schedule, dest) {
+            let dest = factorization.partition.of(owner);
+            if is_residual_destination(factorization, dest) {
                 residual.insert(owner);
             } else {
                 active_targets.insert(dest);
@@ -293,7 +293,7 @@ fn build_frontier_starts(
 }
 
 fn close_frontier(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     start: FrontierStart,
@@ -309,7 +309,7 @@ fn close_frontier(
 
     loop {
         if let Some(verdict) =
-            close_atomic_units(schedule, index, &mut owners, &mut extension_target)
+            close_atomic_units(factorization, index, &mut owners, &mut extension_target)
         {
             return FrontierOutcome::Diagnostic(FrontierDiagnostic {
                 owners,
@@ -321,7 +321,7 @@ fn close_frontier(
 
         let key = (extension_target, owners.iter().copied().collect::<Vec<_>>());
         if !seen.insert(key) {
-            let verdict = evaluate_current(schedule, context, index, &owners);
+            let verdict = evaluate_current(factorization, context, index, &owners);
             return FrontierOutcome::Diagnostic(FrontierDiagnostic {
                 owners,
                 extension_target,
@@ -330,10 +330,10 @@ fn close_frontier(
             });
         }
 
-        let verdict = evaluate_current(schedule, context, index, &owners);
+        let verdict = evaluate_current(factorization, context, index, &owners);
         let size_lines = owners
             .iter()
-            .map(|owner| owner_line_count(schedule, *owner))
+            .map(|owner| owner_line_count(factorization, *owner))
             .sum::<usize>();
         if size_lines > size_cap_lines {
             return FrontierOutcome::Diagnostic(FrontierDiagnostic {
@@ -345,7 +345,12 @@ fn close_frontier(
         }
 
         if verdict.status == PeelCandidateStatus::PeelableNow
-            || extension_cycle_is_internal_to_target(schedule, &owners, extension_target, &verdict)
+            || extension_cycle_is_internal_to_target(
+                factorization,
+                &owners,
+                extension_target,
+                &verdict,
+            )
         {
             return FrontierOutcome::Certified(CertifiedProposal {
                 owners,
@@ -370,22 +375,27 @@ fn close_frontier(
             PeelCandidateStatus::PeelableNow => {}
             PeelCandidateStatus::BlockedResidualDependency => {
                 for owner in &verdict.residual_dependency_blocker_owner_ids {
-                    if !add_repair_owner(schedule, *owner, &mut owners, &mut extension_target) {
+                    if !add_repair_owner(factorization, *owner, &mut owners, &mut extension_target)
+                    {
                         conflict = true;
                     }
                 }
             }
             PeelCandidateStatus::BlockedCycle => {
                 for &edge_idx in &verdict.constraining_owner_edge_indices {
-                    let Some(edge) = schedule.analysis.owner_graph.edges.get(edge_idx) else {
+                    let Some(edge) = factorization.analysis.owner_graph.edges.get(edge_idx) else {
                         continue;
                     };
                     for endpoint in [edge.from, edge.to] {
                         if owners.contains(&endpoint) {
                             continue;
                         }
-                        if !add_repair_owner(schedule, endpoint, &mut owners, &mut extension_target)
-                        {
+                        if !add_repair_owner(
+                            factorization,
+                            endpoint,
+                            &mut owners,
+                            &mut extension_target,
+                        ) {
                             conflict = true;
                         }
                     }
@@ -401,7 +411,12 @@ fn close_frontier(
             });
         }
         if owners == before
-            && !extension_cycle_is_internal_to_target(schedule, &owners, extension_target, &verdict)
+            && !extension_cycle_is_internal_to_target(
+                factorization,
+                &owners,
+                extension_target,
+                &verdict,
+            )
         {
             return FrontierOutcome::Diagnostic(FrontierDiagnostic {
                 owners,
@@ -414,7 +429,7 @@ fn close_frontier(
 }
 
 fn close_atomic_units(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     index: &FactorizeIndex,
     owners: &mut BTreeSet<OwnerId>,
     extension_target: &mut Option<ModuleId>,
@@ -428,8 +443,8 @@ fn close_atomic_units(
                 continue;
             };
             for &member in &index.owners_by_unit[unit_idx] {
-                let dest = schedule.partition.of(member);
-                if is_residual_destination(schedule, dest) {
+                let dest = factorization.partition.of(member);
+                if is_residual_destination(factorization, dest) {
                     changed |= owners.insert(member);
                 } else if let Some(target) = extension_target {
                     if *target != dest {
@@ -445,13 +460,13 @@ fn close_atomic_units(
 }
 
 fn add_repair_owner(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     owner: OwnerId,
     owners: &mut BTreeSet<OwnerId>,
     extension_target: &mut Option<ModuleId>,
 ) -> bool {
-    let dest = schedule.partition.of(owner);
-    if is_residual_destination(schedule, dest) {
+    let dest = factorization.partition.of(owner);
+    if is_residual_destination(factorization, dest) {
         owners.insert(owner);
         true
     } else if let Some(target) = extension_target {
@@ -463,7 +478,7 @@ fn add_repair_owner(
 }
 
 fn evaluate_current(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     owners: &BTreeSet<OwnerId>,
@@ -475,7 +490,7 @@ fn evaluate_current(
         .collect();
     declared.sort();
     declared.dedup();
-    evaluate_peel_candidate(schedule, context, &owner_vec, declared)
+    evaluate_peel_candidate(factorization, context, &owner_vec, declared)
 }
 
 fn empty_blocked_cycle(owners: &BTreeSet<OwnerId>) -> PeelCandidateEvaluation {
@@ -497,7 +512,7 @@ fn certified_verdict(mut verdict: PeelCandidateEvaluation) -> PeelCandidateEvalu
 }
 
 fn extension_cycle_is_internal_to_target(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     owners: &BTreeSet<OwnerId>,
     extension_target: Option<ModuleId>,
     verdict: &PeelCandidateEvaluation,
@@ -512,22 +527,22 @@ fn extension_cycle_is_internal_to_target(
         return false;
     }
     verdict.constraining_owner_edge_indices.iter().all(|&idx| {
-        let Some(edge) = schedule.analysis.owner_graph.edges.get(idx) else {
+        let Some(edge) = factorization.analysis.owner_graph.edges.get(idx) else {
             return true;
         };
         [edge.from, edge.to].into_iter().all(|owner| {
             owners.contains(&owner)
-                || schedule
+                || factorization
                     .analysis
                     .owner_graph
                     .node(owner)
-                    .is_some_and(|_| schedule.partition.of(owner) == target)
+                    .is_some_and(|_| factorization.partition.of(owner) == target)
         })
     })
 }
 
 fn coalesce_certified_proposals(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     index: &FactorizeIndex,
     proposals: &mut Vec<CertifiedProposal>,
@@ -550,15 +565,15 @@ fn coalesce_certified_proposals(
                     .collect();
                 let size_lines = union
                     .iter()
-                    .map(|owner| owner_line_count(schedule, *owner))
+                    .map(|owner| owner_line_count(factorization, *owner))
                     .sum::<usize>();
                 if size_lines > size_cap_lines {
                     continue;
                 }
-                let verdict = evaluate_current(schedule, context, index, &union);
+                let verdict = evaluate_current(factorization, context, index, &union);
                 if verdict.status != PeelCandidateStatus::PeelableNow
                     && !extension_cycle_is_internal_to_target(
-                        schedule,
+                        factorization,
                         &union,
                         proposals[left].extension_target,
                         &verdict,
@@ -585,14 +600,14 @@ fn coalesce_certified_proposals(
         let a_start = a
             .owners
             .iter()
-            .filter_map(|owner| schedule.analysis.owner_graph.node(*owner))
+            .filter_map(|owner| factorization.analysis.owner_graph.node(*owner))
             .filter_map(|node| node.source_location.as_ref().map(|loc| loc.start_line))
             .min()
             .unwrap_or(usize::MAX);
         let b_start = b
             .owners
             .iter()
-            .filter_map(|owner| schedule.analysis.owner_graph.node(*owner))
+            .filter_map(|owner| factorization.analysis.owner_graph.node(*owner))
             .filter_map(|node| node.source_location.as_ref().map(|loc| loc.start_line))
             .min()
             .unwrap_or(usize::MAX);
@@ -602,8 +617,8 @@ fn coalesce_certified_proposals(
     });
 }
 
-fn owner_line_count(schedule: &ChunkFactorization, owner: OwnerId) -> usize {
-    schedule
+fn owner_line_count(factorization: &ChunkFactorization, owner: OwnerId) -> usize {
+    factorization
         .analysis
         .owner_graph
         .node(owner)
@@ -621,7 +636,7 @@ fn make_cell(
     node_by_owner: &[FactorizeNode],
     verdict: &PeelCandidateEvaluation,
     bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
 ) -> FactorizeCell {
     let mut owner_ids: Vec<String> = owners.iter().copied().map(owner_key).collect();
     owner_ids.sort();
@@ -640,7 +655,7 @@ fn make_cell(
     let mut size_lines: usize = 0;
     let empty_vec: Vec<BindingName> = Vec::new();
     for owner_id in &owners {
-        let Some(node) = schedule.analysis.owner_graph.node(*owner_id) else {
+        let Some(node) = factorization.analysis.owner_graph.node(*owner_id) else {
             continue;
         };
         let declared_bindings: &Vec<BindingName> =
@@ -668,7 +683,7 @@ fn make_cell(
         .constraining_owner_edge_indices
         .iter()
         .flat_map(|&idx| {
-            let edge = &schedule.analysis.owner_graph.edges[idx];
+            let edge = &factorization.analysis.owner_graph.edges[idx];
             [edge.from, edge.to]
         })
         .filter(|o| !owners.contains(o))
@@ -686,7 +701,7 @@ fn make_cell(
     // cell relationships in `peel_factorize.rs`).
     let mut active_modules_referenced: HashSet<String> = HashSet::new();
     for &owner_id in &owners {
-        for edge in schedule.analysis.owner_graph.edges.iter() {
+        for edge in factorization.analysis.owner_graph.edges.iter() {
             if edge.from != owner_id {
                 continue;
             }
@@ -746,7 +761,7 @@ fn make_diagnostic(
     verdict: &PeelCandidateEvaluation,
     reason: FactorizeDiagnosticReason,
     bindings_by_owner: &HashMap<OwnerId, Vec<BindingName>>,
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
 ) -> FactorizeDiagnostic {
     let mut owner_ids: Vec<String> = owners.iter().copied().map(owner_key).collect();
     owner_ids.sort();
@@ -762,7 +777,7 @@ fn make_diagnostic(
         if let Some(bindings) = bindings_by_owner.get(owner) {
             binding_ids_set.extend(bindings.iter().cloned());
         }
-        let Some(node) = schedule.analysis.owner_graph.node(*owner) else {
+        let Some(node) = factorization.analysis.owner_graph.node(*owner) else {
             continue;
         };
         if let Some(loc) = &node.source_location {
@@ -781,7 +796,7 @@ fn make_diagnostic(
         .constraining_owner_edge_indices
         .iter()
         .flat_map(|&edge_idx| {
-            let edge = &schedule.analysis.owner_graph.edges[edge_idx];
+            let edge = &factorization.analysis.owner_graph.edges[edge_idx];
             [edge.from, edge.to]
         })
         .filter(|owner| !owners.contains(owner))
@@ -802,7 +817,7 @@ fn make_diagnostic(
 
     let mut active_modules_referenced: HashSet<String> = HashSet::new();
     for &owner in &owners {
-        for edge in schedule.analysis.owner_graph.edges.iter() {
+        for edge in factorization.analysis.owner_graph.edges.iter() {
             if edge.from != owner || owners.contains(&edge.to) {
                 continue;
             }

--- a/devinfra/js/debundle/ids.rs
+++ b/devinfra/js/debundle/ids.rs
@@ -27,7 +27,7 @@ pub struct LogicalModuleIndex(pub usize);
 /// Wraps a [`LogicalModuleIndex`] pointing into the schedule's
 /// `logical_modules` list. The residual catch-all is just a logical
 /// module flagged `residual: true` — synthesized by the materializer
-/// before `Schedule::build` for chunks that need a default
+/// before `ChunkFactorization::build` for chunks that need a default
 /// destination (every `InlineInEntry` and `CatchallFile` chunk; the
 /// `MiniFactors` synthesizer handles assignments itself).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
@@ -196,7 +196,7 @@ pub struct LogicalModule {
     /// Source-chunk top-level statement ordinals this module claims
     /// as anonymous-statement members (owners with empty
     /// `declared_bindings` that the spec resolves by AST shape via
-    /// `spec::LogicalModule::anonymous_statements`). Schedule uses
+    /// `spec::LogicalModule::anonymous_statements`). ChunkFactorization uses
     /// these to override the otherwise-residual destination of those
     /// owners so cross-destination/cycle checks see the closure as
     /// the materializer will emit it.

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -14,6 +14,8 @@
 //!    same graph model.
 
 mod atomic_units;
+mod chunk_analysis;
+mod chunk_factorization;
 mod factor_assembly;
 mod factorize;
 mod facts;
@@ -25,12 +27,13 @@ mod purity;
 mod realizability;
 mod report_schema;
 mod reports;
-mod schedule;
 mod validation;
 
 pub use atomic_units::{
     AtomicUnit, OwnerGraphAndUnits, compute_atomic_units, compute_owner_graph_and_units,
 };
+pub use chunk_analysis::ChunkAnalysis;
+pub use chunk_factorization::ChunkFactorization;
 pub use factor_assembly::{
     AssemblyOutcome, AtomicUnitConflict, ConflictingClaim, assemble_partition,
 };
@@ -65,10 +68,9 @@ pub use report_schema::{
     ResidualOwnerCompanionOptionReport, ResidualOwnerPeelHorizonReport, ResidualOwnerPeelStatus,
     SourceLocation,
 };
-pub use schedule::Schedule;
 pub use validation::{
-    CycleEdge, CycleReport, ScheduleReport, render_atomic_unit_conflict_summary,
-    render_cycle_summary, validate_schedule,
+    CycleEdge, CycleReport, FactorizationReport, render_atomic_unit_conflict_summary,
+    render_cycle_summary, validate_factorization,
 };
 
 #[cfg(test)]

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -10,11 +10,11 @@ use super::*;
 pub(super) fn cross_module_imports_for_plan(
     from_file: &str,
     mut imports_by_provider: BTreeMap<usize, BTreeMap<String, String>>,
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     occupied: &mut BTreeSet<String>,
     renames: &mut BTreeMap<String, String>,
 ) -> Vec<ModuleItem> {
-    // Sort providers by their position in the schedule's
+    // Sort providers by their position in the factorization's
     // `linker_order` (a topological linearization of `I ∪ S`).
     // ECMA-262's depth-first link traversal visits each module's
     // `import` directives in source order, and the deepest leaf
@@ -24,7 +24,7 @@ pub(super) fn cross_module_imports_for_plan(
     // "Lemma 2".
     let mut providers: Vec<usize> = imports_by_provider.keys().copied().collect();
     providers.sort_by_key(|&idx| {
-        schedule
+        factorization
             .linker_position(ModuleId(LogicalModuleIndex(idx)))
             .unwrap_or(usize::MAX)
     });
@@ -32,7 +32,7 @@ pub(super) fn cross_module_imports_for_plan(
         .into_iter()
         .filter_map(|provider_index| {
             let bindings = imports_by_provider.remove(&provider_index)?;
-            schedule
+            factorization
                 .analysis
                 .logical_module(LogicalModuleIndex(provider_index))
                 .map(|provider| {

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -10,7 +10,7 @@ use super::*;
 pub(super) fn cross_module_imports_for_plan(
     from_file: &str,
     mut imports_by_provider: BTreeMap<usize, BTreeMap<String, String>>,
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     occupied: &mut BTreeSet<String>,
     renames: &mut BTreeMap<String, String>,
 ) -> Vec<ModuleItem> {
@@ -33,6 +33,7 @@ pub(super) fn cross_module_imports_for_plan(
         .filter_map(|provider_index| {
             let bindings = imports_by_provider.remove(&provider_index)?;
             schedule
+                .analysis
                 .logical_module(LogicalModuleIndex(provider_index))
                 .map(|provider| {
                     let resolved = disambiguate_import_locals(&bindings, occupied, renames);

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -36,7 +36,7 @@ pub(super) struct LowerChunkInputs<'a> {
     /// the spec claimed as anonymous-statement members. See
     /// `ModulePlan::anonymous_statement_ordinals`.
     pub(super) anonymous_ordinal_assignment: &'a BTreeMap<usize, usize>,
-    pub(super) schedule: &'a Schedule,
+    pub(super) schedule: &'a ChunkFactorization,
     pub(super) runtime_import_facts: &'a RuntimeImportFacts,
     /// In-place renames from `TransformSpec::chunk_renames`. Applied
     /// to bindings staying in entry's body — i.e. those *not* in
@@ -267,7 +267,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             import_decl_for_plan(entry_file, &plan.target_file, &resolved),
         ));
     }
-    // Sort entry imports by Schedule::source_import_position, which
+    // Sort entry imports by ChunkFactorization::source_import_position, which
     // implements Lemma 2 (DESIGN.md "The realizability theorem"):
     // for acyclic imports graphs the order matches linker_order
     // (dependency-first source), but for cyclic-I shapes accepted
@@ -339,7 +339,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         if !auto_grow.is_empty() {
             entry_body.push(export_named_for_bindings(&auto_grow));
         }
-        trim_dead_named_specifiers(&mut entry_body, &schedule.bindings);
+        trim_dead_named_specifiers(&mut entry_body, &schedule.analysis.bindings);
     });
     let entry_exports_by_original_local = time_phase!(timings, "collect_entry_exports", {
         collect_entry_exports_by_original_local(
@@ -491,7 +491,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             rewrite_runtime_sources_for_target(&mut body, chunk_id, entry_file, &plan.target_file);
         });
         // ImportSpecifier-bound members (`BindingKind::Imported` in
-        // `schedule.bindings`): for each `Imported` binding whose
+        // `schedule.analysis.bindings`): for each `Imported` binding whose
         // `re_exported_by` map names this module, emit a re-import
         // (using the local name as the alias) plus mirror the
         // public-name export. Per-destination relative paths are
@@ -573,8 +573,9 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 .iter()
                 .map(|(_, v)| (*v).clone())
                 .collect();
-            let owner_ids =
-                schedule.owner_report_ids_for_bindings(binding_names.iter().map(String::as_str));
+            let owner_ids = schedule
+                .analysis
+                .owner_report_ids_for_bindings(binding_names.iter().map(String::as_str));
             let header = vec![
                 LOWERING_FILE_PRAGMA.to_string(),
                 LOWERING_GENERATOR_HEADER.to_string(),

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -36,7 +36,7 @@ pub(super) struct LowerChunkInputs<'a> {
     /// the spec claimed as anonymous-statement members. See
     /// `ModulePlan::anonymous_statement_ordinals`.
     pub(super) anonymous_ordinal_assignment: &'a BTreeMap<usize, usize>,
-    pub(super) schedule: &'a ChunkFactorization,
+    pub(super) factorization: &'a ChunkFactorization,
     pub(super) runtime_import_facts: &'a RuntimeImportFacts,
     /// In-place renames from `TransformSpec::chunk_renames`. Applied
     /// to bindings staying in entry's body — i.e. those *not* in
@@ -69,7 +69,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         binding_assignment,
         chunk_top_level_mark,
         anonymous_ordinal_assignment,
-        schedule,
+        factorization,
         runtime_import_facts,
         chunk_renames,
         pre_existing_entry_exports,
@@ -275,7 +275,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // sorted so DFS unwinds the dependency first in post-order.
     // Stable sort preserves plan-order for ties.
     entry_imports.sort_by_key(|(idx, _)| {
-        schedule
+        factorization
             .source_import_position(ModuleId(LogicalModuleIndex(*idx)))
             .unwrap_or(usize::MAX)
     });
@@ -339,7 +339,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         if !auto_grow.is_empty() {
             entry_body.push(export_named_for_bindings(&auto_grow));
         }
-        trim_dead_named_specifiers(&mut entry_body, &schedule.analysis.bindings);
+        trim_dead_named_specifiers(&mut entry_body, &factorization.analysis.bindings);
     });
     let entry_exports_by_original_local = time_phase!(timings, "collect_entry_exports", {
         collect_entry_exports_by_original_local(
@@ -349,7 +349,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         )
     });
     let imported_reexports_by_module = time_phase!(timings, "collect_imported_reexports", {
-        collect_imported_reexports_by_module(schedule, module_plans.len())
+        collect_imported_reexports_by_module(factorization, module_plans.len())
     });
     let mut source_import_cache =
         ArtifactSourceImportResolutionCache::new(artifact, artifact_indexes);
@@ -411,7 +411,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             plan_module_reference_needs(
                 index,
                 &body_facts,
-                schedule,
+                factorization,
                 declaration_by_name,
                 binding_assignment,
                 &entry_exports_by_original_local,
@@ -427,7 +427,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             cross_module_imports_for_plan(
                 &plan.target_file,
                 cross_module_imports_by_provider,
-                schedule,
+                factorization,
                 &mut module_import_locals,
                 &mut module_import_renames,
             )
@@ -491,7 +491,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             rewrite_runtime_sources_for_target(&mut body, chunk_id, entry_file, &plan.target_file);
         });
         // ImportSpecifier-bound members (`BindingKind::Imported` in
-        // `schedule.analysis.bindings`): for each `Imported` binding whose
+        // `factorization.analysis.bindings`): for each `Imported` binding whose
         // `re_exported_by` map names this module, emit a re-import
         // (using the local name as the alias) plus mirror the
         // public-name export. Per-destination relative paths are
@@ -573,7 +573,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 .iter()
                 .map(|(_, v)| (*v).clone())
                 .collect();
-            let owner_ids = schedule
+            let owner_ids = factorization
                 .analysis
                 .owner_report_ids_for_bindings(binding_names.iter().map(String::as_str));
             let header = vec![

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -319,7 +319,7 @@ pub(super) fn materialize_logical_chunk(
         // the catchall target. Append unclaimed bindings to that
         // plan so the residual sweep still has a home, and flip
         // its `explicit` flag so downstream consumers see it as
-        // the residual destination (residual flag on the schedule
+        // the residual destination (residual flag on the factorization
         // module, OutputRole::ResidualModule in artifact metadata,
         // residual_logical_modules count on the chunk report).
         let owner_index = module_plans
@@ -355,7 +355,7 @@ pub(super) fn materialize_logical_chunk(
     })?
     .unwrap_or_default();
 
-    let (schedule, redundant_purity_hints) = {
+    let (factorization, redundant_purity_hints) = {
         // Spec annotations carried on any member form (logical-module
         // member, chunk_renames member) propagate the same way:
         // collect them by local binding name and feed them into fact
@@ -522,7 +522,7 @@ pub(super) fn materialize_logical_chunk(
             });
         // Commit 1 transitional behavior: the partition's "default
         // destination" — the module owners with no claim fall back to —
-        // is a schedule-only sentinel logical module appended past
+        // is a factorization-only sentinel logical module appended past
         // `module_plans.len()`. The emit loop iterates `module_plans`,
         // so the sentinel never gets emitted as a file. Anonymous
         // statements without an explicit logical-module
@@ -556,7 +556,7 @@ pub(super) fn materialize_logical_chunk(
                 )
             })
             .collect();
-        let schedule = time_phase!(timings, "build_schedule", {
+        let factorization = time_phase!(timings, "build_schedule", {
             ChunkFactorization::build_with(
                 chunk_id.to_string(),
                 analysis.facts,
@@ -567,15 +567,17 @@ pub(super) fn materialize_logical_chunk(
                 default_destination,
             )
         });
-        (schedule, redundant_purity_hints)
+        (factorization, redundant_purity_hints)
     };
-    let schedule_report = time_phase!(timings, "validate_factorization", { schedule.validate() });
+    let schedule_report = time_phase!(timings, "validate_factorization", {
+        factorization.validate()
+    });
     if let Some(report_out_dir) = report_out_dir {
         time_phase!(timings, "write_schedule_report", {
             write_chunk_report_json(report_out_dir, chunk_id, "schedule.json", &schedule_report)
         })?;
         let owner_graph_report = time_phase!(timings, "build_owner_graph_report", {
-            schedule.owner_graph_report()
+            factorization.owner_graph_report()
         });
         time_phase!(timings, "write_owner_graph_report", {
             write_chunk_report_json(
@@ -590,7 +592,7 @@ pub(super) fn materialize_logical_chunk(
     if !schedule_report.atomic_unit_conflicts.is_empty() {
         let summary =
             render_atomic_unit_conflict_summary(&schedule_report.atomic_unit_conflicts, &|id| {
-                schedule.analysis.module_name(id)
+                factorization.analysis.module_name(id)
             });
         let causes = render_atomic_unit_cause_guidance(&schedule_report.atomic_unit_conflicts);
         bail!(
@@ -632,7 +634,7 @@ pub(super) fn materialize_logical_chunk(
             binding_assignment: &binding_assignment,
             chunk_top_level_mark,
             anonymous_ordinal_assignment: &anonymous_ordinal_assignment,
-            schedule: &schedule,
+            factorization: &factorization,
             chunk_renames: &chunk_renames_map,
             runtime_import_facts: &runtime_import_facts,
             pre_existing_entry_exports: &pre_existing_entry_exports,
@@ -654,7 +656,7 @@ pub(super) fn materialize_logical_chunk(
                 sorted.sort_by(|a, b| a.0.cmp(b.0));
                 let binding_names: Vec<String> = sorted.iter().map(|(k, _)| (*k).clone()).collect();
                 let member_names: Vec<String> = sorted.iter().map(|(_, v)| (*v).clone()).collect();
-                let owner_ids = schedule
+                let owner_ids = factorization
                     .analysis
                     .owner_report_ids_for_bindings(binding_names.iter().map(String::as_str));
                 FinalModuleContent {

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -483,11 +483,11 @@ pub(super) fn materialize_logical_chunk(
             })?;
         }
         let chunk_top_level_mark = runtime_ast.top_level_mark;
-        let mut logical_modules: Vec<ScheduleLogicalModule> =
+        let mut logical_modules: Vec<FactorizationLogicalModule> =
             time_phase!(timings, "project_schedule_modules", {
                 module_plans
                     .iter()
-                    .map(|plan| ScheduleLogicalModule {
+                    .map(|plan| FactorizationLogicalModule {
                         id: plan.id.clone(),
                         target_file: plan.target_file.clone(),
                         residual: !plan.explicit,
@@ -538,7 +538,7 @@ pub(super) fn materialize_logical_chunk(
             .transpose()?
             .unwrap_or_else(|| target_file.clone());
         let sentinel_idx = logical_modules.len();
-        logical_modules.push(ScheduleLogicalModule {
+        logical_modules.push(FactorizationLogicalModule {
             id: format!("{chunk_id}::anon_residual_sentinel"),
             target_file: sentinel_residual_target,
             residual: true,

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -501,7 +501,7 @@ pub(super) fn materialize_logical_chunk(
                                 )
                             })
                             .collect(),
-                        // Schedule's owner graph uses post-comma-list-split
+                        // ChunkFactorization's owner graph uses post-comma-list-split
                         // `StatementOrdinal`s; convert body indices here so
                         // the destination override targets the right owner
                         // node (an anon body item is always a single
@@ -557,7 +557,7 @@ pub(super) fn materialize_logical_chunk(
             })
             .collect();
         let schedule = time_phase!(timings, "build_schedule", {
-            Schedule::build_with(
+            ChunkFactorization::build_with(
                 chunk_id.to_string(),
                 analysis.facts,
                 precomputed,
@@ -569,7 +569,7 @@ pub(super) fn materialize_logical_chunk(
         });
         (schedule, redundant_purity_hints)
     };
-    let schedule_report = time_phase!(timings, "validate_schedule", { schedule.validate() });
+    let schedule_report = time_phase!(timings, "validate_factorization", { schedule.validate() });
     if let Some(report_out_dir) = report_out_dir {
         time_phase!(timings, "write_schedule_report", {
             write_chunk_report_json(report_out_dir, chunk_id, "schedule.json", &schedule_report)
@@ -590,7 +590,7 @@ pub(super) fn materialize_logical_chunk(
     if !schedule_report.atomic_unit_conflicts.is_empty() {
         let summary =
             render_atomic_unit_conflict_summary(&schedule_report.atomic_unit_conflicts, &|id| {
-                schedule.module_name(id)
+                schedule.analysis.module_name(id)
             });
         let causes = render_atomic_unit_cause_guidance(&schedule_report.atomic_unit_conflicts);
         bail!(
@@ -655,6 +655,7 @@ pub(super) fn materialize_logical_chunk(
                 let binding_names: Vec<String> = sorted.iter().map(|(k, _)| (*k).clone()).collect();
                 let member_names: Vec<String> = sorted.iter().map(|(_, v)| (*v).clone()).collect();
                 let owner_ids = schedule
+                    .analysis
                     .owner_report_ids_for_bindings(binding_names.iter().map(String::as_str));
                 FinalModuleContent {
                     binding_names,

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -12,11 +12,11 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::{
-    AnalysisHints, AtomicUnitConflict, BindingKind, BindingName, DepKind, KnownEffect,
-    LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId, OwnerGraphAndUnits,
-    OwnerId, RedundantPureMemberReason, RedundantPurityHint, RedundantPurityReason, Schedule,
-    analyze_chunk, compute_owner_graph_and_units, render_atomic_unit_conflict_summary,
-    render_cycle_summary, top_level_id,
+    AnalysisHints, AtomicUnitConflict, BindingKind, BindingName, ChunkFactorization, DepKind,
+    KnownEffect, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
+    OwnerGraphAndUnits, OwnerId, RedundantPureMemberReason, RedundantPurityHint,
+    RedundantPurityReason, analyze_chunk, compute_owner_graph_and_units,
+    render_atomic_unit_conflict_summary, render_cycle_summary, top_level_id,
 };
 use artifact::{
     ArtifactIndexes, ArtifactSourceImportResolver, ChunkAnalysis, ChunkArtifact, ChunkBundle,

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -13,7 +13,7 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::{
     AnalysisHints, AtomicUnitConflict, BindingKind, BindingName, ChunkFactorization, DepKind,
-    KnownEffect, LogicalModule as ScheduleLogicalModule, LogicalModuleIndex, ModuleId,
+    KnownEffect, LogicalModule as FactorizationLogicalModule, LogicalModuleIndex, ModuleId,
     OwnerGraphAndUnits, OwnerId, RedundantPureMemberReason, RedundantPurityHint,
     RedundantPurityReason, analyze_chunk, compute_owner_graph_and_units,
     render_atomic_unit_conflict_summary, render_cycle_summary, top_level_id,

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -85,15 +85,16 @@ impl<'a> ArtifactSourceImportResolutionCache<'a> {
 }
 
 pub(super) fn collect_imported_reexports_by_module(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     module_count: usize,
 ) -> Vec<Vec<ImportedReexport>> {
     let mut by_module: Vec<Vec<ImportedReexport>> = (0..module_count).map(|_| Vec::new()).collect();
-    // Stable iteration order on `schedule.analysis.bindings` (HashMap): the
+    // Stable iteration order on `factorization.analysis.bindings` (HashMap): the
     // recorded sequence determines the emit order of
     // `import { ... }` statements per module body and we want that
     // source-level shape pinned.
-    let mut sorted_bindings: Vec<(&Id, &BindingKind)> = schedule.analysis.bindings.iter().collect();
+    let mut sorted_bindings: Vec<(&Id, &BindingKind)> =
+        factorization.analysis.bindings.iter().collect();
     sorted_bindings.sort_by(|a, b| a.0.0.cmp(&b.0.0));
     for (id, kind) in sorted_bindings {
         // The body of this loop refers to the sym-typed `local` name
@@ -135,7 +136,7 @@ pub(super) struct RuntimeImportLookup<'a> {
 pub(super) fn plan_module_reference_needs<'a>(
     module_index: usize,
     body_facts: &ModuleBodyFacts,
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &HashMap<Id, usize>,
     entry_exports_by_original_local: &HashMap<Id, EntryExport>,
@@ -144,13 +145,13 @@ pub(super) fn plan_module_reference_needs<'a>(
     let mut needs = ModuleReferenceNeeds::default();
     for body_id in &body_facts.referenced_idents {
         // body_id is the hygiene-aware (sym, ctxt) of one referenced ident.
-        // Spec-derived lookup tables (schedule.{owner_of, logical_module},
+        // Spec-derived lookup tables (factorization.{owner_of, logical_module},
         // declaration_by_name, binding_assignment, entry_exports_by_original_local,
         // LogicalModule.rename_map) are still String-keyed by sym; convert at
         // each call. `runtime_imports.imports` IS Id-keyed.
         let name_str = body_id.0.as_ref();
         if let Some(ModuleId(LogicalModuleIndex(provider_index))) =
-            schedule.analysis.owner_of(name_str)
+            factorization.analysis.owner_of(name_str)
         {
             // provider.rename_map is now Id-keyed; reconstruct the
             // provider's Id from the body ident's sym + ctxt. Within
@@ -159,7 +160,7 @@ pub(super) fn plan_module_reference_needs<'a>(
             // binding ctxt.
             let provider_key: Id = (body_id.0.clone(), body_id.1);
             if provider_index != module_index
-                && let Some(provider) = schedule
+                && let Some(provider) = factorization
                     .analysis
                     .logical_module(LogicalModuleIndex(provider_index))
                 && let Some(exported_name) = provider.rename_map.get(&provider_key)

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -85,15 +85,15 @@ impl<'a> ArtifactSourceImportResolutionCache<'a> {
 }
 
 pub(super) fn collect_imported_reexports_by_module(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     module_count: usize,
 ) -> Vec<Vec<ImportedReexport>> {
     let mut by_module: Vec<Vec<ImportedReexport>> = (0..module_count).map(|_| Vec::new()).collect();
-    // Stable iteration order on `schedule.bindings` (HashMap): the
+    // Stable iteration order on `schedule.analysis.bindings` (HashMap): the
     // recorded sequence determines the emit order of
     // `import { ... }` statements per module body and we want that
     // source-level shape pinned.
-    let mut sorted_bindings: Vec<(&Id, &BindingKind)> = schedule.bindings.iter().collect();
+    let mut sorted_bindings: Vec<(&Id, &BindingKind)> = schedule.analysis.bindings.iter().collect();
     sorted_bindings.sort_by(|a, b| a.0.0.cmp(&b.0.0));
     for (id, kind) in sorted_bindings {
         // The body of this loop refers to the sym-typed `local` name
@@ -135,7 +135,7 @@ pub(super) struct RuntimeImportLookup<'a> {
 pub(super) fn plan_module_reference_needs<'a>(
     module_index: usize,
     body_facts: &ModuleBodyFacts,
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &HashMap<Id, usize>,
     entry_exports_by_original_local: &HashMap<Id, EntryExport>,
@@ -149,7 +149,9 @@ pub(super) fn plan_module_reference_needs<'a>(
         // LogicalModule.rename_map) are still String-keyed by sym; convert at
         // each call. `runtime_imports.imports` IS Id-keyed.
         let name_str = body_id.0.as_ref();
-        if let Some(ModuleId(LogicalModuleIndex(provider_index))) = schedule.owner_of(name_str) {
+        if let Some(ModuleId(LogicalModuleIndex(provider_index))) =
+            schedule.analysis.owner_of(name_str)
+        {
             // provider.rename_map is now Id-keyed; reconstruct the
             // provider's Id from the body ident's sym + ctxt. Within
             // a chunk all top-level bindings share the chunk's
@@ -157,7 +159,9 @@ pub(super) fn plan_module_reference_needs<'a>(
             // binding ctxt.
             let provider_key: Id = (body_id.0.clone(), body_id.1);
             if provider_index != module_index
-                && let Some(provider) = schedule.logical_module(LogicalModuleIndex(provider_index))
+                && let Some(provider) = schedule
+                    .analysis
+                    .logical_module(LogicalModuleIndex(provider_index))
                 && let Some(exported_name) = provider.rename_map.get(&provider_key)
             {
                 needs

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -59,7 +59,7 @@ pub(super) struct ModulePlan {
     /// Local-name → public-export-name for every owned binding this
     /// plan claims (i.e. members whose `selector.binding.kind` is
     /// _not_ `ImportSpecifier`). ImportSpecifier-bound members live
-    /// in `Schedule.bindings` as `BindingKind::Imported` and their
+    /// in `ChunkFactorization.bindings` as `BindingKind::Imported` and their
     /// emit is driven from there. Iteration order is undefined;
     /// emit / report sites sort by local name before consuming so
     /// the emitted source and JSON shapes stay deterministic.

--- a/devinfra/js/debundle/peelability.rs
+++ b/devinfra/js/debundle/peelability.rs
@@ -10,10 +10,11 @@ use crate::reports::{
     binding_reports, is_residual_destination, module_id_from_key, module_report_ref, owner_key,
 };
 use crate::{
-    AtomicUnit, BindingKind, BindingName, DepKind, EvaluatedPeelCandidateReport,
-    LogicalModuleIndex, ModuleId, OwnerGraphPeelSetReport, OwnerGraphPeelabilityReport, OwnerId,
-    OwnerNode, PeelCandidateStatus, QuotientEdgeReport, ResidualOwnerCompanionOptionReport,
-    ResidualOwnerPeelHorizonReport, ResidualOwnerPeelStatus, Schedule, compute_atomic_units,
+    AtomicUnit, BindingKind, BindingName, ChunkFactorization, DepKind,
+    EvaluatedPeelCandidateReport, LogicalModuleIndex, ModuleId, OwnerGraphPeelSetReport,
+    OwnerGraphPeelabilityReport, OwnerId, OwnerNode, PeelCandidateStatus, QuotientEdgeReport,
+    ResidualOwnerCompanionOptionReport, ResidualOwnerPeelHorizonReport, ResidualOwnerPeelStatus,
+    compute_atomic_units,
 };
 
 pub(crate) struct PeelabilityContext<'a> {
@@ -55,11 +56,12 @@ pub(crate) struct PeelCandidateEvaluation {
 }
 
 pub(crate) fn build_peelability_report(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     owner_edges: &[OwnerEdge],
     quotient_edges: &[QuotientEdgeReport],
 ) -> OwnerGraphPeelabilityReport {
     let residual_destinations: BTreeSet<ModuleId> = schedule
+        .analysis
         .owner_graph
         .iter_nodes()
         .filter_map(|node| {
@@ -70,7 +72,7 @@ pub(crate) fn build_peelability_report(
 
     let context = PeelabilityContext::new(schedule, owner_edges, quotient_edges);
     let mut declared_by_owner = BTreeMap::<OwnerId, Vec<BindingName>>::new();
-    for node in schedule.owner_graph.iter_nodes() {
+    for node in schedule.analysis.owner_graph.iter_nodes() {
         if !is_residual_destination(schedule, schedule.partition.of(node.id)) {
             continue;
         }
@@ -179,7 +181,7 @@ pub(crate) fn build_peelability_report(
 }
 
 fn build_residual_owner_horizon(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
     candidates: &[PeelCandidateEvaluation],
 ) -> (Vec<ResidualOwnerPeelHorizonReport>, BTreeSet<String>) {
@@ -275,6 +277,7 @@ fn build_residual_owner_horizon(
         }
 
         let node = schedule
+            .analysis
             .owner_graph
             .node(*owner_id)
             .expect("residual owner horizon should reference an existing owner");
@@ -301,14 +304,17 @@ fn build_candidate_owner_sets(candidates: &[PeelCandidateEvaluation]) -> Vec<BTr
         .collect()
 }
 
-fn residual_declared_for_owner(schedule: &Schedule, node: &OwnerNode) -> Vec<BindingName> {
+fn residual_declared_for_owner(
+    schedule: &ChunkFactorization,
+    node: &OwnerNode,
+) -> Vec<BindingName> {
     node.declared
         .iter()
-        .map(|binding| schedule.binding_name(*binding))
+        .map(|binding| schedule.analysis.binding_name(*binding))
         .filter(|name| {
-            // schedule.bindings is Id-keyed but BindingTable.name returns
+            // schedule.analysis.bindings is Id-keyed but BindingTable.name returns
             // sym only; match by sym.
-            !schedule.bindings.iter().any(|(id, kind)| {
+            !schedule.analysis.bindings.iter().any(|(id, kind)| {
                 id.0.as_ref() == name.as_str() && matches!(kind, BindingKind::Imported { .. })
             })
         })
@@ -318,11 +324,11 @@ fn residual_declared_for_owner(schedule: &Schedule, node: &OwnerNode) -> Vec<Bin
 
 impl<'a> PeelabilityContext<'a> {
     pub(crate) fn new(
-        schedule: &'a Schedule,
+        schedule: &'a ChunkFactorization,
         owner_edges: &'a [OwnerEdge],
         quotient_edges: &[QuotientEdgeReport],
     ) -> Self {
-        let owner_count = schedule.owner_graph.nodes.len();
+        let owner_count = schedule.analysis.owner_graph.nodes.len();
         let mut owner_out_edges = vec![Vec::new(); owner_count];
         for (idx, edge) in owner_edges.iter().enumerate() {
             if let Some(indices) = owner_out_edges.get_mut(edge.from.0) {
@@ -330,15 +336,17 @@ impl<'a> PeelabilityContext<'a> {
             }
         }
 
-        let atomic_units = compute_atomic_units(&schedule.owner_graph);
+        let atomic_units = compute_atomic_units(&schedule.analysis.owner_graph);
 
         // The realizability primitive is the single shared
         // implementation of clause 3 (and clause 2). The candidate
         // evaluator pushes a hypothetical destination move onto this
         // index and reads the verdict — the same verdict the
         // validator would produce for the post-peel partition.
-        let realizability =
-            RealizabilityIndex::from_partition(&schedule.owner_graph, schedule.partition.clone());
+        let realizability = RealizabilityIndex::from_partition(
+            &schedule.analysis.owner_graph,
+            schedule.partition.clone(),
+        );
 
         // Reserve a module-id one past every index currently in use,
         // so the candidate's hypothetical destination is a fresh node
@@ -346,7 +354,7 @@ impl<'a> PeelabilityContext<'a> {
         // partition's actual assignments, and any module-id that
         // appears in the quotient-edges report — covering synthesized
         // residual sentinels and external/vendor modules.
-        let mut max_index = schedule.logical_modules.len();
+        let mut max_index = schedule.analysis.logical_modules.len();
         for (_, module) in schedule.partition.iter() {
             max_index = max_index.max(module.0.0 + 1);
         }
@@ -381,7 +389,7 @@ impl<'a> PeelabilityContext<'a> {
 }
 
 fn residual_pair_candidates_from_singleton_blockers(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     singleton_candidates: &[(OwnerId, PeelCandidateEvaluation)],
     owner_edges: &[OwnerEdge],
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
@@ -434,7 +442,7 @@ fn residual_pair_candidates_from_singleton_blockers(
 /// statements with no class binding) are skipped: there'd be nothing
 /// to land in `members[]`.
 fn residual_atomic_unit_candidates(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
 ) -> Vec<PeelCandidateEvaluation> {
@@ -470,15 +478,15 @@ fn residual_atomic_unit_candidates(
     candidates
 }
 
-fn owner_is_in_residual(schedule: &Schedule, owner_id: OwnerId) -> bool {
-    if schedule.owner_graph.node(owner_id).is_none() {
+fn owner_is_in_residual(schedule: &ChunkFactorization, owner_id: OwnerId) -> bool {
+    if schedule.analysis.owner_graph.node(owner_id).is_none() {
         return false;
     }
     is_residual_destination(schedule, schedule.partition.of(owner_id))
 }
 
 fn residual_dependency_closure_candidates(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     singleton_candidates: &[(OwnerId, PeelCandidateEvaluation)],
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
@@ -538,10 +546,10 @@ struct ResidualDependencyClosureIndex {
 }
 
 impl ResidualDependencyClosureIndex {
-    fn new(schedule: &Schedule, context: &PeelabilityContext<'_>) -> Self {
+    fn new(schedule: &ChunkFactorization, context: &PeelabilityContext<'_>) -> Self {
         let mut graph = DiGraph::<OwnerId, ()>::new();
-        let mut node_by_owner = vec![None; schedule.owner_graph.nodes.len()];
-        for node in schedule.owner_graph.iter_nodes() {
+        let mut node_by_owner = vec![None; schedule.analysis.owner_graph.nodes.len()];
+        for node in schedule.analysis.owner_graph.iter_nodes() {
             if !is_residual_destination(schedule, schedule.partition.of(node.id)) {
                 continue;
             }
@@ -621,8 +629,14 @@ impl ResidualDependencyClosureIndex {
     }
 }
 
-fn owners_share_residual_destination(schedule: &Schedule, left: OwnerId, right: OwnerId) -> bool {
-    if schedule.owner_graph.node(left).is_none() || schedule.owner_graph.node(right).is_none() {
+fn owners_share_residual_destination(
+    schedule: &ChunkFactorization,
+    left: OwnerId,
+    right: OwnerId,
+) -> bool {
+    if schedule.analysis.owner_graph.node(left).is_none()
+        || schedule.analysis.owner_graph.node(right).is_none()
+    {
         return false;
     }
     let left_module = schedule.partition.of(left);
@@ -646,7 +660,7 @@ fn sorted_owner_pair(left: OwnerId, right: OwnerId) -> (OwnerId, OwnerId) {
 /// The same primitive backs the validator, so a `PeelableNow` here is
 /// a `PeelableNow` at the gate.
 pub(crate) fn evaluate_peel_candidate(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     owner_ids: &[OwnerId],
     declared: Vec<BindingName>,
@@ -805,7 +819,7 @@ fn candidate_atomic_unit_split_edge_indices(
 /// derived from `moved_owners` (all moved owners share one
 /// destination by precondition).
 fn candidate_source_destination_blocker_owner_ids(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     moved_owners: &BTreeSet<OwnerId>,
 ) -> Vec<OwnerId> {
@@ -823,7 +837,7 @@ fn candidate_source_destination_blocker_owner_ids(
             if moved_owners.contains(&edge.to) {
                 continue;
             }
-            if schedule.owner_graph.node(edge.to).is_none() {
+            if schedule.analysis.owner_graph.node(edge.to).is_none() {
                 continue;
             }
             if schedule.partition.of(edge.to) != source_destination {

--- a/devinfra/js/debundle/peelability.rs
+++ b/devinfra/js/debundle/peelability.rs
@@ -20,7 +20,7 @@ use crate::{
 pub(crate) struct PeelabilityContext<'a> {
     owner_edges: &'a [OwnerEdge],
     owner_out_edges: Vec<Vec<usize>>,
-    /// Atomic units of the schedule's owner graph (SCCs of the
+    /// Atomic units of the factorization's owner graph (SCCs of the
     /// constraining-edge subgraph `G_atomic`). Used by
     /// `residual_atomic_unit_candidates` to enumerate multi-owner
     /// candidates.
@@ -56,27 +56,27 @@ pub(crate) struct PeelCandidateEvaluation {
 }
 
 pub(crate) fn build_peelability_report(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     owner_edges: &[OwnerEdge],
     quotient_edges: &[QuotientEdgeReport],
 ) -> OwnerGraphPeelabilityReport {
-    let residual_destinations: BTreeSet<ModuleId> = schedule
+    let residual_destinations: BTreeSet<ModuleId> = factorization
         .analysis
         .owner_graph
         .iter_nodes()
         .filter_map(|node| {
-            let module = schedule.partition.of(node.id);
-            is_residual_destination(schedule, module).then_some(module)
+            let module = factorization.partition.of(node.id);
+            is_residual_destination(factorization, module).then_some(module)
         })
         .collect();
 
-    let context = PeelabilityContext::new(schedule, owner_edges, quotient_edges);
+    let context = PeelabilityContext::new(factorization, owner_edges, quotient_edges);
     let mut declared_by_owner = BTreeMap::<OwnerId, Vec<BindingName>>::new();
-    for node in schedule.analysis.owner_graph.iter_nodes() {
-        if !is_residual_destination(schedule, schedule.partition.of(node.id)) {
+    for node in factorization.analysis.owner_graph.iter_nodes() {
+        if !is_residual_destination(factorization, factorization.partition.of(node.id)) {
             continue;
         }
-        let declared = residual_declared_for_owner(schedule, node);
+        let declared = residual_declared_for_owner(factorization, node);
         if declared.is_empty() {
             continue;
         }
@@ -87,12 +87,12 @@ pub(crate) fn build_peelability_report(
     for (&owner_id, declared) in &declared_by_owner {
         singleton_candidates.push((
             owner_id,
-            evaluate_peel_candidate(schedule, &context, &[owner_id], declared.clone()),
+            evaluate_peel_candidate(factorization, &context, &[owner_id], declared.clone()),
         ));
     }
 
     let pair_owner_sets = residual_pair_candidates_from_singleton_blockers(
-        schedule,
+        factorization,
         &singleton_candidates,
         owner_edges,
         &declared_by_owner,
@@ -105,21 +105,21 @@ pub(crate) fn build_peelability_report(
         declared.sort();
         declared.dedup();
 
-        let candidate = evaluate_peel_candidate(schedule, &context, &[left, right], declared);
+        let candidate = evaluate_peel_candidate(factorization, &context, &[left, right], declared);
         if candidate.status == PeelCandidateStatus::PeelableNow {
             pair_candidates.push(candidate);
         }
     }
 
     let dependency_closure_candidates = residual_dependency_closure_candidates(
-        schedule,
+        factorization,
         &context,
         &singleton_candidates,
         &declared_by_owner,
     );
 
     let atomic_unit_candidates =
-        residual_atomic_unit_candidates(schedule, &context, &declared_by_owner);
+        residual_atomic_unit_candidates(factorization, &context, &declared_by_owner);
 
     let mut candidates: Vec<PeelCandidateEvaluation> = singleton_candidates
         .into_iter()
@@ -137,14 +137,14 @@ pub(crate) fn build_peelability_report(
     }
 
     let (residual_owner_horizon, minimal_peel_set_ids) =
-        build_residual_owner_horizon(schedule, &declared_by_owner, &candidates);
+        build_residual_owner_horizon(factorization, &declared_by_owner, &candidates);
     let minimal_peel_sets = candidates
         .iter()
         .filter(|candidate| minimal_peel_set_ids.contains(&candidate.id))
         .map(|candidate| OwnerGraphPeelSetReport {
             candidate_id: candidate.id.clone(),
             owner_ids: candidate.owner_ids.iter().copied().map(owner_key).collect(),
-            members: binding_reports(schedule, candidate.members.iter()),
+            members: binding_reports(factorization, candidate.members.iter()),
         })
         .collect();
 
@@ -153,7 +153,7 @@ pub(crate) fn build_peelability_report(
         .map(|candidate| EvaluatedPeelCandidateReport {
             candidate_id: candidate.id.clone(),
             owner_ids: candidate.owner_ids.iter().copied().map(owner_key).collect(),
-            members: binding_reports(schedule, candidate.members.iter()),
+            members: binding_reports(factorization, candidate.members.iter()),
             status: candidate.status,
             cycle_blockers: candidate
                 .constraining_owner_edge_indices
@@ -172,7 +172,7 @@ pub(crate) fn build_peelability_report(
     OwnerGraphPeelabilityReport {
         residual_destinations: residual_destinations
             .into_iter()
-            .map(|id| module_report_ref(schedule, id))
+            .map(|id| module_report_ref(factorization, id))
             .collect(),
         minimal_peel_sets,
         residual_owner_horizon,
@@ -181,7 +181,7 @@ pub(crate) fn build_peelability_report(
 }
 
 fn build_residual_owner_horizon(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
     candidates: &[PeelCandidateEvaluation],
 ) -> (Vec<ResidualOwnerPeelHorizonReport>, BTreeSet<String>) {
@@ -267,7 +267,7 @@ fn build_residual_owner_horizon(
                     .filter(|id| id != &owner_report_id)
                     .collect(),
                 companion_members: binding_reports(
-                    schedule,
+                    factorization,
                     candidate
                         .members
                         .iter()
@@ -276,7 +276,7 @@ fn build_residual_owner_horizon(
             });
         }
 
-        let node = schedule
+        let node = factorization
             .analysis
             .owner_graph
             .node(*owner_id)
@@ -287,8 +287,11 @@ fn build_residual_owner_horizon(
             source_location: node.source_location.clone(),
             statement_kind: node.kind,
             purity: node.purity.clone(),
-            current_destination: module_report_ref(schedule, schedule.partition.of(node.id)),
-            members: binding_reports(schedule, bindings.iter()),
+            current_destination: module_report_ref(
+                factorization,
+                factorization.partition.of(node.id),
+            ),
+            members: binding_reports(factorization, bindings.iter()),
             status,
             peel_set_ids,
             companion_options,
@@ -305,16 +308,16 @@ fn build_candidate_owner_sets(candidates: &[PeelCandidateEvaluation]) -> Vec<BTr
 }
 
 fn residual_declared_for_owner(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     node: &OwnerNode,
 ) -> Vec<BindingName> {
     node.declared
         .iter()
-        .map(|binding| schedule.analysis.binding_name(*binding))
+        .map(|binding| factorization.analysis.binding_name(*binding))
         .filter(|name| {
-            // schedule.analysis.bindings is Id-keyed but BindingTable.name returns
+            // factorization.analysis.bindings is Id-keyed but BindingTable.name returns
             // sym only; match by sym.
-            !schedule.analysis.bindings.iter().any(|(id, kind)| {
+            !factorization.analysis.bindings.iter().any(|(id, kind)| {
                 id.0.as_ref() == name.as_str() && matches!(kind, BindingKind::Imported { .. })
             })
         })
@@ -324,11 +327,11 @@ fn residual_declared_for_owner(
 
 impl<'a> PeelabilityContext<'a> {
     pub(crate) fn new(
-        schedule: &'a ChunkFactorization,
+        factorization: &'a ChunkFactorization,
         owner_edges: &'a [OwnerEdge],
         quotient_edges: &[QuotientEdgeReport],
     ) -> Self {
-        let owner_count = schedule.analysis.owner_graph.nodes.len();
+        let owner_count = factorization.analysis.owner_graph.nodes.len();
         let mut owner_out_edges = vec![Vec::new(); owner_count];
         for (idx, edge) in owner_edges.iter().enumerate() {
             if let Some(indices) = owner_out_edges.get_mut(edge.from.0) {
@@ -336,7 +339,7 @@ impl<'a> PeelabilityContext<'a> {
             }
         }
 
-        let atomic_units = compute_atomic_units(&schedule.analysis.owner_graph);
+        let atomic_units = compute_atomic_units(&factorization.analysis.owner_graph);
 
         // The realizability primitive is the single shared
         // implementation of clause 3 (and clause 2). The candidate
@@ -344,8 +347,8 @@ impl<'a> PeelabilityContext<'a> {
         // index and reads the verdict — the same verdict the
         // validator would produce for the post-peel partition.
         let realizability = RealizabilityIndex::from_partition(
-            &schedule.analysis.owner_graph,
-            schedule.partition.clone(),
+            &factorization.analysis.owner_graph,
+            factorization.partition.clone(),
         );
 
         // Reserve a module-id one past every index currently in use,
@@ -354,8 +357,8 @@ impl<'a> PeelabilityContext<'a> {
         // partition's actual assignments, and any module-id that
         // appears in the quotient-edges report — covering synthesized
         // residual sentinels and external/vendor modules.
-        let mut max_index = schedule.analysis.logical_modules.len();
-        for (_, module) in schedule.partition.iter() {
+        let mut max_index = factorization.analysis.logical_modules.len();
+        for (_, module) in factorization.partition.iter() {
             max_index = max_index.max(module.0.0 + 1);
         }
         for edge in quotient_edges {
@@ -389,7 +392,7 @@ impl<'a> PeelabilityContext<'a> {
 }
 
 fn residual_pair_candidates_from_singleton_blockers(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     singleton_candidates: &[(OwnerId, PeelCandidateEvaluation)],
     owner_edges: &[OwnerEdge],
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
@@ -411,7 +414,7 @@ fn residual_pair_candidates_from_singleton_blockers(
                 continue;
             };
             if declared_by_owner.contains_key(&other)
-                && owners_share_residual_destination(schedule, *owner_id, other)
+                && owners_share_residual_destination(factorization, *owner_id, other)
             {
                 pair_owner_sets.insert(sorted_owner_pair(*owner_id, other));
             }
@@ -442,7 +445,7 @@ fn residual_pair_candidates_from_singleton_blockers(
 /// statements with no class binding) are skipped: there'd be nothing
 /// to land in `members[]`.
 fn residual_atomic_unit_candidates(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
 ) -> Vec<PeelCandidateEvaluation> {
@@ -454,7 +457,7 @@ fn residual_atomic_unit_candidates(
         if !unit
             .members
             .iter()
-            .all(|m| owner_is_in_residual(schedule, *m))
+            .all(|m| owner_is_in_residual(factorization, *m))
         {
             continue;
         }
@@ -472,26 +475,26 @@ fn residual_atomic_unit_candidates(
         }
 
         let owner_ids: Vec<OwnerId> = unit.members.iter().copied().collect();
-        let candidate = evaluate_peel_candidate(schedule, context, &owner_ids, declared);
+        let candidate = evaluate_peel_candidate(factorization, context, &owner_ids, declared);
         candidates.push(candidate);
     }
     candidates
 }
 
-fn owner_is_in_residual(schedule: &ChunkFactorization, owner_id: OwnerId) -> bool {
-    if schedule.analysis.owner_graph.node(owner_id).is_none() {
+fn owner_is_in_residual(factorization: &ChunkFactorization, owner_id: OwnerId) -> bool {
+    if factorization.analysis.owner_graph.node(owner_id).is_none() {
         return false;
     }
-    is_residual_destination(schedule, schedule.partition.of(owner_id))
+    is_residual_destination(factorization, factorization.partition.of(owner_id))
 }
 
 fn residual_dependency_closure_candidates(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     singleton_candidates: &[(OwnerId, PeelCandidateEvaluation)],
     declared_by_owner: &BTreeMap<OwnerId, Vec<BindingName>>,
 ) -> Vec<PeelCandidateEvaluation> {
-    let mut closure_index = ResidualDependencyClosureIndex::new(schedule, context);
+    let mut closure_index = ResidualDependencyClosureIndex::new(factorization, context);
     let mut seen_components = BTreeSet::<usize>::new();
     let mut candidates = Vec::new();
     for (owner_id, candidate) in singleton_candidates {
@@ -530,7 +533,7 @@ fn residual_dependency_closure_candidates(
             continue;
         }
 
-        let candidate = evaluate_peel_candidate(schedule, context, &closure, declared);
+        let candidate = evaluate_peel_candidate(factorization, context, &closure, declared);
         if candidate.status == PeelCandidateStatus::PeelableNow {
             candidates.push(candidate);
         }
@@ -546,11 +549,11 @@ struct ResidualDependencyClosureIndex {
 }
 
 impl ResidualDependencyClosureIndex {
-    fn new(schedule: &ChunkFactorization, context: &PeelabilityContext<'_>) -> Self {
+    fn new(factorization: &ChunkFactorization, context: &PeelabilityContext<'_>) -> Self {
         let mut graph = DiGraph::<OwnerId, ()>::new();
-        let mut node_by_owner = vec![None; schedule.analysis.owner_graph.nodes.len()];
-        for node in schedule.analysis.owner_graph.iter_nodes() {
-            if !is_residual_destination(schedule, schedule.partition.of(node.id)) {
+        let mut node_by_owner = vec![None; factorization.analysis.owner_graph.nodes.len()];
+        for node in factorization.analysis.owner_graph.iter_nodes() {
+            if !is_residual_destination(factorization, factorization.partition.of(node.id)) {
                 continue;
             }
             if let Some(slot) = node_by_owner.get_mut(node.id.0) {
@@ -630,18 +633,18 @@ impl ResidualDependencyClosureIndex {
 }
 
 fn owners_share_residual_destination(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     left: OwnerId,
     right: OwnerId,
 ) -> bool {
-    if schedule.analysis.owner_graph.node(left).is_none()
-        || schedule.analysis.owner_graph.node(right).is_none()
+    if factorization.analysis.owner_graph.node(left).is_none()
+        || factorization.analysis.owner_graph.node(right).is_none()
     {
         return false;
     }
-    let left_module = schedule.partition.of(left);
-    let right_module = schedule.partition.of(right);
-    left_module == right_module && is_residual_destination(schedule, left_module)
+    let left_module = factorization.partition.of(left);
+    let right_module = factorization.partition.of(right);
+    left_module == right_module && is_residual_destination(factorization, left_module)
 }
 
 fn sorted_owner_pair(left: OwnerId, right: OwnerId) -> (OwnerId, OwnerId) {
@@ -660,7 +663,7 @@ fn sorted_owner_pair(left: OwnerId, right: OwnerId) -> (OwnerId, OwnerId) {
 /// The same primitive backs the validator, so a `PeelableNow` here is
 /// a `PeelableNow` at the gate.
 pub(crate) fn evaluate_peel_candidate(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     owner_ids: &[OwnerId],
     declared: Vec<BindingName>,
@@ -678,7 +681,7 @@ pub(crate) fn evaluate_peel_candidate(
     // need to import a same-destination at-init read", driving the
     // residual-dependency-closure candidate family.
     let residual_dependency_blocker_owner_ids =
-        candidate_source_destination_blocker_owner_ids(schedule, context, &moved_owners);
+        candidate_source_destination_blocker_owner_ids(factorization, context, &moved_owners);
     if !residual_dependency_blocker_owner_ids.is_empty() {
         return PeelCandidateEvaluation {
             id: candidate_id,
@@ -819,14 +822,14 @@ fn candidate_atomic_unit_split_edge_indices(
 /// derived from `moved_owners` (all moved owners share one
 /// destination by precondition).
 fn candidate_source_destination_blocker_owner_ids(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     context: &PeelabilityContext<'_>,
     moved_owners: &BTreeSet<OwnerId>,
 ) -> Vec<OwnerId> {
     let Some(&first) = moved_owners.iter().next() else {
         return Vec::new();
     };
-    let source_destination = schedule.partition.of(first);
+    let source_destination = factorization.partition.of(first);
     let mut blockers = BTreeSet::new();
     for owner_id in moved_owners {
         for &edge_idx in context.owner_out_edge_indices(*owner_id) {
@@ -837,10 +840,10 @@ fn candidate_source_destination_blocker_owner_ids(
             if moved_owners.contains(&edge.to) {
                 continue;
             }
-            if schedule.analysis.owner_graph.node(edge.to).is_none() {
+            if factorization.analysis.owner_graph.node(edge.to).is_none() {
                 continue;
             }
-            if schedule.partition.of(edge.to) != source_destination {
+            if factorization.partition.of(edge.to) != source_destination {
                 continue;
             }
             blockers.insert(edge.to);

--- a/devinfra/js/debundle/report_schema.rs
+++ b/devinfra/js/debundle/report_schema.rs
@@ -25,7 +25,7 @@ pub struct OwnerGraphReport {
     pub quotient: OwnerGraphQuotientReport,
     pub peelability: OwnerGraphPeelabilityReport,
     /// Algorithmic peel proposer output. Always populated by
-    /// `Schedule::owner_graph_report`; empty `cells` when there
+    /// `ChunkFactorization::owner_graph_report`; empty `cells` when there
     /// are no residual owners. Each cell carries a verdict from
     /// the SSOT predicate in
     /// `peelability::evaluate_peel_candidate`, so

--- a/devinfra/js/debundle/reports.rs
+++ b/devinfra/js/debundle/reports.rs
@@ -16,13 +16,13 @@ struct QuotientEdgeAccumulator {
     constrains_init_order: bool,
 }
 
-pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGraphReport {
-    let owner_edges = &schedule.analysis.owner_graph.edges;
-    let quotient_edges = build_quotient_edge_reports(schedule, owner_edges);
-    let quotient_nodes = build_quotient_node_reports(schedule);
-    let quotient_sccs = build_quotient_scc_reports(schedule, &quotient_edges);
-    let peelability = build_peelability_report(schedule, owner_edges, &quotient_edges);
-    let nodes = schedule
+pub(crate) fn build_owner_graph_report(factorization: &ChunkFactorization) -> OwnerGraphReport {
+    let owner_edges = &factorization.analysis.owner_graph.edges;
+    let quotient_edges = build_quotient_edge_reports(factorization, owner_edges);
+    let quotient_nodes = build_quotient_node_reports(factorization);
+    let quotient_sccs = build_quotient_scc_reports(factorization, &quotient_edges);
+    let peelability = build_peelability_report(factorization, owner_edges, &quotient_edges);
+    let nodes = factorization
         .analysis
         .owner_graph
         .iter_nodes()
@@ -30,10 +30,13 @@ pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGr
             id: owner_key(node.id),
             statement_ordinal: node.statement_ordinal,
             source_location: node.source_location.clone(),
-            declared_bindings: binding_reports_for_ids(schedule, node.declared.iter().copied()),
+            declared_bindings: binding_reports_for_ids(
+                factorization,
+                node.declared.iter().copied(),
+            ),
             statement_kind: node.kind,
             purity: node.purity.clone(),
-            destination: module_report_ref(schedule, schedule.partition.of(node.id)),
+            destination: module_report_ref(factorization, factorization.partition.of(node.id)),
         })
         .collect();
     let edges = owner_edges
@@ -46,13 +49,13 @@ pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGr
             binding: edge
                 .reason
                 .binding
-                .map(|binding| schedule.analysis.binding_name(binding).to_string()),
+                .map(|binding| factorization.analysis.binding_name(binding).to_string()),
             statement_ordinal: edge.reason.statement_ordinal,
             constrains_init_order: edge.reason.constrains_init_order(),
         })
         .collect();
     OwnerGraphReport {
-        chunk_id: schedule.analysis.chunk_id.clone(),
+        chunk_id: factorization.analysis.chunk_id.clone(),
         nodes,
         edges,
         quotient: OwnerGraphQuotientReport {
@@ -64,7 +67,7 @@ pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGr
         // Filled in by
         // `ChunkFactorization::owner_graph_report_with_factorize_options`
         // after this function returns. The default value is the
-        // empty report (no cells); the schedule unconditionally
+        // empty report (no cells); the factorization unconditionally
         // overwrites it with the real factorize verdict so JSON
         // consumers always see a populated `factorize` block.
         factorize: crate::FactorizeReport::default(),
@@ -72,22 +75,22 @@ pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGr
 }
 
 pub(crate) fn binding_reports_for_ids<I>(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     bindings: I,
 ) -> Vec<BindingReport>
 where
     I: IntoIterator<Item = BindingId>,
 {
     binding_reports(
-        schedule,
+        factorization,
         bindings
             .into_iter()
-            .map(|binding| schedule.analysis.binding_name(binding)),
+            .map(|binding| factorization.analysis.binding_name(binding)),
     )
 }
 
 pub(crate) fn binding_reports<'a, I>(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     bindings: I,
 ) -> Vec<BindingReport>
 where
@@ -97,34 +100,34 @@ where
         .into_iter()
         .map(|binding| BindingReport {
             binding: binding.clone(),
-            export_name: schedule.analysis.export_name_for(binding),
+            export_name: factorization.analysis.export_name_for(binding),
         })
         .collect()
 }
 
-fn build_quotient_node_reports(schedule: &ChunkFactorization) -> Vec<ModuleReportRef> {
+fn build_quotient_node_reports(factorization: &ChunkFactorization) -> Vec<ModuleReportRef> {
     let mut modules = BTreeSet::<ModuleId>::new();
-    for idx in 0..schedule.analysis.logical_modules.len() {
+    for idx in 0..factorization.analysis.logical_modules.len() {
         modules.insert(ModuleId(LogicalModuleIndex(idx)));
     }
-    for (_, module) in schedule.partition.iter() {
+    for (_, module) in factorization.partition.iter() {
         modules.insert(module);
     }
-    for (from, to, _) in schedule.dep_graph.iter_edges() {
+    for (from, to, _) in factorization.dep_graph.iter_edges() {
         modules.insert(from);
         modules.insert(to);
     }
     modules
         .into_iter()
-        .map(|id| module_report_ref(schedule, id))
+        .map(|id| module_report_ref(factorization, id))
         .collect()
 }
 
 pub(crate) fn build_quotient_edge_reports(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     owner_edges: &[OwnerEdge],
 ) -> Vec<QuotientEdgeReport> {
-    let partition = &schedule.partition;
+    let partition = &factorization.partition;
     let mut accum = BTreeMap::<(ModuleId, ModuleId), QuotientEdgeAccumulator>::new();
     let mut seen_side_effect_module_pairs = BTreeSet::<(ModuleId, ModuleId)>::new();
     for edge in owner_edges {
@@ -154,14 +157,14 @@ pub(crate) fn build_quotient_edge_reports(
 }
 
 fn build_quotient_scc_reports(
-    schedule: &ChunkFactorization,
+    factorization: &ChunkFactorization,
     quotient_edges: &[QuotientEdgeReport],
 ) -> Vec<QuotientSccReport> {
     let quotient_edges_by_source = quotient_edge_indices_by_source(quotient_edges);
     let mut sccs = Vec::new();
-    for scc in tarjan_scc(&schedule.dep_graph.graph) {
+    for scc in tarjan_scc(&factorization.dep_graph.graph) {
         let is_cycle = scc.len() > 1
-            || (scc.len() == 1 && schedule.dep_graph.graph.contains_edge(scc[0], scc[0]));
+            || (scc.len() == 1 && factorization.dep_graph.graph.contains_edge(scc[0], scc[0]));
         if !is_cycle {
             continue;
         }
@@ -189,7 +192,7 @@ fn build_quotient_scc_reports(
             .iter()
             .map(|key| {
                 module_id_from_key(key)
-                    .map(|id| schedule.analysis.module_name(id))
+                    .map(|id| factorization.analysis.module_name(id))
                     .unwrap_or_else(|| key.clone())
             })
             .collect();
@@ -230,9 +233,9 @@ fn quotient_edge_indices_by_source(
 /// `ChunkFactorization::build`. Used by peelability and the destination
 /// projection in reports to gate residual-only predicates without
 /// string-matching module ids or labels.
-pub(crate) fn is_residual_destination(schedule: &ChunkFactorization, id: ModuleId) -> bool {
+pub(crate) fn is_residual_destination(factorization: &ChunkFactorization, id: ModuleId) -> bool {
     let LogicalModuleIndex(idx) = id.0;
-    schedule
+    factorization
         .analysis
         .logical_modules
         .get(idx)
@@ -254,13 +257,16 @@ pub(crate) fn module_id_from_key(key: &str) -> Option<ModuleId> {
         .map(|idx| ModuleId(LogicalModuleIndex(idx)))
 }
 
-pub(crate) fn module_report_ref(schedule: &ChunkFactorization, id: ModuleId) -> ModuleReportRef {
+pub(crate) fn module_report_ref(
+    factorization: &ChunkFactorization,
+    id: ModuleId,
+) -> ModuleReportRef {
     let LogicalModuleIndex(idx) = id.0;
-    let logical = schedule.analysis.logical_modules.get(idx);
+    let logical = factorization.analysis.logical_modules.get(idx);
     ModuleReportRef {
         id: module_key(id),
-        label: schedule.analysis.module_name(id),
-        residual: is_residual_destination(schedule, id),
+        label: factorization.analysis.module_name(id),
+        residual: is_residual_destination(factorization, id),
         index: logical.map(|_| idx),
         target_file: logical.map(|module| module.target_file.clone()),
     }

--- a/devinfra/js/debundle/reports.rs
+++ b/devinfra/js/debundle/reports.rs
@@ -5,9 +5,9 @@ use petgraph::algo::tarjan_scc;
 use crate::graph::OwnerEdge;
 use crate::peelability::build_peelability_report;
 use crate::{
-    BindingId, BindingName, BindingReport, DepKind, LogicalModuleIndex, ModuleId, ModuleReportRef,
-    OwnerGraphEdgeReport, OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport,
-    OwnerId, QuotientEdgeReport, QuotientSccReport, Schedule,
+    BindingId, BindingName, BindingReport, ChunkFactorization, DepKind, LogicalModuleIndex,
+    ModuleId, ModuleReportRef, OwnerGraphEdgeReport, OwnerGraphNodeReport,
+    OwnerGraphQuotientReport, OwnerGraphReport, OwnerId, QuotientEdgeReport, QuotientSccReport,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -16,13 +16,14 @@ struct QuotientEdgeAccumulator {
     constrains_init_order: bool,
 }
 
-pub(crate) fn build_owner_graph_report(schedule: &Schedule) -> OwnerGraphReport {
-    let owner_edges = &schedule.owner_graph.edges;
+pub(crate) fn build_owner_graph_report(schedule: &ChunkFactorization) -> OwnerGraphReport {
+    let owner_edges = &schedule.analysis.owner_graph.edges;
     let quotient_edges = build_quotient_edge_reports(schedule, owner_edges);
     let quotient_nodes = build_quotient_node_reports(schedule);
     let quotient_sccs = build_quotient_scc_reports(schedule, &quotient_edges);
     let peelability = build_peelability_report(schedule, owner_edges, &quotient_edges);
     let nodes = schedule
+        .analysis
         .owner_graph
         .iter_nodes()
         .map(|node| OwnerGraphNodeReport {
@@ -45,13 +46,13 @@ pub(crate) fn build_owner_graph_report(schedule: &Schedule) -> OwnerGraphReport 
             binding: edge
                 .reason
                 .binding
-                .map(|binding| schedule.binding_name(binding).to_string()),
+                .map(|binding| schedule.analysis.binding_name(binding).to_string()),
             statement_ordinal: edge.reason.statement_ordinal,
             constrains_init_order: edge.reason.constrains_init_order(),
         })
         .collect();
     OwnerGraphReport {
-        chunk_id: schedule.chunk_id.clone(),
+        chunk_id: schedule.analysis.chunk_id.clone(),
         nodes,
         edges,
         quotient: OwnerGraphQuotientReport {
@@ -61,7 +62,7 @@ pub(crate) fn build_owner_graph_report(schedule: &Schedule) -> OwnerGraphReport 
         },
         peelability,
         // Filled in by
-        // `Schedule::owner_graph_report_with_factorize_options`
+        // `ChunkFactorization::owner_graph_report_with_factorize_options`
         // after this function returns. The default value is the
         // empty report (no cells); the schedule unconditionally
         // overwrites it with the real factorize verdict so JSON
@@ -70,7 +71,10 @@ pub(crate) fn build_owner_graph_report(schedule: &Schedule) -> OwnerGraphReport 
     }
 }
 
-pub(crate) fn binding_reports_for_ids<I>(schedule: &Schedule, bindings: I) -> Vec<BindingReport>
+pub(crate) fn binding_reports_for_ids<I>(
+    schedule: &ChunkFactorization,
+    bindings: I,
+) -> Vec<BindingReport>
 where
     I: IntoIterator<Item = BindingId>,
 {
@@ -78,11 +82,14 @@ where
         schedule,
         bindings
             .into_iter()
-            .map(|binding| schedule.binding_name(binding)),
+            .map(|binding| schedule.analysis.binding_name(binding)),
     )
 }
 
-pub(crate) fn binding_reports<'a, I>(schedule: &Schedule, bindings: I) -> Vec<BindingReport>
+pub(crate) fn binding_reports<'a, I>(
+    schedule: &ChunkFactorization,
+    bindings: I,
+) -> Vec<BindingReport>
 where
     I: IntoIterator<Item = &'a BindingName>,
 {
@@ -90,14 +97,14 @@ where
         .into_iter()
         .map(|binding| BindingReport {
             binding: binding.clone(),
-            export_name: schedule.export_name_for(binding),
+            export_name: schedule.analysis.export_name_for(binding),
         })
         .collect()
 }
 
-fn build_quotient_node_reports(schedule: &Schedule) -> Vec<ModuleReportRef> {
+fn build_quotient_node_reports(schedule: &ChunkFactorization) -> Vec<ModuleReportRef> {
     let mut modules = BTreeSet::<ModuleId>::new();
-    for idx in 0..schedule.logical_modules.len() {
+    for idx in 0..schedule.analysis.logical_modules.len() {
         modules.insert(ModuleId(LogicalModuleIndex(idx)));
     }
     for (_, module) in schedule.partition.iter() {
@@ -114,7 +121,7 @@ fn build_quotient_node_reports(schedule: &Schedule) -> Vec<ModuleReportRef> {
 }
 
 pub(crate) fn build_quotient_edge_reports(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     owner_edges: &[OwnerEdge],
 ) -> Vec<QuotientEdgeReport> {
     let partition = &schedule.partition;
@@ -147,7 +154,7 @@ pub(crate) fn build_quotient_edge_reports(
 }
 
 fn build_quotient_scc_reports(
-    schedule: &Schedule,
+    schedule: &ChunkFactorization,
     quotient_edges: &[QuotientEdgeReport],
 ) -> Vec<QuotientSccReport> {
     let quotient_edges_by_source = quotient_edge_indices_by_source(quotient_edges);
@@ -182,7 +189,7 @@ fn build_quotient_scc_reports(
             .iter()
             .map(|key| {
                 module_id_from_key(key)
-                    .map(|id| schedule.module_name(id))
+                    .map(|id| schedule.analysis.module_name(id))
                     .unwrap_or_else(|| key.clone())
             })
             .collect();
@@ -220,12 +227,13 @@ fn quotient_edge_indices_by_source(
 
 /// True iff `id` refers to a logical module whose `residual` flag is
 /// set — the chunk's catch-all destination synthesized before
-/// `Schedule::build`. Used by peelability and the destination
+/// `ChunkFactorization::build`. Used by peelability and the destination
 /// projection in reports to gate residual-only predicates without
 /// string-matching module ids or labels.
-pub(crate) fn is_residual_destination(schedule: &Schedule, id: ModuleId) -> bool {
+pub(crate) fn is_residual_destination(schedule: &ChunkFactorization, id: ModuleId) -> bool {
     let LogicalModuleIndex(idx) = id.0;
     schedule
+        .analysis
         .logical_modules
         .get(idx)
         .is_some_and(|module| module.residual)
@@ -246,12 +254,12 @@ pub(crate) fn module_id_from_key(key: &str) -> Option<ModuleId> {
         .map(|idx| ModuleId(LogicalModuleIndex(idx)))
 }
 
-pub(crate) fn module_report_ref(schedule: &Schedule, id: ModuleId) -> ModuleReportRef {
+pub(crate) fn module_report_ref(schedule: &ChunkFactorization, id: ModuleId) -> ModuleReportRef {
     let LogicalModuleIndex(idx) = id.0;
-    let logical = schedule.logical_modules.get(idx);
+    let logical = schedule.analysis.logical_modules.get(idx);
     ModuleReportRef {
         id: module_key(id),
-        label: schedule.module_name(id),
+        label: schedule.analysis.module_name(id),
         residual: is_residual_destination(schedule, id),
         index: logical.map(|_| idx),
         target_file: logical.map(|module| module.target_file.clone()),

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -16,11 +16,11 @@ use crate::{
 
 /// Result of validating a module dep graph.
 #[derive(Debug, Clone, Serialize)]
-pub struct ScheduleReport {
+pub struct FactorizationReport {
     pub cycles: Vec<CycleReport>,
     /// Atomic factor units the spec splits across destination
     /// modules — unrealizable by construction. Populated from
-    /// `Schedule::assembly_conflicts`; the materializer rejects any
+    /// `ChunkFactorization::assembly_conflicts`; the materializer rejects any
     /// spec with a non-empty list before emitting code.
     pub atomic_unit_conflicts: Vec<AtomicUnitConflict>,
     /// Topological linearization of `I ∪ S` rooted at the entry,
@@ -158,14 +158,14 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
 /// catching the canonical `console.log(readB())` shape, but the
 /// asymmetry persists until either Lemma 2 lands in the materializer
 /// or the proposer is also tightened.
-pub fn validate_schedule(
+pub fn validate_factorization(
     owner_graph: &OwnerGraph,
     partition: &Partition,
     module_name: &dyn Fn(ModuleId) -> String,
-) -> ScheduleReport {
+) -> FactorizationReport {
     let verdict = check_realizability(owner_graph, partition);
     if verdict.unrealizable_sccs.is_empty() {
-        return ScheduleReport {
+        return FactorizationReport {
             cycles: Vec::new(),
             atomic_unit_conflicts: Vec::new(),
             linker_order: Vec::new(),
@@ -220,7 +220,7 @@ pub fn validate_schedule(
             cut,
         });
     }
-    ScheduleReport {
+    FactorizationReport {
         cycles,
         atomic_unit_conflicts: Vec::new(),
         linker_order: Vec::new(),


### PR DESCRIPTION
## Summary

Split the per-chunk `Schedule` type into two along its input/output divide, and rename:

- **`ChunkAnalysis`** (new file `chunk_analysis.rs`) — owns the chunk inputs (`facts`, `bindings`, `logical_modules`, `chunk_renames`), the IR (`owner_graph`), and the input-derived caches (`owner_report_ids_by_binding`, `export_name_by_binding`). Methods that read only inputs (`owner_of`, `module_name`, `logical_module`, `binding_name`, `export_name_for`, `owner_report_ids_for_bindings`) live here.
- **`ChunkFactorization`** (renamed from `Schedule`, new file `chunk_factorization.rs`) — holds `Arc<ChunkAnalysis>` plus the factorize-produced partition (`partition`, `assembly_conflicts`, `dep_graph`, `linker_order`) and partition-derived caches (linker / source-import positions). Methods that depend on the partition (`linker_position`, `source_import_position`, `validate`, `owner_graph_report`) live here.
- **`ScheduleReport` → `FactorizationReport`**, **`validate_schedule` → `validate_factorization`**, **`ScheduleLogicalModule` alias → `FactorizationLogicalModule`**, **test helpers `schedule_for`/`schedule_with_residual_module` → `factorization_for`/`factorization_with_residual_module`**, variable bindings `schedule` → `factorization`.

The serde shape is unchanged — `ScheduleReport`'s struct name doesn't appear in JSON, and the on-disk `schedule.json` filename + `build_schedule` phase label string literals are preserved.

## Why split

`Schedule` bundled four kinds of state with different lifecycles:
- **Inputs** (`facts`, `bindings`, `logical_modules`, `chunk_renames`) — fixed after parse + spec load.
- **IR** (`owner_graph`) — derived from facts; one-shot.
- **Factorization output** (`partition`, `assembly_conflicts`, `dep_graph`, `linker_order`) — depends on which assignment the spec chose; would change if peelability explored alternatives.
- **Caches** — some derived from inputs, some from the factorization output.

The split makes the input/output boundary type-level. Future peelability rewrites can hold a `ChunkAnalysis` fixed and explore many `ChunkFactorization` candidates. Tests can build the inputs without committing to a partition. Code that only reads inputs takes `&ChunkAnalysis` and can't accidentally read the partition.

## Per-commit breakdown

1. **`0b20cf0`** — Split: new `ChunkAnalysis` + `ChunkFactorization` types, methods moved appropriately. ~47 sites switch from `schedule.X` to `schedule.analysis.X` for analysis-side fields/methods.
2. **`60eec06`** — Rename variable `schedule` → `factorization` everywhere in code. String literals (filenames, phase labels) preserved.
3. **`7d00d4f`** — Last identifier renames: test helpers + `ScheduleLogicalModule` alias.
4. **`67010b9`** — Drop the now-stale TODO entry.

## Test plan

- [x] `bazel build //devinfra/js/debundle/...` — green.
- [x] `bazel test //devinfra/js/debundle/...` — 50/50 GREEN.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_