### PR TITLE
cluster/forgejo: packages/LFS/attachments on SeaweedFS S3

### DIFF
--- a/cluster/k8s/forgejo/app/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/app/flux-kustomization.yaml
@@ -25,7 +25,9 @@ spec:
     - name: gateway
     - name: cert-manager
     - name: forgejo-secrets
-    - name: reflector # Mirrors forgejo-oauth-client-secret from authentik namespace
+    - name: seaweedfs-forgejo-bucket # S3 bucket for packages/LFS/attachments
+    - name: seaweedfs-secrets # source of s3-identity-forgejo (mirrored into the namespace by reflector)
+    - name: reflector # Mirrors forgejo-oauth-client-secret + s3-identity-forgejo into the namespace
     - name: sso-providers-tf # Writes forgejo-oauth-client-secret to authentik namespace
     - name: authentik # Authentik must be running for OIDC
     # Forgejo validates OIDC at init time (the configure init container fetches the discovery URL).

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -114,6 +114,33 @@ spec:
           UPDATE_AVATAR: true
           ACCOUNT_LINKING: login
 
+        # Object storage on SeaweedFS S3: packages (container registry), LFS,
+        # attachments, artifacts. Git repos stay on the seaweedfs-ovh PVC — git
+        # needs a POSIX filesystem, so there's no S3 backend for repos. Creds
+        # are injected via additionalConfigFromEnvs below.
+        storage:
+          STORAGE_TYPE: minio
+          MINIO_ENDPOINT: seaweedfs-s3.seaweedfs.svc:8333
+          MINIO_BUCKET: forgejo
+          MINIO_LOCATION: us-east-1
+          MINIO_USE_SSL: false
+          MINIO_BUCKET_LOOKUP: path
+
+      # SeaweedFS S3 credentials from the Reflector-mirrored s3-identity-forgejo
+      # Secret (source in the seaweedfs namespace). FORGEJO__ is the chart's
+      # env -> app.ini prefix.
+      additionalConfigFromEnvs:
+        - name: FORGEJO__storage__MINIO_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: s3-identity-forgejo
+              key: accessKey
+        - name: FORGEJO__storage__MINIO_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3-identity-forgejo
+              key: secretKey
+
     # Trust cluster CA bundle (includes Let's Encrypt staging CA)
     deployment:
       # Reloader: auto-restart pods when secrets change

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -320,6 +320,7 @@ resources:
   - seaweedfs/vm-images-bucket/flux-kustomization.yaml
   - seaweedfs/vm-images-s3/flux-kustomization.yaml
   - seaweedfs/drivefs-artifacts-bucket/flux-kustomization.yaml
+  - seaweedfs/forgejo-bucket/flux-kustomization.yaml
   - seaweedfs/drivefs-artifacts-s3/flux-kustomization.yaml
   - seaweedfs/monitoring/flux-kustomization.yaml
   - seaweedfs-csi/flux-kustomization.yaml

--- a/cluster/k8s/seaweedfs/forgejo-bucket/bucket.yaml
+++ b/cluster/k8s/seaweedfs/forgejo-bucket/bucket.yaml
@@ -1,0 +1,14 @@
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Bucket
+metadata:
+  name: forgejo
+  namespace: seaweedfs
+spec:
+  name: forgejo
+  clusterRef:
+    name: seaweedfs
+    namespace: seaweedfs
+  reclaimPolicy: Retain
+  access:
+    - user: forgejo
+      actions: [Read, Write, List, Tagging]

--- a/cluster/k8s/seaweedfs/forgejo-bucket/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/forgejo-bucket/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: seaweedfs-forgejo-bucket
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  path: ./cluster/k8s/seaweedfs/forgejo-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: seaweedfs-cluster
+      namespace: flux-system
+  wait: true
+  timeout: 5m
+  healthChecks:
+    - apiVersion: seaweed.seaweedfs.com/v1
+      kind: Bucket
+      name: forgejo
+      namespace: seaweedfs

--- a/cluster/k8s/seaweedfs/forgejo-bucket/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/forgejo-bucket/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bucket.yaml

--- a/cluster/k8s/seaweedfs/secrets/identities/forgejo.sops.yaml
+++ b/cluster/k8s/seaweedfs/secrets/identities/forgejo.sops.yaml
@@ -1,0 +1,99 @@
+# SeaweedFS s3 identity for "forgejo".
+# Scoped to the forgejo bucket (Bucket CR in seaweedfs/forgejo-bucket/).
+# Forgejo uses this for object storage: packages (container registry), LFS,
+# attachments, artifacts. The Secret is mirrored into the forgejo namespace
+# via Reflector so the Forgejo HelmRelease can inject the creds as env.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: s3-identity-forgejo
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity
+    annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: forgejo
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: forgejo
+type: Opaque
+stringData:
+    name: forgejo
+    actions: Read:forgejo,Write:forgejo,List:forgejo,Tagging:forgejo
+    accessKey: ENC[AES256_GCM,data:/n4bzzh2JjwodCavtnww93IM9LHQu3wqA4fKNiDfnUw=,iv:rFHLJNYz8d3eLX6QC4wfGfPRkAtqaoQaQ1wFEY2RHHk=,tag:dLMdDNTgHe9uglJSw8zx+w==,type:str]
+    secretKey: ENC[AES256_GCM,data:h0dUAPt89iO18FUoSAA7TxEwcwmb6a3ob9H0kk/zsvzmB8cM8wu5yi9K0VnLqGz+AdnwsrlvLGcQiOzxdf/B9w==,iv:BSjd9Feg1/aq5g+DV/Jn5TKSakZSF482zR9dB6cTmIw=,tag:v96q3dJr9RlT5Ii1v89Iww==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWGN2RlNRRmljTjhZK3cz
+            bDB5a2FGcVNGZnVOZnNZU2tueDZHdnZsWHlvCmdma0tqblZJQXNienU2RzZNbjFB
+            cWZpVU9RNnNFUCtKRDZkU3pJTlZwQ2MKLS0tIEJBV1JEMlA3a1Z3UUp0c1BBcGhR
+            TDVoNEFqa2ZSYnBKQ3kvV0ZkTWEybUkK2sWb8yRzKqU0vFxikpXeEYKi89/nmpPt
+            vJqUI8Itr0zJEH1/uK6vuITkyiTiROwbumGTl0/VCIZvxruMSKGc4g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cVBNbnVPWXRPYlQ2cTFY
+            K2NKMC9Jeis0S2xTN0Flbk1mYVE3NmxGaEg4ClQvVnFkUTBYM2FtWHEwWWx5M0N3
+            anE0cTUvdmJneXRuZ2tlWjNKNWo0M0UKLS0tIHorQzlSUTNWaVp5ZUwrOFUrR3hZ
+            ZmpZZy9mUzlWMm1qSGJ4a1VVc0UwVzgKHlsHnlj8+I7EA+ColK1XHgtMS6PQ1XUp
+            62ka+W/1qpabZgy3hCDoZbgOZm97DBT8GdWNZVkk/ocnVtd7iRxD7Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-01T23:19:45Z"
+    mac: ENC[AES256_GCM,data:55J7Bds4Eumuujp6suVWq7ppCDBVNlu/orP2yOZxxSZVw+oeAhyyO096eaubUZNkHk+3vkdMZeAMHI+/FECPI1G04iMwVE1mRComDcX8tSKtz9zqymHdeibDW8gqc7uhO8OM5ifIbj21iXofiKWUNJl73foNm+ZfKpMfmkPOGis=,iv:735h4NtIrKbMb8mqWv5eFv7anGT3QmpN2MQ+6Vi2++U=,tag:fAS1+uTQjtMW2z6Oy6H2KQ==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+    name: s3-identity-forgejo-json
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity-json
+spec:
+    refreshInterval: 1m
+    secretStoreRef:
+        kind: SecretStore
+        name: seaweedfs-identities
+    target:
+        name: s3-identity-forgejo-json
+        template:
+            type: Opaque
+            data:
+                identity: |
+                    {"name":"{{ .name }}",
+                     "credentials":[{"accessKey":"{{ .accessKey }}","secretKey":"{{ .secretKey }}"}],
+                     "actions":[{{- $first := true -}}
+                       {{- range splitList "," .actions -}}
+                       {{- if not $first }},{{ end -}}"{{ . }}"{{- $first = false -}}
+                       {{- end }}]}
+    dataFrom:
+        - extract:
+            key: s3-identity-forgejo
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWGN2RlNRRmljTjhZK3cz
+            bDB5a2FGcVNGZnVOZnNZU2tueDZHdnZsWHlvCmdma0tqblZJQXNienU2RzZNbjFB
+            cWZpVU9RNnNFUCtKRDZkU3pJTlZwQ2MKLS0tIEJBV1JEMlA3a1Z3UUp0c1BBcGhR
+            TDVoNEFqa2ZSYnBKQ3kvV0ZkTWEybUkK2sWb8yRzKqU0vFxikpXeEYKi89/nmpPt
+            vJqUI8Itr0zJEH1/uK6vuITkyiTiROwbumGTl0/VCIZvxruMSKGc4g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cVBNbnVPWXRPYlQ2cTFY
+            K2NKMC9Jeis0S2xTN0Flbk1mYVE3NmxGaEg4ClQvVnFkUTBYM2FtWHEwWWx5M0N3
+            anE0cTUvdmJneXRuZ2tlWjNKNWo0M0UKLS0tIHorQzlSUTNWaVp5ZUwrOFUrR3hZ
+            ZmpZZy9mUzlWMm1qSGJ4a1VVc0UwVzgKHlsHnlj8+I7EA+ColK1XHgtMS6PQ1XUp
+            62ka+W/1qpabZgy3hCDoZbgOZm97DBT8GdWNZVkk/ocnVtd7iRxD7Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-01T23:19:45Z"
+    mac: ENC[AES256_GCM,data:55J7Bds4Eumuujp6suVWq7ppCDBVNlu/orP2yOZxxSZVw+oeAhyyO096eaubUZNkHk+3vkdMZeAMHI+/FECPI1G04iMwVE1mRComDcX8tSKtz9zqymHdeibDW8gqc7uhO8OM5ifIbj21iXofiKWUNJl73foNm+ZfKpMfmkPOGis=,iv:735h4NtIrKbMb8mqWv5eFv7anGT3QmpN2MQ+6Vi2++U=,tag:fAS1+uTQjtMW2z6Oy6H2KQ==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1

--- a/cluster/k8s/seaweedfs/secrets/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/secrets/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   # by the attic Bucket CR but not present in s3-config).
   - identities/admin.sops.yaml
   - identities/augur-assets.sops.yaml
+  - identities/forgejo.sops.yaml
   - identities/listing-monitor-captures.sops.yaml
   - identities/loki.sops.yaml
   - identities/tempo.sops.yaml


### PR DESCRIPTION
Routes Forgejo's bulk object storage to SeaweedFS S3, so the container registry (and LFS/attachments/artifacts) lives in object storage instead of on the data PVC. Groundwork for hosting the **props** agent images on Forgejo.

## What's added

- **Bucket CR** `cluster/k8s/seaweedfs/forgejo-bucket/` — a `forgejo` bucket (`reclaimPolicy: Retain`), same pattern as the existing drivefs/vm-images buckets.
- **S3 identity** `cluster/k8s/seaweedfs/secrets/identities/forgejo.sops.yaml` — scoped `Read/Write/List/Tagging` on the `forgejo` bucket; SOPS-encrypted keys; assembled into the gateway config by the existing `seaweedfs-s3-config` ESO. Annotated for **Reflector** so the Secret is mirrored into the `forgejo` namespace.
- **HelmRelease** `[storage]` → minio at `seaweedfs-s3.seaweedfs.svc:8333` (path-style, HTTP, region `us-east-1`, bucket `forgejo`). Creds injected via `FORGEJO__storage__MINIO_ACCESS_KEY_ID` / `_SECRET_ACCESS_KEY` from the mirrored `s3-identity-forgejo` Secret (`FORGEJO__` is the chart's env→app.ini prefix).

## What lands where

- **SeaweedFS S3**: packages (container registry), LFS, attachments, artifacts.
- **`seaweedfs-ovh` PVC (unchanged)**: git repos + config — git needs a POSIX filesystem, so there's no S3 backend for repos.

## Wiring

The `forgejo` app kustomization now `dependsOn` `seaweedfs-forgejo-bucket` (bucket exists before Forgejo writes) and `seaweedfs-secrets` (source of the mirrored creds); `reflector` was already a dep.

## Validation / rollout

`pre-commit` green: kubeconform (validates the Bucket CR, ExternalSecret, and HelmRelease), prettier. On reconcile, Forgejo restarts and picks up minio storage (no existing packages to migrate — props isn't on Forgejo yet). Worth checking after merge: the `forgejo` Bucket goes Ready, the `s3-identity-forgejo` Secret reflects into the `forgejo` namespace, and a test `docker push` to `git.allegedly.works` lands a blob in the bucket.

https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B)_