### PR TITLE
cluster/props: set grader_model = glm-4.6 (default evaluator)

### DIFF
--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -1,6 +1,9 @@
 auto_migrate = true
 auto_sync_specimens = true
 backend_url = "http://props:8000"
+# Default evaluator: the grader supervisor auto-grades critic runs with this
+# model. glm-4.6 (z.ai via LiteLLM) so grading runs without the home GPU host.
+grader_model = "glm-4.6"
 
 [executor]
 type = "kubernetes"


### PR DESCRIPTION
Sets GLM-4.6 as the default evaluator (grader) model in props.

## Change

`grader_model = "glm-4.6"` in `cluster/k8s/props/app/config.toml`. It was unset, which **disables the grader supervisor** entirely (`app.py`: "Grader supervisor disabled (grader_model not set)"). Setting it starts the supervisor and makes it auto-grade with GLM-4.6.

## Why glm-4.6

GLM-4.6 runs via LiteLLM → z.ai (the path validated end-to-end in #1840), and grader agents only need the LLM (not local GPU). So **grading works even while the home GPU host (`wyrm2`) is down** — unlike an ollama-backed grader.

## Dependency

Grader agents pull the grader image from the props registry, so live grading depends on the `props-images` pipeline having pushed current agent images — which is exactly what I'm verifying in parallel (a live run is in flight). If those images are stale/absent, grader pods would fail to pull; the config itself is correct regardless.

Validated: `check-toml`, kustomize build, cluster pre-commit pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_