### PR TITLE
simplify airlock secret distribution: drop Reflector, use ESO

### DIFF
--- a/airlock/oauth/k8s_client.py
+++ b/airlock/oauth/k8s_client.py
@@ -35,7 +35,6 @@ class K8sTokenStore:
         token: TokenData,
         *,
         fields: frozenset[str] = ALL_TOKEN_FIELDS,
-        annotations: dict[str, str] | None = None,
     ) -> None:
         data = {k: v for k, v in token.model_dump(mode="json").items() if k in fields}
         secret = client.V1Secret(
@@ -43,7 +42,6 @@ class K8sTokenStore:
                 name=secret_name,
                 namespace=namespace,
                 labels={"app.kubernetes.io/managed-by": self._managed_by},
-                annotations=annotations or None,
             ),
             string_data=data,
             type="Opaque",
@@ -59,28 +57,6 @@ class K8sTokenStore:
                 logger.info(f"Created secret {namespace}/{secret_name}")
             else:
                 raise
-
-    async def reconcile_annotations(self, secret_name: str, namespace: str, annotations: dict[str, str]) -> None:
-        """Ensure a managed secret carries the configured annotations, without rewriting token data.
-
-        Merges (adds/updates the configured keys; leaves any others). This lets config-level
-        annotation changes — e.g. adding a reflector target namespace — reach already-written
-        secrets even when the token itself never changes. Plaid access tokens, for instance,
-        never refresh, so without this they would keep stale annotations until the next re-link.
-        """
-        if not annotations:
-            return
-        try:
-            secret = await self._api.read_namespaced_secret(secret_name, namespace)
-        except ApiException as e:
-            if e.status == 404:
-                return  # provider not linked yet — nothing to reconcile
-            raise
-        current = secret.metadata.annotations or {}
-        if all(current.get(key) == value for key, value in annotations.items()):
-            return  # already in sync
-        await self._api.patch_namespaced_secret(secret_name, namespace, {"metadata": {"annotations": annotations}})
-        logger.info(f"Reconciled annotations on secret {namespace}/{secret_name}")
 
     async def delete_orphaned_secrets(self, namespace: str, known_names: frozenset[str]) -> None:
         """Delete managed secrets whose names are not in known_names."""

--- a/airlock/oauth/provider.py
+++ b/airlock/oauth/provider.py
@@ -28,7 +28,6 @@ def generate_pkce_pair() -> tuple[str, str]:
 
 class TokenSecretConfig(BaseModel):
     name: str
-    annotations: dict[str, str] = Field(default_factory=dict)
 
 
 class BaseProviderConfig(BaseModel):

--- a/airlock/oauth/refresh.py
+++ b/airlock/oauth/refresh.py
@@ -45,13 +45,6 @@ async def token_refresh_loop(
     warned_scope_drifts: set[tuple[str, str]] = set()
     while True:
         for name, provider in providers.items():
-            # Reconcile managed-secret annotations (e.g. reflector target namespaces) on every
-            # pass, even when the token never changes, so config edits propagate without a re-link.
-            for secret_cfg in (provider.config.refresh_secret, provider.config.access_secret):
-                try:
-                    await k8s_store.reconcile_annotations(secret_cfg.name, target_namespace, secret_cfg.annotations)
-                except Exception:
-                    logger.exception(f"Failed to reconcile annotations for {secret_cfg.name}")
             try:
                 token = await k8s_store.read_token(provider.config.refresh_secret.name, target_namespace)
                 if token is None:
@@ -62,18 +55,9 @@ async def token_refresh_loop(
                     continue
                 logger.info(f"Refreshing token for {name} (expires {token.expires_at})")
                 new_token = await provider.refresh_tokens(token.refresh_token)
+                await k8s_store.write_token(provider.config.refresh_secret.name, target_namespace, new_token)
                 await k8s_store.write_token(
-                    provider.config.refresh_secret.name,
-                    target_namespace,
-                    new_token,
-                    annotations=provider.config.refresh_secret.annotations or None,
-                )
-                await k8s_store.write_token(
-                    provider.config.access_secret.name,
-                    target_namespace,
-                    new_token,
-                    annotations=provider.config.access_secret.annotations or None,
-                    fields=ACCESS_TOKEN_FIELDS,
+                    provider.config.access_secret.name, target_namespace, new_token, fields=ACCESS_TOKEN_FIELDS
                 )
                 logger.info(f"Refreshed token for {name} (new expiry {new_token.expires_at})")
             except Exception:

--- a/airlock/oauth/routes.py
+++ b/airlock/oauth/routes.py
@@ -99,18 +99,9 @@ def create_oauth_router(providers: dict[str, Provider], k8s_store: K8sTokenStore
             raise HTTPException(400, "State/provider mismatch")
 
         token = await provider.exchange_code(code, code_verifier=pending.code_verifier)
+        await k8s_store.write_token(provider.config.refresh_secret.name, target_namespace, token)
         await k8s_store.write_token(
-            provider.config.refresh_secret.name,
-            target_namespace,
-            token,
-            annotations=provider.config.refresh_secret.annotations or None,
-        )
-        await k8s_store.write_token(
-            provider.config.access_secret.name,
-            target_namespace,
-            token,
-            annotations=provider.config.access_secret.annotations or None,
-            fields=ACCESS_TOKEN_FIELDS,
+            provider.config.access_secret.name, target_namespace, token, fields=ACCESS_TOKEN_FIELDS
         )
         logger.info(f"Stored tokens for {provider_name} (expires {token.expires_at})")
         return RedirectResponse("/#/oauth")
@@ -124,18 +115,9 @@ def create_oauth_router(providers: dict[str, Provider], k8s_store: K8sTokenStore
         if not isinstance(provider, PlaidProvider):
             raise HTTPException(405, f"{provider_name} does not support POST callback")
         token = await provider.exchange_public_token(body.public_token)
+        await k8s_store.write_token(provider.config.refresh_secret.name, target_namespace, token)
         await k8s_store.write_token(
-            provider.config.refresh_secret.name,
-            target_namespace,
-            token,
-            annotations=provider.config.refresh_secret.annotations or None,
-        )
-        await k8s_store.write_token(
-            provider.config.access_secret.name,
-            target_namespace,
-            token,
-            annotations=provider.config.access_secret.annotations or None,
-            fields=ACCESS_TOKEN_FIELDS,
+            provider.config.access_secret.name, target_namespace, token, fields=ACCESS_TOKEN_FIELDS
         )
         logger.info(f"Stored Plaid tokens for {provider_name}")
         return RedirectResponse("/#/oauth", status_code=303)

--- a/airlock/oauth/test_provider.py
+++ b/airlock/oauth/test_provider.py
@@ -249,10 +249,7 @@ def test_oauth_config_from_dict() -> None:
                 "scopes": ["a"],
                 "redirect_uri": "http://localhost/callback/test",
                 "refresh_secret": {"name": "test-tokens"},
-                "access_secret": {
-                    "name": "test-access-token",
-                    "annotations": {"reflector.v1.k8s.emberstack.com/reflection-allowed": "true"},
-                },
+                "access_secret": {"name": "test-access-token"},
             }
         ],
     }
@@ -262,9 +259,6 @@ def test_oauth_config_from_dict() -> None:
     assert config.providers[0].name == "test"
     assert config.providers[0].refresh_secret.name == "test-tokens"
     assert config.providers[0].access_secret.name == "test-access-token"
-    assert config.providers[0].access_secret.annotations == {
-        "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
-    }
 
 
 def test_oauth_config_defaults() -> None:

--- a/airlock/oauth/test_refresh.py
+++ b/airlock/oauth/test_refresh.py
@@ -75,10 +75,8 @@ async def test_refresh_loop_refreshes_expiring_token(provider: GenericOAuth2Prov
         await _run_loop_briefly({"test": provider}, mock_store, "test-ns")
 
     mock_store.read_token.assert_called_with("test-tokens", "test-ns")
-    mock_store.write_token.assert_any_call("test-tokens", "test-ns", refreshed_token, annotations=None)
-    mock_store.write_token.assert_any_call(
-        "test-access-token", "test-ns", refreshed_token, annotations=None, fields=ACCESS_TOKEN_FIELDS
-    )
+    mock_store.write_token.assert_any_call("test-tokens", "test-ns", refreshed_token)
+    mock_store.write_token.assert_any_call("test-access-token", "test-ns", refreshed_token, fields=ACCESS_TOKEN_FIELDS)
 
 
 async def test_refresh_loop_skips_fresh_token(provider: GenericOAuth2Provider) -> None:
@@ -92,24 +90,6 @@ async def test_refresh_loop_skips_fresh_token(provider: GenericOAuth2Provider) -
 
     mock_refresh.assert_not_called()
     mock_store.write_token.assert_not_called()
-
-
-async def test_refresh_loop_reconciles_annotations_without_refresh(provider: GenericOAuth2Provider) -> None:
-    # Annotations are reconciled every pass even when the token is fresh and never rewritten —
-    # this is what lets a config-level reflector-target change reach the live secret.
-    provider.config.access_secret.annotations = {"reflector/ns": "openclaw-sandbox,plaid-mcp"}
-    mock_store = AsyncMock()
-    mock_store.read_token.return_value = _make_token(hours_until_expiry=720)
-
-    with patch.object(provider, "refresh_tokens") as mock_refresh:
-        await _run_loop_briefly({"test": provider}, mock_store, "test-ns")
-
-    mock_refresh.assert_not_called()
-    mock_store.write_token.assert_not_called()
-    mock_store.reconcile_annotations.assert_any_call(
-        "test-access-token", "test-ns", {"reflector/ns": "openclaw-sandbox,plaid-mcp"}
-    )
-    mock_store.reconcile_annotations.assert_any_call("test-tokens", "test-ns", {})
 
 
 async def test_refresh_loop_skips_unconnected_provider(provider: GenericOAuth2Provider) -> None:

--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -36,11 +36,6 @@ oauth:
         name: oura-tokens
       access_secret:
         name: oura-access-token
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
       refresh_margin_seconds: 3600
     - name: google
       provider_type: oauth2
@@ -60,11 +55,6 @@ oauth:
         name: google-tokens
       access_secret:
         name: google-access-token
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
       refresh_margin_seconds: 300
       extra_auth_params:
         access_type: offline
@@ -81,11 +71,6 @@ oauth:
         name: plaid-chase-tokens
       access_secret:
         name: plaid-chase-access-token
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
     - name: plaid_bofa
       provider_type: plaid
       display_name: Plaid (BofA)
@@ -98,11 +83,6 @@ oauth:
         name: plaid-bofa-tokens
       access_secret:
         name: plaid-bofa-access-token
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: openclaw-sandbox,claude-sandbox
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: openclaw-sandbox,claude-sandbox
     - name: bsc
       provider_type: oauth2
       display_name: Blue Shield of California (FHIR sandbox)
@@ -123,7 +103,6 @@ oauth:
       redirect_uri: https://airlock.allegedly.works/oauth/callback/bsc
       refresh_secret:
         name: bsc-tokens
-      # Not reflected to sandbox namespaces yet — keep BSC tokens in `airlock` only.
       access_secret:
         name: bsc-access-token
       refresh_margin_seconds: 300

--- a/cluster/k8s/agents/airlock/eso-access-tokens.yaml
+++ b/cluster/k8s/agents/airlock/eso-access-tokens.yaml
@@ -1,131 +1,78 @@
-# ExternalSecrets that distribute airlock OAuth access tokens to sandbox namespaces.
+# ClusterExternalSecrets distribute airlock OAuth access tokens to sandbox namespaces.
 # Airlock writes the source secrets into the `airlock` namespace; ESO mirrors them here.
-# refreshInterval: 1m keeps sandbox copies fresh within one refresh cycle.
 ---
 apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+kind: ClusterExternalSecret
 metadata:
   name: oura-access-token
-  namespace: openclaw-sandbox
 spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: oura-access-token
-  dataFrom:
-    - extract:
-        key: oura-access-token
+  namespaces:
+    - openclaw-sandbox
+    - claude-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-airlock-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: oura-access-token
+    dataFrom:
+      - extract:
+          key: oura-access-token
 ---
 apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: oura-access-token
-  namespace: claude-sandbox
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: oura-access-token
-  dataFrom:
-    - extract:
-        key: oura-access-token
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+kind: ClusterExternalSecret
 metadata:
   name: google-access-token
-  namespace: openclaw-sandbox
 spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: google-access-token
-  dataFrom:
-    - extract:
-        key: google-access-token
+  namespaces:
+    - openclaw-sandbox
+    - claude-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-airlock-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: google-access-token
+    dataFrom:
+      - extract:
+          key: google-access-token
 ---
 apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: google-access-token
-  namespace: claude-sandbox
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: google-access-token
-  dataFrom:
-    - extract:
-        key: google-access-token
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+kind: ClusterExternalSecret
 metadata:
   name: plaid-chase-access-token
-  namespace: openclaw-sandbox
 spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: plaid-chase-access-token
-  dataFrom:
-    - extract:
-        key: plaid-chase-access-token
+  namespaces:
+    - openclaw-sandbox
+    - claude-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-airlock-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: plaid-chase-access-token
+    dataFrom:
+      - extract:
+          key: plaid-chase-access-token
 ---
 apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: plaid-chase-access-token
-  namespace: claude-sandbox
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: plaid-chase-access-token
-  dataFrom:
-    - extract:
-        key: plaid-chase-access-token
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
+kind: ClusterExternalSecret
 metadata:
   name: plaid-bofa-access-token
-  namespace: openclaw-sandbox
 spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: plaid-bofa-access-token
-  dataFrom:
-    - extract:
-        key: plaid-bofa-access-token
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: plaid-bofa-access-token
-  namespace: claude-sandbox
-spec:
-  refreshInterval: 1m
-  secretStoreRef:
-    name: kubernetes-airlock-secret-store
-    kind: ClusterSecretStore
-  target:
-    name: plaid-bofa-access-token
-  dataFrom:
-    - extract:
-        key: plaid-bofa-access-token
+  namespaces:
+    - openclaw-sandbox
+    - claude-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-airlock-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: plaid-bofa-access-token
+    dataFrom:
+      - extract:
+          key: plaid-bofa-access-token

--- a/cluster/k8s/agents/airlock/eso-access-tokens.yaml
+++ b/cluster/k8s/agents/airlock/eso-access-tokens.yaml
@@ -1,0 +1,131 @@
+# ExternalSecrets that distribute airlock OAuth access tokens to sandbox namespaces.
+# Airlock writes the source secrets into the `airlock` namespace; ESO mirrors them here.
+# refreshInterval: 1m keeps sandbox copies fresh within one refresh cycle.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oura-access-token
+  namespace: openclaw-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: oura-access-token
+  dataFrom:
+    - extract:
+        key: oura-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oura-access-token
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: oura-access-token
+  dataFrom:
+    - extract:
+        key: oura-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: google-access-token
+  namespace: openclaw-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: google-access-token
+  dataFrom:
+    - extract:
+        key: google-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: google-access-token
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: google-access-token
+  dataFrom:
+    - extract:
+        key: google-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plaid-chase-access-token
+  namespace: openclaw-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: plaid-chase-access-token
+  dataFrom:
+    - extract:
+        key: plaid-chase-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plaid-chase-access-token
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: plaid-chase-access-token
+  dataFrom:
+    - extract:
+        key: plaid-chase-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plaid-bofa-access-token
+  namespace: openclaw-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: plaid-bofa-access-token
+  dataFrom:
+    - extract:
+        key: plaid-bofa-access-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plaid-bofa-access-token
+  namespace: claude-sandbox
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: kubernetes-airlock-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: plaid-bofa-access-token
+  dataFrom:
+    - extract:
+        key: plaid-bofa-access-token

--- a/cluster/k8s/agents/airlock/kustomization.yaml
+++ b/cluster/k8s/agents/airlock/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - service.yaml
   - httproute.yaml
   - ciliumnetworkpolicy.yaml
+  - eso-access-tokens.yaml
 
 configMapGenerator:
   - name: airlock-config

--- a/cluster/k8s/external-secrets/config/airlock-secret-store.yaml
+++ b/cluster/k8s/external-secrets/config/airlock-secret-store.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-airlock-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: default
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets-system
+      remoteNamespace: airlock

--- a/cluster/k8s/external-secrets/config/external-secrets-config.yaml
+++ b/cluster/k8s/external-secrets/config/external-secrets-config.yaml
@@ -74,22 +74,3 @@ spec:
           name: external-secrets
           namespace: external-secrets-system
       remoteNamespace: openhands
----
-apiVersion: external-secrets.io/v1
-kind: ClusterSecretStore
-metadata:
-  name: kubernetes-airlock-secret-store
-spec:
-  provider:
-    kubernetes:
-      server:
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: default
-      auth:
-        serviceAccount:
-          name: external-secrets
-          namespace: external-secrets-system
-      remoteNamespace: airlock

--- a/cluster/k8s/external-secrets/config/external-secrets-config.yaml
+++ b/cluster/k8s/external-secrets/config/external-secrets-config.yaml
@@ -74,3 +74,22 @@ spec:
           name: external-secrets
           namespace: external-secrets-system
       remoteNamespace: openhands
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-airlock-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: default
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets-system
+      remoteNamespace: airlock

--- a/cluster/k8s/external-secrets/config/kustomization.yaml
+++ b/cluster/k8s/external-secrets/config/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - external-secrets-config.yaml # ClusterSecretStore only
+  - external-secrets-config.yaml
+  - airlock-secret-store.yaml


### PR DESCRIPTION
Airlock no longer stamps Reflector annotations onto OAuth access-token
secrets. Instead, ESO ExternalSecrets in openclaw-sandbox and claude-sandbox
pull the tokens directly from the airlock namespace via a new
kubernetes-airlock-secret-store ClusterSecretStore.

Changes:
- Remove TokenSecretConfig.annotations field and all annotation-passing code
  (write_token annotations param, reconcile_annotations method and its
  reconciliation loop in the refresh task)
- Strip reflector annotation blocks from config.yaml for oura, google,
  plaid_chase, plaid_bofa access_secrets
- Add kubernetes-airlock-secret-store ClusterSecretStore pointing at airlock ns
- Add eso-access-tokens.yaml with ExternalSecrets for the 4 access tokens
  in both openclaw-sandbox and claude-sandbox (1m refreshInterval)

https://claude.ai/code/session_019dRANJe45boci1Ac4g7p4J