### PR TITLE
fix pre-commit: ruff ASYNC240 (tg_backup) + ruff-format drift (product decode)

### DIFF
--- a/augur/product/decode.py
+++ b/augur/product/decode.py
@@ -88,9 +88,7 @@ def monthly_metric_arrays(
         "home_equity_usd": home_equity_usd,
         "liquid_net_worth_usd": liquid_net_worth_usd,
         "net_worth_usd": liquid_net_worth_usd + home_equity_usd + private_equity_value_usd,
-        "shortfall_usd": _shortfall_by_month(
-            dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index
-        ),
+        "shortfall_usd": _shortfall_by_month(dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index),
     }
 
 
@@ -170,9 +168,7 @@ def _cash_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rol
     return cast(np.ndarray, dense.buffers.state.cash_state[:, cash_slots, rollout_index].sum(axis=1))
 
 
-def _holding_value_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
-) -> np.ndarray:
+def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
     """Sum of liquid-holding lots (stocks + crypto) priced at sampled series.
 
     Excludes private-equity lots: PE is illiquid (saleable only at tender events) so it
@@ -481,7 +477,9 @@ def _failure_events(run: SimulationRun, *, primary_agent_id: str) -> tuple[Rollo
     )
 
 
-def _property_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
+def _property_value_by_month(
+    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
+) -> np.ndarray:
     plan = dense.plan
     values = np.zeros(plan.horizon_months + 1, dtype=np.float64)
     series_index_by_id = {key: index for index, key in enumerate(plan.series_keys)}
@@ -509,7 +507,9 @@ def _property_value_by_month(dense: DenseSimulationResult, *, primary_agent_code
     return values
 
 
-def _mortgage_balance_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
+def _mortgage_balance_by_month(
+    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
+) -> np.ndarray:
     plan = dense.plan
     balance = np.zeros(plan.horizon_months + 1, dtype=np.float64)
     for lia in range(plan.liabilities.codes.shape[0]):

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -152,9 +152,7 @@ class ProductService:
         events = tuple(
             event
             for event in rollout_events_from(
-                single.decode(),
-                primary_agent_id=self._primary_agent_id,
-                asset_label_by_id=self._asset_label_by_id,
+                single.decode(), primary_agent_id=self._primary_agent_id, asset_label_by_id=self._asset_label_by_id
             )
             if event.month_index < horizon_months
         )

--- a/tgarchive/tg_backup.py
+++ b/tgarchive/tg_backup.py
@@ -75,14 +75,22 @@ async def _download_one(client: TelegramClient, msg: Message, dest: Path, sem: a
         await client.download_media(msg, file=dest)
 
 
-async def _export(takeout: TelegramClient, client: TelegramClient, entity: Entity, out_dir: Path) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    media_dir = out_dir / "media"
-    media_dir.mkdir(exist_ok=True)
+def _prepare_export_dir(out_dir: Path, entity: Entity) -> Path:
+    """Create the export + media dirs and write entity.json; return the media dir.
 
+    Synchronous on purpose: run via `asyncio.to_thread` from the async exporter so the blocking
+    filesystem setup doesn't stall the event loop (ASYNC240).
+    """
+    media_dir = out_dir / "media"
+    media_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "entity.json").write_text(
         json.dumps(entity.to_dict(), default=_json_default, indent=2, ensure_ascii=False)
     )
+    return media_dir
+
+
+async def _export(takeout: TelegramClient, client: TelegramClient, entity: Entity, out_dir: Path) -> None:
+    media_dir = await asyncio.to_thread(_prepare_export_dir, out_dir, entity)
 
     desc = _entity_slug(entity)
     total = (await takeout.get_messages(entity, limit=0)).total
@@ -104,7 +112,10 @@ async def _export(takeout: TelegramClient, client: TelegramClient, entity: Entit
                 await task
                 bar.update(1)
 
-    (out_dir / "messages.json").write_text(json.dumps(messages, default=_json_default, indent=2, ensure_ascii=False))
+    await asyncio.to_thread(
+        (out_dir / "messages.json").write_text,
+        json.dumps(messages, default=_json_default, indent=2, ensure_ascii=False),
+    )
 
 
 async def _abort_dangling_takeout(client: TelegramClient) -> None:


### PR DESCRIPTION
`nix develop --command pre-commit run --all-files` was red on `devel`. Two unrelated failures, both fixed here so the whole suite is green:

1. **`ruff-check` — `ASYNC240` in `tgarchive/tg_backup.py`.** `_export()` called blocking `pathlib` (`mkdir` / `write_text`) directly inside an `async` function. Moved the filesystem setup into a synchronous `_prepare_export_dir()` run via `asyncio.to_thread`, and the final `messages.json` write goes through `to_thread` too — so the blocking I/O no longer stalls the event loop.
2. **`ruff-format` drift in `augur/product/{decode,service}.py`.** Landed with #1859 — multi-line calls that fit on one line (and one over-long signature that should wrap). Pure reflow, semantically identical.

The `prettier` "failure" seen with a bare system `prettier` was a missing-`prettier-plugin-svelte` artifact of running outside the nix devshell — under `nix develop` (the CI environment) prettier passes. Verified the full suite green via `nix develop --command pre-commit run --all-files`.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_