### PR TITLE
debundle: fix modules-propose self-merge bug + treat tiny modules as fold candidates

### DIFF
--- a/devinfra/js/debundle/peel/factorize.rs
+++ b/devinfra/js/debundle/peel/factorize.rs
@@ -277,7 +277,7 @@ fn factorize_with_context(
             if node.destination.residual {
                 return None;
             }
-            Some((i, active_module_label(node, active_claims)))
+            Some((i, active_module_label(node, active_claims, &graph.chunk_id)))
         })
         .collect();
 
@@ -367,14 +367,38 @@ fn factorize_with_context(
 fn active_module_label(
     node: &OwnerGraphNodeReport,
     active_claims: &BTreeMap<String, String>,
+    chunk_id: &str,
 ) -> String {
-    node.declared_bindings
+    let label = node
+        .declared_bindings
         .iter()
         .find_map(|b| active_claims.get(b.binding.as_str()))
         .cloned()
         .or_else(|| (!node.destination.label.is_empty()).then(|| node.destination.label.clone()))
         .or_else(|| node.destination.target_file.clone())
-        .unwrap_or_else(|| node.destination.id.clone())
+        .unwrap_or_else(|| node.destination.id.clone());
+    canonical_module_label(&label, chunk_id)
+}
+
+/// Collapse the two spellings of one module to a single label.
+///
+/// Production owner-graph destinations spell a module's label with a
+/// `"<chunk_id>::"` prefix (e.g. `static/index-DI2GynTv::domains/system/ids`),
+/// while the active-claim lookup yields the clean spec path
+/// (`domains/system/ids`). Within one spec module some owners resolve
+/// via the claim and others fall through to `destination.label`, so a
+/// single class collects both spellings and would emit a bogus
+/// `merge_into` self-merge. Stripping the chunk-id prefix canonicalizes
+/// both to the clean path.
+fn canonical_module_label(label: &str, chunk_id: &str) -> String {
+    if chunk_id.is_empty() {
+        return label.to_string();
+    }
+    label
+        .strip_prefix(chunk_id)
+        .and_then(|rest| rest.strip_prefix("::"))
+        .map(str::to_string)
+        .unwrap_or_else(|| label.to_string())
 }
 
 /// Spec-module groups derived from `graph.nodes` destinations.
@@ -1235,6 +1259,41 @@ mod tests {
                 "domains/system/id_helpers".to_string(),
                 "domains/system/ids".to_string(),
             ],
+        );
+    }
+
+    #[test]
+    fn chunk_prefixed_and_clean_label_of_one_module_do_not_self_merge() {
+        // Two owners of ONE spec module (same destination.id ->
+        // `spec_module_groups` contracts them into one class). Owner
+        // `a` resolves its label via an active claim to the clean
+        // path `domains/system/ids`; owner `b` has no claim and falls
+        // through to `destination.label`, which production reports
+        // spell with the `<chunk_id>::` prefix
+        // (`x::domains/system/ids`). The two spellings denote the same
+        // module, so the class must collapse to a single label and
+        // emit NO `merge_into` self-merge.
+        let dest = module_report_ref(
+            "logical:1",
+            "x::domains/system/ids",
+            "domains/system/ids.js",
+        );
+        let a = owner_at("a", 1, &["a"], 10, dest.clone());
+        let b = owner_at("b", 2, &["b"], 10, dest.clone());
+        let graph = graph_with_atomic_units(
+            vec![a.clone(), b.clone()],
+            vec![
+                edge("e1", "a", "b", DepKind::EagerUse, true),
+                edge("e2", "b", "a", DepKind::EagerUse, true),
+            ],
+            vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
+            vec![],
+        );
+        let claims = BTreeMap::from([("a".to_string(), "domains/system/ids".to_string())]);
+        let report = factorize(&graph, &claims, 10_000);
+        assert!(
+            report.proposals.iter().all(|p| p.merge_into.is_none()),
+            "expected no self-merge proposal from two spellings of one module: {report:#?}",
         );
     }
 

--- a/devinfra/js/debundle/skills/debundle_architect/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_architect/SKILL.md
@@ -95,12 +95,22 @@ names, export names, and importer neighborhoods, then decide whether each name
 describes a durable concept or only the operation performed by one helper
 function.
 
-Also review tiny modules and one-consumer modules. A small file is not wrong by
-itself, and one consumer is not enough to prove ownership. The suspicious shape
-is a tiny helper/config/style/function module whose only meaningful caller is an
-adjacent component, command, service, parser, or state module. In that case,
-recommend merging or co-peeling the helper with the owner unless layer
-ownership argues against it.
+Actively hunt small-LOC modules to fold — tiny modules are a smell. A debundle
+over-splits when the chunker emits a separate module for what a developer would
+have written inline in a larger file. Judge by LINES OF CODE, not member count:
+a one-binding module that is a 500-line React component is idiomatic and must be
+left alone; the smell is small-LOC standalone files (a 1-3 line accessor,
+predicate, constant, or wrapper in its own module). The suspicious shape is such
+a small-LOC helper/config/style/function whose only real caller is an adjacent
+component, command, service, parser, or state module — exclude non-semantic
+re-export catalogs / bundle barrels when counting consumers. Recommend folding
+it into that single consumer, or into a sibling that was clearly the same
+original source file (use `source_location` adjacency / shared CSS-module class
+prefixes as evidence), unless layer ownership argues against it. Do NOT fold a
+small-LOC module that is a widely-consumed shared primitive (a shared constant,
+a React context, a public predicate), a real public-API/service/class boundary,
+or anything whose fold would cross a layer boundary or break the realizability
+gate. See `references/module_shape.md` for the full rule.
 
 Treat one-callable modules as a recurring antipattern when the module name is
 just the callable name and the callable is not itself the architecture boundary.

--- a/devinfra/js/debundle/skills/debundle_lane_worker/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_lane_worker/SKILL.md
@@ -55,6 +55,19 @@ A good module has a coherent reason to exist: stable public surface, internal
 references dominating external references, clear layer ownership, or multiple
 meaningful consumers. Member count alone is not the rule.
 
+Tiny modules are a smell — try to fold them. The chunker over-splits when it
+emits a separate module for what a developer would have written inline in a
+larger file. Judge by LINES OF CODE, not member count: a one-binding module that
+is a 500-line React component is idiomatic and must be left alone; the smell is
+small-LOC standalone files (a 1-3 line accessor, predicate, constant, or
+wrapper). Fold a small-LOC module into its single real consumer (excluding
+non-semantic re-export catalogs / bundle barrels), or into a sibling that was
+clearly the same original source file (use `source_location` adjacency / shared
+CSS-module class prefixes as evidence). Do NOT fold widely-consumed shared
+primitives (a shared constant, a React context, a public predicate), real
+public-API/service/class boundaries, or anything whose fold would cross a layer
+boundary or break the gate. See `references/module_shape.md`.
+
 Usually avoid standalone modules for:
 
 - primitive constants with one consumer

--- a/devinfra/js/debundle/skills/shared/module_shape.md
+++ b/devinfra/js/debundle/skills/shared/module_shape.md
@@ -29,6 +29,39 @@ Member count is not the rule. A single substantial service, state machine, or
 component can be a module. A one-line constant with one consumer usually is
 not.
 
+## Tiny Modules Are a Smell — Try to Fold Them
+
+A debundle over-splits when the chunker (or atomic-unit granularity) emits a
+separate module for what a developer would have written inline in a larger
+file. Actively look for small modules and try to fold each into its true owner:
+its single real consumer, or a sibling that was clearly the same original
+source file.
+
+Judge by LINES OF CODE, not member count. A one-binding module that is a
+500-line React component is a perfectly idiomatic file and must be left alone.
+The smell is small-LOC standalone files: a 1-3 line accessor, predicate,
+constant, or wrapper sitting in its own module.
+
+Fold a small-LOC module when either holds:
+
+- it has a single real consumer (exclude non-semantic re-export catalogs /
+  bundle barrels) — fold into that consumer
+- it is a co-located helper/style/type of a sibling that was clearly the same
+  original source file — use `source_location` adjacency / shared CSS-module
+  class prefixes as evidence
+
+Do NOT fold:
+
+- small-LOC modules that are widely-consumed shared primitives (a shared
+  constant, a React context, a public predicate used across the app)
+- real public-API / service / class boundaries
+- anything whose fold would cross a layer boundary or break the realizability
+  gate
+
+Source-proximity — adjacent owner statement ordinals or line ranges in the
+upstream blob — is the strongest signal that several small modules were one
+original file.
+
 ## Locality vs Layer Ownership
 
 Co-consumption is evidence, but architecture ownership is stronger. Do not


### PR DESCRIPTION
Two improvements to the generic debundle tooling, surfaced while debundling Tana.

## Fix: `modules propose` self-merge bug (`peel/factorize.rs`)
`debundle modules propose` was emitting mostly noise — on a real spec, **86 of 90 merge proposals were zero-line "mirror-file" self-merges**. Within one spec module, some owners resolve their label via the active-claim lookup (clean path `X`) while others fall through to `destination.label` (chunk-prefixed `<chunk_id>::X`); `class_to_labels` collected both spellings for the same class, so `build_proposal` saw ≥2 labels and proposed merging the module **with itself** (0 owners moved).

Adds `canonical_module_label()` which strips a leading `<chunk_id>::` and threads `chunk_id` through `active_module_label`, so both spellings collapse to the clean path at the single `owner_to_active_module` source — no self-merge proposals, and `edges_to_active`/`active_modules_referenced` report consistently. Genuine cross-module merges (≥2 distinct clean labels) are unaffected.

Reproduce-first regression test `chunk_prefixed_and_clean_label_of_one_module_do_not_self_merge`: **failed before** (self-merge emitted), **passes after**; all `//devinfra/js/debundle` tests green, rustfmt clean.

The commit message also writes up a deferred **Fix 2** proposal: an opt-in `--source-adjacency` proposal mode (new `peel/source_adjacency.rs`) that clusters small-LOC non-hub sibling modules by interleaved `source_location` ranges — i.e. modules the chunker split out of one original source file — which the current constraining-edge-only candidate enumeration can never surface. Deferred as a genuinely new advisory subsystem rather than half-implemented.

## Skills: tiny modules are a fold smell
Updates the debundle skills (`skills/shared/module_shape.md`, `debundle_architect`, `debundle_lane_worker`) to actively hunt small-LOC standalone modules and fold them into their owner — **judged by LOC, not member count** (a 500-line single-component file is idiomatic and left alone; the smell is 1–3 line accessors/predicates/constants in their own module), with the do-not-fold cases (widely-consumed shared primitives, real API/service boundaries, layer-crossing or gate-breaking folds) and `source_location` adjacency as the strongest same-file signal.

https://claude.ai/code/session_01QcZ5GMz2vK8PE53vuvJYEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcZ5GMz2vK8PE53vuvJYEA)_