### PR TITLE
props: stream registry proxy request bodies

### DIFF
--- a/props/registry_proxy/routes.py
+++ b/props/registry_proxy/routes.py
@@ -67,14 +67,14 @@ async def _proxy_to_upstream(request: Request) -> Response:
     if auth:
         headers.append((b"authorization", auth.encode()))
 
-    body = await request.body() if request.method not in ("GET", "HEAD") else b""
+    content = None if request.method in ("GET", "HEAD") else request.stream()
 
     try:
         # 600s: agent image layers are large and can take minutes to stream
         # through to the upstream; the old 30s read timeout surfaced as
         # `502 Upstream error` on big blobs.
         upstream_request = client.build_request(
-            method=request.method, url=upstream_url, headers=headers, content=body, timeout=600.0
+            method=request.method, url=upstream_url, headers=headers, content=content, timeout=600.0
         )
         upstream_response = await client.send(upstream_request, stream=True)
     except httpx.RequestError as e:

--- a/props/registry_proxy/test_routes.py
+++ b/props/registry_proxy/test_routes.py
@@ -111,6 +111,40 @@ async def test_proxy_preserves_multi_valued_accept_headers(monkeypatch: pytest.M
         )
 
 
+async def test_proxy_forwards_streaming_mutation_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blob upload PATCH requests should stream through without losing body bytes."""
+    captured_body = b""
+
+    upstream_app = FastAPI()
+
+    @upstream_app.api_route("/{path:path}", methods=["PATCH"])
+    async def catch_all(request: Request) -> Response:
+        nonlocal captured_body
+        chunks = [chunk async for chunk in request.stream()]
+        captured_body = b"".join(chunks)
+        return Response(status_code=202)
+
+    proxy_app = FastAPI()
+
+    @proxy_app.api_route("/{path:path}", methods=["PATCH"])
+    async def proxy(request: Request) -> Response:
+        return await _proxy_to_upstream(request)
+
+    async def body_chunks():
+        yield b"first-"
+        await asyncio.sleep(0)
+        yield b"second"
+
+    async with _run_server(upstream_app) as upstream_url:
+        monkeypatch.setenv("PROPS_REGISTRY_UPSTREAM_URL", upstream_url)
+
+        async with _run_server(proxy_app) as proxy_url, httpx.AsyncClient(base_url=proxy_url) as client:
+            response = await client.patch("/v2/critic/blobs/uploads/session", content=body_chunks())
+
+    assert response.status_code == 202
+    assert captured_body == b"first-second"
+
+
 def test_only_grader_builtin_tag_move_notifies_supervisor() -> None:
     """The GraderSupervisor restart is triggered ONLY by a move of the grader's
     builtin tag. By-digest pushes and per-commit sha pins (pushed alongside


### PR DESCRIPTION
## Summary
- Stream non-GET/HEAD registry proxy request bodies through to the upstream registry instead of materializing them in memory.
- Keep response streaming behavior and add coverage for streaming PATCH blob-upload bodies.

## Verification
- `bbr test //props/registry_proxy:test_routes`

## Context
While validating the deployed props agent path, the critic image pull through `props-registry.allegedly.works` was much slower than expected for a ~201 MB image. The pull side already uses `StreamingResponse`, but the mutation/upload side still buffered request bodies. This PR fixes that part and keeps the proxy behavior covered.