### PR TITLE
props: support chat completions LLM models

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -38,6 +38,7 @@ py_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":tool_provider",
+        "//openai_utils:api_shape",
         "//openai_utils:model",
         "@pypi//pydantic",
     ],
@@ -114,6 +115,19 @@ py_library(
 )
 
 py_library(
+    name = "model",
+    srcs = ["model.py"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//openai_utils:api_shape",
+        "//openai_utils:model",
+        "//openai_utils:retry",
+        "@pypi//openai",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "agent",
     srcs = ["agent.py"],
     visibility = ["//visibility:public"],
@@ -121,6 +135,7 @@ py_library(
         ":events",
         ":handler",
         ":loop_control",
+        ":model",
         ":tool_provider",
         "//openai_utils:model",
         "//openai_utils:types",
@@ -238,6 +253,20 @@ py_test(
         "@pypi//more_itertools",
         "@pypi//pydantic",
         "@pypi//pyhamcrest",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_chat_model_adapter",
+    srcs = ["test_chat_model_adapter.py"],
+    deps = [
+        ":conftest",
+        ":model",
+        "//openai_utils:model",
+        "@pypi//httpx",
+        "@pypi//openai",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -40,6 +40,7 @@ py_library(
         ":tool_provider",
         "//openai_utils:api_shape",
         "//openai_utils:model",
+        "@pypi//openai",
         "@pypi//pydantic",
     ],
 )
@@ -266,6 +267,28 @@ py_test(
         ":model",
         "//openai_utils:model",
         "@pypi//httpx",
+        "@pypi//openai",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_zai_chat_adapter_live",
+    srcs = ["test_zai_chat_adapter_live.py"],
+    env_inherit = [
+        "ZAI_API_KEY",
+        "ZAI_MODEL",
+    ],
+    tags = [
+        "live_openai_api",
+        "no-remote-exec",
+    ],
+    deps = [
+        ":conftest",
+        ":model",
+        "//openai_utils:api_shape",
+        "//openai_utils:model",
         "@pypi//openai",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/agent_core/agent.py
+++ b/agent_core/agent.py
@@ -39,6 +39,7 @@ from agent_core.loop_control import (
     RequireSpecific,
     ToolPolicy,
 )
+from agent_core.model import AgentModelProto, AgentModelRequest, ResponsesAgentModel
 from agent_core.tool_provider import ImageContent, ResultContent, TextContent, ToolOutputData, ToolProvider, ToolResult
 from openai_utils.model import (
     AssistantMessage,
@@ -49,7 +50,6 @@ from openai_utils.model import (
     InputItem,
     OpenAIModelProto,
     ReasoningItem,
-    ResponsesRequest,
     SystemMessage,
     ToolChoice,
     ToolChoiceFunction,
@@ -362,7 +362,7 @@ class Agent:
         self,
         *,
         tool_provider: ToolProvider,
-        client: OpenAIModelProto,
+        client: AgentModelProto | OpenAIModelProto,
         reasoning_effort: ReasoningEffort | None = None,
         reasoning_summary: ReasoningSummary | None = None,
         parallel_tool_calls: bool,
@@ -371,7 +371,7 @@ class Agent:
         dynamic_instructions: Callable[[], Awaitable[str]] | None = None,
     ) -> None:
         self._tool_provider = tool_provider
-        self._client = client
+        self._client = client if isinstance(client, AgentModelProto) else ResponsesAgentModel(client)
         self._parallel_tool_calls = parallel_tool_calls
         self._tool_policy = tool_policy
         self._transcript: list[TranscriptItem] = []
@@ -585,10 +585,9 @@ class Agent:
             prompt_file = Path(__file__).parent / "compaction_prompt.md"
             custom_prompt = prompt_file.read_text()
 
-        # Build summarization request
-        req = ResponsesRequest(input=[UserMessage.text(conversation)], instructions=custom_prompt, stream=False)
+        req = AgentModelRequest(input=[UserMessage.text(conversation)], instructions=custom_prompt, stream=False)
 
-        resp = await self._client.responses_create(req)
+        resp = await self._client.sample(self._client.prepare(req))
 
         # Extract text from response
         if resp.output and len(resp.output) > 0:
@@ -858,7 +857,7 @@ class Agent:
             # Build OpenAI Responses tools list from tool provider
             tool_schemas = await self._tool_provider.list_tools()
 
-            req = ResponsesRequest(
+            req = AgentModelRequest(
                 input=self.to_openai_messages(),
                 instructions=await self._build_effective_instructions(),
                 stream=False,
@@ -875,12 +874,19 @@ class Agent:
             # and reconstructing full request from transcript + metadata.
             request_id = uuid4()
             phase_number = sum(1 for evt in self._transcript if isinstance(evt, Response))
+            prepared_request = self._client.prepare(req)
             for h in self._handlers:
                 h.on_api_request_event(
-                    ApiRequest(request=req, model=self._client.model, request_id=request_id, phase_number=phase_number)
+                    ApiRequest(
+                        api_shape=prepared_request.api_shape,
+                        request=prepared_request.wire_body,
+                        model=self._client.model,
+                        request_id=request_id,
+                        phase_number=phase_number,
+                    )
                 )
 
-            resp = await self._client.responses_create(req)
+            resp = await self._client.sample(prepared_request)
             sdk_usage = resp.usage
             usage = (
                 GroundTruthUsage(
@@ -971,7 +977,7 @@ class Agent:
         *,
         tool_provider: ToolProvider,
         handlers: Iterable[BaseHandler],
-        client: OpenAIModelProto,
+        client: AgentModelProto | OpenAIModelProto,
         reasoning_effort: ReasoningEffort | None = None,
         reasoning_summary: ReasoningSummary | None = None,
         parallel_tool_calls: bool = True,

--- a/agent_core/events.py
+++ b/agent_core/events.py
@@ -14,14 +14,15 @@ but doesn't "un-happen" the events. Consider splitting into:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
+from openai.types.chat.completion_create_params import CompletionCreateParamsNonStreaming
 from pydantic import BaseModel, Field
 
 from agent_core.tool_provider import ToolResult
 from openai_utils.api_shape import LLMApiShape
-from openai_utils.model import InputTokensDetails, OutputTokensDetails, ReasoningItem
+from openai_utils.model import InputTokensDetails, OutputTokensDetails, ReasoningItem, ResponsesRequest
 
 
 # ---- Ground-truth usage (OpenAI upstream fields only; no derived numbers) ----
@@ -72,7 +73,7 @@ class ApiRequest(BaseModel):
     type: Literal["api_request"] = "api_request"
 
     api_shape: LLMApiShape = LLMApiShape.RESPONSES
-    request: dict[str, Any]
+    request: ResponsesRequest | CompletionCreateParamsNonStreaming
 
     # TODO: Consider moving model into ResponsesRequest and removing the "model handle" layer
     # Currently model lives on client, not in request object

--- a/agent_core/events.py
+++ b/agent_core/events.py
@@ -14,13 +14,14 @@ but doesn't "un-happen" the events. Consider splitting into:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 from agent_core.tool_provider import ToolResult
-from openai_utils.model import InputTokensDetails, OutputTokensDetails, ReasoningItem, ResponsesRequest
+from openai_utils.api_shape import LLMApiShape
+from openai_utils.model import InputTokensDetails, OutputTokensDetails, ReasoningItem
 
 
 # ---- Ground-truth usage (OpenAI upstream fields only; no derived numbers) ----
@@ -70,8 +71,8 @@ class ApiRequest(BaseModel):
 
     type: Literal["api_request"] = "api_request"
 
-    # The complete request (reuses existing typed model)
-    request: ResponsesRequest
+    api_shape: LLMApiShape = LLMApiShape.RESPONSES
+    request: dict[str, Any]
 
     # TODO: Consider moving model into ResponsesRequest and removing the "model handle" layer
     # Currently model lives on client, not in request object
@@ -83,7 +84,7 @@ class ApiRequest(BaseModel):
 
 
 class Response(BaseModel):
-    """One OpenAI responses.create result (non-streaming) with usage.
+    """One model result (non-streaming) with usage.
 
     Emitted once per model call to avoid duplicating usage across assistant/tool events.
     """

--- a/agent_core/model.py
+++ b/agent_core/model.py
@@ -8,7 +8,19 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from openai import AsyncOpenAI
-from openai.types.chat import CompletionCreateParams
+from openai.types import CompletionUsage
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageParam,
+    ChatCompletionMessageToolCallParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionToolChoiceOptionParam,
+    ChatCompletionToolMessageParam,
+    ChatCompletionToolParam,
+    ChatCompletionUserMessageParam,
+)
+from openai.types.chat.completion_create_params import CompletionCreateParamsNonStreaming
+from openai.types.shared_params.function_definition import FunctionDefinition
 from pydantic import BaseModel
 
 from openai_utils.api_shape import LLMApiShape
@@ -38,6 +50,8 @@ from openai_utils.model import (
 )
 from openai_utils.retry import chat_create_with_retries
 from openai_utils.types import ReasoningParams
+
+type AgentWireBody = ResponsesRequest | CompletionCreateParamsNonStreaming
 
 
 @dataclass(frozen=True)
@@ -70,7 +84,7 @@ class AgentModelRequest:
 class PreparedAgentModelRequest:
     api_shape: LLMApiShape
     request: AgentModelRequest
-    wire_body: dict[str, Any]
+    wire_body: AgentWireBody
 
 
 @dataclass(frozen=True)
@@ -102,8 +116,7 @@ class ResponsesAgentModel(AgentModelProto):
 
     def prepare(self, request: AgentModelRequest) -> PreparedAgentModelRequest:
         responses_request = request.to_responses_request()
-        wire_body = responses_request.model_dump(mode="json", exclude_none=True)
-        wire_body["model"] = self.model
+        wire_body = responses_request.model_copy(update={"model": self.model})
         return PreparedAgentModelRequest(api_shape=self.api_shape, request=request, wire_body=wire_body)
 
     async def sample(self, request: PreparedAgentModelRequest) -> AgentModelResult:
@@ -118,7 +131,7 @@ class ChatCompletionsAgentModel(AgentModelProto):
     api_shape: LLMApiShape = LLMApiShape.CHAT_COMPLETIONS
 
     def prepare(self, request: AgentModelRequest) -> PreparedAgentModelRequest:
-        body: dict[str, Any] = {
+        body: CompletionCreateParamsNonStreaming = {
             "model": self.model,
             "messages": _input_to_chat_messages(request.input, request.instructions),
             "stream": False,
@@ -134,7 +147,9 @@ class ChatCompletionsAgentModel(AgentModelProto):
         return PreparedAgentModelRequest(api_shape=self.api_shape, request=request, wire_body=body)
 
     async def sample(self, request: PreparedAgentModelRequest) -> AgentModelResult:
-        response = await chat_create_with_retries(self.client, cast(CompletionCreateParams, request.wire_body))
+        response = await chat_create_with_retries(
+            self.client, cast(CompletionCreateParamsNonStreaming, request.wire_body)
+        )
         choice = response.choices[0]
         message = choice.message
         output: list[ResponseOutItem] = []
@@ -166,7 +181,7 @@ def _agent_result_from_responses(result: ResponsesResult) -> AgentModelResult:
     return AgentModelResult(id=result.id, usage=result.usage, output=result.output)
 
 
-def _content_text(content: Sequence[Any] | None) -> str:
+def _content_text(content: Sequence[InputTextPart | OutputTextPart | OutputText] | None) -> str:
     parts = [
         part.text
         for part in content or []
@@ -175,72 +190,66 @@ def _content_text(content: Sequence[Any] | None) -> str:
     return "\n".join(parts)
 
 
-def _chat_message_text(content: Any) -> str:
+def _chat_message_text(content: str | None) -> str:
     if content is None:
         return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, Sequence):
-        parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict) and isinstance(part.get("text"), str):
-                parts.append(part["text"])
-            elif isinstance(part, BaseModel):
-                data = part.model_dump(mode="json")
-                if isinstance(data.get("text"), str):
-                    parts.append(data["text"])
-        return "\n".join(parts)
-    return str(content)
+    return content
 
 
-def _message_extra_str(message: Any, key: str) -> str | None:
-    if not isinstance(message, BaseModel):
-        return None
+def _message_extra_str(message: BaseModel, key: str) -> str | None:
     data = message.model_dump(mode="json")
     value = data.get(key)
     if isinstance(value, str):
         return value
     extra = message.model_extra
     if isinstance(extra, dict):
-        extra_value = extra.get(key)
+        extra_value = cast(dict[str, Any], extra).get(key)
         if isinstance(extra_value, str):
             return extra_value
     return None
 
 
-def _input_to_chat_messages(input_items: list[InputItem] | str, instructions: str | None) -> list[dict[str, Any]]:
+def _input_to_chat_messages(
+    input_items: list[InputItem] | str, instructions: str | None
+) -> list[ChatCompletionMessageParam]:
     if isinstance(input_items, str):
-        messages: list[dict[str, Any]] = [{"role": "user", "content": input_items}]
+        messages: list[ChatCompletionMessageParam] = [ChatCompletionUserMessageParam(role="user", content=input_items)]
     else:
         messages = []
-        pending_tool_calls: list[dict[str, Any]] = []
+        pending_tool_calls: list[ChatCompletionMessageToolCallParam] = []
 
         def flush_tool_calls() -> None:
             nonlocal pending_tool_calls
             if pending_tool_calls:
-                messages.append({"role": "assistant", "content": None, "tool_calls": pending_tool_calls})
+                messages.append(
+                    ChatCompletionAssistantMessageParam(role="assistant", content=None, tool_calls=pending_tool_calls)
+                )
                 pending_tool_calls = []
 
         for item in input_items:
             if isinstance(item, FunctionCallItem):
                 pending_tool_calls.append(
-                    {
-                        "id": item.call_id,
-                        "type": "function",
-                        "function": {"name": item.name, "arguments": item.arguments or "{}"},
-                    }
+                    ChatCompletionMessageToolCallParam(
+                        id=item.call_id,
+                        type="function",
+                        function={"name": item.name, "arguments": item.arguments or "{}"},
+                    )
                 )
                 continue
 
             flush_tool_calls()
             if isinstance(item, UserMessage):
-                messages.append({"role": "user", "content": _content_text(item.content)})
+                messages.append(ChatCompletionUserMessageParam(role="user", content=_content_text(item.content)))
             elif isinstance(item, SystemMessage):
-                messages.append({"role": "system", "content": _content_text(item.content)})
+                messages.append(ChatCompletionSystemMessageParam(role="system", content=_content_text(item.content)))
             elif isinstance(item, AssistantMessage):
-                messages.append({"role": "assistant", "content": _content_text(item.content)})
+                messages.append(
+                    ChatCompletionAssistantMessageParam(role="assistant", content=_content_text(item.content))
+                )
             elif isinstance(item, FunctionCallOutputItem):
-                messages.append({"role": "tool", "tool_call_id": item.call_id, "content": item.output})
+                messages.append(
+                    ChatCompletionToolMessageParam(role="tool", tool_call_id=item.call_id, content=item.output)
+                )
             elif isinstance(item, ReasoningItem):
                 continue
             else:
@@ -251,12 +260,12 @@ def _input_to_chat_messages(input_items: list[InputItem] | str, instructions: st
         insert_at = 0
         while insert_at < len(messages) and messages[insert_at].get("role") == "system":
             insert_at += 1
-        messages.insert(insert_at, {"role": "system", "content": instructions})
+        messages.insert(insert_at, ChatCompletionSystemMessageParam(role="system", content=instructions))
     return messages
 
 
-def _tool_to_chat_tool(tool: FunctionToolParam) -> dict[str, Any]:
-    function: dict[str, Any] = {"name": tool.name, "parameters": tool.parameters}
+def _tool_to_chat_tool(tool: FunctionToolParam) -> ChatCompletionToolParam:
+    function = FunctionDefinition(name=tool.name, parameters=tool.parameters)
     if tool.description is not None:
         function["description"] = tool.description
     if tool.strict is not None:
@@ -264,7 +273,7 @@ def _tool_to_chat_tool(tool: FunctionToolParam) -> dict[str, Any]:
     return {"type": "function", "function": function}
 
 
-def _tool_choice_to_chat_tool_choice(tool_choice: ToolChoice) -> Any:
+def _tool_choice_to_chat_tool_choice(tool_choice: ToolChoice) -> ChatCompletionToolChoiceOptionParam:
     if isinstance(tool_choice, str):
         return tool_choice
     if isinstance(tool_choice, ToolChoiceFunction):
@@ -272,20 +281,15 @@ def _tool_choice_to_chat_tool_choice(tool_choice: ToolChoice) -> Any:
     raise TypeError(f"Unsupported tool_choice: {tool_choice!r}")
 
 
-def _chat_usage_to_response_usage(usage: Any) -> ResponseUsage | None:
+def _chat_usage_to_response_usage(usage: CompletionUsage | None) -> ResponseUsage | None:
     if usage is None:
         return None
-    if not isinstance(usage, BaseModel):
-        raise TypeError(f"Unsupported chat usage type: {type(usage).__name__}")
-    usage_data = usage.model_dump(mode="json")
-    prompt_details = usage_data.get("prompt_tokens_details")
-    completion_details = usage_data.get("completion_tokens_details")
-    cached_tokens = prompt_details.get("cached_tokens", 0) if isinstance(prompt_details, dict) else 0
-    reasoning_tokens = completion_details.get("reasoning_tokens", 0) if isinstance(completion_details, dict) else 0
+    cached_tokens = usage.prompt_tokens_details.cached_tokens if usage.prompt_tokens_details else None
+    reasoning_tokens = usage.completion_tokens_details.reasoning_tokens if usage.completion_tokens_details else None
     return ResponseUsage(
-        input_tokens=usage_data["prompt_tokens"],
-        output_tokens=usage_data["completion_tokens"],
-        total_tokens=usage_data["total_tokens"],
+        input_tokens=usage.prompt_tokens,
+        output_tokens=usage.completion_tokens,
+        total_tokens=usage.total_tokens,
         input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens or 0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens or 0),
     )

--- a/agent_core/model.py
+++ b/agent_core/model.py
@@ -1,0 +1,291 @@
+"""Model adapters used by the agent loop."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from openai import AsyncOpenAI
+from openai.types.chat import CompletionCreateParams
+from pydantic import BaseModel
+
+from openai_utils.api_shape import LLMApiShape
+from openai_utils.model import (
+    AssistantMessage,
+    AssistantMessageOut,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    FunctionToolParam,
+    InputItem,
+    InputTextPart,
+    InputTokensDetails,
+    OpenAIModelProto,
+    OutputText,
+    OutputTextPart,
+    OutputTokensDetails,
+    ReasoningContentItem,
+    ReasoningItem,
+    ResponseOutItem,
+    ResponsesRequest,
+    ResponsesResult,
+    ResponseUsage,
+    SystemMessage,
+    ToolChoice,
+    ToolChoiceFunction,
+    UserMessage,
+)
+from openai_utils.retry import chat_create_with_retries
+from openai_utils.types import ReasoningParams
+
+
+@dataclass(frozen=True)
+class AgentModelRequest:
+    input: list[InputItem] | str
+    instructions: str | None = None
+    tools: list[FunctionToolParam] | None = None
+    tool_choice: ToolChoice | None = None
+    parallel_tool_calls: bool | None = None
+    stream: bool = False
+    store: bool | None = None
+    reasoning: ReasoningParams | None = None
+    max_output_tokens: int | None = None
+
+    def to_responses_request(self) -> ResponsesRequest:
+        return ResponsesRequest(
+            input=self.input,
+            instructions=self.instructions,
+            tools=self.tools,
+            tool_choice=self.tool_choice,
+            parallel_tool_calls=self.parallel_tool_calls,
+            stream=self.stream,
+            store=self.store,
+            reasoning=self.reasoning,
+            max_output_tokens=self.max_output_tokens,
+        )
+
+
+@dataclass(frozen=True)
+class PreparedAgentModelRequest:
+    api_shape: LLMApiShape
+    request: AgentModelRequest
+    wire_body: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgentModelResult:
+    id: str
+    usage: ResponseUsage | None
+    output: list[ResponseOutItem]
+
+
+class AgentModelProto(ABC):
+    model: str
+    api_shape: LLMApiShape
+
+    @abstractmethod
+    def prepare(self, request: AgentModelRequest) -> PreparedAgentModelRequest: ...
+
+    @abstractmethod
+    async def sample(self, request: PreparedAgentModelRequest) -> AgentModelResult: ...
+
+
+@dataclass
+class ResponsesAgentModel(AgentModelProto):
+    base: OpenAIModelProto
+    model: str = ""
+    api_shape: LLMApiShape = LLMApiShape.RESPONSES
+
+    def __post_init__(self) -> None:
+        self.model = self.base.model
+
+    def prepare(self, request: AgentModelRequest) -> PreparedAgentModelRequest:
+        responses_request = request.to_responses_request()
+        wire_body = responses_request.model_dump(mode="json", exclude_none=True)
+        wire_body["model"] = self.model
+        return PreparedAgentModelRequest(api_shape=self.api_shape, request=request, wire_body=wire_body)
+
+    async def sample(self, request: PreparedAgentModelRequest) -> AgentModelResult:
+        result = await self.base.responses_create(request.request.to_responses_request())
+        return _agent_result_from_responses(result)
+
+
+@dataclass
+class ChatCompletionsAgentModel(AgentModelProto):
+    client: AsyncOpenAI
+    model: str
+    api_shape: LLMApiShape = LLMApiShape.CHAT_COMPLETIONS
+
+    def prepare(self, request: AgentModelRequest) -> PreparedAgentModelRequest:
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": _input_to_chat_messages(request.input, request.instructions),
+            "stream": False,
+        }
+        if request.tools is not None:
+            body["tools"] = [_tool_to_chat_tool(tool) for tool in request.tools]
+        if request.tool_choice is not None:
+            body["tool_choice"] = _tool_choice_to_chat_tool_choice(request.tool_choice)
+        if request.parallel_tool_calls is not None:
+            body["parallel_tool_calls"] = request.parallel_tool_calls
+        if request.max_output_tokens is not None:
+            body["max_completion_tokens"] = request.max_output_tokens
+        return PreparedAgentModelRequest(api_shape=self.api_shape, request=request, wire_body=body)
+
+    async def sample(self, request: PreparedAgentModelRequest) -> AgentModelResult:
+        response = await chat_create_with_retries(self.client, cast(CompletionCreateParams, request.wire_body))
+        choice = response.choices[0]
+        message = choice.message
+        output: list[ResponseOutItem] = []
+
+        reasoning_text = _message_extra_str(message, "reasoning_content")
+        if reasoning_text:
+            output.append(ReasoningItem(content=[ReasoningContentItem(text=reasoning_text)]))
+
+        text = _chat_message_text(message.content)
+        if text:
+            output.append(AssistantMessageOut(content=[OutputText(text=text)]))
+
+        output.extend(
+            [
+                FunctionCallItem(
+                    name=tool_call.function.name,
+                    arguments=tool_call.function.arguments,
+                    call_id=tool_call.id,
+                    id=tool_call.id,
+                )
+                for tool_call in message.tool_calls or []
+            ]
+        )
+
+        return AgentModelResult(id=response.id, usage=_chat_usage_to_response_usage(response.usage), output=output)
+
+
+def _agent_result_from_responses(result: ResponsesResult) -> AgentModelResult:
+    return AgentModelResult(id=result.id, usage=result.usage, output=result.output)
+
+
+def _content_text(content: Sequence[Any] | None) -> str:
+    parts = [
+        part.text
+        for part in content or []
+        if isinstance(part, InputTextPart | OutputTextPart | OutputText) and part.text
+    ]
+    return "\n".join(parts)
+
+
+def _chat_message_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+            elif isinstance(part, BaseModel):
+                data = part.model_dump(mode="json")
+                if isinstance(data.get("text"), str):
+                    parts.append(data["text"])
+        return "\n".join(parts)
+    return str(content)
+
+
+def _message_extra_str(message: Any, key: str) -> str | None:
+    if not isinstance(message, BaseModel):
+        return None
+    data = message.model_dump(mode="json")
+    value = data.get(key)
+    if isinstance(value, str):
+        return value
+    extra = message.model_extra
+    if isinstance(extra, dict):
+        extra_value = extra.get(key)
+        if isinstance(extra_value, str):
+            return extra_value
+    return None
+
+
+def _input_to_chat_messages(input_items: list[InputItem] | str, instructions: str | None) -> list[dict[str, Any]]:
+    if isinstance(input_items, str):
+        messages: list[dict[str, Any]] = [{"role": "user", "content": input_items}]
+    else:
+        messages = []
+        pending_tool_calls: list[dict[str, Any]] = []
+
+        def flush_tool_calls() -> None:
+            nonlocal pending_tool_calls
+            if pending_tool_calls:
+                messages.append({"role": "assistant", "content": None, "tool_calls": pending_tool_calls})
+                pending_tool_calls = []
+
+        for item in input_items:
+            if isinstance(item, FunctionCallItem):
+                pending_tool_calls.append(
+                    {
+                        "id": item.call_id,
+                        "type": "function",
+                        "function": {"name": item.name, "arguments": item.arguments or "{}"},
+                    }
+                )
+                continue
+
+            flush_tool_calls()
+            if isinstance(item, UserMessage):
+                messages.append({"role": "user", "content": _content_text(item.content)})
+            elif isinstance(item, SystemMessage):
+                messages.append({"role": "system", "content": _content_text(item.content)})
+            elif isinstance(item, AssistantMessage):
+                messages.append({"role": "assistant", "content": _content_text(item.content)})
+            elif isinstance(item, FunctionCallOutputItem):
+                messages.append({"role": "tool", "tool_call_id": item.call_id, "content": item.output})
+            elif isinstance(item, ReasoningItem):
+                continue
+            else:
+                raise TypeError(f"Unsupported chat input item: {type(item).__name__}")
+        flush_tool_calls()
+
+    if instructions:
+        insert_at = 0
+        while insert_at < len(messages) and messages[insert_at].get("role") == "system":
+            insert_at += 1
+        messages.insert(insert_at, {"role": "system", "content": instructions})
+    return messages
+
+
+def _tool_to_chat_tool(tool: FunctionToolParam) -> dict[str, Any]:
+    function: dict[str, Any] = {"name": tool.name, "parameters": tool.parameters}
+    if tool.description is not None:
+        function["description"] = tool.description
+    if tool.strict is not None:
+        function["strict"] = tool.strict
+    return {"type": "function", "function": function}
+
+
+def _tool_choice_to_chat_tool_choice(tool_choice: ToolChoice) -> Any:
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, ToolChoiceFunction):
+        return {"type": "function", "function": {"name": tool_choice.name}}
+    raise TypeError(f"Unsupported tool_choice: {tool_choice!r}")
+
+
+def _chat_usage_to_response_usage(usage: Any) -> ResponseUsage | None:
+    if usage is None:
+        return None
+    if not isinstance(usage, BaseModel):
+        raise TypeError(f"Unsupported chat usage type: {type(usage).__name__}")
+    usage_data = usage.model_dump(mode="json")
+    prompt_details = usage_data.get("prompt_tokens_details")
+    completion_details = usage_data.get("completion_tokens_details")
+    cached_tokens = prompt_details.get("cached_tokens", 0) if isinstance(prompt_details, dict) else 0
+    reasoning_tokens = completion_details.get("reasoning_tokens", 0) if isinstance(completion_details, dict) else 0
+    return ResponseUsage(
+        input_tokens=usage_data["prompt_tokens"],
+        output_tokens=usage_data["completion_tokens"],
+        total_tokens=usage_data["total_tokens"],
+        input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens or 0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens or 0),
+    )

--- a/agent_core/test_chat_model_adapter.py
+++ b/agent_core/test_chat_model_adapter.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import httpx
 import pytest_bazel
 from openai import AsyncOpenAI
+from openai.types.chat.completion_create_params import CompletionCreateParamsNonStreaming
 
 from agent_core.model import AgentModelRequest, ChatCompletionsAgentModel
 from openai_utils.model import (
@@ -19,10 +21,11 @@ from openai_utils.model import (
 
 
 async def test_chat_adapter_prepares_and_parses_tool_call() -> None:
-    captured: dict[str, object] = {}
+    captured_body: CompletionCreateParamsNonStreaming | None = None
 
     def handler(request: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(request.content)
+        nonlocal captured_body
+        captured_body = cast(CompletionCreateParamsNonStreaming, json.loads(request.content))
         return httpx.Response(
             200,
             json={
@@ -83,7 +86,9 @@ async def test_chat_adapter_prepares_and_parses_tool_call() -> None:
         )
 
         prepared = model.prepare(request)
-        assert prepared.wire_body["messages"] == [
+        wire_body = prepared.wire_body
+        assert isinstance(wire_body, dict)
+        assert wire_body["messages"] == [
             {"role": "system", "content": "static system"},
             {"role": "system", "content": "dynamic instructions"},
             {"role": "user", "content": "hello"},
@@ -101,7 +106,7 @@ async def test_chat_adapter_prepares_and_parses_tool_call() -> None:
     finally:
         await http_client.aclose()
 
-    assert captured["body"] == prepared.wire_body
+    assert captured_body == prepared.wire_body
     assert result.id == "chatcmpl_test"
     assert result.usage is not None
     assert result.usage.input_tokens == 10

--- a/agent_core/test_chat_model_adapter.py
+++ b/agent_core/test_chat_model_adapter.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest_bazel
+from openai import AsyncOpenAI
+
+from agent_core.model import AgentModelRequest, ChatCompletionsAgentModel
+from openai_utils.model import (
+    AssistantMessageOut,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    FunctionToolParam,
+    ReasoningItem,
+    SystemMessage,
+    UserMessage,
+)
+
+
+async def test_chat_adapter_prepares_and_parses_tool_call() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl_test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "chat-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "reasoning_content": "I should call the tool.",
+                            "content": "Calling now.",
+                            "tool_calls": [
+                                {
+                                    "id": "call_2",
+                                    "type": "function",
+                                    "function": {"name": "next_tool", "arguments": '{"ok": true}'},
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "prompt_tokens_details": {"cached_tokens": 3},
+                    "completion_tokens": 5,
+                    "completion_tokens_details": {"reasoning_tokens": 2},
+                    "total_tokens": 15,
+                },
+            },
+        )
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        client = AsyncOpenAI(base_url="http://test/v1", api_key="sk-test", http_client=http_client)
+        model = ChatCompletionsAgentModel(client=client, model="chat-model")
+        request = AgentModelRequest(
+            input=[
+                SystemMessage.text("static system"),
+                UserMessage.text("hello"),
+                FunctionCallItem(name="first_tool", arguments='{"x": 1}', call_id="call_1"),
+                FunctionCallOutputItem(call_id="call_1", output='{"result": 2}'),
+            ],
+            instructions="dynamic instructions",
+            tools=[
+                FunctionToolParam(
+                    name="next_tool",
+                    description="Next tool",
+                    parameters={"type": "object", "properties": {}, "additionalProperties": False},
+                    strict=True,
+                )
+            ],
+            tool_choice="required",
+            parallel_tool_calls=False,
+        )
+
+        prepared = model.prepare(request)
+        assert prepared.wire_body["messages"] == [
+            {"role": "system", "content": "static system"},
+            {"role": "system", "content": "dynamic instructions"},
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "first_tool", "arguments": '{"x": 1}'}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"result": 2}'},
+        ]
+
+        result = await model.sample(prepared)
+    finally:
+        await http_client.aclose()
+
+    assert captured["body"] == prepared.wire_body
+    assert result.id == "chatcmpl_test"
+    assert result.usage is not None
+    assert result.usage.input_tokens == 10
+    assert result.usage.input_tokens_details is not None
+    assert result.usage.input_tokens_details.cached_tokens == 3
+    assert result.usage.output_tokens == 5
+    assert result.usage.output_tokens_details is not None
+    assert result.usage.output_tokens_details.reasoning_tokens == 2
+    assert isinstance(result.output[0], ReasoningItem)
+    assert isinstance(result.output[1], AssistantMessageOut)
+    assert isinstance(result.output[2], FunctionCallItem)
+    assert result.output[2].call_id == "call_2"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/agent_core/test_zai_chat_adapter_live.py
+++ b/agent_core/test_zai_chat_adapter_live.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest_bazel
+from openai import AsyncOpenAI
+
+from agent_core.model import AgentModelRequest, ChatCompletionsAgentModel
+from openai_utils.api_shape import LLMApiShape
+from openai_utils.model import FunctionCallItem, FunctionToolParam, UserMessage
+
+
+async def test_zai_chat_adapter_tool_call_live() -> None:
+    api_key = os.environ.get("ZAI_API_KEY")
+    assert api_key, "ZAI_API_KEY must be set for the live z.ai chat adapter smoke test"
+
+    client = AsyncOpenAI(base_url="https://api.z.ai/api/coding/paas/v4", api_key=api_key)
+    model = ChatCompletionsAgentModel(client=client, model=os.environ.get("ZAI_MODEL", "glm-4.6"))
+    request = AgentModelRequest(
+        input=[UserMessage.text('Call record_result with exactly {"answer": "ok"}.')],
+        instructions="Use record_result. Do not answer in prose.",
+        tools=[
+            FunctionToolParam(
+                name="record_result",
+                description="Record the final answer for the test harness.",
+                parameters={
+                    "type": "object",
+                    "properties": {"answer": {"type": "string", "enum": ["ok"]}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+                strict=True,
+            )
+        ],
+        tool_choice="auto",
+        max_output_tokens=256,
+    )
+
+    prepared = model.prepare(request)
+    assert prepared.api_shape == LLMApiShape.CHAT_COMPLETIONS
+
+    try:
+        result = await model.sample(prepared)
+    finally:
+        await client.close()
+
+    tool_calls = [item for item in result.output if isinstance(item, FunctionCallItem)]
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "record_result"
+    arguments = tool_calls[0].arguments
+    assert arguments is not None
+    assert json.loads(arguments) == {"answer": "ok"}
+    assert result.usage is not None
+    assert result.usage.total_tokens > 0
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -27,9 +27,8 @@ PGDATABASE = "eval_results"
 url = "http://ollama.ollama.svc.cluster.local:11434/v1"
 api_key_env = "OLLAMA_API_KEY"
 
-# In-cluster LiteLLM. props speaks the OpenAI Responses API ({url}/responses);
-# LiteLLM bridges that to the upstream's chat/completions (e.g. z.ai's GLM,
-# which has no native Responses API). Auth = LiteLLM master key.
+# In-cluster LiteLLM. Chat-shaped models use props' /v1/chat/completions
+# endpoint directly so LiteLLM stays on its native chat path.
 [upstreams.litellm]
 url = "http://litellm.litellm.svc.cluster.local:4000/v1"
 api_key_env = "LITELLM_API_KEY"
@@ -50,6 +49,7 @@ max_parallel_agents = 3
 name = "glm-4.6"
 upstream = "litellm"
 upstream_model = "glm-4.6"
+api_shape = "chat_completions"
 input_usd_per_1m_tokens = 0.39
 cached_input_usd_per_1m_tokens = 0.39
 output_usd_per_1m_tokens = 1.74

--- a/docs/z_ai_api.md
+++ b/docs/z_ai_api.md
@@ -72,6 +72,20 @@ The Chat Completions endpoint supports tools in the OpenAI-compatible `tools` ar
 
 See `open.bigmodel.cn/dev/api/normal-model/glm-4` for the full tool-use request format.
 
+Empirical notes for the coding endpoint (`glm-4.6`, measured 2026-06-05):
+
+- Function tools work with ordinary OpenAI chat-completions `tools`. The response uses
+  `finish_reason: "tool_calls"` and returns `message.tool_calls[]` with
+  `function.name` and JSON-string `function.arguments`.
+- `tool_choice: "auto"` works, and omitting `tool_choice` also works.
+- OpenAI strict tool metadata works: `function.strict: true`, `required`, `enum`, and
+  `additionalProperties: false` were accepted in a function tool schema.
+- Forced named tool choice in the OpenAI object form is rejected:
+  `{"type": "function", "function": {"name": "..."}}` returns `400` with
+  `{"error":{"code":"1210","message":"Invalid API parameter, please check the documentation."}}`.
+  If a caller needs z.ai to call a specific tool, use prompt instructions plus
+  `tool_choice: "auto"` rather than the forced named object shape.
+
 ## Not Supported
 
 - **OpenAI Responses API** (`/v1/responses`): returns 404 on both general and coding
@@ -130,6 +144,8 @@ models at $0) and the coding endpoint.
 
 - `thinking: {"type": "disabled"}` disables reasoning (reasoning_tokens → 0). Recommended for
   structured-output tasks that don't need chain-of-thought (e.g. JSON generation).
+- Both `max_completion_tokens` and legacy `max_tokens` are accepted by the OpenAI-compatible
+  chat-completions endpoint.
 - `response_format: {"type": "json_object"}` works on the paid coding models and on `glm-4.7-flash`,
   but free `glm-4.5-flash` returns `400` (`code 1210`, "Invalid API parameter") when `thinking` /
   `response_format` are present. **Probe a candidate model with the real generation params** before

--- a/openai_utils/BUILD.bazel
+++ b/openai_utils/BUILD.bazel
@@ -5,6 +5,12 @@ load("//openai_utils/testing:testing.bzl", "live_openai_py_test")
 # gazelle:exclude test_pydantic_strict_mode.py
 
 py_library(
+    name = "api_shape",
+    srcs = ["api_shape.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_library(
     name = "types",
     srcs = ["types.py"],
     visibility = ["//:__subpackages__"],

--- a/openai_utils/api_shape.py
+++ b/openai_utils/api_shape.py
@@ -1,0 +1,12 @@
+"""Shared OpenAI-compatible API shape primitives."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class LLMApiShape(StrEnum):
+    """OpenAI-compatible API shape used for a logical model."""
+
+    RESPONSES = "responses"
+    CHAT_COMPLETIONS = "chat_completions"

--- a/openai_utils/retry.py
+++ b/openai_utils/retry.py
@@ -77,7 +77,7 @@ async def chat_create_with_retries(client: AsyncOpenAI, params: CompletionCreate
     """
     if params.get("stream"):
         raise ValueError("chat_create_with_retries does not support streaming (stream=True)")
-    request_params: dict[str, Any] = dict(params)
+    request_params = dict(params)
     request_params.pop("stream", None)
     # Explicit stream=False ensures we get ChatCompletion (non-streaming) overload
     create: Callable[..., Awaitable[ChatCompletion]] = cast(

--- a/openai_utils/retry.py
+++ b/openai_utils/retry.py
@@ -77,11 +77,13 @@ async def chat_create_with_retries(client: AsyncOpenAI, params: CompletionCreate
     """
     if params.get("stream"):
         raise ValueError("chat_create_with_retries does not support streaming (stream=True)")
+    request_params: dict[str, Any] = dict(params)
+    request_params.pop("stream", None)
     # Explicit stream=False ensures we get ChatCompletion (non-streaming) overload
     create: Callable[..., Awaitable[ChatCompletion]] = cast(
         Callable[..., Awaitable[ChatCompletion]], client.chat.completions.create
     )
-    return await translate_context_length(create, stream=False, **params)
+    return await translate_context_length(create, stream=False, **request_params)
 
 
 @dataclass

--- a/props/BUILD.bazel
+++ b/props/BUILD.bazel
@@ -23,6 +23,7 @@ py_library(
     srcs = ["config.py"],
     visibility = ["//props:__subpackages__"],
     deps = [
+        "//openai_utils:api_shape",
         "//openai_utils:model_metadata",
         "@pypi//pydantic",
     ],

--- a/props/TODO.md
+++ b/props/TODO.md
@@ -16,4 +16,3 @@
 
 - Sane story for applying migrations without full `db recreate` (direct `alembic upgrade head`)
 - Bulk specimen sync in `props db sync` from Bazel bundle artifacts (currently one-by-one via `sync-specimen`)
-- LLM API shape: props is OpenAI-Responses-only (`backend/routes/llm.py` proxies `/v1/responses`). z.ai (no native `/responses`) only works through LiteLLM's `use_chat_completions_api` chat→Responses bridge, which mislabels GLM reasoning content as `output_text` (worked around by `ReasoningOutputTextItem` in `openai_utils/model.py`). Find a better fix: a LiteLLM config/version that emits `reasoning_text`, or teach props to speak `chat/completions` directly so reasoning doesn't round-trip the lossy Responses bridge.

--- a/props/agents/BUILD.bazel
+++ b/props/agents/BUILD.bazel
@@ -19,7 +19,9 @@ py_library(
     visibility = ["//props:__subpackages__"],
     deps = [
         ":schema",
+        "//agent_core:model",
         "//mako_utils:preprocessor",
+        "//openai_utils:api_shape",
         "//openai_utils:model",
         "//openai_utils:retry",
         "//props/db:database",

--- a/props/agents/critic_dev/authoring_agents.md.mako
+++ b/props/agents/critic_dev/authoring_agents.md.mako
@@ -40,7 +40,7 @@ The backend's LLM proxy at `OPENAI_BASE_URL` authenticates with `OPENAI_API_KEY`
 | Capability | Critic | Grader | Critic developer (you) |
 |------------|--------|--------|------------------------|
 | PostgreSQL (RLS-scoped) | Yes | Yes | Yes |
-| LLM proxy (`/v1/responses`) | Yes | Yes | Yes |
+| LLM proxy (`/v1/responses`, `/v1/chat/completions`) | Yes | Yes | Yes |
 | Runs API (`/api/runs/critic`) | No | No | Yes |
 | Registry proxy (`/v2/*`) | No | No | Yes |
 
@@ -161,7 +161,7 @@ The unified backend at `PROPS_BACKEND_URL` serves all functionality:
 |------|-------------|-------------|
 | `POST /api/runs/critic` | Run a critic agent on an example | Yes |
 | `/v2/*` | Registry proxy (OCI API) | Yes |
-| `/v1/responses` | LLM proxy (OpenAI API) | Yes |
+| `/v1/responses`, `/v1/chat/completions` | LLM proxy (OpenAI API) | Yes |
 | `/api/stats/*` | Dashboard stats | No (admin) |
 | `/api/runs/*` | Agent run management | No (admin) |
 | `/api/gt/*` | Ground truth management | No (admin) |

--- a/props/agents/critic_dev/rollouts.md.mako
+++ b/props/agents/critic_dev/rollouts.md.mako
@@ -4,9 +4,9 @@ Diagnostic queries for agent execution traces. Schema and basic queries are in t
 
 ## Extracting Tool Calls
 
-Tool calls appear as `function_call` items in `response_body->'output'`. Their results appear as `function_call_output` items in the *next* request's `request_body->'input'`.
+Tool-call JSON depends on `llm_requests.api_shape`.
 
-### Calls only
+### Responses calls
 
 ```sql
 SELECT r.created_at, r.model,
@@ -14,11 +14,12 @@ SELECT r.created_at, r.model,
 FROM llm_requests r,
     jsonb_array_elements(r.response_body->'output') AS tc
 WHERE r.agent_run_id = '<run_id>'
+  AND r.api_shape = 'responses'
   AND tc->>'type' = 'function_call'
 ORDER BY r.created_at;
 ```
 
-### Calls with outputs
+### Responses calls with outputs
 
 ```sql
 WITH calls AS (
@@ -28,6 +29,7 @@ WITH calls AS (
     FROM llm_requests r,
         jsonb_array_elements(r.response_body->'output') AS tc
     WHERE r.agent_run_id = '<run_id>'
+      AND r.api_shape = 'responses'
       AND tc->>'type' = 'function_call'
 ),
 outputs AS (
@@ -35,6 +37,7 @@ outputs AS (
     FROM llm_requests r,
         jsonb_array_elements(r.request_body->'input') AS item
     WHERE r.agent_run_id = '<run_id>'
+      AND r.api_shape = 'responses'
       AND item->>'type' = 'function_call_output'
 )
 SELECT c.created_at, c.model, c.tool_name, c.args,
@@ -42,6 +45,33 @@ SELECT c.created_at, c.model, c.tool_name, c.args,
 FROM calls c
 LEFT JOIN outputs o ON c.call_id = o.call_id
 ORDER BY c.created_at;
+```
+
+### Chat Completions calls
+
+```sql
+SELECT r.created_at, r.model,
+       tc->'function'->>'name' AS tool_name,
+       tc->'function'->>'arguments' AS args
+FROM llm_requests r,
+     jsonb_array_elements(r.response_body->'choices') AS choice,
+     jsonb_array_elements(COALESCE(choice->'message'->'tool_calls', '[]'::jsonb)) AS tc
+WHERE r.agent_run_id = '<run_id>'
+  AND r.api_shape = 'chat_completions'
+ORDER BY r.created_at;
+```
+
+### Chat Completions tool outputs
+
+```sql
+SELECT r.created_at, msg->>'tool_call_id' AS call_id,
+       LEFT(msg->>'content', 500) AS output_preview
+FROM llm_requests r,
+     jsonb_array_elements(r.request_body->'messages') AS msg
+WHERE r.agent_run_id = '<run_id>'
+  AND r.api_shape = 'chat_completions'
+  AND msg->>'role' = 'tool'
+ORDER BY r.created_at;
 ```
 
 ## Diagnostic Patterns

--- a/props/agents/docs/db/llm_requests.md.mako
+++ b/props/agents/docs/db/llm_requests.md.mako
@@ -6,14 +6,20 @@ The `llm_requests` table stores LLM API request/response payloads logged by the 
 
 ${describe_relation("llm_requests")}
 
-Each row captures a single OpenAI Responses API call made by an agent through the LLM proxy.
+Each row captures one LLM proxy call made by an agent. Use `api_shape` to read
+the raw JSON correctly:
+
+- `responses`: OpenAI Responses API payloads (`request_body->'input'`,
+  `response_body->'output'`)
+- `chat_completions`: OpenAI Chat Completions payloads
+  (`request_body->'messages'`, `response_body->'choices'`)
 
 ### Queries
 
 All LLM requests for a specific agent run:
 
 ```sql
-SELECT model, latency_ms, error, created_at
+SELECT model, api_shape, latency_ms, error, created_at
 FROM llm_requests
 WHERE agent_run_id = '<uuid>'
 ORDER BY created_at;
@@ -22,7 +28,7 @@ ORDER BY created_at;
 Full request/response payloads for debugging:
 
 ```sql
-SELECT request_body, response_body, error
+SELECT api_shape, request_body, response_body, error
 FROM llm_requests
 WHERE agent_run_id = '<uuid>'
 ORDER BY created_at;

--- a/props/agents/runtime.py
+++ b/props/agents/runtime.py
@@ -14,12 +14,14 @@ from openai import AsyncOpenAI
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from agent_core.model import AgentModelProto, ChatCompletionsAgentModel, ResponsesAgentModel
 from mako_utils.preprocessor import markdown_heading_preprocessor
-from openai_utils.model import BoundOpenAIModel, OpenAIModelProto
+from openai_utils.api_shape import LLMApiShape
+from openai_utils.model import BoundOpenAIModel
 from openai_utils.retry import RetryingOpenAIModel
 from props.agents.schema import describe_table
 from props.db.database import Database
-from props.db.models import AgentRun, AgentRunStatus
+from props.db.models import AgentRun, AgentRunStatus, ModelMetadata
 from props.db.queries import get_agent_run
 from props.db.snapshot_io import fetch_snapshot_to_path
 
@@ -136,16 +138,22 @@ def render_template_string(content: str, db: Database, helpers: dict[str, Any] |
     return result
 
 
-def create_bound_model_from_env(db: Database) -> OpenAIModelProto:
-    """Create a retrying OpenAI model using environment variables.
+def create_bound_model_from_env(db: Database) -> AgentModelProto:
+    """Create an agent model adapter using environment variables.
 
     Gets model from current agent run. Uses OPENAI_BASE_URL and OPENAI_API_KEY.
-    Wraps in RetryingOpenAIModel for automatic retries on transient errors (500,
-    rate limits, connection errors).
     """
     with db.session() as session:
         agent_run = get_current_agent_run(session)
         model = agent_run.model
+        metadata = session.get(ModelMetadata, model)
+        if metadata is None:
+            raise RuntimeError(f"Current agent run model is missing from model_metadata: {model}")
+        api_shape = LLMApiShape(metadata.api_shape)
 
     client = AsyncOpenAI(base_url=os.environ["OPENAI_BASE_URL"], api_key=os.environ["OPENAI_API_KEY"])
-    return RetryingOpenAIModel(base=BoundOpenAIModel(client=client, model=model))
+    if api_shape == LLMApiShape.RESPONSES:
+        return ResponsesAgentModel(base=RetryingOpenAIModel(base=BoundOpenAIModel(client=client, model=model)))
+    if api_shape == LLMApiShape.CHAT_COMPLETIONS:
+        return ChatCompletionsAgentModel(client=client, model=model)
+    raise RuntimeError(f"Unsupported model api_shape: {api_shape}")

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -81,6 +81,7 @@ py_library(
     visibility = ["//props/backend:__subpackages__"],
     deps = [
         ":ground_truth",
+        "//openai_utils:api_shape",
         "//openai_utils:model",
         "//props/backend:auth",
         "//props/backend:deps",
@@ -209,6 +210,7 @@ py_library(
     srcs = ["model_metadata.py"],
     visibility = ["//props/backend:__subpackages__"],
     deps = [
+        "//openai_utils:api_shape",
         "//props/backend:deps",
         "//props/db:models",
         "@pypi//fastapi",

--- a/props/backend/routes/BUILD.bazel
+++ b/props/backend/routes/BUILD.bazel
@@ -46,6 +46,7 @@ py_library(
     srcs = ["llm.py"],
     visibility = ["//visibility:public"],
     deps = [
+        "//openai_utils:api_shape",
         "//openai_utils:model",
         "//props:config",
         "//props/backend:auth",
@@ -126,6 +127,7 @@ py_test(
     requires_docker = True,
     deps = [
         ":llm",
+        "//openai_utils:api_shape",
         "//props:config",
         "//props:conftest",
         "//props/backend:conftest",

--- a/props/backend/routes/llm.py
+++ b/props/backend/routes/llm.py
@@ -1,9 +1,8 @@
 """LLM Proxy routes - OpenAI API proxy with auth, logging, and cost tracking.
 
-TODO: Rename this file to openai_responses_api.py since that's what we're emulating.
-
 Endpoints:
 - POST /v1/responses - OpenAI Responses API proxy (non-streaming only)
+- POST /v1/chat/completions - OpenAI Chat Completions API proxy (non-streaming only)
 
 Features:
 - Validates agent auth tokens against Postgres
@@ -28,6 +27,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
+from openai_utils.api_shape import LLMApiShape
 from openai_utils.model import ResponseUsage
 from props.backend.auth import AgentRole, Auth, AuthenticatedIdentity
 from props.backend.deps import AdminDb, Config
@@ -54,6 +54,22 @@ class UpstreamRoute:
     model_name: str  # Model name to send in API request
 
 
+@dataclass(frozen=True)
+class LLMAccess:
+    agent_run_id: UUID
+    allowed_model: str
+    budget_usd: float
+    parent_agent_run_id: UUID | None
+    agent_type: str
+
+
+@dataclass(frozen=True)
+class LLMUsageCounts:
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
 def _resolve_upstream_url(config: UpstreamConfig) -> str:
     """Resolve URL from static url or url_env."""
     if config.url:
@@ -63,7 +79,9 @@ def _resolve_upstream_url(config: UpstreamConfig) -> str:
     raise ValueError("Upstream config must have url or url_env")
 
 
-def _get_upstream_route(model_id: str, session: Session, config: LLMProxyConfig) -> UpstreamRoute:
+def _get_upstream_route(
+    model_id: str, session: Session, config: LLMProxyConfig, api_shape: LLMApiShape
+) -> UpstreamRoute:
     """Look up upstream routing info for a model.
 
     Returns UpstreamRoute with resolved URL, API key, and model name to send.
@@ -71,6 +89,10 @@ def _get_upstream_route(model_id: str, session: Session, config: LLMProxyConfig)
     metadata = session.get(ModelMetadata, model_id)
     if metadata is None:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
+    if metadata.api_shape != api_shape.value:
+        raise HTTPException(
+            status_code=400, detail=f"Model '{model_id}' uses api_shape='{metadata.api_shape}', not '{api_shape.value}'"
+        )
 
     # Determine which upstream to use (NULL = "openai" default)
     upstream_name = metadata.upstream_name
@@ -112,7 +134,7 @@ def _check_budget(session: Session, agent_run_id: UUID, budget_usd: float) -> No
         )
 
 
-def require_llm_access(auth: Auth, admin_db: AdminDb) -> tuple[UUID, str, float]:
+def require_llm_access(auth: Auth, admin_db: AdminDb) -> LLMAccess:
     """FastAPI dependency requiring LLM API access (agent credentials only).
 
     Returns (agent_run_id, allowed_model, budget_usd) or raises HTTPException.
@@ -128,56 +150,115 @@ def require_llm_access(auth: Auth, admin_db: AdminDb) -> tuple[UUID, str, float]
         if agent_run.status != AgentRunStatus.IN_PROGRESS:
             raise HTTPException(status_code=403, detail=f"Agent run is not in progress (status={agent_run.status})")
 
-        return auth.role.agent_run_id, agent_run.model, agent_run.budget_usd
+        return LLMAccess(
+            agent_run_id=auth.role.agent_run_id,
+            allowed_model=agent_run.model,
+            budget_usd=agent_run.budget_usd,
+            parent_agent_run_id=agent_run.parent_agent_run_id,
+            agent_type=agent_run.type_config.agent_type.value,
+        )
+
+
+def _extract_responses_usage(response_body: dict[str, Any] | None) -> LLMUsageCounts:
+    if response_body is None:
+        return LLMUsageCounts()
+    usage_body = response_body.get("usage")
+    if not isinstance(usage_body, dict):
+        return LLMUsageCounts()
+    usage = ResponseUsage.model_validate(usage_body)
+    return LLMUsageCounts(
+        input_tokens=usage.input_tokens,
+        cached_input_tokens=usage.input_tokens_details.cached_tokens if usage.input_tokens_details else None,
+        output_tokens=usage.output_tokens,
+    )
+
+
+def _extract_chat_completions_usage(response_body: dict[str, Any] | None) -> LLMUsageCounts:
+    if response_body is None:
+        return LLMUsageCounts()
+    usage_body = response_body.get("usage")
+    if not isinstance(usage_body, dict):
+        return LLMUsageCounts()
+    input_details = usage_body.get("prompt_tokens_details")
+    cached_tokens = input_details.get("cached_tokens") if isinstance(input_details, dict) else None
+    return LLMUsageCounts(
+        input_tokens=usage_body.get("prompt_tokens") if isinstance(usage_body.get("prompt_tokens"), int) else None,
+        cached_input_tokens=cached_tokens if isinstance(cached_tokens, int) else None,
+        output_tokens=usage_body.get("completion_tokens")
+        if isinstance(usage_body.get("completion_tokens"), int)
+        else None,
+    )
+
+
+def _extract_usage(api_shape: LLMApiShape, response_body: dict[str, Any] | None) -> LLMUsageCounts:
+    if api_shape == LLMApiShape.RESPONSES:
+        return _extract_responses_usage(response_body)
+    if api_shape == LLMApiShape.CHAT_COMPLETIONS:
+        return _extract_chat_completions_usage(response_body)
+    raise ValueError(f"Unsupported LLM API shape: {api_shape}")
 
 
 def _log_request(
     session: Session,
     agent_run_id: UUID,
     model: str,
+    api_shape: LLMApiShape,
     request_body: dict[str, Any],
     response_body: dict[str, Any] | None,
     error: str | None,
     latency_ms: int,
 ) -> None:
     """Log LLM request to database with token usage extracted from response."""
-    input_tokens = None
-    cached_input_tokens = None
-    output_tokens = None
+    usage = LLMUsageCounts()
     if response_body is not None and error is None:
-        usage = ResponseUsage.model_validate(response_body["usage"])
-        input_tokens = usage.input_tokens
-        cached_input_tokens = usage.input_tokens_details.cached_tokens if usage.input_tokens_details else None
-        output_tokens = usage.output_tokens
+        usage = _extract_usage(api_shape, response_body)
     llm_request = LLMRequest(
         agent_run_id=agent_run_id,
         model=model,
+        api_shape=api_shape.value,
         request_body=request_body,
         response_body=response_body,
         error=error,
-        input_tokens=input_tokens,
-        cached_input_tokens=cached_input_tokens,
-        output_tokens=output_tokens,
+        input_tokens=usage.input_tokens,
+        cached_input_tokens=usage.cached_input_tokens,
+        output_tokens=usage.output_tokens,
         latency_ms=latency_ms,
     )
     session.add(llm_request)
     session.commit()
 
 
-@router.post("/v1/responses")
-async def responses(
+def _merge_props_metadata(
+    body: dict[str, Any], *, access: LLMAccess, api_shape: LLMApiShape, logical_model: str, upstream_model: str
+) -> None:
+    metadata = body.get("metadata")
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise HTTPException(status_code=400, detail="metadata must be an object when provided")
+
+    props_metadata: dict[str, str] = {
+        "props.agent_run_id": str(access.agent_run_id),
+        "props.agent_type": access.agent_type,
+        "props.api_shape": api_shape.value,
+        "props.logical_model": logical_model,
+        "props.upstream_model": upstream_model,
+    }
+    if access.parent_agent_run_id is not None:
+        props_metadata["props.parent_agent_run_id"] = str(access.parent_agent_run_id)
+
+    body["metadata"] = {**metadata, **props_metadata}
+
+
+async def _proxy_openai_request(
     request: Request,
     admin_db: AdminDb,
     config: Config,
-    auth: Annotated[tuple[UUID, str, float], Depends(require_llm_access)],
+    access: LLMAccess,
+    *,
+    api_shape: LLMApiShape,
+    upstream_path: str,
 ) -> JSONResponse:
-    """Proxy OpenAI Responses API requests.
-
-    Validates model against agent's allowed model, checks budget,
-    resolves upstream routing, forwards request, logs with token usage, returns response.
-    """
-    agent_run_id, allowed_model, budget_usd = auth
-
     # Parse request body
     try:
         body = await request.json()
@@ -185,35 +266,40 @@ async def responses(
         raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
 
     request_model = body.get("model")
-    if not request_model:
+    if not isinstance(request_model, str) or not request_model:
         raise HTTPException(status_code=400, detail="model field is required")
 
     # Enforce model restriction
-    if request_model != allowed_model:
+    if request_model != access.allowed_model:
         raise HTTPException(
-            status_code=403, detail=f"Model '{request_model}' not allowed. Agent is restricted to '{allowed_model}'"
+            status_code=403,
+            detail=f"Model '{request_model}' not allowed. Agent is restricted to '{access.allowed_model}'",
         )
 
     # Reject streaming requests
     if body.get("stream"):
         raise HTTPException(status_code=400, detail="Streaming is not supported")
 
-    # Strip stateful API modes (we log everything ourselves)
-    body.pop("store", None)
-    if body.get("previous_response_id"):
-        raise HTTPException(status_code=400, detail="Stateful mode 'previous_response_id' is not supported")
+    if api_shape == LLMApiShape.RESPONSES:
+        # Strip stateful API modes (we log everything ourselves)
+        body.pop("store", None)
+        if body.get("previous_response_id"):
+            raise HTTPException(status_code=400, detail="Stateful mode 'previous_response_id' is not supported")
 
     # Resolve upstream routing and check budget
     with admin_db.session() as session:
-        _check_budget(session, agent_run_id, budget_usd)
-        upstream = _get_upstream_route(request_model, session, config)
+        _check_budget(session, access.agent_run_id, access.budget_usd)
+        upstream = _get_upstream_route(request_model, session, config, api_shape)
 
     # Rewrite model in request body to upstream model name
     body["model"] = upstream.model_name
+    _merge_props_metadata(
+        body, access=access, api_shape=api_shape, logical_model=request_model, upstream_model=upstream.model_name
+    )
 
     # Forward request to upstream
     start_time = time.monotonic()
-    upstream_url = f"{upstream.url}/responses"
+    upstream_url = f"{upstream.url}/{upstream_path}"
 
     async with httpx.AsyncClient() as client:
         try:
@@ -228,8 +314,9 @@ async def responses(
             with admin_db.session() as session:
                 _log_request(
                     session=session,
-                    agent_run_id=agent_run_id,
+                    agent_run_id=access.agent_run_id,
                     model=request_model,
+                    api_shape=api_shape,
                     request_body=body,
                     response_body=None,
                     error="Upstream timeout",
@@ -241,8 +328,9 @@ async def responses(
             with admin_db.session() as session:
                 _log_request(
                     session=session,
-                    agent_run_id=agent_run_id,
+                    agent_run_id=access.agent_run_id,
                     model=request_model,
+                    api_shape=api_shape,
                     request_body=body,
                     response_body=None,
                     error=str(e),
@@ -266,8 +354,9 @@ async def responses(
     with admin_db.session() as session:
         _log_request(
             session=session,
-            agent_run_id=agent_run_id,
+            agent_run_id=access.agent_run_id,
             model=request_model,
+            api_shape=api_shape,
             request_body=body,
             response_body=response_body,
             error=error,
@@ -275,3 +364,23 @@ async def responses(
         )
 
     return JSONResponse(content=response_body, status_code=upstream_response.status_code)
+
+
+@router.post("/v1/responses")
+async def responses(
+    request: Request, admin_db: AdminDb, config: Config, auth: Annotated[LLMAccess, Depends(require_llm_access)]
+) -> JSONResponse:
+    """Proxy OpenAI Responses API requests."""
+    return await _proxy_openai_request(
+        request, admin_db, config, auth, api_shape=LLMApiShape.RESPONSES, upstream_path="responses"
+    )
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(
+    request: Request, admin_db: AdminDb, config: Config, auth: Annotated[LLMAccess, Depends(require_llm_access)]
+) -> JSONResponse:
+    """Proxy OpenAI Chat Completions API requests."""
+    return await _proxy_openai_request(
+        request, admin_db, config, auth, api_shape=LLMApiShape.CHAT_COMPLETIONS, upstream_path="chat/completions"
+    )

--- a/props/backend/routes/llm.py
+++ b/props/backend/routes/llm.py
@@ -250,6 +250,16 @@ def _merge_props_metadata(
     body["metadata"] = {**metadata, **props_metadata}
 
 
+async def _read_json_object(request: Request) -> dict[str, Any]:
+    try:
+        raw_body = await request.json()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
+    if not isinstance(raw_body, dict):
+        raise HTTPException(status_code=400, detail="JSON body must be an object")
+    return raw_body
+
+
 async def _proxy_openai_request(
     request: Request,
     admin_db: AdminDb,
@@ -259,11 +269,7 @@ async def _proxy_openai_request(
     api_shape: LLMApiShape,
     upstream_path: str,
 ) -> JSONResponse:
-    # Parse request body
-    try:
-        body = await request.json()
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
+    body = await _read_json_object(request)
 
     request_model = body.get("model")
     if not isinstance(request_model, str) or not request_model:

--- a/props/backend/routes/llm.py
+++ b/props/backend/routes/llm.py
@@ -89,9 +89,11 @@ def _get_upstream_route(
     metadata = session.get(ModelMetadata, model_id)
     if metadata is None:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
-    if metadata.api_shape != api_shape.value:
+    metadata_api_shape = LLMApiShape(metadata.api_shape)
+    if metadata_api_shape != api_shape:
         raise HTTPException(
-            status_code=400, detail=f"Model '{model_id}' uses api_shape='{metadata.api_shape}', not '{api_shape.value}'"
+            status_code=400,
+            detail=f"Model '{model_id}' uses api_shape='{metadata_api_shape.value}', not '{api_shape.value}'",
         )
 
     # Determine which upstream to use (NULL = "openai" default)

--- a/props/backend/routes/model_metadata.py
+++ b/props/backend/routes/model_metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from openai_utils.api_shape import LLMApiShape
 from props.backend.deps import AdminDb
 from props.db.models import ModelMetadata
 
@@ -13,7 +14,7 @@ router = APIRouter()
 
 class ModelMetadataInfo(BaseModel):
     model_id: str
-    api_shape: str
+    api_shape: LLMApiShape
     input_usd_per_1m_tokens: float
     cached_input_usd_per_1m_tokens: float
     output_usd_per_1m_tokens: float

--- a/props/backend/routes/model_metadata.py
+++ b/props/backend/routes/model_metadata.py
@@ -13,6 +13,7 @@ router = APIRouter()
 
 class ModelMetadataInfo(BaseModel):
     model_id: str
+    api_shape: str
     input_usd_per_1m_tokens: float
     cached_input_usd_per_1m_tokens: float
     output_usd_per_1m_tokens: float
@@ -33,6 +34,7 @@ def list_model_metadata(admin_db: AdminDb) -> ModelMetadataResponse:
             models=[
                 ModelMetadataInfo(
                     model_id=row.model_id,
+                    api_shape=row.api_shape,
                     input_usd_per_1m_tokens=row.input_usd_per_1m_tokens,
                     cached_input_usd_per_1m_tokens=row.cached_input_usd_per_1m_tokens,
                     output_usd_per_1m_tokens=row.output_usd_per_1m_tokens,

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -20,7 +20,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import case, func
 
-from openai_utils.model import ResponsesRequest, ResponsesResult
 from props.backend.auth import (
     AgentRole,
     AuthenticatedIdentity,
@@ -296,16 +295,16 @@ class LLMRequestInfo(BaseModel):
     """LLM request information for API response.
 
     Directly mirrors LLMRequest ORM model fields. When the upstream returned
-    an error (4xx/5xx), the raw error JSON is in response_error_body instead
-    of response_body so it doesn't fail ResponsesResult validation.
+    an error (4xx/5xx), the raw error JSON is in response_error_body.
     """
 
     model_config = {"from_attributes": True}
 
     id: int
     model: str
-    request_body: ResponsesRequest
-    response_body: ResponsesResult | None
+    api_shape: str = "responses"
+    request_body: dict[str, Any]
+    response_body: dict[str, Any] | None
     response_error_body: dict[str, Any] | None = None
     error: str | None
     latency_ms: int | None
@@ -314,14 +313,14 @@ class LLMRequestInfo(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _split_error_response_body(cls, data: Any) -> Any:
-        """Move error response bodies to response_error_body to avoid ResponsesResult validation failure."""
-        if hasattr(data, "response_body"):
-            # ORM object path (from_attributes)
-            response_body = getattr(data, "response_body", None)
+        """Move error response bodies to response_error_body."""
+        if isinstance(data, LLMRequest):
+            response_body = data.response_body
             if isinstance(response_body, dict) and "id" not in response_body:
                 return {
                     "id": data.id,
                     "model": data.model,
+                    "api_shape": data.api_shape,
                     "request_body": data.request_body,
                     "response_body": None,
                     "response_error_body": response_body,

--- a/props/backend/routes/runs.py
+++ b/props/backend/routes/runs.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import case, func
 
+from openai_utils.api_shape import LLMApiShape
 from props.backend.auth import (
     AgentRole,
     AuthenticatedIdentity,
@@ -302,7 +303,7 @@ class LLMRequestInfo(BaseModel):
 
     id: int
     model: str
-    api_shape: str = "responses"
+    api_shape: LLMApiShape = LLMApiShape.RESPONSES
     request_body: dict[str, Any]
     response_body: dict[str, Any] | None
     response_error_body: dict[str, Any] | None = None

--- a/props/backend/routes/test_llm_routing.py
+++ b/props/backend/routes/test_llm_routing.py
@@ -171,7 +171,7 @@ def test_api_shape_mismatch_raises_400(synced_db: Database, sample_config: Props
                 max_output_tokens=2048,
                 upstream_name="local",
                 upstream_model="chat-upstream",
-                api_shape=LLMApiShape.CHAT_COMPLETIONS.value,
+                api_shape=LLMApiShape.CHAT_COMPLETIONS,
             )
         )
         session.commit()

--- a/props/backend/routes/test_llm_routing.py
+++ b/props/backend/routes/test_llm_routing.py
@@ -8,12 +8,20 @@ Tests that _get_upstream_route correctly resolves:
 from __future__ import annotations
 
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 import pytest_bazel
 from fastapi import HTTPException
 
-from props.backend.routes.llm import _get_upstream_route, _resolve_upstream_url
+from openai_utils.api_shape import LLMApiShape
+from props.backend.routes.llm import (
+    LLMAccess,
+    _extract_usage,
+    _get_upstream_route,
+    _merge_props_metadata,
+    _resolve_upstream_url,
+)
 from props.config import CustomModelConfig, PropsConfig, UpstreamConfig
 from props.db.database import Database
 from props.db.models import ModelMetadata
@@ -84,7 +92,7 @@ def test_openai_model_uses_default_upstream(synced_db: Database, sample_config: 
 
     with synced_db.session() as session:
         with patch.dict("os.environ", {"OPENAI_BASE_URL": "https://api.openai.com/v1", "OPENAI_API_KEY": "sk-test"}):
-            route = _get_upstream_route("gpt-4o", session, sample_config)
+            route = _get_upstream_route("gpt-4o", session, sample_config, LLMApiShape.RESPONSES)
         assert route.url == "https://api.openai.com/v1"
         assert route.api_key == "sk-test"
         assert route.model_name == "gpt-4o"
@@ -110,7 +118,7 @@ def test_custom_model_routes_to_configured_upstream(synced_db: Database, sample_
 
     with synced_db.session() as session:
         with patch.dict("os.environ", {"LOCAL_API_KEY": "local-key"}):
-            route = _get_upstream_route("local:llama-70b", session, sample_config)
+            route = _get_upstream_route("local:llama-70b", session, sample_config, LLMApiShape.RESPONSES)
         assert route.url == "http://localhost:11434/v1"
         assert route.api_key == "local-key"
         assert route.model_name == "llama3.3:70b"
@@ -120,7 +128,7 @@ def test_unknown_model_raises_400(synced_db: Database, sample_config: PropsConfi
     """Unknown model ID raises HTTPException(400)."""
     with synced_db.session() as session:
         with pytest.raises(HTTPException) as exc_info:
-            _get_upstream_route("nonexistent-model", session, sample_config)
+            _get_upstream_route("nonexistent-model", session, sample_config, LLMApiShape.RESPONSES)
         assert exc_info.value.status_code == 400
         assert "Unknown model" in exc_info.value.detail
 
@@ -145,9 +153,78 @@ def test_unknown_upstream_raises_500(synced_db: Database, sample_config: PropsCo
 
     with synced_db.session() as session:
         with pytest.raises(HTTPException) as exc_info:
-            _get_upstream_route("broken-model", session, sample_config)
+            _get_upstream_route("broken-model", session, sample_config, LLMApiShape.RESPONSES)
         assert exc_info.value.status_code == 500
         assert "unknown upstream" in exc_info.value.detail
+
+
+def test_api_shape_mismatch_raises_400(synced_db: Database, sample_config: PropsConfig) -> None:
+    """A chat-shaped model cannot be routed through the Responses endpoint."""
+    with synced_db.session() as session:
+        session.merge(
+            ModelMetadata(
+                model_id="chat-model",
+                input_usd_per_1m_tokens=0.0,
+                cached_input_usd_per_1m_tokens=0.0,
+                output_usd_per_1m_tokens=0.0,
+                context_window_tokens=8192,
+                max_output_tokens=2048,
+                upstream_name="local",
+                upstream_model="chat-upstream",
+                api_shape=LLMApiShape.CHAT_COMPLETIONS.value,
+            )
+        )
+        session.commit()
+
+    with synced_db.session() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            _get_upstream_route("chat-model", session, sample_config, LLMApiShape.RESPONSES)
+        assert exc_info.value.status_code == 400
+        assert "api_shape" in exc_info.value.detail
+
+
+def test_chat_usage_extraction() -> None:
+    usage = _extract_usage(
+        LLMApiShape.CHAT_COMPLETIONS,
+        {
+            "usage": {
+                "prompt_tokens": 17,
+                "prompt_tokens_details": {"cached_tokens": 5},
+                "completion_tokens": 23,
+                "total_tokens": 40,
+            }
+        },
+    )
+    assert usage.input_tokens == 17
+    assert usage.cached_input_tokens == 5
+    assert usage.output_tokens == 23
+
+
+def test_props_metadata_is_merged_for_langfuse_correlation() -> None:
+    body = {"metadata": {"client.run_id": "external"}}
+    _merge_props_metadata(
+        body,
+        access=LLMAccess(
+            agent_run_id=UUID("00000000-0000-0000-0000-000000000001"),
+            allowed_model="glm-4.6",
+            budget_usd=1.0,
+            parent_agent_run_id=UUID("00000000-0000-0000-0000-000000000002"),
+            agent_type="critic",
+        ),
+        api_shape=LLMApiShape.CHAT_COMPLETIONS,
+        logical_model="glm-4.6",
+        upstream_model="glm-4.6",
+    )
+
+    assert body["metadata"] == {
+        "client.run_id": "external",
+        "props.agent_run_id": "00000000-0000-0000-0000-000000000001",
+        "props.parent_agent_run_id": "00000000-0000-0000-0000-000000000002",
+        "props.agent_type": "critic",
+        "props.api_shape": "chat_completions",
+        "props.logical_model": "glm-4.6",
+        "props.upstream_model": "glm-4.6",
+    }
 
 
 if __name__ == "__main__":

--- a/props/config.py
+++ b/props/config.py
@@ -35,6 +35,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, model_validator
 
+from openai_utils.api_shape import LLMApiShape
 from openai_utils.model_metadata import ModelMetadata as BaseModelMetadata
 
 ENV_CONFIG_FILE = "PROPS_CONFIG_FILE"
@@ -73,6 +74,7 @@ class CustomModelConfig(BaseModelMetadata):
     name: str
     upstream: str
     upstream_model: str
+    api_shape: LLMApiShape = LLMApiShape.RESPONSES
     max_parallel_agents: int | None = None
 
 

--- a/props/db/BUILD.bazel
+++ b/props/db/BUILD.bazel
@@ -64,6 +64,7 @@ py_library(
     visibility = ["//props:__subpackages__"],
     deps = [
         ":snapshots",
+        "//openai_utils:api_shape",
         "//props/core:agent_types",
         "//props/core:ids",
         "//props/core:splits",

--- a/props/db/migrations/versions/20260605000000_add_llm_api_shape.py
+++ b/props/db/migrations/versions/20260605000000_add_llm_api_shape.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
     op.create_check_constraint(
         "model_metadata_api_shape_check", "model_metadata", "api_shape IN ('responses', 'chat_completions')"
     )
+    op.execute("GRANT SELECT ON TABLE model_metadata TO agent_base")
 
     op.add_column("llm_requests", sa.Column("api_shape", sa.String(), nullable=False, server_default="responses"))
     op.create_check_constraint(
@@ -79,5 +80,6 @@ def downgrade() -> None:
     """)
     op.drop_constraint("llm_requests_api_shape_check", "llm_requests", type_="check")
     op.drop_column("llm_requests", "api_shape")
+    op.execute("REVOKE SELECT ON TABLE model_metadata FROM agent_base")
     op.drop_constraint("model_metadata_api_shape_check", "model_metadata", type_="check")
     op.drop_column("model_metadata", "api_shape")

--- a/props/db/migrations/versions/20260605000000_add_llm_api_shape.py
+++ b/props/db/migrations/versions/20260605000000_add_llm_api_shape.py
@@ -1,0 +1,83 @@
+"""Add LLM API shape columns.
+
+Revision ID: 20260605000000
+Revises: 20260604000001
+Create Date: 2026-06-05
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260605000000"
+down_revision: str | None = "20260604000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("model_metadata", sa.Column("api_shape", sa.String(), nullable=False, server_default="responses"))
+    op.create_check_constraint(
+        "model_metadata_api_shape_check", "model_metadata", "api_shape IN ('responses', 'chat_completions')"
+    )
+
+    op.add_column("llm_requests", sa.Column("api_shape", sa.String(), nullable=False, server_default="responses"))
+    op.create_check_constraint(
+        "llm_requests_api_shape_check", "llm_requests", "api_shape IN ('responses', 'chat_completions')"
+    )
+
+    op.execute("""
+        CREATE OR REPLACE VIEW llm_request_costs AS
+        SELECT
+            r.id,
+            r.agent_run_id,
+            r.model,
+            r.input_tokens,
+            r.cached_input_tokens,
+            r.output_tokens,
+            r.latency_ms,
+            r.created_at,
+            (
+                (COALESCE(r.input_tokens, 0) - COALESCE(r.cached_input_tokens, 0))
+                    * COALESCE(m.input_usd_per_1m_tokens, 0) / 1000000.0
+                + COALESCE(r.cached_input_tokens, 0)
+                    * COALESCE(m.cached_input_usd_per_1m_tokens, 0) / 1000000.0
+                + COALESCE(r.output_tokens, 0)
+                    * COALESCE(m.output_usd_per_1m_tokens, 0) / 1000000.0
+            ) AS cost_usd
+        FROM llm_requests r
+        LEFT JOIN model_metadata m ON r.model = m.model_id
+    """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE VIEW llm_request_costs AS
+        SELECT
+            r.id,
+            r.agent_run_id,
+            r.model,
+            r.input_tokens,
+            r.cached_input_tokens,
+            r.output_tokens,
+            r.latency_ms,
+            r.created_at,
+            COALESCE(
+                (r.input_tokens - COALESCE(r.cached_input_tokens, 0))
+                    * m.input_usd_per_1m_tokens / 1000000.0
+                + COALESCE(r.cached_input_tokens, 0)
+                    * m.cached_input_usd_per_1m_tokens / 1000000.0
+                + r.output_tokens
+                    * m.output_usd_per_1m_tokens / 1000000.0,
+                0
+            ) AS cost_usd
+        FROM llm_requests r
+        LEFT JOIN model_metadata m ON r.model = m.model_id
+    """)
+    op.drop_constraint("llm_requests_api_shape_check", "llm_requests", type_="check")
+    op.drop_column("llm_requests", "api_shape")
+    op.drop_constraint("model_metadata_api_shape_check", "model_metadata", type_="check")
+    op.drop_column("model_metadata", "api_shape")

--- a/props/db/models.py
+++ b/props/db/models.py
@@ -34,6 +34,7 @@ from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, UUID as PG_UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 from sqlalchemy.types import TypeDecorator
 
+from openai_utils.api_shape import LLMApiShape
 from props.core.agent_types import (
     AgentType,
     CriticDevImproveTypeConfig,
@@ -1025,8 +1026,13 @@ class ModelMetadata(Base):
     max_output_tokens: Mapped[int] = mapped_column(nullable=False)
     upstream_name: Mapped[str | None] = mapped_column(String, nullable=True)
     upstream_model: Mapped[str | None] = mapped_column(String, nullable=True)
+    api_shape: Mapped[str] = mapped_column(String, nullable=False, server_default=LLMApiShape.RESPONSES.value)
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint("api_shape IN ('responses', 'chat_completions')", name="model_metadata_api_shape_check"),
     )
 
 
@@ -1433,6 +1439,7 @@ class LLMRequest(Base):
         PG_UUID(as_uuid=True), ForeignKey("agent_runs.agent_run_id", ondelete="CASCADE"), nullable=False, index=True
     )
     model: Mapped[str] = mapped_column(String, ForeignKey("model_metadata.model_id"), nullable=False, index=True)
+    api_shape: Mapped[str] = mapped_column(String, nullable=False, server_default=LLMApiShape.RESPONSES.value)
     request_body: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     response_body: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -1444,6 +1451,10 @@ class LLMRequest(Base):
 
     # Relationships
     agent_run: Mapped[AgentRun] = relationship(back_populates="llm_requests")
+
+    __table_args__ = (
+        CheckConstraint("api_shape IN ('responses', 'chat_completions')", name="llm_requests_api_shape_check"),
+    )
 
 
 class AgentRun(Base):

--- a/props/db/models.py
+++ b/props/db/models.py
@@ -263,6 +263,31 @@ class StrEnumColumn[E: StrEnum](TypeDecorator[E]):
         return self._enum_class(value)
 
 
+class StringBackedStrEnumColumn[E: StrEnum](TypeDecorator[E]):
+    """String column that returns a StrEnum in Python.
+
+    Use this when the database stores a text/varchar column with a check
+    constraint rather than a PostgreSQL native enum type.
+    """
+
+    impl = String
+    cache_ok = True
+
+    def __init__(self, enum_class: type[E], length: int | None = None):
+        self._enum_class = enum_class
+        super().__init__(length=length)
+
+    def process_bind_param(self, value: E | str | None, dialect: Any) -> str | None:
+        if value is None:
+            return None
+        return value.value if isinstance(value, self._enum_class) else str(value)
+
+    def process_result_value(self, value: str | None, dialect: Any) -> E | None:
+        if value is None:
+            return None
+        return self._enum_class(value)
+
+
 class Base(DeclarativeBase):
     type_annotation_map: ClassVar[dict[type, Any]] = {
         dict[str, Any]: JSONB,
@@ -1026,7 +1051,9 @@ class ModelMetadata(Base):
     max_output_tokens: Mapped[int] = mapped_column(nullable=False)
     upstream_name: Mapped[str | None] = mapped_column(String, nullable=True)
     upstream_model: Mapped[str | None] = mapped_column(String, nullable=True)
-    api_shape: Mapped[str] = mapped_column(String, nullable=False, server_default=LLMApiShape.RESPONSES.value)
+    api_shape: Mapped[LLMApiShape] = mapped_column(
+        StringBackedStrEnumColumn(LLMApiShape), nullable=False, server_default=LLMApiShape.RESPONSES.value
+    )
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
     )
@@ -1439,7 +1466,9 @@ class LLMRequest(Base):
         PG_UUID(as_uuid=True), ForeignKey("agent_runs.agent_run_id", ondelete="CASCADE"), nullable=False, index=True
     )
     model: Mapped[str] = mapped_column(String, ForeignKey("model_metadata.model_id"), nullable=False, index=True)
-    api_shape: Mapped[str] = mapped_column(String, nullable=False, server_default=LLMApiShape.RESPONSES.value)
+    api_shape: Mapped[LLMApiShape] = mapped_column(
+        StringBackedStrEnumColumn(LLMApiShape), nullable=False, server_default=LLMApiShape.RESPONSES.value
+    )
     request_body: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     response_body: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/props/db/sync/BUILD.bazel
+++ b/props/db/sync/BUILD.bazel
@@ -45,6 +45,7 @@ py_library(
     visibility = ["//props:__subpackages__"],
     deps = [
         ":stats",
+        "//openai_utils:api_shape",
         "//openai_utils:model_metadata",
         "//props:config",
         "//props/db:models",

--- a/props/db/sync/model_metadata.py
+++ b/props/db/sync/model_metadata.py
@@ -39,7 +39,7 @@ def sync_model_metadata_with_session(session: Session, config: PropsConfig | Non
             max_output_tokens=meta.max_output_tokens,
             upstream_name=None,
             upstream_model=None,
-            api_shape=LLMApiShape.RESPONSES.value,
+            api_shape=LLMApiShape.RESPONSES,
         )
 
     # Add custom models from config
@@ -54,7 +54,7 @@ def sync_model_metadata_with_session(session: Session, config: PropsConfig | Non
                 max_output_tokens=custom.max_output_tokens,
                 upstream_name=custom.upstream,
                 upstream_model=custom.upstream_model,
-                api_shape=custom.api_shape.value,
+                api_shape=custom.api_shape,
             )
 
     # Full sync: make DB exactly match source

--- a/props/db/sync/model_metadata.py
+++ b/props/db/sync/model_metadata.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
+from openai_utils.api_shape import LLMApiShape
 from openai_utils.model_metadata import MODEL_METADATA
 from props.db.models import ModelMetadata
 from props.db.sync.stats import SyncStats
@@ -38,6 +39,7 @@ def sync_model_metadata_with_session(session: Session, config: PropsConfig | Non
             max_output_tokens=meta.max_output_tokens,
             upstream_name=None,
             upstream_model=None,
+            api_shape=LLMApiShape.RESPONSES.value,
         )
 
     # Add custom models from config
@@ -52,6 +54,7 @@ def sync_model_metadata_with_session(session: Session, config: PropsConfig | Non
                 max_output_tokens=custom.max_output_tokens,
                 upstream_name=custom.upstream,
                 upstream_model=custom.upstream_model,
+                api_shape=custom.api_shape.value,
             )
 
     # Full sync: make DB exactly match source

--- a/props/db/test_split_based_rls.py
+++ b/props/db/test_split_based_rls.py
@@ -46,6 +46,7 @@ from props.db.models import (
     AgentRunStatus,
     FalsePositive,
     LLMRequest,
+    ModelMetadata,
     OccurrenceRangeORM,
     Snapshot,
     TruePositive,
@@ -106,6 +107,14 @@ async def test_critic_dev_optimize_can_see_all_snapshots_metadata(
     assert "train" in splits
     assert "valid" in splits
     assert "test" in splits
+
+
+async def test_critic_dev_optimize_can_read_model_metadata(synced_db: Database, critic_dev_optimize_session: Session):
+    """Agent roles can read model metadata needed to pick the LLM API shape."""
+    metadata = critic_dev_optimize_session.get(ModelMetadata, DEFAULT_TEST_MODEL)
+
+    assert metadata is not None
+    assert metadata.model_id == DEFAULT_TEST_MODEL
 
 
 async def test_critic_dev_optimize_can_see_train_split_snapshots(

--- a/props/docs/SPEC.md
+++ b/props/docs/SPEC.md
@@ -167,7 +167,7 @@ Critic-dev agents perform the full definition development loop:
 - Parent run link (for child agents)
 - Child run links
 - LLM requests table (from `llm_requests`):
-  - Model, latency, token counts, cost
+  - Model, API shape, latency, token counts, cost
   - Expandable request/response bodies
 - Container logs (merged stdout/stderr from Loki, via `GET /api/runs/{id}/logs`)
 - Completion summary when done

--- a/props/docs/agent_credential_passthrough.md
+++ b/props/docs/agent_credential_passthrough.md
@@ -52,13 +52,13 @@ async def trigger_validation(admin_db: AdminDb) -> Job:
 
 **Using AdminDb:**
 
-| Endpoint                     | Reason                   |
-| ---------------------------- | ------------------------ |
-| `POST /api/llm/v1/responses` | Proxy needs admin INSERT |
-| `POST /api/eval/*`           | Launches agent runs      |
-| `POST /api/registry/*`       | Definition push          |
-| `GET /api/ground_truth/*`    | Admin dashboard          |
-| `POST /api/runs/validation`  | Launches runs            |
+| Endpoint                    | Reason                   |
+| --------------------------- | ------------------------ |
+| `POST /api/llm/v1/*`        | Proxy needs admin INSERT |
+| `POST /api/eval/*`          | Launches agent runs      |
+| `POST /api/registry/*`      | Definition push          |
+| `GET /api/ground_truth/*`   | Admin dashboard          |
+| `POST /api/runs/validation` | Launches runs            |
 
 ## Admin Token Authentication
 

--- a/props/docs/agent_loop_inside_container.md
+++ b/props/docs/agent_loop_inside_container.md
@@ -59,13 +59,13 @@ The LLM proxy is integrated into the unified backend (`props/backend/routes/llm.
 
 | Aspect            | Decision                                                       |
 | ----------------- | -------------------------------------------------------------- |
-| Env vars          | `OPENAI_BASE_URL`, `OPENAI_API_KEY` (Responses API compatible) |
+| Env vars          | `OPENAI_BASE_URL`, `OPENAI_API_KEY` (OpenAI-compatible API)    |
 | Token             | Same as existing Postgres password (`agent_{uuid}`)            |
 | Token validation  | Via Postgres (lookup agent_runs by username pattern)           |
 | Model restriction | One model per run, enforced by proxy                           |
 | Cost budget       | Per-agent token counts, tracked via parent-child in agent_runs |
 | Streaming         | Not supported (simplifies logging/budgeting)                   |
-| Implementation    | FastAPI route in unified backend at `POST /v1/responses`       |
+| Implementation    | LLM proxy routes at `/v1/responses` and `/v1/chat/completions` |
 | Port              | 8000 (same as backend)                                         |
 
 ### Resource Limits
@@ -221,8 +221,9 @@ grading_pending view         ◄──────────  wait_until_grade
 **`llm_requests` table:**
 
 - `id`, `agent_run_id` (FK), `created_at`
-- `request_body` (JSONB) - full OpenAI Responses API request
-- `response_body` (JSONB) - full response including `usage` field
+- `api_shape` - `responses` or `chat_completions`
+- `request_body` (JSONB) - full OpenAI-compatible request in that API shape
+- `response_body` (JSONB) - full response including `usage` field when provided
 - `model` (denormalized for filtering)
 - `latency_ms`
 - `error` (TEXT, nullable)
@@ -243,7 +244,7 @@ Services in `props/compose.yaml`:
 
 - `postgres` (5433:5432) - on `props-internal` + `props-agents`
 - `registry` (5000:5000) - on `props-internal` + `default`
-- `backend` (8000:8000) - on `props-internal` + `props-agents` (serves LLM proxy at `/v1/responses`, registry proxy at `/v2/*`, critic runs API at `/api/runs/critic`, dashboard API)
+- `backend` (8000:8000) - on `props-internal` + `props-agents` (serves LLM proxy routes, registry proxy at `/v2/*`, critic runs API at `/api/runs/critic`, dashboard API)
 
 **Network topology:**
 

--- a/props/docs/backend_api.md
+++ b/props/docs/backend_api.md
@@ -61,8 +61,9 @@ schema = httpx.get(f"{backend_url}/openapi.json").json()
 | `/api/runs/{id}/logs`         | GET    | A run's container logs (from Loki); RLS-scoped to your descendants |
 | `/v2/*`                       | \*     | OCI registry proxy                                                 |
 
-The LLM proxy (`/v1/responses`) is a **separate service** (`props-llm-proxy`),
-reached via `OPENAI_BASE_URL`, not this backend. Read a launched agent's
+The LLM proxy (`/v1/responses` and `/v1/chat/completions`) is a **separate
+service** (`props-llm-proxy`), reached via `OPENAI_BASE_URL`, not this backend.
+Read a launched agent's
 **transcript** from `llm_requests` (DB, also exposed above) and its **container
 logs** via `/api/runs/{id}/logs` — agents cannot query Loki directly.
 

--- a/props/docs/budget_enforcement.md
+++ b/props/docs/budget_enforcement.md
@@ -16,7 +16,7 @@ Every agent run has an explicit `budget_usd` limit. The LLM proxy enforces this 
 
 ## Budget Checking
 
-The LLM proxy (`/api/llm/v1/responses`) checks budget before forwarding:
+The LLM proxy (`/v1/responses` and `/v1/chat/completions`) checks budget before forwarding:
 
 ```python
 # Compute consumed cost via recursive CTE (self + all descendants)

--- a/props/docs/plans/chat_completions_api.md
+++ b/props/docs/plans/chat_completions_api.md
@@ -1,22 +1,23 @@
 # Plan: Chat Completions support in props LLM proxy
 
-**Status:** implementation in progress.
+**Status:** first implementation is complete on the chat-completions branch.
+Deployment and end-to-end cluster verification are still pending.
 
 ## Motivation
 
-Props currently exposes an OpenAI-compatible `/v1/responses` endpoint to agent
-containers. That works well for OpenAI Responses-native clients, but it forces
+Props already exposes an OpenAI-compatible `/v1/responses` endpoint to agent
+containers. That works well for Responses-native clients, but it forces
 chat-only providers such as z.ai through LiteLLM's Responses-to-chat translation
 path.
 
-That translation path has already been operationally annoying: LiteLLM `1.86.3`
-does not emit Langfuse OTEL traces for z.ai calls made through `/v1/responses`,
-and upstream `1.87.1` / `1.88.0-rc.3` showed the same relevant code shape during
+That translation path has been operationally annoying: LiteLLM `1.86.3` did not
+emit Langfuse OTEL traces for z.ai calls made through `/v1/responses`, and
+upstream `1.87.1` / `1.88.0-rc.3` showed the same relevant code shape during
 inspection. See `cluster/debug/2026-06-05-litellm-responses-langfuse-otel.md`.
 
 The goal is to let props speak the OpenAI Chat Completions API directly when a
-model/provider is naturally chat-shaped, while preserving the existing Responses
-path for agents and models that already use it.
+model/provider is naturally chat-shaped, while preserving the existing
+Responses path for agents and models that already use it.
 
 ## Non-goals
 
@@ -27,170 +28,32 @@ path for agents and models that already use it.
 - Do not replace the existing `/v1/responses` path or force all agents to move.
 - Do not rely on LiteLLM's Responses-to-chat bridge for tracing correctness.
 
-## Current state
+## Completed First Slice
 
-- `props/backend/routes/llm.py` served only `POST /v1/responses` before this
-  implementation.
-- `llm_requests` stores raw `request_body` and `response_body` as JSONB plus
-  extracted token counts: `input_tokens`, `cached_input_tokens`, `output_tokens`.
-- `llm_request_costs`, `llm_run_costs`, and `agent_run_budget_status` compute
-  cost/budget from those extracted token columns.
-- `GET /api/runs/{id}/llm_requests` currently validates rows as
-  `ResponsesRequest` / `ResponsesResult`, so chat-shaped rows would break the
-  read API even though the DB can store the raw JSON.
-- Model routing is already endpoint-agnostic in spirit: `model_metadata` maps the
-  logical props model to `upstream_name` and `upstream_model`, and config maps the
-  upstream name to a base URL and API key.
-- Custom model config currently declares upstream routing, pricing, and limits,
-  but not which OpenAI-compatible API shape is expected for the model.
-
-## Target shape
-
-The LLM proxy should support both endpoints:
-
-- `POST /v1/responses`
-- `POST /v1/chat/completions`
-
-Both endpoints should share:
-
-- agent credential authentication
-- allowed-model enforcement
-- budget preflight
-- upstream routing through `model_metadata` + `upstreams`
-- request/response logging to `llm_requests`
-- cost accounting from token usage
-- correlation metadata injection for Langfuse/searchability
-
-The DB/API should record which API shape was used:
+The first implementation keeps Responses and Chat Completions as distinct wire
+shapes and records which shape was used:
 
 ```text
 api_shape = "responses" | "chat_completions"
 ```
 
-Raw request and response payloads remain API-shape-specific JSON.
+Completed pieces:
 
-Models declare exactly one API shape:
-
-```text
-model_metadata.api_shape = "responses" | "chat_completions"
-```
-
-The model declaration is a routing/capability contract and the agent runtime uses
-it to choose the model adapter. The request row's `llm_requests.api_shape` is the
-historical fact of what endpoint was actually called.
-
-## Schema changes
-
-MVP migration:
-
-```sql
-ALTER TABLE llm_requests
-  ADD COLUMN api_shape text NOT NULL DEFAULT 'responses';
-
-ALTER TABLE llm_requests
-  ADD CONSTRAINT llm_requests_api_shape_check
-  CHECK (api_shape IN ('responses', 'chat_completions'));
-
-ALTER TABLE model_metadata
-  ADD COLUMN api_shape text NOT NULL DEFAULT 'responses';
-
-ALTER TABLE model_metadata
-  ADD CONSTRAINT model_metadata_api_shape_check
-  CHECK (api_shape IN ('responses', 'chat_completions'));
-```
-
-SQLAlchemy:
-
-- Add an `LLMApiShape` `StrEnum` or literal-backed string column.
-- Set existing rows to `responses` through the default.
-- Include `api_shape` in `LLMRequestInfo`.
-- Add `api_shape` to `ModelMetadata` and `CustomModelConfig`, defaulting to
-  Responses for backward compatibility.
-- Sync model API-shape fields into `model_metadata` along with the existing
-  pricing, limit, and upstream routing fields.
-
-No cost-view shape change is required if chat usage is mapped into the existing
-token columns. If partial usage objects are accepted, harden the view expression
-to `COALESCE` each token column individually; the current expression coalesces
-the final cost value, so one unexpected `NULL` term can zero the whole request's
-cost.
-
-Optional later columns, not needed for MVP:
-
-- `upstream_name` and `upstream_model` for historical routing/debugging.
-- `upstream_status_code` instead of encoding HTTP errors as text.
-- `correlation_id` if we want a first-class DB key that also appears in
-  Langfuse metadata.
-
-## Token usage mapping
-
-Responses rows keep the current extraction:
-
-- `usage.input_tokens` -> `input_tokens`
-- `usage.input_tokens_details.cached_tokens` -> `cached_input_tokens`
-- `usage.output_tokens` -> `output_tokens`
-
-Chat Completions rows map OpenAI-compatible chat usage as:
-
-- `usage.prompt_tokens` -> `input_tokens`
-- `usage.prompt_tokens_details.cached_tokens` -> `cached_input_tokens`
-- `usage.completion_tokens` -> `output_tokens`
-
-If the whole `usage` object is missing, store `NULL` token counts and compute
-zero cost. If the `usage` object is present but one subfield is missing, prefer
-storing `0` for the missing subfield or hardening the cost view to coalesce each
-column. Do not require every OpenAI-compatible provider to emit OpenAI's full
-details object.
-
-## Backend proxy changes
-
-1. Split the current request handling into shared helpers:
-   - parse JSON
-   - validate `model`
-   - reject streaming for now
-   - enforce model restriction
-   - check budget
-   - resolve upstream route
-   - inject correlation metadata
-   - forward to an upstream path
-   - log request/response/error with `api_shape`
-
-2. Keep `/v1/responses` behavior stable:
-   - forward to `{upstream.url}/responses`
-   - keep rejecting `previous_response_id`
-   - keep removing `store`
-   - extract Responses usage
-
-3. Add `/v1/chat/completions`:
-   - forward to `{upstream.url}/chat/completions`
-   - reject `stream: true` initially, matching the Responses proxy limitation
-   - rewrite `model` to `upstream.model_name`
-   - extract Chat Completions usage
-   - log as `api_shape='chat_completions'`
-
-4. Enforce model API-shape capabilities.
-   - `/v1/responses` requires `api_shape='responses'`.
-   - `/v1/chat/completions` requires `api_shape='chat_completions'`.
-   - Explicit endpoint calls still record their actual endpoint in
-     `llm_requests.api_shape`.
-
-5. Preserve the logical props model in `LLMRequest.model`.
-   - This is what pricing joins and run summaries use.
-   - If debugging needs the upstream model later, add explicit upstream columns
-     rather than overloading `model`.
-
-6. Consider logging the original client request body rather than the mutated
-   upstream body.
-   - Current code mutates `body["model"]` before logging.
-   - For Langfuse correlation, the proxy can still inject metadata before
-     forwarding; the DB can either store the forwarded body or store both client
-     and upstream forms in a follow-up.
-
-## Correlation and Langfuse metadata
-
-For Chat Completions through cluster LiteLLM, LiteLLM's native chat path should
-record Langfuse traces. Props should make those traces easy to connect back to
-agent runs by merging metadata into the outgoing request:
+- Added `api_shape` to model metadata/config so each logical model declares
+  exactly one supported API shape.
+- Added `api_shape` to `llm_requests` so each logged request records the actual
+  API shape used.
+- Added `/v1/chat/completions` to the props LLM proxy.
+- Kept `/v1/responses` behavior stable.
+- Enforced endpoint/model shape compatibility:
+  - `/v1/responses` requires `api_shape = "responses"`.
+  - `/v1/chat/completions` requires `api_shape = "chat_completions"`.
+- Mapped Chat Completions usage into the existing cost columns:
+  - `usage.prompt_tokens` -> `input_tokens`
+  - `usage.prompt_tokens_details.cached_tokens` -> `cached_input_tokens`
+  - `usage.completion_tokens` -> `output_tokens`
+- Kept cost/budget accounting on the existing token columns.
+- Added metadata injection for correlation through LiteLLM/Langfuse:
 
 ```json
 {
@@ -203,178 +66,97 @@ agent runs by merging metadata into the outgoing request:
 }
 ```
 
-Rules:
+- Updated `GET /api/runs/{id}/llm_requests` to treat request/response bodies as
+  raw JSON audit payloads instead of forcing all rows through Responses models.
+- Kept the existing frontend Responses renderer and added a raw JSON fallback
+  for chat-shaped request rows.
+- Added an agent model-adapter boundary:
+  - Responses-backed models use the existing Responses client path.
+  - Chat-backed models use `client.chat.completions.create(...)`.
+  - Internal transcript/request objects stay neutral enough for the core loop.
+- Used OpenAI SDK chat parameter/usage types where they describe the chat API
+  boundary. Raw persisted/proxied JSON remains `dict[str, Any]`.
+- Configured `glm-4.6` as a chat-completions model in props config.
 
-- Preserve caller-provided `metadata` when present.
-- Prefix props-owned keys with `props.` to avoid collisions.
-- Do not assume `metadata.trace_id` becomes Langfuse's trace id; previous live
-  chat testing showed LiteLLM keeps client trace ids in metadata/attributes rather
-  than making them the ClickHouse `traces.id`.
-- If exact DB-row-to-Langfuse lookup becomes important, generate a proxy
-  `correlation_id` at request start, store it in the DB row, and put the same
-  value in outgoing metadata.
+## z.ai Findings
 
-## API and frontend changes
+Live z.ai testing against the coding endpoint confirmed the basic chat adapter
+path works with `glm-4.6`:
 
-The first backend API change should be correctness, not presentation polish:
+- OpenAI-compatible Chat Completions requests work.
+- Function `tools` work.
+- `tool_choice: "auto"` works.
+- Omitting `tool_choice` works.
+- Strict tool metadata works: `function.strict: true`, `required`, `enum`, and
+  `additionalProperties: false`.
+- Both `max_completion_tokens` and legacy `max_tokens` are accepted.
 
-- Add `api_shape` to `LLMRequestInfo`.
-- Stop validating all `request_body` values as `ResponsesRequest`.
-- Stop validating all successful `response_body` values as `ResponsesResult`.
-- Either expose raw `dict[str, Any]` bodies for all rows, or use a discriminated
-  union keyed by `api_shape`.
+z.ai does **not** accept forced named OpenAI tool-choice objects:
 
-Frontend MVP:
-
-- Keep the existing Responses renderer for `api_shape === "responses"`.
-- For `api_shape === "chat_completions"`, show the same row header plus raw JSON
-  request/response sections.
-- Defer a specialized chat renderer for `messages`, `choices`, `tool_calls`, and
-  `usage` until there is real demand.
-
-## Typing approach
-
-Do not try to force Chat Completions into the existing `ResponsesRequest` /
-`ResponsesResult` wrappers.
-
-For the proxy path, prefer minimal runtime validation:
-
-- request is valid JSON
-- `model` is present and is a string
-- `stream` is absent or false
-- `metadata`, if present, is an object so props can merge correlation keys
-- response body is JSON when the upstream returns JSON
-
-The proxy should then extract the small typed accounting surface it actually
-uses:
-
-```python
-class LLMUsageCounts(BaseModel):
-    input_tokens: int | None
-    cached_input_tokens: int | None
-    output_tokens: int | None
+```json
+{ "type": "function", "function": { "name": "record_result" } }
 ```
 
-Implement separate extraction functions:
+That returns `400` / code `1210`. If z.ai needs to call a specific tool, use
+prompt instructions plus `tool_choice: "auto"` unless/until props gains a
+provider capability flag for this quirk. The detailed API notes live in
+`docs/z_ai_api.md`.
 
-```python
-def extract_responses_usage(body: Mapping[str, Any] | None) -> LLMUsageCounts: ...
-def extract_chat_completions_usage(body: Mapping[str, Any] | None) -> LLMUsageCounts: ...
-```
+## Remaining Deployment Work
 
-For `GET /api/runs/{id}/llm_requests`, the least brittle MVP is:
-
-```python
-class LLMRequestInfo(BaseModel):
-    id: int
-    api_shape: LLMApiShape
-    model: str
-    request_body: dict[str, Any]
-    response_body: dict[str, Any] | None
-    response_error_body: dict[str, Any] | None
-    error: str | None
-    latency_ms: int | None
-    created_at: datetime
-```
-
-That intentionally makes the transcript API an audit/log API rather than a
-strict OpenAI schema validator. The raw payload is already persisted as JSONB,
-and OpenAI-compatible providers routinely add fields that are useful to keep.
-
-If richer typing becomes valuable later, add a discriminated union keyed by
-`api_shape`:
-
-```python
-ResponsesLLMRequestInfo | ChatCompletionsLLMRequestInfo
-```
-
-Even then, keep both shapes permissive (`extra="allow"`) and avoid requiring
-complete OpenAI SDK parity. The typed fields should be the ones the UI or
-accounting code consumes, not every possible provider-specific extension.
-
-For client code that actually makes model calls, prefer the OpenAI SDK's own
-types where possible. `openai_utils.retry.chat_create_with_retries` already uses
-`CompletionCreateParams` and returns `ChatCompletion`; that is the right layer
-for typed chat-calling helpers. The DB transcript layer does not need to share
-that exact type.
-
-## Client usage
-
-Agents that want chat completions should be able to use the normal OpenAI SDK
-against the same `OPENAI_BASE_URL` and `OPENAI_API_KEY` they already receive:
-
-```python
-await client.chat.completions.create(
-    model="glm-4.6",
-    messages=[{"role": "user", "content": "hello"}],
-)
-```
-
-This does not require converting existing Responses-based agents. It only enables
-agents or helper libraries that already know how to call Chat Completions to do so
-through props' auth, budget, logging, and routing layer.
-
-For config-backed custom models, chat-shaped providers should declare the API
-shape explicitly:
-
-```toml
-[[models]]
-name = "glm-4.6"
-upstream = "litellm"
-upstream_model = "glm-4.6"
-api_shape = "chat_completions"
-```
-
-If a provider supports both paths, declare the one props-controlled agents should
-use for that logical model.
-
-## Tests
-
-Backend tests should cover:
-
-- `/v1/chat/completions` requires agent auth.
-- model restriction still applies.
-- `stream: true` is rejected.
-- the proxy forwards to `/chat/completions`, not `/responses`.
-- logical model is rewritten to the upstream model in the forwarded body.
-- chat usage is extracted into `input_tokens`, `cached_input_tokens`, and
-  `output_tokens`.
-- models reject endpoint calls that do not match `model_metadata.api_shape`.
-- chat rows affect `llm_run_costs` and `agent_run_budget_status`.
-- `GET /api/runs/{id}/llm_requests` returns both Responses and Chat Completions
-  rows without validation errors.
-
-Likely focused targets:
-
-```bash
-bbr test //props/backend/routes:test_llm_routing
-bbr test //props/backend/routes:test_llm_budget
-bbr test //props/backend/routes:test_runs
-```
-
-Add frontend tests only if the raw JSON fallback touches existing components in a
-non-trivial way.
-
-## Deployment slice
-
-1. Land schema/API/backend support with no config change.
+1. Merge the chat-completions branch.
 2. Deploy props proxy/backend.
-3. Update `glm-4.6` config/model metadata to declare
-   `api_shape='chat_completions'`.
-4. Smoke test `/v1/responses` on an existing model to prove no regression.
+3. Sync/update model metadata so `glm-4.6` is `api_shape = "chat_completions"`.
+4. Smoke test `/v1/responses` on an existing Responses model to prove no
+   regression.
 5. Smoke test `/v1/chat/completions` with `glm-4.6` through cluster LiteLLM.
 6. Verify a matching `llm_requests` row exists with
-   `api_shape='chat_completions'`.
-7. Verify Langfuse received a trace for the native chat call and that props
-   metadata is visible in the trace/generation metadata.
+   `api_shape = "chat_completions"`.
+7. Verify Langfuse receives a trace for the native chat call.
+8. Verify props metadata is visible in the Langfuse trace/generation metadata.
+9. Run a critic/grader path against `glm-4.6` through props/LiteLLM and confirm
+   tool calls, request logging, budget accounting, and Langfuse metadata all
+   line up.
 
-## Open questions
+## Remaining Design Questions
 
 - Should props log the client request, the forwarded upstream request, or both?
-  Current code logs the forwarded request after model rewrite.
+  Current behavior logs the forwarded request after model rewrite/metadata
+  injection.
 - Do we want a first-class `correlation_id` column now, or is metadata-only
   correlation enough until we need direct DB-to-Langfuse joins?
+- Do we need a provider/model capability for "no forced named chat tool choice"
+  so z.ai can avoid `ToolChoiceFunction` while OpenAI-compatible providers that
+  support it keep using it?
 - Should a future `ResponsesViaChatModel` adapter exist for Responses-based
   agents that must run against chat-only providers? If so, keep it at the model
   client boundary; do not make the DB/API pretend chat payloads are Responses
   payloads.
+
+## Later Frontend Work
+
+The first slice intentionally avoids a specialized chat transcript UI. If there
+is demand, add a chat renderer for:
+
+- `messages`
+- `choices`
+- `message.tool_calls`
+- `usage`
+- provider-specific fields such as `reasoning_content`
+
+Keep the raw JSON fallback even after a richer renderer exists; provider
+extensions are common and useful during debugging.
+
+## Verification So Far
+
+Completed verification on the branch:
+
+```bash
+bbr test //agent_core/... //openai_utils/... //props/backend/routes/... //props/llm_proxy/... --test_tag_filters=-live_openai_api
+bazelisk test //agent_core:test_zai_chat_adapter_live --test_output=streamed --nocache_test_results --test_env=ZAI_API_KEY --test_env=ZAI_MODEL
+bbr test //props/frontend:svelte_check_test //props/frontend/src/components:visual_LLMRequests //props/frontend/src/components:visual_LLMRequestsToolCall
+bbr test //props/backend/routes/... //props/llm_proxy:test_app --test_tag_filters=-live_openai_api
+bbr build //props/backend/routes:model_metadata
+bbr test //props/frontend:svelte_check_test
+bbr test //props/backend/routes:test_llm_routing
+```

--- a/props/docs/plans/chat_completions_api.md
+++ b/props/docs/plans/chat_completions_api.md
@@ -1,6 +1,6 @@
 # Plan: Chat Completions support in props LLM proxy
 
-**Status:** deferred design. No implementation is active.
+**Status:** implementation in progress.
 
 ## Motivation
 
@@ -29,7 +29,8 @@ path for agents and models that already use it.
 
 ## Current state
 
-- `props/backend/routes/llm.py` serves only `POST /v1/responses`.
+- `props/backend/routes/llm.py` served only `POST /v1/responses` before this
+  implementation.
 - `llm_requests` stores raw `request_body` and `response_body` as JSONB plus
   extracted token counts: `input_tokens`, `cached_input_tokens`, `output_tokens`.
 - `llm_request_costs`, `llm_run_costs`, and `agent_run_budget_status` compute
@@ -68,17 +69,15 @@ api_shape = "responses" | "chat_completions"
 
 Raw request and response payloads remain API-shape-specific JSON.
 
-Models should also declare which API shapes they support and which one should be
-used by default:
+Models declare exactly one API shape:
 
 ```text
-model_metadata.supported_api_shapes = ["responses"] | ["chat_completions"] | [...]
-model_metadata.default_api_shape = "responses" | "chat_completions"
+model_metadata.api_shape = "responses" | "chat_completions"
 ```
 
-The model declaration is a routing/capability contract. The request row's
-`llm_requests.api_shape` is the historical fact of what endpoint was actually
-called.
+The model declaration is a routing/capability contract and the agent runtime uses
+it to choose the model adapter. The request row's `llm_requests.api_shape` is the
+historical fact of what endpoint was actually called.
 
 ## Schema changes
 
@@ -93,21 +92,11 @@ ALTER TABLE llm_requests
   CHECK (api_shape IN ('responses', 'chat_completions'));
 
 ALTER TABLE model_metadata
-  ADD COLUMN supported_api_shapes text[] NOT NULL DEFAULT ARRAY['responses'];
+  ADD COLUMN api_shape text NOT NULL DEFAULT 'responses';
 
 ALTER TABLE model_metadata
-  ADD COLUMN default_api_shape text NOT NULL DEFAULT 'responses';
-
-ALTER TABLE model_metadata
-  ADD CONSTRAINT model_metadata_default_api_shape_check
-  CHECK (default_api_shape IN ('responses', 'chat_completions'));
-
-ALTER TABLE model_metadata
-  ADD CONSTRAINT model_metadata_supported_api_shapes_check
-  CHECK (
-    supported_api_shapes <@ ARRAY['responses', 'chat_completions']::text[]
-    AND default_api_shape = ANY(supported_api_shapes)
-  );
+  ADD CONSTRAINT model_metadata_api_shape_check
+  CHECK (api_shape IN ('responses', 'chat_completions'));
 ```
 
 SQLAlchemy:
@@ -115,9 +104,8 @@ SQLAlchemy:
 - Add an `LLMApiShape` `StrEnum` or literal-backed string column.
 - Set existing rows to `responses` through the default.
 - Include `api_shape` in `LLMRequestInfo`.
-- Add `supported_api_shapes` and `default_api_shape` to `ModelMetadata`.
-- Add matching fields to `CustomModelConfig`, defaulting to Responses for
-  backward compatibility.
+- Add `api_shape` to `ModelMetadata` and `CustomModelConfig`, defaulting to
+  Responses for backward compatibility.
 - Sync model API-shape fields into `model_metadata` along with the existing
   pricing, limit, and upstream routing fields.
 
@@ -181,11 +169,9 @@ details object.
    - log as `api_shape='chat_completions'`
 
 4. Enforce model API-shape capabilities.
-   - `/v1/responses` requires `responses` in `supported_api_shapes`.
-   - `/v1/chat/completions` requires `chat_completions` in
-     `supported_api_shapes`.
-   - `default_api_shape` is for clients/runtimes that select the endpoint from a
-     model name; explicit endpoint calls still record their actual endpoint in
+   - `/v1/responses` requires `api_shape='responses'`.
+   - `/v1/chat/completions` requires `api_shape='chat_completions'`.
+   - Explicit endpoint calls still record their actual endpoint in
      `llm_requests.api_shape`.
 
 5. Preserve the logical props model in `LLMRequest.model`.
@@ -336,12 +322,11 @@ shape explicitly:
 name = "glm-4.6"
 upstream = "litellm"
 upstream_model = "glm-4.6"
-supported_api_shapes = ["chat_completions"]
-default_api_shape = "chat_completions"
+api_shape = "chat_completions"
 ```
 
-If a model genuinely supports both paths, list both and set `default_api_shape`
-to the path props-controlled agents should prefer.
+If a provider supports both paths, declare the one props-controlled agents should
+use for that logical model.
 
 ## Tests
 
@@ -354,8 +339,7 @@ Backend tests should cover:
 - logical model is rewritten to the upstream model in the forwarded body.
 - chat usage is extracted into `input_tokens`, `cached_input_tokens`, and
   `output_tokens`.
-- models reject endpoint calls whose `api_shape` is not in
-  `supported_api_shapes`.
+- models reject endpoint calls that do not match `model_metadata.api_shape`.
 - chat rows affect `llm_run_costs` and `agent_run_budget_status`.
 - `GET /api/runs/{id}/llm_requests` returns both Responses and Chat Completions
   rows without validation errors.
@@ -376,7 +360,7 @@ non-trivial way.
 1. Land schema/API/backend support with no config change.
 2. Deploy props proxy/backend.
 3. Update `glm-4.6` config/model metadata to declare
-   `default_api_shape='chat_completions'`.
+   `api_shape='chat_completions'`.
 4. Smoke test `/v1/responses` on an existing model to prove no regression.
 5. Smoke test `/v1/chat/completions` with `glm-4.6` through cluster LiteLLM.
 6. Verify a matching `llm_requests` row exists with
@@ -386,9 +370,6 @@ non-trivial way.
 
 ## Open questions
 
-- Should `default_api_shape` be only advisory, or should agent runtime helpers use
-  it to choose between `responses.create` and `chat.completions.create` from a
-  generic model handle?
 - Should props log the client request, the forwarded upstream request, or both?
   Current code logs the forwarded request after model rewrite.
 - Do we want a first-class `correlation_id` column now, or is metadata-only

--- a/props/frontend/src/components/BUILD.bazel
+++ b/props/frontend/src/components/BUILD.bazel
@@ -65,11 +65,21 @@ js_library(
 )
 
 js_library(
+    name = "RawJsonSection",
+    srcs = ["RawJsonSection.svelte"],
+    deps = [
+        ":CopyButton",
+        "//props/frontend/src/lib:llmRequestUtils",
+    ],
+)
+
+js_library(
     name = "LLMRequestViewer",
     srcs = ["LLMRequestViewer.svelte"],
     deps = [
         ":LLMRequestSection",
         ":LLMResponseSection",
+        ":RawJsonSection",
         "//props/frontend/src/lib:client",
     ],
 )

--- a/props/frontend/src/components/LLMRequestViewer.svelte
+++ b/props/frontend/src/components/LLMRequestViewer.svelte
@@ -3,6 +3,7 @@
   import type { LLMRequestInfo } from "../lib/api/client";
   import LLMRequestSection from "./LLMRequestSection.svelte";
   import LLMResponseSection from "./LLMResponseSection.svelte";
+  import RawJsonSection from "./RawJsonSection.svelte";
 
   interface Props {
     requests: LLMRequestInfo[];
@@ -37,8 +38,14 @@
         </summary>
 
         <div class="border-t dark:border-gray-700 divide-y dark:divide-gray-700">
-          <LLMRequestSection requestBody={req.request_body as Record<string, unknown>} />
-          {#if req.response_body}
+          {#if req.api_shape === "chat_completions"}
+            <RawJsonSection title="Chat Request JSON" value={req.request_body} />
+          {:else}
+            <LLMRequestSection requestBody={req.request_body as Record<string, unknown>} />
+          {/if}
+          {#if req.response_body && req.api_shape === "chat_completions"}
+            <RawJsonSection title="Chat Response JSON" value={req.response_body} />
+          {:else if req.response_body}
             <LLMResponseSection responseBody={req.response_body as Record<string, unknown>} />
           {/if}
           {#if req.response_error_body}

--- a/props/frontend/src/components/RawJsonSection.svelte
+++ b/props/frontend/src/components/RawJsonSection.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import CopyButton from "./CopyButton.svelte";
+  import { formatJson } from "../lib/llmRequestUtils";
+
+  interface Props {
+    title: string;
+    value: unknown;
+  }
+
+  const { title, value }: Props = $props();
+  const json = $derived(formatJson(value));
+</script>
+
+<div class="p-4 space-y-3">
+  <div class="flex items-center justify-between">
+    <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</h4>
+    <CopyButton text={json} label="Copy JSON" />
+  </div>
+  <pre class="bg-gray-50 dark:bg-gray-900 p-3 rounded text-xs overflow-auto">{json}</pre>
+</div>

--- a/props/llm_proxy/app.py
+++ b/props/llm_proxy/app.py
@@ -1,7 +1,7 @@
 """Standalone LLM proxy app — the agent **data plane**, split out of the unified
 backend so the dashboard/API can roll without disrupting in-flight agents.
 
-Serves only ``/v1/responses`` (auth + budget + cost + upstream routing). It reuses
+Serves ``/v1/responses`` and ``/v1/chat/completions`` (auth + budget + cost + upstream routing). It reuses
 the backend's ``llm`` router, ``auth``, and ``deps`` unchanged — no frontend,
 orchestration, registry proxy, or SSO. The router's only app-state requirements
 are ``admin_db`` (a ``Database`` admin pool, for auth + budget/cost/upstream

--- a/props/llm_proxy/cli.py
+++ b/props/llm_proxy/cli.py
@@ -17,7 +17,7 @@ cli = typer.Typer(help="props LLM proxy")
 # argument the image entrypoint passes ("Got unexpected extra argument (serve)").
 @cli.callback()
 def _root() -> None:
-    """props LLM proxy — the agent data plane (/v1/responses)."""
+    """props LLM proxy — the agent data plane."""
 
 
 @cli.command()

--- a/props/llm_proxy/test_app.py
+++ b/props/llm_proxy/test_app.py
@@ -40,6 +40,13 @@ def test_responses_requires_auth() -> None:
         assert resp.status_code == 401
 
 
+def test_chat_completions_requires_auth() -> None:
+    """Unauthenticated chat completions calls are also guarded by agent auth."""
+    with _client() as client:
+        resp = client.post("/v1/chat/completions", json={"model": "x", "messages": []})
+        assert resp.status_code == 401
+
+
 def test_serve_is_a_subcommand() -> None:
     """The image entrypoint runs `serve <args>`; a single-command Typer (no
     callback) rejects `serve` as an unexpected argument — the prod crash this


### PR DESCRIPTION
## Summary

- Add a single `api_shape` contract for model metadata/config and logged LLM requests (`responses` or `chat_completions`).
- Add a `/v1/chat/completions` LLM proxy path with model-shape enforcement, token usage extraction, and `metadata` correlation fields for Langfuse/LiteLLM.
- Introduce an agent model adapter boundary so props agents can use either Responses or Chat Completions while keeping the internal transcript model stable.
- Use OpenAI SDK chat parameter/usage types at the chat adapter boundary while keeping raw external JSON payloads as `dict[str, Any]`.
- Configure `glm-4.6` to use the chat completions path through LiteLLM and update the relevant props docs/agent DB docs.
- Add a live z.ai chat adapter smoke test and document the z.ai tool-calling quirk: tools and `tool_choice: "auto"` work, but forced named OpenAI `tool_choice` objects return z.ai `400/1210`.
- Keep frontend Responses rendering and show raw JSON for chat-shaped LLM request rows.

## Tests

- `bbr test //agent_core/... //openai_utils/... //props/backend/routes/... //props/llm_proxy/... --test_tag_filters=-live_openai_api`
- `bazelisk test //agent_core:test_zai_chat_adapter_live --test_output=streamed --nocache_test_results --test_env=ZAI_API_KEY --test_env=ZAI_MODEL` (passed against z.ai `glm-4.6`; local Bazel lint/typecheck actions were separately covered by the RBE suite because this host lacks `/bin/bash` for those local aspect wrappers)
- `bbr test //props/frontend:svelte_check_test //props/frontend/src/components:visual_LLMRequests //props/frontend/src/components:visual_LLMRequestsToolCall`
- `bbr test //props/backend/routes/... //props/llm_proxy:test_app --test_tag_filters=-live_openai_api`
- `bbr build //props/backend/routes:model_metadata`
- `bbr test //props/frontend:svelte_check_test`
- `bbr test //props/backend/routes:test_llm_routing`