### PR TITLE
cluster/forgejo: un-suspend (roll out on OVH)

### DIFF
--- a/cluster/k8s/forgejo/app/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/app/flux-kustomization.yaml
@@ -4,8 +4,6 @@ metadata:
   name: forgejo
   namespace: flux-system
 spec:
-  suspend: true
-  # Suspended pending rollout — OVH-resident now (independent of wyrm2); un-suspend to deploy.
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/forgejo/db/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/db/flux-kustomization.yaml
@@ -4,8 +4,6 @@ metadata:
   name: forgejo-db
   namespace: flux-system
 spec:
-  suspend: true
-  # Suspended pending rollout — OVH-resident now (independent of wyrm2); un-suspend to deploy.
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/forgejo/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/namespace/flux-kustomization.yaml
@@ -4,8 +4,6 @@ metadata:
   name: forgejo-namespace
   namespace: flux-system
 spec:
-  suspend: true
-  # Suspended pending rollout — OVH-resident now (independent of wyrm2); un-suspend to deploy.
   interval: 1h
   path: ./cluster/k8s/forgejo/namespace
   prune: false

--- a/cluster/k8s/forgejo/secrets/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/secrets/flux-kustomization.yaml
@@ -4,8 +4,6 @@ metadata:
   name: forgejo-secrets
   namespace: flux-system
 spec:
-  suspend: true
-  # Suspended pending rollout — OVH-resident now (independent of wyrm2); un-suspend to deploy.
   retryInterval: 1m
   interval: 10m
   path: ./cluster/k8s/forgejo/secrets

--- a/cluster/k8s/forgejo/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/servicemonitor/flux-kustomization.yaml
@@ -4,8 +4,6 @@ metadata:
   name: forgejo-servicemonitor
   namespace: flux-system
 spec:
-  suspend: true
-  # Suspended pending rollout — OVH-resident now (independent of wyrm2); un-suspend to deploy.
   interval: 10m
   path: ./cluster/k8s/forgejo/servicemonitor
   prune: true


### PR DESCRIPTION
Un-suspends Forgejo so Flux actually deploys it. The Gitea→Forgejo switch (#1779) landed with `suspend: true` on all kustomizations; this removes it from all 5.

**On merge + reconcile, Flux will create:**
- the `forgejo` namespace
- `forgejo-db` — OVH-HA CNPG Postgres (2 instances on separate `hil-ovh` kimsufi nodes, `local-path-ovh`)
- the Forgejo app (Helm), pinned to `hil-ovh`, with repos/data on a `seaweedfs-ovh` PVC
- the ServiceMonitor, plus the Authentik OIDC app + reflected `forgejo-oauth-client-secret` (via `sso-providers-tf`)

Reachable at `git.allegedly.works` once up.

No manifest changes beyond removing `suspend: true` (+ the stale suspend comment) from the 5 `cluster/k8s/forgejo/*/flux-kustomization.yaml`. pre-commit green (kubeconform).

Worth watching after merge: the OVH-HA Postgres reaching Ready (both instances), the `seaweedfs-ovh` PVC binding on an OVH node, and Forgejo's init container fetching the OIDC discovery URL.

https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B)_