### PR TITLE
debundle: code-review cleanup batch — tests, encapsulation, docs

### DIFF
--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -73,10 +73,6 @@ Newtype over `DiGraphMap` with `Deref`/`DerefMut` to inner type. Exposes full pe
 
 `flat_edges`, `nodes`, `edges`, `out_edges`, `in_edges` all `pub(crate)`. Any module can corrupt graph invariants. Reduce to explicit query methods.
 
-### `RealizabilityIndex` — raw `push`/`undo` should be private (`realizability.rs`)
-
-The `scoped` guard API is good, but `push` and `undo` are also `pub(crate)`, allowing callers to bypass the guard and corrupt the journal. Make them private unless a specific caller needs manual control (documented).
-
 ### `BTreeMap`/`BTreeSet` as default collection in hot-path graph structures
 
 `rollback_graph.rs`, `artifact.rs`, `realizability.rs` all use BTree collections exclusively. For structures with many lookups, `HashMap`/`HashSet` would be faster. If deterministic iteration is needed, document it at the struct level. `RollbackDiGraph` in particular does many lookups per operation where hash-based would be measurably faster.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -14,11 +14,6 @@ Remaining: strip-specific helpers, annotation/identity logic, wrapper generation
 
 Mixes graph construction (`ChunkCodeGraph`), whitelist constant tables (~400 lines of static data), expression classification, PlainData write scanning, and TS enum IIFE recognition.
 
-- Whitelist tables (`PURE_STATIC_PROPS` through `PLAIN_DATA_HOSTILE_BUILTINS`, lines ~1600–1750) should be in `purity/whitelists.rs` or a data file.
-- `classify_fresh_array_spread_source_purity` and `classify_fresh_array_spread_source_for_iterable` are near-identical recursive classifiers differing only in the result interpretation. Unify with a parameterized return.
-- ~80-line doc comment on `PURE_OBJECT_CALLS_ON_PLAIN_DATA` (lines 1657–1741) and ~55-line PlainData soundness comment (lines 37–91) are design-doc material. Keep 3–5 line summaries in code.
-- `ChunkCodeGraph` mixes SCC computation with classification state. The SCC computation could be a standalone function.
-
 ### `analysis_tests.rs` (4095 lines, 8+ subsystems)
 
 Tests 8+ distinct subsystems in one file: fact analysis, decorate helpers, cycle detection, atomic unit conflicts, purity classification, plain-data tracking, redundant hints, statement splitting, factor assembly. A test for purity must scroll past 600 lines of fact-analysis tests to find helpers.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -129,10 +129,6 @@ Identical to `CommandResult` (line 660). Only used in `assert_node_output` which
 
 Uses inline comment markers instead of `#[ignore]` with reason strings (like `purity_test.rs` does). Inconsistent.
 
-### `vendor_swap_test.rs` — 4 bundled_partial_swap tests duplicate inline fixture setup
-
-Lines 1030–1617 are four tests each manually creating the entire fixture inline (155 lines per test). Extract `run_bundled_partial_swap_fixture`.
-
 ---
 
 ## Live Proxy

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -133,10 +133,6 @@ Uses inline comment markers instead of `#[ignore]` with reason strings (like `pu
 
 Lines 1030–1617 are four tests each manually creating the entire fixture inline (155 lines per test). Extract `run_bundled_partial_swap_fixture`.
 
-### BUILD.bazel — all e2e tests depend on `:analysis` unconditionally
-
-Most tests don't need it. Split into two list comprehensions: one with standard deps, one for tests needing `:analysis`.
-
 ---
 
 ## Live Proxy

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -133,10 +133,6 @@ Uses inline comment markers instead of `#[ignore]` with reason strings (like `pu
 
 Lines 1030–1617 are four tests each manually creating the entire fixture inline (155 lines per test). Extract `run_bundled_partial_swap_fixture`.
 
-### `pure_members_test.rs` — 3 identical fixture shapes with different `pure_members` values
-
-Table-driven test candidate.
-
 ### BUILD.bazel — all e2e tests depend on `:analysis` unconditionally
 
 Most tests don't need it. Split into two list comprehensions: one with standard deps, one for tests needing `:analysis`.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -133,10 +133,6 @@ Uses inline comment markers instead of `#[ignore]` with reason strings (like `pu
 
 Lines 1030–1617 are four tests each manually creating the entire fixture inline (155 lines per test). Extract `run_bundled_partial_swap_fixture`.
 
-### `chunk_renames_test.rs` — verbose `FixtureOpts` construction repeated 4x
-
-8-field struct literal repeated. Add `FixtureOpts::new(...).with_chunk_renames(renames)` builder.
-
 ### `pure_members_test.rs` — 3 identical fixture shapes with different `pure_members` values
 
 Table-driven test candidate.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -129,14 +129,6 @@ Identical to `CommandResult` (line 660). Only used in `assert_node_output` which
 
 Uses inline comment markers instead of `#[ignore]` with reason strings (like `purity_test.rs` does). Inconsistent.
 
-### `realizability_test.rs` — inconsistent JSON construction
-
-Some tests use `logical_module()` helper, others use raw JSON for identical structures (`cyclic_spec_is_rejected_with_clear_error` has no non-standard fields that would justify raw JSON).
-
-### `realizability_test.rs:assert_fraction_metric` — float equality via `assert_eq!`
-
-Fragile for computed fractions. Use `assert!((a - b).abs() < 1e-10)` or approx comparison.
-
 ### `vendor_swap_test.rs` — 4 bundled_partial_swap tests duplicate inline fixture setup
 
 Lines 1030–1617 are four tests each manually creating the entire fixture inline (155 lines per test). Extract `run_bundled_partial_swap_fixture`.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -10,15 +10,14 @@ Full-package review of `devinfra/js/debundle/` (~47K lines). Findings prioritize
 
 Remaining: strip-specific helpers, annotation/identity logic, wrapper generation could each lift out into their own modules alongside the already-extracted `vendor/manifests.rs` and `vendor/strip.rs`.
 
-### `purity.rs` (2671 lines, 5 concerns)
+### `purity/mod.rs` (~2300 lines) — remaining concerns
 
-Mixes graph construction (`ChunkCodeGraph`), whitelist constant tables (~400 lines of static data), expression classification, PlainData write scanning, and TS enum IIFE recognition.
-
-### `analysis_tests.rs` (4095 lines, 8+ subsystems)
-
-Tests 8+ distinct subsystems in one file: fact analysis, decorate helpers, cycle detection, atomic unit conflicts, purity classification, plain-data tracking, redundant hints, statement splitting, factor assembly. A test for purity must scroll past 600 lines of fact-analysis tests to find helpers.
-
-Split into topic-aligned modules: `tests/facts.rs`, `tests/purity.rs`, `tests/plain_data.rs`, `tests/cycles.rs`, `tests/atomic_units.rs`, `tests/statement_splitting.rs`.
+Whitelist tables already in `purity/whitelists.rs`; long PlainData /
+`PURE_OBJECT_CALLS_ON_PLAIN_DATA` rustdocs already trimmed to
+`docs/purity_soundness.md`. Remaining: graph construction
+(`ChunkCodeGraph`), expression classification, PlainData write
+scanning, and TS enum IIFE recognition still live in `mod.rs` —
+could be sub-split further if it keeps growing.
 
 ### `facts.rs` (1213 lines, 2 concerns)
 
@@ -40,10 +39,6 @@ Split into topic-aligned modules: `tests/facts.rs`, `tests/purity.rs`, `tests/pl
 
 ## P2 — Structural Issues
 
-### `lowering/materialize.rs` (1026 lines) mixes 4 concerns
-
-Orchestration/plan resolution (lines 39–342), factorization wiring (344–579), rebind folding (914–1026), and artifact assembly (787–912) are unrelated. Extract `fold_rebind_atomic_units` into its own file and factor out the `analysis_hints` collection (lines 359–405 — two near-identical loops for `explicit_requests` and `chunk_renames`).
-
 ### `lower/lower.rs` — monolithic function (partially extracted)
 
 `lower_chunk` had 8 sequential phases inline. Four have been extracted into named functions (`compute_selected_ordinals`, `plan_selected_exports`, `split_entry_body`, `build_module_output`). Remaining inline phases (naturalization, disambiguation, import planning, the per-module loop) could be further extracted, though each requires substantial captured state from `LowerChunkInputs` (15–20 fields).
@@ -60,25 +55,9 @@ Each returns `self.root.join(CONSTANT)`. Replace with a data-driven approach: `r
 
 ## P3 — Encapsulation & Type Design
 
-### `ModuleQuotient` Deref/DerefMut leak (`graph.rs`)
-
-Newtype over `DiGraphMap` with `Deref`/`DerefMut` to inner type. Exposes full petgraph mutation API, defeating the newtype. `DerefMut` lets anyone add arbitrary edges. Expose only intended operations via explicit methods.
-
-### `OwnerGraph` exposes internal CSR structures (`graph.rs`)
-
-`flat_edges`, `nodes`, `edges`, `out_edges`, `in_edges` all `pub(crate)`. Any module can corrupt graph invariants. Reduce to explicit query methods.
-
 ### `BTreeMap`/`BTreeSet` as default collection in hot-path graph structures
 
 `rollback_graph.rs`, `artifact.rs`, `realizability.rs` all use BTree collections exclusively. For structures with many lookups, `HashMap`/`HashSet` would be faster. If deterministic iteration is needed, document it at the struct level. `RollbackDiGraph` in particular does many lookups per operation where hash-based would be measurably faster.
-
-### Hand-rolled Tarjan SCC (`rollback_graph.rs:119–191`)
-
-The file already depends on petgraph (used in tests). Implement petgraph's `GraphProp`/`IntoNeighbors` traits for `RollbackDiGraph` and use `petgraph::algo::tarjan_scc` instead of ~70 lines of hand-rolled Tarjan.
-
-### `RollbackDiGraph` allocates Vec per adjacency query
-
-`successors` and `predecessors` return `Vec<N>`, allocating on every call. Hot paths (SCC computation) call these in a loop. Return an iterator borrowing from the BTreeSet.
 
 ### `StatementFacts` (facts.rs) — 14 BTreeSet<Id> fields
 

--- a/devinfra/js/debundle/docs/purity_soundness.md
+++ b/devinfra/js/debundle/docs/purity_soundness.md
@@ -1,0 +1,132 @@
+# Purity classification — soundness notes
+
+Long-form rationales for two whitelist tables and one binding kind in
+`devinfra/js/debundle/purity/`. The code holds 3–5 line summaries; the
+exhaustive prose lives here so future audits don't have to scroll past
+80 lines of `///` to read the next function.
+
+## `ChunkBinding::PlainData`
+
+A chunk-top binding admits as `PlainData` when its declared value is a
+plain object/array literal, and the chunk-wide write scan can prove no
+post-init mutation can install an accessor on the binding's cell.
+Concrete shapes admitted: `const X = <plain literal>`; `let X = <plain
+literal>` / `var X = <plain literal>` with every chunk-top re-bind
+being another plain literal (whole-object replacement, no in-place
+mutation); the TS-enum-IIFE shape `var X = ((p) => (p.A = "a", …, p))(X
+|| {})` whose IIFE produces a plain object by parameter mutation (see
+`is_ts_enum_iife_init_for_binding`).
+
+Why member reads on PlainData are pure:
+
+- **No accessor channels at any program point.** The initial init is a
+  syntactic plain literal — no getters/setters/methods/computed
+  keys/`__proto__` — so the value carries only data properties. Every
+  re-bind writes another plain-literal value, so the post-write value
+  still has only data properties. Object/array spread inside the
+  literal (`{...src}`, `[...src]`) is permitted: `CopyDataProperties`
+  copies values via `CreateDataPropertyOrThrow` regardless of the
+  source's descriptor shape — the result is plain.
+
+- **No post-init accessor installation.** The chunk-wide write scan
+  rejects any member write (`X.k = …`, `X[k] = …`), member update,
+  member delete, or call to `Object.{defineProperty,defineProperties,
+setPrototypeOf,assign}` /
+  `Reflect.{defineProperty,set,setPrototypeOf,deleteProperty}` with
+  `X` as first arg. Plain-ident writes whose RHS is not a
+  plain-literal also disqualify.
+
+- **Re-bind soundness for `let`.** Reads on `X` after a re-bind see
+  the new plain-literal value; reads before still saw the old
+  plain-literal value. At no program point does `X` hold an
+  accessor-carrying value, so member reads fire no user code regardless
+  of write/read interleaving. The re-bind statement itself is
+  independently classified impure (the existing `AssignOrUpdate` rule
+  on `Expr::Assign`), so it keeps its `S`-edge and the debundler
+  cannot move it past sequenced points.
+
+Sound enabler for the recursive-purity claim "`x` reads on `x.k` /
+`x[pure]` are pure iff `x` is bound to a plain-data shape that has no
+accessor channels". Eliminates the chain-of-hints needed when a
+chunk-local helper's body is just a property read on a chunk-local
+config object — including the `let envConfig = {...}` / `envConfig =
+{...envConfig, ...n}` pattern that the
+`runtime/environment/env_config.yaml` spec hints in gaffer-private
+were a workaround for.
+
+## `PURE_OBJECT_CALLS_ON_PLAIN_DATA`
+
+Static `Object` methods that are Pure when called with a single
+argument that is structurally a fresh plain-data object/array literal
+(no accessors / methods / `__proto__` / computed keys / spread of
+non-plain-data sources) OR a chunk-top binding that has admitted as
+`ChunkBinding::PlainData`.
+
+The contract is stricter than `PURE_STATIC_CALLS` because every member
+here either invokes `[[Get]]` on own keys (which fires user getters /
+Proxy traps on a general argument) or mutates descriptor state
+(`freeze`). Restricting the argument shape to a fresh plain-data
+receiver — verified syntactically at the call site — closes both
+holes: no own-key access can fire a user accessor (none exist), and
+the mutation in `freeze`'s case targets a value that is not aliased
+through any user-observable channel before the call.
+
+Soundness per entry:
+
+- `Object.keys(O)` — ECMA-262 §20.1.2.17 calls `ToObject(O)` (no
+  coercion on an object), then `EnumerableOwnPropertyNames(O, "key")`.
+  The latter calls `[[OwnPropertyKeys]]` (for an ordinary plain
+  object: returns the integer-index keys then string keys in insertion
+  order, no user code) and per-key `[[GetOwnProperty]]` to check
+  `[[Enumerable]]` — also a structural read with no user code on a
+  fresh plain literal / PlainData binding.
+
+- `Object.values(O)` / `Object.entries(O)` — same as `keys` but
+  additionally call `[[Get]]` on each own key. For an ordinary
+  plain-data receiver every own key resolves to a data property
+  ($\Rightarrow$ no accessor fires). PlainData receivers carry the
+  same guarantee by the chunk-wide write scan (`PlainDataWriteScanner`
+  rejects any `Object.defineProperty(X, …)` /
+  `Object.setPrototypeOf(X, …)` that could install an accessor
+  post-init).
+
+- `Object.freeze(O)` — ECMA-262 §20.1.2.6 calls
+  `SetIntegrityLevel(O, "frozen")` which sets `[[Extensible]]` to
+  false and rewrites each own property descriptor to non-configurable
+  (and non-writable for data properties). No `[[Get]]` is performed,
+  no user code fires. The mutation is on the just-allocated literal
+  (for the literal form) or on a binding whose only producer/consumer
+  is the chunk being debundled (for the PlainData form), so it cannot
+  perturb user-observable state outside the call.
+
+- `Object.fromEntries(I)` — ECMA-262 §20.1.2.7 invokes
+  `I[@@iterator]()`. For a fresh `Array` literal with no spread, that
+  resolves to the built-in Array iterator, which `[[Get]]`s indices
+  `0..length` (own data properties on a fresh array, no user code) and
+  stops. Each yielded entry must itself be a 2-element Array literal
+  whose `[0]/[1]` reads are own data properties (gated by
+  `is_fresh_entry_array_for_from_entries`). Both gates together rule
+  out the "non-iterable argument throws TypeError" path that breaks
+  purity for arbitrary arg shapes (the throw is observable). For a
+  PlainData Object binding the call would throw, so PlainData shapes
+  are admitted only for the non-fromEntries methods.
+
+Out of scope (not admitted; flagged for follow-up review):
+
+- `Object.assign(target, src)` — mutates `target` AND calls
+  `[[OwnPropertyKeys]]`/`[[Get]]` on `src`. The target-mutation half
+  rules out the literal-arg shortcut: even with two literal args,
+  `Object.assign({}, …)` returns the first arg mutated, which is
+  observable only if the result is captured — but the mutation itself
+  is invisible without the capture, so this is safely pure-of-result.
+  Skipped to keep the rule tight; the `assign` path needs its own
+  argument-count + result-shape analysis.
+
+- `Object.getOwnPropertyNames(O)` / `getPrototypeOf(O)` /
+  `getOwnPropertyDescriptor(O, k)` — same shape as `keys` but produces
+  a richer return value. Could ride on the same gate in a follow-up;
+  out for v1 to minimize the audit surface.
+
+- `Array.from(I[, mapFn])` — sound only when `mapFn` is absent (a
+  `mapFn` invokes user code per element). Skipped to avoid the
+  per-call argument-count gate.

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -24,6 +24,22 @@ rust_library(
     ],
 )
 
+# Standard e2e tests: shell out to the built debundler binary against
+# a fixture spec and assert on the emitted artifact tree. They do not
+# call into the `:analysis` Rust library — splitting that dep off
+# avoids dragging the library through every test's compile graph.
+_STANDARD_E2E_DEPS = [
+    ":support",
+    "@crates//:serde",
+    "@crates//:serde_json",
+    "@crates//:serde_yaml",
+    "@crates//:swc_common",
+    "@crates//:swc_ecma_ast",
+    "@crates//:swc_ecma_parser",
+    "@crates//:tempfile",
+    "@rules_rust//tools/runfiles",
+]
+
 [
     rust_test(
         name = name,
@@ -34,18 +50,7 @@ rust_library(
             "@nodejs_linux_amd64//:bin/node",
         ],
         edition = "2024",
-        deps = [
-            ":support",
-            "//devinfra/js/debundle:analysis",
-            "@crates//:serde",
-            "@crates//:serde_json",
-            "@crates//:serde_yaml",
-            "@crates//:swc_common",
-            "@crates//:swc_ecma_ast",
-            "@crates//:swc_ecma_parser",
-            "@crates//:tempfile",
-            "@rules_rust//tools/runfiles",
-        ],
+        deps = _STANDARD_E2E_DEPS,
     )
     for name in [
         "anonymous_statement_test",
@@ -64,19 +69,14 @@ rust_library(
         "missing_binding_member_test",
         "residual_member_rename_test",
         "source_order_emit_test",
-        "realizability_test",
         "cross_module_emission_test",
         "purity_test",
-        "owner_graph_purity_reason_test",
         "import_coalescing_test",
         "object_literal_import_collapse_test",
         "object_literal_return_shorthand_drops_import_test",
         "duplicate_export_test",
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
-        "at_init_promotion_fndecl_direct_read_test",
-        "at_init_cross_module_call_body_reads_test",
-        "at_init_s_chain_dataflow_test",
         "auto_grown_export_alias_collision_test",
         "runtime_tdz_on_imported_class_test",
         "accepted_spec_runs_under_node_test",
@@ -84,6 +84,30 @@ rust_library(
         "mediator_reaches_asymmetric_cycle_test",
         "namespace_aggregator_split_tdz_test",
         "spec_comments_test",
+    ]
+]
+
+# E2E tests that also inspect the in-process analysis types
+# (`OwnerGraphReport`, `BindingReport`, etc.) emitted alongside the
+# debundler's text output. These need a direct dep on `:analysis`.
+[
+    rust_test(
+        name = name,
+        srcs = ["{}.rs".format(name)],
+        crate_root = "{}.rs".format(name),
+        data = [
+            "//devinfra/js/debundle",
+            "@nodejs_linux_amd64//:bin/node",
+        ],
+        edition = "2024",
+        deps = _STANDARD_E2E_DEPS + ["//devinfra/js/debundle:analysis"],
+    )
+    for name in [
+        "realizability_test",
+        "owner_graph_purity_reason_test",
+        "at_init_promotion_fndecl_direct_read_test",
+        "at_init_cross_module_call_body_reads_test",
+        "at_init_s_chain_dataflow_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/chunk_renames_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_renames_test.rs
@@ -32,39 +32,43 @@
 //! unowned decls share `ResidualEntry` ownership; no cycle.
 
 use debundle_e2e_support::*;
-use serde_json::json;
+use serde_json::{Value, json};
+
+/// Build a `chunk_renames` spec entry that renames a single residual
+/// binding to a new export name. All tests in this file rename a
+/// single binding; the helper hides the wire shape.
+fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
+    json!({
+        "id": "chunk_renames__static_app",
+        "members": [
+            {
+                "name": rename_to,
+                "selector": { "binding": { "name": from_binding } },
+            },
+        ],
+    })
+}
 
 #[test]
 fn chunk_renames_renames_residual_bindings_in_entry() {
-    let opts = FixtureOpts {
-        // S1 (orphan-S):       console.log("before")
-        // S2 (decl with S):    let x = (..., "x-value")  -- stays in entry
-        // S3 (orphan-R+S):     console.log(x)            -- reads x at-init
-        //
-        // Default `unassigned_mode`: `x` stays in `ResidualEntry`-land.
-        // `chunk_renames` renames `x` -> `payload`. The lowerer rewrites
-        // the in-entry references; the export statement carries the
-        // new name.
-        source: r#"console.log("before");
+    // S1 (orphan-S):       console.log("before")
+    // S2 (decl with S):    let x = (..., "x-value")  -- stays in entry
+    // S3 (orphan-R+S):     console.log(x)            -- reads x at-init
+    //
+    // Default `unassigned_mode`: `x` stays in `ResidualEntry`-land.
+    // `chunk_renames` renames `x` -> `payload`. The lowerer rewrites
+    // the in-entry references; the export statement carries the
+    // new name.
+    let opts = FixtureOpts::new(
+        r#"console.log("before");
 let x = (globalThis.__touched = true, "x-value");
 console.log(x);
 export { x };
 "#,
-        logical_modules: vec![],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                {
-                    "name": "payload",
-                    "selector": { "binding": { "name": "x" } },
-                },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_inline(),
-        dataflow_aware_s_chain: false,
-        extra_files: &[],
-    };
+        vec![],
+    )
+    .with_chunk_renames(chunk_rename("payload", "x"))
+    .with_unassigned_mode(unassigned_mode_inline());
     let fixture = run_fixture(opts);
     // The chunk evaluates: orphan logs "before", x's init runs (sets
     // globalThis.__touched and binds "x-value"), orphan logs the
@@ -88,32 +92,22 @@ export { x };
 
 #[test]
 fn chunk_renames_preserve_named_import_exported_names() {
-    let opts = FixtureOpts {
-        source: r#"import { x as importedThing, y } from "../vendor/entry.js";
+    let opts = FixtureOpts::new(
+        r#"import { x as importedThing, y } from "../vendor/entry.js";
 let x = "local";
 console.log(x, importedThing, y);
 export { x };
 "#,
-        logical_modules: vec![],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                {
-                    "name": "payload",
-                    "selector": { "binding": { "name": "x" } },
-                },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_inline(),
-        dataflow_aware_s_chain: false,
-        extra_files: &[(
-            "static/vendor/entry.js",
-            r#"export const x = "dep-x";
+        vec![],
+    )
+    .with_chunk_renames(chunk_rename("payload", "x"))
+    .with_unassigned_mode(unassigned_mode_inline())
+    .with_extra_files(&[(
+        "static/vendor/entry.js",
+        r#"export const x = "dep-x";
 export const y = "dep-y";
 "#,
-        )],
-    };
+    )]);
     let fixture = run_fixture(opts);
 
     assert_entry_output(&fixture, "local dep-x dep-y\n");
@@ -136,8 +130,8 @@ export const y = "dep-y";
 
 #[test]
 fn extracted_module_imports_chunk_renamed_residual_helper_for_execution() {
-    let opts = FixtureOpts {
-        source: r#"function helper() {
+    let opts = FixtureOpts::new(
+        r#"function helper() {
   return "ok";
 }
 function run() {
@@ -146,21 +140,10 @@ function run() {
 console.log("entry");
 export { helper, run };
 "#,
-        logical_modules: vec![logical_module("mod_run", &[Member::new("run")])],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                {
-                    "name": "readableHelper",
-                    "selector": { "binding": { "name": "helper" } },
-                },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_inline(),
-        dataflow_aware_s_chain: false,
-        extra_files: &[],
-    };
+        vec![logical_module("mod_run", &[Member::new("run")])],
+    )
+    .with_chunk_renames(chunk_rename("readableHelper", "helper"))
+    .with_unassigned_mode(unassigned_mode_inline());
     let fixture = run_fixture(opts);
 
     assert_entry_output(&fixture, "entry\n");
@@ -203,8 +186,8 @@ fn private_chunk_renamed_residual_helper_used_by_extracted_module_auto_grows_ent
     // residual entry bindings are importable because the emitter
     // auto-exports them on demand; "private to entry" is not a
     // first-class spec contract.
-    let opts = FixtureOpts {
-        source: r#"function helper() {
+    let opts = FixtureOpts::new(
+        r#"function helper() {
   return "ok";
 }
 function run() {
@@ -212,21 +195,10 @@ function run() {
 }
 export { run };
 "#,
-        logical_modules: vec![logical_module("mod_run", &[Member::new("run")])],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                {
-                    "name": "readableHelper",
-                    "selector": { "binding": { "name": "helper" } },
-                },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_inline(),
-        dataflow_aware_s_chain: false,
-        extra_files: &[],
-    };
+        vec![logical_module("mod_run", &[Member::new("run")])],
+    )
+    .with_chunk_renames(chunk_rename("readableHelper", "helper"))
+    .with_unassigned_mode(unassigned_mode_inline());
 
     let fixture = run_fixture(opts);
     assert_module_source(
@@ -253,32 +225,29 @@ console.log(run());
 /// error.
 #[test]
 fn surfaces_every_chunk_rename_violation_at_once() {
-    let opts = FixtureOpts {
-        source: r#"let alpha = "alpha-value";
+    let opts = FixtureOpts::new(
+        r#"let alpha = "alpha-value";
 let bravo = "bravo-value";
 let charlie = "charlie-value";
 let delta = "delta-value";
 console.log(alpha, bravo, charlie, delta);
 export { alpha, bravo, charlie, delta };
 "#,
-        logical_modules: vec![],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                // Invalid JS identifier — should report a "not a valid JS identifier" error.
-                { "name": "1-bad-ident", "selector": { "binding": { "name": "alpha" } } },
-                // Collides with the existing body local `delta`.
-                { "name": "delta",        "selector": { "binding": { "name": "bravo" } } },
-                // Duplicate target — both `charlie` and `delta` would rename to the same name.
-                { "name": "shared_target", "selector": { "binding": { "name": "charlie" } } },
-                { "name": "shared_target", "selector": { "binding": { "name": "delta" } } },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_inline(),
-        dataflow_aware_s_chain: false,
-        extra_files: &[],
-    };
+        vec![],
+    )
+    .with_chunk_renames(json!({
+        "id": "chunk_renames__static_app",
+        "members": [
+            // Invalid JS identifier — should report a "not a valid JS identifier" error.
+            { "name": "1-bad-ident", "selector": { "binding": { "name": "alpha" } } },
+            // Collides with the existing body local `delta`.
+            { "name": "delta",        "selector": { "binding": { "name": "bravo" } } },
+            // Duplicate target — both `charlie` and `delta` would rename to the same name.
+            { "name": "shared_target", "selector": { "binding": { "name": "charlie" } } },
+            { "name": "shared_target", "selector": { "binding": { "name": "delta" } } },
+        ],
+    }))
+    .with_unassigned_mode(unassigned_mode_inline());
 
     expect_rejection_containing_all(
         opts,

--- a/devinfra/js/debundle/e2e/pure_members_test.rs
+++ b/devinfra/js/debundle/e2e/pure_members_test.rs
@@ -17,19 +17,76 @@
 use debundle_e2e_support::*;
 use serde_json::json;
 
+const VENDOR_FILE: &[(&str, &str)] = &[(
+    "static/app/vendor.js",
+    "export function makePure(arg) { return arg; }\n",
+)];
+
+/// Cycle-forcing fixture body parameterized by the per-case knobs.
+///
+/// Shared layout across every test:
+///   * `import * as ns from "./vendor.js"` — vendor namespace.
+///   * `const a = (() => 1)()` — SE, stays in residual.
+///   * `const b = ns.makePure(<arg>)` — the call site under test.
+///   * `const c = <expr> + a` — reads `b` at init.
+///   * `console.log(c)`.
+///
+/// Tests vary only the call argument, the `c` expression (which
+/// determines whether the cycle is "real"), and the `pure_members`
+/// list. The fixture must be a `FixtureOpts` borrowed from caller-
+/// owned strings to satisfy `FixtureOpts<'a>`'s lifetime.
+struct PureMembersCase {
+    source: String,
+    pure_members: serde_json::Value,
+}
+
+impl PureMembersCase {
+    fn new(makepure_arg: &str, c_expr: &str, pure_members: &[&str]) -> Self {
+        let source = format!(
+            r#"import * as ns from "./vendor.js";
+const a = (() => 1)();
+const b = ns.makePure({makepure_arg});
+const c = {c_expr} + a;
+console.log(c);
+export {{ a, b, c }};
+"#,
+        );
+        Self {
+            source,
+            pure_members: json!({
+                "id": "chunk_renames__static_app",
+                "members": [
+                    {
+                        "name": "React",
+                        "selector": {
+                            "binding": {
+                                "name": "ns",
+                                "kind": "import_specifier",
+                            },
+                        },
+                        "pure_members": pure_members,
+                    },
+                ],
+            }),
+        }
+    }
+
+    fn opts(&self) -> FixtureOpts<'_> {
+        FixtureOpts::new(
+            &self.source,
+            vec![logical_module("b_module", &[Member::new("b")])],
+        )
+        .with_chunk_renames(self.pure_members.clone())
+        .with_extra_files(VENDOR_FILE)
+    }
+}
+
 /// Vendor-namespace fixture: a star-import binding `ns` whose
 /// `ns.makePure(...)` call site would force a side-effect-order
 /// edge under default classification (`ns.makePure` is a member call
 /// on an unknown receiver). With `pure_members: [makePure]` on the
 /// `ns` member, the analyzer admits the call as pure, drops the
 /// `S` edge, and the cycle-forcing fixture accepts.
-///
-/// Cycle-forcing layout:
-///   1. `const a = (() => 1)();` — SE; stays in residual
-///   2. `const b = ns.makePure({ value: 1 });` — would be SE
-///      without the rule; peeled to b_module
-///   3. `const c = b.value + a;` — reads b at init
-///   4. `console.log(c);`
 ///
 /// Without the rule: `ns.makePure(...)` is Unknown → `b` is SE →
 /// `b → a` s-edge → after peeling `b` to b_module, that crosses
@@ -40,39 +97,8 @@ use serde_json::json;
 /// no `b → a` s-edge. Only `residual → b_module` remains. DAG.
 #[test]
 fn pure_members_admits_namespace_member_call() {
-    let opts = FixtureOpts {
-        source: r#"import * as ns from "./vendor.js";
-const a = (() => 1)();
-const b = ns.makePure({ value: 1 });
-const c = b.value + a;
-console.log(c);
-export { a, b, c };
-"#,
-        logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
-        chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
-            "members": [
-                {
-                    "name": "React",
-                    "selector": {
-                        "binding": {
-                            "name": "ns",
-                            "kind": "import_specifier",
-                        },
-                    },
-                    "pure_members": ["makePure"],
-                },
-            ],
-        })),
-        chunk_id: "static/app",
-        unassigned_mode: unassigned_mode_catchall_file(None),
-        dataflow_aware_s_chain: false,
-        extra_files: &[(
-            "static/app/vendor.js",
-            "export function makePure(arg) { return arg; }\n",
-        )],
-    };
-    let fixture = run_fixture(opts);
+    let case = PureMembersCase::new("{ value: 1 }", "b.value", &["makePure"]);
+    let fixture = run_fixture(case.opts());
 
     // Peel succeeded: b is in b_module without dragging a.
     // The fact that the build didn't error on a cycle proves
@@ -95,42 +121,9 @@ export { a, b, c };
 /// the annotation doesn't bleed onto sibling properties.
 #[test]
 fn pure_members_does_not_bleed_to_other_props() {
-    expect_rejection_containing_all(
-        FixtureOpts {
-            source: r#"import * as ns from "./vendor.js";
-const a = (() => 1)();
-const b = ns.makePure({ value: 1 });
-const c = b.value + a;
-console.log(c);
-export { a, b, c };
-"#,
-            logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
-            chunk_renames: Some(json!({
-                "id": "chunk_renames__static_app",
-                "members": [
-                    {
-                        "name": "React",
-                        "selector": {
-                            "binding": {
-                                "name": "ns",
-                                "kind": "import_specifier",
-                            },
-                        },
-                        // Annotated property is not the one called.
-                        "pure_members": ["somethingElse"],
-                    },
-                ],
-            })),
-            chunk_id: "static/app",
-            unassigned_mode: unassigned_mode_catchall_file(None),
-            dataflow_aware_s_chain: false,
-            extra_files: &[(
-                "static/app/vendor.js",
-                "export function makePure(arg) { return arg; }\n",
-            )],
-        },
-        &["cycle", "b_module", "residual"],
-    );
+    // Annotated property is not the one called.
+    let case = PureMembersCase::new("{ value: 1 }", "b.value", &["somethingElse"]);
+    expect_rejection_containing_all(case.opts(), &["cycle", "b_module", "residual"]);
 }
 
 /// Args are still classified independently of the spec hint — the
@@ -139,39 +132,10 @@ export { a, b, c };
 /// classified impure, the cycle closes, and the validator rejects.
 #[test]
 fn pure_members_call_with_impure_arg_does_not_admit() {
-    expect_rejection_containing_all(
-        FixtureOpts {
-            source: r#"import * as ns from "./vendor.js";
-const a = (() => 1)();
-const b = ns.makePure((() => globalThis.touched = 1)());
-const c = (b ? 1 : 0) + a;
-console.log(c);
-export { a, b, c };
-"#,
-            logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
-            chunk_renames: Some(json!({
-                "id": "chunk_renames__static_app",
-                "members": [
-                    {
-                        "name": "React",
-                        "selector": {
-                            "binding": {
-                                "name": "ns",
-                                "kind": "import_specifier",
-                            },
-                        },
-                        "pure_members": ["makePure"],
-                    },
-                ],
-            })),
-            chunk_id: "static/app",
-            unassigned_mode: unassigned_mode_catchall_file(None),
-            dataflow_aware_s_chain: false,
-            extra_files: &[(
-                "static/app/vendor.js",
-                "export function makePure(arg) { return arg; }\n",
-            )],
-        },
-        &["cycle", "b_module", "residual"],
+    let case = PureMembersCase::new(
+        "(() => globalThis.touched = 1)()",
+        "(b ? 1 : 0)",
+        &["makePure"],
     );
+    expect_rejection_containing_all(case.opts(), &["cycle", "b_module", "residual"]);
 }

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -89,24 +89,8 @@ console.log(B.ref, D.ref);
 export { A, B, C, D };
 "#,
         vec![
-            (
-                "mod_x".to_string(),
-                json!({
-                    "members": [
-                        { "name": "A", "selector": { "binding": { "name": "A" } } },
-                        { "name": "D", "selector": { "binding": { "name": "D" } } },
-                    ],
-                }),
-            ),
-            (
-                "mod_y".to_string(),
-                json!({
-                    "members": [
-                        { "name": "B", "selector": { "binding": { "name": "B" } } },
-                        { "name": "C", "selector": { "binding": { "name": "C" } } },
-                    ],
-                }),
-            ),
+            logical_module("mod_x", &[Member::new("A"), Member::new("D")]),
+            logical_module("mod_y", &[Member::new("B"), Member::new("C")]),
         ],
     );
     expect_rejection(opts, &["cycle", "mod_x", "mod_y"]);
@@ -669,23 +653,8 @@ console.log(x1.id, y.id, x2[y.id]);
 export { x1, y, x2 };
 "#,
         vec![
-            (
-                "mod_a".to_string(),
-                json!({
-                    "members": [
-                        { "name": "x1", "selector": { "binding": { "name": "x1" } } },
-                        { "name": "x2", "selector": { "binding": { "name": "x2" } } },
-                    ],
-                }),
-            ),
-            (
-                "mod_b".to_string(),
-                json!({
-                    "members": [
-                        { "name": "y", "selector": { "binding": { "name": "y" } } },
-                    ],
-                }),
-            ),
+            logical_module("mod_a", &[Member::new("x1"), Member::new("x2")]),
+            logical_module("mod_b", &[Member::new("y")]),
         ],
     ));
     assert_entry_output(&fixture, "x1 k v\n");

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -266,6 +266,30 @@ impl<'a> FixtureOpts<'a> {
         self.dataflow_aware_s_chain = true;
         self
     }
+
+    /// Attach a `TransformSpec.chunk_renames` entry for this chunk.
+    pub fn with_chunk_renames(mut self, chunk_renames: Value) -> Self {
+        self.chunk_renames = Some(chunk_renames);
+        self
+    }
+
+    /// Override the default `chunk_id` of `static/app`.
+    pub fn with_chunk_id(mut self, chunk_id: &'a str) -> Self {
+        self.chunk_id = chunk_id;
+        self
+    }
+
+    /// Override the default `unassigned_mode` of `catchall_file`.
+    pub fn with_unassigned_mode(mut self, mode: Value) -> Self {
+        self.unassigned_mode = mode;
+        self
+    }
+
+    /// Extra files to mirror into the materialized app root post-run.
+    pub fn with_extra_files(mut self, extra_files: &'a [(&'a str, &'a str)]) -> Self {
+        self.extra_files = extra_files;
+        self
+    }
 }
 
 /// Build the JSON body for an `unassigned_mode: inline_in_entry`

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -201,6 +201,70 @@ impl VendorTestWorkspace {
         let chunk_id = chunk_path.strip_suffix(".js").unwrap_or(chunk_path);
         self.wrapper_root.join(chunk_id).join("entry.js")
     }
+
+    /// Write `source` to `<root>/external-bundles/<filename>` and
+    /// return the absolute bundle path. Used by bundled_partial_swap
+    /// fixtures whose spec carries a `bundle: { path: ... }` block.
+    fn write_bundle(&self, filename: &str, source: &str) -> PathBuf {
+        let bundle_root = self.root.path().join("external-bundles");
+        fs::create_dir_all(&bundle_root).unwrap();
+        let bundle_path = bundle_root.join(filename);
+        write_text_file(&bundle_path, source);
+        bundle_path
+    }
+}
+
+/// Set up a workspace for a bundled_partial_swap fixture, writing the
+/// chunks (`snapshot_root/<path> = source`), the js-list, and the
+/// bundle file. The returned tuple `(ws, bundle_path)` is everything
+/// downstream wiring needs to compose the spec.
+fn setup_bundled_partial_swap(
+    tempdir_prefix: &str,
+    bundle_filename: &str,
+    bundle_source: &str,
+    chunks: &[(&str, &str)],
+) -> (VendorTestWorkspace, PathBuf) {
+    let ws = VendorTestWorkspace::new(tempdir_prefix);
+    for (chunk_path, source) in chunks {
+        ws.write_chunk(chunk_path, source);
+    }
+    let entries: String = chunks
+        .iter()
+        .map(|(p, _)| format!("{p}\n"))
+        .collect::<Vec<_>>()
+        .join("");
+    ws.write_js_list(&entries);
+    let bundle_path = ws.write_bundle(bundle_filename, bundle_source);
+    (ws, bundle_path)
+}
+
+/// Build the common `inputs` / `swap_vendor_chunks` / `write_js_tree`
+/// blocks for a bundled_partial_swap spec, given an outer `vendor:`
+/// block authored by the caller. `extra` is merged onto the top-level
+/// spec object — used by the materialization-rewrite test which adds
+/// `logical_modules` / `unassigned_mode` / `materialize_logical_modules`.
+fn build_bundled_partial_swap_spec(
+    ws: &VendorTestWorkspace,
+    vendor: Value,
+    extra: Option<Value>,
+) -> Value {
+    let mut spec = json!({
+        "vendor": vendor,
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "swap_vendor_chunks": {
+            "output_manifest_path": &ws.manifest_path,
+            "output_wrapper_dir": &ws.wrapper_root,
+            "write": true,
+        },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    if let Some(Value::Object(extras)) = extra {
+        let object = spec.as_object_mut().expect("spec is JSON object");
+        for (k, v) in extras {
+            object.insert(k, v);
+        }
+    }
+    spec
 }
 
 fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFixture {
@@ -996,59 +1060,33 @@ fn bundled_partial_swap_replaces_react_cjs_family_with_singleton_esm_facade() {
     const JSX_RUNTIME_NAME: &str = "react/jsx-runtime";
     const PACKAGE_VERSION: &str = "18.3.1";
 
-    let root = TempDir::with_prefix("vendor-bundled-partial-swap-react-").expect("create tempdir");
-    let workspace_root = root.path().join("workspace");
-    let extracted_root = workspace_root.join("extracted");
-    let snapshot_root = workspace_root.join("snapshot");
-    let out_root = workspace_root.join("out");
-    let wrapper_root = out_root.join("app").join("vendors").join("generated");
-    let manifest_path = out_root.join("reports").join("vendor_swaps.json");
-    let bundle_root = root.path().join("external-bundles");
-    let bundle_path = bundle_root.join("react-family.esbuilt.js");
-    let package_root = root.path().join("upstream").join(PACKAGE_NAME);
-    fs::create_dir_all(&extracted_root).unwrap();
-    fs::create_dir_all(&snapshot_root).unwrap();
-    fs::create_dir_all(&out_root).unwrap();
-    fs::create_dir_all(&bundle_root).unwrap();
-    fs::create_dir_all(&package_root).unwrap();
-    fs::create_dir_all(snapshot_root.join("static")).unwrap();
-
-    write_text_file(
-        &snapshot_root.join(MEGACHUNK_PATH),
-        "const dispatcher = { current: \"vendor\" };\n\
-         const React = { dispatcher, useState: () => dispatcher.current };\n\
-         const jsxRuntime = { jsx: () => dispatcher.current };\n\
-         export { React as a, jsxRuntime as j };\n",
-    );
-    write_text_file(
-        &snapshot_root.join(CALLER_PATH),
-        "import { a as React, j as jsxRuntime } from \"../megachunk/entry.js\";\n\
-         console.log(`${React.useState()}:${jsxRuntime.jsx()}`);\n",
-    );
-    let js_list_path = extracted_root.join("js-files.txt");
-    write_text_file(&js_list_path, &format!("{MEGACHUNK_PATH}\n{CALLER_PATH}\n"));
-    write_text_file(
-        &bundle_path,
+    let (ws, bundle_path) = setup_bundled_partial_swap(
+        "vendor-bundled-partial-swap-react-",
+        "react-family.esbuilt.js",
         "const dispatcher = { current: \"package\" };\n\
          const React = { dispatcher, useState: () => dispatcher.current };\n\
          const jsxRuntime = { jsx: () => dispatcher.current };\n\
          export { React, jsxRuntime };\n",
+        &[
+            (
+                MEGACHUNK_PATH,
+                "const dispatcher = { current: \"vendor\" };\n\
+                 const React = { dispatcher, useState: () => dispatcher.current };\n\
+                 const jsxRuntime = { jsx: () => dispatcher.current };\n\
+                 export { React as a, jsxRuntime as j };\n",
+            ),
+            (
+                CALLER_PATH,
+                "import { a as React, j as jsxRuntime } from \"../megachunk/entry.js\";\n\
+                 console.log(`${React.useState()}:${jsxRuntime.jsx()}`);\n",
+            ),
+        ],
     );
-
-    write_text_file(
-        &package_root.join("package.json"),
-        &format!(
-            "{}\n",
-            serde_json::to_string_pretty(&json!({
-                "name": PACKAGE_NAME,
-                "version": PACKAGE_VERSION,
-                "main": "index.js",
-            }))
-            .unwrap(),
-        ),
-    );
-    write_text_file(
-        &package_root.join("index.js"),
+    let package_root = ws.write_upstream_package(
+        &format!("upstream/{PACKAGE_NAME}"),
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "index.js",
         "const dispatcher = { current: \"package\" };\n\
          exports.dispatcher = dispatcher;\n\
          exports.useState = () => dispatcher.current;\n",
@@ -1059,9 +1097,9 @@ fn bundled_partial_swap_replaces_react_cjs_family_with_singleton_esm_facade() {
          exports.jsx = () => React.dispatcher.current;\n",
     );
 
-    let spec_path = root.path().join("transform_spec.yaml");
-    let spec = json!({
-        "vendor": {
+    let spec = build_bundled_partial_swap_spec(
+        &ws,
+        json!({
             MEGACHUNK_PATH: {
                 "level": "bundled_partial_swap",
                 "identity": "React CJS family bundled partial swap fixture",
@@ -1083,15 +1121,10 @@ fn bundled_partial_swap_replaces_react_cjs_family_with_singleton_esm_facade() {
                     "j": { "package": JSX_RUNTIME_NAME, "kind": "namespace" },
                 },
             },
-        },
-        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
-        "swap_vendor_chunks": {
-            "output_manifest_path": &manifest_path,
-            "output_wrapper_dir": &wrapper_root,
-            "write": true,
-        },
-        "write_js_tree": { "out_dir": &out_root },
-    });
+        }),
+        None,
+    );
+    let spec_path = ws.root.path().join("transform_spec.yaml");
     write_yaml_file(&spec_path, &spec);
 
     let result = run_debundler(
@@ -1109,7 +1142,7 @@ fn bundled_partial_swap_replaces_react_cjs_family_with_singleton_esm_facade() {
         result.stderr,
     );
 
-    let caller_path = out_root.join("app/static/app").join("entry.js");
+    let caller_path = ws.out_root.join("app/static/app").join("entry.js");
     let caller = fs::read_to_string(&caller_path).expect("caller emitted");
     assert!(
         !caller.contains("from \"react\"") && !caller.contains("from \"react/jsx-runtime\""),
@@ -1120,15 +1153,15 @@ fn bundled_partial_swap_replaces_react_cjs_family_with_singleton_esm_facade() {
             && caller.contains("vendors/generated/static/megachunk/react_jsx-runtime.js"),
         "caller should import generated ESM facades:\n{caller}",
     );
-    assert!(wrapper_root.join("static/megachunk/bundle.js").exists());
-    assert!(wrapper_root.join("static/megachunk/react.js").exists());
+    assert!(ws.wrapper_root.join("static/megachunk/bundle.js").exists());
+    assert!(ws.wrapper_root.join("static/megachunk/react.js").exists());
     assert!(
-        wrapper_root
+        ws.wrapper_root
             .join("static/megachunk/react_jsx-runtime.js")
             .exists()
     );
 
-    let probe_path = out_root.join("__run_entry.mjs");
+    let probe_path = ws.out_root.join("__run_entry.mjs");
     write_text_file(
         &probe_path,
         "await import(\"./app/static/app/entry.js\");\n",
@@ -1152,51 +1185,9 @@ fn bundled_partial_swap_runtime_cannot_mix_swapped_client_with_residual_singleto
     const CLIENT_NAME: &str = "singleton-kit/client";
     const PACKAGE_VERSION: &str = "1.0.0";
 
-    let root =
-        TempDir::with_prefix("vendor-bundled-partial-swap-singleton-").expect("create tempdir");
-    let workspace_root = root.path().join("workspace");
-    let extracted_root = workspace_root.join("extracted");
-    let snapshot_root = workspace_root.join("snapshot");
-    let out_root = workspace_root.join("out");
-    let wrapper_root = out_root.join("app").join("vendors").join("generated");
-    let manifest_path = out_root.join("reports").join("vendor_swaps.json");
-    let bundle_root = root.path().join("external-bundles");
-    let bundle_path = bundle_root.join("singleton-kit.esbuilt.js");
-    let package_root = root.path().join("upstream").join(PACKAGE_NAME);
-    fs::create_dir_all(&extracted_root).unwrap();
-    fs::create_dir_all(&snapshot_root).unwrap();
-    fs::create_dir_all(&out_root).unwrap();
-    fs::create_dir_all(&bundle_root).unwrap();
-    fs::create_dir_all(&package_root).unwrap();
-    fs::create_dir_all(snapshot_root.join("static")).unwrap();
-
-    write_text_file(
-        &snapshot_root.join(VENDOR_PATH),
-        "const dispatcher = { current: null };\n\
-         const Hooks = {\n\
-           useCell() {\n\
-             if (dispatcher.current === null) throw new TypeError(\"residual dispatcher is null\");\n\
-             return dispatcher.current.cell;\n\
-           },\n\
-         };\n\
-         function Component() { return Hooks.useCell(); }\n\
-         const Client = {\n\
-           render(component) {\n\
-             dispatcher.current = { cell: \"vendor\" };\n\
-             try { return component(); } finally { dispatcher.current = null; }\n\
-           },\n\
-         };\n\
-         export { Hooks as a, Client as h, Component as c };\n",
-    );
-    write_text_file(
-        &snapshot_root.join(APP_PATH),
-        "import { h as Client, c as Component } from \"../vendor/entry.js\";\n\
-         console.log(Client.render(Component));\n",
-    );
-    let js_list_path = extracted_root.join("js-files.txt");
-    write_text_file(&js_list_path, &format!("{VENDOR_PATH}\n{APP_PATH}\n"));
-    write_text_file(
-        &bundle_path,
+    let (ws, bundle_path) = setup_bundled_partial_swap(
+        "vendor-bundled-partial-swap-singleton-",
+        "singleton-kit.esbuilt.js",
         "const dispatcher = { current: null };\n\
          const Hooks = {\n\
            useCell() {\n\
@@ -1211,22 +1202,37 @@ fn bundled_partial_swap_runtime_cannot_mix_swapped_client_with_residual_singleto
            },\n\
          };\n\
          export { Hooks, Client };\n",
+        &[
+            (
+                VENDOR_PATH,
+                "const dispatcher = { current: null };\n\
+                 const Hooks = {\n\
+                   useCell() {\n\
+                     if (dispatcher.current === null) throw new TypeError(\"residual dispatcher is null\");\n\
+                     return dispatcher.current.cell;\n\
+                   },\n\
+                 };\n\
+                 function Component() { return Hooks.useCell(); }\n\
+                 const Client = {\n\
+                   render(component) {\n\
+                     dispatcher.current = { cell: \"vendor\" };\n\
+                     try { return component(); } finally { dispatcher.current = null; }\n\
+                   },\n\
+                 };\n\
+                 export { Hooks as a, Client as h, Component as c };\n",
+            ),
+            (
+                APP_PATH,
+                "import { h as Client, c as Component } from \"../vendor/entry.js\";\n\
+                 console.log(Client.render(Component));\n",
+            ),
+        ],
     );
-
-    write_text_file(
-        &package_root.join("package.json"),
-        &format!(
-            "{}\n",
-            serde_json::to_string_pretty(&json!({
-                "name": PACKAGE_NAME,
-                "version": PACKAGE_VERSION,
-                "main": "index.js",
-            }))
-            .unwrap(),
-        ),
-    );
-    write_text_file(
-        &package_root.join("index.js"),
+    let package_root = ws.write_upstream_package(
+        &format!("upstream/{PACKAGE_NAME}"),
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "index.js",
         "exports.useCell = () => \"package\";\n",
     );
     write_text_file(
@@ -1234,9 +1240,9 @@ fn bundled_partial_swap_runtime_cannot_mix_swapped_client_with_residual_singleto
         "exports.render = component => component();\n",
     );
 
-    let spec_path = root.path().join("transform_spec.yaml");
-    let spec = json!({
-        "vendor": {
+    let spec = build_bundled_partial_swap_spec(
+        &ws,
+        json!({
             VENDOR_PATH: {
                 "level": "bundled_partial_swap",
                 "identity": "singleton runtime mixed-copy fixture",
@@ -1258,15 +1264,10 @@ fn bundled_partial_swap_runtime_cannot_mix_swapped_client_with_residual_singleto
                     "h": { "package": CLIENT_NAME, "kind": "namespace" },
                 },
             },
-        },
-        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
-        "swap_vendor_chunks": {
-            "output_manifest_path": &manifest_path,
-            "output_wrapper_dir": &wrapper_root,
-            "write": true,
-        },
-        "write_js_tree": { "out_dir": &out_root },
-    });
+        }),
+        None,
+    );
+    let spec_path = ws.root.path().join("transform_spec.yaml");
     write_yaml_file(&spec_path, &spec);
 
     let result = run_debundler(
@@ -1281,7 +1282,7 @@ fn bundled_partial_swap_runtime_cannot_mix_swapped_client_with_residual_singleto
         result.stderr,
     );
 
-    let probe_path = out_root.join("__run_entry.mjs");
+    let probe_path = ws.out_root.join("__run_entry.mjs");
     write_text_file(
         &probe_path,
         "await import(\"./app/static/app/entry.js\");\n",
@@ -1306,64 +1307,37 @@ fn bundled_partial_swap_rewrites_imports_created_by_logical_module_materializati
     const PACKAGE_NAME: &str = "observer-kit/observer";
     const PACKAGE_VERSION: &str = "1.0.0";
 
-    let root =
-        TempDir::with_prefix("vendor-bundled-partial-swap-materialized-").expect("create tempdir");
-    let workspace_root = root.path().join("workspace");
-    let extracted_root = workspace_root.join("extracted");
-    let snapshot_root = workspace_root.join("snapshot");
-    let out_root = workspace_root.join("out");
-    let report_root = out_root.join("reports").join("tree");
-    let wrapper_root = out_root.join("app").join("vendors").join("generated");
-    let manifest_path = out_root.join("reports").join("vendor_swaps.json");
-    let bundle_root = root.path().join("external-bundles");
-    let bundle_path = bundle_root.join("observer-kit.esbuilt.js");
-    let package_root = root.path().join("upstream").join("observer-kit");
-    fs::create_dir_all(&extracted_root).unwrap();
-    fs::create_dir_all(&snapshot_root).unwrap();
-    fs::create_dir_all(&out_root).unwrap();
-    fs::create_dir_all(&bundle_root).unwrap();
-    fs::create_dir_all(&package_root).unwrap();
-    fs::create_dir_all(snapshot_root.join("static")).unwrap();
-
-    write_text_file(
-        &snapshot_root.join(VENDOR_PATH),
-        "const observer = value => `vendor:${value}`;\n\
-         export { observer as o };\n",
-    );
-    write_text_file(
-        &snapshot_root.join(APP_PATH),
-        "import { o as observe } from \"../../vendor/entry.js\";\n\
-         const observed = observe(\"ok\");\n\
-         export { observed };\n",
-    );
-    let js_list_path = extracted_root.join("js-files.txt");
-    write_text_file(&js_list_path, &format!("{VENDOR_PATH}\n{APP_PATH}\n"));
-    write_text_file(
-        &bundle_path,
+    let (ws, bundle_path) = setup_bundled_partial_swap(
+        "vendor-bundled-partial-swap-materialized-",
+        "observer-kit.esbuilt.js",
         "const observe = value => `package:${value}`;\n\
          export { observe };\n",
+        &[
+            (
+                VENDOR_PATH,
+                "const observer = value => `vendor:${value}`;\n\
+                 export { observer as o };\n",
+            ),
+            (
+                APP_PATH,
+                "import { o as observe } from \"../../vendor/entry.js\";\n\
+                 const observed = observe(\"ok\");\n\
+                 export { observed };\n",
+            ),
+        ],
     );
-
-    write_text_file(
-        &package_root.join("package.json"),
-        &format!(
-            "{}\n",
-            serde_json::to_string_pretty(&json!({
-                "name": "observer-kit",
-                "version": PACKAGE_VERSION,
-                "main": "index.js",
-            }))
-            .unwrap(),
-        ),
-    );
-    write_text_file(
-        &package_root.join("observer.js"),
+    let report_root = ws.out_root.join("reports").join("tree");
+    let package_root = ws.write_upstream_package(
+        "upstream/observer-kit",
+        "observer-kit",
+        PACKAGE_VERSION,
+        "observer.js",
         "export default function observe(value) { return `package:${value}`; }\n",
     );
 
-    let spec_path = root.path().join("transform_spec.yaml");
-    let spec = json!({
-        "vendor": {
+    let spec = build_bundled_partial_swap_spec(
+        &ws,
+        json!({
             VENDOR_PATH: {
                 "level": "bundled_partial_swap",
                 "identity": "materialized import bundled partial swap fixture",
@@ -1379,35 +1353,31 @@ fn bundled_partial_swap_rewrites_imports_created_by_logical_module_materializati
                     "o": { "package": PACKAGE_NAME, "kind": "default" },
                 },
             },
-        },
-        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
-        "logical_modules": {
-            "static/app": {
-                "helpers/observer": {
-                    "members": [
-                        {
-                            "name": "observed",
-                            "selector": { "binding": { "name": "observed" } },
-                        },
-                    ],
+        }),
+        Some(json!({
+            "logical_modules": {
+                "static/app": {
+                    "helpers/observer": {
+                        "members": [
+                            {
+                                "name": "observed",
+                                "selector": { "binding": { "name": "observed" } },
+                            },
+                        ],
+                    },
                 },
             },
-        },
-        "unassigned_mode": {
-            "static/app": { "kind": "inline_in_entry" },
-        },
-        "materialize_logical_modules": {
-            "prune_other_chunks": false,
-            "report_out_dir": &report_root,
-            "target_dir": "modules",
-        },
-        "swap_vendor_chunks": {
-            "output_manifest_path": &manifest_path,
-            "output_wrapper_dir": &wrapper_root,
-            "write": true,
-        },
-        "write_js_tree": { "out_dir": &out_root },
-    });
+            "unassigned_mode": {
+                "static/app": { "kind": "inline_in_entry" },
+            },
+            "materialize_logical_modules": {
+                "prune_other_chunks": false,
+                "report_out_dir": &report_root,
+                "target_dir": "modules",
+            },
+        })),
+    );
+    let spec_path = ws.root.path().join("transform_spec.yaml");
     write_yaml_file(&spec_path, &spec);
 
     let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
@@ -1419,7 +1389,9 @@ fn bundled_partial_swap_rewrites_imports_created_by_logical_module_materializati
         result.stderr,
     );
 
-    let materialized_path = out_root.join("app/static/app/modules/helpers/observer.js");
+    let materialized_path = ws
+        .out_root
+        .join("app/static/app/modules/helpers/observer.js");
     let materialized = fs::read_to_string(&materialized_path).expect("materialized module emitted");
     assert!(
         !materialized.contains("vendor/entry.js"),
@@ -1430,7 +1402,7 @@ fn bundled_partial_swap_rewrites_imports_created_by_logical_module_materializati
         "materialized module should import the generated bundled facade:\n{materialized}",
     );
 
-    let probe_path = out_root.join("__run_materialized.mjs");
+    let probe_path = ws.out_root.join("__run_materialized.mjs");
     write_text_file(
         &probe_path,
         "const { observed } = await import(\"./app/static/app/modules/helpers/observer.js\");\n\
@@ -1451,63 +1423,36 @@ fn bundled_partial_swap_rewrites_non_exported_local_helper_in_vendor_chunk() {
     const PACKAGE_NAME: &str = "zod";
     const PACKAGE_VERSION: &str = "4.1.12";
 
-    let root =
-        TempDir::with_prefix("vendor-bundled-partial-swap-local-helper-").expect("create tempdir");
-    let workspace_root = root.path().join("workspace");
-    let extracted_root = workspace_root.join("extracted");
-    let snapshot_root = workspace_root.join("snapshot");
-    let out_root = workspace_root.join("out");
-    let wrapper_root = out_root.join("app").join("vendors").join("generated");
-    let manifest_path = out_root.join("reports").join("vendor_swaps.json");
-    let bundle_root = root.path().join("external-bundles");
-    let bundle_path = bundle_root.join("zod.esbuilt.js");
-    let package_root = root.path().join("upstream").join(PACKAGE_NAME);
-    fs::create_dir_all(&extracted_root).unwrap();
-    fs::create_dir_all(&snapshot_root).unwrap();
-    fs::create_dir_all(&out_root).unwrap();
-    fs::create_dir_all(&bundle_root).unwrap();
-    fs::create_dir_all(&package_root).unwrap();
-    fs::create_dir_all(snapshot_root.join("static")).unwrap();
-
-    write_text_file(
-        &snapshot_root.join(VENDOR_PATH),
-        "function nY(Ctor) { return `vendor:${Ctor.name}`; }\n\
-         const schema = nY(URL);\n\
-         export { schema as keep };\n",
-    );
-    write_text_file(
-        &snapshot_root.join(APP_PATH),
-        "import { keep } from \"../vendor/entry.js\";\n\
-         console.log(keep);\n",
-    );
-    let js_list_path = extracted_root.join("js-files.txt");
-    write_text_file(&js_list_path, &format!("{VENDOR_PATH}\n{APP_PATH}\n"));
-    write_text_file(
-        &bundle_path,
+    let (ws, bundle_path) = setup_bundled_partial_swap(
+        "vendor-bundled-partial-swap-local-helper-",
+        "zod.esbuilt.js",
         "const Zod = { instanceof: Ctor => `package:${Ctor.name}` };\n\
          export { Zod };\n",
+        &[
+            (
+                VENDOR_PATH,
+                "function nY(Ctor) { return `vendor:${Ctor.name}`; }\n\
+                 const schema = nY(URL);\n\
+                 export { schema as keep };\n",
+            ),
+            (
+                APP_PATH,
+                "import { keep } from \"../vendor/entry.js\";\n\
+                 console.log(keep);\n",
+            ),
+        ],
     );
-
-    write_text_file(
-        &package_root.join("package.json"),
-        &format!(
-            "{}\n",
-            serde_json::to_string_pretty(&json!({
-                "name": PACKAGE_NAME,
-                "version": PACKAGE_VERSION,
-                "main": "index.js",
-            }))
-            .unwrap(),
-        ),
-    );
-    write_text_file(
-        &package_root.join("index.js"),
+    let package_root = ws.write_upstream_package(
+        &format!("upstream/{PACKAGE_NAME}"),
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        "index.js",
         "const inst = Ctor => `package:${Ctor.name}`;\nexport { inst as instanceof };\n",
     );
 
-    let spec_path = root.path().join("transform_spec.yaml");
-    let spec = json!({
-        "vendor": {
+    let spec = build_bundled_partial_swap_spec(
+        &ws,
+        json!({
             VENDOR_PATH: {
                 "level": "bundled_partial_swap",
                 "identity": "local helper bundled partial swap fixture",
@@ -1529,15 +1474,10 @@ fn bundled_partial_swap_rewrites_non_exported_local_helper_in_vendor_chunk() {
                     },
                 },
             },
-        },
-        "inputs": { "input_root": &snapshot_root, "js_list_path": &js_list_path },
-        "swap_vendor_chunks": {
-            "output_manifest_path": &manifest_path,
-            "output_wrapper_dir": &wrapper_root,
-            "write": true,
-        },
-        "write_js_tree": { "out_dir": &out_root },
-    });
+        }),
+        None,
+    );
+    let spec_path = ws.root.path().join("transform_spec.yaml");
     write_yaml_file(&spec_path, &spec);
 
     let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
@@ -1549,7 +1489,7 @@ fn bundled_partial_swap_rewrites_non_exported_local_helper_in_vendor_chunk() {
         result.stderr,
     );
 
-    let vendor = fs::read_to_string(out_root.join("app/static/vendor/entry.js"))
+    let vendor = fs::read_to_string(ws.out_root.join("app/static/vendor/entry.js"))
         .expect("vendor chunk emitted");
     assert!(
         !vendor.contains("function nY"),
@@ -1560,7 +1500,7 @@ fn bundled_partial_swap_rewrites_non_exported_local_helper_in_vendor_chunk() {
         "residual schema should call the bundled facade:\n{vendor}",
     );
 
-    let probe_path = out_root.join("__run_local_helper.mjs");
+    let probe_path = ws.out_root.join("__run_local_helper.mjs");
     write_text_file(
         &probe_path,
         "await import(\"./app/static/app/entry.js\");\n",

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -48,55 +48,14 @@ enum ChunkBinding {
     /// `purity` is the worst purity reachable from the body, computed
     /// by fixed-point iteration over all chunk-top functions.
     Function { purity: Purity },
-    /// Chunk-top `const X = <plain literal>` (immutable cell) OR
-    /// `let X = <plain literal>` / `var X = <plain literal>` whose
-    /// only assignments anywhere in the chunk re-bind X to another
-    /// plain literal (whole-object replacement; no in-place
-    /// mutation). For `var`, multiple chunk-top `var X = init_n`
-    /// declarations are also admitted as long as every init is
-    /// plain-literal. Inits can additionally take the TS-enum-IIFE
-    /// shape `var X = ((p) => (p.A = "a", p.B = "b", p))(X || {})` where
-    /// the IIFE produces a plain object by parameter mutation; see
-    /// `is_ts_enum_iife_init_for_binding` for the syntactic shape
-    /// and soundness argument. Property reads `X.k` / `X[k]` (k pure) on such a
-    /// binding are pure regardless of when they fire:
-    ///
-    /// * **No accessor channels at any program point.** The initial
-    ///   init is a syntactic plain literal — no
-    ///   getters/setters/methods/computed keys/`__proto__`, so the
-    ///   value carries only data properties. Every re-bind (`let`
-    ///   case) writes another plain-literal value, so the post-write
-    ///   value still has only data properties. Object/array spread
-    ///   inside the literal (`{...src}`, `[...src]`) is permitted:
-    ///   `CopyDataProperties` copies values via
-    ///   `CreateDataPropertyOrThrow` regardless of the source's
-    ///   descriptor shape — the result is plain.
-    /// * **No post-init accessor installation.** The chunk-wide
-    ///   write scan rejects any member write (`X.k = …`,
-    ///   `X[k] = …`), member update, member delete, or call to
-    ///   `Object.{defineProperty,defineProperties,setPrototypeOf,assign}`
-    ///   / `Reflect.{defineProperty,set,setPrototypeOf,deleteProperty}`
-    ///   with `X` as first arg. Plain-ident writes whose RHS is not
-    ///   a plain-literal also disqualify.
-    /// * **Re-bind soundness for `let`.** Reads on `X` after a
-    ///   re-bind see the new plain-literal value; reads before still
-    ///   saw the old plain-literal value. At no program point does
-    ///   `X` hold an accessor-carrying value, so member reads fire
-    ///   no user code regardless of write/read interleaving. The
-    ///   re-bind statement itself is independently classified impure
-    ///   (the existing `AssignOrUpdate` rule on `Expr::Assign`), so
-    ///   it keeps its `S`-edge and the debundler cannot move it past
-    ///   sequenced points.
-    ///
-    /// Sound enabler for the recursive-purity claim "`x` reads on
-    /// `x.k` / `x[pure]` are pure iff `x` is bound to a plain-data
-    /// shape that has no accessor channels". Eliminates the
-    /// chain-of-hints needed when a chunk-local helper's body is
-    /// just a property read on a chunk-local config object —
-    /// including the `let envConfig = {...}` /
-    /// `envConfig = {...envConfig, ...n}` pattern that the
-    /// `runtime/environment/env_config.yaml` spec hints in
-    /// gaffer-private were a workaround for.
+    /// Chunk-top binding whose value is provably a plain object/array
+    /// — `const X = <plain literal>`, or `let`/`var` whose every
+    /// re-bind is also a plain literal, or the TS-enum-IIFE shape
+    /// (see `is_ts_enum_iife_init_for_binding`). The chunk-wide write
+    /// scan (`PlainDataWriteScanner`) rejects any post-init accessor
+    /// installation, so property reads `X.k` / `X[k]` are pure.
+    /// Full soundness write-up: <docs/purity_soundness.md> §
+    /// "ChunkBinding::PlainData".
     PlainData,
 }
 

--- a/devinfra/js/debundle/purity/whitelists.rs
+++ b/devinfra/js/debundle/purity/whitelists.rs
@@ -196,82 +196,14 @@ pub(super) const PURE_STATIC_FUNCTION_REFS: &[(&str, &str)] = &[
 
 /// Static `Object` methods that are Pure when called with a single
 /// argument that is structurally a fresh plain-data object/array
-/// literal (no accessors / methods / `__proto__` / computed keys /
-/// spread of non-plain-data sources) OR a chunk-top binding that has
-/// admitted as `ChunkBinding::PlainData` (whose plain-data shape is
-/// enforced syntactically by `collect_plain_data_bindings` and whose
-/// post-init accessor-installation is rejected by
-/// `PlainDataWriteScanner`).
-///
-/// The contract is stricter than `PURE_STATIC_CALLS` because every
-/// member here either invokes `[[Get]]` on own keys (which fires user
-/// getters / Proxy traps on a general argument) or mutates descriptor
-/// state (`freeze`). Restricting the argument shape to a fresh plain-
-/// data receiver — verified syntactically at the call site — closes
-/// both holes: no own-key access can fire a user accessor (none
-/// exist), and the mutation in `freeze`'s case targets a value that
-/// is not aliased through any user-observable channel before the
-/// call.
-///
-/// Soundness contract per entry:
-///
-/// * `Object.keys(O)` — ECMA-262 §20.1.2.17 calls `ToObject(O)`
-///   (no coercion on an object), then `EnumerableOwnPropertyNames(O,
-///   "key")`. The latter calls `[[OwnPropertyKeys]]` (for an
-///   ordinary plain object: returns the integer-index keys then
-///   string keys in insertion order, no user code) and per-key
-///   `[[GetOwnProperty]]` to check `[[Enumerable]]` — also a
-///   structural read with no user code on a fresh plain literal /
-///   PlainData binding.
-/// * `Object.values(O)` / `Object.entries(O)` — same as `keys` but
-///   additionally call `[[Get]]` on each own key. For an ordinary
-///   plain-data receiver every own key resolves to a data property
-///   ($\Rightarrow$ no accessor fires). PlainData receivers carry
-///   the same guarantee by the chunk-wide write scan
-///   (`PlainDataWriteScanner` rejects any
-///   `Object.defineProperty(X, …)` /
-///   `Object.setPrototypeOf(X, …)` that could install an accessor
-///   post-init).
-/// * `Object.freeze(O)` — ECMA-262 §20.1.2.6 calls
-///   `SetIntegrityLevel(O, "frozen")` which sets `[[Extensible]]`
-///   to false and rewrites each own property descriptor to non-
-///   configurable (and non-writable for data properties). No
-///   `[[Get]]` is performed, no user code fires. The mutation is
-///   on the just-allocated literal (for the literal form) or on a
-///   binding whose only producer/consumer is the chunk being
-///   debundled (for the PlainData form), so it cannot perturb
-///   user-observable state outside the call.
-/// * `Object.fromEntries(I)` — ECMA-262 §20.1.2.7 invokes
-///   `I[@@iterator]()`. For a fresh `Array` literal with no spread,
-///   that resolves to the built-in Array iterator, which `[[Get]]`s
-///   indices `0..length` (own data properties on a fresh array,
-///   no user code) and stops. Each yielded entry must itself be a
-///   2-element Array literal whose [0]/[1] reads are own data
-///   properties (gated by `is_fresh_entry_array_for_from_entries`).
-///   Both gates together rule out the
-///   "non-iterable argument throws TypeError" path that breaks
-///   purity for arbitrary arg shapes (the throw is observable). For
-///   a PlainData Object binding the call would throw, so PlainData
-///   shapes are admitted only for the non-fromEntries methods.
-///
-/// Out of scope (not admitted here; flagged for follow-up review):
-///
-/// * `Object.assign(target, src)` — mutates `target` AND calls
-///   `[[OwnPropertyKeys]]`/`[[Get]]` on `src`. The target-mutation
-///   half rules out the literal-arg shortcut: even with two literal
-///   args, `Object.assign({}, …)` returns the first arg mutated,
-///   which is observable only if the result is captured — but the
-///   mutation itself is invisible without the capture, so this is
-///   safely pure-of-result. Skipped here to keep the rule tight;
-///   the `assign` path needs its own argument-count + result-shape
-///   analysis.
-/// * `Object.getOwnPropertyNames(O)` / `getPrototypeOf(O)` /
-///   `getOwnPropertyDescriptor(O, k)` — same shape as `keys` but
-///   produces a richer return value. Could ride on the same gate
-///   in a follow-up; out for v1 to minimize the audit surface.
-/// * `Array.from(I[, mapFn])` — sound only when `mapFn` is absent
-///   (a `mapFn` invokes user code per element). Skipped here to
-///   avoid the per-call argument-count gate.
+/// literal OR a chunk-top `ChunkBinding::PlainData` binding. Stricter
+/// than `PURE_STATIC_CALLS` because each entry either invokes
+/// `[[Get]]` on own keys (which fires user accessors on a general
+/// receiver) or mutates descriptor state (`freeze`); the plain-data
+/// receiver gate closes both holes. Per-entry ECMA-262 soundness +
+/// the excluded shortlist (`Object.assign`,
+/// `Object.getOwnPropertyNames`, `Array.from`) live in
+/// <docs/purity_soundness.md> § "PURE_OBJECT_CALLS_ON_PLAIN_DATA".
 pub(super) const PURE_OBJECT_CALLS_ON_PLAIN_DATA: &[(&str, &str)] = &[
     ("Object", "keys"),
     ("Object", "values"),

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -1497,9 +1497,17 @@ impl RealizabilityIndex {
     ///
     /// Prefer [`Self::scoped`] when the delta lifetime is lexical —
     /// the `push`/`undo` pair is then guaranteed to be balanced and
-    /// LIFO-ordered without manual bookkeeping. Use raw `push`/`undo`
-    /// only when the lifetime crosses control-flow boundaries that
-    /// `scoped` can't span.
+    /// LIFO-ordered without manual bookkeeping. The raw `push`/`undo`
+    /// surface exists only for the `peel/quotient.rs` cases that
+    /// `scoped` cannot express:
+    /// * `commit_merge`: a batch of deltas lands permanently with no
+    ///   matching undo.
+    /// * `verdict_after_chained_deltas`: push a batch, read the post-
+    ///   push verdict, then undo every handle in reverse order.
+    ///
+    /// All other callers must use [`Self::scoped`]; the
+    /// `unbalanced_journal_push_undo_should_not_compile` doctest below
+    /// is the contract.
     pub fn push(&mut self, owner_graph: &OwnerGraph, delta: PartitionDelta) -> DeltaHandle {
         let entry = match delta {
             PartitionDelta::MoveOwners { owners, to } => {
@@ -1542,7 +1550,8 @@ impl RealizabilityIndex {
     }
 
     /// Roll back the delta identified by `handle`. Must be the top of
-    /// the journal; debug builds panic otherwise.
+    /// the journal; debug builds panic otherwise. `pub` for the same
+    /// peel-internal reasons as [`Self::push`] — prefer [`Self::scoped`].
     pub fn undo(&mut self, owner_graph: &OwnerGraph, handle: DeltaHandle) {
         debug_assert_eq!(
             handle.0 + 1,


### PR DESCRIPTION
## Summary

Working through the CODE_REVIEW.md backlog. Per-commit:

* `28d39e5d0` (Item 1) realizability_test: normalize raw `json!()` to `logical_module()`; `assert_fraction_metric` already uses `< f64::EPSILON`.
* `61034996b` (Item 3) chunk_renames_test: collapse 4× `FixtureOpts { ... }` struct literals into `FixtureOpts::new(...).with_chunk_renames(...)` chains; introduce `chunk_rename()` helper.
* `dcb053a1e` (Item 4) pure_members_test: parameterize 3 identical cycle-forcing fixtures via `PureMembersCase::new(arg, c_expr, pure_members)`.
* `15f13cbba` (Item 5) e2e BUILD.bazel: split `:analysis` out of `_STANDARD_E2E_DEPS` so only the 5 tests that read analysis types pay for it.
* `b11b02282` (Item 2) vendor_swap_test: extract `setup_bundled_partial_swap` and `build_bundled_partial_swap_spec` helpers; rewrite all 4 `bundled_partial_swap_*` tests around them.
* `aef15d294` (Item 15) realizability: document the two peel-internal escape hatches for `push`/`undo`. Tightening visibility to `pub(crate)` isn't viable because `peel` is a sibling rust_library crate.
* `e2bb26683` (Items 7–9) purity: move ~130 lines of soundness prose from inline rustdoc into `docs/purity_soundness.md`; keep 5-line summaries.
* `6f0bcbf08` Tracker cleanup: drop items that were already done before this branch (items 6, 8 partial, 10, 11, 12, 13, 14, 16, 17).

## Skipped — already done before this branch

* Item 6 — `run_named_from_module_default_fixture` / `run_named_from_default_fixture` already delegate to `run_full_swap_fixture` which uses `VendorTestWorkspace`.
* Item 8 — the two `classify_fresh_array_spread_source_*` functions already collapsed to a single `classify_fresh_array_spread_source`.
* Item 10 — SCC orchestration is already a one-line `tarjan_scc(&call_graph)` call inside `ChunkCodeGraph::build_full`.
* Item 11 — `analysis_tests.rs` (4095 lines) is already split into `analysis_tests/mod.rs` (699 lines, focused on facts/decorate helpers/vendor-prune) with purity tests in `purity/classifier_tests.rs` / `purity/graph_purity_tests.rs` / `purity/redundant_hints_tests.rs`.
* Item 12 — `lowering/materialize.rs` (1026 lines) is already split into `lowering/materialize/{mod,apply,plan_builder,rebind_folding}.rs`; the duplicated `explicit_requests` / `chunk_renames` loops are now `collect_analysis_hints`.
* Item 13 — `ModuleQuotient` no longer has Deref/DerefMut; explicit methods only.
* Item 14 — `OwnerGraph` CSR fields are private; accessed through explicit query methods.
* Items 16, 17 — `rollback_graph.rs` already uses `petgraph::algo::tarjan_scc` via a `PetgraphView` adapter (no hand-rolled Tarjan) and `successors`/`predecessors` already return borrowed iterators.

## Test plan

- [x] `bbr build //devinfra/js/debundle/...` passes
- [x] `bbr test //devinfra/js/debundle/e2e:{realizability,chunk_renames,pure_members,vendor_swap}_test` passes