### PR TITLE
cluster/harbor: suspend all harbor kustomizations

### DIFF
--- a/cluster/k8s/harbor/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/agent-rbac/flux-kustomization.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     description: Agent RBAC for harbor namespace. Lightweight — only RoleBindings. Depends on namespace existing + claude-rbac for ClusterRoles.
 spec:
+  suspend: true
   interval: 10m
   path: ./cluster/k8s/harbor/agent-rbac
   prune: true

--- a/cluster/k8s/harbor/app/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/app/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 10m

--- a/cluster/k8s/harbor/ci/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/ci/flux-kustomization.yaml
@@ -5,6 +5,7 @@ metadata:
   name: harbor-ci
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   path: ./cluster/k8s/harbor/ci

--- a/cluster/k8s/harbor/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/namespace/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor-namespace
   namespace: flux-system
 spec:
+  suspend: true
   interval: 1h
   path: ./cluster/k8s/harbor/namespace
   prune: false

--- a/cluster/k8s/harbor/oidc-config/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/oidc-config/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor-oidc-config
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   timeout: 5m

--- a/cluster/k8s/harbor/proxy-cache/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/proxy-cache/flux-kustomization.yaml
@@ -5,6 +5,7 @@ metadata:
   name: harbor-proxy-cache
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m0s
   path: ./cluster/k8s/harbor/proxy-cache

--- a/cluster/k8s/harbor/secrets/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/secrets/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor-secrets
   namespace: flux-system
 spec:
+  suspend: true
   retryInterval: 1m
   interval: 10m
   path: ./cluster/k8s/harbor/secrets

--- a/cluster/k8s/harbor/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/harbor/servicemonitor/flux-kustomization.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor-servicemonitor
   namespace: flux-system
 spec:
+  suspend: true
   interval: 10m
   path: ./cluster/k8s/harbor/servicemonitor
   prune: true


### PR DESCRIPTION
Tearing down Harbor for now. The registry has been unavailable for ~18 days following the 2026-06-02 OVH-rename SeaweedFS volume loss (`harbor-db` CNPG could not bootstrap; cascade of `harbor-{ci,oidc-config,props,proxy-cache,servicemonitor,app}` Flux kustomizations stuck behind it, plus 4 tofu-controller TF resources). Re-pull through ghcr directly until there's a real plan for the DB.

Suspend committed in git rather than via `kubectl patch` because the `flux-system` meta-Kustomization re-applies child Kustomization specs via SSA and resets a kubectl-merge-patched `suspend` field on the next reconcile cycle. In-git suspend is sticky.

Adjacent cleanup (already done out-of-band):
- `harbor-db` CNPG Cluster deleted
- `harbor` namespace deleted (will re-delete once Flux applies the suspend so it stops getting recreated)
- 4 TF resources in `flux-system` (`harbor-{ci,oidc-config,props,proxy-cache}`) deleted
- `flux-system/harbor-ci-robot-desired` Secret deleted
- 4 Released PVs that were holding harbor PVCs cleaned up

Resume when ready: revert this commit, run `flux reconcile kustomization flux-system`.