### PR TITLE
augur: apply calibration ruff formatting

### DIFF
--- a/augur/calibration/calibration.py
+++ b/augur/calibration/calibration.py
@@ -70,7 +70,6 @@ def kl_bits_market_vs_model(p_market: float, p_model: float) -> float:
     return max(0.0, total)
 
 
-
 class AugurContext(BaseModel):
     """A related (NOT equal) augur signal surfaced next to a market that isn't scored."""
 


### PR DESCRIPTION
## Summary
- Remove the extra blank line in augur/calibration/calibration.py that made the devel pre-commit ruff-format hook rewrite the file.

## Verification
- pre-commit run ruff-format --files augur/calibration/calibration.py
- commit hook suite for the scoped commit