### PR TITLE
cluster: agent RBAC for plaid-mcp namespace (log read)

### DIFF
--- a/cluster/k8s/agents/plaid-mcp/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/agents/plaid-mcp/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plaid-mcp-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: Agent RBAC for plaid-mcp namespace. Lightweight — only RoleBindings. Depends on namespace existing + claude-rbac for ClusterRoles.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/plaid-mcp/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: plaid-mcp-namespace
+    - name: claude-rbac

--- a/cluster/k8s/agents/plaid-mcp/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/agents/plaid-mcp/agent-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-logs-configmaps-reader.yaml

--- a/cluster/k8s/agents/plaid-mcp/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agents/plaid-mcp/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: plaid-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logs-configmaps-reader
+# Only the kubectl-sandbox-users group (operator/agent kubectl + the kubectl-local MCP) —
+# deliberately not the openclaw-sandbox ServiceAccount: plaid-mcp isn't an openclaw backend,
+# and its logs can carry financial-account context, so log access stays operator-scoped.
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -86,6 +86,7 @@ resources:
   - agents/manifold-mcp/app/flux-kustomization.yaml
   - agents/plaid-mcp/namespace/flux-kustomization.yaml
   - agents/plaid-mcp/app/flux-kustomization.yaml
+  - agents/plaid-mcp/agent-rbac/flux-kustomization.yaml
   - agents/postscanmail-mcp/namespace/flux-kustomization.yaml
   - agents/postscanmail-mcp/app/flux-kustomization.yaml
   - agents/homeassistant-proxy/flux-kustomization.yaml


### PR DESCRIPTION
`plaid-mcp` (added in #1735) shipped without an `agent-rbac/` directory, so the
`kubectl-sandbox-users` group — the identity behind operator/agent `kubectl` and the
`kubectl-local` MCP — has no `pods/log` in the namespace. That makes the Plaid MCP server
undiagnosable from a session: when it misbehaves (e.g. a TLS error on the Plaid or Authentik
hop), I can't read its logs, and there's no Loki to fall back on (the stack is Mimir-only).

Adds `cluster/k8s/agents/plaid-mcp/agent-rbac/` following the per-service pattern (same as
airlock/grocy/etc.):

- `rolebinding-logs-configmaps-reader.yaml` — binds the `logs-configmaps-reader` ClusterRole
  in `plaid-mcp`.
- `kustomization.yaml` + `flux-kustomization.yaml` — its own Flux kustomization
  (`dependsOn: plaid-mcp-namespace`, `claude-rbac`), wired into the root `kustomization.yaml`.

Bound to the **`kubectl-sandbox-users` group only** — deliberately *not* the
`openclaw-sandbox` ServiceAccount that some other bindings include, since plaid-mcp isn't an
openclaw backend and its logs can carry financial-account context, so log read stays
operator-scoped.

Once merged + reconciled I'll be able to read the plaid-mcp logs and chase down the
certificate error.

### Verified

`bbr test //cluster/validation/...` — 10/10 (Flux dependency graph resolves the new
kustomization's `dependsOn`, kustomize build + orphan/wiring checks pass).

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_