### PR TITLE
secrets: don't leak strict-mode shell options when env scripts are sourced

### DIFF
--- a/devinfra/secrets/_common.sh
+++ b/devinfra/secrets/_common.sh
@@ -8,7 +8,26 @@
 #
 # On failure, writes diagnostics to stderr. Scripts export vars directly
 # into the current shell — source them, don't eval their stdout.
+#
+# These scripts are *sourced* into the caller's shell, so they must not leak their
+# strict-mode options. A leaked `set -u` in particular breaks later interactive
+# commands that legitimately reference unset variables — e.g. Claude Code's
+# shell-snapshot `grep`/`find` wrappers probe `[[ -n $ZSH_VERSION ]]`, which aborts
+# with "ZSH_VERSION: unbound variable" once nounset is on. So we snapshot the
+# caller's option state here and the entrypoint scripts restore it via
+# `_secrets_restore_shell_opts` as their last line.
+_secrets_saved_shell_opts="$(set +o)"
 set -euo pipefail
+
+# Restore the caller's shell options captured above (errexit/nounset/pipefail), so
+# strict mode covers our own execution without persisting into the sourcing shell.
+# Idempotent and self-cleaning; called at the end of each entrypoint (cli/web/ci_env).
+_secrets_restore_shell_opts() {
+  [ -n "${_secrets_saved_shell_opts:-}" ] || return 0
+  eval "$_secrets_saved_shell_opts"
+  unset _secrets_saved_shell_opts
+  unset -f _secrets_restore_shell_opts
+}
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 

--- a/devinfra/secrets/_common.sh
+++ b/devinfra/secrets/_common.sh
@@ -21,12 +21,13 @@ set -euo pipefail
 
 # Restore the caller's shell options captured above (errexit/nounset/pipefail), so
 # strict mode covers our own execution without persisting into the sourcing shell.
-# Idempotent and self-cleaning; called at the end of each entrypoint (cli/web/ci_env).
+# Called at the end of each entrypoint (cli/web/ci_env). Idempotent: once the saved
+# state is consumed the guard makes any further call a no-op. (The function itself is
+# left defined — bash can't unset a function from within its own running body.)
 _secrets_restore_shell_opts() {
   [ -n "${_secrets_saved_shell_opts:-}" ] || return 0
   eval "$_secrets_saved_shell_opts"
   unset _secrets_saved_shell_opts
-  unset -f _secrets_restore_shell_opts
 }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/devinfra/secrets/ci_env.sh
+++ b/devinfra/secrets/ci_env.sh
@@ -1,37 +1,15 @@
 #!/usr/bin/env bash
-# CI environment: common secrets + registry/release credentials.
+# CI environment: common secrets only (BuildBuddy). No machine-user identity.
+#
+# Sourced by CI steps that need BuildBuddy credentials without the full
+# web/CLI secret set.
+#
 # Usage: source devinfra/secrets/ci_env.sh
 #
-# Age recipients: ci (+ admin via _common.sh)
-#   secrets/ci/*.sops.yaml:             admin, ci
-#
-# Consumed by:
-#   - .github/actions/setup-ci-secrets (GitHub Actions)
-#
-# GITHUB_TOKEN is NOT sourced from SOPS here. GHCR pushes and any other
-# workflow-run-scoped GitHub API use `${{ secrets.GITHUB_TOKEN }}` (the
-# workflow-scoped token GitHub Actions provisions per run) plumbed through
-# `bb remote`'s `x-buildbuddy-platform.env-overrides`. See
-# .github/workflows/push-images.yml for the wiring.
-#
-# TODO: secrets/ci/ghcr-credentials.sops.yaml is no longer consumed by any
-# CI workflow after the migration to secrets.GITHUB_TOKEN. It can be deleted
-# once no out-of-tree consumer depends on it; keeping it temporarily so the
-# change is trivially revertible.
-
 # shellcheck source=_common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+# ci_env.sh adds nothing beyond _common.sh today; it exists as the documented
+# CI entry point and a seam for future CI-only secrets.
 
-# Attic binary cache writer token for `main` namespace.
-# Auto-rotated by the attic-rotate-ducktape-ci-writer CronJob in the cluster
-# (see cluster/k8s/agents/attic-jwt-rotation/).
-# CLEANUP(2026-05-04): Delete secrets/ci/attic-token.sops.yaml once no
-# out-of-tree consumer reads it.
-try_export ATTIC_TOKEN "$REPO_ROOT/secrets/ci/attic-main-writer.sops.yaml" '["attic_token"]'
-
-# Harbor CI robot
-try_export PROPS_REGISTRY_USERNAME "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["username"]'
-try_export PROPS_REGISTRY_PASSWORD "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["password"]'
-
-# GitHub releases (agentydragon account, contents:write on ducktape)
-try_export GH_RELEASE_PAT "$REPO_ROOT/secrets/ci/gh-release-pat.sops.yaml" '["token"]'
+# Restore the caller's shell options (don't leak our `set -euo pipefail`; see _common.sh).
+_secrets_restore_shell_opts

--- a/devinfra/secrets/ci_env.sh
+++ b/devinfra/secrets/ci_env.sh
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
-# CI environment: common secrets only (BuildBuddy). No machine-user identity.
-#
-# Sourced by CI steps that need BuildBuddy credentials without the full
-# web/CLI secret set.
-#
+# CI environment: common secrets + registry/release credentials.
 # Usage: source devinfra/secrets/ci_env.sh
 #
+# Age recipients: ci (+ admin via _common.sh)
+#   secrets/ci/*.sops.yaml:             admin, ci
+#
+# Consumed by:
+#   - .github/actions/setup-ci-secrets (GitHub Actions)
+#
+# GITHUB_TOKEN is NOT sourced from SOPS here. GHCR pushes and any other
+# workflow-run-scoped GitHub API use `${{ secrets.GITHUB_TOKEN }}` (the
+# workflow-scoped token GitHub Actions provisions per run) plumbed through
+# `bb remote`'s `x-buildbuddy-platform.env-overrides`. See
+# .github/workflows/push-images.yml for the wiring.
+#
+# TODO: secrets/ci/ghcr-credentials.sops.yaml is no longer consumed by any
+# CI workflow after the migration to secrets.GITHUB_TOKEN. It can be deleted
+# once no out-of-tree consumer depends on it; keeping it temporarily so the
+# change is trivially revertible.
+
 # shellcheck source=_common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
-# ci_env.sh adds nothing beyond _common.sh today; it exists as the documented
-# CI entry point and a seam for future CI-only secrets.
 
-# Restore the caller's shell options (don't leak our `set -euo pipefail`; see _common.sh).
+# Attic binary cache writer token for `main` namespace.
+# Auto-rotated by the attic-rotate-ducktape-ci-writer CronJob in the cluster
+# (see cluster/k8s/agents/attic-jwt-rotation/).
+# CLEANUP(2026-05-04): Delete secrets/ci/attic-token.sops.yaml once no
+# out-of-tree consumer reads it.
+try_export ATTIC_TOKEN "$REPO_ROOT/secrets/ci/attic-main-writer.sops.yaml" '["attic_token"]'
+
+# Harbor CI robot
+try_export PROPS_REGISTRY_USERNAME "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["username"]'
+try_export PROPS_REGISTRY_PASSWORD "$REPO_ROOT/secrets/ci/harbor-ci-robot.sops.yaml" '["password"]'
+
+# GitHub releases (agentydragon account, contents:write on ducktape)
+try_export GH_RELEASE_PAT "$REPO_ROOT/secrets/ci/gh-release-pat.sops.yaml" '["token"]'
+
+# Restore the caller's shell options (do not leak our `set -euo pipefail`; see _common.sh).
 _secrets_restore_shell_opts

--- a/devinfra/secrets/cli_env.sh
+++ b/devinfra/secrets/cli_env.sh
@@ -17,3 +17,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 # Bootstrap note: after the first deploy of the Alloy JWT rotator, the SOPS
 # file may be absent until the first successful rotation job writes it.
 try_export DUCKTAPE_OTEL_BEARER_TOKEN "$REPO_ROOT/secrets/alloy-otlp-bearer-token.yaml" '["token"]' "OTEL bearer token — traces to Grafana Alloy"
+
+# Restore the caller's shell options (do not leak our `set -euo pipefail`; see _common.sh).
+_secrets_restore_shell_opts

--- a/devinfra/secrets/web_env.sh
+++ b/devinfra/secrets/web_env.sh
@@ -32,3 +32,6 @@ try_export DUCKTAPE_OTEL_BEARER_TOKEN "$REPO_ROOT/secrets/alloy-otlp-bearer-toke
 
 # CI read-only fine-grained PAT (personal, agentydragon — read GHA runs/artifacts)
 try_export DUCKTAPE_CI_READ_GITHUB_TOKEN "$REPO_ROOT/secrets/github-ci-read-pat.yaml" '["github_token"]' "CI read PAT (agentydragon) — read GHA runs and artifacts"
+
+# Restore the caller's shell options (do not leak our `set -euo pipefail`; see _common.sh).
+_secrets_restore_shell_opts


### PR DESCRIPTION
## Problem

`devinfra/secrets/_common.sh` runs `set -euo pipefail` and never restores it. Because the env scripts are **sourced** (`source devinfra/secrets/web_env.sh`) to export creds into the current shell, that strict mode — `nounset` in particular — stays permanently enabled in the sourcing shell.

A leaked `set -u` then breaks any later command that legitimately references an unset variable. The one that bit me repeatedly this session: Claude Code's shell-snapshot `grep`/`find` wrappers probe `[[ -n $ZSH_VERSION ]]`, which aborts with `ZSH_VERSION: unbound variable` (exit 127) once `nounset` is on — so the first `grep`/`find` after sourcing `web_env.sh` dies, and in a batched tool call the whole batch gets cancelled.

Reproduced precisely (before the fix):
```
$ bash --norc -c 'set +u; source devinfra/secrets/web_env.sh; [[ -n $ZSH_VERSION ]]'
…: ZSH_VERSION: unbound variable   # exit 1
```

## Fix

In `_common.sh`, snapshot the caller's option state (`$(set +o)`) **before** enabling strict mode, and restore it via a new `_secrets_restore_shell_opts` helper that each entrypoint (`web_env.sh` / `cli_env.sh` / `ci_env.sh`) calls as its last line. Strict mode still covers the scripts' own execution; it just no longer persists into the sourcing shell. The caller's prior state is restored **exactly** — strict-on callers (e.g. `web_setup.sh`, which sets `set -euo pipefail` before sourcing) stay strict; interactive/agent shells stay lenient. The helper is guarded by an empty-var check so repeat calls are no-ops.

## Verification

- `bash -n` clean on all four scripts.
- Source `web_env.sh` with `nounset` **off** → stays off; `[[ -n $ZSH_VERSION ]]` no longer crashes; `BUILDBUDDY_API_KEY` still exported; the saved-state var is cleaned up (no namespace residue).
- Source `cli_env.sh` with `nounset` **on** → stays on (caller state preserved exactly).
- Source `ci_env.sh` → sources cleanly, all four CI secret exports (`ATTIC_TOKEN`, `PROPS_REGISTRY_{USERNAME,PASSWORD}`, `GH_RELEASE_PAT`) intact.
- `web_setup.sh` (strict-on before sourcing) restored to strict-on; `.envrc`/direnv unaffected (shell options don't cross direnv's env capture).

No Bazel/shellcheck coverage exists for these scripts (shfmt is the only shell pre-commit hook, formatting-only), so verification is the syntax + behavioral checks above.

_Branch history note: commit 2 is a fixup of commit 1, which (a) failed to actually append the restore call to web/cli_env.sh and (b) accidentally rewrote ci_env.sh. Commit 2 corrects both; the net diff is `_common.sh` + a 3-line append to each entrypoint._

https://claude.ai/code/session_01GfJT1ZY5GwfSdomKKbRPTF