### PR TITLE
debundle: RED e2e test — peeled method reassigning top-level let throws at runtime

### DIFF
--- a/devinfra/js/debundle/e2e/accepted_spec_runs_under_node_test.rs
+++ b/devinfra/js/debundle/e2e/accepted_spec_runs_under_node_test.rs
@@ -252,3 +252,65 @@ export { T, readT, init, disableDevMode, middleHelper, loggerReader };
     let fixture = run_fixture(opts);
     assert_entry_output(&fixture, "ready\n");
 }
+
+#[test]
+fn peeled_method_reassigning_top_level_let_executes_under_node() {
+    // ★ RED test: minimal reproduction of the
+    // `Assignment to constant variable` runtime crash hit
+    // when peeling Tana's `ComputedViewRunner` class.
+    //
+    // Tana shape (paraphrased):
+    //
+    //   let isSearchBeingRefreshedForNode = (n) => false;
+    //   class ComputedViewRunner {
+    //     static setIsSearchBeingRefreshedForNodeHandler(e) {
+    //       isSearchBeingRefreshedForNode = e;           // ← write
+    //     }
+    //   }
+    //
+    // Before peeling `ComputedViewRunner`, the write lives in
+    // the same module as the `let` declaration: legal. After
+    // peeling `ComputedViewRunner` into its own module, the
+    // emitted file looks like:
+    //
+    //   import { isSearchBeingRefreshedForNode } from "../entry.js";
+    //   class ComputedViewRunner {
+    //     static setIsSearchBeingRefreshedForNodeHandler(e) {
+    //       isSearchBeingRefreshedForNode = e;
+    //     }
+    //   }
+    //
+    // Imported bindings are immutable per ESM — the method
+    // throws `TypeError: Assignment to constant variable` the
+    // first time it's called.
+    //
+    // Ducktape's realizability gate today accepts this peel
+    // because the write is inside a method body (lazy
+    // position). The fix must either reject any peel whose
+    // emitted module assigns to a binding declared in another
+    // module, or rewrite the write through a setter exported
+    // from the declaring module.
+    let mut opts = FixtureOpts::new(
+        r#"let counter = 0;
+class Counter {
+  bump(b) { counter = b; }
+  read() { return counter; }
+}
+const c = new Counter();
+c.bump(1);
+console.log(c.read());
+export { counter, Counter, c };
+"#,
+        vec![
+            // Peel the class + its instance into a separate
+            // module. `counter` (the let) stays in residual.
+            logical_module(
+                "mod_counter_class",
+                &[Member::new("Counter"), Member::new("c")],
+            ),
+        ],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let fixture = run_fixture(opts);
+    assert_entry_output(&fixture, "1\n");
+}


### PR DESCRIPTION
## Summary

A spec ducktape accepts that emits a module assigning to a top-level
`let` declared in another module **builds cleanly** but **throws at
runtime** with `TypeError: Assignment to constant variable` — imported
ESM bindings are immutable.

This RED test pins the soundness invariant ("any spec the gate accepts
must execute"). It belongs alongside the other RED tests in
`accepted_spec_runs_under_node_test.rs` from #1687.

## Encountered in production

Discovered while peeling Tana's `ComputedViewRunner` class as part of
the top-20 peelability audit:

```js
let isSearchBeingRefreshedForNode = (n) => false;
class ComputedViewRunner {
  static setIsSearchBeingRefreshedForNodeHandler(e) {
    isSearchBeingRefreshedForNode = e;   // ← write
  }
}
```

Before the peel, this lives in one module — legal `let` reassignment.
After peeling the class into its own module, the emitted file is:

```js
import { isSearchBeingRefreshedForNode } from "../entry.js";
class ComputedViewRunner {
  static setIsSearchBeingRefreshedForNodeHandler(e) {
    isSearchBeingRefreshedForNode = e;
  }
}
```

`isSearchBeingRefreshedForNode` is now an imported binding, which is
read-only per ESM. The first call to the method throws.

## Why the gate misses it today

The current realizability gate tracks at-init **reads** (eager_use)
through call promotion. A method-body **write** to an imported binding
isn't flagged: it's a lazy position from the gate's perspective. But
unlike a lazy read (where order matters but legality is fine), a write
to an imported binding is **never** legal in ESM regardless of order.

## Expected fix

Either:

1. **Reject** any peel whose emitted module assigns to a binding declared
   in another module (the binding's write site and its declaration must
   live in the same module), or
2. **Rewrite** the write through a setter exported by the declaring
   module.

(1) is the structural option; (2) is the surface-level rewrite. The
choice belongs in `realizability.rs` / lowering.

## Test plan

- [x] New test `peeled_method_reassigning_top_level_let_executes_under_node`
      in `accepted_spec_runs_under_node_test.rs`.
- [x] Test FAILS on current devel with the exact `TypeError: Assignment
      to constant variable` shape (RBE: BB invocation
      `9f3bc795-a3c1-4efe-8335-2a689bd67d92`).
- [x] Other 5 tests in the same file still pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ8MrgvbXXEEu6nC3nTdu4)_