### PR TITLE
props: split lifespan + /readyz so probes answer during slow init

### DIFF
--- a/cluster/k8s/props/app/deployment.yaml
+++ b/cluster/k8s/props/app/deployment.yaml
@@ -93,6 +93,17 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          # Startup work (alembic migrations + specimen sync + executor build)
+          # runs in a background task on the event loop; meanwhile /health
+          # responds immediately so kubelet doesn't kill the pod. /readyz
+          # only flips to 200 once that background task completes.
+          # startupProbe gives 10min for the slow path before liveness kicks in.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health
@@ -101,7 +112,7 @@ spec:
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -12,15 +12,16 @@ view directly, not as a REST endpoint.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import traceback
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
@@ -92,62 +93,98 @@ def _sync_all_specimens(db: Database) -> None:
 def _make_lifespan(deps: BackendDeps):
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        logger.info("Starting props backend...")
+        # Fast path: bind the HTTP server immediately so kubelet probes can reach
+        # /health and /readyz. All the slow startup work (alembic migrations,
+        # specimen sync, executor + registry construction, grader supervisor)
+        # runs in a background task. Readiness is gated on `startup_complete`
+        # so the Service won't route traffic until the slow work has finished.
+        logger.info("Starting props backend (fast lifespan; slow init backgrounded)...")
+        app.state.startup_complete = False
+        app.state.grader_supervisor = None
+        app.state.registry = None
+        app.state.admin_db = None
 
         db_config = DatabaseConfig()
         db = Database(db_config)
         app.state.admin_db = db
         app.state.config = deps.config
 
-        if deps.config.auto_migrate:
-            upgrade_database(db.engine)
-        ensure_evaluator_role(db_config)
+        async def _slow_startup() -> None:
+            if deps.config.auto_migrate:
+                await asyncio.to_thread(upgrade_database, db.engine)
+            await asyncio.to_thread(ensure_evaluator_role, db_config)
 
-        # Sync model metadata on boot (ensures custom models from config are in DB)
-        with db.session() as session:
-            stats = sync_model_metadata_with_session(session, deps.config)
-            if stats.added or stats.deleted:
-                logger.info(f"Model metadata synced: +{stats.added} added, -{stats.deleted} deleted")
+            def _sync_metadata() -> None:
+                with db.session() as session:
+                    stats = sync_model_metadata_with_session(session, deps.config)
+                    if stats.added or stats.deleted:
+                        logger.info(f"Model metadata synced: +{stats.added} added, -{stats.deleted} deleted")
 
-        if deps.config.auto_sync_specimens:
-            _sync_all_specimens(db)
+            await asyncio.to_thread(_sync_metadata)
 
-        executor = await create_executor(deps.config.executor, db_config, deps.registry_proxy_config)
-        logger.info("Using %s executor", deps.config.executor.type)
-        model_parallelism_limits = {
-            m.name: m.max_parallel_agents for m in deps.config.models if m.max_parallel_agents is not None
-        }
-        app.state.registry = AgentRegistry(
-            executor=executor,
-            db=db,
-            db_config=db_config,
-            backend_url=deps.backend_url,
-            agent_base_env=deps.config.agent_env,
-            registry_config=deps.registry_proxy_config,
-            model_parallelism_limits=model_parallelism_limits,
-        )
+            if deps.config.auto_sync_specimens:
+                await asyncio.to_thread(_sync_all_specimens, db)
 
-        if deps.grader_model:
-            app.state.grader_supervisor = GraderSupervisor(
-                registry=app.state.registry, db_config=db_config, model=deps.grader_model, db=db
+            executor = await create_executor(deps.config.executor, db_config, deps.registry_proxy_config)
+            logger.info("Using %s executor", deps.config.executor.type)
+            model_parallelism_limits = {
+                m.name: m.max_parallel_agents for m in deps.config.models if m.max_parallel_agents is not None
+            }
+            app.state.registry = AgentRegistry(
+                executor=executor,
+                db=db,
+                db_config=db_config,
+                backend_url=deps.backend_url,
+                agent_base_env=deps.config.agent_env,
+                registry_config=deps.registry_proxy_config,
+                model_parallelism_limits=model_parallelism_limits,
             )
-            await app.state.grader_supervisor.start()
-            logger.info(f"Grader supervisor started (model: {deps.grader_model})")
-        else:
-            app.state.grader_supervisor = None
-            logger.info("Grader supervisor disabled (grader_model not set in config)")
 
-        admin_token = db_config.basic_auth_token
-        protocol = "https" if deps.port == 443 else "http"
-        logger.info(f"Admin token: {admin_token}")
-        logger.info(f"Admin URL: {protocol}://{deps.host}:{deps.port}/?token={admin_token}")
-        logger.info("Props backend ready")
+            if deps.grader_model:
+                app.state.grader_supervisor = GraderSupervisor(
+                    registry=app.state.registry, db_config=db_config, model=deps.grader_model, db=db
+                )
+                await app.state.grader_supervisor.start()
+                logger.info(f"Grader supervisor started (model: {deps.grader_model})")
+            else:
+                logger.info("Grader supervisor disabled (grader_model not set in config)")
+
+            admin_token = db_config.basic_auth_token
+            protocol = "https" if deps.port == 443 else "http"
+            logger.info(f"Admin token: {admin_token}")
+            logger.info(f"Admin URL: {protocol}://{deps.host}:{deps.port}/?token={admin_token}")
+            logger.info("Props backend ready")
+            app.state.startup_complete = True
+
+        startup_task = asyncio.create_task(_slow_startup())
+
+        # If the slow-startup task raises, asyncio will only log the unhandled
+        # exception by default — the server keeps running NotReady forever.
+        # That's worse than crashing: a stuck-NotReady pod silently fails any
+        # rollout and obscures the underlying bug. Re-raise via os._exit so
+        # kubelet restarts us and the failure is loud (matches the pre-change
+        # behaviour where lifespan exceptions crashed the worker).
+        def _on_startup_done(task: asyncio.Task[None]) -> None:
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                logger.exception("Background startup failed; exiting to trigger restart", exc_info=exc)
+                os._exit(1)
+
+        startup_task.add_done_callback(_on_startup_done)
+
         yield
 
         logger.info("Shutting down props backend...")
-        if app.state.grader_supervisor:
+        if not startup_task.done():
+            startup_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await startup_task
+        if app.state.grader_supervisor is not None:
             await app.state.grader_supervisor.shutdown()
-        await app.state.registry.close()
+        if app.state.registry is not None:
+            await app.state.registry.close()
         db.dispose()
         logger.info("Props backend stopped")
 
@@ -182,7 +219,23 @@ def create_app(*, deps: BackendDeps, static_dir: Path | None = None) -> FastAPI:
 
     @app.get("/health")
     def health() -> dict[str, str]:
+        # Liveness: the HTTP server is up and the event loop is responsive.
+        # Returns 200 even during the backgrounded slow-startup window
+        # (alembic migrations, specimen sync, registry construction) so that
+        # kubelet doesn't kill the pod mid-init. Readiness — "is this pod
+        # ready to receive Service traffic?" — lives at /readyz below.
         return {"status": "ok"}
+
+    @app.get("/readyz")
+    def readyz(response: Response) -> dict[str, str]:
+        # Readiness: backgrounded startup task has finished (specimens synced,
+        # registry built, grader supervisor up). Backed by kubelet's
+        # readinessProbe in deployment.yaml; the Service won't route traffic
+        # to the pod until this returns 200.
+        if getattr(app.state, "startup_complete", False):
+            return {"status": "ready"}
+        response.status_code = 503
+        return {"status": "starting"}
 
     @app.exception_handler(Exception)
     async def debug_exception_handler(request: Request, exc: Exception) -> PlainTextResponse:


### PR DESCRIPTION
## Summary

- Backend lifespan was running migrations, evaluator-role setup, model-metadata sync, `_sync_all_specimens`, executor creation, registry build, and grader supervisor start **before** yielding. Specimen sync alone takes minutes; meanwhile kubelet's `livenessProbe`/`readinessProbe` (both on `/health`) couldn't bind, the pod restarted, repeat. props.allegedly.works was effectively down.
- Lifespan now yields immediately after a fast DB-handle setup. All slow work moves into an `asyncio` background task (`_slow_startup`) with sync calls wrapped in `asyncio.to_thread`. A done-callback `os._exit(1)`s on failure so the pod crashes loudly instead of sitting NotReady forever.
- New `/readyz` returns 503 until `app.state.startup_complete=True`, 200 after. `/health` stays cheap (just "event loop is responsive").
- Deployment gets a `startupProbe` on `/readyz` (`failureThreshold: 60`, `periodSeconds: 10` = 10 min budget) plus `readinessProbe` flipped to `/readyz`. `livenessProbe` stays on `/health` so transient slow startup never trips it.

## Test plan

- [ ] CI green
- [ ] After merge: watch `kubectl -n props get pods -w`; pod should go Ready briefly Ready-NotReady (with `/readyz` 503 → 200) instead of CrashLoopBackOff
- [ ] `curl https://props.allegedly.works/health` → 200 within seconds
- [ ] `curl https://props.allegedly.works/readyz` → 503 during sync, 200 after sync completes
- [ ] Logs show "Starting props backend (fast lifespan; slow init backgrounded)..." then "Props backend ready" several minutes later