### PR TITLE
props/llm_proxy: standalone LLM proxy service + deploy (running, not yet cut over)

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -80,6 +80,7 @@ jobs:
             }
           - { image: "//mcp_infra/exec:direct_image", image_name: exec-backend, test_target: "//mcp_infra/exec/..." }
           - { image: "//props/backend:image", image_name: props-backend, test_target: "//props/backend/..." }
+          - { image: "//props/llm_proxy:image", image_name: props-llm-proxy, test_target: "//props/llm_proxy/..." }
           - { image: "//tana/firebase_resigner:image", image_name: tana-firebase-resigner, test_target: "" }
           - {
               image: "//x/mcp_oauth_facade:image",

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - props-backend-image-repository.yaml
   - props-backend-image-policy.yaml
+  - props-llm-proxy-image-repository.yaml
+  - props-llm-proxy-image-policy.yaml
   - image-update-automation.yaml
   - openclaw-image-repository.yaml
   - openclaw-image-policy.yaml

--- a/cluster/k8s/flux-image-automation-ghcr/props-llm-proxy-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/props-llm-proxy-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: props-llm-proxy
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: props-llm-proxy
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/props-llm-proxy-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/props-llm-proxy-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: props-llm-proxy
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/props-llm-proxy
+  interval: 5m

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -67,6 +67,9 @@ spec:
       name: props-backend
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
+      name: props-llm-proxy
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
       name: manifold-mcp-server
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/props/app/kustomization.yaml
+++ b/cluster/k8s/props/app/kustomization.yaml
@@ -14,5 +14,7 @@ resources:
   - rbac-executor.yaml
   - deployment.yaml
   - service.yaml
+  - llm-proxy-deployment.yaml
+  - llm-proxy-service.yaml
   - httproute.yaml
   - rolebinding-ollama-consumer.yaml

--- a/cluster/k8s/props/app/llm-proxy-deployment.yaml
+++ b/cluster/k8s/props/app/llm-proxy-deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: props-llm-proxy
+  namespace: props
+  annotations:
+    reloader.stakater.com/auto: "true"
+    description: >-
+      LLM proxy data plane — serves /v1/responses for agents (auth + budget +
+      cost + upstream routing), split out of the props backend so the
+      dashboard/API can roll without disrupting in-flight agents.
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: props
+      app.kubernetes.io/name: props-llm-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: llm-proxy
+        app.kubernetes.io/instance: props
+        app.kubernetes.io/name: props-llm-proxy
+    spec:
+      # The proxy never touches the k8s API (unlike the backend's orchestration).
+      automountServiceAccountToken: false
+      nodeSelector:
+        topology.kubernetes.io/zone: hil-ovh
+      containers:
+        - name: llm-proxy
+          image: ghcr.io/agentydragon/props-llm-proxy:devel-00000000000000-0000000 # {"$imagepolicy": "flux-system:props-llm-proxy"}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          env:
+            - name: PROPS_CONFIG_FILE
+              value: /etc/props/config.toml
+            - name: PGHOST
+              value: props-db-rw
+            - name: PGPORT
+              value: "5432"
+            - name: PGDATABASE
+              value: eval_results
+            - name: PGUSER
+              value: props
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: props-db-app
+                  key: password
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: props-openai-api-key
+                  key: api-key
+            - name: OLLAMA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-master-key
+                  key: api-key
+            # Auth for the in-cluster LiteLLM upstream (config.toml [upstreams.litellm]).
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-master-key
+                  key: api-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/props
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          # No slow startup (just DB + config wiring), so readiness is immediate.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: props-config

--- a/cluster/k8s/props/app/llm-proxy-service.yaml
+++ b/cluster/k8s/props/app/llm-proxy-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: props-llm-proxy
+  namespace: props
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/component: llm-proxy
+    app.kubernetes.io/instance: props
+    app.kubernetes.io/name: props-llm-proxy

--- a/props/docs/plans/k8s_native_execution.md
+++ b/props/docs/plans/k8s_native_execution.md
@@ -104,6 +104,19 @@ earlier ones only where noted.
 - **Done when:** rolling the API server does not interrupt an in-flight agent's
   LLM calls; transcripts are queryable from the DB.
 - **Risk:** low. Pure extraction of an existing chokepoint.
+- **TODO — split the config.** The proxy needs only `upstreams` (+ DB and the
+  upstream API-key envs). `backend_url`, `grader_model`, `executor`,
+  `auto_migrate`/`auto_sync_specimens`, `agent_env`, `models`, and the specimens
+  are API-server-only — and the proxy reads model routing from the DB
+  `ModelMetadata` table (synced by the API server), not `config.models`. The
+  initial split reuses the full `PropsConfig` and reads only `.upstreams`; follow
+  up by carving `PropsConfig` into shared / proxy-only / api-only shapes so each
+  service gets a minimal config (the proxy ideally just `upstreams`), and mount
+  the proxy a slimmer `config.toml`.
+- **Sub-PRs:** (1) the standalone proxy app + `oci_image` + test (no deploy);
+  (2) deploy (Deployment + Service + image automation + `push-images` row),
+  running but unused; (3) cutover — repoint `OPENAI_BASE_URL` via a new
+  `llm_proxy_url` and drop the `/v1` mount from the backend.
 
 ### Stage 2 — Agent-readable logs (transcript + Loki)
 

--- a/props/llm_proxy/BUILD.bazel
+++ b/props/llm_proxy/BUILD.bazel
@@ -1,0 +1,83 @@
+"""Standalone LLM proxy — the agent data plane (only /v1/responses), split out of
+the unified backend so the dashboard/API can roll without disrupting agents.
+
+Reuses the backend's `llm` router + auth + deps; the image bundles just the
+binary (no frontend, no specimens, no orchestration)."""
+
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "app",
+    srcs = ["app.py"],
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        "//props:config",
+        "//props/backend/routes:llm",
+        "//props/db:config",
+        "//props/db:database",
+        "//util:logging",
+        "@pypi//fastapi",
+    ],
+)
+
+py_library(
+    name = "cli",
+    srcs = ["cli.py"],
+    visibility = ["//props:__subpackages__"],
+    deps = [
+        ":app",
+        "@pypi//typer",
+        "@pypi//uvicorn",
+    ],
+)
+
+py_test(
+    name = "test_app",
+    srcs = ["test_app.py"],
+    deps = [
+        ":app",
+        "//props:config",
+        "@pypi//fastapi",
+        "@pypi//httpx",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+# =============================================================================
+# OCI Image
+# =============================================================================
+
+# Container-specific binary using aspect_rules_py (py_image_layer requires it).
+aspect_py_binary(
+    name = "llm_proxy_bin",
+    main = "cli.py",
+    visibility = ["//props:__subpackages__"],
+    deps = [":cli"],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":llm_proxy_bin",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("llm_proxy_bin") + [
+        "serve",
+        "--host",
+        "0.0.0.0",
+    ],
+    env = py_image_env(),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [":layers"],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["props-llm-proxy:latest"],
+)

--- a/props/llm_proxy/app.py
+++ b/props/llm_proxy/app.py
@@ -1,0 +1,62 @@
+"""Standalone LLM proxy app — the agent **data plane**, split out of the unified
+backend so the dashboard/API can roll without disrupting in-flight agents.
+
+Serves only ``/v1/responses`` (auth + budget + cost + upstream routing). It reuses
+the backend's ``llm`` router, ``auth``, and ``deps`` unchanged — no frontend,
+orchestration, registry proxy, or SSO. The router's only app-state requirements
+are ``admin_db`` (a ``Database`` admin pool, for auth + budget/cost/upstream
+queries) and ``config`` (``PropsConfig``, for upstream routing); the SSO/session
+branch of ``get_request_identity`` is inert here because no ``SessionMiddleware``
+is installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+from props.backend.routes import llm
+from props.config import PropsConfig, load_config_from_env
+from props.db.config import DatabaseConfig
+from props.db.database import Database
+from util.logging import LogLevel, configure_logging
+
+configure_logging(
+    log_output=os.environ.get("PROPS_LOG_OUTPUT", "stderr"), log_level=os.environ.get("PROPS_LOG_LEVEL", LogLevel.INFO)
+)
+logger = logging.getLogger(__name__)
+
+
+def create_app(*, db: Database | None = None, config: PropsConfig | None = None) -> FastAPI:
+    """Build the LLM proxy app.
+
+    `db`/`config` are injected in tests; in production they are loaded from the
+    environment (``PG*`` for the DB, ``PROPS_CONFIG_FILE`` for the config).
+    """
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.admin_db = db or Database(DatabaseConfig())
+        app.state.config = config or load_config_from_env()
+        logger.info("LLM proxy ready")
+        yield
+
+    app = FastAPI(title="props-llm-proxy", lifespan=lifespan)
+    app.include_router(llm.router)
+
+    # The proxy has no slow startup (just DB + config wiring), so readiness is
+    # equivalent to liveness.
+    @app.get("/health", response_class=PlainTextResponse)
+    async def health() -> str:
+        return "ok"
+
+    @app.get("/readyz", response_class=PlainTextResponse)
+    async def readyz() -> str:
+        return "ok"
+
+    return app

--- a/props/llm_proxy/cli.py
+++ b/props/llm_proxy/cli.py
@@ -1,0 +1,29 @@
+"""LLM proxy entrypoint: `serve` starts the uvicorn server."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+import uvicorn
+
+from props.llm_proxy.app import create_app
+
+cli = typer.Typer()
+
+
+@cli.command()
+def serve(
+    host: Annotated[str, typer.Option(help="Host to bind to")] = "127.0.0.1",
+    port: Annotated[int, typer.Option(help="Port to bind to")] = 8000,
+) -> None:
+    """Start the LLM proxy server."""
+    uvicorn.run(create_app(), host=host, port=port)
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/props/llm_proxy/test_app.py
+++ b/props/llm_proxy/test_app.py
@@ -1,0 +1,40 @@
+"""Smoke test: the standalone LLM proxy app assembles and enforces auth.
+
+Routing/budget logic is covered by the router's own helper tests
+(`props/backend/routes/test_llm_*`); this verifies the split-out app wires the
+`llm` router + auth dependency correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest_bazel
+from fastapi.testclient import TestClient
+
+from props.config import PropsConfig
+from props.llm_proxy.app import create_app
+
+
+def _client() -> TestClient:
+    config = PropsConfig(backend_url="http://test", agent_env={})
+    # The auth-rejection paths below never touch the DB, so a MagicMock suffices.
+    return TestClient(create_app(db=MagicMock(), config=config), raise_server_exceptions=False)
+
+
+def test_health_ok() -> None:
+    with _client() as client:
+        assert client.get("/health").text == "ok"
+        assert client.get("/readyz").status_code == 200
+
+
+def test_responses_requires_auth() -> None:
+    """An unauthenticated /v1/responses call is 401 — proving the proxy reuses the
+    backend auth dependency rather than serving the route unguarded."""
+    with _client() as client:
+        resp = client.post("/v1/responses", json={"model": "x", "input": "hi"})
+        assert resp.status_code == 401
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
Plan Stage 1 — split the agent **data plane** (the LLM proxy) out of the unified backend so the dashboard/API can roll without disrupting in-flight agents. Bundles **sub-PRs 1 (artifact) + 2 (deploy)**; the **cutover is deliberately deferred** so the proxy bakes before anything depends on it.

## Artifact (`props/llm_proxy/`)

- `app.py` — a small FastAPI app serving only `/v1/responses`, **reusing the backend's `llm` router + `auth` + `deps` unchanged**; lifespan wires `app.state.admin_db` (admin DB pool) + `app.state.config` (`PropsConfig`). No frontend, orchestration, registry proxy, or SSO; the SSO/session branch of `get_request_identity` is inert without `SessionMiddleware`, so agent Bearer-token auth still resolves to an `AgentRole`.
- `cli.py` — uvicorn `serve` entrypoint; `:image` — a **lean `oci_image`** (binary only).
- `test_app.py` — smoke test: `/health` ok + unauthenticated `/v1/responses` → 401.

## Deploy (running but unused)

- `cluster/k8s/props/app/llm-proxy-{deployment,service}.yaml` — Deployment + Service in `props`, reusing the `props-config` ConfigMap and DB/upstream secrets with a **slimmed env** (PG\* + OPENAI/OLLAMA/LITELLM keys only) and `automountServiceAccountToken: false` (never touches the k8s API).
- Flux image automation (`ImageRepository`/`ImagePolicy` + webhook receiver) + a `push-images.yml` matrix row that builds/publishes `ghcr.io/agentydragon/props-llm-proxy`.
- The image tag is a placeholder until CI publishes the first image post-merge and Flux updates it. The props flux-kustomization healthcheck still gates only on the backend Deployment, so the pending proxy pod won't block reconciliation.

**Nothing routes to it yet** — agents still use the backend's `/v1`.

## Deferred — sub-PR 3 (cutover)

Add `llm_proxy_url`, repoint agents' `OPENAI_BASE_URL` at the proxy Service, drop the `/v1` mount from the backend. Plus the recorded **config-split TODO** (the proxy needs only `upstreams` + DB; the rest of `PropsConfig` is API-server-only).

`bbr test //props/llm_proxy/...` green; kubeconform + cluster validation pass on the manifests.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o