### PR TITLE
augur/sim: profile rollouts + cut encode/compile-boundary overhead

### DIFF
--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -28,23 +28,23 @@ OOM-kills the process beyond ~500–1000 rollouts at a 100-year horizon on a
 15 GB box.
 
 So the user's hypothesis ("we're doing a lot serially instead of in parallel")
-is only half right: the *temporal* axis is serial (correct, and inherent), but
-the *rollout* axis is already SIMD-vectorized in NumPy — it is not the
+is only half right: the _temporal_ axis is serial (correct, and inherent), but
+the _rollout_ axis is already SIMD-vectorized in NumPy — it is not the
 bottleneck. The bottleneck is encode/decode and compile-time ingestion.
 
 ## Measured breakdown
 
 500 rollouts × 1200 months, 26.9 s wall (cProfile, single core):
 
-| Stage                                     | Time    | %    |
-| ----------------------------------------- | ------- | ---- |
-| `decode_run` (dense arrays → Polars)      | 15.6 s  | 58%  |
-| ↳ `decode_tax_liabilities`                | 11.4 s  | 42%  |
-| ↳ other decoders (state history, events)  | ~4.2 s  | 16%  |
-| `external_values_cube` (compile)          | 4.3 s   | 16%  |
-| `_validate_series_indexed_amounts`        | 4.1 s   | 15%  |
-| dense month loop (`_run_month_step`×1200) | 1.9 s   | 7%   |
-| buffer alloc + snapshot + misc            | ~1.0 s  | 4%   |
+| Stage                                     | Time   | %   |
+| ----------------------------------------- | ------ | --- |
+| `decode_run` (dense arrays → Polars)      | 15.6 s | 58% |
+| ↳ `decode_tax_liabilities`                | 11.4 s | 42% |
+| ↳ other decoders (state history, events)  | ~4.2 s | 16% |
+| `external_values_cube` (compile)          | 4.3 s  | 16% |
+| `_validate_series_indexed_amounts`        | 4.1 s  | 15% |
+| dense month loop (`_run_month_step`×1200) | 1.9 s  | 7%  |
+| buffer alloc + snapshot + misc            | ~1.0 s | 4%  |
 
 Top `tottime` offenders: `{built-in method new_str}` 6.66 s (string-column
 materialization), `decode_tax_liabilities` 5.03 s, `DataFrame.iter_rows` 3.84 s
@@ -58,7 +58,7 @@ Wall clock at 500 rollouts, varying horizon: 240 mo → 2.7 s, 600 mo → 8.8 s,
 `(snapshots × liability_slots × R)` and `liability_slots` grows with the number
 of tax years (`compile_tax_liability_slots`: one slot per link per year-end).
 At 1200 mo that grid is `1201 × 200 × 500 = 120 M` elements, and
-`decode_tax_liabilities` builds three int64 index arrays over the *full* grid
+`decode_tax_liabilities` builds three int64 index arrays over the _full_ grid
 (`state_axes`) before masking → ~4 GB transient for one decoder, ×R OOM beyond
 ~1000 rollouts.
 
@@ -68,7 +68,7 @@ At 1200 mo that grid is `1201 × 200 × 500 = 120 M` elements, and
    `state_axes(snapshots, R, slots)` over the full grid, then masks. Instead get
    the active triples first (`np.argwhere(active)` / `np.nonzero`) and gather
    only those — the pattern `decode_tax_accruals`/`decode_capital_gains` already
-   use. Kills ~11 s *and* the OOM. Apply to every full-grid
+   use. Kills ~11 s _and_ the OOM. Apply to every full-grid
    `state_history_frame_from_columns` decoder (tax_liabilities, property_state,
    liabilities). Biggest single win.
 
@@ -98,18 +98,17 @@ At 1200 mo that grid is `1201 × 200 × 500 = 120 M` elements, and
 
 6. **Decimate state snapshots.** `_snapshot_current_state` copies ~25 arrays
    every month (0.83 s + all the memory decode then walks). If consumers only
-   need year-end / terminal values, snapshot at those indices instead of all
-   1201. Cuts both snapshot cost and downstream decode volume.
+   need year-end / terminal values, snapshot at those indices instead of all 1201. Cuts both snapshot cost and downstream decode volume.
 
 7. **Drop `~current.failed` boolean-mask fancy-indexing in the hot phases.**
    `current.cash[slot, active_rollout] -= amount[active_rollout]` does a
-   gather+scatter copy *every* slot *every* month even when no rollout has failed
+   gather+scatter copy _every_ slot _every_ month even when no rollout has failed
    (the common case). Fast-path `if not current.failed.any():` to operate on the
    full contiguous slice; only fall back to masked writes once failures exist.
 
 8. **Hoist month-invariant per-slot Python loops.** Transfers/obligations do
    `for slot in range(...)` per month re-reading `plan.transfers.cause[month,
-   slot]`. For recurring transfers the active-slot set is largely static —
+slot]`. For recurring transfers the active-slot set is largely static —
    precompute per-month active slots at compile time, or fold the whole transfer
    step into a segment-sum/matmul into `cash` keyed by from/to slot. Turns
    O(months × slots) Python into O(months) NumPy.
@@ -181,5 +180,5 @@ and are deliberately left as follow-ups to the boundary fixes above.
 Rollouts are independent, so beyond the above the R axis can be **chunked**
 (e.g. batches of 2000) and run per-chunk — trivially parallel across
 processes/cores/nodes, and it bounds peak memory. But chunking is only worth it
-*after* interventions 1–6: today the eager full-grid decode, not the rollout
+_after_ interventions 1–6: today the eager full-grid decode, not the rollout
 math, is what caps you at ~500 rollouts × 1200 months in 15 GB.

--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -126,6 +126,56 @@ At 1200 mo that grid is `1201 × 200 × 500 = 120 M` elements, and
     bandwidth where precision allows. Also reuse scratch in `_amount_values`/FIFO
     (each `np.full(rollout_count, …)` allocates per call) to cut allocator churn.
 
+## Results after the first optimization pass
+
+Three boundary fixes landed (rollout math untouched — it was never the problem):
+
+1. **Sparse-active `decode_tax_liabilities`** — gather active `(month, rollout, slot)`
+   triples via `np.nonzero` instead of building three full-grid int64 index arrays
+   (`state_axes`) and masking. Removes the ~2.9 GB transient index allocation.
+2. **Vectorized `external_values_cube`** — columnar `series_id → index` map + a single
+   fancy-index scatter, replacing a Python `iter_rows()` loop over every
+   `(rollout, month, series)` row.
+3. **Short-circuited `_validate_series_indexed_amounts`** — returns immediately when no
+   `SeriesIndexedAmount` is in use (the common case), and filters to referenced series
+   otherwise, instead of unconditionally building a millions-of-entries dict from
+   `iter_rows()`.
+
+500 rollouts × 1200 months: **26.9 s → 18.1 s** (function calls 5.9 M → 484 K). The two
+compile-time `iter_rows` hotspots are gone; `decode_tax_liabilities` is now dominated by
+Polars `new_str` building the `agent_id`/`jurisdiction_id` string columns over the
+(still large) active-row set.
+
+### Where the memory actually goes (the 1000–10000 rollout wall)
+
+A `--dense-only` profiler mode (compile + month loop, **no** Polars decode) isolates pure
+rollout compute from the encode boundary:
+
+| rollouts | dense-only (compute) | full `simulate()` (with decode) |
+| -------- | -------------------- | ------------------------------- |
+| 1000     | 2.8 GB / 3.2 s ✅    | OOM (decode frames)             |
+| 4000     | 11 GB / 11 s ✅      | OOM                             |
+| 10000    | OOM ❌               | OOM                             |
+
+So the rollout compute itself is cheap and parallel — 1000 rollouts in 3.2 s / 2.8 GB.
+The remaining walls are two O(horizon² × R) eager allocations, **not** the per-cell state:
+
+- **Dense `tax_liability_state` buffer** `(snapshots, years×links, R)`. At 1000 rollouts
+  that's `1201 × 200 × 1000 × 8 B = 1.9 GB`; at 10000 the dense-only run dies allocating
+  exactly `17.9 GiB for an array with shape (1201, 200, 10000)`. Every snapshot stores
+  all 200 per-year liability slots even though each liability only exists ~12 months —
+  quadratic in horizon. This is intervention #2 and is the next lever: store tax
+  liabilities as events (set at year-end, cleared at settlement), not a dense
+  per-snapshot grid. (`tax_liability_active_state` + the decoded long frame have the same
+  shape problem.)
+- **Eager full decode** of every state-history frame (intervention #5). `simulate()`
+  materializes ~15 Polars long frames up front; for large fan-out this is tens of GB.
+  Making decode lazy/opt-in (the `DenseSimulationResult` already exists) lets summary
+  callers reduce on the dense arrays and never build the long frames.
+
+Both are deeper changes (they touch the `SimulationRun` contract / state-history storage)
+and are deliberately left as follow-ups to the boundary fixes above.
+
 ## Note on parallelism
 
 Rollouts are independent, so beyond the above the R axis can be **chunked**

--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -1,0 +1,135 @@
+# Rollout performance profiling (100-year horizon, large fan-out)
+
+Investigation of where time and memory go when running augur sim rollouts at a
+"production-ish" scale: a mortgage + nontrivial knob config, 100-year horizon
+(1200 months), and 500–10000 parallel rollouts.
+
+Tooling added for this: `//augur/sim:profile_rollout`
+(<augur/sim/profile_rollout.py>) — builds the spike-1 bench scenario plus a
+financed primary-residence purchase (mortgage origination + monthly
+amortization, property tax, mortgage-interest deduction) and runs `simulate(...)`
+under `cProfile`.
+
+```bash
+bazelisk run //augur/sim:profile_rollout --config=nolint -- \
+  --rollouts 500 --horizon-months 1200 --sort tottime
+```
+
+(Built with `bazelisk` + system Java 21 and the BuildBuddy remote cache.)
+
+## Headline finding
+
+**The rollout math is already vectorized and parallel across the rollout (R)
+axis. The serial month loop is cheap (~7% of wall time). The cost is at the
+boundaries: decoding dense arrays into long-form Polars frames, and ingesting /
+validating the external-series long frame via Python row iteration.** There is
+also an O(horizon² × R) memory blow-up in tax-liability state history that
+OOM-kills the process beyond ~500–1000 rollouts at a 100-year horizon on a
+15 GB box.
+
+So the user's hypothesis ("we're doing a lot serially instead of in parallel")
+is only half right: the *temporal* axis is serial (correct, and inherent), but
+the *rollout* axis is already SIMD-vectorized in NumPy — it is not the
+bottleneck. The bottleneck is encode/decode and compile-time ingestion.
+
+## Measured breakdown
+
+500 rollouts × 1200 months, 26.9 s wall (cProfile, single core):
+
+| Stage                                     | Time    | %    |
+| ----------------------------------------- | ------- | ---- |
+| `decode_run` (dense arrays → Polars)      | 15.6 s  | 58%  |
+| ↳ `decode_tax_liabilities`                | 11.4 s  | 42%  |
+| ↳ other decoders (state history, events)  | ~4.2 s  | 16%  |
+| `external_values_cube` (compile)          | 4.3 s   | 16%  |
+| `_validate_series_indexed_amounts`        | 4.1 s   | 15%  |
+| dense month loop (`_run_month_step`×1200) | 1.9 s   | 7%   |
+| buffer alloc + snapshot + misc            | ~1.0 s  | 4%   |
+
+Top `tottime` offenders: `{built-in method new_str}` 6.66 s (string-column
+materialization), `decode_tax_liabilities` 5.03 s, `DataFrame.iter_rows` 3.84 s
+(3.6 M calls — from `external_values_cube` + `_validate_series_indexed_amounts`,
+each walking the full 1.8 M-row external-series long frame once).
+
+### Scaling
+
+Wall clock at 500 rollouts, varying horizon: 240 mo → 2.7 s, 600 mo → 8.8 s,
+1200 mo → 23.6 s. Super-linear, because tax-liability state history is
+`(snapshots × liability_slots × R)` and `liability_slots` grows with the number
+of tax years (`compile_tax_liability_slots`: one slot per link per year-end).
+At 1200 mo that grid is `1201 × 200 × 500 = 120 M` elements, and
+`decode_tax_liabilities` builds three int64 index arrays over the *full* grid
+(`state_axes`) before masking → ~4 GB transient for one decoder, ×R OOM beyond
+~1000 rollouts.
+
+## Top 10 interventions (highest impact first)
+
+1. **Sparse-active decode for `decode_tax_liabilities` (and peers).** It calls
+   `state_axes(snapshots, R, slots)` over the full grid, then masks. Instead get
+   the active triples first (`np.argwhere(active)` / `np.nonzero`) and gather
+   only those — the pattern `decode_tax_accruals`/`decode_capital_gains` already
+   use. Kills ~11 s *and* the OOM. Apply to every full-grid
+   `state_history_frame_from_columns` decoder (tax_liabilities, property_state,
+   liabilities). Biggest single win.
+
+2. **Stop storing tax liabilities (and rarely-read state) as a dense
+   per-snapshot grid.** Liability slots accumulate as `years × links` and
+   persist in every future snapshot → O(horizon² × R). Model them as events
+   (set at year-end, cleared at settlement) or snapshot only the columns a
+   consumer reads. Removes the quadratic-in-horizon memory term.
+
+3. **Vectorize `external_values_cube` (4.3 s).** Replace
+   `for row in series_values.iter_rows()` with columnar extraction:
+   pull `series_id`/`rollout_index`/`month_index`/`value` as NumPy arrays, map
+   `series_id → index` once (Polars `replace`/categorical), then a single
+   fancy-index scatter `values[idx, rollout, month] = value`. ~50–100× faster.
+
+4. **Short-circuit `_validate_series_indexed_amounts` (4.1 s, ~100% wasted
+   here).** It unconditionally builds a 1.8 M-entry Python dict from
+   `iter_rows()` before checking whether any `SeriesIndexedAmount` exists. Return
+   early when `_series_indexed_amount_uses` yields none; when they do exist, do
+   the membership/zero checks with a Polars filter/join, not a per-row dict.
+
+5. **Make decode lazy / opt-in.** `simulate()` eagerly decodes ~15 Polars
+   frames; most callers (benches, parameter sweeps, summary stats) need a
+   handful. Return `DenseSimulationResult` and decode per-frame on demand
+   (`simulate_dense_with_external_series` already exposes this). For Monte-Carlo
+   summaries, reduce on the dense arrays and never build long frames at all.
+
+6. **Decimate state snapshots.** `_snapshot_current_state` copies ~25 arrays
+   every month (0.83 s + all the memory decode then walks). If consumers only
+   need year-end / terminal values, snapshot at those indices instead of all
+   1201. Cuts both snapshot cost and downstream decode volume.
+
+7. **Drop `~current.failed` boolean-mask fancy-indexing in the hot phases.**
+   `current.cash[slot, active_rollout] -= amount[active_rollout]` does a
+   gather+scatter copy *every* slot *every* month even when no rollout has failed
+   (the common case). Fast-path `if not current.failed.any():` to operate on the
+   full contiguous slice; only fall back to masked writes once failures exist.
+
+8. **Hoist month-invariant per-slot Python loops.** Transfers/obligations do
+   `for slot in range(...)` per month re-reading `plan.transfers.cause[month,
+   slot]`. For recurring transfers the active-slot set is largely static —
+   precompute per-month active slots at compile time, or fold the whole transfer
+   step into a segment-sum/matmul into `cash` keyed by from/to slot. Turns
+   O(months × slots) Python into O(months) NumPy.
+
+9. **Keep ID columns integer/categorical, not Python `object` strings.** The
+   6.7 s `new_str` is per-row Python string objects for `agent_id` /
+   `jurisdiction_id` across tens of millions of rows. Emit dictionary-encoded
+   `pl.Categorical`/`Enum` (or int codes joined to a tiny code→string table at
+   the very end) so Polars never allocates per-row `str`.
+
+10. **float32 state + scratch reuse for large fan-out.** State buffers and the
+    external cube are float64; for 100-year × 10k-rollout Monte Carlo the engine
+    is memory-bandwidth-bound on the R axis, so float32 ~halves memory and
+    bandwidth where precision allows. Also reuse scratch in `_amount_values`/FIFO
+    (each `np.full(rollout_count, …)` allocates per call) to cut allocator churn.
+
+## Note on parallelism
+
+Rollouts are independent, so beyond the above the R axis can be **chunked**
+(e.g. batches of 2000) and run per-chunk — trivially parallel across
+processes/cores/nodes, and it bounds peak memory. But chunking is only worth it
+*after* interventions 1–6: today the eager full-grid decode, not the rollout
+math, is what caps you at ~500 rollouts × 1200 months in 15 GB.

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -173,6 +173,7 @@ py_library(
         ":engine",
         ":external_series",
         ":scenario",
+        "@pypi//polars",
     ],
 )
 
@@ -384,6 +385,7 @@ py_binary(
     main_module = "augur.sim.profile_rollout",
     deps = [
         ":bench_scenario",
+        ":external_series",
         ":locations",
         ":scenario",
         ":simulate",

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -378,6 +378,18 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "profile_rollout",
+    srcs = ["profile_rollout.py"],
+    main_module = "augur.sim.profile_rollout",
+    deps = [
+        ":bench_scenario",
+        ":locations",
+        ":scenario",
+        ":simulate",
+    ],
+)
+
 py_test(
     name = "bench_test",
     size = "medium",

--- a/augur/sim/codec/helpers.py
+++ b/augur/sim/codec/helpers.py
@@ -74,6 +74,21 @@ def state_axes(h1: int, r: int, s: int) -> tuple[np.ndarray, np.ndarray, np.ndar
     return months, rollouts, slots
 
 
+def active_state_axes(active: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """`(month, rollout, slot)` index arrays for the True positions of a `(h1, r, s)` active
+    grid, in row-major order.
+
+    The sparse counterpart to `state_axes` + a boolean mask: decoders whose state is mostly
+    inactive (tax liabilities, properties, debts — slots that only switch on partway through
+    the horizon) should gather active positions directly via `np.nonzero` instead of
+    materializing three full-grid index arrays and then masking. For a 100-year horizon the
+    full grid is `snapshots × slots × R` (≫100 M cells); this avoids building it.
+    """
+
+    months, rollouts, slots = np.nonzero(active)
+    return months, rollouts, slots
+
+
 def state_history_frame_from_columns(columns: dict[str, np.ndarray], spec: Any) -> pl.DataFrame:
     """Build a state-history frame from pre-built numpy column arrays. State-history specs
     don't carry `month_index` in their schema (the cross-section is one month wide); decode

--- a/augur/sim/codec/tax.py
+++ b/augur/sim/codec/tax.py
@@ -10,6 +10,7 @@ import polars as pl
 
 from augur.sim.buffers import SimulationBuffers
 from augur.sim.codec.helpers import (
+    active_state_axes,
     codes_to_strings,
     frame_from_columns,
     r_first_view,
@@ -71,21 +72,19 @@ def decode_capital_gains(plan: CompiledSimulation, buffers: SimulationBuffers) -
 def decode_tax_liabilities(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.DataFrame:
     state = r_first_view(buffers.state.tax_liability_state)  # (H+1, r, s)
     active = r_first_view(buffers.state.tax_liability_active_state)
-    h1, r, s = state.shape
-    months, rollouts, slots = state_axes(h1, r, s)
-    mask = active.reshape(-1)
+    months, rollouts, slots = active_state_axes(active)
     profile_per_slot = plan.tax_liabilities.profile_index.astype(np.int64)
     link_per_slot = plan.tax_liabilities.link_index.astype(np.int64)
     agent_per_profile = codes_to_strings(plan, plan.tax.profile_agent)
     juris_per_link = codes_to_strings(plan, plan.tax.link_jurisdiction)
     return state_history_frame_from_columns(
         {
-            "rollout_index": rollouts[mask],
-            "month_index": months[mask],
-            "agent_id": agent_per_profile[profile_per_slot[slots[mask]]],
-            "jurisdiction_id": juris_per_link[link_per_slot[slots[mask]]],
-            "tax_year_end_month": plan.tax_liabilities.year_end_month.astype(np.int64)[slots[mask]],
-            "amount_owed_usd": state.reshape(-1)[mask],
+            "rollout_index": rollouts,
+            "month_index": months,
+            "agent_id": agent_per_profile[profile_per_slot[slots]],
+            "jurisdiction_id": juris_per_link[link_per_slot[slots]],
+            "tax_year_end_month": plan.tax_liabilities.year_end_month.astype(np.int64)[slots],
+            "amount_owed_usd": state[months, rollouts, slots],
         },
         TAX_LIABILITIES_FRAME,
     )

--- a/augur/sim/compiler/series.py
+++ b/augur/sim/compiler/series.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import polars as pl
 
 from augur.model.series import LevelSeriesKey, try_parse_level_series_key
 from augur.product.asset_key import asset_price_key, asset_price_key_or_none
@@ -72,17 +73,26 @@ def external_values_cube(
     horizon_months: int,
 ) -> np.ndarray:
     values = np.full((len(series_index_by_id), rollout_count, horizon_months + 1), np.nan, dtype=np.float64)
-    if external_series.series_values.is_empty():
+    frame = external_series.series_values
+    if frame.is_empty():
         return values
     # The external frame is still keyed by series_id wire strings; bridge to the typed index
-    # once via wire_id (removed when the frame itself goes typed).
+    # once via wire_id (removed when the frame itself goes typed). Vectorized scatter: map
+    # series_id → compiled index columnwise, then a single fancy-index assignment, instead of
+    # a Python loop over every (rollout, month, series) row (millions at a 100-year horizon).
     index_by_wire_id = {key.wire_id: index for key, index in series_index_by_id.items()}
-    for row in external_series.series_values.iter_rows(named=True):
-        series_index = index_by_wire_id.get(str(row["series_id"]))
-        if series_index is None:
-            continue
-        rollout_index = int(row["rollout_index"])
-        month_index = int(row["month_index"])
-        if 0 <= rollout_index < rollout_count and 0 <= month_index <= horizon_months:
-            values[series_index, rollout_index, month_index] = float(row["value"])
+    series_index = (
+        frame.get_column("series_id").replace_strict(index_by_wire_id, default=-1, return_dtype=pl.Int64).to_numpy()
+    )
+    rollout_index = frame.get_column("rollout_index").to_numpy()
+    month_index = frame.get_column("month_index").to_numpy()
+    value = frame.get_column("value").to_numpy()
+    keep = (
+        (series_index >= 0)
+        & (rollout_index >= 0)
+        & (rollout_index < rollout_count)
+        & (month_index >= 0)
+        & (month_index <= horizon_months)
+    )
+    values[series_index[keep], rollout_index[keep], month_index[keep]] = value[keep]
     return values

--- a/augur/sim/profile_rollout.py
+++ b/augur/sim/profile_rollout.py
@@ -24,6 +24,7 @@ import pstats
 import time
 
 from augur.sim.bench_scenario import build_bench_scenario
+from augur.sim.external_series import materialize_external_series
 from augur.sim.locations import Location
 from augur.sim.scenario import (
     Agent,
@@ -35,7 +36,7 @@ from augur.sim.scenario import (
     Scenario,
     ScheduledPropertyPurchase,
 )
-from augur.sim.simulate import simulate
+from augur.sim.simulate import simulate, simulate_dense_with_external_series
 
 PROFILE_LOCATION_ID = "sf"
 
@@ -107,25 +108,44 @@ def main() -> None:
     parser.add_argument("--sort", choices=["cumulative", "tottime"], default="cumulative")
     parser.add_argument("--top", type=int, default=35)
     parser.add_argument("--no-profile", action="store_true", help="wall-clock only, no cProfile overhead")
+    parser.add_argument(
+        "--dense-only",
+        action="store_true",
+        help="run the dense engine (compile + month loop) and skip the Polars decode, to isolate "
+        "pure rollout-compute cost/memory from the encode boundary",
+    )
     args = parser.parse_args()
 
     scenario, locations = build_profile_scenario(horizon_months=args.horizon_months)
 
-    # Warm-up tiny run to pay one-time import / JIT-ish costs outside the timed region.
-    simulate(scenario, rollout_count=2, locations=locations)
+    def run(rollout_count: int) -> None:
+        if args.dense_only:
+            external_series = materialize_external_series(
+                scenario.external_series,
+                rollout_seeds=tuple(range(rollout_count)),
+                horizon_months=int(scenario.horizon_months),
+            )
+            simulate_dense_with_external_series(
+                scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
+            )
+        else:
+            simulate(scenario, rollout_count=rollout_count, locations=locations)
 
-    print(f"rollouts={args.rollouts} horizon_months={args.horizon_months}")
+    # Warm-up tiny run to pay one-time import / JIT-ish costs outside the timed region.
+    run(2)
+
+    print(f"rollouts={args.rollouts} horizon_months={args.horizon_months} dense_only={args.dense_only}")
 
     if args.no_profile:
         t0 = time.perf_counter()
-        simulate(scenario, rollout_count=args.rollouts, locations=locations)
+        run(args.rollouts)
         print(f"wall_clock_sec={time.perf_counter() - t0:.3f}")
         return
 
     profiler = cProfile.Profile()
     t0 = time.perf_counter()
     profiler.enable()
-    simulate(scenario, rollout_count=args.rollouts, locations=locations)
+    run(args.rollouts)
     profiler.disable()
     elapsed = time.perf_counter() - t0
     print(f"wall_clock_sec={elapsed:.3f}")

--- a/augur/sim/profile_rollout.py
+++ b/augur/sim/profile_rollout.py
@@ -7,9 +7,9 @@ Builds a "nontrivial knob config" on top of the spike-1 bench scenario:
     amortization), property-tax carrying cost, and a mortgage-interest
     deduction policy.
 
-Runs `simulate(...)` under cProfile and prints the hottest call sites by
-both cumulative and total (self) time, plus a per-phase wall-clock
-breakdown of the month loop.
+Runs `simulate(...)` (or just the dense engine, with `--dense-only`) under
+cProfile and prints the hottest call sites by cumulative and/or total (self)
+time (see `--sort`).
 
 Invoke locally:
   bazelisk run //augur/sim:profile_rollout -- --rollouts 4000 --horizon-months 1200
@@ -75,15 +75,9 @@ def build_profile_scenario(*, horizon_months: int) -> tuple[Scenario, dict[str, 
             "agents": [*base.agents, *extra_agents],
             "initial_cash": [*base.initial_cash, *extra_cash],
             "scheduled_property_purchases": [purchase],
-            "initial_primary_residences": [
-                PrimaryResidenceAssignment(agent_id="alice", property_id="home")
-            ],
+            "initial_primary_residences": [PrimaryResidenceAssignment(agent_id="alice", property_id="home")],
             "property_tax_policies": [
-                PropertyTaxPolicy(
-                    property_id="home",
-                    owner_agent_id="alice",
-                    tax_authority_agent_id="irs",
-                )
+                PropertyTaxPolicy(property_id="home", owner_agent_id="alice", tax_authority_agent_id="irs")
             ],
             "mortgage_interest_deduction_policies": [
                 MortgageInterestDeductionPolicy(liability_id="alice_mortgage", owner_agent_id="alice")
@@ -105,7 +99,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="augur rollout profiler")
     parser.add_argument("--rollouts", type=int, default=4000)
     parser.add_argument("--horizon-months", type=int, default=1200)
-    parser.add_argument("--sort", choices=["cumulative", "tottime"], default="cumulative")
+    parser.add_argument("--sort", choices=["cumulative", "tottime", "both"], default="both")
     parser.add_argument("--top", type=int, default=35)
     parser.add_argument("--no-profile", action="store_true", help="wall-clock only, no cProfile overhead")
     parser.add_argument(
@@ -150,7 +144,8 @@ def main() -> None:
     elapsed = time.perf_counter() - t0
     print(f"wall_clock_sec={elapsed:.3f}")
 
-    for sort_key in ("cumulative", "tottime"):
+    sort_keys = ("cumulative", "tottime") if args.sort == "both" else (args.sort,)
+    for sort_key in sort_keys:
         stream = io.StringIO()
         stats = pstats.Stats(profiler, stream=stream).sort_stats(sort_key)
         stats.print_stats(args.top)

--- a/augur/sim/profile_rollout.py
+++ b/augur/sim/profile_rollout.py
@@ -1,0 +1,142 @@
+"""Standalone rollout profiler for the augur dense-array sim engine.
+
+Builds a "nontrivial knob config" on top of the spike-1 bench scenario:
+  - W-2 income, rent, 3-asset portfolio, liquidity policy, CA+federal tax
+    (everything `build_bench_scenario` already wires), PLUS
+  - a financed primary-residence purchase (mortgage origination + monthly
+    amortization), property-tax carrying cost, and a mortgage-interest
+    deduction policy.
+
+Runs `simulate(...)` under cProfile and prints the hottest call sites by
+both cumulative and total (self) time, plus a per-phase wall-clock
+breakdown of the month loop.
+
+Invoke locally:
+  bazelisk run //augur/sim:profile_rollout -- --rollouts 4000 --horizon-months 1200
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import pstats
+import time
+
+from augur.sim.bench_scenario import build_bench_scenario
+from augur.sim.locations import Location
+from augur.sim.scenario import (
+    Agent,
+    InitialAccountBalance,
+    MortgageFinancing,
+    MortgageInterestDeductionPolicy,
+    PrimaryResidenceAssignment,
+    PropertyTaxPolicy,
+    Scenario,
+    ScheduledPropertyPurchase,
+)
+from augur.sim.simulate import simulate
+
+PROFILE_LOCATION_ID = "sf"
+
+
+def build_profile_scenario(*, horizon_months: int) -> tuple[Scenario, dict[str, Location]]:
+    """Bench scenario + a financed primary residence with property tax and MID."""
+    base = build_bench_scenario(horizon_months=horizon_months)
+
+    extra_agents = [Agent(agent_id="lender"), Agent(agent_id="property_seller")]
+    extra_cash = [
+        InitialAccountBalance(agent_id="lender", account_id="checking", balance_usd=0.0),
+        InitialAccountBalance(agent_id="property_seller", account_id="checking", balance_usd=0.0),
+    ]
+    purchase = ScheduledPropertyPurchase(
+        month=0,
+        cause_id="alice_home_purchase",
+        property_id="home",
+        location_id=PROFILE_LOCATION_ID,
+        buyer_agent_id="alice",
+        buyer_account_id="checking",
+        seller_agent_id="property_seller",
+        purchase_price_usd=1_200_000.0,
+        down_payment_usd=240_000.0,
+        buyer_closing_cost_usd=12_000.0,
+        rented_fraction=0.0,
+        mortgage=MortgageFinancing(
+            liability_id="alice_mortgage",
+            lender_agent_id="lender",
+            principal_usd=960_000.0,
+            annual_interest_rate=0.065,
+            term_months=360,
+        ),
+    )
+    scenario = base.model_copy(
+        update={
+            "agents": [*base.agents, *extra_agents],
+            "initial_cash": [*base.initial_cash, *extra_cash],
+            "scheduled_property_purchases": [purchase],
+            "initial_primary_residences": [
+                PrimaryResidenceAssignment(agent_id="alice", property_id="home")
+            ],
+            "property_tax_policies": [
+                PropertyTaxPolicy(
+                    property_id="home",
+                    owner_agent_id="alice",
+                    tax_authority_agent_id="irs",
+                )
+            ],
+            "mortgage_interest_deduction_policies": [
+                MortgageInterestDeductionPolicy(liability_id="alice_mortgage", owner_agent_id="alice")
+            ],
+        }
+    )
+    locations = {
+        PROFILE_LOCATION_ID: Location(
+            location_id=PROFILE_LOCATION_ID,
+            display_name="San Francisco",
+            jurisdiction_ids=["federal_us", "california"],
+            annual_property_tax_rate=0.0118,
+        )
+    }
+    return scenario, locations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="augur rollout profiler")
+    parser.add_argument("--rollouts", type=int, default=4000)
+    parser.add_argument("--horizon-months", type=int, default=1200)
+    parser.add_argument("--sort", choices=["cumulative", "tottime"], default="cumulative")
+    parser.add_argument("--top", type=int, default=35)
+    parser.add_argument("--no-profile", action="store_true", help="wall-clock only, no cProfile overhead")
+    args = parser.parse_args()
+
+    scenario, locations = build_profile_scenario(horizon_months=args.horizon_months)
+
+    # Warm-up tiny run to pay one-time import / JIT-ish costs outside the timed region.
+    simulate(scenario, rollout_count=2, locations=locations)
+
+    print(f"rollouts={args.rollouts} horizon_months={args.horizon_months}")
+
+    if args.no_profile:
+        t0 = time.perf_counter()
+        simulate(scenario, rollout_count=args.rollouts, locations=locations)
+        print(f"wall_clock_sec={time.perf_counter() - t0:.3f}")
+        return
+
+    profiler = cProfile.Profile()
+    t0 = time.perf_counter()
+    profiler.enable()
+    simulate(scenario, rollout_count=args.rollouts, locations=locations)
+    profiler.disable()
+    elapsed = time.perf_counter() - t0
+    print(f"wall_clock_sec={elapsed:.3f}")
+
+    for sort_key in ("cumulative", "tottime"):
+        stream = io.StringIO()
+        stats = pstats.Stats(profiler, stream=stream).sort_stats(sort_key)
+        stats.print_stats(args.top)
+        print(f"\n===== top {args.top} by {sort_key} =====")
+        print(stream.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -8,6 +8,8 @@ DataFrames for API and product projection code.
 
 from __future__ import annotations
 
+import polars as pl
+
 from augur.sim.codec.plan import DenseSimulationResult, SimulationRun
 from augur.sim.engine import simulate_with_external_series_dense_result
 from augur.sim.external_series import ExternalSeriesContext, materialize_external_series
@@ -56,16 +58,29 @@ def _validate_series_indexed_amounts(
 ) -> None:
     """Validate path-indexed amount schedules before compiling dense arrays."""
 
+    uses = [
+        (label, amount, months)
+        for label, amount, months in _series_indexed_amount_uses(scenario)
+        if isinstance(amount, SeriesIndexedAmount) and months
+    ]
+    if not uses:
+        # No path-indexed amounts → nothing references the external series here. Skip building
+        # the per-(series, month, rollout) lookup entirely; at a 100-year, many-rollout horizon
+        # that dict is millions of entries built from a Python row loop, all for nothing.
+        return
+
+    # Only the referenced series matter; filtering first keeps the lookup small even when the
+    # external frame carries many unrelated series (asset prices, etc.).
+    needed_wire_ids = {amount.series.wire_id for _, amount, _ in uses}
+    relevant = external_series.series_values.filter(pl.col("series_id").is_in(list(needed_wire_ids)))
     series_levels: dict[tuple[str, int, int], float | None] = {}
-    for row in external_series.series_values.iter_rows(named=True):
+    for row in relevant.iter_rows(named=True):
         value = row["value"]
         series_levels[(str(row["series_id"]), int(row["month_index"]), int(row["rollout_index"]))] = (
             None if value is None else float(value)
         )
 
-    for label, amount, months in _series_indexed_amount_uses(scenario):
-        if not isinstance(amount, SeriesIndexedAmount) or not months:
-            continue
+    for label, amount, months in uses:
         before_base = [month for month in months if month < amount.base_month_index]
         if before_base:
             raise ValueError(


### PR DESCRIPTION
## What

Profiles augur sim rollouts at a "production-ish" scale (mortgage + nontrivial knob config, 100-year / 1200-month horizon, large fan-out), and lands the proven boundary optimizations it surfaced.

Adds `//augur/sim:profile_rollout` (cProfile harness over the bench scenario + a financed primary residence: mortgage origination/amortization, property tax, MID) and `augur/debug/rollout_perf_profiling.md`.

## Headline finding

The rollout math is **already vectorized and parallel** across the rollout (R) axis. The serial month loop is ~7% of wall time. The cost is at the boundaries: decoding dense arrays into long-form Polars frames, and ingesting/validating the external-series long frame via Python row iteration.

## Optimizations (output unchanged, sim tests green)

1. **Sparse-active `decode_tax_liabilities`** — gather active `(month, rollout, slot)` triples via `np.nonzero` instead of materializing three full-grid int64 index arrays (`state_axes`) and masking. Removes a ~2.9 GB transient at 500×1200.
2. **Vectorized `external_values_cube`** — columnar `series_id → index` map + a single fancy-index scatter, replacing a Python `iter_rows()` loop over every `(rollout, month, series)` row.
3. **Short-circuited `_validate_series_indexed_amounts`** — returns immediately when no `SeriesIndexedAmount` is in use (the common case), else filters to referenced series, instead of unconditionally building a millions-of-entries dict from `iter_rows()`.

**500 rollouts × 1200 months: 26.9 s → 18.1 s** (function calls 5.9 M → 484 K).

## What's left (documented, deliberately not in this PR)

A `--dense-only` profiler mode (compile + month loop, no decode) isolates pure compute:

| rollouts | dense-only (compute) | full `simulate()` (with decode) |
| -------- | -------------------- | ------------------------------- |
| 1000     | 2.8 GB / 3.2 s ✅    | OOM (decode frames)             |
| 4000     | 11 GB / 11 s ✅      | OOM                             |
| 10000    | OOM ❌               | OOM                             |

The remaining 1000–10000-rollout walls are two O(horizon² × R) eager allocations, **not** the per-cell state:
- the dense `tax_liability_state` buffer `(snapshots, years×links, R)` — at 10000 it dies allocating exactly `17.9 GiB for (1201, 200, 10000)`; needs event-based storage;
- the eager full decode of every state-history frame — needs lazy/opt-in decode.

Both touch the `SimulationRun` contract / state-history storage and are left as follow-ups.

## Test

`bazel test //augur/sim/...` — all 9 sim tests pass (`simulate_test`, `bench_test`, `test_rental_lifecycle_e2e`, `projections_test`, `tax_test`, …). Lint (ruff + mypy) clean.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_