### PR TITLE
debundle/peel: per-call ModuleId->[OwnerIdx] inverse in translate_verdict_with_owner_modules

### DIFF
--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -1263,6 +1263,22 @@ impl QuotientGraph {
     /// per-owner ModuleId vector. Used by speculative queries that
     /// read the post-push verdict but commit the undo before the
     /// translation runs.
+    ///
+    /// Perf (#12prime): the naive translation iterated all
+    /// `self.owner_ids` per SCC — O(K * num_owners), ~10% self in
+    /// `modules propose` profiles on tana (9709 owners, many tiny
+    /// SCCs per call). We instead build a per-call inverse index
+    /// `module_to_owners: FxHashMap<ModuleId, Vec<OwnerIdx>>` from
+    /// `owner_modules` in one O(num_owners) pass, then visit only
+    /// the owners actually in each SCC's modules. New cost is
+    /// `num_owners + sum_scc(|scc.modules| * owners_in_those_modules)`,
+    /// which is a strict win whenever the SCCs don't cover most
+    /// owners — the common case for the proposer. We chose the
+    /// per-call inverse over a kernel-maintained `class_to_owners`
+    /// to keep the surface contained: maintaining a kernel field
+    /// would touch every `owner_to_class` write site
+    /// (rebuild_class_adjacency, contract, merge_classes_unchecked,
+    /// etc.) for marginal additional savings.
     fn translate_verdict_with_owner_modules(
         &self,
         verdict: &RealizabilityVerdict,
@@ -1280,22 +1296,28 @@ impl QuotientGraph {
             }
             c
         };
+        // One pass over owner_modules to build the inverse index.
+        // Bounded length: we only consider owner indices that exist
+        // in BOTH self.owner_ids and owner_modules — the old code
+        // also skipped `owner_idx >= owner_modules.len()`.
+        let max_idx = self.owner_ids.len().min(owner_modules.len());
+        let mut module_to_owners: FxHashMap<ModuleId, Vec<usize>> = FxHashMap::default();
+        for (owner_idx, &module) in owner_modules.iter().enumerate().take(max_idx) {
+            module_to_owners.entry(module).or_default().push(owner_idx);
+        }
         let mut cycles: Vec<CycleClassSet> = Vec::new();
         for scc in &verdict.unrealizable_sccs {
-            let modules_in_scc: BTreeSet<ModuleId> = scc.modules.iter().copied().collect();
             let mut owner_ids: BTreeSet<String> = BTreeSet::new();
             let mut class_set: BTreeSet<ClassId> = BTreeSet::new();
-            for (owner_idx, owner_id_str) in self.owner_ids.iter().enumerate() {
-                if owner_idx >= owner_modules.len() {
+            for module in &scc.modules {
+                let Some(idxs) = module_to_owners.get(module) else {
                     continue;
+                };
+                for &owner_idx in idxs {
+                    owner_ids.insert(self.owner_ids[owner_idx].clone());
+                    let c = self.owner_to_class[owner_idx];
+                    class_set.insert(project(c));
                 }
-                let module = owner_modules[owner_idx];
-                if !modules_in_scc.contains(&module) {
-                    continue;
-                }
-                owner_ids.insert(owner_id_str.clone());
-                let c = self.owner_to_class[owner_idx];
-                class_set.insert(project(c));
             }
             if class_set.len() < 2 {
                 continue;


### PR DESCRIPTION
## Summary

- `translate_verdict_with_owner_modules` was iterating all `self.owner_ids` (9709 entries on tana) per SCC inside the verdict, shows as ~10% self in `modules propose` profiles since it is called per `would_be_cycles_after_contract` (= per PQ-pop attempt that hits the unrealizable case).
- Build a per-call `FxHashMap<ModuleId, Vec<OwnerIdx>>` from `owner_modules` once at function entry (O(num_owners)); then for each SCC iterate only the owners whose modules are in `scc.modules`.
- Per-call inverse beats kernel-maintained `class_to_owners`: same asymptote, contained surface — no touching of `owner_to_class` write sites.

## Verification

- 75/75 debundle tests pass (cli, peel, peel_quotient_integration, all e2e including the byte-identity property tests).
- `modules propose --format json` against the tana fixture is md5-identical to baseline (5.8MB / 312k lines).
- Wall time on the tana fixture (opt+debuginfo, 5 interleaved rounds): baseline avg 45.5s (range 43.0-46.4), new avg 45.8s (range 43.1-47.9). Improvement is within noise on this workload; the change is asymptotically correct for inputs with larger SCC counts.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...:all` (75 pass)
- [x] md5 byte-identity check on `modules propose --format json` (tana fixture)
- [x] Wall-time measurement (5 interleaved opt+debuginfo runs)