### PR TITLE
finance/beancount_export: exporter runner (Plaid mirror → classified → ledger → git)

### DIFF
--- a/augur/budget/schema.py
+++ b/augur/budget/schema.py
@@ -269,6 +269,18 @@ class BudgetSourceConfig(ApiModel):
     coverage_starts: date | None = None
 
 
+class FundingAccountDef(ApiModel):
+    """Maps a Plaid account to its Beancount funding (asset/liability) account.
+
+    The funding account is the leg opposite the bucket's contra account in each
+    exported entry (the money's source/sink: checking, a credit-card liability, a
+    brokerage). Consumed only by the Beancount exporter, not the in-app budget.
+    """
+
+    plaid_account_id: str
+    account: str = Field(pattern=_BEANCOUNT_ACCOUNT_PATTERN)
+
+
 class BudgetConfig(ApiModel):
     """Top-level budget planner config (optional; absent = budget endpoints return 400)."""
 
@@ -290,6 +302,10 @@ class BudgetConfig(ApiModel):
     # Transactions with abs(amount) >= this threshold are flagged as "lumpy" (in addition to
     # appearing in their natural bucket). User can re-classify them as one-off vs recurring.
     lumpy_threshold_usd: float = Field(default=500.0, gt=0.0)
+    # Plaid account_id -> Beancount funding account (the funding leg of each exported
+    # entry; the bucket supplies the contra leg). Consumed by the Beancount exporter,
+    # not the in-app budget. Accounts not listed fall back to the exporter's default.
+    funding_accounts: tuple[FundingAccountDef, ...] = ()
 
     @model_validator(mode="after")
     def _validate_references(self) -> BudgetConfig:
@@ -317,4 +333,9 @@ class BudgetConfig(ApiModel):
             if override.transaction_id in seen_override_ids:
                 raise ValueError(f"duplicate override for transaction_id {override.transaction_id!r}")
             seen_override_ids.add(override.transaction_id)
+        seen_funding_ids: set[str] = set()
+        for funding in self.funding_accounts:
+            if funding.plaid_account_id in seen_funding_ids:
+                raise ValueError(f"duplicate funding account for plaid_account_id {funding.plaid_account_id!r}")
+            seen_funding_ids.add(funding.plaid_account_id)
         return self

--- a/augur/budget/sql_read_model.py
+++ b/augur/budget/sql_read_model.py
@@ -270,6 +270,24 @@ WHERE classified_tx.bucket_id = :bucket_id
 ORDER BY classified_tx.date, classified_tx.transaction_id
 """
 
+# Every live classified txn (all buckets at once), for the Beancount exporter. Reuses the
+# same classified-tx CTE as the budget UI so the exported ledger and the in-app budget can
+# never disagree about which bucket a transaction landed in.
+_EXPORT_TAIL = """
+SELECT
+    classified_tx.transaction_id,
+    classified_tx.date,
+    classified_tx.amount,
+    classified_tx.name,
+    classified_tx.merchant_name,
+    classified_tx.pfc_primary,
+    classified_tx.pfc_detailed,
+    classified_tx.account_id,
+    classified_tx.bucket_id
+FROM classified_tx
+ORDER BY classified_tx.date, classified_tx.transaction_id
+"""
+
 # Stale-override probe (decision 7): a GLOBAL existence check by transaction_id, NOT
 # scoped to the request window/accounts, so an override for an out-of-window txn is not
 # falsely flagged. An override whose txn is gone (e.g. after a relink mints new ids, or
@@ -441,3 +459,52 @@ async def read_budget_bucket_transactions(
             for row in rows
         )
     return BudgetTransactionsResponse(bucket_id=bucket_id, transactions=transactions)
+
+
+@dataclass(frozen=True)
+class ClassifiedRow:
+    """One live classified transaction, as the Beancount exporter consumes it."""
+
+    transaction_id: str
+    date: date
+    amount: float
+    name: str
+    merchant_name: str | None
+    pfc_primary: str | None
+    pfc_detailed: str | None
+    account_id: str
+    bucket_id: str
+
+
+async def read_all_classified(
+    *, session_factory: async_sessionmaker[AsyncSession], config: BudgetConfig, window_start: date, window_end: date
+) -> tuple[ClassifiedRow, ...]:
+    """Return every live transaction in [window_start, window_end] with its bucket.
+
+    Unlike the snapshot/drilldown readers this returns all buckets at once and applies
+    no per-bucket filter -- it's the full projection the Beancount exporter renders.
+    Account scope comes from the configured source (``plaid_account_ids``).
+    """
+    stmt, params = _budget_query(
+        _EXPORT_TAIL,
+        config=config,
+        window_start=window_start,
+        window_end=window_end,
+        account_ids=tuple(config.source.plaid_account_ids),
+    )
+    async with session_factory() as session:
+        rows = (await session.execute(stmt, params)).mappings()
+        return tuple(
+            ClassifiedRow(
+                transaction_id=row["transaction_id"],
+                date=row["date"],
+                amount=float(row["amount"]),
+                name=row["name"],
+                merchant_name=row["merchant_name"],
+                pfc_primary=row["pfc_primary"],
+                pfc_detailed=row["pfc_detailed"],
+                account_id=row["account_id"],
+                bucket_id=row["bucket_id"],
+            )
+            for row in rows
+        )

--- a/augur/budget/test_sql_read_model.py
+++ b/augur/budget/test_sql_read_model.py
@@ -566,5 +566,36 @@ async def test_match_rule_account_condition(session_factory: async_sessionmaker[
     assert await _custom_bucket_txns(session_factory, config) == ["target_preempt"]
 
 
+async def test_read_all_classified_returns_every_live_txn_with_its_bucket(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await _seed_budget_rows(session_factory)
+    config = _budget_config()  # source.plaid_account_ids=("checking",), coverage_starts=2026-03-15
+
+    rows = await sql_read_model.read_all_classified(
+        session_factory=session_factory, config=config, window_start=date(2026, 3, 15), window_end=date(2026, 4, 30)
+    )
+
+    # Same classification as the snapshot, but flat (every bucket at once, no aggregation).
+    # Excludes the other-account, pending, removed, revoked-link, and out-of-window rows.
+    assert {row.transaction_id: row.bucket_id for row in rows} == {
+        "target_preempt": "custom",
+        "anthropic_default_skipped": "other",
+        "wealthfront_out": "transfers_out",
+        "wealthfront_in": "transfers_in",
+        "tax_refund": "tax_refunds",
+        "zero": "other",
+        "grocery_lumpy": "groceries",
+        "payroll": "income",
+    }
+    # Ordered by (date, transaction_id); carries the fields the exporter renders.
+    assert [(row.date, row.transaction_id) for row in rows] == sorted((row.date, row.transaction_id) for row in rows)
+    grocery = next(row for row in rows if row.transaction_id == "grocery_lumpy")
+    assert grocery.amount == 1000.0
+    assert grocery.account_id == "checking"
+    assert grocery.merchant_name == "Grocery"
+    assert grocery.pfc_primary == "FOOD_AND_DRINK"
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/finance/beancount_export/BUILD.bazel
+++ b/finance/beancount_export/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devinfra/python:defs.bzl", "py_library", "py_test")
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -9,6 +9,27 @@ py_library(
         "//augur/budget:schema",
         "@pypi//beancount",
     ],
+)
+
+py_library(
+    name = "runner",
+    srcs = ["runner.py"],
+    deps = [
+        ":export",
+        "//augur/budget:schema",
+        "//augur/budget:sql_read_model",
+        "//plaid_utils:schema",
+        "@pypi//beancount",
+        "@pypi//pyyaml",
+        "@pypi//structlog",
+        "@pypi//typer",
+    ],
+)
+
+py_binary(
+    name = "export_ledger",
+    main_module = "finance.beancount_export.runner",
+    deps = [":runner"],
 )
 
 py_test(

--- a/finance/beancount_export/runner.py
+++ b/finance/beancount_export/runner.py
@@ -1,0 +1,200 @@
+"""Budget Beancount exporter runner.
+
+Reads the Plaid mirror, classifies every live transaction with augur's budget
+read model (the same classification the in-app budget uses), renders a Beancount
+ledger (:mod:`finance.beancount_export.export`), and either writes it to a file
+(``render``) or commits it to a git repo (``sync``, used by the CronJob).
+
+The exporter is a pure, deterministic function of (mirror + config): re-running
+it produces byte-identical output, so ``sync`` only commits when the ledger
+actually changed -- no spurious commits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import tempfile
+from datetime import date
+from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import structlog
+import typer
+import yaml
+from beancount import loader
+from beancount.parser import printer
+
+from augur.budget.schema import BudgetConfig
+from augur.budget.sql_read_model import ClassifiedRow, read_all_classified
+from finance.beancount_export.export import ClassifiedTxn, render_ledger
+from plaid_utils.schema import async_session_factory
+
+log = structlog.get_logger()
+
+# Where to read the config from when no --config is given (mirrors augur's convention).
+_AUGUR_CONFIG_PATH_ENV = "AUGUR_CONFIG_PATH"
+_DEFAULT_CONFIG_PATH = Path("/etc/augur/config.yaml")
+
+app = typer.Typer(help="Render / sync the budget Beancount ledger.", no_args_is_help=True)
+
+# Earliest date to scan when the config sets no coverage floor.
+_DEFAULT_FLOOR = date(2000, 1, 1)
+# Funding leg for any Plaid account not mapped in config.funding_accounts.
+_UNLINKED_ACCOUNT = "Equity:Unlinked"
+
+# Module-level typer option singletons (ruff B008: no calls in argument defaults).
+_OUT_OPTION = typer.Option(..., help="Path to write the ledger to.")
+_CONFIG_OPTION = typer.Option(None, "--config", help="augur config YAML (default: resolve).")
+_TITLE_OPTION = typer.Option("Budget", help='Ledger title (option "title").')
+_GIT_URL_OPTION = typer.Option(..., help="Ledger repo https URL (creds via GIT_USERNAME/GIT_PASSWORD env).")
+_BRANCH_OPTION = typer.Option("main", help="Branch to commit to.")
+_LEDGER_NAME_OPTION = typer.Option("main.beancount", help="File path within the repo.")
+_AUTHOR_NAME_OPTION = typer.Option("augur budget exporter", help="Commit author name.")
+_AUTHOR_EMAIL_OPTION = typer.Option("augur@allegedly.works", help="Commit author email.")
+
+
+def _load_budget_config(config_path: Path | None) -> BudgetConfig:
+    """Parse just the ``budget:`` block from the augur config YAML.
+
+    The exporter only needs the budget config (buckets/rules/overrides/funding), not
+    the rest of augur's Config, so it reads the block directly rather than validating
+    the whole augur Config -- keeping the exporter independent of the augur server.
+    """
+    path = config_path or Path(os.environ.get(_AUGUR_CONFIG_PATH_ENV, _DEFAULT_CONFIG_PATH))
+    raw = yaml.safe_load(path.read_text())
+    budget = raw.get("budget") if isinstance(raw, dict) else None
+    if budget is None:
+        raise typer.BadParameter(f"no `budget:` block in config {path}")
+    return BudgetConfig.model_validate(budget)
+
+
+def _database_url(config: BudgetConfig) -> str:
+    env_var = config.source.database_url_env
+    url = os.environ.get(env_var)
+    if not url:
+        raise typer.BadParameter(f"env var {env_var!r} (budget.source.database_url_env) is not set")
+    return url
+
+
+def _to_txn(row: ClassifiedRow, currency: str) -> ClassifiedTxn:
+    return ClassifiedTxn(
+        transaction_id=row.transaction_id,
+        date=row.date,
+        amount=row.amount,
+        name=row.name,
+        account_id=row.account_id,
+        bucket_id=row.bucket_id,
+        merchant_name=row.merchant_name,
+        pfc_primary=row.pfc_primary,
+        pfc_detailed=row.pfc_detailed,
+        iso_currency_code=currency,
+    )
+
+
+async def _read_rows(config: BudgetConfig, db_url: str, *, window_end: date) -> tuple[ClassifiedRow, ...]:
+    engine, session_factory = async_session_factory(db_url)
+    try:
+        window_start = config.source.coverage_starts or _DEFAULT_FLOOR
+        return await read_all_classified(
+            session_factory=session_factory, config=config, window_start=window_start, window_end=window_end
+        )
+    finally:
+        await engine.dispose()
+
+
+def build_ledger(config: BudgetConfig, db_url: str, *, window_end: date, title: str) -> str:
+    """Read + classify + render. Accounts not in funding_accounts fall back to Equity:Unlinked."""
+    rows = asyncio.run(_read_rows(config, db_url, window_end=window_end))
+    currency = config.source.iso_currency_code
+    funding = {f.plaid_account_id: f.account for f in config.funding_accounts}
+    for account_id in {row.account_id for row in rows}:
+        funding.setdefault(account_id, _UNLINKED_ACCOUNT)
+    buckets = {bucket.id: bucket for bucket in config.buckets}
+    ledger = render_ledger(
+        [_to_txn(row, currency) for row in rows], buckets, funding, title=title, operating_currency=currency
+    )
+    _validate(ledger)
+    log.info("rendered ledger", transactions=len(rows), accounts=len(funding), bytes=len(ledger))
+    return ledger
+
+
+def _validate(ledger: str) -> None:
+    """Parse the rendered ledger with beancount; raise if it has any errors.
+
+    Guards the sync path: a malformed ledger (unbalanced, account opened after use,
+    bad syntax) fails here instead of being committed to the repo.
+    """
+    _, errors, _ = loader.load_string(ledger)
+    if errors:
+        raise RuntimeError(
+            "rendered ledger failed beancount validation:\n"
+            + "\n".join(printer.format_error(error) for error in errors[:20])
+        )
+
+
+def _authenticated_url(url: str) -> str:
+    """Inject GIT_USERNAME/GIT_PASSWORD into an https URL, if both are set."""
+    user, password = os.environ.get("GIT_USERNAME"), os.environ.get("GIT_PASSWORD")
+    if not (user and password):
+        return url
+    parts = urlsplit(url)
+    netloc = f"{quote(user, safe='')}:{quote(password, safe='')}@{parts.hostname}"
+    if parts.port:
+        netloc += f":{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+    return result.stdout
+
+
+@app.command()
+def render(out: Path = _OUT_OPTION, config_path: Path | None = _CONFIG_OPTION, title: str = _TITLE_OPTION) -> None:
+    """Render the ledger to a local file (no git)."""
+    config = _load_budget_config(config_path)
+    out.write_text(build_ledger(config, _database_url(config), window_end=date.today(), title=title))
+    log.info("wrote ledger", path=str(out))
+
+
+@app.command()
+def sync(
+    git_url: str = _GIT_URL_OPTION,
+    branch: str = _BRANCH_OPTION,
+    ledger_name: str = _LEDGER_NAME_OPTION,
+    config_path: Path | None = _CONFIG_OPTION,
+    title: str = _TITLE_OPTION,
+    author_name: str = _AUTHOR_NAME_OPTION,
+    author_email: str = _AUTHOR_EMAIL_OPTION,
+) -> None:
+    """Render the ledger and commit+push it to the repo, only if it changed."""
+    config = _load_budget_config(config_path)
+    ledger = build_ledger(config, _database_url(config), window_end=date.today(), title=title)
+
+    url = _authenticated_url(git_url)
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        _git(Path(tmp), "clone", "--depth", "1", "--branch", branch, url, str(repo))
+        (repo / ledger_name).write_text(ledger)
+        if not _git(repo, "status", "--porcelain").strip():
+            log.info("ledger unchanged; nothing to commit")
+            return
+        _git(repo, "add", ledger_name)
+        _git(
+            repo,
+            "-c",
+            f"user.name={author_name}",
+            "-c",
+            f"user.email={author_email}",
+            "commit",
+            "-m",
+            f"budget ledger: {date.today().isoformat()}",
+        )
+        _git(repo, "push", "origin", branch)
+        log.info("pushed ledger", branch=branch, ledger=ledger_name)
+
+
+if __name__ == "__main__":
+    app()

--- a/plaid_utils/BUILD.bazel
+++ b/plaid_utils/BUILD.bazel
@@ -44,6 +44,7 @@ py_library(
     srcs = ["schema.py"],
     visibility = [
         "//augur:__subpackages__",
+        "//finance/beancount_export:__pkg__",
         "//plaid_utils:__subpackages__",
     ],
     deps = [


### PR DESCRIPTION
Builds the **exporter runner** — the next piece of the budget → Beancount → Fava pipeline (after #1941, #1942). The runner reads the live Plaid mirror, classifies every transaction with augur's **exact** budget classification, and renders a Beancount ledger.

## What's here
- **`sql_read_model.read_all_classified()` + `ClassifiedRow`**: every live txn with its bucket, via the *same* `classified_tx` CTE the in-app budget's snapshot/drilldown use — just one more `SELECT` tail, no reimplemented rules. So the exported ledger and the budget UI can never disagree about a transaction's bucket. Tested against the seeded testcontainers harness (account-scope, pending/removed/revoked/out-of-window exclusion, classification, ordering).
- **`BudgetConfig.funding_accounts`**: Plaid `account_id` → Beancount funding account (the leg opposite the bucket's contra account). Optional; unmapped accounts fall back to `Equity:Unlinked`.
- **`runner.py` (`export_ledger` binary)**: reads just the `budget:` block from the augur config YAML (no `augur.api.config` dep → the exporter stays independent of the server), builds the ledger, and **self-validates** it with `beancount.loader` before output. `render` writes a file; `sync` commits+pushes to the ledger repo only when it changed (used by the upcoming CronJob).

## Verified against the live mirror
Ran `export_ledger render` against the cluster Plaid DB (port-forward): **2322 transactions → a 601 KB ledger that passes beancount validation**. Spot-checks: the \$6,825.84 "Returned Payment" → `Equity:Transfers:TransfersOut` and Herman Miller → `Expenses:Gifts` overrides, and The Willows → `Expenses:RestaurantsInPerson`, all render to the right accounts with `plaid-id`/`bucket`/`plaid-pfc` reconciliation metadata.

## Next (separate PRs)
Forgejo ledger repo (tofu-controller), the exporter CronJob, and the Fava deployment (behind authentik). Also queued: extracting the shared Postgres testcontainers harness (duplicated across `augur/budget` + `plaid_utils` tests) into `util/testing`.