### PR TITLE
debundle/DESIGN: refresh Lemma 2 sections + validation.rs comment for tightened gate

### DIFF
--- a/devinfra/js/debundle/DESIGN.md
+++ b/devinfra/js/debundle/DESIGN.md
@@ -552,13 +552,33 @@ produces entry imports `[mod_b, mod_a]` so the linker DFS visits
 mod_b → mod_a → mod_b (cycle no-op) and evaluates mod_a first, then
 mod_b. mod_b's at-init read of A succeeds.
 
-Because Lemma 2 is implemented, the validator
-(`validate_schedule` in `devinfra/js/debundle/validation.rs`) and
-the proposer (`evaluate_peel_candidate` in
-`devinfra/js/debundle/peelability.rs`) share the realizability
-primitive's verdict — a `peelable_now` from the proposer is a peel
-the gate will accept and the bundle will execute correctly at
-runtime.
+**Residual-in-cycle carve-out.** Lemma 2's "DFS unwinds via the
+dependency" only works when the cycle sits **below** the chunk's
+runtime entry (= the residual module emitted as `entry.js`). When
+residual is itself a cycle member, residual is the ESM DFS root —
+post-order evaluates every other cycle member first, then residual.
+Any constraining edge whose **target** is residual reads residual's
+not-yet-evaluated `class`/`const`/`let` bindings in their temporal
+dead zone. No source-order trick can fix this: ESM hoists every
+`import` above any statement, so residual's class declaration can't
+run before the imports' deps are evaluated.
+
+The realizability primitive (`check_realizability`) catches this
+shape with a second Tarjan pass over the full `I`-graph: any
+multi-module SCC containing residual with at least one constraining
+edge whose target is residual is rejected outright. The
+`(at-init forward, lazy back)` cycles that Lemma 2 _does_ satisfy —
+between non-residual modules — continue to pass.
+
+Because Lemma 2 is implemented (`ChunkFactorization::source_import_position`,
+consumed by `lowering::lower_chunk` when sorting entry's import list)
+and the residual-in-cycle carve-out is enforced by the gate, the
+validator (`validate_factorization` in
+`devinfra/js/debundle/validation.rs`) and the proposer
+(`evaluate_peel_candidate` in `devinfra/js/debundle/peelability.rs`)
+share the realizability primitive's verdict — a `peelable_now` from
+the proposer is a peel the gate will accept and the bundle will
+execute correctly at runtime.
 
 ## The realizability theorem
 
@@ -798,10 +818,10 @@ runs its body after the recursive calls return — that's
 post-order DFS. Acyclic `I` ensures every recursive descent
 terminates without revisiting a still-evaluating module. ∎
 
-**Lemma 2 (Author choice — capability, not current behavior).**
-The materializer's emit construction _can_ author each emitted
+**Lemma 2 (Author-side import-order steering).**
+The materializer's emit construction authors each emitted
 module's `import` directive list in an order that makes ECMA-262
-reach any chosen topological linearization `L` of `I` rooted at
+reach a chosen topological linearization `L` of `I` rooted at
 the entry.
 
 _Proof._ The DFS in `InnerModuleEvaluation` visits requested
@@ -813,25 +833,24 @@ in `I`, sort the import list so that the earliest-in-`L` successor
 appears first (DFS goes deepest into the first import). The
 resulting DFS post-order is `L`. ∎
 
-The current emitter does not actually steer for a specific `L` —
-imports come out in module-plan order. **For acyclic `I` alone,
-this is sufficient**: every `L` produced by the linker's default
-DFS is a topological linearization of `I`, so L3 and L4 hold under
-any of them. **`L` selection is only required when `S` adds
-constraints** that the default DFS doesn't already satisfy — and
-the validator's strict gate on `I ∪ S` rejects specs whose `S`
-constraints aren't already implied by `I`. Specs that satisfy
-`I ∪ S` acyclicity but require `L`-steering for `S` do exist in
-principle (a chunk where two side-effecting top-level statements
-in different modules have no read dependency between them); for
-those, the materializer would need to actually realize the choice
-this lemma proves possible. **Known impl gap**: the emitter does
-not steer for a specific `L` today. The realizability gate still
-rejects SCCs containing constraining edges, but if an otherwise
-valid acyclic spec ever requires `L`-steering for `S` to satisfy a
-constraint that's invisible to ESM's default DFS, the emit would
-silently violate it. Tracked as a follow-up if a real spec exposes
-it.
+**Implementation.** `ChunkFactorization::source_import_position`
+(see "Lemma 2: entry-side import ordering" above) computes `L` from
+the constraining-edge subgraph's toposort, reversed within each
+`I ∪ S` SCC so that the cycle dependent is imported first and DFS
+unwinds through the dependency. `lowering::lower_chunk` sorts
+entry's emitted `import` directives by this position. The validator
+rejects any spec the primitive's tightened clause-3 rule does not
+accept, so every spec the materializer reaches `lower_chunk` for has
+an `L` Lemma 2 can realize.
+
+The remaining principled gap is the `(at-init forward, lazy back)`
+shape **where residual itself is a cycle member**. Lemma 2's
+"unwind through the dependency" fails there — residual is the ESM
+DFS root, so post-order evaluates every other cycle member first,
+and a constraining read into residual TDZs. The primitive's
+tightened rule rejects this shape outright (see the residual-in-
+cycle carve-out under "Lemma 2: entry-side import ordering"); the
+emitter never sees one.
 
 **Lemma 3 (At-init read correctness).**
 Under any evaluation order `L` respecting `I`, every at-init read

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -141,23 +141,26 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
 /// non-trivial cycle (size > 1 OR a self-loop). Trivial single-node
 /// non-self-loop SCCs are dropped.
 ///
-/// The validator uses the **strict** rule: any quotient SCC carrying
-/// a constraining cross-module edge is unrealizable. This is more
-/// conservative than the realizability primitive's relaxed rule
-/// (constraining-edge subgraph has no multi-module SCC) because the
-/// materializer does not currently implement DESIGN.md "Lemma 2"
-/// (steering the ESM linker's import-source order to land on a
-/// topological linearization of `I ∪ S`). Mixed cycles the relaxed
-/// rule would accept can still TDZ at runtime under the current
-/// materializer.
+/// Validator + proposer + primitive now share one verdict:
+/// [`crate::realizability::check_realizability`] gates this whole
+/// function (early return when its verdict is empty), and the
+/// proposer (`evaluate_peel_candidate` in `peelability.rs`) calls
+/// the same primitive for advisory peel classification. The
+/// historical asymmetry between a "strict" validator and a "relaxed"
+/// primitive is gone: the primitive's tightened clause-3 rule
+/// rejects both the symmetric-constraining-cycle case (any
+/// multi-module SCC in the constraining subgraph) and the
+/// residual-in-cycle case (any multi-module SCC in `I` containing
+/// residual with a constraining edge whose target is residual), and
+/// `lower_chunk` realizes Lemma 2's source-import-order steering for
+/// every spec that makes it past the gate. See DESIGN.md "Lemma 2:
+/// entry-side import ordering" for the order-steering algorithm and
+/// the residual-in-cycle carve-out.
 ///
-/// The proposer (`evaluate_peel_candidate` in `peelability.rs`) uses
-/// the relaxed rule via [`crate::realizability::check_realizability`]
-/// for advisory peel classification. The at-init call promotion in
-/// `build_owner_graph` narrows the gap between the two predicates by
-/// catching the canonical `console.log(readB())` shape, but the
-/// asymmetry persists until either Lemma 2 lands in the materializer
-/// or the proposer is also tightened.
+/// The cycle reports this function emits are advisory evidence for
+/// spec authors — when the primitive rejects, this function walks
+/// the quotient and prints which modules + edges are involved so
+/// the author can pick a colocation or move that breaks the cycle.
 pub fn validate_factorization(
     owner_graph: &OwnerGraph,
     partition: &Partition,


### PR DESCRIPTION
## Summary

Refreshes three doc passages that described a pre-#1683 reality:

- DESIGN.md's `§"Lemma 2: entry-side import ordering"` claimed
  Lemma 2 was implemented but said the validator used the
  primitive's *relaxed* rule without mentioning the
  residual-in-cycle carve-out that #1683 introduced.
- DESIGN.md's `**Lemma 2 (Author choice — capability, not current
  behavior)**` was outright stale: it said "the emitter does not
  steer for a specific `L`" and described a "Known impl gap"
  follow-up. `ChunkFactorization::source_import_position` exists,
  is computed at factorization-build time, and
  `lowering::lower_chunk` consumes it to sort entry's imports.
- `validation::validate_factorization`'s doc comment described an
  asymmetry between a "strict validator" and a "relaxed primitive".
  After #1683 both share one verdict — `check_realizability` gates
  this function and the proposer (`evaluate_peel_candidate`) calls
  the same primitive for advisory peel classification.

## Changes

- DESIGN.md §"Lemma 2: entry-side import ordering" gains a
  **Residual-in-cycle carve-out** paragraph: when residual is a
  cycle member, Lemma 2's "DFS unwinds via the dependency" fails
  (residual is the ESM DFS root, post-order evaluates other members
  first, constraining read into residual TDZs). The primitive's
  tightened rule rejects this shape outright.
- DESIGN.md formal `**Lemma 2**` statement drops the "capability,
  not current behavior" hedge and the "Known impl gap" passage,
  replaced with: implementation pointer + the residual-in-cycle
  carve-out reference.
- `validation::validate_factorization` doc comment retires the
  strict/relaxed framing. New framing: validator + primitive +
  proposer share one verdict, and this function's role is to emit
  advisory cycle evidence when the primitive rejects.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — 55/55 green.
  (No behavior change; doc-only.)

https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZmgJmMUXFECyQGtsrBMd)_