### PR TITLE
augur/api: add types_pyyaml dep to unbreak devel bazel-ci

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -248,6 +248,7 @@ py_library(
         "@pypi//fastapi",
         "@pypi//pydantic",
         "@pypi//pyyaml",
+        "@pypi//types_pyyaml",
         "@pypi//uvicorn",
     ],
 )
@@ -285,6 +286,8 @@ aspect_py_binary(
         ":server_lib",
         "@pypi//fastapi",
         "@pypi//more_itertools",
+        "@pypi//pyyaml",
+        "@pypi//types_pyyaml",
         "@pypi//uvicorn",
     ],
 )


### PR DESCRIPTION
## What

Adds `@pypi//types_pyyaml` to `//augur/api:server_lib` and `//augur/api:server_image_binary` so the mypy lint aspect on `server.py` passes.

## Why — devel is currently red, which is blocking the augur deploy

#1775 added `import yaml` to `augur/api/server.py` (to parse the `SampleSanitySpec`) and `@pypi//pyyaml` to `server_lib`, but not the `types-PyYAML` stubs mypy requires. The pre-merge subagent build checked `//augur/api:server` (the lib) and passed, but the **image** target `//augur/api:server_image_binary` re-declares `srcs = ["server.py"]` (rather than `main_module`-ing `:server_lib`), so its lint aspect re-checks `server.py`'s imports against the *binary's own* deps. Both needed the stubs. The failure:

```
augur/api/server.py:11: error: Library stubs not installed for "yaml"  [import-untyped]
```

This failed **`bazel-ci / Test & Build`** on devel after #1775's squash-merge, which gates `push-images` in `ci.yml` → that job was **skipped** → **no new augur image was built/pushed to GHCR**. As a result, Flux's `ImageRepository` has nothing newer than the pre-#1775 image, and the augur deployment can't roll forward.

### Live impact (why this matters now)
gaffer-private #231 (which adds `calibration_catalog.sample_sanity_path` to the deployed config) merged and rolled its configMap onto the **old** augur image — which doesn't yet have the `sample_sanity_path` field — so the new pod is in `CrashLoopBackOff`:
```
pydantic ValidationError: calibration_catalog.sample_sanity_path
  Extra inputs are not permitted [extra_forbidden]
```
augur stays up on the old pod (`maxUnavailable: 0`), but the rollout won't complete until the #1775 image exists. Landing this fix lets bazel-ci pass → `push-images` builds the new image → Flux rolls it → the new pod (which accepts `sample_sanity_path`) comes ready and the crashloop clears.

## Verification
`bbr build //augur/api:server_image_binary //augur/api:image` → green with lint. `gazelle --mode=diff` agrees with the dep edit (no further drift).

## Follow-up (not in this PR)
`server_image_binary` should use `main_module = "augur.api.server"` on `:server_lib` instead of duplicating `srcs = ["server.py"]`, per STYLE.md's `py_binary` rule — that removes the dep-duplication this fix re-introduces.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_