### PR TITLE
augur/calibration: fix redis_cache mypy errors breaking devel CI

### DIFF
--- a/augur/calibration/redis_cache.py
+++ b/augur/calibration/redis_cache.py
@@ -9,6 +9,8 @@ import os
 import time
 from collections.abc import Callable, Mapping
 from contextlib import AbstractAsyncContextManager
+from functools import partial
+from types import TracebackType
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 
@@ -58,7 +60,9 @@ class MarketSnapshot(BaseModel):
 
 class AsyncKeyValueContext(AbstractAsyncContextManager[AsyncKeyValue], Protocol):
     async def __aenter__(self) -> AsyncKeyValue: ...
-    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool | None: ...
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> bool | None: ...
 
 
 StoreFactory = Callable[[], AsyncKeyValueContext]
@@ -81,7 +85,9 @@ class ValkeyStoreContext:
         self._store = store
         return await store.__aenter__()
 
-    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+    ) -> bool | None:
         if self._store is None:
             return None
         return await self._store.__aexit__(exc_type, exc, tb)
@@ -127,7 +133,7 @@ def wrap_price_clients_with_redis_cache(
         platform: RedisCachingPriceClient(
             platform=platform,
             upstream=client,
-            store_factory=lambda config=config: ValkeyStoreContext(config),
+            store_factory=partial(ValkeyStoreContext, config),
             ttl_seconds=config.ttl_seconds,
             retention_seconds=config.retention_seconds,
             clock=clock,


### PR DESCRIPTION
## What

Fixes 4 mypy errors in `augur/calibration/redis_cache.py` (landed in `697838c`) that are currently **breaking `bazel-ci` on `devel`** (the mypy lint aspect fails, so every PR built against `devel` inherits a red build).

- `ValkeyStoreContext.__aexit__` (and the `AsyncKeyValueContext` Protocol) declared their params as `object`, but `__aexit__` forwards them to `ValkeyStore.__aexit__`, which expects `type[BaseException] | None` / `BaseException | None` / `TracebackType | None`. Typed both `__aexit__` signatures precisely so the forwarding call checks (3 errors at line 87).
- Replaced the un-inferable `store_factory=lambda config=config: ValkeyStoreContext(config)` with `partial(ValkeyStoreContext, config)` so mypy can resolve the factory type (1 error at line 130).

## Test

- `bazel build --config=rbe //augur/calibration:redis_cache` — clean with lint (mypy + ruff).
- `bazel test --config=rbe //augur/calibration:test_redis_cache` — PASSED.
- `pre-commit` clean on the file.

Standalone fix split out of the augur JAX-engine PR (#1905) so it can land on `devel` independently and unblock everyone's CI.

https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYv5maUG91A17axRLcNNMZ)_