### PR TITLE
cluster/litellm: prefer proxmox instead of hard-pinning (OVH fallback)

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -26,12 +26,20 @@ spec:
     spec:
       serviceAccountName: litellm
       terminationGracePeriodSeconds: 90
-      # litellm proxies to local Ollama for fallback paths and lives close
-      # to ollama on the Proxmox GPU host. Pin to the proxmox region so it
-      # only schedules where it belongs (and stays Pending when those
-      # nodes are offline, rather than landing on a hil worker).
-      nodeSelector:
-        topology.kubernetes.io/region: proxmox
+      # Prefer the Proxmox GPU host (co-located with ollama for its fallback
+      # paths), but allow scheduling elsewhere (e.g. OVH) so external-provider
+      # models (z.ai/GLM) keep serving when the home node is offline — ollama
+      # is unreachable during a home outage regardless of where litellm runs.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - proxmox
       containers:
         - name: litellm
           image: litellm/litellm:1.82.1


### PR DESCRIPTION
Follow-up to #1831 (z.ai/GLM-4.6 via LiteLLM). The z.ai wiring deployed correctly, but its LiteLLM bridge can't run: litellm is hard-pinned to `region: proxmox`, and `wyrm2` (the only proxmox node) is `NotReady`, so the pods are `Pending: FailedScheduling`.

## Change

Replace the hard `nodeSelector: topology.kubernetes.io/region: proxmox` with a **preferred** `nodeAffinity` (weight 100):
- **Home up** → still prefers the Proxmox GPU host, co-located with ollama (unchanged behavior).
- **Home down** → schedules on an OVH worker instead of sitting `Pending`, so external-provider models (z.ai/GLM) keep serving.

ollama-backed models are unavailable during a home outage regardless (ollama itself is down), so nothing is lost there. litellm is a CPU-only proxy (no GPU/PVC dependency), so OVH scheduling is fine.

Note: `preferredDuringSchedulingIgnoredDuringExecution` only affects *initial* scheduling — after a home outage litellm stays on OVH until its next rollout (no auto-migration back). That's acceptable; ollama calls just take the cross-region hop until then.

## Why now

This unblocks the GLM-4.6 route (`props → litellm → z.ai`). Once merged + reconciled, litellm should schedule on OVH and come up; then I can run the GLM-4.6 critic smoke test through props to validate the LiteLLM Responses→chat bridge end-to-end.

Validated: kustomize build, kubeconform, kustomization-layering all pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_