### PR TITLE
authentik: assign the fava proxy provider to the embedded outpost

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -36,3 +36,4 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, sdr]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, adsb]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, openhands]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, fava]]


### PR DESCRIPTION
Fixes the fava login failure (Google `redirect_uri_mismatch`).

#1948 created the fava Proxy Provider + Application + single-user binding, but the embedded outpost's provider list is **enumerated explicitly** in `embedded-outpost.yaml` and I forgot to add `fava`. So the embedded outpost never served `fava.allegedly.works`.

Symptom: with no proxy provider registered for that host, hitting `fava.allegedly.works` reached authentik-server with `Host: fava.allegedly.works`, and authentik built the Google OAuth `redirect_uri` against *that* host (`https://fava.allegedly.works/...`) — which isn't in the Google client's authorized list → `redirect_uri_mismatch`. (That's why you saw a fresh Google prompt instead of SSO off your existing auth.allegedly.works session.)

Fix: add `fava` to the embedded outpost's providers. After this reconciles, `fava.allegedly.works` goes through the proxy outpost → authentik authorize at `auth.allegedly.works` → your existing session → straight through (agentydragon-only).