### PR TITLE
cluster/k8s: drop dead harbor-pull-robot imagePullSecrets refs from 5 ghcr-pulling deployments

### DIFF
--- a/cluster/k8s/activitywatch/deployment.yaml
+++ b/cluster/k8s/activitywatch/deployment.yaml
@@ -24,8 +24,6 @@ spec:
         fsGroup: 999
       nodeSelector:
         topology.kubernetes.io/region: proxmox
-      imagePullSecrets:
-        - name: harbor-pull-robot
       containers:
         - name: aw-server
           image: ghcr.io/agentydragon/aw-server:devel-20260522024811-bae306b # {"$imagepolicy": "flux-system:activitywatch"}

--- a/cluster/k8s/agents/airlock/deployment.yaml
+++ b/cluster/k8s/agents/airlock/deployment.yaml
@@ -23,8 +23,6 @@ spec:
       serviceAccountName: airlock
       securityContext:
         fsGroup: 1000
-      imagePullSecrets:
-        - name: harbor-pull-robot
       containers:
         - name: airlock
           image: ghcr.io/agentydragon/airlock:devel-20260515210919-a51187a # {"$imagepolicy": "flux-system:airlock"}

--- a/cluster/k8s/agents/airlock/kubeapi-admin-exec-mcp-deployment.yaml
+++ b/cluster/k8s/agents/airlock/kubeapi-admin-exec-mcp-deployment.yaml
@@ -20,8 +20,6 @@ spec:
         app.kubernetes.io/name: airlock
         app.kubernetes.io/component: kubeapi-admin-exec-mcp
     spec:
-      imagePullSecrets:
-        - name: harbor-pull-robot
       serviceAccountName: kubeapi-admin-exec-mcp
       automountServiceAccountToken: true
       containers:

--- a/cluster/k8s/agents/homeassistant-proxy/deployment.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/deployment.yaml
@@ -22,8 +22,6 @@ spec:
       serviceAccountName: homeassistant-proxy
       securityContext:
         fsGroup: 1000
-      imagePullSecrets:
-        - name: harbor-pull-robot
       containers:
         - name: homeassistant-proxy
           image: ghcr.io/agentydragon/homeassistant-proxy:devel-20260522024329-b644a41 # {"$imagepolicy": "flux-system:homeassistant-proxy"}

--- a/cluster/k8s/agents/tana-mcp/README.md
+++ b/cluster/k8s/agents/tana-mcp/README.md
@@ -215,7 +215,6 @@ Expected path behavior through the proxy:
 
 ## Secrets
 
-| Secret                                    | Key                 | Source                                        |
-| ----------------------------------------- | ------------------- | --------------------------------------------- |
-| `harbor-pull-robot`                       | `.dockerconfigjson` | harbor-ci TF (Reflector mirror)               |
-| `tana-agentydragon-gmail-com-account-pat` | `token`             | SOPS-managed PAT for `agentydragon@gmail.com` |
+| Secret                                    | Key     | Source                                        |
+| ----------------------------------------- | ------- | --------------------------------------------- |
+| `tana-agentydragon-gmail-com-account-pat` | `token` | SOPS-managed PAT for `agentydragon@gmail.com` |

--- a/cluster/k8s/agents/tana-mcp/deployment.yaml
+++ b/cluster/k8s/agents/tana-mcp/deployment.yaml
@@ -21,8 +21,6 @@ spec:
     spec:
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
-      imagePullSecrets:
-        - name: harbor-pull-robot
       containers:
         # Tana Desktop running under Xvfb with noVNC for graphical admin access
         - name: tana-desktop


### PR DESCRIPTION
The harbor-pull-robot secret is a dockerconfigjson for registry.allegedly.works
and is only reflected to the props namespace (tf/gitops/harbor-ci/main.tf).
None of these deployments pull from Harbor — they all pull public images from
ghcr.io/agentydragon/* — so the imagePullSecrets refs were non-functional and
were producing FailedToRetrieveImagePullSecret warning events.

Affected: tana-mcp, homeassistant-proxy, airlock (server + kubeapi-admin-exec-mcp),
activitywatch (Flux-suspended). Also drop the harbor-pull-robot row from
tana-mcp/README.md secrets table.