### PR TITLE
study_casino: drop schema-app duplication; reuse real FastAPI app

### DIFF
--- a/x/auragon_study_casino/BUILD.bazel
+++ b/x/auragon_study_casino/BUILD.bazel
@@ -91,7 +91,12 @@ py_library(
 py_library(
     name = "app",
     srcs = ["app.py"],
-    data = ["//x/auragon_study_casino/frontend:bundle"],
+    # The bundle is a runtime asset, not a build-time dependency of the
+    # library. Putting it on `:app` would create a cycle: `:export_schema_lib`
+    # imports `:app` to scrape OpenAPI, and the bundle transitively depends on
+    # `:schema_zod` (via the generated zod imports in sync.js), which depends
+    # back on `:export_schema_bin`. The bundle is carried on `:server` /
+    # `:server_bin` instead, the targets that actually run the FastAPI app.
     visibility = ["//visibility:public"],
     deps = [
         ":actions",
@@ -114,11 +119,10 @@ py_library(
     name = "export_schema_lib",
     srcs = ["export_schema.py"],
     deps = [
-        ":actions",
-        ":events",
+        ":app",
+        ":config",
         ":state",
-        ":stats",
-        "@pypi//fastapi",
+        ":store",
     ],
 )
 
@@ -131,6 +135,7 @@ py_binary(
 
 py_binary(
     name = "server",
+    data = ["//x/auragon_study_casino/frontend:bundle"],
     main_module = "x.auragon_study_casino.app",
     visibility = ["//visibility:public"],
     deps = [":app"],
@@ -211,6 +216,7 @@ py_test(
 
 aspect_py_binary(
     name = "server_bin",
+    data = ["//x/auragon_study_casino/frontend:bundle"],
     main = "app.py",
     deps = [":app"],
 )

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -224,13 +224,20 @@ def _mutate_blackjack_step(s: Session, username: str, hand_id: str, move: str, r
     )
 
 
-def create_app(settings: Settings) -> FastAPI:
+def create_app(settings: Settings, *, store: SqlStore | None = None) -> FastAPI:
+    """Build the FastAPI app, including all routes.
+
+    `store` is injectable so `export_schema.py` can scrape `app.openapi()`
+    against a stub store without a live database — handlers never execute
+    during OpenAPI extraction, only their signatures matter.
+    """
     frontend_dist = settings.frontend_dist_dir or (Path(__file__).parent / "frontend" / "dist")
 
     # One shared-schema store backs every user; per-user scoping is by
     # `user_id` column. The store seeds a balance row + default prize
     # catalog on first contact for any new user.
-    store = SqlStore(settings.database_url)
+    if store is None:
+        store = SqlStore(settings.database_url)
 
     oidc = settings.oidc_config()
     current_user_dep = make_current_user_dep(oidc.session_secret if oidc else None)

--- a/x/auragon_study_casino/export_schema.py
+++ b/x/auragon_study_casino/export_schema.py
@@ -1,170 +1,50 @@
 """Export the Study Casino API OpenAPI schema to stdout.
 
-Schema-only FastAPI app: every route declares the same request/response models
-as the real backend in `app.py`, but the handler bodies raise — `app.openapi()`
-only consults the route signatures. The frontend codegen target
-`//x/auragon_study_casino/frontend/lib:schema_zod` consumes this JSON to emit
-Zod schemas the frontend parses at the fetch boundary.
+Builds the real FastAPI app from `app.py` with a stub `SqlStore` so route
+handlers are registered with their real request/response models without
+needing a live database. `app.openapi()` only inspects route signatures —
+handler bodies (which would touch the store) are never invoked here.
 
-Keeping this separate from `app.py` (which creates a real `SqlStore` on the
-configured Postgres URL) means schema export has zero runtime dependencies —
-no DB, no settings, no auth secrets.
+The output JSON feeds `//x/auragon_study_casino/frontend/lib:schema_zod`,
+which runs `@hey-api/openapi-ts --plugins zod` to produce
+`lib/api/schema.zod.mjs` for the frontend's fetch-boundary validators.
 """
 
 from __future__ import annotations
 
 import json
-from typing import NoReturn
+from typing import Any, cast
 
-from fastapi import FastAPI
-
-from x.auragon_study_casino.actions import (
-    ActionResponse,
-    AddPastSessionRequest,
-    BlackjackDealRequest,
-    BlackjackHandRequest,
-    ConvertRequest,
-    DeleteSessionRequest,
-    EditSessionRequest,
-    ImportRequest,
-    PrizeCreateRequest,
-    PrizeDeleteRequest,
-    PrizeRedeemRequest,
-    ResetRequest,
-    RouletteSpinRequest,
-    SessionCompleteRequest,
-    SlotsSpinRequest,
-)
-from x.auragon_study_casino.events import GameEventRead, LedgerEventRead
-from x.auragon_study_casino.state import (
-    AdminUsersResponse,
-    HealthResponse,
-    MeResponse,
-    StateDump,
-    WsStateChangedMessage,
-)
-from x.auragon_study_casino.stats import CasinoStats
+from x.auragon_study_casino.app import create_app
+from x.auragon_study_casino.config import Settings
+from x.auragon_study_casino.state import WsStateChangedMessage
+from x.auragon_study_casino.store import SqlStore
 
 
-def _stub() -> NoReturn:
-    raise RuntimeError("schema-only route")
+class _StubStore:
+    """`SqlStore` stand-in whose every method raises. The schema-export
+    code path constructs the FastAPI app to scrape `app.openapi()`; routes
+    register their signatures but their bodies (which call into the store)
+    never run."""
 
+    def __getattr__(self, name: str) -> Any:
+        def _unreachable(*_: object, **__: object) -> Any:
+            raise RuntimeError(f"schema-only: SqlStore.{name} must not be called")
 
-def create_schema_app() -> FastAPI:
-    app = FastAPI(title="Study Casino")
-
-    @app.get("/healthz", response_model=HealthResponse)
-    def healthz() -> HealthResponse:
-        return _stub()
-
-    @app.get("/me", response_model=MeResponse)
-    def me() -> MeResponse:
-        return _stub()
-
-    @app.get("/state", response_model=StateDump)
-    def get_state() -> StateDump:
-        return _stub()
-
-    @app.get("/admin/users", response_model=AdminUsersResponse)
-    def admin_users() -> AdminUsersResponse:
-        return _stub()
-
-    @app.get("/admin/state", response_model=StateDump)
-    def admin_state() -> StateDump:
-        return _stub()
-
-    @app.get("/game-events", response_model=list[GameEventRead])
-    def list_game_events() -> list[GameEventRead]:
-        return _stub()
-
-    @app.get("/ledger-events", response_model=list[LedgerEventRead])
-    def list_ledger_events() -> list[LedgerEventRead]:
-        return _stub()
-
-    @app.get("/casino/stats", response_model=CasinoStats)
-    def casino_stats() -> CasinoStats:
-        return _stub()
-
-    @app.get("/admin/casino/stats", response_model=CasinoStats)
-    def admin_casino_stats() -> CasinoStats:
-        return _stub()
-
-    @app.post("/actions/session/complete", response_model=ActionResponse)
-    def session_complete(_: SessionCompleteRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/session/add-past", response_model=ActionResponse)
-    def session_add_past(_: AddPastSessionRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/session/edit", response_model=ActionResponse)
-    def session_edit(_: EditSessionRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/session/delete", response_model=ActionResponse)
-    def session_delete(_: DeleteSessionRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/convert", response_model=ActionResponse)
-    def convert(_: ConvertRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/prize/create", response_model=ActionResponse)
-    def prize_create(_: PrizeCreateRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/prize/delete", response_model=ActionResponse)
-    def prize_delete(_: PrizeDeleteRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/prize/redeem", response_model=ActionResponse)
-    def prize_redeem(_: PrizeRedeemRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/import", response_model=ActionResponse)
-    def import_state(_: ImportRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/actions/reset", response_model=ActionResponse)
-    def reset_state(_: ResetRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/slots/spin", response_model=ActionResponse)
-    def slots_spin(_: SlotsSpinRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/roulette/spin", response_model=ActionResponse)
-    def roulette_spin(_: RouletteSpinRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/blackjack/deal", response_model=ActionResponse)
-    def blackjack_deal(_: BlackjackDealRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/blackjack/hit", response_model=ActionResponse)
-    def blackjack_hit(_: BlackjackHandRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/blackjack/stand", response_model=ActionResponse)
-    def blackjack_stand(_: BlackjackHandRequest) -> ActionResponse:
-        return _stub()
-
-    @app.post("/casino/blackjack/double", response_model=ActionResponse)
-    def blackjack_double(_: BlackjackHandRequest) -> ActionResponse:
-        return _stub()
-
-    # /ws messages are not HTTP endpoints — FastAPI doesn't emit them into
-    # the OpenAPI schema. Declare a schema-only POST so the message body type
-    # lands in `components.schemas` for the frontend.
-    @app.post("/_ws_state_changed", response_model=WsStateChangedMessage, include_in_schema=True)
-    def _ws_state_changed(_: WsStateChangedMessage) -> WsStateChangedMessage:
-        return _stub()
-
-    return app
+        return _unreachable
 
 
 def main() -> None:
-    print(json.dumps(create_schema_app().openapi(), indent=2))
+    settings = Settings(database_url="stub://schema-only")
+    app = create_app(settings, store=cast(SqlStore, _StubStore()))
+    schema = app.openapi()
+    # FastAPI doesn't emit WebSocket frame schemas — there are no
+    # `response_model` annotations on websocket routes. Inject the
+    # `/ws` payload model so the frontend can validate incoming frames.
+    schema.setdefault("components", {}).setdefault("schemas", {})["WsStateChangedMessage"] = (
+        WsStateChangedMessage.model_json_schema(ref_template="#/components/schemas/{model}")
+    )
+    print(json.dumps(schema, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Builds on #1663. Replaces the duplicated route declarations in
`export_schema.py` (which re-listed every endpoint and would rot every time
a new route was added) with a thin wrapper around the real `create_app()`.

## Changes

- `create_app(settings, *, store: SqlStore | None = None)` — accepts an
  injectable store. If unset, behaves exactly as before (constructs
  `SqlStore(settings.database_url)`).
- `export_schema.py` shrinks to ~30 lines: build a real `Settings`, build a
  `_StubStore` whose `__getattr__` returns a callable that raises, call
  `create_app(...)`, scrape `app.openapi()`. Handler bodies are never
  executed during OpenAPI extraction, so the stub never gets called.
- The Bazel cycle this exposed (`:app → bundle → sync → schema_zod →
  :export_schema_bin → :app`) is broken by moving the frontend bundle's
  `data` dep from `:app` onto `:server` / `:server_bin` — the targets that
  actually serve the dist. The library itself doesn't need the bundle at
  analysis time.
- `/ws` payload (`WsStateChangedMessage`) isn't auto-discovered by FastAPI
  (no `response_model` on WebSocket routes), so `export_schema.py` injects
  it into `components.schemas` after `app.openapi()`.

Net: -159 / +52 lines.

## Test plan

- [x] `bbr build //x/auragon_study_casino/...` — green
- [x] `bbr test //x/auragon_study_casino/...` — 7/7 pass (incl. visual
      golden test and e2e browser smoke)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E13nc4iaZEZ5shtEfkr4qJ)_