### PR TITLE
debundle: canonical linker_order is Vec<ModuleId>; derive position map via helper

### DIFF
--- a/devinfra/js/debundle/ARCH_REVIEW_2026_05.md
+++ b/devinfra/js/debundle/ARCH_REVIEW_2026_05.md
@@ -67,7 +67,6 @@ Six distinct types in the orbit of "stuff a chunk analysis produced" (after the 
 Watch out for:
 
 - **`ChunkFactorization` vs `ChunkAnalysis`**: both are per-chunk IR; the difference is whether the partition is applied. Could be `ChunkAnalysis` (no partition) vs `FactorizedChunk` (partition applied) and the meaning would be more obvious.
-- **`linker_order` (`Vec<String>` in `FactorizationReport`)** vs **`linker_order` (`Vec<ModuleId>` in `ChunkFactorization`)** vs **`chunk_linker_order` (`BTreeMap<ModuleId, usize>` in `graph.rs`)** — three different shapes for "the toposort of the constraining-edge graph", differing in element type and whether it's "list" or "map (position lookup)". Pick one canonical type, derive the others.
 - **`SccDiagnosis` (`realizability.rs:65`, renamed from `UnrealizableScc` in `3dbaf1037`)** vs **`CycleReport` (`validation.rs:38`)** vs **`QuotientSccReport` (`reports/schema.rs:174`)** vs **`AtomicUnitConflict` (`factor_assembly.rs:42`)** — four representations of "the spec is unrealizable, here's why" with subtly different fields. `SccDiagnosis` carries `constraining_owner_edges`; `CycleReport` carries `cut` (a minimum cut) + `evidence`; `QuotientSccReport` carries `module_edge_ids` + `constraining_module_edge_ids`. Two of these contain the same data ("the modules in the SCC + the edges in the SCC"), with the cut/evidence/min decoration added by the validator. The right shape is one core type with optional decorations, not four parallel structs.
 
 ## Algorithmic clarity (realizability gate, atom detection)

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::atomic_units::{AtomicUnit, OwnerGraphAndUnits, compute_owner_graph_and_units};
@@ -132,18 +132,17 @@ impl ChunkFactorization {
         // simulator share one source of truth — see `graph.rs:
         // chunk_constraining_module_edges` for the invariant doc.
         let canonical_edges = chunk_constraining_module_edges(&owner_graph, &partition);
-        let linker_position_btree: BTreeMap<ModuleId, usize> = chunk_linker_order(&canonical_edges);
-        // Recover the linker-order Vec by sorting modules by their
-        // assigned position. Modules absent from the canonical set
-        // are unconstrained relative to it and not present here.
-        let mut linker_order_pairs: Vec<(ModuleId, usize)> = linker_position_btree
+        // Canonical linker order (Vec<ModuleId>, dependency-first).
+        // Modules absent from the canonical set are not present here.
+        let linker_order: Vec<ModuleId> = chunk_linker_order(&canonical_edges);
+        // O(1) position-lookup cache for `linker_position(id)` queries
+        // — built once here so downstream code doesn't re-derive it.
+        let linker_position_by_module: HashMap<ModuleId, usize> = linker_order
             .iter()
-            .map(|(m, p)| (*m, *p))
+            .copied()
+            .enumerate()
+            .map(|(idx, id)| (id, idx))
             .collect();
-        linker_order_pairs.sort_by_key(|(_, p)| *p);
-        let linker_order: Vec<ModuleId> = linker_order_pairs.into_iter().map(|(m, _)| m).collect();
-        let linker_position_by_module: HashMap<ModuleId, usize> =
-            linker_position_btree.into_iter().collect();
         // Every logical module needs a deterministic source-order
         // slot for emit stability, even singletons that don't
         // participate in any canonical edge.

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -1307,10 +1307,13 @@ impl ChunkConstrainingEdgeSet {
 }
 
 /// Toposort of the canonical edge set, deepest dependency first.
-/// The position of a module in the returned map is its
-/// "linker_position": the relative order ECMA-262's depth-first
-/// link traversal needs to evaluate this chunk so that every
-/// constraining edge `M → M'` has `M'` evaluating before `M`.
+/// The returned `Vec<ModuleId>` is the canonical "linker order":
+/// element 0 is the deepest dependency (must evaluate before
+/// everything else); the last element is the most-dependent module.
+/// Position in this vector is the module's "linker_position" — the
+/// relative order ECMA-262's depth-first link traversal needs to
+/// evaluate this chunk so that every constraining edge `M → M'` has
+/// `M'` evaluating before `M`.
 ///
 /// Modules that don't participate in any canonical edge are omitted
 /// from the result (they're absent from the constraining DAG, hence
@@ -1318,12 +1321,15 @@ impl ChunkConstrainingEdgeSet {
 /// when sorting by linker_position so unconstrained modules sort
 /// LAST.
 ///
+/// Callers that need O(1) position lookup should pipe the result
+/// through [`position_lookup`] once.
+///
 /// Note: every edge in the canonical set already satisfies
 /// `constrains_init_order()`, so the toposort runs on the full
 /// set — no extra filter needed. If the canonical edge set has a
 /// constraining-only cycle (Pass 1 reports it as unrealizable),
-/// `toposort` returns `Err`; this function returns the empty map.
-pub fn chunk_linker_order(edges: &ChunkConstrainingEdgeSet) -> BTreeMap<ModuleId, usize> {
+/// `toposort` returns `Err`; this function returns the empty vector.
+pub fn chunk_linker_order(edges: &ChunkConstrainingEdgeSet) -> Vec<ModuleId> {
     chunk_linker_order_from_pairs(edges.pairs())
 }
 
@@ -1334,7 +1340,7 @@ pub fn chunk_linker_order(edges: &ChunkConstrainingEdgeSet) -> BTreeMap<ModuleId
 /// reaching for the full canonical edge map.
 pub fn chunk_linker_order_from_pairs(
     pairs: impl IntoIterator<Item = (ModuleId, ModuleId)>,
-) -> BTreeMap<ModuleId, usize> {
+) -> Vec<ModuleId> {
     use petgraph::algo::toposort;
     let mut graph: DiGraphMap<ModuleId, ()> = DiGraphMap::new();
     for (from, to) in pairs {
@@ -1343,14 +1349,29 @@ pub fn chunk_linker_order_from_pairs(
         graph.add_edge(from, to, ());
     }
     match toposort(&graph, None) {
-        Ok(order) => order
-            .into_iter()
-            .rev()
-            .enumerate()
-            .map(|(idx, id)| (id, idx))
-            .collect(),
-        Err(_) => BTreeMap::new(),
+        // `toposort` yields dependents first (root → leaves); the
+        // canonical "linker order" is dependency-first, so reverse.
+        Ok(order) => order.into_iter().rev().collect(),
+        Err(_) => Vec::new(),
     }
+}
+
+/// Build an O(1) position lookup from a canonical linker-order slice.
+/// `result[id] = i` iff `id` is at index `i` in `order`. Modules
+/// absent from `order` are absent from the returned map; callers
+/// fall back to `usize::MAX` when sorting.
+///
+/// This is the one place that materializes the
+/// `BTreeMap<ModuleId, usize>` view of the linker order. Callers
+/// that only need to iterate in order should consume the
+/// `Vec<ModuleId>` directly instead of going through this helper.
+pub fn position_lookup(order: &[ModuleId]) -> BTreeMap<ModuleId, usize> {
+    order
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(idx, id)| (id, idx))
+        .collect()
 }
 
 /// Lemma 2 ordering: sort by `(SCC dep rank ASC, intra-SCC
@@ -1391,7 +1412,11 @@ pub fn chunk_source_import_order_from_adjacency(
     extra_nodes: &BTreeSet<ModuleId>,
 ) -> Vec<ModuleId> {
     use petgraph::algo::tarjan_scc;
-    let linker_position = chunk_linker_order_from_pairs(constraining_pairs);
+    // We need O(1) position lookups inside the sort comparator below,
+    // so materialize the linker order into the position-lookup map
+    // once. The canonical linker-order Vec is the toposort output;
+    // `position_lookup` is the small enumerate-collect adapter.
+    let linker_position = position_lookup(&chunk_linker_order_from_pairs(constraining_pairs));
     // SCCs are computed over the FULL I-graph (constraining + lazy
     // back-edges) so Lemma 2's intra-SCC `linker_position`-DESC
     // reversal catches asymmetric cycles. The constraining-only
@@ -1616,9 +1641,10 @@ mod chunk_constraining_module_edges_tests {
         partition.set(OwnerId(2), module_id(3)); // top
         let canonical = chunk_constraining_module_edges(&owner_graph, &partition);
         let linker = chunk_linker_order(&canonical);
+        let pos = position_lookup(&linker);
         // leaf (mod_1) must come before middle (mod_2) and top (mod_3).
-        assert!(linker[&module_id(1)] < linker[&module_id(2)]);
-        assert!(linker[&module_id(2)] < linker[&module_id(3)]);
+        assert!(pos[&module_id(1)] < pos[&module_id(2)]);
+        assert!(pos[&module_id(2)] < pos[&module_id(3)]);
     }
 
     /// `chunk_source_import_order` reverses within an SCC so the

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -50,6 +50,7 @@ pub use graph::{
     OwnerEdge, OwnerEdgeId, OwnerGraph, OwnerGraphOptions, OwnerId, OwnerNode, OwnerReportIndex,
     build_module_quotient, build_owner_graph, build_owner_graph_with,
     chunk_constraining_module_edges, chunk_linker_order, chunk_source_import_order,
+    position_lookup,
 };
 pub use ids::{
     BindingKind, ChunkId, ChunkTable, LogicalModule, LogicalModuleIndex, ModuleId,

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -41,7 +41,7 @@ use crate::OwnerId;
 use crate::graph::{
     ModuleQuotient, OwnerEdge, OwnerEdgeId, OwnerGraph, build_module_quotient,
     chunk_constraining_module_edges, chunk_linker_order_from_pairs,
-    chunk_source_import_order_from_adjacency,
+    chunk_source_import_order_from_adjacency, position_lookup,
 };
 use crate::ids::ModuleId;
 use crate::partition::Partition;
@@ -352,7 +352,12 @@ impl EsmEvaluationSimulator {
     ) -> Self {
         let mut extra = BTreeSet::new();
         extra.insert(residual);
-        let linker_position = chunk_linker_order_from_pairs(constraining_pairs.iter().copied());
+        // Position-lookup view of the canonical linker order — the
+        // simulator's `EsmIGraph` resolves neighbor sort keys with
+        // O(1) per probe.
+        let linker_position = position_lookup(&chunk_linker_order_from_pairs(
+            constraining_pairs.iter().copied(),
+        ));
         let source_import_order = chunk_source_import_order_from_adjacency(
             constraining_pairs.iter().copied(),
             i_successors,


### PR DESCRIPTION
## Summary

Resolves the ARCH_REVIEW backlog entry naming three shapes for "toposort of the constraining-edge graph":

- `Vec<String>` on `FactorizationReport` (JSON wire shape)
- `Vec<ModuleId>` on `ChunkFactorization` (in-memory IR)
- `BTreeMap<ModuleId, usize>` returned by `graph.rs::chunk_linker_order` (position lookup)

The canonical in-memory type is now **`Vec<ModuleId>`** (the natural toposort output).

- `graph::chunk_linker_order` and `chunk_linker_order_from_pairs` now return `Vec<ModuleId>` directly.
- New `graph::position_lookup(&[ModuleId]) -> BTreeMap<ModuleId, usize>` is the single place the position-map view is materialised.
- `ChunkFactorization::build_with` builds its `linker_order` Vec straight from `chunk_linker_order`; its O(1) `linker_position_by_module: HashMap<ModuleId, usize>` cache is enumerated from the Vec (no more sort-pairs round-trip through a `BTreeMap`).
- `EsmEvaluationSimulator::build` (realizability.rs, one call site) wraps the result with `position_lookup` so the simulator's downstream `BTreeMap<ModuleId, usize>` consumers (`EsmIGraph` / `simulate_esm_post_order`) are unchanged.
- `FactorizationReport::linker_order` stays `Vec<String>` (JSON wire shape; pinned by `factorization_report_serializes_linker_order_as_snake_case`, consumed by `materialize/mod.rs:322` → `ChunkValidationSummary.linker_order` → `chunk.json`). Stringification happens at the IR→report boundary in `ChunkFactorization::validate` via `analysis.module_name`.

ARCH_REVIEW item dropped.

## Test plan

- [x] `bazelisk test //devinfra/js/debundle/...:all` — all 75 tests pass.
- [x] Byte-identity property tests + JSON wire-shape tests pass (the load-bearing safety net for this type-shape refactor).
