### PR TITLE
debundle: return a clean error (not panic) on malformed owner-graph in peel proposer

### DIFF
--- a/devinfra/js/debundle/e2e/peel_factorize_extend_anonymous_test.rs
+++ b/devinfra/js/debundle/e2e/peel_factorize_extend_anonymous_test.rs
@@ -73,7 +73,7 @@ export { anchor, Foo };
             logical_module("features/foo", &[Member::new("Foo")]),
         ],
     );
-    let report = factorize(&report_graph, &claims(&[("Foo", "features/foo")]), 10_000);
+    let report = factorize(&report_graph, &claims(&[("Foo", "features/foo")]), 10_000).unwrap();
 
     let extension = report
         .proposals
@@ -142,7 +142,8 @@ export { anchor, Foo, Bar };
         &report_graph,
         &claims(&[("Foo", "features/foo"), ("Bar", "features/bar")]),
         10_000,
-    );
+    )
+    .unwrap();
 
     // No anon-only extension proposal should exist. The mixed-deps
     // anonymous statement must land as a fresh-module proposal
@@ -179,7 +180,7 @@ export { anchor, Foo };
             logical_module("features/foo", &[Member::new("Foo")]),
         ],
     );
-    let report = factorize(&report_graph, &claims(&[("Foo", "features/foo")]), 10_000);
+    let report = factorize(&report_graph, &claims(&[("Foo", "features/foo")]), 10_000).unwrap();
 
     // No extension of `features/foo` should be proposed for the
     // intra-residual anon.

--- a/devinfra/js/debundle/e2e/peel_factorize_landability_test.rs
+++ b/devinfra/js/debundle/e2e/peel_factorize_landability_test.rs
@@ -85,7 +85,7 @@ export { anchor, consumer };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     assert!(
         report.proposals.iter().all(|proposal| proposal.status
@@ -120,7 +120,7 @@ export { anchor, consumer_a, consumer_b };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
     assert!(
         report
             .proposals
@@ -149,7 +149,7 @@ export { anchor, dep, consumer };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     assert!(
         report.proposals.iter().any(|proposal| {
@@ -192,7 +192,7 @@ export { a, b, c };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     let chain_cell = report
         .proposals
@@ -247,7 +247,7 @@ export { anchor, consumer };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     let consumer_alone = report
         .proposals
@@ -283,7 +283,7 @@ export { anchor, consumer };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     let consumer_alone = report
         .proposals
@@ -318,7 +318,7 @@ export { anchor, consumer_a, consumer_b };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     let combined = report
         .proposals
@@ -367,7 +367,7 @@ export { anchor, impure, pureBrand };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
     assert!(
         report.proposals.iter().any(|proposal| {
             proposal.binding_ids == vec!["pureBrand".to_string()]
@@ -416,7 +416,7 @@ export { anchor, mutable, peer };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
     assert!(
         report.proposals.iter().any(|proposal| {
             proposal.binding_ids == vec!["mutable".to_string()]
@@ -484,7 +484,7 @@ export { anchor, SearchPopoverState };
     let fixture = run_fixture(opts);
     let graph: OwnerGraphReport =
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
-    let report = factorize(&graph, &no_claims(), 10_000);
+    let report = factorize(&graph, &no_claims(), 10_000).unwrap();
 
     assert!(
         report.proposals.iter().any(|proposal| {

--- a/devinfra/js/debundle/peel/factorize.rs
+++ b/devinfra/js/debundle/peel/factorize.rs
@@ -233,21 +233,21 @@ pub fn analyze_peel_factorize(options: &PeelFactorizeOptions) -> Result<PeelFact
     } else {
         None
     };
-    Ok(factorize_with_context(
+    factorize_with_context(
         &graph,
         &claims,
         options.size_cap_lines,
         FactorizeContext {
             addressable_anonymous_owner_ids,
         },
-    ))
+    )
 }
 
 pub fn factorize(
     graph: &OwnerGraphReport,
     active_claims: &BTreeMap<String, ModulePath>,
     size_cap_lines: usize,
-) -> PeelFactorizeReport {
+) -> Result<PeelFactorizeReport> {
     factorize_with_context(
         graph,
         active_claims,
@@ -266,7 +266,7 @@ fn factorize_with_context(
     active_claims: &BTreeMap<String, ModulePath>,
     size_cap_lines: usize,
     context: FactorizeContext,
-) -> PeelFactorizeReport {
+) -> Result<PeelFactorizeReport> {
     let owner_index: HashMap<&str, usize> = graph
         .nodes
         .iter()
@@ -286,13 +286,9 @@ fn factorize_with_context(
         .nodes
         .iter()
         .enumerate()
-        .filter_map(|(i, node)| {
-            if graph.is_residual(&node.destination) {
-                return None;
-            }
-            Some((i, active_module_label(node, active_claims, graph)))
-        })
-        .collect();
+        .filter(|(_, node)| !graph.is_residual(&node.destination))
+        .map(|(i, node)| Ok((i, active_module_label(node, active_claims, graph)?)))
+        .collect::<Result<_>>()?;
 
     // Spec-module groups: every active-claimed module's owners
     // pre-contracted into one class. Used by `build_seed_quotient`'s
@@ -364,7 +360,7 @@ fn factorize_with_context(
     let status_counts = status_counts(&proposals);
     let diagnostic_counts = diagnostic_counts(&diagnostics);
     let size_distributions = size_distributions(&proposals);
-    PeelFactorizeReport {
+    Ok(PeelFactorizeReport {
         proposals,
         diagnostics,
         size_cap_lines,
@@ -374,7 +370,7 @@ fn factorize_with_context(
         diagnostic_counts,
         size_distributions,
         seed_rejections,
-    }
+    })
 }
 
 /// The canonical [`ModulePath`] an owner's destination resolves to.
@@ -384,30 +380,31 @@ fn factorize_with_context(
 /// module table — a single source of truth, already normalized, so no
 /// chunk-prefix stripping or fallback chain is needed and two owners of
 /// one module can never disagree (the former self-merge bug). A
-/// destination key absent from the table is a malformed report we
-/// surface by panicking rather than inventing an identity.
+/// destination key absent from the table is a malformed report
+/// (truncated / version-skewed `owner_graph.json`), surfaced as an
+/// `Err` rather than a panic so the CLI reports it cleanly.
 fn active_module_label(
     node: &OwnerGraphNodeReport,
     active_claims: &BTreeMap<String, ModulePath>,
     graph: &OwnerGraphReport,
-) -> ModulePath {
+) -> Result<ModulePath> {
     if let Some(claimed) = node
         .declared_bindings
         .iter()
         .find_map(|b| active_claims.get(b.binding.as_str()))
     {
-        return claimed.clone();
+        return Ok(claimed.clone());
     }
-    graph
+    Ok(graph
         .module(&node.destination)
-        .unwrap_or_else(|| {
-            panic!(
-                "owner {} destination {} absent from module table",
+        .with_context(|| {
+            format!(
+                "malformed owner graph: owner {} destination {} absent from module table",
                 node.id, node.destination
             )
-        })
+        })?
         .path
-        .clone()
+        .clone())
 }
 
 /// Spec-module groups derived from `graph.nodes` destinations.
@@ -1185,7 +1182,7 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![],
         );
-        let report = factorize(&graph, &no_claims(), 10_000);
+        let report = factorize(&graph, &no_claims(), 10_000).unwrap();
         assert_eq!(report.residual_owner_count, 2);
         assert_eq!(report.proposals.len(), 2);
         assert!(report.proposals.iter().all(|p| p.owner_ids.len() == 1));
@@ -1223,7 +1220,7 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![atomic_edge("atomic_edge:0", "atomic:0", "atomic:1")],
         );
-        let report = factorize(&graph, &no_claims(), 10_000);
+        let report = factorize(&graph, &no_claims(), 10_000).unwrap();
         assert!(
             report.proposals.iter().any(|p| p.binding_ids
                 == vec!["a".to_string(), "b".to_string()]
@@ -1243,7 +1240,7 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![atomic_edge("atomic_edge:0", "atomic:1", "atomic:0")],
         );
-        let report = factorize(&graph, &claims(&[("a", "ui/x")]), 10_000);
+        let report = factorize(&graph, &claims(&[("a", "ui/x")]), 10_000).unwrap();
         let proposal = report
             .proposals
             .iter()
@@ -1313,7 +1310,8 @@ mod tests {
             &graph,
             &claims(&[("foo", "features/foo"), ("baz", "features/baz")]),
             10_000,
-        );
+        )
+        .unwrap();
 
         // The scenario must actually produce the `features/foo`
         // extension carrying the residual-origin `bridge`, plus a
@@ -1397,7 +1395,7 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![],
         );
-        let report = factorize(&graph, &no_claims(), 10_000);
+        let report = factorize(&graph, &no_claims(), 10_000).unwrap();
         let proposal = report
             .proposals
             .iter()
@@ -1436,10 +1434,45 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![],
         );
-        let report = factorize(&graph, &claims(&[("a", "domains/system/ids")]), 10_000);
+        let report = factorize(&graph, &claims(&[("a", "domains/system/ids")]), 10_000).unwrap();
         assert!(
             report.proposals.iter().all(|p| p.merge_into.is_none()),
             "expected no self-merge proposal from two spellings of one module: {report:#?}",
+        );
+    }
+
+    #[test]
+    fn non_residual_owner_with_missing_destination_is_clean_error_not_panic() {
+        // A non-residual owner whose `destination` key is absent from
+        // the module table (`quotient.nodes`) models a truncated /
+        // version-skewed `owner_graph.json` deserialized from disk by
+        // `analyze_peel_factorize`. `is_residual` returns false for an
+        // unknown key, so the owner survives the residual filter and
+        // reaches `active_module_label` — which used to `panic!`. The
+        // proposer must instead surface a clean `Err` so the CLI
+        // (`debundle modules propose`) reports it through `anyhow`
+        // rather than aborting.
+        let a = owner_at("a", 1, &["a"], 10, test_utils::module_ref("features/foo"));
+        let mut graph = graph_with_atomic_units(
+            vec![a.clone()],
+            vec![],
+            vec![unit("atomic:0", &[&a])],
+            vec![],
+        );
+        // Drop the owner's destination from the module table to
+        // simulate the malformed report.
+        graph
+            .quotient
+            .nodes
+            .retain(|entry| entry.key != a.destination);
+        assert!(graph.module(&a.destination).is_none());
+
+        let result = factorize(&graph, &no_claims(), 10_000);
+        let err = result.expect_err("missing destination must be a clean error, not a panic");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("malformed owner graph") && message.contains(&a.id),
+            "error must name the malformed report and the offending owner: {message}",
         );
     }
 
@@ -1453,7 +1486,7 @@ mod tests {
             vec![unit("atomic:0", &[&import])],
             vec![],
         );
-        let report = factorize(&graph, &no_claims(), 10_000);
+        let report = factorize(&graph, &no_claims(), 10_000).unwrap();
         let proposal = report.proposals.first().expect("anonymous proposal");
         assert_eq!(
             proposal.anonymous_statement_owner_ids,
@@ -1490,7 +1523,8 @@ mod tests {
             FactorizeContext {
                 addressable_anonymous_owner_ids: Some(BTreeSet::from(["owner:effect".to_string()])),
             },
-        );
+        )
+        .unwrap();
         let proposal = report.proposals.first().expect("anonymous proposal");
         assert!(proposal.landable_today, "{proposal:?}");
         assert!(proposal.unaddressable_anonymous_owner_ids.is_empty());
@@ -1514,7 +1548,8 @@ mod tests {
             FactorizeContext {
                 addressable_anonymous_owner_ids: Some(BTreeSet::new()),
             },
-        );
+        )
+        .unwrap();
         let proposal = report.proposals.first().expect("anonymous proposal");
         assert_eq!(
             proposal.anonymous_statement_owner_ids,
@@ -1549,7 +1584,7 @@ mod tests {
             vec![unit("atomic:0", &[&a]), unit("atomic:1", &[&b])],
             vec![atomic_edge("atomic_edge:0", "atomic:0", "atomic:1")],
         );
-        let report = factorize(&graph, &no_claims(), 5);
+        let report = factorize(&graph, &no_claims(), 5).unwrap();
         assert!(
             report.proposals.is_empty(),
             "oversized owners should not appear as proposals: {report:#?}",

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -635,10 +635,10 @@ fn factorize_golden_output_unchanged() {
     // Snapshots live at `devinfra/js/debundle/peel/golden/`. To
     // regenerate (only after a deliberate, justified change), set
     // `UPDATE_GOLDENS=1` when running the test.
-    let f1 = factorize(&golden_residual_singletons(), &no_claims(), 10_000);
-    let f2 = factorize(&golden_closed_residual_unit(), &no_claims(), 10_000);
+    let f1 = factorize(&golden_residual_singletons(), &no_claims(), 10_000).unwrap();
+    let f2 = factorize(&golden_closed_residual_unit(), &no_claims(), 10_000).unwrap();
     let claims_active = claims(&[("BindingA", "ui/x")]);
-    let f3 = factorize(&golden_extend_active_via_anon(), &claims_active, 10_000);
+    let f3 = factorize(&golden_extend_active_via_anon(), &claims_active, 10_000).unwrap();
 
     let json1 = serde_json::to_string_pretty(&f1).unwrap();
     let json2 = serde_json::to_string_pretty(&f2).unwrap();
@@ -1464,7 +1464,7 @@ fn greedy_on_gaffer_chunk_completes_under_one_minute() {
     // its own active module, which is what the planner would see
     // before any spec edits).
     let started = std::time::Instant::now();
-    let result = factorize(&report, &no_claims(), 10_000);
+    let result = factorize(&report, &no_claims(), 10_000).unwrap();
     let elapsed = started.elapsed();
     let extension_proposals: usize = result
         .proposals
@@ -1654,7 +1654,8 @@ fn merge_two_existing_modules_with_mutual_eager_reads() {
         &report,
         &claims(&[("BindingA", "ui/a"), ("BindingB", "ui/b")]),
         10_000,
-    );
+    )
+    .unwrap();
     let merge_proposals: Vec<&peel::factorize::FactorizeProposal> = result
         .proposals
         .iter()
@@ -1713,7 +1714,8 @@ fn merge_absorbs_residual_owner_with_only_intra_deps() {
         &report,
         &claims(&[("BindingA", "ui/a"), ("BindingB", "ui/b")]),
         10_000,
-    );
+    )
+    .unwrap();
     let merge_proposals: Vec<&peel::factorize::FactorizeProposal> = result
         .proposals
         .iter()
@@ -1766,9 +1768,9 @@ fn unification_byte_identical_on_well_formed_inputs() {
     // `factorize_golden_output_unchanged`.
     let claims_active = claims(&[("BindingA", "ui/x")]);
 
-    let r1 = factorize(&golden_residual_singletons(), &no_claims(), 10_000);
-    let r2 = factorize(&golden_closed_residual_unit(), &no_claims(), 10_000);
-    let r3 = factorize(&golden_extend_active_via_anon(), &claims_active, 10_000);
+    let r1 = factorize(&golden_residual_singletons(), &no_claims(), 10_000).unwrap();
+    let r2 = factorize(&golden_closed_residual_unit(), &no_claims(), 10_000).unwrap();
+    let r3 = factorize(&golden_extend_active_via_anon(), &claims_active, 10_000).unwrap();
 
     assert!(
         r1.seed_rejections.is_empty(),
@@ -1936,7 +1938,7 @@ fn unification_rejects_cyclic_atomic_reachability_with_diagnostic() {
     // Spec module mod_alpha contains Foo. The factorize entry
     // point derives spec_modules from the owner destinations, so
     // the active owner above is already registered as mod_alpha.
-    let result = factorize(&report, &claims(&[("Foo", "mod_alpha")]), 10_000);
+    let result = factorize(&report, &claims(&[("Foo", "mod_alpha")]), 10_000).unwrap();
 
     // (a) No proposal should bundle Foo with Helper or Bar — the
     // cycle prevents merging Foo's class with Helper's class


### PR DESCRIPTION
One of the follow-up correctness fixes from the debundle review.

## Bug

`peel/factorize.rs::active_module_label` did `graph.module(&node.destination).unwrap_or_else(|| panic!(...))`. A non-residual owner whose `destination` `ModuleKey` is absent from the module table (`is_residual` returns false for unknown keys, so it slips past the residual filter) reaches that `panic!`. Since `analyze_peel_factorize` reads `owner_graph.json` from disk, a truncated or version-skewed report crashes `debundle modules propose` with a panic instead of erroring cleanly — everything else on this CLI path uses `anyhow`.

## Fix

Thread a `Result` out instead of panicking:
- `active_module_label` returns `Result<ModulePath>`, replacing the `panic!` with `.with_context(...)?` → `"malformed owner graph: owner {id} destination {dest} absent from module table"`.
- `factorize_with_context`, the public `factorize` wrapper, and `analyze_peel_factorize` propagate `Result` (the latter already returned `Result`, and the CLI chain in `plan.rs` already consumes it with `?`), so the error surfaces through `anyhow` with no further up-stack changes.
- Test callers (inline `factorize.rs` tests, `quotient_integration_test.rs`, both `e2e/peel_factorize_*_test.rs`) updated to `.unwrap()`.

## Test (red→green)

`non_residual_owner_with_missing_destination_is_clean_error_not_panic` (inline `tests`, `//devinfra/js/debundle:peel_test`): builds a graph with a non-residual owner in `features/foo`, strips that entry from `quotient.nodes`, and asserts a clean `Err` naming the malformed report and the offending owner.

- RED (original `panic!` restored): test panics (`owner a destination features/foo absent from module table`).
- GREEN (fix): clean `Err`; passes.

## Verification

`bbr test //devinfra/js/debundle/...` — 77/77 pass; rustfmt + pre-commit clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_