### PR TITLE
augur/frontend: prettier-format calibration.jsx (fix devel pre-commit)

### DIFF
--- a/augur/frontend/calibration.jsx
+++ b/augur/frontend/calibration.jsx
@@ -337,12 +337,7 @@ export function CalibrationWorkspace({ bootstrap, rolloutCount, exogenousModel }
     <CurrencyDisplayProvider value={currencyDisplayContext}>
       <div className="min-w-0 space-y-5">
         <section className="grid min-w-0 gap-5 min-[864px]:grid-cols-[28rem_minmax(0,1fr)]">
-          <CalibrationForm
-            input={input}
-            catalog={catalog}
-            exogenousModel={exogenousModel}
-            onChange={updateInput}
-          />
+          <CalibrationForm input={input} catalog={catalog} exogenousModel={exogenousModel} onChange={updateInput} />
 
           <div className="min-w-0 space-y-5">
             {runError ? (


### PR DESCRIPTION
## What

Reformats `augur/frontend/calibration.jsx` to satisfy the repo's `prettier` hook — collapses the multi-line `<CalibrationForm>` element onto a single line.

## Why

`devel` was red on the **pre-commit** check ([run 26693627980](https://github.com/agentydragon/ducktape/actions/runs/26693627980)): `prettier` reformatted this file, so the hook exited non-zero. The change landed in #1754 without `pre-commit` having run locally.

## Scope

Single-line formatting change; no behavior change. Rebased onto current `devel` (atop #1758).

The `bazel-ci` / `//augur:visual_test` failure that was also red on the old `devel` HEAD was **already fixed by #1758** ("fix shared exogenous-model wiring missed by #1753 squash", which also regenerated the three goldens) — so it is **not** part of this PR. I verified on the rebased tree via RBE that `//augur:visual_test` now **passes**, and that `prettier --check` passes with the repo's plugin config.

https://claude.ai/code/session_01S5UXQ6L1ZXcE4t3hgRVSuX