### PR TITLE
[LINT] eslint: dedupe config (P4) — factor shared plugins/globals/settings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,13 @@ import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 
+// ── Shared building blocks (factored so the per-glob configs below stay DRY) ──
+const browserGlobals = { ...globals.browser };
+const tsPlugins = { "@typescript-eslint": tseslint, import: importPlugin };
+const reactSettings = { react: { version: "18.3" } };
+// Allow intentionally-unused identifiers/args when prefixed with `_`.
+const unusedVarsOptions = { argsIgnorePattern: "^_", varsIgnorePattern: "^_" };
+
 // All project source directories (add new TS/Svelte projects here)
 const projectGlobs = [
   "props/frontend/src/**",
@@ -57,7 +64,7 @@ const coreRules = {
   "@typescript-eslint/consistent-type-imports": "error",
   // recommended sets a plain `error`; override to keep our leading-underscore escape hatch.
   // (recommended already disables the base `no-unused-vars`, so no need to repeat that here.)
-  "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+  "@typescript-eslint/no-unused-vars": ["error", unusedVarsOptions],
   // TypeScript already resolves identifiers/types; eslint's no-undef misfires on type-only
   // names (e.g. `RequestInit`) and ambient globals, so defer to the compiler.
   "no-undef": "off",
@@ -86,12 +93,9 @@ export default [
     languageOptions: {
       parser: tsparser,
       parserOptions: { ecmaVersion: "latest", sourceType: "module" },
-      globals: { ...globals.browser },
+      globals: browserGlobals,
     },
-    plugins: {
-      "@typescript-eslint": tseslint,
-      import: importPlugin,
-    },
+    plugins: tsPlugins,
     rules: coreRules,
   },
 
@@ -106,12 +110,9 @@ export default [
     languageOptions: {
       parser: svelteParser,
       parserOptions: { parser: tsparser, ecmaVersion: "latest", sourceType: "module" },
-      globals: { ...globals.browser },
+      globals: browserGlobals,
     },
-    plugins: {
-      "@typescript-eslint": tseslint,
-      import: importPlugin,
-    },
+    plugins: tsPlugins,
     rules: {
       ...coreRules,
       "svelte/no-unused-svelte-ignore": "error",
@@ -123,7 +124,7 @@ export default [
     files: reactFiles,
     languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
     plugins: { react, "react-hooks": reactHooks },
-    settings: { react: { version: "18.3" } },
+    settings: reactSettings,
     rules: {
       ...react.configs.recommended.rules,
       "react/react-in-jsx-scope": "off", // automatic JSX runtime, no React import needed
@@ -142,16 +143,16 @@ export default [
     files: ["x/study_casino/frontend/**/*.{js,jsx}"],
     languageOptions: {
       parserOptions: { ecmaVersion: "latest", sourceType: "module", ecmaFeatures: { jsx: true } },
-      globals: { ...globals.browser },
+      globals: browserGlobals,
     },
     plugins: { react },
-    settings: { react: { version: "18.3" } },
+    settings: reactSettings,
     rules: {
       "react/jsx-uses-react": "error",
       "react/jsx-uses-vars": "error",
       // Match the repo's policy elsewhere (coreRules): unused vars are build-blocking
       // errors, with a leading-underscore escape hatch.
-      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-unused-vars": ["error", unusedVarsOptions],
     },
   },
 ];


### PR DESCRIPTION
## What

**P4 of `plans/eslint_tightening.md`** — dedupe `eslint.config.js`. Pure
refactor: factor the literals duplicated across the per-glob config blocks into
named consts.

| const | value | used by |
|-------|-------|---------|
| `browserGlobals` | `{ ...globals.browser }` | TS, Svelte, study_casino |
| `tsPlugins` | `{ @typescript-eslint, import }` | TS, Svelte |
| `reactSettings` | `{ react: { version: "18.3" } }` | React, study_casino |
| `unusedVarsOptions` | `{ argsIgnorePattern, varsIgnorePattern }` | coreRules, study_casino |

study_casino now shares these (P4 option (a): it stays untyped JS; a TS
migration is tracked as a follow-up).

## Behavior-preserving — verified

Each const is byte-identical to the literal it replaced. Building all six
frontends with `--keep_going`, the dedup introduces **zero** new findings — the
only error is a **pre-existing** `react/no-unescaped-entities` in
`augur/frontend/budget.tsx` that fails identically on plain devel (confirmed by
rebuilding `budget` with this branch's config `git stash`ed).

## Dependency

> ⚠️ That pre-existing budget error is fixed in **#1801**. CI here stays red on
> `//augur/frontend:budget` until #1801 lands; this PR will go green on rebase.
> The error is unrelated to the refactor.

`BAZEL_TEST_INVOCATIONS=none:` — eslint config-only refactor; verified
behavior-preserving via the lint-aspect build (const extraction only, no rule or
coverage change).

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_