### PR TITLE
augur(M2): coupled company-valuation + dilution channel (opt-in)

### DIFF
--- a/augur/SPEC.md
+++ b/augur/SPEC.md
@@ -67,7 +67,7 @@ deployment config are not supported by the product endpoint yet.
 
 PE state crosses the model↔sim boundary as a single typed
 `PrivateEquityBundle` — one wide polars frame keyed by
-`(rollout_index, month_index, issuer_id)` with nine dtype-typed channels.
+`(rollout_index, month_index, issuer_id)` with ten dtype-typed channels.
 The model layer must emit a complete per-issuer entry whenever a
 scenario holds the issuer; producing an issuer with any channel missing
 is a schema violation, not a runtime sim-compile failure. Channels
@@ -80,6 +80,7 @@ group by dtype:
 |                             | `eligible_fraction`           | Fraction of currently held units eligible for voluntary sale.                                                                                                        |
 |                             | `forced_sale_fraction`        | Fraction of currently held units forcibly sold in that month.                                                                                                        |
 |                             | `forced_recovery_cashout_usd` | Dollar recovery paid for the remaining position in that month.                                                                                                       |
+|                             | `company_valuation_usd`       | Opt-in M2 company market cap `V(t)`. All-zeros when the valuation channel is off (no `current_valuation_usd` anchor); a positive market cap is never all-zeros.      |
 | `PrivateEquityIntChannel`   | `regime_code`                 | `PrivateEquityRegimeCode`: `PRIVATE_OPERATING`, `PUBLIC_MARKET`, `ACQUIRED`, `COLLAPSED`.                                                                            |
 |                             | `event_kind_code`             | `PrivateEquityEventKindCode`: `NONE`, `TENDER`, `ADMIN_MARK_UPDATE`, `PUBLIC_MARKET_OPEN`, `ACQUISITION_CASHOUT`, `LEGAL_IMPAIRMENT`, `FORCED_RECOVERY`, `COLLAPSE`. |
 | `PrivateEquityBoolChannel`  | `sale_opportunity_active`     | Discrete voluntary tender opportunity flag. Public-market saleability is represented by the `PUBLIC_MARKET` regime, not by this flag.                                |

--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -103,16 +103,21 @@ are deleted and the CI prefix-guard is in place.
       `macro_market_bundle_provider` shape directly; mine it only for
       data loading/config ideas after the native `SampledExogenousBundle`
       API is the target.
-- [ ] **Fit the PE valuation + share-dilution process, not just a static
-      scale.** M2 (`augur/plans/prediction_market_calibration.md`) adds a
-      company-valuation channel `V = mark × shares(t)` plus a dilution
-      process, but v1 uses point estimates (`shares₀`, `annual_dilution_rate`).
-      The trainer already ingests `valuation_observation`s but collapses them to
-      a single static `scale_prior.current_market_cap_usd`; make the scale
-      **dynamic and Bayesian** — fit a posterior over the dilution rate and the
+- [ ] **Fit the PE valuation + share-dilution process, not just static
+      points (M2.2).** M2 (`augur/plans/prediction_market_calibration.md`) landed
+      the coupled, opt-in company-valuation channel:
+      `latent_mark = current_mark × (V(t)/V₀) / dilution_factor(t)` on
+      `current_valuation_usd`, with `V(t)` a Student-t random walk and
+      `dilution_factor(t) = (1 + annual_dilution_rate)^(t/12)`, flowing out on the
+      `PrivateEquityBundle.company_valuation_usd` channel and scoring
+      `valuation_by_date` markets. Still v1 point estimates: `shares_outstanding_initial`
+      and `annual_dilution_rate` are hand-set, and the valuation RW params are not
+      evidence-fit. The trainer also still collapses `valuation_observation`s to a
+      single static `scale_prior.current_market_cap_usd`. Remaining work: make the
+      scale **dynamic and Bayesian** — fit a posterior over the dilution rate and the
       valuation drift/vol jointly from the paired (price, valuation) series so
-      `shares(t)` / `V(t)` carry real uncertainty instead of hand-set points.
-      Distinguish primary-issuance dilution (funding rounds) from secondaries
+      `shares(t)` / `V(t)` carry real uncertainty instead of hand-set points — and
+      distinguish primary-issuance dilution (funding rounds) from secondaries
       (no new shares) and employee-equity (PPU/RSU) issuance.
 
 ## Liquidity Policy

--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -349,14 +349,14 @@ py_binary(
 py_test(
     name = "export_schema_test",
     srcs = ["test_export_schema.py"],
-    # Source follows the test_<module>.py convention while the target keeps the
-    # conventional <name>_test label, so the inferred main wouldn't match srcs.
-    main = "test_export_schema.py",
     data = [
         ":public_fixture_calibration_catalog",
         ":public_fixture_config",
         ":public_fixture_properties",
     ],
+    # Source follows the test_<module>.py convention while the target keeps the
+    # conventional <name>_test label, so the inferred main wouldn't match srcs.
+    main = "test_export_schema.py",
     deps = [
         ":export_schema",
         "@pypi//pytest_bazel",

--- a/augur/calibration/resolvers.py
+++ b/augur/calibration/resolvers.py
@@ -12,10 +12,12 @@ gives ``p_model``.
 Only EVENT-based markets map cleanly. augur models going-public
 (``PUBLIC_MARKET_OPEN``), collapse (``COLLAPSE`` / ``FORCED_RECOVERY``) and
 acquisition (``ACQUISITION_CASHOUT``) as first-class absorbing events, so
-"IPO by date" and "collapse/acquired before IPO" are apples-to-apples. augur does
-NOT model company valuation (the mark is per-UNIT; there is no shares or market-cap
-concept) nor revenue, so markets needing those are surfaced for interpretation, not
-scored against the model.
+"IPO by date" and "collapse/acquired before IPO" are apples-to-apples. With the
+opt-in M2 valuation channel an issuer ALSO carries a company market-cap path
+``company_valuation_usd`` (``V(t)``), making "valuation >= $X by date" scoreable
+(``valuation_by_date``). Issuers without the channel (no ``current_valuation_usd``
+anchor) leave it ``None``, and valuation markets stay unscored/surfaced. Revenue
+is still unmodeled.
 
 This module is generic over the issuer -- nothing here is specific to any one
 company. Pass the issuer through ``trajectories_from_bundle``.
@@ -66,6 +68,11 @@ class RolloutTrajectory:
     event_kind_code: npt.NDArray[np.int64]  # (horizon+1,) PrivateEquityEventKindCode values
     regime_code: npt.NDArray[np.int64]  # (horizon+1,) PrivateEquityRegimeCode values
     as_of: date
+    # (horizon+1,) company market cap V(t) in USD, or None when the issuer has no
+    # opt-in M2 valuation channel. `trajectories_from_bundle` passes None when the
+    # bundle's `company_valuation_usd` is all-zeros for the issuer (the
+    # channel-off sentinel) — a positive market cap is never all-zeros.
+    company_valuation_usd: npt.NDArray[np.float64] | None = None
 
     @property
     def horizon_months(self) -> int:
@@ -101,11 +108,33 @@ def resolve_pre_ipo_failure(traj: RolloutTrajectory) -> Resolution:
     return Resolution.UNRESOLVED  # still private-operating at end of horizon
 
 
+def resolve_valuation_by_date(traj: RolloutTrajectory, *, threshold_usd: float, by_month: int) -> Resolution:
+    """YES iff company valuation V(m) >= ``threshold_usd`` for some month m <= by_month.
+
+    Needs the opt-in M2 valuation channel: an issuer with no ``company_valuation_usd``
+    (channel off) is UNRESOLVED. With the channel, YES if the threshold is ever reached
+    by month ``min(by_month, horizon)``; otherwise NO when the deadline is within the
+    simulated horizon, or UNRESOLVED when the deadline lies beyond it (the threshold
+    might still be reached later).
+    """
+    if traj.company_valuation_usd is None:
+        return Resolution.UNRESOLVED  # issuer has no valuation channel — not scoreable
+    horizon = traj.horizon_months
+    window_end = min(by_month, horizon)
+    if window_end >= 0 and np.any(traj.company_valuation_usd[: window_end + 1] >= threshold_usd):
+        return Resolution.YES
+    if by_month <= horizon:
+        return Resolution.NO  # whole window simulated, threshold never reached
+    return Resolution.UNRESOLVED  # deadline beyond the simulated horizon, not yet reached
+
+
 def resolve_market(traj: RolloutTrajectory, *, mapping_kind: str, params: dict[str, object]) -> Resolution:
     """Dispatch a cleanly-mappable (`exact`) catalog entry to its resolver.
 
-    Only event-based kinds are handled; valuation/revenue markets are not scored
-    (augur does not model those quantities) and must be surfaced, not resolved here.
+    Event-based kinds (`ipo_by_date`, `pre_ipo_failure`) are always handled.
+    `valuation_by_date` is handled too but only resolves YES/NO for issuers with
+    the opt-in M2 valuation channel (UNRESOLVED otherwise). Revenue and other
+    unmodeled quantities must be surfaced, not resolved here.
     """
     match mapping_kind:
         case "ipo_by_date":
@@ -114,6 +143,12 @@ def resolve_market(traj: RolloutTrajectory, *, mapping_kind: str, params: dict[s
             )
         case "pre_ipo_failure":
             return resolve_pre_ipo_failure(traj)
+        case "valuation_by_date":
+            return resolve_valuation_by_date(
+                traj,
+                threshold_usd=float(params["threshold_usd"]),  # type: ignore[arg-type]
+                by_month=traj.month_on_or_before(date.fromisoformat(str(params["by_date"]))),
+            )
     raise ValueError(f"mapping_kind {mapping_kind!r} is not cleanly resolvable against augur (surface it instead)")
 
 
@@ -130,7 +165,18 @@ def trajectories_from_bundle(
     regimes = bundle.issuer_int_matrix(
         issuer, "regime_code", rollout_count=rollout_count, horizon_months=horizon_months
     )
+    valuations = bundle.issuer_float_matrix(
+        issuer, "company_valuation_usd", rollout_count=rollout_count, horizon_months=horizon_months
+    )
+    # All-zeros across the whole issuer is the channel-off sentinel (a real market
+    # cap is strictly positive). Detect once for the issuer, not per-rollout, so a
+    # rollout that happens to dip to 0 inside an active channel isn't misread.
+    valuation_channel_on = bool(np.any(valuations > 0.0))
     for r in range(rollout_count):
         yield RolloutTrajectory(
-            mark_usd_per_unit=marks[r], event_kind_code=events[r], regime_code=regimes[r], as_of=as_of
+            mark_usd_per_unit=marks[r],
+            event_kind_code=events[r],
+            regime_code=regimes[r],
+            as_of=as_of,
+            company_valuation_usd=valuations[r] if valuation_channel_on else None,
         )

--- a/augur/calibration/test_manifold.py
+++ b/augur/calibration/test_manifold.py
@@ -26,7 +26,7 @@ def test_fetch_yes_probability_raises_when_probability_missing() -> None:
     # A market with no `probability` (e.g. a non-binary market) has no YES probability,
     # so the wrapper raises rather than inventing one.
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"id": "NOPROB"})
+        return httpx.Response(200, json={"id": "NOPROB", "url": "https://manifold.markets/test/NOPROB"})
 
     client = ManifoldClient(client=httpx.Client(transport=httpx.MockTransport(handler)))
     assert client.get_market("NOPROB").probability is None
@@ -40,7 +40,7 @@ def test_get_market_caches_within_ttl_and_refetches_after() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls["count"] += 1
-        return httpx.Response(200, json={"id": "AAA", "probability": 0.3})
+        return httpx.Response(200, json={"id": "AAA", "url": "https://manifold.markets/test/AAA", "probability": 0.3})
 
     client = ManifoldClient(
         cache_ttl_seconds=120.0, clock=lambda: now[0], client=httpx.Client(transport=httpx.MockTransport(handler))

--- a/augur/calibration/test_resolvers.py
+++ b/augur/calibration/test_resolvers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 
 import numpy as np
+import numpy.typing as npt
 import pytest_bazel
 
 from augur.calibration.resolvers import (
@@ -13,19 +14,28 @@ from augur.calibration.resolvers import (
     resolve_ipo_by_date,
     resolve_market,
     resolve_pre_ipo_failure,
+    resolve_valuation_by_date,
 )
 from augur.model.series import PrivateEquityEventKindCode, PrivateEquityRegimeCode
 
 AS_OF = date(2026, 5, 27)
 
 
-def _traj(horizon: int = 24, *, events: dict[int, int] | None = None) -> RolloutTrajectory:
+def _traj(
+    horizon: int = 24, *, events: dict[int, int] | None = None, valuation: npt.NDArray[np.float64] | None = None
+) -> RolloutTrajectory:
     marks = np.ones(horizon + 1, dtype=np.float64)
     event_kind = np.zeros(horizon + 1, dtype=np.int64)
     regime = np.full(horizon + 1, int(PrivateEquityRegimeCode.PRIVATE_OPERATING), dtype=np.int64)
     for month, code in (events or {}).items():
         event_kind[month] = int(code)
-    return RolloutTrajectory(mark_usd_per_unit=marks, event_kind_code=event_kind, regime_code=regime, as_of=AS_OF)
+    return RolloutTrajectory(
+        mark_usd_per_unit=marks,
+        event_kind_code=event_kind,
+        regime_code=regime,
+        as_of=AS_OF,
+        company_valuation_usd=valuation,
+    )
 
 
 def test_ipo_by_date_yes_no_unresolved() -> None:
@@ -50,6 +60,28 @@ def test_pre_ipo_failure_race() -> None:
     assert resolve_pre_ipo_failure(survives) is Resolution.UNRESOLVED  # still private at end of horizon
 
 
+def test_valuation_by_date_yes_no_unresolved() -> None:
+    # V climbs 1e11 -> 1.2e12 over 24 months; crosses 1e12 at month 20.
+    valuation = np.linspace(1e11, 1.2e12, 25)
+    traj = _traj(horizon=24, valuation=valuation)
+    assert resolve_valuation_by_date(traj, threshold_usd=1e12, by_month=20) is Resolution.YES  # crosses exactly here
+    assert (
+        resolve_valuation_by_date(traj, threshold_usd=1e12, by_month=24) is Resolution.YES
+    )  # later deadline still YES
+    assert resolve_valuation_by_date(traj, threshold_usd=1e12, by_month=19) is Resolution.NO  # not reached by deadline
+    # Threshold never reached anywhere in the simulated window -> NO (whole window covered).
+    assert resolve_valuation_by_date(traj, threshold_usd=5e12, by_month=24) is Resolution.NO
+    # Deadline beyond the simulated horizon and not yet reached -> UNRESOLVED (might cross later).
+    assert resolve_valuation_by_date(traj, threshold_usd=5e12, by_month=999) is Resolution.UNRESOLVED
+
+
+def test_valuation_by_date_channel_off_is_unresolved() -> None:
+    """An issuer with no valuation channel (`company_valuation_usd is None`) is never scoreable."""
+    traj = _traj(horizon=24)  # valuation defaults to None
+    assert resolve_valuation_by_date(traj, threshold_usd=1.0, by_month=24) is Resolution.UNRESOLVED
+    assert resolve_valuation_by_date(traj, threshold_usd=1e12, by_month=999) is Resolution.UNRESOLVED
+
+
 def test_month_on_or_before() -> None:
     traj = _traj(horizon=120)
     assert traj.month_on_or_before(AS_OF) == 0
@@ -63,8 +95,27 @@ def test_resolve_market_dispatch() -> None:
     assert resolve_market(traj, mapping_kind="ipo_by_date", params={"by_date": "2026-09-01"}) is Resolution.NO
 
 
+def test_resolve_market_dispatch_valuation_by_date() -> None:
+    # by_date 2027-01-01 is month 7 from AS_OF; V crosses 1e12 at month 4 here.
+    valuation = np.full(121, 1e11, dtype=np.float64)
+    valuation[4:] = 1.5e12
+    traj = _traj(horizon=120, valuation=valuation)
+    yes = resolve_market(
+        traj, mapping_kind="valuation_by_date", params={"threshold_usd": 1e12, "by_date": "2027-01-01"}
+    )
+    assert yes is Resolution.YES
+    no = resolve_market(traj, mapping_kind="valuation_by_date", params={"threshold_usd": 1e12, "by_date": "2026-08-01"})
+    assert no is Resolution.NO  # 2026-08-01 is month 2; the threshold crossing is at month 4
+    # No valuation channel -> the otherwise-scoreable kind is UNRESOLVED, never an error.
+    off = resolve_market(
+        _traj(horizon=120), mapping_kind="valuation_by_date", params={"threshold_usd": 1e12, "by_date": "2027-01-01"}
+    )
+    assert off is Resolution.UNRESOLVED
+
+
 def test_resolve_market_refuses_unmodeled_kind() -> None:
-    """Valuation is not modeled by augur; it must not be silently scored."""
+    """`valuation_threshold` is not a recognized mapping kind (revenue/other unmodeled
+    quantities likewise); such markets must be surfaced, not silently scored."""
     traj = _traj()
     try:
         resolve_market(traj, mapping_kind="valuation_threshold", params={"threshold_usd": 1e12})

--- a/augur/model/private_equity_bundle.py
+++ b/augur/model/private_equity_bundle.py
@@ -1,6 +1,6 @@
 """Wide private-equity protocol bundle.
 
-The PE protocol carries 9 conceptually-parallel channels per issuer:
+The PE protocol carries 10 conceptually-parallel channels per issuer:
 
 | Channel                       | Type    | Meaning                                      |
 | ----------------------------- | ------- | -------------------------------------------- |
@@ -13,6 +13,7 @@ The PE protocol carries 9 conceptually-parallel channels per issuer:
 | `forced_sale_fraction`        | float   | Fraction forcibly sold in that month         |
 | `liquidity_blocked`           | bool    | Voluntary sales blocked                       |
 | `forced_recovery_cashout_usd` | float   | Dollar recovery for the remaining position   |
+| `company_valuation_usd`       | float   | Company market cap `V(t)` (0 == channel off) |
 
 Producers used to emit these as 8 separate level series + 1 event series +
 a separate typed protocol frame, validated together at sim compile time.
@@ -21,6 +22,11 @@ polars DataFrame: every channel is a required column, and producers must
 go through `PrivateEquityBundle.from_issuer_arrays` which keyword-only
 requires every channel matrix. Missing any one is a `TypeError`, not a
 sim-compile validation error.
+
+`company_valuation_usd` is the M2 coupled-valuation channel.  It carries the
+sampled company market cap `V(t)` and is all-zeros for issuers whose valuation
+channel is disabled (no `current_valuation_usd` anchor) — zero is a valid
+sentinel for "no valuation modeled", distinct from any positive market cap.
 """
 
 from __future__ import annotations
@@ -45,6 +51,7 @@ class PrivateEquityFloatChannel(StrEnum):
     ELIGIBLE_FRACTION = "eligible_fraction"
     FORCED_SALE_FRACTION = "forced_sale_fraction"
     FORCED_RECOVERY_CASHOUT_USD = "forced_recovery_cashout_usd"
+    COMPANY_VALUATION_USD = "company_valuation_usd"
 
 
 class PrivateEquityIntChannel(StrEnum):
@@ -77,6 +84,7 @@ PRIVATE_EQUITY_BUNDLE_SCHEMA = pl.Schema(
         "forced_sale_fraction": pl.Float64(),
         "liquidity_blocked": pl.Boolean(),
         "forced_recovery_cashout_usd": pl.Float64(),
+        "company_valuation_usd": pl.Float64(),
     }
 )
 
@@ -90,6 +98,7 @@ _FLOAT_COLUMNS = frozenset(
         "eligible_fraction",
         "forced_sale_fraction",
         "forced_recovery_cashout_usd",
+        "company_valuation_usd",
     }
 )
 _INT_COLUMNS = frozenset({"regime_code", "event_kind_code"})
@@ -134,10 +143,16 @@ class PrivateEquityBundle:
         forced_sale_fraction: FloatMatrix,
         liquidity_blocked: BoolMatrix,
         forced_recovery_cashout_usd: FloatMatrix,
+        company_valuation_usd: FloatMatrix,
         rollout_count: int,
         horizon_months: int,
     ) -> PrivateEquityBundle:
-        """Build a single-issuer bundle. Every channel is a required keyword."""
+        """Build a single-issuer bundle. Every channel is a required keyword.
+
+        ``company_valuation_usd`` is the M2 coupled-valuation channel; producers
+        with no valuation concept pass an all-zeros matrix (channel off). Zeros
+        are valid (non-negative); only negatives are rejected.
+        """
 
         expected_shape = (rollout_count, horizon_months + 1)
         _require_float_matrix(mark_usd_per_unit, expected_shape, "mark_usd_per_unit")
@@ -153,6 +168,10 @@ class PrivateEquityBundle:
         _require_float_matrix(forced_recovery_cashout_usd, expected_shape, "forced_recovery_cashout_usd")
         if np.any(forced_recovery_cashout_usd < 0.0):
             raise ValueError(f"PE issuer {issuer_id!r} forced_recovery_cashout_usd must be non-negative")
+        _require_float_matrix(company_valuation_usd, expected_shape, "company_valuation_usd")
+        # Market cap is non-negative; all-zeros means the valuation channel is off.
+        if np.any(company_valuation_usd < 0.0):
+            raise ValueError(f"PE issuer {issuer_id!r} company_valuation_usd must be non-negative")
         _require_code_values(regime_code, frozenset(int(c) for c in PrivateEquityRegimeCode), "regime_code")
         _require_code_values(event_kind_code, frozenset(int(c) for c in PrivateEquityEventKindCode), "event_kind_code")
         # Invariant: a voluntary tender opportunity (`sale_opportunity_active`) is the same
@@ -180,6 +199,7 @@ class PrivateEquityBundle:
                 "forced_sale_fraction": forced_sale_fraction.reshape(-1),
                 "liquidity_blocked": liquidity_blocked.reshape(-1),
                 "forced_recovery_cashout_usd": forced_recovery_cashout_usd.reshape(-1),
+                "company_valuation_usd": company_valuation_usd.reshape(-1),
             },
             schema=PRIVATE_EQUITY_BUNDLE_SCHEMA,
         )

--- a/augur/model/private_equity_protocol.py
+++ b/augur/model/private_equity_protocol.py
@@ -42,7 +42,8 @@ def neutral_private_equity_issuer_bundle(
 
     Private operating regime; tender event kind on tender months, `NONE` otherwise;
     full sale capacity and eligibility; no forced sales; no liquidity block; no forced
-    recovery cashout.
+    recovery cashout. The opt-in M2 company-valuation channel is off here (all-zeros):
+    this protocol has no market-cap concept, only a per-unit mark.
     """
 
     expected_shape = (rollout_count, horizon_months + 1)
@@ -62,6 +63,7 @@ def neutral_private_equity_issuer_bundle(
         forced_sale_fraction=np.zeros(expected_shape, dtype=np.float64),
         liquidity_blocked=np.zeros(expected_shape, dtype=np.bool_),
         forced_recovery_cashout_usd=np.zeros(expected_shape, dtype=np.float64),
+        company_valuation_usd=np.zeros(expected_shape, dtype=np.float64),
         rollout_count=rollout_count,
         horizon_months=horizon_months,
     )

--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -110,6 +110,46 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
     annual_collapse_probability: float = Field(default=0.0, ge=0.0, le=1.0)
     collapsed_mark_fraction: float = Field(default=0.0, ge=0.0, le=1.0)
 
+    # -- M2 coupled valuation + dilution channel (opt-in) --------------------
+    #
+    # When `current_valuation_usd` is set, the per-unit latent mark stops being
+    # a standalone Student-t random walk and instead becomes a quantity DERIVED
+    # from a sampled company valuation V(t) and a deterministic dilution factor:
+    #
+    #     latent_mark(t) = current_mark_usd * (V(t) / V0) / dilution_factor(t)
+    #
+    # Leaving `current_valuation_usd` unset keeps today's independent latent-mark
+    # random walk byte-for-byte (zero-value regression for existing configs).
+    current_valuation_usd: float | None = Field(default=None, gt=0)
+    """Company market-cap anchor `V0` (USD).
+
+    `None` disables the valuation channel AND selects the legacy independent
+    latent-mark random walk. Must be set together with
+    `shares_outstanding_initial`.
+    """
+    valuation_monthly_log_return_mu: float = 0.0
+    """Monthly log-space drift of V(t). Only meaningful when the channel is on."""
+    valuation_monthly_log_return_sigma: float = Field(default=0.0, ge=0.0)
+    """Monthly log-space volatility of V(t). Only meaningful when the channel is on."""
+    valuation_student_t_nu: float = Field(default=5.0, gt=2.0)
+    """Degrees of freedom for V(t)'s Student-t shocks. Only meaningful when the channel is on."""
+    shares_outstanding_initial: float | None = Field(default=None, gt=0)
+    """Initial share count `shares0`.
+
+    Required together with `current_valuation_usd`. In v1 only the *ratio*
+    `shares(t)/shares0` enters the mark via the dilution factor, so V0 and
+    shares0 cancel at t=0; we still require it set so the process is honestly
+    specified for the Bayesian fit (M2.2 / TODO #1734).
+    """
+    annual_dilution_rate: float = Field(default=0.0, ge=0.0)
+    """Continuous per-year share-count growth (employee mint + baseline).
+
+    Drives `dilution_factor(t) = (1 + annual_dilution_rate) ** (t / 12)`. This
+    is a v1 point estimate: the primary-round / secondary-trade distinction and
+    the hierarchical Bayesian fit are DEFERRED to M2.2 (TODO #1734). Only
+    meaningful when the valuation channel is on.
+    """
+
     @model_validator(mode="after")
     def _validate_ranges(self) -> PrivateEquityRiskIssuerConfig:
         if self.liquidity_suspension_months_max < self.liquidity_suspension_months_min:
@@ -122,7 +162,21 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
         cumulatives = [anchor.cumulative_probability for anchor in self.public_market_cdf_anchors]
         if any(later < earlier for earlier, later in itertools.pairwise(cumulatives)):
             raise ValueError("public_market_cdf_anchors must be non-decreasing in cumulative_probability")
+        # `current_valuation_usd` (V0) and `shares_outstanding_initial` (shares0)
+        # must be set together or both left unset: you need both to form the
+        # coupled mark honestly. `annual_dilution_rate` and the valuation RW
+        # params are only meaningful when the channel is on; they default to
+        # inert values and are simply ignored when it is off, so they are left
+        # deliberately unguarded.
+        if (self.current_valuation_usd is None) != (self.shares_outstanding_initial is None):
+            raise ValueError("current_valuation_usd and shares_outstanding_initial must be set together or both unset")
         return self
+
+    @property
+    def valuation_channel_enabled(self) -> bool:
+        """Whether the opt-in coupled valuation + dilution channel is active."""
+
+        return self.current_valuation_usd is not None
 
 
 class PrivateEquityRiskProviderConfig(FrozenModel):
@@ -158,6 +212,7 @@ class PrivateEquityRiskModel:
                     forced_sale_fraction=paths.forced_sale_fraction.astype(np.float64),
                     liquidity_blocked=(paths.liquidity_blocked >= 0.5).astype(np.bool_),
                     forced_recovery_cashout_usd=paths.forced_recovery_cashout_usd.astype(np.float64),
+                    company_valuation_usd=paths.company_valuation_usd.astype(np.float64),
                     rollout_count=rollout_count,
                     horizon_months=horizon_months,
                 )
@@ -187,6 +242,9 @@ class _IssuerPaths:
     forced_sale_fraction: FloatMatrix
     liquidity_blocked: FloatMatrix
     forced_recovery_cashout_usd: FloatMatrix
+    # Company market cap V(t), (R, T+1). All-zeros when the valuation channel
+    # is off (no `current_valuation_usd` anchor).
+    company_valuation_usd: FloatMatrix
 
 
 # Plan-derived constants (realization_risk_model_plan.md §Liquidity And Legal Execution Shocks).
@@ -246,7 +304,32 @@ def _sample_issuer(
     level_seeds = derive_stream_rollout_seeds(request.rollout_seeds, stream_id=f"{issuer_id}:pe_risk_level")
     event_seeds = derive_stream_rollout_seeds(request.rollout_seeds, stream_id=f"{issuer_id}:pe_risk_event")
 
-    latent_mark = _sample_latent_marks_vectorized(issuer, level_seeds=level_seeds, horizon_months=horizon_months)
+    # M2 coupled valuation + dilution channel (opt-in via `current_valuation_usd`).
+    #
+    # Channel ON: V(t) is the primitive (its OWN derived seed stream, independent
+    # of the latent-mark/event streams), and the per-unit latent mark is DERIVED
+    #   latent_mark(t) = current_mark_usd * (V(t)/V0) / dilution_factor(t).
+    # Because only ratios enter, V0 and shares0 cancel at t=0, so latent_mark[:,0]
+    # == current_mark_usd exactly. The event-noisy marks below already read
+    # `latent_mark[branch, t]`, so tender/admin/public-market/forced-sale noise
+    # composes on TOP of the coupled mark unchanged.
+    #
+    # Channel OFF: the legacy independent Student-t latent-mark walk is used
+    # verbatim and the valuation path is all-zeros. The valuation seed stream is
+    # NOT derived in this branch, so neither the level nor the event RNG stream
+    # is perturbed — the mark/event arrays stay byte-identical to pre-M2.
+    # Direct `is not None` check (equivalent to `issuer.valuation_channel_enabled`) so
+    # mypy narrows `current_valuation_usd` to `float` for the division/log below.
+    if issuer.current_valuation_usd is not None:
+        valuation_seeds = derive_stream_rollout_seeds(request.rollout_seeds, stream_id=f"{issuer_id}:pe_risk_valuation")
+        company_valuation_usd = _sample_company_valuation_vectorized(
+            issuer, valuation_seeds=valuation_seeds, horizon_months=horizon_months
+        )
+        dilution = _dilution_factor(annual_dilution_rate=issuer.annual_dilution_rate, horizon_months=horizon_months)
+        latent_mark = issuer.current_mark_usd * (company_valuation_usd / issuer.current_valuation_usd) / dilution
+    else:
+        latent_mark = _sample_latent_marks_vectorized(issuer, level_seeds=level_seeds, horizon_months=horizon_months)
+        company_valuation_usd = np.zeros(shape, dtype=np.float64)
 
     # Per-rollout deterministic event-month masks ((R, T+1) booleans). One Generator
     # seeded by the hash of all per-rollout event seeds; vectorization gives up the
@@ -535,6 +618,7 @@ def _sample_issuer(
         forced_sale_fraction=forced_sale_fraction,
         liquidity_blocked=liquidity_blocked,
         forced_recovery_cashout_usd=forced_recovery_cashout_usd,
+        company_valuation_usd=company_valuation_usd,
     )
 
 
@@ -563,6 +647,53 @@ def _sample_latent_marks_vectorized(
     if not np.all(np.isfinite(paths)) or np.any(paths <= 0.0):
         raise ValueError("private-equity risk model produced invalid marks")
     return paths
+
+
+def _sample_company_valuation_vectorized(
+    issuer: PrivateEquityRiskIssuerConfig, *, valuation_seeds: tuple[int, ...], horizon_months: int
+) -> FloatMatrix:
+    """Vectorized company-valuation V(t) sampler: returns (R, horizon_months + 1).
+
+    Mirrors `_sample_latent_marks_vectorized` EXACTLY (same log-space Student-t
+    random walk) but anchored at `current_valuation_usd` and driven by the
+    valuation-specific RW params off an independent seed stream. Column 0 equals
+    `current_valuation_usd` for every rollout. Only called when the valuation
+    channel is enabled, so `current_valuation_usd` is not None.
+    """
+
+    # Caller only invokes this when the channel is on, so V0 is set; assert to narrow for mypy.
+    current_valuation_usd = issuer.current_valuation_usd
+    assert current_valuation_usd is not None
+    rollout_count = len(valuation_seeds)
+    paths = np.empty((rollout_count, horizon_months + 1), dtype=np.float64)
+    paths[:, 0] = current_valuation_usd
+    if horizon_months == 0:
+        return paths
+    rng = np.random.default_rng(_seed_from_rollout_seeds(valuation_seeds))
+    shocks = rng.standard_t(df=issuer.valuation_student_t_nu, size=(rollout_count, horizon_months))
+    shocks *= issuer.valuation_monthly_log_return_sigma
+    log_path = math.log(current_valuation_usd) + np.cumsum(issuer.valuation_monthly_log_return_mu + shocks, axis=1)
+    try:
+        with np.errstate(over="raise", invalid="raise"):
+            paths[:, 1:] = np.exp(log_path)
+    except FloatingPointError as error:
+        raise ValueError("private-equity risk model produced non-finite company valuation") from error
+    if not np.all(np.isfinite(paths)) or np.any(paths <= 0.0):
+        raise ValueError("private-equity risk model produced invalid company valuation")
+    return paths
+
+
+def _dilution_factor(*, annual_dilution_rate: float, horizon_months: int) -> FloatMatrix:
+    """Per-month dilution factor row `(horizon_months + 1,)`.
+
+    `dilution_factor(t) = (1 + annual_dilution_rate) ** (t / 12)` with
+    `dilution_factor(0) == 1`. v1 point estimate; the primary-round /
+    secondary-trade split is DEFERRED (TODO #1734). Broadcasts against the
+    `(R, T+1)` valuation ratio so the coupled mark divides by it per month.
+    """
+
+    months = np.arange(horizon_months + 1, dtype=np.float64)
+    return np.power(1.0 + annual_dilution_rate, months / 12.0)
 
 
 def _sample_event_month_mask_vectorized(

--- a/augur/model/private_equity_risk_test.py
+++ b/augur/model/private_equity_risk_test.py
@@ -19,7 +19,9 @@ from augur.model.private_equity_risk import (
     PrivateEquityRiskIssuerConfig,
     PrivateEquityRiskProviderConfig,
     PublicMarketCdfAnchor,
+    _dilution_factor,
     _public_market_open_hazard_by_month,
+    _sample_company_valuation_vectorized,
 )
 from augur.model.series import IssuerId, PrivateEquityEventKindCode, PrivateEquityRegimeCode
 
@@ -441,6 +443,195 @@ def test_public_market_open_realized_probability_tracks_anchor_cdf() -> None:
     assert realized[7] == pytest.approx(0.75, abs=0.02)
     assert realized[19] == pytest.approx(0.89, abs=0.02)
     assert realized[31] == pytest.approx(0.93, abs=0.02)
+
+
+def _valuation_issuer(**updates: object) -> PrivateEquityRiskIssuerConfig:
+    """An issuer with the opt-in M2 coupled valuation+dilution channel enabled.
+
+    Adverse hazards are all left at their (zero) defaults so the only thing moving
+    the mark is the coupled V(t)/dilution machinery — keeps the assertions clean.
+    """
+
+    return _issuer(
+        current_valuation_usd=1.0e11,
+        shares_outstanding_initial=1.0e9,
+        valuation_monthly_log_return_mu=0.02,
+        valuation_monthly_log_return_sigma=0.10,
+        valuation_student_t_nu=5.0,
+        # No legacy latent-mark drift/vol: when the channel is ON these are unused,
+        # but keeping them inert makes the channel-OFF baseline below unambiguous.
+        monthly_log_return_mu=0.0,
+        monthly_log_return_sigma=0.0,
+        # Push tender/admin precursors past the horizon so mark[:,0] and the coupled
+        # path aren't perturbed by event-price noise in the first columns.
+        tender_interval_months_median=600.0,
+        **updates,
+    )
+
+
+def test_valuation_channel_off_by_default() -> None:
+    """`current_valuation_usd` unset ⇒ channel off ⇒ `company_valuation_usd` all-zeros."""
+
+    sampled = _sample(_issuer(), horizon_months=4)
+    valuation = _float(sampled, PrivateEquityFloatChannel.COMPANY_VALUATION_USD, horizon=4)
+    np.testing.assert_array_equal(valuation, np.zeros((1, 5), dtype=np.float64))
+    assert not _issuer().valuation_channel_enabled
+
+
+def test_valuation_channel_on_anchors_columns_zero() -> None:
+    """Channel ON: valuation[:,0] == V0 and mark[:,0] == current_mark_usd exactly."""
+
+    issuer = _valuation_issuer()
+    assert issuer.valuation_channel_enabled
+    sampled = _sample(issuer, horizon_months=6)
+
+    valuation = _float(sampled, PrivateEquityFloatChannel.COMPANY_VALUATION_USD, horizon=6)
+    mark = _float(sampled, PrivateEquityFloatChannel.MARK_USD_PER_UNIT, horizon=6)
+
+    np.testing.assert_array_equal(valuation[:, 0], np.full(valuation.shape[0], 1.0e11))
+    assert mark[0, 0] == pytest.approx(100.0)
+    # The coupled valuation is a strictly positive market cap, never the all-zeros sentinel.
+    assert np.all(valuation > 0.0)
+
+
+def test_valuation_channel_on_is_deterministic_under_fixed_seeds() -> None:
+    """Two samples with identical `rollout_seeds` produce identical coupled arrays."""
+
+    issuer = _valuation_issuer()
+    request = ExogenousSamplingRequest(
+        horizon_months=8, rollout_seeds=(11, 22, 33), required_private_equity_issuers=frozenset({IssuerId("acme")})
+    )
+    model = PrivateEquityRiskProviderConfig(issuers={"acme": issuer}).realize_model()
+    first = model.sample(request)
+    second = model.sample(request)
+
+    for channel in (PrivateEquityFloatChannel.COMPANY_VALUATION_USD, PrivateEquityFloatChannel.MARK_USD_PER_UNIT):
+        a = first.private_equity.issuer_float_matrix("acme", str(channel), rollout_count=3, horizon_months=8)
+        b = second.private_equity.issuer_float_matrix("acme", str(channel), rollout_count=3, horizon_months=8)
+        np.testing.assert_array_equal(a, b)
+
+
+def test_dilution_factor_shape_and_values() -> None:
+    """`dilution_factor(t) = (1+rate)^(t/12)`, with t=0 ⇒ 1 and t=12 ⇒ 1+rate."""
+
+    rate = 0.30
+    factor = _dilution_factor(annual_dilution_rate=rate, horizon_months=24)
+    assert factor.shape == (25,)
+    assert factor[0] == pytest.approx(1.0)
+    assert factor[12] == pytest.approx(1.0 + rate)
+    assert factor[24] == pytest.approx((1.0 + rate) ** 2)
+    # Zero dilution ⇒ identity row.
+    np.testing.assert_allclose(_dilution_factor(annual_dilution_rate=0.0, horizon_months=6), np.ones(7))
+
+
+def test_positive_dilution_makes_coupled_mark_grow_slower_than_valuation_ratio() -> None:
+    """`annual_dilution_rate > 0` ⇒ the coupled latent mark grows strictly slower than V(t)/V0.
+
+    The coupled latent mark is `current_mark × (V(t)/V0) / dilution_factor(t)` with
+    `dilution_factor(t) = (1+rate)^(t/12) > 1` for t > 0. Verified directly on the
+    sampler's building blocks (`_sample_company_valuation_vectorized` + `_dilution_factor`),
+    since the observed `mark_usd_per_unit` channel is piecewise-constant between observation
+    events and so doesn't continuously track the latent mark. Same V(t) used for both rates
+    (identical valuation seed stream), so the only difference is the dilution divisor.
+    """
+
+    rate = 0.30
+    horizon = 12
+    issuer = _valuation_issuer(annual_dilution_rate=rate)
+    valuation_seeds = (900, 901, 902, 903)
+    valuation = _sample_company_valuation_vectorized(issuer, valuation_seeds=valuation_seeds, horizon_months=horizon)
+    valuation_ratio = valuation / valuation[:, [0]]
+
+    diluted = _dilution_factor(annual_dilution_rate=rate, horizon_months=horizon)
+    undiluted = _dilution_factor(annual_dilution_rate=0.0, horizon_months=horizon)
+    coupled_mark = issuer.current_mark_usd * valuation_ratio / diluted
+    coupled_mark_no_dilution = issuer.current_mark_usd * valuation_ratio / undiluted
+
+    mark_ratio = coupled_mark / coupled_mark[:, [0]]
+    # t == 0: mark ratio equals valuation ratio (dilution_factor(0) == 1).
+    np.testing.assert_allclose(mark_ratio[:, 0], valuation_ratio[:, 0])
+    # t > 0: strictly below the valuation ratio, by exactly the dilution factor.
+    assert np.all(mark_ratio[:, 1:] < valuation_ratio[:, 1:])
+    np.testing.assert_allclose(mark_ratio, valuation_ratio / diluted)
+    # Zero dilution ⇒ coupled mark tracks V(t)/V0 exactly.
+    np.testing.assert_allclose(coupled_mark_no_dilution / issuer.current_mark_usd, valuation_ratio)
+
+
+def test_valuation_channel_off_is_byte_identical_to_pre_m2_baseline() -> None:
+    """Zero-regression guard: turning the channel off must leave mark/event arrays
+    bit-identical to a model with NO valuation fields at all (the pre-M2 shape).
+
+    Both issuers share every legacy parameter and a non-trivial mark random walk plus
+    live adverse hazards, exercised over many rollouts so any perturbation of the level
+    or event RNG streams (e.g. an accidentally-derived valuation seed stream) would show
+    up as a difference. The valuation-fields-present-but-disabled issuer must reproduce
+    the bare issuer exactly, and emit an all-zeros valuation channel.
+    """
+
+    legacy_params: dict[str, object] = {
+        "monthly_log_return_mu": 0.01,
+        "monthly_log_return_sigma": 0.08,
+        "tender_interval_months_median": 9.0,
+        "tender_interval_log_sigma": 0.3,
+        "annual_public_market_probability": 0.05,
+        "annual_collapse_probability": 0.02,
+        "annual_legal_event_probability": 0.05,
+        "annual_forced_sale_probability": 0.02,
+    }
+    rollout_count = 256
+    rollout_seeds = tuple(range(4242, 4242 + rollout_count))
+    request = ExogenousSamplingRequest(
+        horizon_months=18, rollout_seeds=rollout_seeds, required_private_equity_issuers=frozenset({IssuerId("acme")})
+    )
+
+    # Pre-M2 shape: no valuation fields set at all.
+    bare = PrivateEquityRiskProviderConfig(issuers={"acme": _issuer(**legacy_params)}).realize_model().sample(request)
+    # M2 fields present but channel OFF (current_valuation_usd unset). Set the inert
+    # valuation RW params to NON-zero values to prove they cannot leak when the channel
+    # is off (their seed stream is never derived).
+    disabled = (
+        PrivateEquityRiskProviderConfig(
+            issuers={
+                "acme": _issuer(
+                    valuation_monthly_log_return_mu=0.5,
+                    valuation_monthly_log_return_sigma=0.5,
+                    valuation_student_t_nu=3.0,
+                    annual_dilution_rate=0.4,
+                    **legacy_params,
+                )
+            }
+        )
+        .realize_model()
+        .sample(request)
+    )
+
+    def matrix(bundle: SampledExogenousBundle, channel: PrivateEquityFloatChannel) -> np.ndarray:
+        return bundle.private_equity.issuer_float_matrix(
+            "acme", str(channel), rollout_count=rollout_count, horizon_months=18
+        )
+
+    def int_matrix(bundle: SampledExogenousBundle, channel: PrivateEquityIntChannel) -> np.ndarray:
+        return bundle.private_equity.issuer_int_matrix(
+            "acme", str(channel), rollout_count=rollout_count, horizon_months=18
+        )
+
+    # Mark and event-kind arrays must be byte-identical between the bare and disabled issuers.
+    np.testing.assert_array_equal(
+        matrix(bare, PrivateEquityFloatChannel.MARK_USD_PER_UNIT),
+        matrix(disabled, PrivateEquityFloatChannel.MARK_USD_PER_UNIT),
+    )
+    np.testing.assert_array_equal(
+        int_matrix(bare, PrivateEquityIntChannel.EVENT_KIND_CODE),
+        int_matrix(disabled, PrivateEquityIntChannel.EVENT_KIND_CODE),
+    )
+    np.testing.assert_array_equal(
+        int_matrix(bare, PrivateEquityIntChannel.REGIME_CODE), int_matrix(disabled, PrivateEquityIntChannel.REGIME_CODE)
+    )
+    # Disabled channel emits the all-zeros sentinel.
+    np.testing.assert_array_equal(
+        matrix(disabled, PrivateEquityFloatChannel.COMPANY_VALUATION_USD),
+        np.zeros((rollout_count, 19), dtype=np.float64),
+    )
 
 
 if __name__ == "__main__":

--- a/augur/model/testing.py
+++ b/augur/model/testing.py
@@ -29,7 +29,9 @@ class PrivateEquityChannels:
 
     `mark_usd_per_unit` is required; every other channel has a neutral
     default (`PRIVATE_OPERATING` regime, no events, full capacity /
-    eligibility, no forced sale, no liquidity block, no recovery cashout).
+    eligibility, no forced sale, no liquidity block, no recovery cashout,
+    and the opt-in M2 company-valuation channel off — `company_valuation_usd`
+    all-zeros).
     """
 
     mark_usd_per_unit: LevelOverride
@@ -41,6 +43,7 @@ class PrivateEquityChannels:
     forced_sale_fraction: LevelOverride = 0.0
     liquidity_blocked: EventOverride = False
     forced_recovery_cashout_usd: LevelOverride = 0.0
+    company_valuation_usd: LevelOverride = 0.0
 
 
 @dataclass
@@ -103,6 +106,7 @@ def _pe_bundle_from_channels(
         forced_sale_fraction=_level_matrix(channels.forced_sale_fraction, request),
         liquidity_blocked=_event_matrix(channels.liquidity_blocked, request),
         forced_recovery_cashout_usd=_level_matrix(channels.forced_recovery_cashout_usd, request),
+        company_valuation_usd=_level_matrix(channels.company_valuation_usd, request),
         rollout_count=request.rollout_count,
         horizon_months=request.horizon_months,
     )

--- a/augur/plans/prediction_market_calibration.md
+++ b/augur/plans/prediction_market_calibration.md
@@ -14,8 +14,10 @@ read-only with respect to the model; model changes are deliberate and land in
     `model_anchor_date` property month indices are measured from).
   - `resolvers.py` — per-rollout resolution: a `RolloutTrajectory` (one rollout's slice
     of the augur→sim `PrivateEquityBundle`) resolves each `exact` market to YES / NO /
-    UNRESOLVED. Only EVENT markets map cleanly (`ipo_by_date`, `pre_ipo_failure`); augur
-    models neither company valuation nor revenue.
+    UNRESOLVED. Event markets always map cleanly (`ipo_by_date`, `pre_ipo_failure`); with
+    the opt-in M2 valuation channel, `valuation_by_date` ("valuation ≥ $X by date") is also
+    scoreable for issuers carrying `company_valuation_usd` (UNRESOLVED otherwise). Revenue
+    remains unmodeled.
   - `manifold.py` — an injectable `ManifoldClient` (httpx) fetching live YES
     probabilities per market; tests inject a hermetic stub.
   - `calibration.py` — `run_calibration(...) -> CalibrationResult` (p_model + Wilson CI +
@@ -76,15 +78,40 @@ below 2029's 0.93). Competing risks (collapse can preempt) make realized P(IPO b
 under the anchors; M1 also pulls pre-IPO-failure down. The `(cdf_anchors → monthly hazard +
 tail)` machinery is generic — reusable for any event we get market term structure for.
 
-### M2 — company valuation + dilution, decoupled from per-unit mark
+### M2 — company valuation + dilution, coupled to the per-unit mark ✅ (mark v1 landed)
 
-augur emits only a per-**unit** mark, so (a) the valuation markets ($1T-by-date) are
-unmappable and (b) the per-share value the user holds ignores **dilution** (new shares in
-funding rounds erode per-share value even as the company cap grows). Add a company
-market-cap trajectory + a share-count/dilution process with `mark = cap / shares`: the
-valuation markets become scoreable (more calibration signal) and the holding value reflects
-dilution — the most realistic-but-missing piece for the actual finance question. Cost: a few
-more parameters to fit. **Worth it — stage after M1.**
+augur used to emit only a per-**unit** mark, so (a) the valuation markets ($1T-by-date) were
+unmappable and (b) the per-share value the user holds ignored **dilution** (new shares in
+funding rounds erode per-share value even as the company cap grows).
+
+**Landed (v1, opt-in).** `PrivateEquityRiskIssuerConfig` gains a `current_valuation_usd`
+anchor (`V0`); when set, the per-unit latent mark stops being a standalone Student-t random
+walk and becomes a quantity DERIVED from a sampled company valuation `V(t)` and a
+deterministic dilution factor:
+
+```
+latent_mark(t) = current_mark_usd × (V(t) / V0) / dilution_factor(t)
+dilution_factor(t) = (1 + annual_dilution_rate) ** (t / 12)   # dilution_factor(0) = 1
+```
+
+`V(t)` is a log-space Student-t random walk anchored at `V0`, driven by its OWN derived seed
+stream (`<issuer>:pe_risk_valuation`) and its own RW params (`valuation_monthly_log_return_mu/
+sigma`, `valuation_student_t_nu`). Only ratios enter the mark, so `V0`/`shares0` cancel at
+`t=0` and `latent_mark[:,0] == current_mark_usd` exactly while `company_valuation_usd[:,0] ==
+current_valuation_usd`. The valuation flows out on the new `PrivateEquityBundle`
+`company_valuation_usd` channel, which makes `valuation_by_date` markets scoreable
+(`resolvers.py`).
+
+**Opt-in / zero-regression.** Leaving `current_valuation_usd` unset selects the legacy
+independent latent-mark random walk verbatim and emits an all-zeros `company_valuation_usd`
+channel (the channel-off sentinel: a positive market cap is never all-zeros). The valuation
+seed stream is NOT derived in the off branch, so the mark/event arrays stay byte-identical to
+pre-M2 for every existing config — guarded by a fixed-seed regression test.
+
+**Deferred to M2.2** (TODO.md "Fit the PE valuation + share-dilution process"): `shares0` and
+`annual_dilution_rate` are v1 point estimates; the primary-issuance vs secondary-trade
+dilution split and the hierarchical Bayesian fit of the dilution rate + valuation drift/vol
+from paired (price, valuation) series are not yet done.
 
 ### M3 — IPO lockup: probabilistic + refined
 

--- a/augur/sim/simulate_test.py
+++ b/augur/sim/simulate_test.py
@@ -3895,6 +3895,7 @@ def _pe_external_series(
             forced_recovery_cashout_usd=forced_recovery_cashout_usd
             if forced_recovery_cashout_usd is not None
             else default_float(0.0),
+            company_valuation_usd=default_float(0.0),
             rollout_count=rollout_count,
             horizon_months=horizon_months,
         ),


### PR DESCRIPTION
## What

Adds the opt-in **M2 coupled company-valuation + dilution** channel to the
private-equity risk model, makes `valuation_by_date` prediction markets
scoreable, and threads a new required `company_valuation_usd` channel through
the typed `PrivateEquityBundle`.

## Coupled-mark formula

When an issuer sets `current_valuation_usd` (V0), the per-unit latent mark stops
being a standalone Student-t random walk and becomes a derived quantity:

```
latent_mark(t) = current_mark_usd × (V(t) / V0) / dilution_factor(t)
dilution_factor(t) = (1 + annual_dilution_rate) ** (t / 12)     # dilution_factor(0) = 1
```

`V(t)` is a log-space Student-t random walk anchored at V0, driven by its OWN
derived seed stream (`<issuer>:pe_risk_valuation`) and its own RW params
(`valuation_monthly_log_return_mu/sigma`, `valuation_student_t_nu`). Only ratios
enter the mark, so V0/shares0 cancel at t=0: `latent_mark[:,0] ==
current_mark_usd` and `company_valuation_usd[:,0] == current_valuation_usd`
exactly. Event-noisy marks (tender/admin/public-market/forced-sale) compose on
top of the coupled mark unchanged. A positive `annual_dilution_rate` makes the
coupled mark grow strictly slower than V(t)/V0, by exactly the dilution factor.

## Opt-in gating + zero-regression invariant

Leaving `current_valuation_usd` unset selects the **legacy independent
latent-mark random walk verbatim** and emits an **all-zeros**
`company_valuation_usd` channel — the channel-off sentinel (a real market cap is
strictly positive, so all-zeros is unambiguous). The valuation seed stream is
NOT derived in the off branch, so neither the level nor the event RNG stream is
perturbed and the mark/event arrays stay **byte-identical** to pre-M2 for every
existing config.

**How I proved it:** `test_valuation_channel_off_is_byte_identical_to_pre_m2_baseline`
samples two issuers over 256 rollouts × 18 months with live adverse hazards and
a non-trivial mark random walk: (a) a *bare* issuer with no valuation fields at
all (the pre-M2 shape), and (b) an issuer with the M2 fields present but the
channel OFF, where the inert valuation RW params + `annual_dilution_rate` are set
to **non-zero** values to prove they cannot leak when the channel is off. The
test asserts `mark_usd_per_unit`, `event_kind_code`, and `regime_code` are
`array_equal` between the two, and that the disabled issuer emits an all-zeros
`company_valuation_usd`. No pre-existing test needed an expected-VALUE change —
only the new column was threaded — so the coupling did not leak into the legacy
path.

## Producer audit (the unfinished piece)

`company_valuation_usd` is now a required kwarg of
`PrivateEquityBundle.from_issuer_arrays`. All four producers updated:

- `augur/model/private_equity_risk.py` — real producer; emits sampled `V(t)`
  when the channel is on, all-zeros otherwise.
- `augur/model/private_equity_protocol.py` (`neutral_private_equity_issuer_bundle`)
  — zeros (no market-cap concept; this is the path the `trained_private_equity`
  model uses, so that producer is covered too).
- `augur/model/testing.py` (`PrivateEquityChannels` + `_pe_bundle_from_channels`)
  — new fixture channel defaulting to `0.0` (off), threaded like the other floats.
- `augur/sim/simulate_test.py` — zeros (was already done by the prior agent).

The sim compiler/codec consume the bundle by **named column**
(`compile_pe_channels` reads specific columns; `PEChannels` is unchanged), so the
new channel threads through unread by consumers — no engine-semantics change.

## `valuation_by_date` semantics

`resolve_valuation_by_date(traj, threshold_usd, by_month)`:

- **UNRESOLVED** if the issuer has no valuation channel (`company_valuation_usd is
  None`) — not scoreable.
- **YES** if `V(m) ≥ threshold` for any month `m ≤ min(by_month, horizon)`.
- **NO** if the threshold is never reached and `by_month ≤ horizon` (whole window
  simulated).
- **UNRESOLVED** if the deadline lies beyond the simulated horizon and the
  threshold has not yet been reached (might cross later).

`trajectories_from_bundle` reads the issuer's `company_valuation_usd` matrix and
passes `None` to each `RolloutTrajectory` when it is all-zeros (detected once per
issuer, so a rollout that dips to 0 inside an active channel isn't misread).

## Tests

- `model/private_equity_risk_test.py`: channel-off-by-default zeros; channel-on
  column-0 anchoring (`valuation[:,0]==V0`, `mark[:,0]==current_mark`);
  determinism under fixed `rollout_seeds`; `_dilution_factor` values; positive
  dilution makes the coupled mark grow strictly slower than V/V0 (verified on the
  sampler building blocks, since the observed mark channel is piecewise-constant
  between observation events); and the byte-identical zero-regression guard above.
- `calibration/test_resolvers.py`: `resolve_valuation_by_date` YES/NO/UNRESOLVED
  incl. threshold-never-reached, deadline-beyond-horizon, and channel-None; plus
  `valuation_by_date` dispatch through `resolve_market`.

## Docs

- `augur/SPEC.md` — added `company_valuation_usd` to the PE float-channel list
  (now ten channels).
- `augur/plans/prediction_market_calibration.md` — M2 section marked landed
  (coupled, opt-in, `valuation_by_date`); primary/secondary split + Bayesian fit
  deferred to M2.2.
- `augur/TODO.md` — reframed the valuation/dilution item as M2.2 (what landed vs.
  what remains).

## Drive-by fixes required for a green `//augur/...`

Both pre-existing and unrelated to the feature:

- mypy `float | None` narrowing error in the new sampler (the prior agent's code
  divided by / `math.log`'d `current_valuation_usd` behind a property guard mypy
  couldn't follow) — switched to a direct `is not None` check / local assert.
- `augur/calibration/test_manifold.py` mock JSON was missing the now-required
  `url` field on `ManifoldMarket` (added in #1743 without updating the test
  mocks); added `url` to the two inline handlers.

## Verification

- `bbr test //augur/...` — **green, 43/43 tests pass.** BuildBuddy Bazel
  invocation: `1ea29fe9-04ff-43b2-85db-96c681d7886b`
  (bbr wrapper `a610961b-dece-40ae-99a8-dc12e1a1c7da`). Lint (ruff + mypy aspects)
  ran as part of the build and passed.
- `pre-commit run --all-files` — all hooks green.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_