### PR TITLE
study_casino: type GameEventRead.outcome as Pydantic union

### DIFF
--- a/x/auragon_study_casino/events.py
+++ b/x/auragon_study_casino/events.py
@@ -16,6 +16,60 @@ from pydantic import BaseModel, ConfigDict
 from x.auragon_study_casino.models import GameEventRow, LedgerEventRow
 
 
+class Card(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: str
+    suit: str
+
+
+class RouletteOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bet_type: str
+    bet_number: int | None
+    multiplier: int
+    result_color: str
+    result_number: int
+    # Server-resolved rows include the wheel index; pre-2026-05-07
+    # `client_reported` rows predate that field.
+    result_index: int | None = None
+    won: bool
+
+
+class SlotsOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbols: list[str]
+    glyphs: list[str]
+    label: str
+    payout_kind: str
+
+
+class BlackjackOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: str
+    text: str
+    player_cards: list[Card]
+    dealer_cards: list[Card]
+    player_value: int
+    dealer_value: int
+    player_blackjack: bool
+    dealer_blackjack: bool
+    initial_wager: int
+    doubled: bool
+
+
+GameOutcome = RouletteOutcome | SlotsOutcome | BlackjackOutcome
+
+_OUTCOME_BY_GAME: dict[str, type[RouletteOutcome] | type[SlotsOutcome] | type[BlackjackOutcome]] = {
+    "roulette": RouletteOutcome,
+    "slots": SlotsOutcome,
+    "blackjack": BlackjackOutcome,
+}
+
+
 class GameEventRead(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -36,16 +90,18 @@ class GameEventRead(BaseModel):
     server_tokens: int
     rules_version: str | None = None
     rng_version: str | None = None
-    outcome: dict[str, Any]
+    outcome: GameOutcome
 
 
 def game_event_from_row(row: GameEventRow) -> GameEventRead:
+    game = cast(Literal["roulette", "slots", "blackjack"], row.game)
+    outcome = _OUTCOME_BY_GAME[game].model_validate_json(row.outcome_json)
     return GameEventRead(
         id=row.id,
         client_event_id=row.client_event_id,
         server_at_ms=row.server_at_ms,
         occurred_at_ms=row.occurred_at_ms,
-        game=cast(Literal["roulette", "slots", "blackjack"], row.game),
+        game=game,
         event_type=cast(Literal["settle"], row.event_type),
         source=cast(Literal["client_reported", "server_resolved"], row.source),
         wager_credits=row.wager_credits,
@@ -58,7 +114,7 @@ def game_event_from_row(row: GameEventRow) -> GameEventRead:
         server_tokens=row.server_tokens,
         rules_version=row.rules_version,
         rng_version=row.rng_version,
-        outcome=json.loads(row.outcome_json),
+        outcome=outcome,
     )
 
 

--- a/x/auragon_study_casino/store.py
+++ b/x/auragon_study_casino/store.py
@@ -24,7 +24,16 @@ from sqlalchemy import create_engine, delete, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from x.auragon_study_casino.events import GameEventRead, LedgerEventRead, game_event_from_row, ledger_event_from_row
+from x.auragon_study_casino.events import (
+    BlackjackOutcome,
+    GameEventRead,
+    GameOutcome,
+    LedgerEventRead,
+    RouletteOutcome,
+    SlotsOutcome,
+    game_event_from_row,
+    ledger_event_from_row,
+)
 from x.auragon_study_casino.games import RULES_VERSION, theoretical_bucket_rtp
 from x.auragon_study_casino.models import (
     BalanceRow,
@@ -482,26 +491,23 @@ _BLACKJACK_BUCKETS: list[tuple[str, str]] = [
 ]
 
 
-def _roulette_bucket_key(outcome: dict[str, Any]) -> str | None:
-    bet_type = outcome.get("bet_type")
-    return bet_type if isinstance(bet_type, str) else None
+def _roulette_bucket_key(outcome: GameOutcome) -> str | None:
+    return outcome.bet_type if isinstance(outcome, RouletteOutcome) else None
 
 
-def _slots_bucket_key(outcome: dict[str, Any]) -> str | None:
-    kind = outcome.get("payout_kind")
-    return kind if isinstance(kind, str) else None
+def _slots_bucket_key(outcome: GameOutcome) -> str | None:
+    return outcome.payout_kind if isinstance(outcome, SlotsOutcome) else None
 
 
-def _blackjack_bucket_key(outcome: dict[str, Any]) -> str | None:
-    kind = outcome.get("outcome")
-    return kind if isinstance(kind, str) else None
+def _blackjack_bucket_key(outcome: GameOutcome) -> str | None:
+    return outcome.outcome if isinstance(outcome, BlackjackOutcome) else None
 
 
 def _aggregate_game(
     events: list[GameEventRead],
     game: str,
     bucket_defs: list[tuple[str, str]],
-    bucket_key: Callable[[dict[str, Any]], str | None],
+    bucket_key: Callable[[GameOutcome], str | None],
     theoretical: dict[tuple[str, str], tuple[float, float]],
 ) -> GameStats:
     game_events = [e for e in events if e.game == game]
@@ -604,14 +610,10 @@ _BJ_UPCARD_BUCKETS: list[tuple[str, str]] = [
 ]
 
 
-def _bj_upcard_key(outcome: dict[str, Any]) -> str | None:
-    dealer = outcome.get("dealer_cards")
-    if not isinstance(dealer, list) or not dealer:
+def _bj_upcard_key(outcome: BlackjackOutcome) -> str | None:
+    if not outcome.dealer_cards:
         return None
-    first = dealer[0]
-    if not isinstance(first, dict):
-        return None
-    rank = first.get("rank")
+    rank = outcome.dealer_cards[0].rank
     if rank in ("J", "Q", "K", "10"):
         return "10"
     if rank in ("A", "2", "3", "4", "5", "6", "7", "8", "9"):
@@ -626,7 +628,8 @@ def _blackjack_slice(key: str, label: str, events: list[GameEventRead]) -> Black
     for e in events:
         wagered += e.wager_credits
         returned += e.payout_tokens
-        outcome = e.outcome.get("outcome")
+        assert isinstance(e.outcome, BlackjackOutcome)
+        outcome = e.outcome.outcome
         if outcome in _BJ_WIN_OUTCOMES:
             wins += 1
         elif outcome in _BJ_LOSS_OUTCOMES:
@@ -652,7 +655,8 @@ def _blackjack_slice(key: str, label: str, events: list[GameEventRead]) -> Black
 def _blackjack_summary(events: list[GameEventRead]) -> BlackjackSummary:
     wins = losses = pushes = blackjacks = busts = 0
     for e in events:
-        outcome = e.outcome.get("outcome")
+        assert isinstance(e.outcome, BlackjackOutcome)
+        outcome = e.outcome.outcome
         if outcome == "blackjack":
             blackjacks += 1
         elif outcome == "bust":
@@ -681,8 +685,9 @@ def _blackjack_outcome_freq(events: list[GameEventRead]) -> list[BlackjackOutcom
     total = len(events)
     by_key: dict[str, list[GameEventRead]] = {key: [] for key, _ in _BLACKJACK_BUCKETS}
     for e in events:
-        key = e.outcome.get("outcome")
-        if isinstance(key, str) and key in by_key:
+        assert isinstance(e.outcome, BlackjackOutcome)
+        key = e.outcome.outcome
+        if key in by_key:
             by_key[key].append(e)
     return [
         BlackjackOutcomeFreq(
@@ -699,6 +704,7 @@ def _blackjack_outcome_freq(events: list[GameEventRead]) -> list[BlackjackOutcom
 def _blackjack_upcard_slices(events: list[GameEventRead]) -> list[BlackjackSlice]:
     by_key: dict[str, list[GameEventRead]] = {key: [] for key, _ in _BJ_UPCARD_BUCKETS}
     for e in events:
+        assert isinstance(e.outcome, BlackjackOutcome)
         key = _bj_upcard_key(e.outcome)
         if key is not None:
             by_key[key].append(e)
@@ -706,8 +712,12 @@ def _blackjack_upcard_slices(events: list[GameEventRead]) -> list[BlackjackSlice
 
 
 def _blackjack_doubled_slices(events: list[GameEventRead]) -> list[BlackjackSlice]:
-    doubled = [e for e in events if bool(e.outcome.get("doubled"))]
-    not_doubled = [e for e in events if not bool(e.outcome.get("doubled"))]
+    def _doubled(e: GameEventRead) -> bool:
+        assert isinstance(e.outcome, BlackjackOutcome)
+        return e.outcome.doubled
+
+    doubled = [e for e in events if _doubled(e)]
+    not_doubled = [e for e in events if not _doubled(e)]
     return [
         _blackjack_slice("doubled", "Doubled", doubled),
         _blackjack_slice("not_doubled", "Not doubled", not_doubled),

--- a/x/auragon_study_casino/test_store.py
+++ b/x/auragon_study_casino/test_store.py
@@ -22,6 +22,46 @@ def store(db_url: str) -> SqlStore:
 _U = "u"
 
 
+def _roulette_outcome(bet_type: str, won: bool) -> dict[str, object]:
+    """Minimal RouletteOutcome dict — only `bet_type` and `won` matter for these tests."""
+    return {
+        "bet_type": bet_type,
+        "bet_number": None,
+        "multiplier": 2,
+        "result_color": "red",
+        "result_number": 1,
+        "result_index": 0,
+        "won": won,
+    }
+
+
+def _slots_outcome(payout_kind: str) -> dict[str, object]:
+    """Minimal SlotsOutcome dict — only `payout_kind` matters for these tests."""
+    return {"symbols": ["a", "b", "c"], "glyphs": ["A", "B", "C"], "label": "test", "payout_kind": payout_kind}
+
+
+def _blackjack_outcome(
+    outcome: str, *, doubled: bool = False, dealer_cards: list[dict[str, str]] | None = None
+) -> dict[str, object]:
+    """Minimal BlackjackOutcome dict — only `outcome`, `doubled`, `dealer_cards` matter for these tests.
+
+    `dealer_cards` defaults to a single 7♥ upcard so tests that don't care about
+    upcard bucketing land in a non-aggregating slice.
+    """
+    return {
+        "outcome": outcome,
+        "text": "",
+        "player_cards": [],
+        "dealer_cards": dealer_cards if dealer_cards is not None else [{"rank": "7", "suit": "♥"}],
+        "player_value": 0,
+        "dealer_value": 0,
+        "player_blackjack": False,
+        "dealer_blackjack": False,
+        "initial_wager": 1,
+        "doubled": doubled,
+    }
+
+
 def test_fresh_store_has_zero_balance_and_default_prizes(store: SqlStore) -> None:
     state = store.state_dump(_U)
     assert state["balance"] == {"credits": 0, "tokens": 0}
@@ -223,7 +263,7 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             "server_resolved",
             10,
             20,
-            {"bet_type": "red", "won": True},
+            _roulette_outcome("red", True),
             1_778_200_000_000,
         ),  # 2026-05-08
         (
@@ -232,7 +272,7 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             "server_resolved",
             10,
             20,
-            {"bet_type": "red", "won": True},
+            _roulette_outcome("red", True),
             1_778_200_001_000,
         ),  # 2026-05-08
         (
@@ -241,12 +281,13 @@ def test_casino_stats_aggregates_server_resolved_only(store: SqlStore) -> None:
             "server_resolved",
             10,
             0,
-            {"bet_type": "red", "won": False},
+            _roulette_outcome("red", False),
             1_778_300_000_000,
         ),  # 2026-05-09
-        ("ce-4", "slots", "server_resolved", 5, 100, {"payout_kind": "triple"}, 1_778_200_002_000),  # 2026-05-08
-        ("ce-5", "blackjack", "server_resolved", 4, 8, {"outcome": "win"}, 1_778_200_003_000),  # 2026-05-08
-        ("legacy", "roulette", "client_reported", 99, 0, {"bet_type": "black"}, 1_746_000_000_000),
+        ("ce-4", "slots", "server_resolved", 5, 100, _slots_outcome("triple"), 1_778_200_002_000),  # 2026-05-08
+        ("ce-5", "blackjack", "server_resolved", 4, 8, _blackjack_outcome("win"), 1_778_200_003_000),  # 2026-05-08
+        # Legacy `client_reported` row — pre-2026-05-07. Excluded from casino_stats.
+        ("legacy", "roulette", "client_reported", 99, 0, _roulette_outcome("black", False), 1_746_000_000_000),
     ]
     # Need a balance row first (for FK / seed convention).
     store.state_dump(_U)
@@ -358,12 +399,12 @@ def _seed_blackjack_events(store: SqlStore, fixtures: list[tuple[str, int, int, 
 def test_casino_stats_blackjack_summary_and_outcome_freq(store: SqlStore) -> None:
     """Summary counts split W/L/P/blackjack/bust and exclude pushes from win-rate."""
     fixtures: list[tuple[str, int, int, dict[str, object]]] = [
-        ("h1", 2, 5, {"outcome": "blackjack", "doubled": False, "dealer_cards": [{"rank": "6", "suit": "♥"}]}),
-        ("h2", 1, 2, {"outcome": "win", "doubled": False, "dealer_cards": [{"rank": "7", "suit": "♥"}]}),
-        ("h3", 1, 2, {"outcome": "dealerBust", "doubled": False, "dealer_cards": [{"rank": "5", "suit": "♦"}]}),
-        ("h4", 1, 1, {"outcome": "push", "doubled": False, "dealer_cards": [{"rank": "K", "suit": "♣"}]}),
-        ("h5", 1, 0, {"outcome": "lose", "doubled": False, "dealer_cards": [{"rank": "A", "suit": "♠"}]}),
-        ("h6", 1, 0, {"outcome": "bust", "doubled": False, "dealer_cards": [{"rank": "10", "suit": "♥"}]}),
+        ("h1", 2, 5, _blackjack_outcome("blackjack", dealer_cards=[{"rank": "6", "suit": "♥"}])),
+        ("h2", 1, 2, _blackjack_outcome("win", dealer_cards=[{"rank": "7", "suit": "♥"}])),
+        ("h3", 1, 2, _blackjack_outcome("dealerBust", dealer_cards=[{"rank": "5", "suit": "♦"}])),
+        ("h4", 1, 1, _blackjack_outcome("push", dealer_cards=[{"rank": "K", "suit": "♣"}])),
+        ("h5", 1, 0, _blackjack_outcome("lose", dealer_cards=[{"rank": "A", "suit": "♠"}])),
+        ("h6", 1, 0, _blackjack_outcome("bust", dealer_cards=[{"rank": "10", "suit": "♥"}])),
     ]
     _seed_blackjack_events(store, fixtures)
 
@@ -391,12 +432,12 @@ def test_casino_stats_blackjack_by_dealer_upcard_collapses_face_cards(store: Sql
     """J/Q/K and 10 share one bucket; A is separate. Slices retain real W/L/P stats."""
     fixtures: list[tuple[str, int, int, dict[str, object]]] = [
         # Two hands with dealer-K → bucketed under "10"
-        ("k1", 2, 4, {"outcome": "win", "doubled": False, "dealer_cards": [{"rank": "K", "suit": "♠"}]}),
-        ("k2", 2, 0, {"outcome": "lose", "doubled": False, "dealer_cards": [{"rank": "K", "suit": "♣"}]}),
+        ("k1", 2, 4, _blackjack_outcome("win", dealer_cards=[{"rank": "K", "suit": "♠"}])),
+        ("k2", 2, 0, _blackjack_outcome("lose", dealer_cards=[{"rank": "K", "suit": "♣"}])),
         # One hand with dealer-Q → also under "10"
-        ("q1", 2, 0, {"outcome": "bust", "doubled": False, "dealer_cards": [{"rank": "Q", "suit": "♦"}]}),
+        ("q1", 2, 0, _blackjack_outcome("bust", dealer_cards=[{"rank": "Q", "suit": "♦"}])),
         # One ace upcard (player-favouring loss)
-        ("a1", 1, 0, {"outcome": "lose", "doubled": False, "dealer_cards": [{"rank": "A", "suit": "♥"}]}),
+        ("a1", 1, 0, _blackjack_outcome("lose", dealer_cards=[{"rank": "A", "suit": "♥"}])),
     ]
     _seed_blackjack_events(store, fixtures)
 
@@ -429,13 +470,13 @@ def test_casino_stats_blackjack_by_doubled_separates_doubled_from_baseline(store
     """Doubled and not-doubled hands aggregate independently."""
     fixtures: list[tuple[str, int, int, dict[str, object]]] = [
         # Doubled win (initial wager 2 → 4 after double → pays 8)
-        ("d1", 4, 8, {"outcome": "win", "doubled": True, "dealer_cards": [{"rank": "6"}]}),
+        ("d1", 4, 8, _blackjack_outcome("win", doubled=True, dealer_cards=[{"rank": "6", "suit": "♥"}])),
         # Doubled loss
-        ("d2", 4, 0, {"outcome": "lose", "doubled": True, "dealer_cards": [{"rank": "10"}]}),
+        ("d2", 4, 0, _blackjack_outcome("lose", doubled=True, dealer_cards=[{"rank": "10", "suit": "♥"}])),
         # Baseline (no-double) win
-        ("n1", 1, 2, {"outcome": "win", "doubled": False, "dealer_cards": [{"rank": "5"}]}),
+        ("n1", 1, 2, _blackjack_outcome("win", dealer_cards=[{"rank": "5", "suit": "♥"}])),
         # Baseline loss
-        ("n2", 1, 0, {"outcome": "bust", "doubled": False, "dealer_cards": [{"rank": "7"}]}),
+        ("n2", 1, 0, _blackjack_outcome("bust", dealer_cards=[{"rank": "7", "suit": "♥"}])),
     ]
     _seed_blackjack_events(store, fixtures)
 


### PR DESCRIPTION
## Summary

`GameEventRead.outcome: dict[str, Any]` forced every consumer in
`x/auragon_study_casino/store.py` to do `.get()` + isinstance dances and
caused the mypy `no-any-return` lint failure on `_bj_upcard_key`. Replace
it with a typed union `RouletteOutcome | SlotsOutcome | BlackjackOutcome`
(plus a `Card` model) dispatched on `row.game` in
`game_event_from_row`. All store-side accessors now read typed
attributes (`outcome.dealer_cards[0].rank`, `outcome.doubled`,
`outcome.bet_type`, …) and the original lint error disappears by
construction.

## Live-data verification

Queried the production `studycasino` DB via the readonly secret mirrored
into `claude-sandbox` to confirm the model matches reality:

- 16 legacy `client_reported` blackjack rows have the same 10-key shape
  as the 66 `server_resolved` rows.
- 8 legacy `client_reported` roulette rows lack `result_index` (added
  with server-side WHEEL indexing); otherwise identical to the 91
  `server_resolved` rows. Modeled as `result_index: int | None = None`.
- No legacy slots rows exist.

Everything else is required (no suspicious nullability).

## Test fixtures

The previous tests built partial dicts (`{"bet_type": "red", "won":
True}`) which strict Pydantic models reject. Added three small builders
— `_roulette_outcome`, `_slots_outcome`, `_blackjack_outcome` — that
fill in the irrelevant required fields so each test only specifies what
it actually exercises.

## Test plan

- [x] `bbr build //x/auragon_study_casino/...` — green (mypy clean)
- [x] `bbr test //x/auragon_study_casino/...` — 7/7 pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01E13nc4iaZEZ5shtEfkr4qJ)_