### PR TITLE
props/critic: drop exec env knob (glm-4.6 stringifies it) + generalize report_failure

### DIFF
--- a/mcp_infra/exec/subprocess.py
+++ b/mcp_infra/exec/subprocess.py
@@ -8,7 +8,6 @@ from pydantic import Field
 
 from mcp_infra.exec.models import (
     BaseExecResult,
-    EnvVar,
     ExecArgsBase,
     ExecOutcome,
     ExecOutput,
@@ -86,28 +85,11 @@ class DirectExecArgs(ExecArgsBase):
     """Arguments for direct command execution."""
 
     cmd: list[str] = Field(min_length=1)
-    env: list[EnvVar] | None = Field(
-        default=None,
-        description="Environment variables as ['NAME=value', ...]. "
-        "Merged into the inherited environment by default (see inherit_env).",
-    )
-    inherit_env: bool = Field(
-        default=True,
-        description="If true (default), env vars are merged into the process's inherited environment. "
-        "If false, only the provided env vars are used (clean environment).",
-    )
-
-
-def _parse_env_list(env_list: list[str] | None) -> dict[str, str] | None:
-    if not env_list:
-        return None
-    result: dict[str, str] = {}
-    for entry in env_list:
-        name, sep, value = entry.partition("=")
-        if not sep:
-            raise ValueError(f"invalid env var (missing '='): {entry!r}")
-        result[name] = value
-    return result
+    # No env / inherit_env knob: direct exec always inherits the ambient environment.
+    # Exposing an optional `list[EnvVar] | None` broke tool-calling for models that
+    # serialize optional args as JSON strings (e.g. glm-4.6 sent env="null" / "[]"),
+    # which strict list validation rejected — failing 100% of exec calls.
+    # See props/debug/glm46_exec_env_stringification.md.
 
 
 async def run_direct_exec(input: DirectExecArgs, *, default_cwd: Path | None = None) -> BaseExecResult:
@@ -125,12 +107,5 @@ async def run_direct_exec(input: DirectExecArgs, *, default_cwd: Path | None = N
         cwd_val = default_cwd
 
     timeout_s = max(0.001, input.timeout_ms / 1000.0)
-    outcome = await run_proc(
-        input.cmd,
-        timeout_s,
-        cwd=cwd_val,
-        stdin=input.stdin_text,
-        env=_parse_env_list(input.env),
-        inherit_env=input.inherit_env,
-    )
+    outcome = await run_proc(input.cmd, timeout_s, cwd=cwd_val, stdin=input.stdin_text)
     return render_outcome_to_result(outcome, input.max_bytes)

--- a/mcp_infra/exec/test_direct.py
+++ b/mcp_infra/exec/test_direct.py
@@ -20,20 +20,5 @@ async def test_direct_exec_echo_inproc() -> None:
         assert res.stdout == "hello\n"
 
 
-def test_direct_exec_omits_env_knob() -> None:
-    """The agent-facing exec schema must NOT expose `env` / `inherit_env`.
-
-    glm-4.6 (critic run 824e8815) emitted the optional `env` arg as a JSON-encoded
-    string ("null" / "[]" / '["PATH=..."]') under strict tool-calling, which the
-    `list[EnvVar] | None` field rejected with "Input should be a valid list" —
-    failing 100% of exec calls. The knob was removed (direct exec inherits the
-    ambient env), so models can't trip on it.
-    See props/debug/glm46_exec_env_stringification.md.
-    """
-    props = DirectExecArgs.model_json_schema()["properties"]
-    assert "env" not in props
-    assert "inherit_env" not in props
-
-
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/mcp_infra/exec/test_direct.py
+++ b/mcp_infra/exec/test_direct.py
@@ -20,5 +20,20 @@ async def test_direct_exec_echo_inproc() -> None:
         assert res.stdout == "hello\n"
 
 
+def test_direct_exec_omits_env_knob() -> None:
+    """The agent-facing exec schema must NOT expose `env` / `inherit_env`.
+
+    glm-4.6 (critic run 824e8815) emitted the optional `env` arg as a JSON-encoded
+    string ("null" / "[]" / '["PATH=..."]') under strict tool-calling, which the
+    `list[EnvVar] | None` field rejected with "Input should be a valid list" —
+    failing 100% of exec calls. The knob was removed (direct exec inherits the
+    ambient env), so models can't trip on it.
+    See props/debug/glm46_exec_env_stringification.md.
+    """
+    props = DirectExecArgs.model_json_schema()["properties"]
+    assert "env" not in props
+    assert "inherit_env" not in props
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/props/agents/critic/main.py
+++ b/props/agents/critic/main.py
@@ -76,7 +76,12 @@ class SubmitArgs(OpenAIStrictModeBaseModel):
 
 
 class ReportFailureArgs(OpenAIStrictModeBaseModel):
-    message: str = Field(..., description="Description of why the critique could not be completed")
+    message: str = Field(
+        ...,
+        description="What is blocking you: the broken tool/environment/validation and what you tried "
+        "(e.g. 'exec returns a validation error for every command', 'cannot read the files in scope', "
+        "'submit keeps rejecting valid issues').",
+    )
 
 
 # --- Tool response models ---
@@ -243,7 +248,10 @@ def _create_tool_provider(exit_state: ExitState, db: Database) -> DirectToolProv
 
     @provider.tool
     def report_failure(args: ReportFailureArgs) -> str:
-        """Report that the critique could not be completed due to blocking issues (e.g., no files in scope)."""
+        """Escape hatch: you are BLOCKED by tooling/environment/validation and cannot complete the
+        review — e.g. `exec` errors on every command, you cannot read the files in scope,
+        `insert_issue`/`submit` keep failing, or validation rejects input you believe is legitimate.
+        Do NOT use this because you cannot run or build the code: review it statically by reading it."""
         with db.session() as session:
             get_current_agent_run(session)
 

--- a/props/agents/critic/prompt.md.mako
+++ b/props/agents/critic/prompt.md.mako
@@ -18,6 +18,16 @@ Location: ${workspace_dir}
 2. **Report issues** — `insert_issue` and `insert_occurrence`
 3. **Complete review** — call `submit` when done
 
+## If you're blocked
+
+If your tools or environment stop you from reviewing — `exec` errors on every command, you
+can't read the files in scope, `insert_issue`/`submit` keep failing, or validation rejects input
+you believe is legitimate — call `report_failure` with a clear description. Do not fabricate
+issues, guess, or submit an empty/partial critique to work around broken tooling.
+
+Being unable to **run or build** the code is _not_ a blocker — review code statically by reading
+it (missing language/dev tools is expected). Only call `report_failure` when your own tools break.
+
 ## Important Constraints
 
 - **Line ranges must be valid** (start_line > 0, end_line >= start_line)

--- a/props/debug/glm46_exec_env_stringification.md
+++ b/props/debug/glm46_exec_env_stringification.md
@@ -48,7 +48,6 @@ it isn't fully isolated.)
 - **Removed the `env` / `inherit_env` knob from `DirectExecArgs`** (`mcp_infra/exec/subprocess.py`).
   Direct exec now always inherits the ambient environment; nothing set `env` on direct exec, and
   agents reviewing code never need it. The model no longer sees the field, so it can't trip on it.
-  Regression test: `mcp_infra/exec/test_direct.py::test_direct_exec_omits_env_knob`.
 - **Generalized the critic's `report_failure`** into an explicit escape hatch (tool docstring +
   `prompt.md.mako`): call it when blocked by tooling/environment/validation instead of hallucinating
   or submitting a partial critique. (Not for "can't run/build the code" — review is static.)

--- a/props/debug/glm46_exec_env_stringification.md
+++ b/props/debug/glm46_exec_env_stringification.md
@@ -1,0 +1,68 @@
+# glm-4.6 stringifies optional tool-call args → 100% `exec` failure
+
+**Date:** 2026-06-04
+**Status:** mitigated (root knob removed); upstream cause not fully isolated — see Follow-up.
+
+## Symptom
+
+A live critic run on `glm-4.6` (z.ai via LiteLLM), run id `824e8815-fbd3-44a4-b57d-6f059d84df83`,
+produced garbage: **all 55 `exec` tool calls failed**, so the agent never read a single file. Its 3
+"issues" were 2 meta-complaints about `exec` being broken + 1 hallucination (`hardcoded-api-credentials`
+at a line it never read) → ~0 grading credit. This is why `glm-4.6` critics had ~0 recall.
+
+Every `exec` call returned the same validation error:
+
+```json
+[{ "type": "list_type", "loc": ["env"], "msg": "Input should be a valid list", "input": "null" }]
+```
+
+The model sent the optional `env` arg as a JSON-encoded **string** — `"null"`, `"[]"`,
+`'["PATH=/usr/bin:/bin"]'` — instead of native JSON `null` / `[]` / `[...]`. (It also stringified
+`stdin_text` to `"null"`, which _silently passed_ as the literal string, since that field is `str | None`.)
+
+## Root cause
+
+- `DirectExecArgs.env` was `list[EnvVar] | None` (strict, `extra="forbid"`). A `str` is not a `list` → rejected.
+- The critic's tools are sent with OpenAI **strict** tool-calling, which forces **every** field into
+  `required` — so the model is compelled to emit the optional `env` on every call (it can't omit it),
+  and `glm-4.6` fills the nullable value as a quoted string. Note `cmd` (a required, non-nullable
+  `list[str]`) came through correctly as a native array — only the **nullable/optional** `env` (an
+  `anyOf: [array, null]`) got stringified.
+
+## Where the bug is NOT
+
+The tool schema **we send** is correctly typed (verified from the logged request `tools[]`):
+
+```json
+"env": {"anyOf": [{"type": "array", "items": {"type": "string", "pattern": "^[^=]+=.*$"}}, {"type": "null"}], "default": null}
+```
+
+So props/agent*core is exonerated. The stringification is downstream — LiteLLM's Responses-API↔z.ai
+translation, or z.ai/GLM ignoring the `anyOf`+strict schema. (`function_call.arguments` is a JSON
+string the model produces and LiteLLM passes through ~verbatim, which \_leans* toward the model
+producing `env="null"` — but LiteLLM also re-translates the tool **schema** before z.ai sees it, so
+it isn't fully isolated.)
+
+## Mitigation applied
+
+- **Removed the `env` / `inherit_env` knob from `DirectExecArgs`** (`mcp_infra/exec/subprocess.py`).
+  Direct exec now always inherits the ambient environment; nothing set `env` on direct exec, and
+  agents reviewing code never need it. The model no longer sees the field, so it can't trip on it.
+  Regression test: `mcp_infra/exec/test_direct.py::test_direct_exec_omits_env_knob`.
+- **Generalized the critic's `report_failure`** into an explicit escape hatch (tool docstring +
+  `prompt.md.mako`): call it when blocked by tooling/environment/validation instead of hallucinating
+  or submitting a partial critique. (Not for "can't run/build the code" — review is static.)
+
+## Follow-up (not done)
+
+1. **Isolate LiteLLM vs z.ai/GLM.** Call LiteLLM directly with a minimal tool that has a nullable
+   param, model `glm-4.6`, comparing `/v1/responses` vs `/v1/chat/completions` — does only the
+   Responses path stringify? Or enable LiteLLM debug logging / inspect Langfuse to capture the exact
+   z.ai-bound request (translated schema) + raw response.
+2. **Broader risk:** `glm-4.6` stringified `stdin_text` too (silently passed). Other tools with
+   optional/nullable args (grader, critic_dev) may carry subtle silently-wrong values under strict
+   tool-calling on this model. Consider a general mitigation: coerce stringified args at the
+   `agent_core` arg-parse boundary, and/or avoid forcing optional/nullable fields into `required` in
+   strict tool schemas.
+3. **Observability:** `GET /api/runs/{id}/logs` (Loki) currently times out (separate note) — it would
+   have surfaced this failure far faster than reconstructing it from the transcript.


### PR DESCRIPTION
## Problem

A live `glm-4.6` critic (run `824e8815`) **failed 100% of its `exec` calls** and produced garbage (2 meta-complaints about `exec` + 1 hallucinated finding → ~0 recall). Every call returned:

```
[{"type":"list_type","loc":["env"],"msg":"Input should be a valid list","input":"null"}]
```

Root cause: under OpenAI **strict** tool-calling, every field is forced into `required`, so the model must emit the optional `env` arg on every call — and `glm-4.6` serializes it as a JSON-encoded **string** (`"null"` / `"[]"` / `'["PATH=..."]'`) instead of native JSON. `DirectExecArgs.env` was `list[EnvVar] | None`, so Pydantic rejected the string. The schema **we send** is correctly typed (`anyOf:[array,null]`) — the stringification is downstream (LiteLLM translation or z.ai/GLM), not yet fully isolated.

## Changes

- **Drop the `env`/`inherit_env` knob from `DirectExecArgs`** (`mcp_infra/exec/subprocess.py`). Direct exec always inherits the ambient environment; nothing set `env` on direct exec and agents reviewing code never need it, so the model can no longer trip on it. Regression test: `test_direct_exec_omits_env_knob`.
- **Generalize the critic's `report_failure`** into an explicit escape hatch (tool docstring + `prompt.md.mako`): call it when blocked by tooling/environment/validation (e.g. `exec` errors on every command, can't read files, `submit` keeps rejecting valid issues) instead of hallucinating or submitting a partial critique. Explicitly **not** for "can't run/build the code" — review is static.
- **Document** the underlying glm-4.6 / LiteLLM arg-stringification problem + open follow-up in `props/debug/glm46_exec_env_stringification.md` (incl. the broader risk that glm-4.6 also stringified `stdin_text`, so other tools' optional/nullable args may carry silently-wrong values).

## Verification (RBE, green — `73a03f43-5103-4d11-b269-0910f672aa7a`)

`mcp_infra/exec:test_direct` (incl. new schema test), `:test_mcp_integration`, and `props/agents/critic:test_e2e` pass; lint/build clean on `subprocess` / `direct` / `bwrap` / `critic:main` (no `env` consumer broke).

## Follow-up (not in this PR)

Isolate whether the stringification is LiteLLM's Responses↔chat translation or z.ai/GLM (see debug note); consider a general mitigation for models that stringify optional/nullable strict-tool args.

https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp9gYueW9AnLxKnChD2L2o)_