### PR TITLE
airlock: reconcile managed-secret annotations every refresh pass

### DIFF
--- a/airlock/oauth/BUILD.bazel
+++ b/airlock/oauth/BUILD.bazel
@@ -7,7 +7,7 @@ py_library(
     srcs = ["provider.py"],
     visibility = [
         "//airlock:__subpackages__",
-        "//x/plaid:__pkg__",
+        "//plaid:__pkg__",
     ],
     deps = [
         "@pypi//httpx",
@@ -76,6 +76,18 @@ py_test(
         ":provider",
         ":refresh",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_k8s_client",
+    srcs = ["test_k8s_client.py"],
+    deps = [
+        ":conftest",
+        ":k8s_client",
+        "@pypi//kubernetes_asyncio",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],

--- a/airlock/oauth/k8s_client.py
+++ b/airlock/oauth/k8s_client.py
@@ -60,6 +60,28 @@ class K8sTokenStore:
             else:
                 raise
 
+    async def reconcile_annotations(self, secret_name: str, namespace: str, annotations: dict[str, str]) -> None:
+        """Ensure a managed secret carries the configured annotations, without rewriting token data.
+
+        Merges (adds/updates the configured keys; leaves any others). This lets config-level
+        annotation changes — e.g. adding a reflector target namespace — reach already-written
+        secrets even when the token itself never changes. Plaid access tokens, for instance,
+        never refresh, so without this they would keep stale annotations until the next re-link.
+        """
+        if not annotations:
+            return
+        try:
+            secret = await self._api.read_namespaced_secret(secret_name, namespace)
+        except ApiException as e:
+            if e.status == 404:
+                return  # provider not linked yet — nothing to reconcile
+            raise
+        current = secret.metadata.annotations or {}
+        if all(current.get(key) == value for key, value in annotations.items()):
+            return  # already in sync
+        await self._api.patch_namespaced_secret(secret_name, namespace, {"metadata": {"annotations": annotations}})
+        logger.info(f"Reconciled annotations on secret {namespace}/{secret_name}")
+
     async def delete_orphaned_secrets(self, namespace: str, known_names: frozenset[str]) -> None:
         """Delete managed secrets whose names are not in known_names."""
         label_selector = f"app.kubernetes.io/managed-by={self._managed_by}"

--- a/airlock/oauth/refresh.py
+++ b/airlock/oauth/refresh.py
@@ -45,6 +45,13 @@ async def token_refresh_loop(
     warned_scope_drifts: set[tuple[str, str]] = set()
     while True:
         for name, provider in providers.items():
+            # Reconcile managed-secret annotations (e.g. reflector target namespaces) on every
+            # pass, even when the token never changes, so config edits propagate without a re-link.
+            for secret_cfg in (provider.config.refresh_secret, provider.config.access_secret):
+                try:
+                    await k8s_store.reconcile_annotations(secret_cfg.name, target_namespace, secret_cfg.annotations)
+                except Exception:
+                    logger.exception(f"Failed to reconcile annotations for {secret_cfg.name}")
             try:
                 token = await k8s_store.read_token(provider.config.refresh_secret.name, target_namespace)
                 if token is None:

--- a/airlock/oauth/test_k8s_client.py
+++ b/airlock/oauth/test_k8s_client.py
@@ -1,0 +1,52 @@
+"""Tests for K8sTokenStore.reconcile_annotations."""
+
+from unittest.mock import AsyncMock
+
+import pytest_bazel
+from kubernetes_asyncio.client import ApiException, V1ObjectMeta, V1Secret
+
+from airlock.oauth.k8s_client import K8sTokenStore
+
+
+def _store(annotations: dict[str, str] | None) -> tuple[K8sTokenStore, AsyncMock]:
+    api = AsyncMock()
+    api.read_namespaced_secret.return_value = V1Secret(metadata=V1ObjectMeta(annotations=annotations))
+    return K8sTokenStore(api, managed_by="airlock"), api
+
+
+async def test_reconcile_patches_on_drift() -> None:
+    store, api = _store({"reflector/ns": "openclaw-sandbox"})
+    await store.reconcile_annotations(
+        "plaid-chase-access-token", "airlock", {"reflector/ns": "openclaw-sandbox,plaid-mcp"}
+    )
+    api.patch_namespaced_secret.assert_awaited_once_with(
+        "plaid-chase-access-token",
+        "airlock",
+        {"metadata": {"annotations": {"reflector/ns": "openclaw-sandbox,plaid-mcp"}}},
+    )
+
+
+async def test_reconcile_noop_when_in_sync() -> None:
+    # Configured keys already present (extra unmanaged keys are left alone).
+    store, api = _store({"reflector/ns": "openclaw-sandbox,plaid-mcp", "other": "x"})
+    await store.reconcile_annotations("s", "airlock", {"reflector/ns": "openclaw-sandbox,plaid-mcp"})
+    api.patch_namespaced_secret.assert_not_called()
+
+
+async def test_reconcile_noop_when_secret_absent() -> None:
+    api = AsyncMock()
+    api.read_namespaced_secret.side_effect = ApiException(status=404)
+    store = K8sTokenStore(api, managed_by="airlock")
+    await store.reconcile_annotations("s", "airlock", {"k": "v"})
+    api.patch_namespaced_secret.assert_not_called()
+
+
+async def test_reconcile_noop_when_no_annotations_configured() -> None:
+    store, api = _store({})
+    await store.reconcile_annotations("s", "airlock", {})
+    api.read_namespaced_secret.assert_not_called()
+    api.patch_namespaced_secret.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/airlock/oauth/test_refresh.py
+++ b/airlock/oauth/test_refresh.py
@@ -94,6 +94,24 @@ async def test_refresh_loop_skips_fresh_token(provider: GenericOAuth2Provider) -
     mock_store.write_token.assert_not_called()
 
 
+async def test_refresh_loop_reconciles_annotations_without_refresh(provider: GenericOAuth2Provider) -> None:
+    # Annotations are reconciled every pass even when the token is fresh and never rewritten —
+    # this is what lets a config-level reflector-target change reach the live secret.
+    provider.config.access_secret.annotations = {"reflector/ns": "openclaw-sandbox,plaid-mcp"}
+    mock_store = AsyncMock()
+    mock_store.read_token.return_value = _make_token(hours_until_expiry=720)
+
+    with patch.object(provider, "refresh_tokens") as mock_refresh:
+        await _run_loop_briefly({"test": provider}, mock_store, "test-ns")
+
+    mock_refresh.assert_not_called()
+    mock_store.write_token.assert_not_called()
+    mock_store.reconcile_annotations.assert_any_call(
+        "test-access-token", "test-ns", {"reflector/ns": "openclaw-sandbox,plaid-mcp"}
+    )
+    mock_store.reconcile_annotations.assert_any_call("test-tokens", "test-ns", {})
+
+
 async def test_refresh_loop_skips_unconnected_provider(provider: GenericOAuth2Provider) -> None:
     mock_store = AsyncMock()
     mock_store.read_token.return_value = None


### PR DESCRIPTION
Adds `K8sTokenStore.reconcile_annotations()` and calls it from the token refresh loop for every provider's refresh + access secret on every pass — even when the token doesn't change.

## Why

airlock only (re)writes a managed token secret when it writes a token. For providers whose tokens never refresh (e.g. Plaid access tokens, which never expire), a config-level annotation change — like adding a reflector target namespace to an `access_secret` — never reached the live secret without a manual re-link. Now it propagates on the next refresh-loop pass.

## What

- `reconcile_annotations(secret, ns, annotations)` merges the configured annotations onto an existing managed secret (adds/updates the configured keys, leaves any others; no-op when already in sync or when the secret doesn't exist yet). Does not touch token data.
- The refresh loop reconciles annotations for each provider's refresh + access secret every pass (runs on startup and every `check_interval`), independent of `needs_refresh`.

## Tests

- `airlock/oauth/test_k8s_client.py` (new): patch-on-drift / no-op-when-in-sync / no-op-when-absent / no-op-when-no-annotations-configured.
- `airlock/oauth/test_refresh.py`: reconciliation runs for a fresh, non-refreshed token.

`bbr test //airlock/oauth/...` green.

Split out of the in-progress Plaid MCP work so it can be reviewed/merged independently. (Supersedes #1736, which was from a fork and couldn't run secret-dependent CI.)

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_