### PR TITLE
augur: O(N²)→O(N) batch slicing of metric_fan rollouts (+ scale benchmark)

### DIFF
--- a/augur/product/BUILD.bazel
+++ b/augur/product/BUILD.bazel
@@ -100,6 +100,24 @@ py_test(
 )
 
 py_test(
+    name = "service_scale_test",
+    size = "medium",
+    srcs = ["service_scale_test.py"],
+    data = [
+        "//augur/api:public_fixture_config",
+        "//augur/api:public_fixture_properties",
+    ],
+    deps = [
+        ":conftest",
+        ":service",
+        ":wire",
+        "//:conftest",
+        "//augur/api:config",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "service_test",
     size = "medium",
     srcs = ["service_test.py"],

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -54,7 +54,7 @@ from augur.sim.codec.plan import DenseSimulationResult
 from augur.sim.external_series import materialize_sampled_exogenous
 from augur.sim.locations import Location
 from augur.sim.simulate import simulate_dense_with_external_series
-from augur.sim.slice import slice_dense_result
+from augur.sim.slice import slice_dense_results
 
 DEFAULT_MAX_CACHE_ROLLOUTS = 25_000
 
@@ -243,9 +243,11 @@ class ProductService:
             locations=self._locations,
         )
         model_id = str(sampled.metadata.get("model_id") or scenario_key.model_id)
+        # Slice the whole batch in one pass (partitions the exogenous frames once) — slicing
+        # per seed would re-filter the full batch frame R times, i.e. O(R²).
+        sliced = slice_dense_results(dense, range(len(seeds)))
         return {
-            seed: _CachedRollout(dense=slice_dense_result(dense, rollout_index=batch_index), model_id=model_id)
-            for batch_index, seed in enumerate(seeds)
+            seed: _CachedRollout(dense=sliced[batch_index], model_id=model_id) for batch_index, seed in enumerate(seeds)
         }
 
     def _cache_get(self, scenario_key: ScenarioKey, seed: int) -> _CachedRollout | None:

--- a/augur/product/service_scale_test.py
+++ b/augur/product/service_scale_test.py
@@ -1,0 +1,77 @@
+"""End-to-end product-path scale benchmark/smoke.
+
+Drives the real `ProductService.metric_fan` (exogenous sampling → batched
+`simulate_dense` → per-seed `slice_dense_result` + cache → dense reductions →
+percentiles) at a configurable rollout count, so we can see where time/memory go
+through the *actual* product entry point rather than the synthetic sim profiler.
+
+CI runs it tiny (defaults) as a smoke test. Scale it locally:
+
+  bazelisk test //augur/product:service_scale_test --config=nolint \\
+    --test_env=AUGUR_BENCH_ROLLOUTS=10000 --test_env=AUGUR_BENCH_HORIZON=240 \\
+    --test_env=AUGUR_BENCH_PROFILE=1 --test_output=all --nocache_test_results \\
+    --test_timeout=900
+"""
+
+from __future__ import annotations
+
+import cProfile
+import io
+import os
+import pstats
+import time
+
+import pytest_bazel
+
+from augur.api.config import Config
+from augur.product.conftest import MakeProductService
+from augur.product.service import ProductService
+from augur.product.wire import MetricFanRequest, RolloutRequest, ScenarioKey
+
+
+def test_metric_fan_scale(make_product_service: MakeProductService, augur_config: Config) -> None:
+    rollouts = int(os.environ.get("AUGUR_BENCH_ROLLOUTS", "64"))
+    horizon = int(os.environ.get("AUGUR_BENCH_HORIZON", str(min(60, augur_config.max_horizon_months))))
+    profile = os.environ.get("AUGUR_BENCH_PROFILE") == "1"
+
+    # `make_product_service` registers the realized model under "current_model" (see conftest),
+    # so the scenario must reference that id regardless of the config's default preset name.
+    model = augur_config.models[augur_config.default_model_id].realize_model()
+    service: ProductService = make_product_service(model, max_cache_rollouts=rollouts + 16)
+    scenario = ScenarioKey(
+        model_id="current_model", horizon_months=horizon, monthly_spend_usd=5_000.0, spend_index="none"
+    )
+    request = MetricFanRequest(
+        scenario=scenario, rollout_seeds=tuple(range(rollouts)), metric="cash_usd", percentiles=(5.0, 50.0, 95.0)
+    )
+
+    profiler = cProfile.Profile() if profile else None
+    start = time.perf_counter()
+    if profiler is not None:
+        profiler.enable()
+    response = service.metric_fan(request)
+    if profiler is not None:
+        profiler.disable()
+    fan_elapsed = time.perf_counter() - start
+
+    # A single-rollout detail view exercises the lazy decode path (events_log + asset_lots only).
+    rollout_start = time.perf_counter()
+    service.rollout(RolloutRequest(scenario=scenario, seed=0))
+    rollout_elapsed = time.perf_counter() - rollout_start
+
+    print(
+        f"\n[bench] metric_fan rollouts={rollouts} horizon={horizon} "
+        f"fan_wall={fan_elapsed:.3f}s rollout_detail_wall={rollout_elapsed:.3f}s "
+        f"failed={response.failed_count}"
+    )
+    if profiler is not None:
+        stream = io.StringIO()
+        pstats.Stats(profiler, stream=stream).sort_stats("tottime").print_stats(20)
+        print(stream.getvalue())
+
+    assert response.failed_count <= rollouts
+    assert len(response.monthly_metric_fan["month_index"]) == (horizon + 1) * len(request.percentiles)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/slice.py
+++ b/augur/sim/slice.py
@@ -1,8 +1,9 @@
-"""Slice a batched DenseSimulationResult into a single-rollout (R=1) result."""
+"""Slice a batched DenseSimulationResult into single-rollout (R=1) results."""
 
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -14,11 +15,40 @@ from augur.sim.codec.plan import DenseSimulationResult
 from augur.sim.external_series import ExternalSeriesContext
 
 
+def slice_dense_results(dense: DenseSimulationResult, rollout_indices: Sequence[int]) -> list[DenseSimulationResult]:
+    """Slice a batched result into one R=1 result per requested rollout.
+
+    The exogenous Polars frames (`series_values`, the PE bundle) are partitioned by
+    `rollout_index` **once** up front, so slicing all R rollouts is O(R) rather than the
+    O(R²) of filtering the whole batch frame per rollout."""
+    series_by_rollout = _partition_by_rollout(dense.external_series.series_values)
+    pe_by_rollout = (
+        None
+        if dense.external_series.private_equity.is_empty()
+        else _partition_by_rollout(dense.external_series.private_equity.frame)
+    )
+    series_schema = dense.external_series.series_values.clear()
+    return [
+        _slice_one(dense, rollout_index, series_by_rollout, pe_by_rollout, series_schema)
+        for rollout_index in rollout_indices
+    ]
+
+
 def slice_dense_result(dense: DenseSimulationResult, *, rollout_index: int) -> DenseSimulationResult:
     """Return an R=1 DenseSimulationResult for one rollout of a batched result.
 
     The cached slice owns its own memory (via `.copy()` on every array) so the
     source batch can be released."""
+    return slice_dense_results(dense, (rollout_index,))[0]
+
+
+def _slice_one(
+    dense: DenseSimulationResult,
+    rollout_index: int,
+    series_by_rollout: dict[int, pl.DataFrame],
+    pe_by_rollout: dict[int, pl.DataFrame] | None,
+    series_schema: pl.DataFrame,
+) -> DenseSimulationResult:
     sliced_pe_channels = _take_dc(dense.plan.pe_channels, rollout_index, axis=1)
     plan = dataclasses.replace(
         dense.plan,
@@ -39,26 +69,25 @@ def slice_dense_result(dense: DenseSimulationResult, *, rollout_index: int) -> D
         lifecycle=_take_dc(dense.buffers.lifecycle, rollout_index, axis=-1),
         tax_liability_changes=_slice_tax_liability_changes(dense.buffers.tax_liability_changes, rollout_index),
     )
-    external_series = ExternalSeriesContext(
-        series_values=(
-            dense.external_series.series_values.filter(pl.col("rollout_index") == rollout_index).with_columns(
-                rollout_index=pl.lit(0, dtype=pl.Int64)
-            )
-        ),
-        private_equity=_slice_pe_bundle(dense.external_series.private_equity, rollout_index=rollout_index),
+    series_values = series_by_rollout.get(rollout_index, series_schema).with_columns(
+        rollout_index=pl.lit(0, dtype=pl.Int64)
     )
+    if pe_by_rollout is None:
+        private_equity = dense.external_series.private_equity
+    else:
+        pe_frame = pe_by_rollout.get(rollout_index, dense.external_series.private_equity.frame.clear())
+        private_equity = PrivateEquityBundle(frame=pe_frame.with_columns(rollout_index=pl.lit(0, dtype=pl.Int64)))
+    external_series = ExternalSeriesContext(series_values=series_values, private_equity=private_equity)
     return DenseSimulationResult(plan=plan, buffers=buffers, external_series=external_series)
 
 
-def _slice_pe_bundle(pe: PrivateEquityBundle, *, rollout_index: int) -> PrivateEquityBundle:
-    """Restrict a PE bundle to one rollout, remapping rollout indices to 0."""
-
-    if pe.is_empty():
-        return pe
-    sliced = pe.frame.filter(pl.col("rollout_index") == rollout_index).with_columns(
-        rollout_index=pl.lit(0, dtype=pl.Int64)
-    )
-    return PrivateEquityBundle(frame=sliced)
+def _partition_by_rollout(frame: pl.DataFrame) -> dict[int, pl.DataFrame]:
+    """Group a `rollout_index`-keyed frame into one sub-frame per rollout, in a single pass."""
+    return {
+        int(part.get_column("rollout_index")[0]): part
+        for part in frame.partition_by("rollout_index")
+        if part.height > 0
+    }
 
 
 def _slice_tax_liability_changes(log: TaxLiabilityChangeLog, rollout_index: int) -> TaxLiabilityChangeLog:


### PR DESCRIPTION
## What

End-to-end validation of the product path at scale found that `ProductService.metric_fan` was **super-linear (O(N²))**: 1000 rollouts × 240mo = 5.7s, but 10000 = **139s** (10× rollouts → 24× time).

**Root cause:** `slice_dense_result` filtered the whole batch external-series Polars frames (`series_values` + the PE bundle) once *per rollout* (`.filter(rollout_index == i)`), and the service sliced per seed — so R slices each re-scanned an R-row frame → O(R²). (The sim engine and lazy decode were fine; the rollout detail view stayed ~0.04s throughout.)

## Fix

Add `slice_dense_results(dense, rollout_indices)`: **partition** the exogenous frames by `rollout_index` once (single pass), then slice each rollout from its own sub-frame. The service slices the whole batch in one call. `slice_dense_result` remains as a thin single-rollout wrapper (still used by `simulate_test`).

## Results (metric_fan, 240mo) — output identical (failed counts unchanged)

| rollouts | before | after |
| --- | --- | --- |
| 1,000 | 5.7s | **3.0s** |
| 10,000 | 139s | **33.6s** (~4×, scaling now ~linear) |

## Benchmark

Also adds `//augur/product:service_scale_test` — drives the real `metric_fan` (sampling → batched `simulate_dense` → per-seed slice+cache → dense reductions → percentiles). CI-safe tiny by default; scale locally via `AUGUR_BENCH_ROLLOUTS` / `AUGUR_BENCH_HORIZON` / `AUGUR_BENCH_PROFILE`. This is what surfaced the bottleneck.

## Test

`bazel test //augur/sim/...` + `//augur/product/...` + `//augur/api/...` — all 21 pass; lint (ruff + mypy) clean. Branched on current `devel` (post-#1847 lazy decode).

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_