### PR TITLE
debundle: make lowering rename passes scope-aware (fix shadowing miscompilation)

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -66,6 +66,7 @@ _STANDARD_E2E_DEPS = [
         "sibling_declarator_steal_test",
         "chunk_rename_cross_module_test",
         "chunk_renames_test",
+        "rename_shadowed_inner_binding_test",
         "missing_binding_member_test",
         "residual_member_rename_test",
         "source_order_emit_test",

--- a/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
+++ b/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
@@ -1,0 +1,105 @@
+//! Regression: lowering rename passes must be scope-aware.
+//!
+//! A top-level binding rename (here driven by `chunk_renames`, the same
+//! string-keyed map the `IdentifierRenamer` walks the whole entry body with)
+//! must NOT leak into a nested scope that re-binds the same name. The old
+//! sym-only renamer rewrote every matching identifier — including an inner
+//! `var`/`let` declaration and its references that shadow the renamed
+//! top-level name — which both rewrote a binding it had no business touching
+//! and, when the rename target collided with another in-scope binding,
+//! silently merged two distinct bindings and changed runtime behavior.
+//!
+//! This is the emit-side instance of the shadowing root cause fixed in the
+//! purity classifier (#1714).
+
+use debundle_e2e_support::*;
+use serde_json::{Value, json};
+
+fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
+    json!({
+        "id": "chunk_renames__static_app",
+        "members": [
+            {
+                "name": rename_to,
+                "selector": { "binding": { "name": from_binding } },
+            },
+        ],
+    })
+}
+
+/// Renaming top-level `a` -> `b` must leave the inner function's own `var a`
+/// (which shadows the top-level `a`) untouched. The rename target `b` already
+/// names the function's parameter, so a leaked rename of the inner `var a`
+/// would collide with that parameter and merge two distinct bindings —
+/// observably corrupting the return value.
+#[test]
+fn top_level_rename_does_not_leak_into_shadowing_inner_var() {
+    let opts = FixtureOpts::new(
+        r#"var a = "A";
+function f(b) {
+  var a = "innerA";
+  return a + b;
+}
+console.log(f("B") + a);
+export { a, f };
+"#,
+        vec![],
+    )
+    .with_chunk_renames(chunk_rename("b", "a"))
+    .with_unassigned_mode(unassigned_mode_inline());
+    let fixture = run_fixture(opts);
+
+    // Runtime must be unchanged by the rename: f("B") = "innerA" + "B", then
+    // + the top-level value "A". A leaked rename would turn the inner body
+    // into `var b = "innerA"; return b + b;` (the param `b` is clobbered),
+    // yielding "innerAinnerAA".
+    assert_entry_output(&fixture, "innerABA\n");
+
+    // The top-level binding is renamed to `b`; the inner shadowing binding
+    // and its references stay `a`.
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/entry.js",
+        &[
+            "var b = \"A\"",
+            "function f(b)",
+            "var a = \"innerA\"",
+            "return a + b",
+            "console.log(f(\"B\") + b)",
+        ],
+        &["var b = \"innerA\"", "return b + b"],
+    );
+}
+
+/// The same guard for a function parameter that shadows the renamed
+/// top-level name: `f(a)`'s param `a` and its uses refer to the parameter,
+/// not the renamed top-level binding, so they must be left alone.
+#[test]
+fn top_level_rename_does_not_leak_into_shadowing_param() {
+    let opts = FixtureOpts::new(
+        r#"var a = "top";
+function f(a) {
+  return a;
+}
+console.log(f("arg") + a);
+export { a, f };
+"#,
+        vec![],
+    )
+    .with_chunk_renames(chunk_rename("readable", "a"))
+    .with_unassigned_mode(unassigned_mode_inline());
+    let fixture = run_fixture(opts);
+
+    assert_entry_output(&fixture, "argtop\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/entry.js",
+        &[
+            "var readable = \"top\"",
+            "function f(a)",
+            "return a",
+            "console.log(f(\"arg\") + readable)",
+        ],
+        &["function f(readable)", "return readable"],
+    );
+}

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -315,9 +315,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         for item in entry_body.iter_mut() {
             preserve_export_specifier_names(item, &body_renames);
         }
-        let mut renamer = IdentifierRenamer {
-            renames: &body_renames,
-        };
+        let mut renamer = IdentifierRenamer::new(&body_renames);
         for item in entry_body.iter_mut() {
             item.visit_mut_with(&mut renamer);
         }
@@ -713,9 +711,7 @@ fn lower_single_plan(
         )
     })?;
     if !module_import_renames.is_empty() {
-        let mut renamer = IdentifierRenamer {
-            renames: &module_import_renames,
-        };
+        let mut renamer = IdentifierRenamer::new(&module_import_renames);
         for item in body.iter_mut() {
             item.visit_mut_with(&mut renamer);
         }
@@ -761,9 +757,7 @@ fn lower_single_plan(
     // upstream binding.
     if !cross_module_chunk_renames.is_empty() {
         time_phase!(timings, "module.rename_chunk_renames", {
-            let mut renamer = IdentifierRenamer {
-                renames: cross_module_chunk_renames,
-            };
+            let mut renamer = IdentifierRenamer::new(cross_module_chunk_renames);
             for item in body.iter_mut() {
                 item.visit_mut_with(&mut renamer);
             }

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -13,34 +13,184 @@ pub(super) fn naturalize_module_body(
     body: &mut [ModuleItem],
     plan: &ModulePlan,
 ) -> BTreeMap<String, String> {
-    let mut renames = BTreeMap::<String, String>::new();
+    let mut plan_driven = BTreeMap::<String, String>::new();
     // Stable iteration over `plan.bindings` (a HashMap) so the order
-    // renames land in `renames` — and thus the rename-precedence the
+    // renames land in `plan_driven` — and thus the rename-precedence the
     // visitor applies when two locals compete for the same target —
     // doesn't vary by hash seed.
     let mut sorted_bindings: Vec<(&String, &String)> = plan.bindings.iter().collect();
     sorted_bindings.sort_by(|a, b| a.0.cmp(b.0));
     for (local, exported) in sorted_bindings {
         if local != exported && is_valid_js_identifier(exported) {
-            renames.insert(local.clone(), exported.clone());
+            plan_driven.insert(local.clone(), exported.clone());
         }
     }
     let mut heuristic = BTreeMap::<String, String>::new();
     for item in body.iter() {
         collect_naturalization_renames_from_item(item, &mut heuristic);
     }
-    let renames = drop_target_collisions(renames, heuristic);
-    if renames.is_empty() {
+    // The merged map is what callers read back as the local-name → readable
+    // lookup. Application below splits the two categories: plan-driven names
+    // are top-level module bindings and rename module-wide (suppressed in any
+    // subtree that re-binds them); heuristic names are derived from a single
+    // function/constructor/arrow's own params, return-object aliases, or
+    // `this.x = param` assignments and must rename only within that node's
+    // own subtree — applying them module-wide would rewrite an unrelated
+    // binding of the same name in a sibling scope.
+    let merged = drop_target_collisions(plan_driven.clone(), heuristic);
+    // Heuristic-only entries (those not also plan-driven) are the scope-local
+    // ones; plan-driven entries that survived collision-dropping apply
+    // module-wide.
+    let plan_driven_effective: BTreeMap<String, String> = merged
+        .iter()
+        .filter(|(local, _)| plan_driven.contains_key(*local))
+        .map(|(local, target)| (local.clone(), target.clone()))
+        .collect();
+    let heuristic_effective: BTreeMap<String, String> = merged
+        .iter()
+        .filter(|(local, _)| !plan_driven.contains_key(*local))
+        .map(|(local, target)| (local.clone(), target.clone()))
+        .collect();
+
+    if plan_driven_effective.is_empty() && heuristic_effective.is_empty() {
         for item in body.iter_mut() {
             item.visit_mut_with(&mut ShorthandNaturalizer);
         }
-    } else {
-        let mut naturalizer = RenameAndShorthandNaturalizer { renames: &renames };
+        return merged;
+    }
+
+    // Apply plan-driven (module-scope) renames + shorthand collapse first,
+    // module-wide but scope-aware. Shorthand collapse here covers the
+    // top-level object literals/patterns.
+    if !plan_driven_effective.is_empty() {
+        let mut naturalizer = RenameAndShorthandNaturalizer::new(&plan_driven_effective);
         for item in body.iter_mut() {
             item.visit_mut_with(&mut naturalizer);
         }
     }
-    renames
+
+    // Apply heuristic (scope-local) renames per the function/constructor/arrow
+    // they were derived from. `ScopedHeuristicNaturalizer` recurses into the
+    // body, and at each function-like node computes that node's own heuristic
+    // renames and rewrites just that node's subtree (its params + body),
+    // suppressing the rename inside any further-nested subtree that re-binds
+    // the same name.
+    if !heuristic_effective.is_empty() {
+        let mut scoped = ScopedHeuristicNaturalizer {
+            allowed: &heuristic_effective,
+        };
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut scoped);
+        }
+    } else if plan_driven_effective.is_empty() {
+        // No heuristics survived and no plan-driven renames ran: still collapse
+        // shorthand. (Reached only when `merged` is non-empty but every entry
+        // was a heuristic dropped by collision handling — rare, but keep the
+        // shorthand pass.)
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut ShorthandNaturalizer);
+        }
+    }
+
+    merged
+}
+
+/// Walks the module body and applies heuristic naturalization renames
+/// scope-locally: at each function/constructor/arrow it derives that node's
+/// own heuristic renames (param destructure aliases, return-object aliases,
+/// `this.x = param` constructor assignments) and rewrites only that node's
+/// subtree. A heuristic rename derived from one scope must never leak into a
+/// sibling/parent scope that binds the same name, so the rewrite is confined
+/// to the deriving node — and `RenameAndShorthandNaturalizer`'s nested
+/// shadow-suppression still guards any further-nested re-binding subtree.
+struct ScopedHeuristicNaturalizer<'a> {
+    /// The merged set of heuristic renames that survived collision-dropping;
+    /// a node's locally-derived rename only fires if it appears here.
+    allowed: &'a BTreeMap<String, String>,
+}
+
+impl ScopedHeuristicNaturalizer<'_> {
+    /// Filter a node's locally-derived renames down to the globally-allowed
+    /// set, returning the effective scope-local rename map (empty if nothing
+    /// fires).
+    fn effective(&self, derived: BTreeMap<String, String>) -> BTreeMap<String, String> {
+        derived
+            .into_iter()
+            .filter(|(from, to)| self.allowed.get(from) == Some(to))
+            .collect()
+    }
+}
+
+/// Rewrites the statements of a function/constructor body with a heuristic
+/// rename map, treating the body's own (root-scope) bindings as rename
+/// targets rather than shadows. The renamer is applied to each statement
+/// individually so `RenameAndShorthandNaturalizer::visit_mut_block_stmt`
+/// never fires for this root block (its `let`/`const` declarations are the
+/// targets); nested blocks/functions encountered inside the statements do
+/// push their own shadow scopes, so a deeper re-binding of the same name is
+/// still suppressed. Visiting statements one-by-one (rather than the enclosing
+/// block node) is what skips `visit_mut_block_stmt`'s own-decl shadow push for
+/// the root block.
+fn rename_root_body(renamer: &mut RenameAndShorthandNaturalizer<'_>, body: Option<&mut BlockStmt>) {
+    if let Some(body) = body {
+        for stmt in &mut body.stmts {
+            stmt.visit_mut_with(renamer);
+        }
+    }
+}
+
+impl VisitMut for ScopedHeuristicNaturalizer<'_> {
+    fn visit_mut_function(&mut self, function: &mut Function) {
+        // Recurse first so nested functions apply their own heuristics.
+        function.visit_mut_children_with(self);
+        let mut derived = BTreeMap::new();
+        collect_naturalization_renames_from_function(function, &mut derived);
+        let local = self.effective(derived);
+        if local.is_empty() {
+            return;
+        }
+        // Params and the root body share this function's scope, where the
+        // renamed name is bound exactly once and every reference resolves to
+        // it. Drive past the root param/block scope (visiting params and the
+        // body's statements directly) so the own-binding isn't treated as a
+        // shadow; nested subtrees still suppress.
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        function.params.visit_mut_with(&mut renamer);
+        rename_root_body(&mut renamer, function.body.as_mut());
+    }
+
+    fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
+        arrow.visit_mut_children_with(self);
+        let mut derived = BTreeMap::new();
+        for param in &arrow.params {
+            collect_naturalization_renames_from_pattern(param, &mut derived);
+        }
+        let local = self.effective(derived);
+        if local.is_empty() {
+            return;
+        }
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        arrow.params.visit_mut_with(&mut renamer);
+        match &mut *arrow.body {
+            BlockStmtOrExpr::BlockStmt(block) => rename_root_body(&mut renamer, Some(block)),
+            BlockStmtOrExpr::Expr(expr) => expr.visit_mut_with(&mut renamer),
+        }
+    }
+
+    fn visit_mut_constructor(&mut self, constructor: &mut Constructor) {
+        constructor.visit_mut_children_with(self);
+        let mut derived = BTreeMap::new();
+        collect_naturalization_renames_from_constructor(constructor, &mut derived);
+        let local = self.effective(derived);
+        if local.is_empty() {
+            return;
+        }
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        for param in &mut constructor.params {
+            param.visit_mut_with(&mut renamer);
+        }
+        rename_root_body(&mut renamer, constructor.body.as_mut());
+    }
 }
 
 /// Merge `heuristic` into `plan_driven`, dropping any heuristic mapping
@@ -146,23 +296,29 @@ pub(super) fn collect_naturalization_renames_from_class(
     renames: &mut BTreeMap<String, String>,
 ) {
     for member in &class.body {
-        let ClassMember::Constructor(constructor) = member else {
-            continue;
-        };
-        let mut param_names = BTreeSet::new();
-        for param in &constructor.params {
-            if let ParamOrTsParamProp::Param(param) = param
-                && let Pat::Ident(ident) = &param.pat
-            {
-                param_names.insert(ident.id.sym.to_string());
-            }
+        if let ClassMember::Constructor(constructor) = member {
+            collect_naturalization_renames_from_constructor(constructor, renames);
         }
-        let Some(body) = constructor.body.as_ref() else {
-            continue;
-        };
-        for statement in &body.stmts {
-            collect_constructor_assignment_renames(statement, &param_names, renames);
+    }
+}
+
+pub(super) fn collect_naturalization_renames_from_constructor(
+    constructor: &Constructor,
+    renames: &mut BTreeMap<String, String>,
+) {
+    let mut param_names = BTreeSet::new();
+    for param in &constructor.params {
+        if let ParamOrTsParamProp::Param(param) = param
+            && let Pat::Ident(ident) = &param.pat
+        {
+            param_names.insert(ident.id.sym.to_string());
         }
+    }
+    let Some(body) = constructor.body.as_ref() else {
+        return;
+    };
+    for statement in &body.stmts {
+        collect_constructor_assignment_renames(statement, &param_names, renames);
     }
 }
 

--- a/devinfra/js/debundle/lowering/visitors.rs
+++ b/devinfra/js/debundle/lowering/visitors.rs
@@ -5,16 +5,147 @@
 //! - `ShorthandNaturalizer` is the standalone shorthand-only pass.
 //!
 //! The `naturalize_object_*_shorthand` helpers are shared between them.
+//!
+//! ## Scope-aware renaming
+//!
+//! The rename map is keyed by bare symbol, but a rename must never leak
+//! into a subtree that re-binds the same name. When a function/arrow/
+//! method/catch/block introduces a binding whose name is a rename source,
+//! that name inside the subtree refers to the inner binding, not the
+//! top-level binding the rename targets — rewriting it (or its inner
+//! declaration) would change runtime behavior. Both renaming visitors
+//! maintain a scope stack (`RenameScopeStack`) and suppress a name's
+//! rename for the duration of any subtree that shadows it. This mirrors
+//! `purity::PlainDataWriteScanner`'s `shadowed_by_params` + `with_scope`
+//! pattern; here it must additionally track block-scoped `let`/`const`/
+//! `class`/`function` and `catch` bindings because rename targets reach
+//! deeper than the purity scan's parameter-only tracking.
+//!
+//! Over-suppression (skipping a rename in a shadowed subtree where it
+//! might technically have been safe) is acceptable; silent miscompilation
+//! is not. The stack therefore errs toward suppressing whenever a name is
+//! re-bound anywhere in the enclosing subtree.
 
 use super::*;
 
-/// Generates the 6 shared `VisitMut` methods that apply a string-keyed
+/// Stack of per-scope shadow sets. A name is "shadowed at this point in
+/// the traversal" iff it appears in any active stack entry; while shadowed
+/// its rename is suppressed. Shared by both renaming visitors.
+#[derive(Default)]
+pub(super) struct RenameScopeStack {
+    scopes: Vec<BTreeSet<String>>,
+}
+
+impl RenameScopeStack {
+    fn is_shadowed(&self, name: &str) -> bool {
+        self.scopes.iter().any(|scope| scope.contains(name))
+    }
+
+    fn push(&mut self, scope: BTreeSet<String>) {
+        self.scopes.push(scope);
+    }
+
+    fn pop(&mut self) {
+        self.scopes.pop();
+    }
+}
+
+/// Names a single parameter pattern binds that are also rename sources.
+fn collect_shadowed_by_pat(
+    pat: &Pat,
+    renames: &BTreeMap<String, String>,
+    out: &mut BTreeSet<String>,
+) {
+    match pat {
+        Pat::Ident(ident) => {
+            let name = ident.id.sym.as_ref();
+            if renames.contains_key(name) {
+                out.insert(name.to_string());
+            }
+        }
+        Pat::Rest(rest) => collect_shadowed_by_pat(&rest.arg, renames, out),
+        Pat::Assign(assign) => collect_shadowed_by_pat(&assign.left, renames, out),
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_shadowed_by_pat(elem, renames, out);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    ObjectPatProp::KeyValue(kv) => collect_shadowed_by_pat(&kv.value, renames, out),
+                    ObjectPatProp::Assign(assign) => {
+                        let name = assign.key.id.sym.as_ref();
+                        if renames.contains_key(name) {
+                            out.insert(name.to_string());
+                        }
+                    }
+                    ObjectPatProp::Rest(rest) => collect_shadowed_by_pat(&rest.arg, renames, out),
+                }
+            }
+        }
+        Pat::Invalid(_) | Pat::Expr(_) => {}
+    }
+}
+
+fn shadowed_by_params<'a, I>(params: I, renames: &BTreeMap<String, String>) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = &'a Pat>,
+{
+    let mut out = BTreeSet::new();
+    for param in params {
+        collect_shadowed_by_pat(param, renames, &mut out);
+    }
+    out
+}
+
+/// Names that lexical declarations (`let`/`const`/`var`/`function`/`class`)
+/// directly inside `stmts` bind and that are also rename sources. Only the
+/// statement list's own scope is inspected (no descent into nested
+/// function/arrow bodies — those push their own scopes when visited). `var`
+/// hoists to the enclosing function rather than the block, but treating it
+/// as block-shadowing here only over-suppresses, which is sound.
+fn shadowed_by_block_decls(stmts: &[Stmt], renames: &BTreeMap<String, String>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for stmt in stmts {
+        match stmt {
+            Stmt::Decl(Decl::Var(var)) => {
+                for declarator in &var.decls {
+                    collect_shadowed_by_pat(&declarator.name, renames, &mut out);
+                }
+            }
+            Stmt::Decl(Decl::Fn(function)) => {
+                let name = function.ident.sym.as_ref();
+                if renames.contains_key(name) {
+                    out.insert(name.to_string());
+                }
+            }
+            Stmt::Decl(Decl::Class(class)) => {
+                let name = class.ident.sym.as_ref();
+                if renames.contains_key(name) {
+                    out.insert(name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Generates the shared `VisitMut` methods that apply a string-keyed
 /// rename map to identifiers, import specifiers, computed property/member
-/// keys, and named exports. Used by both `IdentifierRenamer` (rename-only)
-/// and `RenameAndShorthandNaturalizer` (rename + shorthand collapse).
+/// keys, and named exports, suppressing renames in subtrees that re-bind
+/// the same name. Used by both `IdentifierRenamer` (rename-only) and
+/// `RenameAndShorthandNaturalizer` (rename + shorthand collapse).
+///
+/// Expects `self.renames: &BTreeMap<String, String>` and
+/// `self.scopes: RenameScopeStack`.
 macro_rules! impl_rename_visit_mut {
     () => {
         fn visit_mut_ident(&mut self, ident: &mut Ident) {
+            if self.scopes.is_shadowed(ident.sym.as_ref()) {
+                return;
+            }
             if let Some(to) = self.renames.get(ident.sym.as_ref()) {
                 ident.sym = to.clone().into();
             }
@@ -22,6 +153,9 @@ macro_rules! impl_rename_visit_mut {
 
         fn visit_mut_import_named_specifier(&mut self, spec: &mut ImportNamedSpecifier) {
             let original_local = spec.local.sym.clone();
+            if self.scopes.is_shadowed(original_local.as_ref()) {
+                return;
+            }
             let Some(to) = self.renames.get(original_local.as_ref()) else {
                 return;
             };
@@ -55,11 +189,63 @@ macro_rules! impl_rename_visit_mut {
         fn visit_mut_export_named_specifier(&mut self, spec: &mut ExportNamedSpecifier) {
             spec.orig.visit_mut_with(self);
         }
+
+        fn visit_mut_function(&mut self, function: &mut Function) {
+            let scope = shadowed_by_params(function.params.iter().map(|p| &p.pat), self.renames);
+            self.with_rename_scope(scope, |s| function.visit_mut_children_with(s));
+        }
+
+        fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
+            let scope = shadowed_by_params(arrow.params.iter(), self.renames);
+            self.with_rename_scope(scope, |s| arrow.visit_mut_children_with(s));
+        }
+
+        fn visit_mut_constructor(&mut self, constructor: &mut Constructor) {
+            let params = constructor.params.iter().filter_map(|p| match p {
+                ParamOrTsParamProp::Param(param) => Some(&param.pat),
+                ParamOrTsParamProp::TsParamProp(_) => None,
+            });
+            let scope = shadowed_by_params(params, self.renames);
+            self.with_rename_scope(scope, |s| constructor.visit_mut_children_with(s));
+        }
+
+        fn visit_mut_catch_clause(&mut self, clause: &mut CatchClause) {
+            let scope = match &clause.param {
+                Some(pat) => {
+                    let mut out = BTreeSet::new();
+                    collect_shadowed_by_pat(pat, self.renames, &mut out);
+                    out
+                }
+                None => BTreeSet::new(),
+            };
+            self.with_rename_scope(scope, |s| clause.visit_mut_children_with(s));
+        }
+
+        fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
+            let scope = shadowed_by_block_decls(&block.stmts, self.renames);
+            self.with_rename_scope(scope, |s| block.visit_mut_children_with(s));
+        }
     };
 }
 
 pub(super) struct IdentifierRenamer<'a> {
     pub(super) renames: &'a BTreeMap<String, String>,
+    pub(super) scopes: RenameScopeStack,
+}
+
+impl<'a> IdentifierRenamer<'a> {
+    pub(super) fn new(renames: &'a BTreeMap<String, String>) -> Self {
+        Self {
+            renames,
+            scopes: RenameScopeStack::default(),
+        }
+    }
+
+    fn with_rename_scope<F: FnOnce(&mut Self)>(&mut self, scope: BTreeSet<String>, f: F) {
+        self.scopes.push(scope);
+        f(self);
+        self.scopes.pop();
+    }
 }
 
 impl VisitMut for IdentifierRenamer<'_> {
@@ -68,6 +254,22 @@ impl VisitMut for IdentifierRenamer<'_> {
 
 pub(super) struct RenameAndShorthandNaturalizer<'a> {
     pub(super) renames: &'a BTreeMap<String, String>,
+    pub(super) scopes: RenameScopeStack,
+}
+
+impl<'a> RenameAndShorthandNaturalizer<'a> {
+    pub(super) fn new(renames: &'a BTreeMap<String, String>) -> Self {
+        Self {
+            renames,
+            scopes: RenameScopeStack::default(),
+        }
+    }
+
+    fn with_rename_scope<F: FnOnce(&mut Self)>(&mut self, scope: BTreeSet<String>, f: F) {
+        self.scopes.push(scope);
+        f(self);
+        self.scopes.pop();
+    }
 }
 
 impl VisitMut for RenameAndShorthandNaturalizer<'_> {


### PR DESCRIPTION
One of a set of follow-up correctness fixes from the debundle review — the emit-side instance of the same shadowing root cause fixed in the purity classifier (#1714) and the vendor rewriter (#1715).

## Bug

The lowering rename visitors were keyed by bare string symbol and walked the whole module, so a top-level binding rename leaked into any nested scope that re-bound the same name — rewriting inner param / `let`/`const` / `catch` bindings (and their declarations) that *shadow* a renamed top-level name, corrupting runtime behavior.

## Fix (minimal scope guard — not the rename-ledger refactor)

- `lowering/visitors.rs`: `IdentifierRenamer` and `RenameAndShorthandNaturalizer` are now scope-aware via a `RenameScopeStack`. At each function/arrow/constructor/catch/block that declares a binding whose name is a rename source, that name's rename is suppressed for the subtree. Mirrors `purity::PlainDataWriteScanner`'s `shadowed_by_params` + `with_scope`, extended to block-scoped `let`/`const`/`class`/`function` and `catch` bindings. `visit_mut_ident` / `visit_mut_import_named_specifier` consult `is_shadowed` before renaming.
- `lowering/naturalize.rs`: split the two rename categories. Plan-driven (top-level) renames apply module-wide through the scope-aware naturalizer; heuristic param / return-object / constructor-`this.x=param` renames are applied **scope-locally** via a new `ScopedHeuristicNaturalizer` so they only rewrite the function they were derived from (driving past that node's own root scope so the target binding is renamed while nested re-binding subtrees stay suppressed). Extracted `collect_naturalization_renames_from_constructor`.
- `lowering/lower.rs`: updated the three `IdentifierRenamer` call sites.

Per `TODO.md` guidance this is the minimal sound scope-guard; it deliberately does **not** build the larger collect → validate → execute rename-ledger architecture.

## Tests (red→green)

`e2e/rename_shadowed_inner_binding_test.rs`, two cases driving the real CLI via the `chunk_renames` string-keyed body-rename path:
- `top_level_rename_does_not_leak_into_shadowing_inner_var`
- `top_level_rename_does_not_leak_into_shadowing_param`

Both pin emitted shape (`assert_module_source`) and runtime output (`assert_entry_output`).

- RED (production files reverted to HEAD): param case emitted `function f(readable) { return readable }` (leaked rename); inner-var case miscompiled to runtime output `innerAinnerAA` instead of `innerABA` (binding merge).
- GREEN (fix): both pass.

## Verification

`bbr test //devinfra/js/debundle/...` — **77/77 pass** on this branch (rebased onto current `devel`). The existing `naturalization_test` cases (heuristic param/constructor/return-object renames) still pass, which drove the scope-local heuristic design.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_