### PR TITLE
debundle: consolidate `strip_parens` into `binding_targets`; record audit findings

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -361,3 +361,94 @@ that yields `Id` for each binding in a `Pat`. `swc_ecma_utils` ships
 `find_pat_ids::<Pat, Id>` which does the same. Worth swapping once
 `swc_ecma_utils` is otherwise in the analysis crate's deps (no good
 reason today — the local walker is small and equivalent).
+
+## Reinvented-wheel audit findings (recorded, no immediate action)
+
+A high-level audit (see chat session
+01VmZmgJmMUXFECyQGtsrBMd, after the `ModuleQuotient` Deref-newtype
+refactor) surveyed the debundler for places where we hand-roll
+something a stdlib / petgraph / swc helper provides. Most findings
+came back "appropriate / not actually a reinvention". The ones
+below are recorded for visibility, with the explicit decision
+that they're not worth doing right now.
+
+### `ChunkTable` interner stays
+
+`ids.rs`'s `ChunkTable` maps chunk paths (`String`) → dense
+`ChunkId(usize)` handles. Superficially looks like the same shape
+as the retired `BindingTable`, but the value proposition is
+different:
+
+- `ChunkId(usize)` is `Copy`, 8 bytes — flows through ~106 sites
+  by value. Swapping to `Atom` (the `BindingName → Id` migration's
+  natural answer) loses `Copy` semantics: `Atom` is `Clone`-not-
+  `Copy` (Arc-backed), forcing `.clone()` at every handle-passing
+  site.
+- swc's `Atom` global interning is tuned for short repeated JS
+  identifiers, not 30-character file paths. The interning win
+  evaporates for the actual chunk-key shape.
+- The dense indexing is used by storage like
+  `Vec<JsChunk>`-indexed-by-`ChunkId.0` and by stable round-trip
+  ordering in `ChunkBundle.chunk_order`.
+
+Keep `ChunkTable` as-is.
+
+### `OwnerGraph` hand-rolled CSR stays
+
+`graph.rs`'s `OwnerGraph` stores `Vec<OwnerEdge>` plus
+`Vec<Vec<OwnerEdgeId>>` (out_edges / in_edges) CSR adjacency. This
+isn't directly replaceable by petgraph because the design
+intentionally carries **multiple reasons per `(from, to)` pair as
+separate edges**, deterministically sorted by
+`(from, to, reason.kind, statement_ordinal, binding)` for stable
+report output. petgraph's `DiGraph`/`DiGraphMap` would force a
+single edge per pair or push the multi-reason list into a single
+edge weight (which is what `ModuleQuotient` does at the quotient
+level, where dedup is wanted). Keep the owner-level CSR.
+
+### `LazyBoundary` + `lazy_visit_*` helpers stay
+
+`facts.rs`'s `LazyBoundary` trait and `descend_lazy` /
+`lazy_visit_function` / `lazy_visit_class_member` family aren't a
+reinvention of `swc_ecma_visit::Visit` — they're a layer **on top
+of** `Visit` that lets the collector track lazy vs eager scope
+context (function bodies, class instance fields, getter/setter
+bodies) without each visitor re-implementing the boundary logic.
+The visitor merge (#1671) already collapsed the per-collector
+boilerplate to one shared collector that uses the helpers; no
+further win available without a generic-walker macro that wouldn't
+read cleaner than the current shape.
+
+### Manual `VisitMut` impls in `lowering/` stay
+
+`IdentifierRenamer`, `RenameAndShorthandNaturalizer`,
+`ShorthandNaturalizer`, etc. each implement custom `VisitMut`
+visitors. These are domain-specific transformations swc doesn't
+expose — the right use of swc's `VisitMut` trait, not a wheel
+reinvention.
+
+### Dense-int newtypes stay
+
+`OwnerId`, `OwnerEdgeId`, `StatementOrdinal`, `LogicalModuleIndex`,
+`ModuleId`, `ChunkId` are all `pub struct Foo(pub usize)` newtypes.
+Crates like `typed_index_collections` / `slotmap` would provide
+marginal type-system safety on `Vec` indexing, at the cost of a
+dep + per-storage-site conversion. Plain newtypes are standard
+compiler-IR practice; keep.
+
+### String-based ID round-tripping (`"owner:N"`, `"logical:N"`) stays
+
+`reports.rs`'s `owner_key` / `module_key` / `module_id_from_key`
+serialize typed IDs to human-readable strings for JSON reports
+and parse them back. Reasonable for the
+serialization-boundary use; not gymnastics.
+
+### `HashMap` + post-hoc `sort()` patterns
+
+~40 sites collect into a `HashMap` / `Vec` and `.sort()` for
+deterministic output. `BTreeMap` / `IndexMap` would eliminate
+the sort at the cost of slightly different iteration semantics.
+Most sites are one-shot init / report generation (not hot path);
+worth converting a few specific report-generation sites to
+`BTreeMap` for semantic clarity (the sorted order is the point,
+not an afterthought), but no urgent action.

--- a/devinfra/js/debundle/binding_targets.rs
+++ b/devinfra/js/debundle/binding_targets.rs
@@ -198,3 +198,16 @@ fn opt_chain_base_id(opt_chain: &OptChainExpr) -> Option<Id> {
         OptChainBase::Call(call) => member_root_id(&call.callee),
     }
 }
+
+/// Unwrap nested `Expr::Paren` layers and return the innermost
+/// expression. swc's pinned `swc_ecma_utils` (29.1.1) doesn't ship
+/// a stable equivalent, so this stays a thin local helper — used
+/// by `facts.rs` and `purity.rs` to peel parens before pattern
+/// matching against `Expr::Ident` / `Expr::Member` / etc.
+pub fn strip_parens(expr: &Expr) -> &Expr {
+    let mut cur = expr;
+    while let Expr::Paren(paren) = cur {
+        cur = &paren.expr;
+    }
+    cur
+}

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use binding_targets::{
     TargetAccessRecorder, binding_names, record_assign_target, record_pat_write,
-    record_update_target,
+    record_update_target, strip_parens,
 };
 use serde::{Deserialize, Serialize};
 use swc_common::{Span, Spanned};
@@ -619,14 +619,6 @@ fn decorate_property_key_is_static(expr: &Expr) -> bool {
 
 fn decorate_flags_are_static(expr: &Expr) -> bool {
     matches!(strip_parens(expr), Expr::Lit(Lit::Num(_)))
-}
-
-fn strip_parens(expr: &Expr) -> &Expr {
-    let mut cur = expr;
-    while let Expr::Paren(paren) = cur {
-        cur = &paren.expr;
-    }
-    cur
 }
 
 fn var_decl_of_item(item: &ModuleItem) -> Option<&VarDecl> {

--- a/devinfra/js/debundle/purity.rs
+++ b/devinfra/js/debundle/purity.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use binding_targets::strip_parens;
 use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
 use serde::{Deserialize, Serialize};
@@ -940,14 +941,6 @@ fn is_ts_enum_iife_body_block(block: &BlockStmt, param: &str) -> bool {
         return false;
     };
     is_ts_enum_iife_body_expr(strip_parens(arg), param)
-}
-
-fn strip_parens(expr: &Expr) -> &Expr {
-    let mut cur = expr;
-    while let Expr::Paren(p) = cur {
-        cur = &p.expr;
-    }
-    cur
 }
 
 /// One step of the IIFE body:


### PR DESCRIPTION
## Summary

Two parts:

### Consolidate `strip_parens`

`facts.rs` and `purity.rs` each had an identical 8-line
`fn strip_parens(expr: &Expr) -> &Expr` helper that peels
`Expr::Paren` layers before pattern-matching against
`Expr::Ident`/`Expr::Member`/etc. swc's pinned `swc_ecma_utils`
(29.1.1) doesn't ship a stable equivalent, so the helper stays —
but only once, exported from `binding_targets.rs` alongside the
other shared AST helpers (`member_root_id`, `member_root_sym`,
`binding_names`).

Net diff: -8 LOC.

### Record audit findings in `TODO.md`

The high-level reinvented-wheel audit (see chat session
`01VmZmgJmMUXFECyQGtsrBMd`, after the `ModuleQuotient` Deref-newtype
refactor) surveyed the debundler. Most findings came back
"appropriate / not actually a reinvention". Records the explicit
decisions:

- **`ChunkTable` interner stays.** Superficially similar to the
  retired `BindingTable` but its value proposition is the
  `Copy`-able `ChunkId(usize)` handle flowing through ~106 sites
  by value. Swapping to `Atom` keys (`Clone`-not-`Copy`,
  Arc-backed) loses that ergonomic — and Atom's global interning
  is tuned for short repeated JS identifiers, not 30-char file
  paths.
- **Hand-rolled CSR in `OwnerGraph` stays.** Deliberately carries
  multiple reasons per `(from, to)` pair as separate edges,
  deterministically sorted for stable report output; petgraph
  would force dedup at this level. `ModuleQuotient` (quotient
  level) does want dedup and is already a `Deref` newtype over
  `DiGraphMap`.
- **`LazyBoundary` + `lazy_visit_*` helpers stay.** Not a
  reinvention of `swc_ecma_visit::Visit` — they're a layer on
  top that lets fact-collection track lazy vs eager scope
  context.
- **Manual `VisitMut` impls in `lowering/` stay.** Domain-specific
  transformations swc doesn't expose.
- **Dense-int newtypes stay.** `OwnerId`, `OwnerEdgeId`, etc. are
  standard compiler-IR practice; `typed_index_collections` /
  `slotmap` would buy marginal safety for a dep.
- **String-based ID round-tripping (`"owner:N"`) stays.**
  Reasonable for the JSON serialization-boundary use.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 54/54 green.

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_