### PR TITLE
augur/fit: fix ruff-format drift on devel (pre-commit red)

### DIFF
--- a/augur/fit/data_test.py
+++ b/augur/fit/data_test.py
@@ -19,7 +19,9 @@ def test_configured_evidence_source_errors_raise_by_default(tmp_path: Path, monk
     # sources resolve normally); the loader must surface the JSON parse error
     # rather than swallow it.
     def fake_resolver(repo_relative: str) -> Path:
-        return malformed_yahoo if repo_relative == evidence_data.YAHOO_SPY_ADJUSTED_JSON else real_resolver(repo_relative)
+        return (
+            malformed_yahoo if repo_relative == evidence_data.YAHOO_SPY_ADJUSTED_JSON else real_resolver(repo_relative)
+        )
 
     monkeypatch.setattr(evidence_data, "_source_path", fake_resolver, raising=True)
 

--- a/augur/fit/evidence_data.py
+++ b/augur/fit/evidence_data.py
@@ -269,17 +269,13 @@ def _return_frame_summary(frame: pd.DataFrame, *, source: str, used_as_marginal_
 
 def load_exogenous_evidence() -> ExogenousEvidence:
     sp500_price = _monthly_last(_read_fred_series(_source_path(FRED_SP500_CSV), "SP500"))
-    sp500_total_return = _monthly_last(
-        _read_yahoo_spy_adjusted_close(_source_path(YAHOO_SPY_ADJUSTED_JSON))
-    )
+    sp500_total_return = _monthly_last(_read_yahoo_spy_adjusted_close(_source_path(YAHOO_SPY_ADJUSTED_JSON)))
     btc_price = _monthly_last(_read_yahoo_adjusted_close(_source_path(YAHOO_BTC_ADJUSTED_JSON)))
     eth_price = _monthly_last(_read_yahoo_adjusted_close(_source_path(YAHOO_ETH_ADJUSTED_JSON)))
     cpi = _monthly_last(_read_fred_series(_source_path(FRED_CPI_US_CSV), "CPIAUCSL"))
     rent = _monthly_last(_read_fred_series(_source_path(FRED_SF_RENT_CPI_CSV), "CUURA422SEHA"))
     case_shiller = _monthly_last(_read_fred_series(_source_path(FRED_SFXRSA_CSV), "SFXRSA"))
-    fhfa = _monthly_last(
-        _read_fred_series(_source_path(FRED_FHFA_SF_OAKLAND_BERKELEY_CSV), "ATNHPIUS41884Q")
-    )
+    fhfa = _monthly_last(_read_fred_series(_source_path(FRED_FHFA_SF_OAKLAND_BERKELEY_CSV), "ATNHPIUS41884Q"))
     mortgage30 = _read_fred_series(_source_path(FRED_MORTGAGE30_CSV), "MORTGAGE30US")
     zillow_path = _source_path(ZILLOW_CITY_ZHVI_CSV)
     home_values = {


### PR DESCRIPTION
## What

Applies `ruff-format` to two files that landed un-formatted on `devel` via #1772, making `pre-commit run --all-files` clean again.

## Why

`devel`'s **"Pre-commit checks" CI is currently red** — #1772 merged with it failing because that check is non-blocking (only `Bazel CI` + the review checks gate merges). The drift is self-inflicted: #1772 renamed `get_required_own_repo_path(...)` → the shorter `_source_path(...)` via search-and-replace, which made two wrapped `_monthly_last(...)` calls fit within the 120-col limit, but `ruff-format` wasn't re-run, so the now-unnecessary line wrapping stayed.

- `evidence_data.py`: unwrap two `_monthly_last(...)` calls that now fit on one line.
- `data_test.py`: wrap the `fake_resolver` return to fit the limit.

## Verification

Ran the full suite in the Nix **devshell** (`nix develop`), the same environment CI's `setup-nix-devtools` provides:
- `ruff-format` → **Passed** (idempotent; re-running produces no changes)
- `ruff-check` → **Passed**
- All other hooks pass (check-yaml, prettier, buildifier, kubeconform, Checkov, tflint, ducktape-pytest-main-check, etc.)

Net **+5 / −7** across 2 files; pure formatting, no behavior change.

### Note on `cluster-validate`

The `ducktape-precommit` hook intermittently reports `cluster-validate: FAILED` with a `TLS handshake timeout` fetching kubevirt's remote `kubevirt-operator.yaml` / `cdi-operator.yaml` from github.com — a network flake (the same validation prints `ok` on other invocations in the same run). Not a content issue; out of scope here.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_