### PR TITLE
augur: surface sample_sanity reasonableness bands on the calibration page

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -36,6 +36,7 @@ py_library(
     deps = [
         ":schemas",
         "//augur/calibration",
+        "//augur/model:sample_sanity",
         "//augur/product:wire",
         "@pypi//pydantic",
     ],
@@ -212,11 +213,14 @@ py_test(
         ":server_lib",
         "//augur/calibration:catalog",
         "//augur/calibration:testing",
+        "//augur/model:sample_sanity",
+        "//augur/model:series",
         "//util/bazel:runfiles",
         "@pypi//fastapi",
         "@pypi//httpx",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
     ],
 )
 
@@ -235,12 +239,15 @@ py_library(
         "//augur/calibration:catalog",
         "//augur/calibration:manifold",
         "//augur/model:exogenous",
+        "//augur/model:sample_sanity",
+        "//augur/model:series",
         "//augur/product:portfolio",
         "//augur/product:scenarios",
         "//augur/product:service",
         "//augur/product:wire",
         "@pypi//fastapi",
         "@pypi//pydantic",
+        "@pypi//pyyaml",
         "@pypi//uvicorn",
     ],
 )

--- a/augur/api/calibration_wire.py
+++ b/augur/api/calibration_wire.py
@@ -8,14 +8,54 @@ on the wire (the frontend camelizes), exported to the frontend Zod schema via
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field, PositiveInt
 
 from augur.api.schemas import ApiModel
 from augur.calibration.calibration import CalibrationResult, MarkFan
+from augur.model.sample_sanity import SanityBandResult
 from augur.product.wire import MAX_HORIZON_MONTHS
 
 # Default percentile bands for the issuer mark fan (5/25/50/75/95).
 CALIBRATION_FAN_PERCENTILES: tuple[float, ...] = (5.0, 25.0, 50.0, 75.0, 95.0)
+
+
+class CalibrationSanityBand(ApiModel):
+    """Wire mirror of `augur.model.sample_sanity.SanityBandResult`: one evaluated
+    reasonableness band (expected bounds vs the observed value(s)) for the calibration page.
+
+    `expected_lower`/`expected_upper`/`month` are legitimately `None` for some bands (a one-sided
+    bound, or a check with no month index); the drop-None wire omits them and the frontend Zod
+    schema treats them as optional, so it can distinguish "no bound" from a present bound.
+    """
+
+    label: str
+    series_id: str
+    kind: str
+    month: int | None = None
+    expected_lower: float | None = None
+    expected_upper: float | None = None
+    observed: list[float] = []
+    observed_labels: list[str] = []
+    status: Literal["pass", "fail", "skipped"]
+    detail: str
+
+
+def sanity_band_to_wire(result: SanityBandResult) -> CalibrationSanityBand:
+    """Map the pure-evaluator `SanityBandResult` dataclass onto its wire model."""
+    return CalibrationSanityBand(
+        label=result.label,
+        series_id=result.series_id,
+        kind=result.kind,
+        month=result.month,
+        expected_lower=result.expected_lower,
+        expected_upper=result.expected_upper,
+        observed=list(result.observed),
+        observed_labels=list(result.observed_labels),
+        status=result.status,
+        detail=result.detail,
+    )
 
 
 class CalibrationRunRequest(ApiModel):
@@ -32,8 +72,13 @@ class CalibrationRunRequest(ApiModel):
 
 
 class CalibrationRunResponse(ApiModel):
-    """`CalibrationResult` (issuer, clean/surfaced rows) plus the issuer mark fan."""
+    """`CalibrationResult` (issuer, clean/surfaced rows) plus the issuer mark fan.
+
+    `sanity_bands` carries the deployment's `sample_sanity` reasonableness bands evaluated
+    against this run's rollouts; empty when the deployment configures no `sample_sanity_path`.
+    """
 
     preset_id: str
     result: CalibrationResult
     mark_fan: MarkFan
+    sanity_bands: list[CalibrationSanityBand] = []

--- a/augur/api/config.py
+++ b/augur/api/config.py
@@ -89,6 +89,16 @@ class CalibrationCatalogConfig(ApiModel):
     catalog_path: Path
     issuer: str = Field(pattern=r"^[a-z0-9][a-z0-9_\-]*$")
     label: str | None = None
+    sample_sanity_path: Path | None = Field(
+        default=None,
+        description=(
+            "Optional `SampleSanitySpec` YAML (resolved relative to the config file, like "
+            "`catalog_path`). When set, `/api/calibration/run` evaluates the spec's reasonableness "
+            "bands against the live rollouts and returns them as `sanity_bands`. The spec is consumed "
+            "only for its `*_checks` + `required_level_series`/`required_private_equity_issuers`; its "
+            "`provider_config_path` is ignored (the page reuses the live calibration model)."
+        ),
+    )
 
 
 class LocationConfig(ApiModel):
@@ -190,11 +200,22 @@ def load_augur_config(path: Path) -> Config:
     config = Config.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
     config = _anchor_property_source_paths(config, base_dir=path.parent)
     config = _anchor_exogenous_provider_paths(config, base_dir=path.parent)
-    catalog = config.calibration_catalog
-    if catalog is not None and not catalog.catalog_path.is_absolute():
-        anchored = catalog.model_copy(update={"catalog_path": (path.parent / catalog.catalog_path).resolve()})
-        config = config.model_copy(update={"calibration_catalog": anchored})
+    config = _anchor_calibration_catalog_paths(config, base_dir=path.parent)
     return config
+
+
+def _anchor_calibration_catalog_paths(config: Config, *, base_dir: Path) -> Config:
+    catalog = config.calibration_catalog
+    if catalog is None:
+        return config
+    updates: dict[str, Path] = {}
+    if not catalog.catalog_path.is_absolute():
+        updates["catalog_path"] = (base_dir / catalog.catalog_path).resolve()
+    if catalog.sample_sanity_path is not None and not catalog.sample_sanity_path.is_absolute():
+        updates["sample_sanity_path"] = (base_dir / catalog.sample_sanity_path).resolve()
+    if not updates:
+        return config
+    return config.model_copy(update={"calibration_catalog": catalog.model_copy(update=updates)})
 
 
 def _anchor_property_source_paths(config: Config, *, base_dir: Path) -> Config:

--- a/augur/api/config_test.py
+++ b/augur/api/config_test.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from augur.api.bootstrap import ActorRole
 from augur.api.config import (
     AgentDefinition,
+    CalibrationCatalogConfig,
     Config,
     LocationConfig,
     PropertyAssetConfig,
@@ -300,6 +301,37 @@ def test_relative_state_space_artifact_path_anchors_against_yaml_dir(tmp_path) -
     provider = reloaded.exogenous_presets[reloaded.default_exogenous_preset_id]
     assert isinstance(provider, StateSpaceProviderConfig)
     assert provider.trained_artifact_path == (tmp_path / "state_space_artifact.json").resolve()
+
+
+def test_calibration_catalog_sample_sanity_path_defaults_to_none() -> None:
+    catalog = CalibrationCatalogConfig(catalog_path=Path("/tmp/catalog.yaml"), issuer="openai")
+    assert catalog.sample_sanity_path is None
+
+
+def test_relative_calibration_catalog_paths_anchor_against_yaml_dir(tmp_path) -> None:
+    """Both `catalog_path` and the optional `sample_sanity_path` resolve against the yaml dir,
+    like the other ConfigMap-mounted deployment paths."""
+    (tmp_path / "properties.json").write_text("[]", encoding="utf-8")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        dump_augur_config_yaml(
+            _minimal_config(
+                property_source=PropertySourceConfig(properties_path=Path("properties.json")),
+                calibration_catalog=CalibrationCatalogConfig(
+                    catalog_path=Path("catalog.yaml"),
+                    issuer="openai",
+                    sample_sanity_path=Path("sample_sanity.yaml"),
+                ),
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    reloaded = load_augur_config(config_path)
+
+    assert reloaded.calibration_catalog is not None
+    assert reloaded.calibration_catalog.catalog_path == (tmp_path / "catalog.yaml").resolve()
+    assert reloaded.calibration_catalog.sample_sanity_path == (tmp_path / "sample_sanity.yaml").resolve()
 
 
 def test_relative_property_source_paths_anchor_against_yaml_dir(tmp_path) -> None:

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -8,22 +8,30 @@ from pathlib import Path
 from typing import Any, cast
 
 import uvicorn
+import yaml
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import ValidationError
 
 from augur.api.bootstrap import BootstrapResponse
-from augur.api.calibration_wire import CALIBRATION_FAN_PERCENTILES, CalibrationRunRequest, CalibrationRunResponse
+from augur.api.calibration_wire import (
+    CALIBRATION_FAN_PERCENTILES,
+    CalibrationRunRequest,
+    CalibrationRunResponse,
+    sanity_band_to_wire,
+)
 from augur.api.casing import plain_json
 from augur.api.catalog import build_bootstrap_payload
 from augur.api.config import CalibrationCatalogConfig, Config, load_augur_config, resolve_augur_config_path
 from augur.api.deployment import DeploymentInfo, build_deployment_info
 from augur.api.schemas import ApiModel
-from augur.calibration.calibration import mark_fan, run_calibration, sample_private_equity_bundle
+from augur.calibration.calibration import mark_fan, run_calibration
 from augur.calibration.catalog import MarketCatalog
 from augur.calibration.manifold import ManifoldClient
-from augur.model.exogenous import Sampler
+from augur.model.exogenous import ExogenousSamplingRequest, Sampler
+from augur.model.sample_sanity import SampleSanitySpec, evaluate_sample_checks
+from augur.model.series import IssuerId
 from augur.product.portfolio import ProductPortfolioResponse, product_portfolio_response
 from augur.product.scenarios import resolve_primary_agent_id, sim_locations_from_config
 from augur.product.service import ProductService
@@ -32,10 +40,17 @@ from augur.product.wire import MetricFanRequest, MetricFanResponse, RolloutReque
 
 @dataclass(frozen=True)
 class LoadedCalibrationCatalog:
-    """The configured calibration catalog config paired with its parsed `MarketCatalog`."""
+    """The configured calibration catalog config paired with its parsed `MarketCatalog`.
+
+    `sample_sanity_spec` is the parsed `SampleSanitySpec` when the deployment configures a
+    `sample_sanity_path`, else None (the feature is simply absent). Only its `*_checks` +
+    `required_*` are consumed; its `provider_config_path` is never realized — the calibration
+    endpoint reuses the live preset model.
+    """
 
     config: CalibrationCatalogConfig
     catalog: MarketCatalog
+    sample_sanity_spec: SampleSanitySpec | None = None
 
 
 @dataclass(frozen=True)
@@ -126,11 +141,20 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         # KeyError on the preset lookup -> 400 via the registered handler.
         model = config.exogenous_models[preset_id]
         issuer = loaded.config.issuer
+        spec = loaded.sample_sanity_spec
         rollout_seeds = tuple(range(request.seed, request.seed + request.rollouts))
-        # One rollout drives both the market scoring and the issuer mark fan.
-        bundle = sample_private_equity_bundle(
-            model, issuer=issuer, horizon_months=request.horizon_months, rollout_seeds=rollout_seeds
+        # Sample one full bundle that drives the market scoring, the issuer mark fan, AND the
+        # sample-sanity bands — still a single rollout. The PE bundle goes to `run_calibration`/
+        # `mark_fan` (preserving today's behavior); the level series the sanity spec needs are
+        # requested here too. A spec asking for a series the preset can't produce raises -> 400.
+        sampling_request = ExogenousSamplingRequest(
+            horizon_months=request.horizon_months,
+            rollout_seeds=rollout_seeds,
+            required_private_equity_issuers=frozenset({IssuerId(issuer)}),
+            required_level_series=frozenset(spec.required_level_series) if spec is not None else frozenset(),
         )
+        sampled = model.sample(sampling_request)
+        bundle = sampled.private_equity
         result = run_calibration(
             model,
             loaded.catalog,
@@ -147,7 +171,19 @@ def create_app(config: ApiServerConfig) -> FastAPI:
             horizon_months=request.horizon_months,
             percentiles=CALIBRATION_FAN_PERCENTILES,
         )
-        return calibration_payload(CalibrationRunResponse(preset_id=preset_id, result=result, mark_fan=fan))
+        sanity_bands = (
+            [
+                sanity_band_to_wire(band)
+                for band in evaluate_sample_checks(
+                    spec, sampled, rollout_count=request.rollouts, horizon_months=request.horizon_months
+                )
+            ]
+            if spec is not None
+            else []
+        )
+        return calibration_payload(
+            CalibrationRunResponse(preset_id=preset_id, result=result, mark_fan=fan, sanity_bands=sanity_bands)
+        )
 
     # The health check is not part of the typed wire contract, so keep it out of the
     # OpenAPI document `export_schema` dumps (no Zod/TS codegen noise). Unknown API routes
@@ -157,6 +193,16 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         return PlainTextResponse("ok\n", headers=no_store)
 
     return app
+
+
+def _load_sample_sanity_spec(path: Path | None) -> SampleSanitySpec | None:
+    """Parse the deployment's `SampleSanitySpec` YAML, or None when unconfigured.
+
+    Consumed only for its `*_checks` + `required_*`; `provider_config_path` is left unresolved
+    (the calibration endpoint reuses the live preset model rather than realizing the spec's)."""
+    if path is None:
+        return None
+    return SampleSanitySpec.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
 def create_app_from_augur_config(augur_config: Config, *, price_client: ManifoldClient | None = None) -> FastAPI:
@@ -170,7 +216,11 @@ def create_app_from_augur_config(augur_config: Config, *, price_client: Manifold
     }
     catalog_config = augur_config.calibration_catalog
     calibration_catalog = (
-        LoadedCalibrationCatalog(config=catalog_config, catalog=MarketCatalog.from_yaml(catalog_config.catalog_path))
+        LoadedCalibrationCatalog(
+            config=catalog_config,
+            catalog=MarketCatalog.from_yaml(catalog_config.catalog_path),
+            sample_sanity_spec=_load_sample_sanity_spec(catalog_config.sample_sanity_path),
+        )
         if catalog_config is not None
         else None
     )

--- a/augur/api/test_calibration_endpoint.py
+++ b/augur/api/test_calibration_endpoint.py
@@ -9,27 +9,43 @@ run stays hermetic (no network). `/api/bootstrap` surfaces the catalog info;
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 import pytest_bazel
+import yaml
 from fastapi.testclient import TestClient
 
-from augur.api.config import load_augur_config
+from augur.api.config import Config, load_augur_config
 from augur.api.server import create_app_from_augur_config
 from augur.calibration.catalog import MarketCatalog
 from augur.calibration.testing import mock_manifold_client
+from augur.model.sample_sanity import (
+    LevelSeriesSanityCheck,
+    PrivateEquityMarkSanityCheck,
+    SampleSanitySpec,
+)
+from augur.model.series import IssuerId, SP500Key
 from util.bazel.runfiles import get_required_path
 
 
-@pytest.fixture
-def client() -> Iterator[TestClient]:
+def _fixture_config() -> Config:
     config = load_augur_config(get_required_path("_main/augur/api/testdata/config.yaml"))
+    assert config.calibration_catalog is not None
+    return config
+
+
+def _client_for(config: Config) -> TestClient:
     assert config.calibration_catalog is not None
     catalog = MarketCatalog.from_yaml(config.calibration_catalog.catalog_path)
     # Every market resolves to the same fixed YES probability so the run is hermetic.
     prices = {market.manifold_id: 0.5 for market in catalog.markets}
-    app = create_app_from_augur_config(config, price_client=mock_manifold_client(prices))
-    with TestClient(app) as test_client:
+    return TestClient(create_app_from_augur_config(config, price_client=mock_manifold_client(prices)))
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with _client_for(_fixture_config()) as test_client:
         yield test_client
 
 
@@ -101,6 +117,65 @@ def test_unknown_calibration_route_still_404(client: TestClient) -> None:
     # catch-all is gone; nginx serves the SPA, so the app is API-only with no static fallback).
     response = client.get("/api/calibration/does-not-exist")
     assert response.status_code == 404, response.text
+
+
+def test_run_calibration_without_sample_sanity_returns_empty_bands(client: TestClient) -> None:
+    # The public fixture configures a `calibration_catalog` but no `sample_sanity_path`, so the
+    # reasonableness-band feature is absent: the endpoint succeeds and returns an empty list.
+    response = client.post("/api/calibration/run", json={"horizon_months": 24, "rollouts": 16, "seed": 1701})
+    assert response.status_code == 200, response.text
+    assert response.json()["sanity_bands"] == []
+
+
+def _config_with_sample_sanity(tmp_path: Path) -> Config:
+    """Fixture config whose `calibration_catalog.sample_sanity_path` points at a temp spec YAML.
+
+    The spec reuses the live `openai_pe` model (its own `provider_config_path` is a placeholder
+    the server never resolves): one level-series band on `sp500` (the macro block anchors it at
+    1.0) and one PE-mark band on the catalog issuer `openai` (anchored at its current mark 100.0).
+    """
+    spec = SampleSanitySpec(
+        provider_config_path=Path("unused.yaml"),
+        horizon_months=24,
+        rollout_count=16,
+        required_level_series=(SP500Key(),),
+        required_private_equity_issuers=(IssuerId("openai"),),
+        level_checks=(LevelSeriesSanityCheck(key=SP500Key(), initial_value=1.0),),
+        private_equity_mark_checks=(
+            PrivateEquityMarkSanityCheck(issuer_id=IssuerId("openai"), initial_value=100.0),
+        ),
+    )
+    spec_path = tmp_path / "sample_sanity.yaml"
+    spec_path.write_text(yaml.safe_dump(spec.model_dump(mode="json")), encoding="utf-8")
+
+    config = _fixture_config()
+    assert config.calibration_catalog is not None
+    catalog = config.calibration_catalog.model_copy(update={"sample_sanity_path": spec_path})
+    return config.model_copy(update={"calibration_catalog": catalog})
+
+
+def test_run_calibration_includes_sample_sanity_bands(tmp_path: Path) -> None:
+    with _client_for(_config_with_sample_sanity(tmp_path)) as client:
+        response = client.post(
+            "/api/calibration/run", json={"horizon_months": 24, "rollouts": 16, "seed": 1701}
+        )
+    assert response.status_code == 200, response.text
+    bands = response.json()["sanity_bands"]
+    assert bands
+
+    # Both the level-series band (sp500) and the PE-mark band (openai) are evaluated.
+    series_ids = {band["series_id"] for band in bands}
+    assert "sp500" in series_ids
+    assert any("openai" in series_id and "mark" in series_id for series_id in series_ids)
+
+    # The deterministic anchor bands (sp500 -> 1.0, openai mark -> 100.0) pass; nothing fails.
+    anchors = {band["series_id"]: band for band in bands if band["kind"] == "anchor"}
+    assert anchors["sp500"]["status"] == "pass"
+    assert anchors["sp500"]["month"] == 0
+    openai_anchor = next(band for series_id, band in anchors.items() if "openai" in series_id)
+    assert openai_anchor["status"] == "pass"
+    assert openai_anchor["expected_lower"] == 100.0
+    assert all(band["status"] != "fail" for band in bands)
 
 
 if __name__ == "__main__":

--- a/augur/frontend/BUILD.bazel
+++ b/augur/frontend/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary", "js_test")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@npm_ducktape//:@tailwindcss/cli/package_json.bzl", tailwindcss_bin = "bin")
@@ -54,6 +54,12 @@ js_library(
         ":data_helpers",
         "//:node_modules/react",
     ],
+)
+
+js_library(
+    name = "sanity_bands",
+    srcs = ["sanity_bands.js"],
+    deps = ["//augur/frontend/lib:format"],
 )
 
 # -- React components -----------------------------------------------------------
@@ -143,6 +149,7 @@ js_library(
         ":fan_chart",
         ":hooks",
         ":input_helpers",
+        ":sanity_bands",
         ":skeleton",
         "//:node_modules/react",
         "//augur/frontend/lib:controls",
@@ -218,6 +225,7 @@ filegroup(
         "input_helpers.js",
         "main.jsx",
         "metric_table.jsx",
+        "sanity_bands.js",
         "skeleton.jsx",
         "//augur/frontend/lib:casing",
         "//augur/frontend/lib:chart",
@@ -325,6 +333,17 @@ build_test(
         ":image",
         ":image.digest",
     ],
+)
+
+# -- JS unit tests --------------------------------------------------------------
+
+js_test(
+    name = "sanity_bands_test",
+    data = [
+        ":sanity_bands",
+        "//augur/frontend/lib:format",
+    ],
+    entry_point = "sanity_bands.test.mjs",
 )
 
 filegroup(

--- a/augur/frontend/calibration.jsx
+++ b/augur/frontend/calibration.jsx
@@ -8,6 +8,7 @@ import { RolloutResultsSkeleton } from "./skeleton.jsx";
 import { CurrencyDisplayProvider } from "./hooks.js";
 import { FAN_PERCENTILES, clampRolloutCount, clampHorizonMonths } from "./input_helpers.js";
 import { markFanRows } from "./data_helpers.js";
+import { sortSanityBands, sanityPassCount, fmtExpectedBand, fmtObserved } from "./sanity_bands.js";
 
 // The issuer mark fan is a per-unit USD price. `chartValue` ending in `Usd` makes the shared
 // `MetricFanChart` axis/tooltip format it as currency; the label keeps it honest as a per-unit
@@ -45,6 +46,31 @@ function klTextClass(klBits) {
   if (klBits >= 0.15) return "font-semibold text-rose-700 dark:text-rose-300";
   if (klBits >= 0.05) return "font-semibold text-amber-700 dark:text-amber-300";
   return "augur-tabular";
+}
+
+// Reasonableness-band status → pill classes. A failing band reads loudest (rose), a passing
+// band reassuring (emerald), a skipped band muted (slate) — the same rose/amber/muted family
+// the KL tints above draw from.
+const SANITY_PILL_CLASS = {
+  pass: "bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-400/20",
+  fail: "bg-rose-50 text-rose-700 ring-rose-600/20 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-400/20",
+  skipped: "bg-slate-100 text-slate-600 ring-slate-500/20 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-400/20",
+};
+
+// A failing band also tints its whole row, mirroring `klToneClass` for loud KL.
+function sanityRowToneClass(status) {
+  return status === "fail" ? "bg-rose-50 dark:bg-rose-950/30" : "";
+}
+
+function SanityStatusPill({ status }) {
+  const tone = SANITY_PILL_CLASS[status] ?? SANITY_PILL_CLASS.skipped;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ring-1 ring-inset ${tone}`}
+    >
+      {status}
+    </span>
+  );
 }
 
 function CalibrationForm({ input, catalog, exogenousModel, onChange }) {
@@ -242,6 +268,68 @@ function MarkFanPanel({ markFan, metricScale }) {
   );
 }
 
+// The deployment's hardcoded `sample_sanity` reasonableness bands evaluated against THIS run's
+// rollouts (same expected-range-vs-observed shape as the model-vs-market table above). Renders
+// nothing when the deployment configured no bands (`sanityBands` empty/absent).
+function SanityBandsPanel({ bands }) {
+  const sorted = useMemo(() => sortSanityBands(bands), [bands]);
+  const passing = sanityPassCount(bands);
+  return (
+    <section className="augur-panel overflow-hidden" aria-label="Reasonableness bands" data-calibration-sanity-panel="">
+      <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+        <div className="min-w-0">
+          <div className="augur-eyebrow">Reasonableness bands (deploy gate)</div>
+          <div className="mt-1 text-xs augur-muted">
+            The hardcoded <code>sample_sanity</code> reasonableness bands: an expected range vs the observed value, the
+            same shape as the model-vs-market calibration above but checked against this run's own rollouts. Tail
+            percentile bands (p1/p99) are noisier at this page's rollout count than at the deploy gate's higher count.
+          </div>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="augur-tabular text-sm font-semibold augur-strong">
+            {passing}/{bands.length}
+          </div>
+          <div className="text-[11px] augur-muted">in band</div>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-t border-slate-200 text-sm dark:border-slate-700">
+          <thead>
+            <tr className="bg-slate-50 text-left text-[11px] uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+              <th className="px-4 py-2 font-semibold">Check</th>
+              <th className="px-3 py-2 text-right font-semibold">Expected</th>
+              <th className="px-3 py-2 text-right font-semibold">Observed</th>
+              <th className="px-3 py-2 text-right font-semibold">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+            {sorted.map((band) => (
+              <tr
+                key={band.label}
+                className={sanityRowToneClass(band.status)}
+                data-calibration-sanity-row={band.label}
+                data-calibration-sanity-status={band.status}
+              >
+                <th className="px-4 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">
+                  {band.label}
+                  {band.status !== "pass" && band.detail && (
+                    <div className="mt-0.5 text-xs font-normal augur-muted">{band.detail}</div>
+                  )}
+                </th>
+                <td className="px-3 py-2 text-right align-top augur-tabular">{fmtExpectedBand(band.kind, band)}</td>
+                <td className="px-3 py-2 text-right align-top augur-tabular">{fmtObserved(band)}</td>
+                <td className="px-3 py-2 text-right align-top">
+                  <SanityStatusPill status={band.status} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 function CalibrationResults({ response, metricScale }) {
   const { result, markFan } = response;
   return (
@@ -270,6 +358,8 @@ function CalibrationResults({ response, metricScale }) {
       </section>
 
       <MarkFanPanel markFan={markFan} metricScale={metricScale} />
+
+      {response.sanityBands?.length > 0 && <SanityBandsPanel bands={response.sanityBands} />}
 
       <section className="augur-panel overflow-hidden" aria-label="Surfaced markets">
         <div className="border-b border-slate-200 px-4 py-3 dark:border-slate-700">

--- a/augur/frontend/sanity_bands.js
+++ b/augur/frontend/sanity_bands.js
@@ -1,0 +1,64 @@
+// Pure presentation logic for the calibration page's "Reasonableness bands" panel.
+//
+// These are the deployment's hardcoded `sample_sanity` reasonableness bands (see
+// `augur.model.sample_sanity`) evaluated against the calibration run's own rollouts: an
+// expected range vs the observed value(s), same shape as the model-vs-market table but checked
+// against this run. Kept React-free so the sort/summary/format logic is unit-testable.
+
+import { fmtPct } from "./lib/format.js";
+
+// `kind`s whose `observed`/`expected` numbers are probabilities in [0,1]; everything else is a
+// unitless ratio (percentile_range/percentile_bound/anchor on a ratio check) or a count
+// (count_range), which we render as a trimmed fixed-decimal number rather than a percentage.
+const PROBABILITY_KINDS = new Set(["threshold_probability", "event_kind_probability"]);
+
+// Loudest-first: failures, then skipped, then passes — mirrors `CleanTable`'s "loudest
+// disagreement first" ordering. Stable within a group (input order preserved).
+const STATUS_RANK = { fail: 0, skipped: 1, pass: 2 };
+
+function statusRank(status) {
+  return STATUS_RANK[status] ?? STATUS_RANK.pass;
+}
+
+export function sortSanityBands(bands) {
+  return bands
+    .map((band, index) => ({ band, index }))
+    .sort((a, b) => statusRank(a.band.status) - statusRank(b.band.status) || a.index - b.index)
+    .map((entry) => entry.band);
+}
+
+// "{n_pass}/{n_total} in band" is computed here, not read from the wire (no count field exists).
+export function sanityPassCount(bands) {
+  return bands.filter((band) => band.status === "pass").length;
+}
+
+// A single observed/expected value: probability kinds → `fmtPct`; everything else → a fixed
+// 3-decimal number with trailing zeros trimmed (so 1.0 → "1", 0.25 → "0.25", 16.700 → "16.7").
+export function fmtBandValue(kind, value) {
+  if (value == null || !Number.isFinite(Number(value))) return "—";
+  if (PROBABILITY_KINDS.has(kind)) return fmtPct(value);
+  return Number(Number(value).toFixed(3)).toString();
+}
+
+// The expected band: "[lo, hi]" when both sides are set, "≥ lo" / "≤ hi" for a one-sided bound,
+// "—" when neither (e.g. a finite/positive/codes check carries no numeric range).
+export function fmtExpectedBand(kind, band) {
+  const hasLower = band.expectedLower != null && Number.isFinite(Number(band.expectedLower));
+  const hasUpper = band.expectedUpper != null && Number.isFinite(Number(band.expectedUpper));
+  if (hasLower && hasUpper)
+    return `[${fmtBandValue(kind, band.expectedLower)}, ${fmtBandValue(kind, band.expectedUpper)}]`;
+  if (hasLower) return `≥ ${fmtBandValue(kind, band.expectedLower)}`;
+  if (hasUpper) return `≤ ${fmtBandValue(kind, band.expectedUpper)}`;
+  return "—";
+}
+
+// The observed value(s) paired with their labels, e.g. "p1 0.25 · p99 16.7" or "p50 0.42".
+// Falls back to "—" when the band carries no observed values.
+export function fmtObserved(band) {
+  const values = band.observed ?? [];
+  if (values.length === 0) return "—";
+  const labels = band.observedLabels ?? [];
+  return values
+    .map((value, index) => `${labels[index] ? `${labels[index]} ` : ""}${fmtBandValue(band.kind, value)}`)
+    .join(" · ");
+}

--- a/augur/frontend/sanity_bands.test.mjs
+++ b/augur/frontend/sanity_bands.test.mjs
@@ -1,0 +1,121 @@
+// Unit tests for the calibration "Reasonableness bands" panel's pure presentation logic.
+// Uses the Node.js built-in test runner (no extra dependencies), mirroring
+// props/frontend/tests/router.test.mjs.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { sortSanityBands, sanityPassCount, fmtBandValue, fmtExpectedBand, fmtObserved } from "./sanity_bands.js";
+
+function band(overrides) {
+  return {
+    label: "band",
+    seriesId: "sp500",
+    kind: "percentile_range",
+    month: null,
+    expectedLower: null,
+    expectedUpper: null,
+    observed: [],
+    observedLabels: [],
+    status: "pass",
+    detail: "",
+    ...overrides,
+  };
+}
+
+test("sortSanityBands: failures first, then skipped, then passes", () => {
+  const input = [
+    band({ label: "pass-a", status: "pass" }),
+    band({ label: "skip-a", status: "skipped" }),
+    band({ label: "fail-a", status: "fail" }),
+    band({ label: "pass-b", status: "pass" }),
+    band({ label: "fail-b", status: "fail" }),
+  ];
+  assert.deepEqual(
+    sortSanityBands(input).map((b) => b.label),
+    ["fail-a", "fail-b", "skip-a", "pass-a", "pass-b"]
+  );
+});
+
+test("sortSanityBands: stable within a status group (input order preserved)", () => {
+  const input = [
+    band({ label: "fail-2", status: "fail" }),
+    band({ label: "fail-1", status: "fail" }),
+    band({ label: "fail-3", status: "fail" }),
+  ];
+  assert.deepEqual(
+    sortSanityBands(input).map((b) => b.label),
+    ["fail-2", "fail-1", "fail-3"]
+  );
+  // The input array is not mutated.
+  assert.deepEqual(
+    input.map((b) => b.label),
+    ["fail-2", "fail-1", "fail-3"]
+  );
+});
+
+test("sanityPassCount: counts only passes, computed from the array", () => {
+  assert.equal(sanityPassCount([]), 0);
+  assert.equal(
+    sanityPassCount([
+      band({ status: "pass" }),
+      band({ status: "fail" }),
+      band({ status: "pass" }),
+      band({ status: "skipped" }),
+    ]),
+    2
+  );
+});
+
+test("fmtBandValue: probability kinds format as percent", () => {
+  assert.equal(fmtBandValue("threshold_probability", 0.42), "42.0%");
+  assert.equal(fmtBandValue("event_kind_probability", 0.015), "1.5%");
+});
+
+test("fmtBandValue: non-probability kinds format as trimmed fixed-decimal ratios/counts", () => {
+  assert.equal(fmtBandValue("percentile_range", 1.0), "1");
+  assert.equal(fmtBandValue("percentile_range", 0.25), "0.25");
+  assert.equal(fmtBandValue("percentile_bound", 16.7), "16.7");
+  assert.equal(fmtBandValue("count_range", 12), "12");
+  assert.equal(fmtBandValue("anchor", 100.0), "100");
+});
+
+test("fmtBandValue: null/undefined/non-finite render as em dash", () => {
+  assert.equal(fmtBandValue("percentile_range", null), "—");
+  assert.equal(fmtBandValue("percentile_range", undefined), "—");
+  assert.equal(fmtBandValue("percentile_range", NaN), "—");
+});
+
+test("fmtExpectedBand: two-sided, one-sided, and absent bounds", () => {
+  assert.equal(fmtExpectedBand("percentile_range", band({ expectedLower: 0.2, expectedUpper: 20 })), "[0.2, 20]");
+  assert.equal(fmtExpectedBand("percentile_bound", band({ expectedLower: 0.2 })), "≥ 0.2");
+  assert.equal(fmtExpectedBand("percentile_bound", band({ expectedUpper: 20 })), "≤ 20");
+  assert.equal(fmtExpectedBand("finite", band({})), "—");
+});
+
+test("fmtExpectedBand: probability bound formats endpoints as percent", () => {
+  assert.equal(
+    fmtExpectedBand(
+      "threshold_probability",
+      band({ kind: "threshold_probability", expectedLower: 0.1, expectedUpper: 0.9 })
+    ),
+    "[10.0%, 90.0%]"
+  );
+});
+
+test("fmtObserved: pairs values with labels", () => {
+  assert.equal(fmtObserved(band({ observed: [0.25, 16.7], observedLabels: ["p1", "p99"] })), "p1 0.25 · p99 16.7");
+  assert.equal(fmtObserved(band({ observed: [0.42], observedLabels: ["p50"] })), "p50 0.42");
+});
+
+test("fmtObserved: probability kind observed values render as percent", () => {
+  assert.equal(
+    fmtObserved(band({ kind: "threshold_probability", observed: [0.42], observedLabels: ["probability"] })),
+    "probability 42.0%"
+  );
+});
+
+test("fmtObserved: missing labels and empty observed degrade gracefully", () => {
+  assert.equal(fmtObserved(band({ observed: [0.5], observedLabels: [] })), "0.5");
+  assert.equal(fmtObserved(band({ observed: [] })), "—");
+});

--- a/augur/model/BUILD.bazel
+++ b/augur/model/BUILD.bazel
@@ -290,9 +290,13 @@ py_test(
         "testdata/fixture_sample_sanity.yaml",
     ],
     deps = [
+        ":exogenous",
         ":sample_sanity",
+        ":series",
+        ":testing",
         "//:conftest",
         "//util/bazel:runfiles",
+        "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
 )

--- a/augur/model/sample_sanity.py
+++ b/augur/model/sample_sanity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -9,7 +10,11 @@ import numpy as np
 import yaml
 from pydantic import Field, TypeAdapter, model_validator
 
-from augur.model.exogenous import ExogenousSamplingRequest, validate_sample_satisfies_request
+from augur.model.exogenous import (
+    ExogenousSamplingRequest,
+    SampledExogenousBundle,
+    validate_sample_satisfies_request,
+)
 from augur.model.provider_config import (
     CompositeProviderConfig,
     ProviderConfig,
@@ -182,12 +187,39 @@ class SampleSanitySpec(FrozenModel):
         return tuple(range(self.rollout_seed_start, self.rollout_seed_start + self.rollout_count))
 
 
+@dataclass(frozen=True)
+class SanityBandResult:
+    """One evaluated sanity check: a labeled expected band vs the observed value(s)."""
+
+    label: str  # human-readable, e.g. "sp500 ratio m12/m0 p1..p99"
+    series_id: str  # the level-series wire id or "PE issuer 'openai' mark"
+    kind: str  # "finite"|"positive"|"anchor"|"percentile_bound"|"percentile_range"|"threshold_probability"|"count_range"|"event_kind_probability"|"codes_allowed"
+    month: int | None  # month index where applicable, else None
+    expected_lower: float | None
+    expected_upper: float | None
+    observed: tuple[float, ...]  # the value(s) bounded: 1 for bound/probability, 2 for a range (lo, hi pctile values)
+    observed_labels: tuple[str, ...]  # parallel labels, e.g. ("p1","p99") or ("p50",) or ("probability",)
+    status: Literal["pass", "fail", "skipped"]
+    detail: str  # "" when pass; failure/skip explanation otherwise
+
+
 def run_sample_sanity_file(path: Path) -> None:
     spec = SampleSanitySpec.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
     run_sample_sanity(spec, base_dir=path.parent)
 
 
 def run_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> None:
+    """Deploy gate: sample the model and raise if any sanity band fails."""
+
+    results = evaluate_sample_sanity(spec, base_dir=base_dir)
+    failures = [result for result in results if result.status == "fail"]
+    if failures:
+        raise AssertionError("\n".join(failure.detail for failure in failures))
+
+
+def evaluate_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> list[SanityBandResult]:
+    """Sample the spec's provider model and evaluate every sanity band against it."""
+
     provider_config_path = _resolve_path(spec.provider_config_path, base_dir=base_dir)
     provider = _load_provider_config(provider_config_path)
     model = provider.realize_model()
@@ -199,130 +231,237 @@ def run_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> None:
     )
     sampled = model.sample(request)
     validate_sample_satisfies_request(request, sampled)
+    return evaluate_sample_checks(
+        spec, sampled, rollout_count=spec.rollout_count, horizon_months=spec.horizon_months
+    )
 
+
+def evaluate_sample_checks(
+    spec: SampleSanitySpec, sampled: SampledExogenousBundle, *, rollout_count: int, horizon_months: int
+) -> list[SanityBandResult]:
+    """Evaluate every check in `spec` against an already-sampled bundle.
+
+    Pure: uses the passed-in `rollout_count`/`horizon_months` (the actual sampled
+    dimensions), not `spec.rollout_count`/`spec.horizon_months`, so callers reusing
+    rollouts sampled at a different count/horizon get correct indexing. Any check
+    whose month exceeds `horizon_months` yields a `status="skipped"` result rather
+    than indexing out of bounds.
+    """
+
+    results: list[SanityBandResult] = []
     for level_check in spec.level_checks:
-        levels = sampled.level_matrix(
-            level_check.key, rollout_count=spec.rollout_count, horizon_months=spec.horizon_months
+        results.extend(
+            _evaluate_level_check(level_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
         )
-        _assert_finite(levels, label=level_check.key.wire_id)
-        if level_check.require_positive and np.any(levels <= 0.0):
-            raise AssertionError(f"series {level_check.key.wire_id!r} produced non-positive level(s)")
-        if level_check.initial_value is not None:
-            np.testing.assert_allclose(
-                levels[:, 0],
-                np.full(spec.rollout_count, float(level_check.initial_value), dtype=np.float64),
+    for event_kind_check in spec.event_kind_observed_checks:
+        results.append(
+            _evaluate_event_kind_check(
+                event_kind_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months
+            )
+        )
+    for mark_check in spec.private_equity_mark_checks:
+        results.extend(
+            _evaluate_mark_check(mark_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
+        )
+    for event_check in spec.event_checks:
+        results.extend(
+            _evaluate_event_check(event_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
+        )
+    for protocol_check in spec.private_equity_protocol_checks:
+        results.extend(
+            _evaluate_protocol_check(
+                protocol_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months
+            )
+        )
+    return results
+
+
+def _evaluate_level_check(
+    level_check: LevelSeriesSanityCheck,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+) -> list[SanityBandResult]:
+    series_id = level_check.key.wire_id
+    levels = sampled.level_matrix(level_check.key, rollout_count=rollout_count, horizon_months=horizon_months)
+    results = [_check_finite(levels, series_id=series_id)]
+    if level_check.require_positive:
+        results.append(_check_positive(levels, series_id=series_id))
+    if level_check.initial_value is not None:
+        results.append(
+            _check_anchor(
+                levels,
+                series_id=series_id,
+                initial_value=level_check.initial_value,
                 atol=level_check.initial_atol,
                 rtol=level_check.initial_rtol,
-                err_msg=f"series {level_check.key.wire_id!r} month-0 anchor mismatch",
+                rollout_count=rollout_count,
             )
-        for value_bound in level_check.value_percentile_bounds:
-            _check_percentile_bound(
-                levels[:, value_bound.month], value_bound, label=f"{level_check.key.wire_id} value m{value_bound.month}"
-            )
-        for value_range in level_check.value_percentile_ranges:
-            _check_percentile_range_bound(
-                levels[:, value_range.month], value_range, label=f"{level_check.key.wire_id} value m{value_range.month}"
-            )
-        for ratio_bound in level_check.ratio_percentile_bounds:
-            ratios = levels[:, ratio_bound.month] / levels[:, 0]
-            _check_percentile_bound(
-                ratios, ratio_bound, label=f"{level_check.key.wire_id} ratio m{ratio_bound.month}/m0"
-            )
-        for ratio_range in level_check.ratio_percentile_ranges:
-            ratios = levels[:, ratio_range.month] / levels[:, 0]
-            _check_percentile_range_bound(
-                ratios, ratio_range, label=f"{level_check.key.wire_id} ratio m{ratio_range.month}/m0"
-            )
-        for threshold_bound in level_check.threshold_probability_bounds:
-            _check_threshold_probability_bound(
-                levels, threshold_bound, series_id=level_check.key.wire_id, rollout_count=spec.rollout_count
-            )
-
-    for event_kind_check in spec.event_kind_observed_checks:
-        event_kind_codes = sampled.private_equity.issuer_int_matrix(
-            event_kind_check.issuer_id,
-            "event_kind_code",
-            rollout_count=spec.rollout_count,
-            horizon_months=spec.horizon_months,
         )
-        _check_event_kind_observed(event_kind_codes, event_kind_check)
+    for value_bound in level_check.value_percentile_bounds:
+        label = f"{series_id} value m{value_bound.month}"
+        if value_bound.month > horizon_months:
+            results.append(_skip_percentile_bound(value_bound, series_id=series_id, label=label, month=value_bound.month, horizon_months=horizon_months))
+            continue
+        results.append(_check_percentile_bound(levels[:, value_bound.month], value_bound, series_id=series_id, label=label))
+    for value_range in level_check.value_percentile_ranges:
+        label = f"{series_id} value m{value_range.month}"
+        if value_range.month > horizon_months:
+            results.append(_skip_percentile_range_bound(value_range, series_id=series_id, label=label, month=value_range.month, horizon_months=horizon_months))
+            continue
+        results.append(_check_percentile_range_bound(levels[:, value_range.month], value_range, series_id=series_id, label=label))
+    for ratio_bound in level_check.ratio_percentile_bounds:
+        label = f"{series_id} ratio m{ratio_bound.month}/m0"
+        if ratio_bound.month > horizon_months:
+            results.append(_skip_percentile_bound(ratio_bound, series_id=series_id, label=label, month=ratio_bound.month, horizon_months=horizon_months))
+            continue
+        ratios = levels[:, ratio_bound.month] / levels[:, 0]
+        results.append(_check_percentile_bound(ratios, ratio_bound, series_id=series_id, label=label))
+    for ratio_range in level_check.ratio_percentile_ranges:
+        label = f"{series_id} ratio m{ratio_range.month}/m0"
+        if ratio_range.month > horizon_months:
+            results.append(_skip_percentile_range_bound(ratio_range, series_id=series_id, label=label, month=ratio_range.month, horizon_months=horizon_months))
+            continue
+        ratios = levels[:, ratio_range.month] / levels[:, 0]
+        results.append(_check_percentile_range_bound(ratios, ratio_range, series_id=series_id, label=label))
+    for threshold_bound in level_check.threshold_probability_bounds:
+        if threshold_bound.month > horizon_months:
+            results.append(_skip_threshold_probability_bound(threshold_bound, series_id=series_id, horizon_months=horizon_months))
+            continue
+        results.append(_check_threshold_probability_bound(levels, threshold_bound, series_id=series_id, rollout_count=rollout_count))
+    return results
 
-    for mark_check in spec.private_equity_mark_checks:
-        marks = sampled.private_equity.issuer_float_matrix(
-            mark_check.issuer_id,
-            "mark_usd_per_unit",
-            rollout_count=spec.rollout_count,
-            horizon_months=spec.horizon_months,
-        )
-        label_prefix = f"PE issuer {mark_check.issuer_id!r} mark"
-        _assert_finite(marks, label=label_prefix)
-        if mark_check.require_positive and np.any(marks <= 0.0):
-            raise AssertionError(f"{label_prefix} produced non-positive value(s)")
-        if mark_check.initial_value is not None:
-            np.testing.assert_allclose(
-                marks[:, 0],
-                np.full(spec.rollout_count, float(mark_check.initial_value), dtype=np.float64),
+
+def _evaluate_mark_check(
+    mark_check: PrivateEquityMarkSanityCheck,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+) -> list[SanityBandResult]:
+    series_id = f"PE issuer {mark_check.issuer_id!r} mark"
+    marks = sampled.private_equity.issuer_float_matrix(
+        mark_check.issuer_id, "mark_usd_per_unit", rollout_count=rollout_count, horizon_months=horizon_months
+    )
+    results = [_check_finite(marks, series_id=series_id)]
+    if mark_check.require_positive:
+        results.append(_check_positive(marks, series_id=series_id))
+    if mark_check.initial_value is not None:
+        results.append(
+            _check_anchor(
+                marks,
+                series_id=series_id,
+                initial_value=mark_check.initial_value,
                 atol=mark_check.initial_atol,
                 rtol=mark_check.initial_rtol,
-                err_msg=f"{label_prefix} month-0 anchor mismatch",
+                rollout_count=rollout_count,
             )
-        for ratio_bound in mark_check.ratio_percentile_bounds:
-            ratios = marks[:, ratio_bound.month] / marks[:, 0]
-            _check_percentile_bound(ratios, ratio_bound, label=f"{label_prefix} ratio m{ratio_bound.month}/m0")
-        for ratio_range in mark_check.ratio_percentile_ranges:
-            ratios = marks[:, ratio_range.month] / marks[:, 0]
-            _check_percentile_range_bound(ratios, ratio_range, label=f"{label_prefix} ratio m{ratio_range.month}/m0")
-        for threshold_bound in mark_check.threshold_probability_bounds:
-            _check_threshold_probability_bound(
-                marks, threshold_bound, series_id=label_prefix, rollout_count=spec.rollout_count
-            )
-
-    for event_check in spec.event_checks:
-        events = sampled.private_equity.issuer_bool_matrix(
-            event_check.issuer_id,
-            "sale_opportunity_active",
-            rollout_count=spec.rollout_count,
-            horizon_months=spec.horizon_months,
         )
-        active_counts = events.astype(np.int64).sum(axis=1)
-        for active_count_bound in event_check.active_count_percentile_bounds:
-            value = float(np.percentile(active_counts, active_count_bound.percentile))
-            _assert_bound(
+    for ratio_bound in mark_check.ratio_percentile_bounds:
+        label = f"{series_id} ratio m{ratio_bound.month}/m0"
+        if ratio_bound.month > horizon_months:
+            results.append(_skip_percentile_bound(ratio_bound, series_id=series_id, label=label, month=ratio_bound.month, horizon_months=horizon_months))
+            continue
+        ratios = marks[:, ratio_bound.month] / marks[:, 0]
+        results.append(_check_percentile_bound(ratios, ratio_bound, series_id=series_id, label=label))
+    for ratio_range in mark_check.ratio_percentile_ranges:
+        label = f"{series_id} ratio m{ratio_range.month}/m0"
+        if ratio_range.month > horizon_months:
+            results.append(_skip_percentile_range_bound(ratio_range, series_id=series_id, label=label, month=ratio_range.month, horizon_months=horizon_months))
+            continue
+        ratios = marks[:, ratio_range.month] / marks[:, 0]
+        results.append(_check_percentile_range_bound(ratios, ratio_range, series_id=series_id, label=label))
+    for threshold_bound in mark_check.threshold_probability_bounds:
+        if threshold_bound.month > horizon_months:
+            results.append(_skip_threshold_probability_bound(threshold_bound, series_id=series_id, horizon_months=horizon_months))
+            continue
+        results.append(_check_threshold_probability_bound(marks, threshold_bound, series_id=series_id, rollout_count=rollout_count))
+    return results
+
+
+def _evaluate_event_kind_check(
+    event_kind_check: EventKindObservedCheck,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+) -> SanityBandResult:
+    event_kind_codes = sampled.private_equity.issuer_int_matrix(
+        event_kind_check.issuer_id, "event_kind_code", rollout_count=rollout_count, horizon_months=horizon_months
+    )
+    if event_kind_check.by_month > horizon_months:
+        return _skip_event_kind_observed(event_kind_check, horizon_months=horizon_months)
+    return _check_event_kind_observed(event_kind_codes, event_kind_check)
+
+
+def _evaluate_event_check(
+    event_check: EventSeriesSanityCheck,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+) -> list[SanityBandResult]:
+    series_id = f"PE issuer {event_check.issuer_id!r} sale_opportunity_active"
+    events = sampled.private_equity.issuer_bool_matrix(
+        event_check.issuer_id, "sale_opportunity_active", rollout_count=rollout_count, horizon_months=horizon_months
+    )
+    active_counts = events.astype(np.int64).sum(axis=1)
+    results: list[SanityBandResult] = []
+    for active_count_bound in event_check.active_count_percentile_bounds:
+        value = float(np.percentile(active_counts, active_count_bound.percentile))
+        results.append(
+            _bound_result(
                 value,
                 lower=active_count_bound.lower,
                 upper=active_count_bound.upper,
+                kind="count_range",
+                series_id=series_id,
+                month=None,
                 label=f"{event_check.issuer_id} active-count p{active_count_bound.percentile:g}",
+                observed_label=f"p{active_count_bound.percentile:g}",
             )
-        for active_count_range in event_check.active_count_percentile_ranges:
+        )
+    for active_count_range in event_check.active_count_percentile_ranges:
+        results.append(
             _check_percentile_count_range_bound(
-                active_counts, active_count_range, label=f"{event_check.issuer_id} active-count"
+                active_counts, active_count_range, series_id=series_id, label=f"{event_check.issuer_id} active-count"
             )
+        )
+    return results
 
-    for protocol_check in spec.private_equity_protocol_checks:
+
+def _evaluate_protocol_check(
+    protocol_check: PrivateEquityProtocolSanityCheck,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+) -> list[SanityBandResult]:
+    results: list[SanityBandResult] = []
+    if protocol_check.allowed_regime_codes:
         regime_codes = sampled.private_equity.issuer_int_matrix(
-            protocol_check.issuer_id,
-            "regime_code",
-            rollout_count=spec.rollout_count,
-            horizon_months=spec.horizon_months,
+            protocol_check.issuer_id, "regime_code", rollout_count=rollout_count, horizon_months=horizon_months
         )
-        event_kind_codes = sampled.private_equity.issuer_int_matrix(
-            protocol_check.issuer_id,
-            "event_kind_code",
-            rollout_count=spec.rollout_count,
-            horizon_months=spec.horizon_months,
-        )
-        if protocol_check.allowed_regime_codes:
-            _assert_codes_allowed(
+        results.append(
+            _check_codes_allowed(
                 regime_codes,
                 allowed=frozenset(protocol_check.allowed_regime_codes),
-                label=f"private-equity issuer {protocol_check.issuer_id!r} regime_code",
+                series_id=f"private-equity issuer {protocol_check.issuer_id!r} regime_code",
             )
-        if protocol_check.allowed_event_kind_codes:
-            _assert_codes_allowed(
+        )
+    if protocol_check.allowed_event_kind_codes:
+        event_kind_codes = sampled.private_equity.issuer_int_matrix(
+            protocol_check.issuer_id, "event_kind_code", rollout_count=rollout_count, horizon_months=horizon_months
+        )
+        results.append(
+            _check_codes_allowed(
                 event_kind_codes,
                 allowed=frozenset(protocol_check.allowed_event_kind_codes),
-                label=f"private-equity issuer {protocol_check.issuer_id!r} event_kind_code",
+                series_id=f"private-equity issuer {protocol_check.issuer_id!r} event_kind_code",
             )
+        )
+    return results
 
 
 def _load_provider_config(path: Path) -> ProviderConfig:
@@ -360,46 +499,129 @@ def _resolve_path(path: Path, *, base_dir: Path) -> Path:
     return path if path.is_absolute() else (base_dir / path).resolve()
 
 
-def _assert_finite(values: np.ndarray, *, label: str) -> None:
-    if not np.all(np.isfinite(values)):
-        raise AssertionError(f"{label} produced non-finite value(s)")
+def _check_finite(values: np.ndarray, *, series_id: str) -> SanityBandResult:
+    finite = bool(np.all(np.isfinite(values)))
+    return SanityBandResult(
+        label=f"{series_id} finite",
+        series_id=series_id,
+        kind="finite",
+        month=None,
+        expected_lower=None,
+        expected_upper=None,
+        observed=(),
+        observed_labels=(),
+        status="pass" if finite else "fail",
+        detail="" if finite else f"{series_id} produced non-finite value(s)",
+    )
 
 
-def _assert_codes_allowed(values: np.ndarray, *, allowed: frozenset[int], label: str) -> None:
+def _check_positive(values: np.ndarray, *, series_id: str) -> SanityBandResult:
+    positive = not bool(np.any(values <= 0.0))
+    return SanityBandResult(
+        label=f"{series_id} positive",
+        series_id=series_id,
+        kind="positive",
+        month=None,
+        expected_lower=None,
+        expected_upper=None,
+        observed=(),
+        observed_labels=(),
+        status="pass" if positive else "fail",
+        detail="" if positive else f"{series_id} produced non-positive value(s)",
+    )
+
+
+def _check_anchor(
+    values: np.ndarray, *, series_id: str, initial_value: float, atol: float, rtol: float, rollout_count: int
+) -> SanityBandResult:
+    expected = np.full(rollout_count, float(initial_value), dtype=np.float64)
+    close = bool(np.allclose(values[:, 0], expected, atol=atol, rtol=rtol))
+    detail = (
+        ""
+        if close
+        else f"{series_id} month-0 anchor mismatch: expected {float(initial_value):g} (atol={atol:g}, rtol={rtol:g})"
+    )
+    return SanityBandResult(
+        label=f"{series_id} m0 anchor",
+        series_id=series_id,
+        kind="anchor",
+        month=0,
+        expected_lower=float(initial_value),
+        expected_upper=float(initial_value),
+        observed=(float(values[:, 0].min()), float(values[:, 0].max())),
+        observed_labels=("m0 min", "m0 max"),
+        status="pass" if close else "fail",
+        detail=detail,
+    )
+
+
+def _check_codes_allowed(values: np.ndarray, *, allowed: frozenset[int], series_id: str) -> SanityBandResult:
     observed = frozenset(int(value) for value in np.unique(values))
     unexpected = sorted(observed - allowed)
-    if unexpected:
-        raise AssertionError(f"{label} produced unexpected code(s): {unexpected}; allowed {sorted(allowed)}")
+    return SanityBandResult(
+        label=f"{series_id} codes",
+        series_id=series_id,
+        kind="codes_allowed",
+        month=None,
+        expected_lower=None,
+        expected_upper=None,
+        observed=(),
+        observed_labels=(),
+        status="pass" if not unexpected else "fail",
+        detail=""
+        if not unexpected
+        else f"{series_id} produced unexpected code(s): {unexpected}; allowed {sorted(allowed)}",
+    )
 
 
-def _check_percentile_bound(values: np.ndarray, bound: PercentileBound, *, label: str) -> None:
+def _check_percentile_bound(
+    values: np.ndarray, bound: PercentileBound, *, series_id: str, label: str
+) -> SanityBandResult:
     value = float(np.percentile(values, bound.percentile))
-    _assert_bound(value, lower=bound.lower, upper=bound.upper, label=f"{label} p{bound.percentile:g}")
+    return _bound_result(
+        value,
+        lower=bound.lower,
+        upper=bound.upper,
+        kind="percentile_bound",
+        series_id=series_id,
+        month=bound.month,
+        label=f"{label} p{bound.percentile:g}",
+        observed_label=f"p{bound.percentile:g}",
+    )
 
 
-def _check_percentile_range_bound(values: np.ndarray, bound: PercentileRangeBound, *, label: str) -> None:
+def _check_percentile_range_bound(
+    values: np.ndarray, bound: PercentileRangeBound, *, series_id: str, label: str
+) -> SanityBandResult:
     lower_value = float(np.percentile(values, bound.lower_percentile))
     upper_value = float(np.percentile(values, bound.upper_percentile))
-    _assert_range_bound(
+    return _range_result(
         lower_value,
         upper_value,
         lower=bound.lower,
         upper=bound.upper,
+        series_id=series_id,
+        month=bound.month,
         label=f"{label} p{bound.lower_percentile:g}..p{bound.upper_percentile:g}",
+        observed_labels=(f"p{bound.lower_percentile:g}", f"p{bound.upper_percentile:g}"),
     )
 
 
 def _check_percentile_count_range_bound(
-    values: np.ndarray, bound: EventCountPercentileRangeBound, *, label: str
-) -> None:
+    values: np.ndarray, bound: EventCountPercentileRangeBound, *, series_id: str, label: str
+) -> SanityBandResult:
     lower_value = float(np.percentile(values, bound.lower_percentile))
     upper_value = float(np.percentile(values, bound.upper_percentile))
-    _assert_range_bound(
+    return _range_result(
         lower_value,
         upper_value,
         lower=bound.lower,
         upper=bound.upper,
+        series_id=series_id,
+        month=None,
         label=f"{label} p{bound.lower_percentile:g}..p{bound.upper_percentile:g}",
+        observed_labels=(f"p{bound.lower_percentile:g}", f"p{bound.upper_percentile:g}"),
+        kind="count_range",
     )
 
 
@@ -408,7 +630,7 @@ _LEVEL_COMPARATORS = {"lt": np.less, "le": np.less_equal, "gt": np.greater, "ge"
 
 def _check_threshold_probability_bound(
     levels: np.ndarray, bound: LevelThresholdProbabilityBound, *, series_id: str, rollout_count: int
-) -> None:
+) -> SanityBandResult:
     if bound.threshold_kind == "absolute":
         threshold = np.full(rollout_count, bound.threshold, dtype=np.float64)
     else:
@@ -420,32 +642,176 @@ def _check_threshold_probability_bound(
         f"{series_id} P(level {bound.comparison} {bound.threshold:g}"
         f"{' * initial' if bound.threshold_kind == 'ratio_of_initial' else ''} at m{bound.month})"
     )
-    _assert_bound(probability, lower=bound.probability_lower, upper=bound.probability_upper, label=label)
+    return _bound_result(
+        probability,
+        lower=bound.probability_lower,
+        upper=bound.probability_upper,
+        kind="threshold_probability",
+        series_id=series_id,
+        month=bound.month,
+        label=label,
+        observed_label="probability",
+    )
 
 
-def _check_event_kind_observed(event_kind_codes: np.ndarray, bound: EventKindObservedCheck) -> None:
+def _check_event_kind_observed(event_kind_codes: np.ndarray, bound: EventKindObservedCheck) -> SanityBandResult:
     window = event_kind_codes[:, : bound.by_month + 1]
     occurrence_mask = np.isin(window, np.asarray(bound.event_kind_codes, dtype=window.dtype))
     occurs_per_rollout = occurrence_mask.any(axis=1)
     successes = occurs_per_rollout if bound.count_op == "at_least_one" else ~occurs_per_rollout
     probability = float(successes.mean())
     kind_names = ",".join(PrivateEquityEventKindCode(code).name for code in bound.event_kind_codes)
+    series_id = f"private-equity issuer {bound.issuer_id!r} event_kind_code"
     label = (
         f"private-equity issuer {bound.issuer_id!r} "
         f"P({bound.count_op.replace('_', ' ')} of {{{kind_names}}} by m{bound.by_month})"
     )
-    _assert_bound(probability, lower=bound.probability_lower, upper=bound.probability_upper, label=label)
+    return _bound_result(
+        probability,
+        lower=bound.probability_lower,
+        upper=bound.probability_upper,
+        kind="event_kind_probability",
+        series_id=series_id,
+        month=bound.by_month,
+        label=label,
+        observed_label="probability",
+    )
 
 
-def _assert_bound(value: float, *, lower: float | None, upper: float | None, label: str) -> None:
+def _bound_result(
+    value: float,
+    *,
+    lower: float | None,
+    upper: float | None,
+    kind: str,
+    series_id: str,
+    month: int | None,
+    label: str,
+    observed_label: str,
+) -> SanityBandResult:
     if lower is not None and value < lower:
-        raise AssertionError(f"{label}={value:g} is below lower bound {lower:g}")
-    if upper is not None and value > upper:
-        raise AssertionError(f"{label}={value:g} is above upper bound {upper:g}")
+        detail = f"{label}={value:g} is below lower bound {lower:g}"
+    elif upper is not None and value > upper:
+        detail = f"{label}={value:g} is above upper bound {upper:g}"
+    else:
+        detail = ""
+    return SanityBandResult(
+        label=label,
+        series_id=series_id,
+        kind=kind,
+        month=month,
+        expected_lower=lower,
+        expected_upper=upper,
+        observed=(value,),
+        observed_labels=(observed_label,),
+        status="pass" if not detail else "fail",
+        detail=detail,
+    )
 
 
-def _assert_range_bound(lower_value: float, upper_value: float, *, lower: float, upper: float, label: str) -> None:
-    if lower_value < lower or upper_value > upper:
-        raise AssertionError(
-            f"{label}=[{lower_value:g}, {upper_value:g}] is outside expected range [{lower:g}, {upper:g}]"
-        )
+def _range_result(
+    lower_value: float,
+    upper_value: float,
+    *,
+    lower: float,
+    upper: float,
+    series_id: str,
+    month: int | None,
+    label: str,
+    observed_labels: tuple[str, str],
+    kind: str = "percentile_range",
+) -> SanityBandResult:
+    out_of_range = lower_value < lower or upper_value > upper
+    detail = (
+        ""
+        if not out_of_range
+        else f"{label}=[{lower_value:g}, {upper_value:g}] is outside expected range [{lower:g}, {upper:g}]"
+    )
+    return SanityBandResult(
+        label=label,
+        series_id=series_id,
+        kind=kind,
+        month=month,
+        expected_lower=lower,
+        expected_upper=upper,
+        observed=(lower_value, upper_value),
+        observed_labels=observed_labels,
+        status="pass" if not out_of_range else "fail",
+        detail=detail,
+    )
+
+
+def _skip_percentile_bound(
+    bound: PercentileBound, *, series_id: str, label: str, month: int, horizon_months: int
+) -> SanityBandResult:
+    return SanityBandResult(
+        label=f"{label} p{bound.percentile:g}",
+        series_id=series_id,
+        kind="percentile_bound",
+        month=month,
+        expected_lower=bound.lower,
+        expected_upper=bound.upper,
+        observed=(),
+        observed_labels=(),
+        status="skipped",
+        detail=f"month {month} > sampled horizon {horizon_months}",
+    )
+
+
+def _skip_percentile_range_bound(
+    bound: PercentileRangeBound, *, series_id: str, label: str, month: int, horizon_months: int
+) -> SanityBandResult:
+    return SanityBandResult(
+        label=f"{label} p{bound.lower_percentile:g}..p{bound.upper_percentile:g}",
+        series_id=series_id,
+        kind="percentile_range",
+        month=month,
+        expected_lower=bound.lower,
+        expected_upper=bound.upper,
+        observed=(),
+        observed_labels=(),
+        status="skipped",
+        detail=f"month {month} > sampled horizon {horizon_months}",
+    )
+
+
+def _skip_threshold_probability_bound(
+    bound: LevelThresholdProbabilityBound, *, series_id: str, horizon_months: int
+) -> SanityBandResult:
+    label = (
+        f"{series_id} P(level {bound.comparison} {bound.threshold:g}"
+        f"{' * initial' if bound.threshold_kind == 'ratio_of_initial' else ''} at m{bound.month})"
+    )
+    return SanityBandResult(
+        label=label,
+        series_id=series_id,
+        kind="threshold_probability",
+        month=bound.month,
+        expected_lower=bound.probability_lower,
+        expected_upper=bound.probability_upper,
+        observed=(),
+        observed_labels=(),
+        status="skipped",
+        detail=f"month {bound.month} > sampled horizon {horizon_months}",
+    )
+
+
+def _skip_event_kind_observed(bound: EventKindObservedCheck, *, horizon_months: int) -> SanityBandResult:
+    kind_names = ",".join(PrivateEquityEventKindCode(code).name for code in bound.event_kind_codes)
+    series_id = f"private-equity issuer {bound.issuer_id!r} event_kind_code"
+    label = (
+        f"private-equity issuer {bound.issuer_id!r} "
+        f"P({bound.count_op.replace('_', ' ')} of {{{kind_names}}} by m{bound.by_month})"
+    )
+    return SanityBandResult(
+        label=label,
+        series_id=series_id,
+        kind="event_kind_probability",
+        month=bound.by_month,
+        expected_lower=bound.probability_lower,
+        expected_upper=bound.probability_upper,
+        observed=(),
+        observed_labels=(),
+        status="skipped",
+        detail=f"month {bound.by_month} > sampled horizon {horizon_months}",
+    )

--- a/augur/model/sample_sanity_test.py
+++ b/augur/model/sample_sanity_test.py
@@ -1,13 +1,117 @@
 from __future__ import annotations
 
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
 import pytest_bazel
 
-from augur.model.sample_sanity import run_sample_sanity_file
+from augur.model.exogenous import ExogenousSamplingRequest, SampledExogenousBundle
+from augur.model.sample_sanity import (
+    LevelSeriesSanityCheck,
+    PercentileRangeBound,
+    SampleSanitySpec,
+    evaluate_sample_checks,
+    run_sample_sanity,
+    run_sample_sanity_file,
+)
+from augur.model.series import SP500Key
+from augur.model.testing import ConstantFrameModel
 from util.bazel.runfiles import get_required_path
+
+_HORIZON_MONTHS = 12
+_ROLLOUT_COUNT = 8
+_SP500_LEVEL = 1000.0
+
+# A passing band straddles the constant level; the failing band sits entirely above it.
+_PASSING_BAND = PercentileRangeBound(month=12, lower_percentile=1, upper_percentile=99, lower=900.0, upper=1100.0)
+_FAILING_BAND = PercentileRangeBound(month=12, lower_percentile=1, upper_percentile=99, lower=2000.0, upper=3000.0)
+
+
+def _spec_with_bands(*bands: PercentileRangeBound) -> SampleSanitySpec:
+    return SampleSanitySpec(
+        provider_config_path=Path("unused.yaml"),
+        horizon_months=_HORIZON_MONTHS,
+        rollout_count=_ROLLOUT_COUNT,
+        required_level_series=(SP500Key(),),
+        level_checks=(LevelSeriesSanityCheck(key=SP500Key(), value_percentile_ranges=bands),),
+    )
+
+
+def _sample_constant_sp500(*, horizon_months: int = _HORIZON_MONTHS) -> SampledExogenousBundle:
+    model = ConstantFrameModel(levels={SP500Key(): _SP500_LEVEL})
+    request = ExogenousSamplingRequest(
+        horizon_months=horizon_months,
+        rollout_seeds=tuple(range(_ROLLOUT_COUNT)),
+        required_level_series=frozenset({SP500Key()}),
+    )
+    return model.sample(request)
 
 
 def test_checked_in_fixture_model_samples_sane_trajectories() -> None:
     run_sample_sanity_file(get_required_path("_main/augur/model/testdata/fixture_sample_sanity.yaml"))
+
+
+def test_evaluate_sample_checks_reports_pass_and_fail() -> None:
+    """A passing and a failing band against the same deterministic series both surface."""
+
+    sampled = _sample_constant_sp500()
+    results = evaluate_sample_checks(
+        _spec_with_bands(_PASSING_BAND, _FAILING_BAND),
+        sampled,
+        rollout_count=_ROLLOUT_COUNT,
+        horizon_months=_HORIZON_MONTHS,
+    )
+
+    statuses = {result.status for result in results}
+    assert "pass" in statuses
+    assert "fail" in statuses
+
+    failures = [result for result in results if result.status == "fail"]
+    # The above-the-level band is the only band that should fail.
+    assert any("2000" in failure.detail and "3000" in failure.detail for failure in failures)
+    # The passing range band records the observed percentile values it bounded.
+    passing_ranges = [r for r in results if r.kind == "percentile_range" and r.status == "pass"]
+    assert passing_ranges and all(r.observed == (_SP500_LEVEL, _SP500_LEVEL) for r in passing_ranges)
+
+
+def test_evaluate_sample_checks_skips_bands_beyond_sampled_horizon() -> None:
+    """A band whose month exceeds the sampled horizon is skipped, not indexed OOB."""
+
+    far_band = PercentileRangeBound(month=120, lower_percentile=1, upper_percentile=99, lower=900.0, upper=1100.0)
+    sampled = _sample_constant_sp500()
+    results = evaluate_sample_checks(
+        _spec_with_bands(far_band),
+        sampled,
+        rollout_count=_ROLLOUT_COUNT,
+        horizon_months=_HORIZON_MONTHS,
+    )
+
+    skipped = [result for result in results if result.status == "skipped"]
+    assert len(skipped) == 1
+    assert skipped[0].detail == f"month 120 > sampled horizon {_HORIZON_MONTHS}"
+
+
+def test_run_sample_sanity_raises_listing_failed_bands(tmp_path: Path) -> None:
+    """The deploy gate raises an AssertionError naming every failed band."""
+
+    provider_path = tmp_path / "provider.yaml"
+    provider_path.write_text(
+        dedent(f"""
+            type: independent
+            sp500:
+              kind: constant
+              value: {_SP500_LEVEL}
+        """),
+        encoding="utf-8",
+    )
+    spec = _spec_with_bands(_FAILING_BAND).model_copy(update={"provider_config_path": Path("provider.yaml")})
+
+    with pytest.raises(AssertionError) as excinfo:
+        run_sample_sanity(spec, base_dir=tmp_path)
+    message = str(excinfo.value)
+    assert "outside expected range" in message
+    assert "2000" in message and "3000" in message
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `sample_sanity` deploy-gate bands (expected percentile ranges / threshold probabilities for the macro level series *and* the PE issuer mark) are the same *shape* as the Manifold model-vs-market calibration surface — an expected range vs an observed model value, pass/fail. This surfaces those hardcoded bands on the calibration page, evaluated live against each run's own rollouts.

Built in three layers (one commit each):

### 1. Structured evaluator (`augur/model/sample_sanity.py`)
Refactor the band checks to return a structured `SanityBandResult` (label, series_id, kind, month, expected lo/hi, observed values+labels, status, detail) instead of raising on first failure. `run_sample_sanity` (the deploy gate) becomes a thin wrapper that raises listing **all** failures — strictly better than the old first-failure-only behavior. Out-of-horizon checks now report `status="skipped"` instead of `IndexError`. Gate signature unchanged, so the in-repo and gaffer-private gate tests are untouched.

### 2. Endpoint + wire (`augur/api/`)
`/api/calibration/run` now samples the full exogenous bundle once (PE issuer **+** the spec's `required_level_series`) and threads `.private_equity` into the existing scoring/mark-fan (still one rollout — no extra sampling). When the deployment configures `calibration_catalog.sample_sanity_path`, the server parses that `SampleSanitySpec` at startup and evaluates its bands against the run's rollouts via `evaluate_sample_checks`, returning them as `CalibrationRunResponse.sanity_bands`. The spec's `provider_config_path` is never realized — the page reuses the live calibration model (single source of truth: the gate and the page read the *same* spec). No catalog → 400; catalog without a sanity path → `sanity_bands: []`.

### 3. Frontend panel (`augur/frontend/`)
A "Reasonableness bands (deploy gate)" table panel on the calibration page (after the mark fan), matching the scored-markets visual language: Check / Expected / Observed / Status pill, failures sorted first, `{n_pass}/{n_total} in band` summary, a caveat that p1/p99 tail bands are noisier at the page's rollout count than at the gate's. Pure formatting/sort helpers extracted to `sanity_bands.js` with a `node:test` unit suite. The frontend Zod schema is build-time generated from the OpenAPI doc, so no schema commit is needed.

**Scope:** table only — deliberately did **not** modify the shared `MetricFanChart` (a fan overlay would touch the product page too; deferred).

**Companion PR:** gaffer-private wires `sample_sanity_path` + ships the spec in its configMap (depends on the config field added here).

### Verification (RBE, green)
`sample_sanity_test`, `test_calibration_endpoint`, `config_test`, `sanity_bands_test` all pass; `export_schema` emits `CalibrationSanityBand` into the OpenAPI doc; frontend bundle + Zod codegen build clean with lint.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_