### PR TITLE
debundle: fix class method body depth + auto-fold rebind atomic units

### DIFF
--- a/devinfra/js/debundle/analysis_tests.rs
+++ b/devinfra/js/debundle/analysis_tests.rs
@@ -171,6 +171,22 @@ mod tests {
         );
     }
 
+    /// A binding rebind inside a class method body sits at depth 1
+    /// (the method's function body is the immediate body, just like
+    /// a bare `function f() { ... }`). Must show up in
+    /// `first_order_lazy_rebinds` so the owner-graph emits a
+    /// constraining `LazyRebind` edge for it.
+    #[test]
+    fn first_order_lazy_rebind_in_class_method_body() {
+        let module = parse("let counter = 0; class C { bump(b) { counter = b; } }");
+        let facts = analyze_facts(&module);
+        assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("counter")]));
+        assert_eq!(
+            facts[1].first_order_lazy_rebinds,
+            BTreeSet::from([test_id("counter")])
+        );
+    }
+
     /// A binding rebind inside a nested closure (depth ≥ 2) shows
     /// up in `lazy_rebinds` but NOT in `first_order_lazy_rebinds`
     /// — invoking the outer function synchronously only stashes

--- a/devinfra/js/debundle/facts.rs
+++ b/devinfra/js/debundle/facts.rs
@@ -1060,7 +1060,11 @@ fn lazy_visit_arrow_expr<V: LazyBoundary>(v: &mut V, node: &ArrowExpr) {
 
 fn lazy_visit_method_prop<V: LazyBoundary>(v: &mut V, node: &MethodProp) {
     node.key.visit_with(v);
-    v.descend_lazy(|s| node.function.visit_with(s));
+    // `node.function.visit_with` dispatches to `visit_function`, which
+    // already calls `descend_lazy` via `lazy_visit_function`. No outer
+    // descend here — the method body must land at lazy_depth 1, the
+    // same as a bare `function f() { ... }`.
+    node.function.visit_with(v);
 }
 
 fn lazy_visit_getter_prop<V: LazyBoundary>(v: &mut V, node: &GetterProp) {
@@ -1089,11 +1093,19 @@ fn lazy_visit_class<V: LazyBoundary>(v: &mut V, node: &Class) {
 fn lazy_visit_class_member<V: LazyBoundary>(v: &mut V, member: &ClassMember) {
     visit_eager_member_parts(v, member);
     match member {
+        // `method.function.visit_with` dispatches to `visit_function`,
+        // which already calls `descend_lazy` via `lazy_visit_function`.
+        // No outer descend here — a method body must land at
+        // lazy_depth 1, the same as a bare `function f() { ... }`,
+        // so rebinds in the immediate body show up in
+        // `first_order_lazy_rebinds` and the owner-graph emits the
+        // constraining `LazyRebind` edge that catches cross-module
+        // writes to imported bindings (ESM rejects at runtime).
         ClassMember::Method(method) => {
-            v.descend_lazy(|s| method.function.visit_with(s));
+            method.function.visit_with(v);
         }
         ClassMember::PrivateMethod(method) => {
-            v.descend_lazy(|s| method.function.visit_with(s));
+            method.function.visit_with(v);
         }
         ClassMember::Constructor(ctor) => {
             v.descend_lazy(|s| ctor.visit_children_with(s));

--- a/devinfra/js/debundle/lowering/materialize.rs
+++ b/devinfra/js/debundle/lowering/materialize.rs
@@ -475,6 +475,15 @@ pub(super) fn materialize_logical_chunk(
         let precomputed = time_phase!(timings, "compute_owner_graph_and_units", {
             compute_owner_graph_and_units_with(&analysis.facts, owner_graph_options)
         });
+        time_phase!(timings, "fold_rebind_atomic_units", {
+            fold_rebind_atomic_units(
+                &precomputed,
+                &mut binding_assignment,
+                &mut bindings_catalogue,
+                &mut module_plans,
+                residual_plan_index,
+            );
+        });
         if matches!(chunk_unassigned_mode, UnassignedMode::MiniFactors) {
             time_phase!(timings, "synthesize_mini_factor_plans", {
                 synthesize_mini_factor_plans(
@@ -844,4 +853,118 @@ pub(super) fn materialized_chunk_artifact(
         },
         decomposition,
     )
+}
+
+/// Resolve rebind-only atomic-unit "soft" conflicts by silently
+/// extending the explicit claim's plan to cover any member of the
+/// cycle that has no explicit destination.
+///
+/// Atomic factor units symmetrize `LazyRebind`/`EagerRebind` edges
+/// (see <atomic_units.rs>) because ESM imports are read-only — a
+/// peel that places the rebind's write site in one module and its
+/// declaration in another would emit code that throws `TypeError:
+/// Assignment to constant variable` the first time the assignment
+/// fires. Without this pass, such a spec would surface as an
+/// `atomic_unit_conflict` and the materializer would bail.
+///
+/// When exactly one member of the cycle carries an explicit claim
+/// and the rest are unclaimed (or were already swept into the
+/// residual landing site), the conflict is the spec author's
+/// implicit oversight rather than a contradiction: they peeled the
+/// writer but left the declarer at the default destination, not
+/// realizing the cycle pulls them together. Extending the writer's
+/// module to cover the declarer keeps the rebind intra-module —
+/// the writer's assignment resolves locally — and preserves the
+/// spec's peel intent.
+///
+/// Multi-explicit-destination conflicts fall through unchanged so
+/// the materializer's bail surfaces the contradiction. Conflicts
+/// with non-rebind causes (`LocalEffect`, eager cycles, sequenced
+/// side-effect chains) also fall through — those have their own
+/// resolution stories and are intentionally surfaced as hard
+/// errors.
+fn fold_rebind_atomic_units(
+    precomputed: &OwnerGraphAndUnits,
+    binding_assignment: &mut HashMap<Id, usize>,
+    bindings_catalogue: &mut HashMap<Id, BindingKind>,
+    module_plans: &mut [ModulePlan],
+    residual_plan_index: Option<usize>,
+) {
+    let owner_graph = &precomputed.owner_graph;
+    'unit: for unit in &precomputed.atomic_units {
+        if unit.causes.is_empty() {
+            continue;
+        }
+        let rebind_only = unit
+            .causes
+            .iter()
+            .all(|cause| matches!(cause, DepKind::LazyRebind | DepKind::EagerRebind));
+        if !rebind_only {
+            continue;
+        }
+        let mut explicit_dest: Option<usize> = None;
+        let mut owners_to_fold: Vec<OwnerId> = Vec::new();
+        for &owner_id in &unit.members {
+            let Some(node) = owner_graph.node(owner_id) else {
+                continue;
+            };
+            if node.declared.is_empty() {
+                // Anonymous statements don't appear in `binding_assignment`;
+                // their routing is via `anonymous_ordinal_assignment`. They
+                // can't be the carrier of a rebind cause anyway — a rebind
+                // edge needs a declared target — so skipping them is safe.
+                continue;
+            }
+            let mut owner_claim: Option<usize> = None;
+            for binding_id in &node.declared {
+                let Some(&idx) = binding_assignment.get(binding_id) else {
+                    continue;
+                };
+                // A binding that was swept into the residual landing site
+                // counts as "unclaimed" for fold purposes — the user didn't
+                // explicitly route it there, the sweep did.
+                if Some(idx) == residual_plan_index {
+                    continue;
+                }
+                owner_claim = Some(idx);
+                break;
+            }
+            match owner_claim {
+                Some(idx) => match explicit_dest {
+                    None => explicit_dest = Some(idx),
+                    Some(existing) if existing != idx => continue 'unit,
+                    _ => {}
+                },
+                None => owners_to_fold.push(owner_id),
+            }
+        }
+        let Some(dest) = explicit_dest else {
+            continue;
+        };
+        if owners_to_fold.is_empty() {
+            continue;
+        }
+        let module_id = ModuleId(LogicalModuleIndex(dest));
+        for owner_id in owners_to_fold {
+            let Some(node) = owner_graph.node(owner_id) else {
+                continue;
+            };
+            for binding_id in &node.declared {
+                let was_assigned = binding_assignment.get(binding_id).copied();
+                binding_assignment.insert(binding_id.clone(), dest);
+                bindings_catalogue
+                    .insert(binding_id.clone(), BindingKind::Owned { owner: module_id });
+                let name = binding_id.0.as_ref().to_string();
+                module_plans[dest]
+                    .bindings
+                    .entry(name.clone())
+                    .or_insert_with(|| name.clone());
+                if let Some(was) = was_assigned
+                    && Some(was) == residual_plan_index
+                {
+                    module_plans[was].bindings.remove(&name);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes the soundness gap pinned by `accepted_spec_runs_under_node_test::peeled_method_reassigning_top_level_let_executes_under_node` (the RED test landed in #1689). A peel that placed `class Counter { bump(b) { counter = b; }}` in `mod_counter_class` while the `let counter` stayed in entry compiled cleanly but threw `TypeError: Assignment to constant variable` the first time `c.bump(1)` ran — imported ESM bindings are read-only.

## Two interacting bugs

1. **Depth tracking double-descend for class/object methods** (`facts.rs`).
   `lazy_visit_class_member` and `lazy_visit_method_prop` each called `descend_lazy(|s| method.function.visit_with(s))`, but `method.function.visit_with` dispatches to `visit_function` which ALREADY calls `descend_lazy` via `lazy_visit_function`. The result: a method body landed at `lazy_depth == 2`, so any rebind inside it was excluded from `first_order_lazy_rebinds`, no `LazyRebind` owner edge was emitted, and the realizability gate accepted the peel.

   Fix: drop the outer `descend_lazy` so the method body lands at depth 1, matching a bare `function f() { ... }`.

2. **Atomic-unit conflict on a soft (unclaimed) rebind target bailed the materializer** (`lowering/materialize.rs`).
   With the depth fix in place, the `LazyRebind(Counter → counter)` edge surfaces an atomic-unit cycle `{Counter, counter}`. The spec claimed `Counter` for `mod_counter_class` but left `counter` unclaimed (default `unassigned_mode: inline_in_entry`), so `assemble_partition` reported a cross-module atomic-unit conflict and `materialize_logical_chunk` bailed.

   Fix: a new `fold_rebind_atomic_units` pass runs right after `compute_owner_graph_and_units` and before factorization. For each atomic unit whose causes are entirely `LazyRebind`/`EagerRebind` and whose members carry exactly one explicit destination plus one or more unclaimed (or residual-swept) members, the unclaimed members are extended onto the explicit destination's plan (`binding_assignment`, `bindings_catalogue`, `module_plans`). Hard conflicts (multiple explicit destinations) and non-rebind causes (`LocalEffect`, eager cycles, sequenced chains) fall through unchanged, so the existing `materializer_rejects_splitting_annotated_decorator_effect_from_target_class` test still surfaces its bail.

This implements option 1 from #1689's "Expected fix": the spec's peel intent is preserved (Counter and c stay in `mod_counter_class`), and `counter` is silently pulled along with them so the rebind resolves intra-module.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...` — all 56 tests pass.
- [x] The previously-RED `peeled_method_reassigning_top_level_let_executes_under_node` now PASSES.
- [x] New unit test `first_order_lazy_rebind_in_class_method_body` pins the depth-1 invariant for class method bodies.
- [x] Existing rebind-rejection tests (`cross_destination_lazy_write_is_rejected`, `materializer_rejects_splitting_annotated_decorator_effect_from_target_class`) still pass — they exercise hard-conflict paths the fold deliberately leaves alone.

https://claude.ai/code/session_01Byjmw3vB1XBPx2qbe8hahV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byjmw3vB1XBPx2qbe8hahV)_