### PR TITLE
debundle: fix accepted-spec runtime TDZ — phantom imports + tighter source order

### DIFF
--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -223,15 +223,19 @@ type StatementFactsInput = crate::StatementFacts;
 /// traversal needs to evaluate (deepest leaf first).
 fn compute_linker_order(
     dep_graph: &ModuleQuotient,
-    logical_modules: &[LogicalModule],
+    _logical_modules: &[LogicalModule],
 ) -> Vec<ModuleId> {
+    // Only modules that participate in a CONSTRAINING edge end up in
+    // linker_order. Modules with only `LazyUse` edges (or no edges at
+    // all) have no init-order constraint and are left out, so
+    // `linker_position_by_module.get(m)` returns `None` for them.
+    // `compute_source_import_order`'s `None`-handling sorts them
+    // AFTER constraining members within their SCC — preserving
+    // Lemma 2's "dependent first" within the constraining subgraph
+    // without letting lazy-only members displace the dependent. See
+    // <accepted_spec_runs_under_node_test::early_entry_importer_…>
+    // for the runtime TDZ that motivated this change.
     let mut graph = DiGraphMap::<ModuleId, ()>::new();
-    // Add every module the factorization knows about so the order
-    // covers them even if they have no dep-graph edges (singleton
-    // leaves still need a deterministic position for emit ordering).
-    for idx in 0..logical_modules.len() {
-        graph.add_node(ModuleId(LogicalModuleIndex(idx)));
-    }
     for (from, to, weight) in dep_graph.all_edges() {
         if !weight.constrains_init_order() {
             continue;
@@ -310,19 +314,26 @@ fn compute_source_import_order(
         let b_rank = b_scc
             .and_then(|i| scc_rank.get(i).copied())
             .unwrap_or(usize::MAX);
-        let a_pos = linker_position_by_module
-            .get(a)
-            .copied()
-            .unwrap_or(usize::MAX);
-        let b_pos = linker_position_by_module
-            .get(b)
-            .copied()
-            .unwrap_or(usize::MAX);
-        // (SCC rank ASC, intra-SCC linker_position DESC). DESC
-        // reverses within each SCC; the rank ASC keeps SCCs
-        // dependency-first relative to each other. For singleton
-        // SCCs, the DESC reverse is a no-op (only one member).
-        a_rank.cmp(&b_rank).then_with(|| b_pos.cmp(&a_pos))
+        let a_pos = linker_position_by_module.get(a).copied();
+        let b_pos = linker_position_by_module.get(b).copied();
+        // (SCC rank ASC, intra-SCC linker_position DESC). DESC reverses
+        // within each SCC so the cycle dependent (highest linker_position
+        // = last in linker_order = the dependent) comes first in entry's
+        // source; the rank ASC keeps SCCs dependency-first relative to
+        // each other.
+        //
+        // Members with NO `linker_position` (not in the constraining-edge
+        // graph — only reachable via `LazyUse`) must come LAST within
+        // their SCC. Otherwise they'd displace the constraining dependent
+        // from first position, and ESM's DFS would enter the SCC via
+        // them, bypassing Lemma 2's planned post-order. See
+        // `accepted_spec_runs_under_node_test::early_entry_importer_…`.
+        a_rank.cmp(&b_rank).then_with(|| match (a_pos, b_pos) {
+            (Some(a), Some(b)) => b.cmp(&a),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        })
     });
     nodes
 }

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -98,19 +98,19 @@ impl EdgeReason {
         }
     }
 
-    pub(crate) fn is_eager_use(&self) -> bool {
+    pub fn is_eager_use(&self) -> bool {
         self.kind == DepKind::EagerUse
     }
-    pub(crate) fn is_rebind(&self) -> bool {
+    pub fn is_rebind(&self) -> bool {
         matches!(self.kind, DepKind::EagerRebind | DepKind::LazyRebind)
     }
-    pub(crate) fn is_sequenced(&self) -> bool {
+    pub fn is_sequenced(&self) -> bool {
         self.kind == DepKind::Sequenced
     }
     /// Every kind except `LazyUse` constrains realizability.
     /// Stated as exclusion so adding a new `DepKind` variant
     /// forces an explicit decision here.
-    pub(crate) fn constrains_init_order(&self) -> bool {
+    pub fn constrains_init_order(&self) -> bool {
         self.kind != DepKind::LazyUse
     }
 }

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -43,6 +43,55 @@ pub(super) fn cross_module_imports_for_plan(
         .collect()
 }
 
+/// Emit `import "./<provider>.js";` (side-effect-only, no specifiers)
+/// for each phantom provider. The phantom imports surface ducktape's
+/// at-init promotion constraints as real ESM imports so the linker's
+/// DFS visits the providers as dependencies of this module — needed
+/// because the actual bindings being read live in residual function
+/// decls (e.g. `gR(iA)` → `startBootProgressTracking()` → reads
+/// `tanaLogger`), so the per-module emit path never adds an explicit
+/// import for `tanaLogger` in `init_state.js` on its own.
+///
+/// Sorted by linker_position so the resulting import order matches
+/// `cross_module_imports_for_plan`. Side-effect imports are emitted
+/// FIRST among module imports so the linker visits them before any
+/// downstream `import { … } from "./entry.js"` (which would otherwise
+/// short-circuit when entry is on the DFS stack, leaving the phantom
+/// targets unvisited).
+pub(super) fn phantom_side_effect_imports(
+    from_file: &str,
+    phantom_providers: BTreeSet<usize>,
+    factorization: &ChunkFactorization,
+) -> Vec<ModuleItem> {
+    let mut providers: Vec<usize> = phantom_providers.into_iter().collect();
+    providers.sort_by_key(|&idx| {
+        factorization
+            .linker_position(ModuleId(LogicalModuleIndex(idx)))
+            .unwrap_or(usize::MAX)
+    });
+    providers
+        .into_iter()
+        .filter_map(|provider_index| {
+            let provider = factorization
+                .analysis
+                .logical_module(LogicalModuleIndex(provider_index))?;
+            let source = super::util::relative_source(from_file, &provider.target_file);
+            Some(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                span: DUMMY_SP,
+                specifiers: Vec::new(),
+                src: Box::new(Str {
+                    span: DUMMY_SP,
+                    value: source.into(),
+                    raw: None,
+                }),
+                type_only: false,
+                with: None,
+                phase: ImportPhase::Evaluation,
+            })))
+        })
+        .collect()
+}
+
 pub(super) fn residual_entry_imports_for_moved_body(
     module_id: &str,
     entry_file: &str,

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -416,6 +416,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             residual_entry_imports,
             missing_residual_exports,
             runtime_reimports,
+            phantom_side_effect_providers,
         } = time_phase!(timings, "module.plan_references", {
             plan_module_reference_needs(
                 index,
@@ -439,6 +440,20 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 factorization,
                 &mut module_import_locals,
                 &mut module_import_renames,
+            )
+        });
+        // Phantom side-effect imports surface at-init-promotion-derived
+        // constraining edges as real ESM imports so the linker's DFS
+        // visits the provider modules as dependencies. Prepended so
+        // they sort before residual-entry and runtime re-imports, all
+        // of which would short-circuit the cycle when the residual is
+        // mid-evaluation. See `phantom_side_effect_imports` and
+        // `accepted_spec_runs_under_node_test::early_entry_importer_…`.
+        let phantom_imports = time_phase!(timings, "module.build_phantom_imports", {
+            phantom_side_effect_imports(
+                &plan.target_file,
+                phantom_side_effect_providers,
+                factorization,
             )
         });
         let mut residual_entry_imports = time_phase!(timings, "module.build_residual_imports", {
@@ -477,8 +492,14 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         })?;
         module_imports.append(&mut residual_entry_imports);
         module_imports.append(&mut runtime_reimports);
-        module_imports.append(&mut body);
-        body = module_imports;
+        // Phantom side-effect imports go FIRST in the emitted module
+        // so the linker DFS-recurses into the providers before the
+        // residual/entry import (which would short-circuit when the
+        // residual is mid-evaluation).
+        let mut combined = phantom_imports;
+        combined.append(&mut module_imports);
+        combined.append(&mut body);
+        body = combined;
         // Apply chunk_renames to the assembled module body so that
         // import-specifier aliases and references in the moved code
         // both pick up the spec's rename. Without this, residual

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -62,7 +62,7 @@ use exports::{
 };
 use imports_cross::{
     collect_entry_exports_by_original_local, cross_module_imports_for_plan, final_module_exports,
-    residual_entry_imports_for_moved_body,
+    phantom_side_effect_imports, residual_entry_imports_for_moved_body,
 };
 use imports_runtime::{
     import_decl_module_item, resolve_imported_binding, source_chunk_imports_for_moved_body,

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -27,6 +27,15 @@ pub(super) struct ModuleReferenceNeeds<'a> {
     pub(super) residual_entry_imports: BTreeMap<String, EntryExport>,
     pub(super) missing_residual_exports: BTreeSet<String>,
     pub(super) runtime_reimports: BTreeMap<String, &'a RuntimeImportInfo>,
+    /// Side-effect-only providers: modules this module has a constraining
+    /// edge to (via at-init call promotion) but whose bindings aren't
+    /// directly referenced in this module's body. Without an explicit
+    /// ESM `import "./<provider>.js";` here, ESM DFS wouldn't see the
+    /// dependency and would evaluate this module's body before the
+    /// provider's body — a runtime TDZ on any of the provider's
+    /// declared bindings the call chain transitively reads. See
+    /// `accepted_spec_runs_under_node_test::early_entry_importer_…`.
+    pub(super) phantom_side_effect_providers: BTreeSet<usize>,
 }
 
 pub(super) type SourceImportResolutionKey = (String, String, String);
@@ -217,5 +226,48 @@ pub(super) fn plan_module_reference_needs<'a>(
             needs.runtime_reimports.insert(name_str.to_string(), info);
         }
     }
+
+    // Phantom side-effect providers (Lemma 2's emit-side fix):
+    //
+    // Walk this module's owners' outgoing constraining edges in the
+    // owner graph. Any target module not already in
+    // `cross_module_imports_by_provider` (and not residual) needs a
+    // side-effect-only ESM import so the linker visits it as a
+    // dependency. Without this, at-init promotion records the
+    // constraint at the ducktape level but ESM doesn't see it (the
+    // actual `import` for the read target lives in the residual
+    // function decl's home, not in this module), so DFS might evaluate
+    // this module's body before the provider's.
+    //
+    // Skip residual: it's entry, the root of every chunk's import
+    // tree. Adding a side-effect import of entry from a peeled module
+    // is redundant — entry is always reachable.
+    let module_id = ModuleId(LogicalModuleIndex(module_index));
+    let residual = factorization.partition.residual();
+    let owner_graph = &factorization.analysis.owner_graph;
+    for (owner_id, owner_module) in factorization.partition.iter() {
+        if owner_module != module_id {
+            continue;
+        }
+        for &edge_id in owner_graph.out_edges_of(owner_id) {
+            let edge = &owner_graph.edges[edge_id.0];
+            if !edge.reason.constrains_init_order() {
+                continue;
+            }
+            let target_module = factorization.partition.of(edge.to);
+            if target_module == module_id || target_module == residual {
+                continue;
+            }
+            let ModuleId(LogicalModuleIndex(target_index)) = target_module;
+            if needs
+                .cross_module_imports_by_provider
+                .contains_key(&target_index)
+            {
+                continue;
+            }
+            needs.phantom_side_effect_providers.insert(target_index);
+        }
+    }
+
     needs
 }


### PR DESCRIPTION
## Summary

Closes the soundness gap pinned by my own RED test from #1687
(`accepted_spec_runs_under_node_test::early_entry_importer_does_not_pull_scc_in_wrong_order`). The realizability gate was accepting specs that ESM then `ReferenceError`'d on at runtime — observed in a real Tana bundle where `init_state.bootstrap → startWebClientBootstrap → startBootProgressTracking → reads tanaLogger` produced TDZ despite ducktape's at-init promotion correctly recording the constraining edge.

## Root cause

ducktape's at-init promotion recorded `M → P (eager_use)` for every binding `M`'s body transitively reads at-init, but the actual ESM `import` for that binding lived in the residual function decl's home (entry.js), not in `M`'s emitted source. ESM's DFS evaluation order is determined by actual `import` statements, not by ducktape's analysis edges — so DFS would visit the SCC via some other entry-side import (e.g., `ui/sidebar/disable_dev_mode` at line 17 of Tana's entry.js, which directly imports `tana_logger`), enter the SCC at the wrong vertex, and evaluate `M.body` before `P.body` had finished.

Three interacting bugs caused this:

1. **`compute_linker_order` added every logical module as a graph node**, so modules with only `LazyUse` edges still got a `linker_position`. The Lemma-2 DESC reversal in `compute_source_import_order` then sorted them ahead of actual constraining-edge endpoints, letting them become entry's first SCC-touching import. **Fix**: only include modules that participate in a constraining edge.

2. **`compute_source_import_order`'s tiebreak treated `linker_position = None` as `usize::MAX`**, which under DESC put non-constraining members FIRST within an SCC. **Fix**: explicit `Option<usize>` match so `None` members sort LAST within their SCC.

3. **Per-module emit added no `import` statement for an at-init promoted read whose target wasn't directly referenced in the module's source.** **Fix**: `plan_module_reference_needs` now also computes `phantom_side_effect_providers` — every target module of a constraining out-edge from owners in this module that isn't already in `cross_module_imports_by_provider` (and isn't residual). `phantom_side_effect_imports` emits `import "./<provider>.js";` (no specifiers) for each, placed FIRST in the module's import list so the linker DFS recurses into them before any residual-entry import.

Together: ESM DFS now visits all at-init-read targets as proper dependencies of the reading module, and the dependent comes first in entry's source order so ESM's post-order matches Lemma 2's planned evaluation order.

## Verification

- `bazelisk test //devinfra/js/debundle/...` — **all 56 tests pass**, no regressions.
- The previously-RED `early_entry_importer_does_not_pull_scc_in_wrong_order` now PASSES.
- Other 4 fixtures in the same file still pass.

## Next steps (out of scope)

- Once this lands, re-pin gaffer-private and try restoring `app/bootstrap/init_state.yaml` and `app/offline_mode/state.yaml` peels (un-peeled in gaffer #196 as a workaround). The TDZ should not recur.

https://claude.ai/code/session_d18aae97-ac47-45d6-8a3c-aacfeaca24c7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_