### PR TITLE
eslint: drop the dead no-console rule (P5)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,6 @@ const coreRules = {
   ...tsRecommendedRules,
   "prefer-const": "error",
   eqeqeq: ["error", "always", { null: "ignore" }],
-  "no-console": ["warn", { allow: ["warn", "error"] }],
   "@typescript-eslint/consistent-type-imports": "error",
   // recommended sets a plain `error`; override to keep our leading-underscore escape hatch.
   // (recommended already disables the base `no-unused-vars`, so no need to repeat that here.)


### PR DESCRIPTION
## What

Removes the `no-console` rule from the shared `coreRules`.

It was `["warn", { allow: ["warn", "error"] }]`, but under the
`fail_on_violation` gate **warnings don't fail the build** — so the rule was
inert dead config (it only printed to a log nobody reads on a green build).
Rather than leave it pretending to enforce something, drop it; `console.*` is
unrestricted, matching the de-facto state.

(This is the P5 item from `plans/eslint_tightening.md`, resolved as "drop" rather
than "promote to error".)

## Validation (RBE)

- `bbr build //{props,augur,x/agent_server,airlock,x/study_casino}/frontend/...`
  — gate green (461 actions); removing an inert warn can't add violations.

`BAZEL_TEST_INVOCATIONS=none:` — eslint config-only.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_