### PR TITLE
debundle: clear stale logical_modules.rs refs + drop dead vendor.rs fields

### DIFF
--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -1390,7 +1390,7 @@ must predict.
 Concretely: when a moved module body references a top-level
 declaration that lives in the residual entry but isn't yet on
 entry's `export {...}` list, the emit step grows the export list to
-include it (see `auto_grown_residual_exports` in `logical_modules.rs`).
+include it (see `auto_grown_residual_exports` in `lowering/exports.rs`).
 The moved module then imports the binding from entry via a normal ESM
 `import { name } from "../entry.js"`. Source-level exports are not
 clobbered: the auto-grow only adds names that the upstream source
@@ -2263,25 +2263,25 @@ peel-set hyperedges so authoring tools can mostly project and filter
 debundler facts instead of re-analyzing JavaScript or private repo
 YAML conventions.
 
-| Step                             | Module                                | Runs when                                                                                                                                             |
-| -------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `load_transform_spec`            | <pipeline.rs>                         | Always; loads either the flat YAML spec or the tree-shaped authoring spec.                                                                            |
-| `validate_transform_spec`        | <spec.rs>                             | Always after spec load.                                                                                                                               |
-| `load_js_chunks`                 | <artifact.rs>                         | Always; configured by `inputs`.                                                                                                                       |
-| `prepare_js_chunks`              | <prepare_chunks.rs>                   | Always. In one parallel per-chunk pass, parses every chunk with SWC, computes shallow program facts, and canonicalizes entries.                       |
-| `build_artifact_indexes`         | <artifact.rs>                         | Always after preparation. Builds chunk id, source path, output path, and import-reference indexes for later stages.                                   |
-| `rewrite_chunk_entry_specifiers` | <rewrite_specifiers.rs>               | Always, after chunk preparation and before data-gated transforms.                                                                                     |
-| `apply_vendor_annotations`       | <vendor.rs>                           | When the `vendor` map is non-empty.                                                                                                                   |
-| `rename_vendor_exports`          | <vendor.rs>                           | When a `vendor` entry has `level: boundary_rename` or `level: swap`.                                                                                  |
-| `swap_vendor_chunks`             | <vendor.rs>                           | When a `vendor` entry has `level: swap`.                                                                                                              |
-| `materialize_logical_modules`    | <logical_modules.rs> + analysis files | When `logical_modules`, `unassigned_mode`, or `chunk_renames` is non-empty. Computes facts, quotients the owner graph into `I ∪ S`, validates, emits. |
-| `write_js_tree`                  | <write_tree.rs>                       | When `write_js_tree` output config is present; writes JS tree manifests with exact `output_metrics`.                                                  |
-| `emit_browser_harness`           | <emit_harness.rs>                     | When `emit_browser_harness` output config is present; writes browser harness manifests with exact `output_metrics`.                                   |
+| Step                             | Module                       | Runs when                                                                                                                                             |
+| -------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load_transform_spec`            | <pipeline.rs>                | Always; loads either the flat YAML spec or the tree-shaped authoring spec.                                                                            |
+| `validate_transform_spec`        | <spec.rs>                    | Always after spec load.                                                                                                                               |
+| `load_js_chunks`                 | <artifact.rs>                | Always; configured by `inputs`.                                                                                                                       |
+| `prepare_js_chunks`              | <prepare_chunks.rs>          | Always. In one parallel per-chunk pass, parses every chunk with SWC, computes shallow program facts, and canonicalizes entries.                       |
+| `build_artifact_indexes`         | <artifact.rs>                | Always after preparation. Builds chunk id, source path, output path, and import-reference indexes for later stages.                                   |
+| `rewrite_chunk_entry_specifiers` | <rewrite_specifiers.rs>      | Always, after chunk preparation and before data-gated transforms.                                                                                     |
+| `apply_vendor_annotations`       | <vendor.rs>                  | When the `vendor` map is non-empty.                                                                                                                   |
+| `rename_vendor_exports`          | <vendor.rs>                  | When a `vendor` entry has `level: boundary_rename` or `level: swap`.                                                                                  |
+| `swap_vendor_chunks`             | <vendor.rs>                  | When a `vendor` entry has `level: swap`.                                                                                                              |
+| `materialize_logical_modules`    | <lowering/> + analysis files | When `logical_modules`, `unassigned_mode`, or `chunk_renames` is non-empty. Computes facts, quotients the owner graph into `I ∪ S`, validates, emits. |
+| `write_js_tree`                  | <write_tree.rs>              | When `write_js_tree` output config is present; writes JS tree manifests with exact `output_metrics`.                                                  |
+| `emit_browser_harness`           | <emit_harness.rs>            | When `emit_browser_harness` output config is present; writes browser harness manifests with exact `output_metrics`.                                   |
 
 Within `materialize_logical_modules`, the substages are:
 
 1. **Spec parsing** → `LogicalRequest` / `ModulePlan` per chunk.
-2. **Chunk AST analysis** (<logical_modules.rs>:
+2. **Chunk AST analysis** (<lowering/chunk_ast.rs>:
    `analyze_chunk_ast`) → top-level declarations, declaration index,
    and runtime import facts in one top-level scan.
 3. **Statement-facts analysis** (<facts.rs>:
@@ -2843,7 +2843,7 @@ exploration before crossing the relevant phase.
    the per-module emission too (`lower_chunk` /
    `apply_module_lowering` paths), not just the entry-body
    rewrite. Out of scope for the purity-propagation change
-   (`logical_modules.rs:528+` declared_pure collection now
+   (`lowering/` declared_pure collection now
    pulls from chunk_renames members) — those are separate
    passes of the same map. Track when a real spec wants
    the renamed name everywhere.
@@ -2880,7 +2880,12 @@ Primary:
 - <factor_assembly.rs> — spec claims projected onto atomic units.
 - <factorize.rs> and <peel_factorize.rs> — advisory factorization
   proposal construction and reporting.
-- <logical_modules.rs> — main splitting transform.
+- <lowering/> — main splitting transform (`mod.rs` plus per-concern
+  sibling files: `chunk_ast.rs`, `lower.rs`, `materialize.rs`,
+  `plans.rs`, `naturalize.rs`, `imports_cross.rs`,
+  `imports_runtime.rs`, `exports.rs`, `plan_references.rs`,
+  `runtime_imports.rs`, `body_facts.rs`, `chunk_renames.rs`,
+  `rewrite_runtime.rs`, `visitors.rs`, `anonymous.rs`, `util.rs`).
 - <pipeline.rs> — fixed transform composition.
 - <program_analysis.rs> — chunk metadata + side-effect
   classification (used as input to the analyzer).

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -216,7 +216,7 @@ to exist when _it_ runs. PR #1627 (`object_literal_import_collapse_test`,
 fixed by e0b9c7f) and PR #1631
 (`object_literal_return_shorthand_drops_import_test`, fixed by the
 heuristic-rename reverse-lookup at
-`logical_modules.rs::plan_module_reference_needs`) are both symptoms of
+`lowering/plan_references.rs::plan_module_reference_needs`) are both symptoms of
 the same shape: a rename happened in one layer and a downstream layer
 keyed off the wrong-era name. Each fix has been a localized defensive
 patch on the consumer side, which leaves the same trap waiting for the
@@ -260,14 +260,14 @@ a defensive sanitizer at the usage site.
 
 Prerequisite work before designing the pipeline:
 
-1. Inventory every current rename contributor in `logical_modules.rs`
-   and adjacent files. Examples already known:
-   `collect_return_object_alias_renames` (line ~3044),
-   `collect_naturalization_renames_from_function` (~2982), the
-   `RenameAndShorthandNaturalizer` `VisitMut` (~3172),
-   `naturalize_object_literal_shorthand` (~3226),
-   `disambiguate_import_locals` (~3668), the chunk-level
-   `chunk_renames` map that flows out of factorize, and any
+1. Inventory every current rename contributor in `lowering/` and
+   adjacent files. Examples already known:
+   `collect_return_object_alias_renames` and
+   `collect_naturalization_renames_from_function` in
+   `lowering/naturalize.rs`; `RenameAndShorthandNaturalizer` and
+   `naturalize_object_literal_shorthand` in `lowering/visitors.rs`;
+   `disambiguate_import_locals` in `lowering/util.rs`; the chunk-level
+   `chunk_renames` map that flows out of factorize; and any
    collision-resolution code path that mutates `module_import_renames`
    at the orchestration site. Capture each contributor's _kind_
    (explicit / heuristic / collision / chunk-level), _scope_ (function
@@ -319,3 +319,28 @@ propKeyA` and `collect_naturalization_renames_from_function` says
    - "all structural moves pre-COLLECT" (cleaner architecturally but
      requires reordering the materializer to compute a final body
      order before any rename intents are submitted).
+
+## Rename `schedule.json` artifact to `factorization.json`
+
+PR #1655 / #1657 renamed the `Schedule` type to `ChunkFactorization`
+(+ split off `ChunkAnalysis`) and cleaned up doc / code references,
+but the on-disk per-chunk validation report
+`<reports>/<chunk_id>/schedule.json` still uses the old name. The
+file is read by gaffer-private's `tana-peel` skills + the
+`AGENT_MODULE_PEEL_GUIDE.md` runbook (find-globs for
+`schedule.json`), so renaming requires a coordinated change:
+
+- **ducktape** side: rename the write filename in
+  `lowering/materialize.rs` (the `write_chunk_report_json(...)`
+  call and the materializer's atomic-unit-conflict error message),
+  the `e2e/realizability_test.rs` fixture path, and the
+  `facts.rs` doc-comment that points at the file.
+- **gaffer-private** side: update the `find` invocations in
+  `tana/re/web/spec/AGENT_MODULE_PEEL_GUIDE.md`, the
+  `.claude/skills/tana-peel/SKILL.md` runbook, and
+  `.claude/skills/tana-peel/tooling.md` reference.
+
+Land both sides in lock-step (or in a release-pin-aware order)
+so an in-flight Tana peel doesn't suddenly miss the file. Adds
+to the broader Tana peel coordination tracked in
+`gaffer-private/tana/re/web/`.

--- a/devinfra/js/debundle/e2e/direct_status_overpromise_test.rs
+++ b/devinfra/js/debundle/e2e/direct_status_overpromise_test.rs
@@ -11,9 +11,9 @@
 //!    `peelability.rs`) pushes the candidate's hypothetical
 //!    `MoveOwners` delta onto the shared `RealizabilityIndex`
 //!    (`devinfra/js/debundle/realizability.rs`) and reads the verdict.
-//! 2. The **cycle gate** (`validate_schedule` in `validation.rs`,
+//! 2. The **cycle gate** (`validate_factorization` in `validation.rs`,
 //!    consumed by `materialize_logical_modules` in
-//!    `logical_modules.rs`) is unchanged in this PR but answers the
+//!    `lowering/`) is unchanged in this PR but answers the
 //!    same three-clause validity predicate. With the proposer routed
 //!    through the same primitive, both sides cannot disagree on
 //!    whether a candidate peel produces a constraining cross-module

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -153,7 +153,7 @@ pub enum StatementKind {
 /// would attribute `B`'s read of `X` to `mod_a` (the first
 /// declared name's owner), inventing or hiding cycles. The
 /// emitter splits the same comma-lists separately at lower-time
-/// (`split_var_decl` in `logical_modules.rs`); this pre-split
+/// (`split_var_decl` in `lowering/util.rs`); this pre-split
 /// just teaches the analyzer the same view.
 /// Locate the first top-level `await` expression in `module`'s
 /// body, if any. Returns the source-order ordinal of the offending

--- a/devinfra/js/debundle/validate_emitted_exports.rs
+++ b/devinfra/js/debundle/validate_emitted_exports.rs
@@ -30,7 +30,7 @@
 //! This stage doesn't *fix* the underlying generation bug — the
 //! emit-side paths that produced the duplicate still need patching
 //! (the immediate one is `auto_grown_residual_exports` in
-//! `logical_modules.rs`, which compares local binding names to
+//! `lowering/exports.rs`, which compares local binding names to
 //! `pre_existing_entry_exports` but never checks whether the public
 //! name it's about to grow would collide with an existing alias's
 //! public name). It just makes the failure mode unmissable.

--- a/devinfra/js/debundle/vendor.rs
+++ b/devinfra/js/debundle/vendor.rs
@@ -1726,7 +1726,6 @@ pub fn apply_partial_vendor_swaps(
             jobs.push(PartialSwapFileJob {
                 caller_chunk_index,
                 caller_chunk_id,
-                caller_chunk_name: caller_chunk_name.clone(),
                 file_path,
                 parts,
                 ast,
@@ -1807,7 +1806,6 @@ pub fn apply_partial_vendor_swaps(
 struct PartialSwapFileJob {
     caller_chunk_index: usize,
     caller_chunk_id: ChunkId,
-    caller_chunk_name: String,
     file_path: String,
     parts: JsFileAstParts,
     ast: ParsedJsModule,
@@ -1815,10 +1813,6 @@ struct PartialSwapFileJob {
 
 struct PartialSwapFileResult {
     caller_chunk_index: usize,
-    #[allow(dead_code)]
-    caller_chunk_name: String,
-    #[allow(dead_code)]
-    file_path: String,
     parts: JsFileAstParts,
     ast: ParsedJsModule,
     /// (chunk_name, chunk_export) -> count of rewritten references in
@@ -2012,8 +2006,6 @@ fn rewrite_partial_swap_in_file(
 
     PartialSwapFileResult {
         caller_chunk_index: job.caller_chunk_index,
-        caller_chunk_name: job.caller_chunk_name,
-        file_path: job.file_path,
         parts: job.parts,
         ast: job.ast,
         references_by_symbol,


### PR DESCRIPTION
## Summary

Two cleanups + a follow-up TODO entry the user requested:

### 1. Stale `logical_modules.rs` references (8 sites)

The file was split into `lowering/` in PR #1643; eight doc-comment and design-note references still pointed at the pre-split path. Updated to the post-split locations:

- **`DESIGN.md`** × 4: pipeline-substages table row → `<lowering/>`; chunk-AST-analysis sub-step → `<lowering/chunk_ast.rs>`; `auto_grown_residual_exports` ref → `lowering/exports.rs`; source-layout appendix entry expanded from `<logical_modules.rs>` to the full `lowering/` file list.
- **`TODO.md`** × 2: `plan_module_reference_needs` → `lowering/plan_references.rs::`; the PR2 contributor inventory list now points at `lowering/{naturalize,visitors,util}.rs` instead of stale line-number references.
- **`facts.rs::collect_declared_names`**: pre-split comma-list comment → `lowering/util.rs::split_var_decl`.
- **`validate_emitted_exports.rs`** module-level note: → `lowering/exports.rs::auto_grown_residual_exports`.
- **`e2e/direct_status_overpromise_test.rs`** cycle-gate comment: → `validate_factorization` in `validation.rs`, consumed by `materialize_logical_modules` in `lowering/`.

### 2. Drop dead `vendor.rs` fields

`PartialSwapFileResult.caller_chunk_name` + `PartialSwapFileResult.file_path` (and the mirroring fields on the upstream `PartialSwapFileJob`) were `#[allow(dead_code)]`-tagged because nothing in the partial-swap consumer reads them. The analogous fields on the parallel `VendorRenameFileResult` (read at `vendor.rs:286-289` to format `caller_counts_by_target` keys) confused the trail. Delete the fields and corresponding construction-site initializers; the `caller_chunk_name` local that builds the upstream error-context message stays.

### 3. New TODO entry — `schedule.json` artifact rename

PRs #1655 / #1657 renamed the `Schedule` type → `ChunkFactorization` and cleaned up doc / code references, but the on-disk per-chunk validation report `<reports>/<chunk_id>/schedule.json` still uses the old filename. The file is read by gaffer-private's `tana-peel` skills + the `AGENT_MODULE_PEEL_GUIDE.md` runbook, so the rename needs to land in lock-step across both repos. Added as a new section in `TODO.md` so the coordination is tracked.

## Test plan

- [x] `bazel test //devinfra/js/debundle/...` — 51/51 GREEN.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_