### PR TITLE
augur(frontend): click away from the lines to clear a rollout selection

### DIFF
--- a/augur/browser_shell_test.py
+++ b/augur/browser_shell_test.py
@@ -178,5 +178,23 @@ def test_property_recurring_expense_events_start_hidden_on_rollout_graph(page: P
         assert page.locator(f"[data-product-rollout-event-marker='{event_kind}']").count() == 0
 
 
+def test_distribution_click_away_clears_selection(page: Page, augur_server: str) -> None:
+    """Selecting a rollout from the distribution chart and then clicking well clear of the line
+    clears the selection (click-away-to-deselect)."""
+    page.goto(f"{augur_server}{_PROPERTY_LIFECYCLE_URL}", wait_until="domcontentloaded")
+    page.locator("[data-augur-surface='product']").wait_for(state="visible", timeout=15_000)
+    page.locator("[data-product-fan-chart='netWorthUsd']").wait_for(state="visible", timeout=30_000)
+    plot = page.locator("[data-product-terminal-distribution-plot]")
+    plot.wait_for(state="visible", timeout=30_000)
+    box = plot.bounding_box()
+    assert box is not None
+    # A first click selects the nearest rollout regardless of distance — the marker appears.
+    plot.click(position={"x": box["width"] * 0.6, "y": box["height"] * 0.5})
+    page.locator("[data-product-distribution-selected]").wait_for(state="visible", timeout=30_000)
+    # A click in the empty top-left (far above the rising net-worth curve) clears the selection.
+    plot.click(position={"x": box["width"] * 0.05, "y": box["height"] * 0.06})
+    page.locator("[data-product-distribution-selected]").wait_for(state="detached", timeout=30_000)
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/augur/frontend/terminal_distribution.tsx
+++ b/augur/frontend/terminal_distribution.tsx
@@ -22,6 +22,11 @@ function orderedRollouts(summaries, metric) {
     .sort((left, right) => left.value - right.value);
 }
 
+// A click whose nearest line is farther than this (in px, on the Y axis) clears an existing
+// selection instead of selecting — "click away to deselect". Gated on an existing selection so a
+// first click anywhere still selects the nearest rollout.
+const DESELECT_DISTANCE_PX = 30;
+
 export function TerminalDistributionChart({
   scenarios,
   resultsById,
@@ -89,7 +94,8 @@ export function TerminalDistributionChart({
 
   // Pick which variant a click/hover binds to: the line nearest the cursor in Y at the cursor's
   // percentile, breaking ties toward the active variant (drawn on top) so overlapping failed floors
-  // resolve to the variant you're already inspecting.
+  // resolve to the variant you're already inspecting. `bestDist` is the distance to the genuinely
+  // nearest line (pre-tie-break), used by the click-away-to-deselect check.
   const pickVariant = (percentile, cursorY) => {
     let best = null;
     let bestDist = Infinity;
@@ -107,7 +113,7 @@ export function TerminalDistributionChart({
         best = entry;
       }
     }
-    return active && activeDist - bestDist <= 8 ? active : best;
+    return { entry: active && activeDist - bestDist <= 8 ? active : best, bestDist };
   };
 
   const localPoint = (event) => {
@@ -118,7 +124,9 @@ export function TerminalDistributionChart({
   };
 
   const selectAt = (percentile, cursorY, variantId) => {
-    const entry = variantId ? series.find((candidate) => candidate.id === variantId) : pickVariant(percentile, cursorY);
+    const entry = variantId
+      ? series.find((candidate) => candidate.id === variantId)
+      : pickVariant(percentile, cursorY).entry;
     if (!entry) return null;
     const seed = entry.ordered[indexAtPercentile(entry, percentile)].seed;
     onSelectRollout(entry.id, seed);
@@ -130,6 +138,13 @@ export function TerminalDistributionChart({
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
     const { percentile, cursorY } = localPoint(event);
+    // Click well clear of every line clears an existing selection. Gated on `selectedSeed` so a
+    // first click anywhere still selects the nearest rollout (no dead zones until something's picked).
+    if (selectedSeed != null && pickVariant(percentile, cursorY).bestDist > DESELECT_DISTANCE_PX) {
+      onClear();
+      dragVariantRef.current = { dragging: false, variantId: null, startX: 0, startY: 0, wasSelected: false };
+      return;
+    }
     const variantId = selectAt(percentile, cursorY, null);
     dragVariantRef.current = {
       dragging: true,


### PR DESCRIPTION
From the #1848 design discussion: the distribution chart bound every click to the nearest line, so once a rollout was selected the only ways to clear it were the Clear button, Esc, or re-clicking the exact selected point.

## What changed

- **Click-away-to-deselect:** a click whose nearest line is more than `DESELECT_DISTANCE_PX` (30px, in Y) away clears the current selection instead of binding to a line.
- **Gated on an existing selection:** a first click anywhere still selects the nearest rollout — there are no dead zones until something is picked. This is deliberately scoped so that **no existing goldens or first-click tests change** (the existing select-then-interact flows click when nothing is selected yet, so they're unaffected).

## Tests

Adds `test_distribution_click_away_clears_selection` to `browser_shell_test.py`: select a rollout from the chart, then click the empty top-left (well above the rising net-worth curve), and assert the `[data-product-distribution-selected]` marker is gone. `eslint_typed_test`, `browser_shell_test`, and the full `//augur:visual_test` suite all pass — and the visual suite passing confirms no goldens moved.

https://claude.ai/code/session_01Ckx1BUmBsCQQYbsX46G4gQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ckx1BUmBsCQQYbsX46G4gQ)_