### PR TITLE
claude_hook: tombstone no-op profile keys; fix stale web_selfcheck checks

### DIFF
--- a/devinfra/claude/claude_hook/config.rs
+++ b/devinfra/claude/claude_hook/config.rs
@@ -1,9 +1,11 @@
 //! Profile YAML configuration.
 //!
-//! The profile is **repo-generic**: unknown fields are ignored so
-//! repo-specific keys (k8s, bazel_bes_proxy, setup_docker, pre_commit, etc.)
-//! don't break parsing. They're consumed by the repo's scripts, not the
-//! daemon.
+//! The profile is **repo-generic**: serde drops unknown fields, so the parser
+//! tolerates vestigial keys the retired Python daemon honored (`otel`,
+//! `bazel_bes_proxy`, `setup_docker`, `setup_tmpfs`, …) and forward-compatible
+//! additions without breaking. Promote such a key into `ProfileConfig` (with a
+//! test) only once the Rust daemon actually consumes it; until then it is
+//! silently ignored. See `devinfra/claude/TODO.md`.
 
 use serde::Deserialize;
 

--- a/devinfra/claude/claude_hook/container_e2e/test_profile.yaml
+++ b/devinfra/claude/claude_hook/container_e2e/test_profile.yaml
@@ -7,18 +7,12 @@
 #     which decrypts /project/secrets/claude-web-k8s-jwt.yaml via sops
 #
 # Stripped (vs real web profile):
-#   - setup_tmpfs / setup_docker  (needs mount/privileges)
-#   - bazel_bes_proxy             Can't exercise BES with a fake
-#                                 BUILDBUDDY_API_KEY: the daemon's BES
-#                                 interceptor forwards build events to
-#                                 remote.buildbuddy.io:443, which rejects
-#                                 the fake key. Bazel treats BES upload
-#                                 failures as fatal (the
-#                                 `--bes_upload_mode=best_effort` flag
-#                                 that used to allow ignoring them was
-#                                 removed — see bazelbuild/bazel#25756).
 #   - network-heavy bg commands   (apt-get, pre-commit install, fork remote)
 #   - context_template            (keep output minimal for test assertions)
+#
+# (The real web profile's vestigial Python-daemon keys — otel, setup_tmpfs,
+# setup_docker, bazel_bes_proxy — were removed 2026-05-30; the Rust daemon
+# ignores unknown fields, so they never affected this fixture either.)
 #
 # The real web profile is at devinfra/claude/claude_hook/profiles/web/profile.yaml.
 

--- a/devinfra/claude/claude_hook/profiles/cli/profile.yaml
+++ b/devinfra/claude/claude_hook/profiles/cli/profile.yaml
@@ -1,7 +1,7 @@
-otel:
-  endpoint: https://alloy-otlp.allegedly.works/v1/traces
-  # bearer_token: sourced from .envrc (cli_env.sh → DUCKTAPE_OTEL_BEARER_TOKEN).
-
+# CLEANUP(2026-05-30): `otel:` removed — ignored by the Rust daemon (config.rs
+# drops unknown fields; OTLP export is a Python-daemon parity gap tracked in
+# devinfra/claude/TODO.md). Endpoint was https://alloy-otlp.allegedly.works/v1/traces;
+# DUCKTAPE_OTEL_BEARER_TOKEN still comes from .envrc (cli_env.sh) regardless.
 git_shim:
   block_amend: true
   # block_stash is disabled because pre-commit (invoked as a git commit hook) uses
@@ -12,7 +12,7 @@ git_shim:
   block_stash: false
   block_add_all: true
 idle_watchdog: true
-setup_tmpfs: false
+# CLEANUP(2026-05-30): `setup_tmpfs` removed for the same reason as `otel:` above.
 env_exports: |
   export DUCKTAPE_PRECOMMIT_ENFORCE_BAZEL_TESTS=0
   export DUCKTAPE_PRECOMMIT_ENFORCE_TEST_TAG=1

--- a/devinfra/claude/claude_hook/profiles/web/profile.yaml
+++ b/devinfra/claude/claude_hook/profiles/web/profile.yaml
@@ -1,14 +1,21 @@
 startup_env_script: devinfra/secrets/web_env.sh
 
-otel:
-  endpoint: https://alloy-otlp.allegedly.works/v1/traces
-  # bearer_token: decrypted via startup_env_script (web_env.sh) at daemon startup.
-
 idle_watchdog: false
-setup_tmpfs: true
-setup_docker: true
-bazel_bes_proxy:
-  target: remote.buildbuddy.io:443
+
+# CLEANUP(2026-05-30): the keys below were removed because the Rust `claude-hook`
+# daemon IGNORES them — serde drops unknown fields (see config.rs), so they were
+# honored only by the retired Python daemon. Leaving them implied behavior that
+# does not happen: `setup_docker: true` did NOT start Docker (confirmed by the
+# web_selfcheck W5 finding on 2026-05-30). Removed:
+#   otel:            { endpoint: https://alloy-otlp.allegedly.works/v1/traces }
+#   setup_tmpfs:     true
+#   setup_docker:    true
+#   bazel_bes_proxy: { target: remote.buildbuddy.io:443 }
+# Restore a key (with a ProfileConfig field + test) when the Rust daemon
+# implements it; otherwise delete this tombstone once the "Rust parity
+# follow-ups" item in devinfra/claude/TODO.md is closed as won't-do.
+# NOTE: DUCKTAPE_OTEL_BEARER_TOKEN is still exported by web_env.sh, independent
+# of the removed `otel:` key.
 env_exports: |
   export DUCKTAPE_PRECOMMIT_ENFORCE_BAZEL_TESTS=0
   export DUCKTAPE_PRECOMMIT_ENFORCE_TEST_TAG=1

--- a/skills/web_selfcheck/SKILL.md
+++ b/skills/web_selfcheck/SKILL.md
@@ -92,19 +92,19 @@ the check is verifying.
 
 ### Common
 
-**C1 — BUILDBUDDY_API_KEY is present and valid.**
+**C1 — BUILDBUDDY_API_KEY is present; validity is proven by C3.**
 
 ```bash
-[ -n "${BUILDBUDDY_API_KEY:-}" ] || echo "FAIL: BUILDBUDDY_API_KEY unset"
-curl -s -o /dev/null -w "%{http_code}\n" \
-  -H "x-buildbuddy-api-key: ${BUILDBUDDY_API_KEY}" \
-  -H "Content-Type: application/proto" \
-  --data-binary '' \
-  https://remote.buildbuddy.io/rpc/BuildBuddyService/GetUser
+[ -n "${BUILDBUDDY_API_KEY:-}" ] && echo "present (len=${#BUILDBUDDY_API_KEY})" \
+  || echo "FAIL: BUILDBUDDY_API_KEY unset"
 ```
 
-Pass: `200` (or `400` = malformed proto but auth passed). `401`/`403` =
-invalid key.
+Presence only — there is **no working lightweight HTTP probe**. The
+`remote.buildbuddy.io` gateway returns `415` for the old `GetUser` curl _with
+or without_ the key (it rejects the content type before auth), so that probe
+cannot distinguish a valid key. The authoritative validity test is the live
+RBE build in **C3 / W4**: a `401`/`403` or a BES auth rejection there is the
+real signal of a bad key.
 
 **C2 — GITHUB_TOKEN is present and valid.**
 
@@ -129,7 +129,8 @@ Pass: exit 0 with no `Unable to resolve host`, `certificate`,
 **C4 — bazelisk shim is active and invocations are session-tagged.**
 
 ```bash
-LIVE=$(basename "$(dirname "$CLAUDE_ENV_FILE")")
+LIVE=${CLAUDE_ENV_FILE:+$(basename "$(dirname "$CLAUDE_ENV_FILE")")}
+LIVE=${LIVE:-$(ps aux | grep '[c]laude-hook daemon' | grep -oP '(?<=--sock /tmp/claude-hd/)[^/]+' | head -1)}
 SESSION_DIR="$HOME/.claude/session-env/$LIVE"
 ls -l "$(command -v bazelisk)"  # must point into $SESSION_DIR/bin
 grep -E 'build_metadata|TAGS' "$SESSION_DIR/bbr.bazelrc" 2>/dev/null
@@ -146,27 +147,32 @@ BuildBuddy invocation tags after a real `bbr` invocation.
 **C6 — throwaway-commit pre-commit end-to-end.**
 
 ```bash
-set -e
 cd /home/user/ducktape
+START_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 TEST_BRANCH="selfcheck/$(date +%s)"
+TEST_FILE=/home/user/ducktape/selfcheck-tmp.txt   # kebab-case: avoids the filename-convention hook
+trap 'git checkout -q "$START_BRANCH"; git branch -D "$TEST_BRANCH" 2>/dev/null; rm -f "$TEST_FILE"' EXIT
 git checkout -q -b "$TEST_BRANCH"
-TEST_FILE=$(mktemp /home/user/ducktape/selfcheck-XXXXX.txt)
-echo "selfcheck $(date -Iseconds)" > "$TEST_FILE"
+printf 'selfcheck %s\n' "$(date -Iseconds)" > "$TEST_FILE"
 git add "$TEST_FILE"
-git commit -m "test: selfcheck — delete me" 2>&1
-EXIT=$?
-git checkout -q -
-git branch -D "$TEST_BRANCH"
-rm -f "$TEST_FILE"
-echo "exit: $EXIT"
+# The commit-msg hook requires a BAZEL_TEST_INVOCATIONS= tag whenever
+# DUCKTAPE_PRECOMMIT_ENFORCE_TEST_TAG=1 (both profiles export this). A bare
+# commit is *correctly* rejected; use the none: form for a no-code change.
+git commit -m "test: selfcheck — delete me
+
+BAZEL_TEST_INVOCATIONS=none: selfcheck throwaway, no code/tests affected" 2>&1 | tail -40
+echo "exit: ${PIPESTATUS[0]}"
 ```
 
-Pass: exit 0.
+Pass: exit 0 with every hook Passed/Skipped (incl. `ducktape-commit-msg`). A
+bare commit _without_ the tag failing at `ducktape-commit-msg` is correct
+policy behavior, not a broken session.
 
 **C7 — hook daemon logs present, no unhandled exceptions.**
 
 ```bash
-LIVE=$(basename "$(dirname "$CLAUDE_ENV_FILE")")
+LIVE=${CLAUDE_ENV_FILE:+$(basename "$(dirname "$CLAUDE_ENV_FILE")")}
+LIVE=${LIVE:-$(ps aux | grep '[c]laude-hook daemon' | grep -oP '(?<=--sock /tmp/claude-hd/)[^/]+' | head -1)}
 LOG="/tmp/claude-hd/$LIVE/daemon.log"
 [ -f "$LOG" ] && grep -cE 'ERROR|Traceback|Exception' "$LOG" || echo MISSING
 ```
@@ -293,11 +299,17 @@ timeout 60 bbr build //devinfra:gazelle --nobuild 2>&1 | tail -10
 Pass: exit 0, no "which remote" prompt, no `Unable to resolve host`, no
 `127.0.0.1:*` in the runner's origin URL.
 
-**W5 — Docker is available.**
+**W5 — Docker (non-goal: the Rust daemon does not set one up).**
 
 ```bash
-docker info >/dev/null 2>&1 && echo OK || echo FAIL
+docker info >/dev/null 2>&1 && echo "present" || echo "absent (expected)"
 ```
+
+The web profile's `setup_docker` key is **ignored** by the Rust daemon — only
+the retired Python daemon started Docker (see `devinfra/claude/TODO.md`). So an
+absent local Docker daemon is **expected, not a failure**: Docker-dependent
+tests run on BuildBuddy RBE workers, not locally. Report `present`/`absent`
+informationally; only flag if a workflow genuinely needs local Docker.
 
 ## Out-of-SPEC diagnostics
 
@@ -335,6 +347,11 @@ There are **two** independent kinds of staleness to check:
 
 **(a) Pin in `nix/artifact-pins.json` is behind HEAD** — sync-pins.yml didn't
 run recently, or release.yml is failing. The repo itself is out of date.
+On a **shallow clone** (Claude Code web clones ~50 commits — check
+`.git/shallow`), the pinned commit is usually absent locally, so the
+`git log` / `git merge-base` ancestry checks below are unreliable. Compare the
+pin SHA against `origin/devel` via the GitHub MCP instead, or just confirm
+`daemon.err.log` shows no schema-drift crashes (the practical signal).
 
 **(b) Installed wheel is behind the pin** — on Firecracker web sessions
 with a persistent rootfs, `nix profile install` is a no-op when devtools
@@ -358,7 +375,7 @@ print('pinned:', m.group(1) if m else 'unknown')
 git -C /home/user/ducktape log --oneline -5 -- devinfra/claude/ nix/artifact-pins.json
 
 # (b) Installed wheel vs pin
-claude-hook --version  # git= shows the commit the installed wheel was built from
+claude-hook --version  # Rust binary: prints the crate version (e.g. 0.0.0), not a git stamp
 # Check daemon.err.log for template/schema crashes that indicate drift
 tail -50 /tmp/claude-hd/*/daemon.err.log 2>/dev/null
 ```
@@ -403,7 +420,7 @@ Profile: <CLI/Web>    Summary: <healthy / degraded / broken>
 | C2  | GITHUB_TOKEN valid             | OK/FAIL       | login=...             |
 | C3  | bbr build trivial              | OK/FAIL       | ...                   |
 | C4  | bazelisk shim + session tag    | OK/FAIL       | ...                   |
-| C5  | PostToolUse auto-apply         | OK/SKIP       | manually verified?    |
+| C5  | bbr imports session metadata   | OK/FAIL       | session:<id> tag      |
 | C6  | throwaway commit end-to-end    | OK/FAIL       | ...                   |
 | C7  | daemon log clean               | OK/FAIL       | N errors              |
 | C8  | OTLP tracing                   | OK/FAIL       | HTTP <code>           |


### PR DESCRIPTION
Both cleanups were surfaced by running `/web_selfcheck` on a live session.

## 1. Tombstone no-op profile keys

The Rust `claude-hook` daemon's `ProfileConfig` (`config.rs`) ignores unknown YAML keys — `otel`, `setup_tmpfs`, `setup_docker`, and `bazel_bes_proxy` were honored only by the **retired Python daemon**, so they were silent no-ops in the profiles. Leaving `setup_docker: true` falsely implied Docker gets set up; the selfcheck's W5 check confirmed no `dockerd` is started.

- `profiles/web/profile.yaml`: removed all four keys behind a `CLEANUP(2026-05-30)` tombstone, with the removal condition pointing at the existing "Rust parity follow-ups" item in `devinfra/claude/TODO.md`. Notes that `DUCKTAPE_OTEL_BEARER_TOKEN` still comes from `web_env.sh`, independent of the removed `otel:` key.
- `profiles/cli/profile.yaml`: removed `otel`/`setup_tmpfs` likewise.
- `config.rs`: the module doc cited these keys as "consumed by the repo's scripts" — they aren't; reworded to vestigial Python-daemon keys that are silently ignored.
- `container_e2e/test_profile.yaml`: its "Stripped vs real web profile" comment referenced keys the real profile no longer has and a BES interceptor the Rust daemon doesn't implement; corrected.

No `ProfileConfig` field is removed (the four were never parsed), so daemon behavior is unchanged — the `parse_with_unknown_fields_ignored` test still passes.

## 2. Fix stale `web_selfcheck` checks

The skill is the runnable acceptance test for the daemon SPEC. These checks were stale/broken when run on a current session:

- **C1**: the `GetUser` curl probe returns `415` with *or without* the key (the gateway rejects the content type before auth), so it can't validate the key. Dropped it; key validity is proven by the live RBE build in C3/W4.
- **C6**: a bare commit is now rejected by the `commit-msg` hook (requires `BAZEL_TEST_INVOCATIONS=`). Added the required tag and a kebab-case temp filename (avoids the filename-convention hook).
- **W5**: Docker is a documented non-goal of the Rust daemon, so reframed from pass/fail to informational (Docker tests run on RBE).
- **C4/C7**: resolve `$LIVE` from `ps` when `$CLAUDE_ENV_FILE` is unset.
- **C5** report row referenced the removed PostToolUse hook; fixed. **D2** `claude-hook --version` note predated the Rust binary; fixed, plus a shallow-clone caveat for D2(a).

`SPEC.md` needs no change — its Non-Goals section already covers these as features the Rust daemon doesn't yet provide.

## Out of scope (flagged for awareness)

- The daemon classified this session's platform as "CLI (local)" while running the **web** profile; the web-only setup paths (Docker/tmpfs) are gated on platform detection and unimplemented in Rust anyway. Not addressed here.
- `otel` is tombstoned as a no-op *profile key*, but OTLP tracing itself (token rotation, `DUCKTAPE_OTEL_BEARER_TOKEN`) is a live subsystem — the Rust daemon just doesn't emit traces yet (tracked in `devinfra/claude/TODO.md`).

## Test

`bbr test //devinfra/claude/claude_hook/... //skills/web_selfcheck:web_selfcheck_frontmatter_test` — 9/9 pass (BuildBuddy invocation `20ec8681-93a7-4ab0-84e0-9eea2608e6b5`), including `config_test` and `test_container_e2e` (which consumes the edited `test_profile.yaml`). pre-commit clean.

https://claude.ai/code/session_01Up3g33MoZGmacFyAphZPL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up3g33MoZGmacFyAphZPL9)_