### PR TITLE
augur/api: switch export_schema to get_required_own_repo_path (complete #1744)

### DIFF
--- a/augur/api/export_schema.py
+++ b/augur/api/export_schema.py
@@ -13,11 +13,11 @@ import json
 
 from augur.api.config import load_augur_config
 from augur.api.server import create_app_from_augur_config
-from util.bazel.runfiles import get_required_path
+from util.bazel.runfiles import get_required_own_repo_path
 
 
 def main() -> None:
-    config = load_augur_config(get_required_path("_main/augur/api/testdata/config.yaml"))
+    config = load_augur_config(get_required_own_repo_path("augur/api/testdata/config.yaml"))
     print(json.dumps(create_app_from_augur_config(config).openapi(), indent=2))
 
 


### PR DESCRIPTION
## The gap

PR #1744 ("export_schema cross-repo runfiles fix") added the helper `get_required_own_repo_path()` / `_own_repo_prefix()` to `util/bazel/runfiles.py` (+ `test_runfiles`, `export_schema_test`), but **never switched the actual call site** — `augur/api/export_schema.py` at `devel` HEAD still does:

```python
from util.bazel.runfiles import get_required_path
...
config = load_augur_config(get_required_path("_main/augur/api/testdata/config.yaml"))
```

So the helper was unused and the cross-repo bug #1744 set out to fix is still live. `#1744`'s new `export_schema_test` went green only because in ducktape's own CI it runs as the **main** repo, where the `_main/` prefix resolves — it never exercised the external-consumer path.

## Impact

When ducktape is consumed as an external Bazel module (gaffer-private's `@ducktape`), building `@ducktape//augur/frontend/lib:schema_zod` — a `js_openapi_zod` genrule whose generator **runs** `//augur/api:export_schema_bin` — fails at the run step:

```
RuntimeError: Resolved path does not exist:
  .../export_schema_bin.runfiles/_main/augur/api/testdata/config.yaml
```

because an external consumer's runfiles place ducktape's data under `ducktape+/...`, not `_main/...`. This breaks gaffer's `backend_dev → schema_zod → export_schema_bin` frontend-schema codegen.

## The fix (one file, import + call)

```diff
-from util.bazel.runfiles import get_required_path
+from util.bazel.runfiles import get_required_own_repo_path
...
-    config = load_augur_config(get_required_path("_main/augur/api/testdata/config.yaml"))
+    config = load_augur_config(get_required_own_repo_path("augur/api/testdata/config.yaml"))
```

`get_required_own_repo_path` derives the prefix from the live runfiles repo-mapping via `Runfiles.CurrentRepository()` — `_main` when ducktape is the Bazel main repo (so this PR is a no-op for ducktape's own CI / the deployed image), and `ducktape+` when consumed externally (which fixes the gaffer build). This is exactly the call-site swap #1744's description claimed but its diff omitted.

## Verification

- ducktape CI (this PR): `export_schema_test` + `//augur/frontend/lib:schema_zod` build stay green (main-repo prefix is `_main` either way — confirms no regression) and pre-commit/lint covers the edit.
- Cross-repo RED→GREEN proof (building `@ducktape//augur/frontend/lib:schema_zod` from the gaffer workspace at this commit) requires a working Bazel/RBE toolchain and will be captured when gaffer re-pins `@ducktape` onto this fix — the correctness is otherwise guaranteed by construction (the helper returns the right prefix for both contexts).

Follow-up: bump gaffer-private's `@ducktape` pin (currently `4c6bd673`, which lacks this) onto the merge commit so its frontend-schema chain builds.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_