### PR TITLE
cluster/forgejo: add upgrade remediation to HelmRelease

### DIFF
--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -20,6 +20,9 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    remediation:
+      retries: 3 # Retry transient upgrade failures (e.g. slow S3 backend readiness) instead of going Stalled
   chart:
     spec:
       chart: forgejo


### PR DESCRIPTION
## What

Adds `upgrade.remediation.retries: 3` to the forgejo HelmRelease, mirroring the
existing `install.remediation.retries: 3`.

## Why

The forgejo HelmRelease only declared **install** remediation, so a single failed
**upgrade** goes straight to `Stalled (RetriesExceeded)` with no auto-retry.

That's exactly what wedged the props-on-Forgejo rollout: the S3-storage upgrade
(adding `STORAGE_TYPE=minio` → SeaweedFS S3) made forgejo crash-loop on startup
(`exit 1`, ~34×) while its minio/S3 backend wasn't yet reachable. Helm's 15m wait
timed out (`context deadline exceeded` → `UpgradeFailed` → `Stalled`), and the
release stayed stalled **even though the pod recovered on its own ~2h later** and
is now `1/1 Running` healthy.

Because the `forgejo` Kustomization has `wait: true` with a HelmRelease health
check, the stalled release fails that check, which blocks `forgejo-props` (the
Terraform CR that provisions the props registry user) and, transitively, the
`props` app rollout.

## Effect

- **Unblocks now**: merging this bumps the HelmRelease generation, which clears the
  `Stalled` state and triggers a fresh upgrade attempt — it should succeed
  immediately since the pod is already healthy.
- **Hardens**: future transient upgrade failures (e.g. slow S3 backend readiness)
  retry instead of permanently wedging the release.

Note: this addresses the Flux-layer stall. The deeper "forgejo started before its
S3 backend was serving" ordering is separate; the `forgejo` Kustomization already
`dependsOn` `seaweedfs-forgejo-bucket` + `seaweedfs-secrets`.

https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B)_