### PR TITLE
augur/sim: fix property-stake decode cross-assignment for >1 property

### DIFF
--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -343,6 +343,21 @@ py_test(
 )
 
 py_test(
+    name = "test_property_stakes_e2e",
+    size = "small",
+    srcs = ["test_property_stakes_e2e.py"],
+    deps = [
+        ":conftest",
+        ":locations",
+        ":scenario",
+        ":simulate",
+        "@pypi//polars",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "projections_test",
     size = "medium",
     srcs = ["projections_test.py"],

--- a/augur/sim/codec/properties.py
+++ b/augur/sim/codec/properties.py
@@ -45,6 +45,13 @@ def decode_property_stakes(plan: CompiledSimulation, buffers: SimulationBuffers)
     h1, r, p = active.shape
     months, rollouts, props = state_axes(h1, r, p)
     mask = active.reshape(-1)
+    # The mask + (month, rollout, property) axes are in R-first order, so the per-property
+    # state buffers must be viewed R-first too before flattening — the raw buffers are
+    # (snapshot, property, rollout). Flattening them raw and applying the R-first mask
+    # cross-assigns stake values between properties once property_count > 1.
+    ownership = r_first_view(buffers.state.property_ownership_state)
+    contribution = r_first_view(buffers.state.property_contribution_state)
+    equity = r_first_view(buffers.state.property_equity_state)
     property_ids = codes_to_strings(plan, plan.properties.id)
     buyer_ids = codes_to_strings(plan, plan.properties.buyer_agent)
     return state_history_frame_from_columns(
@@ -53,9 +60,9 @@ def decode_property_stakes(plan: CompiledSimulation, buffers: SimulationBuffers)
             "month_index": months[mask],
             "property_id": property_ids[props[mask]],
             "agent_id": buyer_ids[props[mask]],
-            "ownership_pct": buffers.state.property_ownership_state.reshape(-1)[mask],
-            "contribution_used_usd": buffers.state.property_contribution_state.reshape(-1)[mask],
-            "equity_ledger_usd": buffers.state.property_equity_state.reshape(-1)[mask],
+            "ownership_pct": ownership.reshape(-1)[mask],
+            "contribution_used_usd": contribution.reshape(-1)[mask],
+            "equity_ledger_usd": equity.reshape(-1)[mask],
         },
         PROPERTY_STAKE_FRAME,
     )

--- a/augur/sim/test_property_stakes_e2e.py
+++ b/augur/sim/test_property_stakes_e2e.py
@@ -1,0 +1,96 @@
+"""Sim-level e2e for property-stake decoding with more than one property.
+
+Regression test for a buffer-layout bug in `decode_property_stakes`: the active
+mask was taken from an R-first view of shape `(snapshot, rollout, property)` but
+applied to the *raw* `(snapshot, property, rollout)` ownership / contribution /
+equity buffers. With a single property the two flattenings coincide, so the bug
+was invisible; with `property_count > 1` and `rollout_count > 1` it
+cross-assigns each property's stake values to the wrong (property, rollout)
+cells.
+
+The scenario is fully deterministic (no exogenous series), so every property's
+stake values must be identical across all rollouts and post-purchase months. The
+bug breaks exactly that invariant.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+import pytest_bazel
+
+from augur.sim.locations import Location
+from augur.sim.scenario import Agent, InitialAccountBalance, Scenario, ScheduledPropertyPurchase
+from augur.sim.simulate import simulate
+
+LOCATION_ID = "loc"
+LOCATIONS = {
+    LOCATION_ID: Location(
+        location_id=LOCATION_ID, display_name="Loc", jurisdiction_ids=[], annual_property_tax_rate=0.0
+    )
+}
+
+
+def _two_property_scenario(*, horizon_months: int = 3) -> Scenario:
+    """Two all-cash purchases by one buyer with distinct ownership/price/down-payment."""
+    return Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="property_seller")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=2_000_000.0),
+            InitialAccountBalance(agent_id="property_seller", account_id="checking", balance_usd=0.0),
+        ],
+        scheduled_property_purchases=[
+            ScheduledPropertyPurchase(
+                month=0,
+                cause_id="buy_p1",
+                property_id="p1",
+                location_id=LOCATION_ID,
+                buyer_agent_id="alice",
+                buyer_account_id="checking",
+                seller_agent_id="property_seller",
+                purchase_price_usd=1_000_000.0,
+                down_payment_usd=200_000.0,
+                ownership_pct=1.0,
+            ),
+            ScheduledPropertyPurchase(
+                month=0,
+                cause_id="buy_p2",
+                property_id="p2",
+                location_id=LOCATION_ID,
+                buyer_agent_id="alice",
+                buyer_account_id="checking",
+                seller_agent_id="property_seller",
+                purchase_price_usd=500_000.0,
+                down_payment_usd=500_000.0,
+                ownership_pct=0.6,
+            ),
+        ],
+        tax_profiles=[],
+        horizon_months=horizon_months,
+    )
+
+
+def test_property_stakes_not_cross_assigned_across_properties() -> None:
+    # Two properties × several rollouts is the exact shape that the (snapshot, rollout, property)
+    # vs (snapshot, property, rollout) flattening mismatch scrambles.
+    run = simulate(_two_property_scenario(), rollout_count=4, locations=LOCATIONS)
+    stakes = run.property_stakes
+
+    # equity_ledger = purchase_price - mortgage_principal (no mortgage here);
+    # contribution_used_usd = down_payment + closing_cost.
+    expected = {
+        "p1": {"ownership_pct": 1.0, "contribution_used_usd": 200_000.0, "equity_ledger_usd": 1_000_000.0},
+        "p2": {"ownership_pct": 0.6, "contribution_used_usd": 500_000.0, "equity_ledger_usd": 500_000.0},
+    }
+    for property_id, fields in expected.items():
+        rows = stakes.filter(pl.col("property_id") == property_id)
+        assert rows.height > 0, f"no stake rows decoded for {property_id}"
+        for column, value in fields.items():
+            distinct = set(rows[column].to_list())
+            # Deterministic inputs ⇒ exactly one value per property across all rollouts/months.
+            assert len(distinct) == 1, f"{property_id}.{column} varies across rollouts: {distinct}"
+            assert distinct.pop() == pytest.approx(value), f"{property_id}.{column} != {value}"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Bug

`decode_property_stakes` builds the active mask from an **R-first** view of `property_active_state` — shape `(snapshot, rollout, property)` — but applies that mask to the **raw** `(snapshot, property, rollout)` ownership / contribution / equity buffers:

```python
active = r_first_view(buffers.state.property_active_state)  # (H+1, r, p)
mask = active.reshape(-1)                                   # (snapshot, rollout, property) order
...
"ownership_pct": buffers.state.property_ownership_state.reshape(-1)[mask],  # raw (snapshot, property, rollout) order
```

The two flattenings only coincide when `property_count == 1` (every real scenario so far), which is why it went unnoticed. With **`property_count > 1` and `rollout_count > 1`** the linear positions diverge and each property's `ownership_pct` / `contribution_used_usd` / `equity_ledger_usd` get assigned to the wrong `(property, rollout)` cells. `property_id`/`agent_id` use the correct R-first axes, so the columns are silently mismatched against the property they're labeled with.

`decode_property_state` already does this correctly for `adjusted_basis` (it views the buffer R-first before flattening); only `decode_property_stakes` was inconsistent.

## Fix

View the per-property state buffers R-first before flattening, matching the mask and the `(month, rollout, property)` axes.

## Test

New sim-level e2e `test_property_stakes_e2e.py`: two all-cash purchases by one buyer with distinct ownership / price / down-payment, run over 4 rollouts. Inputs are deterministic, so each property's stake values must be identical across all rollouts and post-purchase months.

- On unfixed code the test fails: `p1.ownership_pct varies across rollouts: {0.6, 1.0}` (property 0 picks up property 1's ownership for some rollouts).
- With the fix, `//augur/sim/...` (10 tests) passes; lint (ruff + mypy) clean.

Independent of the rollout-profiling/optimization work in #1832 (branches off `devel`, touches a disjoint code path).

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_