### PR TITLE
nix/rbe-worker: pin docker_29 (docker_28 marked insecure)

### DIFF
--- a/x/nix_rbe_image/nixos.nix
+++ b/x/nix_rbe_image/nixos.nix
@@ -38,7 +38,9 @@ in
   security.sudo.wheelNeedsPassword = false;
 
   # Docker — BB starts dockerd via init-dockerd on Firecracker workers.
+  # docker_29: docker_28 was marked insecure (unmaintained since 2025-11).
   virtualisation.docker.enable = true;
+  virtualisation.docker.package = pkgs.docker_29;
 
   # Firecracker's guest kernel may lack nftables support.
   networking.nftables.enable = false;

--- a/x/nix_rbe_image/packages.nix
+++ b/x/nix_rbe_image/packages.nix
@@ -56,7 +56,8 @@ with pkgs;
   git
 
   # Docker CLI (daemon managed by BB's init-dockerd)
-  docker
+  # docker_29: docker_28 was marked insecure (unmaintained since 2025-11).
+  docker_29
 
   # iptables for Firecracker Docker compatibility
   iptables


### PR DESCRIPTION
## Problem

The **Nix Attic push** job is failing on `devel` ([run 27114096776](https://github.com/agentydragon/ducktape/actions/runs/27114096776/job/80019274608)):

> `error: Package 'docker-28.5.2' is marked as insecure, refusing to evaluate.`
> `docker_28 has been unmaintained since November 2025, use docker_29 or newer`

A recent nixpkgs bump marked `docker_28` insecure, so the flake-eval of the `nix-rbe-worker` toplevel now fails. The host enabled docker with the default package (`docker_28`) and also listed bare `docker` in `systemPackages`.

`workstation.nix` already moved to `docker_29`; this brings the RBE worker in line.

## Fix

- `x/nix_rbe_image/nixos.nix` — `virtualisation.docker.package = pkgs.docker_29`
- `x/nix_rbe_image/packages.nix` — `docker` → `docker_29` (CLI)

## Verification

`nix eval` of `nixosConfigurations.nix-rbe-worker.config.system.build.toplevel.drvPath` succeeds (previously threw the insecure-package error). All other host toplevels also eval cleanly.