### PR TITLE
augur/budget: day-normalize the per-bucket monthly average

### DIFF
--- a/augur/budget/BUILD.bazel
+++ b/augur/budget/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devinfra/python:defs.bzl", "py_library")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,6 +33,22 @@ py_library(
     deps = [
         ":categorize",
         ":schema",
+        "//augur:dates",
+        "//plaid_utils:schema",
+    ],
+)
+
+py_test(
+    name = "test_aggregate",
+    srcs = ["test_aggregate.py"],
+    deps = [
+        ":aggregate",
+        ":categorize",
+        ":schema",
+        "//augur:dates",
+        "//plaid_utils:schema",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/augur/budget/aggregate.py
+++ b/augur/budget/aggregate.py
@@ -16,6 +16,7 @@ from datetime import date
 
 from augur.budget.categorize import Classified
 from augur.budget.schema import BucketDef, BucketKind, BudgetConfig
+from augur.dates import DAYS_PER_MONTH
 from plaid_utils.schema import TransactionRow
 
 
@@ -53,7 +54,7 @@ class LumpyTransaction:
 class BucketReport:
     bucket: BucketDef
     monthly: MonthlyBucketSeries
-    current_monthly_avg: float
+    window_monthly_avg: float
     transaction_count: int
 
 
@@ -88,17 +89,24 @@ def _gross_monthly_totals(
 
 
 def aggregate(
-    classified: tuple[Classified, ...], *, config: BudgetConfig, start_month: date, end_month: date
+    classified: tuple[Classified, ...], *, config: BudgetConfig, window_start: date, window_end: date
 ) -> AggregateReport:
-    """Per-bucket monthly view + a list of lumpy single transactions over the window."""
-    months = _enumerate_months(start_month, end_month)
+    """Per-bucket monthly view + a list of lumpy single transactions over [window_start, window_end].
+
+    `window_start` / `window_end` are the actual covered dates (inclusive) -- not month
+    boundaries -- so they bound the day count that normalizes per-month averages. The monthly
+    series itself still snaps to calendar months for the trend chart.
+    """
+    months = _enumerate_months(window_start, window_end)
     months_set = set(months)
     gross = _gross_monthly_totals(classified, months=months)
     bucket_by_id = {bucket.id: bucket for bucket in config.buckets}
 
-    # Recent monthly average = trailing 3 months of the visible window (or the whole
-    # window if it's shorter). Computed per bucket so the UI can sort + label.
-    recent_window = months[-3:] if len(months) >= 3 else months
+    # Day-normalized monthly average: signed window total / days actually covered, scaled to a
+    # representative month. Counting days (not calendar-month slots) is what keeps a partial
+    # current month -- or a mid-month coverage start -- from being treated as a full month, which
+    # otherwise biases every average toward zero by up to a month's worth.
+    days_covered = max((window_end - window_start).days + 1, 1)
     counts_by_bucket: dict[str, int] = defaultdict(int)
     for entry in classified:
         if _month_start(entry.transaction.date) in months_set:
@@ -108,13 +116,12 @@ def aggregate(
     for bucket in config.buckets:
         series_map = gross.get(bucket.id, dict.fromkeys(months, 0.0))
         amounts = tuple(series_map[month] for month in months)
-        recent = [series_map[month] for month in recent_window]
-        avg = sum(recent) / len(recent) if recent else 0.0
+        window_monthly_avg = sum(amounts) / days_covered * DAYS_PER_MONTH
         bucket_reports.append(
             BucketReport(
                 bucket=bucket,
                 monthly=MonthlyBucketSeries(bucket_id=bucket.id, months=months, amounts=amounts),
-                current_monthly_avg=avg,
+                window_monthly_avg=window_monthly_avg,
                 transaction_count=counts_by_bucket.get(bucket.id, 0),
             )
         )

--- a/augur/budget/service.py
+++ b/augur/budget/service.py
@@ -28,17 +28,17 @@ from augur.budget.wire import (
 from plaid_utils.read_model import read_account_directory, read_transactions
 
 
-def _resolve_window(window: WindowSpec, *, today: date, coverage_starts: date | None) -> tuple[date, date]:
-    """Map a wire `WindowSpec` to a concrete (start_month, end_month) pair.
+def _resolve_window(window: WindowSpec, *, today: date, coverage_starts: date | None) -> date:
+    """Map a wire `WindowSpec` to the window's start (the actual first covered day).
 
     For `TrailingMonthsWindow`, walks back N calendar months from the month containing `today`.
     For `CoverageWindow`, anchors at `coverage_starts` (raises if the deployment has none).
     In either case, the start is clamped to `coverage_starts` -- months before that are partial
-    cross-account coverage and would skew family totals.
+    cross-account coverage and would skew family totals. The window always ends at `today`.
     """
-    end_month = date(today.year, today.month, 1)
+    current_month = date(today.year, today.month, 1)
     if isinstance(window, TrailingMonthsWindow):
-        total = end_month.year * 12 + (end_month.month - 1) - (window.months - 1)
+        total = current_month.year * 12 + (current_month.month - 1) - (window.months - 1)
         start_month = date(total // 12, total % 12 + 1, 1)
     else:
         if coverage_starts is None:
@@ -50,7 +50,7 @@ def _resolve_window(window: WindowSpec, *, today: date, coverage_starts: date | 
         start_month = date(coverage_starts.year, coverage_starts.month, 1)
     if coverage_starts is not None and start_month < coverage_starts:
         start_month = coverage_starts
-    return start_month, end_month
+    return start_month
 
 
 @dataclass(frozen=True)
@@ -62,7 +62,7 @@ class BudgetService:
         """Pull + categorize + aggregate, packaged as the wire snapshot."""
         today = date.today()
         coverage_starts = self.config.source.coverage_starts
-        start_month, end_month = _resolve_window(window, today=today, coverage_starts=coverage_starts)
+        start_month = _resolve_window(window, today=today, coverage_starts=coverage_starts)
         transactions = await read_transactions(
             session_factory=self.session_factory,
             start_date=start_month,
@@ -70,7 +70,7 @@ class BudgetService:
             account_ids=self.config.source.plaid_account_ids,
         )
         classified = classify(transactions, config=self.config)
-        report = aggregate(classified, config=self.config, start_month=start_month, end_month=end_month)
+        report = aggregate(classified, config=self.config, window_start=start_month, window_end=today)
         return BudgetSnapshotResponse(
             months=report.months,
             buckets=tuple(
@@ -81,7 +81,7 @@ class BudgetService:
                 BucketMonthly(
                     bucket_id=bucket_report.bucket.id,
                     monthly_amounts=bucket_report.monthly.amounts,
-                    current_monthly_avg=bucket_report.current_monthly_avg,
+                    window_monthly_avg=bucket_report.window_monthly_avg,
                     transaction_count=bucket_report.transaction_count,
                 )
                 for bucket_report in report.buckets
@@ -107,7 +107,7 @@ class BudgetService:
         """Drill-down: all transactions in one bucket, enriched with account+link names."""
         today = date.today()
         coverage_starts = self.config.source.coverage_starts
-        start_month, _ = _resolve_window(window, today=today, coverage_starts=coverage_starts)
+        start_month = _resolve_window(window, today=today, coverage_starts=coverage_starts)
         transactions = await read_transactions(
             session_factory=self.session_factory,
             start_date=start_month,

--- a/augur/budget/test_aggregate.py
+++ b/augur/budget/test_aggregate.py
@@ -1,0 +1,85 @@
+"""Budget aggregation tests, focused on day-normalized monthly averages over partial months."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import pytest_bazel
+
+from augur.budget.aggregate import aggregate
+from augur.budget.categorize import Classified
+from augur.budget.schema import BucketDef, BucketKind, BudgetConfig, BudgetSourceConfig
+from augur.dates import DAYS_PER_MONTH
+from plaid_utils.schema import TransactionRow
+
+
+def _tx(transaction_id: str, on: date, amount: float) -> TransactionRow:
+    return TransactionRow(
+        transaction_id=transaction_id,
+        account_id="acct",
+        item_id="item",
+        date=on,
+        amount=amount,
+        name=transaction_id,
+        merchant_name=None,
+        pending=False,
+        pfc_primary=None,
+        pfc_detailed=None,
+        raw_json={},
+    )
+
+
+def _single_bucket_config() -> BudgetConfig:
+    return BudgetConfig(
+        source=BudgetSourceConfig(),
+        buckets=(BucketDef(id="groceries", label="Groceries", kind=BucketKind.EXPENSE),),
+        default_bucket_id="groceries",
+        include_default_rules=False,
+    )
+
+
+def test_partial_current_month_not_counted_as_whole() -> None:
+    # Two full months at $3000 and an empty partial June (window ends June 2). The run rate is
+    # ~$3000/mo; dividing the $6000 window total by 3 calendar-month slots gave a bogus $2000/mo.
+    config = _single_bucket_config()
+    classified = (
+        Classified(transaction=_tx("a", date(2026, 4, 15), 3000.0), bucket_id="groceries"),
+        Classified(transaction=_tx("b", date(2026, 5, 15), 3000.0), bucket_id="groceries"),
+    )
+    report = aggregate(classified, config=config, window_start=date(2026, 4, 1), window_end=date(2026, 6, 2))
+
+    (bucket_report,) = report.buckets
+    days = (date(2026, 6, 2) - date(2026, 4, 1)).days + 1
+    assert bucket_report.window_monthly_avg == pytest.approx(6000.0 / days * DAYS_PER_MONTH)
+    # Close to the true ~$3000/mo run rate, and far above the old sum/3 == $2000.
+    assert bucket_report.window_monthly_avg == pytest.approx(3000.0, rel=0.05)
+    # The trend series still snaps to calendar-month columns including the partial month.
+    assert report.months == (date(2026, 4, 1), date(2026, 5, 1), date(2026, 6, 1))
+
+
+def test_mid_month_coverage_start_not_counted_as_whole() -> None:
+    # Coverage begins mid-month (Mar 15). Only the 17 covered days of March should weigh in, not
+    # a full March -- so $1000 over a half-month reads as a high monthly rate, not $1000/2 months.
+    config = _single_bucket_config()
+    classified = (Classified(transaction=_tx("a", date(2026, 3, 20), 1000.0), bucket_id="groceries"),)
+    report = aggregate(classified, config=config, window_start=date(2026, 3, 15), window_end=date(2026, 4, 30))
+
+    (bucket_report,) = report.buckets
+    days = (date(2026, 4, 30) - date(2026, 3, 15)).days + 1
+    assert bucket_report.window_monthly_avg == pytest.approx(1000.0 / days * DAYS_PER_MONTH)
+
+
+def test_inflow_average_keeps_sign() -> None:
+    # Plaid signs inflows negative; the day-normalized average must stay signed so the UI can
+    # tell expense-side from income-side buckets.
+    config = _single_bucket_config()
+    classified = (Classified(transaction=_tx("r", date(2026, 1, 10), -500.0), bucket_id="groceries"),)
+    report = aggregate(classified, config=config, window_start=date(2026, 1, 1), window_end=date(2026, 1, 31))
+
+    (bucket_report,) = report.buckets
+    assert bucket_report.window_monthly_avg < 0
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/budget/wire.py
+++ b/augur/budget/wire.py
@@ -42,11 +42,17 @@ class BucketView(ApiModel):
 
 
 class BucketMonthly(ApiModel):
-    """One bucket's monthly trend (and a 3-month average to anchor the trim UI)."""
+    """One bucket's monthly trend plus a day-normalized monthly average over the window."""
 
     bucket_id: str
     monthly_amounts: tuple[float, ...] = Field(description="Signed totals per month; + outflow, - inflow.")
-    current_monthly_avg: float = Field(description="Trailing 3-month average (or fewer if the window is shorter).")
+    window_monthly_avg: float = Field(
+        description=(
+            "Signed window total / days actually covered, scaled to an average month "
+            "(365.25/12 days). Day-normalized so a partial current month or a mid-month "
+            "coverage start isn't counted as a whole month."
+        )
+    )
     transaction_count: NonNegativeInt
 
 

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -471,17 +471,17 @@ export function BudgetWorkspace() {
 
   const rows = useMemo(() => {
     if (!snapshot) return [];
-    const n = snapshot.months.length || 1;
     return snapshot.monthlyByBucket.map((series) => {
       const bucket = bucketsById.get(series.bucketId);
-      const windowAvg = series.monthlyAmounts.reduce((acc, x) => acc + x, 0) / n;
       return {
         bucketId: series.bucketId,
         label: bucket?.label ?? series.bucketId,
         kind: bucket?.kind ?? "expense",
         family: bucket?.family ?? null,
         monthlyAmounts: series.monthlyAmounts,
-        windowAvg,
+        // Day-normalized $/mo from the backend (signed window total / days covered × avg
+        // days/mo). Not sum/months, which counted a partial current month as a full one.
+        windowAvg: series.windowMonthlyAvg,
         transactionCount: series.transactionCount,
       };
     });


### PR DESCRIPTION
## Problem

The budget view computed each bucket's "$/mo" average by dividing the window total by the **number of calendar months it spanned** — counting the partial current month (and, under a mid-month `coverage_starts`, the first month) as a whole month. With today being early in the month, that biased every average toward zero by up to a full month's worth.

The skew lived in two places:

- **Frontend** (`budget.tsx`) — `sum(monthlyAmounts) / months.length`. This is the number actually displayed (bucket rows, family Out/In/Net rollups, headline cards).
- **Backend** (`aggregate.py`) — `current_monthly_avg`, a trailing-3-month average over a denominator of 3 that also included the partial month. It was **dead on the wire**: the frontend recomputed its own average and never read it.

## Fix

Compute the average once on the backend over the real covered span `[start, today]`:

```
window_monthly_avg = signed window total / days actually covered × DAYS_PER_MONTH
```

Counting *days* (not calendar-month slots) makes a partial current month or a mid-month coverage start weigh proportionally instead of as a whole month. Uses the existing `augur.dates.DAYS_PER_MONTH` (Gregorian 365.2425/12). The frontend now consumes this field directly, and the dead `current_monthly_avg` field is removed. The sign is preserved (+ outflow / − inflow) so the UI's expense-vs-income/transfer logic is unchanged.

`_resolve_window` now returns just the start month (the window always ends at `today`), dropping the unused `end_month`.

## Tests

New `augur/budget/test_aggregate.py`:
- partial current month reads near the true run-rate (not `total / 3`)
- mid-month coverage start isn't counted as a whole month
- inflow averages keep their negative sign

Verified on RBE (`d65626b3-42e4-4e5a-8bf3-8fc7c3dd634b`): `//augur/budget:test_aggregate`, `//augur/api:export_schema_test` (wire rename → valid OpenAPI), and `//augur/frontend:tsc_test` (frontend typechecks against the regenerated Zod schema) all pass.

https://claude.ai/code/session_01MtV3Xd5GdpFrCYg4qxykgY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtV3Xd5GdpFrCYg4qxykgY)_