### PR TITLE
debug/eslint: record the Prettier import-sort spike (parked)

### DIFF
--- a/debug/eslint_import_order_bazel.md
+++ b/debug/eslint_import_order_bazel.md
@@ -54,15 +54,27 @@ lint aspect runs read-only; we don't have a hermetic local `eslint --fix` path).
 `import-x`'s package-path walk fundamentally fights Bazel's `bazel-out`
 execution layout. Not worth working around in ESLint.
 
-If import ordering is wanted, the realistic path is a **Prettier import-sort
-plugin** instead of ESLint:
+A **Prettier import-sort plugin** (`@ianvs/` or `@trivago/prettier-plugin-sort-imports`)
+was then evaluated as the alternative — and **parked**:
 
-- `@trivago/prettier-plugin-sort-imports` — purely syntactic grouping/ordering;
-  no resolver, no `package.json` walk, no `bazel-out` interaction. Prettier
-  already runs in pre-commit and auto-fixes, so it covers every frontend
-  uniformly and reorders on save/commit.
-- (`prettier-plugin-organize-imports` uses the TS language service — likely the
-  same project-context problems; prefer the syntactic plugin.)
+- It can sort `.ts` / `.tsx` / `.js` (these plugins hook Prettier's
+  babel/typescript parsers — purely syntactic, no resolver / `package.json` /
+  `bazel-out` issues), but **not `.svelte`**: they don't touch
+  `prettier-plugin-svelte`'s parser, so the `.svelte` components in `props`,
+  `agent_server`, and `airlock` (the bulk of those apps) wouldn't be sorted.
+  Coverage would be inconsistent within a single frontend (a `.ts` sorted, the
+  `.svelte` next to it not).
+- Wiring spans **three build systems**: the Nix-bundled prettier
+  (`nix/packages/prettier/` — `package.json` + an `npmDepsHash` rebuild, since
+  pre-commit's `language: system` prettier resolves plugins off the Nix wrapper's
+  `NODE_PATH`), the pnpm/Bazel `prettier_bin` (`//:prettierrc` deps + lockfile),
+  and `.prettierrc.cjs` (`require()` + `importOrder` groups, with
+  `importOrderSideEffects` care so a side-effect `import "./x.css"` / polyfill
+  isn't reordered into a behavior change) — plus a one-time repo-wide reorder.
 
-That's a formatter change (one big reorder diff, then maintained automatically),
-tracked as a follow-up rather than forcing `import/order` through ESLint.
+For that partial, frontend-inconsistent coverage at a multi-system cost, it
+wasn't worth it. The import hygiene that DOES work under Bazel is already on
+(`import/first`, `import/no-duplicates`, `import/newline-after-import`); only
+grouping/ordering is missing. (`prettier-plugin-organize-imports` uses the TS
+language service — likely the same project-context problems, so the syntactic
+plugin is the only candidate.)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,9 +43,10 @@ const reactFiles = reactProjects.map((g) => `${g}/*.{ts,tsx}`);
 // import/order crashes under Bazel: ranking an import calls getContextPackagePath,
 // which walks up from the source file for a package.json (pkgUp) — but the
 // bazel-out execution tree has none above it, so path.dirname(null) throws. Not
-// fixable via resolver config or the whole-program test path; a Prettier
-// import-sort plugin is the realistic alternative.
-// See debug/eslint_import_order_bazel.md for the full investigation.
+// fixable via resolver config or the whole-program test path. A Prettier
+// import-sort plugin could order .ts/.tsx/.js but not .svelte (it doesn't touch
+// prettier-plugin-svelte's parser) and needs Nix+Bazel+pnpm wiring, so import
+// ordering is parked. See debug/eslint_import_order_bazel.md for the full investigation.
 const importRules = {
   "import/first": "error",
   "import/order": "off",


### PR DESCRIPTION
## What

Records the result of the Prettier import-sort spike (the alternative to the
Bazel-incompatible `import/order`, documented in #1807) — **parked** — so the
conclusion lives next to the rule and in the debug note.

- **`eslint.config.js`** comment: expands the import/order note with the
  Prettier-path caveat — a sort plugin could order `.ts/.tsx/.js` but **not
  `.svelte`**, and needs Nix+Bazel+pnpm wiring, so it's parked.
- **`debug/eslint_import_order_bazel.md`**: corrects the conclusion (it had
  wrongly claimed the plugin "covers every frontend uniformly") with the real
  findings.

## Why parked (the spike result)

- Prettier sort plugins hook the **babel/typescript** parsers — they don't touch
  `prettier-plugin-svelte`'s parser, so the `.svelte` components in props /
  agent_server / airlock (the bulk of those apps) can't be sorted. Coverage
  would be inconsistent within a single frontend.
- Wiring spans **three build systems**: the Nix-bundled prettier
  (`nix/packages/prettier/` + an `npmDepsHash` rebuild — pre-commit's
  `language: system` prettier resolves plugins off the Nix wrapper's
  `NODE_PATH`), the pnpm/Bazel `prettier_bin`, and `.prettierrc.cjs` — plus a
  one-time repo-wide reorder.

Partial, intra-frontend-inconsistent coverage at a multi-system cost → not worth
it. The Bazel-compatible import hygiene (`import/first`, `import/no-duplicates`,
`import/newline-after-import`) is already on.

`BAZEL_TEST_INVOCATIONS=none:` — docs + a comment (`import/order` stays off);
verified the config still loads via `//augur/frontend:app`.

https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9vFTSStdBCi8o7qR7c2ih)_