### PR TITLE
bazel: make ruff + ESLint findings hard-fail the build (fail_on_violation)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,14 @@ build --@rules_python//python/config_settings:python_version=3.13
 build --aspects=//devinfra/lint:linters.bzl%ruff,//devinfra/lint:linters.bzl%mypy_aspect,//devinfra/lint:linters.bzl%eslint,@rules_rust//rust:defs.bzl%rust_clippy_aspect,@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --output_groups=+rules_lint_report,+mypy,+clippy_checks,+rustfmt_checks
 
+# Make ruff + ESLint findings HARD-FAIL the build instead of only populating the
+# rules_lint_report output group. This puts the rules_lint aspects on equal
+# footing with mypy/clippy/rustfmt (whose aspect actions already fail the build
+# directly): code that doesn't lint clean no longer bazel-builds. --config=nolint
+# still bypasses — it drops the rules_lint_report output group, so the
+# report-generating action that enforces this flag is never requested.
+build --@aspect_rules_lint//lint:fail_on_violation
+
 # Skip lint/typecheck. Bazel evaluates aspects lazily, so removing their
 # output groups prevents the aspect actions from running.
 build:nolint --output_groups=-rules_lint_report,-mypy,-clippy_checks,-rustfmt_checks


### PR DESCRIPTION
## What & why

Flip the `aspect_rules_lint` gate from **report-only** to **hard-fail**: add

```
build --@aspect_rules_lint//lint:fail_on_violation
```

to `.bazelrc`. Until now the ruff + ESLint aspects ran on every build but only
populated the `rules_lint_report` output group — a violation produced a report,
not a build failure. So things that didn't lint clean still `bazel build`-ed
(this is exactly how `settingsOpen is not defined` slipped through earlier:
esbuild bundled it and the visual test ran).

This puts the rules_lint aspects on equal footing with **mypy / clippy /
rustfmt**, whose aspect actions already hard-fail the build. Code that doesn't
lint clean no longer bazel-builds.

`--config=nolint` still bypasses for fast iterative builds — it drops the
`rules_lint_report` output group, so the report-generating action that enforces
this flag is never requested (the flag has nothing to act on).

## Why it's safe to flip now

This is the final step after the repo-wide lint cleanup landed:

- #1784, #1785, #1787, #1789, #1791, #1792 — ruff + ESLint fixes (and the
  completed `known-first-party` list that kills the bazel-exec-root `I001`
  false positives)
- #1793 — a pre-existing mypy break in `augur/calibration/calibration_report.py`,
  surfaced while verifying the whole tree

## Validation (RBE)

- `bbr build //... --@aspect_rules_lint//lint:fail_on_violation --keep_going`
  (before #1793 merged) — surfaced **zero** ruff/eslint violations across 3235
  targets; the only failure was the pre-existing mypy break, now fixed by #1793.
- `bbr build //...` on this branch (flag now applied by default via `.bazelrc`,
  rebased on top of #1793) — **green**, 0 failed targets. Invocation
  `80f8f217-ead7-4e2a-a32b-37eb86055226`.

## Follow-up (not in this PR)

Deferred per earlier discussion: the lint aspect's multitool **ruff 0.15.8** vs
the devshell/pre-commit **ruff 0.14.6** version skew. Worth aligning so
pre-commit and the bazel gate can't disagree on findings, but orthogonal to
this flip.

`BAZEL_TEST_INVOCATIONS=none:` — `.bazelrc` config-only change; verified by the
whole-repo `bbr build //...` above.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_