### PR TITLE
cluster/forgejo: temporary agent RBAC for log access (CLEANUP 2026-06-04)

### DIFF
--- a/cluster/k8s/forgejo/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,25 @@
+# CLEANUP(2026-06-02): TEMPORARY — delete this file and the whole
+#   cluster/k8s/forgejo/agent-rbac/ directory, and remove the
+#   forgejo/agent-rbac/flux-kustomization.yaml line from
+#   cluster/k8s/kustomization.yaml, after 2026-06-04. See the RoleBinding for why.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: |
+      TEMPORARY (remove after 2026-06-04) agent RBAC for the forgejo namespace.
+      Binds namespace-diagnostics-reader (includes pods/log) to the sandbox group
+      so Claude can read forgejo pod logs to diagnose the init-app-ini crashloop.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/forgejo/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: forgejo-namespace
+    - name: claude-rbac

--- a/cluster/k8s/forgejo/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/forgejo/agent-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-namespace-diagnostics-reader.yaml

--- a/cluster/k8s/forgejo/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/forgejo/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -1,0 +1,19 @@
+# CLEANUP(2026-06-02): TEMPORARY diagnostic grant — remove this whole
+#   cluster/k8s/forgejo/agent-rbac/ directory (and its entry in
+#   cluster/k8s/kustomization.yaml) after 2026-06-04. Added so the Claude sandbox
+#   group can read forgejo pod logs (namespace-diagnostics-reader includes
+#   pods/log) to diagnose the forgejo init-app-ini crashloop blocking the props
+#   rollout. Read-only; not intended as a permanent grant.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-namespace-diagnostics-reader
+  namespace: forgejo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-diagnostics-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -181,6 +181,8 @@ resources:
   - forgejo/servicemonitor/flux-kustomization.yaml
   - forgejo/secrets/flux-kustomization.yaml
   - forgejo/props/flux-kustomization.yaml
+  # CLEANUP(2026-06-02): remove this line with cluster/k8s/forgejo/agent-rbac/ after 2026-06-04 (temp log access)
+  - forgejo/agent-rbac/flux-kustomization.yaml
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml


### PR DESCRIPTION
## What

Adds `cluster/k8s/forgejo/agent-rbac/` — a RoleBinding of the existing
`namespace-diagnostics-reader` ClusterRole (which includes `pods/log`) to the
`oidc-ksbx-groups:kubectl-sandbox-users` group in the `forgejo` namespace.

Follows the per-service agent-RBAC convention exactly (own Flux kustomization,
`dependsOn: [forgejo-namespace, claude-rbac]`), mirroring `harbor/agent-rbac/`,
`props/agent-rbac/`, etc. Registered in the root `cluster/k8s/kustomization.yaml`.

## Why

The props rollout is currently blocked on forgejo, whose app pod is stuck in
`Init:CrashLoopBackOff` (`init-app-ini`, exit 1, ~97 restarts). I verified the S3
bucket/RBAC/secret wiring is correct and the ExternalSecrets are synced — so the
failure is internal to forgejo's `app.ini` generation. Diagnosing it needs the
`init-app-ini` log, but the sandbox identity hard-denies `pods/log` in `forgejo`
(it's not in the diagnostics-reader namespace list). This grants exactly that
read access.

Read-only (`get/list/watch` on pods/log + diagnostics resources). No secrets,
no write.

## Temporary — remove after 2026-06-04

Every file carries a `CLEANUP(2026-06-02)` tombstone, and the root
`kustomization.yaml` entry has a matching marker. Cleanup = delete the whole
`cluster/k8s/forgejo/agent-rbac/` directory and remove its one line from
`cluster/k8s/kustomization.yaml`.

Pre-commit (incl. `kubeconform` + the cluster kustomization validator) passes.

https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzZWZyZepiVFgsVyFQ7N2B)_