### PR TITLE
augur/fit: fix mypy errors in bayes_dilution

### DIFF
--- a/augur/fit/bayes_dilution.py
+++ b/augur/fit/bayes_dilution.py
@@ -241,14 +241,18 @@ def _generative(
     z = numpyro.sample("z", dist.Normal(jnp.zeros(n_months), 1.0).to_event(1))
     shocks = sigma_v * z
 
-    def _step(log_v_prev: jnp.ndarray, shock: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
+    def _step(log_v_prev: jax.Array, shock: jax.Array) -> tuple[jax.Array, jax.Array]:
         over_onset = jnp.maximum(0.0, log_v_prev - log_value_onset)
         drift = mu_mature + mu_young_excess * jnp.exp(-over_onset / log_value_scale)
         log_v_next = log_v_prev + drift + shock
         return log_v_next, log_v_next
 
-    _, log_v_path = jax.lax.scan(_step, log_v0, shocks)  # log_v_path[m] = log_V at month m+1
-    log_v_grid = jnp.concatenate([log_v0[None], log_v_path])  # index 0 = month 0
+    # `numpyro.sample` is typed as returning the wide `ArrayLike` union; pin the scan carry to a
+    # concrete `jax.Array` so the `Callable[[Carry, X], ...]` carry type matches `_step` and the
+    # `[None]` newaxis index below is valid (matches the lax.scan pattern in augur/model/vecm.py).
+    log_v0_arr = jnp.asarray(log_v0)
+    _, log_v_path = jax.lax.scan(_step, log_v0_arr, shocks)  # log_v_path[m] = log_V at month m+1
+    log_v_grid = jnp.concatenate([log_v0_arr[None], log_v_path])  # index 0 = month 0
 
     log_v_at_val = log_v_grid[val_month_idx]
     log_v_at_price = log_v_grid[price_month_idx]
@@ -296,7 +300,9 @@ def fit_bayesian_dilution_prior(
             f"got {len(prices)} prices, {len(valuations)} valuations"
         )
 
-    origin = min(obs.observed_at for obs in [*prices, *valuations])
+    # prices/valuations are distinct StrictModel subclasses; their join widens to the common base
+    # (no `observed_at`), so min over each typed list separately keeps the attribute access typed.
+    origin = min(min(obs.observed_at for obs in prices), min(obs.observed_at for obs in valuations))
     price_t = np.array([_months_since(obs.observed_at, origin) for obs in prices], dtype=np.float64)
     price_y = np.array([np.log(obs.price_usd_per_share) for obs in prices], dtype=np.float64)
     price_s = np.array([obs.uncertainty_log_sigma for obs in prices], dtype=np.float64)


### PR DESCRIPTION
Fixes the three mypy errors in `augur/fit/bayes_dilution.py` (introduced with the M2.2-D Bayesian fit on this branch), all stemming from `numpyro.sample`'s wide `ArrayLike` return type and a two-typed-list join:

| Line | Error | Fix |
| --- | --- | --- |
| `scan` call | `Callable[[Array, Array], ...]` incompatible with the `ArrayLike` carry inferred from `init` | Pin the carry to a concrete `jax.Array` via `jnp.asarray(log_v0)` (matches the `lax.scan` pattern in `augur/model/vecm.py`) |
| `log_v0[None]` | `ArrayLike` (includes scalars) "is not indexable" | Index the pinned `jax.Array` instead |
| `origin = min(... for obs in [*prices, *valuations])` | join widens to common `StrictModel` base, which has no `observed_at` | `min` over each typed list separately |

No behavioral change — `log_v0` was already a `jax.Array` at runtime; this only narrows the static types.

**Verification:** `bbr build //augur/fit:bayes_dilution` (mypy lint) passes; `//augur/fit:test_bayes_dilution` passes.

Base is `claude/magical-cannon-USFo4` because `bayes_dilution.py` only exists on that branch (it isn't on `devel`).

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_