### PR TITLE
debundle: make partial-swap vendor rewriter hygiene-aware

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -1508,6 +1508,77 @@ fn bundled_partial_swap_rewrites_non_exported_local_helper_in_vendor_chunk() {
     assert_node_output(&probe_path, "package:URL\n", "");
 }
 
+#[test]
+fn partial_swap_does_not_rewrite_shadowing_inner_binding() {
+    // Regression: the partial-swap identifier rewriter must be
+    // hygiene-aware. The caller imports `e6 as zodFlag` (swapped to the
+    // namespace member `z.boolean`), but a nested function declares a
+    // *parameter* named `zodFlag` that shadows the import local and
+    // reads through it. Keying the rewrite on the bare textual symbol
+    // would miscompile the inner read into `z.boolean()`, returning the
+    // upstream value instead of the argument the caller passed. Keying
+    // on the resolver-assigned binding `Id` leaves the shadowed inner
+    // binding untouched.
+    let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
+        chunk_source: "export const e6 = () => \"UPSTREAM\";\nexport const keepMe = () => 7;\n",
+        caller_source: "import { e6 as zodFlag, keepMe as kept } from \"../megachunk/entry.js\";\n\
+                        function pick(zodFlag) { return zodFlag(); }\n\
+                        export const fromImport = zodFlag();\n\
+                        export const fromParam = pick(() => \"PARAM\");\n\
+                        export const keepUse = kept();\n",
+        upstream_source: "export const boolean = () => \"UPSTREAM\";\n",
+        symbols: vec![("e6", "zod", "boolean")],
+        upstream_version: "3.23.8",
+    });
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    // The top-level import-local use is rewritten to the facade member.
+    assert!(
+        caller.contains("z.boolean()"),
+        "top-level import-local use should be rewritten to the facade member:\n{caller}",
+    );
+    // The shadowing parameter and its read must survive verbatim — the
+    // inner `zodFlag()` is a call on the parameter, not the import local.
+    assert!(
+        caller.contains("function pick(zodFlag)") && caller.contains("return zodFlag()"),
+        "shadowing parameter binding must not be rewritten to the facade member:\n{caller}",
+    );
+
+    // Runtime proof: `fromParam` must reflect the argument passed to
+    // `pick`, not the swapped upstream value.
+    let app_root = fixture
+        .caller_emitted_path
+        .ancestors()
+        .nth(3)
+        .expect("app root above static/app/entry.js")
+        .to_path_buf();
+    // The emitted caller imports the bare `zod` specifier; provide a
+    // local `node_modules/zod` so node can resolve it at runtime.
+    write_text_file(
+        &app_root.join("node_modules/zod/package.json"),
+        "{ \"name\": \"zod\", \"version\": \"3.23.8\", \"type\": \"module\", \"main\": \"index.js\" }\n",
+    );
+    write_text_file(
+        &app_root.join("node_modules/zod/index.js"),
+        "export const boolean = () => \"UPSTREAM\";\n",
+    );
+    let probe_path = app_root.join("__run_shadow_probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./static/app/entry.js\");\n\
+         console.log(`${m.fromImport}:${m.fromParam}`);\n",
+    );
+    assert_node_output(&probe_path, "UPSTREAM:PARAM\n", "");
+}
+
 struct PartialSwapKindFixtureArgs<'a> {
     /// "namespace", "default", or "named"
     kind: &'a str,

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -19,7 +19,7 @@ use artifact::{
     get_chunk_entry_path, join_module_path, list_chunk_file_paths, manifest_relative_path,
     module_path_dirname, normalize_module_path, relative_module_specifier,
 };
-use binding_targets::{declaration_name_strings, module_export_name};
+use binding_targets::{declaration_ids, declaration_name_strings, module_export_name};
 #[cfg(test)]
 use js_ast::emit_js_module;
 use js_ast::{ParsedJsModule, parse_js_module, str_value};
@@ -1687,7 +1687,7 @@ fn rewrite_partial_swap_in_file(
     //     `import * as <local> from "<pkg>"`; no identifier rewrite.
     //   - kind=default: queue a per-binding
     //     `import <local> from "<pkg>"`; no identifier rewrite.
-    let mut bindings: BTreeMap<String, IdentRewriteTarget> = BTreeMap::new();
+    let mut bindings: BTreeMap<Id, IdentRewriteTarget> = BTreeMap::new();
     let mut emitted_member_namespace_for: BTreeSet<String> = BTreeSet::new();
     let mut references_by_symbol: BTreeMap<(String, String), usize> = BTreeMap::new();
 
@@ -1708,7 +1708,7 @@ fn rewrite_partial_swap_in_file(
                     let upstream_export = target.upstream_export.as_deref()?;
                     let namespace = package_coords.namespace.as_deref()?;
                     bindings.insert(
-                        local_sym.to_string(),
+                        local_sym.to_id(),
                         IdentRewriteTarget::Member {
                             namespace: namespace.to_string(),
                             upstream_export: upstream_export.to_string(),
@@ -1726,7 +1726,7 @@ fn rewrite_partial_swap_in_file(
                 PartialSwapKind::Namespace => {
                     imports.push(DeferredImport::Namespace {
                         source: target.package.clone(),
-                        local: local_sym.to_string(),
+                        local: local_sym.sym.to_string(),
                     });
                     *references_by_symbol
                         .entry((
@@ -1738,7 +1738,7 @@ fn rewrite_partial_swap_in_file(
                 PartialSwapKind::Default => {
                     imports.push(DeferredImport::Default {
                         source: target.package.clone(),
-                        local: local_sym.to_string(),
+                        local: local_sym.sym.to_string(),
                     });
                     *references_by_symbol
                         .entry((
@@ -1754,9 +1754,9 @@ fn rewrite_partial_swap_in_file(
                         local: upstream_export.to_string(),
                         upstream_export: upstream_export.to_string(),
                     });
-                    if local_sym != upstream_export {
+                    if local_sym.sym.as_ref() != upstream_export {
                         bindings.insert(
-                            local_sym.to_string(),
+                            local_sym.to_id(),
                             IdentRewriteTarget::Rename {
                                 upstream_export: upstream_export.to_string(),
                                 chunk_name: chunk_mapping.chunk_id.clone(),
@@ -1808,7 +1808,7 @@ fn rewrite_bundled_partial_swap_in_file(
 ) -> PartialSwapFileResult {
     let module = &mut job.ast.module;
 
-    let mut bindings: BTreeMap<String, IdentRewriteTarget> = BTreeMap::new();
+    let mut bindings: BTreeMap<Id, IdentRewriteTarget> = BTreeMap::new();
     let mut emitted_default_namespace_for: BTreeSet<String> = BTreeSet::new();
     let mut references_by_symbol: BTreeMap<(String, String), usize> = BTreeMap::new();
     let mut prelude_imports: Vec<DeferredImport> = Vec::new();
@@ -1850,7 +1850,7 @@ fn rewrite_bundled_partial_swap_in_file(
                     let upstream_export = target.upstream_export.as_deref()?;
                     let namespace = package_coords.namespace.as_deref()?;
                     bindings.insert(
-                        local_sym.to_string(),
+                        local_sym.to_id(),
                         IdentRewriteTarget::Member {
                             namespace: namespace.to_string(),
                             upstream_export: upstream_export.to_string(),
@@ -1868,7 +1868,7 @@ fn rewrite_bundled_partial_swap_in_file(
                 PartialSwapKind::Namespace | PartialSwapKind::Default => {
                     imports.push(DeferredImport::Default {
                         source: import_source,
-                        local: local_sym.to_string(),
+                        local: local_sym.sym.to_string(),
                     });
                     *references_by_symbol
                         .entry((
@@ -1921,7 +1921,7 @@ fn rewrite_swap_import_decls<F>(
     mut rewrite_one: F,
 ) -> Vec<ModuleItem>
 where
-    F: FnMut(&str, &str, &str) -> Option<Vec<DeferredImport>>,
+    F: FnMut(&str, &str, &Ident) -> Option<Vec<DeferredImport>>,
 {
     let mut new_body: Vec<ModuleItem> = Vec::with_capacity(original_body.len() + 4);
     for item in original_body {
@@ -1963,11 +1963,9 @@ where
             let ImportSpecifier::Named(named) = specifier else {
                 unreachable!("classified named above");
             };
-            if let Some(imports) = rewrite_one(
-                &target_chunk_name,
-                &imported_name_lookup,
-                named.local.sym.as_ref(),
-            ) {
+            if let Some(imports) =
+                rewrite_one(&target_chunk_name, &imported_name_lookup, &named.local)
+            {
                 decl_local_imports.extend(imports);
             } else {
                 retained_specifiers.push(ImportSpecifier::Named(named));
@@ -1984,7 +1982,12 @@ where
     new_body
 }
 
-fn collect_local_idents_by_export_name(module: &Module) -> BTreeMap<String, String> {
+/// Map each chunk-local named export to the hygiene-preserving `Id`
+/// (`(atom, SyntaxContext)`) of the binding it re-exports. The `orig`
+/// identifier carries the resolver-assigned `SyntaxContext`, so the
+/// returned `Id` is the canonical binding identity used to key the
+/// self-rewrite `bindings` map.
+fn collect_local_idents_by_export_name(module: &Module) -> BTreeMap<String, Id> {
     let mut out = BTreeMap::new();
     for item in &module.body {
         let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
@@ -2005,14 +2008,35 @@ fn collect_local_idents_by_export_name(module: &Module) -> BTreeMap<String, Stri
                 .as_ref()
                 .map(module_export_name)
                 .unwrap_or_else(|| orig.sym.to_string());
-            out.insert(export_name, orig.sym.to_string());
+            out.insert(export_name, orig.to_id());
+        }
+    }
+    out
+}
+
+/// Map each top-level binding name to its hygiene-preserving `Id`
+/// (`(atom, SyntaxContext)`). Used to resolve a manifest-recorded
+/// `local` name (a bare string) to the actual binding cell, so the
+/// self-rewrite map keys on binding identity rather than bare text.
+/// If two top-level declarations share a name (illegal in module
+/// scope after resolver, but defensive), the last one wins.
+fn collect_top_level_binding_ids(module: &Module) -> BTreeMap<String, Id> {
+    let mut out = BTreeMap::new();
+    for item in &module.body {
+        let decl = match item {
+            ModuleItem::Stmt(Stmt::Decl(decl)) => decl,
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => &export_decl.decl,
+            _ => continue,
+        };
+        for id in declaration_ids(decl) {
+            out.insert(id.0.to_string(), id);
         }
     }
     out
 }
 
 struct SelfRewriteOutputs<'a> {
-    bindings: &'a mut BTreeMap<String, IdentRewriteTarget>,
+    bindings: &'a mut BTreeMap<Id, IdentRewriteTarget>,
     prelude_imports: &'a mut Vec<DeferredImport>,
     references_by_symbol: &'a mut BTreeMap<(String, String), usize>,
     self_rewrite_import_locals: &'a mut BTreeSet<Id>,
@@ -2030,13 +2054,20 @@ fn seed_bundled_partial_swap_self_rewrites(
         return;
     };
     let exported_locals = collect_local_idents_by_export_name(module);
+    // The manifest records `local` only as a bare name string. Resolve
+    // it to the hygiene-preserving binding `Id` of the matching
+    // top-level declaration so the self-rewrite map is keyed on binding
+    // identity (matching `ident.to_id()` in the rewriter), not bare
+    // text — otherwise a same-named binding in a nested scope would be
+    // miscompiled.
+    let top_level_bindings = collect_top_level_binding_ids(module);
     let mut used_idents = module_used_idents(module);
     for (chunk_export, target) in &chunk_mapping.symbols {
-        let local_sym = target
-            .local
-            .as_ref()
-            .or_else(|| exported_locals.get(chunk_export));
-        let Some(local_sym) = local_sym else {
+        let local_id = match &target.local {
+            Some(local_name) => top_level_bindings.get(local_name),
+            None => exported_locals.get(chunk_export),
+        };
+        let Some(local_id) = local_id else {
             continue;
         };
         let Some(package_coords) = chunk_mapping.packages.get(&target.package) else {
@@ -2056,7 +2087,7 @@ fn seed_bundled_partial_swap_self_rewrites(
                     .as_deref()
                     .expect("kind=member/named validated to carry upstream_export");
                 outputs.bindings.insert(
-                    local_sym.clone(),
+                    local_id.clone(),
                     IdentRewriteTarget::Member {
                         namespace: local.clone(),
                         upstream_export: upstream_export.to_string(),
@@ -2067,7 +2098,7 @@ fn seed_bundled_partial_swap_self_rewrites(
             }
             PartialSwapKind::Namespace | PartialSwapKind::Default => {
                 outputs.bindings.insert(
-                    local_sym.clone(),
+                    local_id.clone(),
                     IdentRewriteTarget::Rename {
                         upstream_export: local.clone(),
                         chunk_name: chunk_mapping.chunk_id.clone(),
@@ -2349,15 +2380,25 @@ enum IdentRewriteTarget {
     },
 }
 
+/// Rewrites references to a partial-swap import local into the
+/// replacement facade access. `bindings` is keyed by the import
+/// local's hygiene-preserving `Id` (`(atom, SyntaxContext)`), captured
+/// from the actual binding `Ident` at construction. The module here has
+/// been through SWC's `resolver` pass (see
+/// `js_ast::parse_and_resolve`), so `ident.to_id()` is the canonical
+/// binding identity. Keying on `Id` (rather than the bare textual
+/// symbol) ensures a same-named binding in a nested scope — a function
+/// parameter, a shadowing `const`/`let`, a `catch` binding — is left
+/// untouched, since it carries a different `SyntaxContext`.
 struct PartialSwapIdentRewriter<'a> {
-    bindings: &'a BTreeMap<String, IdentRewriteTarget>,
+    bindings: &'a BTreeMap<Id, IdentRewriteTarget>,
     references_by_symbol: &'a mut BTreeMap<(String, String), usize>,
 }
 
 impl VisitMut for PartialSwapIdentRewriter<'_> {
     fn visit_mut_call_expr(&mut self, call: &mut CallExpr) {
         if local_namespace_iife_target(call)
-            .is_some_and(|target| self.bindings.contains_key(target.0.as_ref()))
+            .is_some_and(|target| self.bindings.contains_key(&target))
         {
             // Preserve TS namespace/enum initializer arguments such as
             // `Sa || (Sa = {})`. The strip pass recognizes that shape as
@@ -2386,7 +2427,7 @@ impl VisitMut for PartialSwapIdentRewriter<'_> {
         let Expr::Ident(ident) = expr else {
             return;
         };
-        let Some(target) = self.bindings.get(ident.sym.as_ref()) else {
+        let Some(target) = self.bindings.get(&ident.to_id()) else {
             return;
         };
         let (chunk_name, chunk_export) = match target {
@@ -2625,8 +2666,11 @@ export { b as beta };
                  const direct = Sa.NONE;\n",
             )
             .unwrap();
+            let sa_id = collect_top_level_binding_ids(&parsed.module)
+                .remove("Sa")
+                .expect("`Sa` is declared at top level");
             let bindings = BTreeMap::from([(
-                "Sa".to_string(),
+                sa_id,
                 IdentRewriteTarget::Member {
                     namespace: "__debundle_bps_l3".to_string(),
                     upstream_export: "DiagLogLevel".to_string(),


### PR DESCRIPTION
One of a set of follow-up correctness fixes from the debundle review (companion to the purity shadowing fix in #1714).

## Bug

`vendor/mod.rs::PartialSwapIdentRewriter::visit_mut_expr` rewrote identifiers by bare textual symbol (`bindings.get(ident.sym.as_ref())`), ignoring SWC hygiene. `bindings` is keyed by the import local's name and maps to `<namespace>.<upstream_export>`, so any same-named binding elsewhere in the file — a nested function parameter, a shadowing local `const`/`let`, a catch binding — was wrongly rewritten, miscompiling code that legitimately used the inner binding.

## Fix

The AST is resolver-processed at this stage (every parse path in `js_ast.rs` runs SWC's `resolver`), so `ident.to_id()` carries a meaningful `SyntaxContext` — Id-keying is the correct fix:

- `PartialSwapIdentRewriter.bindings` is now keyed on `Id` (atom + ctxt); `visit_mut_expr` matches `ident.to_id()`.
- Both import-decl construction paths capture the import local's `Id` from the real binding `Ident`.
- The bundled **self-rewrite** path (which only had bare-name strings) now resolves the manifest's bare `local` name to the actual top-level binding `Id` via `binding_targets::declaration_ids`; `collect_local_idents_by_export_name` preserves the identifier's ctxt.

Change is contained to the rewriter and its construction.

## Test (red→green)

`partial_swap_does_not_rewrite_shadowing_inner_binding` in `e2e/vendor_swap_test.rs` drives the real CLI: a nested `function pick(zodFlag) { return zodFlag(); }` shadows the swapped import local `zodFlag`. Asserts the inner read stays `zodFlag()` while the top-level use becomes `z.boolean()`, and runs the bundle under node expecting `UPSTREAM:PARAM`.

- RED (buggy `bindings.get(ident.sym)`): emitted `function pick(zodFlag) { return z.boolean(); }` — failed.
- GREEN (fix): passes.

## Verification

`bbr build //devinfra/js/debundle/...` green; `bbr test //devinfra/js/debundle/...` — 76/76 pass.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_