### PR TITLE
augur: enforce finite/positive marks as runtime assertions, not sanity bands

### DIFF
--- a/augur/frontend/sanity_bands.js
+++ b/augur/frontend/sanity_bands.js
@@ -41,7 +41,7 @@ export function fmtBandValue(kind, value) {
 }
 
 // The expected band: "[lo, hi]" when both sides are set, "≥ lo" / "≤ hi" for a one-sided bound,
-// "—" when neither (e.g. a finite/positive/codes check carries no numeric range).
+// "—" when neither (e.g. an anchor or codes-allowed check carries no numeric range).
 export function fmtExpectedBand(kind, band) {
   const hasLower = band.expectedLower != null && Number.isFinite(Number(band.expectedLower));
   const hasUpper = band.expectedUpper != null && Number.isFinite(Number(band.expectedUpper));

--- a/augur/frontend/sanity_bands.test.mjs
+++ b/augur/frontend/sanity_bands.test.mjs
@@ -90,7 +90,7 @@ test("fmtExpectedBand: two-sided, one-sided, and absent bounds", () => {
   assert.equal(fmtExpectedBand("percentile_range", band({ expectedLower: 0.2, expectedUpper: 20 })), "[0.2, 20]");
   assert.equal(fmtExpectedBand("percentile_bound", band({ expectedLower: 0.2 })), "≥ 0.2");
   assert.equal(fmtExpectedBand("percentile_bound", band({ expectedUpper: 20 })), "≤ 20");
-  assert.equal(fmtExpectedBand("finite", band({})), "—");
+  assert.equal(fmtExpectedBand("codes_allowed", band({})), "—");
 });
 
 test("fmtExpectedBand: probability bound formats endpoints as percent", () => {

--- a/augur/model/sample_sanity.py
+++ b/augur/model/sample_sanity.py
@@ -193,7 +193,7 @@ class SanityBandResult:
 
     label: str  # human-readable, e.g. "sp500 ratio m12/m0 p1..p99"
     series_id: str  # the level-series wire id or "PE issuer 'openai' mark"
-    kind: str  # "finite"|"positive"|"anchor"|"percentile_bound"|"percentile_range"|"threshold_probability"|"count_range"|"event_kind_probability"|"codes_allowed"
+    kind: str  # "anchor"|"percentile_bound"|"percentile_range"|"threshold_probability"|"count_range"|"event_kind_probability"|"codes_allowed"
     month: int | None  # month index where applicable, else None
     expected_lower: float | None
     expected_upper: float | None
@@ -285,9 +285,13 @@ def _evaluate_level_check(
 ) -> list[SanityBandResult]:
     series_id = level_check.key.wire_id
     levels = sampled.level_matrix(level_check.key, rollout_count=rollout_count, horizon_months=horizon_months)
-    results = [_check_finite(levels, series_id=series_id)]
+    # Finiteness / positivity are correctness invariants, not reasonableness bands: a NaN/inf or
+    # non-positive level/mark is a model bug, not a tunable expectation. Enforce them as hard
+    # runtime assertions (raise) rather than surfacing soft pass/fail rows on the calibration page.
+    _assert_finite(levels, series_id=series_id)
     if level_check.require_positive:
-        results.append(_check_positive(levels, series_id=series_id))
+        _assert_positive(levels, series_id=series_id)
+    results: list[SanityBandResult] = []
     if level_check.initial_value is not None:
         results.append(
             _check_anchor(
@@ -344,9 +348,11 @@ def _evaluate_mark_check(
     marks = sampled.private_equity.issuer_float_matrix(
         mark_check.issuer_id, "mark_usd_per_unit", rollout_count=rollout_count, horizon_months=horizon_months
     )
-    results = [_check_finite(marks, series_id=series_id)]
+    # See `_evaluate_level_check`: finiteness/positivity are hard invariants, asserted not banded.
+    _assert_finite(marks, series_id=series_id)
     if mark_check.require_positive:
-        results.append(_check_positive(marks, series_id=series_id))
+        _assert_positive(marks, series_id=series_id)
+    results: list[SanityBandResult] = []
     if mark_check.initial_value is not None:
         results.append(
             _check_anchor(
@@ -499,36 +505,18 @@ def _resolve_path(path: Path, *, base_dir: Path) -> Path:
     return path if path.is_absolute() else (base_dir / path).resolve()
 
 
-def _check_finite(values: np.ndarray, *, series_id: str) -> SanityBandResult:
-    finite = bool(np.all(np.isfinite(values)))
-    return SanityBandResult(
-        label=f"{series_id} finite",
-        series_id=series_id,
-        kind="finite",
-        month=None,
-        expected_lower=None,
-        expected_upper=None,
-        observed=(),
-        observed_labels=(),
-        status="pass" if finite else "fail",
-        detail="" if finite else f"{series_id} produced non-finite value(s)",
-    )
+def _assert_finite(values: np.ndarray, *, series_id: str) -> None:
+    """Hard invariant: every sampled value must be finite. A NaN/inf is a model bug, not a
+    reasonableness question, so raise rather than emit a soft band."""
+    if not bool(np.all(np.isfinite(values))):
+        raise AssertionError(f"{series_id} produced non-finite value(s) — this is a model bug, not a band miss")
 
 
-def _check_positive(values: np.ndarray, *, series_id: str) -> SanityBandResult:
-    positive = not bool(np.any(values <= 0.0))
-    return SanityBandResult(
-        label=f"{series_id} positive",
-        series_id=series_id,
-        kind="positive",
-        month=None,
-        expected_lower=None,
-        expected_upper=None,
-        observed=(),
-        observed_labels=(),
-        status="pass" if positive else "fail",
-        detail="" if positive else f"{series_id} produced non-positive value(s)",
-    )
+def _assert_positive(values: np.ndarray, *, series_id: str) -> None:
+    """Hard invariant: every sampled level/mark must be strictly positive (these are USD prices /
+    index levels). A non-positive value is a model bug, so raise rather than emit a soft band."""
+    if bool(np.any(values <= 0.0)):
+        raise AssertionError(f"{series_id} produced non-positive value(s) — this is a model bug, not a band miss")
 
 
 def _check_anchor(


### PR DESCRIPTION
Per review feedback: a non-finite (NaN/inf) or non-positive level/mark isn't a *reasonableness* question — it's a hard correctness bug, and "if this happens that's quite a bad problem." Rendering it as a soft pass/fail band row on the calibration page (alongside tunable expectation ranges) understates it.

## Change
- Remove the `finite` and `positive` `SanityBandResult` kinds.
- `_evaluate_level_check` / `_evaluate_mark_check` now call hard `_assert_finite` / `_assert_positive` guards that **raise `AssertionError`** on violation (restoring the pre-structured-evaluator gate semantics for these two invariants), before collecting the remaining bands.
- Net effect: a non-finite/non-positive value now blows up loudly — the deploy gate fails and the `/api/calibration/run` endpoint 500s — instead of quietly rendering a red row that looks like a threshold someone could "retune." The `sanity_bands` list now carries only genuine expected-range checks (anchor, percentile bound/range, threshold-probability, count-range, event-kind-probability, codes-allowed).
- Frontend: updated the `kind` doc comment and one test example (`fmtExpectedBand` "no numeric range" case) off the removed kinds — no behavior change, the panel already rendered "—" for rangeless kinds.

## Verification (RBE, green)
`//augur/model:sample_sanity` builds with lint; `sample_sanity_test`, `test_calibration_endpoint`, `sanity_bands_test` all pass. Swept both repos for stragglers referencing the removed kinds — none.

https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa

---
_Generated by [Claude Code](https://claude.ai/code/session_012bGyS5qLvFsEmm5BLdeAoa)_