### PR TITLE
debundle: prune done/stale backlog items, fix stale paths and field lists

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -35,28 +35,6 @@ compute the same partition for different consumers; structurally
 consolidatable behind a wider API change, but not urgent and not on a hot
 path.
 
-### `OwnerGraph::from_report` rehydration carries `declared: BTreeSet::new()`
-
-`graph.rs::OwnerGraph::from_report` rehydrates an `OwnerGraph` from its
-JSON wire shape (`OwnerGraphReport`), but with `declared:
-BTreeSet::new()` because the report does not carry per-node binding sets.
-Current production callers:
-
-1. `cli/module.rs::gate_post_edit_partition` — the CLI realizability gate that runs after every spec edit. It deserializes `OwnerGraphReport` from disk, rehydrates via `OwnerGraph::from_report`, then runs the cycle check before letting the edit land. This is the cross-process Stage B in everything but name — just synchronously inside the CLI process rather than as a separate daemon.
-2. `peel/quotient.rs::QuotientGraph::from_report` — kernel constructor used by every `from_report_with_partition*` entrypoint and the quotient integration tests.
-
-The structural hazard is the empty `declared` value: downstream code that
-touches `OwnerNode::declared` sees "no bindings" instead of the truth.
-The fix is either (a) extend `OwnerGraphReport` to carry per-node
-`declared`, or (b) split into a reconstruct-from-graph-shape function that
-does not pretend `declared` is meaningful.
-
-Related residual cleanup from the abandoned cross-process Stage B (see
-<docs/lessons_learned/cross_process_stage_b.md>): `facts/wire.rs`'s
-`StatementFactsReport` / `IdReport` stay as in-memory carriers (converted
-back via `IdReport::to_id`), but their `Serialize` / `Deserialize` derives
-are no longer consumed and are safe to drop.
-
 ## Encapsulation + module boundaries
 
 ### `ChunkFactorization` is yet another per-chunk IR/report layer

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -61,7 +61,7 @@ Each returns `self.root.join(CONSTANT)`. Replace with a data-driven approach: `r
 
 ### `DepKind` 6-way split vs primary constraining/non-constraining axis
 
-Callers in realizability.rs, validation.rs, facts.rs frequently partition into constraining vs non-constraining via `constrains_init_order()`. Make this a first-class type distinction.
+Callers in realizability.rs, validation.rs, facts/mod.rs frequently partition into constraining vs non-constraining via `constrains_init_order()`. Make this a first-class type distinction.
 
 ### Three-layer edge representation
 

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -19,9 +19,9 @@ Whitelist tables already in `purity/whitelists.rs`; long PlainData /
 scanning, and TS enum IIFE recognition still live in `mod.rs` —
 could be sub-split further if it keeps growing.
 
-### `facts.rs` (1213 lines, 2 concerns)
+### `facts/mod.rs` (1213 lines, 2 concerns)
 
-`StatementFacts` carries 14 BTreeSet<Id> fields with many derivable sets; every construction site must keep them mutually consistent.
+`StatementFacts` carries many derivable `BTreeSet<Id>` sets that every construction site must keep mutually consistent — see the canonical "### `StatementFacts`" item under P3.
 
 ---
 
@@ -31,15 +31,11 @@ could be sub-split further if it keeps growing.
 
 `peel/test_utils.rs` already hosts `binding()`, `member()`, `module_ref()`. The `owner()`, `atomic_unit()`, `atomic_edge()`, `graph_fixture()` helpers have different signatures/semantics between the two test modules and remain local — could probably be unified with a small enum-tagged builder.
 
-### Vendor swap test workspace setup remaining adopters
-
-`VendorTestWorkspace` builder exists but `run_named_from_module_default_fixture` and `run_named_from_default_fixture` still construct workspaces inline. Adopt the builder there to match `run_partial_swap_fixture` / `run_partial_swap_kind_fixture`.
-
 ---
 
 ## P2 — Structural Issues
 
-### `lower/lower.rs` — monolithic function (partially extracted)
+### `lowering/lower.rs` — monolithic function (partially extracted)
 
 `lower_chunk` had 8 sequential phases inline. Four have been extracted into named functions (`compute_selected_ordinals`, `plan_selected_exports`, `split_entry_body`, `build_module_output`). Remaining inline phases (naturalization, disambiguation, import planning, the per-module loop) could be further extracted, though each requires substantial captured state from `LowerChunkInputs` (15–20 fields).
 
@@ -59,9 +55,9 @@ Each returns `self.root.join(CONSTANT)`. Replace with a data-driven approach: `r
 
 `rollback_graph.rs`, `artifact.rs`, `realizability.rs` all use BTree collections exclusively. For structures with many lookups, `HashMap`/`HashSet` would be faster. If deterministic iteration is needed, document it at the struct level. `RollbackDiGraph` in particular does many lookups per operation where hash-based would be measurably faster.
 
-### `StatementFacts` (facts.rs) — 14 BTreeSet<Id> fields
+### `StatementFacts` (facts/mod.rs) — ~10 BTreeSet<Id> fields
 
-reads, eager_reads, writes, eager_writes, rebinds, eager_rebinds, lazy_reads, lazy_writes, lazy_rebinds, calls, at_init_calls, dynamic_imports, side_effects, local_effects. Many are derivable (eager + lazy = total). Every construction site must keep 14 sets mutually consistent. Consider computing derived sets on demand or using a builder that enforces invariants.
+`declared`, `eager_reads`, `eager_rebinds`, `lazy_reads`, `lazy_rebinds`, `first_order_lazy_reads`, `first_order_lazy_rebinds`, `local_effects`, `at_init_calls`, `body_calls`, `first_order_body_calls`. Several are derivable (e.g. the `first_order_*` sets are subsets of their parent). Every construction site must keep the sets mutually consistent. Consider computing derived sets on demand or using a builder that enforces invariants.
 
 ### `DepKind` 6-way split vs primary constraining/non-constraining axis
 
@@ -188,8 +184,6 @@ No longer a standalone crate — absorbed into `swc_ecma_minifier` as `pub(crate
 
 2. **Split `analysis_tests.rs`** into 6–8 topic-aligned test modules. Largest test file at 4095 lines.
 
-3. **Split `lowering/materialize.rs`** — extract `fold_rebind_atomic_units` and deduplicate the `analysis_hints` collection loops.
+3. **Simplify `StatementFacts`** (`facts/mod.rs`) — see the canonical "### `StatementFacts`" item under P3.
 
-4. **Simplify `StatementFacts`** — 14 BTreeSet<Id> fields with many derivable sets; consider computing derived sets on demand.
-
-5. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong and the `generated_by_selected_module_lowering` ordering workaround if stage reordering makes that flag unnecessary.
+4. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong and the `generated_by_selected_module_lowering` ordering workaround if stage reordering makes that flag unnecessary.

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -137,8 +137,6 @@ all live in <perf/proposer.md>.
   while `peel/factorize.rs` produces advisory planner proposals from
   the serialized atomic DAG (surfaced as `debundle modules propose`).
   Keep docs explicit about which one they mean.
-- FACTORIZE.md is deleted; its content is folded into `docs/design.md`
-  §"Layered mental model" + §"Factor assembly inside `debundle run`".
 
 ## Analysis semantics breadth
 
@@ -163,6 +161,14 @@ mock browser bundle. Extend to:
 - HTML/runtime asset layouts outside the current corpus.
 
 ## Rename pipeline: collect → validate → execute _once_
+
+A scope-aware down-payment has landed: the in-place rename visitors
+(`IdentifierRenamer`, `RenameAndShorthandNaturalizer` in
+`lowering/visitors.rs`) now carry a `RenameScopeStack` and suppress a
+rename inside subtrees that re-bind the name, so the "X-layer renamed it,
+Y-layer didn't notice" shadowing class is mitigated. The
+collect→validate→execute **ledger/intent-buffer** architecture below
+remains the open work.
 
 The naturalizer / lowerer currently mutates identifiers in place across
 several independently-discovered passes and lets every downstream consumer

--- a/devinfra/js/debundle/docs/lessons_learned/cross_process_stage_b.md
+++ b/devinfra/js/debundle/docs/lessons_learned/cross_process_stage_b.md
@@ -115,15 +115,6 @@ the materializer reads more cleanly when Stage A is a single
 function call rather than four inline stages — not cross-process
 caching.
 
-## What's still around (residual cleanup)
-
-The structural follow-ups this abandoned design left behind — the
-`OwnerGraph::from_report` empty-`declared` rehydration hazard and the
-now-unconsumed `Serialize`/`Deserialize` derives on `facts/wire.rs`'s
-`StatementFactsReport` / `IdReport` — are tracked in
-<../../ARCHITECTURE_BACKLOG.md>. This note records only why the
-cross-process split was abandoned.
-
 ## Pointers
 
 - `WIRE_FORMAT.md` — the live `Atom`-only convention.

--- a/devinfra/js/debundle/x/purity_recursive.md
+++ b/devinfra/js/debundle/x/purity_recursive.md
@@ -39,22 +39,6 @@ This is a manifest-format and consumer change. Do it when a real bundle has a
 cross-chunk pure-helper chain that is not better modeled as an explicit
 author override.
 
-### Block-Bodied IIFE Enum Forms
-
-The enum recognizer handles emitted expression-body forms. A future bundle may
-emit block-bodied forms:
-
-```js
-(function (target) {
-  target.A = "a";
-  return target;
-})(Enum || {});
-```
-
-The soundness story is the same: assignments to the enum object followed by
-returning that object can be pure if the target object is the enum cell and all
-assigned values are pure.
-
 ### Statement-Level Purity Override
 
 `purity: pure` on a member is callsite-oriented: it says calls to that binding


### PR DESCRIPTION
Backlog-hygiene pass (item from the review follow-up). Audited every debundle tracker doc against current `devel` and pruned items whose work is done or whose references are stale, per the repo's "remove entries once done" convention. Markdown-only.

## Removed (DONE / STALE — verified against code)

- `ARCHITECTURE_BACKLOG.md`: the `OwnerGraph::from_report` empty-`declared` item + its `facts/wire.rs` serde-derive residual paragraph — `from_report` now takes `facts: &[StatementFactsReport]` and populates `declared`; `wire.rs` has no serde derives left.
- `docs/lessons_learned/cross_process_stage_b.md`: "What's still around (residual cleanup)" section — both residuals resolved (kept the rest as valid history).
- `TODO.md`: the "FACTORIZE.md deleted/folded into design.md" bullet — that move is complete.
- `x/purity_recursive.md`: "Block-Bodied IIFE Enum Forms" — handled by `is_ts_enum_iife_body_block`.
- `CODE_REVIEW.md`: "Vendor swap test workspace remaining adopters" — fixtures now go through `run_full_swap_fixture` / `VendorTestWorkspace`.
- `CODE_REVIEW.md`: Top-5 action "Split `lowering/materialize.rs`" — already a split directory (`lowering/materialize/{mod,apply,plan_builder}.rs`); renumbered the rest.

## Corrected (PARTIAL / stale details)

- `TODO.md` "Rename pipeline": noted the scope-aware `RenameScopeStack` down-payment has landed (rename visitors suppress renames in shadowing subtrees); the ledger/intent-buffer architecture remains the open work.
- `CODE_REVIEW.md` `StatementFacts`: fixed path `facts.rs` → `facts/mod.rs` (all four spots incl. the `DepKind` callers list); replaced the stale "14 fields: reads/writes/.../side_effects" enumeration with the real ~11-field set (`declared, eager_reads, eager_rebinds, lazy_reads, lazy_rebinds, first_order_lazy_reads, first_order_lazy_rebinds, local_effects, at_init_calls, body_calls, first_order_body_calls`); de-duplicated the smell from three places to one canonical item.
- `CODE_REVIEW.md`: fixed `lower/lower.rs` → `lowering/lower.rs`.

## Note

Surfaced (not resolved here) a standing contradiction: `TODO.md` wants to keep "factorize" terminology precise while `RENAME.md` plans to delete "factor" vocabulary wholesale — whichever lands first should retire the other's framing.

All touched files prettier-clean.

https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb

---
_Generated by [Claude Code](https://claude.ai/code/session_017oRZDZqzFHY1Ym4teDRNeb)_