### PR TITLE
claude_hook/shim: respawn dead daemon + 2s connect deadline + 20s watchdog

### DIFF
--- a/devinfra/claude/claude_hook/main.rs
+++ b/devinfra/claude/claude_hook/main.rs
@@ -78,7 +78,7 @@ pub(crate) fn daemon_sock_path(session_id: &str) -> PathBuf {
     short_session_dir(session_id).join("d.sock")
 }
 
-fn daemon_dir_path(session_id: &str) -> PathBuf {
+pub(crate) fn daemon_dir_path(session_id: &str) -> PathBuf {
     short_session_dir(session_id)
 }
 
@@ -768,9 +768,17 @@ async fn post_json_over_uds_inner(
     path: &str,
     body: Vec<u8>,
 ) -> Result<Bytes, String> {
-    let stream = UnixStream::connect(sock_path)
-        .await
-        .map_err(|e| format!("connect: {e}"))?;
+    // Connect deadline must stay tight: a hung daemon (or a half-open socket on
+    // an exotic FS) used to spin the shim until the outer 300s ceiling, blocking
+    // the parent shell. The 2s value mirrors `daemon_lifecycle::health_check`.
+    // The "connect:" prefix on both branches lets `shim_runtime` classify this
+    // as "daemon unreachable" and trigger respawn.
+    let stream =
+        match tokio::time::timeout(Duration::from_secs(2), UnixStream::connect(sock_path)).await {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(format!("connect: {e}")),
+            Err(_) => return Err("connect: timed out after 2s".to_string()),
+        };
     let io = TokioIo::new(stream);
     let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
         .await

--- a/devinfra/claude/claude_hook/shim_runtime.rs
+++ b/devinfra/claude/claude_hook/shim_runtime.rs
@@ -6,11 +6,19 @@
 //! or `Execve` with a fully resolved argv (shim just exec's it).
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use claude_hook_shim_install::SHIM_SESSION_ID_ENV;
 use protocol::{ShimExecRequest, ShimResponse};
+
+/// Whole-`run_shim` wall-clock ceiling. Covers: 2s connect + up to 10s
+/// `wait_for_sock` + 2s retry connect + slack. If the deadlock is inside
+/// the tokio runtime itself, this timer won't fire — that's a separate
+/// belt-and-braces story (`setitimer(SIGALRM)`) intentionally out of scope.
+const SHIM_BODY_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The decision the shim is going to take, derived from the daemon's
 /// response (or absence thereof). Split out of `run_shim` so it can be
@@ -27,20 +35,83 @@ pub(crate) enum ShimDecision {
     Passthrough { argv: Vec<String>, reason: String },
 }
 
-/// Ask the daemon how to handle this shim invocation. Turns RPC failures
-/// into `Passthrough { argv, reason }` so `run_shim` doesn't need to know
-/// anything about the daemon wire protocol.
-pub(crate) async fn decide(
+/// Ask the daemon how to handle this shim invocation, with no recovery
+/// (see `decide_with_recovery` for the respawn-and-retry wrapper that
+/// `run_shim` uses). Kept for unit tests that exercise the pure
+/// request → decision path without faking `ensure_daemon`.
+#[cfg(test)]
+async fn decide(sock: &Path, req: &ShimExecRequest, original_argv: Vec<String>) -> ShimDecision {
+    response_to_decision(call_daemon(sock, req).await, original_argv)
+}
+
+/// Why `call_daemon` failed. `Unreachable` means the shim's connect to
+/// the daemon's UDS failed fast or timed out — daemon is dead, restart
+/// candidate. `Other` means the daemon answered but the answer was
+/// unusable (handshake error, HTTP 5xx, malformed body): don't respawn,
+/// just passthrough. The inner `String` is for user-facing display.
+#[derive(Debug)]
+enum CallError {
+    Unreachable(String),
+    Other(String),
+}
+
+impl CallError {
+    fn into_reason(self) -> String {
+        match self {
+            CallError::Unreachable(r) | CallError::Other(r) => r,
+        }
+    }
+}
+
+/// Boundary classifier: the contract with `main.rs::post_json_over_uds_inner`
+/// is that every connect-failure reason starts with `"connect:"` (both the
+/// fast `ECONNREFUSED`/`ENOENT` case and the new connect-timeout case).
+/// Everything else means the daemon answered.
+fn classify_rpc_error(reason: String) -> CallError {
+    if reason.starts_with("connect:") {
+        CallError::Unreachable(reason)
+    } else {
+        CallError::Other(reason)
+    }
+}
+
+fn response_to_decision(
+    response: Result<ShimResponse, CallError>,
+    original_argv: Vec<String>,
+) -> ShimDecision {
+    match response {
+        Ok(ShimResponse::Blocked { message }) => ShimDecision::Block(message),
+        Ok(ShimResponse::Execve { argv }) => ShimDecision::Exec(argv),
+        Err(e) => ShimDecision::Passthrough {
+            argv: original_argv,
+            reason: e.into_reason(),
+        },
+    }
+}
+
+/// `decide` + at-most-one retry after `ensure_daemon` if the first attempt
+/// looks like the daemon is unreachable. The `ensure_daemon` closure is
+/// injectable so tests can stub it without forking a real daemon.
+pub(crate) async fn decide_with_recovery<F, Fut>(
     sock: &Path,
     req: &ShimExecRequest,
     original_argv: Vec<String>,
-) -> ShimDecision {
-    match call_daemon(sock, req).await {
-        Ok(ShimResponse::Blocked { message }) => ShimDecision::Block(message),
-        Ok(ShimResponse::Execve { argv }) => ShimDecision::Exec(argv),
-        Err(reason) => ShimDecision::Passthrough {
+    ensure_daemon: F,
+) -> ShimDecision
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let first = call_daemon(sock, req).await;
+    let first_unreachable = match first {
+        Err(CallError::Unreachable(reason)) => reason,
+        other => return response_to_decision(other, original_argv),
+    };
+    match ensure_daemon().await {
+        Ok(()) => response_to_decision(call_daemon(sock, req).await, original_argv),
+        Err(e) => ShimDecision::Passthrough {
             argv: original_argv,
-            reason,
+            reason: format!("{first_unreachable}; ensure_daemon: {e}"),
         },
     }
 }
@@ -68,8 +139,28 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
     };
 
     let sock_path = crate::daemon_sock_path(&session_id);
+    let daemon_dir = crate::daemon_dir_path(&session_id);
+    let original_argv = argv.clone();
 
-    let approved_argv = match decide(&sock_path, &report, argv).await {
+    let decision_fut = decide_with_recovery(&sock_path, &report, argv, || async {
+        crate::daemon_lifecycle::ensure_daemon(&sock_path, &daemon_dir).await
+    });
+
+    let decision = match tokio::time::timeout(SHIM_BODY_TIMEOUT, decision_fut).await {
+        Ok(d) => d,
+        Err(_) => {
+            eprintln!(
+                "[{name}-shim] watchdog: shim body exceeded {}s — passing through",
+                SHIM_BODY_TIMEOUT.as_secs()
+            );
+            ShimDecision::Passthrough {
+                argv: original_argv,
+                reason: format!("watchdog timeout ({}s)", SHIM_BODY_TIMEOUT.as_secs()),
+            }
+        }
+    };
+
+    let approved_argv = match decision {
         ShimDecision::Block(message) => {
             eprintln!("[{name}-shim] BLOCKED: {message}");
             std::process::exit(1);
@@ -88,10 +179,13 @@ pub async fn run_shim(name: String, forwarded: Vec<String>) -> ! {
     std::process::exit(126);
 }
 
-async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse, String> {
-    let body = serde_json::to_vec(req).map_err(|e| format!("serialize: {e}"))?;
-    let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body).await?;
-    serde_json::from_slice(&resp_bytes).map_err(|e| format!("parse response: {e}"))
+async fn call_daemon(sock: &Path, req: &ShimExecRequest) -> Result<ShimResponse, CallError> {
+    let body = serde_json::to_vec(req).map_err(|e| CallError::Other(format!("serialize: {e}")))?;
+    let resp_bytes = crate::post_json_over_uds(sock, "/shim-exec", body)
+        .await
+        .map_err(classify_rpc_error)?;
+    serde_json::from_slice(&resp_bytes)
+        .map_err(|e| CallError::Other(format!("parse response: {e}")))
 }
 
 #[cfg(test)]
@@ -198,6 +292,158 @@ mod tests {
                 assert!(!reason.is_empty(), "reason should carry the RPC error");
             }
             other => panic!("expected Passthrough, got {other:?}"),
+        }
+    }
+
+    fn assert_unreachable(reason: &str) {
+        match classify_rpc_error(reason.into()) {
+            CallError::Unreachable(_) => {}
+            CallError::Other(r) => panic!("expected Unreachable for {reason:?}, got Other({r})"),
+        }
+    }
+
+    fn assert_other(reason: &str) {
+        match classify_rpc_error(reason.into()) {
+            CallError::Other(_) => {}
+            CallError::Unreachable(r) => {
+                panic!("expected Other for {reason:?}, got Unreachable({r})")
+            }
+        }
+    }
+
+    #[test]
+    fn classify_connect_errors_as_unreachable() {
+        assert_unreachable("connect: No such file or directory (os error 2)");
+        assert_unreachable("connect: Connection refused (os error 111)");
+        assert_unreachable("connect: timed out after 2s");
+    }
+
+    #[test]
+    fn classify_post_connect_errors_as_other() {
+        // Daemon answered the connect — these are not "respawn me" signals.
+        assert_other("http1 handshake: invalid frame");
+        assert_other("send request: closed");
+        assert_other("daemon returned HTTP 500");
+        assert_other("parse response: missing field");
+        assert_other("serialize: cycle");
+        assert_other("daemon request timed out (300s)");
+    }
+
+    /// When `decide` returns Passthrough with a "connect:" reason, the
+    /// recovery wrapper calls `ensure_daemon` exactly once and retries.
+    #[tokio::test]
+    async fn decide_with_recovery_invokes_ensure_on_unreachable() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("nonexistent.sock");
+        let req = git_status_request();
+        let original = req.argv.clone();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let decision = decide_with_recovery(&sock, &req, original.clone(), move || {
+            let calls = calls2.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                // Stub: pretend respawn failed so we don't need a real daemon.
+                Err::<(), String>("test stub: no real daemon".into())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "ensure_daemon must be called exactly once"
+        );
+        match decision {
+            ShimDecision::Passthrough { argv, reason } => {
+                assert_eq!(argv, original);
+                assert!(
+                    reason.contains("ensure_daemon: test stub"),
+                    "ensure_daemon error must surface in passthrough reason, got: {reason}"
+                );
+            }
+            other => panic!("expected Passthrough, got {other:?}"),
+        }
+    }
+
+    /// When the daemon is reachable but returns Blocked, the recovery wrapper
+    /// must NOT call `ensure_daemon` and must return the Block verbatim.
+    #[tokio::test]
+    async fn decide_with_recovery_no_respawn_when_daemon_answers() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("d.sock");
+        let _server = spawn_fake_daemon(
+            sock.clone(),
+            ShimResponse::Blocked {
+                message: "denied".into(),
+            },
+        )
+        .await;
+        let req = git_status_request();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let decision = decide_with_recovery(&sock, &req, req.argv.clone(), move || {
+            let calls = calls2.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), String>(())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "ensure_daemon must not be called when the daemon answered"
+        );
+        match decision {
+            ShimDecision::Block(m) => assert_eq!(m, "denied"),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    /// If `ensure_daemon` succeeds, the wrapper retries `decide` against the
+    /// now-live socket and surfaces whatever the daemon says.
+    #[tokio::test]
+    async fn decide_with_recovery_retries_after_ensure_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("d.sock");
+        let req = git_status_request();
+        let original = req.argv.clone();
+
+        // Don't bind the socket up front — the first decide() call must see
+        // connect failure. The "ensure_daemon" stub spawns the fake daemon,
+        // simulating the real respawn behavior. The retry then sees the live
+        // daemon and gets an Exec response.
+        let sock_for_stub = sock.clone();
+        let decision = decide_with_recovery(&sock, &req, original.clone(), move || async move {
+            spawn_fake_daemon(
+                sock_for_stub,
+                ShimResponse::Execve {
+                    argv: vec!["/usr/bin/git".into(), "status".into()],
+                },
+            )
+            .await;
+            // Wait briefly for axum to start accepting; without this, the
+            // retry can race the listener.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok::<(), String>(())
+        })
+        .await;
+
+        match decision {
+            ShimDecision::Exec(argv) => {
+                assert_eq!(argv, vec!["/usr/bin/git".to_string(), "status".into()]);
+            }
+            other => panic!("expected Exec after respawn, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
Follow-up to #1638 (forensic write-up). Ports the Python shim's
daemon-self-heal behaviour to the Rust shim so a dead per-session hook
daemon no longer wedges `bazelisk` / `bbr` / `git` invocations.

## Summary

- **Respawn on unreachable.** When `call_daemon` fails because the
  shim's connect to the UDS errored fast or timed out, invoke
  `daemon_lifecycle::ensure_daemon` (which already exists, with lock,
  circuit breaker, fork, and `wait_for_sock`) and retry the RPC once.
  Errors that arrive *after* connect — handshake, HTTP 5xx, malformed
  body — are **not** treated as unreachable; we don't respawn a daemon
  that's serving other requests but unhappy with this one.
- **2 s `connect()` deadline** in `post_json_over_uds_inner`. Without
  this, a half-open socket would be absorbed by the existing 300 s outer
  ceiling and never trip the recovery path. Pattern lifted from
  `daemon_lifecycle::health_check`. Error message
  `"connect: timed out after 2s"` keeps the `"connect:"` prefix so it
  classifies as unreachable.
- **20 s wall-clock watchdog** wrapping the entire `run_shim` body. On
  expiry, exec the original argv with a `[<name>-shim] watchdog: …`
  stderr note. Belt-and-braces in case the recovery path itself
  misbehaves. Won't catch a tokio-runtime-internal deadlock — that
  would need `setitimer(SIGALRM)`, explicitly out of scope here.
- **Enum-driven classification, not string-prefix downstream.**
  `CallError { Unreachable(String), Other(String) }` returned by
  `call_daemon`; the `"connect:"` prefix check is confined to a single
  boundary helper (`classify_rpc_error`). User-facing `Passthrough.reason`
  stays a `String`.

## Reproduced live, then fixed

While running tests for this branch, hit the exact bug PR #1638
documents: `claude-hook shim bazelisk` spinning at 111 % CPU for >11 min
against a dead daemon. After the fix, the connect deadline trips at 2 s
and the `ensure_daemon` recovery path takes over.

## What's reused, not reimplemented

The Rust `ensure_daemon` / `fork_daemon` / `wait_for_sock` /
`acquire_daemon_lock` / `health_check` / circuit-breaker code already
existed in `daemon_lifecycle.rs` for the hook-dispatch path. This PR
just routes the shim path through it.

## Test plan

- [x] `bazelisk test //devinfra/claude/claude_hook:claude_hook_test` —
      55 / 55 unit tests pass on RBE. New tests cover:
  - `classify_rpc_error` for both `Unreachable` and `Other` families.
  - `decide_with_recovery_invokes_ensure_on_unreachable` — connect
    failure triggers exactly one `ensure_daemon` call; failure surfaces
    in the passthrough reason.
  - `decide_with_recovery_no_respawn_when_daemon_answers` — `Blocked`
    response does not trigger respawn.
  - `decide_with_recovery_retries_after_ensure_succeeds` — stub spawns
    a fake daemon mid-call; the retry connects and returns the new
    decision.
- [ ] End-to-end (web session): kill the daemon, run
      `claude-hook shim bbr --version`, observe ≤ a couple of seconds
      pause then exec, with a fresh daemon visible in `ps` afterwards.
      Defer to next clean session — can't kill *this* session's daemon
      because it's already dead (the very symptom).

## Out of scope (explicit)

- `setitimer(SIGALRM)` belt-and-braces for tokio-runtime-internal
  deadlocks.
- Removing the no-op `bb` / `bbr` / `bazel` / web-profile `git` shims.
- Investigating *why* the daemon died with zero requests served (a
  separate daemon-side bug — this PR only makes the shim resilient
  to it).
- Replacing `Err(String)` in `post_json_over_uds` with a typed enum.

https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHL6rMEDTQtWmSHD3XbHF)_