### PR TITLE
augur/model: state-space model can emit a level series as a copy of a fitted factor

### DIFF
--- a/augur/model/state_space.py
+++ b/augur/model/state_space.py
@@ -39,7 +39,7 @@ from augur.model.private_equity_protocol import (
 )
 from augur.model.provenance import stable_identity_digest
 from augur.model.schemas import FrozenModel
-from augur.model.series import CryptoKey, IssuerId, LevelSeriesKey, SP500Key
+from augur.model.series import CryptoKey, IssuerId, LevelSeriesKey, SP500Key, parse_level_series_key
 from augur.model.series_model import derive_stream_rollout_seeds
 from augur.model.state_space_factor import FactorKey, PrivateEquityMarkKey, parse_factor_key
 from augur.model.trained_private_equity import TrainedPrivateEquityScalePrior, private_equity_soft_cap_penalty
@@ -69,6 +69,12 @@ class StateSpaceModelArtifact(FrozenModel):
     private_equity_scale_priors: dict[str, TrainedPrivateEquityScalePrior] = Field(default_factory=dict)
     source_manifest: dict[str, Any] = Field(default_factory=dict)
     prior_manifest: dict[str, Any] = Field(default_factory=dict)
+    # Level series the model EMITS as an exact copy of a fitted factor's sampled path, mapping the
+    # emitted wire-id -> source factor wire-id (which must be a fitted level factor in
+    # `factor_names`). This is the model's own modeling choice — e.g. emit a second location's
+    # home_value/rent equal to a fitted location's draws — kept inside the trained artifact so a
+    # different model can fit those series independently instead. Copy and source must share kind.
+    emitted_factor_copies: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_shapes(self) -> StateSpaceModelArtifact:
@@ -100,6 +106,18 @@ class StateSpaceModelArtifact(FrozenModel):
                 "private_equity_event_priors missing issuer(s) "
                 f"{sorted(missing_event_priors)}; private-equity tender event series is required"
             )
+        for copy_wire, source_wire in self.emitted_factor_copies.items():
+            if source_wire not in factors:
+                raise ValueError(f"emitted_factor_copies source {source_wire!r} is not a fitted factor")
+            if copy_wire in factors:
+                raise ValueError(f"emitted_factor_copies key {copy_wire!r} is already a fitted factor; drop the copy")
+            copy_key = parse_level_series_key(copy_wire)
+            source_key = parse_level_series_key(source_wire)
+            if copy_key.kind != source_key.kind:
+                raise ValueError(
+                    f"emitted_factor_copies {copy_wire!r} -> {source_wire!r} must share kind "
+                    f"({copy_key.kind} != {source_key.kind})"
+                )
         return self
 
     @cached_property
@@ -120,6 +138,15 @@ class StateSpaceModelArtifact(FrozenModel):
         """PE issuer ids in `factor_names` order."""
 
         return tuple(item.issuer_id for item in self.factor_classifications if isinstance(item, PrivateEquityMarkKey))
+
+    @cached_property
+    def emitted_copy_level_keys(self) -> tuple[tuple[LevelSeriesKey, LevelSeriesKey], ...]:
+        """(emitted copy key, source factor key) for each `emitted_factor_copies` entry."""
+
+        return tuple(
+            (parse_level_series_key(copy_wire), parse_level_series_key(source_wire))
+            for copy_wire, source_wire in self.emitted_factor_copies.items()
+        )
 
 
 @dataclass(frozen=True)
@@ -254,7 +281,7 @@ class StateSpaceModel:
         return self.artifact.level_factors
 
     def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
-        return frozenset(self.artifact.level_factors)
+        return frozenset(self.artifact.level_factors) | {copy_key for copy_key, _ in self.artifact.emitted_copy_level_keys}
 
     def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
         return frozenset(self.artifact.private_equity_factor_issuers)
@@ -296,6 +323,10 @@ class StateSpaceModel:
                     )
                 continue
             level_by_key[classification] = levels
+        # The model emits its chosen copy series by reusing a fitted factor's sampled draws under
+        # the copy's own level key (e.g. a second location's home_value equal to a fitted one's).
+        for copy_key, source_key in self.artifact.emitted_copy_level_keys:
+            level_by_key[copy_key] = level_by_key[source_key]
         asset_price_blocks, property_value_blocks, index_blocks = partition_level_blocks(level_by_key.items())
         frames = assemble_level_magisteria(
             asset_price_blocks=asset_price_blocks,

--- a/augur/model/state_space_test.py
+++ b/augur/model/state_space_test.py
@@ -21,6 +21,7 @@ from augur.model.series import (
     SP500Key,
 )
 from augur.model.state_space import (
+    StateSpaceModel,
     StateSpaceModelArtifact,
     StateSpacePrivateEquityEventPrior,
     StateSpaceProviderConfig,
@@ -149,7 +150,10 @@ def _provider(
 
 
 def _artifact(
-    *, pe_tender_interval_months_median: float = 2.0, pe_tender_interval_log_sigma: float = 0.1
+    *,
+    pe_tender_interval_months_median: float = 2.0,
+    pe_tender_interval_log_sigma: float = 0.1,
+    emitted_factor_copies: dict[str, str] | None = None,
 ) -> StateSpaceModelArtifact:
     sp500 = SP500Key().wire_id
     inflation = InflationKey().wire_id
@@ -185,7 +189,45 @@ def _artifact(
         },
         source_manifest={"source_ids": ("fixture:public",)},
         prior_manifest={"kind": "fixture"},
+        emitted_factor_copies=emitted_factor_copies or {},
     )
+
+
+def test_state_space_emits_chosen_factor_copies_with_identical_draws() -> None:
+    # The model privately chooses to emit a second location's home_value/rent equal to a fitted
+    # location's draws; the copy series must be emittable and numerically identical to its source.
+    hv_sf = HomeValueKey(location_id=LocationId("san_francisco_ca"))
+    rent_sf = RentKey(location_id=LocationId("san_francisco_ca"))
+    hv_mi = HomeValueKey(location_id=LocationId("mare_island_vallejo_ca"))
+    rent_mi = RentKey(location_id=LocationId("mare_island_vallejo_ca"))
+    artifact = _artifact(emitted_factor_copies={hv_mi.wire_id: hv_sf.wire_id, rent_mi.wire_id: rent_sf.wire_id})
+    model = StateSpaceModel(artifact=artifact, conditioning=ExogenousConditioningContext(start_at=date(2026, 5, 1)))
+
+    assert {hv_mi, rent_mi} <= model.emittable_level_keys()
+    sampled = model.sample(
+        ExogenousSamplingRequest(
+            rollout_seeds=(3, 4),
+            horizon_months=3,
+            **level_series_request_channels(frozenset({hv_mi, rent_mi})),
+        )
+    )
+    for copy_key, source_key in ((hv_mi, hv_sf), (rent_mi, rent_sf)):
+        np.testing.assert_array_equal(
+            sampled.level_matrix(copy_key, rollout_count=2, horizon_months=3),
+            sampled.level_matrix(source_key, rollout_count=2, horizon_months=3),
+        )
+
+
+def test_state_space_artifact_rejects_invalid_factor_copies() -> None:
+    hv_sf = HomeValueKey(location_id=LocationId("san_francisco_ca")).wire_id
+    rent_sf = RentKey(location_id=LocationId("san_francisco_ca")).wire_id
+    hv_mi = HomeValueKey(location_id=LocationId("mare_island_vallejo_ca")).wire_id
+    with pytest.raises(ValueError, match="not a fitted factor"):
+        _artifact(emitted_factor_copies={hv_mi: HomeValueKey(location_id=LocationId("nowhere_xx")).wire_id})
+    with pytest.raises(ValueError, match="already a fitted factor"):
+        _artifact(emitted_factor_copies={hv_sf: hv_sf})
+    with pytest.raises(ValueError, match="must share kind"):
+        _artifact(emitted_factor_copies={hv_mi: rent_sf})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Let a state-space model emit a level series as an exact copy of one of its fitted
factors' sampled draws — a **model-layer** decision recorded in the trained
artifact, not a deployment-config alias.

Motivation: gaffer models `mare_island_vallejo_ca` (a real, distinct property
location) with the same home-value/rent dynamics as `vallejo_ca` / SF rent. The
old `location_series_sources` *provider-config* knob for this was removed (Phase
3 deferral), which left no way to emit those series. This puts the choice where
it belongs: inside the model.

## How

- `StateSpaceModelArtifact.emitted_factor_copies: dict[str, str]` — maps an
  emitted level wire-id → a fitted source factor wire-id (e.g.
  `home_value:mare_island_vallejo_ca` → `home_value:vallejo_ca`).
- `StateSpaceModel.sample(...)` emits each copy by reusing the source factor's
  sampled draws under the copy's own `LevelSeriesKey`; `emittable_level_keys()`
  includes the copies (so `sample_sanity` sees them as modeled).
- Validation: source must be a fitted factor, the copy must not already be one,
  and copy/source must be non-PE level series of the **same kind**.

The model still emits two distinct series (source + copy); it simply chooses to
model one as equal to the other. A different model (or provider type) can fit
them independently instead.

## Tests

- `state_space_test`: emittable includes the copies and `sample` produces
  numerically identical matrices for copy vs source; the artifact rejects an
  unfitted source, an already-fitted copy key, and a kind mismatch.
- `//augur/model/...` all pass on RBE.

## Follow-up

gaffer records its choice (`mare_island`→`vallejo`, `rent:{vallejo,mare_island}`→SF
rent) in its trained artifact and repins to this commit (gaffer #237).

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw)_