### PR TITLE
augur/sim: dict-gather id columns in decode (kill new_str hotspot)

### DIFF
--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -195,6 +195,25 @@ rows accumulated to tens of millions over 100 years), so the full pipeline now f
 Remaining lever for full `simulate()` at 10000 is lazy/opt-in decode (#5): the other
 state-history frames (cash, lots, …) are still materialized eagerly at O(months × R).
 
+## Results after the third pass (dict-encoded id columns)
+
+`new_str` — Polars building `pl.Utf8` columns from NumPy `object` arrays of Python `str` —
+was the dominant remaining decode cost (~60% of decode wall, spread across `decode_cash`,
+`decode_asset_lots`, `decode_liabilities`, `decode_obligations`, `decode_transfers`). The
+codec now carries id columns as a `CodeColumn` (integer codes + small category table) and
+materializes them with a single Arrow dict-gather instead of per-element `str`; the two
+`rollout_status` decoders are likewise vectorized (no Python `failed_month` loop, gather for
+the status string).
+
+500/1000-rollout, 1200-month decode (cProfile, relative): `new_str` 13.3 s → 0.7 s;
+`decode_obligations` 7.2 s → 0.9 s. Full `simulate()` at 1000 × 1200: **7.4 s → 5.1 s**
+(≈30% faster), output frames byte-identical (all sim + product + api tests pass).
+
+`#5` for the genuinely per-month frames (`cash`, `liabilities`, `ordinary_income`) is _not_
+safe to event-ize: unlike tax liabilities, they change every month and consumers query them
+at arbitrary months expecting forward-filled state. Their remaining decode cost is the row
+count itself (O(months × R)); the lever there is lazy/opt-in decode (#1), not event-izing.
+
 ## Note on parallelism
 
 Rollouts are independent, so beyond the above the R axis can be **chunked**

--- a/augur/sim/codec/assets.py
+++ b/augur/sim/codec/assets.py
@@ -11,6 +11,8 @@ from augur.model.series import IssuerId, PrivateEquityEventKindCode, PrivateEqui
 from augur.product.asset_key import PrivateEquityAssetKey
 from augur.sim.buffers import SimulationBuffers
 from augur.sim.codec.helpers import (
+    asset_code_column,
+    code_column,
     codes_to_asset_wire_ids,
     codes_to_strings,
     frame_from_columns,
@@ -28,14 +30,12 @@ def decode_cash(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.Data
     state = r_first_view(buffers.state.cash_state)  # (H+1, r, s)
     h1, r, s = state.shape
     months, rollouts, slots = state_axes(h1, r, s)
-    agent_ids = codes_to_strings(plan, plan.cash_agent_codes)
-    account_ids = codes_to_strings(plan, plan.cash_account_codes)
     return state_history_frame_from_columns(
         {
             "rollout_index": rollouts,
             "month_index": months,
-            "agent_id": agent_ids[slots],
-            "account_id": account_ids[slots],
+            "agent_id": code_column(plan, plan.cash_agent_codes[slots]),
+            "account_id": code_column(plan, plan.cash_account_codes[slots]),
             "balance_usd": state.reshape(-1),
         },
         CASH_BALANCES_FRAME,
@@ -50,10 +50,10 @@ def decode_asset_lots(plan: CompiledSimulation, buffers: SimulationBuffers) -> p
         {
             "rollout_index": rollouts,
             "month_index": months,
-            "lot_id": codes_to_strings(plan, plan.lot_id_codes)[slots],
-            "agent_id": codes_to_strings(plan, plan.lot_agent_codes)[slots],
-            "account_id": codes_to_strings(plan, plan.lot_account_codes)[slots],
-            "asset_id": codes_to_asset_wire_ids(plan, plan.lot_asset_codes)[slots],
+            "lot_id": code_column(plan, plan.lot_id_codes[slots]),
+            "agent_id": code_column(plan, plan.lot_agent_codes[slots]),
+            "account_id": code_column(plan, plan.lot_account_codes[slots]),
+            "asset_id": asset_code_column(plan, plan.lot_asset_codes[slots]),
             "purchase_month_index": plan.lot_purchase_month.astype(np.int64)[slots],
             "cost_basis_per_unit_usd": plan.lot_cost_basis_per_unit.astype(np.float64)[slots],
             "remaining_quantity": state.reshape(-1),

--- a/augur/sim/codec/helpers.py
+++ b/augur/sim/codec/helpers.py
@@ -8,12 +8,56 @@ match the event/state-frame schemas declared in `augur.sim.state` + `augur.sim.e
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any, cast
 
 import numpy as np
 import polars as pl
 
 from augur.sim.compiler import CompiledSimulation
+
+
+@dataclass(frozen=True)
+class CodeColumn:
+    """A string output column carried as integer codes + a (small) category table.
+
+    The frame builders materialize it via a single Arrow dict-gather (`categories[codes]`)
+    instead of constructing a `pl.Utf8` column from a NumPy `object` array of Python `str`
+    (the GIL-bound `new_str` path that dominated decode at scale). `codes < 0` → null.
+    """
+
+    codes: np.ndarray
+    categories: Sequence[str | None]
+
+
+def code_column(plan: CompiledSimulation, codes: np.ndarray) -> CodeColumn:
+    """A `CodeColumn` for ids interned in `plan.strings` (agents, accounts, lots, causes, …)."""
+    return CodeColumn(codes=codes, categories=plan.strings)
+
+
+def asset_code_column(plan: CompiledSimulation, codes: np.ndarray) -> CodeColumn:
+    """A `CodeColumn` mapping asset codes to their wire ids (the frontend's `asset_id`)."""
+    return CodeColumn(codes=codes, categories=[asset.wire_id for asset in plan.assets])
+
+
+def _gather_str(name: str, column: CodeColumn) -> pl.Series:
+    # Prepend a null category so code -1 (NO_CODE) maps to null after the +1 shift; clamp any
+    # other negative code to that null slot too.
+    categories = pl.Series("", [None, *column.categories], dtype=pl.Utf8())
+    codes = np.asarray(column.codes, dtype=np.int64)
+    indices = np.where(codes < 0, -1, codes) + 1
+    return categories.gather(indices).rename(name)
+
+
+def _columns_to_polars(columns: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: (_gather_str(name, value) if isinstance(value, CodeColumn) else value) for name, value in columns.items()
+    }
+
+
+def _column_size(value: Any) -> int:
+    return value.codes.size if isinstance(value, CodeColumn) else value.size
 
 
 def text(plan: CompiledSimulation, code: int) -> str | None:
@@ -74,7 +118,7 @@ def state_axes(h1: int, r: int, s: int) -> tuple[np.ndarray, np.ndarray, np.ndar
     return months, rollouts, slots
 
 
-def state_history_frame_from_columns(columns: dict[str, np.ndarray], spec: Any) -> pl.DataFrame:
+def state_history_frame_from_columns(columns: dict[str, Any], spec: Any) -> pl.DataFrame:
     """Build a state-history frame from pre-built numpy column arrays. State-history specs
     don't carry `month_index` in their schema (the cross-section is one month wide); decode
     adds month_index in front of every column the spec declares, so this helper threads
@@ -88,20 +132,20 @@ def state_history_frame_from_columns(columns: dict[str, np.ndarray], spec: Any) 
             **{name: dtype for name, dtype in spec.schema.items() if name != "rollout_index"},
         }
     )
-    n = next(iter(columns.values())).size
+    n = _column_size(next(iter(columns.values())))
     if n == 0:
         return state_schema.to_frame()
-    return pl.DataFrame(columns, schema=state_schema).select(list(state_schema.names()))
+    return pl.DataFrame(_columns_to_polars(columns), schema=state_schema).select(list(state_schema.names()))
 
 
-def frame_from_columns(spec: Any, **columns: np.ndarray) -> pl.DataFrame:
+def frame_from_columns(spec: Any, **columns: Any) -> pl.DataFrame:
     """Materialize an event frame from numpy column arrays. Empty input produces a
     correctly-typed empty frame matching the spec's schema. Polars cast/infer is driven by
     `spec.schema` so object-dtype numpy arrays of Python strings become `pl.Utf8` (rather
     than `pl.Object`, which breaks downstream concat between dense and empty frames)."""
 
-    n = next(iter(columns.values())).size
+    n = _column_size(next(iter(columns.values())))
     if n == 0:
         return cast(pl.DataFrame, spec.empty())
-    df: pl.DataFrame = pl.DataFrame(columns, schema=spec.schema)
+    df: pl.DataFrame = pl.DataFrame(_columns_to_polars(columns), schema=spec.schema)
     return cast(pl.DataFrame, df.select(spec.schema.names()))

--- a/augur/sim/codec/liabilities.py
+++ b/augur/sim/codec/liabilities.py
@@ -9,6 +9,7 @@ import polars as pl
 
 from augur.sim.buffers import SimulationBuffers
 from augur.sim.codec.helpers import (
+    code_column,
     codes_to_strings,
     frame_from_columns,
     r_first_view,
@@ -26,27 +27,24 @@ def decode_liabilities(plan: CompiledSimulation, buffers: SimulationBuffers) -> 
     h1, r, n_liab = principal.shape
     months, rollouts, liabs = state_axes(h1, r, n_liab)
     mask = active.reshape(-1)
-    liability_ids = codes_to_strings(plan, plan.liabilities.codes)
-    agent_ids = codes_to_strings(plan, plan.liabilities.agent)
-    payment_account_ids = codes_to_strings(plan, plan.liabilities.payment_account)
-    counterparty_agent_ids = codes_to_strings(plan, plan.liabilities.counterparty_agent)
-    counterparty_account_ids = codes_to_strings(plan, plan.liabilities.counterparty_account)
-    property_ids_per_liab = codes_to_strings(plan, plan.properties.id)[plan.liabilities.property_slot.astype(np.int64)]
-    origination_per_liab = plan.properties.month.astype(np.int64)[plan.liabilities.property_slot.astype(np.int64)]
+    liab_idx = liabs[mask]
+    property_slot = plan.liabilities.property_slot.astype(np.int64)
+    property_id_codes = plan.properties.id[property_slot]
+    origination_per_liab = plan.properties.month.astype(np.int64)[property_slot]
     return state_history_frame_from_columns(
         {
             "rollout_index": rollouts[mask],
             "month_index": months[mask],
-            "liability_id": liability_ids[liabs[mask]],
-            "agent_id": agent_ids[liabs[mask]],
-            "payment_account_id": payment_account_ids[liabs[mask]],
-            "counterparty_agent_id": counterparty_agent_ids[liabs[mask]],
-            "counterparty_account_id": counterparty_account_ids[liabs[mask]],
-            "property_id": property_ids_per_liab[liabs[mask]],
+            "liability_id": code_column(plan, plan.liabilities.codes[liab_idx]),
+            "agent_id": code_column(plan, plan.liabilities.agent[liab_idx]),
+            "payment_account_id": code_column(plan, plan.liabilities.payment_account[liab_idx]),
+            "counterparty_agent_id": code_column(plan, plan.liabilities.counterparty_agent[liab_idx]),
+            "counterparty_account_id": code_column(plan, plan.liabilities.counterparty_account[liab_idx]),
+            "property_id": code_column(plan, property_id_codes[liab_idx]),
             "principal_usd": principal.reshape(-1)[mask],
-            "annual_interest_rate": plan.liabilities.annual_rate.astype(np.float64)[liabs[mask]],
-            "term_months": plan.liabilities.term_months.astype(np.int64)[liabs[mask]],
-            "origination_month_index": origination_per_liab[liabs[mask]],
+            "annual_interest_rate": plan.liabilities.annual_rate.astype(np.float64)[liab_idx],
+            "term_months": plan.liabilities.term_months.astype(np.int64)[liab_idx],
+            "origination_month_index": origination_per_liab[liab_idx],
             "monthly_payment_usd": buffers.state.liability_monthly_payment_state.reshape(-1)[mask],
             "interest_paid_ytd_usd": buffers.state.liability_interest_ytd_state.reshape(-1)[mask],
             "principal_paid_ytd_usd": buffers.state.liability_principal_ytd_state.reshape(-1)[mask],

--- a/augur/sim/codec/obligations.py
+++ b/augur/sim/codec/obligations.py
@@ -8,7 +8,7 @@ import numpy as np
 import polars as pl
 
 from augur.sim.buffers import SimulationBuffers
-from augur.sim.codec.helpers import codes_to_strings, frame_from_columns
+from augur.sim.codec.helpers import code_column, codes_to_strings, frame_from_columns
 from augur.sim.compiler import CompiledSimulation
 from augur.sim.events import EVENT_FRAMES
 
@@ -27,13 +27,14 @@ def decode_obligations(
         months, slots, rollouts = np.argwhere(active).T
     else:
         months = slots = rollouts = np.array([], dtype=np.int64)
-    cause_ids = codes_to_strings(plan, plan.obligations.cause)[months, slots]
-    obligation_ids = codes_to_strings(plan, plan.obligations.id)[months, slots]
-    obligation_types = codes_to_strings(plan, plan.obligations.type)[months, slots]
-    agent_ids = codes_to_strings(plan, plan.obligations.agent)[months, slots]
-    from_account_ids = codes_to_strings(plan, plan.obligations.from_account)[months, slots]
-    to_agent_ids = codes_to_strings(plan, plan.obligations.to_agent)[months, slots]
-    to_account_ids = codes_to_strings(plan, plan.obligations.to_account)[months, slots]
+    # Per-event integer code arrays (lifted to strings lazily via CodeColumn dict-gather).
+    cause_codes = plan.obligations.cause[months, slots]
+    obligation_id_codes = plan.obligations.id[months, slots]
+    type_codes = plan.obligations.type[months, slots]
+    agent_codes = plan.obligations.agent[months, slots]
+    from_account_codes = plan.obligations.from_account[months, slots]
+    to_agent_codes = plan.obligations.to_agent[months, slots]
+    to_account_codes = plan.obligations.to_account[months, slots]
     amount_due = buffers.obligations.due[months, slots, rollouts]
     amount_paid = buffers.obligations.paid[months, slots, rollouts]
     shortfall = buffers.obligations.shortfall[months, slots, rollouts]
@@ -44,24 +45,24 @@ def decode_obligations(
         EVENT_FRAMES.obligation_accruals,
         rollout_index=rollouts,
         month_index=months,
-        cause_id=cause_ids,
-        obligation_id=obligation_ids,
-        obligation_type=obligation_types,
-        agent_id=agent_ids,
-        from_account_id=from_account_ids,
-        to_agent_id=to_agent_ids,
-        to_account_id=to_account_ids,
+        cause_id=code_column(plan, cause_codes),
+        obligation_id=code_column(plan, obligation_id_codes),
+        obligation_type=code_column(plan, type_codes),
+        agent_id=code_column(plan, agent_codes),
+        from_account_id=code_column(plan, from_account_codes),
+        to_agent_id=code_column(plan, to_agent_codes),
+        to_account_id=code_column(plan, to_account_codes),
         amount_due_usd=amount_due,
     )
     settlements = frame_from_columns(
         EVENT_FRAMES.obligation_settlements,
         rollout_index=rollouts,
         month_index=months,
-        cause_id=cause_ids,
-        obligation_id=obligation_ids,
-        obligation_type=obligation_types,
-        agent_id=agent_ids,
-        from_account_id=from_account_ids,
+        cause_id=code_column(plan, cause_codes),
+        obligation_id=code_column(plan, obligation_id_codes),
+        obligation_type=code_column(plan, type_codes),
+        agent_id=code_column(plan, agent_codes),
+        from_account_id=code_column(plan, from_account_codes),
         amount_due_usd=amount_due,
         amount_paid_usd=amount_paid,
         shortfall_usd=shortfall,
@@ -74,11 +75,11 @@ def decode_obligations(
             EVENT_FRAMES.transfers,
             rollout_index=rollouts[paid_mask],
             month_index=months[paid_mask],
-            cause_id=cause_ids[paid_mask],
-            from_agent_id=agent_ids[paid_mask],
-            from_account_id=from_account_ids[paid_mask],
-            to_agent_id=to_agent_ids[paid_mask],
-            to_account_id=to_account_ids[paid_mask],
+            cause_id=code_column(plan, cause_codes[paid_mask]),
+            from_agent_id=code_column(plan, agent_codes[paid_mask]),
+            from_account_id=code_column(plan, from_account_codes[paid_mask]),
+            to_agent_id=code_column(plan, to_agent_codes[paid_mask]),
+            to_account_id=code_column(plan, to_account_codes[paid_mask]),
             amount_usd=amount_paid[paid_mask],
             income_category=np.full(int(paid_mask.sum()), None, dtype=object),
         )
@@ -87,16 +88,17 @@ def decode_obligations(
     # Subset 2: obligations whose failure flag fired emit a failure row.
     failure_mask = buffers.obligations.failure_active[months, slots, rollouts]
     if failure_mask.any():
-        failure_cause_ids = np.array([f"{oid}_failure" for oid in obligation_ids[failure_mask]], dtype=object)
+        failed_obligation_ids = codes_to_strings(plan, obligation_id_codes[failure_mask])
+        failure_cause_ids = np.array([f"{oid}_failure" for oid in failed_obligation_ids], dtype=object)
         failures = frame_from_columns(
             EVENT_FRAMES.rollout_failures,
             rollout_index=rollouts[failure_mask],
             month_index=months[failure_mask],
             cause_id=failure_cause_ids,
-            agent_id=agent_ids[failure_mask],
+            agent_id=code_column(plan, agent_codes[failure_mask]),
             deficit_usd=shortfall[failure_mask],
-            obligation_id=obligation_ids[failure_mask],
-            obligation_type=obligation_types[failure_mask],
+            obligation_id=code_column(plan, obligation_id_codes[failure_mask]),
+            obligation_type=code_column(plan, type_codes[failure_mask]),
             amount_due_usd=amount_due[failure_mask],
             amount_paid_usd=amount_paid[failure_mask],
             shortfall_usd=shortfall[failure_mask],

--- a/augur/sim/codec/plan.py
+++ b/augur/sim/codec/plan.py
@@ -126,41 +126,49 @@ def decode_events(plan: CompiledSimulation, buffers: SimulationBuffers) -> Event
     )
 
 
+# Status categories indexed by the rollout's `failed` flag (0 = active, 1 = failed).
+_ROLLOUT_STATUS_CATEGORIES = pl.Series("status", ["active", "failed_insufficient_cash"], dtype=pl.Utf8())
+
+
+def _status_series(failed: np.ndarray) -> pl.Series:
+    """Vectorized `failed`-flag → status string via Arrow take (avoids per-element `new_str`)."""
+    return _ROLLOUT_STATUS_CATEGORIES.gather(failed.astype(np.int64)).rename("status")
+
+
+def _failed_month_series(failed_month: np.ndarray) -> pl.Series:
+    """`failed_month` int array → Int64 column with NO_CODE (-1) mapped to null, no Python loop."""
+    values = failed_month.astype(np.int64)
+    return pl.Series("failed_month", values).set(pl.Series(values < 0), None)
+
+
 def decode_rollout_status_history(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.DataFrame:
     failed_state = buffers.state.rollout_failed_state  # (H+1, r) bool
-    failed_month_state = buffers.state.rollout_failed_month_state.astype(np.int64)  # (H+1, r) int
+    failed_month_state = buffers.state.rollout_failed_month_state  # (H+1, r) int
     h1, r = failed_state.shape
     months = np.broadcast_to(np.arange(h1, dtype=np.int64)[:, None], (h1, r)).ravel()
     rollouts = np.broadcast_to(np.arange(r, dtype=np.int64)[None, :], (h1, r)).ravel()
-    status = np.where(failed_state.reshape(-1), "failed_insufficient_cash", "active")
-    failed_month_flat = failed_month_state.reshape(-1)
-    # Polars rejects an object-dtype column for an Int64 schema; build the int|None list explicitly.
-    # `h1*r` is small (≤ horizon × rollout_count) so the Python loop is fine.
-    failed_month_col = [None if m < 0 else int(m) for m in failed_month_flat]
     return pl.DataFrame(
-        {"rollout_index": rollouts, "month_index": months, "status": status, "failed_month": failed_month_col},
-        schema={
-            "rollout_index": pl.Int64(),
-            "month_index": pl.Int64(),
-            "status": pl.Utf8(),
-            "failed_month": pl.Int64(),
-        },
+        {
+            "rollout_index": rollouts,
+            "month_index": months,
+            "status": _status_series(failed_state.reshape(-1)),
+            "failed_month": _failed_month_series(failed_month_state.reshape(-1)),
+        }
     )
 
 
 def decode_final_rollout_status(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.DataFrame:
     month = plan.horizon_months
     failed = buffers.state.rollout_failed_state[month]  # (r,) bool
-    failed_month = buffers.state.rollout_failed_month_state[month].astype(np.int64)  # (r,) int
     r = failed.shape[0]
     if r == 0:
         return ROLLOUT_STATUS_FRAME.empty()
-    rollouts = np.arange(r, dtype=np.int64)
-    status = np.where(failed, "failed_insufficient_cash", "active")
-    failed_month_col = [None if m < 0 else int(m) for m in failed_month]
     return ROLLOUT_STATUS_FRAME.normalize(
         pl.DataFrame(
-            {"rollout_index": rollouts, "status": status, "failed_month": failed_month_col},
-            schema={"rollout_index": pl.Int64(), "status": pl.Utf8(), "failed_month": pl.Int64()},
+            {
+                "rollout_index": np.arange(r, dtype=np.int64),
+                "status": _status_series(failed),
+                "failed_month": _failed_month_series(buffers.state.rollout_failed_month_state[month]),
+            }
         )
     )

--- a/augur/sim/codec/transfers.py
+++ b/augur/sim/codec/transfers.py
@@ -7,7 +7,7 @@ import numpy as np
 import polars as pl
 
 from augur.sim.buffers import SimulationBuffers
-from augur.sim.codec.helpers import codes_to_strings, frame_from_columns
+from augur.sim.codec.helpers import code_column, frame_from_columns
 from augur.sim.compiler import CompiledSimulation
 from augur.sim.events import EVENT_FRAMES
 
@@ -15,11 +15,6 @@ from augur.sim.events import EVENT_FRAMES
 def decode_transfers(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl.DataFrame:
     active = buffers.transfers.active  # (M, S, R)
     months, slots, rollouts = np.argwhere(active).T if active.any() else (np.array([], dtype=np.int64),) * 3
-    cause_ids = codes_to_strings(plan, plan.transfers.cause)[months, slots]
-    from_agents = codes_to_strings(plan, plan.transfers.from_agent)[months, slots]
-    from_accounts = codes_to_strings(plan, plan.transfers.from_account)[months, slots]
-    to_agents = codes_to_strings(plan, plan.transfers.to_agent)[months, slots]
-    to_accounts = codes_to_strings(plan, plan.transfers.to_account)[months, slots]
     amounts = buffers.transfers.amount[months, slots, rollouts]
     income_categories = np.full(len(months), None, dtype=object)
     income_categories[plan.transfers.income_profile[months, slots] >= 0] = "ordinary"
@@ -27,11 +22,11 @@ def decode_transfers(plan: CompiledSimulation, buffers: SimulationBuffers) -> pl
         EVENT_FRAMES.transfers,
         rollout_index=rollouts,
         month_index=months,
-        cause_id=cause_ids,
-        from_agent_id=from_agents,
-        from_account_id=from_accounts,
-        to_agent_id=to_agents,
-        to_account_id=to_accounts,
+        cause_id=code_column(plan, plan.transfers.cause[months, slots]),
+        from_agent_id=code_column(plan, plan.transfers.from_agent[months, slots]),
+        from_account_id=code_column(plan, plan.transfers.from_account[months, slots]),
+        to_agent_id=code_column(plan, plan.transfers.to_agent[months, slots]),
+        to_account_id=code_column(plan, plan.transfers.to_account[months, slots]),
         amount_usd=amounts,
         income_category=income_categories,
     )


### PR DESCRIPTION
## Context

Re-profiled on `devel` after the event-based tax-liability merge (#1837). The bottleneck had shifted entirely to the **decode boundary** (~77–90% of wall time; the month loop is ~1.7s). Within decode, the dominant cost was **`new_str`** — Polars building `pl.Utf8` columns from NumPy `object` arrays of Python `str` (the GIL-bound per-element path) — and the heaviest single decoder was `decode_obligations` (whose cost *was* `new_str` on its 7 string columns).

This implements items **#2 (dict-encode id columns)** and **#3 (vectorize `decode_obligations`)** from the updated top-10 — they collapse into one fix.

## Change

- New `CodeColumn` (int codes + small category table) in the codec helpers; the frame builders (`frame_from_columns`, `state_history_frame_from_columns`) materialize it with a single **Arrow dict-gather** (`categories[codes]`) instead of constructing Utf8 from a Python `object` array. `codes < 0` → null.
- Routed the id columns of the hot decoders through it: `decode_cash`, `decode_asset_lots`, `decode_liabilities`, `decode_obligations` (incl. the derived-transfer + failure subsets), `decode_transfers`.
- Vectorized `decode_rollout_status_history` / `decode_final_rollout_status`: gather for the status string and a vectorized `failed_month` (dropping a Python loop over `months × R`).

Output frames are **byte-identical** (same Utf8 columns, same values/order) — no schema/contract change.

## Results (1200-month horizon)

cProfile, 1000 × 1200: `new_str` **13.3s → 0.7s**; `decode_obligations` **7.2s → 0.9s**.
Full `simulate()` wall: **7.4s → 5.1s (~30% faster)**.

## Test

`bazel test //augur/sim/...` (10), `//augur/product/...` + `//augur/api/...` (10) — all pass; lint (ruff + mypy) clean.

## Note on #5

For the genuinely per-month frames (`cash`, `liabilities`, `ordinary_income`), event-izing like tax liabilities is **not** safe: they change every month and consumers query them at arbitrary months expecting forward-filled state (the tests filter at months 1, 3, 6, 9, 13, 24…). This PR removes their dominant cost (the string columns); the residual is the O(months × R) row count itself, whose lever is lazy/opt-in decode (#1) — a separate change. Details in `augur/debug/rollout_perf_profiling.md`.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_