### PR TITLE
debundle/exports: avoid public-name collisions in auto-grown residual exports

### DIFF
--- a/devinfra/js/debundle/lowering/chunk_ast.rs
+++ b/devinfra/js/debundle/lowering/chunk_ast.rs
@@ -37,12 +37,25 @@ pub(super) struct ChunkAstAnalysis {
     /// existing source-level export — emitting a duplicate would be
     /// a `SyntaxError: Duplicate export of 'name'` at load time.
     pub(super) pre_existing_entry_exports: HashSet<Id>,
+    /// **Public** names the source chunk's entry already uses (the
+    /// `exported` side of `export { orig as exported }` specifiers
+    /// and the declared name of `export const foo = …` style
+    /// declarations). Distinct from `pre_existing_entry_exports`,
+    /// which is the **local** side. Consulted by
+    /// `auto_grown_residual_exports` so the auto-grown `export {
+    /// local as public }` doesn't reuse a public name that's
+    /// already taken — e.g. when entry has `export { X as av }` and
+    /// a peeled module references a different local binding named
+    /// `av`, growing the export under the same public name would
+    /// produce a duplicate-export `SyntaxError` at load time.
+    pub(super) pre_existing_public_export_names: HashSet<String>,
 }
 
 pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
     let mut imports = HashMap::<Id, RuntimeImportInfo>::new();
     let mut declarations = Vec::new();
     let mut pre_existing_entry_exports = HashSet::<Id>::new();
+    let mut pre_existing_public_export_names = HashSet::<String>::new();
     let mut destructure_siblings = BTreeMap::<String, BTreeSet<String>>::new();
     for (ordinal, item) in module.body.iter().enumerate() {
         let (names, exported) = top_level_declaration_names(item);
@@ -50,6 +63,10 @@ pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
         if !names.is_empty() {
             if exported {
                 pre_existing_entry_exports.extend(ids.iter().cloned());
+                // `export const foo = …` / `export function foo()` /
+                // `export class Foo {}` — the declared name is also
+                // the public name.
+                pre_existing_public_export_names.extend(names.iter().cloned());
             }
             declarations.push(TopLevelDecl {
                 ordinal,
@@ -60,7 +77,11 @@ pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
         }
         record_destructure_sibling_groups(item, &mut destructure_siblings);
         record_runtime_imports(item, &mut imports);
-        record_pre_existing_named_exports(item, &mut pre_existing_entry_exports);
+        record_pre_existing_named_exports(
+            item,
+            &mut pre_existing_entry_exports,
+            &mut pre_existing_public_export_names,
+        );
     }
     let declaration_by_name = declarations
         .iter()
@@ -72,6 +93,7 @@ pub(super) fn analyze_chunk_ast(module: &Module) -> ChunkAstAnalysis {
         declaration_by_name,
         destructure_siblings,
         pre_existing_entry_exports,
+        pre_existing_public_export_names,
     }
 }
 
@@ -111,7 +133,21 @@ pub(super) fn record_destructure_sibling_groups(
 /// because those don't bind a local name in entry. `ExportDecl`
 /// (e.g. `export const foo = …`) is already covered by
 /// `top_level_declaration_ids` returning `(ids, exported = true)`.
-pub(super) fn record_pre_existing_named_exports(item: &ModuleItem, out: &mut HashSet<Id>) {
+///
+/// Populates two parallel sets:
+/// - `local_out` — the `orig` (local-binding) side of each
+///   specifier, keyed on hygiene-aware `Id` so the emit-resolvability
+///   check in `auto_grown_residual_exports` matches the binding cells
+///   the analysis records.
+/// - `public_out` — the `exported` (public-name) side of each
+///   specifier (falls back to `orig`'s sym when no `as` rename is
+///   present). Keyed on bare `String` because export names are pure
+///   labels, not bound to a hygienic scope.
+pub(super) fn record_pre_existing_named_exports(
+    item: &ModuleItem,
+    local_out: &mut HashSet<Id>,
+    public_out: &mut HashSet<String>,
+) {
     let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
         return;
     };
@@ -122,12 +158,16 @@ pub(super) fn record_pre_existing_named_exports(item: &ModuleItem, out: &mut Has
         let ExportSpecifier::Named(specifier) = specifier else {
             continue;
         };
-        // The exported value is the local binding (`orig`); the
-        // public name (`exported`) is irrelevant to the
-        // emit-resolvability check, which keys off the local name.
-        if let ModuleExportName::Ident(ident) = &specifier.orig {
-            out.insert(ident.to_id());
-        }
+        let ModuleExportName::Ident(orig_ident) = &specifier.orig else {
+            continue;
+        };
+        local_out.insert(orig_ident.to_id());
+        let public_name = match &specifier.exported {
+            Some(ModuleExportName::Ident(ident)) => ident.sym.to_string(),
+            Some(ModuleExportName::Str(_)) => continue,
+            None => orig_ident.sym.to_string(),
+        };
+        public_out.insert(public_name);
     }
 }
 

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -173,6 +173,7 @@ pub(super) fn auto_grown_residual_exports(
     declaration_by_name: &HashMap<Id, usize>,
     binding_assignment: &HashMap<Id, usize>,
     pre_existing_entry_exports: &HashSet<Id>,
+    pre_existing_public_export_names: &HashSet<String>,
     entry_renames: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     let mut needed = BTreeSet::<String>::new();
@@ -194,6 +195,19 @@ pub(super) fn auto_grown_residual_exports(
             needed.insert(id.0.as_ref().to_string());
         }
     }
+    // `taken_public_names` accumulates every public name already
+    // committed to entry's export list — the source-level set we
+    // were handed, plus each new grown public name as we mint it.
+    // When a candidate's natural public name collides, suffix-mint
+    // a fresh `<name>$<n>` instead of skipping: skipping forces the
+    // peeled module's body reference to resolve as an unexported
+    // residual binding and `residual_entry_imports_for_moved_body`
+    // would bail with "moved module references residual entry
+    // binding(s) not exported by entry". The peeled module's
+    // importer side renames the import back to the original local
+    // sym via `EntryExport.{local_name, exported_name}`, so the
+    // mint is invisible to the moved body.
+    let mut taken_public_names = pre_existing_public_export_names.clone();
     needed
         .into_iter()
         .map(|name| {
@@ -201,7 +215,22 @@ pub(super) fn auto_grown_residual_exports(
                 .get(&name)
                 .cloned()
                 .unwrap_or_else(|| name.clone());
-            (final_local, name)
+            let public_name = mint_unique_public_name(&name, &mut taken_public_names);
+            (final_local, public_name)
         })
         .collect()
+}
+
+fn mint_unique_public_name(base: &str, taken: &mut HashSet<String>) -> String {
+    if taken.insert(base.to_string()) {
+        return base.to_string();
+    }
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{base}${suffix}");
+        if taken.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
 }

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -52,6 +52,13 @@ pub(super) struct LowerChunkInputs<'a> {
     /// emit a `Duplicate export of 'name'` clash with an existing
     /// source export.
     pub(super) pre_existing_entry_exports: &'a HashSet<Id>,
+    /// **Public** names entry already uses — the `exported` side of
+    /// the same `export { … }` block plus the declared name of any
+    /// `export const/function/class` declaration. Consulted by
+    /// `auto_grown_residual_exports` so the grown public name
+    /// suffix-mints (`<base>$1`) past any source-level alias
+    /// collision instead of emitting a duplicate.
+    pub(super) pre_existing_public_export_names: &'a HashSet<String>,
 }
 
 pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> {
@@ -73,6 +80,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         runtime_import_facts,
         chunk_renames,
         pre_existing_entry_exports,
+        pre_existing_public_export_names,
     } = inputs;
     let mut timings = PhaseTimings::default();
     let selected_ordinals = time_phase!(timings, "compute_selected_ordinals", {
@@ -334,6 +342,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             declaration_by_name,
             binding_assignment,
             pre_existing_entry_exports,
+            pre_existing_public_export_names,
             &entry_binding_renames,
         );
         if !auto_grow.is_empty() {

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -106,6 +106,7 @@ pub(super) fn materialize_logical_chunk(
         declaration_by_name,
         destructure_siblings,
         pre_existing_entry_exports,
+        pre_existing_public_export_names,
     } = chunk_ast_analysis;
     let requests = time_phase!(timings, "build_requests", {
         logical_requests_for_chunk(
@@ -650,6 +651,7 @@ pub(super) fn materialize_logical_chunk(
             chunk_renames: &chunk_renames_map,
             runtime_import_facts: &runtime_import_facts,
             pre_existing_entry_exports: &pre_existing_entry_exports,
+            pre_existing_public_export_names: &pre_existing_public_export_names,
         })
     })?;
     let LoweredChunk {


### PR DESCRIPTION
## Summary

Fixes the bug pinned by #1673. When the chunk's source
`export { … }` aliases a local binding to public name `P`, and a
peeled module references a *different* local binding whose own sym
is also `P`, `auto_grown_residual_exports` would blindly emit
`export { P }` — colliding with the source-level
`<orig> as P` and producing a load-time
`SyntaxError: Duplicate export of 'P'`. `validate_emitted_exports`
caught it at the very end of the pipeline; this moves the avoidance
upstream.

## Root cause

The gate against `pre_existing_entry_exports` checks only the
**local** side of `export { orig as exported }` specifiers. The
**public** side (the `exported` names already taken in the chunk's
emitted export block) was never consulted.

## Fix

- `ChunkAstAnalysis` gains
  `pre_existing_public_export_names: HashSet<String>` alongside
  the existing local-id set. Populated from the `exported` side of
  named export specifiers (falling back to `orig`'s sym when no
  `as` rename is present) and from `ExportDecl` declared names.
- `auto_grown_residual_exports` takes the public-name set and
  mint-checks each candidate's public name against it; on collision
  it **suffix-mints** `<base>$1`, `<base>$2`, … rather than
  skipping. Skipping would force the peeled module's body
  reference to resolve as an unexported residual binding and
  `residual_entry_imports_for_moved_body` would bail with "moved
  module references residual entry binding(s) not exported by
  entry". The peeled module's importer side renames the import
  back to the original local sym via
  `EntryExport.{local_name, exported_name}`, so the mint is
  invisible to the moved body.
- Plumbed through `LowerChunkInputs.pre_existing_public_export_names`
  and the `materialize.rs` materialise loop.

## Test plan

- [x] #1673's RED test
  (`e2e:auto_grown_export_alias_collision_test`) turns GREEN —
  fixture runs and emits `x-impl av-impl av-impl`.
- [x] `bazelisk test //devinfra/js/debundle/...` — 54/54 green
  (existing `duplicate_export_test.rs`, which pins the
  source-level case, continues to pass — the validator behavior
  is unchanged).

## Followup discussion

@agentydragon raised the idea of making
`ModuleQuotient = DiGraphMap<ModuleId, EdgeMetadata>` (type alias)
or a `Deref` newtype, to drop the `.graph` indirection at
~10 callsites. Reasonable. Will raise as a separate PR after
deciding between the two — see the chat for trade-offs.

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_