### PR TITLE
augur/sim: event-based tax-liability state (drop O(horizon²×R) buffer)

### DIFF
--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -175,6 +175,26 @@ The remaining walls are two O(horizon² × R) eager allocations, **not** the per
 Both are deeper changes (they touch the `SimulationRun` contract / state-history storage)
 and are deliberately left as follow-ups to the boundary fixes above.
 
+## Results after the second pass (event-based tax liabilities)
+
+Intervention #2 landed: the dense `(snapshots, year-slots, R)` tax-liability state history
+is replaced by a sparse balance-change log (one event at year-end accrual + one per
+settlement), and the `tax_liabilities` output frame is now those change events. The
+piecewise-constant per-month balance is fully described by the changes, so every existing
+consumer (all in tests, querying the change-months) is unchanged.
+
+This removed both the 17.9 GiB dense buffer _and_ the largest decode frame (tax-liability
+rows accumulated to tens of millions over 100 years), so the full pipeline now fits:
+
+| rollouts | dense-only (compute)       | full `simulate()` (with decode)            |
+| -------- | -------------------------- | ------------------------------------------ |
+| 1000     | 2.8 GB                     | 3.6 GB / 7.4 s ✅ (was OOM)                |
+| 2000     | —                          | 7.1 GB / 14.4 s ✅ (was OOM)               |
+| 10000    | 7.7 GB / 57 s ✅ (was OOM) | (other per-month frames still O(months×R)) |
+
+Remaining lever for full `simulate()` at 10000 is lazy/opt-in decode (#5): the other
+state-history frames (cash, lots, …) are still materialized eagerly at O(months × R).
+
 ## Note on parallelism
 
 Rollouts are independent, so beyond the above the R axis can be **chunked**

--- a/augur/sim/buffers.py
+++ b/augur/sim/buffers.py
@@ -15,7 +15,7 @@ sides of the encoder/decoder pair need to share it as a stable data interface.""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -39,8 +39,6 @@ class StateHistoryBuffers:
     ordinary_state: NDArray[np.float64]
     capital_gain_active_state: NDArray[np.bool_]
     capital_gain_state: NDArray[np.float64]
-    tax_liability_active_state: NDArray[np.bool_]
-    tax_liability_state: NDArray[np.float64]
     property_active_state: NDArray[np.bool_]
     property_basis_state: NDArray[np.float64]
     property_ownership_state: NDArray[np.float64]
@@ -81,15 +79,6 @@ class StateHistoryBuffers:
             self.capital_gain_state,
             shape=(s, plan.capital_gain_agent_count, 2, r),
             dtype=np.float64,
-        )
-        _expect_array(
-            "tax_liability_active_state",
-            self.tax_liability_active_state,
-            shape=(s, plan.tax_liability_count, r),
-            dtype=np.bool_,
-        )
-        _expect_array(
-            "tax_liability_state", self.tax_liability_state, shape=(s, plan.tax_liability_count, r), dtype=np.float64
         )
         _expect_array(
             "property_active_state", self.property_active_state, shape=(s, plan.property_count, r), dtype=np.bool_
@@ -556,6 +545,44 @@ class ObligationEventBuffers:
 
 
 @dataclass
+class TaxLiabilityChange:
+    """One year-tax-liability balance-change event, captured at the month it occurred.
+
+    `slots` indexes `plan.tax_liabilities`; `amount[k, r]` is the post-change balance and
+    `active[k, r]` whether the liability exists for rollout `r` (failed rollouts never accrue
+    one). Decode emits one output row per active `(slot, rollout)`.
+    """
+
+    snapshot_month: int
+    slots: NDArray[np.int64]
+    amount: NDArray[np.float64]
+    active: NDArray[np.bool_]
+
+
+@dataclass
+class TaxLiabilityChangeLog:
+    """Sparse replacement for the old dense `(snapshot, year_slots, R)` tax-liability state
+    history (which was O(horizon² × R) since year-slots grow with the horizon). Year-end
+    accrual and each settlement append one change; the per-month outstanding balance is
+    piecewise-constant between changes, so the change list reconstructs the output frame."""
+
+    changes: list[TaxLiabilityChange] = field(default_factory=list)
+
+    def record(self, *, snapshot_month: int, slots: np.ndarray, amount: np.ndarray, active: np.ndarray) -> None:
+        """Record the post-change balance of `slots` (read from the current-state arrays)."""
+        if slots.size == 0:
+            return
+        self.changes.append(
+            TaxLiabilityChange(
+                snapshot_month=snapshot_month,
+                slots=slots.astype(np.int64, copy=True),
+                amount=amount[slots, :].copy(),
+                active=active[slots, :].copy(),
+            )
+        )
+
+
+@dataclass
 class SimulationBuffers:
     state: StateHistoryBuffers
     transfers: TransferEventBuffers
@@ -566,6 +593,7 @@ class SimulationBuffers:
     obligations: ObligationEventBuffers
     primary_residence: PrimaryResidenceEventBuffers
     lifecycle: LifecycleEventBuffers
+    tax_liability_changes: TaxLiabilityChangeLog
 
     def validate(self, plan: CompiledSimulation) -> None:
         slot_plan = plan.slot_plan

--- a/augur/sim/codec/helpers.py
+++ b/augur/sim/codec/helpers.py
@@ -74,21 +74,6 @@ def state_axes(h1: int, r: int, s: int) -> tuple[np.ndarray, np.ndarray, np.ndar
     return months, rollouts, slots
 
 
-def active_state_axes(active: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """`(month, rollout, slot)` index arrays for the True positions of a `(h1, r, s)` active
-    grid, in row-major order.
-
-    The sparse counterpart to `state_axes` + a boolean mask: decoders whose state is mostly
-    inactive (tax liabilities, properties, debts — slots that only switch on partway through
-    the horizon) should gather active positions directly via `np.nonzero` instead of
-    materializing three full-grid index arrays and then masking. For a 100-year horizon the
-    full grid is `snapshots × slots × R` (≫100 M cells); this avoids building it.
-    """
-
-    months, rollouts, slots = np.nonzero(active)
-    return months, rollouts, slots
-
-
 def state_history_frame_from_columns(columns: dict[str, np.ndarray], spec: Any) -> pl.DataFrame:
     """Build a state-history frame from pre-built numpy column arrays. State-history specs
     don't carry `month_index` in their schema (the cross-section is one month wide); decode

--- a/augur/sim/codec/tax.py
+++ b/augur/sim/codec/tax.py
@@ -10,7 +10,6 @@ import polars as pl
 
 from augur.sim.buffers import SimulationBuffers
 from augur.sim.codec.helpers import (
-    active_state_axes,
     codes_to_strings,
     frame_from_columns,
     r_first_view,
@@ -70,21 +69,44 @@ def decode_capital_gains(plan: CompiledSimulation, buffers: SimulationBuffers) -
 
 
 def decode_tax_liabilities(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.DataFrame:
-    state = r_first_view(buffers.state.tax_liability_state)  # (H+1, r, s)
-    active = r_first_view(buffers.state.tax_liability_active_state)
-    months, rollouts, slots = active_state_axes(active)
+    """Outstanding year-tax-liability balances, one row per balance-change event.
+
+    Replaces the old per-month dense snapshot: each row is the post-change balance at the month
+    the liability accrued or was settled (`month_index` on the snapshot timeline). The balance
+    is piecewise-constant between changes, so these events fully describe the trajectory."""
     profile_per_slot = plan.tax_liabilities.profile_index.astype(np.int64)
     link_per_slot = plan.tax_liabilities.link_index.astype(np.int64)
+    year_end_per_slot = plan.tax_liabilities.year_end_month.astype(np.int64)
     agent_per_profile = codes_to_strings(plan, plan.tax.profile_agent)
     juris_per_link = codes_to_strings(plan, plan.tax.link_jurisdiction)
+
+    month_blocks: list[np.ndarray] = []
+    rollout_blocks: list[np.ndarray] = []
+    slot_blocks: list[np.ndarray] = []
+    amount_blocks: list[np.ndarray] = []
+    for change in buffers.tax_liability_changes.changes:
+        local_slot, rollout = np.nonzero(change.active)  # indices into (k, R)
+        if local_slot.size == 0:
+            continue
+        slots = change.slots[local_slot]
+        month_blocks.append(np.full(slots.shape, change.snapshot_month, dtype=np.int64))
+        rollout_blocks.append(rollout.astype(np.int64))
+        slot_blocks.append(slots)
+        amount_blocks.append(change.amount[local_slot, rollout])
+
+    empty = np.array([], dtype=np.int64)
+    months = np.concatenate(month_blocks) if month_blocks else empty
+    rollouts = np.concatenate(rollout_blocks) if rollout_blocks else empty
+    slots = np.concatenate(slot_blocks) if slot_blocks else empty
+    amounts = np.concatenate(amount_blocks) if amount_blocks else np.array([], dtype=np.float64)
     return state_history_frame_from_columns(
         {
             "rollout_index": rollouts,
             "month_index": months,
             "agent_id": agent_per_profile[profile_per_slot[slots]],
             "jurisdiction_id": juris_per_link[link_per_slot[slots]],
-            "tax_year_end_month": plan.tax_liabilities.year_end_month.astype(np.int64)[slots],
-            "amount_owed_usd": state[months, rollouts, slots],
+            "tax_year_end_month": year_end_per_slot[slots],
+            "amount_owed_usd": amounts,
         },
         TAX_LIABILITIES_FRAME,
     )

--- a/augur/sim/engine/__init__.py
+++ b/augur/sim/engine/__init__.py
@@ -16,6 +16,7 @@ from augur.sim.buffers import (
     SimulationBuffers,
     StateHistoryBuffers,
     TaxEventBuffers,
+    TaxLiabilityChangeLog,
     TransferEventBuffers,
 )
 from augur.sim.codec.plan import DenseSimulationResult
@@ -108,8 +109,8 @@ def _snapshot_current_state(state: StateHistoryBuffers, current: CurrentStateBuf
     state.ordinary_state[snapshot_index] = current.ordinary_ytd
     state.capital_gain_active_state[snapshot_index] = current.capital_gain_active
     state.capital_gain_state[snapshot_index] = current.capital_gain_ytd
-    state.tax_liability_active_state[snapshot_index] = current.tax_liability_active
-    state.tax_liability_state[snapshot_index] = current.tax_liability_amount
+    # Tax liabilities are not snapshotted here: their per-month balance is piecewise-constant
+    # and captured sparsely in buffers.tax_liability_changes (accrual + settlement events).
     state.property_active_state[snapshot_index] = current.property_active
     state.property_basis_state[snapshot_index] = current.property_basis
     state.property_ownership_state[snapshot_index] = current.property_ownership
@@ -194,8 +195,6 @@ def _allocate_buffers(plan: CompiledSimulation) -> SimulationBuffers:
             capital_gain_active_state=np.zeros((s, p.capital_gain_agent_count, 2, r), dtype=np.bool_),
             capital_gain_state=np.zeros((s, p.capital_gain_agent_count, 2, r), dtype=np.float64),
             # tax_liability_*_state[S, T, R]
-            tax_liability_active_state=np.zeros((s, p.tax_liability_count, r), dtype=np.bool_),
-            tax_liability_state=np.zeros((s, p.tax_liability_count, r), dtype=np.float64),
             # property_*_state[S, P, R]
             property_active_state=np.zeros((s, p.property_count, r), dtype=np.bool_),
             property_basis_state=np.zeros((s, p.property_count, r), dtype=np.float64),
@@ -324,6 +323,7 @@ def _allocate_buffers(plan: CompiledSimulation) -> SimulationBuffers:
             ),
             sale_long_term_gain=np.zeros((max(1, int(plan.lifecycle_events.month.shape[0])), r), dtype=np.float64),
         ),
+        tax_liability_changes=TaxLiabilityChangeLog(),
     )
     buffers.validate(plan)
     return buffers

--- a/augur/sim/engine/phases.py
+++ b/augur/sim/engine/phases.py
@@ -933,6 +933,17 @@ def _apply_tax_accruals(
     # links above. Reset so next year's recapture from a separate sale starts fresh.
     current.recapture_section_1250_ytd[:, active_rollout] = 0.0
 
+    # Record this year's accrued liabilities as a balance-change event (sparse replacement for
+    # the old per-month dense tax-liability state history). snapshot_month = month + 1 to match
+    # the snapshot timeline the codec reports as month_index.
+    created_slots = np.flatnonzero(plan.tax_liabilities.year_end_month == month)
+    buffers.tax_liability_changes.record(
+        snapshot_month=month + 1,
+        slots=created_slots,
+        amount=current.tax_liability_amount,
+        active=current.tax_liability_active,
+    )
+
 
 def _apply_brackets(
     amount: npt.NDArray[np.float64], *, upper: np.ndarray, rate: np.ndarray, count: int
@@ -1433,6 +1444,17 @@ def _apply_tax_settlements(
                 year_end_month=int(year_end_month),
                 settlement_amount=tax_settlement_candidate[profile],
                 active=year_active,
+            )
+            # Record the post-settlement balance of this (profile, year) as a change event.
+            settled_slots = np.flatnonzero(
+                (plan.tax_liabilities.profile_index == profile)
+                & (plan.tax_liabilities.year_end_month == int(year_end_month))
+            )
+            buffers.tax_liability_changes.record(
+                snapshot_month=month + 1,
+                slots=settled_slots,
+                amount=current.tax_liability_amount,
+                active=current.tax_liability_active,
             )
 
 

--- a/augur/sim/slice.py
+++ b/augur/sim/slice.py
@@ -9,7 +9,7 @@ import numpy as np
 import polars as pl
 
 from augur.model.private_equity_bundle import PrivateEquityBundle
-from augur.sim.buffers import SimulationBuffers
+from augur.sim.buffers import SimulationBuffers, TaxLiabilityChange, TaxLiabilityChangeLog
 from augur.sim.codec.plan import DenseSimulationResult
 from augur.sim.external_series import ExternalSeriesContext
 
@@ -37,6 +37,7 @@ def slice_dense_result(dense: DenseSimulationResult, *, rollout_index: int) -> D
         obligations=_take_dc(dense.buffers.obligations, rollout_index, axis=-1),
         primary_residence=_take_dc(dense.buffers.primary_residence, rollout_index, axis=-1),
         lifecycle=_take_dc(dense.buffers.lifecycle, rollout_index, axis=-1),
+        tax_liability_changes=_slice_tax_liability_changes(dense.buffers.tax_liability_changes, rollout_index),
     )
     external_series = ExternalSeriesContext(
         series_values=(
@@ -58,6 +59,21 @@ def _slice_pe_bundle(pe: PrivateEquityBundle, *, rollout_index: int) -> PrivateE
         rollout_index=pl.lit(0, dtype=pl.Int64)
     )
     return PrivateEquityBundle(frame=sliced)
+
+
+def _slice_tax_liability_changes(log: TaxLiabilityChangeLog, rollout_index: int) -> TaxLiabilityChangeLog:
+    """Restrict each tax-liability change block to one rollout (keeping the slot axis)."""
+    return TaxLiabilityChangeLog(
+        changes=[
+            TaxLiabilityChange(
+                snapshot_month=change.snapshot_month,
+                slots=change.slots.copy(),
+                amount=change.amount[:, rollout_index : rollout_index + 1].copy(),
+                active=change.active[:, rollout_index : rollout_index + 1].copy(),
+            )
+            for change in log.changes
+        ]
+    )
 
 
 def _take_dc[T](obj: T, rollout_index: int, *, axis: int) -> T:


### PR DESCRIPTION
## Problem

Tax-liability state was stored as a dense per-month history buffer `tax_liability_state (snapshots, year-slots, R)`. Year-slots accumulate **one per link per tax year**, so at a 100-year horizon this grid is `(1201, 200, R)` — quadratic in horizon. It was:

- the **17.9 GiB** allocation that OOM-killed `--dense-only` runs at 10000 rollouts (`Unable to allocate 17.9 GiB for an array with shape (1201, 200, 10000)`), and
- after decode, the **largest output frame** (tens of millions of rows), which OOM'd full `simulate()` at ≥1000 rollouts.

Per [PR #1832](https://github.com/agentydragon/ducktape/pull/1832)'s findings doc, this was intervention #2.

## Change

Replace the dense history with a **sparse balance-change log** (`TaxLiabilityChangeLog` in `buffers.py`): record one event at year-end accrual and one per settlement. The per-month outstanding balance is piecewise-constant between changes, so the change events fully describe the trajectory.

The `tax_liabilities` output frame is now those balance-change events (`month_index` = change month on the snapshot timeline, `amount_owed_usd` = post-change balance). Every consumer is a test querying change-months (year-end accrual at `month_index==12`, settlement at `==13`) or `is_empty()`, so **all existing tests pass unchanged** — no product/api/frontend code reads this frame.

Mechanics:
- drop `tax_liability_{state,active_state}` from `StateHistoryBuffers` + the per-month snapshot;
- record accrual changes in `_apply_tax_accruals`, settlement changes in `_apply_tax_settlements`;
- rewrite `decode_tax_liabilities` to build the frame from the change log;
- slice the log per-rollout in `slice.py`;
- drop the now-unused `active_state_axes` helper (added in #1832 for the old decoder).

Note: failure-zeroing of a dead rollout's liability is intentionally *not* an event (the rollout's death is captured by `rollout_status`); tax scenarios in tests are solvent.

## Results (1200-month horizon, 15 GB box)

| run | before | after |
| --- | ------ | ----- |
| `--dense-only` 10000 | OOM (17.9 GiB) | **7.7 GB / 57 s** ✅ |
| full `simulate()` 1000 | OOM | **3.6 GB / 7.4 s** ✅ |
| full `simulate()` 2000 | OOM | **7.1 GB / 14.4 s** ✅ |

## Test

`bazel test //augur/sim/...` — all 10 sim tests pass; lint (ruff + mypy) clean. `//augur/product/...` and `//augur/api/...` build clean. (`//augur/frontend:main_bundle` fails to build in this environment on a missing generated `zod.gen.ts` — a pre-existing TS-codegen issue unrelated to this Python change.)

Remaining lever for full `simulate()` at 10000 is lazy/opt-in decode of the other per-month state-history frames (cash, lots, …) — intervention #5, separate.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_