### PR TITLE
augur/calibration: derive market probabilities from quotes, not last trade

### DIFF
--- a/finance/augur/TODO.md
+++ b/finance/augur/TODO.md
@@ -53,18 +53,19 @@ Remaining:
 
 - [ ] **Macro level fans** in the calibration view via a generalized `level_fan`
       (today's `mark_fan` is PE-only).
-- [ ] **Prediction-market quote quality.** Calibration currently consumes each
-      platform client's single `Market.probability` value, which for Kalshi is
-      the last-trade price. Track bid and ask separately in the platform model,
-      surface stale/wide/no-quote states, and decide whether scoring should use
-      midpoint, last, or a conservative interval per platform/market family.
-  - [ ] **Honest naming.** Markets expose last trade / bid / ask, not a
-        "probability". `Market.probability` / `require_probability` is really the
-        last-trade price read as an implied probability; the calibrated value comes
-        from the separate price→probability smoothing step. Rename to something like
-        `last_trade_price` / `implied_probability` so it doesn't read as a calibrated
-        probability (cross-cutting across the platform clients + calibration). See the
-        TODO at `augur/calibration/platform.py:Market.probability`.
+- [ ] **Prediction-market quote quality.** _Mostly landed:_ `Market` now carries a structured
+      `quote` (`calibration/quote.py`: `BookQuote` bid/ask/size/last, `PoolQuote` for AMMs);
+      `implied_probability` uses the Stoikov micro-price (mid-else-vol-backed-last-else-None, no
+      fake `0`/`0.5`); ladders aggregate via confidence-weighted isotonic regression + discrete
+      Breeden–Litzenberger differencing (`calibration._fit_ladder_curve`). RCA + before/after in
+      `augur/debug/cpi_yoy_market_line_spikiness.md`. **Remaining:**
+  - [ ] **Surface quote quality in the UI.** Show stale / wide-spread / one-sided / no-quote
+        states (and per-rung confidence) in `frontend/calibration.tsx`; today low-confidence rungs
+        are silently down-weighted in the fit but the user can't see which.
+  - [ ] **Polymarket depth for micro-price.** The gamma response carries best bid/ask but no size,
+        so Polymarket degenerates to the plain midpoint; fetch the CLOB order book for true depth.
+  - [x] **Honest naming.** `Market.probability` / `require_probability` renamed to
+        `Market.quote` / `require_implied_probability`; markets expose quotes, not probabilities.
 - [ ] **Aggregate metric (later, weighting TBD).** Per-channel / volume-weighted
       rollups of per-market KL once the weighting policy is decided.
 

--- a/finance/augur/calibration/BUILD.bazel
+++ b/finance/augur/calibration/BUILD.bazel
@@ -8,9 +8,15 @@ filegroup(
 )
 
 py_library(
+    name = "quote",
+    srcs = ["quote.py"],
+    deps = [],
+)
+
+py_library(
     name = "platform",
     srcs = ["platform.py"],
-    deps = [],
+    deps = [":quote"],
 )
 
 py_library(
@@ -50,6 +56,7 @@ py_library(
     srcs = ["manifold.py"],
     deps = [
         ":platform",
+        ":quote",
         ":transient_retry",
         "@pypi//httpx",
         "@pypi//pydantic",
@@ -61,6 +68,7 @@ py_library(
     srcs = ["polymarket.py"],
     deps = [
         ":platform",
+        ":quote",
         ":transient_retry",
         "@pypi//polymarket_client",
     ],
@@ -71,6 +79,7 @@ py_library(
     srcs = ["kalshi.py"],
     deps = [
         ":platform",
+        ":quote",
         ":transient_retry",
         "@pypi//httpx",
         "@pypi//pydantic",
@@ -94,6 +103,7 @@ py_library(
     srcs = ["redis_cache.py"],
     deps = [
         ":platform",
+        ":quote",
         "@pypi//py_key_value_aio",
         "@pypi//pydantic",
         "@pypi//valkey_glide",
@@ -108,6 +118,7 @@ py_library(
         ":kalshi",
         ":manifold",
         ":platform",
+        ":quote",
         "@pypi//httpx",
     ],
 )
@@ -119,6 +130,7 @@ py_library(
         ":catalog",
         ":manifold",
         ":platform",
+        ":quote",
         ":resolvers",
         "//finance/augur/model:exogenous",
         "//finance/augur/model:private_equity_bundle",
@@ -177,6 +189,17 @@ py_binary(
 )
 
 py_test(
+    name = "test_quote",
+    srcs = ["test_quote.py"],
+    deps = [
+        ":quote",
+        "//:conftest",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_resolvers",
     srcs = ["test_resolvers.py"],
     deps = [
@@ -210,6 +233,7 @@ py_test(
     deps = [
         ":calibration",
         ":catalog",
+        ":quote",
         ":testing",
         "//:conftest",
         "//finance/augur/model:exogenous",
@@ -240,6 +264,7 @@ py_test(
     srcs = ["test_manifold.py"],
     deps = [
         ":manifold",
+        ":quote",
         ":testing",
         "//:conftest",
         "@pypi//httpx",
@@ -254,6 +279,7 @@ py_test(
     srcs = ["test_redis_cache.py"],
     deps = [
         ":platform",
+        ":quote",
         ":redis_cache",
         "//:conftest",
         "@pypi//pytest",

--- a/finance/augur/calibration/calibration.py
+++ b/finance/augur/calibration/calibration.py
@@ -50,6 +50,7 @@ from finance.augur.calibration.catalog import (
     ThresholdLadderFamily,
 )
 from finance.augur.calibration.platform import Direction, Market, Platform, PriceClient
+from finance.augur.calibration.quote import implied_probability, quote_confidence
 from finance.augur.calibration.resolvers import (
     Resolution,
     ResolutionCounts,
@@ -251,7 +252,7 @@ class MarkFan(BaseModel):
 
 
 def _clean_row(market: ExactMarket, counts: ResolutionCounts, live: Market, *, channel: str | None) -> CleanRow:
-    p_market = live.require_probability()
+    p_market = live.require_implied_probability()
     p_model = counts.p_model
     return CleanRow(
         market_id=market.market_id,
@@ -423,22 +424,28 @@ def _threshold_ladder_row(
     family: ThresholdLadderFamily,
     *,
     level_paths: Mapping[LevelSeriesKey, npt.NDArray[np.float64]],
-    live_prices: list[float],
+    live_markets: list[Market | None],
     as_of: date,
     horizon_months: int,
     inflation_history: npt.NDArray[np.float64] | None,
-) -> CategoricalRow:
+) -> CategoricalRow | None:
     """Convert cumulative threshold contracts into one categorical distribution row.
 
     `family.thresholds` are cumulative contracts, not buckets: for `direction=above`,
-    each live price is a survival point `P(value > threshold)`; for `direction=below`,
-    each is a CDF point `P(value < threshold)`. Fit the points to a monotone curve and
-    difference adjacent thresholds into bucket probabilities.
+    each rung is a survival point `P(value > threshold)`; for `direction=below`,
+    each is a CDF point `P(value < threshold)`. Each priced rung contributes its implied
+    probability (mid/micro-price) with a confidence weight; a confidence-weighted monotone fit
+    interpolates across unpriced rungs, and differencing adjacent thresholds recovers the bucket
+    probabilities (the discrete Breeden-Litzenberger identity). Returns None when fewer than two
+    rungs are priced (no curve to fit).
     """
-    ordered = sorted(zip(family.thresholds, live_prices, strict=True), key=lambda item: item[0].threshold)
-    thresholds = [member.threshold for member, _price in ordered]
-    raw_curve = [price for _member, price in ordered]
-    fitted_curve = _monotone_probabilities(raw_curve, increasing=family.direction is Direction.BELOW)
+    ordered = sorted(zip(family.thresholds, live_markets, strict=True), key=lambda item: item[0].threshold)
+    thresholds = [member.threshold for member, _market in ordered]
+    fitted_curve = _fit_ladder_curve(
+        thresholds, [market for _member, market in ordered], increasing=family.direction is Direction.BELOW
+    )
+    if fitted_curve is None:
+        return None
     derived_buckets = _threshold_ladder_buckets(family, thresholds=thresholds, curve=fitted_curve)
     lows = [bucket.low for bucket in derived_buckets]
     highs = [bucket.high for bucket in derived_buckets]
@@ -488,13 +495,22 @@ def _threshold_ladder_row(
 
 
 def _date_ladder_row(
-    family: DateLadderFamily, *, trajectories_by_issuer: Mapping[str, list[RolloutTrajectory]], live_prices: list[float]
-) -> CategoricalRow:
-    """Convert cumulative event-by-date contracts into one timing distribution row."""
-    ordered = sorted(zip(family.dates, live_prices, strict=True), key=lambda item: item[0].by_date)
-    by_dates = [member.by_date for member, _price in ordered]
-    raw_curve = [price for _member, price in ordered]
-    fitted_curve = _monotone_probabilities(raw_curve, increasing=True)
+    family: DateLadderFamily,
+    *,
+    trajectories_by_issuer: Mapping[str, list[RolloutTrajectory]],
+    live_markets: list[Market | None],
+) -> CategoricalRow | None:
+    """Convert cumulative event-by-date contracts into one timing distribution row.
+
+    Returns None when fewer than two dates are priced (no curve to fit).
+    """
+    ordered = sorted(zip(family.dates, live_markets, strict=True), key=lambda item: item[0].by_date)
+    by_dates = [member.by_date for member, _market in ordered]
+    fitted_curve = _fit_ladder_curve(
+        [float(by_date.toordinal()) for by_date in by_dates], [market for _member, market in ordered], increasing=True
+    )
+    if fitted_curve is None:
+        return None
     derived_buckets = _date_ladder_buckets(family, by_dates=by_dates, curve=fitted_curve)
     trajectories = trajectories_by_issuer.get(family.issuer)
     model_counts = None if trajectories is None else ipo_by_date_bucket_counts(trajectories, by_dates=by_dates)
@@ -523,14 +539,62 @@ def _date_ladder_row(
     )
 
 
-def _monotone_probabilities(values: list[float], *, increasing: bool) -> list[float]:
-    """Least-squares monotone fit for probabilities using the pool-adjacent-violators algorithm."""
+def _fit_ladder_curve(positions: list[float], markets: list[Market | None], *, increasing: bool) -> list[float] | None:
+    """Fit a monotone cumulative curve to a ladder's priced rungs and evaluate it at every rung.
+
+    `positions` are the rungs' numeric coordinates (thresholds, or date ordinals) in ascending
+    order, aligned with `markets`. Each priced rung contributes its implied probability with a
+    confidence weight; weighted isotonic regression yields a monotone fit through the priced rungs,
+    which is then linearly interpolated (flat past the ends) at every rung's position so the
+    configured bucket structure is preserved even where a rung was unpriced. Returns None when
+    fewer than two rungs are priced.
+    """
+    observed: list[tuple[float, float, float]] = []  # (position, implied probability, weight)
+    for position, market in zip(positions, markets, strict=True):
+        if market is None:
+            continue
+        probability = implied_probability(market.quote, volume=market.volume)
+        if probability is None:
+            continue
+        observed.append((position, probability, quote_confidence(market.quote, volume=market.volume)))
+    if len(observed) < 2:
+        return None
+    fitted_observed = _monotone_probabilities(
+        [probability for _position, probability, _weight in observed],
+        [weight for _position, _weight, weight in observed],
+        increasing=increasing,
+    )
+    observed_positions = [position for position, _probability, _weight in observed]
+    return [_interpolate(position, observed_positions, fitted_observed) for position in positions]
+
+
+def _interpolate(x: float, xs: list[float], ys: list[float]) -> float:
+    """Piecewise-linear interpolation of `ys` at `x`, holding the end values flat past `xs`'
+    range. `xs` is ascending; preserves monotonicity of `ys`."""
+    if x <= xs[0]:
+        return ys[0]
+    if x >= xs[-1]:
+        return ys[-1]
+    for left in range(len(xs) - 1):
+        if xs[left] <= x <= xs[left + 1]:
+            span = xs[left + 1] - xs[left]
+            if span == 0.0:
+                return ys[left]
+            t = (x - xs[left]) / span
+            return ys[left] + t * (ys[left + 1] - ys[left])
+    return ys[-1]
+
+
+def _monotone_probabilities(values: list[float], weights: list[float], *, increasing: bool) -> list[float]:
+    """Weighted least-squares monotone fit for probabilities via the pool-adjacent-violators
+    algorithm. `weights` are per-point confidences: a high-weight point pins the curve while a
+    low-weight one is freely pooled toward its neighbors."""
     y = [max(0.0, min(1.0, float(value))) for value in values]
     if not increasing:
         y = [-value for value in y]
     blocks: list[_PavaBlock] = []
-    for i, value in enumerate(y):
-        blocks.append(_PavaBlock(start=i, end=i, weight=1.0, value_sum=value))
+    for i, (value, weight) in enumerate(zip(y, weights, strict=True)):
+        blocks.append(_PavaBlock(start=i, end=i, weight=weight, value_sum=value * weight))
         while len(blocks) >= 2 and blocks[-2].average > blocks[-1].average:
             right = blocks.pop()
             left = blocks.pop()
@@ -762,7 +826,7 @@ def _surfaced_row(
         platform=market.platform,
         mappability=market.mappability,
         correlate_of=market.correlate_of if isinstance(market, CorrelateMarket) else None,
-        p_market=live.require_probability(),
+        p_market=live.require_implied_probability(),
         reason=" ".join(market.reason.split()) if market.reason else None,
         augur_context=_augur_context(market, trajectories_by_issuer),
         volume=live.volume,
@@ -819,7 +883,7 @@ def _unmodeled_row(market: ExactMarket, live: Market, target: str) -> SurfacedRo
         url=live.url,
         platform=market.platform,
         mappability="unmodeled",
-        p_market=live.require_probability(),
+        p_market=live.require_implied_probability(),
         reason=f"{target!r} is not emitted by this model preset",
         volume=live.volume,
         volume_unit=live.volume_unit,
@@ -868,10 +932,11 @@ async def run_calibration(
     fetch_slots = asyncio.Semaphore(_MAX_CONCURRENT_MARKET_FETCHES)
 
     async def _live(market_id: str, platform: Platform) -> Market | None:
-        # A single broken catalog row (bad market_id), a transient API hiccup, or a market the
-        # platform priced as None (e.g. Kalshi `last_price_dollars: null`) must not 500 the whole
-        # calibration endpoint -- log + drop just that row instead. Dropping None-probability
-        # markets here keeps every downstream `require_probability()` call safe.
+        # A single broken catalog row (bad market_id), a transient API hiccup, or a market whose
+        # quote carries no information (untraded / one-sided book, no usable last trade) must not
+        # 500 the whole calibration endpoint -- log + drop just that row instead. Dropping markets
+        # with no implied probability here keeps every downstream `require_implied_probability()`
+        # call safe; ladder families tolerate dropped rungs by interpolating across them.
         async with fetch_slots:
             try:
                 market = await price_clients[platform].get_market(market_id)
@@ -880,8 +945,8 @@ async def run_calibration(
                     "dropping calibration row: %s market %r failed to fetch", platform, market_id, exc_info=True
                 )
                 return None
-        if market.probability is None:
-            logger.warning("dropping calibration row: %s market %r returned no YES probability", platform, market_id)
+        if implied_probability(market.quote, volume=market.volume) is None:
+            logger.warning("dropping calibration row: %s market %r carried no informative quote", platform, market_id)
             return None
         return market
 
@@ -940,7 +1005,7 @@ async def run_calibration(
                 "dropping categorical family %r: a bucket failed to fetch or had no price", bucket_family.family_id
             )
             continue
-        live_prices = [live.require_probability() for live in prices if live is not None]
+        live_prices = [live.require_implied_probability() for live in prices if live is not None]
         total = sum(live_prices)
         # Degenerate normalizer (all-zero / non-finite prices) can't form a valid categorical.
         if not math.isfinite(total) or total <= 0.0:
@@ -952,37 +1017,32 @@ async def run_calibration(
             )
         )
     for threshold_family in catalog.threshold_ladder_families:
-        prices = [
+        # Unlike a bucket family, a ladder tolerates dropped rungs: the monotone fit interpolates
+        # across an untraded/illiquid threshold rather than discarding the whole family.
+        threshold_markets = [
             live_markets[threshold_family.platform, threshold.market_id] for threshold in threshold_family.thresholds
         ]
-        if any(live is None for live in prices):
+        row = _threshold_ladder_row(
+            threshold_family,
+            level_paths=paths,
+            live_markets=threshold_markets,
+            as_of=as_of,
+            horizon_months=horizon_months,
+            inflation_history=inflation_history_array,
+        )
+        if row is None:
             logger.warning(
-                "dropping threshold ladder family %r: a threshold failed to fetch or had no price",
-                threshold_family.family_id,
+                "dropping threshold ladder family %r: fewer than 2 priced thresholds", threshold_family.family_id
             )
             continue
-        live_prices = [live.require_probability() for live in prices if live is not None]
-        categorical.append(
-            _threshold_ladder_row(
-                threshold_family,
-                level_paths=paths,
-                live_prices=live_prices,
-                as_of=as_of,
-                horizon_months=horizon_months,
-                inflation_history=inflation_history_array,
-            )
-        )
+        categorical.append(row)
     for date_family in catalog.date_ladder_families:
-        prices = [live_markets[date_family.platform, date_member.market_id] for date_member in date_family.dates]
-        if any(live is None for live in prices):
-            logger.warning(
-                "dropping date ladder family %r: a date failed to fetch or had no price", date_family.family_id
-            )
+        date_markets = [live_markets[date_family.platform, date_member.market_id] for date_member in date_family.dates]
+        row = _date_ladder_row(date_family, trajectories_by_issuer=trajectories_by_issuer, live_markets=date_markets)
+        if row is None:
+            logger.warning("dropping date ladder family %r: fewer than 2 priced dates", date_family.family_id)
             continue
-        live_prices = [live.require_probability() for live in prices if live is not None]
-        categorical.append(
-            _date_ladder_row(date_family, trajectories_by_issuer=trajectories_by_issuer, live_prices=live_prices)
-        )
+        categorical.append(row)
 
     return CalibrationResult(
         as_of=as_of,

--- a/finance/augur/calibration/catalog.py
+++ b/finance/augur/calibration/catalog.py
@@ -14,7 +14,7 @@ resolver's contract -- resolution lives in ``resolvers.py`` and scoring in
 
 The catalog stores NEITHER live prices NOR human-readable market text (the
 ``question``/title and verbatim resolution criterion): all three are fetched live at
-scoring time via the platform clients (``Market.probability`` / ``.title`` / ``.rules``),
+scoring time via the platform clients (``Market.quote`` / ``.title`` / ``.rules``),
 so they can never drift from the platform. The catalog is the stable mapping + provenance
 (IDs, ``notes``) only.
 """

--- a/finance/augur/calibration/kalshi.py
+++ b/finance/augur/calibration/kalshi.py
@@ -1,8 +1,10 @@
 """Live Kalshi prices via their REST API.
 
-Read-only market lookups against the Kalshi Trade API v2 (no auth needed for
-public reads). Raw ``httpx`` — no official Python SDK exists. The API returns
-``last_price_dollars`` on a 0-1 scale (already a probability).
+Read-only market lookups against the Kalshi Trade API v2 (no auth needed for public reads). Raw
+``httpx`` — no official Python SDK exists. The API returns prices as stringified Decimals on a 0-1
+scale (``*_dollars``) and sizes as fixed-point strings (``*_fp``). We read the live order book
+(``yes_bid``/``yes_ask`` + resting sizes) rather than ``last_price``, which on a thin market can be
+a stale or sub-$1 fractional fill far from the book.
 """
 
 from __future__ import annotations
@@ -15,21 +17,37 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 
 from finance.augur.calibration.platform import Market
+from finance.augur.calibration.quote import BookQuote
 from finance.augur.calibration.transient_retry import httpx_is_transient, with_retry_async
 
 _BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
 _MARKET_URL_TEMPLATE = "https://kalshi.com/markets/{ticker}"
 
 
+def _book_side(price: float | None) -> float | None:
+    """A real top-of-book YES price, or None for the untraded placeholder (a 0 bid / a 1 ask)."""
+    return price if price is not None and 0.0 < price < 1.0 else None
+
+
+def _positive(size: float | None) -> float | None:
+    return size or None
+
+
 class _KalshiMarket(BaseModel):
     """The subset of Kalshi's `/markets/{ticker}` payload calibration needs.
 
-    `last_price_dollars` is a stringified Decimal on a 0-1 scale (already a probability);
-    `volume_fp` is all-time contracts traded (each Kalshi binary contract resolves $0-$1,
-    so contract count is an upper bound on dollar volume but not directly comparable)."""
+    `yes_bid_dollars`/`yes_ask_dollars` are the top-of-book YES quote (stringified Decimals on a 0-1
+    scale); `yes_bid_size_fp`/`yes_ask_size_fp` are the resting contract counts there.
+    `last_price_dollars` is the last trade — kept only as a one-sided fallback. `volume_fp` is
+    all-time contracts traded (each Kalshi binary contract resolves $0-$1, so contract count is an
+    upper bound on dollar volume but not directly comparable)."""
 
     model_config = ConfigDict(extra="ignore")
 
+    yes_bid_dollars: float | None = None
+    yes_ask_dollars: float | None = None
+    yes_bid_size_fp: float | None = None
+    yes_ask_size_fp: float | None = None
     last_price_dollars: float | None = None
     volume_fp: float | None = None
     # Title + verbatim resolution rules, surfaced live so the catalog needn't store/drift them.
@@ -95,7 +113,15 @@ class KalshiClient:
         return Market(
             id=market_id,
             url=_MARKET_URL_TEMPLATE.format(ticker=market_id),
-            probability=raw.last_price_dollars,
+            # Kalshi reports an absent book side as a 0 bid / a 1 ask (the 1-cent quote on the
+            # opposite outcome); map those placeholders to None so they don't read as a real quote.
+            quote=BookQuote(
+                bid=_book_side(raw.yes_bid_dollars),
+                ask=_book_side(raw.yes_ask_dollars),
+                bid_size=_positive(raw.yes_bid_size_fp),
+                ask_size=_positive(raw.yes_ask_size_fp),
+                last_trade=raw.last_price_dollars,
+            ),
             volume=raw.volume_fp,
             volume_unit="contracts" if raw.volume_fp is not None else None,
             title=title,
@@ -103,7 +129,7 @@ class KalshiClient:
         )
 
     async def fetch_yes_probability(self, market_id: str) -> float:
-        return (await self.get_market(market_id)).require_probability()
+        return (await self.get_market(market_id)).require_implied_probability()
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/finance/augur/calibration/manifold.py
+++ b/finance/augur/calibration/manifold.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from finance.augur.calibration.platform import Market
+from finance.augur.calibration.quote import PoolQuote
 from finance.augur.calibration.transient_retry import httpx_is_transient, with_retry_async
 
 _MARKET_ENDPOINT = "https://api.manifold.markets/v0/market/"
@@ -108,7 +109,9 @@ class ManifoldClient:
         return Market(
             id=raw.id,
             url=raw.url,
-            probability=raw.probability,
+            # Manifold is a CPMM AMM: its `probability` is the pool-implied fair price (a mid), with
+            # no separate order book — so a PoolQuote, not a BookQuote.
+            quote=PoolQuote(price=raw.probability) if raw.probability is not None else None,
             volume=raw.volume,
             volume_unit="𝕄",  # noqa: RUF001
             title=raw.question,
@@ -117,7 +120,7 @@ class ManifoldClient:
 
     async def fetch_yes_probability(self, market_id: str) -> float:
         """Current YES probability for one binary market; raises if it carries none."""
-        return (await self.get_market(market_id)).require_probability()
+        return (await self.get_market(market_id)).require_implied_probability()
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/finance/augur/calibration/platform.py
+++ b/finance/augur/calibration/platform.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Protocol
 
+from finance.augur.calibration.quote import Quote, implied_probability
+
 
 class Platform(StrEnum):
     MANIFOLD = "manifold"
@@ -46,13 +48,9 @@ class Market:
 
     id: str
     url: str
-    # TODO(naming): markets don't expose a "probability" — they expose a last trade / bid / ask, and
-    # `probability` here is really the last-trade price read as an implied probability (e.g. Kalshi
-    # `last_price_dollars`, Manifold `probability`, Polymarket yes.price). The actual probability comes
-    # from the separate price->probability smoothing step. Rename this (and `require_probability`) to
-    # something honest like `last_trade_price` / `implied_probability` so it doesn't read as a
-    # calibrated probability. Cross-cutting across the platform clients + calibration; see augur/TODO.md.
-    probability: float | None
+    # The live quote (order book or AMM pool price). `implied_probability(quote, volume=...)` turns
+    # it into a single YES probability; markets expose trades/quotes, not a probability directly.
+    quote: Quote
     volume: float | None = None
     volume_unit: str | None = None
     # The market's current title/question and verbatim resolution rules, fetched LIVE alongside the
@@ -61,10 +59,11 @@ class Market:
     title: str | None = None
     rules: str | None = None
 
-    def require_probability(self) -> float:
-        if self.probability is None:
-            raise ValueError(f"Market {self.id!r} returned no YES probability")
-        return self.probability
+    def require_implied_probability(self) -> float:
+        probability = implied_probability(self.quote, volume=self.volume)
+        if probability is None:
+            raise ValueError(f"Market {self.id!r} carried no informative quote")
+        return probability
 
 
 class PriceClient(Protocol):

--- a/finance/augur/calibration/polymarket.py
+++ b/finance/augur/calibration/polymarket.py
@@ -1,8 +1,10 @@
 """Live Polymarket prices via the ``polymarket-client`` SDK.
 
-Read-only market lookups using :class:`polymarket.PublicClient` (no auth
-required). The SDK's ``Market.outcomes.yes.price`` (a ``Decimal``) is converted
-to a plain ``float`` for the generic :class:`Market` probability.
+Read-only market lookups using :class:`polymarket.PublicClient` (no auth required). The gamma
+``Market.prices`` block already carries the top-of-book quote (``best_bid``/``best_ask``/
+``last_trade_price``) in the same response, so no extra CLOB call is needed. The gamma response
+does not surface resting size, so the order book is recorded without depth (the micro-price then
+degenerates to the plain midpoint).
 
 Same TTL-cache + clock-seam pattern as :class:`ManifoldClient` so the live
 calibration auto-refresh doesn't re-hit Polymarket per market per request.
@@ -28,6 +30,7 @@ from polymarket.errors import (
 )
 
 from finance.augur.calibration.platform import Market
+from finance.augur.calibration.quote import BookQuote
 from finance.augur.calibration.transient_retry import with_retry_async
 
 _POLYMARKET_BASE_URL = "https://polymarket.com/event"
@@ -41,10 +44,8 @@ def _polymarket_is_transient(exc: BaseException) -> bool:
     return isinstance(exc, RateLimitError | PolymarketTransportError | PolymarketTimeoutError)
 
 
-def _yes_price_to_probability(price: Decimal | None) -> float | None:
-    if price is None:
-        return None
-    return float(price)
+def _to_float(price: Decimal | None) -> float | None:
+    return None if price is None else float(price)
 
 
 class PolymarketClient:
@@ -89,17 +90,22 @@ class PolymarketClient:
 
     def _fetch(self, market_id: str) -> Market:
         pm_market = self._sdk.get_market(id=market_id)
-        probability = _yes_price_to_probability(
-            pm_market.outcomes.yes.price if pm_market.outcomes is not None else None
-        )
         slug = pm_market.slug or market_id
         # All-time traded volume in USD per the gamma `metrics.volume` field. The SDK's
         # Market.metrics is non-optional but each volume sub-field is.
         volume = float(pm_market.metrics.volume) if pm_market.metrics.volume is not None else None
+        prices = pm_market.prices
         return Market(
             id=market_id,
             url=f"{_POLYMARKET_BASE_URL}/{slug}",
-            probability=probability,
+            # Gamma carries the top-of-book quote but no resting size; depth is therefore unknown.
+            quote=BookQuote(
+                bid=_to_float(prices.best_bid),
+                ask=_to_float(prices.best_ask),
+                bid_size=None,
+                ask_size=None,
+                last_trade=_to_float(prices.last_trade_price),
+            ),
             volume=volume,
             volume_unit="USD" if volume is not None else None,
             title=pm_market.question,
@@ -107,7 +113,7 @@ class PolymarketClient:
         )
 
     async def fetch_yes_probability(self, market_id: str) -> float:
-        return (await self.get_market(market_id)).require_probability()
+        return (await self.get_market(market_id)).require_implied_probability()
 
     async def aclose(self) -> None:
         await asyncio.to_thread(self._sdk.__exit__, None, None, None)

--- a/finance/augur/calibration/quote.py
+++ b/finance/augur/calibration/quote.py
@@ -1,0 +1,115 @@
+"""Turn a prediction market's live quote into a probability estimate and a confidence weight.
+
+Markets do not emit a probability; they emit a *quote* — an order book (a bid and ask, each with
+resting size) on order-book platforms (Kalshi, Polymarket), or a single pool-implied price on an
+AMM (Manifold). The last trade is a poor signal: on a thin book it can be a stale or sub-$1
+fractional fill far from the live book. This module is the principled conversion layer:
+
+- :func:`implied_probability` — a single point estimate per market. For a two-sided book it is the
+  size-weighted micro-price (Stoikov), which corrects for order-book imbalance and degenerates to
+  the plain midpoint when sizes are absent or equal. An AMM pool price is already a fair mid. A
+  one-sided / empty book yields the volume-backed last trade only as a last resort, else ``None``
+  (no observation) — never a fabricated ``0.5`` mid or a fake ``0`` from an untraded contract.
+- :func:`quote_confidence` — an inverse-variance weight (tight, deep books pull hard; wide or thin
+  ones barely count) used to weight the isotonic fit when aggregating a ladder of markets into a
+  distribution. See ``calibration._monotone_probabilities``.
+
+A binary contract's bid/ask is a no-arbitrage band ``bid <= p <= ask``; the spread is the
+market's own statement of how uncertain it is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Confidence tuning knobs (not load-bearing semantics — they only set relative weights within one
+# ladder's isotonic fit). A perfectly tight book would otherwise get infinite weight, so the spread
+# is floored at one cent; a one-sided/last-only rung is a weak signal with a small fixed weight.
+_SPREAD_FLOOR = 0.01
+_ONE_SIDED_WEIGHT = 0.05
+
+
+@dataclass(frozen=True)
+class BookQuote:
+    """Top-of-book snapshot for an order-book binary market; prices in [0,1] YES-probability units.
+
+    Either side may be ``None`` (one-sided or empty book); ``*_size`` is the resting contract/share
+    quantity at that price (``None`` when the platform does not surface depth, e.g. Polymarket's
+    gamma response). ``last_trade`` may be present even with an empty book, but is only ever a
+    fallback — see :func:`implied_probability`.
+    """
+
+    bid: float | None
+    ask: float | None
+    bid_size: float | None
+    ask_size: float | None
+    last_trade: float | None
+
+    @property
+    def is_two_sided(self) -> bool:
+        """A genuine book on both sides — not the untraded placeholder (a 0 bid / a 1 ask, which
+        Kalshi reports for a contract with only a 1-cent quote on the opposite outcome)."""
+        return self.bid is not None and self.ask is not None and self.bid > 0.0 and self.ask < 1.0
+
+
+@dataclass(frozen=True)
+class PoolQuote:
+    """An AMM CPMM pool-implied price (Manifold) — already a fair mid, no separate order book."""
+
+    price: float
+
+
+Quote = BookQuote | PoolQuote | None
+
+
+def implied_probability(quote: Quote, *, volume: float | None) -> float | None:
+    """One YES-probability point estimate, or ``None`` when the quote carries no information.
+
+    ``volume`` is the market's all-time traded volume, used only to gate the one-sided last-trade
+    fallback (an untraded contract's ``last`` is meaningless).
+    """
+    match quote:
+        case PoolQuote(price=price):
+            return price
+        case BookQuote() as book:
+            if book.is_two_sided:
+                assert book.bid is not None
+                assert book.ask is not None
+                if book.bid_size and book.ask_size:
+                    # Stoikov micro-price: weight each side by the *opposite* side's size, so heavy
+                    # resting size on one side pulls the estimate toward the other quote.
+                    return (book.bid * book.ask_size + book.ask * book.bid_size) / (book.bid_size + book.ask_size)
+                return (book.bid + book.ask) / 2
+            return book.last_trade if (book.last_trade and volume) else None
+        case None:
+            return None
+
+
+def quote_confidence(quote: Quote, *, volume: float | None) -> float:
+    """Inverse-variance weight for aggregating this market into a ladder fit.
+
+    A two-sided book's variance grows with the squared spread and shrinks with resting depth (or
+    all-time volume when depth is unknown). A pool price is treated as an exact, depth-weighted
+    observation; a one-sided/last-only rung gets a small fixed weight; no observation gets zero.
+    """
+    match quote:
+        case PoolQuote():
+            return _depth_proxy(None, None, volume)
+        case BookQuote() as book:
+            if book.is_two_sided:
+                assert book.bid is not None
+                assert book.ask is not None
+                spread = max(book.ask - book.bid, _SPREAD_FLOOR)
+                return _depth_proxy(book.bid_size, book.ask_size, volume) / (spread * spread)
+            return _ONE_SIDED_WEIGHT
+        case None:
+            return 0.0
+
+
+def _depth_proxy(bid_size: float | None, ask_size: float | None, volume: float | None) -> float:
+    """How much size backs the quote: the thinner top-of-book side when known, else all-time
+    volume, else a neutral 1.0. Floored at 1.0 so a quote never gets zero confidence purely for
+    lacking a depth figure."""
+    if bid_size and ask_size:
+        return max(1.0, min(bid_size, ask_size))
+    return max(1.0, volume or 0.0)

--- a/finance/augur/calibration/redis_cache.py
+++ b/finance/augur/calibration/redis_cache.py
@@ -16,10 +16,13 @@ from key_value.aio.stores.valkey import ValkeyStore
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from finance.augur.calibration.platform import Market, Platform, PriceClient
+from finance.augur.calibration.quote import BookQuote, PoolQuote, Quote
 
 _LOGGER = logging.getLogger(__name__)
 
-_CACHE_COLLECTION = "augur-market-cache-v1"
+# v2: snapshots store the structured `quote` (book/pool), not the legacy single `probability`.
+_CACHE_COLLECTION = "augur-market-cache-v2"
+_CACHE_SCHEMA_VERSION = 2
 _DEFAULT_REDIS_PORT = 6379
 _DEFAULT_TTL_SECONDS = 12 * 60 * 60
 _DEFAULT_RETENTION_SECONDS = 48 * 60 * 60
@@ -48,7 +51,7 @@ class MarketSnapshot(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1)
+    schema_version: int = Field(default=_CACHE_SCHEMA_VERSION)
     platform: Platform
     market_id: str
     fetched_at_epoch_seconds: float
@@ -195,7 +198,11 @@ class RedisCachingPriceClient:
         except ValidationError:
             _LOGGER.warning("ignoring invalid cached %s market %r", self._platform.value, market_id, exc_info=True)
             return None
-        if snapshot.schema_version != 1 or snapshot.platform != self._platform or snapshot.market_id != market_id:
+        if (
+            snapshot.schema_version != _CACHE_SCHEMA_VERSION
+            or snapshot.platform != self._platform
+            or snapshot.market_id != market_id
+        ):
             _LOGGER.warning("ignoring mismatched cached %s market %r", self._platform.value, market_id)
             return None
         return snapshot
@@ -222,7 +229,7 @@ def _market_to_dict(market: Market) -> dict[str, Any]:
     return {
         "id": market.id,
         "url": market.url,
-        "probability": market.probability,
+        "quote": _quote_to_dict(market.quote),
         "volume": market.volume,
         "volume_unit": market.volume_unit,
         "title": market.title,
@@ -230,8 +237,52 @@ def _market_to_dict(market: Market) -> dict[str, Any]:
     }
 
 
+def _quote_to_dict(quote: Quote) -> dict[str, Any] | None:
+    match quote:
+        case BookQuote():
+            return {
+                "kind": "book",
+                "bid": quote.bid,
+                "ask": quote.ask,
+                "bid_size": quote.bid_size,
+                "ask_size": quote.ask_size,
+                "last_trade": quote.last_trade,
+            }
+        case PoolQuote(price=price):
+            return {"kind": "pool", "price": price}
+        case None:
+            return None
+
+
+def _quote_from_dict(data: dict[str, Any] | None) -> Quote:
+    if data is None:
+        return None
+    match data["kind"]:
+        case "book":
+            return BookQuote(
+                bid=data["bid"],
+                ask=data["ask"],
+                bid_size=data["bid_size"],
+                ask_size=data["ask_size"],
+                last_trade=data["last_trade"],
+            )
+        case "pool":
+            return PoolQuote(price=data["price"])
+        case other:
+            raise ValueError(f"unknown cached quote kind {other!r}")
+
+
 def _market_from_snapshot(snapshot: MarketSnapshot) -> Market:
-    return Market(**snapshot.market)
+    data = snapshot.market
+    return Market(
+        id=data["id"],
+        url=data["url"],
+        quote=_quote_from_dict(data["quote"]),
+        volume=data.get("volume"),
+        volume_unit=data.get("volume_unit"),
+        title=data.get("title"),
+        rules=data.get("rules"),
+    )
 
 
 def _parse_db(path: str) -> int:

--- a/finance/augur/calibration/test_calibration.py
+++ b/finance/augur/calibration/test_calibration.py
@@ -16,6 +16,8 @@ import pytest
 import pytest_bazel
 
 from finance.augur.calibration.calibration import (
+    _fit_ladder_curve,
+    _monotone_probabilities,
     build_anchored_level_paths,
     mark_fan,
     run_calibration,
@@ -42,7 +44,8 @@ from finance.augur.calibration.catalog import (
     ThresholdLadderMember,
 )
 from finance.augur.calibration.platform import Direction, Market, Platform, PriceClient
-from finance.augur.calibration.testing import mock_price_clients
+from finance.augur.calibration.quote import BookQuote, PoolQuote
+from finance.augur.calibration.testing import KalshiRungQuote, mock_price_clients
 from finance.augur.model.exogenous import ExogenousSamplingRequest
 from finance.augur.model.private_equity_bundle import PrivateEquityFloatChannel
 from finance.augur.model.series import InflationKey, IssuerId, PrivateEquityEventKindCode, SP500Key
@@ -402,6 +405,108 @@ async def test_threshold_ladder_family_derives_categorical_distribution() -> Non
     assert family.kl_bits is not None
 
 
+def test_weighted_isotonic_lets_confident_points_pin_the_curve() -> None:
+    """A low-confidence rung that violates monotonicity is pooled toward its confident neighbor,
+    rather than dragging the confident value to the unweighted midpoint."""
+    values = [0.80, 0.60, 0.65, 0.20]  # the 0.60 -> 0.65 step violates a decreasing survival curve
+    uniform = _monotone_probabilities(values, [1.0, 1.0, 1.0, 1.0], increasing=False)
+    # T3.5 confident (weight 10), the violating T4.0 wide/low-confidence (weight 0.1).
+    weighted = _monotone_probabilities(values, [1.0, 10.0, 0.1, 1.0], increasing=False)
+    assert uniform[1] == pytest.approx(0.625)  # unweighted pools 0.60 & 0.65 to their mean
+    assert weighted[1] < 0.605  # weighted keeps the confident rung near its own 0.60
+
+
+def test_fit_ladder_curve_interpolates_unpriced_rungs() -> None:
+    def market(mid: float) -> Market:
+        return Market(
+            id="x", url="u", quote=BookQuote(bid=mid, ask=mid, bid_size=None, ask_size=None, last_trade=mid), volume=1.0
+        )
+
+    # Position 1 is unpriced: the fitted survival curve interpolates between its priced neighbors
+    # (0.8 at 0 and 0.4 at 2) to 0.6 — never injecting a 0.
+    curve = _fit_ladder_curve([0.0, 1.0, 2.0, 3.0], [market(0.8), None, market(0.4), market(0.2)], increasing=False)
+    assert curve == pytest.approx([0.8, 0.6, 0.4, 0.2])
+    # Fewer than two priced rungs -> no curve.
+    assert _fit_ladder_curve([0.0, 1.0], [market(0.5), None], increasing=False) is None
+
+
+async def test_threshold_ladder_uses_quote_mids_and_interpolates_unpriced() -> None:
+    """End-to-end on Kalshi mock responses: bucket masses come from order-book MIDS (not the spiky
+    last trades) and an untraded rung is interpolated across, not dropped or read as zero."""
+    model = ConstantFrameModel(
+        levels={InflationKey(): _inflation_levels},
+        private_equity={
+            IssuerId(_ISSUER): PrivateEquityChannels(mark_usd_per_unit=50.0, event_kind_code=_event_kind_codes)
+        },
+    )
+    catalog = MarketCatalog(
+        metadata={"as_of": "2026-05-27", "anchors": {"inflation": 100.0}},
+        markets=[],
+        threshold_ladder_families=[
+            ThresholdLadderFamily(
+                family_id="cpi_yoy",
+                question="CPI YoY threshold ladder",
+                platform=Platform.KALSHI,
+                series="inflation",
+                value_kind="inflation_yoy",
+                direction=Direction.ABOVE,
+                at_date=date(2026, 12, 31),
+                thresholds=[
+                    ThresholdLadderMember(market_id="CPI-T3.0", threshold=0.03),
+                    ThresholdLadderMember(market_id="CPI-T3.5", threshold=0.035),
+                    ThresholdLadderMember(market_id="CPI-T4.0", threshold=0.04),
+                ],
+            )
+        ],
+    )
+    seeds = tuple(range(4))
+    sampled = model.sample(
+        ExogenousSamplingRequest(
+            horizon_months=_HORIZON,
+            rollout_seeds=seeds,
+            required_index_series=frozenset({InflationKey()}),
+            required_private_equity_issuers=frozenset({IssuerId(_ISSUER)}),
+        )
+    )
+    level_paths = build_anchored_level_paths(
+        sampled,
+        anchors={"inflation": 100.0},
+        requested_wire_ids=catalog.referenced_level_series(),
+        rollout_count=4,
+        horizon_months=_HORIZON,
+    )
+    clients = mock_price_clients(
+        {
+            Platform.KALSHI: {
+                # Tight books at mid 0.90 / 0.20; the last trades (0.10, 0.95) are deliberately
+                # spiky and must be ignored in favor of the mids.
+                "CPI-T3.0": KalshiRungQuote(
+                    bid=0.88, ask=0.92, bid_size=100.0, ask_size=100.0, last=0.10, volume=500.0
+                ),
+                # Untraded one-sided rung (only a 1c-equivalent ask, no bid/last/volume) -> dropped
+                # from the fit and interpolated across.
+                "CPI-T3.5": KalshiRungQuote(ask=0.99, ask_size=75.0),
+                "CPI-T4.0": KalshiRungQuote(
+                    bid=0.18, ask=0.22, bid_size=100.0, ask_size=100.0, last=0.95, volume=500.0
+                ),
+            }
+        }
+    )
+    result = await run_calibration(
+        catalog,
+        horizon_months=_HORIZON,
+        rollout_seeds=seeds,
+        price_clients=clients,
+        bundle=sampled.private_equity,
+        level_paths=level_paths,
+        inflation_history=[100.0] * 5,
+    )
+
+    family = result.categorical[0]
+    # Survival from mids: 0.90 @3.0, interpolated 0.55 @3.5, 0.20 @4.0 -> buckets below.
+    assert [bucket.p_market for bucket in family.buckets] == pytest.approx([0.10, 0.35, 0.35, 0.20])
+
+
 async def test_date_ladder_family_derives_event_timing_distribution(model: ConstantFrameModel) -> None:
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-27"},
@@ -443,21 +548,26 @@ async def test_date_ladder_family_derives_event_timing_distribution(model: Const
 
 
 class _ProbClient:
-    """A minimal PriceClient returning a Market with a fixed (possibly None) probability."""
+    """A minimal PriceClient returning a Market with a fixed (possibly None) implied probability."""
 
     def __init__(self, probabilities: dict[str, float | None]) -> None:
         self._probabilities = probabilities
 
     async def get_market(self, market_id: str) -> Market:
-        return Market(id=market_id, url=f"https://test.example/{market_id}", probability=self._probabilities[market_id])
+        probability = self._probabilities[market_id]
+        return Market(
+            id=market_id,
+            url=f"https://test.example/{market_id}",
+            quote=None if probability is None else PoolQuote(price=probability),
+        )
 
     async def aclose(self) -> None:
         pass
 
 
 async def test_none_probability_and_degenerate_family_are_dropped(macro_model: ConstantFrameModel) -> None:
-    """A market the platform prices as None, and a categorical family whose bucket prices sum to
-    zero, are both dropped (logged) rather than 500-ing via require_probability()."""
+    """A market whose quote carries no probability, and a categorical family whose bucket prices
+    sum to zero, are both dropped (logged) rather than 500-ing via require_implied_probability()."""
     catalog = MarketCatalog(
         metadata={"as_of": "2026-05-27", "anchors": {"sp500": _SP500_ANCHOR}},
         markets=[

--- a/finance/augur/calibration/test_manifold.py
+++ b/finance/augur/calibration/test_manifold.py
@@ -13,6 +13,7 @@ import pytest
 import pytest_bazel
 
 from finance.augur.calibration.manifold import ManifoldClient
+from finance.augur.calibration.quote import PoolQuote
 from finance.augur.calibration.testing import mock_manifold_client
 
 
@@ -29,8 +30,8 @@ async def test_fetch_yes_probability_raises_when_probability_missing() -> None:
         return httpx.Response(200, json={"id": "NOPROB", "url": "https://manifold.markets/test/NOPROB"})
 
     client = ManifoldClient(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
-    assert (await client.get_market("NOPROB")).probability is None
-    with pytest.raises(ValueError, match="no YES probability"):
+    assert (await client.get_market("NOPROB")).quote is None
+    with pytest.raises(ValueError, match="no informative quote"):
         await client.fetch_yes_probability("NOPROB")
 
 
@@ -47,15 +48,15 @@ async def test_get_market_caches_within_ttl_and_refetches_after() -> None:
     )
 
     # First read hits the network; a second read inside the TTL is served from cache.
-    assert (await client.get_market("AAA")).probability == 0.3
+    assert (await client.get_market("AAA")).quote == PoolQuote(price=0.3)
     assert calls["count"] == 1
     now[0] += 119.0
-    assert (await client.get_market("AAA")).probability == 0.3
+    assert (await client.get_market("AAA")).quote == PoolQuote(price=0.3)
     assert calls["count"] == 1
 
     # Crossing the TTL forces a fresh network read.
     now[0] += 2.0
-    assert (await client.get_market("AAA")).probability == 0.3
+    assert (await client.get_market("AAA")).quote == PoolQuote(price=0.3)
     assert calls["count"] == 2
 
 

--- a/finance/augur/calibration/test_quote.py
+++ b/finance/augur/calibration/test_quote.py
@@ -1,0 +1,65 @@
+"""Unit tests for the quote -> probability / confidence layer."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_bazel
+
+from finance.augur.calibration.quote import BookQuote, PoolQuote, implied_probability, quote_confidence
+
+
+def test_micro_price_weights_each_side_by_the_opposite_size() -> None:
+    # Heavy resting size on the bid (300) vs the ask (100) pulls the estimate toward the ask:
+    # (0.6*100 + 0.8*300)/400 = 0.75, above the plain midpoint of 0.70.
+    quote = BookQuote(bid=0.6, ask=0.8, bid_size=300.0, ask_size=100.0, last_trade=0.62)
+    assert implied_probability(quote, volume=1000.0) == pytest.approx(0.75)
+
+
+def test_micro_price_degenerates_to_midpoint_without_sizes() -> None:
+    assert implied_probability(
+        BookQuote(bid=0.6, ask=0.8, bid_size=None, ask_size=None, last_trade=0.99), volume=1.0
+    ) == pytest.approx(0.7)
+    assert implied_probability(
+        BookQuote(bid=0.6, ask=0.8, bid_size=50.0, ask_size=50.0, last_trade=0.99), volume=1.0
+    ) == pytest.approx(0.7)
+
+
+def test_last_trade_ignored_when_a_two_sided_book_exists() -> None:
+    # The whole point of the fix: a stale/fractional last trade (0.04) does not override a live book.
+    quote = BookQuote(bid=0.69, ask=0.84, bid_size=10.0, ask_size=10.0, last_trade=0.04)
+    assert implied_probability(quote, volume=7000.0) == pytest.approx(0.765)
+
+
+def test_one_sided_book_falls_back_to_volume_backed_last() -> None:
+    # A deep-OTM bucket with only a 1-cent ask but real volume keeps its ~1% via the last trade.
+    quote = BookQuote(bid=None, ask=0.01, bid_size=None, ask_size=600.0, last_trade=0.01)
+    assert implied_probability(quote, volume=60000.0) == pytest.approx(0.01)
+
+
+def test_untraded_contract_is_no_observation_not_zero() -> None:
+    # Kalshi encodes "never traded" as last 0 / a 0 bid / a 1 ask; that must be None, not P=0.
+    untraded = BookQuote(bid=0.0, ask=0.99, bid_size=0.0, ask_size=75.0, last_trade=0.0)
+    assert implied_probability(untraded, volume=0.0) is None
+    # A last trade with no volume behind it is equally untrustworthy.
+    assert (
+        implied_probability(BookQuote(bid=None, ask=None, bid_size=None, ask_size=None, last_trade=0.5), volume=None)
+        is None
+    )
+
+
+def test_pool_quote_passes_through_and_none_is_none() -> None:
+    assert implied_probability(PoolQuote(price=0.42), volume=None) == 0.42
+    assert implied_probability(None, volume=100.0) is None
+
+
+def test_confidence_ranks_tight_over_wide_over_one_sided_over_none() -> None:
+    tight = BookQuote(bid=0.58, ask=0.62, bid_size=100.0, ask_size=100.0, last_trade=0.6)
+    wide = BookQuote(bid=0.10, ask=0.55, bid_size=100.0, ask_size=100.0, last_trade=0.3)
+    one_sided = BookQuote(bid=None, ask=0.01, bid_size=None, ask_size=600.0, last_trade=0.01)
+    assert quote_confidence(tight, volume=1000.0) > quote_confidence(wide, volume=1000.0)
+    assert quote_confidence(wide, volume=1000.0) > quote_confidence(one_sided, volume=60000.0)
+    assert quote_confidence(None, volume=1000.0) == 0.0
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/finance/augur/calibration/test_redis_cache.py
+++ b/finance/augur/calibration/test_redis_cache.py
@@ -6,7 +6,13 @@ import pytest
 import pytest_bazel
 
 from finance.augur.calibration.platform import Market, Platform
-from finance.augur.calibration.redis_cache import MarketSnapshot, RedisCachingPriceClient, market_cache_config_from_env
+from finance.augur.calibration.quote import PoolQuote
+from finance.augur.calibration.redis_cache import (
+    MarketSnapshot,
+    RedisCachingPriceClient,
+    _market_to_dict,
+    market_cache_config_from_env,
+)
 
 
 class _FakeStore:
@@ -48,7 +54,7 @@ async def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
         "manifold:m1": _snapshot(
             market_id="m1",
             fetched_at=10.0,
-            market=Market(id="m1", url="https://example.com/m1", probability=0.4, title="cached"),
+            market=Market(id="m1", url="https://example.com/m1", quote=PoolQuote(price=0.4), title="cached"),
         )
     }
     ttls: dict[str, int] = {}
@@ -56,7 +62,7 @@ async def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
     client = _client(upstream=upstream, data=data, ttls=ttls, now=20.0, ttl_seconds=30.0)
 
     assert await client.get_market("m1") == Market(
-        id="m1", url="https://example.com/m1", probability=0.4, title="cached"
+        id="m1", url="https://example.com/m1", quote=PoolQuote(price=0.4), title="cached"
     )
     assert upstream.calls == []
 
@@ -64,11 +70,13 @@ async def test_fresh_cache_hit_avoids_upstream_fetch() -> None:
 async def test_stale_cache_refreshes_from_upstream_and_updates_cache() -> None:
     data = {
         "manifold:m1": _snapshot(
-            market_id="m1", fetched_at=10.0, market=Market(id="m1", url="https://example.com/stale", probability=0.4)
+            market_id="m1",
+            fetched_at=10.0,
+            market=Market(id="m1", url="https://example.com/stale", quote=PoolQuote(price=0.4)),
         )
     }
     ttls: dict[str, int] = {}
-    upstream_market = Market(id="m1", url="https://example.com/fresh", probability=0.7, volume=12.0)
+    upstream_market = Market(id="m1", url="https://example.com/fresh", quote=PoolQuote(price=0.7), volume=12.0)
     upstream = _FakeUpstream(market=upstream_market)
     client = _client(upstream=upstream, data=data, ttls=ttls, now=50.0, ttl_seconds=30.0, retention_seconds=120)
 
@@ -79,7 +87,7 @@ async def test_stale_cache_refreshes_from_upstream_and_updates_cache() -> None:
 
 
 async def test_stale_cache_survives_upstream_failure() -> None:
-    cached_market = Market(id="m1", url="https://example.com/stale", probability=0.4)
+    cached_market = Market(id="m1", url="https://example.com/stale", quote=PoolQuote(price=0.4))
     data = {"manifold:m1": _snapshot(market_id="m1", fetched_at=10.0, market=cached_market)}
     ttls: dict[str, int] = {}
     upstream = _FakeUpstream(error=RuntimeError("upstream down"))
@@ -100,7 +108,7 @@ async def test_cache_miss_propagates_upstream_failure() -> None:
 async def test_invalid_cache_payload_is_ignored() -> None:
     data = {"manifold:m1": {"schema_version": 1, "platform": "kalshi", "market_id": "m1"}}
     ttls: dict[str, int] = {}
-    upstream_market = Market(id="m1", url="https://example.com/fresh", probability=0.7)
+    upstream_market = Market(id="m1", url="https://example.com/fresh", quote=PoolQuote(price=0.7))
     upstream = _FakeUpstream(market=upstream_market)
     client = _client(upstream=upstream, data=data, ttls=ttls, now=20.0)
 
@@ -151,15 +159,7 @@ def _snapshot(*, market_id: str, fetched_at: float, market: Market) -> dict[str,
         platform=Platform.MANIFOLD,
         market_id=market_id,
         fetched_at_epoch_seconds=fetched_at,
-        market={
-            "id": market.id,
-            "url": market.url,
-            "probability": market.probability,
-            "volume": market.volume,
-            "volume_unit": market.volume_unit,
-            "title": market.title,
-            "rules": market.rules,
-        },
+        market=_market_to_dict(market),
     ).model_dump(mode="json")
 
 

--- a/finance/augur/calibration/test_transient_retry.py
+++ b/finance/augur/calibration/test_transient_retry.py
@@ -84,10 +84,10 @@ async def test_kalshi_client_recovers_from_flapping_503() -> None:
         responses["n"] += 1
         if responses["n"] < 3:
             return httpx.Response(503)
-        return httpx.Response(200, json={"market": {"last_price_dollars": 0.37}})
+        return httpx.Response(200, json={"market": {"yes_bid_dollars": "0.36", "yes_ask_dollars": "0.38"}})
 
     client = KalshiClient(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)), sleep=_noop_sleep)
-    assert (await client.get_market("KXTEST")).probability == 0.37
+    assert (await client.get_market("KXTEST")).require_implied_probability() == 0.37
     assert responses["n"] == 3
 
 

--- a/finance/augur/calibration/testing.py
+++ b/finance/augur/calibration/testing.py
@@ -4,18 +4,37 @@
 ``httpx.MockTransport`` so they exercise the client's actual caching/parsing path.
 ``mock_price_clients`` is a convenience that assembles a ``dict[Platform, PriceClient]``
 from per-platform price maps.
+
+A Kalshi ticker maps to either a bare ``float`` (a tight two-sided book at that probability — the
+common case, exercising the mid path) or a :class:`KalshiRungQuote` to model a real order book
+(wide spread, one-sided, stale/fractional last trade) for the aggregation tests.
 """
 
 from __future__ import annotations
 
 import time
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 
 import httpx
 
 from finance.augur.calibration.kalshi import KalshiClient
 from finance.augur.calibration.manifold import ManifoldClient
 from finance.augur.calibration.platform import Market, Platform, PriceClient
+from finance.augur.calibration.quote import BookQuote
+
+
+@dataclass(frozen=True)
+class KalshiRungQuote:
+    """A Kalshi market's order book for a mock response: top-of-book YES bid/ask (0-1) with resting
+    sizes, the last trade, and all-time volume. Any field may be omitted to model a missing side."""
+
+    bid: float | None = None
+    ask: float | None = None
+    bid_size: float | None = None
+    ask_size: float | None = None
+    last: float | None = None
+    volume: float | None = None
 
 
 def mock_manifold_client(
@@ -44,24 +63,39 @@ def mock_manifold_client(
     )
 
 
+def _kalshi_market_json(ticker: str, spec: float | KalshiRungQuote) -> dict[str, object]:
+    # A bare float is a tight two-sided book at that probability (bid == ask == p, with depth and a
+    # matching last trade), so it resolves to the mid p and stays the simple default for callers.
+    quote = (
+        KalshiRungQuote(bid=spec, ask=spec, bid_size=1.0, ask_size=1.0, last=spec, volume=1.0)
+        if isinstance(spec, float | int)
+        else spec
+    )
+    market: dict[str, object] = {"ticker": ticker, "title": ticker, "rules_primary": f"Resolves per market {ticker}."}
+    fields = {
+        "yes_bid_dollars": quote.bid,
+        "yes_ask_dollars": quote.ask,
+        "yes_bid_size_fp": quote.bid_size,
+        "yes_ask_size_fp": quote.ask_size,
+        "last_price_dollars": quote.last,
+        "volume_fp": quote.volume,
+    }
+    market.update({key: str(value) for key, value in fields.items() if value is not None})
+    return {"market": market}
+
+
 def mock_kalshi_client(
-    prices: Mapping[str, float], *, clock: Callable[[], float] = time.monotonic, cache_ttl_seconds: float = 120.0
+    prices: Mapping[str, float | KalshiRungQuote],
+    *,
+    clock: Callable[[], float] = time.monotonic,
+    cache_ttl_seconds: float = 120.0,
 ) -> KalshiClient:
-    """A ``KalshiClient`` whose market reads resolve from `prices` (0-1 scale) keyed by ticker."""
+    """A ``KalshiClient`` whose market reads resolve from `prices` keyed by ticker; each value is a
+    bare probability (tight book) or a :class:`KalshiRungQuote` order book."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         ticker = request.url.path.rstrip("/").rsplit("/", 1)[-1]
-        return httpx.Response(
-            200,
-            json={
-                "market": {
-                    "last_price_dollars": str(prices[ticker]),
-                    "ticker": ticker,
-                    "title": ticker,
-                    "rules_primary": f"Resolves per market {ticker}.",
-                }
-            },
-        )
+        return httpx.Response(200, json=_kalshi_market_json(ticker, prices[ticker]))
 
     return KalshiClient(
         clock=clock,
@@ -71,16 +105,17 @@ def mock_kalshi_client(
 
 
 class _StaticClient:
-    """Minimal ``PriceClient`` backed by a fixed price map."""
+    """Minimal ``PriceClient`` returning a tight two-sided book at each id's probability."""
 
     def __init__(self, prices: Mapping[str, float]) -> None:
         self._prices = prices
 
     async def get_market(self, market_id: str) -> Market:
+        price = self._prices[market_id]
         return Market(
             id=market_id,
             url=f"https://test.example/{market_id}",
-            probability=self._prices[market_id],
+            quote=BookQuote(bid=price, ask=price, bid_size=None, ask_size=None, last_trade=price),
             title=market_id,
             rules=f"Resolves per market {market_id}.",
         )
@@ -90,7 +125,7 @@ class _StaticClient:
 
 
 def mock_price_clients(
-    prices_by_platform: Mapping[Platform, Mapping[str, float]],
+    prices_by_platform: Mapping[Platform, Mapping[str, float | KalshiRungQuote]],
     *,
     clock: Callable[[], float] = time.monotonic,
     cache_ttl_seconds: float = 120.0,
@@ -99,14 +134,23 @@ def mock_price_clients(
 
     Manifold and Kalshi use their real client classes (exercising parsing/caching).
     Polymarket (and any future platform without a specialised mock) gets a
-    ``_StaticClient`` that returns ``Market`` directly.
+    ``_StaticClient`` that returns ``Market`` directly. Only Kalshi accepts
+    :class:`KalshiRungQuote` values; the others require bare floats.
     """
     result: dict[Platform, PriceClient] = {}
     for platform, prices in prices_by_platform.items():
-        if platform == Platform.MANIFOLD:
-            result[platform] = mock_manifold_client(prices, clock=clock, cache_ttl_seconds=cache_ttl_seconds)
-        elif platform == Platform.KALSHI:
+        if platform == Platform.KALSHI:
             result[platform] = mock_kalshi_client(prices, clock=clock, cache_ttl_seconds=cache_ttl_seconds)
         else:
-            result[platform] = _StaticClient(prices)
+            floats = {market_id: _require_float(platform, value) for market_id, value in prices.items()}
+            if platform == Platform.MANIFOLD:
+                result[platform] = mock_manifold_client(floats, clock=clock, cache_ttl_seconds=cache_ttl_seconds)
+            else:
+                result[platform] = _StaticClient(floats)
     return result
+
+
+def _require_float(platform: Platform, value: float | KalshiRungQuote) -> float:
+    if not isinstance(value, float | int):
+        raise TypeError(f"{platform} mock takes bare-float probabilities, not {type(value).__name__}")
+    return value

--- a/finance/augur/calibration/x/BUILD.bazel
+++ b/finance/augur/calibration/x/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//devinfra/python:defs.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "inspect_cpi_quotes",
+    srcs = ["inspect_cpi_quotes.py"],
+    deps = [
+        "//finance/augur/calibration",
+        "//finance/augur/calibration:catalog",
+        "//finance/augur/calibration:kalshi",
+        "//finance/augur/calibration:platform",
+        "//finance/augur/calibration:quote",
+    ],
+)

--- a/finance/augur/calibration/x/inspect_cpi_quotes.py
+++ b/finance/augur/calibration/x/inspect_cpi_quotes.py
@@ -1,0 +1,89 @@
+"""Diagnostic: run the REAL quote -> probability -> ladder-distribution pipeline against live
+Kalshi data for the configured CPI-YoY threshold ladder, and contrast it with the old
+last-trade-based survival curve.
+
+Throwaway investigation tool (hence `x/`) for the CPI market-line spikiness. It uses the actual
+``KalshiClient`` parser, :func:`implied_probability` / :func:`quote_confidence`, and the real
+``_fit_ladder_curve`` + ``_threshold_ladder_buckets`` so what it prints is exactly what
+calibration produces. Run via ``bb run`` with the sandbox disabled (Kalshi host is off the sandbox
+allowlist):
+
+    bb run //finance/augur/calibration/x:inspect_cpi_quotes
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+from finance.augur.calibration.calibration import _fit_ladder_curve, _threshold_ladder_buckets
+from finance.augur.calibration.catalog import ThresholdLadderFamily, ThresholdLadderMember
+from finance.augur.calibration.kalshi import KalshiClient
+from finance.augur.calibration.platform import Direction, Market, Platform
+from finance.augur.calibration.quote import BookQuote, implied_probability, quote_confidence
+
+_TICKERS = [f"KXCPIYOY-26JUL-T{whole}.{tenth}" for whole in (3, 4) for tenth in range(10)] + ["KXCPIYOY-26JUL-T5.0"]
+_THRESHOLDS = [whole * 0.01 + tenth * 0.001 for whole in (3, 4) for tenth in range(10)] + [0.05]
+
+
+def _fmt(value: float | None) -> str:
+    return f"{value:.4f}" if value is not None else "-"
+
+
+def _buckets(curve: list[float] | None) -> list[float] | None:
+    if curve is None:
+        return None
+    family = ThresholdLadderFamily(
+        family_id="cpi",
+        question="cpi",
+        platform=Platform.KALSHI,
+        series="inflation",
+        value_kind="inflation_yoy",
+        direction=Direction.ABOVE,
+        at_date=date(2026, 7, 31),
+        thresholds=[ThresholdLadderMember(market_id=f"T{t}", threshold=t) for t in _THRESHOLDS],
+    )
+    return [
+        round(bucket.p_market, 3) for bucket in _threshold_ladder_buckets(family, thresholds=_THRESHOLDS, curve=curve)
+    ]
+
+
+def _tight_book_market(value: float) -> Market:
+    return Market(
+        id="x", url="u", quote=BookQuote(bid=value, ask=value, bid_size=1.0, ask_size=1.0, last_trade=value), volume=1.0
+    )
+
+
+async def main() -> None:
+    client = KalshiClient()
+    try:
+        markets: list[Market | None] = [await client.get_market(ticker) for ticker in _TICKERS]
+    finally:
+        await client.aclose()
+
+    print(f"{'rung':>5} {'bid':>6} {'ask':>6} {'last':>6} {'implied':>8} {'weight':>10}")
+    last_markets: list[Market | None] = []
+    for ticker, market in zip(_TICKERS, markets, strict=True):
+        assert market is not None
+        quote = market.quote
+        assert isinstance(quote, BookQuote)
+        prob = implied_probability(quote, volume=market.volume)
+        weight = quote_confidence(quote, volume=market.volume)
+        last_markets.append(_tight_book_market(quote.last_trade) if quote.last_trade is not None else None)
+        print(
+            f"{ticker.split('-T')[-1]:>5} {_fmt(quote.bid):>6} {_fmt(quote.ask):>6} {_fmt(quote.last_trade):>6} "
+            f"{_fmt(prob):>8} {weight:>10.1f}"
+        )
+
+    print(
+        "\nNEW buckets (quote-mid, weighted isotonic):",
+        _buckets(_fit_ladder_curve(_THRESHOLDS, markets, increasing=False)),
+    )
+    print(
+        "OLD buckets (last-trade, uniform):         ",
+        _buckets(_fit_ladder_curve(_THRESHOLDS, last_markets, increasing=False)),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/finance/augur/debug/cpi_yoy_market_line_spikiness.md
+++ b/finance/augur/debug/cpi_yoy_market_line_spikiness.md
@@ -1,0 +1,53 @@
+# CPI-YoY Kalshi calibration market line — spikiness RCA + fix
+
+## Symptom
+
+The calibration "market line" for the CPI-YoY-on-Kalshi threshold ladder
+(`cpi_yoy_july_2026`, 21 rungs 3.0%–5.0%) rendered spiky/weird.
+
+## Root cause (from live Kalshi data, not the hypothesis)
+
+The pipeline fed each rung's `last_price_dollars` into the survival curve. On this thin ladder
+`last_price` is unreliable:
+
+1. **`last_price` is set by sub-$1 fractional fills.** Rung T4.1 reported `last=0.04` from two
+   0.99- and 0.01-contract trades, while real size (484+200 contracts) had traded at 0.58–0.63 and
+   the live book was 0.69–0.84. Differencing that stale/tiny value produced the dominant ~0.42–0.51
+   bucket spike.
+2. **Untraded rungs report `last_price="0.0000"` (a string, not JSON `null`).** The old
+   `last_price_dollars: float | None` guard and the `_live` drop-on-`None` never fired, so untraded
+   rungs (T3.1, T3.5) injected a fake `P=0` survival point. Only 2 of 21 rungs are truly untraded —
+   most of the visible zeros were PAVA-pooling/differencing artifacts.
+3. **The tail (4.2%–5.0%) has genuinely wide / one-sided books** (e.g. T4.2 `bid=0.02 / ask=0.82`),
+   so any single-snapshot estimate there is low-confidence. `volume_24h=0` on nearly every rung —
+   the order-book mid is the only always-fresh signal.
+
+The bucket families (SP500/BTC/ETH, all liquid) and the IPO date ladder were already healthy; CPI
+is sick purely because it is thin.
+
+## Fix
+
+Principled two-layer conversion (see `calibration/quote.py`, `calibration/calibration.py`):
+
+- **Layer 1 (market → probability):** Stoikov micro-price (size-weighted mid) when a genuine
+  two-sided book exists, degenerating to the plain midpoint without sizes; volume-backed `last`
+  only as a one-sided fallback; untraded/empty → no observation (never `0`/`0.5`).
+- **Layer 2 (ladder → distribution):** confidence-weighted isotonic regression (weighted PAVA,
+  weight = inverse-variance from spread + depth) + adjacent differencing (discrete
+  Breeden–Litzenberger). Unpriced rungs are interpolated across, not dropped or zeroed.
+
+## Before/after on live data
+
+From `bb run //finance/augur/calibration/x:inspect_cpi_quotes` (exercises the real pipeline):
+
+```
+OLD buckets (last-trade, uniform):  [0.01, 0,0,0,0, 0.03, 0.03, 0, 0.06, 0.055, 0, 0.51, 0, 0.015, 0, 0.08, 0.13, 0,0,0,0, 0.08]
+NEW buckets (quote-mid, weighted):  [0.287, 0,0,0,0,0,0, 0.015, 0, 0.053, 0,0, 0.313, 0,0,0,0, 0.044, 0,0,0, 0.288]
+```
+
+The dominant spurious `0.51` spike (T4.1 fractional-fill last trade) is gone; mass is driven by the
+confident rungs. Residual lumpiness reflects the ladder's genuine wide-book uncertainty, not a code
+artifact. Untraded T3.1/T3.5 are dropped from the fit and interpolated.
+
+Codified hermetically in `test_calibration.py::test_threshold_ladder_uses_quote_mids_and_interpolates_unpriced`
+and the Layer-1 unit tests in `test_quote.py`.


### PR DESCRIPTION
## Why

The CPI-YoY-on-Kalshi calibration "market line" rendered spiky/weird. Investigation against **live Kalshi data** (orderbook/trades endpoints, not just the market summary) showed the root cause is that calibration consumed each market's `last_price` as the survival-curve input, which on a thin ladder is unreliable:

- **Fractional fills set `last_price`** — rung T4.1 reported `last=0.04` from two 0.99-/0.01-contract trades while the live book was 0.69–0.84 → the dominant ~0.5 bucket spike.
- **Untraded-as-zero** — Kalshi encodes no-data as the string `"0.0000"` (not JSON `null`), so the `float | None` guard never fired and untraded rungs injected a fake `P=0`.
- The 4–5% tail has genuinely wide / one-sided books; the order-book mid is the only always-fresh signal.

Bucket families (SP500/BTC/ETH) and the IPO date ladder were already healthy — CPI is sick only because it's thin.

## What

A principled two-layer conversion from prediction markets to probabilities:

- **Layer 1 — `quote.py`**: `BookQuote`/`PoolQuote` union; `implied_probability` uses the **Stoikov micro-price** (size-weighted mid → plain mid → volume-backed last → `None`; never a fabricated `0`/`0.5`); `quote_confidence` is an inverse-variance weight (spread + depth).
- **Layer 2 — `calibration.py`**: aggregate ladders via **confidence-weighted isotonic regression** (weighted PAVA) + adjacent differencing (the discrete Breeden–Litzenberger identity). Unpriced rungs are **interpolated**, not zeroed or dropped.
- Kalshi/Polymarket/Manifold parsers populate the quote; `Market.probability`→`Market.quote`, `require_probability`→`require_implied_probability`; Redis cache schema bumped to v2.

## Validation

`bb run //finance/augur/calibration/x:inspect_cpi_quotes` against **live Kalshi** (real code path):

```
OLD buckets (last-trade, uniform):  [0.01, …, 0.51, …, 0.13, …]   <- spurious T4.1 spike
NEW buckets (quote-mid, weighted):  [0.287, …, 0.313, …, 0.288]   <- spike gone, driven by confident rungs
```

RCA + before/after in `finance/augur/debug/cpi_yoy_market_line_spikiness.md`. Codified hermetically in `test_quote.py` (Layer 1) and `test_calibration.py` (weighted-isotonic dragging, unpriced-rung interpolation, mid-vs-last end-to-end on Kalshi mocks).

`bbr test //finance/augur/...` → green (build + ruff + mypy + tests).

## Notes

- Frontend is unchanged (consumes derived `bucket.pMarket`; smoother buckets de-spike automatically). Surfacing per-rung quote quality in the UI + Polymarket CLOB depth for micro-price are tracked as follow-ups in `augur/TODO.md`.
