### PR TITLE
augur: drop legacy "Terminal scenario comparison" visual-test guard

### DIFF
--- a/augur/visual_test.py
+++ b/augur/visual_test.py
@@ -118,7 +118,6 @@ def _wait_for_product_page(page: Page) -> None:
         """,
         timeout=30_000,
     )
-    assert page.get_by_text("Terminal scenario comparison").count() == 0
     assert page.evaluate("() => document.documentElement.scrollWidth <= window.innerWidth + 1")
     page.evaluate("() => document.fonts.ready.then(() => true)")
     _wait_for_product_chart_geometry(page)


### PR DESCRIPTION
## What

Removes a single stale assertion from `augur/visual_test.py`:

```python
assert page.get_by_text("Terminal scenario comparison").count() == 0
```

## Why

This guarded against a multi-scenario comparison surface that was removed from the product view. It no longer maps to any feature — it just asserts that deleted UI stays deleted, which is noise. When the multi-scenario fan overlay is reintroduced (per `plans/roadmap.md`, `sim/TODO.md`, `TODO.md`), it will be replaced by a *positive* visual case that asserts the comparison renders.

Landing this separately keeps the upcoming feature diff focused.

## Test

`//augur:visual_test` passes on RBE (the assertion removal is purely subtractive and cannot change any golden screenshot):

`BAZEL_TEST_INVOCATIONS=buildbuddy:69852674-ce2d-4b33-a24c-4bdeb26fdb15`

https://claude.ai/code/session_01EcdxgZg2XD5jg4Eef9hqvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcdxgZg2XD5jg4Eef9hqvg)_