### PR TITLE
augur: reduce metric-fan/terminal to percentiles on-device

### DIFF
--- a/augur/product/BUILD.bazel
+++ b/augur/product/BUILD.bazel
@@ -145,6 +145,7 @@ py_test(
         "//augur/model:provider_config",
         "//augur/model:series",
         "//augur/model:testing",
+        "//augur/sim:engine",
         "//augur/sim:external_series",
         "//augur/sim:scenario",
         "//augur/sim:simulate",

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -7,8 +7,6 @@ agent, initial cash); does not know about properties, locations, or bootstrap.
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
-from typing import cast
 
 import numpy as np
 
@@ -38,35 +36,21 @@ from augur.product.scenarios import (
 from augur.product.wire import (
     MetricFanRequest,
     MetricFanResponse,
-    MetricName,
     RolloutOutput,
     RolloutRequest,
     RolloutResponse,
     ScenarioKey,
     TerminalDistributionRequest,
     TerminalDistributionResponse,
-    TerminalMetrics,
 )
 from augur.sim.codec.plan import DenseSimulationResult
 from augur.sim.compiler import compile_simulation
-from augur.sim.engine.jax_engine import run_jax_product_metrics
+from augur.sim.engine.jax_engine import ProductSummary, run_jax_product_summary
 from augur.sim.external_series import materialize_sampled_exogenous
 from augur.sim.locations import Location
 from augur.sim.runtime import load_jurisdictions_for
 from augur.sim.scenario import HarvestPolicy, Scenario
 from augur.sim.simulate import simulate_dense_with_external_series
-
-
-@dataclass(frozen=True)
-class _DecodedRollout:
-    seed: int
-    monthly_metric_arrays: dict[str, np.ndarray]
-    terminal_metrics: TerminalMetrics
-    model_id: str
-
-    @property
-    def failed(self) -> bool:
-        return self.terminal_metrics.failed_month_index is not None
 
 
 class ProductService:
@@ -107,35 +91,33 @@ class ProductService:
     def metric_fan(self, request: MetricFanRequest) -> MetricFanResponse:
         if request.rollout_count > self._max_rollout_samples:
             raise ValueError(f"rollout count {request.rollout_count} exceeds max {self._max_rollout_samples}")
+        percentiles = tuple(float(pct) for pct in request.percentiles)
         with self._projection_lock:
-            decoded = self._decoded_rollouts(request.scenario, tuple(int(seed) for seed in request.rollout_seeds))
-            model_id = decoded[0].model_id if decoded else request.scenario.model_id
-            percentiles = tuple(float(pct) for pct in request.percentiles)
+            summary, model_id = self._simulate_product_summary(
+                request.scenario, request.rollout_seeds, metric=request.metric, percentiles=percentiles
+            )
             return MetricFanResponse(
                 model_id=model_id,
                 metric=request.metric,
-                monthly_metric_fan=_monthly_metric_fan(decoded, metric=request.metric, percentiles=percentiles),
-                terminal_metric_percentiles=_terminal_metric_percentiles(
-                    decoded, metric=request.metric, percentiles=percentiles
-                ),
-                failed_count=sum(1 for rollout in decoded if rollout.failed),
+                monthly_metric_fan=_monthly_fan_frame(summary, percentiles),
+                terminal_metric_percentiles=_percentile_frame(summary.terminal_samples, percentiles),
+                failed_count=_failed_count(summary),
             )
 
     def terminal_distribution(self, request: TerminalDistributionRequest) -> TerminalDistributionResponse:
         if request.rollout_count > self._max_rollout_samples:
             raise ValueError(f"rollout count {request.rollout_count} exceeds max {self._max_rollout_samples}")
+        percentiles = tuple(float(pct) for pct in request.percentiles)
         with self._projection_lock:
-            decoded = self._decoded_rollouts(request.scenario, tuple(int(seed) for seed in request.rollout_seeds))
-            model_id = decoded[0].model_id if decoded else request.scenario.model_id
-            percentiles = tuple(float(pct) for pct in request.percentiles)
+            summary, model_id = self._simulate_product_summary(
+                request.scenario, request.rollout_seeds, metric=request.metric, percentiles=None
+            )
             return TerminalDistributionResponse(
                 model_id=model_id,
                 metric=request.metric,
-                terminal_metric_percentiles=_terminal_metric_percentiles(
-                    decoded, metric=request.metric, percentiles=percentiles
-                ),
-                terminal_metric_samples=_terminal_metric_samples(decoded, metric=request.metric),
-                failed_count=sum(1 for rollout in decoded if rollout.failed),
+                terminal_metric_percentiles=_percentile_frame(summary.terminal_samples, percentiles),
+                terminal_metric_samples=_terminal_samples_frame(request.rollout_seeds, summary),
+                failed_count=_failed_count(summary),
             )
 
     def rollout(self, request: RolloutRequest) -> RolloutResponse:
@@ -172,25 +154,6 @@ class ProductService:
             ),
         )
 
-    def _decoded_rollouts(self, scenario_key: ScenarioKey, seeds: tuple[int, ...]) -> tuple[_DecodedRollout, ...]:
-        self._validate_scenario_key(scenario_key)
-        batch_metrics, batch_failed, model_id = self._simulate_product_metrics(scenario_key, seeds)
-        month_index = batch_metrics["month_index"].copy()
-        decoded: list[_DecodedRollout] = []
-        for batch_index, seed in enumerate(seeds):
-            arrays = {
-                name: (month_index if name == "month_index" else values[:, batch_index].copy())
-                for name, values in batch_metrics.items()
-            }
-            failed_month = int(batch_failed[batch_index])
-            terminal = terminal_metrics_from_arrays(
-                arrays, failed_month_index=None if failed_month < 0 else failed_month
-            )
-            decoded.append(
-                _DecodedRollout(seed=seed, monthly_metric_arrays=arrays, terminal_metrics=terminal, model_id=model_id)
-            )
-        return tuple(decoded)
-
     def _validate_scenario_key(self, scenario_key: ScenarioKey) -> None:
         if scenario_key.model_id not in self._models:
             raise ValueError(f"unknown model_id: {scenario_key.model_id!r} (known presets: {sorted(self._models)})")
@@ -208,9 +171,10 @@ class ProductService:
         if horizon_months > self._max_horizon_months:
             raise ValueError(f"requested horizon {horizon_months} exceeds server max {self._max_horizon_months}")
 
-    def _simulate_product_metrics(
-        self, scenario_key: ScenarioKey, seeds: tuple[int, ...]
-    ) -> tuple[dict[str, np.ndarray], np.ndarray, str]:
+    def _simulate_product_summary(
+        self, scenario_key: ScenarioKey, seeds: tuple[int, ...], *, metric: str, percentiles: tuple[float, ...] | None
+    ) -> tuple[ProductSummary, str]:
+        self._validate_scenario_key(scenario_key)
         scenario, sampled, model_id = self._scenario_and_sample(scenario_key, seeds)
         plan = compile_simulation(
             scenario,
@@ -219,8 +183,10 @@ class ProductService:
             jurisdictions=load_jurisdictions_for(scenario),
             locations=self._locations,
         )
-        batch_metrics, batch_failed = run_jax_product_metrics(plan, primary_agent_id=self._primary_agent_id)
-        return batch_metrics, batch_failed, model_id
+        summary = run_jax_product_summary(
+            plan, primary_agent_id=self._primary_agent_id, metric=metric, percentiles=percentiles
+        )
+        return summary, model_id
 
     def _simulate_dense(self, scenario_key: ScenarioKey, seeds: tuple[int, ...]) -> tuple[DenseSimulationResult, str]:
         scenario, sampled, model_id = self._scenario_and_sample(scenario_key, seeds)
@@ -263,81 +229,31 @@ class ProductService:
         return scenario, sampled, model_id
 
 
-def _monthly_metric_fan(
-    rollouts: tuple[_DecodedRollout, ...], *, metric: MetricName, percentiles: tuple[float, ...]
-) -> Frame:
-    matrix = _metric_matrix(rollouts, metric=metric)
-    if matrix is None:
-        return {"month_index": [], "percentile": [], "value": []}
-    month_indices, values = matrix
-    percentile_values = _percentile(values, percentiles, axis=0)
+def _monthly_fan_frame(summary: ProductSummary, percentiles: tuple[float, ...]) -> Frame:
+    month_indices = summary.month_index
+    bands = summary.monthly_bands  # (n_percentiles, H+1)
+    assert bands is not None, "monthly fan requires percentiles"
     percentile_array = np.asarray(percentiles, dtype=np.float64)
     return {
         "month_index": np.repeat(month_indices, percentile_array.size).tolist(),
         "percentile": np.tile(percentile_array, month_indices.size).tolist(),
-        "value": percentile_values.T.reshape(-1).tolist(),
+        "value": bands.T.reshape(-1).tolist(),
     }
 
 
-def _terminal_metric_percentiles(
-    rollouts: tuple[_DecodedRollout, ...], *, metric: MetricName, percentiles: tuple[float, ...]
-) -> Frame:
-    values = np.asarray(
-        [_terminal_metric_value(rollout.terminal_metrics, metric) for rollout in rollouts], dtype=np.float64
-    )
-    if values.size == 0:
-        return {"percentile": [], "value": []}
+def _percentile_frame(samples: np.ndarray, percentiles: tuple[float, ...]) -> Frame:
     percentile_array = np.asarray(percentiles, dtype=np.float64)
-    percentile_values = _percentile(values, percentiles, axis=0)
-    return {"percentile": percentile_array.tolist(), "value": percentile_values.tolist()}
+    values = np.percentile(samples, percentile_array, method="linear")
+    return {"percentile": percentile_array.tolist(), "value": np.asarray(values, dtype=np.float64).tolist()}
 
 
-def _terminal_metric_samples(rollouts: tuple[_DecodedRollout, ...], *, metric: MetricName) -> Frame:
+def _terminal_samples_frame(seeds: tuple[int, ...], summary: ProductSummary) -> Frame:
     return {
-        "seed": [rollout.seed for rollout in rollouts],
-        "value": [_terminal_metric_value(rollout.terminal_metrics, metric) for rollout in rollouts],
-        "failed": [rollout.failed for rollout in rollouts],
+        "seed": list(seeds),
+        "value": summary.terminal_samples.tolist(),
+        "failed": (summary.failed_month >= 0).tolist(),
     }
 
 
-def _metric_matrix(
-    rollouts: tuple[_DecodedRollout, ...], *, metric: MetricName
-) -> tuple[np.ndarray, np.ndarray] | None:
-    if not rollouts:
-        return None
-    month_indices = rollouts[0].monthly_metric_arrays["month_index"]
-    values = np.empty((len(rollouts), month_indices.size), dtype=np.float64)
-    for rollout_index, rollout in enumerate(rollouts):
-        rollout_months = rollout.monthly_metric_arrays["month_index"]
-        if rollout_months.shape != month_indices.shape or not np.array_equal(rollout_months, month_indices):
-            raise ValueError("metric fan rollouts have inconsistent month indices")
-        values[rollout_index] = rollout.monthly_metric_arrays[metric].astype(np.float64, copy=False)
-    return month_indices, values
-
-
-def _percentile(values: np.ndarray, percentiles: tuple[float, ...], *, axis: int) -> np.ndarray:
-    return cast(
-        np.ndarray, np.percentile(values, np.asarray(percentiles, dtype=np.float64), axis=axis, method="linear")
-    )
-
-
-def _terminal_metric_value(terminal: TerminalMetrics, metric: MetricName) -> float:
-    match metric:
-        case "cash_usd":
-            return terminal.cash_usd
-        case "holding_value_usd":
-            return terminal.holding_value_usd
-        case "private_equity_value_usd":
-            return terminal.private_equity_value_usd
-        case "property_value_usd":
-            return terminal.property_value_usd
-        case "mortgage_balance_usd":
-            return terminal.mortgage_balance_usd
-        case "home_equity_usd":
-            return terminal.home_equity_usd
-        case "liquid_net_worth_usd":
-            return terminal.liquid_net_worth_usd
-        case "net_worth_usd":
-            return terminal.net_worth_usd
-        case "shortfall_usd":
-            return terminal.shortfall_usd
+def _failed_count(summary: ProductSummary) -> int:
+    return int((summary.failed_month >= 0).sum())

--- a/augur/product/service_test.py
+++ b/augur/product/service_test.py
@@ -70,6 +70,7 @@ from augur.product.wire import (
     SetRentedFractionEventWire,
     TerminalDistributionRequest,
 )
+from augur.sim.engine.jax_engine import ProductSummary
 from augur.sim.external_series import EXTERNAL_SERIES_VALUES_FRAME, ExternalSeriesContext
 from augur.sim.scenario import Agent, InitialAccountBalance, InitialLot, Scenario, SeriesIndexedAmount
 from augur.sim.simulate import simulate_dense_with_external_series
@@ -353,20 +354,29 @@ def test_metric_fan_terminal_distribution_and_rollout_detail_behavior(
     assert fan_with_one_new_seed.monthly_metric_fan["percentile"] == [50.0] * 4
 
 
-def test_reduced_product_projection_matches_dense_metric_decode(
+def test_reduced_product_summary_matches_dense_metric_decode(
     product: service.ProductService, scenario_key: ScenarioKey
 ) -> None:
     seeds = (7, 8)
     dense, _model_id = product._simulate_dense(scenario_key, seeds)
     expected_metrics = decode.monthly_metric_arrays_batch(dense, primary_agent_id=product._primary_agent_id)
     expected_failed = decode.failed_month_index_batch(dense)
+    percentiles = (0.0, 25.0, 50.0, 75.0, 100.0)
 
-    actual_metrics, actual_failed, _model_id = product._simulate_product_metrics(scenario_key, seeds)
-
-    assert set(actual_metrics) == set(expected_metrics)
-    for name, expected in expected_metrics.items():
-        np.testing.assert_allclose(actual_metrics[name], expected, rtol=0.0, atol=1e-9)
-    np.testing.assert_array_equal(actual_failed, expected_failed)
+    # The reduced product projection emits the same numbers as the full dense decode, but reduced
+    # on-device to the requested metric's monthly percentile bands + per-rollout terminal samples.
+    for name, expected_series in expected_metrics.items():
+        if name == "month_index":
+            continue
+        summary, _model_id = product._simulate_product_summary(
+            scenario_key, seeds, metric=name, percentiles=percentiles
+        )
+        np.testing.assert_array_equal(summary.failed_month, expected_failed)
+        # Terminal shortfall is cumulative over the horizon; every other metric is the end snapshot.
+        expected_terminal = expected_series.sum(axis=0) if name == "shortfall_usd" else expected_series[-1]
+        np.testing.assert_allclose(summary.terminal_samples, expected_terminal, rtol=0.0, atol=1e-9)
+        expected_bands = np.percentile(expected_series, np.asarray(percentiles), axis=1, method="linear")
+        np.testing.assert_allclose(summary.monthly_bands, expected_bands, rtol=1e-9, atol=1e-6)
 
 
 def test_concurrent_fan_and_terminal_requests_run_serially(
@@ -375,16 +385,16 @@ def test_concurrent_fan_and_terminal_requests_run_serially(
     monkeypatch: pytest.MonkeyPatch,
     scenario_key: ScenarioKey,
 ) -> None:
-    original_simulate_product_metrics = product._simulate_product_metrics
+    original_simulate_product_summary = product._simulate_product_summary
     first_simulation_started = threading.Event()
     release_first_simulation = threading.Event()
     active_simulations = 0
     max_active_simulations = 0
     active_lock = threading.Lock()
 
-    def slow_simulate_product_metrics(
-        scenario: ScenarioKey, seeds: tuple[int, ...]
-    ) -> tuple[dict[str, np.ndarray], np.ndarray, str]:
+    def slow_simulate_product_summary(
+        scenario: ScenarioKey, seeds: tuple[int, ...], *, metric: str, percentiles: tuple[float, ...] | None
+    ) -> tuple[ProductSummary, str]:
         nonlocal active_simulations, max_active_simulations
         with active_lock:
             active_simulations += 1
@@ -392,12 +402,12 @@ def test_concurrent_fan_and_terminal_requests_run_serially(
             first_simulation_started.set()
         release_first_simulation.wait(timeout=5)
         try:
-            return original_simulate_product_metrics(scenario, seeds)
+            return original_simulate_product_summary(scenario, seeds, metric=metric, percentiles=percentiles)
         finally:
             with active_lock:
                 active_simulations -= 1
 
-    monkeypatch.setattr(product, "_simulate_product_metrics", slow_simulate_product_metrics)
+    monkeypatch.setattr(product, "_simulate_product_summary", slow_simulate_product_summary)
 
     fan_request = MetricFanRequest(
         scenario=scenario_key, first_seed=7, rollout_count=2, metric="cash_usd", percentiles=(5, 50, 95)
@@ -468,7 +478,7 @@ def test_terminal_distribution_samples_identify_rollout_terminal_values(
 def test_metric_fan_runs_reduced_product_projection_once_per_batch(
     product: service.ProductService, monkeypatch: pytest.MonkeyPatch, scenario_key: ScenarioKey
 ) -> None:
-    original = service.run_jax_product_metrics
+    original = service.run_jax_product_summary
     calls = 0
 
     def counted(*args, **kwargs):
@@ -476,7 +486,7 @@ def test_metric_fan_runs_reduced_product_projection_once_per_batch(
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(service, "run_jax_product_metrics", counted)
+    monkeypatch.setattr(service, "run_jax_product_summary", counted)
 
     product.metric_fan(
         MetricFanRequest(scenario=scenario_key, first_seed=7, rollout_count=4, metric="cash_usd", percentiles=(50,))

--- a/augur/sim/engine/jax_engine.py
+++ b/augur/sim/engine/jax_engine.py
@@ -328,15 +328,76 @@ def run_jax_scan(plan: CompiledSimulation, buffers: SimulationBuffers) -> None:
     scatter_ys_to_buffers(plan, buffers, meta, ys, sale_disp)
 
 
-def run_jax_product_metrics(
-    plan: CompiledSimulation, *, primary_agent_id: str
-) -> tuple[dict[str, np.ndarray], np.ndarray]:
-    """Run the JAX month loop but emit only product fan/terminal metrics.
+@dataclass(frozen=True)
+class ProductSummary:
+    """Reduced product projection for the percentile (fan / terminal) endpoints.
 
-    This keeps the accounting algorithm identical to `run_jax_scan` while avoiding the full
-    DenseSimulationResult history/event slabs. The product fan and terminal endpoints need these
-    reduced histories for all seeds; the full dense trace is reserved for the selected-rollout detail
-    endpoint.
+    Carries only what those endpoints consume — the requested metric's monthly percentile bands and
+    its per-rollout terminal samples — so the full (H+1, R) per-metric history is reduced on-device
+    and never copied to the host or re-stored per rollout.
+    """
+
+    month_index: np.ndarray  # (H+1,)
+    failed_month: np.ndarray  # (R,) int64; -1 = never failed
+    terminal_samples: np.ndarray  # (R,) requested metric's terminal value per rollout
+    monthly_bands: np.ndarray | None  # (n_percentiles, H+1) for the requested metric, or None
+
+
+# The six metrics the scan emits per month (see `product_metrics`); the wire's three remaining
+# metrics (home_equity, liquid_net_worth, net_worth) are linear combinations of these.
+_PRODUCT_BASE_METRICS = (
+    "cash_usd",
+    "holding_value_usd",
+    "private_equity_value_usd",
+    "property_value_usd",
+    "mortgage_balance_usd",
+    "shortfall_usd",
+)
+_PRODUCT_BASE_INDEX = {name: index for index, name in enumerate(_PRODUCT_BASE_METRICS)}
+
+
+def _product_metric_series(
+    metric: str, initial_ys: tuple[jnp.ndarray, ...], monthly_ys: tuple[jnp.ndarray, ...]
+) -> jnp.ndarray:
+    """Full (H+1, R) device series for one product metric, composing derived metrics from base series.
+
+    Only the base series the requested metric needs are assembled, so a single-metric fan never
+    materializes all nine metrics' histories.
+    """
+
+    def base(name: str) -> jnp.ndarray:
+        index = _PRODUCT_BASE_INDEX[name]
+        return jnp.concatenate([jnp.asarray(initial_ys[index])[None, :], jnp.asarray(monthly_ys[index])], axis=0)
+
+    match metric:
+        case "home_equity_usd":
+            return base("property_value_usd") - base("mortgage_balance_usd")
+        case "liquid_net_worth_usd":
+            # Excludes private equity by design (matches `monthly_metric_arrays_batch`): PE is only
+            # saleable at sparse tender events, so it isn't "cash you could get tomorrow".
+            return base("cash_usd") + base("holding_value_usd")
+        case "net_worth_usd":
+            return (
+                base("cash_usd")
+                + base("holding_value_usd")
+                + base("property_value_usd")
+                - base("mortgage_balance_usd")
+                + base("private_equity_value_usd")
+            )
+        case _:
+            return base(metric)
+
+
+def run_jax_product_summary(
+    plan: CompiledSimulation, *, primary_agent_id: str, metric: str, percentiles: tuple[float, ...] | None
+) -> ProductSummary:
+    """Run the JAX month loop and reduce, on-device, to the requested metric's monthly percentile
+    bands (when `percentiles` is given) and its per-rollout terminal samples.
+
+    Shares the exact accounting scan with `run_jax_scan`; only the emitted summary differs. Avoiding
+    the full DenseSimulationResult history/event slabs — and reducing each metric to percentiles
+    before the device→host copy — means neither the host nor the response ever holds per-rollout
+    monthly state. The full dense trace is reserved for the selected-rollout detail endpoint.
     """
     validate_seed_dependent_inputs(plan)
 
@@ -346,29 +407,26 @@ def run_jax_product_metrics(
     product_ys, product_tail = _program_impl(
         external, pe, cfg, baked, p, structure, product_summary=product_static, product_inputs=product_inputs
     )
-    product_ys, product_tail = jax.device_get((product_ys, product_tail))
-    (oversell, final_failed_month) = product_tail
-    if bool(np.asarray(oversell)):
+    oversell, final_failed_month = product_tail
+    if bool(np.asarray(jax.device_get(oversell))):
         raise ValueError("scheduled asset sale exceeds available lots")
+
     initial_ys, monthly_ys = product_ys
-    names = (
-        "cash_usd",
-        "holding_value_usd",
-        "private_equity_value_usd",
-        "property_value_usd",
-        "mortgage_balance_usd",
-        "shortfall_usd",
+    series = _product_metric_series(metric, initial_ys, monthly_ys)  # (H+1, R), on device
+    # Terminal sample: cumulative over the horizon for shortfall, end-of-horizon snapshot otherwise.
+    terminal = series.sum(axis=0) if metric == "shortfall_usd" else series[-1]
+    bands = (
+        jnp.quantile(series, jnp.asarray(percentiles, dtype=jnp.float64) / 100.0, axis=1, method="linear")
+        if percentiles is not None
+        else None
     )
-    arrays: dict[str, np.ndarray] = {"month_index": np.arange(plan.horizon_months + 1, dtype=np.int64)}
-    for name, initial, monthly in zip(names, initial_ys, monthly_ys, strict=True):
-        values = np.concatenate([np.asarray(initial, dtype=np.float64)[None, :], np.asarray(monthly, dtype=np.float64)])
-        arrays[name] = values
-    arrays["home_equity_usd"] = arrays["property_value_usd"] - arrays["mortgage_balance_usd"]
-    arrays["liquid_net_worth_usd"] = arrays["cash_usd"] + arrays["holding_value_usd"]
-    arrays["net_worth_usd"] = (
-        arrays["liquid_net_worth_usd"] + arrays["home_equity_usd"] + arrays["private_equity_value_usd"]
+
+    return ProductSummary(
+        month_index=np.arange(plan.horizon_months + 1, dtype=np.int64),
+        failed_month=np.asarray(jax.device_get(final_failed_month), dtype=np.int64),
+        terminal_samples=np.asarray(jax.device_get(terminal), dtype=np.float64),
+        monthly_bands=None if bands is None else np.asarray(jax.device_get(bands), dtype=np.float64),
     )
-    return arrays, np.asarray(final_failed_month, dtype=np.int64)
 
 
 def _program_inputs(plan: CompiledSimulation) -> tuple[jnp.ndarray, dict[str, jnp.ndarray], _TracedConfig]:

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -1,9 +1,8 @@
 """Forward simulation entrypoints.
 
-`simulate(scenario, rollout_count) -> SimulationRun` materializes external
-series and runs the dense-array engine. The engine keeps the month loop in
-NumPy arrays and decodes the resulting boundary tables as Polars
-DataFrames for API and product projection code.
+`simulate(scenario, rollout_count) -> SimulationRun` materializes external series and runs the JAX
+engine: the whole month loop compiles into one XLA program, whose stacked outputs are scattered into
+NumPy buffers and decoded as Polars DataFrames for API and product projection code.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why
Producing augur graphs in-cluster is slow. The product fan/terminal endpoints decoded **all nine metrics** as `(H+1, R)` host arrays, unpacked them into per-rollout dicts (a `.copy()` per metric per rollout), built per-rollout `TerminalMetrics`, then repacked the one requested metric into an `(R, H+1)` matrix before computing percentiles — mostly wasted work for a single-metric fan, and it holds the full per-rollout monthly history on the host.

## What
- Replace `run_jax_product_metrics` with **`run_jax_product_summary(metric, percentiles)`**. It runs the *same* accounting scan (shared with the single-rollout path via `_program_impl`) but reduces the requested metric to monthly percentile **bands** (`jnp.quantile` over the rollout axis) and per-rollout **terminal samples** on-device, **before** the device→host copy. The full `(H+1, R)` history never crosses to the host or gets re-stored per rollout. Only the requested metric's series is assembled; derived metrics are composed from base series.
- `service.py` drops `_DecodedRollout` and the unpack/repack; fan and terminal frames are built directly from the reduced summary.
- Fix a stale `simulate.py` docstring (claimed the month loop runs in NumPy; it compiles to XLA).

## Correctness
New `test_reduced_product_summary_matches_dense_metric_decode` validates the on-device bands + terminal samples against the full dense decode for every metric.

## Tests
- `//augur/product:service_test`, `//augur/product:service_scale_test`: **pass**.
- `//augur/...`: 64 pass / 6 skip. `//augur:visual_test` fails **identically on clean `devel`** (verified by stashing this branch) — pre-existing `playwright wait_for_function` 30s timeouts (the chart never renders in time, itself a symptom of the cold-compile slowness this effort targets). Not caused by this PR.
- pre-commit clean.

## Companion changes (separate, not in this PR)
- gaffer-private: enable the JAX on-disk compile cache (emptyDir) + raise burst CPU for the augur deployment.
- Follow-up PR (after this merges): remove now-vestigial dual-backend indirection (`simulate_with_external_series_dense_result` naming, `r_first_view`/`state_axes` NumPy-era buffer-layout artifacts).