### PR TITLE
plaid-mcp: set namespace on app kustomization (unblocks stuck apply + cert fix)

### DIFF
--- a/cluster/k8s/agents/plaid-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/plaid-mcp/app/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# Sets metadata.namespace on every resource, including the configMapGenerator output
+# below — generators don't inherit a namespace, and Flux's server-side apply rejects a
+# namespaced resource (the plaid-mcp-items ConfigMap) that doesn't have one.
+namespace: plaid-mcp
 # plaid-client-credentials and plaid-{chase,bofa}-access-token are mirrored from
 # the `airlock` namespace by the ExternalSecrets in external-secret.yaml (ESO
 # Kubernetes provider). plaid-mcp-oidc (facade Authentik creds) is created by the


### PR DESCRIPTION
## Why the plaid-mcp cert fix (#1749) never deployed

While watching for #1749 to roll, I found the plaid-mcp **app kustomization has been failing
to apply since #1746**:

```
plaid-mcp Ready=False
  ConfigMap/plaid-mcp-items namespace not specified: the server could not find the requested resource
lastAppliedRevision: 4d6bfc0   # #1745 — stuck here
```

The `configMapGenerator` added in #1746 produces the `plaid-mcp-items` ConfigMap with **no
namespace** — generators don't inherit one, and the kustomization had no `namespace:`
directive (the hand-written resources each carry `namespace: plaid-mcp` in their own
metadata, so they were fine). `kustomize build` happily emits a namespaceless ConfigMap, so
cluster-validation passed, but Flux's **server-side apply rejects it** — so every apply since
#1746 failed, leaving the pod stuck on the old image and blocking both #1746's config change
and #1749's CA-cert fix from rolling.

## Fix

Add `namespace: plaid-mcp` to the app kustomization, so it stamps the namespace on every
resource — the generated ConfigMap included.

Verified with `kustomize build`: all 10 rendered resources (ConfigMaps, Deployment, Service,
HTTPRoute, CiliumNetworkPolicy, 3 ExternalSecrets, RedisReplication) now resolve to
`plaid-mcp` (the `plaid-mcp-items` ConfigMap was `namespace=None` before). `bbr test
//cluster/validation/...` 10/10.

Once merged, the app kustomization applies again → the deployment picks up
`plaid-mcp-server:devel-…-8c207bf` (already built + selected by the ImagePolicy) → the cert
fix goes live.

Follow-up worth considering: cluster-validation should flag a namespaced build-output resource
with no namespace (same class of gap that let the #1741 image-automation bug ship) — happy to
add that separately.

https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4nPp3SfsTPgnV3NmcnZvs)_