### PR TITLE
augur/sim/TODO.md: drop bogus single-rollout-reduction TODO

### DIFF
--- a/augur/sim/TODO.md
+++ b/augur/sim/TODO.md
@@ -301,10 +301,6 @@ What's left is load-bearing and needs a real refactor, each its own PR:
   R-first (and transposing once in `jax_scatter`, or emitting R-first from the
   scan) removes ~12 per-decode transposes. Area is perf-sensitive — see
   <augur/debug/rollout_perf_profiling.md>.
-- **On-device single-rollout reduction.** The rollout-detail endpoint
-  materializes all R rollouts' dense buffers then filters to one. It could
-  reduce on-device like `run_jax_product_summary` does for the fan, avoiding the
-  full `(…, R)` device→host copy for a single rollout.
 
 ## Future / nice-to-have
 


### PR DESCRIPTION
The "On-device single-rollout reduction" bullet (added in #1925) claimed the rollout-detail endpoint "materializes all R rollouts' dense buffers then filters to one." That described the removed `slice.py` design, not current behavior.

Verified the single-rollout path is already R=1 end-to-end:
- `RolloutRequest` carries only `{scenario, seed}`.
- `rollout()` → `_simulate_dense(scenario, (seed,))` → `compile_simulation(rollout_count=1)`.
- The exogenous sampler builds one PRNGKey per seed (`vecm.py:_simulate_multipliers`), so `(seed,)` generates exactly one path and reproduces the fan's index-K path deterministically.

Nothing to reduce, so the TODO is removed. Doc-only.