### PR TITLE
augur: apply ruff-format + prettier formatting

### DIFF
--- a/augur/api/portfolio_sources_test.py
+++ b/augur/api/portfolio_sources_test.py
@@ -241,10 +241,7 @@ def test_plaid_source_expands_holding_period_buckets(
     [holding] = resolved.portfolio.holdings
     assert holding.lots == (
         HoldingTaxLotConfig(
-            lot_id="wealthfront_sp500_plaid_lt12",
-            holding_period_months_at_start=4,
-            quantity=0.25,
-            cost_basis_usd=300.0,
+            lot_id="wealthfront_sp500_plaid_lt12", holding_period_months_at_start=4, quantity=0.25, cost_basis_usd=300.0
         ),
         HoldingTaxLotConfig(
             lot_id="wealthfront_sp500_plaid_ltcore",

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -91,8 +91,7 @@ def create_app(config: ApiServerConfig) -> FastAPI:
     settings = build_settings(augur_config)
     loaded_calibration = config.calibration_catalog
     calibration_info = build_calibration_info(
-        loaded_calibration.catalog if loaded_calibration is not None else None,
-        augur_config.calibration_catalog,
+        loaded_calibration.catalog if loaded_calibration is not None else None, augur_config.calibration_catalog
     )
     deployment_info = build_deployment_info()
     product_service = ProductService(

--- a/augur/calibration/calibration.py
+++ b/augur/calibration/calibration.py
@@ -398,9 +398,7 @@ def build_anchored_level_paths(
             )
         anchor_map[key] = anchors[key.wire_id]
     anchored = anchor_sampled_series_levels(sampled, level_series_anchors=anchor_map) if anchor_map else sampled
-    return {
-        key: anchored.level_matrix(key, rollout_count=rollout_count, horizon_months=horizon_months) for key in keys
-    }
+    return {key: anchored.level_matrix(key, rollout_count=rollout_count, horizon_months=horizon_months) for key in keys}
 
 
 def _augur_context(

--- a/augur/calibration/calibration_report.py
+++ b/augur/calibration/calibration_report.py
@@ -116,7 +116,11 @@ def main(argv: list[str] | None = None) -> int:
     fan_months = [0, 6, 12, 24, 60, 120]
     for issuer in emit_issuers:
         mark_pct = mark_fan(
-            bundle, issuer=issuer, rollout_count=args.rollouts, horizon_months=args.horizon, percentiles=(5.0, 50.0, 95.0)
+            bundle,
+            issuer=issuer,
+            rollout_count=args.rollouts,
+            horizon_months=args.horizon,
+            percentiles=(5.0, 50.0, 95.0),
         )
         mark_rows = [
             [m, f"${b.values['5.0']:.0f}", f"${b.values['50.0']:.0f}", f"${b.values['95.0']:.0f}"]

--- a/augur/calibration/catalog.py
+++ b/augur/calibration/catalog.py
@@ -329,6 +329,8 @@ class MarketCatalog(BaseModel):
 
     def referenced_issuers(self) -> set[str]:
         """Every PE issuer the catalog's exact PE markets score (and correlate signals reference)."""
-        issuers = {market.mapping.issuer for market in self.exact_markets() if isinstance(market.mapping, PeEventMapping)}
+        issuers = {
+            market.mapping.issuer for market in self.exact_markets() if isinstance(market.mapping, PeEventMapping)
+        }
         issuers |= {market.issuer for market in self.markets if isinstance(market, CorrelateMarket) and market.issuer}
         return issuers

--- a/augur/calibration/test_calibration.py
+++ b/augur/calibration/test_calibration.py
@@ -108,11 +108,7 @@ def _run(model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[
     seeds = tuple(range(4))
     bundle = sample_private_equity_bundle(model, issuer=_ISSUER, horizon_months=_HORIZON, rollout_seeds=seeds)
     return run_calibration(
-        catalog,
-        horizon_months=_HORIZON,
-        rollout_seeds=seeds,
-        price_clients=price_clients,
-        bundle=bundle,
+        catalog, horizon_months=_HORIZON, rollout_seeds=seeds, price_clients=price_clients, bundle=bundle
     )
 
 
@@ -389,7 +385,9 @@ def test_none_probability_and_degenerate_family_are_dropped(macro_model: Constan
         rollout_count=4,
         horizon_months=_HORIZON,
     )
-    clients: dict[Platform, PriceClient] = {Platform.POLYMARKET: _ProbClient({"NOPRICE": None, "Z-LO": 0.0, "Z-HI": 0.0})}
+    clients: dict[Platform, PriceClient] = {
+        Platform.POLYMARKET: _ProbClient({"NOPRICE": None, "Z-LO": 0.0, "Z-HI": 0.0})
+    }
     result = run_calibration(
         catalog,
         horizon_months=_HORIZON,

--- a/augur/frontend/calibration.tsx
+++ b/augur/frontend/calibration.tsx
@@ -411,7 +411,9 @@ function CategoricalPanel({ families }) {
                   </div>
                 </div>
               </div>
-              <div className={`shrink-0 text-right text-sm ${klTextClass(family.klBits)}`}>{fmtBits(family.klBits)}</div>
+              <div className={`shrink-0 text-right text-sm ${klTextClass(family.klBits)}`}>
+                {fmtBits(family.klBits)}
+              </div>
             </div>
             <table className="mt-2 min-w-full text-sm">
               <thead>

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -206,9 +206,7 @@ class ProductService:
             full_failed_month = failed_month_index_for_rollout(cached.dense)
             # Months are 0-based (0..horizon-1); a failure at/after the requested horizon is outside it.
             in_window = full_failed_month is not None and full_failed_month < horizon_months
-            terminal = terminal_metrics_from_arrays(
-                arrays, failed_month_index=full_failed_month if in_window else None
-            )
+            terminal = terminal_metrics_from_arrays(arrays, failed_month_index=full_failed_month if in_window else None)
             decoded.append(
                 _DecodedRollout(seed=seed, monthly_metric_arrays=arrays, terminal_metrics=terminal, cached=cached)
             )

--- a/augur/product/service_test.py
+++ b/augur/product/service_test.py
@@ -172,9 +172,7 @@ def test_metric_fan_truncates_one_cached_max_horizon_rollout(
     assert one(short.terminal_metric_percentiles["value"]) == pytest.approx(short_by_month[2])
 
 
-def test_metric_fan_rejects_horizon_above_server_max(
-    product: service.ProductService, augur_config: Config
-) -> None:
+def test_metric_fan_rejects_horizon_above_server_max(product: service.ProductService, augur_config: Config) -> None:
     request = MetricFanRequest(
         scenario=ScenarioKey(
             model_id="current_model",


### PR DESCRIPTION
PRs #1830 and #1841 merged unformatted augur code, leaving pre-commit
(ruff-format + prettier) red on devel. Reformat the affected files to
restore green. Changes are AST-preserving line-wrapping only.

BAZEL_TEST_INVOCATIONS=buildbuddy:3e5b710a-e307-4068-8e50-68d43685b39a

https://claude.ai/code/session_018eZpHfag68YjBiUzzAu1H9