### PR TITLE
test: extract shared write_jsonl helper to util/testing

### DIFF
--- a/augur/fit/BUILD.bazel
+++ b/augur/fit/BUILD.bazel
@@ -182,6 +182,7 @@ py_test(
         "//augur/model:exogenous",
         "//augur/model:series",
         "//augur/model:trained_private_equity",
+        "//util/testing:jsonl",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/augur/fit/private_equity_test.py
+++ b/augur/fit/private_equity_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import numpy as np
@@ -21,11 +20,7 @@ from augur.model.trained_private_equity import (
     TrainedPrivateEquityModelArtifact,
     TrainedPrivateEquityScalePrior,
 )
-
-
-def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
-    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
-    return path
+from util.testing.jsonl import write_jsonl
 
 
 def _rows() -> list[dict[str, object]]:
@@ -83,7 +78,7 @@ def broad_scale_prior() -> TrainedPrivateEquityScalePrior:
 
 
 def test_load_jsonl_accepts_valuation_observations(tmp_path: Path) -> None:
-    path = _write_jsonl(
+    path = write_jsonl(
         tmp_path / "observations.jsonl",
         [
             {
@@ -106,7 +101,7 @@ def test_load_jsonl_accepts_valuation_observations(tmp_path: Path) -> None:
 
 def test_primary_valuation_requires_cash_raised(tmp_path: Path) -> None:
     """`valuation_kind=primary` without `cash_raised_usd` is rejected at parse time."""
-    path = _write_jsonl(
+    path = write_jsonl(
         tmp_path / "observations.jsonl",
         [
             {
@@ -126,7 +121,7 @@ def test_primary_valuation_requires_cash_raised(tmp_path: Path) -> None:
 
 def test_non_primary_valuation_rejects_cash_raised(tmp_path: Path) -> None:
     """`cash_raised_usd` set on a non-primary observation is rejected (catches mis-tags)."""
-    path = _write_jsonl(
+    path = write_jsonl(
         tmp_path / "observations.jsonl",
         [
             {
@@ -147,7 +142,7 @@ def test_non_primary_valuation_rejects_cash_raised(tmp_path: Path) -> None:
 
 def test_primary_valuation_accepts_cash_raised(tmp_path: Path) -> None:
     """Happy path: primary kind + cash_raised_usd + optional shares_outstanding_post_round."""
-    path = _write_jsonl(
+    path = write_jsonl(
         tmp_path / "observations.jsonl",
         [
             {
@@ -173,7 +168,7 @@ def test_primary_valuation_accepts_cash_raised(tmp_path: Path) -> None:
 
 
 def test_load_jsonl_rejects_unknown_observation_type(tmp_path: Path) -> None:
-    path = _write_jsonl(
+    path = write_jsonl(
         tmp_path / "observations.jsonl",
         [{"type": "mystery_observation", "issuer_id": "private_company_a", "observed_at": "2025-10-28"}],
     )
@@ -183,7 +178,7 @@ def test_load_jsonl_rejects_unknown_observation_type(tmp_path: Path) -> None:
 
 
 def test_fit_requires_current_ppu_mark(tmp_path: Path) -> None:
-    observations = load_price_observations_jsonl(_write_jsonl(tmp_path / "observations.jsonl", _rows()[:2]))
+    observations = load_price_observations_jsonl(write_jsonl(tmp_path / "observations.jsonl", _rows()[:2]))
     config = PrivateEquityTrainingConfig(
         issuer_id="private_company_a",
         observations_path="observations.jsonl",
@@ -196,7 +191,7 @@ def test_fit_requires_current_ppu_mark(tmp_path: Path) -> None:
 
 
 def test_train_round_trips_compact_model_and_runtime_samples(tmp_path: Path) -> None:
-    _write_jsonl(tmp_path / "observations.jsonl", _rows())
+    write_jsonl(tmp_path / "observations.jsonl", _rows())
     config_path = tmp_path / "train.yaml"
     config_path.write_text(
         """
@@ -308,7 +303,7 @@ def test_runtime_tender_updates_observed_private_mark(broad_scale_prior: Trained
 
 def test_sparse_tender_appreciation_is_shrunk_toward_stock_like_forward_prior(tmp_path: Path) -> None:
     observations = load_price_observations_jsonl(
-        _write_jsonl(
+        write_jsonl(
             tmp_path / "observations.jsonl",
             [
                 {
@@ -363,7 +358,7 @@ def test_sparse_tender_appreciation_is_shrunk_toward_stock_like_forward_prior(tm
 
 def test_valuation_observations_create_soft_macro_scale_prior(tmp_path: Path) -> None:
     observations = load_price_observations_jsonl(
-        _write_jsonl(
+        write_jsonl(
             tmp_path / "observations.jsonl",
             [
                 {

--- a/augur/model/BUILD.bazel
+++ b/augur/model/BUILD.bazel
@@ -432,6 +432,7 @@ py_test(
         ":private_equity_trajectories",
         ":series",
         "//:conftest",
+        "//util/testing:jsonl",
         "@pypi//numpy",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/augur/model/private_equity_trajectories_test.py
+++ b/augur/model/private_equity_trajectories_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -18,6 +17,7 @@ from augur.model.private_equity_trajectories import (
     read_private_equity_trajectories_jsonl,
 )
 from augur.model.series import SP500Key
+from util.testing.jsonl import write_jsonl
 
 
 @dataclass(frozen=True)
@@ -33,13 +33,8 @@ class _MinimalSampler(Sampler):
         return self.bundle
 
 
-def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
-    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
-    return path
-
-
 def test_read_jsonl_groups_tender_events_by_issuer_and_trajectory(tmp_path: Path) -> None:
-    artifact = _write_jsonl(
+    artifact = write_jsonl(
         tmp_path / "pe.jsonl",
         [
             {
@@ -86,14 +81,14 @@ def test_read_jsonl_groups_tender_events_by_issuer_and_trajectory(tmp_path: Path
 
 
 def test_read_jsonl_rejects_issuers_with_no_modeled_trajectories(tmp_path: Path) -> None:
-    artifact = _write_jsonl(tmp_path / "pe.jsonl", [])
+    artifact = write_jsonl(tmp_path / "pe.jsonl", [])
 
     with pytest.raises(ValueError, match="no modeled trajectories"):
         read_private_equity_trajectories_jsonl(artifact, initial_marks={"holdco": 12.5})
 
 
 def test_read_jsonl_rejects_unknown_issuer(tmp_path: Path) -> None:
-    artifact = _write_jsonl(
+    artifact = write_jsonl(
         tmp_path / "pe.jsonl",
         [
             {

--- a/util/testing/BUILD.bazel
+++ b/util/testing/BUILD.bazel
@@ -10,6 +10,13 @@ py_library(
 )
 
 py_library(
+    name = "jsonl",
+    testonly = True,
+    srcs = ["jsonl.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "otel_tracing",
     testonly = True,
     srcs = ["otel_tracing.py"],

--- a/util/testing/jsonl.py
+++ b/util/testing/jsonl.py
@@ -1,0 +1,13 @@
+"""Write JSONL (one JSON object per line) — a tiny shared test helper for round-tripping
+JSONL artifacts (price observations, PE trajectories) through the readers under test."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
+    """Write `rows` as JSONL to `path` and return it."""
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return path

--- a/util/testing/jsonl.py
+++ b/util/testing/jsonl.py
@@ -4,10 +4,12 @@ JSONL artifacts (price observations, PE trajectories) through the readers under 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 
-def write_jsonl(path: Path, rows: list[dict[str, object]]) -> Path:
-    """Write `rows` as JSONL to `path` and return it."""
-    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+def write_jsonl(path: Path, rows: Iterable[Mapping[str, object]]) -> Path:
+    """Write `rows` as JSONL to `path` (one JSON object per line; empty when there are no
+    rows, never a stray blank line) and return it."""
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
     return path


### PR DESCRIPTION
## What & why

`augur/fit/private_equity_test.py` and `augur/model/private_equity_trajectories_test.py` each
defined a **byte-identical** `_write_jsonl(path, rows)` helper for round-tripping JSONL artifacts
(price observations / PE trajectories) through the readers under test.

This promotes it to a single shared `util.testing.jsonl.write_jsonl`, imported by both, and drops
the now-unused `import json` from each test. New `//util/testing:jsonl` target; both test targets
gain the dep.

This is the one genuinely-mergeable duplicate from a sweep of the augur test suite. (Two other
candidates — the `browser`/`page` Playwright fixtures and the `scenario_key`/`mortgage_purchase_scenario`
fixtures — were left alone: their differences are substantive, and consolidating would couple
unrelated concerns / lose readable named fixtures.)

## Validation (RBE)

`bbr test //augur/fit:private_equity_test //augur/model:private_equity_trajectories_test` — both pass.

https://claude.ai/code/session_01H59oex5Er919Zud9FvHagT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H59oex5Er919Zud9FvHagT)_