### PR TITLE
debundle: make quotient seed pass-3 diagnostic walk non-mutating

### DIFF
--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -2664,36 +2664,45 @@ pub fn build_seed_quotient(
         if cs == ct {
             continue;
         }
-        match q.contract(cs, ct) {
-            Ok(_) => {
-                // Should be unreachable: fixed-point loop already
-                // exited on zero successful contractions.
-                continue;
-            }
-            Err(ContractRejected::WouldCreateCycle { cycle }) => {
-                rejected.push(SeedContractionRejected::AtomicReachability {
-                    edge_id: edge.id.clone(),
-                    source_unit_id: edge.source.clone(),
-                    target_unit_id: edge.target.clone(),
-                    rejected_pair: (
-                        q.owner_id(src_pivot).to_string(),
-                        q.owner_id(tgt_pivot).to_string(),
-                    ),
-                    cycle,
-                });
-            }
-            Err(_) => {
-                rejected.push(SeedContractionRejected::AtomicReachability {
-                    edge_id: edge.id.clone(),
-                    source_unit_id: edge.source.clone(),
-                    target_unit_id: edge.target.clone(),
-                    rejected_pair: (
-                        q.owner_id(src_pivot).to_string(),
-                        q.owner_id(tgt_pivot).to_string(),
-                    ),
-                    cycle: CycleEvidence::default(),
-                });
-            }
+        // Diagnostic-only: classify *why* this edge's pair did not
+        // contract using the kernel's read-only predicates. This walk
+        // must NOT commit a merge: a stray successful `contract` here
+        // would mutate the partition the post-seed realizability gate
+        // below reads, committing a merge that is never counted or
+        // looped — silently corrupting the partition. The fixed-point
+        // loop above already applied every legitimate contraction, so
+        // any pair reaching here is expected to be rejected.
+        //
+        // We reproduce `check_merge`'s own classification order
+        // (preconditions, then cycle gate) without committing:
+        //   - preconditions fail -> the non-cycle `Err(_)` arm
+        //     (ResidualSticky / ExceedsCap / SameClass),
+        //   - cycle evidence     -> the `WouldCreateCycle` arm,
+        //   - neither            -> the merge *would* have succeeded;
+        //     unreachable at fixed point. Do nothing (and, critically,
+        //     never commit it) — the old `Ok(_)` arm's stray mutation.
+        if q.check_merge_preconditions(cs, ct).is_err() {
+            rejected.push(SeedContractionRejected::AtomicReachability {
+                edge_id: edge.id.clone(),
+                source_unit_id: edge.source.clone(),
+                target_unit_id: edge.target.clone(),
+                rejected_pair: (
+                    q.owner_id(src_pivot).to_string(),
+                    q.owner_id(tgt_pivot).to_string(),
+                ),
+                cycle: CycleEvidence::default(),
+            });
+        } else if let Some(cycle) = q.would_be_cycles_after_contract(cs, ct) {
+            rejected.push(SeedContractionRejected::AtomicReachability {
+                edge_id: edge.id.clone(),
+                source_unit_id: edge.source.clone(),
+                target_unit_id: edge.target.clone(),
+                rejected_pair: (
+                    q.owner_id(src_pivot).to_string(),
+                    q.owner_id(tgt_pivot).to_string(),
+                ),
+                cycle,
+            });
         }
     }
 

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -1991,6 +1991,107 @@ fn unification_rejects_cyclic_atomic_reachability_with_diagnostic() {
     );
 }
 
+#[test]
+fn pass3_diagnostic_walk_never_commits_a_merge() {
+    // Invariant guard for the pass-3 diagnostic walk in
+    // `build_seed_quotient`. After the fixed-point contraction loop
+    // exits (zero successful contractions), the diagnostic walk
+    // re-classifies each still-unmerged atomic-DAG edge to record
+    // *why* it could not contract. That walk must be read-only: it
+    // must never commit a merge. A stray successful contraction there
+    // would join two classes the fixed-point loop deliberately left
+    // apart, silently corrupting the partition that the post-seed
+    // realizability gate (and the returned `q`) then reads — and that
+    // merge would be neither counted nor looped.
+    //
+    // We pin the externally-observable consequence: for every
+    // `AtomicReachability`-rejected pair, the two pivot owners remain
+    // in DISTINCT classes in the returned quotient. If the diagnostic
+    // walk had committed the rejected merge (the pre-fix `contract` in
+    // the diagnostics phase's stray `Ok(_)` arm), the pair's owners
+    // would share a class — exactly the corruption the read-only
+    // predicates (`check_merge_preconditions` /
+    // `would_be_cycles_after_contract`) prevent.
+    //
+    // Fixture mirrors the cycle in
+    // `unification_rejects_cyclic_atomic_reachability_with_diagnostic`:
+    // residual Bar / Helper and active Foo (in spec module mod_alpha)
+    // form a constraining 3-cycle; pass-3's atomic-DAG-reachability
+    // contraction rejects the cycle-closing edges, driving the
+    // diagnostic walk.
+    let foo = active_owner("owner:foo", 1, &["Foo"], 5, "mod_alpha");
+    let bar = residual_owner("owner:bar", 2, &["Bar"], 5);
+    let helper = residual_owner("owner:helper", 3, &["Helper"], 5);
+    let edges = vec![
+        owner_edge("edge:0", "owner:bar", "owner:foo", DepKind::EagerUse, true),
+        owner_edge(
+            "edge:1",
+            "owner:foo",
+            "owner:helper",
+            DepKind::EagerUse,
+            true,
+        ),
+        owner_edge(
+            "edge:2",
+            "owner:helper",
+            "owner:bar",
+            DepKind::EagerUse,
+            true,
+        ),
+    ];
+    let report = graph_of(
+        vec![foo.clone(), bar.clone(), helper.clone()],
+        edges,
+        vec![
+            atomic_unit_for("atomic:foo", &[&foo]),
+            atomic_unit_for("atomic:bar", &[&bar]),
+            atomic_unit_for("atomic:helper", &[&helper]),
+        ],
+        vec![
+            atomic_edge("atomic_edge:a", "atomic:bar", "atomic:foo"),
+            atomic_edge("atomic_edge:b", "atomic:foo", "atomic:helper"),
+            atomic_edge("atomic_edge:c", "atomic:helper", "atomic:bar"),
+        ],
+    );
+    let spec = vec![SpecModuleGroup {
+        module_id: "mod_alpha".to_string(),
+        owner_ids: vec!["owner:foo".to_string()],
+    }];
+    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000);
+
+    let reachability_rejections: Vec<&SeedContractionRejected> = rejected
+        .iter()
+        .filter(|r| matches!(r, SeedContractionRejected::AtomicReachability { .. }))
+        .collect();
+    assert!(
+        !reachability_rejections.is_empty(),
+        "fixture must drive the pass-3 diagnostic walk via at least one \
+         AtomicReachability rejection, got: {rejected:?}",
+    );
+
+    // The load-bearing assertion: no rejected pair was actually
+    // merged by the diagnostic walk. Each pivot pair stays in a
+    // distinct class.
+    for r in &reachability_rejections {
+        let SeedContractionRejected::AtomicReachability { rejected_pair, .. } = r else {
+            unreachable!("filtered to AtomicReachability above");
+        };
+        let (src_owner, tgt_owner) = rejected_pair;
+        let src_idx = q
+            .owner_idx_of(src_owner)
+            .unwrap_or_else(|| panic!("rejected source owner {src_owner} must be in graph"));
+        let tgt_idx = q
+            .owner_idx_of(tgt_owner)
+            .unwrap_or_else(|| panic!("rejected target owner {tgt_owner} must be in graph"));
+        assert_ne!(
+            q.class_of(src_idx),
+            q.class_of(tgt_idx),
+            "diagnostic walk must NOT have committed the rejected merge of \
+             {src_owner} and {tgt_owner}; they must remain in distinct classes",
+        );
+    }
+}
+
 // ---------- Track A unification: planner gate ≡ materializer gate. ----------
 //
 // The peel planner's seed-quotient cycle gate must produce the same


### PR DESCRIPTION
Last of the follow-up correctness fixes from the debundle review.

## Bug

`peel/quotient.rs::build_seed_quotient`'s post-fixed-point diagnostic walk (pass 3) called `q.contract(cs, ct)` and treated `Ok(_)` as "should be unreachable". Because `contract` mutates the quotient, a stray successful contract there would commit a merge that's never counted or looped — silently corrupting the partition the post-seed realizability gate then reads.

## Fix

Replace the `contract(...)` match with the kernel's read-only predicates, reproducing `check_merge`'s exact classification order without committing a merge:
- `check_merge_preconditions(cs, ct).is_err()` → non-cycle `Err` arm (`ResidualSticky`/`ExceedsCap`/`SameClass`), emitting `AtomicReachability` with `CycleEvidence::default()`.
- else `would_be_cycles_after_contract(cs, ct)` → `WouldCreateCycle` arm with the cycle evidence (this predicate uses scoped push/undo internally and restores state — it does not commit).
- neither → would have succeeded (unreachable at fixed point); now a no-op instead of a stray commit.

Since this mirrors `check_merge` (`check_merge_preconditions` then `would_be_cycles_after_contract`), diagnostic output is unchanged for all legitimate cases; only the stray-mutation path is removed.

## Test (red→green, invariant-pinning)

The literal `Ok(_)` arm can't fire given the deterministic fixed-point exit, so this is an invariant-pinning test: `pass3_diagnostic_walk_never_commits_a_merge` in `quotient_integration_test.rs` builds the cyclic fixture that drives the diagnostic walk and asserts every `AtomicReachability`-rejected pair's pivot owners remain in **distinct classes** in the returned quotient — exactly the corruption a stray merge would cause.

- RED (transiently injecting a forced `merge_classes_unchecked` into the diagnostic walk, simulating the bug): test fails.
- GREEN (real fix): passes.

## Verification

`//devinfra/js/debundle:peel_quotient_integration_test` and `:peel_test` pass; pre-commit (incl. rustfmt) clean. Rebased onto current `devel`.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_