### PR TITLE
augur/budget: hide buckets + override per-bucket monthly amounts

### DIFF
--- a/augur/frontend/BUILD.bazel
+++ b/augur/frontend/BUILD.bazel
@@ -166,10 +166,18 @@ js_library(
     srcs = ["budget_csv.ts"],
 )
 
+# Pure planning-adjustment model (hidden / override) + URL encoding + adjusted-total math for the
+# budget tab (no React/DOM; see `:budget_adjustments_test`).
+js_library(
+    name = "budget_adjustments",
+    srcs = ["budget_adjustments.ts"],
+)
+
 js_library(
     name = "budget",
     srcs = ["budget.tsx"],
     deps = [
+        ":budget_adjustments",
         ":budget_csv",
         ":client",
         "//:node_modules/@mantine/core",
@@ -372,9 +380,11 @@ tsc_bin.tsc_test(
     ],
     chdir = package_name(),
     data = [
+        "budget_adjustments.test.ts",
         "budget_csv.test.ts",
         "sanity_bands.test.ts",
         "tsconfig.json",
+        ":budget_adjustments",
         ":budget_csv",
         ":main_lib",
         ":sanity_bands",
@@ -398,10 +408,12 @@ eslint_bin.eslint_test(
     ],
     chdir = package_name(),
     data = [
+        "budget_adjustments.test.ts",
         "budget_csv.test.ts",
         "eslint.typed.config.js",
         "sanity_bands.test.ts",
         "tsconfig.json",
+        ":budget_adjustments",
         ":budget_csv",
         ":main_lib",
         ":sanity_bands",
@@ -430,6 +442,18 @@ vitest_bin.vitest_test(
         "budget_csv.test.ts",
         "vitest.config.ts",
         ":budget_csv",
+        "//:node_modules",
+    ],
+)
+
+vitest_bin.vitest_test(
+    name = "budget_adjustments_test",
+    args = ["run"],
+    chdir = package_name(),
+    data = [
+        "budget_adjustments.test.ts",
+        "vitest.config.ts",
+        ":budget_adjustments",
         "//:node_modules",
     ],
 )

--- a/augur/frontend/app.tsx
+++ b/augur/frontend/app.tsx
@@ -364,10 +364,11 @@ function ProductProjectionWorkspace({
   useEffect(() => {
     const params = new URLSearchParams(productInputToSearch(input, bootstrap));
     if (currencyDisplay !== "compact") params.set("fmt", "exact");
-    // The shell-owned shared params live outside the product input. Carry whichever are currently set
-    // across so rewriting the product `?s=` state doesn't drop them.
+    // The shell-owned shared params live outside the product input, as do the budget tab's
+    // planning params (`bhide`/`bset`). Carry whichever are currently set across so rewriting the
+    // product `?s=` state doesn't drop them when switching away from and back to another tab.
     const currentParams = new URLSearchParams(window.location.search);
-    for (const key of ["n", "seed", "x", "h", "scale", "fmt"]) {
+    for (const key of ["n", "seed", "x", "h", "scale", "fmt", "bhide", "bset"]) {
       const value = currentParams.get(key);
       if (value != null) params.set(key, value);
     }

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -342,7 +342,11 @@ function BucketRow({ entry, onSelect, selected, onAdjust }) {
         <button
           type="button"
           className="ml-2 augur-link"
-          onClick={() => onAdjust(entry.bucketId, entry.hidden ? null : { kind: "hidden" })}
+          onClick={() => {
+            // Close the override editor first so a hidden row never keeps a stray open input.
+            setEditing(false);
+            onAdjust(entry.bucketId, entry.hidden ? null : { kind: "hidden" });
+          }}
         >
           {entry.hidden ? "Show" : "Hide"}
         </button>
@@ -595,8 +599,14 @@ export function BudgetWorkspace() {
   const [bucketTx, setBucketTx] = useState(null);
   const [bucketTxError, setBucketTxError] = useState(null);
   // Planning adjustments (hidden buckets / per-bucket overrides) initialized from the URL so a
-  // shared link reopens the same tweaked view; every change is written back in applyAdjustment.
+  // shared link reopens the same tweaked view.
   const [adjustments, setAdjustments] = useState(() => parseAdjustments(window.location.search));
+
+  // Mirror adjustments to the URL whenever they change (replaceState; preserves other params). On
+  // mount this re-emits the params just parsed in, so the no-change guard makes it a no-op.
+  useEffect(() => {
+    writeAdjustmentsToSearch(adjustments);
+  }, [adjustments]);
 
   const windowSpec = useMemo(() => windowSpecFromChoice(windowChoice), [windowChoice]);
 
@@ -697,7 +707,9 @@ export function BudgetWorkspace() {
 
   const exportSummary = () => {
     if (!snapshot) return;
-    downloadCsv(`budget-summary-${windowSlug(windowChoice)}.csv`, buildSummaryCsv(snapshot.months, rows));
+    // Pass the adjusted rows so the export carries the planning overlay (Planned $/mo + Hidden
+    // columns) alongside the historical actuals when any bucket is hidden/overridden.
+    downloadCsv(`budget-summary-${windowSlug(windowChoice)}.csv`, buildSummaryCsv(snapshot.months, adjustedRows));
   };
 
   const exportTransactions = () => {
@@ -706,19 +718,18 @@ export function BudgetWorkspace() {
   };
 
   // null clears the bucket back to "actual"; otherwise set hidden / override. One adjustment per
-  // bucket (hide and override are mutually exclusive). Every change is mirrored to the URL.
+  // bucket (hide and override are mutually exclusive). Functional update so rapid successive
+  // changes each compose on the latest state; the effect above mirrors the result to the URL.
   const applyAdjustment = (bucketId, adjustment) => {
-    const next = new Map(adjustments);
-    if (adjustment) next.set(bucketId, adjustment);
-    else next.delete(bucketId);
-    setAdjustments(next);
-    writeAdjustmentsToSearch(next);
+    setAdjustments((previous) => {
+      const next = new Map(previous);
+      if (adjustment) next.set(bucketId, adjustment);
+      else next.delete(bucketId);
+      return next;
+    });
   };
 
-  const resetAdjustments = () => {
-    setAdjustments(new Map());
-    writeAdjustmentsToSearch(new Map());
-  };
+  const resetAdjustments = () => setAdjustments(new Map());
 
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8 space-y-5">

--- a/augur/frontend/budget.tsx
+++ b/augur/frontend/budget.tsx
@@ -3,6 +3,7 @@ import { NativeSelect } from "@mantine/core";
 
 import { fetchBudgetSnapshot, fetchBudgetTransactions } from "./client.ts";
 import { buildSummaryCsv, buildTransactionsCsv } from "./budget_csv.ts";
+import { parseAdjustments, adjustmentsToParams, effectiveSignedAvg, computeTotals } from "./budget_adjustments.ts";
 import { fmtUsd, fmtNumber } from "./lib/format.ts";
 
 // Only expense buckets stack into the "monthly spend" outflow chart. Inflow / transfer /
@@ -53,6 +54,22 @@ function downloadCsv(filename, content) {
 }
 
 const EXPORT_BUTTON_CLASS = "augur-icon-button gap-1.5 px-2.5 py-1.5 text-xs font-medium";
+
+// Mirror the product/calibration shell's URL-state pattern: rewrite only our two budget params
+// (preserving everything else) so a hidden-rent / overridden view round-trips through the URL.
+function writeAdjustmentsToSearch(adjustments) {
+  const params = new URLSearchParams(window.location.search);
+  const { bhide, bset } = adjustmentsToParams(adjustments);
+  if (bhide) params.set("bhide", bhide);
+  else params.delete("bhide");
+  if (bset) params.set("bset", bset);
+  else params.delete("bset");
+  const search = params.toString();
+  const newUrl = `${window.location.pathname}${search ? "?" + search : ""}${window.location.hash}`;
+  if (newUrl !== window.location.pathname + window.location.search + window.location.hash) {
+    window.history.replaceState(null, "", newUrl);
+  }
+}
 
 const UNGROUPED_FAMILY = "_ungrouped";
 
@@ -230,10 +247,58 @@ function StackedMonthlyChart({ months, bucketSeries }) {
   );
 }
 
-function BucketRow({ entry, onSelect, selected }) {
+// Inline editor for a per-bucket override. Prefills with the bucket's current planned magnitude
+// (the override if set, else the rounded historical average) so "Set" is a one-keystroke tweak.
+function OverrideEditor({ entry, onAdjust, onClose }) {
+  const [draft, setDraft] = useState(() =>
+    entry.overridden ? String(entry.adjustment.monthly) : String(Math.round(Math.abs(entry.windowAvg)))
+  );
+  const commit = () => {
+    const value = Number(draft);
+    if (draft.trim() !== "" && Number.isFinite(value) && value >= 0) {
+      onAdjust(entry.bucketId, { kind: "override", monthly: value });
+    }
+    onClose();
+  };
+  return (
+    <div className="flex items-center justify-end gap-1" onClick={(event) => event.stopPropagation()}>
+      <input
+        type="number"
+        min={0}
+        autoFocus
+        aria-label={`Planned monthly amount for ${entry.label}`}
+        className="augur-input w-24 text-right augur-tabular"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") commit();
+          else if (event.key === "Escape") onClose();
+        }}
+      />
+      <button type="button" className="text-[11px] augur-link" onClick={commit}>
+        Save
+      </button>
+      <button type="button" className="text-[11px] augur-link" onClick={onClose}>
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function BucketRow({ entry, onSelect, selected, onAdjust }) {
+  const [editing, setEditing] = useState(false);
+  const stop = (event) => event.stopPropagation();
+  // Effective figure shown in the $/mo cell: the override when set, otherwise the historical
+  // average. Overridden rows render in accent + carry a "was …" reset line; hidden rows are
+  // dimmed and struck through (they're dropped from totals/chart but stay visible to bring back).
+  const valueClass = entry.overridden
+    ? "font-semibold augur-accent-text"
+    : entry.hidden
+      ? "line-through opacity-70"
+      : "";
   return (
     <tr
-      className={`cursor-pointer transition-colors ${selected ? "bg-sky-50 dark:bg-sky-950/30" : "hover:bg-slate-50 dark:hover:bg-slate-900"}`}
+      className={`cursor-pointer transition-colors ${selected ? "bg-sky-50 dark:bg-sky-950/30" : "hover:bg-slate-50 dark:hover:bg-slate-900"} ${entry.hidden ? "opacity-50" : ""}`}
       onClick={() => onSelect(entry.bucketId)}
       data-budget-bucket-row={entry.bucketId}
     >
@@ -243,21 +308,57 @@ function BucketRow({ entry, onSelect, selected }) {
           <KindBadge kind={entry.kind} />
         </span>
       </th>
-      <td className="px-3 py-2 text-right text-sm augur-tabular">{fmtUsd(entry.windowAvg)}</td>
+      <td className="px-3 py-2 text-right text-sm augur-tabular" onClick={stop}>
+        {editing ? (
+          <OverrideEditor entry={entry} onAdjust={onAdjust} onClose={() => setEditing(false)} />
+        ) : (
+          <>
+            <span className={valueClass}>{fmtUsd(entry.effectiveAvg)}</span>
+            {entry.overridden && (
+              <div className="text-[10px] augur-muted">
+                was {fmtUsd(entry.windowAvg)} ·{" "}
+                <button type="button" className="augur-link" onClick={() => onAdjust(entry.bucketId, null)}>
+                  reset
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </td>
       <td className="px-3 py-2 text-right text-sm augur-tabular augur-muted">{fmtNumber(entry.transactionCount)}</td>
       <td className="px-3 py-2 text-right">
         <Sparkline amounts={entry.monthlyAmounts} />
+      </td>
+      <td
+        className="px-3 py-2 text-right whitespace-nowrap text-[11px]"
+        onClick={stop}
+        data-budget-bucket-plan={entry.bucketId}
+      >
+        {!entry.hidden && !editing && (
+          <button type="button" className="augur-link" onClick={() => setEditing(true)}>
+            {entry.overridden ? "Edit" : "Set"}
+          </button>
+        )}
+        <button
+          type="button"
+          className="ml-2 augur-link"
+          onClick={() => onAdjust(entry.bucketId, entry.hidden ? null : { kind: "hidden" })}
+        >
+          {entry.hidden ? "Show" : "Hide"}
+        </button>
       </td>
     </tr>
   );
 }
 
-function HeadlineCards({ totals, windowMonths }) {
+function HeadlineCards({ totals, historical, windowMonths, adjustmentsActive }) {
   // Always show "Monthly burn" (net of inflows + income). Show "Inflows" / "Income"
   // cards only when nonzero so we don't render a wall of $0 cards on simple flows.
   // When inflows == income == 0, "spend" and "netBurn" are identical -- skip the
-  // duplicate card.
-  const subtitle = `${windowMonths}-month average`;
+  // duplicate card. With planning adjustments active the figures are the *adjusted*
+  // totals (hidden buckets dropped, overrides applied); the burn card then anchors
+  // them against the unadjusted history so the tweak's effect is legible.
+  const subtitle = adjustmentsActive ? "planned $/mo" : `${windowMonths}-month average`;
   const cards = [];
   const hasOffsets = totals.inflow > 0 || totals.income > 0;
   if (hasOffsets) {
@@ -279,9 +380,11 @@ function HeadlineCards({ totals, windowMonths }) {
     });
   }
   cards.push({
-    label: hasOffsets ? "Net monthly burn" : "Monthly burn",
+    label: adjustmentsActive ? "Planned monthly burn" : hasOffsets ? "Net monthly burn" : "Monthly burn",
     value: totals.netBurn,
-    note: "Positive = drawing down savings.",
+    note: adjustmentsActive
+      ? `Historical: ${fmtUsd(historical.netBurn)}/mo. Positive = drawing down savings.`
+      : "Positive = drawing down savings.",
   });
   const cols = cards.length === 4 ? "sm:grid-cols-4" : cards.length === 3 ? "sm:grid-cols-3" : "sm:grid-cols-2";
   return (
@@ -299,27 +402,59 @@ function HeadlineCards({ totals, windowMonths }) {
   );
 }
 
-function FamilyPanel({ family, rows, onSelectBucket, selectedBucketId, windowMonths }) {
-  // Roll up the family-level totals from each row's window average so the summary
-  // lines up with the row figures instead of telling a different story.
+// A running summary of the active planning adjustments with a one-click reset. Renders nothing
+// until something is hidden or overridden, so the default view stays uncluttered.
+function AdjustmentsBar({ rows, onReset }) {
+  const hidden = rows.filter((row) => row.hidden);
+  const overridden = rows.filter((row) => row.overridden);
+  if (!hidden.length && !overridden.length) return null;
+  return (
+    <section
+      className="augur-note-info flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg p-3 text-xs"
+      data-budget-adjustments=""
+    >
+      <span className="augur-eyebrow text-[10px]">Planning adjustments</span>
+      {hidden.length > 0 && (
+        <span>
+          <span className="font-semibold">Hidden:</span> {hidden.map((row) => row.label).join(", ")}
+        </span>
+      )}
+      {overridden.length > 0 && (
+        <span>
+          <span className="font-semibold">Set:</span>{" "}
+          {overridden.map((row) => `${row.label} → ${fmtUsd(Math.abs(row.effectiveAvg))}/mo`).join(", ")}
+        </span>
+      )}
+      <button type="button" className="augur-link ml-auto" onClick={onReset}>
+        Reset all
+      </button>
+    </section>
+  );
+}
+
+function FamilyPanel({ family, rows, onSelectBucket, selectedBucketId, onAdjust, windowMonths }) {
+  // Roll up the family-level totals from each row's effective average (override when set, else
+  // historical) so the summary lines up with the row figures. Hidden buckets are excluded -- the
+  // panel total tracks the same adjusted view the headline cards show.
   let grossOut = 0;
   let grossIn = 0;
   for (const row of rows) {
-    if (row.kind === "expense") grossOut += row.windowAvg;
-    else if (row.kind === "inflow") grossIn += Math.abs(row.windowAvg);
-    else if (row.kind === "income") grossIn += Math.abs(row.windowAvg);
+    if (row.hidden) continue;
+    if (row.kind === "expense") grossOut += row.effectiveAvg;
+    else if (row.kind === "inflow") grossIn += Math.abs(row.effectiveAvg);
+    else if (row.kind === "income") grossIn += Math.abs(row.effectiveAvg);
   }
   // `transfer` buckets are direction-agnostic -- their sign is real (negative = net inflow).
   // Add their signed average to the relevant side so net stays honest.
   for (const row of rows) {
-    if (row.kind !== "transfer") continue;
-    if (row.windowAvg >= 0) grossOut += row.windowAvg;
-    else grossIn += -row.windowAvg;
+    if (row.hidden || row.kind !== "transfer") continue;
+    if (row.effectiveAvg >= 0) grossOut += row.effectiveAvg;
+    else grossIn += -row.effectiveAvg;
   }
   const net = grossOut - grossIn;
   // Hide the In/Net columns when the family is purely expense-side -- no signal there.
   const hasInflowSide = grossIn > 0;
-  const sortedRows = rows.slice().sort((l, r) => Math.abs(r.windowAvg) - Math.abs(l.windowAvg));
+  const sortedRows = rows.slice().sort((l, r) => Math.abs(r.effectiveAvg) - Math.abs(l.effectiveAvg));
   return (
     <section className="augur-panel overflow-hidden" data-budget-family={family}>
       <div className="border-b border-slate-200 px-4 py-3 dark:border-slate-700">
@@ -360,6 +495,7 @@ function FamilyPanel({ family, rows, onSelectBucket, selectedBucketId, windowMon
               <th className="px-3 py-2 text-right font-semibold">{windowMonths}-month avg $/mo</th>
               <th className="px-3 py-2 text-right font-semibold">Tx count</th>
               <th className="px-3 py-2 text-right font-semibold">Trend</th>
+              <th className="px-3 py-2 text-right font-semibold">Plan</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -369,6 +505,7 @@ function FamilyPanel({ family, rows, onSelectBucket, selectedBucketId, windowMon
                 entry={row}
                 onSelect={onSelectBucket}
                 selected={selectedBucketId === row.bucketId}
+                onAdjust={onAdjust}
               />
             ))}
           </tbody>
@@ -457,6 +594,9 @@ export function BudgetWorkspace() {
   const [selectedBucketId, setSelectedBucketId] = useState(null);
   const [bucketTx, setBucketTx] = useState(null);
   const [bucketTxError, setBucketTxError] = useState(null);
+  // Planning adjustments (hidden buckets / per-bucket overrides) initialized from the URL so a
+  // shared link reopens the same tweaked view; every change is written back in applyAdjustment.
+  const [adjustments, setAdjustments] = useState(() => parseAdjustments(window.location.search));
 
   const windowSpec = useMemo(() => windowSpecFromChoice(windowChoice), [windowChoice]);
 
@@ -511,11 +651,32 @@ export function BudgetWorkspace() {
     });
   }, [snapshot, bucketsById]);
 
+  // Overlay the planning adjustments onto each row: `hidden`/`overridden` flags + the `effectiveAvg`
+  // (override re-signed into the bucket's direction, else the historical window average) the
+  // headline, family rollups, and per-row display all read from.
+  const adjustedRows = useMemo(
+    () =>
+      rows.map((row) => {
+        const adjustment = adjustments.get(row.bucketId);
+        return {
+          ...row,
+          adjustment,
+          hidden: adjustment?.kind === "hidden",
+          overridden: adjustment?.kind === "override",
+          effectiveAvg: effectiveSignedAvg(row.kind, row.windowAvg, adjustment),
+        };
+      }),
+    [rows, adjustments]
+  );
+
+  // Hidden buckets drop out of the stacked chart entirely (the "natural spending without rent" view).
+  const visibleRows = useMemo(() => adjustedRows.filter((row) => !row.hidden), [adjustedRows]);
+
   const rowsByFamily = useMemo(() => {
     // Group rows by family. Buckets without a declared family share a synthetic
     // "_ungrouped" key so they still render -- just below the named families.
     const grouped = new Map();
-    for (const row of rows) {
+    for (const row of adjustedRows) {
       const key = row.family ?? UNGROUPED_FAMILY;
       if (!grouped.has(key)) grouped.set(key, []);
       grouped.get(key).push(row);
@@ -527,21 +688,12 @@ export function BudgetWorkspace() {
       return l.localeCompare(r);
     });
     return families.map((family) => ({ family, rows: grouped.get(family) }));
-  }, [rows]);
+  }, [adjustedRows]);
 
-  const totals = useMemo(() => {
-    if (!snapshot) return null;
-    let spend = 0;
-    let inflow = 0;
-    let income = 0;
-    for (const row of rows) {
-      if (row.kind === "expense") spend += row.windowAvg;
-      else if (row.kind === "inflow") inflow += Math.abs(row.windowAvg);
-      else if (row.kind === "income") income += Math.abs(row.windowAvg);
-    }
-    // Net burn subtracts inflows + income from gross outflow.
-    return { spend, inflow, income, netBurn: spend - inflow - income };
-  }, [snapshot, rows]);
+  // Adjusted totals power the headline cards; the unadjusted version anchors the "Historical: …"
+  // note so the effect of hiding/overriding is legible. With no adjustments the two coincide.
+  const totals = useMemo(() => (snapshot ? computeTotals(rows, adjustments) : null), [snapshot, rows, adjustments]);
+  const historicalTotals = useMemo(() => (snapshot ? computeTotals(rows, new Map()) : null), [snapshot, rows]);
 
   const exportSummary = () => {
     if (!snapshot) return;
@@ -551,6 +703,21 @@ export function BudgetWorkspace() {
   const exportTransactions = () => {
     if (!selectedBucketId || !bucketTx) return;
     downloadCsv(`budget-transactions-${selectedBucketId}.csv`, buildTransactionsCsv(bucketTx));
+  };
+
+  // null clears the bucket back to "actual"; otherwise set hidden / override. One adjustment per
+  // bucket (hide and override are mutually exclusive). Every change is mirrored to the URL.
+  const applyAdjustment = (bucketId, adjustment) => {
+    const next = new Map(adjustments);
+    if (adjustment) next.set(bucketId, adjustment);
+    else next.delete(bucketId);
+    setAdjustments(next);
+    writeAdjustmentsToSearch(next);
+  };
+
+  const resetAdjustments = () => {
+    setAdjustments(new Map());
+    writeAdjustmentsToSearch(new Map());
   };
 
   return (
@@ -606,17 +773,25 @@ export function BudgetWorkspace() {
 
       {snapshot && (
         <>
-          <HeadlineCards totals={totals} windowMonths={snapshot.months.length} />
+          <HeadlineCards
+            totals={totals}
+            historical={historicalTotals}
+            windowMonths={snapshot.months.length}
+            adjustmentsActive={adjustments.size > 0}
+          />
+
+          <AdjustmentsBar rows={adjustedRows} onReset={resetAdjustments} />
 
           <section className="augur-panel overflow-hidden">
             <div className="border-b border-slate-200 px-4 py-3 dark:border-slate-700">
               <div className="augur-eyebrow">Monthly spend by bucket</div>
               <div className="mt-1 text-[11px] augur-muted">
-                Stacked expense outflows only. Inflows are shown per-family below, not netted here.
+                Stacked expense outflows only. Inflows are shown per-family below, not netted here. Hidden buckets are
+                excluded.
               </div>
             </div>
             <div className="p-4">
-              <StackedMonthlyChart months={snapshot.months} bucketSeries={rows} />
+              <StackedMonthlyChart months={snapshot.months} bucketSeries={visibleRows} />
             </div>
           </section>
 
@@ -627,6 +802,7 @@ export function BudgetWorkspace() {
               rows={familyRows}
               onSelectBucket={setSelectedBucketId}
               selectedBucketId={selectedBucketId}
+              onAdjust={applyAdjustment}
               windowMonths={snapshot.months.length}
             />
           ))}

--- a/augur/frontend/budget_adjustments.test.ts
+++ b/augur/frontend/budget_adjustments.test.ts
@@ -55,6 +55,12 @@ test("effectiveSignedAvg re-signs an override into the bucket's natural directio
   expect(effectiveSignedAvg("expense", 312, { kind: "hidden" })).toBe(312);
 });
 
+test("effectiveSignedAvg preserves a transfer's historical direction", () => {
+  // Transfers are direction-agnostic: an override keeps pointing the way the history did.
+  expect(effectiveSignedAvg("transfer", -1000, { kind: "override", monthly: 800 })).toBe(-800);
+  expect(effectiveSignedAvg("transfer", 1000, { kind: "override", monthly: 800 })).toBe(800);
+});
+
 const ROWS = [
   { bucketId: "rent", kind: "expense", windowAvg: 3200 },
   { bucketId: "groceries", kind: "expense", windowAvg: 600 },

--- a/augur/frontend/budget_adjustments.test.ts
+++ b/augur/frontend/budget_adjustments.test.ts
@@ -1,0 +1,88 @@
+// Unit tests for the budget tab's planning-adjustment encoding + adjusted-total math.
+// Runs under vitest; see //augur/frontend:budget_adjustments_test.
+
+import { test, expect } from "vitest";
+
+import {
+  type Adjustments,
+  parseAdjustments,
+  adjustmentsToParams,
+  effectiveSignedAvg,
+  computeTotals,
+} from "./budget_adjustments.ts";
+
+test("parseAdjustments reads hidden buckets and numeric overrides", () => {
+  const adjustments = parseAdjustments("?bhide=rent,utilities&bset=insurance:450,phone:0");
+  expect(adjustments.get("rent")).toEqual({ kind: "hidden" });
+  expect(adjustments.get("utilities")).toEqual({ kind: "hidden" });
+  expect(adjustments.get("insurance")).toEqual({ kind: "override", monthly: 450 });
+  // A zero override is meaningful ("I'll stop paying this") and distinct from hiding.
+  expect(adjustments.get("phone")).toEqual({ kind: "override", monthly: 0 });
+});
+
+test("parseAdjustments skips malformed or negative override entries", () => {
+  const adjustments = parseAdjustments("?bset=insurance:,broken,neg:-5,ok:12");
+  expect(adjustments.has("insurance")).toBe(false); // empty value
+  expect(adjustments.has("broken")).toBe(false); // no colon
+  expect(adjustments.has("neg")).toBe(false); // negative rejected
+  expect(adjustments.get("ok")).toEqual({ kind: "override", monthly: 12 });
+});
+
+test("adjustmentsToParams round-trips and sorts ids for stable URLs", () => {
+  const adjustments: Adjustments = new Map([
+    ["utilities", { kind: "hidden" }],
+    ["rent", { kind: "hidden" }],
+    ["insurance", { kind: "override", monthly: 450 }],
+  ]);
+  const params = adjustmentsToParams(adjustments);
+  expect(params.bhide).toBe("rent,utilities");
+  expect(params.bset).toBe("insurance:450");
+  // Round-trip through a query string reproduces the same map.
+  const search = `?bhide=${params.bhide}&bset=${params.bset}`;
+  expect(parseAdjustments(search)).toEqual(adjustments);
+});
+
+test("adjustmentsToParams returns null for empty sides", () => {
+  expect(adjustmentsToParams(new Map())).toEqual({ bhide: null, bset: null });
+});
+
+test("effectiveSignedAvg re-signs an override into the bucket's natural direction", () => {
+  expect(effectiveSignedAvg("expense", 312, { kind: "override", monthly: 450 })).toBe(450);
+  // Inflows/income are stored negative (money in); an override magnitude re-signs negative.
+  expect(effectiveSignedAvg("inflow", -300, { kind: "override", monthly: 280 })).toBe(-280);
+  // No override (or hidden) keeps the historical value.
+  expect(effectiveSignedAvg("expense", 312, undefined)).toBe(312);
+  expect(effectiveSignedAvg("expense", 312, { kind: "hidden" })).toBe(312);
+});
+
+const ROWS = [
+  { bucketId: "rent", kind: "expense", windowAvg: 3200 },
+  { bucketId: "groceries", kind: "expense", windowAvg: 600 },
+  { bucketId: "insurance", kind: "expense", windowAvg: 312 },
+  { bucketId: "reimbursement", kind: "inflow", windowAvg: -200 },
+  { bucketId: "salary", kind: "income", windowAvg: -5000 },
+];
+
+test("computeTotals with no adjustments sums window averages", () => {
+  const totals = computeTotals(ROWS, new Map());
+  expect(totals.spend).toBe(4112);
+  expect(totals.inflow).toBe(200);
+  expect(totals.income).toBe(5000);
+  expect(totals.netBurn).toBe(4112 - 200 - 5000);
+});
+
+test("computeTotals drops hidden buckets from spend and net burn", () => {
+  const totals = computeTotals(ROWS, new Map([["rent", { kind: "hidden" }]]));
+  expect(totals.spend).toBe(912); // 4112 - 3200
+  expect(totals.netBurn).toBe(912 - 200 - 5000);
+});
+
+test("computeTotals applies an expense override in place of the historical average", () => {
+  const totals = computeTotals(ROWS, new Map([["insurance", { kind: "override", monthly: 450 }]]));
+  expect(totals.spend).toBe(4250); // 4112 - 312 + 450
+});
+
+test("computeTotals applies an inflow override by magnitude", () => {
+  const totals = computeTotals(ROWS, new Map([["reimbursement", { kind: "override", monthly: 500 }]]));
+  expect(totals.inflow).toBe(500);
+});

--- a/augur/frontend/budget_adjustments.ts
+++ b/augur/frontend/budget_adjustments.ts
@@ -1,0 +1,99 @@
+// Per-bucket "planning adjustments" overlaid on the historical budget snapshot, persisted in the
+// URL so a tweaked view (rent hidden, health insurance set to a known going-forward figure) is
+// bookmarkable. Pure + DOM-free so the encoding and the adjusted-total math are unit-testable;
+// budget.tsx owns reading/writing window.location.
+//
+// A bucket is in exactly one of three states: actual (default, absent from the map), hidden, or
+// overridden with a fixed monthly magnitude. An override is entered as a positive number and
+// re-signed into the bucket's natural direction (Plaid convention: + out, - in) so the existing
+// total/rollup math keeps working unchanged.
+
+export type Adjustment = { kind: "hidden" } | { kind: "override"; monthly: number };
+
+// bucketId -> adjustment. Buckets in their default "actual" state are simply absent.
+export type Adjustments = Map<string, Adjustment>;
+
+const HIDE_PARAM = "bhide";
+const OVERRIDE_PARAM = "bset";
+
+function splitList(value: string | null): string[] {
+  return value ? value.split(",").filter((entry) => entry.length > 0) : [];
+}
+
+// `?bhide=rent,utilities` + `?bset=insurance:450,phone:0`. Bucket ids match ^[a-z0-9][a-z0-9_]*$,
+// so neither "," nor ":" can occur inside one. Malformed override entries are skipped (augur is
+// pre-production; we don't migrate old URL encodings).
+export function parseAdjustments(search: string): Adjustments {
+  const params = new URLSearchParams(search);
+  const adjustments: Adjustments = new Map();
+  for (const id of splitList(params.get(HIDE_PARAM))) {
+    adjustments.set(id, { kind: "hidden" });
+  }
+  for (const entry of splitList(params.get(OVERRIDE_PARAM))) {
+    const separator = entry.indexOf(":");
+    if (separator <= 0) continue;
+    const id = entry.slice(0, separator);
+    const raw = entry.slice(separator + 1);
+    const monthly = Number(raw);
+    if (raw !== "" && Number.isFinite(monthly) && monthly >= 0) {
+      adjustments.set(id, { kind: "override", monthly });
+    }
+  }
+  return adjustments;
+}
+
+// Serialize back to the two param strings (null when empty so the caller drops the key). Ids are
+// sorted so the URL is stable regardless of the map's insertion order.
+export function adjustmentsToParams(adjustments: Adjustments): { bhide: string | null; bset: string | null } {
+  const hidden: string[] = [];
+  const overrides: string[] = [];
+  for (const [id, adjustment] of adjustments) {
+    if (adjustment.kind === "hidden") hidden.push(id);
+    else overrides.push(`${id}:${adjustment.monthly}`);
+  }
+  hidden.sort();
+  overrides.sort();
+  return {
+    bhide: hidden.length ? hidden.join(",") : null,
+    bset: overrides.length ? overrides.join(",") : null,
+  };
+}
+
+// The signed monthly value to feed the existing total/rollup math. Hidden buckets keep their
+// historical value here; callers exclude them separately.
+export function effectiveSignedAvg(kind: string, windowAvg: number, adjustment: Adjustment | undefined): number {
+  if (adjustment?.kind !== "override") return windowAvg;
+  return kind === "inflow" || kind === "income" ? -adjustment.monthly : adjustment.monthly;
+}
+
+export interface AdjustableRow {
+  bucketId: string;
+  kind: string;
+  windowAvg: number;
+}
+
+export interface BudgetTotals {
+  spend: number;
+  inflow: number;
+  income: number;
+  netBurn: number;
+}
+
+// Headline totals after adjustments: hidden buckets drop out entirely; overrides replace the
+// historical average. Covers the kinds the headline cares about (expense / inflow / income;
+// transfers are surfaced per-family only). With an empty map this reduces to the plain
+// window-average totals.
+export function computeTotals(rows: readonly AdjustableRow[], adjustments: Adjustments): BudgetTotals {
+  let spend = 0;
+  let inflow = 0;
+  let income = 0;
+  for (const row of rows) {
+    const adjustment = adjustments.get(row.bucketId);
+    if (adjustment?.kind === "hidden") continue;
+    const effective = effectiveSignedAvg(row.kind, row.windowAvg, adjustment);
+    if (row.kind === "expense") spend += effective;
+    else if (row.kind === "inflow") inflow += Math.abs(effective);
+    else if (row.kind === "income") income += Math.abs(effective);
+  }
+  return { spend, inflow, income, netBurn: spend - inflow - income };
+}

--- a/augur/frontend/budget_adjustments.ts
+++ b/augur/frontend/budget_adjustments.ts
@@ -60,10 +60,15 @@ export function adjustmentsToParams(adjustments: Adjustments): { bhide: string |
 }
 
 // The signed monthly value to feed the existing total/rollup math. Hidden buckets keep their
-// historical value here; callers exclude them separately.
+// historical value here; callers exclude them separately. An override is entered as a positive
+// magnitude and re-signed into the bucket's natural direction: inflows/income are money in (-);
+// transfers are direction-agnostic so preserve the historical sign (negative = net inflow);
+// expenses (and zero-history transfers) are outflows (+).
 export function effectiveSignedAvg(kind: string, windowAvg: number, adjustment: Adjustment | undefined): number {
   if (adjustment?.kind !== "override") return windowAvg;
-  return kind === "inflow" || kind === "income" ? -adjustment.monthly : adjustment.monthly;
+  if (kind === "inflow" || kind === "income") return -adjustment.monthly;
+  if (kind === "transfer" && windowAvg < 0) return -adjustment.monthly;
+  return adjustment.monthly;
 }
 
 export interface AdjustableRow {

--- a/augur/frontend/budget_csv.test.ts
+++ b/augur/frontend/budget_csv.test.ts
@@ -113,3 +113,48 @@ test("buildSummaryCsv neutralizes a formula-triggering bucket label", () => {
   );
   expect(csv.trimEnd().split("\n")[1]).toBe("'=DANGER,expense,,10.00,10.00,1");
 });
+
+test("buildSummaryCsv adds Planned $/mo + Hidden columns only when rows carry adjustments", () => {
+  const csv = buildSummaryCsv(
+    ["2025-05-01"],
+    [
+      // Hidden → planned 0 + "yes"; historical avg retained.
+      {
+        label: "Rent",
+        kind: "expense",
+        family: null,
+        monthlyAmounts: [3200],
+        windowAvg: 3200,
+        transactionCount: 1,
+        hidden: true,
+        effectiveAvg: 3200,
+      },
+      // Overridden → planned = override; not hidden.
+      {
+        label: "Insurance",
+        kind: "expense",
+        family: null,
+        monthlyAmounts: [312],
+        windowAvg: 312,
+        transactionCount: 1,
+        overridden: true,
+        effectiveAvg: 450,
+      },
+      // Untouched → planned = historical avg.
+      {
+        label: "Groceries",
+        kind: "expense",
+        family: null,
+        monthlyAmounts: [600],
+        windowAvg: 600,
+        transactionCount: 1,
+        effectiveAvg: 600,
+      },
+    ]
+  );
+  const lines = csv.trimEnd().split("\n");
+  expect(lines[0]).toBe("Bucket,Kind,Family,2025-05,Avg $/mo,Tx count,Planned $/mo,Hidden");
+  expect(lines[1]).toBe("Rent,expense,,3200.00,3200.00,1,0.00,yes");
+  expect(lines[2]).toBe("Insurance,expense,,312.00,312.00,1,450.00,");
+  expect(lines[3]).toBe("Groceries,expense,,600.00,600.00,1,600.00,");
+});

--- a/augur/frontend/budget_csv.ts
+++ b/augur/frontend/budget_csv.ts
@@ -19,6 +19,14 @@ export interface SummaryRow {
   monthlyAmounts: number[];
   windowAvg: number;
   transactionCount: number;
+  // Planning overlay (present when the budget tab passes its adjusted rows). When any row carries
+  // an adjustment, the summary gains "Planned $/mo" + "Hidden" columns so the CSV matches the
+  // on-screen plan without dropping the historical actuals. `effectiveAvg` is the override (signed
+  // into the bucket's direction) or the historical average; `hidden` buckets are excluded from the
+  // plan (Planned $/mo = 0).
+  effectiveAvg?: number;
+  hidden?: boolean;
+  overridden?: boolean;
 }
 
 export interface TransactionCsvRow {
@@ -63,11 +71,18 @@ function monthColumn(iso: string): string {
 }
 
 // Bucket × month matrix: one row per bucket, one column per month, plus the window average and
-// transaction count the UI shows. Built to paste into a spreadsheet and adjust by hand.
+// transaction count the UI shows. Built to paste into a spreadsheet and adjust by hand. When any
+// row carries a planning adjustment, two extra columns ("Planned $/mo", "Hidden") capture the
+// on-screen plan without distorting the historical actuals (the monthly columns stay historical).
 export function buildSummaryCsv(months: string[], rows: SummaryRow[]): string {
-  const header = ["Bucket", "Kind", "Family", ...months.map(monthColumn), "Avg $/mo", "Tx count"].map(csvField);
-  const lines = [header.join(",")];
+  const includePlanning = rows.some((row) => row.hidden || row.overridden);
+  const planningHeaders = includePlanning ? ["Planned $/mo", "Hidden"] : [];
+  const header = ["Bucket", "Kind", "Family", ...months.map(monthColumn), "Avg $/mo", "Tx count", ...planningHeaders];
+  const lines = [header.map(csvField).join(",")];
   for (const row of rows) {
+    const planningFields = includePlanning
+      ? [csvField(amount(row.hidden ? 0 : (row.effectiveAvg ?? row.windowAvg))), csvField(row.hidden ? "yes" : "")]
+      : [];
     lines.push(
       [
         textField(row.label),
@@ -76,6 +91,7 @@ export function buildSummaryCsv(months: string[], rows: SummaryRow[]): string {
         ...row.monthlyAmounts.map((value) => csvField(amount(value))),
         csvField(amount(row.windowAvg)),
         csvField(String(row.transactionCount)),
+        ...planningFields,
       ].join(",")
     );
   }


### PR DESCRIPTION
## What

A per-bucket **planning-adjustment** layer on the Budget tab so spending can be modelled on top of the historical snapshot — the core "how much can I trim / how much rent can I afford" workflow.

Per bucket, in its family-panel row:

- **Hide** → drops the bucket from the headline totals and the stacked chart (e.g. hide Rent to see "natural spending" without housing). The row stays, dimmed, with a **Show** toggle to bring it back.
- **Set / Edit** → override the historical average with a fixed monthly amount used in the totals (e.g. "health insurance will be $450 going forward"). The row shows the override + "was $X"; the chart keeps showing actuals.

When any adjustment is active, the headline burn card relabels to **Planned monthly burn** and notes the unadjusted **Historical: $X/mo**; a summary bar lists what's hidden / overridden with a one-click **Reset all**.

## How

State lives in two URL params (`bhide` / `bset`), mirroring the product tab's URL-state pattern, so a tweaked view is bookmarkable; the product tab's `?s=` rewriter now preserves them across tab switches. All math is client-side over the existing snapshot — the adjustment model, URL encoding, and adjusted totals are a pure, unit-tested `budget_adjustments.ts` module (`:budget_adjustments_test`). No backend or wire-schema changes.

## Stacked on #1813

This branch is stacked on #1813 (CSV export); both edit `budget.tsx`. **Merge after #1813** — once it lands, this PR's diff against `devel` reduces to just the adjustments commit. Until then, review the top commit (`augur/budget: hide buckets + override …`) for the changes specific to this PR.

## Test

`bbr test //augur/frontend:{budget_adjustments_test,budget_csv_test,tsc_test,eslint_typed_test}` — all pass; bundle + image build clean.

https://claude.ai/code/session_01MXuKQyGthUrSXRJeKjGsrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXuKQyGthUrSXRJeKjGsrW)_