### PR TITLE
debundle/peel: FxHash on owner_id_to_idx + linear-merge rank_candidate

### DIFF
--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -70,7 +70,7 @@
 //! block for the underlying literature.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 
 use analysis::{
     DepKind, ModuleId, OwnerGraph, OwnerGraphReport, OwnerId, OwnerReportIndex, Partition,
@@ -277,7 +277,7 @@ pub struct QuotientGraph {
     /// that, so this stays in sync. Backs `owner_idx_of` so callers
     /// avoid an O(n) linear scan per lookup (hot on `peel plan-work`,
     /// 17.6% inclusive in the 2026-05-25 callgraph profile).
-    owner_id_to_idx: HashMap<String, OwnerIdx>,
+    owner_id_to_idx: FxHashMap<String, OwnerIdx>,
     /// Owner → current class. Dense, indexed by `OwnerIdx.0`.
     owner_to_class: Vec<ClassId>,
     /// Class metadata. Indexed by `ClassId.0`. Entries for emptied
@@ -418,7 +418,7 @@ impl QuotientGraph {
     pub fn from_report(report: &OwnerGraphReport, cap_lines: usize) -> Self {
         let (owner_graph, report_index) = OwnerGraph::from_report(report, &[]);
         let owner_ids: Vec<String> = report.nodes.iter().map(|n| n.id.clone()).collect();
-        let owner_id_to_idx: HashMap<String, OwnerIdx> = owner_ids
+        let owner_id_to_idx: FxHashMap<String, OwnerIdx> = owner_ids
             .iter()
             .enumerate()
             .map(|(i, id)| (id.clone(), OwnerIdx(i)))
@@ -628,7 +628,7 @@ impl QuotientGraph {
 
     /// Look up the owner index for a stable owner-id string. Returns
     /// `None` for ids not present in the source report. O(1) via the
-    /// `owner_id_to_idx` HashMap.
+    /// `owner_id_to_idx` FxHashMap.
     pub fn owner_idx_of(&self, owner_id: &str) -> Option<OwnerIdx> {
         self.owner_id_to_idx.get(owner_id).copied()
     }
@@ -2282,19 +2282,32 @@ fn rank_candidate(q: &QuotientGraph, a: ClassId, b: ClassId) -> RankedCandidate 
     // otherwise. Currently the cycle set is always preserved or
     // shrunk; a true "reduction" happens when low and high are in a
     // 2-class cycle. We check via the cached cycle index.
+    //
+    // Implementation note: on healthy corpora `cached_cycles` is
+    // empty, so both lookups return `None` and the inner branch is
+    // never entered (verified on the tana fixture: 59663 calls, 0
+    // entries into the inner branch). On corpora with pre-existing
+    // constraining cycles the per-class index lists are small —
+    // typically length ≤ 1-2 — so a nested
+    // `.iter().any(|a| other.contains(a))` is O(|la| · |lb|) with no
+    // allocation. This is strictly cheaper than the prior
+    // `BTreeSet::collect` + probe (one allocator round-trip per
+    // entry into the inner branch). Inner Vecs are produced by
+    // `rebuild_class_to_cycle_indices` via forward `enumerate()`
+    // pushes, so each is ascending — a sort-and-binary-search would
+    // be safe if profiling on a cyclic corpus later shows the lists
+    // growing.
     let mut reduces = false;
     if let (Some(la), Some(lb)) = (
         q.class_to_cycle_indices.get(&low),
         q.class_to_cycle_indices.get(&high),
     ) {
-        // Intersection of cycle indices.
-        let set_a: BTreeSet<usize> = la.iter().copied().collect();
-        for idx in lb {
-            if set_a.contains(idx) {
-                reduces = true;
-                break;
-            }
-        }
+        let (probe, other) = if la.len() <= lb.len() {
+            (la, lb)
+        } else {
+            (lb, la)
+        };
+        reduces = probe.iter().any(|idx| other.contains(idx));
     }
     key[0] = if reduces { 0 } else { 1 };
 


### PR DESCRIPTION
## Summary

Two of the three post-EdgeState constant-factor wins flagged in [`devinfra/js/debundle/perf/proposer_roadmap.md`](../blob/devel/devinfra/js/debundle/perf/proposer_roadmap.md) (P1 #1, #3):

- **#1 (SipHash → FxHash on `owner_id_to_idx`)** — Swap `HashMap<String, OwnerIdx>` to `FxHashMap`. `rustc-hash` is already in the workspace via the EdgeState refactor. DoS resistance is irrelevant on this internal table; SipHash was ~6% self in the 2026-05-25 profile.

- **#3 (linear-merge `rank_candidate` cycle-reduces bit)** — Replace the per-call `BTreeSet<usize>` allocation that intersected the two cycle-index lists with a nested `.iter().any()` over the smaller list. Lists are typically length ≤ 1-2; the quadratic worst case is cheaper than one allocator round-trip. Inner Vecs are already ascending (forward `enumerate()` push order in `rebuild_class_to_cycle_indices`), so a sort-and-binary-search escape hatch is available if profiling on a cyclic corpus shows growth.

**P1 #4 (epoch buffer for `would_create_cycle`) is not included.** The Pearce-Kelly `peel/topo_order.rs` module lives only on `origin/debundle-pearce-kelly-topo` and has not been merged to devel — there is no `TopoOrder::would_create_cycle` to refactor against current devel. The epoch-buffer fix belongs in the PK PR's follow-up once PK is rebased onto post-EdgeState devel.

## Verification

- **Byte-identical output:** `modules propose --format json` on the tana 78d928dca7 fixture is byte-identical before and after, md5 `1fda9b1bab7bdf706cd4a63106a0554e`, 3 runs each.
- **Wall time (opt build, 3 runs):** before 43.61/44.41/43.64 (avg 43.89 s); after 43.69/43.83/45.74 (avg 44.42 s). Within noise — both fixes target latent constant-factor work that is not the hot bucket on this corpus (`cached_cycles` empty, `owner_id_to_idx` only hot at init), but the structural ceilings are gone.
- **Tests:** all 75 `//devinfra/js/debundle/...:all` pass.
- **rank_candidate length distribution on tana:** instrumented for one run (then removed). 59663 calls; 0 entries into the inner branch (both `class_to_cycle_indices.get` returned `None` every time on this healthy corpus). The fix is a structural ceiling for corpora that do have cycles; on tana the change is neutral.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...:all --config=nolint` (75/75 pass)
- [x] Byte-identical proposer output on tana fixture (md5 match)
- [x] Opt build wall time on tana fixture (3 runs before, 3 runs after)