### PR TITLE
props/orchestration: attributable reconcile logging in GraderSupervisor

### DIFF
--- a/props/orchestration/BUILD.bazel
+++ b/props/orchestration/BUILD.bazel
@@ -129,6 +129,7 @@ py_test(
     deps = [
         ":grader_supervisor",
         "//props/core:ids",
+        "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],

--- a/props/orchestration/grader_supervisor.py
+++ b/props/orchestration/grader_supervisor.py
@@ -96,7 +96,9 @@ class GraderSupervisor:
             return
         notification = SnapshotCreatedNotification.model_validate_json(payload)
         logger.info(f"Snapshot created: {notification.snapshot_slug}")
-        self._launch_background(self.reconcile(), name="reconcile-snapshot-created")
+        self._launch_background(
+            self.reconcile(trigger=f"snapshot_created:{notification.snapshot_slug}"), name="reconcile-snapshot-created"
+        )
 
     def _grader_definition_changed_callback(
         self, connection: asyncpg.Connection[Any] | PoolConnectionProxy[Any], pid: int, channel: str, payload: object
@@ -108,7 +110,10 @@ class GraderSupervisor:
             return
         notification = GraderDefinitionChangedNotification.model_validate_json(payload)
         logger.info(f"Grader definition changed: {notification.tag} -> {notification.digest}")
-        self._launch_background(self.reconcile(restart_existing=True), name="reconcile-definition-changed")
+        self._launch_background(
+            self.reconcile(trigger=f"grader_definition_changed:{notification.tag}", restart_existing=True),
+            name="reconcile-definition-changed",
+        )
 
     # --- Lifecycle ---
 
@@ -118,53 +123,66 @@ class GraderSupervisor:
 
     async def spawn_existing(self) -> None:
         """Initial reconciliation after HTTP server is ready."""
-        await self.reconcile()
+        await self.reconcile(trigger="startup")
 
     # --- Core reconciliation ---
 
-    async def reconcile(self, *, restart_existing: bool = False) -> None:
+    async def reconcile(self, *, trigger: str, restart_existing: bool = False) -> None:
         """Converge actual state toward desired state.
 
         Desired: one grader per snapshot (if image available).
         Actual: self._handles.
 
-        If restart_existing is True, kill all tracked graders first (used
-        when the grader image changes).
+        `trigger` labels what caused this reconcile (startup, snapshot_created,
+        grader_definition_changed, ...) — logged so grader churn is attributable.
+        If restart_existing is True, kill all tracked graders first (used when the
+        grader image changes); note this cancels graders mid-run.
         """
         if self._shutdown:
             return
+
+        logger.info("Reconcile triggered by %s (restart_existing=%s)", trigger, restart_existing)
 
         # Resolve image — if unavailable, nothing to do.
         try:
             resolved = await self._registry.resolve_image(AgentType.GRADER, BUILTIN_TAG)
         except ImageResolutionError:
-            logger.warning("Grader image not available — skipping reconciliation")
+            logger.warning("Reconcile [%s] aborted: grader image not available", trigger)
             return
 
         # Get desired set from DB.
         with self._db.session() as session:
             desired: set[SnapshotSlug] = {s.slug for s in session.query(Snapshot.slug).all()}
 
-        # If image changed, kill everything so containers pick up the new image.
+        killed = 0
+        # If the image changed, kill everything so containers pick up the new image.
+        # This cancels any in-flight grade (-> AgentRunStatus.CANCELLED).
         if restart_existing:
             for slug in list(self._handles.keys()):
-                await self._kill_grader(slug)
+                await self._kill_grader(slug, reason="grader_image_changed")
+                killed += 1
 
         # Kill graders for snapshots that no longer exist.
         for slug in list(self._handles.keys()):
             if slug not in desired:
-                logger.info(f"Snapshot {slug} removed, killing grader")
-                await self._kill_grader(slug)
+                await self._kill_grader(slug, reason="snapshot_removed")
+                killed += 1
 
         # Spawn missing graders.
         spawned = 0
         for slug in desired:
             if slug not in self._handles:
-                await self._spawn_grader(slug, image=resolved)
+                await self._spawn_grader(slug, image=resolved, trigger=trigger)
                 spawned += 1
 
-        if spawned or restart_existing:
-            logger.info(f"Reconciled: {len(self._handles)} graders running ({spawned} spawned, {len(desired)} desired)")
+        logger.info(
+            "Reconcile [%s] done: desired=%d killed=%d spawned=%d running=%d",
+            trigger,
+            len(desired),
+            killed,
+            spawned,
+            len(self._handles),
+        )
 
     # --- Internal helpers ---
 
@@ -188,20 +206,22 @@ class GraderSupervisor:
                 logger.warning(f"Error closing listener connection: {e}")
             self._listener_conn = None
 
-    async def _spawn_grader(self, snapshot_slug: SnapshotSlug, *, image: ResolvedImage) -> None:
+    async def _spawn_grader(self, snapshot_slug: SnapshotSlug, *, image: ResolvedImage, trigger: str) -> None:
         try:
-            logger.info(f"Starting grader for {snapshot_slug}")
             handle = await self._registry.start_snapshot_grader(
                 image=image, snapshot_slug=snapshot_slug, model=self._model
             )
             self._handles[snapshot_slug] = handle
-            logger.info(f"Grader container {handle.name} running for {snapshot_slug}")
+            logger.info(
+                "Spawned grader %s for %s (trigger: %s, image: %s)", handle.name, snapshot_slug, trigger, image.digest
+            )
         except Exception:
-            logger.exception(f"Failed to start grader for {snapshot_slug}")
+            logger.exception("Failed to start grader for %s (trigger: %s)", snapshot_slug, trigger)
 
-    async def _kill_grader(self, snapshot_slug: SnapshotSlug) -> None:
+    async def _kill_grader(self, snapshot_slug: SnapshotSlug, *, reason: str) -> None:
         handle = self._handles.pop(snapshot_slug, None)
         if handle:
+            logger.info("Killing grader %s for %s (reason: %s)", handle.name, snapshot_slug, reason)
             await handle.kill_and_delete()
 
     async def shutdown(self) -> None:
@@ -210,5 +230,5 @@ class GraderSupervisor:
         logger.info("Shutting down graders...")
         await self._stop_listener()
         for slug in list(self._handles.keys()):
-            await self._kill_grader(slug)
+            await self._kill_grader(slug, reason="shutdown")
         logger.info("All graders stopped")

--- a/props/orchestration/test_grader_supervisor.py
+++ b/props/orchestration/test_grader_supervisor.py
@@ -6,11 +6,13 @@ snapshot when an image is available.
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 import pytest_bazel
 
 from props.core.ids import SnapshotSlug
@@ -92,23 +94,23 @@ def _mock_session(rows: list[Any]) -> Any:
 async def test_reconcile_spawns_for_all_snapshots():
     """reconcile() spawns a grader for each snapshot."""
     gs, _ = _make_supervisor([SNAP_A, SNAP_B, SNAP_C])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     assert set(gs._handles.keys()) == {SNAP_A, SNAP_B, SNAP_C}
 
 
 async def test_reconcile_noop_when_image_unavailable():
     """reconcile() does nothing when no grader image is available."""
     gs, _ = _make_supervisor([SNAP_A], image=None)
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     assert gs._handles == {}
 
 
 async def test_reconcile_idempotent():
     """Calling reconcile() twice doesn't create duplicate graders."""
     gs, _ = _make_supervisor([SNAP_A, SNAP_B])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     handles_first = dict(gs._handles)
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     # Same handles, not replaced
     assert gs._handles == handles_first
 
@@ -116,13 +118,13 @@ async def test_reconcile_idempotent():
 async def test_reconcile_spawns_new_snapshot():
     """reconcile() spawns for a newly added snapshot without touching existing."""
     gs, _ = _make_supervisor([SNAP_A])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     handle_a = gs._handles[SNAP_A]
 
     # Simulate new snapshot appearing in DB
     gs._db.session = _mock_session([MagicMock(slug=s) for s in [SNAP_A, SNAP_B]])  # type: ignore[method-assign]
 
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     assert gs._handles[SNAP_A] is handle_a
     assert SNAP_B in gs._handles
 
@@ -130,13 +132,13 @@ async def test_reconcile_spawns_new_snapshot():
 async def test_reconcile_kills_removed_snapshot():
     """reconcile() kills grader when snapshot disappears from DB."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     handle_b = gs._handles[SNAP_B]
 
     # Simulate snap-b removed from DB
     gs._db.session = _mock_session([MagicMock(slug=SNAP_A)])  # type: ignore[method-assign]
 
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     assert SNAP_B not in gs._handles
     assert handle_b in registry.killed
 
@@ -144,11 +146,11 @@ async def test_reconcile_kills_removed_snapshot():
 async def test_reconcile_restart_kills_and_respawns():
     """reconcile(restart_existing=True) kills all and respawns."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     old_a = gs._handles[SNAP_A]
     old_b = gs._handles[SNAP_B]
 
-    await gs.reconcile(restart_existing=True)
+    await gs.reconcile(trigger="test", restart_existing=True)
     assert old_a in registry.killed
     assert old_b in registry.killed
     # New handles created
@@ -159,13 +161,13 @@ async def test_reconcile_restart_kills_and_respawns():
 async def test_reconcile_restart_also_spawns_missing():
     """restart_existing=True also spawns graders for snapshots not yet tracked."""
     gs, registry = _make_supervisor([SNAP_A])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     old_a = gs._handles[SNAP_A]
 
     # Add snap-b to DB, trigger restart
     gs._db.session = _mock_session([MagicMock(slug=s) for s in [SNAP_A, SNAP_B]])  # type: ignore[method-assign]
 
-    await gs.reconcile(restart_existing=True)
+    await gs.reconcile(trigger="test", restart_existing=True)
     assert old_a in registry.killed
     assert SNAP_A in gs._handles
     assert SNAP_B in gs._handles
@@ -174,7 +176,7 @@ async def test_reconcile_restart_also_spawns_missing():
 async def test_shutdown_kills_all():
     """shutdown() kills all tracked graders."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B])
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     handles = list(gs._handles.values())
 
     await gs.shutdown()
@@ -186,8 +188,22 @@ async def test_reconcile_noop_after_shutdown():
     """reconcile() does nothing after shutdown."""
     gs, _ = _make_supervisor([SNAP_A])
     await gs.shutdown()
-    await gs.reconcile()
+    await gs.reconcile(trigger="test")
     assert gs._handles == {}
+
+
+async def test_reconcile_logs_trigger_and_kill_reason(caplog: pytest.LogCaptureFixture) -> None:
+    """Every reconcile logs its trigger and every grader kill logs its reason, so
+    churn (e.g. an image push restarting an in-flight grade) is attributable."""
+    gs, _ = _make_supervisor([SNAP_A])
+    with caplog.at_level(logging.INFO, logger="props.orchestration.grader_supervisor"):
+        await gs.reconcile(trigger="startup")
+        await gs.reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
+    log = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Reconcile triggered by startup" in log
+    assert "Reconcile triggered by grader_definition_changed:latest" in log
+    # The image-push restart attributes why it killed the running grader.
+    assert "reason: grader_image_changed" in log
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes grader churn **attributable from logs**, per the visibility discussion. The live probe showed a snapshot's grader cycling through several instances (orphaned / `exit 1` / replaced) with no signal as to *why*. This adds reasoned logging to `GraderSupervisor`:

- `reconcile()` now takes a **required `trigger`** — `startup`, `snapshot_created:<slug>`, or `grader_definition_changed:<tag>` — and logs it, plus a per-reconcile summary: `desired/killed/spawned/running`.
- Every `_kill_grader` logs the grader name + a **reason**: `grader_image_changed`, `snapshot_removed`, or `shutdown`.
- `_spawn_grader` logs the trigger + the image digest it launched.

So the churn we saw — an image push firing `grader_definition_changed` → `restart_existing` cancelling an in-flight grade — now reads as a `Killing grader … (reason: grader_image_changed)` line attributed to that trigger, instead of silent restarts. (Pairs with the just-merged `CANCELLED` status #1874: the cancelled run is terminal *and* the supervisor log says why.)

## Testing

`bbr test //props/orchestration:test_grader_supervisor` — PASS. New `test_reconcile_logs_trigger_and_kill_reason` asserts the trigger and the kill reason are logged; all existing reconcile-behavior tests updated to pass the now-required `trigger` and still pass.

## Note

This is observability only — no behavior change. The underlying churn (graders shouldn't be killed mid-grade by an unrelated image push) is a separate fix; these logs will confirm whether that's what's happening.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_