### PR TITLE
augur(calibration): drop dead CleanRow wire fields; fix KL threshold comment

### DIFF
--- a/augur/api/test_calibration_endpoint.py
+++ b/augur/api/test_calibration_endpoint.py
@@ -61,10 +61,10 @@ def test_run_calibration(client: TestClient) -> None:
     clean_row = result["clean"][0]
     # Every market's p_market is the injected live stub price.
     assert clean_row["p_market"] == 0.5
-    # Snake_case on the wire (the frontend camelizes). p_model/kl_bits/resolution_deadline
-    # are optional (dropped when None — e.g. no rollout resolved within the horizon), so we
-    # only require the always-present fields here.
-    assert {"slug", "mapping_kind", "p_market", "ci95", "n_resolved", "unresolved"} <= set(clean_row)
+    # Snake_case on the wire (the frontend camelizes). p_model/kl_bits are optional (dropped when
+    # None — e.g. no rollout resolved within the horizon), so we only require the always-present
+    # fields here.
+    assert {"slug", "question", "url", "p_market", "ci95", "n_resolved", "unresolved"} <= set(clean_row)
     surfaced_row = result["surfaced"][0]
     assert {"slug", "question", "url", "mappability", "p_market"} <= set(surfaced_row)
     assert surfaced_row["p_market"] == 0.5

--- a/augur/calibration/calibration.py
+++ b/augur/calibration/calibration.py
@@ -89,11 +89,6 @@ class CleanRow(BaseModel):
     # Canonical Manifold market page, fetched live alongside the price (the catalog stores
     # only a slug). The frontend links the question title to this URL.
     url: str
-    mapping_kind: str
-    # The nullable fields default to None so the generated Zod schema treats them as
-    # optional. The endpoint drops None-valued keys (`exclude_none=True`); without a
-    # default the codegen emits required `.nullable()` and rejects the omitted key.
-    resolution_deadline: date | None = None
     p_market: float
     p_model: float | None = None  # None when no rollout resolved YES/NO within the horizon
     ci95: tuple[float, float]
@@ -157,8 +152,6 @@ def _clean_row(market: ExactMarket, trajectories: list[RolloutTrajectory], manif
         slug=market.slug,
         question=market.question,
         url=manifold.url,
-        mapping_kind=market.mapping_kind,
-        resolution_deadline=market.resolution_deadline,
         p_market=p_market,
         p_model=p_model,
         ci95=wilson_interval(yes, n),

--- a/augur/frontend/calibration.jsx
+++ b/augur/frontend/calibration.jsx
@@ -31,7 +31,8 @@ function fmtBits(value) {
 }
 
 // Bigger model-vs-market divergences get a louder tint so the eye lands on the disagreements
-// first. Thresholds are in bits of D_KL (≈0.03 bits ≈ a 0.4-vs-0.25 forecast gap).
+// first. Thresholds are in bits of D_KL: amber ≥0.05 bits (≈ a market at 0.50 vs model 0.37),
+// rose ≥0.15 bits (≈ 0.50 vs 0.29).
 function klToneClass(klBits) {
   if (klBits == null || !Number.isFinite(Number(klBits))) return "";
   if (klBits >= 0.15) return "bg-rose-50 dark:bg-rose-950/30";


### PR DESCRIPTION
Two small calibration cleanups (follow-ups to #1759).

## Drop dead `CleanRow` wire fields

The scored-markets table stopped rendering the **Mapping** and **Deadline** columns in #1759, but the API still computed and shipped `CleanRow.mapping_kind` and `CleanRow.resolution_deadline` on the wire. Removed both from the Pydantic model and the `_clean_row` constructor.

The catalog `ExactMarket` still carries `mapping_kind` / `resolution_deadline` — those are real inputs to `resolve_market` and `_augur_context`; only the redundant copies on the response row are gone. The endpoint test's required-wire-keys assertion is updated (now also asserts `question`/`url`).

## Fix inaccurate KL threshold comment

The tint-threshold comment in `calibration.jsx` claimed "≈0.03 bits ≈ a 0.4-vs-0.25 forecast gap". The actual `D_KL(0.40 ‖ 0.25)` is **0.078 bits**. Corrected it to state the amber (≥0.05) and rose (≥0.15) thresholds with accurate reference points (market 0.50 vs model ≈0.37 / ≈0.29).

## Verification (BuildBuddy RBE)

`//augur/calibration/...` + `//augur/api/...` — **12/12 pass** (incl. `export_schema_test` confirming the regenerated Zod schema is consistent). No visual goldens affected — the columns were already gone in #1759.

https://claude.ai/code/session_01GfJT1ZY5GwfSdomKKbRPTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfJT1ZY5GwfSdomKKbRPTF)_