### PR TITLE
nix/attic: refresh trusted-public-keys after recreating main+gaffer caches

### DIFF
--- a/nix/nixos/modules/attic-substituter.nix
+++ b/nix/nixos/modules/attic-substituter.nix
@@ -59,8 +59,8 @@ in
         # them back into this file via the github-secrets-sync-pat PAT
         # (same mechanism the rotator uses for SOPS files). Pubkeys only
         # change on full cluster rebuild, so the manual step is rare.
-        "main:cy5xhwCNq/T7R55I9TaLv0z6SM6EipXvdFhqrbxC7nc="
-        "gaffer:Z8sM2kptUUDGk4ARVD/YkcpzWdMgmZX7nVLV5joK7r8="
+        "main:owYQITaq2ixR/EnqKoIQAxgjalKKVqMemFwRMaUW53U="
+        "gaffer:78zVKxf5n254+14vXQeDKV2EHk1q2I9CrG6fLdwlQws="
       ];
       netrc-file = config.sops.templates."attic-netrc".path;
       connect-timeout = 5;


### PR DESCRIPTION
The attic server had **lost both caches**: admin `GET /_api/v1/cache-config/{main,gaffer}` returned **404**, and `nix-attic-push` CI was failing persistently with `NoSuchCache: The requested cache does not exist`. (The bootstrap Job created them 35d ago; the attic Postgres DB appears to have dropped them since — root cause of the data loss is unknown / worth watching.)

**Fix applied (ops):** recreated `main` and `gaffer` via the bootstrap POST body (`keypair=Generate`, `is_public=false`, …) — both now `GET 200`.

**This PR:** recreation minted fresh signing keypairs, so the old `trusted-public-keys` no longer match pushed paths. Updates both to the new pubkeys from `/_api/v1/cache-config/<cache>`.

Unblocks ducktape + gaffer-private `nix-attic-push` and substituter trust on consumers (dev machines / web_setup / NixOS hosts). Bazel CI on devel was already green; this only concerns the nix binary cache.