### PR TITLE
props+litellm: add z.ai GLM-4.6 model via LiteLLM

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -50,6 +50,12 @@ spec:
                 secretKeyRef:
                   name: litellm-master-key
                   key: api-key
+            # z.ai (GLM) key for the z.ai upstream models in proxy-config.yaml.
+            - name: ZAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-zai-key
+                  key: ZAI_API_KEY
           # TODO: Re-enable langfuse-api-keys envFrom when Langfuse is unsuspended
           # (suspended 2026-03-31, see cluster/docs/plan.md).
           livenessProbe:

--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -38,6 +38,26 @@ _MODELS: list[tuple[str, list[tuple[str, int | None]]]] = [
     ("gemma4:31b-it-q8_0", [("128k", None)]),
 ]
 
+# z.ai (GLM) models served via the Coding Plan endpoint. The key comes from the
+# ZAI_API_KEY env var (litellm-zai-key secret). These speak OpenAI chat/completions;
+# LiteLLM bridges its /responses endpoint to chat so props' OpenAI-Responses proxy
+# (props/backend/routes/llm.py) can route to them.
+_ZAI_CODING_BASE = "https://api.z.ai/api/coding/paas/v4"
+_ZAI_MODELS: list[str] = ["glm-4.6"]
+
+
+def _zai_entries() -> Iterator[dict]:
+    for model in _ZAI_MODELS:
+        yield {
+            "model_name": model,
+            "litellm_params": {
+                "model": f"openai/{model}",
+                "api_base": _ZAI_CODING_BASE,
+                "api_key": "os.environ/ZAI_API_KEY",
+            },
+            "model_info": {"mode": "chat", "supports_function_calling": True},
+        }
+
 
 def _model_entries(tag: str, ctx_variants: list[tuple[str, int | None]]) -> Iterator[dict]:
     name_base = tag.replace(":", "-")
@@ -66,6 +86,7 @@ def generate() -> str:
     model_list: list[dict] = []
     for tag, ctx_variants in _MODELS:
         model_list.extend(_model_entries(tag, ctx_variants))
+    model_list.extend(_zai_entries())
 
     # Master key is injected as LITELLM_MASTER_KEY env var in the Deployment;
     # not repeated here.

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -108,5 +108,13 @@ model_list:
     model_info:
       mode: chat
       supports_function_calling: true
+  - model_name: glm-4.6
+    litellm_params:
+      model: openai/glm-4.6
+      api_base: https://api.z.ai/api/coding/paas/v4
+      api_key: os.environ/ZAI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
 litellm_settings:
   drop_params: true

--- a/cluster/k8s/litellm/secrets/kustomization.yaml
+++ b/cluster/k8s/litellm/secrets/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - zai-api-key-eso.yaml

--- a/cluster/k8s/litellm/secrets/zai-api-key-eso.yaml
+++ b/cluster/k8s/litellm/secrets/zai-api-key-eso.yaml
@@ -1,0 +1,22 @@
+# z.ai (GLM) API key for LiteLLM's z.ai upstream models, mirrored from the
+# existing openhands-secrets via the openhands ClusterSecretStore — so there is
+# no second plaintext/sops copy of the key. Consumed as the ZAI_API_KEY env var
+# in the litellm Deployment (referenced by proxy-config.yaml's z.ai models).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-zai-key
+  namespace: litellm
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes-openhands-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: litellm-zai-key
+    creationPolicy: Owner
+  data:
+    - secretKey: ZAI_API_KEY
+      remoteRef:
+        key: openhands-secrets
+        property: ZAI_API_KEY

--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -16,6 +16,13 @@ PGDATABASE = "eval_results"
 url = "http://ollama.ollama.svc.cluster.local:11434/v1"
 api_key_env = "OLLAMA_API_KEY"
 
+# In-cluster LiteLLM. props speaks the OpenAI Responses API ({url}/responses);
+# LiteLLM bridges that to the upstream's chat/completions (e.g. z.ai's GLM,
+# which has no native Responses API). Auth = LiteLLM master key.
+[upstreams.litellm]
+url = "http://litellm.litellm.svc.cluster.local:4000/v1"
+api_key_env = "LITELLM_API_KEY"
+
 [[models]]
 name = "gpt-oss-20b-128k"
 upstream = "ollama"
@@ -26,3 +33,15 @@ output_usd_per_1m_tokens = 0
 context_window_tokens = 131072
 max_output_tokens = 131072
 max_parallel_agents = 3
+
+# z.ai GLM-4.6 via LiteLLM (api.z.ai coding plan). Pricing = z.ai list rates.
+[[models]]
+name = "glm-4.6"
+upstream = "litellm"
+upstream_model = "glm-4.6"
+input_usd_per_1m_tokens = 0.39
+cached_input_usd_per_1m_tokens = 0.39
+output_usd_per_1m_tokens = 1.74
+context_window_tokens = 200000
+max_output_tokens = 131072
+max_parallel_agents = 2

--- a/cluster/k8s/props/app/deployment.yaml
+++ b/cluster/k8s/props/app/deployment.yaml
@@ -58,6 +58,12 @@ spec:
                 secretKeyRef:
                   name: litellm-master-key
                   key: api-key
+            # Auth for the in-cluster LiteLLM upstream (config.toml [upstreams.litellm]).
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-master-key
+                  key: api-key
             - name: PROPS_EVALUATOR_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Lets props run **z.ai's GLM-4.6**.

## Architecture (why the LiteLLM hop)

props' LLM proxy (`props/backend/routes/llm.py`) only speaks the OpenAI **Responses API** (`{upstream}/responses`, parses Responses-shaped `usage`). z.ai exposes only **chat/completions** + Anthropic (confirmed: `/v1/responses` 404s). So the in-cluster **LiteLLM** bridges:

```
props  ──/v1/responses──▶  LiteLLM  ──chat/completions──▶  api.z.ai (GLM-4.6)
```

## Changes

**LiteLLM**
- `generate_litellm.py`: add `glm-4.6` (`openai/` provider → `https://api.z.ai/api/coding/paas/v4`, key from `ZAI_API_KEY`); `proxy-config.yaml` regenerated (parity test passes).
- `secrets/zai-api-key-eso.yaml`: `ExternalSecret` mirroring `ZAI_API_KEY` from `openhands-secrets` via `kubernetes-openhands-secret-store` — no new sops copy.
- `deployment`: `ZAI_API_KEY` env from the `litellm-zai-key` secret.

**props**
- `config.toml`: `[upstreams.litellm]` (`litellm.litellm:4000/v1`, auth `LITELLM_API_KEY`) + a `glm-4.6` `[[models]]` entry — z.ai list pricing **$0.39 / $1.74** per 1M, 200k ctx, `max_parallel_agents = 2`.
- `deployment`: `LITELLM_API_KEY` env (= the LiteLLM master key).

## Validated

Poked z.ai directly with the real key (now reachable via the merged claude-sandbox ESO):
- Models live (coding plan): `glm-4.5/-air`, **`glm-4.6`**, `glm-4.7`, `glm-5/-turbo`, `glm-5.1`.
- chat/completions returns the standard OpenAI shape; **tool calling works** (`finish_reason: tool_calls`, proper `tool_calls[].function.{name,arguments}`) — needed by the critic/grader agents.
- Note: GLM-4.6 is a **heavy reasoner** (171 reasoning tokens to say "pong") → real eval cost/latency.

## To verify post-deploy (the bits only the running stack can exercise)

1. **LiteLLM Responses→chat bridge**: a `glm-4.6` critic smoke test through props, confirming LiteLLM maps z.ai's `prompt_tokens`/`completion_tokens` → `input_tokens`/`output_tokens` (else props' `_log_request` would throw).
2. **props→litellm reachability**: cross-namespace `props`→`litellm:4000` (no CiliumNetworkPolicy blocks it — props already reaches `ollama` cross-ns, so likely fine).
3. **Pricing**: `$0.39/$1.74` are z.ai list rates; the Coding Plan is a flat subscription, so adjust if you want budget math to reflect that.

Caveat: the key is sourced from `openhands-secrets` (the verified-live z.ai source). If you'd prefer a canonical agent-owned key, that's a follow-up.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_