### PR TITLE
augur/calibration: async price clients + one long-lived Valkey cache

### DIFF
--- a/augur/TODO.md
+++ b/augur/TODO.md
@@ -58,6 +58,13 @@ Remaining:
       the last-trade price. Track bid and ask separately in the platform model,
       surface stale/wide/no-quote states, and decide whether scoring should use
       midpoint, last, or a conservative interval per platform/market family.
+  - [ ] **Honest naming.** Markets expose last trade / bid / ask, not a
+        "probability". `Market.probability` / `require_probability` is really the
+        last-trade price read as an implied probability; the calibrated value comes
+        from the separate price→probability smoothing step. Rename to something like
+        `last_trade_price` / `implied_probability` so it doesn't read as a calibrated
+        probability (cross-cutting across the platform clients + calibration). See the
+        TODO at `augur/calibration/platform.py:Market.probability`.
 - [ ] **Aggregate metric (later, weighting TBD).** Per-channel / volume-weighted
       rollups of per-market KL once the weighting policy is decided.
 

--- a/augur/api/conftest.py
+++ b/augur/api/conftest.py
@@ -26,7 +26,7 @@ from augur.api.portfolio_source_config import (
     PlaidSp500ProxyGroupConfig,
     PortfolioSourcesConfig,
 )
-from augur.api.server import ApiServerConfig, create_app
+from augur.api.server import ApiServerConfig, create_app, static_price_clients
 from augur.api.wire import ActorRole
 from augur.model.independent import IndependentProviderConfig
 from augur.model.provider_config import ProviderConfig
@@ -283,7 +283,13 @@ def make_client(augur_config: Config) -> Iterator[MakeClient]:
 
         def _make(models: dict[str, Any]) -> TestClient:
             return stack.enter_context(
-                TestClient(create_app(ApiServerConfig(augur_config=augur_config, models=models, price_clients={})))
+                TestClient(
+                    create_app(
+                        ApiServerConfig(
+                            augur_config=augur_config, models=models, price_clients=static_price_clients({})
+                        )
+                    )
+                )
             )
 
         yield _make

--- a/augur/api/export_schema.py
+++ b/augur/api/export_schema.py
@@ -19,7 +19,7 @@ from augur.api.config import AgentDefinition, CalibrationCatalogConfig, Config, 
 from augur.api.finance import FinanceSnapshot
 from augur.api.local_regulation import LocalRegulation, TaxRegime
 from augur.api.portfolio_source_config import FixedPortfolioSourceConfig, PortfolioSourcesConfig
-from augur.api.server import create_app_from_augur_config
+from augur.api.server import create_app_from_augur_config, static_price_clients
 from augur.api.wire import ActorRole, Property
 from augur.model.independent import IndependentProviderConfig
 
@@ -91,7 +91,8 @@ def main() -> None:
         print(
             json.dumps(
                 create_app_from_augur_config(
-                    _schema_export_config(properties_path, calibration_catalog_path), price_clients={}
+                    _schema_export_config(properties_path, calibration_catalog_path),
+                    price_clients=static_price_clients({}),
                 ).openapi(),
                 indent=2,
             )

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import os
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -38,7 +40,7 @@ from augur.budget.wire import (
 )
 from augur.calibration.calibration import build_anchored_level_paths, mark_fan, run_calibration
 from augur.calibration.catalog import MarketCatalog
-from augur.calibration.default_clients import build_default_price_clients
+from augur.calibration.default_clients import default_price_clients
 from augur.calibration.macro_anchors import resolve_anchors
 from augur.calibration.platform import Platform, PriceClient
 from augur.model.exogenous import ExogenousSamplingRequest, Sampler, level_series_request_channels
@@ -73,14 +75,25 @@ class LoadedCalibrationCatalog:
     sample_sanity_spec: SampleSanitySpec | None = None
 
 
+PriceClientsProvider = AbstractAsyncContextManager[dict[Platform, PriceClient]]
+
+
+@asynccontextmanager
+async def static_price_clients(clients: dict[Platform, PriceClient]) -> AsyncIterator[dict[Platform, PriceClient]]:
+    """A no-lifecycle price-client provider over an already-built mapping (tests, product-only apps)."""
+    yield clients
+
+
 @dataclass(frozen=True)
 class ApiServerConfig:
     augur_config: Config
     models: dict[str, Sampler]
-    # Live prediction-market price sources for `/api/calibration/run` (per-market YES probs).
-    # Maps each Platform to its client. Reused across requests, so the TTL caches serve the
-    # calibration tab's rapid auto-refreshes.
-    price_clients: dict[Platform, PriceClient]
+    # Live prediction-market price sources for `/api/calibration/run` (per-market YES probs), as an
+    # async context manager entered once for the app's lifetime (server lifespan): it yields the
+    # `{Platform: client}` map and owns the one long-lived Valkey cache store + upstream clients,
+    # closing them on shutdown. Use `default_price_clients()` in production, `static_price_clients(...)`
+    # for already-built (hermetic) clients in tests.
+    price_clients: PriceClientsProvider
     # The deployment's calibration catalog parsed into a `MarketCatalog` at startup. None only
     # when the app is assembled directly without loading it (e.g. a product-only TestClient);
     # `/api/calibration/run` then 400s. `create_app_from_augur_config` always loads it.
@@ -115,7 +128,16 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         max_horizon_months=augur_config.max_horizon_months,
     )
 
-    app = FastAPI(title="Augur scenario API")
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        # Enter the price-client provider once for the process: it builds the one long-lived Valkey
+        # store + upstream clients in the serving loop (so they're bound to it) and closes them on
+        # shutdown. `/api/calibration/run` reads them off `app.state`.
+        async with config.price_clients as price_clients:
+            app.state.price_clients = price_clients
+            yield
+
+    app = FastAPI(title="Augur scenario API", lifespan=lifespan)
     no_store = {"cache-control": "no-store"}
 
     def error(status_code: int, detail: Any) -> JSONResponse:
@@ -175,7 +197,7 @@ def create_app(config: ApiServerConfig) -> FastAPI:
         return JSONResponse(content=value.model_dump(mode="json", exclude_none=True), headers=no_store)
 
     @app.post("/api/calibration/run", response_model=CalibrationRunResponse)
-    def calibration_run(request: CalibrationRunRequest) -> JSONResponse:
+    async def calibration_run(request: CalibrationRunRequest) -> JSONResponse:
         loaded = config.calibration_catalog
         if loaded is None:
             return error(400, "calibration catalog is not loaded for this server instance")
@@ -226,11 +248,11 @@ def create_app(config: ApiServerConfig) -> FastAPI:
             rollout_count=request.rollouts,
             horizon_months=request.horizon_months,
         )
-        result = run_calibration(
+        result = await run_calibration(
             loaded.catalog,
             horizon_months=request.horizon_months,
             rollout_seeds=rollout_seeds,
-            price_clients=config.price_clients,
+            price_clients=app.state.price_clients,
             bundle=bundle,
             level_paths=level_paths,
             inflation_history=anchors.inflation_history,
@@ -346,11 +368,12 @@ def _load_sample_sanity_spec(path: Path | None) -> SampleSanitySpec | None:
     return SampleSanitySpec.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
-def create_app_from_augur_config(augur_config: Config, *, price_clients: dict[Platform, PriceClient]) -> FastAPI:
+def create_app_from_augur_config(augur_config: Config, *, price_clients: PriceClientsProvider) -> FastAPI:
     """Build the app from a `Config`.
 
-    `price_clients` is the live prediction-market price source map for
-    `/api/calibration/run` (callers construct the appropriate clients)."""
+    `price_clients` is the live prediction-market price-source provider for `/api/calibration/run`,
+    entered once for the app's lifetime (server lifespan). Production passes `default_price_clients()`;
+    tests pass `static_price_clients(...)` over hermetic clients."""
     models: dict[str, Sampler] = {
         preset_id: cast(Sampler, provider.realize_model()) for preset_id, provider in augur_config.models.items()
     }
@@ -409,7 +432,7 @@ def build_configured_server_arg_parser(
 
 
 def _run_server_with_args(*, augur_config: Config, args: argparse.Namespace) -> int:
-    app = create_app_from_augur_config(augur_config, price_clients=build_default_price_clients())
+    app = create_app_from_augur_config(augur_config, price_clients=default_price_clients())
     return run_app(app=app, augur_config=augur_config, host=args.host, port=args.port)
 
 

--- a/augur/api/test_calibration_endpoint.py
+++ b/augur/api/test_calibration_endpoint.py
@@ -18,7 +18,7 @@ import yaml
 from fastapi.testclient import TestClient
 
 from augur.api.config import Config
-from augur.api.server import create_app_from_augur_config
+from augur.api.server import create_app_from_augur_config, static_price_clients
 from augur.calibration.catalog import MarketCatalog
 from augur.calibration.platform import Platform
 from augur.calibration.testing import mock_price_clients
@@ -42,7 +42,9 @@ def _client_for(config: Config) -> TestClient:
     for date_family in catalog.date_ladder_families:
         for date_member in date_family.dates:
             by_platform[date_family.platform][date_member.market_id] = 0.5
-    return TestClient(create_app_from_augur_config(config, price_clients=mock_price_clients(dict(by_platform))))
+    return TestClient(
+        create_app_from_augur_config(config, price_clients=static_price_clients(mock_price_clients(dict(by_platform))))
+    )
 
 
 @pytest.fixture

--- a/augur/budget/README.md
+++ b/augur/budget/README.md
@@ -9,17 +9,17 @@ of force-netting, and surfaces lumpy one-offs separately.
 
 ## Architecture
 
-| Layer               | What it does                                                                                                                          |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `schema.py`         | `BudgetConfig` Pydantic: bucket taxonomy (kinds: expense / inflow / transfer / income) + the condition DSL and rule kinds, loaded from augur YAML |
+| Layer               | What it does                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `schema.py`         | `BudgetConfig` Pydantic: bucket taxonomy (kinds: expense / inflow / transfer / income) + the condition DSL and rule kinds, loaded from augur YAML                                          |
 | `sql_read_model.py` | Reads Plaid transactions from Postgres, compiles the rules to a first-match-wins SQL CASE, classifies (direction-gated) + applies overrides, aggregates monthly totals, returns drilldowns |
-| `service.py`        | Orchestrates request windows, database session reuse, CSV export, and wire types                                                      |
-| `wire.py`           | HTTP wire schemas (drive frontend Zod codegen via `export_schema`)                                                                    |
+| `service.py`        | Orchestrates request windows, database session reuse, CSV export, and wire types                                                                                                           |
+| `wire.py`           | HTTP wire schemas (drive frontend Zod codegen via `export_schema`)                                                                                                                         |
 
 ## What lives in ducktape vs gaffer-private
 
 **ducktape (public):** The framework — schemas, the condition DSL + rule kinds,
-the SQL read model, the API endpoints, and the frontend tab. No rule *content*
+the SQL read model, the API endpoints, and the frontend tab. No rule _content_
 ships in the framework; every rule lives in the deployment's config.
 
 **gaffer-private (private):** The actual `budget:` config block in the

--- a/augur/budget/sql_read_model.py
+++ b/augur/budget/sql_read_model.py
@@ -299,9 +299,7 @@ def _budget_query(
 ) -> tuple[Any, dict[str, object]]:
     """Build an executable statement (classified-tx CTE + `tail`) and its bind params."""
     matched_case, rule_params = _compile_rules_case(config)
-    cte = _CLASSIFIED_TX_CTE_TEMPLATE.format(
-        account_filter=_account_filter_sql(account_ids), matched_case=matched_case
-    )
+    cte = _CLASSIFIED_TX_CTE_TEMPLATE.format(account_filter=_account_filter_sql(account_ids), matched_case=matched_case)
     params: dict[str, object] = {
         "bucket_defs_json": _bucket_defs_json(config),
         "overrides_json": _overrides_json(config),

--- a/augur/budget/test_sql_read_model.py
+++ b/augur/budget/test_sql_read_model.py
@@ -501,10 +501,7 @@ async def test_match_rule_all_of_combines_merchant_and_amount(
             MatchRule(
                 bucket_id="custom",
                 condition=AllOfCondition(
-                    conditions=(
-                        MerchantSubstringCondition(pattern="Grocery"),
-                        AmountCondition(min=500.0),
-                    )
+                    conditions=(MerchantSubstringCondition(pattern="Grocery"), AmountCondition(min=500.0))
                 ),
             ),
         )

--- a/augur/calibration/BUILD.bazel
+++ b/augur/calibration/BUILD.bazel
@@ -217,6 +217,7 @@ py_test(
         "//augur/model:testing",
         "@pypi//numpy",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )
@@ -243,6 +244,7 @@ py_test(
         "//:conftest",
         "@pypi//httpx",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )
@@ -255,6 +257,7 @@ py_test(
         ":redis_cache",
         "//:conftest",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )
@@ -268,6 +271,7 @@ py_test(
         "//:conftest",
         "@pypi//httpx",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )
@@ -283,6 +287,7 @@ py_test(
         "//:conftest",
         "//augur/model:private_equity_risk",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )

--- a/augur/calibration/calibration.py
+++ b/augur/calibration/calibration.py
@@ -19,6 +19,7 @@ hermetic mock clients.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 from collections import Counter
@@ -81,6 +82,11 @@ logger = logging.getLogger(__name__)
 # whole calibration run: httpx for the manifold + kalshi clients, PolymarketError for the
 # polymarket SDK (covers "id is invalid", rate limits, transport errors, timeouts).
 _LIVE_FETCH_ERRORS: tuple[type[BaseException], ...] = (httpx.HTTPError, PolymarketError)
+
+# Cap concurrent live market fetches so a large catalog can't open hundreds of simultaneous
+# upstream connections (and trip rate limits) on a cold cache. Warm-cache reads hit the shared
+# Valkey store and rarely reach the upstreams at all.
+_MAX_CONCURRENT_MARKET_FETCHES = 16
 
 
 def wilson_interval(yes: int, n: int) -> tuple[float, float]:
@@ -820,7 +826,7 @@ def _unmodeled_row(market: ExactMarket, live: Market, target: str) -> SurfacedRo
     )
 
 
-def run_calibration(
+async def run_calibration(
     catalog: MarketCatalog,
     *,
     horizon_months: int,
@@ -859,25 +865,52 @@ def run_calibration(
         for issuer in sorted(catalog.referenced_issuers() & emitted_issuers)
     }
 
-    def _live(market_id: str, platform: Platform) -> Market | None:
+    fetch_slots = asyncio.Semaphore(_MAX_CONCURRENT_MARKET_FETCHES)
+
+    async def _live(market_id: str, platform: Platform) -> Market | None:
         # A single broken catalog row (bad market_id), a transient API hiccup, or a market the
         # platform priced as None (e.g. Kalshi `last_price_dollars: null`) must not 500 the whole
         # calibration endpoint -- log + drop just that row instead. Dropping None-probability
         # markets here keeps every downstream `require_probability()` call safe.
-        try:
-            market = price_clients[platform].get_market(market_id)
-        except _LIVE_FETCH_ERRORS:
-            logger.warning("dropping calibration row: %s market %r failed to fetch", platform, market_id, exc_info=True)
-            return None
+        async with fetch_slots:
+            try:
+                market = await price_clients[platform].get_market(market_id)
+            except _LIVE_FETCH_ERRORS:
+                logger.warning(
+                    "dropping calibration row: %s market %r failed to fetch", platform, market_id, exc_info=True
+                )
+                return None
         if market.probability is None:
             logger.warning("dropping calibration row: %s market %r returned no YES probability", platform, market_id)
             return None
         return market
 
+    # Every (platform, market_id) the catalog references, deduped (one market can back several rows),
+    # fetched concurrently once; the row builders below read from this resolved map.
+    needed: set[tuple[Platform, str]] = set()
+    needed.update((market.platform, market.market_id) for market in catalog.exact_markets())
+    needed.update((market.platform, market.market_id) for market in catalog.surfaced_markets())
+    needed.update(
+        (family.platform, bucket.market_id) for family in catalog.bucket_families for bucket in family.buckets
+    )
+    needed.update(
+        (family.platform, threshold.market_id)
+        for family in catalog.threshold_ladder_families
+        for threshold in family.thresholds
+    )
+    needed.update(
+        (family.platform, date_member.market_id)
+        for family in catalog.date_ladder_families
+        for date_member in family.dates
+    )
+    keys = list(needed)
+    fetched = await asyncio.gather(*(_live(market_id, platform) for platform, market_id in keys))
+    live_markets: dict[tuple[Platform, str], Market | None] = dict(zip(keys, fetched, strict=True))
+
     clean: list[CleanRow] = []
     surfaced: list[SurfacedRow] = []
     for market in catalog.exact_markets():
-        live = _live(market.market_id, market.platform)
+        live = live_markets[market.platform, market.market_id]
         if live is None:
             continue
         outcome = _exact_market_counts(
@@ -893,15 +926,14 @@ def run_calibration(
         else:
             counts, channel = outcome
             clean.append(_clean_row(market, counts, live, channel=channel))
-    surfaced.extend(
-        _surfaced_row(market, trajectories_by_issuer, live)
-        for market in catalog.surfaced_markets()
-        if (live := _live(market.market_id, market.platform)) is not None
-    )
+    for surfaced_market in catalog.surfaced_markets():
+        live = live_markets[surfaced_market.platform, surfaced_market.market_id]
+        if live is not None:
+            surfaced.append(_surfaced_row(surfaced_market, trajectories_by_issuer, live))
 
     categorical: list[CategoricalRow] = []
     for bucket_family in catalog.bucket_families:
-        prices = [_live(member.market_id, bucket_family.platform) for member in bucket_family.buckets]
+        prices = [live_markets[bucket_family.platform, bucket.market_id] for bucket in bucket_family.buckets]
         # A bucket that failed to fetch or had no probability makes the categorical ill-defined.
         if any(live is None for live in prices):
             logger.warning(
@@ -920,7 +952,9 @@ def run_calibration(
             )
         )
     for threshold_family in catalog.threshold_ladder_families:
-        prices = [_live(member.market_id, threshold_family.platform) for member in threshold_family.thresholds]
+        prices = [
+            live_markets[threshold_family.platform, threshold.market_id] for threshold in threshold_family.thresholds
+        ]
         if any(live is None for live in prices):
             logger.warning(
                 "dropping threshold ladder family %r: a threshold failed to fetch or had no price",
@@ -939,7 +973,7 @@ def run_calibration(
             )
         )
     for date_family in catalog.date_ladder_families:
-        prices = [_live(member.market_id, date_family.platform) for member in date_family.dates]
+        prices = [live_markets[date_family.platform, date_member.market_id] for date_member in date_family.dates]
         if any(live is None for live in prices):
             logger.warning(
                 "dropping date ladder family %r: a date failed to fetch or had no price", date_family.family_id

--- a/augur/calibration/calibration_report.py
+++ b/augur/calibration/calibration_report.py
@@ -14,6 +14,7 @@ KL divergence (loudest disagreement first).
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from pathlib import Path
 
@@ -22,14 +23,14 @@ from tabulate import tabulate
 from augur.api.config import load_augur_config
 from augur.calibration.calibration import build_anchored_level_paths, mark_fan, run_calibration
 from augur.calibration.catalog import MarketCatalog
-from augur.calibration.default_clients import build_default_price_clients
+from augur.calibration.default_clients import default_price_clients
 from augur.calibration.macro_anchors import resolve_anchors
 from augur.model.exogenous import ExogenousSamplingRequest, level_series_request_channels
 from augur.model.private_equity_bundle import PrivateEquityFloatChannel
 from augur.model.series import IssuerId, parse_level_series_key
 
 
-def main(argv: list[str] | None = None) -> int:
+async def _run(argv: list[str] | None) -> int:
     parser = argparse.ArgumentParser(description="Run calibration against live prediction markets for a config.")
     parser.add_argument("config", type=Path, help="Path to augur config.yaml")
     parser.add_argument("--preset", default=None, help="Preset id (default = config default)")
@@ -72,9 +73,8 @@ def main(argv: list[str] | None = None) -> int:
         horizon_months=args.horizon,
     )
 
-    price_clients = build_default_price_clients()
-    try:
-        result = run_calibration(
+    async with default_price_clients() as price_clients:
+        result = await run_calibration(
             catalog,
             horizon_months=args.horizon,
             rollout_seeds=sampling.rollout_seeds,
@@ -83,9 +83,6 @@ def main(argv: list[str] | None = None) -> int:
             level_paths=level_paths,
             inflation_history=anchors.inflation_history,
         )
-    finally:
-        for client in price_clients.values():
-            client.close()
 
     clean_rows = sorted(result.clean, key=lambda r: -abs(r.kl_bits) if r.kl_bits is not None else 0)
     clean_table = [
@@ -150,6 +147,10 @@ def main(argv: list[str] | None = None) -> int:
         print(tabulate(val_rows, headers=["month", "p5", "p50", "p95"]))
 
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(argv))
 
 
 if __name__ == "__main__":

--- a/augur/calibration/default_clients.py
+++ b/augur/calibration/default_clients.py
@@ -7,11 +7,18 @@ being duplicated. Tests still construct their own hermetic clients directly.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
+
 from augur.calibration.kalshi import KalshiClient
 from augur.calibration.manifold import ManifoldClient
 from augur.calibration.platform import Platform, PriceClient
 from augur.calibration.polymarket import PolymarketClient
-from augur.calibration.redis_cache import market_cache_config_from_env, wrap_price_clients_with_redis_cache
+from augur.calibration.redis_cache import (
+    market_cache_config_from_env,
+    open_market_cache_store,
+    wrap_price_clients_with_redis_cache,
+)
 
 # These clients are constructed once per server process and reused for every calibration run, so
 # the TTL bounds how stale a surfaced price/title can be — not how often a single request re-fetches.
@@ -21,13 +28,24 @@ from augur.calibration.redis_cache import market_cache_config_from_env, wrap_pri
 _DEFAULT_CACHE_TTL_SECONDS = 12 * 60 * 60
 
 
-def build_default_price_clients() -> dict[Platform, PriceClient]:
+@asynccontextmanager
+async def default_price_clients() -> AsyncIterator[dict[Platform, PriceClient]]:
+    """One process-lifetime set of live price clients, plus the shared Valkey cache store when
+    `AUGUR_MARKET_CACHE_URL` is set. Enter once per server/CLI run (server lifespan / CLI `main`);
+    the upstream httpx/SDK clients and the persistent Valkey store are closed on exit.
+    """
     cache_config = market_cache_config_from_env()
-    platform_cache_ttl_seconds = 0 if cache_config is not None else _DEFAULT_CACHE_TTL_SECONDS
-    clients = _build_upstream_price_clients(cache_ttl_seconds=platform_cache_ttl_seconds)
-    if cache_config is None:
-        return clients
-    return wrap_price_clients_with_redis_cache(clients, cache_config)
+    # With the shared Valkey cache on, the per-client in-memory TTL is redundant (the store bounds
+    # staleness across the whole process), so disable it; otherwise keep the 12h in-memory window.
+    platform_cache_ttl_seconds = 0.0 if cache_config is not None else _DEFAULT_CACHE_TTL_SECONDS
+    upstream = _build_upstream_price_clients(cache_ttl_seconds=platform_cache_ttl_seconds)
+    async with AsyncExitStack() as stack:
+        stack.push_async_callback(_aclose_all, upstream)
+        if cache_config is None:
+            yield upstream
+            return
+        store = await stack.enter_async_context(open_market_cache_store(cache_config))
+        yield wrap_price_clients_with_redis_cache(upstream, cache_config, store)
 
 
 def _build_upstream_price_clients(*, cache_ttl_seconds: float) -> dict[Platform, PriceClient]:
@@ -36,3 +54,8 @@ def _build_upstream_price_clients(*, cache_ttl_seconds: float) -> dict[Platform,
         Platform.POLYMARKET: PolymarketClient(cache_ttl_seconds=cache_ttl_seconds),
         Platform.KALSHI: KalshiClient(cache_ttl_seconds=cache_ttl_seconds),
     }
+
+
+async def _aclose_all(clients: dict[Platform, PriceClient]) -> None:
+    for client in clients.values():
+        await client.aclose()

--- a/augur/calibration/ipo_prior.py
+++ b/augur/calibration/ipo_prior.py
@@ -18,6 +18,7 @@ ready-to-paste ``public_market_cdf_anchors:`` block.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 from pathlib import Path
 
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 _MAX_CUMULATIVE_PROBABILITY = 0.999
 
 
-def derive_public_market_anchors(
+async def derive_public_market_anchors(
     catalog: MarketCatalog, *, price_client: ManifoldClient
 ) -> tuple[PublicMarketCdfAnchor, ...]:
     """Build a monotone going-public CDF from the catalog's live ``ipo_by_date`` markets.
@@ -60,7 +61,7 @@ def derive_public_market_anchors(
                 "dropping %s: deadline %s is at month %d < 1 (before sim start)", market.market_id, by_date, month
             )
             continue
-        prob = min(max(price_client.fetch_yes_probability(market.market_id), 0.0), _MAX_CUMULATIVE_PROBABILITY)
+        prob = min(max(await price_client.fetch_yes_probability(market.market_id), 0.0), _MAX_CUMULATIVE_PROBABILITY)
         if month in prob_by_month and prob <= prob_by_month[month]:
             logger.info(
                 "collapsing duplicate month %d for %s: keeping higher prob %.4f",
@@ -99,7 +100,7 @@ def _render_anchors_yaml(anchors: tuple[PublicMarketCdfAnchor, ...]) -> str:
     )
 
 
-def main(argv: list[str] | None = None) -> int:
+async def _run(argv: list[str] | None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("catalog", type=Path, help="Path to a MarketCatalog YAML.")
@@ -108,11 +109,15 @@ def main(argv: list[str] | None = None) -> int:
     catalog = MarketCatalog.from_yaml(args.catalog)
     client = ManifoldClient()
     try:
-        anchors = derive_public_market_anchors(catalog, price_client=client)
+        anchors = await derive_public_market_anchors(catalog, price_client=client)
     finally:
-        client.close()
+        await client.aclose()
     print(_render_anchors_yaml(anchors))
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(argv))
 
 
 if __name__ == "__main__":

--- a/augur/calibration/kalshi.py
+++ b/augur/calibration/kalshi.py
@@ -7,14 +7,15 @@ public reads). Raw ``httpx`` — no official Python SDK exists. The API returns
 
 from __future__ import annotations
 
+import asyncio
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import httpx
 from pydantic import BaseModel, ConfigDict
 
 from augur.calibration.platform import Market
-from augur.calibration.transient_retry import httpx_is_transient, with_retry
+from augur.calibration.transient_retry import httpx_is_transient, with_retry_async
 
 _BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
 _MARKET_URL_TEMPLATE = "https://kalshi.com/markets/{ticker}"
@@ -57,16 +58,16 @@ class KalshiClient:
         timeout: float = 30.0,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
-        client: httpx.Client | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._client = client if client is not None else httpx.Client(timeout=timeout)
+        self._client = client if client is not None else httpx.AsyncClient(timeout=timeout)
         self._cache_ttl_seconds = cache_ttl_seconds
         self._clock = clock
         self._sleep = sleep
         self._cache: dict[str, tuple[Market, float]] = {}
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         """One market's current state, served from the TTL cache when still fresh.
 
         ``market_id`` is the Kalshi ticker (e.g. ``"KXIPOOPENAI-26DEC01"``). Kalshi's API
@@ -75,7 +76,7 @@ class KalshiClient:
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
-        market = with_retry(
+        market = await with_retry_async(
             lambda: self._fetch(market_id),
             what=f"kalshi market {market_id!r}",
             is_transient=httpx_is_transient,
@@ -84,8 +85,8 @@ class KalshiClient:
         self._cache[market_id] = (market, now)
         return market
 
-    def _fetch(self, market_id: str) -> Market:
-        response = self._client.get(f"{_BASE_URL}/markets/{market_id}")
+    async def _fetch(self, market_id: str) -> Market:
+        response = await self._client.get(f"{_BASE_URL}/markets/{market_id}")
         response.raise_for_status()
         raw = _KalshiResponse.model_validate(response.json()).market
         # Kalshi's per-market title is the event headline; the leg's distinguishing clause lives in
@@ -101,8 +102,8 @@ class KalshiClient:
             rules=raw.rules_primary,
         )
 
-    def fetch_yes_probability(self, market_id: str) -> float:
-        return self.get_market(market_id).require_probability()
+    async def fetch_yes_probability(self, market_id: str) -> float:
+        return (await self.get_market(market_id)).require_probability()
 
-    def close(self) -> None:
-        self._client.close()
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/augur/calibration/manifold.py
+++ b/augur/calibration/manifold.py
@@ -15,16 +15,17 @@ Consumers use the concrete :class:`ManifoldClient`; tests inject a ``MockTranspo
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import httpx
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from augur.calibration.platform import Market
-from augur.calibration.transient_retry import httpx_is_transient, with_retry
+from augur.calibration.transient_retry import httpx_is_transient, with_retry_async
 
 _MARKET_ENDPOINT = "https://api.manifold.markets/v0/market/"
 _USER_AGENT = "augur-pm-calibration/1.0"
@@ -71,17 +72,17 @@ class ManifoldClient:
         timeout: float = 30.0,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
-        client: httpx.Client | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._client = client if client is not None else httpx.Client(headers=_headers(), timeout=timeout)
+        self._client = client if client is not None else httpx.AsyncClient(headers=_headers(), timeout=timeout)
         self._cache_ttl_seconds = cache_ttl_seconds
         self._clock = clock
         self._sleep = sleep
         # market id -> (last fetched market state, monotonic timestamp of that fetch).
         self._cache: dict[str, tuple[Market, float]] = {}
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         """One market's current state, served from the TTL cache when still fresh.
 
         A transient 5xx/timeout is retried with backoff before propagating.
@@ -89,7 +90,7 @@ class ManifoldClient:
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
-        market = with_retry(
+        market = await with_retry_async(
             lambda: self._fetch(market_id),
             what=f"manifold market {market_id!r}",
             is_transient=httpx_is_transient,
@@ -98,8 +99,8 @@ class ManifoldClient:
         self._cache[market_id] = (market, now)
         return market
 
-    def _fetch(self, market_id: str) -> Market:
-        response = self._client.get(f"{_MARKET_ENDPOINT}{market_id}")
+    async def _fetch(self, market_id: str) -> Market:
+        response = await self._client.get(f"{_MARKET_ENDPOINT}{market_id}")
         response.raise_for_status()
         raw = _ManifoldResponse.model_validate(response.json())
         # Manifold's brand symbol for mana is double-struck capital M (U+1D544); RUF001 flags
@@ -114,9 +115,9 @@ class ManifoldClient:
             rules=raw.text_description,
         )
 
-    def fetch_yes_probability(self, market_id: str) -> float:
+    async def fetch_yes_probability(self, market_id: str) -> float:
         """Current YES probability for one binary market; raises if it carries none."""
-        return self.get_market(market_id).require_probability()
+        return (await self.get_market(market_id)).require_probability()
 
-    def close(self) -> None:
-        self._client.close()
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/augur/calibration/platform.py
+++ b/augur/calibration/platform.py
@@ -46,6 +46,12 @@ class Market:
 
     id: str
     url: str
+    # TODO(naming): markets don't expose a "probability" — they expose a last trade / bid / ask, and
+    # `probability` here is really the last-trade price read as an implied probability (e.g. Kalshi
+    # `last_price_dollars`, Manifold `probability`, Polymarket yes.price). The actual probability comes
+    # from the separate price->probability smoothing step. Rename this (and `require_probability`) to
+    # something honest like `last_trade_price` / `implied_probability` so it doesn't read as a
+    # calibrated probability. Cross-cutting across the platform clients + calibration; see augur/TODO.md.
     probability: float | None
     volume: float | None = None
     volume_unit: str | None = None
@@ -62,5 +68,5 @@ class Market:
 
 
 class PriceClient(Protocol):
-    def get_market(self, market_id: str) -> Market: ...
-    def close(self) -> None: ...
+    async def get_market(self, market_id: str) -> Market: ...
+    async def aclose(self) -> None: ...

--- a/augur/calibration/polymarket.py
+++ b/augur/calibration/polymarket.py
@@ -10,8 +10,9 @@ calibration auto-refresh doesn't re-hit Polymarket per market per request.
 
 from __future__ import annotations
 
+import asyncio
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from decimal import Decimal
 
 from polymarket import PublicClient
@@ -27,7 +28,7 @@ from polymarket.errors import (
 )
 
 from augur.calibration.platform import Market
-from augur.calibration.transient_retry import with_retry
+from augur.calibration.transient_retry import with_retry_async
 
 _POLYMARKET_BASE_URL = "https://polymarket.com/event"
 
@@ -57,7 +58,7 @@ class PolymarketClient:
         *,
         cache_ttl_seconds: float = 120.0,
         clock: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
         sdk_client: PublicClient | None = None,
     ) -> None:
         self._sdk = sdk_client if sdk_client is not None else PublicClient()
@@ -66,18 +67,19 @@ class PolymarketClient:
         self._sleep = sleep
         self._cache: dict[str, tuple[Market, float]] = {}
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         """One market's current state, served from the TTL cache when still fresh.
 
         ``market_id`` is the Polymarket condition_id passed to
-        ``PublicClient.get_market(id=...)``. A transient 5xx/rate-limit/timeout is retried
-        with backoff before propagating.
+        ``PublicClient.get_market(id=...)``. The Polymarket SDK is synchronous, so the live
+        read runs in a worker thread; a transient 5xx/rate-limit/timeout is retried with
+        backoff before propagating.
         """
         now = self._clock()
         if (cached := self._cache.get(market_id)) is not None and now - cached[1] < self._cache_ttl_seconds:
             return cached[0]
-        market = with_retry(
-            lambda: self._fetch(market_id),
+        market = await with_retry_async(
+            lambda: asyncio.to_thread(self._fetch, market_id),
             what=f"polymarket market {market_id!r}",
             is_transient=_polymarket_is_transient,
             sleep=self._sleep,
@@ -104,8 +106,8 @@ class PolymarketClient:
             rules=pm_market.description,
         )
 
-    def fetch_yes_probability(self, market_id: str) -> float:
-        return self.get_market(market_id).require_probability()
+    async def fetch_yes_probability(self, market_id: str) -> float:
+        return (await self.get_market(market_id)).require_probability()
 
-    def close(self) -> None:
-        self._sdk.__exit__(None, None, None)
+    async def aclose(self) -> None:
+        await asyncio.to_thread(self._sdk.__exit__, None, None, None)

--- a/augur/calibration/redis_cache.py
+++ b/augur/calibration/redis_cache.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import math
 import os
 import time
 from collections.abc import Callable, Mapping
 from contextlib import AbstractAsyncContextManager
-from functools import partial
-from types import TracebackType
-from typing import Any, Protocol
+from typing import Any
 from urllib.parse import unquote, urlparse
 
 from key_value.aio.protocols import AsyncKeyValue
@@ -58,39 +55,18 @@ class MarketSnapshot(BaseModel):
     market: dict[str, Any]
 
 
-class AsyncKeyValueContext(AbstractAsyncContextManager[AsyncKeyValue], Protocol):
-    async def __aenter__(self) -> AsyncKeyValue: ...
-    async def __aexit__(
-        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
-    ) -> bool | None: ...
-
-
-StoreFactory = Callable[[], AsyncKeyValueContext]
-
-
-class ValkeyStoreContext:
-    def __init__(self, config: RedisMarketCacheConfig) -> None:
-        self._config = config
-        self._store: ValkeyStore | None = None
-
-    async def __aenter__(self) -> AsyncKeyValue:
-        store = ValkeyStore(
-            host=self._config.host,
-            port=self._config.port,
-            db=self._config.db,
-            username=self._config.username,
-            password=self._config.password,
-            default_collection=_CACHE_COLLECTION,
-        )
-        self._store = store
-        return await store.__aenter__()
-
-    async def __aexit__(
-        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
-    ) -> bool | None:
-        if self._store is None:
-            return None
-        return await self._store.__aexit__(exc_type, exc, tb)
+def open_market_cache_store(config: RedisMarketCacheConfig) -> AbstractAsyncContextManager[AsyncKeyValue]:
+    """One long-lived Valkey store for the process: `async with` it once (server lifespan / CLI
+    run) and share the entered store across every platform's caching client, instead of opening a
+    fresh connection per cache read/write."""
+    return ValkeyStore(
+        host=config.host,
+        port=config.port,
+        db=config.db,
+        username=config.username,
+        password=config.password,
+        default_collection=_CACHE_COLLECTION,
+    )
 
 
 def market_cache_config_from_env(env: Mapping[str, str] = os.environ) -> RedisMarketCacheConfig | None:
@@ -127,13 +103,18 @@ def market_cache_config_from_env(env: Mapping[str, str] = os.environ) -> RedisMa
 
 
 def wrap_price_clients_with_redis_cache(
-    clients: Mapping[Platform, PriceClient], config: RedisMarketCacheConfig, *, clock: Callable[[], float] = time.time
+    clients: Mapping[Platform, PriceClient],
+    config: RedisMarketCacheConfig,
+    store: AsyncKeyValue,
+    *,
+    clock: Callable[[], float] = time.time,
 ) -> dict[Platform, PriceClient]:
+    """Wrap each upstream client in a read-through cache over the shared, already-open `store`."""
     return {
         platform: RedisCachingPriceClient(
             platform=platform,
             upstream=client,
-            store_factory=partial(ValkeyStoreContext, config),
+            store=store,
             ttl_seconds=config.ttl_seconds,
             retention_seconds=config.retention_seconds,
             clock=clock,
@@ -143,11 +124,11 @@ def wrap_price_clients_with_redis_cache(
 
 
 class RedisCachingPriceClient:
-    """Sync ``PriceClient`` wrapper backed by Redis/Valkey.
+    """Async ``PriceClient`` wrapper backed by a long-lived Valkey ``store``.
 
-    The platform clients are synchronous and the Valkey client available in this repo is async.
-    Server endpoints that call ``PriceClient`` are sync FastAPI handlers, so each cache operation is
-    bridged with ``asyncio.run`` and uses a short-lived Valkey context.
+    Reads/writes go through the one persistent store handed in at construction — no per-call
+    client creation, no ``asyncio.run`` bridge. Cache read/write failures are best-effort: a read
+    miss or a store error degrades to the upstream fetch rather than failing the request.
     """
 
     def __init__(
@@ -155,26 +136,26 @@ class RedisCachingPriceClient:
         *,
         platform: Platform,
         upstream: PriceClient,
-        store_factory: StoreFactory,
+        store: AsyncKeyValue,
         ttl_seconds: float = _DEFAULT_TTL_SECONDS,
         retention_seconds: int = _DEFAULT_RETENTION_SECONDS,
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._platform = platform
         self._upstream = upstream
-        self._store_factory = store_factory
+        self._store = store
         self._ttl_seconds = ttl_seconds
         self._retention_seconds = retention_seconds
         self._clock = clock
 
-    def get_market(self, market_id: str) -> Market:
-        cached = self._load(market_id)
+    async def get_market(self, market_id: str) -> Market:
+        cached = await self._load(market_id)
         now = self._clock()
         if cached is not None and now - cached.fetched_at_epoch_seconds <= self._ttl_seconds:
             return _market_from_snapshot(cached)
 
         try:
-            market = self._upstream.get_market(market_id)
+            market = await self._upstream.get_market(market_id)
         except Exception:
             if cached is not None:
                 _LOGGER.warning(
@@ -186,7 +167,7 @@ class RedisCachingPriceClient:
                 return _market_from_snapshot(cached)
             raise
 
-        self._store(
+        await self._store_snapshot(
             MarketSnapshot(
                 platform=self._platform,
                 market_id=market_id,
@@ -196,12 +177,14 @@ class RedisCachingPriceClient:
         )
         return market
 
-    def close(self) -> None:
-        self._upstream.close()
+    async def aclose(self) -> None:
+        await self._upstream.aclose()
 
-    def _load(self, market_id: str) -> MarketSnapshot | None:
+    async def _load(self, market_id: str) -> MarketSnapshot | None:
         try:
-            raw = asyncio.run(self._async_load(market_id))
+            raw = await self._store.get(_cache_key(self._platform, market_id))
+        # Cache reads are best-effort: a store/connection error must fall through to the upstream
+        # fetch, not fail the request. Broad except is intentional here.
         except Exception:
             _LOGGER.warning("failed to read cached %s market %r", self._platform.value, market_id, exc_info=True)
             return None
@@ -217,24 +200,17 @@ class RedisCachingPriceClient:
             return None
         return snapshot
 
-    async def _async_load(self, market_id: str) -> dict[str, Any] | None:
-        async with self._store_factory() as store:
-            return await store.get(_cache_key(self._platform, market_id))
-
-    def _store(self, snapshot: MarketSnapshot) -> None:
+    async def _store_snapshot(self, snapshot: MarketSnapshot) -> None:
         try:
-            asyncio.run(self._async_store(snapshot))
-        except Exception:
-            _LOGGER.warning(
-                "failed to write cached %s market %r", self._platform.value, snapshot.market_id, exc_info=True
-            )
-
-    async def _async_store(self, snapshot: MarketSnapshot) -> None:
-        async with self._store_factory() as store:
-            await store.put(
+            await self._store.put(
                 _cache_key(self._platform, snapshot.market_id),
                 snapshot.model_dump(mode="json"),
                 ttl=self._retention_seconds,
+            )
+        # Cache writes are best-effort: a store error must not fail an otherwise-successful fetch.
+        except Exception:
+            _LOGGER.warning(
+                "failed to write cached %s market %r", self._platform.value, snapshot.market_id, exc_info=True
             )
 
 

--- a/augur/calibration/test_calibration.py
+++ b/augur/calibration/test_calibration.py
@@ -100,18 +100,18 @@ def price_clients() -> dict[Platform, PriceClient]:
     return mock_price_clients({Platform.MANIFOLD: {"AAA": 0.40, "BBB": 0.10, "CCC": 0.66}})
 
 
-def _run(model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[Platform, PriceClient]):
+async def _run(model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[Platform, PriceClient]):
     seeds = tuple(range(4))
     bundle = sample_private_equity_bundle(model, issuer=_ISSUER, horizon_months=_HORIZON, rollout_seeds=seeds)
-    return run_calibration(
+    return await run_calibration(
         catalog, horizon_months=_HORIZON, rollout_seeds=seeds, price_clients=price_clients, bundle=bundle
     )
 
 
-def test_clean_rows_score_events(
+async def test_clean_rows_score_events(
     model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[Platform, PriceClient]
 ) -> None:
-    result = _run(model, catalog, price_clients)
+    result = await _run(model, catalog, price_clients)
     assert result.rollout_count == 4
     clean = {row.market_id: row for row in result.clean}
 
@@ -136,10 +136,10 @@ def test_clean_rows_score_events(
     assert math.isclose(fail.p_model, 1 / 3)
 
 
-def test_surfaced_row_carries_augur_context(
+async def test_surfaced_row_carries_augur_context(
     model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[Platform, PriceClient]
 ) -> None:
-    result = _run(model, catalog, price_clients)
+    result = await _run(model, catalog, price_clients)
     assert [row.market_id for row in result.surfaced] == ["CCC"]
     surfaced = result.surfaced[0]
     assert surfaced.platform == "manifold"
@@ -153,14 +153,14 @@ def test_surfaced_row_carries_augur_context(
     assert surfaced.augur_context.p_model == 0.25
 
 
-def test_run_calibration_shares_bundle_with_mark_fan(
+async def test_run_calibration_shares_bundle_with_mark_fan(
     model: ConstantFrameModel, catalog: MarketCatalog, price_clients: dict[Platform, PriceClient]
 ) -> None:
     # One sampled bundle drives both the clean/surfaced scoring and the issuer mark_fan, so
     # both views come from a single rollout.
     seeds = tuple(range(4))
     bundle = sample_private_equity_bundle(model, issuer=_ISSUER, horizon_months=_HORIZON, rollout_seeds=seeds)
-    result = run_calibration(
+    result = await run_calibration(
         catalog, horizon_months=_HORIZON, rollout_seeds=seeds, price_clients=price_clients, bundle=bundle
     )
     assert {row.market_id for row in result.clean} == {"AAA", "BBB"}
@@ -204,7 +204,7 @@ def macro_model() -> ConstantFrameModel:
     )
 
 
-def test_macro_level_market_scored_over_full_rollouts(macro_model: ConstantFrameModel) -> None:
+async def test_macro_level_market_scored_over_full_rollouts(macro_model: ConstantFrameModel) -> None:
     """A point-in-time S&P threshold market scores against the anchored sp500 channel, and a
     market on an unmodeled series (inflation) surfaces as `unmodeled` rather than failing."""
     catalog = MarketCatalog(
@@ -249,7 +249,7 @@ def test_macro_level_market_scored_over_full_rollouts(macro_model: ConstantFrame
         horizon_months=_HORIZON,
     )
     clients = mock_price_clients({Platform.MANIFOLD: {"SPX": 0.30, "SPX-TOUCH": 0.45, "CPI": 0.20}})
-    result = run_calibration(
+    result = await run_calibration(
         catalog,
         horizon_months=_HORIZON,
         rollout_seeds=seeds,
@@ -274,7 +274,7 @@ def test_macro_level_market_scored_over_full_rollouts(macro_model: ConstantFrame
     assert cpi.p_market == 0.20
 
 
-def test_bucket_family_scored_as_multinomial(macro_model: ConstantFrameModel) -> None:
+async def test_bucket_family_scored_as_multinomial(macro_model: ConstantFrameModel) -> None:
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-27", "anchors": {"sp500": _SP500_ANCHOR}},
         markets=[],
@@ -311,7 +311,7 @@ def test_bucket_family_scored_as_multinomial(macro_model: ConstantFrameModel) ->
     )
     # Live bucket prices 0.2/0.5/0.3 (already sum to 1); model month-7 counts [1,2,1] -> [0.25,0.5,0.25].
     clients = mock_price_clients({Platform.KALSHI: {"B-LO": 0.20, "B-MID": 0.50, "B-HI": 0.30}})
-    result = run_calibration(
+    result = await run_calibration(
         catalog,
         horizon_months=_HORIZON,
         rollout_seeds=seeds,
@@ -338,7 +338,7 @@ def _inflation_levels(request: ExogenousSamplingRequest) -> npt.NDArray[np.float
     return matrix
 
 
-def test_threshold_ladder_family_derives_categorical_distribution() -> None:
+async def test_threshold_ladder_family_derives_categorical_distribution() -> None:
     model = ConstantFrameModel(
         levels={InflationKey(): _inflation_levels},
         private_equity={
@@ -382,7 +382,7 @@ def test_threshold_ladder_family_derives_categorical_distribution() -> None:
         horizon_months=_HORIZON,
     )
     clients = mock_price_clients({Platform.KALSHI: {"CPI-T3.0": 0.90, "CPI-T3.5": 0.60, "CPI-T4.0": 0.20}})
-    result = run_calibration(
+    result = await run_calibration(
         catalog,
         horizon_months=_HORIZON,
         rollout_seeds=seeds,
@@ -402,7 +402,7 @@ def test_threshold_ladder_family_derives_categorical_distribution() -> None:
     assert family.kl_bits is not None
 
 
-def test_date_ladder_family_derives_event_timing_distribution(model: ConstantFrameModel) -> None:
+async def test_date_ladder_family_derives_event_timing_distribution(model: ConstantFrameModel) -> None:
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-27"},
         markets=[],
@@ -422,7 +422,7 @@ def test_date_ladder_family_derives_event_timing_distribution(model: ConstantFra
     seeds = tuple(range(4))
     bundle = sample_private_equity_bundle(model, issuer=_ISSUER, horizon_months=_HORIZON, rollout_seeds=seeds)
     clients = mock_price_clients({Platform.KALSHI: {"IPO-2026": 0.30, "IPO-2031": 0.70}})
-    result = run_calibration(
+    result = await run_calibration(
         catalog, horizon_months=_HORIZON, rollout_seeds=seeds, price_clients=clients, bundle=bundle
     )
 
@@ -448,14 +448,14 @@ class _ProbClient:
     def __init__(self, probabilities: dict[str, float | None]) -> None:
         self._probabilities = probabilities
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         return Market(id=market_id, url=f"https://test.example/{market_id}", probability=self._probabilities[market_id])
 
-    def close(self) -> None:
+    async def aclose(self) -> None:
         pass
 
 
-def test_none_probability_and_degenerate_family_are_dropped(macro_model: ConstantFrameModel) -> None:
+async def test_none_probability_and_degenerate_family_are_dropped(macro_model: ConstantFrameModel) -> None:
     """A market the platform prices as None, and a categorical family whose bucket prices sum to
     zero, are both dropped (logged) rather than 500-ing via require_probability()."""
     catalog = MarketCatalog(
@@ -501,7 +501,7 @@ def test_none_probability_and_degenerate_family_are_dropped(macro_model: Constan
     clients: dict[Platform, PriceClient] = {
         Platform.POLYMARKET: _ProbClient({"NOPRICE": None, "Z-LO": 0.0, "Z-HI": 0.0})
     }
-    result = run_calibration(
+    result = await run_calibration(
         catalog,
         horizon_months=_HORIZON,
         rollout_seeds=seeds,
@@ -522,7 +522,7 @@ def test_wilson_interval_edges() -> None:
     assert math.isclose((lo + hi) / 2, 0.5, abs_tol=1e-9)
 
 
-def test_multi_platform_dispatches_to_correct_client(model: ConstantFrameModel) -> None:
+async def test_multi_platform_dispatches_to_correct_client(model: ConstantFrameModel) -> None:
     """Kalshi + Manifold markets each hit their own client and carry the right platform tag."""
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-29"},
@@ -542,7 +542,7 @@ def test_multi_platform_dispatches_to_correct_client(model: ConstantFrameModel) 
     clients = mock_price_clients({Platform.MANIFOLD: {"M1": 0.75}, Platform.KALSHI: {"KXIPOOPENAI-26SEP01": 0.50}})
     seeds = tuple(range(4))
     bundle = sample_private_equity_bundle(model, issuer=_ISSUER, horizon_months=_HORIZON, rollout_seeds=seeds)
-    result = run_calibration(
+    result = await run_calibration(
         catalog, horizon_months=_HORIZON, rollout_seeds=seeds, price_clients=clients, bundle=bundle
     )
     by_id = {row.market_id: row for row in result.clean}

--- a/augur/calibration/test_ipo_prior.py
+++ b/augur/calibration/test_ipo_prior.py
@@ -49,8 +49,8 @@ def prices() -> ManifoldClient:
     return mock_manifold_client({"B27": 0.30, "B28": 0.55, "B29": 0.93, "B30": 0.80, "BPRE": 0.99})
 
 
-def test_derives_monotone_anchors_dropping_market_noise(catalog: MarketCatalog, prices: ManifoldClient) -> None:
-    anchors = derive_public_market_anchors(catalog, price_client=prices)
+async def test_derives_monotone_anchors_dropping_market_noise(catalog: MarketCatalog, prices: ManifoldClient) -> None:
+    anchors = await derive_public_market_anchors(catalog, price_client=prices)
 
     # The before-sim-start market (month -1) and the non-monotone 2030 point are dropped.
     assert [anchor.month for anchor in anchors] == [7, 19, 31]
@@ -63,20 +63,22 @@ def test_derives_monotone_anchors_dropping_market_noise(catalog: MarketCatalog, 
     assert all(later >= earlier for earlier, later in itertools.pairwise(cumulatives))
 
 
-def test_derived_anchors_validate_against_m1_issuer_config(catalog: MarketCatalog, prices: ManifoldClient) -> None:
+async def test_derived_anchors_validate_against_m1_issuer_config(
+    catalog: MarketCatalog, prices: ManifoldClient
+) -> None:
     # The whole point of the derivation: the output must satisfy the M1 model validator
     # (strictly-increasing month, non-decreasing CDF), so the markets can feed the model.
-    anchors = derive_public_market_anchors(catalog, price_client=prices)
+    anchors = await derive_public_market_anchors(catalog, price_client=prices)
     config = PrivateEquityRiskIssuerConfig(current_mark_usd=100.0, public_market_cdf_anchors=anchors)
     assert config.public_market_cdf_anchors == anchors
 
 
-def test_probabilities_clamped_below_one() -> None:
+async def test_probabilities_clamped_below_one() -> None:
     # A near-certain (>= 1.0) market must clamp into [0, 1) so the `lt=1.0` field accepts it.
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-29", "augur_model_as_of": "2026-05-27"}, markets=[_ipo_market("CERT", "2029-01-01")]
     )
-    anchors = derive_public_market_anchors(catalog, price_client=mock_manifold_client({"CERT": 1.0}))
+    anchors = await derive_public_market_anchors(catalog, price_client=mock_manifold_client({"CERT": 1.0}))
     assert anchors[0].cumulative_probability < 1.0
 
 

--- a/augur/calibration/test_manifold.py
+++ b/augur/calibration/test_manifold.py
@@ -16,25 +16,25 @@ from augur.calibration.manifold import ManifoldClient
 from augur.calibration.testing import mock_manifold_client
 
 
-def test_fetch_yes_probability_returns_market_probability() -> None:
+async def test_fetch_yes_probability_returns_market_probability() -> None:
     client = mock_manifold_client({"AAA": 0.42})
-    assert client.fetch_yes_probability("AAA") == 0.42
-    assert client.get_market("AAA").id == "AAA"
+    assert await client.fetch_yes_probability("AAA") == 0.42
+    assert (await client.get_market("AAA")).id == "AAA"
 
 
-def test_fetch_yes_probability_raises_when_probability_missing() -> None:
+async def test_fetch_yes_probability_raises_when_probability_missing() -> None:
     # A market with no `probability` (e.g. a non-binary market) has no YES probability,
     # so the wrapper raises rather than inventing one.
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"id": "NOPROB", "url": "https://manifold.markets/test/NOPROB"})
 
-    client = ManifoldClient(client=httpx.Client(transport=httpx.MockTransport(handler)))
-    assert client.get_market("NOPROB").probability is None
+    client = ManifoldClient(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+    assert (await client.get_market("NOPROB")).probability is None
     with pytest.raises(ValueError, match="no YES probability"):
-        client.fetch_yes_probability("NOPROB")
+        await client.fetch_yes_probability("NOPROB")
 
 
-def test_get_market_caches_within_ttl_and_refetches_after() -> None:
+async def test_get_market_caches_within_ttl_and_refetches_after() -> None:
     now = [1000.0]
     calls = {"count": 0}
 
@@ -43,19 +43,19 @@ def test_get_market_caches_within_ttl_and_refetches_after() -> None:
         return httpx.Response(200, json={"id": "AAA", "url": "https://manifold.markets/test/AAA", "probability": 0.3})
 
     client = ManifoldClient(
-        cache_ttl_seconds=120.0, clock=lambda: now[0], client=httpx.Client(transport=httpx.MockTransport(handler))
+        cache_ttl_seconds=120.0, clock=lambda: now[0], client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
     )
 
     # First read hits the network; a second read inside the TTL is served from cache.
-    assert client.get_market("AAA").probability == 0.3
+    assert (await client.get_market("AAA")).probability == 0.3
     assert calls["count"] == 1
     now[0] += 119.0
-    assert client.get_market("AAA").probability == 0.3
+    assert (await client.get_market("AAA")).probability == 0.3
     assert calls["count"] == 1
 
     # Crossing the TTL forces a fresh network read.
     now[0] += 2.0
-    assert client.get_market("AAA").probability == 0.3
+    assert (await client.get_market("AAA")).probability == 0.3
     assert calls["count"] == 2
 
 

--- a/augur/calibration/test_redis_cache.py
+++ b/augur/calibration/test_redis_cache.py
@@ -9,16 +9,12 @@ from augur.calibration.platform import Market, Platform
 from augur.calibration.redis_cache import MarketSnapshot, RedisCachingPriceClient, market_cache_config_from_env
 
 
-class _FakeStoreContext:
+class _FakeStore:
+    """Minimal in-memory ``AsyncKeyValue`` for the read-through cache, already 'open'."""
+
     def __init__(self, data: dict[str, dict[str, Any]], ttls: dict[str, int]) -> None:
         self._data = data
         self._ttls = ttls
-
-    async def __aenter__(self) -> _FakeStoreContext:
-        return self
-
-    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-        return None
 
     async def get(self, key: str) -> dict[str, Any] | None:
         return self._data.get(key)
@@ -36,18 +32,18 @@ class _FakeUpstream:
         self.calls: list[str] = []
         self.closed = False
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         self.calls.append(market_id)
         if self.error is not None:
             raise self.error
         assert self.market is not None
         return self.market
 
-    def close(self) -> None:
+    async def aclose(self) -> None:
         self.closed = True
 
 
-def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
+async def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
     data = {
         "manifold:m1": _snapshot(
             market_id="m1",
@@ -59,11 +55,13 @@ def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
     upstream = _FakeUpstream(error=RuntimeError("should not fetch"))
     client = _client(upstream=upstream, data=data, ttls=ttls, now=20.0, ttl_seconds=30.0)
 
-    assert client.get_market("m1") == Market(id="m1", url="https://example.com/m1", probability=0.4, title="cached")
+    assert await client.get_market("m1") == Market(
+        id="m1", url="https://example.com/m1", probability=0.4, title="cached"
+    )
     assert upstream.calls == []
 
 
-def test_stale_cache_refreshes_from_upstream_and_updates_cache() -> None:
+async def test_stale_cache_refreshes_from_upstream_and_updates_cache() -> None:
     data = {
         "manifold:m1": _snapshot(
             market_id="m1", fetched_at=10.0, market=Market(id="m1", url="https://example.com/stale", probability=0.4)
@@ -74,39 +72,39 @@ def test_stale_cache_refreshes_from_upstream_and_updates_cache() -> None:
     upstream = _FakeUpstream(market=upstream_market)
     client = _client(upstream=upstream, data=data, ttls=ttls, now=50.0, ttl_seconds=30.0, retention_seconds=120)
 
-    assert client.get_market("m1") == upstream_market
+    assert await client.get_market("m1") == upstream_market
     assert upstream.calls == ["m1"]
     assert MarketSnapshot.model_validate(data["manifold:m1"]).market["url"] == "https://example.com/fresh"
     assert ttls == {"manifold:m1": 120}
 
 
-def test_stale_cache_survives_upstream_failure() -> None:
+async def test_stale_cache_survives_upstream_failure() -> None:
     cached_market = Market(id="m1", url="https://example.com/stale", probability=0.4)
     data = {"manifold:m1": _snapshot(market_id="m1", fetched_at=10.0, market=cached_market)}
     ttls: dict[str, int] = {}
     upstream = _FakeUpstream(error=RuntimeError("upstream down"))
     client = _client(upstream=upstream, data=data, ttls=ttls, now=50.0, ttl_seconds=30.0)
 
-    assert client.get_market("m1") == cached_market
+    assert await client.get_market("m1") == cached_market
     assert upstream.calls == ["m1"]
 
 
-def test_cache_miss_propagates_upstream_failure() -> None:
+async def test_cache_miss_propagates_upstream_failure() -> None:
     upstream = _FakeUpstream(error=RuntimeError("upstream down"))
     client = _client(upstream=upstream, data={}, ttls={}, now=50.0)
 
     with pytest.raises(RuntimeError, match="upstream down"):
-        client.get_market("m1")
+        await client.get_market("m1")
 
 
-def test_invalid_cache_payload_is_ignored() -> None:
+async def test_invalid_cache_payload_is_ignored() -> None:
     data = {"manifold:m1": {"schema_version": 1, "platform": "kalshi", "market_id": "m1"}}
     ttls: dict[str, int] = {}
     upstream_market = Market(id="m1", url="https://example.com/fresh", probability=0.7)
     upstream = _FakeUpstream(market=upstream_market)
     client = _client(upstream=upstream, data=data, ttls=ttls, now=20.0)
 
-    assert client.get_market("m1") == upstream_market
+    assert await client.get_market("m1") == upstream_market
     assert upstream.calls == ["m1"]
 
 
@@ -141,7 +139,7 @@ def _client(
     return RedisCachingPriceClient(
         platform=Platform.MANIFOLD,
         upstream=upstream,
-        store_factory=lambda: _FakeStoreContext(data, ttls),
+        store=_FakeStore(data, ttls),
         ttl_seconds=ttl_seconds,
         retention_seconds=retention_seconds,
         clock=lambda: now,

--- a/augur/calibration/test_transient_retry.py
+++ b/augur/calibration/test_transient_retry.py
@@ -1,4 +1,4 @@
-"""Tests for `with_retry`: it retries transient failures with backoff, gives up after the
+"""Tests for `with_retry_async`: it retries transient failures with backoff, gives up after the
 attempt budget, and never retries non-transient errors.
 
 The Kalshi client wiring is exercised end-to-end with a `MockTransport` that 503s a fixed
@@ -13,7 +13,11 @@ import pytest
 import pytest_bazel
 
 from augur.calibration.kalshi import KalshiClient
-from augur.calibration.transient_retry import httpx_is_transient, with_retry
+from augur.calibration.transient_retry import httpx_is_transient, with_retry_async
+
+
+async def _noop_sleep(_seconds: float) -> None:
+    pass
 
 
 def _http_status_error(status: int) -> httpx.HTTPStatusError:
@@ -21,44 +25,47 @@ def _http_status_error(status: int) -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError("boom", request=request, response=httpx.Response(status, request=request))
 
 
-def test_retries_transient_then_succeeds() -> None:
+async def test_retries_transient_then_succeeds() -> None:
     attempts = {"n": 0}
     slept: list[float] = []
 
-    def fetch() -> str:
+    async def fetch() -> str:
         attempts["n"] += 1
         if attempts["n"] < 3:
             raise _http_status_error(503)
         return "ok"
 
-    result = with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=slept.append)
+    async def record_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    result = await with_retry_async(fetch, what="thing", is_transient=httpx_is_transient, sleep=record_sleep)
     assert result == "ok"
     assert attempts["n"] == 3
     # Exponential backoff between the two failed attempts: 0.5s, then 1.0s.
     assert slept == [0.5, 1.0]
 
 
-def test_gives_up_after_max_attempts_and_reraises_last() -> None:
+async def test_gives_up_after_max_attempts_and_reraises_last() -> None:
     attempts = {"n": 0}
 
-    def fetch() -> str:
+    async def fetch() -> str:
         attempts["n"] += 1
         raise _http_status_error(503)
 
     with pytest.raises(httpx.HTTPStatusError):
-        with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=lambda _: None)
+        await with_retry_async(fetch, what="thing", is_transient=httpx_is_transient, sleep=_noop_sleep)
     assert attempts["n"] == 3
 
 
-def test_non_transient_status_is_not_retried() -> None:
+async def test_non_transient_status_is_not_retried() -> None:
     attempts = {"n": 0}
 
-    def fetch() -> str:
+    async def fetch() -> str:
         attempts["n"] += 1
         raise _http_status_error(404)
 
     with pytest.raises(httpx.HTTPStatusError):
-        with_retry(fetch, what="thing", is_transient=httpx_is_transient, sleep=lambda _: None)
+        await with_retry_async(fetch, what="thing", is_transient=httpx_is_transient, sleep=_noop_sleep)
     # A 404 won't fix itself: fail immediately without burning the retry budget.
     assert attempts["n"] == 1
 
@@ -70,7 +77,7 @@ def test_httpx_is_transient_classification() -> None:
     assert httpx_is_transient(httpx.ConnectTimeout("slow"))
 
 
-def test_kalshi_client_recovers_from_flapping_503() -> None:
+async def test_kalshi_client_recovers_from_flapping_503() -> None:
     responses = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -79,8 +86,8 @@ def test_kalshi_client_recovers_from_flapping_503() -> None:
             return httpx.Response(503)
         return httpx.Response(200, json={"market": {"last_price_dollars": 0.37}})
 
-    client = KalshiClient(client=httpx.Client(transport=httpx.MockTransport(handler)), sleep=lambda _: None)
-    assert client.get_market("KXTEST").probability == 0.37
+    client = KalshiClient(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)), sleep=_noop_sleep)
+    assert (await client.get_market("KXTEST")).probability == 0.37
     assert responses["n"] == 3
 
 

--- a/augur/calibration/testing.py
+++ b/augur/calibration/testing.py
@@ -38,7 +38,9 @@ def mock_manifold_client(
         )
 
     return ManifoldClient(
-        clock=clock, cache_ttl_seconds=cache_ttl_seconds, client=httpx.Client(transport=httpx.MockTransport(handler))
+        clock=clock,
+        cache_ttl_seconds=cache_ttl_seconds,
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
 
 
@@ -62,7 +64,9 @@ def mock_kalshi_client(
         )
 
     return KalshiClient(
-        clock=clock, cache_ttl_seconds=cache_ttl_seconds, client=httpx.Client(transport=httpx.MockTransport(handler))
+        clock=clock,
+        cache_ttl_seconds=cache_ttl_seconds,
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
 
 
@@ -72,7 +76,7 @@ class _StaticClient:
     def __init__(self, prices: Mapping[str, float]) -> None:
         self._prices = prices
 
-    def get_market(self, market_id: str) -> Market:
+    async def get_market(self, market_id: str) -> Market:
         return Market(
             id=market_id,
             url=f"https://test.example/{market_id}",
@@ -81,7 +85,7 @@ class _StaticClient:
             rules=f"Resolves per market {market_id}.",
         )
 
-    def close(self) -> None:
+    async def aclose(self) -> None:
         pass
 
 

--- a/augur/calibration/transient_retry.py
+++ b/augur/calibration/transient_retry.py
@@ -17,12 +17,12 @@ flakiness entirely. Tracked in augur/TODO.md.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import httpx
-from tenacity import RetryCallState, Retrying, retry_if_exception, stop_after_attempt, wait_exponential
+from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -41,16 +41,16 @@ def httpx_is_transient(exc: BaseException) -> bool:
     return isinstance(exc, httpx.TransportError)
 
 
-def with_retry[T](
-    fetch: Callable[[], T],
+async def with_retry_async[T](
+    fetch: Callable[[], Awaitable[T]],
     *,
     what: str,
     is_transient: Callable[[BaseException], bool],
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
-    sleep: Callable[[float], None] = time.sleep,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> T:
-    """Call ``fetch`` via tenacity, retrying with exponential backoff only failures for
+    """Await ``fetch`` via tenacity, retrying with exponential backoff only failures for
     which ``is_transient`` returns True; any other exception (and the final transient one,
     once the attempt budget is spent) propagates. ``what`` labels the resource in the log.
     """
@@ -65,7 +65,7 @@ def with_retry[T](
             exc,
         )
 
-    retrying = Retrying(
+    retrying = AsyncRetrying(
         retry=retry_if_exception(is_transient),
         stop=stop_after_attempt(max_attempts),
         wait=wait_exponential(multiplier=backoff_base_seconds, exp_base=2),
@@ -73,4 +73,11 @@ def with_retry[T](
         before_sleep=_log_retry,
         reraise=True,
     )
-    return retrying(fetch)
+
+    # tenacity only awaits the retried callable when it's a coroutine *function*; `fetch` is often a
+    # plain lambda returning a coroutine (so the client can bind args), which tenacity would call but
+    # not await. Wrap it in an `async def` so each attempt is awaited.
+    async def _attempt() -> T:
+        return await fetch()
+
+    return await retrying(_attempt)

--- a/augur/dev_server.py
+++ b/augur/dev_server.py
@@ -10,9 +10,13 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 
 from augur.api.config import Config, load_augur_config, resolve_augur_config_path
-from augur.api.server import build_configured_server_arg_parser, create_app_from_augur_config, run_app
-from augur.calibration.default_clients import build_default_price_clients
-from augur.calibration.platform import Platform, PriceClient
+from augur.api.server import (
+    PriceClientsProvider,
+    build_configured_server_arg_parser,
+    create_app_from_augur_config,
+    run_app,
+)
+from augur.calibration.default_clients import default_price_clients
 from util.bazel.runfiles import get_required_path
 
 _AUGUR_BUNDLE_INDEX_RUNFILE_ENV_VAR = "AUGUR_BUNDLE_INDEX_RUNFILE"
@@ -54,9 +58,7 @@ def _mount_static_bundle(app: FastAPI, static_path: StaticPathResolver) -> None:
         return FileResponse(path, headers=no_store)
 
 
-def build_dev_app(
-    augur_config: Config, *, api_only: bool = False, price_clients: dict[Platform, PriceClient]
-) -> FastAPI:
+def build_dev_app(augur_config: Config, *, api_only: bool = False, price_clients: PriceClientsProvider) -> FastAPI:
     """The combined dev app (API routes plus, unless `api_only`, the static SPA bundle).
 
     `price_clients` is the live price source map for `/api/calibration/run`."""
@@ -73,7 +75,7 @@ def main(argv: list[str] | None = None) -> int:
     ).parse_args(argv)
     config_path = Path(args.config).resolve() if args.config else resolve_augur_config_path()
     augur_config = load_augur_config(config_path)
-    app = build_dev_app(augur_config, api_only=args.api_only, price_clients=build_default_price_clients())
+    app = build_dev_app(augur_config, api_only=args.api_only, price_clients=default_price_clients())
     return run_app(app=app, augur_config=augur_config, host=args.host, port=args.port)
 
 

--- a/augur/visual_test.py
+++ b/augur/visual_test.py
@@ -32,6 +32,7 @@ import pytest_bazel
 import uvicorn
 
 from augur.api.config import Config
+from augur.api.server import static_price_clients
 from augur.calibration.catalog import MarketCatalog
 from augur.calibration.platform import Platform
 from augur.calibration.testing import mock_price_clients
@@ -460,7 +461,7 @@ def hermetic_prices() -> dict[Platform, dict[str, float]]:
 @pytest.fixture(scope="module")
 def augur_server(augur_config: Config, hermetic_prices: dict[Platform, dict[str, float]]) -> Iterator[str]:
     # Inject hermetic mock clients so the calibration tab's auto-run never hits the network.
-    app = build_dev_app(augur_config, price_clients=mock_price_clients(hermetic_prices))
+    app = build_dev_app(augur_config, price_clients=static_price_clients(mock_price_clients(hermetic_prices)))
     port = pick_free_port("127.0.0.1")
     server = uvicorn.Server(uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="warning"))
     thread = threading.Thread(target=server.run, name="augur-visual-uvicorn", daemon=True)


### PR DESCRIPTION
Fixes the slow/flaky valkey behavior diagnosed earlier: the market cache opened a **brand-new Valkey client per cache read/write** and bridged each op with `asyncio.run` inside sync FastAPI handlers, so a calibration run churned hundreds of connect→handshake→teardown cycles and intermittently timed out on connection setup. This goes **async all the way through** and holds **one long-lived client**.

## What changed
- **`PriceClient` protocol is async** (`get_market` / `aclose`). Manifold + Kalshi use `httpx.AsyncClient` + tenacity `AsyncRetrying`; Polymarket keeps its sync SDK behind `asyncio.to_thread`. `transient_retry` exposes `with_retry_async` (wraps the thunk in an `async def` so tenacity actually awaits each attempt).
- **One persistent Valkey store.** `RedisCachingPriceClient` is async over a single shared `ValkeyStore`. `default_clients.default_price_clients()` is an async context manager that opens the store + upstream clients once and closes them on exit; the server enters it in a **FastAPI lifespan** and stashes the clients on `app.state`. No per-op client, no `asyncio.run` in handlers.
- **Concurrent fetches.** `run_calibration` is async and fetches every referenced market with `asyncio.gather` (deduped, bounded by a semaphore) instead of one-at-a-time. The `/api/calibration/run` handler and the `calibration_report` / `ipo_prior` CLIs are async with a single top-level `asyncio.run`.
- Tests are async (pytest-asyncio, already auto-mode via the root `conftest.py`); added the plugin dep to the affected targets. Endpoint tests inject hermetic clients through a `static_price_clients(...)` provider.

## Drive-bys (same files)
- Fixed the **pre-existing `calibration.py` mypy error** (the family/market loops reused one loop variable across distinct types) — this also unblocks `bbr build //augur/...`, which was red on `devel`.
- Added a TODO at `Market.probability`: markets expose a last trade / bid / ask, not a probability; the field is really the last-trade implied probability and the calibrated value comes from the separate smoothing step. Rename is cross-cutting (tracked in `augur/TODO.md`).

## Tests
`bbr build //augur/...` green (mypy clean across the tree). `//augur/calibration:{test_calibration,test_manifold,test_redis_cache,test_transient_retry,test_ipo_prior}`, `//augur/api:{test_calibration_endpoint,server_test}` all pass. pre-commit clean.