### PR TITLE
props: split PropsConfig — minimal upstreams-only config for the LLM proxy

### DIFF
--- a/props/backend/deps.py
+++ b/props/backend/deps.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 
-from props.config import PropsConfig
+from props.config import LLMProxyConfig
 from props.db.database import Database
 
 
@@ -20,13 +20,18 @@ def get_admin_db(request: Request) -> Database:
     return request.app.state.admin_db  # type: ignore[no-any-return]
 
 
-def get_config(request: Request) -> PropsConfig:
-    """Get PropsConfig from app state."""
+def get_config(request: Request) -> LLMProxyConfig:
+    """Get the LLM-proxy config (`upstreams`) from app state.
+
+    Typed as `LLMProxyConfig` because the only consumer is the LLM proxy's
+    `/v1/responses` route. The API server sets a full `PropsConfig` here (a
+    subtype), which satisfies this dependency too.
+    """
     return request.app.state.config  # type: ignore[no-any-return]
 
 
 # Type alias for admin database dependency (use in FastAPI route signatures)
 AdminDb = Annotated[Database, Depends(get_admin_db)]
 
-# Type alias for config dependency
-Config = Annotated[PropsConfig, Depends(get_config)]
+# Type alias for config dependency (LLM-proxy upstreams)
+Config = Annotated[LLMProxyConfig, Depends(get_config)]

--- a/props/backend/routes/llm.py
+++ b/props/backend/routes/llm.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 from openai_utils.model import ResponseUsage
 from props.backend.auth import AgentRole, Auth, AuthenticatedIdentity
 from props.backend.deps import AdminDb, Config
-from props.config import PropsConfig, UpstreamConfig
+from props.config import LLMProxyConfig, UpstreamConfig
 from props.db.models import AgentRun, AgentRunBudgetStatus, AgentRunStatus, LLMRequest, ModelMetadata
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ def _resolve_upstream_url(config: UpstreamConfig) -> str:
     raise ValueError("Upstream config must have url or url_env")
 
 
-def _get_upstream_route(model_id: str, session: Session, config: PropsConfig) -> UpstreamRoute:
+def _get_upstream_route(model_id: str, session: Session, config: LLMProxyConfig) -> UpstreamRoute:
     """Look up upstream routing info for a model.
 
     Returns UpstreamRoute with resolved URL, API key, and model name to send.

--- a/props/config.py
+++ b/props/config.py
@@ -99,8 +99,23 @@ class KubernetesExecutorConfig(BaseModel):
 ExecutorConfig = Annotated[DockerExecutorConfig | KubernetesExecutorConfig, Discriminator("type")]
 
 
-class PropsConfig(BaseModel):
+class LLMProxyConfig(BaseModel):
+    """Config the standalone LLM proxy reads from the config file: just the
+    upstream provider definitions (per-upstream URL + API-key env var).
+
+    The proxy's DB comes from `PG*` env vars and its model routing from the DB
+    `model_metadata` table (synced by the API server), so `upstreams` is the only
+    config-file field it needs. `PropsConfig` (the API server's config) extends
+    this with the API-only fields, which the proxy never reads.
+    """
+
     model_config = ConfigDict(frozen=True)
+
+    upstreams: dict[str, UpstreamConfig] = {}
+
+
+class PropsConfig(LLMProxyConfig):
+    """Full config for the API server: the shared `upstreams` plus API-only fields."""
 
     backend_url: str
     # Base URL agents use for the LLM proxy (split out of the backend); agents get
@@ -108,7 +123,6 @@ class PropsConfig(BaseModel):
     llm_proxy_url: str | None = None
     grader_model: str | None = None
     agent_env: dict[str, str]
-    upstreams: dict[str, UpstreamConfig] = {}
     models: list[CustomModelConfig] = []
     executor: ExecutorConfig = Field(default_factory=DockerExecutorConfig)
     auto_migrate: bool = False
@@ -127,3 +141,17 @@ def load_config_from_env() -> PropsConfig:
     if not path_str:
         raise ValueError(f"{ENV_CONFIG_FILE} environment variable not set")
     return load_config(Path(path_str))
+
+
+def load_proxy_config(path: Path) -> LLMProxyConfig:
+    """Load just the LLM-proxy slice (`upstreams`) from a TOML file; the API-only
+    fields in the same file are ignored."""
+    return LLMProxyConfig.model_validate(tomllib.loads(path.read_text()))
+
+
+def load_proxy_config_from_env() -> LLMProxyConfig:
+    """Load the LLM-proxy config from the path in PROPS_CONFIG_FILE env var."""
+    path_str = os.environ.get(ENV_CONFIG_FILE)
+    if not path_str:
+        raise ValueError(f"{ENV_CONFIG_FILE} environment variable not set")
+    return load_proxy_config(Path(path_str))

--- a/props/llm_proxy/app.py
+++ b/props/llm_proxy/app.py
@@ -5,7 +5,7 @@ Serves only ``/v1/responses`` (auth + budget + cost + upstream routing). It reus
 the backend's ``llm`` router, ``auth``, and ``deps`` unchanged — no frontend,
 orchestration, registry proxy, or SSO. The router's only app-state requirements
 are ``admin_db`` (a ``Database`` admin pool, for auth + budget/cost/upstream
-queries) and ``config`` (``PropsConfig``, for upstream routing); the SSO/session
+queries) and ``config`` (``LLMProxyConfig``, for upstream routing); the SSO/session
 branch of ``get_request_identity`` is inert here because no ``SessionMiddleware``
 is installed.
 """
@@ -21,7 +21,7 @@ from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
 from props.backend.routes import llm
-from props.config import PropsConfig, load_config_from_env
+from props.config import LLMProxyConfig, load_proxy_config_from_env
 from props.db.config import DatabaseConfig
 from props.db.database import Database
 from util.logging import LogLevel, configure_logging
@@ -32,7 +32,7 @@ configure_logging(
 logger = logging.getLogger(__name__)
 
 
-def create_app(*, db: Database | None = None, config: PropsConfig | None = None) -> FastAPI:
+def create_app(*, db: Database | None = None, config: LLMProxyConfig | None = None) -> FastAPI:
     """Build the LLM proxy app.
 
     `db`/`config` are injected in tests; in production they are loaded from the
@@ -42,7 +42,7 @@ def create_app(*, db: Database | None = None, config: PropsConfig | None = None)
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.admin_db = db or Database(DatabaseConfig())
-        app.state.config = config or load_config_from_env()
+        app.state.config = config or load_proxy_config_from_env()
         logger.info("LLM proxy ready")
         yield
 

--- a/props/llm_proxy/test_app.py
+++ b/props/llm_proxy/test_app.py
@@ -13,13 +13,15 @@ import pytest_bazel
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
-from props.config import PropsConfig
+from props.config import LLMProxyConfig
 from props.llm_proxy.app import create_app
 from props.llm_proxy.cli import cli
 
 
 def _client() -> TestClient:
-    config = PropsConfig(backend_url="http://test", agent_env={})
+    # The proxy needs only the minimal LLMProxyConfig (just upstreams); the
+    # health + auth-rejection paths below never route, so empty upstreams suffice.
+    config = LLMProxyConfig()
     # The auth-rejection paths below never touch the DB, so a MagicMock suffices.
     return TestClient(create_app(db=MagicMock(), config=config), raise_server_exceptions=False)
 


### PR DESCRIPTION
The Stage 1 config-split follow-up. The standalone LLM proxy read the full `PropsConfig` but uses only `upstreams` — its DB comes from `PG*` env vars and its model routing from the DB `model_metadata` table.

## Change

- Carve a minimal **`LLMProxyConfig`** base (just `upstreams`). **`PropsConfig`** (the API server's config) now **inherits** it and adds the API-only fields (`backend_url`, `llm_proxy_url`, `grader_model`, `agent_env`, `models`, `executor`, `auto_*`).
- The proxy app + the shared `/v1/responses` router (`deps.Config`, `llm._get_upstream_route`) depend on `LLMProxyConfig`. The proxy loads only `upstreams` from the config file via new `load_proxy_config_from_env` (API-only fields ignored).
- Because `PropsConfig` stays a **subtype** of `LLMProxyConfig`, the API server and every existing construction site (incl. the e2e fixture, which hands the proxy a `PropsConfig`) are unchanged. `deps.Config`'s sole consumer is the proxy's llm router, so retyping it is safe.
- `test_app.py` now builds the minimal `LLMProxyConfig()`, demonstrating the reduced surface.

No cluster config change needed — the proxy reads the same `config.toml` and just ignores the API-only keys.

## Verification (RBE, green — `98184a08-1f0b-41b0-a446-9880f32e5f8a`)

`llm_proxy:test_app`, `routes:test_llm_routing`, `routes:test_llm_budget`, `db/sync:test_model_metadata_sync` (constructs `PropsConfig` with `upstreams`+`models`), and `agents/critic:test_e2e` (proxy end-to-end) all pass; mypy lint clean on `config` / `deps` / `routes:llm` / `llm_proxy:app` / `backend:app`.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_