### PR TITLE
debundle: bail on silently-dropped swap-reachable observable side effects

### DIFF
--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -719,6 +719,40 @@ fn partial_swap_keeps_side_effect_init() {
 }
 
 #[test]
+fn partial_swap_rejects_observable_side_effect_reading_swapped_binding() {
+    // A `Hard`, globally-observable side effect (`globalThis.__zodBoolean =
+    // e6`) that *reads* the swapped binding `e6`. The read makes the
+    // statement swap-reachable, so the keep-pass declines to honor it for its
+    // side effect and it would otherwise be silently dropped — even though
+    // residual / external code can witness the global write via
+    // `globalThis.__zodBoolean`. The strip pass must bail rather than ship a
+    // bundle missing the effect.
+    let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
+        chunk_source: "export const e6 = () => true;\nglobalThis.__zodBoolean = e6;\n",
+        caller_source: "import { e6 as zodBoolean } from \"../megachunk/entry.js\";\nexport function go() { return zodBoolean(); }\n",
+        upstream_source: "export const boolean = () => true;\n",
+        symbols: vec![("e6", "zod", "boolean")],
+        upstream_version: "3.23.8",
+    });
+
+    assert!(
+        !fixture.result.status.success(),
+        "debundler should reject an observable side effect that reads a swapped binding\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture
+            .result
+            .stderr
+            .contains("observable side-effect item")
+            && fixture.result.stderr.contains("swap-reachable"),
+        "expected observable-side-effect soundness diagnostic in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
 fn partial_swap_drops_original_package_island_with_local_mutations() {
     let fixture = run_partial_swap_fixture(PartialSwapFixtureArgs {
         chunk_source: "class ZodBoolean {}\nZodBoolean.displayName = \"ZodBoolean\";\nconst e6 = () => new ZodBoolean();\nexport { e6 };\n",

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
-use analysis::{AnalysisHints, ChunkId, LocalEffectPolicy, StatementFacts, analyze_chunk};
+use analysis::{
+    AnalysisHints, ChunkId, EffectCell, LocalEffectPolicy, StatementFacts, analyze_chunk,
+};
 use anyhow::{Context, Result, bail};
 use binding_targets::{
     binding_name_strings, declaration_ids, declaration_name_strings, module_export_name,
@@ -565,6 +567,20 @@ fn sweep_unreachable_top_level(
         &shareable_items,
     );
 
+    // An item carries a globally-observable side effect when it is either a
+    // `Hard` statement (impure / module linkage) or a `LocalMutation` that
+    // writes a target which is neither a chunk-local declaration nor a
+    // replacement-import local — i.e. the write lands on a global / external
+    // object whose post-strip value residual or external code may read.
+    let observable_side_effect = |i: usize| -> bool {
+        let an = &analyses[i];
+        an.side_effect == SideEffectKind::Hard
+            || (an.side_effect == SideEffectKind::LocalMutation
+                && an.local_effects.iter().any(|id| {
+                    !declarer.contains_key(id) && !replacement_import_locals.contains(id)
+                }))
+    };
+
     let mut live = vec![false; analyses.len()];
     let mut live_reasons = vec![None; analyses.len()];
     for (i, an) in analyses.iter().enumerate() {
@@ -575,12 +591,7 @@ fn sweep_unreachable_top_level(
             .cloned()
             .collect::<Vec<_>>();
         let residual_export = !residual_exports.is_empty();
-        let hard_side_effect = (an.side_effect == SideEffectKind::Hard
-            || (an.side_effect == SideEffectKind::LocalMutation
-                && an.local_effects.iter().any(|id| {
-                    !declarer.contains_key(id) && !replacement_import_locals.contains(id)
-                })))
-            && swapped_reachability[i].is_empty();
+        let hard_side_effect = observable_side_effect(i) && swapped_reachability[i].is_empty();
         if residual_export {
             live[i] = true;
             live_reasons[i] = Some(LiveReason::ResidualExport(residual_exports));
@@ -650,6 +661,68 @@ fn sweep_unreachable_top_level(
                 );
             }
         }
+    }
+
+    // Soundness gate: a top-level item carrying a globally-observable side
+    // effect must never be *silently* dropped. The keep-pass above honors such
+    // an item only when it is not swap-reachable; a swap-reachable one falls
+    // through to deletion. Dropping is sound only when the effect is provably
+    // swap-private — every storage cell it writes stays inside the swapped
+    // island, so no retained / external code can witness its post-strip value:
+    //
+    //   * a static-key `globalThis.<prop>` write is never private (external or
+    //     other-chunk code may read the global back — e.g. `window.foo =
+    //     <swappedThing>` read via `window.foo`);
+    //   * a binding write is private unless some *retained* (`live`) item reads
+    //     that binding; writes to a replacement-import local stay private
+    //     (the old island configuring the new facade has no residual reader);
+    //   * a statement the analyzer cannot summarize (dynamic `globalThis[expr]`,
+    //     `eval`, `with`, `Function(...)`) may touch any cell and is never
+    //     private.
+    //
+    // A swap-reachable observable effect that is not provably swap-private would
+    // be silently deleted — an under-restriction soundness violation. Bail so
+    // the spec author restructures rather than shipping a broken bundle.
+    let live_reads: BTreeSet<Id> = analyses
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| live[i])
+        .flat_map(|(_, an)| an.reads.iter().chain(an.local_effects.iter()).cloned())
+        .collect();
+    let swap_private_effect = |i: usize| -> bool {
+        let an = &analyses[i];
+        if !an.effects_summarizable {
+            return false;
+        }
+        an.observable_writes.iter().all(|cell| match cell {
+            EffectCell::GlobalProp(_) => false,
+            EffectCell::Binding(id) => {
+                replacement_import_locals.contains(id) || !live_reads.contains(id)
+            }
+        })
+    };
+    for i in 0..analyses.len() {
+        if live[i]
+            || swapped_reachability[i].is_empty()
+            || !observable_side_effect(i)
+            || swap_private_effect(i)
+        {
+            continue;
+        }
+        let packages = swapped_reachability[i]
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(",");
+        let declared = analyses[i]
+            .declared
+            .iter()
+            .map(id_name)
+            .collect::<Vec<_>>()
+            .join(",");
+        bail!(
+            "strip_swapped_vendor_exports vendor entry {chunk_path}: observable side-effect item {i} is swap-reachable from package(s) [{packages}] (declared=[{declared}]) but its observable effect is not provably swap-private (it writes a global / external cell residual code may read), so it would be silently dropped — restructure the spec so the side effect does not read swapped binding(s)",
+        );
     }
 
     let mut original = std::mem::take(&mut module.body);
@@ -1035,6 +1108,16 @@ struct ItemAnalysis {
     export_aliases: BTreeSet<String>,
     side_effect: SideEffectKind,
     shareable_helper: bool,
+    /// Outer-observable storage cells this statement writes at-init
+    /// (binding rebinds and static-key `globalThis.<prop>` writes).
+    /// Empty/incomplete unless `effects_summarizable` is true.
+    observable_writes: BTreeSet<EffectCell>,
+    /// False when the statement contains a shape the analyzer cannot
+    /// statically summarize (dynamic `globalThis[expr]`, `with`,
+    /// direct `eval`, `Function(...)`, etc.); in that case the write
+    /// set is unreliable and the statement must be treated as touching
+    /// every observable cell.
+    effects_summarizable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1092,6 +1175,8 @@ fn item_analysis_from_fact(item: &ModuleItem, fact: &StatementFacts) -> ItemAnal
         export_aliases: export_aliases_for_item(item),
         side_effect,
         shareable_helper: item_is_shareable_helper(item),
+        observable_writes: fact.effects.writes.clone(),
+        effects_summarizable: fact.effects.dataflow_summarizable,
     }
 }
 


### PR DESCRIPTION
One of a set of follow-up correctness fixes from the debundle review.

## Bug (soundness gap)

`vendor/strip.rs` honored a `Hard` (observable) side-effect statement only when its `swapped_reachability` was empty. A `Hard` side-effect that *also* read a swapped binding got its reachability set and was therefore **silently dropped**. The split-brain detector only fires for *kept* (`live`) items, and the soundness gate only checked *binding reads* — not global/observable effects. So e.g. `globalThis.__x = <swappedThing>` (which residual/external code may read back) was removed with no diagnostic, producing a silently-broken bundle. Per AGENTS.md "soundness over completeness", a silent drop the output relies on is an under-restriction = soundness violation.

## Fix (bail — over-restriction)

A `Hard`/globally-observable side effect is by classification observable outside the swapped island, so a per-chunk pass can never *prove* it isn't witnessed by retained/external code. The fix extends the soundness gate: a swap-reachable observable side-effect item that would be dropped now **bails with a dedicated diagnostic unless it is provably swap-private**, using a precise, checkable precondition (mirroring the `dataflow_summarizable` conditional-correctness pattern in AGENTS.md):

`effects.dataflow_summarizable` AND every observable write cell stays inside the island —
- static-key `globalThis.<prop>` write → never private (may be read back);
- binding write → private unless a retained (`live`) item reads it; replacement-import-local writes stay private (old island configuring the new facade);
- non-summarizable statements (`eval`, `with`, `Function(...)`, dynamic `globalThis[expr]`) → never private.

This reuses `StatementEffectSummary` (`EffectCell::{Binding,GlobalProp}`, `dataflow_summarizable`) already produced by the analyzer, threaded through `ItemAnalysis`. The `observable_side_effect` predicate is factored out and shared by the keep-logic and the new gate.

The four pre-existing `strip::tests` for genuinely swap-private island drops were investigated and **encode a real contract** (writes confined to island-local bindings / replacement-import facades, no global read-back) — the refined criterion keeps them dropping; all four pass unmodified.

## Test (red→green)

`partial_swap_rejects_observable_side_effect_reading_swapped_binding` in `e2e/vendor_swap_test.rs` — fixture `globalThis.__zodBoolean = e6;` where `e6` is the swapped export.
- RED (unmodified): statement silently dropped, debundler exits success — failed.
- GREEN (fix): pass bails with the new diagnostic — passes.

## Verification

`bbr test //devinfra/js/debundle:vendor_test //devinfra/js/debundle/e2e:vendor_swap_test` — 2/2 pass on this branch (rebased onto current `devel`, which includes #1715). Agent's full `//devinfra/js/debundle/...` run was 76/76.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_