### PR TITLE
cluster/litellm: upgrade 1.82.1 → 1.86.3 (enable /responses→chat bridge)

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -42,7 +42,7 @@ spec:
                       - proxmox
       containers:
         - name: litellm
-          image: litellm/litellm:1.82.1
+          image: litellm/litellm:1.86.3
           args: ["--config", "/etc/litellm/config.yaml"]
           ports:
             - name: http


### PR DESCRIPTION
Upgrades litellm `1.82.1 → 1.86.3` so the `/responses → /chat/completions` bridge actually works for z.ai/GLM.

## Why

After #1835 merged (`use_chat_completions_api: true` on the glm-4.6 entry), I re-ran the smoke test against the live, rolled litellm pod. It **still** failed:

```
litellm.NotFoundError: ... {"status":404,"path":"/v4/responses"}. Received Model Group=glm-4.6
```

I confirmed the live `litellm-config` ConfigMap **does** contain `use_chat_completions_api: true`, and the running pod (`988d64c5d`, created after the merge) loaded it — yet `/v1/responses` still forwarded to z.ai's non-existent `/v4/responses`. The opt-in flag was only added to litellm after **1.82.1** (the feature request, [#23716](https://github.com/BerriAI/litellm/issues/23716), was opened 2026-03-16; current stable is 1.86.3/1.87.0), so the old image silently ignores it.

The model itself is fine — `litellm /v1/chat/completions` for `glm-4.6` works on 1.82.1 today (returns content + usage). Only the `/responses` bridge needed the newer version.

## Change

Bump `litellm/litellm:1.82.1` → `1.86.3`. The bridge flag is already in `proxy-config.yaml` (from #1835); this just runs a version that honors it.

## Risk / blast radius

litellm is a shared gateway, but right now little routes through it: props hits ollama directly (and ollama is down anyway — wyrm2 NotReady), and kagent/openhands call z.ai directly, not via litellm. So the practical blast radius is low, and the change is trivially revertible (restore the tag). I checked the deployment config is standard `model_list` (no schema features at risk across the bump).

## After merge

litellm rolls to 1.86.3; I'll re-run the `/v1/responses` glm-4.6 test to confirm it now bridges to chat and returns a Responses object with `usage.input_tokens`/`output_tokens` (props' logger shape). That completes end-to-end validation of `props → litellm → z.ai`.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_