### PR TITLE
props/orchestration: reconcile graders against the runtime API (adopt/reap, label pods)

### DIFF
--- a/props/orchestration/BUILD.bazel
+++ b/props/orchestration/BUILD.bazel
@@ -93,7 +93,6 @@ py_library(
     visibility = ["//props:__subpackages__"],
     deps = [
         ":agent_registry",
-        ":executor",
         "//props/core:agent_types",
         "//props/core:ids",
         "//props/core:oci_utils",
@@ -127,6 +126,8 @@ py_test(
         "test_grader_supervisor.py",
     ],
     deps = [
+        ":agent_registry",
+        ":executor",
         ":grader_supervisor",
         "//props/core:ids",
         "@pypi//pytest",

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -64,9 +64,19 @@ from props.db.config import DatabaseConfig
 from props.db.database import Database
 from props.db.models import AgentRun, AgentRunBudgetStatus, AgentRunStatus, Snapshot
 from props.orchestration.agent_credentials import ensure_agent_role
-from props.orchestration.executor import ContainerExecutor, ContainerHandle, ContainerResult, Exited, TimedOut
+from props.orchestration.executor import ContainerExecutor, ContainerHandle, ContainerResult, Exited, PodPhase, TimedOut
 
 logger = logging.getLogger(__name__)
+
+# Pod metadata keys. The supervisor reconciles graders by listing pods with
+# these labels, so it survives backend restarts (no in-memory source of truth).
+LABEL_PROJECT = "adgn.project"
+LABEL_AGENT_RUN_ID = "adgn.agent_run_id"
+LABEL_AGENT_TYPE = "adgn.agent_type"
+LABEL_SNAPSHOT = "adgn.snapshot"  # sanitized slug (label-safe); for kubectl filtering
+# Exact slug — kept in an annotation because a slug ("repo/version") is not a
+# valid k8s label value. (Docker folds annotations into labels; see DockerExecutor.)
+ANNOTATION_SNAPSHOT_SLUG = "adgn.snapshot_slug"
 
 
 # --- Exceptions ---
@@ -137,6 +147,17 @@ class ResolvedImage:
 
     digest: str
     oci_ref: str
+
+
+@dataclass(frozen=True)
+class GraderPodInfo:
+    """A grader pod as observed from the runtime (via labels), for reconciliation."""
+
+    name: str
+    agent_run_id: UUID
+    snapshot_slug: SnapshotSlug
+    image_ref: str
+    phase: PodPhase
 
 
 # --- Agent Run View ---
@@ -288,7 +309,15 @@ class AgentRegistry:
         oci_ref = self._registry_config.build_oci_reference(agent_type, digest)
         return ResolvedImage(digest=digest, oci_ref=oci_ref)
 
-    async def _create_container(self, agent_run_id: UUID, *, image: str, name: str) -> ContainerHandle:
+    async def _create_container(
+        self,
+        agent_run_id: UUID,
+        *,
+        image: str,
+        name: str,
+        extra_labels: dict[str, str] | None = None,
+        annotations: dict[str, str] | None = None,
+    ) -> ContainerHandle:
         """Ensure image, create DB role, create and start an agent container."""
         image_id = await self._pull_image(image)
         logger.info("Using image %s from %s", image_id[:19], image)
@@ -312,7 +341,8 @@ class AgentRegistry:
             name=name,
             image_id=image_id,
             env=env,
-            labels={"adgn.project": "props", "adgn.agent_run_id": str(agent_run_id)},
+            labels={LABEL_PROJECT: "props", LABEL_AGENT_RUN_ID: str(agent_run_id), **(extra_labels or {})},
+            annotations=annotations,
         )
 
     async def _collect_run(
@@ -383,7 +413,14 @@ class AgentRegistry:
             logger.info("Updated %s status to %s", agent_run_id, status)
 
     async def _start_agent(
-        self, agent_run_id: UUID, *, image: str, timeout_seconds: int | None = None, name: str
+        self,
+        agent_run_id: UUID,
+        *,
+        image: str,
+        timeout_seconds: int | None = None,
+        name: str,
+        extra_labels: dict[str, str] | None = None,
+        annotations: dict[str, str] | None = None,
     ) -> AgentRunHandle:
         """Create and start agent container, returning a handle that manages its lifecycle.
 
@@ -391,7 +428,9 @@ class AgentRegistry:
         and updates DB status. Await the returned handle to block until completion;
         call kill_and_delete() to stop early.
         """
-        handle = await self._create_container(agent_run_id, image=image, name=name)
+        handle = await self._create_container(
+            agent_run_id, image=image, name=name, extra_labels=extra_labels, annotations=annotations
+        )
         task = asyncio.create_task(self._collect_run(agent_run_id, handle, timeout_seconds))
         return AgentRunHandle(task, handle.name, agent_run_id)
 
@@ -459,6 +498,8 @@ class AgentRegistry:
         verify_snapshot: SnapshotSlug | None = None,
         container_name: str,
         timeout_seconds: int | None = None,
+        extra_labels: dict[str, str] | None = None,
+        annotations: dict[str, str] | None = None,
     ) -> AgentRunHandle:
         """Create DB record and start container, returning a handle."""
         self._create_run(
@@ -470,7 +511,14 @@ class AgentRegistry:
             parent_run_id=parent_run_id,
             verify_snapshot=verify_snapshot,
         )
-        return await self._start_agent(agent_run_id, image=image.oci_ref, name=container_name)
+        return await self._start_agent(
+            agent_run_id,
+            image=image.oci_ref,
+            name=container_name,
+            timeout_seconds=timeout_seconds,
+            extra_labels=extra_labels,
+            annotations=annotations,
+        )
 
     async def run_critic(
         self,
@@ -660,4 +708,72 @@ class AgentRegistry:
             budget_usd=10_000.0,
             verify_snapshot=snapshot_slug,
             container_name=container_name,
+            extra_labels={LABEL_AGENT_TYPE: str(AgentType.GRADER), LABEL_SNAPSHOT: slug_seg},
+            annotations={ANNOTATION_SNAPSHOT_SLUG: str(snapshot_slug)},
         )
+
+    # --- Grader pod reconciliation (used by GraderSupervisor) ---
+
+    async def list_grader_pods(self) -> list[GraderPodInfo]:
+        """List grader pods currently known to the runtime, by label.
+
+        This is the supervisor's source of truth for actual state — it reflects
+        graders started by any backend instance, not just this process.
+        """
+        pods = await self._executor.list_pods({LABEL_PROJECT: "props", LABEL_AGENT_TYPE: str(AgentType.GRADER)})
+        graders: list[GraderPodInfo] = []
+        for p in pods:
+            run_id = p.labels.get(LABEL_AGENT_RUN_ID)
+            # k8s keeps the exact slug in an annotation; Docker folds it into labels.
+            slug = p.annotations.get(ANNOTATION_SNAPSHOT_SLUG) or p.labels.get(ANNOTATION_SNAPSHOT_SLUG)
+            if run_id is None or slug is None:
+                logger.warning("Grader pod %s missing run-id/slug metadata; ignoring", p.name)
+                continue
+            graders.append(
+                GraderPodInfo(
+                    name=p.name,
+                    agent_run_id=UUID(run_id),
+                    snapshot_slug=SnapshotSlug(slug),
+                    image_ref=p.image,
+                    phase=p.phase,
+                )
+            )
+        return graders
+
+    def adopt_grader_pod(self, pod: GraderPodInfo) -> AgentRunHandle:
+        """Resume ownership of an already-running grader pod (e.g. one started by
+        a previous backend instance): attach a collector task that captures logs
+        and finalizes the run when the pod exits or is killed."""
+        handle = self._executor.handle_for(pod.name)
+        task = asyncio.create_task(self._collect_run(pod.agent_run_id, handle, None))
+        logger.info("Adopted grader pod %s for %s", pod.name, pod.snapshot_slug)
+        return AgentRunHandle(task, pod.name, pod.agent_run_id)
+
+    async def reap_grader_pod(self, pod: GraderPodInfo, *, reason: str) -> None:
+        """Delete an unwanted grader pod (duplicate, orphan, removed snapshot, or
+        wrong image) and finalize its run as CANCELLED if it's still in progress."""
+        logger.info("Reaping grader pod %s (snapshot=%s, reason=%s)", pod.name, pod.snapshot_slug, reason)
+        logs = await self._executor.read_logs(pod.name)
+        self._finalize_run_if_in_progress(
+            pod.agent_run_id, status=AgentRunStatus.CANCELLED, container_exit_code=None, stdout=logs
+        )
+        await self._executor.handle_for(pod.name).kill_and_delete()
+
+    def _finalize_run_if_in_progress(
+        self, agent_run_id: UUID, *, status: AgentRunStatus, container_exit_code: int | None, stdout: str
+    ) -> None:
+        """Set a grader run's terminal status + logs, but only if it's still
+        IN_PROGRESS — idempotent across reconciles and safe for orphan runs that
+        another path may already have finalized."""
+        with self._db.session() as session:
+            run = session.get(AgentRun, agent_run_id)
+            if run is None:
+                logger.warning("Grader run %s not found while finalizing; deleting pod anyway", agent_run_id)
+                return
+            if run.status != AgentRunStatus.IN_PROGRESS:
+                return
+            run.status = status
+            run.container_exit_code = container_exit_code
+            run.container_stdout = stdout or None
+            session.commit()
+            logger.info("Finalized grader run %s -> %s", agent_run_id, status)

--- a/props/orchestration/docker_executor.py
+++ b/props/orchestration/docker_executor.py
@@ -12,9 +12,21 @@ from dataclasses import dataclass
 
 import aiodocker
 
-from props.orchestration.executor import ContainerResult, Exited, TimedOut
+from props.orchestration.executor import ContainerResult, Exited, PodInfo, PodPhase, TimedOut
 
 logger = logging.getLogger(__name__)
+
+# Docker container state -> runtime-agnostic PodPhase. Docker's list summary
+# carries a coarse state string (no exit code), so "exited" maps to "failed";
+# terminal pods are finalized by the supervisor either way.
+_DOCKER_STATE_MAP: dict[str, PodPhase] = {
+    "created": "pending",
+    "restarting": "pending",
+    "running": "running",
+    "paused": "running",
+    "exited": "failed",
+    "dead": "failed",
+}
 
 
 @dataclass
@@ -100,9 +112,19 @@ class DockerExecutor:
         return image_id
 
     async def run_container(
-        self, *, name: str, image_id: str, env: dict[str, str], labels: dict[str, str]
+        self,
+        *,
+        name: str,
+        image_id: str,
+        env: dict[str, str],
+        labels: dict[str, str],
+        annotations: dict[str, str] | None = None,
     ) -> DockerContainerHandle:
-        """Create and start a Docker container."""
+        """Create and start a Docker container.
+
+        Docker has no annotations, so annotations are folded into labels (slug
+        values are valid Docker label values, unlike k8s label values).
+        """
         host_config: dict[str, object] = {"NetworkMode": self._network_name, "AutoRemove": False}
         if self._extra_hosts:
             host_config["ExtraHosts"] = [f"{host}:{ip}" for host, ip in self._extra_hosts.items()]
@@ -111,7 +133,7 @@ class DockerExecutor:
             "Image": image_id,
             "Env": [f"{k}={v}" for k, v in env.items()],
             "HostConfig": host_config,
-            "Labels": labels,
+            "Labels": {**labels, **(annotations or {})},
         }
 
         container = await self._docker_client.containers.create(
@@ -123,6 +145,37 @@ class DockerExecutor:
         await container.start()
         logger.info("Started container %s", name)
         return DockerContainerHandle(container=container, name=name)
+
+    async def list_pods(self, label_selector: dict[str, str]) -> list[PodInfo]:
+        filters = {"label": [f"{k}={v}" for k, v in label_selector.items()]}
+        containers = await self._docker_client.containers.list(all=True, filters=filters)
+        pods: list[PodInfo] = []
+        for c in containers:
+            summary = c._container  # list() summary dict
+            names = summary.get("Names") or [summary.get("Id", "")]
+            labels = summary.get("Labels") or {}
+            phase: PodPhase = _DOCKER_STATE_MAP.get(summary.get("State", ""), "unknown")
+            pods.append(
+                PodInfo(
+                    name=names[0].lstrip("/"),
+                    image=summary.get("Image", ""),
+                    phase=phase,
+                    labels=labels,
+                    annotations={},  # folded into labels on create
+                )
+            )
+        return pods
+
+    def handle_for(self, name: str) -> DockerContainerHandle:
+        return DockerContainerHandle(container=self._docker_client.containers.container(name), name=name)
+
+    async def read_logs(self, name: str) -> str:
+        try:
+            container = self._docker_client.containers.container(name)
+            return "".join(await container.log(stdout=True, stderr=True))
+        except aiodocker.DockerError as e:
+            logger.warning("Failed to read logs for container %s: %s", name, e)
+            return ""
 
     async def close(self) -> None:
         """Close the Docker client."""

--- a/props/orchestration/executor.py
+++ b/props/orchestration/executor.py
@@ -7,8 +7,28 @@ and Kubernetes (K8sExecutor).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+# Runtime-agnostic pod lifecycle phase. Maps k8s pod phases directly; the Docker
+# executor maps container states onto the same set.
+PodPhase = Literal["pending", "running", "succeeded", "failed", "unknown"]
+
+
+@dataclass(frozen=True)
+class PodInfo:
+    """Snapshot of a running/terminal agent container, as observed from the runtime.
+
+    The GraderSupervisor reconciles against this (listed by label) rather than
+    in-memory handles, so it survives backend restarts and can adopt/reap
+    containers a previous instance started.
+    """
+
+    name: str
+    image: str
+    phase: PodPhase
+    labels: dict[str, str] = field(default_factory=dict)
+    annotations: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -73,9 +93,36 @@ class ContainerExecutor(Protocol):
         ...
 
     async def run_container(
-        self, *, name: str, image_id: str, env: dict[str, str], labels: dict[str, str]
+        self,
+        *,
+        name: str,
+        image_id: str,
+        env: dict[str, str],
+        labels: dict[str, str],
+        annotations: dict[str, str] | None = None,
     ) -> ContainerHandle:
-        """Create and start a container/pod. Returns a handle for lifecycle management."""
+        """Create and start a container/pod. Returns a handle for lifecycle management.
+
+        `annotations` carry metadata that may not be a valid label value (e.g. a
+        snapshot slug containing '/'). Kubernetes stores them as pod annotations;
+        Docker (which has no annotations) folds them into labels.
+        """
+        ...
+
+    async def list_pods(self, label_selector: dict[str, str]) -> list[PodInfo]:
+        """List containers/pods matching all of the given labels."""
+        ...
+
+    def handle_for(self, name: str) -> ContainerHandle:
+        """Build a handle for an already-running container/pod by name.
+
+        Used to adopt or delete a container that this process did not start
+        (e.g. a grader left running by a previous backend instance).
+        """
+        ...
+
+    async def read_logs(self, name: str) -> str:
+        """Read a container/pod's current logs. Best-effort; returns '' on failure."""
         ...
 
     async def close(self) -> None:

--- a/props/orchestration/grader_supervisor.py
+++ b/props/orchestration/grader_supervisor.py
@@ -7,21 +7,30 @@ Reconciliation is triggered by:
 - startup (spawn_existing)
 - pg_notify snapshot_created
 - pg_notify grader_definition_changed (image push)
+- a periodic backstop (catches drift between events)
 
 Each trigger calls reconcile(), which compares desired state (all snapshot
-slugs from DB) against actual state (self._handles) and creates/kills
-containers to converge.
+slugs from DB) against **actual state read from the runtime** (grader pods
+listed by label) and converges:
 
-Event-driven triggers (snapshot_created, grader_definition_changed) are
-debounced: a burst coalesces into a single trailing-edge reconcile, so rapid
-image pushes delay-and-collapse into one respawn instead of many restart
-storms. Startup reconciles immediately.
+- adopt a healthy existing grader (right image, running) — so graders survive
+  backend restarts instead of being orphaned and duplicated;
+- reap duplicates, graders for removed snapshots, wrong-image graders, and
+  terminal pods (finalizing their run record);
+- spawn a grader for any snapshot that lacks a healthy one.
+
+Because actual state comes from the API (not in-memory handles), a restarted
+backend re-adopts the running graders rather than spawning a second generation.
+
+Event-driven triggers are debounced: a burst coalesces into a single
+trailing-edge reconcile. Startup reconciles immediately.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections import defaultdict
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -40,7 +49,7 @@ from props.db.notifications import (
     GraderDefinitionChangedNotification,
     SnapshotCreatedNotification,
 )
-from props.orchestration.agent_registry import AgentRunHandle, ImageResolutionError, ResolvedImage
+from props.orchestration.agent_registry import AgentRunHandle, GraderPodInfo, ImageResolutionError, ResolvedImage
 
 if TYPE_CHECKING:
     from props.orchestration.agent_registry import AgentRegistry
@@ -50,21 +59,21 @@ logger = logging.getLogger(__name__)
 # Coalesce reconcile triggers arriving within this window into a single
 # trailing-edge reconcile (delay-and-collapse, never skip).
 DEFAULT_RECONCILE_DEBOUNCE_S = 30.0
+# Backstop reconcile interval: catches drift the event triggers miss (a grader
+# that crashed, a pod deleted out-of-band). 0 disables the loop.
+DEFAULT_PERIODIC_RECONCILE_S = 120.0
 
 
 class GraderSupervisor:
-    """Manages per-snapshot grader containers via reconciliation.
-
-    Each snapshot gets one long-lived grader container. The supervisor
-    maintains a dict of handles and reconciles against the DB snapshot
-    list whenever an event fires (new snapshot, new image, startup).
+    """Manages per-snapshot grader containers via reconciliation against the
+    Kubernetes/Docker API.
 
     Use as async context manager:
 
         async with GraderSupervisor(...) as gs:
             await gs.spawn_existing()
             ...
-        # gs.shutdown() called automatically
+        # gs.shutdown() called automatically (leaves graders running)
     """
 
     def __init__(
@@ -75,11 +84,15 @@ class GraderSupervisor:
         db: Database,
         *,
         reconcile_debounce_s: float = DEFAULT_RECONCILE_DEBOUNCE_S,
+        periodic_reconcile_s: float = DEFAULT_PERIODIC_RECONCILE_S,
     ):
         self._registry = registry
         self._db_config = db_config
         self._model = model
         self._db = db
+        # Lifecycle handles for the graders this process currently owns (spawned
+        # or adopted). NOT the source of truth for reconcile — that's the API —
+        # only a place to retain collector tasks so they aren't GC'd.
         self._handles: dict[SnapshotSlug, AgentRunHandle] = {}
         self._listener_conn: asyncpg.Connection[Any] | None = None
         self._shutdown = False
@@ -87,8 +100,10 @@ class GraderSupervisor:
         # Trailing-edge debounce of event-driven reconciles.
         self._reconcile_debounce_s = reconcile_debounce_s
         self._debounce_task: asyncio.Task[None] | None = None
-        self._pending_restart_existing = False
         self._pending_triggers: list[str] = []
+        # Periodic backstop.
+        self._periodic_reconcile_s = periodic_reconcile_s
+        self._periodic_task: asyncio.Task[None] | None = None
 
     async def __aenter__(self) -> GraderSupervisor:
         await self.start()
@@ -123,34 +138,37 @@ class GraderSupervisor:
             return
         notification = GraderDefinitionChangedNotification.model_validate_json(payload)
         logger.info(f"Grader definition changed: {notification.tag} -> {notification.digest}")
-        self._schedule_reconcile(trigger=f"grader_definition_changed:{notification.tag}", restart_existing=True)
+        # No restart flag: reconcile detects wrong-image graders from the API and
+        # replaces them, so a tag move just schedules a normal reconcile.
+        self._schedule_reconcile(trigger=f"grader_definition_changed:{notification.tag}")
 
     # --- Lifecycle ---
 
     async def start(self) -> None:
-        """Start pg_notify listeners. Call spawn_existing() separately after HTTP is ready."""
+        """Start pg_notify listeners + periodic backstop. Call spawn_existing() after HTTP is ready."""
         await self._start_listener()
+        if self._periodic_reconcile_s > 0:
+            self._periodic_task = asyncio.create_task(self._periodic_loop(), name="grader-periodic-reconcile")
 
     async def spawn_existing(self) -> None:
         """Initial reconciliation after HTTP server is ready."""
         await self.reconcile(trigger="startup")
 
+    async def _periodic_loop(self) -> None:
+        while not self._shutdown:
+            try:
+                await asyncio.sleep(self._periodic_reconcile_s)
+            except asyncio.CancelledError:
+                return
+            self._schedule_reconcile(trigger="periodic")
+
     # --- Debounced reconcile scheduling ---
 
-    def _schedule_reconcile(self, *, trigger: str, restart_existing: bool = False) -> None:
+    def _schedule_reconcile(self, *, trigger: str) -> None:
         """Debounce an event-driven reconcile: coalesce rapid triggers into one
-        trailing-edge run.
-
-        A burst of events (several grader image pushes, a batch of new
-        snapshots) collapses into a single reconcile that fires after
-        ``reconcile_debounce_s`` of quiet. The respawn is *delayed and
-        coalesced*, never skipped — ``restart_existing`` is OR'd across the
-        window so a genuine image change in the burst still restarts graders,
-        exactly once.
-        """
+        trailing-edge run after ``reconcile_debounce_s`` of quiet."""
         if self._shutdown:
             return
-        self._pending_restart_existing |= restart_existing
         self._pending_triggers.append(trigger)
         # Reset the quiet window so we fire once, after the LAST trigger. Only a
         # still-debouncing timer is cancelled — never an in-flight reconcile.
@@ -174,71 +192,112 @@ class GraderSupervisor:
         self._debounce_task = None
         if self._shutdown:
             return
-        restart_existing = self._pending_restart_existing
         triggers = self._pending_triggers
-        self._pending_restart_existing = False
         self._pending_triggers = []
         label = triggers[0] if len(triggers) == 1 else f"debounced({len(triggers)}): {', '.join(triggers)}"
-        await self.reconcile(trigger=label, restart_existing=restart_existing)
+        await self.reconcile(trigger=label)
 
     # --- Core reconciliation ---
 
-    async def reconcile(self, *, trigger: str, restart_existing: bool = False) -> None:
-        """Converge actual state toward desired state.
-
-        Desired: one grader per snapshot (if image available).
-        Actual: self._handles.
-
-        `trigger` labels what caused this reconcile (startup, snapshot_created,
-        grader_definition_changed, ...) — logged so grader churn is attributable.
-        If restart_existing is True, kill all tracked graders first (used when the
-        grader image changes); note this cancels graders mid-run.
-        """
+    async def reconcile(self, *, trigger: str) -> None:
+        """Converge actual state (grader pods listed from the runtime) toward
+        desired state (one grader per snapshot on the current image)."""
         if self._shutdown:
             return
 
-        logger.info("Reconcile triggered by %s (restart_existing=%s)", trigger, restart_existing)
+        logger.info("Reconcile triggered by %s", trigger)
 
-        # Resolve image — if unavailable, nothing to do.
         try:
             resolved = await self._registry.resolve_image(AgentType.GRADER, BUILTIN_TAG)
         except ImageResolutionError:
             logger.warning("Reconcile [%s] aborted: grader image not available", trigger)
             return
 
-        # Get desired set from DB.
         with self._db.session() as session:
             desired: set[SnapshotSlug] = {s.slug for s in session.query(Snapshot.slug).all()}
 
-        killed = 0
-        # If the image changed, kill everything so containers pick up the new image.
-        # This cancels any in-flight grade (-> AgentRunStatus.CANCELLED).
-        if restart_existing:
-            for slug in list(self._handles.keys()):
-                await self._kill_grader(slug, reason="grader_image_changed")
-                killed += 1
+        pods = await self._registry.list_grader_pods()
+        by_snapshot: dict[SnapshotSlug, list[GraderPodInfo]] = defaultdict(list)
+        for pod in pods:
+            by_snapshot[pod.snapshot_slug].append(pod)
 
-        # Kill graders for snapshots that no longer exist.
-        for slug in list(self._handles.keys()):
-            if slug not in desired:
-                await self._kill_grader(slug, reason="snapshot_removed")
-                killed += 1
+        handles_by_pod_name = {h.name: h for h in self._handles.values()}
+        new_handles: dict[SnapshotSlug, AgentRunHandle] = {}
+        kept = adopted = reaped = spawned = 0
 
-        # Spawn missing graders.
-        spawned = 0
+        for slug, plist in by_snapshot.items():
+            # A keeper is one running pod, for a desired snapshot, on the current image.
+            keeper = next(
+                (p for p in plist if slug in desired and p.phase == "running" and p.image_ref == resolved.oci_ref), None
+            )
+            for pod in plist:
+                if keeper is not None and pod.name == keeper.name:
+                    continue
+                await self._reap(pod, desired=desired, image=resolved, tracked=handles_by_pod_name)
+                reaped += 1
+            if keeper is not None:
+                existing = handles_by_pod_name.get(keeper.name)
+                if existing is not None:
+                    new_handles[slug] = existing
+                    kept += 1
+                else:
+                    new_handles[slug] = self._registry.adopt_grader_pod(keeper)
+                    adopted += 1
+
         for slug in desired:
-            if slug not in self._handles:
-                await self._spawn_grader(slug, image=resolved, trigger=trigger)
-                spawned += 1
+            if slug not in new_handles:
+                handle = await self._spawn_grader(slug, image=resolved, trigger=trigger)
+                if handle is not None:
+                    new_handles[slug] = handle
+                    spawned += 1
+
+        # Cancel collectors for handles we no longer carry (pod vanished out-of-band
+        # or was reaped); finalizes their run as CANCELLED.
+        carried = {id(h) for h in new_handles.values()}
+        for old in self._handles.values():
+            if id(old) not in carried:
+                await old.kill_and_delete()
+        self._handles = new_handles
 
         logger.info(
-            "Reconcile [%s] done: desired=%d killed=%d spawned=%d running=%d",
+            "Reconcile [%s] done: desired=%d kept=%d adopted=%d spawned=%d reaped=%d running=%d",
             trigger,
             len(desired),
-            killed,
+            kept,
+            adopted,
             spawned,
+            reaped,
             len(self._handles),
         )
+
+    async def _reap(
+        self,
+        pod: GraderPodInfo,
+        *,
+        desired: set[SnapshotSlug],
+        image: ResolvedImage,
+        tracked: dict[str, AgentRunHandle],
+    ) -> None:
+        """Delete an unwanted grader pod and finalize its run.
+
+        If this process owns the pod (has a handle), cancel via the handle so its
+        collector finalizes; otherwise reap it via the registry (orphan path).
+        """
+        reason = (
+            "snapshot_removed"
+            if pod.snapshot_slug not in desired
+            else "wrong_image"
+            if pod.image_ref != image.oci_ref
+            else "terminal"
+            if pod.phase in ("succeeded", "failed")
+            else "duplicate"
+        )
+        handle = tracked.get(pod.name)
+        if handle is not None:
+            logger.info("Reaping tracked grader %s for %s (reason: %s)", pod.name, pod.snapshot_slug, reason)
+            await handle.kill_and_delete()
+        else:
+            await self._registry.reap_grader_pod(pod, reason=reason)
 
     # --- Internal helpers ---
 
@@ -262,31 +321,32 @@ class GraderSupervisor:
                 logger.warning(f"Error closing listener connection: {e}")
             self._listener_conn = None
 
-    async def _spawn_grader(self, snapshot_slug: SnapshotSlug, *, image: ResolvedImage, trigger: str) -> None:
+    async def _spawn_grader(
+        self, snapshot_slug: SnapshotSlug, *, image: ResolvedImage, trigger: str
+    ) -> AgentRunHandle | None:
         try:
             handle = await self._registry.start_snapshot_grader(
                 image=image, snapshot_slug=snapshot_slug, model=self._model
             )
-            self._handles[snapshot_slug] = handle
             logger.info(
                 "Spawned grader %s for %s (trigger: %s, image: %s)", handle.name, snapshot_slug, trigger, image.digest
             )
+            return handle
         except Exception:
             logger.exception("Failed to start grader for %s (trigger: %s)", snapshot_slug, trigger)
-
-    async def _kill_grader(self, snapshot_slug: SnapshotSlug, *, reason: str) -> None:
-        handle = self._handles.pop(snapshot_slug, None)
-        if handle:
-            logger.info("Killing grader %s for %s (reason: %s)", handle.name, snapshot_slug, reason)
-            await handle.kill_and_delete()
+            return None
 
     async def shutdown(self) -> None:
-        """Kill all grader containers and stop listeners."""
+        """Stop listeners + timers. Leaves grader pods running so the next backend
+        instance adopts them (no restart churn)."""
         self._shutdown = True
-        logger.info("Shutting down graders...")
+        logger.info("Shutting down grader supervisor (leaving graders running)...")
         if self._debounce_task is not None and not self._debounce_task.done():
             self._debounce_task.cancel()
+        if self._periodic_task is not None and not self._periodic_task.done():
+            self._periodic_task.cancel()
         await self._stop_listener()
-        for slug in list(self._handles.keys()):
-            await self._kill_grader(slug, reason="shutdown")
-        logger.info("All graders stopped")
+        # Intentionally do NOT kill grader pods or cancel their collector tasks:
+        # the pods outlive this process and are adopted on the next startup.
+        self._handles = {}
+        logger.info("Grader supervisor stopped")

--- a/props/orchestration/k8s_executor.py
+++ b/props/orchestration/k8s_executor.py
@@ -23,9 +23,17 @@ from kubernetes_asyncio.client import (
     V1PodSpec,
 )
 
-from props.orchestration.executor import ContainerResult, Exited, TimedOut
+from props.orchestration.executor import ContainerResult, Exited, PodInfo, PodPhase, TimedOut
 
 logger = logging.getLogger(__name__)
+
+# k8s pod.status.phase -> runtime-agnostic PodPhase.
+_PHASE_MAP: dict[str, PodPhase] = {
+    "Pending": "pending",
+    "Running": "running",
+    "Succeeded": "succeeded",
+    "Failed": "failed",
+}
 
 
 @dataclass
@@ -115,7 +123,13 @@ class K8sExecutor:
         return image_ref
 
     async def run_container(
-        self, *, name: str, image_id: str, env: dict[str, str], labels: dict[str, str]
+        self,
+        *,
+        name: str,
+        image_id: str,
+        env: dict[str, str],
+        labels: dict[str, str],
+        annotations: dict[str, str] | None = None,
     ) -> K8sPodHandle:
         """Create and start a pod in the configured namespace."""
         v1 = self._core_v1
@@ -127,11 +141,40 @@ class K8sExecutor:
         if self._image_pull_secret:
             pod_spec.image_pull_secrets = [client.V1LocalObjectReference(name=self._image_pull_secret)]
 
-        pod = V1Pod(metadata=V1ObjectMeta(name=name, namespace=self._namespace, labels=labels), spec=pod_spec)
+        meta = V1ObjectMeta(name=name, namespace=self._namespace, labels=labels, annotations=annotations or None)
+        pod = V1Pod(metadata=meta, spec=pod_spec)
 
         await v1.create_namespaced_pod(namespace=self._namespace, body=pod)
         logger.info("Created pod %s in namespace %s", name, self._namespace)
         return K8sPodHandle(name=name, namespace=self._namespace, core_v1=self._core_v1)
+
+    async def list_pods(self, label_selector: dict[str, str]) -> list[PodInfo]:
+        selector = ",".join(f"{k}={v}" for k, v in label_selector.items())
+        resp = await self._core_v1.list_namespaced_pod(namespace=self._namespace, label_selector=selector)
+        pods: list[PodInfo] = []
+        for pod in resp.items:
+            phase: PodPhase = _PHASE_MAP.get(pod.status.phase if pod.status else "", "unknown")
+            image = pod.spec.containers[0].image if pod.spec and pod.spec.containers else ""
+            pods.append(
+                PodInfo(
+                    name=pod.metadata.name,
+                    image=image,
+                    phase=phase,
+                    labels=pod.metadata.labels or {},
+                    annotations=pod.metadata.annotations or {},
+                )
+            )
+        return pods
+
+    def handle_for(self, name: str) -> K8sPodHandle:
+        return K8sPodHandle(name=name, namespace=self._namespace, core_v1=self._core_v1)
+
+    async def read_logs(self, name: str) -> str:
+        try:
+            return str(await self._core_v1.read_namespaced_pod_log(name=name, namespace=self._namespace))
+        except ApiException as e:
+            logger.warning("Failed to read logs for pod %s: %s", name, e)
+            return ""
 
     async def close(self) -> None:
         """Close the k8s API client."""

--- a/props/orchestration/test_grader_supervisor.py
+++ b/props/orchestration/test_grader_supervisor.py
@@ -1,7 +1,10 @@
 """Tests for grader supervisor reconciliation logic.
 
-Tests the core invariant: reconcile() converges toward one grader per
-snapshot when an image is available.
+The supervisor reconciles desired state (DB snapshots) against actual state read
+from the runtime (grader pods listed by label). These tests drive a FakeRegistry
+that simulates that pod list plus spawn/adopt/reap, and assert the supervisor
+adopts healthy graders, reaps duplicates/orphans/wrong-image/terminal pods, and
+spawns only what's missing.
 """
 
 from __future__ import annotations
@@ -12,15 +15,18 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 import pytest_bazel
 
 from props.core.ids import SnapshotSlug
-from props.orchestration.agent_registry import ImageResolutionError, ResolvedImage
+from props.orchestration.agent_registry import GraderPodInfo, ImageResolutionError, ResolvedImage
+from props.orchestration.executor import PodPhase
 from props.orchestration.grader_supervisor import GraderSupervisor
 
 FAKE_IMAGE = ResolvedImage(digest="sha256:abc123", oci_ref="localhost:8000/grader@sha256:abc123")
+OLD_IMAGE = ResolvedImage(digest="sha256:old", oci_ref="localhost:8000/grader@sha256:old")
 
 SNAP_A = SnapshotSlug("snap-a")
 SNAP_B = SnapshotSlug("snap-b")
@@ -29,26 +35,28 @@ SNAP_C = SnapshotSlug("snap-c")
 
 @dataclass
 class FakeHandle:
-    """Minimal ContainerHandle stand-in with kill tracking."""
+    """Stand-in for AgentRunHandle: deleting it removes the pod from the registry."""
 
     name: str
-    _killed_list: list[FakeHandle] = field(repr=False)
-
-    async def wait(self, *, timeout_seconds: int | None) -> None:
-        raise NotImplementedError
+    registry: FakeRegistry = field(repr=False)
 
     async def kill_and_delete(self) -> None:
-        self._killed_list.append(self)
+        self.registry.killed.append(self.name)
+        self.registry.pods.pop(self.name, None)
 
 
 @dataclass
 class FakeRegistry:
-    """Test double for AgentRegistry — tracks spawned/killed handles."""
+    """Simulates the runtime grader-pod list plus spawn/adopt/reap."""
 
     image: ResolvedImage | None = FAKE_IMAGE
+    pods: dict[str, GraderPodInfo] = field(default_factory=dict)
+    resolve_count: int = 0
+    spawned: list[SnapshotSlug] = field(default_factory=list)
+    adopted: list[str] = field(default_factory=list)
+    reaped: list[str] = field(default_factory=list)
+    killed: list[str] = field(default_factory=list)
     _counter: int = 0
-    killed: list[FakeHandle] = field(default_factory=list)
-    resolve_count: int = 0  # incremented once per reconcile() run
 
     async def resolve_image(self, agent_type: Any, tag: str) -> ResolvedImage:
         self.resolve_count += 1
@@ -56,21 +64,36 @@ class FakeRegistry:
             raise ImageResolutionError("no image")
         return self.image
 
+    async def list_grader_pods(self) -> list[GraderPodInfo]:
+        return list(self.pods.values())
+
+    def add_pod(self, slug: SnapshotSlug, *, image_ref: str, phase: PodPhase = "running") -> GraderPodInfo:
+        """Seed a pre-existing pod (e.g. one a previous backend instance started)."""
+        self._counter += 1
+        name = f"grader-{slug}-{self._counter}"
+        pod = GraderPodInfo(name=name, agent_run_id=uuid4(), snapshot_slug=slug, image_ref=image_ref, phase=phase)
+        self.pods[name] = pod
+        return pod
+
     async def start_snapshot_grader(
         self, *, image: ResolvedImage, snapshot_slug: SnapshotSlug, model: str
     ) -> FakeHandle:
-        self._counter += 1
-        return FakeHandle(name=f"grader-{self._counter}", _killed_list=self.killed)
+        pod = self.add_pod(snapshot_slug, image_ref=image.oci_ref)
+        self.spawned.append(snapshot_slug)
+        return FakeHandle(name=pod.name, registry=self)
+
+    def adopt_grader_pod(self, pod: GraderPodInfo) -> FakeHandle:
+        self.adopted.append(pod.name)
+        return FakeHandle(name=pod.name, registry=self)
+
+    async def reap_grader_pod(self, pod: GraderPodInfo, *, reason: str) -> None:
+        self.reaped.append(pod.name)
+        self.pods.pop(pod.name, None)
 
 
 def _make_supervisor(
     snapshot_slugs: list[SnapshotSlug], *, image: ResolvedImage | None = FAKE_IMAGE, reconcile_debounce_s: float = 0.05
 ) -> tuple[GraderSupervisor, FakeRegistry]:
-    """Build a GraderSupervisor with a FakeRegistry and mock DB.
-
-    `reconcile_debounce_s` defaults small so debounce tests run fast; the
-    direct `reconcile()` tests don't touch the debounce path.
-    """
     registry = FakeRegistry(image=image)
 
     @contextmanager
@@ -88,183 +111,166 @@ def _make_supervisor(
         model="gpt-5-mini",
         db=db,
         reconcile_debounce_s=reconcile_debounce_s,
+        periodic_reconcile_s=0,  # no backstop loop in unit tests
     )
     return gs, registry
 
 
-def _mock_session(rows: list[Any]) -> Any:
-    """Create a mock session context manager returning given rows."""
-
+def _set_snapshots(gs: GraderSupervisor, slugs: list[SnapshotSlug]) -> None:
     @contextmanager
     def fake_session() -> Any:
         session = MagicMock()
-        session.query.return_value.all.return_value = rows
+        session.query.return_value.all.return_value = [MagicMock(slug=s) for s in slugs]
         yield session
 
-    return fake_session
+    gs._db.session = fake_session  # type: ignore[method-assign]
 
 
 async def test_reconcile_spawns_for_all_snapshots():
-    """reconcile() spawns a grader for each snapshot."""
-    gs, _ = _make_supervisor([SNAP_A, SNAP_B, SNAP_C])
+    """With no existing pods, reconcile spawns one grader per snapshot."""
+    gs, registry = _make_supervisor([SNAP_A, SNAP_B, SNAP_C])
     await gs.reconcile(trigger="test")
-    assert set(gs._handles.keys()) == {SNAP_A, SNAP_B, SNAP_C}
+    assert sorted(registry.spawned) == sorted([SNAP_A, SNAP_B, SNAP_C])
+    assert set(gs._handles) == {SNAP_A, SNAP_B, SNAP_C}
 
 
 async def test_reconcile_noop_when_image_unavailable():
-    """reconcile() does nothing when no grader image is available."""
-    gs, _ = _make_supervisor([SNAP_A], image=None)
+    gs, registry = _make_supervisor([SNAP_A], image=None)
     await gs.reconcile(trigger="test")
+    assert registry.spawned == []
     assert gs._handles == {}
 
 
-async def test_reconcile_idempotent():
-    """Calling reconcile() twice doesn't create duplicate graders."""
-    gs, _ = _make_supervisor([SNAP_A, SNAP_B])
-    await gs.reconcile(trigger="test")
-    handles_first = dict(gs._handles)
-    await gs.reconcile(trigger="test")
-    # Same handles, not replaced
-    assert gs._handles == handles_first
-
-
-async def test_reconcile_spawns_new_snapshot():
-    """reconcile() spawns for a newly added snapshot without touching existing."""
-    gs, _ = _make_supervisor([SNAP_A])
-    await gs.reconcile(trigger="test")
-    handle_a = gs._handles[SNAP_A]
-
-    # Simulate new snapshot appearing in DB
-    gs._db.session = _mock_session([MagicMock(slug=s) for s in [SNAP_A, SNAP_B]])  # type: ignore[method-assign]
-
-    await gs.reconcile(trigger="test")
-    assert gs._handles[SNAP_A] is handle_a
-    assert SNAP_B in gs._handles
-
-
-async def test_reconcile_kills_removed_snapshot():
-    """reconcile() kills grader when snapshot disappears from DB."""
+async def test_reconcile_idempotent_keeps_existing():
+    """A second reconcile keeps the grader (tracked handle) — no respawn, no reap."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B])
     await gs.reconcile(trigger="test")
-    handle_b = gs._handles[SNAP_B]
-
-    # Simulate snap-b removed from DB
-    gs._db.session = _mock_session([MagicMock(slug=SNAP_A)])  # type: ignore[method-assign]
-
+    assert len(registry.spawned) == 2
     await gs.reconcile(trigger="test")
-    assert SNAP_B not in gs._handles
-    assert handle_b in registry.killed
+    assert len(registry.spawned) == 2  # unchanged
+    assert registry.reaped == []
+    assert registry.adopted == []
 
 
-async def test_reconcile_restart_kills_and_respawns():
-    """reconcile(restart_existing=True) kills all and respawns."""
-    gs, registry = _make_supervisor([SNAP_A, SNAP_B])
+async def test_reconcile_adopts_orphan_without_respawning():
+    """Restart safety: a healthy grader left by a previous instance (pod present,
+    no handle) is adopted, not duplicated."""
+    gs, registry = _make_supervisor([SNAP_A])
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref)  # previous instance's grader
+    await gs.reconcile(trigger="startup")
+    assert registry.adopted
+    assert not registry.spawned
+    assert not registry.reaped
+    assert SNAP_A in gs._handles
+
+
+async def test_reconcile_reaps_duplicate():
+    """Two pods for one snapshot → keep one, reap the extra."""
+    gs, registry = _make_supervisor([SNAP_A])
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref)
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref)
     await gs.reconcile(trigger="test")
-    old_a = gs._handles[SNAP_A]
-    old_b = gs._handles[SNAP_B]
-
-    await gs.reconcile(trigger="test", restart_existing=True)
-    assert old_a in registry.killed
-    assert old_b in registry.killed
-    # New handles created
-    assert gs._handles[SNAP_A] is not old_a
-    assert gs._handles[SNAP_B] is not old_b
+    assert len(registry.reaped) == 1
+    assert len(registry.pods) == 1  # one kept
 
 
-async def test_reconcile_restart_also_spawns_missing():
-    """restart_existing=True also spawns graders for snapshots not yet tracked."""
+async def test_reconcile_reaps_removed_snapshot():
+    """A grader for a snapshot no longer in the DB is reaped."""
+    gs, registry = _make_supervisor([])
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref)
+    await gs.reconcile(trigger="test")
+    assert len(registry.reaped) == 1
+    assert registry.pods == {}
+
+
+async def test_reconcile_replaces_wrong_image():
+    """A grader on a stale image is reaped and replaced — no restart_existing flag."""
+    gs, registry = _make_supervisor([SNAP_A])
+    registry.add_pod(SNAP_A, image_ref=OLD_IMAGE.oci_ref)
+    await gs.reconcile(trigger="grader_definition_changed:latest")
+    assert len(registry.reaped) == 1
+    assert registry.spawned == [SNAP_A]
+    # exactly one pod, on the new image
+    assert len(registry.pods) == 1
+    assert next(iter(registry.pods.values())).image_ref == FAKE_IMAGE.oci_ref
+
+
+async def test_reconcile_reaps_terminal_pod_and_respawns():
+    """A crashed (Failed) grader is finalized/reaped and a fresh one spawned."""
+    gs, registry = _make_supervisor([SNAP_A])
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="failed")
+    await gs.reconcile(trigger="periodic")
+    assert len(registry.reaped) == 1
+    assert registry.spawned == [SNAP_A]
+
+
+async def test_reconcile_spawns_new_snapshot_only():
+    """A newly added snapshot gets a grader; the existing one is kept."""
     gs, registry = _make_supervisor([SNAP_A])
     await gs.reconcile(trigger="test")
-    old_a = gs._handles[SNAP_A]
-
-    # Add snap-b to DB, trigger restart
-    gs._db.session = _mock_session([MagicMock(slug=s) for s in [SNAP_A, SNAP_B]])  # type: ignore[method-assign]
-
-    await gs.reconcile(trigger="test", restart_existing=True)
-    assert old_a in registry.killed
-    assert SNAP_A in gs._handles
-    assert SNAP_B in gs._handles
+    _set_snapshots(gs, [SNAP_A, SNAP_B])
+    await gs.reconcile(trigger="test")
+    assert registry.spawned.count(SNAP_B) == 1
+    assert set(gs._handles) == {SNAP_A, SNAP_B}
+    assert registry.reaped == []
 
 
-async def test_shutdown_kills_all():
-    """shutdown() kills all tracked graders."""
+async def test_shutdown_leaves_graders_running():
+    """Shutdown must NOT kill graders — the next instance adopts them."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B])
     await gs.reconcile(trigger="test")
-    handles = list(gs._handles.values())
-
+    pods_before = dict(registry.pods)
     await gs.shutdown()
-    assert all(h in registry.killed for h in handles)
+    assert registry.pods == pods_before  # nothing reaped/killed
+    assert registry.killed == []
     assert gs._handles == {}
 
 
 async def test_reconcile_noop_after_shutdown():
-    """reconcile() does nothing after shutdown."""
-    gs, _ = _make_supervisor([SNAP_A])
+    gs, registry = _make_supervisor([SNAP_A])
     await gs.shutdown()
     await gs.reconcile(trigger="test")
-    assert gs._handles == {}
+    assert registry.spawned == []
 
 
-async def test_reconcile_logs_trigger_and_kill_reason(caplog: pytest.LogCaptureFixture) -> None:
-    """Every reconcile logs its trigger and every grader kill logs its reason, so
-    churn (e.g. an image push restarting an in-flight grade) is attributable."""
-    gs, _ = _make_supervisor([SNAP_A])
-    with caplog.at_level(logging.INFO, logger="props.orchestration.grader_supervisor"):
-        await gs.reconcile(trigger="startup")
-        await gs.reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
-    log = "\n".join(r.getMessage() for r in caplog.records)
-    assert "Reconcile triggered by startup" in log
-    assert "Reconcile triggered by grader_definition_changed:latest" in log
-    # The image-push restart attributes why it killed the running grader.
-    assert "reason: grader_image_changed" in log
+# --- Debounce (trailing-edge coalescing) ---
 
 
-async def test_schedule_reconcile_debounces_burst() -> None:
-    """A burst of triggers coalesces into a single trailing-edge reconcile —
-    rapid image pushes must not each restart every grader."""
+async def test_schedule_reconcile_debounces_burst():
+    """A burst of triggers coalesces into a single trailing-edge reconcile."""
     gs, registry = _make_supervisor([SNAP_A, SNAP_B], reconcile_debounce_s=0.05)
     for _ in range(5):
-        gs._schedule_reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
-    # Debounced, not immediate: nothing has reconciled yet.
-    assert registry.resolve_count == 0
+        gs._schedule_reconcile(trigger="grader_definition_changed:latest")
+    assert registry.resolve_count == 0  # debounced, not immediate
     await asyncio.sleep(0.2)
-    # The whole burst produced exactly one reconcile.
-    assert registry.resolve_count == 1
+    assert registry.resolve_count == 1  # one reconcile for the whole burst
     assert set(gs._handles) == {SNAP_A, SNAP_B}
 
 
-async def test_schedule_reconcile_delays_but_does_not_drop() -> None:
-    """The reconcile is delayed by the debounce window, then runs — delay, not cancel."""
+async def test_schedule_reconcile_delays_but_does_not_drop():
+    """The reconcile is delayed by the window, then runs — delay, not cancel."""
     gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.1)
     gs._schedule_reconcile(trigger="snapshot_created:snap-a")
-    assert registry.resolve_count == 0  # still within the quiet window
-    assert gs._handles == {}
+    assert registry.resolve_count == 0
     await asyncio.sleep(0.25)
-    assert registry.resolve_count == 1  # fired after the window
+    assert registry.resolve_count == 1
     assert SNAP_A in gs._handles
 
 
-async def test_schedule_reconcile_ors_restart_existing() -> None:
-    """If any trigger in the window asked to restart, the single coalesced
-    reconcile restarts existing graders (OR semantics)."""
-    gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.05)
-    await gs.reconcile(trigger="seed")  # one grader already running
-    old = gs._handles[SNAP_A]
-    gs._schedule_reconcile(trigger="snapshot_created:x")  # restart_existing=False
-    gs._schedule_reconcile(trigger="grader_definition_changed:latest", restart_existing=True)
-    await asyncio.sleep(0.2)
-    assert old in registry.killed  # restart took effect
-    assert gs._handles[SNAP_A] is not old  # respawned
-
-
-async def test_schedule_reconcile_noop_after_shutdown() -> None:
-    """Scheduling after shutdown does nothing (no late respawn)."""
+async def test_schedule_reconcile_noop_after_shutdown():
     gs, registry = _make_supervisor([SNAP_A], reconcile_debounce_s=0.05)
     await gs.shutdown()
     gs._schedule_reconcile(trigger="late")
     await asyncio.sleep(0.15)
     assert registry.resolve_count == 0
-    assert gs._handles == {}
+
+
+async def test_reconcile_logs_trigger(caplog: pytest.LogCaptureFixture) -> None:
+    """Every reconcile logs its trigger so churn stays attributable."""
+    gs, _ = _make_supervisor([SNAP_A])
+    with caplog.at_level(logging.INFO, logger="props.orchestration.grader_supervisor"):
+        await gs.reconcile(trigger="startup")
+    assert "Reconcile triggered by startup" in "\n".join(r.getMessage() for r in caplog.records)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `GraderSupervisor` kept actual-state in memory (`self._handles`). On every backend rollout it started a **fresh generation** of graders without seeing the previous one — and grader pods have **no `ownerReferences`**, so k8s never GC'd them. Result: duplicate grader pods per snapshot piling up on each deploy (we observed `2025-11-20-00`, `11-22-02`, `12-04-00`, … each running two). It also blindly killed every grader on image change and on shutdown.

This is the orphan-duplicate path that #1878/#1879 (grader-image-push churn) did **not** touch — it's driven by backend rollouts, not image pushes.

## Change — make it a real controller

- **Label grader pods**: `adgn.agent_type=grader`, `adgn.snapshot=<sanitized>` (label-safe, for `kubectl` filtering), and `adgn.snapshot_slug=<exact>` as an annotation (a slug `repo/version` isn't a valid k8s label value).
- **`reconcile()` reads actual state from the runtime** (`registry.list_grader_pods()`, listed by label) instead of `self._handles`, then converges:
  - **adopt** a healthy existing grader (running, current image) → a restarted backend re-adopts instead of duplicating;
  - **reap** duplicates / removed-snapshot / wrong-image / terminal pods, finalizing their run record (orphans no longer leak `IN_PROGRESS`);
  - **spawn** only snapshots lacking a healthy grader.
- **Drop `restart_existing`**: wrong-image graders are detected from the pod's image and replaced, so a grader image push is just a normal reconcile.
- **Periodic backstop** reconcile (120s) catches drift the events miss (a crashed grader, an out-of-band deletion).
- **`shutdown()` no longer kills graders** — they outlive the process and are adopted on next startup (no restart churn).

Executor gains generic `list_pods(label_selector)`, `handle_for(name)`, `read_logs(name)`, and `annotations` on `run_container` (k8s → pod annotations; Docker → folded into labels). Implemented for both runtimes.

## Behavior changes to flag for review

- Backend shutdown/rollout now **leaves graders running** (intentional — they get adopted). Previously every grader was killed on shutdown.
- `restart_existing` is gone from `reconcile()` and the `grader_definition_changed` path.

## Testing

`bbr test //props/orchestration:test_grader_supervisor` — PASS. The suite now drives a `FakeRegistry` simulating the pod list + spawn/adopt/reap, covering: adopt-orphan-without-respawn (restart safety), reap duplicate / removed-snapshot / wrong-image / terminal, idempotent keep, debounce. Also ran `//props/orchestration:test_agent_registry` and `:test_k8s_executor`; `bbr build //props/...` is green (mypy clean across both executors + callers).

## Follow-up

The `DockerExecutor` path (and the annotations-fold-into-labels special-casing) exists only because local dev/e2e use Docker; a local **kind** cluster would let everything run against a real k8s API and retire that duplication. Out of scope here.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_