### PR TITLE
augur/budget: split transfers by direction + assert single-direction

### DIFF
--- a/augur/budget/BUILD.bazel
+++ b/augur/budget/BUILD.bazel
@@ -27,6 +27,18 @@ py_library(
     ],
 )
 
+py_test(
+    name = "test_categorize",
+    srcs = ["test_categorize.py"],
+    deps = [
+        ":categorize",
+        ":schema",
+        "//plaid_utils:schema",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 py_library(
     name = "aggregate",
     srcs = ["aggregate.py"],

--- a/augur/budget/README.md
+++ b/augur/budget/README.md
@@ -66,7 +66,10 @@ budget:
     - { id: esketamine, label: Esketamine (net of Anthem), kind: reimbursable, reimbursed_by: medical_reimbursement }
     - { id: therapy, label: Therapy (net of Anthem), kind: reimbursable, reimbursed_by: medical_reimbursement }
     - { id: medical_other, label: Other medical, kind: expense }
-    - { id: transfers, label: Transfers (internal), kind: transfer }
+    # Transfers are split by direction so each bucket stays single-sided (the categorizer
+    # asserts a transfer bucket never mixes inflow and outflow).
+    - { id: transfers_out, label: Transfers out (internal), kind: transfer }
+    - { id: transfers_in, label: Transfers in (internal), kind: transfer }
     - { id: income, label: Income, kind: income }
     - { id: other, label: Uncategorized, kind: expense }
 

--- a/augur/budget/categorize.py
+++ b/augur/budget/categorize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from augur.budget.default_rules import DEFAULT_RULES
-from augur.budget.schema import BudgetConfig, MerchantSubstringRule, NameSubstringRule, PfcRule, Rule
+from augur.budget.schema import BucketKind, BudgetConfig, MerchantSubstringRule, NameSubstringRule, PfcRule, Rule
 from plaid_utils.schema import TransactionRow
 
 
@@ -50,4 +50,42 @@ def classify(transactions: tuple[TransactionRow, ...], *, config: BudgetConfig) 
                 matched_bucket = rule.bucket_id
                 break
         classified.append(Classified(transaction=tx, bucket_id=matched_bucket or config.default_bucket_id))
-    return tuple(classified)
+    result = tuple(classified)
+    assert_transfer_directions(result, config=config)
+    return result
+
+
+def _describe(tx: TransactionRow) -> str:
+    return f"{tx.date} {tx.merchant_name or tx.name} {tx.amount:+.2f}"
+
+
+def assert_transfer_directions(classified: tuple[Classified, ...], *, config: BudgetConfig) -> None:
+    """A `kind=transfer` bucket must stay single-direction (all outflow or all inflow).
+
+    Transfers are internal account movements; the snapshot splits them into an outflow-side and an
+    inflow-side bucket (transfers_out / transfers_in) so each reads as a clean expense-like or
+    income-like figure instead of a net that hides the gross legs. A transfer bucket carrying both
+    signs means a rule routed opposing flows into one bucket -- raise so the miscategorization
+    surfaces instead of silently netting to a meaningless number. (Plaid signs outflows positive,
+    inflows negative.)
+    """
+    kind_by_bucket = {bucket.id: bucket.kind for bucket in config.buckets}
+    outflow: dict[str, TransactionRow] = {}
+    inflow: dict[str, TransactionRow] = {}
+    for entry in classified:
+        if kind_by_bucket[entry.bucket_id] != BucketKind.TRANSFER:
+            continue
+        if entry.transaction.amount > 0:
+            outflow.setdefault(entry.bucket_id, entry.transaction)
+        elif entry.transaction.amount < 0:
+            inflow.setdefault(entry.bucket_id, entry.transaction)
+    if mixed := sorted(outflow.keys() & inflow.keys()):
+        detail = "; ".join(
+            f"{bucket_id} (out e.g. {_describe(outflow[bucket_id])}, in e.g. {_describe(inflow[bucket_id])})"
+            for bucket_id in mixed
+        )
+        raise ValueError(
+            "transfer bucket(s) mix outflow and inflow, netting opposing legs into a misleading "
+            f"figure: {detail}. Route each direction to its own bucket (e.g. transfers_out / "
+            "transfers_in) or add a rule."
+        )

--- a/augur/budget/default_rules.py
+++ b/augur/budget/default_rules.py
@@ -29,7 +29,8 @@ DEFAULT_BUCKET_IDS = frozenset(
         "taxes",
         "travel",
         "government",
-        "transfers",
+        "transfers_out",
+        "transfers_in",
         "income",
         "bank_fees",
         "personal_care",
@@ -139,15 +140,18 @@ DEFAULT_RULES: tuple[Rule, ...] = (
     PfcRule(primary="GOVERNMENT_AND_NON_PROFIT", detailed="GOVERNMENT_AND_NON_PROFIT_DONATIONS", bucket_id="donations"),
     PfcRule(primary="GOVERNMENT_AND_NON_PROFIT", bucket_id="government"),
     PfcRule(primary="TRAVEL", bucket_id="travel"),
-    # Transfers / loan payments are internal-account movements, not spending. They get their
-    # own bucket so they show in the snapshot but are excluded from net-spend rollups.
-    PfcRule(primary="TRANSFER_OUT", bucket_id="transfers"),
-    PfcRule(primary="TRANSFER_IN", bucket_id="transfers"),
-    PfcRule(primary="LOAN_PAYMENTS", bucket_id="transfers"),
-    PfcRule(primary="LOAN_DISBURSEMENTS", bucket_id="transfers"),
-    # Tax refunds aren't "income" -- they're a return of taxes the user already paid, and
-    # augur's tax model accounts for the actual burden separately. Route to `taxes` (transfer
-    # kind) so the refund doesn't double-count against income / inflate spendable monthly avg.
+    # Transfers / loan movements are internal-account flows, not spending -- they get their own
+    # buckets (excluded from net-spend rollups), split by direction so each side reads as a clean
+    # outflow or inflow instead of netting to a misleading number. Plaid signs outflows positive,
+    # inflows negative; categorize.assert_transfer_directions enforces that a transfer bucket
+    # never carries both.
+    PfcRule(primary="TRANSFER_OUT", bucket_id="transfers_out"),
+    PfcRule(primary="LOAN_PAYMENTS", bucket_id="transfers_out"),
+    PfcRule(primary="TRANSFER_IN", bucket_id="transfers_in"),
+    PfcRule(primary="LOAN_DISBURSEMENTS", bucket_id="transfers_in"),
+    # Tax refunds aren't "income" -- they're a return of taxes the user already paid, and augur's
+    # tax model accounts for the actual burden separately. Route to the `taxes` expense bucket so
+    # the refund nets against tax payments (a negative expense) rather than counting as income.
     PfcRule(primary="INCOME", detailed="INCOME_TAX_REFUND", bucket_id="taxes"),
     # True income (paychecks) goes last so that more-specific rules (HCCLAIMPMT, brokerage
     # transfers that Plaid mis-tags as INCOME_CONTRACTOR) get the chance to override it.

--- a/augur/budget/test_categorize.py
+++ b/augur/budget/test_categorize.py
@@ -1,0 +1,94 @@
+"""Categorization tests: transfer-direction split and the single-direction invariant."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import pytest_bazel
+
+from augur.budget.categorize import Classified, assert_transfer_directions, classify
+from augur.budget.schema import BucketDef, BucketKind, BudgetConfig, BudgetSourceConfig
+from plaid_utils.schema import TransactionRow
+
+# Plaid signs outflows positive, inflows negative.
+_TRANSFER_BUCKETS = (
+    BucketDef(id="transfers_out", label="Transfers out", kind=BucketKind.TRANSFER),
+    BucketDef(id="transfers_in", label="Transfers in", kind=BucketKind.TRANSFER),
+)
+
+
+def _tx(transaction_id: str, *, amount: float, pfc_primary: str | None = None) -> TransactionRow:
+    return TransactionRow(
+        transaction_id=transaction_id,
+        account_id="acct",
+        item_id="item",
+        date=date(2026, 1, 15),
+        amount=amount,
+        name=transaction_id,
+        merchant_name=None,
+        pending=False,
+        pfc_primary=pfc_primary,
+        pfc_detailed=None,
+        raw_json={},
+    )
+
+
+def _config(*buckets: BucketDef, include_default_rules: bool = False) -> BudgetConfig:
+    return BudgetConfig(
+        source=BudgetSourceConfig(),
+        buckets=(*buckets, BucketDef(id="other", label="Other", kind=BucketKind.EXPENSE)),
+        default_bucket_id="other",
+        include_default_rules=include_default_rules,
+    )
+
+
+def test_default_rules_split_transfers_by_direction() -> None:
+    config = _config(*_TRANSFER_BUCKETS, include_default_rules=True)
+    txns = (
+        _tx("out", amount=500.0, pfc_primary="TRANSFER_OUT"),
+        _tx("loan_pay", amount=300.0, pfc_primary="LOAN_PAYMENTS"),
+        _tx("in", amount=-700.0, pfc_primary="TRANSFER_IN"),
+        _tx("loan_disb", amount=-900.0, pfc_primary="LOAN_DISBURSEMENTS"),
+    )
+    routed = {entry.transaction.transaction_id: entry.bucket_id for entry in classify(txns, config=config)}
+    assert routed == {
+        "out": "transfers_out",
+        "loan_pay": "transfers_out",
+        "in": "transfers_in",
+        "loan_disb": "transfers_in",
+    }
+
+
+def test_single_direction_transfer_buckets_pass() -> None:
+    config = _config(*_TRANSFER_BUCKETS)
+    classified = (
+        Classified(transaction=_tx("a", amount=500.0), bucket_id="transfers_out"),
+        Classified(transaction=_tx("b", amount=-700.0), bucket_id="transfers_in"),
+    )
+    assert_transfer_directions(classified, config=config)  # does not raise
+
+
+def test_mixed_direction_transfer_bucket_raises() -> None:
+    # A single transfer bucket holding both an outflow and an inflow nets opposing legs.
+    config = _config(BucketDef(id="transfers", label="Transfers", kind=BucketKind.TRANSFER))
+    classified = (
+        Classified(transaction=_tx("out", amount=500.0), bucket_id="transfers"),
+        Classified(transaction=_tx("in", amount=-500.0), bucket_id="transfers"),
+    )
+    with pytest.raises(ValueError, match="transfers"):
+        assert_transfer_directions(classified, config=config)
+
+
+def test_expense_bucket_may_mix_signs() -> None:
+    # Refunds make an expense bucket legitimately two-signed; the invariant is transfer-only.
+    config = _config(BucketDef(id="taxes", label="Taxes", kind=BucketKind.EXPENSE))
+    classified = (
+        Classified(transaction=_tx("pay", amount=4000.0), bucket_id="taxes"),
+        Classified(transaction=_tx("refund", amount=-1500.0), bucket_id="taxes"),
+    )
+    assert_transfer_directions(classified, config=config)  # does not raise
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Problem

Plaid `TRANSFER_IN` / `TRANSFER_OUT` (and the loan legs `LOAN_PAYMENTS` / `LOAN_DISBURSEMENTS`) all routed to a single `transfers` bucket. Its monthly total was therefore the **net** of inflow and outflow — a number that hides the gross legs and whose sign flips on noise. The frontend then inferred the bucket's direction from that net sign, so a transfer bucket couldn't cleanly read as expense-side or income-side.

## Fix

Split by direction (Plaid signs outflows positive, inflows negative):

- `TRANSFER_OUT`, `LOAN_PAYMENTS` → **`transfers_out`** (outflow / expense-like)
- `TRANSFER_IN`, `LOAN_DISBURSEMENTS` → **`transfers_in`** (inflow / income-like)

Add `categorize.assert_transfer_directions`: a `kind=transfer` bucket must hold a single direction (all outflow or all inflow). `classify()` enforces it, so a rule that routes opposing flows into one transfer bucket raises a `ValueError` with the offending bucket + example legs (surfaced as a 400 by the existing handler) instead of silently netting to a meaningless figure. The frontend's existing sign-based direction logic is unchanged and now always sees a single-signed series per transfer bucket.

Also corrected the `taxes` rule comment: it's an **expense** bucket where a refund nets as a negative expense — not "transfer kind". (A transfer-kind bucket mixing tax payments and refunds would, correctly, trip the new assertion.)

## ⚠️ Cross-repo follow-up

The actual bucket list lives in the private gaffer config, not here. **That config must define `transfers_out` / `transfers_in` buckets** (the README example is updated to match). Until it does, transfer transactions fall through to `default_bucket_id`. No other ducktape references to the old `transfers` bucket exist.

## Tests

New `augur/budget/test_categorize.py`:
- default rules route each Plaid transfer/loan PFC to the correct directional bucket
- single-direction transfer buckets pass
- a transfer bucket mixing signs raises
- an expense bucket may mix signs (refunds) — the invariant is transfer-only

Verified on RBE (`99950f94-e692-4e97-b33c-ba09dbd89c79`): `//augur/budget/...` and `//augur/api:export_schema_test` pass.

## Note

This is independent of and stacks cleanly on #1810 (day-normalized averages), already merged.

The README's `reimbursable` / `reimbursement` / `reimbursed_by` example lines are stale vs the current `BucketKind` (expense/inflow/transfer/income) — left untouched here to keep this PR focused; worth a separate doc cleanup.

https://claude.ai/code/session_01MtV3Xd5GdpFrCYg4qxykgY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtV3Xd5GdpFrCYg4qxykgY)_