### PR TITLE
docs/test: glm-4.6 stringifies union-typed tool params (+live recipe tests)

### DIFF
--- a/agent_core/test_zai_chat_adapter_live.py
+++ b/agent_core/test_zai_chat_adapter_live.py
@@ -3,12 +3,178 @@ from __future__ import annotations
 import json
 import os
 
+import pytest
 import pytest_bazel
 from openai import AsyncOpenAI
 
 from agent_core.model import AgentModelRequest, ChatCompletionsAgentModel
 from openai_utils.api_shape import LLMApiShape
 from openai_utils.model import FunctionCallItem, FunctionToolParam, UserMessage
+
+_ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+
+
+async def _sample_tool_call_arguments(*, parameters: dict, strict: bool, user_text: str) -> dict:
+    """Send one tool to z.ai glm-4.6 and return the parsed JSON arguments of its sole tool call.
+
+    Used by the tool-schema recipe tests below to observe how glm-4.6 encodes a structured
+    (nested-object) parameter under different parameter-schema shapes.
+    """
+    api_key = os.environ.get("ZAI_API_KEY")
+    assert api_key, "ZAI_API_KEY must be set for the live z.ai tool-schema tests"
+
+    client = AsyncOpenAI(base_url=_ZAI_BASE_URL, api_key=api_key)
+    model = ChatCompletionsAgentModel(client=client, model=os.environ.get("ZAI_MODEL", "glm-4.6"))
+    request = AgentModelRequest(
+        input=[UserMessage.text(user_text)],
+        instructions="Use start_critic. Do not answer in prose.",
+        tools=[
+            FunctionToolParam(
+                name="start_critic",
+                description="Start a critic run on a single example.",
+                parameters=parameters,
+                strict=strict,
+            )
+        ],
+        tool_choice="auto",
+        max_output_tokens=512,
+    )
+    prepared = model.prepare(request)
+    assert prepared.api_shape == LLMApiShape.CHAT_COMPLETIONS
+    try:
+        result = await model.sample(prepared)
+    finally:
+        await client.close()
+
+    tool_calls = [item for item in result.output if isinstance(item, FunctionCallItem)]
+    assert len(tool_calls) == 1
+    assert tool_calls[0].arguments is not None
+    return json.loads(tool_calls[0].arguments)
+
+
+# The recommended recipe for a discriminated union: a single concrete object that carries the
+# superset of fields with `kind` as an enum. glm-4.6 emits this as a proper nested object.
+# (Per-`kind` required fields — e.g. files_hash only for file_set — are enforced server-side.)
+_EXAMPLE_OBJECT = {
+    "type": "object",
+    "properties": {
+        "kind": {"type": "string", "enum": ["file_set", "whole_snapshot"]},
+        "snapshot_slug": {"type": "string"},
+        "files_hash": {"type": "string", "description": "required when kind=file_set"},
+    },
+    "required": ["kind", "snapshot_slug"],
+    "additionalProperties": False,
+}
+
+_START_CRITIC_USER_TEXT = (
+    "Call start_critic. definition_id=sha256:59142, the example is a file_set on "
+    "snapshot_slug crush/2025-08-30-internal_db with files_hash c27fe50118b25dbc185f00315006c37b."
+)
+
+
+def _example_union(combinator: str) -> dict:
+    """Build an `anyOf`/`oneOf` discriminated union of the two example object variants.
+
+    Mirrors props' ExampleSpec. glm-4.6 stringifies either combinator — see the canary below.
+    """
+    return {
+        combinator: [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "const": "whole_snapshot"},
+                    "snapshot_slug": {"type": "string"},
+                },
+                "required": ["kind", "snapshot_slug"],
+                "additionalProperties": False,
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "const": "file_set"},
+                    "snapshot_slug": {"type": "string"},
+                    "files_hash": {"type": "string"},
+                },
+                "required": ["kind", "snapshot_slug", "files_hash"],
+                "additionalProperties": False,
+            },
+        ],
+        "discriminator": {"propertyName": "kind"},
+    }
+
+
+async def test_zai_object_tool_param_returned_as_object_live() -> None:
+    """Working recipe: a single concrete object tool parameter comes back as a nested JSON object.
+
+    glm-4.6 reliably emits a proper object for a concrete object schema (even with a multi-value
+    enum discriminator). This is the shape props tool inputs should use (contrast the union canary).
+    """
+    args = await _sample_tool_call_arguments(
+        parameters={
+            "type": "object",
+            "properties": {"definition_id": {"type": "string"}, "example": _EXAMPLE_OBJECT},
+            "required": ["definition_id", "example"],
+            "additionalProperties": False,
+        },
+        strict=True,
+        user_text=_START_CRITIC_USER_TEXT,
+    )
+    example = args["example"]
+    assert isinstance(example, dict), f"expected a nested object, got {type(example).__name__}: {example!r}"
+    assert example["kind"] == "file_set"
+    assert example["snapshot_slug"] == "crush/2025-08-30-internal_db"
+    assert example["files_hash"] == "c27fe50118b25dbc185f00315006c37b"
+
+
+async def test_zai_flat_tool_params_returned_live() -> None:
+    """Working recipe (alternative): flat top-level scalar params instead of a nested object.
+
+    With no nesting there is nothing for glm-4.6 to stringify; every field is populated directly.
+    """
+    args = await _sample_tool_call_arguments(
+        parameters={
+            "type": "object",
+            "properties": {
+                "definition_id": {"type": "string"},
+                "example_kind": {"type": "string", "enum": ["file_set", "whole_snapshot"]},
+                "example_snapshot_slug": {"type": "string"},
+                "example_files_hash": {"type": "string"},
+            },
+            "required": ["definition_id", "example_kind", "example_snapshot_slug"],
+            "additionalProperties": False,
+        },
+        strict=True,
+        user_text=_START_CRITIC_USER_TEXT,
+    )
+    assert args["example_kind"] == "file_set"
+    assert args["example_snapshot_slug"] == "crush/2025-08-30-internal_db"
+
+
+@pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+@pytest.mark.xfail(
+    reason="glm-4.6 stringifies anyOf/oneOf union object tool params instead of emitting a nested "
+    "object (see docs/z_ai_api.md). xfail(strict=False) so a future z.ai fix surfaces as xpass, "
+    "signalling the union-flattening workaround can be dropped.",
+    strict=False,
+)
+async def test_zai_union_tool_param_returned_as_object_live(combinator: str) -> None:
+    """Canary documenting the live limitation: an anyOf/oneOf union example is stringified.
+
+    glm-4.6 returns the union value as a JSON-encoded string, so args["example"] is a str, not a
+    dict — which is exactly what broke critic_dev_optimize run a4cb7710 (every start_critic call
+    failed Pydantic's "Input should be a valid dictionary or object" validation).
+    """
+    args = await _sample_tool_call_arguments(
+        parameters={
+            "type": "object",
+            "properties": {"definition_id": {"type": "string"}, "example": _example_union(combinator)},
+            "required": ["definition_id", "example"],
+            "additionalProperties": False,
+        },
+        strict=True,
+        user_text=_START_CRITIC_USER_TEXT,
+    )
+    assert isinstance(args["example"], dict), f"glm-4.6 stringified the {combinator} union: {args['example']!r}"
 
 
 async def test_zai_chat_adapter_tool_call_live() -> None:

--- a/docs/z_ai_api.md
+++ b/docs/z_ai_api.md
@@ -93,6 +93,41 @@ Empirical notes for the coding endpoint (`glm-4.6`, measured 2026-06-05):
   JSON array for a required nullable array. Required non-null string/array
   fields worked, and non-null sentinel shapes worked. Prefer non-null sentinel
   or mode-object schemas over `anyOf: [T, null]` for z.ai tool inputs.
+- The `anyOf` weakness extends to **object-typed union parameters**. A tool
+  parameter whose schema is an `anyOf`/`oneOf` of object variants (e.g. a
+  Pydantic discriminated union) comes back as a **JSON-encoded string**, not a
+  nested object: the top-level `arguments` still parses as valid JSON, but the
+  union field's value is a string, so server-side Pydantic rejects it with
+  `model_attributes_type` ("Input should be a valid dictionary or object to
+  extract fields from"). Measured 2026-06-07 against the coding endpoint and
+  reproduced in a live props `critic_dev_optimize` run (`a4cb7710`): every
+  `start_critic` call stringified its `example` union and failed validation,
+  exhausting the agent's budget on retries.
+  - The trigger is the **union combinator** (`anyOf` _and_ `oneOf`, 3/3
+    stringified each) — not `strict`, not `$ref`/`$defs`, and not the
+    discriminator (inlining or dropping them doesn't help).
+  - **Working shapes** (3/3 proper objects): a single concrete object schema
+    with defined `properties` — `const` or multi-value `enum` `kind`,
+    `additionalProperties` either `true` or `false` — and fully-flat top-level
+    scalar params (no nesting).
+  - **Root cause** (not z.ai-API-specific — a GLM model-level bug, reproduced on
+    both the z.ai API and OpenCode Zen): GLM emits tool calls in an **XML**
+    format (`<parameter name="x">…</parameter>`), and the XML→arguments parser
+    stringifies a tag's content unless the schema declares a single concrete
+    type. A plain `object` schema is JSON-parsed back into an object; an
+    `anyOf`/`oneOf`/`allOf` union is type-ambiguous, so the parser leaves the
+    raw JSON string. See
+    [zai-org/GLM-4.7 discussion #18](https://huggingface.co/zai-org/GLM-4.7/discussions/18)
+    ("Unable to produce correct `object` type tool call param", open/unresolved
+    as of 2025-12). z.ai's own
+    [function-calling docs](https://docs.z.ai/guides/capabilities/function-calling)
+    are examples-only and say nothing about schema-feature support; the single
+    explicit schema constraint they state is `tool_choice` "only supports auto".
+  - **Recipe**: represent a discriminated union as a single concrete object
+    (carry the superset of fields, keep `kind` as an `enum`, enforce the
+    per-`kind` required fields server-side) or as flat top-level params — never
+    `anyOf`/`oneOf`. Both working shapes are canaried live in
+    `agent_core/test_zai_chat_adapter_live.py`.
 - Forced named tool choice in the OpenAI object form is rejected:
   `{"type": "function", "function": {"name": "..."}}` returns `400` with
   `{"error":{"code":"1210","message":"Invalid API parameter, please check the documentation."}}`.

--- a/props/debug/glm46_strict_tool_schema_experiments.md
+++ b/props/debug/glm46_strict_tool_schema_experiments.md
@@ -55,3 +55,61 @@ For direct props exec, remove model-controlled optional/nullable args instead of
 them. `env` was already removed; `stdin_text` was removed after this experiment. If a future tool
 needs these concepts, prefer non-null sentinel shapes or an explicit object with a mode discriminator,
 and validate that exact shape against z.ai before deploying it.
+
+## Follow-up: object-typed union parameters are stringified (2026-06-07)
+
+The same `anyOf` weakness applies to **object** parameters, not just nullable scalars/arrays.
+
+A `critic_dev_optimize` run (`a4cb7710-d9d8-424b-9264-9c7ef8845a25`, glm-4.6, $50 budget) failed
+(`exit 1`, only $1.53 spent) because **every** `start_critic` call stringified its `example`
+argument. `start_critic`'s `example` is the props `ExampleSpec` discriminated union, rendered as
+`anyOf: [WholeSnapshotExample, SingleFileSetExample]` with a `discriminator`. glm-4.6 emitted:
+
+```json
+"example": "{\"kind\": \"file_set\", \"snapshot_slug\": \"...\", \"files_hash\": \"...\"}"
+```
+
+i.e. a JSON-encoded **string** where the schema wants an object. The top-level `arguments` blob is
+still valid JSON (a naive "is it valid JSON" check passes), but Pydantic rejected the field with
+`model_attributes_type` — "Input should be a valid dictionary or object to extract fields from". The
+agent retried 8×, reshuffling keys and bumping budget/timeout but never switching the string to an
+object, then gave up via `report_failure`, mis-attributing it to a "tool compatibility issue".
+
+### Experiment
+
+Replayed `start_critic`'s tool schema against the z.ai coding endpoint (3 samples each,
+`temperature: 0`), varying only the `example` parameter's schema shape:
+
+| Variant                                                                    | `example` returned |
+| -------------------------------------------------------------------------- | ------------------ |
+| real schema (`anyOf` + `$ref`/`$defs` + discriminator, `strict: true`)     | STR ✗ (3/3)        |
+| same but `strict: false`                                                   | STR ✗ (3/3)        |
+| `anyOf` inlined (no `$ref`/`$defs`)                                        | STR ✗ (3/3)        |
+| `oneOf` union (instead of `anyOf`)                                         | STR ✗ (3/3)        |
+| single concrete object, `const` kind                                       | OBJ ✓ (3/3)        |
+| single concrete object, multi-value `enum` kind (superset of fields)       | OBJ ✓ (3/3)        |
+| single concrete object, `additionalProperties: true`                       | OBJ ✓ (3/3)        |
+| fully-flat top-level params (`example_kind`, `example_snapshot_slug`, ...) | OBJ ✓ (3/3)        |
+
+The trigger is the **union combinator** (`anyOf` _and_ `oneOf`) — independent of `strict`,
+`$ref`/`$defs`, and the discriminator. Any single concrete object schema (with defined `properties`)
+or a fully-flat parameter list works.
+
+This is a **GLM model-level bug**, not a z.ai-API quirk: it reproduces on both the z.ai API and
+OpenCode Zen, and other models (Claude, MiniMax) handle the same unioned tools fine. GLM emits tool
+calls as **XML** (`<parameter name="x">…</parameter>`); the XML→arguments parser stringifies a tag's
+content unless the schema declares a single concrete type, so a plain `object` is JSON-parsed back to
+an object while an `anyOf`/`oneOf`/`allOf` union is type-ambiguous and left as a raw string. See
+[zai-org/GLM-4.7 discussion #18](https://huggingface.co/zai-org/GLM-4.7/discussions/18) (same bug on
+GLM-4.7's Notion `update-page` `allOf`/`anyOf` schema; open/unresolved as of 2025-12). z.ai's
+[function-calling docs](https://docs.z.ai/guides/capabilities/function-calling) are examples-only and
+document no schema-feature constraints beyond `tool_choice` "only supports auto".
+
+### Decision
+
+For z.ai tool inputs, represent a discriminated union as a **single concrete object** schema (carry
+the superset of fields, keep `kind` as an `enum` over the variants, and enforce the per-`kind`
+required fields server-side after validation) — or as flat top-level params. Never `anyOf`/`oneOf`.
+Both working shapes are canaried live in `agent_core/test_zai_chat_adapter_live.py`
+(`test_zai_object_tool_param_returned_as_object_live` passes; the `anyOf` union variant is `xfail`).
+See also <../../docs/z_ai_api.md> "Tool Use / Function Calling".


### PR DESCRIPTION
## What

glm-4.6 (and GLM models generally) **stringify object-typed tool parameters whose schema is an `anyOf`/`oneOf`/`allOf` union** — the value comes back as a JSON-encoded string instead of a nested object, failing server-side Pydantic validation (`model_attributes_type`, "Input should be a valid dictionary or object").

This broke `critic_dev_optimize` run `a4cb7710` (glm-4.6, $50 budget, failed at $1.53): every `start_critic` call stringified its `ExampleSpec` discriminated-union `example`, and the agent gave up after exhausting retries.

## Findings (measured against the z.ai coding endpoint, 3× each)

| `example` schema shape | result |
| --- | --- |
| `anyOf` union (real schema / `strict:false` / inlined / no discriminator) | STR ✗ |
| `oneOf` union | STR ✗ |
| single concrete object (`const` or `enum` kind, `additionalProperties` either) | OBJ ✓ |
| fully-flat top-level params | OBJ ✓ |

The trigger is the **union combinator** itself — not `strict`, `$ref`/`$defs`, or the discriminator.

**Root cause** (model-level, not z.ai-API-specific — reproduces on z.ai API and OpenCode Zen; Claude/MiniMax handle the same tools fine): GLM emits tool calls as XML and the XML→arguments parser stringifies a tag's content unless the schema declares one concrete type. See [zai-org/GLM-4.7 discussion #18](https://huggingface.co/zai-org/GLM-4.7/discussions/18) (same bug, unresolved as of 2025-12). z.ai's [function-calling docs](https://docs.z.ai/guides/capabilities/function-calling) are examples-only; the only explicit schema constraint is `tool_choice` "only supports auto".

## Changes

- **`agent_core/test_zai_chat_adapter_live.py`** — extend the existing live z.ai test (assumes `ZAI_API_KEY`) with executable recipes: working single-object and flat-params tests **pass**; an `anyOf`/`oneOf` union canary is `xfail(strict=False)` so a future z.ai fix surfaces as `xpass`.
- **`docs/z_ai_api.md`** — document the behavior, working shapes, and XML-parser root cause.
- **`props/debug/glm46_strict_tool_schema_experiments.md`** — append the experiment matrix + decision.

## Test

```
bazelisk test //agent_core:test_zai_chat_adapter_live --test_tag_filters=live_openai_api \
  --test_env=ZAI_API_KEY=... --norun_validations
# 3 passed, 2 xfailed
```

## Follow-up (not in this PR)

Flatten `start_critic`'s `ExampleSpec` tool schema to a single concrete object (or flat params) so glm-4.6 optimize/improve runs stop failing.