### PR TITLE
eslint: stop listing rspcache as a lint target (it has none)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,12 @@ const unusedVarsOptions = { argsIgnorePattern: "^_", varsIgnorePattern: "^_" };
 
 // Project source dirs, bucketed by framework so each config block targets the
 // right files — and a new project is declared exactly once, in the right list.
-const reactProjects = ["x/rspcache/admin_ui/src/**", "augur/frontend/**"];
+//
+// x/rspcache/admin_ui is intentionally NOT listed: its BUILD.bazel has no
+// js_library targets (the Vite build is a WIP stub), so the lint aspect never
+// runs on it. Listing it here would be dead config implying coverage that does
+// not exist — re-add once it's Bazelized (per-file js_library + tsc_test).
+const reactProjects = ["augur/frontend/**"];
 const svelteProjects = ["props/frontend/src/**", "x/agent_server/web/src/**", "airlock/frontend/**"];
 const projectGlobs = [...reactProjects, ...svelteProjects];
 


### PR DESCRIPTION
## What

Removes `x/rspcache/admin_ui/src/**` from the ESLint config's `reactProjects`.

It *looked* covered (it was listed as a React project), but rspcache's
`BUILD.bazel` has **no `js_library` targets** — its Vite build is a WIP stub
("build/typecheck manually with `npx`"). The lint aspect only runs on Bazel JS
targets, so `App.tsx`/`main.tsx` there got **neither ESLint nor tsc** in CI. The
config entry implied coverage that didn't exist.

Drop it and document why (with a re-add condition). This is the lightweight,
honest fix for the "rspcache silently unlinted" gap; the heavier alternative —
Bazelizing rspcache (per-file `js_library` + `tsc_test`, like augur) — is a
separate effort that doesn't belong in a config cleanup, especially while its
own build is a stub.

**No change to the actually-linted set** (rspcache was never linted); augur
still gets the React rules.

## Validation (RBE)

- `bbr build //{props,augur,x/agent_server,airlock,x/study_casino}/frontend/...`
  — gate green (461 actions).

`BAZEL_TEST_INVOCATIONS=none:` — eslint config-only.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_