### PR TITLE
debundle: classify Object.is calls as pure

### DIFF
--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -278,6 +278,9 @@ fn whitelist_static_calls_are_pure_regardless_of_arg() {
     assert!((classify("Number.isFinite(x)")).is_pure());
     assert!((classify("Number.isInteger(x)")).is_pure());
     assert!((classify("Number.isSafeInteger(x)")).is_pure());
+    // Object.is performs SameValue (ECMA-262 §20.1.2.13) with no
+    // coercion of either argument — fires no user code on any type.
+    assert!((classify("Object.is(a, b)")).is_pure());
 }
 
 #[test]

--- a/devinfra/js/debundle/purity/whitelists.rs
+++ b/devinfra/js/debundle/purity/whitelists.rs
@@ -77,6 +77,13 @@ pub(super) const PURE_STATIC_CALLS: &[(&str, &str)] = &[
     ("Number", "isInteger"),
     ("Number", "isNaN"),
     ("Number", "isSafeInteger"),
+    // `Object.is(value1, value2)` — ECMA-262 §20.1.2.13 returns
+    // `SameValue(value1, value2)`. SameValue (§7.2.11) dispatches on
+    // the argument Types and compares structurally; it performs no
+    // `ToNumber` / `ToString` / `ToPrimitive` coercion, fires no
+    // iterator/proxy/getter path, and mutates nothing. Pure on any
+    // argument values.
+    ("Object", "is"),
 ];
 
 /// Pure global callables (no receiver). Same admission contract as


### PR DESCRIPTION
Two purity-analysis items from the debundle review backlog.

## 1. `Object.is` → `PURE_STATIC_CALLS`

Added `("Object", "is")` to `PURE_STATIC_CALLS` in `purity/whitelists.rs` with an ECMA-262 §20.1.2.13 citation: `Object.is` returns `SameValue`, which dispatches on argument Types and compares structurally — no `ToNumber`/`ToString`/`ToPrimitive` coercion, no iterator/proxy/getter path, no mutation, so calls are unconditionally pure on any argument type. The existing read-pure function-ref entry stays intact (read pure + call now pure are consistent).

Positive test added to `whitelist_static_calls_are_pure_regardless_of_arg` in `purity/classifier_tests.rs`, alongside the `Array.isArray` / `Number.isNaN` cases.

- RED (test present, whitelist edit absent): `Object.is(a, b)` classified Unknown — `analysis_test` failed.
- GREEN (whitelist edit): passes; full suite 78/78.

## 2. `KnownEffect::TypescriptDecorateHelper` — verified live, kept

Audited per the backlog question. The variant is genuinely constructed **and** consumed:
- Constructed: `lowering/plans.rs::known_effect_from_member_effect` (maps the spec `MemberEffect`), inserted into `hints.known_effects`.
- Read: `facts/mod.rs::recognized_local_effect_target` matches it to recognize a TypeScript `__decorate` call as a local-effect target (drives `typescript_decorate_helper_target`); also exercised by `analysis_tests`.

No code change — reporting the finding (not dead).

## Verification

`analysis_test` pass; full `//devinfra/js/debundle/...` = 78/78; rustfmt clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_