### PR TITLE
props/llm_proxy: fix CLI so `serve` is a real subcommand (proxy crash-loop)

### DIFF
--- a/props/llm_proxy/BUILD.bazel
+++ b/props/llm_proxy/BUILD.bazel
@@ -39,10 +39,12 @@ py_test(
     srcs = ["test_app.py"],
     deps = [
         ":app",
+        ":cli",
         "//props:config",
         "@pypi//fastapi",
         "@pypi//httpx",
         "@pypi//pytest_bazel",
+        "@pypi//typer",
     ],
 )
 

--- a/props/llm_proxy/cli.py
+++ b/props/llm_proxy/cli.py
@@ -9,7 +9,15 @@ import uvicorn
 
 from props.llm_proxy.app import create_app
 
-cli = typer.Typer()
+cli = typer.Typer(help="props LLM proxy")
+
+
+# A callback forces typer to treat `serve` as a required subcommand. Without it a
+# single-command Typer collapses into a no-subcommand app and rejects the `serve`
+# argument the image entrypoint passes ("Got unexpected extra argument (serve)").
+@cli.callback()
+def _root() -> None:
+    """props LLM proxy — the agent data plane (/v1/responses)."""
 
 
 @cli.command()

--- a/props/llm_proxy/test_app.py
+++ b/props/llm_proxy/test_app.py
@@ -11,9 +11,11 @@ from unittest.mock import MagicMock
 
 import pytest_bazel
 from fastapi.testclient import TestClient
+from typer.testing import CliRunner
 
 from props.config import PropsConfig
 from props.llm_proxy.app import create_app
+from props.llm_proxy.cli import cli
 
 
 def _client() -> TestClient:
@@ -34,6 +36,14 @@ def test_responses_requires_auth() -> None:
     with _client() as client:
         resp = client.post("/v1/responses", json={"model": "x", "input": "hi"})
         assert resp.status_code == 401
+
+
+def test_serve_is_a_subcommand() -> None:
+    """The image entrypoint runs `serve <args>`; a single-command Typer (no
+    callback) rejects `serve` as an unexpected argument — the prod crash this
+    guards against."""
+    result = CliRunner().invoke(cli, ["serve", "--help"])
+    assert result.exit_code == 0, result.output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Fixes the props-llm-proxy crash-loop** (regression in #1886's proxy). The image built and deployed, but the container crash-loops on startup:

```
Usage: cli.py [OPTIONS]
Error: Got unexpected extra argument (serve)
```

The image entrypoint runs `serve --host 0.0.0.0`, but a `typer.Typer()` with a **single** `@command()` collapses into a no-subcommand app and rejects the command name. The backend's `serve` works because it registers a `cli.callback()`. Fix: add a callback so `serve` is a required subcommand, and add a `CliRunner` test that invokes `serve --help` to guard the entrypoint contract (this would have caught it — the smoke test only exercised `create_app()`, not the CLI).

Once merged + the image rebuilds + Flux rolls it, the proxy pod should go Ready — then the cutover (#1890) is unblocked.

`bbr test //props/llm_proxy:test_app` green.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_