### PR TITLE
cluster/agents: mirror z.ai API key into claude-sandbox via ESO

### DIFF
--- a/cluster/k8s/agents/claude-zai-key/external-secret.yaml
+++ b/cluster/k8s/agents/claude-zai-key/external-secret.yaml
@@ -1,0 +1,26 @@
+# Mirrors the z.ai (GLM) API key into the claude-sandbox namespace so the agent
+# can read it via kubectl — e.g. to validate the z.ai API and wire props -> litellm.
+# Sourced from the existing openhands-secrets via the openhands ClusterSecretStore,
+# so there is no second plaintext/sops copy of the key to keep in sync.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zai-api-key
+  namespace: claude-sandbox
+  annotations:
+    description: >-
+      z.ai (GLM) API key mirrored into claude-sandbox for the agent, sourced from
+      openhands-secrets via kubernetes-openhands-secret-store.
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes-openhands-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: zai-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: ZAI_API_KEY
+      remoteRef:
+        key: openhands-secrets
+        property: ZAI_API_KEY

--- a/cluster/k8s/agents/claude-zai-key/flux-kustomization.yaml
+++ b/cluster/k8s/agents/claude-zai-key/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: claude-zai-key
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/claude-zai-key
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 5m
+  dependsOn:
+    - name: claude-rbac
+    - name: external-secrets-config

--- a/cluster/k8s/agents/claude-zai-key/kustomization.yaml
+++ b/cluster/k8s/agents/claude-zai-key/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -66,6 +66,7 @@ resources:
   - agents/claude-jwt-rotation/flux-kustomization.yaml
   - agents/attic-jwt-rotation/flux-kustomization.yaml
   - agents/claude-sandbox-firecracker/flux-kustomization.yaml
+  - agents/claude-zai-key/flux-kustomization.yaml
   - agents/airlock/flux-kustomization.yaml
   - agents/airlock-oidc-proxy-tf/flux-kustomization.yaml
   - agents/google-workspace-mcp/flux-kustomization.yaml


### PR DESCRIPTION
Gives the agent (claude-sandbox identity) read access to the z.ai (GLM) API key, so it can validate the z.ai API before wiring `props -> litellm -> z.ai`.

## Why this is needed

This session has **no path to the z.ai key**:
- **kube**: the sandbox identity (`kubectl-sandbox-users`) has `can-i get secrets` = **no** in `kagent`/`openhands`/`litellm`, and there's no secret-reader ClusterRole in `claude-rbac`.
- **sops**: the sandbox's age key (`age15gxx…`) is **not a recipient** of the cluster secrets (they're encrypted to `age1u858…` + `age1nywl…`), so `sops -d` fails.

But the sandbox identity *does* have full secret CRUD in `claude-sandbox`. So mirroring the key there unblocks `kubectl` read.

## Why ESO (not editing the sops file)

Adding Reflector annotations directly to an existing z.ai sops secret was considered and **tested** — under this repo's default SOPS config (no `mac_only_encrypted`), adding a metadata annotation breaks decryption (`MAC mismatch`, exit 51), so Flux would fail to decrypt. Re-encrypting with `mac_only_encrypted` needs the plaintext, which the sandbox can't decrypt. So an `ExternalSecret` is the only no-plaintext path — it reads the *live* (already-decrypted) source Secret, sidestepping the sops file/MAC entirely.

## What it does

A dedicated, layered Flux kustomization `claude-zai-key` (dependsOn `claude-rbac` + `external-secrets-config`) with one `ExternalSecret` in `claude-sandbox` that materializes `ZAI_API_KEY`, sourced from the existing `openhands-secrets` via `kubernetes-openhands-secret-store`. No second plaintext/sops copy of the key.

Source choice: `openhands-secrets` is the verified-live source — its `ExternalSecret` (`openhands/openhands-settings-json`) is currently `SecretSynced / Ready=True`, whereas `kagent-secrets` is not-ready. Trade-off: this couples the agent's z.ai key to `openhands-secrets`. If you'd prefer a cleaner durable home, the alternative is an agent-owned sops secret in `cluster/k8s/agents/shared-secrets/` — but that needs you to drop the plaintext (the sandbox can't author it).

## After merge

Once Flux reconciles, `kubectl -n claude-sandbox get secret zai-api-key` will hold the key, and I can poke `api.z.ai` to validate the chat/completions shapes, then wire `props -> litellm -> z.ai`.

Validated: `kubectl kustomize` renders cleanly; pre-commit `kubeconform` + kustomization-layering validator pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_