### PR TITLE
debundler: RED e2e test for accepted spec that TDZs at runtime

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -82,6 +82,7 @@ rust_library(
         "at_init_promotion_fndecl_direct_read_test",
         "at_init_s_chain_dataflow_test",
         "auto_grown_export_alias_collision_test",
+        "runtime_tdz_on_imported_class_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
+++ b/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
@@ -1,0 +1,115 @@
+//! RED test: a chunk the realizability gate ACCEPTS should
+//! actually execute under Node when materialized. Today the
+//! gate sometimes accepts a partition whose emitted ESM graph
+//! TDZs at runtime — the gate's proof is unsound for this
+//! shape.
+//!
+//! ## Shape
+//!
+//! Two cells. Entry declares
+//!
+//! ```js
+//! class Backend { constructor() { this.tag = "B"; } }
+//! ```
+//!
+//! and a co-located logger triple
+//!
+//! ```js
+//! let currentLogger;
+//! function setLogger(impl) { currentLogger = impl; }
+//! setLogger(new Backend());           // at-init read of `Backend`
+//! console.log(currentLogger.tag);
+//! ```
+//!
+//! The spec peels the logger triple (`{currentLogger, setLogger}`
+//! plus the anonymous `setLogger(new Backend());` statement)
+//! into a logical module. `Backend` stays in residual / entry.
+//!
+//! Emitted module shape:
+//!
+//! - `mod_logger.js` imports `Backend` from entry and runs
+//!   `setLogger(new Backend())` at top level (at-init read).
+//! - `entry.js` imports `currentLogger` / `setLogger` (or just
+//!   side-effects) from `mod_logger.js`, declares `class Backend`,
+//!   runs `console.log(currentLogger.tag)`.
+//!
+//! Cycle: `entry ↔ mod_logger`. ESM evaluates by post-order DFS
+//! from the entry. The standard outcome is:
+//!
+//! 1. DFS visits entry; entry imports mod_logger → visit mod_logger.
+//! 2. mod_logger imports `Backend` from entry; entry is already
+//!    on the DFS stack (cycle) → don't recurse.
+//! 3. Done with mod_logger's deps → evaluate mod_logger's body.
+//! 4. Body runs `setLogger(new Backend())`. `Backend` resolves
+//!    to entry's `Backend` binding, but entry's body has NOT yet
+//!    evaluated past the `class Backend` declaration.
+//! 5. `class Backend` is a class declaration — Temporal Dead Zone
+//!    until its line runs. The body crashes with
+//!    `ReferenceError: Cannot access 'Backend' before initialization`.
+//!
+//! ## Why ducktape accepts
+//!
+//! The cycle `entry ↔ mod_logger` carries:
+//!
+//! - `mod_logger → entry`: at-init `EagerUse(Backend)` from the
+//!   anonymous `setLogger(new Backend())` statement.
+//! - `entry → mod_logger`: a `LazyUse` of `currentLogger`
+//!   (the `console.log` reads it; or the residual statement is
+//!   peeled and replaced by a re-export).
+//!
+//! The relaxed realizability primitive (DESIGN.md "Realizability
+//! primitive", clause 3) accepts cycles whose constraining-edge
+//! subgraph (drops `LazyUse`) has no multi-module SCC. Here the
+//! constraining edges from `mod_logger → entry` form a singleton
+//! SCC, so the primitive's verdict is "realizable" — based on
+//! Lemma 2's claim that the materializer's `source_import_position`
+//! puts the cycle dependent (here `mod_logger`) FIRST in entry's
+//! source so the linker's DFS lands entry first.
+//!
+//! That claim is the bug. The cycle dependent (`mod_logger`)
+//! being put FIRST in entry's source means ESM's DFS visits it
+//! FIRST, not entry first — so post-order evaluation runs
+//! mod_logger's body before entry's body. Backend is TDZ at
+//! mod_logger's evaluation. Lemma 2's direction is inverted for
+//! the `(at-init forward, lazy back)` shape we hit here.
+//!
+//! ## Expected outcomes
+//!
+//! - **Today (RED)**: pipeline accepts the spec; Node throws
+//!   `ReferenceError: Cannot access 'Backend' before initialization`
+//!   when running the emitted entry. `assert_entry_output`
+//!   panics on the non-zero exit.
+//! - **After the fix**: either the gate rejects this shape
+//!   (constraining at-init edge `mod_logger → entry` should be
+//!   recognized as a TDZ hazard against the class declaration),
+//!   or the materializer's `source_import_position` for this
+//!   shape sequences things so ESM DFS evaluates entry first.
+//!   Either way: the emitted entry runs and prints `B`.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn at_init_use_of_residual_class_does_not_tdz() {
+    let mut opts = FixtureOpts::new(
+        r#"class Backend { constructor() { this.tag = "B"; } }
+let currentLogger;
+function setLogger(impl) {
+    currentLogger = impl;
+    globalThis.__tag = impl.tag;
+}
+setLogger(new Backend());
+globalThis.__final = "done";
+console.log(globalThis.__tag, globalThis.__final);
+export { Backend, currentLogger, setLogger };
+"#,
+        vec![logical_module_with_anon(
+            "mod_logger",
+            &[Member::new("currentLogger"), Member::new("setLogger")],
+            &["setLogger(new Backend());"],
+        )],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    opts.dataflow_aware_s_chain = true;
+    let fixture = run_fixture(opts);
+    assert_entry_output(&fixture, "B done\n");
+}


### PR DESCRIPTION
## Summary

Pins the contract that **a chunk the realizability gate ACCEPTS
should actually execute under Node when materialized**. Today
the gate accepts a partition whose emitted ESM graph
`ReferenceError`s at module-link time — the gate's proof is
unsound for the `(at-init forward, lazy back)` cycle shape.

The RED test is end-to-end: the materializer must accept the
spec, and Node must successfully evaluate the emitted entry
(stdout assertion `B done`). Today the materializer accepts and
Node TDZs.

## The shape

Two cells. Entry declares

```js
class Backend { constructor() { this.tag = "B"; } }
```

The spec peels a logger triple (`setLogger` + `currentLogger`
+ the anonymous `setLogger(new Backend());` statement) into
`mod_logger`. `Backend` stays in entry.

Emitted modules:

```js
// mod_logger.js
import { Backend } from "../entry.js";
let currentLogger;
function setLogger(impl) { currentLogger = impl; globalThis.__tag = impl.tag; }
setLogger(new Backend());                // ← at-init read of Backend
export { currentLogger, setLogger };

// entry.js
import { currentLogger, setLogger } from "./modules/mod_logger.js";
class Backend { constructor() { this.tag = "B"; } }
globalThis.__final = "done";
console.log(globalThis.__tag, globalThis.__final);
export { Backend, currentLogger, setLogger };
```

The cycle `entry ↔ mod_logger` carries:

- `mod_logger → entry`: at-init `EagerUse(Backend)` from the
  anonymous `setLogger(new Backend())` statement
- `entry → mod_logger`: `LazyUse` only (entry re-exports
  `currentLogger`/`setLogger` without using them at-init; the
  bottom-of-entry side-effects write `globalThis.__final` which
  is disjoint from mod_logger's writes, so the dataflow-aware
  S-chain doesn't sequence them)

The relaxed realizability primitive (DESIGN.md "Realizability
primitive", clause 3) accepts: the constraining-edge subgraph
has no multi-module SCC. Lemma 2's proof claims
`source_import_position` places the cycle dependent first so
the ESM linker's DFS unwinds the cycle through the dependency.

**The claim is inverted for this shape.** Putting `mod_logger`
first in entry's source means ESM DFS *visits* `mod_logger`
first, so post-order *evaluation* runs `mod_logger`'s body
before entry's body. `class Backend` hasn't executed when
`new Backend()` reads it — TDZ.

## Runtime evidence

```
$ bazelisk test //devinfra/js/debundle/e2e:runtime_tdz_on_imported_class_test
ReferenceError: Cannot access 'Backend' before initialization
    at .../mod_logger.js:12:15
    at ModuleJob.run (node:internal/modules/esm/module_job:268:25)
    at async onImport.tracePromise.__proto__ ...
```

Real RBE execution: BuildBuddy invocation
[`7d0038bc-fc37-4838-bbeb-d5e946992549`](https://app.buildbuddy.io/invocation/7d0038bc-fc37-4838-bbeb-d5e946992549),
54.9s elapsed, 53.89s critical path, 2 remote actions (rust_test
compile + node subprocess). Verified not a stuck shim — re-ran
with `--nocache_test_results` and got a fresh tmpdir and fresh
node TDZ.

## Provenance

Anonymized from a real failure observed in a large bundle where
`setTanaLoggerBackend(new BrowserTanaLoggerBackend())` in
`infra/logging/tana_logger_backend.js` ReferenceErrors at load
because the dependent class `BrowserTanaLoggerBackend` lives in
entry. The bundle's chunk passes the realizability gate +
`validate_emitted_exports` (with the dataflow-aware S-chain
opt-in landed in #1670 and the auto-grown export collision fix
in #1677), then Node crashes on the same shape this fixture
captures.

## Fix sketch (not in this PR)

Two candidate directions:

1. **Tighten the realizability gate.** Recognize that an at-init
   read of a binding declared by a class declaration (or any
   TDZ-locked declaration: `class`, `const`, `let`) in a cycle
   partner is a constraining edge whose direction ESM cannot
   satisfy via DFS-driven post-order evaluation. The current
   relaxed clause 3 is unsound for this shape; tighten it
   either by re-introducing the constraint, or by detecting
   the specific class-decl-back-edge pattern.

2. **Sequence the materializer's source order.** Have
   `source_import_position` place entry's class-decl statement
   *before* its `import` of `mod_logger`. But ESM hoists all
   imports above any statement, so this only works if entry's
   class declaration can also be hoisted — and class
   declarations cannot be hoisted in source order while
   retaining TDZ semantics.

Either way: the emitted entry must run and print `B done`.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/e2e:runtime_tdz_on_imported_class_test`
  fails today (RED) — pipeline accepts; Node `ReferenceError`s.
- [ ] After the fix in `realizability.rs` (or wherever the
  source order is decided), the test turns GREEN: emitted
  entry runs and prints `B done`.
- [x] Existing realizability tests continue to pass:
  no change to `realizability_test.rs`.

https://claude.ai/code/session_9d29c3bf-a5e6-4ed8-b67b-1ecd5fe1ea31

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_