### PR TITLE
debundle: reject `(at-init forward, lazy back)` cycles through residual

### DIFF
--- a/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
+++ b/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
@@ -75,23 +75,21 @@
 //!
 //! ## Expected outcomes
 //!
-//! - **Today (RED)**: pipeline accepts the spec; Node throws
+//! - **Today**: pipeline accepts the spec; Node throws
 //!   `ReferenceError: Cannot access 'Backend' before initialization`
-//!   when running the emitted entry. `assert_entry_output`
-//!   panics on the non-zero exit.
-//! - **After the fix**: either the gate rejects this shape
-//!   (constraining at-init edge `mod_logger → entry` should be
-//!   recognized as a TDZ hazard against the class declaration),
-//!   or the materializer's `source_import_position` for this
-//!   shape sequences things so ESM DFS evaluates entry first.
-//!   Either way: the emitted entry runs and prints `B`.
+//!   when running the emitted entry.
+//! - **After the fix (this PR)**: the realizability gate
+//!   recognizes the asymmetric-cycle shape `(at-init forward, lazy
+//!   back)` and rejects the spec. The materializer can't emit
+//!   working JS for this partition — ESM hoists all imports above
+//!   any statement, so re-sequencing `source_import_position` is
+//!   never going to put entry's `class Backend` declaration before
+//!   `mod_logger`'s `new Backend()`. The only sound outcome is
+//!   reject loudly so the spec author sees the conflict.
 
 use debundle_e2e_support::*;
 
-#[test]
-fn at_init_use_of_residual_class_does_not_tdz() {
-    let mut opts = FixtureOpts::new(
-        r#"class Backend { constructor() { this.tag = "B"; } }
+const FIXTURE_SOURCE: &str = r#"class Backend { constructor() { this.tag = "B"; } }
 let currentLogger;
 function setLogger(impl) {
     currentLogger = impl;
@@ -101,7 +99,11 @@ setLogger(new Backend());
 globalThis.__final = "done";
 console.log(globalThis.__tag, globalThis.__final);
 export { Backend, currentLogger, setLogger };
-"#,
+"#;
+
+fn opts_for_fixture() -> FixtureOpts<'static> {
+    let mut opts = FixtureOpts::new(
+        FIXTURE_SOURCE,
         vec![logical_module_with_anon(
             "mod_logger",
             &[Member::new("currentLogger"), Member::new("setLogger")],
@@ -110,6 +112,21 @@ export { Backend, currentLogger, setLogger };
     );
     opts.unassigned_mode = unassigned_mode_inline();
     opts.dataflow_aware_s_chain = true;
-    let fixture = run_fixture(opts);
-    assert_entry_output(&fixture, "B done\n");
+    opts
+}
+
+#[test]
+fn at_init_use_of_residual_class_is_rejected_to_avoid_tdz() {
+    // Cycle: mod_logger → entry (EagerUse Backend, constraining)
+    // + entry → mod_logger (LazyUse currentLogger / setLogger via
+    // entry's re-export, captured because `visit_named_export`
+    // records the orig idents as lazy reads). The tightened
+    // realizability rule catches the asymmetric I-cycle: a
+    // multi-module SCC in I that contains a constraining edge is
+    // unrealizable. Pipeline rejects with a cycle report instead
+    // of emitting JS that would TDZ at runtime.
+    expect_rejection(
+        opts_for_fixture(),
+        &["unrealizable", "cycle", "tdz", "cannot access"],
+    );
 }

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -876,11 +876,40 @@ impl Visit for StatementFactsCollector {
     fn visit_import_decl(&mut self, _node: &ImportDecl) {}
 
     // Export specifiers (`export { X }`, `export * from ...`) don't
-    // fire reads at module-init: ESM links them lazily when consumers
-    // import. Counting them as at-init reads invents spurious `R`/`I`
-    // edges. `export var X = ...` / `export class X {}` etc. route
-    // through `ExportDecl` and are still visited.
-    fn visit_named_export(&mut self, _node: &NamedExport) {}
+    // fire at-init reads: ESM resolves the binding when a consumer's
+    // `import` references it. But the materializer's routing layer
+    // treats a re-exported binding's destination as a lazy
+    // dependency: if the binding moves to a different module, the
+    // emitter inserts `import { X } from <new home>` at the top of
+    // this chunk's entry to keep the export surface intact. The
+    // realizability primitive's I-graph cycle check needs to see
+    // that materializer-induced lazy import edge, so record each
+    // `orig` Ident as a LAZY read (placed directly into `lazy_reads`,
+    // bypassing `record_read`'s lazy-depth bucketing — these reads
+    // are semantically deferred regardless of where the export
+    // specifier sits syntactically). Not added to
+    // `first_order_lazy_reads`: re-exports aren't reachable through
+    // at-init call promotion, so excluding them from that subset
+    // prevents the promotion pass from inventing spurious eager
+    // edges for re-exported bindings.
+    //
+    // `export { X } from "./foo"` (with `src.is_some()`) is a
+    // different shape: the binding lives in `./foo`, not in this
+    // chunk; the `import`-side dep is captured by the import-decl
+    // path, not via specifier reads here.
+    fn visit_named_export(&mut self, node: &NamedExport) {
+        if node.src.is_some() {
+            return;
+        }
+        for specifier in &node.specifiers {
+            let ExportSpecifier::Named(named) = specifier else {
+                continue;
+            };
+            if let ModuleExportName::Ident(ident) = &named.orig {
+                self.lazy_reads.insert(ident.to_id());
+            }
+        }
+    }
     fn visit_export_all(&mut self, _node: &ExportAll) {}
 
     fn visit_await_expr(&mut self, node: &AwaitExpr) {

--- a/devinfra/js/debundle/partition.rs
+++ b/devinfra/js/debundle/partition.rs
@@ -20,6 +20,14 @@ use crate::{ModuleId, OwnerGraph, OwnerId};
 #[derive(Debug, Clone)]
 pub struct Partition {
     of: Vec<ModuleId>,
+    /// The chunk's residual logical module — where unassigned owners
+    /// default to, and which the materializer emits as the chunk's
+    /// runtime entry. Realizability uses this to identify the ESM
+    /// DFS root: any cycle in `I` that contains `residual` with a
+    /// constraining edge whose target is `residual` is unsound,
+    /// because ESM post-order DFS evaluates `residual` LAST and the
+    /// reading module sees `residual`'s bindings in TDZ.
+    residual: ModuleId,
 }
 
 impl Partition {
@@ -32,7 +40,15 @@ impl Partition {
     pub fn new(owner_graph: &OwnerGraph, default_destination: ModuleId) -> Self {
         Self {
             of: vec![default_destination; owner_graph.nodes.len()],
+            residual: default_destination,
         }
+    }
+
+    /// The chunk's residual module — the ESM DFS root for the
+    /// emitted entry. Equal to the `default_destination` the
+    /// partition was constructed with.
+    pub fn residual(&self) -> ModuleId {
+        self.residual
     }
 
     /// Build a partition that assigns each owner the module of any

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -102,12 +102,22 @@ pub fn check_realizability(
 ) -> RealizabilityVerdict {
     let mut verdict = RealizabilityVerdict::default();
 
-    // Per-pair constraining owner-edge ids. Sequenced edges are
-    // deduped per (from, to) — multiple sequenced reasons between the
-    // same module pair represent the same ordering constraint and
-    // would over-weight evidence if counted separately. (Matches
-    // `build_module_quotient`'s sequenced-edge dedup.)
+    // Two parallel adjacency tables:
+    //   - `constraining_adj`: only `EagerUse` + `Sequenced` (+
+    //     `LocalEffect`) edges, deduped sequenced-per-pair. The
+    //     evidence carrier — SCCs here are *the* clause-3 violation.
+    //   - `i_adj`: every cross-module edge in the I-graph, including
+    //     `LazyUse`. SCCs here catch the asymmetric-cycle shape
+    //     `(at-init forward, lazy back)` whose constraining-only
+    //     subgraph is acyclic but whose ESM evaluation still TDZs.
+    //
+    // Sequenced edges are deduped per (from, to) — multiple sequenced
+    // reasons between the same module pair represent the same
+    // ordering constraint and would over-weight evidence if counted
+    // separately. (Matches `build_module_quotient`'s sequenced-edge
+    // dedup.)
     let mut constraining_adj: BTreeMap<(ModuleId, ModuleId), Vec<OwnerEdgeId>> = BTreeMap::new();
+    let mut i_adj: BTreeMap<(ModuleId, ModuleId), Vec<OwnerEdgeId>> = BTreeMap::new();
     let mut seen_sequenced_pairs: BTreeSet<(ModuleId, ModuleId)> = BTreeSet::new();
 
     for edge in &owner_graph.edges {
@@ -130,6 +140,8 @@ pub fn check_realizability(
             });
             continue;
         }
+        // Every non-rebind cross-module edge participates in I.
+        i_adj.entry((from, to)).or_default().push(edge.id);
         if !edge.reason.constrains_init_order() {
             continue;
         }
@@ -142,20 +154,38 @@ pub fn check_realizability(
             .push(edge.id);
     }
 
-    if constraining_adj.is_empty() {
+    if i_adj.is_empty() {
         return verdict;
     }
 
-    // Run Tarjan over the constraining-edge quotient.
-    let mut graph: DiGraphMap<ModuleId, ()> = DiGraphMap::new();
+    // Run Tarjan twice:
+    //   1. Over the constraining-edge subgraph — the historical
+    //      relaxed clause-3 rule. Catches **mutual** constraining
+    //      cycles (both sides eager-read each other; no source order
+    //      can satisfy both).
+    //   2. Over the full I-graph (constraining + lazy), then filter
+    //      to SCCs that **contain the residual module and a
+    //      constraining edge whose target IS residual**. Catches the
+    //      `(at-init forward, lazy back)` shape where one cycle
+    //      member at-init reads from residual while residual lazily
+    //      re-imports from the member. ESM's DFS starts at the
+    //      chunk's runtime entry (= residual), so residual evaluates
+    //      LAST in post-order — every other cycle member runs first
+    //      and reads residual's class/const/let bindings in TDZ.
+    //
+    //      Asymmetric I-cycles where the constraining edge target
+    //      is a non-residual module DO satisfy Lemma 2: the
+    //      materializer's `source_import_position` puts the cycle
+    //      dependent first in residual's import list, ESM DFS unwinds
+    //      via the dependency, eval order respects the constraint.
+    //      Those stay realizable.
+    let residual = partition.residual();
+    let mut con_graph: DiGraphMap<ModuleId, ()> = DiGraphMap::new();
     for &(from, to) in constraining_adj.keys() {
-        graph.add_edge(from, to, ());
+        con_graph.add_edge(from, to, ());
     }
-    for scc in tarjan_scc(&graph) {
-        // Single-vertex SCCs without a self-loop don't represent a
-        // multi-module cycle. (A constraining intra-module edge would
-        // not appear in the quotient adjacency at all; we skip
-        // `from == to` above.)
+    let mut reported: BTreeSet<BTreeSet<ModuleId>> = BTreeSet::new();
+    for scc in tarjan_scc(&con_graph) {
         if scc.len() < 2 {
             continue;
         }
@@ -165,6 +195,40 @@ pub fn check_realizability(
             if modules.contains(from) && modules.contains(to) {
                 owner_edges.extend_from_slice(edges);
             }
+        }
+        owner_edges.sort();
+        reported.insert(modules.clone());
+        verdict.unrealizable_sccs.push(UnrealizableScc {
+            modules,
+            constraining_owner_edges: owner_edges,
+        });
+    }
+
+    let mut i_graph: DiGraphMap<ModuleId, ()> = DiGraphMap::new();
+    for &(from, to) in i_adj.keys() {
+        i_graph.add_edge(from, to, ());
+    }
+    for scc in tarjan_scc(&i_graph) {
+        if scc.len() < 2 {
+            continue;
+        }
+        let modules: BTreeSet<ModuleId> = scc.iter().copied().collect();
+        if !modules.contains(&residual) {
+            continue;
+        }
+        // Collect only the constraining edges into residual within
+        // this SCC. If any exist, the cycle's TDZ shape is real.
+        let mut owner_edges: Vec<OwnerEdgeId> = Vec::new();
+        for ((from, to), edges) in &constraining_adj {
+            if *to == residual && modules.contains(from) {
+                owner_edges.extend_from_slice(edges);
+            }
+        }
+        if owner_edges.is_empty() {
+            continue;
+        }
+        if reported.contains(&modules) {
+            continue;
         }
         owner_edges.sort();
         verdict.unrealizable_sccs.push(UnrealizableScc {


### PR DESCRIPTION
## Summary

Closes #1681. The relaxed clause-3 realizability rule accepts cycles
in `I` as long as the constraining-edge subgraph (drops `LazyUse`)
has no multi-module SCC. Per DESIGN.md "Lemma 2",
`source_import_position` orders residual's imports so ESM's DFS
unwinds the cycle through the dependency. That holds when residual
is **outside** the cycle.

When residual itself is in the cycle, Lemma 2 collapses: residual is
the ESM DFS root (where `node entry.js` starts). DFS visits every
cycle member first, post-order evaluates them before residual runs,
and any constraining edge with target = residual TDZs at runtime —
the cycle member's `new Backend()` / `setTanaLoggerBackend(new
BrowserTanaLoggerBackend())` runs while residual's
`class Backend` / `class BrowserTanaLoggerBackend` is still in its
temporal dead zone.

## Three changes

### 1. `facts.rs` — capture re-export-induced lazy imports

`visit_named_export` previously skipped the whole subtree to avoid
spurious eager reads. Now records each specifier's `orig` ident
into `lazy_reads` directly (NOT `first_order_lazy_reads`, so at-init
call promotion doesn't invent eager edges for re-exports). This
captures the materializer-induced `import { X } from <new home>`
that the emitter inserts when a re-exported binding routes to a
different module. Without it the realizability gate sees no edge
from residual to the destination module and the cycle is invisible.

### 2. `partition.rs` — expose residual module

`Partition` now stores its `default_destination` and exposes
`Partition::residual()`. Lets the realizability check identify the
ESM DFS root without threading a separate parameter through every
caller (`validate_factorization`, `RealizabilityIndex`, etc.).

### 3. `realizability.rs` — tightened clause 3

`check_realizability` now runs Tarjan twice:

- Over the constraining-edge subgraph (historical strict rule:
  reject any multi-module SCC).
- Over the full I-graph (new rule: reject any multi-module SCC
  containing residual that has at least one constraining edge
  whose **target is residual**).

The new pass is narrow: it doesn't fire on
`mixed_cycle_with_lazy_back_edge` (cycle is `{mod_a, mod_b}`,
residual outside, Lemma 2 still works), `accepts_cycle_when_all_back_edges_are_lazy`
(no constraining edges in SCC), or `pure_var_decl_hub_…` peel
candidates (hypothetical move puts the constraining target on the
new module, not residual).

## Tana verification

Verified locally against `//tana/re/web/spec:debundle_78d928dca7`
in gaffer-private via `local_path_override` on the ducktape
dependency. The Tana pipeline now correctly **rejects**, surfacing
4 cut edges including
`infra/logging/tana_logger_backend → anon_residual_sentinel` —
exactly the `setTanaLoggerBackend(new BrowserTanaLoggerBackend())`
TDZ shape called out in #1681's provenance section.

The previous "passing" Tana build was emitting JS that would TDZ
under Node at load time; the pipeline silently accepting was the
soundness bug. The spec author now has a clear pipeline-time error
pointing at the cells that need to move (either keep the
`setLogger(new Backend())`-style anon statement in residual, or
co-locate the class declaration with its consumer module).

⚠️ Tana spec follow-up needed in gaffer-private before bumping the
ducktape pin past this commit, otherwise
`//tana/re/web/spec:debundle_78d928dca7` will fail to build.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 55/55 green.
- [x] RED test
  `e2e/runtime_tdz_on_imported_class_test.rs` flips from expecting
  the (impossible) `B done` output to expecting rejection.
  Substring set covers the actual error wording.
- [x] All other realizability tests
  (`mixed_cycle_with_lazy_back_edge_is_realizable`,
  `accepts_cycle_when_all_back_edges_are_lazy`,
  `mixed_cycle_without_at_init_call_is_realizable`,
  `pure_var_decl_hub_…`, etc.) continue to pass.
- [x] Tana spec verification via local_path_override — rejects with
  the expected cut-edge shape.

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_