### PR TITLE
airlock: fix reconnect-test race; x/plaid: fix mypy no-any-return

### DIFF
--- a/airlock/test_reconnect.py
+++ b/airlock/test_reconnect.py
@@ -67,9 +67,12 @@ async def test_client_reconnects_after_server_restart(
             a2 = await agent.call_echo("after-restart", session_key=session_key)
             assert a2.key.action_seq > a1.key.action_seq
 
-        # Approve via operator and verify execution
+        # Approve via operator and wait for execution to finish (decide() returns
+        # before the backend call completes — it only resolves the decision future).
         async with GateClient(operator_transport(base_url, operator_jwt)) as operator:
             await operator.approve(a2.key)
+            with anyio.fail_after(10.0):
+                await operator.wait_for(a2.key, ActionStatus.DONE)
 
         assert "after-restart" in echo_backend.calls
 

--- a/x/plaid/client.py
+++ b/x/plaid/client.py
@@ -90,7 +90,8 @@ class PlaidExtras:
             )
             if r.is_error:
                 raise RuntimeError(f"POST {path} -> {r.status_code}: {r.text}")
-            return r.json()
+            result: dict[str, Any] = r.json()
+            return result
 
     async def sandbox_public_token_create(
         self, institution_id: str = "ins_109508", initial_products: list[str] | None = None


### PR DESCRIPTION
Two small fixes.

## airlock: `test_client_reconnects_after_server_restart` race

The test approved an action via the operator, then immediately asserted the echo backend had been called. But `decide()` (behind `approve_action`) only resolves the in-memory decision future and returns — the backend call runs in a background task (`_await_human_decision` → `_apply_decision` → `call_tool_mcp`). So `echo_backend.calls` was still `[]` at the assertion.

Fixed by waiting for the action to reach `DONE` before asserting, matching the other two reconnect tests in the file.

## x/plaid: mypy `no-any-return`

`PlaidExtras._post` did `return r.json()`, returning `Any` from a `dict[str, Any]`-typed function, which trips mypy's `no-any-return` (`warn_return_any = True`). Bound the result to a typed local first — the pattern already used in `gatelet/reporter.py` and `x/grocy_mcp/batch_tools.py`.

## Verification

Both verified on BuildBuddy RBE:

- `bbr test //airlock:test_reconnect` → PASSED
- `bbr build //x/plaid:client` → mypy clean

## Note: the profile-path issue is not a repo bug

While recovering this session I found the hook daemon failed to start because `DUCKTAPE_CLAUDE_HOOKS_PROFILE` pointed at the old `devinfra/claude/hook_daemon/profiles/web/profile.yaml` (the dir was renamed to `claude_hook/`). That env var lives in the Claude Code web UI settings, not in the repo. Every in-repo reference to the profile path already uses `claude_hook/` (`.envrc`, `README.md`, `SPEC.md`, `settings.py`, `main.rs`), so there is no in-repo path fix to make.

https://claude.ai/code/session_01TP2fymbHKSya4VxHpXRrDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TP2fymbHKSya4VxHpXRrDw)_