### PR TITLE
props/llm_proxy: cut agents over to the proxy (keep backend /v1)

### DIFF
--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -1,6 +1,10 @@
 auto_migrate = true
 auto_sync_specimens = true
 backend_url = "http://props:8000"
+# Agents reach the LLM proxy (split out of the backend) here, not the dashboard,
+# so the API server can roll without disrupting in-flight agents. See
+# cluster/k8s/props/app/llm-proxy-deployment.yaml.
+llm_proxy_url = "http://props-llm-proxy:8000"
 # Default evaluator: the grader supervisor auto-grades critic runs with this
 # model. glm-4.6 (z.ai via LiteLLM) so grading runs without the home GPU host.
 grader_model = "glm-4.6"

--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -149,6 +149,7 @@ def _make_lifespan(deps: BackendDeps):
                 agent_base_env=deps.config.agent_env,
                 registry_config=deps.registry_proxy_config,
                 model_parallelism_limits=model_parallelism_limits,
+                llm_base_url=deps.config.llm_proxy_url,
             )
 
             if deps.grader_model:

--- a/props/config.py
+++ b/props/config.py
@@ -103,6 +103,9 @@ class PropsConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     backend_url: str
+    # Base URL agents use for the LLM proxy (split out of the backend); agents get
+    # OPENAI_BASE_URL = <llm_proxy_url>/v1. None falls back to backend_url.
+    llm_proxy_url: str | None = None
     grader_model: str | None = None
     agent_env: dict[str, str]
     upstreams: dict[str, UpstreamConfig] = {}

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -200,11 +200,16 @@ class AgentRegistry:
         agent_base_env: dict[str, str],
         registry_config: RegistryProxyConfig,
         model_parallelism_limits: dict[str, int] | None = None,
+        llm_base_url: str | None = None,
     ) -> None:
         self._executor = executor
         self._db = db
         self._db_config = db_config
         self._backend_url = backend_url
+        # Base URL agents use for the LLM proxy: OPENAI_BASE_URL = <this>/v1. The
+        # proxy is split out of the backend (props/llm_proxy); None falls back to
+        # the backend, which still serves /v1 for dev and not-yet-cycled agents.
+        self._llm_base_url = llm_base_url or backend_url
         self._agent_base_env = agent_base_env
         self._registry_config = registry_config
         # Track running background critic tasks by agent_run_id to prevent GC and allow lookup
@@ -333,7 +338,7 @@ class AgentRegistry:
             "PGUSER": creds.username,
             "PGPASSWORD": creds.password,
             "PROPS_BACKEND_URL": self._backend_url,
-            "OPENAI_BASE_URL": f"{self._backend_url}/v1",
+            "OPENAI_BASE_URL": f"{self._llm_base_url}/v1",
             "OPENAI_API_KEY": api_key,
         }
 

--- a/props/orchestration/test_agent_registry.py
+++ b/props/orchestration/test_agent_registry.py
@@ -156,5 +156,25 @@ async def test_collect_run_cancellation_finalizes_as_cancelled(db: Database) -> 
         assert run.container_exit_code is None
 
 
+def _registry_with(db: Database, *, llm_base_url: str | None) -> AgentRegistry:
+    return AgentRegistry(
+        executor=cast(Any, _FakeExecutor()),
+        db=db,
+        db_config=DatabaseConfig(host="h", port=5432, database="d", user="u", password="p"),
+        backend_url="http://b:8000",
+        agent_base_env={},
+        registry_config=RegistryProxyConfig(host="reg", port=8000),
+        llm_base_url=llm_base_url,
+    )
+
+
+def test_llm_base_url_falls_back_to_backend_url(db: Database) -> None:
+    """Agents' OPENAI_BASE_URL derives from llm_base_url; an unset value falls back
+    to backend_url, so the proxy cutover can't silently strand agents without an
+    LLM endpoint."""
+    assert _registry_with(db, llm_base_url=None)._llm_base_url == "http://b:8000"
+    assert _registry_with(db, llm_base_url="http://proxy:8000")._llm_base_url == "http://proxy:8000"
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
Plan Stage 1 — **sub-PR 3 (cutover)**, following #1886 (proxy artifact + deploy). Points production agents' LLM calls at the standalone `props-llm-proxy` Service instead of the dashboard backend, so the API server can roll without disrupting in-flight agents.

- `config.py`: add `PropsConfig.llm_proxy_url` (`None` falls back to `backend_url`).
- `agent_registry.py`: `AgentRegistry(llm_base_url=...)`; agents' `OPENAI_BASE_URL` is now `<llm_base_url>/v1`, falling back to `backend_url` when unset (dev / e2e).
- `app.py`: pass `llm_base_url=config.llm_proxy_url`.
- `config.toml`: point agents at `http://props-llm-proxy:8000`.

## Safety

- **The backend still serves `/v1`.** Already-running agents keep their old `OPENAI_BASE_URL`, and graders are long-lived — so dropping the `/v1` mount from the backend is a **follow-up** once agents have cycled onto the proxy.
- The `llm_base_url` fallback (`None → backend_url`) is unit-tested so the cutover can't silently strand agents without an LLM endpoint.

## ⚠️ Merge gate

Merge **only once the `props-llm-proxy` image is published and the pod is healthy in-cluster** (this PR points production agents at it). I'm monitoring the #1886 rollout and will confirm when it's cutover-ready.

`bbr test //props/orchestration:test_agent_registry` green; libs build clean.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_