### PR TITLE
debundle: remove speculative dead state from peel quotient

### DIFF
--- a/devinfra/js/debundle/peel/factorize.rs
+++ b/devinfra/js/debundle/peel/factorize.rs
@@ -301,7 +301,8 @@ fn factorize_with_context(
         &spec_modules,
         size_cap_lines,
     );
-    let _greedy_steps = greedy_merge_to_convergence(&mut quotient);
+    // Mutates the quotient in place; the returned merge-step list is unused here.
+    greedy_merge_to_convergence(&mut quotient);
 
     // Per-class edge accounting. Walk every constraining owner
     // edge and classify (source-class, target-class) into:

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -68,8 +68,8 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 
 use analysis::{
-    DepKind, ModuleId, OwnerGraph, OwnerGraphReport, OwnerId, OwnerReportIndex, Partition,
-    PartitionDelta, RealizabilityIndex, RealizabilityVerdict, record_gate_diagnostic_translation,
+    DepKind, ModuleId, OwnerGraph, OwnerGraphReport, OwnerId, Partition, PartitionDelta,
+    RealizabilityIndex, RealizabilityVerdict, record_gate_diagnostic_translation,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
@@ -249,12 +249,6 @@ pub struct QuotientGraph {
     /// (`analysis::check_realizability`). Stored once at
     /// construction; never mutated.
     owner_graph: OwnerGraph,
-    /// Owner-id string → `analysis::OwnerId` table. Parallels
-    /// `owner_ids`; carried for fast lookup when projecting
-    /// `Partition`s. Currently unused but kept for the next-commit
-    /// persistent-state incremental algorithm.
-    #[allow(dead_code)]
-    owner_index: OwnerReportIndex,
     /// Owners whose `OwnerGraphNodeReport.destination.residual` is
     /// `true`. Set by `from_report` from the JSON wire flag (the
     /// same residual identification `factorize.rs` uses). Used by
@@ -409,7 +403,7 @@ impl QuotientGraph {
     /// reconstructed graph) needs `declared`, switch this call to
     /// pass the chunk's `StatementFactsReport` slice.
     pub fn from_report(report: &OwnerGraphReport, cap_lines: usize) -> Self {
-        let (owner_graph, report_index) = OwnerGraph::from_report(report, &[]);
+        let (owner_graph, _) = OwnerGraph::from_report(report, &[]);
         let owner_ids: Vec<String> = report.nodes.iter().map(|n| n.id.clone()).collect();
         let owner_id_to_idx: FxHashMap<String, OwnerIdx> = owner_ids
             .iter()
@@ -513,7 +507,6 @@ impl QuotientGraph {
         let num_classes = classes.len();
         let mut q = QuotientGraph {
             owner_graph,
-            owner_index: report_index,
             gate_residual_owners,
             owner_ids,
             owner_id_to_idx,


### PR DESCRIPTION
From the debundle review backlog ("remove dead/speculative state").

`QuotientGraph` carried an `owner_index: OwnerReportIndex` field marked `#[allow(dead_code)]` with the comment "Currently unused but kept for the next-commit persistent-state incremental algorithm." It is never read anywhere (`grep '\.owner_index'` → no hits). Removed:
- the field + its doc comment + `#[allow(dead_code)]`,
- the now-orphaned `report_index` binding from the `OwnerGraph::from_report(report, &[])` tuple (now `let (owner_graph, _) = ...`),
- the now-unused `OwnerReportIndex` import.

Also tidied `factorize.rs`: `let _greedy_steps = greedy_merge_to_convergence(&mut quotient);` → a bare call (it mutates the quotient in place; the returned merge-step `Vec` is unused there, and the fn isn't `#[must_use]`).

Pure dead-code removal — no behavior change, so no new test.

## Verification

`bbr test //devinfra/js/debundle:peel_test //devinfra/js/debundle:peel_quotient_integration_test` — 2/2 pass; rustfmt clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_