### PR TITLE
test/docs: z.ai Anthropic shape returns union tool params as objects

### DIFF
--- a/agent_core/BUILD.bazel
+++ b/agent_core/BUILD.bazel
@@ -289,6 +289,7 @@ py_test(
         ":model",
         "//openai_utils:api_shape",
         "//openai_utils:model",
+        "@pypi//anthropic",
         "@pypi//openai",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/agent_core/test_zai_chat_adapter_live.py
+++ b/agent_core/test_zai_chat_adapter_live.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 import pytest_bazel
+from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
 
 from agent_core.model import AgentModelRequest, ChatCompletionsAgentModel
@@ -12,6 +13,8 @@ from openai_utils.api_shape import LLMApiShape
 from openai_utils.model import FunctionCallItem, FunctionToolParam, UserMessage
 
 _ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+# z.ai also exposes an Anthropic Messages-shaped endpoint; the SDK posts to {base_url}/v1/messages.
+_ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic"
 
 
 async def _sample_tool_call_arguments(*, parameters: dict, strict: bool, user_text: str) -> dict:
@@ -175,6 +178,59 @@ async def test_zai_union_tool_param_returned_as_object_live(combinator: str) -> 
         user_text=_START_CRITIC_USER_TEXT,
     )
     assert isinstance(args["example"], dict), f"glm-4.6 stringified the {combinator} union: {args['example']!r}"
+
+
+async def _sample_anthropic_tool_input(*, example_schema: dict, user_text: str) -> dict:
+    """Call z.ai's Anthropic Messages endpoint with a start_critic tool; return tool_use.input.
+
+    The Anthropic wire format carries tool inputs as a structured object (tool_use.input), not a
+    stringified arguments blob — so it sidesteps glm-4.6's chat-completions union-stringification bug.
+    """
+    api_key = os.environ.get("ZAI_API_KEY")
+    assert api_key, "ZAI_API_KEY must be set for the live z.ai tool-schema tests"
+
+    client = AsyncAnthropic(base_url=_ZAI_ANTHROPIC_BASE_URL, api_key=api_key)
+    try:
+        message = await client.messages.create(
+            model=os.environ.get("ZAI_MODEL", "glm-4.6"),
+            max_tokens=1024,
+            messages=[{"role": "user", "content": user_text}],
+            tools=[
+                {
+                    "name": "start_critic",
+                    "description": "Start a critic run on a single example.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"definition_id": {"type": "string"}, "example": example_schema},
+                        "required": ["definition_id", "example"],
+                    },
+                }
+            ],
+        )
+    finally:
+        await client.close()
+
+    tool_uses = [block for block in message.content if block.type == "tool_use"]
+    assert len(tool_uses) == 1
+    return tool_uses[0].input
+
+
+@pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+async def test_zai_anthropic_shape_union_tool_param_returned_as_object_live(combinator: str) -> None:
+    """z.ai's Anthropic Messages shape returns anyOf/oneOf union object params as nested objects.
+
+    This is the escape hatch for glm-4.6's chat-completions union-stringification bug (the xfail
+    canary above): the very same union that stringifies over chat-completions comes through as a
+    structured object over the Anthropic wire format, because tool_use.input must be a JSON object.
+    """
+    tool_input = await _sample_anthropic_tool_input(
+        example_schema=_example_union(combinator), user_text=_START_CRITIC_USER_TEXT
+    )
+    example = tool_input["example"]
+    assert isinstance(example, dict), f"Anthropic shape stringified the {combinator} union: {example!r}"
+    assert example["kind"] == "file_set"
+    assert example["snapshot_slug"] == "crush/2025-08-30-internal_db"
+    assert example["files_hash"] == "c27fe50118b25dbc185f00315006c37b"
 
 
 async def test_zai_chat_adapter_tool_call_live() -> None:

--- a/docs/z_ai_api.md
+++ b/docs/z_ai_api.md
@@ -123,11 +123,22 @@ Empirical notes for the coding endpoint (`glm-4.6`, measured 2026-06-05):
     [function-calling docs](https://docs.z.ai/guides/capabilities/function-calling)
     are examples-only and say nothing about schema-feature support; the single
     explicit schema constraint they state is `tool_choice` "only supports auto".
-  - **Recipe**: represent a discriminated union as a single concrete object
-    (carry the superset of fields, keep `kind` as an `enum`, enforce the
-    per-`kind` required fields server-side) or as flat top-level params — never
-    `anyOf`/`oneOf`. Both working shapes are canaried live in
-    `agent_core/test_zai_chat_adapter_live.py`.
+  - **The bug is chat-completions-shape-specific.** The same `anyOf`/`oneOf`
+    union, sent to z.ai's **Anthropic Messages** endpoint
+    (`/api/anthropic/v1/messages`) with the schema as the tool `input_schema`,
+    comes back as a proper nested object (3/3 for both `anyOf` and `oneOf`,
+    measured 2026-06-07). The Anthropic wire format requires `tool_use.input` to
+    be a JSON object, so z.ai's Anthropic adapter parses GLM's XML tool call back
+    into a structured object instead of leaving the raw string. So routing
+    glm-4.6 through the Anthropic shape avoids the bug without flattening any
+    schema. Canaried live in `agent_core/test_zai_chat_adapter_live.py`
+    (`test_zai_anthropic_shape_union_tool_param_returned_as_object_live`).
+  - **Recipe**: either (a) route glm-4.6 through the Anthropic Messages shape and
+    keep union schemas as-is, or (b) on chat-completions, represent a
+    discriminated union as a single concrete object (carry the superset of
+    fields, keep `kind` as an `enum`, enforce the per-`kind` required fields
+    server-side) or as flat top-level params — never `anyOf`/`oneOf`. All working
+    shapes are canaried live in `agent_core/test_zai_chat_adapter_live.py`.
 - Forced named tool choice in the OpenAI object form is rejected:
   `{"type": "function", "function": {"name": "..."}}` returns `400` with
   `{"error":{"code":"1210","message":"Invalid API parameter, please check the documentation."}}`.

--- a/props/debug/glm46_strict_tool_schema_experiments.md
+++ b/props/debug/glm46_strict_tool_schema_experiments.md
@@ -105,11 +105,30 @@ GLM-4.7's Notion `update-page` `allOf`/`anyOf` schema; open/unresolved as of 202
 [function-calling docs](https://docs.z.ai/guides/capabilities/function-calling) are examples-only and
 document no schema-feature constraints beyond `tool_choice` "only supports auto".
 
+### The bug is chat-completions-shape-specific
+
+z.ai also exposes an **Anthropic Messages** endpoint (`/api/anthropic/v1/messages`). Sending the
+**same** `anyOf`/`oneOf` union as the tool `input_schema` there returns a proper nested object (3/3
+for both combinators, measured 2026-06-07) — because the Anthropic wire format requires
+`tool_use.input` to be a JSON object, so z.ai's Anthropic adapter parses GLM's XML tool call back into
+a structured object instead of leaving the raw string. So routing glm-4.6 through the Anthropic shape
+avoids the bug entirely, without flattening any schema. Canaried live in
+`agent_core/test_zai_chat_adapter_live.py`
+(`test_zai_anthropic_shape_union_tool_param_returned_as_object_live` passes).
+
 ### Decision
 
-For z.ai tool inputs, represent a discriminated union as a **single concrete object** schema (carry
-the superset of fields, keep `kind` as an `enum` over the variants, and enforce the per-`kind`
-required fields server-side after validation) — or as flat top-level params. Never `anyOf`/`oneOf`.
-Both working shapes are canaried live in `agent_core/test_zai_chat_adapter_live.py`
-(`test_zai_object_tool_param_returned_as_object_live` passes; the `anyOf` union variant is `xfail`).
-See also <../../docs/z_ai_api.md> "Tool Use / Function Calling".
+Two options for unblocking glm-4.6 tool inputs:
+
+1. **Route glm-4.6 through the Anthropic Messages shape** — unions (and the existing `ExampleSpec`
+   discriminated union) work as-is, no schema changes. Needs an Anthropic-shaped model adapter /
+   litellm route (props currently wires glm-4.6 as `api_shape: chat_completions`).
+2. **Stay on chat-completions** and represent a discriminated union as a **single concrete object**
+   schema (carry the superset of fields, keep `kind` as an `enum` over the variants, and enforce the
+   per-`kind` required fields server-side after validation) — or as flat top-level params. Never
+   `anyOf`/`oneOf`.
+
+All shapes above are canaried live in `agent_core/test_zai_chat_adapter_live.py`
+(`test_zai_object_tool_param_returned_as_object_live` passes; the chat-completions `anyOf`/`oneOf`
+variant is `xfail`; the Anthropic-shape union variant passes). See also
+<../../docs/z_ai_api.md> "Tool Use / Function Calling".


### PR DESCRIPTION
## What

Follow-up to #1927. The glm-4.6 union-stringification bug (an `anyOf`/`oneOf` object tool param comes back as a JSON-encoded string) is **chat-completions-shape-specific**.

z.ai also exposes an **Anthropic Messages** endpoint (`/api/anthropic/v1/messages`). Sending the *same* union as the tool `input_schema` there returns a **proper nested object** (verified 3/3 for both `anyOf` and `oneOf`):

```json
"example": { "kind": "file_set", "snapshot_slug": "crush/2025-08-30-internal_db",
             "files_hash": "c27fe50118b25dbc185f00315006c37b" }
```

**Why:** same GLM XML tool-call output underneath, different server-side parser. The Anthropic wire format requires `tool_use.input` to be a JSON object, so z.ai's Anthropic adapter parses the XML back into an object; the chat-completions path leaves union/nested content as a raw string.

## Changes

- **`agent_core/test_zai_chat_adapter_live.py`** — add `_sample_anthropic_tool_input` (anthropic SDK → z.ai Anthropic endpoint) and a parametrized `anyOf`/`oneOf` test asserting the union returns a nested object. Passes live, in contrast to the `xfail` chat-completions canary.
- **`agent_core/BUILD.bazel`** — add `@pypi//anthropic`.
- **`docs/z_ai_api.md`** + **`props/debug/glm46_strict_tool_schema_experiments.md`** — document that the bug is chat-completions-specific and the Anthropic shape is the escape hatch.

## Test

```
bazelisk test //agent_core:test_zai_chat_adapter_live --test_tag_filters=live_openai_api \
  --test_env=ZAI_API_KEY=... --norun_validations
# 5 passed, 2 xfailed (chat-completions union canary)
```

## Implication

For props, this means glm-4.6 optimize/improve can be unblocked **either** by flattening union schemas (chat-completions) **or** by routing glm-4.6 through z.ai's Anthropic shape (keeps `ExampleSpec` as-is). Adapter/litellm wiring for the latter is not in this PR.