### PR TITLE
airlock/frontend: fix prefer-const eslint errors

### DIFF
--- a/airlock/frontend/ActionDetail.svelte
+++ b/airlock/frontend/ActionDetail.svelte
@@ -2,7 +2,7 @@
   import { getApiClient } from "./api.ts";
   import type { Action, DoneState, RejectedState } from "./types.ts";
 
-  let { action }: { action: Action } = $props();
+  const { action }: { action: Action } = $props();
   let rejectReason = $state("");
   let approving = $state(false);
   let rejecting = $state(false);

--- a/airlock/frontend/ActionList.svelte
+++ b/airlock/frontend/ActionList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Action } from "./types.ts";
 
-  let { pending, recent }: { pending: Action[]; recent: Action[] } = $props();
+  const { pending, recent }: { pending: Action[]; recent: Action[] } = $props();
 
   function fmt(iso: string): string {
     return new Date(iso).toLocaleString();


### PR DESCRIPTION
Part of making the eslint aspect a hard build gate (the `--@aspect_rules_lint//lint:fail_on_violation` flag is flipped in a final PR once every project is clean).

Svelte 5 `$props()` destructuring is never reassigned, so `let` → `const` (`prefer-const`). Two files: `ActionList.svelte`, `ActionDetail.svelte`.

airlock is now eslint-clean (0 errors); all airlock visual tests pass.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_