### PR TITLE
augur: format pm reifier profiling outputs

### DIFF
--- a/augur/debug/rollout_perf_profiling.md
+++ b/augur/debug/rollout_perf_profiling.md
@@ -383,7 +383,7 @@ Two fixes (both landed):
 2. **Series indices are traced operands, not static structure** — a series index is
    just a row into `external_values`, so it's now threaded as a traced device array
    (`_Operands.*`, dynamic gather) instead of a Python `int` baked into the jit static
-   key. The compiled program is independent of *which* row, so no series-index value
+   key. The compiled program is independent of _which_ row, so no series-index value
    can trigger a recompile by construction. The two jit-arg pytrees were renamed to say
    what they are: `_Static` (the compile cache key — counts, slot indices, folded event
    tuples, masks) and `_Operands` (every traced device array the scan closes over).

--- a/augur/sim/compiler/series.py
+++ b/augur/sim/compiler/series.py
@@ -37,7 +37,9 @@ def collect_level_series_keys(scenario: Scenario, external_series: ExternalSerie
     # program's STATIC structure (e.g. `_FoldedPE.floor_series`), so a non-deterministic order busts the
     # native `jax.jit` compile cache (every other compile re-traces). Sorting makes the index assignment
     # deterministic so identical scenarios produce an identical structure → one compile, then cache hits.
-    for series_id in external_series.series_values.select("series_id").unique().get_column("series_id").sort().to_list():
+    for series_id in (
+        external_series.series_values.select("series_id").unique().get_column("series_id").sort().to_list()
+    ):
         # Boundary parse: the external frame is still series_id-string keyed (typed in the frame
         # pass). Every row is a non-PE level series, so the parse must succeed.
         add(_require_level_series_key(str(series_id)))

--- a/augur/x/pm_reifier/results/compare_stats.json
+++ b/augur/x/pm_reifier/results/compare_stats.json
@@ -2,16 +2,10 @@
   "llm": {
     "model": "glm-4.5",
     "mean_pit": 0.6203177097903758,
-    "mean_ci": [
-      0.5040879467319069,
-      0.7491651353747558
-    ],
+    "mean_ci": [0.5040879467319069, 0.7491651353747558],
     "mean_excludes_half": true,
     "tail_rate": 0.31,
-    "tail_ci": [
-      0.23,
-      0.42
-    ],
+    "tail_ci": [0.23, 0.42],
     "tail_excludes_null": true,
     "jsd": 0.051870046004174664,
     "rho1": 0.600548520279638,
@@ -21,16 +15,10 @@
   "state_space": {
     "model": "state_space (log-return Gaussian, trailing-window fit)",
     "mean_pit": 0.4013616480018587,
-    "mean_ci": [
-      0.3234831492585675,
-      0.48425820300116207
-    ],
+    "mean_ci": [0.3234831492585675, 0.48425820300116207],
     "mean_excludes_half": true,
     "tail_rate": 0.23,
-    "tail_ci": [
-      0.11,
-      0.36
-    ],
+    "tail_ci": [0.11, 0.36],
     "tail_excludes_null": false,
     "jsd": 0.05596954501607279,
     "rho1": 0.4585336610498575,


### PR DESCRIPTION
## Summary

- Apply the formatter output reported by PR #1911 pre-commit on Augur files that are already on `devel`.
- Keeps the props chat-completions PR from carrying unrelated Augur formatting changes.

## Verification

- Commit hook run during `git commit`:
  - `ruff-check`
  - `ruff-format`
  - `prettier`
  - `ducktape pre-commit`
  - `ducktape pytest-main-check`
  - `ducktape enforce-bazel-tests`