### PR TITLE
props/frontend: fix eslint errors (prefer-const + svelte idioms)

### DIFF
--- a/props/frontend/src/App.svelte
+++ b/props/frontend/src/App.svelte
@@ -28,8 +28,8 @@
   let usernameInput = $state("");
   let passwordInput = $state("");
   // Disable the other mode when one has input
-  let tokenHasInput = $derived(tokenInput.trim().length > 0);
-  let credsHasInput = $derived(usernameInput.trim().length > 0 || passwordInput.length > 0);
+  const tokenHasInput = $derived(tokenInput.trim().length > 0);
+  const credsHasInput = $derived(usernameInput.trim().length > 0 || passwordInput.length > 0);
 
   function handleOpenRunModal(prefill?: ModalPrefill) {
     modalPrefill = prefill;

--- a/props/frontend/src/components/BackButton.svelte
+++ b/props/frontend/src/components/BackButton.svelte
@@ -7,7 +7,7 @@
     class?: string;
   }
 
-  let { href: hrefProp, label = "← Back", class: className }: Props = $props();
+  const { href: hrefProp, label = "← Back", class: className }: Props = $props();
 </script>
 
 <a

--- a/props/frontend/src/components/Breadcrumb.svelte
+++ b/props/frontend/src/components/Breadcrumb.svelte
@@ -11,7 +11,7 @@
     items: BreadcrumbItem[];
   }
 
-  let { items }: Props = $props();
+  const { items }: Props = $props();
 </script>
 
 <nav class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">

--- a/props/frontend/src/components/CollapsibleSection.svelte
+++ b/props/frontend/src/components/CollapsibleSection.svelte
@@ -6,7 +6,7 @@
     label: string;
     jsonData: Record<string, unknown>;
   }
-  let { label, jsonData }: Props = $props();
+  const { label, jsonData }: Props = $props();
 </script>
 
 <details class="group">

--- a/props/frontend/src/components/CopyButton.svelte
+++ b/props/frontend/src/components/CopyButton.svelte
@@ -9,7 +9,7 @@
     successMessage?: string;
   }
 
-  let { text, label = "Copy", successMessage = "Copied to clipboard" }: Props = $props();
+  const { text, label = "Copy", successMessage = "Copied to clipboard" }: Props = $props();
 
   let copied = $state(false);
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/props/frontend/src/components/DefinitionDetail.svelte
+++ b/props/frontend/src/components/DefinitionDetail.svelte
@@ -13,7 +13,7 @@
   interface Props {
     data: DefinitionDetailResponse;
   }
-  let { data }: Props = $props();
+  const { data }: Props = $props();
 
   // Column group configs (same as DefinitionsTable)
   const colGroups: { split: Split; kind: ExampleKind; label: string }[] = [

--- a/props/frontend/src/components/ExampleDetail.svelte
+++ b/props/frontend/src/components/ExampleDetail.svelte
@@ -11,7 +11,7 @@
   interface Props {
     data: ExampleDetailResponse;
   }
-  let { data }: Props = $props();
+  const { data }: Props = $props();
 
   function formatStatusCounts(counts: Record<string, number>): string {
     const parts: string[] = [];

--- a/props/frontend/src/components/ExpandableItem.svelte
+++ b/props/frontend/src/components/ExpandableItem.svelte
@@ -8,7 +8,7 @@
     alignItems?: string;
     children: Snippet<[]>;
   }
-  let { item, alignItems, children }: Props = $props();
+  const { item, alignItems, children }: Props = $props();
 </script>
 
 <div class="space-y-1">

--- a/props/frontend/src/components/FileTree.svelte
+++ b/props/frontend/src/components/FileTree.svelte
@@ -10,9 +10,9 @@
     selectedPath?: string;
   }
 
-  let { nodes, onFileClick, selectedPath }: Props = $props();
+  const { nodes, onFileClick, selectedPath }: Props = $props();
 
-  let expanded = $state(new SvelteSet<string>());
+  const expanded = new SvelteSet<string>();
 
   function toggleExpand(path: string) {
     if (expanded.has(path)) {

--- a/props/frontend/src/components/FileViewer.svelte
+++ b/props/frontend/src/components/FileViewer.svelte
@@ -32,7 +32,7 @@
     defaultCollapsed?: boolean;
   }
 
-  let {
+  const {
     file,
     tps = [],
     fps = [],
@@ -153,7 +153,7 @@
     return map;
   });
 
-  let expandedIssues = $state(new SvelteSet<string>());
+  const expandedIssues = new SvelteSet<string>();
 
   function toggleIssue(id: string) {
     if (expandedIssues.has(id)) {

--- a/props/frontend/src/components/GradingEdges.svelte
+++ b/props/frontend/src/components/GradingEdges.svelte
@@ -20,7 +20,7 @@
     snapshotSlug?: string; // For linking TP/FP occurrence IDs
   }
 
-  let {
+  const {
     edges,
     missedOccurrences = [],
     totalCredit,

--- a/props/frontend/src/components/IssueComment.svelte
+++ b/props/frontend/src/components/IssueComment.svelte
@@ -20,7 +20,7 @@
     snapshotSlug?: string; // For linking grading edge targets (TP/FP occurrences)
   }
 
-  let {
+  const {
     kind,
     issueId,
     rationale,

--- a/props/frontend/src/components/LLMRequestSection.svelte
+++ b/props/frontend/src/components/LLMRequestSection.svelte
@@ -7,7 +7,7 @@
   interface Props {
     requestBody: Record<string, unknown>;
   }
-  let { requestBody }: Props = $props();
+  const { requestBody }: Props = $props();
 
   const inputItems = Array.isArray(requestBody.input) ? (requestBody.input as Record<string, unknown>[]) : null;
   const inputStr = typeof requestBody.input === "string" ? requestBody.input : null;
@@ -31,7 +31,7 @@
 
   <!-- Input conversation items -->
   {#if inputItems}
-    {#each inputItems as item}
+    {#each inputItems as item, i (i)}
       {@const role = typeof item.role === "string" ? item.role : null}
       {@const itype = typeof item.type === "string" ? item.type : null}
       {#if role}

--- a/props/frontend/src/components/LLMRequestViewer.svelte
+++ b/props/frontend/src/components/LLMRequestViewer.svelte
@@ -8,7 +8,7 @@
     requests: LLMRequestInfo[];
     initialExpanded?: number[];
   }
-  let { requests, initialExpanded = [] }: Props = $props();
+  const { requests, initialExpanded = [] }: Props = $props();
 </script>
 
 {#if requests.length === 0}

--- a/props/frontend/src/components/LLMResponseSection.svelte
+++ b/props/frontend/src/components/LLMResponseSection.svelte
@@ -7,7 +7,7 @@
   interface Props {
     responseBody: Record<string, unknown>;
   }
-  let { responseBody }: Props = $props();
+  const { responseBody }: Props = $props();
 
   const outputItems = Array.isArray(responseBody.output) ? (responseBody.output as Record<string, unknown>[]) : null;
   const usage = responseBody.usage as Record<string, unknown> | null | undefined;
@@ -22,7 +22,7 @@
 
   <!-- Output items -->
   {#if outputItems}
-    {#each outputItems as item}
+    {#each outputItems as item, i (i)}
       {@const itype = typeof item.type === "string" ? item.type : null}
       {#if itype === "message"}
         <ExpandableItem {item}>

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -38,7 +38,7 @@
     initialFileContents?: Map<string, FileContentResponse>;
     initialLLMRequests?: LLMRequestInfo[];
   }
-  let { runId, initialRun, initialSnapshotDetail, initialFileContents, initialLLMRequests }: Props = $props();
+  const { runId, initialRun, initialSnapshotDetail, initialFileContents, initialLLMRequests }: Props = $props();
 
   // State
   let run: AgentRunDetail | null = $state(initialRun ?? null);

--- a/props/frontend/src/components/RunTriggerModal.svelte
+++ b/props/frontend/src/components/RunTriggerModal.svelte
@@ -26,7 +26,7 @@
     prefill?: Prefill;
   }
 
-  let { open, onClose, prefill }: Props = $props();
+  const { open, onClose, prefill }: Props = $props();
 
   type RunMode = "validation" | "optimize" | "improve";
   let mode: RunMode = $state("validation");

--- a/props/frontend/src/components/RunsBrowser.svelte
+++ b/props/frontend/src/components/RunsBrowser.svelte
@@ -31,7 +31,7 @@
     initialRuns?: RunInfo[];
     initialTotalCount?: number;
   }
-  let { initialDefinitionId, initialSplit, initialKind, onTriggerRun, initialRuns, initialTotalCount }: Props =
+  const { initialDefinitionId, initialSplit, initialKind, onTriggerRun, initialRuns, initialTotalCount }: Props =
     $props();
 
   // State

--- a/props/frontend/src/components/TabButton.svelte
+++ b/props/frontend/src/components/TabButton.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import type { Snippet } from "svelte";
+
   interface Props {
     active: boolean;
     onclick: () => void;
-    children: import("svelte").Snippet;
+    children: Snippet;
   }
 
-  let { active, onclick, children }: Props = $props();
+  const { active, onclick, children }: Props = $props();
 </script>
 
 <button

--- a/props/frontend/src/components/stats/CoverageHeatmap.svelte
+++ b/props/frontend/src/components/stats/CoverageHeatmap.svelte
@@ -33,7 +33,7 @@
     cells: Cell[];
   }
 
-  let { definitions, examples, cells }: Props = $props();
+  const { definitions, examples, cells }: Props = $props();
 
   let canvas: HTMLCanvasElement;
   let chart: Chart | null = $state(null);
@@ -161,7 +161,7 @@
       class="flex flex-col justify-around text-xs text-gray-600 dark:text-gray-400 font-mono"
       style="min-width: 100px;"
     >
-      {#each definitions as def}
+      {#each definitions as def (def.image_digest)}
         <div class="flex items-center gap-1 truncate" title={def.image_digest}>
           {formatDigest(def.image_digest)} ({def.best_on_count})
         </div>

--- a/props/frontend/src/components/stats/CreditBadge.svelte
+++ b/props/frontend/src/components/stats/CreditBadge.svelte
@@ -4,7 +4,7 @@
     nRuns: number;
   }
 
-  let { meanCredit, nRuns }: Props = $props();
+  const { meanCredit, nRuns }: Props = $props();
 
   const colorClass = $derived(
     meanCredit >= 0.7

--- a/props/frontend/src/components/stats/DefinitionsTable.svelte
+++ b/props/frontend/src/components/stats/DefinitionsTable.svelte
@@ -17,7 +17,7 @@
     onCellClick?: (_: CellClickInfo) => void;
   }
 
-  let { definitions, exampleCounts, onCellClick }: Props = $props();
+  const { definitions, exampleCounts, onCellClick }: Props = $props();
 
   function getStats(def: DefinitionRow, split: Split, kind: ExampleKind): SplitScopeStats | undefined {
     return def.stats[split]?.[kind];

--- a/props/frontend/src/components/stats/DistributionChart.svelte
+++ b/props/frontend/src/components/stats/DistributionChart.svelte
@@ -12,7 +12,7 @@
     color?: string;
   }
 
-  let {
+  const {
     values,
     title,
     numBuckets = 10,

--- a/props/frontend/src/components/stats/OccurrenceStats.svelte
+++ b/props/frontend/src/components/stats/OccurrenceStats.svelte
@@ -14,7 +14,7 @@
     occurrences: OccurrenceStatsRow[];
   }
 
-  let { occurrences }: Props = $props();
+  const { occurrences }: Props = $props();
 
   function pctParts(v: number): { integer: string; fraction: string } {
     const [integer, fraction] = (v * 100).toFixed(1).split(".");

--- a/props/frontend/src/components/stats/SummaryCards.svelte
+++ b/props/frontend/src/components/stats/SummaryCards.svelte
@@ -7,7 +7,7 @@
     data: OverviewResponse;
   }
 
-  let { data }: Props = $props();
+  const { data }: Props = $props();
 
   // Find best definition by valid whole-snapshot recall (preserves full StatsWithCI)
   function findBestDefinition(): { def: DefinitionRow; recall_stats: StatsWithCI } | null {

--- a/props/frontend/src/lib/CritiqueIssueLink.svelte
+++ b/props/frontend/src/lib/CritiqueIssueLink.svelte
@@ -11,7 +11,7 @@
     displayText?: string; // Override default issueId display
   }
 
-  let { runId, issueId, displayText }: Props = $props();
+  const { runId, issueId, displayText }: Props = $props();
 
   const text = $derived(displayText ?? issueId);
 </script>

--- a/props/frontend/src/lib/DefinitionIdLink.svelte
+++ b/props/frontend/src/lib/DefinitionIdLink.svelte
@@ -7,7 +7,7 @@
     display_name?: string | null;
   }
 
-  let { id, display_name }: Props = $props();
+  const { id, display_name }: Props = $props();
 </script>
 
 <a

--- a/props/frontend/src/lib/ExampleLink.svelte
+++ b/props/frontend/src/lib/ExampleLink.svelte
@@ -13,7 +13,7 @@
     example: Example;
   }
 
-  let { example }: Props = $props();
+  const { example }: Props = $props();
 
   const displayText = $derived(
     example.kind === "whole_snapshot"

--- a/props/frontend/src/lib/FileLink.svelte
+++ b/props/frontend/src/lib/FileLink.svelte
@@ -11,7 +11,7 @@
     displayText?: string; // Override default filePath display
   }
 
-  let { snapshotSlug, filePath, displayText }: Props = $props();
+  const { snapshotSlug, filePath, displayText }: Props = $props();
 
   const text = $derived(displayText ?? filePath);
 </script>

--- a/props/frontend/src/lib/IssueIdLink.svelte
+++ b/props/frontend/src/lib/IssueIdLink.svelte
@@ -12,7 +12,7 @@
     displayText?: string; // Override default issueId display
   }
 
-  let { snapshotSlug, issueId, kind, displayText }: Props = $props();
+  const { snapshotSlug, issueId, kind, displayText }: Props = $props();
 
   const text = $derived(displayText ?? issueId);
 </script>

--- a/props/frontend/src/lib/OccurrenceLink.svelte
+++ b/props/frontend/src/lib/OccurrenceLink.svelte
@@ -13,7 +13,7 @@
     displayText?: string; // Override default "{issueId}/{occurrenceId}" display
   }
 
-  let { snapshotSlug, issueId, occurrenceId, filePath, displayText }: Props = $props();
+  const { snapshotSlug, issueId, occurrenceId, filePath, displayText }: Props = $props();
 
   const urlPath = $derived.by(() => {
     const url = `/snapshots/${snapshotSlug}/${issueId}/${occurrenceId}`;

--- a/props/frontend/src/lib/RunIdLink.svelte
+++ b/props/frontend/src/lib/RunIdLink.svelte
@@ -9,7 +9,7 @@
     id: string;
   }
 
-  let { id }: Props = $props();
+  const { id }: Props = $props();
 </script>
 
 <a

--- a/props/frontend/src/lib/SnapshotLink.svelte
+++ b/props/frontend/src/lib/SnapshotLink.svelte
@@ -10,7 +10,7 @@
     showFull?: boolean; // Show full slug instead of first component
   }
 
-  let { slug, showFull = false }: Props = $props();
+  const { slug, showFull = false }: Props = $props();
 
   const displayText = $derived(showFull ? slug : formatSnapshotSlug(slug));
 </script>

--- a/props/frontend/src/pages/DefinitionDetailPage.svelte
+++ b/props/frontend/src/pages/DefinitionDetailPage.svelte
@@ -5,7 +5,7 @@
   interface Props {
     definitionId: string;
   }
-  let { definitionId }: Props = $props();
+  const { definitionId }: Props = $props();
 
   let definition: DefinitionDetailResponse | null = $state(null);
   let loading = $state(true);

--- a/props/frontend/src/pages/ExamplesPage.svelte
+++ b/props/frontend/src/pages/ExamplesPage.svelte
@@ -7,7 +7,7 @@
     initialData?: ExampleDetailResponse;
   }
 
-  let { initialData }: Props = $props();
+  const { initialData }: Props = $props();
 
   // svelte-ignore state_referenced_locally
   let example: ExampleDetailResponse | null = $state(initialData ?? null);

--- a/props/frontend/src/pages/OverviewPage.svelte
+++ b/props/frontend/src/pages/OverviewPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, getContext } from "svelte";
+  import { SvelteURLSearchParams } from "svelte/reactivity";
   import { goto } from "$lib/router";
   import type { RunModalPrefill } from "$lib/types";
   import { fetchOverview, fetchCoverage, type OverviewResponse, type CoverageResponse } from "$lib/api/client";
@@ -16,7 +17,7 @@
     initialData?: OverviewResponse;
   }
 
-  let { initialData }: Props = $props();
+  const { initialData }: Props = $props();
 
   // svelte-ignore state_referenced_locally
   let overview: OverviewResponse | null = $state(initialData ?? null);
@@ -75,7 +76,7 @@
   });
 
   function handleNavigateToRuns(filters: RunModalPrefill) {
-    const params = new URLSearchParams();
+    const params = new SvelteURLSearchParams();
     if (filters.definitionId) params.set("definition", filters.definitionId);
     if (filters.split) params.set("split", filters.split);
     if (filters.kind) params.set("kind", filters.kind);

--- a/props/frontend/src/pages/RunDetailPage.svelte
+++ b/props/frontend/src/pages/RunDetailPage.svelte
@@ -4,7 +4,7 @@
   interface Props {
     runId: string;
   }
-  let { runId }: Props = $props();
+  const { runId }: Props = $props();
 </script>
 
 {#if runId}

--- a/props/frontend/src/pages/SnapshotDetailPage.svelte
+++ b/props/frontend/src/pages/SnapshotDetailPage.svelte
@@ -3,8 +3,20 @@
   import { toast } from "svelte-sonner";
   import { splitBadgeClass } from "$lib/colors";
   import { formatLocationAnchor } from "$lib/formatters";
-  import type { SnapshotDetailResponse, FileContentResponse, FileTreeResponse, ClusterResponse } from "$lib/api/client";
-  import { fetchSnapshotDetail, fetchSnapshotTree, fetchSnapshotFile, fetchSnapshotClusters } from "$lib/api/client";
+  import type {
+    SnapshotDetailResponse,
+    FileContentResponse,
+    FileTreeResponse,
+    ClusterResponse,
+    OccurrenceStatsRow,
+  } from "$lib/api/client";
+  import {
+    fetchSnapshotDetail,
+    fetchSnapshotTree,
+    fetchSnapshotFile,
+    fetchSnapshotClusters,
+    fetchOccurrenceStats,
+  } from "$lib/api/client";
   import FileTree from "$components/FileTree.svelte";
   import FileViewer from "$components/FileViewer.svelte";
   import TabButton from "$components/TabButton.svelte";
@@ -14,8 +26,6 @@
   import OccurrenceLink from "$lib/OccurrenceLink.svelte";
   import CreditBadge from "$components/stats/CreditBadge.svelte";
   import OccurrenceStats from "$components/stats/OccurrenceStats.svelte";
-  import { fetchOccurrenceStats } from "$lib/api/client";
-  import type { OccurrenceStatsRow } from "$lib/api/client";
   import { createExpansionState } from "$lib/expansionState.svelte";
 
   interface Props {
@@ -23,7 +33,7 @@
     initialSnapshot?: SnapshotDetailResponse;
     initialTree?: FileTreeResponse;
   }
-  let { slug, initialSnapshot, initialTree }: Props = $props();
+  const { slug, initialSnapshot, initialTree }: Props = $props();
 
   // Parse the slug into components.
   // Snapshot slugs are "org/date" (2 parts), optionally followed by issueId/occurrenceId.
@@ -50,7 +60,7 @@
   let selectedFile: FileContentResponse | null = $state(null);
   let loadingFile = $state(false);
   let occurrenceStats: OccurrenceStatsRow[] = $state([]);
-  let occurrenceStatsMap = $derived(new Map(occurrenceStats.map((o) => [`${o.tp_id}:${o.occurrence_id}`, o])));
+  const occurrenceStatsMap = $derived(new Map(occurrenceStats.map((o) => [`${o.tp_id}:${o.occurrence_id}`, o])));
   let clusters: ClusterResponse[] = $state([]);
 
   async function loadData() {

--- a/props/frontend/src/pages/SnapshotsPage.svelte
+++ b/props/frontend/src/pages/SnapshotsPage.svelte
@@ -8,7 +8,7 @@
     initialData?: SnapshotsResponse["snapshots"];
   }
 
-  let { initialData }: Props = $props();
+  const { initialData }: Props = $props();
 
   // svelte-ignore state_referenced_locally
   let snapshots: SnapshotsResponse["snapshots"] = $state(initialData ?? []);


### PR DESCRIPTION
Part of making the eslint aspect a hard build gate (the `--@aspect_rules_lint//lint:fail_on_violation` flag is flipped in a final PR once every project is clean). `props/frontend` is now **eslint-clean (0 errors)**.

- **`prefer-const`:** Svelte 5 `$props()`/`$derived` destructuring and other never-reassigned bindings → `const` (43 declarations across 38 files).
- **`svelte/require-each-key`:** add keys to `{#each}` (LLMRequestSection, LLMResponseSection, CoverageHeatmap).
- **`svelte/no-unnecessary-state-wrap`:** `SvelteSet` is already reactive — drop the redundant `$state()` wrap (FileViewer, FileTree).
- **`svelte/prefer-svelte-reactivity`:** `URLSearchParams` → `SvelteURLSearchParams` (OverviewPage).
- **`@typescript-eslint/consistent-type-imports`:** inline `import()` type → `import type { Snippet }` (TabButton).
- **`import/no-duplicates`:** merge the duplicate `$lib/api/client` imports (SnapshotDetailPage).

`svelte-check` and all 14 props visual tests pass.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_