### PR TITLE
augur(frontend): escape apostrophe in budget.tsx (react/no-unescaped-entities)

### DIFF
--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -378,7 +378,7 @@ export function BudgetWorkspace() {
         {snapshot?.coverageStarts && (
           <div className="mt-2 text-[11px] augur-muted">
             Spend before <span className="font-semibold">{snapshot.coverageStarts}</span> is partial -- one or more
-            linked accounts didn't return earlier transactions. The selected window is clamped to that date for
+            linked accounts didn&apos;t return earlier transactions. The selected window is clamped to that date for
             consistency.
           </div>
         )}


### PR DESCRIPTION
## What

`augur/frontend/budget.tsx:381` has a literal `'` ("didn't") in JSX text, which
trips `react/no-unescaped-entities` (a react-recommended rule enforced by the
ESLint gate). **devel is currently red on it** — introduced with the recent
`augur(budget)` change. Escape as `&apos;` (renders identically, "didn't").

## Validation (RBE)

- `bbr build //augur/frontend:budget` — green (was failing the ESLint gate).

`BAZEL_TEST_INVOCATIONS=none:` — JSX text-escape; no behavior/visual change
(`&apos;` renders as `'`).

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_