### PR TITLE
cluster/props: point agent PGHOST at CNPG service (props-db-rw)

### DIFF
--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -11,7 +11,11 @@ namespace = "props"
 image_pull_secret = "props-forgejo-robot"
 
 [agent_env]
-PGHOST = "props-postgresql"
+# Agents connect to the CNPG primary (read-write) service. Must match the
+# backend's PGHOST (deployment.yaml). The old Bitnami "props-postgresql"
+# service no longer exists since the CNPG migration, so a stale value here
+# makes every critic/grader crash at Database.from_env() before any work.
+PGHOST = "props-db-rw"
 PGPORT = "5432"
 PGDATABASE = "eval_results"
 


### PR DESCRIPTION
## What

`config.toml`'s `[agent_env]` block still set `PGHOST = "props-postgresql"` — the **old Bitnami service name**, which no longer exists after the props DB was migrated to the CNPG cluster `props-db` (services `props-db-{rw,ro,r}`). The backend's own `deployment.yaml` was updated to `props-db-rw`, but the agent env was not. Point it at `props-db-rw` to match.

## Symptom — discovered by running a live critic + grader

Firing a critic run on the richest snapshot (`ducktape/2025-12-04-00`, 146 TPs / recall_denominator 263) produced `status=exited, exit_code=1, llm_call_count=0`. Catching the ephemeral agent pod's logs before the orchestrator deleted it showed the real cause:

```
INFO __main__: Critic agent starting
INFO props.db.database: Connecting to database: props-postgresql:5432/eval_results
psycopg2.OperationalError: could not translate host name "props-postgresql"
  to address: Name or service not known
```

The agent crashes in `Database.from_env()` → `_verify_connection()` **before any LLM call**. Because every critic/grader/critic-dev pod gets the same `[agent_env]`, this is model-independent — `gpt-oss-20b-128k` critics and `glm-4.6` graders fail identically. It has silently broken **all** agent execution since the CNPG migration (~2 days ago), which is why the leaderboard `stats` are all empty.

The grader side of the pipeline is otherwise healthy: the grader supervisor **does** pick up drift (it spawned a burst of `glm-4.6` graders across many snapshots), they just die at the same DB-connect step.

## Fix

```diff
 [agent_env]
-PGHOST = "props-postgresql"
+PGHOST = "props-db-rw"
```

Stakater reloader restarts the backend on the ConfigMap change; subsequently-spawned agent pods connect to the CNPG primary.

## Validation

- `kubectl kustomize cluster/k8s/props/app` renders; agent `PGHOST` now equals the backend deployment's `PGHOST` (`props-db-rw`).
- Confirmed no other live references to `props-postgresql` (the one remaining hit is a frozen specimen snapshot under `props/specimens/.../2026-05-20-00/code/`, intentionally untouched).
- pre-commit (check-toml, cluster validators, kubeconform) clean.

## Follow-ups (out of scope, observed during diagnosis)

- A handful of grader pods hit `FailedToRetrieveImagePullSecret (props-forgejo-robot)` → `ErrImagePull` on at least one node — worth checking the pull-secret reflection/availability.
- ~28 `glm-4.6` grader runs are stuck `in_progress` (orphaned, no pods) from the failed attempts; they won't self-heal and may need a cleanup pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_