### PR TITLE
debundler: RED tests for dataflow-aware S-chain emission

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -80,6 +80,7 @@ rust_library(
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
         "at_init_promotion_fndecl_direct_read_test",
+        "at_init_s_chain_dataflow_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -1,0 +1,274 @@
+//! RED tests: the S-chain should consult per-statement dataflow
+//! before emitting a `Sequenced` owner edge between two
+//! consecutive impure top-level statements.
+//!
+//! Background. `graph.rs` (S-chain emission around lines
+//! 469-478) walks every impure top-level statement in source
+//! order and unconditionally emits
+//!
+//! ```ignore
+//! raw_edges.push((curr, prev, EdgeReason::sequenced(curr.ord)));
+//! ```
+//!
+//! This is the transitive reduction of the total order over
+//! impure statements. It is sound (every realizable schedule
+//! satisfies it), but it is maximally conservative — it
+//! manufactures an init-order constraint between every adjacent
+//! pair of impure statements regardless of whether they
+//! actually interact via dataflow.
+//!
+//! ESM evaluates modules to completion in some linker-chosen
+//! order. Two impure statements that touch disjoint pieces of
+//! observable state are commutative across that boundary: the
+//! relative source-order between them is irrelevant to anyone
+//! else (no reader observes both an intermediate "after A,
+//! before B" and a "after B, before A" state because there is
+//! no shared cell to observe).
+//!
+//! Proposed refinement (the "full dataflow" S-chain): for each
+//! impure top-level statement, compute its write set and read
+//! set (rebinds + global property mutations + property writes;
+//! reads from bindings + global properties); emit
+//! `Sequenced(prev → curr)` only when
+//!
+//! ```text
+//! prev.writes ∩ (curr.reads ∪ curr.writes) ≠ ∅
+//! ```
+//!
+//! This is strictly a relaxation of the existing chain (we
+//! never add an edge that wasn't there before), so soundness is
+//! straightforward: any realizable schedule of the relaxed
+//! graph is also realizable for the strict graph, and any
+//! schedule violated by the strict graph but not the relaxed
+//! one corresponds to a swap of two disjoint impure statements
+//! — observably indistinguishable.
+//!
+//! ## Patterns covered
+//!
+//! Anonymized from a real over-conservative S-chain observed
+//! in a large bundle's quotient cycle: 4 of 10 residual cut
+//! edges were S-chain edges between owners that touched
+//! disjoint state.
+//!
+//! 1. **Disjoint global property writes.** Two impure
+//!    statements that each `globalThis.X = ...` distinct,
+//!    independent property keys. Today: S-edge chains them.
+//!    After fix: writes are `{globalThis.alpha}` vs
+//!    `{globalThis.beta}` — disjoint — no edge.
+//!
+//! 2. **Fresh-local-only allocation after a global write.** A
+//!    `globalThis.tag = ...` followed by a `new LocalClass()`
+//!    or `Object.freeze({...})` call whose effect is confined
+//!    to a fresh local value. Today: both are impure, S-edge
+//!    chains them. After fix: the fresh-alloc statement's
+//!    write set is just its own binding and its read set
+//!    doesn't intersect `globalThis.tag` — no edge.
+//!
+//! 3. **Independent cross-module inits.** Two modules each
+//!    construct a one-off instance of a local class whose
+//!    constructor only touches `this`. Today: S-edge chains
+//!    them. After fix: each statement writes only its own
+//!    binding (plus the fresh instance); read sets are
+//!    disjoint — no edge.
+//!
+//! ## Test shape
+//!
+//! Each test builds a fixture, inspects
+//! `owner_graph.json::edges`, and asserts that no
+//! `Sequenced` owner edge connects the two non-interacting
+//! statements (in either direction). The fixtures themselves
+//! run correctly under the materializer — the S-edge is a
+//! spurious extra constraint, not a cycle-closer in
+//! isolation. Real impact (the gaffer case) is when the
+//! spurious edge happens to land inside an SCC of other
+//! constraining edges and becomes a member of the cut.
+
+use analysis::{DepKind, OwnerGraphReport};
+use debundle_e2e_support::*;
+use serde::de::DeserializeOwned;
+use std::{fs, path::Path};
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> T {
+    serde_json::from_str(
+        &fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("read JSON report {}: {err}", path.display())),
+    )
+    .unwrap_or_else(|err| panic!("parse JSON report {}: {err}", path.display()))
+}
+
+fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
+    let node = graph
+        .nodes
+        .iter()
+        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
+        .unwrap_or_else(|| {
+            panic!(
+                "no owner-graph node declares binding `{binding}`; \
+                 nodes: {:#?}",
+                graph.nodes,
+            )
+        });
+    node.id.as_str()
+}
+
+fn sequenced_edges_between<'a>(
+    graph: &'a OwnerGraphReport,
+    a: &str,
+    b: &str,
+) -> Vec<&'a analysis::OwnerGraphEdgeReport> {
+    graph
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.edge_kind == DepKind::Sequenced
+                && ((edge.source == a && edge.target == b)
+                    || (edge.source == b && edge.target == a))
+        })
+        .collect()
+}
+
+#[test]
+fn s_chain_skips_disjoint_global_property_writes() {
+    // Two top-level impure statements, each writing a distinct
+    // `globalThis.<key>` property. Today's S-chain links the
+    // second statement to the first; with dataflow, the write
+    // sets `{globalThis.alpha}` and `{globalThis.beta}` are
+    // disjoint and the read sets are empty, so no S-edge is
+    // warranted.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const tagA = (globalThis.alpha = "alpha-val", "tag-a");
+const tagB = (globalThis.beta = "beta-val", "tag-b");
+console.log(tagA, tagB, globalThis.alpha, globalThis.beta);
+export { tagA, tagB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("tagA")]),
+            logical_module("mod_b", &[Member::new("tagB")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "tag-a tag-b alpha-val beta-val\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let owner_a = owner_for_binding(&graph, "tagA");
+    let owner_b = owner_for_binding(&graph, "tagB");
+    let offending = sequenced_edges_between(&graph, owner_a, owner_b);
+    assert!(
+        offending.is_empty(),
+        "no Sequenced edge should link `tagA`'s owner to `tagB`'s \
+         owner: the two statements write disjoint globalThis \
+         properties (alpha vs beta) and read no shared state, so \
+         their relative order is unobservable to any third party. \
+         Offending edges: {offending:#?}\n\nFull graph: {graph:#?}",
+    );
+}
+
+#[test]
+fn s_chain_skips_fresh_local_alloc_after_global_write() {
+    // `tagA` writes a globalThis property; `boxedB` allocates a
+    // fresh frozen object literal. The freeze is impure as a
+    // call (Object.freeze can throw on a non-object), but its
+    // observable effect is confined to the fresh local — no
+    // outside cell is touched. Dataflow:
+    //   tagA.writes  = {tagA, globalThis.tag}
+    //   tagA.reads   = {}
+    //   boxedB.writes = {boxedB}
+    //   boxedB.reads  = {Object}
+    // No intersection — no S-edge.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const tagA = (globalThis.tag = "first", "tag-a");
+const boxedB = Object.freeze({ kind: "fresh" });
+console.log(tagA, boxedB.kind, globalThis.tag);
+export { tagA, boxedB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("tagA")]),
+            logical_module("mod_b", &[Member::new("boxedB")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "tag-a fresh first\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let owner_a = owner_for_binding(&graph, "tagA");
+    let owner_b = owner_for_binding(&graph, "boxedB");
+    let offending = sequenced_edges_between(&graph, owner_a, owner_b);
+    assert!(
+        offending.is_empty(),
+        "no Sequenced edge should link `tagA` to `boxedB`: the \
+         Object.freeze of a fresh literal touches no outside \
+         state, so swapping the two statements is unobservable. \
+         Offending edges: {offending:#?}\n\nFull graph: {graph:#?}",
+    );
+}
+
+#[test]
+fn s_chain_skips_independent_cross_module_constructor_calls() {
+    // Two modules each call a constructor whose only effect is
+    // writing to its own freshly-allocated `this`. The
+    // constructors touch no shared cell. Today's S-chain links
+    // them; with dataflow, the write sets are each
+    // `{instance_X}` and the read sets are each `{ClassX}` —
+    // disjoint pairwise.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"class Holder1 { constructor() { this.kind = "h1"; } }
+class Holder2 { constructor() { this.kind = "h2"; } }
+const instA = new Holder1();
+const instB = new Holder2();
+console.log(instA.kind, instB.kind);
+export { Holder1, Holder2, instA, instB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("Holder1"), Member::new("instA")]),
+            logical_module("mod_b", &[Member::new("Holder2"), Member::new("instB")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "h1 h2\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let owner_a = owner_for_binding(&graph, "instA");
+    let owner_b = owner_for_binding(&graph, "instB");
+    let offending = sequenced_edges_between(&graph, owner_a, owner_b);
+    assert!(
+        offending.is_empty(),
+        "no Sequenced edge should link `instA`'s owner to \
+         `instB`'s owner: each `new HolderN()` only mutates its \
+         own `this`, so their cross-module init order is \
+         unobservable. Offending edges: {offending:#?}\n\nFull \
+         graph: {graph:#?}",
+    );
+}
+
+#[test]
+fn s_chain_keeps_edge_when_writes_overlap() {
+    // Sanity guard: the relaxation must NOT remove S-edges
+    // between statements that genuinely interact via dataflow.
+    // Both statements write `globalThis.shared` (the LAST one
+    // wins, and any reader of `globalThis.shared` observes the
+    // ordering). The edge must remain.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const tagA = (globalThis.shared = "from-a", "tag-a");
+const tagB = (globalThis.shared = "from-b", "tag-b");
+console.log(tagA, tagB, globalThis.shared);
+export { tagA, tagB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("tagA")]),
+            logical_module("mod_b", &[Member::new("tagB")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "tag-a tag-b from-b\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let owner_a = owner_for_binding(&graph, "tagA");
+    let owner_b = owner_for_binding(&graph, "tagB");
+    let kept = sequenced_edges_between(&graph, owner_a, owner_b);
+    assert!(
+        !kept.is_empty(),
+        "Sequenced edge between `tagA` and `tagB` must be kept: \
+         both statements write `globalThis.shared`, so any \
+         reader observes their relative order. Graph: {graph:#?}",
+    );
+}


### PR DESCRIPTION
## Summary

Files RED tests for a refinement of the S-chain emission in
`graph.rs:469-478`: skip the `Sequenced(prev → curr)` owner edge when
`prev`'s write set is disjoint from `curr`'s read/write set.

The current S-chain unconditionally links every adjacent pair of impure
top-level statements in source order. This is sound (every realizable
schedule satisfies it) but maximally conservative — it manufactures an
init-order constraint between every consecutive pair of impure
statements regardless of whether they actually share state.

## Motivating evidence

In a real bundle we were debundling, 4 of 10 residual cut edges in a
124→10 quotient cycle were spurious Sequenced edges between owners that
touched disjoint observable state:

- `const x = document.getElementById("app")` (DOM read; writes only the
  local binding) sequenced after a `Symbol.toStringTag` polyfill IIFE
  (writes `Symbol`) — disjoint global touches
- `const obj = Object.freeze({...})` sequenced after a bootstrap that
  writes `globalThis.someUnrelated` — fresh-local-only effect
- `const T = new SomeClass()` sequenced cross-module to an
  `env_config` initializer that touches disjoint state
- `logger(new BackendImpl())` sequenced to a prior `globalThis`
  write that the logger doesn't read

Each of these is the kind of pair the relaxation handles: their writes
don't intersect the other statement's reads or writes, so swapping
their evaluation order is unobservable to any reader.

## Proposed refinement

For each impure top-level statement, compute a (writes, reads) summary:

- **writes**: rebound bindings + `globalThis.<key>` property writes +
  member writes on bindings reachable from the statement
- **reads**: bindings read + `globalThis.<key>` property reads +
  member reads on bindings reachable from the statement

Then in the S-chain loop emit `Sequenced(prev → curr)` only when

```text
prev.writes ∩ (curr.reads ∪ curr.writes) ≠ ∅
```

The refinement is strictly a relaxation. Soundness:

- The strict chain is realizable ⇒ the relaxed chain is realizable
  (any schedule that satisfies the strict chain trivially satisfies the
  relaxed subset of edges).
- Any schedule violating the strict chain but not the relaxed one
  corresponds to a swap of two consecutive impure statements whose
  write/read sets are disjoint. No reader can distinguish "after A,
  before B" from "after B, before A" when neither cell touched by A is
  read by B and vice versa — so the swap is unobservable.

## RED tests

Three patterns + one over-relaxation guard, all using generic JS (no
references to the originating bundle):

1. **`s_chain_skips_disjoint_global_property_writes`** —
   `globalThis.alpha = ...` then `globalThis.beta = ...` in separate
   modules. Disjoint property keys, no read overlap.
2. **`s_chain_skips_fresh_local_alloc_after_global_write`** —
   `globalThis.tag = ...` then `const obj = Object.freeze({...})`.
   The `Object.freeze` only touches a fresh literal; no outside cell
   is read or written.
3. **`s_chain_skips_independent_cross_module_constructor_calls`** —
   two `new LocalClass()` in separate modules, each constructor only
   writes its own `this`.
4. **`s_chain_keeps_edge_when_writes_overlap`** (guard) — both
   statements write `globalThis.shared`. Any reader observes the
   ordering. The S-edge must remain after the refinement.

Each test builds a fixture, inspects `owner_graph.json::edges`, and
asserts that no `Sequenced` edge connects (or in the guard case, does
connect) the relevant owners.

The fixtures themselves run correctly under the materializer today —
the spurious S-edge isn't a cycle-closer in isolation. Real impact
appears only when such an edge lands inside an SCC of other
constraining edges and becomes a member of the cut.

## What this PR is and isn't

- It is: a failing-test specification for the dataflow-aware S-chain.
- It isn't: the implementation. Wiring the per-statement (writes,
  reads) summary into `facts.rs` and gating the emission loop in
  `graph.rs` is follow-up work. These tests become the acceptance
  criteria for that PR.

## Test plan

- [ ] `bbr test //devinfra/js/debundle/e2e:at_init_s_chain_dataflow_test`
  fails today (all four assertions fire RED on the relaxation candidates;
  the guard test should already be GREEN since the strict chain emits
  the overlap edge).
- [ ] Existing S-chain tests continue to pass:
  `bbr test //devinfra/js/debundle/e2e:realizability_test`.
- [ ] After the dataflow-aware refinement lands, all four tests turn
  GREEN.

https://claude.ai/code/session_9d29c3bf-a5e6-4ed8-b67b-1ecd5fe1ea31

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_