### PR TITLE
cluster/validation: enforce image-automation ↔ webhook consistency

### DIFF
--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -108,6 +108,12 @@ py_library(
 )
 
 py_library(
+    name = "image_automation",
+    srcs = ["image_automation.py"],
+    deps = ["@pypi//pyyaml"],
+)
+
+py_library(
     name = "validate_all",
     srcs = ["validate_all.py"],
     deps = [
@@ -118,6 +124,7 @@ py_library(
         ":flux",
         ":health_checks",
         ":helm_templates",
+        ":image_automation",
         ":kustomize",
     ],
 )
@@ -282,5 +289,15 @@ py_test(
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
+    ],
+)
+
+py_test(
+    name = "test_image_automation",
+    srcs = ["test_image_automation.py"],
+    deps = [
+        ":image_automation",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )

--- a/cluster/validation/image_automation.py
+++ b/cluster/validation/image_automation.py
@@ -1,0 +1,60 @@
+"""Consistency between Flux image automation and the GitHub webhook receiver.
+
+Every `ImageRepository` must be listed in the `flux-webhook` GitHub `Receiver` so a push /
+`registry_package` webhook reconciles it immediately — otherwise new GHCR tags are only
+picked up on the 5-minute `ImageRepository` poll. Also checks that every `ImagePolicy`
+references a defined `ImageRepository`, and that the webhook doesn't reference one that no
+longer exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _docs(path: Path) -> list[Any]:
+    if not path.exists():
+        return []
+    return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict) and d.get("kind")]
+
+
+def check_image_automation_webhook(root: Path) -> list[str]:
+    image_repos: set[str] = set()
+    policy_refs: dict[str, Any] = {}
+    for f in sorted(root.rglob("*.yaml")):
+        if f.name.endswith(".sops.yaml"):
+            continue
+        for doc in _docs(f):
+            if doc["kind"] == "ImageRepository":
+                image_repos.add((doc.get("metadata") or {}).get("name"))
+            elif doc["kind"] == "ImagePolicy":
+                ref = ((doc.get("spec") or {}).get("imageRepositoryRef") or {}).get("name")
+                policy_refs[(doc.get("metadata") or {}).get("name")] = ref
+
+    webhook_repos: set[str] = set()
+    for doc in _docs(root / "flux-webhook" / "github-webhook-receiver.yaml"):
+        if doc["kind"] == "Receiver":
+            for ref in (doc.get("spec") or {}).get("resources") or []:
+                if isinstance(ref, dict) and ref.get("kind") == "ImageRepository":
+                    webhook_repos.add(ref.get("name"))
+
+    return [
+        *(
+            f"ImageRepository '{name}' is not listed in flux-webhook/github-webhook-receiver.yaml; "
+            "new GHCR tags will only be picked up on the 5m poll, not on push. Add it to the Receiver's resources."
+            for name in sorted(image_repos - webhook_repos)
+        ),
+        *(
+            f"flux-webhook/github-webhook-receiver.yaml references ImageRepository '{name}', "
+            "but no such ImageRepository is defined under cluster/k8s."
+            for name in sorted(webhook_repos - image_repos)
+        ),
+        *(
+            f"ImagePolicy '{policy}' references ImageRepository '{ref}', which is not defined."
+            for policy, ref in sorted(policy_refs.items())
+            if ref not in image_repos
+        ),
+    ]

--- a/cluster/validation/test_image_automation.py
+++ b/cluster/validation/test_image_automation.py
@@ -1,0 +1,76 @@
+"""Tests for check_image_automation_webhook."""
+
+from pathlib import Path
+
+import pytest_bazel
+
+from cluster.validation.image_automation import check_image_automation_webhook
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def _repo(name: str) -> str:
+    return (
+        "apiVersion: image.toolkit.fluxcd.io/v1beta2\n"
+        "kind: ImageRepository\n"
+        f"metadata: {{name: {name}, namespace: flux-system}}\n"
+    )
+
+
+def _policy(name: str, repo: str) -> str:
+    return (
+        "apiVersion: image.toolkit.fluxcd.io/v1\n"
+        "kind: ImagePolicy\n"
+        f"metadata: {{name: {name}, namespace: flux-system}}\n"
+        f"spec: {{imageRepositoryRef: {{name: {repo}}}}}\n"
+    )
+
+
+def _receiver(repos: list[str]) -> str:
+    lines = "\n".join(
+        f"    - {{apiVersion: image.toolkit.fluxcd.io/v1beta2, kind: ImageRepository, name: {r}}}" for r in repos
+    )
+    return (
+        "apiVersion: notification.toolkit.fluxcd.io/v1\n"
+        "kind: Receiver\n"
+        "metadata: {name: github, namespace: flux-system}\n"
+        "spec:\n"
+        "  type: github\n"
+        "  resources:\n"
+        f"{lines}\n"
+    )
+
+
+def test_consistent_is_clean(tmp_path: Path) -> None:
+    _write(tmp_path, "flux-image-automation-ghcr/foo.yaml", _repo("foo") + "---\n" + _policy("foo", "foo"))
+    _write(tmp_path, "flux-webhook/github-webhook-receiver.yaml", _receiver(["foo"]))
+    assert check_image_automation_webhook(tmp_path) == []
+
+
+def test_repository_missing_from_webhook(tmp_path: Path) -> None:
+    _write(tmp_path, "flux-image-automation-ghcr/foo.yaml", _repo("foo") + "---\n" + _policy("foo", "foo"))
+    _write(tmp_path, "flux-webhook/github-webhook-receiver.yaml", _receiver([]))
+    errors = check_image_automation_webhook(tmp_path)
+    assert any("foo" in e and "github-webhook-receiver" in e for e in errors)
+
+
+def test_stale_webhook_entry(tmp_path: Path) -> None:
+    _write(tmp_path, "flux-image-automation-ghcr/foo.yaml", _repo("foo") + "---\n" + _policy("foo", "foo"))
+    _write(tmp_path, "flux-webhook/github-webhook-receiver.yaml", _receiver(["foo", "gone"]))
+    errors = check_image_automation_webhook(tmp_path)
+    assert any("gone" in e for e in errors)
+
+
+def test_dangling_policy_reference(tmp_path: Path) -> None:
+    _write(tmp_path, "flux-image-automation-ghcr/bar.yaml", _policy("bar", "ghost"))
+    _write(tmp_path, "flux-webhook/github-webhook-receiver.yaml", _receiver([]))
+    errors = check_image_automation_webhook(tmp_path)
+    assert any("bar" in e and "ghost" in e for e in errors)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/cluster/validation/validate_all.py
+++ b/cluster/validation/validate_all.py
@@ -15,6 +15,9 @@ Checks:
    enable in pre-commit with DUCKTAPE_HELM_VALIDATE=1)
 9. Blueprint completeness: All authentik blueprint files must be listed in configMapGenerator
 10. Goldilocks explicit decision: Namespaces with workloads must explicitly set goldilocks enabled label
+11. Image automation <-> webhook: every ImageRepository is listed in the GitHub webhook
+    receiver (so pushes reconcile immediately, not just on the 5m poll), and every ImagePolicy
+    references a defined ImageRepository
 
 See AGENTS.md section "Flux Kustomization Layering" for CRD layering details.
 """
@@ -38,6 +41,7 @@ from cluster.validation.dependencies import validate_dependencies
 from cluster.validation.flux import validate_flux_build
 from cluster.validation.health_checks import check_controller_health_checks
 from cluster.validation.helm_templates import validate_helm_templates
+from cluster.validation.image_automation import check_image_automation_webhook
 from cluster.validation.kustomize import KustomizeBuildError, run_kustomize_build
 
 
@@ -81,6 +85,7 @@ async def validate(
     errors.extend(check_goldilocks_explicit_decision(cluster))
     errors.extend(validate_dependencies(cluster, root))
     errors.extend(check_controller_health_checks(cluster, root))
+    errors.extend(check_image_automation_webhook(root))
 
     if not skip_flux_build:
         errors.extend(await validate_flux_build(root))


### PR DESCRIPTION
Adds a cluster-validation check (`check_image_automation_webhook`, wired into `validate_all`) that enforces the image-automation invariant `container-images.md` documents but is easy to forget when adding an image:

- every `ImageRepository` must be listed in the `flux-webhook` GitHub `Receiver` (otherwise new GHCR tags are only picked up on the 5-minute `ImageRepository` poll, not on push);
- every `ImagePolicy` must reference a defined `ImageRepository`;
- the webhook must not reference an `ImageRepository` that no longer exists.

It runs in pre-commit (the `ducktape pre-commit` cluster validator) and the `test_cluster_integration` Bazel test, so it covers the real cluster as well as the focused unit tests in `test_image_automation.py`. The cluster is currently consistent (21 repos / 21 policies / 21 webhook refs), so this is green today and guards future additions.

`bbr test //cluster/validation:test_image_automation //cluster/validation:test_cluster_integration` green.

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_