### PR TITLE
debundle: drop direct EagerUse edges to hoisted FnDecl owners

### DIFF
--- a/devinfra/js/debundle/e2e/peel_horizon_pure_hub_test.rs
+++ b/devinfra/js/debundle/e2e/peel_horizon_pure_hub_test.rs
@@ -119,22 +119,29 @@ fn assert_not_peelable(graph: &OwnerGraphReport, binding: &str) {
     );
 }
 
-/// Canonical reproduction of the gaffer bug: pure `function`
-/// declaration with many eager-use consumers AND an intra-residual
-/// lazy out-edge. Before the fix the post-peel cycle reachability
-/// walked the lazy out-edge into residual, observed the eager
-/// in-edges back from residual, and flagged the candidate
-/// `BlockedCycle` with hundreds of cycle blockers. After the fix:
-/// the constraining-edge subgraph forms a DAG (residual → Se eager,
-/// no constraining edges out of Se), so the candidate certifies as
-/// `PeelableNow`.
+/// `function` declaration hubs are trivially direct-peelable
+/// post-PR #1659: the FnDecl filter in
+/// `graph.rs::build_owner_graph` (mirroring the long-standing
+/// `target_is_hoisted` filter in `promote_at_init_calls`) drops
+/// every direct top-level `EagerUse` edge that targets a FnDecl
+/// owner. ESM Phase 1 of module linking
+/// (`ModuleDeclarationInstantiation`) hoists every
+/// `FunctionDeclaration` binding before any module body runs, so
+/// the reads can't observe a TDZ regardless of which module owns
+/// the FnDecl. The original gaffer bug shape (many incoming
+/// eager-use + lazy intra-residual out-edge → spurious
+/// `BlockedCycle`) is impossible for FnDecl hubs because the
+/// incoming eager-use edges aren't emitted. The sibling tests
+/// (`pure_var_decl_hub_…`, `pure_class_decl_hub_…`) still cover the
+/// real bug shape for declaration kinds that are TDZ-locked.
 #[test]
 fn pure_fn_decl_hub_with_eager_consumers_and_lazy_intra_residual_out_is_direct_peelable() {
-    // Five top-level consumers each eagerly read `Se` at init time
-    // (`var ci = Se(...)` evaluates Se synchronously). `Se`'s body
-    // lazily reads `Helper`, which stays in residual — that
-    // lazy out-edge is the bug trigger. `Existing` is a logical
-    // module so the pipeline does real peel work.
+    // Same fixture as the var/class variants: a pure top-level
+    // declaration with five eager-use consumers and a lazy
+    // intra-residual out-edge to `Helper`. The peelability proposer
+    // should certify `Se` as `PeelableNow` because — post-PR #1659 —
+    // the FnDecl filter strips the incoming eager_use edges and the
+    // hub ends up with no constraining edges in either direction.
     let mut opts = FixtureOpts::new(
         r#"function Se(n) { return Helper(n); }
 function Helper(n) { return n * 2; }
@@ -156,10 +163,11 @@ export { Se, Helper, c1, c2, c3, c4, c5, Existing };
     let graph = owner_graph(&fixture);
     assert_direct_peel(&graph, "Se");
 
-    // Sanity-check the bug shape is actually exercised: Se has at
-    // least 5 incoming eager_use edges from same-residual consumers
-    // AND a lazy out-edge to a same-residual `Helper`. Without that
-    // mixed-edge topology the test would be silently weakened.
+    // Post-PR #1659 invariant: the FnDecl filter strips every
+    // incoming direct `EagerUse` edge to a `function` declaration
+    // owner. Pin this here so a future regression that re-emits
+    // those edges (and reintroduces the pure-hub `BlockedCycle`
+    // bug) surfaces as a precise diagnostic.
     let se_node = graph
         .nodes
         .iter()
@@ -172,21 +180,11 @@ export { Se, Helper, c1, c2, c3, c4, c5, Existing };
         .filter(|edge| edge.target == se_id && edge.edge_kind == analysis::DepKind::EagerUse)
         .collect();
     assert!(
-        eager_in.len() >= 5,
-        "Se must have >= 5 incoming eager_use edges to reproduce the bug shape; got {}",
-        eager_in.len(),
-    );
-    let lazy_out_to_residual_present = graph.edges.iter().any(|edge| {
-        edge.source == se_id
-            && !edge.constrains_init_order
-            && graph
-                .nodes
-                .iter()
-                .any(|n| n.id == edge.target && n.destination.residual)
-    });
-    assert!(
-        lazy_out_to_residual_present,
-        "Se must have at least one lazy out-edge to a same-residual owner to reproduce the bug shape",
+        eager_in.is_empty(),
+        "EagerUse edges to a FnDecl owner should be filtered out by \
+         `target_is_hoisted` in `build_owner_graph` (ESM Phase 1 hoists \
+         `function` declarations before any module body runs). Offending \
+         edges: {eager_in:#?}",
     );
 }
 

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -321,6 +321,34 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
     // Collect (from, to, reason) triples; the final `edges` Vec is
     // sorted at the end so `OwnerEdgeId` indices are stable.
     let mut raw_edges = Vec::<(OwnerId, OwnerId, EdgeReason)>::new();
+    // Look-aside table for "what statement owns this OwnerId" — shared
+    // by the direct eager-read filter below and by
+    // `promote_at_init_calls` (which builds its own local copy; the
+    // duplicate cost is negligible).
+    let stmt_by_owner: std::collections::HashMap<OwnerId, &StatementFacts> = facts
+        .iter()
+        .map(|stmt| (OwnerId(stmt.ordinal.0), stmt))
+        .collect();
+    // A top-level eager read of a binding declared by a `function`
+    // declaration cannot observe a TDZ: ECMAScript Phase 1 of module
+    // linking (`ModuleDeclarationInstantiation`) binds every
+    // `FunctionDeclaration` to its hoisted closure before any module
+    // body runs. So `const x = f()` where `f` is a chunk-declared
+    // FnDecl is safe regardless of which module owns `f` — there is
+    // no init-order constraint to record, and emitting an `EagerUse`
+    // edge would manufacture a cross-module constraint no realizable
+    // trace demands. Same rule as the FnDecl exclusion in
+    // `promote_at_init_calls`. Other declared kinds (VarDecl,
+    // ClassDecl) are TDZ-locked until their statement runs, so their
+    // cross-module reads stay constrained.
+    let target_is_hoisted = |binding_id: BindingId| -> bool {
+        binding_owner
+            .get(binding_id.0)
+            .and_then(|owner| owner.as_ref())
+            .and_then(|owner| stmt_by_owner.get(owner))
+            .map(|stmt| stmt.kind == StatementKind::FnDecl)
+            .unwrap_or(false)
+    };
     let push_binding_edge = |raw_edges: &mut Vec<(OwnerId, OwnerId, EdgeReason)>,
                              from: OwnerId,
                              binding: &BindingName,
@@ -340,6 +368,11 @@ pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
     for stmt in facts {
         let from = OwnerId(stmt.ordinal.0);
         for binding in &stmt.eager_reads {
+            if let Some(binding_id) = binding_table.get(binding)
+                && target_is_hoisted(binding_id)
+            {
+                continue;
+            }
             push_binding_edge(
                 &mut raw_edges,
                 from,


### PR DESCRIPTION
## Summary

Flips PR #1659's RED test (`at_init_promotion_fndecl_direct_read_test`) from RED to GREEN.

`graph.rs::promote_at_init_calls` already filters out promoted reads of `StatementKind::FnDecl` bindings via `target_is_hoisted`: ESM Phase 1 of module linking (`ModuleDeclarationInstantiation`) binds every `FunctionDeclaration` to its hoisted closure before any module body runs, so a cross-module read of a FnDecl never observes a TDZ. The direct top-level `EagerUse` path (`build_owner_graph`'s loop over `stmt.eager_reads`) didn't apply the same filter — any top-level `const x = f()` where `f` is a hoisted `function f() {}` emitted an `EagerUse` edge with `constrains_init_order: true`, manufacturing a cross-module init-order constraint no realizable trace demands.

## Implementation

`build_owner_graph` now builds a `stmt_by_owner` look-aside table (matching the one `promote_at_init_calls` constructs locally — the duplicate hashmap is negligible) and defines `target_is_hoisted` as a closure used by the direct `eager_reads` loop. When the target owner's statement is `StatementKind::FnDecl`, the loop skips `push_binding_edge` entirely. Other declared kinds (`VarDecl`, `ClassDecl`) are TDZ-locked until their statement runs, so their cross-module reads stay constrained.

## Test fixture impact

The `pure_fn_decl_hub_with_eager_consumers_and_lazy_intra_residual_out_is_direct_peelable` case in `peel_horizon_pure_hub_test` previously asserted that `Se` (a `function Se(...) {}` hub) had **≥ 5** incoming `EagerUse` edges as the "bug shape" sanity check. Post-fix that's structurally impossible for FnDecl hubs — the filter strips every direct top-level eager read. The test still asserts the hub certifies as `PeelableNow` (now trivially, with no constraining edges in either direction) and flips the inner sanity check to `eager_in.is_empty()` so a future regression that re-emits those edges surfaces as a precise diagnostic. The sibling `pure_var_decl_hub_…` / `pure_class_decl_hub_…` tests still cover the real pure-hub bug shape for declaration kinds that are TDZ-locked.

## Test plan

- [x] `bazel test //devinfra/js/debundle/...` — 52/52 GREEN (was 51/52 with the RED test from PR #1659).
- [x] The RED test (`at_init_promotion_fndecl_direct_read_test`) flips to GREEN.
- [x] The adjusted `pure_fn_decl_hub_…` test still asserts `PeelableNow` for the FnDecl hub and now pins the post-#1659 emission invariant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_