### PR TITLE
augur: fix private_equity_risk mypy errors (M2.2 scale-reverting types)

### DIFF
--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -921,7 +921,7 @@ def _sample_company_valuation_vectorized(
 
 
 def _scale_reverting_rate(
-    log_value: FloatMatrix, *, rate_mature: float, reversion: ValuationDriftScaleReversion
+    log_value: FloatMatrix, *, rate_mature: float | FloatMatrix, reversion: ValuationDriftScaleReversion
 ) -> FloatMatrix:
     """Generic scale-reverting rate: `rate(s) = rate_mature + (rate_young - rate_mature) *
     exp(-max(0, s - s_onset) / s_scale)`, where `rate_young = reversion.monthly_log_return_mu_young`.
@@ -1025,6 +1025,7 @@ def _sample_company_valuation_and_shares_with_rounds_vectorized(
 
     for m in range(horizon_months):
         # 1) V random walk between events (explicit Euler with scale-reverting drift if set).
+        drift_v: FloatMatrix | float
         if v_reversion is None:
             drift_v = issuer.valuation_monthly_log_return_mu
         else:
@@ -1089,7 +1090,8 @@ def _public_market_marginal_cdf(issuer: PrivateEquityRiskIssuerConfig, *, horizo
         if issuer.annual_public_market_probability <= 0.0:
             return np.zeros_like(months)
         monthly_hazard = 1.0 - (1.0 - issuer.annual_public_market_probability) ** (1.0 / 12.0)
-        return 1.0 - (1.0 - monthly_hazard) ** months
+        flat_tail: FloatMatrix = 1.0 - (1.0 - monthly_hazard) ** months
+        return flat_tail
 
     # Piecewise-constant monthly hazard between anchors that reproduces the CDF exactly,
     # then a flat tail at `annual_public_market_probability` past the last anchor.


### PR DESCRIPTION
## What

Fixes the 3 mypy errors currently breaking `//augur/model:private_equity_risk` on `devel` (introduced by the M2.2-C/D scale-reverting valuation + mint-streams code). **Type-only, behavior-preserving** changes:

- `_scale_reverting_rate(rate_mature: float)` → `rate_mature: float | FloatMatrix` — it's called once with a per-rollout matrix (`mint_rate_mature_per_rollout`) and once with a scalar hazard rate.
- `drift_v: FloatMatrix | float` annotation — the V random-walk drift is a scalar (`valuation_monthly_log_return_mu`) or a per-rollout matrix (`_scale_reverting_drift(...)`) depending on the reversion branch.
- A typed `flat_tail: FloatMatrix` intermediate for the flat public-market hazard return (`float ** ndarray` was inferring `Any`).

No runtime behavior changes — the values were already matrices/floats at runtime; only the annotations were wrong.

## Why

`devel` HEAD is red on this target (verified by building `origin/devel` directly). Pulled out as a standalone fix so it can land independently and unblock devel's bazel-ci, ahead of the larger augur typing branch (#1752) that also carries it.

## Test

`bazelisk test //augur/model:private_equity_risk_test //augur/model:private_equity_trajectories_test --config=rbe` — green (mypy aspect + tests).

https://claude.ai/code/session_016exMxxCw6CcaZkTMyeekhF

---
_Generated by [Claude Code](https://claude.ai/code/session_016exMxxCw6CcaZkTMyeekhF)_