### PR TITLE
live_proxy: surface proxy startup failures instead of swallowing them

### DIFF
--- a/devinfra/js/debundle/live_proxy/BUILD.bazel
+++ b/devinfra/js/debundle/live_proxy/BUILD.bazel
@@ -59,3 +59,12 @@ py_test(
         "@pypi//pytest",
     ],
 )
+
+py_test(
+    name = "server_test",
+    srcs = ["server_test.py"],
+    deps = [
+        ":proxy_lib",
+        "@pypi//pytest",
+    ],
+)

--- a/devinfra/js/debundle/live_proxy/server.py
+++ b/devinfra/js/debundle/live_proxy/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -72,13 +73,46 @@ async def start_proxy_in_process(options: LiveProxyOptions):
     master = DumpMaster(mitm_options, with_termlog=False, with_dumper=False)
     master.addons.add(DebundleLiveProxyAddon(options))
     task = asyncio.create_task(master.run())
-    await wait_for_port(config.proxy_host, config.proxy_port)
-    print_startup_summary(config)
     try:
+        await wait_until_listening(task, config.proxy_host, config.proxy_port)
+        print_startup_summary(config)
         yield ProxyHandles(config=config)
     finally:
         master.shutdown()
-        await asyncio.wait([task], timeout=5)
+        done, _pending = await asyncio.wait([task], timeout=5)
+        if task in done:
+            # Retrieve the result so a proxy failure isn't lost as a
+            # "Task exception was never retrieved" warning. We're in teardown
+            # (the body already ran), so log rather than mask any exception
+            # already propagating out of the body.
+            if (exc := task.exception()) is not None:
+                log.warning("proxy task exited with error: %r", exc)
+        else:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+async def wait_until_listening(task: asyncio.Task, host: str, port: int, timeout_s: float = 10.0) -> None:
+    """Wait until the proxy accepts connections, or surface its startup failure.
+
+    Races `wait_for_port` against the proxy `task` so that if `master.run()`
+    fails during startup (e.g. the listen port can't be bound) the real error
+    is re-raised promptly instead of timing out with a generic message while
+    the task's exception is silently discarded.
+    """
+    port_ready = asyncio.ensure_future(wait_for_port(host, port, timeout_s))
+    try:
+        await asyncio.wait({task, port_ready}, return_when=asyncio.FIRST_COMPLETED)
+        if task.done():
+            task.result()  # re-raises master.run()'s exception if it failed
+            raise RuntimeError("proxy task exited before the listener was ready")
+        await port_ready  # re-raise wait_for_port's error if it timed out
+    finally:
+        if not port_ready.done():
+            port_ready.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await port_ready
 
 
 async def wait_for_port(host: str, port: int, timeout_s: float = 10.0) -> None:

--- a/devinfra/js/debundle/live_proxy/server_test.py
+++ b/devinfra/js/debundle/live_proxy/server_test.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from devinfra.js.debundle.live_proxy import server
+from devinfra.js.debundle.live_proxy.core import LiveProxyOptions
+
+
+@dataclass
+class _FakeConfig:
+    state_dir: Path
+    ca_dir: Path
+    proxy_host: str = "127.0.0.1"
+    # A port nothing is listening on, so `wait_for_port` never succeeds and
+    # the proxy task's failure is what must surface.
+    proxy_port: int = 65432
+
+
+class _FakeAddons:
+    def add(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class _FailingMaster:
+    """Stand-in DumpMaster whose run() fails immediately, the way a real
+    listen-port bind failure would."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.addons = _FakeAddons()
+
+    async def run(self) -> None:
+        raise RuntimeError("listen port bind failed")
+
+    def shutdown(self) -> None:
+        pass
+
+
+class StartProxyInProcessTest(unittest.IsolatedAsyncioTestCase):
+    async def test_propagates_proxy_startup_failure(self) -> None:
+        # A proxy whose run() fails during startup must surface that error to
+        # the caller, not swallow it (as "Task exception was never retrieved")
+        # behind a generic wait_for_port timeout.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = _FakeConfig(state_dir=root / "state", ca_dir=root / "ca")
+            with (
+                mock.patch.object(server, "load_live_proxy_configuration", return_value=config),
+                mock.patch.object(server, "DumpMaster", _FailingMaster),
+                mock.patch.object(server, "DebundleLiveProxyAddon"),
+                mock.patch.object(server, "Options"),
+                pytest.raises(RuntimeError) as excinfo,
+            ):
+                async with server.start_proxy_in_process(LiveProxyOptions()):
+                    pass
+        assert "listen port bind failed" in str(excinfo.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One of the follow-up correctness fixes from the debundle review.

## Bug

`live_proxy/server.py::start_proxy_in_process` launched `master.run()` as a bare `asyncio.create_task` and only awaited it (with a 5s timeout) in `finally`. If the proxy failed during startup — e.g. the listen port can't be bound — the task's exception was never retrieved (logged as "Task exception was never retrieved") while the caller saw only a generic `wait_for_port` timeout ("proxy did not start listening on …"). The real error was lost.

## Fix

- New `wait_until_listening(task, host, port)` races `wait_for_port` against the proxy `task`; if the task finishes first (i.e. `master.run()` raised), it re-raises that error promptly (and cancels the pending port probe).
- Teardown now retrieves the task result so a late failure is surfaced (logged as a warning rather than masking any exception already propagating out of the body), and cancels + awaits the task if it's still pending.

## Test (red→green)

`server_test.py::StartProxyInProcessTest.test_propagates_proxy_startup_failure` patches `DumpMaster` with a stand-in whose `run()` raises immediately (as a bind failure would) and asserts `start_proxy_in_process` propagates that specific error.

- RED (production fix reverted): test fails — the proxy error is swallowed and the caller gets the generic timeout message (Bazel exit 3).
- GREEN (fix): the real `"listen port bind failed"` propagates; test passes.

## Verification

`bbr test //devinfra/js/debundle/live_proxy:server_test` green (exit 0); `ruff check` and the mypy lint aspect clean on the touched files. New `server_test` target added to `live_proxy/BUILD.bazel`.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_