### PR TITLE
augur(frontend): fix browser_shell_test for #1848 distribution UI

### DIFF
--- a/augur/browser_shell_test.py
+++ b/augur/browser_shell_test.py
@@ -139,12 +139,12 @@ def test_product_shell_renders_metric_fan_charts(page: Page, augur_server: str) 
     page.locator("[data-product-fan-chart='cashUsd'][data-product-scale='log']").wait_for(
         state="visible", timeout=15_000
     )
-    page.locator("[data-product-histogram-scale='log']").wait_for(state="visible", timeout=15_000)
+    page.locator("[data-product-distribution-scale='log']").wait_for(state="visible", timeout=15_000)
     page.get_by_label("Chart scale").get_by_text("Linear", exact=True).click()
     page.locator("[data-product-fan-chart='cashUsd'][data-product-scale='linear']").wait_for(
         state="visible", timeout=15_000
     )
-    page.locator("[data-product-histogram-scale='linear']").wait_for(state="visible", timeout=15_000)
+    page.locator("[data-product-distribution-scale='linear']").wait_for(state="visible", timeout=15_000)
     page.get_by_label("Metric to plot").select_option("holding_value_usd")
     page.locator("[data-product-fan-chart='holdingValueUsd']").wait_for(state="visible", timeout=30_000)
     page.get_by_text("Initial portfolio").wait_for(state="visible", timeout=15_000)
@@ -160,7 +160,9 @@ def test_property_recurring_expense_events_start_hidden_on_rollout_graph(page: P
     page.goto(f"{augur_server}{_PROPERTY_LIFECYCLE_URL}", wait_until="domcontentloaded")
     page.locator("[data-augur-surface='product']").wait_for(state="visible", timeout=15_000)
     page.locator("[data-product-fan-chart='netWorthUsd']").wait_for(state="visible", timeout=30_000)
-    page.locator("[data-product-rollout-sliver]").first.click()
+    # Select a rollout by clicking the terminal-distribution plot (the per-rollout "sliver" strip
+    # was replaced by the quantile-line distribution in #1848; the plot is the click-to-inspect surface).
+    page.locator("[data-product-terminal-distribution-plot]").click()
     page.get_by_text("Selected rollout events").wait_for(state="visible", timeout=30_000)
     page.get_by_text("Event kinds").wait_for(state="visible", timeout=30_000)
     legend = page.get_by_label("Event-kind visibility legend")


### PR DESCRIPTION
## What

`//augur:browser_shell_test` is red on `devel` — independent of any in-flight
work. #1848 ("multi-variant quantile-line terminal distribution") replaced the
terminal histogram with a quantile-line distribution (`histogram.tsx` →
`terminal_distribution.tsx`) and dropped the per-rollout "sliver" strip, but
`browser_shell_test.py` (last touched in #1817) still waited on selectors that no
longer exist:

- `data-product-histogram-scale` → renamed to `data-product-distribution-scale`.
- `data-product-rollout-sliver` → removed; #1848 explicitly drops the
  `rolloutSliver` helpers.

## How

- Swap both `histogram-scale` waits to `distribution-scale`.
- Select a rollout by clicking the terminal-distribution plot
  (`data-product-terminal-distribution-plot`, `role="slider"`) — the new
  "click to inspect a rollout" surface — instead of the removed sliver strip.
  The downstream assertions (default-hidden recurring-expense event markers) are
  unchanged.

## Tests

`//augur:browser_shell_test` passes on RBE (both `test_product_shell_renders_metric_fan_charts`
and `test_property_recurring_expense_events_start_hidden_on_rollout_graph`).

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw)_