### PR TITLE
eslint: bucket frontends into reactProjects / svelteProjects (declarative scope)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,21 +19,20 @@ const reactSettings = { react: { version: "18.3" } };
 // Allow intentionally-unused identifiers/args when prefixed with `_`.
 const unusedVarsOptions = { argsIgnorePattern: "^_", varsIgnorePattern: "^_" };
 
-// All project source directories (add new TS/Svelte projects here)
-const projectGlobs = [
-  "props/frontend/src/**",
-  "x/agent_server/web/src/**",
-  "x/rspcache/admin_ui/src/**",
-  "airlock/frontend/**",
-  "augur/frontend/**",
-];
+// Project source dirs, bucketed by framework so each config block targets the
+// right files — and a new project is declared exactly once, in the right list.
+const reactProjects = ["x/rspcache/admin_ui/src/**", "augur/frontend/**"];
+const svelteProjects = ["props/frontend/src/**", "x/agent_server/web/src/**", "airlock/frontend/**"];
+const projectGlobs = [...reactProjects, ...svelteProjects];
 
+// All projects' .ts/.tsx get the shared TS rules. .svelte (+ .svelte.ts) come
+// only from the Svelte projects; the React projects' .ts/.tsx additionally get
+// eslint-plugin-react + react-hooks (the Svelte projects' .ts are plain modules,
+// so React rules — notably react-hooks/rules-of-hooks — stay off them).
 const tsFiles = projectGlobs.map((g) => `${g}/*.{ts,tsx}`);
-const svelteFiles = projectGlobs.map((g) => `${g}/*.svelte`);
-const svelteTsFiles = projectGlobs.map((g) => `${g}/*.svelte.ts`);
-
-// React projects (subset of projectGlobs) get eslint-plugin-react + react-hooks.
-const reactFiles = ["x/rspcache/admin_ui/src/**", "augur/frontend/**"].map((g) => `${g}/*.{ts,tsx}`);
+const svelteFiles = svelteProjects.map((g) => `${g}/*.svelte`);
+const svelteTsFiles = svelteProjects.map((g) => `${g}/*.svelte.ts`);
+const reactFiles = reactProjects.map((g) => `${g}/*.{ts,tsx}`);
 
 // Import ordering (TS equivalent of ruff's isort)
 // import/order is disabled: eslint-plugin-import-x's import/order rule crashes under


### PR DESCRIPTION
## What

Follow-up to the P4 dedup. Replace the hand-maintained `reactFiles` subset of
`projectGlobs` with two declarative framework buckets:

```js
const reactProjects  = ["x/rspcache/admin_ui/src/**", "augur/frontend/**"];
const svelteProjects = ["props/frontend/src/**", "x/agent_server/web/src/**", "airlock/frontend/**"];
const projectGlobs   = [...reactProjects, ...svelteProjects];

const tsFiles       = projectGlobs.map((g) => `${g}/*.{ts,tsx}`);   // all projects
const svelteFiles   = svelteProjects.map((g) => `${g}/*.svelte`);   // Svelte only
const svelteTsFiles = svelteProjects.map((g) => `${g}/*.svelte.ts`);
const reactFiles    = reactProjects.map((g) => `${g}/*.{ts,tsx}`);  // React only
```

## Why

The old shape required keeping two lists in sync — add a new React frontend to
`projectGlobs` but forget the separate `reactFiles` literal and it silently
loses `react-hooks` coverage. Now each frontend is declared **exactly once**, in
the right bucket, and its rule scope derives automatically. It also removes the
temptation to broaden the React block onto the Svelte projects' plain `.ts`
modules (where `react-hooks/rules-of-hooks` would be a latent false positive on
any `use*`-named helper).

## Behavior-preserving — verified

The set of files each block matches is unchanged: `projectGlobs` is the same 5
dirs (order within a `files` array doesn't affect matching), and deriving the
Svelte globs from `svelteProjects` is identical because the React projects have
**0** `.svelte`/`.svelte.ts` files (confirmed).

- `bbr build //{props,augur,x/rspcache,x/agent_server,airlock,x/study_casino}/frontend/...`
  — gate green, no new findings.
- `bbr test //props/frontend:svelte_check_test //augur/frontend:tsc_test
  //augur/frontend:eslint_typed_test` — all pass.

`BAZEL_TEST_INVOCATIONS=none:` — eslint config-only refactor; same file→rule mapping.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_