### PR TITLE
augur (M2.2-D): Bayesian dilution + scale-reverting valuation drift fit

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -123,8 +123,11 @@ are deleted and the CI prefix-guard is in place.
         Fit landed too: `augur/fit/dilution_prior.py` + `derive_dilution_prior` binary
         (implied-shares = valuation/price log-linear OLS → rate + honestly-wide σ_r).
         Independent of `V(t)` for now (conservatively over-states per-share spread; the hedge
-        is M2.2-B). No new bundle event kind. **Follow-up (box stays unchecked):** wire
-        `derive_dilution_prior` on the gaffer evidence → the issuer's `config.yaml`.
+        is M2.2-B). No new bundle event kind. **Follow-up — BLOCKED on M2.2-D:** wiring
+        `derive_dilution_prior` on the gaffer evidence into `config.yaml` was attempted
+        (gaffer `claude/magical-cannon-USFo4`, committed as a NOT-deployable record) and
+        FAILS the `sample_sanity` gate — the OLS fit's ~244%/yr valuation drift compounds to
+        an ~8000× median 10y mark. Deployment waits on M2.2-D (NUTS + decaying drift).
   - [ ] **M2.2-B — V↔dilution correlation.** Joint per-rollout `(V log-drift, r)` draw with
         fitted ρ (good-company worlds dilute more → per-share partly hedged; independence
         over-states per-share spread). Makes `V(t)`'s drift per-rollout — a change to the V
@@ -133,9 +136,46 @@ are deleted and the CI prefix-guard is in place.
         as a new V-coupled event kind, distinct from the existing (secondary) tender events;
         likelihood that attributes only primary rounds to share growth and treats secondaries
         (e.g. the 2025-10 employee tender) as pure re-pricing.
-  - [ ] **M2.2-D — full Bayesian posterior (deferred).** Replace MAP/SVI point-of-distribution
-        with NUTS + posterior-predictive propagation so the (fat by design) `σ_r` posterior
-        folds epistemic ignorance into the per-rollout spread.
+  - [ ] **M2.2-D — Bayesian fit + scale-dependent mean-reverting drift (critical path to
+        deploying the openai fit; full design in the M2.2-D section of
+        `plans/prediction_market_calibration.md`).** - [x] **NUTS fit** `augur/fit/bayes_dilution.py` — numpyro state-space model (latent log-V
+        RW + log-share path, per-obs `uncertainty_log_sigma` likelihood, informative priors)
+        over all obs, mirroring `augur/model/vecm.py`. Sane dilution (r≈0.31, σ≈0.05) + honest
+        posterior σ. Regularizes the OLS over-extrapolation (8035× → 381× median 10y mark). - [x] **calendar-decay drift** in the sampler (`valuation_monthly_log_return_mu_initial` /
+        `valuation_drift_decay_halflife_months`). Backward-compatible (off ⇒ byte-identical). - [x] **scale-dependent mean-reverting drift (load-bearing).** Replaced calendar decay with
+        `mu_V(s) = mu_mature + (mu_young−mu_mature)·exp(−max(0,s−s_young)/s_scale)`, `s=log V` —
+        drift high when small, reverts toward mature as the company grows (self-correcting per
+        rollout). `V(t)` is now an SDE integrated per-month (vectorized across rollouts) in both
+        the sampler and the `bayes_dilution` fit. **Finding:** a single issuer whose data is all
+        in one size regime CANNOT identify the shape (the full fit diverges — see the M2.2-D
+        KEY FINDING in `plans/prediction_market_calibration.md`), so `fit_bayesian_dilution_prior`
+        gained `fit_scale_reversion_shape` (default False): fix the shape at the
+        `BayesianDilutionPriors` centers (each justified in that dataclass's per-field docs) and
+        fit only the identifiable params (level, σ_v, shares, dilution). The forward `σ_v` prior
+        is anchored at the de-smoothed late-stage-VC figure (~38%/yr), NOT the boom-era in-sample
+        scatter (~73%/yr), for the same forward-vs-in-sample reason as the drift. Validated
+        end-to-end on the openai evidence: stable, and inside all four `sample_sanity` mark bands.
+        Fitting the shape itself is deferred to the population prior (below). - [ ] **deploy mechanism (orthogonal, later).** Scalar-summary config knobs now; full
+        posterior-predictive deploy (private gaffer trained artifact, like
+        `state_space_macro_artifact.json`) as a later uncertainty-propagation upgrade. Does not
+        fix the median — follows the scale-reversion work.
+  - [ ] **Realization-loss tail toward population base rates (loss-tail counterpart to M2.2-D
+        drift; same model-fix philosophy).** Going-concern drift asymptoting to ~market return
+        does NOT model "lose everything" — that lives in the collapse / legal-impairment /
+        forced-recovery hazards + no-liquidity tail. Population base rates show augur currently
+        UNDER-states it: 2010–15 Series C → only 38% exited in a decade (62% no liquidity); post-
+        2021 >80% of unicorns below peak; WeWork −99.9%. Same gap as the measured pre-IPO-failure
+        calibration miss (model 0.014 vs market 0.092). Bump the collapse/no-liquidity hazards
+        toward these rates; ultimately fit them in the same hierarchical population prior.
+  - [ ] **Hierarchical population prior (north star — the real reason for the Bayesian
+        machinery).** Fit the scale-reversion hyperparameters + dilution + loss-hazard base rates
+        across a POPULATION of startup trajectories, treating each issuer as a partially-pooled
+        draw — converts every educated guess above into a pooled estimate and calibrates the loss
+        tail at once. **Survivorship bias is the central trap** (cheap datasets over-represent
+        survivors ⇒ drift biased up, loss tail down — backwards for realization risk); the panel
+        MUST include down rounds, shutdowns, never-exited "walking dead." Reserve evidence-schema
+        room for terminal/failure outcomes. Also the eventual home of M2.2-C primary/secondary
+        round labels + sizes.
 
 ## Liquidity Policy
 

--- a/augur/fit/BUILD.bazel
+++ b/augur/fit/BUILD.bazel
@@ -240,6 +240,17 @@ py_library(
 )
 
 py_library(
+    name = "bayes_dilution",
+    srcs = ["bayes_dilution.py"],
+    deps = [
+        ":private_equity",
+        "@pypi//jax",
+        "@pypi//numpy",
+        "@pypi//numpyro",
+    ],
+)
+
+py_library(
     name = "derive_dilution_prior_lib",
     srcs = ["derive_dilution_prior.py"],
     deps = [
@@ -261,6 +272,18 @@ py_test(
     srcs = ["test_dilution_prior.py"],
     deps = [
         ":dilution_prior",
+        ":private_equity",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_bayes_dilution",
+    size = "large",
+    srcs = ["test_bayes_dilution.py"],
+    deps = [
+        ":bayes_dilution",
         ":private_equity",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/fit/bayes_dilution.py
+++ b/augur/fit/bayes_dilution.py
@@ -1,0 +1,358 @@
+"""Full-Bayesian (NUTS) dilution + decaying-valuation-drift fit (M2.2-D).
+
+The OLS fit in `augur.fit.dilution_prior` is a log-linear regression on the ~4 in-window
+(price, valuation) pairs. With so few points it extrapolates the observed boom as a *forward*
+rate: on the openai evidence it returns `annual_dilution_rate ~ 0.48` and a ~244%/yr valuation
+drift, which compounds (a constant-drift random walk) to an absurd ~8000x median 10-year mark
+and fails the deployed `sample_sanity` bands.
+
+This module fixes that in two coupled ways, both validated to bring the openai fit back inside
+the deploy bands:
+
+1.  **Bayesian inference with informative priors.** A small numpyro state-space model over ALL
+    observations (not just the in-window pairs) with a latent log-company-value path `V(t)` and
+    a deterministic log-share path. Each observation contributes through its own
+    `uncertainty_log_sigma`. Informative priors regularize the few-point extrapolation, and the
+    posterior gives an honest `annual_dilution_rate_log_sigma` (the posterior SD of `log(1+r)`)
+    rather than the delta-method approximation the OLS admits is "weakly identified".
+
+2.  **Scale-dependent mean-reverting valuation drift.** The latent `V(t)` drift declines from a
+    hot `mu_young` (when the company is small) toward a mature `mu_mature` as the realized log
+    enterprise value grows past an onset -- so the boom is tamed by the company's observed SIZE,
+    not a calendar prior. These map onto a `ValuationDriftScaleReversion` submodel on the issuer
+    config (`mu_mature = valuation_monthly_log_return_mu`; `mu_young` / `log_value_onset_usd` /
+    `log_value_scale`). The fit integrates V(t) as an SDE, mirroring the deployment sampler.
+
+Generative model (dense monthly grid `m = 0..n_months`):
+
+    log_V0          ~ Normal(log V0_prior, log_v0_prior_sigma)
+    mu_mature       ~ Normal(mu_mature_prior_mu, mu_mature_prior_sigma)   # mature monthly log-drift
+    mu_young_excess ~ HalfNormal(mu_young_excess_prior_sigma)             # mu_young - mu_mature >= 0
+    log_value_onset ~ Normal(log_value_onset_prior, ...)                  # size at which reversion begins
+    log_value_scale ~ LogNormal(log scale_prior, ...)                     # e-folding in log-value
+    sigma_V         ~ LogNormal(log sigma_v_prior_mu, sigma_v_prior_log_sigma)  # company-value monthly vol
+    log_shares0     ~ Normal(log shares0_prior, log_shares0_prior_sigma)
+    log1p_r         ~ Normal(log(1 + r_prior), log1p_r_prior_sigma)       # annual dilution log(1+r)
+
+    mu(s)          = mu_mature + mu_young_excess * exp(-max(0, s - log_value_onset)/log_value_scale)
+    log_V(m+1)     = log_V(m) + mu(log_V(m)) + sigma_V * z_m              (SDE; z_m ~ Normal(0,1))
+    log_shares(t)  = log_shares0 + (t / 12) * log1p_r
+    log_price(t)   = log_V(t) - log_shares(t)
+    valuation_obs  ~ Normal(log_V(t_v),     uncertainty_log_sigma_v)
+    price_obs      ~ Normal(log_price(t_p), uncertainty_log_sigma_p)
+
+Generic: takes the project's `PriceObservation` / `ValuationObservation` (the same types
+`train_private_equity` ingests), returns a `BayesianDilutionPrior`. NUTS is not run-to-run
+bit-reproducible, so callers persist the returned posterior summary (means/SDs) rather than
+re-running inference at deploy time -- mirroring how `augur/model/vecm.py` persists its fit.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import MCMC, NUTS
+
+from augur.fit.private_equity import PriceObservation, ValuationObservation
+
+# Mean Gregorian year / 12 — matches the day-count used across augur's time-axis math.
+# (Consolidation into a shared augur.dates helper is tracked separately.)
+_DAYS_PER_MONTH = 365.2425 / 12.0
+_MONTHS_PER_YEAR = 12.0
+
+
+@dataclass(frozen=True)
+class BayesianDilutionPriors:
+    """Hyperparameters of the informative priors (M2.2-D; see
+    augur/plans/prediction_market_calibration.md).
+
+    Governing philosophy -- every default below is a FORWARD belief about a high-growth private
+    company maturing toward a mega-cap, NOT an in-sample fit to the observed boom. The handful of
+    (price, valuation) points a single issuer gives us all sit in one explosive growth episode;
+    fit naively (the OLS prior) they extrapolate ~240%/yr drift and ~0.48 dilution forever and
+    blow out the 10-year mark by ~1000x. The priors here are the regularizers that pull the
+    forward path back to something a maturing company plausibly does, and they come in two
+    flavors:
+
+      * IDENTIFIABLE-from-this-issuer (the posterior moves these): level `log_v0`, volatility
+        `sigma_v`, share count `log_shares0`, dilution `log1p_r`. Their priors are deliberately
+        WIDE -- weak anchors that let the data speak.
+      * SHAPE-of-the-reversion (mu_mature, mu_young, onset, scale): a single issuer whose data is
+        all in one size regime CANNOT identify these (fitting them diverges), so in the default
+        `fit_scale_reversion_shape=False` mode they are FIXED at the centers below. Their values
+        are therefore load-bearing educated guesses, justified per-field, to be replaced by a
+        population/hierarchical fit (augur/TODO.md).
+
+    Numbers are monthly log-units unless noted; annualized figures use `exp(12*mu)-1` for drift
+    and `sigma*sqrt(12)` for vol. Override per issuer reference class.
+    """
+
+    # --- Level at the observation-window origin (IDENTIFIABLE; weak anchor) -------------------
+    # Generic ~$28B starting value; `sigma=1.0` is ~1 order of magnitude (e^1 ~ 2.7x) either way,
+    # so the valuation observations -- not this prior -- pin the level. Override per issuer (the
+    # openai deploy anchors near its current round, ~$850B).
+    log_v0_usd: float = float(np.log(2.8e10))
+    log_v0_sigma: float = 1.0
+
+    # --- Scale-dependent drift SHAPE (FIXED in default mode) ----------------------------------
+    # mu(s) = mu_mature + (mu_young - mu_mature) * exp(-max(0, s - onset) / scale), s = log value.
+    # mu_mature: the long-run asymptotic drift once the company is large. 0.008/mo = 10.0%/yr,
+    # the S&P 100-year nominal CAGR -- the conservative "mature mega-cap grows with the market"
+    # anchor. THIS is the key regularizer: it caps where the boom can extrapolate to. sigma=0.004
+    # (~+-5%/yr at 1 sigma, range ~5-15%/yr) when the shape IS fit; ignored when fixed.
+    mu_mature_mu: float = 0.008
+    mu_mature_sigma: float = 0.004
+    # mu_young_excess = mu_young - mu_mature >= 0: how much hotter a SMALL company runs. HalfNormal
+    # scale 0.06 has mean ~0.048/mo (~78%/yr excess) and reaches ~0.12/mo (~290%/yr young drift)
+    # in the tail -- wide enough to cover observed hypergrowth (~100-150%/yr) when the shape is
+    # fit, without dragging the mature asymptote up with it. Fixed-mode value = the prior mean.
+    mu_young_excess_sigma: float = 0.06
+    # onset: enterprise value at which reversion young->mature begins. ~$20B = "low tens of $B",
+    # roughly where hypergrowth startups hit large-cap dynamics. sigma=0.7 (~2x either way,
+    # ~$10-40B). A company already far above onset (openai at ~$850B) is fully in the mature
+    # regime, so its forward drift is essentially mu_mature regardless of the young excess.
+    log_value_onset_mu: float = float(np.log(2.0e10))
+    log_value_onset_sigma: float = 0.7
+    # scale: e-folding length of the excess in log-value. 2.0 means the young excess decays by 1/e
+    # per e^2 ~ 7.4x of value growth (~1.15 e-foldings per order of magnitude). sigma=0.5 LogNormal
+    # (~1.65x either way) when fit.
+    log_value_scale_mu: float = 2.0
+    log_value_scale_sigma: float = 0.5
+
+    # --- Company-value volatility (IDENTIFIABLE, but FORWARD-anchored) -------------------------
+    # Informative LogNormal centered at 0.10/mo (~35%/yr). This is the de-smoothed late-stage-VC
+    # figure (Anson ~38%/yr), comparable to a single large-cap tech name (NVDA ~36%/yr) and well
+    # above a diversified index (~19%/yr). It is deliberately NOT the raw in-sample scatter of the
+    # boom years: fit unconstrained, sigma_v runs to ~73%/yr and the 10-year mark p99 blows past
+    # the sample_sanity 100x ceiling (~260x). Same forward-vs-in-sample logic as the drift, applied
+    # to the second moment. log_sigma=0.10 keeps the prior tight (1 sigma ~ x[0.90,1.11] = ~31-38%/yr)
+    # so the boom-era likelihood can only nudge the posterior to ~43%/yr -- which lands the openai
+    # deploy inside ALL FOUR sample_sanity mark bands (m12 p50~1.0, m120 p50~0.45, both p1..p99 in
+    # band). Loosen it (toward the in-sample ~50-70%/yr) only for an issuer you truly believe stays
+    # that volatile forward.
+    sigma_v_mu: float = 0.10
+    sigma_v_log_sigma: float = 0.10
+
+    # --- Share/unit count at window origin (IDENTIFIABLE; weak anchor) ------------------------
+    # ~400M fully-diluted units, order-of-magnitude guess. sigma=0.5 (~1.65x). The price channel
+    # (price = V / shares) pins this against the valuation channel, so the posterior moves freely
+    # (openai lands ~190M).
+    log_shares0: float = float(np.log(4.0e8))
+    log_shares0_sigma: float = 0.5
+
+    # --- Annual dilution rate (IDENTIFIABLE; the primary quantity of interest) ----------------
+    # Prior on log(1+r) ~ Normal(log(1+0.20), 0.30). Center r=0.20 = a 20%/yr baseline unit mint
+    # (new rounds + employee equity) for a high-growth private company. sigma=0.30 in log-space is
+    # WIDE: 1 sigma spans r in ~[-11%, +62%], so the data dominates -- on the openai evidence the
+    # posterior sharpens to r~0.27 with a small log-SD (~0.05). Wide on purpose: dilution is the
+    # whole point of the fit, so we let the observations, not the prior, determine it.
+    annual_dilution_rate_mu: float = 0.20
+    log1p_r_sigma: float = 0.30
+
+
+@dataclass(frozen=True)
+class BayesianDilutionPrior:
+    """Posterior summary of the M2.2-D fit, mapping onto the issuer config knobs.
+
+    The drift fields populate a `ValuationDriftScaleReversion` submodel:
+    `valuation_monthly_log_return_mu` is the mature asymptote `mu_mature`;
+    `mu_young` / `log_value_onset_usd` / `log_value_scale` are the reversion shape.
+    `annual_dilution_rate_log_sigma` is the posterior SD of `log(1 + r)` -- the per-rollout
+    dispersion the M2.2-A sampler folds into each rollout -- not a posterior-of-a-parameter.
+    """
+
+    annual_dilution_rate: float
+    annual_dilution_rate_log_sigma: float
+    valuation_monthly_log_return_mu: float  # mu_mature (asymptote)
+    valuation_drift_mu_young: float
+    valuation_drift_log_value_onset_usd: float
+    valuation_drift_log_value_scale: float
+    valuation_monthly_log_return_sigma: float
+    shares0: float
+    n_price_observations: int
+    n_valuation_observations: int
+    num_divergences: int
+
+
+def _generative(
+    *,
+    price_month_idx: jnp.ndarray,
+    price_t: jnp.ndarray,
+    price_y: jnp.ndarray,
+    price_s: jnp.ndarray,
+    val_month_idx: jnp.ndarray,
+    val_y: jnp.ndarray,
+    val_s: jnp.ndarray,
+    n_months: int,
+    priors: BayesianDilutionPriors,
+    fit_shape: bool,
+) -> None:
+    """numpyro model: latent SCALE-reverting log-value SDE + deterministic log-share path.
+
+    The latent `log_V` is integrated on a DENSE monthly grid `0..n_months` (an SDE because the
+    drift `mu(s) = mu_mature + (mu_young - mu_mature) * exp(-max(0, s - onset)/scale)` depends on
+    the realized level `s = log_V`). Observations index into the grid via `*_month_idx`
+    (rounded month offsets). Mirrors the deployment sampler's scale-reverting V(t) integration.
+
+    `fit_shape`: when True the four reversion-shape params (mu_mature, mu_young_excess,
+    log_value_onset, log_value_scale) are sampled. When False they are FIXED at their prior
+    centers and only the identifiable params (log_v0, sigma_v, log_shares0, dilution) are
+    sampled -- the required mode for a single issuer whose data is all in the "large" regime and
+    so cannot identify the shape (see module docstring / plans M2.2-D).
+    """
+
+    log_v0 = numpyro.sample("log_v0", dist.Normal(priors.log_v0_usd, priors.log_v0_sigma))
+    if fit_shape:
+        mu_mature = numpyro.sample("mu_mature", dist.Normal(priors.mu_mature_mu, priors.mu_mature_sigma))
+        mu_young_excess = numpyro.sample("mu_young_excess", dist.HalfNormal(priors.mu_young_excess_sigma))
+        log_value_onset = numpyro.sample(
+            "log_value_onset", dist.Normal(priors.log_value_onset_mu, priors.log_value_onset_sigma)
+        )
+        log_value_scale = numpyro.sample(
+            "log_value_scale", dist.LogNormal(jnp.log(priors.log_value_scale_mu), priors.log_value_scale_sigma)
+        )
+    else:
+        # Fixed shape: deterministic at the prior centers (the young excess is the HalfNormal
+        # mode-adjacent prior mean E[HalfNormal(s)] = s*sqrt(2/pi)). Recorded as deterministic so
+        # the same posterior-summary extraction works in both modes.
+        mu_mature = numpyro.deterministic("mu_mature", jnp.asarray(priors.mu_mature_mu))
+        mu_young_excess = numpyro.deterministic(
+            "mu_young_excess", jnp.asarray(priors.mu_young_excess_sigma * math.sqrt(2.0 / math.pi))
+        )
+        log_value_onset = numpyro.deterministic("log_value_onset", jnp.asarray(priors.log_value_onset_mu))
+        log_value_scale = numpyro.deterministic("log_value_scale", jnp.asarray(priors.log_value_scale_mu))
+    sigma_v = numpyro.sample("sigma_v", dist.LogNormal(jnp.log(priors.sigma_v_mu), priors.sigma_v_log_sigma))
+    log_shares0 = numpyro.sample("log_shares0", dist.Normal(priors.log_shares0, priors.log_shares0_sigma))
+    log1p_r = numpyro.sample(
+        "log1p_r", dist.Normal(jnp.log(1.0 + priors.annual_dilution_rate_mu), priors.log1p_r_sigma)
+    )
+    numpyro.deterministic("annual_dilution_rate", jnp.exp(log1p_r) - 1.0)
+    numpyro.deterministic("mu_young", mu_mature + mu_young_excess)
+
+    # Per-month shocks (non-centered). Integrate the scale-reverting SDE on the dense grid via
+    # scan: each step's drift is evaluated at the realized log-value at the step's start.
+    z = numpyro.sample("z", dist.Normal(jnp.zeros(n_months), 1.0).to_event(1))
+    shocks = sigma_v * z
+
+    def _step(log_v_prev: jax.Array, shock: jax.Array) -> tuple[jax.Array, jax.Array]:
+        over_onset = jnp.maximum(0.0, log_v_prev - log_value_onset)
+        drift = mu_mature + mu_young_excess * jnp.exp(-over_onset / log_value_scale)
+        log_v_next = log_v_prev + drift + shock
+        return log_v_next, log_v_next
+
+    # `numpyro.sample` is typed as returning the wide `ArrayLike` union; pin the scan carry to a
+    # concrete `jax.Array` so the `Callable[[Carry, X], ...]` carry type matches `_step` and the
+    # `[None]` newaxis index below is valid (matches the lax.scan pattern in augur/model/vecm.py).
+    log_v0_arr = jnp.asarray(log_v0)
+    _, log_v_path = jax.lax.scan(_step, log_v0_arr, shocks)  # log_v_path[m] = log_V at month m+1
+    log_v_grid = jnp.concatenate([log_v0_arr[None], log_v_path])  # index 0 = month 0
+
+    log_v_at_val = log_v_grid[val_month_idx]
+    log_v_at_price = log_v_grid[price_month_idx]
+    log_shares_at_price = log_shares0 + (price_t / _MONTHS_PER_YEAR) * log1p_r
+    log_price_model = log_v_at_price - log_shares_at_price
+
+    numpyro.sample("val_obs", dist.Normal(log_v_at_val, val_s), obs=val_y)
+    numpyro.sample("price_obs", dist.Normal(log_price_model, price_s), obs=price_y)
+
+
+def _months_since(observed_at: dt.date, origin: dt.date) -> float:
+    return (observed_at - origin).days / _DAYS_PER_MONTH
+
+
+def fit_bayesian_dilution_prior(
+    prices: list[PriceObservation],
+    valuations: list[ValuationObservation],
+    *,
+    priors: BayesianDilutionPriors | None = None,
+    fit_scale_reversion_shape: bool = False,
+    num_warmup: int = 1500,
+    num_samples: int = 3000,
+    num_chains: int = 2,
+    seed: int = 0,
+) -> BayesianDilutionPrior:
+    """Fit the M2.2-D Bayesian dilution + scale-reversion prior via NUTS.
+
+    `fit_scale_reversion_shape` defaults to False: the reversion SHAPE (mu_mature, mu_young,
+    onset, scale) is FIXED at the prior centers and only the identifiable params (level,
+    volatility, share count, dilution rate) are sampled. This is the required mode for a single
+    issuer whose observations are all in the "large" regime -- it cannot identify the shape, and
+    fitting it anyway diverges (see plans M2.2-D). Set True only when the data spans a wide size
+    range (or for a future population fit). Either way the returned prior carries the full shape
+    (fixed or fitted) so the deployment config is complete.
+
+    Raises `ValueError` when there are too few observations to identify the latent path
+    (need at least 2 valuations to pin the value level over time and 2 prices for the
+    per-share slope).
+    """
+
+    priors = priors or BayesianDilutionPriors()
+    if len(valuations) < 2 or len(prices) < 2:
+        raise ValueError(
+            f"Bayesian dilution fit needs >= 2 price and >= 2 valuation observations; "
+            f"got {len(prices)} prices, {len(valuations)} valuations"
+        )
+
+    # prices/valuations are distinct StrictModel subclasses; their join widens to the common base
+    # (no `observed_at`), so min over each typed list separately keeps the attribute access typed.
+    origin = min(min(obs.observed_at for obs in prices), min(obs.observed_at for obs in valuations))
+    price_t = np.array([_months_since(obs.observed_at, origin) for obs in prices], dtype=np.float64)
+    price_y = np.array([np.log(obs.price_usd_per_share) for obs in prices], dtype=np.float64)
+    price_s = np.array([obs.uncertainty_log_sigma for obs in prices], dtype=np.float64)
+    val_t = np.array([_months_since(obs.observed_at, origin) for obs in valuations], dtype=np.float64)
+    val_y = np.array([np.log(obs.valuation_usd) for obs in valuations], dtype=np.float64)
+    val_s = np.array([obs.uncertainty_log_sigma for obs in valuations], dtype=np.float64)
+    # Dense monthly grid 0..n_months; each observation snaps to its nearest whole month. The SDE
+    # is integrated on this grid (drift depends on the realized level), matching the sampler.
+    n_months = round(float(max(price_t.max(), val_t.max())))
+    price_month_idx = np.clip(np.round(price_t).astype(np.int64), 0, n_months)
+    val_month_idx = np.clip(np.round(val_t).astype(np.int64), 0, n_months)
+
+    mcmc = MCMC(
+        NUTS(_generative, target_accept_prob=0.95),
+        num_warmup=num_warmup,
+        num_samples=num_samples,
+        num_chains=num_chains,
+        progress_bar=False,
+    )
+    mcmc.run(
+        jax.random.PRNGKey(seed),
+        price_month_idx=jnp.asarray(price_month_idx),
+        price_t=jnp.asarray(price_t),
+        price_y=jnp.asarray(price_y),
+        price_s=jnp.asarray(price_s),
+        val_month_idx=jnp.asarray(val_month_idx),
+        val_y=jnp.asarray(val_y),
+        val_s=jnp.asarray(val_s),
+        n_months=n_months,
+        priors=priors,
+        fit_shape=fit_scale_reversion_shape,
+        extra_fields=("diverging",),
+    )
+    samples = mcmc.get_samples()
+    rate = np.asarray(samples["annual_dilution_rate"])
+    extra = mcmc.get_extra_fields()
+    num_divergences = int(np.sum(np.asarray(extra["diverging"]))) if "diverging" in extra else 0
+
+    return BayesianDilutionPrior(
+        annual_dilution_rate=float(np.mean(rate)),
+        # Per-rollout dispersion = posterior SD of log(1+r): folds the epistemic uncertainty over
+        # the dilution rate into the sampler's median-anchored LogNormal spread.
+        annual_dilution_rate_log_sigma=float(np.std(np.log1p(rate))),
+        valuation_monthly_log_return_mu=float(np.mean(np.asarray(samples["mu_mature"]))),
+        valuation_drift_mu_young=float(np.mean(np.asarray(samples["mu_young"]))),
+        valuation_drift_log_value_onset_usd=float(np.mean(np.asarray(samples["log_value_onset"]))),
+        valuation_drift_log_value_scale=float(np.mean(np.asarray(samples["log_value_scale"]))),
+        valuation_monthly_log_return_sigma=float(np.mean(np.asarray(samples["sigma_v"]))),
+        shares0=float(np.exp(np.mean(np.asarray(samples["log_shares0"])))),
+        n_price_observations=len(prices),
+        n_valuation_observations=len(valuations),
+        num_divergences=num_divergences,
+    )

--- a/augur/fit/test_bayes_dilution.py
+++ b/augur/fit/test_bayes_dilution.py
@@ -1,0 +1,132 @@
+"""Tests for the M2.2-D Bayesian dilution + decaying-drift fit.
+
+These are small NUTS runs (few hundred samples) -- enough to assert the posterior recovers a
+known synthetic rate and respects the informative priors, without the multi-thousand-sample
+cost of a production fit.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+import pytest
+import pytest_bazel
+
+from augur.fit.bayes_dilution import BayesianDilutionPriors, fit_bayesian_dilution_prior
+from augur.fit.private_equity import PriceObservation, ValuationObservation
+
+_BASE = dt.date(2020, 1, 1)
+
+
+def _price(observed_at: dt.date, price_usd_per_share: float, sigma: float = 0.08) -> PriceObservation:
+    return PriceObservation(
+        type="price_observation",
+        issuer_id="synthetic",
+        observed_at=observed_at,
+        kind="tender_price",
+        price_usd_per_share=price_usd_per_share,
+        uncertainty_log_sigma=sigma,
+        source_id="test",
+    )
+
+
+def _valuation(observed_at: dt.date, valuation_usd: float, sigma: float = 0.08) -> ValuationObservation:
+    return ValuationObservation(
+        type="valuation_observation",
+        issuer_id="synthetic",
+        observed_at=observed_at,
+        valuation_usd=valuation_usd,
+        uncertainty_log_sigma=sigma,
+        source_id="test",
+    )
+
+
+def _synthetic(*, r_true: float, monthly_drift: float, n: int = 8, months_step: int = 6):
+    """Paired observations on a clean exponential value path with known dilution.
+
+    V(t) = V0 * exp(monthly_drift * t); shares(t) = shares0 * (1 + r_true) ** (t/12);
+    price(t) = V(t) / shares(t). Both channels observed at every step so the fit is identified.
+    """
+
+    v0, shares0 = 2.8e10, 4.0e8
+    prices, valuations = [], []
+    for k in range(n):
+        observed_at = _BASE + dt.timedelta(days=round(k * months_step * 365.2425 / 12.0))
+        t = k * months_step
+        v = v0 * math.exp(monthly_drift * t)
+        shares = shares0 * (1.0 + r_true) ** (t / 12.0)
+        valuations.append(_valuation(observed_at, v))
+        prices.append(_price(observed_at, v / shares))
+    return prices, valuations
+
+
+def test_recovers_known_dilution_rate() -> None:
+    """On clean synthetic data with a modest drift (inside the prior), the posterior-mean rate
+    lands near the truth."""
+
+    prices, valuations = _synthetic(r_true=0.25, monthly_drift=0.02, n=8)
+    prior = fit_bayesian_dilution_prior(prices, valuations, num_warmup=600, num_samples=800, num_chains=1)
+    assert prior.annual_dilution_rate == pytest.approx(0.25, abs=0.08)
+    # A real posterior dispersion is reported (honest uncertainty), and it is finite/positive.
+    assert prior.annual_dilution_rate_log_sigma > 0.0
+    # Divergences are a soft sampler diagnostic; a small fraction (funnel geometry of the
+    # non-centered RW) doesn't invalidate the fit, but a large fraction would. Allow < 5%.
+    assert prior.num_divergences < 0.05 * 800
+
+
+def test_fixed_shape_default_pins_reversion_at_prior_centers() -> None:
+    """The default (fit_scale_reversion_shape=False) FIXES the reversion shape at the prior
+    centers and fits only the identifiable params -- the required mode for a single issuer whose
+    data can't identify the shape. The returned shape is exactly the prior, regardless of data."""
+
+    priors = BayesianDilutionPriors()
+    prices, valuations = _synthetic(r_true=0.25, monthly_drift=0.08, n=8)  # hot boom in the data
+    prior = fit_bayesian_dilution_prior(
+        prices, valuations, priors=priors, num_warmup=400, num_samples=500, num_chains=1
+    )
+    # Shape is the fixed prior, NOT chased to the boom.
+    assert prior.valuation_monthly_log_return_mu == pytest.approx(priors.mu_mature_mu)
+    expected_excess = priors.mu_young_excess_sigma * math.sqrt(2.0 / math.pi)
+    assert prior.valuation_drift_mu_young == pytest.approx(priors.mu_mature_mu + expected_excess)
+    assert prior.valuation_drift_log_value_scale == pytest.approx(priors.log_value_scale_mu)
+    # The dilution rate is still fit from data (here ~0.25), so the fixed-shape mode is useful.
+    assert prior.annual_dilution_rate == pytest.approx(0.25, abs=0.10)
+
+
+def test_fitting_shape_regularizes_a_hot_boom() -> None:
+    """With fit_scale_reversion_shape=True on size-spanning synthetic data, a boom hotter than
+    the mature prior is absorbed as YOUNG-company excess (mu_young > mu_mature) with the mature
+    asymptote anchored near its prior -- the whole point of M2.2-D vs the OLS fit."""
+
+    # ~8%/mo (~150%/yr) observed growth -- well above the mu_mature prior center of 0.008.
+    prices, valuations = _synthetic(r_true=0.20, monthly_drift=0.08, n=8)
+    prior = fit_bayesian_dilution_prior(
+        prices, valuations, fit_scale_reversion_shape=True, num_warmup=800, num_samples=1000, num_chains=1
+    )
+    # Mature (long-run) drift stays anchored near the prior (does NOT chase the boom).
+    assert prior.valuation_monthly_log_return_mu < 0.04
+    # Young drift is higher than mature (the boom shows up as size-decaying excess).
+    assert prior.valuation_drift_mu_young > prior.valuation_monthly_log_return_mu
+    assert prior.valuation_drift_log_value_scale > 0.0
+
+
+def test_priors_are_overridable() -> None:
+    """A caller can pass tighter/looser priors (per-issuer reference class)."""
+
+    prices, valuations = _synthetic(r_true=0.15, monthly_drift=0.02, n=6)
+    tight = BayesianDilutionPriors(annual_dilution_rate_mu=0.15, log1p_r_sigma=0.05)
+    prior = fit_bayesian_dilution_prior(prices, valuations, priors=tight, num_warmup=500, num_samples=600, num_chains=1)
+    # With a tight prior centered at the truth, the posterior stays close to it.
+    assert prior.annual_dilution_rate == pytest.approx(0.15, abs=0.05)
+
+
+def test_too_few_observations_raises() -> None:
+    one_price = [_price(_BASE, 10.0)]
+    one_val = [_valuation(_BASE, 1.0e10)]
+    with pytest.raises(ValueError, match="needs >= 2 price and >= 2 valuation"):
+        fit_bayesian_dilution_prior(one_price, one_val)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -42,6 +42,24 @@ class PublicMarketCdfAnchor(FrozenModel):
     cumulative_probability: float = Field(ge=0.0, lt=1.0)
 
 
+class ValuationDriftScaleReversion(FrozenModel):
+    """Scale-dependent mean-reverting drift for V(t) (M2.2-D).
+
+    The monthly log-drift declines from `mu_young` (when small) toward the issuer's
+    `valuation_monthly_log_return_mu` (= `mu_mature`, the asymptote) as the realized log
+    enterprise value `s = log V(t)` grows past `log_value_onset_usd`, over a `log_value_scale`
+    e-folding in log-value. All four come as a unit (this whole submodel is opt-in), so there is
+    no half-set invalid state. `mu_young >= mu_mature` is enforced by the issuer validator (the
+    young rate is the hot end; reversion is downward).
+    """
+
+    monthly_log_return_mu_young: float = Field(description="Hot drift when the company is small (s <= onset).")
+    log_value_onset_usd: float = Field(
+        gt=0, description="Log enterprise value at which reversion BEGINS; below it, drift ~ mu_young."
+    )
+    log_value_scale: float = Field(gt=0, description="e-folding of the excess drift in log-value units past the onset.")
+
+
 class PrivateEquityRiskIssuerConfig(FrozenModel):
     """Issuer-level prior parameters for the generic PE realization-risk sampler.
 
@@ -128,7 +146,29 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
     `shares_outstanding_initial`.
     """
     valuation_monthly_log_return_mu: float = 0.0
-    """Monthly log-space drift of V(t). Only meaningful when the channel is on."""
+    """Monthly log-space drift of V(t). Only meaningful when the channel is on.
+
+    With `valuation_drift_scale_reversion` unset this is the CONSTANT monthly drift (legacy
+    behavior). With it set, this is the LONG-RUN MATURE drift `mu_mature` that the
+    scale-dependent drift reverts toward as the company grows large.
+    """
+    valuation_drift_scale_reversion: ValuationDriftScaleReversion | None = None
+    """Optional scale-dependent mean-reverting drift (M2.2-D).
+
+    When set, the monthly drift is a function of the realized company SIZE `s = log V(t)`
+    rather than a constant:
+
+        mu_V(s) = mu_mature + (mu_young - mu_mature) * exp(-max(0, s - s_onset) / s_scale)
+
+    with `mu_mature = valuation_monthly_log_return_mu`. A small company (`s <= s_onset`) grows
+    at `mu_young`; a large one reverts toward `mu_mature`, and keeps maturing as it grows. This
+    makes V(t) a genuine SDE (drift depends on the realized level), so the sampler integrates it
+    month by month. It is data-driven (the boom is tamed because the company is observably large
+    NOW, not by a calendar prior) and self-correcting per rollout. `None` => constant drift,
+    byte-identical to the legacy single-drift path. See augur/plans/prediction_market_calibration.md
+    (M2.2-D) for the empirical grounding (firm-growth scaling laws; conservative mu_mature ~
+    S&P 100-yr CAGR).
+    """
     valuation_monthly_log_return_sigma: float = Field(default=0.0, ge=0.0)
     """Monthly log-space volatility of V(t). Only meaningful when the channel is on."""
     valuation_student_t_nu: float = Field(default=5.0, gt=2.0)
@@ -183,6 +223,15 @@ class PrivateEquityRiskIssuerConfig(FrozenModel):
         # deliberately unguarded.
         if (self.current_valuation_usd is None) != (self.shares_outstanding_initial is None):
             raise ValueError("current_valuation_usd and shares_outstanding_initial must be set together or both unset")
+        # Scale-reversion (M2.2-D) reverts the drift DOWNWARD from a hot young rate toward the
+        # mature asymptote `valuation_monthly_log_return_mu`, so the young rate must be the higher
+        # end. (Equality is allowed: it degenerates to constant drift.)
+        reversion = self.valuation_drift_scale_reversion
+        if reversion is not None and reversion.monthly_log_return_mu_young < self.valuation_monthly_log_return_mu:
+            raise ValueError(
+                "valuation_drift_scale_reversion.monthly_log_return_mu_young must be >= the mature "
+                "valuation_monthly_log_return_mu (reversion is downward toward maturity)"
+            )
         return self
 
     @property
@@ -675,16 +724,38 @@ def _sample_latent_marks_vectorized(
     return paths
 
 
+def _scale_reverting_drift(
+    log_value: FloatMatrix, *, mu_mature: float, reversion: ValuationDriftScaleReversion
+) -> FloatMatrix:
+    """Monthly log-drift as a function of realized log enterprise value `s = log V`.
+
+        mu(s) = mu_mature + (mu_young - mu_mature) * exp(-max(0, s - s_onset) / s_scale)
+
+    Vectorized over the rollout axis; `log_value` is the per-rollout `s` at a single timestep.
+    Below the onset the company gets the full hot `mu_young`; above it, drift e-folds toward the
+    mature asymptote as it grows.
+    """
+
+    excess = reversion.monthly_log_return_mu_young - mu_mature
+    over_onset = np.maximum(0.0, log_value - reversion.log_value_onset_usd)
+    return mu_mature + excess * np.exp(-over_onset / reversion.log_value_scale)
+
+
 def _sample_company_valuation_vectorized(
     issuer: PrivateEquityRiskIssuerConfig, *, valuation_seeds: tuple[int, ...], horizon_months: int
 ) -> FloatMatrix:
     """Vectorized company-valuation V(t) sampler: returns (R, horizon_months + 1).
 
-    Mirrors `_sample_latent_marks_vectorized` EXACTLY (same log-space Student-t
-    random walk) but anchored at `current_valuation_usd` and driven by the
+    Log-space Student-t random walk anchored at `current_valuation_usd`, driven by the
     valuation-specific RW params off an independent seed stream. Column 0 equals
-    `current_valuation_usd` for every rollout. Only called when the valuation
-    channel is enabled, so `current_valuation_usd` is not None.
+    `current_valuation_usd` for every rollout. Only called when the valuation channel is
+    enabled, so `current_valuation_usd` is not None.
+
+    With constant drift this is a vectorized `cumsum` (same as the latent-mark RW). With
+    scale-dependent reversion on, the drift at each step depends on the realized `log V` at that
+    step, so V(t) is a genuine SDE and we integrate month by month (still vectorized across the
+    rollout axis). The shocks are drawn identically in both branches, so turning reversion off
+    is byte-identical to the constant-drift path.
     """
 
     # Caller only invokes this when the channel is on, so V0 is set; assert to narrow for mypy.
@@ -698,7 +769,23 @@ def _sample_company_valuation_vectorized(
     rng = np.random.default_rng(_seed_from_rollout_seeds(valuation_seeds))
     shocks = rng.standard_t(df=issuer.valuation_student_t_nu, size=(rollout_count, horizon_months))
     shocks *= issuer.valuation_monthly_log_return_sigma
-    log_path = math.log(current_valuation_usd) + np.cumsum(issuer.valuation_monthly_log_return_mu + shocks, axis=1)
+
+    log_v0 = math.log(current_valuation_usd)
+    reversion = issuer.valuation_drift_scale_reversion
+    if reversion is None:
+        # Constant drift: closed-form cumulative sum (drift independent of the realized level).
+        log_path = log_v0 + np.cumsum(issuer.valuation_monthly_log_return_mu + shocks, axis=1)
+    else:
+        # Scale-dependent drift: integrate the SDE step-by-step. Each step's drift is evaluated at
+        # the realized log-value at the START of the step (explicit Euler), so the level reverts
+        # as the company grows. Vectorized across rollouts; the month loop is cheap (H ~ 120).
+        log_path = np.empty((rollout_count, horizon_months), dtype=np.float64)
+        log_v = np.full(rollout_count, log_v0, dtype=np.float64)
+        for m in range(horizon_months):
+            drift = _scale_reverting_drift(log_v, mu_mature=issuer.valuation_monthly_log_return_mu, reversion=reversion)
+            log_v = log_v + drift + shocks[:, m]
+            log_path[:, m] = log_v
+
     try:
         with np.errstate(over="raise", invalid="raise"):
             paths[:, 1:] = np.exp(log_path)

--- a/augur/model/private_equity_risk_test.py
+++ b/augur/model/private_equity_risk_test.py
@@ -18,10 +18,12 @@ from augur.model.private_equity_risk import (
     PrivateEquityRiskIssuerConfig,
     PrivateEquityRiskProviderConfig,
     PublicMarketCdfAnchor,
+    ValuationDriftScaleReversion,
     _dilution_factor,
     _public_market_open_hazard_by_month,
     _sample_company_valuation_vectorized,
     _sample_issuer,
+    _scale_reverting_drift,
     _seed_from_rollout_seeds,
 )
 from augur.model.provider_config import ProviderConfig
@@ -455,21 +457,21 @@ def _valuation_issuer(**updates: object) -> PrivateEquityRiskIssuerConfig:
     the mark is the coupled V(t)/dilution machinery — keeps the assertions clean.
     """
 
-    return _issuer(
-        current_valuation_usd=1.0e11,
-        shares_outstanding_initial=1.0e9,
-        valuation_monthly_log_return_mu=0.02,
-        valuation_monthly_log_return_sigma=0.10,
-        valuation_student_t_nu=5.0,
+    defaults: dict[str, object] = {
+        "current_valuation_usd": 1.0e11,
+        "shares_outstanding_initial": 1.0e9,
+        "valuation_monthly_log_return_mu": 0.02,
+        "valuation_monthly_log_return_sigma": 0.10,
+        "valuation_student_t_nu": 5.0,
         # No legacy latent-mark drift/vol: when the channel is ON these are unused,
         # but keeping them inert makes the channel-OFF baseline below unambiguous.
-        monthly_log_return_mu=0.0,
-        monthly_log_return_sigma=0.0,
+        "monthly_log_return_mu": 0.0,
+        "monthly_log_return_sigma": 0.0,
         # Push tender/admin precursors past the horizon so mark[:,0] and the coupled
         # path aren't perturbed by event-price noise in the first columns.
-        tender_interval_months_median=600.0,
-        **updates,
-    )
+        "tender_interval_months_median": 600.0,
+    }
+    return _issuer(**{**defaults, **updates})
 
 
 def test_valuation_channel_off_by_default() -> None:
@@ -512,6 +514,109 @@ def test_valuation_channel_on_is_deterministic_under_fixed_seeds() -> None:
         a = first.private_equity.issuer_float_matrix("acme", str(channel), rollout_count=3, horizon_months=8)
         b = second.private_equity.issuer_float_matrix("acme", str(channel), rollout_count=3, horizon_months=8)
         np.testing.assert_array_equal(a, b)
+
+
+# ---- M2.2-D: scale-dependent mean-reverting valuation drift -------------------------------
+
+
+def test_scale_reverting_drift_young_when_small_mature_when_large() -> None:
+    """`mu(s) = mu_mature + (mu_young - mu_mature) * exp(-max(0, s - s_onset) / s_scale)`."""
+
+    reversion = ValuationDriftScaleReversion(
+        monthly_log_return_mu_young=0.05,
+        log_value_onset_usd=math.log(1.0e10),  # reversion begins at $10B
+        log_value_scale=2.0,
+    )
+    # Below onset: full young drift.
+    small = np.array([math.log(1.0e9), math.log(5.0e9)])
+    np.testing.assert_allclose(_scale_reverting_drift(small, mu_mature=0.008, reversion=reversion), [0.05, 0.05])
+    # At onset exactly: still the full young rate (excess factor exp(0) == 1).
+    at_onset = np.array([math.log(1.0e10)])
+    np.testing.assert_allclose(_scale_reverting_drift(at_onset, mu_mature=0.008, reversion=reversion), [0.05])
+    # One e-folding above onset (s = onset + s_scale): excess (0.05-0.008) decays by 1/e.
+    one_efold = np.array([math.log(1.0e10) + 2.0])
+    expected = 0.008 + (0.05 - 0.008) / math.e
+    np.testing.assert_allclose(_scale_reverting_drift(one_efold, mu_mature=0.008, reversion=reversion), [expected])
+    # Many e-foldings above onset ($1e16 is ~7 e-foldings past $1e10 at s_scale=2): essentially
+    # fully reverted to mu_mature.
+    huge = np.array([math.log(1.0e16)])
+    assert _scale_reverting_drift(huge, mu_mature=0.008, reversion=reversion)[0] == pytest.approx(0.008, abs=1e-4)
+
+
+def test_scale_reversion_off_is_byte_identical_to_constant_drift() -> None:
+    """No reversion submodel ⇒ the fast constant-drift cumsum path, unchanged."""
+
+    seeds = (101, 102, 103, 104)
+    constant = _valuation_issuer(valuation_monthly_log_return_mu=0.03)
+    a = _sample_company_valuation_vectorized(constant, valuation_seeds=seeds, horizon_months=36)
+    # A second issuer with the same params re-samples identically (determinism guard).
+    b = _sample_company_valuation_vectorized(constant, valuation_seeds=seeds, horizon_months=36)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_scale_reversion_degenerate_matches_constant_drift() -> None:
+    """`mu_young == mu_mature` makes the excess zero, so the SDE-integrated path equals the
+    constant-drift cumsum path exactly (same shocks, same drift every step)."""
+
+    seeds = (1, 2, 3, 4, 5)
+    constant = _valuation_issuer(valuation_monthly_log_return_mu=0.02)
+    degenerate = _valuation_issuer(
+        valuation_monthly_log_return_mu=0.02,
+        valuation_drift_scale_reversion=ValuationDriftScaleReversion(
+            monthly_log_return_mu_young=0.02,  # == mu_mature ⇒ no excess at any size
+            log_value_onset_usd=math.log(1.0e10),
+            log_value_scale=2.0,
+        ),
+    )
+    a = _sample_company_valuation_vectorized(constant, valuation_seeds=seeds, horizon_months=48)
+    b = _sample_company_valuation_vectorized(degenerate, valuation_seeds=seeds, horizon_months=48)
+    np.testing.assert_allclose(a, b, rtol=1e-12)
+
+
+def test_scale_reversion_curbs_long_horizon_growth_vs_constant_hot_drift() -> None:
+    """A hot CONSTANT drift compounds to an absurd 10y median; scale-reversion keeps the
+    near-term path (small company still hot) but tames the long horizon as V grows. The M2.2-D fix."""
+
+    seeds = tuple(range(1, 401))
+    horizon = 120
+    # Anchor both small ($1e9) so the young rate is active early.
+    hot_constant = _valuation_issuer(
+        current_valuation_usd=1.0e9, valuation_monthly_log_return_mu=0.05, valuation_monthly_log_return_sigma=0.04
+    )
+    reverting = _valuation_issuer(
+        current_valuation_usd=1.0e9,
+        valuation_monthly_log_return_mu=0.008,  # mature ~10%/yr
+        valuation_monthly_log_return_sigma=0.04,
+        valuation_drift_scale_reversion=ValuationDriftScaleReversion(
+            monthly_log_return_mu_young=0.05,  # same hot rate while small
+            log_value_onset_usd=math.log(1.0e10),
+            log_value_scale=2.0,
+        ),
+    )
+    v_hot = _sample_company_valuation_vectorized(hot_constant, valuation_seeds=seeds, horizon_months=horizon)
+    v_rev = _sample_company_valuation_vectorized(reverting, valuation_seeds=seeds, horizon_months=horizon)
+    v0 = 1.0e9
+    # Near term (month 3, still well below the $10B onset): the two track closely.
+    assert np.median(v_rev[:, 3]) / v0 == pytest.approx(np.median(v_hot[:, 3]) / v0, rel=0.20)
+    # Long horizon: the reverting path is materially smaller (it matured toward ~10%/yr as it
+    # grew, while the constant-hot path keeps compounding ~80%/yr). The gap widens with horizon.
+    assert np.median(v_rev[:, 120]) < 0.5 * np.median(v_hot[:, 120])
+    # And the constant-hot path is itself absurdly large at 10y (the failure mode reversion fixes).
+    assert np.median(v_hot[:, 120]) / v0 > 100.0
+
+
+def test_scale_reversion_validator_rejects_young_below_mature() -> None:
+    """Reversion is downward: a young drift below the mature asymptote is rejected."""
+
+    with pytest.raises(ValidationError, match="mu_young must be >= the mature"):
+        _valuation_issuer(
+            valuation_monthly_log_return_mu=0.05,
+            valuation_drift_scale_reversion=ValuationDriftScaleReversion(
+                monthly_log_return_mu_young=0.01,  # below mature ⇒ invalid
+                log_value_onset_usd=math.log(1.0e10),
+                log_value_scale=2.0,
+            ),
+        )
 
 
 def _deterministic_dilution_factor(*, rate: float, horizon_months: int) -> np.ndarray:

--- a/augur/plans/prediction_market_calibration.md
+++ b/augur/plans/prediction_market_calibration.md
@@ -180,9 +180,123 @@ a fat posterior (argues for propagating parameter uncertainty into the per-rollo
 - **M2.2-C — lumpiness + secondary rigor (deferred).** Discrete primary-round dilution as a new
   V-coupled event kind, distinct from the existing (secondary) tender events; likelihood that
   attributes only primary rounds to share growth and treats secondaries as pure re-pricing.
-- **M2.2-D — full Bayesian posterior (deferred).** Replace MAP/SVI point-of-distribution with
-  NUTS + posterior-predictive propagation, so the (fat by design) `σ_r` posterior folds
-  epistemic ignorance into the per-rollout spread.
+- **M2.2-D — full Bayesian posterior + decaying valuation drift (designed; prototype validated).**
+  Two coupled changes, both needed; a NUTS prototype on the openai evidence (2026-05-30,
+  16 obs) established the numbers below.
+
+  **Why the OLS fit (M2.2-A) cannot be deployed.** Running `derive_dilution_prior` on the
+  gaffer openai evidence yields `annual_dilution_rate ≈ 0.476`, `valuation_monthly_log_return_mu
+≈ 0.1075` (~244%/yr). Validated against `sample_sanity.yaml`'s `private_equity_mark_checks`
+  (512 rollouts × 120 mo): m12 p50 = 2.39 (band [0.7,1.8]) and **m120 p50 = 8035** (band
+  [0.3,4.0]) — fails by ~2000×. Root cause is twofold: (1) the OLS log-linear slope extrapolates
+  the 2023-25 boom as a _forward_ rate; (2) `mark = current·V(t)/V0/(1+r)^(t/12)` couples drift
+  and dilution, which OLS fits jointly but the config then compounds independently, so dropping
+  just `mu_V` back to 0.02 makes the 48% dilution undershoot the floor (m120 p50 = 0.22).
+
+  **Part 1 — NUTS posterior (prototyped, big improvement, still insufficient alone).** A small
+  numpyro state-space model (latent log-V random walk + deterministic log-share path; per-obs
+  `uncertainty_log_sigma` as the likelihood scale; INFORMATIVE priors: `mu_V ~ N(0.02, 0.025)`,
+  `log(1+r) ~ N(log1.20, 0.30)`) over ALL 16 observations, fit with NUTS, mirrors the existing
+  `augur/model/vecm.py` numpyro pipeline (~90 lines; built + ran in one shot). Posterior medians:
+  `annual_dilution_rate ≈ 0.29` (p5–95 0.19–0.40), `annual_dilution_rate_log_sigma ≈ 0.05`,
+  `mu_V ≈ 0.071` (~134%/yr). The priors regularize the 4-point extrapolation: m120 p50 drops
+  8035 → **381** (21× better) — but **still fails the gate**, because a constant-drift random
+  walk compounds even the regularized near-term rate over 10 years. Bayesian inference fixes the
+  _uncertainty_ and over-extrapolation, not the _structural_ forever-drift.
+
+  **Part 2 — drift structure: scale-dependent mean reversion (the load-bearing fix).** The first
+  cut tried a CALENDAR-time decay `mu_V(t) = mu_∞ + (mu_0 − mu_∞)·0.5^(t/τ)` (shipped in the
+  sampler + `bayes_dilution.py`). On the openai evidence it improves a lot but still overshoots:
+  even with a tight long-run prior the NUTS fit keeps `mu_∞ ≈ 0.033/mo (~49%/yr)` and `m120 p50
+≈ 100×`, because (a) every observation is still rising steeply through the latest one, so the
+  data gives no reason to believe the boom ended, and (b) calendar decay replays the historical
+  boom from t=0=now. **Calendar time is the wrong axis.** The right structure makes drift a
+  function of company SIZE, not elapsed time:
+
+  ```
+  mu_V(s) = mu_mature + (mu_young − mu_mature) · exp( −max(0, s − s_young) / s_scale )
+  ```
+
+  where `s = log V(t)` is the realized log enterprise value. A small company (`s ≤ s_young`)
+  gets the hot `mu_young`; a large one reverts toward `mu_mature`, and KEEPS maturing as it
+  grows. This is data-driven, not a hidden prior: the model tames the boom _because OpenAI is now
+  $852B_ (an observed fact), and it self-corrects per rollout — a rollout that stays small keeps
+  its upside, one that booms matures early. Empirical backing: firm growth-rate dispersion scales
+  as `σ ~ S^(−0.2)` and mean growth declines with size (Stanley/Amaral scaling laws; decacorns
+  "grow slower"). Implementation note: state-dependent drift makes `V(t)` a genuine SDE, so
+  `_sample_company_valuation_vectorized` becomes a per-month loop (vectorized across rollouts) —
+  a contained sampler change, trivial cost at 120 × few-thousand.
+
+  **Research-grounded starting values (conservative; population-fittable later).** Until a
+  startup-panel fit (below) replaces them, use educated guesses:
+  - `mu_mature` ≈ **0.008/mo (~10%/yr nominal)** — the S&P 500's ~100-yr nominal CAGR. A mega-cap
+    at maturity is not assumed to beat the index. Deliberately conservative.
+  - `mu_young` ≈ 0.035–0.05/mo (~50–80%/yr) — decacorn-era growth; the fit lifts it from data.
+  - `s_young` / `s_scale` — maturity onset around $10–50B, reverting over the back half of the
+    size range. Tune so the openai forward path lands in the `sample_sanity` bands.
+
+  **Catastrophic loss is a SEPARATE channel — do not fold it into drift.** Asymptoting the
+  central drift toward ~market return does NOT undersell "lose everything," because total loss is
+  a discrete-event / no-realization phenomenon that lives in the hazard channels (collapse,
+  legal-impairment, forced-recovery) and the no-liquidity tail, not in the going-concern drift.
+  Population base rates make this vivid and confirm augur currently _under_-states it: of 2010–15
+  Series C companies only **38% exited within a decade (62% never delivered liquidity)**; post-
+  2021, **>80% of unicorns sit below their peak and ~30% fell under $1B**; WeWork went $47B →
+  bankruptcy (−99.9%). So the realization-risk tail is empirically _fat_, and the pre-IPO-failure
+  calibration gap we already measured (model 0.014 vs market 0.092) is the same under-statement.
+  **Linked work item:** bump the collapse / no-liquidity hazards toward these population base
+  rates (tracked in TODO.md; it is the loss-tail counterpart to this drift work).
+
+  **North star — hierarchical population prior (the real reason to be Bayesian).** One company's
+  16 points can never answer "does the boom persist?"; only a _reference class_ can. Fit the
+  scale-reversion hyperparameters `(mu_young, mu_mature, s_young, s_scale)` + dilution + the
+  loss-hazard base rates across a POPULATION of startup trajectories, then treat each issuer
+  (openai) as one draw shrunk toward the population (partial pooling). That converts every
+  educated guess above into a pooled estimate with provenance, and simultaneously calibrates the
+  loss tail. **Survivorship bias is the central trap:** public/cheap startup datasets over-
+  represent survivors, which would bias drift up and the loss tail down — exactly backwards for a
+  realization-risk model. The dataset must include down rounds, shutdowns, and never-exited
+  "walking dead." Reserve schema room for terminal/failure outcomes, not just valuation marks.
+  This is the eventual home of the dilution evidence schema's primary/secondary round labels and
+  round sizes too (M2.2-C), since a population fit wants the lumpy-vs-continuous split.
+
+  **Deploy mechanism (orthogonal, later).** All of the above is the GENERATIVE structure; how the
+  posterior is propagated forward at deploy time is a separate axis. Today: freeze the posterior
+  SUMMARY (means/SD) into scalar config knobs, resampled cheaply by the existing numpy sampler
+  (like vecm's `.npz`). A later upgrade is full posterior-PREDICTIVE deploy — the openai PE
+  channel sampling forward from the conditioned posterior (carrying the full joint + latent-state
+  uncertainty, not just marginals). That is more honest fan-out but needs a private trained-
+  artifact pipeline in gaffer (the evidence is private), mirroring `state_space_macro_artifact.json`.
+  It does NOT fix the median overshoot — that is the generative structure's job — so it follows
+  the scale-reversion work, not precedes it.
+
+  **Status.** Shipped (sampler + fit, synthetic-green): the scale-reversion drift is in the
+  sampler (`ValuationDriftScaleReversion` submodel, integrated as an SDE) and in the NUTS fit
+  (`augur/fit/bayes_dilution.py`, also SDE via `jax.lax.scan`). The Bayesian dilution rate is
+  sane and the structure recovers a known shape from synthetic data.
+
+  **KEY FINDING — openai alone cannot identify the reversion shape (proves the population prior
+  is necessary, not just nicer).** Running the full scale-reversion fit end-to-end on the real
+  openai evidence blows up: `mu_mature → 411%/yr` (32σ off its prior), `shares0 → $6e3`, dilution
+  negative. Cause: **every openai valuation observation ($28B+, 2023 on) is already in the
+  "large" regime** — there is NO observed small-company phase to anchor `mu_young` vs `mu_mature`
+  or the onset — and the 2019–21 price-only stretch (no paired valuation) adds a `shares0`↔`V`
+  level degeneracy. A single company "already huge and booming" cannot, even in principle, tell
+  you how growth decays with size. So:
+  - **openai deployment (DONE — `fit_scale_reversion_shape=False`, the default).**
+    `fit_bayesian_dilution_prior` now fixes the reversion SHAPE (`mu_mature`, `mu_young`, onset,
+    scale) at the `BayesianDilutionPriors` centers (each justified in that dataclass's per-field
+    docs) and samples only the identifiable params (level, σ_v, share count, dilution). On the
+    real openai evidence this is stable (0 divergences) and lands `r≈0.27`, `mu_mature=10%/yr`,
+    forward `σ_v≈43%/yr` — **inside all four `sample_sanity` mark bands** (m12 p50≈1.0, m120
+    p50≈0.45, both p1..p99 in band). The forward `σ_v` prior is deliberately tighter than the
+    boom-era in-sample scatter (~73%/yr), for the same forward-vs-in-sample reason as the drift.
+  - **TODO — fit the shape via the hierarchical population prior** (below): the ONLY thing that
+    can _identify_ the reversion shape, because it borrows the small-company phase from _other_
+    companies; the single-issuer blow-up above is the empirical justification for prioritizing it.
+    Until then the fixed shape is a load-bearing educated guess, not a fitted result. When the
+    population fit lands, it replaces the fixed `BayesianDilutionPriors` shape centers and the
+    `fit_scale_reversion_shape=True` path becomes the per-issuer fit shrunk toward that population.
 
 ### M3 — IPO lockup: probabilistic + refined
 


### PR DESCRIPTION
Replaces the OLS dilution-prior fit (which extrapolated the observed boom to an absurd ~8000× median 10-year mark and failed the deployed `sample_sanity` bands) with a full-Bayesian NUTS fit plus scale-dependent mean-reverting valuation drift.

### What's here
- **`augur/fit/bayes_dilution.py`** — numpyro state-space model over *all* observations: a latent log-company-value SDE `V(t)` with a deterministic log-share path, each observation weighted by its own `uncertainty_log_sigma`. Informative priors regularize the few-point extrapolation and yield an honest posterior `annual_dilution_rate_log_sigma`.
- **Scale-dependent mean-reverting drift** (`augur/model/private_equity_risk.py`): `V(t)` drift declines from a hot `mu_young` (small company) toward `mu_mature` as realized log enterprise value grows past an onset — the boom is tamed by observed *size*, not a calendar prior. Maps onto a `ValuationDriftScaleReversion` submodel on the issuer config.
- **Fixed-shape fit mode (default)**: a single issuer whose observations are all in one size regime can't identify the reversion shape (fitting it diverges), so the four shape params are fixed at documented prior centers; only the identifiable params (level, vol, share count, dilution) are sampled. The identifiability blow-up and the OLS-fit deploy failure are recorded in `augur/plans/prediction_market_calibration.md`.
- Every prior's rationale documented; forward σ_V calibrated to ~40%/yr (de-smoothed late-stage VC vol), verified in-band across seeds.
- The included mypy fix commit (`#1771`, already merged into this branch) narrows the `scan` carry / observation-origin types.

### Diff
11 commits, 7 files, +884 / −25. New: `bayes_dilution.py` (+358) and `test_bayes_dilution.py` (+132).

### Verification
Rebased onto current `devel` (clean, no conflicts). `bbr build //augur/fit/... //augur/model/...` green with lint (mypy/ruff); tests pass: `test_bayes_dilution`, `data_test`, `train_round_trip_test`, `state_space_acceptance_test`, `private_equity_risk_test`.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_