### PR TITLE
augur: fix mypy break in calibration_report (type price_clients dict)

### DIFF
--- a/augur/calibration/calibration_report.py
+++ b/augur/calibration/calibration_report.py
@@ -24,7 +24,7 @@ from augur.calibration.calibration import mark_fan, run_calibration
 from augur.calibration.catalog import MarketCatalog
 from augur.calibration.kalshi import KalshiClient
 from augur.calibration.manifold import ManifoldClient
-from augur.calibration.platform import Platform
+from augur.calibration.platform import Platform, PriceClient
 from augur.calibration.polymarket import PolymarketClient
 from augur.model.exogenous import ExogenousSamplingRequest
 from augur.model.private_equity_bundle import PrivateEquityFloatChannel
@@ -41,9 +41,7 @@ def main(argv: list[str] | None = None) -> int:
 
     augur_config = load_augur_config(args.config)
     preset_id = args.preset or augur_config.default_model_id
-    print(
-        f"loaded config: presets={list(augur_config.models)}, default={augur_config.default_model_id}"
-    )
+    print(f"loaded config: presets={list(augur_config.models)}, default={augur_config.default_model_id}")
     print(f"running preset: {preset_id}")
 
     catalog_config = augur_config.calibration_catalog
@@ -64,7 +62,7 @@ def main(argv: list[str] | None = None) -> int:
     sampled = model.sample(sampling)
     bundle = sampled.private_equity
 
-    price_clients = {
+    price_clients: dict[Platform, PriceClient] = {
         Platform.MANIFOLD: ManifoldClient(),
         Platform.POLYMARKET: PolymarketClient(),
         Platform.KALSHI: KalshiClient(),


### PR DESCRIPTION
## What & why

`bbr build //...` is currently **red on devel** on a mypy error in
`augur/calibration/calibration_report.py` (unrelated to any lint/ruff/eslint
change — surfaced while verifying the whole-repo lint gate):

```
calibration_report.py:79: error: Argument "price_clients" to "run_calibration" has
  incompatible type "dict[Platform, object]"; expected "Mapping[Platform, PriceClient]"  [arg-type]
calibration_report.py:84: error: "object" has no attribute "close"  [attr-defined]
```

mypy infers the literal

```python
price_clients = {
    Platform.MANIFOLD: ManifoldClient(),
    Platform.POLYMARKET: PolymarketClient(),
    Platform.KALSHI: KalshiClient(),
}
```

as `dict[Platform, object]` — the **nominal** join of three unrelated concrete
client classes — even though all three structurally satisfy the `PriceClient`
protocol (`get_market` + `close`). That breaks both the
`run_calibration(price_clients=...)` arg-type check and the `client.close()`
call in the `finally` block.

## Fix

One-line explicit annotation so each value is checked against the protocol:

```python
price_clients: dict[Platform, PriceClient] = { ... }
```

No runtime behavior change. (ruff-format also collapsed an adjacent multi-line
`print(...)` that already fit on one line.)

## Validation (RBE)

- `bbr build //augur/calibration:calibration_report` — green (mypy aspect passes).
  Invocation `abab4488-a005-4c29-a1f0-f1ca1bb18571`.

`BAZEL_TEST_INVOCATIONS=none:` — type-only annotation on a `py_binary` with no
test target; verified via the mypy lint aspect.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_