### PR TITLE
openai_utils/model: distinct type for GLM-mislabeled reasoning content

### DIFF
--- a/openai_utils/BUILD.bazel
+++ b/openai_utils/BUILD.bazel
@@ -142,6 +142,18 @@ py_test(
 )
 
 py_test(
+    name = "test_model",
+    srcs = ["test_model.py"],
+    deps = [
+        ":conftest",
+        ":model",
+        "@pypi//openai",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_json_schema",
     srcs = ["test_json_schema.py"],
     deps = [

--- a/openai_utils/BUILD.bazel
+++ b/openai_utils/BUILD.bazel
@@ -148,6 +148,7 @@ py_test(
         ":conftest",
         ":model",
         "@pypi//openai",
+        "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/openai_utils/model.py
+++ b/openai_utils/model.py
@@ -14,7 +14,7 @@ from openai.types.responses import (
     ResponseOutputText,
     response_usage as sdk_usage_types,
 )
-from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+from openai.types.responses.response_reasoning_item import Content as SdkReasoningContent, ResponseReasoningItem
 from pydantic import BaseModel, ConfigDict, Field
 
 from openai_utils.errors import translate_context_length
@@ -142,19 +142,38 @@ class ReasoningSummaryItem(BaseModel):
 
 
 class ReasoningContentItem(BaseModel):
-    """Content item within a reasoning block (contains actual reasoning text)."""
+    """Content item within a reasoning block (OpenAI-standard reasoning text)."""
 
     text: str
-    # OpenAI tags reasoning content "reasoning_text". z.ai's GLM models (e.g.
-    # glm-4.6) bridged to the Responses API by our in-cluster LiteLLM
-    # (chat/completions -> Responses) instead put the chain-of-thought in a
-    # reasoning item whose content parts are tagged "output_text". Verified
-    # against the live stack: the actual answer and tool calls still arrive as
-    # separate `message` / `function_call` output items, so this is purely a
-    # mislabel of the reasoning text — accept "output_text" here so
-    # ResponsesResult.from_sdk (and the backend's LLMRequestInfo, which 500s on
-    # the same mismatch) don't reject the GLM stack's reasoning items.
-    type: Literal["reasoning_text", "output_text"] = "reasoning_text"
+    type: Literal["reasoning_text"] = "reasoning_text"
+
+
+class ReasoningOutputTextItem(BaseModel):
+    """Reasoning-block content that the z.ai GLM stack tags "output_text".
+
+    z.ai's GLM models (e.g. glm-4.6) return the chain-of-thought in chat
+    `reasoning_content`; our in-cluster LiteLLM chat->Responses bridge
+    (`use_chat_completions_api`) maps it to a reasoning output item but tags the
+    content parts "output_text" instead of the OpenAI-standard "reasoning_text".
+    It is still reasoning — verified against the live stack, the actual answer
+    and tool calls arrive as separate `message` / `function_call` items. We keep
+    this as a distinct type (rather than widening ReasoningContentItem) so the
+    OpenAI-standard model stays strict.
+
+    TODO: this is a workaround for a LiteLLM bridge mislabel. Prefer a real fix:
+    a LiteLLM config/version that emits "reasoning_text", or have props speak
+    chat/completions directly (it is currently Responses-API-only, see
+    props/backend/routes/llm.py) so reasoning doesn't round-trip through the
+    lossy Responses bridge at all. Track in props/TODO.md.
+    """
+
+    text: str
+    type: Literal["output_text"] = "output_text"
+
+
+# A reasoning item's content is normally "reasoning_text"; the z.ai GLM stack
+# mislabels it "output_text" (see ReasoningOutputTextItem).
+ReasoningContent = ReasoningContentItem | ReasoningOutputTextItem
 
 
 class ReasoningItem(BaseModel):
@@ -167,7 +186,7 @@ class ReasoningItem(BaseModel):
     type: Literal["reasoning"] = "reasoning"
     id: str | None = None
     summary: list[ReasoningSummaryItem] = Field(default_factory=list)
-    content: list[ReasoningContentItem] = Field(default_factory=list)
+    content: list[ReasoningContent] = Field(default_factory=list)
     # Don't serialize status for input - use Field(exclude=True) or model_dump(exclude={'status'})
     model_config = ConfigDict(extra="allow")
 
@@ -317,6 +336,19 @@ def _message_output_to_assistant(message: ResponseOutputMessage) -> AssistantMes
     return AssistantMessageOut(content=parts, id=message.id)
 
 
+def _reasoning_content_from_sdk(content: SdkReasoningContent) -> ReasoningContent:
+    """Map an SDK reasoning content part to our typed item.
+
+    The z.ai GLM stack tags reasoning content "output_text" (see
+    ReasoningOutputTextItem); everything else is OpenAI-standard "reasoning_text".
+    """
+    # The SDK declares content.type as Literal["reasoning_text"], but the GLM
+    # stack sends "output_text" at runtime; compare as str to dodge that lie.
+    if cast(str, content.type) == "output_text":
+        return ReasoningOutputTextItem(text=content.text)
+    return ReasoningContentItem(text=content.text)
+
+
 class ResponsesResult(BaseModel):
     id: str
     usage: ResponseUsage | None = None
@@ -335,9 +367,7 @@ class ResponsesResult(BaseModel):
                         summary=[ReasoningSummaryItem(text=s.text, type=s.type) for s in item.summary]
                         if item.summary
                         else [],
-                        content=[ReasoningContentItem(text=c.text, type=c.type) for c in item.content]
-                        if item.content
-                        else [],
+                        content=[_reasoning_content_from_sdk(c) for c in item.content] if item.content else [],
                         # Don't include status - it causes "Unknown parameter" error when sent back as input
                     )
                 )

--- a/openai_utils/model.py
+++ b/openai_utils/model.py
@@ -145,7 +145,16 @@ class ReasoningContentItem(BaseModel):
     """Content item within a reasoning block (contains actual reasoning text)."""
 
     text: str
-    type: Literal["reasoning_text"] = "reasoning_text"
+    # OpenAI tags reasoning content "reasoning_text". z.ai's GLM models (e.g.
+    # glm-4.6) bridged to the Responses API by our in-cluster LiteLLM
+    # (chat/completions -> Responses) instead put the chain-of-thought in a
+    # reasoning item whose content parts are tagged "output_text". Verified
+    # against the live stack: the actual answer and tool calls still arrive as
+    # separate `message` / `function_call` output items, so this is purely a
+    # mislabel of the reasoning text — accept "output_text" here so
+    # ResponsesResult.from_sdk (and the backend's LLMRequestInfo, which 500s on
+    # the same mismatch) don't reject the GLM stack's reasoning items.
+    type: Literal["reasoning_text", "output_text"] = "reasoning_text"
 
 
 class ReasoningItem(BaseModel):

--- a/openai_utils/test_model.py
+++ b/openai_utils/test_model.py
@@ -1,0 +1,98 @@
+"""Tests for ResponsesResult.from_sdk output-item parsing."""
+
+from typing import Any, cast
+
+import pytest_bazel
+from openai.types.responses import Response, ResponseFunctionToolCall, ResponseOutputMessage, ResponseOutputText
+from openai.types.responses.response_reasoning_item import Content, ResponseReasoningItem
+
+from openai_utils.model import (
+    AssistantMessageOut,
+    FunctionCallItem,
+    ReasoningContentItem,
+    ReasoningItem,
+    ResponsesResult,
+)
+
+
+def test_reasoning_content_item_accepts_glm_output_text() -> None:
+    # z.ai GLM via the LiteLLM Responses bridge tags reasoning content
+    # "output_text" instead of "reasoning_text"; the model must accept it.
+    assert ReasoningContentItem(text="thinking", type="output_text").type == "output_text"
+    assert ReasoningContentItem(text="thinking").type == "reasoning_text"
+
+
+def _glm_sdk_response() -> Response:
+    """A Response shaped like glm-4.6's real output through the LiteLLM bridge:
+    a reasoning item whose content is mislabeled "output_text", followed by the
+    actual answer as a `message` and a `function_call`. model_construct mirrors
+    what the SDK hands us at runtime."""
+    return Response.model_construct(
+        id="resp_1",
+        created_at=0.0,
+        model="glm-4.6",
+        object="response",
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=None,
+        output=[
+            ResponseReasoningItem.model_construct(
+                id="rs_1",
+                type="reasoning",
+                summary=[],
+                # The SDK's reasoning Content.type is Literal["reasoning_text"];
+                # GLM sends "output_text". cast injects the real wire value past
+                # the SDK literal (model_construct already skips validation).
+                content=[
+                    Content.model_construct(text="The user wants the total apples.", type=cast(Any, "output_text"))
+                ],
+            ),
+            ResponseOutputMessage.model_construct(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText.model_construct(type="output_text", text="The total is 11.", annotations=[])
+                ],
+            ),
+            ResponseFunctionToolCall.model_construct(
+                id="fc_1",
+                type="function_call",
+                call_id="call_1",
+                name="multiply",
+                arguments='{"a": 2, "b": 4}',
+                status="completed",
+            ),
+        ],
+    )
+
+
+def test_from_sdk_handles_glm_mislabeled_reasoning_with_separate_answer() -> None:
+    result = ResponsesResult.from_sdk(_glm_sdk_response())
+
+    assert [type(item).__name__ for item in result.output] == [
+        "ReasoningItem",
+        "AssistantMessageOut",
+        "FunctionCallItem",
+    ]
+
+    reasoning = result.output[0]
+    assert isinstance(reasoning, ReasoningItem)
+    # The mislabeled "output_text" reasoning content is kept as reasoning.
+    assert reasoning.content == [ReasoningContentItem(text="The user wants the total apples.", type="output_text")]
+
+    # The real answer survives as a separate assistant message — not buried in reasoning.
+    answer = result.output[1]
+    assert isinstance(answer, AssistantMessageOut)
+    assert answer.content is not None
+    assert answer.content[0].text == "The total is 11."
+
+    call = result.output[2]
+    assert isinstance(call, FunctionCallItem)
+    assert call.name == "multiply"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/openai_utils/test_model.py
+++ b/openai_utils/test_model.py
@@ -2,24 +2,28 @@
 
 from typing import Any, cast
 
+import pytest
 import pytest_bazel
 from openai.types.responses import Response, ResponseFunctionToolCall, ResponseOutputMessage, ResponseOutputText
 from openai.types.responses.response_reasoning_item import Content, ResponseReasoningItem
+from pydantic import ValidationError
 
 from openai_utils.model import (
     AssistantMessageOut,
     FunctionCallItem,
     ReasoningContentItem,
     ReasoningItem,
+    ReasoningOutputTextItem,
     ResponsesResult,
 )
 
 
-def test_reasoning_content_item_accepts_glm_output_text() -> None:
-    # z.ai GLM via the LiteLLM Responses bridge tags reasoning content
-    # "output_text" instead of "reasoning_text"; the model must accept it.
-    assert ReasoningContentItem(text="thinking", type="output_text").type == "output_text"
-    assert ReasoningContentItem(text="thinking").type == "reasoning_text"
+def test_reasoning_content_item_stays_strict() -> None:
+    # ReasoningContentItem is OpenAI-standard "reasoning_text" only; the z.ai GLM
+    # "output_text" variant is a separate type, not a widening of this one.
+    with pytest.raises(ValidationError):
+        ReasoningContentItem.model_validate({"text": "x", "type": "output_text"})
+    assert ReasoningOutputTextItem(text="thinking").type == "output_text"
 
 
 def _glm_sdk_response() -> Response:
@@ -80,8 +84,9 @@ def test_from_sdk_handles_glm_mislabeled_reasoning_with_separate_answer() -> Non
 
     reasoning = result.output[0]
     assert isinstance(reasoning, ReasoningItem)
-    # The mislabeled "output_text" reasoning content is kept as reasoning.
-    assert reasoning.content == [ReasoningContentItem(text="The user wants the total apples.", type="output_text")]
+    # GLM's "output_text" reasoning content becomes the distinct variant type,
+    # leaving ReasoningContentItem untouched.
+    assert reasoning.content == [ReasoningOutputTextItem(text="The user wants the total apples.")]
 
     # The real answer survives as a separate assistant message — not buried in reasoning.
     answer = result.output[1]
@@ -92,6 +97,30 @@ def test_from_sdk_handles_glm_mislabeled_reasoning_with_separate_answer() -> Non
     call = result.output[2]
     assert isinstance(call, FunctionCallItem)
     assert call.name == "multiply"
+
+
+def test_from_sdk_keeps_standard_reasoning_text() -> None:
+    resp = Response.model_construct(
+        id="resp_2",
+        created_at=0.0,
+        model="gpt-5",
+        object="response",
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=None,
+        output=[
+            ResponseReasoningItem.model_construct(
+                id="rs_2",
+                type="reasoning",
+                summary=[],
+                content=[Content.model_construct(text="standard cot", type="reasoning_text")],
+            )
+        ],
+    )
+    reasoning = ResponsesResult.from_sdk(resp).output[0]
+    assert isinstance(reasoning, ReasoningItem)
+    assert reasoning.content == [ReasoningContentItem(text="standard cot")]
 
 
 if __name__ == "__main__":

--- a/props/TODO.md
+++ b/props/TODO.md
@@ -16,3 +16,4 @@
 
 - Sane story for applying migrations without full `db recreate` (direct `alembic upgrade head`)
 - Bulk specimen sync in `props db sync` from Bazel bundle artifacts (currently one-by-one via `sync-specimen`)
+- LLM API shape: props is OpenAI-Responses-only (`backend/routes/llm.py` proxies `/v1/responses`). z.ai (no native `/responses`) only works through LiteLLM's `use_chat_completions_api` chat→Responses bridge, which mislabels GLM reasoning content as `output_text` (worked around by `ReasoningOutputTextItem` in `openai_utils/model.py`). Find a better fix: a LiteLLM config/version that emits `reasoning_text`, or teach props to speak `chat/completions` directly so reasoning doesn't round-trip the lossy Responses bridge.


### PR DESCRIPTION
## What

z.ai's GLM models (e.g. `glm-4.6`), bridged to the OpenAI Responses API by our in-cluster LiteLLM (`chat/completions` → Responses, `use_chat_completions_api`), return the chain-of-thought in a `reasoning` output item whose content parts are tagged **`output_text`** instead of the OpenAI-standard **`reasoning_text`**.

`ResponsesResult.from_sdk` built every reasoning content part as `ReasoningContentItem` (`type: Literal["reasoning_text"]`), so the first GLM call raised:

```
ValidationError: ReasoningContentItem.type
  Input should be 'reasoning_text' [input_value='output_text']
```

This crashed **every glm-4.6 agent on its first LLM call** — critics and, crucially, **graders** (the default grader model is glm-4.6) — and also **500'd** `GET /api/runs/{id}/llm_requests` (its `LLMRequestInfo.response_body` is a `ResponsesResult`, validated through the same model).

## Where the mislabel comes from (verified on the live stack)

- Poked **z.ai natively** (`/chat/completions`): it's clean — returns the thinking in `reasoning_content` and the answer in `content` as separate fields.
- Poked **litellm `/v1/responses`** (`glm-4.6` + reasoning + tools): the bridge correctly splits these into a `reasoning` item + a `message` item + a `function_call`, but tags the reasoning item's content `output_text`:
  ```
  output[0] reasoning      content[0].type=output_text   ← chain-of-thought
  output[1] message        content[0].type=output_text   ← the actual answer
  output[2] function_call  name=multiply ...             ← tool call
  ```
  So it's purely a **LiteLLM bridge mislabel**; the answer and tool calls are never buried.

## Change (distinct type, not a widening)

`ReasoningContentItem` stays strictly `Literal["reasoning_text"]`. A new `ReasoningOutputTextItem` (`type: Literal["output_text"]`) carries the GLM variant; `ReasoningItem.content` becomes `list[ReasoningContent]` (= `ReasoningContentItem | ReasoningOutputTextItem`), and `from_sdk` dispatches on the wire type.

A `TODO` (and a `props/TODO.md` entry) tracks a better long-term fix: a LiteLLM config/version that emits `reasoning_text`, or teaching props to speak `chat/completions` directly (it is **Responses-API-only** today — `backend/routes/llm.py`) so reasoning doesn't round-trip the lossy Responses bridge.

## Testing

- `bbr test //openai_utils:test_model` — PASS. Tests: `ReasoningContentItem` stays strict (rejects `output_text`); `from_sdk` maps GLM's mislabeled reasoning to `ReasoningOutputTextItem` while the answer survives as a separate `message`; standard `reasoning_text` still parses to `ReasoningContentItem`.
- `bbr build //props/backend/routes:runs //props/backend/routes:llm //props/backend:app` — clean (the `ResponsesResult` union change doesn't break props consumers). ruff + mypy aspects clean.

## Note

Unblocks glm-4.6 critics/graders once the rebuilt images deploy (CI) — the remaining blocker after #1860 (agent DB PGHOST). gpt-oss critics remain gated only on the home GPU / ollama being up (separate).

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o