### PR TITLE
props/backend: GET /api/runs/{id}/logs — agent container logs from Loki (Stage 2)

### DIFF
--- a/cluster/k8s/monitoring/loki/cilium-network-policy.yaml
+++ b/cluster/k8s/monitoring/loki/cilium-network-policy.yaml
@@ -46,6 +46,17 @@ spec:
             - port: "3100"
               protocol: TCP
 
+    # Props backend → Loki (GET /api/runs/{id}/logs reads agent container logs)
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/component: backend
+            app.kubernetes.io/instance: props
+            k8s:io.kubernetes.pod.namespace: props
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP
+
     # Alloy → Loki (OTel log forwarding)
     - fromEndpoints:
         - matchLabels:

--- a/props/backend/BUILD.bazel
+++ b/props/backend/BUILD.bazel
@@ -50,6 +50,24 @@ py_library(
 )
 
 py_library(
+    name = "loki",
+    srcs = ["loki.py"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@pypi//httpx"],
+)
+
+py_test(
+    name = "test_loki",
+    srcs = ["test_loki.py"],
+    deps = [
+        ":loki",
+        "//props:conftest",
+        "@pypi//pytest_asyncio",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_library(
     name = "app",
     srcs = ["app.py"],
     visibility = ["//:__subpackages__"],

--- a/props/backend/loki.py
+++ b/props/backend/loki.py
@@ -1,0 +1,64 @@
+"""Query agent container logs from Loki.
+
+Promtail ships every pod's stdout/stderr to Loki with standard stream labels
+(`namespace`, `pod`, `container`, ...). Agent pods are named
+`<agent_type>-<slug>-<agent_run_id[:8]>`, so a run's logs are the streams whose
+`pod` label ends in the run-id's 8-char prefix. Container logs are not persisted
+to the DB (only the run's status is) — this is how they're read back.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# In-cluster Loki read (SimpleScalable) — overridable for tests / other clusters.
+DEFAULT_LOKI_URL = "http://loki-read.loki.svc.cluster.local:3100"
+ENV_LOKI_URL = "PROPS_LOKI_URL"
+
+_QUERY_TIMEOUT_S = 10.0
+_MAX_LINES = 5000  # newest N lines (the tail, where failures show up)
+_LOOKBACK = timedelta(days=14)
+
+
+def loki_base_url() -> str:
+    return os.environ.get(ENV_LOKI_URL, DEFAULT_LOKI_URL)
+
+
+def _logql_for_run(run_id: UUID) -> str:
+    # Anchored regex (Loki label matchers are fully anchored): the pod name ends
+    # in `-<run_id[:8]>`. The 8 hex chars are unique enough across the window.
+    return f'{{namespace="props",pod=~".+-{str(run_id)[:8]}"}}'
+
+
+def parse_query_range(payload: dict) -> str:
+    """Flatten a Loki query_range response into chronological log text."""
+    entries: list[tuple[str, str]] = []
+    for stream in payload.get("data", {}).get("result", []):
+        entries.extend((ts, line) for ts, line in stream.get("values", []))
+    entries.sort(key=lambda e: e[0])  # by nanosecond timestamp, ascending
+    return "\n".join(line for _, line in entries)
+
+
+async def fetch_run_logs(run_id: UUID, *, base_url: str | None = None) -> str:
+    """Return an agent run's container logs (up to the most recent `_MAX_LINES`),
+    in chronological order. Empty string if Loki has nothing for the run."""
+    base = base_url or loki_base_url()
+    end = datetime.now(UTC)
+    params = {
+        "query": _logql_for_run(run_id),
+        "start": str(int((end - _LOOKBACK).timestamp() * 1e9)),
+        "end": str(int(end.timestamp() * 1e9)),
+        "limit": str(_MAX_LINES),
+        "direction": "backward",  # newest first; we re-sort ascending for display
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{base}/loki/api/v1/query_range", params=params, timeout=_QUERY_TIMEOUT_S)
+        resp.raise_for_status()
+        return parse_query_range(resp.json())

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -83,6 +83,7 @@ py_library(
         "//openai_utils:model",
         "//props/backend:auth",
         "//props/backend:deps",
+        "//props/backend:loki",
         "//props/core:agent_types",
         "//props/core:eval_api_models",
         "//props/core:oci_utils",

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -30,6 +30,7 @@ from props.backend.auth import (
     require_evaluator_or_admin_access,
 )
 from props.backend.deps import AdminDb
+from props.backend.loki import fetch_run_logs
 from props.backend.routes.ground_truth import get_snapshot_or_404
 from props.core.agent_types import AgentType, TargetMetric, TypeConfig
 from props.core.eval_api_models import RunCriticRequest, StartCriticResponse
@@ -1031,6 +1032,26 @@ def get_run_llm_requests(run_id: UUID, caller_db: CallerDb) -> LLMRequestsRespon
         )
 
         return LLMRequestsResponse(requests=[LLMRequestInfo.model_validate(req) for req in requests])
+
+
+class RunLogsResponse(BaseModel):
+    run_id: UUID
+    logs: str
+
+
+@router.get("/{run_id}/logs")
+async def get_run_logs(run_id: UUID, caller_db: CallerDb) -> RunLogsResponse:
+    """Container logs for an agent run, fetched from Loki.
+
+    RLS-scoped: an agent (e.g. critic_dev) sees only runs it launched (its
+    descendants); admin/evaluator see all. Container logs are not persisted to
+    the DB — only the run's status is — so this reads them back from Loki by the
+    run's pod label. (The LLM transcript is read separately from /llm_requests.)
+    """
+    with caller_db.session() as session:
+        if session.get(AgentRun, run_id) is None:
+            raise HTTPException(status_code=404, detail=f"Agent run {run_id} not found")
+    return RunLogsResponse(run_id=run_id, logs=await fetch_run_logs(run_id))
 
 
 def _build_run_info(

--- a/props/backend/test_loki.py
+++ b/props/backend/test_loki.py
@@ -1,0 +1,68 @@
+"""Tests for Loki log fetching (query construction + response parsing)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest_bazel
+
+from props.backend.loki import _logql_for_run, fetch_run_logs, parse_query_range
+
+RUN = UUID("11da4746-40f8-431a-a0f2-c11f23c1c056")
+
+
+def test_logql_matches_pod_by_run_id_prefix() -> None:
+    # The pod name ends in the run-id's 8-char prefix; the matcher must be anchored.
+    assert _logql_for_run(RUN) == '{namespace="props",pod=~".+-11da4746"}'
+
+
+def test_parse_query_range_orders_chronologically() -> None:
+    payload = {
+        "data": {
+            "result": [
+                {"stream": {"pod": "critic-x-11da4746"}, "values": [["20", "second"], ["10", "first"]]},
+                {"stream": {"pod": "critic-x-11da4746"}, "values": [["30", "third"]]},
+            ]
+        }
+    }
+    assert parse_query_range(payload) == "first\nsecond\nthird"
+
+
+def test_parse_query_range_empty() -> None:
+    assert parse_query_range({"data": {"result": []}}) == ""
+
+
+async def test_fetch_run_logs_queries_and_parses() -> None:
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        def raise_for_status(self) -> None: ...
+
+        def json(self) -> dict:
+            return {"data": {"result": [{"values": [["10", "hello"]]}]}}
+
+    class _Client:
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *_: object) -> None: ...
+
+        async def get(self, url: str, **kwargs: object) -> _Resp:
+            captured["url"] = url
+            captured["params"] = kwargs["params"]
+            return _Resp()
+
+    with patch("props.backend.loki.httpx.AsyncClient", return_value=_Client()):
+        logs = await fetch_run_logs(RUN, base_url="http://loki:3100")
+
+    assert logs == "hello"
+    assert captured["url"] == "http://loki:3100/loki/api/v1/query_range"
+    params = captured["params"]
+    assert isinstance(params, dict)
+    assert params["query"] == '{namespace="props",pod=~".+-11da4746"}'
+    assert params["direction"] == "backward"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/props/docs/backend_api.md
+++ b/props/docs/backend_api.md
@@ -54,11 +54,17 @@ schema = httpx.get(f"{backend_url}/openapi.json").json()
 
 ## Available Endpoints
 
-| Endpoint           | Method | Description               |
-| ------------------ | ------ | ------------------------- |
-| `/api/runs/critic` | POST   | Run critic on an example  |
-| `/v1/responses`    | POST   | LLM proxy (OpenAI format) |
-| `/v2/*`            | \*     | OCI registry proxy        |
+| Endpoint                      | Method | Description                                                        |
+| ----------------------------- | ------ | ------------------------------------------------------------------ |
+| `/api/runs/critic`            | POST   | Run critic on an example                                           |
+| `/api/runs/{id}/llm_requests` | GET    | A run's LLM transcript (request/response rows); RLS-scoped         |
+| `/api/runs/{id}/logs`         | GET    | A run's container logs (from Loki); RLS-scoped to your descendants |
+| `/v2/*`                       | \*     | OCI registry proxy                                                 |
+
+The LLM proxy (`/v1/responses`) is a **separate service** (`props-llm-proxy`),
+reached via `OPENAI_BASE_URL`, not this backend. Read a launched agent's
+**transcript** from `llm_requests` (DB, also exposed above) and its **container
+logs** via `/api/runs/{id}/logs` — agents cannot query Loki directly.
 
 ## Access Control
 

--- a/props/docs/plans/k8s_native_execution.md
+++ b/props/docs/plans/k8s_native_execution.md
@@ -126,16 +126,28 @@ earlier ones only where noted.
     API (#1882) and the executor SA can `list` pods (#1891), so the grader
     controller maintains one labeled grader per snapshot.
 
-### Stage 2 — Agent-readable logs (transcript + Loki)
+### Stage 2 — Agent-readable logs (Loki)
 
-- Promtail config: promote `adgn.agent_run_id` to a Loki stream label.
-- Add `GET /api/runs/{id}/transcript` and `GET /api/runs/{id}/logs` (the latter
-  proxies a Loki query), authorized by run lineage.
-- Add the data-plane component(s) to the Loki `NetworkPolicy` ingress allowlist.
-- Update critic_dev agent docs/tools to read both.
-- **Done when:** a critic_dev agent can fetch both the transcript and raw logs
-  of a critic it launched.
-- **Depends on:** Stage 1 (transcript capture).
+- **Transcript stays DB-direct — no endpoint.** The proxy already logs each
+  request+response to `llm_requests`, and `GET /api/runs/{id}/llm_requests`
+  (RLS-scoped) already returns it; agents read their descendants' transcripts
+  straight from the DB.
+- **Logs:** `GET /api/runs/{id}/logs` queries Loki by the run's pod label
+  (`{namespace="props",pod=~".+-<run_id[:8]>"}`) — promtail already labels `pod`,
+  so no relabel is needed. **RBAC is RLS:** the run is looked up via the caller's
+  RLS-scoped DB (the `agent_runs_select_descendants` policy), so an agent sees
+  only runs it launched and admin/evaluator see all. Container logs are no longer
+  persisted to the DB — Loki is the store.
+- Added the props backend to the Loki `NetworkPolicy` ingress allowlist.
+- **Status (2026-06-04): logs endpoint + Loki client landed.** Done when a
+  critic_dev agent fetches a launched critic's logs via the endpoint.
+- **TODO — namespace-isolate agent pods from the backend.** Agent pods (critic,
+  grader) currently share the `props` namespace with the backend + DB. Consider
+  moving them to their own namespace under a restrictive NetworkPolicy so they
+  **cannot reach Loki / DB-admin / other infra directly** and must go through the
+  backend's RBAC'd endpoints (e.g. `/api/runs/{id}/logs`). The Loki ingress policy
+  already admits only `component=backend`, not agent pods — namespace isolation
+  makes that boundary structural and shrinks the agent blast radius.
 
 ### Stage 3 — In-cluster Forgejo pulls
 


### PR DESCRIPTION
Plan **Stage 2** — agent-readable logs.

Container logs aren't persisted to the DB (only run status is), so agents (e.g. critic_dev debugging a critic it launched) need a way to read them back. Adds **`GET /api/runs/{id}/logs`**:

- Queries **Loki** for the run's pod streams: `{namespace="props",pod=~".+-<run_id[:8]>"}`. Promtail already labels `pod`, so **no relabel needed**; returns the most-recent lines (tail) in chronological order.
- **RBAC is RLS, not a bespoke check:** the run is looked up via the caller's RLS-scoped `CallerDb`, so the existing `agent_runs_select_descendants` policy already restricts an agent to runs it launched, while admin/evaluator see all.
- Opens Loki's `NetworkPolicy` to the props backend (only `component=backend` — **agent pods still can't reach Loki directly**, so they must go through this endpoint).

**Transcript stays DB-direct — no new endpoint.** The proxy already logs each request+response to `llm_requests`, exposed by the existing `GET /api/runs/{id}/llm_requests`.

Also:
- Agent-facing API doc updated (drops the now-stale backend `/v1/responses`, documents `logs` + `llm_requests`).
- Plan **TODO** recorded (your call): **namespace-isolate agent pods from the backend** so they can't reach Loki / DB-admin directly and must go through these RBAC'd endpoints — making the Loki-ingress boundary structural and shrinking the agent blast radius.

`bbr test //props/backend:test_loki` PASS (query construction + parsing); `//props/backend:app` + `:image` build green; kubeconform passes on the NetworkPolicy.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_