### PR TITLE
augur/sim: capital-loss netting + carryforward (TLH Piece 1)

### DIFF
--- a/augur/plans/tax_loss_harvesting.md
+++ b/augur/plans/tax_loss_harvesting.md
@@ -1,0 +1,105 @@
+# Tax-loss harvesting (TLH) in Augur
+
+Status: 2026-06-04. Piece 1 (capital-loss netting + carryforward) in progress;
+Piece 2 (harvest process) designed, not started.
+
+## Motivation
+
+A tax-loss-harvesting direct-indexing account (the deployment's Wealthfront
+"S&P 500 Direct Portfolio") tracks an index on a pre-tax basis but continually
+realizes capital losses by selling individual constituents that have fallen
+below basis and rebuying correlated replacements. Those realized losses offset
+gains elsewhere, shelter up to $3,000/yr of ordinary income, and carry forward.
+This "tax alpha" is the entire economic reason to hold direct indexing over an
+index ETF, and Augur currently models **none** of it.
+
+Ground-truth evidence (private, see `gaffer-private/gaffer_augur/wealthfront/`):
+TY2025 1099-B for the live account shows ~$73k net realized loss, ~5%/yr of
+portfolio value, **essentially all short-term**, with **zero wash sales**.
+
+## What already shipped
+
+`PlaidSp500ProxyGroupConfig.holding_period_buckets` (ducktape #1839) splits the
+Plaid-fed aggregate sleeve into holding-period bands with independent value and
+basis fractions. This fixed the **static** picture — liquidation/sale tax now
+realizes a realistic short-/long-term mix instead of treating the whole sleeve
+as one long-term lot. It does **not** model ongoing harvesting.
+
+## The modeling spectrum (and what to avoid)
+
+Generating harvestable losses requires cross-sectional dispersion among the
+underlying names. A single SP500 series has none, so options range from cheap to
+expensive:
+
+1. **Single index series (today).** Zero dispersion → zero harvest. Wrong.
+2. **Reduced-form harvest yield (chosen).** Do not simulate constituents. Emit a
+   realized loss each period as a calibrated function of the index path Augur
+   already samples. One series in, a loss number out.
+3. **Few-sleeve lightweight dispersion.** ~5–10 representative sleeves =
+   index factor + scaled idiosyncratic noise; run real FIFO harvesting on them.
+   Emergent harvesting, still inside the existing lot machinery.
+4. **Full factor model.** Hundreds of names with a covariance/factor structure,
+   per-name idiosyncratic vol, rebalancing, wash-sale tracking. **Avoid.** This
+   is whole-market modeling: it forces a correlation structure into Augur's
+   exogenous engine (which samples series independently today) and a large
+   surface of *unobservable* parameters to reproduce a quantity we can measure
+   directly from the 1099-B. Mechanistic fidelity we cannot calibrate is worse
+   than a simple form we can.
+
+Decision: build #2 now. Keep #3 as the documented upgrade path if a decision
+ever turns on harvesting behavior in a regime unlike the calibration window.
+Never build #4.
+
+## Piece 1 — capital-loss netting + carryforward (prerequisite, not TLH-specific)
+
+Today the bracket walks (`augur/sim/tax.py`) clamp negative taxable amounts to
+zero and no cross-year capital state exists, so any realized loss simply
+evaporates. Standard §1211/§1212 mechanics are required before harvesting can
+mean anything — and they also fix correctness for existing OpenAI/IBKR sales:
+
+- Net realized losses against realized gains within ST and LT, then across the
+  two categories (net ST loss offsets net LT gain and vice versa).
+- Apply up to **$3,000/yr** of net capital loss against ordinary income.
+- Carry the remainder forward as a per-`(rollout, agent)` scalar that reduces
+  next years' net capital gain (and, while positive, keeps feeding the $3k
+  ordinary offset).
+
+This is bookkeeping over the realized-gain frames the sim already produces —
+vectorized scalars per `(rollout, year)`, no market modeling. It is independently
+useful and lands first.
+
+## Piece 2 — reduced-form harvest process (the actual TLH)
+
+Attach an optional harvest process to a holding. Each tax period:
+
+- **Driver:** harvest yield is a function of the period's index return
+  (drawdowns harvest more) and the position's **embedded-gain ratio**
+  (basis/MV — as it rises, fewer lots sit below basis, so yield decays). 2–3
+  params; optionally realized volatility.
+- **Form:** `gross_harvest_t ≈ MV_t · g(return_t, embedded_gain_ratio_t)`, with
+  `g` rising in drawdowns and decaying toward a floor as embedded gain grows.
+  Split output into ST/LT (mostly ST early; seed from the holding-period
+  buckets).
+- **Basis feedback (the one real state element):** harvesting realizes a loss
+  *and* resets that slice's basis to current market (sell-underwater + rebuy).
+  So the process (a) books the loss into Piece 1, and (b) lowers the position's
+  tracked cost basis, which raises the embedded-gain ratio and **decays future
+  yield**. A scalar basis update per position — no per-stock state.
+- **No wash-sale gate needed:** TY2025 had zero wash sales (replacement-buying
+  works), so gross index exposure stays continuous and the realized-loss output
+  is unaffected.
+
+### Calibration
+
+- Level + ST/LT mix anchored to the TY2025 1099-B (~5%/yr net, all ST).
+- The **decay rate** (yield vs account maturity) is the one genuinely unknown
+  parameter. Needs prior-year 1099-Bs (TY2022–24) to fit. Until then, mark it
+  `[HEURISTIC]` and keep it conservative — a flat 5%/yr extrapolated 10 years
+  would massively overstate the benefit.
+- Generic process + calibration *schema* live in ducktape; the account's fitted
+  numbers live in `gaffer-private/gaffer_augur/wealthfront/`.
+
+## Open inputs
+
+- Prior-year 1099-Bs (TY2022–24) for the decay term.
+- Confirmation the sleeve tracks the S&P 500 and dividend-reinvestment handling.

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -269,6 +269,7 @@ py_library(
         ":external_series",
         ":runtime",
         ":scenario",
+        ":tax",
         ":tensor_fifo",
         "//augur/model:series",
         "@pypi//numpy",

--- a/augur/sim/TODO.md
+++ b/augur/sim/TODO.md
@@ -6,6 +6,13 @@ Anything fully shipped is removed — git history is the record of done work.
 
 ## Architecture / cutover
 
+- **Capital-loss netting + carryforward (TLH Piece 1).** The bracket walks in
+  `tax.py` clamp negative taxable amounts to zero and no cross-year capital
+  state exists, so realized losses evaporate. Add §1211/§1212 mechanics:
+  net ST/LT losses against gains, $3k/yr ordinary offset, per-`(rollout, agent)`
+  carryforward. Prerequisite for tax-loss-harvesting modeling and a correctness
+  fix for existing OpenAI/IBKR sales. See <plans/tax_loss_harvesting.md>.
+
 - Replace the `dense.decode()` → `SimulationRun` polars materialization
   step on the rollout-detail endpoint with `ProjectionRun` read models
   (`augur/sim/projections.py`). The metric-fan path already bypasses

--- a/augur/sim/buffers.py
+++ b/augur/sim/buffers.py
@@ -151,6 +151,11 @@ class CurrentStateBuffers:
     ordinary_ytd: NDArray[np.float64]
     capital_gain_active: NDArray[np.bool_]
     capital_gain_ytd: NDArray[np.float64]
+    # Pooled unused capital-loss carryforward per (capital-gain agent, rollout), >= 0. Updated at
+    # year-end by the §1211/§1212 netting: this year's net capital loss, less the portion applied
+    # against ordinary income ($3k cap), carries here into future years. Unlike the YTD gain
+    # buffers it is NOT zeroed at year-end — it persists across tax years by design.
+    capital_loss_carryforward: NDArray[np.float64]
     tax_liability_active: NDArray[np.bool_]
     tax_liability_amount: NDArray[np.float64]
     property_active: NDArray[np.bool_]
@@ -221,6 +226,12 @@ class CurrentStateBuffers:
             "current capital_gain_ytd",
             self.capital_gain_ytd,
             shape=(plan.capital_gain_agent_count, 2, r),
+            dtype=np.float64,
+        )
+        _expect_array(
+            "current capital_loss_carryforward",
+            self.capital_loss_carryforward,
+            shape=(plan.capital_gain_agent_count, r),
             dtype=np.float64,
         )
         _expect_array(

--- a/augur/sim/engine/__init__.py
+++ b/augur/sim/engine/__init__.py
@@ -72,6 +72,7 @@ def _allocate_current_state(plan: CompiledSimulation) -> CurrentStateBuffers:
         ordinary_ytd=np.zeros((p.tax_profile_count, r), dtype=np.float64),
         capital_gain_active=np.zeros((p.capital_gain_agent_count, 2, r), dtype=np.bool_),
         capital_gain_ytd=np.zeros((p.capital_gain_agent_count, 2, r), dtype=np.float64),
+        capital_loss_carryforward=np.zeros((p.capital_gain_agent_count, r), dtype=np.float64),
         tax_liability_active=np.zeros((p.tax_liability_count, r), dtype=np.bool_),
         tax_liability_amount=np.zeros((p.tax_liability_count, r), dtype=np.float64),
         property_active=np.zeros((p.property_count, r), dtype=np.bool_),
@@ -135,6 +136,7 @@ def _zero_failed_state(current: CurrentStateBuffers) -> None:
     current.lot_remaining[:, failed] = 0.0
     current.ordinary_ytd[:, failed] = 0.0
     current.capital_gain_ytd[:, :, failed] = 0.0
+    current.capital_loss_carryforward[:, failed] = 0.0
     current.tax_liability_amount[:, failed] = 0.0
     current.property_basis[:, failed] = 0.0
     current.property_ownership[:, failed] = 0.0

--- a/augur/sim/engine/phases.py
+++ b/augur/sim/engine/phases.py
@@ -20,6 +20,7 @@ from augur.sim.enums import (
     PrivateEquityDispositionKind,
     PrivateEquityOpportunityOutcome,
 )
+from augur.sim.tax import net_capital_gains_with_carryforward
 from augur.sim.tensor_fifo import FifoSaleResult, fifo_sell_dollars, fifo_sell_units, lot_order_for_pool
 
 
@@ -806,6 +807,34 @@ def _apply_depreciation_accrual(plan: CompiledSimulation, current: CurrentStateB
         current.property_depreciation_ytd[prop, active_for_property] += monthly_dep[active_for_property]
 
 
+def _apply_capital_loss_netting(
+    plan: CompiledSimulation, current: CurrentStateBuffers, active_rollout: np.ndarray
+) -> None:
+    """Year-end §1211/§1212 netting, run once per capital-gain agent before the per-link bracket
+    walks. Replaces this year's raw ST/LT YTD gains with the post-netting figures the walks then
+    tax, reduces ordinary_ytd by the (≤$3k) capital-loss offset, and persists the residual loss in
+    `capital_loss_carryforward` for future years. Only active rollouts are mutated."""
+    processed: set[int] = set()
+    for profile in range(current.ordinary_ytd.shape[0]):
+        gain_profile = int(plan.tax_profile_capital_gain_index[profile])
+        if gain_profile < 0 or gain_profile in processed:
+            continue
+        processed.add(gain_profile)
+        net_short_term, net_long_term, ordinary_offset, carryforward_out = net_capital_gains_with_carryforward(
+            current.capital_gain_ytd[gain_profile, CapitalGainClassification.SHORT_TERM, :],
+            current.capital_gain_ytd[gain_profile, CapitalGainClassification.LONG_TERM, :],
+            current.capital_loss_carryforward[gain_profile, :],
+        )
+        current.capital_gain_ytd[gain_profile, CapitalGainClassification.SHORT_TERM, active_rollout] = net_short_term[
+            active_rollout
+        ]
+        current.capital_gain_ytd[gain_profile, CapitalGainClassification.LONG_TERM, active_rollout] = net_long_term[
+            active_rollout
+        ]
+        current.ordinary_ytd[profile, active_rollout] -= ordinary_offset[active_rollout]
+        current.capital_loss_carryforward[gain_profile, active_rollout] = carryforward_out[active_rollout]
+
+
 def _apply_tax_accruals(
     plan: CompiledSimulation, buffers: SimulationBuffers, current: CurrentStateBuffers, month: int
 ) -> None:
@@ -839,6 +868,11 @@ def _apply_tax_accruals(
             continue
         current.ordinary_ytd[profile, active_rollout] -= ytd[active_rollout]
     current.property_depreciation_ytd[:, active_rollout] = 0.0
+
+    # Capital-loss netting + carryforward (§1211/§1212). Must run before the bracket walks so the
+    # netted ST/LT gains and the $3k ordinary-income offset are reflected in every jurisdiction
+    # link's computation (each link reads capital_gain_ytd / ordinary_ytd directly).
+    _apply_capital_loss_netting(plan, current, active_rollout)
 
     link_count = plan.tax.link_profile.shape[0]
     # First pass: every link that isn't a SALT-active federal link. Stash its annual tax so

--- a/augur/sim/tax.py
+++ b/augur/sim/tax.py
@@ -38,6 +38,58 @@ def apply_brackets(amounts_per_rollout: np.ndarray, brackets: list[TaxBracket]) 
     return tax
 
 
+def net_capital_gains_with_carryforward(
+    short_term: np.ndarray,
+    long_term: np.ndarray,
+    carryforward_in: np.ndarray,
+    *,
+    max_ordinary_offset_usd: float = 3000.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Apply simplified §1211/§1212 capital-loss netting for one tax year.
+
+    Per-rollout vectors: `short_term`/`long_term` are this year's net realized ST/LT capital
+    gain (signed; negative = a net loss in that category); `carryforward_in` is prior years'
+    unused capital loss (>= 0, a loss magnitude). Returns `(net_short_term, net_long_term,
+    ordinary_offset, carryforward_out)`:
+
+    - `net_short_term`/`net_long_term` (>= 0): gains that remain to be taxed (short-term at
+      ordinary rates, long-term at LTCG rates).
+    - `ordinary_offset` (0 .. `max_ordinary_offset_usd`): net capital loss applied against
+      ordinary income this year.
+    - `carryforward_out` (>= 0): residual loss carried to future years.
+
+    Simplifications vs the IRC: the carryforward is a single pooled magnitude (ST/LT character is
+    not preserved across years), it is applied against short-term gains before long-term
+    (taxpayer-favorable, ST being taxed at the higher ordinary rate), and — like the bracket
+    walks — the offset can exceed ordinary income (no NOL modeling)."""
+    st = np.asarray(short_term, dtype=np.float64).copy()
+    lt = np.asarray(long_term, dtype=np.float64).copy()
+
+    # Cross-net opposite-sign categories: a net loss in one offsets a net gain in the other.
+    st_loss_vs_lt_gain = np.minimum(np.maximum(-st, 0.0), np.maximum(lt, 0.0))
+    st += st_loss_vs_lt_gain
+    lt -= st_loss_vs_lt_gain
+    lt_loss_vs_st_gain = np.minimum(np.maximum(-lt, 0.0), np.maximum(st, 0.0))
+    lt += lt_loss_vs_st_gain
+    st -= lt_loss_vs_st_gain
+
+    # Consume prior-year carryforward against remaining gains, short-term first.
+    carry = np.asarray(carryforward_in, dtype=np.float64).copy()
+    used_short_term = np.minimum(np.maximum(st, 0.0), carry)
+    st -= used_short_term
+    carry -= used_short_term
+    used_long_term = np.minimum(np.maximum(lt, 0.0), carry)
+    lt -= used_long_term
+    carry -= used_long_term
+
+    net_short_term = np.maximum(st, 0.0)
+    net_long_term = np.maximum(lt, 0.0)
+    residual_loss = np.maximum(-(st + lt), 0.0) + carry
+    ordinary_offset = np.minimum(residual_loss, max_ordinary_offset_usd)
+    carryforward_out = residual_loss - ordinary_offset
+    return net_short_term, net_long_term, ordinary_offset, carryforward_out
+
+
 def apply_ltcg_brackets(
     ltcg_amount: np.ndarray, ordinary_taxable: np.ndarray, ltcg_brackets: list[TaxBracket]
 ) -> np.ndarray:

--- a/augur/sim/tax_test.py
+++ b/augur/sim/tax_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest_bazel
 
 from augur.sim.jurisdictions import TaxBracket, load_jurisdiction
-from augur.sim.tax import apply_brackets, apply_ltcg_brackets
+from augur.sim.tax import apply_brackets, apply_ltcg_brackets, net_capital_gains_with_carryforward
 
 
 def test_apply_brackets_hand_computed_federal_single_50k() -> None:
@@ -104,6 +104,78 @@ def test_ltcg_brackets_vectorized() -> None:
     assert math.isclose(tax[1], 446.25, abs_tol=1e-6)
     assert math.isclose(tax[2], 7500.0, abs_tol=1e-6)
     assert math.isclose(tax[3], 0.0, abs_tol=1e-6)
+
+
+def test_net_capital_gains_pure_gains_pass_through() -> None:
+    """With no losses and no carryforward, ST/LT gains are returned untouched and nothing offsets
+    ordinary income — the netting must be a no-op for the common all-gains year."""
+    net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([4_000.0]), np.array([10_000.0]), np.array([0.0])
+    )
+    assert math.isclose(net_st[0], 4_000.0)
+    assert math.isclose(net_lt[0], 10_000.0)
+    assert math.isclose(offset[0], 0.0)
+    assert math.isclose(carry_out[0], 0.0)
+
+
+def test_net_capital_gains_short_term_loss_offsets_long_term_gain() -> None:
+    """A net short-term loss cross-nets against a long-term gain before either is taxed."""
+    net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([-3_000.0]), np.array([10_000.0]), np.array([0.0])
+    )
+    assert math.isclose(net_st[0], 0.0)
+    assert math.isclose(net_lt[0], 7_000.0)
+    assert math.isclose(offset[0], 0.0)
+    assert math.isclose(carry_out[0], 0.0)
+
+
+def test_net_capital_gains_net_loss_caps_ordinary_offset_and_carries_remainder() -> None:
+    """A $12k net capital loss deducts $3k against ordinary income this year and carries the
+    remaining $9k forward; no gains remain to tax."""
+    net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([-5_000.0]), np.array([-7_000.0]), np.array([0.0])
+    )
+    assert math.isclose(net_st[0], 0.0)
+    assert math.isclose(net_lt[0], 0.0)
+    assert math.isclose(offset[0], 3_000.0)
+    assert math.isclose(carry_out[0], 9_000.0)
+
+
+def test_net_capital_gains_small_loss_fully_offsets_ordinary() -> None:
+    """A net loss below the $3k cap is fully deducted with nothing carried forward."""
+    _, _, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([-1_200.0]), np.array([0.0]), np.array([0.0])
+    )
+    assert math.isclose(offset[0], 1_200.0)
+    assert math.isclose(carry_out[0], 0.0)
+
+
+def test_net_capital_gains_carryforward_consumes_following_year_gain() -> None:
+    """A prior-year carryforward offsets this year's gains (short-term first), shrinking the taxed
+    gain and the carryforward balance."""
+    net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([2_000.0]), np.array([5_000.0]), np.array([9_000.0])
+    )
+    # $9k carryforward wipes the $2k ST gain and $5k LT gain (total $7k); the unused $2k is then a
+    # net capital loss that deducts (under the $3k cap) against ordinary income, leaving $0 to carry.
+    assert math.isclose(net_st[0], 0.0)
+    assert math.isclose(net_lt[0], 0.0)
+    assert math.isclose(offset[0], 2_000.0)
+    assert math.isclose(carry_out[0], 0.0)
+
+
+def test_net_capital_gains_vectorized_independent_rollouts() -> None:
+    """One call over multiple rollouts: a gain year, a carryforward-consumed year, and a
+    net-loss year each resolve independently."""
+    net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
+        np.array([4_000.0, 1_000.0, -2_000.0]),
+        np.array([10_000.0, 1_000.0, -6_000.0]),
+        np.array([0.0, 0.0, 0.0]),
+    )
+    assert np.allclose(net_st, [4_000.0, 1_000.0, 0.0])
+    assert np.allclose(net_lt, [10_000.0, 1_000.0, 0.0])
+    assert np.allclose(offset, [0.0, 0.0, 3_000.0])
+    assert np.allclose(carry_out, [0.0, 0.0, 5_000.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The year-end bracket walks (`augur/sim/tax.py`) clamp negative taxable amounts to zero and no cross-year capital state existed, so realized **capital losses simply evaporated** — both a correctness gap for existing OpenAI/IBKR sales and a hard blocker for modeling tax-loss harvesting.

This is **Piece 1** of the TLH plan (`augur/plans/tax_loss_harvesting.md`, also added here): the prerequisite tax-engine mechanics. The harvest process itself (Piece 2) is separate.

## What

- **`net_capital_gains_with_carryforward()`** in `tax.py` (pure numpy): cross-nets ST/LT, consumes a pooled prior-year carryforward (short-term gains first), applies up to **$3,000/yr** of net loss against ordinary income, and carries the remainder forward.
- **New `capital_loss_carryforward` buffer** per `(capital-gain agent, rollout)` — persists across tax years (deliberately *not* zeroed by the year-end YTD resets); wired into allocation, `validate()`, and the failure-reset.
- **Year-end pre-pass** `_apply_capital_loss_netting` runs once per capital-gain agent *before* the per-jurisdiction bracket walks, rewriting the netted ST/LT YTD gains and the ordinary offset so every link (federal + CA) sees them.

### Documented simplifications
Pooled carryforward (ST/LT character not preserved across years), applied ST-gains-first (taxpayer-favorable), $3k offset can exceed ordinary income (no NOL modeling), and the federal-computed netting is applied uniformly across links (CA conforms).

## Tests

6 new unit tests for the netting math (pass-through, ST-loss-offsets-LT-gain, $3k cap + carryforward, small-loss full offset, carryforward consuming next-year gains, vectorized). All 10 `//augur/sim/...` targets pass on RBE (incl. `tax_test`, `simulate_test`, e2e LTCG/rental/property), ruff + mypy included. With no losses and zero carryforward the pre-pass is a no-op, so gain-only scenarios are unchanged.

https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4)_