### PR TITLE
debundle: share module quotient between factorization and validation

### DIFF
--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -10,7 +10,7 @@ use crate::graph::{
 };
 use crate::partition::Partition;
 use crate::reports::build_owner_graph_report;
-use crate::validation::validate_factorization;
+use crate::validation::validate_factorization_with_quotient;
 
 use crate::{
     FactorizationReport, LogicalModule, LogicalModuleIndex, ModuleId, ModuleQuotient,
@@ -213,10 +213,12 @@ impl ChunkFactorization {
     /// Run SCC analysis over the dep graph. Spec authors consume the
     /// resulting report to fix any cycles or atomic-unit conflicts.
     pub fn validate(&self) -> FactorizationReport {
-        let mut report =
-            validate_factorization(&self.analysis.owner_graph, &self.partition, &|id| {
-                self.analysis.module_name(id)
-            });
+        let mut report = validate_factorization_with_quotient(
+            &self.analysis.owner_graph,
+            &self.partition,
+            &self.dep_graph,
+            &|id| self.analysis.module_name(id),
+        );
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();
         report.linker_order = self
             .linker_order

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -62,7 +62,7 @@ pub use purity::{
 };
 pub use realizability::{
     CrossRebindEdge, DeltaHandle, PartitionDelta, RealizabilityIndex, RealizabilityVerdict,
-    SccDiagnosis, check_realizability,
+    SccDiagnosis, check_realizability, check_realizability_with_quotient,
 };
 pub use reports::schema::{
     AtomicGraphReport, AtomicUnitEdgeReport, AtomicUnitReport, BindingReport, EdgeRoleReport,
@@ -75,6 +75,7 @@ pub use stage_one::{StageOneAnalysis, compute_stage_one_analysis};
 pub use validation::{
     BlockingSccEntry, CycleEdge, CycleReport, FactorizationReport,
     render_atomic_unit_conflict_summary, render_cycle_summary, validate_factorization,
+    validate_factorization_with_quotient,
 };
 
 #[cfg(test)]

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -38,8 +38,9 @@ use petgraph::visit::{DfsPostOrder, GraphBase, GraphRef, IntoNeighbors, Visitabl
 
 use crate::OwnerId;
 use crate::graph::{
-    OwnerEdge, OwnerEdgeId, OwnerGraph, build_module_quotient, chunk_constraining_module_edges,
-    chunk_linker_order_from_pairs, chunk_source_import_order_from_adjacency,
+    ModuleQuotient, OwnerEdge, OwnerEdgeId, OwnerGraph, build_module_quotient,
+    chunk_constraining_module_edges, chunk_linker_order_from_pairs,
+    chunk_source_import_order_from_adjacency,
 };
 use crate::ids::ModuleId;
 use crate::partition::Partition;
@@ -130,12 +131,36 @@ impl RealizabilityVerdict {
 /// correctness reference for the `RealizabilityIndex`'s incremental
 /// backing (verified by differential test in the
 /// `RealizabilityIndex` step 1b follow-up).
+///
+/// Thin wrapper over [`check_realizability_with_quotient`] for callers
+/// that don't already have a built `ModuleQuotient`. If you do
+/// (e.g. `ChunkFactorization::build_with`, which materialises
+/// `dep_graph = build_module_quotient(...)` for its own use), pass it
+/// to the `_with_quotient` form to avoid a redundant
+/// `build_module_quotient` + `tarjan_scc` pass.
 pub fn check_realizability(
     owner_graph: &OwnerGraph,
     partition: &Partition,
 ) -> RealizabilityVerdict {
+    let quotient = build_module_quotient(owner_graph, partition);
+    check_realizability_with_quotient(owner_graph, partition, &quotient)
+}
+
+/// Same as [`check_realizability`], but takes a pre-built
+/// `ModuleQuotient` to read SCCs from instead of constructing one
+/// from `(owner_graph, partition)` internally. The quotient must be
+/// the one produced by `build_module_quotient(owner_graph, partition)`
+/// for the same arguments — `build_module_quotient` is deterministic,
+/// so any two `ModuleQuotient`s built that way are equivalent and
+/// `quotient.sccs()` is byte-identical to a fresh
+/// `build_module_quotient(...).sccs()`.
+pub fn check_realizability_with_quotient(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    quotient: &ModuleQuotient,
+) -> RealizabilityVerdict {
     let mut verdict = RealizabilityVerdict {
-        scc_partition: build_module_quotient(owner_graph, partition).sccs(),
+        scc_partition: quotient.sccs(),
         ..RealizabilityVerdict::default()
     };
 
@@ -1696,6 +1721,39 @@ mod tests {
             .expect("parse module");
         let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
         build_owner_graph(&facts)
+    }
+
+    /// `check_realizability` is a thin wrapper around
+    /// `check_realizability_with_quotient` that builds the quotient
+    /// fresh. Both forms must produce byte-identical verdicts (incl.
+    /// `scc_partition`, `unrealizable_sccs`, `cross_rebinds`) on the
+    /// same `(owner_graph, partition, build_module_quotient(...))`
+    /// triple. This pins the wrapper-equivalence used by
+    /// `ChunkFactorization::build_with` to share its already-built
+    /// `dep_graph` instead of building a second quotient inside
+    /// validation.
+    #[test]
+    fn check_realizability_with_quotient_matches_pure_form() {
+        // A constraining cross-module cycle so every verdict field
+        // (incl. `unrealizable_sccs` and `scc_partition`) is populated
+        // — exercises more than just the empty-verdict happy path.
+        let source = "const a = b + 1; const b = a + 1;";
+        let owner_graph = parse_and_build(source);
+        let mut partition = Partition::new(&owner_graph, module_id(0));
+        partition.set(OwnerId(1), module_id(1));
+
+        let pure_form = check_realizability(&owner_graph, &partition);
+        let quotient = build_module_quotient(&owner_graph, &partition);
+        let threaded = check_realizability_with_quotient(&owner_graph, &partition, &quotient);
+
+        assert_eq!(
+            pure_form, threaded,
+            "wrapper-vs-threaded forms must yield byte-identical verdicts",
+        );
+        assert!(
+            !pure_form.is_realizable(),
+            "fixture should produce a non-empty verdict to exercise all fields",
+        );
     }
 
     /// Two top-level constants in different modules, with one reading

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::factor_assembly::AtomicUnitConflict;
 use crate::graph::build_module_quotient;
 use crate::partition::Partition;
-use crate::realizability::check_realizability;
+use crate::realizability::{RealizabilityVerdict, check_realizability_with_quotient};
 use swc_atoms::Atom;
 
 use crate::{DepKind, ModuleId, ModuleQuotient, OwnerGraph, StatementOrdinal};
@@ -295,7 +295,24 @@ pub fn validate_factorization(
     partition: &Partition,
     module_name: &dyn Fn(ModuleId) -> String,
 ) -> FactorizationReport {
-    let verdict = check_realizability(owner_graph, partition);
+    let quotient = build_module_quotient(owner_graph, partition);
+    validate_factorization_with_quotient(owner_graph, partition, &quotient, module_name)
+}
+
+/// Same as [`validate_factorization`] but takes a pre-built
+/// `ModuleQuotient` so callers that already constructed one (notably
+/// `ChunkFactorization::build_with`, which caches it as
+/// `self.dep_graph`) don't pay for a second
+/// `build_module_quotient` + `tarjan_scc` pass on the way through
+/// the realizability check.
+pub fn validate_factorization_with_quotient(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    quotient: &ModuleQuotient,
+    module_name: &dyn Fn(ModuleId) -> String,
+) -> FactorizationReport {
+    let verdict: RealizabilityVerdict =
+        check_realizability_with_quotient(owner_graph, partition, quotient);
     if verdict.unrealizable_sccs.is_empty() {
         return FactorizationReport {
             cycles: Vec::new(),
@@ -318,7 +335,7 @@ pub fn validate_factorization(
                 .map(|id| (node.statement_ordinal, id.0.clone()))
         })
         .collect();
-    let graph = &build_module_quotient(owner_graph, partition);
+    let graph = quotient;
     let mut cycles = Vec::new();
     for scc in verdict.scc_partition() {
         let in_scc: HashSet<ModuleId> = scc.iter().copied().collect();


### PR DESCRIPTION
## Summary

`ChunkFactorization::build_with` builds a `ModuleQuotient` (`self.dep_graph`) and runs `tarjan_scc` over it once for `dep_graph_sccs`. Validation downstream (`validate_factorization` → `check_realizability`) ignored that and rebuilt the same quotient + ran Tarjan twice more on the same `(owner_graph, partition)`. ARCH_REVIEW_2026_05 flagged this under \"Duplicated calculations: tarjan_scc over the module quotient\".

This PR adds `check_realizability_with_quotient` and `validate_factorization_with_quotient`, threads `self.dep_graph` through `ChunkFactorization::validate`, and keeps the original entry points as thin wrappers that build the quotient and delegate (so `cli/edit_gate.rs`, which has no pre-built quotient, keeps working unchanged).

Per `ChunkFactorization::build_with` invocation this saves one `build_module_quotient` (`O(V_owner + E_owner)`) plus two `tarjan_scc` walks over the modules graph. Not a hot path — code clarity, not wall time.

## Test plan
- [x] `bazelisk build //devinfra/js/debundle/...` — clean
- [x] `bazelisk test //devinfra/js/debundle/...:all` — 75/75 pass (incl. the new `check_realizability_with_quotient_matches_pure_form` equivalence test on a constraining-cycle fixture so every verdict field is exercised, not just the empty happy path)
- [x] Byte-identical proposer-output property tests under `e2e/` — pass