### PR TITLE
devinfra/js: emit js_openapi_zod .ts schema as a real copy, not a symlink

### DIFF
--- a/devinfra/js/openapi.bzl
+++ b/devinfra/js/openapi.bzl
@@ -11,7 +11,6 @@ They differ in what they run on that JSON:
 """
 
 load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@npm_ducktape//:@hey-api/openapi-ts/package_json.bzl", openapi_ts_bin = "bin")
 load("@npm_ducktape//:openapi-typescript/package_json.bzl", openapi_typescript_bin = "bin")
 
@@ -116,10 +115,15 @@ def js_openapi_zod(name, generator, out = "api/schema.zod.mjs", visibility = Non
     )
 
     if out.endswith(".ts") or out.endswith(".mts"):
-        copy_file(
+        # A real content copy, not `copy_file`'s symlink: esbuild resolves imported modules to
+        # their realpath, and the gen-dir `zod.gen.ts` the symlink points at is not an input of
+        # downstream bundle actions, so a symlinked `out` makes esbuild fail with
+        # "Could not read from file .../zod.gen.ts".
+        native.genrule(
             name = "_" + name + "_emit",
-            src = ":_" + name + "_generate_ts",
-            out = out,
+            srcs = [":_" + name + "_generate_ts"],
+            outs = [out],
+            cmd = "cp $< $@",
         )
         emit = ":_" + name + "_emit"
     else:


### PR DESCRIPTION
## Problem

`bazel test //...` fails at **build** time on `//augur/frontend:main_bundle` (esbuild):

```
augur/frontend/client.ts:18:7: ERROR: Could not read from file:
  .../augur/frontend/lib/_schema_zod_hey_api_out/zod.gen.ts
Error: Build failed with 1 error
...
All tests passed but there were other errors during the build.
```

All tests pass, but the build error makes the `bazel-ci` job exit non-zero.

## Root cause

`js_openapi_zod` (in `devinfra/js/openapi.bzl`) with a `.ts`/`.mts` `out` used `copy_file` to emit the schema module (here `augur/frontend/lib/api/schema.zod.ts`) from the hey-api codegen output `_schema_zod_hey_api_out/zod.gen.ts`.

`copy_file` produces a **symlink**:

```
api/schema.zod.ts -> _schema_zod_hey_api_out/zod.gen.ts
```

esbuild resolves imported modules to their **realpath**, so it tries to read `zod.gen.ts` directly — but that file is an output of a *different* action and is **not** an input of the downstream bundle action, so it's absent from the bundle's sandbox → "Could not read from file."

## Fix

Emit a real content copy via `genrule` (`cp`) so the schema module is self-contained in the consuming bundle's sandbox. The `.mjs` path already produced a real file (via `js_run_binary` strip-types), so only the `.ts`/`.mts` branch was affected. Also drops the now-unused `copy_file` load.

## Verification

- `bazel build //augur/frontend:main_bundle` — now **succeeds** (was the failing action).
- `//augur:browser_shell_test` — PASSED.
- buildifier — clean.
- The emitted `schema.zod.ts` is byte-identical to before (a real copy of the same `zod.gen.ts` content), so the bundle output and rendered frontend are unchanged.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_