### PR TITLE
augur: capture TLH follow-ups in sim TODO; mark Pieces 1 & 2 shipped

### DIFF
--- a/augur/plans/tax_loss_harvesting.md
+++ b/augur/plans/tax_loss_harvesting.md
@@ -1,13 +1,15 @@
 # Tax-loss harvesting (TLH) in Augur
 
-Status: 2026-06-04. Piece 1 (capital-loss netting + carryforward) landed
-(ducktape #1846). Piece 2: Step 2a (yield core, `augur/sim/tlh_harvest.py`) landed; Step 2b
-(engine integration) implemented — config `HarvestProcessConfig` →
-`Scenario.harvest_policies` → compiled `harvest_policies` table (`augur/sim/compiler/tlh_harvest.py`)
-→ engine phase `_apply_tlh_harvest` + sale-time basis give-back in
-`_record_capital_gains` (`augur/sim/engine/phases.py`), with the per-(policy, rollout)
-`tlh_cumulative_harvest` scalar in `augur/sim/buffers.py`. The basis-reset design fork below
-was resolved as option **(B)** (scalar, not extra lot slots).
+Status: 2026-06-04. **Pieces 1 & 2 shipped.** Piece 1 (capital-loss netting +
+carryforward, ducktape #1846). Piece 2 (reduced-form harvest, ducktape #1881):
+yield core `augur/sim/tlh_harvest.py` → `reduced_form_tlh` config (`tlh_model`) →
+`Scenario.harvest_policies` → compiled table (`augur/sim/compiler/tlh_harvest.py`) →
+engine phase `_apply_tlh_harvest` + sale-time basis give-back in `_record_capital_gains`
+(`augur/sim/engine/phases.py`), threaded through the product path; the per-(policy,
+rollout) `tlh_cumulative_harvest` scalar lives in `augur/sim/buffers.py`. The basis-reset
+design fork below was resolved as option **(B)** (scalar, not extra lot slots). The live
+Wealthfront sleeve is wired in gaffer-private (#244). Remaining follow-ups now tracked in
+<../sim/TODO.md>.
 
 ## Motivation
 

--- a/augur/sim/TODO.md
+++ b/augur/sim/TODO.md
@@ -6,12 +6,24 @@ Anything fully shipped is removed — git history is the record of done work.
 
 ## Architecture / cutover
 
-- **Capital-loss netting + carryforward (TLH Piece 1).** The bracket walks in
-  `tax.py` clamp negative taxable amounts to zero and no cross-year capital
-  state exists, so realized losses evaporate. Add §1211/§1212 mechanics:
-  net ST/LT losses against gains, $3k/yr ordinary offset, per-`(rollout, agent)`
-  carryforward. Prerequisite for tax-loss-harvesting modeling and a correctness
-  fix for existing OpenAI/IBKR sales. See <plans/tax_loss_harvesting.md>.
+- **TLH follow-ups.** Pieces 1 (capital-loss netting + carryforward, #1846) and 2
+  (reduced-form harvest process, #1881) shipped. Remaining, in rough priority:
+  - **Re-fit the decay annually.** The `reduced_form_tlh` decay params are
+    `[HEURISTIC]` — the account opened in 2025, so there's no prior-year 1099-B to
+    fit decay; the curve shape is an external prior ([VANGUARD-2024]). As TY2026+
+    forms arrive, fit the decay; replace the heuristic with a fitted rate once ≥2
+    forms exist. See <plans/tax_loss_harvesting.md>.
+  - **`representative_sleeve_tlh` variant (plan option #3 — the honest model).**
+    A sibling of the `reduced_form_tlh` discriminator: ~5–10 representative sleeves
+    (index factor + scaled idiosyncratic noise) running real FIFO harvesting on
+    sub-lots, so losses emerge from actual below-basis names instead of a calibrated
+    yield. Build only if a decision turns on harvesting behavior in a regime unlike
+    the TY2025 calibration window. (Never build option #4, the full factor model.)
+  - **Surface `tlh_cumulative_harvest` in output frames.** It's internal engine
+    state today (the per-`(policy, rollout)` basis give-back accumulator); add a
+    codec/decoder if we want harvested-loss visibility in the rollout detail / UI.
+  - **Wash-sale gate.** Not modeled — TY2025 had zero wash sales, so the continuous
+    replacement-buying assumption holds; revisit if the sleeve's behavior changes.
 
 - Replace the `dense.decode()` → `SimulationRun` polars materialization
   step on the rollout-detail endpoint with `ProjectionRun` read models


### PR DESCRIPTION
Docs-only. TLH Pieces 1 (#1846) and 2 (#1881) shipped, and the live Wealthfront sleeve is wired in gaffer-private (#244), so:

- **`augur/sim/TODO.md`** — replace the now-done Piece-1 entry with the remaining TLH follow-ups:
  - re-fit the `reduced_form_tlh` decay annually as TY2026+ 1099-Bs arrive (params are `[HEURISTIC]` — no prior-year form exists);
  - the honest `representative_sleeve_tlh` variant (plan option #3 — representative sleeves + real FIFO harvesting), build only if a decision turns on it; never build option #4;
  - surface `tlh_cumulative_harvest` in output frames (codec/decoder) for harvested-loss visibility;
  - wash-sale gate (not modeled; TY2025 had zero, revisit if behavior changes).
- **`augur/plans/tax_loss_harvesting.md`** — refresh the status block (Pieces 1 & 2 shipped, gaffer wired) and point live follow-ups at the sim TODO; fix the stale `HarvestProcessConfig` reference to the shipped `tlh_model` / `reduced_form_tlh` config.

No code changes.

https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4)_