### PR TITLE
debundle/e2e: RED test pinning direct top-level eager_use over-constrains FnDecl reads

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -79,6 +79,7 @@ rust_library(
         "duplicate_export_test",
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
+        "at_init_promotion_fndecl_direct_read_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
@@ -1,0 +1,118 @@
+//! RED test: a direct top-level eager read of a binding declared
+//! by a hoisted function declaration must NOT emit an `EagerUse`
+//! owner edge that `constrains_init_order`.
+//!
+//! Background: `graph.rs::target_is_hoisted` (lines 576-584)
+//! recognizes `StatementKind::FnDecl` as ESM-Phase-1 hoisted and
+//! excludes promoted at-init reads of FnDecl bindings from the
+//! call-graph closure that feeds the promoted-edge emission. But
+//! the *direct* top-level eager-read path (the loop over
+//! `stmt.eager_reads` around `graph.rs:342`) doesn't apply that
+//! filter: any top-level `const x = f()` where `f` is a
+//! hoisted `function f() {}` emits a direct `EagerUse` edge
+//! `caller → f_owner` with `constrains_init_order: true`.
+//!
+//! ## Why this is over-conservative
+//!
+//! ECMAScript Phase 1 of module linking
+//! (`ModuleDeclarationInstantiation`) binds every
+//! `FunctionDeclaration` to its hoisted closure before any module
+//! body runs. So when a residual or peeled module evaluates
+//! `const x = f()` at top level, the binding `f` is guaranteed
+//! initialized — the read cannot observe a TDZ, regardless of
+//! which module owns `f`. Recording an `EagerUse` edge for this
+//! read manufactures a cross-module init-order constraint that
+//! no realizable trace actually demands.
+//!
+//! Compare with `target_is_hoisted` in `graph.rs:576-584`:
+//!
+//! > Other declared kinds (`VarDecl`, `ClassDecl`) are kept:
+//! > const / let / class are TDZ-locked until their statement
+//! > runs, so a cross-module read inside an at-init-called
+//! > function does fire the realizability hazard.
+//!
+//! The same logic that justifies the FnDecl exclusion in
+//! promoted reads (no TDZ on hoisted bindings) applies to direct
+//! reads. The fix family: hoist the predicate to module scope
+//! (or reuse it as a free function) and gate the direct
+//! `stmt.eager_reads` loop with it.
+//!
+//! ## Fixture
+//!
+//! `f` lives in `mod_f`; residual reads it eagerly at top level.
+//! There is no real cross-module init-order hazard: ESM Phase 1
+//! hoists `f`'s binding before any module body evaluates, so the
+//! `const x = f()` in residual sees a fully-bound `f` no matter
+//! what order modules run in.
+//!
+//! ## Expected outcomes
+//!
+//! - **Today (RED)**: the owner-graph report emits an
+//!   `EagerUse` edge for binding `f` from the residual `const x`
+//!   statement to the FnDecl owner, with
+//!   `constrains_init_order: true`. The assertion in
+//!   `eager_use_to_fndecl_is_not_emitted` fails.
+//! - **After the proposed tightening**: the direct-read path in
+//!   `graph.rs` applies the same `target_is_hoisted` filter the
+//!   promoted-read path uses, so no `EagerUse` edge to a FnDecl
+//!   owner is emitted. The assertion passes.
+
+use analysis::{DepKind, OwnerGraphReport};
+use debundle_e2e_support::*;
+use serde::de::DeserializeOwned;
+use std::{fs, path::Path};
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> T {
+    serde_json::from_str(
+        &fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("read JSON report {}: {err}", path.display())),
+    )
+    .unwrap_or_else(|err| panic!("parse JSON report {}: {err}", path.display()))
+}
+
+#[test]
+fn eager_use_to_fndecl_is_not_emitted() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function f() { return "from-f"; }
+const x = f();
+console.log(x);
+export { f };
+"#,
+        vec![logical_module("mod_f", &[Member::new("f")])],
+    ));
+
+    assert_entry_output(&fixture, "from-f\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+
+    let fndecl_owner = graph
+        .nodes
+        .iter()
+        .find(|node| {
+            node.declared_bindings
+                .iter()
+                .any(|binding_report| binding_report.binding == "f")
+        })
+        .expect("FnDecl owner for `f` should exist in owner graph");
+
+    let offending_edges: Vec<_> = graph
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.target == fndecl_owner.id
+                && edge.edge_kind == DepKind::EagerUse
+                && edge.binding.as_deref() == Some("f")
+                && edge.constrains_init_order
+        })
+        .collect();
+
+    assert!(
+        offending_edges.is_empty(),
+        "no EagerUse edge to a FnDecl owner should constrain init order — \
+         ESM Phase 1 hoists FunctionDeclaration bindings before any \
+         module body runs, so a direct top-level read of `f` cannot \
+         observe a TDZ. Offending edges: {offending_edges:#?}\n\nFull \
+         owner graph: {graph:#?}",
+    );
+}


### PR DESCRIPTION
## RED test

Pins that ducktape emits a direct `eager_use` edge with
`constrains_init_order: true` from a top-level statement to a
**FnDecl** binding in another module. ESM Phase 1
(`ModuleDeclarationInstantiation`) hoists every
`FunctionDeclaration` binding into its module's environment record
before any module body runs, so a cross-module direct read of a
FnDecl can never TDZ. The edge is over-conservative.

The hoisted-target filter at `graph.rs:576-584` already skips this
case, but only for the **promoted** read path
(`promote_at_init_calls`). The direct `stmt.eager_reads` loop at
`graph.rs:340-398` doesn't consult the filter.

## Fixture

```js
function f() { return "from-f"; }
const x = f();
console.log(x);
export { f };
```

Spec: `mod_f` = `{f}`, residual = `{const x = f(); console.log(x);}`.

Test asserts `owner_graph.json.edges[]` has no
`{edge_kind: "eager_use", constrains_init_order: true, binding: "f"}`
targeting the FnDecl owner of `f`. Today: such an edge exists.
After the fix: absent.

The fixture is realizable: `assert_entry_output("from-f\n")`.

## Suggested fix family

Extend the hoisted-target filter to the direct-read path. The
cleanest formulation: extract `target_is_hoisted` from
`promote_at_init_calls` to module scope (or a free function in
`graph.rs`), then apply it in the eager-read emission loop at
`graph.rs:340-398`:

```rust
for binding in &stmt.eager_reads {
    let Some(binding_id) = binding_table.get(binding) else { continue };
    if target_is_hoisted(binding_id) { continue; }
    push_binding_edge(&mut raw_edges, from, binding, EdgeReason::eager_use, stmt.ordinal);
}
```

## Soundness

`target_is_hoisted` returns true iff the binding's owning statement
is `StatementKind::FnDecl`. ESM `ModuleDeclarationInstantiation`
binds every FunctionDeclaration to its hoisted function value
during Phase 1 of linking, before any module's top-level body
evaluates. Cross-module reads of such a binding via an `import`
specifier resolve to the live function value with no TDZ window.

Mutual recursion via cross-module FnDecls is realizable today and
remains so after the fix (the analyzer simply stops emitting
spurious constraints).

`class_decl` and `var_decl` (including `const fn = () => {}` and
`const fn = function(){}`) stay TDZ-locked and continue to emit
constraining edges — unchanged.

## Test plan

- [x] The new RED test fails today: emits exactly the spurious
      eager_use edge the test rejects
- [ ] After the fix: test flips to GREEN

This PR ships only the test. The classifier fix is a follow-up.