### PR TITLE
props/orchestration: debounce GraderSupervisor reconcile (coalesce trigger bursts)

### DIFF
--- a/props/orchestration/grader_supervisor.py
+++ b/props/orchestration/grader_supervisor.py
@@ -11,13 +11,17 @@ Reconciliation is triggered by:
 Each trigger calls reconcile(), which compares desired state (all snapshot
 slugs from DB) against actual state (self._handles) and creates/kills
 containers to converge.
+
+Event-driven triggers (snapshot_created, grader_definition_changed) are
+debounced: a burst coalesces into a single trailing-edge reconcile, so rapid
+image pushes delay-and-collapse into one respawn instead of many restart
+storms. Startup reconciles immediately.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Coroutine
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +47,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Coalesce reconcile triggers arriving within this window into a single
+# trailing-edge reconcile (delay-and-collapse, never skip).
+DEFAULT_RECONCILE_DEBOUNCE_S = 30.0
+
 
 class GraderSupervisor:
     """Manages per-snapshot grader containers via reconciliation.
@@ -59,7 +67,15 @@ class GraderSupervisor:
         # gs.shutdown() called automatically
     """
 
-    def __init__(self, registry: AgentRegistry, db_config: DatabaseConfig, model: str, db: Database):
+    def __init__(
+        self,
+        registry: AgentRegistry,
+        db_config: DatabaseConfig,
+        model: str,
+        db: Database,
+        *,
+        reconcile_debounce_s: float = DEFAULT_RECONCILE_DEBOUNCE_S,
+    ):
         self._registry = registry
         self._db_config = db_config
         self._model = model
@@ -68,6 +84,11 @@ class GraderSupervisor:
         self._listener_conn: asyncpg.Connection[Any] | None = None
         self._shutdown = False
         self._background_tasks: set[asyncio.Task[None]] = set()
+        # Trailing-edge debounce of event-driven reconciles.
+        self._reconcile_debounce_s = reconcile_debounce_s
+        self._debounce_task: asyncio.Task[None] | None = None
+        self._pending_restart_existing = False
+        self._pending_triggers: list[str] = []
 
     async def __aenter__(self) -> GraderSupervisor:
         await self.start()
@@ -78,13 +99,7 @@ class GraderSupervisor:
     ) -> None:
         await self.shutdown()
 
-    def _launch_background(self, coro: Coroutine[Any, Any, None], *, name: str) -> None:
-        """Launch a background task and prevent garbage collection."""
-        task = asyncio.create_task(coro, name=name)
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
-
-    # --- Event handlers (thin wrappers that trigger reconcile) ---
+    # --- Event handlers (debounced — coalesce bursts into one reconcile) ---
 
     def _snapshot_created_callback(
         self, connection: asyncpg.Connection[Any] | PoolConnectionProxy[Any], pid: int, channel: str, payload: object
@@ -96,9 +111,7 @@ class GraderSupervisor:
             return
         notification = SnapshotCreatedNotification.model_validate_json(payload)
         logger.info(f"Snapshot created: {notification.snapshot_slug}")
-        self._launch_background(
-            self.reconcile(trigger=f"snapshot_created:{notification.snapshot_slug}"), name="reconcile-snapshot-created"
-        )
+        self._schedule_reconcile(trigger=f"snapshot_created:{notification.snapshot_slug}")
 
     def _grader_definition_changed_callback(
         self, connection: asyncpg.Connection[Any] | PoolConnectionProxy[Any], pid: int, channel: str, payload: object
@@ -110,10 +123,7 @@ class GraderSupervisor:
             return
         notification = GraderDefinitionChangedNotification.model_validate_json(payload)
         logger.info(f"Grader definition changed: {notification.tag} -> {notification.digest}")
-        self._launch_background(
-            self.reconcile(trigger=f"grader_definition_changed:{notification.tag}", restart_existing=True),
-            name="reconcile-definition-changed",
-        )
+        self._schedule_reconcile(trigger=f"grader_definition_changed:{notification.tag}", restart_existing=True)
 
     # --- Lifecycle ---
 
@@ -124,6 +134,52 @@ class GraderSupervisor:
     async def spawn_existing(self) -> None:
         """Initial reconciliation after HTTP server is ready."""
         await self.reconcile(trigger="startup")
+
+    # --- Debounced reconcile scheduling ---
+
+    def _schedule_reconcile(self, *, trigger: str, restart_existing: bool = False) -> None:
+        """Debounce an event-driven reconcile: coalesce rapid triggers into one
+        trailing-edge run.
+
+        A burst of events (several grader image pushes, a batch of new
+        snapshots) collapses into a single reconcile that fires after
+        ``reconcile_debounce_s`` of quiet. The respawn is *delayed and
+        coalesced*, never skipped — ``restart_existing`` is OR'd across the
+        window so a genuine image change in the burst still restarts graders,
+        exactly once.
+        """
+        if self._shutdown:
+            return
+        self._pending_restart_existing |= restart_existing
+        self._pending_triggers.append(trigger)
+        # Reset the quiet window so we fire once, after the LAST trigger. Only a
+        # still-debouncing timer is cancelled — never an in-flight reconcile.
+        if self._debounce_task is not None and not self._debounce_task.done():
+            self._debounce_task.cancel()
+        task = asyncio.create_task(self._run_debounced_reconcile(), name="grader-debounced-reconcile")
+        self._debounce_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _run_debounced_reconcile(self) -> None:
+        try:
+            await asyncio.sleep(self._reconcile_debounce_s)
+        except asyncio.CancelledError:
+            # Superseded by a newer trigger (window reset) or shutdown — the
+            # replacement timer, if any, will fire. Don't reconcile here.
+            return
+        # Window elapsed. Clear the timer handle first so a trigger arriving
+        # during the (awaited) reconcile opens a fresh window instead of
+        # cancelling this run.
+        self._debounce_task = None
+        if self._shutdown:
+            return
+        restart_existing = self._pending_restart_existing
+        triggers = self._pending_triggers
+        self._pending_restart_existing = False
+        self._pending_triggers = []
+        label = triggers[0] if len(triggers) == 1 else f"debounced({len(triggers)}): {', '.join(triggers)}"
+        await self.reconcile(trigger=label, restart_existing=restart_existing)
 
     # --- Core reconciliation ---
 
@@ -228,6 +284,8 @@ class GraderSupervisor:
         """Kill all grader containers and stop listeners."""
         self._shutdown = True
         logger.info("Shutting down graders...")
+        if self._debounce_task is not None and not self._debounce_task.done():
+            self._debounce_task.cancel()
         await self._stop_listener()
         for slug in list(self._handles.keys()):
             await self._kill_grader(slug, reason="shutdown")

--- a/props/orchestration/test_grader_supervisor.py
+++ b/props/orchestration/test_grader_supervisor.py
@@ -6,6 +6,7 @@ snapshot when an image is available.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -47,8 +48,10 @@ class FakeRegistry:
     image: ResolvedImage | None = FAKE_IMAGE
     _counter: int = 0
     killed: list[FakeHandle] = field(default_factory=list)
+    resolve_count: int = 0  # incremented once per reconcile() run
 
     async def resolve_image(self, agent_type: Any, tag: str) -> ResolvedImage:
+        self.resolve_count += 1
         if self.image is None:
             raise ImageResolutionError("no image")
         return self.image
@@ -61,9 +64,13 @@ class FakeRegistry:
 
 
 def _make_supervisor(
-    snapshot_slugs: list[SnapshotSlug], *, image: ResolvedImage | None = FAKE_IMAGE
+    snapshot_slugs: list[SnapshotSlug], *, image: ResolvedImage | None = FAKE_IMAGE, reconcile_debounce_s: float = 0.05
 ) -> tuple[GraderSupervisor, FakeRegistry]:
-    """Build a GraderSupervisor with a FakeRegistry and mock DB."""
+    """Build a GraderSupervisor with a FakeRegistry and mock DB.
+
+    `reconcile_debounce_s` defaults small so debounce tests run fast; the
+    direct `reconcile()` tests don't touch the debounce path.
+    """
     registry = FakeRegistry(image=image)
 
     @contextmanager
@@ -75,7 +82,13 @@ def _make_supervisor(
     db = MagicMock()
     db.session = fake_session
 
-    gs = GraderSupervisor(registry=registry, db_config=MagicMock(), model="gpt-5-mini", db=db)  # type: ignore[arg-type]
+    gs = GraderSupervisor(
+        registry=registry,  # type: ignore[arg-type]
+        db_config=MagicMock(),
+        model="gpt-5-mini",
+        db=db,
+        reconcile_debounce_s=reconcile_debounce_s,
+    )
     return gs, registry
 
 
@@ -204,6 +217,54 @@ async def test_reconcile_logs_trigger_and_kill_reason(caplog: pytest.LogCaptureF
     assert "Reconcile triggered by grader_definition_changed:latest" in log
     # The image-push restart attributes why it killed the running grader.
     assert "reason: grader_image_changed" in log
+
+
+async def test_schedule_reconcile_debounces_burst() -> None:
+    """A burst of triggers coalesces into a single trailing-edge reconcile —
+    rapid image pushes must not each restart every grader."""
+    gs, registry = _make_supervisor([SNAP_A, SNAP_B], reconcile_debounce_s=0.05)
+    for _ in range(5):
+        gs._schedule_reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
+    # Debounced, not immediate: nothing has reconciled yet.
+    assert registry.resolve_count == 0
+    await asyncio.sleep(0.2)
+    # The whole burst produced exactly one reconcile.
+    assert registry.resolve_count == 1
+    assert set(gs._handles) == {SNAP_A, SNAP_B}
+
+
+async def test_schedule_reconcile_delays_but_does_not_drop() -> None:
+    """The reconcile is delayed by the debounce window, then runs — delay, not cancel."""
+    gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.1)
+    gs._schedule_reconcile(trigger="snapshot_created:snap-a")
+    assert registry.resolve_count == 0  # still within the quiet window
+    assert gs._handles == {}
+    await asyncio.sleep(0.25)
+    assert registry.resolve_count == 1  # fired after the window
+    assert SNAP_A in gs._handles
+
+
+async def test_schedule_reconcile_ors_restart_existing() -> None:
+    """If any trigger in the window asked to restart, the single coalesced
+    reconcile restarts existing graders (OR semantics)."""
+    gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.05)
+    await gs.reconcile(trigger="seed")  # one grader already running
+    old = gs._handles[SNAP_A]
+    gs._schedule_reconcile(trigger="snapshot_created:x")  # restart_existing=False
+    gs._schedule_reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
+    await asyncio.sleep(0.2)
+    assert old in registry.killed  # restart took effect
+    assert gs._handles[SNAP_A] is not old  # respawned
+
+
+async def test_schedule_reconcile_noop_after_shutdown() -> None:
+    """Scheduling after shutdown does nothing (no late respawn)."""
+    gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.05)
+    await gs.shutdown()
+    gs._schedule_reconcile(trigger="late")
+    await asyncio.sleep(0.15)
+    assert registry.resolve_count == 0
+    assert gs._handles == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes the `GraderSupervisor` a **debouncer**: event-driven reconcile triggers (`snapshot_created`, `grader_definition_changed`) are coalesced into a single trailing-edge reconcile after a quiet window (`reconcile_debounce_s`, default 30s) instead of each one immediately killing + respawning every grader.

The respawn is **delayed and coalesced, never skipped**:
- A burst (e.g. several image pushes, a batch of new snapshots) collapses into **one** reconcile after the burst settles.
- `restart_existing` is OR'd across the window, so a genuine image change in the burst still restarts graders — exactly once.
- Only a still-*debouncing* timer is ever cancelled; an in-flight reconcile is never interrupted.
- Startup (`spawn_existing`) still reconciles immediately.

Also drops the now-unused `_launch_background` helper (both callbacks go through the debounce scheduler).

## Why

Defense-in-depth on top of #1878. #1878 stops the *source* of the churn (no-op image re-pushes spuriously firing `grader_definition_changed`); this ensures that even if some future path emits a trigger storm, the supervisor coalesces it into one delayed respawn rather than a restart storm that cancels in-flight grades.

This is the "circuit breaker" from the visibility discussion, reframed per your steer as a **debouncer** (delay, don't cancel/skip a respawn).

## Testing

`bbr test //props/orchestration:test_grader_supervisor` — PASS. New tests:
- `test_schedule_reconcile_debounces_burst` — 5 rapid triggers → exactly 1 reconcile.
- `test_schedule_reconcile_delays_but_does_not_drop` — reconcile is delayed by the window, then runs (delay, not cancel).
- `test_schedule_reconcile_ors_restart_existing` — a `restart_existing` trigger anywhere in the window restarts existing graders.
- `test_schedule_reconcile_noop_after_shutdown` — no late respawn after shutdown.

All existing reconcile-behavior tests unchanged and still pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_