### PR TITLE
augur: holding-period buckets for Plaid SP500 proxy groups

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -145,6 +145,7 @@ py_test(
         ":portfolio_sources",
         "//augur/product:asset_key",
         "//plaid_utils:read_model",
+        "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/augur/api/portfolio_source_config.py
+++ b/augur/api/portfolio_source_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from enum import StrEnum
 
 from pydantic import Field, NonNegativeInt, PositiveFloat, model_validator
@@ -23,6 +24,37 @@ class PlaidCashSourceConfig(ApiModel):
     balance_field: PlaidBalanceField = PlaidBalanceField.CURRENT
 
 
+class PlaidProxyHoldingPeriodBucket(ApiModel):
+    """One holding-period band used to split a Plaid SP500 proxy's aggregate into representative lots.
+
+    Plaid reports a tax-loss-harvesting direct-indexing sleeve (e.g. Wealthfront) as a single
+    aggregate security with no per-lot acquisition dates, so without buckets the proxy collapses to
+    one lot at `default_holding_period_months_at_start` and liquidation tax is modeled as entirely
+    long-term. These buckets carry an offline calibration (from the institution's own tax-lot
+    export) of how value and basis split across holding-period bands. The live value and cost basis
+    still come from Plaid at startup and are distributed across buckets using these fixed fractions,
+    so the position totals always match the current Plaid snapshot.
+    """
+
+    key: str = Field(pattern=_ID_PATTERN, description="Lot-id suffix for this bucket, e.g. 'lt12'.")
+    holding_period_months_at_start: NonNegativeInt = Field(
+        description="Representative months held at month 0 for this bucket's lot (e.g. the MV-weighted mean age)."
+    )
+    market_value_fraction: float = Field(
+        gt=0.0, le=1.0, description="Share of the proxy's aggregate market value in this bucket."
+    )
+    cost_basis_fraction: float | None = Field(
+        default=None,
+        gt=0.0,
+        le=1.0,
+        description=(
+            "Share of the proxy's aggregate cost basis in this bucket. Defaults to "
+            "`market_value_fraction` (uniform embedded gain) when omitted; set it explicitly to "
+            "capture that older buckets carry more embedded gain than freshly harvested ones."
+        ),
+    )
+
+
 class PlaidSp500ProxyGroupConfig(ApiModel):
     """Map selected Plaid investment accounts into one Augur SP500 proxy position."""
 
@@ -37,6 +69,35 @@ class PlaidSp500ProxyGroupConfig(ApiModel):
     security_kind: HoldingKind = HoldingKind.OTHER
     unit_value_usd: PositiveFloat = 1000.0
     default_holding_period_months_at_start: NonNegativeInt = 0
+    holding_period_buckets: tuple[PlaidProxyHoldingPeriodBucket, ...] = Field(
+        default=(),
+        description=(
+            "Optional holding-period histogram. When empty, the proxy resolves to a single "
+            "aggregate lot at `default_holding_period_months_at_start`. When set, the live Plaid "
+            "value/basis is distributed across these buckets so short- vs long-term tax treatment "
+            "is modeled."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_holding_period_buckets(self) -> PlaidSp500ProxyGroupConfig:
+        buckets = self.holding_period_buckets
+        if not buckets:
+            return self
+        keys = [bucket.key for bucket in buckets]
+        if len(set(keys)) != len(keys):
+            raise ValueError(f"holding_period_buckets keys must be unique, got {keys}")
+        market_value_sum = sum(bucket.market_value_fraction for bucket in buckets)
+        if not math.isclose(market_value_sum, 1.0, abs_tol=1e-2):
+            raise ValueError(f"holding_period_buckets market_value_fraction must sum to ~1.0, got {market_value_sum}")
+        basis_specified = [bucket.cost_basis_fraction is not None for bucket in buckets]
+        if any(basis_specified) and not all(basis_specified):
+            raise ValueError("holding_period_buckets cost_basis_fraction must be set on all buckets or none")
+        if all(basis_specified):
+            basis_sum = sum(bucket.cost_basis_fraction for bucket in buckets if bucket.cost_basis_fraction is not None)
+            if not math.isclose(basis_sum, 1.0, abs_tol=1e-2):
+                raise ValueError(f"holding_period_buckets cost_basis_fraction must sum to ~1.0, got {basis_sum}")
+        return self
 
 
 class PlaidPortfolioSourceConfig(ApiModel):

--- a/augur/api/portfolio_sources.py
+++ b/augur/api/portfolio_sources.py
@@ -159,7 +159,6 @@ def _sp500_proxy_holding(
             group.position_id,
             sorted(missing_basis),
         )
-    unit_value_usd = float(group.unit_value_usd)
     return HoldingPositionConfig(
         position_id=group.position_id,
         account_id=group.portfolio_account_id,
@@ -167,16 +166,48 @@ def _sp500_proxy_holding(
         symbol=group.symbol,
         security_kind=group.security_kind,
         value_series=SP500AssetKey(),
-        unit_value_usd=unit_value_usd,
-        lots=(
+        unit_value_usd=float(group.unit_value_usd),
+        lots=_proxy_lots(group, total_value_usd=total_value_usd, total_cost_basis_usd=total_cost_basis_usd),
+    )
+
+
+def _proxy_lots(
+    group: PlaidSp500ProxyGroupConfig, *, total_value_usd: float, total_cost_basis_usd: float
+) -> tuple[HoldingTaxLotConfig, ...]:
+    unit_value_usd = float(group.unit_value_usd)
+    if not group.holding_period_buckets:
+        return (
             HoldingTaxLotConfig(
                 lot_id=f"{group.position_id}_plaid_aggregate",
                 holding_period_months_at_start=int(group.default_holding_period_months_at_start),
                 quantity=total_value_usd / unit_value_usd,
                 cost_basis_usd=total_cost_basis_usd,
             ),
-        ),
-    )
+        )
+    # Distribute the live Plaid aggregate across the calibrated holding-period buckets. Normalize by
+    # the configured fraction sums (validated to ~1.0) so the lot totals still equal the Plaid
+    # snapshot exactly despite rounding in the authored fractions.
+    buckets = group.holding_period_buckets
+    market_value_fraction_sum = sum(bucket.market_value_fraction for bucket in buckets)
+    basis_fractions = [bucket.cost_basis_fraction for bucket in buckets if bucket.cost_basis_fraction is not None]
+    basis_fraction_sum = sum(basis_fractions) if basis_fractions else market_value_fraction_sum
+    lots: list[HoldingTaxLotConfig] = []
+    for bucket in buckets:
+        market_value_weight = bucket.market_value_fraction / market_value_fraction_sum
+        basis_weight = (
+            bucket.cost_basis_fraction / basis_fraction_sum
+            if bucket.cost_basis_fraction is not None
+            else market_value_weight
+        )
+        lots.append(
+            HoldingTaxLotConfig(
+                lot_id=f"{group.position_id}_plaid_{bucket.key}",
+                holding_period_months_at_start=int(bucket.holding_period_months_at_start),
+                quantity=(total_value_usd * market_value_weight) / unit_value_usd,
+                cost_basis_usd=total_cost_basis_usd * basis_weight,
+            )
+        )
+    return tuple(lots)
 
 
 def _holding_value_usd(holding: CurrentHolding) -> float:

--- a/augur/api/portfolio_sources_test.py
+++ b/augur/api/portfolio_sources_test.py
@@ -4,11 +4,18 @@ from datetime import UTC, datetime
 
 import pytest
 import pytest_bazel
+from pydantic import ValidationError
 
 from augur.api.conftest import MinimalConfig
 from augur.api.finance import FinanceSnapshot
 from augur.api.portfolio import HoldingPositionConfig, HoldingTaxLotConfig, PortfolioAccountConfig, PortfolioConfig
-from augur.api.portfolio_source_config import FixedPortfolioSourceConfig, PlaidCashSourceConfig, PortfolioSourcesConfig
+from augur.api.portfolio_source_config import (
+    FixedPortfolioSourceConfig,
+    PlaidCashSourceConfig,
+    PlaidProxyHoldingPeriodBucket,
+    PlaidSp500ProxyGroupConfig,
+    PortfolioSourcesConfig,
+)
 from augur.api.portfolio_sources import resolve_portfolio_sources
 from augur.product.asset_key import SP500AssetKey
 from plaid_utils.read_model import CurrentCashBalance, CurrentHolding
@@ -172,6 +179,117 @@ def test_plaid_source_reuses_existing_portfolio_account(
 
     assert len(resolved.portfolio.accounts) == 1
     assert resolved.portfolio.holdings[0].total_cost_basis_usd == 0.0
+
+
+def test_plaid_source_expands_holding_period_buckets(
+    monkeypatch: pytest.MonkeyPatch, minimal_config: MinimalConfig, plaid_config: PortfolioSourcesConfig
+) -> None:
+    """A configured holding-period histogram splits the single live Plaid aggregate into per-band
+    lots (so short- vs long-term tax treatment is modeled), while preserving the aggregate value and
+    cost basis. Basis is split independently of market value so younger bands carry less embedded
+    gain."""
+    monkeypatch.setenv("AUGUR_PLAID_DATABASE_URL", "postgresql://example/plaidmcp")
+
+    async def fake_cash(**kwargs) -> tuple[CurrentCashBalance, ...]:
+        return ()
+
+    async def fake_holdings(**kwargs) -> tuple[CurrentHolding, ...]:
+        return (
+            CurrentHolding(
+                account_id="wealthfront_account",
+                account_name="Wealthfront",
+                institution_name="Wealthfront",
+                security_id="us-direct-indexing",
+                security_name="US Direct Indexing",
+                ticker_symbol="US.DIRECT.INDEXING",
+                security_type="equity",
+                captured_at=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+                quantity=1000.0,
+                cost_basis=600.0,
+                institution_price=1.0,
+                institution_value=1000.0,
+                iso_currency_code="USD",
+            ),
+        )
+
+    monkeypatch.setattr("augur.api.portfolio_sources.read_current_cash_balances", fake_cash)
+    monkeypatch.setattr("augur.api.portfolio_sources.read_current_holdings", fake_holdings)
+
+    [group] = plaid_config.plaid.sp500_proxy_groups
+    bucketed_group = group.model_copy(
+        update={
+            "holding_period_buckets": (
+                PlaidProxyHoldingPeriodBucket(
+                    key="lt12", holding_period_months_at_start=4, market_value_fraction=0.25, cost_basis_fraction=0.5
+                ),
+                PlaidProxyHoldingPeriodBucket(
+                    key="ltcore", holding_period_months_at_start=16, market_value_fraction=0.75, cost_basis_fraction=0.5
+                ),
+            )
+        }
+    )
+    source = plaid_config.model_copy(
+        update={
+            "plaid": plaid_config.plaid.model_copy(
+                update={"cash": PlaidCashSourceConfig(), "sp500_proxy_groups": (bucketed_group,)}
+            )
+        }
+    )
+
+    resolved = resolve_portfolio_sources(minimal_config(portfolio_sources=source))
+
+    [holding] = resolved.portfolio.holdings
+    assert holding.lots == (
+        HoldingTaxLotConfig(
+            lot_id="wealthfront_sp500_plaid_lt12",
+            holding_period_months_at_start=4,
+            quantity=0.25,
+            cost_basis_usd=300.0,
+        ),
+        HoldingTaxLotConfig(
+            lot_id="wealthfront_sp500_plaid_ltcore",
+            holding_period_months_at_start=16,
+            quantity=0.75,
+            cost_basis_usd=300.0,
+        ),
+    )
+    # The split preserves the live Plaid aggregate exactly.
+    assert holding.total_quantity == 1.0
+    assert holding.total_cost_basis_usd == 600.0
+
+
+def test_holding_period_buckets_market_value_fractions_must_sum_to_one() -> None:
+    with pytest.raises(ValidationError, match="market_value_fraction must sum"):
+        PlaidSp500ProxyGroupConfig(
+            position_id="wealthfront_sp500",
+            portfolio_account_id="wealthfront_taxable",
+            owner_agent_id="owner",
+            plaid_account_ids=("wealthfront_account",),
+            holding_period_buckets=(
+                PlaidProxyHoldingPeriodBucket(key="lt12", holding_period_months_at_start=4, market_value_fraction=0.25),
+                PlaidProxyHoldingPeriodBucket(
+                    key="ltcore", holding_period_months_at_start=16, market_value_fraction=0.25
+                ),
+            ),
+        )
+
+
+def test_holding_period_buckets_cost_basis_fraction_all_or_none() -> None:
+    with pytest.raises(ValidationError, match="cost_basis_fraction must be set on all buckets or none"):
+        PlaidSp500ProxyGroupConfig(
+            position_id="wealthfront_sp500",
+            portfolio_account_id="wealthfront_taxable",
+            owner_agent_id="owner",
+            plaid_account_ids=("wealthfront_account",),
+            holding_period_buckets=(
+                PlaidProxyHoldingPeriodBucket(
+                    key="lt12", holding_period_months_at_start=4, market_value_fraction=0.25, cost_basis_fraction=0.1
+                ),
+                PlaidProxyHoldingPeriodBucket(
+                    key="ltcore", holding_period_months_at_start=16, market_value_fraction=0.75
+                ),
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

A tax-loss-harvesting direct-indexing sleeve (e.g. Wealthfront's "S&P 500 Direct Portfolio") is reported to Plaid as a **single aggregate security** with no per-lot acquisition dates. So `_sp500_proxy_holding` collapsed the whole position to one lot at a flat `default_holding_period_months_at_start`, and liquidation tax was modeled as **entirely long-term** — even though a meaningful slice of such an account is short-term.

## What

Add an optional `holding_period_buckets` histogram to `PlaidSp500ProxyGroupConfig`:

- The live Plaid value and cost basis are still resolved at startup; the buckets only **distribute** them across calibrated holding-period bands.
- Each `PlaidProxyHoldingPeriodBucket` has a `key`, a representative `holding_period_months_at_start`, a `market_value_fraction`, and an optional `cost_basis_fraction` (independent of value, so younger bands can carry less embedded gain than an old deep-gain core).
- A model validator enforces unique keys and that the fractions sum to ~1.0 (basis fractions all-or-none). Fractions are normalized when applied, so the per-lot totals match the Plaid snapshot exactly despite authoring rounding.
- Empty `holding_period_buckets` preserves the prior single-aggregate-lot behavior (IBKR proxy unchanged).

The deployment-side calibration (Wealthfront's actual histogram, derived from its tax-lot export) lives in gaffer-private and depends on this change via a ducktape pin bump.

## Tests

`//augur/api:portfolio_sources_test` (new: bucketed expansion preserves the aggregate; two validator rejections) and `//augur/api:config_test` pass on RBE, lint included.

https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4)_