### PR TITLE
augur/calibration: cache live market fetches for 12h in the default clients

### DIFF
--- a/augur/calibration/default_clients.py
+++ b/augur/calibration/default_clients.py
@@ -12,10 +12,17 @@ from augur.calibration.manifold import ManifoldClient
 from augur.calibration.platform import Platform, PriceClient
 from augur.calibration.polymarket import PolymarketClient
 
+# These clients are constructed once per server process and reused for every calibration run, so
+# the TTL bounds how stale a surfaced price/title can be — not how often a single request re-fetches.
+# 12h keeps the catalog cheap to re-score and, crucially, rides over the upstream APIs' intermittent
+# 5xx (Kalshi in particular flaps `503 Service Unavailable` per-ticker): once a market is fetched
+# successfully it stays cached for the window instead of dropping out of the next run's results.
+_DEFAULT_CACHE_TTL_SECONDS = 12 * 60 * 60
+
 
 def build_default_price_clients() -> dict[Platform, PriceClient]:
     return {
-        Platform.MANIFOLD: ManifoldClient(),
-        Platform.POLYMARKET: PolymarketClient(),
-        Platform.KALSHI: KalshiClient(),
+        Platform.MANIFOLD: ManifoldClient(cache_ttl_seconds=_DEFAULT_CACHE_TTL_SECONDS),
+        Platform.POLYMARKET: PolymarketClient(cache_ttl_seconds=_DEFAULT_CACHE_TTL_SECONDS),
+        Platform.KALSHI: KalshiClient(cache_ttl_seconds=_DEFAULT_CACHE_TTL_SECONDS),
     }


### PR DESCRIPTION
## What

Bump the deployed price-client cache TTL from **120s → 12h** in
`build_default_price_clients()` (the shared wiring used by `api.server`,
`dev_server`, and `calibration_report`).

## Why

The augur server constructs the `{Platform: PriceClient}` map **once per process**
and reuses it for every `/api/calibration/run`. So the per-client TTL bounds how
stale a surfaced price/title can be — not how often a single request re-fetches.

More importantly, it rides over the upstream APIs' **intermittent 5xx**. Kalshi in
particular flaps `503 Service Unavailable` per-ticker (verified live: the same
ticker returns 200 one moment and 503 the next). On the live deployment this was
dropping **every** Kalshi row from each calibration run — the frontend showed only
Manifold markets:

```
dropping calibration row: kalshi market 'KXETHY-27JAN0100-B4375' failed to fetch
httpx.HTTPStatusError: Server error '503 Service Unavailable' ...
dropping categorical family 'eth_eoy_2026': a bucket failed to fetch or had no price
```

With a 12h cache, a market that fetches successfully once stays in subsequent runs'
results for the window instead of re-rolling the 503 dice each time. Only the per-
client default changes here; the class defaults (120s) and the clock-seam used by
tests are untouched.

## Caveat / follow-up

This is the interim mitigation the issue asks for ("for now"). It does not help a
**cold** cache: a market that 503s on its first fetch after a process restart still
drops until a later run catches it on a good response. A proper fix would add
bounded retry-with-backoff on 5xx in the clients (and/or negative-result handling);
left as follow-up.

## Tests

`//augur/calibration:test_manifold` and `//augur/api:test_calibration_endpoint` pass
on RBE; `//augur/calibration:default_clients` builds clean (ruff + mypy aspect).

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw)_