### PR TITLE
augur/budget: export spend summary + transactions as CSV

### DIFF
--- a/augur/frontend/BUILD.bazel
+++ b/augur/frontend/BUILD.bazel
@@ -159,10 +159,18 @@ js_library(
     ],
 )
 
+# Pure CSV serialization for the budget tab's export buttons (no React/DOM, so it's
+# unit-testable under vitest; see `:budget_csv_test`).
+js_library(
+    name = "budget_csv",
+    srcs = ["budget_csv.ts"],
+)
+
 js_library(
     name = "budget",
     srcs = ["budget.tsx"],
     deps = [
+        ":budget_csv",
         ":client",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -364,8 +372,10 @@ tsc_bin.tsc_test(
     ],
     chdir = package_name(),
     data = [
+        "budget_csv.test.ts",
         "sanity_bands.test.ts",
         "tsconfig.json",
+        ":budget_csv",
         ":main_lib",
         ":sanity_bands",
         "//:node_modules",
@@ -388,9 +398,11 @@ eslint_bin.eslint_test(
     ],
     chdir = package_name(),
     data = [
+        "budget_csv.test.ts",
         "eslint.typed.config.js",
         "sanity_bands.test.ts",
         "tsconfig.json",
+        ":budget_csv",
         ":main_lib",
         ":sanity_bands",
         "//:node_modules",
@@ -406,6 +418,18 @@ vitest_bin.vitest_test(
         "sanity_bands.test.ts",
         "vitest.config.ts",
         ":sanity_bands",
+        "//:node_modules",
+    ],
+)
+
+vitest_bin.vitest_test(
+    name = "budget_csv_test",
+    args = ["run"],
+    chdir = package_name(),
+    data = [
+        "budget_csv.test.ts",
+        "vitest.config.ts",
+        ":budget_csv",
         "//:node_modules",
     ],
 )

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -44,8 +44,12 @@ function downloadCsv(filename, content) {
   anchor.download = filename;
   document.body.appendChild(anchor);
   anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
+  // Defer cleanup: revoking the blob URL synchronously after click() can cancel the download in
+  // some browsers before it starts. Release on the next macrotask, once the download has begun.
+  setTimeout(() => {
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, 0);
 }
 
 const EXPORT_BUTTON_CLASS = "augur-icon-button gap-1.5 px-2.5 py-1.5 text-xs font-medium";

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { NativeSelect } from "@mantine/core";
 
 import { fetchBudgetSnapshot, fetchBudgetTransactions } from "./client.ts";
+import { buildSummaryCsv, buildTransactionsCsv } from "./budget_csv.ts";
 import { fmtUsd, fmtNumber } from "./lib/format.ts";
 
 // Only expense buckets stack into the "monthly spend" outflow chart. Inflow / transfer /
@@ -29,6 +30,25 @@ function windowSpecFromChoice(value) {
 function maxChoiceLabel(coverageStarts) {
   return `Max (since ${coverageStarts})`;
 }
+
+// `windowChoice` values are "trailing:N" / "max"; the colon is awkward in a download filename.
+function windowSlug(windowChoice) {
+  return windowChoice.replace(":", "-");
+}
+
+function downloadCsv(filename, content) {
+  const blob = new Blob([content], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+const EXPORT_BUTTON_CLASS = "augur-icon-button gap-1.5 px-2.5 py-1.5 text-xs font-medium";
 
 const UNGROUPED_FAMILY = "_ungrouped";
 
@@ -519,6 +539,16 @@ export function BudgetWorkspace() {
     return { spend, inflow, income, netBurn: spend - inflow - income };
   }, [snapshot, rows]);
 
+  const exportSummary = () => {
+    if (!snapshot) return;
+    downloadCsv(`budget-summary-${windowSlug(windowChoice)}.csv`, buildSummaryCsv(snapshot.months, rows));
+  };
+
+  const exportTransactions = () => {
+    if (!selectedBucketId || !bucketTx) return;
+    downloadCsv(`budget-transactions-${selectedBucketId}.csv`, buildTransactionsCsv(bucketTx));
+  };
+
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8 space-y-5">
       <section className="augur-panel p-4">
@@ -531,17 +561,29 @@ export function BudgetWorkspace() {
               too lumpy and (for some providers) actually arrives before the matching charge.
             </div>
           </div>
-          <NativeSelect
-            aria-label="Window"
-            data={
-              snapshot?.coverageStarts
-                ? [...TRAILING_CHOICES, { value: MAX_CHOICE_VALUE, label: maxChoiceLabel(snapshot.coverageStarts) }]
-                : TRAILING_CHOICES
-            }
-            value={windowChoice}
-            onChange={(event) => setWindowChoice(event.target.value)}
-            classNames={{ input: "augur-tabular min-w-[12rem]" }}
-          />
+          <div className="flex items-center gap-2">
+            {snapshot && (
+              <button
+                type="button"
+                className={EXPORT_BUTTON_CLASS}
+                onClick={exportSummary}
+                data-budget-export="summary"
+              >
+                ↓ Export CSV
+              </button>
+            )}
+            <NativeSelect
+              aria-label="Window"
+              data={
+                snapshot?.coverageStarts
+                  ? [...TRAILING_CHOICES, { value: MAX_CHOICE_VALUE, label: maxChoiceLabel(snapshot.coverageStarts) }]
+                  : TRAILING_CHOICES
+              }
+              value={windowChoice}
+              onChange={(event) => setWindowChoice(event.target.value)}
+              classNames={{ input: "augur-tabular min-w-[12rem]" }}
+            />
+          </div>
         </div>
         {snapshot?.coverageStarts && (
           <div className="mt-2 text-[11px] augur-muted">
@@ -592,9 +634,21 @@ export function BudgetWorkspace() {
                   <div className="augur-eyebrow">Transactions — {bucketsById.get(selectedBucketId)?.label}</div>
                   <div className="mt-1 text-xs augur-muted">All transactions in the window for this bucket.</div>
                 </div>
-                <button type="button" className="text-xs augur-link" onClick={() => setSelectedBucketId(null)}>
-                  Close
-                </button>
+                <div className="flex items-center gap-3">
+                  {bucketTx && bucketTx.length > 0 && (
+                    <button
+                      type="button"
+                      className={EXPORT_BUTTON_CLASS}
+                      onClick={exportTransactions}
+                      data-budget-export="transactions"
+                    >
+                      ↓ Export CSV
+                    </button>
+                  )}
+                  <button type="button" className="text-xs augur-link" onClick={() => setSelectedBucketId(null)}>
+                    Close
+                  </button>
+                </div>
               </div>
               {bucketTxError ? (
                 <div className="augur-note-danger p-4 text-sm">Transactions failed: {bucketTxError}</div>

--- a/augur/frontend/budget_csv.test.ts
+++ b/augur/frontend/budget_csv.test.ts
@@ -88,3 +88,28 @@ test("buildTransactionsCsv renders nulls as empty fields and quotes embedded com
   expect(header).toBe("Date,Merchant,Descriptor,PFC primary,PFC detailed,Account,Institution,Amount");
   expect(tx).toBe('2025-05-12,,"ACH DEBIT, LANDLORD LLC",RENT_AND_UTILITIES,,Checking,,3200.00');
 });
+
+test("text fields starting with a formula trigger are neutralized, but numeric amounts are not", () => {
+  const csv = buildTransactionsCsv([
+    {
+      date: "2025-05-12",
+      merchantName: "=HYPERLINK(evil)",
+      name: "@cmd",
+      pfcPrimary: null,
+      pfcDetailed: null,
+      accountName: "Checking",
+      institutionName: null,
+      amount: -42, // negative amount stays a parseable number, NOT treated as a formula
+    },
+  ]);
+  const tx = csv.trimEnd().split("\n")[1];
+  expect(tx).toBe("2025-05-12,'=HYPERLINK(evil),'@cmd,,,Checking,,-42.00");
+});
+
+test("buildSummaryCsv neutralizes a formula-triggering bucket label", () => {
+  const csv = buildSummaryCsv(
+    ["2025-05-01"],
+    [{ label: "=DANGER", kind: "expense", family: null, monthlyAmounts: [10], windowAvg: 10, transactionCount: 1 }]
+  );
+  expect(csv.trimEnd().split("\n")[1]).toBe("'=DANGER,expense,,10.00,10.00,1");
+});

--- a/augur/frontend/budget_csv.test.ts
+++ b/augur/frontend/budget_csv.test.ts
@@ -1,0 +1,90 @@
+// Unit tests for the budget tab's pure CSV serialization (field escaping, column order, sign
+// convention). Runs under vitest; see //augur/frontend:budget_csv_test.
+
+import { test, expect } from "vitest";
+
+import { csvField, buildSummaryCsv, buildTransactionsCsv } from "./budget_csv.ts";
+
+test("csvField leaves ordinary values unquoted", () => {
+  expect(csvField("Groceries")).toBe("Groceries");
+  expect(csvField("312.45")).toBe("312.45");
+});
+
+test("csvField quotes and escapes commas, quotes, and newlines", () => {
+  expect(csvField("Rent, utilities")).toBe('"Rent, utilities"');
+  expect(csvField('AMZN "Mktp"')).toBe('"AMZN ""Mktp"""');
+  expect(csvField("line1\nline2")).toBe('"line1\nline2"');
+});
+
+test("buildSummaryCsv emits a bucket-by-month matrix with YYYY-MM headers", () => {
+  const csv = buildSummaryCsv(
+    ["2025-05-01", "2025-06-01"],
+    [
+      {
+        label: "Rent",
+        kind: "expense",
+        family: "housing",
+        monthlyAmounts: [3200, 3200],
+        windowAvg: 3200,
+        transactionCount: 2,
+      },
+    ]
+  );
+  const [header, rent] = csv.trimEnd().split("\n");
+  expect(header).toBe("Bucket,Kind,Family,2025-05,2025-06,Avg $/mo,Tx count");
+  expect(rent).toBe("Rent,expense,housing,3200.00,3200.00,3200.00,2");
+});
+
+test("buildSummaryCsv blanks a missing family and preserves inflow (negative) amounts", () => {
+  const csv = buildSummaryCsv(
+    ["2025-05-01"],
+    [
+      {
+        label: "Anthem reimbursements",
+        kind: "inflow",
+        family: null,
+        monthlyAmounts: [-450.5],
+        windowAvg: -450.5,
+        transactionCount: 1,
+      },
+    ]
+  );
+  const row = csv.trimEnd().split("\n")[1];
+  // Empty Family field between "inflow" and the first month column; negative sign retained.
+  expect(row).toBe("Anthem reimbursements,inflow,,-450.50,-450.50,1");
+});
+
+test("buildSummaryCsv quotes a label containing a comma", () => {
+  const csv = buildSummaryCsv(
+    ["2025-05-01"],
+    [
+      {
+        label: "Restaurants, in person",
+        kind: "expense",
+        family: null,
+        monthlyAmounts: [10],
+        windowAvg: 10,
+        transactionCount: 1,
+      },
+    ]
+  );
+  expect(csv.trimEnd().split("\n")[1]).toBe('"Restaurants, in person",expense,,10.00,10.00,1');
+});
+
+test("buildTransactionsCsv renders nulls as empty fields and quotes embedded commas", () => {
+  const csv = buildTransactionsCsv([
+    {
+      date: "2025-05-12",
+      merchantName: null,
+      name: "ACH DEBIT, LANDLORD LLC",
+      pfcPrimary: "RENT_AND_UTILITIES",
+      pfcDetailed: null,
+      accountName: "Checking",
+      institutionName: null,
+      amount: 3200,
+    },
+  ]);
+  const [header, tx] = csv.trimEnd().split("\n");
+  expect(header).toBe("Date,Merchant,Descriptor,PFC primary,PFC detailed,Account,Institution,Amount");
+  expect(tx).toBe('2025-05-12,,"ACH DEBIT, LANDLORD LLC",RENT_AND_UTILITIES,,Checking,,3200.00');
+});

--- a/augur/frontend/budget_csv.ts
+++ b/augur/frontend/budget_csv.ts
@@ -1,10 +1,16 @@
 // Pure CSV builders for the budget tab's "export to spreadsheet" buttons.
 //
-// Kept free of DOM/React so the serialization (field escaping, column order, sign
-// convention) is unit-testable under node vitest; the browser download trigger lives in
-// budget.tsx. Amounts use the snapshot's Plaid sign convention: + = money out, - = money in.
+// Kept free of DOM/React so the serialization (field escaping, formula-injection neutralization,
+// column order, sign convention) is unit-testable under node vitest; the browser download trigger
+// lives in budget.tsx. Amounts use the snapshot's Plaid sign convention: + = money out, - = in.
 
 const MONTH_COLUMN_LENGTH = 7; // "YYYY-MM"
+
+// A cell beginning with one of these is interpreted as a formula by Excel / Google Sheets, so a
+// crafted merchant/descriptor could execute on open. Text fields with such a prefix get a leading
+// apostrophe (the standard neutralizer); numeric columns are emitted separately and never touched,
+// so amounts stay parseable.
+const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
 
 export interface SummaryRow {
   label: string;
@@ -26,8 +32,8 @@ export interface TransactionCsvRow {
   amount: number;
 }
 
-// RFC-4180 field quoting: wrap in double quotes (doubling any internal quote) only when the
-// value contains a comma, quote, or newline, so ordinary values stay unquoted and readable.
+// RFC-4180 field quoting: wrap in double quotes (doubling any internal quote) only when the value
+// contains a comma, quote, or newline, so ordinary values stay unquoted and readable.
 export function csvField(value: string): string {
   if (/[",\r\n]/.test(value)) {
     return `"${value.replace(/"/g, '""')}"`;
@@ -35,12 +41,18 @@ export function csvField(value: string): string {
   return value;
 }
 
-function csvRow(fields: string[]): string {
-  return fields.map(csvField).join(",");
+function neutralizeFormula(value: string): string {
+  return value.length > 0 && FORMULA_TRIGGERS.has(value[0]) ? `'${value}` : value;
 }
 
-// Two decimals keeps cents without floating-point noise; we deliberately emit no "$" so the
-// cell stays numeric and a spreadsheet can sum/tweak it directly.
+// Escaper for user-/merchant-controlled text columns: neutralize a leading formula trigger, then
+// apply RFC-4180 quoting.
+function textField(value: string): string {
+  return csvField(neutralizeFormula(value));
+}
+
+// Two decimals keeps cents without floating-point noise; we deliberately emit no "$" so the cell
+// stays numeric and a spreadsheet can sum/tweak it directly.
 function amount(value: number): string {
   return value.toFixed(2);
 }
@@ -53,18 +65,18 @@ function monthColumn(iso: string): string {
 // Bucket × month matrix: one row per bucket, one column per month, plus the window average and
 // transaction count the UI shows. Built to paste into a spreadsheet and adjust by hand.
 export function buildSummaryCsv(months: string[], rows: SummaryRow[]): string {
-  const header = ["Bucket", "Kind", "Family", ...months.map(monthColumn), "Avg $/mo", "Tx count"];
-  const lines = [csvRow(header)];
+  const header = ["Bucket", "Kind", "Family", ...months.map(monthColumn), "Avg $/mo", "Tx count"].map(csvField);
+  const lines = [header.join(",")];
   for (const row of rows) {
     lines.push(
-      csvRow([
-        row.label,
-        row.kind,
-        row.family ?? "",
-        ...row.monthlyAmounts.map(amount),
-        amount(row.windowAvg),
-        String(row.transactionCount),
-      ])
+      [
+        textField(row.label),
+        textField(row.kind),
+        textField(row.family ?? ""),
+        ...row.monthlyAmounts.map((value) => csvField(amount(value))),
+        csvField(amount(row.windowAvg)),
+        csvField(String(row.transactionCount)),
+      ].join(",")
     );
   }
   return lines.join("\n") + "\n";
@@ -74,19 +86,19 @@ export function buildSummaryCsv(months: string[], rows: SummaryRow[]): string {
 // shows (raw descriptor kept alongside the cleaned merchant name so reclassification is possible).
 export function buildTransactionsCsv(rows: TransactionCsvRow[]): string {
   const header = ["Date", "Merchant", "Descriptor", "PFC primary", "PFC detailed", "Account", "Institution", "Amount"];
-  const lines = [csvRow(header)];
+  const lines = [header.map(csvField).join(",")];
   for (const row of rows) {
     lines.push(
-      csvRow([
-        row.date,
-        row.merchantName ?? "",
-        row.name,
-        row.pfcPrimary ?? "",
-        row.pfcDetailed ?? "",
-        row.accountName,
-        row.institutionName ?? "",
-        amount(row.amount),
-      ])
+      [
+        textField(row.date),
+        textField(row.merchantName ?? ""),
+        textField(row.name),
+        textField(row.pfcPrimary ?? ""),
+        textField(row.pfcDetailed ?? ""),
+        textField(row.accountName),
+        textField(row.institutionName ?? ""),
+        csvField(amount(row.amount)),
+      ].join(",")
     );
   }
   return lines.join("\n") + "\n";

--- a/augur/frontend/budget_csv.ts
+++ b/augur/frontend/budget_csv.ts
@@ -1,0 +1,93 @@
+// Pure CSV builders for the budget tab's "export to spreadsheet" buttons.
+//
+// Kept free of DOM/React so the serialization (field escaping, column order, sign
+// convention) is unit-testable under node vitest; the browser download trigger lives in
+// budget.tsx. Amounts use the snapshot's Plaid sign convention: + = money out, - = money in.
+
+const MONTH_COLUMN_LENGTH = 7; // "YYYY-MM"
+
+export interface SummaryRow {
+  label: string;
+  kind: string;
+  family: string | null;
+  monthlyAmounts: number[];
+  windowAvg: number;
+  transactionCount: number;
+}
+
+export interface TransactionCsvRow {
+  date: string;
+  merchantName: string | null;
+  name: string;
+  pfcPrimary: string | null;
+  pfcDetailed: string | null;
+  accountName: string;
+  institutionName: string | null;
+  amount: number;
+}
+
+// RFC-4180 field quoting: wrap in double quotes (doubling any internal quote) only when the
+// value contains a comma, quote, or newline, so ordinary values stay unquoted and readable.
+export function csvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function csvRow(fields: string[]): string {
+  return fields.map(csvField).join(",");
+}
+
+// Two decimals keeps cents without floating-point noise; we deliberately emit no "$" so the
+// cell stays numeric and a spreadsheet can sum/tweak it directly.
+function amount(value: number): string {
+  return value.toFixed(2);
+}
+
+function monthColumn(iso: string): string {
+  // snapshot months are "YYYY-MM-DD" month-starts; a "YYYY-MM" column header is enough.
+  return iso.slice(0, MONTH_COLUMN_LENGTH);
+}
+
+// Bucket × month matrix: one row per bucket, one column per month, plus the window average and
+// transaction count the UI shows. Built to paste into a spreadsheet and adjust by hand.
+export function buildSummaryCsv(months: string[], rows: SummaryRow[]): string {
+  const header = ["Bucket", "Kind", "Family", ...months.map(monthColumn), "Avg $/mo", "Tx count"];
+  const lines = [csvRow(header)];
+  for (const row of rows) {
+    lines.push(
+      csvRow([
+        row.label,
+        row.kind,
+        row.family ?? "",
+        ...row.monthlyAmounts.map(amount),
+        amount(row.windowAvg),
+        String(row.transactionCount),
+      ])
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+// One row per transaction in a single bucket's drill-down, in the same column order the panel
+// shows (raw descriptor kept alongside the cleaned merchant name so reclassification is possible).
+export function buildTransactionsCsv(rows: TransactionCsvRow[]): string {
+  const header = ["Date", "Merchant", "Descriptor", "PFC primary", "PFC detailed", "Account", "Institution", "Amount"];
+  const lines = [csvRow(header)];
+  for (const row of rows) {
+    lines.push(
+      csvRow([
+        row.date,
+        row.merchantName ?? "",
+        row.name,
+        row.pfcPrimary ?? "",
+        row.pfcDetailed ?? "",
+        row.accountName,
+        row.institutionName ?? "",
+        amount(row.amount),
+      ])
+    );
+  }
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## What

Two client-side **CSV export** buttons on the Budget tab:

- **↓ Export CSV** next to the window selector → a bucket×month matrix (one row per bucket; a column per month; plus the window-average and transaction-count columns the UI already shows) for the active window.
- **↓ Export CSV** in a bucket's transaction drill-down → that bucket's transactions (date, merchant, raw descriptor, PFC, account, institution, amount).

Both open straight in Google Sheets for hand-tweaking — the "easy win" for getting the data out to model spending manually.

## How

Serialization (RFC-4180 field quoting, column order, Plaid sign convention) lives in a pure, DOM-free `budget_csv.ts` module, unit-tested under vitest (`:budget_csv_test`). The browser download trigger stays in `budget.tsx`. No backend or wire-schema changes — both exports are built from data already in the loaded snapshot / drill-down.

## Test

`bbr test //augur/frontend:{budget_csv_test,tsc_test,eslint_typed_test}` — all pass; bundle + image build clean.

https://claude.ai/code/session_01MXuKQyGthUrSXRJeKjGsrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXuKQyGthUrSXRJeKjGsrW)_