### PR TITLE
augur/api: repo-agnostic runfiles lookup in export_schema

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -346,6 +346,23 @@ py_binary(
     deps = [":export_schema"],
 )
 
+py_test(
+    name = "export_schema_test",
+    srcs = ["test_export_schema.py"],
+    # Source follows the test_<module>.py convention while the target keeps the
+    # conventional <name>_test label, so the inferred main wouldn't match srcs.
+    main = "test_export_schema.py",
+    data = [
+        ":public_fixture_calibration_catalog",
+        ":public_fixture_config",
+        ":public_fixture_properties",
+    ],
+    deps = [
+        ":export_schema",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 filegroup(
     name = "public_fixture_config",
     srcs = ["testdata/config.yaml"],

--- a/augur/api/test_export_schema.py
+++ b/augur/api/test_export_schema.py
@@ -1,0 +1,39 @@
+"""Test that export_schema emits a valid OpenAPI doc from its own-repo fixture.
+
+This exercises the repo-agnostic fixture lookup the frontend Zod codegen relies on
+(`get_required_own_repo_path("augur/api/testdata/config.yaml")`): it must resolve
+the `data`-dep fixture and build the real app end to end. Running as the ducktape
+main repo proves the `_main` runfiles prefix still resolves after the migration off
+the previously-hardcoded prefix.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+import pytest_bazel
+
+from augur.api import export_schema
+
+
+def test_export_schema_emits_openapi_with_components() -> None:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        export_schema.main()
+    doc = json.loads(buffer.getvalue())
+
+    # A well-formed OpenAPI document with the component schemas the frontend's
+    # Zod/TS codegen consumes.
+    assert doc["openapi"].startswith("3.")
+    assert doc["paths"], "expected the fixture app to register routes"
+    assert doc["components"]["schemas"], "expected component schemas for Zod codegen"
+    # The calibration routes are the reason the fixture builds the full app; their
+    # presence confirms the fixture config (and its calibration catalog data dep)
+    # resolved, not a degenerate empty app.
+    assert any(path.startswith("/api/calibration/") for path in doc["paths"])
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/util/bazel/BUILD.bazel
+++ b/util/bazel/BUILD.bazel
@@ -15,6 +15,15 @@ py_library(
     deps = ["@rules_python//python/runfiles"],
 )
 
+py_test(
+    name = "test_runfiles",
+    srcs = ["test_runfiles.py"],
+    deps = [
+        ":runfiles",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 py_library(
     name = "subprocess",
     srcs = ["subprocess.py"],

--- a/util/bazel/runfiles.py
+++ b/util/bazel/runfiles.py
@@ -32,3 +32,34 @@ def get_required_path(rlocation: str) -> Path:
     if not (path := Path(resolved)).exists():
         raise RuntimeError(f"Resolved path does not exist: {path}")
     return path
+
+
+def _own_repo_prefix() -> str:
+    """Canonical runfiles prefix for *this* (ducktape's) Bazel repository.
+
+    `Runfiles.CurrentRepository()` resolves the Bazel repo that owns the calling
+    `.py` file (via its frame's source path / repo-mapping). This function lives in
+    `util/bazel/runfiles.py`, which is always compiled into the ducktape repo, so
+    the lookup yields ducktape's *canonical* repo name regardless of who calls it:
+    `""` when ducktape is the Bazel main repo, or `"ducktape+"` (the canonical
+    `<module>+` name) when ducktape is consumed as an external module. The runfiles
+    tree is keyed by canonical repo name, with the main repo's tree aliased to the
+    `_main` workspace dir — hence the `_main` fallback for the empty (main) name.
+    """
+    repo = _get_runfiles().CurrentRepository()
+    return repo if repo else "_main"
+
+
+def get_required_own_repo_path(relpath: str) -> Path:
+    """Resolve a runfiles path that lives in *this* repository, repo-agnostically.
+
+    Use instead of a hardcoded `_main/`-prefixed `get_required_path` for data deps
+    that ship in ducktape's own runfiles. A literal `_main/` prefix only resolves
+    when ducktape is the Bazel main repo; an external consumer's runfiles place the
+    same data under `ducktape+/...`, so the hardcoded lookup raises. This helper
+    derives the correct prefix from the live runfiles repo-mapping instead.
+
+    Args:
+        relpath: Repo-root-relative path, e.g. "augur/api/testdata/config.yaml".
+    """
+    return get_required_path(f"{_own_repo_prefix()}/{relpath}")

--- a/util/bazel/test_runfiles.py
+++ b/util/bazel/test_runfiles.py
@@ -1,0 +1,42 @@
+"""Tests for the repo-agnostic runfiles helpers in util.bazel.runfiles."""
+
+from __future__ import annotations
+
+import pytest_bazel
+
+from util.bazel import runfiles
+
+
+def test_own_repo_prefix_is_derived_not_hardcoded() -> None:
+    # The prefix must be COMPUTED from the live runfiles repo-mapping, never a
+    # baked-in literal: CurrentRepository() yields "" for the Bazel main repo
+    # (whose tree aliases to the "_main" workspace dir) or a canonical "<module>+"
+    # name (e.g. "ducktape+") when ducktape is an external module. Mirror that here
+    # and assert the helper agrees.
+    repo = runfiles._get_runfiles().CurrentRepository()
+    assert runfiles._own_repo_prefix() == (repo if repo else "_main")
+    # Whatever the context, the prefix is a real current-repo path component, not
+    # the empty string — so the constructed rlocation is always "<repo>/<relpath>".
+    assert runfiles._own_repo_prefix()
+
+
+def test_get_required_own_repo_path_resolves_own_repo_data() -> None:
+    # runfiles.py ships in this test's runfiles via the //util/bazel:runfiles dep,
+    # so the own-repo helper must resolve it to an existing file. This exercises the
+    # full CurrentRepository() -> Rlocation() path end to end (the same path
+    # export_schema.py relies on for its fixture config).
+    resolved = runfiles.get_required_own_repo_path("util/bazel/runfiles.py")
+    assert resolved.is_file()
+
+
+def test_own_repo_helper_only_swaps_in_the_prefix() -> None:
+    # The own-repo helper must resolve to exactly what get_required_path produces
+    # for the explicit canonical prefix, proving it changes nothing about
+    # resolution beyond computing the prefix.
+    prefix = runfiles._own_repo_prefix()
+    explicit = runfiles.get_required_path(f"{prefix}/util/bazel/runfiles.py")
+    assert runfiles.get_required_own_repo_path("util/bazel/runfiles.py") == explicit
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## The bug

`augur/api/export_schema.py` (run by `//augur/api:export_schema_bin`, which the `//augur/frontend/lib:schema_zod` genrule invokes for the frontend Zod codegen) resolved its fixture config with a hardcoded `_main/` runfiles prefix:

```python
config = load_augur_config(get_required_path("_main/augur/api/testdata/config.yaml"))
```

`_main/` is the runfiles workspace dir only when ducktape is the Bazel **main** repo. When ducktape is consumed as an **external** Bazel module (gaffer-private's `@ducktape`), its runfiles live under the canonical repo name (`ducktape+/...`), so `Rlocation("_main/...")` returns a path that doesn't exist and the binary raises -- breaking any external consumer that builds the frontend schema (e.g. gaffer's `backend_dev` -> `schema_zod` -> `export_schema_bin`). The fixture *is* in runfiles (a `data` dep of `:export_schema`); only the lookup prefix was wrong.

## The fix

Repo-agnostic resolution in Python, so the generic `js_openapi_zod` macro (`devinfra/js/openapi.bzl`) needs no change:

- New helper `get_required_own_repo_path(relpath)` in `util/bazel/runfiles.py`. It derives the prefix from the live runfiles repo-mapping via `Runfiles.CurrentRepository()` instead of baking in `_main/`: `prefix = repo if repo else "_main"`, then `Rlocation(f"{prefix}/{relpath}")`.
- `export_schema.py` now calls `get_required_own_repo_path("augur/api/testdata/config.yaml")`.
- New unit test `util/bazel:test_runfiles` and integration test `augur/api:export_schema_test`.

### Why the external (`ducktape+`) case now resolves

`Runfiles.CurrentRepository(frame=1)` (default `frame=1` = the direct caller) inspects the calling `.py` file's path within the runfiles tree and returns the **canonical** name of the Bazel repo that owns it: `""` for the main repo, `"<module>+"` (i.e. `"ducktape+"`) when ducktape is an external module. The runfiles tree is keyed by canonical repo name, and the rules_python lib maps the `_main` runfiles directory back to the main repo's canonical name `""` (see its `CurrentRepository`: `if caller_runfiles_directory == "_main": ... return ""`). So:

- **main repo**: `CurrentRepository()` -> `""` -> prefix `_main` -> `Rlocation("_main/augur/api/testdata/config.yaml")` (the form that already worked).
- **external**: `CurrentRepository()` -> `"ducktape+"` -> prefix `ducktape+` -> `Rlocation("ducktape+/augur/api/testdata/config.yaml")`, exactly where an external consumer's runfiles place ducktape's `data`.

The helper lives in ducktape's own `util/bazel/runfiles.py`, and because `CurrentRepository()` resolves the repo of the *calling frame* (`_own_repo_prefix` inside that file), it always yields **ducktape's** canonical name regardless of who invokes the helper -- so it resolves ducktape's own data whether ducktape is main or external. Just swapping `_main` -> `ducktape+` would only move the breakage to the main-repo case; computing the prefix at runtime fixes both. (`frame`/`_main` semantics confirmed against the in-use rules_python runfiles lib and by the passing RBE runs below.)

## Verification (RBE)

- `bbr test //util/bazel:test_runfiles //augur/api:export_schema_test` -- both PASS, 2 of 2 (inv `eeeeedd4-f510-474f-8aa3-2eccc7cfe55b`). `export_schema_test` runs `export_schema.main()` against the fixture, proving the main-repo lookup still resolves end to end.
- `bbr build //augur/frontend/lib:schema_zod //augur/frontend/lib:_schema_zod_openapi_json //augur/api:export_schema_bin` -- build completed successfully (inv `e36d9a23-77cf-4505-bd26-41802ba85c0f`). The `_schema_zod_openapi_json` genrule runs `export_schema_bin` and emits a valid OpenAPI 3.1.0 document (7 paths incl. `/api/calibration/*`, 64 component schemas).
- `bbr test //augur/...` -- 43 of 43 test targets pass, 0 failures (inv `8936b01a-2b13-46f0-a48a-4093cd4731b9`).
- `pre-commit run --all-files` -- the only failing hook is a **pre-existing** cluster-manifest validator error (`ConstructorError: could not determine a constructor for the tag '!Find'` on `cluster/k8s/authentik/app/blueprints/*-sso.yaml`), reproduced identically on a clean checkout of `devel`; it is unrelated to this PR (which touches no YAML/cluster files). All Python/Bazel hooks pass.

## Scope

Focused on the export_schema bug + the shared helper. Other ducktape `_main/` own-repo lookups exist (e.g. `augur/visual_test.py`, `augur/api/test_calibration_endpoint.py`, `augur/browser_shell_test.py`, `util/testing/frontend_visual.py`, several under `x/`) and could adopt the same helper later, but none are on an external-consumer hot path, so they're left for follow-ups. Note: `augur/api/server.py` reads its config from `$AUGUR_CONFIG_PATH` at runtime, **not** runfiles -- it is not a magic-prefix site. (The repo's `augur/plans/typed_series_config.md` / `augur/TODO.md` "magic-prefix" plan is about series/asset *key strings* like `crypto:`/`home_value:`, an unrelated concern; no plan-doc update applies to this runfiles fix.)

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_