### PR TITLE
augur/sim: spike-1 clean rewrite — event-log canonical, polars-vectorized

### DIFF
--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -19,9 +19,20 @@ py_library(
 )
 
 py_library(
+    name = "market_py",
+    srcs = ["market.py"],
+    deps = [
+        "@pypi//numpy",
+        "@pypi//polars",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "scenario_py",
     srcs = ["scenario.py"],
     deps = [
+        ":market_py",
         "@pypi//pydantic",
     ],
 )
@@ -41,6 +52,7 @@ py_library(
     srcs = ["step.py"],
     deps = [
         ":events_py",
+        ":market_py",
         ":scenario_py",
         ":state_py",
         "@pypi//polars",
@@ -62,6 +74,7 @@ py_library(
     deps = [
         ":apply_py",
         ":events_py",
+        ":market_py",
         ":run_py",
         ":scenario_py",
         ":state_py",
@@ -75,6 +88,7 @@ py_test(
     srcs = ["simulate_test.py"],
     deps = [
         ":apply_py",
+        ":market_py",
         ":scenario_py",
         ":simulate_py",
         "@pypi//polars",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -158,15 +158,27 @@ py_library(
     ],
 )
 
+py_library(
+    name = "replay_py",
+    srcs = ["replay.py"],
+    deps = [
+        ":apply_py",
+        ":run_py",
+        ":scenario_py",
+        ":simulate_py",
+        ":state_py",
+        "@pypi//polars",
+    ],
+)
+
 py_test(
     name = "simulate_test",
     srcs = ["simulate_test.py"],
     deps = [
-        ":apply_py",
         ":market_py",
+        ":replay_py",
         ":scenario_py",
         ":simulate_py",
-        ":state_py",
         "@pypi//polars",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -54,6 +54,27 @@ py_test(
 )
 
 py_library(
+    name = "tax_py",
+    srcs = ["tax.py"],
+    deps = [
+        ":jurisdictions_py",
+        "@pypi//numpy",
+    ],
+)
+
+py_test(
+    name = "tax_test",
+    srcs = ["tax_test.py"],
+    deps = [
+        ":jurisdictions_py",
+        ":tax_py",
+        "@pypi//numpy",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_library(
     name = "scenario_py",
     srcs = ["scenario.py"],
     deps = [
@@ -77,9 +98,12 @@ py_library(
     srcs = ["step.py"],
     deps = [
         ":events_py",
+        ":jurisdictions_py",
         ":market_py",
         ":scenario_py",
         ":state_py",
+        ":tax_py",
+        "@pypi//numpy",
         "@pypi//polars",
     ],
 )
@@ -99,6 +123,7 @@ py_library(
     deps = [
         ":apply_py",
         ":events_py",
+        ":jurisdictions_py",
         ":market_py",
         ":run_py",
         ":scenario_py",
@@ -116,6 +141,7 @@ py_test(
         ":market_py",
         ":scenario_py",
         ":simulate_py",
+        ":state_py",
         "@pypi//polars",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -77,7 +77,6 @@ py_test(
         ":apply_py",
         ":scenario_py",
         ":simulate_py",
-        ":state_py",
         "@pypi//polars",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devinfra/python:defs.bzl", "py_library", "py_test")
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,6 +31,31 @@ py_library(
 filegroup(
     name = "jurisdiction_data",
     srcs = glob(["data/jurisdictions/*.yaml"]),
+)
+
+filegroup(
+    name = "location_data",
+    srcs = glob(["data/locations/*.yaml"]),
+)
+
+py_library(
+    name = "locations_py",
+    srcs = ["locations.py"],
+    data = [":location_data"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_test(
+    name = "locations_test",
+    srcs = ["locations_test.py"],
+    deps = [
+        ":locations_py",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 py_library(
@@ -142,6 +167,39 @@ py_test(
         ":scenario_py",
         ":simulate_py",
         ":state_py",
+        "@pypi//polars",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_library(
+    name = "bench_scenario_py",
+    srcs = ["bench_scenario.py"],
+    deps = [
+        ":market_py",
+        ":scenario_py",
+    ],
+)
+
+py_binary(
+    name = "bench",
+    srcs = ["bench.py"],
+    main_module = "augur.sim.bench",
+    deps = [
+        ":bench_scenario_py",
+        ":simulate_py",
+    ],
+)
+
+py_test(
+    name = "bench_test",
+    srcs = ["bench_test.py"],
+    deps = [
+        ":bench_scenario_py",
+        ":market_py",
+        ":scenario_py",
+        ":simulate_py",
         "@pypi//polars",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -1,0 +1,85 @@
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "state_py",
+    srcs = ["state.py"],
+    deps = [
+        "@pypi//polars",
+    ],
+)
+
+py_library(
+    name = "events_py",
+    srcs = ["events.py"],
+    deps = [
+        "@pypi//polars",
+    ],
+)
+
+py_library(
+    name = "scenario_py",
+    srcs = ["scenario.py"],
+    deps = [
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
+    name = "apply_py",
+    srcs = ["apply.py"],
+    deps = [
+        ":events_py",
+        ":state_py",
+        "@pypi//polars",
+    ],
+)
+
+py_library(
+    name = "step_py",
+    srcs = ["step.py"],
+    deps = [
+        ":events_py",
+        ":scenario_py",
+        ":state_py",
+        "@pypi//polars",
+    ],
+)
+
+py_library(
+    name = "run_py",
+    srcs = ["run.py"],
+    deps = [
+        ":events_py",
+        "@pypi//polars",
+    ],
+)
+
+py_library(
+    name = "simulate_py",
+    srcs = ["simulate.py"],
+    deps = [
+        ":apply_py",
+        ":events_py",
+        ":run_py",
+        ":scenario_py",
+        ":state_py",
+        ":step_py",
+        "@pypi//polars",
+    ],
+)
+
+py_test(
+    name = "simulate_test",
+    srcs = ["simulate_test.py"],
+    deps = [
+        ":apply_py",
+        ":scenario_py",
+        ":simulate_py",
+        ":state_py",
+        "@pypi//polars",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -28,6 +28,31 @@ py_library(
     ],
 )
 
+filegroup(
+    name = "jurisdiction_data",
+    srcs = glob(["data/jurisdictions/*.yaml"]),
+)
+
+py_library(
+    name = "jurisdictions_py",
+    srcs = ["jurisdictions.py"],
+    data = [":jurisdiction_data"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_test(
+    name = "jurisdictions_test",
+    srcs = ["jurisdictions_test.py"],
+    deps = [
+        ":jurisdictions_py",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 py_library(
     name = "scenario_py",
     srcs = ["scenario.py"],

--- a/augur/sim/DESIGN.md
+++ b/augur/sim/DESIGN.md
@@ -665,7 +665,8 @@ refactoring L1's transfer.
    year-tax computation; capital-gains classification rule.
    `tax_year_breakdown_log`.
 7. **L7** — ordinary-income aggregation; SALT-cap interaction;
-   itemized vs standard deduction; filing status (single + HoH).
+   itemized vs standard deduction; filing status (single only;
+   HoH / MFJ / MFS deferred).
 8. **L8** — `liabilities` frame; `amortizing_loan` template;
    mortgage origination / payment / payoff transactions; Bank Bob
    as non-tax-paying agent.

--- a/augur/sim/DESIGN.md
+++ b/augur/sim/DESIGN.md
@@ -13,6 +13,50 @@ liquidity + multi-jurisdiction-tax spec without retrofitting. If a
 later layer requires moving primitives around, that's a design bug
 to catch here.
 
+## Canonical log; derived state
+
+**The event log is the source of truth.** State at month M is, by
+definition, `apply_events(initial_state, all events at months ≤ M)`.
+The simulator maintains a per-month state representation as an
+incremental cache (so each step doesn't re-aggregate the full log
+from month 0), but that cache is by construction equal to what
+re-deriving from the log would produce. There is no "state value
+the engine tracks independently of any logged event".
+
+Practical consequences of this discipline:
+
+- Every state transition that's the result of "something happened"
+  is logged as an event. State doesn't move without an event.
+- Two kinds of state attributes get treated differently:
+  - **Event-sourced attributes** — anything that's the cumulative
+    result of events: cash balances, asset lot units + basis,
+    liability principal, occupancy mode, cumulative depreciation,
+    ownership tenure, primary-residence-use months, rollout status.
+    These are aggregations over the event log.
+  - **Market-derived attributes** — anything that's "what's the
+    current price / current value / current availability": asset
+    unit prices, property current market values, sellability
+    masks. These are per-month reads from the market bundle, not
+    on the log. They're recomputed each month rather than stored
+    long-term.
+- The `apply_events(state, events) → state'` function is the only
+  state-mutation primitive. It's called once per step and is the
+  single testable site where "this event changes state this way"
+  is enforced.
+- The replay invariant is a property: `state_at(M) ==
+  apply_events(initial_state, log.filter(month ≤ M))` for every M.
+  Easy to assert in tests; opt-in `--check-replay` flag asserts it
+  per-month at runtime. If it ever fails, the bug is in
+  `apply_events` and the fix is in one place.
+
+The legacy engine had state mutation interleaved with transaction
+recording in a way that made the two get out of sync over time —
+mortgage payments updated some matrices but not others, sale
+recorders wrote one shape and tax allocation read another, and the
+"what's actually happened" answer was scattered across five
+overlapping representations. This design says: there's one answer
+to "what happened" (the log), and state is its incremental view.
+
 ## Five data layers
 
 State / configuration in the simulator lives at five distinct
@@ -48,64 +92,81 @@ engine's "five overlapping representations" problem.
    the existing augur market bundle, adapted to template-id-keyed
    lookups.
 
-4. **Working state — the canonical state-over-time long-form
-   frames** (polars). Six frames, all keyed by `(rollout_index,
-   month_index)` plus the entity-id columns for each kind:
+4. **Event log — the canonical record of what happened** (polars,
+   append-only). Every state-changing happening in the simulation
+   appears here:
+   - `events_log` — every event chronologically: cash transfers,
+     asset purchases / sales, lot consumptions, mortgage payments
+     (with P+I split), obligation accruals + settlements, tax
+     accruals + payments, income arrivals, depreciation accruals,
+     property purchases / sales (composite, multiple atomic rows
+     sharing a `cause_id`), occupancy-mode changes, ownership
+     starts / ends, failures. See [Event taxonomy](#event-taxonomy)
+     below for the kinds.
+   - Per-event-kind projections that fall out at output time:
+     `transactions_log` (cash-bearing events), `lot_dispositions_log`
+     (one row per consumed lot per sale, projected from
+     asset-sale events), `obligations_lifecycle_log` (accrual +
+     settlement pairs grouped by obligation), `failure_events_log`
+     (failure events), `policy_decisions_log` (every policy
+     evaluation, including no-fire), `tax_year_breakdown_log`
+     (year-end snapshots of the year-tax computation per
+     jurisdiction).
+
+   All event-sourced state at month M is `apply_events(initial_
+   state, events_log.filter(month ≤ M))`. The log is what survives
+   if working-state-layer 5 is dropped.
+
+5. **Working state — the incremental materialization of layer 4**
+   (polars, six frames). The simulator's current view of the
+   world. Six long-form frames keyed by `(rollout_index,
+   month_index)` plus entity-id columns:
    - `cash_balances` — `(rollout, month, agent_id, account_id,
-     balance_usd)`
+     balance_usd)`. **Event-sourced** — cumulative cash deltas.
    - `asset_lots` — `(rollout, month, agent_id, position_id,
      lot_id, template_id, units, basis_usd, acquired_month,
-     cost_basis_method, sellability_mask_ref)`
+     cost_basis_method, sellability_mask_ref, current_unit_price_
+     usd, current_market_value_usd)`. **Mixed**: units + basis +
+     acquired_month are event-sourced; current_unit_price_usd and
+     current_market_value_usd are market-derived (refreshed each
+     month from the market bundle).
    - `liabilities` — `(rollout, month, agent_id, liability_id,
      template_id, counterparty_agent_id, principal_usd,
      interest_accrued_this_month_usd, principal_paid_this_month_
-     usd, deductibility_flag, …)`
+     usd, deductibility_flag, …)`. Event-sourced.
    - `property_state` — `(rollout, month, property_id, location_
-     id, occupancy_mode, current_market_value_usd, adjusted_
-     basis_usd, cumulative_depreciation_usd, primary_residence_
-     use_months_within_window, owned_since_month, …)`
+     id, occupancy_mode, adjusted_basis_usd, cumulative_
+     depreciation_usd, owned_since_month, current_market_value_
+     usd, …)`. Mixed: occupancy_mode + adjusted_basis_usd +
+     cumulative_depreciation_usd + owned_since_month are
+     event-sourced; current_market_value_usd is market-derived.
+     §121 use-clock + ownership-tenure-clock are derived on demand
+     from the occupancy-change event history (not stored).
    - `property_stakes` — `(rollout, month, agent_id, property_id,
-     ownership_pct, contribution_used_usd, equity_ledger_usd)`
-     — single-row-per-property for single-owner; multi-row for
-     partner-equity stretch.
+     ownership_pct, contribution_used_usd, equity_ledger_usd)`.
+     Event-sourced. Single-row-per-property for single-owner;
+     multi-row for partner-equity stretch.
    - `rollout_status` — `(rollout, month, status, failure_event_
-     id, failure_month)`
+     id, failure_month)`. Event-sourced.
 
-   These frames **grow forward** as the loop advances: at month M
-   the frames have rows for months `0..M`. The state at month M is
-   `frame.filter(month_index == M)`; the per-rollout net worth
-   trajectory at agent A is `frame.filter(agent_id == A).group_by
-   (rollout_index, month_index).agg(...)`. The state-over-time IS
-   the output — there is no separate "snapshot matrices" layer
-   built post-hoc.
+   These frames **grow forward** as the loop advances; at month M
+   they hold rows for months `0..M`. The state at month M is
+   `frame.filter(month_index == M)`. Per-rollout / per-agent
+   queries are polars filters / group-bys.
 
-5. **Append-only logs** (polars, accumulated). The ledger of what
-   happened:
-   - `transactions_log` — every transaction (transfer, sale, tax
-     payment, etc.) chronologically with cause-id linking back to
-     the policy or obligation that produced it.
-   - `obligations_lifecycle_log` — every obligation accrual +
-     settlement with amount_due, amount_paid, status.
-   - `lot_dispositions_log` — one row per consumed lot per sale:
-     `(rollout, month, agent_id, position_id, lot_id, units_sold,
-     proceeds_usd, basis_consumed_usd, realized_gain_usd, holding_
-     period_days, tax_classification)`.
-   - `failure_events_log` — every unfunded required obligation.
-   - `policy_decisions_log` — every decision a policy made or
-     considered (including "did not fire because condition not
-     met"), for diagnostics.
-   - `tax_year_breakdown_log` — per `(rollout, agent, year,
-     jurisdiction)` the income totals, deduction amounts, bracket
-     walks, NIIT calc, totals.
+   **The state-over-time IS an output of the simulation, but it
+   is the materialization of the event log + market reads**, not a
+   separately-maintained truth. If we ever needed to compress the
+   simulation's persistence footprint, the log + initial state +
+   market bundle is the complete record; everything else is
+   derivable.
 
 The boundary discipline: layer 1 is law-and-place data, edited
 when reality changes. Layer 2 is what the user wants to simulate.
-Layer 3 is exogenous market input. Layer 4 IS the simulation —
-state evolves forward. Layer 5 is the audit trail of how state
-got from its prior value to its current value. Nothing in layer 4
-is computed from layer 5 post-hoc (that's the legacy engine's
-smell); nothing in layer 5 is needed to compute layer 4 (forward
-loop only reads state).
+Layer 3 is exogenous market input. **Layer 4 is what happened;
+layer 5 is its per-month view plus market-derived attributes.**
+The forward loop appends to layer 4 and incrementally maintains
+layer 5; the replay invariant guarantees they stay aligned.
 
 ## The forward loop
 
@@ -114,25 +175,38 @@ state_t = StateCrossSection.initial(scenario, market, rollout_count)
 append(state_t → state_frames at month 0)
 
 for month in range(horizon_months):
-    step_result = step(
+    # Step produces events for this month. Pure: no state mutation
+    # happens inside step(); state_t is read-only.
+    events_t = step_emit_events(
         state=state_t,
         market=market.at(month),
         jurisdictions=jurisdiction_set,
         scenario=scenario,
         month=month,
     )
-    state_t = step_result.next_state          # state at month+1
+
+    # Apply events to advance event-sourced state. Single mutation
+    # point. apply_events is the ONLY function that writes the
+    # event-sourced columns of state.
+    state_t_event_sourced = apply_events(state_t.event_sourced, events_t)
+
+    # Refresh market-derived attributes from the next month's
+    # market reads. Not part of apply_events because these aren't
+    # caused by events — they're per-month market lookups.
+    state_t = compose_state(
+        event_sourced=state_t_event_sourced,
+        market_derived=market.derive_at(state_t_event_sourced, month + 1),
+    )
+
     append(state_t → state_frames at month+1)
-    extend(step_result.transactions → transactions_log)
-    extend(step_result.obligations → obligations_lifecycle_log)
-    extend(step_result.lot_dispositions → lot_dispositions_log)
-    extend(step_result.failure_events → failure_events_log)
-    extend(step_result.policy_decisions → policy_decisions_log)
-    extend(step_result.tax_year_breakdown → tax_year_breakdown_log)
+    extend(events_t → events_log)
 
 return SimulationRun(
     state_frames=concat_state_frames(...),
-    logs=concat_logs(...),
+    events_log=concat(events_log),
+    # Per-event-kind projections (lot dispositions, obligations
+    # lifecycle, failures, policy decisions, tax breakdowns) are
+    # filters over events_log assembled at output time.
 )
 ```
 
@@ -142,188 +216,249 @@ step body — `state_t` is "the rollouts at one fixed month"); the
 loop tags it with `month_index = M` when appending to the
 forward-growing frames.
 
-## The step function — six phases
+**Replay invariant** (asserted in tests; opt-in `--check-replay`
+flag asserts it per-month at runtime):
 
-`step(state, market, jurisdictions, scenario, month) → StepResult`.
+```
+state_t.event_sourced ==
+    apply_events(
+        initial_state.event_sourced,
+        events_log.filter(month_index ≤ t),
+    )
+```
+
+If this ever fails, the bug is in `apply_events` (the only place
+that writes event-sourced state) and the fix is in one place.
+
+## The step function — five phases of event emission
+
+`step_emit_events(state, market, jurisdictions, scenario, month) →
+events_for_month`. The step is a **pure function**: it reads
+`state` (the per-month cross-section, including market-derived
+attributes refreshed at the prior iteration's end) and returns a
+batch of events for this month. It does not mutate state. The
+loop's `apply_events(state, events)` step is the single mutation
+point.
+
 Phases run in this fixed order. Each phase is one or more polars
 expressions over the rollout column; no Python iteration over
-rollouts; each phase produces transaction rows + an updated state
-cross-section.
+rollouts; each phase **appends rows to the within-step event
+buffer**. Phases later in the order can read events emitted by
+earlier phases via that buffer + a virtual "what state would be
+if we applied buffered events so far" projection (a thin wrapper
+over `apply_events` that doesn't commit). This lets phase 3 see
+the obligation accruals from phase 2 without phases having to
+share state mutation.
 
-1. **Mark-to-market.** Refresh asset unit prices and property
-   values from this month's market path. Pure read; no
-   transactions. Updates `asset_lots.unit_price_usd` (derived
-   column) and `property_state.current_market_value_usd`. Also
-   refreshes `asset_lots.sellability_at_this_month` from the
-   per-position sellability_mask_ref.
+1. **Scheduled events.** Apply scenario-scheduled events whose
+   month equals this month. Each emits one or more event rows:
+   - Property purchase event → emits a property-purchase composite
+     event (cash debit for down + buy closing, property creation,
+     mortgage origination).
+   - Property sale event → emits a property-sale composite event
+     (proceeds calc, mortgage payoff, net to seller, property
+     retirement, lot dispositions).
+   - Occupancy-mode switch → emits an occupancy-change event.
+   - Income arrival → emits an income event.
+   - Recurring-obligation accruals due this month → each emits an
+     obligation-accrual event (property tax, HOA, insurance,
+     maintenance, special assessment if due, mortgage payment,
+     monthly spend, outside rent).
+   - Tax-obligation accruals at marker months → each emits a
+     tax-accrual event per (agent, jurisdiction). Quarterly
+     estimated at Apr 15 / Jun 15 / Sep 15 / Jan 15 of next year;
+     year-end true-up at Dec.
 
-2. **Scheduled events.** Apply scenario-scheduled events whose
-   month equals this month:
-   - Property purchase event: instantiate a property_state row,
-     transfer down-payment + buy-closing-costs from agent cash,
-     originate the associated mortgage liability (a new
-     liabilities row).
-   - Property sale event: compute proceeds (current value − sale
-     closing costs), pay off any outstanding secured mortgage to
-     the counterparty agent's cash, transfer net proceeds to
-     seller, retire the property_state and liability rows (mark
-     `occupancy_mode = sold`), record the realized gain on the
-     lot-dispositions log.
-   - Occupancy-mode switch (primary → rental, rental → primary,
-     etc.): flip the property_state.occupancy_mode flag at this
-     month, which starts / stops depreciation accrual in phase 5
-     and starts / stops the rental-income stream in phase 3.
-   - Income arrival: W-2 paychecks, rental rent (per the
-     property's rental policy), classified for tax purposes.
-   - Recurring-obligation accruals due this month: property tax,
-     HOA, insurance, maintenance, special assessment if due,
-     mortgage payment, monthly spend, outside rent. Each accrues
-     an obligations_lifecycle row with status `accrued`.
-   - Tax-obligation accruals at marker months: quarterly
-     estimated tax (Apr 15, Jun 15, Sep 15, Jan 15 of next year)
-     based on safe-harbor of prior-year tax; year-end true-up at
-     Dec of each tax year based on the year's actual tax minus
-     estimated paid so far. Per-agent per-jurisdiction.
+2. **Settle required obligations.** For every accrued-but-unpaid
+   required obligation (read from the within-step buffer + the
+   prior month's still-open obligations), emit a settlement
+   event:
+   1. Pay from the agent's checking cash if sufficient → emits
+      an obligation-settlement event with cash side.
+   2. If short, walk the agent's funding chain. For each sale
+      step, emit an asset-sale event (consumes lots per the
+      position's cost-basis method) → cash side credits the
+      obligation. Stop selling as soon as the obligation is
+      funded.
+   3. If still short after the chain, emit a failure event for
+      the obligation + a rollout-status-change event flipping
+      the rollout to `failed` for this month.
 
-3. **Settle required obligations.** For every obligation row with
-   status `accrued` and required `true` (mortgage, property tax,
-   HOA, insurance, maintenance, tax — recurring and one-off —
-   special assessment, outside rent, partner contribution if in
-   scope), settle:
-   1. Pay from the agent's checking cash if sufficient.
-   2. If short, walk the agent's funding chain (sell from
-      configured asset-position preference order). Each sale
-      consumes lots per the position's cost-basis method, emits
-      lot-disposition rows, updates asset_lots units/basis, and
-      credits the agent's cash. Stop selling as soon as the
-      obligation is funded.
-   3. If still short after the chain, emit a failure_events row
-      and flip the rollout's status to `failed` for this month
-      (which persists for subsequent months until a configured
-      recovery, see S11.3 — phase 3 of a later month succeeds
-      and the status flips back to `active`).
-
-   Settlement order within phase 3 is fixed per agent: tax →
+   Settlement order within phase 2 is fixed per agent: tax →
    mortgage → property carrying costs → outside rent → partner
-   contribution → monthly spend. This is the existing engine's
-   priority and not currently parameterized; document it.
+   contribution → monthly spend.
 
-4. **Discretionary policies.** Each agent's configured policies
-   evaluate against the post-settlement state:
-   - Floor-triggered sale ("if checking < $X, sell $Y of position
-     Z"): a polars expression that masks the rollouts where the
-     condition holds and produces sale transactions for the masked
-     subset.
-   - Reinvest-excess ("if checking > $X, buy $Y of position Z").
-   - Any other configured policy.
+3. **Discretionary policies.** Each agent's configured policies
+   evaluate against the buffer's running view:
+   - Floor-triggered sale → emits asset-sale events for the
+     rollouts where the condition holds.
+   - Reinvest-excess → emits asset-purchase events.
+   - Other configured policies → emit appropriate events.
 
-   Each policy emits a policy_decisions row for every rollout
-   (whether or not it fired); the rows that fired also produce
-   transactions.
+   Each policy also emits a policy-decision diagnostic row
+   (whether or not it fired) for the policy_decisions projection.
 
-5. **End-of-month accruals.** State-only updates that don't move
-   cash:
-   - Depreciation tick on every property in `rental` occupancy
-     mode: `cumulative_depreciation_usd += monthly_depreciation
-     = building_portion_of_basis / (27.5 * 12)` per the
-     jurisdiction's residential-rental schedule.
-   - Mortgage liability principal-balance roll: next-month's
-     principal balance computed from this month's amortization
-     (already captured in the mortgage-payment transaction at
-     phase 3; this is just the forward-projection bookkeeping if
-     anything is needed).
-   - §121 use clock tick: `primary_residence_use_months_within_
-     window` increments by 1 for properties currently in
-     `primary_residence` mode; decrements the oldest month
-     falling off the 60-month window. (Or computed on demand at
-     sale; see decision below.)
-   - Asset lot ages increment by 1 (or derived on demand from
-     `acquired_month` vs current month at sale time — same
-     answer, derived-on-demand is simpler).
+4. **End-of-month accruals.** Emit non-cash state-changing
+   events:
+   - Depreciation accrual on every property in `rental`
+     occupancy mode → emits a depreciation-accrual event
+     `(rollout, month, property_id, monthly_depreciation_amount)`.
+     The jurisdiction's residential-rental schedule supplies the
+     denominator.
+   - Mortgage interest accrual / amortization tick is already
+     captured by the mortgage-payment event at phase 1; no
+     additional event needed.
+   - Clock-style state (§121 use clock, ownership tenure, asset
+     lot age) is **not** stored on state and **not** emitted as
+     events — it's derived on demand at sale time from the
+     occupancy-change event history (for §121) or from
+     `acquired_month` vs current month (for lot age). This
+     drops a category of "tick" events from the log and
+     simplifies state.
 
-6. **Construct next state cross-section.** Assemble all the
-   updates above into the `state_{M+1}` cross-section. Append-
-   ready for the loop's frame-extension step.
+5. **Rollout-status check.** If any required obligation in this
+   month went unfunded (failure event emitted in phase 2), the
+   rollout-status-change event was already emitted there. This
+   phase exists for any cross-phase status reconciliation (e.g.,
+   if a previously-failed rollout completed a settlement this
+   month, emit a rollout-status-change reverting to `active`).
 
-The returned `StepResult` carries:
-- `next_state`: the new cross-section.
-- `transactions`: all transactions produced this month (one row
-  per transaction, schema below).
-- `obligations`: every accrued / settled / unpaid obligation row
-  for this month.
-- `lot_dispositions`: rows for any sales this month.
-- `failure_events`: rows for any unfunded required obligations.
-- `policy_decisions`: rows for every policy evaluation this month.
-- `tax_year_breakdown`: rows when the year-end tax computation
-  fires (December of each year + scenario horizon end).
+The returned `events_for_month` is the union of all phase event
+buffers, in emission order. Each event row carries `(rollout,
+month, kind, cause_id, ...kind-specific columns)`. The loop's
+`apply_events(state_t, events_for_month)` consumes this and
+produces the event-sourced part of `state_{t+1}`.
 
-## Transaction taxonomy
+Per-event-kind projections (transactions, lot dispositions,
+obligation lifecycle, failures, policy decisions, tax
+breakdowns) are filters / joins / group-bys over `events_log`
+assembled at output time. They are not separately tracked
+alongside the log.
 
-Every state mutation goes through one of a small set of
-transaction kinds. Discriminated union; balance-checked at
-construction; each row on the `transactions_log` carries the kind
-plus the kind-specific columns.
+## Event taxonomy
 
-Cash-side balance invariant: every transaction's `Σ(agent_cash_
-delta_usd) == 0` (money moves between agents and the sink-agent
-representation of an external counterparty; see lender note in
-REQUIREMENTS.md).
+Every state-changing happening in the simulation appears as one
+or more events on the `events_log`. Discriminated union; each row
+carries `kind` + `cause_id` + kind-specific columns.
 
-Transaction kinds (the full set; not every kind is needed at
-every layer):
+The single per-step buffer is the union of all events emitted
+this month. `apply_events(state, events)` is the only function
+that mutates event-sourced state; it dispatches on `kind` to
+update the relevant frame.
+
+**Cash-side balance invariant**: for events that move cash,
+`Σ(agent_cash_delta_usd) == 0` across the agents the event
+touches. For events that aren't cash transactions (occupancy
+mode change, depreciation accrual, rollout status change), no
+cash invariant applies — they update non-cash state.
+
+Event kinds (the full set; not every kind is needed at every
+layer):
+
+**Cash-bearing (transactions):**
 
 - **Transfer** — cash moves between two agents' accounts. The
-  primitive that S1.1 uses. May carry an income classification on
-  the receiving side.
+  primitive that S1.1 uses. May carry an income classification
+  on the receiving side.
+- **Income arrival** — recurring cash inflow with a
+  tax-classification label (W-2 ordinary, rental income, etc.).
+  Practically a Transfer from a market-sink agent.
 - **Asset purchase** — cash leaves an agent's account, a new lot
-  appears on the asset_lots frame for that agent. (For market
-  purchases; the counterparty is the market sink.)
-- **Asset sale** — units of one or more lots are consumed (per the
-  position's cost-basis method); cash arrives. Realized gain is
-  derived from the lot dispositions, not carried separately on
-  the transaction itself.
-- **Property purchase** — composite: cash leaves (down payment +
-  buy closing), property_state row appears, mortgage liability
-  originates (linked to a separate Transfer-like cash-flow between
-  the lender's cash and the purchaser's cash for the loan principal,
-  which immediately routes back out as part of the down + balance
-  going to seller).
-- **Property sale** — composite: closing cost out, mortgage payoff
-  out, net proceeds to seller, property_state retires.
+  appears on the asset_lots frame. Counterparty is the market
+  sink (for market buys) or another agent (for inter-agent
+  transfers of an asset, if we ever model that).
+- **Asset sale** — units of one or more lots are consumed (per
+  the position's cost-basis method); cash arrives. The lot
+  consumption is part of the event; the realized gain falls
+  out of (proceeds − basis_consumed).
 - **Mortgage payment** — composite: borrower's cash out (P+I);
   lender's cash in; borrower's mortgage liability principal
-  decreases by P; the I portion is recorded for the borrower's
-  qualified-residence-interest-paid tally and the lender's
-  interest-income tally (lender is not-tax-paying per scope, but
-  the row is recorded for symmetry).
-- **Obligation settlement** — composite of "cash out + obligation
-  status flips to `paid`". When the obligation is a recurring
-  charge like property tax that has no specific counterparty
-  agent, the cash exits to a designated sink representing the
-  external counterparty (taxing authority, HOA, insurance
-  company). The sink is not modeled beyond being the recipient of
-  the funds.
-- **Tax accrual** — non-cash: a TAX_PAYABLE liability appears on
-  the agent's books at year-end; an offsetting tax-expense
-  classification is recorded for that year. Net effect: the
-  agent's net worth shows the tax liability accrued but not paid.
-- **Tax payment** — quarterly estimated payment or year-end
+  decreases by P. The I portion is captured as a column on the
+  event for the borrower's qualified-residence-interest tally
+  and the lender's interest-income tally (lender is
+  not-tax-paying per scope; the row exists for symmetry).
+- **Obligation settlement** — cash out from the obligated agent;
+  cash in to either a counterparty agent (intra-sim) or a sink
+  (taxing authority, HOA, insurance company); marks the
+  obligation as paid. If only partially funded, the obligation
+  remains open with `unpaid_amount_usd > 0` and a failure event
+  fires separately.
+- **Tax payment** — special-case obligation settlement against
+  the tax-payable liability. Quarterly estimated or year-end
   true-up. Cash out, tax_payable balance decreases.
-- **Income arrival** — recurring cash inflow with a tax-
-  classification label (W-2 ordinary, rental income, etc.).
-- **Depreciation accrual** — non-cash: property's `cumulative_
-  depreciation_usd` increases; the year's tally for the property's
-  owner accumulates for net-rental-income computation. Not on the
-  transactions log proper (it's not a cash event) but recorded
-  for audit.
+- **Property purchase / sale (composite)** — produces multiple
+  atomic events sharing a `cause_id`: a cash debit for down +
+  buy closing, an asset-purchase-equivalent (the property
+  appears on `property_state`), a mortgage-origination event
+  for the liability side. Property sale: closing cost out,
+  mortgage payoff (a Mortgage payment event that fully pays the
+  remaining balance), net proceeds to seller (a Transfer to the
+  seller's cash), and a property retirement.
 
-The "composite" transactions (Property purchase / sale, Mortgage
-payment, etc.) produce multiple rows on the transactions_log —
-one row per atomic balance-checked cash/asset movement, all
-sharing a `cause_id` linking them as one logical event. The
-materialize step can group by cause_id to produce a coarse-grained
-view (e.g., "this is one mortgage payment with these P+I splits")
-when the user wants that.
+**Non-cash state mutations:**
+
+- **Obligation accrual** — an obligation comes into being for
+  this month (a property tax bill is due, a tax-payment marker
+  fires, the mortgage's monthly payment is due). Adds a row to
+  the (open obligations view, derivable from log) and feeds
+  phase 2's settlement.
+- **Tax accrual** — at year-end, a TAX_PAYABLE liability appears
+  on the agent's books for the year's actual tax minus already-
+  paid estimated. Subsequent tax-payment events settle it.
+- **Depreciation accrual** — property's `cumulative_
+  depreciation_usd` increases by `monthly_depreciation_amount`.
+  Year-end tax computation reads the year's sum.
+- **Occupancy-mode change** — property's `occupancy_mode` flips
+  from one value to another at this month. Drives whether
+  depreciation accrues, whether rental-income arrives, whether
+  the §121 use clock is ticking. The §121 use clock and ownership
+  tenure are derived on demand from the chronological sequence
+  of these events — they're not stored on state.
+- **Mortgage origination** — a new amortizing-loan liability
+  comes into being for a borrower with a counterparty lender.
+  Cash side (loan principal → borrower cash) is recorded as part
+  of the property-purchase composite or as a standalone Transfer
+  if origination is standalone.
+- **Failure event** — a required obligation went unfunded after
+  the funding chain ran. Row carries `(rollout, month,
+  obligation_id, obligation_type, amount_due, amount_paid,
+  shortfall, attempted_funding_sources)`.
+- **Rollout-status change** — `rollout_status` flips from
+  `active` to `failed` (or back). Event-sourced; the
+  `rollout_status` frame is the per-month materialization.
+- **Policy decision (diagnostic)** — every policy evaluation
+  for every rollout, including no-fires. Doesn't change
+  event-sourced state directly (the asset-sale / asset-purchase
+  events the policy emitted do that), but is on the log for
+  diagnostics. The `policy_decisions_log` projection filters
+  for these.
+- **Tax-year breakdown (diagnostic)** — at each year-end, a
+  snapshot of the year-tax computation: per `(rollout, agent,
+  year, jurisdiction)` the income totals, deduction amounts,
+  bracket walks, NIIT, totals. Doesn't itself drive state
+  (the tax accrual + tax payment events do that), but is a
+  first-class diagnostic on the log.
+
+Composite events (Property purchase / sale, Mortgage origination
++ down-payment in one logical purchase, etc.) emit multiple
+atomic event rows sharing a `cause_id`. Each atomic row is
+balance-checked on its own. The materialize step can
+`group_by(cause_id)` to produce a coarse-grained "one mortgage
+payment with P+I split" view when the user wants that.
+
+The `apply_events` function dispatches on event `kind` to update
+the right frame:
+- Cash-bearing events → update `cash_balances`.
+- Asset purchase / sale → update `asset_lots`.
+- Mortgage payment / origination → update `liabilities`.
+- Property purchase / sale → update `property_state` (+ the
+  cash + asset + liability rows that fall out).
+- Occupancy-mode change / depreciation accrual → update
+  `property_state`.
+- Rollout-status change → update `rollout_status`.
+- Tax accrual → update `liabilities` (tax_payable row).
+- Failure event / policy decision / tax-year breakdown →
+  diagnostic only, no state mutation.
 
 ## Templates, jurisdictions, locations as data
 

--- a/augur/sim/DESIGN.md
+++ b/augur/sim/DESIGN.md
@@ -44,7 +44,7 @@ Practical consequences of this discipline:
   single testable site where "this event changes state this way"
   is enforced.
 - The replay invariant is a property: `state_at(M) ==
-  apply_events(initial_state, log.filter(month ≤ M))` for every M.
+apply_events(initial_state, log.filter(month ≤ M))` for every M.
   Easy to assert in tests; opt-in `--check-replay` flag asserts it
   per-month at runtime. If it ever fails, the bug is in
   `apply_events` and the fix is in one place.
@@ -114,40 +114,40 @@ engine's "five overlapping representations" problem.
      jurisdiction).
 
    All event-sourced state at month M is `apply_events(initial_
-   state, events_log.filter(month ≤ M))`. The log is what survives
+state, events_log.filter(month ≤ M))`. The log is what survives
    if working-state-layer 5 is dropped.
 
 5. **Working state — the incremental materialization of layer 4**
    (polars, six frames). The simulator's current view of the
    world. Six long-form frames keyed by `(rollout_index,
-   month_index)` plus entity-id columns:
+month_index)` plus entity-id columns:
    - `cash_balances` — `(rollout, month, agent_id, account_id,
-     balance_usd)`. **Event-sourced** — cumulative cash deltas.
+balance_usd)`. **Event-sourced** — cumulative cash deltas.
    - `asset_lots` — `(rollout, month, agent_id, position_id,
-     lot_id, template_id, units, basis_usd, acquired_month,
-     cost_basis_method, sellability_mask_ref, current_unit_price_
-     usd, current_market_value_usd)`. **Mixed**: units + basis +
+lot_id, template_id, units, basis_usd, acquired_month,
+cost_basis_method, sellability_mask_ref, current_unit_price_
+usd, current_market_value_usd)`. **Mixed**: units + basis +
      acquired_month are event-sourced; current_unit_price_usd and
      current_market_value_usd are market-derived (refreshed each
      month from the market bundle).
    - `liabilities` — `(rollout, month, agent_id, liability_id,
-     template_id, counterparty_agent_id, principal_usd,
-     interest_accrued_this_month_usd, principal_paid_this_month_
-     usd, deductibility_flag, …)`. Event-sourced.
+template_id, counterparty_agent_id, principal_usd,
+interest_accrued_this_month_usd, principal_paid_this_month_
+usd, deductibility_flag, …)`. Event-sourced.
    - `property_state` — `(rollout, month, property_id, location_
-     id, occupancy_mode, adjusted_basis_usd, cumulative_
-     depreciation_usd, owned_since_month, current_market_value_
-     usd, …)`. Mixed: occupancy_mode + adjusted_basis_usd +
+id, occupancy_mode, adjusted_basis_usd, cumulative_
+depreciation_usd, owned_since_month, current_market_value_
+usd, …)`. Mixed: occupancy_mode + adjusted_basis_usd +
      cumulative_depreciation_usd + owned_since_month are
      event-sourced; current_market_value_usd is market-derived.
      §121 use-clock + ownership-tenure-clock are derived on demand
      from the occupancy-change event history (not stored).
    - `property_stakes` — `(rollout, month, agent_id, property_id,
-     ownership_pct, contribution_used_usd, equity_ledger_usd)`.
+ownership_pct, contribution_used_usd, equity_ledger_usd)`.
      Event-sourced. Single-row-per-property for single-owner;
      multi-row for partner-equity stretch.
    - `rollout_status` — `(rollout, month, status, failure_event_
-     id, failure_month)`. Event-sourced.
+id, failure_month)`. Event-sourced.
 
    These frames **grow forward** as the loop advances; at month M
    they hold rows for months `0..M`. The state at month M is
@@ -406,7 +406,7 @@ layer):
   on the agent's books for the year's actual tax minus already-
   paid estimated. Subsequent tax-payment events settle it.
 - **Depreciation accrual** — property's `cumulative_
-  depreciation_usd` increases by `monthly_depreciation_amount`.
+depreciation_usd` increases by `monthly_depreciation_amount`.
   Year-end tax computation reads the year's sum.
 - **Occupancy-mode change** — property's `occupancy_mode` flips
   from one value to another at this month. Drives whether
@@ -421,8 +421,8 @@ layer):
   if origination is standalone.
 - **Failure event** — a required obligation went unfunded after
   the funding chain ran. Row carries `(rollout, month,
-  obligation_id, obligation_type, amount_due, amount_paid,
-  shortfall, attempted_funding_sources)`.
+obligation_id, obligation_type, amount_due, amount_paid,
+shortfall, attempted_funding_sources)`.
 - **Rollout-status change** — `rollout_status` flips from
   `active` to `failed` (or back). Event-sourced; the
   `rollout_status` frame is the per-month materialization.
@@ -434,20 +434,22 @@ layer):
   for these.
 - **Tax-year breakdown (diagnostic)** — at each year-end, a
   snapshot of the year-tax computation: per `(rollout, agent,
-  year, jurisdiction)` the income totals, deduction amounts,
+year, jurisdiction)` the income totals, deduction amounts,
   bracket walks, NIIT, totals. Doesn't itself drive state
   (the tax accrual + tax payment events do that), but is a
   first-class diagnostic on the log.
 
 Composite events (Property purchase / sale, Mortgage origination
-+ down-payment in one logical purchase, etc.) emit multiple
-atomic event rows sharing a `cause_id`. Each atomic row is
-balance-checked on its own. The materialize step can
-`group_by(cause_id)` to produce a coarse-grained "one mortgage
-payment with P+I split" view when the user wants that.
+
+- down-payment in one logical purchase, etc.) emit multiple
+  atomic event rows sharing a `cause_id`. Each atomic row is
+  balance-checked on its own. The materialize step can
+  `group_by(cause_id)` to produce a coarse-grained "one mortgage
+  payment with P+I split" view when the user wants that.
 
 The `apply_events` function dispatches on event `kind` to update
 the right frame:
+
 - Cash-bearing events → update `cash_balances`.
 - Asset purchase / sale → update `asset_lots`.
 - Mortgage payment / origination → update `liabilities`.
@@ -484,13 +486,14 @@ Concretely:
   - `"tax_payable"` for accrued-but-unpaid tax.
 
 Per-template rules live in code as functions over polars frames:
+
 - `apply_mark_to_market_capital_gains_eligible_holding(frames,
-  market)` — filters asset_lots by `template_id =
-  "capital_gains_eligible_holding"`, joins market prices, returns
+market)` — filters asset_lots by `template_id =
+"capital_gains_eligible_holding"`, joins market prices, returns
   updated rows.
 - `apply_depreciation_accrual_depreciable_real_property(frames,
-  jurisdiction)` — filters property_state by `template_id =
-  "depreciable_real_property"` + `occupancy_mode = "rental"`,
+jurisdiction)` — filters property_state by `template_id =
+"depreciable_real_property"` + `occupancy_mode = "rental"`,
   applies the jurisdiction's residential-rental schedule, returns
   updated rows.
 - `apply_amortization_amortizing_loan(frames, month)` — filters
@@ -506,6 +509,7 @@ filter functions; the rest of the engine doesn't change.
 
 **Jurisdictions** are Pydantic records loaded from YAML at
 startup:
+
 - `JurisdictionId` is a string (`"federal_us"`, `"california"`).
 - A `Jurisdiction` record carries: brackets per filing status,
   standard deduction per filing status, NIIT params, SALT cap,
@@ -517,6 +521,7 @@ startup:
   entry.
 
 **Locations** are Pydantic records loaded from YAML at startup:
+
 - `LocationId` is a string (`"san_francisco"`, `"palo_alto"`).
 - A `Location` record carries: applicable jurisdiction ids (list,
   ordered), property tax rate / formula, transfer tax schedule,

--- a/augur/sim/DESIGN.md
+++ b/augur/sim/DESIGN.md
@@ -1,0 +1,573 @@
+# Augur sim — design
+
+Companion to <REQUIREMENTS.md>. This doc translates the requirements
+into a concrete shape — the layers of state, the forward loop, the
+transaction taxonomy, how templates + jurisdictions + locations are
+expressed, and the file layout — without committing to particular
+function signatures yet. Read it as the **load-bearing structural
+decisions**, not the API.
+
+The goal: design once, in shape that grows from S1.1 (Alice gives
+Bob \$5) up through the full housing + multi-property + constrained-
+liquidity + multi-jurisdiction-tax spec without retrofitting. If a
+later layer requires moving primitives around, that's a design bug
+to catch here.
+
+## Five data layers
+
+State / configuration in the simulator lives at five distinct
+lifetimes. Each layer is read by a specific set of consumers; muddy
+boundaries between them are the smell that produced the legacy
+engine's "five overlapping representations" problem.
+
+1. **Static reference data** (YAML, repo-checked-in). Federal + CA
+   tax brackets, NIIT thresholds, SALT cap, qualified-residence
+   interest cap, LTCG thresholds, depreciation schedules, §1250
+   rate, §121 exclusion amount. Per-location property-tax rates,
+   transfer-tax schedules, applicable-jurisdiction lists. Loaded
+   once at startup; validated by Pydantic models; consumed by
+   templates as parameters.
+
+2. **Scenario configuration** (Pydantic, constructed by users).
+   The agents, their initial balance sheets, their tax profiles
+   (filing status, prior-year tax), their positions (one per
+   capital-gains-eligible holding configured), their liabilities
+   (mortgage origination events with terms), their properties
+   (with location id, occupancy timeline, mortgage reference),
+   their policies (funding chain order, sale rules, spending),
+   their scheduled events (property purchases, sales, occupancy
+   switches), and the market-bundle reference. Validated at
+   construction time.
+
+3. **Market bundle** (external, lazy / sampled). Per-rollout
+   per-month paths for every market driver the scenario consumes:
+   asset unit-price multipliers, property-value multipliers per
+   location, sellability masks for constrained-liquidity
+   positions, spending-variance paths, rental-income variance
+   paths, tender-opportunity masks. Same input-output contract as
+   the existing augur market bundle, adapted to template-id-keyed
+   lookups.
+
+4. **Working state — the canonical state-over-time long-form
+   frames** (polars). Six frames, all keyed by `(rollout_index,
+   month_index)` plus the entity-id columns for each kind:
+   - `cash_balances` — `(rollout, month, agent_id, account_id,
+     balance_usd)`
+   - `asset_lots` — `(rollout, month, agent_id, position_id,
+     lot_id, template_id, units, basis_usd, acquired_month,
+     cost_basis_method, sellability_mask_ref)`
+   - `liabilities` — `(rollout, month, agent_id, liability_id,
+     template_id, counterparty_agent_id, principal_usd,
+     interest_accrued_this_month_usd, principal_paid_this_month_
+     usd, deductibility_flag, …)`
+   - `property_state` — `(rollout, month, property_id, location_
+     id, occupancy_mode, current_market_value_usd, adjusted_
+     basis_usd, cumulative_depreciation_usd, primary_residence_
+     use_months_within_window, owned_since_month, …)`
+   - `property_stakes` — `(rollout, month, agent_id, property_id,
+     ownership_pct, contribution_used_usd, equity_ledger_usd)`
+     — single-row-per-property for single-owner; multi-row for
+     partner-equity stretch.
+   - `rollout_status` — `(rollout, month, status, failure_event_
+     id, failure_month)`
+
+   These frames **grow forward** as the loop advances: at month M
+   the frames have rows for months `0..M`. The state at month M is
+   `frame.filter(month_index == M)`; the per-rollout net worth
+   trajectory at agent A is `frame.filter(agent_id == A).group_by
+   (rollout_index, month_index).agg(...)`. The state-over-time IS
+   the output — there is no separate "snapshot matrices" layer
+   built post-hoc.
+
+5. **Append-only logs** (polars, accumulated). The ledger of what
+   happened:
+   - `transactions_log` — every transaction (transfer, sale, tax
+     payment, etc.) chronologically with cause-id linking back to
+     the policy or obligation that produced it.
+   - `obligations_lifecycle_log` — every obligation accrual +
+     settlement with amount_due, amount_paid, status.
+   - `lot_dispositions_log` — one row per consumed lot per sale:
+     `(rollout, month, agent_id, position_id, lot_id, units_sold,
+     proceeds_usd, basis_consumed_usd, realized_gain_usd, holding_
+     period_days, tax_classification)`.
+   - `failure_events_log` — every unfunded required obligation.
+   - `policy_decisions_log` — every decision a policy made or
+     considered (including "did not fire because condition not
+     met"), for diagnostics.
+   - `tax_year_breakdown_log` — per `(rollout, agent, year,
+     jurisdiction)` the income totals, deduction amounts, bracket
+     walks, NIIT calc, totals.
+
+The boundary discipline: layer 1 is law-and-place data, edited
+when reality changes. Layer 2 is what the user wants to simulate.
+Layer 3 is exogenous market input. Layer 4 IS the simulation —
+state evolves forward. Layer 5 is the audit trail of how state
+got from its prior value to its current value. Nothing in layer 4
+is computed from layer 5 post-hoc (that's the legacy engine's
+smell); nothing in layer 5 is needed to compute layer 4 (forward
+loop only reads state).
+
+## The forward loop
+
+```
+state_t = StateCrossSection.initial(scenario, market, rollout_count)
+append(state_t → state_frames at month 0)
+
+for month in range(horizon_months):
+    step_result = step(
+        state=state_t,
+        market=market.at(month),
+        jurisdictions=jurisdiction_set,
+        scenario=scenario,
+        month=month,
+    )
+    state_t = step_result.next_state          # state at month+1
+    append(state_t → state_frames at month+1)
+    extend(step_result.transactions → transactions_log)
+    extend(step_result.obligations → obligations_lifecycle_log)
+    extend(step_result.lot_dispositions → lot_dispositions_log)
+    extend(step_result.failure_events → failure_events_log)
+    extend(step_result.policy_decisions → policy_decisions_log)
+    extend(step_result.tax_year_breakdown → tax_year_breakdown_log)
+
+return SimulationRun(
+    state_frames=concat_state_frames(...),
+    logs=concat_logs(...),
+)
+```
+
+The simulator does not re-derive any prior month. Each `state_t`
+is the polars cross-section (no `month_index` column inside the
+step body — `state_t` is "the rollouts at one fixed month"); the
+loop tags it with `month_index = M` when appending to the
+forward-growing frames.
+
+## The step function — six phases
+
+`step(state, market, jurisdictions, scenario, month) → StepResult`.
+Phases run in this fixed order. Each phase is one or more polars
+expressions over the rollout column; no Python iteration over
+rollouts; each phase produces transaction rows + an updated state
+cross-section.
+
+1. **Mark-to-market.** Refresh asset unit prices and property
+   values from this month's market path. Pure read; no
+   transactions. Updates `asset_lots.unit_price_usd` (derived
+   column) and `property_state.current_market_value_usd`. Also
+   refreshes `asset_lots.sellability_at_this_month` from the
+   per-position sellability_mask_ref.
+
+2. **Scheduled events.** Apply scenario-scheduled events whose
+   month equals this month:
+   - Property purchase event: instantiate a property_state row,
+     transfer down-payment + buy-closing-costs from agent cash,
+     originate the associated mortgage liability (a new
+     liabilities row).
+   - Property sale event: compute proceeds (current value − sale
+     closing costs), pay off any outstanding secured mortgage to
+     the counterparty agent's cash, transfer net proceeds to
+     seller, retire the property_state and liability rows (mark
+     `occupancy_mode = sold`), record the realized gain on the
+     lot-dispositions log.
+   - Occupancy-mode switch (primary → rental, rental → primary,
+     etc.): flip the property_state.occupancy_mode flag at this
+     month, which starts / stops depreciation accrual in phase 5
+     and starts / stops the rental-income stream in phase 3.
+   - Income arrival: W-2 paychecks, rental rent (per the
+     property's rental policy), classified for tax purposes.
+   - Recurring-obligation accruals due this month: property tax,
+     HOA, insurance, maintenance, special assessment if due,
+     mortgage payment, monthly spend, outside rent. Each accrues
+     an obligations_lifecycle row with status `accrued`.
+   - Tax-obligation accruals at marker months: quarterly
+     estimated tax (Apr 15, Jun 15, Sep 15, Jan 15 of next year)
+     based on safe-harbor of prior-year tax; year-end true-up at
+     Dec of each tax year based on the year's actual tax minus
+     estimated paid so far. Per-agent per-jurisdiction.
+
+3. **Settle required obligations.** For every obligation row with
+   status `accrued` and required `true` (mortgage, property tax,
+   HOA, insurance, maintenance, tax — recurring and one-off —
+   special assessment, outside rent, partner contribution if in
+   scope), settle:
+   1. Pay from the agent's checking cash if sufficient.
+   2. If short, walk the agent's funding chain (sell from
+      configured asset-position preference order). Each sale
+      consumes lots per the position's cost-basis method, emits
+      lot-disposition rows, updates asset_lots units/basis, and
+      credits the agent's cash. Stop selling as soon as the
+      obligation is funded.
+   3. If still short after the chain, emit a failure_events row
+      and flip the rollout's status to `failed` for this month
+      (which persists for subsequent months until a configured
+      recovery, see S11.3 — phase 3 of a later month succeeds
+      and the status flips back to `active`).
+
+   Settlement order within phase 3 is fixed per agent: tax →
+   mortgage → property carrying costs → outside rent → partner
+   contribution → monthly spend. This is the existing engine's
+   priority and not currently parameterized; document it.
+
+4. **Discretionary policies.** Each agent's configured policies
+   evaluate against the post-settlement state:
+   - Floor-triggered sale ("if checking < $X, sell $Y of position
+     Z"): a polars expression that masks the rollouts where the
+     condition holds and produces sale transactions for the masked
+     subset.
+   - Reinvest-excess ("if checking > $X, buy $Y of position Z").
+   - Any other configured policy.
+
+   Each policy emits a policy_decisions row for every rollout
+   (whether or not it fired); the rows that fired also produce
+   transactions.
+
+5. **End-of-month accruals.** State-only updates that don't move
+   cash:
+   - Depreciation tick on every property in `rental` occupancy
+     mode: `cumulative_depreciation_usd += monthly_depreciation
+     = building_portion_of_basis / (27.5 * 12)` per the
+     jurisdiction's residential-rental schedule.
+   - Mortgage liability principal-balance roll: next-month's
+     principal balance computed from this month's amortization
+     (already captured in the mortgage-payment transaction at
+     phase 3; this is just the forward-projection bookkeeping if
+     anything is needed).
+   - §121 use clock tick: `primary_residence_use_months_within_
+     window` increments by 1 for properties currently in
+     `primary_residence` mode; decrements the oldest month
+     falling off the 60-month window. (Or computed on demand at
+     sale; see decision below.)
+   - Asset lot ages increment by 1 (or derived on demand from
+     `acquired_month` vs current month at sale time — same
+     answer, derived-on-demand is simpler).
+
+6. **Construct next state cross-section.** Assemble all the
+   updates above into the `state_{M+1}` cross-section. Append-
+   ready for the loop's frame-extension step.
+
+The returned `StepResult` carries:
+- `next_state`: the new cross-section.
+- `transactions`: all transactions produced this month (one row
+  per transaction, schema below).
+- `obligations`: every accrued / settled / unpaid obligation row
+  for this month.
+- `lot_dispositions`: rows for any sales this month.
+- `failure_events`: rows for any unfunded required obligations.
+- `policy_decisions`: rows for every policy evaluation this month.
+- `tax_year_breakdown`: rows when the year-end tax computation
+  fires (December of each year + scenario horizon end).
+
+## Transaction taxonomy
+
+Every state mutation goes through one of a small set of
+transaction kinds. Discriminated union; balance-checked at
+construction; each row on the `transactions_log` carries the kind
+plus the kind-specific columns.
+
+Cash-side balance invariant: every transaction's `Σ(agent_cash_
+delta_usd) == 0` (money moves between agents and the sink-agent
+representation of an external counterparty; see lender note in
+REQUIREMENTS.md).
+
+Transaction kinds (the full set; not every kind is needed at
+every layer):
+
+- **Transfer** — cash moves between two agents' accounts. The
+  primitive that S1.1 uses. May carry an income classification on
+  the receiving side.
+- **Asset purchase** — cash leaves an agent's account, a new lot
+  appears on the asset_lots frame for that agent. (For market
+  purchases; the counterparty is the market sink.)
+- **Asset sale** — units of one or more lots are consumed (per the
+  position's cost-basis method); cash arrives. Realized gain is
+  derived from the lot dispositions, not carried separately on
+  the transaction itself.
+- **Property purchase** — composite: cash leaves (down payment +
+  buy closing), property_state row appears, mortgage liability
+  originates (linked to a separate Transfer-like cash-flow between
+  the lender's cash and the purchaser's cash for the loan principal,
+  which immediately routes back out as part of the down + balance
+  going to seller).
+- **Property sale** — composite: closing cost out, mortgage payoff
+  out, net proceeds to seller, property_state retires.
+- **Mortgage payment** — composite: borrower's cash out (P+I);
+  lender's cash in; borrower's mortgage liability principal
+  decreases by P; the I portion is recorded for the borrower's
+  qualified-residence-interest-paid tally and the lender's
+  interest-income tally (lender is not-tax-paying per scope, but
+  the row is recorded for symmetry).
+- **Obligation settlement** — composite of "cash out + obligation
+  status flips to `paid`". When the obligation is a recurring
+  charge like property tax that has no specific counterparty
+  agent, the cash exits to a designated sink representing the
+  external counterparty (taxing authority, HOA, insurance
+  company). The sink is not modeled beyond being the recipient of
+  the funds.
+- **Tax accrual** — non-cash: a TAX_PAYABLE liability appears on
+  the agent's books at year-end; an offsetting tax-expense
+  classification is recorded for that year. Net effect: the
+  agent's net worth shows the tax liability accrued but not paid.
+- **Tax payment** — quarterly estimated payment or year-end
+  true-up. Cash out, tax_payable balance decreases.
+- **Income arrival** — recurring cash inflow with a tax-
+  classification label (W-2 ordinary, rental income, etc.).
+- **Depreciation accrual** — non-cash: property's `cumulative_
+  depreciation_usd` increases; the year's tally for the property's
+  owner accumulates for net-rental-income computation. Not on the
+  transactions log proper (it's not a cash event) but recorded
+  for audit.
+
+The "composite" transactions (Property purchase / sale, Mortgage
+payment, etc.) produce multiple rows on the transactions_log —
+one row per atomic balance-checked cash/asset movement, all
+sharing a `cause_id` linking them as one logical event. The
+materialize step can group by cause_id to produce a coarse-grained
+view (e.g., "this is one mortgage payment with these P+I splits")
+when the user wants that.
+
+## Templates, jurisdictions, locations as data
+
+The asset templates listed in REQUIREMENTS.md are not Python
+classes. They are **discriminator values on the appropriate frame**
+plus a **per-template rule function** that the engine applies to
+the rows tagged with that template.
+
+Concretely:
+
+- `asset_lots.template_id` is a string column. Values:
+  - `"capital_gains_eligible_holding"` for stock-like / crypto-
+    like / PE-like positions.
+  - (Possibly future: `"interest_bearing_account"` for savings,
+    `"non_taxable_holding"` for tax-advantaged accounts, etc.)
+
+- `property_state.template_id` is a string column. Values:
+  - `"depreciable_real_property"` for any property.
+
+- `liabilities.template_id` is a string column. Values:
+  - `"amortizing_loan"` for mortgages and any other fixed-payment
+    debt between two agents.
+  - `"tax_payable"` for accrued-but-unpaid tax.
+
+Per-template rules live in code as functions over polars frames:
+- `apply_mark_to_market_capital_gains_eligible_holding(frames,
+  market)` — filters asset_lots by `template_id =
+  "capital_gains_eligible_holding"`, joins market prices, returns
+  updated rows.
+- `apply_depreciation_accrual_depreciable_real_property(frames,
+  jurisdiction)` — filters property_state by `template_id =
+  "depreciable_real_property"` + `occupancy_mode = "rental"`,
+  applies the jurisdiction's residential-rental schedule, returns
+  updated rows.
+- `apply_amortization_amortizing_loan(frames, month)` — filters
+  liabilities by `template_id = "amortizing_loan"`, computes
+  this month's P+I split.
+- `compute_year_tax_tax_payable(frames, jurisdiction, year)` —
+  filters liabilities by `template_id = "tax_payable"`, computes
+  the year's accrual based on aggregated income + gains.
+
+The engine's per-month step calls one function per (rule,
+template). Adding a new template = new discriminator value + new
+filter functions; the rest of the engine doesn't change.
+
+**Jurisdictions** are Pydantic records loaded from YAML at
+startup:
+- `JurisdictionId` is a string (`"federal_us"`, `"california"`).
+- A `Jurisdiction` record carries: brackets per filing status,
+  standard deduction per filing status, NIIT params, SALT cap,
+  qualified-residence-interest cap, LTCG threshold table,
+  depreciation schedule, §1250 rate, §121 exclusion amount,
+  ordinary-vs-LTCG treatment flag for capital gains.
+- The `JurisdictionSet` is the loaded collection — a frozen dict
+  `jurisdiction_id → Jurisdiction`. Loaded once at simulate()
+  entry.
+
+**Locations** are Pydantic records loaded from YAML at startup:
+- `LocationId` is a string (`"san_francisco"`, `"palo_alto"`).
+- A `Location` record carries: applicable jurisdiction ids (list,
+  ordered), property tax rate / formula, transfer tax schedule,
+  any other per-location parameters.
+- The `LocationSet` is the loaded collection. Loaded once.
+
+Property rows reference a `location_id`; agent residence rows
+reference a `location_id`. Tax computation iterates over the
+relevant jurisdictions for each row and applies their parameters.
+
+## Output assembly
+
+At end of `simulate(...)`:
+
+- The per-month state cross-sections (one per month, accumulated
+  during the loop) are concatenated into the long-form
+  state-over-time frames with `month_index` injected as a column.
+- The per-month log rows (transactions, obligations, lot
+  dispositions, failures, policy decisions, tax breakdowns) are
+  concatenated into the long-form append-only log frames.
+- A small set of **projections** are computed on demand from the
+  state-over-time:
+  - Net-worth time series per `(rollout, agent)`: cash + sum of
+    asset market value − sum of liability principal.
+  - Total income tax per `(rollout, year)`: sum across agents
+    across applicable jurisdictions from the tax_year_breakdown
+    log.
+  - Realized vs unrealized capital gains per `(rollout, year)`:
+    realized from lot dispositions, unrealized from state-over-
+    time.
+
+The returned `SimulationRun` is a Pydantic object wrapping the
+state-over-time frames + the log frames + the projections. The
+wire / API shape adapts these to the existing `ScenarioRunArrays`
+contract — projections expose specific named columns from
+state-over-time at materialize time.
+
+## Failure modes
+
+A rollout that fails on month M continues running for months >M;
+its `rollout_status[rollout=R].status` carries `"failed"` from
+month M onward (until recovery flips it back). Operations in
+phases 2-5 in subsequent months continue to apply over all
+rollouts — failed ones aren't structurally removed. Materialized
+outputs distinguish "across all rollouts" from "across rollouts
+active at month X" at projection time.
+
+A rollout that recovers (a later month's funding chain succeeds
+where a prior month's didn't) flips `status` back to `"active"`.
+The failure_events log retains the original failure row; the
+status frame tells the recovery story.
+
+## File and module layout
+
+Flat over nested; one library per concern. Initial layout:
+
+```
+augur/sim/
+  REQUIREMENTS.md                  — the spec
+  DESIGN.md                        — this doc
+  BUILD.bazel
+  data/                            — checked-in YAML
+    jurisdictions/{federal_us,california}.yaml
+    locations/{san_francisco,palo_alto,san_mateo,oakland,sunnyvale}.yaml
+
+  loader.py                        — load YAML → Pydantic, validate
+  jurisdictions.py                 — Jurisdiction model + JurisdictionSet
+  locations.py                     — Location model + LocationSet
+
+  scenario.py                      — Scenario Pydantic model (+ Agent,
+                                     Position, Liability, Property,
+                                     Policy, ScheduledEvent submodels)
+  market.py                        — MarketBundle interface
+
+  state.py                         — StateCrossSection + schemas for
+                                     the six working-state frames
+  transactions.py                  — Transaction discriminated union +
+                                     schemas for the six log frames
+
+  templates_capital_gains.py       — per-template rules for
+                                     capital-gains-eligible-holding
+  templates_real_property.py       — per-template rules for
+                                     depreciable-real-property
+  templates_amortizing_loan.py     — per-template rules for
+                                     amortizing-loan
+  templates_tax_liability.py       — per-template rules for the
+                                     tax-liability instrument
+  templates_obligation.py          — recurring-obligation template
+                                     + income-stream template
+                                     (small enough to share a file)
+
+  rules_capital_gains_class.py     — short-term vs long-term
+                                     classification (one function;
+                                     consumes any LTCG-eligible row)
+  rules_funding_chain.py           — obligation funding chain
+                                     (one function; consumes any
+                                     unfunded obligation)
+  rules_year_tax.py                — per-jurisdiction year-tax
+                                     computation (one function;
+                                     parameterized by jurisdiction)
+
+  step.py                          — the per-month step()
+  simulate.py                      — the forward loop + outputs
+                                     assembly
+
+  net_worth.py                     — net-worth projection from state
+  tax_breakdown.py                 — tax-year-breakdown projection
+
+  *_test.py                        — tests adjacent to each module
+```
+
+Each `templates_*.py` and `rules_*.py` is small (~50-200 LOC) and
+imports only the frames + schemas it consumes. The step function
+in `step.py` orchestrates them but does not contain rule logic.
+
+## Implementation order
+
+Each step lands a code commit + tests. Numbering matches the
+REQUIREMENTS.md scenario layer it satisfies. Earlier steps
+intentionally don't build infrastructure later steps need —
+the design is sized so that L4's lot model doesn't require
+refactoring L1's transfer.
+
+1. **L1.1 + L1.2 + L1.3** — `cash_balances` frame, `Transfer`
+   transaction, `Scenario` carrying initial cash, `simulate()`
+   stub running the forward loop with no policies / market. One
+   rollout, one month. Alice and Bob exist; Bob → Alice $5 ;
+   state at month 1 shows the new balances. Tests assert balance
+   math and the conservation invariant.
+2. **L2** — multi-month loop, recurring transfer / income.
+3. **L3** — rollout dimension goes from 1 to N. Same test in 2
+   rollouts; same test in 100 rollouts; assert linear scaling.
+4. **L4** — `asset_lots` frame with the lot model + cost-basis
+   methods. `AssetSale` transaction with lot consumption +
+   `lot_dispositions_log`. The capital-gains-eligible-holding
+   template + its rules (mark-to-market, sale, classification).
+5. **L5** — `MarketBundle` interface; state-dependent decisions
+   via polars expressions.
+6. **L6** — quarterly + year-end tax obligations + safe harbor;
+   the tax-liability-instrument template; per-jurisdiction
+   year-tax computation; capital-gains classification rule.
+   `tax_year_breakdown_log`.
+7. **L7** — ordinary-income aggregation; SALT-cap interaction;
+   itemized vs standard deduction; filing status (single + HoH).
+8. **L8** — `liabilities` frame; `amortizing_loan` template;
+   mortgage origination / payment / payoff transactions; Bank Bob
+   as non-tax-paying agent.
+9. **L9** — agent policies (floor-triggered sale, asset
+   preference chain, reinvest, monthly spend, variable spend
+   from market). The `policy_decisions_log`.
+10. **L10** — market-driven divergent rollouts; sellability
+    masks (preparing for L14).
+11. **L11** — `failure_events_log`; rollout status flips;
+    recovery semantics.
+12. **L12** — `property_state` frame; `depreciable_real_property`
+    template; property purchase / carrying costs / sale; §121
+    exclusion; SALT cap interaction; qualified-residence interest
+    cap.
+13. **L13** — occupancy modes; depreciation; rental income +
+    expenses; §1250 recapture; multi-property at multiple Bay
+    Area locations.
+14. **L14** — constrained sellability via sellability_mask
+    (already wired in L10, scenarios exercising tender-only +
+    mixed-liquidity).
+
+The "Implementation order" map is a checklist, not a calendar.
+Each step's deliverable is the smallest commit that passes that
+layer's scenarios + adds the necessary code.
+
+## What's not in this design
+
+- **Concrete function signatures.** The step function and rule
+  functions are described as "they exist and have this
+  responsibility"; their argument lists firm up as the first
+  commits land.
+- **Concrete polars schema dtypes for every column.** The schemas
+  are listed at the conceptual level; the production code's
+  `pl.DataType` declarations land with the first frame.
+- **Performance characterization.** The forward loop is
+  vectorized by construction (per the requirements doc) but
+  benchmarking against the legacy engine is deferred to after
+  L4 / L8 land.
+- **Wire compatibility with the existing `ScenarioRunArrays`
+  schema.** A compatibility shim exists conceptually (projection
+  layer at simulate()'s output), but the actual mapping is a
+  late-stage concern when the sim engine is being swapped in.
+
+These get decided when the code lands. The structural shape
+above is what stays load-bearing through that work.

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -1,0 +1,559 @@
+# Augur sim — requirements
+
+A clean-rewrite target for the Augur financial-futures simulator. The
+existing engine in `augur/core/scenario_engine.py` has accreted several
+overlapping representations of state and time; this document captures
+what the new implementation must be able to model, framed as
+natural-language scenarios free of API choices. The companion design
+work happens in `augur/sim/` alongside the code as it lands; nothing
+here commits to a function shape, a library, or a file layout.
+
+## What the simulator is
+
+A double-entry bookkeeping financial simulator over a fixed sequence
+of months, run as many rollouts in parallel. Each rollout is a
+self-consistent timeline driven by the same exogenous market path
+(or by per-rollout sampled market paths from a shared model). Agents
+own cash accounts, asset positions, and liabilities; agents take
+actions; actions transfer value between agents and between accounts.
+Tax law sits on top: realized income and capital gains accrue tax
+liability, which becomes a real obligation the agent must settle on
+real-world IRS / state schedules.
+
+Outputs: a per-month time series of every agent's full balance sheet
+in every rollout, plus an append-only ledger of every transaction
+that produced those balances.
+
+## Foundational principles
+
+These are non-negotiable shapes. Every scenario below assumes them.
+
+- **Forward-only time.** The simulation is a strict
+  `state_{t+1} = step(state_t, market_t, decisions_t)` loop. No
+  post-hoc passes that re-derive earlier months from later facts; no
+  "compute state at month M from the log" reconstructions running
+  alongside a maintained state; no second sweep.
+- **State is carried, not rebuilt.** The working state at month T+1 is
+  produced from the state at T plus this month's transactions. It is
+  not re-derived from scratch from independent sources each iteration.
+- **Vectorized across rollouts.** Every operation — reads, decisions,
+  state updates — is a bulk operation over all rollouts at once. There
+  is no Python loop over rollouts anywhere in the per-month step;
+  the rollout dimension is silent in policy and transition code the
+  same way it is silent in an elementwise numpy add.
+- **Double-entry bookkeeping.** Every transaction balances. Money does
+  not appear or disappear. A transfer debits one account and credits
+  another. A sale debits an asset position and credits cash. A tax
+  accrual debits a tax-expense bucket and credits a tax-payable
+  liability. Total assets across the system equal total liabilities +
+  equity at every month boundary.
+- **Single source of truth for state-over-time.** The per-month
+  state-over-time is the primary output, not a derived view. Other
+  outputs (net worth charts, sale-tax breakdowns, per-year tax
+  liability) are projections of either the state series or the
+  transaction log.
+- **One representation per concept.** Cash balance is one thing,
+  stored one way. Asset units / basis is one thing. Tax owed is one
+  thing. There is no "the engine has it as A, the wire has it as B,
+  the summary derives it as C from the log".
+
+Everything below builds on these.
+
+## Scenarios — bottom up
+
+Each scenario adds one new capability. The simulator must handle all
+of them; the order is the order in which the implementation should
+acquire support, not a runtime classification.
+
+### Layer 1: Just transfers
+
+#### S1.1 — Alice gives Bob five dollars, once.
+
+Alice starts with \$10 in checking. Bob starts with \$20 in checking.
+At month 0, Bob transfers \$5 to Alice. After month 0: Alice has \$15,
+Bob has \$15. Total system cash is \$30 before and after.
+
+The simulator must:
+
+- Record the transfer as a transaction with an identifiable sender,
+  recipient, amount, and month.
+- Produce a per-month balance series for each agent (one month long,
+  in this case): Alice \$10 → \$15, Bob \$20 → \$15.
+- Preserve the conservation invariant — sum across agents is \$30 at
+  every month.
+
+#### S1.2 — Transfer that's classified as income for one party.
+
+Same as S1.1, but the transfer carries a label that marks it as
+ordinary income to Alice (and not income to Bob — for Bob it's a
+gift or an expense). The simulator's per-agent income totals at the
+end of the year must reflect: Alice \$5 ordinary income, Bob \$0.
+
+This is not a tax computation yet — just the classification riding
+on the transaction.
+
+#### S1.3 — Multiple agents, multiple transactions, one month.
+
+Three agents, two transfers in the same month. The order of
+application within a single month should not change end-of-month
+balances when the transactions are independent. When they aren't
+independent (Alice can only send what she has), the engine resolves
+the cash-availability question deterministically and reports it.
+
+### Layer 2: Time
+
+#### S2.1 — Multiple months, no events.
+
+One agent, \$1000 in cash, ten months, no transactions. The per-month
+balance series is \$1000 repeated ten times. The simulator carries
+state forward without dropping or recomputing it.
+
+#### S2.2 — Recurring transfer.
+
+One agent receives \$3000 paycheck on the first of every month for a
+year. End-of-year balance is starting balance + \$36000. The
+transaction log has twelve rows; the balance series shows monotone
+growth.
+
+### Layer 3: Rollouts
+
+#### S3.1 — Two rollouts, deterministic, identical.
+
+The same scenario as S2.2 but run as two parallel rollouts with no
+random inputs. Both rollouts produce identical balance series. The
+output is shaped so that the rollout dimension is a first-class axis
+(one row per rollout-month-agent in long form, or one slice per
+rollout in any per-rollout view).
+
+#### S3.2 — Two rollouts with different exogenous market paths.
+
+Same scenario, but a market-driven input (e.g. interest rate on a
+savings account, or stock price — whichever lands first) differs
+across rollouts. The two rollouts diverge in observable ways. The
+simulator does not require copying state across rollouts; it just
+runs the same bulk operation over the rollout axis.
+
+#### S3.3 — Hundreds of rollouts.
+
+Same scenario at scale. Runtime is approximately linear in rollout
+count; no per-rollout Python overhead.
+
+### Layer 4: Assets
+
+#### S4.1 — Agent holds stock; price doesn't move.
+
+Alice holds 100 shares of an S&P 500 ETF, cost basis \$10000, market
+value \$10000 at month 0. Price flat for 12 months. End-of-year net
+worth = cash + \$10000 stock. No realized gain, no tax.
+
+#### S4.2 — Stock price moves, no sales.
+
+Same as S4.1 but the market path goes \$100 → \$150 over 12 months.
+Unrealized gain = \$5000 at month 12. Reported separately from
+realized gain. No tax.
+
+#### S4.3 — Agent sells stock at a gain.
+
+Same as S4.2. At month 12 Alice sells 50 shares for \$7500. Cost
+basis of the sold portion is \$5000 (proportional to units sold).
+Realized gain is \$2500. Alice's holding drops to 50 shares cost
+basis \$5000. Alice's cash gains \$7500.
+
+The simulator must:
+
+- Record the sale as a transaction (debit stock units + basis,
+  credit cash).
+- Compute the realized gain at sale time.
+- Make the gain available to the tax computation (Layer 6) without
+  the policy code having to know anything about tax.
+
+#### S4.4 — Multiple sales in different months, partial lots.
+
+Alice sells \$5000 of stock in month 3, another \$5000 in month 9.
+Each sale realizes gain proportional to the basis-per-unit at that
+month. The order is preserved on the transaction log.
+
+#### S4.5 — Multiple asset classes.
+
+Alice owns SP500, BTC, and a private-equity position with a
+configured liquidity regime. Each holds its own units + basis, each
+has its own market price path. Holdings and balances scale row-wise
+in the output, not by adding columns.
+
+### Layer 5: Market integration
+
+#### S5.1 — Decisions depend on observed market state.
+
+Alice's policy: "If my SP500 position is up more than 20% from
+basis, sell half." Different rollouts hit the trigger at different
+months (or never). The simulator evaluates the condition over the
+rollout axis and fires sales in only the rollouts where it triggers.
+
+#### S5.2 — Decisions depend on the agent's own state.
+
+Alice's policy: "If my checking cash drops below \$100, sell \$1000
+of SP500." The condition reads Alice's current cash; the decision is
+"sell \$1000 of stock, deposit proceeds into checking". When the
+condition holds in some rollouts and not others, the simulator
+applies the action only where the condition is true. Where Alice
+holds less than \$1000 of stock, the simulator sells what it can and
+records the shortfall.
+
+#### S5.3 — Market path is shared across agents but not rollouts.
+
+Two agents in the same scenario observe the same market path within
+a single rollout. Two rollouts observe two different market paths
+(sampled from the configured market model). Rollouts diverge
+endogenously when agents make state-dependent decisions on top of
+exogenously divergent market paths.
+
+### Layer 6: Capital gains taxation
+
+#### S6.1 — Realized gain in a year creates a tax liability for that year.
+
+Alice realizes \$10000 of long-term capital gain in calendar year 2025.
+At year-end of 2025 the simulator computes Alice's federal tax for
+2025 — which includes the \$10000 LTCG taxed at federal LTCG rates
+appropriate to her total income — and accrues the corresponding
+tax obligation. The obligation has a real settlement schedule (see
+S6.4 / S6.5); the simulator does not pretend the tax was paid
+already.
+
+#### S6.2 — Multiple gain sources in one year combine.
+
+Alice realizes \$10000 from SP500 (long-term), \$3000 from BTC
+(long-term), and \$5000 from a private-equity sale (long-term). All
+fold into the same long-term-capital-gain bucket for federal tax
+purposes, which is summed once and taxed once at federal LTCG rates.
+California treats LTCG as ordinary income — the same gains feed CA's
+ordinary-income computation. The simulator does not compute tax on
+SP500 sales separately, double-count, or miss a source.
+
+#### S6.3 — Short-term gain is ordinary income.
+
+If a sale is held less than a year, the realized gain is taxed at
+ordinary federal + CA rates rather than LTCG. The simulator carries
+the held-since date (or sufficient information to derive holding
+period) on every asset lot.
+
+#### S6.4 — Quarterly estimated tax with safe harbor.
+
+Alice has substantial investment income. To avoid IRS underpayment
+penalties, she pays quarterly estimated tax on the IRS schedule:
+Q1 = April 15, Q2 = June 15, Q3 = September 15, Q4 = January 15 of
+the following year. Each quarterly amount is sized to satisfy the
+safe-harbor rule: total quarterly payments cover the lesser of
+(actual current-year tax) or (a fraction of prior-year tax —
+typically 100% but 110% above the high-income threshold). For year
+zero (no prior-year tax data) the simulator's behavior is
+deterministic and documented; reasonable choices include "no
+quarterly payments emit, year-end true-up covers the full year" or
+"user supplies a prior-year-tax knob".
+
+The simulator must:
+
+- Emit quarterly obligations at the right months with the right
+  amounts.
+- Settle each obligation from Alice's cash, drawing on her funding
+  policies (e.g. sell stock to cover) if cash is short.
+- True up at year-end: the year-end obligation is `actual_year_tax
+  − sum_of_quarterlies`, never producing a payment greater than the
+  actual year tax across all five settlement events.
+
+#### S6.5 — Net investment income tax.
+
+Above the federal MAGI threshold (today \$200k single / \$250k MFJ),
+an additional 3.8% NIIT applies to investment income. The simulator
+applies it correctly — including the cap at `min(NII, MAGI − threshold)`
+— and folds it into the year's federal tax.
+
+### Layer 7: Ordinary income taxation, US + CA
+
+#### S7.1 — W-2 income, federal brackets, standard deduction.
+
+Alice earns \$120000 of W-2 income for the year (the simulator
+either receives this as twelve \$10000 transfers labeled income, or
+as a configured annual amount; the requirement is that ordinary
+income aggregates correctly). At year-end, federal tax on
+`(ordinary_income − standard_deduction)` is computed via the
+applicable filing-status brackets. Federal tax owed equals the
+bracket walk, less any withholding the scenario configures.
+
+#### S7.2 — California state income tax.
+
+California treats W-2 income as ordinary, with CA's own brackets and
+CA's own standard deduction. Capital gains (long-term and short-term)
+are ordinary income in California — there is no preferential rate.
+The simulator computes CA tax in parallel with federal, with no
+shared bracket walk.
+
+#### S7.3 — Itemized vs standard deduction.
+
+Property tax paid + mortgage interest paid + state-income-tax paid
+(subject to the federal SALT cap) is itemizable on federal. The
+simulator uses the larger of itemized or standard. CA itemization
+differs slightly (no SALT cap intra-state, mortgage interest treated
+slightly differently); the simulator handles each jurisdiction's
+rules separately.
+
+#### S7.4 — Filing status.
+
+Single, married filing jointly, married filing separately, head of
+household. Each filing status pins different bracket boundaries,
+standard deduction amounts, and threshold values (NIIT, safe-harbor
+high-income). The simulator carries the filing status per agent
+(or per tax-household — see open question below) and looks up the
+right tables.
+
+#### S7.5 — Combined ordinary + capital scenario.
+
+Alice has \$120k W-2 + \$10k LTCG + \$1500 short-term gain.
+Federal tax is computed by stacking LTCG on top of ordinary income
+in the LTCG bracket walk; short-term is ordinary; the simulator
+produces the correct federal + CA total. The same year's safe-harbor
+quarterly payments cover the right amount; the year-end true-up
+clears.
+
+### Layer 8: Mortgage — inter-agent loan with a contract
+
+#### S8.1 — Origination.
+
+Alice buys a house for \$500k. A lender (modeled as another agent
+in the simulation — "Bank Bob") originates a 30-year fixed mortgage
+at 6%, lending Alice \$400k for \$400k cash at closing. Alice
+contributes \$100k from her own cash. Bank Bob debits its loan
+receivable asset for \$400k and credits its cash by \$400k. Alice
+debits her property asset for \$500k, debits her mortgage liability
+for \$400k, credits her cash by \$100k.
+
+The simulator models the mortgage as a **contract between two
+agents** with the standard amortization schedule attached, not as
+an opaque "mortgage" piece of engine state.
+
+#### S8.2 — Monthly payment amortization.
+
+Every month, Alice owes a payment equal to the scheduled
+fixed-payment amount. The payment splits between interest (paid to
+Bank Bob; reduces neither asset nor liability — flows to Bank Bob's
+interest-income bucket) and principal (reduces Alice's outstanding
+mortgage liability AND Bank Bob's loan receivable by the same
+amount). The transaction log records both halves. Alice's checking
+cash drops by the full payment. Bank Bob's cash rises by the full
+payment.
+
+#### S8.3 — Bank Bob's interest income is taxable.
+
+Bank Bob earns ordinary income on each month's interest portion.
+If Bank Bob is modeled as a tax-paying agent (i.e. it has a filing
+status and tax profile), then year-end federal + CA tax on that
+income is computed and accrued on Bank Bob's books. If Bank Bob is
+modeled as a non-tax-paying entity (e.g. an institutional lender out
+of scope for tax), the income is still recorded — it's a contract
+parameter, not a tax-profile parameter — but no tax accrues.
+
+#### S8.4 — Mortgage interest is deductible for Alice.
+
+Alice's federal itemized deduction includes the year's mortgage
+interest paid (subject to the federal cap on interest deductibility
+above the principal cap). California also allows the deduction with
+similar rules. Itemized deduction is the larger-of with standard.
+
+#### S8.5 — Alice misses a payment.
+
+Alice's checking cash is below the required mortgage payment at
+month M. Her funding policies (sell stock first, sell crypto next,
+etc., per her configured chain) attempt to cover the shortfall.
+If still short, the obligation is recorded as unpaid; the
+rollout's failure state is recorded; subsequent month projections
+continue but the rollout is flagged. The simulator does not
+crash, does not silently underpay, does not double-pay.
+
+#### S8.6 — Mortgage payoff at property sale.
+
+Alice sells the house for \$700k. Outstanding mortgage principal
+(say \$380k) is paid off at closing — debits Alice's mortgage
+liability to zero, credits Bank Bob's loan receivable to zero,
+credits Bank Bob's cash by \$380k. Closing costs come out of
+Alice's proceeds. Net proceeds settle to Alice's checking. The
+capital gain (proceeds − adjusted basis − closing costs −
+depreciation-recapture treatment) feeds year tax per Layer 6.
+
+### Layer 9: Agent policies
+
+#### S9.1 — Floor-triggered stock sale.
+
+"If checking cash drops below \$100, sell \$1000 of SP500." The
+policy reads the agent's cash at the start of the month, evaluates
+the condition over the rollout dimension, and emits a sale decision
+in rollouts where the condition holds. The decision becomes a
+transaction; the transaction updates state. In rollouts where the
+agent has less than \$1000 of stock available, the simulator sells
+what it can and records the shortfall on the decision row.
+
+#### S9.2 — Asset preference chain.
+
+"If short of cash, sell SP500 first; if SP500 exhausted, sell BTC;
+if both exhausted, sell private equity." The chain is per-agent
+configured order; the simulator walks the chain per-rollout per-month,
+applying as much as needed in priority order until the obligation
+is funded or the assets are exhausted.
+
+#### S9.3 — Reinvest excess cash.
+
+"If checking exceeds \$50k, buy SP500 with the excess." The
+condition evaluates after this month's other transactions land
+(or in a configured ordering position within the month — the
+simulator's per-month order is documented and stable).
+
+#### S9.4 — Mortgage payment is non-discretionary.
+
+The mortgage payment scenario (Layer 8) is not a policy in this
+sense — it's a contract-imposed obligation that fires unconditionally
+each month, settled before discretionary policies. The simulator
+distinguishes obligations (required) from policies (discretionary).
+
+#### S9.5 — Combination: monthly spend + emergency sale.
+
+"\$3500/month spend on living expenses (debit checking). If checking
+drops below \$5000 after spending, sell \$10000 of SP500." The spend
+fires every month; the sale fires only in rollouts where the
+post-spend cash is below the floor. Different rollouts (different
+market paths affecting stock value) make different decisions.
+
+### Layer 10: Market model integration
+
+#### S10.1 — Per-rollout sampled market paths.
+
+The simulator integrates with an external market model that, given a
+rollout count and a horizon, produces per-rollout per-month
+multipliers for each asset class. Rollouts have different SP500
+paths, different BTC paths, different property-value paths, etc.
+
+#### S10.2 — Agents' decisions feed back into the rollout's trajectory.
+
+Within a single rollout, an agent's state-dependent decision
+(e.g. "sell \$10k of stock when cash low") affects that rollout's
+subsequent state, but does NOT affect the market path in that
+rollout — the market path is exogenous. Two rollouts with identical
+market paths but different agent policies would diverge; two
+rollouts with the same policies but different market paths also
+diverge. The cross-product is the standard Monte Carlo behavior.
+
+#### S10.3 — Same market model across agents.
+
+All agents in a scenario observe the same per-rollout market path
+within a rollout (one rollout has one SP500 path; both Alice and
+Bank Bob see the same stock prices). The simulator does not give
+different agents different views of the same asset's price.
+
+### Layer 11: Failure modes
+
+#### S11.1 — Cash goes negative.
+
+If a required obligation cannot be funded even after walking the
+agent's full asset chain, the simulator records the rollout as
+having transitioned into a failure state at that month. State
+arrays for subsequent months continue to compute (the property
+keeps depreciating, the stock price keeps moving) but the rollout
+carries a failure flag. The transaction log records the unpaid
+obligation.
+
+#### S11.2 — Rollout failure is per-rollout, not scenario-wide.
+
+In a 100-rollout scenario where 12 rollouts fail at various months
+and 88 stay solvent, the simulator continues all 100 rollouts and
+labels the failed ones. Reported metrics distinguish "across all
+rollouts" from "across surviving rollouts" where the distinction
+matters.
+
+#### S11.3 — Recovery from temporary shortfall.
+
+If a funding policy sells assets in month M to cover a shortfall and
+succeeds, the rollout does not enter failure — it continues
+normally. Failure is "obligation went unpaid"; sale-driven
+recovery is not failure.
+
+## Outputs the simulator must produce
+
+For any run (scenario + market bundle + rollout count + horizon
+months):
+
+- **Per-rollout per-month per-agent state**: cash balances by
+  account, asset holdings (units + basis + current market value) by
+  asset, liability balances (principal + monthly interest accrued +
+  monthly principal paid) by liability. Long-form, one row per
+  (rollout, month, agent, entity-id). The cardinality of agents,
+  accounts, assets, liabilities goes into row count, not into the
+  schema.
+- **Transaction log**: every transaction recorded chronologically with
+  (rollout, month, kind, parties, amounts, cause-id). Causes link
+  back to the policy or obligation that produced the transaction.
+- **Per-rollout net worth time series**: derivable from the state
+  frames as cash + asset market value − liability principal, summed
+  over the agent's holdings. Exposed as a first-class output because
+  it's the primary chart consumer.
+- **Per-year tax computation breakdown**: per (rollout, year, agent)
+  the income totals, deduction amounts, bracket walks, LTCG bracket
+  walks, NIIT calculation, federal/CA totals. Enough to audit any
+  rollout's tax math.
+- **Per-obligation lifecycle**: every obligation (mortgage payment,
+  property tax, quarterly tax, year-end tax) with its accrual month,
+  amount due, amount paid, settlement month(s), unpaid balance.
+- **Rollout status**: active vs failed, with failure month and the
+  obligation that triggered the failure.
+
+These outputs are projections of the state series and transaction log;
+they are not maintained alongside as separate state.
+
+## Non-goals
+
+- **Per-rollout policy parameter divergence.** Policies are scenario-
+  level configuration; two rollouts of the same scenario apply the
+  same policies. Per-rollout variation in market paths produces
+  divergent trajectories naturally.
+- **Within-month sub-stepping.** Within a single month, the ordering
+  of operations is fixed and documented (mark-to-market → scheduled
+  cashflows → required obligations → discretionary policies →
+  end-of-month accruals); there is no event-driven simulation within
+  the month.
+- **Inflation modeling, currency conversion, or non-USD assets.**
+  Single currency. Inflation, if relevant, lives in the market model
+  (e.g. growing rent / property-tax paths) rather than as a separate
+  layer.
+- **Liquidity, slippage, transaction costs above what scenarios
+  configure as explicit closing costs.** Sales execute at the
+  mark-to-market price.
+- **Behavioral / regret modeling.** Agents follow their configured
+  policies deterministically.
+
+## Open questions
+
+These are unresolved and need a decision before the relevant layer
+lands. They aren't blocking the earlier layers.
+
+- **Tax household scope.** Tax computation today is single-agent.
+  Joint filers with separate cash accounts but a single tax return —
+  is the tax computation on an "agent" or on a "tax household"
+  abstraction that aggregates one or more agents? Either works; the
+  decision affects how filing status, joint deductions, and combined
+  brackets are modeled.
+- **Bank Bob's existence model.** The mortgage scenarios above
+  describe the lender as another agent in the same simulation. An
+  alternative is to model lenders as "contract counterparties"
+  without their own balance sheet, since simulating a bank's balance
+  sheet is usually not what the user wants. The decision affects how
+  many agents typical scenarios carry and whether lenders pay tax.
+- **Year-zero quarterly estimated tax.** With no prior-year tax data,
+  several behaviors are defensible: (a) no quarterlies fire and the
+  year-end true-up covers the full year, (b) the user supplies a
+  `prior_year_tax_usd` knob, (c) the simulator estimates from the
+  scenario's configured ordinary income. The current legacy engine
+  picked (a) + (b); the new implementation should commit to a default
+  explicitly.
+- **Agent-to-agent gifting tax treatment.** S1.2 establishes that
+  transfers can carry an income classification. Gift tax,
+  exclusions, lifetime exemption — out of scope here, or modeled?
+- **Inter-agent loans beyond mortgages.** S8 describes one specific
+  contract type. Should the simulator support arbitrary inter-agent
+  loans (e.g. partner equity loans, intra-family lending), or is
+  mortgage the only template?

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -108,16 +108,23 @@ The templates below are the target set; the exact list firms up as
 implementation proceeds, but the principle is fixed: every rule
 applies to a template, not to a name.
 
-- **Capital-gains-eligible holding.** Carries units, cost basis, a
-  market unit-price path (per-rollout per-month from the market
-  model), and a holding-period rule for distinguishing short-term
-  vs long-term. Sales realize gain (`proceeds − basis_consumed`)
-  classified by holding period; the gain feeds the LTCG or
-  ordinary-income tax computation per the per-jurisdiction rules.
-  Covers everything one would call a stock-like or crypto-like or
-  ETF-like or single-issuer-position: scenarios configure as many
-  named positions as needed (e.g. `"sp500_etf"`, `"individual_aapl"`,
-  `"bitcoin"`, `"ethereum"`) and the engine treats them uniformly.
+- **Capital-gains-eligible holding.** A named position composed of
+  one or more **tax lots**, where each lot has its own units, cost
+  basis, and acquisition date. The position carries a market
+  unit-price path (per-rollout per-month from the market model) and
+  a cost-basis method (FIFO / LIFO / HIFO / specific-id / average
+  cost) that determines which lots a sale consumes. Sales realize
+  per-lot gain (`(units_sold × price) − units_sold × per_unit_basis`);
+  each consumed lot's gain is classified short-term or long-term
+  based on its own acquisition date vs the sale date; per-lot gains
+  flow into the LTCG or ordinary-income tax buckets accordingly.
+  Buying more of the same position adds a new lot (or extends an
+  existing lot, in the average-cost case). Covers everything one
+  would call a stock-like, crypto-like, ETF-like, or single-issuer
+  position. Scenarios configure as many named positions as needed
+  (e.g. `"sp500_etf"`, `"individual_aapl"`, `"bitcoin"`, `"ethereum"`)
+  and the engine treats them uniformly — the lot structure lives
+  inside the template, not as a per-asset-class concept.
 - **Depreciable real-property holding.** Capital-gains-eligible plus
   a depreciation schedule, an §1250 recapture rule on sale, a SALT-
   cap-eligible property-tax stream, and a qualified-residence
@@ -320,13 +327,68 @@ The simulator must:
 - Make the gain available to the tax computation (Layer 6) without
   the policy code having to know anything about tax.
 
-#### S4.4 — Multiple sales in different months, partial lots.
+#### S4.4 — Multiple lots of the same position.
 
-Alice sells \$5000 of stock in month 3, another \$5000 in month 9.
-Each sale realizes gain proportional to the basis-per-unit at that
-month. The order is preserved on the transaction log.
+Alice buys 100 shares of `"sp500_etf"` at \$100/share in month 0
+(\$10000 basis, acquired month 0). She buys 50 more shares of the
+same position at \$150/share in month 6 (\$7500 basis, acquired
+month 6). After month 6 she holds 150 shares in one position with
+two distinct tax lots: one of 100 shares cost basis \$10000 acquired
+month 0, and one of 50 shares cost basis \$7500 acquired month 6.
+Total basis \$17500. The simulator must keep the per-lot identity
+intact across months — these are not collapsed into an aggregate
+"150 shares, \$17500 basis" representation unless the position's
+configured cost-basis method is average-cost.
 
-#### S4.5 — Many positions, all going through one code path.
+#### S4.5 — Sale within a single lot (FIFO default).
+
+Same setup as S4.4. The position is configured for FIFO basis. In
+month 8, with the lot-0 price at \$120 and the lot-6 price at \$120,
+Alice sells 75 shares. FIFO consumes 75 of the 100 shares from the
+month-0 lot: 75 shares × \$100/share basis = \$7500 basis consumed,
+\$9000 proceeds, \$1500 realized gain. The month-0 lot has 25
+shares left (\$2500 basis); the month-6 lot is untouched (50 shares,
+\$7500 basis). Total basis remaining = \$10000.
+
+#### S4.6 — Sale crossing two lots, mixed holding periods.
+
+Alice buys 100 shares in month 0 at \$100/share. Buys 50 more in
+month 13 at \$120/share. Price in month 14 is \$130/share. Alice
+sells 120 shares in month 14 (price \$130).
+
+FIFO consumes:
+
+- 100 shares from the month-0 lot. Held 14 months → long-term.
+  Proceeds \$13000, basis \$10000, **long-term capital gain \$3000**.
+- 20 shares from the month-13 lot. Held 1 month → short-term.
+  Proceeds \$2600, basis \$2400, **short-term capital gain \$200**.
+
+The year-tax computation must route these into different buckets:
+the \$3000 long-term gain feeds the LTCG bracket walk; the \$200
+short-term gain feeds the ordinary-income bracket walk. The
+simulator does NOT merge them into a single "\$3200 capital gain"
+and apply one rate.
+
+#### S4.7 — Lot selection at sale (specific-id / HIFO).
+
+Same setup as S4.6 but the position is configured for HIFO
+(highest-in-first-out) basis selection. The month-13 lot has higher
+basis-per-unit (\$120) than month-0 (\$100), so HIFO consumes
+month-13 first:
+
+- 50 shares from month-13. Held 1 month → short-term.
+  Proceeds \$6500, basis \$6000, **short-term gain \$500**.
+- 70 shares from month-0. Held 14 months → long-term.
+  Proceeds \$9100, basis \$7000, **long-term gain \$2100**.
+
+Total realized gain (\$2600) differs from S4.6's FIFO total
+(\$3200) because different lots are consumed. The simulator
+correctly routes whichever lots the configured method selects.
+The same code path covers FIFO, LIFO, HIFO, specific-identification,
+and average-cost — the difference is which lots are picked, not how
+the gain is computed once they're picked.
+
+#### S4.8 — Many positions, all going through one code path.
 
 Alice owns ten differently-named positions in a single scenario:
 say `"sp500_etf"`, `"intl_etf"`, `"bond_etf"`, `"bitcoin"`,
@@ -335,10 +397,12 @@ through `"position_005"`. Each is configured at the scenario level
 with its own market price path; eight point at the standard
 capital-gains-eligible-holding template (LTCG-after-1y / STCG-
 otherwise); two point at a "no-LTCG-discount" variant for an
-illustrative jurisdiction where everything is ordinary income. The
-engine does NOT have ten separate per-position code paths — every
-position runs through the same template-driven code, with the
-position's template-id routing it to the right rules.
+illustrative jurisdiction where everything is ordinary income. Each
+position carries its own lots (see S4.4-S4.7) under its own
+configured cost-basis method. The engine does NOT have ten separate
+per-position code paths — every position runs through the same
+template-driven code, with the position's template-id routing it
+to the right rules.
 
 Adding an 11th position is a scenario edit, not an engine edit.
 
@@ -425,10 +489,12 @@ The simulator must:
 
 #### S6.5 — Net investment income tax.
 
-Above the federal MAGI threshold (today \$200k single / \$250k MFJ),
-an additional 3.8% NIIT applies to investment income. The simulator
-applies it correctly — including the cap at `min(NII, MAGI − threshold)`
-— and folds it into the year's federal tax.
+Above the federal MAGI threshold (today \$200k single / \$200k head-
+of-household), an additional 3.8% NIIT applies to investment income.
+The simulator applies it correctly — including the cap at
+`min(NII, MAGI − threshold)` — and folds it into the year's federal
+tax. Thresholds are filing-status-keyed; MFJ thresholds aren't
+relevant because MFJ is out of scope.
 
 ### Layer 7: Ordinary income taxation, US + CA
 
@@ -461,12 +527,14 @@ rules separately.
 
 #### S7.4 — Filing status.
 
-Single, married filing jointly, married filing separately, head of
-household. Each filing status pins different bracket boundaries,
-standard deduction amounts, and threshold values (NIIT, safe-harbor
-high-income). The simulator carries the filing status per agent
-(or per tax-household — see open question below) and looks up the
-right tables.
+Single or head-of-household. Each filing status pins different
+bracket boundaries, standard deduction amounts, and threshold
+values (NIIT, safe-harbor high-income). The simulator carries the
+filing status per tax-paying agent and looks up the right tables.
+
+(Married-filing-jointly and married-filing-separately are
+out of scope — see [Non-goals](#non-goals). A scenario representing
+a couple files each agent as single.)
 
 #### S7.5 — Combined ordinary + capital scenario.
 
@@ -693,6 +761,14 @@ they are not maintained alongside as separate state.
   mark-to-market price.
 - **Behavioral / regret modeling.** Agents follow their configured
   policies deterministically.
+- **Joint filing (MFJ / MFS).** The tax-paying-agent unit covers
+  single-filer scenarios. Married-filing-jointly and married-
+  filing-separately are not modeled. Filing-status values exist
+  (filer agents pick single or head-of-household, per S7.4), but
+  the joint-return wiring — two agents sharing one tax return,
+  combined brackets, MFJ standard deduction — is out of scope.
+  If a scenario wants to model a couple, both agents file as
+  single (or HoH where applicable).
 
 ## Resolved decisions
 
@@ -780,17 +856,6 @@ the design that's worth examining before shipping.
 These are still unresolved and need a decision before the relevant
 layer lands. They aren't blocking the earlier layers.
 
-- **Tax household scope.** A "tax-paying agent" is the unit of tax
-  computation as established above. Joint filers — two people who
-  share a single tax return but possibly maintain separate cash
-  accounts and holdings — is a separate question on top: is a
-  married-filing-jointly couple modeled as one tax-paying agent
-  whose holdings span the joint estate, or as two cash-account-
-  owning agents that get joined at tax time into a tax-household
-  abstraction? The first is simpler; the second is closer to how
-  real joint filing works. Decision affects how MFJ filing status
-  and the joint standard deduction are wired but does not block
-  any single-filer scenario.
 - **Agent-to-agent gifting tax treatment.** S1.2 establishes that
   transfers can carry an income classification. Gift tax,
   exclusions, lifetime exemption — out of scope here, or modeled?

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -56,14 +56,167 @@ These are non-negotiable shapes. Every scenario below assumes them.
   stored one way. Asset units / basis is one thing. Tax owed is one
   thing. There is no "the engine has it as A, the wire has it as B,
   the summary derives it as C from the log".
+- **No hardcoded asset classes; generic templates instead.** The
+  engine does not mention `sp500`, `crypto`, `private_equity` by name
+  in its logic. It defines a small set of **asset templates** that
+  capture _behavior_ (e.g. "capital-gains-eligible holding with a
+  market price path and a cost basis", "depreciable real-property with
+  §1250 treatment", "loan principal with an amortization schedule
+  and a counterparty"). A scenario configures any number of concrete
+  asset positions, each pointing at a template and supplying the
+  template's parameters (display name, market-path provider, holding-
+  period rule, …). Two stocks named `"foo"` and `"bar"` and a crypto
+  named `"baz"` all share the same code path through the engine —
+  three positions with the same template id flow through the same
+  gain calculator. Adding a new named position is configuration, not
+  engine code, unless it needs a genuinely new behavior template.
+- **DRY rule routing.** Every rule the law (or the user) imposes on
+  N things is implemented **once**, and the N things route through
+  that one implementation by declaring which behavior they participate
+  in. Long-term capital gain treatment is one bracket walk that
+  consumes the sum of LTCG-eligible realized gains across all assets
+  marked LTCG-eligible; it is not a per-asset-class function called N
+  times. The same applies to deduction caps, withholding rules,
+  obligation settlement chains, depreciation schedules, accrual
+  cadences. If the spec changes the SALT cap or the LTCG threshold,
+  exactly one place changes.
+- **Vectorized hot path.** Performance is a requirement, not an
+  afterthought. The per-month step runs as polars expressions / numpy
+  ufuncs / equivalent bulk-vectorized ops over the rollout dimension.
+  Python-level per-rollout work in the hot loop is a bug. Where a
+  rule is naturally expressed as a join+group-by+window across a
+  long-form frame (e.g. "this year's LTCG bucket is the sum of
+  taxable_gain across all LTCG-eligible asset_change_log rows grouped
+  by (rollout, year)"), that's the implementation — not a Python loop
+  over rollouts that re-derives the same thing. The choice of
+  numpy / polars / pytorch / something else per piece is whatever
+  best vectorizes the operation; the constraint is "no per-rollout
+  Python in the hot path", not the library.
 
 Everything below builds on these.
+
+## Asset templates and rule routing
+
+The engine defines a small fixed set of behavior templates. Concrete
+asset positions, liabilities, and obligation streams in a scenario
+each point at one template and carry the template-required
+parameters. Rules (tax math, depreciation, deductibility,
+settlement) are implemented once per template and consume **every**
+position that points at that template.
+
+The templates below are the target set; the exact list firms up as
+implementation proceeds, but the principle is fixed: every rule
+applies to a template, not to a name.
+
+- **Capital-gains-eligible holding.** Carries units, cost basis, a
+  market unit-price path (per-rollout per-month from the market
+  model), and a holding-period rule for distinguishing short-term
+  vs long-term. Sales realize gain (`proceeds − basis_consumed`)
+  classified by holding period; the gain feeds the LTCG or
+  ordinary-income tax computation per the per-jurisdiction rules.
+  Covers everything one would call a stock-like or crypto-like or
+  ETF-like or single-issuer-position: scenarios configure as many
+  named positions as needed (e.g. `"sp500_etf"`, `"individual_aapl"`,
+  `"bitcoin"`, `"ethereum"`) and the engine treats them uniformly.
+- **Depreciable real-property holding.** Capital-gains-eligible plus
+  a depreciation schedule, an §1250 recapture rule on sale, a SALT-
+  cap-eligible property-tax stream, and a qualified-residence
+  interest seam (when the property is the agent's primary residence).
+  One template per legal treatment (e.g. owner-occupied vs rental);
+  multiple properties of the same legal treatment in one scenario
+  are multiple rows on the same template.
+- **Amortizing loan.** Carries outstanding principal, an
+  amortization schedule, an interest rate, two counterparties
+  (borrower agent and lender agent), and an interest-deductibility
+  flag (e.g. qualified-residence interest is deductible up to the
+  principal cap; investment-property interest follows different
+  rules; an intra-family personal loan typically isn't deductible).
+  One implementation covers mortgages, intra-family loans, and any
+  other inter-agent fixed-payment debt. Multiple loans in one
+  scenario route through the same monthly-payment + principal-vs-
+  interest split + counterparty cash-flow code.
+- **Tax-liability instrument.** Federal income tax + CA income tax
+  for each (rollout, agent or tax-household, year) — accrued at
+  year-end based on the year's ordinary income + capital gains +
+  deductions, settled via the IRS quarterly-estimated + year-end
+  schedule. One template, parameterized by jurisdiction (federal vs
+  CA) and filing status. Adding another state means adding another
+  parameter set, not new code.
+- **Recurring obligation.** A fixed-amount fixed-cadence cash demand
+  (HOA dues, insurance premium, special assessment, outside rent,
+  monthly spend allowance, recurring transfer). Settles each due
+  month against the obligated agent's cash via the agent's
+  configured funding chain. One template, configured N times per
+  scenario.
+- **Income stream.** A recurring or scheduled cash inflow with a
+  tax-classification label (W-2 ordinary, K-1 ordinary, rental
+  income net of expenses, etc.). The cash arrives, the label feeds
+  the year's tax computation, and the same income-classification
+  enum is what the tax template's rules dispatch on — no
+  W-2-specific code path separate from a K-1-specific one when the
+  treatment is the same.
+
+Rules attached to templates (what runs over them, exactly once):
+
+- **Year-tax computation** consumes the year's aggregated ordinary
+  income (sum across income streams marked ordinary) + the year's
+  LTCG bucket (sum across capital-gains-eligible holdings'
+  long-term sales) + the year's STCG bucket (short-term sales,
+  routed into ordinary) + the year's depreciation recapture (from
+  §1250-marked property sales) + deduction inputs (property tax,
+  qualified-residence interest, SALT cap, standard deduction). It
+  is one function per jurisdiction, taking aggregated inputs;
+  per-asset-class versions are forbidden.
+- **Per-month tax allocation** spreads the year's tax back to the
+  months that produced taxable events, proportionally to each
+  event's share of the year's taxable income. One function,
+  consumes the per-month realized-gain stream regardless of which
+  template produced each entry.
+- **Quarterly estimated tax + safe harbor** is one function consuming
+  the year's running income totals and the prior-year actual tax.
+  Federal and CA each have their own parameters, same code.
+- **Capital-gains classification** (long-term vs short-term) is one
+  function consuming holding period across every capital-gains-
+  eligible row. No per-asset-class duplicate.
+- **Obligation funding chain** (when an agent is short of cash to
+  settle a required obligation) is one function consuming the
+  agent's configured chain of capital-gains-eligible positions in
+  preference order. Sells happen against the same code path
+  regardless of whether the position is stock-like or crypto-like.
+- **Depreciation accrual** is one function consuming every
+  depreciable-property-marked row's schedule + month. The engine
+  doesn't have a separate "residential" and "rental" depreciation
+  implementation — it has one, parameterized.
+
+Concretely on the existing engine's smell: the current
+`scenario_engine.py` has separate `sp500_*`, `crypto_*`, and
+`private_equity_*` matrices, separate sale-record lists per asset
+class, separate `_record_sp500_sale_*` / `_record_crypto_sale_*` /
+`_record_private_equity_sale_*` recorders, and separate
+`generic_sp500_sale_tax_usd` / `crypto_sale_tax_usd` /
+`private_equity_sale_tax_usd` output columns. The new engine has
+**one** `asset_holding_frame` keyed by `(rollout, agent, asset_id)`
+with a `template_id` column, **one** sale recorder that consumes
+rows of any template, **one** taxable-gain aggregator that filters by
+the template's tax-treatment column. Adding a 4th capital-gains-
+eligible asset class is a config change.
 
 ## Scenarios — bottom up
 
 Each scenario adds one new capability. The simulator must handle all
 of them; the order is the order in which the implementation should
 acquire support, not a runtime classification.
+
+**Notation note on asset names.** Names like `"sp500"`, `"btc"`,
+`"alice_aapl"`, `"primary_residence"`, `"rental_unit_2"` appearing
+below are **scenario-level configured identifiers**, not strings the
+engine recognizes. They identify positions; what the engine does
+with each position is determined by the template the position points
+at (see [Asset templates and rule routing](#asset-templates-and-rule-routing)).
+Replacing `"sp500"` with `"global_equities"` in a scenario is a
+display-name change; the engine doesn't notice. Two scenarios with
+ten differently-named stock-like positions each route through the
+same capital-gains-eligible-holding code path.
 
 ### Layer 1: Just transfers
 
@@ -173,12 +326,21 @@ Alice sells \$5000 of stock in month 3, another \$5000 in month 9.
 Each sale realizes gain proportional to the basis-per-unit at that
 month. The order is preserved on the transaction log.
 
-#### S4.5 — Multiple asset classes.
+#### S4.5 — Many positions, all going through one code path.
 
-Alice owns SP500, BTC, and a private-equity position with a
-configured liquidity regime. Each holds its own units + basis, each
-has its own market price path. Holdings and balances scale row-wise
-in the output, not by adding columns.
+Alice owns ten differently-named positions in a single scenario:
+say `"sp500_etf"`, `"intl_etf"`, `"bond_etf"`, `"bitcoin"`,
+`"ethereum"`, plus five individual stocks named `"position_001"`
+through `"position_005"`. Each is configured at the scenario level
+with its own market price path; eight point at the standard
+capital-gains-eligible-holding template (LTCG-after-1y / STCG-
+otherwise); two point at a "no-LTCG-discount" variant for an
+illustrative jurisdiction where everything is ordinary income. The
+engine does NOT have ten separate per-position code paths — every
+position runs through the same template-driven code, with the
+position's template-id routing it to the right rules.
+
+Adding an 11th position is a scenario edit, not an engine edit.
 
 ### Layer 5: Market integration
 
@@ -221,13 +383,15 @@ already.
 
 #### S6.2 — Multiple gain sources in one year combine.
 
-Alice realizes \$10000 from SP500 (long-term), \$3000 from BTC
-(long-term), and \$5000 from a private-equity sale (long-term). All
-fold into the same long-term-capital-gain bucket for federal tax
-purposes, which is summed once and taxed once at federal LTCG rates.
-California treats LTCG as ordinary income — the same gains feed CA's
-ordinary-income computation. The simulator does not compute tax on
-SP500 sales separately, double-count, or miss a source.
+Alice realizes \$10000 from `"sp500_etf"` (long-term), \$3000 from
+`"bitcoin"` (long-term), and \$5000 from `"alice_private_equity"`
+(long-term). All three positions point at capital-gains-eligible-
+holding templates marked LTCG-on-this-sale; the year-tax math sums
+their realized gains into **one** LTCG bucket and walks the federal
+LTCG bracket **once**. California treats LTCG as ordinary income —
+the same summed gains feed CA's ordinary-income bracket walk, also
+once. There is no per-position-class tax computation; adding a 4th
+LTCG-eligible position adds a row to the bucket, not a code path.
 
 #### S6.3 — Short-term gain is ordinary income.
 
@@ -245,10 +409,9 @@ the following year. Each quarterly amount is sized to satisfy the
 safe-harbor rule: total quarterly payments cover the lesser of
 (actual current-year tax) or (a fraction of prior-year tax —
 typically 100% but 110% above the high-income threshold). For year
-zero (no prior-year tax data) the simulator's behavior is
-deterministic and documented; reasonable choices include "no
-quarterly payments emit, year-end true-up covers the full year" or
-"user supplies a prior-year-tax knob".
+zero of the simulation, the prior-year tax value comes from the
+scenario's tax-profile configuration (see [Resolved decisions](#resolved-decisions));
+the engine does not synthesize one.
 
 The simulator must:
 
@@ -341,15 +504,18 @@ amount). The transaction log records both halves. Alice's checking
 cash drops by the full payment. Bank Bob's cash rises by the full
 payment.
 
-#### S8.3 — Bank Bob's interest income is taxable.
+#### S8.3 — Bank Bob's interest income is recorded but not taxed.
 
-Bank Bob earns ordinary income on each month's interest portion.
-If Bank Bob is modeled as a tax-paying agent (i.e. it has a filing
-status and tax profile), then year-end federal + CA tax on that
-income is computed and accrued on Bank Bob's books. If Bank Bob is
-modeled as a non-tax-paying entity (e.g. an institutional lender out
-of scope for tax), the income is still recorded — it's a contract
-parameter, not a tax-profile parameter — but no tax accrues.
+Bank Bob earns interest income on each month's interest portion of
+Alice's payment. The transaction lands on Bank Bob's books — the
+cash inflow + the income classification are recorded for symmetry
+and for auditability — but Bank Bob is marked as a non-tax-paying
+agent (see [Resolved decisions](#resolved-decisions)), so no
+year-tax accrual fires on Bank Bob and Bank Bob has no tax-payable
+liability. For the simulation's purposes Bank Bob is a money sink:
+its cash balance is allowed to grow without bound and never matters
+to any decision. Mortgage origination treats Bank Bob's cash
+availability as unconditional.
 
 #### S8.4 — Mortgage interest is deductible for Alice.
 
@@ -481,10 +647,12 @@ months):
 - **Per-rollout per-month per-agent state**: cash balances by
   account, asset holdings (units + basis + current market value) by
   asset, liability balances (principal + monthly interest accrued +
-  monthly principal paid) by liability. Long-form, one row per
-  (rollout, month, agent, entity-id). The cardinality of agents,
-  accounts, assets, liabilities goes into row count, not into the
-  schema.
+  monthly principal paid) by liability — addressable for any
+  `(rollout, month, agent, entity-id)` tuple. Long-form vs wide-form
+  is an implementation choice; the constraint is that any concrete
+  query (one rollout's full state at month M, one agent's net worth
+  series across months, an asset's units across rollouts) is
+  cheap and obvious to express.
 - **Transaction log**: every transaction recorded chronologically with
   (rollout, month, kind, parties, amounts, cause-id). Causes link
   back to the policy or obligation that produced the transaction.
@@ -526,10 +694,40 @@ they are not maintained alongside as separate state.
 - **Behavioral / regret modeling.** Agents follow their configured
   policies deterministically.
 
+## Resolved decisions
+
+- **Lenders are agents for bookkeeping, not for tax.** The lender
+  side of an inter-agent loan (e.g. "Bank Bob" in S8) is a
+  first-class agent for the purpose of double-entry bookkeeping —
+  the loan principal sits on the lender's books as a receivable
+  asset, monthly interest income lands on the lender's books, and
+  cash flows are recorded symmetrically — but the lender's books
+  are a **sink**: no tax accrual fires on the lender, and the
+  lender is assumed to have unbounded cash for the purpose of
+  origination. The lender's "net worth" / "income" outputs may be
+  computed (they fall out of the same machinery) but are not the
+  point of the simulation. Bank Bob's interest income does NOT
+  generate a tax-liability instrument; the year-tax computation
+  template just doesn't apply to lender-flagged agents.
+
+  Modeling consequence: agents carry a `tax_payer` flag (or a
+  filing-status field whose value is "n/a — not a tax payer" /
+  similar). The year-tax template runs only over agents with a
+  configured tax profile.
+
+- **Year-zero estimated tax: prior-year value is scenario
+  configuration.** When the safe-harbor rule kicks in for year 0
+  of a simulation, the simulator uses a `prior_year_tax_usd` value
+  that the scenario supplies as part of the agent's (or tax
+  household's) tax profile. No engine-side fallback (no estimate
+  from the configured ordinary income, no "skip quarterlies in year
+  0"). If the scenario does not configure it, the engine raises at
+  scenario-validation time — the user has to make the call.
+
 ## Open questions
 
-These are unresolved and need a decision before the relevant layer
-lands. They aren't blocking the earlier layers.
+These are still unresolved and need a decision before the relevant
+layer lands. They aren't blocking the earlier layers.
 
 - **Tax household scope.** Tax computation today is single-agent.
   Joint filers with separate cash accounts but a single tax return —
@@ -537,23 +735,12 @@ lands. They aren't blocking the earlier layers.
   abstraction that aggregates one or more agents? Either works; the
   decision affects how filing status, joint deductions, and combined
   brackets are modeled.
-- **Bank Bob's existence model.** The mortgage scenarios above
-  describe the lender as another agent in the same simulation. An
-  alternative is to model lenders as "contract counterparties"
-  without their own balance sheet, since simulating a bank's balance
-  sheet is usually not what the user wants. The decision affects how
-  many agents typical scenarios carry and whether lenders pay tax.
-- **Year-zero quarterly estimated tax.** With no prior-year tax data,
-  several behaviors are defensible: (a) no quarterlies fire and the
-  year-end true-up covers the full year, (b) the user supplies a
-  `prior_year_tax_usd` knob, (c) the simulator estimates from the
-  scenario's configured ordinary income. The current legacy engine
-  picked (a) + (b); the new implementation should commit to a default
-  explicitly.
 - **Agent-to-agent gifting tax treatment.** S1.2 establishes that
   transfers can carry an income classification. Gift tax,
   exclusions, lifetime exemption — out of scope here, or modeled?
 - **Inter-agent loans beyond mortgages.** S8 describes one specific
   contract type. Should the simulator support arbitrary inter-agent
   loans (e.g. partner equity loans, intra-family lending), or is
-  mortgage the only template?
+  mortgage the only template? The amortizing-loan template above
+  is written to cover both; whether scenarios actually configure
+  non-mortgage instances is the open question.

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -660,14 +660,13 @@ rules separately.
 
 #### S7.4 — Filing status.
 
-Single or head-of-household. Each filing status pins different
-bracket boundaries, standard deduction amounts, and threshold
-values (NIIT, safe-harbor high-income). The simulator carries the
-filing status per tax-paying agent and looks up the right tables.
-
-(Married-filing-jointly and married-filing-separately are
-out of scope — see [Non-goals](#non-goals). A scenario representing
-a couple files each agent as single.)
+Single only at this stage. The infrastructure carries filing status
+per tax-paying agent and looks up the right tables (bracket
+boundaries, standard deduction, threshold values like NIIT and
+safe-harbor high-income), so adding head-of-household / MFJ / MFS
+later is a matter of dropping in the corresponding rows in the
+jurisdiction YAML and (for MFJ/MFS) wiring two agents to a shared
+return — see [Non-goals](#non-goals).
 
 #### S7.5 — Combined ordinary + capital scenario.
 
@@ -1159,14 +1158,14 @@ they are not maintained alongside as separate state.
   mark-to-market price.
 - **Behavioral / regret modeling.** Agents follow their configured
   policies deterministically.
-- **Joint filing (MFJ / MFS).** The tax-paying-agent unit covers
-  single-filer scenarios. Married-filing-jointly and married-
-  filing-separately are not modeled. Filing-status values exist
-  (filer agents pick single or head-of-household, per S7.4), but
-  the joint-return wiring — two agents sharing one tax return,
-  combined brackets, MFJ standard deduction — is out of scope.
-  If a scenario wants to model a couple, both agents file as
-  single (or HoH where applicable).
+- **Filing statuses beyond single (HoH / MFJ / MFS).** The tax-
+  paying-agent unit covers single-filer scenarios. Head-of-
+  household, married-filing-jointly, and married-filing-separately
+  are out of scope. The filing-status field on the tax profile is
+  retained as `"single"` only; HoH brackets and the MFJ joint-
+  return wiring (two agents sharing one return, combined brackets,
+  MFJ standard deduction) come later. If a scenario wants to model
+  a couple in the meantime, both agents file as single.
 
 ## Resolved decisions
 

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -119,19 +119,38 @@ applies to a template, not to a name.
   based on its own acquisition date vs the sale date; per-lot gains
   flow into the LTCG or ordinary-income tax buckets accordingly.
   Buying more of the same position adds a new lot (or extends an
-  existing lot, in the average-cost case). Covers everything one
-  would call a stock-like, crypto-like, ETF-like, or single-issuer
-  position. Scenarios configure as many named positions as needed
-  (e.g. `"sp500_etf"`, `"individual_aapl"`, `"bitcoin"`, `"ethereum"`)
-  and the engine treats them uniformly — the lot structure lives
-  inside the template, not as a per-asset-class concept.
-- **Depreciable real-property holding.** Capital-gains-eligible plus
-  a depreciation schedule, an §1250 recapture rule on sale, a SALT-
-  cap-eligible property-tax stream, and a qualified-residence
-  interest seam (when the property is the agent's primary residence).
-  One template per legal treatment (e.g. owner-occupied vs rental);
-  multiple properties of the same legal treatment in one scenario
-  are multiple rows on the same template.
+  existing lot, in the average-cost case). The position also carries
+  a **sellability mask** parameter (per-rollout per-month boolean,
+  default "always sellable"); sales fire only in months where the
+  mask permits, otherwise the engine queues the policy's behavior
+  per its configured fallback (wait, fail, fall through to next
+  funding source). PE-style lockup-and-tender positions, IPO
+  lockups, and similar liquidity constraints come out of this one
+  parameter without a new template. Covers everything one would
+  call a stock-like, crypto-like, ETF-like, single-issuer, or
+  private-equity position. Scenarios configure as many named
+  positions as needed (e.g. `"sp500_etf"`, `"individual_aapl"`,
+  `"bitcoin"`, `"ethereum"`, `"alice_private_equity"`) and the
+  engine treats them uniformly — the lot structure, sellability,
+  and basis method all live inside the template, not as
+  per-asset-class concepts.
+- **Depreciable real-property holding.** Capital-gains-eligible
+  plus a depreciation schedule, an §1250 recapture rule on sale,
+  a §121 primary-residence exclusion eligibility tracker
+  (ownership + use clocks), a SALT-cap-eligible property-tax
+  stream, and a qualified-residence interest seam (when the
+  property is the agent's primary residence and finances it via
+  an amortizing-loan template instance). Carries an
+  **occupancy mode** field (primary residence / rental / vacant)
+  that determines whether depreciation accrues, whether rental
+  income/expenses are collected, and whether §121 eligibility is
+  accruing. Mode can change mid-simulation via scheduled events.
+  References a **location** (see [Locations and tax jurisdictions](#locations-and-tax-jurisdictions))
+  for property-tax rate, transfer-tax rate, and applicable tax
+  jurisdictions. Multiple properties — owned by the same agent
+  or different agents, in the same location or different locations
+  — are multiple instances of the same template. The engine does
+  not branch on count.
 - **Amortizing loan.** Carries outstanding principal, an
   amortization schedule, an interest rate, two counterparties
   (borrower agent and lender agent), and an interest-deductibility
@@ -207,6 +226,58 @@ with a `template_id` column, **one** sale recorder that consumes
 rows of any template, **one** taxable-gain aggregator that filters by
 the template's tax-treatment column. Adding a 4th capital-gains-
 eligible asset class is a config change.
+
+## Locations and tax jurisdictions
+
+Property carrying costs, sale-side transfer taxes, and the
+applicable income-tax law all vary by where the property (or the
+agent) is located. The engine handles location-specific variation
+via two configurable concepts wired into the templates above:
+
+- **Tax jurisdiction.** A parameter set capturing one body of tax
+  law: filing-status-keyed brackets, deductions, NIIT thresholds,
+  LTCG vs ordinary treatment of capital gains, SALT cap, qualified-
+  residence interest cap, depreciation schedule (e.g. 27.5-year
+  residential rental), §1250 recapture rate, §121 primary-residence
+  exclusion amount, deductibility rules — whatever varies between
+  jurisdictions. Federal-US is one jurisdiction; California is
+  another; New York is another; a hypothetical foreign jurisdiction
+  is another. The tax-liability-instrument template **runs once
+  per applicable jurisdiction per (agent, year)**, taking the
+  jurisdiction's parameter set as input. Adding another state is
+  adding another parameter set, not new code.
+
+- **Location.** A named place (e.g. `"san_francisco_ca"`,
+  `"manhattan_ny"`, `"austin_tx"`) carrying:
+  - the ordered list of tax jurisdictions that apply to property
+    or income at that location (federal-US + california for SF;
+    federal-US + new-york-state + nyc-municipal for Manhattan;
+    federal-US + texas for Austin),
+  - the property tax rate (or a more elaborate formula),
+  - the transfer-tax rate that lands on sale-side closing costs,
+  - any other location-specific parameters scenarios need (e.g.
+    rent-control rules, special-assessment defaults, location-
+    specific deduction caps).
+
+  A scenario declares the location of each property and of each
+  agent's residence. Property tax on property X uses X's location's
+  rate. Agent A's income tax uses the jurisdictions of A's
+  residence-location. **One agent owning two properties in
+  different locations** is routine: each property's carrying
+  costs and sale-side transfer tax follow its own location's
+  rates; aggregate deductions (e.g. SALT) sum across all the
+  agent's properties subject to the federal cap. The engine does
+  not need a multi-location code path — the per-property and
+  per-agent location parameters route into the same per-template
+  rule.
+
+This DRYs out "renting properties in different places" exactly the
+same way the asset-template structure DRYs out asset classes:
+location-specific variation is **configuration in the scenario**;
+the engine routes by `location_id` on each property / agent row
+into the same template-level rules. Adding a new state is a new
+TaxJurisdiction record + a new Location record (or two) referencing
+it; the engine doesn't notice.
 
 ## Scenarios — bottom up
 
@@ -654,6 +725,34 @@ fires every month; the sale fires only in rollouts where the
 post-spend cash is below the floor. Different rollouts (different
 market paths affecting stock value) make different decisions.
 
+#### S9.6 — Fixed monthly spend.
+
+The standalone case: Alice spends \$3500 every month on living
+expenses. One recurring-obligation instance with `cadence=monthly`
+and a fixed amount, classified as `spending` (not income; not
+deductible; non-tax-paying expense). Each month: cash drops by
+\$3500; if insufficient cash, the funding chain may sell assets to
+cover (same chain as any other obligation); if still short, the
+month's spend obligation is unfundable and a failure-event row is
+emitted.
+
+#### S9.7 — Variable monthly spend from the market model.
+
+Same template as S9.6, but the monthly amount is supplied by a
+market-model "spending-variance" path: per-rollout per-month
+amounts that differ across rollouts. The recurring-obligation
+template's amount source is either a scenario-configured fixed
+value (S9.6) or a market-model path (this scenario) — the engine
+doesn't branch on the source; it just reads `amount_due[rollout,
+month]` and settles. Different rollouts diverge endogenously
+because higher-spend months drain cash faster and trigger
+floor-policy sales earlier.
+
+This is the seam that lets a scenario model "Alice's spending is
+volatile" without an engine change. The same seam supports
+market-driven variable rental income (S13.2) and any other
+recurring obligation whose amount is rollout-dependent.
+
 ### Layer 10: Market model integration
 
 #### S10.1 — Per-rollout sampled market paths.
@@ -707,6 +806,224 @@ succeeds, the rollout does not enter failure — it continues
 normally. Failure is "obligation went unpaid"; sale-driven
 recovery is not failure.
 
+### Layer 12: Housing — primary residence
+
+#### S12.1 — Buy a house with a mortgage.
+
+Alice buys a house in `"san_francisco_ca"` at month 0. Purchase
+price \$500k. Buy-side closing costs \$5k (configurable per-location
+percentage or absolute amount). Down payment \$100k from Alice's
+cash. Bank Bob originates a 30-year fixed mortgage at 6% for the
+remaining \$400k (the same amortizing-loan-template instance from
+S8.1).
+
+Per S8.1's bookkeeping: Alice's checking debits \$105k (down + buy
+closing). Closing costs roll into the property's **adjusted basis**
+(not deductible) → the depreciable-real-property-holding instance
+records `adjusted_basis = $505k`. Mortgage originates simultaneously.
+The location is `"san_francisco_ca"`; the property tax rate, transfer
+tax (sell side), and applicable tax jurisdictions are pulled from
+that location's config.
+
+#### S12.2 — Monthly carrying costs while owner-occupied.
+
+Each month while Alice lives in the house: property tax accrues
+(location's rate × current property value, billed monthly or annually
+per the location's cadence), HOA dues, insurance premium,
+maintenance. Each is a recurring-obligation instance settling from
+Alice's cash. Property-tax accruals are flagged SALT-cap-eligible
+for federal itemized deduction at year-end.
+
+#### S12.3 — Property tax + SALT cap deduction.
+
+In a tax year where Alice pays \$12k of property tax, the federal
+itemized deduction picks up \$10k (SALT cap) for federal purposes,
+\$12k for CA. Combined with mortgage interest and any state-income-
+tax paid, the year's itemized-deduction total is compared against
+the standard deduction; the larger wins.
+
+#### S12.4 — Qualified-residence mortgage interest deduction.
+
+Mortgage interest paid in a year is deductible — federally up to the
+interest on the first \$750k of principal (post-TCJA), CA with its
+own equivalent cap. Above the cap, the deduction is proportionally
+reduced (`deductible_interest = total_interest × min(1, $750k /
+average_principal_balance_during_year)`). One function consumes the
+amortizing-loan-template instance's principal-balance schedule and
+the year's interest-paid total to produce the deductible portion.
+
+#### S12.5 — Sell primary residence, §121 exclusion fully covers gain.
+
+Alice sells the house at month 60 (5 years of ownership + primary-
+residence use). Sale price \$700k. Sell-side closing costs \$35k
+(transfer tax + agent commissions, per the location). Adjusted
+basis \$505k. Realized gain = \$700k − \$35k − \$505k = \$160k.
+
+§121 exclusion (single filer, ≥2 of last 5 years as primary residence)
+allows excluding the first \$250k of gain from federal LTCG. The
+\$160k gain is fully excluded; no federal LTCG accrues. California
+mirrors §121. Mortgage payoff at closing (per S8.6) settles the
+remaining principal back to Bank Bob.
+
+#### S12.6 — Sell primary residence with gain above §121 cap.
+
+Same setup as S12.5 but sale price is \$900k. Gain = \$900k − \$35k
+− \$505k = \$360k. §121 excludes \$250k; the remaining \$110k is
+taxable as LTCG (federal + CA), routed through the year-tax
+computation alongside any other LTCG bucket entries.
+
+#### S12.7 — Special assessment.
+
+The HOA issues a \$20k special assessment at month 36. Recurring-
+obligation instance with cadence "one-off at month 36". Settles via
+Alice's configured funding chain the same way any obligation does.
+
+### Layer 13: Housing — rental, occupancy modes, multiple properties
+
+#### S13.1 — Convert primary residence to rental.
+
+At month 24 Alice moves out and starts renting the house to a
+tenant. The depreciable-real-property-holding instance's
+`occupancy_mode` flips from `primary_residence` to `rental`.
+Effects, all driven by the mode flip:
+
+- Monthly depreciation starts accruing on the building portion of
+  adjusted basis (residential rental: 27.5-year straight-line; the
+  applicable jurisdiction's schedule).
+- A rental-income stream and a rental-expense pipeline begin
+  (mgmt fee, leasing fee, …).
+- The §121 ownership clock keeps running but the use clock stops —
+  later sale eligibility depends on how recent the primary-residence
+  usage was.
+
+#### S13.2 — Rental income, expenses, depreciation, net rental income.
+
+While the house is rented (months 24-83 in our running example):
+
+- Rental gross income (e.g. \$3000/month, possibly market-path-
+  driven so different rollouts see different rents) lands in Alice's
+  cash each month.
+- Rental expenses (mgmt fee = 8% of gross rent; one-month leasing
+  fee on the first month; the same property-tax / HOA / insurance /
+  maintenance recurring obligations as S12.2) reduce taxable rental
+  income.
+- Accrued depreciation (computed by the depreciable-real-property
+  template) reduces taxable rental income further, separately from
+  cash (depreciation does not move cash; it's a tax artifact).
+
+Net rental income for the year = `Σ(gross_income) − Σ(rental_expenses)
+− Σ(depreciation)`. Folds into the year's ordinary-income bucket via
+the tax-liability-instrument template. Passive-activity loss
+limitations apply when net rental income is negative (modeled per
+the applicable jurisdiction's rules).
+
+#### S13.3 — Sell a rental property: §1250 depreciation recapture.
+
+Alice sells the rental at month 84 for \$900k. Adjusted basis
+\$505k. Cumulative depreciation over months 24-83 = \$50k. Sell-side
+closing \$35k. Realized gain = \$900k − \$35k − \$505k = \$360k.
+
+§1250 recapture: the portion of the gain attributable to prior
+depreciation is taxed at the federal §1250 rate (capped 25%) rather
+than the LTCG rate. CA: ordinary income. Recapture amount = `min(
+realized_gain, cumulative_depreciation)` = \$50k. The remaining
+\$310k is LTCG. §121 may not apply (or only partially apply) because
+the recent primary-residence usage test fails for this timeline —
+the simulator computes §121 eligibility from the ownership / use
+clocks and routes the rest of the gain accordingly.
+
+The year-tax computation must:
+
+- Walk one federal §1250 bracket once on the recapture portion across
+  all the agent's §1250-eligible property sales this year.
+- Walk one federal LTCG bracket once on the LTCG portion across all
+  LTCG-eligible asset sales this year (Layer 6 rules).
+- Walk one CA ordinary bracket once on the combined recapture + LTCG
+  amount, plus any non-rental ordinary income.
+
+#### S13.4 — Outside rent: agent is the tenant.
+
+Alice owns a house she rents out (S13.1-S13.3 timeline) and
+simultaneously rents a place to live in. Monthly outside-rent is a
+recurring-obligation instance on Alice as tenant — settles from
+Alice's cash via the same funding chain as any other obligation. Not
+deductible for federal personal income tax (rent paid by a non-
+business individual isn't a deduction). The simulator records it on
+the transaction log and decrements cash; no tax effect.
+
+#### S13.5 — Multiple properties at different locations.
+
+Alice owns two properties: a primary residence in
+`"san_francisco_ca"` and a rental in `"austin_tx"`. Each carries its
+own location's property-tax rate, transfer-tax rate, and applicable
+tax jurisdictions. The SF property's income (none — primary
+residence) and sale gain run through federal + CA; the Austin
+property's rental income and sale gain run through federal + TX
+(which has no state income tax). At year-end, Alice's federal
+itemized SALT deduction sums property tax paid across **both**
+properties subject to the federal \$10k cap. The simulator must
+not double-count, drop a property, or hard-code the count.
+
+#### S13.6 — Occupancy mode switching over a multi-year timeline.
+
+Alice's house: months 0-23 primary residence, 24-83 rental, sold
+month 84. The simulator handles the full timeline:
+
+- Depreciation accrues only months 24-83.
+- Carrying costs (property tax, HOA, insurance, maintenance) accrue
+  every month regardless of mode (they're owner-paid in both modes).
+- Rental income / expense streams accrue only months 24-83.
+- §121 eligibility at month 84: requires 24 months of primary-
+  residence use within the prior 60 (months 24-83). Alice's primary-
+  residence use during that window = 0 months. §121 does not apply;
+  full gain is taxable per S13.3's split.
+
+#### S13.7 — One agent owning multiple properties simultaneously.
+
+A separate variant: Alice owns three properties at month 30 — one
+primary residence, two rentals at different locations. Each is its
+own depreciable-real-property-holding instance with its own location,
+its own carrying-cost obligations, its own depreciation schedule
+(rentals only), its own occupancy-mode timeline. The engine carries
+N rows of the same template and runs each rule against all N rows
+in one bulk operation per rule. Adding a 4th property at month 48
+is a configuration change: a new property row created at that
+month via a configured purchase event.
+
+### Layer 14: Constrained sellability
+
+#### S14.1 — Position with tender-only liquidity.
+
+Alice's position `"alice_private_equity"` is a capital-gains-eligible
+holding configured with a `sellability_mask` derived from a market-
+model "tender opportunity" path: false except at the specific months
+where a tender is offered to the rollout. A floor-triggered sale
+policy (S9.1-style) attempts to sell in month M:
+
+- If `sellability_mask[rollout, M]` is true, the sale fires.
+- If false, the sale falls through to the next funding source per
+  the policy's preference chain (S9.2). The position is not sold;
+  the policy is not silently no-op'd — the failure-to-sell-this-
+  asset is recorded so the decision log shows that this asset was
+  considered and skipped.
+
+#### S14.2 — Mixed-liquidity positions in one scenario.
+
+Alice holds three capital-gains-eligible positions:
+
+- `"sp500_etf"` — sellability_mask = all true (default).
+- `"alice_preipo"` — sellability_mask = false until month 36
+  (lockup), then true. Represents an IPO lockup.
+- `"alice_private_equity"` — sellability_mask sampled from the
+  market-model tender path per rollout (S14.1 style).
+
+All three are instances of the same capital-gains-eligible-holding
+template. The engine does not have a "PE sale" code path separate
+from a "stock sale" code path — sales route through one function
+that filters by `sellability_mask[rollout, M]` and skips ineligible
+rollouts. Different rollouts may execute the same scheduled sale
+on different positions depending on which masks permit it.
+
 ## Outputs the simulator must produce
 
 For any run (scenario + market bundle + rollout count + horizon
@@ -733,10 +1050,26 @@ months):
   walks, NIIT calculation, federal/CA totals. Enough to audit any
   rollout's tax math.
 - **Per-obligation lifecycle**: every obligation (mortgage payment,
-  property tax, quarterly tax, year-end tax) with its accrual month,
-  amount due, amount paid, settlement month(s), unpaid balance.
+  property tax, quarterly tax, year-end tax, HOA, special assessment,
+  outside rent, monthly spend) with its accrual month, amount due,
+  amount paid, settlement month(s), unpaid balance.
+- **Lot disposition log**: every sale of a capital-gains-eligible
+  position emits one row per consumed lot, carrying `(rollout,
+  month, agent_id, position_id, lot_id, units_sold, proceeds_usd,
+  basis_consumed_usd, realized_gain_usd, holding_period_days,
+  tax_classification)`. Sales that consume two lots emit two rows;
+  the lot identity carries through from the lot's acquisition.
+  This is the audit trail for every tax-relevant capital event and
+  the primary input to per-month tax allocation.
+- **Failure-event log**: every unfunded required obligation emits a
+  row carrying `(rollout, month, obligation_id, obligation_type,
+  amount_due_usd, amount_paid_usd, shortfall_usd, attempted_funding_
+  sources)`. The same agent can recover in a later month (see
+  S11.3) — failure-event rows do not retroactively delete; they
+  record the moment.
 - **Rollout status**: active vs failed, with failure month and the
-  obligation that triggered the failure.
+  obligation that triggered the failure (joinable to the failure-
+  event log).
 
 These outputs are projections of the state series and transaction log;
 they are not maintained alongside as separate state.
@@ -850,6 +1183,39 @@ the design that's worth examining before shipping.
   If adding "Alice borrows \$20k from her mom" to a scenario
   requires touching engine code, the amortizing-loan template
   isn't generic enough.
+
+- **Partner equity / co-ownership of an asset.** The existing legacy
+  engine has a "partner equity accrual" feature: a second agent
+  contributes a fixed monthly cash amount toward a shared property
+  and builds up an equity stake over time per a configured
+  equity-per-dollar-contributed formula; at sale, the partner
+  receives their share of net proceeds. This is genuinely
+  multi-agent — two agents have stakes in one property — and ties
+  the multi-agent-tax stretch goal (above) to a concrete scenario.
+
+  Critical floor: single-owner properties work. Stretch: a property
+  can carry a "co-ownership ledger" — rows on a `property_stake`
+  frame, one per (agent, property) pair — that tracks each agent's
+  contribution + equity share over time. Sale proceeds split across
+  the ledger. The depreciable-real-property template already
+  references a stake column (per [Asset templates and rule
+  routing](#asset-templates-and-rule-routing)); making it
+  multi-row-per-property is the stretch.
+
+  If achieving this requires inventing a separate "partner
+  contribution" obligation pathway with its own state matrices and
+  its own settlement logic (which the legacy engine has), the
+  generic obligation + recurring-cash-transfer machinery isn't
+  generic enough — partner contributions should be a recurring
+  transfer between two agents, recorded against the partner's
+  stake row at the receiving agent, settled via the contributing
+  agent's funding chain like any other recurring obligation.
+
+  Lower priority than the multi-agent tax stretch above; landing
+  this without it requires the partner stake but not the partner's
+  own tax computation (which simplifies somewhat, since the
+  partner is effectively a non-tax-paying co-owner in single-
+  primary-agent scenarios).
 
 ## Open questions
 

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -24,6 +24,26 @@ Outputs: a per-month time series of every agent's full balance sheet
 in every rollout, plus an append-only ledger of every transaction
 that produced those balances.
 
+## Scope
+
+The simulator targets **federal US tax law + California tax law**.
+The only tax jurisdictions that need to ship are `federal_us` and
+`california`. The only locations that need to ship are a small set
+of California Bay Area places (e.g. San Francisco, San Mateo, Palo
+Alto, Oakland, Sunnyvale) — they differ from each other in property-
+tax rate (county assessor + Prop 13 + Mello-Roos), in city-level
+real-estate transfer tax (SF in particular has a graduated transfer
+tax), and in HOA / special-assessment defaults, so locations stay a
+configurable thing even within California.
+
+The architecture is described in terms of jurisdictions and
+locations as configurable records (see [Locations and tax
+jurisdictions](#locations-and-tax-jurisdictions)) so that adding a
+new state, city, or country is a parameter-record addition with no
+engine change required. That's a design-quality property, not a
+roadmap commitment — no scenarios exercising non-CA jurisdictions
+need to ship, and no scenario crossing state lines is in scope.
+
 ## Foundational principles
 
 These are non-negotiable shapes. Every scenario below assumes them.
@@ -162,12 +182,14 @@ applies to a template, not to a name.
   scenario route through the same monthly-payment + principal-vs-
   interest split + counterparty cash-flow code.
 - **Tax-liability instrument.** Federal income tax + CA income tax
-  for each (rollout, agent or tax-household, year) — accrued at
-  year-end based on the year's ordinary income + capital gains +
-  deductions, settled via the IRS quarterly-estimated + year-end
-  schedule. One template, parameterized by jurisdiction (federal vs
-  CA) and filing status. Adding another state means adding another
-  parameter set, not new code.
+  for each (rollout, agent, year) — accrued at year-end based on
+  the year's ordinary income + capital gains + deductions, settled
+  via the IRS quarterly-estimated + year-end schedule. One
+  template, parameterized by jurisdiction and filing status; runs
+  once for `federal_us` and once for `california` per (agent, year)
+  under the shipping scope. The structure permits adding another
+  jurisdiction by parameter record only; no other jurisdiction is
+  in scope.
 - **Recurring obligation.** A fixed-amount fixed-cadence cash demand
   (HOA dues, insurance premium, special assessment, outside rent,
   monthly spend allowance, recurring transfer). Settles each due
@@ -240,36 +262,43 @@ via two configurable concepts wired into the templates above:
   residence interest cap, depreciation schedule (e.g. 27.5-year
   residential rental), §1250 recapture rate, §121 primary-residence
   exclusion amount, deductibility rules — whatever varies between
-  jurisdictions. Federal-US is one jurisdiction; California is
-  another; New York is another; a hypothetical foreign jurisdiction
-  is another. The tax-liability-instrument template **runs once
-  per applicable jurisdiction per (agent, year)**, taking the
-  jurisdiction's parameter set as input. Adding another state is
-  adding another parameter set, not new code.
+  jurisdictions. The shipping jurisdiction set is exactly two:
+  `federal_us` and `california` (see [Scope](#scope)). The tax-
+  liability-instrument template **runs once per applicable
+  jurisdiction per (agent, year)**, taking the jurisdiction's
+  parameter set as input — so it runs twice per (agent, year) under
+  the shipping scope. The structure exists so that another
+  jurisdiction is a parameter-record addition with no engine
+  change; no other jurisdiction needs to ship.
 
-- **Location.** A named place (e.g. `"san_francisco_ca"`,
-  `"manhattan_ny"`, `"austin_tx"`) carrying:
+- **Location.** A named place (e.g. `"san_francisco"`, `"san_mateo"`,
+  `"palo_alto"`, `"oakland"`, `"sunnyvale"`) carrying:
   - the ordered list of tax jurisdictions that apply to property
-    or income at that location (federal-US + california for SF;
-    federal-US + new-york-state + nyc-municipal for Manhattan;
-    federal-US + texas for Austin),
-  - the property tax rate (or a more elaborate formula),
-  - the transfer-tax rate that lands on sale-side closing costs,
+    or income at that location. Under the shipping scope every
+    location is in California, so every location's jurisdiction
+    list is `[federal_us, california]` (possibly with a city-
+    level row for local transfer tax / Mello-Roos).
+  - the property tax rate (county assessor + Prop 13 base + any
+    Mello-Roos or parcel-tax surcharges; one rate or a more
+    elaborate formula per location).
+  - the transfer-tax rate that lands on sale-side closing costs
+    (SF has a graduated city-level transfer tax; San Mateo
+    County's is different; Santa Clara's is different again).
   - any other location-specific parameters scenarios need (e.g.
-    rent-control rules, special-assessment defaults, location-
-    specific deduction caps).
+    HOA / special-assessment defaults, rent-control rules where
+    they apply).
 
   A scenario declares the location of each property and of each
   agent's residence. Property tax on property X uses X's location's
-  rate. Agent A's income tax uses the jurisdictions of A's
-  residence-location. **One agent owning two properties in
-  different locations** is routine: each property's carrying
-  costs and sale-side transfer tax follow its own location's
-  rates; aggregate deductions (e.g. SALT) sum across all the
-  agent's properties subject to the federal cap. The engine does
-  not need a multi-location code path — the per-property and
-  per-agent location parameters route into the same per-template
-  rule.
+  rate; agent A's income tax uses A's residence-location's
+  jurisdictions (`[federal_us, california]` under the shipping
+  scope). **One agent owning two Bay Area properties** in different
+  cities is routine: each property's carrying costs and sale-side
+  transfer tax follow its own location's rates; aggregate
+  deductions (e.g. SALT) sum across all the agent's properties
+  subject to the federal cap. The engine does not need a
+  multi-location code path — the per-property and per-agent
+  location parameters route into the same per-template rule.
 
 This DRYs out "renting properties in different places" exactly the
 same way the asset-template structure DRYs out asset classes:
@@ -810,7 +839,7 @@ recovery is not failure.
 
 #### S12.1 — Buy a house with a mortgage.
 
-Alice buys a house in `"san_francisco_ca"` at month 0. Purchase
+Alice buys a house in `"san_francisco"` at month 0. Purchase
 price \$500k. Buy-side closing costs \$5k (configurable per-location
 percentage or absolute amount). Down payment \$100k from Alice's
 cash. Bank Bob originates a 30-year fixed mortgage at 6% for the
@@ -821,7 +850,7 @@ Per S8.1's bookkeeping: Alice's checking debits \$105k (down + buy
 closing). Closing costs roll into the property's **adjusted basis**
 (not deductible) → the depreciable-real-property-holding instance
 records `adjusted_basis = $505k`. Mortgage originates simultaneously.
-The location is `"san_francisco_ca"`; the property tax rate, transfer
+The location is `"san_francisco"`; the property tax rate, transfer
 tax (sell side), and applicable tax jurisdictions are pulled from
 that location's config.
 
@@ -951,18 +980,21 @@ deductible for federal personal income tax (rent paid by a non-
 business individual isn't a deduction). The simulator records it on
 the transaction log and decrements cash; no tax effect.
 
-#### S13.5 — Multiple properties at different locations.
+#### S13.5 — Multiple Bay Area properties at different locations.
 
 Alice owns two properties: a primary residence in
-`"san_francisco_ca"` and a rental in `"austin_tx"`. Each carries its
-own location's property-tax rate, transfer-tax rate, and applicable
-tax jurisdictions. The SF property's income (none — primary
-residence) and sale gain run through federal + CA; the Austin
-property's rental income and sale gain run through federal + TX
-(which has no state income tax). At year-end, Alice's federal
-itemized SALT deduction sums property tax paid across **both**
-properties subject to the federal \$10k cap. The simulator must
-not double-count, drop a property, or hard-code the count.
+`"san_francisco"` and a rental in `"palo_alto"`. Both are in
+California, so both run through `[federal_us, california]` for
+income tax — but each location carries its own property-tax rate
+(SF County assessor's Prop-13 base vs Santa Clara County's; any
+Mello-Roos on the Palo Alto property; SF's city-level real-estate
+transfer tax on sale of the SF property vs Santa Clara County's
+on sale of the Palo Alto property). The simulator routes property
+tax and transfer tax by `location_id`. At year-end, Alice's
+federal itemized SALT deduction sums property tax paid across
+**both** properties subject to the federal \$10k cap. The
+simulator must not double-count, drop a property, or hard-code
+the count.
 
 #### S13.6 — Occupancy mode switching over a multi-year timeline.
 

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -724,23 +724,73 @@ they are not maintained alongside as separate state.
   0"). If the scenario does not configure it, the engine raises at
   scenario-validation time — the user has to make the call.
 
+## Stretch goals (signs of good design)
+
+These are not critical-path requirements but they are diagnostic.
+If the design comes out clean, they fall out for free; if achieving
+them requires intrusive engine changes, that points at a smell in
+the design that's worth examining before shipping.
+
+- **Tax math applies to any tax-paying agent, not a hardwired
+  "primary owner".** The critical floor is that one primary agent
+  pays their federal + CA income taxes correctly (S6, S7). The
+  stretch goal is that the engine has no special-case path for that
+  one agent: the year-tax template (see [Asset templates and rule
+  routing](#asset-templates-and-rule-routing)) runs once per
+  (rollout, year), grouped over every agent the scenario marks as
+  tax-paying. If the scenario configures two tax-paying agents,
+  both get year-tax computations, both get quarterly + year-end
+  obligations, both settle from their own cash + funding chains —
+  with no engine-level changes. If achieving this requires more
+  than scenario configuration, the design has a `primary_owner`
+  hardcoded somewhere it shouldn't be.
+
+  This stretches naturally to a hypothetical scenario where Alice
+  and Auragon are both individual tax-paying agents in the same
+  rollout (each with their own filing status, own income streams,
+  own holdings, own deductions). Owner-plus-partner property
+  scenarios should not need to invent a special "second agent
+  pathway" — the second agent is just a second `tax_payer=true` row
+  in the agents frame.
+
+  Single-agent tax math is **critical**; multi-agent tax math is
+  **stretch**. If multi-agent doesn't work but single-agent does,
+  that's a shippable state; the engine's structure should make
+  multi-agent a small follow-up, not a redesign.
+
+- **Adding a new inter-agent loan instance is configuration.**
+  Today the only inter-agent loan type the simulator must handle is
+  a mortgage between an individual (Alice) and a lender (Bank Bob).
+  The amortizing-loan template (see [Asset templates and rule
+  routing](#asset-templates-and-rule-routing)) is written to cover
+  ANY fixed-payment debt between two agents — the same code path
+  serves an intra-family personal loan, a partner-equity loan, a
+  car loan, an HELOC, etc. The stretch goal is that adding such a
+  loan to a scenario is **scenario configuration**, not engine
+  code: pick the template, supply the principal / rate / term /
+  borrower / lender / deductibility-flag parameters, and the loan
+  works.
+
+  If adding "Alice borrows \$20k from her mom" to a scenario
+  requires touching engine code, the amortizing-loan template
+  isn't generic enough.
+
 ## Open questions
 
 These are still unresolved and need a decision before the relevant
 layer lands. They aren't blocking the earlier layers.
 
-- **Tax household scope.** Tax computation today is single-agent.
-  Joint filers with separate cash accounts but a single tax return —
-  is the tax computation on an "agent" or on a "tax household"
-  abstraction that aggregates one or more agents? Either works; the
-  decision affects how filing status, joint deductions, and combined
-  brackets are modeled.
+- **Tax household scope.** A "tax-paying agent" is the unit of tax
+  computation as established above. Joint filers — two people who
+  share a single tax return but possibly maintain separate cash
+  accounts and holdings — is a separate question on top: is a
+  married-filing-jointly couple modeled as one tax-paying agent
+  whose holdings span the joint estate, or as two cash-account-
+  owning agents that get joined at tax time into a tax-household
+  abstraction? The first is simpler; the second is closer to how
+  real joint filing works. Decision affects how MFJ filing status
+  and the joint standard deduction are wired but does not block
+  any single-filer scenario.
 - **Agent-to-agent gifting tax treatment.** S1.2 establishes that
   transfers can carry an income classification. Gift tax,
   exclusions, lifetime exemption — out of scope here, or modeled?
-- **Inter-agent loans beyond mortgages.** S8 describes one specific
-  contract type. Should the simulator support arbitrary inter-agent
-  loans (e.g. partner equity loans, intra-family lending), or is
-  mortgage the only template? The amortizing-loan template above
-  is written to cover both; whether scenarios actually configure
-  non-mortgage instances is the open question.

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -308,6 +308,38 @@ into the same template-level rules. Adding a new state is a new
 TaxJurisdiction record + a new Location record (or two) referencing
 it; the engine doesn't notice.
 
+### Configuration data lives in YAML, not Python
+
+The jurisdiction and location records — federal + California
+brackets, deductions, NIIT thresholds, SALT cap, qualified-residence
+interest cap, LTCG threshold tables, residential-rental depreciation
+schedule, §1250 rate, §121 exclusion amount, county property-tax
+rates, city transfer-tax schedules, Mello-Roos defaults — are
+**configuration data, not code**. They live in checked-in YAML files
+that the engine reads at startup. A new tax year's bracket update
+is a YAML edit; a new Bay Area location is a YAML edit; correcting
+the SF transfer-tax schedule is a YAML edit. The engine never has
+literal bracket boundaries or rate values inline.
+
+Pydantic models in code validate the YAML's shape (so a typo in a
+tax-bracket boundary fails at startup rather than silently doing
+something wrong), but the **values** are externalized. The same
+data files feed any per-jurisdiction sanity checks, golden-test
+fixtures, and external auditability — there's one canonical source
+for "what the law says in 2026".
+
+This applies to anything that is "the law says" or "this place
+charges X". It does **not** apply to scenario-specific
+configuration (the agents in this scenario, their initial holdings,
+their policies, the market paths). Scenarios are constructed
+programmatically or via their own user-facing config; jurisdiction
++ location data are repo-checked-in reference data.
+
+Existing precedent: `augur/core/annual_tax_parameters.yaml` already
+holds the legacy engine's federal + CA bracket data. The new sim
+extends the pattern to locations and any other "static reference
+data" that varies with real-world law and place.
+
 ## Scenarios — bottom up
 
 Each scenario adds one new capability. The simulator must handle all

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -333,7 +333,8 @@ charges X". It does **not** apply to scenario-specific
 configuration (the agents in this scenario, their initial holdings,
 their policies, the market paths). Scenarios are constructed
 programmatically or via their own user-facing config; jurisdiction
-+ location data are repo-checked-in reference data.
+
+- location data are repo-checked-in reference data.
 
 Existing precedent: `augur/core/annual_tax_parameters.yaml` already
 holds the legacy engine's federal + CA bracket data. The new sim
@@ -616,7 +617,7 @@ The simulator must:
 - Settle each obligation from Alice's cash, drawing on her funding
   policies (e.g. sell stock to cover) if cash is short.
 - True up at year-end: the year-end obligation is `actual_year_tax
-  − sum_of_quarterlies`, never producing a payment greater than the
+− sum_of_quarterlies`, never producing a payment greater than the
   actual year tax across all five settlement events.
 
 #### S6.5 — Net investment income tax.
@@ -1119,16 +1120,16 @@ months):
   amount paid, settlement month(s), unpaid balance.
 - **Lot disposition log**: every sale of a capital-gains-eligible
   position emits one row per consumed lot, carrying `(rollout,
-  month, agent_id, position_id, lot_id, units_sold, proceeds_usd,
-  basis_consumed_usd, realized_gain_usd, holding_period_days,
-  tax_classification)`. Sales that consume two lots emit two rows;
+month, agent_id, position_id, lot_id, units_sold, proceeds_usd,
+basis_consumed_usd, realized_gain_usd, holding_period_days,
+tax_classification)`. Sales that consume two lots emit two rows;
   the lot identity carries through from the lot's acquisition.
   This is the audit trail for every tax-relevant capital event and
   the primary input to per-month tax allocation.
 - **Failure-event log**: every unfunded required obligation emits a
   row carrying `(rollout, month, obligation_id, obligation_type,
-  amount_due_usd, amount_paid_usd, shortfall_usd, attempted_funding_
-  sources)`. The same agent can recover in a later month (see
+amount_due_usd, amount_paid_usd, shortfall_usd, attempted_funding_
+sources)`. The same agent can recover in a later month (see
   S11.3) — failure-event rows do not retroactively delete; they
   record the moment.
 - **Rollout status**: active vs failed, with failure month and the

--- a/augur/sim/REQUIREMENTS.md
+++ b/augur/sim/REQUIREMENTS.md
@@ -1281,6 +1281,44 @@ the design that's worth examining before shipping.
   partner is effectively a non-tax-paying co-owner in single-
   primary-agent scenarios).
 
+## Deferred quality improvements
+
+Lower-priority cleanups that aren't blocking any layer but should
+land before the simulator is treated as production-grade.
+
+- **Fixed-point arithmetic for exact-cent quantities.** Cash
+  balances, tax payments, transfer amounts, lot proceeds, and
+  every other dollar quantity that conceptually has a finite
+  cent-precision representation should be carried as `int64` in
+  the relevant base unit, not `float64`. Concretely:
+  - **Cash / dollar columns**: `int64` cents. Every column whose
+    suffix is `_usd` today becomes `_cents` (or stays `_usd`
+    with the dtype change documented). The replay-invariant
+    helper's float-rounding tolerance disappears — equality
+    becomes bit-exact.
+  - **Tax-form line items**: `int64` whole dollars. IRS Form 1040
+    (and the FTB 540 equivalents) instruct you to round to whole
+    dollars on every line, and quarterly estimated vouchers
+    require it. Bracket-walk outputs and accrual amounts should
+    round to whole dollars before being booked / paid.
+  - **Asset quantities with native indivisible units**: carry in
+    the smallest indivisible unit. Bitcoin in satoshis (1 BTC =
+    10^8 sat), fractional shares at the broker's native precision
+    (typically 10^-6 shares), property in whole-square-foot lot
+    sizes if those ever matter.
+  - **Inherently-float quantities**: market prices, GBM log
+    returns, depreciation fractions, bracket rates. These stay
+    `float64`; the engine multiplies them by the integer unit
+    quantities and rounds the result back to the integer
+    representation at settlement boundaries (e.g. `proceeds_cents
+= round_half_even(quantity_units * price_usd_float * 100)`).
+
+  Splits cleanly across the engine boundary: scenario YAML
+  declares dollar / unit amounts; the engine internalizes them as
+  integers; output formatting converts back for the human-readable
+  surfaces. None of the math changes — only the dtypes and the
+  rounding-at-settlement convention do.
+
 ## Open questions
 
 These are still unresolved and need a decision before the relevant

--- a/augur/sim/SPIKE_1.md
+++ b/augur/sim/SPIKE_1.md
@@ -69,7 +69,7 @@ One tax-paying agent (Alice, single filer, located `"san_francisco"`):
    column with no Python rollout loop.
 2. **Replay invariant holds.** For every M,
    `state_at(M).event_sourced == apply_events(initial,
-   log.filter(month ≤ M))`. Asserted in tests; opt-in
+log.filter(month ≤ M))`. Asserted in tests; opt-in
    `--check-replay` flag for production.
 3. **Tax math correctness.** The deterministic-market single-
    rollout case computes federal + CA year tax to within 1¢ of a

--- a/augur/sim/SPIKE_1.md
+++ b/augur/sim/SPIKE_1.md
@@ -1,0 +1,150 @@
+# Spike 1
+
+End-to-end benchable scenario that exercises the parts that historically
+got tangled in the legacy engine — market-driven rollout divergence,
+the lot model + tax classification, federal + CA year-tax math with
+quarterly + year-end timing, the obligation funding chain. Validates
+the event-log-canonical / polars-vectorized architecture at scale.
+
+See <REQUIREMENTS.md> for the full target spec and <DESIGN.md> for
+the structural plan.
+
+## In scope (REQUIREMENTS layer coverage)
+
+- **L1-L3** — transfers, time, rollouts. The spine.
+- **L4.1-4.7** — lots, FIFO cost basis (FIFO only this spike; HIFO /
+  specific-id / average deferred), sale crossing lots with mixed
+  holding periods.
+- **L4.8** — many positions through one code path. The DRY proof
+  point.
+- **L5** — state-dependent decisions over the rollout column.
+- **L6.1-6.4** — LTCG/STCG classification, year-tax accrual,
+  quarterly estimated + year-end true-up. (NIIT deferred.)
+- **L7.1, 7.2, 7.4, 7.5** — federal + CA brackets, single filer,
+  standard deduction, combined ordinary + capital. (Itemized
+  deductions deferred — nothing to itemize against until L8 / L12.)
+- **L9.1, 9.2, 9.6** — floor-triggered sale, asset preference chain,
+  fixed monthly spend.
+- **L10.1-10.3** — market model integration (per-rollout sampled
+  paths, agent decisions don't feed the market, agents share path
+  within a rollout). Sellability mask plumbed but no scenarios
+  exercise it.
+- **L11.1, 11.2** — cash-negative failure flag, per-rollout failure
+  scope. (Recovery semantics deferred — failed rollouts stay failed
+  this spike.)
+
+## Deferred to later spikes
+
+L8 mortgages • L12-13 housing (purchase / sale / depreciation / §121
+/ §1250 / occupancy / multi-property) • L14 constrained sellability
+(mask wired but no scenarios) • partner-equity stretch • S9.7
+variable spend from market • HoH filing status • NIIT • itemized
+deductions • S11.3 failure recovery • multi-jurisdiction beyond
+federal + CA • multiple Bay Area locations beyond `san_francisco`.
+
+## Deliverable: benchable scenario
+
+One tax-paying agent (Alice, single filer, located `"san_francisco"`):
+
+- Configured W-2 ordinary income of \$200k/year, arriving monthly.
+- Three capital-gains-eligible positions — `"vti"`, `"qqq"`, `"btc"`
+  — each with initial lots configured at scenario start.
+- Market bundle: per-rollout per-month price multipliers for each
+  position (simple stochastic model, GBM-like or bootstrapped from
+  a configured distribution; doesn't need to be the production
+  market model yet).
+- One floor-triggered sale policy: "if checking < \$5000, sell
+  \$20000 of vti, then qqq, then btc in order".
+- One \$5000/month recurring spend obligation.
+- Federal + CA year-tax computation with quarterly estimated
+  payments and year-end true-up; prior-year-tax knob supplied via
+  scenario.
+- Horizon: 5 years (60 months) × 1000 rollouts.
+
+## Success criteria
+
+1. **Architecture proven.** The event log is canonical;
+   `apply_events` is the single state-mutation point; every phase
+   of `step_emit_events` is polars expressions over the rollout
+   column with no Python rollout loop.
+2. **Replay invariant holds.** For every M,
+   `state_at(M).event_sourced == apply_events(initial,
+   log.filter(month ≤ M))`. Asserted in tests; opt-in
+   `--check-replay` flag for production.
+3. **Tax math correctness.** The deterministic-market single-
+   rollout case computes federal + CA year tax to within 1¢ of a
+   hand-computed expected value. The quarterly + year-end true-up
+   payments sum to the full-year tax exactly.
+4. **Rollout divergence.** 1000 rollouts with the same scenario
+   produce 1000 different end-state net-worth trajectories because
+   the market paths differ. Same market paths with different
+   policies also diverge.
+5. **Benchable.** A bench script (sibling to
+   `augur/core/bench_augur_run.py`) runs the representative
+   scenario end-to-end on RBE and reports wall-clock time. No
+   specific perf target this round — establishes the baseline that
+   later waves' bench targets are set against.
+6. **DRY proof.** Adding a 4th capital-gains-eligible position to
+   the scenario is a config edit (one Position record + one market
+   path); zero engine code touched. A test exercises exactly this.
+
+## What spike 1 intentionally does NOT prove
+
+- That mortgages, property purchases / sales, depreciation, §121,
+  §1250 work — those require L8 + L12-13 templates, deferred to
+  spike 2.
+- That the wire schema matches existing `ScenarioRunArrays` —
+  deferred. The new sim has its own `SimulationRun` output type
+  for now; the legacy-wire adapter is a separate concern.
+- That partner-equity multi-stakeholder works — deferred.
+- That performance beats the legacy engine — measures it, doesn't
+  yet require a specific target. Tightening comes after L8 + L12
+  land and we can compare apples to apples.
+
+## Implementation order (≈15 commits)
+
+Each commit stands alone with adjacent tests. Earlier commits don't
+build later-commit infrastructure.
+
+1. **L1.1-1.3** — `cash_balances` frame schema, `Transfer` event,
+   `apply_events` skeleton dispatching on event kind, `simulate()`
+   loop with one rollout. Alice gives Bob \$5 test.
+2. **L2.1-2.2** — multi-month loop, recurring transfer (paycheck
+   arriving each month as repeated Transfer events).
+3. **L3.1-3.3** — rollout dimension scales from 1 to N as a polars
+   column. Multi-rollout tests; assert at 1k rollouts.
+4. **L4 lots part A** — `asset_lots` schema, `AssetPurchase` +
+   `AssetSale` events with FIFO lot consumption, lot-disposition
+   projection. Single-lot scenarios.
+5. **L4 lots part B** — multi-lot scenarios (S4.4-S4.6): mixed
+   holding periods, sale crossing two lots, per-lot LTCG/STCG
+   classification.
+6. **L5 + L10 market integration** — `MarketBundle` interface,
+   per-rollout per-month price paths, asset market values flowing
+   as market-derived state attributes, sellability_mask plumbing
+   (no scenarios exercise non-default mask yet).
+7. **Jurisdiction YAML loader** —
+   `data/jurisdictions/{federal_us,california}.yaml`, Pydantic
+   models, validation, loader.
+8. **L7 ordinary income tax** — `tax_liability` template;
+   ordinary-income year-tax computation for federal + CA single
+   filer + std deduction; year-end tax accrual event creates a
+   `tax_payable` liability.
+9. **L6 capital gains tax** — LTCG/STCG classification function
+   over the lot_dispositions projection; year-tax including LTCG
+   bracket walk; integrate with ordinary year-tax.
+10. **L6 quarterly + year-end timing** — quarterly markers (Apr 15,
+    Jun 15, Sep 15, Jan 15 of next year), safe-harbor with
+    `prior_year_tax_usd` scenario knob, year-end true-up, tax-
+    payment events.
+11. **L9 + L11 policies + failures** — floor-triggered sale, asset
+    preference chain, monthly-spend obligation, obligation funding
+    chain (sell to cover insufficient cash), failure-event
+    emission, rollout-status flip.
+12. **Locations YAML loader** —
+    `data/locations/san_francisco.yaml` (the only one for spike 1;
+    no property templates yet). Wired to agent's residence.
+13. **End-to-end bench scenario** — the representative scenario
+    described above; bench script; capture baseline timing on RBE.
+14. **DRY test + cleanup** — the "add 4th position by config" test;
+    tighten any rough edges; doc/comments pass.

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -22,16 +22,22 @@ from __future__ import annotations
 import polars as pl
 
 from augur.sim.events import EventLog
-from augur.sim.state import StateCrossSection
+from augur.sim.state import ASSET_LOT_SCHEMA, StateCrossSection
 
 
 def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSection:
     """Apply all events in `events` to `state`. Returns the new
     cross-section. Pure: does not mutate inputs."""
     cash_balances = state.cash_balances
+    asset_lots = state.asset_lots
+    if not events.asset_purchases.is_empty():
+        asset_lots = _apply_asset_purchases(asset_lots, events.asset_purchases)
+    if not events.lot_dispositions.is_empty():
+        asset_lots = _apply_lot_dispositions_to_lots(asset_lots, events.lot_dispositions)
+        cash_balances = _apply_lot_dispositions_to_cash(cash_balances, events.lot_dispositions)
     if not events.transfers.is_empty():
         cash_balances = _apply_transfers(cash_balances, events.transfers)
-    return StateCrossSection(cash_balances=cash_balances)
+    return StateCrossSection(cash_balances=cash_balances, asset_lots=asset_lots)
 
 
 def _apply_transfers(cash_balances: pl.DataFrame, transfers: pl.DataFrame) -> pl.DataFrame:
@@ -56,4 +62,53 @@ def _apply_transfers(cash_balances: pl.DataFrame, transfers: pl.DataFrame) -> pl
             balance_usd=pl.col("balance_usd") - pl.col("_delta_out").fill_null(0.0) + pl.col("_delta_in").fill_null(0.0)
         )
         .drop(["_delta_out", "_delta_in"])
+    )
+
+
+def _apply_asset_purchases(asset_lots: pl.DataFrame, purchases: pl.DataFrame) -> pl.DataFrame:
+    """Append purchase events as new lot rows. Each purchase row
+    becomes one lot with `remaining_quantity = quantity`. Lots are
+    keyed by `(rollout_index, lot_id)`; the scenario is responsible
+    for assigning unique `lot_id` strings."""
+    new_lots = purchases.select(
+        pl.col("rollout_index"),
+        pl.col("lot_id"),
+        pl.col("agent_id"),
+        pl.col("asset_id"),
+        pl.col("month_index").alias("purchase_month_index"),
+        pl.col("cost_basis_per_unit_usd"),
+        pl.col("quantity").alias("remaining_quantity"),
+    ).select(list(ASSET_LOT_SCHEMA.keys()))
+    if asset_lots.is_empty():
+        return new_lots
+    return pl.concat([asset_lots, new_lots])
+
+
+def _apply_lot_dispositions_to_lots(asset_lots: pl.DataFrame, dispositions: pl.DataFrame) -> pl.DataFrame:
+    """Reduce `remaining_quantity` on the lots consumed by each
+    disposition. Aggregates `units_sold` per `(rollout_index,
+    lot_id)` so multiple dispositions of the same lot (e.g. two
+    sales of the same asset in the same month) compose. Vectorized:
+    one left-join + one with_columns."""
+    deltas = dispositions.group_by(["rollout_index", "lot_id"]).agg(pl.col("units_sold").sum().alias("_units_consumed"))
+    return (
+        asset_lots.join(deltas, on=["rollout_index", "lot_id"], how="left")
+        .with_columns(remaining_quantity=pl.col("remaining_quantity") - pl.col("_units_consumed").fill_null(0.0))
+        .drop("_units_consumed")
+    )
+
+
+def _apply_lot_dispositions_to_cash(cash_balances: pl.DataFrame, dispositions: pl.DataFrame) -> pl.DataFrame:
+    """Credit sale proceeds to the configured `proceeds_account_id`
+    on each disposition. Aggregates per (rollout, agent, account)
+    before joining so multi-lot sales fold into a single delta."""
+    credits = (
+        dispositions.group_by(["rollout_index", "agent_id", "proceeds_account_id"])
+        .agg(pl.col("proceeds_usd").sum().alias("_delta_in"))
+        .rename({"proceeds_account_id": "account_id"})
+    )
+    return (
+        cash_balances.join(credits, on=["rollout_index", "agent_id", "account_id"], how="left")
+        .with_columns(balance_usd=pl.col("balance_usd") + pl.col("_delta_in").fill_null(0.0))
+        .drop("_delta_in")
     )

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -1,0 +1,59 @@
+"""apply_events — the single state-mutation primitive.
+
+`apply_events(state, events) → state'` is the only function in the
+simulator that writes the event-sourced columns of state. The
+forward loop calls it once per iteration; tests + an opt-in
+`--check-replay` flag use it to validate that incrementally-
+maintained state agrees with re-derivation from the cumulative
+event log:
+
+    state_at(M).event_sourced ==
+        apply_events(initial_state, events_log.filter(month <= M))
+
+for every M. If the invariant ever fails, the bug is here and the
+fix is in one place.
+
+Dispatch is by event kind: each kind's frame is consumed by a
+kind-specific apply function. `apply_events` composes them.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from augur.sim.events import EventLog
+from augur.sim.state import StateCrossSection
+
+
+def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSection:
+    """Apply all events in `events` to `state`. Returns the new
+    cross-section. Pure: does not mutate inputs."""
+    cash_balances = state.cash_balances
+    if not events.transfers.is_empty():
+        cash_balances = _apply_transfers(cash_balances, events.transfers)
+    return StateCrossSection(cash_balances=cash_balances)
+
+
+def _apply_transfers(cash_balances: pl.DataFrame, transfers: pl.DataFrame) -> pl.DataFrame:
+    """Apply transfer events to cash_balances. Each transfer debits
+    `from_agent`'s `from_account` and credits `to_agent`'s `to_account`.
+    Vectorized: aggregates per-(rollout, agent, account) deltas and
+    joins them into the cash_balances frame in one expression."""
+    outgoing = (
+        transfers.group_by(["rollout_index", "from_agent_id", "from_account_id"])
+        .agg(pl.col("amount_usd").sum())
+        .rename({"from_agent_id": "agent_id", "from_account_id": "account_id", "amount_usd": "_delta_out"})
+    )
+    incoming = (
+        transfers.group_by(["rollout_index", "to_agent_id", "to_account_id"])
+        .agg(pl.col("amount_usd").sum())
+        .rename({"to_agent_id": "agent_id", "to_account_id": "account_id", "amount_usd": "_delta_in"})
+    )
+    return (
+        cash_balances.join(outgoing, on=["rollout_index", "agent_id", "account_id"], how="left")
+        .join(incoming, on=["rollout_index", "agent_id", "account_id"], how="left")
+        .with_columns(
+            balance_usd=pl.col("balance_usd") - pl.col("_delta_out").fill_null(0.0) + pl.col("_delta_in").fill_null(0.0)
+        )
+        .drop(["_delta_out", "_delta_in"])
+    )

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -32,12 +32,13 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
     cross-section. Pure: does not mutate inputs.
 
     Order matters: income-carrying transfers increment
-    `ordinary_income_ytd` first, then asset sales credit cash and
-    consume lots, then year-end tax accruals book a liability and
-    zero out the year-to-date income."""
+    `ordinary_income_ytd` first, asset sales both credit cash and
+    bucket capital gains into ltcg/stcg, then year-end tax accruals
+    book a liability and zero out the year-to-date totals."""
     cash_balances = state.cash_balances
     asset_lots = state.asset_lots
     ordinary_income_ytd = state.ordinary_income_ytd
+    capital_gains_ytd = state.capital_gains_ytd
     tax_liabilities = state.tax_liabilities
 
     if not events.asset_purchases.is_empty():
@@ -45,17 +46,20 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
     if not events.lot_dispositions.is_empty():
         asset_lots = _apply_lot_dispositions_to_lots(asset_lots, events.lot_dispositions)
         cash_balances = _apply_lot_dispositions_to_cash(cash_balances, events.lot_dispositions)
+        capital_gains_ytd = _apply_dispositions_to_capital_gains_ytd(capital_gains_ytd, events.lot_dispositions)
     if not events.transfers.is_empty():
         cash_balances = _apply_transfers(cash_balances, events.transfers)
         ordinary_income_ytd = _apply_income_to_ytd(ordinary_income_ytd, events.transfers)
     if not events.tax_accruals.is_empty():
         tax_liabilities = _apply_tax_accruals_to_liabilities(tax_liabilities, events.tax_accruals)
         ordinary_income_ytd = _reset_ytd_for_taxed_agents(ordinary_income_ytd, events.tax_accruals)
+        capital_gains_ytd = _reset_capital_gains_for_taxed_agents(capital_gains_ytd, events.tax_accruals)
 
     return StateCrossSection(
         cash_balances=cash_balances,
         asset_lots=asset_lots,
         ordinary_income_ytd=ordinary_income_ytd,
+        capital_gains_ytd=capital_gains_ytd,
         tax_liabilities=tax_liabilities,
     )
 
@@ -169,6 +173,31 @@ def _apply_tax_accruals_to_liabilities(tax_liabilities: pl.DataFrame, tax_accrua
     return pl.concat([tax_liabilities, new_rows])
 
 
+def _apply_dispositions_to_capital_gains_ytd(
+    capital_gains_ytd: pl.DataFrame, dispositions: pl.DataFrame
+) -> pl.DataFrame:
+    """Bucket each lot disposition's `gain_usd = proceeds_usd -
+    cost_basis_consumed_usd` into LTCG (holding period ≥ 12 months)
+    or STCG, aggregate per (rollout, agent, classification), and
+    add to the running YTD. Rollouts × agents that have no
+    pre-existing row are appended; existing rows accumulate."""
+    classified = dispositions.with_columns(
+        gain_usd=pl.col("proceeds_usd") - pl.col("cost_basis_consumed_usd"),
+        classification=pl.when(pl.col("month_index") - pl.col("purchase_month_index") >= 12)
+        .then(pl.lit("ltcg"))
+        .otherwise(pl.lit("stcg")),
+    )
+    deltas = classified.group_by(["rollout_index", "agent_id", "classification"]).agg(
+        pl.col("gain_usd").sum().alias("_delta")
+    )
+    merged = capital_gains_ytd.join(
+        deltas, on=["rollout_index", "agent_id", "classification"], how="full", coalesce=True
+    )
+    return merged.with_columns(gain_usd=pl.col("gain_usd").fill_null(0.0) + pl.col("_delta").fill_null(0.0)).drop(
+        "_delta"
+    )
+
+
 def _reset_ytd_for_taxed_agents(ordinary_income_ytd: pl.DataFrame, tax_accruals: pl.DataFrame) -> pl.DataFrame:
     """Zero `ordinary_income_usd` for every (rollout, agent) that
     has a tax accrual fired this month — that's "year closed, start
@@ -183,5 +212,16 @@ def _reset_ytd_for_taxed_agents(ordinary_income_ytd: pl.DataFrame, tax_accruals:
             .then(0.0)
             .otherwise(pl.col("ordinary_income_usd"))
         )
+        .drop("_reset")
+    )
+
+
+def _reset_capital_gains_for_taxed_agents(capital_gains_ytd: pl.DataFrame, tax_accruals: pl.DataFrame) -> pl.DataFrame:
+    """Year-end reset of LTCG / STCG running totals — same pattern
+    as the ordinary-income reset, keyed by (rollout, agent)."""
+    affected = tax_accruals.select("rollout_index", "agent_id").unique().with_columns(pl.lit(True).alias("_reset"))
+    return (
+        capital_gains_ytd.join(affected, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(gain_usd=pl.when(pl.col("_reset").fill_null(False)).then(0.0).otherwise(pl.col("gain_usd")))
         .drop("_reset")
     )

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -14,7 +14,9 @@ for every M. If the invariant ever fails, the bug is here and the
 fix is in one place.
 
 Dispatch is by event kind: each kind's frame is consumed by a
-kind-specific apply function. `apply_events` composes them.
+kind-specific apply function. `apply_events` composes them in a
+fixed order so that downstream kinds (tax accruals) see the
+already-updated state from upstream kinds (income transfers).
 """
 
 from __future__ import annotations
@@ -27,9 +29,17 @@ from augur.sim.state import ASSET_LOT_SCHEMA, StateCrossSection
 
 def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSection:
     """Apply all events in `events` to `state`. Returns the new
-    cross-section. Pure: does not mutate inputs."""
+    cross-section. Pure: does not mutate inputs.
+
+    Order matters: income-carrying transfers increment
+    `ordinary_income_ytd` first, then asset sales credit cash and
+    consume lots, then year-end tax accruals book a liability and
+    zero out the year-to-date income."""
     cash_balances = state.cash_balances
     asset_lots = state.asset_lots
+    ordinary_income_ytd = state.ordinary_income_ytd
+    tax_liabilities = state.tax_liabilities
+
     if not events.asset_purchases.is_empty():
         asset_lots = _apply_asset_purchases(asset_lots, events.asset_purchases)
     if not events.lot_dispositions.is_empty():
@@ -37,7 +47,17 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
         cash_balances = _apply_lot_dispositions_to_cash(cash_balances, events.lot_dispositions)
     if not events.transfers.is_empty():
         cash_balances = _apply_transfers(cash_balances, events.transfers)
-    return StateCrossSection(cash_balances=cash_balances, asset_lots=asset_lots)
+        ordinary_income_ytd = _apply_income_to_ytd(ordinary_income_ytd, events.transfers)
+    if not events.tax_accruals.is_empty():
+        tax_liabilities = _apply_tax_accruals_to_liabilities(tax_liabilities, events.tax_accruals)
+        ordinary_income_ytd = _reset_ytd_for_taxed_agents(ordinary_income_ytd, events.tax_accruals)
+
+    return StateCrossSection(
+        cash_balances=cash_balances,
+        asset_lots=asset_lots,
+        ordinary_income_ytd=ordinary_income_ytd,
+        tax_liabilities=tax_liabilities,
+    )
 
 
 def _apply_transfers(cash_balances: pl.DataFrame, transfers: pl.DataFrame) -> pl.DataFrame:
@@ -62,6 +82,25 @@ def _apply_transfers(cash_balances: pl.DataFrame, transfers: pl.DataFrame) -> pl
             balance_usd=pl.col("balance_usd") - pl.col("_delta_out").fill_null(0.0) + pl.col("_delta_in").fill_null(0.0)
         )
         .drop(["_delta_out", "_delta_in"])
+    )
+
+
+def _apply_income_to_ytd(ordinary_income_ytd: pl.DataFrame, transfers: pl.DataFrame) -> pl.DataFrame:
+    """Increment per-(rollout, recipient) ordinary_income_ytd by
+    the sum of transfer amounts whose `income_category == "ordinary"`.
+    Transfers without that tag don't touch YTD."""
+    ordinary_transfers = transfers.filter(pl.col("income_category") == "ordinary")
+    if ordinary_transfers.is_empty():
+        return ordinary_income_ytd
+    deltas = (
+        ordinary_transfers.group_by(["rollout_index", "to_agent_id"])
+        .agg(pl.col("amount_usd").sum().alias("_delta"))
+        .rename({"to_agent_id": "agent_id"})
+    )
+    return (
+        ordinary_income_ytd.join(deltas, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(ordinary_income_usd=pl.col("ordinary_income_usd") + pl.col("_delta").fill_null(0.0))
+        .drop("_delta")
     )
 
 
@@ -111,4 +150,38 @@ def _apply_lot_dispositions_to_cash(cash_balances: pl.DataFrame, dispositions: p
         cash_balances.join(credits, on=["rollout_index", "agent_id", "account_id"], how="left")
         .with_columns(balance_usd=pl.col("balance_usd") + pl.col("_delta_in").fill_null(0.0))
         .drop("_delta_in")
+    )
+
+
+def _apply_tax_accruals_to_liabilities(tax_liabilities: pl.DataFrame, tax_accruals: pl.DataFrame) -> pl.DataFrame:
+    """Append each accrual as a new liability row. Liabilities are
+    additive — paying them down is a later (step-9) concern that
+    reduces `amount_owed_usd` via tax-payment events."""
+    new_rows = tax_accruals.select(
+        pl.col("rollout_index"),
+        pl.col("agent_id"),
+        pl.col("jurisdiction_id"),
+        pl.col("tax_year_end_month"),
+        pl.col("amount_usd").alias("amount_owed_usd"),
+    )
+    if tax_liabilities.is_empty():
+        return new_rows
+    return pl.concat([tax_liabilities, new_rows])
+
+
+def _reset_ytd_for_taxed_agents(ordinary_income_ytd: pl.DataFrame, tax_accruals: pl.DataFrame) -> pl.DataFrame:
+    """Zero `ordinary_income_usd` for every (rollout, agent) that
+    has a tax accrual fired this month — that's "year closed, start
+    counting again from zero". Multiple jurisdictions accruing for
+    the same agent collapse to one reset via the `_reset` flag from
+    the left join."""
+    affected = tax_accruals.select("rollout_index", "agent_id").unique().with_columns(pl.lit(True).alias("_reset"))
+    return (
+        ordinary_income_ytd.join(affected, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(
+            ordinary_income_usd=pl.when(pl.col("_reset").fill_null(False))
+            .then(0.0)
+            .otherwise(pl.col("ordinary_income_usd"))
+        )
+        .drop("_reset")
     )

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -40,6 +40,7 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
     ordinary_income_ytd = state.ordinary_income_ytd
     capital_gains_ytd = state.capital_gains_ytd
     tax_liabilities = state.tax_liabilities
+    rollout_status = state.rollout_status
 
     if not events.asset_purchases.is_empty():
         asset_lots = _apply_asset_purchases(asset_lots, events.asset_purchases)
@@ -54,6 +55,8 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
         tax_liabilities = _apply_tax_accruals_to_liabilities(tax_liabilities, events.tax_accruals)
         ordinary_income_ytd = _reset_ytd_for_taxed_agents(ordinary_income_ytd, events.tax_accruals)
         capital_gains_ytd = _reset_capital_gains_for_taxed_agents(capital_gains_ytd, events.tax_accruals)
+    if not events.rollout_failures.is_empty():
+        rollout_status = _apply_rollout_failures(rollout_status, events.rollout_failures)
 
     return StateCrossSection(
         cash_balances=cash_balances,
@@ -61,6 +64,7 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
         ordinary_income_ytd=ordinary_income_ytd,
         capital_gains_ytd=capital_gains_ytd,
         tax_liabilities=tax_liabilities,
+        rollout_status=rollout_status,
     )
 
 
@@ -213,6 +217,28 @@ def _reset_ytd_for_taxed_agents(ordinary_income_ytd: pl.DataFrame, tax_accruals:
             .otherwise(pl.col("ordinary_income_usd"))
         )
         .drop("_reset")
+    )
+
+
+def _apply_rollout_failures(rollout_status: pl.DataFrame, failures: pl.DataFrame) -> pl.DataFrame:
+    """Mark the listed rollouts failed. Once flagged, the status is
+    sticky: a second failure event on an already-failed rollout
+    leaves the original `failed_month` in place. The `status` field
+    transitions monotonically from "active" to a failure state."""
+    first_failure = failures.group_by("rollout_index").agg(pl.col("month_index").min().alias("_failed_month"))
+    return (
+        rollout_status.join(first_failure, on="rollout_index", how="left")
+        .with_columns(
+            status=pl.when(pl.col("status") != "active")
+            .then(pl.col("status"))
+            .when(pl.col("_failed_month").is_not_null())
+            .then(pl.lit("failed_insufficient_cash"))
+            .otherwise(pl.col("status")),
+            failed_month=pl.when(pl.col("failed_month").is_not_null())
+            .then(pl.col("failed_month"))
+            .otherwise(pl.col("_failed_month")),
+        )
+        .drop("_failed_month")
     )
 
 

--- a/augur/sim/apply.py
+++ b/augur/sim/apply.py
@@ -34,29 +34,19 @@ def apply_events(state: StateCrossSection, events: EventLog) -> StateCrossSectio
     Order matters: income-carrying transfers increment
     `ordinary_income_ytd` first, asset sales both credit cash and
     bucket capital gains into ltcg/stcg, then year-end tax accruals
-    book a liability and zero out the year-to-date totals."""
-    cash_balances = state.cash_balances
-    asset_lots = state.asset_lots
-    ordinary_income_ytd = state.ordinary_income_ytd
-    capital_gains_ytd = state.capital_gains_ytd
-    tax_liabilities = state.tax_liabilities
-    rollout_status = state.rollout_status
-
-    if not events.asset_purchases.is_empty():
-        asset_lots = _apply_asset_purchases(asset_lots, events.asset_purchases)
-    if not events.lot_dispositions.is_empty():
-        asset_lots = _apply_lot_dispositions_to_lots(asset_lots, events.lot_dispositions)
-        cash_balances = _apply_lot_dispositions_to_cash(cash_balances, events.lot_dispositions)
-        capital_gains_ytd = _apply_dispositions_to_capital_gains_ytd(capital_gains_ytd, events.lot_dispositions)
-    if not events.transfers.is_empty():
-        cash_balances = _apply_transfers(cash_balances, events.transfers)
-        ordinary_income_ytd = _apply_income_to_ytd(ordinary_income_ytd, events.transfers)
-    if not events.tax_accruals.is_empty():
-        tax_liabilities = _apply_tax_accruals_to_liabilities(tax_liabilities, events.tax_accruals)
-        ordinary_income_ytd = _reset_ytd_for_taxed_agents(ordinary_income_ytd, events.tax_accruals)
-        capital_gains_ytd = _reset_capital_gains_for_taxed_agents(capital_gains_ytd, events.tax_accruals)
-    if not events.rollout_failures.is_empty():
-        rollout_status = _apply_rollout_failures(rollout_status, events.rollout_failures)
+    book a liability and zero out the year-to-date totals. Each
+    `_apply_*` helper is a polars no-op on an empty event frame, so
+    no per-kind guards are needed at this layer."""
+    asset_lots = _apply_asset_purchases(state.asset_lots, events.asset_purchases)
+    asset_lots = _apply_lot_dispositions_to_lots(asset_lots, events.lot_dispositions)
+    cash_balances = _apply_lot_dispositions_to_cash(state.cash_balances, events.lot_dispositions)
+    capital_gains_ytd = _apply_dispositions_to_capital_gains_ytd(state.capital_gains_ytd, events.lot_dispositions)
+    cash_balances = _apply_transfers(cash_balances, events.transfers)
+    ordinary_income_ytd = _apply_income_to_ytd(state.ordinary_income_ytd, events.transfers)
+    tax_liabilities = _apply_tax_accruals_to_liabilities(state.tax_liabilities, events.tax_accruals)
+    ordinary_income_ytd = _reset_ytd_for_taxed_agents(ordinary_income_ytd, events.tax_accruals)
+    capital_gains_ytd = _reset_capital_gains_for_taxed_agents(capital_gains_ytd, events.tax_accruals)
+    rollout_status = _apply_rollout_failures(state.rollout_status, events.rollout_failures)
 
     return StateCrossSection(
         cash_balances=cash_balances,
@@ -97,11 +87,9 @@ def _apply_income_to_ytd(ordinary_income_ytd: pl.DataFrame, transfers: pl.DataFr
     """Increment per-(rollout, recipient) ordinary_income_ytd by
     the sum of transfer amounts whose `income_category == "ordinary"`.
     Transfers without that tag don't touch YTD."""
-    ordinary_transfers = transfers.filter(pl.col("income_category") == "ordinary")
-    if ordinary_transfers.is_empty():
-        return ordinary_income_ytd
     deltas = (
-        ordinary_transfers.group_by(["rollout_index", "to_agent_id"])
+        transfers.filter(pl.col("income_category") == "ordinary")
+        .group_by(["rollout_index", "to_agent_id"])
         .agg(pl.col("amount_usd").sum().alias("_delta"))
         .rename({"to_agent_id": "agent_id"})
     )
@@ -116,7 +104,9 @@ def _apply_asset_purchases(asset_lots: pl.DataFrame, purchases: pl.DataFrame) ->
     """Append purchase events as new lot rows. Each purchase row
     becomes one lot with `remaining_quantity = quantity`. Lots are
     keyed by `(rollout_index, lot_id)`; the scenario is responsible
-    for assigning unique `lot_id` strings."""
+    for assigning unique `lot_id` strings. Both inputs share the
+    ASSET_LOT-shaped schema after projection, so concat-on-empty
+    cases naturally no-op."""
     new_lots = purchases.select(
         pl.col("rollout_index"),
         pl.col("lot_id"),
@@ -126,8 +116,6 @@ def _apply_asset_purchases(asset_lots: pl.DataFrame, purchases: pl.DataFrame) ->
         pl.col("cost_basis_per_unit_usd"),
         pl.col("quantity").alias("remaining_quantity"),
     ).select(list(ASSET_LOT_SCHEMA.keys()))
-    if asset_lots.is_empty():
-        return new_lots
     return pl.concat([asset_lots, new_lots])
 
 
@@ -163,8 +151,8 @@ def _apply_lot_dispositions_to_cash(cash_balances: pl.DataFrame, dispositions: p
 
 def _apply_tax_accruals_to_liabilities(tax_liabilities: pl.DataFrame, tax_accruals: pl.DataFrame) -> pl.DataFrame:
     """Append each accrual as a new liability row. Liabilities are
-    additive — paying them down is a later (step-9) concern that
-    reduces `amount_owed_usd` via tax-payment events."""
+    additive — paying them down is a later concern that reduces
+    `amount_owed_usd` via tax-payment events."""
     new_rows = tax_accruals.select(
         pl.col("rollout_index"),
         pl.col("agent_id"),
@@ -172,8 +160,6 @@ def _apply_tax_accruals_to_liabilities(tax_liabilities: pl.DataFrame, tax_accrua
         pl.col("tax_year_end_month"),
         pl.col("amount_usd").alias("amount_owed_usd"),
     )
-    if tax_liabilities.is_empty():
-        return new_rows
     return pl.concat([tax_liabilities, new_rows])
 
 

--- a/augur/sim/bench.py
+++ b/augur/sim/bench.py
@@ -1,0 +1,43 @@
+"""Bench script for the spike-1 representative scenario.
+
+Runs `build_bench_scenario()` end-to-end at 1000 rollouts and
+reports wall-clock time. No specific perf target this round —
+the goal is to establish the baseline that later waves' bench
+targets are set against. Invoke via `bb run`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from augur.sim.bench_scenario import build_bench_scenario
+from augur.sim.simulate import simulate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Spike-1 augur sim bench")
+    parser.add_argument("--rollouts", type=int, default=1000)
+    parser.add_argument("--horizon-months", type=int, default=60)
+    args = parser.parse_args()
+
+    scenario = build_bench_scenario(horizon_months=args.horizon_months)
+
+    t0 = time.perf_counter()
+    result = simulate(scenario, rollout_count=args.rollouts)
+    elapsed = time.perf_counter() - t0
+
+    print(f"rollouts: {args.rollouts}")
+    print(f"horizon_months: {args.horizon_months}")
+    print(f"wall_clock_sec: {elapsed:.3f}")
+    print(f"cash_balances_rows: {result.cash_balances.height}")
+    print(f"asset_lots_rows: {result.asset_lots.height}")
+    print(f"market_prices_rows: {result.market_prices.height}")
+    print(f"transfers: {result.events_log.transfers.height}")
+    print(f"lot_dispositions: {result.events_log.lot_dispositions.height}")
+    print(f"tax_accruals: {result.events_log.tax_accruals.height}")
+    print(f"rollout_failures: {result.events_log.rollout_failures.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/augur/sim/bench_scenario.py
+++ b/augur/sim/bench_scenario.py
@@ -1,0 +1,149 @@
+"""The spike-1 bench scenario — a single deliverable that
+exercises every layer the spike adds.
+
+Alice, a single-filer SF resident, has:
+  - W-2 paychecks totaling $200k/year (recurring transfer with
+    `income_category="ordinary"`).
+  - Initial holdings in three positions: VTI, QQQ, BTC. Each is
+    a pre-horizon lot at a configurable basis.
+  - A floor-triggered sale policy: if checking < $5k, top up to
+    $5k by liquidating VTI → QQQ → BTC in order at market
+    prices.
+  - A $5k/month recurring spend obligation (rent).
+  - Federal + California tax profile with prior-year-tax
+    estimated knob, single filer, standard deduction.
+
+The market bundle samples each asset as a GBM path with its own
+seed, so the 1000 rollouts diverge by market path. Horizon = 60
+months (5 years).
+
+`build_bench_scenario()` returns a `Scenario` instance with the
+defaults above; tune via keyword args.
+"""
+
+from __future__ import annotations
+
+from augur.sim.market import GeometricBrownianPath, MarketBundle
+from augur.sim.scenario import (
+    Agent,
+    FloorTriggeredSalePolicy,
+    InitialAccountBalance,
+    InitialLot,
+    RecurringTransfer,
+    Scenario,
+    TaxProfile,
+)
+
+
+def build_bench_scenario(
+    *,
+    horizon_months: int = 60,
+    annual_wages_usd: float = 200_000.0,
+    monthly_spend_usd: float = 5_000.0,
+    floor_usd: float = 5_000.0,
+    initial_cash_usd: float = 20_000.0,
+    prior_year_tax_usd: float = 40_000.0,
+) -> Scenario:
+    """The benchable scenario, parameterized for sensitivity
+    studies. Defaults reflect the spike-1 spec deliverable."""
+    return Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll"), Agent(agent_id="landlord"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=initial_cash_usd),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="landlord", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_vti",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-36,
+                quantity=300.0,
+                cost_basis_per_unit_usd=180.0,
+            ),
+            InitialLot(
+                lot_id="alice_qqq",
+                agent_id="alice",
+                asset_id="qqq",
+                purchase_month_index=-24,
+                quantity=120.0,
+                cost_basis_per_unit_usd=300.0,
+            ),
+            InitialLot(
+                lot_id="alice_btc",
+                agent_id="alice",
+                asset_id="btc",
+                purchase_month_index=-18,
+                quantity=2.0,
+                cost_basis_per_unit_usd=25_000.0,
+            ),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=annual_wages_usd / 12.0,
+                income_category="ordinary",
+            ),
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_rent",
+                from_agent_id="alice",
+                from_account_id="checking",
+                to_agent_id="landlord",
+                to_account_id="checking",
+                amount_usd=monthly_spend_usd,
+            ),
+        ],
+        market=MarketBundle(
+            paths=[
+                GeometricBrownianPath(
+                    asset_id="vti",
+                    initial_price_usd=240.0,
+                    monthly_log_return_mu=0.0067,
+                    monthly_log_return_sigma=0.04,
+                    rng_seed=11,
+                ),
+                GeometricBrownianPath(
+                    asset_id="qqq",
+                    initial_price_usd=400.0,
+                    monthly_log_return_mu=0.008,
+                    monthly_log_return_sigma=0.05,
+                    rng_seed=22,
+                ),
+                GeometricBrownianPath(
+                    asset_id="btc",
+                    initial_price_usd=60_000.0,
+                    monthly_log_return_mu=0.012,
+                    monthly_log_return_sigma=0.15,
+                    rng_seed=33,
+                ),
+            ]
+        ),
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status="single",
+                jurisdiction_ids=["federal_us", "california"],
+                tax_authority_agent_id="irs",
+                prior_year_tax_usd=prior_year_tax_usd,
+            )
+        ],
+        floor_triggered_sale_policies=[
+            FloorTriggeredSalePolicy(
+                agent_id="alice",
+                account_id="checking",
+                floor_usd=floor_usd,
+                replenish_buffer_usd=0.0,
+                asset_preference_chain=["vti", "qqq", "btc"],
+                cause_id_prefix="alice_floor_sale",
+            )
+        ],
+        horizon_months=horizon_months,
+    )

--- a/augur/sim/bench_test.py
+++ b/augur/sim/bench_test.py
@@ -1,0 +1,85 @@
+"""Smoke + DRY tests for the bench scenario.
+
+The bench scenario sums up everything spike 1 added: lots, market
+divergence, ordinary + capital-gains tax, floor-triggered sale,
+rollout-failure detection. The tests below don't pin specific
+amounts (the market is stochastic); they verify the engine runs
+the configured scenario at scale without code changes.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest_bazel
+
+from augur.sim.bench_scenario import build_bench_scenario
+from augur.sim.market import DeterministicPath
+from augur.sim.scenario import InitialLot
+from augur.sim.simulate import simulate
+
+
+def test_bench_scenario_runs_at_low_rollout_count() -> None:
+    """Sanity check: the full scenario completes without raising
+    on a small rollout count. Pins the structural facts but not
+    the (market-dependent) numbers."""
+    scenario = build_bench_scenario(horizon_months=24)
+    result = simulate(scenario, rollout_count=10)
+
+    # Two recurring transfers (paycheck + rent) × 24 months × 10
+    # rollouts = 480 transfer rows.
+    assert result.events_log.transfers.height == 2 * 24 * 10
+
+    # Year-end accruals: 2 jurisdictions × 2 years (months 11, 23)
+    # × 10 rollouts = 40 accrual rows.
+    assert result.events_log.tax_accruals.height == 2 * 2 * 10
+
+    # Market prices: 3 assets × 25 months (0..24) × 10 rollouts.
+    assert result.market_prices.height == 3 * 25 * 10
+
+    # Rollout status frame has one row per rollout, all active or
+    # failed (no other states).
+    statuses = set(result.rollout_status.get_column("status").unique().to_list())
+    assert statuses.issubset({"active", "failed_insufficient_cash"})
+
+
+def test_dry_add_fourth_position_is_config_only() -> None:
+    """Spike-1 DRY proof: adding a 4th capital-gains-eligible
+    position to the scenario takes one new InitialLot record and
+    one new MarketPathSpec, zero engine code. The simulator
+    accepts the new asset_id ("efv") through the same code paths
+    as VTI/QQQ/BTC. After running 10 rollouts at 24 months we see
+    EFV as a tracked asset in lots and market-prices frames."""
+    base = build_bench_scenario(horizon_months=24)
+    # Append a new asset + lot. (Pydantic deep-copies via model_copy)
+    new_lot = InitialLot(
+        lot_id="alice_efv",
+        agent_id="alice",
+        asset_id="efv",
+        purchase_month_index=-12,
+        quantity=50.0,
+        cost_basis_per_unit_usd=70.0,
+    )
+    efv_path = DeterministicPath(asset_id="efv", prices_usd=[100.0] * 25)
+    extended = base.model_copy(
+        update={
+            "initial_lots": [*base.initial_lots, new_lot],
+            "market": base.market.model_copy(update={"paths": [*base.market.paths, efv_path]}),
+            "floor_triggered_sale_policies": [
+                p.model_copy(update={"asset_preference_chain": [*p.asset_preference_chain, "efv"]})
+                for p in base.floor_triggered_sale_policies
+            ],
+        }
+    )
+
+    result = simulate(extended, rollout_count=10)
+
+    # The new asset shows up in lots:
+    efv_lots = result.asset_lots.filter(pl.col("asset_id") == "efv")
+    assert efv_lots.height > 0
+    # And in market prices:
+    efv_prices = result.market_prices.filter(pl.col("asset_id") == "efv")
+    assert efv_prices.height == 25 * 10  # months × rollouts
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/bench_test.py
+++ b/augur/sim/bench_test.py
@@ -26,8 +26,9 @@ def test_bench_scenario_runs_at_low_rollout_count() -> None:
     result = simulate(scenario, rollout_count=10)
 
     # Two recurring transfers (paycheck + rent) × 24 months × 10
-    # rollouts = 480 transfer rows.
-    assert result.events_log.transfers.height == 2 * 24 * 10
+    # rollouts = 480 monthly transfer rows, plus 2 jurisdictions ×
+    # 2 years × 10 rollouts = 40 year-end tax-payment transfers.
+    assert result.events_log.transfers.height == 2 * 24 * 10 + 2 * 2 * 10
 
     # Year-end accruals: 2 jurisdictions × 2 years (months 11, 23)
     # × 10 rollouts = 40 accrual rows.

--- a/augur/sim/data/jurisdictions/california.yaml
+++ b/augur/sim/data/jurisdictions/california.yaml
@@ -1,0 +1,24 @@
+# California state income tax — 2024 tax-year brackets.
+#
+# Single filer only. CA taxes long-term capital gains at ordinary
+# income rates (no separate LTCG bracket), so `ltcg_brackets` is
+# omitted here — the tax layer will fall through to the ordinary
+# bracket when no LTCG-specific brackets are configured.
+#
+# The 1% mental-health surcharge on income above $1M is deferred.
+jurisdiction_id: california
+
+ordinary_income_brackets:
+  single:
+    - { upper_usd: 10412.0, rate: 0.010 }
+    - { upper_usd: 24684.0, rate: 0.020 }
+    - { upper_usd: 38959.0, rate: 0.040 }
+    - { upper_usd: 54081.0, rate: 0.060 }
+    - { upper_usd: 68350.0, rate: 0.080 }
+    - { upper_usd: 349137.0, rate: 0.093 }
+    - { upper_usd: 418961.0, rate: 0.103 }
+    - { upper_usd: 698271.0, rate: 0.113 }
+    - { upper_usd: .inf, rate: 0.123 }
+
+standard_deduction:
+  single: 5363.0

--- a/augur/sim/data/jurisdictions/federal_us.yaml
+++ b/augur/sim/data/jurisdictions/federal_us.yaml
@@ -1,0 +1,32 @@
+# U.S. federal income tax — 2024 tax-year brackets.
+#
+# Single filer only (MFJ / HoH / MFS deferred). Standard deduction
+# only (itemized deductions deferred until housing layer lands).
+#
+# `upper_usd: .inf` is the open-ended top bracket. Brackets are
+# walked low to high; the rate applies to income in the slice
+# (lower_of_this_bracket, upper_of_this_bracket].
+#
+# LTCG brackets are walked separately on long-term capital gains
+# (holding period >= 12 months); the LTCG bracket position depends
+# on total taxable income (ordinary + LTCG combined) per §1(h).
+jurisdiction_id: federal_us
+
+ordinary_income_brackets:
+  single:
+    - { upper_usd: 11600.0, rate: 0.10 }
+    - { upper_usd: 47150.0, rate: 0.12 }
+    - { upper_usd: 100525.0, rate: 0.22 }
+    - { upper_usd: 191950.0, rate: 0.24 }
+    - { upper_usd: 243725.0, rate: 0.32 }
+    - { upper_usd: 609350.0, rate: 0.35 }
+    - { upper_usd: .inf, rate: 0.37 }
+
+ltcg_brackets:
+  single:
+    - { upper_usd: 47025.0, rate: 0.00 }
+    - { upper_usd: 518900.0, rate: 0.15 }
+    - { upper_usd: .inf, rate: 0.20 }
+
+standard_deduction:
+  single: 14600.0

--- a/augur/sim/data/locations/san_francisco.yaml
+++ b/augur/sim/data/locations/san_francisco.yaml
@@ -1,0 +1,20 @@
+# San Francisco, CA — agent residence location data.
+#
+# At spike 1 the location record is mostly forward-looking: the
+# housing layer (L8 + L12-13, deferred) consumes the property-tax
+# rate and special-assessment surcharges to model owner-occupied
+# real estate. For spike-1 simulations the only field used is
+# `jurisdiction_ids`, which scopes the agent's tax filings to
+# federal + CA.
+location_id: san_francisco
+display_name: "San Francisco, CA"
+jurisdiction_ids:
+  - federal_us
+  - california
+# Property tax rate (proposition-13 capped at 1% of assessed
+# value, plus city-level surcharges of ~0.18%). Unused at spike 1.
+annual_property_tax_rate: 0.01180
+# Special-assessment surcharges (bonds + parcel taxes) per assessed
+# dollar. Unused at spike 1; present so the schema is forward-
+# compatible with the housing layer.
+annual_special_assessment_rate: 0.0

--- a/augur/sim/events.py
+++ b/augur/sim/events.py
@@ -6,10 +6,10 @@ can hand one object to `apply_events`. Each kind frame's schema is
 keyed by `(rollout_index, month_index, cause_id)` plus the kind-
 specific columns.
 
-At spike 1 only `transfers` is populated; later layers add
-asset_purchases, asset_sales, mortgage_payments, obligation
-accruals + settlements, tax accruals + payments, occupancy-mode
-changes, depreciation accruals, failure events, etc.
+At spike 1 step 4: `transfers`, `asset_purchases`, and
+`lot_dispositions` are populated. Later layers add tax accruals +
+payments, mortgage payments, obligation accruals + settlements,
+occupancy-mode changes, depreciation accruals, failure events, etc.
 """
 
 from __future__ import annotations
@@ -29,6 +29,44 @@ TRANSFER_EVENT_SCHEMA: dict[str, pl.DataType] = {
     "amount_usd": pl.Float64(),
 }
 
+# `AssetPurchase` records the creation of a new tax lot — either an
+# initial holding seeded at scenario start, or (later) an in-sim buy.
+# Initial-holding purchases at spike-1 step 4 do not draw cash; an
+# in-sim buy in a later layer will be paired with a transfer that
+# debits cash. The lot the purchase creates is keyed by
+# `(rollout_index, lot_id)` and shows up as a new row in
+# `state.asset_lots` with `remaining_quantity = quantity`.
+ASSET_PURCHASE_EVENT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "cause_id": pl.Utf8(),
+    "agent_id": pl.Utf8(),
+    "asset_id": pl.Utf8(),
+    "lot_id": pl.Utf8(),
+    "quantity": pl.Float64(),
+    "cost_basis_per_unit_usd": pl.Float64(),
+}
+
+# `LotDisposition` records the consumption of part (or all) of one
+# lot by one logical sale. A single AssetSale "sell N units of vti"
+# decomposes into one disposition row per lot the sale ate into;
+# `cause_id` groups all dispositions of the same sale for downstream
+# tax classification. Holding period for LTCG/STCG is
+# `month_index - purchase_month_index`.
+LOT_DISPOSITION_EVENT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "cause_id": pl.Utf8(),
+    "agent_id": pl.Utf8(),
+    "asset_id": pl.Utf8(),
+    "lot_id": pl.Utf8(),
+    "purchase_month_index": pl.Int64(),
+    "units_sold": pl.Float64(),
+    "cost_basis_consumed_usd": pl.Float64(),
+    "proceeds_usd": pl.Float64(),
+    "proceeds_account_id": pl.Utf8(),
+}
+
 
 @dataclass(frozen=True)
 class EventLog:
@@ -36,7 +74,13 @@ class EventLog:
     per event kind."""
 
     transfers: pl.DataFrame
+    asset_purchases: pl.DataFrame
+    lot_dispositions: pl.DataFrame
 
     @classmethod
     def empty(cls) -> EventLog:
-        return cls(transfers=pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA))
+        return cls(
+            transfers=pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA),
+            asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
+            lot_dispositions=pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA),
+        )

--- a/augur/sim/events.py
+++ b/augur/sim/events.py
@@ -66,6 +66,18 @@ TAX_ACCRUAL_EVENT_SCHEMA: dict[str, pl.DataType] = {
     "amount_usd": pl.Float64(),
 }
 
+# `RolloutFailure` flags a rollout as having run out of disposable
+# wealth — agent's cash is negative even after the floor-triggered
+# sale policy has done its best. Once flagged, the rollout stays
+# failed for the rest of the sim (L11.2).
+ROLLOUT_FAILURE_EVENT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "cause_id": pl.Utf8(),
+    "agent_id": pl.Utf8(),
+    "deficit_usd": pl.Float64(),
+}
+
 # `LotDisposition` records the consumption of part (or all) of one
 # lot by one logical sale. A single AssetSale "sell N units of vti"
 # decomposes into one disposition row per lot the sale ate into;
@@ -96,6 +108,7 @@ class EventLog:
     asset_purchases: pl.DataFrame
     lot_dispositions: pl.DataFrame
     tax_accruals: pl.DataFrame
+    rollout_failures: pl.DataFrame
 
     @classmethod
     def empty(cls) -> EventLog:
@@ -104,4 +117,5 @@ class EventLog:
             asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
             lot_dispositions=pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA),
             tax_accruals=pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA),
+            rollout_failures=pl.DataFrame(schema=ROLLOUT_FAILURE_EVENT_SCHEMA),
         )

--- a/augur/sim/events.py
+++ b/augur/sim/events.py
@@ -27,6 +27,10 @@ TRANSFER_EVENT_SCHEMA: dict[str, pl.DataType] = {
     "to_agent_id": pl.Utf8(),
     "to_account_id": pl.Utf8(),
     "amount_usd": pl.Float64(),
+    # Tax classification: when set (e.g. "ordinary" for W-2 wages),
+    # apply_events increments the recipient's ordinary_income_ytd.
+    # Null for non-income transfers (e.g. expense payments).
+    "income_category": pl.Utf8(),
 }
 
 # `AssetPurchase` records the creation of a new tax lot — either an
@@ -45,6 +49,21 @@ ASSET_PURCHASE_EVENT_SCHEMA: dict[str, pl.DataType] = {
     "lot_id": pl.Utf8(),
     "quantity": pl.Float64(),
     "cost_basis_per_unit_usd": pl.Float64(),
+}
+
+# `TaxAccrual` records a year-end tax computation: a single
+# year's ordinary income for one agent under one jurisdiction has
+# been bracket-walked, and the resulting tax `amount_usd` is now
+# owed. apply_events appends a row to `state.tax_liabilities` and
+# zeroes the agent's `ordinary_income_ytd` for the next year.
+TAX_ACCRUAL_EVENT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "cause_id": pl.Utf8(),
+    "agent_id": pl.Utf8(),
+    "jurisdiction_id": pl.Utf8(),
+    "tax_year_end_month": pl.Int64(),
+    "amount_usd": pl.Float64(),
 }
 
 # `LotDisposition` records the consumption of part (or all) of one
@@ -76,6 +95,7 @@ class EventLog:
     transfers: pl.DataFrame
     asset_purchases: pl.DataFrame
     lot_dispositions: pl.DataFrame
+    tax_accruals: pl.DataFrame
 
     @classmethod
     def empty(cls) -> EventLog:
@@ -83,4 +103,5 @@ class EventLog:
             transfers=pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA),
             asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
             lot_dispositions=pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA),
+            tax_accruals=pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA),
         )

--- a/augur/sim/events.py
+++ b/augur/sim/events.py
@@ -1,0 +1,42 @@
+"""Event log for the simulation.
+
+Every state-changing happening is a row on an event-kind frame.
+`EventLog` bundles all the kind frames together so the simulate loop
+can hand one object to `apply_events`. Each kind frame's schema is
+keyed by `(rollout_index, month_index, cause_id)` plus the kind-
+specific columns.
+
+At spike 1 only `transfers` is populated; later layers add
+asset_purchases, asset_sales, mortgage_payments, obligation
+accruals + settlements, tax accruals + payments, occupancy-mode
+changes, depreciation accruals, failure events, etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+
+TRANSFER_EVENT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "cause_id": pl.Utf8(),
+    "from_agent_id": pl.Utf8(),
+    "from_account_id": pl.Utf8(),
+    "to_agent_id": pl.Utf8(),
+    "to_account_id": pl.Utf8(),
+    "amount_usd": pl.Float64(),
+}
+
+
+@dataclass(frozen=True)
+class EventLog:
+    """Per-step or per-simulation collection of events, one frame
+    per event kind."""
+
+    transfers: pl.DataFrame
+
+    @classmethod
+    def empty(cls) -> EventLog:
+        return cls(transfers=pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA))

--- a/augur/sim/jurisdictions.py
+++ b/augur/sim/jurisdictions.py
@@ -1,0 +1,53 @@
+"""Tax jurisdiction definitions loaded from YAML.
+
+A jurisdiction is one taxing authority — federal U.S., California
+state, etc. Each carries bracket schedules (ordinary income;
+optionally a separate LTCG schedule) and a standard deduction
+keyed by filing status.
+
+The data files live in `augur/sim/data/jurisdictions/*.yaml`. The
+loader resolves them relative to this module's location so Bazel's
+runfiles tree (which preserves the source layout) can find them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+_DATA_DIR = Path(__file__).parent / "data" / "jurisdictions"
+
+
+class TaxBracket(BaseModel):
+    """One marginal-rate slice. `upper_usd` is the inclusive upper
+    edge; `math.inf` in YAML (`.inf`) denotes the open-ended top
+    bracket. Brackets in a schedule are walked low to high, and the
+    rate applies to income in the slice
+    `(previous_upper, upper_usd]`."""
+
+    upper_usd: float
+    rate: float
+
+
+class Jurisdiction(BaseModel):
+    """A taxing authority's complete bracket + deduction config.
+
+    `ltcg_brackets` is optional: when absent, the engine taxes
+    long-term capital gains at the ordinary-income rate
+    (California-style)."""
+
+    jurisdiction_id: str
+    ordinary_income_brackets: dict[str, list[TaxBracket]]
+    ltcg_brackets: dict[str, list[TaxBracket]] | None = Field(default=None)
+    standard_deduction: dict[str, float]
+
+
+def load_jurisdiction(jurisdiction_id: str) -> Jurisdiction:
+    """Load and validate the YAML for `jurisdiction_id`. Raises
+    `FileNotFoundError` if the file is missing and Pydantic's
+    `ValidationError` if the schema doesn't match."""
+    path = _DATA_DIR / f"{jurisdiction_id}.yaml"
+    data = yaml.safe_load(path.read_text())
+    return Jurisdiction.model_validate(data)

--- a/augur/sim/jurisdictions_test.py
+++ b/augur/sim/jurisdictions_test.py
@@ -1,0 +1,49 @@
+"""Tests for the jurisdiction YAML loader."""
+
+from __future__ import annotations
+
+import math
+
+import pytest_bazel
+
+from augur.sim.jurisdictions import load_jurisdiction
+
+
+def test_load_federal_us_has_seven_ordinary_brackets() -> None:
+    fed = load_jurisdiction("federal_us")
+    assert fed.jurisdiction_id == "federal_us"
+    single = fed.ordinary_income_brackets["single"]
+    assert len(single) == 7
+    assert single[0].rate == 0.10
+    assert single[0].upper_usd == 11600.0
+    assert single[-1].rate == 0.37
+    assert math.isinf(single[-1].upper_usd)
+
+
+def test_load_federal_us_has_three_ltcg_brackets() -> None:
+    fed = load_jurisdiction("federal_us")
+    assert fed.ltcg_brackets is not None
+    ltcg = fed.ltcg_brackets["single"]
+    assert [b.rate for b in ltcg] == [0.0, 0.15, 0.20]
+    assert math.isinf(ltcg[-1].upper_usd)
+
+
+def test_load_california_omits_ltcg_brackets() -> None:
+    """California taxes LTCG as ordinary income; the YAML doesn't
+    declare separate LTCG brackets and the loader represents that
+    as `ltcg_brackets = None`."""
+    ca = load_jurisdiction("california")
+    assert ca.jurisdiction_id == "california"
+    assert ca.ltcg_brackets is None
+    assert len(ca.ordinary_income_brackets["single"]) == 9
+
+
+def test_standard_deduction_present_for_single() -> None:
+    fed = load_jurisdiction("federal_us")
+    ca = load_jurisdiction("california")
+    assert fed.standard_deduction["single"] == 14600.0
+    assert ca.standard_deduction["single"] == 5363.0
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/locations.py
+++ b/augur/sim/locations.py
@@ -1,0 +1,36 @@
+"""Location records loaded from YAML.
+
+A `Location` is a place an agent can reside in — at spike 1 only
+"san_francisco" is shipped. Locations carry the tax jurisdictions
+that apply at that address and (for the deferred housing layer)
+property-tax / special-assessment rates.
+
+The data files live in `augur/sim/data/locations/*.yaml`; layout
+mirrors `jurisdictions/`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+_DATA_DIR = Path(__file__).parent / "data" / "locations"
+
+
+class Location(BaseModel):
+    """A residence location with tax + housing-cost configuration.
+    `jurisdiction_ids` are the taxing authorities that apply (used
+    by tax profiles); the property-tax fields are scaffolding for
+    the deferred housing layer."""
+
+    location_id: str
+    display_name: str
+    jurisdiction_ids: list[str]
+    annual_property_tax_rate: float = 0.0
+    annual_special_assessment_rate: float = 0.0
+
+
+def load_location(location_id: str) -> Location:
+    path = _DATA_DIR / f"{location_id}.yaml"
+    return Location.model_validate(yaml.safe_load(path.read_text()))

--- a/augur/sim/locations_test.py
+++ b/augur/sim/locations_test.py
@@ -1,0 +1,20 @@
+"""Tests for the location YAML loader."""
+
+from __future__ import annotations
+
+import pytest_bazel
+
+from augur.sim.locations import load_location
+
+
+def test_load_san_francisco() -> None:
+    loc = load_location("san_francisco")
+    assert loc.location_id == "san_francisco"
+    assert loc.jurisdiction_ids == ["federal_us", "california"]
+    assert loc.display_name == "San Francisco, CA"
+    # The property-tax rate is scaffolding for the housing layer.
+    assert loc.annual_property_tax_rate > 0
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/market.py
+++ b/augur/sim/market.py
@@ -1,0 +1,152 @@
+"""Market bundle — exogenous per-(asset, rollout, month) price paths.
+
+The market is the only source of rollout divergence at spike 1: agent
+decisions don't feed back into the market, and within a rollout every
+agent reads the same price path. The bundle is materialized at sim
+start into a long-form polars frame keyed by
+`(rollout_index, month_index, asset_id)` with one column
+`price_per_unit_usd`. Subsequent step calls index into it by month.
+
+Two path-generator kinds are supported at spike 1:
+
+- **DeterministicPath**: a fixed list of monthly prices that the
+  same value applies across every rollout. Useful for tests and for
+  the bench scenario's deterministic-comparison case.
+- **GeometricBrownianPath**: per-rollout GBM samples driven by
+  `numpy.random.default_rng(asset_seed)`. Each asset has its own
+  seeded generator so results are reproducible.
+
+Real production market models are out of scope for spike 1; this is
+just enough infrastructure to prove the rollout-divergence
+plumbing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Literal
+
+import numpy as np
+import polars as pl
+from pydantic import BaseModel, Field
+
+MARKET_PRICES_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "month_index": pl.Int64(),
+    "asset_id": pl.Utf8(),
+    "price_per_unit_usd": pl.Float64(),
+}
+
+
+class DeterministicPath(BaseModel):
+    """A fixed per-month price curve shared across rollouts. The
+    `prices_usd` list runs from month 0 through `horizon_months`
+    inclusive; the engine asserts the length matches the scenario
+    horizon at materialization time."""
+
+    kind: Literal["deterministic"] = "deterministic"
+    asset_id: str
+    prices_usd: list[float]
+
+
+class GeometricBrownianPath(BaseModel):
+    """Per-rollout GBM-sampled price path. `initial_price_usd` is
+    month-0 price; subsequent months apply `exp(N(mu, sigma))` to
+    the previous month's price. Sampling uses
+    `numpy.random.default_rng(rng_seed)` so the same seed yields
+    the same paths across runs."""
+
+    kind: Literal["gbm"] = "gbm"
+    asset_id: str
+    initial_price_usd: float
+    monthly_log_return_mu: float = 0.0
+    monthly_log_return_sigma: float = 0.0
+    rng_seed: int = 0
+
+
+MarketPathSpec = Annotated[DeterministicPath | GeometricBrownianPath, Field(discriminator="kind")]
+
+
+class MarketBundle(BaseModel):
+    """The full set of per-asset price-path specifications. Empty
+    bundle is valid (no assets traded in the scenario)."""
+
+    paths: list[MarketPathSpec] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MarketContext:
+    """The materialized market frame plus quick filtered views.
+    Construct once at sim start; pass alongside `state` into step
+    calls. The frame schema is `MARKET_PRICES_SCHEMA`."""
+
+    prices: pl.DataFrame
+
+    def prices_at(self, month_index: int) -> pl.DataFrame:
+        """Cross-section view at the given month: one row per
+        (rollout_index, asset_id)."""
+        return self.prices.filter(pl.col("month_index") == month_index).select(
+            "rollout_index", "asset_id", "price_per_unit_usd"
+        )
+
+
+def materialize_market(bundle: MarketBundle, *, rollout_count: int, horizon_months: int) -> MarketContext:
+    """Realize every path spec into a long-form polars frame and
+    bundle it as a `MarketContext`. The output covers months 0
+    through `horizon_months` inclusive (so length `horizon_months
+    + 1` per (rollout, asset)). An empty bundle yields an empty
+    frame with the correct schema."""
+    if not bundle.paths:
+        return MarketContext(prices=pl.DataFrame(schema=MARKET_PRICES_SCHEMA))
+    blocks = [_materialize_path(p, rollout_count=rollout_count, horizon_months=horizon_months) for p in bundle.paths]
+    return MarketContext(prices=pl.concat(blocks).select(list(MARKET_PRICES_SCHEMA.keys())))
+
+
+def _materialize_path(path: MarketPathSpec, *, rollout_count: int, horizon_months: int) -> pl.DataFrame:
+    if isinstance(path, DeterministicPath):
+        return _materialize_deterministic(path, rollout_count=rollout_count, horizon_months=horizon_months)
+    return _materialize_gbm(path, rollout_count=rollout_count, horizon_months=horizon_months)
+
+
+def _materialize_deterministic(path: DeterministicPath, *, rollout_count: int, horizon_months: int) -> pl.DataFrame:
+    expected = horizon_months + 1
+    if len(path.prices_usd) != expected:
+        msg = (
+            f"DeterministicPath for {path.asset_id} has {len(path.prices_usd)} prices; "
+            f"need {expected} (month 0..{horizon_months} inclusive)"
+        )
+        raise ValueError(msg)
+    months = pl.DataFrame(
+        {"month_index": list(range(expected)), "price_per_unit_usd": path.prices_usd},
+        schema={"month_index": pl.Int64(), "price_per_unit_usd": pl.Float64()},
+    ).with_columns(pl.lit(path.asset_id, dtype=pl.Utf8()).alias("asset_id"))
+    rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
+    return rollouts.join(months, how="cross").select(list(MARKET_PRICES_SCHEMA.keys()))
+
+
+def _materialize_gbm(path: GeometricBrownianPath, *, rollout_count: int, horizon_months: int) -> pl.DataFrame:
+    """Sample (rollout_count, horizon_months) log-returns and
+    accumulate them into per-month prices. `numpy.random.default_rng`
+    is the canonical generator — seeding it with `path.rng_seed`
+    yields identical paths across runs."""
+    rng = np.random.default_rng(path.rng_seed)
+    # Shape (rollouts, horizon): one log-return per (rollout, transition).
+    log_returns = rng.normal(
+        loc=path.monthly_log_return_mu, scale=path.monthly_log_return_sigma, size=(rollout_count, horizon_months)
+    )
+    cumulative = np.cumsum(log_returns, axis=1)  # cumulative log return at end of month m+1
+    prices = np.empty((rollout_count, horizon_months + 1), dtype=np.float64)
+    prices[:, 0] = path.initial_price_usd
+    prices[:, 1:] = path.initial_price_usd * np.exp(cumulative)
+    rollout_idx = np.repeat(np.arange(rollout_count, dtype=np.int64), horizon_months + 1)
+    month_idx = np.tile(np.arange(horizon_months + 1, dtype=np.int64), rollout_count)
+    flat_prices = prices.reshape(-1)
+    return pl.DataFrame(
+        {
+            "rollout_index": rollout_idx,
+            "month_index": month_idx,
+            "asset_id": [path.asset_id] * (rollout_count * (horizon_months + 1)),
+            "price_per_unit_usd": flat_prices,
+        },
+        schema=MARKET_PRICES_SCHEMA,
+    )

--- a/augur/sim/replay.py
+++ b/augur/sim/replay.py
@@ -1,0 +1,115 @@
+"""Shared replay-invariant assertion for scenario tests.
+
+The spike-1 central guarantee:
+
+    state_at(M).event_sourced ==
+        apply_events(initial_state, events_log.filter(month <= M))
+
+for every M. `assert_replay_invariant_holds` is the verification of
+this guarantee at the end-of-horizon cross-section: any scenario test
+can drop it in after a successful `simulate()` call to ratify the
+invariant for that scenario, without writing scenario-specific replay
+plumbing.
+
+The helper compares every state frame the engine touches —
+`cash_balances`, `asset_lots`, `ordinary_income_ytd`,
+`capital_gains_ytd`, `tax_liabilities`, `rollout_status`. New frames
+added in later spikes need new entries here.
+
+Also intended as the verification hook for an opt-in
+`--check-replay` flag in production (per `DESIGN.md`); not yet wired.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from augur.sim.apply import apply_events
+from augur.sim.run import SimulationRun
+from augur.sim.scenario import Scenario
+from augur.sim.simulate import _initial_state
+from augur.sim.state import StateCrossSection
+
+
+def assert_replay_invariant_holds(scenario: Scenario, result: SimulationRun, *, rollout_count: int) -> None:
+    """Re-derive the end-state by applying the full event log to a
+    fresh initial state, then check it matches the incremental
+    result frame-by-frame.
+
+    The `rollout_count` argument must match the value passed to
+    `simulate()` — it's not stored on `SimulationRun` because the
+    rollout dimension lives implicitly in every long-form frame."""
+    initial = _initial_state(scenario, rollout_count)
+    replayed = apply_events(initial, result.events_log)
+    horizon = int(scenario.horizon_months)
+    _check_frame(
+        kind="cash_balances",
+        incremental=_horizon_slice(result.cash_balances, horizon),
+        replayed=replayed.cash_balances,
+        sort_keys=["rollout_index", "agent_id", "account_id"],
+    )
+    _check_frame(
+        kind="asset_lots",
+        incremental=_horizon_slice(result.asset_lots, horizon),
+        replayed=replayed.asset_lots,
+        sort_keys=["rollout_index", "lot_id"],
+    )
+    _check_frame(
+        kind="ordinary_income_ytd",
+        incremental=_horizon_slice(result.ordinary_income_ytd, horizon),
+        replayed=replayed.ordinary_income_ytd,
+        sort_keys=["rollout_index", "agent_id"],
+    )
+    _check_frame(
+        kind="capital_gains_ytd",
+        incremental=_horizon_slice(result.capital_gains_ytd, horizon),
+        replayed=replayed.capital_gains_ytd,
+        sort_keys=["rollout_index", "agent_id", "classification"],
+    )
+    _check_frame(
+        kind="tax_liabilities",
+        incremental=_horizon_slice(result.tax_liabilities, horizon),
+        replayed=replayed.tax_liabilities,
+        sort_keys=["rollout_index", "agent_id", "jurisdiction_id", "tax_year_end_month"],
+    )
+    _check_rollout_status(incremental=result.rollout_status, replayed=replayed)
+
+
+def _horizon_slice(frame: pl.DataFrame, horizon: int) -> pl.DataFrame:
+    """End-of-horizon cross-section view of a per-month long-form
+    frame, projected to the schema apply_events produces."""
+    return frame.filter(pl.col("month_index") == horizon).drop("month_index")
+
+
+# Cumulative replay sums all months' transfers in one polars group_by;
+# the incremental loop sums per month and accumulates. Float addition
+# is non-associative, so a many-paycheck-plus-tax-payment scenario can
+# land a few ULPs apart on the two paths. Round float columns before
+# `.equals` so the invariant compares values up to nano-cent precision
+# (more than enough for tax accuracy) without flagging FP noise.
+_FLOAT_COMPARISON_DECIMALS: int = 6
+
+
+def _check_frame(*, kind: str, incremental: pl.DataFrame, replayed: pl.DataFrame, sort_keys: list[str]) -> None:
+    inc_sorted = _round_floats(incremental.sort(sort_keys))
+    rep_sorted = _round_floats(replayed.sort(sort_keys))
+    if not inc_sorted.equals(rep_sorted):
+        msg = f"replay invariant violated for {kind!r}:\n  incremental:\n{inc_sorted}\n  replayed:\n{rep_sorted}"
+        raise AssertionError(msg)
+
+
+def _round_floats(frame: pl.DataFrame) -> pl.DataFrame:
+    """Round every float column to `_FLOAT_COMPARISON_DECIMALS` to
+    swallow FP-associativity noise between the per-month and
+    cumulative apply paths."""
+    return frame.with_columns(
+        pl.col(name).round(_FLOAT_COMPARISON_DECIMALS) for name, dtype in frame.schema.items() if dtype.is_float()
+    )
+
+
+def _check_rollout_status(*, incremental: pl.DataFrame, replayed: StateCrossSection) -> None:
+    """`rollout_status` is already a single cross-section on
+    `SimulationRun`; no horizon slicing needed."""
+    _check_frame(
+        kind="rollout_status", incremental=incremental, replayed=replayed.rollout_status, sort_keys=["rollout_index"]
+    )

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -22,5 +22,7 @@ class SimulationRun:
 
     cash_balances: pl.DataFrame
     asset_lots: pl.DataFrame
+    ordinary_income_ytd: pl.DataFrame
+    tax_liabilities: pl.DataFrame
     market_prices: pl.DataFrame
     events_log: EventLog

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -25,5 +25,6 @@ class SimulationRun:
     ordinary_income_ytd: pl.DataFrame
     capital_gains_ytd: pl.DataFrame
     tax_liabilities: pl.DataFrame
+    rollout_status: pl.DataFrame
     market_prices: pl.DataFrame
     events_log: EventLog

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -2,8 +2,8 @@
 
 The state-over-time frames (long-form, keyed by
 `(rollout_index, month_index, ...)`) plus the append-only event
-log. At spike 1 only `cash_balances` is populated; later layers
-add `asset_lots`, `liabilities`, `property_state`, etc.
+log. At spike 1 step 4: `cash_balances` and `asset_lots`. Later
+layers add `liabilities`, `property_state`, etc.
 """
 
 from __future__ import annotations
@@ -21,4 +21,5 @@ class SimulationRun:
     `(rollout_index, month_index, ...)` plus the event log."""
 
     cash_balances: pl.DataFrame
+    asset_lots: pl.DataFrame
     events_log: EventLog

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -22,4 +22,5 @@ class SimulationRun:
 
     cash_balances: pl.DataFrame
     asset_lots: pl.DataFrame
+    market_prices: pl.DataFrame
     events_log: EventLog

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -23,6 +23,7 @@ class SimulationRun:
     cash_balances: pl.DataFrame
     asset_lots: pl.DataFrame
     ordinary_income_ytd: pl.DataFrame
+    capital_gains_ytd: pl.DataFrame
     tax_liabilities: pl.DataFrame
     market_prices: pl.DataFrame
     events_log: EventLog

--- a/augur/sim/run.py
+++ b/augur/sim/run.py
@@ -1,0 +1,24 @@
+"""`SimulationRun` — outputs of one `simulate()` call.
+
+The state-over-time frames (long-form, keyed by
+`(rollout_index, month_index, ...)`) plus the append-only event
+log. At spike 1 only `cash_balances` is populated; later layers
+add `asset_lots`, `liabilities`, `property_state`, etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+
+from augur.sim.events import EventLog
+
+
+@dataclass(frozen=True)
+class SimulationRun:
+    """Outputs of a simulation. Long-form polars frames keyed by
+    `(rollout_index, month_index, ...)` plus the event log."""
+
+    cash_balances: pl.DataFrame
+    events_log: EventLog

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -68,13 +68,52 @@ class RecurringTransfer(BaseModel):
         return self.start_month <= month and (self.end_month is None or month <= self.end_month)
 
 
+class InitialLot(BaseModel):
+    """A tax lot that exists at scenario start. Models pre-existing
+    holdings: Alice already owns 100 units of VTI bought 24 months
+    before the sim starts at $80/unit. The sim creates this lot at
+    month 0 as an `AssetPurchase` event with the supplied
+    `purchase_month_index` (which may be negative — purchases
+    pre-dating the horizon are fine and feed into LTCG/STCG
+    classification of later sales)."""
+
+    lot_id: str
+    agent_id: str
+    asset_id: str
+    purchase_month_index: int
+    quantity: float
+    cost_basis_per_unit_usd: float
+
+
+class ScheduledAssetSale(BaseModel):
+    """Sell a configured quantity of an asset at a fixed month. The
+    sale consumes from the agent's lots of that asset in FIFO order
+    by `purchase_month_index`. Proceeds = `quantity *
+    price_per_unit_usd` are credited to `proceeds_account_id`.
+
+    At spike-1 step 4 the price is configured directly; at L5 + L10
+    the market bundle supplies it from the per-rollout per-month
+    price path."""
+
+    month: int
+    cause_id: str
+    agent_id: str
+    asset_id: str
+    quantity: float
+    price_per_unit_usd: float
+    proceeds_account_id: str
+
+
 class Scenario(BaseModel):
     """Spike-1 simulation scenario. Carries the minimum to run
     a multi-rollout simulation over a fixed horizon with both
-    scheduled and recurring transfers."""
+    scheduled and recurring transfers, plus tax lots and asset
+    sales."""
 
     agents: list[Agent]
     initial_cash: list[InitialAccountBalance]
+    initial_lots: list[InitialLot] = Field(default_factory=list)
     scheduled_transfers: list[ScheduledTransfer] = Field(default_factory=list)
     recurring_transfers: list[RecurringTransfer] = Field(default_factory=list)
+    scheduled_asset_sales: list[ScheduledAssetSale] = Field(default_factory=list)
     horizon_months: PositiveInt

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -147,13 +147,17 @@ class TaxProfile(BaseModel):
     `["federal_us", "california"]` for a CA resident.
 
     `tax_authority_agent_id` is the destination of tax-payment
-    transfers when timing logic emits them (a later step); it is a
-    bookkeeping sink, not a taxed agent itself."""
+    transfers — a bookkeeping sink, not a taxed agent itself.
+    `payment_account_id` is the agent's account that the engine
+    debits at year-end; `tax_authority_account_id` is the matching
+    credit account on the authority side."""
 
     agent_id: str
     filing_status: str = "single"
     jurisdiction_ids: list[str]
     tax_authority_agent_id: str
+    payment_account_id: str = "checking"
+    tax_authority_account_id: str = "checking"
     prior_year_tax_usd: float = 0.0
 
 

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, PositiveInt
 
+from augur.sim.market import MarketBundle
+
 
 class Agent(BaseModel):
     """An agent in the simulation. Identified by a stable id used
@@ -88,20 +90,22 @@ class InitialLot(BaseModel):
 class ScheduledAssetSale(BaseModel):
     """Sell a configured quantity of an asset at a fixed month. The
     sale consumes from the agent's lots of that asset in FIFO order
-    by `purchase_month_index`. Proceeds = `quantity *
-    price_per_unit_usd` are credited to `proceeds_account_id`.
+    by `purchase_month_index`. Proceeds = `quantity * unit_price`
+    are credited to `proceeds_account_id`.
 
-    At spike-1 step 4 the price is configured directly; at L5 + L10
-    the market bundle supplies it from the per-rollout per-month
-    price path."""
+    `price_per_unit_usd` is optional: when supplied the sale uses
+    that price uniformly across rollouts (useful for deterministic
+    tests). When `None`, the per-rollout per-month price comes from
+    the scenario's `MarketBundle` — the canonical case once L5
+    market integration is in play."""
 
     month: int
     cause_id: str
     agent_id: str
     asset_id: str
     quantity: float
-    price_per_unit_usd: float
     proceeds_account_id: str
+    price_per_unit_usd: float | None = None
 
 
 class Scenario(BaseModel):
@@ -116,4 +120,5 @@ class Scenario(BaseModel):
     scheduled_transfers: list[ScheduledTransfer] = Field(default_factory=list)
     recurring_transfers: list[RecurringTransfer] = Field(default_factory=list)
     scheduled_asset_sales: list[ScheduledAssetSale] = Field(default_factory=list)
+    market: MarketBundle = Field(default_factory=MarketBundle)
     horizon_months: PositiveInt

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -33,7 +33,13 @@ class InitialAccountBalance(BaseModel):
 class ScheduledTransfer(BaseModel):
     """A cash transfer between two agents scheduled at a fixed
     month. Emitted by the engine as a Transfer event at that month;
-    the same amount applies to every rollout."""
+    the same amount applies to every rollout.
+
+    `income_category` tags the transfer for downstream tax
+    classification. The canonical value at spike 1 is `"ordinary"`
+    (W-2-style wages for the recipient). When set, the recipient's
+    `ordinary_income_ytd` increments by the transferred amount at
+    apply time."""
 
     month: int
     cause_id: str
@@ -42,6 +48,7 @@ class ScheduledTransfer(BaseModel):
     to_agent_id: str
     to_account_id: str
     amount_usd: float
+    income_category: str | None = None
 
 
 class RecurringTransfer(BaseModel):
@@ -65,6 +72,7 @@ class RecurringTransfer(BaseModel):
     to_agent_id: str
     to_account_id: str
     amount_usd: float
+    income_category: str | None = None
 
     def is_active_at(self, month: int) -> bool:
         return self.start_month <= month and (self.end_month is None or month <= self.end_month)
@@ -108,6 +116,24 @@ class ScheduledAssetSale(BaseModel):
     price_per_unit_usd: float | None = None
 
 
+class TaxProfile(BaseModel):
+    """A taxed agent's tax-time configuration. At spike 1 only
+    single filers are modeled; later layers add MFJ / HoH and any
+    filing-status-driven branching. `jurisdiction_ids` is the
+    ordered list of taxing authorities — typically
+    `["federal_us", "california"]` for a CA resident.
+
+    `tax_authority_agent_id` is the destination of tax-payment
+    transfers when timing logic emits them (a later step); it is a
+    bookkeeping sink, not a taxed agent itself."""
+
+    agent_id: str
+    filing_status: str = "single"
+    jurisdiction_ids: list[str]
+    tax_authority_agent_id: str
+    prior_year_tax_usd: float = 0.0
+
+
 class Scenario(BaseModel):
     """Spike-1 simulation scenario. Carries the minimum to run
     a multi-rollout simulation over a fixed horizon with both
@@ -121,4 +147,5 @@ class Scenario(BaseModel):
     recurring_transfers: list[RecurringTransfer] = Field(default_factory=list)
     scheduled_asset_sales: list[ScheduledAssetSale] = Field(default_factory=list)
     market: MarketBundle = Field(default_factory=MarketBundle)
+    tax_profiles: list[TaxProfile] = Field(default_factory=list)
     horizon_months: PositiveInt

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -116,6 +116,29 @@ class ScheduledAssetSale(BaseModel):
     price_per_unit_usd: float | None = None
 
 
+class FloorTriggeredSalePolicy(BaseModel):
+    """If the agent's cash account drops below `floor_usd`, sell
+    enough of the listed assets — in `asset_preference_chain` order
+    — to bring cash back up to `floor_usd + replenish_buffer_usd`.
+    The engine resolves "enough" per-rollout: it walks the preference
+    chain, sells the minimum quantity at the current market price
+    that covers the remaining deficit. If even draining every
+    preferred asset leaves a residual deficit, the rollout has run
+    out of disposable wealth — L11 marks it failed.
+
+    Spike-1 limits: one policy per agent. Sale proceeds always land
+    on `account_id` (the same account whose balance is being
+    monitored). Market price comes from the scenario's MarketBundle
+    — direct prices on individual sales aren't supported here."""
+
+    agent_id: str
+    account_id: str
+    floor_usd: float
+    replenish_buffer_usd: float = 0.0
+    asset_preference_chain: list[str]
+    cause_id_prefix: str = "floor_triggered_sale"
+
+
 class TaxProfile(BaseModel):
     """A taxed agent's tax-time configuration. At spike 1 only
     single filers are modeled; later layers add MFJ / HoH and any
@@ -148,4 +171,5 @@ class Scenario(BaseModel):
     scheduled_asset_sales: list[ScheduledAssetSale] = Field(default_factory=list)
     market: MarketBundle = Field(default_factory=MarketBundle)
     tax_profiles: list[TaxProfile] = Field(default_factory=list)
+    floor_triggered_sale_policies: list[FloorTriggeredSalePolicy] = Field(default_factory=list)
     horizon_months: PositiveInt

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -1,0 +1,53 @@
+"""Scenario configuration — Pydantic models for the user-facing
+config of a simulation run.
+
+At spike 1, the scenario carries the agents, their initial cash
+balances, a list of scheduled transfer events, and the horizon in
+months. Later layers extend `Scenario` with positions (asset
+holdings), liabilities (mortgages), properties, policies, the
+market-bundle reference, and tax profiles per agent.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, PositiveInt
+
+
+class Agent(BaseModel):
+    """An agent in the simulation. Identified by a stable id used
+    on every frame keyed by agent_id."""
+
+    agent_id: str
+
+
+class InitialAccountBalance(BaseModel):
+    """Starting cash for one (agent, account) pair at month 0."""
+
+    agent_id: str
+    account_id: str
+    balance_usd: float
+
+
+class ScheduledTransfer(BaseModel):
+    """A cash transfer between two agents scheduled at a fixed
+    month. Emitted by the engine as a Transfer event at that month;
+    the same amount applies to every rollout."""
+
+    month: int
+    cause_id: str
+    from_agent_id: str
+    from_account_id: str
+    to_agent_id: str
+    to_account_id: str
+    amount_usd: float
+
+
+class Scenario(BaseModel):
+    """Spike-1 simulation scenario. Carries the minimum to run
+    a multi-rollout simulation over a fixed horizon with a list of
+    scheduled transfers."""
+
+    agents: list[Agent]
+    initial_cash: list[InitialAccountBalance]
+    scheduled_transfers: list[ScheduledTransfer] = Field(default_factory=list)
+    horizon_months: PositiveInt

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -42,12 +42,39 @@ class ScheduledTransfer(BaseModel):
     amount_usd: float
 
 
+class RecurringTransfer(BaseModel):
+    """A cash transfer that fires every month within a window. The
+    canonical use is a recurring paycheck (income arriving monthly)
+    or recurring rent / utilities (a fixed monthly cost). The engine
+    emits one Transfer event per active month per rollout — the
+    same amount across rollouts at spike 1.
+
+    `start_month` is inclusive. `end_month` is inclusive when
+    supplied; when `None`, the transfer fires through the scenario's
+    horizon end. The `cause_id` is reused on every emitted event row
+    so a user can group_by it to see "every paycheck Alice
+    received"."""
+
+    start_month: int
+    end_month: int | None = None
+    cause_id: str
+    from_agent_id: str
+    from_account_id: str
+    to_agent_id: str
+    to_account_id: str
+    amount_usd: float
+
+    def is_active_at(self, month: int) -> bool:
+        return self.start_month <= month and (self.end_month is None or month <= self.end_month)
+
+
 class Scenario(BaseModel):
     """Spike-1 simulation scenario. Carries the minimum to run
-    a multi-rollout simulation over a fixed horizon with a list of
-    scheduled transfers."""
+    a multi-rollout simulation over a fixed horizon with both
+    scheduled and recurring transfers."""
 
     agents: list[Agent]
     initial_cash: list[InitialAccountBalance]
     scheduled_transfers: list[ScheduledTransfer] = Field(default_factory=list)
+    recurring_transfers: list[RecurringTransfer] = Field(default_factory=list)
     horizon_months: PositiveInt

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -35,10 +35,11 @@ from augur.sim.state import (
     CAPITAL_GAINS_YTD_SCHEMA,
     CASH_BALANCES_SCHEMA,
     ORDINARY_INCOME_YTD_SCHEMA,
+    ROLLOUT_STATUS_SCHEMA,
     TAX_LIABILITIES_SCHEMA,
     StateCrossSection,
 )
-from augur.sim.step import step_emit_events
+from augur.sim.step import step_emit_policy_events, step_emit_scheduled_events
 
 
 def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
@@ -53,7 +54,7 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
     cross_sections: list[StateCrossSection] = [state_t]
     events_by_month: list[EventLog] = []
     for month in range(int(scenario.horizon_months)):
-        events_t = step_emit_events(
+        events_p1 = step_emit_scheduled_events(
             state=state_t,
             scenario=scenario,
             market=market,
@@ -61,15 +62,18 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
             month=month,
             rollout_count=rollout_count,
         )
-        state_t = apply_events(state_t, events_t)
+        state_t = apply_events(state_t, events_p1)
+        events_p2 = step_emit_policy_events(state=state_t, scenario=scenario, market=market, month=month)
+        state_t = apply_events(state_t, events_p2)
         cross_sections.append(state_t)
-        events_by_month.append(events_t)
+        events_by_month.append(_merge_event_logs(events_p1, events_p2))
     return SimulationRun(
         cash_balances=_stack_cash_balances(cross_sections),
         asset_lots=_stack_asset_lots(cross_sections),
         ordinary_income_ytd=_stack_income_ytd(cross_sections),
         capital_gains_ytd=_stack_capital_gains(cross_sections),
         tax_liabilities=_stack_tax_liabilities(cross_sections),
+        rollout_status=cross_sections[-1].rollout_status,
         market_prices=market.prices,
         events_log=_concat_events(events_by_month),
     )
@@ -95,13 +99,22 @@ def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
     ordinary_income_ytd = _initial_ordinary_income_ytd(scenario, rollouts)
     capital_gains_ytd = pl.DataFrame(schema=CAPITAL_GAINS_YTD_SCHEMA)
     tax_liabilities = pl.DataFrame(schema=TAX_LIABILITIES_SCHEMA)
+    rollout_status = _initial_rollout_status(rollouts)
     return StateCrossSection(
         cash_balances=cash,
         asset_lots=asset_lots,
         ordinary_income_ytd=ordinary_income_ytd,
         capital_gains_ytd=capital_gains_ytd,
         tax_liabilities=tax_liabilities,
+        rollout_status=rollout_status,
     )
+
+
+def _initial_rollout_status(rollouts: pl.DataFrame) -> pl.DataFrame:
+    """One row per rollout, status = "active", failed_month = null."""
+    return rollouts.with_columns(
+        status=pl.lit("active", dtype=pl.Utf8()), failed_month=pl.lit(None, dtype=pl.Int64())
+    ).select(list(ROLLOUT_STATUS_SCHEMA.keys()))
 
 
 def _initial_cash(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFrame:
@@ -216,16 +229,40 @@ def _stack_tax_liabilities(cross_sections: list[StateCrossSection]) -> pl.DataFr
     )
 
 
+def _merge_event_logs(a: EventLog, b: EventLog) -> EventLog:
+    """Concatenate two per-phase logs into one per-month log."""
+    return EventLog(
+        transfers=_concat_or_empty(a.transfers, b.transfers),
+        asset_purchases=_concat_or_empty(a.asset_purchases, b.asset_purchases),
+        lot_dispositions=_concat_or_empty(a.lot_dispositions, b.lot_dispositions),
+        tax_accruals=_concat_or_empty(a.tax_accruals, b.tax_accruals),
+        rollout_failures=_concat_or_empty(a.rollout_failures, b.rollout_failures),
+    )
+
+
+def _concat_or_empty(a: pl.DataFrame, b: pl.DataFrame) -> pl.DataFrame:
+    """Concatenate two frames sharing a schema, dropping empties so
+    the result doesn't carry phantom rows when one side has nothing
+    to contribute."""
+    if a.is_empty():
+        return b
+    if b.is_empty():
+        return a
+    return pl.concat([a, b])
+
+
 def _concat_events(events_by_month: list[EventLog]) -> EventLog:
     """Concatenate per-month event logs into one cumulative log."""
     transfer_blocks = [e.transfers for e in events_by_month if not e.transfers.is_empty()]
     purchase_blocks = [e.asset_purchases for e in events_by_month if not e.asset_purchases.is_empty()]
     disposition_blocks = [e.lot_dispositions for e in events_by_month if not e.lot_dispositions.is_empty()]
     accrual_blocks = [e.tax_accruals for e in events_by_month if not e.tax_accruals.is_empty()]
+    failure_blocks = [e.rollout_failures for e in events_by_month if not e.rollout_failures.is_empty()]
     empty = EventLog.empty()
     return EventLog(
         transfers=pl.concat(transfer_blocks) if transfer_blocks else empty.transfers,
         asset_purchases=pl.concat(purchase_blocks) if purchase_blocks else empty.asset_purchases,
         lot_dispositions=pl.concat(disposition_blocks) if disposition_blocks else empty.lot_dispositions,
         tax_accruals=pl.concat(accrual_blocks) if accrual_blocks else empty.tax_accruals,
+        rollout_failures=pl.concat(failure_blocks) if failure_blocks else empty.rollout_failures,
     )

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -32,6 +32,7 @@ from augur.sim.run import SimulationRun
 from augur.sim.scenario import Scenario
 from augur.sim.state import (
     ASSET_LOT_SCHEMA,
+    CAPITAL_GAINS_YTD_SCHEMA,
     CASH_BALANCES_SCHEMA,
     ORDINARY_INCOME_YTD_SCHEMA,
     TAX_LIABILITIES_SCHEMA,
@@ -67,6 +68,7 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
         cash_balances=_stack_cash_balances(cross_sections),
         asset_lots=_stack_asset_lots(cross_sections),
         ordinary_income_ytd=_stack_income_ytd(cross_sections),
+        capital_gains_ytd=_stack_capital_gains(cross_sections),
         tax_liabilities=_stack_tax_liabilities(cross_sections),
         market_prices=market.prices,
         events_log=_concat_events(events_by_month),
@@ -91,11 +93,13 @@ def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
     cash = _initial_cash(scenario, rollouts)
     asset_lots = _initial_asset_lots(scenario, rollouts)
     ordinary_income_ytd = _initial_ordinary_income_ytd(scenario, rollouts)
+    capital_gains_ytd = pl.DataFrame(schema=CAPITAL_GAINS_YTD_SCHEMA)
     tax_liabilities = pl.DataFrame(schema=TAX_LIABILITIES_SCHEMA)
     return StateCrossSection(
         cash_balances=cash,
         asset_lots=asset_lots,
         ordinary_income_ytd=ordinary_income_ytd,
+        capital_gains_ytd=capital_gains_ytd,
         tax_liabilities=tax_liabilities,
     )
 
@@ -192,6 +196,14 @@ def _stack_income_ytd(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
         for month, cs in enumerate(cross_sections)
     ]
     return pl.concat(blocks).select(["rollout_index", "month_index", "agent_id", "ordinary_income_usd"])
+
+
+def _stack_capital_gains(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
+    blocks = [
+        cs.capital_gains_ytd.with_columns(pl.lit(month, dtype=pl.Int64()).alias("month_index"))
+        for month, cs in enumerate(cross_sections)
+    ]
+    return pl.concat(blocks).select(["rollout_index", "month_index", "agent_id", "classification", "gain_usd"])
 
 
 def _stack_tax_liabilities(cross_sections: list[StateCrossSection]) -> pl.DataFrame:

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -1,0 +1,85 @@
+"""Forward simulation loop.
+
+`simulate(scenario, rollout_count) → SimulationRun` runs the
+per-month step over the scenario's horizon and produces the
+state-over-time long-form frames + the event log.
+
+The loop carries `state_t` (the polars cross-section, no
+month_index column) forward. Each iteration:
+
+  events_t = step_emit_events(state_t, scenario, month, rollout_count)
+  state_t = apply_events(state_t, events_t)
+
+`apply_events` is the only state-mutation point. The replay
+invariant holds by construction: at any month M, `state_t` equals
+`apply_events(initial_state, events_log.filter(month < M))`.
+
+The state-over-time frames in the returned `SimulationRun` are
+the concatenation of the per-month cross-sections with
+`month_index` injected as a column.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from augur.sim.apply import apply_events
+from augur.sim.events import EventLog
+from augur.sim.run import SimulationRun
+from augur.sim.scenario import Scenario
+from augur.sim.state import CASH_BALANCES_SCHEMA, StateCrossSection
+from augur.sim.step import step_emit_events
+
+
+def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
+    if rollout_count <= 0:
+        msg = f"rollout_count must be positive; got {rollout_count}"
+        raise ValueError(msg)
+    state_t = _initial_state(scenario, rollout_count)
+    cross_sections: list[StateCrossSection] = [state_t]
+    events_by_month: list[EventLog] = []
+    for month in range(int(scenario.horizon_months)):
+        events_t = step_emit_events(state=state_t, scenario=scenario, month=month, rollout_count=rollout_count)
+        state_t = apply_events(state_t, events_t)
+        cross_sections.append(state_t)
+        events_by_month.append(events_t)
+    return SimulationRun(cash_balances=_stack_cash_balances(cross_sections), events_log=_concat_events(events_by_month))
+
+
+def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
+    """Build the initial (month-0) state cross-section from the
+    scenario's `initial_cash` list. Each `(agent, account)` pair
+    in the scenario expands to one row per rollout via a cross
+    join — no Python loop over rollouts."""
+    if not scenario.initial_cash:
+        cash = pl.DataFrame(schema=CASH_BALANCES_SCHEMA)
+        return StateCrossSection(cash_balances=cash)
+    rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
+    entries = pl.DataFrame(
+        {
+            "agent_id": [e.agent_id for e in scenario.initial_cash],
+            "account_id": [e.account_id for e in scenario.initial_cash],
+            "balance_usd": [e.balance_usd for e in scenario.initial_cash],
+        },
+        schema={"agent_id": pl.Utf8(), "account_id": pl.Utf8(), "balance_usd": pl.Float64()},
+    )
+    cash = rollouts.join(entries, how="cross").select(list(CASH_BALANCES_SCHEMA.keys()))
+    return StateCrossSection(cash_balances=cash)
+
+
+def _stack_cash_balances(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
+    """Concatenate per-month cross-sections into the long-form
+    state-over-time frame with `month_index` injected."""
+    blocks = [
+        cs.cash_balances.with_columns(pl.lit(month, dtype=pl.Int64()).alias("month_index"))
+        for month, cs in enumerate(cross_sections)
+    ]
+    return pl.concat(blocks).select(["rollout_index", "month_index", "agent_id", "account_id", "balance_usd"])
+
+
+def _concat_events(events_by_month: list[EventLog]) -> EventLog:
+    """Concatenate per-month event logs into one cumulative log."""
+    transfer_blocks = [e.transfers for e in events_by_month if not e.transfers.is_empty()]
+    if not transfer_blocks:
+        return EventLog.empty()
+    return EventLog(transfers=pl.concat(transfer_blocks))

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -7,7 +7,8 @@ state-over-time long-form frames + the event log.
 The loop carries `state_t` (the polars cross-section, no
 month_index column) forward. Each iteration:
 
-  events_t = step_emit_events(state_t, scenario, month, rollout_count)
+  events_t = step_emit_events(state_t, scenario, market,
+                              jurisdictions, month, rollout_count)
   state_t = apply_events(state_t, events_t)
 
 `apply_events` is the only state-mutation point. The replay
@@ -25,10 +26,17 @@ import polars as pl
 
 from augur.sim.apply import apply_events
 from augur.sim.events import EventLog
+from augur.sim.jurisdictions import Jurisdiction, load_jurisdiction
 from augur.sim.market import materialize_market
 from augur.sim.run import SimulationRun
 from augur.sim.scenario import Scenario
-from augur.sim.state import ASSET_LOT_SCHEMA, CASH_BALANCES_SCHEMA, StateCrossSection
+from augur.sim.state import (
+    ASSET_LOT_SCHEMA,
+    CASH_BALANCES_SCHEMA,
+    ORDINARY_INCOME_YTD_SCHEMA,
+    TAX_LIABILITIES_SCHEMA,
+    StateCrossSection,
+)
 from augur.sim.step import step_emit_events
 
 
@@ -39,12 +47,18 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
     market = materialize_market(
         scenario.market, rollout_count=rollout_count, horizon_months=int(scenario.horizon_months)
     )
+    jurisdictions = _load_jurisdictions_for(scenario)
     state_t = _initial_state(scenario, rollout_count)
     cross_sections: list[StateCrossSection] = [state_t]
     events_by_month: list[EventLog] = []
     for month in range(int(scenario.horizon_months)):
         events_t = step_emit_events(
-            state=state_t, scenario=scenario, market=market, month=month, rollout_count=rollout_count
+            state=state_t,
+            scenario=scenario,
+            market=market,
+            jurisdictions=jurisdictions,
+            month=month,
+            rollout_count=rollout_count,
         )
         state_t = apply_events(state_t, events_t)
         cross_sections.append(state_t)
@@ -52,9 +66,18 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
     return SimulationRun(
         cash_balances=_stack_cash_balances(cross_sections),
         asset_lots=_stack_asset_lots(cross_sections),
+        ordinary_income_ytd=_stack_income_ytd(cross_sections),
+        tax_liabilities=_stack_tax_liabilities(cross_sections),
         market_prices=market.prices,
         events_log=_concat_events(events_by_month),
     )
+
+
+def _load_jurisdictions_for(scenario: Scenario) -> dict[str, Jurisdiction]:
+    """Load every jurisdiction referenced by any tax profile.
+    Loaded once at sim start; the step closes over the dict."""
+    ids = {jid for profile in scenario.tax_profiles for jid in profile.jurisdiction_ids}
+    return {jid: load_jurisdiction(jid) for jid in ids}
 
 
 def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
@@ -67,7 +90,14 @@ def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
     rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
     cash = _initial_cash(scenario, rollouts)
     asset_lots = _initial_asset_lots(scenario, rollouts)
-    return StateCrossSection(cash_balances=cash, asset_lots=asset_lots)
+    ordinary_income_ytd = _initial_ordinary_income_ytd(scenario, rollouts)
+    tax_liabilities = pl.DataFrame(schema=TAX_LIABILITIES_SCHEMA)
+    return StateCrossSection(
+        cash_balances=cash,
+        asset_lots=asset_lots,
+        ordinary_income_ytd=ordinary_income_ytd,
+        tax_liabilities=tax_liabilities,
+    )
 
 
 def _initial_cash(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFrame:
@@ -108,6 +138,22 @@ def _initial_asset_lots(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFr
     return rollouts.join(entries, how="cross").select(list(ASSET_LOT_SCHEMA.keys()))
 
 
+def _initial_ordinary_income_ytd(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFrame:
+    """One row per (taxed agent, rollout) at YTD = 0. Agents
+    without a tax profile aren't tracked here — there's no use
+    case for accumulating income on a non-taxed account."""
+    if not scenario.tax_profiles:
+        return pl.DataFrame(schema=ORDINARY_INCOME_YTD_SCHEMA)
+    profile_rows = pl.DataFrame(
+        {
+            "agent_id": [p.agent_id for p in scenario.tax_profiles],
+            "ordinary_income_usd": [0.0] * len(scenario.tax_profiles),
+        },
+        schema={"agent_id": pl.Utf8(), "ordinary_income_usd": pl.Float64()},
+    )
+    return rollouts.join(profile_rows, how="cross").select(list(ORDINARY_INCOME_YTD_SCHEMA.keys()))
+
+
 def _stack_cash_balances(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
     """Concatenate per-month cross-sections into the long-form
     state-over-time frame with `month_index` injected."""
@@ -140,14 +186,34 @@ def _stack_asset_lots(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
     )
 
 
+def _stack_income_ytd(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
+    blocks = [
+        cs.ordinary_income_ytd.with_columns(pl.lit(month, dtype=pl.Int64()).alias("month_index"))
+        for month, cs in enumerate(cross_sections)
+    ]
+    return pl.concat(blocks).select(["rollout_index", "month_index", "agent_id", "ordinary_income_usd"])
+
+
+def _stack_tax_liabilities(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
+    blocks = [
+        cs.tax_liabilities.with_columns(pl.lit(month, dtype=pl.Int64()).alias("month_index"))
+        for month, cs in enumerate(cross_sections)
+    ]
+    return pl.concat(blocks).select(
+        ["rollout_index", "month_index", "agent_id", "jurisdiction_id", "tax_year_end_month", "amount_owed_usd"]
+    )
+
+
 def _concat_events(events_by_month: list[EventLog]) -> EventLog:
     """Concatenate per-month event logs into one cumulative log."""
     transfer_blocks = [e.transfers for e in events_by_month if not e.transfers.is_empty()]
     purchase_blocks = [e.asset_purchases for e in events_by_month if not e.asset_purchases.is_empty()]
     disposition_blocks = [e.lot_dispositions for e in events_by_month if not e.lot_dispositions.is_empty()]
+    accrual_blocks = [e.tax_accruals for e in events_by_month if not e.tax_accruals.is_empty()]
     empty = EventLog.empty()
     return EventLog(
         transfers=pl.concat(transfer_blocks) if transfer_blocks else empty.transfers,
         asset_purchases=pl.concat(purchase_blocks) if purchase_blocks else empty.asset_purchases,
         lot_dispositions=pl.concat(disposition_blocks) if disposition_blocks else empty.lot_dispositions,
+        tax_accruals=pl.concat(accrual_blocks) if accrual_blocks else empty.tax_accruals,
     )

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -25,6 +25,7 @@ import polars as pl
 
 from augur.sim.apply import apply_events
 from augur.sim.events import EventLog
+from augur.sim.market import materialize_market
 from augur.sim.run import SimulationRun
 from augur.sim.scenario import Scenario
 from augur.sim.state import ASSET_LOT_SCHEMA, CASH_BALANCES_SCHEMA, StateCrossSection
@@ -35,17 +36,23 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
     if rollout_count <= 0:
         msg = f"rollout_count must be positive; got {rollout_count}"
         raise ValueError(msg)
+    market = materialize_market(
+        scenario.market, rollout_count=rollout_count, horizon_months=int(scenario.horizon_months)
+    )
     state_t = _initial_state(scenario, rollout_count)
     cross_sections: list[StateCrossSection] = [state_t]
     events_by_month: list[EventLog] = []
     for month in range(int(scenario.horizon_months)):
-        events_t = step_emit_events(state=state_t, scenario=scenario, month=month, rollout_count=rollout_count)
+        events_t = step_emit_events(
+            state=state_t, scenario=scenario, market=market, month=month, rollout_count=rollout_count
+        )
         state_t = apply_events(state_t, events_t)
         cross_sections.append(state_t)
         events_by_month.append(events_t)
     return SimulationRun(
         cash_balances=_stack_cash_balances(cross_sections),
         asset_lots=_stack_asset_lots(cross_sections),
+        market_prices=market.prices,
         events_log=_concat_events(events_by_month),
     )
 

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -27,7 +27,7 @@ from augur.sim.apply import apply_events
 from augur.sim.events import EventLog
 from augur.sim.run import SimulationRun
 from augur.sim.scenario import Scenario
-from augur.sim.state import CASH_BALANCES_SCHEMA, StateCrossSection
+from augur.sim.state import ASSET_LOT_SCHEMA, CASH_BALANCES_SCHEMA, StateCrossSection
 from augur.sim.step import step_emit_events
 
 
@@ -43,18 +43,29 @@ def simulate(scenario: Scenario, *, rollout_count: int) -> SimulationRun:
         state_t = apply_events(state_t, events_t)
         cross_sections.append(state_t)
         events_by_month.append(events_t)
-    return SimulationRun(cash_balances=_stack_cash_balances(cross_sections), events_log=_concat_events(events_by_month))
+    return SimulationRun(
+        cash_balances=_stack_cash_balances(cross_sections),
+        asset_lots=_stack_asset_lots(cross_sections),
+        events_log=_concat_events(events_by_month),
+    )
 
 
 def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
     """Build the initial (month-0) state cross-section from the
-    scenario's `initial_cash` list. Each `(agent, account)` pair
-    in the scenario expands to one row per rollout via a cross
-    join — no Python loop over rollouts."""
-    if not scenario.initial_cash:
-        cash = pl.DataFrame(schema=CASH_BALANCES_SCHEMA)
-        return StateCrossSection(cash_balances=cash)
+    scenario's `initial_cash` and `initial_lots`. Each entry expands
+    to one row per rollout via a cross join — no Python loop over
+    rollouts. Pre-horizon `purchase_month_index` (e.g. -24 for a lot
+    bought before the sim) is preserved as-is for later holding-
+    period classification."""
     rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
+    cash = _initial_cash(scenario, rollouts)
+    asset_lots = _initial_asset_lots(scenario, rollouts)
+    return StateCrossSection(cash_balances=cash, asset_lots=asset_lots)
+
+
+def _initial_cash(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFrame:
+    if not scenario.initial_cash:
+        return pl.DataFrame(schema=CASH_BALANCES_SCHEMA)
     entries = pl.DataFrame(
         {
             "agent_id": [e.agent_id for e in scenario.initial_cash],
@@ -63,8 +74,31 @@ def _initial_state(scenario: Scenario, rollout_count: int) -> StateCrossSection:
         },
         schema={"agent_id": pl.Utf8(), "account_id": pl.Utf8(), "balance_usd": pl.Float64()},
     )
-    cash = rollouts.join(entries, how="cross").select(list(CASH_BALANCES_SCHEMA.keys()))
-    return StateCrossSection(cash_balances=cash)
+    return rollouts.join(entries, how="cross").select(list(CASH_BALANCES_SCHEMA.keys()))
+
+
+def _initial_asset_lots(scenario: Scenario, rollouts: pl.DataFrame) -> pl.DataFrame:
+    if not scenario.initial_lots:
+        return pl.DataFrame(schema=ASSET_LOT_SCHEMA)
+    entries = pl.DataFrame(
+        {
+            "lot_id": [lot.lot_id for lot in scenario.initial_lots],
+            "agent_id": [lot.agent_id for lot in scenario.initial_lots],
+            "asset_id": [lot.asset_id for lot in scenario.initial_lots],
+            "purchase_month_index": [lot.purchase_month_index for lot in scenario.initial_lots],
+            "cost_basis_per_unit_usd": [lot.cost_basis_per_unit_usd for lot in scenario.initial_lots],
+            "remaining_quantity": [lot.quantity for lot in scenario.initial_lots],
+        },
+        schema={
+            "lot_id": pl.Utf8(),
+            "agent_id": pl.Utf8(),
+            "asset_id": pl.Utf8(),
+            "purchase_month_index": pl.Int64(),
+            "cost_basis_per_unit_usd": pl.Float64(),
+            "remaining_quantity": pl.Float64(),
+        },
+    )
+    return rollouts.join(entries, how="cross").select(list(ASSET_LOT_SCHEMA.keys()))
 
 
 def _stack_cash_balances(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
@@ -77,9 +111,36 @@ def _stack_cash_balances(cross_sections: list[StateCrossSection]) -> pl.DataFram
     return pl.concat(blocks).select(["rollout_index", "month_index", "agent_id", "account_id", "balance_usd"])
 
 
+def _stack_asset_lots(cross_sections: list[StateCrossSection]) -> pl.DataFrame:
+    """Concatenate per-month lot cross-sections with `month_index`
+    injected. A lot row exists every month from its creation
+    onward; `remaining_quantity` shrinks as the lot is sold off."""
+    blocks = [
+        cs.asset_lots.with_columns(pl.lit(month, dtype=pl.Int64()).alias("month_index"))
+        for month, cs in enumerate(cross_sections)
+    ]
+    return pl.concat(blocks).select(
+        [
+            "rollout_index",
+            "month_index",
+            "lot_id",
+            "agent_id",
+            "asset_id",
+            "purchase_month_index",
+            "cost_basis_per_unit_usd",
+            "remaining_quantity",
+        ]
+    )
+
+
 def _concat_events(events_by_month: list[EventLog]) -> EventLog:
     """Concatenate per-month event logs into one cumulative log."""
     transfer_blocks = [e.transfers for e in events_by_month if not e.transfers.is_empty()]
-    if not transfer_blocks:
-        return EventLog.empty()
-    return EventLog(transfers=pl.concat(transfer_blocks))
+    purchase_blocks = [e.asset_purchases for e in events_by_month if not e.asset_purchases.is_empty()]
+    disposition_blocks = [e.lot_dispositions for e in events_by_month if not e.lot_dispositions.is_empty()]
+    empty = EventLog.empty()
+    return EventLog(
+        transfers=pl.concat(transfer_blocks) if transfer_blocks else empty.transfers,
+        asset_purchases=pl.concat(purchase_blocks) if purchase_blocks else empty.asset_purchases,
+        lot_dispositions=pl.concat(disposition_blocks) if disposition_blocks else empty.lot_dispositions,
+    )

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -15,7 +15,6 @@ import pytest_bazel
 from augur.sim.apply import apply_events
 from augur.sim.scenario import Agent, InitialAccountBalance, Scenario, ScheduledTransfer
 from augur.sim.simulate import _initial_state, simulate
-from augur.sim.state import StateCrossSection
 
 
 def _alice_bob_scenario() -> Scenario:
@@ -109,19 +108,6 @@ def test_no_scheduled_transfers_leaves_balances_unchanged() -> None:
 def test_rejects_zero_rollout_count() -> None:
     with pytest.raises(ValueError, match="rollout_count"):
         simulate(_alice_bob_scenario(), rollout_count=0)
-
-
-def test_state_cross_section_is_frozen() -> None:
-    """StateCrossSection must be immutable so that downstream
-    callers can't accidentally mutate state mid-step."""
-    initial = _initial_state(_alice_bob_scenario(), rollout_count=1)
-    assert isinstance(initial, StateCrossSection)
-    try:
-        initial.cash_balances = pl.DataFrame()
-    except (AttributeError, TypeError):
-        return
-    msg = "expected StateCrossSection to be frozen"
-    raise AssertionError(msg)
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -13,7 +13,7 @@ import pytest
 import pytest_bazel
 
 from augur.sim.apply import apply_events
-from augur.sim.scenario import Agent, InitialAccountBalance, Scenario, ScheduledTransfer
+from augur.sim.scenario import Agent, InitialAccountBalance, RecurringTransfer, Scenario, ScheduledTransfer
 from augur.sim.simulate import _initial_state, simulate
 
 
@@ -108,6 +108,142 @@ def test_no_scheduled_transfers_leaves_balances_unchanged() -> None:
 def test_rejects_zero_rollout_count() -> None:
     with pytest.raises(ValueError, match="rollout_count"):
         simulate(_alice_bob_scenario(), rollout_count=0)
+
+
+def test_recurring_paycheck_accrues_monthly() -> None:
+    """Alice receives a $3000 paycheck every month from a payroll
+    sink for 12 months. Starting cash $1000; ending cash
+    $1000 + 12 × $3000 = $37000. One Transfer event per month on
+    the log."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=1000.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=3000.0,
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    alice_final = (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 12))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert alice_final == 1000.0 + 12 * 3000.0
+
+    # Conservation: payroll sink goes negative by the same amount.
+    payroll_final = (
+        result.cash_balances.filter((pl.col("agent_id") == "payroll") & (pl.col("month_index") == 12))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert payroll_final == -12 * 3000.0
+
+    # 12 paycheck events on the log (one per month).
+    assert result.events_log.transfers.height == 12
+    assert set(result.events_log.transfers.get_column("month_index").to_list()) == set(range(12))
+    assert set(result.events_log.transfers.get_column("cause_id").unique().to_list()) == {"alice_paycheck"}
+
+
+def test_recurring_transfer_bounded_by_end_month() -> None:
+    """Recurring transfer with end_month=4 fires months 0-4
+    (inclusive), then stops. Asserts the end_month bound is
+    honored — no events at month 5+."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="sink")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="sink", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                end_month=4,
+                cause_id="bounded_pay",
+                from_agent_id="sink",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=100.0,
+            )
+        ],
+        horizon_months=10,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    assert result.events_log.transfers.height == 5  # months 0..4
+
+    # Alice's balance plateaus at 500.0 from month 5 onward.
+    balances = (
+        result.cash_balances.filter(pl.col("agent_id") == "alice")
+        .sort("month_index")
+        .get_column("balance_usd")
+        .to_list()
+    )
+    assert balances == [0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 500.0, 500.0, 500.0, 500.0, 500.0]
+
+
+def test_combined_one_off_and_recurring() -> None:
+    """A scenario with both a recurring monthly paycheck and a
+    one-off bonus transfer at month 5. Both fire through the same
+    Transfer event path; the log shows both. Tests that the step
+    emits both kinds in one call."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="employer")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="employer", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_paycheck",
+                from_agent_id="employer",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=1000.0,
+            )
+        ],
+        scheduled_transfers=[
+            ScheduledTransfer(
+                month=5,
+                cause_id="alice_bonus",
+                from_agent_id="employer",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=5000.0,
+            )
+        ],
+        horizon_months=10,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # 10 paycheck events + 1 bonus = 11.
+    assert result.events_log.transfers.height == 11
+
+    # Alice at end-of-horizon: 10 × $1000 paychecks + $5000 bonus = $15000.
+    alice_final = (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 10))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert alice_final == 15000.0
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -196,6 +196,54 @@ def test_recurring_transfer_bounded_by_end_month() -> None:
     assert balances == [0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 500.0, 500.0, 500.0, 500.0, 500.0]
 
 
+def test_one_thousand_rollouts_identical_when_inputs_are() -> None:
+    """L3: scale the rollout dimension to 1000. With deterministic
+    inputs (no market path, same scenario), every rollout produces
+    the same trajectory. Exercises the polars cross-join expansion
+    of the rollout column at scale; asserts the engine has no
+    Python loop over rollouts (otherwise this would be too slow)."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="employer")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=1000.0),
+            InitialAccountBalance(agent_id="employer", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_paycheck",
+                from_agent_id="employer",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=2000.0,
+            )
+        ],
+        horizon_months=24,
+    )
+    rollout_count = 1000
+
+    result = simulate(scenario, rollout_count=rollout_count)
+
+    # Every rollout: Alice ends at 1000 + 24×2000 = 49000.
+    alice_final = result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 24)).sort(
+        "rollout_index"
+    )
+    assert alice_final.height == rollout_count
+    assert alice_final.get_column("balance_usd").to_list() == [49000.0] * rollout_count
+
+    # Event log expands rollouts × months: 1000 × 24 = 24000 events.
+    assert result.events_log.transfers.height == rollout_count * 24
+
+    # Conservation at every month, across every rollout.
+    totals = (
+        result.cash_balances.group_by(["rollout_index", "month_index"])
+        .agg(pl.col("balance_usd").sum().alias("total"))
+        .sort(["rollout_index", "month_index"])
+    )
+    assert totals.get_column("total").unique().to_list() == [1000.0]
+
+
 def test_combined_one_off_and_recurring() -> None:
     """A scenario with both a recurring monthly paycheck and a
     one-off bonus transfer at month 5. Both fire through the same

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -819,8 +819,8 @@ def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
     and writes one tax_liability row per jurisdiction.
 
     Federal: $200,000 - $14,600 = $185,400 taxable.
-      10% × 11600 + 12% × 35550 + 22% × 53375 + 24% × 84825
-      = 1160.00 + 4266.00 + 11742.50 + 20358.00 = 37526.50
+      10% × 11600 + 12% × 35550 + 22% × 53375 + 24% × 84875
+      = 1160.00 + 4266.00 + 11742.50 + 20370.00 = 37538.50
     California: $200,000 - $5,363 = $194,637 taxable.
       1% × 10412 + 2% × 14272 + 4% × 14275 + 6% × 15122 + 8% × 14269
       + 9.3% × 126287 = 104.12 + 285.44 + 571.00 + 907.32 + 1141.52
@@ -866,7 +866,7 @@ def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
     accruals = result.events_log.tax_accruals.sort("jurisdiction_id")
     assert accruals.height == 2
     accruals_by_jurisdiction = {row["jurisdiction_id"]: row for row in accruals.iter_rows(named=True)}
-    assert accruals_by_jurisdiction["federal_us"]["amount_usd"] == pytest.approx(37526.50, abs=0.01)
+    assert accruals_by_jurisdiction["federal_us"]["amount_usd"] == pytest.approx(37538.50, abs=0.01)
     assert accruals_by_jurisdiction["california"]["amount_usd"] == pytest.approx(14754.09, abs=0.02)
     assert accruals_by_jurisdiction["federal_us"]["month_index"] == 11
     assert accruals_by_jurisdiction["federal_us"]["tax_year_end_month"] == 11
@@ -876,13 +876,16 @@ def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
     end_liabilities = result.tax_liabilities.filter(pl.col("month_index") == 12).sort("jurisdiction_id")
     assert end_liabilities.height == 2
     assert end_liabilities.get_column("amount_owed_usd").to_list()[0] == pytest.approx(14754.09, abs=0.02)
-    assert end_liabilities.get_column("amount_owed_usd").to_list()[1] == pytest.approx(37526.50, abs=0.01)
+    assert end_liabilities.get_column("amount_owed_usd").to_list()[1] == pytest.approx(37538.50, abs=0.01)
 
-    # YTD ordinary income peaks at $200000 at month 11, resets to 0
-    # at month 12 after the year-end accrual fires.
+    # YTD reflects accumulated income across the year; the year-end
+    # reset at month 11 (visible at month_index 12) drops it back
+    # to 0. At month_index 11 (post-month-10) Alice has had 11
+    # paychecks.
     ytd_alice = result.ordinary_income_ytd.filter(pl.col("agent_id") == "alice").sort("month_index")
-    assert ytd_alice.get_column("ordinary_income_usd").to_list()[-2] == pytest.approx(200_000.0, abs=1e-6)
-    assert ytd_alice.get_column("ordinary_income_usd").to_list()[-1] == 0.0
+    ytd_values = ytd_alice.get_column("ordinary_income_usd").to_list()
+    assert ytd_values[11] == pytest.approx(11 * (200_000.0 / 12.0), abs=1e-6)
+    assert ytd_values[12] == 0.0
 
 
 def test_no_tax_profile_means_no_year_end_accrual() -> None:

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -22,6 +22,7 @@ from augur.sim.scenario import (
     Scenario,
     ScheduledAssetSale,
     ScheduledTransfer,
+    TaxProfile,
 )
 from augur.sim.simulate import _initial_state, simulate
 
@@ -810,6 +811,107 @@ def test_gbm_market_diverges_across_rollouts_same_seed_is_reproducible() -> None
         (pl.col("agent_id") == "alice") & (pl.col("month_index") == 6)
     ).get_column("balance_usd")
     assert cash_at_end.n_unique() > 100
+
+
+def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
+    """L7 — Alice gets $200k of W-2 income in year 0. At month 11
+    the engine computes federal + CA tax on (200000 - std_deduction)
+    and writes one tax_liability row per jurisdiction.
+
+    Federal: $200,000 - $14,600 = $185,400 taxable.
+      10% × 11600 + 12% × 35550 + 22% × 53375 + 24% × 84825
+      = 1160.00 + 4266.00 + 11742.50 + 20358.00 = 37526.50
+    California: $200,000 - $5,363 = $194,637 taxable.
+      1% × 10412 + 2% × 14272 + 4% × 14275 + 6% × 15122 + 8% × 14269
+      + 9.3% × 126287 = 104.12 + 285.44 + 571.00 + 907.32 + 1141.52
+      + 11744.69 = 14754.09
+    """
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                end_month=11,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=200_000.0 / 12.0,
+                income_category="ordinary",
+            )
+        ],
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status="single",
+                jurisdiction_ids=["federal_us", "california"],
+                tax_authority_agent_id="irs",
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # 12 paycheck transfers fired (income_category = "ordinary").
+    assert result.events_log.transfers.filter(pl.col("income_category") == "ordinary").height == 12
+
+    # Two tax accruals at month 11 — federal + CA — for one rollout.
+    accruals = result.events_log.tax_accruals.sort("jurisdiction_id")
+    assert accruals.height == 2
+    accruals_by_jurisdiction = {row["jurisdiction_id"]: row for row in accruals.iter_rows(named=True)}
+    assert accruals_by_jurisdiction["federal_us"]["amount_usd"] == pytest.approx(37526.50, abs=0.01)
+    assert accruals_by_jurisdiction["california"]["amount_usd"] == pytest.approx(14754.09, abs=0.02)
+    assert accruals_by_jurisdiction["federal_us"]["month_index"] == 11
+    assert accruals_by_jurisdiction["federal_us"]["tax_year_end_month"] == 11
+
+    # tax_liabilities at end-of-horizon has two rows (one per
+    # jurisdiction) with matching amounts.
+    end_liabilities = result.tax_liabilities.filter(pl.col("month_index") == 12).sort("jurisdiction_id")
+    assert end_liabilities.height == 2
+    assert end_liabilities.get_column("amount_owed_usd").to_list()[0] == pytest.approx(14754.09, abs=0.02)
+    assert end_liabilities.get_column("amount_owed_usd").to_list()[1] == pytest.approx(37526.50, abs=0.01)
+
+    # YTD ordinary income peaks at $200000 at month 11, resets to 0
+    # at month 12 after the year-end accrual fires.
+    ytd_alice = result.ordinary_income_ytd.filter(pl.col("agent_id") == "alice").sort("month_index")
+    assert ytd_alice.get_column("ordinary_income_usd").to_list()[-2] == pytest.approx(200_000.0, abs=1e-6)
+    assert ytd_alice.get_column("ordinary_income_usd").to_list()[-1] == 0.0
+
+
+def test_no_tax_profile_means_no_year_end_accrual() -> None:
+    """If no agent has a tax profile, the year-end accrual emits
+    nothing — confirms the engine doesn't tax non-taxed agents."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=5_000.0,
+                income_category="ordinary",
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    assert result.events_log.tax_accruals.is_empty()
+    assert result.tax_liabilities.is_empty()
 
 
 def test_explicit_sale_price_overrides_market() -> None:

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -12,8 +12,8 @@ import polars as pl
 import pytest
 import pytest_bazel
 
-from augur.sim.apply import apply_events
 from augur.sim.market import DeterministicPath, GeometricBrownianPath, MarketBundle
+from augur.sim.replay import assert_replay_invariant_holds
 from augur.sim.scenario import (
     Agent,
     FloorTriggeredSalePolicy,
@@ -25,7 +25,7 @@ from augur.sim.scenario import (
     ScheduledTransfer,
     TaxProfile,
 )
-from augur.sim.simulate import _initial_state, simulate
+from augur.sim.simulate import simulate
 
 
 def _alice_bob_scenario() -> Scenario:
@@ -79,23 +79,13 @@ def test_alice_gives_bob_five_dollars_one_rollout() -> None:
 
 
 def test_apply_events_is_only_mutation_replays_from_log() -> None:
-    """Replay invariant: re-applying the event log to the initial
-    state from scratch produces the same final cross-section as the
-    incrementally-maintained one. If apply_events ever drifts from
-    the log this test catches it."""
+    """Smoke test for the replay-invariant helper on the L1 baseline
+    scenario. The helper checks every state frame the engine touches;
+    most scenario tests below also invoke it after their assertions to
+    extend the invariant coverage cheaply."""
     scenario = _alice_bob_scenario()
-    rollout_count = 1
-    result = simulate(scenario, rollout_count=rollout_count)
-
-    final_incremental = result.cash_balances.filter(pl.col("month_index") == int(scenario.horizon_months)).sort(
-        ["rollout_index", "agent_id", "account_id"]
-    )
-
-    # Re-derive: apply the entire event log to a fresh initial state.
-    initial = _initial_state(scenario, rollout_count)
-    from_log = apply_events(initial, result.events_log).cash_balances.sort(["rollout_index", "agent_id", "account_id"])
-
-    assert from_log.equals(final_incremental.drop("month_index"))
+    result = simulate(scenario, rollout_count=1)
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_no_scheduled_transfers_leaves_balances_unchanged() -> None:
@@ -303,6 +293,7 @@ def test_combined_one_off_and_recurring() -> None:
         .item()
     )
     assert alice_final == 15000.0
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_initial_lot_partial_sale_consumes_units_credits_proceeds() -> None:
@@ -370,6 +361,7 @@ def test_initial_lot_partial_sale_consumes_units_credits_proceeds() -> None:
     assert disp["units_sold"] == 30.0
     assert disp["cost_basis_consumed_usd"] == 2400.0
     assert disp["proceeds_usd"] == 3600.0
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_initial_lot_full_sale_zeros_remaining_quantity() -> None:
@@ -458,9 +450,8 @@ def test_asset_sale_scales_across_rollouts() -> None:
 
 
 def test_lot_disposition_replay_invariant() -> None:
-    """Replaying the event log from the initial state must
-    reproduce the incremental end-state — for both cash and lots.
-    This catches drift between `apply_events` and the live loop."""
+    """Replay invariant on an L4-style scenario with lot dispositions.
+    Exercises the cap-gains YTD bucket path through the helper."""
     scenario = Scenario(
         agents=[Agent(agent_id="alice")],
         initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=50.0)],
@@ -488,23 +479,8 @@ def test_lot_disposition_replay_invariant() -> None:
         horizon_months=2,
     )
     rollout_count = 3
-
     result = simulate(scenario, rollout_count=rollout_count)
-
-    initial = _initial_state(scenario, rollout_count)
-    replayed = apply_events(initial, result.events_log)
-
-    final_cash = (
-        result.cash_balances.filter(pl.col("month_index") == 2)
-        .drop("month_index")
-        .sort(["rollout_index", "agent_id", "account_id"])
-    )
-    final_lots = (
-        result.asset_lots.filter(pl.col("month_index") == 2).drop("month_index").sort(["rollout_index", "lot_id"])
-    )
-
-    assert replayed.cash_balances.sort(["rollout_index", "agent_id", "account_id"]).equals(final_cash)
-    assert replayed.asset_lots.sort(["rollout_index", "lot_id"]).equals(final_lots)
+    assert_replay_invariant_holds(scenario, result, rollout_count=rollout_count)
 
 
 def test_fifo_sale_crossing_two_lots() -> None:
@@ -582,6 +558,7 @@ def test_fifo_sale_crossing_two_lots() -> None:
         .item()
         == 24000.0
     )
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_fifo_holding_period_classification_per_disposition() -> None:
@@ -887,6 +864,7 @@ def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
     ytd_values = ytd_alice.get_column("ordinary_income_usd").to_list()
     assert ytd_values[11] == pytest.approx(11 * (200_000.0 / 12.0), abs=1e-6)
     assert ytd_values[12] == 0.0
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_year_end_tax_includes_long_term_capital_gain_under_federal_ltcg_schedule() -> None:
@@ -968,6 +946,7 @@ def test_year_end_tax_includes_long_term_capital_gain_under_federal_ltcg_schedul
     row = cg_at_month_11.row(0, named=True)
     assert row["classification"] == "ltcg"
     assert row["gain_usd"] == pytest.approx(20_000.0, abs=1e-6)
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_no_tax_profile_means_no_year_end_accrual() -> None:
@@ -1059,6 +1038,7 @@ def test_year_end_tax_payment_debits_agent_cash() -> None:
         .item()
     )
     assert irs_end_cash == pytest.approx(52_292.59, abs=0.02)
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_tax_payment_can_trigger_rollout_failure_when_unfunded() -> None:
@@ -1124,6 +1104,7 @@ def test_tax_payment_can_trigger_rollout_failure_when_unfunded() -> None:
     assert failures.height == 1
     assert failures.row(0, named=True)["month_index"] == 11
     assert result.rollout_status.row(0, named=True)["status"] == "failed_insufficient_cash"
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_explicit_sale_price_overrides_market() -> None:
@@ -1226,6 +1207,7 @@ def test_floor_triggered_sale_covers_monthly_spend_deficit() -> None:
         .item()
     )
     assert end_cash == pytest.approx(0.0, abs=1e-6)
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 def test_rollout_marked_failed_when_assets_exhausted() -> None:
@@ -1280,6 +1262,7 @@ def test_rollout_marked_failed_when_assets_exhausted() -> None:
     status_row = result.rollout_status.row(0, named=True)
     assert status_row["status"] == "failed_insufficient_cash"
     assert status_row["failed_month"] == 0
+    assert_replay_invariant_holds(scenario, result, rollout_count=1)
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -1,0 +1,128 @@
+"""End-to-end tests for the spike-1 simulator.
+
+L1 baseline: Alice gives Bob $5, single rollout, one-month horizon.
+The simulator advances state via the apply_events pipeline, records
+the transfer on the event log, and produces a long-form
+state-over-time frame that satisfies the conservation invariant.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+import pytest_bazel
+
+from augur.sim.apply import apply_events
+from augur.sim.scenario import Agent, InitialAccountBalance, Scenario, ScheduledTransfer
+from augur.sim.simulate import _initial_state, simulate
+from augur.sim.state import StateCrossSection
+
+
+def _alice_bob_scenario() -> Scenario:
+    return Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="bob")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=10.0),
+            InitialAccountBalance(agent_id="bob", account_id="checking", balance_usd=20.0),
+        ],
+        scheduled_transfers=[
+            ScheduledTransfer(
+                month=0,
+                cause_id="bob_gives_alice_5",
+                from_agent_id="bob",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=5.0,
+            )
+        ],
+        horizon_months=1,
+    )
+
+
+def test_alice_gives_bob_five_dollars_one_rollout() -> None:
+    """One scheduled transfer at month 0 moves $5 from Bob to Alice.
+    After month 0: Alice $15, Bob $15. The transfer is on the log;
+    the post-step cross-section reflects it; total cash in the
+    system is conserved at every month."""
+    result = simulate(_alice_bob_scenario(), rollout_count=1)
+
+    initial = result.cash_balances.filter(pl.col("month_index") == 0).sort("agent_id")
+    assert initial.get_column("balance_usd").to_list() == [10.0, 20.0]
+
+    post = result.cash_balances.filter(pl.col("month_index") == 1).sort("agent_id")
+    assert post.get_column("balance_usd").to_list() == [15.0, 15.0]
+
+    # Conservation invariant: total cash unchanged at every month.
+    totals = (
+        result.cash_balances.group_by("month_index").agg(pl.col("balance_usd").sum().alias("total")).sort("month_index")
+    )
+    assert totals.get_column("total").to_list() == [30.0, 30.0]
+
+    # The transfer is on the log.
+    assert result.events_log.transfers.height == 1
+    txn = result.events_log.transfers.row(0, named=True)
+    assert txn["from_agent_id"] == "bob"
+    assert txn["to_agent_id"] == "alice"
+    assert txn["amount_usd"] == 5.0
+    assert txn["month_index"] == 0
+
+
+def test_apply_events_is_only_mutation_replays_from_log() -> None:
+    """Replay invariant: re-applying the event log to the initial
+    state from scratch produces the same final cross-section as the
+    incrementally-maintained one. If apply_events ever drifts from
+    the log this test catches it."""
+    scenario = _alice_bob_scenario()
+    rollout_count = 1
+    result = simulate(scenario, rollout_count=rollout_count)
+
+    final_incremental = result.cash_balances.filter(pl.col("month_index") == int(scenario.horizon_months)).sort(
+        ["rollout_index", "agent_id", "account_id"]
+    )
+
+    # Re-derive: apply the entire event log to a fresh initial state.
+    initial = _initial_state(scenario, rollout_count)
+    from_log = apply_events(initial, result.events_log).cash_balances.sort(["rollout_index", "agent_id", "account_id"])
+
+    assert from_log.equals(final_incremental.drop("month_index"))
+
+
+def test_no_scheduled_transfers_leaves_balances_unchanged() -> None:
+    """Multi-month horizon with no events should carry initial cash
+    forward unchanged. Exercises the empty-event-log path through
+    the loop."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=100.0)],
+        horizon_months=5,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Six rows: initial month 0 through end-of-horizon month 5.
+    assert result.cash_balances.height == 6
+    assert result.cash_balances.get_column("balance_usd").to_list() == [100.0] * 6
+    assert result.events_log.transfers.is_empty()
+
+
+def test_rejects_zero_rollout_count() -> None:
+    with pytest.raises(ValueError, match="rollout_count"):
+        simulate(_alice_bob_scenario(), rollout_count=0)
+
+
+def test_state_cross_section_is_frozen() -> None:
+    """StateCrossSection must be immutable so that downstream
+    callers can't accidentally mutate state mid-step."""
+    initial = _initial_state(_alice_bob_scenario(), rollout_count=1)
+    assert isinstance(initial, StateCrossSection)
+    try:
+        initial.cash_balances = pl.DataFrame()
+    except (AttributeError, TypeError):
+        return
+    msg = "expected StateCrossSection to be frozen"
+    raise AssertionError(msg)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -841,8 +841,8 @@ def test_explicit_sale_price_overrides_market() -> None:
                 proceeds_account_id="checking",
             )
         ],
-        market=MarketBundle(paths=[DeterministicPath(asset_id="vti", prices_usd=[10.0, 10.0])]),
-        horizon_months=1,
+        market=MarketBundle(paths=[DeterministicPath(asset_id="vti", prices_usd=[10.0, 10.0, 10.0])]),
+        horizon_months=2,
     )
 
     result = simulate(scenario, rollout_count=1)

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -888,6 +888,87 @@ def test_year_end_tax_accrual_federal_and_california_single_filer() -> None:
     assert ytd_values[12] == 0.0
 
 
+def test_year_end_tax_includes_long_term_capital_gain_under_federal_ltcg_schedule() -> None:
+    """L8 — Alice gets $50k W-2 wages, plus sells a long-held VTI
+    lot (24 months pre-horizon) for a $20k gain at month 6.
+
+    Federal taxable ordinary = 50000 - 14600 = 35400.
+      10% × 11600 + 12% × 23800 = 1160 + 2856 = 4016.
+    LTCG stacks above ordinary. The 0% bracket ends at 47025, so
+    11625 of LTCG falls in 0%; the remaining 8375 falls in 15%.
+      LTCG tax = 8375 × 0.15 = 1256.25.
+    Federal total = 4016 + 1256.25 = 5272.25.
+
+    California taxes LTCG as ordinary income.
+      Total CA taxable = 50000 + 20000 - 5363 = 64637.
+      1% × 10412 + 2% × 14272 + 4% × 14275 + 6% × 15122 + 8% × 10556
+      = 104.12 + 285.44 + 571.00 + 907.32 + 844.48 = 2712.36."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_long_vti",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-24,
+                quantity=10.0,
+                cost_basis_per_unit_usd=80.0,
+            )
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                end_month=11,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=50_000.0 / 12.0,
+                income_category="ordinary",
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=6,
+                cause_id="alice_long_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=10.0,
+                price_per_unit_usd=280.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status="single",
+                jurisdiction_ids=["federal_us", "california"],
+                tax_authority_agent_id="irs",
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    accruals = {row["jurisdiction_id"]: row for row in result.events_log.tax_accruals.iter_rows(named=True)}
+    assert accruals["federal_us"]["amount_usd"] == pytest.approx(5272.25, abs=0.01)
+    assert accruals["california"]["amount_usd"] == pytest.approx(2712.36, abs=0.01)
+
+    # YTD captured the LTCG ($20k) before year-end reset.
+    cg_at_month_11 = result.capital_gains_ytd.filter((pl.col("month_index") == 11) & (pl.col("agent_id") == "alice"))
+    assert cg_at_month_11.height == 1
+    row = cg_at_month_11.row(0, named=True)
+    assert row["classification"] == "ltcg"
+    assert row["gain_usd"] == pytest.approx(20_000.0, abs=1e-6)
+
+
 def test_no_tax_profile_means_no_year_end_accrual() -> None:
     """If no agent has a tax profile, the year-end accrual emits
     nothing — confirms the engine doesn't tax non-taxed agents."""

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -999,6 +999,133 @@ def test_no_tax_profile_means_no_year_end_accrual() -> None:
     assert result.tax_liabilities.is_empty()
 
 
+def test_year_end_tax_payment_debits_agent_cash() -> None:
+    """The year-end tax accrual is mirrored into a transfer event
+    from the taxed agent's checking to the tax authority. Alice
+    earns $200k of W-2 income across year 0; at month 11 the
+    engine emits one tax-payment transfer per jurisdiction whose
+    amount matches the accrual. End-of-year cash reflects the
+    payments having gone out."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                end_month=11,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=200_000.0 / 12.0,
+                income_category="ordinary",
+            )
+        ],
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status="single",
+                jurisdiction_ids=["federal_us", "california"],
+                tax_authority_agent_id="irs",
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Year-end tax: $37538.50 federal + $14754.09 CA = $52292.59.
+    tax_payments = result.events_log.transfers.filter(pl.col("cause_id").str.contains("_payment"))
+    assert tax_payments.height == 2
+    assert tax_payments.get_column("amount_usd").sum() == pytest.approx(52_292.59, abs=0.02)
+    # Tax payments fire at year-end month 11.
+    assert set(tax_payments.get_column("month_index").to_list()) == {11}
+    # Cash flow: $200k income - $52292.59 tax = $147707.41 at end of horizon.
+    alice_end_cash = (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 12))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert alice_end_cash == pytest.approx(200_000.0 - 52_292.59, abs=0.02)
+    # The IRS sink accumulates the tax inflows.
+    irs_end_cash = (
+        result.cash_balances.filter((pl.col("agent_id") == "irs") & (pl.col("month_index") == 12))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert irs_end_cash == pytest.approx(52_292.59, abs=0.02)
+
+
+def test_tax_payment_can_trigger_rollout_failure_when_unfunded() -> None:
+    """When the tax-payment transfer at year-end exceeds the
+    agent's cash plus liquidatable assets, the floor-triggered
+    sale policy tries to cover, and the rollout-failure detector
+    fires when even that fails. The "mandatory obligation that
+    fails the scenario if unpaid" pattern works for any cash
+    outflow — taxes here, rent in other tests, later mortgages."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="payroll"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="payroll", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                end_month=11,
+                cause_id="alice_paycheck",
+                from_agent_id="payroll",
+                from_account_id="checking",
+                to_agent_id="alice",
+                to_account_id="checking",
+                amount_usd=500_000.0 / 12.0,  # big tax bill
+                income_category="ordinary",
+            ),
+            RecurringTransfer(
+                start_month=0,
+                end_month=11,
+                cause_id="alice_rent",
+                from_agent_id="alice",
+                from_account_id="checking",
+                to_agent_id="payroll",  # use payroll as sink
+                to_account_id="checking",
+                amount_usd=500_000.0 / 12.0,  # spend it all on rent
+            ),
+        ],
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status="single",
+                jurisdiction_ids=["federal_us", "california"],
+                tax_authority_agent_id="irs",
+            )
+        ],
+        floor_triggered_sale_policies=[
+            FloorTriggeredSalePolicy(
+                agent_id="alice",
+                account_id="checking",
+                floor_usd=0.0,
+                asset_preference_chain=[],  # no assets to sell
+            )
+        ],
+        horizon_months=12,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    # Alice has $0 cash at year-end (income == rent), no assets,
+    # but the tax bill arrives. Failure event fires at month 11.
+    failures = result.events_log.rollout_failures
+    assert failures.height == 1
+    assert failures.row(0, named=True)["month_index"] == 11
+    assert result.rollout_status.row(0, named=True)["status"] == "failed_insufficient_cash"
+
+
 def test_explicit_sale_price_overrides_market() -> None:
     """If `ScheduledAssetSale.price_per_unit_usd` is set the engine
     uses that scalar; market is ignored for that sale. This is the

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -13,7 +13,15 @@ import pytest
 import pytest_bazel
 
 from augur.sim.apply import apply_events
-from augur.sim.scenario import Agent, InitialAccountBalance, RecurringTransfer, Scenario, ScheduledTransfer
+from augur.sim.scenario import (
+    Agent,
+    InitialAccountBalance,
+    InitialLot,
+    RecurringTransfer,
+    Scenario,
+    ScheduledAssetSale,
+    ScheduledTransfer,
+)
 from augur.sim.simulate import _initial_state, simulate
 
 
@@ -292,6 +300,208 @@ def test_combined_one_off_and_recurring() -> None:
         .item()
     )
     assert alice_final == 15000.0
+
+
+def test_initial_lot_partial_sale_consumes_units_credits_proceeds() -> None:
+    """L4 part A — single-lot scenario. Alice has 100 units of VTI
+    bought 24 months pre-horizon at $80/unit (so cost basis $8000).
+    At month 3 she sells 30 units at $120/unit; proceeds = $3600
+    credit to checking. After the sale: lot has 70 units remaining,
+    cash up by $3600. One lot_disposition row records the FIFO
+    consumption with cost_basis_consumed = 30 × $80 = $2400."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_vti_seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-24,
+                quantity=100.0,
+                cost_basis_per_unit_usd=80.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=3,
+                cause_id="alice_partial_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=30.0,
+                price_per_unit_usd=120.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=6,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Pre-sale: month 3 cross-section still has 100 units (apply for
+    # month M produces the M+1 cross-section).
+    lots_at_m3 = result.asset_lots.filter(pl.col("month_index") == 3)
+    assert lots_at_m3.get_column("remaining_quantity").to_list() == [100.0]
+
+    # Post-sale: month 4 onward, 70 units remain.
+    for month in (4, 5, 6):
+        snapshot = result.asset_lots.filter(pl.col("month_index") == month)
+        assert snapshot.get_column("remaining_quantity").to_list() == [70.0]
+
+    # Cash: 0 at month 0..3, then $3600 at month 4 onward.
+    cash_trajectory = (
+        result.cash_balances.filter(pl.col("agent_id") == "alice")
+        .sort("month_index")
+        .get_column("balance_usd")
+        .to_list()
+    )
+    assert cash_trajectory == [0.0, 0.0, 0.0, 0.0, 3600.0, 3600.0, 3600.0]
+
+    # Disposition log: one row, with FIFO from the seeded lot.
+    assert result.events_log.lot_dispositions.height == 1
+    disp = result.events_log.lot_dispositions.row(0, named=True)
+    assert disp["lot_id"] == "alice_vti_seed"
+    assert disp["cause_id"] == "alice_partial_sale"
+    assert disp["month_index"] == 3
+    assert disp["purchase_month_index"] == -24
+    assert disp["units_sold"] == 30.0
+    assert disp["cost_basis_consumed_usd"] == 2400.0
+    assert disp["proceeds_usd"] == 3600.0
+
+
+def test_initial_lot_full_sale_zeros_remaining_quantity() -> None:
+    """Selling all 100 units exhausts the lot. Remaining quantity
+    drops to 0; the lot row persists in the asset_lots frame with
+    `remaining_quantity = 0` (lots are not deleted on full
+    disposition — they remain in state for historical reference)."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_vti_seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-12,
+                quantity=100.0,
+                cost_basis_per_unit_usd=90.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=2,
+                cause_id="full_liquidation",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=100.0,
+                price_per_unit_usd=150.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=3,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    remaining_after = result.asset_lots.filter(pl.col("month_index") == 3).get_column("remaining_quantity").item()
+    assert remaining_after == 0.0
+
+    assert result.events_log.lot_dispositions.height == 1
+    disp = result.events_log.lot_dispositions.row(0, named=True)
+    assert disp["units_sold"] == 100.0
+    assert disp["proceeds_usd"] == 15000.0
+    assert disp["cost_basis_consumed_usd"] == 9000.0
+
+
+def test_asset_sale_scales_across_rollouts() -> None:
+    """The lot frame fans across rollouts identically when inputs
+    are deterministic; the disposition resolution is vectorized
+    over the rollout dimension."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=0,
+                quantity=50.0,
+                cost_basis_per_unit_usd=100.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=1,
+                cause_id="sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=20.0,
+                price_per_unit_usd=110.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=2,
+    )
+    rollout_count = 100
+    result = simulate(scenario, rollout_count=rollout_count)
+
+    # Every rollout has one disposition.
+    assert result.events_log.lot_dispositions.height == rollout_count
+    # Every rollout's lot row at end-of-horizon has 30 units remaining.
+    end_state = result.asset_lots.filter(pl.col("month_index") == 2)
+    assert end_state.height == rollout_count
+    assert end_state.get_column("remaining_quantity").unique().to_list() == [30.0]
+
+
+def test_lot_disposition_replay_invariant() -> None:
+    """Replaying the event log from the initial state must
+    reproduce the incremental end-state — for both cash and lots.
+    This catches drift between `apply_events` and the live loop."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=50.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-6,
+                quantity=40.0,
+                cost_basis_per_unit_usd=75.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=1,
+                cause_id="partial",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=10.0,
+                price_per_unit_usd=200.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=2,
+    )
+    rollout_count = 3
+
+    result = simulate(scenario, rollout_count=rollout_count)
+
+    initial = _initial_state(scenario, rollout_count)
+    replayed = apply_events(initial, result.events_log)
+
+    final_cash = (
+        result.cash_balances.filter(pl.col("month_index") == 2)
+        .drop("month_index")
+        .sort(["rollout_index", "agent_id", "account_id"])
+    )
+    final_lots = (
+        result.asset_lots.filter(pl.col("month_index") == 2).drop("month_index").sort(["rollout_index", "lot_id"])
+    )
+
+    assert replayed.cash_balances.sort(["rollout_index", "agent_id", "account_id"]).equals(final_cash)
+    assert replayed.asset_lots.sort(["rollout_index", "lot_id"]).equals(final_lots)
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -504,5 +504,204 @@ def test_lot_disposition_replay_invariant() -> None:
     assert replayed.asset_lots.sort(["rollout_index", "lot_id"]).equals(final_lots)
 
 
+def test_fifo_sale_crossing_two_lots() -> None:
+    """L4 part B — multi-lot FIFO crossing. Alice has two lots of
+    VTI: lot A (older, 6 months pre-horizon, 100 units @ $80) and
+    lot B (month 2, 50 units @ $100). At month 8 she sells 120
+    units at $200/unit; FIFO consumes the full 100 units of lot A
+    plus 20 units of lot B. Proceeds = 120 × $200 = $24000."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="lot_a_old",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-6,
+                quantity=100.0,
+                cost_basis_per_unit_usd=80.0,
+            ),
+            InitialLot(
+                lot_id="lot_b_younger",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=2,
+                quantity=50.0,
+                cost_basis_per_unit_usd=100.0,
+            ),
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=8,
+                cause_id="big_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=120.0,
+                price_per_unit_usd=200.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=10,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Two disposition rows for one sale (FIFO crossed two lots).
+    assert result.events_log.lot_dispositions.height == 2
+    by_lot = {
+        row["lot_id"]: row
+        for row in result.events_log.lot_dispositions.sort("purchase_month_index").iter_rows(named=True)
+    }
+    assert by_lot["lot_a_old"]["units_sold"] == 100.0
+    assert by_lot["lot_a_old"]["cost_basis_consumed_usd"] == 8000.0
+    assert by_lot["lot_a_old"]["proceeds_usd"] == 20000.0
+    assert by_lot["lot_b_younger"]["units_sold"] == 20.0
+    assert by_lot["lot_b_younger"]["cost_basis_consumed_usd"] == 2000.0
+    assert by_lot["lot_b_younger"]["proceeds_usd"] == 4000.0
+
+    # Post-sale lot snapshot: lot A is empty, lot B has 30 units.
+    post = (
+        result.asset_lots.filter(pl.col("month_index") == 9)
+        .sort("lot_id")
+        .select("lot_id", "remaining_quantity")
+        .to_dicts()
+    )
+    assert post == [
+        {"lot_id": "lot_a_old", "remaining_quantity": 0.0},
+        {"lot_id": "lot_b_younger", "remaining_quantity": 30.0},
+    ]
+
+    # Cash credited with full $24000.
+    assert (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 9))
+        .get_column("balance_usd")
+        .item()
+        == 24000.0
+    )
+
+
+def test_fifo_holding_period_classification_per_disposition() -> None:
+    """The disposition log carries `purchase_month_index` and
+    sale-time `month_index` so downstream tax classification can
+    compute holding period = sale - purchase per disposition row.
+    LTCG split happens at 12 months; here the older lot is 18
+    months old (LTCG) and the younger lot is 4 months old (STCG)."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="long_held",
+                agent_id="alice",
+                asset_id="btc",
+                purchase_month_index=-12,
+                quantity=2.0,
+                cost_basis_per_unit_usd=20000.0,
+            ),
+            InitialLot(
+                lot_id="short_held",
+                agent_id="alice",
+                asset_id="btc",
+                purchase_month_index=2,
+                quantity=1.0,
+                cost_basis_per_unit_usd=40000.0,
+            ),
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=6,
+                cause_id="liquidate",
+                agent_id="alice",
+                asset_id="btc",
+                quantity=2.5,
+                price_per_unit_usd=60000.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        horizon_months=7,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    dispositions = result.events_log.lot_dispositions.with_columns(
+        holding_period_months=pl.col("month_index") - pl.col("purchase_month_index")
+    ).sort("purchase_month_index")
+
+    rows = dispositions.iter_rows(named=True)
+    long_disp = next(rows)
+    short_disp = next(rows)
+
+    assert long_disp["lot_id"] == "long_held"
+    assert long_disp["holding_period_months"] == 18  # ≥12 → LTCG
+    assert long_disp["units_sold"] == 2.0
+    assert short_disp["lot_id"] == "short_held"
+    assert short_disp["holding_period_months"] == 4  # <12 → STCG
+    assert short_disp["units_sold"] == 0.5
+
+
+def test_sales_of_two_different_assets_are_independent() -> None:
+    """Two sales at different months on different assets resolve
+    against their own lots independently. Tests that the
+    `(agent, asset)` filter in FIFO doesn't bleed across assets."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="vti_lot",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=0,
+                quantity=10.0,
+                cost_basis_per_unit_usd=100.0,
+            ),
+            InitialLot(
+                lot_id="qqq_lot",
+                agent_id="alice",
+                asset_id="qqq",
+                purchase_month_index=0,
+                quantity=10.0,
+                cost_basis_per_unit_usd=200.0,
+            ),
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=2,
+                cause_id="sell_vti",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=4.0,
+                price_per_unit_usd=150.0,
+                proceeds_account_id="checking",
+            ),
+            ScheduledAssetSale(
+                month=5,
+                cause_id="sell_qqq",
+                agent_id="alice",
+                asset_id="qqq",
+                quantity=3.0,
+                price_per_unit_usd=250.0,
+                proceeds_account_id="checking",
+            ),
+        ],
+        horizon_months=6,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    assert result.events_log.lot_dispositions.height == 2
+
+    end_lots = result.asset_lots.filter(pl.col("month_index") == 6).sort("lot_id")
+    by_lot = {row["lot_id"]: row["remaining_quantity"] for row in end_lots.iter_rows(named=True)}
+    assert by_lot == {"qqq_lot": 7.0, "vti_lot": 6.0}
+
+    # Cash: 4×150 + 3×250 = $1350.
+    assert (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 6))
+        .get_column("balance_usd")
+        .item()
+        == 1350.0
+    )
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -13,6 +13,7 @@ import pytest
 import pytest_bazel
 
 from augur.sim.apply import apply_events
+from augur.sim.market import DeterministicPath, GeometricBrownianPath, MarketBundle
 from augur.sim.scenario import (
     Agent,
     InitialAccountBalance,
@@ -701,6 +702,151 @@ def test_sales_of_two_different_assets_are_independent() -> None:
         .item()
         == 1350.0
     )
+
+
+def test_market_driven_sale_uses_deterministic_price_curve() -> None:
+    """L5 — when a ScheduledAssetSale omits `price_per_unit_usd`,
+    the engine reads the per-month price from the scenario's
+    MarketBundle. With a DeterministicPath the price is identical
+    across rollouts; the sale's proceeds reflect the configured
+    month-N price."""
+    horizon = 6
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-3,
+                quantity=10.0,
+                cost_basis_per_unit_usd=90.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=4,
+                cause_id="market_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=4.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        market=MarketBundle(
+            paths=[DeterministicPath(asset_id="vti", prices_usd=[100.0, 110.0, 120.0, 130.0, 150.0, 160.0, 170.0])]
+        ),
+        horizon_months=horizon,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Sale at month 4 used the month-4 price of $150 → 4 × 150 = $600.
+    assert result.events_log.lot_dispositions.height == 1
+    disp = result.events_log.lot_dispositions.row(0, named=True)
+    assert disp["units_sold"] == 4.0
+    assert disp["proceeds_usd"] == 600.0
+
+    # Market prices on the run match the configured path.
+    vti = result.market_prices.filter(pl.col("asset_id") == "vti").sort("month_index")
+    assert vti.get_column("price_per_unit_usd").to_list() == [100.0, 110.0, 120.0, 130.0, 150.0, 160.0, 170.0]
+
+
+def test_gbm_market_diverges_across_rollouts_same_seed_is_reproducible() -> None:
+    """L10.1 — GBM paths produce different per-rollout trajectories
+    (so sale proceeds differ across rollouts) but a fixed `rng_seed`
+    reproduces the same prices across runs."""
+    bundle = MarketBundle(
+        paths=[
+            GeometricBrownianPath(
+                asset_id="vti",
+                initial_price_usd=100.0,
+                monthly_log_return_mu=0.005,
+                monthly_log_return_sigma=0.05,
+                rng_seed=42,
+            )
+        ]
+    )
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=0,
+                quantity=5.0,
+                cost_basis_per_unit_usd=100.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=3,
+                cause_id="market_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=5.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        market=bundle,
+        horizon_months=6,
+    )
+
+    result_a = simulate(scenario, rollout_count=200)
+    result_b = simulate(scenario, rollout_count=200)
+
+    # Reproducibility: same seed → same prices across two runs.
+    assert result_a.market_prices.sort(["rollout_index", "month_index"]).equals(
+        result_b.market_prices.sort(["rollout_index", "month_index"])
+    )
+
+    # Divergence: distinct per-rollout proceeds — far more than one
+    # cluster, but bounded by the GBM variance. Loose check: at
+    # least 100 distinct cash balances across 200 rollouts.
+    cash_at_end = result_a.cash_balances.filter(
+        (pl.col("agent_id") == "alice") & (pl.col("month_index") == 6)
+    ).get_column("balance_usd")
+    assert cash_at_end.n_unique() > 100
+
+
+def test_explicit_sale_price_overrides_market() -> None:
+    """If `ScheduledAssetSale.price_per_unit_usd` is set the engine
+    uses that scalar; market is ignored for that sale. This is the
+    test-fixture path used in L4 tests; still valid in the
+    market-aware engine."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice")],
+        initial_cash=[InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0)],
+        initial_lots=[
+            InitialLot(
+                lot_id="seed",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=0,
+                quantity=10.0,
+                cost_basis_per_unit_usd=50.0,
+            )
+        ],
+        scheduled_asset_sales=[
+            ScheduledAssetSale(
+                month=1,
+                cause_id="fixed_sale",
+                agent_id="alice",
+                asset_id="vti",
+                quantity=3.0,
+                price_per_unit_usd=99.0,
+                proceeds_account_id="checking",
+            )
+        ],
+        market=MarketBundle(paths=[DeterministicPath(asset_id="vti", prices_usd=[10.0, 10.0])]),
+        horizon_months=1,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+    assert result.events_log.lot_dispositions.get_column("proceeds_usd").item() == 3.0 * 99.0
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -16,6 +16,7 @@ from augur.sim.apply import apply_events
 from augur.sim.market import DeterministicPath, GeometricBrownianPath, MarketBundle
 from augur.sim.scenario import (
     Agent,
+    FloorTriggeredSalePolicy,
     InitialAccountBalance,
     InitialLot,
     RecurringTransfer,
@@ -1033,6 +1034,125 @@ def test_explicit_sale_price_overrides_market() -> None:
 
     result = simulate(scenario, rollout_count=1)
     assert result.events_log.lot_dispositions.get_column("proceeds_usd").item() == 3.0 * 99.0
+
+
+def test_floor_triggered_sale_covers_monthly_spend_deficit() -> None:
+    """L9 — Alice has $1k cash, a $5k/month spend, and 100 units of
+    VTI at $100/unit market price. The floor-triggered sale policy
+    has floor $0 + replenish buffer $0: any deficit triggers asset
+    sale. At month 0, cash falls to -$4k after spending; the policy
+    sells $4k of VTI (40 units) to bring cash back to $0. Spends
+    repeat each month; the policy keeps selling until 100 units
+    are exhausted."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="landlord")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=1000.0),
+            InitialAccountBalance(agent_id="landlord", account_id="checking", balance_usd=0.0),
+        ],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_vti",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-1,
+                quantity=100.0,
+                cost_basis_per_unit_usd=50.0,
+            )
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_rent",
+                from_agent_id="alice",
+                from_account_id="checking",
+                to_agent_id="landlord",
+                to_account_id="checking",
+                amount_usd=5000.0,
+            )
+        ],
+        market=MarketBundle(paths=[DeterministicPath(asset_id="vti", prices_usd=[100.0] * 4)]),
+        floor_triggered_sale_policies=[
+            FloorTriggeredSalePolicy(
+                agent_id="alice",
+                account_id="checking",
+                floor_usd=0.0,
+                replenish_buffer_usd=0.0,
+                asset_preference_chain=["vti"],
+            )
+        ],
+        horizon_months=3,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Month-0 sale: deficit was 4000, sold 40 units at $100 = $4000.
+    m0_dispositions = result.events_log.lot_dispositions.filter(pl.col("month_index") == 0)
+    assert m0_dispositions.height == 1
+    assert m0_dispositions.row(0, named=True)["units_sold"] == pytest.approx(40.0, abs=1e-6)
+    assert m0_dispositions.row(0, named=True)["proceeds_usd"] == pytest.approx(4000.0, abs=1e-6)
+
+    # End-of-horizon (month 3) cash for Alice should be at the floor (0).
+    end_cash = (
+        result.cash_balances.filter((pl.col("agent_id") == "alice") & (pl.col("month_index") == 3))
+        .get_column("balance_usd")
+        .item()
+    )
+    assert end_cash == pytest.approx(0.0, abs=1e-6)
+
+
+def test_rollout_marked_failed_when_assets_exhausted() -> None:
+    """L11 — when the agent's preference chain is exhausted but
+    cash still negative, the engine marks the rollout failed."""
+    scenario = Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="landlord")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="landlord", account_id="checking", balance_usd=0.0),
+        ],
+        initial_lots=[
+            InitialLot(
+                lot_id="alice_vti",
+                agent_id="alice",
+                asset_id="vti",
+                purchase_month_index=-1,
+                quantity=5.0,  # only $500 of VTI at $100/unit
+                cost_basis_per_unit_usd=80.0,
+            )
+        ],
+        recurring_transfers=[
+            RecurringTransfer(
+                start_month=0,
+                cause_id="alice_rent",
+                from_agent_id="alice",
+                from_account_id="checking",
+                to_agent_id="landlord",
+                to_account_id="checking",
+                amount_usd=1000.0,
+            )
+        ],
+        market=MarketBundle(paths=[DeterministicPath(asset_id="vti", prices_usd=[100.0, 100.0])]),
+        floor_triggered_sale_policies=[
+            FloorTriggeredSalePolicy(
+                agent_id="alice", account_id="checking", floor_usd=0.0, asset_preference_chain=["vti"]
+            )
+        ],
+        horizon_months=1,
+    )
+
+    result = simulate(scenario, rollout_count=1)
+
+    # Failure event fired at month 0: spend 1000, sold $500 of VTI,
+    # still -$500 left.
+    assert result.events_log.rollout_failures.height == 1
+    failure = result.events_log.rollout_failures.row(0, named=True)
+    assert failure["month_index"] == 0
+    assert failure["deficit_usd"] == pytest.approx(500.0, abs=1e-6)
+    assert failure["agent_id"] == "alice"
+
+    status_row = result.rollout_status.row(0, named=True)
+    assert status_row["status"] == "failed_insufficient_cash"
+    assert status_row["failed_month"] == 0
 
 
 if __name__ == "__main__":

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -916,7 +916,7 @@ def test_year_end_tax_includes_long_term_capital_gain_under_federal_ltcg_schedul
                 agent_id="alice",
                 asset_id="vti",
                 purchase_month_index=-24,
-                quantity=10.0,
+                quantity=100.0,
                 cost_basis_per_unit_usd=80.0,
             )
         ],
@@ -939,7 +939,7 @@ def test_year_end_tax_includes_long_term_capital_gain_under_federal_ltcg_schedul
                 cause_id="alice_long_sale",
                 agent_id="alice",
                 asset_id="vti",
-                quantity=10.0,
+                quantity=100.0,
                 price_per_unit_usd=280.0,
                 proceeds_account_id="checking",
             )

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -1037,13 +1037,13 @@ def test_explicit_sale_price_overrides_market() -> None:
 
 
 def test_floor_triggered_sale_covers_monthly_spend_deficit() -> None:
-    """L9 — Alice has $1k cash, a $5k/month spend, and 100 units of
+    """L9 — Alice has $1k cash, a $5k/month spend, and 200 units of
     VTI at $100/unit market price. The floor-triggered sale policy
     has floor $0 + replenish buffer $0: any deficit triggers asset
     sale. At month 0, cash falls to -$4k after spending; the policy
-    sells $4k of VTI (40 units) to bring cash back to $0. Spends
-    repeat each month; the policy keeps selling until 100 units
-    are exhausted."""
+    sells $4k of VTI (40 units) to bring cash back to $0. The lot
+    is large enough to cover all three months of spend, so cash
+    stays at the floor through end-of-horizon."""
     scenario = Scenario(
         agents=[Agent(agent_id="alice"), Agent(agent_id="landlord")],
         initial_cash=[
@@ -1056,7 +1056,7 @@ def test_floor_triggered_sale_covers_monthly_spend_deficit() -> None:
                 agent_id="alice",
                 asset_id="vti",
                 purchase_month_index=-1,
-                quantity=100.0,
+                quantity=200.0,
                 cost_basis_per_unit_usd=50.0,
             )
         ],

--- a/augur/sim/state.py
+++ b/augur/sim/state.py
@@ -1,0 +1,31 @@
+"""Working-state cross-section at one month boundary.
+
+`StateCrossSection` carries the per-month polars frames the engine
+reads and writes. At spike 1 there's only the `cash_balances` frame;
+later layers add `asset_lots`, `liabilities`, `property_state`,
+`property_stakes`, `rollout_status`.
+
+Schemas drop the `month_index` column — the cross-section is one
+month wide. The simulate loop tags rows with their month when it
+appends them to the growing long-form state frames at output time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+
+CASH_BALANCES_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "agent_id": pl.Utf8(),
+    "account_id": pl.Utf8(),
+    "balance_usd": pl.Float64(),
+}
+
+
+@dataclass(frozen=True)
+class StateCrossSection:
+    """State at one month boundary, one polars frame per state kind."""
+
+    cash_balances: pl.DataFrame

--- a/augur/sim/state.py
+++ b/augur/sim/state.py
@@ -58,6 +58,17 @@ CAPITAL_GAINS_YTD_SCHEMA: dict[str, pl.DataType] = {
     "gain_usd": pl.Float64(),
 }
 
+# Per-rollout terminal status. "active" is the only running state;
+# `"failed_insufficient_cash"` is set once and not cleared (L11.2:
+# failed rollouts stay failed). One row per rollout regardless of
+# how many agents are in the scenario — the failure is a property
+# of the rollout, not of an agent.
+ROLLOUT_STATUS_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "status": pl.Utf8(),
+    "failed_month": pl.Int64(),
+}
+
 # An asset lot is a tax-relevant unit-of-acquisition: a quantity of
 # some asset bought at a specific time at a specific per-unit cost
 # basis. Sales consume from lots in some order (FIFO for spike 1);
@@ -88,3 +99,4 @@ class StateCrossSection:
     ordinary_income_ytd: pl.DataFrame
     capital_gains_ytd: pl.DataFrame
     tax_liabilities: pl.DataFrame
+    rollout_status: pl.DataFrame

--- a/augur/sim/state.py
+++ b/augur/sim/state.py
@@ -23,6 +23,28 @@ CASH_BALANCES_SCHEMA: dict[str, pl.DataType] = {
     "balance_usd": pl.Float64(),
 }
 
+# Running total of ordinary (W-2-style) income for the current tax
+# year, per `(rollout_index, agent_id)`. Reset to 0 by year-end
+# tax accrual events. Only taxed agents have rows here (the engine
+# initializes one row per `TaxProfile.agent_id` per rollout).
+ORDINARY_INCOME_YTD_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "agent_id": pl.Utf8(),
+    "ordinary_income_usd": pl.Float64(),
+}
+
+# Outstanding tax liabilities — money owed to a tax authority that
+# hasn't been paid yet. The year-end accrual event creates one row
+# per `(rollout, agent, jurisdiction, tax_year_end_month)`; later
+# layers reduce `amount_owed_usd` as payments fire.
+TAX_LIABILITIES_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "agent_id": pl.Utf8(),
+    "jurisdiction_id": pl.Utf8(),
+    "tax_year_end_month": pl.Int64(),
+    "amount_owed_usd": pl.Float64(),
+}
+
 # An asset lot is a tax-relevant unit-of-acquisition: a quantity of
 # some asset bought at a specific time at a specific per-unit cost
 # basis. Sales consume from lots in some order (FIFO for spike 1);
@@ -50,3 +72,5 @@ class StateCrossSection:
 
     cash_balances: pl.DataFrame
     asset_lots: pl.DataFrame
+    ordinary_income_ytd: pl.DataFrame
+    tax_liabilities: pl.DataFrame

--- a/augur/sim/state.py
+++ b/augur/sim/state.py
@@ -1,9 +1,9 @@
 """Working-state cross-section at one month boundary.
 
 `StateCrossSection` carries the per-month polars frames the engine
-reads and writes. At spike 1 there's only the `cash_balances` frame;
-later layers add `asset_lots`, `liabilities`, `property_state`,
-`property_stakes`, `rollout_status`.
+reads and writes. At spike 1 step 4 there are two frames:
+`cash_balances` and `asset_lots`. Later layers add `liabilities`,
+`property_state`, `property_stakes`, `rollout_status`.
 
 Schemas drop the `month_index` column — the cross-section is one
 month wide. The simulate loop tags rows with their month when it
@@ -23,9 +23,30 @@ CASH_BALANCES_SCHEMA: dict[str, pl.DataType] = {
     "balance_usd": pl.Float64(),
 }
 
+# An asset lot is a tax-relevant unit-of-acquisition: a quantity of
+# some asset bought at a specific time at a specific per-unit cost
+# basis. Sales consume from lots in some order (FIFO for spike 1);
+# the holding period from `purchase_month_index` determines LTCG vs
+# STCG classification in later layers. `remaining_quantity` shrinks
+# as the lot is sold off and reaches 0 when fully disposed.
+#
+# `(rollout_index, lot_id)` is the unique key: the same configured
+# lot fans out into one row per rollout so different rollouts can
+# diverge in remaining_quantity if their sale paths differ.
+ASSET_LOT_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "lot_id": pl.Utf8(),
+    "agent_id": pl.Utf8(),
+    "asset_id": pl.Utf8(),
+    "purchase_month_index": pl.Int64(),
+    "cost_basis_per_unit_usd": pl.Float64(),
+    "remaining_quantity": pl.Float64(),
+}
+
 
 @dataclass(frozen=True)
 class StateCrossSection:
     """State at one month boundary, one polars frame per state kind."""
 
     cash_balances: pl.DataFrame
+    asset_lots: pl.DataFrame

--- a/augur/sim/state.py
+++ b/augur/sim/state.py
@@ -45,6 +45,19 @@ TAX_LIABILITIES_SCHEMA: dict[str, pl.DataType] = {
     "amount_owed_usd": pl.Float64(),
 }
 
+# Running total of net capital gains for the current tax year, per
+# `(rollout_index, agent_id, classification)` where `classification`
+# is one of {"ltcg", "stcg"}. Reset at year-end alongside ordinary
+# income. The split is determined at the lot_disposition level by
+# `holding_period = sale_month - purchase_month` against the 12-
+# month LTCG threshold.
+CAPITAL_GAINS_YTD_SCHEMA: dict[str, pl.DataType] = {
+    "rollout_index": pl.Int64(),
+    "agent_id": pl.Utf8(),
+    "classification": pl.Utf8(),
+    "gain_usd": pl.Float64(),
+}
+
 # An asset lot is a tax-relevant unit-of-acquisition: a quantity of
 # some asset bought at a specific time at a specific per-unit cost
 # basis. Sales consume from lots in some order (FIFO for spike 1);
@@ -73,4 +86,5 @@ class StateCrossSection:
     cash_balances: pl.DataFrame
     asset_lots: pl.DataFrame
     ordinary_income_ytd: pl.DataFrame
+    capital_gains_ytd: pl.DataFrame
     tax_liabilities: pl.DataFrame

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -35,7 +35,7 @@ from augur.sim.jurisdictions import Jurisdiction
 from augur.sim.market import MarketContext
 from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer, TaxProfile
 from augur.sim.state import StateCrossSection
-from augur.sim.tax import apply_brackets
+from augur.sim.tax import apply_brackets, apply_ltcg_brackets
 
 
 def step_emit_events(
@@ -52,7 +52,12 @@ def step_emit_events(
     transfers = _emit_transfers(scenario, month, rollout_count)
     dispositions = _emit_lot_dispositions(state, scenario, market, month)
     tax_accruals = _emit_year_end_tax_accruals(
-        state=state, scenario=scenario, jurisdictions=jurisdictions, month=month, transfers=transfers
+        state=state,
+        scenario=scenario,
+        jurisdictions=jurisdictions,
+        month=month,
+        transfers=transfers,
+        dispositions=dispositions,
     )
     return EventLog(
         transfers=transfers,
@@ -193,68 +198,112 @@ def _emit_year_end_tax_accruals(
     jurisdictions: dict[str, Jurisdiction],
     month: int,
     transfers: pl.DataFrame,
+    dispositions: pl.DataFrame,
 ) -> pl.DataFrame:
     """At year-end emit one `tax_accrual` row per (taxed agent,
-    jurisdiction, rollout). Tax = bracket-walk(
-    end_of_year_ordinary_income - standard_deduction) where
-    `end_of_year_ordinary_income` is the pre-month YTD from state
-    plus the income arriving this month (which the step is emitting
-    itself, so it can sum without round-tripping through apply)."""
+    jurisdiction, rollout). Federal tax = ordinary_bracket_walk
+    (ordinary_income + STCG  - std_ded) + LTCG_bracket_walk(LTCG
+    stacked above ordinary_taxable). California tax = ordinary
+    bracket walk on (ordinary_income + LTCG + STCG  - std_ded) —
+    CA does not have a separate LTCG schedule.
+
+    Like ordinary income, capital gains are summed as `state YTD +
+    this-month's dispositions` since `apply_events` will produce
+    that same YTD before the year closes."""
     if not _is_year_end(month) or not scenario.tax_profiles:
         return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
-    end_of_year_income = _compute_end_of_year_ordinary_income(state, transfers, scenario.tax_profiles)
-    blocks = [
-        _tax_accruals_for_profile(profile, end_of_year_income, jurisdictions, month)
-        for profile in scenario.tax_profiles
-    ]
+    eoy = _compute_end_of_year_taxable_components(state, transfers, dispositions, scenario.tax_profiles, month)
+    blocks = [_tax_accruals_for_profile(profile, eoy, jurisdictions, month) for profile in scenario.tax_profiles]
     blocks = [b for b in blocks if not b.is_empty()]
     if not blocks:
         return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
     return pl.concat(blocks).select(list(TAX_ACCRUAL_EVENT_SCHEMA.keys()))
 
 
-def _compute_end_of_year_ordinary_income(
-    state: StateCrossSection, transfers: pl.DataFrame, profiles: list[TaxProfile]
+def _compute_end_of_year_taxable_components(
+    state: StateCrossSection,
+    transfers: pl.DataFrame,
+    dispositions: pl.DataFrame,
+    profiles: list[TaxProfile],
+    month: int,
 ) -> pl.DataFrame:
-    """Return a frame of `(rollout_index, agent_id,
-    ordinary_income_usd)` for every taxed agent. The value is the
-    pre-month YTD plus this month's incoming ordinary transfers
-    (so apply_events would produce the same YTD before the year
-    closes)."""
-    taxed_agents = {p.agent_id for p in profiles}
-    pre_month = state.ordinary_income_ytd.filter(pl.col("agent_id").is_in(list(taxed_agents)))
-    this_month = (
-        transfers.filter((pl.col("income_category") == "ordinary") & pl.col("to_agent_id").is_in(list(taxed_agents)))
+    """Return one row per (rollout, agent) with columns
+    `ordinary_income_usd`, `ltcg_usd`, `stcg_usd` — the end-of-year
+    totals matching what apply_events will materialize. Computed
+    as `pre-month state YTD + this-month's emitted events` so the
+    step can compose the tax accrual without round-tripping."""
+    taxed_agents = [p.agent_id for p in profiles]
+    pre_ord = state.ordinary_income_ytd.filter(pl.col("agent_id").is_in(taxed_agents))
+    pre_cg = state.capital_gains_ytd.filter(pl.col("agent_id").is_in(taxed_agents))
+    pre_ltcg = pre_cg.filter(pl.col("classification") == "ltcg").select(
+        "rollout_index", "agent_id", pl.col("gain_usd").alias("ltcg_usd")
+    )
+    pre_stcg = pre_cg.filter(pl.col("classification") == "stcg").select(
+        "rollout_index", "agent_id", pl.col("gain_usd").alias("stcg_usd")
+    )
+    this_month_ord = (
+        transfers.filter((pl.col("income_category") == "ordinary") & pl.col("to_agent_id").is_in(taxed_agents))
         .group_by(["rollout_index", "to_agent_id"])
-        .agg(pl.col("amount_usd").sum().alias("_this_month_income"))
+        .agg(pl.col("amount_usd").sum().alias("_this_month_ord"))
         .rename({"to_agent_id": "agent_id"})
     )
+    classified_dispositions = dispositions.filter(pl.col("agent_id").is_in(taxed_agents)).with_columns(
+        gain_usd=pl.col("proceeds_usd") - pl.col("cost_basis_consumed_usd"),
+        is_ltcg=(pl.lit(month) - pl.col("purchase_month_index")) >= 12,
+    )
+    this_month_ltcg = (
+        classified_dispositions.filter(pl.col("is_ltcg"))
+        .group_by(["rollout_index", "agent_id"])
+        .agg(pl.col("gain_usd").sum().alias("_this_month_ltcg"))
+    )
+    this_month_stcg = (
+        classified_dispositions.filter(~pl.col("is_ltcg"))
+        .group_by(["rollout_index", "agent_id"])
+        .agg(pl.col("gain_usd").sum().alias("_this_month_stcg"))
+    )
     return (
-        pre_month.join(this_month, on=["rollout_index", "agent_id"], how="left")
-        .with_columns(ordinary_income_usd=pl.col("ordinary_income_usd") + pl.col("_this_month_income").fill_null(0.0))
-        .drop("_this_month_income")
+        pre_ord.join(this_month_ord, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(ordinary_income_usd=pl.col("ordinary_income_usd") + pl.col("_this_month_ord").fill_null(0.0))
+        .drop("_this_month_ord")
+        .join(pre_ltcg, on=["rollout_index", "agent_id"], how="left")
+        .join(this_month_ltcg, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(ltcg_usd=pl.col("ltcg_usd").fill_null(0.0) + pl.col("_this_month_ltcg").fill_null(0.0))
+        .drop("_this_month_ltcg")
+        .join(pre_stcg, on=["rollout_index", "agent_id"], how="left")
+        .join(this_month_stcg, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(stcg_usd=pl.col("stcg_usd").fill_null(0.0) + pl.col("_this_month_stcg").fill_null(0.0))
+        .drop("_this_month_stcg")
     )
 
 
 def _tax_accruals_for_profile(
-    profile: TaxProfile, end_of_year_income: pl.DataFrame, jurisdictions: dict[str, Jurisdiction], month: int
+    profile: TaxProfile, eoy: pl.DataFrame, jurisdictions: dict[str, Jurisdiction], month: int
 ) -> pl.DataFrame:
-    """Compute one row per jurisdiction in the profile by walking
-    that jurisdiction's bracket schedule against
-    `max(income - standard_deduction, 0)`. The walk is vectorized
-    via numpy across the rollout dimension."""
-    income_rows = end_of_year_income.filter(pl.col("agent_id") == profile.agent_id).sort("rollout_index")
-    if income_rows.is_empty():
+    """Compute one row per jurisdiction in the profile. Federal vs
+    California is distinguished by whether the jurisdiction has its
+    own LTCG schedule: federal stacks LTCG above ordinary+STCG;
+    California flattens everything into ordinary brackets."""
+    eoy_rows = eoy.filter(pl.col("agent_id") == profile.agent_id).sort("rollout_index")
+    if eoy_rows.is_empty():
         return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
-    rollout_idx = income_rows.get_column("rollout_index").to_numpy()
-    income = income_rows.get_column("ordinary_income_usd").to_numpy()
+    rollout_idx = eoy_rows.get_column("rollout_index").to_numpy()
+    ordinary = eoy_rows.get_column("ordinary_income_usd").to_numpy()
+    ltcg = eoy_rows.get_column("ltcg_usd").to_numpy()
+    stcg = eoy_rows.get_column("stcg_usd").to_numpy()
     blocks = []
     for jurisdiction_id in profile.jurisdiction_ids:
         jurisdiction = jurisdictions[jurisdiction_id]
         deduction = jurisdiction.standard_deduction[profile.filing_status]
-        taxable = np.maximum(income - deduction, 0.0)
-        brackets = jurisdiction.ordinary_income_brackets[profile.filing_status]
-        tax = apply_brackets(taxable, brackets)
+        ord_brackets = jurisdiction.ordinary_income_brackets[profile.filing_status]
+        if jurisdiction.ltcg_brackets is not None:
+            ltcg_brackets = jurisdiction.ltcg_brackets[profile.filing_status]
+            ordinary_taxable = np.maximum(ordinary + stcg - deduction, 0.0)
+            tax = apply_brackets(ordinary_taxable, ord_brackets) + apply_ltcg_brackets(
+                ltcg, ordinary_taxable, ltcg_brackets
+            )
+        else:
+            total_taxable = np.maximum(ordinary + ltcg + stcg - deduction, 0.0)
+            tax = apply_brackets(total_taxable, ord_brackets)
         cause_id = f"{profile.agent_id}_{jurisdiction_id}_year_end_accrual_m{month}"
         blocks.append(
             pl.DataFrame(

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -68,12 +68,12 @@ def _emit_transfers(scenario: Scenario, month: int, rollout_count: int) -> pl.Da
     their configured month; recurring transfers fire every month in
     `[start_month, end_month]` (or through horizon end). One row per
     (transfer, rollout)."""
-    scheduled = [t for t in scenario.scheduled_transfers if t.month == month]
-    recurring = [t for t in scenario.recurring_transfers if t.is_active_at(month)]
-    if not scheduled and not recurring:
+    active: list[ScheduledTransfer | RecurringTransfer] = [t for t in scenario.scheduled_transfers if t.month == month]
+    active.extend(t for t in scenario.recurring_transfers if t.is_active_at(month))
+    if not active:
         return pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA)
     rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
-    blocks = [_transfer_block_per_rollout(t, rollouts, month) for t in (*scheduled, *recurring)]
+    blocks = [_transfer_block_per_rollout(t, rollouts, month) for t in active]
     return pl.concat(blocks).select(list(TRANSFER_EVENT_SCHEMA.keys()))
 
 

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -1,30 +1,38 @@
 """`step_emit_events` — pure function that reads state + scenario +
 month index and returns the events for that month.
 
-At spike 1 the step is small: it only emits scheduled transfers
-that the scenario configured. Later layers add scheduled property
-events, recurring obligation accruals, tax-marker accruals,
-obligation settlement (with funding chain), discretionary policies,
-and end-of-month accruals.
+At spike 1 step 4 the step emits:
 
-The step does not mutate `state`. The simulate loop calls
-`apply_events(state, step_result)` separately.
+  - transfer events for scheduled + recurring transfers active at
+    this month;
+  - lot_disposition events for scheduled asset sales active at this
+    month — FIFO across the agent's lots of the asset, vectorized
+    over the rollout dimension.
+
+Initial holdings are seeded into `state.asset_lots` at _initial_state
+time, not via in-sim AssetPurchase events. In-sim purchases (a later
+layer) will emit AssetPurchase events here. The step does not mutate
+`state`. The simulate loop calls `apply_events(state, step_result)`
+separately.
 """
 
 from __future__ import annotations
 
 import polars as pl
 
-from augur.sim.events import TRANSFER_EVENT_SCHEMA, EventLog
-from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledTransfer
+from augur.sim.events import ASSET_PURCHASE_EVENT_SCHEMA, LOT_DISPOSITION_EVENT_SCHEMA, TRANSFER_EVENT_SCHEMA, EventLog
+from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer
 from augur.sim.state import StateCrossSection
 
 
 def step_emit_events(*, state: StateCrossSection, scenario: Scenario, month: int, rollout_count: int) -> EventLog:
     """Return the events to apply at this month. Pure: does not
     mutate `state`."""
-    _ = state  # spike 1 step doesn't read state yet; later layers will
-    return EventLog(transfers=_emit_transfers(scenario, month, rollout_count))
+    return EventLog(
+        transfers=_emit_transfers(scenario, month, rollout_count),
+        asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
+        lot_dispositions=_emit_lot_dispositions(state, scenario, month),
+    )
 
 
 def _emit_transfers(scenario: Scenario, month: int, rollout_count: int) -> pl.DataFrame:
@@ -59,3 +67,64 @@ def _transfer_block_per_rollout(
         pl.lit(t.to_account_id, dtype=pl.Utf8()).alias("to_account_id"),
         pl.lit(t.amount_usd, dtype=pl.Float64()).alias("amount_usd"),
     )
+
+
+def _emit_lot_dispositions(state: StateCrossSection, scenario: Scenario, month: int) -> pl.DataFrame:
+    """Emit `LotDisposition` rows for every scheduled asset sale at
+    this month. Each sale is FIFO-resolved against the agent's
+    current lots of the asset; the same resolution applies
+    per-rollout via polars window functions over `rollout_index`.
+
+    At spike-1 step 4 part A scenarios have at most one sale per
+    `(agent, asset)` per month, so the resolution reads the current
+    `state.asset_lots` directly and emits its dispositions without
+    chaining."""
+    sales = [s for s in scenario.scheduled_asset_sales if s.month == month]
+    if not sales:
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    blocks = [_fifo_dispositions_for_sale(state, sale, month) for sale in sales]
+    blocks = [b for b in blocks if not b.is_empty()]
+    if not blocks:
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    return pl.concat(blocks).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))
+
+
+def _fifo_dispositions_for_sale(state: StateCrossSection, sale: ScheduledAssetSale, month: int) -> pl.DataFrame:
+    """Vectorized FIFO consumption of one sale across all rollouts.
+
+    Within each rollout the lots of the matching `(agent_id,
+    asset_id)` are ordered by `purchase_month_index` ascending; the
+    sale eats from the oldest forward. A lot's `units_sold` is
+    `clip(sale.quantity - prev_cumulative_remaining, 0,
+    remaining_quantity)`. The result is one disposition row per
+    consumed lot per rollout."""
+    candidates = state.asset_lots.filter(
+        (pl.col("agent_id") == sale.agent_id)
+        & (pl.col("asset_id") == sale.asset_id)
+        & (pl.col("remaining_quantity") > 0)
+    )
+    if candidates.is_empty():
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    ordered = candidates.sort(["rollout_index", "purchase_month_index", "lot_id"])
+    with_cum = ordered.with_columns(
+        _prev_cum_remaining=(
+            pl.col("remaining_quantity").cum_sum().over("rollout_index") - pl.col("remaining_quantity")
+        )
+    )
+    sized = with_cum.with_columns(
+        _units_from_lot=pl.min_horizontal(
+            pl.col("remaining_quantity"),
+            pl.max_horizontal(pl.lit(0.0), pl.lit(sale.quantity) - pl.col("_prev_cum_remaining")),
+        )
+    )
+    consumed = sized.filter(pl.col("_units_from_lot") > 0)
+    if consumed.is_empty():
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    return consumed.with_columns(
+        pl.lit(month, dtype=pl.Int64()).alias("month_index"),
+        pl.lit(sale.cause_id, dtype=pl.Utf8()).alias("cause_id"),
+        pl.col("_units_from_lot").alias("units_sold"),
+        (pl.col("_units_from_lot") * pl.col("cost_basis_per_unit_usd")).alias("cost_basis_consumed_usd"),
+        (pl.col("_units_from_lot") * pl.lit(sale.price_per_unit_usd)).alias("proceeds_usd"),
+        pl.lit(sale.proceeds_account_id, dtype=pl.Utf8()).alias("proceeds_account_id"),
+    ).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -58,8 +58,9 @@ def step_emit_scheduled_events(
     rollout_count: int,
 ) -> EventLog:
     """Phase 1 of the month step: scheduled / recurring transfers,
-    scheduled asset sales, and year-end tax accruals. Pure: does
-    not mutate `state`."""
+    scheduled asset sales, year-end tax accruals, and tax-payment
+    transfers derived from those accruals. Pure: does not mutate
+    `state`."""
     transfers = _emit_transfers(scenario, month, rollout_count)
     dispositions = _emit_lot_dispositions(state, scenario, market, month)
     tax_accruals = _emit_year_end_tax_accruals(
@@ -70,8 +71,9 @@ def step_emit_scheduled_events(
         transfers=transfers,
         dispositions=dispositions,
     )
+    tax_payments = _emit_tax_payment_transfers(tax_accruals, scenario.tax_profiles)
     return EventLog(
-        transfers=transfers,
+        transfers=pl.concat([transfers, tax_payments]),
         asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
         lot_dispositions=dispositions,
         tax_accruals=tax_accruals,
@@ -409,6 +411,40 @@ def _is_year_end(month: int) -> bool:
     """Tax years are calendar-year-aligned at spike 1: the year
     ends at month index 11, 23, 35, …"""
     return month % 12 == 11
+
+
+def _emit_tax_payment_transfers(tax_accruals: pl.DataFrame, profiles: list[TaxProfile]) -> pl.DataFrame:
+    """Mirror each year-end tax accrual into a payment transfer
+    from the taxed agent's `payment_account_id` to the configured
+    tax authority. Combined with the accrual itself this means the
+    full year's tax is paid in one go at year-end; quarterly +
+    true-up timing is deferred to a later step.
+
+    A tax-payment transfer is just like any other mandatory cash
+    outflow (rent today; later mortgage payments): if the cash
+    isn't there, phase-2's floor-triggered sale tries to cover and
+    the rollout-failure detector fires when even that fails."""
+    blocks: list[pl.DataFrame] = []
+    for profile in profiles:
+        agent_accruals = tax_accruals.filter(pl.col("agent_id") == profile.agent_id)
+        if agent_accruals.is_empty():
+            continue
+        blocks.append(
+            agent_accruals.select(
+                pl.col("rollout_index"),
+                pl.col("month_index"),
+                (pl.col("cause_id") + pl.lit("_payment")).alias("cause_id"),
+                pl.lit(profile.agent_id, dtype=pl.Utf8()).alias("from_agent_id"),
+                pl.lit(profile.payment_account_id, dtype=pl.Utf8()).alias("from_account_id"),
+                pl.lit(profile.tax_authority_agent_id, dtype=pl.Utf8()).alias("to_agent_id"),
+                pl.lit(profile.tax_authority_account_id, dtype=pl.Utf8()).alias("to_account_id"),
+                pl.col("amount_usd"),
+                pl.lit(None, dtype=pl.Utf8()).alias("income_category"),
+            )
+        )
+    if not blocks:
+        return pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA)
+    return pl.concat(blocks).select(list(TRANSFER_EVENT_SCHEMA.keys()))
 
 
 def _emit_year_end_tax_accruals(

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import polars as pl
 
 from augur.sim.events import TRANSFER_EVENT_SCHEMA, EventLog
-from augur.sim.scenario import Scenario, ScheduledTransfer
+from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledTransfer
 from augur.sim.state import StateCrossSection
 
 
@@ -24,24 +24,32 @@ def step_emit_events(*, state: StateCrossSection, scenario: Scenario, month: int
     """Return the events to apply at this month. Pure: does not
     mutate `state`."""
     _ = state  # spike 1 step doesn't read state yet; later layers will
-    return EventLog(transfers=_emit_scheduled_transfers(scenario, month, rollout_count))
+    return EventLog(transfers=_emit_transfers(scenario, month, rollout_count))
 
 
-def _emit_scheduled_transfers(scenario: Scenario, month: int, rollout_count: int) -> pl.DataFrame:
-    """Emit one Transfer row per (scheduled_transfer scheduled at
-    `month`, rollout). Same amount across rollouts at spike 1 —
-    scheduled transfers are scenario-fixed inputs."""
-    matching = [t for t in scenario.scheduled_transfers if t.month == month]
-    if not matching:
+def _emit_transfers(scenario: Scenario, month: int, rollout_count: int) -> pl.DataFrame:
+    """Emit Transfer event rows for every scheduled or recurring
+    transfer active at this month. Scheduled transfers fire only at
+    their configured month; recurring transfers fire every month in
+    `[start_month, end_month]` (or through horizon end). One row per
+    (transfer, rollout)."""
+    scheduled = [t for t in scenario.scheduled_transfers if t.month == month]
+    recurring = [t for t in scenario.recurring_transfers if t.is_active_at(month)]
+    if not scheduled and not recurring:
         return pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA)
     rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
-    blocks = [_transfer_block_per_rollout(t, rollouts, month) for t in matching]
+    blocks = [_transfer_block_per_rollout(t, rollouts, month) for t in (*scheduled, *recurring)]
     return pl.concat(blocks).select(list(TRANSFER_EVENT_SCHEMA.keys()))
 
 
-def _transfer_block_per_rollout(t: ScheduledTransfer, rollouts: pl.DataFrame, month: int) -> pl.DataFrame:
-    """One row per rollout for one scheduled transfer. The rollout
-    dimension is expanded vectorized — no Python loop over rollouts."""
+def _transfer_block_per_rollout(
+    t: ScheduledTransfer | RecurringTransfer, rollouts: pl.DataFrame, month: int
+) -> pl.DataFrame:
+    """One row per rollout for one transfer config. The rollout
+    dimension is expanded vectorized — no Python loop over rollouts.
+    Handles both ScheduledTransfer (one-off at a specific month) and
+    RecurringTransfer (firing at this active month) — same event
+    schema, only the cadence config differs."""
     return rollouts.with_columns(
         pl.lit(month, dtype=pl.Int64()).alias("month_index"),
         pl.lit(t.cause_id, dtype=pl.Utf8()).alias("cause_id"),

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -21,24 +21,34 @@ will produce.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 import polars as pl
 
 from augur.sim.events import (
     ASSET_PURCHASE_EVENT_SCHEMA,
     LOT_DISPOSITION_EVENT_SCHEMA,
+    ROLLOUT_FAILURE_EVENT_SCHEMA,
     TAX_ACCRUAL_EVENT_SCHEMA,
     TRANSFER_EVENT_SCHEMA,
     EventLog,
 )
 from augur.sim.jurisdictions import Jurisdiction
 from augur.sim.market import MarketContext
-from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer, TaxProfile
+from augur.sim.scenario import (
+    FloorTriggeredSalePolicy,
+    RecurringTransfer,
+    Scenario,
+    ScheduledAssetSale,
+    ScheduledTransfer,
+    TaxProfile,
+)
 from augur.sim.state import StateCrossSection
 from augur.sim.tax import apply_brackets, apply_ltcg_brackets
 
 
-def step_emit_events(
+def step_emit_scheduled_events(
     *,
     state: StateCrossSection,
     scenario: Scenario,
@@ -47,8 +57,9 @@ def step_emit_events(
     month: int,
     rollout_count: int,
 ) -> EventLog:
-    """Return the events to apply at this month. Pure: does not
-    mutate `state`."""
+    """Phase 1 of the month step: scheduled / recurring transfers,
+    scheduled asset sales, and year-end tax accruals. Pure: does
+    not mutate `state`."""
     transfers = _emit_transfers(scenario, month, rollout_count)
     dispositions = _emit_lot_dispositions(state, scenario, market, month)
     tax_accruals = _emit_year_end_tax_accruals(
@@ -64,6 +75,24 @@ def step_emit_events(
         asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
         lot_dispositions=dispositions,
         tax_accruals=tax_accruals,
+        rollout_failures=pl.DataFrame(schema=ROLLOUT_FAILURE_EVENT_SCHEMA),
+    )
+
+
+def step_emit_policy_events(
+    *, state: StateCrossSection, scenario: Scenario, market: MarketContext, month: int
+) -> EventLog:
+    """Phase 2 of the month step: discretionary policies +
+    failure detection. Runs on the post-phase-1 state so the floor
+    check sees cash after all scheduled events have applied."""
+    dispositions = _emit_floor_triggered_sales(state, scenario, market, month)
+    failures = _emit_rollout_failures(state, scenario, dispositions, market, month)
+    return EventLog(
+        transfers=pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA),
+        asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
+        lot_dispositions=dispositions,
+        tax_accruals=pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA),
+        rollout_failures=failures,
     )
 
 
@@ -183,6 +212,197 @@ def _attach_unit_price(lots: pl.DataFrame, sale: ScheduledAssetSale, prices_at_m
         {"price_per_unit_usd": "_unit_price"}
     )
     return lots.join(prices_for_asset.select("rollout_index", "_unit_price"), on="rollout_index", how="left")
+
+
+def _emit_floor_triggered_sales(
+    state: StateCrossSection, scenario: Scenario, market: MarketContext, month: int
+) -> pl.DataFrame:
+    """For every `FloorTriggeredSalePolicy`, find rollouts whose
+    monitored account is below the floor and emit FIFO lot
+    dispositions walking the asset preference chain until either
+    the deficit is covered or the chain is exhausted. Vectorized
+    over rollouts; Python-loops only over asset slots (typically
+    3-5 entries)."""
+    if not scenario.floor_triggered_sale_policies:
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    prices = market.prices_at(month)
+    active_rollouts = state.rollout_status.filter(pl.col("status") == "active").select("rollout_index")
+    blocks: list[pl.DataFrame] = []
+    for policy in scenario.floor_triggered_sale_policies:
+        blocks.extend(_dispositions_for_policy(state, policy, prices, active_rollouts, month))
+    blocks = [b for b in blocks if not b.is_empty()]
+    if not blocks:
+        return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
+    return pl.concat(blocks).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))
+
+
+def _dispositions_for_policy(
+    state: StateCrossSection,
+    policy: FloorTriggeredSalePolicy,
+    prices: pl.DataFrame,
+    active_rollouts: pl.DataFrame,
+    month: int,
+) -> list[pl.DataFrame]:
+    """Resolve one policy across the rollout column. Returns a list
+    of disposition blocks (one per asset slot consumed)."""
+    cash = state.cash_balances.filter(
+        (pl.col("agent_id") == policy.agent_id) & (pl.col("account_id") == policy.account_id)
+    ).select("rollout_index", pl.col("balance_usd").alias("_balance_usd"))
+    deficit = (
+        cash.join(active_rollouts, on="rollout_index", how="inner")
+        .with_columns(
+            _remaining_deficit_usd=pl.lit(policy.floor_usd + policy.replenish_buffer_usd) - pl.col("_balance_usd")
+        )
+        .filter(pl.col("_remaining_deficit_usd") > 0)
+        .select("rollout_index", "_remaining_deficit_usd")
+    )
+    if deficit.is_empty():
+        return []
+    blocks: list[pl.DataFrame] = []
+    for slot_index, asset_id in enumerate(policy.asset_preference_chain):
+        if deficit.is_empty():
+            break
+        cause_id = f"{policy.cause_id_prefix}_m{month}_{asset_id}"
+        result = _consume_asset_for_policy(
+            state=state,
+            policy=policy,
+            asset_id=asset_id,
+            slot_index=slot_index,
+            prices=prices,
+            deficit=deficit,
+            cause_id=cause_id,
+            month=month,
+        )
+        if result.dispositions is not None and not result.dispositions.is_empty():
+            blocks.append(result.dispositions)
+        deficit = result.remaining_deficit
+    return blocks
+
+
+@dataclass(frozen=True)
+class _PolicyAssetResult:
+    """Output of consuming one asset within a policy: the lot
+    dispositions emitted for the asset plus the residual deficit
+    after this asset's sale (to feed the next asset slot)."""
+
+    dispositions: pl.DataFrame | None
+    remaining_deficit: pl.DataFrame
+
+
+def _consume_asset_for_policy(
+    *,
+    state: StateCrossSection,
+    policy: FloorTriggeredSalePolicy,
+    asset_id: str,
+    slot_index: int,
+    prices: pl.DataFrame,
+    deficit: pl.DataFrame,
+    cause_id: str,
+    month: int,
+) -> _PolicyAssetResult:
+    """Walk the agent's lots of `asset_id` in FIFO order to cover
+    as much of each rollout's remaining deficit as the asset
+    supports. Decrement the deficit by the dollars actually
+    realized. Returns the new disposition frame and an updated
+    deficit frame for the next asset slot."""
+    asset_price = prices.filter(pl.col("asset_id") == asset_id).select(
+        "rollout_index", pl.col("price_per_unit_usd").alias("_unit_price")
+    )
+    lots = (
+        state.asset_lots.filter(
+            (pl.col("agent_id") == policy.agent_id)
+            & (pl.col("asset_id") == asset_id)
+            & (pl.col("remaining_quantity") > 0)
+        )
+        .join(asset_price, on="rollout_index", how="left")
+        .join(deficit, on="rollout_index", how="inner")
+    )
+    if lots.is_empty():
+        return _PolicyAssetResult(dispositions=None, remaining_deficit=deficit)
+    ordered = lots.sort(["rollout_index", "purchase_month_index", "lot_id"])
+    with_cum = ordered.with_columns(
+        _prev_cum_dollars=(
+            (pl.col("remaining_quantity") * pl.col("_unit_price")).cum_sum().over("rollout_index")
+            - (pl.col("remaining_quantity") * pl.col("_unit_price"))
+        )
+    )
+    sized = with_cum.with_columns(
+        _dollars_from_lot=pl.min_horizontal(
+            pl.col("remaining_quantity") * pl.col("_unit_price"),
+            pl.max_horizontal(pl.lit(0.0), pl.col("_remaining_deficit_usd") - pl.col("_prev_cum_dollars")),
+        )
+    )
+    consumed = sized.filter(pl.col("_dollars_from_lot") > 0).with_columns(
+        _units_from_lot=pl.col("_dollars_from_lot") / pl.col("_unit_price")
+    )
+    if consumed.is_empty():
+        return _PolicyAssetResult(dispositions=None, remaining_deficit=deficit)
+    dispositions = consumed.with_columns(
+        pl.lit(month, dtype=pl.Int64()).alias("month_index"),
+        pl.lit(cause_id, dtype=pl.Utf8()).alias("cause_id"),
+        pl.col("_units_from_lot").alias("units_sold"),
+        (pl.col("_units_from_lot") * pl.col("cost_basis_per_unit_usd")).alias("cost_basis_consumed_usd"),
+        pl.col("_dollars_from_lot").alias("proceeds_usd"),
+        pl.lit(policy.account_id, dtype=pl.Utf8()).alias("proceeds_account_id"),
+    ).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))
+    _ = slot_index  # reserved for future use (e.g. partial-fill accounting)
+    realized_per_rollout = consumed.group_by("rollout_index").agg(
+        pl.col("_dollars_from_lot").sum().alias("_realized_usd")
+    )
+    new_deficit = (
+        deficit.join(realized_per_rollout, on="rollout_index", how="left")
+        .with_columns(_remaining_deficit_usd=pl.col("_remaining_deficit_usd") - pl.col("_realized_usd").fill_null(0.0))
+        .filter(pl.col("_remaining_deficit_usd") > 0)
+        .select("rollout_index", "_remaining_deficit_usd")
+    )
+    return _PolicyAssetResult(dispositions=dispositions, remaining_deficit=new_deficit)
+
+
+def _emit_rollout_failures(
+    state: StateCrossSection, scenario: Scenario, policy_dispositions: pl.DataFrame, market: MarketContext, month: int
+) -> pl.DataFrame:
+    """Flag any active rollout whose monitored cash account is
+    still below 0 after the floor-triggered sales have fired. Cash
+    on the post-phase-1 state is in `state.cash_balances`; the
+    policy dispositions emitted this phase haven't been applied
+    yet, so we credit them in projection before checking the
+    floor."""
+    _ = market
+    if not scenario.floor_triggered_sale_policies:
+        return pl.DataFrame(schema=ROLLOUT_FAILURE_EVENT_SCHEMA)
+    active_rollouts = state.rollout_status.filter(pl.col("status") == "active").select("rollout_index")
+    blocks: list[pl.DataFrame] = []
+    for policy in scenario.floor_triggered_sale_policies:
+        policy_proceeds = (
+            policy_dispositions.filter(
+                (pl.col("agent_id") == policy.agent_id) & (pl.col("proceeds_account_id") == policy.account_id)
+            )
+            .group_by("rollout_index")
+            .agg(pl.col("proceeds_usd").sum().alias("_proceeds"))
+        )
+        pre_failure_cash = (
+            state.cash_balances.filter(
+                (pl.col("agent_id") == policy.agent_id) & (pl.col("account_id") == policy.account_id)
+            )
+            .select("rollout_index", pl.col("balance_usd").alias("_balance"))
+            .join(policy_proceeds, on="rollout_index", how="left")
+            .with_columns(_projected=pl.col("_balance") + pl.col("_proceeds").fill_null(0.0))
+            .join(active_rollouts, on="rollout_index", how="inner")
+            .filter(pl.col("_projected") < 0)
+        )
+        if pre_failure_cash.is_empty():
+            continue
+        blocks.append(
+            pre_failure_cash.with_columns(
+                pl.lit(month, dtype=pl.Int64()).alias("month_index"),
+                pl.lit(f"{policy.cause_id_prefix}_failure_m{month}", dtype=pl.Utf8()).alias("cause_id"),
+                pl.lit(policy.agent_id, dtype=pl.Utf8()).alias("agent_id"),
+                deficit_usd=-pl.col("_projected"),
+            ).select(list(ROLLOUT_FAILURE_EVENT_SCHEMA.keys()))
+        )
+    if not blocks:
+        return pl.DataFrame(schema=ROLLOUT_FAILURE_EVENT_SCHEMA)
+    return pl.concat(blocks)
 
 
 def _is_year_end(month: int) -> bool:

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -1,0 +1,53 @@
+"""`step_emit_events` — pure function that reads state + scenario +
+month index and returns the events for that month.
+
+At spike 1 the step is small: it only emits scheduled transfers
+that the scenario configured. Later layers add scheduled property
+events, recurring obligation accruals, tax-marker accruals,
+obligation settlement (with funding chain), discretionary policies,
+and end-of-month accruals.
+
+The step does not mutate `state`. The simulate loop calls
+`apply_events(state, step_result)` separately.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from augur.sim.events import TRANSFER_EVENT_SCHEMA, EventLog
+from augur.sim.scenario import Scenario, ScheduledTransfer
+from augur.sim.state import StateCrossSection
+
+
+def step_emit_events(*, state: StateCrossSection, scenario: Scenario, month: int, rollout_count: int) -> EventLog:
+    """Return the events to apply at this month. Pure: does not
+    mutate `state`."""
+    _ = state  # spike 1 step doesn't read state yet; later layers will
+    return EventLog(transfers=_emit_scheduled_transfers(scenario, month, rollout_count))
+
+
+def _emit_scheduled_transfers(scenario: Scenario, month: int, rollout_count: int) -> pl.DataFrame:
+    """Emit one Transfer row per (scheduled_transfer scheduled at
+    `month`, rollout). Same amount across rollouts at spike 1 —
+    scheduled transfers are scenario-fixed inputs."""
+    matching = [t for t in scenario.scheduled_transfers if t.month == month]
+    if not matching:
+        return pl.DataFrame(schema=TRANSFER_EVENT_SCHEMA)
+    rollouts = pl.DataFrame({"rollout_index": list(range(rollout_count))}, schema={"rollout_index": pl.Int64()})
+    blocks = [_transfer_block_per_rollout(t, rollouts, month) for t in matching]
+    return pl.concat(blocks).select(list(TRANSFER_EVENT_SCHEMA.keys()))
+
+
+def _transfer_block_per_rollout(t: ScheduledTransfer, rollouts: pl.DataFrame, month: int) -> pl.DataFrame:
+    """One row per rollout for one scheduled transfer. The rollout
+    dimension is expanded vectorized — no Python loop over rollouts."""
+    return rollouts.with_columns(
+        pl.lit(month, dtype=pl.Int64()).alias("month_index"),
+        pl.lit(t.cause_id, dtype=pl.Utf8()).alias("cause_id"),
+        pl.lit(t.from_agent_id, dtype=pl.Utf8()).alias("from_agent_id"),
+        pl.lit(t.from_account_id, dtype=pl.Utf8()).alias("from_account_id"),
+        pl.lit(t.to_agent_id, dtype=pl.Utf8()).alias("to_agent_id"),
+        pl.lit(t.to_account_id, dtype=pl.Utf8()).alias("to_account_id"),
+        pl.lit(t.amount_usd, dtype=pl.Float64()).alias("amount_usd"),
+    )

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -1,40 +1,64 @@
 """`step_emit_events` — pure function that reads state + scenario +
 month index and returns the events for that month.
 
-At spike 1 step 4 the step emits:
+At spike 1 step 7 the step emits:
 
   - transfer events for scheduled + recurring transfers active at
-    this month;
-  - lot_disposition events for scheduled asset sales active at this
-    month — FIFO across the agent's lots of the asset, vectorized
-    over the rollout dimension.
+    this month, optionally tagged with an `income_category`;
+  - lot_disposition events for scheduled asset sales (FIFO across
+    the agent's lots);
+  - tax_accrual events at the end of each tax year (month_index
+    in {11, 23, 35, ...}) — one per (taxed agent, jurisdiction),
+    computed by bracket-walking end-of-year ordinary income minus
+    the jurisdiction's standard deduction.
 
-Initial holdings are seeded into `state.asset_lots` at _initial_state
-time, not via in-sim AssetPurchase events. In-sim purchases (a later
-layer) will emit AssetPurchase events here. The step does not mutate
-`state`. The simulate loop calls `apply_events(state, step_result)`
-separately.
+The step does not mutate `state`. The simulate loop calls
+`apply_events(state, step_result)` separately. apply_events
+processes income transfers before tax accruals so the accrual
+amount the step computes is consistent with the YTD that apply
+will produce.
 """
 
 from __future__ import annotations
 
+import numpy as np
 import polars as pl
 
-from augur.sim.events import ASSET_PURCHASE_EVENT_SCHEMA, LOT_DISPOSITION_EVENT_SCHEMA, TRANSFER_EVENT_SCHEMA, EventLog
+from augur.sim.events import (
+    ASSET_PURCHASE_EVENT_SCHEMA,
+    LOT_DISPOSITION_EVENT_SCHEMA,
+    TAX_ACCRUAL_EVENT_SCHEMA,
+    TRANSFER_EVENT_SCHEMA,
+    EventLog,
+)
+from augur.sim.jurisdictions import Jurisdiction
 from augur.sim.market import MarketContext
-from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer
+from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer, TaxProfile
 from augur.sim.state import StateCrossSection
+from augur.sim.tax import apply_brackets
 
 
 def step_emit_events(
-    *, state: StateCrossSection, scenario: Scenario, market: MarketContext, month: int, rollout_count: int
+    *,
+    state: StateCrossSection,
+    scenario: Scenario,
+    market: MarketContext,
+    jurisdictions: dict[str, Jurisdiction],
+    month: int,
+    rollout_count: int,
 ) -> EventLog:
     """Return the events to apply at this month. Pure: does not
     mutate `state`."""
+    transfers = _emit_transfers(scenario, month, rollout_count)
+    dispositions = _emit_lot_dispositions(state, scenario, market, month)
+    tax_accruals = _emit_year_end_tax_accruals(
+        state=state, scenario=scenario, jurisdictions=jurisdictions, month=month, transfers=transfers
+    )
     return EventLog(
-        transfers=_emit_transfers(scenario, month, rollout_count),
+        transfers=transfers,
         asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
-        lot_dispositions=_emit_lot_dispositions(state, scenario, market, month),
+        lot_dispositions=dispositions,
+        tax_accruals=tax_accruals,
     )
 
 
@@ -69,6 +93,7 @@ def _transfer_block_per_rollout(
         pl.lit(t.to_agent_id, dtype=pl.Utf8()).alias("to_agent_id"),
         pl.lit(t.to_account_id, dtype=pl.Utf8()).alias("to_account_id"),
         pl.lit(t.amount_usd, dtype=pl.Float64()).alias("amount_usd"),
+        pl.lit(t.income_category, dtype=pl.Utf8()).alias("income_category"),
     )
 
 
@@ -153,3 +178,96 @@ def _attach_unit_price(lots: pl.DataFrame, sale: ScheduledAssetSale, prices_at_m
         {"price_per_unit_usd": "_unit_price"}
     )
     return lots.join(prices_for_asset.select("rollout_index", "_unit_price"), on="rollout_index", how="left")
+
+
+def _is_year_end(month: int) -> bool:
+    """Tax years are calendar-year-aligned at spike 1: the year
+    ends at month index 11, 23, 35, …"""
+    return month % 12 == 11
+
+
+def _emit_year_end_tax_accruals(
+    *,
+    state: StateCrossSection,
+    scenario: Scenario,
+    jurisdictions: dict[str, Jurisdiction],
+    month: int,
+    transfers: pl.DataFrame,
+) -> pl.DataFrame:
+    """At year-end emit one `tax_accrual` row per (taxed agent,
+    jurisdiction, rollout). Tax = bracket-walk(
+    end_of_year_ordinary_income - standard_deduction) where
+    `end_of_year_ordinary_income` is the pre-month YTD from state
+    plus the income arriving this month (which the step is emitting
+    itself, so it can sum without round-tripping through apply)."""
+    if not _is_year_end(month) or not scenario.tax_profiles:
+        return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
+    end_of_year_income = _compute_end_of_year_ordinary_income(state, transfers, scenario.tax_profiles)
+    blocks = [
+        _tax_accruals_for_profile(profile, end_of_year_income, jurisdictions, month)
+        for profile in scenario.tax_profiles
+    ]
+    blocks = [b for b in blocks if not b.is_empty()]
+    if not blocks:
+        return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
+    return pl.concat(blocks).select(list(TAX_ACCRUAL_EVENT_SCHEMA.keys()))
+
+
+def _compute_end_of_year_ordinary_income(
+    state: StateCrossSection, transfers: pl.DataFrame, profiles: list[TaxProfile]
+) -> pl.DataFrame:
+    """Return a frame of `(rollout_index, agent_id,
+    ordinary_income_usd)` for every taxed agent. The value is the
+    pre-month YTD plus this month's incoming ordinary transfers
+    (so apply_events would produce the same YTD before the year
+    closes)."""
+    taxed_agents = {p.agent_id for p in profiles}
+    pre_month = state.ordinary_income_ytd.filter(pl.col("agent_id").is_in(list(taxed_agents)))
+    this_month = (
+        transfers.filter((pl.col("income_category") == "ordinary") & pl.col("to_agent_id").is_in(list(taxed_agents)))
+        .group_by(["rollout_index", "to_agent_id"])
+        .agg(pl.col("amount_usd").sum().alias("_this_month_income"))
+        .rename({"to_agent_id": "agent_id"})
+    )
+    return (
+        pre_month.join(this_month, on=["rollout_index", "agent_id"], how="left")
+        .with_columns(ordinary_income_usd=pl.col("ordinary_income_usd") + pl.col("_this_month_income").fill_null(0.0))
+        .drop("_this_month_income")
+    )
+
+
+def _tax_accruals_for_profile(
+    profile: TaxProfile, end_of_year_income: pl.DataFrame, jurisdictions: dict[str, Jurisdiction], month: int
+) -> pl.DataFrame:
+    """Compute one row per jurisdiction in the profile by walking
+    that jurisdiction's bracket schedule against
+    `max(income - standard_deduction, 0)`. The walk is vectorized
+    via numpy across the rollout dimension."""
+    income_rows = end_of_year_income.filter(pl.col("agent_id") == profile.agent_id).sort("rollout_index")
+    if income_rows.is_empty():
+        return pl.DataFrame(schema=TAX_ACCRUAL_EVENT_SCHEMA)
+    rollout_idx = income_rows.get_column("rollout_index").to_numpy()
+    income = income_rows.get_column("ordinary_income_usd").to_numpy()
+    blocks = []
+    for jurisdiction_id in profile.jurisdiction_ids:
+        jurisdiction = jurisdictions[jurisdiction_id]
+        deduction = jurisdiction.standard_deduction[profile.filing_status]
+        taxable = np.maximum(income - deduction, 0.0)
+        brackets = jurisdiction.ordinary_income_brackets[profile.filing_status]
+        tax = apply_brackets(taxable, brackets)
+        cause_id = f"{profile.agent_id}_{jurisdiction_id}_year_end_accrual_m{month}"
+        blocks.append(
+            pl.DataFrame(
+                {
+                    "rollout_index": rollout_idx,
+                    "month_index": np.full_like(rollout_idx, month),
+                    "cause_id": [cause_id] * len(rollout_idx),
+                    "agent_id": [profile.agent_id] * len(rollout_idx),
+                    "jurisdiction_id": [jurisdiction_id] * len(rollout_idx),
+                    "tax_year_end_month": np.full_like(rollout_idx, month),
+                    "amount_usd": tax,
+                },
+                schema=TAX_ACCRUAL_EVENT_SCHEMA,
+            )
+        )
+    return pl.concat(blocks)

--- a/augur/sim/step.py
+++ b/augur/sim/step.py
@@ -21,17 +21,20 @@ from __future__ import annotations
 import polars as pl
 
 from augur.sim.events import ASSET_PURCHASE_EVENT_SCHEMA, LOT_DISPOSITION_EVENT_SCHEMA, TRANSFER_EVENT_SCHEMA, EventLog
+from augur.sim.market import MarketContext
 from augur.sim.scenario import RecurringTransfer, Scenario, ScheduledAssetSale, ScheduledTransfer
 from augur.sim.state import StateCrossSection
 
 
-def step_emit_events(*, state: StateCrossSection, scenario: Scenario, month: int, rollout_count: int) -> EventLog:
+def step_emit_events(
+    *, state: StateCrossSection, scenario: Scenario, market: MarketContext, month: int, rollout_count: int
+) -> EventLog:
     """Return the events to apply at this month. Pure: does not
     mutate `state`."""
     return EventLog(
         transfers=_emit_transfers(scenario, month, rollout_count),
         asset_purchases=pl.DataFrame(schema=ASSET_PURCHASE_EVENT_SCHEMA),
-        lot_dispositions=_emit_lot_dispositions(state, scenario, month),
+        lot_dispositions=_emit_lot_dispositions(state, scenario, market, month),
     )
 
 
@@ -69,27 +72,31 @@ def _transfer_block_per_rollout(
     )
 
 
-def _emit_lot_dispositions(state: StateCrossSection, scenario: Scenario, month: int) -> pl.DataFrame:
+def _emit_lot_dispositions(
+    state: StateCrossSection, scenario: Scenario, market: MarketContext, month: int
+) -> pl.DataFrame:
     """Emit `LotDisposition` rows for every scheduled asset sale at
     this month. Each sale is FIFO-resolved against the agent's
     current lots of the asset; the same resolution applies
     per-rollout via polars window functions over `rollout_index`.
 
-    At spike-1 step 4 part A scenarios have at most one sale per
-    `(agent, asset)` per month, so the resolution reads the current
-    `state.asset_lots` directly and emits its dispositions without
-    chaining."""
+    When the sale supplies an explicit `price_per_unit_usd` that
+    price applies uniformly across rollouts; otherwise the price
+    comes from the market bundle's per-rollout per-month curve."""
     sales = [s for s in scenario.scheduled_asset_sales if s.month == month]
     if not sales:
         return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
-    blocks = [_fifo_dispositions_for_sale(state, sale, month) for sale in sales]
+    prices_at_month = market.prices_at(month)
+    blocks = [_fifo_dispositions_for_sale(state, sale, prices_at_month, month) for sale in sales]
     blocks = [b for b in blocks if not b.is_empty()]
     if not blocks:
         return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
     return pl.concat(blocks).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))
 
 
-def _fifo_dispositions_for_sale(state: StateCrossSection, sale: ScheduledAssetSale, month: int) -> pl.DataFrame:
+def _fifo_dispositions_for_sale(
+    state: StateCrossSection, sale: ScheduledAssetSale, prices_at_month: pl.DataFrame, month: int
+) -> pl.DataFrame:
     """Vectorized FIFO consumption of one sale across all rollouts.
 
     Within each rollout the lots of the matching `(agent_id,
@@ -97,7 +104,12 @@ def _fifo_dispositions_for_sale(state: StateCrossSection, sale: ScheduledAssetSa
     sale eats from the oldest forward. A lot's `units_sold` is
     `clip(sale.quantity - prev_cumulative_remaining, 0,
     remaining_quantity)`. The result is one disposition row per
-    consumed lot per rollout."""
+    consumed lot per rollout.
+
+    Pricing: if `sale.price_per_unit_usd` is set it's used as a
+    scalar; otherwise `prices_at_month` is joined by
+    `(rollout_index, asset_id)` so each rollout gets its own
+    market-derived price."""
     candidates = state.asset_lots.filter(
         (pl.col("agent_id") == sale.agent_id)
         & (pl.col("asset_id") == sale.asset_id)
@@ -105,7 +117,8 @@ def _fifo_dispositions_for_sale(state: StateCrossSection, sale: ScheduledAssetSa
     )
     if candidates.is_empty():
         return pl.DataFrame(schema=LOT_DISPOSITION_EVENT_SCHEMA)
-    ordered = candidates.sort(["rollout_index", "purchase_month_index", "lot_id"])
+    priced = _attach_unit_price(candidates, sale, prices_at_month)
+    ordered = priced.sort(["rollout_index", "purchase_month_index", "lot_id"])
     with_cum = ordered.with_columns(
         _prev_cum_remaining=(
             pl.col("remaining_quantity").cum_sum().over("rollout_index") - pl.col("remaining_quantity")
@@ -125,6 +138,18 @@ def _fifo_dispositions_for_sale(state: StateCrossSection, sale: ScheduledAssetSa
         pl.lit(sale.cause_id, dtype=pl.Utf8()).alias("cause_id"),
         pl.col("_units_from_lot").alias("units_sold"),
         (pl.col("_units_from_lot") * pl.col("cost_basis_per_unit_usd")).alias("cost_basis_consumed_usd"),
-        (pl.col("_units_from_lot") * pl.lit(sale.price_per_unit_usd)).alias("proceeds_usd"),
+        (pl.col("_units_from_lot") * pl.col("_unit_price")).alias("proceeds_usd"),
         pl.lit(sale.proceeds_account_id, dtype=pl.Utf8()).alias("proceeds_account_id"),
     ).select(list(LOT_DISPOSITION_EVENT_SCHEMA.keys()))
+
+
+def _attach_unit_price(lots: pl.DataFrame, sale: ScheduledAssetSale, prices_at_month: pl.DataFrame) -> pl.DataFrame:
+    """Add a `_unit_price` column to the candidate lots. Scalar
+    price (configured on the sale) is broadcast across rollouts;
+    market-derived price is joined per `(rollout_index, asset_id)`."""
+    if sale.price_per_unit_usd is not None:
+        return lots.with_columns(pl.lit(sale.price_per_unit_usd, dtype=pl.Float64()).alias("_unit_price"))
+    prices_for_asset = prices_at_month.filter(pl.col("asset_id") == sale.asset_id).rename(
+        {"price_per_unit_usd": "_unit_price"}
+    )
+    return lots.join(prices_for_asset.select("rollout_index", "_unit_price"), on="rollout_index", how="left")

--- a/augur/sim/tax.py
+++ b/augur/sim/tax.py
@@ -36,3 +36,26 @@ def apply_brackets(amounts_per_rollout: np.ndarray, brackets: list[TaxBracket]) 
         tax += in_bracket * bracket.rate
         prev_upper = bracket.upper_usd
     return tax
+
+
+def apply_ltcg_brackets(
+    ltcg_amount: np.ndarray, ordinary_taxable: np.ndarray, ltcg_brackets: list[TaxBracket]
+) -> np.ndarray:
+    """Walk a federal-style LTCG bracket schedule where rates depend
+    on where the gain sits in the combined ordinary+LTCG stack
+    (§1(h)). Conceptually: ordinary income occupies brackets first;
+    LTCG fills the brackets above it at the LTCG rates.
+
+    For each bracket, the LTCG slice in it is
+    `clip(min(ordinary + ltcg, upper) - max(ordinary, prev_upper),
+    0, ∞)`. Vectorized across the rollout dimension."""
+    tax = np.zeros_like(ltcg_amount, dtype=np.float64)
+    prev_upper = 0.0
+    total_taxable = ordinary_taxable + ltcg_amount
+    for bracket in ltcg_brackets:
+        slice_top = np.minimum(total_taxable, bracket.upper_usd)
+        slice_bottom = np.maximum(ordinary_taxable, prev_upper)
+        in_bracket = np.maximum(slice_top - slice_bottom, 0.0)
+        tax += in_bracket * bracket.rate
+        prev_upper = bracket.upper_usd
+    return tax

--- a/augur/sim/tax.py
+++ b/augur/sim/tax.py
@@ -1,0 +1,38 @@
+"""Tax computation primitives.
+
+The bracket-walk function (`apply_brackets`) is the only piece of
+tax math that doesn't live inline in `step.py` / `apply.py`. It
+takes a per-rollout vector of taxable income and a bracket
+schedule (already loaded from a jurisdiction YAML) and returns the
+per-rollout tax owed. Pure numpy, no scenario / state knowledge.
+
+At spike 1 step 7 only ordinary-income brackets are walked.
+Capital-gains-aware bracket math comes at step 8.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from augur.sim.jurisdictions import TaxBracket
+
+
+def apply_brackets(amounts_per_rollout: np.ndarray, brackets: list[TaxBracket]) -> np.ndarray:
+    """Walk a marginal-rate schedule across each amount in
+    `amounts_per_rollout` and return the per-rollout tax owed.
+
+    Vectorized: each bracket contributes
+    `clip(min(amount, upper) - prev_upper, 0, ∞) * rate` to the
+    running tax for every rollout simultaneously. The top
+    `upper_usd: .inf` bracket catches all remaining income.
+
+    Inputs at or below 0 (e.g. after standard-deduction subtraction)
+    produce 0 tax — `clip` clamps the negative slice to 0."""
+    tax = np.zeros_like(amounts_per_rollout, dtype=np.float64)
+    prev_upper = 0.0
+    for bracket in brackets:
+        slice_top = np.minimum(amounts_per_rollout, bracket.upper_usd)
+        in_bracket = np.maximum(slice_top - prev_upper, 0.0)
+        tax += in_bracket * bracket.rate
+        prev_upper = bracket.upper_usd
+    return tax

--- a/augur/sim/tax_test.py
+++ b/augur/sim/tax_test.py
@@ -1,0 +1,63 @@
+"""Tests for the marginal-rate bracket walk."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest_bazel
+
+from augur.sim.jurisdictions import TaxBracket, load_jurisdiction
+from augur.sim.tax import apply_brackets
+
+
+def test_apply_brackets_hand_computed_federal_single_50k() -> None:
+    """Federal single filer on $50k taxable income (2024 brackets):
+    10% × 11600 + 12% × (47150-11600) + 22% × (50000-47150)
+    = 1160.00 + 4266.00 + 627.00 = 6053.00."""
+    fed = load_jurisdiction("federal_us")
+    tax = apply_brackets(np.array([50_000.0]), fed.ordinary_income_brackets["single"])
+    assert math.isclose(tax[0], 6053.0, abs_tol=1e-6)
+
+
+def test_apply_brackets_hand_computed_federal_single_200k() -> None:
+    """Federal single filer on $200k taxable income:
+    10% × 11600 + 12% × 35550 + 22% × 53375 + 24% × 91425 + 32% × 8050
+    = 1160 + 4266 + 11742.50 + 21942.00 + 2576.00 = 41686.50."""
+    fed = load_jurisdiction("federal_us")
+    tax = apply_brackets(np.array([200_000.0]), fed.ordinary_income_brackets["single"])
+    assert math.isclose(tax[0], 41_686.5, abs_tol=1e-6)
+
+
+def test_apply_brackets_vectorized_handles_multiple_rollouts() -> None:
+    """Walk a vector of incomes in one pass — every rollout
+    consumes the same schedule but produces independent tax
+    figures."""
+    fed = load_jurisdiction("federal_us")
+    incomes = np.array([0.0, 11_600.0, 50_000.0, 200_000.0])
+    tax = apply_brackets(incomes, fed.ordinary_income_brackets["single"])
+    assert math.isclose(tax[0], 0.0)
+    assert math.isclose(tax[1], 1160.0, abs_tol=1e-6)
+    assert math.isclose(tax[2], 6053.0, abs_tol=1e-6)
+    assert math.isclose(tax[3], 41_686.5, abs_tol=1e-6)
+
+
+def test_apply_brackets_negative_input_zeroes_out() -> None:
+    """Sub-zero amounts (e.g. after subtracting the standard
+    deduction from a low income) produce zero tax."""
+    brackets = [TaxBracket(upper_usd=10.0, rate=0.1), TaxBracket(upper_usd=math.inf, rate=0.2)]
+    tax = apply_brackets(np.array([-50.0, 0.0, 5.0, 15.0]), brackets)
+    assert tax.tolist() == [0.0, 0.0, 0.5, 2.0]
+
+
+def test_apply_brackets_california_single_100k() -> None:
+    """California single filer on $100k:
+    1% × 10412 + 2% × 14272 + 4% × 14275 + 6% × 15122 + 8% × 14269 + 9.3% × 31650
+    = 104.12 + 285.44 + 571.00 + 907.32 + 1141.52 + 2943.45 = 5952.85."""
+    ca = load_jurisdiction("california")
+    tax = apply_brackets(np.array([100_000.0]), ca.ordinary_income_brackets["single"])
+    assert math.isclose(tax[0], 5952.85, abs_tol=0.01)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/tax_test.py
+++ b/augur/sim/tax_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest_bazel
 
 from augur.sim.jurisdictions import TaxBracket, load_jurisdiction
-from augur.sim.tax import apply_brackets
+from augur.sim.tax import apply_brackets, apply_ltcg_brackets
 
 
 def test_apply_brackets_hand_computed_federal_single_50k() -> None:
@@ -57,6 +57,53 @@ def test_apply_brackets_california_single_100k() -> None:
     ca = load_jurisdiction("california")
     tax = apply_brackets(np.array([100_000.0]), ca.ordinary_income_brackets["single"])
     assert math.isclose(tax[0], 5952.85, abs_tol=0.01)
+
+
+def test_ltcg_brackets_zero_when_total_taxable_below_threshold() -> None:
+    """Ordinary $30k + LTCG $10k = $40k total. The federal 0% LTCG
+    bracket extends to $47,025 so all $10k of LTCG falls in it →
+    zero tax."""
+    fed = load_jurisdiction("federal_us")
+    assert fed.ltcg_brackets is not None
+    tax = apply_ltcg_brackets(np.array([10_000.0]), np.array([30_000.0]), fed.ltcg_brackets["single"])
+    assert math.isclose(tax[0], 0.0, abs_tol=1e-6)
+
+
+def test_ltcg_brackets_split_across_zero_and_fifteen_percent() -> None:
+    """Ordinary $30k + LTCG $20k = $50k total. The 0% bracket ends
+    at $47,025; LTCG occupies $30k-$50k.
+    0% rate on $30k-$47,025 = $17,025 → $0.
+    15% rate on $47,025-$50,000 = $2,975 → $446.25.
+    Total LTCG tax = $446.25."""
+    fed = load_jurisdiction("federal_us")
+    assert fed.ltcg_brackets is not None
+    tax = apply_ltcg_brackets(np.array([20_000.0]), np.array([30_000.0]), fed.ltcg_brackets["single"])
+    assert math.isclose(tax[0], 446.25, abs_tol=1e-6)
+
+
+def test_ltcg_brackets_pure_fifteen_when_ordinary_already_in_15pct_band() -> None:
+    """Ordinary income $100k already past the 0% LTCG threshold.
+    LTCG $50k sits entirely in the 15% bracket → $7500."""
+    fed = load_jurisdiction("federal_us")
+    assert fed.ltcg_brackets is not None
+    tax = apply_ltcg_brackets(np.array([50_000.0]), np.array([100_000.0]), fed.ltcg_brackets["single"])
+    assert math.isclose(tax[0], 7500.0, abs_tol=1e-6)
+
+
+def test_ltcg_brackets_vectorized() -> None:
+    """One call, four rollouts, each with its own ordinary + LTCG
+    combination — all bracket walks share the same schedule."""
+    fed = load_jurisdiction("federal_us")
+    assert fed.ltcg_brackets is not None
+    tax = apply_ltcg_brackets(
+        np.array([10_000.0, 20_000.0, 50_000.0, 0.0]),
+        np.array([30_000.0, 30_000.0, 100_000.0, 0.0]),
+        fed.ltcg_brackets["single"],
+    )
+    assert math.isclose(tax[0], 0.0, abs_tol=1e-6)
+    assert math.isclose(tax[1], 446.25, abs_tol=1e-6)
+    assert math.isclose(tax[2], 7500.0, abs_tol=1e-6)
+    assert math.isclose(tax[3], 0.0, abs_tol=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean rewrite of the simulator under `augur/sim/` replacing the 5-way
mishmash in `augur/core/scenario_engine.py`. Built from scratch starting
from "Alice gives Bob $5" and layered up through the spike-1 spec
(<augur/sim/SPIKE_1.md>).

## Architectural principles (all enforced by the code)

- **Event log canonical, state as materialization.** `apply_events` is
  the only function that writes state. `state_at(M)` equals
  `apply_events(initial_state, log.filter(month ≤ M))` — modulo
  year-boundary resets that the cumulative-replay form doesn't preserve.
- **One forward loop over months.** No post-hoc second pass; causality
  flows past → future via the two-phase step (scheduled events,
  then policy reactions).
- **Vectorized over rollouts.** Every step expression is polars over
  the rollout column. The only Python loops are over months (the
  outermost) and over assets within a policy (typically 3–5 items).
- **Generic templates.** `vti`, `qqq`, `btc`, `efv` flow through
  identical code paths — `asset_id` is data, not branched code.
- **DRY tax routing.** Federal stacks LTCG above ordinary+STCG per
  §1(h); California flattens all gains into ordinary brackets. One
  bracket-walk function, one LTCG-walk function — both vectorized.

## What landed (spike-1 implementation order)

- L1–L3 — transfers, multi-month, 1k-rollout scaling
- L4 — tax lots (FIFO consumption, single + multi-lot crossings)
- L5+L10 — market integration (DeterministicPath, GBM with seeded RNG)
- jurisdiction + location YAML loaders (federal_us, california, san_francisco)
- L7 — ordinary income tax + year-end accrual
- L6 — LTCG/STCG classification + federal LTCG bracket walk + CA flatten
- L9+L11 — floor-triggered sale policy, rollout failure detection
- Benchable end-to-end scenario + bench script
- DRY proof: 4th capital-gains-eligible position is one InitialLot +
  one MarketPath; zero engine code touched (asserted in
  `bench_test.py::test_dry_add_fourth_position_is_config_only`)

## Deferred (out of spike-1 scope)

- L6 quarterly estimated-payment timing — year-end accrual books the
  liability but no quarterly transfers (full tax effectively due at
  year-end).
- L8 mortgages, L12–L13 housing, L14 constrained sellability
  (mask wired but no scenarios exercise it), partner-equity stretch,
  S9.7 variable spend from market, HoH/MFJ, NIIT, itemized deductions,
  multi-jurisdiction beyond federal+CA.
- Replay-invariant tests for the new state frames
  (tax_liabilities, capital_gains_ytd, rollout_status).

## Test plan

- [x] `bbr test //augur/sim/...` — all 5 test targets pass on RBE
  (`bench_test`, `locations_test`, `simulate_test`,
  `jurisdictions_test`, `tax_test`)
- [x] Hand-computed tax figures match the engine:
  Federal single $200k W-2 ≈ $37,538.50; CA $14,754.09;
  Federal $50k W-2 + $20k LTCG ≈ $5,272.25
- [x] 1000 rollouts × 60 months bench scenario runs end-to-end
- [ ] Replay-invariant assertions extended to tax + rollout-status
      frames (deferred to next spike)

https://claude.ai/code/session_01WsVZGoEeh3XbPnpeaPWrCt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsVZGoEeh3XbPnpeaPWrCt)_