### PR TITLE
plaid_utils: pin certifi CA bundle so plaid-python verifies TLS (fixes plaid-mcp cert error)

### DIFF
--- a/plaid_utils/BUILD.bazel
+++ b/plaid_utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devinfra/python:defs.bzl", "py_binary", "py_library")
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_library(
     name = "models",
@@ -11,7 +11,20 @@ py_library(
     name = "client",
     srcs = ["client.py"],
     visibility = ["//plaid_utils:__subpackages__"],
-    deps = ["@pypi//plaid_python"],
+    deps = [
+        "@pypi//certifi",
+        "@pypi//plaid_python",
+    ],
+)
+
+py_test(
+    name = "test_client",
+    srcs = ["test_client.py"],
+    deps = [
+        ":client",
+        "@pypi//certifi",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 py_library(

--- a/plaid_utils/client.py
+++ b/plaid_utils/client.py
@@ -9,6 +9,7 @@ lives in `plaid_utils.dev_creds` so the MCP server never bundles that machinery.
 
 from dataclasses import dataclass
 
+import certifi
 import plaid
 from plaid.api import plaid_api
 
@@ -27,4 +28,9 @@ def plaid_client(creds: PlaidCreds) -> plaid_api.PlaidApi:
     configuration = plaid.Configuration(
         host=PLAID_HOSTS[creds.env], api_key={"clientId": creds.client_id, "secret": creds.secret}
     )
+    # plaid-python (urllib3) passes ca_certs=ssl_ca_cert; left unset urllib3 falls back to the
+    # system trust store, which the debian_slim runtime image ships empty -> production.plaid.com
+    # fails with CERTIFICATE_VERIFY_FAILED. Point it at certifi's bundle (already in the image via
+    # fastmcp -> httpx), matching how the other MCP servers get their CA roots.
+    configuration.ssl_ca_cert = certifi.where()
     return plaid_api.PlaidApi(plaid.ApiClient(configuration))

--- a/plaid_utils/test_client.py
+++ b/plaid_utils/test_client.py
@@ -1,0 +1,21 @@
+"""Tests for the Plaid SDK client factory."""
+
+from pathlib import Path
+
+import certifi
+import pytest_bazel
+
+from plaid_utils.client import PlaidCreds, plaid_client
+
+
+def test_plaid_client_pins_certifi_ca_bundle() -> None:
+    # The debian_slim runtime image ships no system CA bundle, so the client must point
+    # urllib3 at certifi's, or production.plaid.com fails with CERTIFICATE_VERIFY_FAILED.
+    api = plaid_client(PlaidCreds(client_id="cid", secret="secret", env="production"))
+    ca_cert = api.api_client.configuration.ssl_ca_cert
+    assert ca_cert == certifi.where()
+    assert Path(ca_cert).exists()
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Diagnosis (read from the live pod, now that #1748 gave log access)

The deployed `plaid-mcp-server` fails **every** Plaid call:

```
HTTPSConnectionPool(host='production.plaid.com', port=443):
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1032)
```

Root cause: plaid-python's `rest.py` builds its urllib3 pool with
`ca_certs=configuration.ssl_ca_cert`. We never set `ssl_ca_cert`, so it's `None` and urllib3
falls back to the **system** trust store — which the `debian_slim` runtime image ships empty.
The httpx-based MCP servers (manifold, grocy, …) don't hit this because `httpx` always uses
`certifi`.

## Fix

`plaid_client()` now sets `configuration.ssl_ca_cert = certifi.where()`. `certifi` is already
in the image (via `fastmcp` → `httpx`) and its `cacert.pem` is in the Bazel runfiles, so this
just points plaid-python at the same CA roots everything else uses — no image/base change.

`test_client.py` constructs the real client and asserts the bundle is pinned to
`certifi.where()` and that the file exists.

## Verified

`bbr build //plaid_utils/...` (lint/mypy) + `bbr test //plaid_utils/...` — `test_client` PASSED
(certifi resolves to a real `cacert.pem` in the runfiles), `test_config`/`test_server` green.

After merge, CI rebuilds the `plaid-mcp-server` image and Flux's ImagePolicy rolls it — then
Plaid calls verify. (Heads-up: the `plaid-mcp` **app** kustomization is currently `Ready=False`
on a `tofu-controller` → `agent-machine-access-tf` dependency cascade, unrelated to this; the
new image won't roll until that clears.)

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_