### PR TITLE
augur/TODO: defer Bayesian fit of PE valuation + dilution process

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -68,6 +68,17 @@ this file as a backlog, not a second ordered roadmap.
       `macro_market_bundle_provider` shape directly; mine it only for
       data loading/config ideas after the native `SampledExogenousBundle`
       API is the target.
+- [ ] **Fit the PE valuation + share-dilution process, not just a static
+      scale.** M2 (`augur/plans/prediction_market_calibration.md`) adds a
+      company-valuation channel `V = mark × shares(t)` plus a dilution
+      process, but v1 uses point estimates (`shares₀`, `annual_dilution_rate`).
+      The trainer already ingests `valuation_observation`s but collapses them to
+      a single static `scale_prior.current_market_cap_usd`; make the scale
+      **dynamic and Bayesian** — fit a posterior over the dilution rate and the
+      valuation drift/vol jointly from the paired (price, valuation) series so
+      `shares(t)` / `V(t)` carry real uncertainty instead of hand-set points.
+      Distinguish primary-issuance dilution (funding rounds) from secondaries
+      (no new shares) and employee-equity (PPU/RSU) issuance.
 
 ## Liquidity Policy
 


### PR DESCRIPTION
Records the M2 follow-up we agreed to defer: make the PE valuation/share-dilution **scale dynamic and Bayesian** rather than today's single static `scale_prior.current_market_cap_usd` point estimate.

The trainer already ingests `valuation_observation`s but collapses them to one constant scale. The eventual upgrade is to fit a posterior over the dilution rate + valuation drift/vol jointly from the paired (price, valuation) series, so `shares(t)` / `V(t) = mark·shares(t)` carry real uncertainty. M2 v1 will ship with point-estimate parameters; this TODO captures the later fit.

One-line addition to `augur/TODO.md`'s Exogenous Models & Evidence section.

_Commit unsigned per maintainer's OK._

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_