### PR TITLE
augur: fix bayesian_mint_streams calibration 500 — clamp public-market CDF to the horizon

### DIFF
--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -1105,7 +1105,10 @@ def _public_market_marginal_cdf(issuer: PrivateEquityRiskIssuerConfig, *, horizo
         survival_ratio = (1.0 - anchor.cumulative_probability) / max(1.0 - prev_cum, 1e-12)
         # Per-month survival factor that interpolates the anchor CDF exactly.
         per_month_survival = survival_ratio ** (1.0 / span)
-        for t in range(prev_month + 1, anchor.month + 1):
+        # Clamp the write loop to the horizon: an anchor month beyond `horizon_months` would
+        # index past `cdf` (length `horizon_months + 1`). `prev_month`/`prev_cum` still advance to
+        # the true anchor below so the flat-tail and later anchors stay anchored correctly.
+        for t in range(prev_month + 1, min(anchor.month, horizon_months) + 1):
             cdf[t] = 1.0 - (1.0 - prev_cum) * per_month_survival ** (t - prev_month)
         prev_month, prev_cum = anchor.month, anchor.cumulative_probability
     # Flat tail past the last anchor.

--- a/augur/model/private_equity_risk_test.py
+++ b/augur/model/private_equity_risk_test.py
@@ -1146,6 +1146,28 @@ def test_public_market_marginal_cdf_without_anchors_is_flat_hazard() -> None:
     assert cdf[12] == pytest.approx(expected_cdf_12, rel=1e-9)
 
 
+def test_public_market_marginal_cdf_horizon_shorter_than_largest_anchor() -> None:
+    """A horizon shorter than the largest anchor month must not index past `cdf` (regression for
+    the `bayesian_mint_streams` preset crashing at short calibration horizons): the write loop is
+    clamped to the horizon while `prev_month`/`prev_cum` keep advancing to the true anchor."""
+
+    issuer = _mint_streams_issuer(
+        public_market_cdf_anchors=(
+            PublicMarketCdfAnchor(month=12, cumulative_probability=0.30),
+            PublicMarketCdfAnchor(month=36, cumulative_probability=0.70),
+        ),
+        annual_public_market_probability=0.05,
+    )
+    # Horizon (24) sits between the two anchors (12 and 36); the second anchor is past the horizon.
+    cdf = _public_market_marginal_cdf(issuer, horizon_months=24)
+    assert cdf.shape == (25,)
+    assert cdf[0] == 0.0
+    assert cdf[12] == pytest.approx(0.30, abs=1e-9)
+    # Monotone non-decreasing all the way to the horizon, partway up the 12->36 anchor segment.
+    assert np.all(np.diff(cdf) >= -1e-12)
+    assert 0.30 < cdf[24] < 0.70
+
+
 def test_legacy_bayesian_central_trajectory_collapses() -> None:
     """Documents the defect that motivated the mint-streams model: with a flat 28%/yr smooth
     dilution + scale-reverting V drift, the central 10y per-share mark collapses despite V


### PR DESCRIPTION
## What

Root-cause fix for the `/api/calibration/run` **500 (`IndexError: index 2 is out of bounds for axis 0 with size 2`)** seen with the `bayesian_mint_streams` preset.

`_public_market_marginal_cdf` (`augur/model/private_equity_risk.py`) allocates `cdf` of length `horizon_months + 1`, but its anchor loop wrote `cdf[t]` up to each `public_market_cdf_anchor.month`. When an issuer's IPO anchor month exceeds the sampling horizon, the write runs off the end. Scrolling the Calibration tab's chart wheel down to a short horizon drove the sample at `horizon_months=1` → `cdf` size 2 → `cdf[2]` overflow. Only `bayesian_mint_streams` hit it (the only preset whose PE issuer carries explicit `public_market_cdf_anchors` routed through the rounds path).

## Fix

Clamp the write loop to `min(anchor.month, horizon_months) + 1`; `prev_month`/`prev_cum` still advance to the true anchor so the flat tail and subsequent anchors stay anchored correctly. Now **no** caller can overflow it — calibration at any horizon, a direct API request, or any future short-horizon sampler.

Regression test (`private_equity_risk_test.py`): samples a `public_market_cdf_anchors` issuer at a horizon between two anchors (12 / 36, horizon 24) and asserts no raise + a monotone CDF of length `horizon+1`.

## Note on the UI

The Calibration tab's UI symptom is independently handled by #1885 (already on devel), which pins calibration sampling to the deployment max horizon and removes the wheel zoom from the calibration fans — so the tab no longer issues short-horizon runs. This PR is the **defense-in-depth root-cause fix** so the function is safe regardless of caller.

## Test plan

- [x] `bbr build //augur/...` — clean (lint + mypy)
- [x] `bbr test //augur/model:private_equity_risk_test` — pass (incl. the new regression test)

https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZqWEw2nP8z4vajVovtjE4)_