### PR TITLE
debundle/graph: collapse ModuleQuotient into a Deref newtype

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -800,7 +800,6 @@ Ro([Z], C.prototype, dynamicKey, 2);"#,
         assert!(
             factorization
                 .dep_graph
-                .graph
                 .contains_edge(logical(0), ModuleId::logical(1)),
             "the quotient should expose the logical-module -> residual read",
         );
@@ -3432,14 +3431,14 @@ mutable = mutable + 1;"#,
         let mod_0 = ModuleId(LogicalModuleIndex(0));
         let mod_1 = ModuleId(LogicalModuleIndex(1));
         assert!(
-            !factorization.dep_graph.graph.contains_edge(mod_0, mod_1),
+            !factorization.dep_graph.contains_edge(mod_0, mod_1),
             "no edge mod_0 → mod_1 expected, got: {:?}",
-            factorization.dep_graph.graph.edge_weight(mod_0, mod_1),
+            factorization.dep_graph.edge_weight(mod_0, mod_1),
         );
         assert!(
-            !factorization.dep_graph.graph.contains_edge(mod_1, mod_0),
+            !factorization.dep_graph.contains_edge(mod_1, mod_0),
             "no edge mod_1 → mod_0 expected, got: {:?}",
-            factorization.dep_graph.graph.edge_weight(mod_1, mod_0),
+            factorization.dep_graph.edge_weight(mod_1, mod_0),
         );
     }
 

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -232,7 +232,7 @@ fn compute_linker_order(
     for idx in 0..logical_modules.len() {
         graph.add_node(ModuleId(LogicalModuleIndex(idx)));
     }
-    for (from, to, weight) in dep_graph.iter_edges() {
+    for (from, to, weight) in dep_graph.all_edges() {
         if !weight.constrains_init_order() {
             continue;
         }
@@ -273,7 +273,7 @@ fn compute_source_import_order(
     logical_modules: &[LogicalModule],
     linker_position_by_module: &HashMap<ModuleId, usize>,
 ) -> Vec<ModuleId> {
-    let sccs = tarjan_scc(&dep_graph.graph);
+    let sccs = tarjan_scc(&dep_graph.0);
     let mut scc_of: HashMap<ModuleId, usize> = HashMap::new();
     let mut scc_rank: Vec<usize> = Vec::with_capacity(sccs.len());
     for (idx, scc) in sccs.iter().enumerate() {
@@ -293,7 +293,7 @@ fn compute_source_import_order(
     let mut nodes: Vec<ModuleId> = (0..logical_modules.len())
         .map(|idx| ModuleId(LogicalModuleIndex(idx)))
         .collect();
-    for (from, to, _) in dep_graph.iter_edges() {
+    for (from, to, _) in dep_graph.all_edges() {
         if !nodes.contains(&from) {
             nodes.push(from);
         }

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -247,15 +247,39 @@ impl EdgeMetadata {
 /// Module dep graph built from per-statement facts and a binding →
 /// module assignment.
 ///
-/// Backed by `petgraph::DiGraphMap`: one edge per directed
-/// `(from, to)` pair, weight = `EdgeMetadata`. Multiple reasons
-/// for the same physical edge (e.g. several at-init reads of
-/// bindings owned by the same target module) accumulate into the
-/// edge's reason list. Cycle detection runs through petgraph's
-/// `tarjan_scc`.
+/// Thin newtype around `petgraph::DiGraphMap<ModuleId,
+/// EdgeMetadata>`: one edge per directed `(from, to)` pair, weight =
+/// `EdgeMetadata`. Multiple reasons for the same physical edge (e.g.
+/// several at-init reads of bindings owned by the same target
+/// module) accumulate into the edge's reason list. Cycle detection
+/// runs through petgraph's `tarjan_scc`.
+///
+/// `Deref` / `DerefMut` to the inner graph lets callers reach
+/// `petgraph` methods (`all_edges`, `edge_weight`, `nodes`,
+/// `contains_edge`, …) directly: `dep_graph.all_edges()` instead of
+/// `dep_graph.graph.all_edges()`. The newtype is kept (rather than a
+/// bare type alias) so the semantic name "the I∪S module-dep
+/// quotient" stays distinct from arbitrary
+/// `DiGraphMap<ModuleId, EdgeMetadata>` instances.
+///
+/// For `petgraph::algo::tarjan_scc` (a generic function whose
+/// inference doesn't trigger `Deref` coercion), callers reach for
+/// the inner graph with `&dep_graph.0` or `&*dep_graph`.
 #[derive(Debug, Clone, Default)]
-pub struct ModuleQuotient {
-    pub graph: DiGraphMap<ModuleId, EdgeMetadata>,
+pub struct ModuleQuotient(pub DiGraphMap<ModuleId, EdgeMetadata>);
+
+impl std::ops::Deref for ModuleQuotient {
+    type Target = DiGraphMap<ModuleId, EdgeMetadata>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ModuleQuotient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl ModuleQuotient {
@@ -263,32 +287,10 @@ impl ModuleQuotient {
         if from == to {
             return;
         }
-        if !self.graph.contains_edge(from, to) {
-            self.graph.add_edge(from, to, EdgeMetadata::default());
+        if !self.contains_edge(from, to) {
+            self.add_edge(from, to, EdgeMetadata::default());
         }
-        self.graph
-            .edge_weight_mut(from, to)
-            .unwrap()
-            .reasons
-            .push(reason);
-    }
-
-    /// Iterate edges as `(from, to, &EdgeMetadata)`.
-    pub fn iter_edges(&self) -> impl Iterator<Item = (ModuleId, ModuleId, &EdgeMetadata)> + '_ {
-        self.graph.all_edges()
-    }
-
-    /// Edge metadata, if the edge exists.
-    pub fn edge(&self, from: ModuleId, to: ModuleId) -> Option<&EdgeMetadata> {
-        self.graph.edge_weight(from, to)
-    }
-
-    /// `true` if the directed edge `(from, to)` is present and at
-    /// least one of its reasons is an at-init read.
-    pub fn has_eager_use_edge(&self, from: ModuleId, to: ModuleId) -> bool {
-        self.graph
-            .edge_weight(from, to)
-            .is_some_and(EdgeMetadata::has_eager_use)
+        self.edge_weight_mut(from, to).unwrap().reasons.push(reason);
     }
 
     /// `true` if the edge `(from, to)` exists and constrains
@@ -296,8 +298,7 @@ impl ModuleQuotient {
     /// ordering). Used by the realizability gate to decide
     /// whether an `I ∪ S` SCC is unrealizable.
     pub fn has_init_order_constraining_edge(&self, from: ModuleId, to: ModuleId) -> bool {
-        self.graph
-            .edge_weight(from, to)
+        self.edge_weight(from, to)
             .is_some_and(EdgeMetadata::constrains_init_order)
     }
 }
@@ -778,9 +779,7 @@ fn promote_at_init_calls(
 /// public construction path; peelability and reports both go through
 /// this for any non-hypothetical quotient.
 pub fn build_module_quotient(owner_graph: &OwnerGraph, partition: &Partition) -> ModuleQuotient {
-    let mut graph = ModuleQuotient {
-        graph: DiGraphMap::new(),
-    };
+    let mut graph = ModuleQuotient(DiGraphMap::new());
     let mut seen_side_effect_module_pairs = BTreeSet::<(ModuleId, ModuleId)>::new();
     for edge in &owner_graph.edges {
         let from = partition.of(edge.from);

--- a/devinfra/js/debundle/reports.rs
+++ b/devinfra/js/debundle/reports.rs
@@ -93,7 +93,7 @@ fn build_quotient_node_reports(factorization: &ChunkFactorization) -> Vec<Module
     for (_, module) in factorization.partition.iter() {
         modules.insert(module);
     }
-    for (from, to, _) in factorization.dep_graph.iter_edges() {
+    for (from, to, _) in factorization.dep_graph.all_edges() {
         modules.insert(from);
         modules.insert(to);
     }
@@ -142,9 +142,9 @@ fn build_quotient_scc_reports(
 ) -> Vec<QuotientSccReport> {
     let quotient_edges_by_source = quotient_edge_indices_by_source(quotient_edges);
     let mut sccs = Vec::new();
-    for scc in tarjan_scc(&factorization.dep_graph.graph) {
+    for scc in tarjan_scc(&factorization.dep_graph.0) {
         let is_cycle = scc.len() > 1
-            || (scc.len() == 1 && factorization.dep_graph.graph.contains_edge(scc[0], scc[0]));
+            || (scc.len() == 1 && factorization.dep_graph.contains_edge(scc[0], scc[0]));
         if !is_cycle {
             continue;
         }

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -172,12 +172,11 @@ pub fn validate_factorization(
         };
     }
     let graph = &build_module_quotient(owner_graph, partition);
-    let sccs = tarjan_scc(&graph.graph);
+    let sccs = tarjan_scc(&graph.0);
     let mut cycles = Vec::new();
     for scc in sccs {
         let in_scc: HashSet<ModuleId> = scc.iter().copied().collect();
-        let is_cycle =
-            scc.len() > 1 || (scc.len() == 1 && graph.graph.contains_edge(scc[0], scc[0]));
+        let is_cycle = scc.len() > 1 || (scc.len() == 1 && graph.contains_edge(scc[0], scc[0]));
         if !is_cycle {
             continue;
         }
@@ -197,7 +196,7 @@ pub fn validate_factorization(
             continue;
         }
         let mut evidence = Vec::new();
-        for (from, to, weight) in graph.iter_edges() {
+        for (from, to, weight) in graph.all_edges() {
             if !in_scc.contains(&from) || !in_scc.contains(&to) {
                 continue;
             }
@@ -327,7 +326,7 @@ fn compute_realizability_cut(
     for &m in scc {
         working.add_node(m);
     }
-    for (from, to, weight) in graph.iter_edges() {
+    for (from, to, weight) in graph.all_edges() {
         if !in_scc.contains(&from) || !in_scc.contains(&to) || from == to {
             continue;
         }


### PR DESCRIPTION
## Summary

`ModuleQuotient` used to carry a single named
`graph: DiGraphMap<ModuleId, EdgeMetadata>` field plus a handful of
thin pass-through methods (`iter_edges` → `all_edges`, `edge` →
`edge_weight`, etc.) that duplicated the petgraph API. Every
external use site dropped to `.graph.foo()` for anything not
pre-wrapped, and `tarjan_scc` specifically needed `.graph` because
Rust's deref coercion doesn't fire for generic functions.

Switch to:

```rust
pub struct ModuleQuotient(pub DiGraphMap<ModuleId, EdgeMetadata>);
impl Deref for ModuleQuotient { type Target = DiGraphMap<...>; ... }
impl DerefMut for ModuleQuotient { ... }
```

Drop the redundant pass-through methods. `has_eager_use_edge`
(defined but unused externally) goes away.
`has_init_order_constraining_edge` stays — one external caller in
`validation::residual_post_cycle_edges`, and the predicate is
domain-meaningful enough to keep named.

The named newtype is kept (rather than a bare `pub type`) so the
semantic identity "the I∪S module-dep quotient" stays distinct from
arbitrary `DiGraphMap<ModuleId, EdgeMetadata>` values.

## Callsite simplification

| before                              | after                       |
|-------------------------------------|-----------------------------|
| `dep_graph.iter_edges()`            | `dep_graph.all_edges()`     |
| `dep_graph.graph.contains_edge(…)`  | `dep_graph.contains_edge(…)`|
| `dep_graph.graph.edge_weight(…)`    | `dep_graph.edge_weight(…)`  |
| `tarjan_scc(&dep_graph.graph)`      | `tarjan_scc(&dep_graph.0)`  |

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 54/54 green.

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_