### PR TITLE
augur: clear ruff-format + prettier drift (unblocks PR pre-commit)

### DIFF
--- a/augur/calibration/resolvers.py
+++ b/augur/calibration/resolvers.py
@@ -216,7 +216,9 @@ def level_by_date_counts(
     if by_month < 0:
         return ResolutionCounts(yes=0, no=0, unresolved=n)
     window = matrix[:, : min(by_month, horizon_months) + 1]
-    reached = np.any(window >= threshold, axis=1) if direction is Direction.ABOVE else np.any(window < threshold, axis=1)
+    reached = (
+        np.any(window >= threshold, axis=1) if direction is Direction.ABOVE else np.any(window < threshold, axis=1)
+    )
     yes = int(np.count_nonzero(reached))
     if by_month <= horizon_months:
         return ResolutionCounts(yes=yes, no=n - yes, unresolved=0)

--- a/augur/plans/tax_loss_harvesting.md
+++ b/augur/plans/tax_loss_harvesting.md
@@ -42,7 +42,7 @@ expensive:
    per-name idiosyncratic vol, rebalancing, wash-sale tracking. **Avoid.** This
    is whole-market modeling: it forces a correlation structure into Augur's
    exogenous engine (which samples series independently today) and a large
-   surface of *unobservable* parameters to reproduce a quantity we can measure
+   surface of _unobservable_ parameters to reproduce a quantity we can measure
    directly from the 1099-B. Mechanistic fidelity we cannot calibrate is worse
    than a simple form we can.
 
@@ -81,7 +81,7 @@ Attach an optional harvest process to a holding. Each tax period:
   Split output into ST/LT (mostly ST early; seed from the holding-period
   buckets).
 - **Basis feedback (the one real state element):** harvesting realizes a loss
-  *and* resets that slice's basis to current market (sell-underwater + rebuy).
+  _and_ resets that slice's basis to current market (sell-underwater + rebuy).
   So the process (a) books the loss into Piece 1, and (b) lowers the position's
   tracked cost basis, which raises the embedded-gain ratio and **decays future
   yield**. A scalar basis update per position — no per-stock state.
@@ -96,7 +96,7 @@ Attach an optional harvest process to a holding. Each tax period:
   parameter. Needs prior-year 1099-Bs (TY2022–24) to fit. Until then, mark it
   `[HEURISTIC]` and keep it conservative — a flat 5%/yr extrapolated 10 years
   would massively overstate the benefit.
-- Generic process + calibration *schema* live in ducktape; the account's fitted
+- Generic process + calibration _schema_ live in ducktape; the account's fitted
   numbers live in `gaffer-private/gaffer_augur/wealthfront/`.
 
 ## Open inputs

--- a/augur/sim/tax_test.py
+++ b/augur/sim/tax_test.py
@@ -168,9 +168,7 @@ def test_net_capital_gains_vectorized_independent_rollouts() -> None:
     """One call over multiple rollouts: a gain year, a carryforward-consumed year, and a
     net-loss year each resolve independently."""
     net_st, net_lt, offset, carry_out = net_capital_gains_with_carryforward(
-        np.array([4_000.0, 1_000.0, -2_000.0]),
-        np.array([10_000.0, 1_000.0, -6_000.0]),
-        np.array([0.0, 0.0, 0.0]),
+        np.array([4_000.0, 1_000.0, -2_000.0]), np.array([10_000.0, 1_000.0, -6_000.0]), np.array([0.0, 0.0, 0.0])
     )
     assert np.allclose(net_st, [4_000.0, 1_000.0, 0.0])
     assert np.allclose(net_lt, [10_000.0, 1_000.0, 0.0])


### PR DESCRIPTION
Formatter-only, no behavior change:
- `ruff format` on `augur/calibration/resolvers.py` and `augur/sim/tax_test.py`
- `prettier` on `augur/plans/tax_loss_harvesting.md`

These drifted in on `devel` and fail the all-files `pre-commit` check. Because PR CI runs pre-commit against the PR *merged with devel*, this currently fails the pre-commit check on every open PR (e.g. #1850), not just changes that touch these files. Clearing it here unblocks them.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_