### PR TITLE
props: stop grader restart storm from no-op image re-pushes

### DIFF
--- a/props/agents/push_images.py
+++ b/props/agents/push_images.py
@@ -52,8 +52,19 @@ def main() -> None:
         base_tag = variant_tag or "latest"
         sha_tag = f"{variant_tag}-{sha}" if variant_tag else sha
 
+        # Content dedup: the images are Bazel-reproducible, so on commits that
+        # don't change an agent image its digest is identical to what's already
+        # published. Re-pushing re-PUTs the moving tag's manifest, which the
+        # registry proxy turns into a grader_definition_changed notify ->
+        # GraderSupervisor restarts every grader (cancelling in-flight grades).
+        # Skip the no-op, mirroring the GHCR matrix dedup in push-images.yml.
+        base_ref = f"{registry}/{repo_name}:{base_tag}"
+        if crane.digest_or_none(base_ref) == local_digest:
+            print(f"{base_ref}: digest unchanged ({local_digest[:19]}) — skipping")
+            continue
+
         ref = f"{registry}/{repo_name}@{local_digest}"
-        print(f"{registry}/{repo_name}:{base_tag}: pushing {local_digest[:19]}")
+        print(f"{base_ref}: pushing {local_digest[:19]}")
         crane.push(image_dir, ref)
         crane.tag(ref, base_tag)
         crane.tag(ref, sha_tag)

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -166,6 +166,8 @@ py_test(
     deps = [
         ":registry",
         "//props:conftest",
+        "//props/core:agent_types",
+        "//props/core:oci_utils",
         "@pypi//fastapi",
         "@pypi//httpx",
         "@pypi//pytest",

--- a/props/backend/routes/registry.py
+++ b/props/backend/routes/registry.py
@@ -28,7 +28,7 @@ from props.backend.auth import (
     is_critic_dev_agent,
 )
 from props.backend.deps import AdminDb
-from props.core.oci_utils import UpstreamRegistryConfig, get_upstream_registry_config, is_digest
+from props.core.oci_utils import BUILTIN_TAG, UpstreamRegistryConfig, get_upstream_registry_config, is_digest
 from props.db.database import Database
 from props.db.models import AgentDefinition, AgentType
 from props.db.notifications import GRADER_DEFINITION_CHANGED_CHANNEL, GraderDefinitionChangedNotification
@@ -204,6 +204,19 @@ def _deny(identity: RequestIdentity, action: str) -> HTTPException:
     return HTTPException(status_code=403, detail=f"{identity} not allowed to {action}")
 
 
+def _is_grader_builtin_push(repo: str, ref: str) -> bool:
+    """True iff this push moves the grader's builtin tag — the only push the
+    GraderSupervisor reacts to.
+
+    The supervisor resolves graders by `grader:BUILTIN_TAG`, so only a move of
+    that tag changes which image graders run. By-digest pushes and pinned
+    per-commit sha tags (e.g. `grader:<gitsha>`, pushed alongside `latest` by
+    //props/agents:push_images) do not — notifying on them needlessly restarts
+    every grader, cancelling in-flight grades.
+    """
+    return repo == str(AgentType.GRADER) and ref == BUILTIN_TAG
+
+
 @router.put("/v2/{repo}/manifests/{ref}", include_in_schema=False)
 async def put_manifest(request: Request, repo: str, ref: str, admin_db: AdminDb, auth: Auth) -> Response:
     """Push a manifest — records agent definition on success."""
@@ -223,9 +236,9 @@ async def put_manifest(request: Request, repo: str, ref: str, admin_db: AdminDb,
         manifest_digest = f"sha256:{hashlib.sha256(body).hexdigest()}"
         await _record_manifest_push(repo, manifest_digest, body, agent_run_id, admin_db)
 
-        # When a grader tag moves, notify the GraderSupervisor so it can
-        # (re)start graders that failed due to missing image at startup.
-        if not is_digest(ref) and repo == str(AgentType.GRADER):
+        # When the grader's builtin tag moves, notify the GraderSupervisor so it
+        # can (re)start graders that failed due to missing image at startup.
+        if _is_grader_builtin_push(repo, ref):
             notification = GraderDefinitionChangedNotification(digest=manifest_digest, tag=ref)
             with admin_db.session() as session:
                 session.execute(

--- a/props/backend/routes/test_registry_proxy.py
+++ b/props/backend/routes/test_registry_proxy.py
@@ -19,7 +19,9 @@ import uvicorn
 from fastapi import FastAPI, Request
 from starlette.responses import Response
 
-from props.backend.routes.registry import _proxy_to_upstream
+from props.backend.routes.registry import _is_grader_builtin_push, _proxy_to_upstream
+from props.core.agent_types import AgentType
+from props.core.oci_utils import BUILTIN_TAG
 
 DOCKER_ACCEPT_TYPES = [
     "application/vnd.docker.distribution.manifest.v2+json",
@@ -107,6 +109,22 @@ async def test_proxy_preserves_multi_valued_accept_headers(monkeypatch: pytest.M
         assert media_type in all_accept, (
             f"Accept type {media_type!r} was lost during proxying. Upstream received Accept: {upstream_accept_values!r}"
         )
+
+
+def test_only_grader_builtin_tag_move_notifies_supervisor() -> None:
+    """The GraderSupervisor restart is triggered ONLY by a move of the grader's
+    builtin tag. By-digest pushes and per-commit sha pins (pushed alongside
+    `latest` by //props/agents:push_images) must not trigger it — otherwise
+    every devel commit restarts every grader, cancelling in-flight grades."""
+    grader = str(AgentType.GRADER)
+    # The one case that should notify: grader builtin tag moved.
+    assert _is_grader_builtin_push(grader, BUILTIN_TAG)
+    # Per-commit pinned sha tag pushed next to latest — must NOT notify.
+    assert not _is_grader_builtin_push(grader, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+    # By-digest push (crane push @sha256:...) — must NOT notify.
+    assert not _is_grader_builtin_push(grader, "sha256:" + "ab" * 32)
+    # Other repos never drive the grader supervisor, even on their builtin tag.
+    assert not _is_grader_builtin_push(str(AgentType.CRITIC), BUILTIN_TAG)
 
 
 if __name__ == "__main__":

--- a/util/crane.py
+++ b/util/crane.py
@@ -110,6 +110,21 @@ class Crane:
     def digest(self, image_ref: str) -> str:
         return self._run("digest", image_ref)
 
+    def digest_or_none(self, image_ref: str) -> str | None:
+        """Remote digest of `image_ref`, or None when the tag/repo doesn't exist yet.
+
+        For content-dedup before a push: an unpublished tag (`MANIFEST_UNKNOWN`)
+        or repo (`NAME_UNKNOWN`) means "nothing there, push it". Any other crane
+        failure (auth, transport, 5xx) re-raises — a real error must not be
+        mistaken for "absent" and silently turned into a churny re-push.
+        """
+        try:
+            return self._run("digest", image_ref)
+        except RuntimeError as e:
+            if "MANIFEST_UNKNOWN" in str(e) or "NAME_UNKNOWN" in str(e):
+                return None
+            raise
+
     def ls(self, repo: str) -> list[str]:
         return self._run("ls", repo).splitlines()
 

--- a/util/test_crane.py
+++ b/util/test_crane.py
@@ -78,6 +78,35 @@ def test_run_handles_calledprocesserror_with_none_streams() -> None:
     assert "crane tag x y failed (exit 1)" in str(exc_info.value)
 
 
+def test_digest_or_none_returns_digest_when_present() -> None:
+    crane = Crane(path=Path("/nonexistent/crane"))
+    done = subprocess.CompletedProcess(args=["crane", "digest"], returncode=0, stdout="sha256:abc123\n", stderr="")
+    with patch("subprocess.run", return_value=done):
+        assert crane.digest_or_none("repo:latest") == "sha256:abc123"
+
+
+@pytest.mark.parametrize("marker", ["MANIFEST_UNKNOWN", "NAME_UNKNOWN"])
+def test_digest_or_none_returns_none_for_absent_tag_or_repo(marker: str) -> None:
+    """An unpublished tag/repo is the expected 'push it' case — not an error."""
+    crane = Crane(path=Path("/nonexistent/crane"))
+    fake_error = subprocess.CalledProcessError(
+        returncode=1, cmd=["crane", "digest", "repo:latest"], stderr=f"{marker}: not found\n"
+    )
+    with patch("subprocess.run", side_effect=fake_error):
+        assert crane.digest_or_none("repo:latest") is None
+
+
+def test_digest_or_none_reraises_real_errors() -> None:
+    """Auth/transport failures must propagate, not be mistaken for 'absent'
+    (which would silently churn a re-push)."""
+    crane = Crane(path=Path("/nonexistent/crane"))
+    fake_error = subprocess.CalledProcessError(
+        returncode=1, cmd=["crane", "digest", "repo:latest"], stderr="UNAUTHORIZED: token expired\n"
+    )
+    with patch("subprocess.run", side_effect=fake_error), pytest.raises(RuntimeError):
+        crane.digest_or_none("repo:latest")
+
+
 def test_arun_raises_with_stderr_and_stdout() -> None:
     """Async `_arun` is symmetric: stderr is in the message, stdout when nonempty."""
     crane = Crane(path=Path("/nonexistent/crane"))


### PR DESCRIPTION
## Problem

The GraderSupervisor was restarting **every** grader ~twice per devel commit — regardless of whether the grader image actually changed — orphaning ~177 grader runs as `in_progress`/`cancelled`. The cause was **no-op re-pushes of byte-identical agent images**, compounded by an over-eager notify. Two defects:

1. **`//props/agents:push_images` had no content dedup.** Unlike the GHCR matrix in `push-images.yml` (which fetches `.digest` and skips when unchanged), `push_images.py` unconditionally re-pushed and re-tagged `latest` plus a fresh per-commit sha tag on every devel CI run. The agent images are Bazel-**reproducible**, so on commits that don't touch their deps the digest is identical — yet the tags were moved anyway.

2. **The registry proxy fired `grader_definition_changed` on every non-digest grader tag push** (`registry.py`: `if not is_digest(ref) and repo == grader`). Since `is_digest("<40-hex-gitsha>")` is `False`, **both** the `latest` tag **and** the per-commit sha tag fired it. Each fire → `GraderSupervisor.reconcile(restart_existing=True)` → kills + respawns every grader, cancelling in-flight grades (the `IN_PROGRESS`→`CANCELLED` leak from #1874).

Net: ~2 full grader restart-storms per devel commit, **independent of image content**.

## Fix

So `grader_definition_changed` fires **exactly once, only on a genuine grader image change**:

- **`push_images.py`**: skip push+tag when the moving tag already resolves to the local digest, via a new `Crane.digest_or_none` (returns `None` for `MANIFEST_UNKNOWN`/`NAME_UNKNOWN`, re-raises real errors so an auth/transport failure isn't mistaken for "absent"). No-op commits now push nothing.
- **`registry.py`**: notify only on a move of the grader **builtin** tag (`ref == BUILTIN_TAG`), never by-digest pushes or pinned per-commit sha tags.

## Tests

- `util/test_crane.py`: `digest_or_none` returns the digest when present, `None` for absent tag/repo, and re-raises real errors.
- `props/backend/routes/test_registry_proxy.py`: only a grader builtin-tag move qualifies for the supervisor notify; sha pins, by-digest pushes, and other repos do not.

Both pass on RBE (`test_registry_proxy` is `requires_docker`).

A GraderSupervisor-side debounce (defense-in-depth, coalescing any future trigger bursts) is being added separately on top of #1875.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_