### PR TITLE
cluster/tf: refresh allegedly.works DNS for the renamed node set

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -201,15 +201,43 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
       L2 announce is stale stay in the `*.allegedly.works` round-robin until a human
       notices — most recently the augur oauth2-proxy crash-looped on OIDC discovery
       against `auth.allegedly.works` because DNS resolved to a dead IP ~2/5 of the
-      time (PR fixing the immediate bleeding: ducktape#1820). Options to wire up:
-      (a) `data "kubernetes_resources"` looking up nodes by a `gateway-public-ip`
-      label/annotation; (b) read from the main cluster TF state via
-      `terraform_remote_state` (or import the OVH node IPs directly) so the
-      provisioning side is the source of truth; (c) reuse a Cilium
-      `CiliumLoadBalancerIPPool` already constrained by node health. (a) is the
-      smallest change and would catch the L2-announce-stale case if combined with a
-      readiness gate (`Programmed=True` check). (b) is the most architecturally
-      coherent — DNS and node provisioning share state already, just not via TF.
+      time (PR fixing the immediate bleeding: ducktape#1820).
+
+      Survey of where the public IPs actually live today:
+
+      - **OVH cluster TF**: `cluster/terraform/main/ovh-nodes.tf:335-337` already rolls
+        `data.ovh_dedicated_server.kimsufi[*].ip` into `local.kimsufi_public_ips`.
+        This is the canonical, live source of truth and would expose as one output.
+      - **Kubernetes Node objects**: NOT currently usable. Checked
+        `kubectl get node ovh-ns102453 -o json` — `status.addresses` has only
+        `InternalIP=10.42.0.15` (Nebula) and hostname; no `ExternalIP`, no public-IP
+        annotation, `spec.providerID` empty. The talos-CCM is *installed* (Flux
+        `k8s/talos-cloud-controller-manager/helmrelease.yaml`, configured with
+        `publicIPDiscovery: true` for `topology.kubernetes.io/region=hil`) but
+        switched off: its log says `is kubelet has args: --cloud-provider=external on
+        the node?` — the Talos kubelet isn't started with that flag, so it never
+        applies the `node.cloudprovider.kubernetes.io/uninitialized` taint, so the
+        CCM's `cloud-node` controller short-circuits without populating addresses.
+      - **`CiliumLoadBalancerIPPool`**: not applicable — this cluster uses
+        hostNetwork Gateways (`Programmed=False` bug above), no LB IP allocation.
+
+      Two paths, mostly orthogonal:
+
+      1. **Fix the data gap at the right layer**: add
+         `machine.kubelet.extraArgs.cloud-provider: external` to the Talos machine
+         config for every Kimsufi node. Existing CCM then populates `ExternalIP` +
+         `providerID`. The DNS TF (and `kubectl get nodes -o wide`, and anything
+         else that asks the cluster for node addresses) just works. Needs a
+         per-node config patch + reboot; check kube-vip / Cilium / longhorn
+         tolerate the temporary uninitialized taint at startup.
+      2. **Wire DNS TF to cluster TF state**: add a
+         `terraform_remote_state` data source for the cluster TF root and pull
+         `local.kimsufi_public_ips`. Lower blast radius (TF-only), no node restart,
+         but only fixes DNS — leaves Node objects still missing ExternalIP for
+         everyone else.
+
+      (1) is the right architectural answer; (2) is the right next-PR answer.
+
 - [ ] Decouple wyrm2 from tofu: `module.wyrm2` in the same TF root as the cluster means
       any `tofu apply` risks rebooting wyrm2 (the machine running tofu). The `--exclude`
       flag is a workaround but error-prone. Options: separate TF root for wyrm2, or manage
@@ -482,11 +510,9 @@ wasn't reconciling.
 
 Per-HR opt-in fix:
 
-```yaml
-spec:
-  driftDetection:
-    mode: enabled
-```
+    spec:
+      driftDetection:
+        mode: enabled
 
 - [ ] Enable on `grafana-operator` (low-risk; nothing else writes that
       Deployment)

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -195,6 +195,21 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
       status as `Programmed=False` / `AddressNotAssigned`. Verify whether this is cosmetic
       (routes still work) or blocks CEC programming. If blocking, try `spec.addresses`
       with static OVH Gateway IPs, or track the upstream fix.
+- [ ] Autopopulate `tf/gitops/dns-records` IP lists from cluster state instead of a
+      hand-edited literal. After every `talos-* → ovh-ns*` rename the comments rot
+      (none of those rename commits touched the DNS TF) and IPs of nodes whose Cilium
+      L2 announce is stale stay in the `*.allegedly.works` round-robin until a human
+      notices — most recently the augur oauth2-proxy crash-looped on OIDC discovery
+      against `auth.allegedly.works` because DNS resolved to a dead IP ~2/5 of the
+      time (PR fixing the immediate bleeding: ducktape#1820). Options to wire up:
+      (a) `data "kubernetes_resources"` looking up nodes by a `gateway-public-ip`
+      label/annotation; (b) read from the main cluster TF state via
+      `terraform_remote_state` (or import the OVH node IPs directly) so the
+      provisioning side is the source of truth; (c) reuse a Cilium
+      `CiliumLoadBalancerIPPool` already constrained by node health. (a) is the
+      smallest change and would catch the L2-announce-stale case if combined with a
+      readiness gate (`Programmed=True` check). (b) is the most architecturally
+      coherent — DNS and node provisioning share state already, just not via TF.
 - [ ] Decouple wyrm2 from tofu: `module.wyrm2` in the same TF root as the cluster means
       any `tofu apply` risks rebooting wyrm2 (the machine running tofu). The `--exclude`
       flag is a workaround but error-prone. Options: separate TF root for wyrm2, or manage

--- a/tf/gitops/dns-records/main.tf
+++ b/tf/gitops/dns-records/main.tf
@@ -18,20 +18,31 @@ locals {
   domain = "allegedly.works"
 
   # Public Gateway node IPs. Update when public Gateway-capable nodes change.
+  # Comments name the current node (post talos-* → ovh-ns* renames). An IP listed
+  # here lands in the `*.allegedly.works` round-robin, so a dead IP gives every
+  # consumer a ~1/N transient failure rate — only list IPs whose node is currently
+  # announcing the Cilium gateway.
   public_gateway_ips = [
-    "147.135.37.175", # talos-kimsufi-cp-0
-    "147.135.39.162", # talos-kimsufi-worker-0
-    "147.135.39.176", # talos-kimsufi-worker-1
-    "147.135.104.5",  # talos-ks-game-worker-0
-    "147.135.104.16", # talos-ks-game-worker-1
+    "147.135.37.175", # ovh-ns102453 (formerly talos-kimsufi-cp-0)
+    "147.135.39.162", # ovh-ns103656 (formerly talos-kimsufi-worker-0)
+    "147.135.104.16", # ovh-ns104963 (formerly talos-ks-game-worker-1)
+    # Dropped 2026-06-02: `.176` (ovh-ns103711, formerly talos-kimsufi-worker-1) and
+    # `.5` (ovh-ns104952, formerly talos-ks-game-worker-0) — both nodes are up but
+    # the IPs return RST (Cilium L2 announce not active on these post-rename), so
+    # the augur oauth2-proxy and similar consumers intermittently fail OIDC
+    # discovery when their DNS round-robin lands on one. Restore once L2
+    # announcement / per-node public-IP wiring is fixed.
   ]
 
-  # Kubernetes API endpoints. Keep this narrower than public_gateway_ips:
-  # kubeconfigs use api.allegedly.works:6443, and worker-only gateway nodes do
-  # not serve the apiserver on that port.
+  # Kubernetes API endpoints — every control-plane node, not just the ones whose
+  # Cilium gateway is healthy. The apiserver listens on the host directly so it
+  # is independent of L2-announce state: `ovh-ns103711` (`.176`) is dropped from
+  # `public_gateway_ips` above for gateway-RST reasons but still serves the API
+  # on :6443.
   kube_api_ips = [
-    "147.135.37.175", # talos-kimsufi-cp-0
-    "147.135.39.162", # talos-kimsufi-worker-0
+    "147.135.37.175", # ovh-ns102453 (formerly talos-kimsufi-cp-0)
+    "147.135.39.162", # ovh-ns103656 (formerly talos-kimsufi-worker-0)
+    "147.135.39.176", # ovh-ns103711 (formerly talos-kimsufi-worker-1)
   ]
 }
 


### PR DESCRIPTION
## Symptom

The augur calibration repin (just-merged #1819 → gaffer's pin bump) landed cleanly, but the rolling pod gets stuck on its oauth2-proxy container:

```
Failed to discover OIDC configuration: ... read tcp 10.244.2.172:40912->147.135.104.5:443: read: connection reset by peer
```

## Root cause

`*.allegedly.works` DNS round-robins across 5 IPs that were hand-edited into `tf/gitops/dns-records/main.tf`. After the recent `talos-*` → `ovh-ns*` renames (`a01f8c4b2`, `abd386930`, `86fc7f91f`, `63ea78ae9`, `4c79bc7cd`), none of those commits touched the DNS TF — so its comments lie about which node owns each IP. More importantly, per-IP testing shows:

| IP | Comment (old, stale) | Current node | `:443` | `:6443` |
|---|---|---|---|---|
| `147.135.37.175` | talos-kimsufi-cp-0 | ovh-ns102453 | envoy 404 | OPEN |
| `147.135.39.162` | talos-kimsufi-worker-0 | ovh-ns103656 | envoy 404 | OPEN |
| `147.135.39.176` | talos-kimsufi-worker-1 | ovh-ns103711 | **RST** | OPEN |
| `147.135.104.5` | talos-ks-game-worker-0 | ovh-ns104952 | **RST** | CLOSED |
| `147.135.104.16` | talos-ks-game-worker-1 | ovh-ns104963 | envoy 404 | CLOSED |

The 3 reachable IPs return envoy 404 because the Cilium Gateway is `Programmed=False` (separate / wider issue — `cluster-gateway` listener `Address not ready yet`). But the two RST'ing IPs are what's biting consumers right now — any pod whose DNS lookup lands on `.176` or `.5` fails to even reach envoy.

## Fix (this PR)

Surgical, scoped to today's bleeding:

- Drop `.176` and `.5` from `public_gateway_ips` until Cilium L2 announcement is restored on those nodes.
- Refresh the comments to current `ovh-ns*` names.
- Add `ovh-ns103711` (`.176`) to `kube_api_ips` — that node is a control plane now, and the apiserver listens on the host directly so it's independent of L2-announce state (`:6443` is OPEN even though `:443` is RST).

## Out of scope (follow-ups)

- Make `public_gateway_ips` / `kube_api_ips` derive from the cluster (Cilium `CiliumLoadBalancerIPPool`, node labels, or a Talos TF data source) so future node rotations don't bitrot DNS.
- Fix the Cilium Gateway `Programmed=False` state — that's why even the reachable IPs return 404 instead of routing properly.

Once this PR + tofu-controller reconcile, the failing 2/5 round-robin outcome goes away and the augur calibration tab actually serves (instead of crash-looping oauth2-proxy on bad-luck DNS).