### PR TITLE
debundle: clear lingering Schedule references in DESIGN.md + materializer

### DIFF
--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -17,7 +17,7 @@
 > order, with explicit `import` / `export` declarations. There is no
 > init-wrapper machinery, no closure pass, no implicit binding
 > pulls — every owned binding is named explicitly in the spec,
-> and `Imported` bindings flow through `Schedule.bindings` /
+> and `Imported` bindings flow through `ChunkAnalysis.bindings` /
 > `BindingKind::Imported`, carrying the single re-exporter
 > `ModuleId` and public name that claimed it.
 > Anonymous (empty-`declared`) top-level statements have no name
@@ -490,7 +490,7 @@ module's `import` directives must be emitted in a specific source
 order so that depth-first link traversal lands on a Phase-2
 evaluation order matching the constraining-edge linearization.
 
-The materializer computes `Schedule::source_import_position` to drive
+The materializer computes `ChunkFactorization::source_import_position` to drive
 this. The algorithm:
 
 1. Compute SCCs of the full quotient `I ∪ S` via Tarjan.
@@ -978,8 +978,8 @@ not in the spec.
 
 The validator currently runs per-chunk; cross-chunk edges appear
 as `ExternalChunk(_)` leaves in the per-chunk graph. **Future
-work**: a multi-chunk lift would have `validate_schedule` take a
-`BTreeMap<ChunkId, Schedule>` and walk the union graph.
+work**: a multi-chunk lift would have `validate_factorization` take a
+`BTreeMap<ChunkId, ChunkFactorization>` and walk the union graph.
 
 ### Corollary: the role of the validator
 
@@ -1068,7 +1068,7 @@ SCC or an unimportable residual dependency. The tool may rank,
 summarize, or annotate those projections, but it does not silently
 assign bindings on behalf of the spec author.
 
-`ScheduleReport` remains the compact validation report. The detailed
+`FactorizationReport` remains the compact validation report. The detailed
 next-action data lives in `<reports>/<chunk_id>/owner_graph.json`,
 which is emitted on both success and rejection. Re-running the
 pipeline on an updated spec produces fresh graph and peelability
@@ -2135,19 +2135,19 @@ prettifier reformats whitespace but preserves AST structure, and
 upstream changes that touch the statement's content surface as a
 zero-match diagnostic the spec author can fix.
 
-### Schedule integration
+### ChunkFactorization integration
 
-`Schedule` validates realizability (the cycle gate over `I ∪ S`)
+`ChunkFactorization` validates realizability (the cycle gate over `I ∪ S`)
 by quotienting the owner graph by each owner's destination.
 Anonymous owners default to `ModuleId::ResidualEntry`; the
-schedule overrides that destination for any anon owner the spec
+factorization overrides that destination for any anon owner the spec
 claimed. Without this override, an anon owner with a constraining
 in-edge from a peeled named owner would create a fake cross-module
 edge — the validator would reject the spec even though the
 materializer would emit the closure correctly. After the override,
 the validator sees the same module dep graph the materializer
 will emit, and the cycle gate fires only on real unrealizable
-splits. See `Schedule::build` in `schedule.rs`.
+splits. See `ChunkFactorization::build` in `chunk_factorization.rs`.
 
 ## Comma-list var-decls with split owners
 
@@ -2461,24 +2461,27 @@ Computed keys aren't special: they read identifiers at-init like
 any other expression, and the dep graph captures that read
 without any special-case logic.
 
-## Schedule: owner graph plus quotient
+## ChunkAnalysis + ChunkFactorization: owner graph plus quotient
 
-The target runtime data structure the validator and emitter both
-consume is a single per-chunk `Schedule`: it carries the chunk's
-statement facts, the binding catalogue, the explicit logical
-modules, the owner graph, and the module dep graph derived by
-quotienting that owner graph under the spec assignment.
+The target runtime data structures the validator and emitter both
+consume are a pair: a per-chunk `ChunkAnalysis` (inputs + IR) and a
+`ChunkFactorization` wrapping it (partition + derived realizability
+views). Together they carry the chunk's statement facts, the binding
+catalogue, the explicit logical modules, the owner graph, and the
+module dep graph derived by quotienting that owner graph under the
+spec assignment.
 
-The implementation builds this structure directly: statement facts
-feed the owner graph, and the module dep graph is a quotient of that
-owner graph under the current spec assignment.
+The implementation builds these directly: statement facts feed the
+owner graph (stored on `ChunkAnalysis`), and the module dep graph is
+a quotient of that owner graph under the current spec assignment
+(stored on `ChunkFactorization`).
 
-The schedule is keyed per-chunk; the chunk is contextual within
-the schedule, so binding keys collapse to just `name`. Keys for
-the dep graph extend `ModuleId` with an `ExternalChunk(ChunkId)`
-variant so cross-chunk reads are first-class.
+Both are keyed per-chunk; the chunk is contextual within the
+analysis, so binding keys collapse to just `name`. Keys for the dep
+graph extend `ModuleId` with an `ExternalChunk(ChunkId)` variant so
+cross-chunk reads are first-class.
 
-Conceptually, the schedule carries:
+Conceptually, the analysis + factorization carry:
 
 - chunk identity;
 - per-statement facts in source order;
@@ -2575,7 +2578,7 @@ pub struct LogicalModulePath(String);
 /// distinct from `LogicalModulePath` (different abstraction
 /// — paths can change in a spec edit; ids stay stable through
 /// a single materialize run). Implemented as a `usize` index
-/// into `Schedule.logical_modules`; wrapped to keep it from
+/// into `ChunkAnalysis.logical_modules`; wrapped to keep it from
 /// being mistaken for `StatementOrdinal` etc.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LogicalModuleIndex(usize);
@@ -2585,7 +2588,7 @@ pub struct LogicalModuleIndex(usize);
 pub struct StatementOrdinal(usize);
 
 /// Local name of a binding in a chunk's top-level scope. Used
-/// as a key in `Schedule.bindings`. The string itself is the
+/// as a key in `ChunkAnalysis.bindings`. The string itself is the
 /// JavaScript identifier (scrambled in source, possibly
 /// renamed in emit).
 pub type BindingName = String;
@@ -2870,7 +2873,8 @@ Primary:
 - <facts.rs> — `StatementFacts` analyzer.
 - <graph.rs> — owner graph and `ModuleDepGraph` builders.
 - <validation.rs> — realizability checks.
-- <schedule.rs> — schedule construction and linker-order reasoning.
+- <chunk_analysis.rs> — `ChunkAnalysis` (inputs + IR + input-derived caches).
+- <chunk_factorization.rs> — `ChunkFactorization` construction and linker-order reasoning.
 - <peelability.rs> — residual peelability horizon.
 - <atomic_units.rs> — owner-level hard colocation units.
 - <factor_assembly.rs> — spec claims projected onto atomic units.

--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -4123,7 +4123,7 @@ const consumer_three = dep_a + dep_b;"#,
     }
 
     #[test]
-    fn schedule_report_serializes_linker_order_as_snake_case() {
+    fn factorization_report_serializes_linker_order_as_snake_case() {
         let factorization = factorization_for(
             "const A = 1; const B = A + 1;",
             &[("A", logical(0)), ("B", logical(1))],

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -484,7 +484,7 @@ pub(super) fn materialize_logical_chunk(
         }
         let chunk_top_level_mark = runtime_ast.top_level_mark;
         let mut logical_modules: Vec<FactorizationLogicalModule> =
-            time_phase!(timings, "project_schedule_modules", {
+            time_phase!(timings, "project_factorization_modules", {
                 module_plans
                     .iter()
                     .map(|plan| FactorizationLogicalModule {
@@ -547,7 +547,7 @@ pub(super) fn materialize_logical_chunk(
         });
         let default_destination = ModuleId(LogicalModuleIndex(sentinel_idx));
         let redundant_purity_hints = analysis.redundant_purity_hints;
-        let schedule_chunk_renames: HashMap<Id, swc_atoms::Atom> = chunk_renames_map
+        let factorization_chunk_renames: HashMap<Id, swc_atoms::Atom> = chunk_renames_map
             .iter()
             .map(|(local, exported)| {
                 (
@@ -556,25 +556,30 @@ pub(super) fn materialize_logical_chunk(
                 )
             })
             .collect();
-        let factorization = time_phase!(timings, "build_schedule", {
+        let factorization = time_phase!(timings, "build_factorization", {
             ChunkFactorization::build_with(
                 chunk_id.to_string(),
                 analysis.facts,
                 precomputed,
                 bindings_catalogue,
                 logical_modules,
-                schedule_chunk_renames,
+                factorization_chunk_renames,
                 default_destination,
             )
         });
         (factorization, redundant_purity_hints)
     };
-    let schedule_report = time_phase!(timings, "validate_factorization", {
+    let factorization_report = time_phase!(timings, "validate_factorization", {
         factorization.validate()
     });
     if let Some(report_out_dir) = report_out_dir {
-        time_phase!(timings, "write_schedule_report", {
-            write_chunk_report_json(report_out_dir, chunk_id, "schedule.json", &schedule_report)
+        time_phase!(timings, "write_factorization_report", {
+            write_chunk_report_json(
+                report_out_dir,
+                chunk_id,
+                "schedule.json",
+                &factorization_report,
+            )
         })?;
         let owner_graph_report = time_phase!(timings, "build_owner_graph_report", {
             factorization.owner_graph_report()
@@ -589,33 +594,33 @@ pub(super) fn materialize_logical_chunk(
         })?;
     }
 
-    if !schedule_report.atomic_unit_conflicts.is_empty() {
-        let summary =
-            render_atomic_unit_conflict_summary(&schedule_report.atomic_unit_conflicts, &|id| {
-                factorization.analysis.module_name(id)
-            });
-        let causes = render_atomic_unit_cause_guidance(&schedule_report.atomic_unit_conflicts);
+    if !factorization_report.atomic_unit_conflicts.is_empty() {
+        let summary = render_atomic_unit_conflict_summary(
+            &factorization_report.atomic_unit_conflicts,
+            &|id| factorization.analysis.module_name(id),
+        );
+        let causes = render_atomic_unit_cause_guidance(&factorization_report.atomic_unit_conflicts);
         bail!(
             "materialize_logical_modules: chunk {chunk_id} has {n} atomic-factor-unit conflict(s) — the spec assigns members of one atomic factor unit to different destination modules, forming a cycle in the module dep graph that the constraining-edge SCC analysis says is unrealizable. Atomic factor units come from FACTORIZE.md's `G_atomic` SCC over the owner graph; every member must co-locate. {causes}Resolve by reconciling each unit's claims into a single destination. Full evidence written to <reports>/{chunk_id}/schedule.json; owner graph written to <reports>/{chunk_id}/owner_graph.json. Summary:\n{summary}",
-            n = schedule_report.atomic_unit_conflicts.len(),
+            n = factorization_report.atomic_unit_conflicts.len(),
         );
     }
 
-    if !schedule_report.cycles.is_empty() {
+    if !factorization_report.cycles.is_empty() {
         if let Some(report_out_dir) = report_out_dir {
             time_phase!(timings, "write_cycles_report", {
                 write_chunk_report_json(
                     report_out_dir,
                     chunk_id,
                     "cycles.json",
-                    &schedule_report.cycles,
+                    &factorization_report.cycles,
                 )
             })?;
         }
-        let summary = render_cycle_summary(&schedule_report.cycles);
+        let summary = render_cycle_summary(&factorization_report.cycles);
         bail!(
             "materialize_logical_modules: chunk {chunk_id} has {} cycle(s) in the imports + side-effect module dep graph; spec is unrealizable. Resolve by colocating cyclically-coupled bindings or moving the constraining owner endpoints. Full cycle evidence written to <reports>/{chunk_id}/cycles.json; owner graph written to <reports>/{chunk_id}/owner_graph.json. Summary:\n{summary}",
-            schedule_report.cycles.len(),
+            factorization_report.cycles.len(),
         );
     }
 


### PR DESCRIPTION
## Summary

Clears the remaining `Schedule` / `schedule_*` references that PR #1655's type rename + split missed:

- **`DESIGN.md`** — 9 prose / docstring sites pointing at `Schedule::build`, `Schedule.bindings`, `Schedule.logical_modules`, `Schedule::source_import_position`, `ScheduleReport`, the `## Schedule: owner graph plus quotient` and `### Schedule integration` headers, plus the source-layout appendix entry `<schedule.rs>`. Renamed to `ChunkAnalysis` / `ChunkFactorization` per the split (bindings + logical_modules live on the analysis side; `build` / `source_import_position` / report on the factorization side). The appendix entry replaced with `<chunk_analysis.rs>` + `<chunk_factorization.rs>`.
- **`materialize.rs`** — variable `schedule_report` → `factorization_report`, `schedule_chunk_renames` → `factorization_chunk_renames`. Three `time_phase!` labels renamed (`"build_schedule"` → `"build_factorization"`, `"write_schedule_report"` → `"write_factorization_report"`, `"project_schedule_modules"` → `"project_factorization_modules"`); these surface in profile reports.
- **`analysis_tests.rs`** — `schedule_report_serializes_linker_order_as_snake_case` → `factorization_report_serializes_linker_order_as_snake_case`.

## What stays as-is

The on-disk `<chunk_id>/schedule.json` filename and every reference to it (the `facts.rs` doc-comment, the `realizability_test.rs` fixture path, the materializer error message that points spec authors at the file) stay unchanged. That file is a public artifact: gaffer-private's `tana-peel` skills + the `AGENT_MODULE_PEEL_GUIDE.md` runbook find peel diagnostics by globbing for `schedule.json`. Renaming would need cross-repo coordination and is a separate change.

## Test plan

- [x] `bazel test //devinfra/js/debundle/...` — 51/51 GREEN.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_