### PR TITLE
ruff: fix remaining 0.15.8 aspect findings + note first-party guard TODO

### DIFF
--- a/augur/fit/metrics_test.py
+++ b/augur/fit/metrics_test.py
@@ -235,7 +235,7 @@ class TestRollingOriginPredictiveScore:
 
     def test_unscored_model_records_reason(self) -> None:
         historical = _toy_historical(20, mu=np.array([0.0]), sigma=np.array([0.01]), seed=22)
-        result = rolling_origin_predictive_score(lambda: _UnscoredModel(), historical, min_train=5, refit_every=1)
+        result = rolling_origin_predictive_score(_UnscoredModel, historical, min_train=5, refit_every=1)
         assert isinstance(result, UnscoredRollingOriginResult)
         assert "returned None" in result.unscored_reason
 

--- a/plaid_utils/sync.py
+++ b/plaid_utils/sync.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import Any, Protocol, TypeVar, cast
+from typing import Any, Protocol, cast
 from uuid import UUID
 
 from plaid.exceptions import ApiException as PlaidApiException
@@ -49,9 +49,6 @@ class PlaidApiLike(Protocol):
     def investments_holdings_get(self, request: InvestmentsHoldingsGetRequest, /) -> object: ...
     def investments_transactions_get(self, request: InvestmentsTransactionsGetRequest, /) -> object: ...
     def liabilities_get(self, request: LiabilitiesGetRequest, /) -> object: ...
-
-
-_PlaidRequestT = TypeVar("_PlaidRequestT", bound=PlaidRequestLike)
 
 
 @dataclass(frozen=True)
@@ -269,13 +266,13 @@ async def _fetch_investment_transactions(
     return out
 
 
-async def _call(
+async def _call[PlaidRequestT: PlaidRequestLike](
     api: PlaidApiLike,
     storage: PlaidLinkStorage,
     run_id: UUID,
     endpoint: str,
-    call: Callable[[_PlaidRequestT], object],
-    request: _PlaidRequestT,
+    call: Callable[[PlaidRequestT], object],
+    request: PlaidRequestT,
     item_id: str,
 ) -> dict[str, Any]:
     started = time.monotonic()

--- a/ruff.toml
+++ b/ruff.toml
@@ -123,7 +123,13 @@ default-section = "third-party"
 # Force third-party for packages that have same-named directories in repo
 known-third-party = ["ansible", "docker"]
 # First-party = our workspace packages (ruff uses heuristics otherwise)
-# TODO: Auto-generate this list from Bazel once bazelized
+# TODO(first-party guard): add a CI/pre-commit check that fails when this list drifts
+#   — i.e. a top-level Python package is missing here, or a first-party import root
+#   collides with a third-party import name (from devinfra/gazelle_python.yaml). It
+#   can't be a hermetic bazel test: genquery's `scope` rejects `//...` so it can't
+#   enumerate all py targets, and a test sandbox can't glob the tree. A pre-commit /
+#   `bazel run` validator that scans the tree (or runs `bazel query`) is the shape.
+#   Until then, a missing entry surfaces as a (cryptic) bazel-out I001 from the lint aspect.
 known-first-party = [
     "devinfra",
     "util",

--- a/skills/eval_infra/eval_sandbox.py
+++ b/skills/eval_infra/eval_sandbox.py
@@ -22,6 +22,7 @@ Usage:
         await agent.run(...)
 """
 
+import asyncio
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -71,13 +72,13 @@ async def eval_sandbox(
     The container has host networking, proxy env wired, and `cwd`/`user`/`env`
     fields hidden from the model.
     """
-    workspace.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(workspace.mkdir, parents=True, exist_ok=True)
     binds: list[BindMount] = [
-        BindMount(host_path=skill.files_path.resolve(), container_path=SKILL_PATH, mode="ro"),
-        BindMount(host_path=workspace.resolve(), container_path=WORK_PATH, mode="rw"),
+        BindMount(host_path=await asyncio.to_thread(skill.files_path.resolve), container_path=SKILL_PATH, mode="ro"),
+        BindMount(host_path=await asyncio.to_thread(workspace.resolve), container_path=WORK_PATH, mode="rw"),
     ]
     if inputs is not None:
-        binds.append(BindMount(host_path=inputs.resolve(), container_path=INPUT_PATH, mode="ro"))
+        binds.append(BindMount(host_path=await asyncio.to_thread(inputs.resolve), container_path=INPUT_PATH, mode="ro"))
 
     config = ContainerExecServerConfig(
         image=image,

--- a/skills/reverse_engineer/evals/agent_framework/re_rollout.py
+++ b/skills/reverse_engineer/evals/agent_framework/re_rollout.py
@@ -134,7 +134,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     skill_on = args.skill == "on"
     suffix = "skill_on" if skill_on else "skill_off"
     out_dir: Path = args.output_dir
-    out_dir.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
 
     workspace = out_dir / f"work_{suffix}"
     transcript_path = out_dir / f"transcript_{suffix}.jsonl"

--- a/x/grocy_mcp/eval/run.py
+++ b/x/grocy_mcp/eval/run.py
@@ -157,7 +157,7 @@ async def run_grocy_eval(
     *, case: EvalCase, api: str, model: str, grocy_base_url: str, output_dir: Path, base_url: str | None = None
 ) -> EvalResult:
     """Run one eval case: seed → task → postmortem → snapshot."""
-    output_dir.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
     transcript_path = output_dir / "transcript.jsonl"
     summary_path = output_dir / "summary.json"
     final_state_path = output_dir / "final_state.json"


### PR DESCRIPTION
The lint aspect runs ruff **0.15.8** (newer than pre-commit's 0.14.6), so it flags findings pre-commit doesn't. Fixing them so the aspect is clean (toward the `fail_on_violation` flag flip):

- **PLW0108** (`augur/fit/metrics_test`): `lambda: _UnscoredModel()` → pass the class directly (zero-arg factory).
- **UP047** (`plaid_utils/sync`): `_call` → PEP-695 inline generic `_call[_PlaidRequestT: PlaidRequestLike]`; drop the module-level `TypeVar`.
- **ASYNC240 ×5** (`skills/eval_infra`, `skills/reverse_engineer`, `x/grocy_mcp`): async eval/setup funcs called blocking `Path.mkdir()`/`.resolve()` → wrap in `asyncio.to_thread(...)` (keeps `pathlib.Path` return type, no anyio churn).

Also leaves a **TODO in `ruff.toml`** for a first-party-list drift guard (a missing top-level package, or a first-party↔third-party name clash, should fail CI). I investigated `genquery`, but its `scope` can't be `//...` and a hermetic bazel test can't enumerate the tree, so it's deferred to a pre-commit/`bazel run` validator.

**Validation:** aspect (0.15.8) reports 0 ruff errors on these packages; pre-commit (0.14.6) and the 24 affected tests pass.

⚠️ As noted, the aspect's ruff (0.15.8) vs pre-commit's (0.14.6) version gap remains — worth aligning before the flag flip so the gate and local dev enforce the same rules.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_