### PR TITLE
debundle/live_proxy: typed config + single casing, drop dead fields/hasattr, migrate tests to pytest_bazel macro

### DIFF
--- a/devinfra/js/debundle/live_proxy/BUILD.bazel
+++ b/devinfra/js/debundle/live_proxy/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/python:defs.bzl", "py_test")
 
 exports_files(["harness_monitor.html"])
 
@@ -48,6 +49,7 @@ py_test(
     deps = [
         ":proxy_lib",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 
@@ -57,6 +59,7 @@ py_test(
     deps = [
         ":proxy_lib",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 
@@ -66,5 +69,6 @@ py_test(
     deps = [
         ":proxy_lib",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )

--- a/devinfra/js/debundle/live_proxy/addon.py
+++ b/devinfra/js/debundle/live_proxy/addon.py
@@ -39,13 +39,13 @@ class DebundleLiveProxyAddon:
 
         request_path = urlsplit(flow.request.path or "/").path
         if request_path == "/sw.js":
-            self._serve_local_mapping(flow, self.config.control_paths["service_worker"])
+            self._serve_local_mapping(flow, self.config.control_paths.service_worker)
             return
         if request_path.startswith(f"{self.config.internal_prefix}/"):
             self._serve_local_mapping(flow, flow.request.path)
             return
         if is_target_document_request(flow.request.method, headers, self.config):
-            self._serve_local_mapping(flow, self.config.control_paths["live_index"])
+            self._serve_local_mapping(flow, self.config.control_paths.live_index)
             return
 
     def _serve_local_mapping(self, flow: http.HTTPFlow, path: str) -> None:

--- a/devinfra/js/debundle/live_proxy/browser_runner.py
+++ b/devinfra/js/debundle/live_proxy/browser_runner.py
@@ -161,7 +161,7 @@ def collect_ignored_console_errors(signals: BrowserSignals, ignored_patterns=())
 
 
 def compile_patterns(patterns):
-    return [pattern if hasattr(pattern, "search") else re.compile(pattern) for pattern in patterns]
+    return [pattern if isinstance(pattern, re.Pattern) else re.compile(pattern) for pattern in patterns]
 
 
 def assert_no_console_errors(signals: BrowserSignals, detail: str, ignored_patterns=()) -> None:

--- a/devinfra/js/debundle/live_proxy/core.py
+++ b/devinfra/js/debundle/live_proxy/core.py
@@ -7,12 +7,15 @@ import posixpath
 import re
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
+from enum import StrEnum
 from html import escape as html_escape
 from pathlib import Path
 from typing import Any, NoReturn, cast
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from devinfra.js.debundle.live_proxy.vendor_runtime import (
+    PartialSwapEntry,
+    VendorRuntimeEntry,
     build_partial_swap_import_map,
     load_partial_swap_runtime_index,
     load_vendor_runtime_index,
@@ -77,20 +80,25 @@ class LiveProxyOptions:
 
 
 @dataclass(frozen=True)
+class ControlPaths:
+    """Same-origin internal URLs the proxy serves directly."""
+
+    live_index: str
+    service_worker: str
+
+
+@dataclass(frozen=True)
 class LiveProxyConfig:
     app_asset_prefix: str
-    app_manifest: dict
     app_manifest_path: Path
     app_root: Path
-    asset_summary: dict
     asset_summary_path: Path | None
     bootstrap_url: str
     ca_dir: Path
-    control_paths: dict[str, str]
+    control_paths: ControlPaths
     injected_html: str
     internal_prefix: str
     out_root: Path
-    output_report: dict
     profile_dir: Path
     proxy_host: str
     proxy_port: int
@@ -101,14 +109,23 @@ class LiveProxyConfig:
     target_url: str
     ui_version: str
     vendor_manifest_path: Path
-    vendor_runtime_index: dict
+    vendor_runtime_index: dict[str, VendorRuntimeEntry]
     partial_swap_manifest_path: Path
-    partial_swap_runtime_index: dict
+    partial_swap_runtime_index: dict[str, PartialSwapEntry]
+
+
+class LocalAssetKind(StrEnum):
+    LIVE_INDEX = "live-index"
+    SERVICE_WORKER = "service-worker"
+    VENDOR_FILE = "vendor-file"
+    PARTIAL_SWAP_REDIRECT = "partial-swap-redirect"
+    PARTIAL_SWAP_FILE = "partial-swap-file"
+    FILE = "file"
 
 
 @dataclass(frozen=True)
 class LocalAssetMapping:
-    kind: str
+    kind: LocalAssetKind
     content_type: str | None = None
     file_path: Path | None = None
     body: bytes | None = None
@@ -189,7 +206,6 @@ def load_live_proxy_configuration(raw_options: LiveProxyOptions | dict) -> LiveP
 
     runtime_report = read_json(app_manifest_path)
     reports_root = app_manifest_path.parent
-    output_report = read_optional_json(reports_root / "output.json", {})
     source_assets_report = read_optional_json(reports_root / "source_assets.json", {})
     provenance_report = read_optional_json(reports_root / "provenance.json", {})
     asset_summary = source_assets_report.get("asset_summary") or {}
@@ -235,19 +251,17 @@ def load_live_proxy_configuration(raw_options: LiveProxyOptions | dict) -> LiveP
     target_origin = f"{target_parts.scheme}://{target_parts.netloc}"
     return LiveProxyConfig(
         app_asset_prefix=app_asset_prefix,
-        app_manifest=runtime_report,
         app_manifest_path=app_manifest_path,
         app_root=app_root,
-        asset_summary=asset_summary,
         asset_summary_path=resolve_relative(reports_root, source_assets_report["source_path"])
         if source_assets_report.get("source_path")
         else None,
         bootstrap_url=f"{app_asset_prefix}/bootstrap.js",
         ca_dir=state_dir / "mitm-ca",
-        control_paths={
-            "live_index": f"{internal_prefix}/live-index.html",
-            "service_worker": f"{internal_prefix}/sw.js",
-        },
+        control_paths=ControlPaths(
+            live_index=f"{internal_prefix}/live-index.html",
+            service_worker=f"{internal_prefix}/sw.js",
+        ),
         injected_html=rewrite_html_for_live_proxy(
             source_html,
             app_asset_prefix=app_asset_prefix,
@@ -257,7 +271,6 @@ def load_live_proxy_configuration(raw_options: LiveProxyOptions | dict) -> LiveP
         ),
         internal_prefix=internal_prefix,
         out_root=app_root,
-        output_report=output_report,
         profile_dir=state_dir / "browser-profile",
         proxy_host=options.proxy_host or DEFAULT_PROXY_HOST,
         proxy_port=options.proxy_port or DEFAULT_PROXY_PORT,
@@ -341,16 +354,9 @@ def rewrite_snapshot_asset_urls(html: str, app_asset_prefix: str) -> str:
     )
 
 
-def is_target_document_request(method: str, headers: dict, config: LiveProxyConfig | dict) -> bool:
-    target_host = (
-        config.target_host
-        if isinstance(config, LiveProxyConfig)
-        else config["targetHost"]
-        if "targetHost" in config
-        else config["target_host"]
-    )
+def is_target_document_request(method: str, headers: dict, config: LiveProxyConfig) -> bool:
     host = normalize_host(header_get(headers, "host") or "")
-    if host != normalize_host(target_host):
+    if host != normalize_host(config.target_host):
         return False
     destination = (header_get(headers, "sec-fetch-dest") or "").lower()
     if destination in {"document", "iframe"}:
@@ -363,13 +369,15 @@ def map_local_asset_path(pathname: str, config: LiveProxyConfig) -> LocalAssetMa
     normalized_path = pathname.split("?", 1)[0]
     if not normalized_path.startswith(f"{config.internal_prefix}/"):
         return None
-    if normalized_path == config.control_paths["live_index"]:
+    if normalized_path == config.control_paths.live_index:
         return LocalAssetMapping(
-            kind="live-index", body=config.injected_html.encode("utf-8"), content_type="text/html; charset=utf-8"
+            kind=LocalAssetKind.LIVE_INDEX,
+            body=config.injected_html.encode("utf-8"),
+            content_type="text/html; charset=utf-8",
         )
-    if normalized_path == config.control_paths["service_worker"]:
+    if normalized_path == config.control_paths.service_worker:
         return LocalAssetMapping(
-            kind="service-worker",
+            kind=LocalAssetKind.SERVICE_WORKER,
             body=noop_service_worker_source().encode("utf-8"),
             content_type="text/javascript; charset=utf-8",
         )
@@ -378,7 +386,7 @@ def map_local_asset_path(pathname: str, config: LiveProxyConfig) -> LocalAssetMa
     vendor_runtime = resolve_vendor_runtime_request(suffix, config.vendor_runtime_index)
     if vendor_runtime:
         return LocalAssetMapping(
-            kind="vendor-file",
+            kind=LocalAssetKind.VENDOR_FILE,
             chunk_id=vendor_runtime.entry.chunk_id,
             content_type=content_type_for_path(vendor_runtime.file_path),
             file_path=vendor_runtime.file_path,
@@ -387,11 +395,11 @@ def map_local_asset_path(pathname: str, config: LiveProxyConfig) -> LocalAssetMa
     if partial_swap:
         if partial_swap.resolved_suffix and partial_swap.resolved_suffix != partial_swap.request_suffix:
             return LocalAssetMapping(
-                kind="partial-swap-redirect",
+                kind=LocalAssetKind.PARTIAL_SWAP_REDIRECT,
                 redirect_to=f"{config.internal_prefix}/app/_partial_swap/{partial_swap.entry.package}/{partial_swap.resolved_suffix}",
             )
         return LocalAssetMapping(
-            kind="partial-swap-file",
+            kind=LocalAssetKind.PARTIAL_SWAP_FILE,
             content_type=content_type_for_path(partial_swap.file_path),
             file_path=partial_swap.file_path,
             package=partial_swap.entry.package,
@@ -401,7 +409,7 @@ def map_local_asset_path(pathname: str, config: LiveProxyConfig) -> LocalAssetMa
     if app_relative_path is None:
         return None
     return LocalAssetMapping(
-        kind="file",
+        kind=LocalAssetKind.FILE,
         content_type=content_type_for_path(Path(app_relative_path)),
         file_path=safe_join(config.app_root or config.out_root, app_relative_path),
     )

--- a/devinfra/js/debundle/live_proxy/core_test.py
+++ b/devinfra/js/debundle/live_proxy/core_test.py
@@ -6,9 +6,11 @@ import unittest
 from pathlib import Path
 
 import pytest
+import pytest_bazel
 
 from devinfra.js.debundle.live_proxy.addon import DebundleLiveProxyAddon
 from devinfra.js.debundle.live_proxy.core import (
+    LocalAssetKind,
     LocalAssetMapping,
     is_target_document_request,
     load_live_proxy_configuration,
@@ -49,7 +51,7 @@ class LiveProxyCoreTest(unittest.TestCase):
 
         assert config.target_origin == "https://example.test"
         assert config.bootstrap_url == "/_debundle/live/example/app/bootstrap.js"
-        assert config.control_paths["live_index"] == "/_debundle/live/example/live-index.html"
+        assert config.control_paths.live_index == "/_debundle/live/example/live-index.html"
         assert 'src="/_debundle/live/example/app/bootstrap.js"' in config.injected_html
         assert "js-debundle-live-proxy" in config.injected_html
 
@@ -148,7 +150,16 @@ class LiveProxyCoreTest(unittest.TestCase):
         assert 'href="/favicon.ico"' in rewritten
 
     def test_is_target_document_request(self) -> None:
-        config = {"target_host": "example.test"}
+        fixture = write_base_fixture()
+        config = load_live_proxy_configuration(
+            {
+                "app_manifest_path": str(fixture.app_manifest_path),
+                "proxy_host": "127.0.0.1",
+                "proxy_port": 9807,
+                "state_dir": str(fixture.root / "state"),
+            }
+        )
+        assert config.target_host == "example.test"
 
         assert is_target_document_request(
             "GET",
@@ -193,15 +204,15 @@ class LiveProxyCoreTest(unittest.TestCase):
         )
 
         file_mapping = require_mapping(map_local_asset_path("/_debundle/live/example/app/bootstrap.js", config))
-        assert file_mapping.kind == "file"
+        assert file_mapping.kind == LocalAssetKind.FILE
         assert file_mapping.file_path == fixture.app_root / "bootstrap.js"
 
         html_mapping = require_mapping(map_local_asset_path("/_debundle/live/example/live-index.html", config))
-        assert html_mapping.kind == "live-index"
+        assert html_mapping.kind == LocalAssetKind.LIVE_INDEX
         assert b"js-debundle-live-proxy" in (html_mapping.body or b"")
 
         sw_mapping = require_mapping(map_local_asset_path("/_debundle/live/example/sw.js", config))
-        assert sw_mapping.kind == "service-worker"
+        assert sw_mapping.kind == LocalAssetKind.SERVICE_WORKER
         assert b"skipWaiting" in (sw_mapping.body or b"")
 
     def test_vendor_and_partial_swap_resolution(self) -> None:
@@ -264,7 +275,7 @@ class LiveProxyCoreTest(unittest.TestCase):
         runtime_hit = require_mapping(
             map_local_asset_path("/_debundle/live/vendor/app/static/katex-BZy9Y_85/runtime.js", config)
         )
-        assert runtime_hit.kind == "vendor-file"
+        assert runtime_hit.kind == LocalAssetKind.VENDOR_FILE
         assert runtime_hit.file_path == fixture.packages_root / "katex" / "dist" / "katex.mjs"
 
         sibling_hit = require_mapping(
@@ -280,7 +291,7 @@ class LiveProxyCoreTest(unittest.TestCase):
         partial_redirect = require_mapping(
             map_local_asset_path("/_debundle/live/vendor/app/_partial_swap/mobx-react-lite/dist/platform", config)
         )
-        assert partial_redirect.kind == "partial-swap-redirect"
+        assert partial_redirect.kind == LocalAssetKind.PARTIAL_SWAP_REDIRECT
         assert (
             partial_redirect.redirect_to
             == "/_debundle/live/vendor/app/_partial_swap/mobx-react-lite/dist/platform/index.js"
@@ -431,4 +442,4 @@ def require_mapping(mapping: LocalAssetMapping | None) -> LocalAssetMapping:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest_bazel.main()

--- a/devinfra/js/debundle/live_proxy/package_tree_test.py
+++ b/devinfra/js/debundle/live_proxy/package_tree_test.py
@@ -18,6 +18,7 @@ import unittest
 from pathlib import Path
 
 import pytest
+import pytest_bazel
 
 from devinfra.js.debundle.live_proxy.package_tree import resolve_package_subpath
 
@@ -106,4 +107,4 @@ class SubpathEscapeTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest_bazel.main()

--- a/devinfra/js/debundle/live_proxy/responses.py
+++ b/devinfra/js/debundle/live_proxy/responses.py
@@ -4,14 +4,14 @@ from pathlib import Path
 
 from mitmproxy import http
 
-from devinfra.js.debundle.live_proxy.core import LocalAssetMapping
+from devinfra.js.debundle.live_proxy.core import LocalAssetKind, LocalAssetMapping
 
 NO_STORE = "no-store"
 TEXT_PLAIN = "text/plain; charset=utf-8"
 
 
 def response_for_mapping(mapping: LocalAssetMapping) -> http.Response:
-    if mapping.kind == "partial-swap-redirect":
+    if mapping.kind == LocalAssetKind.PARTIAL_SWAP_REDIRECT:
         return http.Response.make(301, b"", {"location": mapping.redirect_to or "/"})
     if mapping.body is not None:
         return ok_response(mapping.body, mapping.content_type)

--- a/devinfra/js/debundle/live_proxy/server_test.py
+++ b/devinfra/js/debundle/live_proxy/server_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import pytest_bazel
 
 from devinfra.js.debundle.live_proxy import server
 from devinfra.js.debundle.live_proxy.core import LiveProxyOptions
@@ -62,4 +63,4 @@ class StartProxyInProcessTest(unittest.IsolatedAsyncioTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest_bazel.main()

--- a/devinfra/js/debundle/live_proxy/vendor_runtime.py
+++ b/devinfra/js/debundle/live_proxy/vendor_runtime.py
@@ -20,7 +20,6 @@ class VendorRuntimeEntry:
     subpath: str
     version: str
     generated_wrapper_path: Path | None = None
-    wrapper_shape: str | None = None
 
 
 @dataclass(frozen=True)
@@ -55,6 +54,8 @@ PARTIAL_SWAP_URL_PREFIX = "_partial_swap"
 
 
 def load_vendor_resolution_manifest(manifest_path: Path) -> dict:
+    # Opaque external JSON produced by the Rust vendor-swap pipeline; entries are
+    # parsed into typed VendorRuntimeEntry objects in load_vendor_runtime_index.
     if not manifest_path or not manifest_path.exists():
         return {}
     raw = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -100,7 +101,6 @@ def load_vendor_runtime_index(
             subpath=entry["subpath"],
             version=entry["version"],
             generated_wrapper_path=wrapper_abs_path,
-            wrapper_shape=entry.get("wrapper_shape") if wrapper_abs_path else None,
         )
     return by_chunk_id
 


### PR DESCRIPTION
Three `live_proxy` cleanups from the debundle review backlog.

## 1. Typed config, single casing

- `is_target_document_request` takes `LiveProxyConfig` only and reads `config.target_host` — removed the `dict` branch and the `targetHost`/`target_host` dual-casing probe.
- Added a `ControlPaths` frozen dataclass; `config.control_paths` is accessed via `.live_index` / `.service_worker` (in `core.py`, `addon.py`) instead of `dict["..."]` keys.
- Added `LocalAssetKind(StrEnum)`; `LocalAssetMapping.kind` is now the enum and `responses.py` dispatches on `LocalAssetKind.PARTIAL_SWAP_REDIRECT` (no more string compares).
- Tightened `vendor_runtime_index` / `partial_swap_runtime_index` from bare `dict` to `dict[str, VendorRuntimeEntry]` / `dict[str, PartialSwapEntry]`.
- Removed dead config fields `app_manifest`, `asset_summary`, `output_report` (stored but never read, verified repo-wide; dropped the unused `output.json` load) and `VendorRuntimeEntry.wrapper_shape` (Python never read it — only the Rust side consumes it).
- The genuinely-opaque vendor manifest JSON stays a bare `dict` with a documenting comment; entries are parsed into typed `VendorRuntimeEntry` at the boundary.

## 2. No `hasattr`

`browser_runner.py::compile_patterns` uses `isinstance(pattern, re.Pattern)` instead of `hasattr(pattern, "search")`.

## 3. Repo `pytest_bazel` test macro

`core_test`, `package_tree_test`, `server_test` now use the `py_test` macro from `//devinfra/python:defs.bzl`, with `@pypi//pytest_bazel` deps and `pytest_bazel.main()` entry points (replacing `unittest.main()`) — so they actually execute under Bazel (the reviewer flagged they previously may have run as no-op scripts). **Confirmed non-zero test counts: core_test 11, package_tree_test 5, server_test 1.** Migration surfaced no latent test-logic failures (one mypy fix: `core_test` indexed `control_paths["live_index"]` → attribute access).

## Verification

`bbr test //devinfra/js/debundle/live_proxy/...` — 3/3 pass (mypy + ruff aspects on); `bbr build //devinfra/js/debundle/...` green (no rdep breakage); ruff clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_