### PR TITLE
plaid-mcp: item registry as a YAML config file, not inline JSON env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -266,6 +266,7 @@ repos:
             # Application config files, not K8s manifests
             cluster/k8s/gatus/app/config\.yaml|
             cluster/k8s/agents/airlock/config\.yaml|
+            cluster/k8s/agents/plaid-mcp/app/items\.yaml|
             cluster/k8s/agents/grocy-mcp/envoy\.yaml|
             cluster/k8s/agents/homeassistant-proxy/config\.yaml|
             cluster/k8s/agents/claude-sandbox-firecracker/config\.yaml|

--- a/cluster/k8s/agents/plaid-mcp/app/configmap.yaml
+++ b/cluster/k8s/agents/plaid-mcp/app/configmap.yaml
@@ -15,10 +15,5 @@ data:
   MCP_FACADE_PERSISTENCE__DB: "0"
   # --- plaid-mcp-server (upstream container), non-secret settings ---
   PLAID_MCP_PLAID_ENV: "production"
-  # Item registry: each item's access token is read from the named env var (an
-  # ESO-mirrored Secret). Add items here as more accounts are linked in airlock.
-  PLAID_MCP_ITEMS_META: |
-    [
-      {"key": "chase", "institution": "Chase", "products": ["transactions", "liabilities"], "access_token_env": "PLAID_CHASE_ACCESS_TOKEN"},
-      {"key": "bofa", "institution": "Bank of America", "products": ["transactions"], "access_token_env": "PLAID_BOFA_ACCESS_TOKEN"}
-    ]
+  # The item registry is NOT here — it's a YAML file (items.yaml) generated into the
+  # plaid-mcp-items ConfigMap and mounted at /etc/plaid-mcp/items.yaml.

--- a/cluster/k8s/agents/plaid-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/plaid-mcp/app/deployment.yaml
@@ -38,11 +38,6 @@ spec:
                 configMapKeyRef:
                   name: plaid-mcp-config
                   key: PLAID_MCP_PLAID_ENV
-            - name: PLAID_MCP_ITEMS_META
-              valueFrom:
-                configMapKeyRef:
-                  name: plaid-mcp-config
-                  key: PLAID_MCP_ITEMS_META
             - name: PLAID_MCP_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -80,6 +75,10 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+          volumeMounts:
+            - name: items
+              mountPath: /etc/plaid-mcp
+              readOnly: true
         - name: facade
           image: ghcr.io/agentydragon/mcp-oauth-facade:devel-20260529231610-304b2dd # {"$imagepolicy": "flux-system:mcp-oauth-facade"}
           imagePullPolicy: Always
@@ -120,3 +119,7 @@ spec:
               port: 8765
             initialDelaySeconds: 20
             periodSeconds: 20
+      volumes:
+        - name: items
+          configMap:
+            name: plaid-mcp-items

--- a/cluster/k8s/agents/plaid-mcp/app/items.yaml
+++ b/cluster/k8s/agents/plaid-mcp/app/items.yaml
@@ -1,0 +1,12 @@
+# Plaid MCP item registry. Mounted at /etc/plaid-mcp/items.yaml (PLAID_MCP_ITEMS_CONFIG_PATH)
+# via a configMapGenerator. Each item's access token is read from the named env var (an
+# ESO-mirrored Secret); add items here as more accounts are linked in airlock.
+items:
+  - key: chase
+    institution: Chase
+    products: [transactions, liabilities]
+    access_token_env: PLAID_CHASE_ACCESS_TOKEN
+  - key: bofa
+    institution: Bank of America
+    products: [transactions]
+    access_token_env: PLAID_BOFA_ACCESS_TOKEN

--- a/cluster/k8s/agents/plaid-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/plaid-mcp/app/kustomization.yaml
@@ -12,3 +12,11 @@ resources:
   - service.yaml
   - httproute.yaml
   - networkpolicy.yaml
+# Item registry as a native YAML file (not an inline JSON blob); reloader rolls the
+# deployment when it changes, so the generated name stays stable.
+configMapGenerator:
+  - name: plaid-mcp-items
+    files:
+      - items.yaml
+    options:
+      disableNameSuffixHash: true

--- a/plaid_utils/mcp_server/BUILD.bazel
+++ b/plaid_utils/mcp_server/BUILD.bazel
@@ -9,6 +9,17 @@ py_library(
     deps = [
         "@pypi//pydantic",
         "@pypi//pydantic_settings",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_test(
+    name = "test_config",
+    srcs = ["test_config.py"],
+    deps = [
+        ":config",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/plaid_utils/mcp_server/README.md
+++ b/plaid_utils/mcp_server/README.md
@@ -52,15 +52,16 @@ re-link via airlock).
 
 ## Configuration
 
-Pydantic `BaseSettings`, env prefix `PLAID_MCP_`:
+Scalars via `PLAID_MCP_` env vars (Pydantic `BaseSettings`); the item registry via a YAML file:
 
 - `PLAID_MCP_PLAID_ENV` — `sandbox` or `production`.
 - `PLAID_MCP_CLIENT_ID` / `PLAID_MCP_CLIENT_SECRET` — Plaid app credentials.
-- `PLAID_MCP_ITEMS_META` — JSON `list[PlaidItem]`: `{key, institution, products, access_token_env}`.
+- `PLAID_MCP_ITEMS_CONFIG_PATH` — path to the item-registry YAML file (default
+  `/etc/plaid-mcp/items.yaml`): a list under `items:` of `{key, institution, products, access_token_env}`.
 - `PLAID_MCP_HOST` / `PLAID_MCP_PORT` — bind address (default `0.0.0.0:8080`).
 
 Each item's access token is read from the env var named by its `access_token_env` (e.g.
-`PLAID_CHASE_ACCESS_TOKEN`), so tokens stay in Secrets and metadata in a ConfigMap.
+`PLAID_CHASE_ACCESS_TOKEN`), so tokens stay in Secrets and the registry stays a plain YAML file.
 
 ## Run locally
 

--- a/plaid_utils/mcp_server/config.py
+++ b/plaid_utils/mcp_server/config.py
@@ -1,13 +1,17 @@
-"""Settings for the Plaid MCP server (environment-driven).
+"""Settings for the Plaid MCP server.
 
-Item metadata (non-secret) comes from `PLAID_MCP_ITEMS_META` as JSON; each item's
-access token is read from the env var it names, so secrets stay in Secrets and
-metadata in a ConfigMap.
+Scalars (Plaid env, client creds, bind address) come from `PLAID_MCP_*` env vars. The item
+registry comes from a YAML config file (`PLAID_MCP_ITEMS_CONFIG_PATH`, default
+`/etc/plaid-mcp/items.yaml`) mounted from a ConfigMap — a plain YAML file, not an inline
+JSON blob. Each item names the env var holding its access token, so secrets stay in Secrets
+and the registry stays declarative config.
 """
 
 import os
+from pathlib import Path
 from typing import Literal
 
+import yaml
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -19,6 +23,12 @@ class PlaidItem(BaseModel):
         description="Plaid products enabled for the item, e.g. ['transactions', 'liabilities']."
     )
     access_token_env: str = Field(description="Name of the env var holding this item's Plaid access_token.")
+
+
+class ItemsConfig(BaseModel):
+    """Top-level shape of the item-registry YAML file (`PLAID_MCP_ITEMS_CONFIG_PATH`)."""
+
+    items: list[PlaidItem]
 
 
 class ResolvedItem(BaseModel):
@@ -34,18 +44,21 @@ class ServerSettings(BaseSettings):
     plaid_env: Literal["sandbox", "production"] = Field(description="Plaid environment.")
     client_id: str = Field(description="Plaid client_id.")
     client_secret: str = Field(description="Plaid client secret.")
-    items_meta: list[PlaidItem] = Field(description="Configured items as JSON in PLAID_MCP_ITEMS_META.")
+    items_config_path: Path = Field(
+        default=Path("/etc/plaid-mcp/items.yaml"), description="Path to the item-registry YAML file."
+    )
     host: str = "0.0.0.0"
     port: int = 8080
 
     def resolved_items(self) -> dict[str, ResolvedItem]:
-        """Resolve each item's access token from its env var (raises KeyError if unset)."""
-        resolved: dict[str, ResolvedItem] = {}
-        for item in self.items_meta:
-            resolved[item.key] = ResolvedItem(
+        """Load the item registry from the YAML config and resolve each access token from its env var."""
+        config = ItemsConfig.model_validate(yaml.safe_load(self.items_config_path.read_text()))
+        return {
+            item.key: ResolvedItem(
                 key=item.key,
                 institution=item.institution,
                 products=item.products,
                 access_token=os.environ[item.access_token_env],
             )
-        return resolved
+            for item in config.items
+        }

--- a/plaid_utils/mcp_server/test_config.py
+++ b/plaid_utils/mcp_server/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for ServerSettings (item registry loaded from a YAML config file)."""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import pytest_bazel
+
+from plaid_utils.mcp_server.config import ServerSettings
+
+
+def test_resolved_items_loads_yaml_and_resolves_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    items_yaml = tmp_path / "items.yaml"
+    items_yaml.write_text(
+        dedent("""
+            items:
+              - key: chase
+                institution: Chase
+                products: [transactions, liabilities]
+                access_token_env: PLAID_CHASE_TOKEN
+        """)
+    )
+    monkeypatch.setenv("PLAID_MCP_PLAID_ENV", "sandbox")
+    monkeypatch.setenv("PLAID_MCP_CLIENT_ID", "cid")
+    monkeypatch.setenv("PLAID_MCP_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("PLAID_MCP_ITEMS_CONFIG_PATH", str(items_yaml))
+    monkeypatch.setenv("PLAID_CHASE_TOKEN", "tok-123")
+
+    resolved = ServerSettings().resolved_items()
+
+    assert set(resolved) == {"chase"}
+    assert resolved["chase"].access_token == "tok-123"
+    assert resolved["chase"].products == ["transactions", "liabilities"]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
Follow-up to the #1735 review comment on `configmap.yaml`: the `PLAID_MCP_ITEMS_META`
inline-JSON-in-YAML blob tripped the repo's "no code blobs in YAML/JSON" rule. Move the item
registry to a real YAML config file.

- **`config.py`**: `ServerSettings.resolved_items()` reads the registry from
  `PLAID_MCP_ITEMS_CONFIG_PATH` (default `/etc/plaid-mcp/items.yaml`) via an `ItemsConfig`
  model, instead of the `items_meta` env JSON. Scalars (`plaid_env`, client creds, host/port)
  stay `PLAID_MCP_*` env vars; each item still names the env var holding its access token.
- **cluster**: `items.yaml` is a native, lintable file generated into the `plaid-mcp-items`
  ConfigMap via `configMapGenerator` and mounted at `/etc/plaid-mcp`; the deployment drops the
  `PLAID_MCP_ITEMS_META` env. `reloader` rolls the pod when it changes (stable name via
  `disableNameSuffixHash`). kubeconform excludes it as app config (not a K8s manifest),
  matching `gatus`/`airlock` `config.yaml`.
- **`test_config.py`**: covers loading the registry from a YAML file + resolving the per-item
  access token from its env var.

### Verified

`bbr test //plaid_utils/... //cluster/validation/...` — green, including `test_config` and the
kustomize build of the new `configMapGenerator` + volume mount via `test_cluster_integration`.

(Pre-commit may still show red from the `ducktape-git-hooks` wheel until the #1745 repin lands;
bazel-ci has a flaky `augur/calibration:test_manifold` — neither is from these changes.)

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_