### PR TITLE
debug: document why import/order is incompatible with our Bazel ESLint

### DIFF
--- a/debug/eslint_import_order_bazel.md
+++ b/debug/eslint_import_order_bazel.md
@@ -1,0 +1,68 @@
+# `import/order` is incompatible with our Bazel ESLint setup
+
+**Date:** 2026-06-02
+**Status:** `import/order` stays **off** in `eslint.config.js`. Confirmed not fixable
+via config; see "What was tried" below.
+
+## Symptom
+
+Enabling `import/order` (from `eslint-plugin-import-x`, registered as `import`)
+makes the ESLint action crash — exit 2, not a lint violation:
+
+```
+TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
+Rule: "import/order"
+    at Object.dirname (node:path)
+    at getFilePackagePath (eslint-plugin-import-x/lib/utils/package-path.js:8)
+    at getContextPackagePath (eslint-plugin-import-x/lib/utils/package-path.js:5)
+    at isExternalPath (eslint-plugin-import-x/lib/utils/import-type.js:69)
+    at typeTest → importType → computeRank (eslint-plugin-import-x/lib/rules/order.js)
+```
+
+## Root cause
+
+To order imports, `import/order` must rank each one, which classifies it as
+external/internal via `isExternalPath`. That calls `getContextPackagePath`,
+which walks **up from the file being linted** looking for a `package.json`
+(`pkgUp`). Under Bazel the source is executed from `bazel-out/.../<pkg>/file.tsx`
+(per-file aspect) or the test runfiles tree (whole-program test) — **there is no
+`package.json` anywhere above it**, so `pkgUp` returns `null` and
+`path.dirname(null)` throws.
+
+This is **not** about resolving the _imports_ (the original code comment guessed
+that); it's about locating the _current file's_ package. So resolver config
+doesn't help.
+
+## What was tried (all still crash)
+
+1. Flip `import/order: "error"` in the gate config → crash (per-file aspect).
+2. Add a node resolver with `.ts`/`.tsx` extensions (`import-x/resolver`) → crash.
+3. Set both `import-x/resolver` **and** `import/resolver` namespaces → crash.
+4. Move it to the **whole-program** test (`//augur/frontend:eslint_typed_test`,
+   `parserOptions.projectService`, full tree + node_modules in one sandbox) →
+   crash (same `getContextPackagePath`).
+5. Add `//:package.json` to that test's `data` so `pkgUp` could find one →
+   Bazel **analysis error** (js_test data staging conflict) — a separate yak to
+   shave, and even if cleared, see below.
+
+Even past the crash, enabling `import/order` would flag a repo-wide reordering
+that only `eslint --fix` can apply — and `--fix` is impractical under RBE (the
+lint aspect runs read-only; we don't have a hermetic local `eslint --fix` path).
+
+## Conclusion / recommendation
+
+`import-x`'s package-path walk fundamentally fights Bazel's `bazel-out`
+execution layout. Not worth working around in ESLint.
+
+If import ordering is wanted, the realistic path is a **Prettier import-sort
+plugin** instead of ESLint:
+
+- `@trivago/prettier-plugin-sort-imports` — purely syntactic grouping/ordering;
+  no resolver, no `package.json` walk, no `bazel-out` interaction. Prettier
+  already runs in pre-commit and auto-fixes, so it covers every frontend
+  uniformly and reorders on save/commit.
+- (`prettier-plugin-organize-imports` uses the TS language service — likely the
+  same project-context problems; prefer the syntactic plugin.)
+
+That's a formatter change (one big reorder diff, then maintained automatically),
+tracked as a follow-up rather than forcing `import/order` through ESLint.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,10 +39,13 @@ const svelteFiles = svelteProjects.map((g) => `${g}/*.svelte`);
 const svelteTsFiles = svelteProjects.map((g) => `${g}/*.svelte.ts`);
 const reactFiles = reactProjects.map((g) => `${g}/*.{ts,tsx}`);
 
-// Import ordering (TS equivalent of ruff's isort)
-// import/order is disabled: eslint-plugin-import-x's import/order rule crashes under
-// Bazel's sandboxed execution because resolve() returns null for imports in bazel-out/
-// paths and getFilePackagePath calls path.dirname(null). Affects all file types.
+// Import ordering (the TS equivalent of ruff's isort) is intentionally OFF.
+// import/order crashes under Bazel: ranking an import calls getContextPackagePath,
+// which walks up from the source file for a package.json (pkgUp) — but the
+// bazel-out execution tree has none above it, so path.dirname(null) throws. Not
+// fixable via resolver config or the whole-program test path; a Prettier
+// import-sort plugin is the realistic alternative.
+// See debug/eslint_import_order_bazel.md for the full investigation.
 const importRules = {
   "import/first": "error",
   "import/order": "off",


### PR DESCRIPTION
## What

Documents why `import/order` stays off (you asked to "apply import/order" — I
spiked it thoroughly and it's **not feasible** under our Bazel ESLint setup, so
this captures the finding instead of shipping a crashing config).

- **New `debug/eslint_import_order_bazel.md`** — full RCA + everything tried.
- **Corrects the inline `eslint.config.js` comment** — the old "resolve()
  returns null for imports" note was a wrong guess; it's the *context file's*
  package path that can't be found. Points at the debug note.

## The finding (short version)

`import/order` crashes (`path.dirname(null)`, exit 2 — not a lint violation).
Ranking an import classifies it external/internal via `getContextPackagePath`,
which walks **up from the source file** for a `package.json` (`pkgUp`). The
`bazel-out` execution tree has none above the file → `pkgUp` returns `null` →
`path.dirname(null)` throws. It's the file's *own* package path, not import
resolution — so resolver config can't fix it.

Tried, all still crash: gate flip; node resolver + `.ts` extensions; both
`import-x/`+`import/` resolver namespaces; the whole-program typed test
(`projectService`); injecting `//:package.json` (→ Bazel analysis error). And
even past the crash, enabling it needs a repo-wide `eslint --fix` reorder that's
impractical under RBE.

**Recommendation:** if import ordering is wanted, use a **Prettier import-sort
plugin** (e.g. `@trivago/prettier-plugin-sort-imports`) — syntactic, no
resolver / `package.json` walk / `bazel-out` interaction, auto-fixes via the
formatter that already runs in pre-commit, covers all frontends. Tracked as a
follow-up.

`BAZEL_TEST_INVOCATIONS=none:` — docs + comment correction (`import/order` stays
off); verified the config still loads via `//augur/frontend:app`.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_