### PR TITLE
augur/model: clear ruff-format drift (unblocks Pre-commit checks)

### DIFF
--- a/augur/model/state_space.py
+++ b/augur/model/state_space.py
@@ -281,7 +281,9 @@ class StateSpaceModel:
         return self.artifact.level_factors
 
     def emittable_level_keys(self) -> frozenset[LevelSeriesKey]:
-        return frozenset(self.artifact.level_factors) | {copy_key for copy_key, _ in self.artifact.emitted_copy_level_keys}
+        return frozenset(self.artifact.level_factors) | {
+            copy_key for copy_key, _ in self.artifact.emitted_copy_level_keys
+        }
 
     def emittable_private_equity_issuers(self) -> frozenset[IssuerId]:
         return frozenset(self.artifact.private_equity_factor_issuers)

--- a/augur/model/state_space_test.py
+++ b/augur/model/state_space_test.py
@@ -206,9 +206,7 @@ def test_state_space_emits_chosen_factor_copies_with_identical_draws() -> None:
     assert {hv_mi, rent_mi} <= model.emittable_level_keys()
     sampled = model.sample(
         ExogenousSamplingRequest(
-            rollout_seeds=(3, 4),
-            horizon_months=3,
-            **level_series_request_channels(frozenset({hv_mi, rent_mi})),
+            rollout_seeds=(3, 4), horizon_months=3, **level_series_request_channels(frozenset({hv_mi, rent_mi}))
         )
     )
     for copy_key, source_key in ((hv_mi, hv_sf), (rent_mi, rent_sf)):


### PR DESCRIPTION
## What

`augur/model/state_space.py` and `augur/model/state_space_test.py` landed on `devel` (via #1868) not matching `ruff-format`. The **`Pre-commit checks`** CI job runs `pre-commit run --all-files`, so this drift turns that check **red on `devel` and on every PR branched from it** (e.g. #1870) — even when the PR's own files are clean.

Reformatting clears it. Pure whitespace/line-wrapping; no behavior change.

```
augur/model/state_space.py        | 4 ++--
augur/model/state_space_test.py   | 4 ++--
```

(Applied via the repo's pinned `ruff-format` through `pre-commit`, so it matches CI exactly.)

## Why a separate PR

This is the same recurring augur formatter drift that's had dedicated "clear formatter drift" PRs before (#1845, #1852, #1853). Keeping it out of the unrelated PRs it's blocking, and it unblocks the `Pre-commit checks` job repo-wide once merged.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_