### PR TITLE
ruff: fix bazel-out first-party detection + neutralize EXE002 artifact

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -85,7 +85,13 @@ ignore = [
     "PLR0911",  # too many returns
     "PLR0913",  # too many arguments - often leads to unhelpful refactors
     "B904",     # raise from e
-    "E501"      # line length (formatter handles wrapping)
+    "E501",     # line length (formatter handles wrapping)
+    # EXE002 (file is executable but has no shebang): the lint *aspect* runs ruff on
+    # bazel-out copies, which Bazel marks executable, so EXE002 fires on essentially
+    # every Python file regardless of the source permission bit. Real source files are
+    # non-executable, so pre-commit (which lints the actual tree) never triggers this
+    # and loses no signal. The rest of the EXE group (shebang presence/content) is kept.
+    "EXE002",
 ]
 
 # Avoid conflicts between ruff-format and trailing-comma rules
@@ -147,6 +153,21 @@ known-first-party = [
     "tana",
     "tests",  # test packages (until colocated under main packages)
     "wt",
+    # This list must stay COMPLETE: the lint aspect runs ruff from the bazel exec
+    # root, where ruff cannot auto-detect first-party packages (it only sees
+    # bazel-out/ copies), so any first-party top-level package missing here gets its
+    # imports mis-sorted into the third-party group, producing spurious I001. (When
+    # ruff runs from the repo root — e.g. pre-commit — auto-detection masks omissions.)
+    "agent_cli",
+    "aiquota",
+    "airlock",
+    "augur",
+    "cluster",
+    "mako_utils",
+    "nix",
+    "plaid_utils",
+    "skills",
+    "third_party",
 ]
 combine-as-imports = true
 # Compatible with format.skip-magic-trailing-comma

--- a/skills/info_gathering/evals/function_learning/function_learning.py
+++ b/skills/info_gathering/evals/function_learning/function_learning.py
@@ -34,10 +34,9 @@ from agent_framework import (
     MCPStdioTool,
     Message,
 )
-from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
+from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import stage_skill
 from skills.eval_infra.termination import terminate_when
@@ -52,6 +51,7 @@ from skills.info_gathering.evals.function_learning.result_types import (
 )
 from skills.info_gathering.evals.function_learning.scoring import EVAL_TIMEOUT_S, evaluate_program
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 from skills.skill_spec import SkillSpec
 
 logger = logging.getLogger(__name__)

--- a/skills/info_gathering/evals/function_learning/test_function_learning.py
+++ b/skills/info_gathering/evals/function_learning/test_function_learning.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import aiodocker
 import pytest_bazel
 from agent_framework import ChatResponse, Content, Message
-from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 
+from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import stage_skill
 from skills.info_gathering.evals.function_learning.function_learning import run_game

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/test_twenty_questions.py
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_bazel
 from agent_framework import ChatResponse, Content, Message
-from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 
+from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import stage_skill
 from skills.info_gathering.evals.replay_client import ReplayChatClient

--- a/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/agent_framework/twenty_questions.py
@@ -34,10 +34,9 @@ from agent_framework import (
     MCPStdioTool,
     MiddlewareTermination,
 )
-from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from skills.eval_infra.af_chat_client import build_model_client
+from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.eval_infra.eval_sandbox import eval_sandbox
 from skills.eval_infra.skill_staging import stage_skill
 from skills.eval_infra.termination import terminate_when
@@ -54,6 +53,7 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 from skills.skill_spec import SkillSpec
 
 logger = logging.getLogger(__name__)

--- a/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/crewai/twenty_questions.py
@@ -23,7 +23,6 @@ from crewai import Agent, Crew, Process, Task
 from crewai.tools import BaseTool
 from fastmcp.client import Client
 from pydantic import BaseModel, Field, PrivateAttr
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.types import BindMount
 from skills.eval_infra.docker_exec import scratch_exec_server
@@ -42,6 +41,7 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 logger = logging.getLogger(__name__)
 

--- a/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/langgraph/twenty_questions.py
@@ -33,7 +33,6 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel, Field
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import BindMount
@@ -53,6 +52,7 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 logger = logging.getLogger(__name__)
 

--- a/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/openai_agents/twenty_questions.py
@@ -26,7 +26,6 @@ from agents import (
 )
 from fastmcp.client import Client
 from mcp.types import TextContent
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import BindMount
@@ -46,6 +45,7 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 logger = logging.getLogger(__name__)
 

--- a/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
+++ b/skills/info_gathering/evals/twenty_questions/x/pydantic_ai/twenty_questions.py
@@ -20,7 +20,6 @@ from pydantic_ai.result import RunContext
 from pydantic_ai.toolsets import AbstractToolset
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 from pydantic_ai.toolsets.function import FunctionToolset
-from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 from mcp_infra.exec.docker.server import ContainerExecServer
 from mcp_infra.exec.docker.types import BindMount
@@ -40,6 +39,7 @@ from skills.info_gathering.evals.twenty_questions.x.shared.cli import (
 )
 from skills.info_gathering.evals.twenty_questions.x.shared.output import run_output_paths, save_summary
 from skills.info_gathering.evals.twenty_questions.x.shared.variants import VARIANTS
+from skills.info_gathering.info_gathering_skill_spec import SPEC as INFO_GATHERING_SKILL_SPEC
 
 logger = logging.getLogger(__name__)
 

--- a/skills/reverse_engineer/evals/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/agent_framework/re_rollout.py
@@ -36,16 +36,16 @@ from typing import Literal
 
 from agent_framework import Agent, AgentSession, FunctionTool, Message
 from pydantic import BaseModel, Field
-from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
-from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
 
 from openai_utils.pydantic_strict_mode import OpenAIStrictModeBaseModel
 from skills.eval_infra.af_chat_client import build_model_client
+from skills.eval_infra.empty_skill.empty_skill_skill_spec import SPEC as EMPTY_SKILL_SPEC
 from skills.eval_infra.eval_prompt import compose_system_prompt
 from skills.eval_infra.eval_sandbox import INPUT_PATH, WORK_PATH, eval_sandbox
 from skills.eval_infra.skill_staging import stage_skill
 from skills.eval_infra.termination import terminate_when
 from skills.eval_infra.transcript import JsonlTranscriptProvider
+from skills.reverse_engineer.reverse_engineer_skill_spec import SPEC as REVERSE_ENGINEER_SKILL_SPEC
 from skills.skill_spec import SkillSpec
 from util.bazel.runfiles import get_required_path
 


### PR DESCRIPTION
Groundwork for making the lint aspect a hard build gate (`--@aspect_rules_lint//lint:fail_on_violation`). Running the ruff aspect with that flag surfaced **~1730 violations that are Bazel-sandbox artifacts, not real issues**:

- **`EXE002` (~1456):** the aspect runs ruff on `bazel-out` copies, which Bazel marks executable, so *"file is executable but has no shebang"* fires on nearly every Python file. Source files are `-rw-r--r--`, so pre-commit (which lints the real tree) never sees it. → ignore `EXE002` (the rest of the `EXE` group stays on).
- **`I001` (~275):** the aspect runs ruff from the bazel exec root, where ruff can't auto-detect first-party packages (it only sees `bazel-out/` paths). `known-first-party` was incomplete (missing `cluster`, `augur`, `airlock`, `skills`, …), so their imports got mis-sorted into third-party. → complete the list so isort is **cwd-independent**.

Both are config-only and leave pre-commit behavior identical. With the list complete, ruff then correctly flags **9 genuinely mis-grouped first-party imports** (skills evals — a `skills.…` import sitting in the third-party block), applied via `ruff --fix`.

After this, the full-repo aspect check drops from **~1390 failing targets to ~12** (9 real ruff + 3 study_casino eslint), handled in follow-ups.

⚠️ Note surfaced by this work: the lint aspect uses ruff **0.15.8** while pre-commit/devshell uses **0.14.6** — the remaining 9 ruff findings (`ASYNC240`/`UP047`/`PLW0108`) are flagged only by 0.15.8. Worth aligning the versions before the flag flip.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_