### PR TITLE
study_casino: type ActionMutation.game_event and ImportRequest.data

### DIFF
--- a/x/auragon_study_casino/AGENTS.md
+++ b/x/auragon_study_casino/AGENTS.md
@@ -18,7 +18,11 @@ fetch boundary in `sync.js`.
    new variant to `ActionResult` in `actions.py` if the result shape is
    genuinely new (extra="forbid" + a unique required-field set is what
    lets the Pydantic union discriminate at parse time).
-3. Update `sync.js` (or `use_casino.js`) to parse the response through the
+3. If the endpoint emits a `game_events` row, return an
+   `ActionMutation(game_event=GameEventMutation(...))` — the outcome
+   inside it must be one of `RouletteOutcome` / `SlotsOutcome` /
+   `BlackjackOutcome` (in `events.py`).
+4. Update `sync.js` (or `use_casino.js`) to parse the response through the
    corresponding `z<ResponseModel>` schema.
 
 `bbr build //x/auragon_study_casino/...` regenerates `schema.zod.mjs`

--- a/x/auragon_study_casino/actions.py
+++ b/x/auragon_study_casino/actions.py
@@ -9,9 +9,9 @@ other tabs of the same user know to refetch). Every action carries a
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from x.auragon_study_casino.events import Card, GameEventRead, LedgerEventRead, RouletteOutcome, SlotsOutcome
 
@@ -242,8 +242,65 @@ class PrizeRedeemRequest(ActionRequest):
     prize_id: str = Field(min_length=1, max_length=128)
 
 
+class ImportSession(BaseModel):
+    """A row inside `ImportData.sessions`.
+
+    `extra="allow"` and `validation_alias` accommodate legacy exports — older
+    frontend versions wrote `endedAt` (camelCase) and sometimes carried
+    extra fields like `subject_color` we don't want to reject. The
+    importer reads typed attributes and falls back to defaults for anything
+    absent.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    subject: str = "Imported"
+    seconds: int = 0
+    ended_at_ms: int = Field(default=0, validation_alias=AliasChoices("ended_at_ms", "endedAt"))
+
+
+class ImportPrize(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = None
+    name: str = "Imported prize"
+    cost: int = 1
+
+
+class ImportPrizeLog(BaseModel):
+    """A row inside `ImportData.prize_log` — legacy `at` (camelCase) accepted."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    name: str = "Imported prize"
+    cost: int = 0
+    at_ms: int = Field(default=0, validation_alias=AliasChoices("at_ms", "at"))
+
+
+class ImportData(BaseModel):
+    """Payload for `POST /actions/import`.
+
+    Mirrors what `useCasino.exportData()` writes to disk. Older exports
+    (`version` < 4) carried fewer fields; `extra="allow"` keeps unknowns
+    (`version`, `exportedAt`, `activeSession`) from triggering a validation
+    error on a legacy restore. `prizes=None` opts into the default catalog;
+    `prize_log` accepts both snake and camel keys for the same legacy
+    reasons as the per-row models.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    credits: int = 0
+    tokens: int = 0
+    sessions: list[ImportSession] = Field(default_factory=list)
+    prizes: list[ImportPrize] | None = None
+    prize_log: list[ImportPrizeLog] | None = Field(default=None, validation_alias=AliasChoices("prize_log", "prizeLog"))
+
+
 class ImportRequest(ActionRequest):
-    data: dict[str, Any]
+    data: ImportData
 
 
 class ResetRequest(ActionRequest):

--- a/x/auragon_study_casino/app.py
+++ b/x/auragon_study_casino/app.py
@@ -46,7 +46,7 @@ import time
 import uuid
 from collections import defaultdict
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
@@ -86,7 +86,14 @@ from x.auragon_study_casino.actions import (
 )
 from x.auragon_study_casino.auth import create_oidc_router, decode_session_token, make_current_user_dep
 from x.auragon_study_casino.config import Settings
-from x.auragon_study_casino.events import GameEventRead, LedgerEventRead
+from x.auragon_study_casino.events import (
+    BlackjackOutcome,
+    GameEventMutation,
+    GameEventRead,
+    LedgerEventRead,
+    RouletteOutcome,
+    SlotsOutcome,
+)
 from x.auragon_study_casino.games import (
     RNG_VERSION,
     SecretsRandom,
@@ -226,15 +233,16 @@ def _mutate_blackjack_step(s: Session, username: str, hand_id: str, move: str, r
             settlement=settlement,
         )
     )
-    game_event: dict[str, Any] | None = None
+    game_event: GameEventMutation | None = None
     if settlement is not None:
-        game_event = {
-            "game": "blackjack",
-            "wager_credits": current_wager,
-            "payout_tokens": settlement.payout_tokens,
-            "outcome": settlement.outcome
-            | {"initial_wager": row.wager_credits, "doubled": current_wager > row.wager_credits},
-        }
+        game_event = GameEventMutation(
+            game="blackjack",
+            wager_credits=current_wager,
+            payout_tokens=settlement.payout_tokens,
+            outcome=BlackjackOutcome(
+                **settlement.outcome, initial_wager=row.wager_credits, doubled=current_wager > row.wager_credits
+            ),
+        )
     return ActionMutation(
         result=result,
         details={"hand_id": hand_id, "move": move},
@@ -587,12 +595,12 @@ def create_app(settings: Settings, *, store: SqlStore | None = None) -> FastAPI:
             return ActionMutation(
                 result=SlotsActionResult(**settlement.outcome, payout_tokens=settlement.payout_tokens),
                 details={"wager_credits": body.wager_credits},
-                game_event={
-                    "game": "slots",
-                    "wager_credits": body.wager_credits,
-                    "payout_tokens": settlement.payout_tokens,
-                    "outcome": settlement.outcome,
-                },
+                game_event=GameEventMutation(
+                    game="slots",
+                    wager_credits=body.wager_credits,
+                    payout_tokens=settlement.payout_tokens,
+                    outcome=SlotsOutcome(**settlement.outcome),
+                ),
                 rng_version=RNG_VERSION,
             )
 
@@ -616,12 +624,12 @@ def create_app(settings: Settings, *, store: SqlStore | None = None) -> FastAPI:
             return ActionMutation(
                 result=RouletteActionResult(**settlement.outcome, payout_tokens=settlement.payout_tokens),
                 details={"wager_credits": body.wager_credits, "bet_type": body.bet_type, "bet_number": body.bet_number},
-                game_event={
-                    "game": "roulette",
-                    "wager_credits": body.wager_credits,
-                    "payout_tokens": settlement.payout_tokens,
-                    "outcome": settlement.outcome,
-                },
+                game_event=GameEventMutation(
+                    game="roulette",
+                    wager_credits=body.wager_credits,
+                    payout_tokens=settlement.payout_tokens,
+                    outcome=RouletteOutcome(**settlement.outcome),
+                ),
                 rng_version=RNG_VERSION,
             )
 
@@ -681,12 +689,12 @@ def create_app(settings: Settings, *, store: SqlStore | None = None) -> FastAPI:
                 )
             )
             game_event = (
-                {
-                    "game": "blackjack",
-                    "wager_credits": body.wager_credits,
-                    "payout_tokens": settlement.payout_tokens,
-                    "outcome": settlement.outcome | {"initial_wager": body.wager_credits, "doubled": False},
-                }
+                GameEventMutation(
+                    game="blackjack",
+                    wager_credits=body.wager_credits,
+                    payout_tokens=settlement.payout_tokens,
+                    outcome=BlackjackOutcome(**settlement.outcome, initial_wager=body.wager_credits, doubled=False),
+                )
                 if settlement
                 else None
             )

--- a/x/auragon_study_casino/events.py
+++ b/x/auragon_study_casino/events.py
@@ -70,6 +70,20 @@ _OUTCOME_BY_GAME: dict[str, type[RouletteOutcome] | type[SlotsOutcome] | type[Bl
 }
 
 
+class GameEventMutation(BaseModel):
+    """Per-action fields a mutator emits when it wants to write a
+    `game_events` row. `run_server_action` adds the persistence-side fields
+    (id, occurred_at_ms, credits/tokens before/after, etc.) at commit time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    game: Literal["roulette", "slots", "blackjack"]
+    wager_credits: int
+    payout_tokens: int
+    outcome: GameOutcome
+
+
 class GameEventRead(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/x/auragon_study_casino/store.py
+++ b/x/auragon_study_casino/store.py
@@ -25,9 +25,10 @@ from sqlalchemy import create_engine, delete, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from x.auragon_study_casino.actions import ActionResult
+from x.auragon_study_casino.actions import ActionResult, ImportData
 from x.auragon_study_casino.events import (
     BlackjackOutcome,
+    GameEventMutation,
     GameEventRead,
     GameOutcome,
     LedgerEventRead,
@@ -88,15 +89,16 @@ class ActionMutation:
     """Result returned by a server-action mutator before persistence.
 
     `result` is the typed payload that surfaces as `ActionResponse.result`
-    on the wire. `details` and `game_event` stay loosely typed (`dict`) —
-    they're persisted as JSON to `ledger_events.details_json` and
-    `game_events.outcome_json` respectively, and aren't part of the
-    frontend's read surface.
+    on the wire. `game_event` is the typed payload that gets persisted to
+    `game_events.outcome_json` and re-read as `GameEventRead` by the
+    casino-stats and audit-log endpoints. `details` stays loosely typed —
+    it's audit metadata persisted to `ledger_events.details_json` and not
+    part of the frontend's read surface.
     """
 
     result: ActionResult
     details: dict[str, Any] | None = None
-    game_event: dict[str, Any] | None = None
+    game_event: GameEventMutation | None = None
     rng_version: str | None = None
     rules_version: str = RULES_VERSION
 
@@ -317,7 +319,7 @@ class SqlStore:
 
     # ── Helpers used by import/reset mutators ───────────────────────────────
 
-    def replace_state_for_import(self, s: Session, username: str, data: dict[str, Any]) -> None:
+    def replace_state_for_import(self, s: Session, username: str, data: ImportData) -> None:
         """Wipe sessions/prizes/prize_log + reset balance for `username`, then
         populate from the import payload. Must be called from within a
         `run_server_action` mutator (the surrounding transaction guarantees
@@ -327,42 +329,35 @@ class SqlStore:
         s.execute(delete(PrizeRow).where(PrizeRow.user_id == username))
         s.execute(delete(PrizeLogRow).where(PrizeLogRow.user_id == username))
         balance = self._balance(s, username)
-        balance.credits = int(data.get("credits", 0))
-        balance.tokens = int(data.get("tokens", 0))
+        balance.credits = data.credits
+        balance.tokens = data.tokens
 
-        for session in data.get("sessions", []) or []:
-            session_id = str(session.get("id") or f"imported-{uuid.uuid4()}")
+        for session in data.sessions:
             s.add(
                 SessionRow(
-                    id=session_id,
+                    id=session.id or f"imported-{uuid.uuid4()}",
                     user_id=username,
-                    subject=str(session.get("subject") or "Imported"),
-                    seconds=int(session.get("seconds", 0)),
-                    ended_at_ms=int(session.get("endedAt") or session.get("ended_at_ms") or 0),
+                    subject=session.subject,
+                    seconds=session.seconds,
+                    ended_at_ms=session.ended_at_ms,
                 )
             )
 
-        prizes_data = data.get("prizes") or _DEFAULT_PRIZES_AS_DICTS
-        for prize in prizes_data:
-            prize_id = str(prize.get("id") or f"p-{uuid.uuid4()}")
-            s.add(
-                PrizeRow(
-                    id=prize_id,
-                    user_id=username,
-                    name=str(prize.get("name") or "Imported prize"),
-                    cost=int(prize.get("cost", 1)),
-                )
-            )
+        if data.prizes is None:
+            for prize_id, name, cost in _DEFAULT_PRIZES:
+                s.add(PrizeRow(id=prize_id, user_id=username, name=name, cost=cost))
+        else:
+            for prize in data.prizes:
+                s.add(PrizeRow(id=prize.id or f"p-{uuid.uuid4()}", user_id=username, name=prize.name, cost=prize.cost))
 
-        for entry in data.get("prizeLog") or data.get("prize_log") or []:
-            entry_id = str(entry.get("id") or f"imported-redemption-{uuid.uuid4()}")
+        for entry in data.prize_log or []:
             s.add(
                 PrizeLogRow(
-                    id=entry_id,
+                    id=entry.id or f"imported-redemption-{uuid.uuid4()}",
                     user_id=username,
-                    name=str(entry.get("name") or "Imported prize"),
-                    cost=int(entry.get("cost", 0)),
-                    at_ms=int(entry.get("at") or entry.get("at_ms") or 0),
+                    name=entry.name,
+                    cost=entry.cost,
+                    at_ms=entry.at_ms,
                 )
             )
 
@@ -433,7 +428,7 @@ class SqlStore:
         username: str,
         client_event_id: str,
         server_at_ms: int,
-        event: dict[str, Any],
+        event: GameEventMutation,
         credits_before: int,
         credits_after: int,
         tokens_before: int,
@@ -448,18 +443,18 @@ class SqlStore:
             client_event_id=client_event_id,
             server_at_ms=server_at_ms,
             occurred_at_ms=server_at_ms,
-            game=str(event["game"]),
+            game=event.game,
             event_type="settle",
             source="server_resolved",
-            wager_credits=int(event["wager_credits"]),
-            payout_tokens=int(event["payout_tokens"]),
+            wager_credits=event.wager_credits,
+            payout_tokens=event.payout_tokens,
             credits_before=credits_before,
             credits_after=credits_after,
             tokens_before=tokens_before,
             tokens_after=tokens_after,
             server_credits=server_credits,
             server_tokens=server_tokens,
-            outcome_json=self._json(event["outcome"]),
+            outcome_json=event.outcome.model_dump_json(),
             rules_version=rules_version,
             rng_version=rng_version,
         )
@@ -734,8 +729,3 @@ def _blackjack_stats(events: list[GameEventRead]) -> BlackjackStats:
         by_dealer_upcard=_blackjack_upcard_slices(events),
         by_doubled=_blackjack_doubled_slices(events),
     )
-
-
-_DEFAULT_PRIZES_AS_DICTS: list[dict[str, Any]] = [
-    {"id": prize_id, "name": name, "cost": cost} for prize_id, name, cost in _DEFAULT_PRIZES
-]

--- a/x/auragon_study_casino/test_store.py
+++ b/x/auragon_study_casino/test_store.py
@@ -9,7 +9,7 @@ import pytest_bazel
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from x.auragon_study_casino.actions import ConvertResult, ImportResult, ResetResult
+from x.auragon_study_casino.actions import ConvertResult, ImportData, ImportPrize, ImportResult, ResetResult
 from x.auragon_study_casino.models import BalanceRow, GameEventRow, StateSnapshotRow
 from x.auragon_study_casino.state import BalanceRead
 from x.auragon_study_casino.store import ActionMutation, ActionRejectedError, ServerActionResult, SqlStore
@@ -134,13 +134,9 @@ def test_snapshot_reason_writes_state_snapshots_row(store: SqlStore) -> None:
         store.replace_state_for_import(
             s,
             _U,
-            {
-                "credits": 11,
-                "tokens": 22,
-                "sessions": [],
-                "prizes": [{"id": "p-only", "name": "Only", "cost": 5}],
-                "prize_log": [],
-            },
+            ImportData(
+                credits=11, tokens=22, sessions=[], prizes=[ImportPrize(id="p-only", name="Only", cost=5)], prize_log=[]
+            ),
         )
         return ActionMutation(result=ImportResult(imported=True))
 


### PR DESCRIPTION
## Summary

Closes out the wire-typing arc. The previous PR (#1666) typed
`ActionResponse.result` on the response side; the two remaining
`dict[str, Any]` holes were on the mutation side:

- `ActionMutation.game_event: dict[str, Any] | None` — the loose
  representation of a row about to be written to `game_events`
- `ImportRequest.data: dict[str, Any]` — the messy legacy-export payload
  accepted by `/actions/import`

## `GameEventMutation`

New typed model in `events.py`:

    game: Literal["roulette", "slots", "blackjack"]
    wager_credits: int
    payout_tokens: int
    outcome: GameOutcome   # RouletteOutcome | SlotsOutcome | BlackjackOutcome

Casino handlers now construct typed outcomes directly —
`SlotsOutcome(**settlement.outcome)`,
`BlackjackOutcome(**settlement.outcome, initial_wager=..., doubled=...)` —
instead of dict merges. `_game_event_row` reads typed attributes and
serializes the outcome with `event.outcome.model_dump_json()`.

## `ImportData`

New `ImportData` + nested `ImportSession` / `ImportPrize` /
`ImportPrizeLog` in `actions.py`.

Wire format unchanged. `AliasChoices` accepts the legacy camelCase field
names (`endedAt`, `at`, `prizeLog`) the older exporter emitted, and
`extra="allow"` keeps unknown top-level metadata (`version`, `exportedAt`,
`activeSession`) from triggering validation errors on a legacy restore.
`replace_state_for_import` now reads typed attributes — the previous
`int(data.get(...) or data.get(...) or 0)` gymnastics is gone.

## Other

- `_DEFAULT_PRIZES_AS_DICTS` deleted (was dead — importer now reads
  `_DEFAULT_PRIZES` directly).
- `AGENTS.md` checklist gains a step for typed `GameEventMutation` on new
  endpoints that write to `game_events`.

## Test plan

- [x] `bbr build //x/auragon_study_casino/...` — green (mypy clean)
- [x] `bbr test //x/auragon_study_casino/...` — 7/7 pass (test fixtures
      use `ImportData(...)` + `ImportPrize(...)` instead of dicts;
      `replace_state_for_import` call updated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E13nc4iaZEZ5shtEfkr4qJ)_