### PR TITLE
cluster/litellm: bridge /responses→chat for z.ai (use_chat_completions_api)

### DIFF
--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -54,6 +54,11 @@ def _zai_entries() -> Iterator[dict]:
                 "model": f"openai/{model}",
                 "api_base": _ZAI_CODING_BASE,
                 "api_key": "os.environ/ZAI_API_KEY",
+                # z.ai has no /responses endpoint. Without this, LiteLLM forwards
+                # /v1/responses straight to {api_base}/responses (404). This opts
+                # the openai/ provider into LiteLLM's Responses->chat bridge, so
+                # props' OpenAI-Responses proxy lands on z.ai's chat/completions.
+                "use_chat_completions_api": True,
             },
             "model_info": {"mode": "chat", "supports_function_calling": True},
         }

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -113,6 +113,7 @@ model_list:
       model: openai/glm-4.6
       api_base: https://api.z.ai/api/coding/paas/v4
       api_key: os.environ/ZAI_API_KEY
+      use_chat_completions_api: true
     model_info:
       mode: chat
       supports_function_calling: true


### PR DESCRIPTION
Fixes the GLM-4.6-via-props path uncovered by the smoke test.

## What the smoke test found

With litellm now running (OVH, after #1834), I hit its `/v1/responses` with `model=glm-4.6` — props' exact path. It failed:

```
litellm.NotFoundError: OpenAIException - {"status":404,"path":"/v4/responses"}. Received Model Group=glm-4.6
```

litellm recognized `glm-4.6` but **forwarded the `/responses` request straight to z.ai's `{api_base}/responses`** (which 404s — z.ai has no Responses API). For `openai/`-prefix models with a custom `api_base`, litellm only bridges `/responses → /chat/completions` when you **opt in** (litellm docs / [BerriAI/litellm#23716](https://github.com/BerriAI/litellm/issues/23716)).

## Fix

Set `use_chat_completions_api: true` on the `glm-4.6` entry in `generate_litellm.py` (→ regenerated `proxy-config.yaml`). Now litellm translates props' Responses request to z.ai's chat/completions.

## Evidence it'll work

Against the live litellm, **`/v1/chat/completions` for `glm-4.6` already works** — returns `content: "pong"`, `finish: stop`, and usage. That's exactly the call the bridge will make; the only missing piece was the opt-in flag.

```
"usage": { "prompt_tokens": 12, "completion_tokens": 48, "completion_tokens_details": {"reasoning_tokens": 45} }
```

Parity test (`//cluster/k8s/litellm/app:test_generate_litellm`) + ruff/prettier pass.

## After merge

litellm rolls with the new config; I'll re-run the `/v1/responses` glm-4.6 test to confirm it now bridges and returns a Responses object with `usage.input_tokens`/`output_tokens` (the shape props' logger parses), then the `props → litellm → z.ai` path is fully validated.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_