### PR TITLE
augur: surface unmodeled sample-sanity bands instead of 400-ing calibration

### DIFF
--- a/augur/api/calibration_wire.py
+++ b/augur/api/calibration_wire.py
@@ -38,7 +38,10 @@ class CalibrationSanityBand(ApiModel):
     expected_upper: float | None = None
     observed: list[float] = Field(default_factory=list)
     observed_labels: list[str] = Field(default_factory=list)
-    status: Literal["pass", "fail", "skipped"]
+    # `unmodeled` = this band's series/issuer isn't produced by the deployment's preset; the
+    # frontend renders these distinctly from `skipped` (band's month exceeds the sampled horizon
+    # but the series is otherwise emitted) and `fail` (band failed against an emitted series).
+    status: Literal["pass", "fail", "skipped", "unmodeled"]
     detail: str
 
 

--- a/augur/api/config.py
+++ b/augur/api/config.py
@@ -95,8 +95,8 @@ class CalibrationCatalogConfig(ApiModel):
             "Optional `SampleSanitySpec` YAML (resolved relative to the config file, like "
             "`catalog_path`). When set, `/api/calibration/run` evaluates the spec's reasonableness "
             "bands against the live rollouts and returns them as `sanity_bands`. The spec is consumed "
-            "only for its `*_checks` + `required_level_series`/`required_private_equity_issuers`; its "
-            "`provider_config_path` is ignored (the page reuses the live calibration model)."
+            "only for its `*_checks` (series/issuers to attempt are derived from each check's key); "
+            "its `provider_config_path` is ignored (the page reuses the live calibration model)."
         ),
     )
 

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -43,8 +43,8 @@ from augur.calibration.platform import Platform, PriceClient
 from augur.calibration.polymarket import PolymarketClient
 from augur.model.exogenous import ExogenousSamplingRequest, Sampler, level_series_request_channels
 from augur.model.private_equity_bundle import PrivateEquityFloatChannel
-from augur.model.sample_sanity import SampleSanitySpec, evaluate_sample_checks
-from augur.model.series import IssuerId
+from augur.model.sample_sanity import SampleSanitySpec, evaluate_sample_checks, partition_spec_coverage
+from augur.model.series import IssuerId, LevelSeriesKey
 from augur.product.portfolio import ProductPortfolioResponse, product_portfolio_response
 from augur.product.scenarios import resolve_primary_agent_id, sim_locations_from_config
 from augur.product.service import ProductService
@@ -172,13 +172,25 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         rollout_seeds = tuple(range(request.seed, request.seed + request.rollouts))
         # Sample one full bundle that drives the market scoring, the issuer mark fan, AND the
         # sample-sanity bands — still a single rollout. The PE bundle goes to `run_calibration`/
-        # `mark_fan` (preserving today's behavior); the level series the sanity spec needs are
-        # requested here too. A spec asking for a series the preset can't produce raises -> 400.
+        # `mark_fan` (preserving today's behavior); the level series the sanity spec wants are
+        # added on top, partitioned by what the deployment's preset can actually emit so a
+        # band declared against an unmodeled series renders as "not modeled" rather than 400-ing.
+        # TODO: sample at max(request.horizon_months, max band month in spec) and drop the
+        # `skipped` status — currently a user-picked short horizon silently marks longer spec
+        # bands as skipped, which the sample-sanity team would rather always evaluate. Once
+        # that lands, the calibration tab's horizon control no longer drives sampling and can
+        # either move to the Product tab (sampling-only) or stay as a pure chart-x-axis zoom.
+        spec_modeled_level: frozenset[LevelSeriesKey] = frozenset()
+        spec_modeled_pe: frozenset[IssuerId] = frozenset()
+        unmodeled_level: frozenset[LevelSeriesKey] = frozenset()
+        unmodeled_pe: frozenset[IssuerId] = frozenset()
+        if spec is not None:
+            spec_modeled_level, spec_modeled_pe, unmodeled_level, unmodeled_pe = partition_spec_coverage(spec, model)
         sampling_request = ExogenousSamplingRequest(
             horizon_months=request.horizon_months,
             rollout_seeds=rollout_seeds,
-            required_private_equity_issuers=frozenset({IssuerId(issuer)}),
-            **level_series_request_channels(frozenset(spec.required_level_series) if spec is not None else frozenset()),
+            required_private_equity_issuers=frozenset({IssuerId(issuer)}) | spec_modeled_pe,
+            **level_series_request_channels(spec_modeled_level),
         )
         sampled = model.sample(sampling_request)
         bundle = sampled.private_equity
@@ -220,7 +232,12 @@ def create_app(config: ApiServerConfig) -> FastAPI:
             [
                 sanity_band_to_wire(band)
                 for band in evaluate_sample_checks(
-                    spec, sampled, rollout_count=request.rollouts, horizon_months=request.horizon_months
+                    spec,
+                    sampled,
+                    rollout_count=request.rollouts,
+                    horizon_months=request.horizon_months,
+                    unmodeled_level_keys=unmodeled_level,
+                    unmodeled_pe_issuers=unmodeled_pe,
                 )
             ]
             if spec is not None

--- a/augur/api/test_calibration_endpoint.py
+++ b/augur/api/test_calibration_endpoint.py
@@ -131,8 +131,6 @@ def _config_with_sample_sanity(augur_config: Config, tmp_path: Path) -> Config:
         provider_config_path=Path("unused.yaml"),
         horizon_months=24,
         rollout_count=16,
-        required_level_series=(SP500Key(),),
-        required_private_equity_issuers=(IssuerId("openai"),),
         level_checks=(LevelSeriesSanityCheck(key=SP500Key(), initial_value=1.0),),
         private_equity_mark_checks=(PrivateEquityMarkSanityCheck(issuer_id=IssuerId("openai"), initial_value=100.0),),
     )

--- a/augur/fit/metrics_test.py
+++ b/augur/fit/metrics_test.py
@@ -35,6 +35,7 @@ from augur.model.series import (
     CryptoSymbol,
     HomeValueKey,
     InflationKey,
+    IssuerId,
     LevelSeriesKey,
     LocationId,
     RentKey,
@@ -84,6 +85,12 @@ class _ConstantGaussianModel:
     def fit(self, historical: HistoricalSeries) -> None:
         del historical
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.factor_names)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
+
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         raise NotImplementedError("metric-test fixture; sampling not exercised")
 
@@ -106,6 +113,12 @@ class _UnscoredModel:
 
     def fit(self, historical: HistoricalSeries) -> None:
         del historical
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.factor_names)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         raise NotImplementedError("metric-test fixture; sampling not exercised")

--- a/augur/frontend/calibration.tsx
+++ b/augur/frontend/calibration.tsx
@@ -84,12 +84,15 @@ function PlatformBadge({ platform }) {
 }
 
 // Reasonableness-band status → pill classes. A failing band reads loudest (rose), a passing
-// band reassuring (emerald), a skipped band muted (slate) — the same rose/amber/muted family
-// the KL tints above draw from.
+// band reassuring (emerald), a skipped band muted (slate), an unmodeled band a distinct amber
+// (the spec asked for a series the preset can't emit — a config-shape signal, not a model
+// reading) — the same rose/amber/muted family the KL tints above draw from.
 const SANITY_PILL_CLASS = {
   pass: "bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-400/20",
   fail: "bg-rose-50 text-rose-700 ring-rose-600/20 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-400/20",
   skipped: "bg-slate-100 text-slate-600 ring-slate-500/20 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-400/20",
+  unmodeled:
+    "bg-amber-50 text-amber-700 ring-amber-600/20 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-400/20",
 };
 
 // A failing band also tints its whole row, mirroring `klToneClass` for loud KL.

--- a/augur/frontend/sanity_bands.test.ts
+++ b/augur/frontend/sanity_bands.test.ts
@@ -21,15 +21,23 @@ function band(overrides) {
   };
 }
 
-test("sortSanityBands: failures first, then skipped, then passes", () => {
+test("sortSanityBands: failures first, then unmodeled, then skipped, then passes", () => {
   const input = [
     band({ label: "pass-a", status: "pass" }),
     band({ label: "skip-a", status: "skipped" }),
+    band({ label: "unmodeled-a", status: "unmodeled" }),
     band({ label: "fail-a", status: "fail" }),
     band({ label: "pass-b", status: "pass" }),
     band({ label: "fail-b", status: "fail" }),
   ];
-  expect(sortSanityBands(input).map((b) => b.label)).toEqual(["fail-a", "fail-b", "skip-a", "pass-a", "pass-b"]);
+  expect(sortSanityBands(input).map((b) => b.label)).toEqual([
+    "fail-a",
+    "fail-b",
+    "unmodeled-a",
+    "skip-a",
+    "pass-a",
+    "pass-b",
+  ]);
 });
 
 test("sortSanityBands: stable within a status group (input order preserved)", () => {

--- a/augur/frontend/sanity_bands.ts
+++ b/augur/frontend/sanity_bands.ts
@@ -12,9 +12,11 @@ import { fmtPct } from "./lib/format.ts";
 // (count_range), which we render as a trimmed fixed-decimal number rather than a percentage.
 const PROBABILITY_KINDS = new Set(["threshold_probability", "event_kind_probability"]);
 
-// Loudest-first: failures, then skipped, then passes — mirrors `CleanTable`'s "loudest
-// disagreement first" ordering. Stable within a group (input order preserved).
-const STATUS_RANK = { fail: 0, skipped: 1, pass: 2 };
+// Loudest-first: failures, then unmodeled (a configuration-shape signal: the spec asked for a
+// series the preset can't emit, surfaced so it can be fixed), then skipped (band's month past
+// the sampled horizon), then passes — mirrors `CleanTable`'s "loudest disagreement first"
+// ordering. Stable within a group (input order preserved).
+const STATUS_RANK = { fail: 0, unmodeled: 1, skipped: 2, pass: 3 };
 
 function statusRank(status) {
   return STATUS_RANK[status] ?? STATUS_RANK.pass;

--- a/augur/model/composite.py
+++ b/augur/model/composite.py
@@ -13,6 +13,7 @@ from augur.model.exogenous import (
     validate_sample_satisfies_request,
 )
 from augur.model.private_equity_bundle import PrivateEquityBundle
+from augur.model.series import IssuerId, LevelSeriesKey
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,12 @@ class CompositeModel:
     macro: Sampler
     private_equity: Sampler
     label: str = "composite"
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return self.macro.emittable_level_keys() | self.private_equity.emittable_level_keys()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return self.macro.emittable_private_equity_issuers() | self.private_equity.emittable_private_equity_issuers()
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         # Non-PE level series (all three magisteria) route to the macro provider;

--- a/augur/model/composite_test.py
+++ b/augur/model/composite_test.py
@@ -27,6 +27,12 @@ class _StaticSampler:
     pe_issuer_marks: dict[str, float] = field(default_factory=dict)
     sample_requests: list[ExogenousSamplingRequest] = field(default_factory=list)
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.levels)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset(IssuerId(issuer_id) for issuer_id in self.pe_issuer_marks)
+
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         self.sample_requests.append(request)
 

--- a/augur/model/exogenous.py
+++ b/augur/model/exogenous.py
@@ -261,10 +261,24 @@ class Sampler(Protocol):
     Anything that can't be sampled is unusable in the augur sim. `Fittable`
     (offline trainer) and `Scorable` (metric battery) extend this protocol
     for models that additionally support training / scoring.
+
+    `emittable_level_keys` / `emittable_private_equity_issuers` advertise what the
+    sampler is configured to produce. Consumers (sample-sanity / calibration) partition
+    a list of desired series into modeled-vs-unmodeled by intersecting with these sets,
+    so a check against a series the deployment's model doesn't cover renders as
+    `unmodeled` instead of hard-failing the sample request.
     """
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         """Return all modeled external drivers as a sampled levels bundle."""
+        ...
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        """Level-series keys this sampler is configured to produce in a sampled bundle."""
+        ...
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        """PE issuers this sampler is configured to produce in `sampled.private_equity`."""
         ...
 
 

--- a/augur/model/independent.py
+++ b/augur/model/independent.py
@@ -80,6 +80,15 @@ class IndependentModel(LevelSeriesMagisteria[ScalarSeriesSpec]):
 
         return tuple(self._level_specs_by_level_key())
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self._level_specs_by_level_key())
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        # PE marks live in `pe_marks` but are scalar mark generators only — this provider
+        # doesn't synthesize a full PrivateEquityBundle, so it advertises no PE issuers as
+        # bundle-emittable. PE-bundle emission is a CompositeModel + PE-provider job.
+        return frozenset()
+
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         # PE marks travel via the typed PE bundle / metadata, never a level magisterium
         # — the inherited magisterium groups carry only level series.

--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -15,7 +15,7 @@ from pydantic import Field, model_validator
 from augur.model.exogenous import ExogenousSamplingRequest, SampledExogenousBundle, validate_sample_satisfies_request
 from augur.model.private_equity_bundle import PrivateEquityBundle
 from augur.model.schemas import FrozenModel
-from augur.model.series import PrivateEquityEventKindCode, PrivateEquityRegimeCode
+from augur.model.series import IssuerId, LevelSeriesKey, PrivateEquityEventKindCode, PrivateEquityRegimeCode
 from augur.model.series_model import derive_stream_rollout_seeds
 
 BoolMatrix = npt.NDArray[np.bool_]
@@ -349,6 +349,12 @@ class PrivateEquityRiskProviderConfig(FrozenModel):
 class PrivateEquityRiskModel:
     issuers: dict[str, PrivateEquityRiskIssuerConfig]
     label: str = "private_equity_risk"
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset(IssuerId(issuer_id) for issuer_id in self.issuers)
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         rollout_count = request.rollout_count

--- a/augur/model/private_equity_trajectories.py
+++ b/augur/model/private_equity_trajectories.py
@@ -48,6 +48,7 @@ from augur.model.exogenous import (
 )
 from augur.model.private_equity_bundle import PrivateEquityBundle
 from augur.model.private_equity_protocol import neutral_private_equity_issuer_bundle
+from augur.model.series import IssuerId, LevelSeriesKey
 
 
 @dataclass(frozen=True)
@@ -127,6 +128,15 @@ class PreSampledPrivateEquitySampler:
 
     underlying: Sampler
     trajectories_by_issuer: dict[str, PrivateEquityTrajectorySet]
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        # Level series come straight from the underlying provider; this overlay only adds PE.
+        return self.underlying.emittable_level_keys()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        # The overlay overrides PE wholesale (it strips the underlying's PE bundle first), so
+        # the only PE issuers this sampler emits are the artifact's.
+        return frozenset(IssuerId(issuer) for issuer in self.trajectories_by_issuer)
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         # Forward the non-PE level-series channels straight to the underlying

--- a/augur/model/private_equity_trajectories_test.py
+++ b/augur/model/private_equity_trajectories_test.py
@@ -16,7 +16,7 @@ from augur.model.private_equity_trajectories import (
     TenderEvent,
     read_private_equity_trajectories_jsonl,
 )
-from augur.model.series import SP500Key
+from augur.model.series import IssuerId, LevelSeriesKey, SP500Key
 from util.testing.jsonl import write_jsonl
 
 
@@ -28,6 +28,12 @@ class _MinimalSampler(Sampler):
     bundle: SampledExogenousBundle = field(
         default_factory=lambda: SampledExogenousBundle(metadata={"underlying_id": "minimal"})
     )
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         return self.bundle

--- a/augur/model/sample_sanity.py
+++ b/augur/model/sample_sanity.py
@@ -13,6 +13,7 @@ from pydantic import Field, TypeAdapter, model_validator
 from augur.model.exogenous import (
     ExogenousSamplingRequest,
     SampledExogenousBundle,
+    Sampler,
     level_series_request_channels,
     validate_sample_satisfies_request,
 )
@@ -171,12 +172,21 @@ class PrivateEquityMarkSanityCheck(FrozenModel):
 
 
 class SampleSanitySpec(FrozenModel):
+    """Reasonableness-band specification for a deployment's sampled bundle.
+
+    The set of series/issuers to attempt is derived from the `*_checks` fields — each check
+    declares the key/issuer it bounds and is therefore implicitly a request to sample that
+    series. A check whose key the model can't emit is surfaced as `unmodeled` per band rather
+    than treated as a hard sampling failure; the field used to be `required_level_series` /
+    `required_private_equity_issuers` and gated the sample request, but a sanity-band YAML
+    listing a series the deployment's model doesn't cover was meant to render as "not modeled
+    by <preset>", not 400 the calibration tab.
+    """
+
     provider_config_path: Path
     horizon_months: int = Field(ge=0)
     rollout_seed_start: int = Field(default=1301, ge=0)
     rollout_count: int = Field(gt=0)
-    required_level_series: tuple[LevelSeriesKey, ...] = ()
-    required_private_equity_issuers: tuple[IssuerId, ...] = ()
     level_checks: tuple[LevelSeriesSanityCheck, ...] = ()
     event_checks: tuple[EventSeriesSanityCheck, ...] = ()
     event_kind_observed_checks: tuple[EventKindObservedCheck, ...] = ()
@@ -187,6 +197,26 @@ class SampleSanitySpec(FrozenModel):
     def rollout_seeds(self) -> tuple[int, ...]:
         return tuple(range(self.rollout_seed_start, self.rollout_seed_start + self.rollout_count))
 
+    @property
+    def attempted_level_keys(self) -> frozenset[LevelSeriesKey]:
+        """Level keys this spec bounds, derived from `level_checks[*].key`."""
+
+        return frozenset(check.key for check in self.level_checks)
+
+    @property
+    def attempted_private_equity_issuers(self) -> frozenset[IssuerId]:
+        """PE issuers this spec bounds, derived from every check carrying an `issuer_id`."""
+
+        return frozenset(
+            check.issuer_id
+            for check in (
+                *self.event_checks,
+                *self.event_kind_observed_checks,
+                *self.private_equity_protocol_checks,
+                *self.private_equity_mark_checks,
+            )
+        )
+
 
 @dataclass(frozen=True)
 class SanityBandResult:
@@ -194,14 +224,18 @@ class SanityBandResult:
 
     label: str  # human-readable, e.g. "sp500 ratio m12/m0 p1..p99"
     series_id: str  # the level-series wire id or "PE issuer 'openai' mark"
-    kind: str  # "anchor"|"percentile_bound"|"percentile_range"|"threshold_probability"|"count_range"|"event_kind_probability"|"codes_allowed"
+    kind: str  # "anchor"|"percentile_bound"|"percentile_range"|"threshold_probability"|"count_range"|"event_kind_probability"|"codes_allowed"|"unmodeled"
     month: int | None  # month index where applicable, else None
     expected_lower: float | None
     expected_upper: float | None
     observed: tuple[float, ...]  # the value(s) bounded: 1 for bound/probability, 2 for a range (lo, hi pctile values)
     observed_labels: tuple[str, ...]  # parallel labels, e.g. ("p1","p99") or ("p50",) or ("probability",)
-    status: Literal["pass", "fail", "skipped"]
-    detail: str  # "" when pass; failure/skip explanation otherwise
+    # `unmodeled` = the spec asked for this series/issuer but the deployment's preset can't
+    # emit it (e.g. a state-space artifact not trained on `rent:vallejo_ca`). The calibration
+    # tab renders these distinctly; the offline deploy gate (`run_sample_sanity`) treats them
+    # as failures so a misconfigured spec can't ship silently.
+    status: Literal["pass", "fail", "skipped", "unmodeled"]
+    detail: str  # "" when pass; failure/skip/unmodeled explanation otherwise
 
 
 def run_sample_sanity_file(path: Path) -> None:
@@ -210,12 +244,16 @@ def run_sample_sanity_file(path: Path) -> None:
 
 
 def run_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> None:
-    """Deploy gate: sample the model and raise if any sanity band fails."""
+    """Deploy gate: sample the model and raise if any sanity band fails or is unmodeled.
+
+    `unmodeled` rows are deploy-blockers: the spec is documenting bands for a series the
+    preset can't emit, so something is misconfigured. The calibration tab is more lenient
+    (renders the band as "not modeled by <preset>" instead of 400-ing the page)."""
 
     results = evaluate_sample_sanity(spec, base_dir=base_dir)
-    failures = [result for result in results if result.status == "fail"]
-    if failures:
-        raise AssertionError("\n".join(f"{failure.label}: {failure.detail}" for failure in failures))
+    blockers = [result for result in results if result.status in {"fail", "unmodeled"}]
+    if blockers:
+        raise AssertionError("\n".join(f"{blocker.label}: {blocker.detail}" for blocker in blockers))
 
 
 def evaluate_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> list[SanityBandResult]:
@@ -224,19 +262,67 @@ def evaluate_sample_sanity(spec: SampleSanitySpec, *, base_dir: Path) -> list[Sa
     provider_config_path = _resolve_path(spec.provider_config_path, base_dir=base_dir)
     provider = _load_provider_config(provider_config_path)
     model = provider.realize_model()
+    sampled, unmodeled_level_keys, unmodeled_pe_issuers = sample_for_spec(spec, model)
+    return evaluate_sample_checks(
+        spec,
+        sampled,
+        rollout_count=spec.rollout_count,
+        horizon_months=spec.horizon_months,
+        unmodeled_level_keys=unmodeled_level_keys,
+        unmodeled_pe_issuers=unmodeled_pe_issuers,
+    )
+
+
+def partition_spec_coverage(
+    spec: SampleSanitySpec, model: Sampler
+) -> tuple[frozenset[LevelSeriesKey], frozenset[IssuerId], frozenset[LevelSeriesKey], frozenset[IssuerId]]:
+    """Partition a spec's attempted keys into (modeled_level, modeled_pe, unmodeled_level, unmodeled_pe).
+
+    `modeled_*` is the subset the provider advertises it can emit and goes into the sampling
+    request; `unmodeled_*` becomes `status="unmodeled"` rows in the result. The caller (server
+    calibration_run or `sample_for_spec`) decides which to request — this split is pure."""
+
+    attempted_level = spec.attempted_level_keys
+    attempted_pe = spec.attempted_private_equity_issuers
+    emittable_level = model.emittable_level_keys()
+    emittable_pe = model.emittable_private_equity_issuers()
+    modeled_level = attempted_level & emittable_level
+    modeled_pe = attempted_pe & emittable_pe
+    unmodeled_level = attempted_level - emittable_level
+    unmodeled_pe = attempted_pe - emittable_pe
+    return modeled_level, modeled_pe, unmodeled_level, unmodeled_pe
+
+
+def sample_for_spec(
+    spec: SampleSanitySpec, model: Sampler
+) -> tuple[SampledExogenousBundle, frozenset[LevelSeriesKey], frozenset[IssuerId]]:
+    """Run one sampling pass that satisfies every modeled check in `spec`, plus the unmodeled split.
+
+    Returns the sampled bundle plus the unmodeled-level-keys / unmodeled-PE-issuers sets so the
+    evaluator can emit `status="unmodeled"` rows for the deferred checks. The bundle is asserted
+    against the modeled subset of the request (so a provider bug — emitting nothing for a series
+    it advertises — still raises, while a not-modeled series merely surfaces in the UI)."""
+
+    modeled_level, modeled_pe, unmodeled_level, unmodeled_pe = partition_spec_coverage(spec, model)
     request = ExogenousSamplingRequest(
         horizon_months=spec.horizon_months,
         rollout_seeds=spec.rollout_seeds,
-        **level_series_request_channels(spec.required_level_series),
-        required_private_equity_issuers=frozenset(spec.required_private_equity_issuers),
+        **level_series_request_channels(modeled_level),
+        required_private_equity_issuers=modeled_pe,
     )
     sampled = model.sample(request)
     validate_sample_satisfies_request(request, sampled)
-    return evaluate_sample_checks(spec, sampled, rollout_count=spec.rollout_count, horizon_months=spec.horizon_months)
+    return sampled, unmodeled_level, unmodeled_pe
 
 
 def evaluate_sample_checks(
-    spec: SampleSanitySpec, sampled: SampledExogenousBundle, *, rollout_count: int, horizon_months: int
+    spec: SampleSanitySpec,
+    sampled: SampledExogenousBundle,
+    *,
+    rollout_count: int,
+    horizon_months: int,
+    unmodeled_level_keys: frozenset[LevelSeriesKey] = frozenset(),
+    unmodeled_pe_issuers: frozenset[IssuerId] = frozenset(),
 ) -> list[SanityBandResult]:
     """Evaluate every check in `spec` against an already-sampled bundle.
 
@@ -245,34 +331,86 @@ def evaluate_sample_checks(
     rollouts sampled at a different count/horizon get correct indexing. Any check
     whose month exceeds `horizon_months` yields a `status="skipped"` result rather
     than indexing out of bounds.
+
+    Checks whose series/issuer is in the `unmodeled_*` partition collapse to a single
+    `status="unmodeled"` summary row instead of running their bands — there's nothing in
+    the bundle to evaluate against, and one row per unmodeled check keeps the calibration
+    page legible (compare to the 5-10 per-band rows a fully-modeled check produces).
     """
 
     results: list[SanityBandResult] = []
     for level_check in spec.level_checks:
+        if level_check.key in unmodeled_level_keys:
+            results.append(_unmodeled_level_row(level_check))
+            continue
         results.extend(
             _evaluate_level_check(level_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
         )
-    results.extend(
-        _evaluate_event_kind_check(
-            event_kind_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months
+    for event_kind_check in spec.event_kind_observed_checks:
+        if event_kind_check.issuer_id in unmodeled_pe_issuers:
+            results.append(_unmodeled_pe_row(event_kind_check.issuer_id, kind_label="event_kind"))
+            continue
+        results.append(
+            _evaluate_event_kind_check(
+                event_kind_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months
+            )
         )
-        for event_kind_check in spec.event_kind_observed_checks
-    )
     for mark_check in spec.private_equity_mark_checks:
+        if mark_check.issuer_id in unmodeled_pe_issuers:
+            results.append(_unmodeled_pe_row(mark_check.issuer_id, kind_label="mark"))
+            continue
         results.extend(
             _evaluate_mark_check(mark_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
         )
     for event_check in spec.event_checks:
+        if event_check.issuer_id in unmodeled_pe_issuers:
+            results.append(_unmodeled_pe_row(event_check.issuer_id, kind_label="event"))
+            continue
         results.extend(
             _evaluate_event_check(event_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months)
         )
     for protocol_check in spec.private_equity_protocol_checks:
+        if protocol_check.issuer_id in unmodeled_pe_issuers:
+            results.append(_unmodeled_pe_row(protocol_check.issuer_id, kind_label="protocol"))
+            continue
         results.extend(
             _evaluate_protocol_check(
                 protocol_check, sampled, rollout_count=rollout_count, horizon_months=horizon_months
             )
         )
     return results
+
+
+def _unmodeled_level_row(level_check: LevelSeriesSanityCheck) -> SanityBandResult:
+    series_id = level_check.key.wire_id
+    return SanityBandResult(
+        label=f"{series_id} (not modeled)",
+        series_id=series_id,
+        kind="unmodeled",
+        month=None,
+        expected_lower=None,
+        expected_upper=None,
+        observed=(),
+        observed_labels=(),
+        status="unmodeled",
+        detail=f"level series {series_id!r} is not produced by the deployment's preset",
+    )
+
+
+def _unmodeled_pe_row(issuer_id: IssuerId, *, kind_label: str) -> SanityBandResult:
+    series_id = f"PE issuer {issuer_id!r} {kind_label}"
+    return SanityBandResult(
+        label=f"{series_id} (not modeled)",
+        series_id=series_id,
+        kind="unmodeled",
+        month=None,
+        expected_lower=None,
+        expected_upper=None,
+        observed=(),
+        observed_labels=(),
+        status="unmodeled",
+        detail=f"PE issuer {issuer_id!r} is not produced by the deployment's preset",
+    )
 
 
 def _evaluate_level_check(

--- a/augur/model/sample_sanity_test.py
+++ b/augur/model/sample_sanity_test.py
@@ -10,12 +10,14 @@ from augur.model.exogenous import ExogenousSamplingRequest, SampledExogenousBund
 from augur.model.sample_sanity import (
     LevelSeriesSanityCheck,
     PercentileRangeBound,
+    PrivateEquityMarkSanityCheck,
     SampleSanitySpec,
     evaluate_sample_checks,
+    partition_spec_coverage,
     run_sample_sanity,
     run_sample_sanity_file,
 )
-from augur.model.series import SP500Key
+from augur.model.series import HomeValueKey, IssuerId, LocationId, SP500Key
 from augur.model.testing import ConstantFrameModel
 from util.bazel.runfiles import get_required_path
 
@@ -33,7 +35,6 @@ def _spec_with_bands(*bands: PercentileRangeBound) -> SampleSanitySpec:
         provider_config_path=Path("unused.yaml"),
         horizon_months=_HORIZON_MONTHS,
         rollout_count=_ROLLOUT_COUNT,
-        required_level_series=(SP500Key(),),
         level_checks=(LevelSeriesSanityCheck(key=SP500Key(), value_percentile_ranges=bands),),
     )
 
@@ -88,6 +89,78 @@ def test_evaluate_sample_checks_skips_bands_beyond_sampled_horizon() -> None:
     skipped = [result for result in results if result.status == "skipped"]
     assert len(skipped) == 1
     assert skipped[0].detail == f"month 120 > sampled horizon {_HORIZON_MONTHS}"
+
+
+def test_evaluate_sample_checks_surfaces_unmodeled_level_check() -> None:
+    """A level check whose key the sampler can't emit returns one `unmodeled` summary row."""
+
+    unmodeled_key = HomeValueKey(location_id=LocationId("prices_of_tea_china"))
+    spec = SampleSanitySpec(
+        provider_config_path=Path("unused.yaml"),
+        horizon_months=_HORIZON_MONTHS,
+        rollout_count=_ROLLOUT_COUNT,
+        level_checks=(
+            LevelSeriesSanityCheck(key=SP500Key(), value_percentile_ranges=(_PASSING_BAND,)),
+            LevelSeriesSanityCheck(
+                key=unmodeled_key,
+                value_percentile_ranges=(_PASSING_BAND, _FAILING_BAND),
+                threshold_probability_bounds=(),
+            ),
+        ),
+    )
+    model = ConstantFrameModel(levels={SP500Key(): _SP500_LEVEL})
+    modeled_level, modeled_pe, unmodeled_level, unmodeled_pe = partition_spec_coverage(spec, model)
+    assert modeled_level == frozenset({SP500Key()})
+    assert unmodeled_level == frozenset({unmodeled_key})
+    assert modeled_pe == frozenset()
+    assert unmodeled_pe == frozenset()
+    sampled = _sample_constant_sp500()
+    results = evaluate_sample_checks(
+        spec,
+        sampled,
+        rollout_count=_ROLLOUT_COUNT,
+        horizon_months=_HORIZON_MONTHS,
+        unmodeled_level_keys=unmodeled_level,
+        unmodeled_pe_issuers=unmodeled_pe,
+    )
+
+    # The unmodeled level check collapses to a single summary row regardless of how many bands
+    # it carried, and never indexes into the (absent) series — proves the partition gate works.
+    unmodeled_rows = [result for result in results if result.status == "unmodeled"]
+    assert len(unmodeled_rows) == 1
+    assert unmodeled_rows[0].series_id == unmodeled_key.wire_id
+    assert unmodeled_rows[0].kind == "unmodeled"
+    # Other bands (against the modeled SP500 series) still surface.
+    assert any(result.kind == "percentile_range" and result.status == "pass" for result in results)
+
+
+def test_evaluate_sample_checks_surfaces_unmodeled_pe_mark_check() -> None:
+    """A PE mark check whose issuer the sampler can't emit returns one `unmodeled` summary row."""
+
+    spec = SampleSanitySpec(
+        provider_config_path=Path("unused.yaml"),
+        horizon_months=_HORIZON_MONTHS,
+        rollout_count=_ROLLOUT_COUNT,
+        private_equity_mark_checks=(
+            PrivateEquityMarkSanityCheck(issuer_id=IssuerId("unmodeled_co"), initial_value=100.0),
+        ),
+    )
+    model = ConstantFrameModel(levels={SP500Key(): _SP500_LEVEL})
+    _, _, unmodeled_level, unmodeled_pe = partition_spec_coverage(spec, model)
+    assert unmodeled_pe == frozenset({IssuerId("unmodeled_co")})
+    sampled = _sample_constant_sp500()
+    results = evaluate_sample_checks(
+        spec,
+        sampled,
+        rollout_count=_ROLLOUT_COUNT,
+        horizon_months=_HORIZON_MONTHS,
+        unmodeled_level_keys=unmodeled_level,
+        unmodeled_pe_issuers=unmodeled_pe,
+    )
+
+    assert len(results) == 1
+    assert results[0].status == "unmodeled"
+    assert "unmodeled_co" in results[0].series_id
 
 
 def test_run_sample_sanity_raises_listing_failed_bands(tmp_path: Path) -> None:

--- a/augur/model/series_model.py
+++ b/augur/model/series_model.py
@@ -39,7 +39,7 @@ from augur.model.level_series_groups import (
     PropertyValueGroups,
 )
 from augur.model.poisson_events import PoissonEvents
-from augur.model.series import LevelSeriesKey
+from augur.model.series import IssuerId, LevelSeriesKey
 
 ScalarSeriesSpec = Annotated[Constant | Deterministic | GeometricBrownian, Field(discriminator="kind")]
 ScalarEventSpec = Annotated[PoissonEvents, Field(discriminator="kind")]
@@ -91,6 +91,16 @@ class IndependentSeriesModels(LevelSeriesMagisteria[ScalarSeriesSpec]):
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         return SampledExogenousBundle(**sample_independent_levels(self, request).as_bundle_kwargs())
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(
+            self.asset_prices.by_asset_price_key().keys()
+            | self.property_values.by_property_value_key().keys()
+            | self.index_series.by_index_series_key().keys()
+        )
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
 
 
 SeriesModelSpec = IndependentSeriesModels

--- a/augur/model/state_space.py
+++ b/augur/model/state_space.py
@@ -253,6 +253,12 @@ class StateSpaceModel:
         # PE-mark factors are internal to the joint covariance and surface via the PE bundle.
         return self.artifact.level_factors
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.artifact.level_factors)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset(self.artifact.private_equity_factor_issuers)
+
     def save(self, path: Path) -> None:
         path.write_text(self.artifact.model_dump_json(indent=2), encoding="utf-8")
 

--- a/augur/model/testdata/fixture_sample_sanity.yaml
+++ b/augur/model/testdata/fixture_sample_sanity.yaml
@@ -2,11 +2,6 @@ provider_config_path: fixture_exogenous_provider.yaml
 horizon_months: 12
 rollout_seed_start: 1301
 rollout_count: 512
-required_level_series:
-  - kind: inflation
-  - kind: sp500
-required_private_equity_issuers:
-  - private_company_a
 level_checks:
   - key: { kind: inflation }
     initial_value: 330.0

--- a/augur/model/testing.py
+++ b/augur/model/testing.py
@@ -54,6 +54,12 @@ class ConstantFrameModel:
     metadata: Mapping[str, object] = field(default_factory=lambda: {"model_id": "constant_frame_fixture"})
     sample_requests: list[ExogenousSamplingRequest] = field(default_factory=list)
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.levels)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset(self.private_equity)
+
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         self.sample_requests.append(request)
 

--- a/augur/model/trained_private_equity.py
+++ b/augur/model/trained_private_equity.py
@@ -17,6 +17,7 @@ from augur.model.private_equity_protocol import (
     observed_private_equity_mark_matrix,
 )
 from augur.model.schemas import FrozenModel
+from augur.model.series import IssuerId, LevelSeriesKey
 from augur.model.series_model import derive_stream_rollout_seeds
 
 
@@ -79,6 +80,12 @@ class TrainedPrivateEquityModel(FrozenModel):
         except Exception as error:
             raise ValueError(f"failed to load trained private-equity model {path}: {error}") from error
         return cls(artifact=artifact)
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset({IssuerId(self.artifact.issuer_id)})
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         issuer = self.artifact.issuer_id

--- a/augur/model/vecm.py
+++ b/augur/model/vecm.py
@@ -55,6 +55,7 @@ from augur.model.series import (
     CryptoKey,
     HomeValueKey,
     InflationKey,
+    IssuerId,
     LevelSeriesKey,
     RentKey,
     SP500Key,
@@ -295,6 +296,12 @@ class VecmModel:
         return self._mc_horizon_predictive(log_levels[: t + 1], horizon=horizon, origin=t)
 
     # ──────────────────────── Sampler ────────────────────────
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return frozenset(self.factor_names)
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         """Roll the VECM forward for each rollout seed, convert log-level paths to

--- a/augur/product/service_test.py
+++ b/augur/product/service_test.py
@@ -18,6 +18,7 @@ from augur.model.series import (
     HomeValueKey,
     InflationKey,
     IssuerId,
+    LevelSeriesKey,
     LocationId,
     PrivateEquityEventKindCode,
     PrivateEquityRegimeCode,
@@ -75,6 +76,12 @@ class CountingModel:
     inner: Sampler
     sample_requests: list[ExogenousSamplingRequest] = field(default_factory=list)
 
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        return self.inner.emittable_level_keys()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return self.inner.emittable_private_equity_issuers()
+
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         self.sample_requests.append(request)
         return self.inner.sample(request)
@@ -83,6 +90,15 @@ class CountingModel:
 @dataclass
 class MissingRequiredExogenousModel:
     sample_requests: list[ExogenousSamplingRequest] = field(default_factory=list)
+
+    def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
+        # The whole point of this fixture is to fail validation by emitting nothing while the
+        # request demands something — so it claims to emit "anything" (callers still drive the
+        # request keys directly and `validate_sample_satisfies_request` catches the empty bundle).
+        return frozenset()
+
+    def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
+        return frozenset()
 
     def sample(self, request: ExogenousSamplingRequest) -> SampledExogenousBundle:
         self.sample_requests.append(request)


### PR DESCRIPTION
## Problem

A `sample_sanity.yaml` band declared against a series the deployment's preset can't emit 400s the entire calibration page. Concretely: gaffer's `sample_sanity.yaml` requires `home_value:mare_island_vallejo_ca`, `rent:vallejo_ca`, `rent:mare_island_vallejo_ca`, but the state-space artifact was trained on 7 factors that don't include them — every calibration run dies with `sampled exogenous bundle missing required level series: [...]`.

`SampleSanitySpec` carries `required_level_series` / `required_private_equity_issuers` that gate the sampling request. These were also redundant with `level_checks[*].key` / `*issuer_id` — a check IS implicitly a request to sample that series.

## Fix

Drop the two `required_*` fields. The set of series/issuers to attempt is derived from the checks. Each `Sampler` advertises:

```python
def emittable_level_keys(self) -> frozenset[LevelSeriesKey]: ...
def emittable_private_equity_issuers(self) -> frozenset[IssuerId]: ...
```

`partition_spec_coverage(spec, sampler)` intersects attempted vs emittable to yield modeled/unmodeled splits. `calibration_run` and `evaluate_sample_sanity` request only the modeled subset; unmodeled checks collapse to a single `status="unmodeled"` summary row per series/issuer.

## Frontend

`CalibrationSanityBand.status` Literal gains `"unmodeled"`. The calibration page renders it as an amber pill (distinct from `skipped` slate), sorted ahead of `skipped` / `pass` but after `fail` — loudest-first stays loud.

## Deploy gate

`run_sample_sanity` still raises on `unmodeled` (and `fail`), so a misconfigured spec can't ship. The looser handling is the calibration tab only — that's the UX surface this is about.

## Follow-up TODOs (in code)

1. Sample at `max(request.horizon_months, max band month in spec)` so the `skipped` status becomes dead (currently a user-picked short horizon silently `skipped`s longer bands).
2. Once (1) lands, the calibration tab's horizon control no longer drives sampling — move it to Product or keep as chart-axis zoom.

## Tests

- `//augur/model:sample_sanity_test` — two new tests cover the unmodeled-level-key and unmodeled-PE-issuer paths via `partition_spec_coverage` + `evaluate_sample_checks`.
- `//augur/api:test_calibration_endpoint`, `//augur/model:composite_test`, `//augur/model:state_space_test`, `//augur/frontend:sanity_bands_test` — passing.
- Broader: `//augur/{model,api,calibration,fit,product}/...` including size-filtered (`server_test`, `vecm_test`, `metrics_test`, `train_round_trip_test`, etc.) — all passing.

Cross-repo: gaffer-private's `sample_sanity.yaml` needs `required_level_series` / `required_private_equity_issuers` deleted once this is pinned. Will land that with the repin commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)