### PR TITLE
debundle: RED test for auto-grown export public-name collision

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -81,6 +81,7 @@ rust_library(
         "at_init_promotion_post_await_test",
         "at_init_promotion_fndecl_direct_read_test",
         "at_init_s_chain_dataflow_test",
+        "auto_grown_export_alias_collision_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/auto_grown_export_alias_collision_test.rs
+++ b/devinfra/js/debundle/e2e/auto_grown_export_alias_collision_test.rs
@@ -1,0 +1,81 @@
+//! RED test: when the chunk's source `export { … }` aliases a
+//! local binding to a public name `P`, and `auto_grown_residual_exports`
+//! would grow an export for a different local binding whose symbol
+//! is *also* `P`, the auto-grow pass produces a duplicate public
+//! export name and the chunk link-fails.
+//!
+//! Background. `lowering/exports.rs::auto_grown_residual_exports`
+//! gates each candidate against `pre_existing_entry_exports`, but
+//! that set stores LOCAL bindings (the `orig` side of `export {
+//! orig as exported }`). It never inspects the PUBLIC side — the
+//! `exported` names that are already taken in the chunk's emitted
+//! `export { … }` block. When a peeled module's body happens to
+//! reference a residual binding whose symbol happens to coincide
+//! with an alias used in the chunk's source export, the auto-grow
+//! pass blindly emits a fresh `export { <local> as <name> }`
+//! whose `<name>` collides with an existing public name.
+//!
+//! `validate_emitted_exports` (which runs late in the pipeline)
+//! catches the resulting duplicate-export module — surfacing the
+//! bug as a build-time error rather than a silent blank page in
+//! Chromium — but the fix belongs upstream: the auto-grow pass
+//! should consult the set of public names already exported (the
+//! `exported` side of named export specifiers and `ExportDecl`
+//! bindings) and either rename the new export to a non-colliding
+//! public name or skip it entirely.
+//!
+//! ## Generalized pattern
+//!
+//! Anonymized from a real failure observed in a large bundle
+//! (`static/index-DI2GynTv`), where the chunk's source export
+//! contained `BackgroundPattern as av` and the residual body
+//! also had a top-level `const av = …` binding referenced by a
+//! peeled module. Four public names (`a6`, `aI`, `av`, `bu`) all
+//! collided this way in a single rebuild.
+//!
+//! ## Fixture
+//!
+//! - `X` is a local binding the chunk exports under public name `av`.
+//! - `av` is a *different* top-level binding (a residual one,
+//!   never explicitly exported by the source).
+//! - `usesAv` is a function that reads `av`; the spec moves it to
+//!   `mod_b`, so `mod_b`'s body needs `import { av } from
+//!   '../entry'`.
+//! - The materializer's auto-grow pass sees `av` is referenced,
+//!   declared in the chunk, and not in
+//!   `pre_existing_entry_exports` (which holds only `{X, usesAv}`),
+//!   so it grows `export { av }` — colliding with the source's
+//!   `X as av`.
+//!
+//! ## Expected outcomes
+//!
+//! - **Today (RED)**: `validate_emitted_exports` rejects with a
+//!   duplicate-export error naming `av` in `entry.js`. The
+//!   fixture build fails at pipeline time.
+//! - **After the fix**: `auto_grown_residual_exports` either
+//!   renames the new export to a non-colliding public name
+//!   (e.g. `av$1`) or skips it (forcing the peeled module to
+//!   reach `av` by some other path the upstream invariant
+//!   allows). The fixture build succeeds and the entry runs.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn auto_grown_residual_exports_avoid_alias_collision() {
+    let mut opts = FixtureOpts::new(
+        r#"const X = "x-impl";
+const av = "av-impl";
+function usesAv() { return av; }
+console.log(X, av, usesAv());
+export { X as av, usesAv };
+"#,
+        vec![logical_module("mod_b", &[Member::new("usesAv")])],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let fixture = run_fixture(opts);
+    // Today the build never reaches this point — validate_emitted_exports
+    // rejects on duplicate public name `av`. After the fix to
+    // `auto_grown_residual_exports`, the entry runs and emits this
+    // line.
+    assert_entry_output(&fixture, "x-impl av-impl av-impl\n");
+}


### PR DESCRIPTION
## Summary

Files a failing e2e test pinning a bug in
`lowering/exports.rs::auto_grown_residual_exports`: the auto-grow
pass can produce a duplicate-export module that `validate_emitted_exports`
then rejects at the very end of the pipeline.

Already documented in the validator's own comment:

> the immediate one is `auto_grown_residual_exports` in
> `lowering/exports.rs`, which compares local binding names to
> `pre_existing_entry_exports` but never checks whether the public
> name it's about to grow would collide with an existing alias's
> public name.

## Root cause

`auto_grown_residual_exports` gates each candidate against
`pre_existing_entry_exports`, but that set tracks **local**
bindings (the `orig` side of `export { orig as exported }`). It
never inspects the **public** side — the `exported` names already
taken in the chunk's emitted `export { ... }` block.

When a peeled module's body references a residual binding whose
symbol happens to coincide with an alias used in the chunk's
source export, the auto-grow pass blindly emits
`export { <local> as <name> }` whose `<name>` collides.

## Fixture

```js
const X = "x-impl";
const av = "av-impl";
function usesAv() { return av; }
console.log(X, av, usesAv());
export { X as av, usesAv };
```

With logical module `mod_b` owning `usesAv`. The peeled module's
body references `av`; auto-grow emits `export { av }`, colliding
with the source's `X as av`. Pipeline rejects:

```
validate_emitted_exports: emitted JS contains duplicate `export` names
  chunk static/app file entry.js:
    `av` exported 2× at L5 (named), L? (named)
```

## Provenance

Observed on a real bundle (`static/index-DI2GynTv`) where four
public names (`a6`, `aI`, `av`, `bu`) all collided this way in a
single rebuild. The shape on the real bundle is the same as the
fixture: chunk's source export aliases inner bindings to short
public names; one of those public names happens to coincide with a
literal local binding referenced by a peeled module.

## Fix sketch (not in this PR)

Two options in `auto_grown_residual_exports`:

1. Build a set of public names already used in the chunk's source
   `export { ... }` block (the `exported` side of named export
   specifiers + every `ExportDecl` binding name). When the
   candidate's public name is in that set, either skip the
   candidate (forcing the peeled module to reach the binding by
   another path) or rename to a non-colliding public name
   (`<name>$1`).
2. Reuse `entry_renames` to derive the same public-name set
   directly.

Soundness: skipping is the simpler choice; the validator already
catches any path where this would surface a "moved module
references residual entry binding(s) not exported by entry"
rejection, so we'd at least swap one understandable failure for
another. Renaming would let the peel succeed without forcing the
upstream to relocate.

## Test plan

- [ ] `bbr test //devinfra/js/debundle/e2e:auto_grown_export_alias_collision_test`
  fails today (RED) with the duplicate-export error shown above.
- [ ] After the fix in `lowering/exports.rs`, the test turns
  GREEN: entry runs and emits `x-impl av-impl av-impl`.
- [ ] Existing `duplicate_export_test.rs` (which pins the
  source-level case) continues to pass — the validator behavior
  is unchanged.

https://claude.ai/code/session_9d29c3bf-a5e6-4ed8-b67b-1ecd5fe1ea31

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_