### PR TITLE
augur/sim: lazy SimulationRun (decode frames on first access)

### DIFF
--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -214,6 +214,27 @@ safe to event-ize: unlike tax liabilities, they change every month and consumers
 at arbitrary months expecting forward-filled state. Their remaining decode cost is the row
 count itself (O(months × R)); the lever there is lazy/opt-in decode (#1), not event-izing.
 
+## Results after the fourth pass (lazy decode)
+
+`SimulationRun` is now a lazy facade over the dense result: each long-form frame (and the
+event log) is a `cached_property` decoded on first access, so `decode()` is free and a caller
+only pays to materialize the frames it reads. Public attribute surface unchanged — every
+consumer and test is untouched.
+
+This makes the existing "stats on dense arrays" path (`metric_fan`, `monthly_metric_arrays`)
+pay **zero** decode, and the single-rollout detail view (`rollout_events_from`, which reads
+only `events_log` + `asset_lots`) skip the other ~10 frames it never used. 1000 × 1200:
+
+| caller pattern                                    | before | lazy   |
+| ------------------------------------------------- | ------ | ------ |
+| summary / fan (reduces on dense, decodes nothing) | 6.5 s  | 1.9 s  |
+| rollout detail (`events_log` + `asset_lots`)      | 6.5 s  | 3.85 s |
+| full-frame caller (`materialize all`)             | 6.5 s  | 6.5 s  |
+
+The backend already caches the dense result per `(scenario, seed)` (`ProductService` LRU of
+R=1 `DenseSimulationResult`), so re-deriving any frame or stat for a cached rollout is
+re-simulation-free; lazy decode means that re-derivation only builds what's asked for.
+
 ## Note on parallelism
 
 Rollouts are independent, so beyond the above the R axis can be **chunked**

--- a/augur/sim/codec/plan.py
+++ b/augur/sim/codec/plan.py
@@ -1,11 +1,12 @@
-"""Top-level codec orchestrator: wraps the per-domain decoders into a single
-`decode_run` that produces a `SimulationRun` from a (plan, buffers, external_series)
-triple. `DenseSimulationResult` lives here too so engine.py can stay free of the
-codec dependency."""
+"""Top-level codec orchestrator: `SimulationRun` is a lazy facade over the
+per-domain decoders, producing each long-form Polars frame from a
+(plan, buffers, external_series) triple on first access. `DenseSimulationResult`
+lives here too so engine.py can stay free of the codec dependency."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 
 import numpy as np
 import polars as pl
@@ -39,23 +40,66 @@ from augur.sim.external_series import ExternalSeriesContext
 from augur.sim.state import ROLLOUT_STATUS_FRAME
 
 
-@dataclass(frozen=True)
 class SimulationRun:
-    """Outputs of a simulation. Long-form polars frames keyed by
-    `(rollout_index, month_index, ...)` plus the event log."""
+    """Lazy view of a simulation's outputs: each long-form Polars frame (and the
+    event log) is decoded from the dense buffers on first access and cached, so a
+    caller only pays to materialize the frames it actually reads. The public
+    attribute surface matches the eager frames it replaced."""
 
-    cash_balances: pl.DataFrame
-    asset_lots: pl.DataFrame
-    ordinary_income_ytd: pl.DataFrame
-    capital_gains_ytd: pl.DataFrame
-    tax_liabilities: pl.DataFrame
-    property_state: pl.DataFrame
-    property_stakes: pl.DataFrame
-    liabilities: pl.DataFrame
-    rollout_status_history: pl.DataFrame
-    rollout_status: pl.DataFrame
-    series_values: pl.DataFrame
-    events_log: EventLog
+    def __init__(
+        self, plan: CompiledSimulation, buffers: SimulationBuffers, external_series: ExternalSeriesContext
+    ) -> None:
+        self._plan = plan
+        self._buffers = buffers
+        self._external_series = external_series
+
+    @cached_property
+    def cash_balances(self) -> pl.DataFrame:
+        return decode_cash(self._plan, self._buffers)
+
+    @cached_property
+    def asset_lots(self) -> pl.DataFrame:
+        return decode_asset_lots(self._plan, self._buffers)
+
+    @cached_property
+    def ordinary_income_ytd(self) -> pl.DataFrame:
+        return decode_ordinary_income(self._plan, self._buffers)
+
+    @cached_property
+    def capital_gains_ytd(self) -> pl.DataFrame:
+        return decode_capital_gains(self._plan, self._buffers)
+
+    @cached_property
+    def tax_liabilities(self) -> pl.DataFrame:
+        return decode_tax_liabilities(self._plan, self._buffers)
+
+    @cached_property
+    def property_state(self) -> pl.DataFrame:
+        return decode_property_state(self._plan, self._buffers)
+
+    @cached_property
+    def property_stakes(self) -> pl.DataFrame:
+        return decode_property_stakes(self._plan, self._buffers)
+
+    @cached_property
+    def liabilities(self) -> pl.DataFrame:
+        return decode_liabilities(self._plan, self._buffers)
+
+    @cached_property
+    def rollout_status_history(self) -> pl.DataFrame:
+        return decode_rollout_status_history(self._plan, self._buffers)
+
+    @cached_property
+    def rollout_status(self) -> pl.DataFrame:
+        return decode_final_rollout_status(self._plan, self._buffers)
+
+    @cached_property
+    def series_values(self) -> pl.DataFrame:
+        return self._external_series.series_values
+
+    @cached_property
+    def events_log(self) -> EventLog:
+        return decode_events(self._plan, self._buffers)
 
 
 @dataclass
@@ -65,27 +109,7 @@ class DenseSimulationResult:
     external_series: ExternalSeriesContext
 
     def decode(self) -> SimulationRun:
-        return decode_run(self.plan, self.buffers, self.external_series)
-
-
-def decode_run(
-    plan: CompiledSimulation, buffers: SimulationBuffers, external_series: ExternalSeriesContext
-) -> SimulationRun:
-    events = decode_events(plan, buffers)
-    return SimulationRun(
-        cash_balances=decode_cash(plan, buffers),
-        asset_lots=decode_asset_lots(plan, buffers),
-        ordinary_income_ytd=decode_ordinary_income(plan, buffers),
-        capital_gains_ytd=decode_capital_gains(plan, buffers),
-        tax_liabilities=decode_tax_liabilities(plan, buffers),
-        property_state=decode_property_state(plan, buffers),
-        property_stakes=decode_property_stakes(plan, buffers),
-        liabilities=decode_liabilities(plan, buffers),
-        rollout_status_history=decode_rollout_status_history(plan, buffers),
-        rollout_status=decode_final_rollout_status(plan, buffers),
-        events_log=events,
-        series_values=external_series.series_values,
-    )
+        return SimulationRun(self.plan, self.buffers, self.external_series)
 
 
 def decode_events(plan: CompiledSimulation, buffers: SimulationBuffers) -> EventLog:

--- a/augur/sim/compiler/plan.py
+++ b/augur/sim/compiler/plan.py
@@ -1,5 +1,5 @@
 """Compile-side plan: SlotPlan, CompiledSimulation, compile_simulation. Pairs with
-`codec/plan.py` (DenseSimulationResult, decode_run) at the engine boundary.
+`codec/plan.py` (DenseSimulationResult, SimulationRun) at the engine boundary.
 
 `compile_simulation` is the orchestrator that interns strings, builds the shared
 index maps, calls every per-domain `compile_*` helper, and assembles the

--- a/augur/sim/profile_rollout.py
+++ b/augur/sim/profile_rollout.py
@@ -108,9 +108,40 @@ def main() -> None:
         help="run the dense engine (compile + month loop) and skip the Polars decode, to isolate "
         "pure rollout-compute cost/memory from the encode boundary",
     )
+    parser.add_argument(
+        "--materialize",
+        choices=["all", "rollout", "none"],
+        default="all",
+        help="which lazy SimulationRun frames to force-decode: 'all' (every frame), 'rollout' "
+        "(only what the single-rollout detail view reads: events_log + asset_lots), or 'none' "
+        "(decode nothing — the lazy default)",
+    )
     args = parser.parse_args()
 
     scenario, locations = build_profile_scenario(horizon_months=args.horizon_months)
+
+    def _materialize(result: object) -> None:
+        if args.materialize == "none":
+            return
+        if args.materialize == "rollout":
+            _ = result.events_log  # type: ignore[attr-defined]
+            _ = result.asset_lots  # type: ignore[attr-defined]
+            return
+        for frame in (
+            "cash_balances",
+            "asset_lots",
+            "ordinary_income_ytd",
+            "capital_gains_ytd",
+            "tax_liabilities",
+            "property_state",
+            "property_stakes",
+            "liabilities",
+            "rollout_status_history",
+            "rollout_status",
+            "series_values",
+            "events_log",
+        ):
+            getattr(result, frame)
 
     def run(rollout_count: int) -> None:
         if args.dense_only:
@@ -123,12 +154,15 @@ def main() -> None:
                 scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
             )
         else:
-            simulate(scenario, rollout_count=rollout_count, locations=locations)
+            _materialize(simulate(scenario, rollout_count=rollout_count, locations=locations))
 
     # Warm-up tiny run to pay one-time import / JIT-ish costs outside the timed region.
     run(2)
 
-    print(f"rollouts={args.rollouts} horizon_months={args.horizon_months} dense_only={args.dense_only}")
+    print(
+        f"rollouts={args.rollouts} horizon_months={args.horizon_months} "
+        f"dense_only={args.dense_only} materialize={args.materialize}"
+    )
 
     if args.no_profile:
         t0 = time.perf_counter()


### PR DESCRIPTION
## What

`decode()` eagerly built all ~12 long-form Polars frames, but most callers read only a few:
- the **fan/summary** path (`metric_fan` → `monthly_metric_arrays`, `terminal_metrics_from_arrays`) reduces on the **dense arrays** and reads **no** frames;
- the **single-rollout detail** view (`rollout_events_from`) reads only `events_log` + `asset_lots`.

This makes `SimulationRun` a **lazy facade** over the dense result: each frame (and the event log) is a `cached_property` decoded on first access; `decode()` is now free. The public attribute surface is unchanged, so every consumer and test is untouched, and the per-domain `decode_*` functions stay put — `SimulationRun` is just a thin dispatcher (kept per-domain, not inlined, since the decoders are organized by domain across ~8 modules and several return multiple frames).

Also adds a `--materialize {all,rollout,none}` knob to `//augur/sim:profile_rollout` to measure the lazy behavior.

## Results (1000 × 1200)

| caller pattern | before | lazy |
| --- | --- | --- |
| summary / fan (reduces on dense, decodes nothing) | 6.5 s | **1.9 s** |
| rollout detail (`events_log` + `asset_lots` only) | 6.5 s | **3.85 s** |
| full-frame caller (`materialize all`) | 6.5 s | 6.5 s (unchanged) |

The backend already caches the dense result per `(scenario, seed)` (`ProductService` LRU of R=1 `DenseSimulationResult`), so re-deriving any frame or stat for a cached rollout is re-simulation-free; lazy decode means that re-derivation now builds only what's asked for. No `service.py` change needed — the `rollout()` win falls out of `rollout_events_from` only touching 2 frames.

## Test

`bazel test //augur/sim/...` + `//augur/product/...` + `//augur/api/...` — all 20 pass; lint (ruff + mypy) clean. Rebased on current `devel` (incl. #1845 which cleared the earlier formatter drift).

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_