### PR TITLE
Fix RedirectOnTextMessageHandler firing on every turn

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -345,6 +345,7 @@ py_test(
         ":loop_control",
         "//agent_core/testing/mcp:responses",
         "//openai_utils:model",
+        "@pypi//more_itertools",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/agent_core/handler.py
+++ b/agent_core/handler.py
@@ -261,14 +261,24 @@ class RedirectOnTextMessageHandler(BaseHandler):
         """
         self._reminder = reminder_message
         self._text_detected = False
+        self._tool_called = False
 
     def on_assistant_text_event(self, evt: AssistantText) -> None:
-        """Mark that assistant text was detected."""
-        self._text_detected = True
+        """Mark non-empty assistant text. Empty output_text items (some models emit
+        one on every turn alongside their tool call) are not "text output"."""
+        if evt.text.strip():
+            self._text_detected = True
+
+    def on_tool_call_event(self, evt: ToolCall) -> None:
+        """Mark that a tool was called this turn."""
+        self._tool_called = True
 
     def on_before_sample(self) -> LoopDecision:
-        """If text was detected last turn, inject reminder and reset flag."""
-        if self._text_detected:
-            self._text_detected = False
+        """Inject the reminder only when the previous turn produced text *instead of*
+        tools — i.e. non-empty text with no accompanying tool call."""
+        redirect = self._text_detected and not self._tool_called
+        self._text_detected = False
+        self._tool_called = False
+        if redirect:
             return InjectItems(items=[UserMessage.text(self._reminder)])
         return NoAction()

--- a/agent_core/test_handler.py
+++ b/agent_core/test_handler.py
@@ -1,14 +1,15 @@
-"""Tests for handler.py: CaptureTextHandler and FinishOnTextMessageHandler."""
+"""Tests for handler.py: CaptureTextHandler, FinishOnTextMessageHandler, RedirectOnTextMessageHandler."""
 
 from __future__ import annotations
 
 import pytest
 import pytest_bazel
+from more_itertools import one
 
 from agent_core.agent import Agent
-from agent_core.events import AssistantText
-from agent_core.handler import CaptureTextHandler
-from agent_core.loop_control import AllowAnyToolOrTextMessage
+from agent_core.events import AssistantText, ToolCall
+from agent_core.handler import CaptureTextHandler, RedirectOnTextMessageHandler
+from agent_core.loop_control import AllowAnyToolOrTextMessage, InjectItems, NoAction
 from agent_core.testing.mcp.responses import EchoMock
 from openai_utils.model import OpenAIModelProto, UserMessage
 
@@ -111,6 +112,76 @@ async def test_has_text_property(capture_handler) -> None:
     text = capture_handler.take()
     assert text == "test"
     assert not capture_handler.has_text
+
+
+REMINDER = "Use tools, do not output text directly."
+
+
+@pytest.fixture
+def redirect_handler() -> RedirectOnTextMessageHandler:
+    return RedirectOnTextMessageHandler(REMINDER)
+
+
+def _tool_call() -> ToolCall:
+    return ToolCall(name="exec", args_json="{}", call_id="call_1")
+
+
+def _injected_text(decision: InjectItems) -> str:
+    msg = one(decision.items)
+    assert isinstance(msg, UserMessage)
+    return "".join(part.text for part in (msg.content or []))
+
+
+def test_redirect_text_only_injects_reminder(redirect_handler) -> None:
+    """Non-empty text with no tool call is 'text instead of tools' — redirect."""
+    redirect_handler.on_assistant_text_event(AssistantText(text="I think the bug is in foo.py."))
+
+    decision = redirect_handler.on_before_sample()
+
+    assert isinstance(decision, InjectItems)
+    assert _injected_text(decision) == REMINDER
+
+
+def test_redirect_empty_text_with_tool_call_no_reminder(redirect_handler) -> None:
+    """The glm-4.6 pattern: an empty output_text message alongside a tool call must NOT redirect."""
+    redirect_handler.on_assistant_text_event(AssistantText(text=""))
+    redirect_handler.on_tool_call_event(_tool_call())
+
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
+
+
+def test_redirect_text_preamble_with_tool_call_no_reminder(redirect_handler) -> None:
+    """A prose preamble emitted in the same turn as a tool call is not 'instead of tools'."""
+    redirect_handler.on_assistant_text_event(AssistantText(text="Let me inspect the workspace."))
+    redirect_handler.on_tool_call_event(_tool_call())
+
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
+
+
+def test_redirect_empty_text_only_no_reminder(redirect_handler) -> None:
+    """An empty message with no tool call carries no text — nothing to redirect."""
+    redirect_handler.on_assistant_text_event(AssistantText(text="   "))
+
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
+
+
+def test_redirect_tool_call_only_no_reminder(redirect_handler) -> None:
+    redirect_handler.on_tool_call_event(_tool_call())
+
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
+
+
+def test_redirect_nothing_no_reminder(redirect_handler) -> None:
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
+
+
+def test_redirect_flags_reset_between_turns(redirect_handler) -> None:
+    """Flags are consumed each sample: a text-only turn redirects, a following tool-only turn does not."""
+    redirect_handler.on_assistant_text_event(AssistantText(text="thinking out loud"))
+    assert isinstance(redirect_handler.on_before_sample(), InjectItems)
+
+    redirect_handler.on_tool_call_event(_tool_call())
+    assert isinstance(redirect_handler.on_before_sample(), NoAction)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

In props run [`0a9f8302`](https://props.allegedly.works/#/runs/0a9f8302-5fa6-4111-8bd0-6e00f411f4ca) the *"You must use tools to analyze code and report issues"* reminder was injected on essentially every turn (58 of 59).

`RedirectOnTextMessageHandler` set `_text_detected = True` on **any** assistant-text event, ignoring:
1. that the text could be **empty**, and
2. that a **tool was called in the same turn**.

The handler's contract is to redirect only when the model sends text *instead of* using tools. glm-4.6 (via the proxy's Responses shim) emits an **empty** `output_text` message item on every turn alongside its `function_call`:

```json
{ "role": "assistant", "type": "message",
  "content": [{ "text": "", "type": "output_text" }] }
```

So the agent used a tool every turn and produced no text, yet got the reminder every turn. Verified against the run's `llm_requests`: all 59 responses were `['reasoning', 'message', 'function_call']`, every `message` empty, 58 reminder injections accumulated in the transcript.

## Fix

`agent_core/handler.py` — single shared handler, covers critic, grader, and critic_dev:
- ignore empty/whitespace-only assistant text
- track tool calls via `on_tool_call_event`
- redirect only when a turn produced non-empty text **and** no tool call

## Tests

`agent_core/test_handler.py`: text-only → reminder; empty-text + tool call (the glm-4.6 case) → no reminder; preamble + tool call → no reminder; empty-only / tool-only / nothing → no reminder; flags reset between turns.

Verified on RBE: `//agent_core:test_handler` passes; full `//agent_core/...` mock+unit suite passes (only the `.live` tests fail, which need `ZAI_API_KEY`/live services and are excluded in CI); critic/grader/critic_dev mains build + lint clean.

## Follow-up (not in this PR)

glm-4.6's empty `output_text` items are persisted and re-sent every turn as transcript noise; filtering empty `AssistantMessageOut` in `_process_resp_output` would clean that up separately.