### PR TITLE
augur/plans: encode M2.2 stochastic-dilution design + phased trackers

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -103,22 +103,36 @@ are deleted and the CI prefix-guard is in place.
       `macro_market_bundle_provider` shape directly; mine it only for
       data loading/config ideas after the native `SampledExogenousBundle`
       API is the target.
-- [ ] **Fit the PE valuation + share-dilution process, not just static
-      points (M2.2).** M2 (`augur/plans/prediction_market_calibration.md`) landed
-      the coupled, opt-in company-valuation channel:
-      `latent_mark = current_mark × (V(t)/V₀) / dilution_factor(t)` on
-      `current_valuation_usd`, with `V(t)` a Student-t random walk and
-      `dilution_factor(t) = (1 + annual_dilution_rate)^(t/12)`, flowing out on the
-      `PrivateEquityBundle.company_valuation_usd` channel and scoring
-      `valuation_by_date` markets. Still v1 point estimates: `shares_outstanding_initial`
-      and `annual_dilution_rate` are hand-set, and the valuation RW params are not
-      evidence-fit. The trainer also still collapses `valuation_observation`s to a
-      single static `scale_prior.current_market_cap_usd`. Remaining work: make the
-      scale **dynamic and Bayesian** — fit a posterior over the dilution rate and the
-      valuation drift/vol jointly from the paired (price, valuation) series so
-      `shares(t)` / `V(t)` carry real uncertainty instead of hand-set points — and
-      distinguish primary-issuance dilution (funding rounds) from secondaries
-      (no new shares) and employee-equity (PPU/RSU) issuance.
+- **Stochastic dilution + evidence fit (M2.2).** M2
+  (`augur/plans/prediction_market_calibration.md`) landed the coupled, opt-in
+  company-valuation channel —
+  `latent_mark = current_mark × (V(t)/V₀) / dilution_factor(t)` with `V(t)` a Student-t
+  random walk — but `dilution_factor(t) = (1 + annual_dilution_rate)^(t/12)` is
+  **deterministic** (identical in every rollout → zero per-share spread; all holding-value
+  uncertainty currently comes from `V(t)`), and `shares_outstanding_initial` /
+  `annual_dilution_rate` / the valuation RW params are hand-set, not evidence-fit. The
+  trainer still collapses `valuation_observation`s to a static
+  `scale_prior.current_market_cap_usd`. Design + rationale (structure vs fit, identifiability,
+  the primary/secondary + stale-FMV likelihood caveats) is the **M2.2 section** of
+  `augur/plans/prediction_market_calibration.md`. Staged:
+  - [ ] **M2.2-A — per-rollout stochastic dilution rate (do first).**
+        `r ~ LogNormal(μ_r, σ_r)` drawn once per rollout off its own seed stream (mirror
+        `V(t)`'s `:pe_risk_valuation`), `shares(t) = shares₀·(1+r)^(t/12)` into the mark
+        formula. Add config `annual_dilution_rate_log_sigma`; MAP/SVI-fit `μ_r, σ_r` from the
+        implied-share-growth series in `augur/fit`. Independent of `V(t)` for now
+        (conservatively over-states per-share spread; the hedge is M2.2-B). Touches only the
+        dilution side — no new bundle event kind.
+  - [ ] **M2.2-B — V↔dilution correlation.** Joint per-rollout `(V log-drift, r)` draw with
+        fitted ρ (good-company worlds dilute more → per-share partly hedged; independence
+        over-states per-share spread). Makes `V(t)`'s drift per-rollout — a change to the V
+        sampler, hence its own phase.
+  - [ ] **M2.2-C — lumpiness + secondary rigor (deferred).** Discrete primary-round dilution
+        as a new V-coupled event kind, distinct from the existing (secondary) tender events;
+        likelihood that attributes only primary rounds to share growth and treats secondaries
+        (e.g. the 2025-10 employee tender) as pure re-pricing.
+  - [ ] **M2.2-D — full Bayesian posterior (deferred).** Replace MAP/SVI point-of-distribution
+        with NUTS + posterior-predictive propagation so the (fat by design) `σ_r` posterior
+        folds epistemic ignorance into the per-rollout spread.
 
 ## Liquidity Policy
 

--- a/augur/plans/prediction_market_calibration.md
+++ b/augur/plans/prediction_market_calibration.md
@@ -108,10 +108,69 @@ channel (the channel-off sentinel: a positive market cap is never all-zeros). Th
 seed stream is NOT derived in the off branch, so the mark/event arrays stay byte-identical to
 pre-M2 for every existing config — guarded by a fixed-seed regression test.
 
-**Deferred to M2.2** (TODO.md "Fit the PE valuation + share-dilution process"): `shares0` and
-`annual_dilution_rate` are v1 point estimates; the primary-issuance vs secondary-trade
-dilution split and the hierarchical Bayesian fit of the dilution rate + valuation drift/vol
-from paired (price, valuation) series are not yet done.
+### M2.2 — stochastic dilution + evidence fit
+
+v1's `dilution_factor(t) = (1 + annual_dilution_rate)^(t/12)` is **deterministic**: an
+identical curve in every rollout, so dilution only shifts the per-unit-mark distribution
+down — it adds **zero** per-share spread. All current holding-value uncertainty comes from
+`V(t)`. M2.2 makes share count per-rollout-random and fits the parameters to evidence, in two
+themes — **structure** (what the random object is) and **fit** (how its parameters are
+chosen) — staged A→D so each lands on its own.
+
+**Structure.** Two physically-distinct sources of dilution uncertainty:
+
+1. _Rate uncertainty (epistemic)._ We don't know the long-run mint rate. Model as a
+   per-rollout fixed draw `r ~ LogNormal(μ_r, σ_r)`, applied geometrically
+   `shares(t) = shares0 · (1 + r)^(t/12)`. log-share variance grows **quadratically** in t →
+   a widening cone. This dominates the 10-year per-share spread (the holding-value question).
+2. _Timing/lumpiness (aleatoric)._ Even given a rate, primary rounds land at random months
+   with random sizes (~4–14%/round, ~annual). A within-path process; variance grows
+   **linearly** in t. Matters for path shape; averages out for terminal value. Maps to the
+   real split: continuous employee mint (PPU/RSU → the smooth drift `r`) + discrete primary
+   rounds (lumpy). Secondaries (e.g. the 2025-10 ~$500B employee tender) **re-price but do not
+   dilute**, so any lumpy term must fire on _primary_ rounds only — a new event kind distinct
+   from the model's existing (secondary) tender events.
+
+**Fit.** A latent-trajectory (state-space) fit in `augur/fit` (which already ingests
+`valuation_observation`s but collapses them to a static `scale_prior.current_market_cap_usd`):
+
+```
+log price(t)  = log V(t) − log shares(t)  (+ obs noise)   ← tender prices (tight) + FMV (loose, lagged)
+log V(t)      = latent GBM (drift μ_V, vol σ_V)           ← valuation_observations
+log shares(t) = log shares0 + (t/12)·log(1+r)
+```
+
+Likelihood constraints the data **forces** (naive fitting gets these wrong): (a) attribute
+share growth to _primary_ rounds only — a _secondary_ valuation obs constrains `V(t)` but not
+`shares`; observations are already round-type tagged. (b) The $687.69 FMV is a stale (~4mo)
+administrative mark → large/lagged obs noise, unlike tight tender prices; `V0/shares0` ≈
+$824/sh vs the $687.69 mark — that ~20% wedge **is** the staleness and the fit should _explain_
+it via the lag term, not force-reconcile it. (c) `shares0 ≈ 1.034B` is a soft recap-era prior,
+not an anchor. Identifiability is honest: `μ_r`, `μ_V`, `σ_V` are reasonably pinned (implied
+shares ≈ 418M @2023-04 → 749M @2024-10 → ~1.2B @2026 ≈ **30–40%/yr**, _above_ v1's hand-set
+20%); **`σ_r` is poorly pinned by ~5 paired points — by design**, since that sparsity _is_ the
+dilution uncertainty M2.2 expresses, so `σ_r` should come out wide and a fit should say so via
+a fat posterior (argues for propagating parameter uncertainty into the per-rollout draw).
+
+**Staging** (tracked in `augur/TODO.md`):
+
+- **M2.2-A — per-rollout stochastic dilution rate (ship first).** `r ~ LogNormal(μ_r, σ_r)`
+  drawn once per rollout off its own seed stream (mirroring `V(t)`'s `:pe_risk_valuation`),
+  into the existing mark formula. New config `annual_dilution_rate_log_sigma`; MAP/SVI-fit
+  `μ_r, σ_r` from the implied-share-growth series. Independent of `V(t)` (conservatively
+  _over_-states per-share spread by omitting the hedge in B). Touches only the dilution side —
+  no new bundle event machinery.
+- **M2.2-B — V↔dilution correlation.** Good-company worlds (V rises fast) raise more primary
+  capital → dilute more, so per-share is partly hedged; drawing `r` independent of `V` _over_-
+  states per-share spread. Make _both_ `V`'s log-drift and `r` per-rollout draws from a joint
+  fitted posterior with correlation ρ. Requires making `V(t)`'s drift per-rollout (a change to
+  the V sampler, not just dilution), so it is its own phase.
+- **M2.2-C — lumpiness + secondary rigor (deferred).** Discrete primary-round dilution as a new
+  V-coupled event kind, distinct from the existing (secondary) tender events; likelihood that
+  attributes only primary rounds to share growth and treats secondaries as pure re-pricing.
+- **M2.2-D — full Bayesian posterior (deferred).** Replace MAP/SVI point-of-distribution with
+  NUTS + posterior-predictive propagation, so the (fat by design) `σ_r` posterior folds
+  epistemic ignorance into the per-rollout spread.
 
 ### M3 — IPO lockup: probabilistic + refined
 

--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -262,9 +262,10 @@ the wrong structure.
   can run in parallel with anything.
 - **Prediction-market calibration + model adjustments** — the structured exogenous
   model is scored against Manifold via `augur/calibration` + `/api/calibration` + the
-  frontend calibration tab. The model-adjustment roadmap (empirical IPO prior shipped;
-  valuation/dilution, probabilistic IPO lockup, calibration loop next) lives in
-  [`augur/plans/prediction_market_calibration.md`](prediction_market_calibration.md).
+  frontend calibration tab. The model-adjustment roadmap (M1 empirical IPO prior and M2
+  valuation/dilution mark-coupling shipped; M2.2 stochastic dilution + evidence fit — staged
+  A→D, M2.2-A per-rollout rate next — then M3 probabilistic IPO lockup and M4 calibration loop)
+  lives in [`augur/plans/prediction_market_calibration.md`](prediction_market_calibration.md).
 - **Reintroduce partner/co-owner agreements** after sim has a tested agreement
   model. "Agent X pays agent Y this amount over this period for this share/claim"
   should come back as a tested agreement model in `augur/sim`, not as a


### PR DESCRIPTION
## What

Encodes the **M2.2 (stochastic dilution + evidence fit)** design we worked out, and stages it **A→D** in the trackers so the first slice ships on its own and the deferred pieces are tracked. Docs/plan only — no code.

## Why now

M2 v1 shipped a **deterministic** dilution factor (`(1+annual_dilution_rate)^(t/12)`, identical in every rollout → zero per-share spread; all holding-value uncertainty currently comes from `V(t)`), with `shares0` / `annual_dilution_rate` / valuation RW params hand-set. M2.2 makes share count per-rollout-random and evidence-fit. Recording the structure + fit reasoning before implementation so the phasing and the (deliberately deferred) follow-ups don't get lost.

## The plan (in `prediction_market_calibration.md` → M2.2 section)

**Structure** — two distinct uncertainty sources: per-rollout *rate* draw `r ~ LogNormal(μ_r, σ_r)` (epistemic; variance quadratic in t → the dominant 10-year per-share cone) vs *lumpiness* of discrete primary rounds (aleatoric; linear in t; averages out for terminal value). Secondaries re-price but don't dilute.

**Fit** — a latent `V(t)`+`shares(t)` state-space fit in `augur/fit` reading the valuation series (→ `V`) and tender/FMV prices (→ `V/shares`), with the likelihood caveats the data forces: primary-only share attribution, stale-FMV obs-lag (the ~20% `V0/shares0` vs $687.69 wedge), `shares0` as soft prior. Honest identifiability: `μ_r`/`μ_V`/`σ_V` reasonably pinned (implied shares imply ~30–40%/yr, above v1's 20%); **`σ_r` wide by design** from ~5 paired points — that sparsity *is* the dilution uncertainty.

## Staging (checklist in `augur/TODO.md`)

- **M2.2-A — per-rollout stochastic dilution rate (do first).** `r ~ LogNormal` off its own seed stream; add `annual_dilution_rate_log_sigma`; MAP/SVI-fit `μ_r, σ_r`. Independent of `V(t)`; no new bundle event kind. **Shippable on its own.**
- **M2.2-B — V↔dilution correlation (ρ).** Joint per-rollout `(V drift, r)` draw; corrects A's over-stated per-share spread (good-company worlds dilute more → partial hedge). Makes `V`'s drift per-rollout → its own phase.
- **M2.2-C — lumpiness + secondary rigor (deferred).** Discrete primary-round event kind, distinct from existing (secondary) tenders.
- **M2.2-D — full Bayesian posterior (deferred).** NUTS + posterior-predictive propagation.

Per the steer: OK to start without secondary handling, lumpiness, or full posterior (those are C/D); A/B carry the near-term work, all four tracked.

## Files
- `augur/plans/prediction_market_calibration.md` — full M2.2 design section (replaces the 4-line "Deferred" stub).
- `augur/TODO.md` — prose item → phased A–D checklist pointing at the design.
- `augur/plans/roadmap.md` — calibration status line refreshed (M1+M2 shipped, M2.2-A next).

> Note: the roadmap calibration-status line is also touched by the open #1754 (regime-cleanup) — trivial overlap; whichever merges second rebases that one line.

## Verification
`pre-commit run --files augur/TODO.md augur/plans/prediction_market_calibration.md augur/plans/roadmap.md` — all applicable hooks pass (prettier, trailing-whitespace, ducktape hooks). Docs only.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_