### PR TITLE
props: add Authentik OIDC (SSO) login for the dashboard

### DIFF
--- a/cluster/k8s/props/app/deployment.yaml
+++ b/cluster/k8s/props/app/deployment.yaml
@@ -63,6 +63,30 @@ spec:
                 secretKeyRef:
                   name: props-evaluator-credentials
                   key: password
+            # Authentik SSO for browser users (props/backend/oidc.py). The
+            # props-oidc-config secret is created by tf/gitops/sso-providers and
+            # reflected from the authentik namespace into props.
+            - name: PROPS_OIDC_ISSUER
+              value: https://auth.allegedly.works/application/o/props/
+            - name: PROPS_OIDC_PUBLIC_BASE_URL
+              value: https://props.allegedly.works
+            - name: PROPS_OIDC_ADMIN_EMAILS
+              value: agentydragon@gmail.com
+            - name: PROPS_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: props-oidc-config
+                  key: client-id
+            - name: PROPS_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: props-oidc-config
+                  key: client-secret
+            - name: PROPS_OIDC_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: props-oidc-config
+                  key: session-secret
             - name: PROPS_REGISTRY_UPSTREAM_URL
               value: http://forgejo-http.forgejo:3000
             - name: PROPS_REGISTRY_UPSTREAM_USERNAME

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -38,12 +38,26 @@ py_library(
 )
 
 py_library(
+    name = "oidc",
+    srcs = ["oidc.py"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@pypi//authlib",
+        "@pypi//httpx",
+        "@pypi//pydantic_settings",
+        "@pypi//starlette",
+    ],
+)
+
+py_library(
     name = "app",
     srcs = ["app.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        ":oidc",
         "//props:config",
         "//props/backend/routes:agent_definitions",
+        "//props/backend/routes:auth_routes",
         "//props/backend/routes:ground_truth",
         "//props/backend/routes:llm",
         "//props/backend/routes:model_metadata",
@@ -62,6 +76,8 @@ py_library(
         "//util:logging",
         "@pypi//asyncpg",
         "@pypi//fastapi",
+        "@pypi//itsdangerous",
+        "@pypi//starlette",
     ],
 )
 
@@ -115,6 +131,16 @@ py_test(
         "//props/db:config",
         "//props/db:database",
         "@pypi//fastapi",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_oidc",
+    srcs = ["test_oidc.py"],
+    deps = [
+        ":oidc",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -25,8 +25,19 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
 
-from props.backend.routes import agent_definitions, ground_truth, llm, model_metadata, registry, runs, stats
+from props.backend.oidc import build_oauth, load_oidc_settings
+from props.backend.routes import (
+    agent_definitions,
+    auth_routes,
+    ground_truth,
+    llm,
+    model_metadata,
+    registry,
+    runs,
+    stats,
+)
 from props.config import PropsConfig, load_config_from_env
 from props.core.oci_utils import RegistryProxyConfig, get_registry_proxy_config
 from props.db.config import DatabaseConfig
@@ -208,6 +219,26 @@ def create_app(*, deps: BackendDeps, static_dir: Path | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Optional Authentik SSO for browser users. When unconfigured (local dev,
+    # tests, docker-compose) the dashboard stays token-only; machine clients
+    # always use the Postgres-credential Bearer/Basic path in auth.py.
+    oidc_settings = load_oidc_settings()
+    app.state.oidc_settings = oidc_settings
+    app.state.oauth = None
+    if oidc_settings is not None:
+        app.add_middleware(
+            SessionMiddleware,
+            secret_key=oidc_settings.session_secret,
+            session_cookie="props_session",
+            https_only=oidc_settings.cookie_secure,
+            same_site="lax",
+        )
+        app.state.oauth = build_oauth(oidc_settings)
+        app.include_router(auth_routes.router)
+        logger.info("OIDC SSO enabled (issuer=%s)", oidc_settings.issuer)
+    else:
+        logger.info("OIDC SSO not configured; dashboard uses token auth only")
 
     app.include_router(stats.router, prefix="/api/stats", tags=["stats"])
     app.include_router(runs.router, prefix="/api/runs", tags=["runs"])

--- a/props/backend/auth.py
+++ b/props/backend/auth.py
@@ -198,10 +198,15 @@ def get_request_identity(request: Request, admin_db: AdminDb) -> RequestIdentity
     if not authorization:
         # No token: fall back to an Authentik SSO session cookie if one is present.
         # "session" is in scope only when SessionMiddleware is installed (SSO enabled).
-        if "session" in request.scope:
-            user = request.session.get("user")
-            if user:
-                return SessionIdentity(email=user["email"])
+        # Re-check the admin allowlist on every request — sessions are client-side
+        # (signed) cookies, so revoked access must not linger until the cookie expires.
+        if "session" in request.scope and (user := request.session.get("user")):
+            settings = request.app.state.oidc_settings
+            email = user.get("email")
+            if email and settings is not None and settings.is_admin(email):
+                return SessionIdentity(email=email)
+            # Stale or revoked session: drop it and treat the request as anonymous.
+            request.session.pop("user", None)
         return AnonymousIdentity()
 
     parsed = parse_credentials(authorization)

--- a/props/backend/auth.py
+++ b/props/backend/auth.py
@@ -10,6 +10,10 @@ Tokens contain base64-encoded username:password. Both schemes are supported:
 - Basic: OCI/crane tooling doesn't support token auth (Bearer); crane/docker
   send Basic auth from Docker config
 
+Browser users instead authenticate via Authentik SSO (see oidc.py and
+routes/auth_routes.py), which sets a signed session cookie. A request with no
+Authorization header but a valid session resolves to a SessionIdentity (admin).
+
 This module provides:
 - Credential validation with access level determination
 - Request identity resolution with DB lookup for agent types
@@ -71,14 +75,30 @@ class AnonymousIdentity:
 
 @dataclass(frozen=True)
 class AuthenticatedIdentity:
-    """Authenticated request with Postgres credentials and a role."""
+    """Authenticated request with Postgres credentials and a role.
+
+    Used by machine clients (agents, CI crane pushes, evaluator scripts) that
+    present base64 Postgres credentials as a Bearer/Basic token.
+    """
 
     username: str
     password: str
     role: Role
 
 
-RequestIdentity = AnonymousIdentity | AuthenticatedIdentity
+@dataclass(frozen=True)
+class SessionIdentity:
+    """Browser user authenticated via Authentik SSO (admin-only).
+
+    Unlike AuthenticatedIdentity there is no Postgres password: DB access uses
+    the server-held admin pool (see get_caller_db). SSO currently grants admin
+    only; evaluator/agent roles remain token-based.
+    """
+
+    email: str
+
+
+RequestIdentity = AnonymousIdentity | AuthenticatedIdentity | SessionIdentity
 
 
 _CRITIC_DEV_TYPES = {AgentType.CRITIC_DEV_OPTIMIZE, AgentType.CRITIC_DEV_IMPROVE}
@@ -86,6 +106,8 @@ _CRITIC_DEV_TYPES = {AgentType.CRITIC_DEV_OPTIMIZE, AgentType.CRITIC_DEV_IMPROVE
 
 def is_admin_or_evaluator(identity: RequestIdentity) -> bool:
     """Admin or evaluator — full read access, can launch any agent type."""
+    if isinstance(identity, SessionIdentity):
+        return True  # SSO grants admin
     return isinstance(identity, AuthenticatedIdentity) and isinstance(identity.role, (AdminRole, EvaluatorRole))
 
 
@@ -174,6 +196,12 @@ def get_request_identity(request: Request, admin_db: AdminDb) -> RequestIdentity
     authorization = request.headers.get("authorization")
 
     if not authorization:
+        # No token: fall back to an Authentik SSO session cookie if one is present.
+        # "session" is in scope only when SessionMiddleware is installed (SSO enabled).
+        if "session" in request.scope:
+            user = request.session.get("user")
+            if user:
+                return SessionIdentity(email=user["email"])
         return AnonymousIdentity()
 
     parsed = parse_credentials(authorization)
@@ -219,12 +247,16 @@ def require_critic_run_access(auth: Auth) -> RequestIdentity:
 
 def require_admin_access(auth: Auth) -> None:
     """FastAPI dependency requiring admin access. Raises HTTPException 403 if not admin."""
+    if isinstance(auth, SessionIdentity):
+        return  # SSO grants admin
     if not (isinstance(auth, AuthenticatedIdentity) and isinstance(auth.role, AdminRole)):
         raise HTTPException(status_code=403, detail="Admin access required")
 
 
 def require_evaluator_or_admin_access(auth: Auth) -> None:
     """FastAPI dependency allowing admin or evaluator access."""
+    if isinstance(auth, SessionIdentity):
+        return  # SSO grants admin
     if not (isinstance(auth, AuthenticatedIdentity) and isinstance(auth.role, (AdminRole, EvaluatorRole))):
         raise HTTPException(status_code=403, detail="Admin or evaluator access required")
 
@@ -237,6 +269,7 @@ def require_evaluator_or_admin_access(auth: Auth) -> None:
 def get_caller_db(admin_db: AdminDb, auth: Auth) -> Iterator[Database]:
     """Get Database using caller's credentials for RLS/permission enforcement.
 
+    SSO session: admin-only — returns the shared admin Database.
     Admin: returns the shared admin Database (full access, bypasses RLS).
     Evaluator: per-request Database with evaluator's Postgres role (BYPASSRLS + SELECT-only).
     Agent: per-request Database with agent's Postgres role (RLS-scoped access).
@@ -244,6 +277,11 @@ def get_caller_db(admin_db: AdminDb, auth: Auth) -> Iterator[Database]:
     """
     if isinstance(auth, AnonymousIdentity):
         raise HTTPException(status_code=401, detail="Authentication required")
+
+    # SSO sessions are admin-only: use the server-held admin pool (no caller password).
+    if isinstance(auth, SessionIdentity):
+        yield admin_db
+        return
 
     assert isinstance(auth, AuthenticatedIdentity)
 

--- a/props/backend/oidc.py
+++ b/props/backend/oidc.py
@@ -1,0 +1,82 @@
+"""OIDC (Authentik) login for the props dashboard.
+
+Browser users authenticate against Authentik via the OAuth2 authorization-code
+flow; the resulting identity is stored in a signed session cookie. This is a
+*parallel* path to the Postgres-credential Bearer/Basic auth in `auth.py`:
+machine clients (agents, CI crane pushes, evaluator scripts) keep using tokens,
+only humans using the dashboard go through OIDC.
+
+A successful SSO login maps to admin access only (see `auth.get_caller_db`);
+evaluator/agent roles remain token-based.
+
+All settings come from `PROPS_OIDC_*` env vars. SSO is enabled iff
+`PROPS_OIDC_ISSUER` is set — otherwise the dashboard is token-only (local dev,
+tests, the docker-compose stack).
+"""
+
+from __future__ import annotations
+
+import os
+
+from authlib.integrations.starlette_client import OAuth
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ENV_OIDC_ISSUER = "PROPS_OIDC_ISSUER"
+
+# authlib client registration name; referenced by the /auth routes.
+AUTHENTIK_CLIENT_NAME = "authentik"
+
+
+class OIDCSettings(BaseSettings):
+    """Authentik OIDC relying-party settings, sourced from PROPS_OIDC_* env vars."""
+
+    model_config = SettingsConfigDict(env_prefix="PROPS_OIDC_", frozen=True)
+
+    # Per-provider issuer, e.g. https://auth.allegedly.works/application/o/props/
+    issuer: str
+    client_id: str
+    client_secret: str
+    # Signs the session cookie (HMAC). Generated in Terraform alongside the client.
+    session_secret: str
+    # Public origin of the dashboard, e.g. https://props.allegedly.works.
+    # Used to build the redirect URI and to decide cookie Secure flag.
+    public_base_url: str
+    # Comma-separated allowlist of emails granted admin via SSO. Defense-in-depth
+    # on top of the Authentik application's group policy binding.
+    admin_emails: str
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"{self.public_base_url.rstrip('/')}/auth/callback"
+
+    @property
+    def server_metadata_url(self) -> str:
+        return f"{self.issuer.rstrip('/')}/.well-known/openid-configuration"
+
+    @property
+    def cookie_secure(self) -> bool:
+        return self.public_base_url.startswith("https://")
+
+    def is_admin(self, email: str) -> bool:
+        allowed = {e.strip().lower() for e in self.admin_emails.split(",") if e.strip()}
+        return email.lower() in allowed
+
+
+def load_oidc_settings() -> OIDCSettings | None:
+    """Load OIDC settings from PROPS_OIDC_* env, or None when SSO is not configured."""
+    if not os.environ.get(ENV_OIDC_ISSUER):
+        return None
+    return OIDCSettings()
+
+
+def build_oauth(settings: OIDCSettings) -> OAuth:
+    """Build an authlib OAuth registry with the Authentik provider registered."""
+    oauth = OAuth()
+    oauth.register(
+        name=AUTHENTIK_CLIENT_NAME,
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
+        server_metadata_url=settings.server_metadata_url,
+        client_kwargs={"scope": "openid email profile"},
+    )
+    return oauth

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -14,6 +14,18 @@ py_library(
 )
 
 py_library(
+    name = "auth_routes",
+    srcs = ["auth_routes.py"],
+    visibility = ["//props/backend:__subpackages__"],
+    deps = [
+        "//props/backend:oidc",
+        "@pypi//authlib",
+        "@pypi//fastapi",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "ground_truth",
     srcs = ["ground_truth.py"],
     visibility = ["//props/backend:__subpackages__"],

--- a/props/backend/routes/auth_routes.py
+++ b/props/backend/routes/auth_routes.py
@@ -1,0 +1,82 @@
+"""OIDC login routes for the props dashboard (`/auth/*`).
+
+Included by `create_app` only when SSO is configured. The authlib OAuth registry
+and the `OIDCSettings` live on `app.state` (set in `create_app`), and the signed
+session cookie is provided by Starlette's `SessionMiddleware`.
+
+Flow: `/auth/login` 302s to Authentik; Authentik redirects back to
+`/auth/callback`, which exchanges the code, checks the email against the admin
+allowlist, and stores `{"email": ...}` in the session. `auth.get_request_identity`
+turns that session into a `SessionIdentity` on subsequent requests.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from authlib.integrations.starlette_client import OAuth, OAuthError
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from props.backend.oidc import AUTHENTIK_CLIENT_NAME, OIDCSettings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class MeResponse(BaseModel):
+    email: str
+
+
+def _oauth(request: Request) -> OAuth:
+    return cast(OAuth, request.app.state.oauth)
+
+
+def _settings(request: Request) -> OIDCSettings:
+    return cast(OIDCSettings, request.app.state.oidc_settings)
+
+
+@router.get("/login")
+async def login(request: Request) -> RedirectResponse:
+    client = _oauth(request).create_client(AUTHENTIK_CLIENT_NAME)
+    return cast(RedirectResponse, await client.authorize_redirect(request, _settings(request).redirect_uri))
+
+
+@router.get("/callback")
+async def callback(request: Request) -> RedirectResponse:
+    settings = _settings(request)
+    client = _oauth(request).create_client(AUTHENTIK_CLIENT_NAME)
+    try:
+        token = await client.authorize_access_token(request)
+    except OAuthError as e:
+        raise HTTPException(status_code=401, detail=f"OIDC error: {e.error}")
+
+    userinfo = token.get("userinfo")
+    if not userinfo or not userinfo.get("email"):
+        raise HTTPException(status_code=401, detail="OIDC token missing email claim")
+
+    email = userinfo["email"]
+    if not settings.is_admin(email):
+        logger.warning(f"Rejected non-admin SSO login: {email=}")
+        raise HTTPException(status_code=403, detail=f"{email} is not authorized for props")
+
+    request.session["user"] = {"email": email}
+    logger.info(f"SSO login: {email=}")
+    return RedirectResponse(url="/", status_code=303)
+
+
+@router.get("/logout")
+async def logout(request: Request) -> RedirectResponse:
+    request.session.pop("user", None)
+    return RedirectResponse(url="/", status_code=303)
+
+
+@router.get("/me")
+async def me(request: Request) -> MeResponse:
+    user = request.session.get("user")
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return MeResponse(email=user["email"])

--- a/props/backend/routes/auth_routes.py
+++ b/props/backend/routes/auth_routes.py
@@ -77,6 +77,9 @@ async def logout(request: Request) -> RedirectResponse:
 @router.get("/me")
 async def me(request: Request) -> MeResponse:
     user = request.session.get("user")
-    if not user:
+    email = user.get("email") if user else None
+    # Re-validate against the live allowlist (sessions are client-side signed cookies).
+    if not email or not _settings(request).is_admin(email):
+        request.session.pop("user", None)
         raise HTTPException(status_code=401, detail="Not authenticated")
-    return MeResponse(email=user["email"])
+    return MeResponse(email=email)

--- a/props/backend/test_auth.py
+++ b/props/backend/test_auth.py
@@ -10,7 +10,17 @@ import pytest
 import pytest_bazel
 from fastapi import HTTPException
 
-from props.backend.auth import AdminRole, AgentRole, AnonymousIdentity, AuthenticatedIdentity, get_caller_db
+from props.backend.auth import (
+    AdminRole,
+    AgentRole,
+    AnonymousIdentity,
+    AuthenticatedIdentity,
+    SessionIdentity,
+    get_caller_db,
+    is_admin_or_evaluator,
+    require_admin_access,
+    require_evaluator_or_admin_access,
+)
 from props.db.config import DatabaseConfig
 from props.db.database import Database
 from props.db.models import AgentType
@@ -24,6 +34,25 @@ def test_get_caller_db_admin_returns_admin_db(exhaust_generator):
     gen = get_caller_db(admin_db=admin_db, auth=auth)
     db = exhaust_generator(gen)
     assert db is admin_db
+
+
+def test_get_caller_db_sso_session_returns_admin_db(exhaust_generator):
+    """SSO browser sessions are admin-only: they use the shared admin pool."""
+    admin_db = MagicMock(spec=Database)
+    auth = SessionIdentity(email="agentydragon@gmail.com")
+
+    gen = get_caller_db(admin_db=admin_db, auth=auth)
+    db = exhaust_generator(gen)
+    assert db is admin_db
+
+
+def test_sso_session_passes_admin_and_evaluator_acls():
+    """A SessionIdentity is treated as admin by the ACL helpers."""
+    auth = SessionIdentity(email="agentydragon@gmail.com")
+    assert is_admin_or_evaluator(auth)
+    # These raise HTTPException on denial; not raising means access is allowed.
+    require_admin_access(auth)
+    require_evaluator_or_admin_access(auth)
 
 
 def test_get_caller_db_anonymous_raises_401():

--- a/props/backend/test_oidc.py
+++ b/props/backend/test_oidc.py
@@ -1,0 +1,77 @@
+"""Unit tests for OIDC settings (no DB / Docker required)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_bazel
+
+from props.backend.oidc import OIDCSettings, load_oidc_settings
+
+_FULL_ENV = {
+    "PROPS_OIDC_ISSUER": "https://auth.allegedly.works/application/o/props/",
+    "PROPS_OIDC_CLIENT_ID": "props",
+    "PROPS_OIDC_CLIENT_SECRET": "shh",
+    "PROPS_OIDC_SESSION_SECRET": "cookie-signing-key",
+    "PROPS_OIDC_PUBLIC_BASE_URL": "https://props.allegedly.works",
+    "PROPS_OIDC_ADMIN_EMAILS": "agentydragon@gmail.com, other@example.com",
+}
+
+
+@pytest.fixture
+def oidc_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in _FULL_ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_load_returns_none_when_issuer_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PROPS_OIDC_ISSUER", raising=False)
+    assert load_oidc_settings() is None
+
+
+def test_load_returns_settings_when_configured(oidc_env: None) -> None:
+    settings = load_oidc_settings()
+    assert settings is not None
+    assert settings.client_id == "props"
+
+
+def test_redirect_uri_and_metadata_url(oidc_env: None) -> None:
+    settings = load_oidc_settings()
+    assert settings is not None
+    assert settings.redirect_uri == "https://props.allegedly.works/auth/callback"
+    assert settings.server_metadata_url == (
+        "https://auth.allegedly.works/application/o/props/.well-known/openid-configuration"
+    )
+
+
+def test_cookie_secure_follows_scheme() -> None:
+    https = OIDCSettings(
+        issuer="x",
+        client_id="x",
+        client_secret="x",
+        session_secret="x",
+        admin_emails="a@b",
+        public_base_url="https://props.allegedly.works",
+    )
+    http = OIDCSettings(
+        issuer="x",
+        client_id="x",
+        client_secret="x",
+        session_secret="x",
+        admin_emails="a@b",
+        public_base_url="http://localhost:8000",
+    )
+    assert https.cookie_secure
+    assert not http.cookie_secure
+
+
+def test_is_admin_matches_allowlist_case_insensitively(oidc_env: None) -> None:
+    settings = load_oidc_settings()
+    assert settings is not None
+    assert settings.is_admin("agentydragon@gmail.com")
+    assert settings.is_admin("AgentyDragon@Gmail.com")
+    assert settings.is_admin("other@example.com")
+    assert not settings.is_admin("intruder@evil.com")
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/docs/SPEC.md
+++ b/props/docs/SPEC.md
@@ -403,6 +403,19 @@ CritiqueDetailPage
 - `GET /api/runs/{run_id}/issues-with-locations` — critique issues with file locations
 - Existing: `GET /api/runs/{run_id}` already has grading_edges
 
+### Authentication
+
+Two parallel auth paths share the backend:
+
+- **Machine clients** (agents, CI `docker login`/crane, evaluator scripts) send
+  base64 Postgres credentials as a Bearer/Basic token. Identity and Row-Level
+  Security derive from the Postgres role (`auth.py`).
+- **Browser users** sign in via Authentik OIDC (`GET /auth/login` →
+  `/auth/callback`), establishing a signed session cookie. A successful SSO login
+  maps to admin access only; evaluator/agent roles stay token-based. Enabled when
+  `PROPS_OIDC_ISSUER` is set — otherwise the dashboard is token-only.
+- `GET /auth/me` — current SSO user (`{email}`) or 401; `GET /auth/logout` — clear session.
+
 ---
 
 ## Non-functional Requirements

--- a/props/frontend/src/App.svelte
+++ b/props/frontend/src/App.svelte
@@ -3,7 +3,7 @@
   import { onMount, setContext } from "svelte";
   import { Toaster } from "svelte-sonner";
   import { pathname, resolve, parseParams } from "$lib/router";
-  import { captureTokenFromUrl, getToken, setToken, needsToken } from "$lib/stores/token";
+  import { captureTokenFromUrl, getToken, setToken, clearToken, needsToken } from "$lib/stores/token";
   import RunTriggerModal from "$components/RunTriggerModal.svelte";
   import type { Split, ExampleKind } from "$lib/types";
 
@@ -27,6 +27,11 @@
   let tokenInput = $state("");
   let usernameInput = $state("");
   let passwordInput = $state("");
+  // While true, we're still determining auth (probing for an SSO session cookie),
+  // so render neither the login screen nor the app to avoid a flash.
+  let checking = $state(true);
+  let userEmail = $state<string | null>(null);
+  let showTokenLogin = $state(false);
   // Disable the other mode when one has input
   const tokenHasInput = $derived(tokenInput.trim().length > 0);
   const credsHasInput = $derived(usernameInput.trim().length > 0 || passwordInput.length > 0);
@@ -61,11 +66,38 @@
     }
   }
 
-  onMount(() => {
+  async function handleLogout() {
+    clearToken();
+    // Clear the server-side SSO session too (no-op/404 when SSO is disabled).
+    await fetch("/auth/logout", { credentials: "include" }).catch(() => undefined);
+    window.location.href = "/";
+  }
+
+  async function initAuth() {
     captureTokenFromUrl();
-    if (!getToken()) {
+    if (getToken()) {
+      needsToken.set(false);
+      return;
+    }
+    // No stored token: check for a valid Authentik SSO session cookie.
+    try {
+      const resp = await fetch("/auth/me", { credentials: "include" });
+      if (resp.ok) {
+        const data = (await resp.json()) as { email: string };
+        userEmail = data.email;
+        needsToken.set(false);
+      } else {
+        needsToken.set(true);
+      }
+    } catch {
       needsToken.set(true);
     }
+  }
+
+  onMount(() => {
+    initAuth().finally(() => {
+      checking = false;
+    });
   });
 
   // Navigation items
@@ -118,53 +150,78 @@
 
 <Toaster richColors position="top-right" duration={8000} />
 
-{#if $needsToken}
+{#if checking}
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+    <div class="text-sm text-gray-500 dark:text-gray-400">Loading…</div>
+  </div>
+{:else if $needsToken}
   <div class="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md dark:shadow-gray-950/50 p-8 max-w-md w-full">
-      <h1 class="text-xl font-bold mb-2">Props</h1>
-      <form
-        onsubmit={(e: SubmitEvent) => {
-          e.preventDefault();
-          handleLogin();
-        }}
-        class="flex flex-col gap-3"
+      <h1 class="text-xl font-bold mb-4">Props</h1>
+      <a
+        href="/auth/login"
+        class="block w-full text-center px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700"
       >
-        <div class="flex flex-col gap-2 transition-opacity {tokenHasInput ? 'opacity-40' : ''}">
-          <input
-            type="text"
-            bind:value={usernameInput}
-            placeholder="Username"
-            autocomplete="username"
-            disabled={tokenHasInput}
-            class="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
-          />
-          <input
-            type="password"
-            bind:value={passwordInput}
-            placeholder="Password"
-            autocomplete="current-password"
-            disabled={tokenHasInput}
-            class="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
-          />
-        </div>
-        <div class="flex items-center gap-2">
+        Sign in with Authentik
+      </a>
+      {#if showTokenLogin}
+        <div class="flex items-center gap-2 my-4">
           <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
-          <span class="text-xs text-gray-400 dark:text-gray-500">or token</span>
+          <span class="text-xs text-gray-400 dark:text-gray-500">or use a token</span>
           <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
         </div>
-        <div class="transition-opacity {credsHasInput ? 'opacity-40' : ''}">
-          <input
-            type="text"
-            bind:value={tokenInput}
-            placeholder="base64 token"
-            disabled={credsHasInput}
-            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
-          />
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700">
-          Sign in
+        <form
+          onsubmit={(e: SubmitEvent) => {
+            e.preventDefault();
+            handleLogin();
+          }}
+          class="flex flex-col gap-3"
+        >
+          <div class="flex flex-col gap-2 transition-opacity {tokenHasInput ? 'opacity-40' : ''}">
+            <input
+              type="text"
+              bind:value={usernameInput}
+              placeholder="Username"
+              autocomplete="username"
+              disabled={tokenHasInput}
+              class="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
+            />
+            <input
+              type="password"
+              bind:value={passwordInput}
+              placeholder="Password"
+              autocomplete="current-password"
+              disabled={tokenHasInput}
+              class="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
+            />
+          </div>
+          <div class="flex items-center gap-2">
+            <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
+            <span class="text-xs text-gray-400 dark:text-gray-500">or token</span>
+            <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
+          </div>
+          <div class="transition-opacity {credsHasInput ? 'opacity-40' : ''}">
+            <input
+              type="text"
+              bind:value={tokenInput}
+              placeholder="base64 token"
+              disabled={credsHasInput}
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
+            />
+          </div>
+          <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700">
+            Sign in
+          </button>
+        </form>
+      {:else}
+        <button
+          type="button"
+          onclick={() => (showTokenLogin = true)}
+          class="mt-3 block w-full text-center text-xs text-gray-500 dark:text-gray-400 hover:underline"
+        >
+          Use a token instead
         </button>
-      </form>
+      {/if}
     </div>
   </div>
 {:else}
@@ -190,6 +247,18 @@
             </a>
           {/each}
         </nav>
+        <div class="flex items-center gap-3">
+          {#if userEmail}
+            <span class="text-xs text-gray-500 dark:text-gray-400">{userEmail}</span>
+          {/if}
+          <button
+            type="button"
+            onclick={handleLogout}
+            class="px-3 py-1.5 rounded text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            Logout
+          </button>
+        </div>
       </div>
     </header>
 

--- a/props/frontend/src/App.svelte
+++ b/props/frontend/src/App.svelte
@@ -32,6 +32,8 @@
   let checking = $state(true);
   let userEmail = $state<string | null>(null);
   let showTokenLogin = $state(false);
+  // False when the backend has no SSO configured (/auth/me 404s) — show the token form directly.
+  let ssoAvailable = $state(true);
   // Disable the other mode when one has input
   const tokenHasInput = $derived(tokenInput.trim().length > 0);
   const credsHasInput = $derived(usernameInput.trim().length > 0 || passwordInput.length > 0);
@@ -87,6 +89,11 @@
         userEmail = data.email;
         needsToken.set(false);
       } else {
+        if (resp.status === 404) {
+          // SSO not configured on the backend: skip the SSO button, show the token form.
+          ssoAvailable = false;
+          showTokenLogin = true;
+        }
         needsToken.set(true);
       }
     } catch {
@@ -158,18 +165,22 @@
   <div class="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md dark:shadow-gray-950/50 p-8 max-w-md w-full">
       <h1 class="text-xl font-bold mb-4">Props</h1>
-      <a
-        href="/auth/login"
-        class="block w-full text-center px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700"
-      >
-        Sign in with Authentik
-      </a>
+      {#if ssoAvailable}
+        <a
+          href="/auth/login"
+          class="block w-full text-center px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium hover:bg-blue-700"
+        >
+          Sign in with Authentik
+        </a>
+      {/if}
       {#if showTokenLogin}
-        <div class="flex items-center gap-2 my-4">
-          <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
-          <span class="text-xs text-gray-400 dark:text-gray-500">or use a token</span>
-          <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
-        </div>
+        {#if ssoAvailable}
+          <div class="flex items-center gap-2 my-4">
+            <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
+            <span class="text-xs text-gray-400 dark:text-gray-500">or use a token</span>
+            <div class="flex-1 border-t border-gray-200 dark:border-gray-700"></div>
+          </div>
+        {/if}
         <form
           onsubmit={(e: SubmitEvent) => {
             e.preventDefault();

--- a/props/frontend/src/lib/api/client.ts
+++ b/props/frontend/src/lib/api/client.ts
@@ -2,10 +2,13 @@ import createClient from "openapi-fetch";
 import type { paths, components } from "./schema";
 import { getToken, onAuthFailed } from "$lib/stores/token";
 
-// Create typed API client (types from Bazel: //props/frontend/src/lib:schema)
-export const api = createClient<paths>({ baseUrl: "" });
+// Create typed API client (types from Bazel: //props/frontend/src/lib:schema).
+// `credentials: "include"` sends the Authentik SSO session cookie (props_session)
+// so browser users authenticated via /auth/login don't need a token.
+export const api = createClient<paths>({ baseUrl: "", credentials: "include" });
 
-// Attach admin token as Bearer header to every request
+// Attach the admin token as a Bearer header when one is stored (token fallback).
+// Without a token, the session cookie above carries authentication.
 api.use({
   async onRequest({ request }) {
     const token = getToken();
@@ -27,6 +30,7 @@ api.use({
 async function authedFetch<T>(url: string): Promise<T> {
   const token = getToken();
   const resp = await fetch(url, {
+    credentials: "include",
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (resp.status === 401) onAuthFailed();

--- a/tf/gitops/sso-providers/provider_props.tf
+++ b/tf/gitops/sso-providers/provider_props.tf
@@ -1,0 +1,76 @@
+# ============================================================================
+# Props — OIDC login for the eval dashboard (props.allegedly.works)
+#
+# The props backend is the OIDC relying party (authlib + session cookie); see
+# props/backend/oidc.py. This provider mints the confidential client; the
+# client_id/secret and a generated session-signing secret are written to a K8s
+# secret in the authentik namespace and reflected into the props namespace,
+# where the Deployment consumes them as PROPS_OIDC_* env vars.
+# ============================================================================
+
+resource "authentik_provider_oauth2" "props" {
+  name               = "props-oauth2"
+  client_id          = "props"
+  client_type        = "confidential"
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict"
+      url           = "https://props.allegedly.works/auth/callback"
+    },
+  ]
+}
+
+resource "authentik_application" "props" {
+  name              = "Props"
+  slug              = "props"
+  protocol_provider = authentik_provider_oauth2.props.id
+  meta_description  = "LLM critic evaluation dashboard"
+  meta_launch_url   = "https://props.allegedly.works"
+}
+
+# Gate login to the admins group (which contains agentydragon). The backend
+# additionally checks the email against PROPS_OIDC_ADMIN_EMAILS (defense in depth).
+resource "authentik_policy_binding" "props_admins" {
+  target = authentik_application.props.uuid
+  group  = data.authentik_group.admins.id
+  order  = 0
+}
+
+# Signs the props session cookie (Starlette SessionMiddleware secret_key).
+# Generated here so it lives with the client credentials and rotates together.
+resource "random_password" "props_session_secret" {
+  length  = 64
+  special = false
+}
+
+resource "kubernetes_secret" "props_oidc" {
+  metadata {
+    name      = "props-oidc-config"
+    namespace = "authentik"
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "props"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "props"
+    }
+  }
+
+  data = {
+    client-id      = authentik_provider_oauth2.props.client_id
+    client-secret  = authentik_provider_oauth2.props.client_secret
+    session-secret = random_password.props_session_secret.result
+  }
+}


### PR DESCRIPTION
Browser users can now sign in to the props dashboard with **Authentik** instead of pasting a Postgres-credential token.

## Design — a parallel auth path, nothing existing changes

This adds an app-level OIDC path that **coexists** with the existing Bearer/Basic token auth:

- **You (browser)** → Authentik authorization-code flow → signed session cookie → resolves to a new `SessionIdentity` that maps to **admin**. Because admin DB work already runs on the server-held admin pool, this needed **zero RLS/DB-layer change**.
- **Agents, CI (`docker login`/crane), evaluator scripts** → keep using their base64 Postgres-credential tokens exactly as before. They never present a cookie, so they take the unchanged path.

Access is gated twice: the Authentik application is bound to the admins group, and the backend re-checks the email against `PROPS_OIDC_ADMIN_EMAILS`.

## What's in the change

**Backend**
- `oidc.py` — `OIDCSettings` (`PROPS_OIDC_*` env) + authlib OAuth registry. SSO is enabled iff `PROPS_OIDC_ISSUER` is set; otherwise the dashboard stays token-only (local dev, tests, docker-compose).
- `routes/auth_routes.py` — `/auth/{login,callback,logout,me}`; signed session cookie via Starlette `SessionMiddleware`.
- `auth.py` — new `SessionIdentity` variant; `get_request_identity` falls back to the session cookie when there's no `Authorization` header; ACL helpers + `get_caller_db` treat an SSO session as admin.
- `app.py` — conditionally installs `SessionMiddleware` + the `/auth` router.

**Frontend**
- "Sign in with Authentik" button; the token/password form is kept behind a "Use a token instead" fallback. API client sends the session cookie (`credentials: include`); header shows the signed-in email + Logout.

**Infra**
- `tf/gitops/sso-providers/provider_props.tf` — confidential OAuth2 client + application bound to the admins group; client id/secret and a generated session-signing secret written to `props-oidc-config` and reflected into the `props` namespace.
- `cluster/k8s/props/app/deployment.yaml` — `PROPS_OIDC_*` env wiring.

## Deploy behavior

On merge to `devel`, Flux's Terraform controller applies the `sso-providers` module → mints the Authentik client and the `props-oidc-config` secret → Reflector copies it into `props` → the deployment (stakater reloader) restarts and picks up the env. No manual `kubectl` needed.

## Testing

`bbr test //props/backend/... //props/frontend:svelte_check_test` — **11/11 pass**; ruff/mypy/eslint/buildifier/tflint/kubeconform/Checkov all clean.

**Caveat:** local `frontend:dev` is cross-origin (`:5173`→`:8000`); exercising SSO there needs the `PROPS_OIDC_*` env set and the cookie is non-Secure over http (derived from the base-URL scheme). Day-to-day dev still uses the token path.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_