### PR TITLE
augur: tax-loss harvesting Piece 2 — reduced-form harvest process (model + engine + config)

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -94,6 +94,7 @@ py_library(
         ":finance",
         ":portfolio",
         ":schemas",
+        "//augur/sim:tlh_harvest",
         "@pypi//pydantic",
     ],
 )
@@ -107,6 +108,7 @@ py_library(
         ":portfolio",
         ":portfolio_source_config",
         "//augur/product:asset_key",
+        "//augur/sim:scenario",
         "//plaid_utils:read_model",
         "//plaid_utils:schema",
     ],

--- a/augur/api/portfolio_source_config.py
+++ b/augur/api/portfolio_source_config.py
@@ -10,6 +10,7 @@ from pydantic import Field, NonNegativeInt, PositiveFloat, model_validator
 from augur.api.finance import FinanceSnapshot
 from augur.api.portfolio import HoldingKind, PortfolioAccountType, PortfolioConfig
 from augur.api.schemas import ApiModel
+from augur.sim.tlh_harvest import HarvestYieldParams
 
 _ID_PATTERN = r"^[a-z0-9][a-z0-9_\-]*$"
 
@@ -55,6 +56,30 @@ class PlaidProxyHoldingPeriodBucket(ApiModel):
     )
 
 
+class HarvestProcessConfig(ApiModel):
+    """Optional reduced-form tax-loss-harvesting (TLH) process attached to an SP500 proxy sleeve.
+
+    LIMITED, DELIBERATELY-APPROXIMATE ("untruthful") MODEL — see `augur.sim.scenario.HarvestPolicy`
+    and the engine phase `_apply_tlh_harvest`. It does NOT simulate the direct-indexing sleeve's
+    constituent stocks; the harvestable loss is a calibrated function of the SP500 path, not a real
+    below-basis amount, and all `HarvestYieldParams` are `[HEURISTIC]` (first-year-1099-B anchor,
+    external decay prior). The loss is honest deferral: a basis give-back at sale repays it.
+    """
+
+    yield_params: HarvestYieldParams = Field(description="Calibrated harvest-yield curve. All params [HEURISTIC].")
+    short_term_fraction: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Optional override for the share of each month's harvested loss booked as short-term. "
+            "When omitted, it is seeded from the proxy's holding_period_buckets short-term (<12mo) "
+            "market-value share, defaulting to 1.0 when no buckets are configured (young account, "
+            "all short-term — matching the TY2025 1099-B)."
+        ),
+    )
+
+
 class PlaidSp500ProxyGroupConfig(ApiModel):
     """Map selected Plaid investment accounts into one Augur SP500 proxy position."""
 
@@ -76,6 +101,14 @@ class PlaidSp500ProxyGroupConfig(ApiModel):
             "aggregate lot at `default_holding_period_months_at_start`. When set, the live Plaid "
             "value/basis is distributed across these buckets so short- vs long-term tax treatment "
             "is modeled."
+        ),
+    )
+    harvest: HarvestProcessConfig | None = Field(
+        default=None,
+        description=(
+            "Optional reduced-form TLH harvest process for this sleeve (Piece 2b). When set, the "
+            "sleeve realizes calibrated monthly capital losses with a basis give-back at sale "
+            "(honest deferral). When omitted, the sleeve behaves exactly as before — no harvesting."
         ),
     )
 

--- a/augur/api/portfolio_source_config.py
+++ b/augur/api/portfolio_source_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import Field, NonNegativeInt, PositiveFloat, model_validator
 
@@ -56,16 +57,20 @@ class PlaidProxyHoldingPeriodBucket(ApiModel):
     )
 
 
-class HarvestProcessConfig(ApiModel):
-    """Optional reduced-form tax-loss-harvesting (TLH) process attached to an SP500 proxy sleeve.
+class ReducedFormTlhModel(ApiModel):
+    """`tlh_model` variant `reduced_form_tlh` — a LIMITED, DELIBERATELY-APPROXIMATE ("untruthful")
+    tax-loss-harvesting model. The `type` tag is the honesty signal: it does NOT simulate the
+    direct-indexing sleeve's constituent stocks. The harvestable loss is a calibrated function of
+    the SP500 path (`augur.sim.scenario.HarvestPolicy`, engine phase `_apply_tlh_harvest`), not a
+    real below-basis amount; all `HarvestYieldParams` are `[HEURISTIC]` (first-year-1099-B anchor,
+    external decay prior). The loss is honest deferral — a basis give-back at sale repays it.
 
-    LIMITED, DELIBERATELY-APPROXIMATE ("untruthful") MODEL — see `augur.sim.scenario.HarvestPolicy`
-    and the engine phase `_apply_tlh_harvest`. It does NOT simulate the direct-indexing sleeve's
-    constituent stocks; the harvestable loss is a calibrated function of the SP500 path, not a real
-    below-basis amount, and all `HarvestYieldParams` are `[HEURISTIC]` (first-year-1099-B anchor,
-    external decay prior). The loss is honest deferral: a basis give-back at sale repays it.
+    A less-fake variant (`type: representative_sleeve_tlh`, the plan's option #3 — a handful of
+    index-factor + idiosyncratic-noise sleeves with REAL FIFO harvesting) would join this as a
+    sibling in `TlhModelConfig`; the discriminator then tells you which fidelity is deployed.
     """
 
+    type: Literal["reduced_form_tlh"] = "reduced_form_tlh"
     yield_params: HarvestYieldParams = Field(description="Calibrated harvest-yield curve. All params [HEURISTIC].")
     short_term_fraction: float | None = Field(
         default=None,
@@ -78,6 +83,11 @@ class HarvestProcessConfig(ApiModel):
             "all short-term — matching the TY2025 1099-B)."
         ),
     )
+
+
+# Discriminated by `type`. Single variant today; when the plan's option #3 lands it becomes
+# `Annotated[ReducedFormTlhModel | RepresentativeSleeveTlhModel, Field(discriminator="type")]`.
+TlhModelConfig = ReducedFormTlhModel
 
 
 class PlaidSp500ProxyGroupConfig(ApiModel):
@@ -103,12 +113,13 @@ class PlaidSp500ProxyGroupConfig(ApiModel):
             "is modeled."
         ),
     )
-    harvest: HarvestProcessConfig | None = Field(
+    tlh_model: TlhModelConfig | None = Field(
         default=None,
         description=(
-            "Optional reduced-form TLH harvest process for this sleeve (Piece 2b). When set, the "
-            "sleeve realizes calibrated monthly capital losses with a basis give-back at sale "
-            "(honest deferral). When omitted, the sleeve behaves exactly as before — no harvesting."
+            "Optional tax-loss-harvesting model for this sleeve (Piece 2b), tagged by `type` "
+            "(`reduced_form_tlh`). When set, the sleeve realizes calibrated monthly capital losses "
+            "with a basis give-back at sale (honest deferral). When omitted, the sleeve behaves "
+            "exactly as before — no harvesting."
         ),
     )
 

--- a/augur/api/portfolio_sources.py
+++ b/augur/api/portfolio_sources.py
@@ -117,7 +117,7 @@ async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url:
             )
         )
         holdings.append(_sp500_proxy_holding(group, group_holdings))
-        if group.harvest is not None:
+        if group.tlh_model is not None:
             harvest_policies.append(_harvest_policy(group))
 
     captured = [balance.captured_at for balance in cash_balances] + [
@@ -142,16 +142,17 @@ def _harvest_policy(group: PlaidSp500ProxyGroupConfig) -> HarvestPolicy:
     all short-term, matching the TY2025 1099-B).
     """
 
-    assert group.harvest is not None  # caller guards
-    if group.harvest.short_term_fraction is not None:
-        short_term_fraction = group.harvest.short_term_fraction
+    assert group.tlh_model is not None  # caller guards
+    tlh_model = group.tlh_model
+    if tlh_model.short_term_fraction is not None:
+        short_term_fraction = tlh_model.short_term_fraction
     else:
         short_term_fraction = _bucket_short_term_fraction(group)
     return HarvestPolicy(
         owner_agent_id=group.owner_agent_id,
         account_id=group.portfolio_account_id,
         asset=SP500AssetKey(),
-        yield_params=group.harvest.yield_params,
+        yield_params=tlh_model.yield_params,
         short_term_fraction=short_term_fraction,
     )
 

--- a/augur/api/portfolio_sources.py
+++ b/augur/api/portfolio_sources.py
@@ -19,10 +19,16 @@ from augur.api.portfolio_source_config import (
     PlaidSp500ProxyGroupConfig,
 )
 from augur.product.asset_key import SP500AssetKey
+from augur.sim.scenario import HarvestPolicy
 from plaid_utils.read_model import CurrentCashBalance, CurrentHolding, read_current_cash_balances, read_current_holdings
 from plaid_utils.schema import async_session_factory
 
 logger = logging.getLogger(__name__)
+
+# A direct-indexing sleeve's short-term harvest character comes from its recently-bought lots; a
+# lot is short-term until it has been held a full year (IRC §1222), so buckets below this many
+# months at month 0 contribute to the harvested loss's short-term share.
+_SHORT_TERM_HOLDING_PERIOD_MONTHS = 12
 
 
 @dataclass(frozen=True)
@@ -31,6 +37,7 @@ class _PortfolioContribution:
     as_of_date: str | None
     accounts: tuple[PortfolioAccountConfig, ...]
     holdings: tuple[HoldingPositionConfig, ...]
+    harvest_policies: tuple[HarvestPolicy, ...]
     latest_captured_at: datetime | None
 
 
@@ -38,6 +45,10 @@ class _PortfolioContribution:
 class ResolvedPortfolioSources:
     snapshot: FinanceSnapshot
     portfolio: PortfolioConfig
+    # Reduced-form TLH harvest processes attached to index-tracking sleeves (Piece 2b). Empty when
+    # no proxy group configures `harvest`. Fed into `Scenario.harvest_policies` so the engine's
+    # `_apply_tlh_harvest` phase realizes calibrated losses with a sale-time basis give-back.
+    harvest_policies: tuple[HarvestPolicy, ...]
 
 
 def resolve_portfolio_sources(config: Config) -> ResolvedPortfolioSources:
@@ -54,14 +65,13 @@ def resolve_portfolio_sources(config: Config) -> ResolvedPortfolioSources:
         if not db_url:
             raise ValueError(f"Plaid portfolio source is enabled but ${plaid.database_url_env} is not set")
         contributions.append(asyncio.run(_read_plaid_contribution(plaid, db_url=db_url)))
-    portfolio = _merge_contributions(tuple(contribution for contribution in contributions if contribution is not None))
+    present = tuple(contribution for contribution in contributions if contribution is not None)
+    portfolio = _merge_contributions(present)
     snapshot = FinanceSnapshot(
-        as_of_date=_merged_as_of_date(
-            tuple(contribution for contribution in contributions if contribution is not None)
-        ),
-        cash_usd=sum(contribution.cash_usd for contribution in contributions if contribution is not None),
+        as_of_date=_merged_as_of_date(present), cash_usd=sum(contribution.cash_usd for contribution in present)
     )
-    return ResolvedPortfolioSources(snapshot=snapshot, portfolio=portfolio)
+    harvest_policies = tuple(policy for contribution in present for policy in contribution.harvest_policies)
+    return ResolvedPortfolioSources(snapshot=snapshot, portfolio=portfolio, harvest_policies=harvest_policies)
 
 
 async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url: str) -> _PortfolioContribution:
@@ -91,6 +101,7 @@ async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url:
 
     accounts: list[PortfolioAccountConfig] = []
     holdings: list[HoldingPositionConfig] = []
+    harvest_policies: list[HarvestPolicy] = []
     for group in plaid.sp500_proxy_groups:
         group_holdings = tuple(
             holding for account_id in group.plaid_account_ids for holding in holdings_by_account.get(account_id, ())
@@ -106,6 +117,8 @@ async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url:
             )
         )
         holdings.append(_sp500_proxy_holding(group, group_holdings))
+        if group.harvest is not None:
+            harvest_policies.append(_harvest_policy(group))
 
     captured = [balance.captured_at for balance in cash_balances] + [
         holding.captured_at for holding in current_holdings
@@ -115,8 +128,51 @@ async def _read_plaid_contribution(plaid: PlaidPortfolioSourceConfig, *, db_url:
         as_of_date=None,
         accounts=tuple(accounts),
         holdings=tuple(holdings),
+        harvest_policies=tuple(harvest_policies),
         latest_captured_at=max(captured) if captured else None,
     )
+
+
+def _harvest_policy(group: PlaidSp500ProxyGroupConfig) -> HarvestPolicy:
+    """Build the scenario-level TLH harvest policy for one proxy group's sleeve.
+
+    The policy is keyed to the proxy's (owner_agent, portfolio_account, SP500) lots — the same
+    pool `_sp500_proxy_holding` expanded. The short-term share is the config override if set,
+    else the buckets' short-term (<12mo) market-value share, else 1.0 (no buckets → young account,
+    all short-term, matching the TY2025 1099-B).
+    """
+
+    assert group.harvest is not None  # caller guards
+    if group.harvest.short_term_fraction is not None:
+        short_term_fraction = group.harvest.short_term_fraction
+    else:
+        short_term_fraction = _bucket_short_term_fraction(group)
+    return HarvestPolicy(
+        owner_agent_id=group.owner_agent_id,
+        account_id=group.portfolio_account_id,
+        asset=SP500AssetKey(),
+        yield_params=group.harvest.yield_params,
+        short_term_fraction=short_term_fraction,
+    )
+
+
+def _bucket_short_term_fraction(group: PlaidSp500ProxyGroupConfig) -> float:
+    """Short-term (<12mo) market-value share across the proxy's holding-period buckets.
+
+    With no buckets the sleeve is a single aggregate lot whose age is unknown; treat a fresh
+    direct-indexing account as fully short-term (1.0), which both matches the TY2025 1099-B and is
+    the conservative-for-deferral default (short-term losses are the more valuable to harvest)."""
+
+    buckets = group.holding_period_buckets
+    if not buckets:
+        return 1.0
+    total = sum(bucket.market_value_fraction for bucket in buckets)
+    short_term = sum(
+        bucket.market_value_fraction
+        for bucket in buckets
+        if bucket.holding_period_months_at_start < _SHORT_TERM_HOLDING_PERIOD_MONTHS
+    )
+    return short_term / total if total > 0.0 else 1.0
 
 
 def _cash_total(plaid: PlaidPortfolioSourceConfig, balances: tuple[CurrentCashBalance, ...]) -> float:
@@ -226,6 +282,7 @@ def _fixed_contribution(fixed: FixedPortfolioSourceConfig) -> _PortfolioContribu
         as_of_date=fixed.snapshot.as_of_date if fixed.snapshot is not None else None,
         accounts=fixed.portfolio.accounts,
         holdings=fixed.portfolio.holdings,
+        harvest_policies=(),
         latest_captured_at=None,
     )
 

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -99,6 +99,7 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         portfolio=resolved_portfolio.portfolio,
         initial_cash_usd=float(resolved_portfolio.snapshot.cash_usd),
         primary_agent_id=resolve_primary_agent_id(augur_config),
+        harvest_policies=resolved_portfolio.harvest_policies,
         known_location_ids=catalog.location_ids,
         locations=sim_locations_from_config(augur_config.locations),
         properties_by_id=catalog.properties_by_id,

--- a/augur/plans/tax_loss_harvesting.md
+++ b/augur/plans/tax_loss_harvesting.md
@@ -1,7 +1,13 @@
 # Tax-loss harvesting (TLH) in Augur
 
 Status: 2026-06-04. Piece 1 (capital-loss netting + carryforward) landed
-(ducktape #1846); Piece 2 (harvest process) designed, not started.
+(ducktape #1846). Piece 2: Step 2a (yield core, `augur/sim/tlh_harvest.py`) landed; Step 2b
+(engine integration) implemented — config `HarvestProcessConfig` →
+`Scenario.harvest_policies` → compiled `harvest_policies` table (`augur/sim/compiler/tlh_harvest.py`)
+→ engine phase `_apply_tlh_harvest` + sale-time basis give-back in
+`_record_capital_gains` (`augur/sim/engine/phases.py`), with the per-(policy, rollout)
+`tlh_cumulative_harvest` scalar in `augur/sim/buffers.py`. The basis-reset design fork below
+was resolved as option **(B)** (scalar, not extra lot slots).
 
 ## Motivation
 

--- a/augur/plans/tax_loss_harvesting.md
+++ b/augur/plans/tax_loss_harvesting.md
@@ -1,7 +1,7 @@
 # Tax-loss harvesting (TLH) in Augur
 
-Status: 2026-06-04. Piece 1 (capital-loss netting + carryforward) in progress;
-Piece 2 (harvest process) designed, not started.
+Status: 2026-06-04. Piece 1 (capital-loss netting + carryforward) landed
+(ducktape #1846); Piece 2 (harvest process) designed, not started.
 
 ## Motivation
 
@@ -16,6 +16,14 @@ index ETF, and Augur currently models **none** of it.
 Ground-truth evidence (private, see `gaffer-private/gaffer_augur/wealthfront/`):
 TY2025 1099-B for the live account shows ~$73k net realized loss, ~5%/yr of
 portfolio value, **essentially all short-term**, with **zero wash sales**.
+
+**The account was opened in 2025, so TY2025 is its first year and the only
+1099-B that exists** — there are no prior-year forms, and none ever will be.
+This matters for calibration: a first-year direct-indexing account harvests at
+or near its **maximum** rate (every lot was bought recently, so dispersion below
+basis is widest and embedded gains are smallest). The ~5%/yr all-short-term
+figure is therefore a _first-year peak_, not a steady-state rate, and we have no
+in-account history to observe how it decays as the sleeve matures.
 
 ## What already shipped
 
@@ -73,33 +81,119 @@ useful and lands first.
 Attach an optional harvest process to a holding. Each tax period:
 
 - **Driver:** harvest yield is a function of the period's index return
-  (drawdowns harvest more) and the position's **embedded-gain ratio**
-  (basis/MV — as it rises, fewer lots sit below basis, so yield decays). 2–3
-  params; optionally realized volatility.
-- **Form:** `gross_harvest_t ≈ MV_t · g(return_t, embedded_gain_ratio_t)`, with
-  `g` rising in drawdowns and decaying toward a floor as embedded gain grows.
-  Split output into ST/LT (mostly ST early; seed from the holding-period
-  buckets).
+  (drawdowns harvest more) and the position's **embedded-gain fraction**
+  `e = clip((MV − basis)/MV, 0, 1)`. A fresh cash-funded account has `e ≈ 0`
+  (basis = market value) and harvests near its peak; as winners appreciate and
+  losers get reset away, the position is increasingly dominated by low-basis
+  winners, `e → 1`, and yield decays toward a floor ("ossification",
+  [VANGUARD-2024]). 2–3 params; optionally realized volatility.
+- **Form:** `gross_harvest_t ≈ MV_t · g(return_t, e_t)`, with `g` rising in
+  drawdowns and decaying toward a floor as `e` grows. Split output into ST/LT
+  (mostly ST early; seed from the holding-period buckets).
 - **Basis feedback (the one real state element):** harvesting realizes a loss
   _and_ resets that slice's basis to current market (sell-underwater + rebuy).
   So the process (a) books the loss into Piece 1, and (b) lowers the position's
-  tracked cost basis, which raises the embedded-gain ratio and **decays future
-  yield**. A scalar basis update per position — no per-stock state.
+  tracked cost basis, which raises the embedded-gain fraction `e` and **decays
+  future yield**. A scalar basis update per position — no per-stock state.
 - **No wash-sale gate needed:** TY2025 had zero wash sales (replacement-buying
   works), so gross index exposure stays continuous and the realized-loss output
   is unaffected.
 
 ### Calibration
 
-- Level + ST/LT mix anchored to the TY2025 1099-B (~5%/yr net, all ST).
+- Level + ST/LT mix anchored to the TY2025 1099-B (~5%/yr net, all ST), read as
+  the **first-year peak** (see Motivation).
 - The **decay rate** (yield vs account maturity) is the one genuinely unknown
-  parameter. Needs prior-year 1099-Bs (TY2022–24) to fit. Until then, mark it
-  `[HEURISTIC]` and keep it conservative — a flat 5%/yr extrapolated 10 years
-  would massively overstate the benefit.
+  parameter, and **cannot be fit from this account**: there are no prior-year
+  1099-Bs (the account opened in 2025), and TY2025 is a single point at the
+  high end of the curve. A flat 5%/yr extrapolated 10 years would massively
+  overstate the benefit. Until we have a second point:
+  - Anchor the curve's _shape_ to external direct-indexing TLH research
+    ([VANGUARD-2024], [CBL-2020] — see References). The benefit is **front-loaded**:
+    a cash-funded account starts with cost basis = market value (maximal harvest),
+    and as winners appreciate, dispersion increasingly shows up as _unrealized
+    gains_ rather than harvestable losses ("ossification"), so yield decays toward
+    a low floor. Mark the fitted decay `[HEURISTIC]` and keep it conservative.
+  - Note that Piece 2's basis-feedback mechanism already produces decay
+    _endogenously_ (harvesting resets basis → embedded-gain ratio rises → yield
+    falls); the decay **rate** param only sets how fast. So the structural
+    shape is right even before the rate is pinned.
+  - **Re-fit annually.** Each new tax year (TY2026, TY2027, …) adds one maturity
+    point; the first year-over-year decline is the first directly observed
+    decay signal. Once ≥2 forms exist, replace the heuristic with a fitted rate.
 - Generic process + calibration _schema_ live in ducktape; the account's fitted
   numbers live in `gaffer-private/gaffer_augur/wealthfront/`.
 
+### Implementation proposal
+
+How Piece 2 lands in the sim, grounded in the current engine. Built in two steps
+so the calibratable math lands and is unit-tested before any engine surgery.
+
+**Step 2a — the harvest-yield core (this PR).** A pure, vectorized
+`augur/sim/tlh_harvest.py`: a Pydantic `HarvestYieldParams` (peak/floor annual
+yield, maturity-decay exponent, drawdown sensitivity) and
+`monthly_harvest_fraction(period_return, embedded_gain_fraction, params) -> (R,)`
+plus an ST/LT splitter seeded from holding-period buckets. It encodes the
+[VANGUARD-2024] front-loaded shape: peak at `e = 0`, decaying as `(1 − e)^γ`
+toward a floor, scaled up in drawdowns. All params `[HEURISTIC]` with the
+external anchor cited in-module. No engine dependency; fully unit-tested for the
+monotonicity/bound/decay invariants. The function returns a _fraction of MV_; the
+caller clamps it to the loss actually available below basis.
+
+**Step 2b — engine integration (follow-up PR).** Wire the core into the sim:
+
+- **Config:** add `harvest: HarvestProcessConfig | None = None` to
+  `PlaidSp500ProxyGroupConfig` (`augur/api/portfolio_source_config.py`) — the
+  proxy sleeve already carries `holding_period_buckets`, the natural ST/LT seed.
+- **Plan:** compile a `harvest_policies` table + `holding → policy` map in
+  `augur/sim/compiler/plan.py` (mirror the `pe_policies` / `pe_issuers` tables).
+- **Phase:** add `_apply_harvest` to the monthly step in
+  `augur/sim/engine/__init__.py`, slotted **before** `_apply_pe_tenders`. It reads
+  the index return from `plan.external_values[series_index, :, month]`, computes
+  per-rollout MV/basis → `e`, calls the Step-2a core, clamps to available loss,
+  injects the realized loss into `current.capital_gain_ytd[profile, ST|LT, :]`
+  (Piece 1's netting then handles it unchanged), and applies the **basis reset**.
+  Model the whole phase on the existing `_apply_pe_tenders` template.
+- **Basis-reset mechanism — the one open design fork.** Lots are immutable in the
+  compiled plan (`lot_cost_basis_per_unit`, `lot_purchase_month` are fixed
+  arrays), but harvesting must lower a slice's basis to current market. Two
+  options: **(A)** pre-allocate spare "rebuy" lot slots per harvesting holding and
+  activate them at harvest time (basis = current price, purchase_month = now);
+  **(B)** keep a separate per-(holding, rollout) scalar `harvested_basis_delta`
+  outside the lot array and fold it into MV/basis and final-sale gain math.
+  Recommend **(B)**: no plan-size blowup, no dynamic lot allocation in the
+  vectorized loop, and it matches the plan's "scalar basis update per position —
+  no per-stock state" intent. (A) is closer to literal sell+rebuy but bloats the
+  lot dimension `L` for every harvesting account.
+- **Event logging:** add a `harvest` disposition kind alongside the scheduled /
+  liquidity / pe dispositions for audit + frontend.
+
 ## Open inputs
 
-- Prior-year 1099-Bs (TY2022–24) for the decay term.
+- An external prior for the **decay-curve shape** (direct-indexing TLH
+  whitepapers / academic studies). No prior-year 1099-Bs exist — the account
+  opened in 2025 — so the decay term starts `[HEURISTIC]`, not fitted.
+- Future years' 1099-Bs (TY2026+) to fit decay empirically as they arrive; each
+  adds one maturity point, and decay stays `[HEURISTIC]` until ≥2 exist.
 - Confirmation the sleeve tracks the S&P 500 and dividend-reinvestment handling.
+
+## References
+
+- **[CBL-2020]** Chaudhuri, S. E., Burnham, T. C., & Lo, A. W. (2020). "An
+  Empirical Evaluation of Tax-Loss-Harvesting Alpha." _Financial Analysts
+  Journal_, 76(3), 99–108. <https://doi.org/10.1080/0015198X.2020.1760064>
+  (open copy: <https://dspace.mit.edu/handle/1721.1/135992>). Establishes the
+  magnitude and existence of TLH alpha: ~108 bps/yr before transaction costs over
+  1926–2018 on the 500 largest-cap names, falling to **82 bps/yr under the
+  wash-sale rule** and ~95 bps after costs. Our account had **zero wash sales**,
+  so it sits near the unconstrained end; the figure also bounds the plausible
+  steady-state benefit (well below the ~5%/yr first-year harvest _rate_, which is
+  a gross-loss figure, not after-tax alpha).
+- **[VANGUARD-2024]** Vanguard (July 2024). "Tax-loss harvesting: Why a
+  personalized approach is important."
+  <https://corporate.vanguard.com/content/dam/corp/research/pdf/tax_loss_harvesting_why_a_personalized_approach_is_important.pdf>
+  Documents the **front-loaded** profile this model anchors to: a cash-funded
+  account starts with cost basis = market value (maximal early harvest), and as
+  holdings appreciate, dispersion increasingly surfaces as _unrealized gains_
+  rather than harvestable losses ("ossification"), so harvest yield decays over
+  the account's life. This is the source for the `(1 − e)^γ` decay shape.

--- a/augur/product/conftest.py
+++ b/augur/product/conftest.py
@@ -36,6 +36,7 @@ def make_product_service(augur_config: Config, catalog: CatalogResponse) -> Make
             portfolio=resolved.portfolio,
             initial_cash_usd=float(resolved.snapshot.cash_usd),
             primary_agent_id=resolve_primary_agent_id(cfg),
+            harvest_policies=resolved.harvest_policies,
             known_location_ids=cat.location_ids,
             locations=sim_locations_from_config(cfg.locations),
             properties_by_id=cat.properties_by_id,

--- a/augur/product/scenarios.py
+++ b/augur/product/scenarios.py
@@ -41,6 +41,7 @@ from augur.sim.scenario import (
     CapitalImprovementEvent,
     FilingStatus,
     FixedAmount,
+    HarvestPolicy,
     InitialAccountBalance,
     InitialLot,
     LiquidityPolicy,
@@ -195,6 +196,7 @@ def build_scenario(
     initial_cash_usd: float,
     initial_lots: tuple[InitialLot, ...],
     properties_by_id: dict[str, Property],
+    harvest_policies: tuple[HarvestPolicy, ...] = (),
 ) -> Scenario:
     horizon_months = int(scenario_key.horizon_months)
     end_month = horizon_months - 1
@@ -439,6 +441,7 @@ def build_scenario(
         liquidity_policies=_liquidity_policies_from_funding_policy(
             scenario_key.funding_policy, primary_agent_id=primary_agent_id, initial_lots=initial_lots
         ),
+        harvest_policies=list(harvest_policies),
         horizon_months=horizon_months,
     )
 

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -53,6 +53,7 @@ from augur.product.wire import (
 from augur.sim.codec.plan import DenseSimulationResult
 from augur.sim.external_series import materialize_sampled_exogenous
 from augur.sim.locations import Location
+from augur.sim.scenario import HarvestPolicy
 from augur.sim.simulate import simulate_dense_with_external_series
 from augur.sim.slice import slice_dense_result
 
@@ -89,6 +90,7 @@ class ProductService:
         portfolio: PortfolioConfig,
         initial_cash_usd: float,
         primary_agent_id: str,
+        harvest_policies: tuple[HarvestPolicy, ...] = (),
         known_location_ids: frozenset[str],
         locations: dict[str, Location],
         properties_by_id: dict[str, Property],
@@ -114,6 +116,7 @@ class ProductService:
         self._max_horizon_months = int(max_horizon_months)
         self._max_cache_rollouts = int(max_cache_rollouts)
         self._initial_lots = initial_lots_from_portfolio(portfolio, primary_agent_id=primary_agent_id)
+        self._harvest_policies = harvest_policies
         self._asset_label_by_id = asset_label_by_series_id(portfolio)
         self._cache: OrderedDict[tuple[ScenarioKey, int], _CachedRollout] = OrderedDict()
         # FastAPI + uvicorn dispatches request handlers concurrently. The cache's get→miss→
@@ -240,6 +243,7 @@ class ProductService:
             initial_cash_usd=self._initial_cash_usd,
             initial_lots=self._initial_lots,
             properties_by_id=self._properties_by_id,
+            harvest_policies=self._harvest_policies,
         )
         sampling_request = ExogenousSamplingRequest(
             horizon_months=int(scenario_key.horizon_months),

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -127,6 +127,7 @@ py_library(
     name = "scenario",
     srcs = ["scenario.py"],
     deps = [
+        ":tlh_harvest",
         "//augur/model:series_model",
         "//augur/product:asset_key",
         "@pypi//pydantic",
@@ -219,6 +220,7 @@ py_library(
         "compiler/properties.py",
         "compiler/series.py",
         "compiler/tax.py",
+        "compiler/tlh_harvest.py",
         "compiler/transfers.py",
     ],
     deps = [
@@ -228,6 +230,7 @@ py_library(
         ":locations",
         ":runtime",
         ":scenario",
+        ":tlh_harvest",
         "//augur/model:private_equity_bundle",
         "//augur/model:series",
         "//augur/product:asset_key",
@@ -291,6 +294,7 @@ py_library(
         ":scenario",
         ":tax",
         ":tensor_fifo",
+        ":tlh_harvest",
         "//augur/model:series",
         "@pypi//numpy",
     ],
@@ -346,6 +350,23 @@ py_test(
     size = "medium",
     srcs = ["simulate_test.py"],
     deps = SIMULATE_TEST_DEPS,
+)
+
+py_test(
+    name = "tlh_harvest_engine_test",
+    size = "medium",
+    srcs = ["tlh_harvest_engine_test.py"],
+    deps = [
+        ":external_series",
+        ":scenario",
+        ":simulate",
+        ":tlh_harvest",
+        "//augur/model:series",
+        "//augur/product:asset_key",
+        "@pypi//polars",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 py_test(

--- a/augur/sim/BUILD.bazel
+++ b/augur/sim/BUILD.bazel
@@ -91,6 +91,26 @@ py_library(
     ],
 )
 
+py_library(
+    name = "tlh_harvest",
+    srcs = ["tlh_harvest.py"],
+    deps = [
+        "@pypi//numpy",
+        "@pypi//pydantic",
+    ],
+)
+
+py_test(
+    name = "tlh_harvest_test",
+    srcs = ["tlh_harvest_test.py"],
+    deps = [
+        ":tlh_harvest",
+        "@pypi//numpy",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 py_test(
     name = "tax_test",
     srcs = ["tax_test.py"],

--- a/augur/sim/buffers.py
+++ b/augur/sim/buffers.py
@@ -156,6 +156,13 @@ class CurrentStateBuffers:
     # against ordinary income ($3k cap), carries here into future years. Unlike the YTD gain
     # buffers it is NOT zeroed at year-end — it persists across tax years by design.
     capital_loss_carryforward: NDArray[np.float64]
+    # Cumulative reduced-form TLH harvested loss per (harvest policy, rollout), >= 0 (Piece 2b).
+    # Each month `_apply_tlh_harvest` adds the loss it booked into `capital_gain_ytd` here; the
+    # total lowers the policy holding's adjusted basis (so `e` rises and yield ossifies) and is the
+    # exact amount GIVEN BACK as extra realized gain when the policy's lots are sold. Like the
+    # carryforward it persists across years (it is NOT zeroed at year-end) — it is reset only on
+    # rollout failure, mirroring `capital_loss_carryforward`. Clamped so adjusted_basis stays >= 0.
+    tlh_cumulative_harvest: NDArray[np.float64]
     tax_liability_active: NDArray[np.bool_]
     tax_liability_amount: NDArray[np.float64]
     property_active: NDArray[np.bool_]
@@ -232,6 +239,12 @@ class CurrentStateBuffers:
             "current capital_loss_carryforward",
             self.capital_loss_carryforward,
             shape=(plan.capital_gain_agent_count, r),
+            dtype=np.float64,
+        )
+        _expect_array(
+            "current tlh_cumulative_harvest",
+            self.tlh_cumulative_harvest,
+            shape=(plan.harvest_policy_count, r),
             dtype=np.float64,
         )
         _expect_array(

--- a/augur/sim/compiler/plan.py
+++ b/augur/sim/compiler/plan.py
@@ -46,6 +46,7 @@ from augur.sim.compiler.tax import (
     compile_tax,
     compile_tax_liability_slots,
 )
+from augur.sim.compiler.tlh_harvest import HarvestPolicyCompileOutput, compile_harvest_policies
 from augur.sim.compiler.transfers import TransferCompileOutput, compile_transfer_slots
 from augur.sim.external_series import ExternalSeriesContext
 from augur.sim.jurisdictions import Jurisdiction
@@ -80,6 +81,9 @@ class SlotPlan:
     liquidity_policy_count: int
     max_liquidity_policy_assets: int
     pe_issuer_count: int
+    # Count of reduced-form TLH harvest policies (`max(1, len(scenario.harvest_policies))`); the
+    # sentinel row when there are none carries an empty lot mask the engine skips.
+    harvest_policy_count: int
     max_tax_settlement_slots: int
 
 
@@ -154,6 +158,10 @@ class CompiledSimulation:
     pe_issuers: PEIssuerCompileOutput
     pe_policies: PEPolicyCompileOutput
     pe_channels: PEChannels
+    # Reduced-form TLH harvest policies (Piece 2b). Per-policy yield curve + lot mask + the
+    # owner's capital-gain agent index + the index series index driving the period return.
+    # Consumed by the engine's `_apply_tlh_harvest` phase and the sale-time basis give-back.
+    harvest_policies: HarvestPolicyCompileOutput
     liquidity_policies: LiquidityPolicyCompileOutput
 
 
@@ -316,6 +324,20 @@ def compile_simulation(
         pe_issuers, private_equity=external_series.private_equity, rollout_count=rollout_count, horizon_months=horizon
     )
 
+    # Reduced-form TLH harvest policies. Pass the intern lookups (`strings.require` / `assets.require`)
+    # so the policy's (owner, account, asset) lot mask is matched against the exact codes the lot
+    # table was built from above.
+    harvest_policies = compile_harvest_policies(
+        scenario,
+        series_index_by_id=series_index_by_id,
+        lot_agent_codes=lot_agent_codes_arr,
+        lot_account_codes=np.asarray(lot_account_codes, dtype=np.int64),
+        lot_asset_codes=lot_asset_codes_arr,
+        capital_gain_agent_codes=capital_gain_agent_codes,
+        string_code_of=strings.require,
+        asset_code_of=assets.require,
+    )
+
     slot_plan = SlotPlan(
         event_months=horizon,
         snapshot_months=horizon + 1,
@@ -335,6 +357,7 @@ def compile_simulation(
         liquidity_policy_count=liquidity_policies.assets.shape[0],
         max_liquidity_policy_assets=liquidity_policies.assets.shape[1],
         pe_issuer_count=pe_issuers.codes.shape[0],
+        harvest_policy_count=harvest_policies.gain_profile_index.shape[0],
         max_tax_settlement_slots=max(1, len(scenario.tax_profiles)),
     )
 
@@ -381,6 +404,7 @@ def compile_simulation(
         pe_issuers=pe_issuers,
         pe_policies=pe_policies,
         pe_channels=pe_channels,
+        harvest_policies=harvest_policies,
         liquidity_policies=liquidity_policies,
     )
 

--- a/augur/sim/compiler/tlh_harvest.py
+++ b/augur/sim/compiler/tlh_harvest.py
@@ -1,0 +1,108 @@
+"""Compile-side table for the reduced-form tax-loss-harvesting (TLH) process — Piece 2b.
+
+LIMITED / DELIBERATELY-APPROXIMATE MODEL. This table drives `_apply_tlh_harvest` in the
+engine. It does NOT model the direct-indexing sleeve's individual constituent stocks: the
+harvested loss is a *calibrated* function of the index path (`augur/sim/tlh_harvest.py`), and
+the basis give-back is a single scalar per (policy, rollout). See `HarvestPolicy` and the
+engine phase for the full "this is fake on purpose" rationale, and
+`augur/plans/tax_loss_harvesting.md` for the upgrade path (options #3/#4).
+
+Mirrors the per-policy + lot-mask shape of `private_equity.py`. One row per `HarvestPolicy`:
+its yield-curve params, the index level-series index driving the period return, the owner's
+capital-gain agent index (where harvested losses + the give-back land), the short-term share,
+and a `(policy, lot)` mask flagging the lots the policy harvests + gives back against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from augur.product.asset_key import asset_price_key
+from augur.sim.compiler.helpers import NO_CODE
+from augur.sim.scenario import Scenario
+from augur.sim.tlh_harvest import HarvestYieldParams
+
+
+@dataclass(frozen=True)
+class HarvestPolicyCompileOutput:
+    """Per-`HarvestPolicy` arrays (one row per policy). `lot_mask[p, l]` flags which lots the
+    policy harvests against (and gives basis back on at sale). `gain_profile_index[p]` is the
+    owner's capital-gain agent index (NO_CODE if the owner has no capital-gain profile, in which
+    case the engine skips the policy). `series_index[p]` indexes `external_values` for the index
+    price path. `params` keeps the typed yield curve per policy (small list; no array needed)."""
+
+    gain_profile_index: NDArray[np.int64]
+    series_index: NDArray[np.int64]
+    short_term_fraction: NDArray[np.float64]
+    lot_mask: NDArray[np.bool_]
+    params: tuple[HarvestYieldParams, ...]
+
+
+def compile_harvest_policies(
+    scenario: Scenario,
+    *,
+    series_index_by_id: dict,
+    lot_agent_codes: np.ndarray,
+    lot_account_codes: np.ndarray,
+    lot_asset_codes: np.ndarray,
+    capital_gain_agent_codes: np.ndarray,
+    string_code_of,
+    asset_code_of,
+) -> HarvestPolicyCompileOutput:
+    """Compile per-policy harvest arrays.
+
+    `string_code_of(value)` / `asset_code_of(asset)` are the (already-populated) intern lookups
+    so this matches `lot_agent_codes` / `lot_account_codes` / `lot_asset_codes` exactly the way
+    the lot table was built. A policy's lot mask is the lots matching its (owner, account, asset).
+    """
+
+    policies = scenario.harvest_policies
+    policy_count = max(1, len(policies))
+    lot_count = lot_agent_codes.shape[0]
+
+    gain_profile_index = np.full(policy_count, NO_CODE, dtype=np.int64)
+    series_index = np.full(policy_count, NO_CODE, dtype=np.int64)
+    short_term_fraction = np.ones(policy_count, dtype=np.float64)
+    lot_mask = np.zeros((policy_count, max(1, lot_count)), dtype=np.bool_)
+    params: list[HarvestYieldParams] = []
+
+    # Pad `params` to `policy_count` (the min-1 sentinel row carries a throwaway curve the engine
+    # never reads, since its lot_mask is empty / gain_profile_index is NO_CODE).
+    sentinel_params = HarvestYieldParams(
+        peak_annual_yield=0.01, floor_annual_yield=0.0, maturity_decay_exponent=1.0, drawdown_sensitivity=0.0
+    )
+    if not policies:
+        return HarvestPolicyCompileOutput(
+            gain_profile_index=gain_profile_index,
+            series_index=series_index,
+            short_term_fraction=short_term_fraction,
+            lot_mask=lot_mask,
+            params=(sentinel_params,),
+        )
+
+    gain_index_by_agent_code = {int(code): idx for idx, code in enumerate(capital_gain_agent_codes)}
+    for policy_idx, policy in enumerate(policies):
+        owner_code = string_code_of(policy.owner_agent_id)
+        account_code = string_code_of(policy.account_id)
+        asset_code = asset_code_of(policy.asset)
+        gain_profile_index[policy_idx] = gain_index_by_agent_code.get(int(owner_code), NO_CODE)
+        # The harvested loss is shaped by the *index* path; PE assets have no asset-price series
+        # and are never a valid harvest target, so `asset_price_key` raising here is correct.
+        series_index[policy_idx] = series_index_by_id[asset_price_key(policy.asset)]
+        short_term_fraction[policy_idx] = float(policy.short_term_fraction)
+        params.append(policy.yield_params)
+        if lot_count > 0:
+            lot_mask[policy_idx, :lot_count] = (
+                (lot_agent_codes == owner_code) & (lot_account_codes == account_code) & (lot_asset_codes == asset_code)
+            )
+
+    return HarvestPolicyCompileOutput(
+        gain_profile_index=gain_profile_index,
+        series_index=series_index,
+        short_term_fraction=short_term_fraction,
+        lot_mask=lot_mask,
+        params=tuple(params),
+    )

--- a/augur/sim/engine/__init__.py
+++ b/augur/sim/engine/__init__.py
@@ -35,6 +35,7 @@ from augur.sim.engine.phases import (
     _apply_scheduled_asset_sales,
     _apply_scheduled_transfers,
     _apply_tax_accruals,
+    _apply_tlh_harvest,
 )
 from augur.sim.enums import PrivateEquityDispositionKind
 from augur.sim.external_series import ExternalSeriesContext
@@ -73,6 +74,7 @@ def _allocate_current_state(plan: CompiledSimulation) -> CurrentStateBuffers:
         capital_gain_active=np.zeros((p.capital_gain_agent_count, 2, r), dtype=np.bool_),
         capital_gain_ytd=np.zeros((p.capital_gain_agent_count, 2, r), dtype=np.float64),
         capital_loss_carryforward=np.zeros((p.capital_gain_agent_count, r), dtype=np.float64),
+        tlh_cumulative_harvest=np.zeros((p.harvest_policy_count, r), dtype=np.float64),
         tax_liability_active=np.zeros((p.tax_liability_count, r), dtype=np.bool_),
         tax_liability_amount=np.zeros((p.tax_liability_count, r), dtype=np.float64),
         property_active=np.zeros((p.property_count, r), dtype=np.bool_),
@@ -137,6 +139,9 @@ def _zero_failed_state(current: CurrentStateBuffers) -> None:
     current.ordinary_ytd[:, failed] = 0.0
     current.capital_gain_ytd[:, :, failed] = 0.0
     current.capital_loss_carryforward[:, failed] = 0.0
+    # Reset cumulative harvest on failed rollouts, mirroring capital_loss_carryforward (a failed
+    # rollout's state is meaningless and must not leak deferred basis into snapshots).
+    current.tlh_cumulative_harvest[:, failed] = 0.0
     current.tax_liability_amount[:, failed] = 0.0
     current.property_basis[:, failed] = 0.0
     current.property_ownership[:, failed] = 0.0
@@ -159,6 +164,11 @@ def _run_month_step(
     _apply_obligation_accruals(plan, buffers, current, month)
     _apply_liquidity_policy_sales(plan, buffers, current, month)
     _apply_obligation_settlement(plan, buffers, current, month)
+    # Reduced-form TLH harvest: book each harvest policy's calibrated capital loss into
+    # capital_gain_ytd and grow its cumulative-harvest scalar. Runs BEFORE PE tenders (and the
+    # year-end tax pass) so the harvested loss is available for §1211/§1212 netting this year,
+    # and before any PE tender so a same-month tender's gain nets against the fresh harvest loss.
+    _apply_tlh_harvest(plan, buffers, current, month)
     # PE tender sales fire after obligation settlement so the policy compares against the
     # post-settlement liquid net worth (cash already moved out for this month's bills) and the
     # cap-gain accrual from any tender is captured by the year-end tax pass below.

--- a/augur/sim/engine/phases.py
+++ b/augur/sim/engine/phases.py
@@ -22,6 +22,7 @@ from augur.sim.enums import (
 )
 from augur.sim.tax import net_capital_gains_with_carryforward
 from augur.sim.tensor_fifo import FifoSaleResult, fifo_sell_dollars, fifo_sell_units, lot_order_for_pool
+from augur.sim.tlh_harvest import monthly_harvest_fraction, split_short_long
 
 
 def _apply_scheduled_transfers(
@@ -203,6 +204,110 @@ def _write_tax_link_buffers(
         current.tax_liability_active[tax_slot, active_rollout] = True
         current.tax_liability_amount[tax_slot, active_rollout] = tax[active_rollout]
     return tax
+
+
+def _apply_tlh_harvest(
+    plan: CompiledSimulation, buffers: SimulationBuffers, current: CurrentStateBuffers, month: int
+) -> None:
+    """Reduced-form tax-loss-harvesting (Piece 2b). LIMITED, DELIBERATELY-APPROXIMATE MODEL.
+
+    This is NOT a real direct-indexing harvester. It does not simulate the sleeve's constituent
+    stocks, does not track which names are below basis, and does not run FIFO on sub-lots. For
+    each `HarvestPolicy` it instead books a CALIBRATED capital loss each month — a function of the
+    index path Augur already samples (`augur/sim/tlh_harvest.py`), shaped by the position's
+    embedded-gain fraction and amplified in drawdowns. Every parameter is `[HEURISTIC]`, anchored
+    only to the account's first-year (TY2025) 1099-B; the decay rate is an external prior, not
+    fitted (no prior-year forms exist). See `augur/plans/tax_loss_harvesting.md`.
+
+    The harvested loss is honest tax DEFERRAL, not free money: the loss is offset by a basis
+    give-back at sale (`_record_capital_gains` reduces the sold lots' basis by the accumulated
+    `tlh_cumulative_harvest`). The net lifetime benefit is bounded — it can only come from
+    rate-arbitrage (ST loss now vs LT gain later), the $3k/yr ordinary offset, and deferral timing.
+
+    Per policy, per active rollout this month:
+      MV               = sum over the policy's lots of remaining_units * index_price[month]
+      original_basis   = sum over the policy's lots of remaining_units * cost_basis_per_unit
+      adjusted_basis   = max(0, original_basis - tlh_cumulative_harvest)   # give-back already taken
+      e                = clip((MV - adjusted_basis) / MV, 0, 1)            # embedded-gain fraction
+      period_return    = index_price[month] / index_price[month-1] - 1     # 0 at month 0
+      gross_harvest    = MV * monthly_harvest_fraction(period_return, e, params)
+      gross_harvest    = min(gross_harvest, original_basis - tlh_cumulative_harvest)  # loss ceiling
+    Then split ST/LT by the policy's short_term_fraction and inject the loss as a NEGATIVE into
+    capital_gain_ytd[gain_profile, ST|LT, :] (Piece-1 netting handles it unchanged), and add the
+    gross to tlh_cumulative_harvest. The ceiling keeps adjusted_basis >= 0 and e in [0, 1]; the
+    e -> floor decay already prevents over-harvesting in long bull runs (a vol-tied ceiling is a
+    documented future refinement — see the plan — and is intentionally NOT built here).
+
+    What a more honest / less fake implementation would look like (do not build now): the plan's
+    option #3 — 5-10 representative sleeves, each = index factor + scaled idiosyncratic noise, with
+    REAL FIFO harvesting on sub-lots so losses emerge from actual below-basis names; and option #4
+    — a full factor model with hundreds of names (explicitly never to be built: unobservable,
+    uncalibratable parameters).
+    """
+
+    policy_count = plan.harvest_policies.gain_profile_index.shape[0]
+    if policy_count == 0:
+        return
+    active_rollout = ~current.failed
+    if not active_rollout.any():
+        return
+
+    harvest = plan.harvest_policies
+    for policy_idx in range(policy_count):
+        gain_profile = int(harvest.gain_profile_index[policy_idx])
+        if gain_profile < 0:
+            continue  # owner has no capital-gain profile; nothing to net a harvested loss against
+        lot_indices = np.flatnonzero(harvest.lot_mask[policy_idx])
+        if lot_indices.size == 0:
+            continue
+        series_index = int(harvest.series_index[policy_idx])
+        price = plan.external_values[series_index, :, month]  # (R,)
+        if not np.isfinite(price).all() or (price < 0.0).any():
+            raise ValueError(f"harvest policy {policy_idx} index series produced a negative or non-finite price")
+
+        remaining = current.lot_remaining[lot_indices, :]  # (lot, R)
+        market_value = (remaining * price[None, :]).sum(axis=0)  # (R,)
+        original_basis = (remaining * plan.lot_cost_basis_per_unit[lot_indices, None]).sum(axis=0)  # (R,)
+        cumulative = current.tlh_cumulative_harvest[policy_idx, :]  # (R,)
+        adjusted_basis = np.maximum(0.0, original_basis - cumulative)
+        embedded_gain_fraction = np.divide(
+            market_value - adjusted_basis, market_value, out=np.zeros_like(market_value), where=market_value > 0.0
+        )
+
+        # Period return drives the drawdown kicker. Month 0 has no prior price, so treat it as flat
+        # (return 0): the position still harvests at its base monthly rate.
+        if month == 0:
+            period_return = np.zeros(plan.rollout_count, dtype=np.float64)
+        else:
+            prior_price = plan.external_values[series_index, :, month - 1]
+            period_return = np.divide(
+                price - prior_price, prior_price, out=np.zeros_like(price), where=prior_price > 0.0
+            )
+
+        fraction = monthly_harvest_fraction(period_return, embedded_gain_fraction, harvest.params[policy_idx])
+        gross_harvest = market_value * fraction
+        # Loss ceiling: never harvest more than the remaining below-basis room, so cumulative
+        # harvest stays <= original_basis (adjusted_basis >= 0). Only harvest on active rollouts.
+        ceiling = np.maximum(0.0, original_basis - cumulative)
+        gross_harvest = np.where(active_rollout, np.minimum(np.maximum(gross_harvest, 0.0), ceiling), 0.0)
+        if not (gross_harvest > 0.0).any():
+            continue
+
+        split = split_short_long(gross_harvest, harvest.short_term_fraction[policy_idx])
+        # Inject the harvested loss as a NEGATIVE realized gain — never a synthetic gain or a tax
+        # credit. Piece-1's `net_capital_gains_with_carryforward` nets it like any other loss.
+        if (split.short_term_usd > 0.0).any():
+            current.capital_gain_ytd[gain_profile, CapitalGainClassification.SHORT_TERM, :] -= split.short_term_usd
+            current.capital_gain_active[
+                gain_profile, CapitalGainClassification.SHORT_TERM, split.short_term_usd > 0.0
+            ] = True
+        if (split.long_term_usd > 0.0).any():
+            current.capital_gain_ytd[gain_profile, CapitalGainClassification.LONG_TERM, :] -= split.long_term_usd
+            current.capital_gain_active[
+                gain_profile, CapitalGainClassification.LONG_TERM, split.long_term_usd > 0.0
+            ] = True
+        # Accumulate the give-back scalar: this is exactly the deferred gain repaid at sale.
+        current.tlh_cumulative_harvest[policy_idx, :] += gross_harvest
 
 
 def _apply_pe_tenders(
@@ -1552,6 +1657,11 @@ def _record_capital_gains(
 ) -> None:
     if sold_units.size == 0:
         return
+    # TLH basis give-back (Piece 2b): before recording gains, fold the deferred harvested loss back
+    # into the realized gain of any sold harvest-policy lots, so the deferral is honestly repaid.
+    # Mutates a per-lot copy of `gains` (caller's array is untouched) and drains the cumulative
+    # harvest scalar. Applies across EVERY sale path because they all route through here.
+    gains = _apply_tlh_give_back(plan, current, sold_units=sold_units, gains=gains)
     for profile in range(plan.capital_gain_agent_codes.shape[0]):
         if int(plan.capital_gain_agent_codes[profile]) != agent_code:
             continue
@@ -1564,3 +1674,57 @@ def _record_capital_gains(
             active = sold_units[:, lot] > 0.0
             current.capital_gain_active[profile, cls, active] = True
             current.capital_gain_ytd[profile, cls, :] += gains[:, lot]
+
+
+def _apply_tlh_give_back(
+    plan: CompiledSimulation, current: CurrentStateBuffers, *, sold_units: np.ndarray, gains: np.ndarray
+) -> np.ndarray:
+    """Repay deferred harvested loss as extra realized gain on sold harvest-policy lots.
+
+    CORRECTNESS-CRITICAL (the part the design says to get right and test hardest). `sold_units`
+    and `gains` are `(R, L)`. For each `HarvestPolicy`, the fraction of the policy's pre-sale units
+    being sold in THIS sale determines the share of `tlh_cumulative_harvest` that is realized now:
+    that share is added to the gain of the sold policy-lots (split across them by sold units, so
+    each lot keeps its own ST/LT character) and subtracted from the cumulative scalar. A full
+    liquidation (across one or many sales) therefore gives back exactly the whole accumulated
+    harvest — never more (the scalar is drained, so it cannot double-pay) and never less. Lots left
+    unsold at the terminal carry their unrealized deferred gain forward, which is correct: nothing
+    is realized, so nothing is given back. Returns the give-back-adjusted `(R, L)` gains; the
+    caller's array is not mutated. The harvest phase guarantees `cumulative <= original_basis`, so
+    the give-back can never exceed the gain that the reduced basis implies.
+    """
+
+    harvest = plan.harvest_policies
+    policy_count = harvest.gain_profile_index.shape[0]
+    adjusted_gains = gains
+    copied = False
+    for policy_idx in range(policy_count):
+        if int(harvest.gain_profile_index[policy_idx]) < 0:
+            continue
+        lot_indices = np.flatnonzero(harvest.lot_mask[policy_idx])
+        if lot_indices.size == 0:
+            continue
+        sold_policy = sold_units[:, lot_indices]  # (R, policy_lots)
+        units_sold = sold_policy.sum(axis=1)  # (R,)
+        if not (units_sold > 0.0).any():
+            continue
+        # Pre-sale held units of the policy = units still remaining + units just sold. `sold_units`
+        # was already subtracted from `current.lot_remaining` by the caller before this runs.
+        remaining_policy = current.lot_remaining[lot_indices, :].T  # (R, policy_lots)
+        pre_sale_units = remaining_policy.sum(axis=1) + units_sold  # (R,)
+        cumulative = current.tlh_cumulative_harvest[policy_idx, :]  # (R,)
+        fraction_sold = np.divide(units_sold, pre_sale_units, out=np.zeros_like(units_sold), where=pre_sale_units > 0.0)
+        give_back = fraction_sold * cumulative  # (R,)
+        if not (give_back > 0.0).any():
+            continue
+        if not copied:
+            adjusted_gains = gains.copy()
+            copied = True
+        # Distribute the give-back across the sold policy-lots in proportion to each lot's sold
+        # units, so the realized extra gain follows the lots actually disposed (preserving ST/LT).
+        per_lot_weight = np.divide(
+            sold_policy, units_sold[:, None], out=np.zeros_like(sold_policy), where=units_sold[:, None] > 0.0
+        )  # (R, policy_lots), rows sum to 1 where any policy lot sold
+        adjusted_gains[:, lot_indices] += per_lot_weight * give_back[:, None]
+        current.tlh_cumulative_harvest[policy_idx, :] = cumulative - give_back
+    return adjusted_gains

--- a/augur/sim/scenario.py
+++ b/augur/sim/scenario.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt, model_valida
 from augur.model.series import IndexSeriesKey
 from augur.model.series_model import SeriesModelBundle
 from augur.product.asset_key import AssetKey
+from augur.sim.tlh_harvest import HarvestYieldParams
 
 
 class FilingStatus(StrEnum):
@@ -581,6 +582,45 @@ class PrivateEquityTenderPolicy(BaseModel):
     liquid_net_worth_floor: AmountSchedule
 
 
+class HarvestPolicy(BaseModel):
+    """Attach a reduced-form tax-loss-harvesting (TLH) process to one index-tracking holding.
+
+    LIMITED / DELIBERATELY-APPROXIMATE ("UNTRUTHFUL") MODEL — read before relying on output.
+    This does NOT simulate the real direct-indexing sleeve's constituent stocks. The holding
+    stays a single index-tracking position; the "harvested loss" each month is a *calibrated
+    function* of the index path (see `augur/sim/tlh_harvest.py`), not a real below-basis amount
+    realized by selling specific underwater names. All `HarvestYieldParams` are `[HEURISTIC]`,
+    anchored only to the account's first-year (TY2025) 1099-B. See the engine phase
+    `_apply_tlh_harvest` and `augur/plans/tax_loss_harvesting.md` for the full rationale and for
+    the "what a more honest implementation would look like" note (the plan's options #3/#4).
+
+    The policy is keyed to the lots of one (agent, account, asset) pool — typically the Plaid
+    SP500 proxy sleeve. Each month the engine harvests a calibrated capital LOSS into that
+    owner's `capital_gain_ytd` (Piece-1 netting then nets it like any other realized loss) and
+    accumulates the harvested total into a single scalar `tlh_cumulative_harvest` per
+    (policy, rollout). That scalar lowers the holding's adjusted basis, which (a) raises the
+    embedded-gain fraction so the yield decays toward its floor ("ossification"), and (b) is
+    GIVEN BACK at sale time: any realized gain on this pool's lots uses the *reduced* basis, so
+    the deferred gain is honestly repaid. The net benefit is therefore bounded deferral +
+    rate-arbitrage + the $3k/yr ordinary offset — never free money.
+    """
+
+    owner_agent_id: str
+    account_id: str = "checking"
+    asset: AssetKey = Field(description="Index-tracking asset whose lots this policy harvests (e.g. an SP500AssetKey).")
+    yield_params: HarvestYieldParams
+    short_term_fraction: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Share of each month's harvested loss booked as short-term (the rest is long-term). "
+            "Seeded from the holding-period buckets — near 1.0 for a young account, matching the "
+            "TY2025 1099-B's essentially-all-short-term harvest. [HEURISTIC]."
+        ),
+    )
+
+
 class MortgageInterestDeductionPolicy(BaseModel):
     """Mortgage-interest deduction (IRC §163(h)(3)) for one liability.
 
@@ -641,6 +681,9 @@ class Scenario(BaseModel):
     mortgage_interest_deduction_policies: list[MortgageInterestDeductionPolicy] = Field(default_factory=list)
     federal_salt_deduction_policies: list[FederalSaltDeductionPolicy] = Field(default_factory=list)
     private_equity_tender_policies: list[PrivateEquityTenderPolicy] = Field(default_factory=list)
+    # Reduced-form TLH harvest processes attached to index-tracking holdings (Piece 2). Empty by
+    # default, so scenarios without harvesting reproduce prior behavior exactly. See HarvestPolicy.
+    harvest_policies: list[HarvestPolicy] = Field(default_factory=list)
     external_series: SeriesModelBundle = Field(default_factory=SeriesModelBundle)
     # Required so callers explicitly choose either taxed agents or an intentional no-tax scenario.
     tax_profiles: list[TaxProfile]

--- a/augur/sim/tlh_harvest.py
+++ b/augur/sim/tlh_harvest.py
@@ -1,0 +1,120 @@
+"""Reduced-form tax-loss-harvesting (TLH) yield model — Piece 2 core.
+
+This is the calibratable math behind a direct-indexing harvest process: given the
+period's index return and a position's embedded-gain fraction, it produces the
+*gross realized loss* harvested this period as a fraction of market value. It does
+**not** touch the sim engine — `augur/sim/engine` wires it in (see the
+"Implementation proposal" in `augur/plans/tax_loss_harvesting.md`), reading
+MV/basis and the index path per rollout, clamping the output to the loss actually
+available below basis, and feeding it into the Piece-1 capital-loss netting.
+
+Why reduced-form (not constituent simulation): a single S&P 500 series has no
+cross-sectional dispersion, so harvestable losses must be modeled as a calibrated
+function of the index path Augur already samples rather than emerging from
+hundreds of simulated names. See the plan doc for the full rationale.
+
+Shape and calibration anchor: harvesting is **front-loaded**. A cash-funded
+account starts with cost basis = market value (embedded-gain fraction `e ≈ 0`) and
+harvests near its peak; as winners appreciate and harvested losers are reset away,
+the position becomes dominated by low-basis winners (`e → 1`) and harvestable
+losses dry up ("ossification"). Yield therefore decays from a peak toward a floor
+as `(1 - e) ** maturity_decay_exponent`, and is amplified in drawdowns. This shape
+is taken from Vanguard's "Tax-loss harvesting: Why a personalized approach is
+important" (July 2024); the magnitude of TLH alpha and the wash-sale haircut are
+bounded by Chaudhuri, Burnham & Lo, "An Empirical Evaluation of Tax-Loss-Harvesting
+Alpha," Financial Analysts Journal 76(3) 2020. Full citations: plan References.
+
+All parameters are `[HEURISTIC]`: with only the account's first-year (TY2025)
+1099-B there is no in-account history to fit the decay rate, so the curve's shape
+comes from the external research above and the level is anchored to the first-year
+1099-B (~5%/yr gross, essentially all short-term). Re-fit as future years' forms
+arrive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_MONTHS_PER_YEAR = 12.0
+
+
+class HarvestYieldParams(BaseModel):
+    """Parameters of the reduced-form harvest-yield curve. Annual yields are gross
+    realized loss as a fraction of market value; the monthly model divides by 12."""
+
+    model_config = ConfigDict(frozen=True)
+
+    peak_annual_yield: float = Field(
+        gt=0,
+        description="Gross harvested-loss yield (fraction of MV per year) at embedded_gain_fraction=0 "
+        "and a neutral return — the first-year peak anchored to the TY2025 1099-B (~0.05).",
+    )
+    floor_annual_yield: float = Field(
+        ge=0, description="Asymptotic annual yield as the account ossifies (embedded_gain_fraction -> 1)."
+    )
+    maturity_decay_exponent: float = Field(
+        gt=0,
+        description="Exponent gamma in the (1 - embedded_gain_fraction)**gamma maturity decay between "
+        "floor and peak. Larger = faster decay as embedded gains build.",
+    )
+    drawdown_sensitivity: float = Field(
+        ge=0,
+        description="Extra harvest per unit of negative period return: the base monthly yield is scaled "
+        "by (1 + drawdown_sensitivity * max(0, -period_return)).",
+    )
+
+    @model_validator(mode="after")
+    def _check_floor_below_peak(self) -> HarvestYieldParams:
+        if self.floor_annual_yield > self.peak_annual_yield:
+            raise ValueError(
+                f"floor_annual_yield ({self.floor_annual_yield}) must not exceed "
+                f"peak_annual_yield ({self.peak_annual_yield})"
+            )
+        return self
+
+
+@dataclass(frozen=True)
+class HarvestSplit:
+    """Gross harvested loss split by holding period, per rollout (USD, non-negative)."""
+
+    short_term_usd: npt.NDArray[np.float64]
+    long_term_usd: npt.NDArray[np.float64]
+
+
+def monthly_harvest_fraction(
+    period_return: npt.NDArray[np.float64], embedded_gain_fraction: npt.NDArray[np.float64], params: HarvestYieldParams
+) -> npt.NDArray[np.float64]:
+    """Fraction of market value harvested as gross realized loss this month, per rollout.
+
+    `period_return` and `embedded_gain_fraction` are `(R,)` arrays; the result is `(R,)`.
+    The caller multiplies by market value and clamps to the loss actually available
+    below basis — this function only shapes the yield curve.
+    """
+
+    # e -> [0, 1]: 0 = fresh (basis == MV, peak harvest), 1 = fully ossified (floor).
+    e = np.clip(embedded_gain_fraction, 0.0, 1.0)
+    # Front-loaded decay: (1 - e)**gamma falls from 1 (fresh) to 0 (ossified) [VANGUARD-2024].
+    maturity = (1.0 - e) ** params.maturity_decay_exponent
+    base_monthly = (
+        params.floor_annual_yield + (params.peak_annual_yield - params.floor_annual_yield) * maturity
+    ) / _MONTHS_PER_YEAR
+    # Drawdowns surface more lots below basis; up months get no kicker (drawdown == 0).
+    drawdown = np.maximum(0.0, -period_return)
+    return base_monthly * (1.0 + params.drawdown_sensitivity * drawdown)
+
+
+def split_short_long(
+    gross_harvest_usd: npt.NDArray[np.float64], short_term_fraction: npt.NDArray[np.float64]
+) -> HarvestSplit:
+    """Split gross harvested loss into ST/LT by the harvestable short-term share.
+
+    `short_term_fraction` (per rollout, in `[0, 1]`) is seeded from the holding's
+    holding-period buckets — near 1.0 for a young account (mostly short-term losses).
+    """
+
+    stf = np.clip(short_term_fraction, 0.0, 1.0)
+    return HarvestSplit(short_term_usd=gross_harvest_usd * stf, long_term_usd=gross_harvest_usd * (1.0 - stf))

--- a/augur/sim/tlh_harvest_engine_test.py
+++ b/augur/sim/tlh_harvest_engine_test.py
@@ -1,0 +1,337 @@
+"""Engine-level tests for the reduced-form TLH harvest process (Piece 2b).
+
+These exercise `_apply_tlh_harvest` + the sale-time basis give-back end-to-end through the dense
+engine, complementing the pure-core invariants in `tlh_harvest_test.py`. The four required
+correctness properties (see `augur/plans/tax_loss_harvesting.md`):
+  - down months harvest strictly more loss than flat months; a long bull run ossifies to the floor,
+  - a harvested short-term loss offsets a concurrent realized gain → lower tax than no-harvest,
+  - the basis give-back at sale repays exactly the cumulative harvest (deferral, not free money),
+  - harvest-off reproduces today's behavior exactly (regression).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+import pytest_bazel
+
+from augur.model.series import CryptoSymbol
+from augur.product.asset_key import CryptoAssetKey, SP500AssetKey
+from augur.sim.external_series import EXTERNAL_SERIES_VALUES_FRAME, ExternalSeriesContext
+from augur.sim.scenario import (
+    Agent,
+    FilingStatus,
+    HarvestPolicy,
+    InitialAccountBalance,
+    InitialLot,
+    Scenario,
+    ScheduledAssetSale,
+    TaxProfile,
+)
+from augur.sim.simulate import simulate_with_external_series
+from augur.sim.tlh_harvest import HarvestYieldParams
+
+# A high peak yield + strong drawdown sensitivity makes the harvested losses large enough to read
+# cleanly off the YTD frame in a short horizon. These are test fixtures, not calibrated values.
+_PARAMS = HarvestYieldParams(
+    peak_annual_yield=0.12, floor_annual_yield=0.004, maturity_decay_exponent=1.5, drawdown_sensitivity=6.0
+)
+
+
+def _sp500_levels(levels_by_rollout: list[list[float]]) -> ExternalSeriesContext:
+    return ExternalSeriesContext(
+        series_values=EXTERNAL_SERIES_VALUES_FRAME.normalize(
+            pl.DataFrame(
+                [
+                    {"rollout_index": r, "month_index": m, "series_id": "sp500", "value": level}
+                    for r, levels in enumerate(levels_by_rollout)
+                    for m, level in enumerate(levels)
+                ]
+            )
+        )
+    )
+
+
+def _harvest_scenario(
+    *,
+    horizon_months: int,
+    quantity: float = 1000.0,
+    cost_basis_per_unit_usd: float = 1.0,
+    purchase_month_index: int = 0,
+    with_harvest: bool,
+    short_term_fraction: float = 1.0,
+    scheduled_asset_sales: list[ScheduledAssetSale] | None = None,
+    extra_lots: list[InitialLot] | None = None,
+) -> Scenario:
+    """Single taxable agent holding an SP500 sleeve, optionally with a harvest policy.
+
+    The sleeve is one lot priced by the `sp500` series; `unit_value`/quantity are chosen so MV is
+    easy to reason about (1000 units at $1 cost basis). `extra_lots` adds non-sleeve lots (e.g. a
+    gain lot to offset)."""
+
+    lots = [
+        InitialLot(
+            lot_id="alice_sp500",
+            agent_id="alice",
+            account_id="brokerage",
+            asset=SP500AssetKey(),
+            purchase_month_index=purchase_month_index,
+            quantity=quantity,
+            cost_basis_per_unit_usd=cost_basis_per_unit_usd,
+        )
+    ]
+    if extra_lots:
+        lots.extend(extra_lots)
+    harvest_policies = (
+        [
+            HarvestPolicy(
+                owner_agent_id="alice",
+                account_id="brokerage",
+                asset=SP500AssetKey(),
+                yield_params=_PARAMS,
+                short_term_fraction=short_term_fraction,
+            )
+        ]
+        if with_harvest
+        else []
+    )
+    return Scenario(
+        agents=[Agent(agent_id="alice"), Agent(agent_id="irs")],
+        initial_cash=[
+            InitialAccountBalance(agent_id="alice", account_id="brokerage", balance_usd=0.0),
+            InitialAccountBalance(agent_id="alice", account_id="checking", balance_usd=0.0),
+            InitialAccountBalance(agent_id="irs", account_id="checking", balance_usd=0.0),
+        ],
+        initial_lots=lots,
+        scheduled_asset_sales=scheduled_asset_sales or [],
+        harvest_policies=harvest_policies,
+        tax_profiles=[
+            TaxProfile(
+                agent_id="alice",
+                filing_status=FilingStatus.SINGLE,
+                jurisdiction_ids=["federal_us"],
+                tax_authority_agent_id="irs",
+            )
+        ],
+        horizon_months=horizon_months,
+    )
+
+
+def _ytd_gain(result, *, month_index: int, classification: str, rollout_index: int = 0) -> float:
+    rows = result.capital_gains_ytd.filter(
+        (pl.col("month_index") == month_index)
+        & (pl.col("rollout_index") == rollout_index)
+        & (pl.col("agent_id") == "alice")
+        & (pl.col("classification") == classification)
+    )
+    if rows.is_empty():
+        return 0.0
+    return float(rows.get_column("gain_usd").sum())
+
+
+def _harvested_short_term_in_month(result, *, calendar_month: int, rollout_index: int = 0) -> float:
+    """Magnitude of short-term loss harvested during `calendar_month` (a positive number).
+
+    State snapshot `month_index = m + 1` reflects the end of calendar month `m`, so the loss booked
+    during month `m` is the drop in cumulative YTD short-term gain from snapshot `m` to `m + 1`."""
+
+    before = _ytd_gain(result, month_index=calendar_month, classification="stcg", rollout_index=rollout_index)
+    after = _ytd_gain(result, month_index=calendar_month + 1, classification="stcg", rollout_index=rollout_index)
+    return before - after
+
+
+def test_down_month_harvests_strictly_more_than_flat_month() -> None:
+    # Two rollouts, same fresh sleeve. Rollout 0 has a 20% drawdown in calendar month 1; rollout 1
+    # is flat. The loss harvested DURING month 1 must be strictly larger for the drawdown rollout
+    # (the drawdown kicker), isolating the period-return effect (both enter month 1 with the same
+    # basis and a comparable embedded-gain fraction).
+    scenario = _harvest_scenario(horizon_months=3, with_harvest=True)
+    external_series = _sp500_levels([[1.0, 1.0, 0.8, 0.8], [1.0, 1.0, 1.0, 1.0]])
+    result = simulate_with_external_series(scenario, rollout_count=2, external_series=external_series, locations={})
+
+    drawdown_harvest = _harvested_short_term_in_month(result, calendar_month=2, rollout_index=0)
+    flat_harvest = _harvested_short_term_in_month(result, calendar_month=2, rollout_index=1)
+    assert drawdown_harvest > flat_harvest > 0.0
+
+
+def test_long_bull_run_ossifies_harvest_toward_floor() -> None:
+    # A long, steady bull run: basis stays at month-0 level while MV climbs, so the embedded-gain
+    # fraction e -> 1 and the harvested loss per month decays toward the floor. Compare an early
+    # month's harvest to a late month's; late must be strictly smaller (ossification).
+    horizon = 24
+    # +3%/month compounding bull market, no drawdowns.
+    levels = [1.0 * (1.03**m) for m in range(horizon + 1)]
+    scenario = _harvest_scenario(horizon_months=horizon, with_harvest=True)
+    external_series = _sp500_levels([levels])
+    result = simulate_with_external_series(scenario, rollout_count=1, external_series=external_series, locations={})
+
+    early = _harvested_short_term_in_month(result, calendar_month=1)
+    late = _harvested_short_term_in_month(result, calendar_month=12)
+    assert early > 0.0  # a real loss was harvested early
+    assert late < early  # ossification: harvest decays as embedded gains build
+
+
+def test_harvested_short_term_loss_offsets_realized_gain_lowering_tax() -> None:
+    # Alice realizes a real short-term capital GAIN (a separate crypto-like lot sold at a profit) in
+    # the same year she harvests SP500 losses. With harvesting on, the harvested ST loss nets against
+    # that gain (§1211/§1212), lowering the year's tax vs the no-harvest baseline.
+    gain_lot = InitialLot(
+        lot_id="alice_gain",
+        agent_id="alice",
+        account_id="brokerage",
+        asset=CryptoAssetKey(symbol=CryptoSymbol("gainco")),
+        purchase_month_index=-3,  # short-term when sold at month 6
+        quantity=100.0,
+        cost_basis_per_unit_usd=100.0,
+    )
+    gain_sale = ScheduledAssetSale(
+        month=6,
+        cause_id="alice_gain_sale",
+        agent_id="alice",
+        source_account_id="brokerage",
+        asset=CryptoAssetKey(symbol=CryptoSymbol("gainco")),
+        quantity=100.0,
+        price_per_unit_usd=400.0,  # $30k short-term gain
+        proceeds_account_id="checking",
+    )
+    # SP500 sleeve drops then recovers so harvesting books meaningful losses through the year.
+    sp500_levels = [1.0, 0.85, 0.85, 0.9, 0.9, 0.9, 0.95] + [0.95] * 7
+    gain_levels = [400.0] * 14
+    external_series = ExternalSeriesContext(
+        series_values=EXTERNAL_SERIES_VALUES_FRAME.normalize(
+            pl.DataFrame(
+                [
+                    {"rollout_index": 0, "month_index": m, "series_id": series_id, "value": value}
+                    for series_id, values in (("sp500", sp500_levels), ("crypto:gainco", gain_levels))
+                    for m, value in enumerate(values)
+                ]
+            )
+        )
+    )
+
+    def year_tax(with_harvest: bool) -> float:
+        scenario = _harvest_scenario(
+            horizon_months=13, with_harvest=with_harvest, scheduled_asset_sales=[gain_sale], extra_lots=[gain_lot]
+        )
+        result = simulate_with_external_series(scenario, rollout_count=1, external_series=external_series, locations={})
+        accruals = result.events_log.tax_accruals.filter(pl.col("jurisdiction_id") == "federal_us")
+        return float(accruals.get_column("amount_usd").sum())
+
+    tax_with = year_tax(with_harvest=True)
+    tax_without = year_tax(with_harvest=False)
+    assert tax_with < tax_without
+
+
+def test_give_back_makes_sale_gain_larger_by_cumulative_harvest_and_is_bounded() -> None:
+    # The deferral check. Hold the sleeve, harvest for several months, then liquidate the entire
+    # sleeve. The realized gain at sale must be larger WITH harvesting than without — by exactly the
+    # cumulative harvested loss booked over the held months — so the deferred gain is fully repaid.
+    # Net: the year's total realized capital gain (harvested losses + give-back at sale) returns to
+    # the no-harvest baseline, proving the benefit is deferral/timing, not unbounded free money.
+    horizon = 8
+    sale_month = 6
+    # Flat sleeve price so the sale itself realizes ~zero economic gain; all the give-back is the
+    # repaid deferral. (Price 1.0 == cost basis, so without harvest the sale gain is 0.)
+    levels = [1.0] * (horizon + 1)
+    sale = ScheduledAssetSale(
+        month=sale_month,
+        cause_id="alice_sp500_liquidate",
+        agent_id="alice",
+        source_account_id="brokerage",
+        asset=SP500AssetKey(),
+        quantity=1000.0,
+        price_per_unit_usd=1.0,
+        proceeds_account_id="checking",
+    )
+    external_series = _sp500_levels([levels])
+
+    def run(with_harvest: bool):
+        scenario = _harvest_scenario(horizon_months=horizon, with_harvest=with_harvest, scheduled_asset_sales=[sale])
+        return simulate_with_external_series(scenario, rollout_count=1, external_series=external_series, locations={})
+
+    harvested = run(with_harvest=True)
+    baseline = run(with_harvest=False)
+
+    # Snapshot `month_index = m + 1` is the end of calendar month `m`. The sale fires inside month
+    # `sale_month` (before that month's harvest, which then finds an empty sleeve), so the harvest
+    # accumulated through the END of month sale_month-1 — i.e. snapshot `month_index = sale_month` —
+    # is exactly what gets given back. It is the cumulative short-term loss booked so far (negative).
+    cumulative_harvest = -_ytd_gain(harvested, month_index=sale_month, classification="stcg")
+    assert cumulative_harvest > 0.0
+
+    # Realized gain booked AT the sale = the jump in cumulative YTD across the sale month, i.e. from
+    # snapshot `sale_month` to `sale_month + 1`.
+    def sale_realized(result) -> float:
+        before = _ytd_gain(result, month_index=sale_month, classification="stcg") + _ytd_gain(
+            result, month_index=sale_month, classification="ltcg"
+        )
+        after = _ytd_gain(result, month_index=sale_month + 1, classification="stcg") + _ytd_gain(
+            result, month_index=sale_month + 1, classification="ltcg"
+        )
+        return after - before
+
+    # Baseline sale realizes ~0 (price == basis). The harvested run's sale realizes the give-back —
+    # an extra gain equal to exactly the cumulative harvested loss (deferral repaid).
+    assert sale_realized(baseline) == pytest.approx(0.0, abs=1e-6)
+    assert sale_realized(harvested) == pytest.approx(cumulative_harvest, rel=1e-9, abs=1e-6)
+
+    # Deferral, not free money: after the give-back, the net realized capital gain over the whole
+    # (sub-year) horizon returns to the no-harvest baseline (~0) — bounded, not unbounded free money.
+    net_st = _ytd_gain(harvested, month_index=horizon, classification="stcg")
+    net_lt = _ytd_gain(harvested, month_index=horizon, classification="ltcg")
+    assert net_st + net_lt == pytest.approx(0.0, abs=1e-6)
+
+
+def test_partial_sales_give_back_proportionally_and_never_exceed_harvest() -> None:
+    # Two partial sales (half, then the rest) must together give back exactly the cumulative harvest
+    # — proportional to units sold — and never more (the scalar drains, so no double give-back).
+    horizon = 9
+    levels = [1.0] * (horizon + 1)
+    sales = [
+        ScheduledAssetSale(
+            month=4,
+            cause_id="alice_sp500_half",
+            agent_id="alice",
+            source_account_id="brokerage",
+            asset=SP500AssetKey(),
+            quantity=500.0,
+            price_per_unit_usd=1.0,
+            proceeds_account_id="checking",
+        ),
+        ScheduledAssetSale(
+            month=7,
+            cause_id="alice_sp500_rest",
+            agent_id="alice",
+            source_account_id="brokerage",
+            asset=SP500AssetKey(),
+            quantity=500.0,
+            price_per_unit_usd=1.0,
+            proceeds_account_id="checking",
+        ),
+    ]
+    scenario = _harvest_scenario(horizon_months=horizon, with_harvest=True, scheduled_asset_sales=sales)
+    result = simulate_with_external_series(
+        scenario, rollout_count=1, external_series=_sp500_levels([levels]), locations={}
+    )
+
+    # By the terminal month, all units are sold, so the entire cumulative harvest has been given
+    # back: the year-cumulative net short-term gain returns to ~0 (price flat == basis).
+    net_st = _ytd_gain(result, month_index=horizon, classification="stcg")
+    assert net_st == pytest.approx(0.0, abs=1e-6)
+
+
+def test_harvest_off_reproduces_baseline_capital_gains_exactly() -> None:
+    # Regression: a scenario with no harvest policy must produce byte-identical capital-gain YTD to
+    # the same scenario run on the pre-harvest code path (here: no harvested losses ever appear).
+    horizon = 6
+    levels = [1.0, 0.8, 0.9, 0.85, 0.95, 1.1, 1.2]
+    scenario = _harvest_scenario(horizon_months=horizon, with_harvest=False)
+    result = simulate_with_external_series(
+        scenario, rollout_count=1, external_series=_sp500_levels([levels]), locations={}
+    )
+    # No sales, no harvest → no capital-gain rows at all.
+    assert result.capital_gains_ytd.filter(pl.col("agent_id") == "alice").is_empty()
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/sim/tlh_harvest_test.py
+++ b/augur/sim/tlh_harvest_test.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pytest_bazel
+
+from augur.sim.tlh_harvest import HarvestYieldParams, monthly_harvest_fraction, split_short_long
+
+_PARAMS = HarvestYieldParams(
+    peak_annual_yield=0.05,  # ~5%/yr first-year gross harvest, anchored to TY2025 1099-B
+    floor_annual_yield=0.005,
+    maturity_decay_exponent=1.5,
+    drawdown_sensitivity=4.0,
+)
+
+
+def _arr(*values: float) -> np.ndarray:
+    return np.array(values, dtype=np.float64)
+
+
+def test_fresh_account_neutral_month_harvests_at_peak_rate() -> None:
+    # e=0, flat month -> exactly the peak annual yield / 12, with no drawdown kicker.
+    fraction = monthly_harvest_fraction(_arr(0.0), _arr(0.0), _PARAMS)
+    np.testing.assert_allclose(fraction, _PARAMS.peak_annual_yield / 12.0)
+
+
+def test_first_year_neutral_path_sums_to_peak_annual_anchor() -> None:
+    # Twelve flat months on a fresh account should accumulate ~the first-year anchor (~5%).
+    monthly = monthly_harvest_fraction(np.zeros(1), np.zeros(1), _PARAMS)[0]
+    np.testing.assert_allclose(monthly * 12.0, _PARAMS.peak_annual_yield)
+
+
+def test_yield_decays_monotonically_as_embedded_gain_rises() -> None:
+    # Ossification: more embedded gain -> strictly less harvest (flat month, same return).
+    e = _arr(0.0, 0.25, 0.5, 0.75, 1.0)
+    fraction = monthly_harvest_fraction(np.zeros_like(e), e, _PARAMS)
+    assert np.all(np.diff(fraction) < 0.0)
+
+
+def test_fully_ossified_account_floors_out() -> None:
+    fraction = monthly_harvest_fraction(_arr(0.0), _arr(1.0), _PARAMS)
+    np.testing.assert_allclose(fraction, _PARAMS.floor_annual_yield / 12.0)
+
+
+def test_drawdowns_harvest_more_than_flat_or_up_months() -> None:
+    e = np.zeros(3)
+    # down 10%, flat, up 10% — same maturity, so ordering is purely the drawdown kicker.
+    fraction = monthly_harvest_fraction(_arr(-0.10, 0.0, 0.10), e, _PARAMS)
+    assert fraction[0] > fraction[1]
+    # Up months get no kicker: positive returns clamp the drawdown term to zero.
+    np.testing.assert_allclose(fraction[1], fraction[2])
+
+
+def test_fraction_is_vectorized_over_rollouts() -> None:
+    fraction = monthly_harvest_fraction(_arr(-0.2, 0.0), _arr(0.1, 0.9), _PARAMS)
+    assert fraction.shape == (2,)
+    assert np.all(fraction >= 0.0)
+
+
+def test_split_short_long_conserves_total_and_respects_fraction() -> None:
+    gross = _arr(1000.0, 2000.0)
+    split = split_short_long(gross, _arr(1.0, 0.25))
+    np.testing.assert_allclose(split.short_term_usd + split.long_term_usd, gross)
+    # stf=1.0 -> all short-term (young account); 0.25 -> a quarter short-term.
+    np.testing.assert_allclose(split.short_term_usd, _arr(1000.0, 500.0))
+
+
+def test_floor_above_peak_is_rejected() -> None:
+    with pytest.raises(ValueError, match="floor_annual_yield"):
+        HarvestYieldParams(
+            peak_annual_yield=0.01, floor_annual_yield=0.05, maturity_decay_exponent=1.0, drawdown_sensitivity=1.0
+        )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## What

Implements **Piece 2** of tax-loss harvesting (TLH) in the augur sim: a reduced-form harvest process that realizes calibrated capital **losses** on a direct-indexing sleeve, with an honest basis give-back at sale. Builds on Piece 1 (capital-loss netting + carryforward, #1846).

Three commits:
1. **Plan + yield core** — reworks `augur/plans/tax_loss_harvesting.md` (the account opened in 2025, so TY2025 is the only 1099-B; decay shape is anchored to external research, not fitted — citations added) and lands the pure, unit-tested `augur/sim/tlh_harvest.py` (`monthly_harvest_fraction`, `split_short_long`).
2. **Engine integration** — wires it into the sim: `HarvestPolicy` (scenario) → compiler table → monthly `_apply_tlh_harvest` phase → **basis give-back at sale**.
3. **Config discriminator** — the sleeve's `tlh_model` is a discriminated config tagged `type: reduced_form_tlh`.

## Design (deliberately reduced-form)

It does **not** model constituent stocks. The holding stays one S&P 500-tracking position; the harvest is a calibrated loss number + a scalar basis adjustment:

- **Yield:** `gross = MV · monthly_harvest_fraction(period_return, e)` — peak at embedded-gain fraction `e=0` (fresh, cash-funded → basis≈MV), decaying as `(1−e)^γ` toward a floor ("ossification"), amplified in drawdowns. Front-loaded shape anchored to Vanguard (2024); magnitude/wash-sale bound from Chaudhuri–Burnham–Lo (2020). All params `[HEURISTIC]` (only the first-year 1099-B exists).
- **Honest deferral, not free money:** the loss is injected as a **negative** into `capital_gain_ytd[ST|LT]` (Piece-1 netting feeds, unchanged — **no synthetic gains**). A scalar `tlh_cumulative_harvest` per (policy, rollout) lowers basis; at sale `_apply_tlh_give_back` realizes the proportional share back as extra gain and drains the scalar — full liquidation repays exactly the harvested total, never more (no double-pay) or less. Ceiling keeps `cumulative ≤ original_basis`.
- **Limitations documented in-code**, including what a less-fake implementation (the plan's option #3: representative sleeves with real FIFO harvesting) would look like.

## Test plan (RBE)

- [x] `bbr build //augur/...` — clean (lint + mypy)
- [x] `bbr test //augur/...` — **63/63 pass**, including: down-month harvests more; long bull run ossifies to the floor; harvested ST loss lowers tax vs a no-harvest baseline; **give-back** = larger realized gain on sale by exactly the cumulative harvest (deferral, bounded — not free money); harvest-off regression reproduces prior behavior exactly; `config_test`, `portfolio_sources_test`.

## Follow-ups (not in this PR)

- The product `ScenarioKey` path doesn't yet consume `ResolvedPortfolioSources.harvest_policies` (the Plaid-sources path does); threading it there is a separate change.
- `tlh_cumulative_harvest` isn't surfaced in output frames (internal engine state); add a decoder if we want it visible.
- Gaffer wiring of the live Wealthfront sleeve to `type: reduced_form_tlh` lands as a companion PR.

https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4)_