### PR TITLE
augur/budget: per-transaction overrides + stale-override check

### DIFF
--- a/augur/budget/schema.py
+++ b/augur/budget/schema.py
@@ -116,6 +116,23 @@ class PfcRule(_RuleBase):
 Rule = MerchantSubstringRule | NameSubstringRule | PfcRule
 
 
+class Override(ApiModel):
+    """Manual per-transaction classification, keyed on Plaid `transaction_id`.
+
+    Highest priority -- pre-empts every rule -- and NOT direction-gated: an explicit
+    human/agent assignment routes the txn to its bucket regardless of sign (e.g. a
+    +amount "Returned Payment" reversal -> a transfer bucket). `transaction_id` is stable
+    per Plaid Item; a relink mints new ids, so the read model runs a global existence probe
+    and reports overrides matching no live row (`stale_overrides`) rather than silently
+    no-op'ing. `note` should denormalize a short date/amount/name descriptor so the YAML
+    reads without cross-referencing the DB.
+    """
+
+    transaction_id: str = Field(min_length=1)
+    bucket_id: str = Field(pattern=_ID_PATTERN)
+    note: str = Field(min_length=1)
+
+
 class BudgetSourceConfig(ApiModel):
     """Where to pull transactions from, scoped to a user's accounts."""
 
@@ -146,6 +163,10 @@ class BudgetConfig(ApiModel):
     # User-specific overrides applied BEFORE the generic defaults. First match wins, so listing
     # a private merchant rule here pre-empts the public defaults.
     rules: tuple[Rule, ...] = ()
+    # Per-transaction manual classifications, applied BEFORE any rule and ungated by
+    # direction (see `Override`). The primary tool for residual weird cases rules
+    # shouldn't generalize (reversals, one-off mislabels).
+    overrides: tuple[Override, ...] = ()
     # When True, ship `default_rules.DEFAULT_RULES` after the user's rules. Set False to
     # opt out of the public rule library entirely (rare; useful for testing).
     include_default_rules: bool = True
@@ -172,4 +193,11 @@ class BudgetConfig(ApiModel):
         for rule in self.rules:
             if rule.bucket_id not in bucket_by_id:
                 raise ValueError(f"rule references unknown bucket_id {rule.bucket_id!r}")
+        seen_override_ids: set[str] = set()
+        for override in self.overrides:
+            if override.bucket_id not in bucket_by_id:
+                raise ValueError(f"override references unknown bucket_id {override.bucket_id!r}")
+            if override.transaction_id in seen_override_ids:
+                raise ValueError(f"duplicate override for transaction_id {override.transaction_id!r}")
+            seen_override_ids.add(override.transaction_id)
         return self

--- a/augur/budget/sql_read_model.py
+++ b/augur/budget/sql_read_model.py
@@ -57,6 +57,17 @@ def _bucket_defs_json(config: BudgetConfig) -> str:
     )
 
 
+def _overrides_json(config: BudgetConfig) -> str:
+    bucket_ids = {bucket.id for bucket in config.buckets}
+    return json.dumps(
+        [
+            {"transaction_id": override.transaction_id, "bucket_id": override.bucket_id}
+            for override in config.overrides
+            if override.bucket_id in bucket_ids
+        ]
+    )
+
+
 def _rule_rows_json(config: BudgetConfig) -> str:
     bucket_ids = {bucket.id for bucket in config.buckets}
     rows: list[dict[str, Any]] = []
@@ -125,6 +136,11 @@ rules AS (
             detailed_value text
         )
 ),
+overrides AS (
+    SELECT *
+    FROM jsonb_to_recordset(CAST(:overrides_json AS jsonb))
+        AS o(transaction_id text, bucket_id text)
+),
 base_tx AS (
     SELECT
         t.transaction_id,
@@ -150,6 +166,10 @@ classified_tx AS (
     SELECT
         base_tx.*,
         COALESCE(
+            -- A per-transaction override is the highest-priority assignment and is NOT
+            -- direction-gated: an explicit human/agent call routes the txn to its bucket
+            -- regardless of sign (e.g. a +amount "Returned Payment" -> transfers_out).
+            ovr.bucket_id,
             matched.bucket_id,
             CASE
                 WHEN base_tx.amount < 0 THEN :default_inflow_bucket_id
@@ -157,6 +177,7 @@ classified_tx AS (
             END
         ) AS bucket_id
     FROM base_tx
+    LEFT JOIN overrides AS ovr ON ovr.transaction_id = base_tx.transaction_id
     LEFT JOIN LATERAL (
         SELECT rules.bucket_id
         FROM rules
@@ -241,6 +262,23 @@ ORDER BY classified_tx.date, classified_tx.transaction_id
 """
 )
 
+# Stale-override probe (decision 7): a GLOBAL existence check by transaction_id, NOT
+# scoped to the request window/accounts, so an override for an out-of-window txn is not
+# falsely flagged. An override whose txn is gone (e.g. after a relink mints new ids, or
+# the txn was removed) surfaces here instead of silently no-op'ing.
+_STALE_OVERRIDES_SQL = text(
+    "SELECT transaction_id FROM transactions "
+    "WHERE transaction_id = ANY(CAST(:override_ids AS text[])) AND removed IS FALSE"
+)
+
+
+async def _read_stale_overrides(session: AsyncSession, config: BudgetConfig) -> tuple[str, ...]:
+    override_ids = [override.transaction_id for override in config.overrides]
+    if not override_ids:
+        return ()
+    live = set((await session.execute(_STALE_OVERRIDES_SQL, {"override_ids": override_ids})).scalars())
+    return tuple(sorted({txn_id for txn_id in override_ids if txn_id not in live}))
+
 
 def _statement_params(
     *, config: BudgetConfig, window_start: date, window_end: date, account_ids: tuple[str, ...]
@@ -248,6 +286,7 @@ def _statement_params(
     return {
         "bucket_defs_json": _bucket_defs_json(config),
         "rules_json": _rule_rows_json(config),
+        "overrides_json": _overrides_json(config),
         "window_start": window_start,
         "window_end": window_end,
         "default_inflow_bucket_id": config.default_inflow_bucket_id,
@@ -279,6 +318,7 @@ async def read_budget_snapshot(
     """Return the budget snapshot with filtering, classification, and grouping done in SQL."""
     params = _statement_params(config=config, window_start=window_start, window_end=window_end, account_ids=account_ids)
     async with session_factory() as session:
+        stale_overrides = await _read_stale_overrides(session, config)
         monthly_rows = (
             await session.execute(_budget_statement(_MONTHLY_TOTALS_SQL_TEMPLATE, account_ids), params)
         ).mappings()
@@ -337,6 +377,7 @@ async def read_budget_snapshot(
         ),
         lumpy=lumpy,
         lumpy_threshold_usd=config.lumpy_threshold_usd,
+        stale_overrides=stale_overrides,
         data_window_start=window_start,
         data_window_end=window_end,
         coverage_starts=config.source.coverage_starts,

--- a/augur/budget/test_sql_read_model.py
+++ b/augur/budget/test_sql_read_model.py
@@ -25,6 +25,7 @@ from augur.budget.schema import (
     BudgetSourceConfig,
     MerchantSubstringRule,
     NameSubstringRule,
+    Override,
     TransferDirection,
 )
 from augur.dates import DAYS_PER_MONTH
@@ -91,7 +92,7 @@ async def session_factory(db_url: str) -> AsyncGenerator[async_sessionmaker[Asyn
         await engine.dispose()
 
 
-def _budget_config() -> BudgetConfig:
+def _budget_config(overrides: tuple[Override, ...] = ()) -> BudgetConfig:
     return BudgetConfig(
         source=BudgetSourceConfig(plaid_account_ids=("checking",), coverage_starts=date(2026, 3, 15)),
         buckets=(
@@ -122,6 +123,7 @@ def _budget_config() -> BudgetConfig:
             MerchantSubstringRule(pattern="Target", bucket_id="custom"),
             NameSubstringRule(pattern="Wealthfront", bucket_id="transfers_in"),
         ),
+        overrides=overrides,
         include_default_rules=True,
         lumpy_threshold_usd=500.0,
     )
@@ -405,6 +407,57 @@ async def test_sql_budget_drilldown_rejects_unknown_bucket(session_factory: asyn
             window_end=date(2026, 4, 30),
             account_ids=("checking",),
         )
+
+
+async def test_sql_budget_overrides_beat_rules_and_ignore_direction(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await _seed_budget_rows(session_factory)
+    config = _budget_config(
+        overrides=(
+            # Pre-empts the `Target -> custom` rule.
+            Override(transaction_id="target_preempt", bucket_id="groceries", note="2026-03-20 $40 TARGET STORE"),
+            # Ungated: an inflow-signed (-12000) txn forced into an outflow expense bucket --
+            # something the direction-gated rules could never do.
+            Override(transaction_id="wealthfront_in", bucket_id="custom", note="2026-03-23 -$12000 Wealthfront"),
+        )
+    )
+
+    response = await sql_read_model.read_budget_snapshot(
+        session_factory=session_factory,
+        config=config,
+        window_start=date(2026, 3, 15),
+        window_end=date(2026, 4, 30),
+        account_ids=("checking",),
+    )
+
+    monthly = _monthly_by_bucket(response)
+    assert monthly["groceries"] == (40.0, 1000.0)  # target_preempt (Mar) joins grocery_lumpy (Apr)
+    assert monthly["custom"] == (-12000.0, 0.0)  # wealthfront_in forced here despite its inflow sign
+    assert monthly["transfers_in"] == (0.0, 0.0)  # wealthfront_in no longer lands here
+    assert response.stale_overrides == ()
+
+
+async def test_sql_budget_snapshot_reports_stale_overrides(session_factory: async_sessionmaker[AsyncSession]) -> None:
+    await _seed_budget_rows(session_factory)
+    config = _budget_config(
+        overrides=(
+            Override(transaction_id="target_preempt", bucket_id="groceries", note="live row"),
+            Override(transaction_id="removed_excluded", bucket_id="groceries", note="points at a removed row"),
+            Override(transaction_id="ghost_txn_id", bucket_id="groceries", note="no such txn (e.g. post-relink)"),
+        )
+    )
+
+    response = await sql_read_model.read_budget_snapshot(
+        session_factory=session_factory,
+        config=config,
+        window_start=date(2026, 3, 15),
+        window_end=date(2026, 4, 30),
+        account_ids=("checking",),
+    )
+
+    # Global existence probe: the live row is fine; the removed row and the absent id are stale.
+    assert response.stale_overrides == ("ghost_txn_id", "removed_excluded")
 
 
 if __name__ == "__main__":

--- a/augur/budget/wire.py
+++ b/augur/budget/wire.py
@@ -92,6 +92,14 @@ class BudgetSnapshotResponse(ApiModel):
     monthly_by_bucket: tuple[BucketMonthly, ...]
     lumpy: tuple[LumpyView, ...]
     lumpy_threshold_usd: float
+    stale_overrides: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "transaction_ids of configured per-transaction overrides that matched no live "
+            "transaction (global check, not window-scoped) -- typically because a Plaid relink "
+            "minted new ids or the txn was removed. The UI should warn; the override is a no-op."
+        ),
+    )
     data_window_start: date
     data_window_end: date
     coverage_starts: date | None = Field(


### PR DESCRIPTION
## What

Stage 0 of the budget categorization redesign: a **per-transaction classification override** layer plus a **stale-override check**.

- `BudgetConfig.overrides`: manual classifications keyed on Plaid `transaction_id`, applied **before all rules** and **ungated by direction** — an explicit human/agent assignment routes a txn to any bucket regardless of sign. The SQL read model `COALESCE`s the override over rule matches.
- `BudgetSnapshotResponse.stale_overrides`: a **global** existence probe (not window-scoped) flags configured overrides whose `transaction_id` matches no live row (Plaid relink minted new ids, or the txn was removed) — loud instead of a silent no-op.
- Validation: override `bucket_id` must exist; `transaction_id` unique across overrides.

## Why

A **$6,825.84 "Returned Payment"** that Plaid tagged `BANK_FEES` at `confidence_level=LOW` — actually the reversal of a bounced credit-card autopay, not a fee. Pattern rules can't fix it without also catching legitimate fees; a per-transaction override is the right tool.

## Scope notes

- Framework only. The gaffer-private config override entry (the live fix) lands **after** this ships in the augur image, since `BudgetConfig` is `extra="forbid"`.
- An earlier draft included a "needs-attention worklist"; **dropped** — it re-flagged already-decided rows. Needs a "verified assignment" concept first (deferred).

## Tests

`//augur/budget:test_sql_read_model` (cache-bypassed): override beats a matching rule; ungated cross-sign assignment; stale detection (live vs removed vs absent). Also green: `//augur/api:server_test`, `:export_schema_test`, `:test_csv_export`, and the frontend `schema_zod` codegen. ruff + mypy pass on RBE.