### PR TITLE
augur/product: vectorize metric_fan reduction over the batch

### DIFF
--- a/augur/product/decode.py
+++ b/augur/product/decode.py
@@ -230,9 +230,9 @@ def _shortfall_by_month(dense: DenseSimulationResult, *, primary_agent_code: int
     plan = dense.plan
     shortfall = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     primary_obligations = plan.obligations.agent == primary_agent_code  # [H, O]
-    shortfall[1:] = (
-        dense.buffers.obligations.shortfall * primary_obligations[:, :, None].astype(np.float64)
-    ).sum(axis=1)
+    shortfall[1:] = (dense.buffers.obligations.shortfall * primary_obligations[:, :, None].astype(np.float64)).sum(
+        axis=1
+    )
     return shortfall
 
 

--- a/augur/product/decode.py
+++ b/augur/product/decode.py
@@ -44,34 +44,22 @@ from augur.sim.scenario import ObligationType
 _TAX_PAYMENT_OBLIGATION_TYPES = (ObligationType.ESTIMATED_TAX, ObligationType.TAX_TRUE_UP)
 
 
-def monthly_metric_arrays(
-    dense: DenseSimulationResult, *, primary_agent_id: str, rollout_index: int = 0
-) -> dict[str, np.ndarray]:
-    """Per-month product metrics for one rollout as a `{metric_name: (H+1,) ndarray}` dict.
+def monthly_metric_arrays_batch(dense: DenseSimulationResult, *, primary_agent_id: str) -> dict[str, np.ndarray]:
+    """Per-month product metrics for **every** rollout of a batched result as `{name: (H+1, R)}`.
 
-    Reads column `rollout_index` directly out of `dense`, which may be a batched (R>1) result —
-    the product cache shares one batch across all its seeds and reduces a column per seed,
-    avoiding a per-rollout dense slice. The fan + rollout-detail paths consume this directly
-    (polars-frame construction is the dominant cost in the metric-fan hot path); the
-    rollout-detail wire shape (`Frame = dict[str, list[...]]`) is built straight from these
-    arrays via `.tolist()` in `service.rollout`, with no intermediate polars frame.
+    Each metric is reduced over the whole `(…, R)` batch in one vectorized pass. The product fan
+    path caches one batch per scenario and decodes it once here, then column-slices per seed —
+    rather than looping a single-rollout reduction over R rollouts. `month_index` is the shared
+    `(H+1,)` axis (no rollout dimension).
     """
 
     plan = dense.plan
     primary_agent_code = _required_string_code(plan.strings, primary_agent_id)
-    cash_usd = _cash_by_month(dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index)
-    holding_value_usd = _holding_value_by_month(
-        dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index
-    )
-    private_equity_value_usd = _private_equity_value_by_month(
-        dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index
-    )
-    property_value_usd = _property_value_by_month(
-        dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index
-    )
-    mortgage_balance_usd = _mortgage_balance_by_month(
-        dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index
-    )
+    cash_usd = _cash_by_month(dense, primary_agent_code=primary_agent_code)
+    holding_value_usd = _holding_value_by_month(dense, primary_agent_code=primary_agent_code)
+    private_equity_value_usd = _private_equity_value_by_month(dense, primary_agent_code=primary_agent_code)
+    property_value_usd = _property_value_by_month(dense, primary_agent_code=primary_agent_code)
+    mortgage_balance_usd = _mortgage_balance_by_month(dense, primary_agent_code=primary_agent_code)
     home_equity_usd = property_value_usd - mortgage_balance_usd
     # liquid_net_worth excludes private equity by design: PE is only saleable at sparse
     # tender events, so it doesn't satisfy "cash you could get tomorrow" semantics. The
@@ -88,8 +76,16 @@ def monthly_metric_arrays(
         "home_equity_usd": home_equity_usd,
         "liquid_net_worth_usd": liquid_net_worth_usd,
         "net_worth_usd": liquid_net_worth_usd + home_equity_usd + private_equity_value_usd,
-        "shortfall_usd": _shortfall_by_month(dense, primary_agent_code=primary_agent_code, rollout_index=rollout_index),
+        "shortfall_usd": _shortfall_by_month(dense, primary_agent_code=primary_agent_code),
     }
+
+
+def monthly_metric_arrays(
+    dense: DenseSimulationResult, *, primary_agent_id: str, rollout_index: int = 0
+) -> dict[str, np.ndarray]:
+    """Per-month product metrics for one rollout (column `rollout_index`) as `{name: (H+1,)}`."""
+    batch = monthly_metric_arrays_batch(dense, primary_agent_id=primary_agent_id)
+    return {name: (values if name == "month_index" else values[:, rollout_index]) for name, values in batch.items()}
 
 
 def terminal_metrics_from_arrays(arrays: dict[str, np.ndarray], *, failed_month_index: int | None) -> TerminalMetrics:
@@ -111,9 +107,9 @@ def terminal_metrics_from_arrays(arrays: dict[str, np.ndarray], *, failed_month_
     )
 
 
-def failed_month_index_for_rollout(dense: DenseSimulationResult, *, rollout_index: int = 0) -> int | None:
-    failed_month = int(dense.buffers.state.rollout_failed_month_state[-1, rollout_index])
-    return None if failed_month < 0 else failed_month
+def failed_month_index_batch(dense: DenseSimulationResult) -> np.ndarray:
+    """Per-rollout failure month at the final snapshot; `NO_CODE` (-1) = never failed. Shape `(R,)`."""
+    return cast(np.ndarray, dense.buffers.state.rollout_failed_month_state[-1, :])
 
 
 def rollout_events_from(
@@ -163,12 +159,12 @@ def rollout_events_from(
     return tuple(sorted(events, key=lambda event: (event.month_index, priority[event.kind])))
 
 
-def _cash_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
+def _cash_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     cash_slots = np.flatnonzero(dense.plan.cash_agent_codes == primary_agent_code)
-    return cast(np.ndarray, dense.buffers.state.cash_state[:, cash_slots, rollout_index].sum(axis=1))
+    return cast(np.ndarray, dense.buffers.state.cash_state[:, cash_slots, :].sum(axis=1))
 
 
-def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
+def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     """Sum of liquid-holding lots (stocks + crypto) priced at sampled series.
 
     Excludes private-equity lots: PE is illiquid (saleable only at tender events) so it
@@ -177,31 +173,23 @@ def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code:
     """
 
     return _lot_value_by_month(
-        dense,
-        primary_agent_code=primary_agent_code,
-        include=lambda asset: not isinstance(asset, PrivateEquityAssetKey),
-        rollout_index=rollout_index,
+        dense, primary_agent_code=primary_agent_code, include=lambda asset: not isinstance(asset, PrivateEquityAssetKey)
     )
 
 
-def _private_equity_value_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
-) -> np.ndarray:
+def _private_equity_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     """Sum of private-equity lots priced at the latest sampled mark for each issuer."""
 
     return _lot_value_by_month(
-        dense,
-        primary_agent_code=primary_agent_code,
-        include=lambda asset: isinstance(asset, PrivateEquityAssetKey),
-        rollout_index=rollout_index,
+        dense, primary_agent_code=primary_agent_code, include=lambda asset: isinstance(asset, PrivateEquityAssetKey)
     )
 
 
 def _lot_value_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, include: Callable[[AssetKey], bool], rollout_index: int
+    dense: DenseSimulationResult, *, primary_agent_code: int, include: Callable[[AssetKey], bool]
 ) -> np.ndarray:
     plan = dense.plan
-    values = np.zeros(plan.horizon_months + 1, dtype=np.float64)
+    values = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     series_index_by_id = {key: index for index, key in enumerate(plan.series_keys)}
     pe_issuer_index = {str(issuer_id): idx for idx, issuer_id in enumerate(plan.pe_issuers.issuer_ids)}
     for lot in range(plan.lot_id_codes.shape[0]):
@@ -210,37 +198,40 @@ def _lot_value_by_month(
         asset = plan.assets[int(plan.lot_asset_codes[lot])]
         if not include(asset):
             continue
-        quantity = dense.buffers.state.lot_state[:, lot, rollout_index]
+        quantity = dense.buffers.state.lot_state[:, lot, :]  # (H+1, R)
         # PE lots take their mark from `pe_channels.marks` (typed bundle); non-PE lots
-        # read from the series-indexed external_values cube.
+        # read from the series-indexed external_values cube. Both are stored R-major
+        # `(…, R, months)`, so transpose to the `(months, R)` = `(H+1, R)` metric layout.
         if isinstance(asset, PrivateEquityAssetKey):
             issuer_idx = pe_issuer_index.get(str(asset.issuer_id))
             if issuer_idx is None:
                 raise ValueError(f"holding asset {asset.wire_id!r} has no compiled PE channels")
-            price = plan.pe_channels.marks[issuer_idx, rollout_index, :]
+            price = plan.pe_channels.marks[issuer_idx, :, :].T
         else:
             series_index = series_index_by_id.get(asset_price_key(asset))
             if series_index is None:
                 raise ValueError(
                     f"holding asset {asset.wire_id!r} has no modeled price series in the compiled simulation"
                 )
-            price = plan.external_values[series_index, rollout_index, :]
+            price = plan.external_values[series_index, :, :].T
         missing_price = (np.abs(quantity) > 1e-9) & ~np.isfinite(price)
         if missing_price.any():
-            months = ", ".join(str(month) for month in np.flatnonzero(missing_price)[:5])
-            raise ValueError(f"holding asset {asset.wire_id!r} has non-finite modeled price at month(s): {months}")
+            month, rollout = (int(idx) for idx in np.argwhere(missing_price)[0])
+            raise ValueError(
+                f"holding asset {asset.wire_id!r} has non-finite modeled price at month {month}, rollout {rollout}"
+            )
         values += quantity * price
     # Clamp: floating-point rounding in FIFO dollar-sells (sold_units = sold_value / price)
     # can leave lot quantities at ~-1e-10, producing a tiny negative value here.
     return np.maximum(values, 0.0)
 
 
-def _shortfall_by_month(dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int) -> np.ndarray:
+def _shortfall_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
-    shortfall = np.zeros(plan.horizon_months + 1, dtype=np.float64)
+    shortfall = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     primary_obligations = plan.obligations.agent == primary_agent_code  # [H, O]
     shortfall[1:] = (
-        dense.buffers.obligations.shortfall[:, :, rollout_index] * primary_obligations.astype(np.float64)
+        dense.buffers.obligations.shortfall * primary_obligations[:, :, None].astype(np.float64)
     ).sum(axis=1)
     return shortfall
 
@@ -477,16 +468,14 @@ def _failure_events(run: SimulationRun, *, primary_agent_id: str) -> tuple[Rollo
     )
 
 
-def _property_value_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
-) -> np.ndarray:
+def _property_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
-    values = np.zeros(plan.horizon_months + 1, dtype=np.float64)
+    values = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     series_index_by_id = {key: index for index, key in enumerate(plan.series_keys)}
     for prop in range(plan.properties.id.shape[0]):
         if int(plan.properties.buyer_agent[prop]) != primary_agent_code:
             continue
-        active = dense.buffers.state.property_active_state[:, prop, rollout_index]
+        active = dense.buffers.state.property_active_state[:, prop, :]  # (H+1, R) bool
         purchase_month = int(plan.properties.month[prop])
         if purchase_month < 0:
             continue
@@ -494,28 +483,26 @@ def _property_value_by_month(
         series_index = series_index_by_id.get(HomeValueKey(location_id=LocationId(location_id)))
         if series_index is None:
             continue
-        levels = np.nan_to_num(plan.external_values[series_index, rollout_index, :], nan=0.0)
+        levels = np.nan_to_num(plan.external_values[series_index, :, :], nan=0.0).T  # (H+1, R)
         # State snapshots are H+1 rows: index 0 = pre-month-0 opening, index s = end of month s-1.
         # The property is active starting at snapshot index `purchase_month + 1` (end of purchase month).
-        base_level = float(levels[purchase_month])
-        if base_level == 0.0:
-            continue
+        base_level = levels[purchase_month]  # (R,) per-rollout base value at the purchase month
         purchase_price = float(plan.properties.purchase_price[prop])
-        # snapshot s corresponds to month index s-1 for s >= 1; clamp s=0 to month 0 for the base.
-        market = purchase_price * levels / base_level
+        # Per rollout: market = purchase_price × level / base_level. Rollouts whose base level never
+        # resolved (0) contribute nothing for this property (the R=1 path skipped it via `continue`).
+        safe_base = np.where(base_level == 0.0, 1.0, base_level)
+        market = np.where(base_level[None, :] == 0.0, 0.0, purchase_price * levels / safe_base[None, :])
         values += np.where(active, market, 0.0)
     return values
 
 
-def _mortgage_balance_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, rollout_index: int
-) -> np.ndarray:
+def _mortgage_balance_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
-    balance = np.zeros(plan.horizon_months + 1, dtype=np.float64)
+    balance = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     for lia in range(plan.liabilities.codes.shape[0]):
         if int(plan.liabilities.agent[lia]) != primary_agent_code:
             continue
-        balance += dense.buffers.state.liability_principal_state[:, lia, rollout_index]
+        balance += dense.buffers.state.liability_principal_state[:, lia, :]
     return balance
 
 

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -27,8 +27,8 @@ from augur.model.exogenous import (
     validate_sample_satisfies_request,
 )
 from augur.product.decode import (
-    failed_month_index_for_rollout,
-    monthly_metric_arrays,
+    failed_month_index_batch,
+    monthly_metric_arrays_batch,
     rollout_events_from,
     terminal_metrics_from_arrays,
 )
@@ -203,15 +203,28 @@ class ProductService:
             for seed, entry in fresh.items():
                 cached_by_seed[seed] = entry
                 self._cache_put(cache_key, seed, entry)
+        # Reduce each distinct simulated batch once over its whole (…, R) axis, then column-slice
+        # per seed — rather than calling the reduction once per rollout. Seeds requested together
+        # usually share one batch, so the common fan request is a single vectorized reduction pass.
+        batch_metrics: dict[int, dict[str, np.ndarray]] = {}
+        batch_failed: dict[int, np.ndarray] = {}
         decoded: list[_DecodedRollout] = []
         for seed in seeds:
             cached = cached_by_seed[seed]
-            full_arrays = monthly_metric_arrays(
-                cached.batch, primary_agent_id=self._primary_agent_id, rollout_index=cached.column_index
-            )
+            batch_key = id(cached.batch)
+            if batch_key not in batch_metrics:
+                batch_metrics[batch_key] = monthly_metric_arrays_batch(
+                    cached.batch, primary_agent_id=self._primary_agent_id
+                )
+                batch_failed[batch_key] = failed_month_index_batch(cached.batch)
             # `month_index` runs 0..H_max; keep months 0..horizon (i.e. the first horizon+1 snapshots).
-            arrays = {name: array[: horizon_months + 1] for name, array in full_arrays.items()}
-            full_failed_month = failed_month_index_for_rollout(cached.batch, rollout_index=cached.column_index)
+            # Metric columns are (H+1, R); `month_index` has no rollout axis.
+            arrays = {
+                name: (values if name == "month_index" else values[:, cached.column_index])[: horizon_months + 1]
+                for name, values in batch_metrics[batch_key].items()
+            }
+            failed_month = int(batch_failed[batch_key][cached.column_index])
+            full_failed_month = None if failed_month < 0 else failed_month
             # Months are 0-based (0..horizon-1); a failure at/after the requested horizon is outside it.
             in_window = full_failed_month is not None and full_failed_month < horizon_months
             terminal = terminal_metrics_from_arrays(arrays, failed_month_index=full_failed_month if in_window else None)

--- a/augur/product/service_test.py
+++ b/augur/product/service_test.py
@@ -329,7 +329,7 @@ def test_metric_fan_and_rollout_detail_share_cached_sim_rollouts(
 def test_metric_fan_decodes_each_rollout_once_per_batch(
     product: service.ProductService, monkeypatch: pytest.MonkeyPatch, scenario_key: ScenarioKey
 ) -> None:
-    original = decode.monthly_metric_arrays
+    original = decode.monthly_metric_arrays_batch
     calls = 0
 
     def counted(*args, **kwargs):
@@ -337,13 +337,14 @@ def test_metric_fan_decodes_each_rollout_once_per_batch(
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(service, "monthly_metric_arrays", counted)
+    monkeypatch.setattr(service, "monthly_metric_arrays_batch", counted)
 
     product.metric_fan(
         MetricFanRequest(scenario=scenario_key, rollout_seeds=(7, 8, 9, 10), metric="cash_usd", percentiles=(50,))
     )
 
-    assert calls == 4
+    # All four seeds share one simulated batch, so the batch is reduced exactly once (not per rollout).
+    assert calls == 1
 
 
 def test_metric_fan_does_not_materialize_rollout_events(


### PR DESCRIPTION
## What

After #1859 eliminated per-rollout slicing, the **last marshaling cost** in `metric_fan` was the reduction: `_decoded_rollouts` called `monthly_metric_arrays` once per rollout — 10k Python iterations, each looping over lots / properties / liabilities — ~2.6s (≈17%) at 10k × 100mo.

This makes the metric reductions **batch-native**:
- `monthly_metric_arrays_batch(dense)` reduces every metric over the whole `(…, R)` batch in one vectorized pass, returning `(H+1, R)` per metric (the `_*_by_month` helpers keep the rollout axis and operate on all R at once).
- `_decoded_rollouts` reduces each **distinct batch once** (grouped by `id`) and column-slices per seed, instead of a per-rollout reduction call.
- The single-rollout `monthly_metric_arrays(…, rollout_index)` is kept as a thin column wrapper (used by the R=1 unit test and `rollout()`-adjacent paths).

## Measured (10k rollouts × 100-month horizon)

| | before | after |
|---|---|---|
| whole `metric_fan` (wall) | 15.3s | **11.6s** |
| reduction (`monthly_metric_arrays` ×10k) | 2.6s / 17% | **gone from profile** |
| function calls | 4.0M | 2.3M |

`metric_fan` is now dominated entirely by `simulate_dense_with_external_series` (the month loop) and `composite.sample` (GBM + PE draws) — i.e. the actual stochastic simulation, with no per-rollout Python marshaling left.

## Behavior

Identical — column `i` of the batch reduction equals the old per-rollout result (same arrays, same arithmetic, just kept on the R axis). `service_test` (cache-reuse, **decode-once-per-batch** — now asserts a single batch reduction for the shared-batch fan request, failed-rollout freeze), `server_test`, and `simulate_test` all pass.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_