### PR TITLE
debundle: drop unimplemented runfiles path-resolution contract from AGENTS.md

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -494,27 +494,15 @@ The public spec format consumed by `--spec` is a reviewed contract, but it is
 still debundler-owned. Prefer clean typed shape over compatibility fields kept
 only for older in-repo fixtures.
 
-## Path Resolution Contract
+## Module-specifier path math
 
 The CLI accepts relative or absolute paths for `--spec`, `--package-root
-<pkg>=<dir>`, and `--packages-root`. When the binary runs inside a Bazel
-runfiles context (`bazel run`, `bb run`, or otherwise with `RUNFILES_DIR` /
-`RUNFILES_MANIFEST_FILE` set), each relative path is first resolved through
-runfiles via the standard `runfiles` crate; if the resolution points at an
-existing file the runfiles path is used, otherwise the path is left as-is for
-the caller's filesystem semantics. Outside Bazel the binary behaves as a
-plain CLI — runfiles resolution is opt-in by environment, not a build-time
-mode.
-
-This lets downstream Bazel targets compose absolute-equivalent paths with
-just `$(rlocationpath <label>)` (no shell wrappers, no `$$RUNFILES_DIR`
-substitutions) while keeping the binary usable as a standalone tool outside
-the Bazel tree.
-
-For module-specifier path math, use existing path crates and local helpers
-(`relative-path`, `runfiles`, artifact path helpers, etc.) rather than
-hand-rolled POSIX segment splitting or string replacement. If a helper is
-missing, add one in the path module and keep call sites typed.
+<pkg>=<dir>`, and `--packages-root`; callers pass already-resolved paths
+(e.g. `$(rlocationpath <label>)` from a Bazel target). For module-specifier
+path math, use existing path crates and local helpers (`relative-path`,
+artifact path helpers, etc.) rather than hand-rolled POSIX segment splitting
+or string replacement. If a helper is missing, add one in the path module and
+keep call sites typed.
 
 ## Spec-level `inputs`
 


### PR DESCRIPTION
The review found AGENTS.md's "Path Resolution Contract" describes behavior the binary never implements: it claims `--spec` / `--package-root` / `--packages-root` are resolved through the `runfiles` crate when `RUNFILES_DIR` is set, but `runfiles` appears nowhere in the non-test debundle source (only in `e2e/` tests and an error-message string). Callers pass already-resolved paths (`$(rlocationpath <label>)`).

Remove the unimplemented contract, keep the module-specifier path-math guidance, and drop the misleading `runfiles` helper reference from it.

Doc-only; prettier-clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_