### PR TITLE
debundle: dedupe import-specifier grouping; reject reserved JS words at mint time

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -79,6 +79,7 @@ _STANDARD_E2E_DEPS = [
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
         "auto_grown_export_alias_collision_test",
+        "reserved_word_mint_test",
         "runtime_tdz_on_imported_class_test",
         "accepted_spec_runs_under_node_test",
         "lemma_two_rescued_asymmetric_cycle_test",

--- a/devinfra/js/debundle/e2e/reserved_word_mint_test.rs
+++ b/devinfra/js/debundle/e2e/reserved_word_mint_test.rs
@@ -1,0 +1,93 @@
+//! RED→GREEN test: a mint base / disambiguation target that is a
+//! reserved JS word must not surface verbatim into an emitted import
+//! clause.
+//!
+//! Background. `lowering/import_emit.rs::mint_unique_name` is the single
+//! name minter behind `disambiguate_import_locals`,
+//! `disambiguate_residual_entry_import_locals`, and
+//! `auto_grown_residual_exports`. It used to return its `base` verbatim
+//! whenever the claim closure accepted it, never consulting
+//! `is_valid_js_identifier`. `disambiguate_import_locals` prefers a
+//! binding's PUBLIC export name as the consumer-side local. So when a
+//! logical module exports a binding under a reserved public name
+//! (`export { impl as default }` — valid JS, `default` is a legal export
+//! alias), the entry that still references the binding mints `default` as
+//! the import local and emits `import { default } from "./mod"` — i.e.
+//! `default as default`, which is NOT valid JS (a reserved word cannot be
+//! an import local). Emitted modules are ESM (always strict mode), so the
+//! reserved word is a hard parse error with no debundler-side diagnostic.
+//!
+//! ## Fixture
+//!
+//! - `impl` is a top-level binding the entry references via `show()`.
+//! - The spec moves `impl` to `mod_x`, re-exporting it under the public
+//!   name `default`.
+//! - The entry keeps calling `show()`, which reads `impl`, so the entry
+//!   must re-import the binding from `mod_x`. The disambiguator mints the
+//!   import local from the preferred (public) name `default`.
+//!
+//! ## Expected outcomes
+//!
+//! - **Today (RED)**: the debundler succeeds but emits `import { default }
+//!   from "./modules/mod_x.js"` into `entry.js`. Node rejects the entry
+//!   with a SyntaxError ("Unexpected reserved word"), so
+//!   `assert_entry_output` fails at the node step.
+//! - **After the fix**: `mint_unique_name` rejects the reserved base via
+//!   `is_valid_js_identifier` and suffixes it to `default$1`, emitting
+//!   `import { default$1 as default } from "..."` — a valid identifier
+//!   that parses and runs.
+
+use debundle_e2e_support::*;
+use std::fs;
+use swc_ecma_ast::{ImportSpecifier, ModuleDecl, ModuleItem};
+
+/// Every import local in `source` (across all `import` statements) must
+/// be a parseable, non-reserved identifier. `parse_module` already
+/// rejects un-parseable input; this additionally asserts no import local
+/// is a bare reserved word that slipped through.
+fn assert_import_locals_are_valid(source: &str) {
+    let module = parse_module(source);
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+            continue;
+        };
+        for specifier in &import.specifiers {
+            let local = match specifier {
+                ImportSpecifier::Named(named) => named.local.sym.to_string(),
+                ImportSpecifier::Default(default) => default.local.sym.to_string(),
+                ImportSpecifier::Namespace(ns) => ns.local.sym.to_string(),
+            };
+            assert!(
+                local != "default" && local != "class" && local != "await",
+                "import local `{local}` is a reserved word; emitted import is un-parseable:\n{source}",
+            );
+        }
+    }
+}
+
+#[test]
+fn reserved_public_name_does_not_mint_reserved_import_local() {
+    let mut opts = FixtureOpts::new(
+        r#"const impl = "impl-value";
+function show() { return impl; }
+console.log(show());
+export { show };
+"#,
+        vec![logical_module(
+            "mod_x",
+            &[Member::renamed("default", "impl")],
+        )],
+    );
+    opts.unassigned_mode = unassigned_mode_inline();
+    let fixture = run_fixture(opts);
+
+    let entry = fs::read_to_string(&fixture.entry_path).expect("read entry.js");
+    // `parse_module` inside this helper fails loudly if the emitted
+    // import is un-parseable (the RED signal at the AST level); the
+    // explicit assert pins the reserved-local case specifically.
+    assert_import_locals_are_valid(&entry);
+
+    // Behaviour preservation: the entry still resolves `impl` through
+    // mod_x and prints its value.
+    assert_entry_output(&fixture, "impl-value\n");
+}

--- a/devinfra/js/debundle/lowering/import_emit.rs
+++ b/devinfra/js/debundle/lowering/import_emit.rs
@@ -1,7 +1,15 @@
+use super::util::is_valid_js_identifier;
 use super::*;
 
 pub(super) fn mint_unique_name(base: &str, mut try_claim: impl FnMut(&str) -> bool) -> String {
-    if try_claim(base) {
+    // A reserved word (`default`, `class`, `await`, …) used verbatim as a
+    // local would surface straight into an emitted `import {...}` /
+    // `export {...}` clause and produce un-parseable JS. Suffixing turns
+    // it into a valid identifier (`default$1`), so only offer `base`
+    // directly when it is a usable identifier. `$`-suffixed candidates are
+    // always valid, so the loop below always terminates with a parseable
+    // name.
+    if is_valid_js_identifier(base) && try_claim(base) {
         return base.to_string();
     }
     let mut suffix = 1usize;

--- a/devinfra/js/debundle/lowering/imports_runtime.rs
+++ b/devinfra/js/debundle/lowering/imports_runtime.rs
@@ -56,12 +56,8 @@ pub(super) fn resolve_imported_binding(
 /// Bindings sharing the same rewritten source are consolidated into a
 /// single `ImportDecl` (one statement with all specifiers) so the
 /// emitter matches what an author would write — not one statement per
-/// binding. Namespace specifiers (`import * as ns from "src"`) are
-/// emitted as their own `ImportDecl` even when a same-source group
-/// also has named/default specifiers, because ESM grammar forbids
-/// mixing `NameSpaceImport` with `NamedImports` in a single
-/// `ImportClause`. First-occurrence order is preserved both for the
-/// source groups and for specifiers within each group.
+/// binding. See [`group_specifiers_into_import_decls`] for the grouping
+/// and namespace-split rules.
 pub(super) fn source_chunk_imports_for_moved_body(
     source_import_cache: &mut ArtifactSourceImportResolutionCache<'_>,
     source_chunk_id: &str,
@@ -70,8 +66,7 @@ pub(super) fn source_chunk_imports_for_moved_body(
     needed: BTreeMap<String, &RuntimeImportInfo>,
 ) -> Result<Vec<ModuleItem>> {
     let dest_dir = join_module_path(&[source_chunk_id, &module_path_dirname(dest_target_file)]);
-    let mut groups: Vec<(String, Vec<ImportSpecifier>, Vec<ImportSpecifier>)> = Vec::new();
-    let mut index_by_source: BTreeMap<String, usize> = BTreeMap::new();
+    let mut pairs: Vec<(String, ImportSpecifier)> = Vec::with_capacity(needed.len());
     for (local, info) in needed {
         let rewritten_source = if let Some((target_chunk_id, target_entry_file, _path)) =
             source_import_cache.resolve(&info.src, source_chunk_id, source_runtime_file)?
@@ -103,13 +98,33 @@ pub(super) fn source_chunk_imports_for_moved_body(
             // Bare specifier (npm package etc.) — pass through unchanged.
             info.src.clone()
         };
-        let specifier = runtime_reimport_specifier(&local, info);
-        let group_index = *index_by_source
-            .entry(rewritten_source.clone())
-            .or_insert_with(|| {
-                groups.push((rewritten_source.clone(), Vec::new(), Vec::new()));
-                groups.len() - 1
-            });
+        pairs.push((rewritten_source, runtime_reimport_specifier(&local, info)));
+    }
+    Ok(group_specifiers_into_import_decls(pairs))
+}
+
+/// Consolidate `(rewritten_source, specifier)` pairs into `ImportDecl`
+/// `ModuleItem`s, one statement per source group. First-occurrence order
+/// is preserved both for the source groups and for specifiers within each
+/// group.
+///
+/// Namespace specifiers (`import * as ns from "src"`) are always emitted
+/// as their own `ImportDecl`, even when a same-source group also has
+/// named/default specifiers: ESM grammar forbids mixing a `NameSpaceImport`
+/// with `NamedImports` in one `ImportClause`, and one `ImportClause` holds
+/// at most one `NameSpaceImport`. Within a same-source named/default group,
+/// default specifiers are sorted before named to satisfy ESM grammar
+/// (`import D, { x } from "src"`, not the reverse).
+pub(super) fn group_specifiers_into_import_decls(
+    pairs: Vec<(String, ImportSpecifier)>,
+) -> Vec<ModuleItem> {
+    let mut groups: Vec<(String, Vec<ImportSpecifier>, Vec<ImportSpecifier>)> = Vec::new();
+    let mut index_by_source: BTreeMap<String, usize> = BTreeMap::new();
+    for (src, specifier) in pairs {
+        let group_index = *index_by_source.entry(src.clone()).or_insert_with(|| {
+            groups.push((src.clone(), Vec::new(), Vec::new()));
+            groups.len() - 1
+        });
         let (_, named_or_default, namespace) = &mut groups[group_index];
         match specifier {
             ImportSpecifier::Namespace(_) => namespace.push(specifier),
@@ -118,17 +133,10 @@ pub(super) fn source_chunk_imports_for_moved_body(
     }
     let mut result = Vec::with_capacity(groups.len());
     for (src, mut named_or_default, mut namespace) in groups {
-        // Emit namespace specifiers as their own ImportDecl each: ESM
-        // forbids mixing them with NamedImports in one ImportClause,
-        // and even multiple `import * as ns from "src"` for the same
-        // source cannot share a statement (one ImportClause has at
-        // most one NameSpaceImport).
         for ns_specifier in namespace.drain(..) {
             result.push(import_decl_module_item(vec![ns_specifier], &src));
         }
         if !named_or_default.is_empty() {
-            // Sort default specifiers before named to satisfy ESM
-            // grammar (`import D, { x } from "src"`, not the reverse).
             named_or_default.sort_by_key(|specifier| match specifier {
                 ImportSpecifier::Default(_) => 0,
                 _ => 1,
@@ -136,7 +144,7 @@ pub(super) fn source_chunk_imports_for_moved_body(
             result.push(import_decl_module_item(named_or_default, &src));
         }
     }
-    Ok(result)
+    result
 }
 
 pub(super) fn import_decl_module_item(specifiers: Vec<ImportSpecifier>, src: &str) -> ModuleItem {

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -788,30 +788,20 @@ fn lower_single_plan(
             let dest_abs = join_module_path(&[chunk_id, &plan.target_file]);
             // Group reexports by rewritten source so multiple bindings
             // re-exported from the same import-from end up in a single
-            // `import { ... } from "<src>"` statement, not one
-            // statement per binding. First-occurrence order is
-            // preserved for both source groups and bindings within
-            // each group. All specifiers emitted here are Named, so
-            // ESM's Namespace/Named mutual-exclusion rule doesn't
-            // apply.
-            let mut groups: Vec<(String, Vec<ImportSpecifier>)> =
-                Vec::with_capacity(reexports.len());
-            let mut index_by_source: BTreeMap<String, usize> = BTreeMap::new();
+            // `import { ... } from "<src>"` statement, not one statement
+            // per binding. All specifiers emitted here are Named, so the
+            // namespace-split rule in the shared grouper is a no-op for
+            // this path, but routing through it keeps the grouping logic
+            // single-sourced with `source_chunk_imports_for_moved_body`.
+            let mut pairs: Vec<(String, ImportSpecifier)> = Vec::with_capacity(reexports.len());
             for reexport in reexports {
                 let src = relative_source(&dest_abs, &reexport.imported_from);
                 let specifier =
                     imported_binding_named_specifier(&reexport.local, &reexport.imported_name);
-                let group_index = *index_by_source.entry(src.clone()).or_insert_with(|| {
-                    groups.push((src.clone(), Vec::new()));
-                    groups.len() - 1
-                });
-                groups[group_index].1.push(specifier);
+                pairs.push((src, specifier));
                 import_member_exports.insert(reexport.local.clone(), reexport.public_name.clone());
             }
-            let mut reexport_imports = Vec::with_capacity(groups.len());
-            for (src, specifiers) in groups {
-                reexport_imports.push(import_decl_module_item(specifiers, &src));
-            }
+            let reexport_imports = group_specifiers_into_import_decls(pairs);
             let tail = body.split_off(import_count);
             body.extend(reexport_imports);
             body.extend(tail);

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -67,7 +67,8 @@ use imports_cross::{
     phantom_side_effect_imports, residual_entry_imports_for_moved_body,
 };
 use imports_runtime::{
-    import_decl_module_item, resolve_imported_binding, source_chunk_imports_for_moved_body,
+    group_specifiers_into_import_decls, import_decl_module_item, resolve_imported_binding,
+    source_chunk_imports_for_moved_body,
 };
 use io::{prepare_output_dir, prune_artifact_to_chunk_ids, write_chunk_report_json};
 use lower::{

--- a/devinfra/js/debundle/lowering/util.rs
+++ b/devinfra/js/debundle/lowering/util.rs
@@ -1,11 +1,16 @@
 use super::*;
 
-/// True iff `s` is a valid JavaScript identifier — start char is
-/// `[A-Za-z_$]` and rest is `[A-Za-z0-9_$]`. Reserved words are not
-/// rejected (a target named e.g. `class` or `let` would still trip
-/// at parse time downstream, but that's a louder failure than this
-/// shallow check would catch). The intent is to filter typos
-/// (`with-dash`, `0digit`, empty string) from spec authors.
+/// True iff `s` is a usable JavaScript identifier for the emitted ESM:
+/// the start char is `[A-Za-z_$]`, the rest is `[A-Za-z0-9_$]`, and `s`
+/// is not a reserved word in any ECMAScript context. Reserved words are
+/// rejected because emitted modules are ESM (always strict mode) and a
+/// base like `default` / `class` / `await` used directly in an
+/// `import {...}` / `export {...}` clause would produce un-parseable JS
+/// with no diagnostic. Reserved-word detection uses SWC's
+/// `EsReserved::is_reserved_in_any` (from `swc_ecma_ast`), which covers
+/// the union of sloppy-mode, strict-mode, and ES3 reserved sets. The
+/// intent is also to filter typos (`with-dash`, `0digit`, empty string)
+/// from spec authors.
 pub(super) fn is_valid_js_identifier(s: &str) -> bool {
     let mut chars = s.chars();
     let first = match chars.next() {
@@ -15,7 +20,10 @@ pub(super) fn is_valid_js_identifier(s: &str) -> bool {
     if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
         return false;
     }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$') {
+        return false;
+    }
+    !s.is_reserved_in_any()
 }
 
 pub(super) fn target_file_for_request(target_dir: &str, target_path: &str) -> Result<String> {


### PR DESCRIPTION
Two lowering/emit cleanups from the debundle review backlog.

## 1. Dedupe "group import specifiers by source"

Extracted a shared `group_specifiers_into_import_decls(pairs) -> Vec<ModuleItem>` helper in `lowering/imports_runtime.rs` that always applies the namespace-split rule (own `ImportDecl` per `* as ns` — ESM forbids mixing with named) and the default-before-named sort. Both previously-duplicated sites now route through it:
- `source_chunk_imports_for_moved_body` (same file),
- the imported-reexport loop in `lowering/lower.rs` (~line 797),
- re-exported from `mod.rs`.

The `lower.rs` path provably only carries Named specifiers (its reexports come from `ImportedReexport` via `imported_binding_named_specifier`, always `ImportSpecifier::Named`), so this is a defensive consolidation that removes the divergence risk; relied on the existing import-emit e2e tests staying green rather than a contrived unreachable-case test.

## 2. Reject reserved JS words at mint time

- `lowering/util.rs::is_valid_js_identifier` now also rejects reserved words, using **SWC's own** `EsReserved::is_reserved_in_any` from `swc_ecma_ast` (union of sloppy/strict/ES3 reserved sets) — no hand-rolled keyword list.
- `lowering/import_emit.rs::mint_unique_name` returns `base` verbatim only when `is_valid_js_identifier(base)` holds, so a reserved base (`default`/`class`/`await`) is suffixed to `default$1`; `$`-suffixed candidates are always valid, so the loop still terminates. The existing `naturalize.rs` / `lower.rs` guards that gate on `is_valid_js_identifier` now also avoid emitting reserved-word identifiers.

### Test (red→green)

New e2e `e2e/reserved_word_mint_test.rs`: a logical module re-exports a binding under the reserved public name `default`, so the entry mints its import local from `default`.
- RED (mint fix reverted): emitted `import { default } from "..."`; node rejects with SyntaxError (exit 101).
- GREEN: minted `default$1 as default`; module parses and runs, prints `impl-value`.

## Verification

`bbr build //devinfra/js/debundle/...` green; `bbr test //devinfra/js/debundle/...` — 79/79 pass (incl. `import_coalescing_test`, `cross_module_emission_test`, `object_literal_import_collapse_test`); rustfmt + lint clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_