### PR TITLE
props/testing: run the standalone LLM proxy in the e2e stack

### DIFF
--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -133,6 +133,11 @@ def _make_lifespan(deps: BackendDeps):
             model_parallelism_limits = {
                 m.name: m.max_parallel_agents for m in deps.config.models if m.max_parallel_agents is not None
             }
+            # Agents reach the LLM only through props/llm_proxy (the backend dropped
+            # its own /v1 mount in #1894), so this must be configured.
+            llm_proxy_url = deps.config.llm_proxy_url
+            if llm_proxy_url is None:
+                raise RuntimeError("config.llm_proxy_url must be set for agent runs")
             app.state.registry = AgentRegistry(
                 executor=executor,
                 db=db,
@@ -141,7 +146,7 @@ def _make_lifespan(deps: BackendDeps):
                 agent_base_env=deps.config.agent_env,
                 registry_config=deps.registry_proxy_config,
                 model_parallelism_limits=model_parallelism_limits,
-                llm_base_url=deps.config.llm_proxy_url,
+                llm_base_url=llm_proxy_url,
             )
 
             if deps.grader_model:

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -199,18 +199,17 @@ class AgentRegistry:
         backend_url: str,
         agent_base_env: dict[str, str],
         registry_config: RegistryProxyConfig,
+        llm_base_url: str,
         model_parallelism_limits: dict[str, int] | None = None,
-        llm_base_url: str | None = None,
     ) -> None:
         self._executor = executor
         self._db = db
         self._db_config = db_config
         self._backend_url = backend_url
-        # Base URL agents use for the LLM proxy: OPENAI_BASE_URL = <this>/v1. The
-        # proxy is the standalone props/llm_proxy service (the backend dropped its
-        # own /v1 mount in #1894), so callers should pass llm_base_url; the
-        # backend_url fallback no longer serves /v1 and is only a degraded default.
-        self._llm_base_url = llm_base_url or backend_url
+        # Base URL agents use for the LLM proxy: OPENAI_BASE_URL = <this>/v1. This is
+        # the standalone props/llm_proxy service (the backend dropped its own /v1
+        # mount in #1894); it must point at the proxy, never the backend.
+        self._llm_base_url = llm_base_url
         self._agent_base_env = agent_base_env
         self._registry_config = registry_config
         # Track running background critic tasks by agent_run_id to prevent GC and allow lookup

--- a/props/orchestration/agent_registry.py
+++ b/props/orchestration/agent_registry.py
@@ -207,8 +207,9 @@ class AgentRegistry:
         self._db_config = db_config
         self._backend_url = backend_url
         # Base URL agents use for the LLM proxy: OPENAI_BASE_URL = <this>/v1. The
-        # proxy is split out of the backend (props/llm_proxy); None falls back to
-        # the backend, which still serves /v1 for dev and not-yet-cycled agents.
+        # proxy is the standalone props/llm_proxy service (the backend dropped its
+        # own /v1 mount in #1894), so callers should pass llm_base_url; the
+        # backend_url fallback no longer serves /v1 and is only a degraded default.
         self._llm_base_url = llm_base_url or backend_url
         self._agent_base_env = agent_base_env
         self._registry_config = registry_config

--- a/props/orchestration/test_agent_registry.py
+++ b/props/orchestration/test_agent_registry.py
@@ -50,6 +50,7 @@ def _registry(db: Database) -> AgentRegistry:
         backend_url="http://backend",
         agent_base_env={},
         registry_config=RegistryProxyConfig(host="reg", port=8000),
+        llm_base_url="http://proxy:8000",
     )
 
 
@@ -154,26 +155,6 @@ async def test_collect_run_cancellation_finalizes_as_cancelled(db: Database) -> 
         assert run is not None
         assert run.status == AgentRunStatus.CANCELLED
         assert run.container_exit_code is None
-
-
-def _registry_with(db: Database, *, llm_base_url: str | None) -> AgentRegistry:
-    return AgentRegistry(
-        executor=cast(Any, _FakeExecutor()),
-        db=db,
-        db_config=DatabaseConfig(host="h", port=5432, database="d", user="u", password="p"),
-        backend_url="http://b:8000",
-        agent_base_env={},
-        registry_config=RegistryProxyConfig(host="reg", port=8000),
-        llm_base_url=llm_base_url,
-    )
-
-
-def test_llm_base_url_falls_back_to_backend_url(db: Database) -> None:
-    """Agents' OPENAI_BASE_URL derives from llm_base_url; an unset value falls back
-    to backend_url, so the proxy cutover can't silently strand agents without an
-    LLM endpoint."""
-    assert _registry_with(db, llm_base_url=None)._llm_base_url == "http://b:8000"
-    assert _registry_with(db, llm_base_url="http://proxy:8000")._llm_base_url == "http://proxy:8000"
 
 
 if __name__ == "__main__":

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -63,6 +63,7 @@ py_library(
         "//props/core:oci_utils",
         "//props/db:config",
         "//props/db:database",
+        "//props/llm_proxy:app",
         "//props/orchestration:agent_registry",
         "//props/orchestration:docker_env",
         "//props/orchestration:docker_executor",

--- a/props/testing/fixtures/BUILD.bazel
+++ b/props/testing/fixtures/BUILD.bazel
@@ -72,6 +72,7 @@ py_library(
         "//util:crane",
         "//util:net",
         "@pypi//aiodocker",
+        "@pypi//fastapi",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//uvicorn",

--- a/props/testing/fixtures/e2e_container.py
+++ b/props/testing/fixtures/e2e_container.py
@@ -51,6 +51,7 @@ import aiodocker
 import pytest
 import pytest_asyncio
 import uvicorn
+from fastapi import FastAPI
 
 from openai_utils.model import OpenAIModelProto
 from props.backend.app import BackendDeps, create_app
@@ -59,6 +60,7 @@ from props.core.agent_types import AgentType
 from props.core.oci_utils import BUILTIN_TAG, RegistryProxyConfig
 from props.db.config import DatabaseConfig
 from props.db.database import Database
+from props.llm_proxy.app import create_app as create_llm_proxy_app  # alias: backend.app also defines create_app
 from props.orchestration.agent_registry import AgentRegistry, ResolvedImage
 from props.orchestration.docker_env import PROPS_NETWORK_NAME
 from props.orchestration.docker_executor import DockerExecutor
@@ -135,10 +137,8 @@ def _build_agent_base_env(db_config: DatabaseConfig) -> dict[str, str]:
 
 
 @asynccontextmanager
-async def run_backend(deps: BackendDeps, port: int, host: str = "0.0.0.0") -> AsyncIterator[None]:
-    """Start the real backend app with uvicorn."""
-    app = create_app(deps=deps)
-
+async def _serve_app(app: FastAPI, port: int, *, name: str, host: str = "0.0.0.0") -> AsyncIterator[None]:
+    """Run a FastAPI app under uvicorn for the lifetime of the context."""
     config = uvicorn.Config(app, host=host, port=port, log_level="warning")
     server = uvicorn.Server(config)
     task = asyncio.create_task(server.serve())
@@ -146,10 +146,9 @@ async def run_backend(deps: BackendDeps, port: int, host: str = "0.0.0.0") -> As
     while not server.started:
         await asyncio.sleep(0.01)
         if task.done():
-            exc = task.exception()
-            raise RuntimeError(f"Backend server failed to start: {exc}")
+            raise RuntimeError(f"{name} failed to start on port {port}: {task.exception()}")
 
-    logger.info("Backend started on port %d", port)
+    logger.info("%s started on port %d", name, port)
 
     try:
         yield
@@ -161,7 +160,7 @@ async def run_backend(deps: BackendDeps, port: int, host: str = "0.0.0.0") -> As
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
-        logger.info("Backend stopped")
+        logger.info("%s stopped", name)
 
 
 def _set_backend_env(monkeypatch: pytest.MonkeyPatch, db_config: DatabaseConfig, e2e_registry_url: str) -> None:
@@ -188,24 +187,32 @@ async def _make_stack(
 
     try:
         _set_backend_env(monkeypatch, db.config, e2e_registry_url)
+        # The LLM proxy's upstream: it forwards agents' /v1/responses calls here.
         monkeypatch.setenv("OPENAI_BASE_URL", f"{fake_openai.url}/v1")
 
         backend_port = pick_free_port()
+        llm_proxy_port = pick_free_port()
         registry_proxy_config = RegistryProxyConfig(host="localhost", port=backend_port)
         backend_url = f"http://{E2E_HOST_HOSTNAME}:{backend_port}"
+        # Agents talk to the standalone LLM proxy (the backend dropped its /v1
+        # mount in #1894); the proxy reuses the backend's llm router + auth against
+        # the same DB and forwards to the fake OpenAI upstream above.
+        llm_proxy_url = f"http://{E2E_HOST_HOSTNAME}:{llm_proxy_port}"
         agent_base_env = _build_agent_base_env(db.config)
 
-        deps = BackendDeps(
-            config=PropsConfig(
-                backend_url=backend_url,
-                agent_env=agent_base_env,
-                executor=DockerExecutorConfig(extra_hosts=HOST_GATEWAY),
-            ),
-            registry_proxy_config=registry_proxy_config,
+        config = PropsConfig(
             backend_url=backend_url,
+            agent_env=agent_base_env,
+            executor=DockerExecutorConfig(extra_hosts=HOST_GATEWAY),
+            llm_proxy_url=llm_proxy_url,
         )
+        deps = BackendDeps(config=config, registry_proxy_config=registry_proxy_config, backend_url=backend_url)
 
-        async with ensure_agent_network(async_docker_client), run_backend(deps, port=backend_port):
+        async with (
+            ensure_agent_network(async_docker_client),
+            _serve_app(create_app(deps=deps), backend_port, name="backend"),
+            _serve_app(create_llm_proxy_app(db=db, config=config), llm_proxy_port, name="llm-proxy"),
+        ):
             executor = DockerExecutor(
                 async_docker_client,
                 network_name=PROPS_NETWORK_NAME,
@@ -219,6 +226,7 @@ async def _make_stack(
                 backend_url=backend_url,
                 agent_base_env=agent_base_env,
                 registry_config=registry_proxy_config,
+                llm_base_url=llm_proxy_url,
             )
 
             try:


### PR DESCRIPTION
## Problem

#1894 dropped the backend's `/v1` LLM proxy mount (the proxy is now the standalone `props/llm_proxy` service), but the e2e fixture still pointed agent **containers** at `{backend_url}/v1`. Every agent's `POST /v1/responses` returned **404**, so agents submitted nothing and **all 8 `props/agents/*` e2e tests failed** — e.g. critic's `assert len(run.reported_issues) == 1` → `0 == 1`.

Agent container log from a failing run:

```
POST http://host.docker.internal:.../v1/responses "HTTP/1.1 404 Not Found"
ERROR __main__: Agent error: Error code: 404 - {'detail': 'Not Found'}
openai.NotFoundError: Error code: 404
```

(These e2e tests aren't in the default CI set — github.com history shows they last ran in April — so the regression surfaced only on a manual `bbr test //...`.)

## Changes

1. **Wire the standalone proxy into the e2e stack** (`e2e_container.py::_make_stack`): start `props.llm_proxy.create_app` alongside the backend (it reuses the backend's `llm` router + auth against the **same DB**) and point the `AgentRegistry` at it via `llm_base_url`. Agents now go **agent → llm_proxy → fake OpenAI upstream**, matching production. Refactored `run_backend` into a generic `_serve_app`; added the `//props/llm_proxy:app` BUILD dep.
2. **Remove the dead `backend_url` fallback.** `AgentRegistry`'s `llm_base_url or backend_url` dated from when the backend served `/v1`; post-#1894 it silently pointed at a dead endpoint. `llm_base_url` is now a required argument, and the backend lifespan raises if `config.llm_proxy_url` is unset rather than building a registry that can't reach an LLM. Dropped the now-moot `test_llm_base_url_falls_back_to_backend_url`.
3. **Declare `@pypi//fastapi`** on the `e2e_container` fixture (it imports `FastAPI` for `_serve_app`) — fixes the mypy lint failure CI flagged.

## Verification (RBE)

- All 8 e2e tests pass — `bffabaa7-461c-476e-8d65-6645b5eb0dfc`.
- Re-verified after the fallback removal + mypy fix: `test_agent_registry` + `critic:test_e2e` pass, and `e2e_container` / `backend:app` / `agent_registry` build clean under mypy — `04643091-7d55-4b2a-ad8a-9824157a6056`.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o