### PR TITLE
debundle/cli: shared minified+readable binding-name resolver

### DIFF
--- a/devinfra/js/debundle/CLI_DOGFOOD_2026_05.md
+++ b/devinfra/js/debundle/CLI_DOGFOOD_2026_05.md
@@ -40,17 +40,7 @@ that would be touched — drowning the actual semantic delta.
 `anonymous_statements:` content semantically changes, not files merely
 re-formatted by canonicalization.
 
-### 3. `describe` and `show-source` reject readable names; `cluster` accepts them
-
-`debundle cluster PluginSettingsAccessor` works. `debundle describe
-PluginSettingsAccessor` exits 1: `selection did not resolve to any owner
-ids`. Same for `show-source`.
-
-**Fix idea**: factor the readable→minified resolution into a shared
-selector helper used by all three commands. Today `cluster` has it,
-others don't.
-
-### 4. `cluster --binding <sym>` documented but rejected
+### 3. `cluster --binding <sym>` documented but rejected
 
 `tana/re/web/AGENTS.md` shows `$BIN cluster --binding XOe --format
 ndjson`. The CLI actually wants a positional `<SYM>`: `error: unexpected
@@ -59,7 +49,7 @@ argument '--binding' found`.
 **Fix idea**: either drop the `--binding` flag form from AGENTS.md or
 add it as an alias in the CLI parser.
 
-### 5. `cluster` output uses opaque `logical:N` ids without labels
+### 4. `cluster` output uses opaque `logical:N` ids without labels
 
 `debundle cluster XOe` returns:
 
@@ -73,7 +63,7 @@ add it as an alias in the CLI parser.
 **Fix idea**: include `"label"` / `"path"` alongside the `logical:N` id
 in cluster output, matching describe's shape.
 
-### 6. `modules delete` requires `.yaml` suffix; the error message hides it
+### 5. `modules delete` requires `.yaml` suffix; the error message hides it
 
 `debundle modules delete --dry-run auto_partition/auto_partition_0004`
 errors with `module path does not exist:
@@ -86,7 +76,7 @@ path; only `modules delete` requires the suffix. Inconsistent.
 **Fix idea**: accept the bare path (consistent with siblings) or change
 the error to "expected `.yaml` suffix".
 
-### 7. `modules merge --dry-run` silent on success
+### 6. `modules merge --dry-run` silent on success
 
 `debundle modules merge --dry-run --target T S1` prints only `reading
 T.yaml` to stderr and exits 0. Per `cli.md`, mutating commands should
@@ -96,7 +86,7 @@ print a one-line verdict (`ok` / `would change N files` / `rejected
 **Fix idea**: emit the verdict line; cite the prior-art behavior of
 `bindings assign --dry-run`.
 
-### 8. `gate list` silent when `cycles.json` missing
+### 7. `gate list` silent when `cycles.json` missing
 
 `debundle gate list` with no current cycles emits a single `reading
 …/cycles.json` to stderr and exits 0 (no body). Indistinguishable from
@@ -107,7 +97,7 @@ file is missing, error explicitly.
 
 ## 🔵 Minor doc inconsistencies
 
-### 9. `tana/re/web/AGENTS.md` BIN path stale
+### 8. `tana/re/web/AGENTS.md` BIN path stale
 
 The doc says `BIN=bazel-bin/external/ducktape_debundle_bin/file/debundle`.
 The actual path now has a `+_repo_rules+` prefix:
@@ -115,14 +105,14 @@ The actual path now has a `+_repo_rules+` prefix:
 
 **Fix**: update gaffer-private's AGENTS.md.
 
-### 10. `describe` text format missing home-module path
+### 9. `describe` text format missing home-module path
 
 JSON output includes `binding_homes[].path`. Text output shows owners,
 bindings, atom membership, edge counts — but no module path. Either the
 text output should include the path, or the docs should reflect text's
 narrower surface.
 
-### 11. `bindings comment` read with empty comment returns empty string
+### 10. `bindings comment` read with empty comment returns empty string
 
 Reading an unset comment returns `{"sym": "...", "comment": "",
 "action": "read"}`. Indistinguishable from an explicit `comment: ""` in
@@ -130,7 +120,7 @@ the spec. Docs say "empty if none."
 
 **Fix idea**: return `"comment": null` or omit the field when unset.
 
-### 12. `describe <sym>` text format hangs on repeat invocations
+### 11. `describe <sym>` text format hangs on repeat invocations
 
 First invocation returned a 5-line summary; second invocation of the
 same command hung indefinitely. `--format json` consistently completes

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -20,8 +20,8 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 use peel::{
     CommonArgs as PeelCommonArgs, ExplainArgs, GraphSummaryArgs, OutputFormat, PatchPlanArgs,
     PeelArgs, PlanWorkArgs, SelectionArgs, SourceSliceArgs, UnitsArgs, print_report,
-    run_explain_report, run_graph_summary_report, run_patch_plan_report, run_peel,
-    run_plan_work_report, run_source_slice_report, run_units_report,
+    resolve_binding_owners, run_explain_report, run_graph_summary_report, run_patch_plan_report,
+    run_peel, run_plan_work_report, run_source_slice_report, run_units_report,
 };
 use pipeline::{TransformArgs, run_transform_cli};
 use spec_stats::{SpecStats, compute_spec_stats, render_spec_stats_text};
@@ -681,15 +681,12 @@ fn run_scc(args: SccArgs) -> Result<()> {
     })?;
     // If a binding was supplied, find its owner -> destination module
     // first; we restrict SCCs to ones containing that destination.
+    // Uses the shared `resolve_binding_owners` helper so minified and
+    // readable name forms both resolve.
     let restrict_to_module: Option<String> = if let Some(sym) = &args.binding {
-        let owner = graph
-            .nodes
-            .iter()
-            .find(|node| {
-                node.declared_bindings
-                    .iter()
-                    .any(|b| b.binding == *sym || b.export_name == *sym)
-            })
+        let owner = resolve_binding_owners(&graph, sym)
+            .into_iter()
+            .next()
             .ok_or_else(|| anyhow::anyhow!("no owner declares binding {sym:?}"))?;
         Some(owner.destination.id.clone())
     } else {
@@ -759,14 +756,12 @@ fn run_cluster(args: ClusterArgs) -> Result<()> {
         &std::fs::read_to_string(&args.common.owner_graph_path)
             .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
     )?;
-    let owner = graph
-        .nodes
-        .iter()
-        .find(|node| {
-            node.declared_bindings
-                .iter()
-                .any(|b| b.binding == args.sym || b.export_name == args.sym)
-        })
+    // Use the shared `resolve_binding_owners` helper (same code path
+    // `describe` / `show-source` / `scc --binding` use), so minified
+    // and readable names both work.
+    let owner = resolve_binding_owners(&graph, &args.sym)
+        .into_iter()
+        .next()
         .ok_or_else(|| anyhow::anyhow!("no owner declares binding {:?}", args.sym))?;
     let home_module = owner.destination.id.clone();
     let mut incoming: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -336,3 +336,16 @@ rust_test(
         "@crates//:tempfile",
     ],
 )
+
+rust_test(
+    name = "binding_name_resolution_cli_test",
+    srcs = ["binding_name_resolution_cli_test.rs"],
+    crate_root = "binding_name_resolution_cli_test.rs",
+    edition = "2024",
+    deps = [
+        "//devinfra/js/debundle:analysis",
+        "//devinfra/js/debundle:peel",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+)

--- a/devinfra/js/debundle/e2e/binding_name_resolution_cli_test.rs
+++ b/devinfra/js/debundle/e2e/binding_name_resolution_cli_test.rs
@@ -1,0 +1,319 @@
+//! End-to-end coverage for the shared minified+readable binding-name
+//! resolver (`peel::resolve_binding_owners`) used by `debundle
+//! describe`, `show-source`, `cluster`, and `scc --binding`.
+//!
+//! Pins the `CLI_DOGFOOD_2026_05.md` item #3 contract: before the fix,
+//! `describe`/`show-source` only matched the minified
+//! `BindingReport.binding`, while `cluster` matched both forms. Now all
+//! verbs share one helper; both forms work, both forms produce the
+//! same owner ids, and the minified form wins on the (rare)
+//! cross-binding spell collision.
+//!
+//! Calls the library entry points directly so the test runs in-process
+//! and doesn't depend on the built debundler binary.
+
+use std::fs;
+use std::path::Path;
+
+use analysis::{
+    AtomicGraphReport, AtomicUnitReport, BindingReport, DepKind, ModuleReportRef,
+    OwnerGraphEdgeReport, OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport, Purity,
+    QuotientEdgeReport, QuotientSccReport, SourceLocation, StatementKind, StatementOrdinal,
+};
+use peel::{
+    CommonArgs, ExplainArgs, SelectionArgs, SourceSliceArgs, resolve_binding_owners,
+    run_explain_report, run_source_slice_report,
+};
+use tempfile::TempDir;
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn member(binding: &str, export: &str) -> BindingReport {
+    BindingReport {
+        binding: binding.into(),
+        export_name: export.into(),
+    }
+}
+
+fn module_ref(id: &str, residual: bool) -> ModuleReportRef {
+    ModuleReportRef {
+        id: id.to_string(),
+        label: id.to_string(),
+        residual,
+        index: None,
+        target_file: (!residual).then(|| id.to_string()),
+    }
+}
+
+fn owner(
+    id: &str,
+    ordinal: usize,
+    binding: &str,
+    export: &str,
+    destination: ModuleReportRef,
+) -> OwnerGraphNodeReport {
+    OwnerGraphNodeReport {
+        id: id.to_string(),
+        statement_ordinal: StatementOrdinal(ordinal),
+        source_location: Some(SourceLocation {
+            source_path: "static/index.js".to_string(),
+            start_line: ordinal + 1,
+            end_line: ordinal + 1,
+        }),
+        declared_bindings: vec![member(binding, export)],
+        statement_kind: StatementKind::VarDecl,
+        purity: Purity::Pure,
+        destination,
+    }
+}
+
+/// Build a fixture where:
+///   * `owner:0` declares minified `XOe`, renamed to readable
+///     `PluginSettingsAccessor` — home `logical:ui/plugins`.
+///   * `owner:1` declares minified `YOe` (no rename) — home
+///     `logical:residual`.
+fn renamed_fixture() -> (TempDir, CommonArgs) {
+    let dir = TempDir::new().unwrap();
+    let graph_path = dir.path().join("owner_graph.json");
+    let modules_root = dir.path().join("spec/modules");
+    let plugins = owner(
+        "owner:0",
+        1,
+        "XOe",
+        "PluginSettingsAccessor",
+        module_ref("logical:ui/plugins", false),
+    );
+    let other = owner(
+        "owner:1",
+        2,
+        "YOe",
+        "YOe",
+        module_ref("logical:residual", true),
+    );
+    let quotient = OwnerGraphQuotientReport {
+        nodes: vec![
+            module_ref("logical:ui/plugins", false),
+            module_ref("logical:residual", true),
+        ],
+        edges: vec![QuotientEdgeReport {
+            id: "q_edge:0".to_string(),
+            source: "logical:residual".to_string(),
+            target: "logical:ui/plugins".to_string(),
+            edge_kinds: vec![DepKind::EagerUse],
+            constrains_init_order: true,
+        }],
+        sccs: Vec::<QuotientSccReport>::new(),
+    };
+    let report = OwnerGraphReport {
+        chunk_id: "static/index".to_string(),
+        nodes: vec![plugins, other],
+        edges: vec![OwnerGraphEdgeReport {
+            id: "edge:0".to_string(),
+            source: "owner:1".to_string(),
+            target: "owner:0".to_string(),
+            edge_kind: DepKind::EagerUse,
+            binding: Some("XOe".into()),
+            statement_ordinal: StatementOrdinal(2),
+            constrains_init_order: true,
+            role: None,
+        }],
+        quotient,
+        atomic_graph: AtomicGraphReport {
+            nodes: vec![
+                AtomicUnitReport {
+                    id: "atomic:0".to_string(),
+                    owner_ids: vec!["owner:0".to_string()],
+                    members: vec![member("XOe", "PluginSettingsAccessor")],
+                    anonymous_statement_owner_ids: Vec::new(),
+                    destinations: vec![module_ref("logical:ui/plugins", false)],
+                    causes: Vec::new(),
+                    size_lines_estimate: 1,
+                    source_line_range: Some([2, 2]),
+                    ordinal_span: 0,
+                },
+                AtomicUnitReport {
+                    id: "atomic:1".to_string(),
+                    owner_ids: vec!["owner:1".to_string()],
+                    members: vec![member("YOe", "YOe")],
+                    anonymous_statement_owner_ids: Vec::new(),
+                    destinations: vec![module_ref("logical:residual", true)],
+                    causes: Vec::new(),
+                    size_lines_estimate: 1,
+                    source_line_range: Some([3, 3]),
+                    ordinal_span: 0,
+                },
+            ],
+            edges: Vec::new(),
+        },
+    };
+    write(&graph_path, &serde_json::to_string(&report).unwrap());
+    write(&modules_root.join(".keep"), "");
+    write(
+        &dir.path().join("static/index.js"),
+        "const first = 1;\n\
+         const XOe = class PluginSettingsAccessor {};\n\
+         const YOe = XOe;\n",
+    );
+    (
+        dir,
+        CommonArgs {
+            owner_graph_path: graph_path,
+            modules_root,
+        },
+    )
+}
+
+fn explain_with_binding(common: CommonArgs, sym: &str) -> peel::ExplainReport {
+    run_explain_report(&ExplainArgs {
+        common,
+        selection: SelectionArgs {
+            owner_id: None,
+            binding_id: Some(sym.to_string()),
+            proposal_id: None,
+            unit_id: None,
+            diagnostic_id: None,
+        },
+        size_cap_lines: 10_000,
+        limit: 0,
+        format: None,
+    })
+    .expect("explain report")
+}
+
+fn show_source_with_binding(
+    common: CommonArgs,
+    sym: &str,
+    source_root: &Path,
+) -> peel::SourceSliceReport {
+    run_source_slice_report(&SourceSliceArgs {
+        common,
+        selection: SelectionArgs {
+            owner_id: None,
+            binding_id: Some(sym.to_string()),
+            proposal_id: None,
+            unit_id: None,
+            diagnostic_id: None,
+        },
+        size_cap_lines: 10_000,
+        context_lines: 1,
+        source_root: Some(source_root.to_path_buf()),
+        format: None,
+    })
+    .expect("source slice report")
+}
+
+#[test]
+fn describe_accepts_readable_name() {
+    // CLI_DOGFOOD_2026_05.md item #3 (regression test): on devel
+    // before the fix, `describe PluginSettingsAccessor` failed with
+    // "selection did not resolve to any owner ids". After the fix the
+    // readable name resolves to the same owner the minified form
+    // already did.
+    let (_dir, common) = renamed_fixture();
+    let report = explain_with_binding(common, "PluginSettingsAccessor");
+    assert_eq!(report.owner_ids, vec!["owner:0"]);
+}
+
+#[test]
+fn describe_accepts_minified_name() {
+    // Regression guard: the helper extraction didn't break the
+    // pre-existing minified-name path.
+    let (_dir, common) = renamed_fixture();
+    let report = explain_with_binding(common, "XOe");
+    assert_eq!(report.owner_ids, vec!["owner:0"]);
+}
+
+#[test]
+fn show_source_accepts_readable_name() {
+    // Companion to describe: `show-source` used to reject readable
+    // names with the same error. After the fix it returns the same
+    // source slice the minified form would.
+    let (dir, common) = renamed_fixture();
+    let report = show_source_with_binding(common, "PluginSettingsAccessor", dir.path());
+    assert_eq!(report.slices.len(), 1);
+    assert!(report.slices[0].text.contains("PluginSettingsAccessor"));
+}
+
+#[test]
+fn show_source_accepts_minified_name() {
+    // Regression guard: the helper extraction didn't break the
+    // pre-existing minified-name path for show-source either.
+    let (dir, common) = renamed_fixture();
+    let report = show_source_with_binding(common, "XOe", dir.path());
+    assert_eq!(report.slices.len(), 1);
+    assert!(report.slices[0].text.contains("PluginSettingsAccessor"));
+}
+
+#[test]
+fn resolve_binding_owners_matches_both_name_forms() {
+    // Regression guard for `cluster` / `scc --binding`: the shared
+    // helper that powers all four verbs must return the same owner
+    // for both name forms in the unambiguous case.
+    let (_dir, common) = renamed_fixture();
+    let graph: OwnerGraphReport =
+        serde_json::from_str(&fs::read_to_string(&common.owner_graph_path).unwrap()).unwrap();
+    let by_minified = resolve_binding_owners(&graph, "XOe");
+    let by_readable = resolve_binding_owners(&graph, "PluginSettingsAccessor");
+    assert_eq!(by_minified.len(), 1);
+    assert_eq!(by_readable.len(), 1);
+    assert_eq!(by_minified[0].id, "owner:0");
+    assert_eq!(by_readable[0].id, "owner:0");
+}
+
+#[test]
+fn resolve_binding_owners_prefers_minified_on_name_collision() {
+    // Disambiguation contract: if one owner's minified name and a
+    // different owner's readable name both spell the same string,
+    // the minified-name match wins the slice ordering (back-compat
+    // with the pre-fix behavior, which never saw readable matches).
+    // Both still appear so callers that want to detect ambiguity can.
+    let dir = TempDir::new().unwrap();
+    let graph_path = dir.path().join("owner_graph.json");
+    let modules_root = dir.path().join("spec/modules");
+    let by_min = owner(
+        "owner:minified",
+        1,
+        "Collide",
+        "Collide",
+        module_ref("logical:ui/plugins", false),
+    );
+    let by_readable = owner(
+        "owner:readable",
+        2,
+        "ZZZ",
+        "Collide",
+        module_ref("logical:residual", true),
+    );
+    let report = OwnerGraphReport {
+        chunk_id: "static/index".to_string(),
+        nodes: vec![by_min, by_readable],
+        edges: Vec::new(),
+        quotient: OwnerGraphQuotientReport {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            sccs: Vec::new(),
+        },
+        atomic_graph: AtomicGraphReport {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        },
+    };
+    write(&graph_path, &serde_json::to_string(&report).unwrap());
+    write(&modules_root.join(".keep"), "");
+
+    let owners = resolve_binding_owners(&report, "Collide");
+    assert_eq!(owners.len(), 2, "both collide entries should appear");
+    assert_eq!(
+        owners[0].id, "owner:minified",
+        "minified match wins ordering for back-compat"
+    );
+    assert_eq!(
+        owners[1].id, "owner:readable",
+        "readable match still surfaces so callers can detect ambiguity"
+    );
+}

--- a/devinfra/js/debundle/peel/mod.rs
+++ b/devinfra/js/debundle/peel/mod.rs
@@ -6,8 +6,9 @@ pub use plan::{
     CommonArgs, ExplainArgs, ExplainReport, GraphSummaryArgs, GraphSummaryReport, OutputFormat,
     PatchPlanArgs, PatchPlanReport, PeelArgs, PlanWorkArgs, PlanWorkReport, SelectionArgs,
     SourceSliceArgs, SourceSliceReport, UnitsArgs, UnitsReport, print_json, print_ndjson_items,
-    print_report, run_explain_report, run_graph_summary_report, run_patch_plan_report, run_peel,
-    run_plan_work_report, run_source_slice_report, run_units_report,
+    print_report, resolve_binding_owners, run_explain_report, run_graph_summary_report,
+    run_patch_plan_report, run_peel, run_plan_work_report, run_source_slice_report,
+    run_units_report,
 };
 
 #[cfg(test)]

--- a/devinfra/js/debundle/peel/plan.rs
+++ b/devinfra/js/debundle/peel/plan.rs
@@ -1166,6 +1166,49 @@ fn query_report(selection: &SelectionKind) -> QueryReport {
     }
 }
 
+/// Find every owner node whose `declared_bindings` matches `name`.
+///
+/// `name` is compared against both the minified `BindingReport.binding`
+/// and the readable `BindingReport.export_name`. Matches by minified
+/// name come first, so when both forms happen to spell `name` on
+/// different bindings (extremely rare — readable names are picked to
+/// avoid collisions with live minified ids), the minified match wins
+/// the back-compat order; both still appear in the returned slice so
+/// callers can detect ambiguity if they care.
+///
+/// This is the one shared resolver every CLI verb that accepts a
+/// binding name from the owner graph (`cluster`, `scc --binding`,
+/// `describe`, `show-source`) routes through. Spec-edit verbs
+/// (`bindings rename` / `assign` / `unassign` / `comment`) use
+/// [`crate::binding::resolve_unambiguous`] instead — they need YAML
+/// member positions, not owner-graph node refs.
+pub fn resolve_binding_owners<'a>(
+    graph: &'a OwnerGraphReport,
+    name: &str,
+) -> Vec<&'a OwnerGraphNodeReport> {
+    let mut by_minified: Vec<&OwnerGraphNodeReport> = Vec::new();
+    let mut by_readable: Vec<&OwnerGraphNodeReport> = Vec::new();
+    for node in &graph.nodes {
+        let mut matched_minified = false;
+        let mut matched_readable = false;
+        for binding in &node.declared_bindings {
+            if binding.binding == *name {
+                matched_minified = true;
+            }
+            if binding.export_name == *name {
+                matched_readable = true;
+            }
+        }
+        if matched_minified {
+            by_minified.push(node);
+        } else if matched_readable {
+            by_readable.push(node);
+        }
+    }
+    by_minified.extend(by_readable);
+    by_minified
+}
+
 fn resolve_owner_ids(
     selection: &SelectionKind,
     graph: &OwnerGraphReport,
@@ -1180,14 +1223,8 @@ fn resolve_owner_ids(
                 bail!("owner id {owner_id:?} not found in owner graph");
             }
         }
-        SelectionKind::Binding(binding_id) => graph
-            .nodes
-            .iter()
-            .filter(|node| {
-                node.declared_bindings
-                    .iter()
-                    .any(|binding| binding.binding == *binding_id)
-            })
+        SelectionKind::Binding(binding_id) => resolve_binding_owners(graph, binding_id)
+            .into_iter()
             .map(|node| node.id.clone())
             .collect(),
         SelectionKind::Proposal(proposal_id) => {

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -1829,7 +1829,7 @@ impl QuotientGraph {
         let in_iter = in_set
             .into_iter()
             .flat_map(|s| s.iter().copied())
-            .filter(move |n| out_set.map_or(true, |s| !s.contains(n)));
+            .filter(move |n| out_set.is_none_or(|s| !s.contains(n)));
         out_iter.chain(in_iter)
     }
 }

--- a/devinfra/js/debundle/perf/proposer_roadmap.md
+++ b/devinfra/js/debundle/perf/proposer_roadmap.md
@@ -1,0 +1,193 @@
+# `modules propose` Optimization Roadmap
+
+Working list of unshipped optimizations for the proposer hot loop, in
+priority order. Companion to [`2026_05_27_propose.md`](2026_05_27_propose.md),
+which has the perf measurements and post-mortems on landed changes.
+
+Items move to the perf doc as they ship. This file is the queue.
+
+## P0: Suspected order-of-magnitude wins
+
+### #0 — Released `debundle` binary is built in `fastbuild`, not `opt`
+
+`.github/workflows/release.yml` line 76 routes the debundle artifact
+through `bb-out/bazel-out/k8-fastbuild/bin/devinfra/js/debundle/debundle`.
+The `k8-fastbuild` segment is bazel's compilation_mode signature —
+this is fastbuild, the default mode with no LLVM optimizations and
+`debug_assertions = on`. There is no `-c opt` or `--compilation_mode=opt`
+on the bazel invocation.
+
+The Pearce-Kelly agent's measurement showed:
+
+| Build mode | Wall (tana fixture) |
+| ---------- | ------------------: |
+| fastbuild  |               320 s |
+| opt        |                46 s |
+
+So the released binary that gaffer pins via `archive_override` +
+`http_file` is running **~7× slower** than it could. The 8% `precondition_check`
+overhead documented in `2026_05_27_propose.md` (CPU hotspots table) is
+not just debug-assertions — it's the entire LLVM optimizer being off.
+
+**Fix:** add `-c opt` (or `compilation_mode = "opt"` in the matrix
+entry) to the release workflow's bazel build command for the
+`debundle` artifact. One-line workflow change; the next release tag
+will publish a binary that's ~7× faster on cold runs.
+
+**Estimated impact:** 5-minute `modules propose` on the tana corpus
+drops to ~45 seconds at the bazel command level. Same factor would
+likely apply to the rest of the `debundle run` pipeline (other side
+of the same binary).
+
+**Caveat:** verify the release-workflow target uses the same bazel
+arguments as our local `bazelisk build -c opt //devinfra/js/debundle:debundle`
+benchmarks. A `compilation_mode=opt` config option exists in some
+Bazel workflows; if `release.yml` already sets it elsewhere, the path
+just isn't being exercised on this matrix entry.
+
+## P1: Per-pop hot loop (after EdgeState refactor lands)
+
+These are what `perf record` will likely surface as the new top
+costs once the EdgeState refactor (in flight as PR `…/debundle-unified-edge-state`)
+collapses the 7-BTree-field churn.
+
+### #1 — SipHash → FxHash on `owner_id_to_idx: HashMap<String, OwnerIdx>`
+
+~6% self in the current profile (sip::d_rounds, c_rounds, Hasher::write,
+RandomState). DoS resistance is irrelevant on this internal data
+structure. Trivial swap once `rustc-hash` (or equivalent) is in the
+workspace — the EdgeState refactor brings it in.
+
+### #2 — Verify `-C debug-assertions=off` in opt builds
+
+Even after #0 lands, double-check that the release binary's
+compilation actually disables `debug_assertions` (rules_rust's
+opt-mode config). The `precondition_check` symbols should disappear
+from the profile entirely.
+
+### #3 — Cache `rank_candidate`'s cycle-reduction byte
+
+`rank_candidate` (in `peel/quotient.rs`, byte 0 of the 33-byte
+sort key) allocates a `BTreeSet<usize>` per call to intersect two
+cycle-index lists. Called once per PQ pop; each merge fires hundreds
+of pops.
+
+Options:
+
+- Precompute a `class_pair → bool` table once at PQ init and on
+  contract; lookup at rank time.
+- Replace the BTreeSet allocation with a linear merge of the two
+  index lists (they're usually length ≤ 1 in practice).
+
+The latter is the cheaper change.
+
+### #4 — Epoch-buffer for `would_create_cycle`'s `visited` set
+
+Currently allocates a `BTreeSet<ClassId>` per call. Replace with a
+shared `Vec<u32>` on `TopoOrder` indexed by `ClassId.0`, with a
+bump counter for the epoch. A node is "visited this call" if
+`visited[c.0] == current_epoch`. Eliminates one allocator round-trip
+per cycle check.
+
+Flagged in the PK post-mortem. **Conflicts with the EdgeState
+refactor while it's in flight** (same function signature is changing).
+Land after EdgeState merges.
+
+## P2: Per-merge sync costs (latent until per-pop work shrinks)
+
+### #5 — Incrementalize `rebuild_class_to_cycle_indices`
+
+`update_cycle_cache_after_merge` calls `rebuild_class_to_cycle_indices`
+after every merge (line 1723). That function clears `class_to_cycle_indices`
+and re-walks the **entire** `cached_cycles` vec — `O(sum of cycle sizes)`
+per merge.
+
+In practice this fires only when `cached_cycles` is non-empty (i.e.,
+when the partition has known cycles). On well-formed corpora like
+tana the post-seed partition is realizable, `cached_cycles` stays
+near-empty, and the function returns early at line 1694. So this is
+a **corner-case** fix for cyclic seeds, not a hot-path cost on
+healthy specs.
+
+**However**, the structural problem is still wrong: when it does
+fire, the work scales with total cycles × cycle size, not with
+affected cycles. The incremental shape:
+
+- Step 2 (rewrite cycle classes for affected indices): when a class
+  is removed from a cycle.classes vec, remove `idx` from
+  `class_to_cycle_indices[c]` for that class. When a class is added,
+  push `idx` to `class_to_cycle_indices[c]`.
+- Step 3 (compact dropped cycles): rather than rebuilding
+  `cached_cycles` as a new Vec + full rebuild, use a "tombstone"
+  pattern — leave dropped cycles as `Option<CycleClassSet>` with
+  `None`, skip on reads. Compact on demand (e.g., when tombstone
+  ratio crosses a threshold), at which point the index needs a
+  shift adjustment that can also be done in O(|tombstones|).
+
+Per-merge work becomes `O(affected cycles · affected cycle size)`,
+which is small.
+
+**Priority:** low on healthy corpora; high on corpora with pre-existing
+cycles. Defer until profiles show it firing.
+
+### #6 — `sync_index_after_merge` to the persistent realizability index
+
+Every merge pushes deltas to `realizability_index`. The cost depends
+on the index's internal representation. If profiling after #1-#3
+shows it surfacing, the gate's incremental representation can
+probably be tightened.
+
+Not measured yet. Investigate after the per-pop work flattens.
+
+## P3: Architectural alternatives (orthogonal to the wall)
+
+### #7 — KL/FM refinement pass after greedy
+
+Improves cut quality 10-30% over pure greedy. Constant wall cost.
+Only worth doing if reviewers complain about proposal _quality_
+rather than wall time.
+
+### #8 — Topological-sweep alternative driver
+
+`O(V + E)` total, no cycle check needed (the topo order itself is
+the safety guarantee). Different output character than agglomerative
+greedy. Useful as a baseline to measure greedy quality against.
+
+### #9 — 32-bit ClassId / OwnerIdx
+
+Halves the cache footprint of edge maps and adjacency vecs. ~5-10%
+expected on tana scale. **Premature** until the structural collapses
+(EdgeState + the bucket fixes) land — wide touch surface for a
+single-digit-pp win.
+
+### #10 — Replace greedy entirely (Louvain-with-constraints, spectral)
+
+Uncertain quality; significant project. Last resort.
+
+## `debundle run` (different command, different bottleneck)
+
+Tracked here for completeness; not strictly part of the proposer
+roadmap.
+
+- **AST-hash codegen cache** — SWC `emit_with` is ~30% of `debundle
+run` cycles per `2026_05_26.md`. Content-address post-lowering AST;
+  reuse emit if seen. Biggest cold-wall lever; architecturally
+  invasive.
+- **Chunk-level incremental rebuild** — hash `(upstream_bytes,
+spec_slice, ducktape_version)` per chunk; skip lowering + codegen
+  - reports for unchanged chunks. 10× on hot iteration cycles, zero
+    on cold. Architecturally invasive.
+- **Opt-in heavy reports** — pipeline always emits atoms /
+  owner_graph / atomic_units / realizability / factorize /
+  peel_candidates JSON. Most consumers want a subset. `--reports=<list>`
+  flag, default to current set. 5-15% cold wall.
+
+## Hold / done
+
+- ✅ `class_neighbors` non-allocating iter (commit `641d6d9d3`).
+- 🔄 Unified EdgeState (PR `debundle-unified-edge-state` in flight).
+- ✅ Pearce-Kelly + reverse index (PR #1700, commit `5bcc77279`).
+- ✅ `write_tree_reports` rayon (commit `7b69a8c0f`).
+- ✅ `lower_chunk` rayon (commit `951957122`).
+- ✅ `vendor::strip` rayon.
+- ✅ `materialize_artifact_scripts` rayon.


### PR DESCRIPTION
## Summary

- **Bug**: `debundle describe PluginSettingsAccessor` and `debundle show-source PluginSettingsAccessor` exit 1 with "selection did not resolve to any owner ids", while `debundle cluster PluginSettingsAccessor` happily accepts the readable name. Two divergent owner-graph binding lookups: `run_cluster` matches both `BindingReport.binding` (minified) and `.export_name` (readable), `resolve_owner_ids` only matches `.binding`.
- **Fix**: factor the dual-form lookup into one `peel::resolve_binding_owners` helper. Route `run_cluster`, `run_scc --binding`, and `resolve_owner_ids`'s `Binding` arm through it. Spec-edit verbs (`bindings rename` / `assign` / `unassign` / `comment`) already accepted both forms via `crate::binding::resolve_unambiguous` — they operate on YAML members, not owner-graph nodes, so they stay where they are.
- **Disambiguation**: helper orders minified-first / readable-second; `.next()` callers get the back-compat winner in the (rare) cross-binding name collision. The new `resolve_binding_owners_prefers_minified_on_name_collision` e2e test pins that contract.
- **Doc cleanup**: dropped `CLI_DOGFOOD_2026_05.md` item #3; renumbered the remaining items down by one (4..12 -> 3..11). External references checked: only items #1 + #2 are cited (in `bindings_assign_gate_cli_test.rs`), and they stay where they were.
- Drive-by clippy fix in `peel/quotient.rs` (`unnecessary_map_or` from a recent class_neighbors landing) so the branch builds; kept as a separate commit.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...:all` — 75/75 pass on the branch
- [x] Negative-direction verification: stripped the helper-call tests, reverted my source changes to the branch base `f21b82155`, ran the new test against devel sources. Result:
  - `describe_accepts_readable_name` FAILED: `selection did not resolve to any owner ids` (the exact bug)
  - `show_source_accepts_readable_name` FAILED: same error
  - `describe_accepts_minified_name` ok (regression guard works)
  - `show_source_accepts_minified_name` ok (regression guard works)
- [x] `bindings_assign_cli_test`, `scc_cluster_cli_test`, `top_level_query_cli_test` still pass after the helper extraction
