### PR TITLE
props: pull agent images through registry proxy

### DIFF
--- a/cluster/k8s/props/app/deployment.yaml
+++ b/cluster/k8s/props/app/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - name: PROPS_REGISTRY_PORT
               value: "8000"
             - name: PROPS_REGISTRY_PULL_HOST
-              value: git.allegedly.works
+              value: props.allegedly.works
           volumeMounts:
             - name: config
               mountPath: /etc/props


### PR DESCRIPTION
## Summary\n- point props agent image pull references at props.allegedly.works instead of the Forgejo registry\n- keep kubelet pulls going through the props registry proxy using the existing props imagePullSecret credentials\n\n## Testing\n- pre-commit during commit: prettier, kubeconform (cluster), ducktape pytest-main-check, ducktape enforce-bazel-tests