### PR TITLE
eslint: wire react-hooks v5 + React rules; fix augur violations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,6 +71,7 @@ js_library(
         ":node_modules/@typescript-eslint/parser",
         ":node_modules/eslint-plugin-import-x",
         ":node_modules/eslint-plugin-react",
+        ":node_modules/eslint-plugin-react-hooks",
         ":node_modules/eslint-plugin-svelte",
         ":node_modules/globals",
         ":node_modules/svelte",  # peer dep of svelte-eslint-parser & eslint-plugin-svelte

--- a/augur/frontend/app.tsx
+++ b/augur/frontend/app.tsx
@@ -343,7 +343,7 @@ function ProductProjectionWorkspace({
   );
   const scenarioCacheKey = useMemo(() => JSON.stringify(request.scenario), [request.scenario]);
   const fanRows = useMemo(() => metricFanRows(result), [result]);
-  const rolloutSummaries = result?.rolloutSummaries ?? [];
+  const rolloutSummaries = useMemo(() => result?.rolloutSummaries ?? [], [result]);
   const selectedSummary = useMemo(
     () => rolloutSummaries.find((summary) => Number(summary.seed) === selectedSeed) ?? null,
     [rolloutSummaries, selectedSeed]

--- a/augur/frontend/calibration.tsx
+++ b/augur/frontend/calibration.tsx
@@ -115,8 +115,8 @@ function CalibrationForm({ catalog }) {
         <div className="px-4 py-3">
           <div className="augur-eyebrow">Calibration run</div>
           <div className="mt-1 text-xs augur-muted">
-            Score a built-in exogenous model's rollouts against this deployment's curated prediction-market catalog
-            (exogenous-only — no portfolio, no product scenario). Results update live as you tune the inputs.
+            Score a built-in exogenous model&apos;s rollouts against this deployment&apos;s curated prediction-market
+            catalog (exogenous-only — no portfolio, no product scenario). Results update live as you tune the inputs.
           </div>
         </div>
         <div className="grid gap-3 px-4 py-3">
@@ -289,8 +289,9 @@ function SanityBandsPanel({ bands }) {
           <div className="augur-eyebrow">Reasonableness bands (deploy gate)</div>
           <div className="mt-1 text-xs augur-muted">
             The hardcoded <code>sample_sanity</code> reasonableness bands: an expected range vs the observed value, the
-            same shape as the model-vs-market calibration above but checked against this run's own rollouts. Tail
-            percentile bands (p1/p99) are noisier at this page's rollout count than at the deploy gate's higher count.
+            same shape as the model-vs-market calibration above but checked against this run&apos;s own rollouts. Tail
+            percentile bands (p1/p99) are noisier at this page&apos;s rollout count than at the deploy gate&apos;s
+            higher count.
           </div>
         </div>
         <div className="shrink-0 text-right">

--- a/augur/frontend/fan_chart.tsx
+++ b/augur/frontend/fan_chart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { axisCoordinate, fanChartAxis, fanChartYearTicks, fmtAxisMetricValue, fmtMetricValue } from "./lib/chart.ts";
 import { FAN_PERCENTILES } from "./input_helpers.ts";
 import { useCurrencyDisplay } from "./hooks.ts";
@@ -223,32 +223,31 @@ export function MetricFanChart({
     return `${upper} ${lower}`;
   };
 
-  const handleMouseMove = useCallback(
-    (event) => {
-      const svg = svgRef.current;
-      if (!svg) return;
-      const rect = svg.getBoundingClientRect();
-      const svgX = event.clientX - rect.left;
-      if (svgX < margin.left || svgX > margin.left + plotWidth) {
-        setHoveredMonth(null);
-        return;
+  // Plain handlers (not useCallback): they sit after the early return above, and as DOM event
+  // handlers gain nothing from memoization.
+  const handleMouseMove = (event) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const svgX = event.clientX - rect.left;
+    if (svgX < margin.left || svgX > margin.left + plotWidth) {
+      setHoveredMonth(null);
+      return;
+    }
+    const targetYear = ((svgX - margin.left) / plotWidth) * maxYear;
+    let closest = null;
+    let closestDist = Infinity;
+    for (const row of rows) {
+      const dist = Math.abs(row.year - targetYear);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closest = row;
       }
-      const targetYear = ((svgX - margin.left) / plotWidth) * maxYear;
-      let closest = null;
-      let closestDist = Infinity;
-      for (const row of rows) {
-        const dist = Math.abs(row.year - targetYear);
-        if (dist < closestDist) {
-          closestDist = dist;
-          closest = row;
-        }
-      }
-      setHoveredMonth(closest);
-    },
-    [rows, maxYear, plotWidth, margin.left]
-  );
+    }
+    setHoveredMonth(closest);
+  };
 
-  const handleMouseLeave = useCallback(() => setHoveredMonth(null), []);
+  const handleMouseLeave = () => setHoveredMonth(null);
 
   const hoveredRow = hoveredMonth;
 

--- a/augur/frontend/forms.tsx
+++ b/augur/frontend/forms.tsx
@@ -20,8 +20,8 @@ import {
   buildLifecycleEvents,
   defaultLifecycleEvent,
   nextLifecycleEventId,
+  FAN_PERCENTILES,
 } from "./input_helpers.ts";
-import { FAN_PERCENTILES } from "./input_helpers.ts";
 import { rolloutSliverColor, portfolioHasBucket, isPrivateSecurityPosition } from "./data_helpers.ts";
 
 function firstSaleMonth(events) {
@@ -224,7 +224,7 @@ export function LifecycleEventsEditor({ events, horizonMonths, onChange }) {
       <div className="augur-field-label">Timeline (mid-horizon changes)</div>
       {events.length === 0 && (
         <div className="text-xs augur-muted">
-          Add events to change the property's rented %, primary-home status, fund a capital improvement, or sell
+          Add events to change the property&apos;s rented %, primary-home status, fund a capital improvement, or sell
           mid-horizon.
         </div>
       )}

--- a/augur/frontend/histogram.tsx
+++ b/augur/frontend/histogram.tsx
@@ -22,10 +22,14 @@ export function TerminalDistributionHistogram({
   metric,
   metricScale = "linear",
 }) {
-  if (summaries.length === 0) return null;
+  // Hooks must run unconditionally, before the early return below. `entries` is safe to compute
+  // for empty `summaries` (yields []), so it can live up here to feed the memo.
   const entries = summaries
     .map((summary) => ({ summary, value: terminalMetricValue(summary.terminalMetrics, metric) }))
     .filter((entry) => Number.isFinite(entry.value));
+  const sortedEntries = useMemo(() => entries.slice().sort((left, right) => left.value - right.value), [entries]);
+  const histogramDragRef = useRef({ dragging: false, startX: 0, startY: 0, startSeed: null, wasSelected: false });
+  if (summaries.length === 0) return null;
   const axis =
     entries.length > 0
       ? fanChartAxis(
@@ -53,10 +57,8 @@ export function TerminalDistributionHistogram({
     return ((axisCoordinate(axis, value) - axis.min) / axis.range) * 100;
   };
   const xTicks = Array.isArray(axis.ticks) ? axis.ticks.slice().sort((left, right) => left - right) : [];
-  const sortedEntries = useMemo(() => entries.slice().sort((left, right) => left.value - right.value), [entries]);
   const selectedSliderEntry = sortedEntries.find((entry) => Number(entry.summary.seed) === selectedSeed) ?? null;
   const thumbLeftPct = selectedSliderEntry ? axisLeftPct(selectedSliderEntry.value) : null;
-  const histogramDragRef = useRef({ dragging: false, startX: 0, startY: 0, startSeed: null, wasSelected: false });
   const seedAtPoint = (clientX, clientY) => {
     const target = document.elementFromPoint(clientX, clientY);
     if (!target) return null;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ import sveltePlugin from "eslint-plugin-svelte";
 import svelteParser from "svelte-eslint-parser";
 import importPlugin from "eslint-plugin-import-x";
 import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 
 // All project source directories (add new TS/Svelte projects here)
@@ -23,6 +24,9 @@ const projectGlobs = [
 const tsFiles = projectGlobs.map((g) => `${g}/*.{ts,tsx}`);
 const svelteFiles = projectGlobs.map((g) => `${g}/*.svelte`);
 const svelteTsFiles = projectGlobs.map((g) => `${g}/*.svelte.ts`);
+
+// React projects (subset of projectGlobs) get eslint-plugin-react + react-hooks.
+const reactFiles = ["x/rspcache/admin_ui/src/**", "augur/frontend/**"].map((g) => `${g}/*.{ts,tsx}`);
 
 // Import ordering (TS equivalent of ruff's isort)
 // import/order is disabled: eslint-plugin-import-x's import/order rule crashes under
@@ -43,6 +47,9 @@ const coreRules = {
   "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
   "no-unused-vars": "off",
+  // TypeScript already resolves identifiers/types; eslint's no-undef misfires on type-only
+  // names (e.g. `RequestInit`) and ambient globals, so defer to the compiler.
+  "no-undef": "off",
   ...importRules,
 };
 
@@ -100,23 +107,18 @@ export default [
     },
   },
 
-  // ── Per-project overrides ──────────────────────────────────────────────
-
-  // RSPCache admin UI: React/JSX
+  // ── React projects (eslint-plugin-react recommended + react-hooks) ──────
   {
-    files: ["x/rspcache/admin_ui/src/**/*.{ts,tsx}"],
+    files: reactFiles,
     languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
-    plugins: { react },
+    plugins: { react, "react-hooks": reactHooks },
     settings: { react: { version: "18.3" } },
-    rules: { "react/react-in-jsx-scope": "off" },
-  },
-
-  // Augur frontend: React/JSX
-  {
-    files: ["augur/frontend/**/*.{ts,tsx}"],
-    languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
-    plugins: { react },
-    settings: { react: { version: "18.3" } },
-    rules: { "react/react-in-jsx-scope": "off" },
+    rules: {
+      ...react.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off", // automatic JSX runtime, no React import needed
+      "react/prop-types": "off", // TypeScript handles prop types
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "error",
+    },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "^9.39.2",
     "eslint-plugin-import-x": "^4.16.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-svelte": "^3.13.1",
     "globals": "^16.5.0",
     "http-server": "^14.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks:
-        specifier: ^4.6.0
-        version: 4.6.2(eslint@9.39.4(jiti@2.6.1))
+        specifier: ^5.0.0
+        version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-svelte:
         specifier: ^3.13.1
         version: 3.17.0(eslint@9.39.4(jiti@2.6.1))(svelte@5.55.2)
@@ -3492,11 +3492,11 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
-  eslint-plugin-react-hooks@4.6.2:
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -9877,7 +9877,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@4.6.2(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
 


### PR DESCRIPTION
## What

Groundwork for making the eslint aspect a **hard build gate** (a later change flips `--@aspect_rules_lint//lint:fail_on_violation` once every frontend is clean). This PR wires up the React linting that was silently broken and fixes augur's resulting violations.

The eslint aspect already runs on every build but is **report-only** today. The React projects were also under-linted: `eslint-plugin-react-hooks` was in `package.json` but **never added to the eslint binary's deps**, and at v4.6 it **crashes on ESLint 9** (`context.getSource is not a function`) — so hook rules never actually ran.

## Changes

- **Upgrade `eslint-plugin-react-hooks` 4.6 → 5.x** (ESLint-9 compatible) + add it to `//:eslintrc` deps so the aspect can load it.
- **`eslint.config.js`:** apply `eslint-plugin-react` recommended + `react-hooks` (`rules-of-hooks` + `exhaustive-deps` as **error**) to the React projects (augur, rspcache); disable `no-undef` for TS (the compiler resolves names; `no-undef` misfires on type-only names like `RequestInit`).
- **Fix augur's errors:**
  - **`rules-of-hooks` (real bugs):** `histogram.tsx` called `useMemo`/`useRef` after an early `return` → hoisted above it; `fan_chart.tsx` called `useCallback` after an early `return` → dropped the wrappers (DOM handlers gain nothing from memoization).
  - **`exhaustive-deps`:** `app.tsx` `rolloutSummaries = result?.x ?? []` made a fresh array each render, destabilizing a `useMemo` dep → wrapped in its own `useMemo`.
  - `react/no-unescaped-entities` + `import/no-duplicates` in `calibration.tsx` / `forms.tsx`.

## Validation

augur is **eslint-clean (0 errors)** under the new rules; `tsc`, vitest, and the visual goldens all pass. `props/frontend` and `airlock` are cleaned in follow-up PRs; the flag flip lands after all are merged.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_