### PR TITLE
augur: support file includes for the macro provider and budget config

### DIFF
--- a/augur/api/BUILD.bazel
+++ b/augur/api/BUILD.bazel
@@ -81,6 +81,7 @@ py_library(
         ":wire",
         "//augur/budget:schema",
         "//augur/model:provider_config",
+        "//augur/model:provider_includes",
         "//augur/product:wire",
         "@pypi//pydantic",
         "@pypi//pyyaml",
@@ -134,6 +135,8 @@ py_test(
         "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
+        "@pypi//types_pyyaml",
     ],
 )
 

--- a/augur/api/config.py
+++ b/augur/api/config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import Field, HttpUrl, PositiveInt, model_validator
@@ -28,6 +29,7 @@ from augur.api.schemas import ApiModel
 from augur.api.wire import ActorRole, ProductInputDefaults
 from augur.budget.schema import BudgetConfig
 from augur.model.provider_config import CompositeProviderConfig, MirroringProviderConfig, ProviderConfig
+from augur.model.provider_includes import resolve_provider_includes
 from augur.model.state_space import StateSpaceProviderConfig
 from augur.model.trained_private_equity import TrainedPrivateEquityProviderConfig
 from augur.model.vecm import VecmProviderConfig
@@ -195,13 +197,31 @@ class Config(ApiModel):
 def load_augur_config(path: Path) -> Config:
     """Parse + validate a Config from a YAML file.
 
-    Relative deployment-owned file paths are anchored against the yaml's parent
-    directory — useful for ConfigMap mounts where the yaml and adjacent data live
-    side-by-side (e.g. `/etc/augur/{config.yaml,properties.json}`)."""
-    config = Config.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
+    Before validation, `{provider_config_path: <file>}` provider refs (e.g. the shared macro)
+    and a top-level `budget_path` are inlined from their sibling files, so large shared/split
+    sections live in one place. Relative deployment-owned file paths are then anchored against
+    the yaml's parent directory — useful for ConfigMap mounts where the yaml and adjacent data
+    live side-by-side (e.g. `/etc/augur/{config.yaml,properties.json}`)."""
+    raw = resolve_provider_includes(yaml.safe_load(path.read_text(encoding="utf-8")), base_dir=path.parent)
+    raw = _inline_budget_path(raw, base_dir=path.parent)
+    config = Config.model_validate(raw)
     config = _anchor_property_source_paths(config, base_dir=path.parent)
     config = _anchor_model_paths(config, base_dir=path.parent)
     return _anchor_calibration_catalog_paths(config, base_dir=path.parent)
+
+
+def _inline_budget_path(raw: Any, *, base_dir: Path) -> Any:
+    """Inline a top-level `budget_path: <file>` into the `budget` key from its sibling file, so
+    the (large, per-deployment) transaction-categorization config can live in its own file."""
+    if not isinstance(raw, dict) or "budget_path" not in raw:
+        return raw
+    if raw.get("budget") is not None:
+        raise ValueError("config sets both `budget` and `budget_path`; provide exactly one")
+    raw = dict(raw)
+    budget_ref = Path(raw.pop("budget_path"))
+    budget_path = budget_ref if budget_ref.is_absolute() else base_dir / budget_ref
+    raw["budget"] = yaml.safe_load(budget_path.read_text(encoding="utf-8"))
+    return raw
 
 
 def _anchor_calibration_catalog_paths(config: Config, *, base_dir: Path) -> Config:

--- a/augur/api/config_test.py
+++ b/augur/api/config_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import pytest_bazel
+import yaml
 from pydantic import ValidationError
 
 from augur.api.config import (
@@ -388,6 +389,58 @@ def test_relative_property_source_paths_anchor_against_yaml_dir(tmp_path: Path, 
         str(reloaded.property_source.property_assets[0].image_url)
         == "https://cdn.example.com/augur/location-a-hero.jpg"
     )
+
+
+_MINIMAL_BUDGET = {
+    "source": {},
+    "buckets": [
+        {"id": "rent", "label": "Rent", "kind": "expense", "direction": "outflow"},
+        {"id": "income", "label": "Income", "kind": "income", "direction": "inflow"},
+    ],
+    "default_outflow_bucket_id": "rent",
+    "default_inflow_bucket_id": "income",
+    "include_default_rules": False,
+}
+
+
+def _write_config_with_raw_overrides(tmp_path: Path, minimal_config: MinimalConfig, **overrides: object) -> Path:
+    """Dump a minimal config to YAML, apply raw-dict overrides (to inject loader-only keys the
+    Pydantic model wouldn't accept, e.g. `budget_path`), and write it for `load_augur_config`."""
+    raw = yaml.safe_load(dump_augur_config_yaml(minimal_config()))
+    raw.update(overrides)
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    return path
+
+
+def test_budget_path_inlines_budget_from_sibling_file(tmp_path: Path, minimal_config: MinimalConfig) -> None:
+    (tmp_path / "budget.yaml").write_text(yaml.safe_dump(_MINIMAL_BUDGET), encoding="utf-8")
+    path = _write_config_with_raw_overrides(tmp_path, minimal_config, budget_path="budget.yaml")
+
+    config = load_augur_config(path)
+    assert config.budget is not None
+    assert {bucket.id for bucket in config.budget.buckets} == {"rent", "income"}
+
+
+def test_budget_and_budget_path_are_mutually_exclusive(tmp_path: Path, minimal_config: MinimalConfig) -> None:
+    path = _write_config_with_raw_overrides(tmp_path, minimal_config, budget_path="budget.yaml", budget=_MINIMAL_BUDGET)
+    with pytest.raises(ValueError, match="both `budget` and `budget_path`"):
+        load_augur_config(path)
+
+
+def test_model_macro_provider_config_path_is_inlined(tmp_path: Path, minimal_config: MinimalConfig) -> None:
+    (tmp_path / "macro.yaml").write_text("type: independent\n", encoding="utf-8")
+    model = {
+        "type": "composite",
+        "macro": {"provider_config_path": "macro.yaml"},
+        "private_equity": {"type": "private_equity_risk", "issuers": {"acme": {"current_mark_usd": 10.0}}},
+    }
+    path = _write_config_with_raw_overrides(tmp_path, minimal_config, models={"current_model": model})
+
+    config = load_augur_config(path)
+    provider = config.models[config.default_model_id]
+    assert isinstance(provider, CompositeProviderConfig)
+    assert isinstance(provider.macro, IndependentProviderConfig)
 
 
 if __name__ == "__main__":

--- a/augur/api/config_test.py
+++ b/augur/api/config_test.py
@@ -1,5 +1,5 @@
-"""Schema-level checks for Config. Verifies the contract a deployment
-must satisfy without exercising any actual file loading."""
+"""Checks for the Config contract a deployment must satisfy: schema-level validation plus
+`load_augur_config` file handling (YAML round-trip, `budget_path` / provider include inlining)."""
 
 from __future__ import annotations
 

--- a/augur/model/BUILD.bazel
+++ b/augur/model/BUILD.bazel
@@ -276,11 +276,31 @@ py_library(
 )
 
 py_library(
+    name = "provider_includes",
+    srcs = ["provider_includes.py"],
+    deps = [
+        "@pypi//pyyaml",
+    ],
+)
+
+py_test(
+    name = "provider_includes_test",
+    srcs = ["provider_includes_test.py"],
+    deps = [
+        ":provider_includes",
+        "//:conftest",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_library(
     name = "sample_sanity",
     srcs = ["sample_sanity.py"],
     deps = [
         ":exogenous",
         ":provider_config",
+        ":provider_includes",
         ":schemas",
         ":series",
         "//util/bazel:runfiles",

--- a/augur/model/provider_includes.py
+++ b/augur/model/provider_includes.py
@@ -1,0 +1,36 @@
+"""Resolve `{provider_config_path: <file>}` include nodes in raw provider/config YAML.
+
+A provider sub-tree shared across many places — e.g. the macro model reused by every model
+preset and by the sample-sanity fixture — should live in one file and be referenced, not
+copy-pasted (the copies drift). Before Pydantic validation, a mapping that is *exactly*
+`{provider_config_path: <file>}` is replaced wholesale by the YAML it points at (resolved
+relative to the including file's directory); the included file may itself contain such refs.
+Any other mapping/sequence is walked unchanged.
+
+Path fields *inside* an included provider (e.g. `trained_artifact_path`) stay relative and are
+anchored later against the root config's directory, so an included file and the artifacts it
+names must sit in the same flat directory as the including config — which is exactly how the
+deployment's ConfigMap mounts everything under `/etc/augur`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+INCLUDE_KEY = "provider_config_path"
+
+
+def resolve_provider_includes(node: Any, *, base_dir: Path) -> Any:
+    if isinstance(node, dict):
+        if set(node) == {INCLUDE_KEY}:
+            ref = Path(node[INCLUDE_KEY])
+            ref_path = ref if ref.is_absolute() else base_dir / ref
+            included = yaml.safe_load(ref_path.read_text(encoding="utf-8"))
+            return resolve_provider_includes(included, base_dir=ref_path.parent)
+        return {key: resolve_provider_includes(value, base_dir=base_dir) for key, value in node.items()}
+    if isinstance(node, list):
+        return [resolve_provider_includes(item, base_dir=base_dir) for item in node]
+    return node

--- a/augur/model/provider_includes_test.py
+++ b/augur/model/provider_includes_test.py
@@ -1,0 +1,49 @@
+"""Tests for `resolve_provider_includes`: pure `{provider_config_path: <file>}` refs are inlined
+(recursively, relative to the including file's dir), and any non-pure node is walked untouched —
+so a dict that carries `provider_config_path` alongside other keys (e.g. a sample-sanity spec)
+is left intact rather than mistaken for an include.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest_bazel
+
+from augur.model.provider_includes import resolve_provider_includes
+
+
+def test_pure_ref_is_inlined(tmp_path: Path) -> None:
+    (tmp_path / "macro.yaml").write_text("type: mirroring\nmodel: {type: state_space}\n")
+    resolved = resolve_provider_includes({"provider_config_path": "macro.yaml"}, base_dir=tmp_path)
+    assert resolved == {"type": "mirroring", "model": {"type": "state_space"}}
+
+
+def test_ref_nested_in_larger_node_only_replaces_the_ref(tmp_path: Path) -> None:
+    (tmp_path / "macro.yaml").write_text("type: mirroring\n")
+    node = {"type": "composite", "macro": {"provider_config_path": "macro.yaml"}, "private_equity": {"type": "trained"}}
+    resolved = resolve_provider_includes(node, base_dir=tmp_path)
+    assert resolved == {"type": "composite", "macro": {"type": "mirroring"}, "private_equity": {"type": "trained"}}
+
+
+def test_node_with_extra_keys_is_not_an_include(tmp_path: Path) -> None:
+    # A sample-sanity spec carries `provider_config_path` plus bands; it must not be inlined.
+    node = {"provider_config_path": "macro.yaml", "rollout_count": 64}
+    assert resolve_provider_includes(node, base_dir=tmp_path) == node
+
+
+def test_includes_resolve_recursively(tmp_path: Path) -> None:
+    (tmp_path / "inner.yaml").write_text("type: state_space\n")
+    (tmp_path / "outer.yaml").write_text("type: mirroring\nmodel: {provider_config_path: inner.yaml}\n")
+    resolved = resolve_provider_includes({"provider_config_path": "outer.yaml"}, base_dir=tmp_path)
+    assert resolved == {"type": "mirroring", "model": {"type": "state_space"}}
+
+
+def test_lists_are_walked(tmp_path: Path) -> None:
+    (tmp_path / "a.yaml").write_text("name: a\n")
+    node = {"items": [{"provider_config_path": "a.yaml"}, {"name": "b"}]}
+    assert resolve_provider_includes(node, base_dir=tmp_path) == {"items": [{"name": "a"}, {"name": "b"}]}
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/augur/model/sample_sanity.py
+++ b/augur/model/sample_sanity.py
@@ -25,6 +25,7 @@ from augur.model.provider_config import (
     TrainedPrivateEquityProviderConfig,
     VecmProviderConfig,
 )
+from augur.model.provider_includes import resolve_provider_includes
 from augur.model.schemas import FrozenModel
 from augur.model.series import IssuerId, LevelSeriesKey, PrivateEquityEventKindCode
 from util.bazel.runfiles import get_required_path
@@ -667,7 +668,8 @@ def _evaluate_protocol_check(
 
 
 def _load_provider_config(path: Path) -> ProviderConfig:
-    provider = _ADAPTER.validate_python(yaml.safe_load(path.read_text(encoding="utf-8")))
+    raw = resolve_provider_includes(yaml.safe_load(path.read_text(encoding="utf-8")), base_dir=path.parent)
+    provider = _ADAPTER.validate_python(raw)
     return _anchor_provider_paths(provider, base_dir=path.parent)
 
 


### PR DESCRIPTION
Superseded — going for a single-source layout instead of an include mechanism. Rather than referencing a shared macro file from two places, `sample_sanity` will evaluate the deployed `config.yaml` model directly, so `exogenous_provider.yaml` (the duplicate) is deleted and the macro lives in exactly one place with no template-engine machinery. Closing in favor of that approach.

https://claude.ai/code/session_01Dp9mKVK2NCGd8bkJG2sopw