### PR TITLE
augur/sim: collapse DenseSimulationResult into SimulationRun

### DIFF
--- a/augur/plans/roadmap.md
+++ b/augur/plans/roadmap.md
@@ -45,11 +45,12 @@ then expand it back into typed backend objects.
 The intended production backend path is `augur/model -> augur/sim -> augur/api`:
 model providers sample exogenous levels/events with provenance, `augur/sim`
 deterministically evaluates typed scenarios over those paths, and `augur/api`
-serves compact projection/read models. The product metric-fan endpoint already
-runs NumPy-direct from `DenseSimulationResult.buffers`
-(`monthly_metric_arrays`). The rollout-detail endpoint still calls
-`dense.decode()` on the selected R=1 dense result for event rows while emitting
-monthly metric arrays directly. The next cutover is exposing native
+serves compact projection/read models. The product metric-fan and terminal
+endpoints reduce on-device via `run_jax_product_summary` — emitting percentile
+bands plus per-rollout terminal samples without ever materializing per-rollout
+history. The rollout-detail endpoint runs a single R=1 `SimulationRun`, reading
+`monthly_metric_arrays` directly from its dense buffers and `rollout_events_from`
+for event rows. The next cutover is exposing native
 `ProjectionRun` read models (`augur/sim/projections.py`) over product scenarios
 instead of depending on long-form `SimulationRun` dataframe materialization.
 Tracked under "Architecture / cutover" in `augur/sim/TODO.md`.

--- a/augur/product/decode.py
+++ b/augur/product/decode.py
@@ -1,7 +1,7 @@
-"""Decode a DenseSimulationResult into product-shaped metrics and events.
+"""Decode a `SimulationRun` into product-shaped metrics and events.
 
 Per-month metric reductions take a `rollout_index` and read that column directly out of a
-(possibly batched) result; event decoding operates on an already-R=1 decoded `SimulationRun`.
+(possibly batched) run's dense buffers; event decoding operates on an already-R=1 run.
 """
 
 from __future__ import annotations
@@ -38,14 +38,13 @@ from augur.product.wire import (
     TerminalMetrics,
 )
 from augur.sim.codec.plan import SimulationRun
-from augur.sim.engine import DenseSimulationResult
 from augur.sim.fixed_point import cents_array_to_usd
 from augur.sim.scenario import ObligationType
 
 _TAX_PAYMENT_OBLIGATION_TYPES = (ObligationType.ESTIMATED_TAX, ObligationType.TAX_TRUE_UP)
 
 
-def monthly_metric_arrays_batch(dense: DenseSimulationResult, *, primary_agent_id: str) -> dict[str, np.ndarray]:
+def monthly_metric_arrays_batch(dense: SimulationRun, *, primary_agent_id: str) -> dict[str, np.ndarray]:
     """Per-month product metrics for **every** rollout of a batched result as `{name: (H+1, R)}`.
 
     Each metric is reduced over the whole `(…, R)` batch in one vectorized pass. `month_index` is
@@ -80,7 +79,7 @@ def monthly_metric_arrays_batch(dense: DenseSimulationResult, *, primary_agent_i
 
 
 def monthly_metric_arrays(
-    dense: DenseSimulationResult, *, primary_agent_id: str, rollout_index: int = 0
+    dense: SimulationRun, *, primary_agent_id: str, rollout_index: int = 0
 ) -> dict[str, np.ndarray]:
     """Per-month product metrics for one rollout (column `rollout_index`) as `{name: (H+1,)}`."""
     batch = monthly_metric_arrays_batch(dense, primary_agent_id=primary_agent_id)
@@ -106,7 +105,7 @@ def terminal_metrics_from_arrays(arrays: dict[str, np.ndarray], *, failed_month_
     )
 
 
-def failed_month_index_batch(dense: DenseSimulationResult) -> np.ndarray:
+def failed_month_index_batch(dense: SimulationRun) -> np.ndarray:
     """Per-rollout failure month at the final snapshot; `NO_CODE` (-1) = never failed. Shape `(R,)`."""
     return cast(np.ndarray, dense.buffers.state.rollout_failed_month_state[-1, :])
 
@@ -158,12 +157,12 @@ def rollout_events_from(
     return tuple(sorted(events, key=lambda event: (event.month_index, priority[event.kind])))
 
 
-def _cash_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _cash_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     cash_slots = np.flatnonzero(dense.plan.cash_agent_codes == primary_agent_code)
     return cast(np.ndarray, cents_array_to_usd(dense.buffers.state.cash_state[:, cash_slots, :].sum(axis=1)))
 
 
-def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _holding_value_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     """Sum of liquid-holding lots (stocks + crypto) priced at sampled series.
 
     Excludes private-equity lots: PE is illiquid (saleable only at tender events) so it
@@ -176,7 +175,7 @@ def _holding_value_by_month(dense: DenseSimulationResult, *, primary_agent_code:
     )
 
 
-def _private_equity_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _private_equity_value_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     """Sum of private-equity lots priced at the latest sampled mark for each issuer."""
 
     return _lot_value_by_month(
@@ -185,7 +184,7 @@ def _private_equity_value_by_month(dense: DenseSimulationResult, *, primary_agen
 
 
 def _lot_value_by_month(
-    dense: DenseSimulationResult, *, primary_agent_code: int, include: Callable[[AssetKey], bool]
+    dense: SimulationRun, *, primary_agent_code: int, include: Callable[[AssetKey], bool]
 ) -> np.ndarray:
     plan = dense.plan
     values = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
@@ -225,7 +224,7 @@ def _lot_value_by_month(
     return np.maximum(values, 0.0)
 
 
-def _shortfall_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _shortfall_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
     shortfall = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     primary_obligations = plan.obligations.agent == primary_agent_code  # [H, O]
@@ -467,7 +466,7 @@ def _failure_events(run: SimulationRun, *, primary_agent_id: str) -> tuple[Rollo
     )
 
 
-def _property_value_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _property_value_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
     values = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     series_index_by_id = {key: index for index, key in enumerate(plan.series_keys)}
@@ -495,7 +494,7 @@ def _property_value_by_month(dense: DenseSimulationResult, *, primary_agent_code
     return values
 
 
-def _mortgage_balance_by_month(dense: DenseSimulationResult, *, primary_agent_code: int) -> np.ndarray:
+def _mortgage_balance_by_month(dense: SimulationRun, *, primary_agent_code: int) -> np.ndarray:
     plan = dense.plan
     balance = np.zeros((plan.horizon_months + 1, plan.rollout_count), dtype=np.float64)
     for lia in range(plan.liabilities.codes.shape[0]):

--- a/augur/product/service.py
+++ b/augur/product/service.py
@@ -43,14 +43,14 @@ from augur.product.wire import (
     TerminalDistributionRequest,
     TerminalDistributionResponse,
 )
-from augur.sim.codec.plan import DenseSimulationResult
+from augur.sim.codec.plan import SimulationRun
 from augur.sim.compiler import compile_simulation
 from augur.sim.engine.jax_engine import ProductSummary, run_jax_product_summary
 from augur.sim.external_series import materialize_sampled_exogenous
 from augur.sim.locations import Location
 from augur.sim.runtime import load_jurisdictions_for
 from augur.sim.scenario import HarvestPolicy, Scenario
-from augur.sim.simulate import simulate_dense_with_external_series
+from augur.sim.simulate import simulate_with_external_series
 
 
 class ProductService:
@@ -136,7 +136,7 @@ class ProductService:
         events = tuple(
             event
             for event in rollout_events_from(
-                dense.decode(), primary_agent_id=self._primary_agent_id, asset_label_by_id=self._asset_label_by_id
+                dense, primary_agent_id=self._primary_agent_id, asset_label_by_id=self._asset_label_by_id
             )
             if event.month_index < horizon_months
         )
@@ -188,9 +188,9 @@ class ProductService:
         )
         return summary, model_id
 
-    def _simulate_dense(self, scenario_key: ScenarioKey, seeds: tuple[int, ...]) -> tuple[DenseSimulationResult, str]:
+    def _simulate_dense(self, scenario_key: ScenarioKey, seeds: tuple[int, ...]) -> tuple[SimulationRun, str]:
         scenario, sampled, model_id = self._scenario_and_sample(scenario_key, seeds)
-        dense = simulate_dense_with_external_series(
+        dense = simulate_with_external_series(
             scenario,
             rollout_count=len(seeds),
             external_series=materialize_sampled_exogenous(sampled),

--- a/augur/product/service_test.py
+++ b/augur/product/service_test.py
@@ -73,7 +73,7 @@ from augur.product.wire import (
 from augur.sim.engine.jax_engine import ProductSummary
 from augur.sim.external_series import EXTERNAL_SERIES_VALUES_FRAME, ExternalSeriesContext
 from augur.sim.scenario import Agent, InitialAccountBalance, InitialLot, Scenario, SeriesIndexedAmount
-from augur.sim.simulate import simulate_dense_with_external_series
+from augur.sim.simulate import simulate_with_external_series
 
 
 @dataclass
@@ -245,7 +245,7 @@ def test_monthly_metric_decode_fails_when_holding_price_series_is_missing() -> N
         tax_profiles=[],
         horizon_months=1,
     )
-    dense = simulate_dense_with_external_series(
+    dense = simulate_with_external_series(
         scenario,
         rollout_count=1,
         external_series=ExternalSeriesContext(series_values=EXTERNAL_SERIES_VALUES_FRAME.empty()),

--- a/augur/sim/TODO.md
+++ b/augur/sim/TODO.md
@@ -283,24 +283,19 @@ recovery cashouts. Still missing:
   metadata, valuation provenance, account references, and tender-window
   metadata.
 
-### Remaining dual-backend (NumPy→JAX) indirection cleanup
+### Dual-backend (NumPy→JAX) indirection cleanup — done
 
-Only the JAX engine remains (NumPy backend removed in `cdf0ea1fe`). The safe
-naming/comment vestiges + the unused `slice.py` are gone (#1924 and follow-up).
-What's left is load-bearing and needs a real refactor, each its own PR:
+The NumPy backend was removed in `cdf0ea1fe`; the leftover indirection is now
+cleared: naming/comment vestiges and the unused `slice.py` (#1924/#1925/#1926),
+and `DenseSimulationResult` collapsed into `SimulationRun` (one lazy run handle
+exposing the raw `(plan, buffers, external_series)` triple plus decoded frames).
 
-- **Collapse `DenseSimulationResult` into `SimulationRun`.** Both hold the same
-  `(plan, buffers, external_series)`; `DenseSimulationResult.decode()` just
-  rebuilds a `SimulationRun` from identical fields. The split only existed so
-  either backend could hand off a backend-neutral result. Merging means giving
-  `SimulationRun` public `plan`/`buffers` access and updating consumers
-  (`product/decode.py`, `product/service.py`).
-- **Flip state buffers to R-first.** `r_first_view` / `state_axes`
-  (`codec/helpers.py`) transpose `(S, C, R)` → `(S, R, C)` in every decoder
-  because the buffers keep R last to match the JAX scan output. Allocating
-  R-first (and transposing once in `jax_scatter`, or emitting R-first from the
-  scan) removes ~12 per-decode transposes. Area is perf-sensitive — see
-  <augur/debug/rollout_perf_profiling.md>.
+State buffers intentionally stay **R-last**: the engine's hot rollout math is
+memory-bandwidth-bound on the R axis and the metric-fan reduces over R, so R as
+the contiguous trailing axis is correct. `r_first_view` is a cheap `np.moveaxis`
+view, not a real cost. The actual dense-decode wins are orthogonal to layout —
+sparse-active decoding and not storing rarely-read state as a dense per-snapshot
+grid; see <augur/debug/rollout_perf_profiling.md>.
 
 ## Future / nice-to-have
 

--- a/augur/sim/codec/plan.py
+++ b/augur/sim/codec/plan.py
@@ -1,7 +1,8 @@
 """Top-level codec orchestrator: `SimulationRun` is a lazy facade over the
 per-domain decoders, producing each long-form Polars frame from a
-(plan, buffers, external_series) triple on first access. `DenseSimulationResult`
-lives here too so engine.py can stay free of the codec dependency."""
+(plan, buffers, external_series) triple on first access. The triple is exposed
+as public attributes for callers (product metrics, profiling) that read the raw
+dense buffers directly instead of the decoded frames."""
 
 from __future__ import annotations
 
@@ -40,76 +41,67 @@ from augur.sim.external_series import ExternalSeriesContext
 from augur.sim.state import ROLLOUT_STATUS_FRAME
 
 
+# eq=False: a run is a handle around its (plan, buffers, external_series) triple, so identity
+# equality is what callers want; field-wise __eq__/__hash__ would also choke on the numpy arrays
+# inside `buffers`. frozen so the triple can't be swapped out from under the cached frames.
+@dataclass(frozen=True, eq=False)
 class SimulationRun:
-    """Lazy view of a simulation's outputs: each long-form Polars frame (and the
-    event log) is decoded from the dense buffers on first access and cached, so a
-    caller only pays to materialize the frames it actually reads. The public
-    attribute surface matches the eager frames it replaced."""
+    """Lazy view of a simulation's outputs: each long-form Polars frame (and the event log) is
+    decoded from the dense buffers on first access and cached, so a caller only pays to materialize
+    the frames it actually reads. The `(plan, buffers, external_series)` triple is public for callers
+    that read the raw dense buffers directly."""
 
-    def __init__(
-        self, plan: CompiledSimulation, buffers: SimulationBuffers, external_series: ExternalSeriesContext
-    ) -> None:
-        self._plan = plan
-        self._buffers = buffers
-        self._external_series = external_series
-
-    @cached_property
-    def cash_balances(self) -> pl.DataFrame:
-        return decode_cash(self._plan, self._buffers)
-
-    @cached_property
-    def asset_lots(self) -> pl.DataFrame:
-        return decode_asset_lots(self._plan, self._buffers)
-
-    @cached_property
-    def ordinary_income_ytd(self) -> pl.DataFrame:
-        return decode_ordinary_income(self._plan, self._buffers)
-
-    @cached_property
-    def capital_gains_ytd(self) -> pl.DataFrame:
-        return decode_capital_gains(self._plan, self._buffers)
-
-    @cached_property
-    def tax_liabilities(self) -> pl.DataFrame:
-        return decode_tax_liabilities(self._plan, self._buffers)
-
-    @cached_property
-    def property_state(self) -> pl.DataFrame:
-        return decode_property_state(self._plan, self._buffers)
-
-    @cached_property
-    def property_stakes(self) -> pl.DataFrame:
-        return decode_property_stakes(self._plan, self._buffers)
-
-    @cached_property
-    def liabilities(self) -> pl.DataFrame:
-        return decode_liabilities(self._plan, self._buffers)
-
-    @cached_property
-    def rollout_status_history(self) -> pl.DataFrame:
-        return decode_rollout_status_history(self._plan, self._buffers)
-
-    @cached_property
-    def rollout_status(self) -> pl.DataFrame:
-        return decode_final_rollout_status(self._plan, self._buffers)
-
-    @cached_property
-    def series_values(self) -> pl.DataFrame:
-        return self._external_series.series_values
-
-    @cached_property
-    def events_log(self) -> EventLog:
-        return decode_events(self._plan, self._buffers)
-
-
-@dataclass
-class DenseSimulationResult:
     plan: CompiledSimulation
     buffers: SimulationBuffers
     external_series: ExternalSeriesContext
 
-    def decode(self) -> SimulationRun:
-        return SimulationRun(self.plan, self.buffers, self.external_series)
+    @cached_property
+    def cash_balances(self) -> pl.DataFrame:
+        return decode_cash(self.plan, self.buffers)
+
+    @cached_property
+    def asset_lots(self) -> pl.DataFrame:
+        return decode_asset_lots(self.plan, self.buffers)
+
+    @cached_property
+    def ordinary_income_ytd(self) -> pl.DataFrame:
+        return decode_ordinary_income(self.plan, self.buffers)
+
+    @cached_property
+    def capital_gains_ytd(self) -> pl.DataFrame:
+        return decode_capital_gains(self.plan, self.buffers)
+
+    @cached_property
+    def tax_liabilities(self) -> pl.DataFrame:
+        return decode_tax_liabilities(self.plan, self.buffers)
+
+    @cached_property
+    def property_state(self) -> pl.DataFrame:
+        return decode_property_state(self.plan, self.buffers)
+
+    @cached_property
+    def property_stakes(self) -> pl.DataFrame:
+        return decode_property_stakes(self.plan, self.buffers)
+
+    @cached_property
+    def liabilities(self) -> pl.DataFrame:
+        return decode_liabilities(self.plan, self.buffers)
+
+    @cached_property
+    def rollout_status_history(self) -> pl.DataFrame:
+        return decode_rollout_status_history(self.plan, self.buffers)
+
+    @cached_property
+    def rollout_status(self) -> pl.DataFrame:
+        return decode_final_rollout_status(self.plan, self.buffers)
+
+    @cached_property
+    def series_values(self) -> pl.DataFrame:
+        return self.external_series.series_values
+
+    @cached_property
+    def events_log(self) -> EventLog:
+        return decode_events(self.plan, self.buffers)
 
 
 def decode_events(plan: CompiledSimulation, buffers: SimulationBuffers) -> EventLog:

--- a/augur/sim/compiler/plan.py
+++ b/augur/sim/compiler/plan.py
@@ -1,5 +1,5 @@
 """Compile-side plan: SlotPlan, CompiledSimulation, compile_simulation. Pairs with
-`codec/plan.py` (DenseSimulationResult, SimulationRun) at the engine boundary.
+`codec/plan.py` (SimulationRun) at the engine boundary.
 
 `compile_simulation` is the orchestrator that interns strings, builds the shared
 index maps, calls every per-domain `compile_*` helper, and assembles the

--- a/augur/sim/engine/__init__.py
+++ b/augur/sim/engine/__init__.py
@@ -19,7 +19,7 @@ from augur.sim.buffers import (
     TaxLiabilityChangeLog,
     TransferEventBuffers,
 )
-from augur.sim.codec.plan import DenseSimulationResult
+from augur.sim.codec.plan import SimulationRun
 from augur.sim.compiler import CompiledSimulation, compile_simulation
 from augur.sim.compiler.helpers import NO_CODE
 from augur.sim.engine.jax_engine import run_jax_scan
@@ -32,7 +32,7 @@ from augur.sim.scenario import Scenario
 
 def run_dense_simulation(
     scenario: Scenario, *, rollout_count: int, external_series: ExternalSeriesContext, locations: dict[str, Location]
-) -> DenseSimulationResult:
+) -> SimulationRun:
     plan = compile_simulation(
         scenario,
         rollout_count=rollout_count,
@@ -42,7 +42,7 @@ def run_dense_simulation(
     )
     buffers = _allocate_buffers(plan)
     run_jax_scan(plan, buffers)
-    return DenseSimulationResult(plan=plan, buffers=buffers, external_series=external_series)
+    return SimulationRun(plan=plan, buffers=buffers, external_series=external_series)
 
 
 def _allocate_buffers(plan: CompiledSimulation) -> SimulationBuffers:

--- a/augur/sim/engine/jax_engine.py
+++ b/augur/sim/engine/jax_engine.py
@@ -395,7 +395,7 @@ def run_jax_product_summary(
     bands (when `percentiles` is given) and its per-rollout terminal samples.
 
     Shares the exact accounting scan with `run_jax_scan`; only the emitted summary differs. Avoiding
-    the full DenseSimulationResult history/event slabs — and reducing each metric to percentiles
+    the full dense `SimulationRun` history/event slabs — and reducing each metric to percentiles
     before the device→host copy — means neither the host nor the response ever holds per-rollout
     monthly state. The full dense trace is reserved for the selected-rollout detail endpoint.
     """

--- a/augur/sim/profile_rollout.py
+++ b/augur/sim/profile_rollout.py
@@ -42,7 +42,7 @@ from augur.sim.scenario import (
     ScheduledAssetSale,
     ScheduledPropertyPurchase,
 )
-from augur.sim.simulate import simulate, simulate_dense_with_external_series
+from augur.sim.simulate import simulate, simulate_with_external_series
 
 PROFILE_LOCATION_ID = "sf"
 
@@ -245,7 +245,7 @@ def main() -> None:
                 rollout_seeds=tuple(range(rollout_count)),
                 horizon_months=int(scenario.horizon_months),
             )
-            simulate_dense_with_external_series(
+            simulate_with_external_series(
                 scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
             )
         else:

--- a/augur/sim/simulate.py
+++ b/augur/sim/simulate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import polars as pl
 
-from augur.sim.codec.plan import DenseSimulationResult, SimulationRun
+from augur.sim.codec.plan import SimulationRun
 from augur.sim.engine import run_dense_simulation
 from augur.sim.external_series import ExternalSeriesContext, materialize_external_series
 from augur.sim.locations import Location
@@ -31,18 +31,6 @@ def simulate(scenario: Scenario, *, rollout_count: int, locations: dict[str, Loc
 def simulate_with_external_series(
     scenario: Scenario, *, rollout_count: int, external_series: ExternalSeriesContext, locations: dict[str, Location]
 ) -> SimulationRun:
-    if rollout_count <= 0:
-        msg = f"rollout_count must be positive; got {rollout_count}"
-        raise ValueError(msg)
-    _validate_series_indexed_amounts(scenario, rollout_count=rollout_count, external_series=external_series)
-    return run_dense_simulation(
-        scenario, rollout_count=rollout_count, external_series=external_series, locations=locations
-    ).decode()
-
-
-def simulate_dense_with_external_series(
-    scenario: Scenario, *, rollout_count: int, external_series: ExternalSeriesContext, locations: dict[str, Location]
-) -> DenseSimulationResult:
     if rollout_count <= 0:
         msg = f"rollout_count must be positive; got {rollout_count}"
         raise ValueError(msg)


### PR DESCRIPTION
Follow-up to #1924/#1925/#1926. `DenseSimulationResult` held the same `(plan, buffers, external_series)` triple as `SimulationRun`, and `.decode()` just rebuilt a `SimulationRun` from those identical fields — a vestige of the two-backend era (a backend-neutral handoff before decode). With one backend it's pure indirection.

## Changes (no behavior change)
- `SimulationRun` becomes a `@dataclass(frozen=True, eq=False)` exposing the triple as **public attributes** (`eq=False`: a run is a handle, and field-wise eq/hash would choke on the numpy arrays in `buffers`). `DenseSimulationResult` is deleted.
- Callers reading raw buffers (product metrics, profiling) use `run.plan`/`run.buffers`; callers wanting events/frames use the lazy properties — one object serves both, so the eager-vs-lazy split disappears.
- `simulate_with_external_series` and `simulate_dense_with_external_series` thereby became identical (both return a lazy `SimulationRun`); dropped the `_dense_` variant and pointed its callers (`service`, `profile_rollout`, tests) at the survivor.
- Refreshed a stale `roadmap.md` paragraph (metric-fan reduces on-device via `run_jax_product_summary` now; rollout endpoint runs one R=1 `SimulationRun`) and closed out the dual-backend cleanup section in `augur/sim/TODO.md`, recording the decision to **keep state buffers R-last** (engine is memory-bandwidth-bound on the R axis; `r_first_view` is a free `np.moveaxis` view).

## Tests
`bbr build //augur/sim/... //augur/product/...` green; `//augur/sim:simulate_test`, `//augur/product:service_test`, `//augur/product:service_scale_test`, `//augur/sim:scan_test` pass. pre-commit clean. (`//augur/...` still red on devel from the pre-existing `augur/calibration/calibration.py` mypy error — unrelated.)