### PR TITLE
augur/sim: drop dual-backend naming/comment vestiges

### DIFF
--- a/augur/product/BUILD.bazel
+++ b/augur/product/BUILD.bazel
@@ -63,7 +63,6 @@ py_library(
         "//augur/sim:locations",
         "//augur/sim:runtime",
         "//augur/sim:simulate",
-        "//augur/sim:slice",
         "@pypi//numpy",
     ],
 )

--- a/augur/sim/codec/helpers.py
+++ b/augur/sim/codec/helpers.py
@@ -100,8 +100,8 @@ def codes_to_asset_wire_ids(plan: CompiledSimulation, codes: np.ndarray) -> np.n
 
 
 def r_first_view(state: np.ndarray) -> np.ndarray:
-    """Move R (trailing axis per B0) to axis 1 so the decoders can keep using their
-    (h1, r, count[, ...]) row-major iteration order over the resulting flat buffer."""
+    """Move R from the trailing axis (the layout the JAX scan emits) to axis 1, so decoders can
+    iterate `(h1, r, count[, ...])` row-major over the resulting flat buffer."""
 
     return np.moveaxis(state, -1, 1)
 

--- a/augur/sim/engine/__init__.py
+++ b/augur/sim/engine/__init__.py
@@ -30,7 +30,7 @@ from augur.sim.runtime import load_jurisdictions_for
 from augur.sim.scenario import Scenario
 
 
-def simulate_with_external_series_dense_result(
+def run_dense_simulation(
     scenario: Scenario, *, rollout_count: int, external_series: ExternalSeriesContext, locations: dict[str, Location]
 ) -> DenseSimulationResult:
     plan = compile_simulation(
@@ -54,8 +54,10 @@ def _allocate_buffers(plan: CompiledSimulation) -> SimulationBuffers:
     liability_event_axis = max(1, p.liability_count)
     buffers = SimulationBuffers(
         state=StateHistoryBuffers(
-            # All state-history buffers are R-last per B0: (snapshot, count, R) for 2-axis
-            # state, (snapshot, count_a, count_b, R) for the 3-axis capital-gain split.
+            # State-history buffers keep the rollout axis last to match the JAX scan's output
+            # layout (it emits per-(count, R) arrays): (snapshot, count, R) for 2-axis state,
+            # (snapshot, count_a, count_b, R) for the 3-axis capital-gain split. Decoders move R
+            # to axis 1 via `r_first_view` when they read these.
             # cash_state[S, C, R]
             cash_state=np.zeros((s, p.cash_count, r), dtype=np.int64),
             # lot_state[S, L, R]

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import polars as pl
 
 from augur.sim.codec.plan import DenseSimulationResult, SimulationRun
-from augur.sim.engine import simulate_with_external_series_dense_result
+from augur.sim.engine import run_dense_simulation
 from augur.sim.external_series import ExternalSeriesContext, materialize_external_series
 from augur.sim.locations import Location
 from augur.sim.scenario import Scenario, SeriesIndexedAmount
@@ -35,7 +35,7 @@ def simulate_with_external_series(
         msg = f"rollout_count must be positive; got {rollout_count}"
         raise ValueError(msg)
     _validate_series_indexed_amounts(scenario, rollout_count=rollout_count, external_series=external_series)
-    return simulate_with_external_series_dense_result(
+    return run_dense_simulation(
         scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
     ).decode()
 
@@ -47,7 +47,7 @@ def simulate_dense_with_external_series(
         msg = f"rollout_count must be positive; got {rollout_count}"
         raise ValueError(msg)
     _validate_series_indexed_amounts(scenario, rollout_count=rollout_count, external_series=external_series)
-    return simulate_with_external_series_dense_result(
+    return run_dense_simulation(
         scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
     )
 


### PR DESCRIPTION
Follow-up to #1923. Removes the genuinely-safe leftovers from the old two-backend design (NumPy backend removed in `cdf0ea1fe`; only JAX remains).

## Changes (no behavior change)
- Rename engine `simulate_with_external_series_dense_result` → **`run_dense_simulation`**. The `_dense_result` suffix only distinguished it from the old eager-decode path that no longer exists, and it collided confusingly with the `simulate.py` wrapper `simulate_dense_with_external_series`. Two internal call sites updated.
- Replace stale **"per B0"** milestone references (state-buffer layout comment in `engine/__init__.py`, `r_first_view` docstring in `codec/helpers.py`) with an accurate explanation: R is the trailing axis because that's the JAX scan's output layout; decoders move it to axis 1.
- Drop the stale **`//augur/sim:slice`** dep from the product `service` target — `service.py` doesn't import it.

## Scope: what I deliberately did NOT touch
Most of what looks like "dual-backend indirection" turns out to be load-bearing, not vestigial:
- **`DenseSimulationResult` / `SimulationRun`**: consumed broadly (`product/decode.py`, `product/service.py`, `sim/slice.py`). Collapsing the pair is a real refactor, not a deletion.
- **`r_first_view` / `state_axes`** (R-last buffer layout → transpose in every decoder): genuinely a NumPy-era artifact, but removing it means flipping the buffer layout across the scatter + all decoders. That's the bigger/riskier refactor (and an area already under active perf-tuning per `augur/debug/rollout_perf_profiling.md`). Worth doing as its own PR if desired.
- **`augur/sim/slice.py`** appears reachable only via its own test (`slice_dense_result` is used only by `simulate_test.py`; `slice_dense_results` only internally). Possibly dead, but it's tested and public — flagging rather than deleting unilaterally.

## Tests
`//augur/sim:simulate_test`, `//augur/product:service_test`, `//augur/product:service_scale_test`, `//augur/sim:scan_test`, `//augur/sim:test_property_stakes_e2e`: **pass**. pre-commit clean.

> Note: `bbr build //augur/...` is currently **red on `devel`** due to a pre-existing mypy error in `augur/calibration/calibration.py` (`ThresholdLadderFamily`/`BucketFamily`/`DateLadderFamily`, from `5fa508a10`), unrelated to this PR.