### PR TITLE
[LINT] eslint: enable typescript-eslint recommended set (P2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,8 +39,18 @@ const importRules = {
   "import/no-duplicates": "error",
 };
 
+// typescript-eslint's recommended rule set (ban-ts-comment, no-explicit-any,
+// no-empty-object-type, no-unsafe-function-type, prefer-as-const, …), pulled
+// from the already-present plugin's eslintrc `recommended` config. Its `.rules`
+// also turns off the core rules it supersedes (no-array-constructor,
+// no-unused-vars, no-unused-expressions). We layer it under coreRules so our
+// explicit overrides (no-unused-vars with the `^_` pattern, etc.) win; `no-undef`
+// is already disabled below for the type-name positives TypeScript itself catches.
+const tsRecommendedRules = tseslint.configs.recommended.rules;
+
 // Shared quality + TS rules applied everywhere
 const coreRules = {
+  ...tsRecommendedRules,
   "prefer-const": "error",
   eqeqeq: ["error", "always", { null: "ignore" }],
   "no-console": ["warn", { allow: ["warn", "error"] }],

--- a/props/frontend/src/components/stats/CoverageHeatmap.svelte
+++ b/props/frontend/src/components/stats/CoverageHeatmap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Chart, Tooltip, LinearScale } from "chart.js";
+  import { Chart, Tooltip, LinearScale, type ChartDataset, type ScriptableContext, type TooltipItem } from "chart.js";
   import { MatrixController, MatrixElement } from "chartjs-chart-matrix";
   import { formatDigest } from "../../lib/formatters";
 
@@ -47,15 +47,19 @@
     }))
   );
 
+  // The matrix data points carry a custom `best` field beyond chartjs-chart-matrix's
+  // own data-point type, so each retrieved point is cast to this local shape.
+  type MatrixPoint = { x: number; y: number; v: number; best: boolean };
+
   onMount(() => {
     chart = new Chart(canvas, {
       type: "matrix",
       data: {
         datasets: [
           {
-            data: matrixData as any,
-            backgroundColor(ctx: any) {
-              const v = ctx.dataset.data[ctx.dataIndex];
+            data: matrixData as unknown as ChartDataset["data"],
+            backgroundColor(ctx: ScriptableContext<"matrix">) {
+              const v = ctx.dataset.data[ctx.dataIndex] as unknown as MatrixPoint;
               if (!v) return "rgba(243, 244, 246, 1)"; // gray-100
               if (v.best) {
                 // Green intensity based on recall
@@ -65,11 +69,11 @@
               // Light gray for evaluated-but-not-best
               return `rgba(209, 213, 219, ${0.3 + v.v * 0.5})`;
             },
-            width: ({ chart }: any) => {
+            width: ({ chart }: { chart: Chart }) => {
               const xScale = chart.scales.x;
               return Math.max(xScale.width / (examples.length + 1) - 1, 4);
             },
-            height: ({ chart }: any) => {
+            height: ({ chart }: { chart: Chart }) => {
               const yScale = chart.scales.y;
               return Math.max(yScale.height / (definitions.length + 1) - 1, 12);
             },
@@ -83,8 +87,8 @@
           tooltip: {
             callbacks: {
               title: () => "",
-              label(ctx: any) {
-                const d = ctx.dataset.data[ctx.dataIndex];
+              label(ctx: TooltipItem<"matrix">) {
+                const d = ctx.dataset.data[ctx.dataIndex] as unknown as MatrixPoint;
                 const def = definitions[d.y];
                 const ex = examples[d.x];
                 const slug = ex.snapshot_slug.length > 20 ? ex.snapshot_slug.slice(0, 20) + "…" : ex.snapshot_slug;
@@ -114,8 +118,8 @@
             min: -0.5,
             max: definitions.length - 0.5,
             ticks: {
-              callback: (val: any) => {
-                const def = definitions[Math.round(val)];
+              callback: (val: number | string) => {
+                const def = definitions[Math.round(Number(val))];
                 return def ? formatDigest(def.image_digest) : "";
               },
               autoSkip: false,
@@ -136,7 +140,7 @@
 
   $effect(() => {
     if (chart) {
-      (chart.data.datasets[0].data as any) = matrixData;
+      chart.data.datasets[0].data = matrixData as unknown as ChartDataset["data"];
       chart.update("none");
     }
   });

--- a/props/frontend/src/pages/SnapshotDetailPage.svelte
+++ b/props/frontend/src/pages/SnapshotDetailPage.svelte
@@ -178,7 +178,7 @@
       return false;
     };
 
-    searchInIssues(snap.true_positives) || searchInIssues(snap.false_positives);
+    if (!searchInIssues(snap.true_positives)) searchInIssues(snap.false_positives);
   }
 
   // Scroll to target after file finishes loading


### PR DESCRIPTION
## What & why

**P2** of `plans/eslint_tightening.md` (#1795). Enables `@typescript-eslint`'s
**recommended** rule set across the TS + Svelte blocks, replacing the two
hand-picked `@typescript-eslint/*` rules. The build now enforces
`ban-ts-comment`, `no-explicit-any`, `no-empty-object-type`,
`no-unsafe-function-type`, `prefer-as-const`, `no-misused-new`,
`no-unused-expressions`, and the rest of the set.

## No new dependency (avoids a hoist conflict)

Pulled from the already-present `@typescript-eslint/eslint-plugin`'s eslintrc
`recommended.rules` rather than the `typescript-eslint` meta-package. The
meta-package bundles its own plugin copy at a newer patch (8.60 vs the repo's
8.58), which trips `aspect_rules_js`'s public-hoist conflict check (two versions
hoisted to `/node_modules/@typescript-eslint/eslint-plugin`). The plugin's
`recommended.rules` is self-contained (TS rules + the core-rule-off pairs it
supersedes), so **no `package.json` / `pnpm-lock.yaml` / BUILD change** is
needed. Our explicit `coreRules` overrides (the `^_` `no-unused-vars` pattern,
`no-undef` off) still win — they're spread after it.

## Violations fixed (8, all in props frontend)

- **`CoverageHeatmap.svelte`** — 7 `no-explicit-any`. chart.js's matrix types
  are actually present (`ScriptableContext<"matrix">`, `TooltipItem<"matrix">`),
  so the `any`s were masking real types. Replaced with the chart.js context
  types and cast each retrieved point to a local `MatrixPoint` (the points carry
  a custom `best` field beyond the plugin's data-point type).
- **`SnapshotDetailPage.svelte`** — 1 `no-unused-expressions`. The short-circuit
  `searchInIssues(tp) || searchInIssues(fp)` statement (both calls have side
  effects) became `if (!searchInIssues(tp)) searchInIssues(fp)`.

## Validation (RBE)

- `bbr build //{props,augur,x/rspcache,x/agent_server,airlock,x/study_casino}/frontend/...`
  — eslint gate green across all six frontends.
- `bbr test //props/frontend:svelte_check_test //augur/frontend:tsc_test
  //props/frontend:router_test //augur/frontend:sanity_bands_test` — all pass
  (the chart.js retyping compiles under svelte-check).

`BAZEL_TEST_INVOCATIONS=buildbuddy:6183064e-118e-413a-8280-cff7c2b4dc4b`

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_