### PR TITLE
props/registry: rewrite upstream Location headers + raise proxy timeouts

### DIFF
--- a/cluster/k8s/props/app/httproute.yaml
+++ b/cluster/k8s/props/app/httproute.yaml
@@ -10,6 +10,11 @@ spec:
   hostnames:
     - "props.allegedly.works"
   rules:
-    - backendRefs:
+    # Large agent image layers (registry proxy /v2/* pushes) can take minutes;
+    # default gateway timeout would cut them off mid-upload.
+    - timeouts:
+        request: 600s
+        backendRequest: 600s
+      backendRefs:
         - name: props
           port: 8000

--- a/props/backend/routes/registry.py
+++ b/props/backend/routes/registry.py
@@ -68,17 +68,28 @@ async def _proxy_to_upstream(request: Request) -> Response:
         body = await request.body() if request.method not in ("GET", "HEAD") else b""
 
         try:
+            # 600s: agent image layers are large and can take minutes to stream
+            # through to the upstream; the old 30s read timeout surfaced as
+            # `502 Upstream error` on big blobs.
             upstream_response = await client.request(
-                method=request.method, url=upstream_url, headers=headers, content=body, timeout=30.0
+                method=request.method, url=upstream_url, headers=headers, content=body, timeout=600.0
             )
         except httpx.RequestError as e:
             logger.exception("Upstream request failed")
             raise HTTPException(status_code=502, detail=f"Upstream error: {e}")
 
+        # Rewrite Location back to the client namespace. The upstream returns
+        # blob-upload session URLs under /v2/{project}/<repo>/...; passed through
+        # verbatim, the client would push blobs to the project-prefixed path and
+        # the manifest couldn't find them (BLOB_UNKNOWN). dict(httpx.Headers)
+        # lowercases keys.
+        response_headers = dict(upstream_response.headers)
+        for header_name in ("location", "content-location"):
+            if header_name in response_headers:
+                response_headers[header_name] = upstream.rewrite_location(response_headers[header_name])
+
         return Response(
-            content=upstream_response.content,
-            status_code=upstream_response.status_code,
-            headers=dict(upstream_response.headers),
+            content=upstream_response.content, status_code=upstream_response.status_code, headers=response_headers
         )
 
 

--- a/props/core/oci_utils.py
+++ b/props/core/oci_utils.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 from props.core.agent_types import AgentType
 
@@ -113,10 +114,39 @@ class UpstreamRegistryConfig:
         return None
 
     def rewrite_path(self, path: str) -> str:
-        """Prepend project to path: /v2/critic/... → /v2/props/critic/..."""
+        """Prepend project to path: /v2/critic/... → /v2/props/critic/...
+
+        Idempotent: a path already under /v2/{project}/ is returned unchanged so
+        it can't be double-prefixed (/v2/props/props/critic/...). No agent repo
+        is named after the project, so this never collides with a real repo.
+        """
         if self.project and path.startswith("/v2/") and path != "/v2/":
+            if path == f"/v2/{self.project}" or path.startswith(f"/v2/{self.project}/"):
+                return path
             return f"/v2/{self.project}/{path[4:]}"
         return path
+
+    def rewrite_location(self, value: str) -> str:
+        """Map an upstream Location/Content-Location back to the client namespace.
+
+        Inverse of rewrite_path. Strips any upstream scheme+host (the upstream
+        may return an absolute URL) and the injected /{project} segment, yielding
+        a relative path the client resolves against the proxy. Preserves the
+        query string — chunked blob uploads carry a ?_state=... cursor.
+
+        Without this, the upstream's blob-upload Location (/v2/{project}/<repo>/
+        blobs/uploads/<uuid>) leaks the project prefix to the client, which then
+        pushes blobs to the wrong namespace and the manifest can't find them
+        (BLOB_UNKNOWN).
+        """
+        if not value:
+            return value
+        parts = urlsplit(value)
+        path = parts.path
+        prefix = f"/v2/{self.project}/"
+        if self.project and path.startswith(prefix):
+            path = "/v2/" + path[len(prefix) :]
+        return f"{path}?{parts.query}" if parts.query else path
 
     def repo_path(self, repo: str) -> str:
         """Prefix repo with project if configured: 'critic' → 'props/critic'."""

--- a/props/core/test_oci_utils.py
+++ b/props/core/test_oci_utils.py
@@ -4,7 +4,12 @@ import pytest
 import pytest_bazel
 
 from props.core.agent_types import AgentType
-from props.core.oci_utils import RegistryProxyConfig, is_digest
+from props.core.oci_utils import RegistryProxyConfig, UpstreamRegistryConfig, is_digest
+
+_UPSTREAM = UpstreamRegistryConfig(
+    url="http://forgejo-http.forgejo:3000", username=None, password=None, project="props"
+)
+_NO_PROJECT = UpstreamRegistryConfig(url="http://reg:5000", username=None, password=None, project=None)
 
 
 class TestPullAuthority:
@@ -85,6 +90,64 @@ class TestIsDigest:
     @pytest.mark.parametrize("ref", ["latest", "v1.0", "critic:latest", "localhost:8000/critic@sha256:abc"])
     def test_non_digests(self, ref: str) -> None:
         assert not is_digest(ref)
+
+
+class TestRewritePath:
+    """Tests for UpstreamRegistryConfig.rewrite_path() (client -> upstream)."""
+
+    def test_prepends_project(self) -> None:
+        assert _UPSTREAM.rewrite_path("/v2/critic/blobs/uploads/") == "/v2/props/critic/blobs/uploads/"
+
+    def test_v2_root_unchanged(self) -> None:
+        assert _UPSTREAM.rewrite_path("/v2/") == "/v2/"
+
+    def test_idempotent_no_double_prefix(self) -> None:
+        # A path already under the project must not be prefixed again.
+        assert _UPSTREAM.rewrite_path("/v2/props/critic/manifests/x") == "/v2/props/critic/manifests/x"
+
+    def test_project_exact_unchanged(self) -> None:
+        assert _UPSTREAM.rewrite_path("/v2/props") == "/v2/props"
+
+    def test_no_project_passthrough(self) -> None:
+        assert _NO_PROJECT.rewrite_path("/v2/critic/blobs/uploads/") == "/v2/critic/blobs/uploads/"
+
+
+class TestRewriteLocation:
+    """Tests for UpstreamRegistryConfig.rewrite_location() (upstream -> client)."""
+
+    def test_relative_strips_project(self) -> None:
+        assert _UPSTREAM.rewrite_location("/v2/props/critic/blobs/uploads/abc") == "/v2/critic/blobs/uploads/abc"
+
+    def test_preserves_query(self) -> None:
+        assert (
+            _UPSTREAM.rewrite_location("/v2/props/critic/blobs/uploads/abc?_state=xyz")
+            == "/v2/critic/blobs/uploads/abc?_state=xyz"
+        )
+
+    def test_absolute_upstream_host_stripped(self) -> None:
+        assert (
+            _UPSTREAM.rewrite_location("http://forgejo-http.forgejo:3000/v2/props/critic/blobs/uploads/abc?_state=xyz")
+            == "/v2/critic/blobs/uploads/abc?_state=xyz"
+        )
+
+    def test_absolute_public_host_stripped(self) -> None:
+        assert (
+            _UPSTREAM.rewrite_location("https://git.allegedly.works/v2/props/critic/blobs/uploads/abc")
+            == "/v2/critic/blobs/uploads/abc"
+        )
+
+    def test_path_without_project_only_strips_host(self) -> None:
+        assert _UPSTREAM.rewrite_location("/v2/critic/manifests/sha256:abc") == "/v2/critic/manifests/sha256:abc"
+
+    def test_empty_unchanged(self) -> None:
+        assert _UPSTREAM.rewrite_location("") == ""
+
+    def test_roundtrip_back_to_upstream_path(self) -> None:
+        # The core invariant: a client that follows the rewritten Location and
+        # the proxy that re-applies rewrite_path land on the original upstream
+        # path — no namespace drift, so the manifest finds its blobs.
+        upstream_path = "/v2/props/critic/blobs/uploads/abc"
+        assert _UPSTREAM.rewrite_path(_UPSTREAM.rewrite_location(upstream_path)) == upstream_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the props registry-proxy push failure (`502 Upstream error` on large layers, `BLOB_UNKNOWN` on manifest PUT) that has been blocking agent image pushes — which in turn blocks the new GLM-4.6 grader from getting its image.

## Two root causes

**1. Location-header leak → `BLOB_UNKNOWN`**

The proxy prepends the upstream project (`props`) to request paths (`rewrite_path`) but was returning upstream **response** headers verbatim. So the upstream's blob-upload session URL came back to the client as `/v2/props/<repo>/blobs/uploads/<uuid>`. The client then PUT the blob to that project-prefixed namespace, and the subsequent manifest (pushed to `/v2/<repo>/manifests/...`) couldn't find its blobs → `BLOB_UNKNOWN`.

Fix: a new `UpstreamRegistryConfig.rewrite_location()` maps `Location`/`Content-Location` back to the client namespace — strips any upstream scheme+host (the upstream may return an absolute URL) and the injected `/{project}` segment, while preserving the `?_state=...` cursor that chunked blob uploads carry. `registry.py` applies it to both headers on every proxied response.

`rewrite_path()` is now **idempotent**: a path already under `/v2/{project}/` is returned unchanged, so a re-applied path can't be double-prefixed (`/v2/props/props/...`). No agent repo is named after the project, so this never collides with a real repo.

**2. Timeout on large blobs → `502`**

The httpx client used a 30s timeout and the props `HTTPRoute` had no timeout override, so streaming a multi-minute layer surfaced as `502 Upstream error`. Bumped the proxy client timeout to `600s` and added `request`/`backendRequest: 600s` to the HTTPRoute.

## Files

- `props/core/oci_utils.py` — `rewrite_location()`; idempotent `rewrite_path()`.
- `props/backend/routes/registry.py` — rewrite `Location`/`Content-Location` on responses; `timeout=600.0`.
- `cluster/k8s/props/app/httproute.yaml` — `600s` request/backendRequest timeouts.
- `props/core/test_oci_utils.py` — `TestRewritePath` (prepend, idempotent, `/v2/` root, exact-project, no-project passthrough) and `TestRewriteLocation` (relative/absolute strip, query preservation, host-only strip, empty, and the roundtrip invariant `rewrite_path(rewrite_location(x)) == x`).

## Testing

- `bbr test //props/core:test_oci_utils` — PASSED
- `bbr test //props/backend/routes:test_registry_proxy` (docker) — PASSED
- `bbr build //props/backend/routes:registry //props/backend:app` — clean (ruff + mypy aspects)
- `kubectl kustomize cluster/k8s/props/app` renders; kubeconform passes.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_