### PR TITLE
augur: migrate portfolio_sources plaid reads to session_factory (fix devel)

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -108,6 +108,7 @@ py_library(
         ":portfolio_source_config",
         "//augur/product:asset_key",
         "//plaid_utils:read_model",
+        "//plaid_utils:schema",
     ],
 )
 

--- a/augur/api/portfolio_sources.py
+++ b/augur/api/portfolio_sources.py
@@ -20,6 +20,7 @@ from augur.api.portfolio_source_config import (
 )
 from augur.product.asset_key import SP500AssetKey
 from plaid_utils.read_model import CurrentCashBalance, CurrentHolding, read_current_cash_balances, read_current_holdings
+from plaid_utils.schema import async_session_factory
 
 logger = logging.getLogger(__name__)
 
@@ -64,17 +65,26 @@ def resolve_portfolio_sources(config: Config) -> ResolvedPortfolioSources:
 
 
 async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url: str) -> _PortfolioContribution:
-    cash_balances = await read_current_cash_balances(
-        db_url=db_url, account_ids=plaid.cash.plaid_account_ids, iso_currency_code=plaid.iso_currency_code
-    )
-    cash_usd = _cash_total(plaid, cash_balances)
+    # One-shot resolve at startup: build a throwaway engine for `db_url`, read, then dispose it
+    # (the budget path instead reuses one engine across requests). read_model now takes the
+    # session factory rather than the url.
+    engine, session_factory = async_session_factory(db_url)
+    try:
+        cash_balances = await read_current_cash_balances(
+            session_factory=session_factory,
+            account_ids=plaid.cash.plaid_account_ids,
+            iso_currency_code=plaid.iso_currency_code,
+        )
+        group_account_ids = tuple(
+            sorted({account_id for group in plaid.sp500_proxy_groups for account_id in group.plaid_account_ids})
+        )
+        current_holdings = await read_current_holdings(
+            session_factory=session_factory, account_ids=group_account_ids, iso_currency_code=plaid.iso_currency_code
+        )
+    finally:
+        await engine.dispose()
 
-    group_account_ids = tuple(
-        sorted({account_id for group in plaid.sp500_proxy_groups for account_id in group.plaid_account_ids})
-    )
-    current_holdings = await read_current_holdings(
-        db_url=db_url, account_ids=group_account_ids, iso_currency_code=plaid.iso_currency_code
-    )
+    cash_usd = _cash_total(plaid, cash_balances)
     holdings_by_account: dict[str, list[CurrentHolding]] = {}
     for holding in current_holdings:
         holdings_by_account.setdefault(holding.account_id, []).append(holding)


### PR DESCRIPTION
## Fixes a break on `devel`

Commit `009869c` ("augur(budget): share one plaid engine + add coverage-floor clamp") migrated `plaid_utils/read_model.py` to a `session_factory=` API (dropping the `db_url=` keyword) and updated `augur/budget/service.py`, but **left `augur/api/portfolio_sources.py` calling the old `db_url=` API**. That breaks `//augur/api:portfolio_sources` under the mypy lint aspect on `devel` itself:

```
augur/api/portfolio_sources.py:67: error: Unexpected keyword argument "db_url" for "read_current_cash_balances"  [call-arg]
augur/api/portfolio_sources.py:75: error: Unexpected keyword argument "db_url" for "read_current_holdings"  [call-arg]
```

## Fix

`_read_plaid_contribution` now builds a throwaway async engine from the url via `async_session_factory(db_url)`, passes the `session_factory` to the read-model calls, and disposes the engine after the one-shot startup read — mirroring how the budget path constructs its session factory (the budget path reuses one engine across requests; this resolve path is startup-only, so a per-call engine is fine).

Adds the `//plaid_utils:schema` dep for `async_session_factory`.

Validated on RBE: `//augur/api:portfolio_sources` builds clean (mypy) and `portfolio_sources_test` / `server_test` / `test_calibration_endpoint` pass.

https://claude.ai/code/session_01H59oex5Er919Zud9FvHagT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H59oex5Er919Zud9FvHagT)_