### PR TITLE
[LINT] eslint: promote unused-code rules to error (P1)

### DIFF
--- a/augur/frontend/app.tsx
+++ b/augur/frontend/app.tsx
@@ -20,7 +20,7 @@ import { CalibrationWorkspace } from "./calibration.tsx";
 import { BudgetWorkspace } from "./budget.tsx";
 import { AugurHeader, SharedControls } from "./header.tsx";
 import { RolloutResultsSkeleton, StatCardsSkeleton, ProductProjectionLoading } from "./skeleton.tsx";
-import { CurrencyDisplayProvider, useCurrencyDisplay, useVisibleEventKinds, useEventSelection } from "./hooks.ts";
+import { CurrencyDisplayProvider, useVisibleEventKinds, useEventSelection } from "./hooks.ts";
 import {
   METRIC_OPTIONS,
   productInputDefaults,
@@ -173,7 +173,6 @@ function RolloutResultsPanel({
   eventSelection,
   rolloutError,
 }) {
-  const { display: currencyDisplay } = useCurrencyDisplay();
   return (
     <section className="augur-panel overflow-hidden" aria-label="Cash projection workspace">
       <div className="border-b border-slate-200 px-4 py-3 dark:border-slate-700">

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -204,7 +204,7 @@ function LumpyPanel({ items, bucketsById }) {
   );
 }
 
-function TransactionsPanel({ bucketLabel, transactions }) {
+function TransactionsPanel({ transactions }) {
   if (!transactions) return <div className="px-4 py-6 text-sm augur-muted">Loading…</div>;
   if (!transactions.length) {
     return <div className="px-4 py-6 text-sm augur-muted">No transactions in this bucket.</div>;
@@ -414,7 +414,7 @@ export function BudgetWorkspace() {
               {bucketTxError ? (
                 <div className="augur-note-danger p-4 text-sm">Transactions failed: {bucketTxError}</div>
               ) : (
-                <TransactionsPanel bucketLabel={bucketsById.get(selectedBucketId)?.label} transactions={bucketTx} />
+                <TransactionsPanel transactions={bucketTx} />
               )}
             </section>
           )}

--- a/augur/frontend/fan_chart.tsx
+++ b/augur/frontend/fan_chart.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import { axisCoordinate, fanChartAxis, fanChartYearTicks, fmtAxisMetricValue, fmtMetricValue } from "./lib/chart.ts";
-import { FAN_PERCENTILES } from "./input_helpers.ts";
 import { useCurrencyDisplay } from "./hooks.ts";
 import {
   SELECTED_ROLLOUT_COLOR,
@@ -12,7 +11,7 @@ import {
   eventTitle,
 } from "./data_helpers.ts";
 
-function FanAxes({ left, top, plotWidth, plotHeight, height, x, y, yAxis, maxYear, metric }) {
+function FanAxes({ left, top, plotWidth, plotHeight, height, y, yAxis, maxYear, metric }) {
   return (
     <>
       {yAxis.ticks.map((value) => {
@@ -269,7 +268,6 @@ export function MetricFanChart({
           plotWidth={plotWidth}
           plotHeight={plotHeight}
           height={svgHeight}
-          x={x}
           y={y}
           yAxis={yAxis}
           maxYear={maxYear}

--- a/augur/frontend/forms.tsx
+++ b/augur/frontend/forms.tsx
@@ -1,28 +1,9 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React from "react";
 import { Button, Checkbox, NativeSelect } from "@mantine/core";
 import { NativeSelectField, NumberField } from "./lib/controls.tsx";
 import { clampInteger, fmtNumber, fmtUsd } from "./lib/format.ts";
-import { fmtMetricValue } from "./lib/chart.ts";
-import { AugurHeader } from "./header.tsx";
-import {
-  LIFECYCLE_KINDS,
-  LIFECYCLE_KINDS_BY_VALUE,
-  LIFECYCLE_KIND_FROM_CODE,
-  SELL_BUCKETS,
-  SELL_BUCKET_BY_CODE,
-  DEFAULT_SELL_ORDER_CODES,
-  METRIC_OPTIONS,
-  METRIC_BY_VALUE,
-  productInputDefaults,
-  encodeInputValue,
-  decodeInputValue,
-  sellOrderBuckets,
-  buildLifecycleEvents,
-  defaultLifecycleEvent,
-  nextLifecycleEventId,
-  FAN_PERCENTILES,
-} from "./input_helpers.ts";
-import { rolloutSliverColor, portfolioHasBucket, isPrivateSecurityPosition } from "./data_helpers.ts";
+import { LIFECYCLE_KINDS, SELL_BUCKETS, SELL_BUCKET_BY_CODE, defaultLifecycleEvent } from "./input_helpers.ts";
+import { portfolioHasBucket, isPrivateSecurityPosition } from "./data_helpers.ts";
 
 function firstSaleMonth(events) {
   let earliest = null;

--- a/augur/frontend/histogram.tsx
+++ b/augur/frontend/histogram.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useMemo, useRef } from "react";
 import { axisCoordinate, fanChartAxis, fmtAxisMetricValue, fmtMetricValue } from "./lib/chart.ts";
-import { fmtNumber } from "./lib/format.ts";
 import { FAN_PERCENTILES } from "./input_helpers.ts";
 import { useCurrencyDisplay } from "./hooks.ts";
 import {
   FAILED_ROLLOUT_COLOR,
-  SELECTED_ROLLOUT_COLOR,
   rolloutSliverColor,
   blendWithTeal,
   terminalHistogramBins,

--- a/augur/frontend/input_helpers.ts
+++ b/augur/frontend/input_helpers.ts
@@ -1,5 +1,4 @@
 import { clampInteger } from "./lib/format.ts";
-import { rowsFrom } from "./lib/frame.ts";
 
 // Sell-order is stored as a string of single-char bucket codes, in priority order. "pc" means
 // "sell public securities first, then crypto if needed"; "c" means crypto only; "" disables auto

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ const coreRules = {
   eqeqeq: ["error", "always", { null: "ignore" }],
   "no-console": ["warn", { allow: ["warn", "error"] }],
   "@typescript-eslint/consistent-type-imports": "error",
-  "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+  "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
   "no-unused-vars": "off",
   // TypeScript already resolves identifiers/types; eslint's no-undef misfires on type-only
   // names (e.g. `RequestInit`) and ambient globals, so defer to the compiler.
@@ -103,7 +103,7 @@ export default [
     },
     rules: {
       ...coreRules,
-      "svelte/no-unused-svelte-ignore": "warn",
+      "svelte/no-unused-svelte-ignore": "error",
     },
   },
 
@@ -138,9 +138,9 @@ export default [
     rules: {
       "react/jsx-uses-react": "error",
       "react/jsx-uses-vars": "error",
-      // Match the repo's policy elsewhere (coreRules): unused vars are warnings, not
-      // build-blocking errors. js.recommended makes them errors by default.
-      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      // Match the repo's policy elsewhere (coreRules): unused vars are build-blocking
+      // errors, with a leading-underscore escape hatch.
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
 ];

--- a/props/frontend/src/App.svelte
+++ b/props/frontend/src/App.svelte
@@ -2,7 +2,7 @@
   import "./app.css";
   import { onMount, setContext } from "svelte";
   import { Toaster } from "svelte-sonner";
-  import { pathname, resolve, goto, parseParams } from "$lib/router";
+  import { pathname, resolve, parseParams } from "$lib/router";
   import { captureTokenFromUrl, getToken, setToken, needsToken } from "$lib/stores/token";
   import RunTriggerModal from "$components/RunTriggerModal.svelte";
   import type { Split, ExampleKind } from "$lib/types";

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -133,8 +133,6 @@
     }
   }
 
-  let llmRequestsFetched = false;
-
   // Load LLM requests
   async function loadLLMRequests() {
     if (loadingLLMRequests) return;
@@ -142,7 +140,6 @@
     try {
       const response = await fetchLLMRequests(runId);
       llmRequests = response.requests;
-      llmRequestsFetched = true;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to load LLM requests";
       toast.error(message);

--- a/props/frontend/src/components/RunTriggerModal.svelte
+++ b/props/frontend/src/components/RunTriggerModal.svelte
@@ -225,7 +225,6 @@
     onclick={handleBackdropClick}
     onkeydown={handleKeydown}
   >
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="bg-white dark:bg-gray-800 rounded-lg shadow-xl dark:shadow-gray-950/50 p-6 w-full max-w-md max-h-[90vh] overflow-y-auto"
       role="document"

--- a/props/frontend/src/pages/SnapshotsPage.svelte
+++ b/props/frontend/src/pages/SnapshotsPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { goto, resolve } from "$lib/router";
+  import { goto } from "$lib/router";
   import { fetchSnapshots, type SnapshotsResponse } from "$lib/api/client";
   import { splitBadgeClass } from "$lib/colors";
 

--- a/x/study_casino/frontend/StudyView.jsx
+++ b/x/study_casino/frontend/StudyView.jsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from "react";
+import React from "react";
 
-import { COLORS, fmtClock, fmtHoursMin, getElapsedSec, StatCard, SUBJECTS, SectionTitle } from "./shared.jsx";
+import { COLORS, fmtClock, fmtHoursMin, StatCard, SUBJECTS, SectionTitle } from "./shared.jsx";
 
 export function StudyView({
   offline,

--- a/x/study_casino/frontend/shared.jsx
+++ b/x/study_casino/frontend/shared.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useMemo } from "react";
+import React, { useEffect, useState } from "react";
 
 export const SUBJECTS = [
   "Biochemistry",

--- a/x/study_casino/frontend/study_casino.jsx
+++ b/x/study_casino/frontend/study_casino.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { SyncIcon } from "./SyncIcon.jsx";
 import { useCasino } from "./use_casino.js";
 import { useUrlState } from "./use_url_state.js";
-import { COLORS, SUBJECTS, fmtClock, fmtHoursMin, getElapsedSec } from "./shared.jsx";
+import { COLORS, SUBJECTS, fmtClock, getElapsedSec } from "./shared.jsx";
 import { StudyView } from "./StudyView.jsx";
 import { PrizesView } from "./PrizesView.jsx";
 import { StatsView } from "./StatsView.jsx";


### PR DESCRIPTION
## What & why

**P1** of `plans/eslint_tightening.md` (#1795). Now that the lint gate
(`--@aspect_rules_lint//lint:fail_on_violation`, #1794) is on, `warn`-level
ESLint rules are invisible — warnings don't fail the build, so they print to a
log nobody reads. This promotes the dead-code rules to `error` so unused
imports/vars actually block the build, matching ruff's `F401`/`F841` policy:

| Rule | | |
|---|---|---|
| `@typescript-eslint/no-unused-vars` | `warn` → `error` | coreRules (TS + Svelte) |
| `svelte/no-unused-svelte-ignore` | `warn` → `error` | |
| `no-unused-vars` (study_casino) | `warn` → `error` | |

The `^_` args/vars ignore escape hatch is unchanged; only severity moves.

## Violations fixed (pure dead-code removal, no behavior change)

- **`augur/frontend/forms.tsx`** — 18 dead imports (React hooks + chart / header
  / input_helpers / data_helpers symbols left over from a refactor).
- **`augur/frontend/{histogram,fan_chart,input_helpers,budget,app}`** — stray
  unused imports; dropped the unused `x` prop from `FanAxes` and `bucketLabel`
  from `TransactionsPanel` (at both the destructure **and** the call site);
  dropped the unused `useCurrencyDisplay()` binding + now-orphaned import.
- **`props/frontend`** — unused `goto`/`resolve` router imports; the write-only
  `llmRequestsFetched` flag in `RunDetail`; a stale `svelte-ignore` in
  `RunTriggerModal` (the a11y warning it suppressed no longer fires).
- **`x/study_casino/frontend`** — unused React-hook + `shared.jsx` imports.

## Validation (RBE)

- `bbr build //{props,augur,x/study_casino,...}/frontend/...` — green, ESLint
  gate passes (0 errors) across all frontends.
- `bbr test //augur/frontend:tsc_test //props/frontend:svelte_check_test
  //augur/frontend:sanity_bands_test //props/frontend:router_test` — all pass;
  confirms the removals don't break `tsc` / `svelte-check`.

`BAZEL_TEST_INVOCATIONS=buildbuddy:9160bb18-d851-4379-8e52-df36d19b209f`

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_