### PR TITLE
tf/gitops/budget-ledger: reflect git creds into augur ns

### DIFF
--- a/tf/gitops/budget-ledger/main.tf
+++ b/tf/gitops/budget-ledger/main.tf
@@ -44,11 +44,19 @@ resource "forgejo_repository" "ledger" {
   auto_init = true
 }
 
-# Git credentials for the exporter + Fava, in the budget namespace.
+# Git credentials for the exporter + Fava, in the budget namespace. Reflected into
+# the augur namespace (emberstack reflector) so the exporter CronJob -- which runs
+# alongside augur to reuse its config ConfigMap + plaid DB creds -- can read them.
 resource "kubernetes_secret" "budget_ledger_git_creds" {
   metadata {
     name      = "budget-ledger-git-creds"
     namespace = "budget"
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "augur"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "augur"
+    }
   }
 
   data = {


### PR DESCRIPTION
Small follow-up to #1944: the exporter CronJob will run in the **augur** namespace (to reuse augur's config ConfigMap + plaid DB creds), so `budget-ledger-git-creds` is reflected from `budget`→`augur` via emberstack reflector annotations. The gaffer-private CronJob then reads `GIT_USERNAME`/`GIT_PASSWORD` from the reflected copy.