### PR TITLE
augur(model): empirical prediction-market IPO prior for PE going-public hazard

### DIFF
--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import itertools
 import math
 from dataclasses import dataclass
 from typing import Literal
@@ -25,6 +26,20 @@ from augur.model.series_model import derive_stream_rollout_seeds
 BoolMatrix = npt.NDArray[np.bool_]
 CodeMatrix = npt.NDArray[np.int64]
 FloatMatrix = npt.NDArray[np.float64]
+
+
+class PublicMarketCdfAnchor(FrozenModel):
+    """One point on the empirical going-public CDF, as a month-index/probability pair.
+
+    `month` is a month index measured from sim start (month 0). The PE risk model is
+    calendar-agnostic; the deployment converts prediction-market resolution dates into
+    these month offsets. `cumulative_probability` is P(public market opened by `month`),
+    so it stays in [0, 1) — a stated certainty (1.0) is disallowed because the tail
+    hazard always leaves residual survival mass.
+    """
+
+    month: int = Field(ge=1)
+    cumulative_probability: float = Field(ge=0.0, lt=1.0)
 
 
 class PrivateEquityRiskIssuerConfig(FrozenModel):
@@ -58,7 +73,17 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
     admin_mark_update_log_noise_mu: float = 0.0
     admin_mark_update_log_noise_sigma: float = Field(default=0.10, ge=0.0)
     eligible_fraction: float = Field(default=1.0, ge=0.0, le=1.0)
+    # Going-public (IPO) hazard. When `public_market_cdf_anchors` is empty this is a
+    # flat constant-per-year hazard for the whole horizon. When anchors are supplied
+    # they define a front-loaded, saturating empirical CDF (prediction-market derived)
+    # up to the last anchor month, and this annual rate becomes the TAIL hazard applied
+    # to every month past the last anchor. Existing anchor-free configs are unchanged.
     annual_public_market_probability: float = Field(default=0.0, ge=0.0, le=1.0)
+    # Empirical going-public CDF anchors as (month-from-sim-start, P(public by month))
+    # pairs. Between consecutive anchors a constant monthly hazard reproduces the CDF
+    # exactly; past the last anchor the flat `annual_public_market_probability` tail
+    # takes over. Empty => the legacy flat-hazard behaviour.
+    public_market_cdf_anchors: tuple[PublicMarketCdfAnchor, ...] = ()
     public_market_lockup_months: int = Field(default=0, ge=0)
     public_market_price_log_discount_mu: float = 0.0
     public_market_price_log_discount_sigma: float = Field(default=0.20, ge=0.0)
@@ -91,6 +116,12 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
             raise ValueError("liquidity_suspension_months_max must be >= min")
         if self.forced_recovery_cashout_usd_max < self.forced_recovery_cashout_usd_min:
             raise ValueError("forced_recovery_cashout_usd_max must be >= min")
+        months = [anchor.month for anchor in self.public_market_cdf_anchors]
+        if any(later <= earlier for earlier, later in itertools.pairwise(months)):
+            raise ValueError("public_market_cdf_anchors must be strictly increasing in month")
+        cumulatives = [anchor.cumulative_probability for anchor in self.public_market_cdf_anchors]
+        if any(later < earlier for earlier, later in itertools.pairwise(cumulatives)):
+            raise ValueError("public_market_cdf_anchors must be non-decreasing in cumulative_probability")
         return self
 
 
@@ -251,7 +282,7 @@ def _sample_issuer(
     u_forced_sale = event_rng.random((rollout_count, horizon_months))
     u_tender_cancellation = event_rng.random((rollout_count, horizon_months))
 
-    monthly_public = _monthly_probability(issuer.annual_public_market_probability)
+    monthly_public_open = _public_market_open_hazard_by_month(issuer, horizon_months)
     monthly_suspension = _monthly_probability(issuer.annual_liquidity_suspension_probability)
     monthly_forced_sale = _monthly_probability(issuer.annual_forced_sale_probability)
     monthly_recovery = _monthly_probability(issuer.annual_forced_recovery_probability)
@@ -327,8 +358,9 @@ def _sample_issuer(
                 collapsed |= branch
                 eligible &= ~branch
 
-            # Branch 3: public_market_open.
-            branch = eligible & (u_public[:, u_idx] < monthly_public)
+            # Branch 3: public_market_open. The per-month hazard is the empirical
+            # IPO-prior CDF inside the anchored window and the flat tail past it.
+            branch = eligible & (u_public[:, u_idx] < monthly_public_open[t])
             if branch.any():
                 event_kind_code[branch, t] = int(PrivateEquityEventKindCode.PUBLIC_MARKET_OPEN)
                 # Forward-fill PUBLIC_MARKET regime from t onward.
@@ -581,3 +613,34 @@ def _monthly_probability(annual_probability: float) -> float:
     if annual_probability >= 1.0:
         return 1.0
     return float(1.0 - math.pow(1.0 - annual_probability, 1.0 / 12.0))
+
+
+def _public_market_open_hazard_by_month(
+    issuer: PrivateEquityRiskIssuerConfig, horizon_months: int
+) -> npt.NDArray[np.float64]:
+    """Per-month going-public hazard vector (length horizon_months+1), indexable by month t.
+
+    Index 0 is unused (the loop starts at month 1). Without anchors the whole vector is
+    the flat per-month rate from `annual_public_market_probability`. With anchors, each
+    bucket (m_i, F_i) -> (m_{i+1}, F_{i+1}) gets the constant monthly hazard that exactly
+    reproduces the survival drop S_{i+1}/S_i over its m_{i+1}-m_i months; the first bucket
+    runs from month 0 (S=1) to the first anchor. Months past the last anchor fall back to
+    the flat `annual_public_market_probability` tail hazard.
+    """
+
+    tail_hazard = _monthly_probability(issuer.annual_public_market_probability)
+    hazard = np.full(horizon_months + 1, tail_hazard, dtype=np.float64)
+
+    prev_month = 0
+    prev_survival = 1.0
+    for anchor in issuer.public_market_cdf_anchors:
+        anchor_month = min(anchor.month, horizon_months)
+        survival = 1.0 - anchor.cumulative_probability
+        bucket_hazard = 1.0 - (survival / prev_survival) ** (1.0 / (anchor.month - prev_month))
+        hazard[prev_month + 1 : anchor_month + 1] = bucket_hazard
+        prev_month = anchor.month
+        prev_survival = survival
+        if prev_month >= horizon_months:
+            break
+
+    return hazard

--- a/augur/model/private_equity_risk_test.py
+++ b/augur/model/private_equity_risk_test.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 import pytest_bazel
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from augur.model.exogenous import ExogenousSamplingRequest, SampledExogenousBundle
 from augur.model.exogenous_provider_config import ExogenousProviderConfig
@@ -14,7 +15,12 @@ from augur.model.private_equity_bundle import (
     PrivateEquityFloatChannel,
     PrivateEquityIntChannel,
 )
-from augur.model.private_equity_risk import PrivateEquityRiskIssuerConfig, PrivateEquityRiskProviderConfig
+from augur.model.private_equity_risk import (
+    PrivateEquityRiskIssuerConfig,
+    PrivateEquityRiskProviderConfig,
+    PublicMarketCdfAnchor,
+    _public_market_open_hazard_by_month,
+)
 from augur.model.series import IssuerId, PrivateEquityEventKindCode, PrivateEquityRegimeCode
 
 
@@ -336,6 +342,105 @@ def test_private_equity_risk_unrequested_issuer_still_satisfies_request() -> Non
                 required_private_equity_issuers=frozenset({IssuerId("other_issuer")}),
             )
         )
+
+
+# Empirical going-public CDF prior — prediction-market-derived IPO anchors.
+_IPO_ANCHORS: tuple[PublicMarketCdfAnchor, ...] = (
+    PublicMarketCdfAnchor(month=7, cumulative_probability=0.75),
+    PublicMarketCdfAnchor(month=19, cumulative_probability=0.89),
+    PublicMarketCdfAnchor(month=31, cumulative_probability=0.93),
+)
+
+
+def test_public_market_open_hazard_reproduces_anchor_cdf() -> None:
+    """The hazard builder turns CDF anchors into per-bucket constant monthly hazards
+    whose compounded survival hits each anchor's cumulative probability exactly."""
+
+    issuer = _issuer(public_market_cdf_anchors=_IPO_ANCHORS, annual_public_market_probability=0.07)
+    hazard: npt.NDArray[np.float64] = _public_market_open_hazard_by_month(issuer, horizon_months=36)
+
+    # First three buckets are (0,7], (7,19], (19,31]; their constant monthly hazards
+    # are the front-loaded, saturating shape the prediction market implies.
+    assert hazard[1] == pytest.approx(0.18, abs=2e-3)
+    assert hazard[8] == pytest.approx(0.067, abs=2e-3)
+    assert hazard[20] == pytest.approx(0.037, abs=2e-3)
+
+    # Index 0 is unused by the sampler (the per-month loop runs t>=1), so the CDF the
+    # model realizes is the compounded survival over months 1..N. Reproduce that.
+    cumulative: npt.NDArray[np.float64] = np.zeros_like(hazard)
+    cumulative[1:] = 1.0 - np.cumprod(1.0 - hazard[1:])
+    assert cumulative[7] == pytest.approx(0.75, abs=1e-9)
+    assert cumulative[19] == pytest.approx(0.89, abs=1e-9)
+    assert cumulative[31] == pytest.approx(0.93, abs=1e-9)
+
+    # Past the last anchor the flat annual tail hazard takes over.
+    assert hazard[32] == pytest.approx(1.0 - (1.0 - 0.07) ** (1.0 / 12.0), abs=1e-12)
+
+
+def test_public_market_open_hazard_without_anchors_is_flat_tail() -> None:
+    """No anchors → the whole vector is the legacy flat monthly hazard."""
+
+    issuer = _issuer(annual_public_market_probability=0.07)
+    hazard = _public_market_open_hazard_by_month(issuer, horizon_months=12)
+
+    flat = 1.0 - (1.0 - 0.07) ** (1.0 / 12.0)
+    np.testing.assert_allclose(hazard, np.full(13, flat))
+
+
+def test_public_market_cdf_anchors_reject_non_increasing_month() -> None:
+    with pytest.raises(ValidationError, match="strictly increasing in month"):
+        _issuer(
+            public_market_cdf_anchors=(
+                PublicMarketCdfAnchor(month=7, cumulative_probability=0.5),
+                PublicMarketCdfAnchor(month=7, cumulative_probability=0.6),
+            )
+        )
+
+
+def test_public_market_cdf_anchors_reject_decreasing_cumulative_probability() -> None:
+    with pytest.raises(ValidationError, match="non-decreasing in cumulative_probability"):
+        _issuer(
+            public_market_cdf_anchors=(
+                PublicMarketCdfAnchor(month=7, cumulative_probability=0.6),
+                PublicMarketCdfAnchor(month=19, cumulative_probability=0.5),
+            )
+        )
+
+
+def test_public_market_open_realized_probability_tracks_anchor_cdf() -> None:
+    """Integration: with the empirical anchors and all competing adverse hazards ≈0,
+    the realized fraction of rollouts that have gone public by months 7/19/31 matches
+    the prediction-market CDF (0.75/0.89/0.93) within Monte-Carlo tolerance.
+    """
+
+    rollout_count = 6000
+    rollout_seeds = tuple(range(5000, 5000 + rollout_count))
+    issuer = _issuer(
+        monthly_log_return_mu=0.0,
+        monthly_log_return_sigma=0.0,
+        # Push the tender precursor far past the horizon so it never preempts a month.
+        tender_interval_months_median=600.0,
+        public_market_cdf_anchors=_IPO_ANCHORS,
+        annual_public_market_probability=0.07,
+    )
+    model = PrivateEquityRiskProviderConfig(issuers={"acme": issuer}).realize_model()
+    sampled = model.sample(
+        ExogenousSamplingRequest(
+            horizon_months=31,
+            rollout_seeds=rollout_seeds,
+            required_private_equity_issuers=frozenset({IssuerId("acme")}),
+        )
+    )
+    regime = sampled.private_equity.issuer_int_matrix(
+        "acme", str(PrivateEquityIntChannel.REGIME_CODE), rollout_count=rollout_count, horizon_months=31
+    )
+    public = regime == int(PrivateEquityRegimeCode.PUBLIC_MARKET)
+
+    # PUBLIC_MARKET is absorbing, so "public by month m" == public regime at month m.
+    realized = {m: float(public[:, m].mean()) for m in (7, 19, 31)}
+    assert realized[7] == pytest.approx(0.75, abs=0.02)
+    assert realized[19] == pytest.approx(0.89, abs=0.02)
+    assert realized[31] == pytest.approx(0.93, abs=0.02)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces the structured PE model's flat, memoryless `annual_public_market_probability` IPO hazard with an **empirical, market-derived going-public CDF** — a self-contained `augur/model` change with no dependency on the calibration framework (peeled out of the larger calibration work so it can land on its own).

## What
On `PrivateEquityRiskIssuerConfig`, add `public_market_cdf_anchors: tuple[PublicMarketCdfAnchor, ...]` where `PublicMarketCdfAnchor` is `{month: int >= 1, cumulative_probability: float in [0, 1)}` — cumulative P(public by month), month-indexed from sim start.

- **Within buckets**: constant monthly hazard via survival interpolation, `h = 1 − (S_{i+1}/S_i)^(1/(m_{i+1}−m_i))`, reproducing the CDF exactly at every anchor.
- **Tail past the last anchor**: reverts to the flat `annual_public_market_probability` (a geometric tail), so a market that saturates at e.g. ~0.93 does **not** force the residual mass to "never."
- **Backwards compatible**: empty anchors → the existing flat-hazard behaviour, so all current configs are unchanged.
- A `model_validator` rejects anchors that aren't strictly increasing in `month` or non-decreasing in `cumulative_probability`.
- The per-month sampler loop indexes a precomputed `monthly_public_open[t]` vector; `PUBLIC_MARKET_OPEN` still only fires while eligible (collapse can preempt).

## Why
Calibration against Manifold showed the flat 7%/yr hazard gives P(IPO before 2027) ≈ 0.04 vs the market's ~0.75 — too low and the wrong shape. For openai's {2027:0.75, 2028:0.89, 2029:0.93} anchors this yields ~18%/mo (2026) → ~6.7%/mo (2027) → ~3.7%/mo (2028).

## Tests
`augur/model/private_equity_risk_test.py`: hazard-builder unit test, no-anchor (flat) case, both validator rejections, and a 6000-rollout integration test whose realized P(IPO) tracks the target CDF (7/19/31 → 0.748/0.896/0.933, within ±0.02). Green on RBE (`//augur/model/...`).

The downstream calibration tab + the `ipo_prior.py` deriver (which turns live Manifold prices into these anchors) build on this and land separately.

_Note: commits unsigned per maintainer's OK._

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_