### PR TITLE
props/orchestration: finalize cancelled agent runs (fix IN_PROGRESS leak)

### DIFF
--- a/props/db/migrations/versions/20260604000000_add_cancelled_run_status.py
+++ b/props/db/migrations/versions/20260604000000_add_cancelled_run_status.py
@@ -1,0 +1,35 @@
+"""Add 'cancelled' value to agent_run_status_enum.
+
+Records agent runs whose host task was cancelled before the container finished
+(e.g. the GraderSupervisor replacing a snapshot grader during reconcile, or
+shutdown) as a terminal status, instead of leaking as 'in_progress' forever.
+
+Revision ID: 20260604000000
+Revises: 20260228000000
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260604000000"
+down_revision: str | None = "20260228000000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # PostgreSQL 12+ allows ALTER TYPE ... ADD VALUE inside a transaction as long
+    # as the new value is not used in the same transaction (this migration only
+    # adds it). IF NOT EXISTS keeps it idempotent.
+    op.execute("ALTER TYPE agent_run_status_enum ADD VALUE IF NOT EXISTS 'cancelled'")
+
+
+def downgrade() -> None:
+    # PostgreSQL has no DROP VALUE for enums (removal requires recreating the type
+    # and rewriting every dependent column). Leaving 'cancelled' in place on
+    # downgrade is harmless.
+    pass

--- a/props/db/models.py
+++ b/props/db/models.py
@@ -126,12 +126,18 @@ class StatsWithCIType(TypeDecorator[StatsWithCI | None]):
 class AgentRunStatus(StrEnum):
     """Unified status for all agent types (critic, grader, prompt_optimizer, etc.).
 
-    Terminal states: EXITED (check container_exit_code for success/failure), TIMED_OUT.
+    Terminal states: EXITED (check container_exit_code for success/failure),
+    TIMED_OUT, CANCELLED.
     """
 
     IN_PROGRESS = "in_progress"
     EXITED = "exited"
     TIMED_OUT = "timed_out"
+    # The run's host task was cancelled before the container finished — e.g. the
+    # GraderSupervisor replacing a snapshot grader during reconcile, or shutdown.
+    # The pod is deleted; this records a terminal status so the run doesn't leak
+    # as IN_PROGRESS forever.
+    CANCELLED = "cancelled"
 
 
 class PydanticColumn[T: BaseModel](TypeDecorator[T]):

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -321,6 +321,17 @@ class AgentRegistry:
         """Wait for container exit, capture logs, update DB status, return final status."""
         try:
             result: ContainerResult = await handle.wait(timeout_seconds=timeout_seconds)
+        except asyncio.CancelledError:
+            # The run's host task was cancelled (e.g. GraderSupervisor replacing
+            # this grader during reconcile, or shutdown). The `finally` below still
+            # deletes the pod; record a terminal CANCELLED status so the run does
+            # not leak as IN_PROGRESS — the pod is gone and nothing else will
+            # finalize it. The DB write is synchronous, so it completes even while
+            # the task is being cancelled.
+            self._persist_run_result(
+                agent_run_id, status=AgentRunStatus.CANCELLED, container_exit_code=None, stdout="", stderr=""
+            )
+            raise
         finally:
             try:
                 await handle.kill_and_delete()
@@ -341,6 +352,24 @@ class AgentRegistry:
             status = AgentRunStatus.EXITED
             container_exit_code = exit.exit_code
 
+        self._persist_run_result(
+            agent_run_id,
+            status=status,
+            container_exit_code=container_exit_code,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+        return status
+
+    def _persist_run_result(
+        self, agent_run_id: UUID, *, status: AgentRunStatus, container_exit_code: int | None, stdout: str, stderr: str
+    ) -> None:
+        """Write an agent run's terminal status + captured logs to the DB.
+
+        Persisting the logs (not just logging them) makes failures visible in the
+        run record (GET /api/runs/{id}); the pod is already deleted by the caller,
+        so this is the only durable copy.
+        """
         with self._db.session() as session:
             found_run = session.get(AgentRun, agent_run_id)
             assert found_run is not None, f"Agent run {agent_run_id} not found in database"
@@ -348,14 +377,10 @@ class AgentRegistry:
                 raise RuntimeError(f"Agent run {agent_run_id} expected IN_PROGRESS but found {found_run.status}")
             found_run.status = status
             found_run.container_exit_code = container_exit_code
-            # Persist the captured container logs so failures are visible in the
-            # run record (GET /api/runs/{id}) instead of only in the orchestrator's
-            # own stdout — the pod is deleted above, so this is the only durable copy.
-            found_run.container_stdout = result.stdout or None
-            found_run.container_stderr = result.stderr or None
+            found_run.container_stdout = stdout or None
+            found_run.container_stderr = stderr or None
             session.commit()
-            logger.info(f"Updated {agent_run_id} status to {status}")
-        return status
+            logger.info("Updated %s status to %s", agent_run_id, status)
 
     async def _start_agent(
         self, agent_run_id: UUID, *, image: str, timeout_seconds: int | None = None, name: str

--- a/props/orchestration/test_agent_registry.py
+++ b/props/orchestration/test_agent_registry.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any, cast
 from uuid import UUID, uuid4
 
+import pytest
 import pytest_bazel
 
 from props.core.ids import SnapshotSlug
@@ -113,6 +115,45 @@ async def test_collect_run_timeout_persists_partial_logs(db: Database) -> None:
         assert run.status == AgentRunStatus.TIMED_OUT
         assert run.container_exit_code is None
         assert run.container_stdout == "partial output"
+
+
+@dataclass
+class _BlockingHandle:
+    """Handle whose wait() blocks until the task is cancelled (mimics a long-running grader)."""
+
+    name: str
+    started: asyncio.Event
+    killed: bool = False
+
+    async def wait(self, *, timeout_seconds: int | None) -> ContainerResult:
+        self.started.set()
+        await asyncio.Event().wait()  # block forever — only a cancel unblocks us
+        raise AssertionError("unreachable")
+
+    async def kill_and_delete(self) -> None:
+        self.killed = True
+
+
+async def test_collect_run_cancellation_finalizes_as_cancelled(db: Database) -> None:
+    # Reproduces the leak: the GraderSupervisor cancels a grader's task (via
+    # AgentRunHandle.kill_and_delete) while it is waiting on the pod. Previously
+    # the DB status update was skipped and the run leaked as IN_PROGRESS; now it
+    # is finalized to CANCELLED.
+    agent_run_id = _in_progress_critic_run(db)
+    handle = _BlockingHandle(name="grader-x", started=asyncio.Event())
+
+    task = asyncio.create_task(_registry(db)._collect_run(agent_run_id, cast(Any, handle), None))
+    await asyncio.wait_for(handle.started.wait(), timeout=5)  # ensure it is blocked in wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert handle.killed  # pod is still deleted on cancellation
+    with db.session() as session:
+        run = session.get(AgentRun, agent_run_id)
+        assert run is not None
+        assert run.status == AgentRunStatus.CANCELLED
+        assert run.container_exit_code is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The leak (spotted live)

A live probe showed **two graders for one snapshot**, which violates the "one grader per snapshot" invariant. Investigation: there was exactly **one grader pod**, but an *earlier* grader run was orphaned — `status=in_progress` with **no pod** for ~10 min.

Root cause: when `GraderSupervisor.reconcile()` replaces a snapshot grader (or on shutdown) it calls `AgentRunHandle.kill_and_delete()` → **cancels the run's `_collect_run` task**. The cancellation raises at `await handle.wait()`; the `finally` deletes the pod, but `CancelledError` then propagates and the **DB status update never runs**. The run leaks as `in_progress` forever. (This is also the source of the ~28 stuck `in_progress` graders seen earlier in the cluster.) The supervisor counts *pods*, so it still functions — but the API/leaderboard show phantom "still running" graders.

## Fix

- New terminal status **`AgentRunStatus.CANCELLED`** (enum + migration `ALTER TYPE agent_run_status_enum ADD VALUE 'cancelled'`), per the idea that we want a status reflecting "the task was cancelled/superseded".
- `_collect_run` now catches `asyncio.CancelledError`, persists `CANCELLED` (via an extracted `_persist_run_result` helper shared with the normal/timeout paths), and re-raises — the `finally` still deletes the pod. The DB write is synchronous, so it completes even while the task is being cancelled.

The frontend handles the new status without changes — `status.ts`'s `getStatusColor` switch has a `default` (gray badge) and `formatStatus` is generic; no `Record<AgentRunStatus,…>`/exhaustive map exists. The OpenAPI schema (and thus the frontend `AgentRunStatus` type) is generated from the backend at build time, so it picks up `cancelled` automatically.

## Testing

`bbr test //props/orchestration:test_agent_registry` — **PASS** on RBE (`requires_docker`, runs the new migration). New `test_collect_run_cancellation_finalizes_as_cancelled` reproduces the exact leak — cancels `_collect_run` mid-`wait()` against a real Postgres — and asserts the run ends `CANCELLED` (not `IN_PROGRESS`), with the pod still deleted. Existing persist/empty/timeout tests still pass.

## Follow-ups (out of scope)
- Backend-restart orphans: runs `in_progress` from a *previous* backend instance still leak (no startup reconciliation) — a separate fix.
- Optionally add `cancelled` to the frontend `AGENT_RUN_STATUS_VALUES` filter list and a dedicated badge color.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_