### PR TITLE
cluster: drop redundant ServiceAccounts, disable token automount

### DIFF
--- a/cluster/k8s/activitywatch/deployment.yaml
+++ b/cluster/k8s/activitywatch/deployment.yaml
@@ -19,7 +19,8 @@ spec:
       labels:
         app.kubernetes.io/name: activitywatch
     spec:
-      serviceAccountName: activitywatch
+      # No Kubernetes API access; don't mount a SA token.
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 999
       nodeSelector:

--- a/cluster/k8s/activitywatch/kustomization.yaml
+++ b/cluster/k8s/activitywatch/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - deployment.yaml
-  - rbac.yaml
   - pvc.yaml
   - service.yaml
   - cilium-network-policy.yaml

--- a/cluster/k8s/activitywatch/rbac.yaml
+++ b/cluster/k8s/activitywatch/rbac.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: activitywatch
-  namespace: activitywatch

--- a/cluster/k8s/agents/claude-jwt-rotation/alloy-otlp-cronjob.yaml
+++ b/cluster/k8s/agents/claude-jwt-rotation/alloy-otlp-cronjob.yaml
@@ -21,7 +21,8 @@ spec:
       backoffLimit: 2
       template:
         spec:
-          serviceAccountName: claude-jwt-rotator
+          # No Kubernetes API access; don't mount a SA token.
+          automountServiceAccountToken: false
           restartPolicy: OnFailure
           volumes:
             - name: authentik-client

--- a/cluster/k8s/agents/claude-jwt-rotation/cronjob.yaml
+++ b/cluster/k8s/agents/claude-jwt-rotation/cronjob.yaml
@@ -21,7 +21,8 @@ spec:
       backoffLimit: 2
       template:
         spec:
-          serviceAccountName: claude-jwt-rotator
+          # No Kubernetes API access; don't mount a SA token.
+          automountServiceAccountToken: false
           restartPolicy: OnFailure
           volumes:
             - name: authentik-client

--- a/cluster/k8s/agents/claude-jwt-rotation/kustomization.yaml
+++ b/cluster/k8s/agents/claude-jwt-rotation/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
-  - serviceaccount.yaml
   - cronjob.yaml
   - alloy-otlp-cronjob.yaml
 configMapGenerator:

--- a/cluster/k8s/agents/claude-jwt-rotation/serviceaccount.yaml
+++ b/cluster/k8s/agents/claude-jwt-rotation/serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: claude-jwt-rotator
-  namespace: agents-infra
-  annotations:
-    description: "Runs the Authentik JWT rotator CronJobs. No cluster-level perms — mounts client_credentials Secrets, pushes JWTs to git."

--- a/cluster/k8s/agents/homeassistant-proxy/deployment.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/deployment.yaml
@@ -19,7 +19,8 @@ spec:
       labels:
         app.kubernetes.io/name: homeassistant-proxy
     spec:
-      serviceAccountName: homeassistant-proxy
+      # No Kubernetes API access; don't mount a SA token.
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 1000
       containers:

--- a/cluster/k8s/agents/homeassistant-proxy/kustomization.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - namespace.yaml
   - ha-token.sops.yaml
   - proxy-tokens-eso.yaml
-  - serviceaccount.yaml
   - deployment.yaml
   - service.yaml
 generatorOptions:

--- a/cluster/k8s/agents/homeassistant-proxy/serviceaccount.yaml
+++ b/cluster/k8s/agents/homeassistant-proxy/serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: homeassistant-proxy
-  namespace: homeassistant-proxy

--- a/cluster/k8s/agents/manifold-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/deployment.yaml
@@ -18,7 +18,8 @@ spec:
       labels:
         app.kubernetes.io/name: manifold-mcp
     spec:
-      serviceAccountName: manifold-mcp
+      # No Kubernetes API access; don't mount a SA token.
+      automountServiceAccountToken: false
       enableServiceLinks: false
       containers:
         - name: manifold-mcp-server

--- a/cluster/k8s/agents/manifold-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - serviceaccount.yaml
   - configmap.yaml
   - api-key.sops.yaml
   - valkey-kimsufi-instance.yaml

--- a/cluster/k8s/agents/manifold-mcp/app/serviceaccount.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: manifold-mcp
-  namespace: manifold-mcp
-  annotations:
-    description: "SA for the Manifold MCP facade pod. No k8s permissions — Manifold auth is via the static API key in manifold-mcp-api-key Secret."

--- a/cluster/k8s/agents/postscanmail-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/deployment.yaml
@@ -18,7 +18,8 @@ spec:
       labels:
         app.kubernetes.io/name: postscanmail-mcp
     spec:
-      serviceAccountName: postscanmail-mcp
+      # No Kubernetes API access; don't mount a SA token.
+      automountServiceAccountToken: false
       enableServiceLinks: false
       containers:
         - name: postscanmail-mcp-server

--- a/cluster/k8s/agents/postscanmail-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - serviceaccount.yaml
   - configmap.yaml
   - api-key.sops.yaml
   - valkey-kimsufi-instance.yaml

--- a/cluster/k8s/agents/postscanmail-mcp/app/serviceaccount.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: postscanmail-mcp
-  namespace: postscanmail-mcp
-  annotations:
-    description: "SA for the PostScan Mail MCP facade pod. No k8s permissions — PostScan Mail auth is via the static x-api-key in the postscanmail-mcp-api-key Secret."


### PR DESCRIPTION
Five services declared a dedicated `ServiceAccount` that earns its keep nowhere: no `Role`/`RoleBinding`/`ClusterRoleBinding` references them (whole-repo grep), and the pods make no Kubernetes API calls — so each is functionally identical to the namespace `default` SA, except it needlessly mounts an unused SA token.

Removed the SA and set `automountServiceAccountToken: false` on the pod for:

- **manifold-mcp**, **postscanmail-mcp** — MCP facades reaching their upstream API via a static key.
- **homeassistant-proxy** — proxies to Home Assistant.
- **activitywatch** — aw-server + Nebula sidecar; SQLite only.
- **claude-jwt-rotator** — CronJobs that `curl`/`git commit` (both jobs updated); no API.

(Surfaced while removing the same vestigial SA from the new `plaid-mcp`. The two
`kubectl-*-mcp` SAs were **excluded** — `kubernetes-mcp-server` likely relies on the
projected SA token/CA for its in-cluster API connection, so those need a closer look.)

kubeconform + the cluster validator pass.

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_