### PR TITLE
debundle: rename `schedule.json` artifact to `factorization.json`

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -320,31 +320,6 @@ propKeyA` and `collect_naturalization_renames_from_function` says
      requires reordering the materializer to compute a final body
      order before any rename intents are submitted).
 
-## Rename `schedule.json` artifact to `factorization.json`
-
-PR #1655 / #1657 renamed the `Schedule` type to `ChunkFactorization`
-(+ split off `ChunkAnalysis`) and cleaned up doc / code references,
-but the on-disk per-chunk validation report
-`<reports>/<chunk_id>/schedule.json` still uses the old name. The
-file is read by gaffer-private's `tana-peel` skills + the
-`AGENT_MODULE_PEEL_GUIDE.md` runbook (find-globs for
-`schedule.json`), so renaming requires a coordinated change:
-
-- **ducktape** side: rename the write filename in
-  `lowering/materialize.rs` (the `write_chunk_report_json(...)`
-  call and the materializer's atomic-unit-conflict error message),
-  the `e2e/realizability_test.rs` fixture path, and the
-  `facts.rs` doc-comment that points at the file.
-- **gaffer-private** side: update the `find` invocations in
-  `tana/re/web/spec/AGENT_MODULE_PEEL_GUIDE.md`, the
-  `.claude/skills/tana-peel/SKILL.md` runbook, and
-  `.claude/skills/tana-peel/tooling.md` reference.
-
-Land both sides in lock-step (or in a release-pin-aware order)
-so an in-flight Tana peel doesn't suddenly miss the file. Adds
-to the broader Tana peel coordination tracked in
-`gaffer-private/tana/re/web/`.
-
 <!--
 The "Migrate BindingName = String → swc's hygiene-preserving Id"
 entry that used to live here was done by the Id migration PR.

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -510,7 +510,7 @@ export { a1, a2, b1 };
     assert!(
         rejected
             .report_root
-            .join("static/app/schedule.json")
+            .join("static/app/factorization.json")
             .exists(),
         "schedule report should be written alongside owner graph",
     );

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -191,7 +191,7 @@ pub enum StatementKind {
 /// body, if any. Returns the source-order ordinal of the offending
 /// statement (in the post-comma-list-split view that
 /// `analyze_chunk` uses, so reports align with statement indices
-/// in `<chunk_id>/schedule.json`).
+/// in `<chunk_id>/factorization.json`).
 ///
 /// "Top-level" excludes function/method/arrow/getter/setter
 /// bodies and class instance-field initializers — those are lazy

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -585,7 +585,7 @@ pub(super) fn materialize_logical_chunk(
             write_chunk_report_json(
                 report_out_dir,
                 chunk_id,
-                "schedule.json",
+                "factorization.json",
                 &factorization_report,
             )
         })?;
@@ -609,7 +609,7 @@ pub(super) fn materialize_logical_chunk(
         );
         let causes = render_atomic_unit_cause_guidance(&factorization_report.atomic_unit_conflicts);
         bail!(
-            "materialize_logical_modules: chunk {chunk_id} has {n} atomic-factor-unit conflict(s) — the spec assigns members of one atomic factor unit to different destination modules, forming a cycle in the module dep graph that the constraining-edge SCC analysis says is unrealizable. Atomic factor units come from FACTORIZE.md's `G_atomic` SCC over the owner graph; every member must co-locate. {causes}Resolve by reconciling each unit's claims into a single destination. Full evidence written to <reports>/{chunk_id}/schedule.json; owner graph written to <reports>/{chunk_id}/owner_graph.json. Summary:\n{summary}",
+            "materialize_logical_modules: chunk {chunk_id} has {n} atomic-factor-unit conflict(s) — the spec assigns members of one atomic factor unit to different destination modules, forming a cycle in the module dep graph that the constraining-edge SCC analysis says is unrealizable. Atomic factor units come from FACTORIZE.md's `G_atomic` SCC over the owner graph; every member must co-locate. {causes}Resolve by reconciling each unit's claims into a single destination. Full evidence written to <reports>/{chunk_id}/factorization.json; owner graph written to <reports>/{chunk_id}/owner_graph.json. Summary:\n{summary}",
             n = factorization_report.atomic_unit_conflicts.len(),
         );
     }


### PR DESCRIPTION
## Summary

The on-disk per-chunk validation report at
`<reports>/<chunk_id>/schedule.json` was the last "Schedule" name
still flying — the Rust type renamed to `ChunkFactorization` in
#1655 / #1657, but the JSON filename was left behind because
gaffer-private's `tana-peel` skills + `AGENT_MODULE_PEEL_GUIDE.md`
read it via `find` globs and a flip needed coordinated rollout.

This PR ships the ducktape side. The companion gaffer-private PR
agentydragon/gaffer-private#???  updates the `find` globs and skill
references; **land this first** so the file is named
`factorization.json` by the time the gaffer side flips its globs.

## Changes

- `lowering/materialize.rs`: write filename + the atomic-unit-
  conflict error message.
- `e2e/realizability_test.rs`: fixture path.
- `facts.rs`: doc-comment pointer.
- `TODO.md` entry retired.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 54/54 green.
- [ ] After merge: bump the ducktape pin in gaffer-private, then
  land the companion gaffer-private PR.

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_