### PR TITLE
cluster/budget: Fava behind authentik (agentydragon-only)

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/fava-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/fava-sso.yaml
@@ -1,0 +1,40 @@
+version: 1
+metadata:
+  name: SSO - Fava
+  labels:
+    blueprints.goauthentik.io/description: "Fava (Beancount UI) proxy provider, application, and single-user access binding"
+
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    id: fava-provider
+    state: present
+    identifiers:
+      name: fava
+    attrs:
+      external_host: "https://fava.allegedly.works"
+      internal_host: "http://fava.budget.svc.cluster.local:5000"
+      mode: proxy
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: "hours=24"
+
+  - model: authentik_core.application
+    id: fava-app
+    state: present
+    identifiers:
+      slug: fava
+    attrs:
+      name: Fava
+      provider: !KeyOf fava-provider
+      meta_description: "Budget Beancount ledger (read-only web UI)"
+      meta_launch_url: "https://fava.allegedly.works"
+      open_in_new_tab: true
+
+  # Restrict access to the single user agentydragon (mirrors openhands-sso).
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !KeyOf fava-app
+      user: !Find [authentik_core.user, [username, agentydragon]]
+      order: 0

--- a/cluster/k8s/authentik/app/kustomization.yaml
+++ b/cluster/k8s/authentik/app/kustomization.yaml
@@ -32,4 +32,5 @@ configMapGenerator:
       - blueprints/study-casino-sso.yaml
       - blueprints/claude-service-account.yaml
       - blueprints/openhands-sso.yaml
+      - blueprints/fava-sso.yaml
     namespace: authentik

--- a/cluster/k8s/authentik/proxy-routes/fava-httproute.yaml
+++ b/cluster/k8s/authentik/proxy-routes/fava-httproute.yaml
@@ -1,0 +1,18 @@
+# HTTPRoute for Fava via the shared Authentik proxy outpost.
+# Traffic flows: Gateway -> outpost (auth, agentydragon-only) -> fava backend.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: fava
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "fava.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/authentik/proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik/proxy-routes/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - sdr-httproute.yaml
   - adsb-httproute.yaml
   - openhands-httproute.yaml
+  - fava-httproute.yaml

--- a/cluster/k8s/budget/app/deployment.yaml
+++ b/cluster/k8s/budget/app/deployment.yaml
@@ -1,0 +1,134 @@
+# Fava serves the budget Beancount ledger that the exporter CronJob commits to the
+# Forgejo budget-ledger repo. A git-sync sidecar keeps a local checkout fresh; Fava
+# reads /ledger/current/main.beancount and auto-reloads on change. Access is gated
+# by authentik (agentydragon-only) via the proxy outpost -- Fava has no native auth.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fava
+  namespace: budget
+  labels:
+    app.kubernetes.io/name: fava
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fava
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fava
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65533 # git-sync's default uid; Fava runs as the same uid to read the checkout
+        runAsGroup: 65533
+        fsGroup: 65533
+      initContainers:
+        # One-time clone so /ledger/current/main.beancount exists before Fava starts.
+        - name: git-sync-init
+          image: registry.k8s.io/git-sync/git-sync:v4.3.0
+          args:
+            - --repo=http://forgejo-http.forgejo:3000/budget-ledger/ledger.git
+            - --root=/ledger
+            - --link=current
+            - --depth=1
+            - --one-time
+          env:
+            - name: GITSYNC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: budget-ledger-git-creds
+                  key: username
+            - name: GITSYNC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: budget-ledger-git-creds
+                  key: password
+          volumeMounts:
+            - name: ledger
+              mountPath: /ledger
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.3.0
+          args:
+            - --repo=http://forgejo-http.forgejo:3000/budget-ledger/ledger.git
+            - --root=/ledger
+            - --link=current
+            - --depth=1
+            - --period=300s
+          env:
+            - name: GITSYNC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: budget-ledger-git-creds
+                  key: username
+            - name: GITSYNC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: budget-ledger-git-creds
+                  key: password
+          volumeMounts:
+            - name: ledger
+              mountPath: /ledger
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+        - name: fava
+          image: docker.io/yegle/fava:latest
+          command:
+            - fava
+            - --host
+            - 0.0.0.0
+            - --port
+            - "5000"
+            - /ledger/current/main.beancount
+          ports:
+            - name: http
+              containerPort: 5000
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: ledger
+              mountPath: /ledger
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: ledger
+          emptyDir: {}

--- a/cluster/k8s/budget/app/flux-kustomization.yaml
+++ b/cluster/k8s/budget/app/flux-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: budget-app
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster/k8s/budget/app
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: budget-namespace
+    - name: budget-ledger # provisions budget-ledger-git-creds in the budget ns
+    - name: gateway
+    - name: authentik

--- a/cluster/k8s/budget/app/kustomization.yaml
+++ b/cluster/k8s/budget/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/cluster/k8s/budget/app/service.yaml
+++ b/cluster/k8s/budget/app/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fava
+  namespace: budget
+  labels:
+    app.kubernetes.io/name: fava
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: fava
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http
+      protocol: TCP

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -188,6 +188,7 @@ resources:
 
   # --- budget (Beancount ledger + exporter + Fava) ---
   - budget/namespace/flux-kustomization.yaml
+  - budget/app/flux-kustomization.yaml
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml


### PR DESCRIPTION
PR-D, the last build piece of the budget pipeline: **Fava** serving the Beancount ledger, behind authentik, restricted to `agentydragon`.

- **`cluster/k8s/budget/app/`** — Fava Deployment with a **git-sync sidecar** (clones the Forgejo `budget-ledger` repo via `budget-ledger-git-creds` into an emptyDir; Fava reads `/ledger/current/main.beancount` and auto-reloads) + Service + flux Kustomization.
- **authentik** — a Proxy Provider + Application bound to **only the `agentydragon` user** via a `PolicyBinding` (mirrors `openhands-sso`), and an HTTPRoute sending `fava.allegedly.works` through the shared authentik outpost (Fava has no native auth).
- Registered the flux Kustomization, the blueprint (configMapGenerator), and the HTTPRoute.

Validated: kubeconform + kustomize build (budget/app, authentik/proxy-routes, authentik/app) + cluster-validate all pass.

## Notes to verify post-deploy (can't pull/run images from here)
- **Fava image** `docker.io/yegle/fava` and **git-sync** `registry.k8s.io/git-sync/git-sync:v4.3.0` are best-effort pins — I'll confirm the exact image/tag + the fava CLI invocation + git-sync↔fava file permissions from pod logs once it's up. (If `yegle/fava` is stale, I'll switch to a first-party bazel-built fava image.)
- Fava only has data once the **exporter has pushed a ledger** — until the first export the repo holds just the `auto_init` README, so Fava will report a missing file. Depends on the image reaching ghcr (the current GitHub-outage blocker for the CronJob run).