### PR TITLE
augur/calibration: retry transient PM fetch failures with backoff

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -54,6 +54,17 @@ Remaining:
       (today's `mark_fan` is PE-only).
 - [ ] **Aggregate metric (later, weighting TBD).** Per-channel / volume-weighted
       rollups of per-market KL once the weighting policy is decided.
+- [ ] **Split prediction-market fetching into a separate syncer with a local store.**
+      Today the server fetches every catalog market live from Manifold / Kalshi /
+      Polymarket on each calibration run, mitigated only by a per-process TTL cache
+      (`augur/calibration/default_clients.py`) and inline retry-with-backoff
+      (`augur/calibration/transient_retry.py`). This still couples calibration latency and
+      availability to the upstreams' flakiness — Kalshi flaps `503` per-ticker, and a cold
+      cache after a pod restart drops whatever fails its first fetch until a later run
+      catches it. Replace the inline path with a small separate program that continuously
+      synchronizes PM states into a local store (DB/keyed file) with a bounded max
+      staleness, and have the server read snapshots from that store. Decouples scoring from
+      the PM APIs entirely; the inline cache + retry are the stopgap until this lands.
 
 ## Exogenous Models & Evidence
 

--- a/augur/calibration/BUILD.bazel
+++ b/augur/calibration/BUILD.bazel
@@ -37,10 +37,19 @@ py_library(
 )
 
 py_library(
+    name = "transient_retry",
+    srcs = ["transient_retry.py"],
+    deps = [
+        "@pypi//httpx",
+    ],
+)
+
+py_library(
     name = "manifold",
     srcs = ["manifold.py"],
     deps = [
         ":platform",
+        ":transient_retry",
         "@pypi//httpx",
         "@pypi//pydantic",
     ],
@@ -51,6 +60,7 @@ py_library(
     srcs = ["polymarket.py"],
     deps = [
         ":platform",
+        ":transient_retry",
         "@pypi//polymarket_client",
     ],
 )
@@ -60,7 +70,9 @@ py_library(
     srcs = ["kalshi.py"],
     deps = [
         ":platform",
+        ":transient_retry",
         "@pypi//httpx",
+        "@pypi//pydantic",
     ],
 )
 
@@ -215,6 +227,19 @@ py_test(
     deps = [
         ":manifold",
         ":testing",
+        "//:conftest",
+        "@pypi//httpx",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_transient_retry",
+    srcs = ["test_transient_retry.py"],
+    deps = [
+        ":kalshi",
+        ":transient_retry",
         "//:conftest",
         "@pypi//httpx",
         "@pypi//pytest",

--- a/augur/calibration/BUILD.bazel
+++ b/augur/calibration/BUILD.bazel
@@ -41,6 +41,7 @@ py_library(
     srcs = ["transient_retry.py"],
     deps = [
         "@pypi//httpx",
+        "@pypi//tenacity",
     ],
 )
 

--- a/augur/calibration/kalshi.py
+++ b/augur/calibration/kalshi.py
@@ -14,6 +14,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 
 from augur.calibration.platform import Market
+from augur.calibration.transient_retry import httpx_is_transient, with_retry
 
 _BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
 _MARKET_URL_TEMPLATE = "https://kalshi.com/markets/{ticker}"
@@ -56,28 +57,42 @@ class KalshiClient:
         timeout: float = 30.0,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
         client: httpx.Client | None = None,
     ) -> None:
         self._client = client if client is not None else httpx.Client(timeout=timeout)
         self._cache_ttl_seconds = cache_ttl_seconds
         self._clock = clock
+        self._sleep = sleep
         self._cache: dict[str, tuple[Market, float]] = {}
 
     def get_market(self, market_id: str) -> Market:
         """One market's current state, served from the TTL cache when still fresh.
 
-        ``market_id`` is the Kalshi ticker (e.g. ``"KXIPOOPENAI-26DEC01"``).
+        ``market_id`` is the Kalshi ticker (e.g. ``"KXIPOOPENAI-26DEC01"``). Kalshi's API
+        flaps `503` per-ticker, so the live read is retried with backoff before giving up.
         """
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
+        market = with_retry(
+            lambda: self._fetch(market_id),
+            what=f"kalshi market {market_id!r}",
+            retry_on=httpx.HTTPError,
+            is_transient=httpx_is_transient,
+            sleep=self._sleep,
+        )
+        self._cache[market_id] = (market, now)
+        return market
+
+    def _fetch(self, market_id: str) -> Market:
         response = self._client.get(f"{_BASE_URL}/markets/{market_id}")
         response.raise_for_status()
         raw = _KalshiResponse.model_validate(response.json()).market
         # Kalshi's per-market title is the event headline; the leg's distinguishing clause lives in
         # yes_sub_title (e.g. "Above 3.0%"), so join them for a self-describing question.
         title = " — ".join(part for part in (raw.title, raw.yes_sub_title) if part) or None
-        market = Market(
+        return Market(
             id=market_id,
             url=_MARKET_URL_TEMPLATE.format(ticker=market_id),
             probability=raw.last_price_dollars,
@@ -86,8 +101,6 @@ class KalshiClient:
             title=title,
             rules=raw.rules_primary,
         )
-        self._cache[market_id] = (market, now)
-        return market
 
     def fetch_yes_probability(self, market_id: str) -> float:
         return self.get_market(market_id).require_probability()

--- a/augur/calibration/kalshi.py
+++ b/augur/calibration/kalshi.py
@@ -78,7 +78,6 @@ class KalshiClient:
         market = with_retry(
             lambda: self._fetch(market_id),
             what=f"kalshi market {market_id!r}",
-            retry_on=httpx.HTTPError,
             is_transient=httpx_is_transient,
             sleep=self._sleep,
         )

--- a/augur/calibration/manifold.py
+++ b/augur/calibration/manifold.py
@@ -92,7 +92,6 @@ class ManifoldClient:
         market = with_retry(
             lambda: self._fetch(market_id),
             what=f"manifold market {market_id!r}",
-            retry_on=httpx.HTTPError,
             is_transient=httpx_is_transient,
             sleep=self._sleep,
         )

--- a/augur/calibration/manifold.py
+++ b/augur/calibration/manifold.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from augur.calibration.platform import Market
+from augur.calibration.transient_retry import httpx_is_transient, with_retry
 
 _MARKET_ENDPOINT = "https://api.manifold.markets/v0/market/"
 _USER_AGENT = "augur-pm-calibration/1.0"
@@ -70,25 +71,41 @@ class ManifoldClient:
         timeout: float = 30.0,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
         client: httpx.Client | None = None,
     ) -> None:
         self._client = client if client is not None else httpx.Client(headers=_headers(), timeout=timeout)
         self._cache_ttl_seconds = cache_ttl_seconds
         self._clock = clock
+        self._sleep = sleep
         # market id -> (last fetched market state, monotonic timestamp of that fetch).
         self._cache: dict[str, tuple[Market, float]] = {}
 
     def get_market(self, market_id: str) -> Market:
-        """One market's current state, served from the TTL cache when still fresh."""
+        """One market's current state, served from the TTL cache when still fresh.
+
+        A transient 5xx/timeout is retried with backoff before propagating.
+        """
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
+        market = with_retry(
+            lambda: self._fetch(market_id),
+            what=f"manifold market {market_id!r}",
+            retry_on=httpx.HTTPError,
+            is_transient=httpx_is_transient,
+            sleep=self._sleep,
+        )
+        self._cache[market_id] = (market, now)
+        return market
+
+    def _fetch(self, market_id: str) -> Market:
         response = self._client.get(f"{_MARKET_ENDPOINT}{market_id}")
         response.raise_for_status()
         raw = _ManifoldResponse.model_validate(response.json())
         # Manifold's brand symbol for mana is double-struck capital M (U+1D544); RUF001 flags
         # it as ambiguous with plain capital M, but the resemblance is intentional.
-        market = Market(
+        return Market(
             id=raw.id,
             url=raw.url,
             probability=raw.probability,
@@ -97,8 +114,6 @@ class ManifoldClient:
             title=raw.question,
             rules=raw.text_description,
         )
-        self._cache[market_id] = (market, now)
-        return market
 
     def fetch_yes_probability(self, market_id: str) -> float:
         """Current YES probability for one binary market; raises if it carries none."""

--- a/augur/calibration/polymarket.py
+++ b/augur/calibration/polymarket.py
@@ -16,9 +16,29 @@ from decimal import Decimal
 
 from polymarket import PublicClient
 
+# `TimeoutError` / `TransportError` are aliased to avoid shadowing the builtins of the same
+# name; these are the SDK's wait-timeout / transport failures, distinct from
+# `builtins.TimeoutError` and `httpx.TransportError`.
+from polymarket.errors import (
+    PolymarketError,
+    RateLimitError,
+    RequestRejectedError,
+    TimeoutError as PolymarketTimeoutError,
+    TransportError as PolymarketTransportError,
+)
+
 from augur.calibration.platform import Market
+from augur.calibration.transient_retry import with_retry
 
 _POLYMARKET_BASE_URL = "https://polymarket.com/event"
+
+
+def _polymarket_is_transient(exc: BaseException) -> bool:
+    """A Polymarket SDK failure worth retrying: a 5xx server rejection, a rate-limit, or a
+    transport/wait-timeout error. Input-validation and unexpected-shape errors are not."""
+    if isinstance(exc, RequestRejectedError):
+        return exc.status >= 500
+    return isinstance(exc, RateLimitError | PolymarketTransportError | PolymarketTimeoutError)
 
 
 def _yes_price_to_probability(price: Decimal | None) -> float | None:
@@ -38,22 +58,36 @@ class PolymarketClient:
         *,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
         sdk_client: PublicClient | None = None,
     ) -> None:
         self._sdk = sdk_client if sdk_client is not None else PublicClient()
         self._cache_ttl_seconds = cache_ttl_seconds
         self._clock = clock
+        self._sleep = sleep
         self._cache: dict[str, tuple[Market, float]] = {}
 
     def get_market(self, market_id: str) -> Market:
         """One market's current state, served from the TTL cache when still fresh.
 
         ``market_id`` is the Polymarket condition_id passed to
-        ``PublicClient.get_market(id=...)``.
+        ``PublicClient.get_market(id=...)``. A transient 5xx/rate-limit/timeout is retried
+        with backoff before propagating.
         """
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
+        market = with_retry(
+            lambda: self._fetch(market_id),
+            what=f"polymarket market {market_id!r}",
+            retry_on=PolymarketError,
+            is_transient=_polymarket_is_transient,
+            sleep=self._sleep,
+        )
+        self._cache[market_id] = (market, now)
+        return market
+
+    def _fetch(self, market_id: str) -> Market:
         pm_market = self._sdk.get_market(id=market_id)
         probability = _yes_price_to_probability(
             pm_market.outcomes.yes.price if pm_market.outcomes is not None else None
@@ -62,7 +96,7 @@ class PolymarketClient:
         # All-time traded volume in USD per the gamma `metrics.volume` field. The SDK's
         # Market.metrics is non-optional but each volume sub-field is.
         volume = float(pm_market.metrics.volume) if pm_market.metrics.volume is not None else None
-        market = Market(
+        return Market(
             id=market_id,
             url=f"{_POLYMARKET_BASE_URL}/{slug}",
             probability=probability,
@@ -71,8 +105,6 @@ class PolymarketClient:
             title=pm_market.question,
             rules=pm_market.description,
         )
-        self._cache[market_id] = (market, now)
-        return market
 
     def fetch_yes_probability(self, market_id: str) -> float:
         return self.get_market(market_id).require_probability()

--- a/augur/calibration/polymarket.py
+++ b/augur/calibration/polymarket.py
@@ -20,7 +20,6 @@ from polymarket import PublicClient
 # name; these are the SDK's wait-timeout / transport failures, distinct from
 # `builtins.TimeoutError` and `httpx.TransportError`.
 from polymarket.errors import (
-    PolymarketError,
     RateLimitError,
     RequestRejectedError,
     TimeoutError as PolymarketTimeoutError,
@@ -80,7 +79,6 @@ class PolymarketClient:
         market = with_retry(
             lambda: self._fetch(market_id),
             what=f"polymarket market {market_id!r}",
-            retry_on=PolymarketError,
             is_transient=_polymarket_is_transient,
             sleep=self._sleep,
         )

--- a/augur/calibration/test_transient_retry.py
+++ b/augur/calibration/test_transient_retry.py
@@ -1,0 +1,94 @@
+"""Tests for `with_retry`: it retries transient failures with backoff, gives up after the
+attempt budget, and never retries non-transient errors.
+
+The Kalshi client wiring is exercised end-to-end with a `MockTransport` that 503s a fixed
+number of times before succeeding, proving the client recovers from the per-ticker 503
+flapping that motivated the retry.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import pytest_bazel
+
+from augur.calibration.kalshi import KalshiClient
+from augur.calibration.transient_retry import httpx_is_transient, with_retry
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.test/m")
+    return httpx.HTTPStatusError("boom", request=request, response=httpx.Response(status, request=request))
+
+
+def test_retries_transient_then_succeeds() -> None:
+    attempts = {"n": 0}
+    slept: list[float] = []
+
+    def fetch() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise _http_status_error(503)
+        return "ok"
+
+    result = with_retry(
+        fetch,
+        what="thing",
+        retry_on=httpx.HTTPError,
+        is_transient=httpx_is_transient,
+        sleep=slept.append,
+    )
+    assert result == "ok"
+    assert attempts["n"] == 3
+    # Exponential backoff between the two failed attempts: 0.5s, then 1.0s.
+    assert slept == [0.5, 1.0]
+
+
+def test_gives_up_after_max_attempts_and_reraises_last() -> None:
+    attempts = {"n": 0}
+
+    def fetch() -> str:
+        attempts["n"] += 1
+        raise _http_status_error(503)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        with_retry(fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=lambda _: None)
+    assert attempts["n"] == 3
+
+
+def test_non_transient_status_is_not_retried() -> None:
+    attempts = {"n": 0}
+
+    def fetch() -> str:
+        attempts["n"] += 1
+        raise _http_status_error(404)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        with_retry(fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=lambda _: None)
+    # A 404 won't fix itself: fail immediately without burning the retry budget.
+    assert attempts["n"] == 1
+
+
+def test_httpx_is_transient_classification() -> None:
+    assert httpx_is_transient(_http_status_error(503))
+    assert httpx_is_transient(_http_status_error(429))
+    assert not httpx_is_transient(_http_status_error(404))
+    assert httpx_is_transient(httpx.ConnectTimeout("slow"))
+
+
+def test_kalshi_client_recovers_from_flapping_503() -> None:
+    responses = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        responses["n"] += 1
+        if responses["n"] < 3:
+            return httpx.Response(503)
+        return httpx.Response(200, json={"market": {"last_price_dollars": 0.37}})
+
+    client = KalshiClient(client=httpx.Client(transport=httpx.MockTransport(handler)), sleep=lambda _: None)
+    assert client.get_market("KXTEST").probability == 0.37
+    assert responses["n"] == 3
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/calibration/test_transient_retry.py
+++ b/augur/calibration/test_transient_retry.py
@@ -31,9 +31,7 @@ def test_retries_transient_then_succeeds() -> None:
             raise _http_status_error(503)
         return "ok"
 
-    result = with_retry(
-        fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=slept.append
-    )
+    result = with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=slept.append)
     assert result == "ok"
     assert attempts["n"] == 3
     # Exponential backoff between the two failed attempts: 0.5s, then 1.0s.
@@ -48,7 +46,7 @@ def test_gives_up_after_max_attempts_and_reraises_last() -> None:
         raise _http_status_error(503)
 
     with pytest.raises(httpx.HTTPStatusError):
-        with_retry(fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=lambda _: None)
+        with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=lambda _: None)
     assert attempts["n"] == 3
 
 
@@ -60,7 +58,7 @@ def test_non_transient_status_is_not_retried() -> None:
         raise _http_status_error(404)
 
     with pytest.raises(httpx.HTTPStatusError):
-        with_retry(fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=lambda _: None)
+        with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=lambda _: None)
     # A 404 won't fix itself: fail immediately without burning the retry budget.
     assert attempts["n"] == 1
 

--- a/augur/calibration/test_transient_retry.py
+++ b/augur/calibration/test_transient_retry.py
@@ -32,11 +32,7 @@ def test_retries_transient_then_succeeds() -> None:
         return "ok"
 
     result = with_retry(
-        fetch,
-        what="thing",
-        retry_on=httpx.HTTPError,
-        is_transient=httpx_is_transient,
-        sleep=slept.append,
+        fetch, what="thing", retry_on=httpx.HTTPError, is_transient=httpx_is_transient, sleep=slept.append
     )
     assert result == "ok"
     assert attempts["n"] == 3

--- a/augur/calibration/transient_retry.py
+++ b/augur/calibration/transient_retry.py
@@ -22,6 +22,7 @@ import time
 from collections.abc import Callable
 
 import httpx
+from tenacity import RetryCallState, Retrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -44,32 +45,32 @@ def with_retry[T](
     fetch: Callable[[], T],
     *,
     what: str,
-    retry_on: type[BaseException] | tuple[type[BaseException], ...],
     is_transient: Callable[[BaseException], bool],
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
     sleep: Callable[[float], None] = time.sleep,
 ) -> T:
-    """Call ``fetch`` up to ``max_attempts`` times, retrying with exponential backoff only
-    those exceptions in ``retry_on`` for which ``is_transient`` returns True. Any other
-    exception (and the final transient one) propagates to the caller.
-
-    ``what`` is a short human label for the resource being fetched, used in the retry log.
+    """Call ``fetch`` via tenacity, retrying with exponential backoff only failures for
+    which ``is_transient`` returns True; any other exception (and the final transient one,
+    once the attempt budget is spent) propagates. ``what`` labels the resource in the log.
     """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            return fetch()
-        except retry_on as exc:
-            if attempt >= max_attempts or not is_transient(exc):
-                raise
-            backoff = backoff_base_seconds * 2 ** (attempt - 1)
-            logger.warning(
-                "transient error fetching %s (attempt %d/%d): %r; retrying in %.1fs",
-                what,
-                attempt,
-                max_attempts,
-                exc,
-                backoff,
-            )
-            sleep(backoff)
-    raise AssertionError("unreachable: retry loop exited without return or raise")
+
+    def _log_retry(retry_state: RetryCallState) -> None:
+        exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
+        logger.warning(
+            "transient error fetching %s (attempt %d/%d): %r; retrying",
+            what,
+            retry_state.attempt_number,
+            max_attempts,
+            exc,
+        )
+
+    retrying = Retrying(
+        retry=retry_if_exception(is_transient),
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(multiplier=backoff_base_seconds, exp_base=2),
+        sleep=sleep,
+        before_sleep=_log_retry,
+        reraise=True,
+    )
+    return retrying(fetch)

--- a/augur/calibration/transient_retry.py
+++ b/augur/calibration/transient_retry.py
@@ -1,0 +1,75 @@
+"""Bounded retry-with-backoff for the flaky read-only prediction-market APIs.
+
+The read-only PM endpoints intermittently fail for individual markets — Kalshi in
+particular returns `503 Service Unavailable` for a ticker one moment and `200` the next.
+A calibration run fetches the whole catalog, so a single transient 5xx otherwise drops
+that market's row entirely (Kalshi was dropping *every* row this way, leaving only
+Manifold surfaced). Retry the network read a few times with exponential backoff before
+giving up; on final failure the caller's existing handling drops the row as before.
+
+TODO(2026-06-04): The per-process TTL cache + inline retry in the clients is a stopgap.
+The right architecture is a small separate syncer that continuously mirrors Kalshi /
+Manifold / Polymarket market states into a local store with a bounded max staleness, and
+has the server read from that store instead of hitting the upstreams inline on every
+calibration run. That decouples calibration latency and availability from the PM APIs'
+flakiness entirely. Tracked in augur/TODO.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Initial attempt + 2 retries, backing off 0.5s then 1.0s. Bounded so a wedged upstream
+# can't stall a whole-catalog calibration run for long.
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_BACKOFF_BASE_SECONDS = 0.5
+
+
+def httpx_is_transient(exc: BaseException) -> bool:
+    """A raw-httpx failure worth retrying: a 5xx/429 response, or a transport-level error
+    (connect/read timeout, connection reset). 4xx and response-parsing errors won't fix
+    themselves on a retry."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500 or exc.response.status_code == 429
+    return isinstance(exc, httpx.TransportError)
+
+
+def with_retry[T](
+    fetch: Callable[[], T],
+    *,
+    what: str,
+    retry_on: type[BaseException] | tuple[type[BaseException], ...],
+    is_transient: Callable[[BaseException], bool],
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> T:
+    """Call ``fetch`` up to ``max_attempts`` times, retrying with exponential backoff only
+    those exceptions in ``retry_on`` for which ``is_transient`` returns True. Any other
+    exception (and the final transient one) propagates to the caller.
+
+    ``what`` is a short human label for the resource being fetched, used in the retry log.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fetch()
+        except retry_on as exc:
+            if attempt >= max_attempts or not is_transient(exc):
+                raise
+            backoff = backoff_base_seconds * 2 ** (attempt - 1)
+            logger.warning(
+                "transient error fetching %s (attempt %d/%d): %r; retrying in %.1fs",
+                what,
+                attempt,
+                max_attempts,
+                exc,
+                backoff,
+            )
+            sleep(backoff)
+    raise AssertionError("unreachable: retry loop exited without return or raise")


### PR DESCRIPTION
## What

Add bounded retry-with-backoff around the live prediction-market reads in all three
price clients, so a transient upstream failure doesn't drop a market from a
calibration run.

## Why

The read-only PM APIs intermittently fail per-market — **Kalshi returns `503 Service
Unavailable` for a ticker one moment and `200` the next** (verified live). A calibration
run fetches the whole catalog, so a single transient 5xx dropped that market's row
entirely. On the live deployment this dropped *every* Kalshi row, leaving only Manifold
surfaced:

```
dropping calibration row: kalshi market 'KXETHY-27JAN0100-B4375' failed to fetch
httpx.HTTPStatusError: Server error '503 Service Unavailable'
```

The 12h cache (#1877) helps once a market is cached, but a cold cache after a pod restart
still drops first-fetch failures. This adds the durable fix.

## How

- New `augur/calibration/transient_retry.py` — `with_retry(fetch, *, what, retry_on,
  is_transient, ...)`: 3 attempts, 0.5s/1.0s exponential backoff, retrying **only**
  transient failures and re-raising everything else (and the final transient one). A
  `sleep` seam keeps tests fast/hermetic.
- Wired into `kalshi` / `manifold` / `polymarket` (each `get_market` now retries its
  network read). Transient = `httpx` 5xx/429/transport errors; for the Polymarket SDK,
  `RequestRejectedError` 5xx / `RateLimitError` / transport+timeout. 4xx and parse errors
  are **not** retried.
- Fixes a latent missing `@pypi//pydantic` dep on the `kalshi` target (it imports pydantic
  but only resolved it transitively until a narrow target depended on it directly).
- `augur/TODO.md`: TODO to split PM fetching into a separate syncer with a local store
  (bounded staleness) so scoring no longer hits the upstreams inline — the cache + retry
  are the stopgap.

## Tests

`//augur/calibration:test_transient_retry` (new — retries-then-succeeds, gives-up-after-N,
non-transient-not-retried, httpx classifier, and an end-to-end Kalshi `MockTransport` that
503s twice then 200s), plus `//augur/calibration:test_manifold` and
`//augur/api:test_calibration_endpoint`, all green on RBE (ruff + mypy clean).

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw)_