### PR TITLE
cluster/tf: opt all Kimsufi nodes into kubelet --cloud-provider=external

### DIFF
--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -298,7 +298,10 @@ locals {
           image = "factory.talos.dev/installer/${talos_image_factory_schematic.kimsufi.id}:${var.talos_version}"
         }
         files = local.cp_auth_files
-        # Topology labels set explicitly — no CCM for OVH bare metal.
+        # Topology labels set explicitly. The installed talos-CCM only populates
+        # ExternalIP / providerID when `--cloud-provider=external` is in the kubelet
+        # extraArgs (see `kimsufi_cloud_provider_external_enabled_nodes` below); the
+        # CCM transformation matches on `region=hil` set here.
         nodeLabels = {
           "topology.kubernetes.io/region" = "hil"
           "topology.kubernetes.io/zone"   = v.zone
@@ -381,6 +384,54 @@ locals {
     ]
   }
 
+  # Kubelet --cloud-provider=external opt-in. The installed talos-CCM
+  # (k8s/talos-cloud-controller-manager, configured with `publicIPDiscovery: true` for
+  # `region=hil`) only acts on nodes whose kubelet was started with
+  # `--cloud-provider=external` — that's the flag that makes kubelet apply the
+  # `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` taint at first
+  # registration, which is the CCM's input signal. Without it, the CCM short-circuits
+  # ("is kubelet has args: --cloud-provider=external on the node?" in its log) and
+  # Node.spec.providerID + status.addresses[ExternalIP] stay empty — which is why
+  # tf/gitops/dns-records hard-codes IPs by hand. See cluster/docs/plan.md
+  # "Autopopulate tf/gitops/dns-records IP lists" for the motivating goal.
+  #
+  # Kept Kimsufi-only deliberately: Proxmox nodes share `common_machine_base.kubelet`
+  # but their `region=proxmox` doesn't match the CCM transformation's `region=hil`
+  # selector, so flipping the flag there would leave them stuck with the
+  # uninitialized taint and no CCM to clear it.
+  #
+  # MIGRATION NOTE: kubelet only adds the uninitialized taint at first node
+  # registration, not on a flag-flip kubelet restart. Existing nodes that were
+  # already registered before the flag landed need a one-time
+  #
+  #   kubectl taint nodes <node> node.cloudprovider.kubernetes.io/uninitialized=:NoSchedule
+  #
+  # after the kubelet restarts with the flag. The CCM then populates providerID +
+  # ExternalIP and removes the taint, and the node is in steady state.
+  # Fresh-bootstrapped nodes (post-flag install) get this for free.
+  kimsufi_cloud_provider_external_enabled_nodes = toset([
+    "kimsufi_cp0",
+    "kimsufi_worker0",
+    "kimsufi_worker1",
+    "ks_game_worker0",
+    "ks_game_worker1",
+  ])
+
+  kimsufi_cloud_provider_external_patches = {
+    for k in concat(keys(local.active_kimsufi_servers), keys(local.active_kimsufi_cp_servers)) :
+    k => contains(local.kimsufi_cloud_provider_external_enabled_nodes, k) ? [
+      yamlencode({
+        machine = {
+          kubelet = {
+            extraArgs = {
+              "cloud-provider" = "external"
+            }
+          }
+        }
+      }),
+    ] : []
+  }
+
   kimsufi_cp_machine_config_patches = {
     for k, v in local.kimsufi_cp_servers :
     k => yamlencode({
@@ -389,7 +440,10 @@ locals {
           image = "factory.talos.dev/installer/${talos_image_factory_schematic.kimsufi.id}:${var.talos_version}"
         }
         files = local.cp_auth_files
-        # Topology labels set explicitly — no CCM for OVH bare metal.
+        # Topology labels set explicitly. The installed talos-CCM only populates
+        # ExternalIP / providerID when `--cloud-provider=external` is in the kubelet
+        # extraArgs (see `kimsufi_cloud_provider_external_enabled_nodes` below); the
+        # CCM transformation matches on `region=hil` set here.
         nodeLabels = {
           "topology.kubernetes.io/region" = "hil"
           "topology.kubernetes.io/zone"   = v.zone
@@ -424,6 +478,7 @@ data "talos_machine_configuration" "kimsufi" {
     ],
     local.kimsufi_user_volume_config_patches[each.key],
     local.kimsufi_eno1_peer_route_patches[each.key],
+    local.kimsufi_cloud_provider_external_patches[each.key],
     local.nebula_machine_patches[each.key],
   )
 }
@@ -543,6 +598,7 @@ data "talos_machine_configuration" "kimsufi_cp" {
     ],
     local.kimsufi_user_volume_config_patches[each.key],
     local.kimsufi_eno1_peer_route_patches[each.key],
+    local.kimsufi_cloud_provider_external_patches[each.key],
     local.nebula_machine_patches[each.key],
   )
 }


### PR DESCRIPTION
## Why

Bench-tested 2026-06-02 on `ovh-ns104963` (see context below). The installed talos-CCM (`k8s/talos-cloud-controller-manager`, with `publicIPDiscovery: true` for `region=hil`) only acts when the kubelet was started with `--cloud-provider=external` — that flag makes kubelet apply the `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` taint at first registration, which is the CCM's input signal. Without it the CCM logs `is kubelet has args: --cloud-provider=external on the node?` and short-circuits.

Once kubelet has the flag and the taint is present, the CCM:
- sets `Node.spec.providerID` (e.g. `talos://metal/10.42.0.17`),
- populates `status.addresses[ExternalIP]` from Talos node metadata (verified `147.135.104.16` on ns104963),
- removes the taint.

That makes the K8s API a reliable source of node public IPs for downstream consumers — most concretely `tf/gitops/dns-records`, whose hand-edited literal currently rots on every node rename (ducktape#1820 was the most recent symptom).

## What

- New `kimsufi_cloud_provider_external_enabled_nodes` toset, initially all five Kimsufi keys (`kimsufi_cp0`, `kimsufi_worker0`, `kimsufi_worker1`, `ks_game_worker0`, `ks_game_worker1`).
- New `kimsufi_cloud_provider_external_patches` map producing strategic-merge YAML per node.
- Wired into both `data.talos_machine_configuration.kimsufi.config_patches` and `data.talos_machine_configuration.kimsufi_cp.config_patches`.
- Corrects the stale "no CCM for OVH bare metal" comment in the two `nodeLabels` blocks — the CCM is installed; this PR wakes it up.

## Why per-node toset, not `common_machine_base`

`common_machine_base.kubelet` is shared with Proxmox nodes (`proxmox-nodes.tf:210-211` does `merge(local.common_machine_base.kubelet, …)`). Proxmox nodes' `region=proxmox` doesn't match the CCM's `region=hil` selector, so flipping the flag there would leave them stuck with the uninitialized taint and no CCM to clear it. The per-node toset keeps the change Kimsufi-only by construction (same pattern as `kimsufi_eno1_peer_route_enabled_nodes`).

## Migration

Kubelet only applies the uninitialized taint at first node registration, not on flag-flip restart. After `tofu apply`:

```
for node in ovh-ns102453 ovh-ns103656 ovh-ns103711 ovh-ns104952; do
  kubectl taint nodes "$node" node.cloudprovider.kubernetes.io/uninitialized=:NoSchedule
done
```

(`ovh-ns104963` already has providerID + ExternalIP populated from the bench-test, no taint needed there.)

Then verify:
```
kubectl get nodes -o wide   # should show ExternalIP for each ovh-ns* node
```

## Bench-test evidence (ovh-ns104963)

- `talosctl patch mc --mode=no-reboot` with `machine.kubelet.extraArgs.cloud-provider: external` — kubelet restarted with the flag (verified via `talosctl ps`). Pods stayed Running (containerd is independent of kubelet restart).
- Manual `kubectl taint … uninitialized=:NoSchedule` — CCM cleared the taint within ~10s, set `providerID=talos://metal/10.42.0.17` and `ExternalIP=147.135.104.16`.

## Risk

Four other Kimsufi nodes' kubelets will restart simultaneously at `tofu apply` time. Pods keep running (only kubelet process restarts; containerd is independent). Brief readiness-probe gap. Static control-plane pods on the 3 CPs (kube-apiserver, controller-manager, scheduler) are not affected by kubelet restart — Talos manages them.

## Follow-up

Once all five nodes have ExternalIP populated, `tf/gitops/dns-records/main.tf` can drop its hand-edited literal in favor of a `data "kubernetes_resources"` lookup. That's the next PR.