### PR TITLE
[LINT] augur: type-aware eslint test (no-floating-promises) — P3 prototype

### DIFF
--- a/augur/frontend/BUILD.bazel
+++ b/augur/frontend/BUILD.bazel
@@ -4,6 +4,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@npm_ducktape//:@tailwindcss/cli/package_json.bzl", tailwindcss_bin = "bin")
+load("@npm_ducktape//:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm_ducktape//:typescript/package_json.bzl", tsc_bin = "bin")
 load("@npm_ducktape//:vitest/package_json.bzl", vitest_bin = "bin")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
@@ -363,6 +364,31 @@ tsc_bin.tsc_test(
     ],
     chdir = package_name(),
     data = [
+        "sanity_bands.test.ts",
+        "tsconfig.json",
+        ":main_lib",
+        ":sanity_bands",
+        "//:node_modules",
+    ],
+    tags = ["lint"],
+)
+
+# Type-aware ESLint (no-floating-promises, no-misused-promises, await-thenable).
+# Runs as a whole-program test, not via the per-file lint-gate aspect: type-aware
+# rules need the full TS program (built from tsconfig.json), which only a
+# whole-package sandbox provides. Mirrors tsc_test's inputs. See P3 in
+# plans/eslint_tightening.md.
+eslint_bin.eslint_test(
+    name = "eslint_typed_test",
+    args = [
+        "--no-config-lookup",
+        "--config",
+        "eslint.typed.config.js",
+        ".",
+    ],
+    chdir = package_name(),
+    data = [
+        "eslint.typed.config.js",
         "sanity_bands.test.ts",
         "tsconfig.json",
         ":main_lib",

--- a/augur/frontend/eslint.typed.config.js
+++ b/augur/frontend/eslint.typed.config.js
@@ -1,0 +1,35 @@
+// Type-aware ESLint config for the augur frontend, run as a whole-program TEST
+// (//augur/frontend:eslint_typed_test) rather than via the per-file lint-gate
+// aspect. Type-aware rules (no-floating-promises, …) need the full TypeScript
+// program built from tsconfig.json, which the granular per-target gate aspect
+// can't provide; a test target gets the whole `:main_lib` closure + tsconfig in
+// one sandbox (mirrors how tsc_test runs). See plans/eslint_tightening.md (P3).
+
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  {
+    files: ["**/*.{ts,tsx}"],
+    // Inline `eslint-disable` directives in the source target the gate config's
+    // rules (e.g. react-hooks/exhaustive-deps); this secondary type-aware pass
+    // must not report them as unused.
+    linterOptions: { reportUnusedDisableDirectives: "off" },
+    languageOptions: {
+      parser: tsparser,
+      // projectService auto-discovers ./tsconfig.json and builds the program.
+      parserOptions: { projectService: true, ecmaVersion: "latest", sourceType: "module" },
+    },
+    // Register the same plugins the gate config uses so existing inline
+    // `eslint-disable` directives (e.g. react-hooks/exhaustive-deps) resolve.
+    // Only the type-aware rules below are enabled here.
+    plugins: { "@typescript-eslint": tseslint, react, "react-hooks": reactHooks },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
+    },
+  },
+];


### PR DESCRIPTION
## What

**P3 of `plans/eslint_tightening.md`** — proves type-aware ESLint works under
Bazel, and lands it for the augur frontend.

Type-aware typescript-eslint rules (`no-floating-promises`, …) need the **full
TS program**. The per-file lint-gate aspect can't provide that (each lint action
only sees one file + its declared deps), and building a program per action would
be very expensive. So this runs type-aware lint as a **whole-program test
target** — exactly how `tsc_test` / `svelte_check_test` already work.

`//augur/frontend:eslint_typed_test`:

- `eslint.typed.config.js` — `parserOptions.projectService` auto-discovers
  `tsconfig.json` and builds the program; enables `no-floating-promises`,
  `no-misused-promises`, `await-thenable`.
- Test target mirrors `tsc_test`'s inputs (`:main_lib` closure + `tsconfig.json`
  + `//:node_modules`, `chdir` into the package).
- Registers the gate's `react`/`react-hooks` plugins so existing inline
  `eslint-disable` directives resolve, and turns off unused-directive reporting
  (those directives target the gate config, not this secondary pass).

**augur passes clean** — no unhandled async.

## Why a test, not the gate

This is a different shape from P1/P2 (which are gate rules on `bazel build`).
Type-aware lint can't ride the per-file aspect, so it's a `bazel test` like
`tsc`. Documented in the BUILD comment + the plan.

## Rollout (follow-up PRs)

- **react/ts frontends** (`x/rspcache/admin_ui`, `airlock/frontend`) — reuse
  this pattern directly.
- **svelte frontends** (`props`, `x/agent_server/web`) — need type-aware-svelte
  wiring (`eslint-plugin-svelte` + the TS project service); a bigger lift,
  separate PR.

## Validation (RBE)

- `bbr test //augur/frontend:eslint_typed_test` — PASSED (23s). Confirms
  `projectService` builds the program under the Bazel sandbox and the three
  type-aware rules run with zero violations.

`BAZEL_TEST_INVOCATIONS=buildbuddy:012ab3e4-a21a-414c-bb83-564cf2b9c9ae`

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_