### PR TITLE
eslint: lint study_casino frontend (browser globals + JSX)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,4 +121,26 @@ export default [
       "react-hooks/exhaustive-deps": "error",
     },
   },
+
+  // ── study_casino frontend: browser React JS/JSX (no TypeScript) ──────────
+  // Not in projectGlobs (deliberately untyped JS), so it only matches js.recommended.
+  // Give it browser globals (fetch/window/document/WebSocket/...) and JSX parsing so
+  // no-undef doesn't misfire on browser builtins; the two react/jsx-uses-* rules stop
+  // no-unused-vars from flagging `React` and components that are only referenced in JSX.
+  {
+    files: ["x/study_casino/frontend/**/*.{js,jsx}"],
+    languageOptions: {
+      parserOptions: { ecmaVersion: "latest", sourceType: "module", ecmaFeatures: { jsx: true } },
+      globals: { ...globals.browser },
+    },
+    plugins: { react },
+    settings: { react: { version: "18.3" } },
+    rules: {
+      "react/jsx-uses-react": "error",
+      "react/jsx-uses-vars": "error",
+      // Match the repo's policy elsewhere (coreRules): unused vars are warnings, not
+      // build-blocking errors. js.recommended makes them errors by default.
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    },
+  },
 ];


### PR DESCRIPTION
Part of getting the whole repo green so the lint aspect can become a hard build gate.

`x/study_casino/frontend` is deliberately untyped JS, so it isn't in `projectGlobs` and only matched `js.configs.recommended` — which flagged:
- every browser builtin (`fetch`/`window`/`document`/`WebSocket`/`URL`/`URLSearchParams`/`setTimeout`/`location`) as `no-undef`, and
- without `react/jsx-uses-*`, `React` + components only referenced in JSX as `no-unused-vars`.

Adds a dedicated config block for `x/study_casino/frontend/**/*.{js,jsx}`: browser globals, JSX parsing, the two `react/jsx-uses-*` rules, and `no-unused-vars` as a **warning** (matching the repo's policy in `coreRules`, where `@typescript-eslint/no-unused-vars` is `warn`).

study_casino is now eslint-clean (0 errors).

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_