### PR TITLE
github-secrets-sync: document PAT permissions

### DIFF
--- a/cluster/k8s/github-secrets-sync/README.md
+++ b/cluster/k8s/github-secrets-sync/README.md
@@ -1,0 +1,49 @@
+# GitHub Secrets Sync PAT
+
+`github-secrets-sync-pat` is a fine-grained GitHub PAT stored as a SOPS-managed
+Kubernetes Secret in `flux-system`.
+
+The token should be scoped to selected repositories:
+
+- `agentydragon/ducktape`
+- `agentydragon/gaffer-private`
+
+Required repository permissions:
+
+| Permission     | Access     | Why                                                                                                                                                                                                                                                                             |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Contents       | Read/write | The token is mounted into the Authentik and Attic token-rotation CronJobs, which sparse-clone `ducktape`, edit SOPS files, commit, and push to `devel`.                                                                                                                         |
+| Secrets        | Read/write | `tf/gitops/github-secrets-sync` manages the `SOPS_AGE_KEY` GitHub Actions secret for `ducktape` and `gaffer-private`.                                                                                                                                                           |
+| Variables      | Read/write | `tf/gitops/github-secrets-sync` manages the `PROPS_REGISTRY_URL` GitHub Actions variable for `ducktape`. GitHub's fine-grained permission header calls this `actions_variables`; without it, tofu-controller fails with `403 Resource not accessible by personal access token`. |
+| Administration | Read/write | `tf/gitops/github-branch-protection` manages the `ducktape` repository ruleset for branch protection. GitHub lists repository ruleset endpoints under the `Administration` permission.                                                                                          |
+| Webhooks       | Read/write | `tf/gitops/flux-webhook-token` manages the `ducktape` repository webhook used by the Flux GitHub receiver.                                                                                                                                                                      |
+
+`Metadata: read` is implicit for fine-grained PATs.
+
+This shared PAT is deliberately broad because it backs several small GitOps
+modules and token-rotation jobs. If those ownership boundaries need to tighten,
+split this into purpose-specific PATs instead of removing individual permissions
+from the shared token.
+
+The token is reflected from `flux-system` into `agents-infra` and `nix-cache`
+because the JWT rotation CronJobs consume it there.
+
+`PROPS_REGISTRY_URL` existed in GitHub before Terraform owned it, so
+`tf/gitops/github-secrets-sync/main.tf` includes an import block for
+`ducktape:PROPS_REGISTRY_URL`. Keep that import block until the resource is
+present in tofu-controller's remote state.
+
+If `github-secrets-sync` starts failing, check the accepted-permission header
+for the failing endpoint before broadening the token:
+
+```bash
+TOKEN=$(kubectl -n flux-system get secret github-secrets-sync-pat \
+  -o jsonpath='{.data.token}' | base64 -d)
+
+curl -sS -D - -o /tmp/github-body \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/agentydragon/ducktape/actions/variables/PROPS_REGISTRY_URL \
+  | grep -i '^x-accepted-github-permissions:'
+```

--- a/cluster/k8s/github-secrets-sync/secrets/github-secrets-sync-pat.sops.yaml
+++ b/cluster/k8s/github-secrets-sync/secrets/github-secrets-sync-pat.sops.yaml
@@ -4,7 +4,7 @@ metadata:
   name: github-secrets-sync-pat
   namespace: flux-system
   annotations:
-    description: Fine-grained GitHub PAT with secrets:write and contents:write on agentydragon/ducktape. Used by the github-secrets-sync tofu module, claude-jwt-rotation CronJob, and attic-jwt-rotation CronJobs.
+    description: Fine-grained GitHub PAT for GitOps-managed GitHub resources and token-rotation commits. Required permissions and rationale are documented in cluster/k8s/github-secrets-sync/README.md.
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
     reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "agents-infra,nix-cache"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/tf/gitops/github-secrets-sync/main.tf
+++ b/tf/gitops/github-secrets-sync/main.tf
@@ -9,6 +9,8 @@
 # infrastructure secrets.
 #
 # Auth: fine-grained GitHub PAT stored as K8s Secret (SOPS-deployed by Flux).
+# Required PAT permissions are documented in
+# cluster/k8s/github-secrets-sync/README.md.
 
 provider "github" {
   owner = "agentydragon"
@@ -46,6 +48,13 @@ resource "github_actions_secret" "sops_age_key_gaffer_private" {
 }
 
 # --- GitHub Actions Variables ---
+
+# The variable predates Terraform ownership. Import it so tofu-controller adopts
+# the existing GitHub Actions variable instead of trying to create a duplicate.
+import {
+  to = github_actions_variable.props_registry_url
+  id = "ducktape:PROPS_REGISTRY_URL"
+}
 
 # Where props CI pushes agent images: the standalone props registry proxy, which
 # records agent definitions and forwards to Forgejo's registry. CI authenticates


### PR DESCRIPTION
## Summary

- document the fine-grained PAT permissions required by `github-secrets-sync-pat`, including why each permission is needed
- update the SOPS secret annotation to point at the README
- import the pre-existing `ducktape:PROPS_REGISTRY_URL` GitHub Actions variable so tofu-controller adopts it instead of creating a duplicate

## Validation

- `bbr build //tf/gitops/github-secrets-sync:github-secrets-sync`
- live PAT probe confirmed variable endpoints require `actions_variables=read` / `actions_variables=write`, while secrets and contents reads already succeed

## Operator note

The live PAT still needs GitHub repository permission `Variables: Read and write` added in the fine-grained PAT settings. After that, reconcile `github-secrets-sync`.