### PR TITLE
augur: move distribution fan chart to top; count cash-negative correctly

### DIFF
--- a/augur/frontend/app.jsx
+++ b/augur/frontend/app.jsx
@@ -422,10 +422,19 @@ function rolloutStatuses(scenarioResult) {
 
 function rolloutStatusSummary(scenarioResult) {
   const statuses = rolloutStatuses(scenarioResult);
+  // "Cash negative" counts any rollout whose cash crossed zero at any month.
+  // The backend's per-rollout status is ACTIVE / CASH_NEGATIVE / FAILED; a
+  // FAILED rollout (obligation default) can also have gone cash-negative, and
+  // populates `first_negative_cash_month_index` independently. Filtering on
+  // status alone hid those, producing the "P50 cash is negative but 0/N cash
+  // negative" inconsistency.
+  const cashNegative = statuses.filter(
+    (status) => Number.isFinite(Number(status?.firstNegativeCashMonthIndex)) || Number(status?.minCashUsd) < 0
+  ).length;
   return {
     total: statuses.length,
     active: statuses.filter((status) => status?.status === ROLLOUT_STATUS_ACTIVE).length,
-    cashNegative: statuses.filter((status) => status?.status === ROLLOUT_STATUS_CASH_NEGATIVE).length,
+    cashNegative,
   };
 }
 
@@ -2125,8 +2134,6 @@ function DistributionResults({
   normalizedScenarioSetInput,
   propertiesById,
   selection,
-  selectedFanMetric,
-  onSelectedFanMetricChange,
 }) {
   const { scenarioResult } = selection;
   const distribution = distributionResultView(scenarioResult);
@@ -2137,12 +2144,6 @@ function DistributionResults({
         scenarioSetInput={normalizedScenarioSetInput}
         result={result}
         propertiesById={propertiesById}
-      />
-      <MultiScenarioFanChart
-        scenarioSetInput={normalizedScenarioSetInput}
-        result={result}
-        selectedMetric={selectedFanMetric}
-        onSelectedMetricChange={onSelectedFanMetricChange}
       />
       <ScenarioValueSummary distribution={distribution} />
       <PropertySaleTaxDistributionPanel distribution={distribution} />
@@ -2384,6 +2385,14 @@ function AugurAppShell() {
             <div className="flex flex-wrap items-center justify-between gap-3">
               <ResultViewTabs viewMode={viewMode} onViewModeChange={setViewMode} />
             </div>
+            {viewMode === "distribution" && (
+              <MultiScenarioFanChart
+                scenarioSetInput={normalizedScenarioSetInput}
+                result={result}
+                selectedMetric={selectedFanMetric}
+                onSelectedMetricChange={setSelectedFanMetric}
+              />
+            )}
             <PropertyLocationPanel selection={selectedContext} />
             <ScenarioFinancingTaxPanel selection={selectedContext} />
             <MarketMetadataPanel result={result} />
@@ -2412,8 +2421,6 @@ function AugurAppShell() {
                 normalizedScenarioSetInput={normalizedScenarioSetInput}
                 propertiesById={propertiesById}
                 selection={selectedContext}
-                selectedFanMetric={selectedFanMetric}
-                onSelectedFanMetricChange={setSelectedFanMetric}
               />
             )}
           </div>

--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -88,7 +88,9 @@ props (Role + RoleBinding in `props/agent-rbac/`)
 monitoring, kube-system, longhorn-system, grocy-sf, grocy-vallejo, airlock, authentik,
 augur (plus `flux-system` in `shared-rbac/`). The augur binding lives cross-repo
 in `gaffer-private/k8s/augur/agent-rbac/` since augur itself is reconciled from
-gaffer-private.
+gaffer-private. The augur agent-rbac directory also defines an in-namespace Role
+granting `pods/exec`, `pods/attach`, and `pods/portforward` for debugging the
+single-replica augur deployment.
 
 ## Adding Agent RBAC for a New Service
 


### PR DESCRIPTION
## Summary

- **Distribution view layout:** `MultiScenarioFanChart` now renders at the top of the right column (above the property/location panels) when the distribution tab is active. The fan chart is what users come to the distribution tab for; the property/location/financing context is reference material that belongs below.
- **Cash-negative count fix:** `rolloutStatusSummary` was filtering on `status === CASH_NEGATIVE`, but the backend can also mark a rollout `FAILED` (obligation default) — and a FAILED rollout that crossed zero cash still populates `first_negative_cash_month_index`. The old filter hid those, producing the "P50 cash is negative but 0/N rollouts are cash negative" inconsistency. The count now considers any rollout where cash dipped below zero, regardless of obligation-failure status.
- **Docs:** noted in `cluster/k8s/agents/claude-rbac/README.md` that the cross-repo augur agent-rbac directory also grants `pods/exec`/`pods/attach`/`pods/portforward` (companion change in `gaffer-private`).

## Investigation notes (perf, not landed here)

The user flagged the deployed augur as "unusably slow." Logs show only `/healthz` chatter and rare `POST /api/scenario_sets/run` 200s — no errors. Memory is 270 MiB / 4 GiB limit. CPU limit is **1 core**, and `simulate_set(...)` runs synchronously inside the FastAPI async handler (`augur/core/backend.py:51-54`), so a long simulation pegs that core and blocks the event loop too. The per-month Python loop in `scenario_engine.py:1421` does substantial bookkeeping (list appends, accounting traces) on top of vectorized numpy. Direct timing from the agent session was blocked by missing `pods/exec`/`portforward` RBAC in the augur namespace; that's the companion gaffer-private PR.

## Test plan

- [ ] Open `/distribution`: confirm the fan chart is at the very top, above the property card.
- [ ] Open `/trajectory`: confirm layout unchanged (no fan chart at top; property/location card still leads).
- [ ] Run a scenario set where some rollouts default on obligations: confirm rollout-health "Cash negative" count includes them and that "P50 cash is negative but 0/N cash negative" no longer reproduces.
- [ ] Regenerate `augur/frontend/__screenshots__/distribution_*.png` goldens (regeneration in progress in this session).

https://claude.ai/code/session_01WsVZGoEeh3XbPnpeaPWrCt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsVZGoEeh3XbPnpeaPWrCt)_