### PR TITLE
augur/model: clamp public-market CDF anchors to the projection horizon

### DIFF
--- a/augur/model/private_equity_risk.py
+++ b/augur/model/private_equity_risk.py
@@ -1105,7 +1105,10 @@ def _public_market_marginal_cdf(issuer: PrivateEquityRiskIssuerConfig, *, horizo
         survival_ratio = (1.0 - anchor.cumulative_probability) / max(1.0 - prev_cum, 1e-12)
         # Per-month survival factor that interpolates the anchor CDF exactly.
         per_month_survival = survival_ratio ** (1.0 / span)
-        for t in range(prev_month + 1, anchor.month + 1):
+        # Clamp to the horizon: an anchor month past `horizon_months` (e.g. a 31-month anchor on
+        # a 12-month projection) must not index past the `horizon_months + 1`-length array. The
+        # partial span up to the horizon is still interpolated correctly off this anchor's rate.
+        for t in range(prev_month + 1, min(anchor.month, horizon_months) + 1):
             cdf[t] = 1.0 - (1.0 - prev_cum) * per_month_survival ** (t - prev_month)
         prev_month, prev_cum = anchor.month, anchor.cumulative_probability
     # Flat tail past the last anchor.

--- a/augur/model/private_equity_risk_test.py
+++ b/augur/model/private_equity_risk_test.py
@@ -1146,6 +1146,32 @@ def test_public_market_marginal_cdf_without_anchors_is_flat_hazard() -> None:
     assert cdf[12] == pytest.approx(expected_cdf_12, rel=1e-9)
 
 
+def test_public_market_marginal_cdf_horizon_shorter_than_last_anchor() -> None:
+    """A horizon shorter than the last anchor month must not index past the CDF array.
+
+    Regression: the openai anchors are at months 7/19/31, but a 12-month projection only has a
+    13-element CDF; the anchors past the horizon previously overran the array (IndexError),
+    crashing any short-horizon sample of the mint-streams model.
+    """
+
+    issuer = _mint_streams_issuer(
+        public_market_cdf_anchors=(
+            PublicMarketCdfAnchor(month=7, cumulative_probability=0.75),
+            PublicMarketCdfAnchor(month=19, cumulative_probability=0.89),
+            PublicMarketCdfAnchor(month=31, cumulative_probability=0.93),
+        ),
+        annual_public_market_probability=0.07,
+    )
+    cdf = _public_market_marginal_cdf(issuer, horizon_months=12)
+    assert cdf.shape == (13,)
+    assert cdf[0] == 0.0
+    # The in-horizon anchor is hit exactly; months past it interpolate off that anchor's rate
+    # into the (7, 19] span — strictly increasing, still below the next (past-horizon) anchor.
+    assert cdf[7] == pytest.approx(0.75, abs=1e-9)
+    assert cdf[7] < cdf[12] < 0.89
+    assert np.all(np.diff(cdf) >= 0.0)
+
+
 def test_legacy_bayesian_central_trajectory_collapses() -> None:
     """Documents the defect that motivated the mint-streams model: with a flat 28%/yr smooth
     dilution + scale-reverting V drift, the central 10y per-share mark collapses despite V


### PR DESCRIPTION
## What

Fix an `IndexError` in `_public_market_marginal_cdf` (the mint-streams PE sampler's
public-market CDF builder) when the projection horizon is shorter than the last IPO anchor.

## Why

The function fills a `horizon_months + 1`-length CDF array, looping `for t in range(prev_month
+ 1, anchor.month + 1)` per anchor — but never clamped `anchor.month` to the horizon. The
OpenAI IPO anchors are at months **7 / 19 / 31**, so any projection shorter than 31 months
overran the array:

```
IndexError: index 13 is out of bounds for axis 0 with size 13   # 12-month horizon
```

This crashed **every short-horizon sample of the mint-streams model**. It surfaced when wiring
`structural_mint_streams` (the renamed `bayesian_mint_streams`) as gaffer's default model:
`gaffer_augur:config_test` samples the default model on a 12-month horizon. The other models
draw IPO times via the regime sampler (`_public_market_open_hazard_by_month`, which already
clamps), so only the mint-streams marginal-CDF path was affected.

## How

Clamp the per-anchor fill loop to `min(anchor.month, horizon_months)`. The partial span up to
the horizon is still interpolated correctly off that anchor's rate; anchors entirely past the
horizon contribute nothing to the in-horizon array.

## Tests

Added `test_public_market_marginal_cdf_horizon_shorter_than_last_anchor` — samples the function
with the 7/19/31 anchors on a 12-month horizon and asserts no overrun, the in-horizon anchor is
hit exactly, the CDF stays monotonic, and post-anchor months interpolate below the next anchor.
`//augur/model:private_equity_risk_test` passes on RBE (ruff + mypy clean).

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw)_