### PR TITLE
cluster/props: grant props-executor pods 'list' (fix grader reconcile crash-loop)

### DIFF
--- a/cluster/k8s/props/app/rbac-executor.yaml
+++ b/cluster/k8s/props/app/rbac-executor.yaml
@@ -11,8 +11,10 @@ metadata:
   namespace: props
 rules:
   - apiGroups: [""]
+    # list: the GraderSupervisor reconciles graders by listing pods by label
+    # (reconcile-from-API), so it survives restarts and reaps duplicates/orphans.
     resources: ["pods"]
-    verbs: ["create", "get", "delete"]
+    verbs: ["create", "get", "list", "delete"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]


### PR DESCRIPTION
**Regression fix for #1882.** Found while monitoring the rollout: the merged grader controller is crash-looping in-cluster.

#1882 made the `GraderSupervisor` reconcile against the k8s API (`list_namespaced_pod` by label — the reconcile-from-API you asked for), but the `props-executor` Role only had `pods: [create, get, delete]`. So every reconcile dies with:

```
ApiException: (403) pods is forbidden:
User "system:serviceaccount:props:props-executor" cannot list resource "pods" in namespace "props"
```

Effect: no graders are spawned/adopted/reaped, and the pre-#1882 duplicate graders are frozen (0 pods carry the new `adgn.agent_type=grader` label). Fix: add the missing `list` verb (namespace-scoped, the controller already has create/get/delete + `pods/log` get).

Once this deploys, the controller's reconcile runs: it spawns the new labeled graders. The old **unlabeled** graders remain orphans the new controller can't see — same migration as before, so you can delete the leftovers then (I'll confirm when labeled graders appear).

kubeconform + cluster validation pass.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_